### PR TITLE
[codex] Fix KiwiSDR SQL and AGC controls

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -17,16 +17,32 @@ is entirely original. SmartSDR is a trademark of FlexRadio Systems.
   FlexLib:   Copyright (c) 2012-2025 FlexRadio Systems
   Reference: https://www.flexradio.com/
 
-The KiwiSDR receive integration includes source-attributed terminal
-denial-message labels derived from the LGPL-marked KiwiSDR server source. No
-KiwiSDR code is incorporated, vendored, translated, or linked into AetherSDR;
-the referenced source is used only to label server MSG keys and numeric badp
-denial codes in original AetherSDR error handling.
+The KiwiSDR receive integration includes source-attributed protocol facts
+derived from the public KiwiSDR server source. No KiwiSDR code is incorporated,
+vendored, translated, or linked into AetherSDR; the referenced source is
+consulted only to verify wire-protocol facts, which are then expressed in
+original AetherSDR code. The consulted facts are:
+  - server MSG keys and numeric badp denial codes (error handling); and
+  - the accepted `SET squelch=<offset> param=<float>` and
+    `SET agc=… thresh=… decay=… manGain=…` command shapes, plus their numeric
+    ranges, for KiwiSDR replacement-receiver squelch/AGC control.
+See docs/kiwisdr-cleanroom-design.md for the per-file, per-fact provenance.
 
-  KiwiSDR source: Copyright (c) 2014-2024 John Seamons and contributors
-  License:        LGPL-2.0-or-later, per consulted file headers
-  Source:         https://github.com/jks-prv/Beagle_SDR_GPS
-  Reference:      commit efb38e2b25137029cb37a96a94e03366f8d2871e
+  KiwiSDR server source: Copyright (c) 2014-2024 John Seamons and contributors
+  License:               LGPL-2.0-or-later, per consulted file headers
+                         (rx/rx_cmd.{h,cpp}, rx/rx_sound.cpp, rx/rx_sound_cmd.cpp,
+                         rx/rx_server.cpp, rx/rx_util.cpp, support/stats.cpp)
+  Source:                https://github.com/jks-prv/Beagle_SDR_GPS
+  Reference:             commit efb38e2b25137029cb37a96a94e03366f8d2871e
+
+The AGC/squelch numeric ranges (threshold -160..0 dB, manual gain 0..100 dB,
+decay 20..5000 ms, and NBFM squelch behavior) were verified against the CuteSDR
+DSP component bundled in that repository, which is separately licensed. Only the
+documented numeric ranges/behavior were used; no CuteSDR code is incorporated.
+
+  CuteSDR source: Copyright (c) Moe Wheatley (AE4JY), per consulted file headers
+  License:        BSD-2-Clause (Simplified BSD)
+  Source:         https://github.com/jks-prv/Beagle_SDR_GPS  (rx/CuteSDR/)
 
 
 1. WDSP — Spectral Noise Reduction (NR2)

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -77,7 +77,7 @@ black-box observations made in this thread.
   `SERVER DE CLIENT ... W/F`, `SET compression=0`,
   `SET mod=... low_cut=... high_cut=... freq=...`, AGC as the combined
   `SET agc=... hang=... thresh=... slope=... decay=... manGain=...` command,
-  squelch as `SET squelch=... max=...`, waterfall positioning via
+  squelch initially as `SET squelch=... max=...`, waterfall positioning via
   `SET zoom=... cf=...` with compatibility `start=...`, `SET maxdb=... mindb=...`,
   `SET wf_speed=...`, `SET interp=...`, `SET keepalive`, tagged `MSG`, `SND`,
   `W/F`, and `EXT` binary/text dispatch, variable SND and W/F payload layouts,
@@ -92,6 +92,46 @@ black-box observations made in this thread.
   Attenuation, remote mute, PBT, extension launch, IQ streams, and compressed
   audio are not exposed because they would add Kiwi-only product behavior or
   require undefined wire details.
+- Clean server-side parser check from 2026-06-21: the archived KiwiSDR server
+  `rx/rx_sound_cmd.cpp` file carries a GNU Library GPL v2-or-later notice and
+  was used only to verify the exposed squelch command contract. The accepted
+  command shape is `SET squelch=<signed-dB-offset-or-0-off> param=<float>`;
+  the older `max=` shape is retained by the server only as a compatibility
+  no-op.
+- AetherSDR keeps Flex Manual SQL on the app-wide 0-100 `squelch_level` scale,
+  but Kiwi does not use Flex units. Manual Kiwi SQL follows the server's
+  signed margin scale with a tapered UI map: slider `0` maps to `-99 dB`,
+  slider `49` maps to `-1 dB`, slider `50` maps to `+1 dB`, and slider `99`
+  maps to `+99 dB` relative to the Kiwi median RSSI noise-floor estimate.
+  Because the server reserves `SET squelch=0` for open/off, enabled manual SQL
+  normalizes any exact zero threshold to `+1 dB`; disabling SQL sends
+  `SET squelch=0`. This gives the operator downward adjustment below the
+  measured noise floor without conflating the lowest slider position with
+  squelch-off. The Kiwi SQL line is drawn as a noise-floor-relative `N dB`
+  line using the SND S-meter median, because that is the same value family the
+  server uses for non-NBFM squelch. Manual SQL pins that floor when the user
+  sets the threshold; Auto SQL lets it track. Waterfall-derived floor is only a
+  fallback until SND meter samples arrive. Auto SQL uses the smaller direct
+  `5..20 dB` margin because it is already operating in dB-margin units.
+- Clean server-side AGC check from 2026-06-22: the `SET agc=... thresh=...
+  manGain=... decay=...` parser forwards those values to the BSD-licensed
+  CuteSDR AGC implementation. That implementation documents threshold as an
+  AGC knee in nominal `-160..0 dB`, manual gain as `0..100 dB`, and decay as
+  `20..5000 ms`. AetherSDR therefore stores Kiwi replacement AGC-T directly in
+  dB (`-160..0`) instead of using Flex's `0..100` AGC-T scale.
+- Kiwi's server command takes a raw decay time, not named presets. AetherSDR
+  maps its existing AGC UI names to decay values inside the supported range:
+  Fast `300 ms`, Med `1000 ms`, Slow `3000 ms`; Off sends `agc=0` with the
+  manual-gain field from the AGC-off slider.
+- Kiwi virtual receive starts from Kiwi-safe AGC defaults rather than copying
+  the active Flex slice's AGC-T state: `SET agc=1 hang=0 thresh=-100 slope=6
+  decay=1000 manGain=50`. Operator changes in the RX applet still update the
+  Kiwi receiver controls while the Kiwi replacement source is active.
+- Clean server-side send-path check from 2026-06-21: the LGPL-marked server
+  sends an SND squelch UI flag for non-NBFM squelch state, but intentionally
+  does not replace non-NBFM audio with silence. AetherSDR therefore honors that
+  SND flag locally by gating decoded Kiwi audio before it enters the normal
+  AetherSDR RX audio path.
 - User-provided report from 2026-06-18: after protocol setup changes, some
   endpoints returned "sound connection closed" during connection setup, and
   `QWebSocketPrivate::processHandshake` reported HTTP 200 for the root-query
@@ -133,10 +173,10 @@ black-box observations made in this thread.
 - User-provided protocol correction from 2026-06-18: string values in `SET`
   commands must not contain spaces. The current runtime sends only sanitized
   callsign identity strings and fixed client labels without spaces.
-- User-provided corrected implementation spec from 2026-06-18: W/F byte values
-  are raw display/bin values, not calibrated dBm. The runtime no longer uses
-  `byte - 255`; it maps raw bytes into a Kiwi-only display range and applies
-  local auto-aperture/color shaping without claiming RF calibration.
+- Server-side W/F source check from 2026-06-22: direct uncompressed W/F row
+  bytes are wrapped negative dB values. AetherSDR decodes them as
+  `clamp(byte - 255, -200, 0)` for vertical FFT placement, then applies local
+  auto-aperture/color shaping without claiming Flex-calibrated RF dBm.
 - User-provided screenshots from 2026-06-18 showed the panadapter overlay
   displaying a full URL-encoded `MSG load_cfg=...` record as a connection
   error. The corrected parser treats `MSG` records as key-value fields and only
@@ -173,16 +213,16 @@ black-box observations made in this thread.
   peak-hold guidance, dBm-to-S-unit conversion utility, non-fatal extraction
   failures, and mandatory stubs for real SND meter extraction until the SND
   meter field layout and conversion formula are independently verified.
-- User-authorized experimental SND meter extraction from 2026-06-19, backed by
+- User-authorized SND meter extraction from 2026-06-19, initially backed by
   short receive-only black-box SND probes against `22033.proxy.kiwisdr.com:8073`:
   observed 1034-byte frames with `SND` at bytes 0-2, byte 3 as flags, bytes 4-7
   as a little-endian rolling frame counter, bytes 8-9 as a big-endian signed
   candidate meter field, and big-endian PCM beginning at byte 10. The candidate
   field varied plausibly across 7.2 MHz LSB, 10 MHz AM, and 14.2 MHz USB probes.
-  AetherSDR maps it as `raw / 10 - 127 dBm` only under the `experimental` meter
-  capability until independent live validation confirms it. The user-facing
-  meter surface uses the normal S-meter labels while the internal capability
-  remains experimental.
+  A later clean-room server-side check verified bytes 8-9 as the SND S-meter
+  field encoded as `(dBm + 127) * 10`, so AetherSDR maps it as
+  `raw / 10 - 127 dBm` with verified SND-meter capability for that frame
+  layout. The user-facing meter surface uses the normal S-meter labels.
 - Red-team review in this clean-room worktree found integration risks without
   using any Kiwi/WebSDR implementation source: unassigned profile connects could
   reuse stale slice tracking, exact 1024-bin W/F rows could be misread as older
@@ -217,10 +257,8 @@ black-box observations made in this thread.
   - A single direct `W/F` probe with `SET send_dB=1` produced binary `W/F`
     frames of 1040 bytes, with a 16-byte header and 1024 one-byte waterfall
     bins. With observed `center_freq=15000000` and `bandwidth=30000000`, the
-    row spans 0-30 MHz at zoom 0. At the time, observed bin values appeared
-    plausible when interpreted as `byte - 255`; the later corrected
-    user-provided spec supersedes that interpretation and treats W/F bytes as
-    display/bin intensity values rather than calibrated dBm.
+    row spans 0-30 MHz at zoom 0. The later server-side W/F source check
+    confirmed the observed `byte - 255` interpretation for direct rows.
 - Clean black-box follow-up observations against user-provided endpoints
   `sdr.hfunderground.com:8077`, `w0air.ddns.net:8073`, and
   `22033.proxy.kiwisdr.com:8073`, using only rendered UI screenshots and
@@ -407,6 +445,15 @@ the applet-level Kiwi Audio toggle is enabled.
   `support/stats.cpp`, `rx/rx_server.cpp`, `rx/rx_sound.cpp`, and
   `rx/rx_util.cpp`, each carrying GNU Library General Public License
   version 2-or-later headers in that source snapshot.
+- The 2026-06-21 squelch follow-up used the LGPL-marked server files
+  `rx/rx_sound_cmd.cpp` and `rx/rx_sound.cpp` only to verify the public command
+  contract and SND squelch flag behavior accepted/emitted by the server. No
+  KiwiSDR client code was copied, translated, or used to derive AetherSDR
+  behavior.
+- The 2026-06-22 SQL/AGC-T range follow-up used the same server parser file
+  plus BSD-licensed CuteSDR AGC/squelch headers and implementation comments to
+  verify numeric ranges. No KiwiSDR client code was copied, translated, or used
+  to derive AetherSDR behavior.
 - No WebSDR source code, prior WebSDR worktrees, PR #3612, prior WebSDR
   threads, contaminated temporary files, or rollout summaries were used.
 
@@ -668,30 +715,27 @@ Remaining uncertainties are deliberately conservative:
   points and the previous ramp could impose audible speech-correlated
   artifacts. When the SND or W/F sequence counter skips, AetherSDR applies
   bounded gap concealment by repeating the previous decoded audio frame or
-  previous W/F row. The SND meter/RSSI field and conversion remain unverified.
-- Kiwi S-meter display uses an experimental SND candidate only for the
-  independently observed 1034-byte frame layout described above. The extractor
-  is intentionally labeled `experimental`; it must not be promoted to verified
-  calibrated SND metering until the field and conversion are validated against
-  an independent reference.
+  previous W/F row.
+- Kiwi S-meter display uses the verified SND meter field for the independently
+  observed 1034-byte frame layout described above. Unsupported layouts remain
+  unavailable rather than guessed.
 - Kiwi meter display is capability-aware. The SND metadata extraction path is
-  an explicit experimental extractor and must not silently guess unsupported
-  layouts. Decoded Kiwi audio and W/F rows may still produce internal
+  explicit and must not silently guess unsupported layouts. Decoded Kiwi audio
+  and W/F rows may still produce internal
   `relative_audio` and `relative_waterfall` readings for diagnostics, but those
   uncalibrated readings do not drive the user-facing VFO or applet S-meter. The
-  existing Flex-style meter surfaces show either the experimental SND candidate
-  or an unavailable readout. Flex `SLC/LEVEL` meter updates are ignored for
+  existing Flex-style meter surfaces show either the verified SND meter or an
+  unavailable readout. Flex `SLC/LEVEL` meter updates are ignored for
   slices currently assigned to a Kiwi virtual RX antenna, preventing local
   calibrated Flex dBm from racing the remote Kiwi meter state.
-- Waterfall row bytes are treated as raw display/bin intensity values, not
-  calibrated dBm. They are mapped into a Kiwi-only pseudo-dB display range and
-  color-mapped through a Kiwi-only automatic aperture with square-root contrast
-  stretch across the active waterfall color scheme. This is client-side display
-  normalization only: it does not synthesize waterfall data, does not derive
-  pixels from audio, and does not claim calibrated RF power. Earlier black-box
-  W/F captures showed both extended 16-byte-header direct rows and compact
-  encoded rows. AetherSDR requests direct uncompressed W/F rows and drops
-  compact encoded rows until a clean decoder is available.
+- Direct uncompressed W/F row bytes are decoded as wrapped negative dB values
+  and color-mapped through a Kiwi-only automatic aperture with square-root
+  contrast stretch across the active waterfall color scheme. This is
+  client-side display normalization only: it does not synthesize waterfall data
+  from audio and does not claim Flex-calibrated RF power. Earlier black-box W/F
+  captures showed both extended 16-byte-header direct rows and compact encoded
+  rows. AetherSDR requests direct uncompressed W/F rows and drops compact
+  encoded rows until a clean decoder is available.
 - The applet exposes Waterfall Cell and Waterfall Floor sliders using the
   user-supplied -30 dB to +30 dB range. The corrected protocol draft maps
   portable waterfall aperture control to `SET maxdb=... mindb=...`, so slider

--- a/src/core/AgcTCalibrator.cpp
+++ b/src/core/AgcTCalibrator.cpp
@@ -149,6 +149,11 @@ void AgcTCalibrator::startAutoSweep()
         qCWarning(lcAgcCal) << "startAutoSweep with no slice";
         return;
     }
+    if (m_slice->externalReceiveReplacementActive()) {
+        qCWarning(lcAgcCal)
+            << "startAutoSweep skipped for external receive replacement";
+        return;
+    }
     if (m_running) {
         return;
     }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -277,10 +277,22 @@ QJsonObject sliceSnapshot(const SliceModel* s)
         {QStringLiteral("anf"),        s->anfOn()},
         {QStringLiteral("apf"),        s->apfOn()},
         {QStringLiteral("apfLevel"),   s->apfLevel()},
+        {QStringLiteral("externalReceiveReplacement"),
+                                     s->externalReceiveReplacementActive()},
         {QStringLiteral("squelch"),    s->squelchOn()},
         {QStringLiteral("squelchLevel"), s->squelchLevel()},
+        {QStringLiteral("receiveSquelch"), s->receiveSquelchOn()},
+        {QStringLiteral("receiveSquelchLevel"), s->receiveSquelchLevel()},
+        {QStringLiteral("flexSquelch"), s->flexSquelchOn()},
+        {QStringLiteral("flexSquelchLevel"), s->flexSquelchLevel()},
         {QStringLiteral("agcMode"),    s->agcMode()},
         {QStringLiteral("agcThreshold"), s->agcThreshold()},
+        {QStringLiteral("receiveAgcMode"), s->receiveAgcMode()},
+        {QStringLiteral("receiveAgcThreshold"), s->receiveAgcThreshold()},
+        {QStringLiteral("receiveAgcOffLevel"), s->receiveAgcOffLevel()},
+        {QStringLiteral("flexAgcMode"), s->flexAgcMode()},
+        {QStringLiteral("flexAgcThreshold"), s->flexAgcThreshold()},
+        {QStringLiteral("flexAgcOffLevel"), s->flexAgcOffLevel()},
     };
 }
 

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -202,11 +202,29 @@ KiwiSdrReceiverControls normalizedControls(
     const KiwiSdrReceiverControls& controls)
 {
     KiwiSdrReceiverControls normalized = controls;
-    normalized.agcGainDb = std::clamp(normalized.agcGainDb, 0, 100);
-    normalized.agcThresholdDb = std::clamp(normalized.agcThresholdDb, -100, -10);
-    normalized.agcDecayMs = std::clamp(normalized.agcDecayMs, 200, 5000);
-    normalized.squelchLevelDbm =
-        std::clamp(normalized.squelchLevelDbm, -160.0, 0.0);
+    normalized.agcGainDb = std::clamp(
+        normalized.agcGainDb,
+        KiwiSdrProtocol::kAgcManualGainMinDb,
+        KiwiSdrProtocol::kAgcManualGainMaxDb);
+    normalized.agcThresholdDb = std::clamp(
+        normalized.agcThresholdDb,
+        KiwiSdrProtocol::kAgcThresholdMinDb,
+        KiwiSdrProtocol::kAgcThresholdMaxDb);
+    normalized.agcDecayMs = std::clamp(
+        normalized.agcDecayMs,
+        KiwiSdrProtocol::kAgcDecayMinMs,
+        KiwiSdrProtocol::kAgcDecayMaxMs);
+    if (normalized.squelchEnabled) {
+        normalized.squelchThresholdDb = std::clamp(
+            normalized.squelchThresholdDb,
+            KiwiSdrProtocol::kSquelchServerMinMarginDb,
+            KiwiSdrProtocol::kSquelchServerMaxMarginDb);
+        if (normalized.squelchThresholdDb == KiwiSdrProtocol::kSquelchOffLevel) {
+            normalized.squelchThresholdDb = 1;
+        }
+    } else {
+        normalized.squelchThresholdDb = KiwiSdrProtocol::kSquelchOffLevel;
+    }
     return normalized;
 }
 
@@ -219,7 +237,7 @@ bool controlsEqual(const KiwiSdrReceiverControls& a,
         && a.agcThresholdDb == b.agcThresholdDb
         && a.agcDecayMs == b.agcDecayMs
         && a.squelchEnabled == b.squelchEnabled
-        && std::abs(a.squelchLevelDbm - b.squelchLevelDbm) < 0.001;
+        && a.squelchThresholdDb == b.squelchThresholdDb;
 }
 
 QString redactedKiwiCommand(const QString& command)
@@ -1037,17 +1055,13 @@ void KiwiSdrClient::sendSoundSampleRateCommands()
     m_soundSampleRateCommandsSent = true;
     sendSoundCommand(QStringLiteral("SERVER DE CLIENT AetherSDR SND"));
     const KiwiSdrReceiverControls c = normalizedControls(m_receiverControls);
-    sendSoundCommand(QStringLiteral("SET squelch=%1 max=%2")
-        .arg(c.squelchEnabled ? 1 : 0)
-        .arg(c.squelchEnabled ? c.squelchLevelDbm : 0.0, 0, 'f', 2));
+    sendSoundCommand(KiwiSdrProtocol::formatSquelchCommand(
+        c.squelchEnabled, c.squelchThresholdDb));
     sendSoundCommand(QStringLiteral("SET genattn=0"));
     sendSoundCommand(QStringLiteral("SET gen=0 mix=-1"));
-    sendSoundCommand(QStringLiteral("SET agc=%1 hang=%2 thresh=%3 slope=6 decay=%4 manGain=%5")
-        .arg(c.agcEnabled ? 1 : 0)
-        .arg(c.agcHang ? 1 : 0)
-        .arg(c.agcThresholdDb)
-        .arg(c.agcDecayMs)
-        .arg(c.agcGainDb));
+    sendSoundCommand(KiwiSdrProtocol::formatAgcCommand(
+        c.agcEnabled, c.agcHang, c.agcThresholdDb,
+        c.agcGainDb, c.agcDecayMs));
     sendTrackedSliceToServer();
     sendKeepalive();
 }
@@ -1110,15 +1124,11 @@ void KiwiSdrClient::sendReceiverControlsToServer()
     }
 #endif
     const KiwiSdrReceiverControls c = normalizedControls(m_receiverControls);
-    sendSoundCommand(QStringLiteral("SET squelch=%1 max=%2")
-        .arg(c.squelchEnabled ? 1 : 0)
-        .arg(c.squelchEnabled ? c.squelchLevelDbm : 0.0, 0, 'f', 2));
-    sendSoundCommand(QStringLiteral("SET agc=%1 hang=%2 thresh=%3 slope=6 decay=%4 manGain=%5")
-        .arg(c.agcEnabled ? 1 : 0)
-        .arg(c.agcHang ? 1 : 0)
-        .arg(c.agcThresholdDb)
-        .arg(c.agcDecayMs)
-        .arg(c.agcGainDb));
+    sendSoundCommand(KiwiSdrProtocol::formatSquelchCommand(
+        c.squelchEnabled, c.squelchThresholdDb));
+    sendSoundCommand(KiwiSdrProtocol::formatAgcCommand(
+        c.agcEnabled, c.agcHang, c.agcThresholdDb,
+        c.agcGainDb, c.agcDecayMs));
 }
 
 void KiwiSdrClient::sendWaterfallViewToServer()
@@ -1600,9 +1610,13 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
                                             header.sequence)
         : 0;
     updateSoundTelemetry(frame);
-    const KiwiSdrProtocol::MeterReading meterReading =
+    KiwiSdrProtocol::MeterReading meterReading =
         KiwiSdrProtocol::extractMeterFromSndVerifiedLayout(
             frame, KiwiSdrProtocol::MeterContext{});
+    if (meterReading.valid) {
+        meterReading.squelchStateKnown = true;
+        meterReading.squelched = header.squelched;
+    }
     markSoundAudioReady();
     ++m_soundDiagFrames;
     m_soundDiagBytes += static_cast<quint64>(frame.size());
@@ -1667,8 +1681,11 @@ void KiwiSdrClient::handleSoundFrame(const QByteArray& frame)
         return;
     }
 
-    const QByteArray pcm = decodeSoundFrame(frame);
+    QByteArray pcm = decodeSoundFrame(frame);
     if (!pcm.isEmpty()) {
+        if (header.squelched) {
+            pcm.fill(0);
+        }
         if (logSoundFrameShape) {
             qCDebug(lcKiwiSdrAudio).noquote()
                 << "KiwiSDR SND decode"

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -31,7 +31,9 @@ struct KiwiSdrReceiverControls {
     int agcThresholdDb{-100};
     int agcDecayMs{1000};
     bool squelchEnabled{false};
-    double squelchLevelDbm{-105.0};
+    // Kiwi server squelch: 0 open/off, otherwise signed dB offset from
+    // median RSSI floor for non-NBFM modes.
+    int squelchThresholdDb{20};
 };
 
 struct KiwiSdrReceiverTelemetry {

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -31,8 +31,8 @@ struct KiwiSdrReceiverControls {
     int agcThresholdDb{-100};
     int agcDecayMs{1000};
     bool squelchEnabled{false};
-    // Kiwi server squelch: 0 open/off, otherwise signed dB offset from
-    // median RSSI floor for non-NBFM modes.
+    // Kiwi server squelch: 0 open/off; non-NBFM uses signed dB offset from
+    // median RSSI floor, while NBFM uses the raw 1-99 noise squelch level.
     int squelchThresholdDb{20};
 };
 

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -437,6 +437,19 @@ void KiwiSdrManager::updateWaterfallView(int sliceId, const QString& panId,
     }
 }
 
+void KiwiSdrManager::setReceiverControlsForSlice(
+    int sliceId, const KiwiSdrReceiverControls& controls)
+{
+    const QString profileId = m_sliceAssignments.value(sliceId);
+    if (profileId.isEmpty()) {
+        return;
+    }
+
+    if (KiwiSdrClient* c = ensureClient(profileId)) {
+        c->setReceiverControls(controls);
+    }
+}
+
 void KiwiSdrManager::setProfileWaterfallSettings(const QString& id, int cellDb,
                                                  int floorDb, int rate)
 {

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -72,6 +72,8 @@ public slots:
     void updateWaterfallView(int sliceId, const QString& panId,
                              double centerMhz, double bandwidthMhz,
                              int lineDurationMs);
+    void setReceiverControlsForSlice(
+        int sliceId, const KiwiSdrReceiverControls& controls);
     void setProfileWaterfallSettings(const QString& id, int cellDb,
                                      int floorDb, int rate);
 

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -12,8 +12,17 @@ namespace {
 constexpr int kObservedExtendedSoundFrameBytes = 1034;
 constexpr int kServerSoundHeaderBytes = 10;
 constexpr int kObservedMeterOffset = 8;
-constexpr float kExperimentalMeterDbmOffset = -127.0f;
-constexpr float kExperimentalMeterDbPerRawUnit = 0.1f;
+constexpr float kSndMeterDbmOffset = -127.0f;
+constexpr float kSndMeterDbPerRawUnit = 0.1f;
+constexpr quint8 kSoundSquelchFlag = 0x40;
+
+int normalizeEnabledSquelchMarginDb(int thresholdDb)
+{
+    const int clamped = std::clamp(thresholdDb,
+                                   kSquelchServerMinMarginDb,
+                                   kSquelchServerMaxMarginDb);
+    return clamped == kSquelchOffLevel ? 1 : clamped;
+}
 
 float percentile(QVector<float> values, float fraction)
 {
@@ -49,6 +58,7 @@ SoundFrameHeader parseSoundFrameHeader(const QByteArray& frame)
 
     SoundFrameHeader header;
     header.flags = static_cast<uchar>(frame[3]);
+    header.squelched = (header.flags & kSoundSquelchFlag) != 0;
     if (frame.size() >= kServerSoundHeaderBytes) {
         const auto* data = reinterpret_cast<const uchar*>(frame.constData() + 4);
         const quint32 counter = static_cast<quint32>(data[0])
@@ -93,14 +103,10 @@ quint64 sequenceGapCount(int previousSequence, int currentSequence)
 
 float waterfallByteToDisplayLevel(unsigned char value)
 {
-    // Corrected clean-room spec: raw W/F bytes are display/bin intensity
-    // values, not calibrated dBm. Map them into AetherSDR's existing
-    // Kiwi-only pseudo-dB display range without claiming RF calibration.
-    constexpr float kDisplayFloor = -130.0f;
-    constexpr float kDisplayCeiling = 0.0f;
-    constexpr float kDisplaySpan = kDisplayCeiling - kDisplayFloor;
-    return kDisplayFloor
-        + (static_cast<float>(value) / 255.0f) * kDisplaySpan;
+    // Kiwi server W/F direct rows encode negative dB by decrementing the
+    // clamped bin dB and wrapping it into an unsigned byte. So 255 means
+    // 0 dB, 155 means -100 dB, and 55 means -200 dB.
+    return std::clamp(static_cast<float>(value) - 255.0f, -200.0f, 0.0f);
 }
 
 WaterfallAperture autoWaterfallAperture(const QVector<float>& binsDbm)
@@ -187,6 +193,60 @@ IpLimitNotice parseIpLimitNotice(const QString& valueText)
     return notice;
 }
 
+QString formatSquelchCommand(bool enabled, int thresholdDb,
+                             double tailSeconds)
+{
+    const int threshold = enabled
+        ? normalizeEnabledSquelchMarginDb(thresholdDb)
+        : kSquelchOffLevel;
+    const double tail = std::clamp(tailSeconds, 0.0, 2.0);
+    return QStringLiteral("SET squelch=%1 param=%2")
+        .arg(threshold)
+        .arg(tail, 0, 'f', 2);
+}
+
+int squelchSliderLevelToMarginDb(int level)
+{
+    static_assert(kSquelchUiMaxLevel % 2 == 1);
+    const int clamped = std::clamp(level, kSquelchUiMinLevel,
+                                   kSquelchUiMaxLevel);
+    const int margin = (clamped * 2) - kSquelchUiMaxLevel;
+    return std::clamp(margin,
+                      kSquelchServerMinMarginDb,
+                      kSquelchServerMaxMarginDb);
+}
+
+int agcDecayMsForMode(const QString& mode)
+{
+    const QString normalized = mode.trimmed().toLower();
+    if (normalized == QStringLiteral("fast")) {
+        return kAgcFastDecayMs;
+    }
+    if (normalized == QStringLiteral("slow")) {
+        return kAgcSlowDecayMs;
+    }
+    return kAgcMedDecayMs;
+}
+
+QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
+                         int manualGainDb, int decayMs)
+{
+    const int clampedThreshold = std::clamp(
+        thresholdDb, kAgcThresholdMinDb, kAgcThresholdMaxDb);
+    const int clampedManualGain = std::clamp(
+        manualGainDb, kAgcManualGainMinDb, kAgcManualGainMaxDb);
+    const int clampedDecay = std::clamp(
+        decayMs, kAgcDecayMinMs, kAgcDecayMaxMs);
+    return QStringLiteral(
+        "SET agc=%1 hang=%2 thresh=%3 slope=%4 decay=%5 manGain=%6")
+        .arg(enabled ? 1 : 0)
+        .arg(hang ? 1 : 0)
+        .arg(clampedThreshold)
+        .arg(kAgcSlopeDb)
+        .arg(clampedDecay)
+        .arg(clampedManualGain);
+}
+
 MeterReading meterUnavailable(MeterSource source, const QString& notes)
 {
     MeterReading reading;
@@ -208,24 +268,24 @@ MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
         && frame.startsWith("SND")) {
         const qint16 rawMeter =
             readSignedBigEndian16(frame, kObservedMeterOffset);
-        const float dbm = kExperimentalMeterDbmOffset
+        const float dbm = kSndMeterDbmOffset
             + (static_cast<float>(rawMeter)
-               * kExperimentalMeterDbPerRawUnit);
+               * kSndMeterDbPerRawUnit);
 
         MeterReading reading;
         reading.timestampUtcMs = QDateTime::currentMSecsSinceEpoch();
         reading.source = MeterSource::SndMetadata;
-        reading.capability = MeterCapability::Experimental;
+        reading.capability = MeterCapability::CalibratedSndMeter;
         reading.rawValue = static_cast<float>(rawMeter);
         reading.hasRawValue = true;
         reading.dbm = dbm;
         reading.hasDbm = true;
         reading.sUnits = convertDbmToSUnits(dbm);
         reading.valid = true;
-        reading.confidence = MeterConfidence::Low;
+        reading.confidence = MeterConfidence::Verified;
         reading.label = QStringLiteral("S-Meter");
         reading.notes = QStringLiteral(
-            "Experimental SND bytes 8-9 big-endian candidate, dbm=raw/10-127");
+            "SND bytes 8-9 big-endian server S-meter, dbm=raw/10-127");
         return reading;
     }
 
@@ -299,7 +359,7 @@ MeterReading computeRelativeWaterfallLevel(const QVector<float>& bins)
     }
 
     const float signal = percentile(finite, 0.95f);
-    constexpr float kDisplayFloor = -130.0f;
+    constexpr float kDisplayFloor = -200.0f;
     constexpr float kDisplayCeiling = 0.0f;
     const float relativeLevel = std::clamp(
         (signal - kDisplayFloor) / (kDisplayCeiling - kDisplayFloor),

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -9,11 +9,29 @@
 
 namespace AetherSDR::KiwiSdrProtocol {
 
+inline constexpr int kSquelchOffLevel = 0;
+inline constexpr int kSquelchUiMinLevel = 0;
+inline constexpr int kSquelchUiMaxLevel = 99;
+inline constexpr int kSquelchServerMinMarginDb = -99;
+inline constexpr int kSquelchServerMaxMarginDb = 99;
+inline constexpr double kSquelchDefaultTailSeconds = 0.0;
+inline constexpr int kAgcThresholdMinDb = -160;
+inline constexpr int kAgcThresholdMaxDb = 0;
+inline constexpr int kAgcManualGainMinDb = 0;
+inline constexpr int kAgcManualGainMaxDb = 100;
+inline constexpr int kAgcDecayMinMs = 20;
+inline constexpr int kAgcDecayMaxMs = 5000;
+inline constexpr int kAgcFastDecayMs = 300;
+inline constexpr int kAgcMedDecayMs = 1000;
+inline constexpr int kAgcSlowDecayMs = 3000;
+inline constexpr int kAgcSlopeDb = 6;
+
 struct SoundFrameHeader {
     int sequence{-1};
     quint8 flags{0};
     float rssiDbm{0.0f};
     bool hasRssi{false};
+    bool squelched{false};
     bool valid{false};
 };
 
@@ -87,6 +105,8 @@ struct MeterReading {
     QString sUnits;
     float relativeLevel{0.0f};
     bool hasRelativeLevel{false};
+    bool squelchStateKnown{false};
+    bool squelched{false};
     bool valid{false};
     MeterConfidence confidence{MeterConfidence::None};
     QString label{QStringLiteral("Meter unavailable")};
@@ -101,6 +121,12 @@ WaterfallAperture autoWaterfallAperture(const QVector<float>& binsDbm);
 float waterfallColorIndex(float dbm, float minDbm, float maxDbm);
 QVector<MsgToken> parseMsgTokens(const QString& message);
 IpLimitNotice parseIpLimitNotice(const QString& valueText);
+int squelchSliderLevelToMarginDb(int level);
+QString formatSquelchCommand(bool enabled, int thresholdDb,
+                             double tailSeconds = kSquelchDefaultTailSeconds);
+int agcDecayMsForMode(const QString& mode);
+QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
+                         int manualGainDb, int decayMs);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
                                                const MeterContext& context);

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -178,13 +178,14 @@ QString TciProtocol::generateInitBurst()
 
             // SQL
             burst += QStringLiteral("sql_enable:%1,%2;")
-                         .arg(trx).arg(s->squelchOn() ? "true" : "false");
+                         .arg(trx)
+                         .arg(s->receiveSquelchOn() ? "true" : "false");
             burst += QStringLiteral("sql_level:%1,%2;")
-                         .arg(trx).arg(s->squelchLevel());
+                         .arg(trx).arg(s->receiveSquelchLevel());
 
             // AGC
             burst += QStringLiteral("agc_mode:%1,%2;")
-                         .arg(trx).arg(s->agcMode().toLower());
+                         .arg(trx).arg(s->receiveAgcMode().toLower());
 
             // DSP
             burst += QStringLiteral("rx_nb_enable:%1,%2;")
@@ -843,12 +844,13 @@ QString TciProtocol::cmdSqlEnable(const QStringList& args, bool isSet)
 
     if (!isSet) {
         return QStringLiteral("sql_enable:%1,%2;")
-                   .arg(trx).arg(s->squelchOn() ? "true" : "false");
+                   .arg(trx)
+                   .arg(s->receiveSquelchOn() ? "true" : "false");
     }
 
     if (args.size() < 2) return {};
     bool on = (args[1].toLower() == "true");
-    int level = s->squelchLevel();
+    int level = s->receiveSquelchLevel();
     QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
                               Qt::QueuedConnection);
 
@@ -866,12 +868,12 @@ QString TciProtocol::cmdSqlLevel(const QStringList& args, bool isSet)
 
     if (!isSet) {
         return QStringLiteral("sql_level:%1,%2;")
-                   .arg(trx).arg(s->squelchLevel());
+                   .arg(trx).arg(s->receiveSquelchLevel());
     }
 
     if (args.size() < 2) return {};
     int level = args[1].toInt();
-    bool on = s->squelchOn();
+    bool on = s->receiveSquelchOn();
     QMetaObject::invokeMethod(s, [s, on, level]() { s->setSquelch(on, level); },
                               Qt::QueuedConnection);
 
@@ -993,7 +995,7 @@ QString TciProtocol::cmdAgcMode(const QStringList& args, bool isSet)
 
     if (!isSet) {
         return QStringLiteral("agc_mode:%1,%2;")
-                   .arg(trx).arg(s->agcMode().toLower());
+                   .arg(trx).arg(s->receiveAgcMode().toLower());
     }
 
     if (args.size() < 2) return {};
@@ -1016,7 +1018,7 @@ QString TciProtocol::cmdAgcGain(const QStringList& args, bool isSet)
 
     if (!isSet) {
         return QStringLiteral("agc_gain:%1,%2;")
-                   .arg(trx).arg(s->agcThreshold());
+                   .arg(trx).arg(s->receiveAgcThreshold());
     }
 
     if (args.size() < 2) return {};

--- a/src/gui/AgcCalibrationDialog.cpp
+++ b/src/gui/AgcCalibrationDialog.cpp
@@ -273,6 +273,8 @@ void AgcCalibrationDialog::setSlice(SliceModel* slice)
 void AgcCalibrationDialog::connectSlice(SliceModel* slice)
 {
     connect(slice, &SliceModel::agcModeChanged, this, &AgcCalibrationDialog::updateModeUi);
+    connect(slice, &SliceModel::externalReceiveAgcModeChanged,
+            this, &AgcCalibrationDialog::updateModeUi);
     connect(slice, &SliceModel::agcThresholdChanged, &m_engine, &AgcTCalibrator::onValueChanged);
     connect(slice, &SliceModel::agcOffLevelChanged, &m_engine, &AgcTCalibrator::onValueChanged);
     connect(slice, &SliceModel::agcThresholdChanged, this, &AgcCalibrationDialog::refreshFromSlice);
@@ -289,6 +291,11 @@ int AgcCalibrationDialog::liveValue() const
 {
     if (!m_slice) {
         return -1;
+    }
+    if (m_slice->externalReceiveReplacementActive()) {
+        return m_slice->receiveAgcMode() == QStringLiteral("off")
+                   ? m_slice->receiveAgcOffLevel()
+                   : m_slice->receiveAgcThreshold();
     }
     return m_slice->agcMode() == QStringLiteral("off")
                ? m_slice->agcOffLevel()
@@ -310,7 +317,12 @@ bool AgcCalibrationDialog::nrSuppressesCalibration() const
 
 void AgcCalibrationDialog::updateModeUi()
 {
-    const bool off = m_slice && m_slice->agcMode() == QStringLiteral("off");
+    const bool externalReceive =
+        m_slice && m_slice->externalReceiveReplacementActive();
+    const QString mode = m_slice
+        ? (externalReceive ? m_slice->receiveAgcMode() : m_slice->agcMode())
+        : QString();
+    const bool off = mode == QStringLiteral("off");
     const AgcTCalibrator::Strategy s =
         off ? AgcTCalibrator::Strategy::TargetLevel : AgcTCalibrator::Strategy::Knee;
     m_curve->setStrategy(s);
@@ -332,6 +344,12 @@ void AgcCalibrationDialog::updateModeUi()
 
     if (!m_slice) {
         m_modeLabel->setText(QStringLiteral("No active slice."));
+        m_startStopBtn->setEnabled(false);
+        return;
+    }
+    if (externalReceive) {
+        m_modeLabel->setText(QStringLiteral(
+            "AGC-T calibration is available for Flex receive only."));
         m_startStopBtn->setEnabled(false);
         return;
     }
@@ -367,6 +385,10 @@ void AgcCalibrationDialog::onStartStop()
 {
     if (m_engine.isRunning()) {
         m_engine.stop(); // restores original value
+        return;
+    }
+    if (m_slice && m_slice->externalReceiveReplacementActive()) {
+        updateModeUi();
         return;
     }
     // Refuse to start while any NR stage is suppressing the calibration tap.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5942,10 +5942,10 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     syncKiwiSdrTrackingToActiveSlice();
     refreshKiwiSdrWaterfallAvailability();
     syncFlexRxPanToAudioEngine();
-    // Sync squelch line to newly active slice (handles slice switch without waiting
-    // for squelchChanged signal)
-    if (auto* sw2 = spectrumForSlice(s))
-        sw2->setSquelchLine(s->squelchOn(), s->squelchLevel());
+    // Sync squelch line to newly active slice (handles slice switch without
+    // waiting for squelchChanged signal).
+    syncActiveSliceSquelchLineToSpectrums();
+    syncActiveSliceAutoSquelchToSpectrums();
     auto* sw = spectrum();
     if (sw) {
         if (revealOffscreen) {
@@ -7693,8 +7693,8 @@ BandSnapshot MainWindow::captureCurrentBandState() const
         snap.rxAntenna     = s->rxAntenna();
         snap.filterLow     = s->filterLow();
         snap.filterHigh    = s->filterHigh();
-        snap.agcMode       = s->agcMode();
-        snap.agcThreshold  = s->agcThreshold();
+        snap.agcMode       = s->receiveAgcMode();
+        snap.agcThreshold  = s->receiveAgcThreshold();
     }
     // Center and bandwidth are radio-authoritative — don't capture.
     if (auto* sw = spectrum()) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -336,8 +336,13 @@ private:
     void clearKiwiSdrVirtualAntennaForSlice(int sliceId);
     void updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice);
     void updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice);
+    void updateKiwiSdrVirtualReceiverControlsForSlice(SliceModel* slice);
     SliceModel* flexRxPanSourceSlice() const;
     void syncFlexRxPanToAudioEngine();
+    void syncActiveSliceSquelchLineToSpectrums();
+    bool autoSquelchShouldRunOnSpectrum(const QString& panId,
+                                        const SpectrumWidget* spectrum) const;
+    void syncActiveSliceAutoSquelchToSpectrums();
     SliceModel* kiwiSdrDisplaySliceForPan(const QString& panId) const;
     QString kiwiSdrProfileForPan(const QString& panId) const;
     QString kiwiSdrOverlayProfileForPan(const QString& panId) const;

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -22,6 +22,7 @@
 #include "MainWindowHelpers.h"
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
+#include "core/KiwiSdrProtocol.h"
 #include "core/LogManager.h"
 #include "core/MidiSettings.h"
 #include "core/UlanziDialBackend.h"
@@ -62,6 +63,72 @@ QString formatTMate2PowerSmallText(float watts)
 
     const int tenthsKw = std::clamp(static_cast<int>(std::lround(watts / 100.0f)), 10, 99);
     return QStringLiteral("%1k%2").arg(tenthsKw / 10).arg(tenthsKw % 10);
+}
+
+bool usesExternalReceiveControls(const SliceModel* slice)
+{
+    return slice && slice->externalReceiveReplacementActive();
+}
+
+int agcThresholdMinimumForSlice(const SliceModel* slice)
+{
+    return usesExternalReceiveControls(slice)
+        ? KiwiSdrProtocol::kAgcThresholdMinDb
+        : 0;
+}
+
+int agcThresholdMaximumForSlice(const SliceModel* slice)
+{
+    return usesExternalReceiveControls(slice)
+        ? KiwiSdrProtocol::kAgcThresholdMaxDb
+        : 100;
+}
+
+int controllerValueToAgcThreshold(const SliceModel* slice, float value)
+{
+    const float clamped = std::clamp(value, 0.0f, 100.0f);
+    if (!usesExternalReceiveControls(slice)) {
+        return static_cast<int>(std::lround(clamped));
+    }
+    constexpr float kUiSpan = 100.0f;
+    const float agcSpan =
+        static_cast<float>(KiwiSdrProtocol::kAgcThresholdMaxDb
+                           - KiwiSdrProtocol::kAgcThresholdMinDb);
+    return KiwiSdrProtocol::kAgcThresholdMinDb
+        + static_cast<int>(std::lround(clamped * agcSpan / kUiSpan));
+}
+
+float agcThresholdToControllerValue(const SliceModel* slice)
+{
+    if (!slice) {
+        return 0.0f;
+    }
+    if (!usesExternalReceiveControls(slice)) {
+        return static_cast<float>(slice->agcThreshold());
+    }
+    constexpr float kUiSpan = 100.0f;
+    const float agcSpan =
+        static_cast<float>(KiwiSdrProtocol::kAgcThresholdMaxDb
+                           - KiwiSdrProtocol::kAgcThresholdMinDb);
+    return std::clamp(
+        static_cast<float>(slice->receiveAgcThreshold()
+                           - KiwiSdrProtocol::kAgcThresholdMinDb)
+            * kUiSpan / agcSpan,
+        0.0f, kUiSpan);
+}
+
+int agcThresholdOverlayValue(const SliceModel* slice, int threshold)
+{
+    if (!usesExternalReceiveControls(slice)) {
+        return threshold;
+    }
+    return std::clamp(
+        static_cast<int>(std::lround(
+            static_cast<float>(threshold - KiwiSdrProtocol::kAgcThresholdMinDb)
+                * 100.0f
+                / static_cast<float>(KiwiSdrProtocol::kAgcThresholdMaxDb
+                                     - KiwiSdrProtocol::kAgcThresholdMinDb))),
+        0, 100);
 }
 
 QString tmate2EncoderDefaultAction(int encoderIndex)
@@ -406,7 +473,7 @@ void MainWindow::handleFlexControlButton(int button, int action)
     } else if (actionName == "ToggleAgc") {
         if (auto* s = activeSlice()) {
             static const char* modes[] = {"off", "slow", "med", "fast"};
-            const QString cur = s->agcMode().toLower();
+            const QString cur = s->receiveAgcMode().toLower();
             int idx = 0;
             for (int i = 0; i < 4; ++i) {
                 if (cur == modes[i]) { idx = i; break; }
@@ -896,7 +963,7 @@ void MainWindow::dispatchHidAction(const QString& actionName,
     } else if (actionName == "ToggleAgc") {
         if (auto* s = activeSlice()) {
             static const char* modes[] = {"off","slow","med","fast"};
-            const QString cur = s->agcMode().toLower();
+            const QString cur = s->receiveAgcMode().toLower();
             int idx = 0;
             for (int i = 0; i < 4; ++i) if (cur == modes[i]) { idx = i; break; }
             const int nextIdx = (idx + 1) % 4;
@@ -1337,10 +1404,17 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
 #endif
     } else if (actionId == "WheelAgcT") {
         if (auto* s = activeSlice()) {
-            const int next = std::clamp(s->agcThreshold() + steps, 0, 100);
+            const int current = usesExternalReceiveControls(s)
+                ? s->receiveAgcThreshold()
+                : s->agcThreshold();
+            const int next = std::clamp(
+                current + steps,
+                agcThresholdMinimumForSlice(s),
+                agcThresholdMaximumForSlice(s));
             s->setAgcThreshold(next);
 #ifdef HAVE_HIDAPI
-            triggerTMate2Overlay(TMate2Overlay::Agc, next);
+            triggerTMate2Overlay(
+                TMate2Overlay::Agc, agcThresholdOverlayValue(s, next));
 #endif
         }
     } else if (actionId == "WheelApf") {
@@ -1635,12 +1709,25 @@ void MainWindow::registerMidiParams()
         [this]() -> float { auto* s = activeSlice(); return s ? s->audioGain() : 0; });
 
     reg("rx.squelch", "Squelch Level", "RX", P::Slider, 0, 100,
-        [this](float v) { if (auto* s = activeSlice()) s->setSquelch(s->squelchOn(), static_cast<int>(v)); },
-        [this]() -> float { auto* s = activeSlice(); return s ? s->squelchLevel() : 0; });
+        [this](float v) {
+            if (auto* s = activeSlice()) {
+                s->setSquelch(s->receiveSquelchOn(), static_cast<int>(v));
+            }
+        },
+        [this]() -> float {
+            auto* s = activeSlice();
+            return s ? s->receiveSquelchLevel() : 0;
+        });
 
     reg("rx.agcThreshold", "AGC Threshold", "RX", P::Slider, 0, 100,
-        [this](float v) { if (auto* s = activeSlice()) s->setAgcThreshold(static_cast<int>(v)); },
-        [this]() -> float { auto* s = activeSlice(); return s ? s->agcThreshold() : 0; });
+        [this](float v) {
+            if (auto* s = activeSlice()) {
+                s->setAgcThreshold(controllerValueToAgcThreshold(s, v));
+            }
+        },
+        [this]() -> float {
+            return agcThresholdToControllerValue(activeSlice());
+        });
 
     reg("rx.audioPan", "Audio Pan", "RX", P::Slider, 0, 100,
         [this](float v) { if (auto* s = activeSlice()) s->setAudioPan(static_cast<int>(v)); },
@@ -1659,8 +1746,15 @@ void MainWindow::registerMidiParams()
         [this]() -> float { auto* s = activeSlice(); return s && s->anfOn() ? 1 : 0; });
 
     reg("rx.squelchEnable", "Squelch Enable", "RX", P::Toggle, 0, 1,
-        [this](float v) { if (auto* s = activeSlice()) s->setSquelch(v > 0.5f, s->squelchLevel()); },
-        [this]() -> float { auto* s = activeSlice(); return s && s->squelchOn() ? 1 : 0; });
+        [this](float v) {
+            if (auto* s = activeSlice()) {
+                s->setSquelch(v > 0.5f, s->receiveSquelchLevel());
+            }
+        },
+        [this]() -> float {
+            auto* s = activeSlice();
+            return s && s->receiveSquelchOn() ? 1 : 0;
+        });
 
     reg("rx.mute", "Audio Mute", "RX", P::Toggle, 0, 1,
         [this](float v) { m_audio->setMuted(v > 0.5f); },

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -3,14 +3,17 @@
 #include "AppletPanel.h"
 #include "KiwiSdrApplet.h"
 #include "PanadapterApplet.h"
+#include "RxApplet.h"
 #include "PanadapterStack.h"
 #include "SpectrumOverlayMenu.h"
 #include "SpectrumWidget.h"
 #include "SMeterWidget.h"
 #include "VfoWidget.h"
 #include "core/AudioEngine.h"
+#include "core/AppSettings.h"
 #include "core/KiwiSdrClient.h"
 #include "core/KiwiSdrManager.h"
+#include "core/KiwiSdrProtocol.h"
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -18,6 +21,8 @@
 #include <QMetaObject>
 #include <QSet>
 #include <QTimer>
+
+#include <algorithm>
 
 namespace AetherSDR {
 namespace {
@@ -98,6 +103,48 @@ void setKiwiSdrWaterfallActive(RadioModel& radioModel,
     }
 }
 
+int kiwiSdrAgcThresholdDbForSliceValue(int value)
+{
+    return qBound(KiwiSdrProtocol::kAgcThresholdMinDb, value,
+                  KiwiSdrProtocol::kAgcThresholdMaxDb);
+}
+
+int kiwiSdrSquelchThresholdDbForSliceValue(int value)
+{
+    return KiwiSdrProtocol::squelchSliderLevelToMarginDb(value);
+}
+
+bool kiwiSdrModeUsesNbfmSquelch(const QString& mode)
+{
+    const QString normalized = mode.trimmed().toUpper();
+    return normalized == QStringLiteral("FM")
+        || normalized == QStringLiteral("NFM");
+}
+
+KiwiSdrReceiverControls kiwiSdrReceiverControlsForSlice(
+    const SliceModel& slice,
+    int autoSqlMarginDb)
+{
+    const QString mode = slice.receiveAgcMode().trimmed().toLower();
+    KiwiSdrReceiverControls controls;
+    controls.agcEnabled = mode != QStringLiteral("off");
+    controls.agcGainDb = qBound(0, slice.receiveAgcOffLevel(), 100);
+    controls.agcHang = false;
+    controls.agcThresholdDb =
+        kiwiSdrAgcThresholdDbForSliceValue(slice.receiveAgcThreshold());
+    controls.agcDecayMs = KiwiSdrProtocol::agcDecayMsForMode(mode);
+    controls.squelchEnabled = slice.receiveSquelchOn();
+    controls.squelchThresholdDb = autoSqlMarginDb > 0
+        ? qBound(1, autoSqlMarginDb, 20)
+        : kiwiSdrSquelchThresholdDbForSliceValue(slice.receiveSquelchLevel());
+    if (autoSqlMarginDb <= 0 && kiwiSdrModeUsesNbfmSquelch(slice.mode())) {
+        controls.squelchThresholdDb = qBound(
+            1, slice.receiveSquelchLevel(),
+            KiwiSdrProtocol::kSquelchUiMaxLevel);
+    }
+    return controls;
+}
+
 } // namespace
 
 SliceModel* MainWindow::kiwiSdrAudioTargetSlice() const
@@ -137,6 +184,14 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
         return;
     }
 
+    // Selecting a receive source from a VFO/header menu is also selecting the
+    // slice whose receive path is being changed. Keep the side RX applet bound
+    // to that slice so SQL/AGC controls drive the Kiwi replacement source, not
+    // whichever Flex slice happened to be active before the menu action.
+    if (sliceId != m_activeSliceId) {
+        setActiveSliceInternal(sliceId, false);
+    }
+
     if (!m_kiwiSdrVirtualPreviousMute.contains(sliceId)) {
         m_kiwiSdrVirtualPreviousMute.insert(sliceId, slice->flexAudioMute());
     }
@@ -157,6 +212,9 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
         slice->filterLow(), slice->filterHigh(), slice->panId());
     updateKiwiSdrVirtualTrackingForSlice(slice);
     updateKiwiSdrVirtualAudioControlsForSlice(slice);
+    updateKiwiSdrVirtualReceiverControlsForSlice(slice);
+    syncActiveSliceSquelchLineToSpectrums();
+    syncActiveSliceAutoSquelchToSpectrums();
     syncFlexRxPanToAudioEngine();
     syncKiwiSdrDiversityEscControls();
 
@@ -181,6 +239,7 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
                 QStringLiteral("Waiting for KiwiSDR meter data")));
     }
     syncKiwiSdrPanadapterUiState(slice->panId());
+    syncActiveSliceAutoSquelchToSpectrums();
     refreshKiwiSdrWaterfallAvailability();
 }
 
@@ -211,6 +270,8 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
         m_kiwiSdrManager->clearSliceAssignment(sliceId);
     }
     syncFlexRxPanToAudioEngine();
+    syncActiveSliceSquelchLineToSpectrums();
+    syncActiveSliceAutoSquelchToSpectrums();
     syncKiwiSdrDiversityEscControls();
     refreshKiwiSdrWaterfallAvailability();
     if (!panId.isEmpty()) {
@@ -614,6 +675,31 @@ void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice)
     }, Qt::QueuedConnection);
 }
 
+void MainWindow::updateKiwiSdrVirtualReceiverControlsForSlice(SliceModel* slice)
+{
+    if (!m_kiwiSdrManager || !slice
+        || !slice->externalReceiveReplacementActive()) {
+        return;
+    }
+
+    const QString profileId =
+        m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+    if (profileId.isEmpty()) {
+        return;
+    }
+
+    int autoSqlMarginDb = -1;
+    if (slice->externalReceiveAutoSquelchOn()) {
+        autoSqlMarginDb = std::clamp(
+            AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(),
+            5, 20);
+    }
+
+    m_kiwiSdrManager->setReceiverControlsForSlice(
+        slice->sliceId(),
+        kiwiSdrReceiverControlsForSlice(*slice, autoSqlMarginDb));
+}
+
 bool MainWindow::applyKiwiSdrSliceMute()
 {
     SliceModel* target = kiwiSdrAudioTargetSlice();
@@ -802,6 +888,11 @@ void MainWindow::wireKiwiSdr()
                     return;
                 }
                 if (SpectrumWidget* sw = spectrumForSlice(slice)) {
+                    if (meter.valid && meter.hasDbm) {
+                        sw->setKiwiSdrSquelchMeterDbm(
+                            meter.dbm,
+                            meter.squelchStateKnown && meter.squelched);
+                    }
                     if (VfoWidget* vfo = sw->vfoWidget(sliceId)) {
                         vfo->setReceiveMeterReading(meter);
                     }
@@ -874,6 +965,7 @@ void MainWindow::wireKiwiSdr()
                     panId = slice->panId();
                     updateKiwiSdrVirtualTrackingForSlice(slice);
                     updateKiwiSdrVirtualAudioControlsForSlice(slice);
+                    updateKiwiSdrVirtualReceiverControlsForSlice(slice);
                 }
             } else if (m_kiwiSdrManager) {
                 const int sliceId =

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -31,6 +31,7 @@
 #include "MainWindowShortcutState.h"
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
+#include "core/KiwiSdrProtocol.h"
 #include "core/LogManager.h"
 #include "models/SliceModel.h"
 
@@ -741,7 +742,10 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("squelch_toggle", "Squelch Toggle", "Audio",
         QKeySequence(), [this]() {
             auto* s = activeSlice();
-            if (s) s->setSquelch(!s->squelchOn(), s->squelchLevel());
+            if (s) {
+                s->setSquelch(!s->receiveSquelchOn(),
+                              s->receiveSquelchLevel());
+            }
         });
 
     // ── Slice ───────────────────────────────────────────────────────────
@@ -933,7 +937,7 @@ void MainWindow::registerShortcutActions()
             auto* s = activeSlice();
             if (!s) return;
             static const char* modes[] = {"off", "slow", "med", "fast"};
-            QString cur = s->agcMode().toLower();
+            QString cur = s->receiveAgcMode().toLower();
             int idx = 0;
             for (int i = 0; i < 4; ++i)
                 if (cur == modes[i]) { idx = i; break; }
@@ -950,12 +954,26 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("agct_up", "AGC-T Up", "AGC",
         QKeySequence(), [this]() {
             auto* s = activeSlice();
-            if (s) s->setAgcThreshold(std::min(100, s->agcThreshold() + 5));
+            if (s) {
+                const bool external = s->externalReceiveReplacementActive();
+                const int current = external ? s->receiveAgcThreshold()
+                                             : s->agcThreshold();
+                s->setAgcThreshold(std::min(
+                    external ? KiwiSdrProtocol::kAgcThresholdMaxDb : 100,
+                    current + 5));
+            }
         }, true);
     m_shortcutManager.registerAction("agct_down", "AGC-T Down", "AGC",
         QKeySequence(), [this]() {
             auto* s = activeSlice();
-            if (s) s->setAgcThreshold(std::max(0, s->agcThreshold() - 5));
+            if (s) {
+                const bool external = s->externalReceiveReplacementActive();
+                const int current = external ? s->receiveAgcThreshold()
+                                             : s->agcThreshold();
+                s->setAgcThreshold(std::max(
+                    external ? KiwiSdrProtocol::kAgcThresholdMinDb : 0,
+                    current - 5));
+            }
         }, true);
 
     // ── CW ──────────────────────────────────────────────────────────────

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -36,6 +36,7 @@
 #include "core/PeripheralSettings.h"
 #include "core/KiwiSdrClient.h"
 #include "core/KiwiSdrManager.h"
+#include "core/KiwiSdrProtocol.h"
 #include "SpectrumOverlayMenu.h"
 #include "SpectrumWidget.h"
 #include "VfoWidget.h"
@@ -72,6 +73,20 @@ constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
 constexpr int kPanDimensionDecoderFallbackMs = 650;
 constexpr qint64 kProfileLoadDimensionSettleMs = kPanDimensionDecoderFallbackMs + 100;
+
+int currentAutoSqlMarginDb()
+{
+    return std::clamp(
+        AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(), 5, 20);
+}
+
+int kiwiSdrSquelchMarginDbForSliceLevel(const SliceModel* slice, int level)
+{
+    if (slice && slice->externalReceiveAutoSquelchOn()) {
+        return currentAutoSqlMarginDb();
+    }
+    return KiwiSdrProtocol::squelchSliderLevelToMarginDb(level);
+}
 
 bool memoryRevealTargetMatches(double actualMhz, double targetMhz)
 {
@@ -118,6 +133,37 @@ const SliceModel* kiwiSliceForPan(const RadioModel& radioModel,
     return nullptr;
 }
 
+SliceModel* kiwiAssignedSliceForPan(const RadioModel& radioModel,
+                                    const KiwiSdrManager* manager,
+                                    const QString& panId)
+{
+    if (!manager || panId.isEmpty()) {
+        return nullptr;
+    }
+
+    QVector<SliceModel*> candidates;
+    for (SliceModel* slice : radioModel.slices()) {
+        if (!slice || slice->panId() != panId
+            || !radioModel.sliceMayBelongToUs(slice->sliceId())
+            || manager->assignedProfileForSlice(slice->sliceId()).isEmpty()) {
+            continue;
+        }
+        if (slice->isDiversityParent()) {
+            return slice;
+        }
+        candidates.append(slice);
+    }
+    if (candidates.isEmpty()) {
+        return nullptr;
+    }
+    for (SliceModel* slice : candidates) {
+        if (!slice->diversity()) {
+            return slice;
+        }
+    }
+    return candidates.first();
+}
+
 // Pan-follow tuning internals — moved with their only callers from
 // MainWindow.cpp's anonymous namespace (#3351 Phase 1d).
 constexpr int kPanFollowAnimationDurationMs = 110;
@@ -132,6 +178,139 @@ double quantizeIncrementalFollowDelta(double overshootMhz, double stepMhz)
 }
 
 } // namespace
+
+void MainWindow::syncActiveSliceSquelchLineToSpectrums()
+{
+    SliceModel* s = activeSlice();
+    if (!s) {
+        auto clearSpectrum = [](SpectrumWidget* sw) {
+            if (!sw) {
+                return;
+            }
+            sw->clearKiwiSdrSquelchLine();
+            sw->setSquelchLine(false, 0);
+        };
+        if (!m_panStack) {
+            clearSpectrum(spectrum());
+            return;
+        }
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (!applet) {
+                continue;
+            }
+            clearSpectrum(m_panStack->spectrum(applet->panId()));
+        }
+        return;
+    }
+
+    const bool kiwiActive = m_kiwiSdrManager
+        && !m_kiwiSdrManager->assignedProfileForSlice(s->sliceId()).isEmpty();
+    const bool on = kiwiActive ? s->receiveSquelchOn() : s->squelchOn();
+    const int level = kiwiActive ? s->receiveSquelchLevel()
+                                 : s->squelchLevel();
+    const QString kiwiPanId = kiwiActive ? s->panId() : QString();
+    auto applyToSpectrum = [&](const QString& panId, SpectrumWidget* sw) {
+        if (!sw) {
+            return;
+        }
+        if (SliceModel* kiwiSlice =
+                kiwiAssignedSliceForPan(m_radioModel, m_kiwiSdrManager, panId)) {
+            sw->setKiwiSdrSquelchLine(
+                kiwiSlice->receiveSquelchOn(),
+                kiwiSdrSquelchMarginDbForSliceLevel(
+                    kiwiSlice, kiwiSlice->receiveSquelchLevel()),
+                kiwiSlice->externalReceiveAutoSquelchOn());
+            sw->setSquelchLine(false, 0);
+            return;
+        }
+        if (kiwiActive) {
+            if (panId == kiwiPanId) {
+                sw->setKiwiSdrSquelchLine(
+                    on, kiwiSdrSquelchMarginDbForSliceLevel(s, level),
+                    s->externalReceiveAutoSquelchOn());
+            } else {
+                sw->clearKiwiSdrSquelchLine();
+                sw->setSquelchLine(false, 0);
+            }
+            return;
+        }
+        if (!kiwiSdrProfileForPan(panId).isEmpty()
+            || sw->kiwiSdrWaterfallActive()) {
+            sw->clearKiwiSdrSquelchLine();
+            sw->setSquelchLine(false, 0);
+            return;
+        }
+        sw->clearKiwiSdrSquelchLine();
+        sw->setSquelchLine(on, level);
+    };
+
+    if (!m_panStack) {
+        applyToSpectrum(s->panId(), spectrumForSlice(s));
+        return;
+    }
+
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet) {
+            continue;
+        }
+        applyToSpectrum(applet->panId(), m_panStack->spectrum(applet->panId()));
+    }
+}
+
+bool MainWindow::autoSquelchShouldRunOnSpectrum(
+    const QString& panId, const SpectrumWidget* spectrum) const
+{
+    if (const SliceModel* kiwiSlice =
+            kiwiAssignedSliceForPan(m_radioModel, m_kiwiSdrManager, panId)) {
+        return kiwiSlice->externalReceiveAutoSquelchOn();
+    }
+
+    if (!m_appletPanel || !m_appletPanel->rxApplet()
+        || m_appletPanel->rxApplet()->sqlMode() != RxApplet::SqlMode::Auto) {
+        return false;
+    }
+
+    const SliceModel* s = activeSlice();
+    if (!s) {
+        return false;
+    }
+
+    const bool activeKiwi = m_kiwiSdrManager
+        && !m_kiwiSdrManager->assignedProfileForSlice(s->sliceId()).isEmpty();
+
+    if (activeKiwi) {
+        return panId == s->panId();
+    }
+
+    return kiwiSdrProfileForPan(panId).isEmpty()
+        && (!spectrum || !spectrum->kiwiSdrWaterfallActive());
+}
+
+void MainWindow::syncActiveSliceAutoSquelchToSpectrums()
+{
+    auto applyToSpectrum = [this](const QString& panId, SpectrumWidget* sw) {
+        if (!sw) {
+            return;
+        }
+        sw->setAutoSquelchEnable(autoSquelchShouldRunOnSpectrum(panId, sw));
+    };
+
+    if (!m_panStack) {
+        if (SliceModel* s = activeSlice()) {
+            applyToSpectrum(s->panId(), spectrumForSlice(s));
+        } else {
+            applyToSpectrum(QString(), spectrum());
+        }
+        return;
+    }
+
+    for (PanadapterApplet* applet : m_panStack->allApplets()) {
+        if (!applet) {
+            continue;
+        }
+        applyToSpectrum(applet->panId(), m_panStack->spectrum(applet->panId()));
+    }
+}
 
 void MainWindow::wireAetherDspWidget(AetherDspWidget* w)
 {
@@ -454,15 +633,37 @@ void MainWindow::onSliceAdded(SliceModel* s)
         if (s->isTxSlice())
             syncTxWaterfallSliceToSpectrums();
     });
-    // Squelch threshold line on the spectrum overlay — only update for the
-    // active slice so that inactive slices sharing a pan don't overwrite it.
+    // Squelch threshold line on the spectrum overlay. Flex follows the active
+    // slice only; Kiwi replacement audio owns an independent line on its own
+    // pan even when a Flex slice is active elsewhere.
     connect(s, &SliceModel::squelchChanged, this, [this, s](bool on, int level) {
+        Q_UNUSED(on);
+        Q_UNUSED(level);
         if (s != activeSlice()) return;
-        if (auto* sw = spectrumForSlice(s))
-            sw->setSquelchLine(on, level);
+        syncActiveSliceSquelchLineToSpectrums();
     });
-    if (auto* sw = spectrumForSlice(s))
+    connect(s, &SliceModel::externalReceiveSquelchChanged,
+            this, [this, s](bool on, int level) {
+        const bool kiwiAssigned = m_kiwiSdrManager
+            && !m_kiwiSdrManager->assignedProfileForSlice(s->sliceId()).isEmpty();
+        if (!kiwiAssigned) {
+            return;
+        }
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+        if (SpectrumWidget* sw = spectrumForSlice(s)) {
+            sw->setKiwiSdrSquelchLine(
+                on, kiwiSdrSquelchMarginDbForSliceLevel(s, level),
+                s->externalReceiveAutoSquelchOn());
+        }
+        if (s == activeSlice()) {
+            syncActiveSliceSquelchLineToSpectrums();
+        }
+    });
+    if (s == activeSlice()) {
+        syncActiveSliceSquelchLineToSpectrums();
+    } else if (auto* sw = spectrumForSlice(s)) {
         sw->setSquelchLine(s->squelchOn(), s->squelchLevel());
+    }
 
     connect(s, &SliceModel::txSliceChanged, this, [this, s](bool tx) {
         // Update hasTxSlice on all spectrums for waterfall freeze logic
@@ -1322,6 +1523,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     sw->disconnect(this);
     menu->disconnect(this);
     applet->disconnect(this);
+    if (m_appletPanel && m_appletPanel->rxApplet()) {
+        QObject::disconnect(m_appletPanel->rxApplet(), nullptr, sw, nullptr);
+    }
 
     auto updateKiwiWaterfallView = [this, applet, sw](double centerMhz,
                                                       double bandwidthMhz) {
@@ -1755,17 +1959,69 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     // ── Auto-squelch wiring ───────────────────────────────────────────────
     // RxApplet signals → per-pan spectrum widget
     connect(m_appletPanel->rxApplet(), &RxApplet::sqlAutoChanged,
-            sw, &SpectrumWidget::setAutoSquelchEnable);
+            sw, [this, applet, sw](bool) {
+        const QString panId = applet ? applet->panId() : QString();
+        sw->setAutoSquelchEnable(
+            autoSquelchShouldRunOnSpectrum(panId, sw));
+    });
     connect(m_appletPanel->rxApplet(), &RxApplet::squelchStateChanged,
-            sw, &SpectrumWidget::setSquelchLine);
+            sw, [this, applet, sw](bool on, int level) {
+        SliceModel* s = activeSlice();
+        const bool kiwiActive = s && m_kiwiSdrManager
+            && !m_kiwiSdrManager->assignedProfileForSlice(s->sliceId()).isEmpty();
+        if (kiwiActive) {
+            if (applet && applet->panId() == s->panId()) {
+                sw->setKiwiSdrSquelchLine(
+                    on, kiwiSdrSquelchMarginDbForSliceLevel(s, level),
+                    s->externalReceiveAutoSquelchOn());
+            } else {
+                sw->clearKiwiSdrSquelchLine();
+                sw->setSquelchLine(false, 0);
+            }
+            return;
+        }
+        const QString panId = applet ? applet->panId() : QString();
+        if (!kiwiSdrProfileForPan(panId).isEmpty()
+            || sw->kiwiSdrWaterfallActive()) {
+            sw->clearKiwiSdrSquelchLine();
+            sw->setSquelchLine(false, 0);
+            return;
+        }
+        sw->clearKiwiSdrSquelchLine();
+        sw->setSquelchLine(on, level);
+    });
     // Spectrum widget → radio + back to overlay: apply level and immediately
     // update the squelch line on sw so the yellow line never depends on the
     // RxApplet → squelchStateChanged → setSquelchLine round-trip, which can
     // miss the first emission if wirePanadapter runs before setSlice.
     connect(sw, &SpectrumWidget::autoSquelchLevelSuggested,
-            this, [this, sw](int level) {
-        if (auto* s = activeSlice()) s->setSquelch(true, level);
-        sw->setSquelchLine(true, level);
+            this, [this, applet, sw](int level) {
+        const QString panId = applet ? applet->panId() : QString();
+        if (!autoSquelchShouldRunOnSpectrum(panId, sw)) {
+            return;
+        }
+        if (SliceModel* kiwiSlice =
+                kiwiAssignedSliceForPan(m_radioModel, m_kiwiSdrManager, panId)) {
+            const int margin = currentAutoSqlMarginDb();
+            kiwiSlice->setSquelch(true, margin);
+            sw->setKiwiSdrSquelchLine(true, margin, true);
+            return;
+        }
+        SliceModel* s = activeSlice();
+        if (!s) {
+            return;
+        }
+        const bool kiwiActive = m_kiwiSdrManager
+            && !m_kiwiSdrManager->assignedProfileForSlice(s->sliceId()).isEmpty();
+        if (kiwiActive) {
+            const int margin = currentAutoSqlMarginDb();
+            s->setSquelch(true, margin);
+            sw->setKiwiSdrSquelchLine(
+                true, margin, true);
+        } else {
+            s->setSquelch(true, level);
+            sw->setSquelchLine(true, level);
+        }
     });
     // Auto-squelch margin: now driven by the RX Applet's SQL slider when
     // SQL mode is Auto (instead of a separate slider in the Display
@@ -1778,6 +2034,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         auto& s = AppSettings::instance();
         int margin = std::clamp(s.value("AutoSqlMarginDb", "10").toInt(), 5, 20);
         sw->setAutoSqlMarginDb(margin);
+    }
+    {
+        const QString panId = applet ? applet->panId() : QString();
+        sw->setAutoSquelchEnable(
+            autoSquelchShouldRunOnSpectrum(panId, sw));
     }
 
     // Pop out / dock panadapter
@@ -1983,7 +2244,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(menu, &SpectrumOverlayMenu::wfBlankerThresholdChanged,
             sw, &SpectrumWidget::setWfBlankerThreshold);
     connect(menu, &SpectrumOverlayMenu::backgroundImageRequested,
-            this, [this, sw] {
+            this, [sw] {
         QString path = QFileDialog::getOpenFileName(
             sw->window(),
             "Choose Background Image",
@@ -2736,6 +2997,47 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     connect(s, &SliceModel::audioPanChanged, this, [this, s](int) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
     });
+    connect(s, &SliceModel::agcModeChanged, this, [this, s](const QString&) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::agcThresholdChanged, this, [this, s](int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::agcOffLevelChanged, this, [this, s](int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::externalReceiveAgcModeChanged,
+            this, [this, s](const QString&) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::externalReceiveAgcThresholdChanged,
+            this, [this, s](int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::externalReceiveAgcOffLevelChanged,
+            this, [this, s](int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::squelchChanged, this, [this, s](bool, int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::externalReceiveSquelchChanged,
+            this, [this, s](bool, int) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+    });
+    connect(s, &SliceModel::externalReceiveAutoSquelchChanged,
+            this, [this, s](bool) {
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+        syncActiveSliceAutoSquelchToSpectrums();
+        syncActiveSliceSquelchLineToSpectrums();
+    });
+    connect(m_appletPanel->rxApplet(), &RxApplet::autoSqlMarginDbChanged,
+            s, [this, sliceId](int) {
+        if (sliceId == m_activeSliceId) {
+            updateKiwiSdrVirtualReceiverControlsForSlice(
+                m_radioModel.slice(sliceId));
+        }
+    });
     connect(s, &SliceModel::diversityChanged, this, [this](bool) {
         syncKiwiSdrDiversityEscControls();
     });
@@ -2781,7 +3083,7 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         w->setPlayEnabled(true);
     });
     // Client-side playback
-    connect(w, &VfoWidget::playToggled, this, [this, w, sliceId](bool on) {
+    connect(w, &VfoWidget::playToggled, this, [this, sliceId](bool on) {
         bool clientSide = AppSettings::instance().value("RecordingMode", "Radio").toString() == "Client";
         if (clientSide) {
             if (on)
@@ -2934,6 +3236,21 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
                 sw->reacquireNoiseFloorLock();
             }
         }
+    });
+    connect(w, &VfoWidget::autoSqlMarginDbChanged,
+            this, [this, s](int marginDb) {
+        if (m_panStack) {
+            for (PanadapterApplet* applet : m_panStack->allApplets()) {
+                if (!applet || !applet->spectrumWidget()) {
+                    continue;
+                }
+                applet->spectrumWidget()->setAutoSqlMarginDb(marginDb);
+            }
+        } else if (SpectrumWidget* sw = spectrumForSlice(s)) {
+            sw->setAutoSqlMarginDb(marginDb);
+        }
+        updateKiwiSdrVirtualReceiverControlsForSlice(s);
+        syncActiveSliceSquelchLineToSpectrums();
     });
 
     // Wire slice data into widget

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -7,6 +7,7 @@
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
 #include "core/KiwiSdrManager.h"
+#include "core/KiwiSdrProtocol.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "Theme.h"
@@ -188,10 +189,6 @@ static const QString& kButtonBase()
 
 static constexpr const char* kDimLabelStyle =
     "QLabel { color: #8090a0; font-size: 11px; }";
-
-static constexpr const char* kInsetValueStyle =
-    "QLabel { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e; "
-    "border-radius: 3px; padding: 1px 2px; color: #c8d8e8; }";
 
 static const QString& kBlueActive()
 {
@@ -940,25 +937,23 @@ void RxApplet::buildUI()
         connect(m_sqlSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_sqlMode == SqlMode::Manual) {
                 // Cache the user's chosen manual level so re-entering
-                // Manual from Auto/Off restores it, and persist it so the
-                // choice survives launch (the slice's squelchLevel gets
-                // clobbered by Auto's algorithm pushes and can no longer
-                // be trusted as the manual baseline).
-                m_sqlManualLevel = v;
-                auto& s = AppSettings::instance();
-                s.setValue("LastManualSquelchLevel", QString::number(v));
-                s.save();
+                // Manual from Auto/Off restores it on Flex. Kiwi replacement
+                // receive keeps its level in the external receive state, so
+                // it does not update the Flex manual cache.
+                const int level = clampManualSqlLevelForCurrentSurface(v);
+                setManualSqlLevelForCurrentSurface(level);
                 if (m_slice)
-                    m_slice->setSquelch(true, v);
+                    m_slice->setSquelch(true, level);
             } else if (m_sqlMode == SqlMode::Auto) {
                 // Auto SQL: slider sets the dB margin above the measured
                 // noise floor (5–20 dB).  Persist + broadcast so every
                 // pan's auto-squelch algorithm picks up the new margin
                 // and the suggested level recomputes on the next FFT.
+                const int margin = std::clamp(v, 5, 20);
                 auto& s = AppSettings::instance();
-                s.setValue("AutoSqlMarginDb", QString::number(v));
+                s.setValue("AutoSqlMarginDb", QString::number(margin));
                 s.save();
-                emit autoSqlMarginDbChanged(v);
+                emit autoSqlMarginDbChanged(margin);
             }
         });
         rightCol->addLayout(row);
@@ -1000,24 +995,27 @@ void RxApplet::buildUI()
                 return;
             }
             QMenu menu(m_agcTSlider);
-            menu.addAction(QStringLiteral("Calibrate AGC-T against noise floor…"),
-                           this, [this] {
+            QAction* calibrateAction =
+                menu.addAction(QStringLiteral("Calibrate AGC-T against noise floor…"),
+                               this, [this] {
                 if (m_slice) {
                     emit calibrateAgcTRequested(m_slice->sliceId());
                 }
             });
+            calibrateAction->setEnabled(
+                !m_slice->externalReceiveReplacementActive());
             menu.exec(m_agcTSlider->mapToGlobal(pos));
         });
 
         connect(m_agcTSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_slice) {
-                if (m_slice->agcMode() == "off") {
+                if (m_slice->receiveAgcMode() == "off") {
                     m_agcTSlider->setToolTip(
-                        QString("AGC Off Level: %1\nRight-click to calibrate against the noise floor").arg(v));
+                        QString("AGC Off Level: %1 dB\nRight-click to calibrate against the noise floor").arg(v));
                     m_slice->setAgcOffLevel(v);
                 } else {
                     m_agcTSlider->setToolTip(
-                        QString("AGC Threshold: %1\nRight-click to calibrate against the noise floor").arg(v));
+                        QString("AGC Threshold: %1 dB\nRight-click to calibrate against the noise floor").arg(v));
                     m_slice->setAgcThreshold(v);
                 }
             }
@@ -1150,7 +1148,7 @@ void RxApplet::buildUI()
     m_sqlSlider->setToolTip("Squelch threshold. Increase to require a stronger signal before audio opens.");
     // Auto SQL tooltip set inline at construction
     m_agcCombo->setToolTip("AGC speed. Slow resists pumping on quiet bands; Fast tracks rapid signal changes.");
-    m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(m_agcTSlider->value()));
+    m_agcTSlider->setToolTip(QString("AGC Threshold: %1 dB").arg(m_agcTSlider->value()));
     m_ritOnBtn->setToolTip("Receive Incremental Tuning \u2014 offsets the receive frequency without moving transmit.");
     m_ritZero->setToolTip("Resets the RIT offset to zero.");
     m_xitOnBtn->setToolTip("Transmit Incremental Tuning \u2014 offsets the transmit frequency without moving receive.");
@@ -1260,7 +1258,7 @@ void RxApplet::applySqlModeVisuals()
         break;
     }
     // Slider has two distinct roles depending on mode:
-    //   Manual: threshold input (0–100, squelch_level units).
+    //   Manual: threshold input (Flex 0-100, Kiwi 0-99 signed-offset UI).
     //   Auto:   dB margin above measured noise floor (5–20).
     //   Off:    disabled.
     // Switching modes resizes the slider's range and restores the
@@ -1271,15 +1269,21 @@ void RxApplet::applySqlModeVisuals()
         QSignalBlocker b(m_sqlSlider);
         switch (m_sqlMode) {
         case SqlMode::Manual: {
-            m_sqlSlider->setRange(0, 100);
-            // Restore the cached manual level — slice->squelchLevel() may
+            m_sqlSlider->setRange(0, sqlManualMaximum());
+            // Restore the cached manual level — receiveSquelchLevel() may
             // hold a stale Auto-algorithm value that doesn't represent the
-            // user's chosen manual threshold.
-            m_sqlSlider->setValue(m_sqlManualLevel);
-            m_sqlSlider->setEnabled(true);
-            m_sqlSlider->setToolTip(
-                "Squelch threshold (0–100). Increase to require a stronger "
-                "signal before audio opens.");
+            // user's chosen manual threshold. Kiwi replacement receive has
+            // its own visible squelch state, independent of the Flex cache.
+            m_sqlSlider->setValue(sqlManualLevel());
+            m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
+            m_sqlSlider->setToolTip(usingExternalReceiveSquelch()
+                ? QStringLiteral("Kiwi SQL threshold (0-99, mapped to a "
+                                 "signed dB offset from the receiver noise "
+                                 "floor). Increase to require a stronger "
+                                 "signal before audio opens.")
+                : QStringLiteral("Squelch threshold (0-100). Increase to "
+                                 "require a stronger signal before audio "
+                                 "opens."));
             break;
         }
         case SqlMode::Auto: {
@@ -1288,7 +1292,7 @@ void RxApplet::applySqlModeVisuals()
                 AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(),
                 5, 20);
             m_sqlSlider->setValue(margin);
-            m_sqlSlider->setEnabled(true);
+            m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
             m_sqlSlider->setToolTip(
                 "Auto SQL margin (5–20 dB). dB above the measured noise "
                 "floor where the squelch gate opens.");
@@ -1301,6 +1305,9 @@ void RxApplet::applySqlModeVisuals()
                 "before audio opens.");
             break;
         }
+        m_sqlSlider->style()->unpolish(m_sqlSlider);
+        m_sqlSlider->style()->polish(m_sqlSlider);
+        m_sqlSlider->update();
     }
 }
 
@@ -1334,27 +1341,66 @@ int RxApplet::autoSqlMarginDb() const
         AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(), 5, 20);
 }
 
+bool RxApplet::usingExternalReceiveSquelch() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive();
+}
+
+int RxApplet::sqlManualLevel() const
+{
+    if (usingExternalReceiveSquelch()) {
+        return clampManualSqlLevelForCurrentSurface(
+            m_slice->receiveSquelchLevel());
+    }
+    return clampManualSqlLevelForCurrentSurface(m_sqlManualLevel);
+}
+
+int RxApplet::sqlManualMaximum() const
+{
+    return usingExternalReceiveSquelch()
+        ? KiwiSdrProtocol::kSquelchUiMaxLevel
+        : 100;
+}
+
+int RxApplet::clampManualSqlLevelForCurrentSurface(int level) const
+{
+    return std::clamp(level, 0, sqlManualMaximum());
+}
+
+void RxApplet::setManualSqlLevelForCurrentSurface(int level)
+{
+    const int clamped = clampManualSqlLevelForCurrentSurface(level);
+    if (usingExternalReceiveSquelch()) {
+        return;
+    }
+
+    m_sqlManualLevel = clamped;
+    auto& s = AppSettings::instance();
+    s.setValue("LastManualSquelchLevel", QString::number(clamped));
+    s.save();
+}
+
 void RxApplet::setSqlSliderValueExternal(int v)
 {
     if (m_sqlMode == SqlMode::Manual) {
-        m_sqlManualLevel = v;
-        auto& s = AppSettings::instance();
-        s.setValue("LastManualSquelchLevel", QString::number(v));
-        s.save();
+        const int level = clampManualSqlLevelForCurrentSurface(v);
+        setManualSqlLevelForCurrentSurface(level);
         if (m_slice)
-            m_slice->setSquelch(true, v);
+            m_slice->setSquelch(true, level);
         if (m_sqlSlider) {
             QSignalBlocker b(m_sqlSlider);
-            m_sqlSlider->setValue(v);
+            m_sqlSlider->setRange(0, sqlManualMaximum());
+            m_sqlSlider->setValue(level);
         }
     } else if (m_sqlMode == SqlMode::Auto) {
+        const int margin = std::clamp(v, 5, 20);
         auto& s = AppSettings::instance();
-        s.setValue("AutoSqlMarginDb", QString::number(v));
+        s.setValue("AutoSqlMarginDb", QString::number(margin));
         s.save();
-        emit autoSqlMarginDbChanged(v);
+        emit autoSqlMarginDbChanged(margin);
         if (m_sqlSlider) {
             QSignalBlocker b(m_sqlSlider);
-            m_sqlSlider->setValue(v);
+            m_sqlSlider->setValue(margin);
         }
     }
     // Off: ignored — slider is disabled on both UIs.
@@ -1362,10 +1408,23 @@ void RxApplet::setSqlSliderValueExternal(int v)
 
 void RxApplet::setSqlMode(SqlMode m, bool propagateToRadio)
 {
-    if (m == m_sqlMode) return;
+    if (m == m_sqlMode) {
+        if (m_slice && usingExternalReceiveSquelch()) {
+            m_slice->setExternalReceiveAutoSquelch(m == SqlMode::Auto);
+        } else {
+            m_flexSqlMode = m;
+        }
+        applySqlModeVisuals();
+        return;
+    }
     const bool wasAuto = (m_sqlMode == SqlMode::Auto);
     const bool nowAuto = (m == SqlMode::Auto);
     m_sqlMode = m;
+    if (m_slice && usingExternalReceiveSquelch()) {
+        m_slice->setExternalReceiveAutoSquelch(nowAuto);
+    } else {
+        m_flexSqlMode = m;
+    }
     applySqlModeVisuals();
 
     // Notify any mirroring UI (VfoWidget's SQL button + slider) so it can
@@ -1378,13 +1437,15 @@ void RxApplet::setSqlMode(SqlMode m, bool propagateToRadio)
     if (wasAuto != nowAuto)
         emit sqlAutoChanged(nowAuto);
 
-    // Manual / Auto both want the radio squelch ON.  Auto's first level push
-    // arrives from the algorithm via autoSquelchLevelSuggested → setSquelch
-    // routed through MainWindow; the immediate setSquelch(true, slider) here
-    // just makes sure the gate is open while the algorithm warms up.
+    // Manual / Auto both want the radio squelch ON. Use the same model-backed
+    // value that applySqlModeVisuals() displays so the first Kiwi command
+    // cannot diverge from the slider/overlay before the operator drags it.
     if (propagateToRadio && m_slice) {
         const bool sqOn = (m != SqlMode::Off);
-        m_slice->setSquelch(sqOn, m_sqlSlider->value());
+        const int level = (m == SqlMode::Manual)
+            ? sqlManualLevel()
+            : autoSqlMarginDb();
+        m_slice->setSquelch(sqOn, level);
     }
 }
 
@@ -1785,6 +1846,9 @@ void RxApplet::setKiwiSdrManager(KiwiSdrManager* manager)
                 this, [this](int sliceId, const QString&) {
             if (m_slice && m_slice->sliceId() == sliceId) {
                 updateAntennaButtons();
+                applySqlModeVisuals();
+                emit sqlModeChanged(static_cast<int>(m_sqlMode));
+                emit sqlAutoChanged(m_sqlMode == SqlMode::Auto);
             }
         });
     }
@@ -2061,42 +2125,40 @@ void RxApplet::connectSlice(SliceModel* s)
     updateAgcCombo();
     connect(s, &SliceModel::agcModeChanged, this, [this](const QString&) {
         updateAgcCombo();
+        syncAgcSliderFromSlice();
+    });
+    connect(s, &SliceModel::externalReceiveAgcModeChanged,
+            this, [this](const QString&) {
+        updateAgcCombo();
+        syncAgcSliderFromSlice();
     });
 
     // AGC threshold / off level — slider switches based on AGC mode
-    {
-        QSignalBlocker b(m_agcTSlider);
-        if (s->agcMode() == "off") {
-            m_agcTSlider->setValue(s->agcOffLevel());
-            m_agcTSlider->setToolTip(QString("AGC Off Level: %1").arg(s->agcOffLevel()));
-        } else {
-            m_agcTSlider->setValue(s->agcThreshold());
-            m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(s->agcThreshold()));
-        }
-    }
+    syncAgcSliderFromSlice();
     connect(s, &SliceModel::agcThresholdChanged, this, [this](int v) {
-        if (m_slice && m_slice->agcMode() != "off") {
-            QSignalBlocker b(m_agcTSlider);
-            m_agcTSlider->setValue(v);
-            m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(v));
+        Q_UNUSED(v);
+        if (m_slice && m_slice->receiveAgcMode() != "off") {
+            syncAgcSliderFromSlice();
+        }
+    });
+    connect(s, &SliceModel::externalReceiveAgcThresholdChanged,
+            this, [this](int v) {
+        Q_UNUSED(v);
+        if (m_slice && m_slice->receiveAgcMode() != "off") {
+            syncAgcSliderFromSlice();
         }
     });
     connect(s, &SliceModel::agcOffLevelChanged, this, [this](int v) {
-        if (m_slice && m_slice->agcMode() == "off") {
-            QSignalBlocker b(m_agcTSlider);
-            m_agcTSlider->setValue(v);
-            m_agcTSlider->setToolTip(QString("AGC Off Level: %1").arg(v));
+        Q_UNUSED(v);
+        if (m_slice && m_slice->receiveAgcMode() == "off") {
+            syncAgcSliderFromSlice();
         }
     });
-    connect(s, &SliceModel::agcModeChanged, this, [this](const QString& mode) {
-        if (!m_slice) return;
-        QSignalBlocker b(m_agcTSlider);
-        if (mode == "off") {
-            m_agcTSlider->setValue(m_slice->agcOffLevel());
-            m_agcTSlider->setToolTip(QString("AGC Off Level: %1").arg(m_slice->agcOffLevel()));
-        } else {
-            m_agcTSlider->setValue(m_slice->agcThreshold());
-            m_agcTSlider->setToolTip(QString("AGC Threshold: %1").arg(m_slice->agcThreshold()));
+    connect(s, &SliceModel::externalReceiveAgcOffLevelChanged,
+            this, [this](int v) {
+        Q_UNUSED(v);
+        if (m_slice && m_slice->receiveAgcMode() == "off") {
+            syncAgcSliderFromSlice();
         }
     });
 
@@ -2123,25 +2185,64 @@ void RxApplet::connectSlice(SliceModel* s)
         m_panSlider->setValue(v);
     });
 
-    // Squelch — derive 3-way mode from the radio's squelch on/off state.
-    // Auto is client-side only and doesn't survive slice switches, so a
-    // freshly-selected slice always starts in Off or Manual.  The user can
-    // re-enter Auto on the new slice with one click if they want.
+    auto applySquelchState = [this](bool on, int level, bool externalReceive) {
+        // In Auto mode the slider represents the operator-chosen dB margin,
+        // NOT the algorithm-suggested threshold — skip the value update so
+        // the algorithm's tick-by-tick setSquelch echoes don't overwrite
+        // the user's margin choice.  The spectrum-side yellow SQL line
+        // still tracks `level` via MainWindow.
+        if (m_sqlMode != SqlMode::Auto) {
+            QSignalBlocker blocker(m_sqlSlider);
+            m_sqlSlider->setValue(level);
+            // Keep only the Flex manual-level cache in sync with radio-side
+            // squelch changes. Kiwi replacement SQL is independent and lives
+            // in the external receive state on the slice.
+            if (!externalReceive && m_sqlMode == SqlMode::Manual) {
+                setManualSqlLevelForCurrentSurface(level);
+            }
+        }
+        // Auto drives setSquelch every algorithm tick; don't demote out of
+        // Auto when the echo arrives with squelch-on.  Only flip the mode
+        // when the source reports squelch-off or when we were Off and
+        // squelch came on.
+        bool modeChanged = false;
+        if (!on && m_sqlMode != SqlMode::Off) {
+            setSqlMode(SqlMode::Off, /*propagateToRadio=*/false);
+            modeChanged = true;
+        } else if (on && m_sqlMode == SqlMode::Off && m_sqlBtn->isEnabled()) {
+            setSqlMode(SqlMode::Manual, /*propagateToRadio=*/false);
+            modeChanged = true;
+        }
+        if (!modeChanged) {
+            applySqlModeVisuals();
+        }
+        emit squelchStateChanged(on, level);
+    };
+
+    // Squelch — derive 3-way mode from the current receive surface's
+    // squelch on/off state. Auto is client-side only and doesn't survive
+    // slice switches, so a freshly-selected slice starts in Off or Manual.
     {
         QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
-        // Do NOT overwrite m_sqlManualLevel from the slice here — the
-        // slice's squelchLevel may have been clobbered by Auto-mode
-        // algorithm pushes in the prior session, and we want to keep the
-        // user's persisted manual choice as the source of truth across
-        // launches.  The slider value is still visually set to the
-        // slice's current state below; applySqlModeVisuals (via the
-        // setSqlMode call) will overwrite that with m_sqlManualLevel
-        // when entering Manual.
-        m_sqlSlider->setValue(s->squelchLevel());
-        setSqlMode(s->squelchOn() ? SqlMode::Manual : SqlMode::Off,
-                   /*propagateToRadio=*/false);
+        // Do NOT overwrite the Flex manual cache from the slice here. Flex
+        // restores the persisted manual choice; Kiwi replacement receive
+        // reads its own external state through sqlManualLevel().
+        m_sqlSlider->setValue(s->receiveSquelchLevel());
+        SqlMode mode = s->receiveSquelchOn() ? SqlMode::Manual : SqlMode::Off;
+        if (s->externalReceiveReplacementActive()) {
+            if (s->externalReceiveAutoSquelchOn()) {
+                mode = SqlMode::Auto;
+            }
+        } else if (m_flexSqlMode == SqlMode::Auto) {
+            mode = SqlMode::Auto;
+        } else {
+            m_flexSqlMode = mode;
+        }
+        setSqlMode(mode, /*propagateToRadio=*/false);
     }
-    emit squelchStateChanged(s->squelchOn(), s->squelchLevel());
+    emit sqlModeChanged(static_cast<int>(m_sqlMode));
+    emit sqlAutoChanged(m_sqlMode == SqlMode::Auto);
+    emit squelchStateChanged(s->receiveSquelchOn(), s->receiveSquelchLevel());
     // AF gain → radio's per-slice audio_level
     {
         QSignalBlocker sb(m_afSlider);
@@ -2152,37 +2253,28 @@ void RxApplet::connectSlice(SliceModel* s)
         m_afSlider->setValue(static_cast<int>(g));
     });
 
-    connect(s, &SliceModel::squelchChanged, this, [this](bool on, int level) {
-        QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
-        // In Auto mode the slider represents the operator-chosen dB margin,
-        // NOT the algorithm-suggested threshold — skip the value update so
-        // the algorithm's tick-by-tick setSquelch echoes don't overwrite
-        // the user's margin choice.  The spectrum-side yellow SQL line
-        // still tracks `level` via setSquelchLine.
-        if (m_sqlMode != SqlMode::Auto) {
-            m_sqlSlider->setValue(level);
-            // Keep the Manual-level cache in sync with external squelch
-            // changes (TCI client, radio panel knob) so a later Manual
-            // re-entry restores the up-to-date value, not a stale one.
-            // Persist too so launch-time recall reflects the most recent
-            // manual threshold regardless of who set it.
-            if (m_sqlMode == SqlMode::Manual) {
-                m_sqlManualLevel = level;
-                auto& settings = AppSettings::instance();
-                settings.setValue("LastManualSquelchLevel",
-                                  QString::number(level));
-                settings.save();
-            }
+    connect(s, &SliceModel::squelchChanged, this, [this, applySquelchState](bool on, int level) {
+        if (m_slice && m_slice->externalReceiveReplacementActive()) {
+            return;
         }
-        // Auto drives setSquelch every algorithm tick; don't demote out of
-        // Auto when the echo arrives with squelch-on.  Only flip the mode
-        // when the radio reports squelch-off (operator hit it from somewhere
-        // else) or when we were Off and squelch came on (external SQL on).
-        if (!on && m_sqlMode != SqlMode::Off)
-            setSqlMode(SqlMode::Off, /*propagateToRadio=*/false);
-        else if (on && m_sqlMode == SqlMode::Off && m_sqlBtn->isEnabled())
-            setSqlMode(SqlMode::Manual, /*propagateToRadio=*/false);
-        emit squelchStateChanged(on, level);
+        applySquelchState(on, level, false);
+    });
+    connect(s, &SliceModel::externalReceiveSquelchChanged,
+            this, [this, applySquelchState](bool on, int level) {
+        if (!m_slice || !m_slice->externalReceiveReplacementActive()) {
+            return;
+        }
+        applySquelchState(on, level, true);
+    });
+    connect(s, &SliceModel::externalReceiveAutoSquelchChanged,
+            this, [this](bool on) {
+        if (!m_slice || !m_slice->externalReceiveReplacementActive()) {
+            return;
+        }
+        setSqlMode(on ? SqlMode::Auto
+                      : (m_slice->receiveSquelchOn() ? SqlMode::Manual
+                                                     : SqlMode::Off),
+                   /*propagateToRadio=*/false);
     });
 
     // DSP toggles removed — use VFO DSP tab or spectrum overlay
@@ -2529,15 +2621,15 @@ void RxApplet::updateModeSettings(const QString& mode)
         // CW/CWL squelch is radio-managed — no client push, so no "save" either,
         // or the unpaired flag would fabricate a restore on the next mode change
         // (and most visibly across profile-load slice teardown — #3263).
-        if ((m_slice->squelchOn() || m_sqlMode == SqlMode::Auto)
+        if ((m_slice->receiveSquelchOn() || m_sqlMode == SqlMode::Auto)
             && (mode == "DIGU" || mode == "DIGL" || mode == "NT" || mode == "RTTY")) {
             m_savedSquelchOn = true;
-            m_slice->setSquelch(false, m_slice->squelchLevel());
+            m_slice->setSquelch(false, m_slice->receiveSquelchLevel());
             setSqlMode(SqlMode::Off, /*propagateToRadio=*/false);
         }
     } else if (!sqlDisabled && m_slice && m_savedSquelchOn) {
         m_savedSquelchOn = false;
-        m_slice->setSquelch(true, m_slice->squelchLevel());
+        m_slice->setSquelch(true, m_slice->receiveSquelchLevel());
         setSqlMode(SqlMode::Manual, /*propagateToRadio=*/false);
     }
 
@@ -2723,7 +2815,7 @@ void RxApplet::syncStepFromSlice(int stepHz, const QVector<int>& stepList)
 
 void RxApplet::updateAgcCombo()
 {
-    const QString cur = m_slice ? m_slice->agcMode() : "";
+    const QString cur = m_slice ? m_slice->receiveAgcMode() : "";
     QSignalBlocker sb(m_agcCombo);
     for (int i = 0; i < m_agcCombo->count(); ++i) {
         if (m_agcCombo->itemData(i).toString() == cur) {
@@ -2731,6 +2823,42 @@ void RxApplet::updateAgcCombo()
             break;
         }
     }
+}
+
+int RxApplet::agcThresholdMinimum() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive()
+        ? KiwiSdrProtocol::kAgcThresholdMinDb
+        : 0;
+}
+
+int RxApplet::agcThresholdMaximum() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive()
+        ? KiwiSdrProtocol::kAgcThresholdMaxDb
+        : 100;
+}
+
+void RxApplet::syncAgcSliderFromSlice()
+{
+    if (!m_slice || !m_agcTSlider) {
+        return;
+    }
+
+    const bool agcOff = m_slice->receiveAgcMode() == QStringLiteral("off");
+    const int minimum = agcOff ? 0 : agcThresholdMinimum();
+    const int maximum = agcOff ? 100 : agcThresholdMaximum();
+    const int value = std::clamp(
+        agcOff ? m_slice->receiveAgcOffLevel()
+               : m_slice->receiveAgcThreshold(),
+        minimum, maximum);
+
+    QSignalBlocker b(m_agcTSlider);
+    m_agcTSlider->setRange(minimum, maximum);
+    m_agcTSlider->setValue(value);
+    m_agcTSlider->setToolTip(agcOff
+        ? QStringLiteral("AGC Off Level: %1 dB").arg(value)
+        : QStringLiteral("AGC Threshold: %1 dB").arg(value));
 }
 
 void RxApplet::updateOffsetDirButtons()

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -2220,8 +2220,9 @@ void RxApplet::connectSlice(SliceModel* s)
     };
 
     // Squelch — derive 3-way mode from the current receive surface's
-    // squelch on/off state. Auto is client-side only and doesn't survive
-    // slice switches, so a freshly-selected slice starts in Off or Manual.
+    // squelch on/off state. Auto is client-side only: Flex keeps the
+    // applet-wide Auto mode across active Flex slice switches, while Kiwi
+    // replacement receive keeps Auto as per-slice external receive state.
     {
         QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
         // Do NOT overwrite the Flex manual cache from the slice here. Flex

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -54,18 +54,21 @@ public:
 
     // Cross-widget access for the bidirectional SQL sync with VfoWidget.
     // VfoWidget mirrors mode + value via these methods; RxApplet stays the
-    // source of truth for SqlMode, the manual-level cache, and the
-    // AutoSqlMarginDb persistence.
+    // source of truth for SqlMode, the current surface's manual level, and
+    // the AutoSqlMarginDb persistence.
     SqlMode sqlMode() const { return m_sqlMode; }
-    int     sqlManualLevel() const { return m_sqlManualLevel; }
+    bool    isAttachedToSlice(const SliceModel* slice) const { return m_slice == slice; }
+    int     sqlManualLevel() const;
+    int     sqlManualMaximum() const;
     int     autoSqlMarginDb() const;
     // Externally cycle the mode (Off → Manual → Auto → Off) — same path the
     // RxApplet's own SQL button takes.  Emits sqlModeChanged.
     void    cycleSqlModeExternal();
     // Programmatic slider drag from another UI surface.  Branches by mode
-    // exactly like the in-applet slider does: Manual writes the slice and
-    // persists m_sqlManualLevel; Auto writes AppSettings AutoSqlMarginDb
-    // and emits autoSqlMarginDbChanged.  Off is a no-op.
+    // exactly like the in-applet slider does: Manual writes the current
+    // receive surface; Flex also persists m_sqlManualLevel, while Kiwi keeps
+    // its replacement-source level independent. Auto writes AppSettings
+    // AutoSqlMarginDb and emits autoSqlMarginDbChanged. Off is a no-op.
     void    setSqlSliderValueExternal(int v);
     void syncStepFromSlice(int stepHz, const QVector<int>& stepList);
     void cycleStepUp();
@@ -269,6 +272,7 @@ private:
     QPushButton* m_sqlBtn{nullptr};
     QSlider*     m_sqlSlider{nullptr};
     SqlMode      m_sqlMode{SqlMode::Off};
+    SqlMode      m_flexSqlMode{SqlMode::Off};
     bool         m_savedSquelchOn{false};
     // Last user-chosen Manual squelch level (0–100).  Auto mode overwrites
     // the slice's squelchLevel with algorithm-suggested values every FFT
@@ -279,6 +283,12 @@ private:
     void applySqlModeVisuals();
     void cycleSqlMode();
     void setSqlMode(SqlMode m, bool propagateToRadio);
+    bool usingExternalReceiveSquelch() const;
+    int clampManualSqlLevelForCurrentSurface(int level) const;
+    void setManualSqlLevelForCurrentSurface(int level);
+    int agcThresholdMinimum() const;
+    int agcThresholdMaximum() const;
+    void syncAgcSliderFromSlice();
 
 
     // RIT

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -73,7 +73,7 @@ static constexpr int kWaterfallLineDurationMaxMs = 100;
 static constexpr int kWaterfallHistoryCapacityMsPerRow = 50;
 static constexpr int kWaterfallRatePercentMin = 1;
 static constexpr int kWaterfallRatePercentMax = 100;
-static constexpr float kKiwiSdrWaterfallMinDbm = -130.0f;
+static constexpr float kKiwiSdrWaterfallMinDbm = -200.0f;
 static constexpr float kKiwiSdrWaterfallMaxDbm = 0.0f;
 static constexpr int kNativeWaterfallFallbackMinTimeoutMs = 2000;
 static constexpr int kNativeWaterfallFallbackMaxTimeoutMs = 20000;
@@ -657,7 +657,11 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     m_squelchLineHideTimer->setSingleShot(true);
     m_squelchLineHideTimer->setInterval(3000);
     connect(m_squelchLineHideTimer, &QTimer::timeout, this, [this]() {
-        m_squelchLineVisible = false;
+        if (m_kiwiSdrWaterfallActive && m_kiwiSdrSquelchLineVisible) {
+            m_kiwiSdrSquelchLineVisible = false;
+        } else {
+            m_flexSquelchLineVisible = false;
+        }
         markOverlayDirty();
     });
 
@@ -1627,6 +1631,103 @@ float SpectrumWidget::estimateNoiseFloorDbm(const QVector<float>& bins) const
     return (baselineCount > 0) ? baselineSum / static_cast<float>(baselineCount) : mean;
 }
 
+float SpectrumWidget::estimateKiwiSdrVisualNoiseFloorDbm(
+    const QVector<float>& bins) const
+{
+    if (bins.isEmpty()) {
+        return -1000.0f;
+    }
+
+    const int stride = std::max(1, static_cast<int>(bins.size() / 512));
+    QVector<float> finite;
+    finite.reserve((bins.size() + stride - 1) / stride);
+    for (int i = 0; i < bins.size(); i += stride) {
+        const float v = bins[i];
+        if (std::isfinite(v)) {
+            finite.append(v);
+        }
+    }
+    if (finite.isEmpty()) {
+        return -1000.0f;
+    }
+
+    const int middle = finite.size() / 2;
+    std::nth_element(finite.begin(), finite.begin() + middle, finite.end());
+    return finite[middle];
+}
+
+void SpectrumWidget::updateKiwiSdrSquelchVisualFloor(float floorDbm)
+{
+    if (m_kiwiSdrSquelchMeterFloorValid) {
+        return;
+    }
+    if (!std::isfinite(floorDbm)) {
+        return;
+    }
+
+    const float clamped = std::clamp(
+        floorDbm, kKiwiSdrWaterfallMinDbm, kKiwiSdrWaterfallMaxDbm);
+    if (m_kiwiSdrSquelchLiveFloorDbm <= -500.0f) {
+        m_kiwiSdrSquelchLiveFloorDbm = clamped;
+    } else {
+        const float delta = clamped - m_kiwiSdrSquelchLiveFloorDbm;
+        if (std::abs(delta) >= 0.10f) {
+            const float alpha = delta > 0.0f ? 0.06f : 0.18f;
+            m_kiwiSdrSquelchLiveFloorDbm =
+                (1.0f - alpha) * m_kiwiSdrSquelchLiveFloorDbm
+                + alpha * clamped;
+        }
+    }
+
+    if (!m_kiwiSdrSquelchLineVisible) {
+        return;
+    }
+
+    if (m_kiwiSdrSquelchLineFloorRelative) {
+        markOverlayDirty();
+    } else if (!m_kiwiSdrSquelchPinnedThresholdValid
+               || !m_kiwiSdrSquelchPinnedDisplayNormValid) {
+        pinKiwiSdrManualSquelchLine();
+        markOverlayDirty();
+    }
+}
+
+void SpectrumWidget::pinKiwiSdrManualSquelchLine()
+{
+    if (!m_kiwiSdrSquelchLineVisible
+        || m_kiwiSdrSquelchLineFloorRelative
+        || m_kiwiSdrSquelchLevel == KiwiSdrProtocol::kSquelchOffLevel) {
+        return;
+    }
+
+    if (m_kiwiSdrSquelchLiveFloorDbm <= -500.0f) {
+        m_kiwiSdrSquelchPinnedFloorDbm = -999.0f;
+        m_kiwiSdrSquelchPinnedFloorValid = false;
+        m_kiwiSdrSquelchPinnedThresholdDbm = -999.0f;
+        m_kiwiSdrSquelchPinnedThresholdValid = false;
+        m_kiwiSdrSquelchPinnedDisplayNorm = -1.0f;
+        m_kiwiSdrSquelchPinnedDisplayNormValid = false;
+        return;
+    }
+
+    m_kiwiSdrSquelchPinnedFloorDbm = m_kiwiSdrSquelchLiveFloorDbm;
+    m_kiwiSdrSquelchPinnedFloorValid = true;
+    m_kiwiSdrSquelchPinnedThresholdDbm =
+        m_kiwiSdrSquelchPinnedFloorDbm
+        + static_cast<float>(m_kiwiSdrSquelchLevel);
+    m_kiwiSdrSquelchPinnedThresholdValid = true;
+    if (m_dynamicRange > 0.0f) {
+        m_kiwiSdrSquelchPinnedDisplayNorm = std::clamp(
+            (m_refLevel - m_kiwiSdrSquelchPinnedThresholdDbm)
+                / m_dynamicRange,
+            0.0f, 1.0f);
+        m_kiwiSdrSquelchPinnedDisplayNormValid = true;
+    } else {
+        m_kiwiSdrSquelchPinnedDisplayNorm = -1.0f;
+        m_kiwiSdrSquelchPinnedDisplayNormValid = false;
+    }
+}
+
 void SpectrumWidget::clearDbmReleaseRebase()
 {
     m_holdFftUpdatesAfterDbmRelease = 0;
@@ -2112,24 +2213,145 @@ void SpectrumWidget::setWfLineDuration(int ms) {
 
 void SpectrumWidget::setSquelchLine(bool visible, int level)
 {
-    m_squelchLineVisible = visible;
-    m_squelchLevel       = level;
+    m_flexSquelchLineVisible = visible;
+    m_flexSquelchLevel = std::clamp(level, 0, 100);
     markOverlayDirty();
     // Manual SQL: 3 s auto-hide; each slider adjustment restarts the timer.
     // Auto SQL: line stays pinned to the tracked floor level — no timer.
     if (m_squelchLineHideTimer) {
-        if (visible && !m_autoSquelchEnabled) {
+        if (visible && !m_autoSquelchEnabled && !m_kiwiSdrWaterfallActive) {
             m_squelchLineHideTimer->start();
-        } else {
+        } else if (!m_kiwiSdrWaterfallActive) {
             m_squelchLineHideTimer->stop();
         }
     }
 }
 
+void SpectrumWidget::setKiwiSdrSquelchMeterDbm(float dbm, bool squelched)
+{
+    if (!std::isfinite(dbm)) {
+        return;
+    }
+
+    const float clamped = std::clamp(dbm, -127.0f, 3.4f);
+    constexpr int kServerRssiMedianSamples = 65;
+    const bool shouldSample =
+        m_kiwiSdrSquelchMeterSamples.size() < kServerRssiMedianSamples
+        || squelched
+        || !m_kiwiSdrSquelchLineVisible
+        || m_kiwiSdrSquelchLineFloorRelative;
+    if (shouldSample) {
+        m_kiwiSdrSquelchMeterSamples.append(clamped);
+        while (m_kiwiSdrSquelchMeterSamples.size()
+               > kServerRssiMedianSamples) {
+            m_kiwiSdrSquelchMeterSamples.removeFirst();
+        }
+    }
+
+    if (m_kiwiSdrSquelchMeterSamples.isEmpty()) {
+        return;
+    }
+
+    QVector<float> sorted = m_kiwiSdrSquelchMeterSamples;
+    const int middle = sorted.size() / 2;
+    std::nth_element(sorted.begin(), sorted.begin() + middle, sorted.end());
+    const float floorDbm = sorted[middle];
+    m_kiwiSdrSquelchMeterFloorValid = true;
+    if (m_kiwiSdrSquelchLiveFloorDbm <= -500.0f) {
+        m_kiwiSdrSquelchLiveFloorDbm = floorDbm;
+    } else {
+        const float delta = floorDbm - m_kiwiSdrSquelchLiveFloorDbm;
+        if (std::abs(delta) >= 0.10f) {
+            const float alpha = delta > 0.0f ? 0.06f : 0.18f;
+            m_kiwiSdrSquelchLiveFloorDbm =
+                (1.0f - alpha) * m_kiwiSdrSquelchLiveFloorDbm
+                + alpha * floorDbm;
+        }
+    }
+
+    if (!m_kiwiSdrSquelchLineVisible) {
+        return;
+    }
+    if (m_kiwiSdrSquelchLineFloorRelative) {
+        markOverlayDirty();
+    } else if (!m_kiwiSdrSquelchPinnedThresholdValid
+               || !m_kiwiSdrSquelchPinnedDisplayNormValid) {
+        pinKiwiSdrManualSquelchLine();
+        markOverlayDirty();
+    }
+}
+
+void SpectrumWidget::setKiwiSdrSquelchLine(bool visible, int marginDb,
+                                           bool floorRelative)
+{
+    const bool wasVisible = m_kiwiSdrSquelchLineVisible;
+    const int previousLevel = m_kiwiSdrSquelchLevel;
+    const bool wasFloorRelative = m_kiwiSdrSquelchLineFloorRelative;
+    const int clampedLevel = std::clamp(
+        marginDb, KiwiSdrProtocol::kSquelchServerMinMarginDb,
+        KiwiSdrProtocol::kSquelchServerMaxMarginDb);
+    m_kiwiSdrSquelchLevel = clampedLevel;
+    m_kiwiSdrSquelchLineVisible =
+        visible && m_kiwiSdrSquelchLevel != KiwiSdrProtocol::kSquelchOffLevel;
+    m_kiwiSdrSquelchLineFloorRelative = floorRelative;
+    const bool shouldPin =
+        m_kiwiSdrSquelchLineVisible
+        && !floorRelative
+        && (!wasVisible || wasFloorRelative || previousLevel != clampedLevel
+            || !m_kiwiSdrSquelchPinnedThresholdValid);
+    if (shouldPin) {
+        pinKiwiSdrManualSquelchLine();
+    } else if (!m_kiwiSdrSquelchLineVisible) {
+        m_kiwiSdrSquelchPinnedFloorDbm = -999.0f;
+        m_kiwiSdrSquelchPinnedFloorValid = false;
+        m_kiwiSdrSquelchPinnedThresholdDbm = -999.0f;
+        m_kiwiSdrSquelchPinnedThresholdValid = false;
+        m_kiwiSdrSquelchPinnedDisplayNorm = -1.0f;
+        m_kiwiSdrSquelchPinnedDisplayNormValid = false;
+    }
+    m_flexSquelchLineVisible = false;
+    m_flexSquelchLevel = 0;
+    markOverlayDirty();
+    if (m_squelchLineHideTimer) {
+        m_squelchLineHideTimer->stop();
+    }
+}
+
+void SpectrumWidget::clearKiwiSdrSquelchLine()
+{
+    if (!m_kiwiSdrSquelchLineVisible && m_kiwiSdrSquelchLevel == 0
+        && m_sqlNoiseFloorDbm <= -500.0f
+        && m_kiwiSdrSquelchLiveFloorDbm <= -500.0f) {
+        return;
+    }
+    m_kiwiSdrSquelchLineVisible = false;
+    m_kiwiSdrSquelchLevel = 0;
+    m_kiwiSdrSquelchLineFloorRelative = false;
+    m_sqlNoiseFloorDbm = -999.0f;
+    m_kiwiSdrSquelchLiveFloorDbm = -999.0f;
+    m_kiwiSdrSquelchPinnedFloorDbm = -999.0f;
+    m_kiwiSdrSquelchPinnedFloorValid = false;
+    m_kiwiSdrSquelchPinnedThresholdDbm = -999.0f;
+    m_kiwiSdrSquelchPinnedThresholdValid = false;
+    m_kiwiSdrSquelchPinnedDisplayNorm = -1.0f;
+    m_kiwiSdrSquelchPinnedDisplayNormValid = false;
+    m_kiwiSdrSquelchMeterFloorValid = false;
+    m_kiwiSdrSquelchMeterSamples.clear();
+    markOverlayDirty();
+    if (m_squelchLineHideTimer) {
+        m_squelchLineHideTimer->stop();
+    }
+}
+
 void SpectrumWidget::drawAutoSqlFloor(QPainter& p, const QRect& specRect)
 {
-    if (!m_autoSquelchEnabled || m_sqlNoiseFloorDbm <= -500.0f) { return; }
-    const float norm = (m_refLevel - m_sqlNoiseFloorDbm) / m_dynamicRange;
+    const bool useKiwiFloor =
+        m_kiwiSdrWaterfallActive || m_kiwiSdrSquelchLineFloorRelative;
+    const float floorDbm = useKiwiFloor
+        ? m_kiwiSdrSquelchLiveFloorDbm
+        : m_sqlNoiseFloorDbm;
+    if (!m_autoSquelchEnabled || floorDbm <= -500.0f) { return; }
+    const float norm = (m_refLevel - floorDbm) / m_dynamicRange;
     const int y = specRect.top()
         + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
     p.setPen(QPen(AetherSDR::theme::withAlpha("color.accent.warning", 200), 1, Qt::DashLine));
@@ -2139,15 +2361,76 @@ void SpectrumWidget::drawAutoSqlFloor(QPainter& p, const QRect& specRect)
     f.setBold(true);
     p.setFont(f);
     p.setPen(AetherSDR::theme::withAlpha("color.accent.warning", 200));
-    const QString lbl = QString("Floor %1 dBm").arg(static_cast<int>(m_sqlNoiseFloorDbm));
+    const QString lbl = QString("Floor %1 dBm").arg(static_cast<int>(floorDbm));
     p.drawText(specRect.right() - p.fontMetrics().horizontalAdvance(lbl) - 4, y - 2, lbl);
+}
+
+void SpectrumWidget::drawSquelchLine(QPainter& p, const QRect& specRect)
+{
+    constexpr float kSqlMinDbm = -160.0f;
+    float squelchDbm = 0.0f;
+    float pinnedDisplayNorm = 0.0f;
+    bool usePinnedDisplayNorm = false;
+    QString label;
+    if (m_kiwiSdrSquelchLineVisible) {
+        if (m_kiwiSdrSquelchLevel == KiwiSdrProtocol::kSquelchOffLevel) {
+            return;
+        }
+        if (m_kiwiSdrSquelchLineFloorRelative) {
+            const float floorDbm = m_kiwiSdrSquelchLiveFloorDbm;
+            if (floorDbm <= -500.0f) {
+                return;
+            }
+            squelchDbm = floorDbm + static_cast<float>(m_kiwiSdrSquelchLevel);
+        } else {
+            if (!m_kiwiSdrSquelchPinnedThresholdValid
+                || m_kiwiSdrSquelchPinnedThresholdDbm <= -500.0f) {
+                return;
+            }
+            squelchDbm = m_kiwiSdrSquelchPinnedThresholdDbm;
+            if (m_kiwiSdrSquelchPinnedDisplayNormValid) {
+                pinnedDisplayNorm = m_kiwiSdrSquelchPinnedDisplayNorm;
+                usePinnedDisplayNorm = true;
+            }
+        }
+        label = QStringLiteral("SQL %1%2 dB")
+            .arg(m_kiwiSdrSquelchLevel > 0 ? QStringLiteral("+")
+                                            : QString())
+            .arg(m_kiwiSdrSquelchLevel);
+    } else {
+        if (!m_flexSquelchLineVisible || m_flexSquelchLevel <= 0) {
+            return;
+        }
+        squelchDbm = kSqlMinDbm + static_cast<float>(m_flexSquelchLevel);
+        label = QStringLiteral("SQL %1").arg(m_flexSquelchLevel);
+    }
+
+    const float norm = usePinnedDisplayNorm
+        ? pinnedDisplayNorm
+        : (m_refLevel - squelchDbm) / m_dynamicRange;
+    const int y = specRect.top()
+        + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
+    p.setPen(QPen(AetherSDR::theme::withAlpha("color.accent.warning", 220), 1));
+    p.drawLine(specRect.left(), y, specRect.right(), y);
+    QFont f = p.font();
+    f.setPointSize(8);
+    f.setBold(true);
+    p.setFont(f);
+    p.setPen(AetherSDR::theme::withAlpha("color.accent.warning", 220));
+    p.drawText(4, y - 2, label);
 }
 
 void SpectrumWidget::setAutoSquelchEnable(bool on)
 {
-    m_autoSquelchEnabled   = on;
-    m_sqlNoiseFloorDbm     = -999.0f;  // cold-start the floor EWMA on each enable
-    m_lastAutoSquelchLevel = -1;
+    if (m_autoSquelchEnabled == on) {
+        return;
+    }
+
+    m_autoSquelchEnabled = on;
+    if (on) {
+        m_sqlNoiseFloorDbm = -999.0f;  // cold-start the floor EWMA on enable
+        m_lastAutoSquelchLevel = -1;
+    }
     if (on && m_squelchLineHideTimer) {
         // Auto pins the line — cancel any pending manual auto-hide.
         m_squelchLineHideTimer->stop();
@@ -2158,6 +2441,62 @@ void SpectrumWidget::setAutoSqlMarginDb(int dBm)
 {
     m_autoSqlMarginDb      = std::clamp(dBm, 5, 20);
     m_lastAutoSquelchLevel = -1;  // force re-emit with new margin
+}
+
+void SpectrumWidget::updateAutoSquelchFromBins(const QVector<float>& binsDbm)
+{
+    if (!m_autoSquelchEnabled || m_transmitting || binsDbm.isEmpty()) {
+        return;
+    }
+
+    if (m_kiwiSdrWaterfallActive || m_kiwiSdrSquelchLineFloorRelative) {
+        // Kiwi non-NBFM squelch is server-relative:
+        // SET squelch=N opens at median RSSI + N dB. Do not apply the Flex
+        // absolute dBm conversion here.
+        const int level = m_autoSqlMarginDb;
+        if (level != m_lastAutoSquelchLevel) {
+            m_lastAutoSquelchLevel = level;
+            emit autoSquelchLevelSuggested(level);
+        }
+        return;
+    }
+
+    float sum1 = 0.0f;
+    int cnt1 = 0;
+    for (int j = 0; j < binsDbm.size(); j += 4) {
+        sum1 += binsDbm[j];
+        ++cnt1;
+    }
+    if (cnt1 <= 0) {
+        return;
+    }
+    const float mean1 = sum1 / static_cast<float>(cnt1);
+
+    float sum2 = 0.0f;
+    int cnt2 = 0;
+    for (int j = 0; j < binsDbm.size(); j += 4) {
+        if (binsDbm[j] <= mean1) {
+            sum2 += binsDbm[j];
+            ++cnt2;
+        }
+    }
+    const float frameFloor =
+        (cnt2 > 0) ? sum2 / static_cast<float>(cnt2) : mean1;
+    m_sqlNoiseFloorDbm =
+        (m_sqlNoiseFloorDbm <= -500.0f)
+            ? frameFloor
+            : 0.1f * frameFloor + 0.9f * m_sqlNoiseFloorDbm;
+
+    constexpr float kSqlMinDbm = -160.0f;
+    const float targetDbm =
+        m_sqlNoiseFloorDbm + static_cast<float>(m_autoSqlMarginDb);
+    const int level = std::clamp(
+        static_cast<int>(targetDbm - kSqlMinDbm + 0.5f), 1, 100);
+    if (level != m_lastAutoSquelchLevel) {
+        m_lastAutoSquelchLevel = level;
+        emit autoSquelchLevelSuggested(level);
+    }
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setWfColorScheme(int scheme) {
@@ -4161,39 +4500,8 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         }
     }
 
-    // ── Auto-squelch: own two-pass trimmed-mean noise floor ───────────────
-    // Independent copy of the floor measurement — not borrowed from the
-    // display pipeline so it survives any future refactor of the other block.
-    // Two-pass trimmed mean: pass 1 gets the overall mean; pass 2 averages
-    // only bins at-or-below that mean, excluding signal peaks.
-    // EWMA (α=0.1, ~10-frame window at 25 fps) smooths frame-to-frame variation.
-    // kSqlMinDbm: FLEX-8600 maps squelch_level 0-100 → -160 to -60 dBm.
-    // Empirically verified on fw 4.1.5; not explicitly documented in FlexLib.
-    if (m_autoSquelchEnabled && !m_transmitting && !binsDbm.isEmpty()) {
-        // Pass 1 — overall mean
-        float sum1 = 0.0f; int cnt1 = 0;
-        for (int j = 0; j < binsDbm.size(); j += 4) { sum1 += binsDbm[j]; ++cnt1; }
-        const float mean1 = sum1 / cnt1;
-        // Pass 2 — noise-only bins (≤ mean)
-        float sum2 = 0.0f; int cnt2 = 0;
-        for (int j = 0; j < binsDbm.size(); j += 4) {
-            if (binsDbm[j] <= mean1) { sum2 += binsDbm[j]; ++cnt2; }
-        }
-        const float frameFloor = (cnt2 > 0) ? sum2 / cnt2 : mean1;
-        // EWMA with α=0.1
-        m_sqlNoiseFloorDbm = (m_sqlNoiseFloorDbm <= -500.0f)
-            ? frameFloor
-            : 0.1f * frameFloor + 0.9f * m_sqlNoiseFloorDbm;
-
-        constexpr float kSqlMinDbm = -160.0f;
-        const float targetDbm = m_sqlNoiseFloorDbm + static_cast<float>(m_autoSqlMarginDb);
-        const int level = std::clamp(
-            static_cast<int>(targetDbm - kSqlMinDbm + 0.5f), 1, 100);
-        if (level != m_lastAutoSquelchLevel) {
-            m_lastAutoSquelchLevel = level;
-            emit autoSquelchLevelSuggested(level);
-        }
-        markOverlayDirty();
+    if (!m_kiwiSdrWaterfallActive) {
+        updateAutoSquelchFromBins(*spectrumBins);
     }
 
     // Native VITA waterfall tiles are the primary RX source. If they stop
@@ -4446,6 +4754,10 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
 
     saveCurrentWaterfallStreamState();
     m_kiwiSdrWaterfallActive = active;
+    m_lastAutoSquelchLevel = -1;
+    if (!active) {
+        m_sqlNoiseFloorDbm = -999.0f;
+    }
     restoreCurrentWaterfallStreamState();
     // The newly-active stream is no longer reprojected on every pan step
     // (handleWaterfallFrequencyFrameChange now touches only the active stream),
@@ -4455,6 +4767,7 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
     // inactive stream used to receive.
     rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
     if (!active) {
+        clearKiwiSdrSquelchLine();
         m_pendingDbmRangeEcho = false;
         m_pendingDbmRangeEchoFromAutoFloor = false;
         m_pendingDbmRangeEchoStartMs = 0;
@@ -4627,12 +4940,22 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             }
         }
         if (!m_kiwiSdrFftTrace.isEmpty()) {
+            const float previousMeasuredNoiseFloorDbm = m_measuredNoiseFloorDbm;
             const float frameFloor = estimateNoiseFloorDbm(m_kiwiSdrFftTrace);
+            const float visualFloor =
+                estimateKiwiSdrVisualNoiseFloorDbm(m_kiwiSdrFftTrace);
+            updateKiwiSdrSquelchVisualFloor(visualFloor);
             constexpr float kAlpha = 0.05f;
             m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
                 ? frameFloor
                 : m_measuredNoiseFloorDbm * (1.0f - kAlpha)
                     + frameFloor * kAlpha;
+            if (m_kiwiSdrSquelchLineVisible
+                && (previousMeasuredNoiseFloorDbm <= -500.0f
+                    || std::abs(previousMeasuredNoiseFloorDbm
+                                - m_measuredNoiseFloorDbm) > 0.25f)) {
+                markOverlayDirty();
+            }
 
             const bool useFreshLockFrame = m_noiseFloorFreshFrameCount > 0;
             const bool noiseFloorFrameConsumed =
@@ -4640,6 +4963,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             if (useFreshLockFrame && noiseFloorFrameConsumed) {
                 --m_noiseFloorFreshFrameCount;
             }
+            updateAutoSquelchFromBins(m_kiwiSdrFftTrace);
         }
     }
     pushKiwiSdrWaterfallRow(smoothedBins, destWidth,
@@ -6498,9 +6822,8 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
 
 QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
 {
-    // Kiwi W/F bytes are display/bin intensity values, not calibrated dBm.
-    // They are mapped into a Kiwi-only pseudo-dB display range so the
-    // existing waterfall color machinery can be reused without touching Flex.
+    // Kiwi direct W/F bytes are decoded to the server's wrapped negative dB
+    // scale; color aperture is still Kiwi-only and independent of Flex.
     const float floorDbm = m_kiwiSdrAutoRangeValid
         ? m_kiwiSdrAutoFloorDbm
         : kKiwiSdrWaterfallMinDbm;
@@ -7236,27 +7559,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
             drawAutoSqlFloor(p, specRect);
 
-            // ── Squelch threshold line (solid yellow) ────────────────────
-            // Drawn at the radio's actual gate position using the fixed absolute
-            // dBm scale: dBm = -160 + squelch_level. Empirically verified on
-            // FLEX-8600 fw 4.1.5; independent of refLevel/dynamicRange so the
-            // line stays correct regardless of zoom or display range changes.
-            if (m_squelchLineVisible && m_squelchLevel > 0) {
-                constexpr float kSqlMinDbm = -160.0f;
-                const float squelchDbm = kSqlMinDbm + static_cast<float>(m_squelchLevel);
-                const float norm = (m_refLevel - squelchDbm) / m_dynamicRange;
-                const int sy = specRect.top()
-                    + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
-                p.setPen(QPen(AetherSDR::theme::withAlpha("color.accent.warning", 220), 1));
-                p.drawLine(specRect.left(), sy, specRect.right(), sy);
-                QFont f = p.font();
-                f.setPointSize(8);
-                f.setBold(true);
-                p.setFont(f);
-                p.setPen(AetherSDR::theme::withAlpha("color.accent.warning", 220));
-                const QString lbl = QString("SQL %1").arg(m_squelchLevel);
-                p.drawText(4, sy - 2, lbl);
-            }
+            drawSquelchLine(p, specRect);
 
             // WNB / RF gain / Prop forecast indicators (top-right of spectrum)
             {
@@ -8064,19 +8367,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
         drawAutoSqlFloor(p, specRect);
 
-        // ── Squelch threshold line (solid yellow) ────────────────────
-        if (m_squelchLineVisible && m_squelchLevel > 0) {
-            constexpr float kSqlMinDbm = -160.0f;
-            const float squelchDbm = kSqlMinDbm + static_cast<float>(m_squelchLevel);
-            const float norm = (m_refLevel - squelchDbm) / m_dynamicRange;
-            const int sy = specRect.top()
-                + static_cast<int>(std::clamp(norm, 0.0f, 1.0f) * specRect.height());
-            p.setPen(QPen(AetherSDR::theme::withAlpha("color.accent.warning", 220), 1));
-            p.drawLine(specRect.left(), sy, specRect.right(), sy);
-            QFont f = p.font(); f.setPointSize(8); f.setBold(true); p.setFont(f);
-            p.setPen(AetherSDR::theme::withAlpha("color.accent.warning", 220));
-            p.drawText(4, sy - 2, QString("SQL %1").arg(m_squelchLevel));
-        }
+        drawSquelchLine(p, specRect);
 
         drawConnectionAnimation(p, specRect);
         drawKiwiSdrConnectionOverlay(

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -140,10 +140,15 @@ public:
     // Reflects the current band, antenna and preamp — no hardcoded dBm value.
     float noiseFloorDbm() const { return m_measuredNoiseFloorDbm; }
 
-    // Squelch threshold overlay line.  level is the radio squelch_level (0-100),
-    // mapped to absolute dBm via the radio's fixed scale: dBm = -160 + level.
-    // (Empirically verified on FLEX-8600 fw 4.1.5 — not in FlexLib docs.)
+    // Flex squelch threshold overlay line. level is the radio squelch_level
+    // (0-100), mapped to absolute dBm via the radio's fixed scale:
+    // dBm = -160 + level. (Empirically verified on FLEX-8600 fw 4.1.5.)
     void setSquelchLine(bool visible, int level);
+    // KiwiSDR SQL is a dB margin above Kiwi's median noise-floor estimate.
+    // marginDb is the server margin, not the UI slider value.
+    void setKiwiSdrSquelchLine(bool visible, int marginDb, bool floorRelative);
+    void setKiwiSdrSquelchMeterDbm(float dbm, bool squelched);
+    void clearKiwiSdrSquelchLine();
 
     // When enabled, measures the noise floor on every FFT frame using a
     // two-pass trimmed mean (pass 1: overall mean; pass 2: mean of bins
@@ -583,6 +588,8 @@ private:
     void drawSpotMarkers(QPainter& p, const QRect& specRect);
     void drawSwrSweep(QPainter& p, const QRect& specRect);
     void drawAutoSqlFloor(QPainter& p, const QRect& specRect);
+    void drawSquelchLine(QPainter& p, const QRect& specRect);
+    void updateAutoSquelchFromBins(const QVector<float>& binsDbm);
     QRect leftOccludedRect() const;
     void showSpotClusterPopup(const SpotCluster& cluster, const QPoint& globalPos);
     const TnfMarker* tnfMarkerById(int id) const;
@@ -690,6 +697,9 @@ private:
     // quickly, rises slowly), with a candidate-state transient filter
     // so brief upward spikes (lightning crashes) don't pull the lock.
     bool updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline);
+    float estimateKiwiSdrVisualNoiseFloorDbm(const QVector<float>& bins) const;
+    void updateKiwiSdrSquelchVisualFloor(float floorDbm);
+    void pinKiwiSdrManualSquelchLine();
     // Adjust m_refLevel toward the target so the smoothed noise floor
     // sits at m_noiseFloorPosition.  Pans the dB range (keeps span
     // fixed) rather than zooming it (existing zoom-when-floor-moves
@@ -828,9 +838,22 @@ private:
     // Percentile EWMA used for the amber floor overlay line and auto-squelch.
     // Tracked separately from m_measuredNoiseFloorDbm (two-pass trimmed mean)
     // so the auto-adjust display feature and auto-squelch are independent.
-    // Squelch threshold overlay line
-    bool  m_squelchLineVisible{false};
-    int   m_squelchLevel{0};             // 0-100 radio squelch_level units
+    // Squelch threshold overlay lines. Flex and KiwiSDR keep independent
+    // state because they can be controlled from different receive surfaces.
+    bool  m_flexSquelchLineVisible{false};
+    int   m_flexSquelchLevel{0};
+    bool  m_kiwiSdrSquelchLineVisible{false};
+    int   m_kiwiSdrSquelchLevel{0};
+    bool  m_kiwiSdrSquelchLineFloorRelative{false};
+    float m_kiwiSdrSquelchLiveFloorDbm{-999.0f};
+    float m_kiwiSdrSquelchPinnedFloorDbm{-999.0f};
+    bool  m_kiwiSdrSquelchPinnedFloorValid{false};
+    float m_kiwiSdrSquelchPinnedThresholdDbm{-999.0f};
+    bool  m_kiwiSdrSquelchPinnedThresholdValid{false};
+    float m_kiwiSdrSquelchPinnedDisplayNorm{-1.0f};
+    bool  m_kiwiSdrSquelchPinnedDisplayNormValid{false};
+    bool  m_kiwiSdrSquelchMeterFloorValid{false};
+    QVector<float> m_kiwiSdrSquelchMeterSamples;
     QTimer* m_squelchLineHideTimer{nullptr}; // auto-hides yellow line 3 s after enable/adjust (manual SQL only)
     bool  m_autoSquelchEnabled{false};
     float m_sqlNoiseFloorDbm{-999.0f};  // auto-squelch own two-pass trimmed-mean EWMA

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -7,6 +7,7 @@
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
 #include "core/KiwiSdrManager.h"
+#include "core/KiwiSdrProtocol.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -1104,26 +1105,39 @@ void VfoWidget::buildTabContent()
         // MainWindow), delegate the 3-way mode cycle to RxApplet so both
         // UIs share Off / Manual / Auto state.  Standalone fallback
         // (no RxApplet — e.g. tests) keeps the original 2-state toggle.
-        // We turn off Qt's built-in checkable behavior in setRxApplet
-        // so the click handler can drive the cycle explicitly.
+        // syncSqlVisuals turns off Qt's built-in checkable behavior while
+        // this VFO mirrors the side RX applet, so this handler can drive the
+        // cycle explicitly.
         connect(m_sqlBtn, &QPushButton::clicked, this, [this]() {
-            if (m_rxApplet) {
+            if (m_rxApplet && m_slice && !m_slice->isActive()) {
+                emit sliceActivationRequested(m_slice->sliceId());
+            }
+            if (mirrorsRxAppletSql()) {
                 m_rxApplet->cycleSqlModeExternal();
+            } else if (m_slice && m_slice->externalReceiveReplacementActive()) {
+                cycleStandaloneSqlMode();
             } else if (!m_updatingFromModel && m_slice) {
                 m_slice->setSquelch(m_sqlBtn->isChecked(),
-                                    m_sqlSlider->value());
+                                    clampManualSqlLevel(m_sqlSlider->value()));
             }
         });
         connect(m_sqlSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_sqlValueLbl) m_sqlValueLbl->setText(QString::number(v));
             if (m_updatingFromModel) return;
-            if (m_rxApplet) {
+            if (m_rxApplet && m_slice && !m_slice->isActive()) {
+                emit sliceActivationRequested(m_slice->sliceId());
+            }
+            if (mirrorsRxAppletSql()) {
                 // Routes through RxApplet's Manual/Auto branching so the
                 // manual cache, AppSettings persistence, and spectrum-side
                 // margin broadcast all happen exactly once and in one place.
                 m_rxApplet->setSqlSliderValueExternal(v);
+            } else if (m_slice && m_slice->externalReceiveReplacementActive()
+                       && standaloneSqlMode() == LocalSqlMode::Auto) {
+                setAutoSqlMarginDb(v);
             } else if (m_slice) {
-                m_slice->setSquelch(m_sqlBtn->isChecked(), v);
+                m_slice->setSquelch(m_sqlBtn->isChecked(),
+                                    clampManualSqlLevel(v));
             }
         });
         connect(m_agcCmb, &QComboBox::currentTextChanged, this, [this](const QString& text) {
@@ -1138,10 +1152,10 @@ void VfoWidget::buildTabContent()
         });
         connect(m_agcTSlider, &QSlider::valueChanged, this, [this](int v) {
             if (m_agcValueLbl) m_agcValueLbl->setText(QString::number(v));
-            const bool agcOff = m_slice && (m_slice->agcMode() == "off");
+            const bool agcOff = m_slice && (m_slice->receiveAgcMode() == "off");
             m_agcTSlider->setToolTip(agcOff
-                ? QString("AGC Off Level: %1").arg(v)
-                : QString("AGC Threshold: %1").arg(v));
+                ? QString("AGC Off Level: %1 dB").arg(v)
+                : QString("AGC Threshold: %1 dB").arg(v));
             if (!m_updatingFromModel && m_slice) {
                 if (agcOff) m_slice->setAgcOffLevel(v);
                 else m_slice->setAgcThreshold(v);
@@ -2937,6 +2951,13 @@ void VfoWidget::setSlice(SliceModel* slice)
         int idx = m_modeCombo->findText(cur);
         if (idx >= 0) m_modeCombo->setCurrentIndex(idx);
     }
+    connect(m_slice, &SliceModel::activeChanged, this, [this](bool) {
+        syncSqlVisuals();
+    });
+    connect(m_slice, &SliceModel::externalReceiveAutoSquelchChanged,
+            this, [this](bool) {
+        syncSqlVisuals();
+    });
     // Mode
     connect(m_slice, &SliceModel::modeChanged, this, [this](const QString& mode) {
         m_tabBtns[2]->setText(mode);  // update mode tab label
@@ -2979,18 +3000,19 @@ void VfoWidget::setSlice(SliceModel* slice)
             // (#2504). CW/CWL squelch is radio-managed — no client push, so no
             // "save" either, or the unpaired flag would fabricate a restore on
             // the next mode change (#3263).
-            if (m_slice->squelchOn() && (isDig || isRtty)) {
+            if (m_slice->receiveSquelchOn() && (isDig || isRtty)) {
                 m_savedSquelchOn = true;
-                m_slice->setSquelch(false, m_slice->squelchLevel());
+                m_slice->setSquelch(false, m_slice->receiveSquelchLevel());
                 QSignalBlocker sb(m_sqlBtn);
                 m_sqlBtn->setChecked(false);
             }
         } else if (!sqlDisabled && m_slice && m_savedSquelchOn) {
             m_savedSquelchOn = false;
-            m_slice->setSquelch(true, m_slice->squelchLevel());
+            m_slice->setSquelch(true, m_slice->receiveSquelchLevel());
             QSignalBlocker sb(m_sqlBtn);
             m_sqlBtn->setChecked(true);
         }
+        syncSqlVisuals();
         m_apfBtn->setVisible(isCw);
         m_anfBtn->setVisible(isVoice);
         m_anflBtn->setVisible(isVoice);
@@ -3140,9 +3162,9 @@ void VfoWidget::setSlice(SliceModel* slice)
     // suggested level), so skip the value update when m_sqlMode is Auto.
     // The 3-way button visuals are driven separately via syncSqlVisuals
     // on sqlModeChanged — we don't need to touch the button here.
-    connect(m_slice, &SliceModel::squelchChanged, this, [this](bool on, int level) {
+    auto updateSquelchUi = [this](bool on, int level) {
         m_updatingFromModel = true;
-        if (m_rxApplet) {
+        if (mirrorsRxAppletSql()) {
             const bool inAuto =
                 (m_rxApplet->sqlMode() == RxApplet::SqlMode::Auto);
             if (!inAuto)
@@ -3150,32 +3172,69 @@ void VfoWidget::setSlice(SliceModel* slice)
         } else {
             if (m_sqlBtn->isEnabled())
                 m_sqlBtn->setChecked(on);
-            m_sqlSlider->setValue(level);
+            if (!(m_slice && m_slice->externalReceiveReplacementActive()
+                  && standaloneSqlMode() == LocalSqlMode::Auto)) {
+                m_sqlSlider->setValue(level);
+            }
         }
         m_updatingFromModel = false;
+        syncSqlVisuals();
+    };
+    connect(m_slice, &SliceModel::squelchChanged, this, [this, updateSquelchUi](bool on, int level) {
+        if (m_slice && m_slice->externalReceiveReplacementActive()) {
+            return;
+        }
+        updateSquelchUi(on, level);
+    });
+    connect(m_slice, &SliceModel::externalReceiveSquelchChanged,
+            this, [this, updateSquelchUi](bool on, int level) {
+        if (!m_slice || !m_slice->externalReceiveReplacementActive()) {
+            return;
+        }
+        updateSquelchUi(on, level);
     });
     // AGC
-    connect(m_slice, &SliceModel::agcModeChanged, this, [this](const QString& mode) {
+    auto updateAgcModeUi = [this](const QString& mode) {
+        Q_UNUSED(mode);
         m_updatingFromModel = true;
         QSignalBlocker sb(m_agcCmb);
         // Map protocol value to display text
-        if (mode == "off") m_agcCmb->setCurrentText("Off");
-        else if (mode == "slow") m_agcCmb->setCurrentText("Slow");
-        else if (mode == "med") m_agcCmb->setCurrentText("Med");
-        else if (mode == "fast") m_agcCmb->setCurrentText("Fast");
+        const QString receiveMode =
+            m_slice ? m_slice->receiveAgcMode() : QString();
+        if (receiveMode == "off") m_agcCmb->setCurrentText("Off");
+        else if (receiveMode == "slow") m_agcCmb->setCurrentText("Slow");
+        else if (receiveMode == "med") m_agcCmb->setCurrentText("Med");
+        else if (receiveMode == "fast") m_agcCmb->setCurrentText("Fast");
         updateAgcSliderFromSlice();
         m_updatingFromModel = false;
-    });
+    };
+    connect(m_slice, &SliceModel::agcModeChanged, this, updateAgcModeUi);
+    connect(m_slice, &SliceModel::externalReceiveAgcModeChanged,
+            this, updateAgcModeUi);
     connect(m_slice, &SliceModel::agcThresholdChanged, this, [this](int v) {
         Q_UNUSED(v);
         m_updatingFromModel = true;
-        if (m_slice && m_slice->agcMode() != "off") updateAgcSliderFromSlice();
+        if (m_slice && m_slice->receiveAgcMode() != "off") updateAgcSliderFromSlice();
+        m_updatingFromModel = false;
+    });
+    connect(m_slice, &SliceModel::externalReceiveAgcThresholdChanged,
+            this, [this](int v) {
+        Q_UNUSED(v);
+        m_updatingFromModel = true;
+        if (m_slice && m_slice->receiveAgcMode() != "off") updateAgcSliderFromSlice();
         m_updatingFromModel = false;
     });
     connect(m_slice, &SliceModel::agcOffLevelChanged, this, [this](int v) {
         Q_UNUSED(v);
         m_updatingFromModel = true;
-        if (m_slice && m_slice->agcMode() == "off") updateAgcSliderFromSlice();
+        if (m_slice && m_slice->receiveAgcMode() == "off") updateAgcSliderFromSlice();
+        m_updatingFromModel = false;
+    });
+    connect(m_slice, &SliceModel::externalReceiveAgcOffLevelChanged,
+            this, [this](int v) {
+        Q_UNUSED(v);
+        m_updatingFromModel = true;
+        if (m_slice && m_slice->receiveAgcMode() == "off") updateAgcSliderFromSlice();
         m_updatingFromModel = false;
     });
     // RIT/XIT
@@ -3422,14 +3481,10 @@ void VfoWidget::syncFromSlice()
         m_tabBtns[0]->setText(muted ? QString::fromUtf8("\xF0\x9F\x94\x87")
                                     : QString::fromUtf8("\xF0\x9F\x94\x8A"));
     }
-    {
-        QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
-        m_sqlBtn->setChecked(m_slice->squelchOn());
-        m_sqlSlider->setValue(m_slice->squelchLevel());
-    }
+    syncSqlVisuals();
     {
         QSignalBlocker sb(m_agcCmb);
-        const QString& mode = m_slice->agcMode();
+        const QString mode = m_slice->receiveAgcMode();
         if (mode == "off") m_agcCmb->setCurrentText("Off");
         else if (mode == "slow") m_agcCmb->setCurrentText("Slow");
         else if (mode == "med") m_agcCmb->setCurrentText("Med");
@@ -3843,14 +3898,20 @@ void VfoWidget::updateAgcSliderFromSlice()
 {
     if (!m_slice || !m_agcTSlider || !m_agcValueLbl) return;
 
-    const bool agcOff = (m_slice->agcMode() == "off");
-    const int value = agcOff ? m_slice->agcOffLevel() : m_slice->agcThreshold();
+    const bool agcOff = (m_slice->receiveAgcMode() == "off");
+    const int minimum = agcOff ? 0 : agcThresholdMinimum();
+    const int maximum = agcOff ? 100 : agcThresholdMaximum();
+    const int value = std::clamp(
+        agcOff ? m_slice->receiveAgcOffLevel()
+               : m_slice->receiveAgcThreshold(),
+        minimum, maximum);
 
     QSignalBlocker blocker(m_agcTSlider);
+    m_agcTSlider->setRange(minimum, maximum);
     m_agcTSlider->setValue(value);
     m_agcTSlider->setToolTip(agcOff
-        ? QString("AGC Off Level: %1").arg(value)
-        : QString("AGC Threshold: %1").arg(value));
+        ? QString("AGC Off Level: %1 dB").arg(value)
+        : QString("AGC Threshold: %1 dB").arg(value));
     m_agcTSlider->setAccessibleName(agcOff ? "AGC off level" : "AGC threshold");
     m_agcValueLbl->setText(QString::number(value));
 }
@@ -4209,13 +4270,6 @@ void VfoWidget::setRxApplet(RxApplet* rx)
     m_rxApplet = rx;
     if (!rx) return;
 
-    // Take the SQL button out of Qt's built-in checkable behavior — the
-    // 3-way cycle is driven by clicked()'s explicit call to RxApplet.
-    if (m_sqlBtn) {
-        m_sqlBtn->setCheckable(false);
-        m_sqlBtn->setChecked(false);
-    }
-
     // Refresh visuals whenever the RxApplet's mode changes, and once now
     // so the freshly-wired widget shows the current shared state.
     connect(rx, &RxApplet::sqlModeChanged, this, [this](int) {
@@ -4225,6 +4279,7 @@ void VfoWidget::setRxApplet(RxApplet* rx)
     // mirroring it) — reflect them in the slider when we're in Auto mode.
     connect(rx, &RxApplet::autoSqlMarginDbChanged, this, [this](int dB) {
         if (!m_rxApplet || !m_sqlSlider) return;
+        if (!mirrorsRxAppletSql()) return;
         if (m_rxApplet->sqlMode() != RxApplet::SqlMode::Auto) return;
         QSignalBlocker b(m_sqlSlider);
         m_sqlSlider->setValue(dB);
@@ -4233,9 +4288,196 @@ void VfoWidget::setRxApplet(RxApplet* rx)
     syncSqlVisuals();
 }
 
+bool VfoWidget::mirrorsRxAppletSql() const
+{
+    return m_rxApplet && m_slice && m_rxApplet->isAttachedToSlice(m_slice);
+}
+
+VfoWidget::LocalSqlMode VfoWidget::standaloneSqlMode() const
+{
+    if (!m_slice || !m_slice->externalReceiveReplacementActive()) {
+        return (m_slice && m_slice->receiveSquelchOn())
+            ? LocalSqlMode::Manual
+            : LocalSqlMode::Off;
+    }
+    if (m_slice->externalReceiveAutoSquelchOn()) {
+        return LocalSqlMode::Auto;
+    }
+    return m_slice->receiveSquelchOn() ? LocalSqlMode::Manual
+                                       : LocalSqlMode::Off;
+}
+
+void VfoWidget::cycleStandaloneSqlMode()
+{
+    if (!m_slice || !m_slice->externalReceiveReplacementActive()) {
+        return;
+    }
+
+    switch (standaloneSqlMode()) {
+    case LocalSqlMode::Off:
+        m_slice->setExternalReceiveAutoSquelch(false);
+        m_slice->setSquelch(
+            true, clampManualSqlLevel(m_slice->receiveSquelchLevel()));
+        break;
+    case LocalSqlMode::Manual:
+        m_slice->setExternalReceiveAutoSquelch(true);
+        m_slice->setSquelch(true, autoSqlMarginDb());
+        break;
+    case LocalSqlMode::Auto:
+        m_slice->setExternalReceiveAutoSquelch(false);
+        m_slice->setSquelch(false, m_slice->receiveSquelchLevel());
+        break;
+    }
+    syncSqlVisuals();
+}
+
+int VfoWidget::autoSqlMarginDb() const
+{
+    return std::clamp(
+        AppSettings::instance().value("AutoSqlMarginDb", "10").toInt(), 5, 20);
+}
+
+void VfoWidget::setAutoSqlMarginDb(int dB)
+{
+    const int margin = std::clamp(dB, 5, 20);
+    auto& s = AppSettings::instance();
+    s.setValue("AutoSqlMarginDb", QString::number(margin));
+    s.save();
+    emit autoSqlMarginDbChanged(margin);
+    if (m_slice && m_slice->externalReceiveReplacementActive()
+        && m_slice->externalReceiveAutoSquelchOn()) {
+        m_slice->setSquelch(true, margin);
+    }
+}
+
+int VfoWidget::manualSqlMaximum() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive()
+        ? KiwiSdrProtocol::kSquelchUiMaxLevel
+        : 100;
+}
+
+int VfoWidget::clampManualSqlLevel(int level) const
+{
+    return std::clamp(level, 0, manualSqlMaximum());
+}
+
+int VfoWidget::agcThresholdMinimum() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive()
+        ? KiwiSdrProtocol::kAgcThresholdMinDb
+        : 0;
+}
+
+int VfoWidget::agcThresholdMaximum() const
+{
+    return m_slice && m_slice->externalReceiveReplacementActive()
+        ? KiwiSdrProtocol::kAgcThresholdMaxDb
+        : 100;
+}
+
 void VfoWidget::syncSqlVisuals()
 {
-    if (!m_rxApplet || !m_sqlBtn || !m_sqlSlider) return;
+    if (!m_sqlBtn || !m_sqlSlider) return;
+    if (!mirrorsRxAppletSql()) {
+        QSignalBlocker b1(m_sqlBtn), b2(m_sqlSlider);
+        if (m_slice && m_slice->externalReceiveReplacementActive()) {
+            if (m_sqlBtn->isCheckable()) {
+                m_sqlBtn->setCheckable(false);
+                m_sqlBtn->setChecked(false);
+            }
+            switch (standaloneSqlMode()) {
+            case LocalSqlMode::Off:
+                m_sqlBtn->setText("SQL");
+                m_sqlBtn->setStyleSheet(QString(kDspToggle) + kDisabledBtn);
+                m_sqlSlider->setEnabled(false);
+                break;
+            case LocalSqlMode::Manual:
+                m_sqlBtn->setText("SQL");
+                m_sqlBtn->setStyleSheet(
+                    "QPushButton { background: #006040; color: #00ff88; "
+                    "border: 1px solid #00a060; border-radius: 3px; "
+                    "font-size: 10px; font-weight: bold; padding: 1px 2px; }"
+                    "QPushButton:hover { background: #007050; }"
+                    + kDisabledBtn);
+                m_sqlSlider->setRange(0, manualSqlMaximum());
+                m_sqlSlider->setValue(clampManualSqlLevel(
+                    m_slice->receiveSquelchLevel()));
+                m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
+                break;
+            case LocalSqlMode::Auto:
+                m_sqlBtn->setText("AUTO");
+                m_sqlBtn->setStyleSheet(
+                    "QPushButton { background: #604000; color: #ffb800; "
+                    "border: 1px solid #906000; border-radius: 3px; "
+                    "font-size: 10px; font-weight: bold; padding: 1px 2px; }"
+                    "QPushButton:hover { background: #705000; }"
+                    + kDisabledBtn);
+                m_sqlSlider->setRange(5, 20);
+                m_sqlSlider->setValue(autoSqlMarginDb());
+                m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
+                break;
+            }
+            m_sqlSlider->setToolTip(
+                standaloneSqlMode() == LocalSqlMode::Auto
+                    ? QStringLiteral("Auto SQL margin (5-20 dB). dB above "
+                                     "the measured noise floor where the "
+                                     "squelch gate opens.")
+                    : QStringLiteral("Kiwi SQL threshold (0-99, mapped to a "
+                                     "signed dB offset from the receiver "
+                                     "noise floor). Increase to require a "
+                                     "stronger signal before audio opens."));
+            if (m_sqlValueLbl) {
+                m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
+            }
+            m_sqlSlider->style()->unpolish(m_sqlSlider);
+            m_sqlSlider->style()->polish(m_sqlSlider);
+            m_sqlSlider->update();
+            return;
+        }
+
+        if (m_sqlBtn->isCheckable() == false) {
+            m_sqlBtn->setCheckable(true);
+        }
+        const bool on = m_slice && m_slice->receiveSquelchOn();
+        const int level = m_slice ? m_slice->receiveSquelchLevel() : 0;
+        m_sqlBtn->setText("SQL");
+        m_sqlBtn->setChecked(on);
+        m_sqlBtn->setStyleSheet(on
+            ? QStringLiteral("QPushButton { background: #006040; color: #00ff88; "
+                             "border: 1px solid #00a060; border-radius: 3px; "
+                             "font-size: 10px; font-weight: bold; padding: 1px 2px; }"
+                             "QPushButton:hover { background: #007050; }")
+                + kDisabledBtn
+            : QString(kDspToggle) + kDisabledBtn);
+        m_sqlSlider->setRange(0, manualSqlMaximum());
+        m_sqlSlider->setValue(clampManualSqlLevel(level));
+        m_sqlSlider->setEnabled(m_sqlBtn->isEnabled() && on);
+        m_sqlSlider->setToolTip(m_slice && m_slice->externalReceiveReplacementActive()
+            ? QStringLiteral("Kiwi SQL threshold (0-99, mapped to a signed "
+                             "dB offset from the receiver noise floor). "
+                             "Increase to require a stronger signal before "
+                             "audio opens.")
+            : QStringLiteral("Squelch threshold (0-100). Increase to require "
+                             "a stronger signal before audio opens."));
+        if (m_sqlValueLbl) {
+            m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
+        }
+        m_sqlSlider->style()->unpolish(m_sqlSlider);
+        m_sqlSlider->style()->polish(m_sqlSlider);
+        m_sqlSlider->update();
+        return;
+    }
+
+    // Take the SQL button out of Qt's built-in checkable behavior while this
+    // VFO mirrors the side RX applet; the clicked() handler drives the
+    // applet's Off/Manual/Auto cycle explicitly. Inactive VFOs remain
+    // checkable and operate directly on their own slice.
+    if (m_sqlBtn->isCheckable()) {
+        m_sqlBtn->setCheckable(false);
+        m_sqlBtn->setChecked(false);
+    }
+
     const auto mode = m_rxApplet->sqlMode();
     // Match RxApplet's three button styles + label so the two surfaces
     // read identically.
@@ -4263,15 +4505,22 @@ void VfoWidget::syncSqlVisuals()
             + kDisabledBtn);
         break;
     }
-    // Slider swaps role between Manual (0–100 squelch_level) and Auto
-    // (5–20 dB margin).  Block signals during the swap so the resize
+    // Slider swaps role between Manual (Flex 0-100, Kiwi 0-99 signed-offset UI)
+    // and Auto (5–20 dB margin).  Block signals during the swap so the resize
     // doesn't fire a phantom valueChanged.
     QSignalBlocker b(m_sqlSlider);
     switch (mode) {
     case RxApplet::SqlMode::Manual: {
-        m_sqlSlider->setRange(0, 100);
+        m_sqlSlider->setRange(0, m_rxApplet->sqlManualMaximum());
         m_sqlSlider->setValue(m_rxApplet->sqlManualLevel());
-        m_sqlSlider->setEnabled(true);
+        m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
+        m_sqlSlider->setToolTip(m_slice && m_slice->externalReceiveReplacementActive()
+            ? QStringLiteral("Kiwi SQL threshold (0-99, mapped to a signed "
+                             "dB offset from the receiver noise floor). "
+                             "Increase to require a stronger signal before "
+                             "audio opens.")
+            : QStringLiteral("Squelch threshold (0-100). Increase to require "
+                             "a stronger signal before audio opens."));
         if (m_sqlValueLbl)
             m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
         break;
@@ -4279,15 +4528,24 @@ void VfoWidget::syncSqlVisuals()
     case RxApplet::SqlMode::Auto: {
         m_sqlSlider->setRange(5, 20);
         m_sqlSlider->setValue(m_rxApplet->autoSqlMarginDb());
-        m_sqlSlider->setEnabled(true);
+        m_sqlSlider->setEnabled(m_sqlBtn->isEnabled());
+        m_sqlSlider->setToolTip(
+            QStringLiteral("Auto SQL margin (5-20 dB). dB above the measured "
+                           "noise floor where the squelch gate opens."));
         if (m_sqlValueLbl)
             m_sqlValueLbl->setText(QString::number(m_sqlSlider->value()));
         break;
     }
     case RxApplet::SqlMode::Off:
         m_sqlSlider->setEnabled(false);
+        m_sqlSlider->setToolTip(
+            QStringLiteral("Squelch threshold. Increase to require a stronger "
+                           "signal before audio opens."));
         break;
     }
+    m_sqlSlider->style()->unpolish(m_sqlSlider);
+    m_sqlSlider->style()->polish(m_sqlSlider);
+    m_sqlSlider->update();
 }
 
 void VfoWidget::setRadioModel(RadioModel* radioModel)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -148,6 +148,7 @@ Q_SIGNALS:
     void sliceActivationRequested(int sliceId);
     void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
     void flexRxAntennaSelected(int sliceId);
+    void autoSqlMarginDbChanged(int dB);
     // Emitted when the wheel tunes by step so MainWindow can apply the shared
     // tuning/reveal policy.
     void stepTuneRequested(double mhz);
@@ -276,12 +277,22 @@ private:
     void syncTabStackHeightToCurrentPage();
     void relayoutToCurrentContent();
     QPushButton* m_sqlBtn{nullptr};
-    QPointer<RxApplet> m_rxApplet;       // source-of-truth for 3-way SQL state
+    QPointer<RxApplet> m_rxApplet;       // mirrored only while this VFO's slice is active
     QLabel*      m_sqlValueLbl{nullptr}; // captured during buildUI() for syncSqlVisuals
     bool         m_savedSquelchOn{false};
     // Apply the current SqlMode from m_rxApplet to the VfoWidget's SQL
     // button label/style and slider range/value.  Called on rxApplet's
     // sqlModeChanged signal and once after setRxApplet().
+    bool mirrorsRxAppletSql() const;
+    enum class LocalSqlMode { Off, Manual, Auto };
+    LocalSqlMode standaloneSqlMode() const;
+    void cycleStandaloneSqlMode();
+    int autoSqlMarginDb() const;
+    void setAutoSqlMarginDb(int dB);
+    int manualSqlMaximum() const;
+    int clampManualSqlLevel(int level) const;
+    int agcThresholdMinimum() const;
+    int agcThresholdMaximum() const;
     void syncSqlVisuals();
 public:
     void setDiversityAllowed(bool allowed);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1,4 +1,5 @@
 #include "SliceModel.h"
+#include "core/KiwiSdrProtocol.h"
 #include <QDebug>
 
 namespace AetherSDR {
@@ -285,7 +286,18 @@ void SliceModel::setAnflLevel(int v)
 
 void SliceModel::setAgcMode(const QString& mode)
 {
-    if (m_agcMode == mode) return;
+    if (m_externalReceiveAudioReplacement) {
+        if (m_externalReceiveAgcMode == mode) {
+            return;
+        }
+        m_externalReceiveAgcMode = mode;
+        emit externalReceiveAgcModeChanged(m_externalReceiveAgcMode);
+        return;
+    }
+
+    if (m_agcMode == mode) {
+        return;
+    }
     m_agcMode = mode;
     sendCommand(QString("slice set %1 agc_mode=%2").arg(m_id).arg(mode));
     emit agcModeChanged(mode);
@@ -293,8 +305,21 @@ void SliceModel::setAgcMode(const QString& mode)
 
 void SliceModel::setAgcThreshold(int value)
 {
+    if (m_externalReceiveAudioReplacement) {
+        value = qBound(KiwiSdrProtocol::kAgcThresholdMinDb, value,
+                       KiwiSdrProtocol::kAgcThresholdMaxDb);
+        if (m_externalReceiveAgcThreshold == value) {
+            return;
+        }
+        m_externalReceiveAgcThreshold = value;
+        emit externalReceiveAgcThresholdChanged(m_externalReceiveAgcThreshold);
+        return;
+    }
+
     value = qBound(0, value, 100);
-    if (m_agcThreshold == value) return;
+    if (m_agcThreshold == value) {
+        return;
+    }
     m_agcThreshold = value;
     sendCommand(QString("slice set %1 agc_threshold=%2").arg(m_id).arg(value));
     emit agcThresholdChanged(value);
@@ -303,7 +328,18 @@ void SliceModel::setAgcThreshold(int value)
 void SliceModel::setAgcOffLevel(int value)
 {
     value = qBound(0, value, 100);
-    if (m_agcOffLevel == value) return;
+    if (m_externalReceiveAudioReplacement) {
+        if (m_externalReceiveAgcOffLevel == value) {
+            return;
+        }
+        m_externalReceiveAgcOffLevel = value;
+        emit externalReceiveAgcOffLevelChanged(m_externalReceiveAgcOffLevel);
+        return;
+    }
+
+    if (m_agcOffLevel == value) {
+        return;
+    }
     m_agcOffLevel = value;
     sendCommand(QString("slice set %1 agc_off_level=%2").arg(m_id).arg(value));
     emit agcOffLevelChanged(value);
@@ -311,6 +347,19 @@ void SliceModel::setAgcOffLevel(int value)
 
 void SliceModel::setSquelch(bool on, int level)
 {
+    if (m_externalReceiveAudioReplacement) {
+        level = qBound(0, level, 99);
+        const bool onChanged = (m_externalReceiveSquelchOn != on);
+        const bool levelChanged = (m_externalReceiveSquelchLevel != level);
+        if (!onChanged && !levelChanged) {
+            return;
+        }
+        m_externalReceiveSquelchOn = on;
+        m_externalReceiveSquelchLevel = level;
+        emit externalReceiveSquelchChanged(on, level);
+        return;
+    }
+
     level = qBound(0, level, 100);
     const bool onChanged = (m_squelchOn != on);
     const bool levelChanged = (m_squelchLevel != level);
@@ -326,6 +375,15 @@ void SliceModel::setSquelch(bool on, int level)
         sendCommand(QString("slice set %1 squelch_level=%2").arg(m_id).arg(level));
 
     emit squelchChanged(on, level);
+}
+
+void SliceModel::setExternalReceiveAutoSquelch(bool on)
+{
+    if (m_externalReceiveAutoSquelch == on) {
+        return;
+    }
+    m_externalReceiveAutoSquelch = on;
+    emit externalReceiveAutoSquelchChanged(on);
 }
 
 void SliceModel::setRit(bool on, int hz)
@@ -518,6 +576,12 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
     const bool previousVisibleMute = audioMute();
     const float previousVisibleGain = audioGain();
     const int previousVisiblePan = audioPan();
+    const QString previousReceiveAgcMode = receiveAgcMode();
+    const int previousReceiveAgcThreshold = receiveAgcThreshold();
+    const int previousReceiveAgcOffLevel = receiveAgcOffLevel();
+    const bool previousReceiveSquelchOn = receiveSquelchOn();
+    const int previousReceiveSquelchLevel = receiveSquelchLevel();
+    const bool previousExternalAutoSquelch = m_externalReceiveAutoSquelch;
     if (active) {
         m_externalReceiveAudioGain = m_audioGain;
         m_externalReceiveAudioPan = m_audioPan;
@@ -529,6 +593,7 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
         }
     } else {
         m_externalReceiveAudioReplacement = false;
+        m_externalReceiveAutoSquelch = false;
         if (m_audioMute != restoreMute) {
             m_audioMute = restoreMute;
             sendCommand(QString("slice set %1 audio_mute=%2")
@@ -544,6 +609,39 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
     }
     if (audioPan() != previousVisiblePan) {
         emit audioPanChanged(audioPan());
+    }
+    if (receiveAgcMode() != previousReceiveAgcMode) {
+        if (m_externalReceiveAudioReplacement) {
+            emit externalReceiveAgcModeChanged(receiveAgcMode());
+        } else {
+            emit agcModeChanged(agcMode());
+        }
+    }
+    if (receiveAgcThreshold() != previousReceiveAgcThreshold) {
+        if (m_externalReceiveAudioReplacement) {
+            emit externalReceiveAgcThresholdChanged(receiveAgcThreshold());
+        } else {
+            emit agcThresholdChanged(agcThreshold());
+        }
+    }
+    if (receiveAgcOffLevel() != previousReceiveAgcOffLevel) {
+        if (m_externalReceiveAudioReplacement) {
+            emit externalReceiveAgcOffLevelChanged(receiveAgcOffLevel());
+        } else {
+            emit agcOffLevelChanged(agcOffLevel());
+        }
+    }
+    if (receiveSquelchOn() != previousReceiveSquelchOn
+        || receiveSquelchLevel() != previousReceiveSquelchLevel) {
+        if (m_externalReceiveAudioReplacement) {
+            emit externalReceiveSquelchChanged(receiveSquelchOn(),
+                                               receiveSquelchLevel());
+        } else {
+            emit squelchChanged(squelchOn(), squelchLevel());
+        }
+    }
+    if (m_externalReceiveAutoSquelch != previousExternalAutoSquelch) {
+        emit externalReceiveAutoSquelchChanged(m_externalReceiveAutoSquelch);
     }
 }
 

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -78,14 +78,38 @@ public:
     int     nrfLevel()    const { return m_nrfLevel; }
     int     anflLevel()   const { return m_anflLevel; }
     QString agcMode()      const { return m_agcMode; }
+    QString flexAgcMode()  const { return m_agcMode; }
+    QString receiveAgcMode() const { return m_externalReceiveAudioReplacement
+                                          ? m_externalReceiveAgcMode
+                                          : m_agcMode; }
     int     agcThreshold() const { return m_agcThreshold; }
+    int     flexAgcThreshold() const { return m_agcThreshold; }
+    int     receiveAgcThreshold() const { return m_externalReceiveAudioReplacement
+                                              ? m_externalReceiveAgcThreshold
+                                              : m_agcThreshold; }
     int     agcOffLevel()  const { return m_agcOffLevel; }
+    int     flexAgcOffLevel() const { return m_agcOffLevel; }
+    int     receiveAgcOffLevel() const { return m_externalReceiveAudioReplacement
+                                             ? m_externalReceiveAgcOffLevel
+                                             : m_agcOffLevel; }
     bool    audioMute()   const { return m_externalReceiveAudioReplacement
                                       ? m_externalReceiveAudioMute
                                       : m_audioMute; }
     bool    flexAudioMute() const { return m_audioMute; }
     bool    squelchOn()   const { return m_squelchOn; }
+    bool    flexSquelchOn() const { return m_squelchOn; }
+    bool    receiveSquelchOn() const { return m_externalReceiveAudioReplacement
+                                           ? m_externalReceiveSquelchOn
+                                           : m_squelchOn; }
+    bool    externalReceiveAutoSquelchOn() const
+    {
+        return m_externalReceiveAutoSquelch;
+    }
     int     squelchLevel()const { return m_squelchLevel; }
+    int     flexSquelchLevel() const { return m_squelchLevel; }
+    int     receiveSquelchLevel() const { return m_externalReceiveAudioReplacement
+                                              ? m_externalReceiveSquelchLevel
+                                              : m_squelchLevel; }
     bool    ritOn()       const { return m_ritOn; }
     int     ritFreq()     const { return m_ritFreq; }
     bool    xitOn()       const { return m_xitOn; }
@@ -123,6 +147,11 @@ public:
     void setAudioMute(bool mute);
     void setExternalReceiveAudioReplacementMute(bool active,
                                                 bool restoreMute = false);
+    void setExternalReceiveAutoSquelch(bool on);
+    bool externalReceiveReplacementActive() const
+    {
+        return m_externalReceiveAudioReplacement;
+    }
     void setDiversity(bool on);
     bool diversity() const { return m_diversity; }
     bool isDiversityChild() const { return m_diversityChild; }
@@ -249,7 +278,12 @@ signals:
     void escGainChanged(float gain);
     void escPhaseShiftChanged(float deg);
     void rfGainChanged(float gain);
+    void externalReceiveAgcModeChanged(const QString& mode);
+    void externalReceiveAgcThresholdChanged(int value);
+    void externalReceiveAgcOffLevelChanged(int value);
+    void externalReceiveAutoSquelchChanged(bool on);
     void squelchChanged(bool on, int level);
+    void externalReceiveSquelchChanged(bool on, int level);
     void stepChanged(int hz, const QVector<int>& stepList);
     void ritChanged(bool on, int hz);
     void xitChanged(bool on, int hz);
@@ -300,6 +334,14 @@ private:
     bool    m_externalReceiveAudioMute{false};
     float   m_externalReceiveAudioGain{70.0f};
     int     m_externalReceiveAudioPan{50};
+    QString m_externalReceiveAgcMode{"med"};
+    int     m_externalReceiveAgcThreshold{-100};
+    int     m_externalReceiveAgcOffLevel{50};
+    bool    m_externalReceiveAutoSquelch{false};
+    bool    m_externalReceiveSquelchOn{false};
+    // KiwiSDR does not report an initial squelch threshold. Start at the
+    // lowest manual UI level so first-enable cannot unexpectedly close audio.
+    int     m_externalReceiveSquelchLevel{0};
     bool    m_diversity{false};
     bool    m_diversityChild{false};
     bool    m_diversityParent{false};

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -44,8 +44,20 @@ int main()
     if (!serverSoundHeader.valid
         || serverSoundHeader.sequence != 0x12
         || serverSoundHeader.flags != 0x80
+        || serverSoundHeader.squelched
         || serverSoundHeader.hasRssi) {
         return fail("server SND header sequence parsing is wrong");
+    }
+
+    const QByteArray squelchedSoundFrame =
+        QByteArray("SND", 3)
+        + QByteArray::fromHex("40010000000000000102");
+    const SoundFrameHeader squelchedSoundHeader =
+        parseSoundFrameHeader(squelchedSoundFrame);
+    if (!squelchedSoundHeader.valid
+        || !squelchedSoundHeader.squelched
+        || squelchedSoundHeader.flags != 0x40) {
+        return fail("server SND squelch flag parsing is wrong");
     }
 
     QByteArray observedSoundFrame("SND", 3);
@@ -75,7 +87,9 @@ int main()
         return fail("sequence gap accounting is wrong");
     }
 
-    if (!nearlyEqual(waterfallByteToDisplayLevel(0), -130.0f)
+    if (!nearlyEqual(waterfallByteToDisplayLevel(0), -200.0f)
+        || !nearlyEqual(waterfallByteToDisplayLevel(55), -200.0f)
+        || !nearlyEqual(waterfallByteToDisplayLevel(155), -100.0f)
         || !nearlyEqual(waterfallByteToDisplayLevel(255), 0.0f)) {
         return fail("waterfall byte display-level conversion is wrong");
     }
@@ -99,6 +113,60 @@ int main()
     if (parseIpLimitNotice(QStringLiteral("0,192.0.2.1")).valid
         || parseIpLimitNotice(QStringLiteral("not-a-limit")).valid) {
         return fail("invalid ip_limit notice should be rejected");
+    }
+
+    if (formatSquelchCommand(false, 20)
+            != QStringLiteral("SET squelch=0 param=0.00")
+        || formatSquelchCommand(true, 0)
+            != QStringLiteral("SET squelch=1 param=0.00")
+        || formatSquelchCommand(true, 20)
+            != QStringLiteral("SET squelch=20 param=0.00")
+        || formatSquelchCommand(true, -20)
+            != QStringLiteral("SET squelch=-20 param=0.00")
+        || formatSquelchCommand(true, -4)
+            != QStringLiteral("SET squelch=-4 param=0.00")
+        || formatSquelchCommand(true, -250)
+            != QStringLiteral("SET squelch=-99 param=0.00")
+        || formatSquelchCommand(true, 250)
+            != QStringLiteral("SET squelch=99 param=0.00")) {
+        return fail("squelch command formatting is wrong");
+    }
+
+    if (squelchSliderLevelToMarginDb(-10) != -99
+        || squelchSliderLevelToMarginDb(0) != -99
+        || squelchSliderLevelToMarginDb(1) != -97
+        || squelchSliderLevelToMarginDb(20) != -59
+        || squelchSliderLevelToMarginDb(49) != -1
+        || squelchSliderLevelToMarginDb(50) != 1
+        || squelchSliderLevelToMarginDb(75) != 51
+        || squelchSliderLevelToMarginDb(99) != 99
+        || squelchSliderLevelToMarginDb(100) != 99
+        || squelchSliderLevelToMarginDb(150) != 99) {
+        return fail("squelch slider-to-margin mapping is wrong");
+    }
+
+    if (agcDecayMsForMode(QStringLiteral("fast")) != kAgcFastDecayMs
+        || agcDecayMsForMode(QStringLiteral("FAST")) != kAgcFastDecayMs
+        || agcDecayMsForMode(QStringLiteral("med")) != kAgcMedDecayMs
+        || agcDecayMsForMode(QStringLiteral("slow")) != kAgcSlowDecayMs
+        || agcDecayMsForMode(QStringLiteral("off")) != kAgcMedDecayMs
+        || agcDecayMsForMode(QStringLiteral("unexpected")) != kAgcMedDecayMs) {
+        return fail("AGC mode-to-decay mapping is wrong");
+    }
+
+    if (formatAgcCommand(true, false, -100, 50, agcDecayMsForMode("med"))
+            != QStringLiteral("SET agc=1 hang=0 thresh=-100 slope=6 decay=1000 manGain=50")
+        || formatAgcCommand(true, false, -80, 50, agcDecayMsForMode("fast"))
+            != QStringLiteral("SET agc=1 hang=0 thresh=-80 slope=6 decay=300 manGain=50")
+        || formatAgcCommand(true, false, -120, 50, agcDecayMsForMode("slow"))
+            != QStringLiteral("SET agc=1 hang=0 thresh=-120 slope=6 decay=3000 manGain=50")
+        || formatAgcCommand(false, false, -100, 44, agcDecayMsForMode("off"))
+            != QStringLiteral("SET agc=0 hang=0 thresh=-100 slope=6 decay=1000 manGain=44")
+        || formatAgcCommand(true, true, -999, 200, 99999)
+            != QStringLiteral("SET agc=1 hang=1 thresh=-160 slope=6 decay=5000 manGain=100")
+        || formatAgcCommand(true, false, 20, -5, 1)
+            != QStringLiteral("SET agc=1 hang=0 thresh=0 slope=6 decay=20 manGain=0")) {
+        return fail("AGC command formatting is wrong");
     }
 
     const QVector<MsgToken> msgTokens = parseMsgTokens(
@@ -156,17 +224,18 @@ int main()
     extendedSoundFrame[2] = 'D';
     extendedSoundFrame[8] = static_cast<char>(0x02);
     extendedSoundFrame[9] = static_cast<char>(0x1c);
-    const MeterReading experimentalMeter =
+    const MeterReading sndMeter =
         extractMeterFromSndVerifiedLayout(extendedSoundFrame, MeterContext{});
-    if (!experimentalMeter.valid
-        || experimentalMeter.capability != MeterCapability::Experimental
-        || !experimentalMeter.hasRawValue
-        || !nearlyEqual(experimentalMeter.rawValue, 540.0f)
-        || !experimentalMeter.hasDbm
-        || !nearlyEqual(experimentalMeter.dbm, -73.0f)
-        || experimentalMeter.sUnits != QStringLiteral("S9")
-        || experimentalMeter.label != QStringLiteral("S-Meter")) {
-        return fail("experimental SND meter candidate extraction is wrong");
+    if (!sndMeter.valid
+        || sndMeter.capability != MeterCapability::CalibratedSndMeter
+        || sndMeter.confidence != MeterConfidence::Verified
+        || !sndMeter.hasRawValue
+        || !nearlyEqual(sndMeter.rawValue, 540.0f)
+        || !sndMeter.hasDbm
+        || !nearlyEqual(sndMeter.dbm, -73.0f)
+        || sndMeter.sUnits != QStringLiteral("S9")
+        || sndMeter.label != QStringLiteral("S-Meter")) {
+        return fail("SND meter extraction is wrong");
     }
 
     const MeterReading unavailable =

--- a/tests/slice_model_letter_test.cpp
+++ b/tests/slice_model_letter_test.cpp
@@ -143,6 +143,182 @@ int main(int argc, char** argv)
                   QStringLiteral("slice set 4 audio_pan=60"));
     }
 
+    // ── External receive replacement also owns visible AGC and SQL controls.
+    // These controls should drive the replacement source, not hidden Flex state.
+    {
+        SliceModel s(5);
+        QStringList commands;
+        QObject::connect(&s, &SliceModel::commandReady,
+                         [&commands](const QString& cmd) { commands.append(cmd); });
+        s.applyStatus(kv({{"agc_mode", "slow"},
+                          {"agc_threshold", "40"},
+                          {"agc_off_level", "12"},
+                          {"squelch", "1"},
+                          {"squelch_level", "35"}}));
+        EXPECT_EQ(s.agcMode(), QString("slow"));
+        EXPECT_EQ(s.agcThreshold(), 40);
+        EXPECT_EQ(s.agcOffLevel(), 12);
+        EXPECT_EQ(s.squelchOn(), true);
+        EXPECT_EQ(s.squelchLevel(), 35);
+
+        QSignalSpy agcModeSpy(&s, &SliceModel::agcModeChanged);
+        QSignalSpy agcThresholdSpy(&s, &SliceModel::agcThresholdChanged);
+        QSignalSpy agcOffLevelSpy(&s, &SliceModel::agcOffLevelChanged);
+        QSignalSpy externalAgcModeSpy(
+            &s, &SliceModel::externalReceiveAgcModeChanged);
+        QSignalSpy externalAgcThresholdSpy(
+            &s, &SliceModel::externalReceiveAgcThresholdChanged);
+        QSignalSpy externalAgcOffLevelSpy(
+            &s, &SliceModel::externalReceiveAgcOffLevelChanged);
+        QSignalSpy externalAutoSquelchSpy(
+            &s, &SliceModel::externalReceiveAutoSquelchChanged);
+        QSignalSpy squelchSpy(&s, &SliceModel::squelchChanged);
+        QSignalSpy externalSquelchSpy(
+            &s, &SliceModel::externalReceiveSquelchChanged);
+        s.setExternalReceiveAudioReplacementMute(true);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 5 audio_mute=1"));
+        EXPECT_EQ(s.agcMode(), QString("slow"));
+        EXPECT_EQ(s.receiveAgcMode(), QString("med"));
+        EXPECT_EQ(s.flexAgcMode(), QString("slow"));
+        EXPECT_EQ(s.agcThreshold(), 40);
+        EXPECT_EQ(s.receiveAgcThreshold(), -100);
+        EXPECT_EQ(s.flexAgcThreshold(), 40);
+        EXPECT_EQ(s.agcOffLevel(), 12);
+        EXPECT_EQ(s.receiveAgcOffLevel(), 50);
+        EXPECT_EQ(s.flexAgcOffLevel(), 12);
+        EXPECT_EQ(s.squelchOn(), true);
+        EXPECT_EQ(s.receiveSquelchOn(), false);
+        EXPECT_EQ(s.externalReceiveAutoSquelchOn(), false);
+        EXPECT_EQ(s.flexSquelchOn(), true);
+        EXPECT_EQ(s.squelchLevel(), 35);
+        EXPECT_EQ(s.receiveSquelchLevel(), 0);
+        EXPECT_EQ(s.flexSquelchLevel(), 35);
+        EXPECT_EQ(agcModeSpy.count(), 0);
+        EXPECT_EQ(agcThresholdSpy.count(), 0);
+        EXPECT_EQ(agcOffLevelSpy.count(), 0);
+        EXPECT_EQ(externalAgcModeSpy.count(), 1);
+        EXPECT_EQ(externalAgcModeSpy.takeFirst().at(0).toString(), QString("med"));
+        EXPECT_EQ(externalAgcThresholdSpy.count(), 1);
+        EXPECT_EQ(externalAgcThresholdSpy.takeFirst().at(0).toInt(), -100);
+        EXPECT_EQ(externalAgcOffLevelSpy.count(), 1);
+        EXPECT_EQ(externalAgcOffLevelSpy.takeFirst().at(0).toInt(), 50);
+        EXPECT_EQ(squelchSpy.count(), 0);
+        EXPECT_EQ(externalSquelchSpy.count(), 1);
+        EXPECT_EQ(externalSquelchSpy.takeFirst().at(0).toBool(), false);
+        EXPECT_EQ(externalAutoSquelchSpy.count(), 0);
+        commands.clear();
+
+        s.setExternalReceiveAutoSquelch(true);
+        EXPECT_EQ(s.externalReceiveAutoSquelchOn(), true);
+        EXPECT_EQ(commands.join(QStringLiteral("|")), QString());
+        EXPECT_EQ(externalAutoSquelchSpy.count(), 1);
+        EXPECT_EQ(externalAutoSquelchSpy.takeFirst().at(0).toBool(), true);
+
+        s.setAgcMode(QStringLiteral("off"));
+        s.setAgcThreshold(-40);
+        s.setAgcOffLevel(44);
+        s.setSquelch(false, 66);
+        EXPECT_EQ(s.agcMode(), QString("slow"));
+        EXPECT_EQ(s.receiveAgcMode(), QString("off"));
+        EXPECT_EQ(s.flexAgcMode(), QString("slow"));
+        EXPECT_EQ(s.agcThreshold(), 40);
+        EXPECT_EQ(s.receiveAgcThreshold(), -40);
+        EXPECT_EQ(s.flexAgcThreshold(), 40);
+        EXPECT_EQ(s.agcOffLevel(), 12);
+        EXPECT_EQ(s.receiveAgcOffLevel(), 44);
+        EXPECT_EQ(s.flexAgcOffLevel(), 12);
+        EXPECT_EQ(s.squelchOn(), true);
+        EXPECT_EQ(s.receiveSquelchOn(), false);
+        EXPECT_EQ(s.externalReceiveAutoSquelchOn(), true);
+        EXPECT_EQ(s.flexSquelchOn(), true);
+        EXPECT_EQ(s.squelchLevel(), 35);
+        EXPECT_EQ(s.receiveSquelchLevel(), 66);
+        EXPECT_EQ(s.flexSquelchLevel(), 35);
+        EXPECT_EQ(commands.join(QStringLiteral("|")), QString());
+        EXPECT_EQ(agcModeSpy.count(), 0);
+        EXPECT_EQ(agcThresholdSpy.count(), 0);
+        EXPECT_EQ(agcOffLevelSpy.count(), 0);
+        EXPECT_EQ(externalAgcModeSpy.count(), 1);
+        EXPECT_EQ(externalAgcModeSpy.takeFirst().at(0).toString(), QString("off"));
+        EXPECT_EQ(externalAgcThresholdSpy.count(), 1);
+        EXPECT_EQ(externalAgcThresholdSpy.takeFirst().at(0).toInt(), -40);
+        EXPECT_EQ(externalAgcOffLevelSpy.count(), 1);
+        EXPECT_EQ(externalAgcOffLevelSpy.takeFirst().at(0).toInt(), 44);
+        EXPECT_EQ(squelchSpy.count(), 0);
+        EXPECT_EQ(externalSquelchSpy.count(), 1);
+        EXPECT_EQ(externalSquelchSpy.takeFirst().at(0).toBool(), false);
+        commands.clear();
+
+        s.applyStatus(kv({{"agc_mode", "fast"},
+                          {"agc_threshold", "90"},
+                          {"agc_off_level", "8"},
+                          {"squelch", "1"},
+                          {"squelch_level", "12"}}));
+        EXPECT_EQ(s.agcMode(), QString("fast"));
+        EXPECT_EQ(s.receiveAgcMode(), QString("off"));
+        EXPECT_EQ(s.flexAgcMode(), QString("fast"));
+        EXPECT_EQ(s.agcThreshold(), 90);
+        EXPECT_EQ(s.receiveAgcThreshold(), -40);
+        EXPECT_EQ(s.flexAgcThreshold(), 90);
+        EXPECT_EQ(s.agcOffLevel(), 8);
+        EXPECT_EQ(s.receiveAgcOffLevel(), 44);
+        EXPECT_EQ(s.flexAgcOffLevel(), 8);
+        EXPECT_EQ(s.squelchOn(), true);
+        EXPECT_EQ(s.receiveSquelchOn(), false);
+        EXPECT_EQ(s.externalReceiveAutoSquelchOn(), true);
+        EXPECT_EQ(s.flexSquelchOn(), true);
+        EXPECT_EQ(s.squelchLevel(), 12);
+        EXPECT_EQ(s.receiveSquelchLevel(), 66);
+        EXPECT_EQ(s.flexSquelchLevel(), 12);
+        EXPECT_EQ(agcModeSpy.count(), 1);
+        EXPECT_EQ(agcModeSpy.takeFirst().at(0).toString(), QString("fast"));
+        EXPECT_EQ(agcThresholdSpy.count(), 1);
+        EXPECT_EQ(agcThresholdSpy.takeFirst().at(0).toInt(), 90);
+        EXPECT_EQ(agcOffLevelSpy.count(), 1);
+        EXPECT_EQ(agcOffLevelSpy.takeFirst().at(0).toInt(), 8);
+        EXPECT_EQ(squelchSpy.count(), 1);
+        EXPECT_EQ(squelchSpy.takeFirst().at(0).toBool(), true);
+        EXPECT_EQ(externalAgcModeSpy.count(), 0);
+        EXPECT_EQ(externalAgcThresholdSpy.count(), 0);
+        EXPECT_EQ(externalAgcOffLevelSpy.count(), 0);
+        EXPECT_EQ(externalSquelchSpy.count(), 0);
+
+        s.setExternalReceiveAudioReplacementMute(false, false);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 5 audio_mute=0"));
+        EXPECT_EQ(s.agcMode(), QString("fast"));
+        EXPECT_EQ(s.agcThreshold(), 90);
+        EXPECT_EQ(s.agcOffLevel(), 8);
+        EXPECT_EQ(s.squelchOn(), true);
+        EXPECT_EQ(s.squelchLevel(), 12);
+        EXPECT_EQ(s.externalReceiveAutoSquelchOn(), false);
+        EXPECT_EQ(agcModeSpy.count(), 1);
+        EXPECT_EQ(agcModeSpy.takeFirst().at(0).toString(), QString("fast"));
+        EXPECT_EQ(agcThresholdSpy.count(), 1);
+        EXPECT_EQ(agcThresholdSpy.takeFirst().at(0).toInt(), 90);
+        EXPECT_EQ(agcOffLevelSpy.count(), 1);
+        EXPECT_EQ(agcOffLevelSpy.takeFirst().at(0).toInt(), 8);
+        EXPECT_EQ(squelchSpy.count(), 1);
+        EXPECT_EQ(squelchSpy.takeFirst().at(0).toBool(), true);
+        EXPECT_EQ(squelchSpy.count(), 0);
+        EXPECT_EQ(externalSquelchSpy.count(), 0);
+        EXPECT_EQ(externalAutoSquelchSpy.count(), 1);
+        EXPECT_EQ(externalAutoSquelchSpy.takeFirst().at(0).toBool(), false);
+        commands.clear();
+
+        s.setAgcMode(QStringLiteral("med"));
+        s.setAgcThreshold(20);
+        s.setAgcOffLevel(30);
+        s.setSquelch(false, 22);
+        EXPECT_EQ(commands.join(QStringLiteral("|")),
+                  QStringLiteral("slice set 5 agc_mode=med|"
+                                 "slice set 5 agc_threshold=20|"
+                                 "slice set 5 agc_off_level=30|"
+                                 "slice set 5 squelch=0|"
+                                 "slice set 5 squelch_level=22"));
+    }
+
     if (g_failures == 0) {
         std::printf("slice_model_letter_test: all checks passed\n");
         return 0;


### PR DESCRIPTION
## Summary

Implements KiwiSDR receive-source SQL and AGC behavior so the existing RX applet, VFO controls, spectrum SQL overlay, automation/TCI state, and Kiwi receiver command path control the Kiwi replacement receiver when a Kiwi RX antenna is selected, while preserving Flex SQL/AGC behavior for normal Flex slices. This adds server-compatible Kiwi squelch and AGC command formatting, independent Kiwi/Flex SQL state, Kiwi-only SQL overlay rendering, local SND squelch audio gating, verified SND meter handling, and regression coverage for the protocol/model behavior.

## Constitution principle honored

Principle IV — this remains clean-room and source-attributed. No KiwiSDR served JavaScript/client code, WebSDR code, or AGPL client implementation was copied, translated, or used. Public server/DSP source was consulted only to verify wire protocol facts and numeric ranges.

Source attribution:
- KiwiSDR archived public server source `rx/rx_sound_cmd.cpp` is GNU Library GPL v2-or-later and was consulted to verify the accepted `SET agc=...` and `SET squelch=... param=...` parser forms: https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/rx_sound_cmd.cpp#L433-L459
- KiwiSDR server `rx/rx_sound.cpp` was consulted to verify non-NBFM squelch is median-noise-relative and emits the SND squelch UI flag: https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/rx_sound.cpp#L988-L1022 and https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/rx_sound.cpp#L468-L475
- CuteSDR AGC source is Simplified BSD licensed and documents threshold `-160..0 dB`, manual gain `0..100 dB`, and decay `20..5000 ms`: https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/CuteSDR/agc.cpp#L11-L19 and https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/CuteSDR/agc.cpp#L95-L101
- CuteSDR squelch source is Simplified BSD licensed and documents the NBFM squelch value behavior: https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/CuteSDR/squelch.cpp#L12-L19 and https://github.com/jks-prv/Beagle_SDR_GPS/blob/master/rx/CuteSDR/squelch.cpp#L123-L130

The consulted LGPL/GNU Library GPL and Simplified BSD sources are GPL-compatible public sources, and this PR uses only protocol/range facts from them; no source code was incorporated.

## Test plan

- [x] Local build passes (`cmake --build build --target kiwi_sdr_protocol_test slice_model_letter_test AetherSDR`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (`ctest --test-dir build -R "kiwi_sdr_protocol_test|slice_model_letter_test" --output-on-failure`)
- [x] Reproduction steps documented if user-reported bug

Additional local checks:
- [x] `git diff --check`
- [x] `python3 tools/check_a11y.py` exits 0; existing warning-only findings remain

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — Kiwi profile state remains under the existing nested Kiwi settings; SQL margin reuse follows existing app behavior
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary
- [x] All meter UI uses existing meter surfaces/smoothing paths
- [x] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable
