### PR TITLE
build(setup): pin + verify SHA256 for all third_party downloads (#3665)

### DIFF
--- a/scripts/setup/_verify_sha256.ps1
+++ b/scripts/setup/_verify_sha256.ps1
@@ -1,0 +1,21 @@
+# Shared SHA256 verifier for setup-script downloads — supply-chain hardening (#3665).
+# Dot-source this, then: Confirm-Sha256 -Path <file> -Expected <hex>
+# Aborts the script (exit 1) on mismatch, so a tampered/MITM'd download never
+# reaches the extract/build step.
+
+function Confirm-Sha256 {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Expected
+    )
+    if (-not (Test-Path $Path)) {
+        Write-Error "Confirm-Sha256: file not found: $Path"
+        exit 1
+    }
+    $actual = (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $Expected.ToLower()) {
+        Write-Error "SHA256 mismatch for $Path`n  expected: $Expected`n  actual:   $actual"
+        exit 1
+    }
+    Write-Host "Verified SHA256 of $(Split-Path $Path -Leaf)" -ForegroundColor Green
+}

--- a/scripts/setup/_verify_sha256.sh
+++ b/scripts/setup/_verify_sha256.sh
@@ -1,0 +1,29 @@
+# Shared SHA256 verifier for setup-script downloads — supply-chain hardening (#3665).
+# Source this, then: verify_sha256 <file> <expected-hex>
+# Fails hard (returns non-zero) on mismatch or if no hasher is available, so a
+# tampered/MITM'd download never reaches the extract/build step.
+#
+# Not meant to be executed directly — it only defines a function.
+
+verify_sha256() {
+    local file="$1" expected="$2" actual=""
+    if [ ! -f "$file" ]; then
+        echo "ERROR: verify_sha256: file not found: $file" >&2
+        return 1
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$file" | cut -d' ' -f1)"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+    else
+        echo "ERROR: verify_sha256: neither sha256sum nor shasum found" >&2
+        return 1
+    fi
+    if [ "$actual" != "$expected" ]; then
+        echo "ERROR: SHA256 mismatch for $file" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        return 1
+    fi
+    echo "Verified SHA256 of $(basename "$file")"
+}

--- a/scripts/setup/setup-deepfilter.ps1
+++ b/scripts/setup/setup-deepfilter.ps1
@@ -14,6 +14,7 @@
 #>
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\_verify_sha256.ps1"
 
 $DfnrCommit = "d375b2d8309e0935d165700c91da9de862a99c31"
 $DfnrRepo   = "https://github.com/Rikorose/DeepFilterNet.git"
@@ -33,12 +34,15 @@ $ReleaseRepo = if ($env:DFNR_RELEASE_REPO) { $env:DFNR_RELEASE_REPO } else { "te
 $ReleaseTag  = "dfnr-libs"
 $Platform    = "windows-x86_64"
 $Tarball     = "libdeepfilter-$Platform.tar.gz"
+# SHA256 of the prebuilt $Platform tarball (#3665). Bump when dfnr-libs is rebuilt.
+$TarballSha256 = "61541e9bb215c163d19baf91d63c24bc013850b3a502fcf7d2956595e012195a"
 $DownloadUrl = "https://github.com/$ReleaseRepo/releases/download/$ReleaseTag/$Tarball"
 
 Write-Host "Trying pre-built binary from $DownloadUrl ..." -ForegroundColor Cyan
 try {
     $TarPath = Join-Path $env:TEMP $Tarball
     Invoke-WebRequest -Uri $DownloadUrl -OutFile $TarPath -UseBasicParsing -ErrorAction Stop
+    Confirm-Sha256 -Path $TarPath -Expected $TarballSha256
     if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Force -Path $OutDir | Out-Null }
     tar xzf $TarPath -C $OutDir
     Remove-Item $TarPath -ErrorAction SilentlyContinue

--- a/scripts/setup/setup-deepfilter.sh
+++ b/scripts/setup/setup-deepfilter.sh
@@ -20,14 +20,18 @@ OUT_DIR="third_party/deepfilter"
 MODEL_NAME="DeepFilterNet3_onnx.tar.gz"
 
 # SHA256 of each prebuilt libdeepfilter-<platform>.tar.gz on the dfnr-libs
-# release (#3665). Bump when those assets are rebuilt. (The source-build
-# fallback below is already pinned to DFNR_COMMIT.)
-declare -A DFNR_TARBALL_SHA256=(
-    [linux-x86_64]="92a9a21841947074484429cacc838e413a089b0422666b7ba93672a0c38d8cd8"
-    [linux-aarch64]="fa24a6535e58d63f568f719e3266d728059d9ab4dc884eccca6d9a212e68ef75"
-    [darwin-arm64]="51dc53116c130ee42a3225130b2ab47936b4e076ef8e684a81daaadf5b6b4690"
-    [darwin-x86_64]="46a0921f0df2a03d9dbe65c673573ccffb7588fad4669f22868652e50b9c6b3e"
-)
+# release (#3665), keyed by PLATFORM. A case (not an associative array) keeps
+# this working on macOS's stock bash 3.2. Bump when those assets are rebuilt.
+# (The source-build fallback below is already pinned to DFNR_COMMIT.)
+dfnr_tarball_sha256() {
+    case "$1" in
+        linux-x86_64)  echo "92a9a21841947074484429cacc838e413a089b0422666b7ba93672a0c38d8cd8" ;;
+        linux-aarch64) echo "fa24a6535e58d63f568f719e3266d728059d9ab4dc884eccca6d9a212e68ef75" ;;
+        darwin-arm64)  echo "51dc53116c130ee42a3225130b2ab47936b4e076ef8e684a81daaadf5b6b4690" ;;
+        darwin-x86_64) echo "46a0921f0df2a03d9dbe65c673573ccffb7588fad4669f22868652e50b9c6b3e" ;;
+        *)             echo "" ;;
+    esac
+}
 
 # ── Detect platform ──────────────────────────────────────────────────────
 OS=$(uname -s)
@@ -76,7 +80,7 @@ echo "Trying pre-built binary from $DOWNLOAD_URL ..."
 if curl -fsSL --retry 2 --connect-timeout 10 -o "/tmp/$TARBALL" "$DOWNLOAD_URL" 2>/dev/null; then
     # A successful download with a bad hash means tampering, not a transient
     # failure — hard-fail rather than silently falling back to a source build.
-    verify_sha256 "/tmp/$TARBALL" "${DFNR_TARBALL_SHA256[$PLATFORM]:-}" || exit 1
+    verify_sha256 "/tmp/$TARBALL" "$(dfnr_tarball_sha256 "$PLATFORM")" || exit 1
     mkdir -p "$OUT_DIR"
     tar xzf "/tmp/$TARBALL" -C "$OUT_DIR"
     rm -f "/tmp/$TARBALL"

--- a/scripts/setup/setup-deepfilter.sh
+++ b/scripts/setup/setup-deepfilter.sh
@@ -11,10 +11,23 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/setup/_verify_sha256.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_verify_sha256.sh"
+
 DFNR_COMMIT="d375b2d8309e0935d165700c91da9de862a99c31"
 DFNR_REPO="https://github.com/Rikorose/DeepFilterNet.git"
 OUT_DIR="third_party/deepfilter"
 MODEL_NAME="DeepFilterNet3_onnx.tar.gz"
+
+# SHA256 of each prebuilt libdeepfilter-<platform>.tar.gz on the dfnr-libs
+# release (#3665). Bump when those assets are rebuilt. (The source-build
+# fallback below is already pinned to DFNR_COMMIT.)
+declare -A DFNR_TARBALL_SHA256=(
+    [linux-x86_64]="92a9a21841947074484429cacc838e413a089b0422666b7ba93672a0c38d8cd8"
+    [linux-aarch64]="fa24a6535e58d63f568f719e3266d728059d9ab4dc884eccca6d9a212e68ef75"
+    [darwin-arm64]="51dc53116c130ee42a3225130b2ab47936b4e076ef8e684a81daaadf5b6b4690"
+    [darwin-x86_64]="46a0921f0df2a03d9dbe65c673573ccffb7588fad4669f22868652e50b9c6b3e"
+)
 
 # ── Detect platform ──────────────────────────────────────────────────────
 OS=$(uname -s)
@@ -61,6 +74,9 @@ DOWNLOAD_URL="https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG
 
 echo "Trying pre-built binary from $DOWNLOAD_URL ..."
 if curl -fsSL --retry 2 --connect-timeout 10 -o "/tmp/$TARBALL" "$DOWNLOAD_URL" 2>/dev/null; then
+    # A successful download with a bad hash means tampering, not a transient
+    # failure — hard-fail rather than silently falling back to a source build.
+    verify_sha256 "/tmp/$TARBALL" "${DFNR_TARBALL_SHA256[$PLATFORM]:-}" || exit 1
     mkdir -p "$OUT_DIR"
     tar xzf "/tmp/$TARBALL" -C "$OUT_DIR"
     rm -f "/tmp/$TARBALL"

--- a/scripts/setup/setup-fftw.ps1
+++ b/scripts/setup/setup-fftw.ps1
@@ -17,8 +17,11 @@
 #>
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\_verify_sha256.ps1"
 
 $FftwUrl   = "https://fftw.org/pub/fftw/fftw-3.3.5-dll64.zip"
+# SHA256 of the FFTW Windows DLL zip (#3665). Bump if the URL/version changes.
+$FftwSha256 = "cfd88dc0e8d7001115ea79e069a2c695d52c8947f5b4f3b7ac54a192756f439f"
 $OutDir    = "third_party\fftw3"
 $ZipFile   = "third_party\fftw3-dll64.zip"
 # Locate vcvars64.bat in a version/edition-agnostic way. vswhere lives at a
@@ -63,6 +66,7 @@ New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
 if (-not (Test-Path $ZipFile)) {
     Write-Host "Downloading FFTW3 prebuilt DLLs..." -ForegroundColor Cyan
     Invoke-WebRequest -Uri $FftwUrl -OutFile $ZipFile
+    Confirm-Sha256 -Path $ZipFile -Expected $FftwSha256
 }
 
 # ── Extract ──────────────────────────────────────────────────────────────

--- a/scripts/setup/setup-hidapi.ps1
+++ b/scripts/setup/setup-hidapi.ps1
@@ -14,9 +14,12 @@
 #>
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\_verify_sha256.ps1"
 
 $HidapiVersion = "0.14.0"
 $HidapiUrl     = "https://github.com/libusb/hidapi/archive/refs/tags/hidapi-${HidapiVersion}.tar.gz"
+# SHA256 of the GitHub source archive (#3665). Bump alongside the version.
+$HidapiSha256  = "a5714234abe6e1f53647dd8cba7d69f65f71c558b7896ed218864ffcf405bcbd"
 $OutDir        = "third_party\hidapi"
 $TarFile       = "third_party\hidapi-${HidapiVersion}.tar.gz"
 
@@ -37,6 +40,7 @@ New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
 if (-not (Test-Path $TarFile)) {
     Write-Host "Downloading hidapi ${HidapiVersion} source..." -ForegroundColor Cyan
     Invoke-WebRequest -Uri $HidapiUrl -OutFile $TarFile
+    Confirm-Sha256 -Path $TarFile -Expected $HidapiSha256
 }
 
 # ── Extract ──────────────────────────────────────────────────────────────

--- a/scripts/setup/setup-onnxruntime.ps1
+++ b/scripts/setup/setup-onnxruntime.ps1
@@ -15,9 +15,12 @@
 #>
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\_verify_sha256.ps1"
 
 $OrtVersion = "1.18.1"
 $OrtUrl     = "https://github.com/microsoft/onnxruntime/releases/download/v${OrtVersion}/onnxruntime-win-x64-${OrtVersion}.zip"
+# SHA256 of the release zip (#3665). Bump alongside the version.
+$OrtSha256  = "53fb7226fe3cf16001afd1eae79e35f891a20e80bd686185d62ea878e6f9b1a6"
 $OutDir     = "third_party\onnxruntime"
 $ZipFile    = "third_party\onnxruntime-win-x64-${OrtVersion}.zip"
 
@@ -38,6 +41,7 @@ New-Item -ItemType Directory -Force -Path "$OutDir\bin" | Out-Null
 if (-not (Test-Path $ZipFile)) {
     Write-Host "Downloading ONNX Runtime ${OrtVersion} prebuilt package..." -ForegroundColor Cyan
     Invoke-WebRequest -Uri $OrtUrl -OutFile $ZipFile
+    Confirm-Sha256 -Path $ZipFile -Expected $OrtSha256
 }
 
 # ── Extract ──────────────────────────────────────────────────────────────

--- a/scripts/setup/setup-opus.ps1
+++ b/scripts/setup/setup-opus.ps1
@@ -20,11 +20,15 @@ $ErrorActionPreference = "Stop"
 # the same tarball but has been intermittently unreachable from GitHub-
 # hosted Windows runners.  Try GitHub first, fall back to xiph, retry
 # each with backoff before failing the build.
+. "$PSScriptRoot\_verify_sha256.ps1"
 $OpusVersion = "1.5.2"
 $OpusSrcUrls = @(
     "https://github.com/xiph/opus/releases/download/v${OpusVersion}/opus-${OpusVersion}.tar.gz",
     "https://downloads.xiph.org/releases/opus/opus-${OpusVersion}.tar.gz"
 )
+# SHA256 of the release tarball (#3665) — identical on both mirrors above, so
+# one pin verifies whichever served the file. Bump alongside the version.
+$OpusSha256  = "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
 $OutDir      = "third_party\opus"
 $TarFile     = "third_party\opus-${OpusVersion}.tar.gz"
 $VsVars      = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
@@ -69,6 +73,7 @@ if (-not (Test-Path $TarFile)) {
         Write-Error "All Opus download attempts failed (tried $($OpusSrcUrls.Count) mirrors x 3 retries)"
         exit 1
     }
+    Confirm-Sha256 -Path $TarFile -Expected $OpusSha256
 }
 
 # ── Extract headers ──────────────────────────────────────────────────────

--- a/scripts/setup/setup-qtkeychain.ps1
+++ b/scripts/setup/setup-qtkeychain.ps1
@@ -16,9 +16,12 @@
 #>
 
 $ErrorActionPreference = "Stop"
+. "$PSScriptRoot\_verify_sha256.ps1"
 
 $QtKeychainVersion = "0.16.0"
 $QtKeychainUrl     = "https://github.com/frankosterfeld/qtkeychain/archive/refs/tags/${QtKeychainVersion}.tar.gz"
+# SHA256 of the GitHub source archive (#3665). Bump alongside the version.
+$QtKeychainSha256  = "3be26ec4ae30eecf0c2ff7572ba83799791b157c76e15a05ef35f23dc25e4054"
 $OutDir            = "$PSScriptRoot\..\..\third_party\qtkeychain"
 $TarFile           = "$PSScriptRoot\..\..\third_party\qtkeychain-${QtKeychainVersion}.tar.gz"
 
@@ -52,6 +55,7 @@ New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 if (-not (Test-Path $TarFile)) {
     Write-Host "Downloading qtkeychain ${QtKeychainVersion} source..." -ForegroundColor Cyan
     Invoke-WebRequest -Uri $QtKeychainUrl -OutFile $TarFile
+    Confirm-Sha256 -Path $TarFile -Expected $QtKeychainSha256
 }
 
 # ── Extract ──────────────────────────────────────────────────────────────

--- a/scripts/setup/setup-qtkeychain.sh
+++ b/scripts/setup/setup-qtkeychain.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 
 QTKEYCHAIN_VERSION="0.16.0"
 QTKEYCHAIN_REPO="https://github.com/frankosterfeld/qtkeychain.git"
+# Immutable commit the 0.16.0 tag points to (#3665). Pinning the commit, not
+# just the tag, defends against a moved/retagged release. Bump with the version.
+QTKEYCHAIN_COMMIT="aa6da344e1a20b9194e12bace3665caeea6b6304"
 OUT_DIR="third_party/qtkeychain"
 
 # ── Already set up? (lets CI cache third_party/qtkeychain) ───────────────
@@ -62,6 +65,15 @@ SRC_DIR="$(dirname "$OUT_DIR_ABS")/qtkeychain-src"
 rm -rf "$SRC_DIR" "$BUILD_DIR"
 echo "Cloning qtkeychain $QTKEYCHAIN_VERSION..."
 git clone --depth 1 --branch "$QTKEYCHAIN_VERSION" "$QTKEYCHAIN_REPO" "$SRC_DIR"
+
+# Verify the tag resolved to the pinned commit (supply-chain hardening #3665).
+ACTUAL_COMMIT="$(git -C "$SRC_DIR" rev-parse HEAD)"
+if [ "$ACTUAL_COMMIT" != "$QTKEYCHAIN_COMMIT" ]; then
+    echo "ERROR: qtkeychain $QTKEYCHAIN_VERSION resolved to $ACTUAL_COMMIT," >&2
+    echo "       expected $QTKEYCHAIN_COMMIT (tag moved or tampering)." >&2
+    exit 1
+fi
+echo "Verified qtkeychain commit $QTKEYCHAIN_COMMIT"
 
 # ── Build + install ──────────────────────────────────────────────────────
 echo "Building qtkeychain $QTKEYCHAIN_VERSION from source..."


### PR DESCRIPTION
## Summary

Closes #3665. Every `scripts/setup/*` script downloaded a build dependency and built/bundled it into release artifacts **without any integrity check** — a compromised upstream/CDN, a hijacked release asset, or a TLS-MITM could substitute a malicious artifact and nothing would catch it. This pins the expected hash next to each URL/version and **verifies after download, before extract/build, failing hard on mismatch**.

## What changed

- **Shared verifiers** (issue's optional stretch, done so the 8 scripts don't hand-roll it):
  - `_verify_sha256.sh` → `verify_sha256 <file> <hex>` (sha256sum, shasum fallback)
  - `_verify_sha256.ps1` → `Confirm-Sha256 -Path -Expected` (Get-FileHash)
- **SHA256-pinned** (every hash obtained by actually downloading the artifact): onnxruntime 1.18.1, FFTW 3.3.5 dll64, hidapi 0.14.0, opus 1.5.2 (**one hash covers both mirrors — confirmed byte-identical**), qtkeychain 0.16.0 tarball (ps1), and all `libdeepfilter` `dfnr-libs` platform tarballs (linux x86_64/aarch64, darwin arm64/x86_64, windows x86_64).
- **Git-clone cases pin the immutable commit** instead of a file hash: `setup-qtkeychain.sh` verifies the `0.16.0` tag resolves to its pinned commit (`aa6da344…`); `setup-deepfilter`'s source-build fallback was already pinned to `DFNR_COMMIT`.
- The deepfilter prebuilt download **hard-fails on hash mismatch** (tampering) rather than silently falling back to a source build; a download *failure* (network) still falls back as before.

## Verification
- `verify_sha256` **passes a correct artifact and rejects a deliberately-wrong hash** (the issue's acceptance check) — proven locally against the real linux-x86_64 deepfilter tarball.
- `bash -n` clean on all bash scripts; every download-bearing script now has an adjacent verification (no unverified download remains). PowerShell paths validate in Windows CI.

## Note
The two GitHub *auto-generated source archives* (hidapi, qtkeychain.ps1) are pinned too; if GitHub ever regenerates those archives the hash must be re-pinned — but version bumps already require re-pinning, so they move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)