### PR TITLE
fix(smartmtr): disable identity opacity effect so option rows don't render blank

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3242,15 +3242,20 @@ void VfoWidget::syncSmartMtrSettingsState()
     // 0.45 opacity reproduces that dimming on the whole row.
     constexpr double kDisabledOpacity = 0.45;
     const bool speedEnabled = smart && showExt;
-    if (m_extremesSpeedFade) {
-        m_extremesSpeedFade->setOpacity(speedEnabled ? 1.0 : kDisabledOpacity);
-    }
-    if (m_showValuesFade) {
-        m_showValuesFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
-    }
-    if (m_txMeterFade) {
-        m_txMeterFade->setOpacity(smart ? 1.0 : kDisabledOpacity);
-    }
+    // An identity opacity effect (opacity 1.0) can render blank row contents
+    // when multiple VFO flags are GPU-composited (#3695). Disable the effect
+    // entirely while it is at full strength so the row renders directly; keep it
+    // installed only when it is actually dimming the row. (#3750)
+    auto setRowOpacity = [](QGraphicsOpacityEffect* effect, bool fullStrength) {
+        if (!effect) {
+            return;
+        }
+        effect->setOpacity(fullStrength ? 1.0 : kDisabledOpacity);
+        effect->setEnabled(!fullStrength);
+    };
+    setRowOpacity(m_extremesSpeedFade, speedEnabled);
+    setRowOpacity(m_showValuesFade, smart);
+    setRowOpacity(m_txMeterFade, smart);
 
     if (m_showExtremesChk) {
         m_showExtremesChk->setEnabled(smart);


### PR DESCRIPTION
## Summary

Disables the identity `QGraphicsOpacityEffect` on fully-enabled SmartMTR option rows so they don't render blank when multiple VFO flags are GPU-composited.

A fully-enabled option row keeps its `QGraphicsOpacityEffect` at opacity `1.0` (identity). With the GPU-composited slice flags from #3695, an identity opacity effect can render the row's contents blank. The fix disables the effect entirely while it is at full strength (a disabled `QGraphicsOpacityEffect` is a no-op, so the row paints directly) and keeps it installed only while it is actually dimming the row.

## Provenance

This is the net-new fix extracted from #3757. The remainder of that PR re-implemented SmartMTR `#3750` hardening that already landed via #3751 (H1), #3752 (M1–M4), and #3753 (L1–L3); #3757 is being closed in favor of this focused change to avoid re-churning already-merged code. Part of #3750.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable — visual (open the SmartMTR option panel with multiple flags up; rows render, not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
