### PR TITLE
fix(kiwisdr): harden receiver setup and waterfall status

### DIFF
--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -5,12 +5,16 @@
 #include "Resampler.h"
 
 #include <QDateTime>
+#include <QList>
 #include <QStringList>
 #include <QTimer>
 #include <QUrl>
 
 #ifdef HAVE_WEBSOCKETS
 #include <QAbstractSocket>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QWebSocket>
 #include <QWebSocketProtocol>
 #endif
@@ -23,12 +27,15 @@
 namespace AetherSDR {
 namespace {
 constexpr int kAudioReadyTimeoutMs = 12000;
+constexpr int kKeepaliveIntervalMs = 10000;
+constexpr int kStatusPreflightTimeoutMs = 5000;
 constexpr quint16 kDefaultKiwiSdrPort = 8073;
 constexpr double kDefaultWaterfallCenterMhz = 15.0;
 constexpr double kDefaultWaterfallBandwidthMhz = 30.0;
 constexpr int kSpecSoundHeaderBytes = 6;
 constexpr int kObservedSoundHeaderBytes = 10;
-constexpr int kObservedSoundFrameBytes = 1034;
+constexpr quint8 kSoundCompressedFlag = 0x10;
+constexpr quint8 kSoundLittleEndianFlag = 0x80;
 constexpr int kSpecWaterfallHeaderBytes = 4;
 constexpr int kExtendedWaterfallHeaderBytes = 16;
 constexpr int kZoomedWaterfallPrefixBytes = 5;
@@ -37,6 +44,7 @@ constexpr int kDefaultWaterfallFftBins = 1024;
 constexpr quint64 kMaxSequenceGapPaddingFrames = 8;
 constexpr double kWaterfallStartFixedPointScale = 16777216.0; // 2^24
 constexpr quint32 kWaterfallStartServerSnapTolerance = 16;
+constexpr quint64 kWebSocketSessionIdBase = 1ULL << 62;
 
 quint32 readLittleEndianU32(const char* data)
 {
@@ -161,13 +169,104 @@ QString firstBytesHex(const QByteArray& frame, int limit = 16)
     return QString::fromLatin1(frame.left(std::max(0, limit)).toHex(' '));
 }
 
+QString abbreviatedMsgValue(const QString& value)
+{
+    constexpr qsizetype kMaxLoggedMsgValueChars = 160;
+    if (value.size() <= kMaxLoggedMsgValueChars) {
+        return value;
+    }
+
+    return value.left(kMaxLoggedMsgValueChars)
+        + QStringLiteral("...(len=")
+        + QString::number(value.size())
+        + QLatin1Char(')');
+}
+
+bool parseStatusIntField(const QByteArray& payload,
+                         const QByteArray& key,
+                         int* value)
+{
+    const QByteArray prefix = key + '=';
+    const QList<QByteArray> lines = payload.split('\n');
+    for (QByteArray line : lines) {
+        line = line.trimmed();
+        if (!line.startsWith(prefix)) {
+            continue;
+        }
+
+        bool ok = false;
+        const int parsed =
+            QString::fromLatin1(line.mid(prefix.size()).trimmed()).toInt(&ok);
+        if (!ok) {
+            return false;
+        }
+
+        if (value) {
+            *value = parsed;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool soundFrameCompressed(quint8 flags)
+{
+    return (flags & kSoundCompressedFlag) != 0;
+}
+
+bool soundFrameLittleEndian(quint8 flags)
+{
+    return (flags & kSoundLittleEndianFlag) != 0;
+}
+
+int soundPayloadOffset(const QByteArray& frame)
+{
+    return frame.size() >= kObservedSoundHeaderBytes
+        ? kObservedSoundHeaderBytes
+        : kSpecSoundHeaderBytes;
+}
+
+#ifdef HAVE_WEBSOCKETS
+QString webSocketOrigin(const QString& scheme, const QString& host, quint16 port)
+{
+    const QString originScheme = scheme == QStringLiteral("wss")
+        ? QStringLiteral("https")
+        : QStringLiteral("http");
+    return QStringLiteral("%1://%2:%3")
+        .arg(originScheme)
+        .arg(host)
+        .arg(port);
+}
+
+QNetworkRequest kiwiWebSocketRequest(const QString& url,
+                                     const QString& origin)
+{
+    QNetworkRequest request{QUrl(url)};
+    request.setHeader(QNetworkRequest::UserAgentHeader,
+                      QStringLiteral("AetherSDR"));
+    request.setRawHeader("Origin", origin.toUtf8());
+    return request;
+}
+
+QUrl kiwiStatusUrl(const QString& host, quint16 port)
+{
+    QUrl url;
+    url.setScheme(QStringLiteral("http"));
+    url.setHost(host);
+    url.setPort(port);
+    url.setPath(QStringLiteral("/status"));
+    return url;
+}
+#endif
+
 }
 
 KiwiSdrClient::KiwiSdrClient(QObject* parent)
     : QObject(parent)
 {
     m_keepaliveTimer = new QTimer(this);
-    m_keepaliveTimer->setInterval(10000);
+    m_keepaliveTimer->setInterval(kKeepaliveIntervalMs);
     connect(m_keepaliveTimer, &QTimer::timeout,
             this, &KiwiSdrClient::sendKeepalive);
 
@@ -180,10 +279,7 @@ KiwiSdrClient::KiwiSdrClient(QObject* parent)
             return;
         }
 
-        setState(State::Error,
-                 m_soundSampleRateCommandsSent
-                     ? tr("KiwiSDR sound setup completed but no SND audio frames arrived.")
-                     : tr("No KiwiSDR audio channel became available."));
+        setState(State::Error, setupTimeoutDetail());
         cleanupSockets();
     });
 }
@@ -242,9 +338,21 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
     m_loggedSoundFrameShape = false;
     m_loggedWaterfallFrameShape = false;
     m_soundSampleRateHz = 12000.0;
+    m_soundAudioRateText.clear();
     m_soundResamplerRateHz = 0.0;
     m_soundResampler.reset();
     m_haveSoundAudioRate = false;
+    m_haveSoundSampleRate = false;
+    m_soundDiagWindowStartUtcMs = 0;
+    m_lastSoundFrameUtcMs = 0;
+    m_lastSoundKeepaliveSentUtcMs = 0;
+    m_soundDiagFrames = 0;
+    m_soundDiagBytes = 0;
+    m_soundDiagDecodedSamples = 0;
+    m_waterfallDiagWindowStartUtcMs = 0;
+    m_lastWaterfallFrameUtcMs = 0;
+    m_waterfallDiagFrames = 0;
+    m_waterfallDiagBytes = 0;
     m_telemetry = {};
     m_telemetryPending = false;
     m_lastSoundIdentityCallsign.clear();
@@ -263,37 +371,162 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
     m_waterfallRequestPanId.clear();
     m_waterfallRequestLowMhz = 0.0;
     m_waterfallRequestHighMhz = 0.0;
+    m_waterfallAvailable = true;
+    m_waterfallAvailabilityDetail.clear();
+    m_waterfallRxChannel = -1;
+    m_waterfallChannelCount = -1;
     m_userDisconnecting = true;
     cleanupSockets();
     m_userDisconnecting = false;
     const QString callsign = kiwiIdentityCallsign();
     setState(State::Connecting,
              callsign.isEmpty()
-                 ? tr("Connecting to %1 without a radio callsign.").arg(m_endpoint)
-                 : tr("Connecting to %1 as %2.").arg(m_endpoint, callsign));
+                 ? tr("Checking KiwiSDR access policy for %1.").arg(m_endpoint)
+                 : tr("Checking KiwiSDR access policy for %1 as %2.")
+                       .arg(m_endpoint, callsign));
 
 #ifdef HAVE_WEBSOCKETS
-    openWebSockets();
+    startStatusPreflight();
 #else
     setState(State::Error, tr("Qt WebSockets support is required for KiwiSDR."));
 #endif
 }
 
 #ifdef HAVE_WEBSOCKETS
+void KiwiSdrClient::startStatusPreflight()
+{
+    if (!m_statusNetworkAccessManager) {
+        m_statusNetworkAccessManager = new QNetworkAccessManager(this);
+    }
+
+    QNetworkRequest request{kiwiStatusUrl(m_host, m_port)};
+    request.setHeader(QNetworkRequest::UserAgentHeader,
+                      QStringLiteral("AetherSDR"));
+    request.setTransferTimeout(kStatusPreflightTimeoutMs);
+
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR status preflight"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << request.url().toString();
+    m_statusReply = m_statusNetworkAccessManager->get(request);
+    connect(m_statusReply, &QNetworkReply::finished, this,
+            [this, reply = m_statusReply]() {
+        handleStatusPreflightFinished(reply);
+    });
+}
+
+void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
+{
+    if (!reply || reply != m_statusReply) {
+        if (reply) {
+            reply->deleteLater();
+        }
+        return;
+    }
+
+    m_statusReply = nullptr;
+    const QUrl url = reply->url();
+    const bool ok = reply->error() == QNetworkReply::NoError;
+    const QByteArray payload = ok ? reply->readAll() : QByteArray();
+    const int httpStatus =
+        reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    const QString errorText = reply->errorString();
+    reply->deleteLater();
+
+    if (m_userDisconnecting || m_state != State::Connecting) {
+        return;
+    }
+
+    if (ok) {
+        int extApiChannels = -1;
+        if (parseStatusIntField(payload, QByteArrayLiteral("ext_api"),
+                                &extApiChannels)) {
+            qCInfo(lcKiwiSdr).noquote()
+                << "KiwiSDR status preflight"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << "ext_api=" << extApiChannels;
+            if (extApiChannels == 0) {
+                setState(
+                    State::Error,
+                    tr("This KiwiSDR operator does not allow external API clients such as AetherSDR."));
+                cleanupSockets();
+                return;
+            }
+        } else {
+            qCInfo(lcKiwiSdr).noquote()
+                << "KiwiSDR status preflight"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << "ext_api=unreported";
+        }
+
+        int users = -1;
+        int usersMax = -1;
+        int preempt = 0;
+        const bool hasUsers =
+            parseStatusIntField(payload, QByteArrayLiteral("users"), &users);
+        const bool hasUsersMax =
+            parseStatusIntField(payload, QByteArrayLiteral("users_max"),
+                                &usersMax);
+        parseStatusIntField(payload, QByteArrayLiteral("preempt"), &preempt);
+        qCInfo(lcKiwiSdr).noquote()
+            << "KiwiSDR status preflight"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "users="
+            << (hasUsers ? QString::number(users) : QStringLiteral("unreported"))
+            << "users_max="
+            << (hasUsersMax ? QString::number(usersMax) : QStringLiteral("unreported"))
+            << "preempt=" << preempt;
+        if (hasUsers && hasUsersMax && usersMax > 0 && users >= usersMax
+            && preempt <= 0) {
+            setState(
+                State::Error,
+                tr("This KiwiSDR endpoint is at capacity (%1/%2 users). Try again later or choose another receiver.")
+                    .arg(users)
+                    .arg(usersMax));
+            cleanupSockets();
+            return;
+        }
+    } else {
+        qCInfo(lcKiwiSdr).noquote()
+            << "KiwiSDR status preflight unavailable"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "url=" << url.toString()
+            << "http_status=" << httpStatus
+            << "error=" << errorText;
+    }
+
+    const QString callsign = kiwiIdentityCallsign();
+    setState(State::Connecting,
+             callsign.isEmpty()
+                 ? tr("Connecting to %1 without a radio callsign.").arg(m_endpoint)
+                 : tr("Connecting to %1 as %2.").arg(m_endpoint, callsign));
+    openWebSockets();
+}
+
 void KiwiSdrClient::openWebSockets()
 {
     const QString scheme = m_secureWebSocket
         ? QStringLiteral("wss")
         : QStringLiteral("ws");
     const quint16 socketPort = m_secureWebSocket ? 443 : m_port;
-    const QString sessionId = QString::number(QDateTime::currentMSecsSinceEpoch());
-    const QString secureAwareBase = QStringLiteral("%1://%2:%3/%4")
+    // Clean black-box observation against KiwiSDR v1.842 showed the current
+    // web client using /ws/kiwi/<session>/<stream>. Some servers still upgrade
+    // /<session>/<stream> but never emit MSG or stream frames on that path.
+    const quint64 sessionId =
+        kWebSocketSessionIdBase
+        + static_cast<quint64>(QDateTime::currentMSecsSinceEpoch());
+    const QString sessionIdText = QString::number(sessionId);
+    const QString secureAwareBase = QStringLiteral("%1://%2:%3/ws/kiwi/%4")
         .arg(scheme)
         .arg(m_host)
         .arg(socketPort)
-        .arg(sessionId);
+        .arg(sessionIdText);
     const QString soundUrl = secureAwareBase + QStringLiteral("/SND");
     const QString waterfallUrl = secureAwareBase + QStringLiteral("/W/F");
+    const QString origin = webSocketOrigin(scheme, m_host, socketPort);
+    resetProtocolTrace();
+    traceConnectionInfo(scheme, socketPort, sessionIdText, origin,
+                        soundUrl, waterfallUrl);
 
     m_soundSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
     connect(m_soundSocket, &QWebSocket::connected, this, [this]() {
@@ -303,19 +536,27 @@ void KiwiSdrClient::openWebSockets()
         m_audioReadyTimer->start();
     });
     connect(m_soundSocket, &QWebSocket::textMessageReceived,
-            this, &KiwiSdrClient::handleTextMessage);
+            this, [this](const QString& text) {
+        handleTextMessage(StreamKind::Sound, text);
+    });
     connect(m_soundSocket, &QWebSocket::binaryMessageReceived,
-            this, &KiwiSdrClient::handleBinaryMessage);
+            this, [this](const QByteArray& frame) {
+        handleBinaryMessage(StreamKind::Sound, frame);
+    });
     connect(m_soundSocket, &QWebSocket::disconnected, this, [this]() {
+        const int closeCode = m_soundSocket
+            ? static_cast<int>(m_soundSocket->closeCode())
+            : -1;
+        const QString closeReason =
+            m_soundSocket ? m_soundSocket->closeReason() : QString();
         qCInfo(lcKiwiSdr).noquote()
-            << "KiwiSDR SND closed code="
-            << (m_soundSocket
-                    ? static_cast<int>(m_soundSocket->closeCode())
-                    : -1)
-            << "reason="
-            << (m_soundSocket ? m_soundSocket->closeReason() : QString())
+            << "KiwiSDR SND closed"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "code=" << closeCode
+            << "reason=" << closeReason
             << "saw_snd="
             << (m_soundFrameSeen ? QStringLiteral("yes") : QStringLiteral("no"));
+        traceClose(StreamKind::Sound, closeCode, closeReason);
         if (!m_userDisconnecting) {
             if (m_state == State::Connecting) {
                 if (retryWithSecureWebSocket(m_soundSocketConnected)) {
@@ -348,8 +589,11 @@ void KiwiSdrClient::openWebSockets()
                                                 : tr("KiwiSDR sound socket error."),
                                   m_soundSocketConnected);
             });
-    qCInfo(lcKiwiSdr).noquote() << "KiwiSDR SND URL" << soundUrl;
-    m_soundSocket->open(QUrl(soundUrl));
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR SND URL"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << soundUrl;
+    m_soundSocket->open(kiwiWebSocketRequest(soundUrl, origin));
 
     m_waterfallSocket = new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this);
     connect(m_waterfallSocket, &QWebSocket::connected, this, [this]() {
@@ -357,17 +601,25 @@ void KiwiSdrClient::openWebSockets()
         sendWaterfallSetupCommands();
     });
     connect(m_waterfallSocket, &QWebSocket::textMessageReceived,
-            this, &KiwiSdrClient::handleTextMessage);
+            this, [this](const QString& text) {
+        handleTextMessage(StreamKind::Waterfall, text);
+    });
     connect(m_waterfallSocket, &QWebSocket::binaryMessageReceived,
-            this, &KiwiSdrClient::handleBinaryMessage);
+            this, [this](const QByteArray& frame) {
+        handleBinaryMessage(StreamKind::Waterfall, frame);
+    });
     connect(m_waterfallSocket, &QWebSocket::disconnected, this, [this]() {
+        const int closeCode = m_waterfallSocket
+            ? static_cast<int>(m_waterfallSocket->closeCode())
+            : -1;
+        const QString closeReason =
+            m_waterfallSocket ? m_waterfallSocket->closeReason() : QString();
         qCInfo(lcKiwiSdr).noquote()
-            << "KiwiSDR W/F closed code="
-            << (m_waterfallSocket
-                    ? static_cast<int>(m_waterfallSocket->closeCode())
-                    : -1)
-            << "reason="
-            << (m_waterfallSocket ? m_waterfallSocket->closeReason() : QString());
+            << "KiwiSDR W/F closed"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "code=" << closeCode
+            << "reason=" << closeReason;
+        traceClose(StreamKind::Waterfall, closeCode, closeReason);
         if (!m_userDisconnecting) {
             if (retryWithSecureWebSocket(m_waterfallSocketConnected)) {
                 return;
@@ -393,8 +645,11 @@ void KiwiSdrClient::openWebSockets()
                                                     : tr("KiwiSDR waterfall socket error."),
                                   m_waterfallSocketConnected);
             });
-    qCInfo(lcKiwiSdr).noquote() << "KiwiSDR W/F URL" << waterfallUrl;
-    m_waterfallSocket->open(QUrl(waterfallUrl));
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR W/F URL"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << waterfallUrl;
+    m_waterfallSocket->open(kiwiWebSocketRequest(waterfallUrl, origin));
 }
 #endif
 
@@ -478,7 +733,7 @@ void KiwiSdrClient::setWaterfallDisplayAdjustments(int cellDb, int floorDb)
 
 void KiwiSdrClient::setWaterfallRateOverride(int rate)
 {
-    const int clamped = std::clamp(rate, 0, 5);
+    const int clamped = std::clamp(rate, 0, 4);
     if (m_waterfallRateOverride == clamped) {
         return;
     }
@@ -581,13 +836,38 @@ void KiwiSdrClient::cleanupSockets()
     m_loggedSoundFrameShape = false;
     m_loggedWaterfallFrameShape = false;
     m_lastDecodedSoundPcm.clear();
+    m_soundAudioRateText.clear();
+    m_haveSoundAudioRate = false;
+    m_haveSoundSampleRate = false;
+    m_soundDiagWindowStartUtcMs = 0;
+    m_lastSoundFrameUtcMs = 0;
+    m_lastSoundKeepaliveSentUtcMs = 0;
+    m_soundDiagFrames = 0;
+    m_soundDiagBytes = 0;
+    m_soundDiagDecodedSamples = 0;
+    m_waterfallDiagWindowStartUtcMs = 0;
+    m_lastWaterfallFrameUtcMs = 0;
+    m_waterfallDiagFrames = 0;
+    m_waterfallDiagBytes = 0;
     m_lastWaterfallBins.clear();
     m_lastWaterfallPanId.clear();
     m_lastWaterfallLowMhz = 0.0;
     m_lastWaterfallHighMhz = 0.0;
     m_lastWaterfallRowValid = false;
+    m_waterfallAvailable = true;
+    m_waterfallAvailabilityDetail.clear();
+    m_waterfallRxChannel = -1;
+    m_waterfallChannelCount = -1;
+    emit waterfallAvailabilityChanged(true, QString());
 
 #ifdef HAVE_WEBSOCKETS
+    if (m_statusReply) {
+        m_statusReply->disconnect(this);
+        m_statusReply->abort();
+        m_statusReply->deleteLater();
+        m_statusReply = nullptr;
+    }
+
     auto cleanup = [this](QWebSocket*& socket) {
         if (!socket) {
             return;
@@ -618,8 +898,11 @@ void KiwiSdrClient::sendSoundAudioRateAck()
     }
 
     m_soundAudioRateAcked = true;
+    const QString inputRate = !m_soundAudioRateText.isEmpty()
+        ? m_soundAudioRateText
+        : QString::number(m_soundSampleRateHz, 'f', 0);
     sendSoundCommand(QStringLiteral("SET AR OK in=%1 out=24000")
-        .arg(m_soundSampleRateHz, 0, 'f', 0));
+        .arg(inputRate));
 }
 
 void KiwiSdrClient::sendSoundSampleRateCommands()
@@ -630,6 +913,10 @@ void KiwiSdrClient::sendSoundSampleRateCommands()
 
     if (!m_soundAudioRateAcked) {
         m_soundSampleRatePending = true;
+        qCDebug(lcKiwiSdr).noquote()
+            << "KiwiSDR SND setup waiting"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "missing=audio_rate";
         return;
     }
 
@@ -685,7 +972,9 @@ void KiwiSdrClient::sendTrackedSliceToServer()
     const int highCutHz = kiwiHighCutHz();
     if (lowCutHz >= highCutHz) {
         qCWarning(lcKiwiSdr).noquote()
-            << "KiwiSDR refusing invalid passband mode=" << mode
+            << "KiwiSDR refusing invalid passband"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "mode=" << mode
             << "freq_khz=" << QString::number(freqKhz, 'f', 3)
             << "low_cut=" << lowCutHz
             << "high_cut=" << highCutHz;
@@ -835,11 +1124,8 @@ void KiwiSdrClient::sendWaterfallViewToServer()
     m_lastWaterfallHighMhz = 0.0;
     m_lastWaterfallRowValid = false;
 
-    const double centerFreqKhz = ((requestLowMhz + requestHighMhz) * 0.5)
-        * 1000.0;
-    sendWaterfallCommand(QStringLiteral("SET zoom=%1 cf=%2 start=%3")
+    sendWaterfallCommand(QStringLiteral("SET zoom=%1 start=%2")
         .arg(zoom)
-        .arg(centerFreqKhz, 0, 'f', 3)
         .arg(start));
 }
 
@@ -970,13 +1256,11 @@ bool KiwiSdrClient::isSupportedPcmSoundFrame(
     if (!header.valid) {
         return false;
     }
-
-    const bool observedExtendedFrame = frame.size() == kObservedSoundFrameBytes;
-    if (observedExtendedFrame) {
-        return true;
+    if (soundFrameCompressed(header.flags)) {
+        return false;
     }
 
-    const int sampleBytes = frame.size() - kSpecSoundHeaderBytes;
+    const int sampleBytes = frame.size() - soundPayloadOffset(frame);
     if (sampleBytes <= 0 || (sampleBytes % 2) != 0) {
         return false;
     }
@@ -990,11 +1274,10 @@ QByteArray KiwiSdrClient::decodeSoundFrame(const QByteArray& frame)
         return {};
     }
 
-    int payloadOffset = kSpecSoundHeaderBytes;
-    const bool observedExtendedFrame = frame.size() == kObservedSoundFrameBytes;
-    if (observedExtendedFrame) {
-        payloadOffset = kObservedSoundHeaderBytes;
-    }
+    const KiwiSdrProtocol::SoundFrameHeader header =
+        KiwiSdrProtocol::parseSoundFrameHeader(frame);
+    const int payloadOffset = soundPayloadOffset(frame);
+    const bool littleEndian = header.valid && soundFrameLittleEndian(header.flags);
     const int sampleBytes = frame.size() - payloadOffset;
     const int inSamples = sampleBytes / 2;
     if (inSamples <= 0 || (sampleBytes % 2) != 0) {
@@ -1005,12 +1288,12 @@ QByteArray KiwiSdrClient::decodeSoundFrame(const QByteArray& frame)
     const auto* data = reinterpret_cast<const uchar*>(frame.constData() + payloadOffset);
     for (int i = 0; i < inSamples; ++i) {
         int sample = 0;
-        if (observedExtendedFrame) {
-            sample = (static_cast<int>(data[2 * i]) << 8)
-                   | static_cast<int>(data[2 * i + 1]);
-        } else {
+        if (littleEndian) {
             sample = static_cast<int>(data[2 * i])
                    | (static_cast<int>(data[2 * i + 1]) << 8);
+        } else {
+            sample = (static_cast<int>(data[2 * i]) << 8)
+                   | static_cast<int>(data[2 * i + 1]);
         }
         if (sample & 0x8000) {
             sample -= 0x10000;
@@ -1085,7 +1368,9 @@ QVector<float> KiwiSdrClient::decodeWaterfallFrame(const QByteArray& frame) cons
         // from endpoints that ignore that request until a clean decoder is
         // available.
         qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR W/F compressed row ignored len=" << frame.size()
+            << "KiwiSDR W/F compressed row ignored"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "len=" << frame.size()
             << "zoom=" << frameZoom
             << "first=" << firstBytesHex(frame);
         return {};
@@ -1103,22 +1388,27 @@ QVector<float> KiwiSdrClient::decodeWaterfallFrame(const QByteArray& frame) cons
     return bins;
 }
 
-void KiwiSdrClient::handleBinaryMessage(const QByteArray& frame)
+void KiwiSdrClient::handleBinaryMessage(StreamKind stream,
+                                        const QByteArray& frame)
 {
+    traceInboundBinary(stream, frame);
     if (frame.startsWith("MSG")) {
-        handleMessage(frame);
+        handleMessage(stream, frame);
     } else if (frame.startsWith("SND")) {
         handleSoundFrame(frame);
     } else if (frame.startsWith("W/F")) {
         handleWaterfallFrame(frame);
     } else if (frame.startsWith("EXT")) {
         qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR EXT ignored len=" << frame.size()
+            << "KiwiSDR EXT ignored"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     } else {
         const QString tag = QString::fromLatin1(frame.left(3));
         qCDebug(lcKiwiSdr).noquote()
             << "KiwiSDR unknown binary tag=" << tag
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
             << "len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     }
@@ -1127,18 +1417,69 @@ void KiwiSdrClient::handleBinaryMessage(const QByteArray& frame)
 void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
 {
     m_soundFrameSeen = true;
-    if (!m_loggedSoundFrameShape) {
+    const qint64 nowUtcMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 deltaMs = m_lastSoundFrameUtcMs > 0
+        ? nowUtcMs - m_lastSoundFrameUtcMs
+        : 0;
+    m_lastSoundFrameUtcMs = nowUtcMs;
+    const bool logSoundFrameShape = !m_loggedSoundFrameShape;
+    if (logSoundFrameShape) {
         m_loggedSoundFrameShape = true;
         qCDebug(lcKiwiSdrAudio).noquote()
-            << "KiwiSDR SND frame len=" << frame.size()
+            << "KiwiSDR SND frame"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     }
     const KiwiSdrProtocol::SoundFrameHeader header =
         KiwiSdrProtocol::parseSoundFrameHeader(frame);
+    const int payloadOffset = header.valid ? soundPayloadOffset(frame) : 0;
+    const qsizetype payloadBytes =
+        std::max<qsizetype>(0, frame.size() - payloadOffset);
     if (!isSupportedPcmSoundFrame(frame, header)) {
+        if (header.valid && soundFrameCompressed(header.flags)) {
+            qCWarning(lcKiwiSdrAudio).noquote()
+                << "KiwiSDR SND compressed audio unsupported"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << "len=" << frame.size()
+                << "first=" << firstBytesHex(frame)
+                << "flags=0x"
+                << QString::number(header.flags, 16).rightJustified(
+                       2, QLatin1Char('0'))
+                << "compressed=true"
+                << "payload_offset=" << payloadOffset
+                << "payload_len=" << payloadBytes
+                << "decoder=unsupported-compressed"
+                << "audio_rate=" << QString::number(m_soundSampleRateHz, 'f', 0)
+                << "sequence=" << header.sequence
+                << "receive_utc_ms=" << nowUtcMs
+                << "delta_ms=" << deltaMs;
+            setState(State::Error,
+                     tr("Unsupported KiwiSDR compressed SND audio."));
+            cleanupSockets();
+            return;
+        }
         qCWarning(lcKiwiSdrAudio).noquote()
-            << "KiwiSDR SND unsupported frame shape len=" << frame.size()
-            << "first=" << firstBytesHex(frame);
+            << "KiwiSDR SND unsupported frame shape"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "len=" << frame.size()
+            << "first=" << firstBytesHex(frame)
+            << "flags=0x"
+            << (header.valid
+                    ? QString::number(header.flags, 16).rightJustified(
+                          2, QLatin1Char('0'))
+                    : QStringLiteral("--"))
+            << "compressed="
+            << (header.valid && soundFrameCompressed(header.flags)
+                    ? QStringLiteral("true")
+                    : QStringLiteral("false"))
+            << "payload_offset=" << payloadOffset
+            << "payload_len=" << payloadBytes
+            << "decoder=unsupported-pcm-shape"
+            << "audio_rate=" << QString::number(m_soundSampleRateHz, 'f', 0)
+            << "sequence=" << header.sequence
+            << "receive_utc_ms=" << nowUtcMs
+            << "delta_ms=" << deltaMs;
         return;
     }
     const quint64 sequenceGaps = header.valid
@@ -1150,12 +1491,89 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
         KiwiSdrProtocol::extractMeterFromSndVerifiedLayout(
             frame, KiwiSdrProtocol::MeterContext{});
     markSoundAudioReady();
+    ++m_soundDiagFrames;
+    m_soundDiagBytes += static_cast<quint64>(frame.size());
+    m_soundDiagDecodedSamples += static_cast<quint64>(payloadBytes / 2);
+    if (m_soundDiagWindowStartUtcMs == 0) {
+        m_soundDiagWindowStartUtcMs = nowUtcMs;
+    }
+    const qint64 diagElapsedMs = nowUtcMs - m_soundDiagWindowStartUtcMs;
+    if (diagElapsedMs >= 1000) {
+        const double elapsedSeconds =
+            static_cast<double>(diagElapsedMs) / 1000.0;
+        const qint64 keepaliveAgeMs = m_lastSoundKeepaliveSentUtcMs > 0
+            ? nowUtcMs - m_lastSoundKeepaliveSentUtcMs
+            : -1;
+        qCDebug(lcKiwiSdrAudio).noquote()
+            << "KiwiSDR SND rate"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "frames_per_sec="
+            << QString::number(static_cast<double>(m_soundDiagFrames)
+                               / elapsedSeconds, 'f', 1)
+            << "bytes_per_sec="
+            << QString::number(static_cast<double>(m_soundDiagBytes)
+                               / elapsedSeconds, 'f', 0)
+            << "decoded_samples_per_sec="
+            << QString::number(static_cast<double>(m_soundDiagDecodedSamples)
+                               / elapsedSeconds, 'f', 0)
+            << "last_delta_ms=" << deltaMs
+            << "audio_rate=" << QString::number(m_soundSampleRateHz, 'f', 0)
+            << "keepalive_age_ms=" << keepaliveAgeMs;
+        const qint64 msgAgeMs = m_lastInboundMsgUtcMs > 0
+            ? nowUtcMs - m_lastInboundMsgUtcMs
+            : -1;
+        const qint64 outAgeMs = m_lastOutboundCommandUtcMs > 0
+            ? nowUtcMs - m_lastOutboundCommandUtcMs
+            : -1;
+        traceProtocolEvent(
+            QStringLiteral("RATE SND frames_per_sec=%1 bytes_per_sec=%2 "
+                           "decoded_samples_per_sec=%3 "
+                           "receive_queue_depth=n/a audio_queue_depth=n/a "
+                           "dropped_frames=%4 last_keepalive_age_ms=%5 "
+                           "last_inbound_msg_age_ms=%6 "
+                           "last_outbound_command_age_ms=%7")
+                .arg(QString::number(static_cast<double>(m_soundDiagFrames)
+                                     / elapsedSeconds, 'f', 1))
+                .arg(QString::number(static_cast<double>(m_soundDiagBytes)
+                                     / elapsedSeconds, 'f', 0))
+                .arg(QString::number(
+                    static_cast<double>(m_soundDiagDecodedSamples)
+                        / elapsedSeconds,
+                    'f',
+                    0))
+                .arg(m_telemetry.soundSequenceGaps)
+                .arg(keepaliveAgeMs)
+                .arg(msgAgeMs)
+                .arg(outAgeMs));
+        m_soundDiagWindowStartUtcMs = nowUtcMs;
+        m_soundDiagFrames = 0;
+        m_soundDiagBytes = 0;
+        m_soundDiagDecodedSamples = 0;
+    }
     if (!m_audioActive && !m_decodeAudioWhenInactive) {
         return;
     }
 
     const QByteArray pcm = decodeSoundFrame(frame);
     if (!pcm.isEmpty()) {
+        if (logSoundFrameShape) {
+            qCDebug(lcKiwiSdrAudio).noquote()
+                << "KiwiSDR SND decode"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << "len=" << frame.size()
+                << "flags=0x"
+                << QString::number(header.flags, 16).rightJustified(
+                       2, QLatin1Char('0'))
+                << "compressed=false"
+                << "payload_offset=" << payloadOffset
+                << "payload_len=" << payloadBytes
+                << "decoder=pcm16"
+                << "decoded_samples=" << (payloadBytes / 2)
+                << "audio_rate=" << QString::number(m_soundSampleRateHz, 'f', 0)
+                << "sequence=" << header.sequence
+                << "receive_utc_ms=" << nowUtcMs
+                << "delta_ms=" << deltaMs;
+        }
         const quint64 padFrames = std::min(sequenceGaps,
                                           kMaxSequenceGapPaddingFrames);
         if (!m_lastDecodedSoundPcm.isEmpty()) {
@@ -1171,10 +1589,53 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
 
 void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
 {
+    const qint64 nowUtcMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 deltaMs = m_lastWaterfallFrameUtcMs > 0
+        ? nowUtcMs - m_lastWaterfallFrameUtcMs
+        : 0;
+    m_lastWaterfallFrameUtcMs = nowUtcMs;
+    ++m_waterfallDiagFrames;
+    m_waterfallDiagBytes += static_cast<quint64>(frame.size());
+    if (m_waterfallDiagWindowStartUtcMs == 0) {
+        m_waterfallDiagWindowStartUtcMs = nowUtcMs;
+    }
+    const qint64 diagElapsedMs = nowUtcMs - m_waterfallDiagWindowStartUtcMs;
+    if (diagElapsedMs >= 1000) {
+        const double elapsedSeconds =
+            static_cast<double>(diagElapsedMs) / 1000.0;
+        traceProtocolEvent(
+            QStringLiteral("RATE W/F frames_per_sec=%1 bytes_per_sec=%2 "
+                           "dropped_frames=%3 last_delta_ms=%4 "
+                           "request_valid=%5 request_zoom=%6 request_start=%7 "
+                           "request_low_mhz=%8 request_high_mhz=%9")
+                .arg(QString::number(static_cast<double>(
+                                         m_waterfallDiagFrames)
+                                     / elapsedSeconds,
+                                     'f',
+                                     1))
+                .arg(QString::number(static_cast<double>(
+                                         m_waterfallDiagBytes)
+                                     / elapsedSeconds,
+                                     'f',
+                                     0))
+                .arg(m_telemetry.waterfallSequenceGaps)
+                .arg(deltaMs)
+                .arg(m_waterfallRequestValid ? QStringLiteral("true")
+                                             : QStringLiteral("false"))
+                .arg(m_waterfallRequestZoom)
+                .arg(m_waterfallRequestStart)
+                .arg(QString::number(m_waterfallRequestLowMhz, 'f', 6))
+                .arg(QString::number(m_waterfallRequestHighMhz, 'f', 6)));
+        m_waterfallDiagWindowStartUtcMs = nowUtcMs;
+        m_waterfallDiagFrames = 0;
+        m_waterfallDiagBytes = 0;
+    }
     if (!m_loggedWaterfallFrameShape) {
         m_loggedWaterfallFrameShape = true;
         qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR W/F frame len=" << frame.size()
+            << "KiwiSDR W/F frame"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "len=" << frame.size()
             << "first=" << firstBytesHex(frame);
     }
     const KiwiSdrProtocol::WaterfallLineHeader header =
@@ -1262,14 +1723,15 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
     m_lastWaterfallRowValid = true;
 }
 
-void KiwiSdrClient::handleMessage(const QByteArray& frame)
+void KiwiSdrClient::handleMessage(StreamKind stream, const QByteArray& frame)
 {
     const QString text = QString::fromLatin1(frame.constData(), frame.size());
-    handleTextMessage(text);
+    handleTextMessage(stream, text);
 }
 
-void KiwiSdrClient::handleTextMessage(const QString& text)
+void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
 {
+    traceInboundText(stream, text);
     const QString message = text.startsWith(QStringLiteral("MSG"))
         ? text.mid(3).trimmed()
         : text.trimmed();
@@ -1296,16 +1758,24 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
         const QString key = part.left(eq);
         const QString valueText = part.mid(eq + 1);
         qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR MSG" << key << "=" << valueText;
+            << "KiwiSDR MSG"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << key << "=" << abbreviatedMsgValue(valueText);
+        traceProtocolEvent(QStringLiteral("PARSED %1 %2=%3")
+            .arg(streamLabel(stream), key, abbreviatedMsgValue(valueText)));
         if (key == QStringLiteral("too_busy")) {
             bool busyOk = false;
             const int busyValue = valueText.toInt(&busyOk);
-            if (!busyOk || busyValue != 0) {
-                setState(State::Error, tr("KiwiSDR endpoint is busy."));
-                cleanupSockets();
-                return;
-            }
-            continue;
+            // KiwiSDR sends too_busy on denial paths, not as a negative
+            // status. A value of zero means the server configured zero
+            // simultaneous non-Kiwi/API client channels.
+            const QString detail =
+                busyOk && busyValue == 0
+                    ? tr("This KiwiSDR operator does not allow external API clients such as AetherSDR.")
+                    : tr("KiwiSDR endpoint is busy.");
+            setState(State::Error, detail);
+            cleanupSockets();
+            return;
         }
         if (key == QStringLiteral("reason_disabled")) {
             const QString reason =
@@ -1345,7 +1815,9 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
             return;
         }
         if (key == QStringLiteral("audio_init")) {
-            markSoundAudioReady();
+            // audio_init confirms setup progress, not usable decoded audio.
+            // Wait for the first accepted SND frame so camping/silent sessions
+            // do not look connected or stop the setup watchdog early.
             continue;
         }
 
@@ -1356,6 +1828,9 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
         }
         if (key == QStringLiteral("badp")) {
             const int badp = static_cast<int>(value);
+            if (badp != 0) {
+                m_startupTrace.badpNonzeroSeen = true;
+            }
             if (badp != 0) {
                 setState(
                     State::Error,
@@ -1387,14 +1862,34 @@ void KiwiSdrClient::handleTextMessage(const QString& text)
             sendWaterfallViewToServer();
         } else if (key == QStringLiteral("wf_fft_size")) {
             updateWaterfallFftBins(static_cast<int>(value));
+        } else if (stream == StreamKind::Waterfall
+                   && key == QStringLiteral("rx_chan")) {
+            m_waterfallRxChannel = static_cast<int>(value);
+            updateWaterfallAvailability();
+        } else if (stream == StreamKind::Waterfall
+                   && key == QStringLiteral("wf_chans")) {
+            const int channelCount = static_cast<int>(value);
+            if (channelCount >= 0) {
+                m_waterfallChannelCount = channelCount;
+                updateWaterfallAvailability();
+            }
+        } else if (stream == StreamKind::Waterfall
+                   && key == QStringLiteral("wf_chans_real")) {
+            const int channelCount = static_cast<int>(value);
+            if (channelCount > 0) {
+                m_waterfallChannelCount = channelCount;
+                updateWaterfallAvailability();
+            }
         } else if (key == QStringLiteral("audio_rate")) {
             m_haveSoundAudioRate = true;
+            m_soundAudioRateText = valueText;
             setSoundSampleRate(value);
             sendSoundAudioRateAck();
             if (m_soundSampleRatePending) {
                 sendSoundSampleRateCommands();
             }
         } else if (key == QStringLiteral("sample_rate")) {
+            m_haveSoundSampleRate = true;
             sendSoundSampleRateCommands();
         } else if (key == QStringLiteral("users")) {
             const int users = static_cast<int>(value);
@@ -1441,6 +1936,38 @@ bool KiwiSdrClient::updateWaterfallFftBins(int binCount)
     m_waterfallRequestValid = false;
     sendWaterfallViewToServer();
     return true;
+}
+
+void KiwiSdrClient::updateWaterfallAvailability()
+{
+    bool available = true;
+    QString detail;
+    if (m_waterfallRxChannel >= 0 && m_waterfallChannelCount > 0
+        && m_waterfallRxChannel >= m_waterfallChannelCount) {
+        available = false;
+        detail = tr("No KiwiSDR waterfall channel is available. Audio is connected on receiver slot %1, but this server only provides %2 waterfall channels.")
+            .arg(m_waterfallRxChannel + 1)
+            .arg(m_waterfallChannelCount);
+    } else if (m_waterfallRxChannel >= 0 && m_waterfallChannelCount == 0) {
+        available = false;
+        detail = tr("No KiwiSDR waterfall channel is available for this receiver slot.");
+    }
+
+    if (m_waterfallAvailable == available
+        && m_waterfallAvailabilityDetail == detail) {
+        return;
+    }
+
+    m_waterfallAvailable = available;
+    m_waterfallAvailabilityDetail = detail;
+    if (!available) {
+        qCWarning(lcKiwiSdr).noquote()
+            << "KiwiSDR waterfall unavailable"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "rx_chan=" << m_waterfallRxChannel
+            << "wf_chans=" << m_waterfallChannelCount;
+    }
+    emit waterfallAvailabilityChanged(available, detail);
 }
 
 void KiwiSdrClient::updateSoundTelemetry(const QByteArray& frame)
@@ -1511,15 +2038,12 @@ void KiwiSdrClient::sendWaterfallRateToServer()
         return;
     }
 
-    const int flexRate = std::clamp(m_waterfallLineDurationMs, 1, 100);
-    // Clean-room W/F probes on public endpoints showed that the supported
-    // speed control is a compact 1..4 range. On 22033.proxy.kiwisdr.com,
-    // values 5 and above echoed wf_fps=0 and produced no W/F rows.
-    const int speed = std::clamp(
-        1 + static_cast<int>(std::lround((flexRate - 1) * 3.0 / 99.0)),
-        1,
-        4);
-    sendWaterfallCommand(QStringLiteral("SET wf_speed=%1").arg(speed));
+    // Auto mode requests the fastest validated compact Kiwi speed. Public
+    // endpoints advertise wf_fps before this command, but some do not emit
+    // W/F rows until a speed is selected. Clean black-box observations showed
+    // wf_speed=1 is slow, 2 is about 5 fps, 3 is about 13 fps, and 5+ can stop
+    // rows entirely; keep auto at the highest accepted value.
+    sendWaterfallCommand(QStringLiteral("SET wf_speed=4"));
 }
 
 void KiwiSdrClient::markSoundAudioReady()
@@ -1535,8 +2059,342 @@ void KiwiSdrClient::markSoundAudioReady()
     setState(State::Connected, tr("Connected to %1.").arg(m_endpoint));
 }
 
+QString KiwiSdrClient::logEndpoint() const
+{
+    if (!m_endpoint.isEmpty()) {
+        return m_endpoint;
+    }
+    if (!m_host.isEmpty() && m_port > 0) {
+        return QStringLiteral("%1:%2").arg(m_host).arg(m_port);
+    }
+    if (!m_host.isEmpty()) {
+        return m_host;
+    }
+    return QStringLiteral("<unset>");
+}
+
+QString KiwiSdrClient::setupTimeoutDetail() const
+{
+    if (m_soundSampleRateCommandsSent) {
+        return tr("KiwiSDR sound setup completed for %1, but no SND audio frames arrived.")
+            .arg(logEndpoint());
+    }
+
+    QStringList missing;
+    if (!m_haveSoundSampleRate) {
+        missing.append(QStringLiteral("sample_rate"));
+    }
+    if (!m_haveSoundAudioRate) {
+        missing.append(QStringLiteral("audio_rate"));
+    }
+    if (missing.isEmpty()) {
+        return tr("No KiwiSDR audio channel became available from %1.")
+            .arg(logEndpoint());
+    }
+    return tr("No KiwiSDR audio channel became available from %1 (missing %2).")
+        .arg(logEndpoint(), missing.join(QStringLiteral(", ")));
+}
+
+QString KiwiSdrClient::streamLabel(StreamKind stream)
+{
+    switch (stream) {
+    case StreamKind::Sound:
+        return QStringLiteral("SND");
+    case StreamKind::Waterfall:
+        return QStringLiteral("W/F");
+    }
+    return QStringLiteral("?");
+}
+
+void KiwiSdrClient::resetProtocolTrace()
+{
+    m_protocolTraceStartUtcMs = QDateTime::currentMSecsSinceEpoch();
+    m_protocolTraceTail.clear();
+    m_lastOutboundCommand.clear();
+    m_lastInboundMsg.clear();
+    m_lastInboundFrameType.clear();
+    m_lastOutboundCommandUtcMs = 0;
+    m_lastInboundMsgUtcMs = 0;
+    m_lastInboundFrameUtcMs = 0;
+    m_startupTrace = {};
+    m_protocolSendFailed = false;
+}
+
+qint64 KiwiSdrClient::protocolTraceElapsedMs() const
+{
+    if (m_protocolTraceStartUtcMs <= 0) {
+        return 0;
+    }
+    return QDateTime::currentMSecsSinceEpoch() - m_protocolTraceStartUtcMs;
+}
+
+void KiwiSdrClient::traceProtocolEvent(const QString& event)
+{
+    const QString line = QStringLiteral("%1ms %2")
+        .arg(protocolTraceElapsedMs(), 4, 10, QLatin1Char('0'))
+        .arg(event);
+
+    m_protocolTraceTail.append(line);
+    while (m_protocolTraceTail.size() > 20) {
+        m_protocolTraceTail.removeFirst();
+    }
+}
+
+void KiwiSdrClient::traceConnectionInfo(const QString& scheme,
+                                        quint16 socketPort,
+                                        const QString& sessionId,
+                                        const QString& origin,
+                                        const QString& soundUrl,
+                                        const QString& waterfallUrl)
+{
+    traceProtocolEvent(QStringLiteral("CONNECT scheme=%1 port=%2 origin=%3 "
+                                      "user_agent=AetherSDR client_ip=unknown "
+                                      "timestamp=%4 same_timestamp=yes "
+                                      "path_style=/ws/kiwi/TIMESTAMP/STREAM")
+        .arg(scheme)
+        .arg(socketPort)
+        .arg(origin)
+        .arg(sessionId));
+    traceProtocolEvent(QStringLiteral("URL SND %1").arg(soundUrl));
+    traceProtocolEvent(QStringLiteral("URL W/F %1").arg(waterfallUrl));
+}
+
+void KiwiSdrClient::updateStartupTraceForOutbound(StreamKind stream,
+                                                  const QString& command,
+                                                  bool sent)
+{
+    if (!sent || stream != StreamKind::Sound) {
+        return;
+    }
+
+    if (command.startsWith(QStringLiteral("SET auth "))) {
+        m_startupTrace.authSent = true;
+    } else if (command.startsWith(QStringLiteral("SET ident_user="))) {
+        m_startupTrace.identUserSent = true;
+    } else if (command.startsWith(QStringLiteral("SET browser="))) {
+        m_startupTrace.browserSent = true;
+    } else if (command == QStringLiteral("SET compression=0")) {
+        m_startupTrace.compressionSent = true;
+    } else if (command.startsWith(QStringLiteral("SET AR OK "))) {
+        m_startupTrace.arOkSent = true;
+        const QString expected = QStringLiteral("in=%1").arg(m_soundAudioRateText);
+        m_startupTrace.arOkUsedActualAudioRate =
+            m_haveSoundAudioRate
+            && !m_soundAudioRateText.isEmpty()
+            && command.contains(expected);
+    } else if (command.startsWith(QStringLiteral("SERVER DE CLIENT "))) {
+        m_startupTrace.serverDeClientSent = true;
+    } else if (command.startsWith(QStringLiteral("SET squelch="))) {
+        m_startupTrace.squelchSent = true;
+    } else if (command == QStringLiteral("SET genattn=0")) {
+        m_startupTrace.genattnSent = true;
+    } else if (command.startsWith(QStringLiteral("SET gen="))) {
+        m_startupTrace.genSent = true;
+    } else if (command.startsWith(QStringLiteral("SET agc="))) {
+        m_startupTrace.agcSent = true;
+    } else if (command.startsWith(QStringLiteral("SET mod="))) {
+        m_startupTrace.modSent = true;
+    } else if (command == QStringLiteral("SET keepalive")) {
+        m_startupTrace.keepaliveSentOnSound = true;
+    }
+}
+
+void KiwiSdrClient::traceOutboundCommand(StreamKind stream,
+                                         const QString& command,
+                                         bool sent)
+{
+    const QString visible = redactedKiwiCommand(command);
+    m_lastOutboundCommand =
+        QStringLiteral("%1 %2").arg(streamLabel(stream), visible);
+    m_lastOutboundCommandUtcMs = QDateTime::currentMSecsSinceEpoch();
+    if (!sent) {
+        m_protocolSendFailed = true;
+    }
+    updateStartupTraceForOutbound(stream, command, sent);
+    traceProtocolEvent(QStringLiteral("OUT %1 %2%3")
+        .arg(streamLabel(stream),
+             visible,
+             sent ? QString() : QStringLiteral(" send_failed=true")));
+}
+
+void KiwiSdrClient::traceInboundText(StreamKind stream, const QString& text)
+{
+    const QString visible = abbreviatedMsgValue(text);
+    m_lastInboundMsg = QStringLiteral("%1 %2").arg(streamLabel(stream), visible);
+    m_lastInboundMsgUtcMs = QDateTime::currentMSecsSinceEpoch();
+    traceProtocolEvent(QStringLiteral("IN %1 %2")
+        .arg(streamLabel(stream), visible));
+}
+
+void KiwiSdrClient::traceInboundBinary(StreamKind stream,
+                                       const QByteArray& frame)
+{
+    const qint64 nowUtcMs = QDateTime::currentMSecsSinceEpoch();
+    const QString label = streamLabel(stream);
+    m_lastInboundFrameType =
+        QStringLiteral("%1 binary len=%2").arg(label).arg(frame.size());
+    m_lastInboundFrameUtcMs = nowUtcMs;
+
+    if (stream != StreamKind::Sound || !frame.startsWith("SND")) {
+        return;
+    }
+
+    const KiwiSdrProtocol::SoundFrameHeader header =
+        KiwiSdrProtocol::parseSoundFrameHeader(frame);
+    const int payloadOffset = header.valid ? soundPayloadOffset(frame) : 0;
+    const int payloadBytes = static_cast<int>(
+        std::max<qsizetype>(0, frame.size() - payloadOffset));
+    const bool compressed = header.valid && soundFrameCompressed(header.flags);
+    const qint64 deltaMs = m_lastSoundFrameUtcMs > 0
+        ? nowUtcMs - m_lastSoundFrameUtcMs
+        : 0;
+    QString rawSmeter = QStringLiteral("n/a");
+    if (frame.size() >= kObservedSoundHeaderBytes) {
+        const auto* bytes = reinterpret_cast<const uchar*>(frame.constData());
+        const quint16 raw =
+            (static_cast<quint16>(bytes[8]) << 8)
+            | static_cast<quint16>(bytes[9]);
+        rawSmeter = QString::number(static_cast<qint16>(raw));
+    }
+
+    traceProtocolEvent(QStringLiteral("IN SND binary len=%1 first16=%2 "
+                                      "flags=0x%3 compressed=%4 seq=%5 "
+                                      "raw_smeter=%6 payload_offset=%7 "
+                                      "payload_len=%8 decoder=%9 "
+                                      "decoded_sample_count=%10 "
+                                      "audio_rate=%11 expected_samples_per_sec=%12 "
+                                      "receive_utc_ms=%13 delta_ms=%14")
+        .arg(frame.size())
+        .arg(firstBytesHex(frame))
+        .arg(header.valid
+                 ? QString::number(header.flags, 16)
+                       .rightJustified(2, QLatin1Char('0'))
+                 : QStringLiteral("--"))
+        .arg(compressed ? QStringLiteral("true") : QStringLiteral("false"))
+        .arg(header.valid ? QString::number(header.sequence)
+                          : QStringLiteral("n/a"))
+        .arg(rawSmeter)
+        .arg(payloadOffset)
+        .arg(payloadBytes)
+        .arg(compressed ? QStringLiteral("unsupported-compressed")
+                        : QStringLiteral("pcm16"))
+        .arg(compressed ? 0 : payloadBytes / 2)
+        .arg(QString::number(m_soundSampleRateHz, 'f', 0))
+        .arg(QString::number(m_soundSampleRateHz, 'f', 0))
+        .arg(nowUtcMs)
+        .arg(deltaMs));
+}
+
+void KiwiSdrClient::traceClose(StreamKind stream, int closeCode,
+                               const QString& reason)
+{
+    auto boolText = [](bool value) {
+        return value ? QStringLiteral("true") : QStringLiteral("false");
+    };
+    const qint64 nowUtcMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 keepaliveAgeMs = m_lastSoundKeepaliveSentUtcMs > 0
+        ? nowUtcMs - m_lastSoundKeepaliveSentUtcMs
+        : -1;
+    const qint64 lastOutboundAgeMs = m_lastOutboundCommandUtcMs > 0
+        ? nowUtcMs - m_lastOutboundCommandUtcMs
+        : -1;
+    const qint64 lastMsgAgeMs = m_lastInboundMsgUtcMs > 0
+        ? nowUtcMs - m_lastInboundMsgUtcMs
+        : -1;
+    const qint64 lastFrameAgeMs = m_lastInboundFrameUtcMs > 0
+        ? nowUtcMs - m_lastInboundFrameUtcMs
+        : -1;
+    const bool sndFramesContinuous =
+        m_soundFrameSeen && m_telemetry.soundSequenceGaps == 0;
+    const bool keepaliveTimerRunning =
+        m_keepaliveTimer && m_keepaliveTimer->isActive();
+
+    const QStringList closeFields{
+        QStringLiteral("code=%1").arg(closeCode),
+        QStringLiteral("reason=%1").arg(reason),
+        QStringLiteral("connection_duration_ms=%1")
+            .arg(protocolTraceElapsedMs()),
+        QStringLiteral("last_outbound_command=\"%1\"")
+            .arg(m_lastOutboundCommand),
+        QStringLiteral("last_outbound_age_ms=%1").arg(lastOutboundAgeMs),
+        QStringLiteral("last_inbound_msg=\"%1\"").arg(m_lastInboundMsg),
+        QStringLiteral("last_inbound_msg_age_ms=%1").arg(lastMsgAgeMs),
+        QStringLiteral("last_inbound_frame_type=\"%1\"")
+            .arg(m_lastInboundFrameType),
+        QStringLiteral("last_inbound_frame_age_ms=%1").arg(lastFrameAgeMs),
+        QStringLiteral("last_keepalive_age_ms=%1").arg(keepaliveAgeMs),
+        QStringLiteral("send_failed=%1").arg(boolText(m_protocolSendFailed)),
+    };
+
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR TRACE"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << QStringLiteral("%1ms CLOSE %2 %3")
+               .arg(protocolTraceElapsedMs(), 4, 10, QLatin1Char('0'))
+               .arg(streamLabel(stream),
+                    closeFields.join(QLatin1Char(' ')));
+
+    const QStringList startupFields{
+        QStringLiteral("auth_sent=%1").arg(boolText(m_startupTrace.authSent)),
+        QStringLiteral("auth_accepted_or_no_badp_seen=%1")
+            .arg(boolText(!m_startupTrace.badpNonzeroSeen)),
+        QStringLiteral("ident_user_sent=%1")
+            .arg(boolText(m_startupTrace.identUserSent)),
+        QStringLiteral("browser_sent=%1").arg(boolText(m_startupTrace.browserSent)),
+        QStringLiteral("compression_sent=%1")
+            .arg(boolText(m_startupTrace.compressionSent)),
+        QStringLiteral("audio_rate_seen=%1").arg(boolText(m_haveSoundAudioRate)),
+        QStringLiteral("ar_ok_sent=%1").arg(boolText(m_startupTrace.arOkSent)),
+        QStringLiteral("ar_ok_used_actual_audio_rate=%1")
+            .arg(boolText(m_startupTrace.arOkUsedActualAudioRate)),
+        QStringLiteral("sample_rate_seen=%1")
+            .arg(boolText(m_haveSoundSampleRate)),
+        QStringLiteral("server_de_client_sent=%1")
+            .arg(boolText(m_startupTrace.serverDeClientSent)),
+        QStringLiteral("squelch_sent=%1")
+            .arg(boolText(m_startupTrace.squelchSent)),
+        QStringLiteral("genattn_sent=%1")
+            .arg(boolText(m_startupTrace.genattnSent)),
+        QStringLiteral("gen_sent=%1").arg(boolText(m_startupTrace.genSent)),
+        QStringLiteral("agc_sent=%1").arg(boolText(m_startupTrace.agcSent)),
+        QStringLiteral("mod_sent=%1").arg(boolText(m_startupTrace.modSent)),
+        QStringLiteral("first_snd_frame_seen=%1").arg(boolText(m_soundFrameSeen)),
+        QStringLiteral("snd_frames_continuous=%1")
+            .arg(boolText(sndFramesContinuous)),
+        QStringLiteral("keepalive_timer_running=%1")
+            .arg(boolText(keepaliveTimerRunning)),
+        QStringLiteral("keepalive_sent_on_snd_socket=%1")
+            .arg(boolText(m_startupTrace.keepaliveSentOnSound)),
+        QStringLiteral("websocket_ping_pong_ok_if_manual=not_checked"),
+    };
+
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR TRACE"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << QStringLiteral("startup_checklist %1")
+               .arg(startupFields.join(QLatin1Char(' ')));
+
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR TRACE"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << "last_20_protocol_events_begin";
+    for (const QString& event : m_protocolTraceTail) {
+        qCInfo(lcKiwiSdr).noquote()
+            << "KiwiSDR TRACE"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << event;
+    }
+    qCInfo(lcKiwiSdr).noquote()
+        << "KiwiSDR TRACE"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << "last_20_protocol_events_end";
+}
+
 void KiwiSdrClient::sendKeepalive()
 {
+    if (m_soundSocketConnected) {
+        m_lastSoundKeepaliveSentUtcMs = QDateTime::currentMSecsSinceEpoch();
+    }
     sendSoundCommand(QStringLiteral("SET keepalive"));
     sendWaterfallCommand(QStringLiteral("SET keepalive"));
 }
@@ -1568,6 +2426,18 @@ bool KiwiSdrClient::retryWithSecureWebSocket(bool transportEstablished)
     m_loggedSoundFrameShape = false;
     m_loggedWaterfallFrameShape = false;
     m_haveSoundAudioRate = false;
+    m_haveSoundSampleRate = false;
+    m_soundAudioRateText.clear();
+    m_soundDiagWindowStartUtcMs = 0;
+    m_lastSoundFrameUtcMs = 0;
+    m_lastSoundKeepaliveSentUtcMs = 0;
+    m_soundDiagFrames = 0;
+    m_soundDiagBytes = 0;
+    m_soundDiagDecodedSamples = 0;
+    m_waterfallDiagWindowStartUtcMs = 0;
+    m_lastWaterfallFrameUtcMs = 0;
+    m_waterfallDiagFrames = 0;
+    m_waterfallDiagBytes = 0;
     m_soundResamplerRateHz = 0.0;
     m_soundResampler.reset();
 
@@ -1588,21 +2458,35 @@ bool KiwiSdrClient::retryWithSecureWebSocket(bool transportEstablished)
 
 void KiwiSdrClient::sendSoundCommand(const QString& command)
 {
-    if (m_soundSocket && m_soundSocket->state() == QAbstractSocket::ConnectedState) {
-        qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR SND ->" << redactedKiwiCommand(command);
-        m_soundSocket->sendTextMessage(command);
+    const bool connected =
+        m_soundSocket && m_soundSocket->state() == QAbstractSocket::ConnectedState;
+    if (!connected) {
+        return;
     }
+
+    const qint64 bytesWritten = m_soundSocket->sendTextMessage(command);
+    traceOutboundCommand(StreamKind::Sound, command, bytesWritten >= 0);
+    qCDebug(lcKiwiSdr).noquote()
+        << "KiwiSDR SND ->"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << redactedKiwiCommand(command);
 }
 
 void KiwiSdrClient::sendWaterfallCommand(const QString& command)
 {
-    if (m_waterfallSocket
-        && m_waterfallSocket->state() == QAbstractSocket::ConnectedState) {
-        qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR W/F ->" << redactedKiwiCommand(command);
-        m_waterfallSocket->sendTextMessage(command);
+    const bool connected =
+        m_waterfallSocket
+        && m_waterfallSocket->state() == QAbstractSocket::ConnectedState;
+    if (!connected) {
+        return;
     }
+
+    const qint64 bytesWritten = m_waterfallSocket->sendTextMessage(command);
+    traceOutboundCommand(StreamKind::Waterfall, command, bytesWritten >= 0);
+    qCDebug(lcKiwiSdr).noquote()
+        << "KiwiSDR W/F ->"
+        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+        << redactedKiwiCommand(command);
 }
 
 void KiwiSdrClient::handleSocketError(const QString& detail,

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -249,12 +249,14 @@ QNetworkRequest kiwiWebSocketRequest(const QString& url,
     return request;
 }
 
-QUrl kiwiStatusUrl(const QString& host, quint16 port)
+QUrl kiwiStatusUrl(const QString& host, quint16 port, bool secure)
 {
     QUrl url;
-    url.setScheme(QStringLiteral("http"));
+    // Plain Kiwis serve /status over http on their own port; proxied/TLS-only
+    // Kiwis serve it over https on 443 (mirrors the wss-on-443 socket retry).
+    url.setScheme(secure ? QStringLiteral("https") : QStringLiteral("http"));
     url.setHost(host);
-    url.setPort(port);
+    url.setPort(secure ? 443 : port);
     url.setPath(QStringLiteral("/status"));
     return url;
 }
@@ -386,6 +388,7 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
                        .arg(m_endpoint, callsign));
 
 #ifdef HAVE_WEBSOCKETS
+    m_statusPreflightSecure = false;  // try http first, then https
     startStatusPreflight();
 #else
     setState(State::Error, tr("Qt WebSockets support is required for KiwiSDR."));
@@ -399,7 +402,7 @@ void KiwiSdrClient::startStatusPreflight()
         m_statusNetworkAccessManager = new QNetworkAccessManager(this);
     }
 
-    QNetworkRequest request{kiwiStatusUrl(m_host, m_port)};
+    QNetworkRequest request{kiwiStatusUrl(m_host, m_port, m_statusPreflightSecure)};
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       QStringLiteral("AetherSDR"));
     request.setTransferTimeout(kStatusPreflightTimeoutMs);
@@ -493,6 +496,26 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
             << "url=" << url.toString()
             << "http_status=" << httpStatus
             << "error=" << errorText;
+
+        // The http /status failed.  Many Kiwis are proxied / TLS-only, so retry
+        // once over https before giving up.
+        if (!m_statusPreflightSecure) {
+            m_statusPreflightSecure = true;
+            startStatusPreflight();
+            return;
+        }
+
+        // Both http and https failed: we cannot read ext_api, so we cannot
+        // confirm the operator permits external API clients.  Fail CLOSED —
+        // honoring a possible ext_api=0 takes priority over connecting.  (A
+        // server whose /status is unreachable is almost always down for the
+        // WebSocket path too, so this rarely blocks a working receiver.)
+        setState(
+            State::Error,
+            tr("Couldn't verify this KiwiSDR's access policy (its status page is "
+               "unreachable), so AetherSDR won't connect. Try again later."));
+        cleanupSockets();
+        return;
     }
 
     const QString callsign = kiwiIdentityCallsign();

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -5,6 +5,7 @@
 #include <QByteArray>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVector>
 
 #include <QtGlobal>
@@ -14,6 +15,8 @@
 
 class QTimer;
 #ifdef HAVE_WEBSOCKETS
+class QNetworkAccessManager;
+class QNetworkReply;
 class QWebSocket;
 #endif
 
@@ -71,6 +74,11 @@ public:
     }
     KiwiSdrReceiverControls receiverControls() const { return m_receiverControls; }
     KiwiSdrReceiverTelemetry telemetry() const { return m_telemetry; }
+    bool waterfallAvailable() const { return m_waterfallAvailable; }
+    QString waterfallAvailabilityDetail() const
+    {
+        return m_waterfallAvailabilityDetail;
+    }
     static QString normalizeEndpoint(const QString& endpoint);
 
 public slots:
@@ -103,11 +111,35 @@ signals:
     void meterReadingReady(
         const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
     void telemetryChanged();
+    void waterfallAvailabilityChanged(bool available, const QString& detail);
     void recoverableDisconnect(const QString& detail);
 
 private:
+    enum class StreamKind {
+        Sound,
+        Waterfall,
+    };
+
+    struct StartupTraceState {
+        bool authSent{false};
+        bool badpNonzeroSeen{false};
+        bool identUserSent{false};
+        bool browserSent{false};
+        bool compressionSent{false};
+        bool arOkSent{false};
+        bool arOkUsedActualAudioRate{false};
+        bool serverDeClientSent{false};
+        bool squelchSent{false};
+        bool genattnSent{false};
+        bool genSent{false};
+        bool agcSent{false};
+        bool modSent{false};
+        bool keepaliveSentOnSound{false};
+    };
+
     static bool parseEndpoint(const QString& endpoint, QString* host, quint16* port);
     static QString stateLabel(State state);
+    static QString streamLabel(StreamKind stream);
     void setState(State state, const QString& detail);
     void cleanupSockets();
     void sendSoundSetupCommands();
@@ -132,23 +164,44 @@ private:
                                    int* zoom) const;
     QByteArray decodeSoundFrame(const QByteArray& frame);
     QVector<float> decodeWaterfallFrame(const QByteArray& frame) const;
-    void handleBinaryMessage(const QByteArray& frame);
+    void handleBinaryMessage(StreamKind stream, const QByteArray& frame);
     void handleSoundFrame(const QByteArray& frame);
     void handleWaterfallFrame(const QByteArray& frame);
-    void handleMessage(const QByteArray& frame);
-    void handleTextMessage(const QString& text);
+    void handleMessage(StreamKind stream, const QByteArray& frame);
+    void handleTextMessage(StreamKind stream, const QString& text);
     bool updateWaterfallFftBins(int binCount);
+    void updateWaterfallAvailability();
     void updateSoundTelemetry(const QByteArray& frame);
     void updateWaterfallTelemetry(const QByteArray& frame);
     void emitTelemetryChanged();
     void sendWaterfallRateToServer();
     void markSoundAudioReady();
+    QString logEndpoint() const;
+    QString setupTimeoutDetail() const;
     void sendKeepalive();
     void sendSoundCommand(const QString& command);
     void sendWaterfallCommand(const QString& command);
+    void resetProtocolTrace();
+    qint64 protocolTraceElapsedMs() const;
+    void traceProtocolEvent(const QString& event);
+    void traceConnectionInfo(const QString& scheme, quint16 socketPort,
+                             const QString& sessionId,
+                             const QString& origin,
+                             const QString& soundUrl,
+                             const QString& waterfallUrl);
+    void traceOutboundCommand(StreamKind stream, const QString& command,
+                              bool sent);
+    void traceInboundText(StreamKind stream, const QString& text);
+    void traceInboundBinary(StreamKind stream, const QByteArray& frame);
+    void traceClose(StreamKind stream, int closeCode, const QString& reason);
+    void updateStartupTraceForOutbound(StreamKind stream,
+                                       const QString& command,
+                                       bool sent);
 
 #ifdef HAVE_WEBSOCKETS
     void handleSocketError(const QString& detail, bool transportEstablished);
+    void startStatusPreflight();
+    void handleStatusPreflightFinished(QNetworkReply* reply);
     void openWebSockets();
     bool retryWithSecureWebSocket(bool transportEstablished);
 #endif
@@ -185,8 +238,30 @@ private:
     bool m_loggedWaterfallFrameShape{false};
     bool m_decodeAudioWhenInactive{true};
     double m_soundSampleRateHz{12000.0};
+    QString m_soundAudioRateText;
     double m_soundResamplerRateHz{0.0};
     bool m_haveSoundAudioRate{false};
+    bool m_haveSoundSampleRate{false};
+    qint64 m_soundDiagWindowStartUtcMs{0};
+    qint64 m_lastSoundFrameUtcMs{0};
+    qint64 m_lastSoundKeepaliveSentUtcMs{0};
+    quint64 m_soundDiagFrames{0};
+    quint64 m_soundDiagBytes{0};
+    quint64 m_soundDiagDecodedSamples{0};
+    qint64 m_waterfallDiagWindowStartUtcMs{0};
+    qint64 m_lastWaterfallFrameUtcMs{0};
+    quint64 m_waterfallDiagFrames{0};
+    quint64 m_waterfallDiagBytes{0};
+    qint64 m_protocolTraceStartUtcMs{0};
+    QStringList m_protocolTraceTail;
+    QString m_lastOutboundCommand;
+    QString m_lastInboundMsg;
+    QString m_lastInboundFrameType;
+    qint64 m_lastOutboundCommandUtcMs{0};
+    qint64 m_lastInboundMsgUtcMs{0};
+    qint64 m_lastInboundFrameUtcMs{0};
+    StartupTraceState m_startupTrace;
+    bool m_protocolSendFailed{false};
     double m_waterfallServerCenterMhz{15.0};
     double m_waterfallServerBandwidthMhz{30.0};
     QString m_waterfallViewPanId;
@@ -206,6 +281,10 @@ private:
     int m_waterfallFloorDb{0};
     int m_waterfallRateOverride{0};
     int m_waterfallLineDurationMs{100};
+    bool m_waterfallAvailable{true};
+    QString m_waterfallAvailabilityDetail;
+    int m_waterfallRxChannel{-1};
+    int m_waterfallChannelCount{-1};
     std::unique_ptr<Resampler> m_soundResampler;
     QByteArray m_lastDecodedSoundPcm;
     QVector<float> m_lastWaterfallBins;
@@ -217,6 +296,8 @@ private:
     QTimer* m_audioReadyTimer{nullptr};
 
 #ifdef HAVE_WEBSOCKETS
+    QNetworkAccessManager* m_statusNetworkAccessManager{nullptr};
+    QNetworkReply* m_statusReply{nullptr};
     QWebSocket* m_soundSocket{nullptr};
     QWebSocket* m_waterfallSocket{nullptr};
 #endif

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -298,6 +298,9 @@ private:
 #ifdef HAVE_WEBSOCKETS
     QNetworkAccessManager* m_statusNetworkAccessManager{nullptr};
     QNetworkReply* m_statusReply{nullptr};
+    // Status preflight tries http first, then https (proxied/TLS-only Kiwis)
+    // before giving up.  ext_api can't be confirmed unless one succeeds.
+    bool m_statusPreflightSecure{false};
     QWebSocket* m_soundSocket{nullptr};
     QWebSocket* m_waterfallSocket{nullptr};
 #endif

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -19,6 +19,7 @@ constexpr const char* kKiwiSdrRxAntennasSettingsKey = "KiwiSdrRxAntennas";
 constexpr const char* kVirtualAntennaPrefix = "KIWI:";
 constexpr int kRecoverableReconnectDelayMs = 3000;
 constexpr int kKiwiSdrProfileNameMaxChars = 16;
+constexpr int kKiwiSdrWaterfallRateMax = 4;
 
 QString normalizedProfileEndpoint(const QString& endpoint)
 {
@@ -114,6 +115,22 @@ KiwiSdrReceiverTelemetry KiwiSdrManager::telemetry(const QString& id) const
     return m_telemetry.value(id);
 }
 
+bool KiwiSdrManager::waterfallAvailable(const QString& id) const
+{
+    if (KiwiSdrClient* c = client(id)) {
+        return c->waterfallAvailable();
+    }
+    return m_waterfallAvailable.value(id, true);
+}
+
+QString KiwiSdrManager::waterfallDetail(const QString& id) const
+{
+    if (KiwiSdrClient* c = client(id)) {
+        return c->waterfallAvailabilityDetail();
+    }
+    return m_waterfallDetails.value(id);
+}
+
 bool KiwiSdrManager::isConnected(const QString& id) const
 {
     if (KiwiSdrClient* c = client(id)) {
@@ -170,7 +187,8 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
     updated.name = sanitizedName(profile.name, updated.endpoint);
     updated.waterfallCellDb = std::clamp(updated.waterfallCellDb, -30, 30);
     updated.waterfallFloorDb = std::clamp(updated.waterfallFloorDb, -30, 30);
-    updated.waterfallRate = std::clamp(updated.waterfallRate, 0, 5);
+    updated.waterfallRate =
+        std::clamp(updated.waterfallRate, 0, kKiwiSdrWaterfallRateMax);
     const QString oldEndpoint = m_profiles[idx].endpoint;
     m_profiles[idx] = updated;
     saveSettings();
@@ -220,6 +238,8 @@ void KiwiSdrManager::removeProfile(const QString& id)
 
     m_stateDetails.remove(id);
     m_telemetry.remove(id);
+    m_waterfallAvailable.remove(id);
+    m_waterfallDetails.remove(id);
     m_profiles.removeAt(idx);
     saveSettings();
     // The client is already deleted above, so no further audio will be fed for
@@ -428,7 +448,7 @@ void KiwiSdrManager::setProfileWaterfallSettings(const QString& id, int cellDb,
     KiwiSdrAntennaProfile p = m_profiles[idx];
     p.waterfallCellDb = std::clamp(cellDb, -30, 30);
     p.waterfallFloorDb = std::clamp(floorDb, -30, 30);
-    p.waterfallRate = std::clamp(rate, 0, 5);
+    p.waterfallRate = std::clamp(rate, 0, kKiwiSdrWaterfallRateMax);
     updateProfile(p);
 }
 
@@ -454,7 +474,10 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
             << (detail.isEmpty() ? QString() : QStringLiteral("(") + detail + QStringLiteral(")"));
         if (state == KiwiSdrClient::State::Connecting) {
             m_telemetry.insert(id, {});
+            m_waterfallAvailable.insert(id, true);
+            m_waterfallDetails.remove(id);
             emit profileTelemetryChanged(id, m_telemetry.value(id));
+            emit profileWaterfallAvailabilityChanged(id, true, QString());
         }
         if (state == KiwiSdrClient::State::Connected) {
             const int idx = profileIndex(id);
@@ -485,6 +508,16 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
     connect(c, &KiwiSdrClient::telemetryChanged, this, [this, id, c]() {
         m_telemetry.insert(id, c->telemetry());
         emit profileTelemetryChanged(id, m_telemetry.value(id));
+    });
+    connect(c, &KiwiSdrClient::waterfallAvailabilityChanged,
+            this, [this, id](bool available, const QString& detail) {
+        m_waterfallAvailable.insert(id, available);
+        if (detail.isEmpty()) {
+            m_waterfallDetails.remove(id);
+        } else {
+            m_waterfallDetails.insert(id, detail);
+        }
+        emit profileWaterfallAvailabilityChanged(id, available, detail);
     });
     connect(c, &KiwiSdrClient::decodedAudioReady,
             this, [this, id](const QByteArray& pcm) {
@@ -543,7 +576,9 @@ void KiwiSdrManager::loadSettings()
         p.waterfallFloorDb = std::clamp(
             obj.value(QStringLiteral("waterfallFloorDb")).toInt(0), -30, 30);
         p.waterfallRate = std::clamp(
-            obj.value(QStringLiteral("waterfallRate")).toInt(0), 0, 5);
+            obj.value(QStringLiteral("waterfallRate")).toInt(0),
+            0,
+            kKiwiSdrWaterfallRateMax);
         m_profiles.append(p);
     }
 }
@@ -559,7 +594,8 @@ void KiwiSdrManager::saveSettings() const
         obj.insert(QStringLiteral("autoConnect"), p.autoConnect);
         obj.insert(QStringLiteral("waterfallCellDb"), std::clamp(p.waterfallCellDb, -30, 30));
         obj.insert(QStringLiteral("waterfallFloorDb"), std::clamp(p.waterfallFloorDb, -30, 30));
-        obj.insert(QStringLiteral("waterfallRate"), std::clamp(p.waterfallRate, 0, 5));
+        obj.insert(QStringLiteral("waterfallRate"),
+                   std::clamp(p.waterfallRate, 0, kKiwiSdrWaterfallRateMax));
         profiles.append(obj);
     }
 

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -40,6 +40,8 @@ public:
     KiwiSdrClient::State state(const QString& id) const;
     QString stateDetail(const QString& id) const;
     KiwiSdrReceiverTelemetry telemetry(const QString& id) const;
+    bool waterfallAvailable(const QString& id) const;
+    QString waterfallDetail(const QString& id) const;
     bool isConnected(const QString& id) const;
 
     QString assignedProfileForSlice(int sliceId) const;
@@ -80,6 +82,9 @@ signals:
     void profileTelemetryChanged(
         const QString& id,
         const AetherSDR::KiwiSdrReceiverTelemetry& telemetry);
+    void profileWaterfallAvailabilityChanged(const QString& id,
+                                             bool available,
+                                             const QString& detail);
     void profileStreamReset(const QString& id);
     void sliceAssignmentChanged(int sliceId, const QString& profileId);
     void audioSourceEnabledChanged(const QString& id, bool enabled);
@@ -112,6 +117,8 @@ private:
     QHash<QString, QTimer*> m_reconnectTimers;
     QHash<QString, QString> m_stateDetails;
     QHash<QString, KiwiSdrReceiverTelemetry> m_telemetry;
+    QHash<QString, bool> m_waterfallAvailable;
+    QHash<QString, QString> m_waterfallDetails;
     QHash<int, QString> m_sliceAssignments;
     QString m_operatorCallsign;
 };

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -9,6 +9,7 @@ namespace AetherSDR::KiwiSdrProtocol {
 namespace {
 
 constexpr int kObservedExtendedSoundFrameBytes = 1034;
+constexpr int kServerSoundHeaderBytes = 10;
 constexpr int kObservedMeterOffset = 8;
 constexpr float kExperimentalMeterDbmOffset = -127.0f;
 constexpr float kExperimentalMeterDbPerRawUnit = 0.1f;
@@ -47,9 +48,7 @@ SoundFrameHeader parseSoundFrameHeader(const QByteArray& frame)
 
     SoundFrameHeader header;
     header.flags = static_cast<uchar>(frame[3]);
-    const bool observedExtendedFrame =
-        frame.size() == kObservedExtendedSoundFrameBytes;
-    if (observedExtendedFrame && frame.size() >= 8) {
+    if (frame.size() >= kServerSoundHeaderBytes) {
         const auto* data = reinterpret_cast<const uchar*>(frame.constData() + 4);
         const quint32 counter = static_cast<quint32>(data[0])
             | (static_cast<quint32>(data[1]) << 8)

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -298,16 +298,32 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
     }
 
     const KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(profileId);
+    const KiwiSdrClient::State state = m_kiwiSdrManager->state(profileId);
+    const bool kiwiWaterfallChannelAvailable =
+        state == KiwiSdrClient::State::Connected
+            ? m_kiwiSdrManager->waterfallAvailable(profileId)
+            : true;
     spectrum->setKiwiSdrWaterfallAvailable(true);
     spectrum->setKiwiSdrWaterfallProfile(profileId);
     spectrum->setKiwiSdrWaterfallActive(true);
     spectrum->setKiwiSdrWaterfallAdjustments(profile.waterfallCellDb,
                                              profile.waterfallFloorDb);
-    const KiwiSdrClient::State state = m_kiwiSdrManager->state(profileId);
+    const QString overlayDetail =
+        state == KiwiSdrClient::State::Connected
+            && !kiwiWaterfallChannelAvailable
+            ? m_kiwiSdrManager->waterfallDetail(profileId)
+            : kiwiConnectionOverlayDetail(
+                  state, m_kiwiSdrManager->stateDetail(profileId));
+    const QString overlayTitle =
+        state == KiwiSdrClient::State::Connected
+            && !kiwiWaterfallChannelAvailable
+            ? tr("KiwiSDR waterfall unavailable")
+            : QString();
     spectrum->setKiwiSdrConnectionOverlay(
-        state != KiwiSdrClient::State::Connected,
-        kiwiConnectionOverlayDetail(
-            state, m_kiwiSdrManager->stateDetail(profileId)));
+        state != KiwiSdrClient::State::Connected
+            || !kiwiWaterfallChannelAvailable,
+        overlayDetail,
+        overlayTitle);
     if (menu) {
         menu->syncKiwiWaterfallSettings(profile.waterfallCellDb,
                                         profile.waterfallFloorDb,
@@ -610,6 +626,20 @@ void MainWindow::wireKiwiSdr()
                 syncKiwiSdrPanadapterUiState(panId);
             }
         });
+        connect(m_kiwiSdrManager,
+                &KiwiSdrManager::profileWaterfallAvailabilityChanged,
+                this, [this](const QString& profileId, bool, const QString&) {
+            if (!m_kiwiSdrManager) {
+                return;
+            }
+
+            const int sliceId =
+                m_kiwiSdrManager->assignedSliceForProfile(profileId);
+            if (SliceModel* slice = m_radioModel.slice(sliceId)) {
+                syncKiwiSdrPanadapterUiState(slice->panId());
+            }
+            refreshKiwiSdrAppletReceivers();
+        });
         connect(m_kiwiSdrManager, &KiwiSdrManager::profileStreamReset,
                 this, [this](const QString& profileId) {
             if (!m_panStack || profileId.isEmpty()) {
@@ -663,6 +693,10 @@ void MainWindow::refreshKiwiSdrAppletReceivers()
             receiver.name = m_kiwiSdrManager->displayName(profile.id);
             receiver.state = m_kiwiSdrManager->state(profile.id);
             receiver.detail = m_kiwiSdrManager->stateDetail(profile.id);
+            if (receiver.state == KiwiSdrClient::State::Connected
+                && !m_kiwiSdrManager->waterfallAvailable(profile.id)) {
+                receiver.detail = m_kiwiSdrManager->waterfallDetail(profile.id);
+            }
             const int sliceId = m_kiwiSdrManager->assignedSliceForProfile(profile.id);
             receiver.assignedSlice = m_radioModel.slice(sliceId);
             receivers.append(receiver);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -71,6 +71,8 @@ static QString rateSliderLabelText(int sliderValue)
     return QString::number(sliderValue);
 }
 
+static constexpr int kKiwiSdrWaterfallRateMax = 4;
+
 static QString kiwiWaterfallDbText(int db)
 {
     return QStringLiteral("%1%2 dB")
@@ -1766,7 +1768,8 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
     }
     if (m_rateSlider) {
         m_rateSlider->setRange(kiwiMode ? 0 : WF_RATE_SLIDER_MIN,
-                               kiwiMode ? 5 : WF_RATE_SLIDER_MAX);
+                               kiwiMode ? kKiwiSdrWaterfallRateMax
+                                        : WF_RATE_SLIDER_MAX);
         m_rateSlider->setToolTip(kiwiMode
             ? "KiwiSDR waterfall rate. Auto follows the Flex waterfall rate."
             : "Waterfall rate.");
@@ -1793,7 +1796,7 @@ void SpectrumOverlayMenu::syncKiwiWaterfallSettings(int cellDb, int floorDb,
 
     const int clampedCell = std::clamp(cellDb, -30, 30);
     const int clampedFloor = std::clamp(floorDb, -30, 30);
-    const int clampedRate = std::clamp(rate, 0, 5);
+    const int clampedRate = std::clamp(rate, 0, kKiwiSdrWaterfallRateMax);
     QSignalBlocker b1(m_gainSlider), b2(m_blackSlider),
                    b3(m_rateSlider), b4(m_autoBlackBtn);
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2869,15 +2869,19 @@ void SpectrumWidget::setConnectionAnimationVisible(bool on, const QString& label
 }
 
 void SpectrumWidget::setKiwiSdrConnectionOverlay(bool visible,
-                                                 const QString& detail)
+                                                 const QString& detail,
+                                                 const QString& title)
 {
     const QString trimmedDetail = detail.trimmed();
+    const QString trimmedTitle = title.trimmed();
     if (m_kiwiSdrConnectionOverlayVisible == visible
+        && m_kiwiSdrConnectionOverlayTitle == trimmedTitle
         && m_kiwiSdrConnectionOverlayDetail == trimmedDetail) {
         return;
     }
 
     m_kiwiSdrConnectionOverlayVisible = visible;
+    m_kiwiSdrConnectionOverlayTitle = trimmedTitle;
     m_kiwiSdrConnectionOverlayDetail = trimmedDetail;
     markOverlayDirty();
 }
@@ -3074,7 +3078,9 @@ void SpectrumWidget::drawKiwiSdrConnectionOverlay(QPainter& p,
         return;
     }
 
-    const QString title = QStringLiteral("Not connected to KiwiSDR");
+    const QString title = m_kiwiSdrConnectionOverlayTitle.isEmpty()
+        ? QStringLiteral("Not connected to KiwiSDR")
+        : m_kiwiSdrConnectionOverlayTitle;
     const QString detail = m_kiwiSdrConnectionOverlayDetail.isEmpty()
         ? QStringLiteral("Disconnected")
         : m_kiwiSdrConnectionOverlayDetail;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -95,7 +95,9 @@ public:
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     QString rendererDescription() const;
     void setConnectionAnimationVisible(bool on, const QString& label = {});
-    void setKiwiSdrConnectionOverlay(bool visible, const QString& detail = {});
+    void setKiwiSdrConnectionOverlay(bool visible,
+                                     const QString& detail = {},
+                                     const QString& title = {});
     void showInterlockNotification(const QString& message, int durationMs = 5000);
 
     // Feed a new FFT frame. bins are scaled dBm values.
@@ -744,6 +746,7 @@ private:
     bool m_kiwiSdrWaterfallAvailable{false};
     bool m_kiwiSdrWaterfallActive{false};
     bool m_kiwiSdrConnectionOverlayVisible{false};
+    QString m_kiwiSdrConnectionOverlayTitle;
     QString m_kiwiSdrConnectionOverlayDetail;
     WaterfallStreamState m_nativeWaterfallState;
     WaterfallStreamState m_kiwiWaterfallState;

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -26,14 +26,26 @@ int main()
 
     const QByteArray soundFrame =
         QByteArray("SND", 3)
-        + QByteArray::fromHex("051234")
-        + QByteArray::fromHex("0001fffe");
+        + QByteArray::fromHex("051234");
     const SoundFrameHeader soundHeader = parseSoundFrameHeader(soundFrame);
     if (!soundHeader.valid
         || soundHeader.sequence != 5
         || soundHeader.flags != 5
         || soundHeader.hasRssi) {
         return fail("SND header sequence parsing should not invent calibrated RSSI");
+    }
+
+    const QByteArray serverSoundFrame =
+        QByteArray("SND", 3)
+        + QByteArray::fromHex("8012340021021c")
+        + QByteArray::fromHex("0001fffe");
+    const SoundFrameHeader serverSoundHeader =
+        parseSoundFrameHeader(serverSoundFrame);
+    if (!serverSoundHeader.valid
+        || serverSoundHeader.sequence != 0x12
+        || serverSoundHeader.flags != 0x80
+        || serverSoundHeader.hasRssi) {
+        return fail("server SND header sequence parsing is wrong");
     }
 
     QByteArray observedSoundFrame("SND", 3);


### PR DESCRIPTION
## Summary
Adds follow-up hardening for the native KiwiSDR receive integration. This improves KiwiSDR protocol setup, reduces noisy trace logging, handles operator/server limits earlier, surfaces waterfall-unavailable conditions clearly, and keeps Kiwi waterfall controls consistent with the server-supported range.

Notable changes:
- Add `/status` preflight handling for `ext_api=0`, `users`, `users_max`, and `preempt`.
- Show capacity messaging before opening SND/W/F sockets when no receiver slot is available.
- Preserve preemptable-server behavior by not rejecting full servers that report available `preempt` slots.
- Track Kiwi waterfall channel availability separately from audio connection state.
- Show a specific panadapter overlay when audio is connected but no Kiwi waterfall channel is available.
- Update the Kiwi applet status detail for connected receivers with unavailable waterfall data.
- Reduce routine Kiwi trace log spam while retaining close-time protocol trace context.
- Keep Kiwi WF Rate consistently limited to the supported `0..4` range.
- Harden SND frame handling around observed header layout, compression flags, and dynamic audio rate negotiation.

## Constitution principle honored
Principle IV — protocol behavior is implemented from allowed protocol references, clean observations, and GPL-compatible KiwiSDR server protocol references, without using AGPL client/source-derived code.

Principle VII — remote endpoint input and server-reported status are validated before connection setup, and unsupported/limited server states are surfaced explicitly to the operator.

## Test plan
- [x] Local build passes (`cmake --build build --parallel`)
- [x] Behavior verified on public KiwiSDR endpoints during maintainer testing
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
- [x] Kiwi protocol test passes (`ctest --test-dir build -R "[Kk]iwi" --output-on-failure`)
- [x] `git diff --check` passes
- [x] Accessibility check run (`python3 tools/check_a11y.py`; existing warning-only findings remain)

## Checklist
- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
