### PR TITLE
feat(automation): validation hardening for the agent automation bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,10 +499,13 @@ and drive a `QLocalServer` that speaks newline-delimited JSON:
   `aetherTxKeying` property — MOX/PTT, TUNE, ATU, CWX send, packet/APRS send)
   unless `AETHER_AUTOMATION_ALLOW_TX=1`** — the bridge can never key a live
   radio by accident; setpoint sliders ("Tune power", "RF power") stay drivable.
-  Marked controls show `"keying": true` in `dumpTree`.
-- `get radio|transmit|slice|slices|pan|pans [selector] [property]` → live JSON
-  model snapshot (frequency, mode, filter, NB/NR, center MHz, min/max dBm,
-  RF/mic/CW TX-chain, …). Assert on truth without screenshots.
+  Marked controls show `"keying": true` in `dumpTree`. Also **refuses disabled
+  controls** (no silent no-op). Disambiguate duplicate names with a scoped
+  target: `"RxApplet/AF gain"` vs `"PanadapterApplet/AF gain"`.
+- `get radio|transmit|equalizer|slice|slices|pan|pans [selector] [property]` →
+  live JSON model snapshot (frequency, mode, filter, NB/NR, squelch/AGC/APF,
+  center MHz, min/max dBm, RF/mic/CW TX-chain, EQ bands, …). Assert on truth
+  without screenshots. Sliders/spinboxes also report `range` in `dumpTree`.
 
 Quick start: `python3 tools/automation_probe.py demo` (no Qt dependency); also
 `get radio`, `invoke 'Master volume' setValue 35`. Full reference — protocol,

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -116,10 +116,16 @@ Each `<node>`:
   "visible": true,
   "geometry": { "x": 1, "y": 104, "w": 1448, "h": 751 },  // GLOBAL screen coords
   "value": "42",                           // best-effort; see below
+  "range": { "min": 0, "max": 100 },       // numeric controls only (slider/spinbox)
   "keying": true,                          // present only on TX-keying controls (invoke refuses these)
   "children": [ <node>, … ]                // present only if non-empty
 }
 ```
+
+The `range` lets a driver validate against the real bounds (scale) and detect
+**circular/wrapping** controls without guessing: if `setValue(max)` doesn't stick
+but a mid value does, the control wraps (e.g. a 0–360° phase slider where step 72
+≡ 0°) — classify it as wrapping, not broken.
 
 **The `value` field** is the fast path for state assertions — it's filled in
 for common controls so you can assert without a screenshot:
@@ -162,6 +168,13 @@ like `grab`.
 
 `newValue` echoes the control's state *after* the action (same field `dumpTree`
 reports) — a free round-trip confirmation.
+
+**Disabled controls are refused.** Qt's `setValue()`/`setChecked()` still mutate
+a *disabled* widget, so without a guard the bridge would report a happy
+`newValue` while the radio never sees the change (the control is greyed out for
+a reason — wrong mode, not connected, …). `invoke` on a disabled widget returns
+`{"ok":false,"disabled":true,"error":"refused: '…' is disabled …"}` instead, so
+the no-op is an explicit, assertable signal.
 
 | `action` | applies to | `value` |
 |---|---|---|
@@ -214,8 +227,9 @@ connects).
 |---|---|---|
 | `radio` | — | radio snapshot (name, model, version, connected, transmitting, txPower, paTemp, slice/pan counts) |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
+| `equalizer` (or `eq`) | — | 8-band RX+TX graphic EQ: `rxEnabled`/`txEnabled` and `rx`/`tx` band maps keyed by label (`63`…`8k`). Validate EQ-applet slider changes. |
 | `slices` | — | array of all slice snapshots |
-| `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, txSlice, …) |
+| `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, **squelch/squelchLevel, agcMode/agcThreshold, apf/apfLevel**, txSlice, …) |
 | `pans` | — | array of all panadapter snapshots |
 | `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps) |
 
@@ -233,6 +247,13 @@ Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
 
 `grab` and `invoke` resolve a `target` string in this order — first match wins:
 
+0. **Scoped `"<scope>/<name>"`** — disambiguates a control whose
+   `accessibleName` appears in more than one applet (e.g. `"AF gain"` and
+   `"Squelch threshold"` exist in **both** `RxApplet` and `PanadapterApplet`).
+   `<scope>` matches an ancestor by objectName, class, or accessibleName;
+   `<name>` is resolved within that subtree. Use `"RxApplet/AF gain"` vs
+   `"PanadapterApplet/AF gain"`. Falls through to flat matching if it doesn't
+   resolve, so a literal `/` in a name still works.
 1. **Exact `objectName`** — the most stable handle. Prefer this.
 2. **Class name** — full (`AetherSDR::SpectrumWidget`) or short
    (`SpectrumWidget`). Handy when a widget has no objectName (the panadapter is
@@ -328,4 +349,9 @@ lands.
   [`.cpp`](../src/core/AutomationServer.cpp)
 - Startup wiring: [`src/main.cpp`](../src/main.cpp) (after `window.show()`)
 - Driver: [`tools/automation_probe.py`](../tools/automation_probe.py)
+- Validation sweep: [`tools/automation_validate.py`](../tools/automation_validate.py)
+  — records → 3-value scale probe (with circular/wrapping classification) →
+  model cross-check → restore, over every value-bearing applet control;
+  scoped-targets duplicates, skips disabled + keying controls, and prints a
+  findings table with timing. The reusable form of the QA sweep.
 - Log category: `lcAutomation` (`aether.automation`) — toggle in Help → Support.

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -99,6 +99,19 @@ QJsonObject describeWidget(const QWidget* w)
     if (!val.isNull())
         o[QStringLiteral("value")] = val;
 
+    // Range for numeric controls — lets a driver validate against the real
+    // bounds (scale) and detect wrapping/circular sliders without guessing
+    // extremes (#3646).
+    if (auto* s = qobject_cast<const QAbstractSlider*>(w))
+        o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), s->minimum()},
+                                                 {QStringLiteral("max"), s->maximum()}};
+    else if (auto* sb = qobject_cast<const QSpinBox*>(w))
+        o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), sb->minimum()},
+                                                 {QStringLiteral("max"), sb->maximum()}};
+    else if (auto* ds = qobject_cast<const QDoubleSpinBox*>(w))
+        o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), ds->minimum()},
+                                                 {QStringLiteral("max"), ds->maximum()}};
+
     // Surface the TX-keying marker so an agent can see which controls invoke()
     // will refuse before trying them (#3646).
     if (w->property(kTxKeyingProperty).toBool())
@@ -256,6 +269,11 @@ QJsonObject sliceSnapshot(const SliceModel* s)
         {QStringLiteral("nrLevel"),    s->nrLevel()},
         {QStringLiteral("anf"),        s->anfOn()},
         {QStringLiteral("apf"),        s->apfOn()},
+        {QStringLiteral("apfLevel"),   s->apfLevel()},
+        {QStringLiteral("squelch"),    s->squelchOn()},
+        {QStringLiteral("squelchLevel"), s->squelchLevel()},
+        {QStringLiteral("agcMode"),    s->agcMode()},
+        {QStringLiteral("agcThreshold"), s->agcThreshold()},
     };
 }
 
@@ -339,6 +357,25 @@ QJsonObject transmitSnapshot(const TransmitModel* t)
         {QStringLiteral("atuEnabled"),      t->atuEnabled()},
         {QStringLiteral("atuMemories"),     t->memoriesEnabled()},
         {QStringLiteral("apdEnabled"),      t->apdEnabled()},
+    };
+}
+
+// 8-band graphic EQ (RX + TX). Lets a scenario assert EQ-applet slider changes
+// reached the model (#3646). Bands keyed by their short labels (63 … 8k).
+QJsonObject equalizerSnapshot(const EqualizerModel* e)
+{
+    QJsonObject rx, tx;
+    for (int i = 0; i < EqualizerModel::BandCount; ++i) {
+        const auto band = static_cast<EqualizerModel::Band>(i);
+        const QString key = EqualizerModel::bandLabel(band);
+        rx[key] = e->rxBand(band);
+        tx[key] = e->txBand(band);
+    }
+    return QJsonObject{
+        {QStringLiteral("rxEnabled"), e->rxEnabled()},
+        {QStringLiteral("txEnabled"), e->txEnabled()},
+        {QStringLiteral("rx"), rx},
+        {QStringLiteral("tx"), tx},
     };
 }
 
@@ -624,6 +661,29 @@ QWidget* AutomationServer::resolveWidget(const QString& target)
 {
     const QWidgetList tops = QApplication::topLevelWidgets();
 
+    // 0. Scoped target "<scope>/<name>" disambiguates duplicate accessibleNames
+    //    across applets — e.g. "RxApplet/AF gain" vs "PanadapterApplet/AF gain",
+    //    which both exist and would otherwise both resolve to whichever comes
+    //    first in tree order. <scope> matches an ancestor by objectName, class
+    //    (short or full), or accessibleName; <name> is resolved within that
+    //    subtree. Falls through to flat resolution if it doesn't resolve, so a
+    //    literal '/' in a control name still works.
+    const int slash = target.indexOf(QLatin1Char('/'));
+    if (slash > 0) {
+        const QString scope = target.left(slash);
+        const QString inner = target.mid(slash + 1);
+        for (QWidget* tlw : tops) {
+            QWidget* sc = (tlw->objectName() == scope) ? tlw
+                                                       : tlw->findChild<QWidget*>(scope);
+            if (!sc)
+                sc = matchRecursive(tlw, scope);
+            if (sc) {
+                if (QWidget* m = matchRecursive(sc, inner)) return m;
+                if (QWidget* m = matchByButtonText(sc, inner)) return m;
+            }
+        }
+    }
+
     // 1. Exact objectName (cheap, unambiguous).
     for (QWidget* tlw : tops) {
         if (tlw->objectName() == target)
@@ -650,6 +710,20 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
     QWidget* w = resolveWidget(target);
     if (!w)
         return err(QStringLiteral("widget not found: ") + target);
+
+    // Refuse to drive a disabled control. Qt's setValue()/setChecked() still
+    // mutate a disabled widget, so without this the bridge would report a happy
+    // newValue while the radio never sees the change (the control is greyed out
+    // for a reason — wrong mode, not connected, etc.). Surfacing it as an error
+    // turns a silent no-op into an explicit, assertable signal. (#3646)
+    if (!w->isEnabled()) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("refused: '") + target
+                                + QStringLiteral("' is disabled — the radio won't accept the change")},
+                           {QStringLiteral("disabled"), true},
+                           {QStringLiteral("class"), shortClassName(w)}};
+    }
 
     // TX-safety guard — never key a live radio from the test bridge unless the
     // operator has explicitly opted in. (#3646 Phase 1 safety requirement.)
@@ -733,6 +807,8 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = radioSnapshot(radio);
     } else if (model == QLatin1String("transmit")) {
         data = transmitSnapshot(&radio->transmitModel());
+    } else if (model == QLatin1String("equalizer") || model == QLatin1String("eq")) {
+        data = equalizerSnapshot(&radio->equalizerModel());
     } else if (model == QLatin1String("slices")) {
         QJsonArray arr;
         for (const SliceModel* s : radio->slices()) arr.append(sliceSnapshot(s));
@@ -767,7 +843,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use radio|transmit|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use radio|transmit|equalizer|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {

--- a/tools/automation_validate.py
+++ b/tools/automation_validate.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+AetherSDR control-surface validation sweep — part of the agent automation bridge.
+
+Drives the in-app agent automation bridge (launch with AETHER_AUTOMATION=1) to validate
+every value-bearing applet control: records its original value, probes its scale,
+classifies it as linear or circular/wrapping, cross-checks the radio model where
+exposed, and restores the original — then prints a findings table and timing.
+
+It is the reusable form of the ad-hoc QA sweep that found the AM-carrier and
+TX-monitor/CW-sidetone desyncs, hardened with the lessons from that run:
+
+  * Circular/wrapping controls (e.g. the 0-360 phase slider where step 72 == 0)
+    are classified as `wrapping`, not flagged as broken — the linear-clamp
+    assumption is wrong for angular controls.
+  * Disabled controls are skipped and reported as such; the bridge now refuses
+    invoke() on them, so driving one is surfaced rather than a silent no-op.
+  * Duplicate accessibleNames (e.g. "AF gain" in both RxApplet and
+    PanadapterApplet) are addressed with applet-scoped targets ("RxApplet/AF
+    gain") so each is driven deterministically.
+  * Model cross-checks use the expanded `get` coverage (slice squelch/AGC/APF,
+    `equalizer`) to catch GUI<->radio desyncs beyond the widget level.
+
+No transmission: keying controls are skipped (and guarded by the bridge).
+
+Usage:
+    AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
+    python3 tools/automation_validate.py            # full sweep + table
+    python3 tools/automation_validate.py --json out.json
+"""
+
+import argparse
+import json
+import sys
+import time
+
+sys.path.insert(0, "tools")
+from automation_probe import Bridge, discover_socket  # noqa: E402
+
+# accessibleName -> (model, selector, property) for model-level cross-checks.
+MODEL = {
+    "AF gain": ("slice", "active", "audioGain"),
+    "Audio pan": ("slice", "active", "audioPan"),
+    "AGC threshold": ("slice", "active", "agcThreshold"),
+    # "Squelch threshold" is deliberately NOT cross-checked: its value is cached
+    # by RxApplet's Manual/Auto branching and only pushed to slice.squelchLevel
+    # once squelch is enabled in Manual mode, so the model legitimately lags the
+    # widget when squelch is off — a mode-gated control, not a desync.
+    "APF bandwidth": ("slice", "active", "apfLevel"),
+    "RF power": ("transmit", None, "rfPower"),
+    "Tune power": ("transmit", None, "tunePower"),
+    "AM carrier level": ("transmit", None, "amCarrierLevel"),
+    "DEXP threshold": ("transmit", None, "dexpLevel"),
+    "VOX level": ("transmit", None, "voxLevel"),
+    "VOX delay": ("transmit", None, "voxDelay"),
+    "CW speed": ("transmit", None, "cwSpeed"),
+    "Microphone gain": ("transmit", None, "micLevel"),
+    "Processor level": ("transmit", None, "speechProcLevel"),
+    "Monitor volume": ("transmit", None, "monGainSb"),
+    "CW delay": ("transmit", None, "cwDelay"),
+    "CW audio pan": ("transmit", None, "monPanCw"),
+}
+NUMERIC = ("QSlider", "QDial", "QSpinBox", "QDoubleSpinBox")
+
+
+class Validator:
+    def __init__(self, bridge):
+        self.b = bridge
+
+    def req(self, o):
+        return self.b.request(o)
+
+    def model_value(self, name):
+        if name not in MODEL:
+            return None
+        m, sel, prop = MODEL[name]
+        o = {"cmd": "get", "model": m, "property": prop}
+        if sel:
+            o["selector"] = sel
+        return self.req(o).get("value")
+
+    def model_poll(self, name, want, timeout=0.4):
+        """Wait for the mapped model field to reach `want`. (matched, ms, last)"""
+        if name not in MODEL:
+            return None, None, None
+        t0 = time.monotonic()
+        last = None
+        while time.monotonic() - t0 < timeout:
+            last = self.model_value(name)
+            if str(last) == str(want):
+                return True, round((time.monotonic() - t0) * 1000), last
+            time.sleep(0.02)
+        return False, round((time.monotonic() - t0) * 1000), last
+
+    def set(self, target, value):
+        return self.req({"cmd": "invoke", "target": target,
+                         "action": "setValue", "value": str(value)})
+
+    def inventory(self):
+        """Walk the tree, returning value-bearing controls with their applet
+        scope, range, enabled/keying flags. Duplicate accessibleNames get an
+        applet-scoped target so each is addressable."""
+        tree = self.req({"cmd": "dumpTree"})
+        items = []
+        seen = {}
+
+        def walk(n, applet=None):
+            cls = n.get("class", "").split("::")[-1]
+            if cls.endswith("Applet") or cls.endswith("Panel"):
+                applet = cls
+            if applet and cls in NUMERIC + ("QComboBox",):
+                nm = n.get("accessibleName")
+                if nm:
+                    items.append({
+                        "applet": applet, "kind": cls, "name": nm,
+                        "value": n.get("value"), "enabled": n.get("enabled", True),
+                        "keying": bool(n.get("keying")), "range": n.get("range"),
+                    })
+                    seen[nm] = seen.get(nm, 0) + 1
+            for c in n.get("children", []):
+                walk(c, applet)
+        for r in tree["roots"]:
+            walk(r)
+
+        # disambiguate duplicates with applet-scoped targets
+        for it in items:
+            it["target"] = (f"{it['applet']}/{it['name']}"
+                            if seen[it["name"]] > 1 else it["name"])
+            it["duplicate"] = seen[it["name"]] > 1
+        return items
+
+    def classify_numeric(self, it):
+        """3-value scale probe with wrapping detection. Returns a result dict."""
+        target, rng = it["target"], it["range"] or {}
+        lo, hi = rng.get("min"), rng.get("max")
+        res = {"kind_class": None, "min": lo, "max": hi}
+        if lo is None or hi is None:
+            res["kind_class"] = "unknown-range"
+            return res
+        if lo == hi:
+            res["kind_class"] = "fixed"          # genuinely single-valued
+            return res
+
+        # Probe min, max, then mid LAST, so the control is left at a known mid
+        # value for the model cross-check that follows.
+        mid = int((float(lo) + float(hi)) / 2)
+        at_min = self.set(target, lo).get("newValue")
+        at_max = self.set(target, hi).get("newValue")
+        at_mid = self.set(target, mid).get("newValue")
+
+        linear = str(at_max) == str(hi)
+        mid_sticks = at_mid is not None and abs(float(at_mid) - mid) <= 1
+        if linear and str(at_min) == str(lo):
+            res["kind_class"] = "linear"
+        elif not linear and mid_sticks:
+            # max didn't stick but mid-values do -> circular/wrapping control
+            res["kind_class"] = "wrapping"
+            res["wrap_to"] = at_max
+        else:
+            res["kind_class"] = "stuck"          # genuinely unresponsive
+        res.update(at_min=at_min, at_mid=at_mid, at_max=at_max, mid=mid)
+        return res
+
+
+def main():
+    ap = argparse.ArgumentParser(description="AetherSDR control-surface validation sweep")
+    ap.add_argument("--socket", help="override bridge socket path")
+    ap.add_argument("--json", help="write full results to this path")
+    args = ap.parse_args()
+
+    sock = args.socket or discover_socket()
+    if not sock:
+        sys.exit("error: no bridge socket; launch with AETHER_AUTOMATION=1")
+    v = Validator(Bridge(sock))
+
+    items = v.inventory()
+    results, issues = [], []
+    t_start = time.monotonic()
+
+    for it in items:
+        nm, target = it["name"], it["target"]
+        r = {"applet": it["applet"], "control": nm, "target": target,
+             "kind": it["kind"], "duplicate": it["duplicate"]}
+        # disabled -> skip driving; the bridge refuses it, report as suspect
+        if not it["enabled"]:
+            r["status"] = "skipped-disabled"
+            issues.append((it["applet"], nm, "disabled control",
+                           "enabled:false — not driven (bridge refuses invoke)"))
+            results.append(r)
+            continue
+        if it["keying"]:
+            r["status"] = "skipped-keying"
+            results.append(r)
+            continue
+        if it["kind"] not in NUMERIC:
+            r["status"] = "combo-skip"   # combos validated elsewhere; not scale-probed
+            results.append(r)
+            continue
+
+        orig = it["value"]
+        cls = v.classify_numeric(it)
+        r.update(cls)
+        r["status"] = "tested"
+
+        # validity findings
+        if cls["kind_class"] == "stuck":
+            issues.append((it["applet"], nm, "stuck/unresponsive",
+                           f"range [{cls['min']},{cls['max']}] but values don't stick"))
+        if cls["kind_class"] == "unknown-range":
+            issues.append((it["applet"], nm, "no range exposed", ""))
+
+        # model cross-check on the mid value (catches GUI<->model desync)
+        if nm in MODEL and cls.get("at_mid") is not None:
+            conv, lat, after = v.model_poll(nm, cls["at_mid"])
+            r.update(model_converged=conv, model_lat_ms=lat, model_after=after)
+            if conv is False:
+                issues.append((it["applet"], nm, "GUI<->model desync",
+                               f"widget={cls['at_mid']} model={after} (no converge {lat}ms)"))
+
+        # restore
+        if orig is not None:
+            back = v.set(target, orig).get("newValue")
+            r["restored"] = str(back) == str(orig)
+            if r["restored"] is False:
+                issues.append((it["applet"], nm, "restore failed", f"orig={orig} got {back}"))
+        results.append(r)
+
+    total = time.monotonic() - t_start
+    txing = v.req({"cmd": "get", "model": "radio", "property": "transmitting"}).get("value")
+
+    # ---- report ----
+    tested = [r for r in results if r["status"] == "tested"]
+    print(f"\nvalidated {len(tested)} numeric controls "
+          f"({len(items)} total surfaces) in {round(total, 2)}s; transmitting={txing}\n")
+
+    print(f"{'APPLET':16} {'CONTROL':22} {'CLASS':9} {'RANGE':>12} {'MODEL':8}")
+    for r in results:
+        if r["status"] != "tested":
+            print(f"{r['applet']:16} {r['control'][:22]:22} {'· '+r['status']}")
+            continue
+        rng = f"[{r.get('min')},{r.get('max')}]"
+        mdl = ("—" if r.get("model_converged") is None
+               else "OK" if r["model_converged"] else "DESYNC")
+        dup = " (scoped)" if r["duplicate"] else ""
+        print(f"{r['applet']:16} {r['control'][:22]:22} {r['kind_class']:9} {rng:>12} {mdl:8}{dup}")
+
+    print(f"\nISSUES: {len(issues)}")
+    for ap_, nm, typ, det in issues:
+        print(f"  [{ap_}/{nm}] {typ}: {det}")
+
+    if args.json:
+        json.dump({"results": results, "issues": issues, "total_s": round(total, 3),
+                   "transmitting": txing}, open(args.json, "w"), indent=2)
+        print(f"\nfull results -> {args.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Four improvements to the **agent automation bridge**, all surfaced by dogfooding the control-surface QA sweep — plus the reusable validation tool that operationalizes it. Independent of the password-redaction fix (#3717); branched off current `main`.

## 1. Circular/wrapping control detection
`dumpTree` now reports `range: {min, max}` for sliders/spinboxes. A driver classifies a control as **wrapping** (not broken) when `setValue(max)` doesn't stick but a mid value does — e.g. the 0–360° phase slider where step 72 ≡ 0°. The old linear-clamp assumption false-flagged `ESC phase` as stuck.

## 2. Refuse `invoke` on disabled controls
Qt mutates a *disabled* widget on `setValue()`/`setChecked()`, so the bridge used to report a happy `newValue` while the radio never saw the change. `invoke` now returns `{"ok":false,"disabled":true,"error":"refused: … is disabled"}` — a silent no-op becomes an assertable signal.

## 3. Scoped targeting for duplicate names
`"<scope>/<name>"` disambiguates an `accessibleName` that appears in more than one applet — `"AF gain"` and `"Squelch threshold"` exist in **both** `RxApplet` and `PanadapterApplet`. `<scope>` matches an ancestor by objectName/class/accessibleName; falls through to flat matching, so a literal `/` in a name still works. `"RxApplet/AF gain"` vs `"PanadapterApplet/AF gain"`.

## 4. Wider `get` model coverage
- New `equalizer` (alias `eq`) snapshot — 8-band RX+TX graphic EQ.
- `slice` snapshot gains `squelch`/`squelchLevel`, `agcMode`/`agcThreshold`, `apf`/`apfLevel`.

So a sweep can model-check controls that were widget-level-only before.

## Tooling
[`tools/automation_validate.py`](tools/automation_validate.py) — the reusable form of the QA sweep: record → 3-value scale probe with wrapping classification → model cross-check → restore, over every value-bearing applet control; scoped-targets duplicates, skips disabled + keying controls, prints a findings table with timing.

## Verification (live, FLEX-8400M, no transmission)

- Full sweep of **31 numeric controls in ~40 ms**, all restored, `transmitting:false` throughout.
- `ESC phase` (range `[0,72]`) → classified **`wrapping`** (72→0, 36 sticks); `ESC gain` → `linear`.
- Disabled `RxApplet/Squelch threshold` → `invoke` **refused** (`disabled:true`).
- `RxApplet/AF gain` and `PanadapterApplet/AF gain` resolve to **distinct** widgets.
- `get equalizer` → RX/TX bands; `get slice` → new squelch/AGC/APF fields.
- Only flagged issues were the two genuinely-disabled controls (correct). Squelch threshold is deliberately not model-cross-checked: its level is cached by RxApplet's Manual/Auto branching until squelch is enabled — a mode-gated control, not a desync.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
