### PR TITLE
feat(spectrum): GPU-composite slice flags instead of raster siblings

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -34,6 +34,7 @@
 #include <QWidgetAction>
 #include <QApplication>
 #include <QCoreApplication>
+#include <QCursor>
 #include <QGuiApplication>
 #include <QClipboard>
 #include <QDesktopServices>
@@ -590,6 +591,34 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     m_overlayMenu = new SpectrumOverlayMenu(this);
     m_overlayMenu->raise();
 
+#ifdef AETHER_GPU_SPECTRUM
+    // #3617: GPU-composite the slice flags instead of letting them composite as
+    // translucent raster QWidget siblings over the QRhiWidget (which pegs the
+    // main thread re-blending them on every ~30 Hz waterfall frame).  On by
+    // default; set AETHER_NO_GPU_FLAGS=1 to fall back to the legacy live-widget
+    // flags (A/B comparison).  The flag panels are rendered into a dedicated
+    // GPU texture (see renderGpuFrame); the small external buttons stay live
+    // widgets.  This refresh timer re-snapshots the flags so live content
+    // (S-meter, freq) keeps updating — ~12 Hz is smooth for a meter and far
+    // cheaper than the per-frame composite it replaces.
+    m_gpuFlagMode = !qEnvironmentVariableIsSet("AETHER_NO_GPU_FLAGS");
+    m_flagRefreshTimer = new QTimer(this);
+    m_flagRefreshTimer->setInterval(80);
+    connect(m_flagRefreshTimer, &QTimer::timeout, this, [this]() {
+        if (m_gpuFlagMode) {
+            // Runs outside the render callback → safe to show/hide/raise the live
+            // flag and to QWidget::render the sprites here.  (Responsive hover
+            // enter is handled synchronously in mouseMoveEvent.)
+            updateLiveFlag();
+            grabFlagSprites();   // re-rasterize flag content (~12 Hz)
+            update();
+        }
+    });
+    if (m_gpuFlagMode) {
+        m_flagRefreshTimer->start();
+    }
+#endif
+
     m_tnfHoverPopup = new QLabel(this);
     m_tnfHoverPopup->setAttribute(Qt::WA_TransparentForMouseEvents);
     m_tnfHoverPopup->setMargin(6);
@@ -1009,8 +1038,174 @@ void SpectrumWidget::removeVfoWidget(int sliceId)
         if (m_vfoWidget == w)
             m_vfoWidget = nullptr;
         delete w;
+#ifdef AETHER_GPU_SPECTRUM
+        // #3617: drop live-flag state + free the removed flag's GPU sprite.
+        if (m_liveFlagSliceId == sliceId)
+            m_liveFlagSliceId = -1;
+        auto sit = m_flagSprites.find(sliceId);
+        if (sit != m_flagSprites.end()) {
+            releaseFlagSprite(sit.value());
+            m_flagSprites.erase(sit);
+        }
+#endif
     }
 }
+
+#ifdef AETHER_GPU_SPECTRUM
+// #3617 hover-swap: choose which flag (if any) should be shown LIVE — i.e. as a
+// real interactive widget rather than a GPU snapshot — because the cursor is over
+// its panel, a child has keyboard focus (frequency editor), or one of its popup
+// menus is open.  Called every GPU frame (cheap: cursor + focus + popup polls)
+// and synchronously on mouse-move so a hovered flag goes live in time for a click.
+// (Only built with the GPU spectrum path — the legacy software path keeps the
+// flags as ordinary live widgets, so none of this is needed.)
+void SpectrumWidget::updateLiveFlag()
+{
+    if (!m_gpuFlagMode) {
+        return;
+    }
+    // Don't churn flags live/GPU mid-drag (pan/zoom/VFO/filter/dBm) — the drag
+    // owns the mouse; keep the current state until it ends.
+    if (anyDragActive()) {
+        return;
+    }
+    // While a popup (mode/filter/antenna menu) is open, keep the current live
+    // flag — switching it out from under an open menu would be wrong.
+    if (QApplication::activePopupWidget()) {
+        m_liveFlagIdleClock.invalidate();
+        return;
+    }
+
+    int want = -1;
+    // 1) A focused descendant (e.g. the frequency line-edit) keeps the flag live.
+    if (QWidget* fw = QApplication::focusWidget()) {
+        for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+            VfoWidget* f = it.value();
+            if (f && (f == fw || f->isAncestorOf(fw))) {
+                want = it.key();
+                break;
+            }
+        }
+    }
+    // 2) Otherwise the flag whose panel rect contains the cursor.
+    if (want == -1) {
+        const QPoint gp = QCursor::pos();
+        for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+            VfoWidget* f = it.value();
+            if (!f || f->size().isEmpty()) {
+                continue;
+            }
+            const QRect gr(mapToGlobal(f->pos()), f->size());
+            if (gr.contains(gp)) {
+                want = it.key();
+                break;
+            }
+        }
+    }
+
+    // aether.perf diagnostic (#3617): on each live-flag change, log the decision
+    // inputs (cursor vs each flag's global rect, focus/popup state) so a flag that
+    // fails to go live on hover can be traced on any platform/scaling.  Gated by
+    // the aether.perf logging category — silent (zero cost) unless enabled.  Only
+    // fires on a state change (hover enter/leave), not per frame.
+    if (want != m_liveFlagSliceId) {
+        QString rects;
+        for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+            if (VfoWidget* f = it.value()) {
+                const QRect gr(mapToGlobal(f->pos()), f->size());
+                rects += QString(" s%1[%2,%3 %4x%5 vis=%6]")
+                    .arg(it.key()).arg(gr.x()).arg(gr.y())
+                    .arg(gr.width()).arg(gr.height()).arg(f->isVisible() ? 1 : 0);
+            }
+        }
+        const QPoint gp = QCursor::pos();
+        qCDebug(lcPerf).nospace()
+            << "LiveFlag want=" << want << " cur=" << m_liveFlagSliceId
+            << " cursor=" << gp.x() << "," << gp.y()
+            << " popup=" << (QApplication::activePopupWidget() ? 1 : 0)
+            << " rects:" << rects;
+    }
+
+    if (want == m_liveFlagSliceId) {
+        m_liveFlagIdleClock.invalidate();   // still over it → cancel pending hide
+        return;
+    }
+    if (want != -1) {
+        setLiveFlag(want);                  // entered a flag → go live immediately
+    } else {
+        // Left every flag — debounce the hide so sweeping the cursor across the
+        // panadapter doesn't flicker flags live/GPU (and gives a click grace).
+        if (!m_liveFlagIdleClock.isValid()) {
+            m_liveFlagIdleClock.start();
+        } else if (m_liveFlagIdleClock.elapsed() >= kLiveFlagHideDelayMs) {
+            setLiveFlag(-1);
+        }
+    }
+}
+
+void SpectrumWidget::setLiveFlag(int sliceId)
+{
+    if (m_liveFlagSliceId == sliceId) {
+        return;
+    }
+    if (VfoWidget* old = m_vfoWidgets.value(m_liveFlagSliceId, nullptr)) {
+        old->setVisible(false);   // previously-live flag → back to GPU snapshot
+    }
+    m_liveFlagSliceId = sliceId;
+    m_liveFlagIdleClock.invalidate();
+    if (VfoWidget* f = m_vfoWidgets.value(sliceId, nullptr)) {
+        f->setButtonsOccluded(false);
+        f->setVisible(true);      // live, fully interactive, on top of the sprites
+        f->raise();
+        if (m_overlayMenu) {
+            m_overlayMenu->raiseAll();
+        }
+    }
+    // Refresh sprites (the just-released flag is now a sprite again — re-grab so
+    // it isn't stale/blank when it reappears).  Off-frame → safe to render.
+    grabFlagSprites();
+    update();
+}
+
+// #3617: rasterize each non-live flag into its own CPU image.  MUST run OUTSIDE
+// the QRhi render callback (QWidget::render inside an active frame re-enters the
+// renderer and crashes) — called from the refresh timer and on live-flag change.
+void SpectrumWidget::grabFlagSprites()
+{
+    if (!m_gpuFlagMode) {
+        return;
+    }
+    // Rasterize each flag at EXACTLY its on-screen device-pixel size (1:1), so
+    // the sprite texture maps one texel per screen pixel — drawn pixel-aligned
+    // with NEAREST sampling that gives crisp text (no scaling = no blur).  An
+    // earlier supersample + linear downscale just softened it ("verwaschen").
+    const qreal dpr = devicePixelRatioF();
+    for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+        const int id = it.key();
+        VfoWidget* f = it.value();
+        if (!f || f->size().isEmpty() || id == m_liveFlagSliceId) {
+            continue;   // the live flag is shown as a real widget, not grabbed
+        }
+        FlagSprite& s = m_flagSprites[id];   // inserts a blank sprite if absent
+        const QSize devSize(qMax(1, static_cast<int>(std::lround(f->width() * dpr))),
+                            qMax(1, static_cast<int>(std::lround(f->height() * dpr))));
+        if (s.img.size() != devSize) {
+            s.img = QImage(devSize, QImage::Format_RGBA8888_Premultiplied);
+            s.img.setDevicePixelRatio(dpr);
+        }
+        s.img.fill(Qt::transparent);
+        f->render(&s.img, QPoint(0, 0));   // off-frame raster — safe
+        s.imgDirty = true;
+    }
+}
+
+void SpectrumWidget::releaseFlagSprite(FlagSprite& s)
+{
+    delete s.srb;   s.srb = nullptr;   // QRhi defers in-flight native release
+    delete s.tex;   s.tex = nullptr;
+    s.texSize = QSize();
+}
+#endif // AETHER_GPU_SPECTRUM
 
 void SpectrumWidget::setActiveVfoWidget(int sliceId)
 {
@@ -5240,6 +5435,11 @@ void SpectrumWidget::edgePanVelocityStep()
 void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     PerfInputScope perfScope("mouseMove");
+#ifdef AETHER_GPU_SPECTRUM
+    // #3617 hover-swap: as the cursor enters a flag's rect, promote it to a live
+    // widget now (not just on the next render frame) so an immediate click lands.
+    updateLiveFlag();
+#endif
     if (PerfTelemetry::instance().enabled()) {
         const qint64 nowNs = PerfTelemetry::nowNs();
         if (m_lastMouseMoveNs > 0) {
@@ -6571,6 +6771,19 @@ void SpectrumWidget::initOverlayPipeline()
     });
     m_ovSrb->create();
 
+    // #3617 flag sprites: one dynamic vertex buffer holding 4 verts per flag
+    // (positions recomputed every frame).  Per-flag textures + SRBs are created
+    // lazily in renderGpuFrame.  Layout matches the overlay quad: vec2 pos + vec2 uv.
+    m_flagQuadVbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
+                                 kMaxFlagSprites * 4 * 4 * sizeof(float));
+    m_flagQuadVbo->create();
+    // NEAREST filtering for flag sprites — they are drawn 1:1 (texel == screen
+    // pixel), so nearest gives crisp text; linear would soften it.
+    m_flagSampler = r->newSampler(QRhiSampler::Nearest, QRhiSampler::Nearest,
+                                  QRhiSampler::None,
+                                  QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_flagSampler->create();
+
     QShader vs = loadShader(":/shaders/resources/shaders/overlay.vert.qsb");
     QShader fs = loadShader(":/shaders/resources/shaders/overlay.frag.qsb");
     if (!vs.isValid() || !fs.isValid()) {
@@ -6923,6 +7136,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_bgGpuTex, m_ovSampler),
             });
             m_bgSrb->create();
+            // #3617 flag sprites are flag-sized (not panadapter-sized), so a
+            // panadapter resize doesn't touch them — their quads just reposition.
             m_overlayStaticDirty = true;
         }
 
@@ -7166,6 +7381,108 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             m_overlayBgNeedsUpload = false;
         }
 
+        // Position the flags for THIS frame so a dragged flag's sprite is drawn at
+        // the current marker position (no one-frame lag).  (Live-flag selection
+        // runs OUTSIDE the render callback — from the refresh timer / mouse move —
+        // because it shows/raises widgets, which must not happen mid-render.)
+        repositionVfoFlags(specRect);
+
+        // #3617 flag sprites: prepare GPU resources and decide draw order +
+        // button occlusion.  The flags were rasterized into per-flag CPU images by
+        // grabFlagSprites() OFF-FRAME; here we only (re)create + upload their
+        // textures (a memcpy, safe inside the frame) and build the ordered draw
+        // list — NO QWidget::render here (that re-enters the renderer → crash).
+        m_flagDrawOrder.clear();
+        if (m_gpuFlagMode) {
+            // Draw order (= z-order, later = on top): active flag on top, then the
+            // live (hover) flag absolutely last.  The live flag shows as a real
+            // widget, so it's excluded from the sprite list (but still an occluder).
+            QVector<int> order;
+            for (auto it = m_vfoWidgets.cbegin(); it != m_vfoWidgets.cend(); ++it) {
+                if (it.value() && !it.value()->size().isEmpty()) {
+                    order.append(it.key());
+                }
+            }
+            auto moveLast = [&order](int id) {
+                const int i = order.indexOf(id);
+                if (i >= 0 && i < order.size() - 1) {
+                    order.move(i, order.size() - 1);
+                }
+            };
+            if (m_vfoWidget) {
+                moveLast(m_vfoWidgets.key(m_vfoWidget, -1));
+            }
+            moveLast(m_liveFlagSliceId);
+
+            // Occlusion: a flag overlapped by any flag on top (later in order,
+            // incl. the live flag) hides its floating buttons (panels occlude
+            // automatically by draw order / the live widget being on top).
+            for (int i = 0; i < order.size(); ++i) {
+                VfoWidget* fi = m_vfoWidgets.value(order[i], nullptr);
+                if (!fi) {
+                    continue;
+                }
+                const QRect ri(fi->pos(), fi->size());
+                bool occluded = false;
+                for (int j = i + 1; j < order.size(); ++j) {
+                    VfoWidget* fj = m_vfoWidgets.value(order[j], nullptr);
+                    if (fj && QRect(fj->pos(), fj->size()).intersects(ri)) {
+                        occluded = true;
+                        break;
+                    }
+                }
+                fi->setButtonsOccluded(occluded);
+            }
+
+            // Ensure each non-live flag's texture exists + is current, and record
+            // it in the draw list.
+            for (int id : order) {
+                if (id == m_liveFlagSliceId) {
+                    continue;   // shown as a live widget, not a sprite
+                }
+                auto sit = m_flagSprites.find(id);
+                if (sit == m_flagSprites.end() || sit->img.isNull()) {
+                    continue;   // not grabbed yet (next timer tick)
+                }
+                FlagSprite& s = sit.value();
+                const QSize isz = s.img.size();
+                if (!s.tex) {
+                    s.tex = rhi()->newTexture(QRhiTexture::RGBA8, isz);
+                    s.tex->create();
+                    s.srb = rhi()->newShaderResourceBindings();
+                    s.srb->setBindings({
+                        QRhiShaderResourceBinding::sampledTexture(
+                            1, QRhiShaderResourceBinding::FragmentStage, s.tex, m_flagSampler),
+                    });
+                    s.srb->create();
+                    s.texSize = isz;
+                    s.imgDirty = true;
+                } else if (s.texSize != isz) {
+                    // Resize the existing texture object — QRhi re-creates the
+                    // native resource and defers releasing the old one, mirroring
+                    // the m_ovGpuTex resize path; then rebind the SRB to it.
+                    s.tex->setPixelSize(isz);
+                    s.tex->create();
+                    s.srb->setBindings({
+                        QRhiShaderResourceBinding::sampledTexture(
+                            1, QRhiShaderResourceBinding::FragmentStage, s.tex, m_flagSampler),
+                    });
+                    s.srb->create();
+                    s.texSize = isz;
+                    s.imgDirty = true;
+                }
+                if (s.imgDirty) {
+                    QRhiTextureSubresourceUploadDescription d(s.img);
+                    batch->uploadTexture(s.tex, QRhiTextureUploadEntry(0, 0, d));
+                    s.imgDirty = false;
+                    if (perfEnabled) {
+                        PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
+                    }
+                }
+                m_flagDrawOrder.append(id);
+            }
+        }
+
         // Generate FFT spectrum vertices with baked colors
         const QVector<float>& fftBins = displaySpectrumBins();
         if (!fftBins.isEmpty() && m_fftLineVbo && m_fftFillVbo) {
@@ -7318,6 +7635,48 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         }
     }
 
+    // #3617: build this frame's flag-sprite quads (NDC), one 4-vertex strip per
+    // flag in m_flagDrawOrder, into the dynamic VBO.  Positions are taken from the
+    // flags' CURRENT geometry, so a dragged flag follows at frame rate with no
+    // re-raster.  Vertex layout matches kQuadData (vec2 pos + vec2 uv; uv.v=0 top).
+    if (m_gpuFlagMode && m_flagQuadVbo && !m_flagDrawOrder.isEmpty()) {
+        const QSize outSz = renderTarget()->pixelSize();
+        const float outW = static_cast<float>(qMax(1, outSz.width()));
+        const float outH = static_cast<float>(qMax(1, outSz.height()));
+        const float fdpr = outW / static_cast<float>(qMax(1, width()));
+        float verts[kMaxFlagSprites * 16];
+        int vc = 0;
+        const int nDraw = qMin(m_flagDrawOrder.size(), kMaxFlagSprites);
+        for (int i = 0; i < nDraw; ++i) {
+            const int id = m_flagDrawOrder[i];
+            VfoWidget* f = m_vfoWidgets.value(id, nullptr);
+            const auto sit = m_flagSprites.constFind(id);
+            // Pixel-snap: place the quad at the flag's rounded device-px origin and
+            // size it EXACTLY to the sprite's texel dimensions, so one texel maps
+            // to one screen pixel (with NEAREST sampling) — crisp, no resampling.
+            const int left = f ? static_cast<int>(std::lround(f->pos().x() * fdpr)) : 0;
+            const int top  = f ? static_cast<int>(std::lround(f->pos().y() * fdpr)) : 0;
+            const int texW = (sit != m_flagSprites.constEnd()) ? sit->texSize.width() : 0;
+            const int texH = (sit != m_flagSprites.constEnd()) ? sit->texSize.height() : 0;
+            const float xl = 2.0f * left / outW - 1.0f;
+            const float xr = 2.0f * (left + texW) / outW - 1.0f;
+            const float yt = 1.0f - 2.0f * top / outH;
+            const float yb = 1.0f - 2.0f * (top + texH) / outH;
+            const float quad[16] = {
+                xl, yb, 0.0f, 1.0f,   // bottom-left
+                xr, yb, 1.0f, 1.0f,   // bottom-right
+                xl, yt, 0.0f, 0.0f,   // top-left
+                xr, yt, 1.0f, 0.0f,   // top-right
+            };
+            for (float v : quad) {
+                verts[vc++] = v;
+            }
+        }
+        if (vc > 0) {
+            batch->updateDynamicBuffer(m_flagQuadVbo, 0, vc * sizeof(float), verts);
+        }
+    }
+
     cb->resourceUpdate(batch);
 
     // Begin render pass
@@ -7399,87 +7758,32 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         cb->draw(4);
     }
 
-    cb->endPass();
-
-    // Reposition VFO widgets. paintEvent() is compiled only in software mode
-    // (#else !AETHER_GPU_SPECTRUM), so in GPU mode this is the sole place VFOs
-    // are repositioned. Logic mirrors the paintEvent() block below exactly.
-    {
-        struct VfoPos { int sliceId; int x; VfoWidget* w; int splitPartner; };
-        QVector<VfoPos> vfos;
-        for (const auto& so : m_sliceOverlays) {
-            if (auto* vw = m_vfoWidgets.value(so.sliceId, nullptr)) {
-                int x = mhzToX(so.freqMhz);
-                if (so.mode == "RTTY" || so.mode == "DIGL") {
-                    double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
-                    x = mhzToX(hiMhz) + 4;
-                }
-                vfos.append({so.sliceId, x, vw, so.splitPartnerId});
+    // #3617 flag sprites — one textured quad per flag, back→front, on top of the
+    // static overlay (same pipeline + premult-alpha blend).  The live (hover)
+    // flag is shown as a real widget, so it's not in m_flagDrawOrder.
+    if (m_gpuFlagMode && m_ovPipeline && m_flagQuadVbo && !m_flagDrawOrder.isEmpty()) {
+        cb->setGraphicsPipeline(m_ovPipeline);
+        cb->setViewport({0, 0,
+            static_cast<float>(outputSize.width()),
+            static_cast<float>(outputSize.height())});
+        const QRhiCommandBuffer::VertexInput vbuf(m_flagQuadVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        const int nDraw = qMin(m_flagDrawOrder.size(), kMaxFlagSprites);
+        for (int i = 0; i < nDraw; ++i) {
+            auto sit = m_flagSprites.constFind(m_flagDrawOrder[i]);
+            if (sit == m_flagSprites.constEnd() || !sit->srb) {
+                continue;
             }
-        }
-        std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
-            return a.x < b.x;
-        });
-
-        const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
-        const int specW  = specRect.width();
-
-        QMap<int, VfoWidget::FlagDir> dirMap;
-        for (int i = 0; i < vfos.size(); ++i) {
-            if (vfos[i].splitPartner < 0) continue;
-            if (dirMap.contains(vfos[i].sliceId)) continue;
-            int pi = -1;
-            for (int j = 0; j < vfos.size(); ++j) {
-                if (vfos[j].sliceId == vfos[i].splitPartner) { pi = j; break; }
-            }
-            if (pi < 0) continue;
-            // Split partners stay locked to opposite sides regardless of
-            // edge proximity (#2663).  Flipping a partner when near an
-            // edge would collapse both panels onto the same side and the
-            // RX/TX panels would visually overlap; the panadapter is the
-            // user's spatial frame and the side-locking is the whole point
-            // of the split affordance.  The outward-facing panel may clip
-            // the pan edge — the user pans toward center to read it.
-            int leftIdx  = (vfos[i].x <= vfos[pi].x) ? i : pi;
-            int rightIdx = (leftIdx == i) ? pi : i;
-            dirMap[vfos[leftIdx].sliceId]  = VfoWidget::LockLeft;
-            dirMap[vfos[rightIdx].sliceId] = VfoWidget::LockRight;
-        }
-
-        for (const auto& so : m_sliceOverlays) {
-            if (so.mode == "RTTY" || so.mode == "DIGL")
-                dirMap[so.sliceId] = VfoWidget::ForceRight;
-        }
-
-        if (vfos.size() == 1) {
-            VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
-            vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
-        } else {
-            for (int i = 0; i < vfos.size(); ++i) {
-                VfoWidget::FlagDir dir = VfoWidget::Auto;
-                if (dirMap.contains(vfos[i].sliceId)) {
-                    dir = dirMap[vfos[i].sliceId];
-                } else if (vfos.size() == 2) {
-                    dir = (i == 0) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                    if (i == 0 && vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                    if (i == 1 && vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
-                } else {
-                    if (i == 0) {
-                        dir = VfoWidget::ForceLeft;
-                        if (vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                    } else if (i == vfos.size() - 1) {
-                        dir = VfoWidget::ForceRight;
-                        if (vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
-                    } else {
-                        const int gapLeft  = vfos[i].x - vfos[i-1].x;
-                        const int gapRight = vfos[i+1].x - vfos[i].x;
-                        dir = (gapLeft >= gapRight) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                    }
-                }
-                vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);
-            }
+            cb->setShaderResources(sit->srb);
+            cb->draw(4, 1, i * 4, 0);
         }
     }
+
+    cb->endPass();
+
+    // VFO flag/widget repositioning now runs earlier (repositionVfoFlags(),
+    // before the flag-layer render) so GPU-composited flags follow the marker
+    // without a one-frame lag (#3617).
 
     if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible())
         m_interlockNotificationLabel->raise();
@@ -7487,6 +7791,107 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     if (perfEnabled) {
         PerfTelemetry::instance().recordRender(
             static_cast<double>(PerfTelemetry::nowNs() - perfStartNs) / 1000000.0);
+    }
+}
+
+// Reposition VFO widgets. paintEvent() is compiled only in software mode
+// (#else !AETHER_GPU_SPECTRUM), so in GPU mode this is the sole place VFOs are
+// repositioned. Logic mirrors the paintEvent() block below exactly.  Called
+// from renderGpuFrame BEFORE the flag-layer render so a dragged flag's snapshot
+// is rasterized at this frame's position (no one-frame lag).  (#3617)
+void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
+{
+    struct VfoPos { int sliceId; int x; VfoWidget* w; int splitPartner; };
+    QVector<VfoPos> vfos;
+    for (const auto& so : m_sliceOverlays) {
+        if (auto* vw = m_vfoWidgets.value(so.sliceId, nullptr)) {
+            int x = mhzToX(so.freqMhz);
+            if (so.mode == "RTTY" || so.mode == "DIGL") {
+                double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
+                x = mhzToX(hiMhz) + 4;
+            }
+            vfos.append({so.sliceId, x, vw, so.splitPartnerId});
+        }
+    }
+    std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
+        return a.x < b.x;
+    });
+
+    const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
+    const int specW  = specRect.width();
+
+    QMap<int, VfoWidget::FlagDir> dirMap;
+    for (int i = 0; i < vfos.size(); ++i) {
+        if (vfos[i].splitPartner < 0) continue;
+        if (dirMap.contains(vfos[i].sliceId)) continue;
+        int pi = -1;
+        for (int j = 0; j < vfos.size(); ++j) {
+            if (vfos[j].sliceId == vfos[i].splitPartner) { pi = j; break; }
+        }
+        if (pi < 0) continue;
+        // Split partners stay locked to opposite sides regardless of
+        // edge proximity (#2663).  Flipping a partner when near an
+        // edge would collapse both panels onto the same side and the
+        // RX/TX panels would visually overlap; the panadapter is the
+        // user's spatial frame and the side-locking is the whole point
+        // of the split affordance.  The outward-facing panel may clip
+        // the pan edge — the user pans toward center to read it.
+        int leftIdx  = (vfos[i].x <= vfos[pi].x) ? i : pi;
+        int rightIdx = (leftIdx == i) ? pi : i;
+        dirMap[vfos[leftIdx].sliceId]  = VfoWidget::LockLeft;
+        dirMap[vfos[rightIdx].sliceId] = VfoWidget::LockRight;
+    }
+
+    for (const auto& so : m_sliceOverlays) {
+        if (so.mode == "RTTY" || so.mode == "DIGL")
+            dirMap[so.sliceId] = VfoWidget::ForceRight;
+    }
+
+    if (vfos.size() == 1) {
+        VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
+        vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
+    } else {
+        for (int i = 0; i < vfos.size(); ++i) {
+            VfoWidget::FlagDir dir = VfoWidget::Auto;
+            if (dirMap.contains(vfos[i].sliceId)) {
+                dir = dirMap[vfos[i].sliceId];
+            } else if (vfos.size() == 2) {
+                dir = (i == 0) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
+                if (i == 0 && vfos[i].x < panelW) dir = VfoWidget::ForceRight;
+                if (i == 1 && vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
+            } else {
+                if (i == 0) {
+                    dir = VfoWidget::ForceLeft;
+                    if (vfos[i].x < panelW) dir = VfoWidget::ForceRight;
+                } else if (i == vfos.size() - 1) {
+                    dir = VfoWidget::ForceRight;
+                    if (vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
+                } else {
+                    const int gapLeft  = vfos[i].x - vfos[i-1].x;
+                    const int gapRight = vfos[i+1].x - vfos[i].x;
+                    dir = (gapLeft >= gapRight) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
+                }
+            }
+            vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);
+        }
+    }
+
+    // GPU flag mode: keep the flag panels hidden so they never composite as
+    // raster siblings (addVfoWidget shows each flag once so it lays out; this
+    // hides it from the first frame on — setVisible(false) is a no-op once
+    // hidden).  Also mark the flag layer dirty when a flag moved, so its GPU
+    // snapshot re-rasterizes at the new position THIS frame (no lag).  At rest
+    // nothing moves → no extra work (stays at the refresh-timer cadence).
+    if (m_gpuFlagMode) {
+        // Hide every flag panel EXCEPT the live (hover-swapped) one, so it doesn't
+        // composite as a raster sibling.  The live flag stays a real widget for
+        // interaction.  Position is carried by the per-flag sprite quad, so no
+        // move tracking is needed here.  setVisible(false) is a no-op once hidden.
+        for (const auto& vp : vfos) {
+            if (vp.w && vp.sliceId != m_liveFlagSliceId && vp.w->isVisible()) {
+                vp.w->setVisible(false);
+            }
+        }
     }
 }
 
@@ -7516,6 +7921,13 @@ void SpectrumWidget::releaseResources()
     delete m_ovVbo;          m_ovVbo = nullptr;
     delete m_ovGpuTex;       m_ovGpuTex = nullptr;
     delete m_ovSampler;      m_ovSampler = nullptr;
+
+    // #3617 flag sprites — free each flag's texture/SRB + the shared quad VBO.
+    for (auto it = m_flagSprites.begin(); it != m_flagSprites.end(); ++it) {
+        releaseFlagSprite(it.value());
+    }
+    delete m_flagQuadVbo;    m_flagQuadVbo = nullptr;
+    delete m_flagSampler;    m_flagSampler = nullptr;
 
     // Bg-image layer (added with the FFT-above-bg fix) — same lifecycle
     // as the overlay scaffolding it lives alongside; release in the same

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -595,6 +595,11 @@ private:
     void installVfoCursorEventFilter(VfoWidget* widget);
     void setVfoCursorOverride(Qt::CursorShape shape);
     void clearVfoCursorOverride();
+#ifdef AETHER_GPU_SPECTRUM
+    void repositionVfoFlags(const QRect& specRect);  // #3617 — runs before flag render
+    void updateLiveFlag();   // #3617 — pick which flag is live (hover/focus/popup)
+    void setLiveFlag(int sliceId);   // #3617 — show one flag live, snapshot the rest
+#endif
     void setSpectrumCursor(Qt::CursorShape shape);
     void updateTrackedCursorState(const QPoint& localPos, bool insideWidget);
     void updateTnfHoverPopup();
@@ -1180,6 +1185,20 @@ private:
     SpectrumOverlayMenu* m_overlayMenu{nullptr};
     // VFO info widgets (one per slice, attached to VFO markers)
     QMap<int, VfoWidget*> m_vfoWidgets;
+#ifdef AETHER_GPU_SPECTRUM
+    // #3617 GPU-flag state (only with the GPU spectrum path; the software path
+    // keeps the flags as ordinary live widgets).
+    bool m_gpuFlagMode{false};   // flags GPU-composited, panels hidden
+    QTimer* m_flagRefreshTimer{nullptr};   // re-snapshot live flag content
+    // hover-swap: the flag whose panel is currently shown LIVE (interactive)
+    // instead of GPU-composited, because the cursor is over it / it has focus / a
+    // popup is open.  -1 = none (all flags GPU).  The panel hosts interactive
+    // children (freq edit, antenna/mode/filter buttons, tabs) that only work as a
+    // real widget, so we go live on interaction and snapshot back to GPU at rest.
+    int m_liveFlagSliceId{-1};
+    QElapsedTimer m_liveFlagIdleClock;   // debounce hiding when the cursor leaves
+    static constexpr int kLiveFlagHideDelayMs = 200;
+#endif
     VfoWidget* m_vfoWidget{nullptr};  // alias to active slice widget (compat)
 
     // Bottom-left waterfall buttons: S(egment), B(and), −/+.
@@ -1215,6 +1234,28 @@ private:
     QImage m_overlayDynamic;    // FFT spectrum — repainted every frame
     bool m_overlayStaticDirty{true};
     bool m_overlayNeedsUpload{true};
+
+    // #3617 GPU flag sprites: each slice flag is its OWN GPU texture (a "sprite"),
+    // rasterized via QWidget::render into a CPU image on the refresh timer —
+    // OUTSIDE the QRhi render callback (rasterizing widgets inside it re-enters
+    // the renderer and crashes) and only ~12 Hz (no per-move re-raster → no audio
+    // stall).  Each frame the sprite is drawn as a textured quad positioned at the
+    // flag's CURRENT on-screen rect (reusing m_ovPipeline/m_ovSampler), so a
+    // dragged flag follows at frame rate for free — no re-raster on move.
+    struct FlagSprite {
+        QRhiTexture* tex{nullptr};
+        QRhiShaderResourceBindings* srb{nullptr};
+        QImage img;             // CPU raster (filled by grabFlagSprites, off-frame)
+        QSize texSize;          // device-px size the texture was created at
+        bool imgDirty{false};   // img changed → upload to tex next frame
+    };
+    QHash<int, FlagSprite> m_flagSprites;       // keyed by sliceId
+    QVector<int> m_flagDrawOrder;               // sliceIds to draw this frame, back→front
+    QRhiBuffer* m_flagQuadVbo{nullptr};         // dynamic: 4 verts × up to kMaxFlagSprites
+    QRhiSampler* m_flagSampler{nullptr};        // NEAREST — 1:1 crisp sprite text
+    static constexpr int kMaxFlagSprites = 16;  // generous cap (radios have ≤8 slices)
+    void grabFlagSprites();                     // QWidget::render flags → sprite imgs (off-frame)
+    void releaseFlagSprite(FlagSprite& s);      // free one sprite's GPU resources
 
     // Background-image layer — kept separate from m_overlayStatic so it can
     // render BELOW the FFT trace (parity with the software paint path).  Same

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2087,6 +2087,34 @@ void VfoWidget::showTab(int index)
 
 // ── Collapsed flag toggle ─────────────────────────────────────────────────────
 
+void VfoWidget::setButtonsOccluded(bool occluded)
+{
+    if (occluded == m_buttonsOccluded) {
+        return;     // only act on a state change — no per-frame churn
+    }
+    m_buttonsOccluded = occluded;
+    const QList<QWidget*> ext = {
+        m_collapsedFreqLabel.data(), m_lockVfoBtn.data(), m_closeSliceBtn.data(),
+        m_recordBtn.data(), m_playBtn.data()
+    };
+    if (occluded) {
+        m_occludeRestore.clear();
+        for (QWidget* w : ext) {
+            if (w && w->isVisible()) {
+                m_occludeRestore.append(w);
+                w->hide();
+            }
+        }
+    } else {
+        for (const QPointer<QWidget>& w : m_occludeRestore) {
+            if (w) {
+                w->show();
+            }
+        }
+        m_occludeRestore.clear();
+    }
+}
+
 void VfoWidget::setOpaqueMode(bool on)
 {
     if (m_opaqueMode == on)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -94,6 +94,13 @@ public:
     // whole window every frame (the dominant idle CPU cost — see #3283).
     void setOpaqueMode(bool on);
 
+    // #3617 GPU flag mode: the flag panel is GPU-composited (occludes correctly
+    // via render order) but the external buttons stay live widgets that float
+    // above the panadapter texture.  When another flag overlaps this one from in
+    // front, hide this flag's buttons so they don't sit on top of the covering
+    // flag — mirroring the natural widget-stacking occlusion of normal mode.
+    void setButtonsOccluded(bool occluded);
+
     // Which side of the slice marker the flag panel is currently rendered on.
     // Tracked by updatePosition() via m_lastOnLeft.  Used by panFollowVfo()
     // to extend the pan-follow trigger to the flag's outer edge — single-side
@@ -217,6 +224,8 @@ private:
     QPushButton* m_splitBadge{nullptr};
     QPushButton* m_txBadge{nullptr};
     QLabel*      m_sliceBadge{nullptr};
+    QList<QPointer<QWidget>> m_occludeRestore; // #3617 buttons hidden by overlap
+    bool m_buttonsOccluded{false};             // #3617 current occlusion state
     QPointer<QPushButton> m_lockVfoBtn;
     QPointer<QPushButton> m_closeSliceBtn;
     QPointer<QPushButton> m_recordBtn;


### PR DESCRIPTION
<!-- PR DRAFT for #3617 — review before opening. Target: svabi79:fix/panadapter-gpu-flags -> aethersdr:main -->

## Summary

> **Context:** I picked this up out of interest in the panadapter-performance
> topic — it's your own flagship issue, so this PR is as much "here's what I
> found and tried" as a finished change. The GPU-sprite path works and is
> measured below; there's one visual trade-off I've left explicitly for your
> call (see "What was tried"). Take it whichever direction you prefer.

Fixes #3617. GPU-composite the per-slice VFO flags instead of letting them
composite as **translucent raster `QWidget` siblings** over the panadapter
`QRhiWidget` — the cause of the ~75–95% main-thread CPU this issue identifies
(the GPU render itself is ~0.4 ms; the cost is Qt re-blending the translucent
siblings on every waterfall frame).

Each flag is now rasterized into its **own GPU texture** and drawn as a textured
quad positioned at the flag's current on-screen rect. A flag the operator is
**interacting with** (cursor over it, a child focused, or a popup open) swaps back
to a real live widget so every control stays fully functional; at rest it is a
cheap GPU sprite.

**Measured** — test rig: Windows 11, **Intel Core i9-13900K / NVIDIA RTX 4090**,
Qt **D3D11** backend, FLEX-6600. 4 slices, steady state, cursor parked, both at
~30 fps and renderP95 ~0.2 ms:

| flags | main-thread CPU |
|---|---|
| legacy live widgets (`AETHER_NO_GPU_FLAGS=1`) | **0.82 cores** |
| GPU sprites (this PR) | **0.45 cores** |
| **delta** | **−0.37 cores ≈ −45%** |

Render cost and fps are identical in both modes → the win is purely the
eliminated raster-sibling composite, confirming the issue's diagnosis.
`AETHER_NO_GPU_FLAGS=1` keeps the legacy path for A/B comparison.

Note the HW context: this is a **fast** CPU, and the composite still costs ~0.37
cores for 4 slices — so on slower hardware (or at higher slice counts / 4K–8K
panadapters, where the issue reports the worst pain) the absolute main-thread
relief should be proportionally larger. Cross-platform numbers (esp. the
Linux/Wayland setups in the issue) welcome — `aether.perf` + the A/B hatch make
re-measurement easy.

## Constitution principle honored

**Principle XI (Fixes Are Demonstrated)** — ships with before/after main-thread
CPU measurements, an `AETHER_NO_GPU_FLAGS` A/B escape hatch, and an `aether.perf`
diagnostic line for re-measurement on other platforms.

## How it works

- **Sprite raster (off the render thread).** `grabFlagSprites()` runs on the
  refresh timer (~12 Hz) and on live-flag changes — *never* inside the QRhi
  render callback — and `QWidget::render()`s each non-live flag into a per-flag
  premultiplied `QImage`. (Rasterizing a widget *inside* the QRhi frame re-enters
  the renderer and crashes — see "What was tried".)
- **GPU upload + draw (in-frame).** `renderGpuFrame()` (re)creates/uploads each
  flag's texture (a memcpy; safe in-frame) and draws it as a quad sized 1:1 to the
  texture at the flag's current device-pixel position. Following a dragged flag is
  therefore free (just a quad move) — no per-move re-raster, so no audio stall.
- **Interactivity (hover-swap).** The hovered/focused flag is shown as a normal
  live widget; others are sprites. Z-order (active flag on top) and the existing
  overlapping-flag button occlusion are preserved.

Touched files are default review tier: `SpectrumWidget.{cpp,h}`,
`VfoWidget.{cpp,h}`. No FlexLib/RadioModel/MainWindow core. Clean-room
(Principle IV) — no derived/decompiled sources.

## What was tried, and an open trade-off for your decision

The path here, in case it's useful, and one point I'd like your call on:

1. **Shared full-screen flag texture, rasterized in the render callback** — worked
   with one slice but **crashed** with several (`QWidget::render` inside the QRhi
   frame → `beginOffscreenFrame within a still active frame` re-entrancy), and
   caused audio crackle when dragging (per-move full re-raster on the main thread).
   Abandoned for the per-flag, off-frame-rasterized "movable quad" above.
2. **Open visual trade-off (needs a maintainer call).** A non-hovered flag is a
   GPU sprite rasterized via `QWidget::render` → **grayscale AA**; a hovered flag
   is a live widget → **ClearType subpixel AA**. So non-hovered flag text reads
   subtly heavier/softer than the crisp hovered one. This is **fundamental** —
   ClearType subpixel rendering cannot be reproduced in an ARGB texture. I tried a
   2× supersample + linear downscale (made it *worse* — downscale blur) and
   settled on **1:1 texel-per-pixel + NEAREST sampling + pixel-snapped quads**
   (removes the blur; crispest a grayscale texture can be), but a subtle
   grayscale-vs-ClearType difference remains. Options, your call:
   - **(a)** accept the subtle difference (current);
   - **(b)** render the live/hovered flag grayscale too (`QFont::NoSubpixelAntialias`)
     → no hover difference, but all flags a touch heavier than today's ClearType;
   - **(c)** keep flags fully live but opaque (the issue's short-term lever) —
     ~13% only, no GPU-compositing rework;
   - **(d)** a retained-mode / Qt Quick overlay scene (the issue's flagship
     option) — eliminates the gap entirely, but a much larger change.

   This PR implements the GPU-sprite path (a); happy to take it whichever way you
   prefer.

## Test plan

- [x] Local build passes
- [x] Behavior verified on a real radio (FLEX-6600): flags render correctly,
      drag-follow is smooth, no audio crackle, interaction works via hover-swap
- [x] Before/after CPU measured (table above); A/B via `AETHER_NO_GPU_FLAGS`
- [ ] CI

## Checklist

- [x] Commits signed
- [x] No new flat-key `AppSettings` calls (Principle V) — none added
- [x] Code is clean-room (Principle IV)
- [x] Meter UI unchanged (still `MeterSmoother`)
- [ ] Docs — n/a (no user-visible setting; behavior is visually equivalent modulo the AA note above)
