### PR TITLE
docs+fix(smartmtr): dead seed call, migration comment, stale extremes (#3750 L1–L3)

### DIFF
--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -14,8 +14,9 @@ namespace AetherSDR {
 //
 // Stored as a nested JSON blob under AppSettings["Display"], per the
 // nested-JSON-per-feature convention (constitution Principle V).  The legacy
-// flat key "LeanMode" is migrated into this blob on first read so existing
-// users keep their behavior.
+// flat key "LeanMode" is migrated into this blob by migrateLegacy(), called
+// once at startup (before the first read), so existing users keep their
+// behavior.
 class DisplaySettings {
 public:
     static bool leanMode() { return readObj().value("leanMode").toString("False") == "True"; }

--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -93,6 +93,11 @@ public:
             }
             if (m_window.empty()) {
                 m_hasData = false;
+                // Clear the raw min/max too (matching reset()). Current readers
+                // all gate on hasData() first, but leaving stale values here is
+                // a trap for any future reader of minRaw()/maxRaw().
+                m_minRaw = 0.0;
+                m_maxRaw = 0.0;
             } else {
                 double mn = m_window.front().raw, mx = mn;
                 for (const Sample& s : m_window) {

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -882,7 +882,9 @@ void VfoWidget::buildUI()
     m_labelDirtyClock.start();
     connect(m_smartMtrWidget, &SmartMtrWidget::repainted, this,
             &VfoWidget::onSmartMtrRepainted);
-    pushSmartMtrInput(); // seed the at-rest display
+    // No seed here: m_smartMtr is still false during buildUI, so pushSmartMtrInput()
+    // would early-return. applyMeterView() (run from the constructor) seeds the
+    // meter when the persisted choice is SmartMTR.
 
     root->addWidget(m_meterStack);
 


### PR DESCRIPTION
Addresses the three **LOW / nit** items from #3750 (SmartMTR fast-follow), all from #3723. Low-risk cleanup; grouped into one PR.

### L1 — dead no-op seed call
`VfoWidget::buildUI()` had `pushSmartMtrInput(); // seed the at-rest display`, but `m_smartMtr` is still `false` during `buildUI()`, so the gate added in #3723 early-returns — the call does nothing. The real seed is `applyMeterView()`, run from the constructor when the persisted choice is SmartMTR. Replaced the dead call with a comment pointing at where seeding happens.

### L2 — misleading migration comment
`DisplaySettings.h` claimed the legacy flat `"LeanMode"` key is "migrated into this blob **on first read**." It isn't — migration is an explicit `migrateLegacy()` call at startup; `readObj()` does no migration. Reworded so a future maintainer doesn't assume read-time migration safety.

### L3 — stale raw min/max on empty extremes window
`MeterExtremes::tick()` left `m_minRaw`/`m_maxRaw` at their previous values when the sliding window emptied (only `m_hasData` was cleared). Harmless today — every reader (`drawExtremes`, `extremeLabels`, `extremesOpacity`) gates on `hasData()`/`extremesActive()` first — but a latent trap for any future reader of `minRaw()`/`maxRaw()`. Clear them to `0.0`, matching `reset()` and the member initializers.

**Scope:** comment-only + 2 trivial lines, no behavior change. No S-meter path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)