### PR TITLE
fix(rx): RX BW indicator shows bandwidth, not hi cut (#3659)

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2281,15 +2281,12 @@ QString RxApplet::formatHz(int hz)
     return (hz >= 0 ? "+" : "") + QString::number(hz) + " Hz";
 }
 
-QString RxApplet::formatFilterWidth(int lo, int hi, const QString& mode)
+QString RxApplet::formatFilterWidth(int lo, int hi, const QString& /*mode*/)
 {
-    int w;
-    if (mode == "USB" || mode == "DIGU" || mode == "FDV" || mode == "FDVU" || mode == "NT")
-        w = hi;
-    else if (mode == "LSB" || mode == "DIGL" || mode == "FDVL")
-        w = std::abs(lo);
-    else
-        w = hi - lo;
+    // Bandwidth is the passband span (hi - lo) for every mode. The old
+    // per-mode branches returned the hi cut (USB) or |lo| (LSB), so the
+    // indicator showed the cut frequency instead of the bandwidth (#3659).
+    const int w = hi - lo;
     if (w <= 0) return "?";
     if (w >= 1000) return QString::number(w / 1000.0, 'f', 1) + "K";
     return QString::number(w);


### PR DESCRIPTION
Closes #3659. `RxApplet::formatFilterWidth()` returned the **hi cut** for USB/DIGU/FDV (`w = hi`) and `|lo|` for LSB/DIGL, so the RX filter-width readout displayed the cut frequency instead of the **passband bandwidth** — wrong on every slice and divergent from SmartSDR (e.g. a 100–2900 Hz USB filter showed `2.9K` instead of `2.8K`).

Bandwidth is `hi - lo` for every mode (the existing fallback branch already computed this correctly), so compute it unconditionally. The `mode` parameter is now unused (kept in the signature for call-site stability).

`good first issue`, no RFC (correctness fix). Full app builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)