### PR TITLE
[codex] Add Kiwi diversity receive interlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2422,6 +2422,14 @@ if(UNIX)
 endif()
 add_test(NAME transmit_model_test COMMAND transmit_model_test)
 
+add_executable(transmit_inhibit_policy_test
+    tests/transmit_inhibit_policy_test.cpp
+    src/core/CommandParser.cpp
+)
+target_include_directories(transmit_inhibit_policy_test PRIVATE src)
+target_link_libraries(transmit_inhibit_policy_test PRIVATE Qt6::Core)
+add_test(NAME transmit_inhibit_policy_test COMMAND transmit_inhibit_policy_test)
+
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1942,12 +1942,12 @@ void AudioEngine::setKiwiSdrAudioEnabled(bool on)
 
 void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
 {
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, on);
     if (!source || source->enabled == on) {
         return;
     }
 
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     source->enabled = on;
     qCDebug(lcKiwiSdrAudio).noquote()
         << "Audio source" << (on ? "enabled" : "disabled") << source->id;
@@ -1976,6 +1976,7 @@ void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
 void AudioEngine::setKiwiSdrAudioSourceGain(const QString& sourceId,
                                             float gainPercent)
 {
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
     if (!source) {
         return;
@@ -1987,12 +1988,12 @@ void AudioEngine::setKiwiSdrAudioSourceGain(const QString& sourceId,
 void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
                                              bool muted)
 {
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
     if (!source || source->muted == muted) {
         return;
     }
 
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     source->muted = muted;
     source->rxBuffer.clear();
     source->rxPackets.clear();
@@ -2006,6 +2007,7 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
 
 void AudioEngine::setKiwiSdrAudioSourcePan(const QString& sourceId, int pan)
 {
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
     if (!source) {
         return;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2004,6 +2004,16 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
     updateRxBufferStats();
 }
 
+void AudioEngine::setKiwiSdrAudioSourcePan(const QString& sourceId, int pan)
+{
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+    if (!source) {
+        return;
+    }
+
+    source->pan = qBound(0, pan, 100);
+}
+
 void AudioEngine::removeKiwiSdrAudioSource(const QString& sourceId)
 {
     const QString id = sourceId.trimmed();
@@ -2157,6 +2167,10 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 {
     if (!m_audioSink) return;  // PC audio disabled
 
+    const auto sourcePan = [this, externalSource]() {
+        return externalSource ? externalSource->pan : m_rxPan.load();
+    };
+
     // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any
     // pan, and the zero-filled frames the radio sends for muted slices
     // (audio_mute=1 zeroes the payload; it does NOT suppress packets).
@@ -2277,6 +2291,21 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
         updateRxBufferStats();
     };
+    const auto writeAudioAndLevel = [this, externalSource, sourcePan, &writeAudio](
+                                        const QByteArray& data) {
+        const QByteArray* output = &data;
+        QByteArray panned;
+        if (externalSource && sourcePan() != 50) {
+            panned = data;
+            applyRxPanInPlace(
+                reinterpret_cast<float*>(panned.data()),
+                panned.size() / (2 * static_cast<int>(sizeof(float))),
+                sourcePan());
+            output = &panned;
+        }
+        writeAudio(*output);
+        emit levelChanged(computeRMS(*output));
+    };
 
     // Bypass client-side DSP during TX (#367, #1505). NR2/RN2/BNR adapt
     // their internal state to silence during TX, causing distorted audio
@@ -2286,14 +2315,13 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     {
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
         if (m_radioTransmitting) {
-            writeAudio(pcm);
-            emit levelChanged(computeRMS(pcm));
+            writeAudioAndLevel(pcm);
         } else if (m_rn2Enabled && m_rn2) {
             QByteArray processed = m_rn2->process(pcm);
             // Re-apply pan lost during NR mono-mix (#1460)
             applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
                               processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              m_rxPan.load());
+                              sourcePan());
             writeAudio(processed);
             emit levelChanged(computeRMS(processed));
         } else if (m_nr2Enabled && m_nr2) {
@@ -2311,7 +2339,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             // Re-apply pan lost during NR mono-mix (#1460)
             applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
                               processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              m_rxPan.load());
+                              sourcePan());
             writeAudio(processed);
             emit levelChanged(computeRMS(processed));
 #endif
@@ -2321,7 +2349,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             // Re-apply pan lost during NR mono-mix (#1460)
             applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
                               processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              m_rxPan.load());
+                              sourcePan());
             writeAudio(processed);
             emit levelChanged(computeRMS(processed));
 #endif
@@ -2335,8 +2363,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             processBnr(pcm);
             // processBnr writes audio and emits level internally
         } else {
-            writeAudio(pcm);
-            emit levelChanged(computeRMS(pcm));
+            writeAudioAndLevel(pcm);
         }
     }
 }
@@ -4880,7 +4907,8 @@ void AudioEngine::processNr2(const QByteArray& stereoPcm,
         dst[2 * i]     = s;
         dst[2 * i + 1] = s;
     }
-    applyRxPanInPlace(dst, stereoFrames, m_rxPan.load());
+    const int pan = externalSource ? externalSource->pan : m_rxPan.load();
+    applyRxPanInPlace(dst, stereoFrames, pan);
 }
 
 QByteArray AudioEngine::applyBoost(const QByteArray& pcm, float gain) const

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1362,6 +1362,8 @@ bool AudioEngine::startRxStream()
     m_kiwiSdrRxPackets.clear();
     m_rxOutputBuffer.clear();
     m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrBnrOutBuf.clear();
+    m_kiwiSdrBnrPrimed = false;
     m_radeRxBuffer.clear();
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
@@ -1373,6 +1375,10 @@ bool AudioEngine::startRxStream()
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
+        source->bnrUp.reset();
+        source->bnrDown.reset();
+        source->bnrOutBuf.clear();
+        source->bnrPrimed = false;
         source->prebuffering = source->enabled;
     }
     m_rxBufferBytes.store(0);
@@ -1575,6 +1581,8 @@ void AudioEngine::stopRxStream()
     m_kiwiSdrRxPackets.clear();
     m_rxOutputBuffer.clear();
     m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrBnrOutBuf.clear();
+    m_kiwiSdrBnrPrimed = false;
     m_radeRxBuffer.clear();
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
@@ -1586,6 +1594,10 @@ void AudioEngine::stopRxStream()
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
+        source->bnrUp.reset();
+        source->bnrDown.reset();
+        source->bnrOutBuf.clear();
+        source->bnrPrimed = false;
         source->prebuffering = source->enabled;
     }
     m_rxBufferBytes.store(0);
@@ -1959,6 +1971,10 @@ void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
     source->nr2Output.clear();
     source->rxResampler.reset();
     source->rxResamplerR.reset();
+    source->bnrUp.reset();
+    source->bnrDown.reset();
+    source->bnrOutBuf.clear();
+    source->bnrPrimed = false;
     if (on && m_nr2Enabled.load(std::memory_order_relaxed) && !source->nr2) {
         source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
         if (source->nr2->hasPlanFailed()) {
@@ -2001,6 +2017,10 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
     source->nr2Mono.clear();
     source->nr2Processed.clear();
     source->nr2Output.clear();
+    source->bnrUp.reset();
+    source->bnrDown.reset();
+    source->bnrOutBuf.clear();
+    source->bnrPrimed = false;
     source->prebuffering = !muted && source->enabled;
     updateRxBufferStats();
 }
@@ -2069,6 +2089,10 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
+        source->bnrUp.reset();
+        source->bnrDown.reset();
+        source->bnrOutBuf.clear();
+        source->bnrPrimed = false;
         if (m_nr2Enabled && source->nr2) {
             source->nr2->reset();
         }
@@ -2120,8 +2144,12 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
     if (m_bnrEnabled) {
         m_bnrUp = std::make_unique<Resampler>(24000, 48000, 16384);
         m_bnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
+        m_kiwiSdrBnrUp = std::make_unique<Resampler>(24000, 48000, 16384);
+        m_kiwiSdrBnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
         m_bnrOutBuf.clear();
+        m_kiwiSdrBnrOutBuf.clear();
         m_bnrPrimed = false;
+        m_kiwiSdrBnrPrimed = false;
     }
 }
 
@@ -2180,7 +2208,9 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     // Flex audio, the legacy Kiwi stream, or one virtual Kiwi antenna stream.
     // Stateful NR/output resamplers must never see alternating Flex/Kiwi or
     // different Kiwi endpoints on the same DSP state.
-    auto writeAudio = [this, source, externalSource](const QByteArray& data) {
+    auto writeAudio = [this, source, externalSource, sourcePan](
+                          const QByteArray& data,
+                          bool applyOutputPan = false) {
         if (!m_audioDevice || !m_audioDevice->isOpen()) return;
 
         // Client-side parametric EQ runs at the native 24 kHz rate, after
@@ -2284,6 +2314,15 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
             output = &trimmed;
         }
+        QByteArray panned;
+        if (applyOutputPan && sourcePan() != 50) {
+            panned = *output;
+            applyRxPanInPlace(
+                reinterpret_cast<float*>(panned.data()),
+                panned.size() / (2 * static_cast<int>(sizeof(float))),
+                sourcePan());
+            output = &panned;
+        }
         QByteArray& outputBuffer = externalSource
             ? externalSource->outputBuffer
             : (source == RxDspSource::KiwiSdr ? m_kiwiSdrOutputBuffer
@@ -2293,20 +2332,10 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
         updateRxBufferStats();
     };
-    const auto writeAudioAndLevel = [this, externalSource, sourcePan, &writeAudio](
+    const auto writeAudioAndLevel = [this, externalSource, &writeAudio](
                                         const QByteArray& data) {
-        const QByteArray* output = &data;
-        QByteArray panned;
-        if (externalSource && sourcePan() != 50) {
-            panned = data;
-            applyRxPanInPlace(
-                reinterpret_cast<float*>(panned.data()),
-                panned.size() / (2 * static_cast<int>(sizeof(float))),
-                sourcePan());
-            output = &panned;
-        }
-        writeAudio(*output);
-        emit levelChanged(computeRMS(*output));
+        writeAudio(data, externalSource != nullptr);
+        emit levelChanged(computeRMS(data));
     };
 
     // Bypass client-side DSP during TX (#367, #1505). NR2/RN2/BNR adapt
@@ -2358,11 +2387,15 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
 #ifdef __APPLE__
         } else if (m_mnrEnabled && m_mnr) {
             QByteArray processed = m_mnr->process(pcm);
+            // Re-apply pan lost during NR mono-mix (#1460)
+            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
+                              processed.size() / (2 * static_cast<int>(sizeof(float))),
+                              sourcePan());
             writeAudio(processed);
             emit levelChanged(computeRMS(processed));
 #endif
         } else if (m_bnrEnabled && m_bnr && m_bnr->isConnected()) {
-            processBnr(pcm);
+            processBnr(pcm, source, externalSource);
             // processBnr writes audio and emits level internally
         } else {
             writeAudioAndLevel(pcm);
@@ -4644,8 +4677,12 @@ void AudioEngine::setBnrEnabled(bool on)
         // so use a large maxBlockSamples to avoid r8brain buffer overflow.
         m_bnrUp   = std::make_unique<Resampler>(24000, 48000, 16384);
         m_bnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
+        m_kiwiSdrBnrUp = std::make_unique<Resampler>(24000, 48000, 16384);
+        m_kiwiSdrBnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
         m_bnrOutBuf.clear();
+        m_kiwiSdrBnrOutBuf.clear();
         m_bnrPrimed = false;
+        m_kiwiSdrBnrPrimed = false;
         // Set flag AFTER objects are fully constructed
         m_bnrEnabled = true;
 
@@ -4665,6 +4702,10 @@ void AudioEngine::setBnrEnabled(bool on)
                         m_bnr.reset();
                         m_bnrUp.reset();
                         m_bnrDown.reset();
+                        m_kiwiSdrBnrUp.reset();
+                        m_kiwiSdrBnrDown.reset();
+                        m_kiwiSdrBnrOutBuf.clear();
+                        m_kiwiSdrBnrPrimed = false;
                         m_bnrEnabled = false;
                         emit bnrEnabledChanged(false);
                     }
@@ -4685,6 +4726,10 @@ void AudioEngine::setBnrEnabled(bool on)
         m_bnr.reset();
         m_bnrUp.reset();
         m_bnrDown.reset();
+        m_kiwiSdrBnrUp.reset();
+        m_kiwiSdrBnrDown.reset();
+        m_kiwiSdrBnrOutBuf.clear();
+        m_kiwiSdrBnrPrimed = false;
     }
     qCDebug(lcAudio) << "AudioEngine: BNR (NVIDIA NIM)" << (on ? "enabled" : "disabled");
     emit bnrEnabledChanged(on);
@@ -4710,21 +4755,50 @@ bool AudioEngine::bnrConnected() const
     return m_bnr && m_bnr->isConnected();
 }
 
-void AudioEngine::processBnr(const QByteArray& stereoPcm)
+void AudioEngine::processBnr(const QByteArray& stereoPcm,
+                             RxDspSource source,
+                             ExternalRxAudioSourceState* externalSource)
 {
     // ── Feed input to BNR container (non-blocking) ───────────────────────
+    std::vector<float>& monoScratch =
+        externalSource ? externalSource->nr2Mono : m_nr2Mono;
+    std::unique_ptr<Resampler>& bnrUp =
+        externalSource
+            ? externalSource->bnrUp
+            : (source == RxDspSource::KiwiSdr ? m_kiwiSdrBnrUp : m_bnrUp);
+    std::unique_ptr<Resampler>& bnrDown =
+        externalSource
+            ? externalSource->bnrDown
+            : (source == RxDspSource::KiwiSdr ? m_kiwiSdrBnrDown : m_bnrDown);
+    QByteArray& bnrOutBuf =
+        externalSource
+            ? externalSource->bnrOutBuf
+            : (source == RxDspSource::KiwiSdr ? m_kiwiSdrBnrOutBuf : m_bnrOutBuf);
+    bool& bnrPrimed =
+        externalSource
+            ? externalSource->bnrPrimed
+            : (source == RxDspSource::KiwiSdr ? m_kiwiSdrBnrPrimed : m_bnrPrimed);
+
+    if (!bnrUp) {
+        bnrUp = std::make_unique<Resampler>(24000, 48000, 16384);
+    }
+    if (!bnrDown) {
+        bnrDown = std::make_unique<Resampler>(48000, 24000, 16384);
+    }
 
     // 1. 24kHz stereo float32 → 24kHz mono float32 (average L+R)
     const auto* src = reinterpret_cast<const float*>(stereoPcm.constData());
     const int stereoFrames = stereoPcm.size() / (2 * static_cast<int>(sizeof(float)));
 
-    if (static_cast<int>(m_nr2Mono.size()) < stereoFrames)
-        m_nr2Mono.resize(stereoFrames);
-    for (int i = 0; i < stereoFrames; ++i)
-        m_nr2Mono[i] = (src[2 * i] + src[2 * i + 1]) * 0.5f;
+    if (static_cast<int>(monoScratch.size()) < stereoFrames) {
+        monoScratch.resize(stereoFrames);
+    }
+    for (int i = 0; i < stereoFrames; ++i) {
+        monoScratch[i] = (src[2 * i] + src[2 * i + 1]) * 0.5f;
+    }
 
     // 2. 24kHz mono float32 → 48kHz mono float32 (r8brain)
-    QByteArray mono48k = m_bnrUp->process(m_nr2Mono.data(), stereoFrames);
+    QByteArray mono48k = bnrUp->process(monoScratch.data(), stereoFrames);
 
     // 3. Already float32 — pass directly to BNR
     const auto* mono48kSrc = reinterpret_cast<const float*>(mono48k.constData());
@@ -4740,7 +4814,7 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
         const auto* df = reinterpret_cast<const float*>(denoised.constData());
         const int dn = denoised.size() / static_cast<int>(sizeof(float));
 
-        QByteArray mono24k = m_bnrDown->process(df, dn);
+        QByteArray mono24k = bnrDown->process(df, dn);
 
         // 6. Mono float32 → stereo float32 (duplicate L=R)
         const auto* m24 = reinterpret_cast<const float*>(mono24k.constData());
@@ -4752,34 +4826,45 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
             ds[2 * i + 1] = m24[i];
         }
 
-        m_bnrOutBuf.append(stereo);
+        bnrOutBuf.append(stereo);
 
         // Cap jitter buffer at ~500ms (24kHz stereo float32 = 192000 bytes/sec)
         constexpr int maxBufBytes = 96000;  // 500ms
-        if (m_bnrOutBuf.size() > maxBufBytes)
-            m_bnrOutBuf.remove(0, m_bnrOutBuf.size() - maxBufBytes);
+        if (bnrOutBuf.size() > maxBufBytes) {
+            bnrOutBuf.remove(0, bnrOutBuf.size() - maxBufBytes);
+        }
     }
 
     // ── Play from jitter buffer ──────────────────────────────────────────
 
     // Wait for ~50ms of buffered audio before starting playback (priming)
     constexpr int primeBytes = 9600;  // 50ms of 24kHz stereo float32
-    if (!m_bnrPrimed) {
-        if (m_bnrOutBuf.size() >= primeBytes)
-            m_bnrPrimed = true;
-        else
+    if (!bnrPrimed) {
+        if (bnrOutBuf.size() >= primeBytes) {
+            bnrPrimed = true;
+        } else {
             return;  // still priming — silence (no audio output)
+        }
     }
 
     // Play the same amount of audio as the incoming chunk to maintain sync
     const int wantBytes = stereoPcm.size();
-    if (m_bnrOutBuf.size() >= wantBytes) {
-        QByteArray chunk = m_bnrOutBuf.left(wantBytes);
-        m_bnrOutBuf.remove(0, wantBytes);
+    if (bnrOutBuf.size() >= wantBytes) {
+        QByteArray chunk = bnrOutBuf.left(wantBytes);
+        bnrOutBuf.remove(0, wantBytes);
+
+        const int pan = externalSource ? externalSource->pan : m_rxPan.load();
+        applyRxPanInPlace(
+            reinterpret_cast<float*>(chunk.data()),
+            chunk.size() / (2 * static_cast<int>(sizeof(float))),
+            pan);
 
         if (m_audioDevice && m_audioDevice->isOpen()) {
             const int scopeSampleRate = m_rxOutputRate.load();
-            const QByteArray& resampled = (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE) ? resampleStereo(chunk) : chunk;
+            const QByteArray& resampled =
+                (m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE)
+                    ? resampleStereo(chunk, source, externalSource)
+                    : chunk;
             const QByteArray* output = &resampled;
             QByteArray trimmed;
             const float trimDb = m_rxOutputTrimDb.load();
@@ -4789,10 +4874,17 @@ void AudioEngine::processBnr(const QByteArray& stereoPcm)
                 const auto* src = reinterpret_cast<const float*>(resampled.constData());
                 auto* dst = reinterpret_cast<float*>(trimmed.data());
                 const int nSamples = resampled.size() / static_cast<int>(sizeof(float));
-                for (int i = 0; i < nSamples; ++i) dst[i] = src[i] * gain;
+                for (int i = 0; i < nSamples; ++i) {
+                    dst[i] = src[i] * gain;
+                }
                 output = &trimmed;
             }
-            m_rxOutputBuffer.append(*output);
+            QByteArray& outputBuffer =
+                externalSource
+                    ? externalSource->outputBuffer
+                    : (source == RxDspSource::KiwiSdr ? m_kiwiSdrOutputBuffer
+                                                       : m_rxOutputBuffer);
+            outputBuffer.append(*output);
             emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
             emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
             updateRxBufferStats();

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -573,11 +573,15 @@ private:
         std::unique_ptr<SpectralNR> nr2;
         std::unique_ptr<Resampler> rxResampler;
         std::unique_ptr<Resampler> rxResamplerR;
+        std::unique_ptr<Resampler> bnrUp;
+        std::unique_ptr<Resampler> bnrDown;
+        QByteArray bnrOutBuf;
         float gain{1.0f};
         int pan{50};
         bool enabled{false};
         bool muted{false};
         bool prebuffering{false};
+        bool bnrPrimed{false};
     };
 
     QAudioFormat makeFormat() const;
@@ -799,11 +803,17 @@ private:
     std::unique_ptr<NvidiaBnrFilter> m_bnr;
     std::unique_ptr<Resampler> m_bnrUp;    // 24k→48k mono
     std::unique_ptr<Resampler> m_bnrDown;  // 48k→24k mono
+    std::unique_ptr<Resampler> m_kiwiSdrBnrUp;
+    std::unique_ptr<Resampler> m_kiwiSdrBnrDown;
     std::atomic<bool> m_bnrEnabled{false};
     QString m_bnrAddress{"localhost:8001"};
     QByteArray m_bnrOutBuf;  // jitter buffer: denoised 24kHz stereo int16
+    QByteArray m_kiwiSdrBnrOutBuf;
     bool m_bnrPrimed{false}; // true after enough denoised data accumulated
-    void processBnr(const QByteArray& stereoPcm);
+    bool m_kiwiSdrBnrPrimed{false};
+    void processBnr(const QByteArray& stereoPcm,
+                    RxDspSource source,
+                    ExternalRxAudioSourceState* externalSource = nullptr);
 
     // Client-side DFNR (DeepFilterNet3)
 #ifdef HAVE_DFNR

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -492,6 +492,7 @@ public slots:
     void setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on);
     void setKiwiSdrAudioSourceGain(const QString& sourceId, float gainPercent);
     void setKiwiSdrAudioSourceMuted(const QString& sourceId, bool muted);
+    void setKiwiSdrAudioSourcePan(const QString& sourceId, int pan);
     void removeKiwiSdrAudioSource(const QString& sourceId);
 
 signals:
@@ -573,6 +574,7 @@ private:
         std::unique_ptr<Resampler> rxResampler;
         std::unique_ptr<Resampler> rxResamplerR;
         float gain{1.0f};
+        int pan{50};
         bool enabled{false};
         bool muted{false};
         bool prebuffering{false};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5941,6 +5941,7 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     refreshKiwiSdrSlices();
     syncKiwiSdrTrackingToActiveSlice();
     refreshKiwiSdrWaterfallAvailability();
+    syncFlexRxPanToAudioEngine();
     // Sync squelch line to newly active slice (handles slice switch without waiting
     // for squelchChanged signal)
     if (auto* sw2 = spectrumForSlice(s))
@@ -7279,8 +7280,16 @@ SpectrumWidget* MainWindow::spectrumForSlice(SliceModel* s) const
     return spectrum();  // fallback to active pan
 }
 
-void MainWindow::showPanadapterInterlockNotification(const QString& message)
+void MainWindow::showPanadapterInterlockNotification(const QString& message,
+                                                     const QString& panId)
 {
+    if (!panId.trimmed().isEmpty() && m_panStack) {
+        if (SpectrumWidget* sw = m_panStack->spectrum(panId.trimmed())) {
+            sw->showInterlockNotification(message, 5000);
+            return;
+        }
+    }
+
     SliceModel* target = nullptr;
     for (auto* s : m_radioModel.slices()) {
         if (s && s->isTxSlice()) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -336,7 +336,14 @@ private:
     void clearKiwiSdrVirtualAntennaForSlice(int sliceId);
     void updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice);
     void updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice);
+    SliceModel* flexRxPanSourceSlice() const;
+    void syncFlexRxPanToAudioEngine();
+    SliceModel* kiwiSdrDisplaySliceForPan(const QString& panId) const;
     QString kiwiSdrProfileForPan(const QString& panId) const;
+    QString kiwiSdrOverlayProfileForPan(const QString& panId) const;
+    void syncKiwiSdrPanadapterTxInhibit(const QString& panId,
+                                        const QString& profileId);
+    void syncKiwiSdrDiversityEscControls();
     void syncKiwiSdrPanadapterUiState(const QString& panId);
     void syncKiwiSdrPanadapterUiStates();
     void wirePanadapter(PanadapterApplet* applet);
@@ -345,7 +352,8 @@ private:
     void scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
     void onMuteAllSlicesToggle();
-    void showPanadapterInterlockNotification(const QString& message);
+    void showPanadapterInterlockNotification(const QString& message,
+                                             const QString& panId = QString());
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();
     void refreshCwDecodeState();

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1749,7 +1749,7 @@ void MainWindow::registerMidiParams()
         [this]() -> float { return m_radioModel.transmitModel().isTuning() ? 1 : 0; });
 
     reg("tx.atuStart", "ATU Start", "TX", P::Trigger, 0, 1,
-        [this](float) { m_radioModel.sendCommand("atu start"); });
+        [this](float) { m_radioModel.transmitModel().atuStart(); });
 
     // ── Phone/CW ────────────────────────────────────────────────────────
     reg("phone.micLevel", "Mic Level", "Phone/CW", P::Slider, 0, 100,

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -16,6 +16,7 @@
 #include "models/SliceModel.h"
 
 #include <QMetaObject>
+#include <QSet>
 #include <QTimer>
 
 namespace AetherSDR {
@@ -140,6 +141,9 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
         m_kiwiSdrVirtualPreviousMute.insert(sliceId, slice->flexAudioMute());
     }
     slice->setExternalReceiveAudioReplacementMute(true);
+    if (m_appletPanel) {
+        m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+    }
 
     // Receive-only: route audio from the Kiwi profile and mute Flex audio for
     // this slice. No antenna command is sent to the radio (Principle I).
@@ -153,11 +157,15 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
         slice->filterLow(), slice->filterHigh(), slice->panId());
     updateKiwiSdrVirtualTrackingForSlice(slice);
     updateKiwiSdrVirtualAudioControlsForSlice(slice);
+    syncFlexRxPanToAudioEngine();
+    syncKiwiSdrDiversityEscControls();
 
     if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
-        spectrum->setKiwiSdrWaterfallAvailable(true);
-        spectrum->setKiwiSdrWaterfallProfile(profileId);
-        spectrum->setKiwiSdrWaterfallActive(true);
+        if (kiwiSdrDisplaySliceForPan(slice->panId()) == slice) {
+            spectrum->setKiwiSdrWaterfallAvailable(true);
+            spectrum->setKiwiSdrWaterfallProfile(profileId);
+            spectrum->setKiwiSdrWaterfallActive(true);
+        }
         if (VfoWidget* vfo = spectrum->vfoWidget(slice->sliceId())) {
             vfo->setReceiveMeterReading(
                 KiwiSdrProtocol::meterUnavailable(
@@ -189,6 +197,9 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
                 ? m_kiwiSdrVirtualPreviousMute.take(sliceId)
                 : slice->flexAudioMute();
         slice->setExternalReceiveAudioReplacementMute(false, restoreMute);
+        if (m_appletPanel) {
+            m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+        }
         if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
             setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
             spectrum->setKiwiSdrConnectionOverlay(false);
@@ -199,9 +210,69 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
     if (m_kiwiSdrManager) {
         m_kiwiSdrManager->clearSliceAssignment(sliceId);
     }
+    syncFlexRxPanToAudioEngine();
+    syncKiwiSdrDiversityEscControls();
     refreshKiwiSdrWaterfallAvailability();
     if (!panId.isEmpty()) {
         syncKiwiSdrPanadapterUiState(panId);
+    }
+}
+
+SliceModel* MainWindow::flexRxPanSourceSlice() const
+{
+    auto isFlexBacked = [this](const SliceModel* slice) {
+        return slice
+            && m_radioModel.sliceMayBelongToUs(slice->sliceId())
+            && (!m_kiwiSdrManager
+                || m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
+                       .isEmpty());
+    };
+
+    SliceModel* active = m_radioModel.slice(m_activeSliceId);
+    if (isFlexBacked(active)) {
+        return active;
+    }
+
+    if (active && active->diversity()) {
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (!isFlexBacked(slice) || !slice->diversity()
+                || slice->sliceId() == active->sliceId()) {
+                continue;
+            }
+            if ((active->isDiversityChild() && slice->isDiversityParent())
+                || (active->isDiversityParent() && slice->isDiversityChild())) {
+                return slice;
+            }
+        }
+
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (isFlexBacked(slice) && slice->diversity()
+                && slice->sliceId() != active->sliceId()) {
+                return slice;
+            }
+        }
+    }
+
+    SliceModel* onlyUnmutedFlexSlice = nullptr;
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!isFlexBacked(slice) || slice->flexAudioMute()) {
+            continue;
+        }
+        if (onlyUnmutedFlexSlice) {
+            return nullptr;
+        }
+        onlyUnmutedFlexSlice = slice;
+    }
+    return onlyUnmutedFlexSlice;
+}
+
+void MainWindow::syncFlexRxPanToAudioEngine()
+{
+    if (!m_audio) {
+        return;
+    }
+    if (SliceModel* slice = flexRxPanSourceSlice()) {
+        m_audio->setRxPan(slice->flexAudioPan());
     }
 }
 
@@ -224,8 +295,10 @@ void MainWindow::updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice)
         m_kiwiSdrManager->updateWaterfallView(
             slice->sliceId(), slice->panId(), spectrum->centerMhz(),
             spectrum->bandwidthMhz(), spectrum->wfLineDuration());
-        if (m_kiwiSdrManager->isConnected(profileId)) {
+        if (profileId == kiwiSdrProfileForPan(slice->panId())
+            && m_kiwiSdrManager->isConnected(profileId)) {
             spectrum->setKiwiSdrWaterfallAvailable(true);
+            spectrum->setKiwiSdrWaterfallProfile(profileId);
             spectrum->setKiwiSdrWaterfallActive(true);
             syncKiwiSdrAppletWaterfallState();
         }
@@ -233,35 +306,196 @@ void MainWindow::updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice)
     }
 }
 
+SliceModel* MainWindow::kiwiSdrDisplaySliceForPan(const QString& panId) const
+{
+    if (!m_kiwiSdrManager || panId.isEmpty()) {
+        return nullptr;
+    }
+
+    // Diversity pans have one visual source, and it follows the parent slice.
+    // If only the child is using Kiwi, keep the pan/FFT/waterfall on the
+    // parent's Flex source while the child contributes audio only.
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !m_radioModel.sliceMayBelongToUs(slice->sliceId())
+            || !slice->isDiversityParent()) {
+            continue;
+        }
+        return m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
+                   .isEmpty()
+            ? nullptr
+            : slice;
+    }
+
+    QVector<SliceModel*> candidates;
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            continue;
+        }
+        if (!m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
+                 .isEmpty()) {
+            candidates.append(slice);
+        }
+    }
+    if (candidates.isEmpty()) {
+        return nullptr;
+    }
+
+    if (SliceModel* active = activeSlice()) {
+        for (SliceModel* slice : candidates) {
+            if (slice == active) {
+                return slice;
+            }
+        }
+    }
+
+    SliceModel* indexedDiversitySlice = nullptr;
+    for (SliceModel* slice : candidates) {
+        if (!slice->diversity()) {
+            return slice;
+        }
+        if (!indexedDiversitySlice
+            || (slice->diversityIndex() >= 0
+                && (indexedDiversitySlice->diversityIndex() < 0
+                    || slice->diversityIndex()
+                           < indexedDiversitySlice->diversityIndex()))) {
+            indexedDiversitySlice = slice;
+        }
+    }
+
+    return indexedDiversitySlice ? indexedDiversitySlice : candidates.first();
+}
+
 QString MainWindow::kiwiSdrProfileForPan(const QString& panId) const
+{
+    SliceModel* displaySlice = kiwiSdrDisplaySliceForPan(panId);
+    if (!displaySlice || !m_kiwiSdrManager) {
+        return QString();
+    }
+    return m_kiwiSdrManager->assignedProfileForSlice(displaySlice->sliceId());
+}
+
+QString MainWindow::kiwiSdrOverlayProfileForPan(const QString& panId) const
 {
     if (!m_kiwiSdrManager || panId.isEmpty()) {
         return QString();
     }
 
-    if (SliceModel* slice = activeSlice()) {
-        if (slice->panId() == panId
-            && m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
-            const QString profileId =
-                m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
-            if (!profileId.isEmpty()) {
-                return profileId;
-            }
-        }
-    }
+    const QString displayProfileId = kiwiSdrProfileForPan(panId);
+    QSet<QString> visitedProfiles;
+    QString connectingProfileId;
+    QString disconnectedProfileId;
 
     for (SliceModel* slice : m_radioModel.slices()) {
         if (!slice || slice->panId() != panId
             || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
             continue;
         }
+
         const QString profileId =
             m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
-        if (!profileId.isEmpty()) {
+        if (profileId.isEmpty() || profileId == displayProfileId
+            || visitedProfiles.contains(profileId)) {
+            continue;
+        }
+        visitedProfiles.insert(profileId);
+
+        switch (m_kiwiSdrManager->state(profileId)) {
+        case KiwiSdrClient::State::Error:
             return profileId;
+        case KiwiSdrClient::State::Connecting:
+            if (connectingProfileId.isEmpty()) {
+                connectingProfileId = profileId;
+            }
+            break;
+        case KiwiSdrClient::State::Disconnected:
+            if (disconnectedProfileId.isEmpty()) {
+                disconnectedProfileId = profileId;
+            }
+            break;
+        case KiwiSdrClient::State::Connected:
+            break;
         }
     }
-    return QString();
+
+    return !connectingProfileId.isEmpty() ? connectingProfileId
+                                          : disconnectedProfileId;
+}
+
+void MainWindow::syncKiwiSdrPanadapterTxInhibit(const QString& panId,
+                                                const QString& profileId)
+{
+    m_radioModel.setPanTransmitInhibited(
+        panId,
+        !profileId.isEmpty(),
+        tr("Transmit is disabled because this panadapter is displaying a KiwiSDR receiver."));
+}
+
+void MainWindow::syncKiwiSdrDiversityEscControls()
+{
+    QSet<int> blockedSlices;
+    if (m_kiwiSdrManager) {
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (!slice || !slice->diversity()
+                || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+                continue;
+            }
+
+            QVector<SliceModel*> group;
+            bool groupHasKiwi = false;
+            for (SliceModel* other : m_radioModel.slices()) {
+                if (!other || !other->diversity()
+                    || !m_radioModel.sliceMayBelongToUs(other->sliceId())) {
+                    continue;
+                }
+
+                const bool samePan =
+                    !slice->panId().isEmpty()
+                    && slice->panId() == other->panId();
+                const bool parentChildPair =
+                    (slice->isDiversityParent() && other->isDiversityChild())
+                    || (slice->isDiversityChild() && other->isDiversityParent());
+                if (slice == other || samePan || parentChildPair) {
+                    group.append(other);
+                    groupHasKiwi = groupHasKiwi
+                        || !m_kiwiSdrManager
+                                ->assignedProfileForSlice(other->sliceId())
+                                .isEmpty();
+                }
+            }
+
+            if (!groupHasKiwi) {
+                continue;
+            }
+
+            for (SliceModel* member : group) {
+                blockedSlices.insert(member->sliceId());
+            }
+        }
+    }
+
+    // Disable Flex ESC before hiding the controls. Kiwi receive paths are not
+    // phase coherent with Flex RF, so an invisible enabled combiner would be
+    // misleading and could keep stale RF phase/gain state active.
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (slice && blockedSlices.contains(slice->sliceId())
+            && slice->isDiversityParent() && slice->escEnabled()) {
+            slice->setEscEnabled(false);
+        }
+    }
+
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice) {
+            continue;
+        }
+        if (SpectrumWidget* sw = spectrumForSlice(slice)) {
+            if (VfoWidget* vfo = sw->vfoWidget(slice->sliceId())) {
+                vfo->setEscControlsAvailable(
+                    !blockedSlices.contains(slice->sliceId()));
+            }
+        }
+    }
 }
 
 void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
@@ -270,15 +504,27 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
         return;
     }
 
+    const QString profileId = kiwiSdrProfileForPan(panId);
+    syncKiwiSdrPanadapterTxInhibit(panId, profileId);
+
     SpectrumWidget* spectrum = m_panStack->spectrum(panId);
     if (!spectrum) {
         return;
     }
 
-    const QString profileId = kiwiSdrProfileForPan(panId);
     SpectrumOverlayMenu* menu = spectrum->overlayMenu();
     if (profileId.isEmpty()) {
-        spectrum->setKiwiSdrConnectionOverlay(false);
+        const QString overlayProfileId = kiwiSdrOverlayProfileForPan(panId);
+        if (!overlayProfileId.isEmpty()) {
+            spectrum->setKiwiSdrConnectionOverlay(
+                true,
+                kiwiConnectionOverlayDetail(
+                    m_kiwiSdrManager->state(overlayProfileId),
+                    m_kiwiSdrManager->stateDetail(overlayProfileId)),
+                tr("Not connected to KiwiSDR"));
+        } else {
+            spectrum->setKiwiSdrConnectionOverlay(false);
+        }
         setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
         spectrum->setKiwiSdrWaterfallAvailable(false);
         spectrum->setKiwiSdrWaterfallProfile(QString());
@@ -358,10 +604,13 @@ void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice)
 
     const float gainPercent = slice->audioGain();
     const bool muted = slice->audioMute();
+    const int pan = slice->audioPan();
     QMetaObject::invokeMethod(m_audio,
-                              [audio = m_audio, profileId, gainPercent, muted]() {
+                              [audio = m_audio, profileId, gainPercent, muted, pan]() {
+        audio->setKiwiSdrAudioSourceEnabled(profileId, true);
         audio->setKiwiSdrAudioSourceGain(profileId, gainPercent);
         audio->setKiwiSdrAudioSourceMuted(profileId, muted);
+        audio->setKiwiSdrAudioSourcePan(profileId, pan);
     }, Qt::QueuedConnection);
 }
 
@@ -516,6 +765,10 @@ void MainWindow::wireKiwiSdr()
                 return;
             }
 
+            if (kiwiSdrProfileForPan(slice->panId()) != profileId) {
+                return;
+            }
+
             if (SpectrumWidget* sw = spectrumForSlice(slice)) {
                 sw->setKiwiSdrWaterfallProfile(profileId);
                 sw->updateKiwiSdrWaterfallRow(binsDbm, lowFreqMhz,
@@ -579,6 +832,10 @@ void MainWindow::wireKiwiSdr()
                 ? m_radioModel.slice(sliceId)->panId()
                 : QString();
             refreshKiwiSdrAppletReceivers();
+            syncKiwiSdrDiversityEscControls();
+            if (m_appletPanel) {
+                m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+            }
             if (!profileId.isEmpty()) {
                 syncKiwiSdrPanadapterUiState(panId);
                 return;
@@ -589,6 +846,10 @@ void MainWindow::wireKiwiSdr()
                         ? m_kiwiSdrVirtualPreviousMute.take(sliceId)
                         : slice->flexAudioMute();
                 slice->setExternalReceiveAudioReplacementMute(false, restoreMute);
+                if (m_appletPanel) {
+                    m_appletPanel->updateSliceButtons(
+                        m_radioModel.slices(), m_activeSliceId);
+                }
                 if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
                     setKiwiSdrWaterfallActive(
                         m_radioModel, slice->panId(), spectrum, false);
@@ -597,6 +858,7 @@ void MainWindow::wireKiwiSdr()
                 }
             }
             refreshKiwiSdrWaterfallAvailability();
+            syncKiwiSdrDiversityEscControls();
             syncKiwiSdrPanadapterUiState(panId);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::profileStateChanged,
@@ -621,6 +883,7 @@ void MainWindow::wireKiwiSdr()
                 }
             }
             refreshKiwiSdrWaterfallAvailability();
+            syncKiwiSdrDiversityEscControls();
             refreshKiwiSdrAppletReceivers();
             if (!panId.isEmpty()) {
                 syncKiwiSdrPanadapterUiState(panId);
@@ -677,6 +940,7 @@ void MainWindow::wireKiwiSdr()
         QTimer::singleShot(0, m_kiwiSdrManager, &KiwiSdrManager::startAutoConnect);
     }
     syncKiwiSdrPanadapterUiStates();
+    syncKiwiSdrDiversityEscControls();
 }
 
 void MainWindow::refreshKiwiSdrAppletReceivers()

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -272,8 +272,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // if the slice was destroyed and recreated (e.g. by profile global load).
     // During profile recall, RadioModel's profile-load hold suppresses this
     // slice write so it cannot fight the radio's restored profile state.
-    if (s->isTxSlice())
-        m_radioModel.sendCommand(QString("slice set %1 tx=1").arg(s->sliceId()));
+    if (s->isTxSlice()) {
+        s->setTxSlice(true);
+    }
 
     // Keep the radio-side TX DAX flag aligned when the TX slice or mode changes.
     // SmartSDR DAX2 on Windows owns both the dax_tx stream and the radio's
@@ -587,6 +588,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
         updateKiwiSdrVirtualTrackingForSlice(s);
         refreshKiwiSdrWaterfallAvailability();
         syncKiwiSdrPanadapterUiStates();
+        syncKiwiSdrDiversityEscControls();
     });
 
     // Create a VfoWidget for this slice on the correct panadapter
@@ -706,6 +708,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
     refreshKiwiSdrSlices();
     refreshKiwiSdrWaterfallAvailability();
+    syncKiwiSdrDiversityEscControls();
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -803,6 +806,7 @@ void MainWindow::onSliceRemoved(int id)
     m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
     refreshKiwiSdrSlices();
     refreshKiwiSdrWaterfallAvailability();
+    syncKiwiSdrDiversityEscControls();
 }
 
 void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
@@ -1322,6 +1326,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     auto updateKiwiWaterfallView = [this, applet, sw](double centerMhz,
                                                       double bandwidthMhz) {
         if (m_kiwiSdrManager && applet && sw) {
+            const QString displayProfileId =
+                kiwiSdrProfileForPan(applet->panId());
             for (SliceModel* slice : m_radioModel.slices()) {
                 if (!slice || slice->panId() != applet->panId()
                     || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
@@ -1335,8 +1341,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 m_kiwiSdrManager->updateWaterfallView(
                     slice->sliceId(), applet->panId(), centerMhz,
                     bandwidthMhz, sw->wfLineDuration());
-                if (m_kiwiSdrManager->isConnected(profileId)) {
+                if (profileId == displayProfileId
+                    && m_kiwiSdrManager->isConnected(profileId)) {
                     sw->setKiwiSdrWaterfallAvailable(true);
+                    sw->setKiwiSdrWaterfallProfile(profileId);
                     sw->setKiwiSdrWaterfallActive(true);
                     syncKiwiSdrAppletWaterfallState();
                 }
@@ -2723,6 +2731,13 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
     connect(s, &SliceModel::audioMuteChanged, this, [this, s](bool) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
+        syncFlexRxPanToAudioEngine();
+    });
+    connect(s, &SliceModel::audioPanChanged, this, [this, s](int) {
+        updateKiwiSdrVirtualAudioControlsForSlice(s);
+    });
+    connect(s, &SliceModel::diversityChanged, this, [this](bool) {
+        syncKiwiSdrDiversityEscControls();
     });
     connect(w, &VfoWidget::closeSliceRequested, this, [this, sliceId]() {
         if (m_radioModel.slices().size() <= 1) return;
@@ -2907,13 +2922,11 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
 
     // Pan re-apply after NR mono-mix (#1460, #1796): keep AudioEngine in sync
-    // with the radio-side pan value from ALL sources (VFO panel, RX applet,
-    // MIDI, radio echo-back on connect).  Connecting SliceModel::audioPanChanged
-    // covers every path that calls setAudioPan(); only the active slice's value
-    // matters because AudioEngine plays one slice at a time.
-    connect(s, &SliceModel::audioPanChanged, this, [this, sliceId](int v) {
-        if (sliceId == m_activeSliceId)
-            m_audio->setRxPan(v);
+    // with the active Flex-backed slice's radio-side pan value. Kiwi-backed
+    // slices update their own external source pan via
+    // updateKiwiSdrVirtualAudioControlsForSlice().
+    connect(s, &SliceModel::audioPanChanged, this, [this](int) {
+        syncFlexRxPanToAudioEngine();
     });
     connect(s, &SliceModel::rxAntennaChanged, this, [this, sliceId](const QString&) {
         if (auto* sl = m_radioModel.slice(sliceId)) {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1485,9 +1485,8 @@ void RxApplet::setMaxSlices(int maxSlices)
         m_sliceTabRow->setVisible(true);
     }
 
-    // Re-apply the all-muted dim to the freshly-rebuilt buttons so the
-    // visual stays in sync if the rebuild happens while the user is in
-    // the all-muted state.
+    // Re-apply the normal slice-tab palette after rebuild. Mute state belongs
+    // on the speaker control; the slice tabs keep their identity colours.
     refreshAllMutedDim();
 }
 
@@ -1584,9 +1583,14 @@ void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSl
     // string itself doesn't need to change for those.
     auto applyStyleIfChanged = [](QToolButton* btn, int colourIdx,
                                    const QString& stylesheet) {
+        btn->setProperty("normalStyleSheet", stylesheet);
         const QVariant prev = btn->property("colourIdx");
-        if (prev.isValid() && prev.toInt() == colourIdx) return;
+        if (prev.isValid() && prev.toInt() == colourIdx
+            && btn->styleSheet() == stylesheet) {
+            return;
+        }
         btn->setProperty("colourIdx", colourIdx);
+        btn->setProperty("sliceButtonsDimmed", false);
         btn->setStyleSheet(stylesheet);
     };
 
@@ -1695,6 +1699,8 @@ void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSl
         btn->style()->unpolish(btn);
         btn->style()->polish(btn);
     }
+
+    refreshAllMutedDim();
 }
 
 void RxApplet::setSlice(SliceModel* slice)
@@ -2876,67 +2882,34 @@ void RxApplet::updateFreqLabel()
 
 void RxApplet::refreshAllMutedDim()
 {
-    if (!m_radioModel) {
-        setSliceButtonsDimmed(false);
-        return;
-    }
-    const auto slices = m_radioModel->slices();
-    // RadioModel::slices() returns only owned slices (foreign clients are
-    // pruned on client_handle).  The dim should reflect whether every one
-    // of the user's own slices is muted — empty list means "no slices to
-    // indicate state for", treat as not-all-muted.
-    if (slices.isEmpty()) {
-        setSliceButtonsDimmed(false);
-        return;
-    }
-    bool anyUnmuted = false;
-    for (const SliceModel* s : slices) {
-        if (s && !s->audioMute()) { anyUnmuted = true; break; }
-    }
-    setSliceButtonsDimmed(!anyUnmuted);
+    // The slice tabs are identity and selection controls. Older RX Controls
+    // code greyed the entire row when all owned slices were muted, but that
+    // masked the active slice and made the buttons read as disabled. Keep the
+    // slice colours stable; mute state is shown by the speaker button.
+    setSliceButtonsDimmed(false);
 }
 
 void RxApplet::setSliceButtonsDimmed(bool dim)
 {
-    // QGraphicsOpacityEffect doesn't always compose cleanly with QSS-
-    // styled widgets on Linux X11 (the effect is silently dropped on some
-    // configurations).  Swap the stylesheet directly instead so the dim
-    // is guaranteed to render.  Each slice button's QSS carries a per-
-    // slice color baked in by setMaxSlices, so cache that original on
-    // first-dim and restore it on un-dim.
+    Q_UNUSED(dim);
     for (QToolButton* btn : m_sliceBtns) {
-        if (!btn) continue;
-        const QVariant cached = btn->property("originalStyleSheet");
-        if (cached.isNull())
-            btn->setProperty("originalStyleSheet", btn->styleSheet());
-        if (dim) {
-            // Uniform dark gray, no per-slice color — visually
-            // distinct from the foreign-slot grey and the empty-slot
-            // look so the operator can tell at a glance: "all my
-            // receivers are muted."
-            btn->setStyleSheet(
-                "QToolButton { background: #15181c; color: #383d44; "
-                "border: 1px solid #2a2e34; border-radius: 3px; "
-                "font-weight: bold; font-size: 10px; padding: 0; }"
-                "QToolButton:checked { background: #25292f; color: #4a5058; "
-                "border: 1px solid #383d44; }");
-        } else {
-            btn->setStyleSheet(cached.toString());
+        if (!btn) {
+            continue;
+        }
+        btn->setProperty("sliceButtonsDimmed", false);
+        const QVariant normal = btn->property("normalStyleSheet");
+        if (normal.isValid()) {
+            btn->setStyleSheet(normal.toString());
         }
     }
-    // Slice badge (shown on single-slice radios) — same uniform dim.
     if (m_sliceBadge) {
         const QVariant cached = m_sliceBadge->property("originalStyleSheet");
-        if (cached.isNull())
+        if (cached.isNull()) {
             m_sliceBadge->setProperty("originalStyleSheet",
                                        m_sliceBadge->styleSheet());
-        if (dim) {
-            m_sliceBadge->setStyleSheet(
-                "QLabel { background: #25292f; color: #4a5058; "
-                "border-radius: 3px; font-weight: bold; font-size: 11px; }");
-        } else {
-            m_sliceBadge->setStyleSheet(cached.toString());
         }
+        m_sliceBadge->setStyleSheet(
+            m_sliceBadge->property("originalStyleSheet").toString());
     }
 }
 

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -178,11 +178,9 @@ private:
     static QString formatHz(int hz);
     static QString formatStepLabel(int hz);
 
-    // Recomputes the "all owned slices muted" state from RadioModel and
-    // dims the slice-tab buttons accordingly.  Called on any owned-slice
-    // audioMuteChanged + on slice add/remove + after slice-button rebuild.
-    // The dim is the visual ack the user gets after a double-click on
-    // m_muteBtn that toggles every slice.
+    // Keeps slice-tab styling on the normal slice identity palette. The
+    // speaker button owns mute feedback; slice letters must not grey out and
+    // read as disabled after mute-all or Kiwi receive routing changes.
     void refreshAllMutedDim();
     void setSliceButtonsDimmed(bool dim);
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -868,7 +868,7 @@ void VfoWidget::buildUI()
     m_playBtn->setAccessibleName("Play recorded audio");
     m_dbmLabel->setAccessibleName("Signal level dBm");
 
-    adjustSize();
+    relayoutToCurrentContent();
 }
 
 // ── Tab content ───────────────────────────────────────────────────────────────
@@ -1154,11 +1154,7 @@ void VfoWidget::buildTabContent()
         connect(m_divBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_slice)
                 m_slice->setDiversity(on);
-            // ESC panel only on diversity parent, not child
-            m_escPanel->setVisible(on && m_slice && !m_slice->isDiversityChild());
-            // setVisible() only posts a LayoutRequest; adjustSize() activates the
-            // layout first so the panel collapses immediately (#3383)
-            adjustSize();
+            syncEscPanelVisibility();
         });
         connect(m_escBtn, &QPushButton::toggled, this, [this](bool on) {
             if (!m_updatingFromModel && m_slice)
@@ -2082,7 +2078,7 @@ void VfoWidget::showTab(int index)
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
     }
-    adjustSize();
+    relayoutToCurrentContent();
 }
 
 // ── Collapsed flag toggle ─────────────────────────────────────────────────────
@@ -2248,7 +2244,7 @@ void VfoWidget::setCollapsed(bool collapsed)
         syncFromSlice();
     }
 
-    adjustSize();
+    relayoutToCurrentContent();
     update();
 
     // Trigger parent repaint so SpectrumWidget repositions us and the freq label
@@ -2261,11 +2257,116 @@ void VfoWidget::setCollapsed(bool collapsed)
 
 void VfoWidget::setDiversityAllowed(bool allowed)
 {
+    m_diversityAllowed = allowed;
     if (m_divBtn) m_divBtn->setVisible(allowed);
-    // ESC panel only visible when DIV is active on a dual-SCU radio
-    if (m_escPanel && !allowed) {
-        m_escPanel->setVisible(false);
-        adjustSize();  // flush pending layout before sizing (#3383)
+    syncEscPanelVisibility();
+}
+
+void VfoWidget::setEscControlsAvailable(bool available)
+{
+    if (m_escControlsAvailable == available) {
+        return;
+    }
+    m_escControlsAvailable = available;
+    syncEscPanelVisibility();
+}
+
+void VfoWidget::syncEscPanelVisibility()
+{
+    if (!m_escPanel) {
+        return;
+    }
+
+    const bool showEscPanel =
+        m_diversityAllowed
+        && m_escControlsAvailable
+        && m_slice
+        && m_slice->diversity()
+        && !m_slice->isDiversityChild();
+
+    if (showEscPanel) {
+        m_escPanel->setMinimumHeight(0);
+        m_escPanel->setMaximumHeight(QWIDGETSIZE_MAX);
+        m_escPanel->setEnabled(true);
+    } else {
+        // This page is an overlay, not a normal window-managed layout. Force
+        // hidden ESC controls to contribute zero height so the VFO flag shrinks
+        // immediately when Kiwi receive makes ESC unavailable.
+        m_escPanel->setEnabled(false);
+        m_escPanel->setMinimumHeight(0);
+        m_escPanel->setMaximumHeight(0);
+    }
+    m_escPanel->setVisible(showEscPanel);
+    relayoutToCurrentContent();
+}
+
+void VfoWidget::syncTabStackHeightToCurrentPage()
+{
+    if (!m_tabStack) {
+        return;
+    }
+    if (!m_tabStack->isVisible()) {
+        m_tabStack->setMinimumHeight(0);
+        m_tabStack->setMaximumHeight(QWIDGETSIZE_MAX);
+        for (int i = 0; i < m_tabStack->count(); ++i) {
+            if (QWidget* tab = m_tabStack->widget(i)) {
+                tab->setMinimumHeight(0);
+                tab->setMaximumHeight(QWIDGETSIZE_MAX);
+            }
+        }
+        return;
+    }
+
+    QWidget* page = m_tabStack->currentWidget();
+    if (!page) {
+        return;
+    }
+    for (int i = 0; i < m_tabStack->count(); ++i) {
+        if (QWidget* tab = m_tabStack->widget(i)) {
+            tab->setMinimumHeight(0);
+            tab->setMaximumHeight(QWIDGETSIZE_MAX);
+        }
+    }
+    if (page->layout()) {
+        page->layout()->invalidate();
+        page->layout()->activate();
+    }
+
+    const int pageHeight = page->layout()
+        ? qMax(page->layout()->minimumSize().height(), page->layout()->sizeHint().height())
+        : page->sizeHint().height();
+    if (pageHeight > 0) {
+        page->setMinimumHeight(pageHeight);
+        page->setMaximumHeight(pageHeight);
+        page->resize(page->width(), pageHeight);
+        m_tabStack->setMinimumHeight(pageHeight);
+        m_tabStack->setMaximumHeight(pageHeight);
+        m_tabStack->resize(m_tabStack->width(), pageHeight);
+    }
+}
+
+void VfoWidget::relayoutToCurrentContent()
+{
+    syncTabStackHeightToCurrentPage();
+    if (layout()) {
+        layout()->invalidate();
+        layout()->activate();
+    }
+    if (!m_collapsed) {
+        setMinimumHeight(0);
+        setMaximumHeight(QWIDGETSIZE_MAX);
+        const int desiredHeight = sizeHint().height();
+        if (desiredHeight > 0) {
+            setFixedHeight(desiredHeight);
+            setGeometry(x(), y(), width(), desiredHeight);
+        } else {
+            adjustSize();
+        }
+    }
+    updateGeometry();
+    update();
+    if (parentWidget()) {
+        parentWidget()->update();
     }
 }
 
@@ -2877,7 +2978,7 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_nrfBtn->setVisible(!isFm && m_hasExtendedDsp);
         relayoutDspGrid();
         updateFilterLabel();
-        if (m_tabStack->isVisible()) adjustSize();
+        if (m_tabStack->isVisible()) relayoutToCurrentContent();
     });
     // Filter
     connect(m_slice, &SliceModel::filterChanged, this, [this](int, int) {
@@ -2921,8 +3022,7 @@ void VfoWidget::setSlice(SliceModel* slice)
     connect(m_slice, &SliceModel::diversityChanged, this, [this](bool on) {
         QSignalBlocker sb(m_divBtn);
         m_divBtn->setChecked(on);
-        m_escPanel->setVisible(on && !m_slice->isDiversityChild());
-        adjustSize();  // flush pending layout before sizing (#3383)
+        syncEscPanelVisibility();
     });
     // ESC sync — phase is in radians, display as degrees
     {
@@ -2944,7 +3044,7 @@ void VfoWidget::setSlice(SliceModel* slice)
         m_escPhaseLbl->setText(QString::number(deg) + QChar(0x00B0));
         m_phaseKnob->setPhase(rad);
     }
-    m_escPanel->setVisible(m_slice->diversity() && !m_slice->isDiversityChild());
+    syncEscPanelVisibility();
     connect(m_slice, &SliceModel::escEnabledChanged, this, [this](bool on) {
         m_updatingFromModel = true;
         QSignalBlocker sb(m_escBtn);
@@ -3329,7 +3429,7 @@ void VfoWidget::syncFromSlice()
         m_escPhaseLbl->setText(QString::number(deg) + QChar(0x00B0));
         m_phaseKnob->setPhase(rad);
     }
-    m_escPanel->setVisible(m_slice->diversity() && !m_slice->isDiversityChild());
+    syncEscPanelVisibility();
 
     // DSP
     auto syncDsp = [](QPushButton* btn, bool on) {
@@ -4359,7 +4459,7 @@ void VfoWidget::setRadeActive(bool on, const QString& label)
             m_radeCallsignLabel->hide();
         }
     }
-    resize(sizeHint());
+    relayoutToCurrentContent();
 }
 
 void VfoWidget::setRadeSynced(bool synced)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -79,6 +79,7 @@ public:
     // overlay menu and the AetherDSP applet only.
     void setAfGain(int pct);
     void setEscLevel(float dbm);
+    void setEscControlsAvailable(bool available);
     void syncFromSlice();
     void setRecordOn(bool on);
     void setPlayOn(bool on);
@@ -260,6 +261,11 @@ private:
     QLabel*      m_escDbmLbl{nullptr};
     QWidget*     m_escMeterBar{nullptr};
     float        m_escLevelDbm{-130.0f};
+    bool         m_diversityAllowed{true};
+    bool         m_escControlsAvailable{true};
+    void syncEscPanelVisibility();
+    void syncTabStackHeightToCurrentPage();
+    void relayoutToCurrentContent();
     QPushButton* m_sqlBtn{nullptr};
     QPointer<RxApplet> m_rxApplet;       // source-of-truth for 3-way SQL state
     QLabel*      m_sqlValueLbl{nullptr}; // captured during buildUI() for syncSqlVisuals

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -954,13 +954,16 @@ QString RadioModel::localPttInterlockMessage(TransmitModel::PttSource source) co
     }
 
     // CAT/DAX PTT callers acknowledge the request before the asynchronous
-    // model path runs, so local preflight must not silently eat their PTT.
-    // Let the radio be authoritative and report any resulting interlock.
-    if (source == TransmitModel::PttSource::Dax)
+    // model path runs, so legacy local voice-mode preflight must not silently
+    // eat their PTT. Pan-level receive-only TX inhibits above still apply.
+    // Otherwise let the radio be authoritative and report any interlock.
+    if (source == TransmitModel::PttSource::Dax) {
         return QString();
+    }
 
-    if (!s)
+    if (!s) {
         return QStringLiteral("No transmit slice is assigned.");
+    }
 
     const QString mode = s->mode().toUpper();
     const bool nonVoiceSource = (source == TransmitModel::PttSource::Tune

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -12,6 +12,7 @@
 #include "ProfileLoadCommand.h"
 #include "RadioStatusOwnership.h"
 #include "SliceRecreatePolicy.h"
+#include "TransmitInhibitPolicy.h"
 #include <QCoreApplication>
 #include <QDebug>
 #include <QJsonArray>
@@ -439,8 +440,12 @@ RadioModel::RadioModel(QObject* parent)
 
     // Forward tuner commands to the radio — route through tune inhibit check
     connect(&m_tunerModel, &TunerModel::commandReady, this, [this](const QString& cmd){
-        if (cmd.startsWith("tgxl autotune"))
+        if (cmd.startsWith("tgxl autotune")) {
+            if (transmitStartBlockedByInhibit(QStringLiteral("tgxl-autotune"))) {
+                return;
+            }
             applyTuneInhibit();
+        }
         sendCmd(cmd);
     });
 
@@ -456,9 +461,11 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_transmitModel, &TransmitModel::pttBlocked,
             this, [this](const QString& message) {
         m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
+        const QString panId = txSlice() ? txSlice()->panId() : QString();
         emitInterlockNotification(
             message,
-            QStringLiteral("local-ptt:%1").arg(message));
+            QStringLiteral("local-ptt:%1:%2").arg(panId, message),
+            panId);
     });
 
     // Forward transmit model commands to the radio
@@ -487,6 +494,12 @@ RadioModel::RadioModel(QObject* parent)
         if (match.hasMatch()) {
             const bool tx = (match.captured(1) == "1");
             if (tx) {
+                if (transmitStartBlockedByInhibit(QStringLiteral("xmit"))) {
+                    m_pendingTransmitPreflightSource =
+                        TransmitModel::PttSource::Mox;
+                    m_txRequested = false;
+                    return;
+                }
                 armInterlockNotification(m_pendingTransmitPreflightSource);
                 m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
             }
@@ -497,6 +510,9 @@ RadioModel::RadioModel(QObject* parent)
             }
         }
         if (cmd == "transmit tune 1" || cmd == "atu start") {
+            if (transmitStartBlockedByInhibit(QStringLiteral("tune-start"))) {
+                return;
+            }
             armInterlockNotification(m_pendingTransmitPreflightSource);
             m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
             applyTuneInhibit();
@@ -807,15 +823,142 @@ SliceModel* RadioModel::txSlice() const
     return nullptr;
 }
 
+void RadioModel::setPanTransmitInhibited(const QString& panId,
+                                         bool inhibited,
+                                         const QString& reason)
+{
+    const QString trimmedPanId = panId.trimmed();
+    if (trimmedPanId.isEmpty()) {
+        return;
+    }
+
+    if (!inhibited) {
+        m_panTransmitInhibitReasons.remove(trimmedPanId);
+        return;
+    }
+
+    const QString trimmedReason = reason.trimmed().isEmpty()
+        ? QStringLiteral("Transmit is disabled because this panadapter is displaying receive-only data.")
+        : reason.trimmed();
+    if (m_panTransmitInhibitReasons.value(trimmedPanId) == trimmedReason) {
+        return;
+    }
+    m_panTransmitInhibitReasons.insert(trimmedPanId, trimmedReason);
+    enforceTransmitInhibitForPan(trimmedPanId);
+}
+
+bool RadioModel::panTransmitInhibited(const QString& panId) const
+{
+    return m_panTransmitInhibitReasons.contains(panId.trimmed());
+}
+
+QString RadioModel::panTransmitInhibitReason(const QString& panId) const
+{
+    return m_panTransmitInhibitReasons.value(panId.trimmed());
+}
+
+QString RadioModel::transmitInhibitMessageForSlice(const SliceModel* slice) const
+{
+    if (!slice) {
+        return QString();
+    }
+    return panTransmitInhibitReason(slice->panId()).trimmed();
+}
+
+QString RadioModel::transmitInhibitMessageForTxSlice() const
+{
+    return transmitInhibitMessageForSlice(txSlice());
+}
+
+void RadioModel::enforceTransmitInhibitForPan(const QString& panId)
+{
+    if (!panTransmitInhibited(panId)) {
+        return;
+    }
+
+    for (SliceModel* slice : m_slices) {
+        if (slice && slice->panId() == panId
+            && sliceMayBelongToUs(slice->sliceId())) {
+            enforceTransmitInhibitForSlice(slice);
+        }
+    }
+}
+
+void RadioModel::enforceTransmitInhibitForSlice(SliceModel* slice)
+{
+    if (!slice || !slice->isTxSlice()
+        || !sliceMayBelongToUs(slice->sliceId())) {
+        return;
+    }
+
+    const QString message = transmitInhibitMessageForSlice(slice);
+    if (message.isEmpty()) {
+        return;
+    }
+
+    emitInterlockNotification(
+        message,
+        QStringLiteral("pan-tx-inhibit:%1").arg(slice->panId()),
+        slice->panId());
+    sendCmd(QStringLiteral("slice set %1 tx=0").arg(slice->sliceId()));
+}
+
+bool RadioModel::transmitStartBlockedByInhibit(const QString& key)
+{
+    SliceModel* target = txSlice();
+    const QString message = transmitInhibitMessageForSlice(target);
+    if (message.isEmpty()) {
+        return false;
+    }
+
+    const QString panId = target ? target->panId() : QString();
+    emitInterlockNotification(
+        message,
+        QStringLiteral("pan-tx-inhibit:%1:%2").arg(panId, key),
+        panId);
+    m_transmitModel.setTransmitting(false);
+    if (m_txAudioGate) {
+        m_txAudioGate = false;
+        emit txAudioGateChanged(false);
+    }
+    return true;
+}
+
+void RadioModel::sendSliceCommand(SliceModel* slice, const QString& cmd)
+{
+    const TransmitInhibitPolicy::SliceTxCommand txCommand =
+        TransmitInhibitPolicy::parseSliceTxCommand(cmd);
+    if (txCommand.valid && txCommand.txEnabled) {
+        SliceModel* target = slice && slice->sliceId() == txCommand.sliceId
+            ? slice
+            : this->slice(txCommand.sliceId);
+        const QString message = transmitInhibitMessageForSlice(target);
+        if (!message.isEmpty()) {
+            emitInterlockNotification(
+                message,
+                QStringLiteral("pan-tx-inhibit:%1").arg(target->panId()),
+                target->panId());
+            return;
+        }
+    }
+
+    sendCmd(cmd);
+}
+
 QString RadioModel::localPttInterlockMessage(TransmitModel::PttSource source) const
 {
+    auto* s = txSlice();
+    if (const QString message = transmitInhibitMessageForSlice(s);
+        !message.isEmpty()) {
+        return message;
+    }
+
     // CAT/DAX PTT callers acknowledge the request before the asynchronous
     // model path runs, so local preflight must not silently eat their PTT.
     // Let the radio be authoritative and report any resulting interlock.
     if (source == TransmitModel::PttSource::Dax)
         return QString();
 
-    auto* s = txSlice();
     if (!s)
         return QStringLiteral("No transmit slice is assigned.");
 
@@ -950,7 +1093,9 @@ bool RadioModel::interlockNotificationArmed() const
     return QDateTime::currentMSecsSinceEpoch() <= m_interlockNotificationArmedUntilMs;
 }
 
-void RadioModel::emitInterlockNotification(const QString& message, const QString& key)
+void RadioModel::emitInterlockNotification(const QString& message,
+                                           const QString& key,
+                                           const QString& panId)
 {
     const QString trimmed = message.trimmed();
     if (trimmed.isEmpty())
@@ -965,7 +1110,7 @@ void RadioModel::emitInterlockNotification(const QString& message, const QString
 
     m_lastInterlockNotificationKey = effectiveKey;
     m_lastInterlockNotificationMs = now;
-    emit interlockNotificationRequested(trimmed);
+    emit interlockNotificationRequested(trimmed, panId.trimmed());
 }
 
 // ─── Actions ──────────────────────────────────────────────────────────────────
@@ -1296,9 +1441,11 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
     if (tx) {
         const QString message = localPttInterlockMessage(source);
         if (!message.isEmpty()) {
+            const QString panId = txSlice() ? txSlice()->panId() : QString();
             emitInterlockNotification(
                 message,
-                QStringLiteral("local-ptt:%1").arg(message));
+                QStringLiteral("local-ptt:%1:%2").arg(panId, message),
+                panId);
             m_transmitModel.setTransmitting(false);
             return;
         }
@@ -1920,6 +2067,7 @@ void RadioModel::stageSessionModelsForReconnect()
     m_ownedSliceIds.clear();
     m_foreignSliceOwners.clear();
     m_pendingPanStatuses.clear();
+    m_panTransmitInhibitReasons.clear();
     m_activePanId.clear();
 
     if (!m_staleSlices.isEmpty() || !m_stalePanadapters.isEmpty()) {
@@ -2441,7 +2589,7 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
 
                         for (auto* s : m_slices) {
                             for (const QString& cmd : s->drainPendingCommands())
-                                sendCmd(cmd);
+                                sendSliceCommand(s, cmd);
                         }
 
                         // Create remote_audio_rx if PC Audio is enabled. Defer briefly so
@@ -4292,6 +4440,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // with no '=' so the parser puts the whole string in 'object'
             if (kvs.contains("removed") || object.endsWith("removed")) {
                 m_pendingPanStatuses.remove(panId);
+                m_panTransmitInhibitReasons.remove(panId);
                 auto* pan = m_panadapters.take(panId);
                 if (!pan) {
                     pan = m_stalePanadapters.take(panId);
@@ -4356,6 +4505,7 @@ void RadioModel::onStatusReceived(const QString& object,
                     m_stalePanadapters.erase(it);
                 }
                 if (rejectedPan) {
+                    m_panTransmitInhibitReasons.remove(panId);
                     m_panStream->unregisterPanStream(rejectedPan->panStreamId());
                     m_panStream->unregisterWfStream(rejectedPan->wfStreamId());
                     qCDebug(lcProtocol) << "RadioModel: panadapter" << panId
@@ -5120,8 +5270,8 @@ void RadioModel::handleSliceStatus(int id,
         } else {
             s = new SliceModel(id, this);
             // Forward slice commands to the radio
-            connect(s, &SliceModel::commandReady, this, [this](const QString& cmd){
-                sendCmd(cmd);
+            connect(s, &SliceModel::commandReady, this, [this, s](const QString& cmd){
+                sendSliceCommand(s, cmd);
             });
             connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
                 m_meterModel.setActiveTxSlice(activeTxSliceNum());
@@ -5131,9 +5281,11 @@ void RadioModel::handleSliceStatus(int id,
         m_slices.append(s);
         s->applyStatus(kvs);  // populate frequency/mode before notifying UI
         m_meterModel.setActiveTxSlice(activeTxSliceNum());
+        enforceTransmitInhibitForSlice(s);
         if (!reclaimed) {
             emit sliceAdded(s);
         } else if (s->isTxSlice()
+                   && transmitInhibitMessageForSlice(s).isEmpty()
                    && QDateTime::currentMSecsSinceEpoch() >= m_profileLoadRadioStateWriteHoldUntilMs) {
             // Re-claim TX after a radio reboot (#145 semantics): the radio
             // recreates a stale slice model with tx=1 but tx_client_handle
@@ -5147,6 +5299,7 @@ void RadioModel::handleSliceStatus(int id,
 
     s->applyStatus(kvs);
     m_meterModel.setActiveTxSlice(activeTxSliceNum());
+    enforceTransmitInhibitForSlice(s);
 
     // Aurora/AU-520: max_internal_pa_power in slice status reports the true
     // system power capability (e.g. 500W) while transmit status max_power_level
@@ -5161,7 +5314,7 @@ void RadioModel::handleSliceStatus(int id,
     // Send any queued commands (e.g. if GUI changed freq before status arrived)
     if (isConnected()) {
         for (const QString& cmd : s->drainPendingCommands())
-            sendCmd(cmd);
+            sendSliceCommand(s, cmd);
     }
 }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QList>
 #include <QJsonObject>
+#include <QHash>
 #include <QMap>
 #include <QSet>
 #include <functional>
@@ -285,6 +286,11 @@ public:
     QList<SliceModel*> slices() const { return m_slices; }
     SliceModel* slice(int id) const;
     int activeTxSliceNum() const;
+    void setPanTransmitInhibited(const QString& panId,
+                                 bool inhibited,
+                                 const QString& reason = {});
+    bool panTransmitInhibited(const QString& panId) const;
+    QString panTransmitInhibitReason(const QString& panId) const;
 
     // Multi-Flex slot occupancy.  These let UI distinguish three slot
     // states for any global slice index: ours (we have a SliceModel for
@@ -463,7 +469,7 @@ signals:
     // Raw interlock TX state (regardless of ownership — for DAX passthrough).
     void radioTransmittingChanged(bool transmitting);
     // Short operator-facing interlock warnings for the panadapter overlay.
-    void interlockNotificationRequested(const QString& message);
+    void interlockNotificationRequested(const QString& message, const QString& panId);
     // Emitted when global profile list or active profile changes.
     void globalProfilesChanged();
     void profileDatabaseImportingChanged(bool importing);
@@ -754,6 +760,7 @@ private:
         bool    tx3{false};
     };
     QMap<int, TxBandInfo> m_txBandSettings;
+    QHash<QString, QString> m_panTransmitInhibitReasons;
     int  m_tuneInhibitBandId{-1};  // band ID whose TX outputs were inhibited during tune
     bool m_tuneInhibitActive{false};
 
@@ -761,12 +768,20 @@ private:
     void applyTuneInhibit();    // suppress selected TX outputs before tune
     void restoreTuneInhibit();  // re-enable TX outputs after tune
     SliceModel* txSlice() const;
+    QString transmitInhibitMessageForSlice(const SliceModel* slice) const;
+    QString transmitInhibitMessageForTxSlice() const;
+    void enforceTransmitInhibitForPan(const QString& panId);
+    void enforceTransmitInhibitForSlice(SliceModel* slice);
+    bool transmitStartBlockedByInhibit(const QString& key);
+    void sendSliceCommand(SliceModel* slice, const QString& cmd);
     QString localPttInterlockMessage(TransmitModel::PttSource source) const;
     QString txFilterFrequencyLimitMessage(int lowHz, int highHz) const;
     QString radioInterlockNotificationMessage(const QMap<QString, QString>& kvs) const;
     void armInterlockNotification(TransmitModel::PttSource source = TransmitModel::PttSource::Mox);
     bool interlockNotificationArmed() const;
-    void emitInterlockNotification(const QString& message, const QString& key);
+    void emitInterlockNotification(const QString& message,
+                                   const QString& key,
+                                   const QString& panId = QString());
 
 public:
     const QMap<int, TxBandInfo>& txBandSettings() const { return m_txBandSettings; }

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -517,8 +517,10 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
 {
     const bool previousVisibleMute = audioMute();
     const float previousVisibleGain = audioGain();
+    const int previousVisiblePan = audioPan();
     if (active) {
         m_externalReceiveAudioGain = m_audioGain;
+        m_externalReceiveAudioPan = m_audioPan;
         m_externalReceiveAudioMute = false;
         m_externalReceiveAudioReplacement = true;
         if (!m_audioMute) {
@@ -539,6 +541,9 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
     }
     if (audioGain() != previousVisibleGain) {
         emit audioGainChanged(audioGain());
+    }
+    if (audioPan() != previousVisiblePan) {
+        emit audioPanChanged(audioPan());
     }
 }
 
@@ -583,6 +588,15 @@ void SliceModel::setEscPhaseShift(float deg)
 void SliceModel::setAudioPan(int pan)
 {
     pan = qBound(0, pan, 100);
+    if (m_externalReceiveAudioReplacement) {
+        if (m_externalReceiveAudioPan == pan) {
+            return;
+        }
+        m_externalReceiveAudioPan = pan;
+        emit audioPanChanged(m_externalReceiveAudioPan);
+        return;
+    }
+
     if (m_audioPan == pan) return;
     m_audioPan = pan;
     sendCommand(QString("slice set %1 audio_pan=%2").arg(m_id).arg(pan));
@@ -708,8 +722,11 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
         }
     }
     if (kvs.contains("audio_pan")) {
+        const int previousVisiblePan = audioPan();
         m_audioPan = kvs["audio_pan"].toInt();
-        emit audioPanChanged(m_audioPan);
+        if (audioPan() != previousVisiblePan) {
+            emit audioPanChanged(audioPan());
+        }
     }
     if (kvs.contains("audio_mute")) {
         bool mute = kvs["audio_mute"] == "1";

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -47,7 +47,10 @@ public:
                                       ? m_externalReceiveAudioGain
                                       : m_audioGain; }
     float   flexAudioGain() const { return m_audioGain; }
-    int     audioPan()   const { return m_audioPan; }
+    int     audioPan()   const { return m_externalReceiveAudioReplacement
+                                      ? m_externalReceiveAudioPan
+                                      : m_audioPan; }
+    int     flexAudioPan() const { return m_audioPan; }
 
     // Getters — RX DSP state
     QString rxAntenna()   const { return m_rxAntenna; }
@@ -296,6 +299,7 @@ private:
     bool    m_externalReceiveAudioReplacement{false};
     bool    m_externalReceiveAudioMute{false};
     float   m_externalReceiveAudioGain{70.0f};
+    int     m_externalReceiveAudioPan{50};
     bool    m_diversity{false};
     bool    m_diversityChild{false};
     bool    m_diversityParent{false};

--- a/src/models/TransmitInhibitPolicy.h
+++ b/src/models/TransmitInhibitPolicy.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "core/CommandParser.h"
+
+#include <QMap>
+#include <QRegularExpression>
+#include <QString>
+
+namespace AetherSDR::TransmitInhibitPolicy {
+
+struct SliceTxCommand {
+    bool valid{false};
+    int sliceId{-1};
+    bool txEnabled{false};
+};
+
+inline SliceTxCommand parseSliceTxCommand(const QString& command)
+{
+    static const QRegularExpression kSliceSetRe(
+        QStringLiteral(R"(^\s*slice\s+set\s+(\d+)\s+(.+?)\s*$)"),
+        QRegularExpression::CaseInsensitiveOption);
+
+    const QRegularExpressionMatch match = kSliceSetRe.match(command);
+    if (!match.hasMatch()) {
+        return {};
+    }
+
+    bool ok = false;
+    const int sliceId = match.captured(1).toInt(&ok);
+    if (!ok) {
+        return {};
+    }
+
+    const QMap<QString, QString> kvs =
+        CommandParser::parseKVs(match.captured(2));
+    if (!kvs.contains(QStringLiteral("tx"))) {
+        return {};
+    }
+
+    const QString tx = kvs.value(QStringLiteral("tx")).trimmed();
+    if (tx != QStringLiteral("0") && tx != QStringLiteral("1")) {
+        return {};
+    }
+
+    return {.valid = true,
+            .sliceId = sliceId,
+            .txEnabled = tx == QStringLiteral("1")};
+}
+
+} // namespace AetherSDR::TransmitInhibitPolicy

--- a/tests/slice_model_letter_test.cpp
+++ b/tests/slice_model_letter_test.cpp
@@ -94,6 +94,55 @@ int main(int argc, char** argv)
         EXPECT_EQ(spy.count(), 0);
     }
 
+    // ── External receive replacement (KiwiSDR virtual antenna) owns visible
+    // audio pan locally. It must not send audio_pan commands to the Flex radio
+    // while Flex audio is silently muted for the same slice.
+    {
+        SliceModel s(4);
+        QStringList commands;
+        QObject::connect(&s, &SliceModel::commandReady,
+                         [&commands](const QString& cmd) { commands.append(cmd); });
+        s.applyStatus(kv({{"audio_pan", "25"}}));
+        EXPECT_EQ(s.audioPan(), 25);
+        EXPECT_EQ(s.flexAudioPan(), 25);
+
+        QSignalSpy panSpy(&s, &SliceModel::audioPanChanged);
+        s.setExternalReceiveAudioReplacementMute(true);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 4 audio_mute=1"));
+        EXPECT_EQ(s.audioPan(), 25);
+        EXPECT_EQ(s.flexAudioPan(), 25);
+        EXPECT_EQ(panSpy.count(), 0);
+        commands.clear();
+
+        s.setAudioPan(80);
+        EXPECT_EQ(s.audioPan(), 80);
+        EXPECT_EQ(s.flexAudioPan(), 25);
+        EXPECT_EQ(commands.join(QStringLiteral("|")), QString());
+        EXPECT_EQ(panSpy.count(), 1);
+        EXPECT_EQ(panSpy.takeFirst().at(0).toInt(), 80);
+
+        s.applyStatus(kv({{"audio_pan", "10"}}));
+        EXPECT_EQ(s.audioPan(), 80);
+        EXPECT_EQ(s.flexAudioPan(), 10);
+        EXPECT_EQ(panSpy.count(), 0);
+
+        s.setExternalReceiveAudioReplacementMute(false, false);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 4 audio_mute=0"));
+        EXPECT_EQ(s.audioPan(), 10);
+        EXPECT_EQ(s.flexAudioPan(), 10);
+        EXPECT_EQ(panSpy.count(), 1);
+        EXPECT_EQ(panSpy.takeFirst().at(0).toInt(), 10);
+        commands.clear();
+
+        s.setAudioPan(60);
+        EXPECT_EQ(s.audioPan(), 60);
+        EXPECT_EQ(s.flexAudioPan(), 60);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 4 audio_pan=60"));
+    }
+
     if (g_failures == 0) {
         std::printf("slice_model_letter_test: all checks passed\n");
         return 0;

--- a/tests/transmit_inhibit_policy_test.cpp
+++ b/tests/transmit_inhibit_policy_test.cpp
@@ -1,0 +1,55 @@
+#include "models/TransmitInhibitPolicy.h"
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    {
+        const auto parsed = TransmitInhibitPolicy::parseSliceTxCommand(
+            QStringLiteral("slice set 3 tx=1"));
+        ok &= expect(parsed.valid && parsed.sliceId == 3 && parsed.txEnabled,
+                     "parses tx enable command");
+    }
+
+    {
+        const auto parsed = TransmitInhibitPolicy::parseSliceTxCommand(
+            QStringLiteral(" slice   set   12   audio_gain=50 tx=1 "));
+        ok &= expect(parsed.valid && parsed.sliceId == 12 && parsed.txEnabled,
+                     "parses tx enable among other keys");
+    }
+
+    {
+        const auto parsed = TransmitInhibitPolicy::parseSliceTxCommand(
+            QStringLiteral("slice set 3 tx=0"));
+        ok &= expect(parsed.valid && parsed.sliceId == 3 && !parsed.txEnabled,
+                     "parses tx disable command");
+    }
+
+    {
+        const auto parsed = TransmitInhibitPolicy::parseSliceTxCommand(
+            QStringLiteral("slice set 3 audio_gain=50"));
+        ok &= expect(!parsed.valid, "ignores non-TX slice command");
+    }
+
+    {
+        const auto parsed = TransmitInhibitPolicy::parseSliceTxCommand(
+            QStringLiteral("display pan 0x40000000 bandwidth=0.2"));
+        ok &= expect(!parsed.valid, "ignores non-slice command");
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds KiwiSDR support to diversity receive routing. When a diversity child slice uses a Kiwi RX antenna, the panadapter FFT/waterfall remains tied to the diversity parent's visual source while the Kiwi slice contributes audio. Kiwi audio now follows slice left/right pan, mixes with Flex audio, and keeps the existing per-source DSP isolation needed to avoid the NR2 static regression. This also disables/hides ESC controls when any slice in the diversity pair uses Kiwi, restores VFO sizing when diversity/ESC controls collapse, and keeps RX Controls slice letters colored/usable after mute-all or Kiwi routing changes.

The change also adds a receive-only TX interlock for Kiwi-backed panadapters: if a panadapter is displaying a Kiwi receiver, TX enable, MOX/PTT, tune, and ATU-start paths are blocked for slices on that panadapter and an overlay explains why.

## Constitution principle honored

Principle VI -- transmit requires explicit, valid operator intent; receive-only Kiwi panadapters now prevent accidental TX on slices whose displayed RF source is not the Flex radio.

Principle II -- radio-authoritative live state is preserved; Kiwi RX routing mutes/restores Flex audio for the affected slice without pretending the radio's antenna/source changed.

## Test plan

- [x] Local build passes (`cmake --build build --parallel`)
- [x] Focused slice model regression test passes (`./build/slice_model_letter_test`)
- [x] TX inhibit policy test passes (`./build/transmit_inhibit_policy_test`)
- [x] Transmit model regression test passes (`./build/transmit_model_test`)
- [x] GUI accessibility check run (`python3 tools/check_a11y.py`; warning-only existing findings)
- [x] Whitespace check passes (`git diff --check HEAD~1..HEAD`)
- [ ] Behavior verified on a real radio with Flex+Kiwi and Kiwi+Kiwi diversity receive
- [ ] Behavior verified for MOX/PTT/tune/ATU blocked while a Kiwi receiver is displayed

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls -- use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room -- not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
