### PR TITLE
fix(cat): resolve SmartSDR Flex/TS-2000 split behavior gaps and fix TS-2000 satellite-mode TX block

### DIFF
--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -391,7 +391,7 @@ QString SmartCatProtocol::cmdIF()
     body += modeToKenwood(a->mode());
     body += '0';
     body += '0';
-    body += splitActive() ? '1' : '0';
+    body += m_splitEnabled ? '1' : '0';
     body += '0';
     body += QStringLiteral("00");
     body += '0';
@@ -417,27 +417,16 @@ QString SmartCatProtocol::cmdZZSW(const QString& arg) { return splitCommand(QStr
 QString SmartCatProtocol::splitCommand(const QString& prefix, const QString& arg)
 {
     if (arg.isEmpty() || arg == "?")
-        return prefix + (splitActive() ? "1" : "0") + ";";
+        return prefix + (m_splitEnabled ? "1" : "0") + ";";
     if (arg == "1") return enableSplit();
     if (arg == "0") return disableSplit();
     return "?;";   // malformed arg → reject; never silently disable split
 }
 
-// Reported split state, derived from the model: split is on when a slice other
-// than the RX slice (A) is the TX slice. Avoids a stored flag that could drift
-// when split is changed via the GUI, rigctld, or another CAT client.
-bool SmartCatProtocol::splitActive() const
-{
-    if (!m_model) return false;
-    SliceModel* a = sliceA();
-    for (auto* s : m_model->slices())
-        if (s != a && s->isTxSlice()) return true;
-    return false;
-}
-
 // ── Split mechanism (manager-free: reuse the operator's VFO B, else NOT_ENABLED) ─
 QString SmartCatProtocol::enableSplit()
 {
+    if (m_splitEnabled) return {};   // idempotent — already split for this client
     SliceModel* a = sliceA();
     if (!a) return "?;";
     SliceModel* b = sliceB();
@@ -446,13 +435,19 @@ QString SmartCatProtocol::enableSplit()
     // Windows would create a dedicated TX slice here; that create-on-demand path is
     // deferred to the slice-management consolidation.
     if (!b) return "?;";
-    // Engage split by reusing the operator's VFO B as the TX slice. Only claim
-    // ownership (so teardown-on-disconnect undoes it) if it WASN'T already TX —
-    // i.e. don't adopt an operator's/another client's pre-existing split.
+    // Engage split by reusing the operator's VFO B as the TX slice. Claim ownership
+    // (so teardown-on-disconnect undoes it) ONLY if B wasn't already TX — i.e. don't
+    // adopt an operator's/another client's pre-existing split.
     if (!b->isTxSlice()) {
         b->setTxSlice(true);
         m_weEngagedSplit = true;
     }
+    // m_splitEnabled is the reported split state and is set SYNCHRONOUSLY: setTxSlice()
+    // only updates the slice's TX flag asynchronously (on the radio's status echo), so
+    // a read derived from isTxSlice() would report OFF in the window between enable and
+    // that echo. (Cross-consumer reconciliation — split changed via GUI/rigctld — is
+    // RFC #3715 territory.)
+    m_splitEnabled = true;
     return {};
 }
 
@@ -468,6 +463,7 @@ void SmartCatProtocol::teardownSplit()
     // Hand TX back to the RX slice (slice A); it was on the operator's VFO B.
     // No slice is removed — split never created one (reuse only).
     if (SliceModel* a = sliceA()) a->setTxSlice(true);
+    m_splitEnabled = false;
     m_weEngagedSplit = false;
     m_rxVfoB = false;   // clear the RX-VFO selector along with split
 }
@@ -1364,10 +1360,13 @@ QString SmartCatProtocol::cmdBY(const QString& /*arg*/)
 
 QString SmartCatProtocol::cmdOI()
 {
-    // OI reports the "other" (VFO B) IF. With no VFO B, return "?;" rather than
-    // falling back to VFO A — consistent with FB/ZZME (#3633); reporting VFO A's
-    // frequency as VFO B's is the exact contradiction that fix removed.
-    SliceModel* s = sliceB();
+    // OI is a composite STATUS block (like IF) and must always return a body, so
+    // with no VFO B it falls back to VFO A rather than "?;". (The #3633 "?;"-when-
+    // no-VFO-B rule applies to the FB/ZZME value reads, not this status block; a
+    // client polling OI expects a 35-char body, never an error — see CAT test 15.15.)
+    SliceModel* b = sliceB();
+    SliceModel* a = sliceA();
+    SliceModel* s = b ? b : a;
     if (!s) return "?;";
 
     QString body;
@@ -1381,7 +1380,7 @@ QString SmartCatProtocol::cmdOI()
     body += modeToKenwood(s->mode());
     body += '0';
     body += '0';
-    body += splitActive() ? '1' : '0';
+    body += m_splitEnabled ? '1' : '0';
     body += '0';
     body += QStringLiteral("00");
     body += '0';

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -108,9 +108,9 @@ SmartCatProtocol::SmartCatProtocol(RadioModel* model, int vfoA, int vfoB,
 
 SmartCatProtocol::~SmartCatProtocol()
 {
-    // Client disconnect: tear down an active split so a reused VFO B isn't left as
-    // TX. No slice is removed (split never created one — reuse only).
-    if (m_splitEnabled)
+    // Client disconnect: undo a split ONLY if WE engaged it (moved TX to VFO B).
+    // A split set up by the operator or another client must survive our disconnect.
+    if (m_weEngagedSplit)
         teardownSplit();
 }
 
@@ -196,13 +196,7 @@ QString SmartCatProtocol::processCommandImpl(const QString& cmd)
         if (name == "ZZFI") return cmdZZFI(arg);
         if (name == "ZZFJ") return cmdZZFJ(arg);
         if (name == "ZZFR") return cmdZZFR(arg);
-        if (name == "ZZFT") {
-            // Bare "ZZFT;" is a READ of split state, not a toggle. Polling it
-            // previously flipped split on every call (same defect class as ZZTX).
-            if (arg.isEmpty() || arg == "?")
-                return QString("ZZFT%1;").arg(m_splitEnabled ? "1" : "0");
-            return (arg == "1") ? enableSplit() : disableSplit();
-        }
+        if (name == "ZZFT") return splitCommand(QStringLiteral("ZZFT"), arg);
         if (name == "ZZGT") return cmdZZGT(arg);
         if (name == "ZZLE") return cmdZZLE(arg);
         if (name == "ZZLB") return cmdZZLB(arg);
@@ -397,7 +391,7 @@ QString SmartCatProtocol::cmdIF()
     body += modeToKenwood(a->mode());
     body += '0';
     body += '0';
-    body += m_splitEnabled ? '1' : '0';
+    body += splitActive() ? '1' : '0';
     body += '0';
     body += QStringLiteral("00");
     body += '0';
@@ -416,44 +410,56 @@ QString SmartCatProtocol::cmdZZIF()
 
 // ── FT / ZZSW — split enable ─────────────────────────────────────────────────
 
-QString SmartCatProtocol::cmdFT(const QString& arg)
+QString SmartCatProtocol::cmdFT(const QString& arg)   { return splitCommand(QStringLiteral("FT"), arg); }
+QString SmartCatProtocol::cmdZZSW(const QString& arg) { return splitCommand(QStringLiteral("ZZSW"), arg); }
+
+// Shared read/set for the FT / ZZSW / ZZFT split toggles.
+QString SmartCatProtocol::splitCommand(const QString& prefix, const QString& arg)
 {
-    if (arg.isEmpty())
-        return QString("FT%1;").arg(m_splitEnabled ? 1 : 0);
-    return (arg == "1") ? enableSplit() : disableSplit();
+    if (arg.isEmpty() || arg == "?")
+        return prefix + (splitActive() ? "1" : "0") + ";";
+    if (arg == "1") return enableSplit();
+    if (arg == "0") return disableSplit();
+    return "?;";   // malformed arg → reject; never silently disable split
 }
 
-QString SmartCatProtocol::cmdZZSW(const QString& arg)
+// Reported split state, derived from the model: split is on when a slice other
+// than the RX slice (A) is the TX slice. Avoids a stored flag that could drift
+// when split is changed via the GUI, rigctld, or another CAT client.
+bool SmartCatProtocol::splitActive() const
 {
-    if (arg.isEmpty())
-        return QString("ZZSW%1;").arg(m_splitEnabled ? "1" : "0");
-    return (arg == "1") ? enableSplit() : disableSplit();
+    if (!m_model) return false;
+    SliceModel* a = sliceA();
+    for (auto* s : m_model->slices())
+        if (s != a && s->isTxSlice()) return true;
+    return false;
 }
 
-// ── Split mechanism (manager-free: reuse VFO B, else NOT_ENABLED, else XIT) ───
+// ── Split mechanism (manager-free: reuse the operator's VFO B, else NOT_ENABLED) ─
 QString SmartCatProtocol::enableSplit()
 {
-    if (m_splitEnabled) return {};   // idempotent — already split
     SliceModel* a = sliceA();
     if (!a) return "?;";
-
-    // (1) Operator-configured VFO B slice present → use it as the TX slice.
-    if (SliceModel* b = sliceB()) {
+    SliceModel* b = sliceB();
+    // No usable VFO B slice → NOT_ENABLED, matching SmartSDR-for-Mac (covers both a
+    // VFO B configured-but-absent and a genuine single-VFO port). SmartSDR-for-
+    // Windows would create a dedicated TX slice here; that create-on-demand path is
+    // deferred to the slice-management consolidation.
+    if (!b) return "?;";
+    // Engage split by reusing the operator's VFO B as the TX slice. Only claim
+    // ownership (so teardown-on-disconnect undoes it) if it WASN'T already TX —
+    // i.e. don't adopt an operator's/another client's pre-existing split.
+    if (!b->isTxSlice()) {
         b->setTxSlice(true);
-        m_splitEnabled = true;
-        return {};
+        m_weEngagedSplit = true;
     }
-    // (2) No usable VFO B slice → NOT_ENABLED, matching SmartSDR-for-Mac. This
-    //     covers both a VFO B configured-but-absent and a genuine single-VFO port.
-    //     SmartSDR-for-Windows would instead create a dedicated TX slice on a
-    //     single-VFO port; that create-on-demand path is deferred to the
-    //     slice-management consolidation, so split is simply not enabled here.
-    return "?;";
+    return {};
 }
 
 QString SmartCatProtocol::disableSplit()
 {
-    if (m_splitEnabled) teardownSplit();
+    // Explicit client command (FT0/ZZSW0/ZZFT0): hand TX back to the RX slice.
+    teardownSplit();
     return {};
 }
 
@@ -462,7 +468,8 @@ void SmartCatProtocol::teardownSplit()
     // Hand TX back to the RX slice (slice A); it was on the operator's VFO B.
     // No slice is removed — split never created one (reuse only).
     if (SliceModel* a = sliceA()) a->setTxSlice(true);
-    m_splitEnabled = false;
+    m_weEngagedSplit = false;
+    m_rxVfoB = false;   // clear the RX-VFO selector along with split
 }
 
 // ── FR — RX VFO select ───────────────────────────────────────────────────────
@@ -1357,10 +1364,10 @@ QString SmartCatProtocol::cmdBY(const QString& /*arg*/)
 
 QString SmartCatProtocol::cmdOI()
 {
-    SliceModel* b = sliceB();
-    SliceModel* a = sliceA();
-    // Fall back to slice A if there is no VFO B
-    SliceModel* s = b ? b : a;
+    // OI reports the "other" (VFO B) IF. With no VFO B, return "?;" rather than
+    // falling back to VFO A — consistent with FB/ZZME (#3633); reporting VFO A's
+    // frequency as VFO B's is the exact contradiction that fix removed.
+    SliceModel* s = sliceB();
     if (!s) return "?;";
 
     QString body;
@@ -1374,7 +1381,7 @@ QString SmartCatProtocol::cmdOI()
     body += modeToKenwood(s->mode());
     body += '0';
     body += '0';
-    body += m_splitEnabled ? '1' : '0';
+    body += splitActive() ? '1' : '0';
     body += '0';
     body += QStringLiteral("00");
     body += '0';

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -9,8 +9,8 @@
 
 namespace AetherSDR {
 
-// Max RIT/XIT offset the radio accepts (±Hz). Used by RIT/XIT and the XIT-offset
-// split fallback. Declared here so it's visible to all handlers in this file.
+// Max RIT/XIT offset the radio accepts (±Hz). Declared here so it's visible to
+// all RIT/XIT handlers in this file.
 static constexpr int kRitMaxHz = 9999;
 
 // ── Mode conversion tables ──────────────────────────────────────────────────
@@ -109,8 +109,7 @@ SmartCatProtocol::SmartCatProtocol(RadioModel* model, int vfoA, int vfoB,
 SmartCatProtocol::~SmartCatProtocol()
 {
     // Client disconnect: tear down an active split so a reused VFO B isn't left as
-    // TX and an XIT-offset fallback isn't left applied on slice A. No slice is
-    // removed (split never created one — reuse/XIT only).
+    // TX. No slice is removed (split never created one — reuse only).
     if (m_splitEnabled)
         teardownSplit();
 }
@@ -309,23 +308,6 @@ QString SmartCatProtocol::cmdFA(const QString& arg)
 
 QString SmartCatProtocol::cmdFB(const QString& arg)
 {
-    // XIT-fallback split (no VFO B slice): VFO B is slice A's frequency plus the
-    // XIT offset; setting VFO B sets the XIT offset.
-    if (m_xitSplit) {
-        SliceModel* a = sliceA();
-        if (!a) return "?;";
-        if (arg.isEmpty())
-            return "FB" + freqField(a->frequency() + a->xitFreq() / 1e6) + ";";
-        bool ok;
-        double hz = arg.toDouble(&ok);
-        if (!ok) return "?;";
-        const int offset = qRound(hz - a->frequency() * 1e6);
-        // Reject an out-of-range split rather than silently clamping — clamping
-        // would put TX on a frequency the controller never asked for.
-        if (offset < -kRitMaxHz || offset > kRitMaxHz) return "?;";
-        a->setXit(true, offset);
-        return {};
-    }
     SliceModel* b = sliceB();
     // No VFO B → "?;" (do NOT fall back to VFO A). The old VFO-A fallback reported
     // VFO A's frequency for FB while ZZME returned "?;"; that contradiction broke
@@ -370,9 +352,7 @@ QString SmartCatProtocol::cmdZZMD(const QString& arg)
 
 QString SmartCatProtocol::cmdZZME(const QString& arg)
 {
-    // XIT-fallback split shares slice A (no second slice), so VFO B's mode IS
-    // slice A's mode (XIT shifts frequency, not mode).
-    SliceModel* b = m_xitSplit ? sliceA() : sliceB();
+    SliceModel* b = sliceB();
     if (!b) return "?;";
     if (arg.isEmpty())
         return "ZZME" + modeToZZ(b->mode()) + ";";
@@ -451,18 +431,12 @@ QString SmartCatProtocol::enableSplit()
         m_splitEnabled = true;
         return {};
     }
-    // (2) VFO B configured for this port but its slice is absent → NOT_ENABLED.
-    //     Honor the specific VFO B the port asked for (matches SmartSDR-for-Mac).
-    if (m_vfoB >= 0)
-        return "?;";
-    // (3) Genuine single-VFO port → XIT-offset fallback on slice A (TX = RX +
-    //     offset, 0 until set via FB/ZZFB). NOTE: SmartSDR-for-Windows would
-    //     create a dedicated TX slice here; that create-on-demand path is deferred
-    //     to the slice-management consolidation, so we fall back to XIT for now.
-    m_xitSplit = true;
-    a->setXit(true, a->xitFreq());
-    m_splitEnabled = true;
-    return {};
+    // (2) No usable VFO B slice → NOT_ENABLED, matching SmartSDR-for-Mac. This
+    //     covers both a VFO B configured-but-absent and a genuine single-VFO port.
+    //     SmartSDR-for-Windows would instead create a dedicated TX slice on a
+    //     single-VFO port; that create-on-demand path is deferred to the
+    //     slice-management consolidation, so split is simply not enabled here.
+    return "?;";
 }
 
 QString SmartCatProtocol::disableSplit()
@@ -473,19 +447,13 @@ QString SmartCatProtocol::disableSplit()
 
 void SmartCatProtocol::teardownSplit()
 {
-    SliceModel* a = sliceA();
-    if (m_xitSplit) {
-        if (a) a->setXit(false, 0);
-        m_xitSplit = false;
-    }
-    // Hand TX back to the RX slice (slice A); it was on the operator's VFO B
-    // (XIT leaves TX on A already, so this is a no-op there). No slice is removed
-    // — split never created one (reuse/XIT only).
-    if (a) a->setTxSlice(true);
+    // Hand TX back to the RX slice (slice A); it was on the operator's VFO B.
+    // No slice is removed — split never created one (reuse only).
+    if (SliceModel* a = sliceA()) a->setTxSlice(true);
     m_splitEnabled = false;
 }
 
-// ── FR — RX VFO select (accepted, no-op) ─────────────────────────────────────
+// ── FR — RX VFO select ───────────────────────────────────────────────────────
 
 // FR — RX VFO select (TS-2000). FR0 = VFO A, FR1 = VFO B. Per SmartSDR-for-Mac:
 // FR1 is accepted only when a real second VFO exists (a configured VFO B with a

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -1148,7 +1148,7 @@ QString SmartCatProtocol::cmdSH(const QString& arg)
 // class as ZZTX). Selecting the non-active VFO swaps the A/B slice mapping;
 // re-selecting the active VFO is a no-op (idempotent).
 
-QString SmartCatProtocol::cmdZZFR(const QString& arg)
+QString SmartCatProtocol::cmdZZFR(const QString& /*arg*/)
 {
     // ZZFR is not part of the SmartSDR CAT command set — it is unsupported.
     // (RX-VFO selection is done via the Kenwood FR command; see cmdFR.) The old

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -9,6 +9,10 @@
 
 namespace AetherSDR {
 
+// Max RIT/XIT offset the radio accepts (±Hz). Used by RIT/XIT and the XIT-offset
+// split fallback. Declared here so it's visible to all handlers in this file.
+static constexpr int kRitMaxHz = 9999;
+
 // ── Mode conversion tables ──────────────────────────────────────────────────
 //
 // SmartSDR mode strings verified against FLEX-8600 fw v1.4.0.0.
@@ -102,6 +106,15 @@ SmartCatProtocol::SmartCatProtocol(RadioModel* model, int vfoA, int vfoB,
     , m_flexExtensions(flexExtensions)
 {}
 
+SmartCatProtocol::~SmartCatProtocol()
+{
+    // Client disconnect: tear down an active split so a reused VFO B isn't left as
+    // TX and an XIT-offset fallback isn't left applied on slice A. No slice is
+    // removed (split never created one — reuse/XIT only).
+    if (m_splitEnabled)
+        teardownSplit();
+}
+
 // ── Slice accessors ─────────────────────────────────────────────────────────
 
 SliceModel* SmartCatProtocol::sliceA() const
@@ -189,8 +202,7 @@ QString SmartCatProtocol::processCommandImpl(const QString& cmd)
             // previously flipped split on every call (same defect class as ZZTX).
             if (arg.isEmpty() || arg == "?")
                 return QString("ZZFT%1;").arg(m_splitEnabled ? "1" : "0");
-            m_splitEnabled = (arg == "1");
-            return {};
+            return (arg == "1") ? enableSplit() : disableSplit();
         }
         if (name == "ZZGT") return cmdZZGT(arg);
         if (name == "ZZLE") return cmdZZLE(arg);
@@ -297,14 +309,28 @@ QString SmartCatProtocol::cmdFA(const QString& arg)
 
 QString SmartCatProtocol::cmdFB(const QString& arg)
 {
-    SliceModel* b = sliceB();
-    if (!b) {
+    // XIT-fallback split (no VFO B slice): VFO B is slice A's frequency plus the
+    // XIT offset; setting VFO B sets the XIT offset.
+    if (m_xitSplit) {
         SliceModel* a = sliceA();
         if (!a) return "?;";
         if (arg.isEmpty())
-            return "FB" + freqField(a->frequency()) + ";";
+            return "FB" + freqField(a->frequency() + a->xitFreq() / 1e6) + ";";
+        bool ok;
+        double hz = arg.toDouble(&ok);
+        if (!ok) return "?;";
+        const int offset = qRound(hz - a->frequency() * 1e6);
+        // Reject an out-of-range split rather than silently clamping — clamping
+        // would put TX on a frequency the controller never asked for.
+        if (offset < -kRitMaxHz || offset > kRitMaxHz) return "?;";
+        a->setXit(true, offset);
         return {};
     }
+    SliceModel* b = sliceB();
+    // No VFO B → "?;" (do NOT fall back to VFO A). The old VFO-A fallback reported
+    // VFO A's frequency for FB while ZZME returned "?;"; that contradiction broke
+    // controllers' VFO sync (#3633).
+    if (!b) return "?;";
     if (arg.isEmpty())
         return "FB" + freqField(b->frequency()) + ";";
     bool ok;
@@ -344,7 +370,9 @@ QString SmartCatProtocol::cmdZZMD(const QString& arg)
 
 QString SmartCatProtocol::cmdZZME(const QString& arg)
 {
-    SliceModel* b = sliceB();
+    // XIT-fallback split shares slice A (no second slice), so VFO B's mode IS
+    // slice A's mode (XIT shifts frequency, not mode).
+    SliceModel* b = m_xitSplit ? sliceA() : sliceB();
     if (!b) return "?;";
     if (arg.isEmpty())
         return "ZZME" + modeToZZ(b->mode()) + ";";
@@ -400,23 +428,79 @@ QString SmartCatProtocol::cmdFT(const QString& arg)
 {
     if (arg.isEmpty())
         return QString("FT%1;").arg(m_splitEnabled ? 1 : 0);
-    m_splitEnabled = (arg == "1");
-    return {};
+    return (arg == "1") ? enableSplit() : disableSplit();
 }
 
 QString SmartCatProtocol::cmdZZSW(const QString& arg)
 {
     if (arg.isEmpty())
         return QString("ZZSW%1;").arg(m_splitEnabled ? "1" : "0");
-    m_splitEnabled = (arg == "1");
+    return (arg == "1") ? enableSplit() : disableSplit();
+}
+
+// ── Split mechanism (manager-free: reuse VFO B, else NOT_ENABLED, else XIT) ───
+QString SmartCatProtocol::enableSplit()
+{
+    if (m_splitEnabled) return {};   // idempotent — already split
+    SliceModel* a = sliceA();
+    if (!a) return "?;";
+
+    // (1) Operator-configured VFO B slice present → use it as the TX slice.
+    if (SliceModel* b = sliceB()) {
+        b->setTxSlice(true);
+        m_splitEnabled = true;
+        return {};
+    }
+    // (2) VFO B configured for this port but its slice is absent → NOT_ENABLED.
+    //     Honor the specific VFO B the port asked for (matches SmartSDR-for-Mac).
+    if (m_vfoB >= 0)
+        return "?;";
+    // (3) Genuine single-VFO port → XIT-offset fallback on slice A (TX = RX +
+    //     offset, 0 until set via FB/ZZFB). NOTE: SmartSDR-for-Windows would
+    //     create a dedicated TX slice here; that create-on-demand path is deferred
+    //     to the slice-management consolidation, so we fall back to XIT for now.
+    m_xitSplit = true;
+    a->setXit(true, a->xitFreq());
+    m_splitEnabled = true;
     return {};
+}
+
+QString SmartCatProtocol::disableSplit()
+{
+    if (m_splitEnabled) teardownSplit();
+    return {};
+}
+
+void SmartCatProtocol::teardownSplit()
+{
+    SliceModel* a = sliceA();
+    if (m_xitSplit) {
+        if (a) a->setXit(false, 0);
+        m_xitSplit = false;
+    }
+    // Hand TX back to the RX slice (slice A); it was on the operator's VFO B
+    // (XIT leaves TX on A already, so this is a no-op there). No slice is removed
+    // — split never created one (reuse/XIT only).
+    if (a) a->setTxSlice(true);
+    m_splitEnabled = false;
 }
 
 // ── FR — RX VFO select (accepted, no-op) ─────────────────────────────────────
 
-QString SmartCatProtocol::cmdFR(const QString& /*arg*/)
+// FR — RX VFO select (TS-2000). FR0 = VFO A, FR1 = VFO B. Per SmartSDR-for-Mac:
+// FR1 is accepted only when a real second VFO exists (a configured VFO B with a
+// present slice), else "?;". FA always reports VFO A (no A/B swap); FR; reports
+// the current selector.
+QString SmartCatProtocol::cmdFR(const QString& arg)
 {
-    return {};
+    if (arg.isEmpty() || arg == "?")
+        return QString("FR%1;").arg(m_rxVfoB ? 1 : 0);
+    if (arg == "0") { m_rxVfoB = false; return {}; }
+    if (arg == "1") {
+        if (m_vfoB >= 0 && sliceB()) { m_rxVfoB = true; return {}; }
+        return "?;";   // no real VFO B defined → cannot select it
+    }
+    return "?;";       // FR2 (memory) and other values unsupported
 }
 
 // ── TX / ZZTX — PTT on ───────────────────────────────────────────────────────
@@ -525,8 +609,6 @@ static QString zzToAgcMode(const QString& code)
     if (code == "4") return "fast";
     return "med";
 }
-
-static constexpr int kRitMaxHz = 9999;
 
 // ── AG / ZZAG — VFO A audio gain (0-100, 3-digit) ───────────────────────────
 
@@ -1085,15 +1167,11 @@ QString SmartCatProtocol::cmdSH(const QString& arg)
 
 QString SmartCatProtocol::cmdZZFR(const QString& arg)
 {
-    if (arg.isEmpty() || arg == "?")
-        return QString("ZZFR%1;").arg(m_rxVfoB ? "1" : "0");
-    if (arg != "0" && arg != "1") return "?;";
-    const bool wantB = (arg == "1");
-    if (wantB != m_rxVfoB) {
-        std::swap(m_vfoA, m_vfoB);
-        m_rxVfoB = wantB;
-    }
-    return {};
+    // ZZFR is not part of the SmartSDR CAT command set — it is unsupported.
+    // (RX-VFO selection is done via the Kenwood FR command; see cmdFR.) The old
+    // implementation swapped m_vfoA/m_vfoB, an invented behavior with no SmartSDR
+    // equivalent that corrupted the VFO mapping — removed.
+    return "?;";
 }
 
 // ── SQ — squelch level (P1=main/sub selector, P2=000-255) ────────────────────

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -244,6 +244,18 @@ QString SmartCatProtocol::processCommandImpl(const QString& cmd)
         }
         if (name == "FT") return cmdFT(arg);
         if (name == "FR") return cmdFR(arg);
+        if (name == "SA") {
+            // Satellite mode (TS-2000). We are never in satellite mode. Hamlib's
+            // TS-2000 backend queries SA; before VFO ops (set_vfo, reached via
+            // set_split_mode), and treats the generic unknown-command "?;" as a
+            // fatal rejection (-9) — which aborts WSJT-X's set_split_freq_mode in
+            // TS-2000 mode. Report satellite OFF so it proceeds. (First empirical
+            // form: P1=0. If Hamlib's parser needs the full fixed-width SA answer,
+            // widen this.)
+            if (arg.isEmpty() || arg == "?")
+                return QStringLiteral("SA0;");
+            return {};   // accept any SA set as a no-op
+        }
         if (name == "LK") return cmdLK(arg);
         if (name == "MG") return cmdMG(arg);
         if (name == "NB") return cmdNB(arg);

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -19,6 +19,9 @@ public:
     explicit SmartCatProtocol(RadioModel* model,
                               int vfoA = 0, int vfoB = -1,
                               bool flexExtensions = true);
+    // On client disconnect, tear down an active split (restore TX to slice A,
+    // clear any XIT-offset fallback) so it isn't left applied on the radio.
+    ~SmartCatProtocol();
 
     QString processCommand(const QString& cmd);
 
@@ -150,6 +153,13 @@ private:
     QString cmdZZBI(const QString& arg);
     QString cmdZZDE(const QString& arg);
     QString cmdZZFR(const QString& arg);
+    // Split mechanism (manager-free): reuse the operator-configured VFO B slice if
+    // present; else NOT_ENABLED ("?;") when a VFO B is configured but absent; else
+    // an XIT-offset fallback on slice A. Dedicated-TX-slice creation on a genuine
+    // single-VFO port is deferred to the slice-management consolidation.
+    QString enableSplit();
+    QString disableSplit();
+    void    teardownSplit();
 
     QString processCommandImpl(const QString& cmd);
 
@@ -165,6 +175,7 @@ private:
     bool        m_flexExtensions{true};
     bool        m_aiEnabled{false};
     bool        m_splitEnabled{false};
+    bool        m_xitSplit{false};  // XIT-offset split fallback active (no VFO B slice)
     bool        m_rxVfoB{false};   // false = VFO A is the RX VFO (FR/ZZFR selector)
     bool        m_pttAssertedByMe{false};
 };

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -160,6 +160,14 @@ private:
     QString enableSplit();
     QString disableSplit();
     void    teardownSplit();
+    // Reported split state, DERIVED from the model (a non-RX slice is the TX slice)
+    // rather than a stored flag — so it can't drift when split is changed via the
+    // GUI/rigctld/another client.
+    bool    splitActive() const;
+    // Shared read/set for the three split toggles (FT / ZZSW / ZZFT): read form
+    // (empty or "?") returns "<prefix><0|1>"; "1"/"0" enable/disable; anything else
+    // → "?;" (never silently disables on a malformed arg).
+    QString splitCommand(const QString& prefix, const QString& arg);
 
     QString processCommandImpl(const QString& cmd);
 
@@ -174,8 +182,12 @@ private:
     int         m_vfoB{-1};
     bool        m_flexExtensions{true};
     bool        m_aiEnabled{false};
-    bool        m_splitEnabled{false};
-    bool        m_rxVfoB{false};   // false = VFO A is the RX VFO (FR/ZZFR selector)
+    // True only when WE moved TX onto VFO B, so a disconnect undoes only our own
+    // split — never an operator's or another client's. (Reported split state is
+    // derived via splitActive(), not this flag.)
+    bool        m_weEngagedSplit{false};
+    bool        m_rxVfoB{false};   // false = VFO A is the RX VFO. FR selector echo only:
+                                   // intentionally does NOT swap VFOs (SmartSDR-Mac parity).
     bool        m_pttAssertedByMe{false};
 };
 

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -19,8 +19,8 @@ public:
     explicit SmartCatProtocol(RadioModel* model,
                               int vfoA = 0, int vfoB = -1,
                               bool flexExtensions = true);
-    // On client disconnect, tear down an active split (restore TX to slice A,
-    // clear any XIT-offset fallback) so it isn't left applied on the radio.
+    // On client disconnect, tear down an active split (restore TX to slice A)
+    // so it isn't left applied on the radio.
     ~SmartCatProtocol();
 
     QString processCommand(const QString& cmd);
@@ -154,9 +154,9 @@ private:
     QString cmdZZDE(const QString& arg);
     QString cmdZZFR(const QString& arg);
     // Split mechanism (manager-free): reuse the operator-configured VFO B slice if
-    // present; else NOT_ENABLED ("?;") when a VFO B is configured but absent; else
-    // an XIT-offset fallback on slice A. Dedicated-TX-slice creation on a genuine
-    // single-VFO port is deferred to the slice-management consolidation.
+    // present; else NOT_ENABLED ("?;"). Dedicated-TX-slice creation on a genuine
+    // single-VFO port (the SmartSDR-for-Windows behavior) is deferred to the
+    // slice-management consolidation.
     QString enableSplit();
     QString disableSplit();
     void    teardownSplit();
@@ -175,7 +175,6 @@ private:
     bool        m_flexExtensions{true};
     bool        m_aiEnabled{false};
     bool        m_splitEnabled{false};
-    bool        m_xitSplit{false};  // XIT-offset split fallback active (no VFO B slice)
     bool        m_rxVfoB{false};   // false = VFO A is the RX VFO (FR/ZZFR selector)
     bool        m_pttAssertedByMe{false};
 };

--- a/src/core/SmartCatProtocol.h
+++ b/src/core/SmartCatProtocol.h
@@ -160,10 +160,6 @@ private:
     QString enableSplit();
     QString disableSplit();
     void    teardownSplit();
-    // Reported split state, DERIVED from the model (a non-RX slice is the TX slice)
-    // rather than a stored flag — so it can't drift when split is changed via the
-    // GUI/rigctld/another client.
-    bool    splitActive() const;
     // Shared read/set for the three split toggles (FT / ZZSW / ZZFT): read form
     // (empty or "?") returns "<prefix><0|1>"; "1"/"0" enable/disable; anything else
     // → "?;" (never silently disables on a malformed arg).
@@ -182,9 +178,13 @@ private:
     int         m_vfoB{-1};
     bool        m_flexExtensions{true};
     bool        m_aiEnabled{false};
+    // Reported split state (this client's intent). Set SYNCHRONOUSLY in
+    // enableSplit/teardownSplit because setTxSlice() updates the slice's TX flag
+    // only asynchronously (radio status echo); a model-derived read would be stale
+    // in the window right after enable/disable.
+    bool        m_splitEnabled{false};
     // True only when WE moved TX onto VFO B, so a disconnect undoes only our own
-    // split — never an operator's or another client's. (Reported split state is
-    // derived via splitActive(), not this flag.)
+    // split — never an operator's or another client's.
     bool        m_weEngagedSplit{false};
     bool        m_rxVfoB{false};   // false = VFO A is the RX VFO. FR selector echo only:
                                    // intentionally does NOT swap VFOs (SmartSDR-Mac parity).

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -1072,32 +1072,30 @@ void section13(CatClient& c, Runner& r)
     c.send(origBi);
     QThread::msleep(200);
 
-    // ── ZZFR: RX VFO select (0=A, 1=B) — bare form is a READ, not a swap ──────
+    // ── ZZFR: unsupported per the SmartSDR CAT spec → "?;" (RX-VFO selection is
+    //    the Kenwood FR command; see the TS-2000 suite). The old swap-based
+    //    selector — which std::swap'd VFO A/B with no SmartSDR equivalent — was
+    //    removed. All forms (read and set) return "?;" and must NOT move any VFO.
     QString faBefore = c.query(QStringLiteral("ZZFA"));
-    QString fbBefore = c.query(QStringLiteral("ZZFB"));
-    // 13.34r REGRESSION: bare "ZZFR;" reads the selector and must NOT swap VFOs.
+    // 13.34r bare "ZZFR;" → "?" (unsupported) and does not swap VFOs.
     QString zzfrRead = c.query(QStringLiteral("ZZFR"));
     QThread::msleep(50);
     QString faUnchanged = c.query(QStringLiteral("ZZFA"));
-    r.check(QStringLiteral("13.34r bare ZZFR; reads selector ('ZZFR0') without swapping"),
-            zzfrRead == QLatin1String("ZZFR0") && faUnchanged.mid(4) == faBefore.mid(4),
+    r.check(QStringLiteral("13.34r ZZFR; → \"?\" (unsupported) and does not swap VFOs"),
+            zzfrRead == QLatin1String("?") && faUnchanged.mid(4) == faBefore.mid(4),
             QStringLiteral("read=%1 ZZFA before=%2 after=%3")
                 .arg(repr(zzfrRead), repr(faBefore.mid(4)), repr(faUnchanged.mid(4))));
-    // 13.34 explicit select: ZZFR1 selects VFO B as RX → new ZZFA matches old ZZFB.
-    c.send(QStringLiteral("ZZFR1"));
+    // 13.34 ZZFR1; / ZZFR0; are also unsupported → "?" and leave VFO A untouched.
+    // (query, not send: these now reply "?;" — must be consumed or the read stream
+    //  desyncs.)
+    QString zzfr1 = c.query(QStringLiteral("ZZFR1"));
     QThread::msleep(50);
     QString faAfter = c.query(QStringLiteral("ZZFA"));
-    QString zzfrAfter = c.query(QStringLiteral("ZZFR"));
-    // If VFO A and B differ, after ZZFR1 the new ZZFA should match old ZZFB.
-    // If they're equal (single-slice session), the swap is a no-op — treat as pass.
-    const bool zzfrOk = (faBefore.mid(4) == fbBefore.mid(4))
-                        ? true
-                        : (faAfter.mid(4) == fbBefore.mid(4));
-    r.check(QStringLiteral("13.34 ZZFR1; selects VFO B — new ZZFA matches old ZZFB; ZZFR; → 'ZZFR1'"),
-            zzfrOk && zzfrAfter == QLatin1String("ZZFR1"),
-            QStringLiteral("before: ZZFA=%1 ZZFB=%2 after ZZFA=%3 sel=%4")
-                .arg(repr(faBefore.mid(4)), repr(fbBefore.mid(4)), repr(faAfter.mid(4)), repr(zzfrAfter)));
-    c.send(QStringLiteral("ZZFR0"));  // select VFO A again (swap back)
+    r.check(QStringLiteral("13.34 ZZFR1; → \"?\" (unsupported) and does not change VFO A"),
+            zzfr1 == QLatin1String("?") && faAfter.mid(4) == faBefore.mid(4),
+            QStringLiteral("ZZFR1=%1 ZZFA before=%2 after=%3")
+                .arg(repr(zzfr1), repr(faBefore.mid(4)), repr(faAfter.mid(4))));
+    c.query(QStringLiteral("ZZFR0"));  // also "?;" — consume the reply
     QThread::msleep(50);
 
     // ── ZZAR: VFO A AGC threshold (0-100, 3-digit) ───────────────────────────

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -1474,6 +1474,15 @@ void section15pty(Runner& r, const QString& ptyPath)
 }
 #endif
 
+// Skipped form when --pty was not passed: don't try the round-trip (it would just
+// time out against a PTY that isn't wired up) — skip cleanly instead.
+void section15skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 15 — PTY round-trip (skipped — pass --pty PATH to enable)"));
+    for (const char* name : { "15.1 PTY ID;", "15.2 PTY ZZFA;", "15.3 PTY PS;" })
+        r.skip(QString::fromLatin1(name), QStringLiteral("--pty not set"));
+}
+
 } // namespace
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1508,6 +1517,7 @@ int main(int argc, char* argv[])
     const int     timeout = parser.value(QStringLiteral("timeout")).toInt();
     const bool    doPtt   = parser.isSet(QStringLiteral("ptt"));
     const bool    doCw    = parser.isSet(QStringLiteral("cw"));
+    const bool    doPty   = parser.isSet(QStringLiteral("pty"));
 
     std::cout << '\n' << bold(QStringLiteral("AetherSDR FlexCAT (ZZ-extension) Test Suite")).toStdString() << '\n'
               << "Connecting to " << host.toStdString() << ':' << port << " ...\n";
@@ -1552,7 +1562,7 @@ int main(int argc, char* argv[])
     section13(c, r);
     if (doCw) { section14cw(c, r); } else { section14skip(r); }
     section16(c, r);
-    section15pty(r, parser.value(QStringLiteral("pty")));
+    if (doPty) { section15pty(r, parser.value(QStringLiteral("pty"))); } else { section15skip(r); }
 
     // Restore radio state
     c.send(QStringLiteral("ZZAI00"));

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -204,6 +204,14 @@ static QString hz11(qint64 hz)
     return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
 }
 
+// Does this port have a usable VFO B? ZZFB returns its frequency when present, or
+// "?" (NOT_ENABLED) on a single-VFO port / when the VFO B slice isn't open. Single
+// definition so the split-section gates can't drift apart.
+static bool hasVfoB(CatClient& c)
+{
+    return c.query(QStringLiteral("ZZFB")).startsWith(QLatin1String("ZZFB"));
+}
+
 static bool isDigits(const QString& s, int n)
 {
     if (s.size() != n) return false;
@@ -600,7 +608,7 @@ void section8(CatClient& c, Runner& r)
     // read stream if issued with send(). Detect VFO B; when absent, verify the
     // NOT_ENABLED behavior with query() (consuming the "?") and return, keeping
     // the stream in sync.
-    const bool vfoB = c.query(QStringLiteral("ZZFB")).startsWith(QLatin1String("ZZFB"));
+    const bool vfoB = hasVfoB(c);
     if (!vfoB) {
         const QString sw0 = c.query(QStringLiteral("ZZSW"));
         r.check(QStringLiteral("8.1  ZZSW; → ZZSW0 (split off, single VFO)"),
@@ -862,7 +870,7 @@ void section12(CatClient& c, Runner& r)
     // 12.7/12.8 cross-check FT<->ZZSW split agreement — needs a usable VFO B. On a
     // single-VFO port split can't engage (FT1 → "?"), so skip to avoid desyncing
     // the stream; the NOT_ENABLED behavior is covered in section 8.
-    if (c.query(QStringLiteral("ZZFB")).startsWith(QLatin1String("ZZFB"))) {
+    if (hasVfoB(c)) {
         c.send(QStringLiteral("FT1"));
         resp = c.query(QStringLiteral("ZZSW"));
         r.check(QStringLiteral("12.7 set split via FT1; → ZZSW; → ZZSW1"),

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -368,8 +368,12 @@ void section3(CatClient& c, Runner& r)
     r.section(QStringLiteral("Section 3 — ZZFB — VFO-B Frequency"));
 
     QString resp = c.query(QStringLiteral("ZZFB"));
-    r.check(QStringLiteral("3.1  ZZFB; returns \"ZZFB\" + 11-digit Hz"),
-            resp.startsWith(QLatin1String("ZZFB")) && isDigits(resp.mid(4), 11), repr(resp));
+    // Dual port → "ZZFB"+11-digit Hz; single-VFO (or VFO B slice absent) → "?"
+    // (NOT_ENABLED, no VFO-A fallback, #3633). Accept either so the suite is clean
+    // on both port types.
+    r.check(QStringLiteral("3.1  ZZFB; → \"ZZFB\"+11-digit Hz, or \"?\" when no VFO B (#3633)"),
+            (resp.startsWith(QLatin1String("ZZFB")) && isDigits(resp.mid(4), 11))
+                || resp == QLatin1String("?"), repr(resp));
 
     QString fbResp = c.query(QStringLiteral("FB"));
     r.check(QStringLiteral("3.2  ZZFB; and FB; agree"),
@@ -589,6 +593,32 @@ void section7(CatClient& c, Runner& r)
 void section8(CatClient& c, Runner& r)
 {
     r.section(QStringLiteral("Section 8 — ZZSW — Split"));
+
+    // The dual-VFO tests below assume a usable VFO B. On a single-VFO port (or a
+    // port whose VFO B slice isn't open) split cannot engage, so enable commands
+    // return "?" (NOT_ENABLED) instead of a silent ack — which would desync the
+    // read stream if issued with send(). Detect VFO B; when absent, verify the
+    // NOT_ENABLED behavior with query() (consuming the "?") and return, keeping
+    // the stream in sync.
+    const bool vfoB = c.query(QStringLiteral("ZZFB")).startsWith(QLatin1String("ZZFB"));
+    if (!vfoB) {
+        const QString sw0 = c.query(QStringLiteral("ZZSW"));
+        r.check(QStringLiteral("8.1  ZZSW; → ZZSW0 (split off, single VFO)"),
+                sw0 == QLatin1String("ZZSW0"), repr(sw0));
+        const QString sw1 = c.query(QStringLiteral("ZZSW1"));
+        r.check(QStringLiteral("8.2  ZZSW1; with no VFO B → \"?\" (NOT_ENABLED)"),
+                sw1 == QLatin1String("?"), repr(sw1));
+        const QString ft1 = c.query(QStringLiteral("FT1"));
+        r.check(QStringLiteral("8.3  FT1; with no VFO B → \"?\" (NOT_ENABLED)"),
+                ft1 == QLatin1String("?"), repr(ft1));
+        const QString zft1 = c.query(QStringLiteral("ZZFT1"));
+        r.check(QStringLiteral("8.4  ZZFT1; with no VFO B → \"?\" (NOT_ENABLED)"),
+                zft1 == QLatin1String("?"), repr(zft1));
+        const QString sw0b = c.query(QStringLiteral("ZZSW"));
+        r.check(QStringLiteral("8.5  split still off (ZZSW0) after rejected enables"),
+                sw0b == QLatin1String("ZZSW0"), repr(sw0b));
+        return;
+    }
 
     QString resp = c.query(QStringLiteral("ZZSW"));
     r.check(QStringLiteral("8.1  ZZSW; → ZZSW0 (split off initially)"),
@@ -829,15 +859,25 @@ void section12(CatClient& c, Runner& r)
     setAndPollMode(QStringLiteral("12.6 set mode via ZZMD09 (DIGL)"),
                    QStringLiteral("ZZMD09"), QStringLiteral("ZZMD09"), QStringLiteral("MD6"));
 
-    c.send(QStringLiteral("FT1"));
-    resp = c.query(QStringLiteral("ZZSW"));
-    r.check(QStringLiteral("12.7 set split via FT1; → ZZSW; → ZZSW1"),
-            resp == QLatin1String("ZZSW1"), repr(resp));
+    // 12.7/12.8 cross-check FT<->ZZSW split agreement — needs a usable VFO B. On a
+    // single-VFO port split can't engage (FT1 → "?"), so skip to avoid desyncing
+    // the stream; the NOT_ENABLED behavior is covered in section 8.
+    if (c.query(QStringLiteral("ZZFB")).startsWith(QLatin1String("ZZFB"))) {
+        c.send(QStringLiteral("FT1"));
+        resp = c.query(QStringLiteral("ZZSW"));
+        r.check(QStringLiteral("12.7 set split via FT1; → ZZSW; → ZZSW1"),
+                resp == QLatin1String("ZZSW1"), repr(resp));
 
-    c.send(QStringLiteral("ZZSW0"));
-    resp = c.query(QStringLiteral("FT"));
-    r.check(QStringLiteral("12.8 clear split via ZZSW0; → FT; → FT0"),
-            resp == QLatin1String("FT0"), repr(resp));
+        c.send(QStringLiteral("ZZSW0"));
+        resp = c.query(QStringLiteral("FT"));
+        r.check(QStringLiteral("12.8 clear split via ZZSW0; → FT; → FT0"),
+                resp == QLatin1String("FT0"), repr(resp));
+    } else {
+        r.skip(QStringLiteral("12.7 set split via FT1 (FT<->ZZSW cross-check)"),
+               QStringLiteral("no VFO B (single-VFO port)"));
+        r.skip(QStringLiteral("12.8 clear split via ZZSW0 (FT<->ZZSW cross-check)"),
+               QStringLiteral("no VFO B (single-VFO port)"));
+    }
 }
 
 // ═════════════════════════════════════════════════════════════════════════════

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -1047,6 +1047,15 @@ void section14pty(Runner& r, const QString& ptyPath)
 }
 #endif
 
+// Skipped form when --pty was not passed: don't try the round-trip (it would just
+// time out against a PTY that isn't wired up) — skip cleanly instead.
+void section14ptySkip(Runner& r)
+{
+    r.section(QStringLiteral("Section 14 — PTY round-trip (skipped — pass --pty PATH to enable)"));
+    for (const char* name : { "14.1 PTY ID;", "14.2 PTY FA;", "14.3 PTY PS;" })
+        r.skip(QString::fromLatin1(name), QStringLiteral("--pty not set"));
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // Section 15 — Squelch, NR/NL/NT/RL, MG, FW, OI, UP/DN, stubs
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1253,6 +1262,7 @@ int main(int argc, char* argv[])
     const quint16 port    = static_cast<quint16>(parser.value(QStringLiteral("port")).toUInt());
     const int     timeout = parser.value(QStringLiteral("timeout")).toInt();
     const bool    doPtt   = parser.isSet(QStringLiteral("ptt"));
+    const bool    doPty   = parser.isSet(QStringLiteral("pty"));
     const bool    doCw    = parser.isSet(QStringLiteral("cw"));
 
     std::cout << '\n' << bold(QStringLiteral("AetherSDR TS-2000 CAT Test Suite")).toStdString() << '\n'
@@ -1296,7 +1306,7 @@ int main(int argc, char* argv[])
     section11(c, r);
     section12(c, r);
     if (doCw) { section13cw(c, r); } else { section13skip(r); }
-    section14pty(r, parser.value(QStringLiteral("pty")));
+    if (doPty) { section14pty(r, parser.value(QStringLiteral("pty"))); } else { section14ptySkip(r); }
     section15(c, r);
 
     // Restore radio state

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -204,6 +204,13 @@ static QString hz11(qint64 hz)
     return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
 }
 
+// Does this port have a usable VFO B? FB returns its frequency when present, or "?"
+// (NOT_ENABLED) on a single-VFO port / when the VFO B slice isn't open.
+static bool hasVfoB(CatClient& c)
+{
+    return c.query(QStringLiteral("FB")).startsWith(QLatin1String("FB"));
+}
+
 static bool isDigits(const QString& s, int n)
 {
     if (s.size() != n) return false;
@@ -527,7 +534,7 @@ void section7(CatClient& c, Runner& r)
     // (NOT_ENABLED) instead of a silent ack — which would desync the read stream
     // if issued with send(). Detect VFO B; when absent, verify NOT_ENABLED with
     // query() (consuming the "?") and return, keeping the stream in sync.
-    const bool vfoB = c.query(QStringLiteral("FB")).startsWith(QLatin1String("FB"));
+    const bool vfoB = hasVfoB(c);
     if (!vfoB) {
         const QString ft0 = c.query(QStringLiteral("FT"));
         r.check(QStringLiteral("7.1  FT; → FT0 (split off, single VFO)"),

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -340,8 +340,12 @@ void section3(CatClient& c, Runner& r)
     r.section(QStringLiteral("Section 3 — VFO-B Frequency (FB)"));
 
     QString resp = c.query(QStringLiteral("FB"));
-    r.check(QStringLiteral("3.1  FB; returns \"FB\" + 11-digit Hz"),
-            resp.startsWith(QLatin1String("FB")) && isDigits(resp.mid(2), 11),
+    // FB returns the VFO B frequency when a VFO B slice is mapped, else "?" — it
+    // does NOT fall back to VFO A. The old fallback reported VFO A's frequency for
+    // FB while ZZME returned "?;", and that contradiction broke VFO sync (#3633).
+    r.check(QStringLiteral("3.1  FB; → \"FB\"+11-digit Hz (VFO B mapped) or \"?\" (no VFO B)"),
+            (resp.startsWith(QLatin1String("FB")) && isDigits(resp.mid(2), 11))
+                || resp == QLatin1String("?"),
             repr(resp));
 
     QString faResp = c.query(QStringLiteral("FA"));
@@ -550,15 +554,25 @@ void section7(CatClient& c, Runner& r)
 
 void section8(CatClient& c, Runner& r)
 {
-    r.section(QStringLiteral("Section 8 — FR (RX VFO select — accepted, no-op)"));
+    r.section(QStringLiteral("Section 8 — FR (RX VFO select)"));
 
+    // FR0 selects VFO A (always valid → no reply). FR1 selects VFO B, accepted
+    // only when a real VFO B exists (configured + present) else "?;". FA always
+    // reports VFO A (no A/B swap). query() FR1 so a "?;" reply is consumed and the
+    // read stream stays in sync; an accepted FR1 (no reply) just returns empty.
     c.send(QStringLiteral("FR0"));
-    c.send(QStringLiteral("FR1"));
     QThread::msleep(50);
-    QString resp = c.query(QStringLiteral("FA"));
-    r.check(QStringLiteral("8.1  FR0; FR1; produce no response; FA; works normally after"),
-            resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11),
-            repr(resp));
+    QString fr1 = c.query(QStringLiteral("FR1"));   // "?" if no real VFO B, else empty
+    QThread::msleep(50);
+    QString sel = c.query(QStringLiteral("FR"));     // selector read (always replies)
+    QString fa  = c.query(QStringLiteral("FA"));     // FA still reports VFO A
+    const bool faOk = fa.startsWith(QLatin1String("FA")) && isDigits(fa.mid(2), 11);
+    const bool frOk = (fr1 == QLatin1String("?") && sel == QLatin1String("FR0"))   // rejected: no VFO B
+                   || (sel == QLatin1String("FR1"));                                // accepted: VFO B present
+    c.send(QStringLiteral("FR0"));   // restore RX = VFO A
+    r.check(QStringLiteral("8.1  FR1 gated on a real VFO B (else \"?\"); FA reports VFO A; no swap"),
+            faOk && frOk,
+            QStringLiteral("FR1=%1 sel=%2 FA=%3").arg(repr(fr1), repr(sel), repr(fa)));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -522,6 +522,25 @@ void section7(CatClient& c, Runner& r)
 {
     r.section(QStringLiteral("Section 7 — Split (FT)"));
 
+    // The dual-VFO tests below assume a usable VFO B. On a single-VFO port (or a
+    // port whose VFO B slice isn't open) split cannot engage, so FT1 returns "?"
+    // (NOT_ENABLED) instead of a silent ack — which would desync the read stream
+    // if issued with send(). Detect VFO B; when absent, verify NOT_ENABLED with
+    // query() (consuming the "?") and return, keeping the stream in sync.
+    const bool vfoB = c.query(QStringLiteral("FB")).startsWith(QLatin1String("FB"));
+    if (!vfoB) {
+        const QString ft0 = c.query(QStringLiteral("FT"));
+        r.check(QStringLiteral("7.1  FT; → FT0 (split off, single VFO)"),
+                ft0 == QLatin1String("FT0"), repr(ft0));
+        const QString ft1 = c.query(QStringLiteral("FT1"));
+        r.check(QStringLiteral("7.2  FT1; with no VFO B → \"?\" (NOT_ENABLED)"),
+                ft1 == QLatin1String("?"), repr(ft1));
+        const QString ft0b = c.query(QStringLiteral("FT"));
+        r.check(QStringLiteral("7.3  split still off (FT0) after rejected enable"),
+                ft0b == QLatin1String("FT0"), repr(ft0b));
+        return;
+    }
+
     QString resp = c.query(QStringLiteral("FT"));
     r.check(QStringLiteral("7.1  FT; → FT0 (split off initially)"),
             resp == QLatin1String("FT0"), repr(resp));


### PR DESCRIPTION
> ⚠️ **Filed as a draft PR — holding until after the current release cycle.** Complete, reviewed, and tested across platforms; kept in draft so it doesn't land mid-cycle. Companion to #3724 (rigctld). Will be marked ready once the cycle closes.

## Summary

This started as the Flex/TS-2000-vs-SmartSDR **behavior-difference** fixes from the #3702 triage. Integration testing (WSJT-X, fldigi, MacLoggerDX) surfaced one more real fix (TS-2000 `SA`), and a high-effort code review plus cross-platform testing produced lifecycle/robustness hardening.

### 1. SmartCAT behavior alignment (#3702)
- **`FB`/`ZZFB` and `ZZME` with no VFO B → `?;`** (no VFO-A fallback) — the #3633 freq-yes/mode-no contradiction.
- **`FR`** is now a real gated RX-VFO selector (was a no-op); **`ZZFR` → `?;`** (was an invented A/B `std::swap`).
- **Split actually routes TX:** `FT`/`ZZSW`/`ZZFT` engage the operator's VFO B as the TX slice (was a status-flag-only toggle).
- **NOT_ENABLED (`?;`)** when VFO B is configured-but-absent or on a single-VFO port (matches SmartSDR-for-Mac).

### 2. WSJT-X TS-2000 integration fix
- **`SA` (satellite mode)** implemented (`SA0;`). WSJT-X's Hamlib TS-2000 backend queries `SA;` during `set_vfo`/split setup; the prior unknown-command `?;` made Hamlib abort `set_split_freq_mode` (`-9`) and block transmit. Pre-existing TS-2000 gap, folded in here since it lives in this file and blocked TS-2000 split.

### 3. Lifecycle & safety (code review)
- Split **teardown on disconnect undoes only a split we engaged** (`m_weEngagedSplit`) — never stomps an operator's/another client's split this client merely adopted.
- `FT`/`ZZSW`/`ZZFT` share one `splitCommand()` helper; a malformed arg returns `?;` instead of silently disabling split.
- `m_rxVfoB` selector reset on teardown; stale "…else XIT" comment removed; `cmdZZFR` unused-parameter warning fixed (clean on gcc + clang).

### 4. Tests
- Split/VFO-B assertions updated to spec; **single-VFO robustness** (probe VFO B, verify NOT_ENABLED instead of desyncing) via a shared `hasVfoB()` helper.
- **PTY round-trip tests skip unless `--pty`** is passed (no spurious timeouts).

### Scope / deferred
This grew beyond the original #3702 triage. Create-on-demand split on a single-VFO port (the SmartSDR-for-Windows path) and cross-consumer split-state reconciliation are deferred to the slice-lifecycle **RFC #3715**. (Two review suggestions — deriving split state from the model, and `OI`→`?;` — were tried and reverted: the slice TX flag updates asynchronously, and `OI` is a composite status block that must always return a body. See commit `33c3d6e7`.)

Addresses #3702. Refs #3715.

---
Built and regression tested on MacOS (M2), Linux (RPi 5) and Windows 11. Integration testing (WSJT-X 3.0.0, fldigi-4.2, MacLoggerDX) on MacOS (M2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
