### PR TITLE
fix(gui): guard slice DAX-recall singleShot against dangling slice (UAF crash)

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -258,9 +258,15 @@ void MainWindow::onSliceAdded(SliceModel* s)
             const QString key = QString("DaxChannel_Slice%1").arg(QChar('A' + sliceIdx));
             int savedDax = AppSettings::instance().value(key, "0").toInt();
             if (savedDax > 0) {
-                QTimer::singleShot(300, this, [this, s, savedDax]() {
-                    if (s && !profileLoadRadioStateWritesHeld()) {
-                        s->setDaxChannel(savedDax);
+                // QPointer guards against a dangling slice: a raw SliceModel*
+                // stays non-null after the slice is destroyed, so the `s &&`
+                // check below is only meaningful if the capture auto-nulls.
+                // Removing the slice within this 300 ms window (rapid
+                // add/remove) would otherwise dereference freed memory. (#3646)
+                QPointer<SliceModel> sp(s);
+                QTimer::singleShot(300, this, [this, sp, savedDax]() {
+                    if (sp && !profileLoadRadioStateWritesHeld()) {
+                        sp->setDaxChannel(savedDax);
                     }
                 });
             }


### PR DESCRIPTION
## What

Fixes a use-after-free crash (`EXC_BAD_ACCESS` / SIGSEGV) when a slice is
removed within ~300 ms of being added. Closes #3732.

`MainWindow::onSliceAdded()` arms a 300 ms `QTimer::singleShot` to restore a
slice's saved DAX channel (#1221), capturing the slice by **raw pointer**:

```cpp
QTimer::singleShot(300, this, [this, s, savedDax]() {   // s = raw SliceModel*
    if (s && !profileLoadRadioStateWritesHeld())
        s->setDaxChannel(savedDax);
});
```

The `if (s && …)` guard is ineffective — a raw pointer does not go null when
the pointee is destroyed — and the timer's context object is the long-lived
`MainWindow`, so it is not auto-cancelled when the slice goes away. Removing
the slice inside the 300 ms window fires the timer on freed memory:

```
QTimer → setDaxChannel() → sendCommand() → emit commandReady()
       → QtCore doActivate()   ← SIGSEGV on the dangling sender
```

## Why it matters

This is reachable on ordinary paths, not just automation: rapid slice
add/remove, profile recall that recreates slices, and band-stack restore can
all destroy a slice within 300 ms of creating it. The timer arms whenever the
slice index maps to a saved `DaxChannel_Slice{A,B,…} > 0`, so users who have
ever assigned a DAX channel are the most exposed.

## The fix

Capture a `QPointer<SliceModel>` so the existing guard actually nulls out on
destruction — the same dangling-object pattern already used elsewhere in this
TU (#381). One file, +9/-3.

```diff
-                QTimer::singleShot(300, this, [this, s, savedDax]() {
-                    if (s && !profileLoadRadioStateWritesHeld()) {
-                        s->setDaxChannel(savedDax);
-                    }
-                });
+                QPointer<SliceModel> sp(s);
+                QTimer::singleShot(300, this, [this, sp, savedDax]() {
+                    if (sp && !profileLoadRadioStateWritesHeld()) {
+                        sp->setDaxChannel(savedDax);
+                    }
+                });
```

## Testing

Reproduced live on a FLEX-8400M, then verified the fix:

- **Before:** reopen a slice at T=0, remove at T+172 ms → crash at ~T+300 ms
  (`EXC_BAD_ACCESS`, stack as in #3732).
- **After:** 6× add/remove at **120 ms dwell** (deep inside the window) plus a
  full open → tune → handoff → close → reopen → restore lifecycle — no crash,
  process stays up and the control channel stays responsive.
- Clean `RelWithDebInfo` build off `origin/main` (Qt 6.11, macOS arm64).

## Discovery

Found while exercising the slice open/close/reopen lifecycle through the agent
automation bridge — a concrete example of agent-driven testing surfacing a real
pre-existing crash that manual clicking rarely hits because it requires
sub-300 ms timing.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
