### PR TITLE
fix: persist Theme Editor overrides under pre-seeded applet scopes

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -705,15 +705,21 @@ void ThemeManager::readScopeFromJson(const QJsonObject& obj, ThemeScope* into)
         const QJsonObject children = obj.value("scopes").toObject();
         for (auto it = children.constBegin(); it != children.constEnd(); ++it) {
             const QString name = it.key();
-            auto child = std::make_unique<ThemeScope>();
-            child->name = name;
-            child->path = into->path.isEmpty()
-                              ? name
-                              : into->path + QLatin1Char('/') + name;
-            child->parent = into;
-            ThemeScope* raw = child.get();
-            into->children.emplace(name, std::move(child));
-            readScopeFromJson(it.value().toObject(), raw);
+            ThemeScope* childScope = nullptr;
+            auto existing = into->children.find(name);
+            if (existing != into->children.end()) {
+                childScope = existing->second.get();
+            } else {
+                auto child = std::make_unique<ThemeScope>();
+                child->name = name;
+                child->path = into->path.isEmpty()
+                                  ? name
+                                  : into->path + QLatin1Char('/') + name;
+                child->parent = into;
+                childScope = child.get();
+                into->children.emplace(name, std::move(child));
+            }
+            readScopeFromJson(it.value().toObject(), childScope);
         }
     }
 }

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -604,6 +604,72 @@ int main(int argc, char** argv)
         EXPECT_TRUE(tm.isOverriddenAt("deep/middle/leaf", "color.accent"));
     }
 
+    // ── Scope tree: theme JSON merges into pre-seeded applet scopes ──
+    // seedBuiltinDefaults() creates applet/{tx,rx,comp} before every
+    // load.  Saved user overrides under those paths must merge into the
+    // existing nodes rather than being read into discarded duplicates.
+    {
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        const QString themeName = QString("Scope Merge Probe");
+        EXPECT_TRUE(tm.saveCurrentThemeAs(themeName));
+        EXPECT_EQ(tm.activeTheme(), themeName);
+
+        const int rxFreqSize = 41;
+        const int vfoFreqSize = 37;
+        const QColor compColor("#123abc");
+        tm.setSizing("applet/rx", "font.size.freq", rxFreqSize);
+        tm.setSizing("spectrum/vfo", "font.size.freq", vfoFreqSize);
+        tm.setColor("applet/comp", "color.slider.foreground", compColor);
+
+        EXPECT_EQ(tm.sizingAt("applet/rx", "font.size.freq"), rxFreqSize);
+        EXPECT_EQ(tm.sizingAt("spectrum/vfo", "font.size.freq"), vfoFreqSize);
+        EXPECT_EQ(tm.colorAt("applet/comp", "color.slider.foreground").name().toLower(),
+                  compColor.name().toLower());
+
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.setActiveTheme(themeName));
+
+        EXPECT_EQ(tm.sizingAt("applet/rx", "font.size.freq"), rxFreqSize);
+        EXPECT_EQ(tm.sizingAt("spectrum/vfo", "font.size.freq"), vfoFreqSize);
+        EXPECT_EQ(tm.colorAt("applet/comp", "color.slider.foreground").name().toLower(),
+                  compColor.name().toLower());
+    }
+
+    // ── Scope tree: themes with no applet overrides keep seeded defaults ──
+    // A sparse user theme that does not mention applet/* should still
+    // inherit the built-in per-applet differentiation after load.
+    {
+        const QString sparseDir = tmp.path() + "/_sparse_theme_src";
+        QDir().mkpath(sparseDir);
+        const QString sparsePath = sparseDir + "/sparse-theme.json";
+        QFile sf(sparsePath);
+        EXPECT_TRUE(sf.open(QIODevice::WriteOnly));
+        sf.write(R"({
+            "schemaVersion": 2,
+            "name": "Sparse Scope Probe",
+            "scopes": {
+                "root": {
+                    "tokens": {
+                        "color.accent": "#102030"
+                    }
+                }
+            }
+        })");
+        sf.close();
+
+        QString sparseErr;
+        const QString importedSparse = tm.importThemeFromFile(
+            sparsePath, &sparseErr);
+        EXPECT_EQ(importedSparse, QString("Sparse Scope Probe"));
+        EXPECT_TRUE(sparseErr.isEmpty());
+        EXPECT_EQ(tm.color("color.accent").name().toLower(),
+                  QString("#102030"));
+        EXPECT_EQ(tm.colorAt("applet/rx", "color.slider.foreground").name().toLower(),
+                  QString("#4dd87a"));
+        EXPECT_EQ(tm.colorAt("applet/comp", "color.slider.foreground").name().toLower(),
+                  QString("#ffb84d"));
+    }
+
     // ── Compound font tokens: setFontToken round-trip ──
     // setFontToken stores a ThemeFont; fontTokenAt reads it back via the
     // same scope-walk used by every other accessor.  Pins the per-field


### PR DESCRIPTION
## Summary

Fixes #3653. Theme Editor overrides applied under a pre-seeded applet scope (font size on the applet/RX frequency display, and any other `applet/tx`, `applet/rx`, `applet/comp` token) were dropped on restart, while the same edit on the floating VFO flag persisted. `ThemeManager::readScopeFromJson` used `std::map::emplace` for child scopes, which is a no-op when the key already exists. Because `seedBuiltinDefaults()` pre-creates the top-level `applet` scope during load, the saved `applet/*` subtree was read into an orphaned node that was never linked into the scope tree, so every per-applet override was silently discarded. `spectrum` is not pre-seeded, which is why the flag's `spectrum/vfo` override loaded fine and the applet ones did not.

The fix looks up the child scope by name first: if it already exists, recurse into the existing node; otherwise create, link, and recurse as before. This merges saved overrides into the pre-seeded tree instead of writing them into a discarded duplicate. The change is localized to one function. No save-path, schema, or seeding changes are needed, and it restores persistence for every Theme-Editor override under the pre-seeded `applet/*` scopes, not just fonts.

## Constitution principle honored

Principle V — Each Feature Owns Its Configuration As A Single Object. The theme's saved config object now round-trips intact through reload; per-applet overrides survive the save/load cycle instead of being silently lost.

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Added four scenarios to `tests/theme_manager_test.cpp`: a save/reload round-trip of an `applet/rx` `font.size.freq` override (regression lock for this bug), the same for `spectrum/vfo` to confirm the working path does not regress, an `applet/comp` color override to prove the fix is general, and a sparse theme with no `applet/*` overrides to confirm seeded defaults remain intact. `theme_manager_test` builds and passes (1/1) in the project CI image `ghcr.io/ten9876/aethersdr-ci:latest`.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable

AI was used for assistance.
