### PR TITLE
fix: give the idle MOX button a distinct accent color so it reads as the transmit button

### DIFF
--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -232,7 +232,14 @@ void TxApplet::buildUI()
 
         m_moxBtn = new QPushButton("MOX");
         markTxKeying(m_moxBtn);    // manual transmit (PTT) — keys TX (#3646)
-        m_moxBtn->setStyleSheet(btnStyle);
+        const char* moxIdleStyle =
+            "QPushButton { background: #1a3a5a; border: 1px solid #d08020; "
+            "border-radius: 3px; color: #f0c890; font-size: 10px; font-weight: bold; "
+            "padding: 2px; }"
+            "QPushButton:hover { background: #204060; border: 1px solid #e09030; color: #ffd8a0; }"
+            "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
+            "border: 1px solid #2a3040; }";
+        m_moxBtn->setStyleSheet(moxIdleStyle);
         m_moxBtn->setCheckable(true);
         m_moxBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_moxBtn->setFixedHeight(22);
@@ -421,10 +428,12 @@ void TxApplet::setTransmitModel(TransmitModel* model)
             ? "QPushButton { background: #cc2222; border: 1px solid #ff4444; "
               "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; "
               "padding: 2px; }"
-            : "QPushButton { background: #1a3a5a; border: 1px solid #205070; "
-              "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; "
+            : "QPushButton { background: #1a3a5a; border: 1px solid #d08020; "
+              "border-radius: 3px; color: #f0c890; font-size: 10px; font-weight: bold; "
               "padding: 2px; }"
-              "QPushButton:hover { background: #204060; }");
+              "QPushButton:hover { background: #204060; border: 1px solid #e09030; color: #ffd8a0; }"
+              "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
+              "border: 1px solid #2a3040; }");
         m_updatingFromModel = false;
     });
 


### PR DESCRIPTION
## Summary

Gives the idle MOX button a distinct amber accent border and text so it reads as the primary transmit control, instead of sharing the neutral blue `btnStyle` with its TUNE / ATU / MEM neighbors. Before this change the MOX button only became visually distinct (solid red) while transmitting; at idle it was indistinguishable from the other three buttons. The change touches only `src/gui/TxApplet.cpp` in two MOX-specific spots: the idle style at button construction now uses a dedicated `moxIdleStyle` (amber border `#d08020` / amber text `#f0c890`), and the non-transmitting branch of the `moxChanged` handler reverts MOX to that same amber accent rather than the neutral blue style. The solid-red active-TX appearance, the other three buttons, and all model/protocol paths are unchanged.

The issue also floated an optional "customize applet buttons" idea; that is a larger separate theming feature and is intentionally out of scope here.

Refs #3663

## Constitution principle honored

Principle VI — AetherSDR Never Transmits Without Operator Intent: this is an appearance-only change with no effect on transmit keying or interlock state. Principle IV — Every Contribution Is Clean-Room: the new stylesheet is original, not derived from any proprietary binary.

## Test plan

- [x] Local build passes (`cmake --build build`) — CSS-string-only change in one file; the new `moxIdleStyle` C-string literal is well-formed and consumed on the next line.
- [ ] Behavior verified on a real radio if applicable — visual styling only; no radio required.
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug — at idle the MOX button now renders with its amber accent, visually separable from TUNE/ATU/MEM; pressing MOX shows the existing solid red; releasing TX returns it to the amber idle style.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — n/a, no meter UI touched
- [ ] Documentation updated if user-visible behavior changed — no docs cover per-button styling
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a

AI was used for assistance.
