### PR TITLE
[codex] Show Kiwi public receiver limits marker

### DIFF
--- a/src/core/KiwiPublicDirectory.cpp
+++ b/src/core/KiwiPublicDirectory.cpp
@@ -41,7 +41,17 @@ QString KiwiPublicReceiver::apiBadge() const
 
 bool KiwiPublicReceiver::advertisesConnectionLimit() const
 {
-    return sdrHw.contains(QStringLiteral("Limits"), Qt::CaseInsensitive);
+    // Match "Limits" as a whole whitespace-delimited token, not a substring, so
+    // a free-form hardware/firmware descriptor that merely contains those letters
+    // (e.g. "Unlimited", "NoLimitsBeta") can't false-positive. The public
+    // directory appends the marker as its own token in sdr_hw.
+    const QStringList tokens =
+        sdrHw.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    for (const QString& token : tokens) {
+        if (token.compare(QStringLiteral("Limits"), Qt::CaseInsensitive) == 0)
+            return true;
+    }
+    return false;
 }
 
 QString KiwiPublicReceiver::connectionLimitBadge() const

--- a/src/core/KiwiPublicDirectory.cpp
+++ b/src/core/KiwiPublicDirectory.cpp
@@ -39,6 +39,18 @@ QString KiwiPublicReceiver::apiBadge() const
     return QStringLiteral("API policy unknown");
 }
 
+bool KiwiPublicReceiver::advertisesConnectionLimit() const
+{
+    return sdrHw.contains(QStringLiteral("Limits"), Qt::CaseInsensitive);
+}
+
+QString KiwiPublicReceiver::connectionLimitBadge() const
+{
+    return advertisesConnectionLimit()
+        ? QStringLiteral("Limits")
+        : QString();
+}
+
 QVector<KiwiPublicReceiver> KiwiPublicDirectory::parse(const QByteArray& directoryHtml)
 {
     QVector<KiwiPublicReceiver> out;

--- a/src/core/KiwiPublicDirectory.h
+++ b/src/core/KiwiPublicDirectory.h
@@ -49,6 +49,8 @@ struct KiwiPublicReceiver {
 
     // Short human-readable badge for the receiver picker.
     QString apiBadge() const;
+    bool advertisesConnectionLimit() const;
+    QString connectionLimitBadge() const;
 };
 
 // Fetches and parses the public KiwiSDR receiver directory, exposing each

--- a/src/gui/KiwiPublicReceiverPicker.cpp
+++ b/src/gui/KiwiPublicReceiverPicker.cpp
@@ -8,6 +8,7 @@
 #include <QPushButton>
 #include <QStringList>
 #include <QTableWidget>
+#include <QTableWidgetItem>
 #include <QUrl>
 #include <QVBoxLayout>
 
@@ -22,6 +23,15 @@ namespace {
 // without hitting the operators' servers again; "Refresh list" overwrites it.
 QVector<KiwiPublicReceiver> g_sessionCache;
 bool g_haveSessionCache = false;
+
+enum Column {
+    ReceiverColumn,
+    LocationColumn,
+    UsersColumn,
+    ApiColumn,
+    LimitsColumn,
+    ColumnCount,
+};
 
 // "http://host:port" -> "host:port" (what KiwiSdrClient::normalizeEndpoint wants).
 QString endpointFromUrl(const QString& url)
@@ -39,7 +49,7 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
                        QStringLiteral("KiwiPublicReceiverPickerGeometry"), parent)
     , m_dir(new KiwiPublicDirectory(this))
 {
-    resize(680, 460);
+    resize(760, 460);
 
     auto* outer = new QVBoxLayout(bodyWidget());
 
@@ -53,16 +63,19 @@ KiwiPublicReceiverPicker::KiwiPublicReceiverPicker(QWidget* parent)
     topRow->addWidget(m_refresh);
     outer->addLayout(topRow);
 
-    m_table = new QTableWidget(0, 4, this);
+    m_table = new QTableWidget(0, ColumnCount, this);
     m_table->setHorizontalHeaderLabels(
-        {tr("Receiver"), tr("Location"), tr("Users"), tr("API")});
+        {tr("Receiver"), tr("Location"), tr("Users"), tr("API"), tr("Limits")});
     m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
     m_table->setSelectionMode(QAbstractItemView::SingleSelection);
     m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_table->verticalHeader()->setVisible(false);
     m_table->horizontalHeader()->setStretchLastSection(false);
-    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(ReceiverColumn, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(LocationColumn, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(UsersColumn, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(ApiColumn, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(LimitsColumn, QHeaderView::ResizeToContents);
     outer->addWidget(m_table, 1);
 
     m_status = new QLabel(tr("Loading public receivers…"));
@@ -158,11 +171,22 @@ void KiwiPublicReceiverPicker::applyFilter()
         nameItem->setData(Qt::UserRole, endpointFromUrl(r.url));
         nameItem->setData(Qt::UserRole + 1,
                           QUrl(r.url).host().left(16));  // short default name
-        m_table->setItem(row, 0, nameItem);
-        m_table->setItem(row, 1, new QTableWidgetItem(r.location));
-        m_table->setItem(row, 2, new QTableWidgetItem(
+        m_table->setItem(row, ReceiverColumn, nameItem);
+        m_table->setItem(row, LocationColumn, new QTableWidgetItem(r.location));
+        m_table->setItem(row, UsersColumn, new QTableWidgetItem(
             QStringLiteral("%1/%2").arg(r.users).arg(r.usersMax)));
-        m_table->setItem(row, 3, new QTableWidgetItem(r.apiBadge()));
+        m_table->setItem(row, ApiColumn, new QTableWidgetItem(r.apiBadge()));
+
+        auto* limitsItem = new QTableWidgetItem(r.connectionLimitBadge());
+        if (r.advertisesConnectionLimit()) {
+            limitsItem->setToolTip(tr("This receiver advertises connection limits, "
+                                      "but the public directory does not publish "
+                                      "the configured duration."));
+        } else {
+            limitsItem->setToolTip(tr("No connection limit is advertised in the "
+                                      "public directory."));
+        }
+        m_table->setItem(row, LimitsColumn, limitsItem);
         ++shown;
     }
     QString status = tr("%1 receivers allow API access").arg(shown);
@@ -183,7 +207,7 @@ void KiwiPublicReceiverPicker::acceptCurrentRow()
 {
     const int row = m_table->currentRow();
     if (row < 0) return;
-    QTableWidgetItem* item = m_table->item(row, 0);
+    QTableWidgetItem* item = m_table->item(row, ReceiverColumn);
     if (!item) return;
     m_selectedEndpoint = item->data(Qt::UserRole).toString();
     m_selectedName = item->data(Qt::UserRole + 1).toString();

--- a/tests/kiwi_public_directory_test.cpp
+++ b/tests/kiwi_public_directory_test.cpp
@@ -26,7 +26,7 @@ const QByteArray kSample = QByteArrayLiteral(
     "  <!-- status=active -->\n"
     "  <!-- offline=no -->\n"
     "  <!-- name=G3SDR, Weston-super-Mare -->\n"
-    "  <!-- sdr_hw=KiwiSDR 1 v1.842 -->\n"
+    "  <!-- sdr_hw=KiwiSDR 1 v1.842 Limits -->\n"
     "  <!-- bands=0-30000000 -->\n"
     "  <!-- users=3 -->\n"
     "  <!-- users_max=4 -->\n"
@@ -36,6 +36,7 @@ const QByteArray kSample = QByteArrayLiteral(
     // ext_api == users_max -> fully open to API
     "<a href='http://open.example.com:8073' target='_blank'> </a>\n"
     "  <!-- name=Open RX -->\n"
+    "  <!-- sdr_hw=KiwiSDR 1 v1.842 -->\n"
     "  <!-- users=1 -->\n"
     "  <!-- users_max=4 -->\n"
     "  <!-- ext_api=4 -->\n"
@@ -65,12 +66,16 @@ int main()
     if (web.users != 3 || web.usersMax != 4) return fail("users/users_max parse");
     if (web.extApi != 0) return fail("ext_api parse");
     if (web.apiPolicy() != ApiPolicy::Disabled) return fail("ext_api=0 must be Disabled");
+    if (!web.advertisesConnectionLimit()) return fail("limits marker parse");
+    if (web.connectionLimitBadge() != QStringLiteral("Limits")) return fail("limits badge");
     // THE honor guarantee: a web-only receiver is never API-connectable.
     if (web.mayConnectViaApi()) return fail("ext_api=0 must NOT allow API connect");
 
     const KiwiPublicReceiver& open = rxs[1];
     if (open.extApi != 4 || open.usersMax != 4) return fail("open parse");
     if (open.apiPolicy() != ApiPolicy::Open) return fail("ext_api==users_max must be Open");
+    if (open.advertisesConnectionLimit()) return fail("no limits marker should be false");
+    if (!open.connectionLimitBadge().isEmpty()) return fail("no limits badge");
     if (!open.mayConnectViaApi()) return fail("open receiver must allow API connect");
 
     const KiwiPublicReceiver& limited = rxs[2];

--- a/tests/kiwi_public_directory_test.cpp
+++ b/tests/kiwi_public_directory_test.cpp
@@ -78,6 +78,18 @@ int main()
     if (!open.connectionLimitBadge().isEmpty()) return fail("no limits badge");
     if (!open.mayConnectViaApi()) return fail("open receiver must allow API connect");
 
+    // Token match, not substring: a free-form hardware descriptor that merely
+    // contains the letters "limits" must not false-positive, but the real marker
+    // (its own token, any case) must match.
+    KiwiPublicReceiver substr;
+    substr.sdrHw = QStringLiteral("KiwiSDR v1.900 NoLimitsBeta");
+    if (substr.advertisesConnectionLimit())
+        return fail("substring must not match the Limits token");
+    KiwiPublicReceiver tok;
+    tok.sdrHw = QStringLiteral("KiwiSDR v1.900 limits");
+    if (!tok.advertisesConnectionLimit())
+        return fail("case-insensitive Limits token must match");
+
     const KiwiPublicReceiver& limited = rxs[2];
     if (limited.extApi != 4 || limited.usersMax != 8) return fail("limited parse");
     if (limited.apiPolicy() != ApiPolicy::Limited) return fail("0<ext_api<max must be Limited");


### PR DESCRIPTION
## Summary

Adds a `Limits` column to the public KiwiSDR receiver picker so AetherSDR mirrors the limit marker shown in the KiwiSDR public directory. The column displays `Limits` when the directory advertises that marker and stays blank otherwise; it does not infer or claim an exact duration because the public directory and `/status` do not publish that value.

## Constitution principle honored

Principle IV — this uses only server-published public directory/status metadata and does not rely on KiwiSDR server source, served JavaScript, or implementation-derived code.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable
- [x] Focused test passes (`ctest --test-dir build -R kiwi_public_directory_test --output-on-failure`)
- [ ] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
