### PR TITLE
[codex] Document macOS automation sandbox launch

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -53,6 +53,16 @@ to confirm a visual change; parse the JSON to assert on control state.
 
 For headless / CI runs, add `QT_QPA_PLATFORM=offscreen` — no display required.
 
+On macOS, do not host the bridge from a Codex-style sandboxed command. The
+native Cocoa platform can abort during `QApplication` startup if pasteboard or
+HIServices are unavailable, before AetherSDR reaches the automation bridge; with
+`QT_QPA_PLATFORM=offscreen`, the same sandbox can still deny the `QLocalServer`
+socket the bridge needs. Launch outside the command sandbox instead:
+
+```bash
+QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
+```
+
 ---
 
 ## How it works (the contract)


### PR DESCRIPTION
## Summary

Documents the macOS automation-bridge launch constraint observed under Codex-style sandboxed execution. The sandboxed Cocoa launch can abort during `QApplication` startup before AetherSDR reaches the automation bridge, and forcing `QT_QPA_PLATFORM=offscreen` inside the same sandbox still prevents the bridge from binding its `QLocalServer` socket. The doc now gives the supported headless automation launch command: run outside the command sandbox with `QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1`.

## Constitution principle honored

Principle XII - this treats the sandbox boundary as infrastructure behavior, not something AetherSDR can reliably recover from after Qt aborts before app code runs.

## Test plan

- [x] Local build passes (`cmake --build build`)
  - `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
  - `cmake --build build --target AetherSDR --parallel`
- [ ] Behavior verified on a real radio if applicable
  - Not applicable; docs-only launch guidance, no radio connection required.
- [ ] Existing tests pass (CI)
  - Not run locally beyond build and focused launch probes.
- [x] Reproduction steps documented if user-reported bug
  - Reproduced sandboxed macOS launch abort with `AETHER_AUTOMATION=1`.
  - Confirmed unsandboxed `QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1` launch answers `tools/automation_probe.py ping`.

Additional checks:

- `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room - not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
  - Not applicable.
