### PR TITLE
fix(cat): don't cap running CAT ports by receiver count (#3693)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4621,7 +4621,7 @@ void MainWindow::applyCatPortCount()
 {
     auto& s = AppSettings::instance();
     const bool masterOn = s.value("CatEnabled", "False").toString() == "True";
-    const int  target   = catPortTargetCount();
+    const int  target   = catPortTargetCount();  // bounds applet VFO letters, not port count
 
     for (int i = 0; i < kCatPorts; ++i) {
         if (!catPort(i)) continue;
@@ -4629,7 +4629,11 @@ void MainWindow::applyCatPortCount()
         const QString prefix = QString("CatPort_%1_").arg(i);
         const bool portEnabled = s.value(prefix + "Enabled", "False").toString() == "True";
         const int  portNum     = s.value(prefix + "Port", "").toInt();
-        const bool shouldRun   = masterOn && portEnabled && (portNum >= 1024) && (i < target);
+        // A CAT port is a control channel, not a 1:1 mapping to a slice — don't
+        // cap how many configured ports start by the radio's receiver count
+        // (#3693). Receiver capacity bounds the VFO-letter choices per port
+        // (catPortTargetCount() feeds the applet), not whether a port runs.
+        const bool shouldRun   = masterOn && portEnabled && (portNum >= 1024);
 
         if (shouldRun && !catPort(i)->isRunning()) {
             // Re-apply config in case dialect/VFO was changed while stopped


### PR DESCRIPTION
Closes #3693. `applyCatPortCount()` gated each port's `shouldRun` on `(i < target)`, where `target` = the radio's slice-receiver count. So a 5th+ configured CAT port on a 4-RX radio (most 6600/8600) **silently never started** — no error, no feedback.

A CAT port is a *control channel*, not a 1:1 mapping to a slice. Receiver capacity should bound the **VFO-letter choices** per port — which `catPortTargetCount()` still feeds to the applet via `setMaxSlices()` (unchanged) — not **whether** a configured port runs. Dropped the `(i < target)` term so all enabled ports up to `kCatPorts` (8) start.

Model-independent shared GUI code; no RFC (correctness fix). Full app builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)