### PR TITLE
fix(waterfall): independently themable LIVE chip (red live / grey history)

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -43,6 +43,8 @@
           "accent.warning": "{color.amber.500}",
           "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
+          "waterfall.live":    "{color.red.500}",
+          "waterfall.history": "{color.gray.500}",
           "text": {
             "primary":   "{color.gray.200}",
             "secondary": "{color.gray.400}",

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -44,6 +44,8 @@
           "accent.warning": "{color.amber.500}",
           "accent.danger":  "{color.red.500}",
           "accent.success": "{color.green.500}",
+          "waterfall.live":    "{color.red.500}",
+          "waterfall.history": "{color.gray.300}",
           "text": {
             "primary":   "{color.gray.50}",
             "secondary": "{color.gray.100}",

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -372,6 +372,12 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("color.accent.danger",   QString("#ff4d4d"));
     m_tokens.insert("color.accent.success",  QString("#4dd87a"));
 
+    // Waterfall LIVE chip — dedicated so the live/history indicator can be
+    // recolored independently of the shared danger/label semantics (#3744).
+    // Defaults mirror the prior shared values (red live, grey history).
+    m_tokens.insert("color.waterfall.live",    QString("#ff4d4d"));
+    m_tokens.insert("color.waterfall.history", QString("#506070"));
+
     // Text (4 tiers — label and disabled distinct for Phase 4 contrast
     // tuning).  text.primary aligned to the dominant codebase body-text
     // value (#c8d8e8, 367 refs across applets / dialogs / labels).

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -9916,7 +9916,13 @@ void SpectrumWidget::drawTimeScale(QPainter& p, const QRect& wfRect)
 
     const QRect liveRect = waterfallLiveButtonRect(wfRect);
     p.setPen(AetherSDR::ThemeManager::instance().color("color.meter.bar.fill"));
-    p.setBrush(m_wfLive ? AetherSDR::ThemeManager::instance().color("color.text.label") : AetherSDR::ThemeManager::instance().color("color.accent.danger"));
+    // Dedicated, independently-themable tokens for the waterfall LIVE chip
+    // (decoupled from the shared accent.danger / text.label semantics, #3744).
+    // Red while live, grey while viewing history; recolor either via the theme
+    // editor's color.waterfall.live / color.waterfall.history tokens.
+    p.setBrush(m_wfLive
+        ? AetherSDR::ThemeManager::instance().color("color.waterfall.live")
+        : AetherSDR::ThemeManager::instance().color("color.waterfall.history"));
     p.drawRoundedRect(liveRect, 3, 3);
 
     QFont liveFont = p.font();


### PR DESCRIPTION
## Summary

Fixes the reversed waterfall **LIVE** chip colors (#3744) *and* decouples them from the shared `accent.danger` / `text.label` semantic tokens so the indicator can be recolored independently.

- New dedicated tokens **`color.waterfall.live`** (red) and **`color.waterfall.history`** (grey), registered in the ThemeManager defaults (fallback) and both preset themes (`default-dark.json` / `default-light.json`, referencing each theme's `red.500` / `gray.500` palette so appearance is preserved).
- `SpectrumWidget::drawTimeScale` now paints the chip **red while live, grey while viewing history** — the correct "currently live = red" convention from #3744 — via the new tokens.
- Both tokens are editable like any `color.*` token in the Theme Editor, so the live/history colors can be set independently of danger/label.

## Why supersede #3745

#3745 was a one-line color swap reusing `accent.danger`/`text.label`. Per review, the live indicator shouldn't be coupled to the danger/label semantics (recoloring "danger" would recolor the LIVE chip). This PR lands the same visible fix with dedicated, independently-themable tokens. Closing #3745 in favor of this; credit to @jbettik for the report (#3744) and original fix.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Both theme preset JSONs validate
- [ ] Visual: LIVE chip red while live, grey when scrolled into history; recolor `color.waterfall.live` in the Theme Editor and confirm only the chip changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
