### PR TITLE
fix(tci): route DAX RX audio by cached channel→TRX, resilient to transient dax=0 (#3669)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1141,16 +1141,30 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
     // Map DAX channel -> TCI TRX by the slice that owns the channel. Flex
     // slice ids are not necessarily zero-based for this client when another
     // client owns slice 0, but TCI receivers are advertised as 0..N-1.
-    int trx = std::max(0, channel - 1);
+    int trx = -1;
     int owningSliceId = -1;
     if (m_model) {
         for (auto* s : m_model->slices()) {
             if (s->daxChannel() == channel) {
                 trx = TciProtocol::tciTrxForSlice(m_model,s);
                 owningSliceId = s->sliceId();
+                m_channelTrx[channel] = trx;   // remember the resolved mapping (#3669)
                 break;
             }
         }
+    }
+    if (trx < 0) {
+        // The owning slice's DAX binding is transiently 0, so the scan above
+        // missed it: the radio re-broadcasts `dax=0` then `dax=1` during a
+        // band/mode retune, or when a second client (re)subscribes, and
+        // SliceModel zeroes m_daxChannel on the `dax=0`. Route by the last
+        // resolved TRX for this channel instead of the positional `channel-1`
+        // fallback — in a multi-receiver setup tciTrxForSlice() returns the
+        // slice's *index*, which diverges from `channel-1`, so the positional
+        // guess trips the `audioReceiver != trx` filter below and silently
+        // drops audio for the correctly-bound client (#3669). Cold start (no
+        // mapping resolved yet) keeps the legacy positional guess.
+        trx = m_channelTrx.value(channel, std::max(0, channel - 1));
     }
 
     // Check if any client has this receiver's audio enabled. A client that
@@ -2060,6 +2074,7 @@ void TciServer::rearmDaxForProfileLoad()
 
     m_tciDaxStreamIds.clear();
     m_tciDaxBorrowedChannels.clear();
+    m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3669)
     m_tciDaxSlices.clear();
 
     qCInfo(lcCat) << "TCI: profile load completed - re-arming DAX for active audio client";
@@ -2098,6 +2113,7 @@ void TciServer::releaseDaxForTci()
     }
     m_tciDaxStreamIds.clear();
     m_tciDaxBorrowedChannels.clear();
+    m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3669)
 
     // Release DAX channel assignments we made
     for (int sliceId : m_tciDaxSlices) {

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -211,6 +211,7 @@ private:
     QSet<int>         m_tciDaxSlices;   // slice IDs where we auto-assigned DAX (#1331)
     QMap<int, quint32> m_tciDaxStreamIds;      // DAX channel → stream ID created or borrowed by TCI
     QSet<int>          m_tciDaxBorrowedChannels; // channels where TCI reused an existing stream
+    QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
     QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
     QTimer*           m_daxReleaseTimer{nullptr}; // debounced DAX RX teardown
     QTimer*           m_txChronoTimer{nullptr}; // TX_CHRONO frame cadence


### PR DESCRIPTION
## Summary

Fixes #3669 (DAX-1 TCI audio silent on connect; second TCP client kills audio — FLEX-6400, 26.6.3, multi-client).

`TciServer::onDaxAudioReady()` re-derives the destination TCI receiver (`trx`) on **every** DAX audio packet by scanning `slices()` for `daxChannel()==channel`, with a positional `channel-1` fallback. That fallback is fragile, and this PR makes the routing resilient to transient slice-state corruption.

## Root cause (code-confirmed across the whole lifecycle)

1. The radio re-broadcasts `slice N dax=0` then `dax=1` during a band/mode retune **or when a second client (re)subscribes**.
2. `SliceModel::applyStatus()` zeroes `m_daxChannel` unconditionally on the `dax=0` ([SliceModel.cpp](src/models/SliceModel.cpp)) — no transient guard.
3. For that window, `onDaxAudioReady`'s scan finds no owning slice → `trx` falls back to `max(0, channel-1)` ([TciServer.cpp](src/core/TciServer.cpp)).
4. `tciTrxForSlice()` returns the slice's **index** in `slices()` ([TciProtocol.cpp](src/core/TciProtocol.cpp)).

**Why single-slice looks healthy but multi-receiver breaks:** with one receiver on slice 0, `index 0 == channel(1)-1`, so the fallback accidentally matches and audio keeps flowing. In a **multi-receiver** setup — a foreign client owns a slice, pushing our slice to a non-zero index — `channel-1` diverges from the index-based trx, the `audioReceiver != trx` filter drops the packet, and the correctly-bound client goes silent. This is #3669, and the most likely mechanism behind the "second client kills audio" report.

This was established by a full-lifecycle analysis of both support captures: the "healthy" capture (`…-205353`, CAT+DAX logging) is single-slice/single-receiver and `frames_sent` climbed 96k→4.59M continuously — it never reproduced the trigger; the `slice=-1` entries in its DAX stat lines are exactly this transient scan-miss, benign only by the index/channel-1 coincidence.

## Fix

Cache the last successfully-resolved `channel→trx` mapping (`m_channelTrx`); when the live scan transiently misses, route by the cached trx instead of the positional guess. Self-healing — the next `dax!=0` status re-resolves and refreshes the cache. **Cold start (no mapping yet) keeps the legacy positional behavior, so single-receiver setups are byte-for-byte unchanged.** Cache cleared in `releaseDaxForTci()` / `rearmDaxForProfileLoad()` alongside the channel→stream map.

+18 / −1 in `TciServer.cpp`, +1 in `TciServer.h`. `trx` is always assigned a valid value (scan → cache → `channel-1` default); null-model and cold-start paths are identical to before.

## Why this is contained (not the #3305/#3715 refactor)

The maintainer asked whether this needs the full refactor. It does **not**: #3305 (centralize `dax_rx` **stream create/remove** ownership) and #3715 (single **slice-lifecycle** authority) address the *upstream churn* that produces the transient `dax=0`. This PR hardens the **frame-routing** layer against that churn — `onDaxAudioReady`'s trx derivation is untouched by either refactor and would survive both. The `SliceModel` transient-zero is the upstream cause and is intentionally **not** changed here (suppressing the radio's `dax=0` would fight radio-authoritative state).

## Validation

- Built clean on macOS (RelWithDebInfo / Ninja), full tree incl. tests.
- Slice test suite passes: `slice_label_test`, `slice_model_letter_test`, `slice_recreate_policy_test`.
- Two unrelated **pre-existing** failures (`theme_manager_test:744`, `cwx_local_keyer_drift_test` segfault) — both in subsystems with **0 references** to TciServer/DAX; not exercised by this change (`theme_manager` has its own dedicated fix worktree).

## Regression review across the open TCI/DAX cluster

The change only alters the trx **fallback** path (when the slice scan misses); the happy path (`tciTrxForSlice`) is unchanged. Reviewed against the open cluster — no regressions, and it strengthens the multi-receiver cases:
- **#1807** (full-duplex/satellite, 2 slices): routing hardened; happy path unchanged.
- **#3366** (Win11 TCI): different cluster (consumption/watchdog) — unaffected.
- **#2885 / #2360 / #2392 / #3730** (TX level/ALC/split/meters): TX-side — unaffected.
- **#3595** (spots on both waterfalls): spot routing, not DAX-audio routing — unaffected.
- **#3305 / #3715**: complementary; this fix does not conflict with either refactor.

## Honesty / scope

- The routing **mechanism** is code-confirmed; the multi-receiver **field break** is established by code analysis — the existing captures were single-receiver, so a combined-logging capture (`cat`+`connection` ON, sustained 2 slices with a foreign-owned slice) would give the final on-hardware confirmation. Requested on the issue.
- No unit test covers `onDaxAudioReady` routing today (a gap noted for follow-up).
- The agent triage's two earlier hypotheses (registration race; foreign-owner `sliceRemoved` eviction) were **contradicted** by the captures — registration succeeded cleanly and no reclaim/eviction fired; this PR targets the actually-observed mechanism instead.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
