### PR TITLE
fix(smartmtr): timer settle, NaN guard, cross-flag sync, font cache (#3750 M1–M4)

### DIFF
--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -144,6 +144,15 @@ public:
         // so an idle meter still settles rather than pinning the repaint timer at
         // full rate forever (each meter repaint over the GPU panadapter forces a
         // costly recomposite that starves input).
+        // In external-peak (mic) mode the MAX marker is a held radio stat that
+        // sits above the needle by design, so it would "stand off" forever and
+        // pin the timer for the entire TX. Each mic packet re-arms the timer via
+        // setMeterInput (setExternalPeak keeps hasData() true), so here we only
+        // need to keep animating while a marker is actually slewing — drop the
+        // standing-off keep-alive for this mode so the meter settles between
+        // packets instead of repainting at full rate over the GPU panadapter.
+        if (m_useExtPeak)
+            return moving;
         const bool standingOff = (m_maxPos > needlePosUnits + kConvergeEps)
                                  || (m_minPos < needlePosUnits - kConvergeEps);
         return moving || standingOff;

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "SmartMtrStyle.h"
 
+#include <QEvent>
 #include <QFont>
 #include <QFontMetricsF>
 #include <QLinearGradient>
@@ -10,6 +11,7 @@
 #include <QPolygonF>
 
 #include <algorithm>
+#include <cmath>
 
 namespace AetherSDR {
 
@@ -96,6 +98,15 @@ void SmartMtrWidget::applyBallistics(MeterKind kind)
 
 void SmartMtrWidget::setMeterInput(const MeterInput& input)
 {
+    // A non-finite value (NaN/Inf) would survive std::clamp (both comparisons
+    // false), stick in the bar smoother so needsAnimation() never clears, and
+    // poison the extremes running sum permanently. Drop it; the last good frame
+    // stays on screen until a finite reading arrives.
+    if (input.hasValue && !std::isfinite(input.value))
+        return;
+    if (input.hasPeak && !std::isfinite(input.peak))
+        return;
+
     const bool kindChanged = (input.kind != m_kind);
     m_input = input;
     m_kind = input.kind;
@@ -181,6 +192,21 @@ void SmartMtrWidget::advance()
     // timer staying alive through a marker hold (nothing moving) doesn't repaint.
     if (settled || extremesRepaintDue || (barMoving && m_smooth.shouldRepaint()))
         update();
+}
+
+void SmartMtrWidget::changeEvent(QEvent* e)
+{
+    // The cached marker layer (m_aboveBar) bakes label glyphs built from font(),
+    // but the cache key is only {size, kind, dpr}. A theme/app font change would
+    // otherwise leave stale glyphs until the next resize/kind/DPR change, so
+    // invalidate the static layers here and repaint.
+    if (e->type() == QEvent::FontChange
+        || e->type() == QEvent::ApplicationFontChange
+        || e->type() == QEvent::StyleChange) {
+        m_cacheValid = false;
+        update();
+    }
+    QWidget::changeEvent(e);
 }
 
 void SmartMtrWidget::paintEvent(QPaintEvent*)

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -78,6 +78,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent*) override;
+    void changeEvent(QEvent*) override;
 
 private:
     // One element per method; all draw in UNITS via SmartMtrGeometry. Called

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -331,6 +331,13 @@ VfoWidget::VfoWidget(QWidget* parent)
     // its options, so re-push the input when it changes on any flag.
     connect(&MeterViewController::instance(), &MeterViewController::txMeterChanged,
             this, &VfoWidget::pushSmartMtrInput);
+    // The pushes above update this flag's rendering; also re-seed its option
+    // CONTROLS so a change made on another open flag's selector doesn't leave
+    // this flag's checkbox/combos showing a stale value.
+    connect(&MeterViewController::instance(), &MeterViewController::extremesChanged,
+            this, &VfoWidget::syncSmartMtrSettingsControls);
+    connect(&MeterViewController::instance(), &MeterViewController::txMeterChanged,
+            this, &VfoWidget::syncSmartMtrSettingsControls);
     pushSmartMtrOptions(); // apply the persisted options to this new flag
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
@@ -3280,6 +3287,35 @@ void VfoWidget::syncSmartMtrSettingsState()
             }
         }
     }
+}
+
+void VfoWidget::syncSmartMtrSettingsControls()
+{
+    // The meter options are global + live, but the per-flag control widgets are
+    // only seeded once at build and updated by local interaction. When another
+    // open flag changes a setting, re-seed this flag's controls from the
+    // (cached) MeterViewController so they don't show a stale value. Block
+    // signals so this re-seed doesn't echo back into the controller.
+    auto& mv = MeterViewController::instance();
+    if (m_showExtremesChk) {
+        const QSignalBlocker b(m_showExtremesChk);
+        m_showExtremesChk->setChecked(mv.showExtremes());
+    }
+    if (m_extremesSpeedCmb) {
+        const QSignalBlocker b(m_extremesSpeedCmb);
+        m_extremesSpeedCmb->setCurrentIndex(
+            m_extremesSpeedCmb->findData(int(mv.extremesSpeed())));
+    }
+    if (m_showValuesCmb) {
+        const QSignalBlocker b(m_showValuesCmb);
+        m_showValuesCmb->setCurrentIndex(
+            m_showValuesCmb->findData(int(mv.showValues())));
+    }
+    if (m_txMeterCmb) {
+        const QSignalBlocker b(m_txMeterCmb);
+        m_txMeterCmb->setCurrentIndex(m_txMeterCmb->findData(int(mv.txMeter())));
+    }
+    syncSmartMtrSettingsState();  // re-evaluate enable/disable for the new state
 }
 
 // ── Signal level ──────────────────────────────────────────────────────────────

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -319,6 +319,9 @@ private:
     // Enable/disable the SmartMTR-only options per the current meter view and
     // the "Show extremes" checkbox state (see implementation for the rules).
     void syncSmartMtrSettingsState();
+    // Re-seed this flag's option controls from the global MeterViewController
+    // (used when another open flag changes a setting), then re-evaluate state.
+    void syncSmartMtrSettingsControls();
     // Thin spacer between the meter and the tab bar, shown only while the meter
     // selector is open, to give the curved underline room below the indicator.
     QWidget* m_meterUnderlineRoom{nullptr};


### PR DESCRIPTION
Addresses the four **MEDIUM** items from #3750 (SmartMTR fast-follow), all introduced with #3723. Each is independent; grouped into one PR per the follow-up plan.

### M1 — TX/mic mode never lets the 120 Hz timer settle
`MeterExtremes.h`: in external-peak (mic) mode the MAX marker is a held radio stat that sits above the needle by design, so the `standingOff` keep-alive kept `tick()` returning `true` for the entire TX, pinning ~120 Hz repaints over the GPU panadapter. Each mic packet re-arms the timer via `setMeterInput` (`setExternalPeak` keeps `hasData()` true), so we only need to keep animating while a marker is actually slewing — drop the standing-off keep-alive in that mode. Bounded before (PTT release resets), but this restores the idle-settle the perf work intended.

### M2 — NaN/Inf permanently poisons the meter
`SmartMtrWidget::setMeterInput`: a non-finite value survived `std::clamp` (both comparisons false), stuck in the bar smoother (`needsAnimation()` never cleared → timer never stopped), and poisoned `MeterExtremes::m_sumRaw` permanently (corrupting `avgRaw()` → value labels). Drop non-finite `value`/`peak` at entry; the last good frame stays until a finite reading arrives.

### M3 — Cross-flag option-control desync
`VfoWidget`: the global `extremesChanged`/`txMeterChanged` signals only re-pushed each flag's *rendering*, not its option *controls*, which are seeded once at build. With the selector open on two flags, changing a setting on one left the other's checkbox/combos stale. New `syncSmartMtrSettingsControls()` re-seeds the four controls from the (cached, singleton) `MeterViewController`, `QSignalBlocker`-guarded to avoid a re-broadcast loop, then re-runs `syncSmartMtrSettingsState()`. Wired to both global signals.

### M4 — Font change doesn't invalidate the cached marker layer
`SmartMtrWidget`: the static-layer cache key is only `{size, kind, dpr}`, but the cached marker glyphs are built from `font()`. Override `changeEvent` to invalidate on `FontChange`/`ApplicationFontChange`/`StyleChange` so a theme/font-size change doesn't leave stale glyphs until the next resize.

**Scope:** +75 lines across `MeterExtremes.h`, `SmartMtrWidget.{cpp,h}`, `VfoWidget.{cpp,h}`. No change to the S-meter path; FLEX behavior unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)