### PR TITLE
[codex] Add source-attributed KiwiSDR denial messages

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -17,6 +17,17 @@ is entirely original. SmartSDR is a trademark of FlexRadio Systems.
   FlexLib:   Copyright (c) 2012-2025 FlexRadio Systems
   Reference: https://www.flexradio.com/
 
+The KiwiSDR receive integration includes source-attributed terminal
+denial-message labels derived from the LGPL-marked KiwiSDR server source. No
+KiwiSDR code is incorporated, vendored, translated, or linked into AetherSDR;
+the referenced source is used only to label server MSG keys and numeric badp
+denial codes in original AetherSDR error handling.
+
+  KiwiSDR source: Copyright (c) 2014-2024 John Seamons and contributors
+  License:        LGPL-2.0-or-later, per consulted file headers
+  Source:         https://github.com/jks-prv/Beagle_SDR_GPS
+  Reference:      commit efb38e2b25137029cb37a96a94e03366f8d2871e
+
 
 1. WDSP — Spectral Noise Reduction (NR2)
 -----------------------------------------

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -392,11 +392,21 @@ with NR2 disabled; they must not be collapsed into the legacy applet Kiwi
 output buffer, because the final mixer only treats that buffer as active when
 the applet-level Kiwi Audio toggle is enabled.
 
-## Sources Not Used
+## Source Provenance
 
-- No KiwiSDR source code, AGPL repositories, served JavaScript, server code,
-  decoder code, protocol handlers, copied snippets, blogs, forums, or
-  implementation-derived assets were used.
+- The original KiwiSDR receive-path implementation used no KiwiSDR source code,
+  AGPL repositories, served JavaScript, server code, decoder code, protocol
+  handlers, copied snippets, blogs, forums, or implementation-derived assets.
+- A later, source-attributed denial-message follow-up intentionally consulted
+  the LGPL-marked KiwiSDR source repository
+  `https://github.com/jks-prv/Beagle_SDR_GPS.git` at commit
+  `efb38e2b25137029cb37a96a94e03366f8d2871e` to label terminal connection
+  denial codes and MSG keys. No KiwiSDR code was copied, translated, or
+  vendored; the AetherSDR handlers and user-facing strings are original.
+  The consulted files were `rx/rx_cmd.h`, `rx/rx_cmd.cpp`,
+  `support/stats.cpp`, `rx/rx_server.cpp`, `rx/rx_sound.cpp`, and
+  `rx/rx_util.cpp`, each carrying GNU Library General Public License
+  version 2-or-later headers in that source snapshot.
 - No WebSDR source code, prior WebSDR worktrees, PR #3612, prior WebSDR
   threads, contaminated temporary files, or rollout summaries were used.
 
@@ -460,11 +470,13 @@ the active audio source. Connected but inactive profiles may continue serving
 waterfall data, but they must not spend CPU decoding/resampling unused audio
 frames because that can starve the active NR2 path.
 
-The KiwiSDR-side behavior is implemented only where it was observed directly.
-The client opens the observed `SND` and `W/F` sockets, sends only receive-side
-setup commands, requests uncompressed audio, converts 12 kHz mono samples to
-24 kHz stereo float PCM, and projects received W/F rows onto the current
-AetherSDR panadapter using the server-reported full W/F center and bandwidth.
+The KiwiSDR-side receive behavior is implemented only where it was observed
+directly, except for the terminal denial-message labels called out in
+[Source-Attributed Denial Messages](#source-attributed-denial-messages). The
+client opens the observed `SND` and `W/F` sockets, sends only receive-side setup
+commands, requests uncompressed audio, converts 12 kHz mono samples to 24 kHz
+stereo float PCM, and projects received W/F rows onto the current AetherSDR
+panadapter using the server-reported full W/F center and bandwidth.
 The existing panadapter waterfall controls are source-aware: while a Kiwi
 profile is selected they update the selected profile's W/F cell, W/F floor, and
 W/F rate settings only; while a normal Flex antenna is selected they retain the
@@ -508,6 +520,35 @@ operator-relevant: Auto Connect is enabled or a slice is still assigned to that
 Kiwi RX antenna. Server-declared terminal conditions such as `badp`, busy,
 disabled, down, redirect, or camp disconnect are not retried by this local
 recovery path.
+
+## Source-Attributed Denial Messages
+
+The source-attributed follow-up uses the LGPL-marked KiwiSDR source snapshot
+identified in [Source Provenance](#source-provenance) only as a protocol
+reference for terminal denial labels:
+
+- `rx/rx_cmd.h` defines `badp` values 0-7 as OK, try-again/authentication
+  rejection, still determining local IP, IP not allowed, no admin password set,
+  no multiple connections, database update in progress, and admin connection
+  already open.
+- `rx/rx_cmd.cpp` and `support/stats.cpp` send `MSG ip_limit=<minutes>,<ip>`
+  when a per-IP 24-hour usage limit is reached. This message shape was also
+  observed on the wire, so AetherSDR keeps the defensive `ip_limit` parser and
+  reports the server's minute value when valid.
+- `support/stats.cpp` sends `MSG inactivity_timeout=<minutes>` when a connected
+  client exceeds the server inactivity timer.
+- `rx/rx_server.cpp` sends `MSG wb_only` for wideband-only servers and
+  `MSG exclusive_use` when a receiver is locked for exclusive use.
+- `rx/rx_sound.cpp` sends `MSG password_timeout` when password authentication
+  times out.
+- `rx/rx_util.cpp` sends encoded `MSG kiwi_kick=<count>,<message>` when the
+  server kicks sound/waterfall/extension clients.
+
+The runtime still treats these as terminal denial/disconnect states only. It
+does not add new setup commands, does not infer extension behavior, and ignores
+unknown MSG keys. `badp=5` is intentionally worded with both the source-derived
+duplicate-IP meaning and the observed public-access/password hint, because
+deployed receivers have returned that value during public-auth rejection.
 
 Because the observed uncompressed `SND` payload is 512 mono samples at 12 kHz,
 arrival cadence averages about 43 ms per frame but can bunch into burst/gap
@@ -728,9 +769,10 @@ The first safe step is protocol-independent scaffolding:
 ## Non-Goals For This Scaffolding Pass
 
 - No transmitted state, PTT, MOX, tune, or Flex radio mutations.
-- No KiwiSDR wire messages or decoder behavior guessed from memory; every
+- No KiwiSDR wire commands or decoder behavior guessed from memory; every
   implemented wire command and frame interpretation above came from the
-  black-box observations in this thread.
+  black-box observations in this thread. The terminal denial-message labels are
+  the source-attributed exception documented above.
 - No reuse of WebSDR code paths or assumptions.
 - No visual-theme or main-layout changes beyond the requested applet and
   per-panadapter toggle.

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1845,11 +1845,9 @@ void KiwiSdrClient::handleMessage(StreamKind stream, const QByteArray& frame)
 void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
 {
     traceInboundText(stream, text);
-    const QString message = text.startsWith(QStringLiteral("MSG"))
-        ? text.mid(3).trimmed()
-        : text.trimmed();
+    const QVector<KiwiSdrProtocol::MsgToken> msgTokens =
+        KiwiSdrProtocol::parseMsgTokens(text);
 
-    const QStringList parts = message.split(QLatin1Char(' '), Qt::SkipEmptyParts);
     auto setSoundSampleRate = [this](double value) {
         if (!std::isfinite(value) || value < 8000.0 || value > 48000.0) {
             return;
@@ -1863,11 +1861,10 @@ void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
             m_soundResampler.reset();
         }
     };
-    auto messageValue = [&parts](const QString& requestedKey) {
-        for (const QString& candidate : parts) {
-            const int candidateEq = candidate.indexOf(QLatin1Char('='));
-            if (candidateEq > 0 && candidate.left(candidateEq) == requestedKey) {
-                return candidate.mid(candidateEq + 1);
+    auto messageValue = [&msgTokens](const QString& requestedKey) {
+        for (const KiwiSdrProtocol::MsgToken& candidate : msgTokens) {
+            if (candidate.hasValue && candidate.key == requestedKey) {
+                return candidate.value;
             }
         }
         return QString();
@@ -1889,19 +1886,24 @@ void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
         }
         return trKiwiSdrClient("KiwiSDR endpoint is disabled.");
     };
-    for (const QString& part : parts) {
-        const int eq = part.indexOf(QLatin1Char('='));
-        if (eq <= 0) {
-            continue;
+    for (const KiwiSdrProtocol::MsgToken& token : msgTokens) {
+        const QString& key = token.key;
+        const QString& valueText = token.value;
+        if (token.hasValue) {
+            qCDebug(lcKiwiSdr).noquote()
+                << "KiwiSDR MSG"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << key << "=" << abbreviatedMsgValue(valueText);
+            traceProtocolEvent(QStringLiteral("PARSED %1 %2=%3")
+                .arg(streamLabel(stream), key, abbreviatedMsgValue(valueText)));
+        } else {
+            qCDebug(lcKiwiSdr).noquote()
+                << "KiwiSDR MSG"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << key;
+            traceProtocolEvent(QStringLiteral("PARSED %1 %2")
+                .arg(streamLabel(stream), key));
         }
-        const QString key = part.left(eq);
-        const QString valueText = part.mid(eq + 1);
-        qCDebug(lcKiwiSdr).noquote()
-            << "KiwiSDR MSG"
-            << QStringLiteral("endpoint=%1").arg(logEndpoint())
-            << key << "=" << abbreviatedMsgValue(valueText);
-        traceProtocolEvent(QStringLiteral("PARSED %1 %2=%3")
-            .arg(streamLabel(stream), key, abbreviatedMsgValue(valueText)));
         if (key == QStringLiteral("too_busy")) {
             bool busyOk = false;
             const int busyValue = valueText.toInt(&busyOk);

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -86,6 +86,50 @@ QString statusPreflightFailureMessage(int firstHttpStatus,
                            "connect. Try again later.");
 }
 
+// Source-attributed badp labels are documented in the KiwiSDR design note.
+QString badpMessage(int badp, const QString& identityDiagnostic)
+{
+    switch (badp) {
+    case 1:
+        return trKiwiSdrClient("KiwiSDR rejected this authentication attempt "
+                               "(badp=1). %1 This endpoint may require a "
+                               "password or site-specific login.")
+            .arg(identityDiagnostic);
+    case 2:
+        return trKiwiSdrClient("This KiwiSDR is still determining whether this "
+                               "client is local (badp=2). Try again in a few "
+                               "moments.");
+    case 3:
+        return trKiwiSdrClient("This KiwiSDR does not allow access from this IP "
+                               "address (badp=3).");
+    case 4:
+        return trKiwiSdrClient("This KiwiSDR does not allow remote admin access "
+                               "because no admin password is set (badp=4).");
+    case 5:
+        return trKiwiSdrClient("KiwiSDR rejected public receive access (badp=5). "
+                               "This can mean the server does not allow another "
+                               "connection from this IP address; some deployed "
+                               "receivers have also returned it for public-access "
+                               "rejection. %1 This endpoint may require a password "
+                               "or site-specific login.")
+            .arg(identityDiagnostic);
+    case 6:
+        return trKiwiSdrClient("This KiwiSDR is temporarily unavailable while "
+                               "its database is updating (badp=6). Try again "
+                               "in about a minute.");
+    case 7:
+        return trKiwiSdrClient("This KiwiSDR already has an admin connection "
+                               "open (badp=7).");
+    default:
+        return trKiwiSdrClient("KiwiSDR rejected public receive access "
+                               "(badp=%1). %2 This endpoint may require a "
+                               "password, site-specific login, or a different "
+                               "public access policy.")
+            .arg(badp)
+            .arg(identityDiagnostic);
+    }
+}
+
 quint32 readLittleEndianU32(const char* data)
 {
     const auto* bytes = reinterpret_cast<const uchar*>(data);
@@ -1897,6 +1941,22 @@ void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
             }
             continue;
         }
+        if (key == QStringLiteral("wb_only")) {
+            setState(
+                State::Error,
+                tr("This KiwiSDR is configured for wideband use only and does "
+                   "not accept normal receiver connections."));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("exclusive_use")) {
+            setState(
+                State::Error,
+                tr("This KiwiSDR is locked for exclusive use by another "
+                   "operation. Try again later or choose another receiver."));
+            cleanupSockets();
+            return;
+        }
         if (key == QStringLiteral("camp_disconnect")) {
             setState(State::Error,
                      tr("KiwiSDR camping queue disconnected this client."));
@@ -1938,6 +1998,40 @@ void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
             cleanupSockets();
             return;
         }
+        if (key == QStringLiteral("inactivity_timeout")) {
+            bool minutesOk = false;
+            const int minutes = valueText.toInt(&minutesOk);
+            setState(
+                State::Error,
+                minutesOk && minutes > 0
+                    ? tr("This KiwiSDR disconnected the session after %1 "
+                         "minutes without tuning or activity.")
+                          .arg(minutes)
+                    : tr("This KiwiSDR disconnected the session for inactivity."));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("password_timeout")) {
+            setState(
+                State::Error,
+                tr("This KiwiSDR timed out waiting for password authentication."));
+            cleanupSockets();
+            return;
+        }
+        if (key == QStringLiteral("kiwi_kick")) {
+            const QString decoded =
+                QUrl::fromPercentEncoding(valueText.toUtf8()).trimmed();
+            const int comma = decoded.indexOf(QLatin1Char(','));
+            const QString reason =
+                comma >= 0 ? decoded.mid(comma + 1).trimmed() : QString();
+            setState(State::Error,
+                     reason.isEmpty()
+                         ? tr("This KiwiSDR disconnected this client.")
+                         : tr("This KiwiSDR disconnected this client: %1")
+                               .arg(reason));
+            cleanupSockets();
+            return;
+        }
         if (key == QStringLiteral("audio_init")) {
             // audio_init confirms setup progress, not usable decoded audio.
             // Wait for the first accepted SND frame so camping/silent sessions
@@ -1956,14 +2050,8 @@ void KiwiSdrClient::handleTextMessage(StreamKind stream, const QString& text)
                 m_startupTrace.badpNonzeroSeen = true;
             }
             if (badp != 0) {
-                setState(
-                    State::Error,
-                    tr("KiwiSDR rejected public receive access (badp=%1). "
-                       "%2 This endpoint may require a password, "
-                       "site-specific login, or a different public access "
-                       "policy.")
-                        .arg(badp)
-                        .arg(identityDiagnosticText()));
+                setState(State::Error,
+                         badpMessage(badp, identityDiagnosticText()));
                 cleanupSockets();
                 return;
             }

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -136,6 +136,36 @@ float waterfallColorIndex(float dbm, float minDbm, float maxDbm)
     return std::sqrt(normalized);
 }
 
+QVector<MsgToken> parseMsgTokens(const QString& message)
+{
+    const QString body = message.startsWith(QStringLiteral("MSG"))
+        ? message.mid(3).trimmed()
+        : message.trimmed();
+    const QStringList parts =
+        body.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+
+    QVector<MsgToken> tokens;
+    tokens.reserve(parts.size());
+    for (const QString& part : parts) {
+        const int eq = part.indexOf(QLatin1Char('='));
+        if (eq == 0) {
+            continue;
+        }
+
+        MsgToken token;
+        if (eq > 0) {
+            token.key = part.left(eq);
+            token.value = part.mid(eq + 1);
+            token.hasValue = true;
+        } else {
+            token.key = part;
+            token.hasValue = false;
+        }
+        tokens.append(token);
+    }
+    return tokens;
+}
+
 IpLimitNotice parseIpLimitNotice(const QString& valueText)
 {
     const QString decoded =

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -34,6 +34,12 @@ struct IpLimitNotice {
     bool valid{false};
 };
 
+struct MsgToken {
+    QString key;
+    QString value;
+    bool hasValue{false};
+};
+
 enum class MeterSource {
     Unknown,
     SndMetadata,
@@ -93,6 +99,7 @@ quint64 sequenceGapCount(int previousSequence, int currentSequence);
 float waterfallByteToDisplayLevel(unsigned char value);
 WaterfallAperture autoWaterfallAperture(const QVector<float>& binsDbm);
 float waterfallColorIndex(float dbm, float minDbm, float maxDbm);
+QVector<MsgToken> parseMsgTokens(const QString& message);
 IpLimitNotice parseIpLimitNotice(const QString& valueText);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -101,6 +101,36 @@ int main()
         return fail("invalid ip_limit notice should be rejected");
     }
 
+    const QVector<MsgToken> msgTokens = parseMsgTokens(
+        QStringLiteral("MSG wb_only password_timeout inactivity_timeout=15 "
+                       "kiwi_kick=1%2coperator%20request badp=5 =ignored"));
+    if (msgTokens.size() != 5) {
+        return fail("MSG token parser should keep flags and key-value tokens");
+    }
+    if (msgTokens[0].key != QStringLiteral("wb_only")
+        || msgTokens[0].hasValue) {
+        return fail("MSG flag-only token parsing is wrong");
+    }
+    if (msgTokens[1].key != QStringLiteral("password_timeout")
+        || msgTokens[1].hasValue) {
+        return fail("MSG second flag-only token parsing is wrong");
+    }
+    if (msgTokens[2].key != QStringLiteral("inactivity_timeout")
+        || msgTokens[2].value != QStringLiteral("15")
+        || !msgTokens[2].hasValue) {
+        return fail("MSG key-value token parsing is wrong");
+    }
+    if (msgTokens[3].key != QStringLiteral("kiwi_kick")
+        || msgTokens[3].value != QStringLiteral("1%2coperator%20request")
+        || !msgTokens[3].hasValue) {
+        return fail("MSG encoded key-value token parsing is wrong");
+    }
+    if (msgTokens[4].key != QStringLiteral("badp")
+        || msgTokens[4].value != QStringLiteral("5")
+        || !msgTokens[4].hasValue) {
+        return fail("MSG badp token parsing is wrong");
+    }
+
     QVector<float> row(1024, -100.0f);
     for (int i = 1003; i < row.size(); ++i) {
         row[i] = -60.0f;


### PR DESCRIPTION
## Summary

Reintroduce source-attributed KiwiSDR terminal denial handling for the MSG keys and `badp` labels that were intentionally left out of #3699. The follow-up adds provenance in `THIRD_PARTY_LICENSES` and `docs/kiwisdr-cleanroom-design.md`, cites the consulted LGPL-marked KiwiSDR source snapshot, and keeps `badp=5` wording conservative because deployed receivers have returned it for public-access rejection as well as the source-derived duplicate-IP case.

## Constitution principle honored

Principle IV — the protocol labels come from a documented open-source LGPL reference snapshot, with no KiwiSDR code copied, translated, vendored, or linked into AetherSDR.

## Test plan

- [x] Local build passes (`cmake --build /private/tmp/aethersdr-kiwi-source-attribution-build --target AetherSDR -- -j4`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (`ctest --test-dir /private/tmp/aethersdr-kiwi-source-attribution-build -R '^kiwi_sdr_protocol_test$' --output-on-failure`)
- [x] Reproduction steps documented if user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
