### PR TITLE
feat(support): deflate-compress support bundles (#3218)

### DIFF
--- a/src/core/SupportBundle.cpp
+++ b/src/core/SupportBundle.cpp
@@ -43,7 +43,8 @@ bool writeSupportBundleZip(const QString& sourceDir, const QString& archivePath)
     if (entries.isEmpty())
         return false;
 
-    const QByteArray zip = writeStoredZip(entries);
+    // Deflate: support bundles are log-dominated and compress ~5-10x (#3218).
+    const QByteArray zip = writeDeflatedZip(entries);
     if (zip.isEmpty())
         return false;
 

--- a/src/core/ZipArchive.cpp
+++ b/src/core/ZipArchive.cpp
@@ -174,7 +174,35 @@ QMap<QString, QByteArray> readZipEntries(const QByteArray& zip, QString* error)
     return entries;
 }
 
-QByteArray writeStoredZip(const QList<ZipEntryData>& entries)
+namespace {
+
+// Raw DEFLATE (no zlib header), matching the readZipEntries inflate path
+// (inflateInit2(-MAX_WBITS)) so the writer and reader agree on the framing.
+bool rawDeflate(const QByteArray& in, QByteArray& out)
+{
+    z_stream z{};
+    if (deflateInit2(&z, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8,
+                     Z_DEFAULT_STRATEGY) != Z_OK) {
+        return false;
+    }
+    out.resize(static_cast<int>(deflateBound(&z, static_cast<uLong>(in.size()))));
+    z.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(in.constData()));
+    z.avail_in = static_cast<uInt>(in.size());
+    z.next_out = reinterpret_cast<Bytef*>(out.data());
+    z.avail_out = static_cast<uInt>(out.size());
+    const int rc = deflate(&z, Z_FINISH);
+    const uLong produced = z.total_out;
+    deflateEnd(&z);
+    if (rc != Z_STREAM_END)
+        return false;
+    out.resize(static_cast<int>(produced));
+    return true;
+}
+
+// Shared ZIP writer. compress=false → stored (method 0); compress=true →
+// raw-deflate (method 8). Headers carry compressed + uncompressed sizes
+// independently; the CRC is always over the uncompressed data.
+QByteArray writeZipImpl(const QList<ZipEntryData>& entries, bool compress)
 {
     if (entries.size() > std::numeric_limits<quint16>::max())
         return {};
@@ -183,41 +211,49 @@ QByteArray writeStoredZip(const QList<ZipEntryData>& entries)
     QByteArray centralDir;
     for (const ZipEntryData& entry : entries) {
         const QByteArray name = entry.name.toUtf8();
-        const QByteArray& data = entry.data;
+        const QByteArray& raw = entry.data;
+
+        QByteArray deflated;
+        if (compress && !rawDeflate(raw, deflated))
+            return {};
+        const QByteArray& payload = compress ? deflated : raw;
+        const quint16 method = compress ? quint16(8) : quint16(0);
+
         if (name.size() > std::numeric_limits<quint16>::max()
-            || data.size() > std::numeric_limits<quint32>::max()
+            || raw.size() > std::numeric_limits<quint32>::max()
+            || payload.size() > std::numeric_limits<quint32>::max()
             || out.size() > std::numeric_limits<quint32>::max()) {
             return {};
         }
 
         const quint32 localOffset = static_cast<quint32>(out.size());
-        const quint32 checksum = crc32(0L, reinterpret_cast<const Bytef*>(data.constData()),
-                                       static_cast<uInt>(data.size()));
+        const quint32 checksum = crc32(0L, reinterpret_cast<const Bytef*>(raw.constData()),
+                                       static_cast<uInt>(raw.size()));
 
         appendLe32(out, 0x04034b50);
         appendLe16(out, 20);
         appendLe16(out, 0);
-        appendLe16(out, 0);
+        appendLe16(out, method);
         appendLe16(out, 0);
         appendLe16(out, 0);
         appendLe32(out, checksum);
-        appendLe32(out, static_cast<quint32>(data.size()));
-        appendLe32(out, static_cast<quint32>(data.size()));
+        appendLe32(out, static_cast<quint32>(payload.size()));
+        appendLe32(out, static_cast<quint32>(raw.size()));
         appendLe16(out, static_cast<quint16>(name.size()));
         appendLe16(out, 0);
         out += name;
-        out += data;
+        out += payload;
 
         appendLe32(centralDir, 0x02014b50);
         appendLe16(centralDir, 20);
         appendLe16(centralDir, 20);
         appendLe16(centralDir, 0);
-        appendLe16(centralDir, 0);
+        appendLe16(centralDir, method);
         appendLe16(centralDir, 0);
         appendLe16(centralDir, 0);
         appendLe32(centralDir, checksum);
-        appendLe32(centralDir, static_cast<quint32>(data.size()));
-        appendLe32(centralDir, static_cast<quint32>(data.size()));
+        appendLe32(centralDir, static_cast<quint32>(payload.size()));
+        appendLe32(centralDir, static_cast<quint32>(raw.size()));
         appendLe16(centralDir, static_cast<quint16>(name.size()));
         appendLe16(centralDir, 0);
         appendLe16(centralDir, 0);
@@ -244,6 +280,18 @@ QByteArray writeStoredZip(const QList<ZipEntryData>& entries)
     appendLe32(out, centralDirOffset);
     appendLe16(out, 0);
     return out;
+}
+
+} // namespace
+
+QByteArray writeStoredZip(const QList<ZipEntryData>& entries)
+{
+    return writeZipImpl(entries, false);
+}
+
+QByteArray writeDeflatedZip(const QList<ZipEntryData>& entries)
+{
+    return writeZipImpl(entries, true);
 }
 
 } // namespace AetherSDR

--- a/src/core/ZipArchive.h
+++ b/src/core/ZipArchive.h
@@ -13,6 +13,10 @@ struct ZipEntryData {
 };
 
 QMap<QString, QByteArray> readZipEntries(const QByteArray& zip, QString* error);
+// Stored (uncompressed, method 0). Fine for small payloads.
 QByteArray writeStoredZip(const QList<ZipEntryData>& entries);
+// Raw-deflate (method 8) — same bundled zlib as the read path; 5–10x smaller
+// for log-heavy archives like support bundles (#3218).
+QByteArray writeDeflatedZip(const QList<ZipEntryData>& entries);
 
 } // namespace AetherSDR

--- a/tests/zip_archive_test.cpp
+++ b/tests/zip_archive_test.cpp
@@ -57,5 +57,35 @@ int main()
                  && error == QStringLiteral("ZIP entry checksum mismatch."),
                  "stored ZIP reader rejects corrupt entry data");
 
+    // --- Deflated ZIP (#3218): method 8, smaller, and round-trips via the
+    //     existing inflate path (writer/reader cross-check). ---
+    QByteArray bigLog;
+    for (int i = 0; i < 500; ++i)
+        bigLog += "2026-06-21 12:00:00 INF a repetitive, highly compressible log line\n";
+    const QList<AetherSDR::ZipEntryData> dEntries = {
+        {QStringLiteral("aethersdr.log"), bigLog},
+        {QStringLiteral("system-info.json"), QByteArray("{\"os\":\"test\"}\n")},
+        {QStringLiteral("empty.txt"), QByteArray()},
+    };
+
+    const QByteArray dzip = AetherSDR::writeDeflatedZip(dEntries);
+    ok &= expect(dzip.startsWith("PK"), "deflated ZIP has ZIP magic");
+    ok &= expect(readLe16(dzip, 8) == 8, "deflated ZIP local header uses method 8");
+    ok &= expect(dzip.size() < bigLog.size(),
+                 "deflated ZIP is smaller than the raw log it contains");
+
+    QString derror;
+    const QMap<QString, QByteArray> dRoundTrip = AetherSDR::readZipEntries(dzip, &derror);
+    ok &= expect(derror.isEmpty(), "deflated ZIP round-trip has no read error");
+    ok &= expect(dRoundTrip.size() == dEntries.size(),
+                 "deflated ZIP round-trip preserves entry count");
+    ok &= expect(dRoundTrip.value(QStringLiteral("aethersdr.log")) == bigLog,
+                 "deflated ZIP round-trip preserves the (large) log data");
+    ok &= expect(dRoundTrip.value(QStringLiteral("system-info.json")) == QByteArray("{\"os\":\"test\"}\n"),
+                 "deflated ZIP round-trip preserves JSON data");
+    ok &= expect(dRoundTrip.contains(QStringLiteral("empty.txt"))
+                 && dRoundTrip.value(QStringLiteral("empty.txt")).isEmpty(),
+                 "deflated ZIP round-trip preserves empty files");
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Closes #3218. Support bundles are log-dominated and compress ~5–10×, but the in-process ZIP writer from #3206 only emitted **stored** (uncompressed) entries — a user with 50 MB of logs produced a 50 MB bundle, hitting Discord/email/GitHub attachment limits much sooner.

Adds a **raw-DEFLATE** writer using the **same bundled zlib** that already powers the inflate-on-read path (negative window bits → no zlib header, which ZIP doesn't use). No new dependency, no subprocess, no new MSIX content — **all of #3206's Store-compliance wins are preserved**.

## Changes
- `ZipArchive`: `writeStoredZip` and the new `writeDeflatedZip` now share one `writeZipImpl(entries, compress)` — method field + independent compressed/uncompressed sizes; CRC is always over the **uncompressed** data.
- `SupportBundle::writeSupportBundleZip` → `writeDeflatedZip`. `ProfileTransfer` stays stored (tiny payloads).
- `zip_archive_test`: new deflated round-trip asserting method-8 framing, smaller-than-raw output, and a clean round-trip **through the existing reader** (writer/reader cross-check, since `readZipEntries` already handles method 8).

## Why it's not RFC-gated
Internal storage-format change with no UX/behavior change (bundles are still ZIPs, just smaller); the file is never inside the MSIX so WACK's archive rules don't apply.

## Test plan
- [x] `zip_archive_test` passes (stored + deflated round-trips, method byte, size check)
- [x] Full app builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)