### PR TITLE
feat(a11y): QAccessibleInterface for VfoWidget + LevelBar (#3754)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -28,6 +28,7 @@
 #include <QSlider>
 #include <QGraphicsOpacityEffect>
 #include <QAccessible>
+#include <QAccessibleWidget>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QCheckBox>
@@ -281,11 +282,74 @@ static bool likelyTxAntennaFallbackToken(const QString& token)
         || upper == QStringLiteral("XVTR");
 }
 
+// ── Accessibility ─────────────────────────────────────────────────────────────
+// The VFO flag custom-paints its chrome and, while collapsed, the slice-letter
+// and TX badges (the expanded controls are accessible child widgets). Expose a
+// Grouping with a live summary so the flag isn't opaque to AT tools — especially
+// collapsed, where the badges have no widget equivalent. (#3754)
+
+// Object name tagged on the ESC level-meter bars so the factory can recognise
+// them without LevelBar needing its own metaobject (it has no Q_OBJECT).
+static const char* const kLevelBarObjectName = "AetherSDR.LevelBar";
+
+// LevelBar is a render-only meter for the ESC combiner output; like PhaseKnob,
+// the named ESC gain/phase sliders are the accessible interface, so the bar
+// itself is decorative and returns NoRole to drop out of AT navigation.
+class LevelBarAccessible : public QAccessibleWidget {
+public:
+    explicit LevelBarAccessible(QWidget* w) : QAccessibleWidget(w) {}
+    QAccessible::Role role() const override { return QAccessible::NoRole; }
+};
+
+class VfoWidgetAccessible : public QAccessibleWidget {
+public:
+    explicit VfoWidgetAccessible(QWidget* w)
+        : QAccessibleWidget(w, QAccessible::Grouping) {}
+    QString text(QAccessible::Text t) const override
+    {
+        if (t == QAccessible::Name) {
+            if (auto* vfo = qobject_cast<VfoWidget*>(widget()))
+                return vfo->accessibleSummary();
+        }
+        return QAccessibleWidget::text(t);
+    }
+};
+
+static QAccessibleInterface* vfoAccessibleFactory(const QString& key, QObject* obj)
+{
+    if (key == QLatin1String("AetherSDR::VfoWidget"))
+        return new VfoWidgetAccessible(qobject_cast<QWidget*>(obj));
+    if (auto* w = qobject_cast<QWidget*>(obj);
+        w && w->objectName() == QLatin1String(kLevelBarObjectName))
+        return new LevelBarAccessible(w);
+    return nullptr;
+}
+
+QString VfoWidget::accessibleSummary() const
+{
+    if (!m_slice)
+        return QStringLiteral("VFO flag");
+    const QString letter = m_slice->letter();
+    QString s = letter.isEmpty() ? QStringLiteral("VFO")
+                                 : QStringLiteral("VFO slice %1").arg(letter);
+    s += QStringLiteral(", %1 MHz").arg(m_slice->frequency(), 0, 'f', 6);
+    if (m_slice->isTxSlice())
+        s += QStringLiteral(", transmit slice");
+    if (m_collapsed)
+        s += QStringLiteral(", collapsed");
+    return s;
+}
+
 // ── Construction ──────────────────────────────────────────────────────────────
 
 VfoWidget::VfoWidget(QWidget* parent)
     : QWidget(parent)
 {
+    static bool s_a11yFactoryInstalled = false;
+    if (!s_a11yFactoryInstalled) {
+        s_a11yFactoryInstalled = true;
+        QAccessible::installFactory(vfoAccessibleFactory);
+    }
     // Container scope — VFO flags are their own theming surface; inspector
     // clicks should land here, not bubble up to `spectrum`.  Lives under
     // the spectrum scope so unset tokens inherit the spectrum overrides.
@@ -1374,6 +1438,7 @@ void VfoWidget::buildTabContent()
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_escMeterLbl, "QLabel { color: {{color.accent}}; font-size: 11px; font-family: monospace; }");
         escMeterRow->addWidget(m_escMeterLbl);
         m_escMeterBar = new LevelBar(m_escLevelDbm);
+        m_escMeterBar->setObjectName(QLatin1String(kLevelBarObjectName));
         m_escMeterBar->setFixedHeight(8);
         m_escMeterBar->setFixedWidth(60);
         escMeterRow->addWidget(m_escMeterBar);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -107,6 +107,10 @@ public:
     bool isCollapsed() const { return m_collapsed; }
     void setCollapsed(bool collapsed);
 
+    // Spoken summary of this flag for AT tools (slice, frequency, TX state) —
+    // used by VfoWidgetAccessible so collapsed flags aren't opaque. (#3754)
+    QString accessibleSummary() const;
+
     // Lean render mode: drop WA_TranslucentBackground so the panel composites
     // as an opaque, cacheable layer instead of being alpha-blended over the
     // whole window every frame (the dominant idle CPU cost — see #3283).

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -107,8 +107,11 @@ public:
     bool isCollapsed() const { return m_collapsed; }
     void setCollapsed(bool collapsed);
 
-    // Spoken summary of this flag for AT tools (slice, frequency, TX state) —
-    // used by VfoWidgetAccessible so collapsed flags aren't opaque. (#3754)
+    // Spoken summary of this flag for AT tools (slice, frequency, TX state).
+    // Consumed by VfoWidgetAccessible — the QAccessibleInterface implemented
+    // for this widget in VfoWidget.cpp — so collapsed flags, whose slice/TX
+    // badges are custom-painted with no child-widget equivalent, aren't opaque
+    // to screen readers. (#3754)
     QString accessibleSummary() const;
 
     // Lean render mode: drop WA_TranslucentBackground so the panel composites


### PR DESCRIPTION
Closes #3754.

Implements `QAccessibleInterface` for the two custom-painted widgets the Qt Accessibility Static Analysis flagged (both pre-existing; #3751 surfaced them by touching the file).

## VfoWidget → `VfoWidgetAccessible` (role `Grouping`)
The VFO flag custom-paints its chrome and, **while collapsed**, the slice-letter and TX badges — which have no accessible child-widget equivalent, so a screen reader on a collapsed flag got nothing. Added a `text(QAccessible::Name)` summary built from a new `VfoWidget::accessibleSummary()`:

> *"VFO slice A, 14.225000 MHz, transmit slice, collapsed"*

Expanded-mode detail (frequency, dBm) is already announced via the child labels' `QAccessibleValueChangeEvent`s, so this fills the collapsed-mode gap and gives the group a meaningful name for navigation.

## LevelBar → `LevelBarAccessible` (`NoRole`)
`LevelBar` is the render-only ESC combiner level meter. Following the existing `PhaseKnob` precedent (whose comment states *"the named ESC phase/gain sliders are the accessible interface"*), the bar is decorative — the ESC gain/phase **sliders** carry the accessible semantics — so it returns `QAccessible::NoRole` to drop out of AT navigation. Matched by `objectName` since `LevelBar` is a `.cpp`-local class with no `Q_OBJECT` of its own.

## Notes
- Factory registered once via `QAccessible::installFactory`, mirroring `PhaseKnob.cpp`.
- API usage validated with a standalone `-fsyntax-only` compile against Qt6; follows the established a11y pattern in `docs/a11y.md`.
- Live re-announcement on TX-toggle/collapse (firing `QAccessible::NameChanged`) is a possible future enhancement — out of scope here; the summary is correct on query/navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)