### PR TITLE
fix(smartmtr): show no-data on the needle for uncalibrated sources (#3750 H1)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3288,6 +3288,7 @@ void VfoWidget::setSignalLevel(float dbm)
 {
     m_receiveMeterReadingActive = false;
     m_signalDbm = dbm;
+    m_signalHasDbm = true; // FLEX always delivers a calibrated dBm reading
     m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(dbm)));
     m_dbmLabel->setAccessibleName("Signal level dBm");
     updateSignalMeterTarget();
@@ -3319,13 +3320,18 @@ void VfoWidget::pushSmartMtrInput()
         // Peak marker is the radio's separate MICPEAK stat, not a local window max.
         in.hasPeak = true;
         in.peak = m_micPeakDbfs;
+        in.hasValue = true;
     } else {
         in.kind = MeterKind::Signal;
         in.value = m_signalDbm;
         in.min = -127.0; // dBm: S0
         in.max = -13.0;  // dBm: S9+60
+        // No calibrated dBm (e.g. a KiwiSDR slice without a real meter): drive
+        // the needle to its no-data state instead of pegging the hardcoded S0.
+        // The widget parks/fades the indicator and suppresses the value labels
+        // when hasValue is false, matching the "Meter ---" dBm label.
+        in.hasValue = m_signalHasDbm;
     }
-    in.hasValue = true;
     m_smartMtrWidget->setMeterInput(in);
 }
 
@@ -3508,6 +3514,7 @@ void VfoWidget::setReceiveMeterReading(
          || reading.capability == KiwiSdrProtocol::MeterCapability::Experimental)
         && reading.hasDbm;
 
+    m_signalHasDbm = hasDisplayDbm;
     if (hasDisplayDbm) {
         m_signalDbm = reading.dbm;
         m_dbmLabel->setText(QString("%1 dBm").arg(static_cast<int>(reading.dbm)));

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -236,6 +236,10 @@ private:
     bool           m_updatingFromModel{false};
     bool           m_lastOnLeft{true};
     float          m_signalDbm{-130.0f};
+    // Whether m_signalDbm is a real calibrated reading. FLEX always is; a
+    // KiwiSDR slice without a calibrated meter is not, in which case the
+    // SmartMTR needle must show no-data rather than peg the hardcoded S0.
+    bool           m_signalHasDbm{true};
     KiwiSdrProtocol::MeterReading m_receiveMeterReading;
     bool           m_receiveMeterReadingActive{false};
     QTimer         m_signalMeterAnimation;


### PR DESCRIPTION
Fixes the **H1** item from #3750 (SmartMTR fast-follow), introduced with the SmartMTR meter view in #3723.

## Problem
`VfoWidget::pushSmartMtrInput()` hardcodes the FLEX dBm scale (`-127` S0 .. `-13` S9+60) for **every** source. When a KiwiSDR slice has no calibrated meter, the receive path sets the sentinel `m_signalDbm = -130` and the dBm label correctly shows **"Meter ---"** — but the SmartMTR needle clamped `-130` to S0 and rendered a confident **S0**, and the numeric value labels printed the bogus sub-S0 dBm.

The PR author wasn't aware of our KiwiSDR public-receiver feed (#3679), so this interaction was on us (maintainers) to fix.

## Fix
Track whether the current signal reading is a real calibrated dBm:
- new `m_signalHasDbm` — `true` for FLEX (`setSignalLevel`), set from the KiwiSDR meter capability in `setReceiveMeterReading`;
- feed it into `MeterInput::hasValue` for the `Signal` kind.

The widget **already** parks/fades the indicator and suppresses the value labels when `hasValue == false` (see `indicatorPosition()` → `kScaleMin`, the `kSignalFadeLoDbm` needle target, and the `if (m_input.hasValue)` value-label guard). So no widget change is needed — the SmartMTR view now shows no-data, matching the "Meter ---" label, instead of a false S0. The mic (TX) path keeps `hasValue = true`.

## Scope
3 small edits in `VfoWidget.{cpp,h}`, behavior-neutral for FLEX (the flag is always `true` there). No change to the S-meter path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)