### PR TITLE
feat(nets): Net Reminder Scheduler — recurring net reminders with one-click tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,6 +703,7 @@ set(GUI_SOURCES
     src/gui/MainWindow_Spots.cpp
     src/gui/MainWindow_SwrSweep.cpp
     src/gui/MainWindow_Wiring.cpp
+    src/gui/MainWindow_Nets.cpp
     src/gui/MainWindow_KiwiSdr.cpp
     src/gui/map/MapView.cpp
     src/gui/map/MapMarkerItem.cpp
@@ -730,6 +731,8 @@ set(GUI_SOURCES
     src/gui/MemoryCommands.cpp
     src/gui/MemoryBrowsePanel.cpp
     src/gui/MemoryDialog.cpp
+    src/gui/NetSchedulerDialog.cpp
+    src/gui/NetReminderBanner.cpp
     src/gui/SpotSettingsDialog.cpp
     src/gui/AetherDspDialog.cpp
     src/gui/AetherDspWidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,10 @@ set(CORE_SOURCES
     src/core/MemoryCsvCompat.cpp
     src/core/MemoryFieldValues.cpp
     src/core/MemoryRecallPolicy.cpp
+    src/core/NetRecurrence.cpp
+    src/core/NetSchedulePlanner.cpp
+    src/core/NetScheduleStore.cpp
+    src/core/NetScheduler.cpp
     src/core/WfmDemodulator.cpp
     src/core/WfmDsp.cpp
     src/core/WaveOutWriter.cpp
@@ -2288,6 +2292,31 @@ add_executable(memory_recall_policy_test
 target_include_directories(memory_recall_policy_test PRIVATE src)
 target_link_libraries(memory_recall_policy_test PRIVATE Qt6::Core)
 add_test(NAME memory_recall_policy_test COMMAND memory_recall_policy_test)
+
+add_executable(net_recurrence_test
+    tests/net_recurrence_test.cpp
+    src/core/NetRecurrence.cpp
+)
+target_include_directories(net_recurrence_test PRIVATE src)
+target_link_libraries(net_recurrence_test PRIVATE Qt6::Core)
+add_test(NAME net_recurrence_test COMMAND net_recurrence_test)
+
+add_executable(net_schedule_store_test
+    tests/net_schedule_store_test.cpp
+    src/core/NetScheduleStore.cpp
+)
+target_include_directories(net_schedule_store_test PRIVATE src)
+target_link_libraries(net_schedule_store_test PRIVATE Qt6::Core)
+add_test(NAME net_schedule_store_test COMMAND net_schedule_store_test)
+
+add_executable(net_schedule_planner_test
+    tests/net_schedule_planner_test.cpp
+    src/core/NetSchedulePlanner.cpp
+    src/core/NetRecurrence.cpp
+)
+target_include_directories(net_schedule_planner_test PRIVATE src)
+target_link_libraries(net_schedule_planner_test PRIVATE Qt6::Core)
+add_test(NAME net_schedule_planner_test COMMAND net_schedule_planner_test)
 
 add_executable(memory_field_values_test
     tests/memory_field_values_test.cpp

--- a/src/core/NetRecurrence.cpp
+++ b/src/core/NetRecurrence.cpp
@@ -200,16 +200,29 @@ QDateTime nextOccurrence(const QString& rrule,
                          const QDate& startDate,
                          const QDateTime& afterUtc)
 {
-    const ParsedRule rule = parseRule(rrule);
-    if (!rule.isValid())
-        return {};
-
     const QTime time = QTime::fromString(timeOfDay.trimmed(), "HH:mm");
     if (!time.isValid())
         return {};
 
     const QTimeZone tz(timezone.trimmed().toUtf8());
     if (!tz.isValid())
+        return {};
+
+    // An empty rule means a one-time ("Repeat = Never") net: a single event at
+    // startDate + timeOfDay. Returns it only while it is still in the future.
+    if (rrule.trimmed().isEmpty()) {
+        if (!startDate.isValid())
+            return {};
+        QDateTime once(startDate, time, tz);
+        if (!once.isValid())
+            once = QDateTime(startDate, time, tz, QDateTime::TransitionResolution::PreferStandard);
+        if (once.isValid() && once.toUTC() > afterUtc.toUTC())
+            return once;
+        return {};
+    }
+
+    const ParsedRule rule = parseRule(rrule);
+    if (!rule.isValid())
         return {};
 
     // Begin the day-by-day scan from the local date of `afterUtc` so we never
@@ -248,6 +261,9 @@ QDateTime nextOccurrence(const NetEntry& entry, const QDateTime& afterUtc)
 
 QString describeRule(const QString& rrule)
 {
+    if (rrule.trimmed().isEmpty())
+        return QStringLiteral("Once");
+
     const ParsedRule rule = parseRule(rrule);
     if (!rule.isValid())
         return {};

--- a/src/core/NetRecurrence.cpp
+++ b/src/core/NetRecurrence.cpp
@@ -1,0 +1,282 @@
+#include "core/NetRecurrence.h"
+
+#include "models/NetEntry.h"
+
+#include <QStringList>
+#include <QTime>
+#include <QTimeZone>
+
+namespace AetherSDR {
+namespace NetRecurrence {
+
+namespace {
+
+// Search horizon: large enough to cross any supported interval (monthly with a
+// modest INTERVAL, or a sparse weekly BYDAY) yet bounded so a rule that can
+// never fire terminates instead of looping forever.
+constexpr int kSearchHorizonDays = 800;
+
+// Map an RRULE two-letter weekday code to Qt's day-of-week (1=Mon..7=Sun).
+int weekdayFromCode(const QString& code)
+{
+    static const QStringList kCodes = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
+    const int idx = kCodes.indexOf(code.trimmed().toUpper());
+    return idx < 0 ? 0 : idx + 1;
+}
+
+QString weekdayLongName(int qtDow)
+{
+    static const QStringList kNames = {"Monday",   "Tuesday", "Wednesday", "Thursday",
+                                       "Friday",   "Saturday", "Sunday"};
+    if (qtDow < 1 || qtDow > 7)
+        return {};
+    return kNames.at(qtDow - 1);
+}
+
+QString ordinalName(int ordinal)
+{
+    switch (ordinal) {
+    case 1:  return "first";
+    case 2:  return "second";
+    case 3:  return "third";
+    case 4:  return "fourth";
+    case 5:  return "fifth";
+    case -1: return "last";
+    default: return {};
+    }
+}
+
+// Date of the nth `weekday` (Qt 1..7) within `year`/`month`. ordinal>0 counts
+// from the start; ordinal==-1 is the last such weekday. Returns a null QDate if
+// that ordinal does not exist in the month (e.g. a 5th Friday that month lacks).
+QDate nthWeekdayOfMonth(int year, int month, int weekday, int ordinal)
+{
+    if (ordinal == -1) {
+        const QDate last(year, month, QDate(year, month, 1).daysInMonth());
+        const int delta = (last.dayOfWeek() - weekday + 7) % 7;
+        return last.addDays(-delta);
+    }
+    if (ordinal < 1 || ordinal > 5)
+        return {};
+    const QDate first(year, month, 1);
+    const int firstDelta = (weekday - first.dayOfWeek() + 7) % 7;
+    const QDate candidate = first.addDays(firstDelta + (ordinal - 1) * 7);
+    if (candidate.month() != month)
+        return {};
+    return candidate;
+}
+
+// Whole calendar months between two dates (a may be after or before b).
+int monthsBetween(const QDate& a, const QDate& b)
+{
+    return (b.year() - a.year()) * 12 + (b.month() - a.month());
+}
+
+// Monday-anchored week index since an epoch, so weekly INTERVAL phase is stable
+// regardless of which weekday is being tested.
+qint64 mondayWeekIndex(const QDate& d)
+{
+    const QDate monday = d.addDays(-(d.dayOfWeek() - 1));
+    return monday.toJulianDay() / 7;
+}
+
+bool matchesRule(const QDate& date, const ParsedRule& rule, const QDate& startDate)
+{
+    const bool haveAnchor = startDate.isValid();
+
+    switch (rule.freq) {
+    case ParsedRule::Freq::Daily: {
+        if (rule.interval <= 1 || !haveAnchor)
+            return true;
+        const qint64 days = startDate.daysTo(date);
+        return days >= 0 && (days % rule.interval) == 0;
+    }
+    case ParsedRule::Freq::Weekly: {
+        QList<int> days = rule.weekdays;
+        if (days.isEmpty() && haveAnchor)
+            days << startDate.dayOfWeek();
+        if (!days.contains(date.dayOfWeek()))
+            return false;
+        if (rule.interval <= 1 || !haveAnchor)
+            return true;
+        const qint64 weeks = mondayWeekIndex(date) - mondayWeekIndex(startDate);
+        return weeks >= 0 && (weeks % rule.interval) == 0;
+    }
+    case ParsedRule::Freq::Monthly: {
+        if (rule.monthlyWeekday == 0 || rule.monthlyOrdinal == 0)
+            return false;
+        const QDate target =
+            nthWeekdayOfMonth(date.year(), date.month(), rule.monthlyWeekday, rule.monthlyOrdinal);
+        if (target != date)
+            return false;
+        if (rule.interval <= 1 || !haveAnchor)
+            return true;
+        const int months = monthsBetween(startDate, date);
+        return months >= 0 && (months % rule.interval) == 0;
+    }
+    case ParsedRule::Freq::Invalid:
+        break;
+    }
+    return false;
+}
+
+} // namespace
+
+ParsedRule parseRule(const QString& rrule)
+{
+    ParsedRule rule;
+    const QStringList parts = rrule.trimmed().split(';', Qt::SkipEmptyParts);
+    QString byDay;
+
+    for (const QString& part : parts) {
+        const int eq = part.indexOf('=');
+        if (eq < 0)
+            continue;
+        const QString key = part.left(eq).trimmed().toUpper();
+        const QString val = part.mid(eq + 1).trimmed();
+
+        if (key == "FREQ") {
+            const QString f = val.toUpper();
+            if (f == "DAILY")
+                rule.freq = ParsedRule::Freq::Daily;
+            else if (f == "WEEKLY")
+                rule.freq = ParsedRule::Freq::Weekly;
+            else if (f == "MONTHLY")
+                rule.freq = ParsedRule::Freq::Monthly;
+        } else if (key == "INTERVAL") {
+            bool ok = false;
+            const int n = val.toInt(&ok);
+            if (ok && n > 0)
+                rule.interval = n;
+        } else if (key == "BYDAY") {
+            byDay = val;
+        }
+    }
+
+    if (!rule.isValid())
+        return rule;
+
+    if (rule.freq == ParsedRule::Freq::Monthly) {
+        // BYDAY for MONTHLY is a single ordinal weekday, e.g. "1SU" or "-1WE".
+        const QString token = byDay.trimmed().toUpper();
+        int idx = 0;
+        bool negative = false;
+        if (token.startsWith('-')) {
+            negative = true;
+            idx = 1;
+        } else if (token.startsWith('+')) {
+            idx = 1;
+        }
+        int digitsEnd = idx;
+        while (digitsEnd < token.size() && token.at(digitsEnd).isDigit())
+            ++digitsEnd;
+        if (digitsEnd > idx) {
+            int ord = token.mid(idx, digitsEnd - idx).toInt();
+            if (negative)
+                ord = -ord;
+            rule.monthlyOrdinal = ord;
+            rule.monthlyWeekday = weekdayFromCode(token.mid(digitsEnd));
+        }
+        if (rule.monthlyWeekday == 0 || rule.monthlyOrdinal == 0)
+            rule.freq = ParsedRule::Freq::Invalid;
+        return rule;
+    }
+
+    if (rule.freq == ParsedRule::Freq::Weekly && !byDay.isEmpty()) {
+        const QStringList codes = byDay.split(',', Qt::SkipEmptyParts);
+        for (const QString& code : codes) {
+            const int dow = weekdayFromCode(code);
+            if (dow != 0 && !rule.weekdays.contains(dow))
+                rule.weekdays << dow;
+        }
+    }
+
+    return rule;
+}
+
+QDateTime nextOccurrence(const QString& rrule,
+                         const QString& timeOfDay,
+                         const QString& timezone,
+                         const QDate& startDate,
+                         const QDateTime& afterUtc)
+{
+    const ParsedRule rule = parseRule(rrule);
+    if (!rule.isValid())
+        return {};
+
+    const QTime time = QTime::fromString(timeOfDay.trimmed(), "HH:mm");
+    if (!time.isValid())
+        return {};
+
+    const QTimeZone tz(timezone.trimmed().toUtf8());
+    if (!tz.isValid())
+        return {};
+
+    // Begin the day-by-day scan from the local date of `afterUtc` so we never
+    // miss an occurrence later the same day.
+    const QDateTime afterLocal = afterUtc.toUTC().toTimeZone(tz);
+    const QDate startLocalDate = afterLocal.date();
+
+    for (int offset = 0; offset <= kSearchHorizonDays; ++offset) {
+        const QDate candidateDate = startLocalDate.addDays(offset);
+        if (!matchesRule(candidateDate, rule, startDate))
+            continue;
+
+        // Resolve the wall-clock time within DST transitions (the requested
+        // time may not exist on a spring-forward day, or occur twice on
+        // fall-back); pick deterministically so reminders never double-fire.
+        QDateTime candidate(candidateDate, time, tz);
+        if (!candidate.isValid()) {
+            candidate = QDateTime(candidateDate, time, tz,
+                                  QDateTime::TransitionResolution::PreferStandard);
+        }
+        if (!candidate.isValid())
+            continue;
+
+        if (candidate.toUTC() > afterUtc.toUTC())
+            return candidate;
+    }
+
+    return {};
+}
+
+QDateTime nextOccurrence(const NetEntry& entry, const QDateTime& afterUtc)
+{
+    return nextOccurrence(entry.rrule, entry.timeOfDay, entry.timezone,
+                          QDate::fromString(entry.startDate, "yyyy-MM-dd"), afterUtc);
+}
+
+QString describeRule(const QString& rrule)
+{
+    const ParsedRule rule = parseRule(rrule);
+    if (!rule.isValid())
+        return {};
+
+    switch (rule.freq) {
+    case ParsedRule::Freq::Daily:
+        return rule.interval > 1 ? QString("Every %1 days").arg(rule.interval) : "Daily";
+    case ParsedRule::Freq::Weekly: {
+        QStringList names;
+        for (int dow : rule.weekdays)
+            names << weekdayLongName(dow);
+        const QString on = names.isEmpty() ? QString() : QString(" on %1").arg(names.join(", "));
+        if (rule.interval > 1)
+            return QString("Every %1 weeks%2").arg(rule.interval).arg(on);
+        return QString("Weekly%1").arg(on);
+    }
+    case ParsedRule::Freq::Monthly: {
+        const QString body = QString("on the %1 %2")
+                                 .arg(ordinalName(rule.monthlyOrdinal))
+                                 .arg(weekdayLongName(rule.monthlyWeekday));
+        if (rule.interval > 1)
+            return QString("Every %1 months %2").arg(rule.interval).arg(body);
+        return QString("Monthly %1").arg(body);
+    }
+    case ParsedRule::Freq::Invalid:
+        break;
+    }
+    return {};
+}
+
+} // namespace NetRecurrence
+} // namespace AetherSDR

--- a/src/core/NetRecurrence.cpp
+++ b/src/core/NetRecurrence.cpp
@@ -80,6 +80,22 @@ qint64 mondayWeekIndex(const QDate& d)
     return monday.toJulianDay() / 7;
 }
 
+// Build a zoned QDateTime for a local wall-clock time, handling a spring-forward
+// gap (where that wall time doesn't exist) portably across Qt versions — Qt 6.7's
+// QDateTime::TransitionResolution isn't available on the 6.4 CI floor. On a gap
+// the plain constructor returns an invalid datetime; nudge forward one hour to
+// land just past the transition. (A net at 20:00 essentially never hits the
+// ~02:00 DST gap, but we must not crash or silently skip if it does.) On a
+// fall-back overlap the constructor picks deterministically, which is fine since
+// the scheduler always recomputes.
+QDateTime zonedDateTime(const QDate& date, const QTime& time, const QTimeZone& tz)
+{
+    QDateTime dt(date, time, tz);
+    if (!dt.isValid())
+        dt = QDateTime(date, time.addSecs(3600), tz);
+    return dt;
+}
+
 bool matchesRule(const QDate& date, const ParsedRule& rule, const QDate& startDate)
 {
     const bool haveAnchor = startDate.isValid();
@@ -213,9 +229,7 @@ QDateTime nextOccurrence(const QString& rrule,
     if (rrule.trimmed().isEmpty()) {
         if (!startDate.isValid())
             return {};
-        QDateTime once(startDate, time, tz);
-        if (!once.isValid())
-            once = QDateTime(startDate, time, tz, QDateTime::TransitionResolution::PreferStandard);
+        const QDateTime once = zonedDateTime(startDate, time, tz);
         if (once.isValid() && once.toUTC() > afterUtc.toUTC())
             return once;
         return {};
@@ -235,14 +249,8 @@ QDateTime nextOccurrence(const QString& rrule,
         if (!matchesRule(candidateDate, rule, startDate))
             continue;
 
-        // Resolve the wall-clock time within DST transitions (the requested
-        // time may not exist on a spring-forward day, or occur twice on
-        // fall-back); pick deterministically so reminders never double-fire.
-        QDateTime candidate(candidateDate, time, tz);
-        if (!candidate.isValid()) {
-            candidate = QDateTime(candidateDate, time, tz,
-                                  QDateTime::TransitionResolution::PreferStandard);
-        }
+        // Resolve the wall-clock time within DST transitions (see zonedDateTime).
+        const QDateTime candidate = zonedDateTime(candidateDate, time, tz);
         if (!candidate.isValid())
             continue;
 

--- a/src/core/NetRecurrence.h
+++ b/src/core/NetRecurrence.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <QDate>
+#include <QDateTime>
+#include <QList>
+#include <QString>
+
+namespace AetherSDR {
+
+struct NetEntry;
+
+// Recurrence math for scheduled nets. Pure and headless (QtCore only) so it can
+// be exhaustively unit-tested without a radio or a GUI.
+//
+// Supported RFC 5545 RRULE subset (what the UI exposes):
+//   FREQ=DAILY[;INTERVAL=n]
+//   FREQ=WEEKLY[;INTERVAL=n];BYDAY=MO,TU,...      (BYDAY optional; defaults to
+//                                                  the weekday of startDate)
+//   FREQ=MONTHLY[;INTERVAL=n];BYDAY=nXX           (single ordinal weekday,
+//                                                  n in -1..5, -1 = last)
+//
+// INTERVAL>1 ("every other week") needs an anchor to know which periods are
+// "on"; that anchor is the entry's startDate (DTSTART). When startDate is
+// absent INTERVAL phase is not enforced (treated as INTERVAL=1).
+namespace NetRecurrence {
+
+struct ParsedRule {
+    enum class Freq { Invalid, Daily, Weekly, Monthly };
+
+    Freq      freq{Freq::Invalid};
+    int       interval{1};
+    QList<int> weekdays;        // Qt day-of-week (1=Mon..7=Sun) for WEEKLY BYDAY
+    int       monthlyOrdinal{0}; // -1 (last) .. 5 for MONTHLY BYDAY=nXX; 0 = unset
+    int       monthlyWeekday{0}; // Qt day-of-week (1..7) for MONTHLY
+
+    bool isValid() const { return freq != Freq::Invalid; }
+};
+
+// Parse an RRULE string into the supported subset. Unknown FREQ or malformed
+// input yields an invalid rule (isValid() == false).
+ParsedRule parseRule(const QString& rrule);
+
+// Compute the next occurrence START strictly after `afterUtc`, honoring the
+// local wall-clock `timeOfDay` ("HH:MM") in IANA `timezone`, DST-correct.
+// `startDate` (ISO "yyyy-MM-dd", may be null) anchors INTERVAL phasing and
+// provides the default weekday for a BYDAY-less weekly rule.
+//
+// Returns a QDateTime carrying the entry timezone (use toMSecsSinceEpoch() /
+// toUTC() for comparisons). Returns an invalid QDateTime if the rule is
+// invalid or no occurrence is found within the search horizon.
+QDateTime nextOccurrence(const QString& rrule,
+                         const QString& timeOfDay,
+                         const QString& timezone,
+                         const QDate& startDate,
+                         const QDateTime& afterUtc);
+
+// Convenience overload operating on a NetEntry.
+QDateTime nextOccurrence(const NetEntry& entry, const QDateTime& afterUtc);
+
+// Human-readable, friendly summary of a rule for the UI confirmation chip,
+// e.g. "Weekly on Tuesday", "Every 2 weeks on Mon, Wed", "Monthly on the
+// first Sunday", "Daily". Returns an empty string for an invalid rule.
+QString describeRule(const QString& rrule);
+
+} // namespace NetRecurrence
+
+} // namespace AetherSDR

--- a/src/core/NetSchedulePlanner.cpp
+++ b/src/core/NetSchedulePlanner.cpp
@@ -1,0 +1,48 @@
+#include "core/NetSchedulePlanner.h"
+
+#include "core/NetRecurrence.h"
+#include "models/NetEntry.h"
+
+namespace AetherSDR {
+
+PendingReminder nextReminderAcross(const QList<NetEntry>& entries, const QDateTime& afterUtc)
+{
+    PendingReminder best;
+    const QDateTime afterUtcNorm = afterUtc.toUTC();
+
+    for (int i = 0; i < entries.size(); ++i) {
+        const NetEntry& entry = entries.at(i);
+        if (!entry.enabled)
+            continue;
+
+        const int lead = entry.reminderLeadMinutes > 0 ? entry.reminderLeadMinutes : 0;
+        const qint64 leadSecs = static_cast<qint64>(lead) * 60;
+
+        // Walk occurrences forward until this entry yields a reminder instant
+        // strictly after `afterUtc`. The lead-time can push a reminder before
+        // its occurrence into the past, so the soonest future *occurrence* does
+        // not always give the soonest future *reminder* — advance until it does.
+        QDateTime cursorUtc = afterUtcNorm;
+        for (int guard = 0; guard < 64; ++guard) {
+            const QDateTime occ = NetRecurrence::nextOccurrence(entry, cursorUtc);
+            if (!occ.isValid())
+                break;
+            const QDateTime occUtc = occ.toUTC();
+            const QDateTime reminderUtc = occUtc.addSecs(-leadSecs);
+            if (reminderUtc > afterUtcNorm) {
+                if (!best.isValid() || reminderUtc < best.reminderUtc) {
+                    best.entryIndex = i;
+                    best.occurrenceUtc = occUtc;
+                    best.reminderUtc = reminderUtc;
+                }
+                break;
+            }
+            // Reminder already in the past; skip this occurrence and look further.
+            cursorUtc = occUtc;
+        }
+    }
+
+    return best;
+}
+
+} // namespace AetherSDR

--- a/src/core/NetSchedulePlanner.h
+++ b/src/core/NetSchedulePlanner.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QDateTime>
+#include <QList>
+
+namespace AetherSDR {
+
+struct NetEntry;
+
+// Pure planning helper for the net scheduler: given the current entry list and
+// "now", find the single soonest reminder to fire. Headless and deterministic
+// (no timers, no clock of its own) so the scheduling decision can be unit-tested
+// directly. The QObject NetScheduler is a thin timer wrapper around this.
+struct PendingReminder {
+    int       entryIndex{-1};      // index into the entries list
+    QDateTime occurrenceUtc;       // when the net starts (UTC)
+    QDateTime reminderUtc;         // when to alert = occurrence - leadMinutes (UTC)
+
+    bool isValid() const { return entryIndex >= 0; }
+};
+
+// Earliest reminder strictly after `afterUtc` across all enabled entries.
+// Disabled entries, entries with invalid rules, and entries whose reminder
+// instant is not after `afterUtc` are skipped. Returns an invalid
+// PendingReminder when nothing is pending.
+PendingReminder nextReminderAcross(const QList<NetEntry>& entries, const QDateTime& afterUtc);
+
+} // namespace AetherSDR

--- a/src/core/NetScheduleStore.cpp
+++ b/src/core/NetScheduleStore.cpp
@@ -1,0 +1,200 @@
+#include "core/NetScheduleStore.h"
+
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSet>
+#include <QUuid>
+
+namespace AetherSDR {
+
+namespace {
+
+// --- MemoryEntry preset <-> JSON ----------------------------------------
+//
+// Only the fields a net actually needs for recall are serialized; the rest take
+// MemoryEntry's defaults. group/owner/index are radio-slot concepts and
+// deliberately omitted from the portable net format.
+
+QJsonObject presetToJson(const MemoryEntry& m)
+{
+    QJsonObject o;
+    o["freq"] = m.freq;
+    o["mode"] = m.mode;
+    o["step"] = m.step;
+    o["rxFilterLow"] = m.rxFilterLow;
+    o["rxFilterHigh"] = m.rxFilterHigh;
+    if (!m.offsetDir.isEmpty())
+        o["offsetDir"] = m.offsetDir;
+    if (m.repeaterOffset != 0.0)
+        o["repeaterOffset"] = m.repeaterOffset;
+    if (!m.toneMode.isEmpty())
+        o["toneMode"] = m.toneMode;
+    if (m.toneValue != 0.0)
+        o["toneValue"] = m.toneValue;
+    if (m.squelch) {
+        o["squelch"] = true;
+        o["squelchLevel"] = m.squelchLevel;
+    }
+    return o;
+}
+
+MemoryEntry presetFromJson(const QJsonObject& o)
+{
+    MemoryEntry m;
+    m.freq = o.value("freq").toDouble(m.freq);
+    m.mode = o.value("mode").toString(m.mode);
+    m.step = o.value("step").toInt(m.step);
+    m.rxFilterLow = o.value("rxFilterLow").toInt(m.rxFilterLow);
+    m.rxFilterHigh = o.value("rxFilterHigh").toInt(m.rxFilterHigh);
+    m.offsetDir = o.value("offsetDir").toString(m.offsetDir);
+    m.repeaterOffset = o.value("repeaterOffset").toDouble(m.repeaterOffset);
+    m.toneMode = o.value("toneMode").toString(m.toneMode);
+    m.toneValue = o.value("toneValue").toDouble(m.toneValue);
+    m.squelch = o.value("squelch").toBool(m.squelch);
+    m.squelchLevel = o.value("squelchLevel").toInt(m.squelchLevel);
+    return m;
+}
+
+QJsonObject entryToJson(const NetEntry& e)
+{
+    QJsonObject o;
+    o["id"] = e.id;
+    o["name"] = e.name;
+    o["enabled"] = e.enabled;
+    o["rrule"] = e.rrule;
+    if (!e.startDate.isEmpty())
+        o["startDate"] = e.startDate;
+    o["timeOfDay"] = e.timeOfDay;
+    o["timezone"] = e.timezone;
+    o["reminderLeadMinutes"] = e.reminderLeadMinutes;
+    o["durationMinutes"] = e.durationMinutes;
+    if (!e.notes.isEmpty())
+        o["notes"] = e.notes;
+    o["preset"] = presetToJson(e.preset);
+    return o;
+}
+
+NetEntry entryFromJson(const QJsonObject& o)
+{
+    NetEntry e;
+    e.id = o.value("id").toString();
+    e.name = o.value("name").toString();
+    e.enabled = o.value("enabled").toBool(true);
+    e.rrule = o.value("rrule").toString();
+    e.startDate = o.value("startDate").toString();
+    e.timeOfDay = o.value("timeOfDay").toString(e.timeOfDay);
+    e.timezone = o.value("timezone").toString(e.timezone);
+    e.reminderLeadMinutes = o.value("reminderLeadMinutes").toInt(e.reminderLeadMinutes);
+    e.durationMinutes = o.value("durationMinutes").toInt(e.durationMinutes);
+    e.notes = o.value("notes").toString();
+    e.preset = presetFromJson(o.value("preset").toObject());
+    return e;
+}
+
+} // namespace
+
+QString NetScheduleStore::newId()
+{
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
+}
+
+QByteArray NetScheduleStore::serialize(const QList<NetEntry>& nets, const QString& exportedAtIso)
+{
+    QJsonObject root;
+    root["format"] = kFormatId;
+    root["version"] = kFormatVersion;
+    if (!exportedAtIso.isEmpty())
+        root["exportedAt"] = exportedAtIso;
+    root["exportedBy"] = "AetherSDR";
+
+    QJsonArray arr;
+    for (const NetEntry& e : nets)
+        arr.append(entryToJson(e));
+    root["nets"] = arr;
+
+    return QJsonDocument(root).toJson(QJsonDocument::Indented);
+}
+
+NetScheduleStore::ParseResult NetScheduleStore::parse(const QByteArray& bytes)
+{
+    ParseResult result;
+
+    QJsonParseError perr;
+    const QJsonDocument doc = QJsonDocument::fromJson(bytes, &perr);
+    if (doc.isNull()) {
+        result.errors << QString("Invalid JSON: %1").arg(perr.errorString());
+        return result;
+    }
+    if (!doc.isObject()) {
+        result.errors << "Top-level JSON is not an object";
+        return result;
+    }
+
+    const QJsonObject root = doc.object();
+    const QString format = root.value("format").toString();
+    if (!format.isEmpty() && format != kFormatId)
+        result.errors << QString("Unexpected format \"%1\"").arg(format);
+
+    result.version = root.value("version").toInt(0);
+    if (result.version > kFormatVersion) {
+        result.errors << QString("File version %1 is newer than supported version %2")
+                             .arg(result.version)
+                             .arg(kFormatVersion);
+    }
+
+    const QJsonArray arr = root.value("nets").toArray();
+    for (const QJsonValue& v : arr) {
+        if (!v.isObject())
+            continue;
+        NetEntry e = entryFromJson(v.toObject());
+        if (e.id.isEmpty())
+            e.id = newId();
+        result.nets.append(e);
+    }
+
+    return result;
+}
+
+QList<NetEntry> NetScheduleStore::merge(const QList<NetEntry>& existing,
+                                        const QList<NetEntry>& incoming,
+                                        MergePolicy policy)
+{
+    QList<NetEntry> merged = existing;
+    QHash<QString, int> indexById;
+    for (int i = 0; i < merged.size(); ++i) {
+        if (!merged.at(i).id.isEmpty())
+            indexById.insert(merged.at(i).id, i);
+    }
+
+    for (const NetEntry& in : incoming) {
+        NetEntry entry = in;
+        if (entry.id.isEmpty())
+            entry.id = newId();
+
+        const auto it = indexById.constFind(entry.id);
+        if (it == indexById.constEnd()) {
+            indexById.insert(entry.id, merged.size());
+            merged.append(entry);
+            continue;
+        }
+
+        switch (policy) {
+        case MergePolicy::Skip:
+            break;
+        case MergePolicy::Overwrite:
+            merged[it.value()] = entry;
+            break;
+        case MergePolicy::Duplicate:
+            entry.id = newId();
+            indexById.insert(entry.id, merged.size());
+            merged.append(entry);
+            break;
+        }
+    }
+
+    return merged;
+}
+
+} // namespace AetherSDR

--- a/src/core/NetScheduleStore.h
+++ b/src/core/NetScheduleStore.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "models/NetEntry.h"
+
+#include <QByteArray>
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Portable, versioned JSON persistence for the net schedule. This is the
+// canonical backup/share format — pretty-printed, self-describing, and evolved
+// additively (new fields optional with defaults; unknown fields ignored) so
+// files stay forward/backward compatible. Recurrence lives as an RRULE string
+// rather than enumerated dates, and every entry carries a stable UUID so
+// re-import and user-to-user sharing can merge deterministically.
+//
+// Envelope:
+//   {
+//     "format": "aether.netschedule",
+//     "version": 1,
+//     "exportedAt": "2026-06-19T14:00:00Z",
+//     "exportedBy": "AetherSDR",
+//     "nets": [ { ...NetEntry... } ]
+//   }
+class NetScheduleStore {
+public:
+    static constexpr int kFormatVersion = 1;
+    static constexpr const char* kFormatId = "aether.netschedule";
+
+    struct ParseResult {
+        QList<NetEntry> nets;
+        QStringList errors;
+        int version{0};
+
+        bool ok() const { return errors.isEmpty(); }
+    };
+
+    // Merge policy for importing entries whose id already exists locally.
+    enum class MergePolicy {
+        Skip,       // keep the existing entry
+        Overwrite,  // replace the existing entry with the imported one
+        Duplicate,  // import as a brand-new entry with a fresh id
+    };
+
+    // Serialize to pretty-printed JSON bytes. `exportedAtIso` is stamped into
+    // the envelope (pass QDateTime::currentDateTimeUtc().toString(Qt::ISODate)
+    // from the caller — kept as a parameter so this stays clock-free/testable).
+    static QByteArray serialize(const QList<NetEntry>& nets, const QString& exportedAtIso = {});
+
+    // Parse JSON bytes. Tolerant: unknown keys are ignored, missing optional
+    // fields fall back to NetEntry defaults, and entries without an id are
+    // assigned one. Malformed top-level JSON populates errors and returns empty.
+    static ParseResult parse(const QByteArray& bytes);
+
+    // Merge `incoming` into `existing` by id per `policy`. Returns the merged
+    // list; never mutates in place. Entries without an id are treated as new.
+    static QList<NetEntry> merge(const QList<NetEntry>& existing,
+                                 const QList<NetEntry>& incoming,
+                                 MergePolicy policy);
+
+    // Generate a fresh stable id (UUID without braces).
+    static QString newId();
+};
+
+} // namespace AetherSDR

--- a/src/core/NetScheduler.cpp
+++ b/src/core/NetScheduler.cpp
@@ -1,0 +1,77 @@
+#include "core/NetScheduler.h"
+
+namespace AetherSDR {
+
+namespace {
+// Cap a single sleep at ~24h so a far-future reminder still wakes us daily to
+// recompute against the real clock (handles suspend, time changes, DST).
+constexpr qint64 kMaxSleepMs = 24LL * 60 * 60 * 1000;
+// Arm a hair past the reminder instant so the planner's strictly-after query
+// reliably excludes it on the next rearm.
+constexpr int kArmGuardMs = 200;
+
+QString firedKey(const NetEntry& entry, const QDateTime& occurrenceUtc)
+{
+    return entry.id + '|' + QString::number(occurrenceUtc.toMSecsSinceEpoch());
+}
+} // namespace
+
+NetScheduler::NetScheduler(QObject* parent)
+    : QObject(parent)
+{
+    m_timer.setSingleShot(true);
+    connect(&m_timer, &QTimer::timeout, this, &NetScheduler::onTimeout);
+}
+
+QDateTime NetScheduler::nowUtc() const
+{
+    return QDateTime::currentDateTimeUtc();
+}
+
+void NetScheduler::setEntries(const QList<NetEntry>& entries)
+{
+    m_entries = entries;
+    rearm();
+}
+
+void NetScheduler::rearm()
+{
+    m_timer.stop();
+    const QDateTime now = nowUtc();
+
+    // Prune fired keys for occurrences now safely in the past.
+    for (auto it = m_firedKeys.begin(); it != m_firedKeys.end();) {
+        const qint64 occMs = it->section('|', 1).toLongLong();
+        if (occMs < now.toMSecsSinceEpoch() - 60000)
+            it = m_firedKeys.erase(it);
+        else
+            ++it;
+    }
+
+    m_armed = nextReminderAcross(m_entries, now);
+    if (!m_armed.isValid())
+        return;
+
+    const qint64 ms = now.msecsTo(m_armed.reminderUtc);
+    const qint64 sleep = qBound<qint64>(0, ms, kMaxSleepMs) + kArmGuardMs;
+    m_timer.start(static_cast<int>(qMin<qint64>(sleep, kMaxSleepMs + kArmGuardMs)));
+}
+
+void NetScheduler::onTimeout()
+{
+    const QDateTime now = nowUtc();
+
+    if (m_armed.isValid() && now >= m_armed.reminderUtc
+        && m_armed.entryIndex >= 0 && m_armed.entryIndex < m_entries.size()) {
+        const NetEntry entry = m_entries.at(m_armed.entryIndex);
+        const QString key = firedKey(entry, m_armed.occurrenceUtc);
+        if (!m_firedKeys.contains(key)) {
+            m_firedKeys.insert(key);
+            Q_EMIT reminderDue(entry, m_armed.occurrenceUtc);
+        }
+    }
+
+    rearm();
+}
+
+} // namespace AetherSDR

--- a/src/core/NetScheduler.h
+++ b/src/core/NetScheduler.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "core/NetSchedulePlanner.h"
+#include "models/NetEntry.h"
+
+#include <QDateTime>
+#include <QList>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QTimer>
+
+namespace AetherSDR {
+
+// Drives net reminders from a single recompute-and-rearm timer (the standard
+// calendar-engine pattern): always arm one timer at the soonest pending
+// reminder, fire it, advance, re-arm. The sleep is capped so the schedule
+// self-heals across laptop suspend, wall-clock changes, and DST transitions —
+// on every wake it recomputes against the current time rather than trusting a
+// far-future delta. All scheduling logic delegates to the pure
+// nextReminderAcross() planner; this class only owns the timer and clock.
+class NetScheduler : public QObject {
+    Q_OBJECT
+
+public:
+    explicit NetScheduler(QObject* parent = nullptr);
+
+    // Replace the active entry set and immediately recompute the next reminder.
+    void setEntries(const QList<NetEntry>& entries);
+    QList<NetEntry> entries() const { return m_entries; }
+
+    // The currently-armed reminder, for diagnostics / UI "Next: ..." display.
+    PendingReminder nextPending() const { return m_armed; }
+
+Q_SIGNALS:
+    // Emitted when a net's reminder fires. `occurrenceUtc` is when the net
+    // starts; the lead-time has already elapsed-to.
+    void reminderDue(const AetherSDR::NetEntry& entry, const QDateTime& occurrenceUtc);
+
+private:
+    void rearm();
+    void onTimeout();
+    QDateTime nowUtc() const;
+
+    QList<NetEntry> m_entries;
+    QTimer m_timer;
+    PendingReminder m_armed;
+    QSet<QString> m_firedKeys;   // "id|occurrenceMsSinceEpoch" — double-fire guard
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1226,6 +1226,12 @@ MainWindow::MainWindow(QWidget* parent)
     // subsystem doesn't ride along when RadioSession is extracted.
     wireSpotSubsystem();
 
+    // Net Reminder Scheduler: load the operator's saved nets, start the
+    // recompute-and-rearm reminder timer, and create the tray/banner notifiers
+    // → initNetScheduler() (MainWindow_Nets.cpp). Operator-scoped, client-side;
+    // works without a radio connected.
+    initNetScheduler();
+
     // Radio-model + TX-audio-stream wiring → wireRadioModel()
     // (MainWindow_Session.cpp, #3351 Phase 2c).
     wireRadioModel();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -79,6 +79,7 @@
 class QAbstractSlider;
 class QMediaDevices;
 class QShowEvent;
+class QSystemTrayIcon;
 
 #include "gui/ClientEqApplet.h"   // ClientEqApplet::Path enum used in
                                    // onEqCutoffsDragRequested signature.
@@ -103,6 +104,11 @@ class RadioSetupDialog;
 class NetworkDiagnosticsDialog;
 class AgcCalibrationDialog;
 class MemoryDialog;
+class NetSchedulerDialog;
+class NetReminderBanner;
+class NetScheduler;
+struct NetEntry;
+struct MemoryEntry;
 class PropDashboardDialog;
 class UpdateChecker;
 class TxBandDialog;
@@ -414,6 +420,15 @@ private:
 
     void showMemoryDialog();
     void showQuickAddMemoryDialog(const QString& preferredPanId = {});
+
+    // Net Reminder Scheduler (MainWindow_Nets.cpp).
+    void initNetScheduler();
+    void showNetSchedulerDialog();
+    void persistNetSchedule(const QList<NetEntry>& nets);
+    void tuneToNet(const NetEntry& entry);
+    void onNetReminderDue(const NetEntry& entry, const QDateTime& occurrenceUtc);
+    MemoryEntry captureCurrentNetPreset() const;
+    QString netScheduleFilePath() const;
 #ifdef HAVE_WEBSOCKETS
     void showFreeDvReporter();
 #endif
@@ -771,6 +786,10 @@ private:
     QPointer<PropDashboardDialog> m_propDashboardDialog;
     QPointer<TxBandDialog> m_txBandDialog;
     QPointer<MemoryDialog> m_memoryDialog;
+    QPointer<NetSchedulerDialog> m_netSchedulerDialog;
+    NetScheduler* m_netScheduler{nullptr};
+    NetReminderBanner* m_netReminderBanner{nullptr};
+    QSystemTrayIcon* m_trayIcon{nullptr};
     QPointer<Ax25HfPacketDecodeDialog> m_ax25HfPacketDecodeDialog;
     QPointer<PskReporterMapDialog> m_pskReporterMapDialog;
     QPointer<FlexControlDialog> m_flexControlDialog;

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -125,6 +125,10 @@ void MainWindow::buildMenuBar()
     connect(memoryAction, &QAction::triggered, this, [this] {
         showMemoryDialog();
     });
+    auto* netSchedulerAction = settingsMenu->addAction("Net Scheduler...");
+    connect(netSchedulerAction, &QAction::triggered, this, [this] {
+        showNetSchedulerDialog();
+    });
     auto* usbCablesAction = settingsMenu->addAction("USB Cables...");
     connect(usbCablesAction, &QAction::triggered, this, [this] {
         const QString prevComp = m_radioModel.audioCompressionParam();

--- a/src/gui/MainWindow_Nets.cpp
+++ b/src/gui/MainWindow_Nets.cpp
@@ -1,0 +1,197 @@
+// Net Reminder Scheduler wiring for MainWindow (#3351-style sibling TU).
+//
+// Owns the operator's saved net schedule: loads/persists it as client-side JSON
+// (NOT radio memory slots — nets are operator-scoped per Constitution XIII and
+// must work with no radio connected), drives the single recompute-and-rearm
+// reminder timer, and surfaces reminders through an in-app actionable banner
+// plus a best-effort OS tray notification. "Tune Now" reuses the same
+// MemoryRecallPolicy command builders as a memory recall.
+
+#include "MainWindow.h"
+
+#include "NetReminderBanner.h"
+#include "NetSchedulerDialog.h"
+
+#include "core/AppSettings.h"
+#include "core/MemoryRecallPolicy.h"
+#include "core/NetScheduleStore.h"
+#include "core/NetScheduler.h"
+#include "models/NetEntry.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QSaveFile>
+#include <QStatusBar>
+#include <QString>
+#include <QSystemTrayIcon>
+
+namespace AetherSDR {
+
+QString MainWindow::netScheduleFilePath() const
+{
+    const QString settingsPath = AppSettings::instance().filePath();
+    const QString dir = QFileInfo(settingsPath).absolutePath();
+    return QDir(dir).filePath(QStringLiteral("NetSchedule.json"));
+}
+
+void MainWindow::initNetScheduler()
+{
+    m_netScheduler = new NetScheduler(this);
+    connect(m_netScheduler, &NetScheduler::reminderDue, this, &MainWindow::onNetReminderDue);
+
+    QList<NetEntry> nets;
+    QFile file(netScheduleFilePath());
+    if (file.open(QIODevice::ReadOnly)) {
+        const auto result = NetScheduleStore::parse(file.readAll());
+        nets = result.nets;
+    }
+    m_netScheduler->setEntries(nets);
+}
+
+void MainWindow::showNetSchedulerDialog()
+{
+    const bool wasFresh = !m_netSchedulerDialog;
+    NetSchedulerDialog::CaptureFn capture = [this]() { return captureCurrentNetPreset(); };
+    showOrRaisePersistent(m_netSchedulerDialog,
+                          m_netScheduler ? m_netScheduler->entries() : QList<NetEntry>(),
+                          capture);
+    if (wasFresh && m_netSchedulerDialog) {
+        connect(m_netSchedulerDialog.data(), &NetSchedulerDialog::entriesChanged, this,
+                [this](const QList<NetEntry>& nets) { persistNetSchedule(nets); });
+        connect(m_netSchedulerDialog.data(), &NetSchedulerDialog::tuneRequested, this,
+                [this](const NetEntry& entry) { tuneToNet(entry); });
+    }
+}
+
+void MainWindow::persistNetSchedule(const QList<NetEntry>& nets)
+{
+    const QByteArray json = NetScheduleStore::serialize(
+        nets, QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    QSaveFile file(netScheduleFilePath());
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(json);
+        file.commit();
+    }
+    if (m_netScheduler)
+        m_netScheduler->setEntries(nets);
+}
+
+MemoryEntry MainWindow::captureCurrentNetPreset() const
+{
+    MemoryEntry preset;  // freq defaults to 0.0 → "nothing to capture"
+    SliceModel* slice = preferredMemorySlice({});
+    if (!slice)
+        return preset;
+    preset.freq = slice->frequency();
+    preset.mode = slice->mode();
+    preset.rxFilterLow = slice->filterLow();
+    preset.rxFilterHigh = slice->filterHigh();
+    return preset;
+}
+
+void MainWindow::tuneToNet(const NetEntry& entry)
+{
+    SliceModel* slice = preferredMemorySlice({});
+    if (!slice) {
+        statusBar()->showMessage(QStringLiteral("Open a slice before tuning to a net."), 3000);
+        return;
+    }
+    if (slice->isLocked()) {
+        slice->notifyTuneBlockedByLock();
+        statusBar()->showMessage(QStringLiteral("Unlock the slice to tune to a net."), 3000);
+        return;
+    }
+
+    const int sliceId = slice->sliceId();
+    if (!activeSlice() || activeSlice()->sliceId() != sliceId)
+        setActiveSlice(sliceId);
+
+    // Reuse the memory-recall command builders for the retune + repeater/tone
+    // fixup, and set mode/filter/step directly (a net has no radio-side memory
+    // slot to "memory apply").
+    const QString retune = buildMemoryRecallRetuneCommand(sliceId, entry.preset);
+    if (!retune.isEmpty())
+        m_radioModel.sendCommand(retune);
+    if (!entry.preset.mode.isEmpty())
+        m_radioModel.sendCommand(
+            QString("slice set %1 mode=%2").arg(sliceId).arg(entry.preset.mode));
+    if (entry.preset.rxFilterLow != entry.preset.rxFilterHigh) {
+        m_radioModel.sendCommand(QString("filt %1 %2 %3")
+                                     .arg(sliceId)
+                                     .arg(entry.preset.rxFilterLow)
+                                     .arg(entry.preset.rxFilterHigh));
+    }
+    if (entry.preset.step > 0)
+        m_radioModel.sendCommand(QString("slice set %1 step=%2").arg(sliceId).arg(entry.preset.step));
+    const QString fixup = buildMemoryRecallSliceFixupCommand(sliceId, entry.preset);
+    if (!fixup.isEmpty())
+        m_radioModel.sendCommand(fixup);
+
+    statusBar()->showMessage(QString("Tuned to %1").arg(entry.name), 3000);
+}
+
+void MainWindow::onNetReminderDue(const NetEntry& entry, const QDateTime& occurrenceUtc)
+{
+    const qint64 minutes = QDateTime::currentDateTimeUtc().secsTo(occurrenceUtc) / 60;
+    QString headline;
+    if (minutes > 1)
+        headline = QString("%1 starts in %2 min").arg(entry.name).arg(minutes);
+    else if (minutes >= 0)
+        headline = QString("%1 is starting now").arg(entry.name);
+    else
+        headline = QString("%1 is on the air").arg(entry.name);
+
+    const QString detail = QString("%1 MHz · %2")
+                               .arg(entry.preset.freq, 0, 'f', 4)
+                               .arg(entry.preset.mode.isEmpty() ? QStringLiteral("—")
+                                                                : entry.preset.mode);
+
+    const bool canTune = preferredMemorySlice({}) != nullptr;
+
+    // In-app banner — the guaranteed actionable path (created once).
+    if (!m_netReminderBanner) {
+        m_netReminderBanner = new NetReminderBanner(this);
+        connect(m_netReminderBanner, &NetReminderBanner::tuneRequested, this,
+                [this](const QString& netId) {
+                    if (!m_netScheduler)
+                        return;
+                    for (const NetEntry& e : m_netScheduler->entries()) {
+                        if (e.id == netId) {
+                            tuneToNet(e);
+                            break;
+                        }
+                    }
+                    showNormal();
+                    raise();
+                    activateWindow();
+                });
+    }
+    m_netReminderBanner->showReminder(entry.id, headline, detail, canTune);
+
+    // Best-effort OS notification (attention-getter). Created lazily so users
+    // with no scheduled nets never get a persistent tray icon. Click raises the
+    // window; the actionable button lives in the in-app banner above because
+    // QSystemTrayIcon::showMessage() cannot carry one.
+    if (!m_trayIcon && QSystemTrayIcon::isSystemTrayAvailable()) {
+        m_trayIcon = new QSystemTrayIcon(windowIcon(), this);
+        m_trayIcon->setToolTip(QStringLiteral("AetherSDR"));
+        m_trayIcon->show();
+        connect(m_trayIcon, &QSystemTrayIcon::messageClicked, this, [this] {
+            showNormal();
+            raise();
+            activateWindow();
+        });
+    }
+    if (m_trayIcon) {
+        m_trayIcon->showMessage(entry.name, headline + '\n' + detail,
+                                QSystemTrayIcon::Information, 15000);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Nets.cpp
+++ b/src/gui/MainWindow_Nets.cpp
@@ -8,6 +8,7 @@
 // MemoryRecallPolicy command builders as a memory recall.
 
 #include "MainWindow.h"
+#include "MainWindowHelpers.h"
 
 #include "NetReminderBanner.h"
 #include "NetSchedulerDialog.h"
@@ -16,9 +17,11 @@
 #include "core/MemoryRecallPolicy.h"
 #include "core/NetScheduleStore.h"
 #include "core/NetScheduler.h"
+#include "models/BandSettings.h"
 #include "models/NetEntry.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "models/XvtrPolicy.h"
 
 #include <QByteArray>
 #include <QDateTime>
@@ -30,6 +33,7 @@
 #include <QStatusBar>
 #include <QString>
 #include <QSystemTrayIcon>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -111,6 +115,40 @@ void MainWindow::tuneToNet(const NetEntry& entry)
     const int sliceId = slice->sliceId();
     if (!activeSlice() || activeSlice()->sliceId() != sliceId)
         setActiveSlice(sliceId);
+    slice = m_radioModel.slice(sliceId);
+    if (!slice)
+        return;
+
+    const double freqMhz = entry.preset.freq;
+    const QString slicePanId = slice->panId();
+
+    // If the net is on a different band than the slice currently sits on,
+    // preselect that band's stack memory first — a bare `slice tune` will not
+    // move the panadapter across bands, which is why a cross-band net appears
+    // "not to tune". Same preselect path as a memory recall.
+    if (freqMhz > 0.0) {
+        const QString netBand = BandSettings::bandForFrequency(freqMhz);
+        const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
+        if (netBand != currentBand) {
+            const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+            const auto stackKeyResult =
+                XvtrPolicy::resolveBandStackKey(netBand, xvtrs, m_radioModel.capabilities());
+            if (stackKeyResult.isSupported()) {
+                clearSwrSweepForBandChange(-1, slicePanId, netBand);
+                m_bandSettings.setCurrentBand(netBand);
+                m_radioModel.sendCommand(
+                    QString("display pan set %1 band=%2").arg(slicePanId, stackKeyResult.key));
+                QTimer::singleShot(300, this, [this, slicePanId]() {
+                    reassertUnmutedSliceAudioForPan(slicePanId);
+                });
+            } else {
+                statusBar()->showMessage(
+                    QString("Can't tune %1 — %2 isn't available on this radio.")
+                        .arg(entry.name, netBand),
+                    5000);
+            }
+        }
+    }
 
     // Reuse the memory-recall command builders for the retune + repeater/tone
     // fixup, and set mode/filter/step directly (a net has no radio-side memory
@@ -132,6 +170,15 @@ void MainWindow::tuneToNet(const NetEntry& entry)
     const QString fixup = buildMemoryRecallSliceFixupCommand(sliceId, entry.preset);
     if (!fixup.isEmpty())
         m_radioModel.sendCommand(fixup);
+
+    // After the band change + retune settle, recenter the panadapter on the net
+    // frequency if it ended up off-screen (mirrors the memory-recall reveal).
+    QTimer::singleShot(750, this, [this, sliceId, freqMhz]() {
+        if (auto* s = m_radioModel.slice(sliceId)) {
+            const double revealMhz = freqMhz > 0.0 ? freqMhz : s->frequency();
+            revealFrequencyIfNeeded(s, revealMhz, TuneIntent::CommandedTargetCenter, "net-tune");
+        }
+    });
 
     statusBar()->showMessage(QString("Tuned to %1").arg(entry.name), 3000);
 }

--- a/src/gui/NetReminderBanner.cpp
+++ b/src/gui/NetReminderBanner.cpp
@@ -1,0 +1,108 @@
+#include "NetReminderBanner.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPainter>
+#include <QPaintEvent>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+NetReminderBanner::NetReminderBanner(QWidget* parent)
+    : QFrame(parent, Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint)
+{
+    setObjectName("NetReminderBanner");
+    setAttribute(Qt::WA_ShowWithoutActivating);
+    setAccessibleName("Net reminder");
+    setMinimumWidth(320);
+
+    auto* root = new QHBoxLayout(this);
+    root->setContentsMargins(14, 12, 12, 12);
+    root->setSpacing(12);
+
+    auto* glyph = new QLabel(QStringLiteral("📻"), this);
+    glyph->setStyleSheet("font-size: 22px;");
+    root->addWidget(glyph, 0, Qt::AlignTop);
+
+    auto* textCol = new QVBoxLayout();
+    textCol->setSpacing(2);
+    m_headline = new QLabel(this);
+    m_headline->setStyleSheet("font-weight: 600; font-size: 13px; color: palette(text);");
+    m_headline->setWordWrap(true);
+    m_detail = new QLabel(this);
+    m_detail->setStyleSheet("color: palette(mid); font-size: 11px;");
+    textCol->addWidget(m_headline);
+    textCol->addWidget(m_detail);
+    root->addLayout(textCol, 1);
+
+    auto* btnCol = new QVBoxLayout();
+    btnCol->setSpacing(6);
+    auto* tuneBtn = new QPushButton(QStringLiteral("Tune Now"), this);
+    tuneBtn->setObjectName("NetReminderTune");
+    tuneBtn->setAccessibleName("Tune to this net");
+    tuneBtn->setCursor(Qt::PointingHandCursor);
+    tuneBtn->setDefault(true);
+    auto* dismissBtn = new QPushButton(QStringLiteral("Dismiss"), this);
+    dismissBtn->setAccessibleName("Dismiss reminder");
+    dismissBtn->setCursor(Qt::PointingHandCursor);
+    btnCol->addWidget(tuneBtn);
+    btnCol->addWidget(dismissBtn);
+    root->addLayout(btnCol, 0);
+
+    connect(tuneBtn, &QPushButton::clicked, this, [this, tuneBtn] {
+        // Disabled when no radio is connected; guard anyway.
+        if (!tuneBtn->isEnabled())
+            return;
+        Q_EMIT tuneRequested(m_netId);
+        close();
+    });
+    connect(dismissBtn, &QPushButton::clicked, this, [this] {
+        Q_EMIT dismissed(m_netId);
+        close();
+    });
+
+    // Keep a handle so showReminder can flip the enabled state.
+    m_tuneButton = tuneBtn;
+}
+
+void NetReminderBanner::showReminder(const QString& netId, const QString& headline,
+                                     const QString& detail, bool canTune)
+{
+    m_netId = netId;
+    m_headline->setText(headline);
+    m_detail->setText(detail);
+    if (m_tuneButton) {
+        m_tuneButton->setEnabled(canTune);
+        m_tuneButton->setToolTip(canTune ? QString()
+                                         : QStringLiteral("Connect a radio to tune to this net"));
+    }
+    adjustSize();
+    anchorToParent();
+    show();
+    raise();
+}
+
+void NetReminderBanner::anchorToParent()
+{
+    QWidget* anchor = parentWidget();
+    if (!anchor)
+        return;
+    const QRect pg = anchor->frameGeometry();
+    const int margin = 24;
+    move(pg.right() - width() - margin, pg.bottom() - height() - margin);
+}
+
+void NetReminderBanner::paintEvent(QPaintEvent* event)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    QColor bg = palette().color(QPalette::Window);
+    bg.setAlpha(248);
+    p.setBrush(bg);
+    p.setPen(QPen(palette().color(QPalette::Mid), 1));
+    p.drawRoundedRect(rect().adjusted(0, 0, -1, -1), 10, 10);
+    QFrame::paintEvent(event);
+}
+
+} // namespace AetherSDR

--- a/src/gui/NetReminderBanner.h
+++ b/src/gui/NetReminderBanner.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QFrame>
+#include <QString>
+
+class QLabel;
+class QPushButton;
+
+namespace AetherSDR {
+
+// In-app actionable reminder toast for an upcoming net. This is the *guaranteed*
+// notification path: OS-native notifications (tray balloon / Toast / Notification
+// Center) can be suppressed by Do-Not-Disturb, missing permissions, or platforms
+// that don't render action buttons, and QSystemTrayIcon::showMessage() cannot
+// carry a button at all. So the reliable "Tune Now" button lives here, in-app,
+// where the action actually happens; the OS notification is only the
+// attention-getter that raises the window.
+//
+// Rendered as a small frameless popup anchored to the bottom-right of its parent
+// window, styled like the rest of AetherSDR's chrome.
+class NetReminderBanner : public QFrame {
+    Q_OBJECT
+
+public:
+    explicit NetReminderBanner(QWidget* parent = nullptr);
+
+    // Show the toast for a net. `headline` is the bold line (e.g. "County ARES
+    // Net starts in 10 min"), `detail` the dim line (e.g. "146.940 MHz · FM").
+    // `canTune` disables the Tune Now button when no radio/slice is available.
+    void showReminder(const QString& netId, const QString& headline,
+                      const QString& detail, bool canTune);
+
+Q_SIGNALS:
+    void tuneRequested(const QString& netId);
+    void dismissed(const QString& netId);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    void anchorToParent();
+
+    QLabel* m_headline{nullptr};
+    QLabel* m_detail{nullptr};
+    QPushButton* m_tuneButton{nullptr};
+    QString m_netId;
+};
+
+} // namespace AetherSDR

--- a/src/gui/NetSchedulerDialog.cpp
+++ b/src/gui/NetSchedulerDialog.cpp
@@ -1,0 +1,673 @@
+#include "NetSchedulerDialog.h"
+
+#include "core/NetRecurrence.h"
+#include "core/NetScheduleStore.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDateTime>
+#include <QDialogButtonBox>
+#include <QDoubleSpinBox>
+#include <QFile>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSaveFile>
+#include <QSpinBox>
+#include <QStringList>
+#include <QTableWidget>
+#include <QTimeEdit>
+#include <QTimeZone>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+const char* const kWeekdayCodes[7] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
+const char* const kWeekdayShort[7] = {"M", "T", "W", "T", "F", "S", "S"};
+const char* const kWeekdayLong[7] = {"Monday",   "Tuesday", "Wednesday", "Thursday",
+                                     "Friday",   "Saturday", "Sunday"};
+
+QStringList commonModes()
+{
+    return {"LSB", "USB", "CW", "CWL", "CWU", "AM", "SAM",
+            "FM", "NFM", "DIGL", "DIGU", "RTTY", "FDV"};
+}
+
+// Friendly one-line preview of the next firing, e.g.
+// "Next: Tue Jun 23, 8:00 PM CDT" — used in the editor and the table.
+QString formatNext(const NetEntry& entry)
+{
+    const QDateTime occ = NetRecurrence::nextOccurrence(entry, QDateTime::currentDateTimeUtc());
+    if (!occ.isValid())
+        return QStringLiteral("No upcoming dates");
+    const QString when = occ.toString("ddd MMM d, h:mm AP");
+    const QString abbr = occ.timeZoneAbbreviation();
+    return abbr.isEmpty() ? when : QString("%1 %2").arg(when, abbr);
+}
+
+// --- editor -------------------------------------------------------------
+//
+// Modal add/edit sheet with the friendly recurrence pattern from the UX
+// research: a Repeats preset + interval, conditional weekday chips / monthly
+// ordinal, a lead-time preset, and a live "Next: ..." confirmation that updates
+// as the user types — so casual operators never see a raw RRULE.
+
+struct EditorControls {
+    QLineEdit* name{nullptr};
+    QComboBox* freqUnit{nullptr};  // Daily/Weekly/Monthly
+    QSpinBox* interval{nullptr};
+    QLabel* intervalUnit{nullptr};
+    QFrame* weekdayRow{nullptr};
+    QPushButton* weekdayChips[7]{};
+    QFrame* monthlyRow{nullptr};
+    QComboBox* monthlyOrdinal{nullptr};
+    QComboBox* monthlyWeekday{nullptr};
+    QTimeEdit* time{nullptr};
+    QComboBox* timezone{nullptr};
+    QComboBox* lead{nullptr};
+    QDoubleSpinBox* freq{nullptr};
+    QComboBox* mode{nullptr};
+    QSpinBox* filterLow{nullptr};
+    QSpinBox* filterHigh{nullptr};
+    QLineEdit* notes{nullptr};
+    QLabel* nextLabel{nullptr};
+};
+
+QString buildRrule(const EditorControls& c)
+{
+    const int kind = c.freqUnit->currentIndex();  // 0 daily, 1 weekly, 2 monthly
+    const int interval = c.interval->value();
+    const QString intervalPart = interval > 1 ? QString(";INTERVAL=%1").arg(interval) : QString();
+
+    if (kind == 0)
+        return QString("FREQ=DAILY%1").arg(intervalPart);
+
+    if (kind == 1) {
+        QStringList codes;
+        for (int i = 0; i < 7; ++i) {
+            if (c.weekdayChips[i]->isChecked())
+                codes << kWeekdayCodes[i];
+        }
+        if (codes.isEmpty())
+            codes << kWeekdayCodes[0];  // default Monday if no chip is picked
+        return QString("FREQ=WEEKLY%1;BYDAY=%2").arg(intervalPart, codes.join(','));
+    }
+
+    // Monthly: ordinal combo maps 0..4 -> 1..5, index 5 -> -1 (last).
+    const int ordIdx = c.monthlyOrdinal->currentIndex();
+    const int ordinal = (ordIdx == 5) ? -1 : ordIdx + 1;
+    const int wdIdx = c.monthlyWeekday->currentIndex();  // 0..6 = Mon..Sun
+    return QString("FREQ=MONTHLY%1;BYDAY=%2%3")
+        .arg(intervalPart)
+        .arg(ordinal)
+        .arg(kWeekdayCodes[wdIdx]);
+}
+
+void loadRuleIntoControls(EditorControls& c, const QString& rrule)
+{
+    const auto rule = NetRecurrence::parseRule(rrule);
+    c.interval->setValue(rule.interval > 0 ? rule.interval : 1);
+
+    switch (rule.freq) {
+    case NetRecurrence::ParsedRule::Freq::Daily:
+        c.freqUnit->setCurrentIndex(0);
+        break;
+    case NetRecurrence::ParsedRule::Freq::Weekly:
+        c.freqUnit->setCurrentIndex(1);
+        for (int i = 0; i < 7; ++i)
+            c.weekdayChips[i]->setChecked(rule.weekdays.contains(i + 1));
+        break;
+    case NetRecurrence::ParsedRule::Freq::Monthly: {
+        c.freqUnit->setCurrentIndex(2);
+        const int ordIdx = (rule.monthlyOrdinal == -1) ? 5 : (rule.monthlyOrdinal - 1);
+        c.monthlyOrdinal->setCurrentIndex(qBound(0, ordIdx, 5));
+        if (rule.monthlyWeekday >= 1 && rule.monthlyWeekday <= 7)
+            c.monthlyWeekday->setCurrentIndex(rule.monthlyWeekday - 1);
+        break;
+    }
+    case NetRecurrence::ParsedRule::Freq::Invalid:
+        c.freqUnit->setCurrentIndex(1);
+        break;
+    }
+}
+
+int leadMinutesFromIndex(int idx)
+{
+    static const int kMinutes[] = {0, 5, 10, 15, 30, 60};
+    if (idx < 0 || idx >= int(sizeof(kMinutes) / sizeof(int)))
+        return 10;
+    return kMinutes[idx];
+}
+
+int leadIndexFromMinutes(int minutes)
+{
+    static const int kMinutes[] = {0, 5, 10, 15, 30, 60};
+    for (int i = 0; i < int(sizeof(kMinutes) / sizeof(int)); ++i) {
+        if (kMinutes[i] == minutes)
+            return i;
+    }
+    return 2;  // default 10 min
+}
+
+bool editNetEntry(QWidget* parent, NetEntry& entry,
+                  const NetSchedulerDialog::CaptureFn& capture, bool isNew)
+{
+    QDialog dlg(parent);
+    dlg.setWindowTitle(isNew ? QStringLiteral("Add Net") : QStringLiteral("Edit Net"));
+    dlg.setModal(true);
+    dlg.setMinimumWidth(440);
+
+    EditorControls c;
+    auto* root = new QVBoxLayout(&dlg);
+    root->setContentsMargins(16, 16, 16, 16);
+    root->setSpacing(12);
+
+    auto* form = new QFormLayout();
+    form->setLabelAlignment(Qt::AlignRight);
+    form->setSpacing(8);
+    root->addLayout(form);
+
+    c.name = new QLineEdit(&dlg);
+    c.name->setPlaceholderText(QStringLiteral("e.g. Tuesday County ARES Net"));
+    form->addRow(QStringLiteral("Name"), c.name);
+
+    // Repeats row.
+    auto* repeatRow = new QHBoxLayout();
+    c.freqUnit = new QComboBox(&dlg);
+    c.freqUnit->addItems({QStringLiteral("Daily"), QStringLiteral("Weekly"),
+                          QStringLiteral("Monthly")});
+    c.freqUnit->setCurrentIndex(1);
+    repeatRow->addWidget(c.freqUnit);
+    repeatRow->addWidget(new QLabel(QStringLiteral("every"), &dlg));
+    c.interval = new QSpinBox(&dlg);
+    c.interval->setRange(1, 52);
+    c.interval->setValue(1);
+    repeatRow->addWidget(c.interval);
+    c.intervalUnit = new QLabel(QStringLiteral("week(s)"), &dlg);
+    repeatRow->addWidget(c.intervalUnit);
+    repeatRow->addStretch(1);
+    form->addRow(QStringLiteral("Repeats"), repeatRow);
+
+    // Weekday chips (weekly only).
+    c.weekdayRow = new QFrame(&dlg);
+    auto* chipRow = new QHBoxLayout(c.weekdayRow);
+    chipRow->setContentsMargins(0, 0, 0, 0);
+    chipRow->setSpacing(4);
+    for (int i = 0; i < 7; ++i) {
+        auto* chip = new QPushButton(QString::fromLatin1(kWeekdayShort[i]), c.weekdayRow);
+        chip->setCheckable(true);
+        chip->setFixedWidth(34);
+        chip->setCursor(Qt::PointingHandCursor);
+        chip->setAccessibleName(QString::fromLatin1(kWeekdayLong[i]));
+        c.weekdayChips[i] = chip;
+        chipRow->addWidget(chip);
+    }
+    chipRow->addStretch(1);
+    form->addRow(QStringLiteral("On"), c.weekdayRow);
+
+    // Monthly ordinal/weekday (monthly only).
+    c.monthlyRow = new QFrame(&dlg);
+    auto* monthRow = new QHBoxLayout(c.monthlyRow);
+    monthRow->setContentsMargins(0, 0, 0, 0);
+    monthRow->setSpacing(6);
+    monthRow->addWidget(new QLabel(QStringLiteral("on the"), c.monthlyRow));
+    c.monthlyOrdinal = new QComboBox(c.monthlyRow);
+    c.monthlyOrdinal->addItems({QStringLiteral("first"), QStringLiteral("second"),
+                                QStringLiteral("third"), QStringLiteral("fourth"),
+                                QStringLiteral("fifth"), QStringLiteral("last")});
+    monthRow->addWidget(c.monthlyOrdinal);
+    c.monthlyWeekday = new QComboBox(c.monthlyRow);
+    for (int i = 0; i < 7; ++i)
+        c.monthlyWeekday->addItem(QString::fromLatin1(kWeekdayLong[i]));
+    c.monthlyWeekday->setCurrentIndex(6);  // Sunday default
+    monthRow->addWidget(c.monthlyWeekday);
+    monthRow->addStretch(1);
+    form->addRow(QString(), c.monthlyRow);
+
+    // Time + timezone.
+    auto* timeRow = new QHBoxLayout();
+    c.time = new QTimeEdit(&dlg);
+    c.time->setDisplayFormat(QStringLiteral("h:mm AP"));
+    c.time->setTime(QTime(20, 0));
+    timeRow->addWidget(c.time);
+    c.timezone = new QComboBox(&dlg);
+    c.timezone->setEditable(true);
+    c.timezone->setInsertPolicy(QComboBox::NoInsert);
+    {
+        const QByteArray sys = QTimeZone::systemTimeZoneId();
+        c.timezone->addItem(QString::fromUtf8(sys));
+        c.timezone->addItem(QStringLiteral("Etc/UTC"));
+        const auto ids = QTimeZone::availableTimeZoneIds();
+        for (const QByteArray& id : ids) {
+            const QString s = QString::fromUtf8(id);
+            if (c.timezone->findText(s) < 0)
+                c.timezone->addItem(s);
+        }
+        c.timezone->setCurrentIndex(0);
+    }
+    timeRow->addWidget(c.timezone, 1);
+    form->addRow(QStringLiteral("At"), timeRow);
+
+    // Reminder lead.
+    c.lead = new QComboBox(&dlg);
+    c.lead->addItems({QStringLiteral("At start time"), QStringLiteral("5 minutes before"),
+                      QStringLiteral("10 minutes before"), QStringLiteral("15 minutes before"),
+                      QStringLiteral("30 minutes before"), QStringLiteral("1 hour before")});
+    c.lead->setCurrentIndex(2);
+    form->addRow(QStringLiteral("Remind me"), c.lead);
+
+    // Separator.
+    auto* sep = new QFrame(&dlg);
+    sep->setFrameShape(QFrame::HLine);
+    sep->setFrameShadow(QFrame::Sunken);
+    root->addWidget(sep);
+
+    // Tuning preset.
+    auto* tuneForm = new QFormLayout();
+    tuneForm->setLabelAlignment(Qt::AlignRight);
+    tuneForm->setSpacing(8);
+    root->addLayout(tuneForm);
+
+    auto* freqRow = new QHBoxLayout();
+    c.freq = new QDoubleSpinBox(&dlg);
+    c.freq->setDecimals(6);
+    c.freq->setRange(0.0, 10000.0);
+    c.freq->setSuffix(QStringLiteral(" MHz"));
+    c.freq->setValue(146.520000);
+    freqRow->addWidget(c.freq, 1);
+    c.mode = new QComboBox(&dlg);
+    c.mode->addItems(commonModes());
+    c.mode->setCurrentText(QStringLiteral("FM"));
+    freqRow->addWidget(c.mode);
+    auto* captureBtn = new QPushButton(QStringLiteral("Capture current VFO"), &dlg);
+    captureBtn->setCursor(Qt::PointingHandCursor);
+    freqRow->addWidget(captureBtn);
+    tuneForm->addRow(QStringLiteral("Frequency"), freqRow);
+
+    auto* filterRow = new QHBoxLayout();
+    c.filterLow = new QSpinBox(&dlg);
+    c.filterLow->setRange(-12000, 12000);
+    c.filterLow->setSuffix(QStringLiteral(" Hz"));
+    c.filterHigh = new QSpinBox(&dlg);
+    c.filterHigh->setRange(-12000, 12000);
+    c.filterHigh->setSuffix(QStringLiteral(" Hz"));
+    filterRow->addWidget(c.filterLow);
+    filterRow->addWidget(new QLabel(QStringLiteral("to"), &dlg));
+    filterRow->addWidget(c.filterHigh);
+    filterRow->addStretch(1);
+    tuneForm->addRow(QStringLiteral("Filter"), filterRow);
+
+    c.notes = new QLineEdit(&dlg);
+    c.notes->setPlaceholderText(QStringLiteral("Net control, NetLogger name, etc."));
+    tuneForm->addRow(QStringLiteral("Notes"), c.notes);
+
+    // Live next-occurrence preview.
+    c.nextLabel = new QLabel(&dlg);
+    c.nextLabel->setStyleSheet("color: palette(highlight); font-weight: 600;");
+    root->addWidget(c.nextLabel);
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dlg);
+    root->addWidget(buttons);
+    QObject::connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    QObject::connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    // --- behaviour ---
+    auto snapshotEntry = [&c, &entry]() {
+        NetEntry e = entry;
+        e.name = c.name->text();
+        e.rrule = buildRrule(c);
+        e.timeOfDay = c.time->time().toString("HH:mm");
+        e.timezone = c.timezone->currentText().trimmed();
+        e.reminderLeadMinutes = leadMinutesFromIndex(c.lead->currentIndex());
+        e.notes = c.notes->text();
+        e.preset.freq = c.freq->value();
+        e.preset.mode = c.mode->currentText();
+        e.preset.rxFilterLow = c.filterLow->value();
+        e.preset.rxFilterHigh = c.filterHigh->value();
+        return e;
+    };
+
+    auto refresh = [&c, snapshotEntry]() {
+        const int kind = c.freqUnit->currentIndex();
+        c.intervalUnit->setText(kind == 0   ? QStringLiteral("day(s)")
+                                : kind == 1 ? QStringLiteral("week(s)")
+                                            : QStringLiteral("month(s)"));
+        c.weekdayRow->setVisible(kind == 1);
+        c.monthlyRow->setVisible(kind == 2);
+        c.nextLabel->setText(QStringLiteral("Next: ") + formatNext(snapshotEntry()));
+    };
+
+    QObject::connect(c.freqUnit, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
+    QObject::connect(c.interval, &QSpinBox::valueChanged, &dlg, [refresh](int) { refresh(); });
+    QObject::connect(c.monthlyOrdinal, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
+    QObject::connect(c.monthlyWeekday, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
+    QObject::connect(c.time, &QTimeEdit::timeChanged, &dlg, [refresh](const QTime&) { refresh(); });
+    QObject::connect(c.timezone, &QComboBox::currentTextChanged, &dlg, [refresh](const QString&) { refresh(); });
+    QObject::connect(c.lead, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
+    for (int i = 0; i < 7; ++i)
+        QObject::connect(c.weekdayChips[i], &QPushButton::toggled, &dlg, [refresh](bool) { refresh(); });
+
+    QObject::connect(captureBtn, &QPushButton::clicked, &dlg, [&c, &capture, &dlg, refresh]() {
+        if (!capture) {
+            return;
+        }
+        const MemoryEntry m = capture();
+        if (m.freq <= 0.0) {
+            QMessageBox::information(&dlg, QStringLiteral("Capture current VFO"),
+                                     QStringLiteral("Open a slice on a connected radio first."));
+            return;
+        }
+        c.freq->setValue(m.freq);
+        if (!m.mode.isEmpty())
+            c.mode->setCurrentText(m.mode);
+        c.filterLow->setValue(m.rxFilterLow);
+        c.filterHigh->setValue(m.rxFilterHigh);
+        refresh();
+    });
+
+    // Seed controls from the entry being edited.
+    c.name->setText(entry.name);
+    loadRuleIntoControls(c, entry.rrule);
+    {
+        const QTime t = QTime::fromString(entry.timeOfDay, "HH:mm");
+        c.time->setTime(t.isValid() ? t : QTime(20, 0));
+    }
+    if (!entry.timezone.isEmpty()) {
+        const int idx = c.timezone->findText(entry.timezone);
+        if (idx >= 0)
+            c.timezone->setCurrentIndex(idx);
+        else
+            c.timezone->setCurrentText(entry.timezone);
+    }
+    c.lead->setCurrentIndex(leadIndexFromMinutes(entry.reminderLeadMinutes));
+    c.notes->setText(entry.notes);
+    if (entry.preset.freq > 0.0)
+        c.freq->setValue(entry.preset.freq);
+    if (!entry.preset.mode.isEmpty())
+        c.mode->setCurrentText(entry.preset.mode);
+    c.filterLow->setValue(entry.preset.rxFilterLow);
+    c.filterHigh->setValue(entry.preset.rxFilterHigh);
+
+    // On a brand-new net, prefill the preset from the current VFO if available.
+    if (isNew && capture) {
+        const MemoryEntry m = capture();
+        if (m.freq > 0.0) {
+            c.freq->setValue(m.freq);
+            if (!m.mode.isEmpty())
+                c.mode->setCurrentText(m.mode);
+            c.filterLow->setValue(m.rxFilterLow);
+            c.filterHigh->setValue(m.rxFilterHigh);
+        }
+    }
+
+    refresh();
+
+    if (dlg.exec() != QDialog::Accepted)
+        return false;
+
+    NetEntry result = snapshotEntry();
+    // Anchor INTERVAL phasing to today if the entry has no start date yet.
+    if (result.startDate.isEmpty())
+        result.startDate = QDate::currentDate().toString("yyyy-MM-dd");
+    if (result.name.trimmed().isEmpty())
+        result.name = QStringLiteral("Unnamed Net");
+    entry = result;
+    return true;
+}
+
+} // namespace
+
+NetSchedulerDialog::NetSchedulerDialog(QList<NetEntry> entries, CaptureFn capture, QWidget* parent)
+    : PersistentDialog(QStringLiteral("Net Scheduler"),
+                       QStringLiteral("NetSchedulerDialogGeometry"), parent)
+    , m_entries(std::move(entries))
+    , m_capture(std::move(capture))
+{
+    setMinimumSize(640, 380);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setContentsMargins(9, 9, 9, 9);
+    root->setSpacing(9);
+
+    auto* intro = new QLabel(
+        QStringLiteral("Schedule recurring nets and get a reminder with one-click tuning."),
+        bodyWidget());
+    intro->setStyleSheet("color: palette(mid);");
+    root->addWidget(intro);
+
+    m_table = new QTableWidget(bodyWidget());
+    m_table->setColumnCount(6);
+    m_table->setHorizontalHeaderLabels(
+        {QStringLiteral("On"), QStringLiteral("Name"), QStringLiteral("Repeats"),
+         QStringLiteral("Next"), QStringLiteral("Frequency"), QStringLiteral("Mode")});
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    m_table->setAccessibleName(QStringLiteral("Scheduled nets"));
+    root->addWidget(m_table, 1);
+
+    auto* btnRow = new QHBoxLayout();
+    auto* addBtn = new QPushButton(QStringLiteral("Add…"), bodyWidget());
+    m_editBtn = new QPushButton(QStringLiteral("Edit…"), bodyWidget());
+    m_removeBtn = new QPushButton(QStringLiteral("Remove"), bodyWidget());
+    m_toggleBtn = new QPushButton(QStringLiteral("Disable"), bodyWidget());
+    m_tuneBtn = new QPushButton(QStringLiteral("Tune Now"), bodyWidget());
+    btnRow->addWidget(addBtn);
+    btnRow->addWidget(m_editBtn);
+    btnRow->addWidget(m_removeBtn);
+    btnRow->addWidget(m_toggleBtn);
+    btnRow->addWidget(m_tuneBtn);
+    btnRow->addStretch(1);
+    auto* importBtn = new QPushButton(QStringLiteral("Import…"), bodyWidget());
+    auto* exportBtn = new QPushButton(QStringLiteral("Export…"), bodyWidget());
+    btnRow->addWidget(importBtn);
+    btnRow->addWidget(exportBtn);
+    root->addLayout(btnRow);
+
+    connect(addBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onAdd);
+    connect(m_editBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onEdit);
+    connect(m_removeBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onRemove);
+    connect(m_toggleBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onToggleEnabled);
+    connect(m_tuneBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onTuneNow);
+    connect(importBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onImport);
+    connect(exportBtn, &QPushButton::clicked, this, &NetSchedulerDialog::onExport);
+    connect(m_table, &QTableWidget::itemSelectionChanged, this, &NetSchedulerDialog::updateButtons);
+    connect(m_table, &QTableWidget::cellDoubleClicked, this, [this](int, int) { onEdit(); });
+
+    populateTable();
+    updateButtons();
+}
+
+int NetSchedulerDialog::selectedRow() const
+{
+    return m_table->currentRow();
+}
+
+void NetSchedulerDialog::populateTable()
+{
+    m_table->setRowCount(m_entries.size());
+    for (int row = 0; row < m_entries.size(); ++row) {
+        const NetEntry& e = m_entries.at(row);
+
+        auto* onItem = new QTableWidgetItem(e.enabled ? QStringLiteral("✓") : QString());
+        onItem->setTextAlignment(Qt::AlignCenter);
+        onItem->setData(Qt::UserRole, e.id);
+        m_table->setItem(row, 0, onItem);
+
+        m_table->setItem(row, 1, new QTableWidgetItem(e.name));
+        m_table->setItem(row, 2, new QTableWidgetItem(NetRecurrence::describeRule(e.rrule)));
+        m_table->setItem(row, 3, new QTableWidgetItem(e.enabled ? formatNext(e)
+                                                                : QStringLiteral("—")));
+        m_table->setItem(row, 4,
+                         new QTableWidgetItem(QString::number(e.preset.freq, 'f', 4)
+                                              + QStringLiteral(" MHz")));
+        m_table->setItem(row, 5, new QTableWidgetItem(e.preset.mode));
+
+        if (!e.enabled) {
+            for (int col = 0; col < m_table->columnCount(); ++col) {
+                if (auto* it = m_table->item(row, col))
+                    it->setForeground(palette().brush(QPalette::Disabled, QPalette::Text));
+            }
+        }
+    }
+}
+
+void NetSchedulerDialog::updateButtons()
+{
+    const int row = selectedRow();
+    const bool has = row >= 0 && row < m_entries.size();
+    m_editBtn->setEnabled(has);
+    m_removeBtn->setEnabled(has);
+    m_toggleBtn->setEnabled(has);
+    m_tuneBtn->setEnabled(has);
+    if (has)
+        m_toggleBtn->setText(m_entries.at(row).enabled ? QStringLiteral("Disable")
+                                                       : QStringLiteral("Enable"));
+}
+
+void NetSchedulerDialog::commit()
+{
+    populateTable();
+    updateButtons();
+    Q_EMIT entriesChanged(m_entries);
+}
+
+void NetSchedulerDialog::onAdd()
+{
+    NetEntry e;
+    if (!editNetEntry(this, e, m_capture, /*isNew=*/true))
+        return;
+    e.id = NetScheduleStore::newId();
+    m_entries.append(e);
+    commit();
+    m_table->setCurrentCell(m_entries.size() - 1, 1);
+}
+
+void NetSchedulerDialog::onEdit()
+{
+    const int row = selectedRow();
+    if (row < 0 || row >= m_entries.size())
+        return;
+    NetEntry e = m_entries.at(row);
+    if (!editNetEntry(this, e, m_capture, /*isNew=*/false))
+        return;
+    m_entries[row] = e;
+    commit();
+    m_table->setCurrentCell(row, 1);
+}
+
+void NetSchedulerDialog::onRemove()
+{
+    const int row = selectedRow();
+    if (row < 0 || row >= m_entries.size())
+        return;
+    const auto answer = QMessageBox::question(
+        this, QStringLiteral("Remove Net"),
+        QStringLiteral("Remove \"%1\" from your schedule?").arg(m_entries.at(row).name));
+    if (answer != QMessageBox::Yes)
+        return;
+    m_entries.removeAt(row);
+    commit();
+}
+
+void NetSchedulerDialog::onToggleEnabled()
+{
+    const int row = selectedRow();
+    if (row < 0 || row >= m_entries.size())
+        return;
+    m_entries[row].enabled = !m_entries.at(row).enabled;
+    commit();
+    m_table->setCurrentCell(row, 1);
+}
+
+void NetSchedulerDialog::onTuneNow()
+{
+    const int row = selectedRow();
+    if (row < 0 || row >= m_entries.size())
+        return;
+    Q_EMIT tuneRequested(m_entries.at(row));
+}
+
+void NetSchedulerDialog::onImport()
+{
+    const QString path = QFileDialog::getOpenFileName(
+        this, QStringLiteral("Import Net Schedule"), QString(),
+        QStringLiteral("Net schedule (*.json);;All files (*)"));
+    if (path.isEmpty())
+        return;
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this, QStringLiteral("Import"),
+                             QStringLiteral("Could not open the file."));
+        return;
+    }
+    const auto result = NetScheduleStore::parse(file.readAll());
+    if (!result.ok()) {
+        QMessageBox::warning(this, QStringLiteral("Import"),
+                             QStringLiteral("Could not read this file:\n%1")
+                                 .arg(result.errors.join('\n')));
+        return;
+    }
+    if (result.nets.isEmpty()) {
+        QMessageBox::information(this, QStringLiteral("Import"),
+                                 QStringLiteral("No nets were found in this file."));
+        return;
+    }
+
+    NetScheduleStore::MergePolicy policy = NetScheduleStore::MergePolicy::Duplicate;
+    QMessageBox box(this);
+    box.setWindowTitle(QStringLiteral("Import Net Schedule"));
+    box.setText(QStringLiteral("Importing %1 net(s). How should entries that already "
+                               "exist be handled?")
+                    .arg(result.nets.size()));
+    auto* skipBtn = box.addButton(QStringLiteral("Skip existing"), QMessageBox::AcceptRole);
+    auto* overwriteBtn = box.addButton(QStringLiteral("Overwrite"), QMessageBox::AcceptRole);
+    auto* dupBtn = box.addButton(QStringLiteral("Import as new"), QMessageBox::AcceptRole);
+    box.addButton(QMessageBox::Cancel);
+    box.exec();
+    if (box.clickedButton() == skipBtn)
+        policy = NetScheduleStore::MergePolicy::Skip;
+    else if (box.clickedButton() == overwriteBtn)
+        policy = NetScheduleStore::MergePolicy::Overwrite;
+    else if (box.clickedButton() == dupBtn)
+        policy = NetScheduleStore::MergePolicy::Duplicate;
+    else
+        return;
+
+    m_entries = NetScheduleStore::merge(m_entries, result.nets, policy);
+    commit();
+}
+
+void NetSchedulerDialog::onExport()
+{
+    const QString path = QFileDialog::getSaveFileName(
+        this, QStringLiteral("Export Net Schedule"), QStringLiteral("net-schedule.json"),
+        QStringLiteral("Net schedule (*.json)"));
+    if (path.isEmpty())
+        return;
+
+    const QByteArray json = NetScheduleStore::serialize(
+        m_entries, QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly) || file.write(json) != json.size() || !file.commit()) {
+        QMessageBox::warning(this, QStringLiteral("Export"),
+                             QStringLiteral("Could not write the file."));
+        return;
+    }
+}
+
+} // namespace AetherSDR

--- a/src/gui/NetSchedulerDialog.cpp
+++ b/src/gui/NetSchedulerDialog.cpp
@@ -5,6 +5,8 @@
 
 #include <QCheckBox>
 #include <QComboBox>
+#include <QDate>
+#include <QDateEdit>
 #include <QDateTime>
 #include <QDialogButtonBox>
 #include <QDoubleSpinBox>
@@ -63,7 +65,9 @@ QString formatNext(const NetEntry& entry)
 
 struct EditorControls {
     QLineEdit* name{nullptr};
-    QComboBox* freqUnit{nullptr};  // Daily/Weekly/Monthly
+    QComboBox* freqUnit{nullptr};  // Once/Daily/Weekly/Monthly
+    QDateEdit* date{nullptr};      // one-time date (Once)
+    QLabel* dateLabel{nullptr};
     QSpinBox* interval{nullptr};
     QLabel* intervalUnit{nullptr};
     QFrame* weekdayRow{nullptr};
@@ -84,14 +88,17 @@ struct EditorControls {
 
 QString buildRrule(const EditorControls& c)
 {
-    const int kind = c.freqUnit->currentIndex();  // 0 daily, 1 weekly, 2 monthly
+    const int kind = c.freqUnit->currentIndex();  // 0 once, 1 daily, 2 weekly, 3 monthly
     const int interval = c.interval->value();
     const QString intervalPart = interval > 1 ? QString(";INTERVAL=%1").arg(interval) : QString();
 
     if (kind == 0)
+        return QString();  // one-time / "Repeat = Never"
+
+    if (kind == 1)
         return QString("FREQ=DAILY%1").arg(intervalPart);
 
-    if (kind == 1) {
+    if (kind == 2) {
         QStringList codes;
         for (int i = 0; i < 7; ++i) {
             if (c.weekdayChips[i]->isChecked())
@@ -119,15 +126,15 @@ void loadRuleIntoControls(EditorControls& c, const QString& rrule)
 
     switch (rule.freq) {
     case NetRecurrence::ParsedRule::Freq::Daily:
-        c.freqUnit->setCurrentIndex(0);
+        c.freqUnit->setCurrentIndex(1);
         break;
     case NetRecurrence::ParsedRule::Freq::Weekly:
-        c.freqUnit->setCurrentIndex(1);
+        c.freqUnit->setCurrentIndex(2);
         for (int i = 0; i < 7; ++i)
             c.weekdayChips[i]->setChecked(rule.weekdays.contains(i + 1));
         break;
     case NetRecurrence::ParsedRule::Freq::Monthly: {
-        c.freqUnit->setCurrentIndex(2);
+        c.freqUnit->setCurrentIndex(3);
         const int ordIdx = (rule.monthlyOrdinal == -1) ? 5 : (rule.monthlyOrdinal - 1);
         c.monthlyOrdinal->setCurrentIndex(qBound(0, ordIdx, 5));
         if (rule.monthlyWeekday >= 1 && rule.monthlyWeekday <= 7)
@@ -135,7 +142,7 @@ void loadRuleIntoControls(EditorControls& c, const QString& rrule)
         break;
     }
     case NetRecurrence::ParsedRule::Freq::Invalid:
-        c.freqUnit->setCurrentIndex(1);
+        c.freqUnit->setCurrentIndex(2);
         break;
     }
 }
@@ -183,11 +190,12 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
     // Repeats row.
     auto* repeatRow = new QHBoxLayout();
     c.freqUnit = new QComboBox(&dlg);
-    c.freqUnit->addItems({QStringLiteral("Daily"), QStringLiteral("Weekly"),
-                          QStringLiteral("Monthly")});
-    c.freqUnit->setCurrentIndex(1);
+    c.freqUnit->addItems({QStringLiteral("Once (no repeat)"), QStringLiteral("Daily"),
+                          QStringLiteral("Weekly"), QStringLiteral("Monthly")});
+    c.freqUnit->setCurrentIndex(2);
     repeatRow->addWidget(c.freqUnit);
-    repeatRow->addWidget(new QLabel(QStringLiteral("every"), &dlg));
+    auto* everyLabel = new QLabel(QStringLiteral("every"), &dlg);
+    repeatRow->addWidget(everyLabel);
     c.interval = new QSpinBox(&dlg);
     c.interval->setRange(1, 52);
     c.interval->setValue(1);
@@ -196,6 +204,13 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
     repeatRow->addWidget(c.intervalUnit);
     repeatRow->addStretch(1);
     form->addRow(QStringLiteral("Repeats"), repeatRow);
+
+    // One-time date (Once only).
+    c.date = new QDateEdit(QDate::currentDate(), &dlg);
+    c.date->setCalendarPopup(true);
+    c.date->setDisplayFormat(QStringLiteral("ddd MMM d, yyyy"));
+    c.dateLabel = new QLabel(QStringLiteral("On date"), &dlg);
+    form->addRow(c.dateLabel, c.date);
 
     // Weekday chips (weekly only).
     c.weekdayRow = new QFrame(&dlg);
@@ -327,6 +342,8 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
         e.rrule = buildRrule(c);
         e.timeOfDay = c.time->time().toString("HH:mm");
         e.timezone = c.timezone->currentText().trimmed();
+        if (e.rrule.isEmpty())  // one-time: anchor to the chosen date
+            e.startDate = c.date->date().toString("yyyy-MM-dd");
         e.reminderLeadMinutes = leadMinutesFromIndex(c.lead->currentIndex());
         e.notes = c.notes->text();
         e.preset.freq = c.freq->value();
@@ -336,13 +353,19 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
         return e;
     };
 
-    auto refresh = [&c, snapshotEntry]() {
-        const int kind = c.freqUnit->currentIndex();
-        c.intervalUnit->setText(kind == 0   ? QStringLiteral("day(s)")
-                                : kind == 1 ? QStringLiteral("week(s)")
+    auto refresh = [&c, everyLabel, snapshotEntry]() {
+        const int kind = c.freqUnit->currentIndex();  // 0 once,1 daily,2 weekly,3 monthly
+        const bool once = (kind == 0);
+        c.intervalUnit->setText(kind == 1   ? QStringLiteral("day(s)")
+                                : kind == 2 ? QStringLiteral("week(s)")
                                             : QStringLiteral("month(s)"));
-        c.weekdayRow->setVisible(kind == 1);
-        c.monthlyRow->setVisible(kind == 2);
+        everyLabel->setVisible(!once);
+        c.interval->setVisible(!once);
+        c.intervalUnit->setVisible(!once);
+        c.dateLabel->setVisible(once);
+        c.date->setVisible(once);
+        c.weekdayRow->setVisible(kind == 2);
+        c.monthlyRow->setVisible(kind == 3);
         c.nextLabel->setText(QStringLiteral("Next: ") + formatNext(snapshotEntry()));
     };
 
@@ -351,6 +374,7 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
     QObject::connect(c.monthlyOrdinal, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
     QObject::connect(c.monthlyWeekday, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
     QObject::connect(c.time, &QTimeEdit::timeChanged, &dlg, [refresh](const QTime&) { refresh(); });
+    QObject::connect(c.date, &QDateEdit::dateChanged, &dlg, [refresh](const QDate&) { refresh(); });
     QObject::connect(c.timezone, &QComboBox::currentTextChanged, &dlg, [refresh](const QString&) { refresh(); });
     QObject::connect(c.lead, &QComboBox::currentIndexChanged, &dlg, [refresh](int) { refresh(); });
     for (int i = 0; i < 7; ++i)
@@ -376,7 +400,23 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
 
     // Seed controls from the entry being edited.
     c.name->setText(entry.name);
-    loadRuleIntoControls(c, entry.rrule);
+    if (entry.rrule.trimmed().isEmpty()) {
+        if (isNew) {
+            // New nets default to Weekly on today's weekday, not Once.
+            c.freqUnit->setCurrentIndex(2);
+            const int todayDow = QDate::currentDate().dayOfWeek();
+            if (todayDow >= 1 && todayDow <= 7)
+                c.weekdayChips[todayDow - 1]->setChecked(true);
+        } else {
+            c.freqUnit->setCurrentIndex(0);  // saved one-time net
+        }
+    } else {
+        loadRuleIntoControls(c, entry.rrule);
+    }
+    {
+        const QDate seedDate = QDate::fromString(entry.startDate, "yyyy-MM-dd");
+        c.date->setDate(seedDate.isValid() ? seedDate : QDate::currentDate());
+    }
     {
         const QTime t = QTime::fromString(entry.timeOfDay, "HH:mm");
         c.time->setTime(t.isValid() ? t : QTime(20, 0));
@@ -415,8 +455,9 @@ bool editNetEntry(QWidget* parent, NetEntry& entry,
         return false;
 
     NetEntry result = snapshotEntry();
-    // Anchor INTERVAL phasing to today if the entry has no start date yet.
-    if (result.startDate.isEmpty())
+    // Anchor a recurring rule's INTERVAL phasing to today if unset; a one-time
+    // net already carries its chosen date in startDate.
+    if (!result.rrule.isEmpty() && result.startDate.isEmpty())
         result.startDate = QDate::currentDate().toString("yyyy-MM-dd");
     if (result.name.trimmed().isEmpty())
         result.name = QStringLiteral("Unnamed Net");

--- a/src/gui/NetSchedulerDialog.h
+++ b/src/gui/NetSchedulerDialog.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "PersistentDialog.h"
+#include "models/NetEntry.h"
+
+#include <QList>
+
+#include <functional>
+
+class QPushButton;
+class QTableWidget;
+
+namespace AetherSDR {
+
+// Personal net-schedule manager. Mirrors MemoryDialog's table + button-row
+// layout and its import/export affordances, but the rows are recurring nets
+// (recurrence rule + reminder + tuning preset) persisted client-side as JSON,
+// not radio memory slots.
+//
+// The dialog owns a working copy of the entry list and emits entriesChanged()
+// whenever it is mutated so the owner (MainWindow) can persist it and refeed the
+// scheduler. "Tune Now" reuses the same MemoryRecallPolicy path as a memory
+// recall via the tuneRequested() signal.
+class NetSchedulerDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    // capture: returns the current VFO state as a tuning preset (freq/mode/
+    // filter/tone) so a net can be seeded from "what I'm listening to now".
+    // Returns a freq<=0 MemoryEntry when no slice is available.
+    using CaptureFn = std::function<MemoryEntry()>;
+
+    explicit NetSchedulerDialog(QList<NetEntry> entries, CaptureFn capture,
+                                QWidget* parent = nullptr);
+
+    QList<NetEntry> entries() const { return m_entries; }
+
+Q_SIGNALS:
+    void entriesChanged(const QList<AetherSDR::NetEntry>& entries);
+    void tuneRequested(const AetherSDR::NetEntry& entry);
+
+private:
+    void populateTable();
+    void updateButtons();
+    int selectedRow() const;
+    void commit();
+
+    void onAdd();
+    void onEdit();
+    void onRemove();
+    void onToggleEnabled();
+    void onTuneNow();
+    void onImport();
+    void onExport();
+
+    QList<NetEntry> m_entries;
+    CaptureFn m_capture;
+    QTableWidget* m_table{nullptr};
+    QPushButton* m_editBtn{nullptr};
+    QPushButton* m_removeBtn{nullptr};
+    QPushButton* m_toggleBtn{nullptr};
+    QPushButton* m_tuneBtn{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/models/NetEntry.h
+++ b/src/models/NetEntry.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "models/MemoryEntry.h"
+
+#include <QString>
+
+namespace AetherSDR {
+
+// A scheduled amateur-radio "net": a recurring on-air gathering on a fixed
+// frequency/mode at a regular time. Conceptually a memory channel (the tuning
+// preset) plus a recurrence rule, a reminder lead-time, and descriptive
+// metadata.
+//
+// Unlike MemoryEntry — which is radio-authoritative and lives in the radio's
+// memory slots (Constitution Principles II & III) — a NetEntry is purely
+// operator-scoped client state (Principle XIII): it must work whether or not a
+// radio is connected and never consumes a radio memory slot. It is persisted
+// locally as versioned JSON (see NetScheduleStore).
+//
+// The recurrence is stored as an RFC 5545 RRULE string (portable, the standard
+// every calendar interoperates on) plus the local wall-clock time-of-day and an
+// IANA timezone id. The firing instant is always computed lazily from those so
+// "20:00 local" stays correct across DST transitions (see NetRecurrence).
+struct NetEntry {
+    QString     id;                      // stable UUID (no braces) — merge/import key
+    QString     name;                    // user label, e.g. "Tuesday County ARES Net"
+    bool        enabled{true};
+
+    // Recurrence (see NetRecurrence for the supported RRULE subset).
+    QString     rrule;                   // e.g. "FREQ=WEEKLY;BYDAY=TU"
+    QString     startDate;               // DTSTART date, ISO "yyyy-MM-dd"; anchors INTERVAL phase
+    QString     timeOfDay{"20:00"};      // local wall-clock "HH:MM" in `timezone`
+    QString     timezone{"Etc/UTC"};     // IANA id; "Etc/UTC" for UTC/Zulu nets
+    int         reminderLeadMinutes{10}; // fire the reminder this many minutes before start
+    int         durationMinutes{60};     // informational; how long the net runs
+
+    // Tuning preset — reuses the radio memory-channel shape so recall can drive
+    // the same MemoryRecallPolicy command builders the memory dialog uses.
+    MemoryEntry preset;
+
+    QString     notes;                   // free text: NCS callsign, NetLogger name, etc.
+};
+
+} // namespace AetherSDR

--- a/tests/net_recurrence_test.cpp
+++ b/tests/net_recurrence_test.cpp
@@ -1,0 +1,161 @@
+#include "core/NetRecurrence.h"
+
+#include <QDate>
+#include <QDateTime>
+#include <QTime>
+#include <QTimeZone>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+// UTC instant builder that avoids Qt 6.5+ QTimeZone::utc() (CI Qt is pre-6.5).
+QDateTime utc(int y, int mo, int d, int h, int mi)
+{
+    return QDateTime(QDate(y, mo, d), QTime(h, mi), QTimeZone("UTC"));
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // --- parseRule ------------------------------------------------------
+    {
+        const auto r = NetRecurrence::parseRule("FREQ=WEEKLY;BYDAY=TU");
+        ok &= expect(r.isValid() && r.freq == NetRecurrence::ParsedRule::Freq::Weekly,
+                     "weekly rule parses");
+        ok &= expect(r.weekdays.size() == 1 && r.weekdays.first() == 2,
+                     "weekly BYDAY=TU maps to Qt day 2");
+    }
+    {
+        const auto r = NetRecurrence::parseRule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR");
+        ok &= expect(r.interval == 2 && r.weekdays.size() == 3,
+                     "weekly interval + multi BYDAY parse");
+    }
+    {
+        const auto r = NetRecurrence::parseRule("FREQ=MONTHLY;BYDAY=1SU");
+        ok &= expect(r.isValid() && r.monthlyOrdinal == 1 && r.monthlyWeekday == 7,
+                     "monthly first-Sunday parses");
+    }
+    {
+        const auto r = NetRecurrence::parseRule("FREQ=MONTHLY;BYDAY=-1WE");
+        ok &= expect(r.isValid() && r.monthlyOrdinal == -1 && r.monthlyWeekday == 3,
+                     "monthly last-Wednesday parses");
+    }
+    {
+        ok &= expect(!NetRecurrence::parseRule("FREQ=YEARLY").isValid(),
+                     "unsupported FREQ is invalid");
+        ok &= expect(!NetRecurrence::parseRule("garbage").isValid(),
+                     "garbage rule is invalid");
+        ok &= expect(!NetRecurrence::parseRule("FREQ=MONTHLY").isValid(),
+                     "monthly without BYDAY is invalid");
+    }
+
+    // --- weekly next occurrence ----------------------------------------
+    {
+        // Tuesdays 20:00 UTC. After 2026-06-01 00:00Z → Tue Jun 2 20:00Z.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;BYDAY=TU", "20:00", "Etc/UTC", QDate(), utc(2026, 6, 1, 0, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 2, 20, 0),
+                     "weekly Tuesday picks the next Tuesday at 20:00 UTC");
+    }
+    {
+        // Same day but earlier than the time → still fires today.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;BYDAY=TU", "20:00", "Etc/UTC", QDate(), utc(2026, 6, 2, 10, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 2, 20, 0),
+                     "same-day occurrence later than now is returned");
+    }
+    {
+        // Strictly after: at exactly the occurrence, return the next week.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;BYDAY=TU", "20:00", "Etc/UTC", QDate(), utc(2026, 6, 2, 20, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 9, 20, 0),
+                     "occurrence is strictly after the reference instant");
+    }
+
+    // --- weekly INTERVAL phase (needs startDate anchor) -----------------
+    {
+        // Every 2 weeks on Tuesday, anchored Tue Jun 2 → Jun 2, 16, 30 (NOT Jun 9).
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;INTERVAL=2;BYDAY=TU", "20:00", "Etc/UTC", QDate(2026, 6, 2),
+            utc(2026, 6, 2, 20, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 16, 20, 0),
+                     "biweekly skips the off-week using the startDate anchor");
+    }
+
+    // --- monthly nth weekday -------------------------------------------
+    {
+        // First Sunday of the month. After Jun 1 2026 → Sun Jun 7.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=MONTHLY;BYDAY=1SU", "09:00", "Etc/UTC", QDate(), utc(2026, 6, 1, 0, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 7, 9, 0),
+                     "monthly first-Sunday resolves to Jun 7");
+    }
+    {
+        // Last Wednesday of June 2026 is Jun 24.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=MONTHLY;BYDAY=-1WE", "09:00", "Etc/UTC", QDate(), utc(2026, 6, 1, 0, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 24, 9, 0),
+                     "monthly last-Wednesday resolves to Jun 24");
+    }
+
+    // --- daily interval -------------------------------------------------
+    {
+        // Every 3 days anchored Jun 1 → Jun 1, 4, 7. After Jun 2 → Jun 4.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "FREQ=DAILY;INTERVAL=3", "12:00", "Etc/UTC", QDate(2026, 6, 1),
+            utc(2026, 6, 2, 0, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 4, 12, 0),
+                     "every-3-days honors the anchor phase");
+    }
+
+    // --- DST correctness (America/Chicago, 20:00 local stays 20:00) -----
+    {
+        // Winter (CST = UTC-6): Tue Feb 3 2026, 20:00 CST = Feb 4 02:00 UTC.
+        const QDateTime winter = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;BYDAY=TU", "20:00", "America/Chicago", QDate(), utc(2026, 2, 1, 0, 0));
+        const QDateTime winterLocal = winter.toTimeZone(QTimeZone("America/Chicago"));
+        ok &= expect(winterLocal.time() == QTime(20, 0),
+                     "winter net is 20:00 local (CST)");
+        ok &= expect(winter.toUTC() == utc(2026, 2, 4, 2, 0),
+                     "20:00 CST equals 02:00 UTC");
+
+        // Summer (CDT = UTC-5): Tue Jul 7 2026, 20:00 CDT = Jul 8 01:00 UTC.
+        // Use noon UTC as the reference so the local search day is Jul 1 (a
+        // midnight-UTC reference would land on Jun 30 evening Chicago time).
+        const QDateTime summer = NetRecurrence::nextOccurrence(
+            "FREQ=WEEKLY;BYDAY=TU", "20:00", "America/Chicago", QDate(), utc(2026, 7, 1, 12, 0));
+        const QDateTime summerLocal = summer.toTimeZone(QTimeZone("America/Chicago"));
+        ok &= expect(summerLocal.time() == QTime(20, 0),
+                     "summer net is still 20:00 local (CDT)");
+        ok &= expect(summer.toUTC() == utc(2026, 7, 8, 1, 0),
+                     "20:00 CDT equals 01:00 UTC — DST offset applied");
+    }
+
+    // --- describeRule ---------------------------------------------------
+    {
+        ok &= expect(NetRecurrence::describeRule("FREQ=WEEKLY;BYDAY=TU") == "Weekly on Tuesday",
+                     "weekly description");
+        ok &= expect(NetRecurrence::describeRule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE")
+                         == "Every 2 weeks on Monday, Wednesday",
+                     "biweekly multi-day description");
+        ok &= expect(NetRecurrence::describeRule("FREQ=MONTHLY;BYDAY=1SU")
+                         == "Monthly on the first Sunday",
+                     "monthly description");
+        ok &= expect(NetRecurrence::describeRule("FREQ=DAILY") == "Daily", "daily description");
+    }
+
+    return ok ? 0 : 1;
+}

--- a/tests/net_recurrence_test.cpp
+++ b/tests/net_recurrence_test.cpp
@@ -144,6 +144,31 @@ int main()
                      "20:00 CDT equals 01:00 UTC — DST offset applied");
     }
 
+    // --- one-time ("Once" / Repeat = Never) -----------------------------
+    {
+        // Empty rule = single event at startDate + timeOfDay.
+        const QDateTime occ = NetRecurrence::nextOccurrence(
+            "", "20:00", "Etc/UTC", QDate(2026, 6, 20), utc(2026, 6, 19, 0, 0));
+        ok &= expect(occ.toUTC() == utc(2026, 6, 20, 20, 0),
+                     "one-time net fires at its start date/time");
+
+        // Already past → no occurrence.
+        const QDateTime gone = NetRecurrence::nextOccurrence(
+            "", "20:00", "Etc/UTC", QDate(2026, 6, 20), utc(2026, 6, 21, 0, 0));
+        ok &= expect(!gone.isValid(), "one-time net does not recur once past");
+
+        // Same-day-later still fires (the same-day testing case).
+        const QDateTime sameDay = NetRecurrence::nextOccurrence(
+            "", "20:00", "Etc/UTC", QDate(2026, 6, 19), utc(2026, 6, 19, 10, 0));
+        ok &= expect(sameDay.toUTC() == utc(2026, 6, 19, 20, 0),
+                     "one-time net later the same day still fires");
+
+        // No date → nothing.
+        ok &= expect(!NetRecurrence::nextOccurrence("", "20:00", "Etc/UTC", QDate(),
+                                                    utc(2026, 6, 19, 0, 0)).isValid(),
+                     "one-time net with no date yields nothing");
+    }
+
     // --- describeRule ---------------------------------------------------
     {
         ok &= expect(NetRecurrence::describeRule("FREQ=WEEKLY;BYDAY=TU") == "Weekly on Tuesday",
@@ -155,6 +180,7 @@ int main()
                          == "Monthly on the first Sunday",
                      "monthly description");
         ok &= expect(NetRecurrence::describeRule("FREQ=DAILY") == "Daily", "daily description");
+        ok &= expect(NetRecurrence::describeRule("") == "Once", "empty rule describes as Once");
     }
 
     return ok ? 0 : 1;

--- a/tests/net_schedule_planner_test.cpp
+++ b/tests/net_schedule_planner_test.cpp
@@ -1,0 +1,107 @@
+#include "core/NetSchedulePlanner.h"
+
+#include "models/NetEntry.h"
+
+#include <QDate>
+#include <QDateTime>
+#include <QList>
+#include <QTime>
+#include <QTimeZone>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+QDateTime utc(int y, int mo, int d, int h, int mi)
+{
+    return QDateTime(QDate(y, mo, d), QTime(h, mi), QTimeZone("UTC"));
+}
+
+NetEntry weeklyNet(const QString& id, int qtDow, const QString& time, int lead)
+{
+    static const char* codes[] = {"MO", "TU", "WE", "TH", "FR", "SA", "SU"};
+    NetEntry e;
+    e.id = id;
+    e.name = id;
+    e.rrule = QString("FREQ=WEEKLY;BYDAY=%1").arg(codes[qtDow - 1]);
+    e.timeOfDay = time;
+    e.timezone = "Etc/UTC";
+    e.reminderLeadMinutes = lead;
+    return e;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // Reference: Mon 2026-06-01 00:00 UTC.
+    const QDateTime now = utc(2026, 6, 1, 0, 0);
+
+    // --- picks the soonest reminder across entries ----------------------
+    {
+        // Tuesday net 20:00 (lead 10) → reminder Tue Jun 2 19:50Z.
+        // Wednesday net 12:00 (lead 5) → reminder Wed Jun 3 11:55Z.
+        // Tuesday's reminder is sooner.
+        QList<NetEntry> nets = {weeklyNet("tue", 2, "20:00", 10),
+                                weeklyNet("wed", 3, "12:00", 5)};
+        const PendingReminder p = nextReminderAcross(nets, now);
+        ok &= expect(p.isValid() && p.entryIndex == 0, "soonest reminder is the Tuesday net");
+        ok &= expect(p.occurrenceUtc == utc(2026, 6, 2, 20, 0), "occurrence instant correct");
+        ok &= expect(p.reminderUtc == utc(2026, 6, 2, 19, 50), "reminder = occurrence - lead");
+    }
+
+    // --- a long lead-time can reorder which fires first -----------------
+    {
+        // Wednesday net 12:00 with a huge 1500-min (25h) lead → reminder
+        // Tue Jun 2 11:00Z, which beats the Tuesday net's 19:50Z reminder.
+        QList<NetEntry> nets = {weeklyNet("tue", 2, "20:00", 10),
+                                weeklyNet("wed", 3, "12:00", 1500)};
+        const PendingReminder p = nextReminderAcross(nets, now);
+        ok &= expect(p.isValid() && p.entryIndex == 1,
+                     "the longer lead-time fires first despite a later occurrence");
+        ok &= expect(p.reminderUtc == utc(2026, 6, 2, 11, 0), "long-lead reminder instant correct");
+    }
+
+    // --- disabled entries are skipped ----------------------------------
+    {
+        QList<NetEntry> nets = {weeklyNet("tue", 2, "20:00", 10),
+                                weeklyNet("wed", 3, "12:00", 5)};
+        nets[0].enabled = false;
+        const PendingReminder p = nextReminderAcross(nets, now);
+        ok &= expect(p.isValid() && p.entryIndex == 1, "disabled net is skipped");
+    }
+
+    // --- advances past an occurrence whose reminder already elapsed -----
+    {
+        // Net at 20:00 with lead 10 → reminder 19:50. If "now" is 19:55 (after
+        // the reminder but before the net), the next *reminder* is next week.
+        QList<NetEntry> nets = {weeklyNet("tue", 2, "20:00", 10)};
+        const PendingReminder p = nextReminderAcross(nets, utc(2026, 6, 2, 19, 55));
+        ok &= expect(p.isValid() && p.reminderUtc == utc(2026, 6, 9, 19, 50),
+                     "past-reminder occurrence is skipped to next week");
+    }
+
+    // --- nothing pending ------------------------------------------------
+    {
+        QList<NetEntry> empty;
+        ok &= expect(!nextReminderAcross(empty, now).isValid(), "empty list yields no reminder");
+
+        QList<NetEntry> invalid = {weeklyNet("x", 2, "20:00", 10)};
+        invalid[0].rrule = "FREQ=YEARLY";
+        ok &= expect(!nextReminderAcross(invalid, now).isValid(),
+                     "invalid rule yields no reminder");
+    }
+
+    return ok ? 0 : 1;
+}

--- a/tests/net_schedule_store_test.cpp
+++ b/tests/net_schedule_store_test.cpp
@@ -1,0 +1,145 @@
+#include "core/NetScheduleStore.h"
+
+#include <QByteArray>
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* message)
+{
+    if (!condition)
+        std::cerr << "FAIL: " << message << '\n';
+    return condition;
+}
+
+NetEntry sampleNet()
+{
+    NetEntry e;
+    e.id = "fixed-id-1";
+    e.name = "Tuesday County ARES Net";
+    e.enabled = true;
+    e.rrule = "FREQ=WEEKLY;BYDAY=TU";
+    e.startDate = "2026-06-02";
+    e.timeOfDay = "20:00";
+    e.timezone = "America/Chicago";
+    e.reminderLeadMinutes = 10;
+    e.durationMinutes = 45;
+    e.notes = "NCS W1ABC";
+    e.preset.freq = 146.94;
+    e.preset.mode = "FM";
+    e.preset.step = 5000;
+    e.preset.rxFilterLow = -8000;
+    e.preset.rxFilterHigh = 8000;
+    e.preset.offsetDir = "down";
+    e.preset.repeaterOffset = 0.6;
+    e.preset.toneMode = "ctcss_tx";
+    e.preset.toneValue = 103.5;
+    e.preset.squelch = true;
+    e.preset.squelchLevel = 20;
+    return e;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // --- round-trip -----------------------------------------------------
+    {
+        const QList<NetEntry> nets = {sampleNet()};
+        const QByteArray json = NetScheduleStore::serialize(nets, "2026-06-19T14:00:00Z");
+        const auto result = NetScheduleStore::parse(json);
+        ok &= expect(result.ok(), "round-trip parses without errors");
+        ok &= expect(result.version == NetScheduleStore::kFormatVersion, "version preserved");
+        ok &= expect(result.nets.size() == 1, "one net round-tripped");
+
+        const NetEntry& g = result.nets.first();
+        const NetEntry s = sampleNet();
+        ok &= expect(g.id == s.id && g.name == s.name && g.enabled == s.enabled,
+                     "scalar fields preserved");
+        ok &= expect(g.rrule == s.rrule && g.startDate == s.startDate
+                         && g.timeOfDay == s.timeOfDay && g.timezone == s.timezone,
+                     "recurrence fields preserved");
+        ok &= expect(g.reminderLeadMinutes == s.reminderLeadMinutes
+                         && g.durationMinutes == s.durationMinutes && g.notes == s.notes,
+                     "reminder/notes preserved");
+        ok &= expect(g.preset.freq == s.preset.freq && g.preset.mode == s.preset.mode
+                         && g.preset.step == s.preset.step,
+                     "preset freq/mode/step preserved");
+        ok &= expect(g.preset.rxFilterLow == s.preset.rxFilterLow
+                         && g.preset.rxFilterHigh == s.preset.rxFilterHigh,
+                     "preset filter preserved");
+        ok &= expect(g.preset.offsetDir == s.preset.offsetDir
+                         && g.preset.repeaterOffset == s.preset.repeaterOffset
+                         && g.preset.toneMode == s.preset.toneMode
+                         && g.preset.toneValue == s.preset.toneValue,
+                     "preset repeater/tone preserved");
+        ok &= expect(g.preset.squelch == s.preset.squelch
+                         && g.preset.squelchLevel == s.preset.squelchLevel,
+                     "preset squelch preserved");
+    }
+
+    // --- tolerant parsing ----------------------------------------------
+    {
+        // Unknown future field ignored; missing optionals take defaults; missing
+        // id gets assigned.
+        const QByteArray json = R"({
+            "format": "aether.netschedule",
+            "version": 1,
+            "nets": [
+                { "name": "Minimal Net", "rrule": "FREQ=DAILY", "futureField": 42 }
+            ]
+        })";
+        const auto result = NetScheduleStore::parse(json);
+        ok &= expect(result.ok(), "tolerant parse of minimal entry");
+        ok &= expect(result.nets.size() == 1, "minimal entry parsed");
+        ok &= expect(!result.nets.first().id.isEmpty(), "missing id assigned");
+        ok &= expect(result.nets.first().timeOfDay == "20:00", "missing timeOfDay defaulted");
+        ok &= expect(result.nets.first().enabled, "missing enabled defaults true");
+    }
+
+    // --- error handling -------------------------------------------------
+    {
+        const auto bad = NetScheduleStore::parse("{ not json ");
+        ok &= expect(!bad.ok(), "malformed JSON reports an error");
+
+        const QByteArray future = R"({"format":"aether.netschedule","version":999,"nets":[]})";
+        const auto fr = NetScheduleStore::parse(future);
+        ok &= expect(!fr.ok(), "newer-than-supported version reports an error");
+    }
+
+    // --- merge policies -------------------------------------------------
+    {
+        QList<NetEntry> existing = {sampleNet()};   // id = fixed-id-1
+        NetEntry incoming = sampleNet();            // same id
+        incoming.name = "Renamed Net";
+
+        const auto skipped = NetScheduleStore::merge(existing, {incoming},
+                                                     NetScheduleStore::MergePolicy::Skip);
+        ok &= expect(skipped.size() == 1 && skipped.first().name == "Tuesday County ARES Net",
+                     "Skip keeps the existing entry");
+
+        const auto overwritten = NetScheduleStore::merge(existing, {incoming},
+                                                         NetScheduleStore::MergePolicy::Overwrite);
+        ok &= expect(overwritten.size() == 1 && overwritten.first().name == "Renamed Net",
+                     "Overwrite replaces the existing entry");
+
+        const auto duplicated = NetScheduleStore::merge(existing, {incoming},
+                                                        NetScheduleStore::MergePolicy::Duplicate);
+        ok &= expect(duplicated.size() == 2, "Duplicate adds a second entry");
+        ok &= expect(duplicated.at(0).id != duplicated.at(1).id,
+                     "Duplicate assigns a fresh id");
+
+        NetEntry brandNew = sampleNet();
+        brandNew.id = "different-id";
+        const auto added = NetScheduleStore::merge(existing, {brandNew},
+                                                   NetScheduleStore::MergePolicy::Skip);
+        ok &= expect(added.size() == 2, "new id is inserted regardless of policy");
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION

<img width="912" height="534" alt="Screenshot 2026-06-20 at 6 59 15 AM" src="https://github.com/user-attachments/assets/c45ba43a-7a4b-4219-ba13-1e28c7588324" />
<img width="604" height="535" alt="Screenshot 2026-06-20 at 7 00 02 AM" src="https://github.com/user-attachments/assets/50832a9e-975a-4218-943a-be6a9c86c124" />

## Net Reminder Scheduler

Adds a personal **Net Reminder Scheduler**: operators add their favorite recurring nets (recurring on-air gatherings on a fixed frequency/band/mode at a regular time), get a desktop + in-app reminder before each one starts, and click **Tune Now** to jump straight to it — with the saved mode and filter. Think of it as a memory channel plus a recurrence rule and a custom name.

### Design

A net is conceptually *a memory channel + a recurrence + a reminder*. It **reuses** the `MemoryEntry` tuning shape and the existing `MemoryRecallPolicy` command builders, but — unlike radio memories, which are radio-authoritative and live in the radio's slots — a net is **operator-scoped client state** (Constitution Principle XIII): it persists locally as versioned JSON, works with no radio connected, and never consumes a radio memory slot.

Recurrence is stored as an **RFC 5545 RRULE string + IANA timezone + local time-of-day**, never a precomputed instant, so "20:00 local" stays correct across DST. The firing instant is computed lazily via `QTimeZone`.

### What's included

**Headless core** (pure QtCore, unit-tested):
- `NetEntry` — data model embedding a `MemoryEntry` preset
- `NetRecurrence` — RRULE subset (Daily / Weekly / Monthly-nth-weekday) **plus one-time "Once"**, DST-correct `nextOccurrence`, friendly `describeRule`
- `NetSchedulePlanner` — pure soonest-reminder-across-entries selection
- `NetScheduleStore` — versioned, tolerant JSON with UUID-keyed merge (skip / overwrite / duplicate)
- `NetScheduler` — single recompute-and-rearm timer (24h-capped; self-heals across suspend / clock change / DST)

**UI + wiring**:
- `NetSchedulerDialog` — `PersistentDialog` manager mirroring `MemoryDialog`'s table + import/export, with a friendly add/edit sheet: recurrence preset + weekday chips / monthly ordinal / one-time date, lead-time presets, **Capture current VFO**, and a live "Next: …" preview — no raw RRULE shown to the operator
- `NetReminderBanner` — in-app actionable toast; the **guaranteed** "Tune Now" path (unaffected by OS notification permissions / Do-Not-Disturb)
- `MainWindow_Nets.cpp` — loads/persists the schedule, runs the reminder timer, fires the banner + a best-effort OS tray notification, and tunes via the shared recall builders (including the cross-band `display pan set band=…` preselect)
- **Settings ▸ Net Scheduler…** menu entry

### Why a tray balloon *and* an in-app banner

`QSystemTrayIcon::showMessage()` cannot carry an action button and its click signal is unreliable on macOS. So the reliable "Tune Now" button lives in the in-app banner; the OS notification is only the attention-getter that raises the window.

### Testing

- 3 standalone unit-test targets (recurrence incl. **DST** + one-time, JSON round-trip, planner) — all green
- Full macOS app build clean
- **Verified live**: reminder fires at lead time; both the macOS toast and the in-app banner appear; **Tune Now** lands on the correct frequency/mode, including an HF→2 m cross-band switch

### Notes for review

Per `AGENTS.md`, visual/UX specifics are the maintainer's call — the editor layout, the bottom-right banner placement, and the lazily-created tray icon are functional defaults flagged for design review. No radio-authoritative state is persisted client-side.

### Follow-ups (not in this PR)

Seeding from RepeaterBook / hamnets.org directories, live "net is on now" via the NetLogger feed, `.ics` export, and banner snooze.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
