### PR TITLE
fix(automation): redact masked QLineEdit values in dumpTree (#3646)

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -54,8 +54,15 @@ QString widgetValue(const QWidget* w)
     }
     if (auto* cb = qobject_cast<const QComboBox*>(w))
         return cb->currentText();
-    if (auto* le = qobject_cast<const QLineEdit*>(w))
+    if (auto* le = qobject_cast<const QLineEdit*>(w)) {
+        // Never serialize masked fields (password / PIN / keychain secrets):
+        // dumpTree is written to a temp tree.json, so returning the cleartext
+        // would exfiltrate credentials. Reporting a placeholder keeps the field
+        // assertable (present / non-empty) without leaking the value. (#3646)
+        if (le->echoMode() != QLineEdit::Normal)
+            return le->text().isEmpty() ? QString() : QStringLiteral("<hidden>");
         return le->text();
+    }
     if (auto* sb = qobject_cast<const QSpinBox*>(w))
         return QString::number(sb->value());
     if (auto* ds = qobject_cast<const QDoubleSpinBox*>(w))


### PR DESCRIPTION
Follow-up to #3710 (merged) — addresses @aethersdr-agent's post-merge review finding.

## Problem

`dumpTree`'s `widgetValue()` returned `QLineEdit::text()` for **every** line edit, with no echo-mode check. So masked credential fields were serialized in **cleartext** — and the bridge writes `dumpTree` into a temp `tree.json` (`automation_probe.py demo`), so the secret lands in a temp-dir artifact an agent or CI run could read.

Affected `QLineEdit::Password` fields:
- `src/gui/ConnectionPanel.cpp:407` — SmartLink radio password
- `src/gui/MqttSettingsDialog.cpp:110` — MQTT broker password

The bridge is opt-in (`AETHER_AUTOMATION`) and the socket is same-user `0600`, so this isn't privilege escalation — but writing live credentials to a temp file is an easy footgun, and worth closing.

## Fix

One spot in `widgetValue()` — redact any non-`Normal` echo mode (`Password` / `NoEcho` / `PasswordEchoOnEdit`):

```cpp
if (auto* le = qobject_cast<const QLineEdit*>(w)) {
    if (le->echoMode() != QLineEdit::Normal)
        return le->text().isEmpty() ? QString() : QStringLiteral("<hidden>");
    return le->text();
}
```

Slightly more than the suggested one-liner: a **populated** masked field serializes as `"<hidden>"`, an **empty** one omits `value` entirely — so the field stays assertable (present / empty / set) without ever exposing the secret. Normal fields are unchanged.

## Verification (live, FLEX-8400M)

Typed a canary secret into the SmartLink password field via `invoke`, then:

- password field → `"value": "<hidden>"` ✓
- canary string **absent** from the full `dumpTree` JSON ✓
- canary string **absent** from the `tree.json` artifact written by `automation_probe.py demo` ✓
- Normal `QLineEdit` (email) still serializes its value — no over-redaction ✓
- emptied masked field → `value` omitted ✓

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
