### PR TITLE
[codex] Harden SmartMTR meter fast-follows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2286,6 +2286,13 @@ if(UNIX)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
 
+add_executable(meter_extremes_test
+    tests/meter_extremes_test.cpp
+)
+target_include_directories(meter_extremes_test PRIVATE src)
+target_link_libraries(meter_extremes_test PRIVATE Qt6::Core Qt6::Gui)
+add_test(NAME meter_extremes_test COMMAND meter_extremes_test)
+
 add_executable(async_log_writer_test
     tests/async_log_writer_test.cpp
     src/core/AsyncLogWriter.cpp

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -14,9 +14,8 @@ namespace AetherSDR {
 //
 // Stored as a nested JSON blob under AppSettings["Display"], per the
 // nested-JSON-per-feature convention (constitution Principle V).  The legacy
-// flat key "LeanMode" is migrated into this blob by migrateLegacy(), called
-// once at startup (before the first read), so existing users keep their
-// behavior.
+// flat key "LeanMode" is migrated into this blob by migrateLegacy() at startup
+// so existing users keep their behavior.
 class DisplaySettings {
 public:
     static bool leanMode() { return readObj().value("leanMode").toString("False") == "True"; }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -967,7 +967,7 @@ MainWindow::MainWindow(QWidget* parent)
     // created during startup seed their Lean button/widget correctly, then
     // apply once after construction to cover VFOs + the WAVE applet.
     // Persistence is the nested "Display" blob (Principle V); the legacy
-    // flat "LeanMode" key is migrated into it on first read.
+    // flat "LeanMode" key is migrated into it by the startup call below.
     DisplaySettings::migrateLegacy();
     m_leanMode = DisplaySettings::leanMode();
     if (m_leanMode) {

--- a/src/gui/MeterExtremes.h
+++ b/src/gui/MeterExtremes.h
@@ -56,6 +56,10 @@ public:
     // velocity. Mutually exclusive with record() — a kind switch resets() first.
     void setExternalPeak(double rawPeak)
     {
+        if (!std::isfinite(rawPeak)) {
+            reset();
+            return;
+        }
         m_useExtPeak = true;
         m_extPeakRaw = rawPeak;
         m_hasData = true;
@@ -65,6 +69,9 @@ public:
     // signal source (after clamping to the floor), only while a value is present.
     void record(double rawValue, qint64 nowMs)
     {
+        if (!std::isfinite(rawValue)) {
+            return;
+        }
         m_window.push_back({nowMs, rawValue});
         m_sumRaw += rawValue;
         m_hasData = true;
@@ -93,9 +100,10 @@ public:
             }
             if (m_window.empty()) {
                 m_hasData = false;
-                // Clear the raw min/max too (matching reset()). Current readers
-                // all gate on hasData() first, but leaving stale values here is
-                // a trap for any future reader of minRaw()/maxRaw().
+                // Clear the raw aggregates too (matching reset()). Current
+                // readers all gate on hasData() first, but leaving stale values
+                // here is a trap for any future reader of minRaw()/maxRaw().
+                m_sumRaw = 0.0;
                 m_minRaw = 0.0;
                 m_maxRaw = 0.0;
             } else {
@@ -112,12 +120,15 @@ public:
         // 2) Targets in UNITS. With no data left, glide both to the floor. In
         //    external-peak mode the trough is unused, so it targets the needle so
         //    it collapses there (mic draws no trough) without standing off.
-        const double minTgt =
+        double minTgt =
             !m_hasData      ? SmartMtrUnits::kScaleMin
             : m_useExtPeak  ? needlePosUnits
                             : mapToUnits(m_minRaw);
-        const double maxTgt =
+        double maxTgt =
             m_hasData ? mapToUnits(m_maxRaw) : SmartMtrUnits::kScaleMin;
+        if (m_useExtPeak && m_hasData && maxTgt < needlePosUnits) {
+            maxTgt = needlePosUnits;
+        }
 
         // 3) Constant-velocity slew toward each target. External-peak (mic) mode
         //    tracks tightly at the fast peak slew — the radio's peak is a live
@@ -140,27 +151,18 @@ public:
         if (m_maxPos < SmartMtrUnits::kScaleMin) m_maxPos = SmartMtrUnits::kScaleMin;
         if (m_minPos > m_maxPos) m_minPos = m_maxPos;
 
-        // Keep animating while a marker is mid-slew OR has not yet collapsed onto
-        // the needle (a peak/trough is still standing off it). The latter keeps
-        // the timer running through the whole hold->return so the window prunes
-        // and the markers slew at the timer rate — matching the original app's
-        // steady loop and avoiding a staircase clocked by the irregular packet
-        // feed. It self-terminates once min ~= max ~= needle (markers collapsed),
-        // so an idle meter still settles rather than pinning the repaint timer at
-        // full rate forever (each meter repaint over the GPU panadapter forces a
-        // costly recomposite that starves input).
-        // In external-peak (mic) mode the MAX marker is a held radio stat that
-        // sits above the needle by design, so it would "stand off" forever and
-        // pin the timer for the entire TX. Each mic packet re-arms the timer via
-        // setMeterInput (setExternalPeak keeps hasData() true), so here we only
-        // need to keep animating while a marker is actually slewing — drop the
-        // standing-off keep-alive for this mode so the meter settles between
-        // packets instead of repainting at full rate over the GPU panadapter.
-        if (m_useExtPeak)
-            return moving;
+        // Keep RX extremes animating while a marker is mid-slew OR has not yet
+        // collapsed onto the needle (a peak/trough is still standing off it).
+        // The latter keeps the timer running through the whole hold->return so
+        // the window prunes and the markers slew at the timer rate. In external
+        // peak mode, packets refresh the supplied peak; once the marker reaches
+        // that target there is no free-running decay work to do.
         const bool standingOff = (m_maxPos > needlePosUnits + kConvergeEps)
                                  || (m_minPos < needlePosUnits - kConvergeEps);
-        return moving || standingOff;
+        const bool pendingExternalSlew = m_useExtPeak
+            && (std::fabs(m_minPos - minTgt) > kConvergeEps
+                || std::fabs(m_maxPos - maxTgt) > kConvergeEps);
+        return moving || (m_useExtPeak ? pendingExternalSlew : standingOff);
     }
 
     bool hasData() const { return m_hasData; }

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -35,6 +35,29 @@ const QColor& markerColor(MarkerColor color)
     return color == MarkerColor::High ? SmartMtrColors::kMarkerHigh
                                       : SmartMtrColors::kMarkerNormal;
 }
+
+MeterInput sanitizedInput(const MeterInput& input)
+{
+    MeterInput out = input;
+    const bool validRange = std::isfinite(out.min) && std::isfinite(out.max)
+        && out.min < out.max;
+    if (!validRange) {
+        out.hasValue = false;
+        out.min = 0.0;
+        out.max = 1.0;
+    }
+    if (out.hasValue && !std::isfinite(out.value)) {
+        out.hasValue = false;
+        out.value = 0.0;
+    }
+    if (!out.hasValue) {
+        out.hasPeak = false;
+    } else if (out.hasPeak && !std::isfinite(out.peak)) {
+        out.hasPeak = false;
+        out.peak = 0.0;
+    }
+    return out;
+}
 } // namespace
 
 SmartMtrWidget::SmartMtrWidget(QWidget* parent)
@@ -98,36 +121,32 @@ void SmartMtrWidget::applyBallistics(MeterKind kind)
 
 void SmartMtrWidget::setMeterInput(const MeterInput& input)
 {
-    // A non-finite value (NaN/Inf) would survive std::clamp (both comparisons
-    // false), stick in the bar smoother so needsAnimation() never clears, and
-    // poison the extremes running sum permanently. Drop it; the last good frame
-    // stays on screen until a finite reading arrives.
-    if (input.hasValue && !std::isfinite(input.value))
-        return;
-    if (input.hasPeak && !std::isfinite(input.peak))
-        return;
-
-    const bool kindChanged = (input.kind != m_kind);
-    m_input = input;
-    m_kind = input.kind;
+    const MeterInput cleanInput = sanitizedInput(input);
+    const bool kindChanged = (cleanInput.kind != m_kind);
+    m_input = cleanInput;
+    m_kind = cleanInput.kind;
 
     // RX<->TX is a scale discontinuity (signal dBm vs mic dBFS); the extremes
     // window must not mix domains, and the bar ballistics differ per kind.
-    if (kindChanged) {
+    if (kindChanged || !m_input.hasValue) {
         m_extremes.reset();
         applyBallistics(m_kind);
+        m_lastExtremesRepaintMs = -1;
     }
 
     // Drive the extremes engine. Signal derives its min/max from a local sliding
     // window of the dBm stream; mic's peak is a separate radio-sourced stat
     // (MICPEAK over UDP), so it overrides the MAX marker directly rather than
     // synthesizing one. Skip on park (no value) or when disabled.
-    if (m_extremesEnabled && input.hasValue) {
-        if (input.kind == MeterKind::MicLevel) {
-            if (input.hasPeak)
-                m_extremes.setExternalPeak(input.peak);
+    if (m_extremesEnabled && m_input.hasValue) {
+        if (m_input.kind == MeterKind::MicLevel) {
+            if (m_input.hasPeak) {
+                m_extremes.setExternalPeak(m_input.peak);
+            } else {
+                m_extremes.reset();
+            }
         } else {
-            m_extremes.record(input.value, m_extremesClock.elapsed());
+            m_extremes.record(m_input.value, m_extremesClock.elapsed());
         }
     }
 
@@ -136,7 +155,7 @@ void SmartMtrWidget::setMeterInput(const MeterInput& input)
     // and read as "dead"; the mic now uses a snappy PPM ballistic on the live
     // level instead — see applyBallistics — with the PEAK marker still holding
     // the loud peaks.)
-    const double posUnits = indicatorPosition(input);
+    const double posUnits = indicatorPosition(m_input);
 
     // Normalise to the scale band so the ballistics are scale-independent.
     const double span = kScaleMax - kScaleMin;
@@ -144,15 +163,18 @@ void SmartMtrWidget::setMeterInput(const MeterInput& input)
         span > 0.0 ? float((posUnits - kScaleMin) / span) : 0.0f;
 
     m_smooth.setTarget(targetFrac);
-    if (kindChanged)
+    if (kindChanged || !m_input.hasValue)
         m_smooth.snapToTarget(); // snap across the discontinuity, don't glide
 
     // Keep the timer running while EITHER the bar or the extremes markers still
     // need to move (a peak can expire and slide a marker after the bar settles).
-    if ((m_smooth.needsAnimation() || (m_extremesEnabled && m_extremes.hasData()))
+    if (m_input.hasValue
+        && (m_smooth.needsAnimation() || (m_extremesEnabled && m_extremes.hasData()))
         && !m_animTimer.isActive()) {
         m_clock.restart();
         m_animTimer.start();
+    } else if (!m_input.hasValue && m_animTimer.isActive()) {
+        m_animTimer.stop();
     }
     update(); // paint the first frame promptly; the timer carries the rest
 }
@@ -288,6 +310,10 @@ void SmartMtrWidget::drawHole(QPainter& p, const SmartMtrGeometry& g) const
 
 void SmartMtrWidget::drawIndicator(QPainter& p, const SmartMtrGeometry& g) const
 {
+    if (!m_input.hasValue) {
+        return;
+    }
+
     // Bar from the scale minimum to the mapped value position, full hole height.
     // Clipped to the rounded hole so the bar's corners follow the hole's radius.
     const QRectF hole = g.rect(kHoleMargX, kHoleMargY, kHoleW, kHoleH);

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -13,6 +13,7 @@
 #include <QWidget>
 
 class QPainter;
+class QEvent;
 
 namespace AetherSDR {
 
@@ -78,7 +79,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent*) override;
-    void changeEvent(QEvent*) override;
+    void changeEvent(QEvent* event) override;
 
 private:
     // One element per method; all draw in UNITS via SmartMtrGeometry. Called

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -323,21 +323,22 @@ VfoWidget::VfoWidget(QWidget* parent)
     applyMeterView(MeterViewController::instance().smartMtr());
     connect(&MeterViewController::instance(), &MeterViewController::changed,
             this, &VfoWidget::applyMeterView);
-    // Extremes options are also global + live: re-push to this flag's SmartMTR
-    // widget whenever any flag changes them.
+    // SmartMTR options are also global + live: re-seed this flag's open controls
+    // and re-push rendering options whenever any flag changes them.
     connect(&MeterViewController::instance(), &MeterViewController::extremesChanged,
-            this, &VfoWidget::pushSmartMtrOptions);
+            this, [this]() {
+        syncSmartMtrOptionControls();
+        pushSmartMtrOptions();
+    });
     // The TX-meter choice swaps the SmartMTR input (signal <-> mic) rather than
-    // its options, so re-push the input when it changes on any flag.
+    // its options, so re-seed controls and re-push the input when it changes on
+    // any flag.
     connect(&MeterViewController::instance(), &MeterViewController::txMeterChanged,
-            this, &VfoWidget::pushSmartMtrInput);
-    // The pushes above update this flag's rendering; also re-seed its option
-    // CONTROLS so a change made on another open flag's selector doesn't leave
-    // this flag's checkbox/combos showing a stale value.
-    connect(&MeterViewController::instance(), &MeterViewController::extremesChanged,
-            this, &VfoWidget::syncSmartMtrSettingsControls);
-    connect(&MeterViewController::instance(), &MeterViewController::txMeterChanged,
-            this, &VfoWidget::syncSmartMtrSettingsControls);
+            this, [this]() {
+        syncSmartMtrOptionControls();
+        pushSmartMtrInput();
+    });
+    syncSmartMtrOptionControls();
     pushSmartMtrOptions(); // apply the persisted options to this new flag
 
     connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged,
@@ -3227,6 +3228,39 @@ void VfoWidget::syncMeterMenuButtons()
     }
 }
 
+void VfoWidget::syncSmartMtrOptionControls()
+{
+    auto& mv = MeterViewController::instance();
+    auto selectData = [](QComboBox* combo, int value) {
+        if (!combo) {
+            return;
+        }
+        const int idx = combo->findData(value);
+        if (idx >= 0 && combo->currentIndex() != idx) {
+            combo->setCurrentIndex(idx);
+        }
+    };
+
+    if (m_showExtremesChk) {
+        QSignalBlocker blocker(m_showExtremesChk);
+        m_showExtremesChk->setChecked(mv.showExtremes());
+    }
+    if (m_extremesSpeedCmb) {
+        QSignalBlocker blocker(m_extremesSpeedCmb);
+        selectData(m_extremesSpeedCmb, int(mv.extremesSpeed()));
+    }
+    if (m_showValuesCmb) {
+        QSignalBlocker blocker(m_showValuesCmb);
+        selectData(m_showValuesCmb, int(mv.showValues()));
+    }
+    if (m_txMeterCmb) {
+        QSignalBlocker blocker(m_txMeterCmb);
+        selectData(m_txMeterCmb, int(mv.txMeter()));
+    }
+
+    syncSmartMtrSettingsState();
+}
+
 // Enable/disable the SmartMTR-only options to match the current state:
 //   • everything is disabled unless the SmartMTR view is selected;
 //   • "Extremes speed" is further gated on "Show extremes" being checked;
@@ -3241,16 +3275,20 @@ void VfoWidget::syncSmartMtrSettingsState()
     // label.  #5e6e7c is ~0.45 blend of the normal text over the flag bg, so
     // 0.45 opacity reproduces that dimming on the whole row.
     constexpr double kDisabledOpacity = 0.45;
+    auto setRowOpacity = [](QGraphicsOpacityEffect* effect, bool fullStrength) {
+        if (!effect) {
+            return;
+        }
+        // Identity opacity effects can render blank row contents when multiple
+        // VFO flags are GPU-composited. Leave the effect installed only while it
+        // is actually dimming the row.
+        effect->setOpacity(fullStrength ? 1.0 : kDisabledOpacity);
+        effect->setEnabled(!fullStrength);
+    };
     const bool speedEnabled = smart && showExt;
-    if (m_extremesSpeedFade) {
-        m_extremesSpeedFade->setOpacity(speedEnabled ? 1.0 : kDisabledOpacity);
-    }
-    if (m_showValuesFade) {
-        m_showValuesFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
-    }
-    if (m_txMeterFade) {
-        m_txMeterFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
-    }
+    setRowOpacity(m_extremesSpeedFade, speedEnabled);
+    setRowOpacity(m_showValuesFade, smart);
+    setRowOpacity(m_txMeterFade, smart);
 
     if (m_showExtremesChk) {
         m_showExtremesChk->setEnabled(smart);
@@ -3291,35 +3329,6 @@ void VfoWidget::syncSmartMtrSettingsState()
     }
 }
 
-void VfoWidget::syncSmartMtrSettingsControls()
-{
-    // The meter options are global + live, but the per-flag control widgets are
-    // only seeded once at build and updated by local interaction. When another
-    // open flag changes a setting, re-seed this flag's controls from the
-    // (cached) MeterViewController so they don't show a stale value. Block
-    // signals so this re-seed doesn't echo back into the controller.
-    auto& mv = MeterViewController::instance();
-    if (m_showExtremesChk) {
-        const QSignalBlocker b(m_showExtremesChk);
-        m_showExtremesChk->setChecked(mv.showExtremes());
-    }
-    if (m_extremesSpeedCmb) {
-        const QSignalBlocker b(m_extremesSpeedCmb);
-        m_extremesSpeedCmb->setCurrentIndex(
-            m_extremesSpeedCmb->findData(int(mv.extremesSpeed())));
-    }
-    if (m_showValuesCmb) {
-        const QSignalBlocker b(m_showValuesCmb);
-        m_showValuesCmb->setCurrentIndex(
-            m_showValuesCmb->findData(int(mv.showValues())));
-    }
-    if (m_txMeterCmb) {
-        const QSignalBlocker b(m_txMeterCmb);
-        m_txMeterCmb->setCurrentIndex(m_txMeterCmb->findData(int(mv.txMeter())));
-    }
-    syncSmartMtrSettingsState();  // re-evaluate enable/disable for the new state
-}
-
 // ── Signal level ──────────────────────────────────────────────────────────────
 
 void VfoWidget::setSignalLevel(float dbm)
@@ -3352,15 +3361,16 @@ void VfoWidget::pushSmartMtrInput()
             == DisplaySettings::TxMeter::MicLevel;
     if (showMic) {
         in.kind = MeterKind::MicLevel;
+        in.hasValue = true;
         in.value = m_micDbfs;
         in.min = -40.0; // dBFS — scale start
         in.max = 0.0;   // dBFS — full scale / clip (linear scale)
         // Peak marker is the radio's separate MICPEAK stat, not a local window max.
         in.hasPeak = true;
         in.peak = m_micPeakDbfs;
-        in.hasValue = true;
     } else {
         in.kind = MeterKind::Signal;
+        in.hasValue = !usesUnavailableSignalMeter();
         in.value = m_signalDbm;
         in.min = -127.0; // dBm: S0
         in.max = -13.0;  // dBm: S9+60

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -208,6 +208,7 @@ private:
     // clicking the meter strip; syncMeterMenuButtons() reflects the choice.
     void applyMeterView(bool smartMtr);
     void syncMeterMenuButtons();
+    void syncSmartMtrOptionControls();
     void setMeterMenuOpen(bool open);  // open/close the S-Meter/SmartMTR selector
     QRect meterBarRect() const;
     void updateTxBadgeStyle(bool isTx);
@@ -323,9 +324,6 @@ private:
     // Enable/disable the SmartMTR-only options per the current meter view and
     // the "Show extremes" checkbox state (see implementation for the rules).
     void syncSmartMtrSettingsState();
-    // Re-seed this flag's option controls from the global MeterViewController
-    // (used when another open flag changes a setting), then re-evaluate state.
-    void syncSmartMtrSettingsControls();
     // Thin spacer between the meter and the tab bar, shown only while the meter
     // selector is open, to give the curved underline room below the indicator.
     QWidget* m_meterUnderlineRoom{nullptr};

--- a/tests/meter_extremes_test.cpp
+++ b/tests/meter_extremes_test.cpp
@@ -1,0 +1,108 @@
+#include "gui/MeterExtremes.h"
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+double identityUnits(double raw)
+{
+    return raw;
+}
+
+void testRecordRejectsNonFinite()
+{
+    MeterExtremes extremes;
+
+    extremes.record(std::numeric_limits<double>::quiet_NaN(), 0);
+    extremes.record(std::numeric_limits<double>::infinity(), 0);
+
+    report("record rejects non-finite samples",
+           !extremes.hasData() && extremes.avgRaw() == 0.0);
+}
+
+void testWindowExpiryClearsRawBounds()
+{
+    MeterExtremes extremes;
+    MeterExtremes::Tuning tuning;
+    tuning.windowSeconds = 0.001;
+    extremes.setTuning(tuning);
+
+    extremes.record(-90.0, 0);
+    extremes.tick(0, 8, SmartMtrUnits::kScaleMin, identityUnits);
+    const bool seeded = extremes.hasData()
+        && std::fabs(extremes.minRaw() + 90.0) < 0.001
+        && std::fabs(extremes.maxRaw() + 90.0) < 0.001;
+
+    extremes.tick(100, 8, SmartMtrUnits::kScaleMin, identityUnits);
+
+    report("expired window clears raw bounds",
+           seeded && !extremes.hasData()
+               && extremes.minRaw() == 0.0
+               && extremes.maxRaw() == 0.0
+               && extremes.avgRaw() == 0.0);
+}
+
+void testExternalPeakDoesNotAnimateJustForStandingOff()
+{
+    MeterExtremes extremes;
+
+    extremes.setExternalPeak(SmartMtrUnits::kScaleMax);
+    const bool firstTickMoving = extremes.tick(
+        0, 100, SmartMtrUnits::kScaleMin, identityUnits);
+    const bool secondTickMoving = extremes.tick(
+        100, 8, SmartMtrUnits::kScaleMin, identityUnits);
+
+    report("external peak settles after reaching target",
+           firstTickMoving && !secondTickMoving && extremes.hasData());
+}
+
+void testExternalPeakStaysAliveOnZeroElapsedTick()
+{
+    MeterExtremes extremes;
+
+    extremes.setExternalPeak(SmartMtrUnits::kScaleMax);
+
+    report("external peak zero-dt tick keeps pending slew alive",
+           extremes.tick(0, 0, SmartMtrUnits::kScaleMin, identityUnits));
+}
+
+void testExternalPeakBelowNeedleSettlesAtNeedle()
+{
+    MeterExtremes extremes;
+    const double needle = (SmartMtrUnits::kScaleMin + SmartMtrUnits::kScaleMax) / 2.0;
+
+    extremes.setExternalPeak(SmartMtrUnits::kScaleMin);
+    const bool firstTickMoving = extremes.tick(0, 100, needle, identityUnits);
+    const bool secondTickMoving = extremes.tick(100, 8, needle, identityUnits);
+
+    report("external peak below needle settles at needle",
+           firstTickMoving && !secondTickMoving
+               && std::fabs(extremes.maxPosUnits() - needle) < 0.001);
+}
+
+} // namespace
+
+int main()
+{
+    testRecordRejectsNonFinite();
+    testWindowExpiryClearsRawBounds();
+    testExternalPeakDoesNotAnimateJustForStandingOff();
+    testExternalPeakStaysAliveOnZeroElapsedTick();
+    testExternalPeakBelowNeedleSettlesAtNeedle();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #3750. This hardens the SmartMTR meter view fast-follow path: unavailable Kiwi/non-FLEX meter data now renders as no data instead of a confident S0, non-finite meter values are rejected before they can poison smoothing/extremes state, open SmartMTR option controls resync across VFO flags, and fully visible option rows bypass the identity opacity effect that could render them blank when multiple GPU-composited flags were active.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The patch adds focused MeterExtremes regression coverage for the timer/no-data edge cases and was validated with a local app build plus focused tests.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR -- -j4`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (focused `ctest --test-dir build -R '^meter_extremes_test$' --output-on-failure`; full CI pending)
- [x] Reproduction steps documented if user-reported bug
- [x] `git diff --check`
- [x] `python3 tools/check_a11y.py` exits 0 with existing warning-only findings

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
