### PR TITLE
feat(automation): slice/VFO verbs, DAX/TCI a11y, and a log observability suite

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -23,6 +23,9 @@
 #include <QRegularExpression>
 #include <QTimer>
 #include <QDateTime>
+#include <QTime>
+
+#include <limits>
 
 // Best-effort value extraction for common control types.
 #include <QAbstractButton>
@@ -562,9 +565,32 @@ bool AutomationServer::start(const QString& serverName)
                                                     : QString::number(m_txMaxPower));
     }
 
+    // Observability suite (#3646): start the monotonic clock, tap the log
+    // funnel into a ring buffer, and arm the (idle) drain timer used by
+    // `log subscribe`. The tap runs on arbitrary logging threads, so it only
+    // touches the mutex-guarded ring — never a socket.
+    m_monoClock.start();
+    m_logTapId = LogManager::instance().addTap(
+        [this](QtMsgType type, const QString& cat, const QString& msg) {
+            QMutexLocker lk(&m_logMutex);
+            LogEvent e;
+            e.seq    = ++m_logSeq;
+            e.monoUs = m_monoClock.nsecsElapsed() / 1000;
+            e.wall   = QTime::currentTime().toString(QStringLiteral("HH:mm:ss.zzz"));
+            e.type   = static_cast<int>(type);
+            e.cat    = cat;
+            e.msg    = msg;
+            m_logRing.push_back(std::move(e));
+            while (m_logRing.size() > static_cast<size_t>(kLogRingMax))
+                m_logRing.pop_front();
+        });
+    m_logDrain = new QTimer(this);
+    m_logDrain->setInterval(50);
+    connect(m_logDrain, &QTimer::timeout, this, &AutomationServer::onLogDrain);
+
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, grab, invoke, get, txtest, atu)";
+        << "(verbs: ping, dumpTree, grab, invoke, get, txtest, atu, slice, tune, log, mark)";
     return true;
 }
 
@@ -581,6 +607,17 @@ void AutomationServer::stop()
         m_txWatchdog->deleteLater();
         m_txWatchdog = nullptr;
     }
+    // Detach the log tap before teardown so no logging thread can touch us.
+    if (m_logTapId >= 0) {
+        LogManager::instance().removeTap(m_logTapId);
+        m_logTapId = -1;
+    }
+    if (m_logDrain) {
+        m_logDrain->stop();
+        m_logDrain->deleteLater();
+        m_logDrain = nullptr;
+    }
+    m_logSubscribers.clear();
 
     for (auto it = m_buffers.constBegin(); it != m_buffers.constEnd(); ++it)
         it.key()->deleteLater();
@@ -634,7 +671,7 @@ void AutomationServer::onReadyRead()
         buf.remove(0, nl + 1);
         if (line.trimmed().isEmpty())
             continue;
-        const QJsonObject resp = handleLine(line);
+        const QJsonObject resp = handleLine(line, sock);
         sock->write(QJsonDocument(resp).toJson(QJsonDocument::Compact));
         sock->write("\n");
         sock->flush();
@@ -647,11 +684,13 @@ void AutomationServer::onDisconnected()
     if (!sock)
         return;
     m_buffers.remove(sock);
+    if (m_logSubscribers.remove(sock) && m_logSubscribers.isEmpty() && m_logDrain)
+        m_logDrain->stop();
     sock->deleteLater();
     qCDebug(lcAutomation) << "client disconnected;" << m_buffers.size() << "active";
 }
 
-QJsonObject AutomationServer::handleLine(const QByteArray& line)
+QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* sock)
 {
     QString cmd, target, path, action, value, model, selector, property;
 
@@ -700,6 +739,15 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
             action = tok(1); value = tok(2);  // "slice add 14.2", "slice remove 1"
         } else if (cmd == QLatin1String("tune")) {
             value = tok(1);   // "tune 3.7"
+        } else if (cmd == QLatin1String("log")) {
+            action = tok(1);  // categories|get|set|reset|tail|subscribe|unsubscribe
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));  // "aether.protocol on", "200 since=42"
+        } else if (cmd == QLatin1String("mark")) {
+            QStringList rest;
+            for (int i = 1; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));  // free-form annotation text
         } else {  // grab and friends
             target = tok(1); path = tok(2);
         }
@@ -750,6 +798,13 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
         if (value.isEmpty())
             return err(QStringLiteral("tune requires a frequency in MHz"));
         return doTune(value);
+    }
+    if (cmd == QLatin1String("log"))
+        return doLog(action.isEmpty() ? QStringLiteral("categories") : action, value, sock);
+    if (cmd == QLatin1String("mark")) {
+        if (value.isEmpty())
+            return err(QStringLiteral("mark requires annotation text"));
+        return doMark(value);
     }
 
     return err(QStringLiteral("unknown command: ") + cmd);
@@ -1221,5 +1276,190 @@ QJsonObject AutomationServer::doTune(const QString& value)
     s->setFrequency(mhz);
     return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
                        {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
+}
+
+// ---------------------------------------------------------------------------
+// Observability suite (#3646): log control, event ring, markers.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+const char* msgTypeName(int t)
+{
+    switch (t) {
+    case QtDebugMsg:    return "D";
+    case QtInfoMsg:     return "I";
+    case QtWarningMsg:  return "W";
+    case QtCriticalMsg: return "C";
+    case QtFatalMsg:    return "F";
+    default:            return "?";
+    }
+}
+
+} // namespace
+
+// Serialize one event for the wire. PII is redacted here, on egress, so the
+// in-memory ring stays raw (cheap tap) but nothing sensitive ever leaves.
+QJsonObject AutomationServer::logEventToJson(const LogEvent& e)
+{
+    return QJsonObject{
+        {QStringLiteral("type"),    QStringLiteral("log")},
+        {QStringLiteral("seq"),     static_cast<qint64>(e.seq)},
+        {QStringLiteral("mono_us"), e.monoUs},
+        {QStringLiteral("t"),       e.wall},
+        {QStringLiteral("lvl"),     QString::fromLatin1(msgTypeName(e.type))},
+        {QStringLiteral("cat"),     e.cat},
+        {QStringLiteral("msg"),     redactPii(e.msg)},
+    };
+}
+
+QJsonObject AutomationServer::doLog(const QString& action, const QString& arg,
+                                    QLocalSocket* sock)
+{
+    auto& lm = LogManager::instance();
+
+    if (action == QLatin1String("categories")) {
+        QJsonArray arr;
+        for (const auto& c : lm.categories())
+            arr.append(QJsonObject{{QStringLiteral("id"), c.id},
+                                   {QStringLiteral("label"), c.label},
+                                   {QStringLiteral("enabled"), c.enabled}});
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("categories"), arr}};
+    }
+
+    if (action == QLatin1String("get")) {
+        if (arg.isEmpty())
+            return err(QStringLiteral("log get requires a category id"));
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("id"), arg},
+                           {QStringLiteral("enabled"), lm.isEnabled(arg)}};
+    }
+
+    if (action == QLatin1String("set")) {
+        // "<id> <on|off>" or "<id>=<on|off>"; id "all" toggles every category.
+        const QString id = arg.section(QRegularExpression(QStringLiteral("[ =]")), 0, 0).trimmed();
+        const QString st = arg.section(QRegularExpression(QStringLiteral("[ =]")), 1).trimmed().toLower();
+        if (id.isEmpty() || st.isEmpty())
+            return err(QStringLiteral("log set requires '<category> <on|off>'"));
+        const bool on = (st == QLatin1String("on") || st == QLatin1String("true")
+                         || st == QLatin1String("1") || st == QLatin1String("debug"));
+        if (id == QLatin1String("all")) {
+            lm.setAllEnabled(on);
+            return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("id"), id},
+                               {QStringLiteral("enabled"), on}};
+        }
+        lm.setEnabled(id, on);
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("id"), id},
+                           {QStringLiteral("enabled"), lm.isEnabled(id)}};
+    }
+
+    if (action == QLatin1String("reset")) {
+        lm.loadSettings();  // restore the operator's persisted category prefs
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("reset"), true}};
+    }
+
+    if (action == QLatin1String("tail")) {
+        // "[n] [since=<seq>]" — newest n events, optionally only seq > since.
+        int n = 100;
+        quint64 since = 0;
+        for (const QString& tokn : arg.split(QLatin1Char(' '), Qt::SkipEmptyParts)) {
+            if (tokn.startsWith(QLatin1String("since=")))
+                since = tokn.mid(6).toULongLong();
+            else
+                n = tokn.toInt();
+        }
+        if (n <= 0) n = 100;
+        QJsonArray arr;
+        quint64 curSeq;
+        {
+            QMutexLocker lk(&m_logMutex);
+            curSeq = m_logSeq;
+            for (const auto& e : m_logRing)
+                if (e.seq > since)
+                    arr.append(logEventToJson(e));
+        }
+        while (arr.size() > n)              // keep the newest n
+            arr.removeFirst();
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("events"), arr},
+                           {QStringLiteral("seq"), static_cast<qint64>(curSeq)}};
+    }
+
+    if (action == QLatin1String("subscribe")) {
+        if (!sock)
+            return err(QStringLiteral("subscribe requires a connected client"));
+        QMutexLocker lk(&m_logMutex);
+        m_logSubscribers.insert(sock, m_logSeq);  // stream events from now on
+        if (m_logDrain && !m_logDrain->isActive())
+            m_logDrain->start();
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("subscribed"), true},
+                           {QStringLiteral("seq"), static_cast<qint64>(m_logSeq)}};
+    }
+
+    if (action == QLatin1String("unsubscribe")) {
+        const bool was = sock && m_logSubscribers.remove(sock) > 0;
+        if (m_logSubscribers.isEmpty() && m_logDrain)
+            m_logDrain->stop();
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("subscribed"), false},
+                           {QStringLiteral("was"), was}};
+    }
+
+    return err(QStringLiteral("log action must be "
+                              "categories|get|set|reset|tail|subscribe|unsubscribe"));
+}
+
+QJsonObject AutomationServer::doMark(const QString& text)
+{
+    // qCInfo runs the installed handler synchronously on this (main) thread, so
+    // by the time it returns the tap has already assigned the marker its seq —
+    // letting a driver bracket actions with `mark` then `log tail since=<seq>`.
+    qCInfo(lcAutomation).noquote() << "MARK" << text;
+    QMutexLocker lk(&m_logMutex);
+    const qint64 mono = m_logRing.empty() ? 0 : m_logRing.back().monoUs;
+    return QJsonObject{{QStringLiteral("ok"), true},
+                       {QStringLiteral("seq"), static_cast<qint64>(m_logSeq)},
+                       {QStringLiteral("mono_us"), mono},
+                       {QStringLiteral("text"), text}};
+}
+
+void AutomationServer::onLogDrain()
+{
+    if (m_logSubscribers.isEmpty()) {
+        if (m_logDrain) m_logDrain->stop();
+        return;
+    }
+
+    // Copy just the new tail once, under the lock, then write to sockets
+    // outside it so logging threads are never blocked on socket I/O.
+    quint64 minLast = std::numeric_limits<quint64>::max();
+    for (const quint64 v : m_logSubscribers)
+        minLast = std::min(minLast, v);
+
+    std::deque<LogEvent> fresh;
+    quint64 curSeq;
+    {
+        QMutexLocker lk(&m_logMutex);
+        curSeq = m_logSeq;
+        for (const auto& e : m_logRing)
+            if (e.seq > minLast)
+                fresh.push_back(e);
+    }
+    if (fresh.empty())
+        return;
+
+    for (auto it = m_logSubscribers.begin(); it != m_logSubscribers.end(); ++it) {
+        QLocalSocket* s = it.key();
+        const quint64 last = it.value();
+        for (const auto& e : fresh) {
+            if (e.seq <= last)
+                continue;
+            s->write(QJsonDocument(logEventToJson(e)).toJson(QJsonDocument::Compact));
+            s->write("\n");
+        }
+        s->flush();
+        it.value() = curSeq;
+    }
 }
 } // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -303,6 +303,22 @@ QJsonObject panSnapshot(const PanadapterModel* p)
 
 QJsonObject radioSnapshot(const RadioModel* r)
 {
+    // Multi-Flex slot occupancy across the radio's whole slice capacity: each
+    // slot is ours / foreign (another client, e.g. a Maestro) / empty. This is
+    // why an `slice add` can be refused even when we hold only one slice — the
+    // capacity is radio-wide, shared across clients. (#3646)
+    QJsonArray slotArr;   // not "slots" — that's a Qt macro
+    const int maxSlices = r->maxSlices();
+    for (int id = 0; id < maxSlices; ++id) {
+        QString state = QStringLiteral("empty");
+        if (r->isSlotOurs(id))         state = QStringLiteral("ours");
+        else if (r->isSlotForeign(id)) state = QStringLiteral("foreign");
+        QJsonObject slot{{QStringLiteral("id"), id}, {QStringLiteral("state"), state}};
+        if (state == QLatin1String("foreign"))
+            slot[QStringLiteral("owner")] = r->foreignSliceOwnerStation(id);
+        slotArr.append(slot);
+    }
+
     return QJsonObject{
         {QStringLiteral("name"),         r->name()},
         {QStringLiteral("model"),        r->model()},
@@ -315,6 +331,8 @@ QJsonObject radioSnapshot(const RadioModel* r)
         {QStringLiteral("txPower"),      r->txPower()},
         {QStringLiteral("paTemp"),       r->paTemp()},
         {QStringLiteral("sliceCount"),   r->slices().size()},
+        {QStringLiteral("maxSlices"),    maxSlices},
+        {QStringLiteral("slots"),        slotArr},
         {QStringLiteral("panCount"),     r->panadapters().size()},
     };
 }
@@ -678,6 +696,10 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
             model = tok(1); selector = tok(2); property = tok(3);
         } else if (cmd == QLatin1String("txtest") || cmd == QLatin1String("atu")) {
             action = tok(1);  // e.g. "txtest twotone", "atu bypass"
+        } else if (cmd == QLatin1String("slice")) {
+            action = tok(1); value = tok(2);  // "slice add 14.2", "slice remove 1"
+        } else if (cmd == QLatin1String("tune")) {
+            value = tok(1);   // "tune 3.7"
         } else {  // grab and friends
             target = tok(1); path = tok(2);
         }
@@ -718,6 +740,16 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line)
         if (action.isEmpty())
             return err(QStringLiteral("atu requires an action (bypass|start)"));
         return doAtu(action);
+    }
+    if (cmd == QLatin1String("slice")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("slice requires an action (add|remove|select)"));
+        return doSlice(action, value);
+    }
+    if (cmd == QLatin1String("tune")) {
+        if (value.isEmpty())
+            return err(QStringLiteral("tune requires a frequency in MHz"));
+        return doTune(value);
     }
 
     return err(QStringLiteral("unknown command: ") + cmd);
@@ -1102,4 +1134,92 @@ void AutomationServer::onTxWatchdog()
         forceUnkey("max continuous key time exceeded");
 }
 
+QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    RadioModel* radio = m_radioModel;
+
+    if (action == QLatin1String("add")) {
+        // Pre-check radio-wide slot capacity. Slices are a radio resource shared
+        // across MultiFlex clients, so a create is refused when every slot is
+        // taken — even if WE hold only one. Surface that synchronously instead
+        // of issuing a command the radio will silently reject. (#3646)
+        int freeSlots = 0;
+        QString occupant;
+        for (int id = 0; id < radio->maxSlices(); ++id) {
+            if (!radio->isSlotOurs(id) && !radio->isSlotForeign(id)) freeSlots++;
+            else if (radio->isSlotForeign(id) && occupant.isEmpty())
+                occupant = radio->foreignSliceOwnerStation(id);
+        }
+        if (freeSlots == 0) {
+            QString msg = QStringLiteral("refused: no free slice slot (radio at its ")
+                + QString::number(radio->maxSlices()) + QStringLiteral("-slice limit");
+            if (!occupant.isEmpty())
+                msg += QStringLiteral("; a foreign client '") + occupant + QStringLiteral("' holds a slot");
+            return err(msg + QStringLiteral(")"));
+        }
+
+        bool okF = false;
+        const double freq = arg.toDouble(&okF);
+        if (okF && freq > 0)
+            radio->addSliceOnPan(radio->panId(), freq);   // specific frequency
+        else
+            radio->addSlice();                            // default (TX freq / active pan)
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("add")},
+                           {QStringLiteral("freq"), okF ? QJsonValue(freq) : QJsonValue()},
+                           {QStringLiteral("requested"), true},
+                           {QStringLiteral("sliceCount"), radio->slices().size()}};
+    }
+    if (action == QLatin1String("remove")) {
+        bool okId = false;
+        const int id = arg.toInt(&okId);
+        if (!okId)
+            return err(QStringLiteral("slice remove requires a slice id"));
+        if (radio->slices().size() <= 1)
+            return err(QStringLiteral("refused: cannot remove the last slice"));
+        if (!radio->slice(id))
+            return err(QStringLiteral("no slice with id ") + arg);
+        radio->sendCommand(QStringLiteral("slice remove %1").arg(id));
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("remove")},
+                           {QStringLiteral("id"), id}};
+    }
+    if (action == QLatin1String("select")) {
+        bool okId = false;
+        const int id = arg.toInt(&okId);
+        if (!okId || !radio->slice(id))
+            return err(QStringLiteral("slice select requires a valid slice id"));
+        radio->sendCommand(QStringLiteral("slice set %1 active=1").arg(id));
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("select")},
+                           {QStringLiteral("id"), id}};
+    }
+    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select)"));
+}
+
+// ── VFO tuning (#3646) ──────────────────────────────────────────────────────
+// Set the active slice's frequency (MHz). The most fundamental control the
+// VfoWidget couldn't expose (it's custom-painted). Honors the slice lock guard.
+QJsonObject AutomationServer::doTune(const QString& value)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    bool okF = false;
+    const double mhz = value.toDouble(&okF);
+    if (!okF || mhz <= 0)
+        return err(QStringLiteral("tune requires a positive frequency in MHz"));
+
+    SliceModel* s = nullptr;
+    for (SliceModel* c : m_radioModel->slices())
+        if (c->isActive()) { s = c; break; }
+    if (!s && !m_radioModel->slices().isEmpty())
+        s = m_radioModel->slices().first();
+    if (!s)
+        return err(QStringLiteral("no slice to tune"));
+    if (s->isLocked())
+        return err(QStringLiteral("refused: slice ") + s->letter() + QStringLiteral(" is VFO-locked"));
+
+    s->setFrequency(mhz);
+    return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
+                       {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
+}
 } // namespace AetherSDR

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -4,7 +4,11 @@
 #include <QHash>
 #include <QPointer>
 #include <QByteArray>
+#include <QElapsedTimer>
+#include <QMutex>
 #include <QString>
+
+#include <deque>
 
 class QLocalServer;
 class QLocalSocket;
@@ -98,10 +102,15 @@ private slots:
     // it has been keyed continuously past the limit, so a hung/abandoned
     // automation script can never leave a live transmitter on.
     void onTxWatchdog();
+    // Push queued log events to subscribed clients (log subscribe). Runs on the
+    // main thread so QLocalSocket writes are thread-confined; the tap that fills
+    // the ring runs on arbitrary logging threads.
+    void onLogDrain();
 
 private:
-    // Dispatch a single request line and return the response object.
-    QJsonObject handleLine(const QByteArray& line);
+    // Dispatch a single request line and return the response object. The socket
+    // is needed for stateful per-client verbs (log subscribe/unsubscribe).
+    QJsonObject handleLine(const QByteArray& line, QLocalSocket* sock);
 
     QJsonObject doDumpTree() const;
     QJsonObject doGrab(const QString& target, const QString& path) const;
@@ -119,6 +128,12 @@ private:
     // Slice lifecycle (add/remove/select) and VFO tuning — RX/config, no keying.
     QJsonObject doSlice(const QString& action, const QString& arg);
     QJsonObject doTune(const QString& value);
+    // Observability suite (#3646): runtime log-category control, ring-buffer
+    // tail, push subscription, and timeline markers. All diagnostic, no keying.
+    QJsonObject doLog(const QString& action, const QString& arg, QLocalSocket* sock);
+    QJsonObject doMark(const QString& text);
+    struct LogEvent;
+    static QJsonObject logEventToJson(const LogEvent& e);  // redacts on egress
 
     // Resolve a target string to a widget: exact objectName first, then
     // class name (with or without namespace) or accessibleName.
@@ -136,6 +151,24 @@ private:
     int     m_txMaxKeyMs{20000};   // max continuous key time before force-unkey
     int     m_txMaxPower{-1};      // power-ceiling clamp for invoke (-1 = off)
     bool    m_txAllowed{false};    // AETHER_AUTOMATION_ALLOW_TX at start()
+    // Log/event channel (#3646 observability suite). The tap fills m_logRing
+    // from arbitrary logging threads; the main thread reads it for tail/drain.
+    struct LogEvent {
+        quint64 seq{0};
+        qint64  monoUs{0};   // process-monotonic microseconds (jitter-grade)
+        QString wall;        // HH:mm:ss.zzz, to line up with the log file
+        int     type{0};     // QtMsgType
+        QString cat;
+        QString msg;         // raw; PII-redacted only on egress
+    };
+    int            m_logTapId{-1};
+    QElapsedTimer  m_monoClock;            // started in start()
+    mutable QMutex m_logMutex;             // guards m_logRing / m_logSeq
+    std::deque<LogEvent> m_logRing;
+    quint64        m_logSeq{0};
+    QHash<QLocalSocket*, quint64> m_logSubscribers;  // sock -> last seq sent
+    QTimer*        m_logDrain{nullptr};
+    static constexpr int kLogRingMax = 8000;
 };
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -116,6 +116,10 @@ private:
 
     void forceUnkey(const char* reason);  // emergency all-stop (tune/mox/two-tone)
 
+    // Slice lifecycle (add/remove/select) and VFO tuning — RX/config, no keying.
+    QJsonObject doSlice(const QString& action, const QString& arg);
+    QJsonObject doTune(const QString& value);
+
     // Resolve a target string to a widget: exact objectName first, then
     // class name (with or without namespace) or accessibleName.
     static QWidget* resolveWidget(const QString& target);

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -185,8 +185,32 @@ void LogManager::enqueueMessage(QtMsgType type, const QMessageLogContext& ctx, c
         : QStringLiteral("default");
 
     m_writer.enqueue(type, QTime::currentTime(), category, msg);
+
+    // Fan out to diagnostic taps (automation event channel). Held under the
+    // tap mutex; taps are documented as cheap and non-logging, so there is no
+    // re-entrancy. The hash is empty in normal runs, so this is near-free.
+    {
+        QMutexLocker lk(&m_tapMutex);
+        for (const auto& tap : m_taps)
+            tap(type, category, msg);
+    }
+
     if (type == QtFatalMsg)
         m_writer.flush();
+}
+
+int LogManager::addTap(LogTap tap)
+{
+    QMutexLocker lk(&m_tapMutex);
+    const int id = m_nextTapId++;
+    m_taps.insert(id, std::move(tap));
+    return id;
+}
+
+void LogManager::removeTap(int id)
+{
+    QMutexLocker lk(&m_tapMutex);
+    m_taps.remove(id);
 }
 
 void LogManager::flushLog() const

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -4,10 +4,13 @@
 
 #include <QObject>
 #include <QList>
+#include <QHash>
 #include <QString>
 #include <QLoggingCategory>
 #include <QMutex>
 #include <QtCore/qlogging.h>
+
+#include <functional>
 
 namespace AetherSDR {
 
@@ -74,6 +77,16 @@ public:
     void shutdownLogging();
     void enqueueMessage(QtMsgType type, const QMessageLogContext& ctx, const QString& msg);
     void flushLog() const;
+
+    // Diagnostic tap (#3646 observability). Invoked synchronously, on the
+    // logging thread, for every enqueued message — after it is handed to the
+    // writer. The automation bridge registers one to expose a high-resolution,
+    // monotonic-timestamped event stream that mirrors the log file. Taps must
+    // be cheap and MUST NOT log (re-entrancy would deadlock the tap mutex).
+    using LogTap = std::function<void(QtMsgType type, const QString& category,
+                                      const QString& message)>;
+    int  addTap(LogTap tap);
+    void removeTap(int id);
     AsyncLogWriter::Counters logCounters() const;
 
     QString logFilePath() const;
@@ -109,6 +122,10 @@ private:
     mutable QMutex m_pathMutex;
     QString m_activeLogFilePath;
     mutable AsyncLogWriter m_writer;
+
+    mutable QMutex m_tapMutex;
+    QHash<int, LogTap> m_taps;
+    int m_nextTapId{1};
 };
 
 } // namespace AetherSDR

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -62,6 +62,9 @@ void DaxApplet::buildUI()
     daxEnRow->addStretch();
     m_daxEnable = new QPushButton("Enable");
     m_daxEnable->setCheckable(true);
+    m_daxEnable->setObjectName(QStringLiteral("daxEnable"));
+    m_daxEnable->setAccessibleName(tr("DAX enable"));
+    m_daxEnable->setAccessibleDescription(tr("Enable or disable DAX digital audio routing"));
     m_daxEnable->setStyleSheet(kGreenToggle);
     m_daxEnable->setFixedSize(60, 22);
     daxEnRow->addWidget(m_daxEnable);

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -206,6 +206,9 @@ void TciApplet::buildUI()
     m_tciPort->setStyleSheet(kInsetStyle);
     m_tciPort->setFixedWidth(46);
     m_tciPort->setAlignment(Qt::AlignCenter);
+    m_tciPort->setObjectName(QStringLiteral("tciPort"));
+    m_tciPort->setAccessibleName(tr("TCI port"));
+    m_tciPort->setAccessibleDescription(tr("TCP port the TCI server listens on"));
     enableRow->addWidget(m_tciPort);
 
     m_tciStatus = new QLabel("(stopped)");
@@ -214,6 +217,9 @@ void TciApplet::buildUI()
 
     m_tciEnable = new QPushButton("Enable");
     m_tciEnable->setCheckable(true);
+    m_tciEnable->setObjectName(QStringLiteral("tciEnable"));
+    m_tciEnable->setAccessibleName(tr("TCI server enable"));
+    m_tciEnable->setAccessibleDescription(tr("Start or stop the TCI server"));
     m_tciEnable->setStyleSheet(kGreenToggle);
     m_tciEnable->setFixedSize(60, 22);
     {

--- a/tools/automation_logwatch.py
+++ b/tools/automation_logwatch.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+AetherSDR automation-bridge log/observability helper (issue #3646).
+
+Companion to automation_probe.py. Drives the observability suite the bridge
+exposes when launched with AETHER_AUTOMATION=1:
+
+  log categories                 list logging categories + enabled state
+  log get <cat>                  whether a category is enabled
+  log set <cat> <on|off>         toggle a category at runtime (no restart)
+  log set all <on|off>           toggle every category
+  log reset                      restore the operator's persisted prefs
+  log tail [n] [since=<seq>]     pull recent ring events (default newest 100)
+  log subscribe / unsubscribe    push: stream events as they occur
+  mark <text>                    annotate the timeline; returns {seq, mono_us}
+
+Two correlation patterns:
+
+  * Pull (robust, single connection):
+        seq = client.mark("START")["seq"]
+        ... drive controls via the same or another connection ...
+        events = client.tail(since=seq)        # everything logged in between
+
+  * Push (live stream, dedicated connection):
+        with LogStream(cats=["aether.protocol"]) as stream:
+            ... drive controls on a separate Bridge ...
+        events = stream.events                 # collected in a reader thread
+
+Each event: {seq, mono_us, t:"HH:mm:ss.zzz", lvl:"D|I|W|C", cat, msg}.
+mono_us is a process-monotonic microsecond stamp (jitter-grade, NTP-immune).
+"""
+
+import argparse
+import json
+import sys
+import threading
+
+from automation_probe import Bridge, discover_socket
+
+
+class LogClient:
+    """Convenience wrappers over a Bridge for the log/mark verbs."""
+
+    def __init__(self, bridge):
+        self.b = bridge
+
+    def categories(self):
+        return self.b.request({"cmd": "log", "action": "categories"}).get("categories", [])
+
+    def get(self, cat):
+        return self.b.request({"cmd": "log", "action": "get", "value": cat}).get("enabled")
+
+    def set(self, cat, on=True):
+        return self.b.request({"cmd": "log", "action": "set",
+                               "value": f"{cat} {'on' if on else 'off'}"})
+
+    def set_all(self, on=True):
+        return self.b.request({"cmd": "log", "action": "set",
+                               "value": f"all {'on' if on else 'off'}"})
+
+    def reset(self):
+        return self.b.request({"cmd": "log", "action": "reset"})
+
+    def mark(self, text):
+        return self.b.request({"cmd": "mark", "value": text})
+
+    def tail(self, n=100, since=None):
+        val = str(n) + (f" since={since}" if since is not None else "")
+        return self.b.request({"cmd": "log", "action": "tail", "value": val}).get("events", [])
+
+
+class LogStream:
+    """Dedicated subscribe connection with a background reader thread.
+
+    Streamed event lines are read on their own socket so they never collide
+    with request/response traffic on a control connection.
+    """
+
+    def __init__(self, sock_path=None, cats=None, enable=True):
+        self._path = sock_path or discover_socket()
+        self.events = []
+        self._stop = threading.Event()
+        self._thread = None
+        self._cats = cats or []
+        self._enable = enable
+
+    def __enter__(self):
+        # Toggle requested categories via a short-lived control connection.
+        if self._cats and self._enable:
+            ctl = Bridge(self._path)
+            for c in self._cats:
+                ctl.request({"cmd": "log", "action": "set", "value": f"{c} on"})
+            ctl.close()
+        self._b = Bridge(self._path)
+        ack = self._b.request({"cmd": "log", "action": "subscribe"})
+        self.start_seq = ack.get("seq")
+        self._thread = threading.Thread(target=self._reader, daemon=True)
+        self._thread.start()
+        return self
+
+    def _reader(self):
+        while not self._stop.is_set():
+            try:
+                line = self._b._read_line_sock()
+            except Exception:
+                break
+            if isinstance(line, dict) and line.get("type") == "log":
+                self.events.append(line)
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        try:
+            self._b.close()  # closing the socket unblocks the reader's recv
+        except Exception:
+            pass
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="AetherSDR bridge log/observability helper")
+    ap.add_argument("action", choices=["categories", "get", "set", "reset",
+                                        "tail", "mark", "watch"])
+    ap.add_argument("rest", nargs="*")
+    ap.add_argument("--socket")
+    ap.add_argument("--secs", type=float, default=3.0, help="watch duration")
+    args = ap.parse_args()
+
+    path = args.socket or discover_socket()
+    if not path:
+        sys.exit("error: no bridge socket; launch with AETHER_AUTOMATION=1")
+
+    if args.action == "watch":
+        import time
+        with LogStream(path, cats=args.rest or None) as s:
+            time.sleep(args.secs)
+        for e in s.events:
+            print(f"{e['mono_us']:>10} {e['lvl']} {e['cat']}: {e['msg']}")
+        print(f"-- {len(s.events)} events in {args.secs}s", file=sys.stderr)
+        return
+
+    c = LogClient(Bridge(path))
+    if args.action == "categories":
+        for cat in c.categories():
+            print(f"{'x' if cat['enabled'] else ' '} {cat['id']:<28} {cat['label']}")
+    elif args.action == "get":
+        print(c.get(args.rest[0]))
+    elif args.action == "set":
+        print(json.dumps(c.set(args.rest[0], args.rest[1].lower() in ("on", "true", "1"))))
+    elif args.action == "reset":
+        print(json.dumps(c.reset()))
+    elif args.action == "mark":
+        print(json.dumps(c.mark(" ".join(args.rest))))
+    elif args.action == "tail":
+        n = int(args.rest[0]) if args.rest else 100
+        for e in c.tail(n):
+            print(f"{e['seq']:>5} {e['mono_us']:>10} {e['lvl']} {e['cat']}: {e['msg']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Extends the agent automation bridge (#3646, gated behind `AETHER_AUTOMATION`)
with **slice/VFO control**, **DAX/TCI accessibility**, and a full
**observability suite** — runtime log control, a high-resolution event channel,
and timeline markers. Together these let an agent drive the radio's core
surfaces and diagnose timer-, meter-, and protocol-reconcile issues with the
app's own event stream instead of poll-and-reconstruct.

Branches off `main`; independent of the other in-flight bridge PRs. The slice
DAX-recall crash fix is filed separately (#3733) and is **not** included here.

## Slice / VFO / accessibility

- **`slice add [freqMhz] | remove <id> | select <id>`** — slice lifecycle via
  `RadioModel`. `add` pre-checks radio-wide slot capacity and refuses with a
  clear message when full (slices are a MultiFlex-shared resource); `remove`
  guards the last slice like the GUI does.
- **`tune <freqMhz>`** — sets the active slice's frequency. The `VfoWidget` is
  custom-painted and was previously undriveable; honors the VFO lock.
- **`get radio` now reports `maxSlices` + `slots[]`** — per-slot occupancy
  (ours / foreign / empty, with the foreign owner's station), so a refused
  create is self-explaining and MultiFlex slice contention is observable.
- **A11y annotations** so the controls are screen-reader- and bridge-drivable:
  DaxApplet "DAX enable"; TciApplet "TCI port" + "TCI server enable".

## Observability suite

`LogManager` gains a diagnostic **tap** fanned out from its single
`enqueueMessage` funnel — every log message is offered to registered taps,
synchronously on the logging thread, after it is handed to the writer. The hash
is empty in normal runs, so it is near-free.

New bridge verbs (all diagnostic — no keying):

- **`log categories | get <cat> | set <cat> <on|off> | set all <on|off> | reset`**
  — runtime `QLoggingCategory` control with no restart: raise verbosity for a
  scrub, drop it after. `reset` restores the operator's persisted prefs.
- **`log tail [n] [since=<seq>]`** — pull a snapshot of the recent event ring.
- **`log subscribe` / `unsubscribe`** — push: stream `{"type":"log",...}` events
  to the client as they occur, via a 50 ms main-thread drain so socket writes
  stay thread-confined while the tap fills the ring from logging threads.
- **`mark <text>`** — inject a timeline annotation and return its `seq` +
  `mono_us`, so a driver can bracket actions: `mark "START"` → act →
  `log tail since=<seq>`.

Each event carries a process-**monotonic microsecond** timestamp
(`QElapsedTimer`, jitter-grade, NTP-immune) plus the wall `HH:mm:ss.zzz` to line
up with the log file. The ring holds raw text; **PII is redacted on egress**
(`redactPii`) so the tap stays cheap and nothing sensitive leaves the process.
Tap + drain are torn down first in `stop()` so no logging thread can touch a
half-destroyed server.

A `tools/automation_logwatch.py` helper (`LogClient` + `LogStream`) wraps both
correlation patterns: pull (`mark` → `tail since`) on one connection, and push
(`LogStream`, a dedicated subscribe socket with a reader thread) so streamed
events never collide with request/response traffic.

## Why it matters

The event stream surfaces **TX→RX protocol round-trip timing at microsecond
resolution** — e.g. a `slice tune` command and its `apd`/`atu`/`transmit` acks,
~7.5 ms apart — which a poll loop structurally cannot resolve. That is exactly
the visibility needed for the timer/meter/protocol-reconcile bug classes.

## Testing

Built clean off `main` (RelWithDebInfo, Qt 6.11, macOS arm64; full 1214-target
build) and validated live on a FLEX-8400M (radio config / RX only here — no
keying):

- log: 29 categories enumerated; runtime `set`/`get`/`reset`; `mark` → `tail
  since` returned the bracketed window; `subscribe` streamed events on a
  dedicated connection with µs timestamps.
- slice: `slots[]` occupancy correct; `add` → 2 slices; `tune` tracked; `remove`
  clean; per-slice S-meter (`SLC/LEVEL`) present on both indices when a second
  slice opens.

A broader sweep on the integration build (meters resolution/cadence, control
set/confirm/restore, and a two-tone TX into a dummy load on ANT1 — 32 W, SWR
1.18, PA current 7.67 A) exercised the same verbs end to end; those TX results
live with the TX-hardening work, not this PR.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
