### PR TITLE
feat(smartmtr): selectable SmartMTR meter view for the VFO flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -724,6 +724,7 @@ set(GUI_SOURCES
     src/gui/SliceLabel.cpp
     src/gui/VfoWidget.cpp
     src/gui/SmartMtrWidget.cpp
+    src/gui/SmartMtrConfig.cpp
     src/gui/MeterViewController.cpp
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,8 @@ set(GUI_SOURCES
     src/gui/SliceColorManager.cpp
     src/gui/SliceLabel.cpp
     src/gui/VfoWidget.cpp
+    src/gui/SmartMtrWidget.cpp
+    src/gui/MeterViewController.cpp
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp
     src/gui/Ax25HfPacketDecodeDialog.cpp

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -27,6 +27,18 @@ public:
         write(o);
     }
 
+    // VFO meter view: false = standard S-meter, true = SmartMTR component.
+    // Global (not per-slice) — see MeterViewController for the live-broadcast
+    // layer that fans this choice out to every open VFO flag.
+    static bool smartMtr() { return readObj().value("smartMtr").toString("False") == "True"; }
+
+    static void setSmartMtr(bool on)
+    {
+        QJsonObject o = readObj();
+        o["smartMtr"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+
     // One-shot migration from the legacy "LeanMode" flat key.  Run at app
     // startup before any caller reads the new blob.  Safe to call repeatedly:
     // returns immediately if the new blob already exists.

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -42,7 +42,7 @@ public:
     // ── SmartMTR-only display options ───────────────────────────────────────
     // These apply only to the SmartMTR meter view (not the standard S-meter).
     // Persisted here, surfaced in the VFO meter-view selector; consumed by the
-    // SmartMTR rendering layer (wiring lands in a follow-up).
+    // SmartMTR rendering layer via VfoWidget::pushSmartMtrOptions().
 
     // Extremes-speed and shown-values choices, as typed enums so consumers get
     // compile-time exhaustiveness rather than stringly-typed comparisons.

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -49,6 +49,11 @@ public:
     enum class ExtremesSpeed { Slow, Medium, Fast };
     enum class MeterValues { None, Signal, Extremes };
 
+    // What the SmartMTR meter shows while transmitting. None = keep the RX
+    // signal scale (don't switch on TX); MicLevel = swap to the mic-level (dBFS)
+    // scale for the duration of TX. Default None.
+    enum class TxMeter { None, MicLevel };
+
     // Show the peak/trough "extremes" markers on the SmartMTR meter.
     static bool showExtremes()
     {
@@ -91,6 +96,20 @@ public:
         write(o);
     }
 
+    // Which meter to show while transmitting. Default None (stay on RX signal).
+    static TxMeter txMeter()
+    {
+        const QString s = readObj().value("txMeter").toString("None");
+        if (s == QStringLiteral("MicLevel")) return TxMeter::MicLevel;
+        return TxMeter::None;
+    }
+    static void setTxMeter(TxMeter v)
+    {
+        QJsonObject o = readObj();
+        o["txMeter"] = txMeterToken(v);
+        write(o);
+    }
+
     static QString extremesSpeedToken(ExtremesSpeed v)
     {
         switch (v) {
@@ -106,6 +125,14 @@ public:
         case MeterValues::Signal: return QStringLiteral("Signal");
         case MeterValues::Extremes: return QStringLiteral("Extremes");
         case MeterValues::None: break;
+        }
+        return QStringLiteral("None");
+    }
+    static QString txMeterToken(TxMeter v)
+    {
+        switch (v) {
+        case TxMeter::MicLevel: return QStringLiteral("MicLevel");
+        case TxMeter::None: break;
         }
         return QStringLiteral("None");
     }

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -39,6 +39,77 @@ public:
         write(o);
     }
 
+    // ── SmartMTR-only display options ───────────────────────────────────────
+    // These apply only to the SmartMTR meter view (not the standard S-meter).
+    // Persisted here, surfaced in the VFO meter-view selector; consumed by the
+    // SmartMTR rendering layer (wiring lands in a follow-up).
+
+    // Extremes-speed and shown-values choices, as typed enums so consumers get
+    // compile-time exhaustiveness rather than stringly-typed comparisons.
+    enum class ExtremesSpeed { Slow, Medium, Fast };
+    enum class MeterValues { None, Signal, Extremes };
+
+    // Show the peak/trough "extremes" markers on the SmartMTR meter.
+    static bool showExtremes()
+    {
+        return readObj().value("showExtremes").toString("False") == "True";
+    }
+    static void setShowExtremes(bool on)
+    {
+        QJsonObject o = readObj();
+        o["showExtremes"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+
+    // How fast the extremes markers decay / track. Default Medium.
+    static ExtremesSpeed extremesSpeed()
+    {
+        const QString s = readObj().value("extremesSpeed").toString("Medium");
+        if (s == QStringLiteral("Slow")) return ExtremesSpeed::Slow;
+        if (s == QStringLiteral("Fast")) return ExtremesSpeed::Fast;
+        return ExtremesSpeed::Medium;
+    }
+    static void setExtremesSpeed(ExtremesSpeed v)
+    {
+        QJsonObject o = readObj();
+        o["extremesSpeed"] = extremesSpeedToken(v);
+        write(o);
+    }
+
+    // Which numeric value(s) to overlay on the SmartMTR meter. Default None.
+    static MeterValues showValues()
+    {
+        const QString s = readObj().value("showValues").toString("None");
+        if (s == QStringLiteral("Signal")) return MeterValues::Signal;
+        if (s == QStringLiteral("Extremes")) return MeterValues::Extremes;
+        return MeterValues::None;
+    }
+    static void setShowValues(MeterValues v)
+    {
+        QJsonObject o = readObj();
+        o["showValues"] = meterValuesToken(v);
+        write(o);
+    }
+
+    static QString extremesSpeedToken(ExtremesSpeed v)
+    {
+        switch (v) {
+        case ExtremesSpeed::Slow: return QStringLiteral("Slow");
+        case ExtremesSpeed::Fast: return QStringLiteral("Fast");
+        case ExtremesSpeed::Medium: break;
+        }
+        return QStringLiteral("Medium");
+    }
+    static QString meterValuesToken(MeterValues v)
+    {
+        switch (v) {
+        case MeterValues::Signal: return QStringLiteral("Signal");
+        case MeterValues::Extremes: return QStringLiteral("Extremes");
+        case MeterValues::None: break;
+        }
+        return QStringLiteral("None");
+    }
+
     // One-shot migration from the legacy "LeanMode" flat key.  Run at app
     // startup before any caller reads the new blob.  Safe to call repeatedly:
     // returns immediately if the new blob already exists.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -644,6 +644,14 @@ void MainWindow::onSliceAdded(SliceModel* s)
         if (sliceIndex == sid)
             vfo->setEscLevel(dbm);
     });
+    // Feed SmartMTR TX scale: global mic level (dBFS) + MOX state. The VFO shows
+    // mic only on its own TX slice while transmitting.
+    connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
+            vfo, [vfo](float micLevel, float, float, float) {
+        vfo->setMicLevel(micLevel);
+    });
+    connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+            vfo, &VfoWidget::setTransmitting);
     connect(&m_radioModel, &RadioModel::antListChanged,
             vfo, &VfoWidget::setAntennaList);
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -647,8 +647,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // Feed SmartMTR TX scale: global mic level (dBFS) + MOX state. The VFO shows
     // mic only on its own TX slice while transmitting.
     connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
-            vfo, [vfo](float micLevel, float, float, float) {
-        vfo->setMicLevel(micLevel);
+            vfo, [vfo](float micLevel, float, float micPeak, float) {
+        vfo->setMicLevel(micLevel, micPeak);
     });
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             vfo, &VfoWidget::setTransmitting);

--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -104,13 +104,18 @@ public:
         if (m_maxPos < SmartMtrUnits::kScaleMin) m_maxPos = SmartMtrUnits::kScaleMin;
         if (m_minPos > m_maxPos) m_minPos = m_maxPos;
 
-        // Keep animating ONLY while a marker is actually moving. Returning true
-        // whenever the window is non-empty would pin the meter's repaint timer at
-        // full rate forever for any live signal — and every meter repaint over the
-        // GPU panadapter forces a costly recomposite that starves input (drag).
-        // New samples restart the timer via setMeterInput, so expiries are still
-        // picked up promptly; this just lets an idle meter settle.
-        return moving;
+        // Keep animating while a marker is mid-slew OR has not yet collapsed onto
+        // the needle (a peak/trough is still standing off it). The latter keeps
+        // the timer running through the whole hold->return so the window prunes
+        // and the markers slew at the timer rate — matching the original app's
+        // steady loop and avoiding a staircase clocked by the irregular packet
+        // feed. It self-terminates once min ~= max ~= needle (markers collapsed),
+        // so an idle meter still settles rather than pinning the repaint timer at
+        // full rate forever (each meter repaint over the GPU panadapter forces a
+        // costly recomposite that starves input).
+        const bool standingOff = (m_maxPos > needlePosUnits + kConvergeEps)
+                                 || (m_minPos < needlePosUnits - kConvergeEps);
+        return moving || standingOff;
     }
 
     bool hasData() const { return m_hasData; }

--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -45,6 +45,20 @@ public:
         m_minPos = SmartMtrUnits::kScaleMin;
         m_maxPos = SmartMtrUnits::kScaleMin;
         m_hasData = false;
+        m_useExtPeak = false;
+        m_extPeakRaw = 0.0;
+    }
+
+    // External-peak mode: drive the MAX marker from a separately-measured peak
+    // (e.g. the radio's MICPEAK meter over UDP) instead of a sliding-window max.
+    // The trough is unused in this mode (it collapses onto the needle). Each call
+    // refreshes the target; the marker still slews toward it at the constant
+    // velocity. Mutually exclusive with record() — a kind switch resets() first.
+    void setExternalPeak(double rawPeak)
+    {
+        m_useExtPeak = true;
+        m_extPeakRaw = rawPeak;
+        m_hasData = true;
     }
 
     // Record a raw signal sample at a monotonic timestamp (ms). Call from the
@@ -65,33 +79,50 @@ public:
     bool tick(qint64 nowMs, qint64 elapsedMs, double needlePosUnits,
               const std::function<double(double)>& mapToUnits)
     {
-        // 1) Prune expired samples and rescan min/max in a single pass.
-        const qint64 cutoff = nowMs - qint64(m_tuning.windowSeconds * 1000.0);
-        while (!m_window.empty() && m_window.front().t < cutoff) {
-            m_sumRaw -= m_window.front().raw;
-            m_window.pop_front();
-        }
-        if (m_window.empty()) {
-            m_hasData = false;
+        // 1) Establish the raw min/max for this tick. In external-peak mode the
+        //    max comes from the supplied peak and the window is bypassed; the
+        //    trough is unused (it tracks the needle). Otherwise prune expired
+        //    samples and rescan the window min/max in a single pass.
+        if (m_useExtPeak) {
+            m_maxRaw = m_extPeakRaw;
         } else {
-            double mn = m_window.front().raw, mx = mn;
-            for (const Sample& s : m_window) {
-                if (s.raw < mn) mn = s.raw;
-                if (s.raw > mx) mx = s.raw;
+            const qint64 cutoff = nowMs - qint64(m_tuning.windowSeconds * 1000.0);
+            while (!m_window.empty() && m_window.front().t < cutoff) {
+                m_sumRaw -= m_window.front().raw;
+                m_window.pop_front();
             }
-            m_minRaw = mn;
-            m_maxRaw = mx;
+            if (m_window.empty()) {
+                m_hasData = false;
+            } else {
+                double mn = m_window.front().raw, mx = mn;
+                for (const Sample& s : m_window) {
+                    if (s.raw < mn) mn = s.raw;
+                    if (s.raw > mx) mx = s.raw;
+                }
+                m_minRaw = mn;
+                m_maxRaw = mx;
+            }
         }
 
-        // 2) Targets in UNITS. With no data left, glide both to the floor.
+        // 2) Targets in UNITS. With no data left, glide both to the floor. In
+        //    external-peak mode the trough is unused, so it targets the needle so
+        //    it collapses there (mic draws no trough) without standing off.
         const double minTgt =
-            m_hasData ? mapToUnits(m_minRaw) : SmartMtrUnits::kScaleMin;
+            !m_hasData      ? SmartMtrUnits::kScaleMin
+            : m_useExtPeak  ? needlePosUnits
+                            : mapToUnits(m_minRaw);
         const double maxTgt =
             m_hasData ? mapToUnits(m_maxRaw) : SmartMtrUnits::kScaleMin;
 
-        // 3) Constant-velocity slew toward each target.
+        // 3) Constant-velocity slew toward each target. External-peak (mic) mode
+        //    tracks tightly at the fast peak slew — the radio's peak is a live
+        //    stat, not a lazy RX sweep — while the window-derived markers keep
+        //    the deliberately lazy glide.
         bool moving = false;
-        const double step = m_tuning.slewUnitsPerSec * double(elapsedMs) / 1000.0;
+        const double slewRate =
+            m_useExtPeak ? SmartMtrExtremes::kPeakSlewUnitsPerSec
+                         : m_tuning.slewUnitsPerSec;
+        const double step = slewRate * double(elapsedMs) / 1000.0;
         if (step > 0.0) {
             m_minPos = slew(m_minPos, minTgt, step, moving);
             m_maxPos = slew(m_maxPos, maxTgt, step, moving);
@@ -157,6 +188,12 @@ private:
     double m_minPos = SmartMtrUnits::kScaleMin;
     double m_maxPos = SmartMtrUnits::kScaleMin;
     bool m_hasData = false;
+
+    // External-peak mode (mic): the MAX marker is driven by a separately-measured
+    // peak (radio MICPEAK over UDP) instead of the sliding window. Set via
+    // setExternalPeak(); cleared by reset() on a kind switch.
+    bool m_useExtPeak = false;
+    double m_extPeakRaw = 0.0;
 };
 
 } // namespace AetherSDR

--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "SmartMtrStyle.h"
+
+#include <QtGlobal>
+
+#include <cmath>
+#include <deque>
+#include <functional>
+
+namespace AetherSDR {
+
+// Sliding-window min/max envelope tracker for the SmartMTR "extremes" markers.
+//
+// Sits alongside the bar's MeterSmoother but moves differently on purpose: the
+// bar uses an asymmetric exponential ballistic (the analog-meter feel), while the
+// extremes glide at a CONSTANT linear slew over the recent-signal envelope, so
+// they read as separate sweep markers rather than a second needle.
+//
+// History is kept in RAW signal units (dBm for RX, dBFS for TX), not in scale
+// UNITS: the fade rules are dB-based and the dBm->UNIT mapping is piecewise
+// non-linear, so min/max/avg are computed in raw space and mapped to UNITS only
+// for drawing. The slewed display positions live in scale UNITS.
+//
+// Drive it once per physics tick (any rate, even irregular) from the same timer
+// that ticks the bar; pass the monotonic clock and the elapsed dt.
+class MeterExtremes {
+public:
+    struct Tuning {
+        double windowSeconds = SmartMtrExtremes::kWindowMediumSec;
+        double slewUnitsPerSec = SmartMtrExtremes::kSlewUnitsPerSec;
+    };
+
+    void setTuning(const Tuning& t) { m_tuning = t; }
+    const Tuning& tuning() const { return m_tuning; }
+
+    // Clear the window and snap both markers down to the floor. Used on a kind
+    // switch (dBm vs dBFS must not mix) or a hard park.
+    void reset()
+    {
+        m_window.clear();
+        m_sumRaw = 0.0;
+        m_minRaw = 0.0;
+        m_maxRaw = 0.0;
+        m_minPos = SmartMtrUnits::kScaleMin;
+        m_maxPos = SmartMtrUnits::kScaleMin;
+        m_hasData = false;
+    }
+
+    // Record a raw signal sample at a monotonic timestamp (ms). Call from the
+    // signal source (after clamping to the floor), only while a value is present.
+    void record(double rawValue, qint64 nowMs)
+    {
+        m_window.push_back({nowMs, rawValue});
+        m_sumRaw += rawValue;
+        m_hasData = true;
+    }
+
+    // Advance one tick. Prunes expired samples, recomputes the raw window
+    // min/max/avg, then slews both display markers toward their (mapped, clamped)
+    // targets at constant velocity. needlePosUnits is the live bar position, used
+    // for the min <= needle <= max clamp. mapToUnits maps a raw value to a
+    // clamped UNIT position. Returns true while further ticks are useful (a marker
+    // still moving, or window samples that may yet expire and shift the targets).
+    bool tick(qint64 nowMs, qint64 elapsedMs, double needlePosUnits,
+              const std::function<double(double)>& mapToUnits)
+    {
+        // 1) Prune expired samples and rescan min/max in a single pass.
+        const qint64 cutoff = nowMs - qint64(m_tuning.windowSeconds * 1000.0);
+        while (!m_window.empty() && m_window.front().t < cutoff) {
+            m_sumRaw -= m_window.front().raw;
+            m_window.pop_front();
+        }
+        if (m_window.empty()) {
+            m_hasData = false;
+        } else {
+            double mn = m_window.front().raw, mx = mn;
+            for (const Sample& s : m_window) {
+                if (s.raw < mn) mn = s.raw;
+                if (s.raw > mx) mx = s.raw;
+            }
+            m_minRaw = mn;
+            m_maxRaw = mx;
+        }
+
+        // 2) Targets in UNITS. With no data left, glide both to the floor.
+        const double minTgt =
+            m_hasData ? mapToUnits(m_minRaw) : SmartMtrUnits::kScaleMin;
+        const double maxTgt =
+            m_hasData ? mapToUnits(m_maxRaw) : SmartMtrUnits::kScaleMin;
+
+        // 3) Constant-velocity slew toward each target.
+        bool moving = false;
+        const double step = m_tuning.slewUnitsPerSec * double(elapsedMs) / 1000.0;
+        if (step > 0.0) {
+            m_minPos = slew(m_minPos, minTgt, step, moving);
+            m_maxPos = slew(m_maxPos, maxTgt, step, moving);
+        }
+
+        // 4) Ordering / floor clamps: min <= needle <= max, nothing below floor.
+        if (m_maxPos < needlePosUnits) m_maxPos = needlePosUnits;
+        if (m_minPos > needlePosUnits) m_minPos = needlePosUnits;
+        if (m_minPos < SmartMtrUnits::kScaleMin) m_minPos = SmartMtrUnits::kScaleMin;
+        if (m_maxPos < SmartMtrUnits::kScaleMin) m_maxPos = SmartMtrUnits::kScaleMin;
+        if (m_minPos > m_maxPos) m_minPos = m_maxPos;
+
+        // Keep animating ONLY while a marker is actually moving. Returning true
+        // whenever the window is non-empty would pin the meter's repaint timer at
+        // full rate forever for any live signal — and every meter repaint over the
+        // GPU panadapter forces a costly recomposite that starves input (drag).
+        // New samples restart the timer via setMeterInput, so expiries are still
+        // picked up promptly; this just lets an idle meter settle.
+        return moving;
+    }
+
+    bool hasData() const { return m_hasData; }
+    double minRaw() const { return m_minRaw; }
+    double maxRaw() const { return m_maxRaw; }
+    double avgRaw() const
+    {
+        return m_window.empty() ? 0.0 : m_sumRaw / double(m_window.size());
+    }
+    double minPosUnits() const { return m_minPos; }
+    double maxPosUnits() const { return m_maxPos; }
+
+private:
+    struct Sample {
+        qint64 t;
+        double raw;
+    };
+
+    // Move cur toward tgt by at most step (constant velocity). Snaps within a
+    // convergence epsilon so the timer doesn't live forever on sub-pixel motion.
+    static double slew(double cur, double tgt, double step, bool& moving)
+    {
+        const double d = tgt - cur;
+        if (std::fabs(d) <= kConvergeEps)
+            return tgt;
+        moving = true;
+        if (d > step) return cur + step;
+        if (d < -step) return cur - step;
+        return tgt; // reaches target this step
+    }
+
+    static constexpr double kConvergeEps = 0.05; // UNITS
+
+    std::deque<Sample> m_window;
+    Tuning m_tuning;
+    double m_sumRaw = 0.0;
+    double m_minRaw = 0.0;
+    double m_maxRaw = 0.0;
+    double m_minPos = SmartMtrUnits::kScaleMin;
+    double m_maxPos = SmartMtrUnits::kScaleMin;
+    bool m_hasData = false;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MeterViewController.cpp
+++ b/src/gui/MeterViewController.cpp
@@ -51,4 +51,13 @@ void MeterViewController::setShowValues(DisplaySettings::MeterValues v)
     emit extremesChanged();
 }
 
+void MeterViewController::setTxMeter(DisplaySettings::TxMeter v)
+{
+    if (DisplaySettings::txMeter() == v) {
+        return;
+    }
+    DisplaySettings::setTxMeter(v);
+    emit txMeterChanged();
+}
+
 } // namespace AetherSDR

--- a/src/gui/MeterViewController.cpp
+++ b/src/gui/MeterViewController.cpp
@@ -11,6 +11,10 @@ MeterViewController& MeterViewController::instance()
 
 MeterViewController::MeterViewController()
     : m_smartMtr(DisplaySettings::smartMtr())  // restore persisted choice
+    , m_showExtremes(DisplaySettings::showExtremes())
+    , m_extremesSpeed(DisplaySettings::extremesSpeed())
+    , m_showValues(DisplaySettings::showValues())
+    , m_txMeter(DisplaySettings::txMeter())
 {
 }
 
@@ -26,36 +30,40 @@ void MeterViewController::setSmartMtr(bool on)
 
 void MeterViewController::setShowExtremes(bool on)
 {
-    if (DisplaySettings::showExtremes() == on) {
+    if (m_showExtremes == on) {
         return;
     }
+    m_showExtremes = on;
     DisplaySettings::setShowExtremes(on);
     emit extremesChanged();
 }
 
 void MeterViewController::setExtremesSpeed(DisplaySettings::ExtremesSpeed v)
 {
-    if (DisplaySettings::extremesSpeed() == v) {
+    if (m_extremesSpeed == v) {
         return;
     }
+    m_extremesSpeed = v;
     DisplaySettings::setExtremesSpeed(v);
     emit extremesChanged();
 }
 
 void MeterViewController::setShowValues(DisplaySettings::MeterValues v)
 {
-    if (DisplaySettings::showValues() == v) {
+    if (m_showValues == v) {
         return;
     }
+    m_showValues = v;
     DisplaySettings::setShowValues(v);
     emit extremesChanged();
 }
 
 void MeterViewController::setTxMeter(DisplaySettings::TxMeter v)
 {
-    if (DisplaySettings::txMeter() == v) {
+    if (m_txMeter == v) {
         return;
     }
+    m_txMeter = v;
     DisplaySettings::setTxMeter(v);
     emit txMeterChanged();
 }

--- a/src/gui/MeterViewController.cpp
+++ b/src/gui/MeterViewController.cpp
@@ -24,4 +24,31 @@ void MeterViewController::setSmartMtr(bool on)
     emit changed(on);
 }
 
+void MeterViewController::setShowExtremes(bool on)
+{
+    if (DisplaySettings::showExtremes() == on) {
+        return;
+    }
+    DisplaySettings::setShowExtremes(on);
+    emit extremesChanged();
+}
+
+void MeterViewController::setExtremesSpeed(DisplaySettings::ExtremesSpeed v)
+{
+    if (DisplaySettings::extremesSpeed() == v) {
+        return;
+    }
+    DisplaySettings::setExtremesSpeed(v);
+    emit extremesChanged();
+}
+
+void MeterViewController::setShowValues(DisplaySettings::MeterValues v)
+{
+    if (DisplaySettings::showValues() == v) {
+        return;
+    }
+    DisplaySettings::setShowValues(v);
+    emit extremesChanged();
+}
+
 } // namespace AetherSDR

--- a/src/gui/MeterViewController.cpp
+++ b/src/gui/MeterViewController.cpp
@@ -1,0 +1,27 @@
+#include "MeterViewController.h"
+#include "DisplaySettings.h"
+
+namespace AetherSDR {
+
+MeterViewController& MeterViewController::instance()
+{
+    static MeterViewController s_instance;
+    return s_instance;
+}
+
+MeterViewController::MeterViewController()
+    : m_smartMtr(DisplaySettings::smartMtr())  // restore persisted choice
+{
+}
+
+void MeterViewController::setSmartMtr(bool on)
+{
+    if (m_smartMtr == on) {
+        return;
+    }
+    m_smartMtr = on;
+    DisplaySettings::setSmartMtr(on);  // persists via AppSettings
+    emit changed(on);
+}
+
+} // namespace AetherSDR

--- a/src/gui/MeterViewController.h
+++ b/src/gui/MeterViewController.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QObject>
+
+namespace AetherSDR {
+
+// Global, app-wide owner of the VFO meter-view choice (standard S-Meter vs the
+// SmartMTR component).  Every VfoWidget reads the current value and connects to
+// changed() so a toggle on one flag updates all open flags live; the value is
+// persisted (via DisplaySettings) and restored at startup.  Single source of
+// truth: the meter menu in each flag calls setSmartMtr() here.
+class MeterViewController : public QObject {
+    Q_OBJECT
+public:
+    static MeterViewController& instance();
+
+    bool smartMtr() const { return m_smartMtr; }
+    void setSmartMtr(bool on);
+
+Q_SIGNALS:
+    void changed(bool smartMtr);
+
+private:
+    MeterViewController();
+    bool m_smartMtr{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/MeterViewController.h
+++ b/src/gui/MeterViewController.h
@@ -32,13 +32,21 @@ public:
     {
         return DisplaySettings::showValues();
     }
+    DisplaySettings::TxMeter txMeter() const
+    {
+        return DisplaySettings::txMeter();
+    }
     void setShowExtremes(bool on);
     void setExtremesSpeed(DisplaySettings::ExtremesSpeed v);
     void setShowValues(DisplaySettings::MeterValues v);
+    void setTxMeter(DisplaySettings::TxMeter v);
 
 Q_SIGNALS:
     void changed(bool smartMtr);
     void extremesChanged();
+    // The TX-meter choice changed; flags re-evaluate which input to push (the TX
+    // meter swaps the SmartMTR input, not its options, so it gets its own signal).
+    void txMeterChanged();
 
 private:
     MeterViewController();

--- a/src/gui/MeterViewController.h
+++ b/src/gui/MeterViewController.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "DisplaySettings.h"
+
 #include <QObject>
 
 namespace AetherSDR {
@@ -17,8 +19,26 @@ public:
     bool smartMtr() const { return m_smartMtr; }
     void setSmartMtr(bool on);
 
+    // SmartMTR-only extremes options. Persisted via DisplaySettings (the store);
+    // changing any of them emits extremesChanged() so every open VFO flag can
+    // re-push the options to its SmartMtrWidget — same live-broadcast model as the
+    // meter-view choice above. The meter-menu controls in each flag call these.
+    bool showExtremes() const { return DisplaySettings::showExtremes(); }
+    DisplaySettings::ExtremesSpeed extremesSpeed() const
+    {
+        return DisplaySettings::extremesSpeed();
+    }
+    DisplaySettings::MeterValues showValues() const
+    {
+        return DisplaySettings::showValues();
+    }
+    void setShowExtremes(bool on);
+    void setExtremesSpeed(DisplaySettings::ExtremesSpeed v);
+    void setShowValues(DisplaySettings::MeterValues v);
+
 Q_SIGNALS:
     void changed(bool smartMtr);
+    void extremesChanged();
 
 private:
     MeterViewController();

--- a/src/gui/MeterViewController.h
+++ b/src/gui/MeterViewController.h
@@ -23,19 +23,13 @@ public:
     // changing any of them emits extremesChanged() so every open VFO flag can
     // re-push the options to its SmartMtrWidget — same live-broadcast model as the
     // meter-view choice above. The meter-menu controls in each flag call these.
-    bool showExtremes() const { return DisplaySettings::showExtremes(); }
-    DisplaySettings::ExtremesSpeed extremesSpeed() const
-    {
-        return DisplaySettings::extremesSpeed();
-    }
-    DisplaySettings::MeterValues showValues() const
-    {
-        return DisplaySettings::showValues();
-    }
-    DisplaySettings::TxMeter txMeter() const
-    {
-        return DisplaySettings::txMeter();
-    }
+    // Cached (the setters keep them in sync with DisplaySettings) so these stay
+    // off the per-packet path — txMeter() is read on every meter update — rather
+    // than re-parsing the Display JSON blob from AppSettings on each call.
+    bool showExtremes() const { return m_showExtremes; }
+    DisplaySettings::ExtremesSpeed extremesSpeed() const { return m_extremesSpeed; }
+    DisplaySettings::MeterValues showValues() const { return m_showValues; }
+    DisplaySettings::TxMeter txMeter() const { return m_txMeter; }
     void setShowExtremes(bool on);
     void setExtremesSpeed(DisplaySettings::ExtremesSpeed v);
     void setShowValues(DisplaySettings::MeterValues v);
@@ -51,6 +45,10 @@ Q_SIGNALS:
 private:
     MeterViewController();
     bool m_smartMtr{false};
+    bool m_showExtremes{false};
+    DisplaySettings::ExtremesSpeed m_extremesSpeed{DisplaySettings::ExtremesSpeed::Medium};
+    DisplaySettings::MeterValues m_showValues{DisplaySettings::MeterValues::None};
+    DisplaySettings::TxMeter m_txMeter{DisplaySettings::TxMeter::None};
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrConfig.cpp
+++ b/src/gui/SmartMtrConfig.cpp
@@ -81,6 +81,9 @@ MeterConfig buildSignalConfig()
         if (db % 20 == 0) {
             m.size = MarkerSize::Large;
             m.label = QStringLiteral("+") + QString::number(db);
+            // Shift the "+NN" label left so the tick falls between the two
+            // digits rather than under the leading "+". Tune in UNITS.
+            m.labelOffset = -4.0;
         } else {
             m.size = MarkerSize::Small;
         }

--- a/src/gui/SmartMtrConfig.cpp
+++ b/src/gui/SmartMtrConfig.cpp
@@ -65,6 +65,8 @@ MeterConfig buildSignalConfig()
         if (s % 2 == 1) {
             m.size = MarkerSize::Large;
             m.label = QString::number(s);
+            if (s == 9) // S9 is the only strong S-meter label
+                m.labelStyle = LabelStyle::Strong;
         } else {
             m.size = MarkerSize::Small;
         }

--- a/src/gui/SmartMtrConfig.cpp
+++ b/src/gui/SmartMtrConfig.cpp
@@ -1,0 +1,134 @@
+#include "SmartMtrConfig.h"
+
+#include "SmartMtrStyle.h"
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+using namespace SmartMtrUnits;
+
+namespace {
+
+// Linear map of v in [a,b] onto [pa,pb] (unclamped). Degenerate range -> pa.
+double lerp(double v, double a, double b, double pa, double pb)
+{
+    if (a == b)
+        return pa;
+    return pa + (v - a) / (b - a) * (pb - pa);
+}
+
+// Midpoint of the scale band — where S9 is pinned for the signal meter.
+constexpr double kScaleMid = (kScaleMin + kScaleMax) / 2.0; // 120
+
+// ── Signal (received) ───────────────────────────────────────────────────────
+// S-units are 6 dB apart; S9 = -73 dBm (HF convention). S0 sits 9 units below,
+// the top of the scale is +60 dB over S9.
+constexpr double kSignalS0dBm = -127.0; // S9 - 9*6
+constexpr double kSignalS9dBm = -73.0;
+constexpr double kSignalMaxdBm = -13.0; // S9 + 60
+
+// Piecewise so S9 lands exactly at the scale midpoint: S0..S9 fills the lower
+// half, S9..+60 the upper half (each segment linear in dBm, different slopes).
+double mapSignal(double v, double min, double max)
+{
+    if (v <= kSignalS9dBm)
+        return lerp(v, min, kSignalS9dBm, kScaleMin, kScaleMid);
+    return lerp(v, kSignalS9dBm, max, kScaleMid, kScaleMax);
+}
+
+// ── Mic level (transmit) ────────────────────────────────────────────────────
+constexpr double kMicMindB = -40.0;
+constexpr double kMicMaxdB = 0.0;
+
+double mapMic(double v, double min, double max)
+{
+    return lerp(v, min, max, kScaleMin, kScaleMax);
+}
+
+// ── Marker tables ───────────────────────────────────────────────────────────
+// Authored by value and placed through the same mapping fn at the canonical
+// range, so ticks line up with the indicator curve. The stored position is in
+// hole-local UNITS — markers are static.
+
+MeterConfig buildSignalConfig()
+{
+    MeterConfig cfg;
+    cfg.valueToPosition = mapSignal;
+
+    // S0..S9: odd S-units large + labeled, even ones small ticks. All blue.
+    for (int s = 0; s <= 9; ++s) {
+        const double dBm = kSignalS0dBm + s * 6.0;
+        ScaleMarker m;
+        m.position = mapSignal(dBm, kSignalS0dBm, kSignalMaxdBm);
+        m.color = MarkerColor::Normal;
+        if (s % 2 == 1) {
+            m.size = MarkerSize::Large;
+            m.label = QString::number(s);
+        } else {
+            m.size = MarkerSize::Small;
+        }
+        cfg.markers.push_back(m);
+    }
+
+    // +dB over S9: large+labeled at +20/+40/+60, small ticks at +10/+30/+50.
+    // All red ("high").
+    for (int db = 10; db <= 60; db += 10) {
+        const double dBm = kSignalS9dBm + db;
+        ScaleMarker m;
+        m.position = mapSignal(dBm, kSignalS0dBm, kSignalMaxdBm);
+        m.color = MarkerColor::High;
+        if (db % 20 == 0) {
+            m.size = MarkerSize::Large;
+            m.label = QStringLiteral("+") + QString::number(db);
+        } else {
+            m.size = MarkerSize::Small;
+        }
+        cfg.markers.push_back(m);
+    }
+
+    return cfg;
+}
+
+MeterConfig buildMicConfig()
+{
+    MeterConfig cfg;
+    cfg.valueToPosition = mapMic;
+
+    // -40..0 dB in 10 dB steps, all large + labeled. The 0-dB end is red.
+    for (int db = -40; db <= 0; db += 10) {
+        ScaleMarker m;
+        m.position = mapMic(db, kMicMindB, kMicMaxdB);
+        m.size = MarkerSize::Large;
+        m.color = (db >= 0) ? MarkerColor::High : MarkerColor::Normal;
+        m.label = QString::number(db);
+        cfg.markers.push_back(m);
+    }
+
+    return cfg;
+}
+
+} // namespace
+
+const MeterConfig& meterConfig(MeterKind kind)
+{
+    static const MeterConfig signalCfg = buildSignalConfig();
+    static const MeterConfig micCfg = buildMicConfig();
+    switch (kind) {
+    case MeterKind::MicLevel:
+        return micCfg;
+    case MeterKind::Signal:
+        break;
+    }
+    return signalCfg;
+}
+
+double indicatorPosition(const MeterInput& in)
+{
+    if (!in.hasValue)
+        return kScaleMin;
+    const double pos = meterConfig(in.kind).valueToPosition(in.value, in.min, in.max);
+    return std::clamp(pos, kScaleMin, kScaleMax);
+}
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrConfig.cpp
+++ b/src/gui/SmartMtrConfig.cpp
@@ -38,6 +38,9 @@ double mapSignal(double v, double min, double max)
 }
 
 // ── Mic level (transmit) ────────────────────────────────────────────────────
+// Linear dBFS scale from -40 (bottom) to 0 (full scale / clip, top). -20 lands
+// naturally at the midpoint; the top of the scale (-5 and 0) is drawn in the
+// "high" colour as the clip-warning zone.
 constexpr double kMicMindB = -40.0;
 constexpr double kMicMaxdB = 0.0;
 
@@ -100,13 +103,40 @@ MeterConfig buildMicConfig()
     MeterConfig cfg;
     cfg.valueToPosition = mapMic;
 
-    // -40..0 dB in 10 dB steps, all large + labeled. The 0-dB end is red.
-    for (int db = -40; db <= 0; db += 10) {
+    // Authored by value and placed through the linear map, so ticks line up with
+    // the indicator curve. -40..-10 are blue, -5 and 0 are red as the clip-warning
+    // zone. -5 is a small tick, the rest large; all are labeled. labelOffset
+    // shifts the label horizontally (UNITS): the two-digit labels use -4.0 so the
+    // tick falls between the digits (like the signal +dB labels); -5 uses -2.0 so
+    // the "5" digit (not the leading "-") centers on the tick.
+    struct MicTick {
+        double db;
+        MarkerSize size;
+        MarkerColor color;
+        bool labeled;
+        LabelStyle style;
+        double labelOffset;
+    };
+    static const MicTick ticks[] = {
+        { -40.0, MarkerSize::Large, MarkerColor::Normal, true, LabelStyle::Normal, -4.0 },
+        { -30.0, MarkerSize::Large, MarkerColor::Normal, true, LabelStyle::Normal, -4.0 },
+        { -20.0, MarkerSize::Large, MarkerColor::Normal, true, LabelStyle::Normal, -4.0 },
+        { -10.0, MarkerSize::Large, MarkerColor::Normal, true, LabelStyle::Normal, -4.0 },
+        {  -5.0, MarkerSize::Small, MarkerColor::High,   true, LabelStyle::Normal, -2.0 },
+        {   0.0, MarkerSize::Large, MarkerColor::High,   true, LabelStyle::Normal,  0.0 },
+    };
+    for (const MicTick& t : ticks) {
         ScaleMarker m;
-        m.position = mapMic(db, kMicMindB, kMicMaxdB);
-        m.size = MarkerSize::Large;
-        m.color = (db >= 0) ? MarkerColor::High : MarkerColor::Normal;
-        m.label = QString::number(db);
+        m.position = mapMic(t.db, kMicMindB, kMicMaxdB);
+        m.size = t.size;
+        m.color = t.color;
+        m.labelStyle = t.style;
+        m.labelOffset = t.labelOffset;
+        if (t.labeled) {
+            // Positive dBFS values get a leading "+", like the signal +dB labels.
+            m.label = (t.db > 0.0 ? QStringLiteral("+") : QString())
+                      + QString::number(int(t.db));
+        }
         cfg.markers.push_back(m);
     }
 

--- a/src/gui/SmartMtrConfig.h
+++ b/src/gui/SmartMtrConfig.h
@@ -27,6 +27,10 @@ enum class MeterKind { Signal, MicLevel };
 enum class MarkerSize { Small, Large };
 enum class MarkerColor { Normal, High };
 
+// Label emphasis: Strong = full size, regular weight; Normal = slightly smaller
+// and lighter weight.
+enum class LabelStyle { Normal, Strong };
+
 // Pushed by the parent each update.
 struct MeterInput {
     MeterKind kind = MeterKind::Signal;
@@ -43,6 +47,7 @@ struct ScaleMarker {
     MarkerSize size = MarkerSize::Small;
     MarkerColor color = MarkerColor::Normal;
     QString label; // empty -> no label
+    LabelStyle labelStyle = LabelStyle::Normal;
     // Horizontal shift of the label from the marker centre, in UNITS (+ right,
     // - left). Lets a multi-digit label straddle the tick as desired (e.g. the
     // tick falling between the digits of "+20").

--- a/src/gui/SmartMtrConfig.h
+++ b/src/gui/SmartMtrConfig.h
@@ -38,6 +38,13 @@ struct MeterInput {
     double value = 0.0;    // meaning is per kind (signal: dBm, mic: dB, ...)
     double min = 0.0;
     double max = 1.0;
+
+    // Externally-measured peak (same units as value), for kinds whose peak is a
+    // separate radio-sourced stat rather than a locally-derived window max. Mic
+    // uses it (the radio's MICPEAK meter drives the peak marker); signal leaves
+    // hasPeak false and the widget falls back to its sliding-window envelope.
+    bool hasPeak = false;
+    double peak = 0.0;
 };
 
 // One static scale tick, authored per kind. position is in hole-local UNITS

--- a/src/gui/SmartMtrConfig.h
+++ b/src/gui/SmartMtrConfig.h
@@ -43,6 +43,10 @@ struct ScaleMarker {
     MarkerSize size = MarkerSize::Small;
     MarkerColor color = MarkerColor::Normal;
     QString label; // empty -> no label
+    // Horizontal shift of the label from the marker centre, in UNITS (+ right,
+    // - left). Lets a multi-digit label straddle the tick as desired (e.g. the
+    // tick falling between the digits of "+20").
+    double labelOffset = 0.0;
 };
 
 // Static per-kind configuration.

--- a/src/gui/SmartMtrConfig.h
+++ b/src/gui/SmartMtrConfig.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <QString>
+
+#include <functional>
+#include <vector>
+
+namespace AetherSDR {
+
+// ============================================================================
+// SmartMTR meter model
+// ============================================================================
+//
+// The SmartMtrWidget is render-only and radio-agnostic. The parent pushes a
+// MeterInput describing WHAT to show (kind + value + range); each kind owns a
+// static MeterConfig (scale markers + a value->position mapping) that tells the
+// widget how to draw it.
+//
+// To add a new kind: add a MeterKind value and one MeterConfig entry in the
+// registry (SmartMtrConfig.cpp). No widget changes.
+// ============================================================================
+
+// The measurement the control currently shows. Extend here for new kinds.
+enum class MeterKind { Signal, MicLevel };
+
+// Tick footprint and emphasis (see SmartMtrUnits / SmartMtrColors).
+enum class MarkerSize { Small, Large };
+enum class MarkerColor { Normal, High };
+
+// Pushed by the parent each update.
+struct MeterInput {
+    MeterKind kind = MeterKind::Signal;
+    bool hasValue = false; // false -> indicator parks at the scale minimum
+    double value = 0.0;    // meaning is per kind (signal: dBm, mic: dB, ...)
+    double min = 0.0;
+    double max = 1.0;
+};
+
+// One static scale tick, authored per kind. position is in hole-local UNITS
+// (SmartMtrUnits::kScaleMin..kScaleMax); ticks outside that band are not drawn.
+struct ScaleMarker {
+    double position = 0.0;
+    MarkerSize size = MarkerSize::Small;
+    MarkerColor color = MarkerColor::Normal;
+    QString label; // empty -> no label
+};
+
+// Static per-kind configuration.
+struct MeterConfig {
+    std::vector<ScaleMarker> markers;
+    // Maps a value within [min,max] to a hole-local unit position. Unclamped:
+    // callers range-check (markers) or clamp (indicator) as needed.
+    std::function<double(double value, double min, double max)> valueToPosition;
+};
+
+// Registry lookup for a kind's static configuration.
+const MeterConfig& meterConfig(MeterKind kind);
+
+// Clamped indicator position for an input: handles the null value (-> scale
+// minimum) and clamps the mapped position to the scale band.
+double indicatorPosition(const MeterInput& in);
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrGeometry.h
+++ b/src/gui/SmartMtrGeometry.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "SmartMtrStyle.h"
+
+#include <QRect>
+#include <QRectF>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+// ============================================================================
+// UNITS vs. PIXELS  —  the SmartMTR coordinate system
+// ============================================================================
+//
+// All SmartMTR geometry (bar lengths, tick positions, gaps, line thickness,
+// margins, ...) is expressed in *UNITS*, never in raw pixels (see
+// SmartMtrStyle.h for the unit constants).
+//
+// UNITS are abstract, resolution-independent design units that define only the
+// *proportions* of the control. They have no fixed pixel size of their own.
+//
+// At paint time UNITS are converted to pixels with a single scale factor:
+//
+//       pxPerUnit = actualPixelExtent / totalUnitExtent
+//       pixels    = units * pxPerUnit
+//
+// The design area is SmartMtrUnits::kControlW x kControlH. Because the widget's
+// real pixel rect may not share that aspect ratio, we fit-and-center: one
+// uniform scale factor for both axes (aspect ratio preserved, UNITS square),
+// with the design centered and the leftover margin left as transparent
+// letterbox.
+//
+// This struct is the single authority for that mapping. Every element draws
+// through it (g.rect(...) / g.len(...)); no drawing code computes pxPerUnit
+// itself.
+// ============================================================================
+struct SmartMtrGeometry {
+    double pxPerUnit{1.0};
+    double originX{0.0}; // pixel offset of the design's top-left (letterbox)
+    double originY{0.0};
+
+    // Build the mapping that fits the kControlW x kControlH design, centered,
+    // into the given widget pixel rect.
+    static SmartMtrGeometry fit(const QRect& widgetRect);
+
+    // A length in UNITS -> pixels.
+    double len(double units) const { return units * pxPerUnit; }
+
+    // A rectangle given in UNITS (top-left x,y and size w,h) -> pixel QRectF.
+    QRectF rect(double x, double y, double w, double h) const
+    {
+        return QRectF(originX + x * pxPerUnit, originY + y * pxPerUnit,
+                      w * pxPerUnit, h * pxPerUnit);
+    }
+};
+
+inline SmartMtrGeometry SmartMtrGeometry::fit(const QRect& widgetRect)
+{
+    const double w = widgetRect.width();
+    const double h = widgetRect.height();
+
+    SmartMtrGeometry g;
+    // Uniform scale that fits the whole design area in both axes.
+    g.pxPerUnit = std::min(w / SmartMtrUnits::kControlW,
+                           h / SmartMtrUnits::kControlH);
+    // Center the scaled design in the widget; leftover is transparent letterbox.
+    g.originX = widgetRect.x() + (w - SmartMtrUnits::kControlW * g.pxPerUnit) / 2.0;
+    g.originY = widgetRect.y() + (h - SmartMtrUnits::kControlH * g.pxPerUnit) / 2.0;
+    return g;
+}
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrGeometry.h
+++ b/src/gui/SmartMtrGeometry.h
@@ -2,6 +2,7 @@
 
 #include "SmartMtrStyle.h"
 
+#include <QPointF>
 #include <QRect>
 #include <QRectF>
 
@@ -46,6 +47,13 @@ struct SmartMtrGeometry {
 
     // A length in UNITS -> pixels.
     double len(double units) const { return units * pxPerUnit; }
+
+    // A point given in UNITS (x,y) -> pixel QPointF, through the same mapping as
+    // rect(). Used for polygon vertices (e.g. the extreme-marker triangles).
+    QPointF point(double x, double y) const
+    {
+        return QPointF(originX + x * pxPerUnit, originY + y * pxPerUnit);
+    }
 
     // A rectangle given in UNITS (top-left x,y and size w,h) -> pixel QRectF.
     QRectF rect(double x, double y, double w, double h) const

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -82,4 +82,48 @@ inline constexpr double kLabelHeightNormal = 11.0; // normal (slightly smaller)
 inline constexpr double kLabelGap = 1.0;
 } // namespace SmartMtrUnits
 
+// ============================================================================
+// Extremes (min/max peak-hold markers) tuning
+// ============================================================================
+//
+// The min/max "extremes" markers ride the same scale band as the indicator bar.
+// Unlike the bar (asymmetric exponential ballistics in MeterSmoother), the
+// markers glide at a constant linear slew over a sliding-window envelope of the
+// signal, so they read as a separate UI element. Window length is bound to the
+// user's "Extremes speed" setting; fades and slew are constant.
+//
+// All values are tuning constants — geometry in UNITS, fade thresholds in dB.
+namespace SmartMtrExtremes {
+// Sliding-window length per "Extremes speed" setting (seconds).
+inline constexpr double kWindowFastSec = 1.0;
+inline constexpr double kWindowMediumSec = 3.0;
+inline constexpr double kWindowSlowSec = 5.0;
+
+// Constant-velocity slew of the markers, in scale UNITS per second. ~30 deg/s
+// over the source app's 108-deg extremes arc, scaled to the bar's 220-UNIT span:
+// a marker crosses the full bar in ~3.7 s, deliberately lazy vs the bar's attack.
+inline constexpr double kSlewUnitsPerSec = 60.0;
+
+// Proximity fade: markers fade out when min and max are within a few dB (the
+// spread is then just noise). Linear ramp between these two dB thresholds.
+inline constexpr double kFadeLoDb = 3.0; // <= this spread -> hidden
+inline constexpr double kFadeHiDb = 7.0; // >= this spread -> full opacity
+
+// Signal fade: near-floor signals hide the markers (no point showing extremes of
+// noise). Linear ramp on the current signal dBm.
+inline constexpr double kSignalFadeLoDbm = -127.0; // <= this -> hidden
+inline constexpr double kSignalFadeHiDbm = -115.0; // >= this -> full (~S2)
+
+// Marker triangle: apex-up, base stuck to the hole's top edge. Sized off the
+// hole height so it scales with the bar.
+inline constexpr double kExtremeTriH = SmartMtrUnits::kHoleH * 0.6; // height (60% = 6 UNITS)
+inline constexpr double kExtremeTriW = SmartMtrUnits::kHoleH * 0.4; // base width (40% = 4 UNITS)
+
+// Value-label overlay (drawn below the meter by the parent flag): the short
+// vertical connector line from the hole's bottom edge down toward the label, and
+// the gap from the connector to the label text. In UNITS.
+inline constexpr double kLabelConnectorLen = 4.0;
+inline constexpr double kLabelConnectorGap = 1.0;
+} // namespace SmartMtrExtremes
+
 } // namespace AetherSDR

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -24,7 +24,7 @@ inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
 inline const QColor kForeground{QStringLiteral("#ff4444")}; // indicator bar — red
 inline const QColor kIndicator{QStringLiteral("#ffffff")};  // value end-line
 inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
-inline const QColor kShadow{0, 0, 0, 70};                   // inset shadow — TBD
+inline const QColor kShadow{0, 0, 0, 80};                   // inset shadow — TBD
 inline const QColor kMarkerNormal{QStringLiteral("#5ec4ea")}; // scale tick — normal
 inline const QColor kMarkerHigh{QStringLiteral("#ff4444")};   // scale tick — high
 } // namespace SmartMtrColors

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -21,10 +21,12 @@ namespace AetherSDR {
 namespace SmartMtrColors {
 inline const QColor kControl{QStringLiteral("#161620ff")};    // control body — TBD
 inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
-inline const QColor kForeground{QStringLiteral("#fe4343")}; // indicator bar
-inline const QColor kIndicator{QStringLiteral("#ffffff")};  // reserved (future)
+inline const QColor kForeground{QStringLiteral("#ff4444")}; // indicator bar — red
+inline const QColor kIndicator{QStringLiteral("#ffffff")};  // value end-line
 inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
 inline const QColor kShadow{0, 0, 0, 70};                   // inset shadow — TBD
+inline const QColor kMarkerNormal{QStringLiteral("#5ec4ea")}; // scale tick — normal
+inline const QColor kMarkerHigh{QStringLiteral("#ff4444")};   // scale tick — high
 } // namespace SmartMtrColors
 
 // Geometry of the SmartMTR control, in UNITS.
@@ -46,13 +48,26 @@ inline constexpr double kHoleRadius = 4.0;
 // Inset shadow rim width, equal on all four inner sides of the hole.
 inline constexpr double kShadow = 2.0;
 
-// Indicator bar fill, as a fraction of the hole width. Hard-pinned for now;
-// later steps map a measured level onto this.
-inline constexpr double kIndicatorFraction = 0.5; // 50%
+// Indicator scale band, in hole-local units (0..kHoleW). The minimum/null value
+// sits at kScaleMin, the maximum at kScaleMax, leaving a symmetric gap at each
+// end of the hole. Markers outside [kScaleMin, kScaleMax] are not rendered.
+inline constexpr double kScaleMin = 10.0;
+inline constexpr double kScaleMax = 230.0;
 
-// Thickness of the bright marker line sitting on top of the bar's right end
+// Thickness of the bright value line sitting on top of the bar's right end
 // (kIndicator). Right-aligned within the bar, so it never extends past it.
 inline constexpr double kIndicatorLine = 1.0;
+
+// Scale-marker tick sizes (height = length away from the hole, width = thickness
+// straddling the marker position).
+inline constexpr double kMarkerSmallH = 3.0, kMarkerSmallW = 1.0;
+inline constexpr double kMarkerLargeH = 5.0, kMarkerLargeW = 2.0;
+
+// Marker labels (top ticks only): font cell height and gap above the tick.
+// Above-hole budget is kHoleMargY(20) − kMarkerLargeH(5) − kLabelGap(1) = 14
+// units, so up to ~12 fits with a small top margin.
+inline constexpr double kLabelHeight = 12.0;
+inline constexpr double kLabelGap = 1.0;
 } // namespace SmartMtrUnits
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QColor>
+
+namespace AetherSDR {
+
+// ============================================================================
+// SmartMTR design tokens
+// ============================================================================
+//
+// Single source of truth for the SmartMTR control's look. To re-tune the
+// control's proportions or palette, edit THIS file only — no drawing code
+// references magic numbers; every element reads from these constants.
+//
+// Geometry is expressed in UNITS (see SmartMtrGeometry.h for the UNITS->pixel
+// mapping). UNITS are abstract, resolution-independent design units that fix
+// only the proportions of the control, never its pixel size.
+// ============================================================================
+
+// Palette for the SmartMTR meter control.
+namespace SmartMtrColors {
+inline const QColor kControl{QStringLiteral("#161620ff")};    // control body — TBD
+inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
+inline const QColor kForeground{QStringLiteral("#fe4343")}; // indicator bar
+inline const QColor kIndicator{QStringLiteral("#ffffff")};  // reserved (future)
+inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
+inline const QColor kShadow{0, 0, 0, 70};                   // inset shadow — TBD
+} // namespace SmartMtrColors
+
+// Geometry of the SmartMTR control, in UNITS.
+namespace SmartMtrUnits {
+// The control's full design area.
+inline constexpr double kControlW = 250.0;
+inline constexpr double kControlH = 40.0;
+
+// The recessed "hole" / indicator area: horizontally centered, fixed 20 units
+// from the top.
+inline constexpr double kHoleW = 240.0;
+inline constexpr double kHoleH = 10.0;
+inline constexpr double kHoleMargX = (kControlW - kHoleW) / 2.0; // 10, centered
+inline constexpr double kHoleMargY = 20.0;                       // from top
+
+// Corner radius of the hole (and, concentrically, its inset rim), in units.
+inline constexpr double kHoleRadius = 4.0;
+
+// Inset shadow rim width, equal on all four inner sides of the hole.
+inline constexpr double kShadow = 2.0;
+
+// Indicator bar fill, as a fraction of the hole width. Hard-pinned for now;
+// later steps map a measured level onto this.
+inline constexpr double kIndicatorFraction = 0.5; // 50%
+
+// Thickness of the bright marker line sitting on top of the bar's right end
+// (kIndicator). Right-aligned within the bar, so it never extends past it.
+inline constexpr double kIndicatorLine = 1.0;
+} // namespace SmartMtrUnits
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -77,7 +77,7 @@ inline constexpr double kMarkerSmallOpacity = 0.6;
 // Above-hole budget is kHoleMargY(20) − kMarkerLargeH(5) − kLabelGap(1) = 14
 // units, so up to ~12 fits with a small top margin. Strong labels use the full
 // height; normal labels are minimally smaller.
-inline constexpr double kLabelHeight = 12.0;       // strong
+inline constexpr double kLabelHeight = 14.0;       // strong (a bit larger)
 inline constexpr double kLabelHeightNormal = 11.0; // normal (slightly smaller)
 inline constexpr double kLabelGap = 1.0;
 } // namespace SmartMtrUnits
@@ -103,6 +103,13 @@ inline constexpr double kWindowSlowSec = 5.0;
 // over the source app's 108-deg extremes arc, scaled to the bar's 220-UNIT span:
 // a marker crosses the full bar in ~3.7 s, deliberately lazy vs the bar's attack.
 inline constexpr double kSlewUnitsPerSec = 60.0;
+
+// Slew for the external-peak marker (mic MICPEAK over UDP). The radio's peak is
+// a live, separately-measured stat, so its marker tracks tightly — like the bar
+// — rather than the lazy RX sweep above. ~4000 UNIT/s crosses the full 220-UNIT
+// span in ~55 ms, so a typical packet-to-packet jump lands within a frame or two
+// while still smoothing the per-packet step instead of snapping.
+inline constexpr double kPeakSlewUnitsPerSec = 4000.0;
 
 // Repaint cadence (Hz) for a returning marker, used to bypass the bar's lean
 // repaint gate (#3283). In lean mode the bar throttles its repaint to 12 Hz; a

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -25,16 +25,21 @@ inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
 inline const QColor kForeground{QStringLiteral("#ff4444")}; // indicator bar — red
 inline const QColor kIndicator{QStringLiteral("#ffffff")};  // value end-line
 inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
-inline const QColor kShadow{0, 0, 0, 90};                   // inset shadow — TBD
+inline const QColor kShadow{0, 0, 0, 100};                   // inset shadow — TBD
 inline const QColor kMarkerNormal{QStringLiteral("#5ec4ea")}; // scale tick — normal
 inline const QColor kMarkerHigh{QStringLiteral("#ff4444")};   // scale tick — high
 } // namespace SmartMtrColors
 
 // Geometry of the SmartMTR control, in UNITS.
 namespace SmartMtrUnits {
-// The control's full design area.
+// The control's full design area.  The height hugs the actual content extent —
+// the bottom ticks reach kHoleMargY(20) + kHoleH(10) + kMarkerLargeH(5) = 35
+// units — so the widget reserves no empty band below the meter.  That keeps the
+// gap to the tab row below minimal (matching the S-meter), rather than padding
+// it out with leftover canvas.  Width-driven scale means this only trims the
+// bottom; the bar/hole/ticks render at the same size. (#SmartMTR)
 inline constexpr double kControlW = 250.0;
-inline constexpr double kControlH = 40.0;
+inline constexpr double kControlH = 35.0;
 
 // The recessed "hole" / indicator area: horizontally centered, fixed 20 units
 // from the top.
@@ -66,7 +71,7 @@ inline constexpr double kMarkerSmallH = 4.0, kMarkerSmallW = 1.0;
 inline constexpr double kMarkerLargeH = 5.0, kMarkerLargeW = 2.0;
 // Small ticks are drawn a bit transparent so they read as secondary to the
 // large (labeled) ones.
-inline constexpr double kMarkerSmallOpacity = 0.55;
+inline constexpr double kMarkerSmallOpacity = 0.6;
 
 // Marker labels (top ticks only): font cell height and gap above the tick.
 // Above-hole budget is kHoleMargY(20) − kMarkerLargeH(5) − kLabelGap(1) = 14

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -19,12 +19,13 @@ namespace AetherSDR {
 
 // Palette for the SmartMTR meter control.
 namespace SmartMtrColors {
-inline const QColor kControl{QStringLiteral("#161620ff")};    // control body — TBD
+inline const QColor kControl{QStringLiteral("#161620")};      // = slice flag bg
+// (VfoWidget base #0a0a14 + its 5% white depth overlay, composited)
 inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
 inline const QColor kForeground{QStringLiteral("#ff4444")}; // indicator bar — red
 inline const QColor kIndicator{QStringLiteral("#ffffff")};  // value end-line
 inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
-inline const QColor kShadow{0, 0, 0, 80};                   // inset shadow — TBD
+inline const QColor kShadow{0, 0, 0, 90};                   // inset shadow — TBD
 inline const QColor kMarkerNormal{QStringLiteral("#5ec4ea")}; // scale tick — normal
 inline const QColor kMarkerHigh{QStringLiteral("#ff4444")};   // scale tick — high
 } // namespace SmartMtrColors
@@ -45,8 +46,9 @@ inline constexpr double kHoleMargY = 20.0;                       // from top
 // Corner radius of the hole (and, concentrically, its inset rim), in units.
 inline constexpr double kHoleRadius = 4.0;
 
-// Inset shadow rim width, equal on all four inner sides of the hole.
-inline constexpr double kShadow = 2.0;
+// Inset shadow depth: how far the soft gradient reaches inward from each inner
+// edge of the hole (equal on all four sides).
+inline constexpr double kShadow = 3.0;
 
 // Indicator scale band, in hole-local units (0..kHoleW). The minimum/null value
 // sits at kScaleMin, the maximum at kScaleMax, leaving a symmetric gap at each
@@ -60,13 +62,18 @@ inline constexpr double kIndicatorLine = 1.0;
 
 // Scale-marker tick sizes (height = length away from the hole, width = thickness
 // straddling the marker position).
-inline constexpr double kMarkerSmallH = 3.0, kMarkerSmallW = 1.0;
+inline constexpr double kMarkerSmallH = 4.0, kMarkerSmallW = 1.0;
 inline constexpr double kMarkerLargeH = 5.0, kMarkerLargeW = 2.0;
+// Small ticks are drawn a bit transparent so they read as secondary to the
+// large (labeled) ones.
+inline constexpr double kMarkerSmallOpacity = 0.55;
 
 // Marker labels (top ticks only): font cell height and gap above the tick.
 // Above-hole budget is kHoleMargY(20) − kMarkerLargeH(5) − kLabelGap(1) = 14
-// units, so up to ~12 fits with a small top margin.
-inline constexpr double kLabelHeight = 12.0;
+// units, so up to ~12 fits with a small top margin. Strong labels use the full
+// height; normal labels are minimally smaller.
+inline constexpr double kLabelHeight = 12.0;       // strong
+inline constexpr double kLabelHeightNormal = 11.0; // normal (slightly smaller)
 inline constexpr double kLabelGap = 1.0;
 } // namespace SmartMtrUnits
 

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -21,13 +21,13 @@ namespace AetherSDR {
 namespace SmartMtrColors {
 inline const QColor kControl{QStringLiteral("#161620")};      // = slice flag bg
 // (VfoWidget base #0a0a14 + its 5% white depth overlay, composited)
-inline const QColor kBackground{QStringLiteral("#5ec4eaff")}; // recessed hole
-inline const QColor kForeground{QStringLiteral("#ff4444")}; // indicator bar — red
+inline const QColor kBackground{QStringLiteral("#5f89a2")}; // recessed hole
+inline const QColor kForeground{QStringLiteral("#ff5463")}; // indicator bar — red
 inline const QColor kIndicator{QStringLiteral("#ffffff")};  // value end-line
 inline const QColor kExtreme{QStringLiteral("#ffffff")};    // reserved (future)
 inline const QColor kShadow{0, 0, 0, 100};                   // inset shadow — TBD
-inline const QColor kMarkerNormal{QStringLiteral("#5ec4ea")}; // scale tick — normal
-inline const QColor kMarkerHigh{QStringLiteral("#ff4444")};   // scale tick — high
+inline const QColor kMarkerNormal{QStringLiteral("#42e3ff")}; // scale tick — normal
+inline const QColor kMarkerHigh{QStringLiteral("#ff5463")};   // scale tick — high
 } // namespace SmartMtrColors
 
 // Geometry of the SmartMTR control, in UNITS.

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -104,6 +104,14 @@ inline constexpr double kWindowSlowSec = 5.0;
 // a marker crosses the full bar in ~3.7 s, deliberately lazy vs the bar's attack.
 inline constexpr double kSlewUnitsPerSec = 60.0;
 
+// Repaint cadence (Hz) for a returning marker, used to bypass the bar's lean
+// repaint gate (#3283). In lean mode the bar throttles its repaint to 12 Hz; a
+// marker gliding back at kSlewUnitsPerSec sampled to the screen at 12 Hz steps
+// visibly (~2 deg/frame). The original SmartMTR renders its return at a steady
+// 60 Hz, so we match that for the markers while leaving the bar and idle meters
+// lean-gated. Bounds the extra GPU recomposite cost to the return window only.
+inline constexpr int kExtremesRepaintHz = 60;
+
 // Proximity fade: markers fade out when min and max are within a few dB (the
 // spread is then just noise). Linear ramp between these two dB thresholds.
 inline constexpr double kFadeLoDb = 3.0; // <= this spread -> hidden

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -44,7 +44,7 @@ inline constexpr double kHoleMargX = (kControlW - kHoleW) / 2.0; // 10, centered
 inline constexpr double kHoleMargY = 20.0;                       // from top
 
 // Corner radius of the hole (and, concentrically, its inset rim), in units.
-inline constexpr double kHoleRadius = 4.0;
+inline constexpr double kHoleRadius = 2.0;
 
 // Inset shadow depth: how far the soft gradient reaches inward from each inner
 // edge of the hole (equal on all four sides).

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -2,12 +2,34 @@
 
 #include "SmartMtrStyle.h"
 
+#include <QFont>
+#include <QFontMetricsF>
 #include <QPainter>
 #include <QPainterPath>
 
 namespace AetherSDR {
 
 using namespace SmartMtrUnits;
+
+namespace {
+// Tick footprint (height away from the hole, thickness) for a marker size.
+void markerExtent(MarkerSize size, double& height, double& width)
+{
+    if (size == MarkerSize::Large) {
+        height = kMarkerLargeH;
+        width = kMarkerLargeW;
+    } else {
+        height = kMarkerSmallH;
+        width = kMarkerSmallW;
+    }
+}
+
+const QColor& markerColor(MarkerColor color)
+{
+    return color == MarkerColor::High ? SmartMtrColors::kMarkerHigh
+                                      : SmartMtrColors::kMarkerNormal;
+}
+} // namespace
 
 SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     : QWidget(parent)
@@ -29,6 +51,12 @@ SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     setSizePolicy(sp);
 }
 
+void SmartMtrWidget::setMeterInput(const MeterInput& input)
+{
+    m_input = input;
+    update();
+}
+
 void SmartMtrWidget::paintEvent(QPaintEvent*)
 {
     const auto g = SmartMtrGeometry::fit(rect());
@@ -36,12 +64,14 @@ void SmartMtrWidget::paintEvent(QPaintEvent*)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    // Back-to-front: body, recessed hole, indicator fill, then the inset shadow
-    // rim on top so the bar reads as sunken.
+    // Back-to-front: body, recessed hole, indicator fill, the inset shadow rim
+    // on top so the bar reads as sunken, then the scale markers/labels (drawn on
+    // the body above and below the hole).
     drawControl(p, g);
     drawHole(p, g);
     drawIndicator(p, g);
     drawInsetShadow(p, g);
+    drawMarkers(p, g);
 }
 
 void SmartMtrWidget::drawControl(QPainter& p, const SmartMtrGeometry& g) const
@@ -60,22 +90,24 @@ void SmartMtrWidget::drawHole(QPainter& p, const SmartMtrGeometry& g) const
 
 void SmartMtrWidget::drawIndicator(QPainter& p, const SmartMtrGeometry& g) const
 {
-    // Left-to-right bar, full hole height, kIndicatorFraction of the hole width.
+    // Bar from the scale minimum to the mapped value position, full hole height.
     // Clipped to the rounded hole so the bar's corners follow the hole's radius.
     const QRectF hole = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
     const double r = g.len(kHoleRadius);
     QPainterPath clip;
     clip.addRoundedRect(hole, r, r);
 
-    const double barW = kIndicatorFraction * kHoleW;
+    const double pos = indicatorPosition(m_input); // hole-local units, in band
 
+    // The bar always starts at hole-local 0, so a min/blank value (pos == 10)
+    // still renders a short 0..10 stub rather than nothing.
     p.save();
     p.setClipPath(clip);
-    p.fillRect(g.rect(kHoleMargX, kHoleMargY, barW, kHoleH),
+    p.fillRect(g.rect(kHoleMargX, kHoleMargY, pos, kHoleH),
                SmartMtrColors::kForeground);
-    // Bright marker line on top of the bar's right end, right-aligned so it sits
-    // inside the bar (its last kIndicatorLine units), never extending past it.
-    p.fillRect(g.rect(kHoleMargX + barW - kIndicatorLine, kHoleMargY,
+    // Bright value line at the bar's right end (the value), drawn just inside the
+    // end so it never extends past the position.
+    p.fillRect(g.rect(kHoleMargX + pos - kIndicatorLine, kHoleMargY,
                       kIndicatorLine, kHoleH),
                SmartMtrColors::kIndicator);
     p.restore();
@@ -98,6 +130,50 @@ void SmartMtrWidget::drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) con
     // Odd-even fill leaves only the rim (outer minus inner) painted.
     path.setFillRule(Qt::OddEvenFill);
     p.fillPath(path, SmartMtrColors::kShadow);
+}
+
+void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
+{
+    const MeterConfig& cfg = meterConfig(m_input.kind);
+    if (cfg.markers.empty())
+        return;
+
+    // Label font: the app UI font, sized from kLabelHeight with a pixel floor so
+    // it stays legible when the control is small.
+    QFont labelFont = font();
+    labelFont.setPixelSize(qMax(8, qRound(g.len(kLabelHeight))));
+    const QFontMetricsF fm(labelFont);
+    p.setFont(labelFont);
+
+    const double holeBottom = kHoleMargY + kHoleH;
+
+    for (const ScaleMarker& m : cfg.markers) {
+        // Only ticks inside the scale band are rendered.
+        if (m.position < kScaleMin || m.position > kScaleMax)
+            continue;
+
+        double h = 0.0, w = 0.0;
+        markerExtent(m.size, h, w);
+        const QColor& color = markerColor(m.color);
+        const double x = kHoleMargX + m.position - w / 2.0; // centered on position
+
+        // Symmetric pair, each stuck to a hole edge and growing outward.
+        const QRectF above = g.rect(x, kHoleMargY - h, w, h);
+        p.fillRect(above, color);
+        p.fillRect(g.rect(x, holeBottom, w, h), color);
+
+        if (m.label.isEmpty())
+            continue;
+
+        // Label centered on the marker, sitting just above the top tick.
+        const double cx = above.center().x();
+        const double bottom = above.top() - g.len(kLabelGap);
+        const double tw = fm.horizontalAdvance(m.label);
+        const double th = fm.height();
+        const QRectF box(cx - tw, bottom - th, tw * 2.0, th);
+        p.setPen(color);
+        p.drawText(box, Qt::AlignHCenter | Qt::AlignBottom, m.label);
+    }
 }
 
 QSize SmartMtrWidget::sizeHint() const

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -165,8 +165,9 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
         if (m.label.isEmpty())
             continue;
 
-        // Label centered on the marker, sitting just above the top tick.
-        const double cx = above.center().x();
+        // Label centered on the marker (plus its per-marker offset), sitting
+        // just above the top tick.
+        const double cx = above.center().x() + g.len(m.labelOffset);
         const double bottom = above.top() - g.len(kLabelGap);
         const double tw = fm.horizontalAdvance(m.label);
         const double th = fm.height();

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -54,17 +54,9 @@ SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     sp.setHeightForWidth(true);
     setSizePolicy(sp);
 
-    // SmartMTR analog ballistics (ported from the SmartMTR macOS app): a fast
-    // attack and a ~15x slower, lazy decay give the d'Arsonval "jumps up, sags
-    // down" envelope-follower feel. tau values come from per-tick fractions
-    // k=0.60/0.06 at 60 Hz: tau = -(1/60)/ln(1-k). The smoother integrates the
-    // normalised scale fraction; a tiny snap epsilon keeps the slow tail lazy
-    // (the source never snaps on decay) without endless sub-pixel repaints.
-    MeterSmoother::Ballistics b;
-    b.attackSeconds = 0.01818f;  // ~18.2 ms — fast rise
-    b.releaseSeconds = 0.26940f; // ~269 ms — slow fall
-    b.snapEpsilon = 0.0005f;
-    m_smooth.setBallistics(b);
+    // Ballistics depend on the meter kind (signal vs mic) — see applyBallistics.
+    // Seed with the default kind's set; setMeterInput re-applies on a kind switch.
+    applyBallistics(m_kind);
 
     m_animTimer.setTimerType(Qt::PreciseTimer);
     m_animTimer.setInterval(kMeterSmootherIntervalMs); // 8 ms ~= 120 Hz
@@ -75,6 +67,33 @@ SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     m_extremesClock.start();
 }
 
+void SmartMtrWidget::applyBallistics(MeterKind kind)
+{
+    MeterSmoother::Ballistics b;
+    if (kind == MeterKind::MicLevel) {
+        // PPM / audio-meter feel: track the live mic level as tightly as the mic
+        // packet rate allows so speech reads as a lively, twitchy bar. Both tau
+        // are well under the ~50-100 ms gap between mic packets, so the bar
+        // effectively lands on each new sample instead of lagging behind a
+        // falling value. The d'Arsonval lazy sag below is right for an S-meter
+        // but feels dead on voice; the PEAK extremes marker handles peak-hold.
+        b.attackSeconds = 0.002f;  // ~2 ms — essentially instant rise
+        b.releaseSeconds = 0.045f; // ~45 ms — fast fall, just enough to not flicker
+    } else {
+        // SmartMTR analog ballistics (ported from the SmartMTR macOS app): a fast
+        // attack and a ~15x slower, lazy decay give the d'Arsonval "jumps up, sags
+        // down" envelope-follower feel. tau values come from per-tick fractions
+        // k=0.60/0.06 at 60 Hz: tau = -(1/60)/ln(1-k).
+        b.attackSeconds = 0.01818f;  // ~18.2 ms — fast rise
+        b.releaseSeconds = 0.26940f; // ~269 ms — slow fall
+    }
+    // The smoother integrates the normalised scale fraction; a tiny snap epsilon
+    // keeps the slow tail lazy (the source never snaps on decay) without endless
+    // sub-pixel repaints.
+    b.snapEpsilon = 0.0005f;
+    m_smooth.setBallistics(b);
+}
+
 void SmartMtrWidget::setMeterInput(const MeterInput& input)
 {
     const bool kindChanged = (input.kind != m_kind);
@@ -82,21 +101,31 @@ void SmartMtrWidget::setMeterInput(const MeterInput& input)
     m_kind = input.kind;
 
     // RX<->TX is a scale discontinuity (signal dBm vs mic dBFS); the extremes
-    // window must not mix domains.
-    if (kindChanged)
+    // window must not mix domains, and the bar ballistics differ per kind.
+    if (kindChanged) {
         m_extremes.reset();
+        applyBallistics(m_kind);
+    }
 
-    // Feed the raw sample into the extremes window (both kinds; mic uses it for
-    // the AVG bar + PEAK marker). Skip on park (no value) or when disabled.
-    if (m_extremesEnabled && input.hasValue)
-        m_extremes.record(input.value, m_extremesClock.elapsed());
+    // Drive the extremes engine. Signal derives its min/max from a local sliding
+    // window of the dBm stream; mic's peak is a separate radio-sourced stat
+    // (MICPEAK over UDP), so it overrides the MAX marker directly rather than
+    // synthesizing one. Skip on park (no value) or when disabled.
+    if (m_extremesEnabled && input.hasValue) {
+        if (input.kind == MeterKind::MicLevel) {
+            if (input.hasPeak)
+                m_extremes.setExternalPeak(input.peak);
+        } else {
+            m_extremes.record(input.value, m_extremesClock.elapsed());
+        }
+    }
 
-    // Bar target. For mic with extremes on, the bar tracks the windowed AVERAGE
-    // (PEAK shown by the marker); otherwise it tracks the instantaneous value.
-    const double posUnits =
-        (m_extremesEnabled && input.hasValue && input.kind == MeterKind::MicLevel)
-            ? mapRawToUnits(m_extremes.avgRaw())
-            : indicatorPosition(input);
+    // Bar target = the instantaneous value. (Mic used to track the windowed
+    // AVERAGE here for a VU-like read, but a 1-5s mean barely twitches on speech
+    // and read as "dead"; the mic now uses a snappy PPM ballistic on the live
+    // level instead — see applyBallistics — with the PEAK marker still holding
+    // the loud peaks.)
+    const double posUnits = indicatorPosition(input);
 
     // Normalise to the scale band so the ballistics are scale-independent.
     const double span = kScaleMax - kScaleMin;
@@ -310,6 +339,13 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
 
     const double holeBottom = kHoleMargY + kHoleH;
 
+    // Every label is anchored at the LARGE tick height so a small labeled tick's
+    // label sits on the same baseline row as the large ones (only the tick stays
+    // shorter). Its opacity still follows the tick, so a small tick's label reads
+    // as secondary too.
+    double largeH = 0.0, largeW = 0.0;
+    markerExtent(MarkerSize::Large, largeH, largeW);
+
     // Labels come in two fixed styles (strong = full size + regular weight,
     // normal = slightly smaller + light); build each font and its metrics once
     // rather than per labeled tick. App UI font, with a pixel floor for legibility.
@@ -354,15 +390,22 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
         const QFontMetricsF& fm = strong ? strongFm : normalFm;
         p.setFont(labelFont);
 
-        // Label centered on the marker (plus its per-marker offset), sitting
-        // just above the top tick.
+        // Label centered on the marker (plus its per-marker offset), sitting just
+        // above the LARGE tick height (shared baseline) regardless of this tick's
+        // own size.
         const double cx = above.center().x() + g.len(m.labelOffset);
-        const double bottom = above.top() - g.len(kLabelGap);
+        const double labelTop = g.rect(x, kHoleMargY - largeH, w, largeH).top();
+        const double bottom = labelTop - g.len(kLabelGap);
         const double tw = fm.horizontalAdvance(m.label);
         const double th = fm.height();
-        const QRectF box(cx - tw, bottom - th, tw * 2.0, th);
-        p.setPen(color);
-        p.drawText(box, Qt::AlignHCenter | Qt::AlignBottom, m.label);
+        // Center every label on the regular-label center line so a strong (larger)
+        // label is vertically centered with the regular ones, rather than sharing
+        // their bottom baseline (which would push its taller glyphs upward).
+        const double centerY = bottom - normalFm.height() / 2.0;
+        const QRectF box(cx - tw, centerY - th / 2.0, tw * 2.0, th);
+        // Label fades with the tick: a small (secondary) tick gets a dimmed label.
+        p.setPen(tickColor);
+        p.drawText(box, Qt::AlignHCenter | Qt::AlignVCenter, m.label);
     }
 }
 
@@ -501,6 +544,11 @@ void SmartMtrWidget::drawExtremes(QPainter& p, const SmartMtrGeometry& g) const
 QVector<SmartMtrWidget::ExtremeMarker> SmartMtrWidget::extremeLabels() const
 {
     QVector<ExtremeMarker> out;
+
+    // Numeric value labels are a signal-meter feature only; other kinds (mic/TX)
+    // show no value text (the peak marker itself still draws).
+    if (m_kind != MeterKind::Signal)
+        return out;
 
     // Two lines for signal (S-unit over dBm); a single top line for mic (no
     // S-unit), so the value isn't left floating on the lower line.

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -50,12 +50,60 @@ SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::Preferred);
     sp.setHeightForWidth(true);
     setSizePolicy(sp);
+
+    // SmartMTR analog ballistics (ported from the SmartMTR macOS app): a fast
+    // attack and a ~15x slower, lazy decay give the d'Arsonval "jumps up, sags
+    // down" envelope-follower feel. tau values come from per-tick fractions
+    // k=0.60/0.06 at 60 Hz: tau = -(1/60)/ln(1-k). The smoother integrates the
+    // normalised scale fraction; a tiny snap epsilon keeps the slow tail lazy
+    // (the source never snaps on decay) without endless sub-pixel repaints.
+    MeterSmoother::Ballistics b;
+    b.attackSeconds = 0.01818f;  // ~18.2 ms — fast rise
+    b.releaseSeconds = 0.26940f; // ~269 ms — slow fall
+    b.snapEpsilon = 0.0005f;
+    m_smooth.setBallistics(b);
+
+    m_animTimer.setTimerType(Qt::PreciseTimer);
+    m_animTimer.setInterval(kMeterSmootherIntervalMs); // 8 ms ~= 120 Hz
+    connect(&m_animTimer, &QTimer::timeout, this, &SmartMtrWidget::advance);
 }
 
 void SmartMtrWidget::setMeterInput(const MeterInput& input)
 {
     m_input = input;
-    update();
+
+    // Target the smoother at the mapped position, normalised to the scale band
+    // so the ballistics are scale-independent. drawIndicator denormalises.
+    const double span = kScaleMax - kScaleMin;
+    const float targetFrac =
+        span > 0.0 ? float((indicatorPosition(input) - kScaleMin) / span) : 0.0f;
+
+    if (input.kind != m_kind) {
+        // RX<->TX switches the meter to a different scale (signal dBm vs mic
+        // dBFS); snap rather than glide the bar across that discontinuity.
+        m_kind = input.kind;
+        m_smooth.setTarget(targetFrac);
+        m_smooth.snapToTarget();
+        m_animTimer.stop();
+        update();
+        return;
+    }
+
+    m_smooth.setTarget(targetFrac);
+    if (m_smooth.needsAnimation() && !m_animTimer.isActive()) {
+        m_clock.restart();
+        m_animTimer.start();
+    }
+    update(); // paint the first frame promptly; the timer carries the rest
+}
+
+void SmartMtrWidget::advance()
+{
+    const bool settled = !m_smooth.tick(m_clock.restart());
+    if (settled)
+        m_animTimer.stop();
+    if (settled || m_smooth.shouldRepaint())
+        update();
 }
 
 void SmartMtrWidget::paintEvent(QPaintEvent*)
@@ -98,7 +146,9 @@ void SmartMtrWidget::drawIndicator(QPainter& p, const SmartMtrGeometry& g) const
     QPainterPath clip;
     clip.addRoundedRect(hole, r, r);
 
-    const double pos = indicatorPosition(m_input); // hole-local units, in band
+    // Smoothed hole-local position: the ballistics integrate the normalised
+    // scale fraction; map it back into the scale band here.
+    const double pos = kScaleMin + m_smooth.value() * (kScaleMax - kScaleMin);
 
     // The bar always starts at hole-local 0, so a min/blank value (pos == 10)
     // still renders a short 0..10 stub rather than nothing.

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -4,6 +4,7 @@
 
 #include <QFont>
 #include <QFontMetricsF>
+#include <QLinearGradient>
 #include <QPainter>
 #include <QPainterPath>
 
@@ -115,21 +116,46 @@ void SmartMtrWidget::drawIndicator(QPainter& p, const SmartMtrGeometry& g) const
 
 void SmartMtrWidget::drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const
 {
-    // A kShadow-wide rim, equal on all four inner sides of the hole: the rounded
-    // hole minus the same rounded rect deflated by kShadow on every side. The
-    // inner radius shrinks by kShadow too, keeping the corners concentric.
-    const QRectF outer = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
-    const QRectF inner = g.rect(kHoleMargX + kShadow, kHoleMargY + kShadow,
-                                kHoleW - 2.0 * kShadow, kHoleH - 2.0 * kShadow);
-    const double ro = g.len(kHoleRadius);
-    const double ri = g.len(kHoleRadius - kShadow);
+    // Soft inner shadow: each edge fades from the rim colour at the hole's edge
+    // to fully transparent kShadow units inward, so the hole reads as a recess
+    // rather than a flat border. Clipped to the rounded hole, so the gradients
+    // follow the corners; the corner overlap deepens slightly, which looks
+    // natural for a recess.
+    const QRectF hole = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
+    const double r = g.len(kHoleRadius);
+    const double s = g.len(kShadow);
+    if (s <= 0.0)
+        return;
 
-    QPainterPath path;
-    path.addRoundedRect(outer, ro, ro);
-    path.addRoundedRect(inner, ri, ri);
-    // Odd-even fill leaves only the rim (outer minus inner) painted.
-    path.setFillRule(Qt::OddEvenFill);
-    p.fillPath(path, SmartMtrColors::kShadow);
+    QColor edge = SmartMtrColors::kShadow;
+    QColor fade = edge;
+    fade.setAlpha(0);
+
+    QPainterPath clip;
+    clip.addRoundedRect(hole, r, r);
+
+    p.save();
+    p.setClipPath(clip);
+    p.setPen(Qt::NoPen);
+
+    auto edgeGradient = [&](const QRectF& band, const QPointF& from, const QPointF& to) {
+        QLinearGradient grad(from, to); // from = at the rim, to = s units inward
+        grad.setColorAt(0.0, edge);
+        grad.setColorAt(1.0, fade);
+        p.fillRect(band, grad);
+    };
+
+    // Top / bottom / left / right inner edges.
+    edgeGradient(QRectF(hole.left(), hole.top(), hole.width(), s),
+                 QPointF(hole.left(), hole.top()), QPointF(hole.left(), hole.top() + s));
+    edgeGradient(QRectF(hole.left(), hole.bottom() - s, hole.width(), s),
+                 QPointF(hole.left(), hole.bottom()), QPointF(hole.left(), hole.bottom() - s));
+    edgeGradient(QRectF(hole.left(), hole.top(), s, hole.height()),
+                 QPointF(hole.left(), hole.top()), QPointF(hole.left() + s, hole.top()));
+    edgeGradient(QRectF(hole.right() - s, hole.top(), s, hole.height()),
+                 QPointF(hole.right(), hole.top()), QPointF(hole.right() - s, hole.top()));
+
+    p.restore();
 }
 
 void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
@@ -137,13 +163,6 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
     const MeterConfig& cfg = meterConfig(m_input.kind);
     if (cfg.markers.empty())
         return;
-
-    // Label font: the app UI font, sized from kLabelHeight with a pixel floor so
-    // it stays legible when the control is small.
-    QFont labelFont = font();
-    labelFont.setPixelSize(qMax(8, qRound(g.len(kLabelHeight))));
-    const QFontMetricsF fm(labelFont);
-    p.setFont(labelFont);
 
     const double holeBottom = kHoleMargY + kHoleH;
 
@@ -157,13 +176,28 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
         const QColor& color = markerColor(m.color);
         const double x = kHoleMargX + m.position - w / 2.0; // centered on position
 
+        // Small ticks read as secondary, so draw them a bit transparent.
+        QColor tickColor = color;
+        if (m.size == MarkerSize::Small)
+            tickColor.setAlphaF(tickColor.alphaF() * kMarkerSmallOpacity);
+
         // Symmetric pair, each stuck to a hole edge and growing outward.
         const QRectF above = g.rect(x, kHoleMargY - h, w, h);
-        p.fillRect(above, color);
-        p.fillRect(g.rect(x, holeBottom, w, h), color);
+        p.fillRect(above, tickColor);
+        p.fillRect(g.rect(x, holeBottom, w, h), tickColor);
 
         if (m.label.isEmpty())
             continue;
+
+        // Per-label font: strong = full size + regular weight; normal = slightly
+        // smaller + light weight. App UI font, with a pixel floor for legibility.
+        const bool strong = (m.labelStyle == LabelStyle::Strong);
+        QFont labelFont = font();
+        labelFont.setPixelSize(
+            qMax(8, qRound(g.len(strong ? kLabelHeight : kLabelHeightNormal))));
+        labelFont.setWeight(strong ? QFont::Normal : QFont::Light);
+        p.setFont(labelFont);
+        const QFontMetricsF fm(labelFont);
 
         // Label centered on the marker (plus its per-marker offset), sitting
         // just above the top tick.

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -1,47 +1,118 @@
 #include "SmartMtrWidget.h"
-#include "core/ThemeManager.h"
 
-#include <QHBoxLayout>
-#include <QLabel>
+#include "SmartMtrStyle.h"
+
+#include <QPainter>
+#include <QPainterPath>
 
 namespace AetherSDR {
+
+using namespace SmartMtrUnits;
 
 SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     : QWidget(parent)
 {
-    // Transparent so the VFO flag's painted background shows through, matching
-    // the spacer it replaces in the meter row.
+    // Transparent so the VFO flag's painted background shows through the
+    // letterbox margins around the fitted design.
     setAttribute(Qt::WA_TranslucentBackground);
     // The whole meter strip is one click target (toggles the selector); let
     // clicks fall through to VfoWidget::mousePressEvent instead of being eaten
-    // by this placeholder.
+    // by this widget.
     setAttribute(Qt::WA_TransparentForMouseEvents);
-
-    auto* layout = new QHBoxLayout(this);
-    layout->setContentsMargins(0, 0, 0, 0);
-    layout->setSpacing(0);
 
     setAccessibleName(tr("SmartMTR meter"));
 
-    m_label = new QLabel(QStringLiteral("SmartMTR"));
-    m_label->setAlignment(Qt::AlignCenter);
-    m_label->setAttribute(Qt::WA_TransparentForMouseEvents);
-    // Muted, lightweight readout styling so the placeholder sits cleanly within
-    // the 22 px meter strip and reads as a meter element (like the dBm label),
-    // not bold text crowding the frequency above it.
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_label,
-        "QLabel { background: transparent; border: none; "
-        "color: #6888a0; font-size: 11px; font-weight: bold; "
-        "letter-spacing: 1px; }");
-    layout->addWidget(m_label);
+    // Expand to all available parent width; height follows from heightForWidth()
+    // so the control keeps its design aspect ratio at whatever width it gets.
+    QSizePolicy sp(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    sp.setHeightForWidth(true);
+    setSizePolicy(sp);
+}
+
+void SmartMtrWidget::paintEvent(QPaintEvent*)
+{
+    const auto g = SmartMtrGeometry::fit(rect());
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing, true);
+
+    // Back-to-front: body, recessed hole, indicator fill, then the inset shadow
+    // rim on top so the bar reads as sunken.
+    drawControl(p, g);
+    drawHole(p, g);
+    drawIndicator(p, g);
+    drawInsetShadow(p, g);
+}
+
+void SmartMtrWidget::drawControl(QPainter& p, const SmartMtrGeometry& g) const
+{
+    p.fillRect(g.rect(0.0, 0.0, kControlW, kControlH), SmartMtrColors::kControl);
+}
+
+void SmartMtrWidget::drawHole(QPainter& p, const SmartMtrGeometry& g) const
+{
+    const QRectF hole = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
+    const double r = g.len(kHoleRadius);
+    p.setPen(Qt::NoPen);
+    p.setBrush(SmartMtrColors::kBackground);
+    p.drawRoundedRect(hole, r, r);
+}
+
+void SmartMtrWidget::drawIndicator(QPainter& p, const SmartMtrGeometry& g) const
+{
+    // Left-to-right bar, full hole height, kIndicatorFraction of the hole width.
+    // Clipped to the rounded hole so the bar's corners follow the hole's radius.
+    const QRectF hole = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
+    const double r = g.len(kHoleRadius);
+    QPainterPath clip;
+    clip.addRoundedRect(hole, r, r);
+
+    const double barW = kIndicatorFraction * kHoleW;
+
+    p.save();
+    p.setClipPath(clip);
+    p.fillRect(g.rect(kHoleMargX, kHoleMargY, barW, kHoleH),
+               SmartMtrColors::kForeground);
+    // Bright marker line on top of the bar's right end, right-aligned so it sits
+    // inside the bar (its last kIndicatorLine units), never extending past it.
+    p.fillRect(g.rect(kHoleMargX + barW - kIndicatorLine, kHoleMargY,
+                      kIndicatorLine, kHoleH),
+               SmartMtrColors::kIndicator);
+    p.restore();
+}
+
+void SmartMtrWidget::drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const
+{
+    // A kShadow-wide rim, equal on all four inner sides of the hole: the rounded
+    // hole minus the same rounded rect deflated by kShadow on every side. The
+    // inner radius shrinks by kShadow too, keeping the corners concentric.
+    const QRectF outer = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);
+    const QRectF inner = g.rect(kHoleMargX + kShadow, kHoleMargY + kShadow,
+                                kHoleW - 2.0 * kShadow, kHoleH - 2.0 * kShadow);
+    const double ro = g.len(kHoleRadius);
+    const double ri = g.len(kHoleRadius - kShadow);
+
+    QPainterPath path;
+    path.addRoundedRect(outer, ro, ro);
+    path.addRoundedRect(inner, ri, ri);
+    // Odd-even fill leaves only the rim (outer minus inner) painted.
+    path.setFillRule(Qt::OddEvenFill);
+    p.fillPath(path, SmartMtrColors::kShadow);
 }
 
 QSize SmartMtrWidget::sizeHint() const
 {
-    // Placeholder height — matches the S-meter strip (22px) for now so toggling
-    // doesn't jump.  When the real meter component lands it can return a
-    // different height and the VfoWidget will resize to fit.
-    return QSize(QWidget::sizeHint().width(), 22);
+    // Baseline at the design size; the width is only a hint (the widget expands
+    // to the parent), and the height is recomputed from the actual width via
+    // heightForWidth().
+    return QSize(qRound(kControlW), qRound(kControlH));
+}
+
+int SmartMtrWidget::heightForWidth(int width) const
+{
+    // Preserve the design aspect ratio so a full-width control is fully visible
+    // (no vertical clipping) under the uniform UNITS->pixel scale.
+    return qRound(width * (kControlH / kControlW));
 }
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -1,0 +1,47 @@
+#include "SmartMtrWidget.h"
+#include "core/ThemeManager.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+
+namespace AetherSDR {
+
+SmartMtrWidget::SmartMtrWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    // Transparent so the VFO flag's painted background shows through, matching
+    // the spacer it replaces in the meter row.
+    setAttribute(Qt::WA_TranslucentBackground);
+    // The whole meter strip is one click target (toggles the selector); let
+    // clicks fall through to VfoWidget::mousePressEvent instead of being eaten
+    // by this placeholder.
+    setAttribute(Qt::WA_TransparentForMouseEvents);
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    setAccessibleName(tr("SmartMTR meter"));
+
+    m_label = new QLabel(QStringLiteral("SmartMTR"));
+    m_label->setAlignment(Qt::AlignCenter);
+    m_label->setAttribute(Qt::WA_TransparentForMouseEvents);
+    // Muted, lightweight readout styling so the placeholder sits cleanly within
+    // the 22 px meter strip and reads as a meter element (like the dBm label),
+    // not bold text crowding the frequency above it.
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_label,
+        "QLabel { background: transparent; border: none; "
+        "color: #6888a0; font-size: 11px; font-weight: bold; "
+        "letter-spacing: 1px; }");
+    layout->addWidget(m_label);
+}
+
+QSize SmartMtrWidget::sizeHint() const
+{
+    // Placeholder height — matches the S-meter strip (22px) for now so toggling
+    // doesn't jump.  When the real meter component lands it can return a
+    // different height and the VfoWidget will resize to fit.
+    return QSize(QWidget::sizeHint().width(), 22);
+}
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -161,18 +161,60 @@ void SmartMtrWidget::paintEvent(QPaintEvent*)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    // Back-to-front: body, recessed hole, indicator fill, the inset shadow rim
-    // on top so the bar reads as sunken, then the scale markers/labels (drawn on
-    // the body above and below the hole).
-    drawControl(p, g);
-    drawHole(p, g);
+    // Back-to-front: body + recessed hole (cached), indicator fill, the inset
+    // shadow rim + scale markers/labels on top (cached) so the bar reads as
+    // sunken. Only the indicator bar and the extremes markers move frame-to-
+    // frame; the rest is static for a given size/kind/DPR, so it's blitted from
+    // two pixmaps and rebuilt only when that key changes (see
+    // rebuildStaticLayers) — keeping the hot repaint cheap over the GPU panadapter.
+    const qreal dpr = devicePixelRatioF();
+    if (!m_cacheValid || m_cacheSize != size() || m_cacheKind != m_input.kind
+        || m_cacheDpr != dpr)
+        rebuildStaticLayers(g);
+
+    p.drawPixmap(0, 0, m_belowBar);
     drawIndicator(p, g);
-    drawInsetShadow(p, g);
-    drawMarkers(p, g);
+    p.drawPixmap(0, 0, m_aboveBar);
     drawExtremes(p, g);
 
     // Let the parent's value-label overlay repaint in lockstep with the markers.
     emit repainted();
+}
+
+void SmartMtrWidget::rebuildStaticLayers(const SmartMtrGeometry& g)
+{
+    const qreal dpr = devicePixelRatioF();
+    const QSize logical = size();
+    if (logical.isEmpty())
+        return; // nothing to fit yet; stay invalid and rebuild once sized
+
+    // Backing stores at device resolution so the cached layers stay crisp on
+    // HiDPI; the geometry stays in logical units (g already maps through rect()).
+    auto make = [&](QPixmap& pm) {
+        pm = QPixmap(logical * dpr);
+        pm.setDevicePixelRatio(dpr);
+        pm.fill(Qt::transparent);
+    };
+    make(m_belowBar);
+    make(m_aboveBar);
+
+    {
+        QPainter bp(&m_belowBar);
+        bp.setRenderHint(QPainter::Antialiasing, true);
+        drawControl(bp, g);
+        drawHole(bp, g);
+    }
+    {
+        QPainter ap(&m_aboveBar);
+        ap.setRenderHint(QPainter::Antialiasing, true);
+        drawInsetShadow(ap, g);
+        drawMarkers(ap, g);
+    }
+
+    m_cacheSize = logical;
+    m_cacheDpr = dpr;
+    m_cacheKind = m_input.kind;
+    m_cacheValid = true;
 }
 
 void SmartMtrWidget::drawControl(QPainter& p, const SmartMtrGeometry& g) const
@@ -268,6 +310,21 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
 
     const double holeBottom = kHoleMargY + kHoleH;
 
+    // Labels come in two fixed styles (strong = full size + regular weight,
+    // normal = slightly smaller + light); build each font and its metrics once
+    // rather than per labeled tick. App UI font, with a pixel floor for legibility.
+    auto makeLabelFont = [&](bool strong) {
+        QFont f = font();
+        f.setPixelSize(
+            qMax(8, qRound(g.len(strong ? kLabelHeight : kLabelHeightNormal))));
+        f.setWeight(strong ? QFont::Normal : QFont::Light);
+        return f;
+    };
+    const QFont strongFont = makeLabelFont(true);
+    const QFont normalFont = makeLabelFont(false);
+    const QFontMetricsF strongFm(strongFont);
+    const QFontMetricsF normalFm(normalFont);
+
     for (const ScaleMarker& m : cfg.markers) {
         // Only ticks inside the scale band are rendered.
         if (m.position < kScaleMin || m.position > kScaleMax)
@@ -291,15 +348,11 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
         if (m.label.isEmpty())
             continue;
 
-        // Per-label font: strong = full size + regular weight; normal = slightly
-        // smaller + light weight. App UI font, with a pixel floor for legibility.
+        // Pick the prebuilt font/metrics for this label's style.
         const bool strong = (m.labelStyle == LabelStyle::Strong);
-        QFont labelFont = font();
-        labelFont.setPixelSize(
-            qMax(8, qRound(g.len(strong ? kLabelHeight : kLabelHeightNormal))));
-        labelFont.setWeight(strong ? QFont::Normal : QFont::Light);
+        const QFont& labelFont = strong ? strongFont : normalFont;
+        const QFontMetricsF& fm = strong ? strongFm : normalFm;
         p.setFont(labelFont);
-        const QFontMetricsF fm(labelFont);
 
         // Label centered on the marker (plus its per-marker offset), sitting
         // just above the top tick.
@@ -389,8 +442,13 @@ QString SmartMtrWidget::extremeSUnit(double raw) const
     // S0 = -127). Above S9, report the overshoot as "+NdB".
     if (m_kind != MeterKind::Signal)
         return QString();
-    if (raw > -73.0)
-        return QStringLiteral("+%1dB").arg(qRound(raw + 73.0));
+    // Above S9, report the overshoot as "+NdB" — but only once it rounds to at
+    // least +1: a value just past -73 dBm rounds to "+0dB", which should read
+    // "s9", not a meaningless zero overshoot. Sub-1 dB overshoots fall through to
+    // the S-unit branch below, which yields s9 near -73.
+    const int over = qRound(raw + 73.0);
+    if (over >= 1)
+        return QStringLiteral("+%1dB").arg(over);
     // floor, not round: report the S-unit actually reached (e.g. -86 dBm is just
     // shy of S7 at -85, so it reads s6, not s7).
     const int s = std::clamp(int(std::floor((raw + 127.0) / 6.0)), 0, 9);

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -7,6 +7,9 @@
 #include <QLinearGradient>
 #include <QPainter>
 #include <QPainterPath>
+#include <QPolygonF>
+
+#include <algorithm>
 
 namespace AetherSDR {
 
@@ -66,31 +69,48 @@ SmartMtrWidget::SmartMtrWidget(QWidget* parent)
     m_animTimer.setTimerType(Qt::PreciseTimer);
     m_animTimer.setInterval(kMeterSmootherIntervalMs); // 8 ms ~= 120 Hz
     connect(&m_animTimer, &QTimer::timeout, this, &SmartMtrWidget::advance);
+
+    // Free-running monotonic clock for the extremes window (sample timestamps and
+    // slew dt). Kept separate from m_clock, which the smoother restarts each tick.
+    m_extremesClock.start();
 }
 
 void SmartMtrWidget::setMeterInput(const MeterInput& input)
 {
+    const bool kindChanged = (input.kind != m_kind);
     m_input = input;
+    m_kind = input.kind;
 
-    // Target the smoother at the mapped position, normalised to the scale band
-    // so the ballistics are scale-independent. drawIndicator denormalises.
+    // RX<->TX is a scale discontinuity (signal dBm vs mic dBFS); the extremes
+    // window must not mix domains.
+    if (kindChanged)
+        m_extremes.reset();
+
+    // Feed the raw sample into the extremes window (both kinds; mic uses it for
+    // the AVG bar + PEAK marker). Skip on park (no value) or when disabled.
+    if (m_extremesEnabled && input.hasValue)
+        m_extremes.record(input.value, m_extremesClock.elapsed());
+
+    // Bar target. For mic with extremes on, the bar tracks the windowed AVERAGE
+    // (PEAK shown by the marker); otherwise it tracks the instantaneous value.
+    const double posUnits =
+        (m_extremesEnabled && input.hasValue && input.kind == MeterKind::MicLevel)
+            ? mapRawToUnits(m_extremes.avgRaw())
+            : indicatorPosition(input);
+
+    // Normalise to the scale band so the ballistics are scale-independent.
     const double span = kScaleMax - kScaleMin;
     const float targetFrac =
-        span > 0.0 ? float((indicatorPosition(input) - kScaleMin) / span) : 0.0f;
-
-    if (input.kind != m_kind) {
-        // RX<->TX switches the meter to a different scale (signal dBm vs mic
-        // dBFS); snap rather than glide the bar across that discontinuity.
-        m_kind = input.kind;
-        m_smooth.setTarget(targetFrac);
-        m_smooth.snapToTarget();
-        m_animTimer.stop();
-        update();
-        return;
-    }
+        span > 0.0 ? float((posUnits - kScaleMin) / span) : 0.0f;
 
     m_smooth.setTarget(targetFrac);
-    if (m_smooth.needsAnimation() && !m_animTimer.isActive()) {
+    if (kindChanged)
+        m_smooth.snapToTarget(); // snap across the discontinuity, don't glide
+
+    // Keep the timer running while EITHER the bar or the extremes markers still
+    // need to move (a peak can expire and slide a marker after the bar settles).
+    if ((m_smooth.needsAnimation() || (m_extremesEnabled && m_extremes.hasData()))
+        && !m_animTimer.isActive()) {
         m_clock.restart();
         m_animTimer.start();
     }
@@ -99,7 +119,17 @@ void SmartMtrWidget::setMeterInput(const MeterInput& input)
 
 void SmartMtrWidget::advance()
 {
-    const bool settled = !m_smooth.tick(m_clock.restart());
+    const qint64 dt = m_clock.restart();
+    bool moving = m_smooth.tick(dt);
+
+    if (m_extremesEnabled) {
+        const bool extMoving = m_extremes.tick(
+            m_extremesClock.elapsed(), dt, needlePosUnits(),
+            [this](double raw) { return mapRawToUnits(raw); });
+        moving = moving || extMoving;
+    }
+
+    const bool settled = !moving;
     if (settled)
         m_animTimer.stop();
     if (settled || m_smooth.shouldRepaint())
@@ -121,6 +151,10 @@ void SmartMtrWidget::paintEvent(QPaintEvent*)
     drawIndicator(p, g);
     drawInsetShadow(p, g);
     drawMarkers(p, g);
+    drawExtremes(p, g);
+
+    // Let the parent's value-label overlay repaint in lockstep with the markers.
+    emit repainted();
 }
 
 void SmartMtrWidget::drawControl(QPainter& p, const SmartMtrGeometry& g) const
@@ -259,6 +293,169 @@ void SmartMtrWidget::drawMarkers(QPainter& p, const SmartMtrGeometry& g) const
         p.setPen(color);
         p.drawText(box, Qt::AlignHCenter | Qt::AlignBottom, m.label);
     }
+}
+
+void SmartMtrWidget::setExtremesOptions(bool show, ExtremesSpeed speed,
+                                        MeterValues values)
+{
+    m_extremesEnabled = show;
+    m_showValues = values;
+
+    MeterExtremes::Tuning t;
+    switch (speed) {
+    case ExtremesSpeed::Slow:
+        t.windowSeconds = SmartMtrExtremes::kWindowSlowSec;
+        break;
+    case ExtremesSpeed::Fast:
+        t.windowSeconds = SmartMtrExtremes::kWindowFastSec;
+        break;
+    case ExtremesSpeed::Medium:
+        t.windowSeconds = SmartMtrExtremes::kWindowMediumSec;
+        break;
+    }
+    t.slewUnitsPerSec = SmartMtrExtremes::kSlewUnitsPerSec;
+    m_extremes.setTuning(t);
+
+    if (!show)
+        m_extremes.reset();
+    update();
+}
+
+double SmartMtrWidget::mapRawToUnits(double raw) const
+{
+    const double pos = meterConfig(m_kind).valueToPosition(raw, m_input.min, m_input.max);
+    return std::clamp(pos, kScaleMin, kScaleMax);
+}
+
+double SmartMtrWidget::needlePosUnits() const
+{
+    return kScaleMin + double(m_smooth.value()) * (kScaleMax - kScaleMin);
+}
+
+bool SmartMtrWidget::extremesActive() const
+{
+    return m_extremesEnabled && m_extremes.hasData();
+}
+
+double SmartMtrWidget::signalFade() const
+{
+    // Mic (dBFS) has no dBm floor → always full. Signal: fade out near the floor.
+    if (m_kind == MeterKind::MicLevel)
+        return 1.0;
+    const double cur = m_input.hasValue ? m_input.value : SmartMtrExtremes::kSignalFadeLoDbm;
+    return std::clamp(
+        (cur - SmartMtrExtremes::kSignalFadeLoDbm)
+            / (SmartMtrExtremes::kSignalFadeHiDbm - SmartMtrExtremes::kSignalFadeLoDbm),
+        0.0, 1.0);
+}
+
+double SmartMtrWidget::extremesOpacity() const
+{
+    // Mic: the lone PEAK marker has no trough to compare against and the dBFS
+    // scale has no dBm floor, so it shows at full opacity.
+    if (m_kind == MeterKind::MicLevel)
+        return 1.0;
+
+    // Signal: proximity fade (min/max too close) x signal fade (near-floor).
+    const double spread = m_extremes.maxRaw() - m_extremes.minRaw();
+    const double prox = std::clamp(
+        (spread - SmartMtrExtremes::kFadeLoDb)
+            / (SmartMtrExtremes::kFadeHiDb - SmartMtrExtremes::kFadeLoDb),
+        0.0, 1.0);
+    return prox * signalFade();
+}
+
+QString SmartMtrWidget::extremeSUnit(double raw) const
+{
+    // S-units only make sense for the RX signal scale (S9 = -73 dBm, 6 dB each,
+    // S0 = -127). Above S9, report the overshoot as "+NdB".
+    if (m_kind != MeterKind::Signal)
+        return QString();
+    if (raw > -73.0)
+        return QStringLiteral("+%1dB").arg(qRound(raw + 73.0));
+    // floor, not round: report the S-unit actually reached (e.g. -86 dBm is just
+    // shy of S7 at -85, so it reads s6, not s7).
+    const int s = std::clamp(int(std::floor((raw + 127.0) / 6.0)), 0, 9);
+    return QStringLiteral("s%1").arg(s);
+}
+
+QString SmartMtrWidget::extremeDbm(double raw) const
+{
+    const int v = qRound(raw);
+    return m_kind == MeterKind::MicLevel ? QStringLiteral("%1dB").arg(v)
+                                         : QStringLiteral("%1dBm").arg(v);
+}
+
+void SmartMtrWidget::drawExtremes(QPainter& p, const SmartMtrGeometry& g) const
+{
+    if (!extremesActive())
+        return;
+    const double opacity = extremesOpacity();
+    if (opacity < 0.02)
+        return;
+
+    QColor c = SmartMtrColors::kExtreme;
+    c.setAlphaF(c.alphaF() * opacity);
+
+    p.save();
+    p.setPen(Qt::NoPen);
+    p.setBrush(c);
+
+    // Summit (tip) at the top, stuck to the hole's top edge; body hangs down
+    // INSIDE the hole. The tip marks the exact position on the scale.
+    auto drawTri = [&](double posUnits) {
+        const double x = kHoleMargX + posUnits;             // hole-local unit X
+        const double apexY = kHoleMargY;                    // summit on hole top edge
+        const double baseY = kHoleMargY + SmartMtrExtremes::kExtremeTriH; // base inside hole
+        const double halfW = SmartMtrExtremes::kExtremeTriW / 2.0;
+        QPolygonF tri;
+        tri << g.point(x, apexY) << g.point(x - halfW, baseY)
+            << g.point(x + halfW, baseY);
+        p.drawPolygon(tri);
+    };
+
+    // MAX (peak) for both kinds; MIN (trough) for signal only.
+    drawTri(m_extremes.maxPosUnits());
+    if (m_kind == MeterKind::Signal)
+        drawTri(m_extremes.minPosUnits());
+
+    p.restore();
+}
+
+QVector<SmartMtrWidget::ExtremeMarker> SmartMtrWidget::extremeLabels() const
+{
+    QVector<ExtremeMarker> out;
+
+    // Two lines for signal (S-unit over dBm); a single top line for mic (no
+    // S-unit), so the value isn't left floating on the lower line.
+    auto marker = [&](double raw, double pos, double opacity, bool isMax) {
+        const QString s = extremeSUnit(raw);
+        const QString d = extremeDbm(raw);
+        return s.isEmpty() ? ExtremeMarker{ pos, d, QString(), opacity, isMax }
+                           : ExtremeMarker{ pos, s, d, opacity, isMax };
+    };
+
+    if (m_showValues == MeterValues::Signal) {
+        // Current signal value at the live needle position, rendered like the MAX
+        // marker (line + label to its right). Always fully visible when selected —
+        // the fade-out on small min/max spread applies only to the Extremes mode.
+        if (m_input.hasValue)
+            out.push_back(marker(m_input.value, needlePosUnits(), 1.0, true));
+        return out;
+    }
+
+    if (m_showValues == MeterValues::Extremes && extremesActive()) {
+        const double opacity = extremesOpacity();
+        if (opacity < 0.02)
+            return out;
+        // MAX (peak) — both kinds.
+        out.push_back(marker(m_extremes.maxRaw(), m_extremes.maxPosUnits(), opacity, true));
+        // MIN (trough) — signal only.
+        if (m_kind == MeterKind::Signal)
+            out.push_back(
+                marker(m_extremes.minRaw(), m_extremes.minPosUnits(), opacity, false));
+    }
+    return out;
 }
 
 QSize SmartMtrWidget::sizeHint() const

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -120,19 +120,37 @@ void SmartMtrWidget::setMeterInput(const MeterInput& input)
 void SmartMtrWidget::advance()
 {
     const qint64 dt = m_clock.restart();
-    bool moving = m_smooth.tick(dt);
+    const bool barMoving = m_smooth.tick(dt);
+    bool moving = barMoving;
 
+    // A returning marker must repaint at a smooth cadence even when the bar's
+    // lean gate throttles to 12 Hz (the bar is settled during the glide, so its
+    // gate would step the markers). Gate the marker repaint on its own clock at
+    // kExtremesRepaintHz, bypassing the bar's lean gate only while a marker moves.
+    bool extremesRepaintDue = false;
     if (m_extremesEnabled) {
+        const qint64 now = m_extremesClock.elapsed();
         const bool extMoving = m_extremes.tick(
-            m_extremesClock.elapsed(), dt, needlePosUnits(),
+            now, dt, needlePosUnits(),
             [this](double raw) { return mapRawToUnits(raw); });
         moving = moving || extMoving;
+        if (extMoving) {
+            constexpr qint64 kGateMs = 1000 / SmartMtrExtremes::kExtremesRepaintHz;
+            if (m_lastExtremesRepaintMs < 0
+                || now - m_lastExtremesRepaintMs >= kGateMs) {
+                m_lastExtremesRepaintMs = now;
+                extremesRepaintDue = true;
+            }
+        }
     }
 
     const bool settled = !moving;
     if (settled)
         m_animTimer.stop();
-    if (settled || m_smooth.shouldRepaint())
+    // Repaint on: the settled (final) frame; a gated marker step; or the bar
+    // moving (through its lean gate). Gate the bar repaint on barMoving so the
+    // timer staying alive through a marker hold (nothing moving) doesn't repaint.
+    if (settled || extremesRepaintDue || (barMoving && m_smooth.shouldRepaint()))
         update();
 }
 

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -135,6 +135,12 @@ private:
     QElapsedTimer m_extremesClock;
     bool m_extremesEnabled = false;
     MeterValues m_showValues = MeterValues::None;
+
+    // Repaint cadence for a returning marker, independent of the bar's lean
+    // repaint gate (which throttles to 12 Hz and would step the slow glide).
+    // Timestamp (on m_extremesClock) of the last marker-driven repaint; -1 until
+    // the first. See SmartMtrExtremes::kExtremesRepaintHz.
+    qint64 m_lastExtremesRepaintMs = -1;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SmartMtrConfig.h"
 #include "SmartMtrGeometry.h"
 
 #include <QWidget>
@@ -25,6 +26,10 @@ class SmartMtrWidget : public QWidget {
 public:
     explicit SmartMtrWidget(QWidget* parent = nullptr);
 
+    // Push what to display. The parent owns the data (kind + value + range);
+    // the widget just renders it. Triggers a repaint.
+    void setMeterInput(const MeterInput& input);
+
     // The control fills the full available parent width and keeps its design
     // aspect ratio (kControlW:kControlH) by deriving its height from that width.
     // The VfoWidget meter area is a size-to-current-page stack, so it adopts
@@ -44,6 +49,9 @@ private:
     void drawHole(QPainter& p, const SmartMtrGeometry& g) const;
     void drawIndicator(QPainter& p, const SmartMtrGeometry& g) const;
     void drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const;
+    void drawMarkers(QPainter& p, const SmartMtrGeometry& g) const;
+
+    MeterInput m_input; // what to display; default parks at the signal scale min
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include "MeterExtremes.h"
 #include "MeterSmoother.h"
 #include "SmartMtrConfig.h"
 #include "SmartMtrGeometry.h"
 
 #include <QElapsedTimer>
+#include <QString>
 #include <QTimer>
+#include <QVector>
 #include <QWidget>
 
 class QPainter;
@@ -33,6 +36,36 @@ public:
     // the widget just renders it. Triggers a repaint.
     void setMeterInput(const MeterInput& input);
 
+    // Extremes (min/max peak-hold markers) options. Widget-local mirrors of the
+    // DisplaySettings enums so this widget stays free of the settings/AppSettings
+    // layer (the parent translates). "speed" sets the sliding-window length;
+    // "values" decides whether the numeric value labels are exposed (drawn by the
+    // parent's overlay).
+    enum class ExtremesSpeed { Slow, Medium, Fast };
+    enum class MeterValues { None, Signal, Extremes };
+    void setExtremesOptions(bool show, ExtremesSpeed speed, MeterValues values);
+
+    // One min/max marker's data for the parent's value-label overlay. position is
+    // a hole-local UNIT center (SmartMtrUnits::kScaleMin..kScaleMax); the parent
+    // maps it through the live geometry. Two text lines: primary = S-unit (e.g.
+    // "s6"), secondary = dBm (e.g. "-91dBm"). Empty unless extremes + value labels
+    // are active and there is data.
+    struct ExtremeMarker {
+        double position;   // hole-local UNITS
+        QString primary;   // top line — S-unit ("s6", "+10dB"); empty for mic
+        QString secondary; // bottom line — dBm ("-91dBm") / dB (mic)
+        double opacity;    // 0..1
+        bool isMax;        // true = peak (right of line), false = trough (left)
+    };
+    QVector<ExtremeMarker> extremeLabels() const;
+
+Q_SIGNALS:
+    // Emitted at the end of each paint so a companion overlay (the extremes value
+    // labels, drawn by the parent) can repaint in lockstep with the markers as
+    // they animate. The widget itself stays unaware of any overlay.
+    void repainted();
+
+public:
     // The control fills the full available parent width and keeps its design
     // aspect ratio (kControlW:kControlH) by deriving its height from that width.
     // The VfoWidget meter area is a size-to-current-page stack, so it adopts
@@ -53,10 +86,35 @@ private:
     void drawIndicator(QPainter& p, const SmartMtrGeometry& g) const;
     void drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const;
     void drawMarkers(QPainter& p, const SmartMtrGeometry& g) const;
+    void drawExtremes(QPainter& p, const SmartMtrGeometry& g) const;
 
-    // One animation tick: advance the smoother by the elapsed wall-clock, stop
-    // the timer once settled, and repaint through the lean-mode gate.
+    // One animation tick: advance the smoother (and the extremes) by the elapsed
+    // wall-clock, stop the timer once both settle, and repaint through the
+    // lean-mode gate.
     void advance();
+
+    // Map a raw value (dBm/dBFS) to a clamped hole-local UNIT position, using the
+    // current kind's mapping. Mirrors indicatorPosition() for arbitrary values.
+    double mapRawToUnits(double raw) const;
+
+    // Live bar position in hole-local UNITS (denormalised smoother value).
+    double needlePosUnits() const;
+
+    // Extremes are active (enabled, have data) for the current kind.
+    bool extremesActive() const;
+
+    // Shared marker opacity from the fade rules (signal: proximity x signal-fade;
+    // mic: always 1). 0 when nothing should draw.
+    double extremesOpacity() const;
+
+    // Signal-fade component only (near-floor signals fade out; mic: always 1).
+    // Used for the current-signal value label, which has no min/max spread.
+    double signalFade() const;
+
+    // Value-label text per kind: S-unit (signal: "s6" / "+10dB"; mic: empty) and
+    // the dB(m) line.
+    QString extremeSUnit(double raw) const;
+    QString extremeDbm(double raw) const;
 
     MeterInput m_input; // what to display; default parks at the signal scale min
 
@@ -68,6 +126,15 @@ private:
     QTimer m_animTimer;
     QElapsedTimer m_clock;
     MeterKind m_kind = MeterKind::Signal; // last kind, to snap across scale changes
+
+    // Extremes (min/max peak-hold markers): a sliding-window envelope tracker that
+    // glides at a constant linear slew (distinct from the bar's exponential
+    // ballistic). Ticked alongside the smoother in advance(). Free-running clock
+    // is separate from m_clock so the smoother's dt accounting is undisturbed.
+    MeterExtremes m_extremes;
+    QElapsedTimer m_extremesClock;
+    bool m_extremesEnabled = false;
+    MeterValues m_showValues = MeterValues::None;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -1,27 +1,49 @@
 #pragma once
 
+#include "SmartMtrGeometry.h"
+
 #include <QWidget>
 
-class QLabel;
+class QPainter;
 
 namespace AetherSDR {
 
-// Placeholder alternative meter view shown in the VFO flag in place of the
-// standard S-meter when the operator selects "SmartMTR" from the meter menu.
-// No signal-processing logic yet — it simply displays the text "SmartMTR".
+// Alternative meter view shown in the VFO flag in place of the standard
+// S-meter when the operator selects "SmartMTR" from the meter menu.
+//
+// This is the first step of a multi-step build. For now it paints only the
+// static control body, the recessed "hole", and a single indicator bar pinned
+// at SmartMtrUnits::kIndicatorFraction — no signal processing yet.
+//
+// Organization: design tokens (colors + UNIT proportions) live in
+// SmartMtrStyle.h; the UNITS->pixel mapping lives in SmartMtrGeometry.h; this
+// class only orchestrates drawing. Each visual element is one small draw method
+// taking the geometry, so future elements slot in as new methods + one call in
+// paintEvent, in z-order.
 class SmartMtrWidget : public QWidget {
     Q_OBJECT
 public:
     explicit SmartMtrWidget(QWidget* parent = nullptr);
 
+    // The control fills the full available parent width and keeps its design
+    // aspect ratio (kControlW:kControlH) by deriving its height from that width.
     // The VfoWidget meter area is a size-to-current-page stack, so it adopts
-    // whatever height this returns — S-Meter and SmartMTR can therefore differ
-    // in height and the flag resizes when switching.  The real meter component
-    // will set its own preferred height here.
+    // whatever these report — S-Meter and SmartMTR can therefore differ in
+    // height and the flag resizes when switching.
     QSize sizeHint() const override;
+    bool hasHeightForWidth() const override { return true; }
+    int heightForWidth(int width) const override;
+
+protected:
+    void paintEvent(QPaintEvent*) override;
 
 private:
-    QLabel* m_label{nullptr};
+    // One element per method; all draw in UNITS via SmartMtrGeometry. Called
+    // from paintEvent in back-to-front order.
+    void drawControl(QPainter& p, const SmartMtrGeometry& g) const;
+    void drawHole(QPainter& p, const SmartMtrGeometry& g) const;
+    void drawIndicator(QPainter& p, const SmartMtrGeometry& g) const;
+    void drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -6,6 +6,7 @@
 #include "SmartMtrGeometry.h"
 
 #include <QElapsedTimer>
+#include <QPixmap>
 #include <QString>
 #include <QTimer>
 #include <QVector>
@@ -88,6 +89,14 @@ private:
     void drawMarkers(QPainter& p, const SmartMtrGeometry& g) const;
     void drawExtremes(QPainter& p, const SmartMtrGeometry& g) const;
 
+    // Render the static layers (everything except the moving bar and the
+    // extremes markers) into m_belowBar / m_aboveBar at the current size, kind
+    // and device-pixel ratio. paintEvent rebuilds these only when one of those
+    // changes, then blits them each frame — so the per-frame paint during
+    // animation skips the gradient fills (inset shadow) and per-tick font work
+    // (markers) entirely.
+    void rebuildStaticLayers(const SmartMtrGeometry& g);
+
     // One animation tick: advance the smoother (and the extremes) by the elapsed
     // wall-clock, stop the timer once both settle, and repaint through the
     // lean-mode gate.
@@ -141,6 +150,18 @@ private:
     // Timestamp (on m_extremesClock) of the last marker-driven repaint; -1 until
     // the first. See SmartMtrExtremes::kExtremesRepaintHz.
     qint64 m_lastExtremesRepaintMs = -1;
+
+    // Cached static layers, split around the moving indicator bar (the inset
+    // shadow must overlay the bar, so it can't share one pixmap with the body
+    // below it): m_belowBar = control body + recessed hole; m_aboveBar = inset
+    // shadow + scale markers/labels. Rebuilt only when the cache key below
+    // changes; blitted every frame. See rebuildStaticLayers().
+    QPixmap m_belowBar;
+    QPixmap m_aboveBar;
+    QSize m_cacheSize;                       // logical widget size of the cache
+    qreal m_cacheDpr = 0.0;                  // device-pixel ratio of the cache
+    MeterKind m_cacheKind = MeterKind::Signal; // kind the markers were built for
+    bool m_cacheValid = false;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "MeterSmoother.h"
 #include "SmartMtrConfig.h"
 #include "SmartMtrGeometry.h"
 
+#include <QElapsedTimer>
+#include <QTimer>
 #include <QWidget>
 
 class QPainter;
@@ -51,7 +54,20 @@ private:
     void drawInsetShadow(QPainter& p, const SmartMtrGeometry& g) const;
     void drawMarkers(QPainter& p, const SmartMtrGeometry& g) const;
 
+    // One animation tick: advance the smoother by the elapsed wall-clock, stop
+    // the timer once settled, and repaint through the lean-mode gate.
+    void advance();
+
     MeterInput m_input; // what to display; default parks at the signal scale min
+
+    // Ballistics: the indicator chases the mapped target position with the
+    // SmartMTR analog feel (fast attack, slow lazy decay). The smoother runs on
+    // the normalised scale fraction; drawIndicator denormalises it. Isolated to
+    // this widget — the standard S-meters keep their own ballistics.
+    MeterSmoother m_smooth;
+    QTimer m_animTimer;
+    QElapsedTimer m_clock;
+    MeterKind m_kind = MeterKind::Signal; // last kind, to snap across scale changes
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -19,9 +19,9 @@ namespace AetherSDR {
 // Alternative meter view shown in the VFO flag in place of the standard
 // S-meter when the operator selects "SmartMTR" from the meter menu.
 //
-// This is the first step of a multi-step build. For now it paints only the
-// static control body, the recessed "hole", and a single indicator bar pinned
-// at SmartMtrUnits::kIndicatorFraction — no signal processing yet.
+// It renders the meter end-to-end: the static control body and recessed "hole"
+// (cached as pixmaps), an indicator bar driven by analog-needle ballistics, and
+// optional peak/trough extremes markers with value labels.
 //
 // Organization: design tokens (colors + UNIT proportions) live in
 // SmartMtrStyle.h; the UNITS->pixel mapping lives in SmartMtrGeometry.h; this

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QWidget>
+
+class QLabel;
+
+namespace AetherSDR {
+
+// Placeholder alternative meter view shown in the VFO flag in place of the
+// standard S-meter when the operator selects "SmartMTR" from the meter menu.
+// No signal-processing logic yet — it simply displays the text "SmartMTR".
+class SmartMtrWidget : public QWidget {
+    Q_OBJECT
+public:
+    explicit SmartMtrWidget(QWidget* parent = nullptr);
+
+    // The VfoWidget meter area is a size-to-current-page stack, so it adopts
+    // whatever height this returns — S-Meter and SmartMTR can therefore differ
+    // in height and the flag resizes when switching.  The real meter component
+    // will set its own preferred height here.
+    QSize sizeHint() const override;
+
+private:
+    QLabel* m_label{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -102,6 +102,11 @@ private:
     // lean-mode gate.
     void advance();
 
+    // Apply the bar ballistics for a meter kind: the analog d'Arsonval sag for
+    // signal, a snappy PPM attack/decay for mic. Called at construction and on
+    // every RX<->TX kind switch (the smoother set differs per domain).
+    void applyBallistics(MeterKind kind);
+
     // Map a raw value (dBm/dBFS) to a clamped hole-local UNIT position, using the
     // current kind's mapping. Mirrors indicatorPosition() for arbitrary values.
     double mapRawToUnits(double raw) const;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -947,6 +947,10 @@ VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
 
     auto* w = new VfoWidget(this);
     installVfoCursorEventFilter(w);
+    // The flag's SmartMTR value labels are painted in our overlay pass; refresh
+    // the overlay whenever they change or the flag moves.
+    connect(w, &VfoWidget::smartMtrLabelsChanged, this,
+            [this]() { markOverlayDirty(); });
     m_vfoWidgets[sliceId] = w;
     w->show();
     w->raise();
@@ -7017,6 +7021,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 drawSpotMarkers(p, specRect);
             drawSwrSweep(p, specRect);
             drawSliceMarkers(p, specRect, wfRect);
+            drawSmartMtrValueLabels(p);
             drawOffScreenSlices(p, specRect);
 
             drawAutoSqlFloor(p, specRect);
@@ -7648,6 +7653,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
         drawSwrSweep(p, specRect);
         drawSliceMarkers(p, specRect, wfRect);
+        drawSmartMtrValueLabels(p);
         drawOffScreenSlices(p, specRect);
 
         drawAutoSqlFloor(p, specRect);
@@ -9182,6 +9188,17 @@ void SpectrumWidget::showSpotClusterPopup(const SpotCluster& cluster, const QPoi
     menu->popup(globalPos);
     // QMenu self-deletes on close with WA_DeleteOnClose
     menu->setAttribute(Qt::WA_DeleteOnClose);
+}
+
+void SpectrumWidget::drawSmartMtrValueLabels(QPainter& p)
+{
+    // Each flag draws its own SmartMTR value labels (if active) into our overlay
+    // painter, in our (widget) coordinates — so they land on top of the slice
+    // markers drawn just above. Drawn last = guaranteed on top of the slice.
+    for (VfoWidget* w : m_vfoWidgets) {
+        if (w)
+            w->drawSmartMtrLabels(p);
+    }
 }
 
 void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const QRect& wfRect)

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -577,6 +577,8 @@ private:
     void drawGrid(QPainter& p, const QRect& r);
     void drawSpectrum(QPainter& p, const QRect& r);
     void drawSliceMarkers(QPainter& p, const QRect& specRect, const QRect& wfRect);
+    // Draw each flag's SmartMTR extremes value labels on top of the slice markers.
+    void drawSmartMtrValueLabels(QPainter& p);
     void drawOffScreenSlices(QPainter& p, const QRect& specRect);
     void drawBandPlan(QPainter& p, const QRect& specRect);
     void drawTnfMarkers(QPainter& p, const QRect& specRect);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -323,6 +323,11 @@ VfoWidget::VfoWidget(QWidget* parent)
     applyMeterView(MeterViewController::instance().smartMtr());
     connect(&MeterViewController::instance(), &MeterViewController::changed,
             this, &VfoWidget::applyMeterView);
+    // Extremes options are also global + live: re-push to this flag's SmartMTR
+    // widget whenever any flag changes them.
+    connect(&MeterViewController::instance(), &MeterViewController::extremesChanged,
+            this, &VfoWidget::pushSmartMtrOptions);
+    pushSmartMtrOptions(); // apply the persisted options to this new flag
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
             this, [this]() {
@@ -867,6 +872,12 @@ void VfoWidget::buildUI()
 
     m_smartMtrWidget = new SmartMtrWidget;
     m_meterStack->addWidget(m_smartMtrWidget);
+    // The extremes value labels are drawn by SpectrumWidget's overlay pass (so
+    // they sit on top of the slice). Bridge the meter's repaints to a throttled
+    // overlay refresh request.
+    m_labelDirtyClock.start();
+    connect(m_smartMtrWidget, &SmartMtrWidget::repainted, this,
+            &VfoWidget::onSmartMtrRepainted);
     pushSmartMtrInput(); // seed the at-rest display
 
     root->addWidget(m_meterStack);
@@ -1021,18 +1032,22 @@ void VfoWidget::buildUI()
     // Persist + re-evaluate enable/disable rules on change.  Toggling "Show
     // extremes" off disables "Extremes speed" and, if "Show values" is set to
     // Extremes, snaps it back to None (handled in syncSmartMtrSettingsState).
+    // Route through MeterViewController so the change persists AND broadcasts to
+    // every open flag (extremesChanged() → pushSmartMtrOptions on each).
     connect(m_showExtremesChk, &QCheckBox::toggled, this, [this](bool on) {
-        DisplaySettings::setShowExtremes(on);
+        MeterViewController::instance().setShowExtremes(on);
         syncSmartMtrSettingsState();
     });
     connect(m_extremesSpeedCmb, &QComboBox::currentIndexChanged, this,
             [this](int) {
-        DisplaySettings::setExtremesSpeed(static_cast<DisplaySettings::ExtremesSpeed>(
-            m_extremesSpeedCmb->currentData().toInt()));
+        MeterViewController::instance().setExtremesSpeed(
+            static_cast<DisplaySettings::ExtremesSpeed>(
+                m_extremesSpeedCmb->currentData().toInt()));
     });
     connect(m_showValuesCmb, &QComboBox::currentIndexChanged, this, [this](int) {
-        DisplaySettings::setShowValues(static_cast<DisplaySettings::MeterValues>(
-            m_showValuesCmb->currentData().toInt()));
+        MeterViewController::instance().setShowValues(
+            static_cast<DisplaySettings::MeterValues>(
+                m_showValuesCmb->currentData().toInt()));
     });
 
     syncSmartMtrSettingsState();  // initial enable/disable per current state
@@ -2541,6 +2556,10 @@ void VfoWidget::setCollapsed(bool collapsed)
         syncFromSlice();
     }
 
+    // Re-evaluate the extremes labels strip: hidden while collapsed, restored on
+    // expand (it's a parent-child, not auto-managed by the loops above).
+    pushSmartMtrOptions();
+
     relayoutToCurrentContent();
     update();
 
@@ -2823,6 +2842,13 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
 
     move(newPos);
 
+    // The value labels (drawn by the spectrum's above-flags layer) are anchored to
+    // this flag — repaint them as it pans. Only when labels are actually shown.
+    if (m_smartMtr && !m_collapsed
+        && MeterViewController::instance().showValues()
+            != DisplaySettings::MeterValues::None)
+        emit smartMtrLabelsChanged();
+
     // Position close/lock/record/play buttons stacked vertically on the side opposite the marker
     if (m_closeSliceBtn && m_lockVfoBtn) {
         const int btnSize = 20;
@@ -3086,6 +3112,7 @@ void VfoWidget::applyMeterView(bool smartMtr)
     }
     syncMeterMenuButtons();
     syncSmartMtrSettingsState();  // options are SmartMTR-only → enable/disable
+    pushSmartMtrOptions();  // refresh extremes + label-overlay visibility for the view
     adjustSize();  // S-Meter and SmartMTR pages may differ in height → resize the flag
     update();  // repaint the painted S-meter bar (or clear it)
     // Recomposite over the GPU spectrum so the switched meter is visible while
@@ -3200,6 +3227,159 @@ void VfoWidget::pushSmartMtrInput()
     }
     in.hasValue = true;
     m_smartMtrWidget->setMeterInput(in);
+}
+
+void VfoWidget::pushSmartMtrOptions()
+{
+    if (!m_smartMtrWidget)
+        return;
+    auto& mv = MeterViewController::instance();
+    const bool show = mv.showExtremes();
+
+    SmartMtrWidget::ExtremesSpeed speed = SmartMtrWidget::ExtremesSpeed::Medium;
+    switch (mv.extremesSpeed()) {
+    case DisplaySettings::ExtremesSpeed::Slow:
+        speed = SmartMtrWidget::ExtremesSpeed::Slow;
+        break;
+    case DisplaySettings::ExtremesSpeed::Fast:
+        speed = SmartMtrWidget::ExtremesSpeed::Fast;
+        break;
+    case DisplaySettings::ExtremesSpeed::Medium:
+        break;
+    }
+
+    SmartMtrWidget::MeterValues values = SmartMtrWidget::MeterValues::None;
+    switch (mv.showValues()) {
+    case DisplaySettings::MeterValues::Signal:
+        values = SmartMtrWidget::MeterValues::Signal;
+        break;
+    case DisplaySettings::MeterValues::Extremes:
+        values = SmartMtrWidget::MeterValues::Extremes;
+        break;
+    case DisplaySettings::MeterValues::None:
+        break;
+    }
+
+    m_smartMtrWidget->setExtremesOptions(show, speed, values);
+    emit smartMtrLabelsChanged(); // refresh the spectrum-drawn value labels
+}
+
+void VfoWidget::onSmartMtrRepainted()
+{
+    // The meter repaints up to ~120 Hz while markers move; the spectrum's
+    // static-overlay redraw (which draws the value labels) is comparatively
+    // costly, so throttle the refresh requests to ~20 Hz.
+    const qint64 now = m_labelDirtyClock.elapsed();
+    if (m_lastLabelDirtyMs >= 0 && now - m_lastLabelDirtyMs < 50)
+        return;
+    m_lastLabelDirtyMs = now;
+    emit smartMtrLabelsChanged();
+}
+
+void VfoWidget::drawSmartMtrLabels(QPainter& p) const
+{
+    using namespace SmartMtrUnits;
+    if (!m_smartMtrWidget || !m_smartMtr || m_collapsed
+        || !m_smartMtrWidget->isVisible())
+        return;
+    const auto labels = m_smartMtrWidget->extremeLabels();
+    if (labels.isEmpty())
+        return;
+
+    const auto g = SmartMtrGeometry::fit(m_smartMtrWidget->rect());
+
+    QFont f = font();
+    f.setPixelSize(qMax(8, qRound(g.len(kLabelHeightNormal))));
+    f.setWeight(QFont::Light);
+    const QFontMetricsF fm(f);
+    const double lineH = fm.height();
+
+    const double gap = 2.0;                       // px between line and labels
+    const double stripTop = y() + height() + 2.0; // labels sit just below the flag
+    const double lineBottom = stripTop + 2.0 * lineH;
+    const double lineW = qMax(1.0, g.len(1.0));
+    const double kUnitDim = 0.55; // unit text + connector line dim factor
+
+    p.save();
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setFont(f);
+
+    // Draw one stacked text line; the unit (leading "s" / trailing "dB"/"dBm") is
+    // dimmed to emphasise the number. Anchored to the marker line: MAX grows to
+    // the right of x, MIN is right-aligned to the left of x.
+    auto drawLine = [&](const QString& s, double topY, double x, bool isMax,
+                        double opacity) {
+        if (s.isEmpty())
+            return;
+        QString prefix, number = s, suffix;
+        if (s.startsWith(QLatin1Char('s'))) {
+            prefix = QStringLiteral("s");
+            number = s.mid(1);
+        } else if (s.endsWith(QStringLiteral("dBm"))) {
+            suffix = QStringLiteral("dBm");
+            number = s.left(s.size() - 3);
+        } else if (s.endsWith(QStringLiteral("dB"))) {
+            suffix = QStringLiteral("dB");
+            number = s.left(s.size() - 2);
+        }
+        const double wp = fm.horizontalAdvance(prefix);
+        const double wn = fm.horizontalAdvance(number);
+        const double ws = fm.horizontalAdvance(suffix);
+        const double left = isMax ? (x + gap) : (x - gap - (wp + wn + ws));
+
+        auto seg = [&](const QString& t, double sx, double op) {
+            if (t.isEmpty())
+                return;
+            const QRectF r(sx, topY, fm.horizontalAdvance(t) + 1.0, lineH);
+            QColor black(0, 0, 0);
+            black.setAlphaF(op);
+            p.setPen(black);
+            static const int kOff[4][2] = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+            for (const auto& o : kOff)
+                p.drawText(r.translated(o[0], o[1]), Qt::AlignVCenter | Qt::AlignLeft, t);
+            QColor white = SmartMtrColors::kIndicator;
+            white.setAlphaF(white.alphaF() * op);
+            p.setPen(white);
+            p.drawText(r, Qt::AlignVCenter | Qt::AlignLeft, t);
+        };
+        const double unitOp = opacity * kUnitDim; // dim the unit
+        double cx = left;
+        seg(prefix, cx, unitOp);
+        cx += wp;
+        seg(number, cx, opacity);
+        cx += wn;
+        seg(suffix, cx, unitOp);
+    };
+
+    for (const auto& m : labels) {
+        const double xUnit = kHoleMargX + m.position;
+        const QPoint mk = m_smartMtrWidget->mapTo(
+            parentWidget(), g.point(xUnit, kHoleMargY).toPoint());
+        const double x = mk.x();
+        const double lineTop = stripTop; // just below the flag (drawn under the flags)
+
+        // Vertical marker line, dimmed to the same level as the unit text, with a
+        // dark halo so it reads over a bright background.
+        QColor halo(0, 0, 0);
+        halo.setAlphaF(0.7 * m.opacity * kUnitDim);
+        QPen haloPen(halo);
+        haloPen.setWidthF(lineW + 2.0);
+        haloPen.setCapStyle(Qt::RoundCap);
+        p.setPen(haloPen);
+        p.drawLine(QPointF(x, lineTop), QPointF(x, lineBottom));
+        QColor line = SmartMtrColors::kExtreme;
+        line.setAlphaF(line.alphaF() * m.opacity * kUnitDim);
+        QPen pen(line);
+        pen.setWidthF(lineW);
+        pen.setCapStyle(Qt::RoundCap);
+        p.setPen(pen);
+        p.drawLine(QPointF(x, lineTop), QPointF(x, lineBottom));
+
+        drawLine(m.primary, stripTop, x, m.isMax, m.opacity);
+        drawLine(m.secondary, stripTop + lineH, x, m.isMax, m.opacity);
+    }
+
+    p.restore();
 }
 
 void VfoWidget::setMicLevel(float micDbfs)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -861,7 +861,9 @@ void VfoWidget::buildUI()
     meterRow->addWidget(m_dbmLabel, 1);    // 25%
     m_meterStack->addWidget(stdMeterPage);
 
-    m_meterStack->addWidget(new SmartMtrWidget);
+    m_smartMtrWidget = new SmartMtrWidget;
+    m_meterStack->addWidget(m_smartMtrWidget);
+    pushSmartMtrInput(); // seed the at-rest display
 
     root->addWidget(m_meterStack);
 
@@ -2998,6 +3000,46 @@ void VfoWidget::setSignalLevel(float dbm)
     m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(dbm)));
     m_dbmLabel->setAccessibleName("Signal level dBm");
     updateSignalMeterTarget();
+    pushSmartMtrInput();
+}
+
+// SmartMTR feed: choose signal vs mic by TX state and push the input. The
+// canonical ranges match the per-kind configs in SmartMtrConfig.cpp.
+void VfoWidget::pushSmartMtrInput()
+{
+    if (!m_smartMtrWidget)
+        return;
+
+    MeterInput in;
+    const bool showMic = m_transmitting && m_slice && m_slice->isTxSlice();
+    if (showMic) {
+        in.kind = MeterKind::MicLevel;
+        in.value = m_micDbfs;
+        in.min = -40.0; // dBFS
+        in.max = 0.0;
+    } else {
+        in.kind = MeterKind::Signal;
+        in.value = m_signalDbm;
+        in.min = -127.0; // dBm: S0
+        in.max = -13.0;  // dBm: S9+60
+    }
+    in.hasValue = true;
+    m_smartMtrWidget->setMeterInput(in);
+}
+
+void VfoWidget::setMicLevel(float micDbfs)
+{
+    m_micDbfs = micDbfs;
+    if (m_transmitting && m_slice && m_slice->isTxSlice())
+        pushSmartMtrInput();
+}
+
+void VfoWidget::setTransmitting(bool tx)
+{
+    if (m_transmitting == tx)
+        return;
+    m_transmitting = tx;
+    pushSmartMtrInput(); // switch the SmartMTR kind (signal <-> mic)
 }
 
 void VfoWidget::setReceiveMeterReading(
@@ -3020,6 +3062,7 @@ void VfoWidget::setReceiveMeterReading(
         m_dbmLabel->setAccessibleName("Meter unavailable");
     }
     updateSignalMeterTarget();
+    pushSmartMtrInput();
     if (QAccessible::isActive()) {
         QAccessibleValueChangeEvent event(this, m_dbmLabel->text());
         QAccessible::updateAccessibility(&event);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -892,7 +892,7 @@ void VfoWidget::buildUI()
     // otherwise sit flush against the tabs).  Hidden → the meter area is
     // pixel-identical to the original; shown → tabs shift down a few px. (#SmartMTR)
     m_meterUnderlineRoom = new QWidget;
-    m_meterUnderlineRoom->setFixedHeight(8);
+    m_meterUnderlineRoom->setFixedHeight(3);
     m_meterUnderlineRoom->setAttribute(Qt::WA_TranslucentBackground);
     m_meterUnderlineRoom->setAttribute(Qt::WA_TransparentForMouseEvents);
     m_meterUnderlineRoom->hide();

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1,5 +1,7 @@
 #include "VfoWidget.h"
 #include "PhaseKnob.h"
+#include "SmartMtrWidget.h"
+#include "MeterViewController.h"
 #include "ComboStyle.h"
 #include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
@@ -244,6 +246,15 @@ static const QString kModeBtn =
 static const QString kLabelStyle =
     "QLabel { background: transparent; border: none; color: #8aa8c0; font-size: 13px; }";
 
+// Meter-view selector buttons.  Unselected look matches the DSP NR/NB/ANF
+// toggles exactly (kDspToggle base + hover); the selected/checked look matches
+// an enabled filter preset exactly (kModeBtn's blue checked rule).
+static const QString kMeterOptBtn =
+    "QPushButton { background: #1a2a3a; border: 1px solid #304050; border-radius: 2px; "
+    "color: #c8d8e8; font-size: 13px; font-weight: bold; padding: 2px 4px; }"
+    "QPushButton:checked { background: #0070c0; color: #ffffff; border: 1px solid #0090e0; }"
+    "QPushButton:hover { border: 1px solid #0090e0; }";
+
 static bool likelyTxAntennaFallbackToken(const QString& token)
 {
     const QString upper = token.toUpper();
@@ -288,6 +299,14 @@ VfoWidget::VfoWidget(QWidget* parent)
     });
 
     buildUI();
+
+    // Meter view (standard S-Meter vs SmartMTR) is a global, live-updating
+    // choice owned by MeterViewController.  Apply the current value, then track
+    // changes so a toggle on any flag updates this one too.  Restores the
+    // persisted choice for flags opened later or after an app restart.
+    applyMeterView(MeterViewController::instance().smartMtr());
+    connect(&MeterViewController::instance(), &MeterViewController::changed,
+            this, &VfoWidget::applyMeterView);
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
             this, [this]() {
@@ -400,6 +419,14 @@ void VfoWidget::mousePressEvent(QMouseEvent* ev)
     if (ev->button() == Qt::LeftButton && m_sliceBadge && m_sliceBadge->isVisible()
         && m_sliceBadge->geometry().contains(ev->pos())) {
         QTimer::singleShot(0, this, [this] { setCollapsed(true); });
+        return;
+    }
+    // Click on the meter strip → toggle the inline S-Meter / SmartMTR selector.
+    if (ev->button() == Qt::LeftButton && m_meterStack
+        && m_meterStack->geometry().contains(ev->pos())) {
+        if (m_meterMenuRow) {
+            setMeterMenuOpen(!m_meterMenuRow->isVisible());
+        }
         return;
     }
     if (m_slice)
@@ -777,15 +804,40 @@ void VfoWidget::buildUI()
     }
 #endif
 
-    // ── S-meter + dBm row (75/25 split) ────────────────────────────────────
-    // S-meter bar is painted in paintEvent; spacer reserves its space.
-    // dBm label sits to the right.
-    auto* meterRow = new QHBoxLayout;
+    // ── Meter area: stacked S-meter / SmartMTR ─────────────────────────────
+    // Page 0 (standard): S-meter bar painted in paintEvent over a transparent
+    // spacer (75%) + dBm label (25%).  Page 1: the SmartMTR component, full
+    // width.  Which page is shown is driven globally by MeterViewController;
+    // the whole strip is the click target for the meter-view menu (see
+    // mousePressEvent).
+    // TabStack sizes to the *current* page, so the S-meter and SmartMTR pages
+    // can each declare their own height and the flag adapts when toggling
+    // between them (no shared fixed height). (#SmartMTR)
+    m_meterStack = new TabStack(this);
+    m_meterStack->setAttribute(Qt::WA_TranslucentBackground);
+    m_meterStack->setAccessibleName(tr("Signal meter"));
+    m_meterStack->setAccessibleDescription(
+        tr("Click to reveal the S-Meter / SmartMTR selector"));
+    // Clickable control → hand cursor (children are mouse-transparent, so the
+    // cursor falls through to the strip).
+    m_meterStack->setCursor(Qt::PointingHandCursor);
+
+    auto* stdMeterPage = new QWidget;
+    stdMeterPage->setAttribute(Qt::WA_TranslucentBackground);
+    // The whole meter strip is one click target (toggles the selector); make its
+    // contents mouse-transparent so clicks fall through to mousePressEvent.
+    stdMeterPage->setAttribute(Qt::WA_TransparentForMouseEvents);
+    auto* meterRow = new QHBoxLayout(stdMeterPage);
+    meterRow->setContentsMargins(0, 0, 0, 0);
     meterRow->setSpacing(4);
 
+    // Original S-meter row geometry (restored): 22px spacer reserves the strip,
+    // the S-meter bar/scale/labels are painted over it in paintEvent.  Keeping
+    // this exactly as the pre-SmartMTR layout makes the S-meter pixel-identical.
     auto* sMeterSpacer = new QWidget;
     sMeterSpacer->setFixedHeight(22);
     sMeterSpacer->setAttribute(Qt::WA_TranslucentBackground);
+    sMeterSpacer->setAttribute(Qt::WA_TransparentForMouseEvents);
     sMeterSpacer->setStyleSheet("QWidget { background: transparent; }");
     meterRow->addWidget(sMeterSpacer, 3);  // 75%
 
@@ -793,9 +845,70 @@ void VfoWidget::buildUI()
     m_dbmLabel->setStyleSheet("QLabel { background: transparent; border: none; "
                                "color: #6888a0; font-size: 11px; }");
     m_dbmLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_dbmLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     meterRow->addWidget(m_dbmLabel, 1);    // 25%
+    m_meterStack->addWidget(stdMeterPage);
 
-    root->addLayout(meterRow);
+    m_meterStack->addWidget(new SmartMtrWidget);
+
+    root->addWidget(m_meterStack);
+
+    // Underline-room spacer: a thin strip between the meter and the tab bar,
+    // shown ONLY while the meter selector is open.  It gives the curved
+    // underline clean room below the indicator (the S-meter's scale labels
+    // otherwise sit flush against the tabs).  Hidden → the meter area is
+    // pixel-identical to the original; shown → tabs shift down a few px. (#SmartMTR)
+    m_meterUnderlineRoom = new QWidget;
+    m_meterUnderlineRoom->setFixedHeight(8);
+    m_meterUnderlineRoom->setAttribute(Qt::WA_TranslucentBackground);
+    m_meterUnderlineRoom->setAttribute(Qt::WA_TransparentForMouseEvents);
+    m_meterUnderlineRoom->hide();
+    root->addWidget(m_meterUnderlineRoom);
+
+    // ── Meter-view selector row (S-Meter / SmartMTR) ───────────────────────
+    // Inline panel revealed by clicking the meter strip — NOT a popup.  Added
+    // to the layout BELOW the tab bar (see further down) so it drops down under
+    // the DSP / Mode / X/RIT / DAX line like the tab menus.  The two buttons
+    // match the DSP NR/NB/ANF toggles; the selected one uses the enabled-filter
+    // (blue) checked style.  The choice routes through MeterViewController so it
+    // applies globally and persists.
+    m_meterMenuRow = new QWidget;
+    m_meterMenuRow->setAttribute(Qt::WA_TranslucentBackground);
+    auto* meterMenuLayout = new QHBoxLayout(m_meterMenuRow);
+    // Small bottom margin so the buttons aren't flush against the flag's edge.
+    meterMenuLayout->setContentsMargins(0, 0, 0, 6);
+    meterMenuLayout->setSpacing(3);
+
+    m_sMeterOptBtn = new QPushButton(tr("S-Meter"));
+    m_sMeterOptBtn->setCheckable(true);
+    m_sMeterOptBtn->setFixedHeight(26);
+    m_sMeterOptBtn->setStyleSheet(kMeterOptBtn);
+    m_sMeterOptBtn->setAccessibleName(tr("Standard S-Meter view"));
+    m_sMeterOptBtn->setCursor(Qt::PointingHandCursor);
+    meterMenuLayout->addWidget(m_sMeterOptBtn, 1);
+
+    m_smartMtrOptBtn = new QPushButton(tr("SmartMTR"));
+    m_smartMtrOptBtn->setCheckable(true);
+    m_smartMtrOptBtn->setFixedHeight(26);
+    m_smartMtrOptBtn->setStyleSheet(kMeterOptBtn);
+    m_smartMtrOptBtn->setAccessibleName(tr("SmartMTR view"));
+    m_smartMtrOptBtn->setCursor(Qt::PointingHandCursor);
+    meterMenuLayout->addWidget(m_smartMtrOptBtn, 1);
+
+    // Per spec: the menu buttons ONLY change which meter is shown — they do
+    // NOT close the menu.  The menu is opened/closed solely by clicking the
+    // meter strip itself (see mousePressEvent).
+    connect(m_sMeterOptBtn, &QPushButton::clicked, this, [this] {
+        MeterViewController::instance().setSmartMtr(false);
+        syncMeterMenuButtons();  // re-assert state if it was already selected
+    });
+    connect(m_smartMtrOptBtn, &QPushButton::clicked, this, [this] {
+        MeterViewController::instance().setSmartMtr(true);
+        syncMeterMenuButtons();
+    });
+
+    m_meterMenuRow->hide();  // hidden until the meter strip is clicked
+    // NOTE: added to the root layout below the tab bar (see after m_tabBar).
 
     // ── Tab bar ────────────────────────────────────────────────────────────
     m_tabBar = new QWidget;
@@ -834,6 +947,10 @@ void VfoWidget::buildUI()
         m_tabBtns.append(btn);
     }
     root->addWidget(m_tabBar);
+
+    // Meter-view selector drops down just below the tab bar, like the tab
+    // menus (built earlier; placed here for the below-tabs layout position).
+    root->addWidget(m_meterMenuRow);
 
     // ── Tab content (stacked) ──────────────────────────────────────────────
     m_tabStack = new TabStack(this);
@@ -2059,6 +2176,52 @@ void VfoWidget::buildTabContent()
 
 // ── Tab switching ─────────────────────────────────────────────────────────────
 
+// Close whichever tab panel (DSP/Mode/X-RIT/DAX) is currently open, resetting
+// its button to the inactive style.  No-op if none is open.  Used to keep the
+// meter selector and the tab panels mutually exclusive.
+void VfoWidget::closeActiveTab()
+{
+    if (m_activeTab < 0) {
+        return;
+    }
+    if (m_tabStack) {
+        m_tabStack->hide();
+    }
+    if (m_activeTab < m_tabBtns.size()) {
+        m_tabBtns[m_activeTab]->setStyleSheet(kTabLblNormal);
+        m_tabBtns[m_activeTab]->setChecked(false);
+    }
+    m_activeTab = -1;
+}
+
+// Open or close the S-Meter / SmartMTR selector.  Single source of truth for
+// the selector state: toggles the menu row + its underline-room spacer, keeps
+// mutual-exclusion with the tab panels, refits the flag, and recomposites over
+// the GPU spectrum.
+void VfoWidget::setMeterMenuOpen(bool open)
+{
+    if (!m_meterMenuRow) {
+        return;
+    }
+    m_meterMenuRow->setVisible(open);
+    // The underline-room spacer tracks the menu: shown only while open so the
+    // closed view stays pixel-exact. (#SmartMTR)
+    if (m_meterUnderlineRoom) {
+        m_meterUnderlineRoom->setVisible(open);
+    }
+    if (open) {
+        closeActiveTab();  // mutual exclusion with the DSP/Mode/... tabs
+    }
+    adjustSize();  // S-Meter/SmartMTR + menu-row heights → refit the flag
+    update();      // repaint the meter-strip underline
+    // The flag composites over the GPU spectrum (QRhiWidget); our update()
+    // doesn't refresh the parent's texture, so force a recomposite, same as
+    // setOpaqueMode(). (#SmartMTR)
+    if (QWidget* p = parentWidget()) {
+        p->update();
+    }
+}
+
 void VfoWidget::showTab(int index)
 {
     if (m_activeTab == index) {
@@ -2077,6 +2240,10 @@ void VfoWidget::showTab(int index)
         m_tabBtns[index]->setChecked(true);
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
+        // Mutual exclusion: opening a tab closes the meter selector.
+        if (m_meterMenuRow && m_meterMenuRow->isVisible()) {
+            setMeterMenuOpen(false);
+        }
     }
     relayoutToCurrentContent();
 }
@@ -2636,11 +2803,54 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
     p.setRenderHint(QPainter::Antialiasing, false);
 
-    // Bar rect: drawn in the S-meter row (75% left portion)
-    const int barX = 6;
-    const int barW = (width() - 12) * 3 / 4;  // 75% of widget width
-    const int barY = m_dbmLabel->y() + (m_dbmLabel->height() - 6) / 2;
-    const int barH = 6;
+    // When the meter-view selector is open, underline the meter strip in the
+    // tab-active accent (#00b4d8).  Unlike the straight tab underline, this one
+    // is a flat line whose ends hook gently upward (a shallow concave-up curve)
+    // for a distinct, finished look. (#SmartMTR)
+    if (m_meterStack && m_meterMenuRow && m_meterMenuRow->isVisible()) {
+        const QRect g = m_meterStack->geometry();
+        // Baseline below the content actually shown: the S-meter's scale labels
+        // overflow the 22px strip, so anchor below them; SmartMTR is contained,
+        // so anchor at the widget bottom.  The underline-room spacer guarantees
+        // this clears the tab row regardless of indicator height. (#SmartMTR)
+        const qreal yBase = m_smartMtr
+            ? g.bottom() + 1.0
+            : meterBarRect().y() + 20.0;
+        const qreal rise   = 2.0;              // how far the ends curve up (tiny)
+        const qreal curveW = 5.0;              // horizontal span of each hook
+        const qreal xL = g.x();
+        const qreal xR = g.x() + g.width();
+
+        QPainterPath underline;
+        underline.moveTo(xL, yBase - rise);              // raised left tip
+        underline.quadTo(xL, yBase, xL + curveW, yBase); // hook down to the flat
+        underline.lineTo(xR - curveW, yBase);            // flat middle
+        underline.quadTo(xR, yBase, xR, yBase - rise);   // hook up to raised right tip
+
+        const bool prevAA = p.testRenderHint(QPainter::Antialiasing);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        QPen underPen(QColor(0x00, 0xb4, 0xd8), 2.0);
+        underPen.setCapStyle(Qt::RoundCap);
+        p.setPen(underPen);
+        p.setBrush(Qt::NoBrush);
+        p.drawPath(underline);
+        p.setRenderHint(QPainter::Antialiasing, prevAA);
+    }
+
+    // SmartMTR view: the SmartMtrWidget page covers the meter strip, so skip
+    // the painted S-meter bar entirely.
+    if (m_smartMtr) {
+        return;
+    }
+
+    // Bar rect: drawn in the S-meter row (75% left portion).  Derived from the
+    // dBm label's position mapped into widget coords so it stays correct now
+    // that the label lives inside the stacked meter page.
+    const QRect bar = meterBarRect();
+    const int barX = bar.x();
+    const int barW = bar.width();
+    const int barY = bar.y();
+    const int barH = bar.height();
 
     // Background
     p.fillRect(barX, barY, barW, barH, QColor(0x10, 0x18, 0x20));
@@ -2712,6 +2922,59 @@ void VfoWidget::paintEvent(QPaintEvent* event)
         p.drawText(tx - 6, lblY, label.second);
     }
 
+}
+
+// ── Meter view (S-Meter / SmartMTR) ─────────────────────────────────────────────
+
+// Geometry of the painted S-meter bar, in VfoWidget coordinates.  The bar sits
+// in the left 75% of the meter strip, vertically centred on the dBm label —
+// mapped into widget coords so it tracks the label inside the stacked page.
+QRect VfoWidget::meterBarRect() const
+{
+    const int barX = 6;
+    const int barW = (width() - 12) * 3 / 4;  // 75% of widget width
+    const int barH = 6;
+    // Original anchor (restored): the bar sits at the dBm label's vertical
+    // centre.  The label is now nested in the stacked page, so map its position
+    // into widget coordinates — this reproduces the pre-SmartMTR bar position
+    // exactly. (#SmartMTR)
+    int barY = barH;
+    if (m_dbmLabel) {
+        barY = m_dbmLabel->mapTo(this, QPoint(0, 0)).y()
+             + (m_dbmLabel->height() - barH) / 2;
+    }
+    return QRect(barX, barY, barW, barH);
+}
+
+// Apply the global meter-view choice: switch the stacked page, sync the inline
+// selector buttons, and repaint.
+void VfoWidget::applyMeterView(bool smartMtr)
+{
+    m_smartMtr = smartMtr;
+    if (m_meterStack) {
+        m_meterStack->setCurrentIndex(smartMtr ? 1 : 0);
+    }
+    syncMeterMenuButtons();
+    adjustSize();  // S-Meter and SmartMTR pages may differ in height → resize the flag
+    update();  // repaint the painted S-meter bar (or clear it)
+    // Recomposite over the GPU spectrum so the switched meter is visible while
+    // the menu stays open (QRhiWidget — see mousePressEvent). (#SmartMTR)
+    if (QWidget* p = parentWidget()) {
+        p->update();
+    }
+}
+
+// Reflect the current meter-view choice on the inline selector buttons.  The
+// selected one is checked → enabled-filter (blue) style; the other is the
+// plain DSP-toggle look.
+void VfoWidget::syncMeterMenuButtons()
+{
+    if (m_sMeterOptBtn) {
+        m_sMeterOptBtn->setChecked(!m_smartMtr);
+    }
+    if (m_smartMtrOptBtn) {
+        m_smartMtrOptBtn->setChecked(m_smartMtr);
+    }
 }
 
 // ── Signal level ──────────────────────────────────────────────────────────────

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3163,6 +3163,8 @@ void VfoWidget::applyMeterView(bool smartMtr)
     syncMeterMenuButtons();
     syncSmartMtrSettingsState();  // options are SmartMTR-only → enable/disable
     pushSmartMtrOptions();  // refresh extremes + label-overlay visibility for the view
+    pushSmartMtrInput();    // re-seed the meter from the last level on switch-in
+                            // (no-ops while S-meter is selected — see the gate there)
     // Resize via relayoutToCurrentContent() (clears the post-#3706 fixed-height
     // clamp before re-pinning) — a bare adjustSize() can't grow the flag for the
     // taller SmartMTR page. (#SmartMTR)
@@ -3268,7 +3270,11 @@ void VfoWidget::setSignalLevel(float dbm)
 // canonical ranges match the per-kind configs in SmartMtrConfig.cpp.
 void VfoWidget::pushSmartMtrInput()
 {
-    if (!m_smartMtrWidget)
+    // Skip while the S-meter view is shown: feeding the hidden SmartMtrWidget
+    // would run its ballistics + restart the 120 Hz animation timer on every
+    // meter packet, for every flag, for users who never enable SmartMTR — the
+    // page never paints. applyMeterView() re-seeds it on switch-in.
+    if (!m_smartMtrWidget || !m_smartMtr)
         return;
 
     MeterInput in;

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2999,11 +2999,20 @@ void VfoWidget::paintEvent(QPaintEvent* event)
         // overflow the 22px strip, so anchor below them; SmartMTR is contained,
         // so anchor at the widget bottom.  The underline-room spacer guarantees
         // this clears the tab row regardless of indicator height. (#SmartMTR)
-        const qreal yBase = m_smartMtr
-            ? g.bottom() + 1.0
-            : meterBarRect().y() + 20.0;
         const qreal rise   = 2.0;              // how far the ends curve up (tiny)
         const qreal curveW = 5.0;              // horizontal span of each hook
+        const qreal penW   = 2.0;              // accent stroke width
+        // SmartMTR's meter is an OPAQUE child widget (SmartMtrWidget) that repaints
+        // its whole rect, so any underline pixel at/above g.bottom() — including the
+        // upward-hooked ends, which reach rise+penW/2 above the flat baseline — gets
+        // painted over by the child and reads as "cut". Drop the baseline so even the
+        // raised tips clear g.bottom() by 1px; the underline-room spacer (grown to
+        // match in SmartMTR mode, see applyMeterView) keeps the flat baseline off the
+        // tab row. The standard S-meter page is transparent (its bar is painted by
+        // us), so its underline anchors over the overflowing scale labels as before.
+        const qreal yBase = m_smartMtr
+            ? g.bottom() + rise + penW / 2.0 + 1.0
+            : meterBarRect().y() + 20.0;
         const qreal xL = g.x();
         const qreal xR = g.x() + g.width();
 
@@ -3015,7 +3024,7 @@ void VfoWidget::paintEvent(QPaintEvent* event)
 
         const bool prevAA = p.testRenderHint(QPainter::Antialiasing);
         p.setRenderHint(QPainter::Antialiasing, true);
-        QPen underPen(QColor(0x00, 0xb4, 0xd8), 2.0);
+        QPen underPen(QColor(0x00, 0xb4, 0xd8), penW);
         underPen.setCapStyle(Qt::RoundCap);
         p.setPen(underPen);
         p.setBrush(Qt::NoBrush);
@@ -3139,6 +3148,13 @@ void VfoWidget::applyMeterView(bool smartMtr)
     m_smartMtr = smartMtr;
     if (m_meterStack) {
         m_meterStack->setCurrentIndex(smartMtr ? 1 : 0);
+    }
+    // The curved meter-strip underline (painted in paintEvent) needs more vertical
+    // room in SmartMTR mode: its baseline sits below the opaque meter child so the
+    // hooks aren't clipped, which drops the stroke ~3px lower than the S-meter case.
+    // Size the underline-room spacer to contain it per mode. (#SmartMTR)
+    if (m_meterUnderlineRoom) {
+        m_meterUnderlineRoom->setFixedHeight(smartMtr ? 5 : 3);
     }
     syncMeterMenuButtons();
     syncSmartMtrSettingsState();  // options are SmartMTR-only → enable/disable

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2387,7 +2387,11 @@ void VfoWidget::setMeterMenuOpen(bool open)
     if (open) {
         closeActiveTab();  // mutual exclusion with the DSP/Mode/... tabs
     }
-    adjustSize();  // S-Meter/SmartMTR + menu-row heights → refit the flag
+    // Refit via relayoutToCurrentContent(), not adjustSize(): the post-#3706
+    // layout pins the flag with setFixedHeight(), so a bare adjustSize() can't
+    // grow it to make room for the menu row. relayoutToCurrentContent() first
+    // clears the min/max clamp, then recomputes and re-pins. (#SmartMTR)
+    relayoutToCurrentContent();
     update();      // repaint the meter-strip underline
     // The flag composites over the GPU spectrum (QRhiWidget); our update()
     // doesn't refresh the parent's texture, so force a recomposite, same as
@@ -3159,7 +3163,10 @@ void VfoWidget::applyMeterView(bool smartMtr)
     syncMeterMenuButtons();
     syncSmartMtrSettingsState();  // options are SmartMTR-only → enable/disable
     pushSmartMtrOptions();  // refresh extremes + label-overlay visibility for the view
-    adjustSize();  // S-Meter and SmartMTR pages may differ in height → resize the flag
+    // Resize via relayoutToCurrentContent() (clears the post-#3706 fixed-height
+    // clamp before re-pinning) — a bare adjustSize() can't grow the flag for the
+    // taller SmartMTR page. (#SmartMTR)
+    relayoutToCurrentContent();
     update();  // repaint the painted S-meter bar (or clear it)
     // Recomposite over the GPU spectrum so the switched meter is visible while
     // the menu stays open (QRhiWidget — see mousePressEvent). (#SmartMTR)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2,6 +2,7 @@
 #include "PhaseKnob.h"
 #include "SmartMtrWidget.h"
 #include "MeterViewController.h"
+#include "DisplaySettings.h"
 #include "ComboStyle.h"
 #include "FrequencyEntryParser.h"
 #include "GuardedSlider.h"
@@ -29,6 +30,9 @@
 #include <QAccessible>
 #include <QLineEdit>
 #include <QComboBox>
+#include <QCheckBox>
+#include <QFrame>
+#include <QListView>
 #include <QStackedWidget>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -888,9 +892,17 @@ void VfoWidget::buildUI()
     // applies globally and persists.
     m_meterMenuRow = new QWidget;
     m_meterMenuRow->setAttribute(Qt::WA_TranslucentBackground);
-    auto* meterMenuLayout = new QHBoxLayout(m_meterMenuRow);
-    // Small bottom margin so the buttons aren't flush against the flag's edge.
-    meterMenuLayout->setContentsMargins(0, 0, 0, 6);
+    // Outer layout stacks the selector buttons over the SmartMTR-only options.
+    auto* meterMenuOuter = new QVBoxLayout(m_meterMenuRow);
+    // Small bottom margin so the contents aren't flush against the flag's edge.
+    meterMenuOuter->setContentsMargins(0, 0, 0, 6);
+    meterMenuOuter->setSpacing(5);
+
+    // Selector buttons live in their own horizontal row.
+    auto* meterBtnRow = new QWidget;
+    meterBtnRow->setAttribute(Qt::WA_TranslucentBackground);
+    auto* meterMenuLayout = new QHBoxLayout(meterBtnRow);
+    meterMenuLayout->setContentsMargins(0, 0, 0, 0);
     meterMenuLayout->setSpacing(3);
 
     m_sMeterOptBtn = new QPushButton(tr("S-Meter"));
@@ -920,6 +932,110 @@ void VfoWidget::buildUI()
         MeterViewController::instance().setSmartMtr(true);
         syncMeterMenuButtons();
     });
+
+    meterMenuOuter->addWidget(meterBtnRow);
+
+    // ── SmartMTR-only options (vertical) ───────────────────────────────────
+    // Shown below the selector buttons; disabled while the standard S-meter is
+    // selected (these tune the SmartMTR view only).  Persisted via
+    // DisplaySettings; the rendering layer consumes them in a follow-up.
+    using DS = DisplaySettings;
+
+    // Thin horizontal separator matching the selector's border colour.
+    auto makeSeparator = []() {
+        auto* line = new QFrame;
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Plain);
+        line->setFixedHeight(1);
+        line->setStyleSheet(
+            "QFrame { border: none; background: #304050; max-height: 1px; }");
+        line->setAttribute(Qt::WA_TransparentForMouseEvents);
+        return line;
+    };
+    // Label preceding a select control, on the same row as its combo.
+    auto makeOptLabel = [](const QString& text) {
+        auto* lbl = new QLabel(text);
+        lbl->setStyleSheet("QLabel { background: transparent; border: none; "
+                           "color: #c8d8e8; font-size: 12px; }");
+        return lbl;
+    };
+
+    meterMenuOuter->addWidget(makeSeparator());
+
+    // Show extremes — checkbox.
+    m_showExtremesChk = new QCheckBox(tr("Show extremes"));
+    m_showExtremesChk->setChecked(DS::showExtremes());
+    m_showExtremesChk->setCursor(Qt::PointingHandCursor);
+    m_showExtremesChk->setStyleSheet(
+        "QCheckBox { background: transparent; color: #c8d8e8; font-size: 12px; "
+        "spacing: 5px; }"
+        "QCheckBox::indicator { width: 13px; height: 13px; border-radius: 2px; "
+        "border: 1px solid #304050; background: #1a2a3a; }"
+        "QCheckBox::indicator:checked { background: #0070c0; "
+        "border: 1px solid #0090e0; }"
+        "QCheckBox:disabled { color: #5a6a78; }"
+        "QCheckBox::indicator:disabled { border: 1px solid #243240; "
+        "background: #141f2a; }");
+    meterMenuOuter->addWidget(m_showExtremesChk);
+
+    // Extremes speed — Slow / Medium / Fast.
+    auto* speedRow = new QWidget;
+    speedRow->setAttribute(Qt::WA_TranslucentBackground);
+    auto* speedLayout = new QHBoxLayout(speedRow);
+    speedLayout->setContentsMargins(0, 0, 0, 0);
+    speedLayout->setSpacing(4);
+    speedLayout->addWidget(makeOptLabel(tr("Extremes speed")));
+    m_extremesSpeedCmb = new QComboBox;
+    m_extremesSpeedCmb->addItem(tr("Slow"), int(DS::ExtremesSpeed::Slow));
+    m_extremesSpeedCmb->addItem(tr("Medium"), int(DS::ExtremesSpeed::Medium));
+    m_extremesSpeedCmb->addItem(tr("Fast"), int(DS::ExtremesSpeed::Fast));
+    m_extremesSpeedCmb->setCurrentIndex(
+        m_extremesSpeedCmb->findData(int(DS::extremesSpeed())));
+    AetherSDR::applyComboStyle(m_extremesSpeedCmb);
+    speedLayout->addWidget(m_extremesSpeedCmb, 1);
+    m_extremesSpeedFade = new QGraphicsOpacityEffect(speedRow);
+    speedRow->setGraphicsEffect(m_extremesSpeedFade);
+    meterMenuOuter->addWidget(speedRow);
+
+    meterMenuOuter->addWidget(makeSeparator());
+
+    // Show values — None / Signal / Extremes.
+    auto* valuesRow = new QWidget;
+    valuesRow->setAttribute(Qt::WA_TranslucentBackground);
+    auto* valuesLayout = new QHBoxLayout(valuesRow);
+    valuesLayout->setContentsMargins(0, 0, 0, 0);
+    valuesLayout->setSpacing(4);
+    valuesLayout->addWidget(makeOptLabel(tr("Show values")));
+    m_showValuesCmb = new QComboBox;
+    m_showValuesCmb->addItem(tr("None"), int(DS::MeterValues::None));
+    m_showValuesCmb->addItem(tr("Signal"), int(DS::MeterValues::Signal));
+    m_showValuesCmb->addItem(tr("Extremes"), int(DS::MeterValues::Extremes));
+    m_showValuesCmb->setCurrentIndex(
+        m_showValuesCmb->findData(int(DS::showValues())));
+    AetherSDR::applyComboStyle(m_showValuesCmb);
+    valuesLayout->addWidget(m_showValuesCmb, 1);
+    m_showValuesFade = new QGraphicsOpacityEffect(valuesRow);
+    valuesRow->setGraphicsEffect(m_showValuesFade);
+    meterMenuOuter->addWidget(valuesRow);
+
+    // Persist + re-evaluate enable/disable rules on change.  Toggling "Show
+    // extremes" off disables "Extremes speed" and, if "Show values" is set to
+    // Extremes, snaps it back to None (handled in syncSmartMtrSettingsState).
+    connect(m_showExtremesChk, &QCheckBox::toggled, this, [this](bool on) {
+        DisplaySettings::setShowExtremes(on);
+        syncSmartMtrSettingsState();
+    });
+    connect(m_extremesSpeedCmb, &QComboBox::currentIndexChanged, this,
+            [this](int) {
+        DisplaySettings::setExtremesSpeed(static_cast<DisplaySettings::ExtremesSpeed>(
+            m_extremesSpeedCmb->currentData().toInt()));
+    });
+    connect(m_showValuesCmb, &QComboBox::currentIndexChanged, this, [this](int) {
+        DisplaySettings::setShowValues(static_cast<DisplaySettings::MeterValues>(
+            m_showValuesCmb->currentData().toInt()));
+    });
+
+    syncSmartMtrSettingsState();  // initial enable/disable per current state
 
     m_meterMenuRow->hide();  // hidden until the meter strip is clicked
     // NOTE: added to the root layout below the tab bar (see after m_tabBar).
@@ -2969,6 +3085,7 @@ void VfoWidget::applyMeterView(bool smartMtr)
         m_meterStack->setCurrentIndex(smartMtr ? 1 : 0);
     }
     syncMeterMenuButtons();
+    syncSmartMtrSettingsState();  // options are SmartMTR-only → enable/disable
     adjustSize();  // S-Meter and SmartMTR pages may differ in height → resize the flag
     update();  // repaint the painted S-meter bar (or clear it)
     // Recomposite over the GPU spectrum so the switched meter is visible while
@@ -2988,6 +3105,64 @@ void VfoWidget::syncMeterMenuButtons()
     }
     if (m_smartMtrOptBtn) {
         m_smartMtrOptBtn->setChecked(m_smartMtr);
+    }
+}
+
+// Enable/disable the SmartMTR-only options to match the current state:
+//   • everything is disabled unless the SmartMTR view is selected;
+//   • "Extremes speed" is further gated on "Show extremes" being checked;
+//   • with "Show extremes" off, "Show values" can't stay on Extremes — it
+//     snaps back to None.
+void VfoWidget::syncSmartMtrSettingsState()
+{
+    const bool smart = m_smartMtr;  // options apply to SmartMTR only
+    const bool showExt = m_showExtremesChk && m_showExtremesChk->isChecked();
+
+    // Dim disabled select rows (label + combo) to match the disabled-checkbox
+    // label.  #5e6e7c is ~0.45 blend of the normal text over the flag bg, so
+    // 0.45 opacity reproduces that dimming on the whole row.
+    constexpr double kDisabledOpacity = 0.45;
+    const bool speedEnabled = smart && showExt;
+    if (m_extremesSpeedFade) {
+        m_extremesSpeedFade->setOpacity(speedEnabled ? 1.0 : kDisabledOpacity);
+    }
+    if (m_showValuesFade) {
+        m_showValuesFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
+    }
+
+    if (m_showExtremesChk) {
+        m_showExtremesChk->setEnabled(smart);
+    }
+    if (m_extremesSpeedCmb) {
+        m_extremesSpeedCmb->setEnabled(speedEnabled);
+    }
+    if (m_showValuesCmb) {
+        m_showValuesCmb->setEnabled(smart);
+        // The "Extremes" value is meaningless without the extremes markers, so
+        // hide it from the dropdown entirely while "Show extremes" is off (the
+        // combo's view stylesheet forces every item to the primary text colour,
+        // so a merely-disabled item wouldn't read as disabled).  Also clear its
+        // flags as a fallback for styles that ignore row-hiding.
+        const int extremesIdx =
+            m_showValuesCmb->findData(int(DisplaySettings::MeterValues::Extremes));
+        if (extremesIdx >= 0) {
+            if (auto* view = qobject_cast<QListView*>(m_showValuesCmb->view())) {
+                view->setRowHidden(extremesIdx, !showExt);
+            }
+            // Flags role (Qt::UserRole - 1): invalid QVariant = default
+            // (enabled), 0 = no flags (disabled/unselectable).
+            m_showValuesCmb->setItemData(
+                extremesIdx, showExt ? QVariant() : QVariant(0),
+                Qt::UserRole - 1);
+        }
+        // ...and if it was the current choice, snap back to None.
+        if (!showExt && m_showValuesCmb->currentIndex() == extremesIdx) {
+            const int noneIdx =
+                m_showValuesCmb->findData(int(DisplaySettings::MeterValues::None));
+            if (noneIdx >= 0) {
+                m_showValuesCmb->setCurrentIndex(noneIdx);  // persists via signal
+            }
+        }
     }
 }
 

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -201,6 +201,18 @@ public:
         const QWidget* w = currentWidget();
         return w ? w->minimumSizeHint() : QStackedWidget::minimumSizeHint();
     }
+    // Forward height-for-width from the current page so a page that keeps an
+    // aspect ratio (e.g. SmartMtrWidget) drives the strip height; pages without
+    // it (the S-meter spacer) are unaffected.
+    bool hasHeightForWidth() const override {
+        const QWidget* w = currentWidget();
+        return w ? w->hasHeightForWidth() : QStackedWidget::hasHeightForWidth();
+    }
+    int heightForWidth(int width) const override {
+        const QWidget* w = currentWidget();
+        return (w && w->hasHeightForWidth()) ? w->heightForWidth(width)
+                                             : QStackedWidget::heightForWidth(width);
+    }
 };
 
 namespace AetherSDR {

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -327,6 +327,10 @@ VfoWidget::VfoWidget(QWidget* parent)
     // widget whenever any flag changes them.
     connect(&MeterViewController::instance(), &MeterViewController::extremesChanged,
             this, &VfoWidget::pushSmartMtrOptions);
+    // The TX-meter choice swaps the SmartMTR input (signal <-> mic) rather than
+    // its options, so re-push the input when it changes on any flag.
+    connect(&MeterViewController::instance(), &MeterViewController::txMeterChanged,
+            this, &VfoWidget::pushSmartMtrInput);
     pushSmartMtrOptions(); // apply the persisted options to this new flag
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
@@ -1029,6 +1033,27 @@ void VfoWidget::buildUI()
     valuesRow->setGraphicsEffect(m_showValuesFade);
     meterMenuOuter->addWidget(valuesRow);
 
+    meterMenuOuter->addWidget(makeSeparator());
+
+    // TX meter — None / Mic Level. While transmitting, None keeps the RX signal
+    // scale and Mic Level swaps to the mic-level (dBFS) scale for the duration
+    // of TX.
+    auto* txMeterRow = new QWidget;
+    txMeterRow->setAttribute(Qt::WA_TranslucentBackground);
+    auto* txMeterLayout = new QHBoxLayout(txMeterRow);
+    txMeterLayout->setContentsMargins(0, 0, 0, 0);
+    txMeterLayout->setSpacing(4);
+    txMeterLayout->addWidget(makeOptLabel(tr("TX meter")));
+    m_txMeterCmb = new QComboBox;
+    m_txMeterCmb->addItem(tr("None"), int(DS::TxMeter::None));
+    m_txMeterCmb->addItem(tr("Mic Level"), int(DS::TxMeter::MicLevel));
+    m_txMeterCmb->setCurrentIndex(m_txMeterCmb->findData(int(DS::txMeter())));
+    AetherSDR::applyComboStyle(m_txMeterCmb);
+    txMeterLayout->addWidget(m_txMeterCmb, 1);
+    m_txMeterFade = new QGraphicsOpacityEffect(txMeterRow);
+    txMeterRow->setGraphicsEffect(m_txMeterFade);
+    meterMenuOuter->addWidget(txMeterRow);
+
     // Persist + re-evaluate enable/disable rules on change.  Toggling "Show
     // extremes" off disables "Extremes speed" and, if "Show values" is set to
     // Extremes, snaps it back to None (handled in syncSmartMtrSettingsState).
@@ -1048,6 +1073,11 @@ void VfoWidget::buildUI()
         MeterViewController::instance().setShowValues(
             static_cast<DisplaySettings::MeterValues>(
                 m_showValuesCmb->currentData().toInt()));
+    });
+    connect(m_txMeterCmb, &QComboBox::currentIndexChanged, this, [this](int) {
+        MeterViewController::instance().setTxMeter(
+            static_cast<DisplaySettings::TxMeter>(
+                m_txMeterCmb->currentData().toInt()));
     });
 
     syncSmartMtrSettingsState();  // initial enable/disable per current state
@@ -3156,12 +3186,18 @@ void VfoWidget::syncSmartMtrSettingsState()
     if (m_showValuesFade) {
         m_showValuesFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
     }
+    if (m_txMeterFade) {
+        m_txMeterFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
+    }
 
     if (m_showExtremesChk) {
         m_showExtremesChk->setEnabled(smart);
     }
     if (m_extremesSpeedCmb) {
         m_extremesSpeedCmb->setEnabled(speedEnabled);
+    }
+    if (m_txMeterCmb) {
+        m_txMeterCmb->setEnabled(smart);
     }
     if (m_showValuesCmb) {
         m_showValuesCmb->setEnabled(smart);
@@ -3213,12 +3249,19 @@ void VfoWidget::pushSmartMtrInput()
         return;
 
     MeterInput in;
-    const bool showMic = m_transmitting && m_slice && m_slice->isTxSlice();
+    // Only swap to the mic-level scale on TX when the operator opted in via the
+    // "TX meter" setting; otherwise the meter stays on the RX signal scale.
+    const bool showMic = m_transmitting && m_slice && m_slice->isTxSlice()
+        && MeterViewController::instance().txMeter()
+            == DisplaySettings::TxMeter::MicLevel;
     if (showMic) {
         in.kind = MeterKind::MicLevel;
         in.value = m_micDbfs;
-        in.min = -40.0; // dBFS
-        in.max = 0.0;
+        in.min = -40.0; // dBFS — scale start
+        in.max = 0.0;   // dBFS — full scale / clip (linear scale)
+        // Peak marker is the radio's separate MICPEAK stat, not a local window max.
+        in.hasPeak = true;
+        in.peak = m_micPeakDbfs;
     } else {
         in.kind = MeterKind::Signal;
         in.value = m_signalDbm;
@@ -3382,9 +3425,10 @@ void VfoWidget::drawSmartMtrLabels(QPainter& p) const
     p.restore();
 }
 
-void VfoWidget::setMicLevel(float micDbfs)
+void VfoWidget::setMicLevel(float micDbfs, float micPeakDbfs)
 {
     m_micDbfs = micDbfs;
+    m_micPeakDbfs = micPeakDbfs;
     if (m_transmitting && m_slice && m_slice->isTxSlice())
         pushSmartMtrInput();
 }

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -165,8 +165,17 @@ private:
 
     void buildUI();
     void buildTabContent();
+    // Meter view (standard S-Meter vs SmartMTR component).  Driven globally by
+    // MeterViewController; m_meterStack switches pages and meterBarRect() locates
+    // the painted bar.  The inline selector row (m_meterMenuRow) is revealed by
+    // clicking the meter strip; syncMeterMenuButtons() reflects the choice.
+    void applyMeterView(bool smartMtr);
+    void syncMeterMenuButtons();
+    void setMeterMenuOpen(bool open);  // open/close the S-Meter/SmartMTR selector
+    QRect meterBarRect() const;
     void updateTxBadgeStyle(bool isTx);
     void showTab(int index);
+    void closeActiveTab();  // close any open DSP/Mode/... tab panel
     void updateFreqLabel();
     bool cancelDirectEntry();
     void updateFilterLabel();
@@ -234,6 +243,18 @@ private:
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
     QLabel* m_dbmLabel{nullptr};
+    // Meter strip: page 0 = standard S-meter (painted bar + dBm label),
+    // page 1 = SmartMTR component.  m_smartMtr mirrors the current page.
+    QStackedWidget* m_meterStack{nullptr};
+    bool m_smartMtr{false};
+    // Inline selector row revealed by clicking the meter strip (not a popup),
+    // shown between the meter and the tab bar.
+    QWidget* m_meterMenuRow{nullptr};
+    QPushButton* m_sMeterOptBtn{nullptr};
+    QPushButton* m_smartMtrOptBtn{nullptr};
+    // Thin spacer between the meter and the tab bar, shown only while the meter
+    // selector is open, to give the curved underline room below the indicator.
+    QWidget* m_meterUnderlineRoom{nullptr};
     QString m_directEntrySource{"vfo-direct-entry"};
 
     // Sub-menu tabs

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -30,6 +30,7 @@ class RadioModel;
 class PhaseKnob;
 class RxApplet;
 class KiwiSdrManager;
+class SmartMtrWidget;
 
 // Floating VFO info panel attached to the VFO marker on the spectrum display.
 // Shows slice info (antennas, frequency, signal level, filter width, TX/SPLIT)
@@ -55,6 +56,11 @@ public:
     void setSignalLevel(float dbm);
     void setReceiveMeterReading(
         const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
+    // SmartMTR feeds: live mic level (dBFS) and global TX (MOX) state. The
+    // SmartMTR view shows mic level on this VFO's TX slice while transmitting,
+    // and received signal otherwise.
+    void setMicLevel(float micDbfs);
+    void setTransmitting(bool tx);
 
     // Split mode: call whenever TX assignment or active slice changes.
     //   isTxSlice  — this VFO's slice has tx=1
@@ -160,6 +166,9 @@ protected:
 private:
     void updateSignalMeterTarget();
     void animateSignalMeter();
+    // Build and push the current MeterInput (signal vs mic by TX state) to the
+    // SmartMTR widget. Cheap; safe to call on every level/state update.
+    void pushSmartMtrInput();
     bool usesUnavailableSignalMeter() const;
     static float signalDbmToMeterFraction(float dbm);
 
@@ -247,6 +256,9 @@ private:
     // page 1 = SmartMTR component.  m_smartMtr mirrors the current page.
     QStackedWidget* m_meterStack{nullptr};
     bool m_smartMtr{false};
+    SmartMtrWidget* m_smartMtrWidget{nullptr};
+    float m_micDbfs{-40.0f}; // latest mic level (dBFS); SmartMTR TX scale
+    bool m_transmitting{false}; // global MOX state
     // Inline selector row revealed by clicking the meter strip (not a popup),
     // shown between the meter and the tab bar.
     QWidget* m_meterMenuRow{nullptr};

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -23,6 +23,7 @@ class QCheckBox;
 class QGraphicsOpacityEffect;
 class QDoubleSpinBox;
 class QGridLayout;
+class QPainter;
 
 namespace AetherSDR {
 
@@ -81,6 +82,13 @@ public:
 
     // Reposition relative to VFO marker x coordinate.
     void updatePosition(int vfoX, int specTop, FlagDir dir = Auto);
+
+    // Draw this flag's SmartMTR extremes value labels (min/max or current signal,
+    // gated by the meter options) onto the spectrum painter, in the band just
+    // below the flag. Called by SpectrumWidget's overlay pass so the labels land
+    // on top of the slice markers. No-op unless the SmartMTR meter + value labels
+    // are active and the flag is expanded. Coordinates are SpectrumWidget-local.
+    void drawSmartMtrLabels(QPainter& p) const;
 
     // Client-side DSP buttons (NR2 / NR4 / MNR / BNR / DFNR / RN2) were
     // removed from the VFO DSP grid; that family lives in the spectrum
@@ -157,6 +165,10 @@ Q_SIGNALS:
     // (no center line / no top triangle, passband only), 1 = 1 px line,
     // 3 = 3 px line.
     void markerStyleChanged(int markerWidth, bool filterEdgesHidden);
+    // The SmartMTR value labels need a repaint (meter values/options changed).
+    // SpectrumWidget connects this to markOverlayDirty() so the spectrum overlay
+    // (which draws the labels) refreshes. Throttled at the source.
+    void smartMtrLabelsChanged();
 
 protected:
     void paintEvent(QPaintEvent* event) override;
@@ -171,6 +183,12 @@ private:
     // Build and push the current MeterInput (signal vs mic by TX state) to the
     // SmartMTR widget. Cheap; safe to call on every level/state update.
     void pushSmartMtrInput();
+    // Read the global extremes options (MeterViewController) and push them to the
+    // SmartMTR widget; show/hide + reposition the value-label overlay. Called on
+    // construction, on extremesChanged() broadcast, and on meter-view switch.
+    void pushSmartMtrOptions();
+    // Throttled bridge from the meter's repaint to a spectrum-overlay refresh.
+    void onSmartMtrRepainted();
     bool usesUnavailableSignalMeter() const;
     static float signalDbmToMeterFraction(float dbm);
 
@@ -259,6 +277,11 @@ private:
     QStackedWidget* m_meterStack{nullptr};
     bool m_smartMtr{false};
     SmartMtrWidget* m_smartMtrWidget{nullptr};
+    // The SmartMTR extremes value labels are drawn by SpectrumWidget's overlay
+    // pass (so they sit on top of the slice). This clock throttles how often the
+    // meter's repaint asks the spectrum overlay to refresh.
+    QElapsedTimer m_labelDirtyClock;
+    qint64 m_lastLabelDirtyMs{-1};
     float m_micDbfs{-40.0f}; // latest mic level (dBFS); SmartMTR TX scale
     bool m_transmitting{false}; // global MOX state
     // Inline selector row revealed by clicking the meter strip (not a popup),

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -59,10 +59,11 @@ public:
     void setSignalLevel(float dbm);
     void setReceiveMeterReading(
         const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
-    // SmartMTR feeds: live mic level (dBFS) and global TX (MOX) state. The
-    // SmartMTR view shows mic level on this VFO's TX slice while transmitting,
-    // and received signal otherwise.
-    void setMicLevel(float micDbfs);
+    // SmartMTR feeds: live mic level + separately-measured mic peak (both dBFS)
+    // and global TX (MOX) state. The SmartMTR view shows mic level on this VFO's
+    // TX slice while transmitting (peak marker driven by micPeak), and received
+    // signal otherwise.
+    void setMicLevel(float micDbfs, float micPeakDbfs);
     void setTransmitting(bool tx);
 
     // Split mode: call whenever TX assignment or active slice changes.
@@ -283,6 +284,7 @@ private:
     QElapsedTimer m_labelDirtyClock;
     qint64 m_lastLabelDirtyMs{-1};
     float m_micDbfs{-40.0f}; // latest mic level (dBFS); SmartMTR TX scale
+    float m_micPeakDbfs{-40.0f}; // latest mic peak (dBFS, radio MICPEAK stat)
     bool m_transmitting{false}; // global MOX state
     // Inline selector row revealed by clicking the meter strip (not a popup),
     // shown between the meter and the tab bar.
@@ -295,12 +297,16 @@ private:
     QCheckBox* m_showExtremesChk{nullptr};
     QComboBox* m_extremesSpeedCmb{nullptr};
     QComboBox* m_showValuesCmb{nullptr};
+    // Which meter to show while transmitting: None (stay on RX signal) or Mic
+    // Level. Disabled while the standard S-meter is selected.
+    QComboBox* m_txMeterCmb{nullptr};
     // Opacity effects over each select row (label + combo), dimmed when the
     // row is disabled so the disabled state is obvious (the custom combo
     // stylesheet has no :disabled variant).  Matched to the disabled-checkbox
     // label dimming.
     QGraphicsOpacityEffect* m_extremesSpeedFade{nullptr};
     QGraphicsOpacityEffect* m_showValuesFade{nullptr};
+    QGraphicsOpacityEffect* m_txMeterFade{nullptr};
     // Enable/disable the SmartMTR-only options per the current meter view and
     // the "Show extremes" checkbox state (see implementation for the rules).
     void syncSmartMtrSettingsState();

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -19,6 +19,8 @@ class QLineEdit;
 class QStackedWidget;
 class QSlider;
 class QComboBox;
+class QCheckBox;
+class QGraphicsOpacityEffect;
 class QDoubleSpinBox;
 class QGridLayout;
 
@@ -264,6 +266,21 @@ private:
     QWidget* m_meterMenuRow{nullptr};
     QPushButton* m_sMeterOptBtn{nullptr};
     QPushButton* m_smartMtrOptBtn{nullptr};
+    // SmartMTR-only display options, shown vertically below the selector
+    // buttons. Disabled while the standard S-meter is selected. "Extremes
+    // speed" is further gated on "Show extremes" being checked.
+    QCheckBox* m_showExtremesChk{nullptr};
+    QComboBox* m_extremesSpeedCmb{nullptr};
+    QComboBox* m_showValuesCmb{nullptr};
+    // Opacity effects over each select row (label + combo), dimmed when the
+    // row is disabled so the disabled state is obvious (the custom combo
+    // stylesheet has no :disabled variant).  Matched to the disabled-checkbox
+    // label dimming.
+    QGraphicsOpacityEffect* m_extremesSpeedFade{nullptr};
+    QGraphicsOpacityEffect* m_showValuesFade{nullptr};
+    // Enable/disable the SmartMTR-only options per the current meter view and
+    // the "Show extremes" checkbox state (see implementation for the rules).
+    void syncSmartMtrSettingsState();
     // Thin spacer between the meter and the tab bar, shown only while the meter
     // selector is open, to give the curved underline room below the indicator.
     QWidget* m_meterUnderlineRoom{nullptr};


### PR DESCRIPTION
Closes #3450.

Adds an opt-in **SmartMTR** meter view selectable from the VFO flag's meter menu, alongside the existing S-meter (unchanged, pixel-identical when not selected). The implemented scope is broader than the original RFC text — see the implementation-update comment on #3450 for the point-by-point diff and rationale.

## How to try it

The new view is **off by default**. To switch:

1. Open a VFO flag and **click the meter strip** (the S-meter / dBm area). An inline selector drops down under the tab row.
2. Click **SmartMTR**. The choice is **global** (applies to every open flag) and **persists** across restarts.
3. The SmartMTR-only options — **Show extremes**, **Extremes speed** (1s/3s/5s window), **Show values**, **TX meter** — appear in the same panel.

Click the meter strip again to close the selector; click **S-Meter** to switch back.

## What it adds
- Separate, render-only `SmartMtrWidget` (UNITS→pixel geometry, static-layer pixmap caching, repaint gating tuned for the GPU panadapter).
- Analog d'Arsonval bar ballistics (reuses `MeterSmoother`); separate constant-slew min/max "extremes" markers over a sliding window (Fast 1s / Medium 3s / Slow 5s).
- Optional numeric value labels (s-unit + dBm), drawn in the spectrum overlay so they sit above the slice.
- TX mic-level scale (radio MICPEAK-driven peak) swapped in on TX when opted in.
- Global, persisted choice via `MeterViewController` + `DisplaySettings` nested-JSON blob; live-broadcast to every open flag.

## Original-file impact (minimal)
- `CMakeLists.txt` +3 (source registration)
- `MainWindow_Wiring.cpp` +8 (two signal connections)
- `SpectrumWidget` +19 (overlay hook)
- `VfoWidget` large but additive; the S-meter path is preserved.

Full app builds & links clean. Settings persist via `AppSettings` nested-JSON (Principle V). All commits signed.

> Touches `src/gui/` + `CMakeLists.txt` → maintainer review (@ten9876) required per CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
