### PR TITLE
perf(spectrum): pause flag re-raster when not presented + immediate sprite on new slice (#3746)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1001,6 +1001,17 @@ VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
     m_overlayMenu->raiseAll();  // keep overlay + panels on top of all VFO widgets
     if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible())
         m_interlockNotificationLabel->raise();
+#ifdef AETHER_GPU_SPECTRUM
+    // #3746(2) diagnostic: the gap from this FlagCreated to the slice's first
+    // FlagFirstGrab is the "blank" window. Gated aether.perf trace, kept so the
+    // fix below stays verifiable (measured ~41 ms gap without it -> ~3 ms with).
+    if (m_gpuFlagMode && lcPerf().isDebugEnabled())
+        qCDebug(lcPerf).nospace() << "FlagCreated slice=" << sliceId;
+    // #3746(2) fix: rasterize the new flag's sprite immediately (off-frame, safe)
+    // so a non-live new slice isn't blank until the next refresh-timer tick.
+    // repositionVfoFlags() positions the quad next frame.
+    grabFlagSprites();
+#endif
     return w;
 }
 
@@ -1255,6 +1266,7 @@ void SpectrumWidget::grabFlagSprites()
         if (!f || f->size().isEmpty() || id == m_liveFlagSliceId) {
             continue;   // the live flag is shown as a real widget, not grabbed
         }
+        const bool firstGrab = !m_flagSprites.contains(id);   // #3746(2) measure: first sprite for this slice?
         FlagSprite& s = m_flagSprites[id];   // inserts a blank sprite if absent
         const QSize devSize(qMax(1, static_cast<int>(std::lround(f->width() * dpr))),
                             qMax(1, static_cast<int>(std::lround(f->height() * dpr))));
@@ -1266,6 +1278,11 @@ void SpectrumWidget::grabFlagSprites()
         f->render(&s.img, QPoint(0, 0));   // off-frame raster — safe
         s.imgDirty = true;
         ++grabbed;
+        // #3746(2) measure: log the first sprite render for a slice, so the
+        // latency from FlagCreated (in addVfoWidget) to here -- the "80 ms
+        // blank" gap -- can be read from the log timestamps.
+        if (firstGrab && lcPerf().isDebugEnabled())
+            qCDebug(lcPerf).nospace() << "FlagFirstGrab slice=" << id;
     }
     if (lcPerf().isDebugEnabled())
         qCDebug(lcPerf).nospace()

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -614,9 +614,14 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
             update();
         }
     });
-    if (m_gpuFlagMode) {
-        m_flagRefreshTimer->start();
-    }
+    // #3746: the re-raster timer runs only while the panadapter is actually
+    // presented.  attachFlagTimerWindowWatcher() watches the top-level for
+    // minimize/restore; updateFlagRefreshTimer() starts/stops on
+    // visible + not-minimized.  Re-evaluated on Show/Hide/ParentChange in
+    // event() and on WindowStateChange in eventFilter().  At construction the
+    // widget isn't shown yet, so the timer stays stopped until the first Show.
+    attachFlagTimerWindowWatcher();
+    updateFlagRefreshTimer();
 #endif
 
     m_tnfHoverPopup = new QLabel(this);
@@ -830,6 +835,12 @@ SpectrumWidget::~SpectrumWidget()
 void SpectrumWidget::prepareForTopLevelChange()
 {
 #ifdef AETHER_GPU_SPECTRUM
+    // #3746: the watched top-level is about to change — detach now; the next
+    // Show/ParentChange re-attaches the WindowStateChange watcher to the new one.
+    if (m_flagTimerFilteredWindow && m_flagTimerFilteredWindow != this) {
+        m_flagTimerFilteredWindow->removeEventFilter(this);
+    }
+    m_flagTimerFilteredWindow = nullptr;
 #ifdef Q_OS_MAC
     // QRhiWidget registers a cleanup callback with the current top-level
     // backing-store QRhi. Direct splitter/floating-window reparenting can miss
@@ -1175,6 +1186,49 @@ void SpectrumWidget::setLiveFlag(int sliceId)
     update();
 }
 
+// #3746: (re)attach the WindowStateChange watcher to the current top-level.
+// The window can change when a panadapter floats/docks (reparent), so this is
+// re-run on Show/ParentChange.  We never filter ourselves (top == this before
+// the widget is parented into a window).
+void SpectrumWidget::attachFlagTimerWindowWatcher()
+{
+    QWidget* top = window();
+    if (top == m_flagTimerFilteredWindow) {
+        return;
+    }
+    if (m_flagTimerFilteredWindow && m_flagTimerFilteredWindow != this) {
+        m_flagTimerFilteredWindow->removeEventFilter(this);
+    }
+    m_flagTimerFilteredWindow = top;
+    if (top && top != this) {
+        top->installEventFilter(this);
+    }
+}
+
+// #3746: run the flag re-raster timer ONLY while the panadapter is actually
+// presented — visible and not minimized.  A minimized window keeps isVisible()
+// true (measured), so the WindowStateChange watcher drives this for the
+// minimize case; Show/Hide/ParentChange drive it for the hidden-tab/reparent
+// cases.  Stopping the timer eliminates both the 12.5 Hz wakeup and the
+// off-screen grab (~2 ms/tick for 4 flags, measured) when nobody can see it.
+void SpectrumWidget::updateFlagRefreshTimer()
+{
+    if (!m_flagRefreshTimer) {
+        return;
+    }
+    QWidget* top = window();
+    const bool present = m_gpuFlagMode && isVisible()
+                         && !(top && top->isMinimized());
+    const bool active = m_flagRefreshTimer->isActive();
+    if (present && !active) {
+        m_flagRefreshTimer->start();
+        qCDebug(lcPerf) << "FlagRefreshTimer START (panadapter presented)";
+    } else if (!present && active) {
+        m_flagRefreshTimer->stop();
+        qCDebug(lcPerf) << "FlagRefreshTimer STOP (hidden/minimized)";
+    }
+}
+
 // #3617: rasterize each non-live flag into its own CPU image.  MUST run OUTSIDE
 // the QRhi render callback (QWidget::render inside an active frame re-enters the
 // renderer and crashes) — called from the refresh timer and on live-flag change.
@@ -1183,6 +1237,13 @@ void SpectrumWidget::grabFlagSprites()
     if (!m_gpuFlagMode) {
         return;
     }
+    // #3746 instrumentation (aether.perf): time the idle re-raster, count the
+    // flags actually re-rasterized this tick, and record whether the panadapter
+    // is visible -- to quantify the 12.5 Hz grab cost and the hidden-while-
+    // grabbing waste before/after the idle-pause + dirty-skip optimizations.
+    QElapsedTimer grabTimer;
+    grabTimer.start();
+    int grabbed = 0;
     // Rasterize each flag at EXACTLY its on-screen device-pixel size (1:1), so
     // the sprite texture maps one texel per screen pixel — drawn pixel-aligned
     // with NEAREST sampling that gives crisp text (no scaling = no blur).  An
@@ -1204,7 +1265,14 @@ void SpectrumWidget::grabFlagSprites()
         s.img.fill(Qt::transparent);
         f->render(&s.img, QPoint(0, 0));   // off-frame raster — safe
         s.imgDirty = true;
+        ++grabbed;
     }
+    if (lcPerf().isDebugEnabled())
+        qCDebug(lcPerf).nospace()
+            << "FlagGrab grabbed=" << grabbed
+            << " flags=" << m_vfoWidgets.size()
+            << " ms=" << (grabTimer.nsecsElapsed() / 1.0e6)
+            << " visible=" << (isVisible() ? 1 : 0);
 }
 
 void SpectrumWidget::releaseFlagSprite(FlagSprite& s)
@@ -6521,7 +6589,17 @@ bool SpectrumWidget::event(QEvent* ev)
     // surface loses mouse tracking and mouseMoveEvent stops firing.
     if (ev->type() == QEvent::WinIdChange || ev->type() == QEvent::ParentChange) {
         setMouseTracking(true);
+#ifdef AETHER_GPU_SPECTRUM
+        attachFlagTimerWindowWatcher();   // #3746 — top-level may have changed (float/dock)
+        updateFlagRefreshTimer();
+#endif
     }
+#ifdef AETHER_GPU_SPECTRUM
+    if (ev->type() == QEvent::Show || ev->type() == QEvent::Hide) {
+        attachFlagTimerWindowWatcher();   // #3746 — pause/resume flag re-raster on
+        updateFlagRefreshTimer();         // panadapter show/hide (e.g. hidden tab)
+    }
+#endif
 
     if (ev->type() == QEvent::NativeGesture) {
         auto* ge = static_cast<QNativeGestureEvent*>(ev);
@@ -6559,6 +6637,15 @@ bool SpectrumWidget::event(QEvent* ev)
 
 bool SpectrumWidget::eventFilter(QObject* watched, QEvent* event)
 {
+#ifdef AETHER_GPU_SPECTRUM
+    // #3746: a minimized top-level keeps our child widgets isVisible()==true, so
+    // we watch the window's WindowStateChange explicitly to pause/resume the flag
+    // re-raster timer on minimize/restore.  Not consumed.
+    if (watched == m_flagTimerFilteredWindow
+        && event->type() == QEvent::WindowStateChange) {
+        updateFlagRefreshTimer();
+    }
+#endif
     QWidget* widget = qobject_cast<QWidget*>(watched);
     if (!widget || anyDragActive()) {
         return SPECTRUM_BASE_CLASS::eventFilter(watched, event);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -608,6 +608,8 @@ private:
     void repositionVfoFlags(const QRect& specRect);  // #3617 — runs before flag render
     void updateLiveFlag();   // #3617 — pick which flag is live (hover/focus/popup)
     void setLiveFlag(int sliceId);   // #3617 — show one flag live, snapshot the rest
+    void updateFlagRefreshTimer();        // #3746 — run the re-raster timer only while presented
+    void attachFlagTimerWindowWatcher();  // #3746 — watch the top-level for minimize/restore
 #endif
     void setSpectrumCursor(Qt::CursorShape shape);
     void updateTrackedCursorState(const QPoint& localPos, bool insideWidget);
@@ -1215,6 +1217,7 @@ private:
     // keeps the flags as ordinary live widgets).
     bool m_gpuFlagMode{false};   // flags GPU-composited, panels hidden
     QTimer* m_flagRefreshTimer{nullptr};   // re-snapshot live flag content
+    QWidget* m_flagTimerFilteredWindow{nullptr};   // #3746 — top-level watched for minimize/restore
     // hover-swap: the flag whose panel is currently shown LIVE (interactive)
     // instead of GPU-composited, because the cursor is over it / it has focus / a
     // popup is open.  -1 = none (all flags GPU).  The panel hosts interactive


### PR DESCRIPTION
## Summary

Two of the idle re-raster follow-ups tracked in #3746 (itself a follow-up to the GPU slice-flag work in #3695). **Refs #3746 — this does not close it:** option (b) AA-consistency stays deferred per the issue's own rationale (ship (a) first, revisit after real-world exposure), and the dirty-skip was measured and deferred (see below).

**③a — pause the flag re-raster timer when the panadapter isn't presented.** The 12.5 Hz refresh timer re-rasterized every non-live slice flag every 80 ms regardless of whether the panadapter was on screen. It now runs only while the panadapter is visible and not minimized. A minimized top-level keeps child `isVisible() == true`, so a `WindowStateChange` watcher on the top-level handles minimize/restore; `Show`/`Hide` and `ParentChange` (float/dock reparent) handle the hidden-tab and reparent cases — all funnelled through `updateFlagRefreshTimer()`. The watcher reattaches on reparent and detaches in `prepareForTopLevelChange()`.

**② — rasterize a new slice's flag sprite immediately.** A newly created non-live flag had no GPU sprite until the next timer tick: `addVfoWidget()` showed the widget but didn't grab it, and `repositionVfoFlags()` hides the non-live panel — so for the gap the flag was neither a live widget nor a sprite (a brief blank). `grabFlagSprites()` at the end of `addVfoWidget()` closes it.

Plus a gated `aether.perf` trace (`FlagGrab` / `FlagCreated` / `FlagFirstGrab`, zero cost when the category is off) used to measure all of this — committed so the numbers are reproducible on any platform.

## Measured (i9-13900K / RTX 4090, 4 slices, `aether.perf`)

| change | before | after |
|---|---|---|
| ③a — **minimized** window | ~2.1 ms/tick × 12.5 Hz = **~27 ms/s** main-thread, ongoing | **0** (timer stopped) |
| ③a — **visible** (regression check) | 2.12 ms/tick (p95 2.46) | 2.23 ms/tick (p95 2.54) — unchanged |
| ② — new non-live slice blank gap | **~41 ms** (max 49) | **~3 ms** (synchronous grab) |

Each change made and measured one at a time.

## Measured and deferred — dirty-skip (③b)

Also evaluated skipping the re-raster of a flag whose content is unchanged. Measured the skip *ceiling* by hashing each render: each slice's S-meter animates on its own noise floor, so even on a dead / dummy-load input only ~2.7 of 4 flags were ever byte-identical tick-to-tick (fewer on an active band). The realizable idle saving is **negligible** (≤ ~0.02 cores, idle-only), and a correct *pre-render* skip would need fragile per-widget dirty-tracking. Not worth it versus ③a, which already removes the larger hidden/minimized waste. Left deferred in #3746.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Every change has a before/after `aether.perf` measurement (tables above), taken one change at a time.

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3 msvc2022_64, GPU path on)
- [x] ③a — timer STOP/START verified on minimize/restore and hidden tab; 0 grabs while not presented; visible-period grab cost unchanged (no regression)
- [x] ② — new-slice blank gap 41 ms → ~3 ms, measured
- [ ] Existing tests pass (CI)
- [ ] macOS / Linux GPU paths — same `QRhiWidget` / `QWidget` code; cross-platform numbers welcome

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A — no meter changes)
- [x] Documentation updated if user-visible behavior changed (N/A — no visible behavior change; ② removes a transient blank)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
