### PR TITLE
feat(automation): in-app agent-drivable test bridge for the GUI (#3646)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,10 +495,11 @@ and drive a `QLocalServer` that speaks newline-delimited JSON:
 - `grab <widget>` → PNG of any widget, including a correct GPU-framebuffer
   readback of the panadapter (`SpectrumWidget`).
 - `invoke <target> <action> [value]` → click/toggle/setValue/setText/… a
-  control. **Refuses transmit-related _buttons_ (MOX/PTT/Tune/ATU-tune/VOX
-  enable) unless `AETHER_AUTOMATION_ALLOW_TX=1`** — the bridge can never key a
-  live radio by accident; setpoint sliders ("Tune power", "RF power") stay
-  drivable.
+  control. **Refuses any control marked transmit-keying (`markTxKeying()` /
+  `aetherTxKeying` property — MOX/PTT, TUNE, ATU, CWX send, packet/APRS send)
+  unless `AETHER_AUTOMATION_ALLOW_TX=1`** — the bridge can never key a live
+  radio by accident; setpoint sliders ("Tune power", "RF power") stay drivable.
+  Marked controls show `"keying": true` in `dumpTree`.
 - `get radio|transmit|slice|slices|pan|pans [selector] [property]` → live JSON
   model snapshot (frequency, mode, filter, NB/NR, center MHz, min/max dBm,
   RF/mic/CW TX-chain, …). Assert on truth without screenshots.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,3 +482,30 @@ CI enforcement: [`tools/check_a11y.py`](tools/check_a11y.py) runs on every
 PR via [`.github/workflows/a11y-check.yml`](.github/workflows/a11y-check.yml)
 and emits inline diff annotations for the patterns above. Warning-only
 (`exit 0`); never blocks a build.
+
+## Agent Automation Bridge — verify the GUI without pixels
+
+Need to assert on UI state, drive a control, confirm a widget rendered, or
+capture the panadapter while verifying a change? AetherSDR ships an in-process,
+agent-drivable bridge (off in production). Launch with `AETHER_AUTOMATION=1`
+and drive a `QLocalServer` that speaks newline-delimited JSON:
+
+- `dumpTree` → semantic snapshot of the whole widget tree (objectName,
+  accessibleName, enabled, geometry, live `value`) — your "DOM" for controls.
+- `grab <widget>` → PNG of any widget, including a correct GPU-framebuffer
+  readback of the panadapter (`SpectrumWidget`).
+- `invoke <target> <action> [value]` → click/toggle/setValue/setText/… a
+  control. **Refuses transmit-related _buttons_ (MOX/PTT/Tune/ATU-tune/VOX
+  enable) unless `AETHER_AUTOMATION_ALLOW_TX=1`** — the bridge can never key a
+  live radio by accident; setpoint sliders ("Tune power", "RF power") stay
+  drivable.
+- `get radio|transmit|slice|slices|pan|pans [selector] [property]` → live JSON
+  model snapshot (frequency, mode, filter, NB/NR, center MHz, min/max dBm,
+  RF/mic/CW TX-chain, …). Assert on truth without screenshots.
+
+Quick start: `python3 tools/automation_probe.py demo` (no Qt dependency); also
+`get radio`, `invoke 'Master volume' setValue 35`. Full reference — protocol,
+JSON schemas, targeting rules, recipes, gotchas — in
+**[`docs/automation-bridge.md`](docs/automation-bridge.md)**. This is the
+deterministic, cross-OS way to do "snapshot → act → assert" on the native UI
+(issue [#3646](https://github.com/aethersdr/AetherSDR/issues/3646)).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,7 @@ set(CORE_SOURCES
     src/core/SpotModeResolver.cpp
     src/core/TciServer.cpp
     src/core/TciProtocol.cpp
+    src/core/AutomationServer.cpp
     src/core/MqttClient.cpp
     src/core/PgxlConnection.cpp
     src/core/FirmwareUploader.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1,0 +1,244 @@
+# Agent Automation Bridge
+
+> **AI agents (Claude, Codex, …) read this first.** This doc is written for
+> *you*, an agent working in this repo who needs to introspect or capture the
+> running GUI — to verify a change, assert on UI state, or grab the panadapter.
+> Everything below is copy-pasteable. Skip to [Quickstart](#quickstart) and go.
+
+AetherSDR is a **Qt 6 Widgets** native app — no QML, no web layer, so there is
+no DOM or browser tooling to drive. The automation bridge is the in-process
+substitute: an opt-in command channel that exposes the widget tree and lets you
+capture any widget (including the GPU panadapter) as a PNG. It is the
+deterministic, cross-OS way to do "snapshot → act → assert" testing of the UI.
+
+Introduced in issue
+[#3646](https://github.com/aethersdr/AetherSDR/issues/3646) (Phase 0). Off in
+production; it only exists when you ask for it via an env var.
+
+---
+
+## When to use it
+
+| Goal | Use the bridge? |
+|---|---|
+| Assert a control's state after a change (slider value, button checked, label text) | **Yes** — `dumpTree`, read the `value` field. No screenshot needed. |
+| Confirm a widget exists / is enabled / has the right accessibleName | **Yes** — `dumpTree`. |
+| Capture what the panadapter/waterfall actually rendered | **Yes** — `grab SpectrumWidget`. |
+| Visually check a dialog or applet layout | **Yes** — `grab <widget>` → view the PNG. |
+| Click a button or move a slider programmatically | **Not yet** — `invoke()`/`get()` land in Phase 1. Today the bridge is read-only (snapshot + capture). |
+
+---
+
+## Quickstart
+
+```bash
+# 1. Build with the bridge available (it's compiled in unconditionally;
+#    the env var below is what turns it on at runtime).
+cmake --build build --parallel
+
+# 2. Launch the app with the bridge enabled.
+AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &   # macOS
+#   AETHER_AUTOMATION=1 ./build/AetherSDR &                            # Linux/Windows
+
+# 3. Drive it. The dependency-free probe needs no Qt:
+python3 tools/automation_probe.py ping
+python3 tools/automation_probe.py demo --out /tmp/phase0   # → tree.json + panadapter.png
+```
+
+`demo` produces the two canonical artifacts: a semantic snapshot of the UI
+(`tree.json`) and a PNG of the live panadapter (`panadapter.png`). View the PNG
+to confirm a visual change; parse the JSON to assert on control state.
+
+For headless / CI runs, add `QT_QPA_PLATFORM=offscreen` — no display required.
+
+---
+
+## How it works (the contract)
+
+- **Transport:** a `QLocalServer` — an `AF_UNIX` socket on macOS/Linux, a named
+  pipe on Windows. No TCP port, no network exposure.
+- **Framing:** newline-delimited. You send one request per line; you get back
+  exactly one compact-JSON response line.
+- **Request line** is *either* a bare command or a JSON object — both work:
+  - `dumpTree`
+  - `grab SpectrumWidget /tmp/pan.png`
+  - `{"cmd":"grab","target":"SpectrumWidget","path":"/tmp/pan.png"}`
+- **Discovery:** on startup the app writes the resolved socket path to
+  `${TMPDIR:-/tmp}/aethersdr-automation.json`, so you never have to guess the
+  platform-specific endpoint:
+  ```json
+  {"socket":"/var/folders/.../aethersdr-automation","name":"aethersdr-automation","pid":7326,"version":"26.6.3"}
+  ```
+  `tools/automation_probe.py` reads this automatically. Override the socket name
+  at launch with `AETHER_AUTOMATION_SOCKET=<name>`.
+
+### Driving it without the probe
+
+Any language can talk to it; it's just a Unix socket and line-delimited JSON.
+Raw shell example:
+
+```bash
+SOCK=$(python3 -c 'import json,os,tempfile; print(json.load(open(os.path.join(tempfile.gettempdir(),"aethersdr-automation.json")))["socket"])')
+printf '{"cmd":"ping"}\n' | nc -U "$SOCK"
+```
+
+---
+
+## Verbs
+
+### `ping`
+Connectivity / handshake.
+
+```json
+→ {"cmd":"ping"}
+← {"ok":true,"app":"AetherSDR","version":"26.6.3"}
+```
+
+### `dumpTree`
+ARIA-style semantic snapshot of **every** top-level `QWidget` hierarchy. This is
+your "DOM snapshot" for controls.
+
+```json
+→ {"cmd":"dumpTree"}
+← {"ok":true,"roots":[ <node>, <node>, … ]}
+```
+
+Each `<node>`:
+
+```jsonc
+{
+  "class": "AetherSDR::SpectrumWidget",   // C++ class (full, namespaced)
+  "objectName": "masterVolume",            // present only if set
+  "accessibleName": "Master volume",       // present only if set
+  "enabled": true,
+  "visible": true,
+  "geometry": { "x": 1, "y": 104, "w": 1448, "h": 751 },  // GLOBAL screen coords
+  "value": "42",                           // best-effort; see below
+  "children": [ <node>, … ]                // present only if non-empty
+}
+```
+
+**The `value` field** is the fast path for state assertions — it's filled in
+for common controls so you can assert without a screenshot:
+
+| Widget | `value` |
+|---|---|
+| `QAbstractSlider` (sliders, scrollbars, dials) | numeric position, e.g. `"42"` |
+| `QAbstractButton` checkable (checkbox, toggle) | `"checked"` / `"unchecked"` |
+| `QAbstractButton` non-checkable (push button) | its text |
+| `QComboBox` | current text |
+| `QLineEdit` | current text |
+| `QSpinBox` / `QDoubleSpinBox` | numeric value |
+| `QProgressBar` | numeric value |
+| `QLabel` | its text |
+| containers / custom-painted surfaces | omitted |
+
+### `grab`
+PNG capture of a single widget.
+
+```json
+→ {"cmd":"grab","target":"SpectrumWidget","path":"/tmp/pan.png"}
+← {"ok":true,"target":"SpectrumWidget","class":"SpectrumWidget",
+   "path":"/tmp/pan.png","width":2896,"height":1502,"bytes":2248854}
+```
+
+- `path` is optional. If omitted, the PNG is written to
+  `${TMPDIR}/aether-grab-<target>.png` and the path is returned.
+- The panadapter is a GPU (`QRhiWidget`) surface; the bridge does the correct
+  framebuffer readback for it, so the capture is the *real* rendered spectrum,
+  not a blank.
+
+### Errors
+Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
+`widget not found: Foo`, `grab requires a target widget`, `unknown command: x`.
+
+---
+
+## Targeting a widget
+
+`grab` (and, in Phase 1, `invoke`/`get`) resolve a `target` string in this
+order — first match wins:
+
+1. **Exact `objectName`** — the most stable handle. Prefer this.
+2. **Class name** — full (`AetherSDR::SpectrumWidget`) or short
+   (`SpectrumWidget`). Handy when a widget has no objectName (the panadapter is
+   targeted as `SpectrumWidget`).
+3. **`accessibleName`** — e.g. `"Panadapter spectrum display"`,
+   `"Master volume"`.
+
+To find a target: run `dumpTree`, search the JSON for the `accessibleName` or
+`class` you want, and use its `objectName` if it has one. Roughly half of
+`src/gui/` is annotated with `setObjectName`/`setAccessibleName`; finishing that
+backlog (see [`docs/a11y.md`](a11y.md), enforced by
+[`tools/check_a11y.py`](../tools/check_a11y.py)) directly improves what you can
+target here.
+
+---
+
+## Recipes
+
+**Assert on state (no pixels) — the default.**
+```python
+tree = bridge.request({"cmd": "dumpTree"})
+node = find(tree["roots"], accessibleName="Master volume")
+assert node["value"] == "42" and node["enabled"]
+```
+
+**Capture for a genuinely-visual check.**
+```python
+r = bridge.request({"cmd": "grab", "target": "SpectrumWidget", "path": "/tmp/pan.png"})
+assert r["ok"] and r["width"] > 0
+# then view /tmp/pan.png, or perceptual-diff it against a golden (Phase 3)
+```
+
+**Snapshot → act → assert** (the loop you already use for web work): snapshot
+with `dumpTree`, perform your action (today: via the real radio / UI; Phase 1
+adds `invoke`), then `dumpTree` again and diff the `value`/`enabled` fields.
+
+Prefer **structural** assertions (`dumpTree` values) over screenshots wherever
+possible — they're exact, fast, and identical across OSes. Reserve `grab` +
+image comparison for assertions that are *inherently* visual (did the waterfall
+actually paint? is the layout right?), because a live spectrum is
+non-deterministic noise and won't golden-match until replay mode (Phase 2)
+lands.
+
+---
+
+## Gotchas
+
+- **Off by default.** No `AETHER_AUTOMATION` → no server, zero overhead, no
+  socket. This is intentional; never enable it in a shipped build.
+- **Read-only today.** Phase 0 is `ping` / `dumpTree` / `grab`. No clicking or
+  value-setting yet — that's `invoke()`/`get()` in Phase 1.
+- **GPU panadapter capture.** `SpectrumWidget` is a `QRhiWidget` when built with
+  `AETHER_GPU_SPECTRUM` (the default). The bridge uses
+  `QRhiWidget::grabFramebuffer()` for it — plain `QWidget::grab()` returns an
+  empty surface for a GPU widget, so don't reimplement capture that way.
+- **Live spectrum isn't golden-able.** Pixels off a live radio are noise.
+  Deterministic visual diffs need the recorded-fixture replay mode (Phase 2).
+- **Stale socket after a crash.** On a hard kill the C++ destructor may not run,
+  leaving the socket + discovery file behind. This self-heals: the next launch
+  clears the stale socket (`removeServer`) and rewrites the discovery file.
+- **Geometry is global.** `geometry` is in screen coordinates (via
+  `mapToGlobal`), so it correlates with computer-use/screenshots if you ever
+  cross-check.
+
+---
+
+## Roadmap (issue #3646)
+
+| Phase | Adds | Status |
+|---|---|---|
+| 0 | `dumpTree` + `grab` over `QLocalServer` behind `AETHER_AUTOMATION` | **done** |
+| 1 | `invoke(name, action, value)` + `get(model, property)`; clear the a11y backlog | planned |
+| 2 | Replay/fixture mode (recorded VITA-49 FFT + meters) → deterministic panadapter without hardware | planned |
+| 3 | CI E2E matrix: `QT_QPA_PLATFORM=offscreen` + agent scenarios + per-OS perceptual golden diffs | planned |
+| 4 | Computer-use / VNC kept as the *exploratory* tier (real GPU/WM smoke), not the regression backbone | planned |
+
+## Source
+
+- Server: [`src/core/AutomationServer.h`](../src/core/AutomationServer.h) /
+  [`.cpp`](../src/core/AutomationServer.cpp)
+- Startup wiring: [`src/main.cpp`](../src/main.cpp) (after `window.show()`)
+- Driver: [`tools/automation_probe.py`](../tools/automation_probe.py)
+- Log category: `lcAutomation` (`aether.automation`) — toggle in Help → Support.

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -25,7 +25,9 @@ production; it only exists when you ask for it via an env var.
 | Confirm a widget exists / is enabled / has the right accessibleName | **Yes** — `dumpTree`. |
 | Capture what the panadapter/waterfall actually rendered | **Yes** — `grab SpectrumWidget`. |
 | Visually check a dialog or applet layout | **Yes** — `grab <widget>` → view the PNG. |
-| Click a button or move a slider programmatically | **Not yet** — `invoke()`/`get()` land in Phase 1. Today the bridge is read-only (snapshot + capture). |
+| Click a button or move a slider programmatically | **Yes** — `invoke <target> <action> [value]`. |
+| Read live model truth (freq, mode, center, dBm, NB/NR) | **Yes** — `get radio\|slice\|pan …`. Assert on state, no pixels. |
+| Key the radio (MOX/PTT/Tune) | **No** — `invoke` refuses transmit controls by design (see [TX safety](#tx-safety)). |
 
 ---
 
@@ -148,16 +150,73 @@ PNG capture of a single widget.
   framebuffer readback for it, so the capture is the *real* rendered spectrum,
   not a blank.
 
+### `invoke`
+Drive a control deterministically — no pixel-hunting. Resolves `target` exactly
+like `grab`.
+
+```json
+→ {"cmd":"invoke","target":"Master volume","action":"setValue","value":"35"}
+← {"ok":true,"target":"Master volume","class":"QSlider","action":"setValue","newValue":"35"}
+```
+
+`newValue` echoes the control's state *after* the action (same field `dumpTree`
+reports) — a free round-trip confirmation.
+
+| `action` | applies to | `value` |
+|---|---|---|
+| `click` | any `QAbstractButton` | — |
+| `toggle` | any `QAbstractButton` (checkable → toggle, else click) | — |
+| `setChecked` | checkable button | `true`/`false`/`on`/`off`/`1`/`0` |
+| `setValue` | slider / scrollbar / spinbox | integer (or number for double-spin) |
+| `setText` | `QLineEdit` | the text |
+| `setCurrentText` | `QComboBox` | item text |
+| `setCurrentIndex` | `QComboBox` | integer index |
+
+<a name="tx-safety"></a>
+> **🚨 TX safety.** `invoke` **refuses** any control whose name looks
+> transmit-related — `mox`, `ptt`, `tune` (incl. the ATU tune button, which
+> emits a carrier), `transmit`, `vox` — returning
+> `{"ok":false,"error":"blocked: …"}` and never calling the widget. A test
+> bridge must never key a live transmitter by accident. To deliberately drive
+> TX (e.g. a hardware-in-the-loop test on a dummy load), set
+> `AETHER_AUTOMATION_ALLOW_TX=1` in the app's environment at launch. Over-
+> blocking is intentional — the guard matches on substrings.
+
+### `get`
+Read live model state — assert on truth without a screenshot. Requires a radio
+model (present once the app is running; fields are empty until a radio
+connects).
+
+```json
+→ {"cmd":"get","model":"radio"}
+← {"ok":true,"model":"radio","radio":{"connected":true,"model":"FLEX-8400M",
+   "transmitting":false,"txPower":0,"sliceCount":1,"panCount":1, …}}
+
+→ {"cmd":"get","model":"slice","selector":"active","property":"frequency"}
+← {"ok":true,"model":"slice","property":"frequency","value":3.6}
+```
+
+| `model` | `selector` | returns |
+|---|---|---|
+| `radio` | — | radio snapshot (name, model, version, connected, transmitting, txPower, paTemp, slice/pan counts) |
+| `slices` | — | array of all slice snapshots |
+| `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, txSlice, …) |
+| `pans` | — | array of all panadapter snapshots |
+| `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps) |
+
+Add a trailing **property** name to any single-object form to get just that
+field: `get slice active mode` → `{"value":"LSB"}`.
+
 ### Errors
 Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
-`widget not found: Foo`, `grab requires a target widget`, `unknown command: x`.
+`widget not found: Foo`, `blocked: '…' looks transmit-related …`,
+`no slice for selector 'tx'`, `unknown action: x`, `unknown command: x`.
 
 ---
 
 ## Targeting a widget
 
-`grab` (and, in Phase 1, `invoke`/`get`) resolve a `target` string in this
-order — first match wins:
+`grab` and `invoke` resolve a `target` string in this order — first match wins:
 
 1. **Exact `objectName`** — the most stable handle. Prefer this.
 2. **Class name** — full (`AetherSDR::SpectrumWidget`) or short
@@ -191,9 +250,16 @@ assert r["ok"] and r["width"] > 0
 # then view /tmp/pan.png, or perceptual-diff it against a golden (Phase 3)
 ```
 
+**Drive a control and confirm the model followed.**
+```python
+bridge.request({"cmd": "invoke", "target": "sliceModeCombo", "action": "setCurrentText", "value": "USB"})
+assert bridge.request({"cmd": "get", "model": "slice", "selector": "active", "property": "mode"})["value"] == "USB"
+```
+
 **Snapshot → act → assert** (the loop you already use for web work): snapshot
-with `dumpTree`, perform your action (today: via the real radio / UI; Phase 1
-adds `invoke`), then `dumpTree` again and diff the `value`/`enabled` fields.
+with `dumpTree`/`get`, drive the change with `invoke`, then `get` (or another
+`dumpTree`) and assert the `value`/model field changed. Keep transmit out of the
+loop — the guard blocks it, and so should your scenarios.
 
 Prefer **structural** assertions (`dumpTree` values) over screenshots wherever
 possible — they're exact, fast, and identical across OSes. Reserve `grab` +
@@ -208,8 +274,12 @@ lands.
 
 - **Off by default.** No `AETHER_AUTOMATION` → no server, zero overhead, no
   socket. This is intentional; never enable it in a shipped build.
-- **Read-only today.** Phase 0 is `ping` / `dumpTree` / `grab`. No clicking or
-  value-setting yet — that's `invoke()`/`get()` in Phase 1.
+- **`invoke` can't key the radio.** Transmit controls are refused unless
+  `AETHER_AUTOMATION_ALLOW_TX=1` — see [TX safety](#tx-safety). Don't disable the
+  guard just to get a test green.
+- **`get` needs a model.** It reads the active-session `RadioModel`; fields are
+  empty/zero until a radio connects. Run it once connected, or assert on
+  `connected` first.
 - **GPU panadapter capture.** `SpectrumWidget` is a `QRhiWidget` when built with
   `AETHER_GPU_SPECTRUM` (the default). The bridge uses
   `QRhiWidget::grabFramebuffer()` for it — plain `QWidget::grab()` returns an
@@ -230,7 +300,7 @@ lands.
 | Phase | Adds | Status |
 |---|---|---|
 | 0 | `dumpTree` + `grab` over `QLocalServer` behind `AETHER_AUTOMATION` | **done** |
-| 1 | `invoke(name, action, value)` + `get(model, property)`; clear the a11y backlog | planned |
+| 1 | `invoke <target> <action>` (TX-guarded) + `get radio\|slice\|pan` model snapshots | **done** |
 | 2 | Replay/fixture mode (recorded VITA-49 FFT + meters) → deterministic panadapter without hardware | planned |
 | 3 | CI E2E matrix: `QT_QPA_PLATFORM=offscreen` + agent scenarios + per-OS perceptual golden diffs | planned |
 | 4 | Computer-use / VNC kept as the *exploratory* tier (real GPU/WM smoke), not the regression backbone | planned |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -116,6 +116,7 @@ Each `<node>`:
   "visible": true,
   "geometry": { "x": 1, "y": 104, "w": 1448, "h": 751 },  // GLOBAL screen coords
   "value": "42",                           // best-effort; see below
+  "keying": true,                          // present only on TX-keying controls (invoke refuses these)
   "children": [ <node>, … ]                // present only if non-empty
 }
 ```
@@ -173,16 +174,27 @@ reports) — a free round-trip confirmation.
 | `setCurrentIndex` | `QComboBox` | integer index |
 
 <a name="tx-safety"></a>
-> **🚨 TX safety.** `invoke` **refuses any transmit-related _button_** — a
-> control whose name contains `mox`, `ptt`, `tune` (incl. the ATU tune button,
-> which emits a carrier), `transmit`, or `vox` — returning
-> `{"ok":false,"error":"blocked: …"}` and never calling the widget. A test
-> bridge must never key a live transmitter by accident. The guard is scoped to
-> **buttons** because only a discrete button action can key the radio; setpoint
-> **sliders/combos** like `Tune power`, `RF power`, or `VOX level` are *not*
-> blocked — moving a value setter can't transmit. To deliberately drive a keying
-> button (e.g. hardware-in-the-loop on a dummy load), set
-> `AETHER_AUTOMATION_ALLOW_TX=1` in the app's environment at launch.
+> **🚨 TX safety.** `invoke` **refuses any control that keys the transmitter**,
+> returning `{"ok":false,"error":"blocked: …"}` and never calling the widget. A
+> test bridge must never key a live transmitter by accident.
+>
+> The guard is **marker-driven, not name-driven**. Genuinely-keying controls
+> (MOX/PTT, TUNE, ATU, CWX CW send, AX.25 packet/APRS send) are tagged at their
+> creation site with `markTxKeying()` — the `aetherTxKeying` dynamic property —
+> and the guard refuses anything carrying it. This is authoritative: a control
+> is blocked because it was *declared* keying, not because its label matched a
+> word, so it catches keying buttons like **"Send"** that no keyword would. A
+> marked control shows `"keying": true` in `dumpTree`, so you can see what's
+> off-limits before you try. A button-scoped name heuristic
+> (`mox/ptt/tune/atu/transmit/vox/cwx`) remains as a logged belt-and-suspenders
+> fallback for any keying control that predates the marker. Setpoint
+> **sliders/combos** like `Tune power`, `RF power`, or `VOX level` are never
+> blocked — moving a value setter can't transmit.
+>
+> To deliberately drive a keying control (e.g. hardware-in-the-loop on a dummy
+> load), set `AETHER_AUTOMATION_ALLOW_TX=1` in the app's environment at launch.
+> Adding a new keying control? Call `markTxKeying(theButton)` — see
+> `src/core/TxKeyingMarker.h`.
 
 ### `get`
 Read live model state — assert on truth without a screenshot. Requires a radio
@@ -227,6 +239,8 @@ Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
    targeted as `SpectrumWidget`).
 3. **`accessibleName`** — e.g. `"Panadapter spectrum display"`,
    `"Master volume"`.
+4. **Button text** — last resort, e.g. `"Send"`, `"Transmit"`. Lowest priority,
+   so a real objectName/accessibleName always wins; first match in tree order.
 
 To find a target: run `dumpTree`, search the JSON for the `accessibleName` or
 `class` you want, and use its `objectName` if it has one. Roughly half of

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -173,14 +173,16 @@ reports) — a free round-trip confirmation.
 | `setCurrentIndex` | `QComboBox` | integer index |
 
 <a name="tx-safety"></a>
-> **🚨 TX safety.** `invoke` **refuses** any control whose name looks
-> transmit-related — `mox`, `ptt`, `tune` (incl. the ATU tune button, which
-> emits a carrier), `transmit`, `vox` — returning
+> **🚨 TX safety.** `invoke` **refuses any transmit-related _button_** — a
+> control whose name contains `mox`, `ptt`, `tune` (incl. the ATU tune button,
+> which emits a carrier), `transmit`, or `vox` — returning
 > `{"ok":false,"error":"blocked: …"}` and never calling the widget. A test
-> bridge must never key a live transmitter by accident. To deliberately drive
-> TX (e.g. a hardware-in-the-loop test on a dummy load), set
-> `AETHER_AUTOMATION_ALLOW_TX=1` in the app's environment at launch. Over-
-> blocking is intentional — the guard matches on substrings.
+> bridge must never key a live transmitter by accident. The guard is scoped to
+> **buttons** because only a discrete button action can key the radio; setpoint
+> **sliders/combos** like `Tune power`, `RF power`, or `VOX level` are *not*
+> blocked — moving a value setter can't transmit. To deliberately drive a keying
+> button (e.g. hardware-in-the-loop on a dummy load), set
+> `AETHER_AUTOMATION_ALLOW_TX=1` in the app's environment at launch.
 
 ### `get`
 Read live model state — assert on truth without a screenshot. Requires a radio
@@ -199,6 +201,7 @@ connects).
 | `model` | `selector` | returns |
 |---|---|---|
 | `radio` | — | radio snapshot (name, model, version, connected, transmitting, txPower, paTemp, slice/pan counts) |
+| `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
 | `slices` | — | array of all slice snapshots |
 | `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, txSlice, …) |
 | `pans` | — | array of all panadapter snapshots |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1,5 +1,6 @@
 #include "AutomationServer.h"
 #include "LogManager.h"
+#include "TxKeyingMarker.h"       // kTxKeyingProperty — authoritative TX-guard marker
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 
 #include <QLocalServer>
@@ -98,6 +99,11 @@ QJsonObject describeWidget(const QWidget* w)
     if (!val.isNull())
         o[QStringLiteral("value")] = val;
 
+    // Surface the TX-keying marker so an agent can see which controls invoke()
+    // will refuse before trying them (#3646).
+    if (w->property(kTxKeyingProperty).toBool())
+        o[QStringLiteral("keying")] = true;
+
     QJsonArray kids;
     const QObjectList children = w->children();
     for (const QObject* child : children) {
@@ -123,6 +129,24 @@ QWidget* matchRecursive(QWidget* w, const QString& target)
     for (QObject* child : children) {
         if (auto* cw = qobject_cast<QWidget*>(child)) {
             if (QWidget* m = matchRecursive(cw, target))
+                return m;
+        }
+    }
+    return nullptr;
+}
+
+// Last-resort match by a button's visible text — agents often know a control
+// only by its label ("Send", "Transmit"). Lowest priority so an objectName /
+// accessibleName / class always wins first.
+QWidget* matchByButtonText(QWidget* w, const QString& target)
+{
+    if (auto* b = qobject_cast<QAbstractButton*>(w))
+        if (b->text() == target)
+            return w;
+    const QObjectList children = w->children();
+    for (QObject* child : children) {
+        if (auto* cw = qobject_cast<QWidget*>(child)) {
+            if (QWidget* m = matchByButtonText(cw, target))
                 return m;
         }
     }
@@ -158,34 +182,50 @@ bool parseBool(const QString& v)
         || s == QLatin1String("checked");
 }
 
-// TX-safety guard for invoke(). A control that looks transmit-related is
-// refused unless the operator sets AETHER_AUTOMATION_ALLOW_TX. A test bridge
-// must never key a live radio by accident — "tune" deliberately covers the ATU
-// tune button, which emits a carrier.
+// TX-safety guard for invoke(): refuse to drive a control that keys the
+// transmitter unless the operator sets AETHER_AUTOMATION_ALLOW_TX. A test bridge
+// must never key a live radio by accident.
 //
-// The guard is scoped to *buttons* on purpose: only a discrete button action
-// (click/toggle) can actually key the radio — MOX, PTT, TUNE, ATU-tune, and VOX
-// enable are all QAbstractButtons. Setpoint sliders/spinboxes/combos named
-// "Tune power", "RF power", "VOX level", etc. never transmit by being moved, so
-// blocking them was over-reach (#3646 QA finding 3). Requiring a button fixes
-// that without weakening safety, since invoke can't key through a value setter.
+// Authoritative mechanism — a positive marker. Genuinely-keying controls
+// (MOX/PTT, TUNE, ATU, CWX send, packet send) are tagged at their creation site
+// with markTxKeying() (the "aetherTxKeying" dynamic property). The guard honors
+// that property, so a control is blocked because it was *declared* keying, not
+// because its label happened to contain a magic word. This closed the holes the
+// old substring blocklist missed — notably the CW and packet "Send" buttons,
+// which key TX but match no keyword (#3646 review).
+//
+// Belt-and-suspenders fallback — a button-scoped name heuristic, retained only
+// to catch a keying control that predates or forgot the marker. It is *button*
+// scoped because only a discrete button action can key (setpoint sliders like
+// "Tune power"/"RF power" never transmit by being moved). When the fallback
+// fires we log a warning: that control should get an explicit markTxKeying().
 bool isTransmitControl(const QWidget* w)
 {
+    if (w->property(kTxKeyingProperty).toBool())
+        return true;  // authoritative positive marker
+
     const auto* btn = qobject_cast<const QAbstractButton*>(w);
     if (!btn)
         return false;  // sliders / combos / spinboxes can't trigger TX
 
     static const QStringList kDeny = {
         QStringLiteral("mox"), QStringLiteral("ptt"), QStringLiteral("tune"),
-        QStringLiteral("transmit"), QStringLiteral("vox"),
+        QStringLiteral("transmit"), QStringLiteral("vox"), QStringLiteral("cwx"),
+        QStringLiteral("atu"),
     };
     const QStringList hay{w->objectName().toLower(),
                           w->accessibleName().toLower(),
                           btn->text().toLower()};
-    for (const QString& h : hay)
-        for (const QString& d : kDeny)
-            if (h.contains(d))
+    for (const QString& h : hay) {
+        for (const QString& d : kDeny) {
+            if (h.contains(d)) {
+                qCWarning(lcAutomation).noquote()
+                    << "TX guard fell back to name match on" << btn->text()
+                    << "— add markTxKeying() at its creation site if it keys TX";
                 return true;
+            }
+        }
+    }
     return false;
 }
 
@@ -321,6 +361,11 @@ bool AutomationServer::start(const QString& serverName)
 
     m_serverName = serverName;
     m_server = new QLocalServer(this);
+
+    // Restrict the socket to the owning user (0600 / per-user pipe ACL). The
+    // endpoint can key TX and its path is advertised in a shared-temp discovery
+    // file, so another local user must not be able to connect and drive the GUI.
+    m_server->setSocketOptions(QLocalServer::UserAccessOption);
 
     // Clear any stale socket left by a crashed run so we can rebind.
     QLocalServer::removeServer(serverName);
@@ -591,6 +636,11 @@ QWidget* AutomationServer::resolveWidget(const QString& target)
         if (QWidget* m = matchRecursive(tlw, target))
             return m;
     }
+    // 3. Button visible text, last resort (e.g. "Send", "Transmit").
+    for (QWidget* tlw : tops) {
+        if (QWidget* m = matchByButtonText(tlw, target))
+            return m;
+    }
     return nullptr;
 }
 
@@ -609,7 +659,7 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
             << "BLOCKED transmit-related invoke on" << target
             << "(" << shortClassName(w) << ")";
         return err(QStringLiteral("blocked: '") + target
-                   + QStringLiteral("' looks transmit-related (MOX/PTT/Tune/Transmit/VOX). "
+                   + QStringLiteral("' is a transmit-keying control (TX-safety guard). "
                                     "Set AETHER_AUTOMATION_ALLOW_TX=1 to override."));
     }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1,0 +1,411 @@
+#include "AutomationServer.h"
+#include "LogManager.h"
+
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QApplication>
+#include <QWidget>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QImage>
+#include <QPixmap>
+#include <QBuffer>
+#include <QPoint>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QCoreApplication>
+#include <QRegularExpression>
+
+// Best-effort value extraction for common control types.
+#include <QAbstractButton>
+#include <QAbstractSlider>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QLabel>
+#include <QSpinBox>
+#include <QProgressBar>
+
+#ifdef AETHER_GPU_SPECTRUM
+#include <QRhiWidget>
+#endif
+
+namespace AetherSDR {
+
+namespace {
+
+// Human-meaningful "value" for a control, so an assertion can read state
+// without a screenshot. Returns a null QString for widgets that have no
+// natural scalar/text value (containers, custom-painted surfaces).
+QString widgetValue(const QWidget* w)
+{
+    if (auto* s = qobject_cast<const QAbstractSlider*>(w))
+        return QString::number(s->value());
+    if (auto* b = qobject_cast<const QAbstractButton*>(w)) {
+        if (b->isCheckable())
+            return b->isChecked() ? QStringLiteral("checked")
+                                  : QStringLiteral("unchecked");
+        return b->text();
+    }
+    if (auto* cb = qobject_cast<const QComboBox*>(w))
+        return cb->currentText();
+    if (auto* le = qobject_cast<const QLineEdit*>(w))
+        return le->text();
+    if (auto* sb = qobject_cast<const QSpinBox*>(w))
+        return QString::number(sb->value());
+    if (auto* ds = qobject_cast<const QDoubleSpinBox*>(w))
+        return QString::number(ds->value());
+    if (auto* pb = qobject_cast<const QProgressBar*>(w))
+        return QString::number(pb->value());
+    if (auto* lb = qobject_cast<const QLabel*>(w))
+        return lb->text();
+    return QString();  // null -> omitted from snapshot
+}
+
+// Short class name without the AetherSDR:: (or any) namespace prefix.
+QString shortClassName(const QObject* o)
+{
+    return QString::fromUtf8(o->metaObject()->className())
+        .section(QStringLiteral("::"), -1);
+}
+
+QJsonObject describeWidget(const QWidget* w)
+{
+    QJsonObject o;
+    o[QStringLiteral("class")] = QString::fromUtf8(w->metaObject()->className());
+    if (!w->objectName().isEmpty())
+        o[QStringLiteral("objectName")] = w->objectName();
+    if (!w->accessibleName().isEmpty())
+        o[QStringLiteral("accessibleName")] = w->accessibleName();
+    o[QStringLiteral("enabled")] = w->isEnabled();
+    o[QStringLiteral("visible")] = w->isVisible();
+
+    // Geometry in global screen coordinates so a driver can correlate with
+    // computer-use / screenshots if it ever needs to.
+    const QPoint gp = w->mapToGlobal(QPoint(0, 0));
+    QJsonObject geo;
+    geo[QStringLiteral("x")] = gp.x();
+    geo[QStringLiteral("y")] = gp.y();
+    geo[QStringLiteral("w")] = w->width();
+    geo[QStringLiteral("h")] = w->height();
+    o[QStringLiteral("geometry")] = geo;
+
+    const QString val = widgetValue(w);
+    if (!val.isNull())
+        o[QStringLiteral("value")] = val;
+
+    QJsonArray kids;
+    const QObjectList children = w->children();
+    for (const QObject* child : children) {
+        if (auto* cw = qobject_cast<const QWidget*>(child))
+            kids.append(describeWidget(cw));
+    }
+    if (!kids.isEmpty())
+        o[QStringLiteral("children")] = kids;
+
+    return o;
+}
+
+// Depth-first match by class name (full or short) or accessibleName.
+QWidget* matchRecursive(QWidget* w, const QString& target)
+{
+    const QString fullClass = QString::fromUtf8(w->metaObject()->className());
+    if (fullClass == target
+        || shortClassName(w) == target
+        || w->accessibleName() == target) {
+        return w;
+    }
+    const QObjectList children = w->children();
+    for (QObject* child : children) {
+        if (auto* cw = qobject_cast<QWidget*>(child)) {
+            if (QWidget* m = matchRecursive(cw, target))
+                return m;
+        }
+    }
+    return nullptr;
+}
+
+// Capture a widget to an image. The QRhi panadapter needs a framebuffer
+// readback (QWidget::grab() would return empty/garbage for a GPU surface),
+// so route QRhiWidget through its own grab().
+QImage grabWidget(QWidget* w)
+{
+#ifdef AETHER_GPU_SPECTRUM
+    // QRhiWidget inherits QWidget::grab() (which returns an empty pixmap for a
+    // GPU surface); grabFramebuffer() is the real readback and returns a QImage.
+    if (auto* rhi = qobject_cast<QRhiWidget*>(w))
+        return rhi->grabFramebuffer();
+#endif
+    return w->grab().toImage();
+}
+
+} // namespace
+
+AutomationServer::AutomationServer(QObject* parent)
+    : QObject(parent)
+{
+}
+
+AutomationServer::~AutomationServer()
+{
+    stop();
+}
+
+bool AutomationServer::start(const QString& serverName)
+{
+    if (m_server)
+        return true;
+
+    m_serverName = serverName;
+    m_server = new QLocalServer(this);
+
+    // Clear any stale socket left by a crashed run so we can rebind.
+    QLocalServer::removeServer(serverName);
+
+    if (!m_server->listen(serverName)) {
+        qCWarning(lcAutomation) << "failed to listen on" << serverName << ':'
+                                << m_server->errorString();
+        delete m_server;
+        m_server = nullptr;
+        return false;
+    }
+
+    connect(m_server, &QLocalServer::newConnection,
+            this, &AutomationServer::onNewConnection);
+
+    // Drop a discovery file so a driver can find the resolved endpoint without
+    // knowing the platform-specific socket path. Best-effort; not fatal.
+    m_discoveryFile = QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
+                          .filePath(QStringLiteral("aethersdr-automation.json"));
+    QJsonObject disc;
+    disc[QStringLiteral("socket")]  = fullServerName();
+    disc[QStringLiteral("name")]    = serverName;
+    disc[QStringLiteral("pid")]     = QCoreApplication::applicationPid();
+    disc[QStringLiteral("version")] = QCoreApplication::applicationVersion();
+    QFile df(m_discoveryFile);
+    if (df.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        df.write(QJsonDocument(disc).toJson(QJsonDocument::Compact));
+        df.close();
+    } else {
+        m_discoveryFile.clear();
+    }
+
+    qCInfo(lcAutomation).noquote()
+        << "automation bridge listening on" << fullServerName()
+        << "(verbs: ping, dumpTree, grab)";
+    return true;
+}
+
+void AutomationServer::stop()
+{
+    if (!m_server)
+        return;
+
+    for (auto it = m_buffers.constBegin(); it != m_buffers.constEnd(); ++it)
+        it.key()->deleteLater();
+    m_buffers.clear();
+
+    m_server->close();
+    m_server->deleteLater();
+    m_server = nullptr;
+
+    if (!m_discoveryFile.isEmpty()) {
+        QFile::remove(m_discoveryFile);
+        m_discoveryFile.clear();
+    }
+}
+
+bool AutomationServer::isRunning() const
+{
+    return m_server && m_server->isListening();
+}
+
+QString AutomationServer::fullServerName() const
+{
+    return m_server ? m_server->fullServerName() : QString();
+}
+
+void AutomationServer::onNewConnection()
+{
+    while (m_server && m_server->hasPendingConnections()) {
+        QLocalSocket* sock = m_server->nextPendingConnection();
+        m_buffers.insert(sock, QByteArray());
+        connect(sock, &QLocalSocket::readyRead,
+                this, &AutomationServer::onReadyRead);
+        connect(sock, &QLocalSocket::disconnected,
+                this, &AutomationServer::onDisconnected);
+        qCDebug(lcAutomation) << "client connected;" << m_buffers.size() << "active";
+    }
+}
+
+void AutomationServer::onReadyRead()
+{
+    auto* sock = qobject_cast<QLocalSocket*>(sender());
+    if (!sock || !m_buffers.contains(sock))
+        return;
+
+    QByteArray& buf = m_buffers[sock];
+    buf.append(sock->readAll());
+
+    int nl;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+        const QByteArray line = buf.left(nl);
+        buf.remove(0, nl + 1);
+        if (line.trimmed().isEmpty())
+            continue;
+        const QJsonObject resp = handleLine(line);
+        sock->write(QJsonDocument(resp).toJson(QJsonDocument::Compact));
+        sock->write("\n");
+        sock->flush();
+    }
+}
+
+void AutomationServer::onDisconnected()
+{
+    auto* sock = qobject_cast<QLocalSocket*>(sender());
+    if (!sock)
+        return;
+    m_buffers.remove(sock);
+    sock->deleteLater();
+    qCDebug(lcAutomation) << "client disconnected;" << m_buffers.size() << "active";
+}
+
+QJsonObject AutomationServer::handleLine(const QByteArray& line)
+{
+    QString cmd;
+    QString target;
+    QString path;
+
+    const QByteArray trimmed = line.trimmed();
+    if (trimmed.startsWith('{')) {
+        // JSON request: {"cmd":"grab","target":"...","path":"..."}
+        QJsonParseError err{};
+        const QJsonDocument doc = QJsonDocument::fromJson(trimmed, &err);
+        if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+            return QJsonObject{{QStringLiteral("ok"), false},
+                               {QStringLiteral("error"),
+                                QStringLiteral("invalid JSON: ") + err.errorString()}};
+        }
+        const QJsonObject obj = doc.object();
+        cmd    = obj.value(QStringLiteral("cmd")).toString();
+        target = obj.value(QStringLiteral("target")).toString();
+        path   = obj.value(QStringLiteral("path")).toString();
+    } else {
+        // Bare line: "grab <target> [path]"
+        const QList<QByteArray> parts = trimmed.split(' ');
+        cmd = QString::fromUtf8(parts.value(0));
+        if (parts.size() > 1) target = QString::fromUtf8(parts.value(1));
+        if (parts.size() > 2) path   = QString::fromUtf8(parts.value(2));
+    }
+
+    qCDebug(lcAutomation) << "request:" << cmd << target;
+
+    if (cmd == QLatin1String("ping")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("app"), QStringLiteral("AetherSDR")},
+            {QStringLiteral("version"), QCoreApplication::applicationVersion()},
+        };
+    }
+    if (cmd == QLatin1String("dumpTree")) {
+        return doDumpTree();
+    }
+    if (cmd == QLatin1String("grab")) {
+        if (target.isEmpty())
+            return QJsonObject{{QStringLiteral("ok"), false},
+                               {QStringLiteral("error"),
+                                QStringLiteral("grab requires a target widget")}};
+        return doGrab(target, path);
+    }
+
+    return QJsonObject{{QStringLiteral("ok"), false},
+                       {QStringLiteral("error"),
+                        QStringLiteral("unknown command: ") + cmd}};
+}
+
+QJsonObject AutomationServer::doDumpTree() const
+{
+    QJsonArray roots;
+    const QWidgetList tops = QApplication::topLevelWidgets();
+    for (QWidget* w : tops) {
+        // Skip the transient/internal helper windows Qt creates so the
+        // snapshot stays focused on real UI.
+        if (w->objectName() == QLatin1String("qt_scrollarea_viewport"))
+            continue;
+        roots.append(describeWidget(w));
+    }
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("roots"), roots},
+    };
+}
+
+QJsonObject AutomationServer::doGrab(const QString& target, const QString& path) const
+{
+    QWidget* w = resolveWidget(target);
+    if (!w) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("widget not found: ") + target}};
+    }
+
+    const QImage img = grabWidget(w);
+    if (img.isNull()) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("grab produced an empty image for ") + target}};
+    }
+
+    QString outPath = path;
+    if (outPath.isEmpty()) {
+        QString safe = target;
+        safe.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9_.-]")),
+                     QStringLiteral("_"));
+        outPath = QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
+                      .filePath(QStringLiteral("aether-grab-") + safe + QStringLiteral(".png"));
+    }
+
+    if (!img.save(outPath, "PNG")) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("failed to write PNG: ") + outPath}};
+    }
+
+    const qint64 bytes = QFileInfo(outPath).size();
+    qCInfo(lcAutomation).noquote()
+        << "grabbed" << shortClassName(w) << "->" << outPath
+        << QStringLiteral("(%1x%2, %3 bytes)").arg(img.width()).arg(img.height()).arg(bytes);
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("target"), target},
+        {QStringLiteral("class"), shortClassName(w)},
+        {QStringLiteral("path"), outPath},
+        {QStringLiteral("width"), img.width()},
+        {QStringLiteral("height"), img.height()},
+        {QStringLiteral("bytes"), bytes},
+    };
+}
+
+QWidget* AutomationServer::resolveWidget(const QString& target)
+{
+    const QWidgetList tops = QApplication::topLevelWidgets();
+
+    // 1. Exact objectName (cheap, unambiguous).
+    for (QWidget* tlw : tops) {
+        if (tlw->objectName() == target)
+            return tlw;
+        if (QWidget* c = tlw->findChild<QWidget*>(target))
+            return c;
+    }
+    // 2. Class name or accessibleName (e.g. "SpectrumWidget" for the panadapter).
+    for (QWidget* tlw : tops) {
+        if (QWidget* m = matchRecursive(tlw, target))
+            return m;
+    }
+    return nullptr;
+}
+
+} // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -158,20 +158,30 @@ bool parseBool(const QString& v)
         || s == QLatin1String("checked");
 }
 
-// TX-safety guard for invoke(). Any control whose objectName, accessibleName,
-// or (for buttons) text looks transmit-related is refused unless the operator
-// sets AETHER_AUTOMATION_ALLOW_TX. A test bridge must never key a live radio by
-// accident — note "tune" deliberately covers the ATU tune button, which emits
-// a carrier. Conservative over-blocking is the safe failure mode here.
+// TX-safety guard for invoke(). A control that looks transmit-related is
+// refused unless the operator sets AETHER_AUTOMATION_ALLOW_TX. A test bridge
+// must never key a live radio by accident — "tune" deliberately covers the ATU
+// tune button, which emits a carrier.
+//
+// The guard is scoped to *buttons* on purpose: only a discrete button action
+// (click/toggle) can actually key the radio — MOX, PTT, TUNE, ATU-tune, and VOX
+// enable are all QAbstractButtons. Setpoint sliders/spinboxes/combos named
+// "Tune power", "RF power", "VOX level", etc. never transmit by being moved, so
+// blocking them was over-reach (#3646 QA finding 3). Requiring a button fixes
+// that without weakening safety, since invoke can't key through a value setter.
 bool isTransmitControl(const QWidget* w)
 {
+    const auto* btn = qobject_cast<const QAbstractButton*>(w);
+    if (!btn)
+        return false;  // sliders / combos / spinboxes can't trigger TX
+
     static const QStringList kDeny = {
         QStringLiteral("mox"), QStringLiteral("ptt"), QStringLiteral("tune"),
         QStringLiteral("transmit"), QStringLiteral("vox"),
     };
-    QStringList hay{w->objectName().toLower(), w->accessibleName().toLower()};
-    if (auto* b = qobject_cast<const QAbstractButton*>(w))
-        hay << b->text().toLower();
+    const QStringList hay{w->objectName().toLower(),
+                          w->accessibleName().toLower(),
+                          btn->text().toLower()};
     for (const QString& h : hay)
         for (const QString& d : kDeny)
             if (h.contains(d))
@@ -239,6 +249,56 @@ QJsonObject radioSnapshot(const RadioModel* r)
         {QStringLiteral("paTemp"),       r->paTemp()},
         {QStringLiteral("sliceCount"),   r->slices().size()},
         {QStringLiteral("panCount"),     r->panadapters().size()},
+    };
+}
+
+// TX-chain state (TransmitModel) — RF power, mic/processor, VOX/AM/DEXP, CW, ATU
+// and APD. Lets a QA scenario assert that a TX/Phone/CW applet control actually
+// reached the radio model, not just the widget (#3646 QA finding 2). Read-only:
+// keying state (mox/tune/transmitting) is reported but never driven from here.
+QJsonObject transmitSnapshot(const TransmitModel* t)
+{
+    return QJsonObject{
+        // power / keying (read-only)
+        {QStringLiteral("rfPower"),         t->rfPower()},
+        {QStringLiteral("tunePower"),       t->tunePower()},
+        {QStringLiteral("tuning"),          t->isTuning()},
+        {QStringLiteral("mox"),             t->isMox()},
+        {QStringLiteral("transmitting"),    t->isTransmitting()},
+        {QStringLiteral("maxPowerLevel"),   t->maxPowerLevel()},
+        {QStringLiteral("activeProfile"),   t->activeProfile()},
+        // mic / monitor / processor
+        {QStringLiteral("micSelection"),    t->micSelection()},
+        {QStringLiteral("micLevel"),        t->micLevel()},
+        {QStringLiteral("micAcc"),          t->micAcc()},
+        {QStringLiteral("speechProc"),      t->speechProcessorEnable()},
+        {QStringLiteral("speechProcLevel"), t->speechProcessorLevel()},
+        {QStringLiteral("dax"),             t->daxOn()},
+        {QStringLiteral("monitor"),         t->sbMonitor()},
+        {QStringLiteral("monGainSb"),       t->monGainSb()},
+        {QStringLiteral("activeMicProfile"),t->activeMicProfile()},
+        // VOX / AM / DEXP / TX filter
+        {QStringLiteral("voxEnable"),       t->voxEnable()},
+        {QStringLiteral("voxLevel"),        t->voxLevel()},
+        {QStringLiteral("voxDelay"),        t->voxDelay()},
+        {QStringLiteral("amCarrierLevel"),  t->amCarrierLevel()},
+        {QStringLiteral("dexp"),            t->dexpOn()},
+        {QStringLiteral("dexpLevel"),       t->dexpLevel()},
+        {QStringLiteral("txFilterLow"),     t->txFilterLow()},
+        {QStringLiteral("txFilterHigh"),    t->txFilterHigh()},
+        // CW
+        {QStringLiteral("cwSpeed"),         t->cwSpeed()},
+        {QStringLiteral("cwPitch"),         t->cwPitch()},
+        {QStringLiteral("cwBreakIn"),       t->cwBreakIn()},
+        {QStringLiteral("cwDelay"),         t->cwDelay()},
+        {QStringLiteral("cwSidetone"),      t->cwSidetone()},
+        {QStringLiteral("cwIambic"),        t->cwIambic()},
+        {QStringLiteral("monGainCw"),       t->monGainCw()},
+        {QStringLiteral("monPanCw"),        t->monPanCw()},
+        // ATU / APD
+        {QStringLiteral("atuEnabled"),      t->atuEnabled()},
+        {QStringLiteral("atuMemories"),     t->memoriesEnabled()},
+        {QStringLiteral("apdEnabled"),      t->apdEnabled()},
     };
 }
 
@@ -621,6 +681,8 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
 
     if (model == QLatin1String("radio")) {
         data = radioSnapshot(radio);
+    } else if (model == QLatin1String("transmit")) {
+        data = transmitSnapshot(&radio->transmitModel());
     } else if (model == QLatin1String("slices")) {
         QJsonArray arr;
         for (const SliceModel* s : radio->slices()) arr.append(sliceSnapshot(s));
@@ -655,7 +717,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use radio|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use radio|transmit|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1,5 +1,6 @@
 #include "AutomationServer.h"
 #include "LogManager.h"
+#include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 
 #include <QLocalServer>
 #include <QLocalSocket>
@@ -8,6 +9,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QJsonValue>
 #include <QImage>
 #include <QPixmap>
 #include <QBuffer>
@@ -139,6 +141,105 @@ QImage grabWidget(QWidget* w)
         return rhi->grabFramebuffer();
 #endif
     return w->grab().toImage();
+}
+
+QJsonObject err(const QString& msg)
+{
+    return QJsonObject{{QStringLiteral("ok"), false},
+                       {QStringLiteral("error"), msg}};
+}
+
+// Parse a textual boolean from an invoke value: 1/true/on/yes/checked → true.
+bool parseBool(const QString& v)
+{
+    const QString s = v.trimmed().toLower();
+    return s == QLatin1String("1") || s == QLatin1String("true")
+        || s == QLatin1String("on") || s == QLatin1String("yes")
+        || s == QLatin1String("checked");
+}
+
+// TX-safety guard for invoke(). Any control whose objectName, accessibleName,
+// or (for buttons) text looks transmit-related is refused unless the operator
+// sets AETHER_AUTOMATION_ALLOW_TX. A test bridge must never key a live radio by
+// accident — note "tune" deliberately covers the ATU tune button, which emits
+// a carrier. Conservative over-blocking is the safe failure mode here.
+bool isTransmitControl(const QWidget* w)
+{
+    static const QStringList kDeny = {
+        QStringLiteral("mox"), QStringLiteral("ptt"), QStringLiteral("tune"),
+        QStringLiteral("transmit"), QStringLiteral("vox"),
+    };
+    QStringList hay{w->objectName().toLower(), w->accessibleName().toLower()};
+    if (auto* b = qobject_cast<const QAbstractButton*>(w))
+        hay << b->text().toLower();
+    for (const QString& h : hay)
+        for (const QString& d : kDeny)
+            if (h.contains(d))
+                return true;
+    return false;
+}
+
+// ---- Model snapshots for get(). Hand-built from existing getters so we don't
+// have to annotate every model field as a Q_PROPERTY; one call returns the full
+// assertable state an agent needs. ----
+
+QJsonObject sliceSnapshot(const SliceModel* s)
+{
+    return QJsonObject{
+        {QStringLiteral("sliceId"),    s->sliceId()},
+        {QStringLiteral("letter"),     s->letter()},
+        {QStringLiteral("panId"),      s->panId()},
+        {QStringLiteral("frequency"),  s->frequency()},   // MHz
+        {QStringLiteral("mode"),       s->mode()},
+        {QStringLiteral("filterLow"),  s->filterLow()},
+        {QStringLiteral("filterHigh"), s->filterHigh()},
+        {QStringLiteral("active"),     s->isActive()},
+        {QStringLiteral("txSlice"),    s->isTxSlice()},
+        {QStringLiteral("rxAntenna"),  s->rxAntenna()},
+        {QStringLiteral("rfGain"),     s->rfGain()},
+        {QStringLiteral("audioGain"),  s->audioGain()},
+        {QStringLiteral("audioPan"),   s->audioPan()},
+        {QStringLiteral("locked"),     s->isLocked()},
+        {QStringLiteral("nb"),         s->nbOn()},
+        {QStringLiteral("nbLevel"),    s->nbLevel()},
+        {QStringLiteral("nr"),         s->nrOn()},
+        {QStringLiteral("nrLevel"),    s->nrLevel()},
+        {QStringLiteral("anf"),        s->anfOn()},
+        {QStringLiteral("apf"),        s->apfOn()},
+    };
+}
+
+QJsonObject panSnapshot(const PanadapterModel* p)
+{
+    return QJsonObject{
+        {QStringLiteral("panId"),        p->panId()},
+        {QStringLiteral("centerMhz"),    p->centerMhz()},
+        {QStringLiteral("bandwidthMhz"), p->bandwidthMhz()},
+        {QStringLiteral("minDbm"),       p->minDbm()},
+        {QStringLiteral("maxDbm"),       p->maxDbm()},
+        {QStringLiteral("rxAntenna"),    p->rxAntenna()},
+        {QStringLiteral("rfGain"),       p->rfGain()},
+        {QStringLiteral("wide"),         p->wideActive()},
+        {QStringLiteral("fps"),          p->fps()},
+    };
+}
+
+QJsonObject radioSnapshot(const RadioModel* r)
+{
+    return QJsonObject{
+        {QStringLiteral("name"),         r->name()},
+        {QStringLiteral("model"),        r->model()},
+        {QStringLiteral("version"),      r->version()},
+        {QStringLiteral("serial"),       r->serial()},
+        {QStringLiteral("callsign"),     r->callsign()},
+        {QStringLiteral("nickname"),     r->nickname()},
+        {QStringLiteral("connected"),    r->isConnected()},
+        {QStringLiteral("transmitting"), r->isRadioTransmitting()},
+        {QStringLiteral("txPower"),      r->txPower()},
+        {QStringLiteral("paTemp"),       r->paTemp()},
+        {QStringLiteral("sliceCount"),   r->slices().size()},
+        {QStringLiteral("panCount"),     r->panadapters().size()},
+    };
 }
 
 } // namespace
@@ -274,33 +375,53 @@ void AutomationServer::onDisconnected()
 
 QJsonObject AutomationServer::handleLine(const QByteArray& line)
 {
-    QString cmd;
-    QString target;
-    QString path;
+    QString cmd, target, path, action, value, model, selector, property;
 
     const QByteArray trimmed = line.trimmed();
     if (trimmed.startsWith('{')) {
-        // JSON request: {"cmd":"grab","target":"...","path":"..."}
-        QJsonParseError err{};
-        const QJsonDocument doc = QJsonDocument::fromJson(trimmed, &err);
-        if (err.error != QJsonParseError::NoError || !doc.isObject()) {
-            return QJsonObject{{QStringLiteral("ok"), false},
-                               {QStringLiteral("error"),
-                                QStringLiteral("invalid JSON: ") + err.errorString()}};
-        }
+        // JSON request, e.g.
+        //   {"cmd":"invoke","target":"masterVolume","action":"setValue","value":"30"}
+        //   {"cmd":"get","model":"slice","selector":"active","property":"frequency"}
+        QJsonParseError perr{};
+        const QJsonDocument doc = QJsonDocument::fromJson(trimmed, &perr);
+        if (perr.error != QJsonParseError::NoError || !doc.isObject())
+            return err(QStringLiteral("invalid JSON: ") + perr.errorString());
         const QJsonObject obj = doc.object();
-        cmd    = obj.value(QStringLiteral("cmd")).toString();
-        target = obj.value(QStringLiteral("target")).toString();
-        path   = obj.value(QStringLiteral("path")).toString();
+        cmd      = obj.value(QStringLiteral("cmd")).toString();
+        target   = obj.value(QStringLiteral("target")).toString();
+        path     = obj.value(QStringLiteral("path")).toString();
+        action   = obj.value(QStringLiteral("action")).toString();
+        // value may be a string, number, or bool — normalize to text.
+        const QJsonValue v = obj.value(QStringLiteral("value"));
+        if (v.isString())      value = v.toString();
+        else if (v.isDouble()) value = QString::number(v.toDouble());
+        else if (v.isBool())   value = v.toBool() ? QStringLiteral("true")
+                                                  : QStringLiteral("false");
+        model    = obj.value(QStringLiteral("model")).toString();
+        selector = obj.value(QStringLiteral("selector")).toString();
+        property = obj.value(QStringLiteral("property")).toString();
     } else {
-        // Bare line: "grab <target> [path]"
-        const QList<QByteArray> parts = trimmed.split(' ');
-        cmd = QString::fromUtf8(parts.value(0));
-        if (parts.size() > 1) target = QString::fromUtf8(parts.value(1));
-        if (parts.size() > 2) path   = QString::fromUtf8(parts.value(2));
+        // Bare line. Positional by verb:
+        //   grab   <target> [path]
+        //   invoke <target> <action> [value...]   (value joins the rest)
+        //   get    <model>  [selector] [property]
+        const QList<QByteArray> p = trimmed.split(' ');
+        auto tok = [&p](int i) { return QString::fromUtf8(p.value(i)); };
+        cmd = tok(0);
+        if (cmd == QLatin1String("invoke")) {
+            target = tok(1);
+            action = tok(2);
+            QStringList rest;
+            for (int i = 3; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));
+        } else if (cmd == QLatin1String("get")) {
+            model = tok(1); selector = tok(2); property = tok(3);
+        } else {  // grab and friends
+            target = tok(1); path = tok(2);
+        }
     }
 
-    qCDebug(lcAutomation) << "request:" << cmd << target;
+    qCDebug(lcAutomation) << "request:" << cmd << target << action << model << selector;
 
     if (cmd == QLatin1String("ping")) {
         return QJsonObject{
@@ -309,20 +430,25 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
             {QStringLiteral("version"), QCoreApplication::applicationVersion()},
         };
     }
-    if (cmd == QLatin1String("dumpTree")) {
+    if (cmd == QLatin1String("dumpTree"))
         return doDumpTree();
-    }
     if (cmd == QLatin1String("grab")) {
         if (target.isEmpty())
-            return QJsonObject{{QStringLiteral("ok"), false},
-                               {QStringLiteral("error"),
-                                QStringLiteral("grab requires a target widget")}};
+            return err(QStringLiteral("grab requires a target widget"));
         return doGrab(target, path);
     }
+    if (cmd == QLatin1String("invoke")) {
+        if (target.isEmpty() || action.isEmpty())
+            return err(QStringLiteral("invoke requires a target and an action"));
+        return doInvoke(target, action, value);
+    }
+    if (cmd == QLatin1String("get")) {
+        if (model.isEmpty())
+            return err(QStringLiteral("get requires a model (radio|slice|slices|pan|pans)"));
+        return doGet(model, selector, property);
+    }
 
-    return QJsonObject{{QStringLiteral("ok"), false},
-                       {QStringLiteral("error"),
-                        QStringLiteral("unknown command: ") + cmd}};
+    return err(QStringLiteral("unknown command: ") + cmd);
 }
 
 QJsonObject AutomationServer::doDumpTree() const
@@ -406,6 +532,148 @@ QWidget* AutomationServer::resolveWidget(const QString& target)
             return m;
     }
     return nullptr;
+}
+
+QJsonObject AutomationServer::doInvoke(const QString& target, const QString& action,
+                                       const QString& value) const
+{
+    QWidget* w = resolveWidget(target);
+    if (!w)
+        return err(QStringLiteral("widget not found: ") + target);
+
+    // TX-safety guard — never key a live radio from the test bridge unless the
+    // operator has explicitly opted in. (#3646 Phase 1 safety requirement.)
+    if (isTransmitControl(w)
+        && !qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+        qCWarning(lcAutomation).noquote()
+            << "BLOCKED transmit-related invoke on" << target
+            << "(" << shortClassName(w) << ")";
+        return err(QStringLiteral("blocked: '") + target
+                   + QStringLiteral("' looks transmit-related (MOX/PTT/Tune/Transmit/VOX). "
+                                    "Set AETHER_AUTOMATION_ALLOW_TX=1 to override."));
+    }
+
+    bool done = false;
+    if (action == QLatin1String("click")) {
+        if (auto* b = qobject_cast<QAbstractButton*>(w)) { b->click(); done = true; }
+    } else if (action == QLatin1String("toggle")) {
+        if (auto* b = qobject_cast<QAbstractButton*>(w)) {
+            b->isCheckable() ? b->toggle() : b->click();
+            done = true;
+        }
+    } else if (action == QLatin1String("setChecked")) {
+        if (auto* b = qobject_cast<QAbstractButton*>(w); b && b->isCheckable()) {
+            b->setChecked(parseBool(value)); done = true;
+        }
+    } else if (action == QLatin1String("setValue")) {
+        bool okNum = false;
+        const int n = value.toInt(&okNum);
+        if (auto* s = qobject_cast<QAbstractSlider*>(w)) {
+            if (!okNum) return err(QStringLiteral("setValue needs an integer"));
+            s->setValue(n); done = true;
+        } else if (auto* sb = qobject_cast<QSpinBox*>(w)) {
+            if (!okNum) return err(QStringLiteral("setValue needs an integer"));
+            sb->setValue(n); done = true;
+        } else if (auto* ds = qobject_cast<QDoubleSpinBox*>(w)) {
+            bool okD = false; const double d = value.toDouble(&okD);
+            if (!okD) return err(QStringLiteral("setValue needs a number"));
+            ds->setValue(d); done = true;
+        }
+    } else if (action == QLatin1String("setText")) {
+        if (auto* le = qobject_cast<QLineEdit*>(w)) { le->setText(value); done = true; }
+    } else if (action == QLatin1String("setCurrentText")) {
+        if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentText(value); done = true; }
+    } else if (action == QLatin1String("setCurrentIndex")) {
+        if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentIndex(value.toInt()); done = true; }
+    } else {
+        return err(QStringLiteral("unknown action: ") + action);
+    }
+
+    if (!done)
+        return err(QStringLiteral("action '") + action + QStringLiteral("' not applicable to ")
+                   + shortClassName(w));
+
+    qCInfo(lcAutomation).noquote()
+        << "invoke" << action << "on" << target << "(" << shortClassName(w) << ")";
+
+    QJsonObject r{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("target"), target},
+        {QStringLiteral("class"), shortClassName(w)},
+        {QStringLiteral("action"), action},
+    };
+    const QString nv = widgetValue(w);   // round-trip confirmation
+    if (!nv.isNull())
+        r[QStringLiteral("newValue")] = nv;
+    return r;
+}
+
+QJsonObject AutomationServer::doGet(const QString& model, const QString& selector,
+                                    const QString& property) const
+{
+    RadioModel* radio = m_radioModel;
+    if (!radio)
+        return err(QStringLiteral("no radio model available"));
+
+    // Build the payload object for the requested model, then optionally narrow
+    // to a single property.
+    QJsonObject data;
+
+    if (model == QLatin1String("radio")) {
+        data = radioSnapshot(radio);
+    } else if (model == QLatin1String("slices")) {
+        QJsonArray arr;
+        for (const SliceModel* s : radio->slices()) arr.append(sliceSnapshot(s));
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slices"), arr}};
+    } else if (model == QLatin1String("pans")) {
+        QJsonArray arr;
+        for (const PanadapterModel* p : radio->panadapters()) arr.append(panSnapshot(p));
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("pans"), arr}};
+    } else if (model == QLatin1String("slice")) {
+        const SliceModel* s = nullptr;
+        const QList<SliceModel*> slices = radio->slices();
+        if (selector.isEmpty() || selector == QLatin1String("active")) {
+            for (SliceModel* c : slices) if (c->isActive()) { s = c; break; }
+            if (!s && !slices.isEmpty()) s = slices.first();
+        } else if (selector == QLatin1String("tx")) {
+            for (SliceModel* c : slices) if (c->isTxSlice()) { s = c; break; }
+        } else {
+            bool okId = false; const int id = selector.toInt(&okId);
+            if (okId) s = radio->slice(id);
+        }
+        if (!s)
+            return err(QStringLiteral("no slice for selector '") + selector + QStringLiteral("'"));
+        data = sliceSnapshot(s);
+    } else if (model == QLatin1String("pan")) {
+        const PanadapterModel* p = nullptr;
+        if (selector.isEmpty() || selector == QLatin1String("active"))
+            p = radio->activePanadapter();
+        else
+            p = radio->panadapter(selector);   // by panId, e.g. "0x40000000"
+        if (!p)
+            return err(QStringLiteral("no panadapter for selector '") + selector + QStringLiteral("'"));
+        data = panSnapshot(p);
+    } else {
+        return err(QStringLiteral("unknown model: ") + model
+                   + QStringLiteral(" (use radio|slice|slices|pan|pans)"));
+    }
+
+    if (!property.isEmpty()) {
+        if (!data.contains(property))
+            return err(QStringLiteral("no property '") + property + QStringLiteral("' on ") + model);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("model"), model},
+            {QStringLiteral("property"), property},
+            {QStringLiteral("value"), data.value(property)},
+        };
+    }
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("model"), model},
+        {model, data},   // keyed by model name: "radio" / "slice" / "pan"
+    };
 }
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -13,15 +13,17 @@ class QJsonObject;
 
 namespace AetherSDR {
 
-// In-app, agent-first automation bridge (issue #3646, Phase 0).
+class RadioModel;
+
+// In-app, agent-first automation bridge (issue #3646, Phases 0-1).
 //
 // Exposes a tiny line/JSON command channel over a QLocalServer so an external
-// agent can introspect and capture the GUI without driving OS accessibility
-// APIs or pixel-hunting through VNC. It is *off* in production and only starts
-// when the AETHER_AUTOMATION environment variable is set, so it adds no attack
-// surface or overhead to normal runs.
+// agent can introspect, drive, and capture the GUI without driving OS
+// accessibility APIs or pixel-hunting through VNC. It is *off* in production
+// and only starts when the AETHER_AUTOMATION environment variable is set, so
+// it adds no attack surface or overhead to normal runs.
 //
-// Phase 0 implements two read-only verbs:
+// Phase 0 verbs (read-only introspection + capture):
 //
 //   dumpTree                       -> ARIA-style JSON snapshot of every
 //                                     top-level QWidget hierarchy (objectName,
@@ -33,15 +35,31 @@ namespace AetherSDR {
 //                                     framebuffer for the QRhi panadapter so
 //                                     the live spectrum is captured correctly.
 //
-// Requests are newline-delimited. Each line is either a bare command
-// ("ping", "dumpTree", "grab SpectrumWidget /tmp/pan.png") or a JSON object
-// ({"cmd":"grab","target":"SpectrumWidget","path":"/tmp/pan.png"}). Each
-// request yields exactly one compact-JSON response line.
+// Phase 1 verbs (drive + assert):
 //
-// Later phases (invoke/get/replay) layer onto this same channel; keeping it
-// separate from TciServer is deliberate — TCI has external protocol-compat
-// constraints (eesdr-tci aborts on unknown commands) and test verbs must never
-// leak into a radio-control protocol.
+//   invoke <target> <action> [v]   -> drive a control deterministically:
+//                                     click / toggle / setChecked / setValue /
+//                                     setText / setCurrentText / setCurrentIndex.
+//                                     SAFETY: refuses transmit-related controls
+//                                     (MOX/PTT/Tune/Transmit/VOX) unless the
+//                                     AETHER_AUTOMATION_ALLOW_TX env var is set,
+//                                     so the bridge can never key a live radio
+//                                     by accident.
+//   get <model> [selector] [prop]  -> live JSON snapshot of a model:
+//                                     radio | slice <id|active|tx> | slices |
+//                                     pan <panId|active> | pans. With a trailing
+//                                     property name, returns just that field.
+//                                     Assert on state without screenshots.
+//
+// Requests are newline-delimited. Each line is either a bare command
+// ("dumpTree", "grab SpectrumWidget /tmp/pan.png", "invoke masterVolume
+// setValue 30", "get slice active") or a JSON object ({"cmd":"invoke",
+// "target":"masterVolume","action":"setValue","value":"30"}). Each request
+// yields exactly one compact-JSON response line.
+//
+// Keeping this separate from TciServer is deliberate — TCI has external
+// protocol-compat constraints (eesdr-tci aborts on unknown commands) and test
+// verbs must never leak into a radio-control protocol.
 class AutomationServer : public QObject {
     Q_OBJECT
 
@@ -61,6 +79,11 @@ public:
     QString serverName() const { return m_serverName; }
     QString fullServerName() const;  // resolved socket path / pipe name
 
+    // Live model handle for the get() verb. Set once at startup from the
+    // MainWindow's active-session RadioModel; may be null (get() then reports
+    // "no radio model" rather than crashing).
+    void setRadioModel(RadioModel* model) { m_radioModel = model; }
+
 private slots:
     void onNewConnection();
     void onReadyRead();
@@ -72,6 +95,10 @@ private:
 
     QJsonObject doDumpTree() const;
     QJsonObject doGrab(const QString& target, const QString& path) const;
+    QJsonObject doInvoke(const QString& target, const QString& action,
+                         const QString& value) const;
+    QJsonObject doGet(const QString& model, const QString& selector,
+                      const QString& property) const;
 
     // Resolve a target string to a widget: exact objectName first, then
     // class name (with or without namespace) or accessibleName.
@@ -81,6 +108,7 @@ private:
     QString       m_serverName;
     QString       m_discoveryFile;
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
+    QPointer<RadioModel> m_radioModel;           // for get(); may be null
 };
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -40,16 +40,18 @@ class RadioModel;
 //   invoke <target> <action> [v]   -> drive a control deterministically:
 //                                     click / toggle / setChecked / setValue /
 //                                     setText / setCurrentText / setCurrentIndex.
-//                                     SAFETY: refuses transmit-related controls
-//                                     (MOX/PTT/Tune/Transmit/VOX) unless the
-//                                     AETHER_AUTOMATION_ALLOW_TX env var is set,
-//                                     so the bridge can never key a live radio
-//                                     by accident.
+//                                     SAFETY: refuses transmit-related *buttons*
+//                                     (MOX/PTT/Tune/ATU-tune/VOX enable) unless
+//                                     AETHER_AUTOMATION_ALLOW_TX is set, so the
+//                                     bridge can never key a live radio by
+//                                     accident. Setpoint sliders/combos (e.g.
+//                                     "Tune power", "RF power") are not blocked —
+//                                     moving a value setter can't key.
 //   get <model> [selector] [prop]  -> live JSON snapshot of a model:
-//                                     radio | slice <id|active|tx> | slices |
-//                                     pan <panId|active> | pans. With a trailing
-//                                     property name, returns just that field.
-//                                     Assert on state without screenshots.
+//                                     radio | transmit | slice <id|active|tx> |
+//                                     slices | pan <panId|active> | pans. With a
+//                                     trailing property name, returns just that
+//                                     field. Assert on state without screenshots.
 //
 // Requests are newline-delimited. Each line is either a bare command
 // ("dumpTree", "grab SpectrumWidget /tmp/pan.png", "invoke masterVolume

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -40,13 +40,15 @@ class RadioModel;
 //   invoke <target> <action> [v]   -> drive a control deterministically:
 //                                     click / toggle / setChecked / setValue /
 //                                     setText / setCurrentText / setCurrentIndex.
-//                                     SAFETY: refuses transmit-related *buttons*
-//                                     (MOX/PTT/Tune/ATU-tune/VOX enable) unless
+//                                     SAFETY: refuses any control marked as
+//                                     transmit-keying (markTxKeying() / the
+//                                     "aetherTxKeying" property — MOX/PTT, TUNE,
+//                                     ATU, CWX send, packet/APRS send) unless
 //                                     AETHER_AUTOMATION_ALLOW_TX is set, so the
 //                                     bridge can never key a live radio by
-//                                     accident. Setpoint sliders/combos (e.g.
-//                                     "Tune power", "RF power") are not blocked —
-//                                     moving a value setter can't key.
+//                                     accident. A button-scoped name heuristic
+//                                     is a logged fallback; setpoint
+//                                     sliders/combos are never blocked.
 //   get <model> [selector] [prop]  -> live JSON snapshot of a model:
 //                                     radio | transmit | slice <id|active|tx> |
 //                                     slices | pan <panId|active> | pans. With a

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <QObject>
+#include <QHash>
+#include <QPointer>
+#include <QByteArray>
+#include <QString>
+
+class QLocalServer;
+class QLocalSocket;
+class QWidget;
+class QJsonObject;
+
+namespace AetherSDR {
+
+// In-app, agent-first automation bridge (issue #3646, Phase 0).
+//
+// Exposes a tiny line/JSON command channel over a QLocalServer so an external
+// agent can introspect and capture the GUI without driving OS accessibility
+// APIs or pixel-hunting through VNC. It is *off* in production and only starts
+// when the AETHER_AUTOMATION environment variable is set, so it adds no attack
+// surface or overhead to normal runs.
+//
+// Phase 0 implements two read-only verbs:
+//
+//   dumpTree                       -> ARIA-style JSON snapshot of every
+//                                     top-level QWidget hierarchy (objectName,
+//                                     class, accessibleName, role/value,
+//                                     enabled, visible, global geometry).
+//   grab <target> [path]           -> PNG capture of a single widget, resolved
+//                                     by objectName, class name, or
+//                                     accessibleName. Reads back the GPU
+//                                     framebuffer for the QRhi panadapter so
+//                                     the live spectrum is captured correctly.
+//
+// Requests are newline-delimited. Each line is either a bare command
+// ("ping", "dumpTree", "grab SpectrumWidget /tmp/pan.png") or a JSON object
+// ({"cmd":"grab","target":"SpectrumWidget","path":"/tmp/pan.png"}). Each
+// request yields exactly one compact-JSON response line.
+//
+// Later phases (invoke/get/replay) layer onto this same channel; keeping it
+// separate from TciServer is deliberate — TCI has external protocol-compat
+// constraints (eesdr-tci aborts on unknown commands) and test verbs must never
+// leak into a radio-control protocol.
+class AutomationServer : public QObject {
+    Q_OBJECT
+
+public:
+    explicit AutomationServer(QObject* parent = nullptr);
+    ~AutomationServer() override;
+
+    // Start listening on the given QLocalServer name. Returns false if the
+    // server could not bind (e.g. a stale socket that could not be removed).
+    // On success the resolved socket path is written to a discovery file
+    // (<temp>/aethersdr-automation.json) so a driver can find it without
+    // guessing the platform-specific endpoint.
+    bool start(const QString& serverName);
+    void stop();
+
+    bool isRunning() const;
+    QString serverName() const { return m_serverName; }
+    QString fullServerName() const;  // resolved socket path / pipe name
+
+private slots:
+    void onNewConnection();
+    void onReadyRead();
+    void onDisconnected();
+
+private:
+    // Dispatch a single request line and return the response object.
+    QJsonObject handleLine(const QByteArray& line);
+
+    QJsonObject doDumpTree() const;
+    QJsonObject doGrab(const QString& target, const QString& path) const;
+
+    // Resolve a target string to a widget: exact objectName first, then
+    // class name (with or without namespace) or accessibleName.
+    static QWidget* resolveWidget(const QString& target);
+
+    QLocalServer* m_server{nullptr};
+    QString       m_serverName;
+    QString       m_discoveryFile;
+    QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
+};
+
+} // namespace AetherSDR

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -41,6 +41,7 @@ Q_LOGGING_CATEGORY(lcAx25,       "aether.ax25",        QtWarningMsg)
 Q_LOGGING_CATEGORY(lcWaveform,   "aether.waveform",    QtWarningMsg)
 Q_LOGGING_CATEGORY(lcKiwiSdr,    "aether.kiwisdr",     QtDebugMsg)
 Q_LOGGING_CATEGORY(lcKiwiSdrAudio, "aether.kiwisdr.audio", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcAutomation, "aether.automation",  QtInfoMsg)
 
 LogManager::LogManager()
 {
@@ -74,6 +75,7 @@ LogManager::LogManager()
         {"aether.waveform",   "Waveform",    "Docker waveform image install upload"},
         {"aether.kiwisdr",    "KiwiSDR",     "KiwiSDR remote RX antennas: connect, handshake, audio/waterfall negotiation, reconnect, profile lifecycle"},
         {"aether.kiwisdr.audio", "KiwiSDR Audio/DSP", "Verbose KiwiSDR receive audio: frame decode, resampler, jitter/FIFO under/overrun, mixing (high-rate; off by default)"},
+        {"aether.automation", "Automation Bridge", "Agent-drivable test bridge (#3646): QLocalServer verbs, widget snapshots, captures (AETHER_AUTOMATION only)"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -41,6 +41,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcAx25)
 Q_DECLARE_LOGGING_CATEGORY(lcWaveform)
 Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdr)
 Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdrAudio)
+Q_DECLARE_LOGGING_CATEGORY(lcAutomation)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/TxKeyingMarker.h
+++ b/src/core/TxKeyingMarker.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Authoritative marker for controls that *key the transmitter* when activated —
+// MOX/PTT, TUNE, ATU tune, CWX CW send, AX.25 packet send, and any future
+// keying control. The #3646 automation bridge refuses invoke() on any widget
+// carrying this marker unless AETHER_AUTOMATION_ALLOW_TX is set, so an agent can
+// never key a live radio by accident during hardware-in-the-loop tests.
+//
+// This is a *positive* signal set at the keying control's creation site, which
+// is far more robust than matching control names: a TX-capable control is
+// guarded because it was explicitly declared keying, not because its label
+// happened to contain a magic word. Name matching remains in the bridge only as
+// a logged belt-and-suspenders fallback for controls that predate or forget the
+// marker.
+//
+// Usage at the call site, right after creating the button:
+//     m_moxBtn = new QPushButton("MOX");
+//     markTxKeying(m_moxBtn);
+inline constexpr char kTxKeyingProperty[] = "aetherTxKeying";
+
+inline void markTxKeying(QWidget* w)
+{
+    if (w)
+        w->setProperty(kTxKeyingProperty, true);
+}
+
+} // namespace AetherSDR

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -3,6 +3,7 @@
 #include "FramelessWindowTitleBar.h"
 #include "FramelessResizer.h"
 #include "core/AppSettings.h"
+#include "core/TxKeyingMarker.h"
 #include "models/BandPlanManager.h"
 #include "models/MeterModel.h"
 #include "models/PanadapterModel.h"
@@ -299,6 +300,7 @@ void AtuPreTuneDialog::buildConfigPage()
     btnRow->addStretch(1);
     m_cancelBtn = new QPushButton("Cancel", m_configPage);
     m_startBtn  = new QPushButton("START", m_configPage);
+    markTxKeying(m_startBtn);   // starts the ATU pre-tune sweep → keys TX (#3646)
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_startBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
         "color: {{color.text.primary}}; padding: 4px 12px; font-weight: bold; }"
         "QPushButton:hover { background: #007038; }"
@@ -336,12 +338,14 @@ void AtuPreTuneDialog::buildSweepPage()
 
     auto* row = new QHBoxLayout;
     m_tuneBtn  = new QPushButton("Tune this frequency", m_sweepPage);
+    markTxKeying(m_tuneBtn);   // tunes the current point → keys TX (#3646)
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_tuneBtn, "QPushButton { background: #006030; border: 1px solid #008040; "
         "color: {{color.text.primary}}; padding: 4px 12px; font-weight: bold; }"
         "QPushButton:hover { background: #007038; }"
         "QPushButton:disabled { background: #1a2a1a; color: #556070; }");
     m_skipBtn  = new QPushButton("Skip", m_sweepPage);
     m_continueAfterFailBtn = new QPushButton("Continue", m_sweepPage);
+    markTxKeying(m_continueAfterFailBtn);   // resumes tuning after a failed point → keys TX (#3646)
     m_continueAfterFailBtn->setVisible(false);
     m_abortBtn = new QPushButton("ABORT", m_sweepPage);
     setAbortButtonAbortMode();

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -3,6 +3,7 @@
 #include "core/AudioEngine.h"
 #include "core/AppSettings.h"
 #include "core/DaxTxPolicy.h"
+#include "core/TxKeyingMarker.h"
 #include "core/LogManager.h"
 #include "core/MaidenheadLocator.h"
 #include "core/ThemeManager.h"
@@ -938,6 +939,7 @@ Ax25HfPacketDecodeDialog::Ax25HfPacketDecodeDialog(AudioEngine* audio,
     m_txText->setPlaceholderText(QStringLiteral("hello world  or  N0CALL-1>APRS,WIDE1-1:hello world"));
     txLayout->addWidget(m_txText, 1);
     m_txButton = new QPushButton(QStringLiteral("Transmit"), txFrame);
+    markTxKeying(m_txButton);   // transmits an AX.25 packet → keys TX (#3646)
     m_txButton->setMinimumHeight(42);
     txLayout->addWidget(m_txButton);
 
@@ -2606,6 +2608,7 @@ QWidget* Ax25HfPacketDecodeDialog::buildTerminalPage()
     m_terminalInput->installEventFilter(this); // Up/Down command history
     inputRow->addWidget(m_terminalInput, 1);
     m_terminalSendButton = new QPushButton(QStringLiteral("Send"), inputFrame);
+    markTxKeying(m_terminalSendButton);   // sends a packet → keys TX; "Send" matches no keyword (#3646 review)
     m_terminalSendButton->setMinimumHeight(36);
     inputRow->addWidget(m_terminalSendButton);
     layout->addWidget(inputFrame);
@@ -2988,6 +2991,7 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
     m_aprsBeaconText->setText(AprsSettings::beaconText());
     config->addWidget(m_aprsBeaconText, 1, 5);
     m_aprsBeaconNow = new QPushButton(QStringLiteral("Beacon Now"), configFrame);
+    markTxKeying(m_aprsBeaconNow);   // transmits an APRS beacon → keys TX (#3646)
     config->addWidget(m_aprsBeaconNow, 1, 6);
     config->setColumnStretch(5, 1);
 
@@ -3050,6 +3054,7 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
         QStringLiteral("Message text (sent with ack request, retries until acked)"));
     msgLayout->addWidget(m_aprsMsgText, 1);
     m_aprsMsgSend = new QPushButton(QStringLiteral("Send APRS Msg"), msgFrame);
+    markTxKeying(m_aprsMsgSend);   // transmits an APRS message → keys TX (#3646)
     m_aprsMsgSend->setMinimumHeight(42);
     msgLayout->addWidget(m_aprsMsgSend);
     m_aprsEnvelope = new QPushButton(QStringLiteral("✉"), msgFrame);

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -1,4 +1,5 @@
 #include "CwxPanel.h"
+#include "core/TxKeyingMarker.h"
 #include "models/CwxModel.h"
 
 #include <QVBoxLayout>
@@ -170,6 +171,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     barLayout->setSpacing(4);
 
     m_sendBtn = new QPushButton("Send");
+    markTxKeying(m_sendBtn);   // sends CW → keys TX; label "Send" matches no keyword (#3646 review)
     m_sendBtn->setStyleSheet(kBtnStyle);
     barLayout->addWidget(m_sendBtn);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -177,6 +177,12 @@ public:
     explicit MainWindow(QWidget* parent = nullptr);
     ~MainWindow() override;
 
+    // Active-session RadioModel. Bound to the current session's model, so it
+    // tracks Multi-Flex session switches. Used by the automation bridge
+    // (#3646) to read live model state via get(); keep it read-oriented.
+    RadioModel& radioModel() { return m_radioModel; }
+    const RadioModel& radioModel() const { return m_radioModel; }
+
 protected:
     void showEvent(QShowEvent* event) override;
     void closeEvent(QCloseEvent* event) override;

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -4,6 +4,7 @@
 #include "ComboStyle.h"
 #include "HGauge.h"
 #include "Theme.h"
+#include "core/TxKeyingMarker.h"
 #include "models/RadioModel.h"
 #include "models/TransmitModel.h"
 #include "models/TunerModel.h"
@@ -216,6 +217,7 @@ void TxApplet::buildUI()
             "border: 1px solid #2a3040; }";
 
         m_tuneBtn = new QPushButton("TUNE");
+        markTxKeying(m_tuneBtn);   // emits a tune carrier — keys TX (#3646)
         m_tuneBtn->setStyleSheet(btnStyle);
         m_tuneBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_tuneBtn->setFixedHeight(22);
@@ -229,6 +231,7 @@ void TxApplet::buildUI()
         row->addWidget(m_tuneBtn);
 
         m_moxBtn = new QPushButton("MOX");
+        markTxKeying(m_moxBtn);    // manual transmit (PTT) — keys TX (#3646)
         m_moxBtn->setStyleSheet(btnStyle);
         m_moxBtn->setCheckable(true);
         m_moxBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
@@ -238,6 +241,7 @@ void TxApplet::buildUI()
         row->addWidget(m_moxBtn);
 
         m_atuBtn = new QPushButton("ATU");
+        markTxKeying(m_atuBtn);    // starts ATU tune — keys TX (#3646)
         m_atuBtn->setStyleSheet(btnStyle);
         m_atuBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_atuBtn->setFixedHeight(22);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,11 @@
 #include "core/GpuSelector.h"
 #include "core/LogManager.h"
 #include "core/MacMicPermission.h"
+#include "core/AutomationServer.h"
 
 #include <QApplication>
 #include <QSurfaceFormat>
+#include <memory>
 #include <QStyleFactory>
 #include <QDir>
 #include <QDebug>
@@ -408,6 +410,20 @@ int main(int argc, char* argv[])
     {
         AetherSDR::MainWindow window;
         window.show();
+
+        // Agent-drivable automation bridge (#3646, Phase 0). Off in production;
+        // starts only when AETHER_AUTOMATION is set. AETHER_AUTOMATION_SOCKET
+        // overrides the default QLocalServer name.
+        std::unique_ptr<AetherSDR::AutomationServer> automation;
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+            const QString sockName = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
+                ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
+                : QStringLiteral("aethersdr-automation");
+            automation = std::make_unique<AetherSDR::AutomationServer>();
+            if (!automation->start(sockName))
+                automation.reset();
+        }
+
         exitCode = app.exec();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,6 +420,7 @@ int main(int argc, char* argv[])
                 ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
                 : QStringLiteral("aethersdr-automation");
             automation = std::make_unique<AetherSDR::AutomationServer>();
+            automation->setRadioModel(&window.radioModel());  // for the get() verb
             if (!automation->start(sockName))
                 automation.reset();
         }

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+AetherSDR automation-bridge probe (issue #3646, Phase 0).
+
+Drives the in-app automation bridge that AetherSDR exposes when launched with
+AETHER_AUTOMATION=1. The bridge is a QLocalServer speaking newline-delimited
+JSON. This probe needs no Qt or third-party deps -- it talks to the AF_UNIX
+socket (macOS/Linux) or the named pipe (Windows) directly.
+
+It exercises the two Phase-0 verbs and saves the canonical deliverables:
+  * an applet semantic snapshot  -> <out>/tree.json
+  * a panadapter PNG capture     -> <out>/panadapter.png
+
+Discovery: the running app writes the resolved socket path to
+<temp>/aethersdr-automation.json, so you don't have to know the platform
+endpoint. Pass --socket to override.
+
+Usage:
+    AETHER_AUTOMATION=1 ./AetherSDR &        # launch the app with the bridge on
+    python tools/automation_probe.py         # snapshot + panadapter grab
+    python tools/automation_probe.py ping
+    python tools/automation_probe.py grab SpectrumWidget /tmp/pan.png
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+import tempfile
+
+
+def discover_socket():
+    """Read the discovery file the running app drops in the temp dir."""
+    disc = os.path.join(tempfile.gettempdir(), "aethersdr-automation.json")
+    if not os.path.exists(disc):
+        return None
+    try:
+        with open(disc) as f:
+            return json.load(f).get("socket")
+    except (OSError, ValueError):
+        return None
+
+
+class Bridge:
+    """One short-lived connection to the bridge; supports many requests."""
+
+    def __init__(self, sock_path):
+        self.sock_path = sock_path
+        self._buf = b""
+        if sys.platform == "win32":
+            # Qt named pipe: \\.\pipe\<name>. Open like a file.
+            self._pipe = open(rf"\\.\pipe\{os.path.basename(sock_path)}", "r+b", buffering=0)
+            self._sock = None
+        else:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.connect(sock_path)
+            self._pipe = None
+
+    def request(self, obj):
+        line = (json.dumps(obj) + "\n").encode()
+        if self._sock:
+            self._sock.sendall(line)
+            return self._read_line_sock()
+        self._pipe.write(line)
+        self._pipe.flush()
+        return json.loads(self._pipe.readline().decode())
+
+    def _read_line_sock(self):
+        while b"\n" not in self._buf:
+            chunk = self._sock.recv(65536)
+            if not chunk:
+                raise ConnectionError("bridge closed the connection")
+            self._buf += chunk
+        line, _, self._buf = self._buf.partition(b"\n")
+        return json.loads(line.decode())
+
+    def close(self):
+        if self._sock:
+            self._sock.close()
+        if self._pipe:
+            self._pipe.close()
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Drive the AetherSDR automation bridge")
+    ap.add_argument("command", nargs="?", default="demo",
+                    choices=["demo", "ping", "dumpTree", "grab"],
+                    help="verb to run (default: demo = dumpTree + panadapter grab)")
+    ap.add_argument("target", nargs="?", help="widget target for grab")
+    ap.add_argument("path", nargs="?", help="output path for grab")
+    ap.add_argument("--socket", help="override the bridge socket path")
+    ap.add_argument("--out", default=".", help="output dir for demo artifacts")
+    args = ap.parse_args()
+
+    sock_path = args.socket or discover_socket()
+    if not sock_path:
+        sys.exit("error: no bridge socket found. Launch the app with "
+                 "AETHER_AUTOMATION=1, or pass --socket.")
+
+    try:
+        bridge = Bridge(sock_path)
+    except OSError as e:
+        sys.exit(f"error: could not connect to {sock_path}: {e}")
+
+    try:
+        if args.command == "ping":
+            print(json.dumps(bridge.request({"cmd": "ping"}), indent=2))
+
+        elif args.command == "dumpTree":
+            print(json.dumps(bridge.request({"cmd": "dumpTree"}), indent=2))
+
+        elif args.command == "grab":
+            if not args.target:
+                sys.exit("error: grab requires a target widget name")
+            req = {"cmd": "grab", "target": args.target}
+            if args.path:
+                req["path"] = args.path
+            print(json.dumps(bridge.request(req), indent=2))
+
+        else:  # demo: produce the Phase-0 deliverables
+            os.makedirs(args.out, exist_ok=True)
+
+            pong = bridge.request({"cmd": "ping"})
+            print(f"connected: {pong.get('app')} {pong.get('version')}")
+
+            tree = bridge.request({"cmd": "dumpTree"})
+            tree_path = os.path.join(args.out, "tree.json")
+            with open(tree_path, "w") as f:
+                json.dump(tree, f, indent=2)
+            n_roots = len(tree.get("roots", []))
+            print(f"snapshot: {n_roots} top-level window(s) -> {tree_path}")
+
+            png_path = os.path.abspath(os.path.join(args.out, "panadapter.png"))
+            grab = bridge.request({"cmd": "grab", "target": "SpectrumWidget",
+                                   "path": png_path})
+            if grab.get("ok"):
+                print(f"panadapter: {grab['width']}x{grab['height']}, "
+                      f"{grab['bytes']} bytes -> {grab['path']}")
+            else:
+                print(f"panadapter grab failed: {grab.get('error')}", file=sys.stderr)
+                sys.exit(1)
+    finally:
+        bridge.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -83,12 +83,22 @@ class Bridge:
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Drive the AetherSDR automation bridge")
+    ap = argparse.ArgumentParser(
+        description="Drive the AetherSDR automation bridge",
+        epilog="examples:\n"
+               "  automation_probe.py demo\n"
+               "  automation_probe.py get radio\n"
+               "  automation_probe.py get slice active frequency\n"
+               "  automation_probe.py invoke 'Master volume' setValue 35\n"
+               "  automation_probe.py grab SpectrumWidget /tmp/pan.png",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command", nargs="?", default="demo",
-                    choices=["demo", "ping", "dumpTree", "grab"],
+                    choices=["demo", "ping", "dumpTree", "grab", "invoke", "get"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
-    ap.add_argument("target", nargs="?", help="widget target for grab")
-    ap.add_argument("path", nargs="?", help="output path for grab")
+    ap.add_argument("rest", nargs="*",
+                    help="verb args: grab <target> [path] | "
+                         "invoke <target> <action> [value] | "
+                         "get <model> [selector] [property]")
     ap.add_argument("--socket", help="override the bridge socket path")
     ap.add_argument("--out", default=".", help="output dir for demo artifacts")
     args = ap.parse_args()
@@ -111,11 +121,30 @@ def main():
             print(json.dumps(bridge.request({"cmd": "dumpTree"}), indent=2))
 
         elif args.command == "grab":
-            if not args.target:
+            if not args.rest:
                 sys.exit("error: grab requires a target widget name")
-            req = {"cmd": "grab", "target": args.target}
-            if args.path:
-                req["path"] = args.path
+            req = {"cmd": "grab", "target": args.rest[0]}
+            if len(args.rest) > 1:
+                req["path"] = args.rest[1]
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "invoke":
+            if len(args.rest) < 2:
+                sys.exit("error: invoke needs <target> <action> [value]")
+            req = {"cmd": "invoke", "target": args.rest[0], "action": args.rest[1]}
+            if len(args.rest) > 2:
+                req["value"] = " ".join(args.rest[2:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "get":
+            if not args.rest:
+                sys.exit("error: get needs <model> [selector] [property] "
+                         "(model = radio|slice|slices|pan|pans)")
+            req = {"cmd": "get", "model": args.rest[0]}
+            if len(args.rest) > 1:
+                req["selector"] = args.rest[1]
+            if len(args.rest) > 2:
+                req["property"] = args.rest[2]
             print(json.dumps(bridge.request(req), indent=2))
 
         else:  # demo: produce the Phase-0 deliverables


### PR DESCRIPTION
## Summary

Adds the agent-drivable test surface proposed in #3646: an in-process, agent-first automation bridge for cross-OS UX testing of the panadapter/waterfall and applet controls. It gives an agent the "snapshot → act → assert" loop we already use for web work, but for our native Qt 6 Widgets UI — fast, deterministic, identical on macOS/Windows/Linux, and CI-friendly.

This closes a loop that agent-driven development otherwise leaves open, which is why Anthropic considers it foundational rather than nice-to-have. An agent like Claude Code can already write a feature, but on a native desktop app it has had no way to *verify* its own change: there is no DOM to query, no in-process handle on the accessibility tree, and a screenshot of a live SDR spectrum is non-deterministic noise that can't be asserted against. 

Anthropic's view is that the single largest multiplier on agentic coding is a tight, machine-checkable feedback loop — an agent that can act, observe the real result, and assert on it produces dramatically fewer confident-but-wrong changes than one that edits blind and hands the work back for a human to test. 

This bridge gives Claude Code (and any other agent working this repo) exactly that loop for AetherSDR's GUI: drive a control, read the model's ground truth, capture the panadapter, and prove the change did what was intended. It converts "this should work" into "I ran it and here is the evidence" — precisely the Evidence-Over-Assertion discipline the project constitution already asks of every contributor, human or AI. And the value compounds: the same verbs that let an agent self-check a one-off edit become the substrate for deterministic, cross-OS regression tests in CI, so a behavior verified once stays verified on every platform without a human in the loop.

The whole thing is **gated behind `AETHER_AUTOMATION`** and is completely inert in production: no server, no socket, no overhead when the env var is unset.

This is a **dedicated channel, not an extension of TCI** — per the issue's explicit recommendation, since TCI has external protocol-compat constraints (eesdr-tci aborts on unknown commands) and test verbs must never leak into a radio-control protocol.

## What's in it

A `QLocalServer` (AF_UNIX socket / Windows named pipe) speaking newline-delimited JSON. Four verbs:

| Verb | What it does |
|---|---|
| `dumpTree` | ARIA-style JSON snapshot of every top-level `QWidget` tree — class, objectName, accessibleName, enabled, visible, global geometry, and a best-effort live `value` for sliders/buttons/combos/labels. Our "DOM" for controls. |
| `grab <target> [path]` | PNG capture of any widget. Routes the GPU panadapter through `QRhiWidget::grabFramebuffer()` so the live spectrum is captured correctly (`QWidget::grab()` returns an empty surface for a `QRhiWidget`). |
| `invoke <target> <action> [value]` | Drive a control deterministically: `click`/`toggle`/`setChecked`/`setValue`/`setText`/`setCurrentText`/`setCurrentIndex`. Echoes post-action state as `newValue`. |
| `get <model> [selector] [property]` | Live JSON snapshot of `radio`/`transmit`/`slice`/`slices`/`pan`/`pans` (frequency, mode, filter, NB/NR, center MHz, min/max dBm, RF/mic/CW TX-chain, …). Assert on state without screenshots. |

Targets resolve by `objectName` → class name → `accessibleName` → button text. A driver discovers the socket via a discovery file (`<temp>/aethersdr-automation.json`), so it needs no Qt and no knowledge of the platform endpoint.

## 🚨 TX safety

`invoke` **cannot key the radio by accident**, and the mechanism is a **positive marker, not name matching**. Every genuinely-keying control is tagged at its creation site with `markTxKeying()` — the `aetherTxKeying` dynamic property (see [`src/core/TxKeyingMarker.h`](src/core/TxKeyingMarker.h)) — covering MOX/PTT, TUNE, ATU, CWX CW send, and AX.25 packet/APRS send. `invoke` refuses anything carrying that marker, so a control is blocked because it was *declared* keying, not because its label happened to contain a magic word. That closes the structural hole a substring blocklist leaves: it catches keying buttons like **"Send"** and **"Beacon Now"** that no keyword would match, and a keying control added later is guarded the moment it's marked. Marked controls report `"keying": true` in `dumpTree`, so an agent sees what's off-limits before trying.

A button-scoped name heuristic (`mox/ptt/tune/atu/transmit/vox/cwx`) remains only as a *logged* belt-and-suspenders fallback for any keying control that predates the marker — when it fires it warns that the control needs an explicit `markTxKeying()`. Setpoint sliders/combos (`Tune power`, `RF power`, `VOX level`) are never blocked — moving a value setter can't transmit. Override is an explicit opt-in: `AETHER_AUTOMATION_ALLOW_TX=1`, for deliberate hardware-in-the-loop tests. The socket itself is restricted to the owning user (`QLocalServer::UserAccessOption`, 0600) so another local user can't drive the TX-reachable endpoint.

## Design notes

- **`get` uses hand-built model snapshots** from existing getters rather than reflecting `Q_PROPERTY` — so the diff touches **no model internals** (PanadapterModel exposes its display state via plain getters, not properties) and one call returns the full assertable state an agent needs.
- **`MainWindow::radioModel()`** is the one new public accessor; it returns the active-session model so `get` tracks Multi-Flex session switches. `main.cpp` hands it to the server via `setRadioModel()`.
- New `lcAutomation` logging category, registered in the Support dialog.
- Stale-socket self-heal: a hard kill skips the C++ dtor, but the next launch clears the stale socket (`removeServer`) and rewrites the discovery file.

## Verification (live, on a connected FLEX-8400M)

- `dumpTree` → 43 top-level windows, 196 accessibleNames, 1212 live values.
- `grab SpectrumWidget` → 2896×1502 GPU framebuffer readback of the live spectrum (not a blank).
- `get radio`/`slice`/`pan` → correct live state (3.6 MHz LSB, center 3.892 MHz, −124/−34 dBm).
- `invoke "Master volume" setValue 35` → round-tripped (`newValue:35`).
- **TX guard (marker-based) refused every keying control — MOX, Tune, ATU, and the CWX "Send" button, which matches no keyword — while setpoint sliders (`Tune power`, `RF power`) stayed drivable; radio `transmitting:false` throughout.**

## Scope

- Purely additive: **+1518 / −0**. New files: the automation server, the `TxKeyingMarker.h` guard helper, the agent guide, and the no-dependency Python driver. Small hooks elsewhere: CMake source list, a log category, the `radioModel()` accessor, the `main.cpp` startup gate, and one-line `markTxKeying()` calls at each keying control.
- The full agent-facing reference lives in [`docs/automation-bridge.md`](docs/automation-bridge.md).

## Not in this PR (tracked in #3646)

- **Accessibility-linter backlog** — finishing the `setAccessibleName`/`QAccessibleInterface` annotations the linter flags. Improves real accessibility *and* `dumpTree` snapshot quality; handled as a dedicated accessibility change.
- **Replay/fixture mode** — feed a recorded VITA-49 FFT + meter stream so the panadapter is reproducible without hardware, unlocking deterministic visual diffs.
- **CI E2E matrix** — `QT_QPA_PLATFORM=offscreen` + agent scenarios + per-OS perceptual golden diffs.

## Test plan

```bash
cmake --build build --parallel
AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
python3 tools/automation_probe.py demo                 # tree.json + panadapter.png
python3 tools/automation_probe.py get radio
python3 tools/automation_probe.py invoke "MOX transmit" click   # → blocked
```

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat

