### PR TITLE
feat(automation): TX automation hardening for the agent automation bridge

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -21,6 +21,8 @@
 #include <QStandardPaths>
 #include <QCoreApplication>
 #include <QRegularExpression>
+#include <QTimer>
+#include <QDateTime>
 
 // Best-effort value extraction for common control types.
 #include <QAbstractButton>
@@ -321,6 +323,23 @@ QJsonObject radioSnapshot(const RadioModel* r)
 // and APD. Lets a QA scenario assert that a TX/Phone/CW applet control actually
 // reached the radio model, not just the widget (#3646 QA finding 2). Read-only:
 // keying state (mox/tune/transmitting) is reported but never driven from here.
+QString atuStatusName(ATUStatus s)
+{
+    switch (s) {
+    case ATUStatus::None:         return QStringLiteral("none");
+    case ATUStatus::NotStarted:   return QStringLiteral("not_started");
+    case ATUStatus::InProgress:   return QStringLiteral("in_progress");
+    case ATUStatus::Bypass:       return QStringLiteral("bypass");
+    case ATUStatus::Successful:   return QStringLiteral("successful");
+    case ATUStatus::OK:           return QStringLiteral("ok");
+    case ATUStatus::FailBypass:   return QStringLiteral("fail_bypass");
+    case ATUStatus::Fail:         return QStringLiteral("fail");
+    case ATUStatus::Aborted:      return QStringLiteral("aborted");
+    case ATUStatus::ManualBypass: return QStringLiteral("manual_bypass");
+    }
+    return QStringLiteral("unknown");
+}
+
 QJsonObject transmitSnapshot(const TransmitModel* t)
 {
     return QJsonObject{
@@ -363,6 +382,7 @@ QJsonObject transmitSnapshot(const TransmitModel* t)
         // ATU / APD
         {QStringLiteral("atuEnabled"),      t->atuEnabled()},
         {QStringLiteral("atuMemories"),     t->memoriesEnabled()},
+        {QStringLiteral("atuStatus"),       atuStatusName(t->atuStatus())},
         {QStringLiteral("apdEnabled"),      t->apdEnabled()},
     };
 }
@@ -383,6 +403,38 @@ QJsonObject equalizerSnapshot(const EqualizerModel* e)
         {QStringLiteral("txEnabled"), e->txEnabled()},
         {QStringLiteral("rx"), rx},
         {QStringLiteral("tx"), tx},
+    };
+}
+
+// Live meter readout. The flat convenience fields are the headline TX meters
+// with their freshness age (ms since last update, -1 if never) so a reader can
+// reject stale values — critical because some meters (notably PACURRENT) are
+// only reported ~1 s into a transmit. `all` carries every defined meter with
+// per-meter index/source_index/age_ms so duplicate-named meters (one live, one
+// floored) are distinguishable. (#3646)
+QJsonObject metersSnapshot(MeterModel* m)
+{
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    auto age = [now](qint64 ts) -> qint64 { return ts > 0 ? now - ts : -1; };
+    return QJsonObject{
+        {QStringLiteral("fwdPower"),        m->fwdPower()},           // Watts (smoothed)
+        {QStringLiteral("fwdPowerInstant"), m->fwdPowerInstant()},    // Watts (peak)
+        {QStringLiteral("fwdPowerAgeMs"),   age(m->fwdPowerUpdatedAtMs())},
+        {QStringLiteral("swr"),             m->swr()},
+        {QStringLiteral("swrAgeMs"),        age(m->swrUpdatedAtMs())},
+        {QStringLiteral("paTemp"),          m->paTemp()},             // °C
+        {QStringLiteral("supplyVolts"),     m->supplyVolts()},        // V
+        {QStringLiteral("swAlc"),           m->swAlc()},              // dBFS post-ALC SSB peak
+        {QStringLiteral("hwAlc"),           m->hwAlc()},              // dBFS external HW-ALC
+        {QStringLiteral("micPeak"),         m->micPeak()},            // dBFS
+        {QStringLiteral("micLevel"),        m->micLevel()},           // dBFS
+        {QStringLiteral("compPeak"),        m->compPeak()},           // dB compression (peak)
+        {QStringLiteral("compLevel"),       m->compLevel()},          // dB compression
+        {QStringLiteral("hasCompression"),  m->hasCompressionMeterValue()},
+        {QStringLiteral("sLevel"),          m->sLevel()},             // dBm
+        {QStringLiteral("txMetersFresh"),   m->hasRecentTxMeters(2000)},
+        {QStringLiteral("txMetersAgeMs"),   age(m->txMetersUpdatedAtMs())},
+        {QStringLiteral("all"),             m->allMeters()},          // every meter + age_ms
     };
 }
 
@@ -442,9 +494,28 @@ bool AutomationServer::start(const QString& serverName)
         m_discoveryFile.clear();
     }
 
+    // TX safety rails (#3646): when the operator has enabled transmit
+    // automation, arm a watchdog that force-unkeys the radio if it stays keyed
+    // past a limit — a backstop independent of whatever script is driving us.
+    m_txAllowed = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
+    if (m_txAllowed) {
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_MS"))
+            m_txMaxKeyMs = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_MS");
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_POWER"))
+            m_txMaxPower = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_POWER");
+        m_txWatchdog = new QTimer(this);
+        m_txWatchdog->setInterval(500);
+        connect(m_txWatchdog, &QTimer::timeout, this, &AutomationServer::onTxWatchdog);
+        m_txWatchdog->start();
+        qCInfo(lcAutomation).noquote()
+            << "TX automation ENABLED — watchdog max key" << m_txMaxKeyMs << "ms,"
+            << "power ceiling" << (m_txMaxPower < 0 ? QStringLiteral("none")
+                                                    : QString::number(m_txMaxPower));
+    }
+
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, grab)";
+        << "(verbs: ping, dumpTree, grab, invoke, get, txtest, atu)";
     return true;
 }
 
@@ -452,6 +523,15 @@ void AutomationServer::stop()
 {
     if (!m_server)
         return;
+
+    // Safety: never leave the radio keyed when the bridge shuts down.
+    if (m_txAllowed)
+        forceUnkey("automation bridge stopping");
+    if (m_txWatchdog) {
+        m_txWatchdog->stop();
+        m_txWatchdog->deleteLater();
+        m_txWatchdog = nullptr;
+    }
 
     for (auto it = m_buffers.constBegin(); it != m_buffers.constEnd(); ++it)
         it.key()->deleteLater();
@@ -565,6 +645,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
             value = rest.join(QLatin1Char(' '));
         } else if (cmd == QLatin1String("get")) {
             model = tok(1); selector = tok(2); property = tok(3);
+        } else if (cmd == QLatin1String("txtest") || cmd == QLatin1String("atu")) {
+            action = tok(1);  // e.g. "txtest twotone", "atu bypass"
         } else {  // grab and friends
             target = tok(1); path = tok(2);
         }
@@ -593,8 +675,18 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
     }
     if (cmd == QLatin1String("get")) {
         if (model.isEmpty())
-            return err(QStringLiteral("get requires a model (radio|slice|slices|pan|pans)"));
+            return err(QStringLiteral("get requires a model (radio|transmit|meters|slice|slices|pan|pans)"));
         return doGet(model, selector, property);
+    }
+    if (cmd == QLatin1String("txtest")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("txtest requires an action (twotone|off)"));
+        return doTxTest(action);
+    }
+    if (cmd == QLatin1String("atu")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("atu requires an action (bypass|start)"));
+        return doAtu(action);
     }
 
     return err(QStringLiteral("unknown command: ") + cmd);
@@ -744,6 +836,23 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
                                     "Set AETHER_AUTOMATION_ALLOW_TX=1 to override."));
     }
 
+    // Power-ceiling rail (#3646): clamp RF/Tune power setpoints to the
+    // configured max (AETHER_AUTOMATION_TX_MAX_POWER) so automation can't
+    // command more power than the connected load can take.
+    QString effValue = value;
+    if (m_txMaxPower >= 0 && action == QLatin1String("setValue")) {
+        const QString an = w->accessibleName();
+        if (an == QLatin1String("RF power") || an == QLatin1String("Tune power")) {
+            bool okN = false;
+            const int n = value.toInt(&okN);
+            if (okN && n > m_txMaxPower) {
+                effValue = QString::number(m_txMaxPower);
+                qCWarning(lcAutomation).noquote()
+                    << "power ceiling: clamped" << an << n << "->" << m_txMaxPower;
+            }
+        }
+    }
+
     bool done = false;
     if (action == QLatin1String("click")) {
         if (auto* b = qobject_cast<QAbstractButton*>(w)) { b->click(); done = true; }
@@ -758,7 +867,7 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         }
     } else if (action == QLatin1String("setValue")) {
         bool okNum = false;
-        const int n = value.toInt(&okNum);
+        const int n = effValue.toInt(&okNum);
         if (auto* s = qobject_cast<QAbstractSlider*>(w)) {
             if (!okNum) return err(QStringLiteral("setValue needs an integer"));
             s->setValue(n); done = true;
@@ -766,7 +875,7 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
             if (!okNum) return err(QStringLiteral("setValue needs an integer"));
             sb->setValue(n); done = true;
         } else if (auto* ds = qobject_cast<QDoubleSpinBox*>(w)) {
-            bool okD = false; const double d = value.toDouble(&okD);
+            bool okD = false; const double d = effValue.toDouble(&okD);
             if (!okD) return err(QStringLiteral("setValue needs a number"));
             ds->setValue(d); done = true;
         }
@@ -816,6 +925,8 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = transmitSnapshot(&radio->transmitModel());
     } else if (model == QLatin1String("equalizer") || model == QLatin1String("eq")) {
         data = equalizerSnapshot(&radio->equalizerModel());
+    } else if (model == QLatin1String("meters")) {
+        data = metersSnapshot(&radio->meterModel());
     } else if (model == QLatin1String("slices")) {
         QJsonArray arr;
         for (const SliceModel* s : radio->slices()) arr.append(sliceSnapshot(s));
@@ -850,7 +961,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use radio|transmit|equalizer|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {
@@ -869,6 +980,95 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         {QStringLiteral("model"), model},
         {model, data},   // keyed by model name: "radio" / "slice" / "pan"
     };
+}
+
+// ── TX test-signal control (#3646) ──────────────────────────────────────────
+// `txtest twotone` starts the radio's two-tone test (a modulated signal that
+// exercises ALC / PEP / linearity meters a steady carrier can't). `txtest off`
+// stops it. Keying is gated by AETHER_AUTOMATION_ALLOW_TX, and the TX watchdog
+// still backstops it. NOTE: two-tone does not pass through the mic/speech
+// processor, so it does not exercise the compression meter — that needs a real
+// mic-audio source (DAX TX), which is a separate, larger effort.
+QJsonObject AutomationServer::doTxTest(const QString& action)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    auto& tx = m_radioModel->transmitModel();
+
+    if (action == QLatin1String("off") || action == QLatin1String("stop")) {
+        tx.stopTune();
+        m_txKeyedSinceMs = 0;
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("txtest"), QStringLiteral("off")}};
+    }
+    if (action == QLatin1String("twotone")) {
+        if (!m_txAllowed)
+            return err(QStringLiteral("blocked: txtest keys the transmitter — "
+                                      "set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
+        tx.startTwoToneTune();
+        m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();  // arm watchdog window
+        qCInfo(lcAutomation) << "txtest two-tone started (ALLOW_TX)";
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("txtest"), QStringLiteral("twotone")}};
+    }
+    return err(QStringLiteral("unknown txtest action: ") + action + QStringLiteral(" (twotone|off)"));
+}
+
+// ── ATU control (#3646) ─────────────────────────────────────────────────────
+// `atu bypass` takes the tuner out of circuit (no TX), so meter readings see
+// the raw load instead of a recalled antenna match — essential before TX meter
+// measurements. `atu start` runs a tune cycle (keys TX → gated by ALLOW_TX).
+QJsonObject AutomationServer::doAtu(const QString& action)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    auto& tx = m_radioModel->transmitModel();
+
+    if (action == QLatin1String("bypass")) {
+        tx.atuBypass();   // relay switch only — does not transmit
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("atu"), QStringLiteral("bypass")}};
+    }
+    if (action == QLatin1String("start") || action == QLatin1String("tune")) {
+        if (!m_txAllowed)
+            return err(QStringLiteral("blocked: atu start keys the transmitter — "
+                                      "set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
+        tx.atuStart();
+        m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("atu"), QStringLiteral("start")}};
+    }
+    return err(QStringLiteral("unknown atu action: ") + action + QStringLiteral(" (bypass|start)"));
+}
+
+// Emergency all-stop: drop tune, two-tone, and MOX immediately. Used by the
+// watchdog and stop().
+void AutomationServer::forceUnkey(const char* reason)
+{
+    if (!m_radioModel)
+        return;
+    auto& tx = m_radioModel->transmitModel();
+    tx.stopTune();
+    tx.setMox(false);
+    m_txKeyedSinceMs = 0;
+    qCWarning(lcAutomation).noquote() << "TX force-unkey:" << reason;
+}
+
+// TX safety watchdog (#3646). Runs only when AETHER_AUTOMATION_ALLOW_TX is set.
+// Tracks how long the radio has been continuously keyed and force-unkeys past
+// the limit, so a hung or abandoned automation script can never leave a live
+// transmitter on. The limit is AETHER_AUTOMATION_TX_MAX_MS (default 20 s).
+void AutomationServer::onTxWatchdog()
+{
+    if (!m_radioModel)
+        return;
+    const auto& tx = m_radioModel->transmitModel();
+    const bool keyed = tx.isTransmitting() || tx.isTuning() || tx.isMox();
+    if (!keyed) {
+        m_txKeyedSinceMs = 0;
+        return;
+    }
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (m_txKeyedSinceMs == 0)
+        m_txKeyedSinceMs = now;
+    else if (now - m_txKeyedSinceMs > m_txMaxKeyMs)
+        forceUnkey("max continuous key time exceeded");
 }
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -406,16 +406,47 @@ QJsonObject equalizerSnapshot(const EqualizerModel* e)
     };
 }
 
+// Annotate meters known to be unreliable on the connected radio, mirroring the
+// curation the UI already does, so a consumer of the raw `all` table doesn't
+// trust a bad reading. Today this is exactly one entry: PACURRENT on the
+// FLEX-8000 series, where the declared 10 A meter range is below real PA draw so
+// it clips (SMART-11281) — the GUI omits it (see MeterApplet.h), and freshness
+// (age_ms) can't catch a fresh-but-clipped value. Keep this list in sync with
+// the UI; it is intentionally a small explicit table, not a heuristic. (#3729)
+QString unreliableMeterNote(const QString& meterName, const QString& radioModel)
+{
+    if (meterName == QLatin1String("PACURRENT")
+        && radioModel.startsWith(QStringLiteral("FLEX-8"))) {
+        return QStringLiteral("clips at the declared 10A cap on FLEX-8000 series "
+                              "(SMART-11281); omitted from the UI — do not trust");
+    }
+    return QString();
+}
+
 // Live meter readout. The flat convenience fields are the headline TX meters
 // with their freshness age (ms since last update, -1 if never) so a reader can
 // reject stale values — critical because some meters (notably PACURRENT) are
 // only reported ~1 s into a transmit. `all` carries every defined meter with
 // per-meter index/source_index/age_ms so duplicate-named meters (one live, one
-// floored) are distinguishable. (#3646)
-QJsonObject metersSnapshot(MeterModel* m)
+// floored) are distinguishable, plus a `reliable:false`+`note` flag on meters
+// known-bad for the connected radio. (#3646, #3729)
+QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
 {
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     auto age = [now](qint64 ts) -> qint64 { return ts > 0 ? now - ts : -1; };
+
+    QJsonArray all = m->allMeters();
+    for (int i = 0; i < all.size(); ++i) {
+        QJsonObject meter = all[i].toObject();
+        const QString note = unreliableMeterNote(meter.value(QStringLiteral("name")).toString(),
+                                                 radioModel);
+        if (!note.isEmpty()) {
+            meter[QStringLiteral("reliable")] = false;
+            meter[QStringLiteral("note")]     = note;
+            all[i] = meter;
+        }
+    }
+
     return QJsonObject{
         {QStringLiteral("fwdPower"),        m->fwdPower()},           // Watts (smoothed)
         {QStringLiteral("fwdPowerInstant"), m->fwdPowerInstant()},    // Watts (peak)
@@ -434,7 +465,7 @@ QJsonObject metersSnapshot(MeterModel* m)
         {QStringLiteral("sLevel"),          m->sLevel()},             // dBm
         {QStringLiteral("txMetersFresh"),   m->hasRecentTxMeters(2000)},
         {QStringLiteral("txMetersAgeMs"),   age(m->txMetersUpdatedAtMs())},
-        {QStringLiteral("all"),             m->allMeters()},          // every meter + age_ms
+        {QStringLiteral("all"),             all},                     // every meter + age_ms + reliability
     };
 }
 
@@ -926,7 +957,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
     } else if (model == QLatin1String("equalizer") || model == QLatin1String("eq")) {
         data = equalizerSnapshot(&radio->equalizerModel());
     } else if (model == QLatin1String("meters")) {
-        data = metersSnapshot(&radio->meterModel());
+        data = metersSnapshot(&radio->meterModel(), radio->model());
     } else if (model == QLatin1String("slices")) {
         QJsonArray arr;
         for (const SliceModel* s : radio->slices()) arr.append(sliceSnapshot(s));

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -10,6 +10,7 @@ class QLocalServer;
 class QLocalSocket;
 class QWidget;
 class QJsonObject;
+class QTimer;
 
 namespace AetherSDR {
 
@@ -93,6 +94,11 @@ private slots:
     void onReadyRead();
     void onDisconnected();
 
+    // TX safety watchdog (#3646): polls TX state and force-unkeys the radio if
+    // it has been keyed continuously past the limit, so a hung/abandoned
+    // automation script can never leave a live transmitter on.
+    void onTxWatchdog();
+
 private:
     // Dispatch a single request line and return the response object.
     QJsonObject handleLine(const QByteArray& line);
@@ -103,6 +109,12 @@ private:
                          const QString& value) const;
     QJsonObject doGet(const QString& model, const QString& selector,
                       const QString& property) const;
+    // TX test-signal control (two-tone) and ATU control. Both gated by
+    // AETHER_AUTOMATION_ALLOW_TX where they key the transmitter.
+    QJsonObject doTxTest(const QString& action);
+    QJsonObject doAtu(const QString& action);
+
+    void forceUnkey(const char* reason);  // emergency all-stop (tune/mox/two-tone)
 
     // Resolve a target string to a widget: exact objectName first, then
     // class name (with or without namespace) or accessibleName.
@@ -113,6 +125,13 @@ private:
     QString       m_discoveryFile;
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
+
+    // TX safety rails (active only when AETHER_AUTOMATION_ALLOW_TX is set).
+    QTimer* m_txWatchdog{nullptr};
+    qint64  m_txKeyedSinceMs{0};   // when continuous key-down started (0 = idle)
+    int     m_txMaxKeyMs{20000};   // max continuous key time before force-unkey
+    int     m_txMaxPower{-1};      // power-ceiling clamp for invoke (-1 = off)
+    bool    m_txAllowed{false};    // AETHER_AUTOMATION_ALLOW_TX at start()
 };
 
 } // namespace AetherSDR

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -21,7 +21,7 @@ float compressionValueForGauge(float compPeakDb)
     return qBound(0.0f, compPeakDb, 25.0f);
 }
 
-QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
+QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value, qint64 ageMs)
 {
     QJsonObject obj;
     obj["index"] = def.index;
@@ -34,6 +34,10 @@ QJsonObject meterToJson(const MeterDef& def, bool hasValue, float value)
     obj["description"] = def.description;
     obj["has_value"] = hasValue;
     obj["value"] = hasValue ? QJsonValue(value) : QJsonValue();
+    // Milliseconds since this meter's value last updated (-1 = never). Lets a
+    // consumer reject stale reads — a value with a large/-1 age is not a live
+    // measurement (e.g. PACURRENT before the radio first reports it). (#3646)
+    obj["age_ms"] = hasValue ? QJsonValue(ageMs) : QJsonValue(-1);
     return obj;
 }
 
@@ -147,6 +151,7 @@ void MeterModel::removeMeter(int index)
 {
     m_defs.remove(index);
     m_values.remove(index);
+    m_valueUpdatedMs.remove(index);
 
     // Remove from per-slice LEVEL map
     for (auto it = m_sLevelIdxBySlice.begin(); it != m_sLevelIdxBySlice.end(); ) {
@@ -222,6 +227,7 @@ void MeterModel::clear()
 {
     m_defs.clear();
     m_values.clear();
+    m_valueUpdatedMs.clear();
     m_sLevelIdxBySlice.clear();
     m_escLevelIdxBySlice.clear();
     m_compPeakIdxByTxSource.clear();
@@ -433,6 +439,7 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
 
         const float v = convertRaw(*it, vals[i]);
         m_values[idx] = v;
+        m_valueUpdatedMs[idx] = packetUpdatedMs;  // per-meter freshness (#3646)
 
         // Check if this meter is a per-slice LEVEL meter
         bool isSliceLevel = false;
@@ -578,10 +585,13 @@ float MeterModel::value(int index) const
 QJsonArray MeterModel::allMeters() const
 {
     QJsonArray meters;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
     for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
         const auto valueIt = m_values.constFind(it.key());
         const bool hasValue = valueIt != m_values.constEnd();
-        meters.append(meterToJson(*it, hasValue, hasValue ? valueIt.value() : 0.0f));
+        const qint64 upd = m_valueUpdatedMs.value(it.key(), 0);
+        const qint64 ageMs = (hasValue && upd > 0) ? (now - upd) : -1;
+        meters.append(meterToJson(*it, hasValue, hasValue ? valueIt.value() : 0.0f, ageMs));
     }
     return meters;
 }
@@ -589,6 +599,7 @@ QJsonArray MeterModel::allMeters() const
 QJsonArray MeterModel::metersForSource(const QString& source, int sourceIndex) const
 {
     QJsonArray meters;
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
     for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
         const MeterDef& def = *it;
         if (def.source != source)
@@ -598,7 +609,9 @@ QJsonArray MeterModel::metersForSource(const QString& source, int sourceIndex) c
 
         const auto valueIt = m_values.constFind(it.key());
         const bool hasValue = valueIt != m_values.constEnd();
-        meters.append(meterToJson(def, hasValue, hasValue ? valueIt.value() : 0.0f));
+        const qint64 upd = m_valueUpdatedMs.value(it.key(), 0);
+        const qint64 ageMs = (hasValue && upd > 0) ? (now - upd) : -1;
+        meters.append(meterToJson(def, hasValue, hasValue ? valueIt.value() : 0.0f, ageMs));
     }
     return meters;
 }

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -170,6 +170,10 @@ private:
 
     QMap<int, MeterDef> m_defs;        // meter index → definition
     QMap<int, float>    m_values;      // meter index → last converted value
+    QMap<int, qint64>   m_valueUpdatedMs; // meter index → epoch ms of last value
+                                          // update. Lets consumers reject stale
+                                          // reads (e.g. PACURRENT, which the
+                                          // radio sends only ~1 s into TX). (#3646)
 
     // Cached indices for fast lookup of important meters
     QMap<int, int> m_sLevelIdxBySlice;  // sliceIndex → meter index for "SLC"/"LEVEL"

--- a/tools/tx_meter_test.py
+++ b/tools/tx_meter_test.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+TX meter test harness for the agent automation bridge.
+
+Hardware-in-the-loop transmit + meter validation, built from the lessons of the
+manual TX runs:
+
+  * Single-instant meter reads are unreliable — meters update at different rates
+    (PACURRENT is only reported ~1 s into TX). This harness SAMPLES OVER THE
+    KEYED WINDOW and uses the per-meter `age_ms` the bridge now reports to reject
+    stale values (a 0 with a stale/absent age is not a real reading).
+  * The ATU recalls stored antenna matches that corrupt dummy-load readings, so
+    the harness ensures the tuner is BYPASSED before measuring (`atu bypass`).
+  * It never leaves the radio keyed: every burst is short, unkey-verified, and
+    the bridge's TX watchdog is a final backstop.
+
+SAFETY: requires AETHER_AUTOMATION_ALLOW_TX=1 on the app. Confirms the TX antenna
+is the expected dummy-load port before keying, gates on SWR after the first
+(lowest-power) burst, and aborts on any unkey failure. Use into a dummy load.
+
+Usage:
+    AETHER_AUTOMATION=1 AETHER_AUTOMATION_ALLOW_TX=1 ./build/.../AetherSDR &
+    python3 tools/tx_meter_test.py                 # tune sweep + two-tone ALC
+    python3 tools/tx_meter_test.py --ant ANT1 --levels 10,25,50,75,100
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+
+sys.path.insert(0, "tools")
+from automation_probe import Bridge, discover_socket  # noqa: E402
+
+FRESH_MS = 1500          # a meter reading older than this is treated as stale
+
+
+class Tx:
+    def __init__(self, bridge):
+        self.b = bridge
+
+    def g(self, model, prop=None, sel=None):
+        o = {"cmd": "get", "model": model}
+        if sel: o["selector"] = sel
+        if prop: o["property"] = prop
+        r = self.b.request(o)
+        return r.get("value") if prop else r.get(model, {})
+
+    def inv(self, target, action, value=None):
+        o = {"cmd": "invoke", "target": target, "action": action}
+        if value is not None: o["value"] = str(value)
+        return self.b.request(o)
+
+    def cmd(self, **kw):
+        return self.b.request(kw)
+
+    def tuning(self): return bool(self.g("transmit", "tuning"))
+    def mox(self): return bool(self.g("transmit", "mox"))
+    def txing(self): return bool(self.g("radio", "transmitting"))
+
+    def ensure_unkeyed(self):
+        for _ in range(8):
+            if not self.tuning() and not self.mox() and not self.txing():
+                return True
+            if self.tuning(): self.inv("Tune", "click")
+            if self.mox() or self.txing(): self.inv("MOX transmit", "setChecked", "false")
+            self.cmd(cmd="txtest", action="off")
+            time.sleep(0.25)
+        return False
+
+    def meters(self):
+        return self.g("meters")
+
+    @staticmethod
+    def meter_from_all(m, name):
+        """Return (value, age_ms) for a named meter from the 'all' table, picking
+        the freshest instance (disambiguates duplicate-named meters)."""
+        best = (None, None)
+        for x in m.get("all", []):
+            if x.get("name") == name and x.get("has_value"):
+                age = x.get("age_ms", -1)
+                if age is not None and age >= 0 and (best[1] is None or age < best[1]):
+                    best = (x.get("value"), age)
+        return best
+
+    def ensure_atu_bypass(self):
+        st = self.g("transmit", "atuStatus")
+        if st in ("bypass", "manual_bypass"):
+            return True, st
+        # disable auto-recall of stored matches, then bypass
+        self.inv("ATU memories", "setChecked", "false")
+        time.sleep(0.3)
+        self.cmd(cmd="atu", action="bypass")
+        time.sleep(0.4)
+        st = self.g("transmit", "atuStatus")
+        return st in ("bypass", "manual_bypass"), st
+
+
+def sample_window(tx, dur=1.4, settle=0.2):
+    """Key-down meter sampling. Collect fresh fwd/swr/temp/volts and the freshest
+    PACURRENT/ALC over the window. Returns a dict of aggregates + freshness."""
+    fwd, swr, temp, volts, alc = [], [], [], [], []
+    pacur = None  # (value, age) freshest
+    micp = []
+    t0 = time.monotonic()
+    while time.monotonic() - t0 < dur:
+        if time.monotonic() - t0 > settle:
+            m = tx.meters()
+            if m.get("fwdPowerAgeMs", 1e9) < FRESH_MS and m.get("fwdPower", 0) > 0.3:
+                fwd.append(m["fwdPower"])
+            if m.get("swrAgeMs", 1e9) < FRESH_MS:
+                swr.append(m.get("swr", 0))
+            temp.append(m.get("paTemp", 0)); volts.append(m.get("supplyVolts", 0))
+            alc.append(m.get("swAlc", -150))
+            pv, pa = Tx.meter_from_all(m, "PACURRENT")
+            if pv is not None and pa is not None and pa < FRESH_MS:
+                if pacur is None or pv > pacur[0]:
+                    pacur = (pv, pa)
+            micp.append(m.get("micPeak", -150))
+        time.sleep(0.12)
+    return {
+        "fwd": round(statistics.median(fwd), 1) if fwd else None,
+        "swr": round(statistics.median(swr), 2) if swr else None,
+        "paTemp": round(max(temp), 1) if temp else None,
+        "volts": round(statistics.median(volts), 2) if volts else None,
+        "alc": round(max(alc), 1) if alc else None,
+        "paCurrent": round(pacur[0], 2) if pacur else "stale",
+        "n_fwd": len(fwd),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description="TX meter test harness (agent automation bridge)")
+    ap.add_argument("--ant", default="ANT1", help="expected TX antenna (dummy load)")
+    ap.add_argument("--levels", default="10,25,50,75,100", help="tune-power levels W")
+    ap.add_argument("--json", help="write full results here")
+    ap.add_argument("--socket")
+    args = ap.parse_args()
+    levels = [int(x) for x in args.levels.split(",")]
+
+    sock = args.socket or discover_socket()
+    if not sock:
+        sys.exit("error: no bridge socket; launch with AETHER_AUTOMATION=1 AETHER_AUTOMATION_ALLOW_TX=1")
+    tx = Tx(Bridge(sock))
+
+    # --- pre-flight ---
+    print("=== PRE-FLIGHT ===")
+    if tx.txing() or tx.tuning():
+        tx.ensure_unkeyed()
+    # confirm TX antenna via dumpTree
+    tree = tx.b.request({"cmd": "dumpTree"})
+    tx_ants = set()
+    def walk(n):
+        if n.get("accessibleName") == "TX antenna": tx_ants.add(n.get("value"))
+        for c in n.get("children", []): walk(c)
+    for r in tree["roots"]: walk(r)
+    print(f"  TX antenna(s): {tx_ants or '?'}   expected: {args.ant}")
+    if tx_ants and tx_ants != {args.ant}:
+        sys.exit(f"ABORT: TX antenna {tx_ants} != expected {args.ant} — refusing to key")
+    orig_tp = tx.g("transmit", "tunePower")
+    print(f"  idle, tunePower={orig_tp}, transmitting={tx.txing()}")
+
+    ok, st = tx.ensure_atu_bypass()
+    print(f"  ATU bypass: {ok} (status={st})")
+    if not ok:
+        print("  WARNING: ATU not confirmed bypassed — readings may include a stored match")
+
+    # --- tune-power sweep ---
+    print("\n=== TUNE-POWER SWEEP (windowed, freshness-gated) ===")
+    print(f"{'setW':>5} {'fwdW':>6} {'swr':>5} {'PAcur':>7} {'paTemp':>7} {'V':>6} {'ALC':>7} {'n':>3}")
+    rows = []
+    abort = False
+    try:
+        for tp in levels:
+            tx.inv("Tune power", "setValue", tp); time.sleep(0.1)
+            tx.inv("Tune", "click")
+            t0 = time.monotonic()
+            while time.monotonic() - t0 < 1.5 and not tx.tuning():
+                time.sleep(0.05)
+            agg = sample_window(tx)
+            tx.inv("Tune", "click")
+            ok_unkey = tx.ensure_unkeyed()
+            agg.update(set=tp, unkeyed=ok_unkey, atu=tx.g("transmit", "atuStatus"))
+            rows.append(agg)
+            print(f"{tp:>5} {str(agg['fwd']):>6} {str(agg['swr']):>5} {str(agg['paCurrent']):>7} "
+                  f"{str(agg['paTemp']):>7} {str(agg['volts']):>6} {str(agg['alc']):>7} {agg['n_fwd']:>3}")
+            if not ok_unkey:
+                print("  *** UNKEY FAILED — ABORT ***"); abort = True; break
+            if tp == levels[0] and agg["swr"] and agg["swr"] > 2.5:
+                print(f"  *** SWR {agg['swr']} high at lowest power — ABORT ***"); abort = True; break
+            if agg["paTemp"] and agg["paTemp"] > 75:
+                print("  *** PA temp — ABORT ***"); abort = True; break
+            time.sleep(1.6)
+
+        # --- two-tone ALC test ---
+        if not abort:
+            print("\n=== TWO-TONE (ALC / PEP — needs modulation) ===")
+            r = tx.cmd(cmd="txtest", action="twotone")
+            if r.get("ok"):
+                t0 = time.monotonic()
+                while time.monotonic() - t0 < 1.5 and not tx.txing() and not tx.tuning():
+                    time.sleep(0.05)
+                agg = sample_window(tx, dur=1.2)
+                tx.cmd(cmd="txtest", action="off"); ok = tx.ensure_unkeyed()
+                print(f"  two-tone: fwd={agg['fwd']}W swr={agg['swr']} ALC={agg['alc']}dBFS "
+                      f"PAcur={agg['paCurrent']} unkeyed={ok}")
+                rows.append({"set": "two-tone", **agg, "unkeyed": ok})
+            else:
+                print(f"  two-tone unavailable: {r.get('error')}")
+    finally:
+        tx.inv("Tune power", "setValue", orig_tp)
+        safe = tx.ensure_unkeyed()
+        print(f"\nrestored tunePower={tx.g('transmit','tunePower')} transmitting={tx.txing()} "
+              f"atu={tx.g('transmit','atuStatus')} (unkeyed={safe})")
+        if args.json:
+            json.dump(rows, open(args.json, "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tx_meter_test.py
+++ b/tools/tx_meter_test.py
@@ -74,15 +74,20 @@ class Tx:
 
     @staticmethod
     def meter_from_all(m, name):
-        """Return (value, age_ms) for a named meter from the 'all' table, picking
-        the freshest instance (disambiguates duplicate-named meters)."""
+        """Return (value, age_ms, reliable) for a named meter from the 'all'
+        table, picking the freshest instance (disambiguates duplicate-named
+        meters). `reliable` is False if the bridge flagged the meter known-bad
+        for this radio (e.g. PACURRENT clipping on FLEX-8000, #3729)."""
         best = (None, None)
+        reliable = True
         for x in m.get("all", []):
             if x.get("name") == name and x.get("has_value"):
+                if x.get("reliable") is False:
+                    reliable = False
                 age = x.get("age_ms", -1)
                 if age is not None and age >= 0 and (best[1] is None or age < best[1]):
                     best = (x.get("value"), age)
-        return best
+        return best[0], best[1], reliable
 
     def ensure_atu_bypass(self):
         st = self.g("transmit", "atuStatus")
@@ -102,6 +107,7 @@ def sample_window(tx, dur=1.4, settle=0.2):
     PACURRENT/ALC over the window. Returns a dict of aggregates + freshness."""
     fwd, swr, temp, volts, alc = [], [], [], [], []
     pacur = None  # (value, age) freshest
+    pacur_reliable = True
     micp = []
     t0 = time.monotonic()
     while time.monotonic() - t0 < dur:
@@ -113,19 +119,24 @@ def sample_window(tx, dur=1.4, settle=0.2):
                 swr.append(m.get("swr", 0))
             temp.append(m.get("paTemp", 0)); volts.append(m.get("supplyVolts", 0))
             alc.append(m.get("swAlc", -150))
-            pv, pa = Tx.meter_from_all(m, "PACURRENT")
+            pv, pa, prel = Tx.meter_from_all(m, "PACURRENT")
+            if not prel:
+                pacur_reliable = False
             if pv is not None and pa is not None and pa < FRESH_MS:
                 if pacur is None or pv > pacur[0]:
                     pacur = (pv, pa)
             micp.append(m.get("micPeak", -150))
         time.sleep(0.12)
+    # Don't report a number the radio says is unreliable (e.g. clipped PACURRENT)
+    pa_out = ("unreliable" if not pacur_reliable
+              else round(pacur[0], 2) if pacur else "stale")
     return {
         "fwd": round(statistics.median(fwd), 1) if fwd else None,
         "swr": round(statistics.median(swr), 2) if swr else None,
         "paTemp": round(max(temp), 1) if temp else None,
         "volts": round(statistics.median(volts), 2) if volts else None,
         "alc": round(max(alc), 1) if alc else None,
-        "paCurrent": round(pacur[0], 2) if pacur else "stale",
+        "paCurrent": pa_out,
         "n_fwd": len(fwd),
     }
 


### PR DESCRIPTION
Hardens the **agent automation bridge** for hardware-in-the-loop transmit and meter testing. Built and verified on a FLEX-8400M into a 100W dummy load (antennas/transverter removed, ANT1). Branched off current `main`; independent of #3722 (validation hardening) and #3717 (password redaction).

This is the product of several live TX sessions — each item below traces to a concrete thing that bit us.

## Meter readout + freshness (the root meter fix)

Meter bugs have been a recurring cluster, and live testing showed why: **single-instant meter reads are unreliable** because meters update at different rates. `PACURRENT` is only reported sparsely, so a single read catches a stale/zero value that looks real (we briefly "measured" 7W at a 50W setting before realizing it was a sampling artifact).

- **`MeterModel`** now records a per-meter update timestamp (`m_valueUpdatedMs`); `allMeters()` / `metersForSource()` emit **`age_ms` per meter** (-1 = never). This is the root enabler — a consumer can now reject stale reads.
- **`get meters`** verb: flat TX convenience values (fwd/instant power, SWR, PA temp, supply volts, swAlc/hwAlc, mic/comp) each with a freshness age, plus the full `all` meter table (`index`/`source_index`/`age_ms` — so duplicate-named meters, one live and one floored, are distinguishable).

## TX test-signal + ATU control

- **`txtest twotone|off`** — triggers the radio's two-tone test so **ALC/PEP meters can be exercised** (a steady carrier can't). Verified: ALC moved from −40 dBFS (carrier floor) to **−6.4 dBFS**. ALLOW_TX-gated. *(Compression still needs mic-audio injection via DAX TX — out of scope here, noted as follow-up.)*
- **`get transmit.atuStatus`** + **`atu bypass|start`** — the ATU was recalling a stored antenna match against the dummy load (the "abnormal SWR" we chased); `atu bypass` takes the tuner out of circuit for clean readings (`bypass` doesn't transmit; `start` is ALLOW_TX-gated).

## Hardware safety rails (auto-armed when `AETHER_AUTOMATION_ALLOW_TX=1`)

- **TX watchdog** — force-unkeys the radio after a max continuous key time (`AETHER_AUTOMATION_TX_MAX_MS`, default 20s), so a hung/abandoned script can never leave a live transmitter on. Independent of whatever drives the bridge.
- **Power ceiling** — optional clamp on RF/Tune power setpoints (`AETHER_AUTOMATION_TX_MAX_POWER`).
- **Force-unkey on `stop()`** — the bridge never leaves the radio keyed on shutdown.

## Tooling

- **`tools/tx_meter_test.py`** — windowed, freshness-gated TX meter harness: confirms the TX antenna, ensures ATU bypass, keys short bursts, samples meters across the keyed window (median power/SWR, freshest PA current), runs a two-tone ALC pass, restores, with SWR/temp gates and verified unkey after every burst.

## Live verification (FLEX-8400M, 100W dummy load)

- **Watchdog** force-unkeyed a deliberately-held tune at **~8.5s** (8s limit). ✅
- **Power ceiling** clamped 80W/90W setpoints → 30W; 20W passed through. ✅
- **ATU bypass** → clean **SWR 1.15** (was 1.83 with the recalled match). ✅
- **Windowed sweep** tracked tune power ~1:1: 10→9.2W, 25→22.3W, 50→45.9W, 75→69.9W, 100→93.9W; PA temp peaked 32.9°C. ✅
- **Two-tone** drove ALC to −6.4 dBFS. ✅
- **`PACURRENT`** confirmed sparsely/erratically reported by the radio (fresh 0s mid-transmit) — now detectable via `age_ms` rather than mistaken for a real reading. ✅
- Every burst unkey-verified; radio restored (RF power 100, idle) throughout.

## Diff
`AutomationServer.{cpp,h}`, `MeterModel.{cpp,h}`, `tools/tx_meter_test.py` — **+465 / −8**, additive.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
