### PR TITLE
fix(rigctld): resolve SmartSDR rigctld behavior gaps and fix on-demand split VFO

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -913,7 +913,12 @@ QString RigctlProtocol::cmdSetPtt(const QString& arg)
     // the CAT thread (same direct-read pattern as cmdGetSplitVfo).
     auto* txSlice = findTxSlice(/*promote=*/false);
     auto* rx      = currentSlice();
-    const bool splitActive = (m_lastSplitEnable == 1) && txSlice && rx && txSlice != rx;
+    // Split is "active" if a distinct TX slice exists OR a create-on-demand is
+    // still in flight (m_pendingTxSlice not resolvable yet). Covering the pending
+    // window stops a key that arrives before the slice lands from seizing TX back
+    // to the RX slice (transmitting on VFOA — the very symptom this gate prevents).
+    const bool splitActive = (m_lastSplitEnable == 1)
+                             && (m_pendingSplitEnable || (txSlice && rx && txSlice != rx));
 
     QMetaObject::invokeMethod(m_model, [model = m_model, sliceId = m_sliceIndex, tx, splitActive]() {
         // Non-split: ensure this protocol's bound slice is the TX slice so the
@@ -1092,7 +1097,12 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
 // already exists. Promote an existing non-RX slice, else create a second slice
 // and flag deferred promotion (tryPromoteTxSlice applies it when the radio's
 // status response populates the new SliceModel).
-void RigctlProtocol::ensureSplitTxSlice()
+// Max time a create-on-demand may stay "in flight" before the in-flight guard
+// treats it as failed and lets a retry through. Only needs to outlast a normal
+// slice create (~300-400 ms observed) while still deduping the rapid WSJT-X burst.
+static constexpr qint64 kPendingCreateTimeoutMs = 2000;
+
+void RigctlProtocol::ensureSplitTxSlice(bool recordExistingAsEnabled)
 {
     if (!m_model) return;
     auto* rxSlice = currentSlice();
@@ -1104,9 +1114,21 @@ void RigctlProtocol::ensureSplitTxSlice()
     // that stash intact: the promote-existing path below clears m_pendingSplitEnable
     // WITHOUT applying the stash, so we must not fall into it while a create is
     // pending.
-    if (m_pendingSplitEnable) return;
+    // Time-bounded: if the create never lands (radio NAK; or on Multi-Flex the
+    // local slice count was below maxSlices() but the radio is really full), don't
+    // wedge split "pending" forever — once the window lapses, clear and retry.
+    if (m_pendingSplitEnable) {
+        if (m_pendingSplitTimer.isValid()
+                && m_pendingSplitTimer.elapsed() < kPendingCreateTimeoutMs)
+            return;
+        m_pendingSplitEnable = false;   // stale create — fall through and retry
+    }
     if (auto* tx = findTxSlice(/*promote=*/false); tx && tx != rxSlice) {
-        m_lastSplitEnable = 1;   // split already engaged on an existing slice
+        // Record the enable only for enable-intent callers; a passive
+        // set_split_freq/set_split_mode (recordExistingAsEnabled=false) must not
+        // claim a split this client never enabled (see the header note).
+        if (recordExistingAsEnabled)
+            m_lastSplitEnable = 1;   // split already engaged on an existing slice
         return;                  // a distinct TX slice already exists
     }
     for (auto* s : m_model->slices()) {
@@ -1128,6 +1150,7 @@ void RigctlProtocol::ensureSplitTxSlice()
     if (m_model->slices().size() >= m_model->maxSlices())
         return;   // could not engage split — leave m_lastSplitEnable untouched
     m_pendingSplitEnable = true;
+    m_pendingSplitTimer.start();   // arm the time-bounded in-flight guard above
     m_lastSplitEnable = 1;   // engaged via create-on-demand (slice in flight)
     // Create the TX slice on the RX slice's pan AND seeded at the RX frequency,
     // instead of letting addSlice() pick its default geometry (pan-center + 20% of
@@ -1171,7 +1194,9 @@ QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
     // matching set_freq VFOB. The in-flight guard in ensureSplitTxSlice prevents a
     // duplicate when a create is already pending. Without this, a transient race
     // returns RPRT -1 and aborts the transmit.
-    ensureSplitTxSlice();
+    // recordExistingAsEnabled=false: setting the split freq must not, by itself,
+    // claim that THIS client enabled split (that would arm a spurious reclaim).
+    ensureSplitTxSlice(/*recordExistingAsEnabled=*/false);
     // If the new slice hasn't appeared yet, stash the freq; tryPromoteTxSlice()
     // will apply it as soon as the slice becomes visible.
     if (m_pendingSplitEnable) {
@@ -1209,7 +1234,8 @@ QString RigctlProtocol::cmdSetSplitMode(const QString& args)
     const QString mode = hamlibToSmartSDR(parts[0]);
     // Establish the split TX slice on demand (see cmdSetSplitFreq) so a direct
     // set_split_mode — or one racing slice creation — doesn't hard-fail with -1.
-    ensureSplitTxSlice();
+    // recordExistingAsEnabled=false: see cmdSetSplitFreq.
+    ensureSplitTxSlice(/*recordExistingAsEnabled=*/false);
     // If the new slice hasn't appeared yet, stash the mode for tryPromoteTxSlice().
     if (m_pendingSplitEnable) {
         m_pendingSplitMode = mode;

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -216,6 +216,31 @@ RigctlProtocol::RigctlProtocol(RadioModel* model)
     : m_model(model)
 {}
 
+RigctlProtocol::~RigctlProtocol()
+{
+    // Client dropped without a clean set_split_vfo 0 (e.g. WSJT-X quit): best-effort
+    // remove the TX slice we created on demand so it isn't orphaned. Safe if it's
+    // already gone or never existed.
+    removeCreatedTxSlice();
+}
+
+// Best-effort, crash-safe removal of a TX slice we created on demand for split.
+// Tracks by id (not pointer) and re-resolves at removal time, so a stale/removed
+// slice is simply skipped. Only slices WE created are tracked (m_createdTxSliceId);
+// promoted operator slices are never touched. Uses m_model as the invoke context so
+// a destroyed model cancels the queued call (no use-after-free during shutdown).
+void RigctlProtocol::removeCreatedTxSlice()
+{
+    const int id = m_createdTxSliceId;
+    m_createdTxSliceId = -1;
+    if (id < 0 || !m_model) return;
+    auto* model = m_model;
+    QMetaObject::invokeMethod(model, [model, id]{
+        if (model->slice(id))
+            model->sendCommand(QStringLiteral("slice remove %1").arg(id));
+    }, Qt::QueuedConnection);
+}
+
 // ── Mode conversion tables ──────────────────────────────────────────────────
 // SmartSDR mode names observed on FLEX-8600 fw v1.4.0.0.
 // Hamlib mode names follow rig.h RIG_MODE_* definitions.
@@ -948,6 +973,10 @@ void RigctlProtocol::tryPromoteTxSlice()
         if (s != rxSlice) {
             m_pendingSplitEnable = false;
             m_pendingTxSlice = s;
+            // We only reach here after OUR create-on-demand armed m_pendingSplitEnable,
+            // so this newly-appeared slice is one we made — track it for best-effort
+            // removal on disable/disconnect (don't orphan it).
+            m_createdTxSliceId = s->sliceId();
             if (!s->isTxSlice())
                 QMetaObject::invokeMethod(s, [s]{ s->setTxSlice(true); },
                                           Qt::QueuedConnection);
@@ -1047,6 +1076,9 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
                 QMetaObject::invokeMethod(rxSlice, [rxSlice]{ rxSlice->setTxSlice(true); },
                                           Qt::QueuedConnection);
             }
+            // Genuine split→non-split transition: also drop the TX slice we created
+            // on demand, so it isn't orphaned (matches the GUI split's teardown).
+            removeCreatedTxSlice();
         }
         return rprt(0);
     }

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -1181,6 +1181,27 @@ QString RigctlProtocol::cmdGetSplitFreq()
     return QString("%1\n").arg(hz);
 }
 
+// Establish-on-demand contract shared by set_split_freq / set_split_mode. WSJT-X /
+// Hamlib's set_split_freq_mode can call these directly without a preceding
+// set_split_vfo (or in a window racing slice creation), so we create/promote the
+// TX slice here, matching set_freq VFOB. recordExistingAsEnabled=false: setting a
+// split param must not, by itself, claim THIS client enabled split (that would arm
+// a spurious reclaim). If the create is still pending, stash for tryPromoteTxSlice;
+// else apply to the resolved TX slice; else RPRT -1.
+QString RigctlProtocol::applySplitParam(const std::function<void()>& stashPending,
+                                        const std::function<void(SliceModel*)>& applyToTx)
+{
+    ensureSplitTxSlice(/*recordExistingAsEnabled=*/false);
+    if (m_pendingSplitEnable) {
+        stashPending();
+        return rprt(0);
+    }
+    auto* txSlice = findTxSlice();
+    if (!txSlice) return rprt(-1);
+    applyToTx(txSlice);
+    return rprt(0);
+}
+
 QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
 {
     QStringList parts = args.split(' ', Qt::SkipEmptyParts);
@@ -1188,27 +1209,13 @@ QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
     bool ok = false;
     double hz = parts.isEmpty() ? 0.0 : parts[0].toDouble(&ok);
     if (parts.isEmpty() || !ok) return rprt(-1);
-    // Establish the split TX slice on demand. WSJT-X / Hamlib's set_split_freq_mode
-    // can call set_split_freq directly without a preceding set_split_vfo — or in a
-    // window where the TX slice isn't resolvable yet — so create/promote it here,
-    // matching set_freq VFOB. The in-flight guard in ensureSplitTxSlice prevents a
-    // duplicate when a create is already pending. Without this, a transient race
-    // returns RPRT -1 and aborts the transmit.
-    // recordExistingAsEnabled=false: setting the split freq must not, by itself,
-    // claim that THIS client enabled split (that would arm a spurious reclaim).
-    ensureSplitTxSlice(/*recordExistingAsEnabled=*/false);
-    // If the new slice hasn't appeared yet, stash the freq; tryPromoteTxSlice()
-    // will apply it as soon as the slice becomes visible.
-    if (m_pendingSplitEnable) {
-        m_pendingSplitFreqMHz = hz / 1e6;
-        return rprt(0);
-    }
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
     const double mhz = hz / 1e6;
-    QMetaObject::invokeMethod(txSlice, [txSlice, mhz]{ txSlice->setFrequency(mhz); },
-                              Qt::QueuedConnection);
-    return rprt(0);
+    return applySplitParam(
+        [this, mhz]{ m_pendingSplitFreqMHz = mhz; },
+        [mhz](SliceModel* tx) {
+            QMetaObject::invokeMethod(tx, [tx, mhz]{ tx->setFrequency(mhz); },
+                                      Qt::QueuedConnection);
+        });
 }
 
 QString RigctlProtocol::cmdGetSplitMode()
@@ -1232,20 +1239,12 @@ QString RigctlProtocol::cmdSetSplitMode(const QString& args)
     // Canonical reverse table (same as cmdSetMode); the inline subset passed
     // CWR/RTTYR/WFM through unmapped, sending the radio an invalid mode (#7).
     const QString mode = hamlibToSmartSDR(parts[0]);
-    // Establish the split TX slice on demand (see cmdSetSplitFreq) so a direct
-    // set_split_mode — or one racing slice creation — doesn't hard-fail with -1.
-    // recordExistingAsEnabled=false: see cmdSetSplitFreq.
-    ensureSplitTxSlice(/*recordExistingAsEnabled=*/false);
-    // If the new slice hasn't appeared yet, stash the mode for tryPromoteTxSlice().
-    if (m_pendingSplitEnable) {
-        m_pendingSplitMode = mode;
-        return rprt(0);
-    }
-    auto* txSlice = findTxSlice();
-    if (!txSlice) return rprt(-1);
-    QMetaObject::invokeMethod(txSlice, [txSlice, mode]{ txSlice->setMode(mode); },
-                              Qt::QueuedConnection);
-    return rprt(0);
+    return applySplitParam(
+        [this, mode]{ m_pendingSplitMode = mode; },
+        [mode](SliceModel* tx) {
+            QMetaObject::invokeMethod(tx, [tx, mode]{ tx->setMode(mode); },
+                                      Qt::QueuedConnection);
+        });
 }
 
 QString RigctlProtocol::cmdGetLevel(const QString& arg)

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -999,9 +999,17 @@ QString RigctlProtocol::cmdSetSplitVfo(const QString& args)
     // logger that never toggles split leave the user's TX choice alone.
     const bool wasEnabled = (m_lastSplitEnable == 1);
     const bool firstReport = (m_lastSplitEnable < 0);
-    m_lastSplitEnable = enable ? 1 : 0;
+    // m_lastSplitEnable is set to 0 below on disable, and to 1 inside
+    // ensureSplitTxSlice() ONLY when split actually engages — not blanket-set
+    // here. Two reasons: (1) split can also be enabled implicitly via set_freq/
+    // set_mode VFOB (which calls ensureSplitTxSlice without ever reaching this
+    // function), and that must be recorded so a later set_split_vfo 0 sees the
+    // 1→0 edge and reclaims TX; (2) a set_split_vfo 1 that cannot engage (radio
+    // at its slice limit) must not record "enabled", or the next set_split_vfo 0
+    // would run a spurious reclaim and could steal TX.
 
     if (!enable) {
+        m_lastSplitEnable = 0;
         m_pendingSplitEnable = false;
         m_pendingTxSlice = nullptr;
         m_pendingSplitFreqMHz = 0.0;
@@ -1046,8 +1054,10 @@ void RigctlProtocol::ensureSplitTxSlice()
     if (!m_model) return;
     auto* rxSlice = currentSlice();
     if (!rxSlice) return;
-    if (auto* tx = findTxSlice(/*promote=*/false); tx && tx != rxSlice)
-        return;   // a distinct TX slice already exists
+    if (auto* tx = findTxSlice(/*promote=*/false); tx && tx != rxSlice) {
+        m_lastSplitEnable = 1;   // split already engaged on an existing slice
+        return;                  // a distinct TX slice already exists
+    }
     for (auto* s : m_model->slices()) {
         if (s != rxSlice) {
             m_pendingSplitEnable = false;
@@ -1057,11 +1067,17 @@ void RigctlProtocol::ensureSplitTxSlice()
                 QMetaObject::invokeMethod(s, [s]{ s->setTxSlice(true); },
                                           Qt::QueuedConnection);
             }
+            m_lastSplitEnable = 1;   // engaged by promoting an existing slice
             return;
         }
     }
-    // No second slice — create one and flag for deferred promotion.
+    // No second slice — create one and flag for deferred promotion. Bail if the
+    // radio is at its slice-receiver limit: addSlice() would never land, leaving
+    // split stuck "pending" forever (get_split_freq → -1).
+    if (m_model->slices().size() >= m_model->maxSlices())
+        return;   // could not engage split — leave m_lastSplitEnable untouched
     m_pendingSplitEnable = true;
+    m_lastSplitEnable = 1;   // engaged via create-on-demand (slice in flight)
     auto* model = m_model;
     QMetaObject::invokeMethod(m_model, [model]{ model->addSlice(); },
                               Qt::QueuedConnection);

--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -880,10 +880,21 @@ QString RigctlProtocol::cmdSetPtt(const QString& arg)
     if (parts.isEmpty() || !ok) return rprt(-1);
 
     bool tx = (ptt != 0);
-    QMetaObject::invokeMethod(m_model, [model = m_model, sliceId = m_sliceIndex, tx]() {
-        // When keying TX, move the TX badge to this protocol's bound slice
-        // so the correct slice is used for transmission.
-        if (tx && model->isConnected()) {
+
+    // During split the TX slice is deliberately a DIFFERENT slice (VFOB); keying
+    // must transmit there, not seize TX back to this channel's bound (RX) slice.
+    // Without this gate the seize below moves TX to VFOA on every key, so the radio
+    // transmits on the RX VFO — the WSJT-X "Rig" split symptom. Resolve split on
+    // the CAT thread (same direct-read pattern as cmdGetSplitVfo).
+    auto* txSlice = findTxSlice(/*promote=*/false);
+    auto* rx      = currentSlice();
+    const bool splitActive = (m_lastSplitEnable == 1) && txSlice && rx && txSlice != rx;
+
+    QMetaObject::invokeMethod(m_model, [model = m_model, sliceId = m_sliceIndex, tx, splitActive]() {
+        // Non-split: ensure this protocol's bound slice is the TX slice so the
+        // correct slice is used for transmission. Split: leave the split TX slice
+        // (VFOB) keyed — do NOT seize TX back to the RX slice.
+        if (tx && !splitActive && model->isConnected()) {
             const auto slices = model->slices();
             SliceModel* slice = nullptr;
             for (auto* s : slices) {
@@ -1054,6 +1065,14 @@ void RigctlProtocol::ensureSplitTxSlice()
     if (!m_model) return;
     auto* rxSlice = currentSlice();
     if (!rxSlice) return;
+    // A create from a prior call is still in flight (WSJT-X "Rig" split fires
+    // set_freq/set_mode VFOB in quick succession, each routing here). Don't create
+    // a second TX slice — tryPromoteTxSlice() will promote the pending one, and
+    // apply the stashed split freq/mode, when it appears. Returning here also keeps
+    // that stash intact: the promote-existing path below clears m_pendingSplitEnable
+    // WITHOUT applying the stash, so we must not fall into it while a create is
+    // pending.
+    if (m_pendingSplitEnable) return;
     if (auto* tx = findTxSlice(/*promote=*/false); tx && tx != rxSlice) {
         m_lastSplitEnable = 1;   // split already engaged on an existing slice
         return;                  // a distinct TX slice already exists
@@ -1078,9 +1097,22 @@ void RigctlProtocol::ensureSplitTxSlice()
         return;   // could not engage split — leave m_lastSplitEnable untouched
     m_pendingSplitEnable = true;
     m_lastSplitEnable = 1;   // engaged via create-on-demand (slice in flight)
+    // Create the TX slice on the RX slice's pan AND seeded at the RX frequency,
+    // instead of letting addSlice() pick its default geometry (pan-center + 20% of
+    // the visible bandwidth). WSJT-X "Rig" split sends set_split_freq AFTER the
+    // slice is created, so the new slice must be born on-frequency (TX ≈ RX for
+    // FT8) — otherwise it lands several kHz off and the later set_split_freq has to
+    // tune it as a post-hoc correction that can race the radio's create-status
+    // echo. set_split_freq then only fine-tunes an already-settled slice.
     auto* model = m_model;
-    QMetaObject::invokeMethod(m_model, [model]{ model->addSlice(); },
-                              Qt::QueuedConnection);
+    const QString panId = rxSlice->panId();
+    const double  rxFreqMhz = rxSlice->frequency();
+    QMetaObject::invokeMethod(m_model, [model, panId, rxFreqMhz]{
+        if (panId.isEmpty())
+            model->addSlice();                        // no pan → default geometry
+        else
+            model->addSliceOnPan(panId, rxFreqMhz);   // seed TX slice at RX freq
+    }, Qt::QueuedConnection);
 }
 
 QString RigctlProtocol::cmdGetSplitFreq()
@@ -1101,6 +1133,13 @@ QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
     bool ok = false;
     double hz = parts.isEmpty() ? 0.0 : parts[0].toDouble(&ok);
     if (parts.isEmpty() || !ok) return rprt(-1);
+    // Establish the split TX slice on demand. WSJT-X / Hamlib's set_split_freq_mode
+    // can call set_split_freq directly without a preceding set_split_vfo — or in a
+    // window where the TX slice isn't resolvable yet — so create/promote it here,
+    // matching set_freq VFOB. The in-flight guard in ensureSplitTxSlice prevents a
+    // duplicate when a create is already pending. Without this, a transient race
+    // returns RPRT -1 and aborts the transmit.
+    ensureSplitTxSlice();
     // If the new slice hasn't appeared yet, stash the freq; tryPromoteTxSlice()
     // will apply it as soon as the slice becomes visible.
     if (m_pendingSplitEnable) {
@@ -1136,6 +1175,9 @@ QString RigctlProtocol::cmdSetSplitMode(const QString& args)
     // Canonical reverse table (same as cmdSetMode); the inline subset passed
     // CWR/RTTYR/WFM through unmapped, sending the radio an invalid mode (#7).
     const QString mode = hamlibToSmartSDR(parts[0]);
+    // Establish the split TX slice on demand (see cmdSetSplitFreq) so a direct
+    // set_split_mode — or one racing slice creation — doesn't hard-fail with -1.
+    ensureSplitTxSlice();
     // If the new slice hasn't appeared yet, stash the mode for tryPromoteTxSlice().
     if (m_pendingSplitEnable) {
         m_pendingSplitMode = mode;

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -4,6 +4,7 @@
 #include <QMap>
 #include <QPointer>
 #include <QElapsedTimer>
+#include <functional>
 
 namespace AetherSDR {
 
@@ -117,6 +118,13 @@ private:
     // they don't claim an enable this client never made (would arm a spurious
     // 1→0 reclaim on the next polled set_split_vfo 0).
     void ensureSplitTxSlice(bool recordExistingAsEnabled = true);
+    // Shared on-demand establish+resolve for set_split_freq / set_split_mode:
+    // ensures a split TX slice (without claiming the enable), then either stashes
+    // (create still in flight → RPRT 0), applies to the resolved TX slice (RPRT 0),
+    // or returns RPRT -1 if none can be resolved. Keeps the create-on-demand
+    // contract in one place so the two setters can't diverge.
+    QString applySplitParam(const std::function<void()>& stashPending,
+                            const std::function<void(SliceModel*)>& applyToTx);
     QString rprt(int code) const;
 
     // Mode conversion tables

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <QMap>
+#include <QPointer>
 
 namespace AetherSDR {
 
@@ -14,6 +15,9 @@ class SliceModel;
 class RigctlProtocol {
 public:
     explicit RigctlProtocol(RadioModel* model);
+    // On client disconnect, best-effort remove a TX slice we created on demand for
+    // split (so it isn't orphaned when WSJT-X etc. drops without a clean teardown).
+    ~RigctlProtocol();
 
     // Process one command line (may contain ';' or '|'-separated batch commands).
     // '|' separator enables extended responses joined by '|' (rigctld pipe mode).
@@ -97,6 +101,10 @@ private:
     // newly-created second slice to TX as soon as it appears in the model,
     // then applies any stashed split freq/mode from the burst that preceded it.
     void tryPromoteTxSlice();
+    // Best-effort, crash-safe removal of the on-demand TX slice we created
+    // (m_createdTxSliceId): re-resolves by id at removal time and skips if it's
+    // already gone. No-op when we promoted an existing (operator) slice.
+    void removeCreatedTxSlice();
     // Ensure a distinct TX slice exists, enabling split on demand: promote an
     // existing non-RX slice, or create one (deferred promotion). No-op if a TX
     // slice already exists. Used by set_split_vfo's enable path and by
@@ -121,11 +129,18 @@ private:
     bool m_pendingTxSliceChange{false};  // set when setTxSlice(true) was queued for a non-rx slice
     // Slice we intend to be TX — set synchronously when we queue setTxSlice(true)
     // so findTxSlice() returns the right slice before the event loop fires.
-    SliceModel* m_pendingTxSlice{nullptr};
+    // QPointer (not raw): if the user closes this slice out-of-band, it auto-nulls
+    // so findTxSlice() won't hand back a freed SliceModel and crash on deref
+    // (rigctld runs on the GUI thread, same thread as SliceModel, so this is safe).
+    QPointer<SliceModel> m_pendingTxSlice{nullptr};
     // Stashed split freq/mode from commands that arrived before the new slice
     // existed (single-slice path).  Applied in tryPromoteTxSlice().
     double  m_pendingSplitFreqMHz{0.0};
     QString m_pendingSplitMode;
+    // Id of a TX slice WE created on demand for split (NOT a promoted operator
+    // slice). Removed best-effort on split-disable and on disconnect so it isn't
+    // orphaned. -1 = none. Set in tryPromoteTxSlice (only reached after our create).
+    int     m_createdTxSliceId{-1};
 
     // Tracks the last split state this client reported, so set_split_vfo only
     // reclaims TX on an actual split→non-split *transition* — not on every

--- a/src/core/RigctlProtocol.h
+++ b/src/core/RigctlProtocol.h
@@ -3,6 +3,7 @@
 #include <QString>
 #include <QMap>
 #include <QPointer>
+#include <QElapsedTimer>
 
 namespace AetherSDR {
 
@@ -110,7 +111,12 @@ private:
     // slice already exists. Used by set_split_vfo's enable path and by
     // set_freq/set_mode VFOB — targetable_vfo lets clients address the TX VFO
     // directly without a preceding set_split_vfo (e.g. WSJT-X Rig split).
-    void ensureSplitTxSlice();
+    // recordExistingAsEnabled: when split is ALREADY engaged on a distinct slice,
+    // record m_lastSplitEnable=1 only for enable-intent callers (set_split_vfo 1,
+    // set_freq/set_mode VFOB). Passive set_split_freq/set_split_mode pass false so
+    // they don't claim an enable this client never made (would arm a spurious
+    // 1→0 reclaim on the next polled set_split_vfo 0).
+    void ensureSplitTxSlice(bool recordExistingAsEnabled = true);
     QString rprt(int code) const;
 
     // Mode conversion tables
@@ -126,6 +132,8 @@ private:
     // allows this two-line form and Not1MM contest CW relies on it.
     bool m_pendingMorseLine{false};
     bool m_pendingSplitEnable{false};    // set when split enabled but no second slice existed yet
+    QElapsedTimer m_pendingSplitTimer;   // age of the in-flight create; clears stale pending so a
+                                         // NAK'd/lost create can't wedge split "pending" forever
     bool m_pendingTxSliceChange{false};  // set when setTxSlice(true) was queued for a non-rx slice
     // Slice we intend to be TX — set synchronously when we queue setTxSlice(true)
     // so findTxSlice() returns the right slice before the event loop fires.

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -988,6 +988,95 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
         c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // cleanup
     }
+
+    // 5.12  Implicit-enable reclaim (#3703 bug a). Split enabled IMPLICITLY via
+    //        set_freq VFOB (no preceding set_split_vfo 1) must still record the
+    //        enable, so a later set_split_vfo 0 sees the 1→0 edge and reclaims TX
+    //        back to the RX slice. Before the fix m_lastSplitEnable stayed 0 on the
+    //        implicit path, the reclaim was skipped, and get_split_vfo kept
+    //        reporting Split: 1 after disable.  [needs 2 slices]
+    {
+        // Start from a known-off state.
+        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+        QString s;
+        QElapsedTimer t; t.start();
+        do {
+            s = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (s == QLatin1String("0") || t.elapsed() >= 1500) break;
+            QThread::msleep(100);
+        } while (true);
+
+        // Implicit enable: address the TX VFO directly, with NO set_split_vfo first.
+        c.send(QStringLiteral("\\set_freq VFOB %1").arg(origFreq + 4200));
+        QString on;
+        t.restart();
+        do {
+            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
+            QThread::msleep(200);
+        } while (true);
+
+        if (on == QLatin1String("1")) {
+            // Disable; the recorded implicit enable must drive the 1→0 reclaim so
+            // split reads back off.
+            c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+            QString off;
+            t.restart();
+            do {
+                off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+                if (off == QLatin1String("0") || t.elapsed() >= 2000) break;
+                QThread::msleep(200);
+            } while (true);
+            r.check(QStringLiteral("5.12 implicit enable (set_freq VFOB) reclaims TX on set_split_vfo 0  [needs 2 slices]"),
+                    off == QLatin1String("0"),
+                    QStringLiteral("Split after disable=%1 (must be 0)").arg(off));
+        } else {
+            r.skip(QStringLiteral("5.12 implicit-enable reclaim  [needs 2 slices]"),
+                   QStringLiteral("implicit split did not engage — open a second slice"));
+        }
+    }
+
+    // 5.13  maxSlices guard on create-on-demand (#3703 bug b). On a single-slice-
+    //        capacity receiver, set_split_vfo 1 must NOT arm a phantom deferred
+    //        create that can never land (which left tryPromoteTxSlice hung). It
+    //        should fail to engage cleanly: get_split_freq → RPRT -1.
+    //        Conditional: rigctld exposes no slice-count/capacity query, so we
+    //        infer capacity from whether split engages. If it engages (the radio
+    //        has room or a second slice), the guard path isn't reachable in this
+    //        config → SKIP rather than false-fail.
+    {
+        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // known-off
+        QString off;
+        QElapsedTimer t; t.start();
+        do {
+            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
+            QThread::msleep(100);
+        } while (true);
+
+        c.send(QStringLiteral("\\set_split_vfo 1 VFOB"));
+        QString on;
+        t.restart();
+        do {
+            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
+            QThread::msleep(200);
+        } while (true);
+
+        if (on == QLatin1String("1")) {
+            r.skip(QStringLiteral("5.13 maxSlices guard on create-on-demand"),
+                   QStringLiteral("split engaged — radio has slice capacity, guard path not exercised"));
+        } else {
+            // Split could not engage: the guard fired (single-slice-capacity port).
+            // Confirm it failed CLEANLY — get_split_freq returns RPRT -1, with no
+            // phantom TX slice and no hung pending state.
+            QStringList gsf = c.send(QStringLiteral("\\get_split_freq"));
+            r.check(QStringLiteral("5.13 at-capacity set_split_vfo 1 fails cleanly (get_split_freq RPRT -1)"),
+                    !c.ok(gsf),
+                    gsf.join(QStringLiteral(" | ")));
+        }
+        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // cleanup
+    }
 }
 
 // ═════════════════════════════════════════════════════════════════════════════

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -760,6 +760,25 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
         return c.send(kSplitOff);
     };
 
+    // Poll get_split_vfo until Split == want (or timeout); return the final value.
+    // Replaces the do/while poll loop that was hand-rolled at every split check.
+    auto waitForSplit = [&](QLatin1String want, int timeoutMs) -> QString {
+        QString s;
+        QElapsedTimer t; t.start();
+        do {
+            s = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (s == want || t.elapsed() >= timeoutMs) break;
+            QThread::msleep(150);
+        } while (true);
+        return s;
+    };
+    // Settle-disable split and confirm it reached the off state — the "known-off
+    // baseline" precondition several subtests need.
+    auto resetSplitOff = [&]() {
+        disableSplitSettled();
+        return waitForSplit(QLatin1String("0"), 2000) == QLatin1String("0");
+    };
+
     // 5.1  baseline split state
     QStringList lines = c.send(QStringLiteral("\\get_split_vfo"));
     const QString splitVal = c.field(lines, QStringLiteral("Split"));
@@ -775,19 +794,9 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     r.check(QStringLiteral("5.2  set_split_vfo 1 VFOB returns RPRT 0"), c.ok(lines));
 
     // 5.3  poll until split is confirmed active (creating a new slice takes variable time)
-    QString splitOn;
-    {
-        QElapsedTimer t;
-        t.start();
-        do {
-            lines = c.send(QStringLiteral("\\get_split_vfo"));
-            splitOn = c.field(lines, QStringLiteral("Split"));
-            if (splitOn == QLatin1String("1") || t.elapsed() >= 5000) break;
-            QThread::msleep(200);
-        } while (true);
-    }
+    const QString splitOn = waitForSplit(QLatin1String("1"), 5000);
     r.check(QStringLiteral("5.3  get_split_vfo reports Split: 1  [needs 2 slices in GUI]"),
-            c.ok(lines) && splitOn == QLatin1String("1"),
+            splitOn == QLatin1String("1"),
             QStringLiteral("Split=%1 — open a second slice in AetherSDR if this fails")
                 .arg(splitOn));
 
@@ -929,19 +938,9 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     r.check(QStringLiteral("5.9  set_split_vfo 0 VFOA returns RPRT 0"), c.ok(lines));
 
     // 5.9b  poll until split is confirmed off (slice teardown takes variable time)
-    QString splitOff;
-    {
-        QElapsedTimer t;
-        t.start();
-        do {
-            lines = c.send(QStringLiteral("\\get_split_vfo"));
-            splitOff = c.field(lines, QStringLiteral("Split"));
-            if (splitOff == QLatin1String("0") || t.elapsed() >= 2000) break;
-            QThread::msleep(200);
-        } while (true);
-    }
+    const QString splitOff = waitForSplit(QLatin1String("0"), 2000);
     r.check(QStringLiteral("5.9b get_split_vfo confirms Split: 0 after disable"),
-            c.ok(lines) && splitOff == QLatin1String("0"), splitOff);
+            splitOff == QLatin1String("0"), splitOff);
 
     // 5.10 / 5.10b  deferred stash path: enable split then immediately set freq + mode.
     //               Single-slice: stashed in m_pendingSplitFreqMHz / m_pendingSplitMode,
@@ -977,27 +976,12 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        directly ("set_freq VFOB <hz>" / "set_mode VFOB <mode>") WITHOUT a
     //        preceding set_split_vfo — which previously failed with -8.
     {
-        disableSplitSettled();  // ensure split off
-        QString off;
-        QElapsedTimer t; t.start();
-        do {
-            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
-            QThread::msleep(100);
-        } while (true);
-
+        resetSplitOff();  // ensure split off
         lines = c.send(QStringLiteral("\\set_freq VFOB %1").arg(origFreq + 2500));
         r.check(QStringLiteral("5.11 set_freq VFOB with split off auto-enables split (RPRT 0, not -8)"),
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
 
-        disableSplitSettled();  // reset, then re-test mode path
-        t.restart();
-        do {
-            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
-            QThread::msleep(100);
-        } while (true);
-
+        resetSplitOff();  // reset, then re-test mode path
         lines = c.send(QStringLiteral("\\set_mode VFOB PKTUSB -1"));
         r.check(QStringLiteral("5.11 set_mode VFOB with split off auto-enables split (RPRT 0, not -8)"),
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
@@ -1011,37 +995,15 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        implicit path, the reclaim was skipped, and get_split_vfo kept
     //        reporting Split: 1 after disable.  [needs 2 slices]
     {
-        // Start from a known-off state.
-        disableSplitSettled();
-        QString s;
-        QElapsedTimer t; t.start();
-        do {
-            s = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (s == QLatin1String("0") || t.elapsed() >= 1500) break;
-            QThread::msleep(100);
-        } while (true);
-
+        resetSplitOff();  // known-off baseline
         // Implicit enable: address the TX VFO directly, with NO set_split_vfo first.
         c.send(QStringLiteral("\\set_freq VFOB %1").arg(origFreq + 4200));
-        QString on;
-        t.restart();
-        do {
-            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
-            QThread::msleep(200);
-        } while (true);
-
+        const QString on = waitForSplit(QLatin1String("1"), 5000);
         if (on == QLatin1String("1")) {
             // Disable; the recorded implicit enable must drive the 1→0 reclaim so
             // split reads back off.
             disableSplitSettled();
-            QString off;
-            t.restart();
-            do {
-                off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-                if (off == QLatin1String("0") || t.elapsed() >= 2000) break;
-                QThread::msleep(200);
-            } while (true);
+            const QString off = waitForSplit(QLatin1String("0"), 2000);
             r.check(QStringLiteral("5.12 implicit enable (set_freq VFOB) reclaims TX on set_split_vfo 0  [needs 2 slices]"),
                     off == QLatin1String("0"),
                     QStringLiteral("Split after disable=%1 (must be 0)").arg(off));
@@ -1060,24 +1022,9 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        has room or a second slice), the guard path isn't reachable in this
     //        config → SKIP rather than false-fail.
     {
-        disableSplitSettled();  // known-off
-        QString off;
-        QElapsedTimer t; t.start();
-        do {
-            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
-            QThread::msleep(100);
-        } while (true);
-
+        resetSplitOff();  // known-off
         c.send(QStringLiteral("\\set_split_vfo 1 VFOB"));
-        QString on;
-        t.restart();
-        do {
-            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
-            QThread::msleep(200);
-        } while (true);
-
+        const QString on = waitForSplit(QLatin1String("1"), 5000);
         if (on == QLatin1String("1")) {
             r.skip(QStringLiteral("5.13 maxSlices guard on create-on-demand"),
                    QStringLiteral("split engaged — radio has slice capacity, guard path not exercised"));
@@ -1100,27 +1047,14 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        (which aborts the transmit); it should create/promote the TX slice and
     //        engage split. Before the fix, set_split_freq with no TX slice → -1.
     {
-        // Known-off baseline.
-        disableSplitSettled();
-        QString off; QElapsedTimer t; t.start();
-        do {
-            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
-            QThread::msleep(100);
-        } while (true);
-
+        resetSplitOff();  // known-off baseline
         // Direct set_split_freq with NO preceding set_split_vfo.
         lines = c.send(QStringLiteral("\\set_split_freq %1").arg(origFreq + 2500));
         r.check(QStringLiteral("5.14 set_split_freq with split off establishes split on demand (RPRT 0, not -1)"),
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
 
         // Split should engage (slice created or promoted) shortly after.
-        QString on; t.restart();
-        do {
-            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
-            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
-            QThread::msleep(200);
-        } while (true);
+        const QString on = waitForSplit(QLatin1String("1"), 5000);
         r.check(QStringLiteral("5.14 split active after on-demand set_split_freq  [needs a free slice]"),
                 on == QLatin1String("1"), QStringLiteral("Split=%1").arg(on));
 

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -745,6 +745,21 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     r.section(QStringLiteral("Section 5 — Split VFO"));
     const qint64 splitTxFreq = origFreq + 1000;
 
+    // ── DAX-assign settle guard ──────────────────────────────────────────────
+    // Closing a TX slice we created on demand frees its SliceModel. If a deferred
+    // DAX-channel-assign timer is still pending — it's armed on sliceAdded when a
+    // DAX/TCI audio client is active, e.g. after WSJT-X has been used on this radio
+    // — it fires on the freed slice and crashes ASDR. A real client never creates
+    // and removes a split slice this fast; only this test does. So settle before
+    // every on-demand split teardown to let that timer fire on the LIVE slice
+    // first. (The underlying DAX-timer UAF is a separate, app-side issue.)
+    constexpr int kDaxSettleMs = 700;
+    const QString kSplitOff = QStringLiteral("\\set_split_vfo 0 VFOA");
+    auto disableSplitSettled = [&]() {
+        QThread::msleep(kDaxSettleMs);
+        return c.send(kSplitOff);
+    };
+
     // 5.1  baseline split state
     QStringList lines = c.send(QStringLiteral("\\get_split_vfo"));
     const QString splitVal = c.field(lines, QStringLiteral("Split"));
@@ -910,7 +925,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
             QStringLiteral("Split=%1").arg(splitF));
 
     // 5.9  disable split and verify
-    lines = c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+    lines = disableSplitSettled();
     r.check(QStringLiteral("5.9  set_split_vfo 0 VFOA returns RPRT 0"), c.ok(lines));
 
     // 5.9b  poll until split is confirmed off (slice teardown takes variable time)
@@ -954,7 +969,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     r.check(QStringLiteral("5.10b stashed split freq applied to TX slice"),
             stashConfirm > 0 && qAbs(stashConfirm - stashFreq) < 100,
             QStringLiteral("expected≈%1 got=%2").arg(stashFreq).arg(stashConfirm));
-    c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+    disableSplitSettled();
 
     // 5.11  Targetable VFOB: with split OFF, set_freq/set_mode VFOB must enable
     //        split on demand and succeed (RPRT 0), not RPRT -8. We advertise
@@ -962,7 +977,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        directly ("set_freq VFOB <hz>" / "set_mode VFOB <mode>") WITHOUT a
     //        preceding set_split_vfo — which previously failed with -8.
     {
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // ensure split off
+        disableSplitSettled();  // ensure split off
         QString off;
         QElapsedTimer t; t.start();
         do {
@@ -975,7 +990,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
         r.check(QStringLiteral("5.11 set_freq VFOB with split off auto-enables split (RPRT 0, not -8)"),
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
 
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // reset, then re-test mode path
+        disableSplitSettled();  // reset, then re-test mode path
         t.restart();
         do {
             off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
@@ -986,7 +1001,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
         lines = c.send(QStringLiteral("\\set_mode VFOB PKTUSB -1"));
         r.check(QStringLiteral("5.11 set_mode VFOB with split off auto-enables split (RPRT 0, not -8)"),
                 c.ok(lines), lines.join(QStringLiteral(" | ")));
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // cleanup
+        disableSplitSettled();  // cleanup
     }
 
     // 5.12  Implicit-enable reclaim (#3703 bug a). Split enabled IMPLICITLY via
@@ -997,7 +1012,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        reporting Split: 1 after disable.  [needs 2 slices]
     {
         // Start from a known-off state.
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+        disableSplitSettled();
         QString s;
         QElapsedTimer t; t.start();
         do {
@@ -1019,7 +1034,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
         if (on == QLatin1String("1")) {
             // Disable; the recorded implicit enable must drive the 1→0 reclaim so
             // split reads back off.
-            c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));
+            disableSplitSettled();
             QString off;
             t.restart();
             do {
@@ -1045,7 +1060,7 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     //        has room or a second slice), the guard path isn't reachable in this
     //        config → SKIP rather than false-fail.
     {
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // known-off
+        disableSplitSettled();  // known-off
         QString off;
         QElapsedTimer t; t.start();
         do {
@@ -1075,7 +1090,46 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
                     !c.ok(gsf),
                     gsf.join(QStringLiteral(" | ")));
         }
-        c.send(QStringLiteral("\\set_split_vfo 0 VFOA"));  // cleanup
+        disableSplitSettled();  // cleanup
+    }
+
+    // 5.14  set_split_freq / set_split_mode establish split on demand (#3703
+    //        create-on-demand). WSJT-X "Rig" split (via Hamlib set_split_freq_mode)
+    //        can call set_split_freq directly — without a preceding set_split_vfo 1,
+    //        or in a window racing slice creation. It must NOT return RPRT -1
+    //        (which aborts the transmit); it should create/promote the TX slice and
+    //        engage split. Before the fix, set_split_freq with no TX slice → -1.
+    {
+        // Known-off baseline.
+        disableSplitSettled();
+        QString off; QElapsedTimer t; t.start();
+        do {
+            off = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (off == QLatin1String("0") || t.elapsed() >= 1500) break;
+            QThread::msleep(100);
+        } while (true);
+
+        // Direct set_split_freq with NO preceding set_split_vfo.
+        lines = c.send(QStringLiteral("\\set_split_freq %1").arg(origFreq + 2500));
+        r.check(QStringLiteral("5.14 set_split_freq with split off establishes split on demand (RPRT 0, not -1)"),
+                c.ok(lines), lines.join(QStringLiteral(" | ")));
+
+        // Split should engage (slice created or promoted) shortly after.
+        QString on; t.restart();
+        do {
+            on = c.field(c.send(QStringLiteral("\\get_split_vfo")), QStringLiteral("Split"));
+            if (on == QLatin1String("1") || t.elapsed() >= 5000) break;
+            QThread::msleep(200);
+        } while (true);
+        r.check(QStringLiteral("5.14 split active after on-demand set_split_freq  [needs a free slice]"),
+                on == QLatin1String("1"), QStringLiteral("Split=%1").arg(on));
+
+        // set_split_mode must likewise establish-on-demand, never -1.
+        lines = c.send(QStringLiteral("\\set_split_mode USB 2700"));
+        r.check(QStringLiteral("5.14 set_split_mode after on-demand establish returns RPRT 0"),
+                c.ok(lines), lines.join(QStringLiteral(" | ")));
+
+        disableSplitSettled();  // cleanup
     }
 }
 


### PR DESCRIPTION

> ⚠️ **Filed as a draft PR — holding until after the current release cycle.** The work is complete, reviewed,
> and tested across platforms; it is intentionally kept in draft so it doesn't land mid-cycle. It will be
> marked ready for review once the current release cycle closes.

## Summary
This started as the rigctld-vs-SmartSDR **behavior-difference** fixes from the #3703 triage. While
implementing and testing them, integration testing with WSJT-X "Rig" split surfaced several **real split-VFO bugs**, which are fixed here too. Finally, the regression test — which had accreted a lot of one-off tweaks — is **cleaned up** after adding coverage for the new behavior.

### 1. rigctld behavior alignment (#3703 triage)
- **Implicit-enable state**: split enabled via `set_freq`/`set_mode VFOB` (WSJT-X "Rig" split) is now
  recorded, so a later `set_split_vfo 0` reclaims TX to the RX slice.
- **`maxSlices` guard**: at capacity, `set_split_vfo 1` fails cleanly instead of arming a create that can
  never land (which left split stuck "pending").

### 2. Split-VFO fixes found during integration testing (WSJT-X "Rig" split)
- **TX frequency**: the on-demand TX slice is created **at the RX frequency** instead of `addSlice()`'s default geometry (it was landing several kHz off).
- **No duplicate slice**: an in-flight guard stops back-to-back `set_freq`/`set_mode VFOB` from creating two TX slices.
- **PTT routing**: keying transmits on the split slice (**VFOB**), not the RX VFO — previously the PTT path seized TX back to VFOA, so the radio transmitted on the wrong VFO.
- **Establish-on-demand**: `set_split_freq`/`set_split_mode` now create/promote the TX slice rather than returning `RPRT -1` and aborting the transmit on a race.
- **Cleanup**: best-effort removal of the slice **we** created on disable/disconnect; operator-owned slices are never removed.
- **Crash fix**: closing the split TX slice out-of-band no longer causes a use-after-free (`m_pendingTxSlice` is now `QPointer`-guarded).

### 3. Code-review hardening
A high-effort review of the above produced three further fixes: a **time-bounded** in-flight guard so a
NAK'd/lost create (incl. Multi-Flex where the local slice count understates the radio's) can't wedge split
"pending" forever; PTT no longer seizes TX **during** the create window; and a passive
`set_split_freq`/`set_split_mode` no longer arms a phantom reclaim edge that could steal TX off a slice the client never put into split.

### 4. Tests
- **Added** coverage for the new behavior: `5.12` implicit-enable reclaim, `5.13` `maxSlices` guard
  (conditional), `5.14` `set_split_freq`/`set_split_mode` establish-on-demand.
- **Cleaned up** the regression test: the repeated "poll `get_split_vfo` until 0/1" loops (≈8 copies) are
  factored into `waitForSplit()` / `resetSplitOff()` helpers, and the `set_split_freq`/`set_split_mode`
  create-on-demand prologue is shared via `applySplitParam()`. Net ≈70 fewer lines.
- `rigctld_test`: **183/184**. The one failure (`5.10b`) is a documented single-slice create-status-echo
  **timing race** that is slice-count dependent (passes on the promote path); it is not a regression from
  this PR.

### Scope / deferred
This grew beyond the original #3703 triage (two narrow bugs) into making WSJT-X "Rig" split work end-to-end. The remaining create-on-demand fragilities the review confirmed — operator-slice mis-target (no create-ack id), id reuse, fast-disable orphan, shutdown-time deref — are deferred to the slice-lifecycle **RFC #3715**, whose create-ack id / handle is the proper fix. A separate, app-side **DAX-assign-timer UAF** (only reachable by the test's rapid create/remove churn, not normal client use) is tracked as a to-do; the test settles around it.

Addresses #3703 (triage bugs fixed; the create-on-demand-vs-`NOT_ENABLED` policy alignment is deferred to #3715). Refs #3715.

---
Built and regression tested on MacOS (M2), Linux (RPi 5) and Windows 11. Integration testing (WSJT-X 3.0.0, fldigi-4.2) on MacOS (M2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
