### PR TITLE
fix(spectrum): reproject only the active waterfall stream while panning (#3700)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2569,12 +2569,31 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
                            newCenterMhz, newBandwidthMhz);
     };
 
-    reprojectStream(false);
-    reprojectStream(true);
-    if (m_kiwiSdrWaterfallActive != originalKiwiActive) {
-        saveCurrentWaterfallStreamState();
-        m_kiwiSdrWaterfallActive = originalKiwiActive;
-        restoreCurrentWaterfallStreamState();
+    // #3668 (KiwiSDR integration) replaced #3578's single per-pan reproject with
+    // an unconditional native + kiwi double reproject. The inactive stream is not
+    // on screen, so reprojecting it on every pan step is wasted work -- and the
+    // stream-state save/restore around it leaves m_waterfall COW-shared, so the
+    // next fill() in rebuildWaterfallViewportForFrame deep-copies the whole
+    // (potentially very large) waterfall image on every pan step. On high-res
+    // displays that cost 60-80 ms of UI-thread stall per pan step -- a visible
+    // regression (measured: wfUpdateP95 0.1 ms -> 68 ms with the second pass).
+    //
+    // Reproject only the active stream. The inactive stream is remapped to the
+    // current frequency frame when it next becomes visible (see
+    // setKiwiSdrWaterfallActive); each history row carries its own capture frame
+    // (#3578), so toggling streams stays seamless. AETHER_WF_KIWI_ALWAYS=1
+    // restores the old unconditional double pass for A/B verification.
+    static const bool kiwiAlways = qEnvironmentVariableIsSet("AETHER_WF_KIWI_ALWAYS");
+    if (kiwiAlways) {
+        reprojectStream(false);
+        reprojectStream(true);
+        if (m_kiwiSdrWaterfallActive != originalKiwiActive) {
+            saveCurrentWaterfallStreamState();
+            m_kiwiSdrWaterfallActive = originalKiwiActive;
+            restoreCurrentWaterfallStreamState();
+        }
+    } else {
+        reprojectStream(m_kiwiSdrWaterfallActive);
     }
 }
 
@@ -4225,6 +4244,13 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
     saveCurrentWaterfallStreamState();
     m_kiwiSdrWaterfallActive = active;
     restoreCurrentWaterfallStreamState();
+    // The newly-active stream is no longer reprojected on every pan step
+    // (handleWaterfallFrequencyFrameChange now touches only the active stream),
+    // so its restored viewport can lag the current frequency frame. Remap it now
+    // that it is visible -- exact, since each history row keeps its own capture
+    // frame (#3578). This is the lazy counterpart to the per-pan reproject the
+    // inactive stream used to receive.
+    rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
     if (!active) {
         m_pendingDbmRangeEcho = false;
         m_pendingDbmRangeEchoFromAutoFloor = false;


### PR DESCRIPTION
## Summary

Fixes #3700. Panning the waterfall regressed on wide / high-DPI displays after **#3668** (KiwiSDR integration): every pan mouse-move ran an unconditional **native + kiwi** double reproject, even with no KiwiSDR receiver connected. The second pass is wasted work, and its waterfall-stream-state save/restore leaves `m_waterfall` copy-on-write–shared, so the next `fill()` in `rebuildWaterfallViewportForFrame()` **deep-copies the whole waterfall image** every pan step — 60–80 ms of UI-thread stall per step. This re-introduced, by a different path, the per-pan-step cost that **#3578** (#3575) had removed.

This PR reprojects **only the active stream** per pan, and remaps the other stream to the current frequency frame when it next becomes visible (`setKiwiSdrWaterfallActive`) — exact, because each history row carries its own capture frame (#3578). `AETHER_WF_KIWI_ALWAYS=1` restores the old double pass for A/B.

## How we got here (approach)

Came at this from interest in the panadapter-perf topic — same lane as #3578/#3617. The path mattered, so here it is:

1. **Measured first, didn't guess.** `aether.perf` showed the pan stall is client-side: `wfUpdateP95` 0.1 ms idle → ~68 ms during pan, `panAgeP95` ~160 ms, 200+ main-thread stalls of 60–83 ms — while `renderP95` stayed ~7 ms and `fftRestarts`/`wfRestarts`/loss were all 0. So **not** the GPU render, and **not** the radio/retune (our first hypothesis — the data disproved it).
2. **Bisected by inspection.** The cost lands in `rebuildWaterfallViewportForFrame` (fill + remap every visible row) — but #3578 had made that acceptable. `git log` on the pan path since #3578 surfaced exactly one suspect: **#3668** replaced the single `reprojectWaterfall()` with `reprojectStream(false) + reprojectStream(true)` (merged the same day the choppiness appeared).
3. **Two mechanisms.** The unconditional second (kiwi) pass; and the QImage COW detach the stream-state save/restore triggers on the next `fill()` — a full deep-copy of the (large) waterfall image, per pan step.
4. **Proved it with a one-variable A/B** — same binary, `AETHER_WF_KIWI_ALWAYS` toggling *only* the second pass:

| metric (hand pan) | #3668 double pass | this PR (active only) |
|---|---|---|
| `wfUpdateP95Ms` | 63–68 ms | **0.1 ms** |
| `panAgeP95Ms` | 150–174 ms | **22–32 ms** |
| `inputP95Ms` | 19–24 ms | **0.2–3.6 ms** |
| `uiLagMaxMs` | 75–85 ms | **23–41 ms** |
| total `PerfStall` | 931 | **15** |

The single switch flips it — the second pass *is* the regression, reprojecting only the active stream *is* the fix.

## The change

- **`handleWaterfallFrequencyFrameChange()`** — reproject only the active stream (`reprojectStream(m_kiwiSdrWaterfallActive)`): no stream swap, so no COW-share and no per-step deep-copy.
- **`setKiwiSdrWaterfallActive()`** — after restoring the switched-in stream's state, `rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz)` aligns it to the current frame the moment it's shown. This is the lazy counterpart to the per-pan reproject the inactive stream used to receive, so toggling streams stays seamless.
- **`AETHER_WF_KIWI_ALWAYS=1`** keeps the old unconditional double pass available for verification.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Root cause and fix both confirmed by `aether.perf` before/after (table above), same binary, one variable changed.

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3 msvc2022_64, GPU path on)
- [x] Before/after measured with the gated `aether.perf` telemetry (two runs each)
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented in #3700
- [ ] ⚠️ **KiwiSDR-active path not hardware-tested** — I have no KiwiSDR receiver, so the measured path is FLEX (active = native). The stream-switch remap reuses the existing `rebuildWaterfallViewportForFrame`; a KiwiSDR-equipped user toggling streams mid-pan would confirm the switch stays aligned. Flagging for maintainer / KiwiSDR review.

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV) — not decompiled / reverse-engineered
- [x] All meter UI uses `MeterSmoother` (N/A)
- [x] Documentation updated if user-visible behavior changed (N/A — pan is visually unchanged, just smooth again)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
