### PR TITLE
fix(spectrum): draw the panadapter grid below the FFT trace in the GPU path (#3606)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6988,6 +6988,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // #3606: the grid lives in the background layer so it composites
             // BELOW the FFT trace (GPU/software parity) -- the rectangular grid
             // cells must sit behind the signal peaks, not paint over them.
+            // Reset opacity first: the bg-image branch above leaves bp at
+            // (1 - m_bgOpacity/100), and drawGrid sets its own pen but not
+            // opacity, so the grid must not inherit the image opacity (review @NF0T).
+            bp.setOpacity(1.0);
             drawGrid(bp, specRect);
             m_overlayBgNeedsUpload = true;
         }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6985,6 +6985,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 bp.setOpacity(1.0 - m_bgOpacity / 100.0);
                 bp.drawImage(specRect.topLeft(), m_bgScaled);
             }
+            // #3606: the grid lives in the background layer so it composites
+            // BELOW the FFT trace (GPU/software parity) -- the rectangular grid
+            // cells must sit behind the signal peaks, not paint over them.
+            drawGrid(bp, specRect);
             m_overlayBgNeedsUpload = true;
         }
 
@@ -6994,7 +6998,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QPainter p(&m_overlayStatic);
             p.setRenderHint(QPainter::Antialiasing, false);
 
-            drawGrid(p, specRect);
+            // #3606: grid moved to the background layer (composites below the
+            // FFT trace). The static overlay composites ABOVE the trace, so only
+            // markers/scales/band-plan that belong on top of the peaks stay here.
             if (m_bandPlanFontSize > 0)
                 drawBandPlan(p, specRect);
 


### PR DESCRIPTION
## Summary

Fixes #3606. In the GPU (`QRhi`) render path the panadapter **grid** (the dB / frequency lines that form the rectangular cells) was composited **on top of** the FFT trace, so it painted over the signal peaks — visible interference in the reporter's screenshot. This moves the grid below the trace, matching the software path and conventional panadapter rendering.

## Root cause — GPU vs. software z-order parity gap

The software (`QPainter`) path already draws the grid correctly, **behind** the trace:

```cpp
drawGrid(p, specRect);      // grid first
drawSpectrum(p, specRect);  // trace on top
```

The GPU path composites the frame from texture layers. Per `renderGpuFrame()` the order is (bottom → top):

1. waterfall
2. **background layer** `m_overlayBg` (fill + background image) — explicitly drawn *below* the FFT (this is what #3124 fixed for the background image)
3. FFT fill + line (the trace / peaks)
4. **static overlay** `m_overlayStatic` — drawn *above* the FFT
5. slice flags

The grid was baked into the **static overlay** (step 4), so it composited *after* — i.e. over — the peaks. #3124 moved the background *image* below the trace but left the grid on top; this closes the remaining half of that parity gap.

> The maintainer triage bot independently reached the same diagnosis and proposed this exact move — see the [triage comment on #3606](https://github.com/aethersdr/AetherSDR/issues/3606).

## The change

Move **only** the grid into `m_overlayBg` (the layer already composited below the FFT). Everything else in the static overlay — band plan, slice/TNF markers, frequency scale, indicators — stays on top, exactly as the software path draws them after `drawSpectrum()`.

Resulting GPU order, now identical to software:

```
waterfall → bg fill/image → grid → FFT fill/line → band plan / markers / scales / flags
```

## Performance — neutral by construction

The grid is in the render hot path, so worth being explicit: this is **zero-cost**. `m_overlayBg` and `m_overlayStatic` are both rebuilt under the *same* `m_overlayStaticDirty` gate and uploaded on the same cadence. The grid was already painted once per dirty event; it is now painted into a different cached layer — same paint, same upload, no per-frame work added. No interaction with the waterfall or FFT pipelines.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Verified visually: grid renders behind the peaks (before/after screenshots below). The software path is the reference for correct z-order.

<!-- before: grid painting over the peaks (current release) -->
<!-- after:  grid sitting behind the peaks -->

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3 msvc2022_64, GPU path on)
- [x] Visual check: grid now composites behind the FFT trace, matching the software path
- [ ] Existing tests pass (CI)
- [x] Reproduction / expected result documented (#3606)
- [ ] Cross-platform GPU paths (Metal/Vulkan) — same code path; a macOS/Linux screenshot welcome

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A)
- [x] Documentation updated if user-visible behavior changed (N/A — code comments at the move sites)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
