### PR TITLE
chore(metainfo): polish AppStream for Flathub submission

### DIFF
--- a/docs/brainstorms/2026-06-20-appstream-metainfo-polish-requirements.md
+++ b/docs/brainstorms/2026-06-20-appstream-metainfo-polish-requirements.md
@@ -1,0 +1,39 @@
+---
+date: 2026-06-20
+topic: appstream-metainfo-polish
+---
+
+# Polish AetherSDR AppStream Metainfo
+
+## Summary
+
+Edit `packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` so `appstreamcli validate` reports zero info/pedantic notices and the file is Flathub-submittable. Single-file change; no C++ or build-system work.
+
+## Requirements
+
+- R1. Add an OARS content rating with an all-none config to clear the `content-rating-missing` notice.
+- R2. Add a `<developer>` element to clear the `developer-info-missing` notice.
+- R3. Add a `<releases>` element listing the 5 most recent tagged versions, each with `version` and `date` attributes.
+- R4. Rewrite the summary so it neither starts with the article "A" nor ends with a period, per AppStream style.
+- R5. Update the default screenshot to use a tagged-commit URL (not `refs/heads/main`) and add a `<caption>`. `width` and `height` attributes are optional.
+- R6. Expand the `<description>` with a `<ul>` feature list (panadapter, SmartSDR protocol, audio DSP, etc.) below the existing paragraph.
+
+## Acceptance
+
+`appstreamcli validate packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` exits clean with zero info/pedantic notices.
+
+## Key Decisions
+
+- **Include the optional description expansion.** Low cost, raises the value the file carries in software centers, stays within the same single-file edit.
+- **All-none OARS rating.** AetherSDR is amateur-radio software with no objectionable content; the all-none config matches Flathub's permissive-default policy.
+- **5 release entries.** Matches the recent-release cadence and gives software centers a useful version history without bloat.
+
+## Outstanding Questions
+
+- Deferred to Planning: exact `<developer>` text (likely "AetherSDR contributors" — planner should confirm against project conventions); whether to add `width`/`height` on the screenshot (Flathub generally accepts omission).
+
+## Sources
+
+- GitHub issue #3675 — https://github.com/aethersdr/AetherSDR/issues/3675
+- Current metainfo file as of 2026-06-20
+- Most recent releases: v26.6.3 (2026-06-14), v26.6.2 (2026-06-08), v26.6.1.1 (2026-06-02), v26.6.1 (2026-06-01), v26.5.3 (2026-05-24)

--- a/docs/plans/2026-06-20-001-chore-appstream-metainfo-polish-plan.md
+++ b/docs/plans/2026-06-20-001-chore-appstream-metainfo-polish-plan.md
@@ -1,0 +1,99 @@
+---
+title: "chore: Polish AppStream metainfo for Flathub submission"
+type: chore
+date: 2026-06-20
+origin: docs/brainstorms/2026-06-20-appstream-metainfo-polish-requirements.md
+---
+
+# chore: Polish AppStream metainfo for Flathub submission
+
+## Summary
+
+Edit `packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` so `appstreamcli validate` reports zero info/pedantic notices and the file is Flathub-submittable. Six co-located XML edits, no C++ or build-system work, no runtime behavior change.
+
+## Problem Frame
+
+`packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` (introduced in #3673, merged as `a01a089`) currently triggers several `appstreamcli validate` notices: missing content rating, missing developer, missing releases, an unstable `refs/heads/main` screenshot URL, and a non-conformant summary. Flathub requires all of these to be addressed before the file can be submitted; software centers also use the developer, releases, and rating elements to display the app. Polishing the file is the next smallest step toward a Flathub listing and a richer software-center experience.
+
+## Requirements
+
+### AppStream validation
+
+- R1. The file declares an OARS content rating with an all-none config so `appstreamcli` does not flag `content-rating-missing`.
+- R2. The file declares a `<developer>` element so `appstreamcli` does not flag `developer-info-missing`.
+- R3. The file declares a `<releases>` element listing the 5 most recent tagged versions, each with `version` and `date` attributes.
+- R4. The summary neither starts with the article "A" nor ends with a period, per AppStream style.
+- R5. The default screenshot uses a tagged-commit URL (not `refs/heads/main`) and carries a `<caption>`. `width` and `height` are optional.
+
+### Description content
+
+- R6. The `<description>` adds a `<ul>` feature list (panadapter, SmartSDR protocol, audio DSP, etc.) below the existing paragraph.
+
+## Key Technical Decisions
+
+- **All-none OARS rating.** AetherSDR is amateur-radio software with no objectionable content; the all-none config matches Flathub's permissive-default policy. Selecting per-category ratings would falsely imply content categories the project does not actually ship.
+- **`<developer>` text: "AetherSDR".** The project's identity is the application, not a corporate entity. "AetherSDR" matches the convention used in the existing `<name>` element and reads correctly in software centers.
+- **5 release entries.** Captures the recent-release cadence (a release every 1-2 weeks) and gives software centers a useful version history without bloating the file. Older releases can be added later if Flathub requires more depth.
+- **Screenshot URL points to `v26.6.3`.** The latest tagged release at the time of writing; using a tag (not `main`) keeps the URL stable across further commits. Width and height are omitted — Flathub accepts the omission and `appstreamcli` does not flag it.
+- **Description feature list derived from the README.** The list of features (panadapter, SmartSDR protocol, audio DSP, etc.) should be sourced from the project's actual capabilities as documented in `README.md`, not invented. The implementer should lift 4-6 representative features from the README's feature list.
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- **CI check for metainfo validity.** A GitHub Actions job that runs `appstreamcli validate` on every PR touching the metainfo file would prevent regressions. Out of scope for this change; worth a separate issue.
+- **Translation support.** AppStream supports `<translation>` elements for localized metadata. Not requested in #3675 and not required by Flathub.
+- **Sponsorship / donation URLs.** Optional AppStream elements; out of scope.
+
+## System-Wide Impact
+
+- **Linux packagers and Flathub reviewers.** This change unblocks Flathub submission and is the prerequisite for any further metainfo-related work.
+- **Software center users.** Indirectly: the description, developer, releases, and rating display in GNOME Software, KDE Discover, elementary AppCenter, and other libAppStream consumers.
+- **No runtime or build-system impact.** The C++ application is unaffected; the change is pure packaging metadata.
+
+## Risks & Dependencies
+
+- **`<developer>` text acceptance.** Flathub has historically been strict about `<developer>` content. If the chosen text is rejected, the file is one edit away from a fix — no plan restructure needed.
+- **Release-list coverage.** If the project wants 10 releases listed rather than 5, the diff grows but the structure stays the same. The 5-entry count is a default, not a hard limit.
+- **No new dependencies.** `appstreamcli` ships in standard Linux distributions (`appstream` package on Debian/Ubuntu, `appstream` on Fedora/Arch). No install or pinning required for local development.
+
+## Implementation Units
+
+### U1. Apply all six XML edits to the metainfo file
+
+- **Goal:** Land the six AppStream corrections and the description expansion in a single coherent edit.
+- **Requirements:** R1, R2, R3, R4, R5, R6
+- **Dependencies:** None
+- **Files:** `packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml`
+- **Approach:**
+  - Read the current file (already known from the brainstorm; current content has name, summary, description, launchable, screenshots, urls) and identify anchor points for each edit.
+  - Insert the OARS `<content_rating>` element with `<content_rating id="oars-1.0">` and the all-none config block.
+  - Insert the `<developer>` element with the project name.
+  - Insert the `<releases>` block with the 5 most recent tagged versions.
+  - Edit the `<summary>` to drop the leading "A" and trailing period.
+  - Update the screenshot URL to point to `v26.6.3` and add a `<caption>`.
+  - Expand `<description>` with a `<ul>` feature list sourced from `README.md`.
+- **Patterns to follow:** Freedesktop AppStream metainfo spec for element shape and ordering; the file's existing XML style (2-space indent, attribute alignment).
+- **Test scenarios:** This is a packaging change; behavioral tests are not applicable. `Test expectation: none` — verification is the validator run in U2.
+- **Verification:** The file is well-formed XML; all six required changes are visible in the diff; the diff is reviewable in a small set of hunks.
+
+### U2. Validate with `appstreamcli` and confirm clean output
+
+- **Goal:** Confirm the file passes `appstreamcli validate` clean.
+- **Requirements:** R1, R2, R3, R4, R5
+- **Dependencies:** U1
+- **Files:** `packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` (read-only)
+- **Approach:**
+  - Run `appstreamcli validate packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` and capture the output.
+  - Confirm exit code 0 and no `W:` (warning) or `I:` (info) lines.
+  - If warnings or info notices remain, amend U1's diff and re-run.
+- **Patterns to follow:** `appstreamcli` is the standard Flathub-submission validator.
+- **Test scenarios:** This unit IS the test, executed by running the validator. `Test expectation: none` — the validator run is the verification.
+- **Verification:** Validator output shows no warnings or info notices. The file is Flathub-submittable.
+
+## Sources & Research
+
+- GitHub issue #3675 — https://github.com/aethersdr/AetherSDR/issues/3675
+- Brainstorm requirements doc: `docs/brainstorms/2026-06-20-appstream-metainfo-polish-requirements.md` (currently at `C:/tmp/aethersdr-2026-06-20-appstream-metainfo-polish-requirements.md` until the AetherSDR repo is cloned)
+- Freedesktop AppStream metainfo specification — defines `<content_rating>`, `<developer>`, `<releases>`, `<screenshot>` structure and ordering rules.
+- AetherSDR release list (5 most recent): v26.6.3 (2026-06-14), v26.6.2 (2026-06-08), v26.6.1.1 (2026-06-02), v26.6.1 (2026-06-01), v26.5.3 (2026-05-24)

--- a/packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
+++ b/packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml
@@ -1,29 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>io.github.aethersdr.aethersdr</id>
-  
+
   <name>AetherSDR</name>
-  <summary>A Linux-native client for FlexRadio Systems transceivers</summary>
-  
+  <summary>Linux-native client for FlexRadio Systems transceivers</summary>
+
   <metadata_license>MIT</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  
+
   <description>
     <p>
       AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
     </p>
+    <p>Highlights:</p>
+    <ul>
+      <li>Native SmartSDR protocol — speaks v1.4.0.0 directly without Wine or virtual machines</li>
+      <li>GPU-accelerated spectrum and waterfall with multi-panadapter support and native VITA-49 streams</li>
+      <li>Aetherial Audio Channel Strip — unified RX/TX DSP suite with six noise-reduction engines</li>
+      <li>Multi-client (Multi-Flex) operation alongside SmartSDR and Maestro, plus SmartLink remote and TCI v2.0 server</li>
+      <li>AetherModem packet radio, CW operator suite, FreeDV RADE, and per-slice WFM demodulator for satellite data</li>
+    </ul>
   </description>
-  
+
   <launchable type="desktop-id">AetherSDR.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/aethersdr/AetherSDR/refs/heads/main/docs/assets/screenshot-current.png</image>
+      <image>https://raw.githubusercontent.com/aethersdr/AetherSDR/v26.6.3/docs/assets/screenshot-current.png</image>
+      <caption>AetherSDR main window showing panadapter and waterfall</caption>
     </screenshot>
   </screenshots>
-  
+
   <url type="homepage">https://github.com/aethersdr/AetherSDR</url>
   <url type="bugtracker">https://github.com/aethersdr/AetherSDR/issues</url>
   <url type="help">https://github.com/aethersdr/AetherSDR/blob/main/SUPPORT.md</url>
   <url type="vcs-browser">https://github.com/aethersdr/AetherSDR</url>
   <url type="contribute">https://github.com/aethersdr/AetherSDR#contributing</url>
+
+  <developer id="io.github.aethersdr">
+    <name>AetherSDR</name>
+  </developer>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+
+  <releases>
+    <release version="26.6.3" date="2026-06-14"/>
+    <release version="26.6.2" date="2026-06-07"/>
+    <release version="26.6.1.1" date="2026-06-01"/>
+    <release version="26.6.1" date="2026-06-01"/>
+    <release version="26.5.3" date="2026-05-24"/>
+  </releases>
 </component>


### PR DESCRIPTION
Fixes #3675

Six co-located edits to `packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml` to make the file Flathub-submittable.

## What changed

- **R1 — OARS content rating.** Added `<content_rating type="oars-1.1">` with the 22-attribute all-none config (all ids verified against the canonical `hughsie/oars/specification/oars-1.1.rnc` schema). AetherSDR is amateur-radio software with no objectionable content; the all-none config matches Flathub's permissive-default policy.
- **R2 — Developer tag.** Added `<developer id="io.github.aethersdr"><name>AetherSDR</name></developer>` with a reverse-DNS `id`, per the Flathub metainfo guidelines.
- **R3 — Releases.** Added a `<releases>` block with the 5 most recent tagged versions: v26.6.3 (2026-06-14), v26.6.2 (2026-06-07), v26.6.1.1 (2026-06-01), v26.6.1 (2026-06-01), v26.5.3 (2026-05-24). Dates sourced from `git log` on each tag, not the requirements doc.
- **R4 — Summary.** Dropped the leading article from `<summary>` and removed the trailing period, per AppStream style.
- **R5 — Screenshot URL.** Updated from `refs/heads/main` to the `v26.6.3` tag so the URL stays stable across further commits. Added a `<caption>`.
- **R6 — Description.** Expanded `<description>` with a 5-item `<ul>` feature list lifted from `README.md` Highlights (SmartSDR protocol, GPU spectrum & waterfall, Aetherial Audio Channel Strip, Multi-Flex, AetherModem/CW/FreeDV/WFM).

## Verification

```
$ wsl -d Ubuntu -e bash -c 'cd /mnt/c/tmp/AetherSDR && appstreamcli validate packaging/linux/io.github.aethersdr.aethersdr.metainfo.xml'
✔ Validation was successful.
```

Both default and `--strict` modes exit 0 with no `W:` or `I:` lines. File is Flathub-submittable.

## Out of scope (deferred to follow-up)

- CI check for metainfo validity (a GitHub Actions job running `appstreamcli validate` on every PR touching the metainfo file). Worth a separate issue.
- Translation support via `<translation>` elements.
- Sponsorship / donation URLs.

## Principle cited

Principle VIII. — Evidence Over Assertion. The fix is verified by the `appstreamcli validate` clean run, not by the implementing agent's confidence.

## Includes

- The originating brainstorm requirements doc at `docs/brainstorms/2026-06-20-appstream-metainfo-polish-requirements.md`
- The implementation plan at `docs/plans/2026-06-20-001-chore-appstream-metainfo-polish-plan.md`