### PR TITLE
fix: pace TX waterfall rows to line_duration to match RX scroll rate

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3611,6 +3611,7 @@ void SpectrumWidget::setTransmitting(bool tx)
 {
     if (tx && !m_transmitting) {
         m_preTxAutoBlack = m_autoBlackThresh;  // save before TX
+        m_nextFallbackWaterfallRowMs = 0;      // first TX FFT row should render immediately
         beginTxDbmRangeFreeze();
     }
     if (!tx && m_transmitting) {
@@ -3992,12 +3993,19 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         // native waterfall path.
         const bool txAffectsPan = txWaterfallAffectsThisPan();
         if (txAffectsPan && m_showTxInWaterfall) {
-            const bool visibleStream = beginWaterfallStreamWrite(false);
-            auto restoreStream = qScopeGuard([&] {
-                endWaterfallStreamWrite(false, visibleStream);
-            });
-            if (!m_waterfall.isNull()) {
-                pushWaterfallRow(*spectrumBins, m_waterfall.width());
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            if (m_nextFallbackWaterfallRowMs <= 0) {
+                m_nextFallbackWaterfallRowMs = now;
+            }
+            if (now >= m_nextFallbackWaterfallRowMs) {
+                const bool visibleStream = beginWaterfallStreamWrite(false);
+                auto restoreStream = qScopeGuard([&] {
+                    endWaterfallStreamWrite(false, visibleStream);
+                });
+                if (!m_waterfall.isNull()) {
+                    pushWaterfallRow(*spectrumBins, m_waterfall.width());
+                    m_nextFallbackWaterfallRowMs = now + waterfallFallbackIntervalMs();
+                }
             }
         } else if (!txAffectsPan) {
             const qint64 now = QDateTime::currentMSecsSinceEpoch();
@@ -6348,8 +6356,8 @@ QRgb SpectrumWidget::intensityToRgb(float intensity) const
 void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
                                       double tileLowMhz, double tileHighMhz)
 {
-    // Callers own cadence: TX can push one row per FFT frame, while RX stale-
-    // native fallback is explicitly paced by pushRxWaterfallFallbackIfDue().
+    // Callers own cadence: TX and RX stale-native fallback pace FFT-derived
+    // rows from the requested waterfall interval before appending here.
     // Time-axis labelling uses m_wfMsPerRow, seeded from the requested rate and
     // corrected from appended-row timestamps, so the scale follows whichever
     // path is currently producing visible rows.


### PR DESCRIPTION
## Summary

Fixes #3641. On TX the waterfall scrolled at a different cadence than on RX because the two paths used different pacing sources. The TX branch in `updateSpectrum()` pushed one waterfall row per FFT frame (tracking the FFT FPS slider), while RX paces FFT-derived rows to `line_duration` through `m_nextFallbackWaterfallRowMs` and `waterfallFallbackIntervalMs()` (tracking the waterfall rate slider). This change gates the TX `pushWaterfallRow` call behind the same due-time mechanism RX already uses, so TX and RX scroll at the same rate-slider-driven cadence. `m_nextFallbackWaterfallRowMs` is reset on the RX to TX transition in `setTransmitting()` so the first TX row renders immediately. No fixed rows/sec cap is reintroduced; cadence still follows the live rate slider, keeping the #3019 guarantee intact.

## Constitution principle honored

Principle XIII (The Operator Outranks Every Agent): the visible scroll rate now follows the operator's rate slider on both TX and RX, instead of silently diverging based on which slider was last touched.

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Reproduction: set the FFT FPS slider and the waterfall rate slider to non-aligned values, then transmit. Before this change the TX waterfall scrolls at the FFT FPS rate while RX scrolls at the rate-slider rate; after this change both scroll at the rate-slider rate. RX to TX transition pushes the first TX row immediately (no stall from an un-seeded timer). Could not run a local build: Qt6 is not installed in this environment, so CI verifies the build.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable

AI was used for assistance.
