### PR TITLE
fix(smartmtr): render extremes labels + meter selector in GPU flag sprites

### DIFF
--- a/src/gui/ComboStyle.h
+++ b/src/gui/ComboStyle.h
@@ -66,6 +66,12 @@ inline QString comboStyleTemplate()
         " color: {{color.text.primary}};"
         " border: 1px solid {{color.background.2}};"
         " padding: 2px 2px 2px 4px; border-radius: 2px; }"
+        // Disabled combos must read as disabled — the base rule sets an explicit
+        // colour, which otherwise overrides Qt's native disabled greying. This is
+        // also render()-compatible (unlike a QGraphicsEffect), so a disabled combo
+        // stays dimmed when a widget is rasterized into an image (GPU flag sprites).
+        "QComboBox:disabled { color: {{color.text.secondary}};"
+        " border: 1px solid {{color.background.1}}; }"
         "QComboBox::drop-down { border: none; width: 14px; }"
         "QComboBox::down-arrow { image: url(%1); width: 8px; height: 6px; }"
         "QComboBox QAbstractItemView { background: {{color.background.1}};"

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -598,6 +598,8 @@ QVector<SmartMtrWidget::ExtremeMarker> SmartMtrWidget::extremeLabels() const
         const double opacity = extremesOpacity();
         if (opacity < 0.02)
             return out;
+        // Same opacity as the triangle markers (drawExtremes) so they fade and
+        // disappear together.
         // MAX (peak) — both kinds.
         out.push_back(marker(m_extremes.maxRaw(), m_extremes.maxPosUnits(), opacity, true));
         // MIN (trough) — signal only.

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -3507,8 +3507,15 @@ void VfoWidget::onSmartMtrRepainted()
 void VfoWidget::drawSmartMtrLabels(QPainter& p) const
 {
     using namespace SmartMtrUnits;
+    // Don't gate on m_smartMtrWidget->isVisible(): in the default GPU flag mode
+    // the flag QWidget is hidden (setVisible(false)) and drawn as a grabbed
+    // sprite, so the in-meter triangle markers ride along in that sprite but
+    // isVisible() is false — which used to skip these overlay-drawn value labels
+    // entirely (they only appeared on the brief "live"/hover frames). Gate on the
+    // meter having a real size instead — the same condition the flag sprite is
+    // drawn under — so the labels track the markers in both GPU and software modes.
     if (!m_smartMtrWidget || !m_smartMtr || m_collapsed
-        || !m_smartMtrWidget->isVisible())
+        || m_smartMtrWidget->size().isEmpty())
         return;
     const auto labels = m_smartMtrWidget->extremeLabels();
     if (labels.isEmpty())

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -1044,8 +1044,13 @@ void VfoWidget::buildUI()
     // Label preceding a select control, on the same row as its combo.
     auto makeOptLabel = [](const QString& text) {
         auto* lbl = new QLabel(text);
+        // :disabled dims the label when its row is disabled — a render()-compatible
+        // replacement for the old QGraphicsOpacityEffect (which QWidget::render()
+        // can't rasterize, so it blanked these rows in GPU flag sprites). #5e6e7c is
+        // ~0.45 of the normal text over the flag background.
         lbl->setStyleSheet("QLabel { background: transparent; border: none; "
-                           "color: #c8d8e8; font-size: 12px; }");
+                           "color: #c8d8e8; font-size: 12px; }"
+                           "QLabel:disabled { color: #5e6e7c; }");
         return lbl;
     };
 
@@ -1082,8 +1087,7 @@ void VfoWidget::buildUI()
         m_extremesSpeedCmb->findData(int(DS::extremesSpeed())));
     AetherSDR::applyComboStyle(m_extremesSpeedCmb);
     speedLayout->addWidget(m_extremesSpeedCmb, 1);
-    m_extremesSpeedFade = new QGraphicsOpacityEffect(speedRow);
-    speedRow->setGraphicsEffect(m_extremesSpeedFade);
+    m_speedRow = speedRow;  // disabled as a unit → label + combo dim via :disabled
     meterMenuOuter->addWidget(speedRow);
 
     meterMenuOuter->addWidget(makeSeparator());
@@ -1103,8 +1107,7 @@ void VfoWidget::buildUI()
         m_showValuesCmb->findData(int(DS::showValues())));
     AetherSDR::applyComboStyle(m_showValuesCmb);
     valuesLayout->addWidget(m_showValuesCmb, 1);
-    m_showValuesFade = new QGraphicsOpacityEffect(valuesRow);
-    valuesRow->setGraphicsEffect(m_showValuesFade);
+    m_valuesRow = valuesRow;
     meterMenuOuter->addWidget(valuesRow);
 
     meterMenuOuter->addWidget(makeSeparator());
@@ -1124,8 +1127,7 @@ void VfoWidget::buildUI()
     m_txMeterCmb->setCurrentIndex(m_txMeterCmb->findData(int(DS::txMeter())));
     AetherSDR::applyComboStyle(m_txMeterCmb);
     txMeterLayout->addWidget(m_txMeterCmb, 1);
-    m_txMeterFade = new QGraphicsOpacityEffect(txMeterRow);
-    txMeterRow->setGraphicsEffect(m_txMeterFade);
+    m_txMeterRow = txMeterRow;
     meterMenuOuter->addWidget(txMeterRow);
 
     // Persist + re-evaluate enable/disable rules on change.  Toggling "Show
@@ -2466,6 +2468,7 @@ void VfoWidget::setMeterMenuOpen(bool open)
     if (!m_meterMenuRow) {
         return;
     }
+    m_meterMenuOpen = open;
     m_meterMenuRow->setVisible(open);
     // The underline-room spacer tracks the menu: shown only while open so the
     // closed view stays pixel-exact. (#SmartMTR)
@@ -3113,7 +3116,7 @@ void VfoWidget::paintEvent(QPaintEvent* event)
     // tab-active accent (#00b4d8).  Unlike the straight tab underline, this one
     // is a flat line whose ends hook gently upward (a shallow concave-up curve)
     // for a distinct, finished look. (#SmartMTR)
-    if (m_meterStack && m_meterMenuRow && m_meterMenuRow->isVisible()) {
+    if (m_meterStack && m_meterMenuRow && m_meterMenuOpen) {
         const QRect g = m_meterStack->geometry();
         // Baseline below the content actually shown: the S-meter's scale labels
         // overflow the 22px strip, so anchor below them; SmartMTR is contained,
@@ -3316,25 +3319,20 @@ void VfoWidget::syncSmartMtrSettingsState()
     const bool smart = m_smartMtr;  // options apply to SmartMTR only
     const bool showExt = m_showExtremesChk && m_showExtremesChk->isChecked();
 
-    // Dim disabled select rows (label + combo) to match the disabled-checkbox
-    // label.  #5e6e7c is ~0.45 blend of the normal text over the flag bg, so
-    // 0.45 opacity reproduces that dimming on the whole row.
-    constexpr double kDisabledOpacity = 0.45;
+    // Disable inapplicable select rows as a unit: the label + combo dim via their
+    // :disabled stylesheet (render()-compatible, so they stay dimmed rather than
+    // blank when the flag is rasterized into a GPU sprite — unlike the old
+    // QGraphicsOpacityEffect, which render() can't draw).
     const bool speedEnabled = smart && showExt;
-    // An identity opacity effect (opacity 1.0) can render blank row contents
-    // when multiple VFO flags are GPU-composited (#3695). Disable the effect
-    // entirely while it is at full strength so the row renders directly; keep it
-    // installed only when it is actually dimming the row. (#3750)
-    auto setRowOpacity = [](QGraphicsOpacityEffect* effect, bool fullStrength) {
-        if (!effect) {
-            return;
-        }
-        effect->setOpacity(fullStrength ? 1.0 : kDisabledOpacity);
-        effect->setEnabled(!fullStrength);
-    };
-    setRowOpacity(m_extremesSpeedFade, speedEnabled);
-    setRowOpacity(m_showValuesFade, smart);
-    setRowOpacity(m_txMeterFade, smart);
+    if (m_speedRow) {
+        m_speedRow->setEnabled(speedEnabled);
+    }
+    if (m_valuesRow) {
+        m_valuesRow->setEnabled(smart);
+    }
+    if (m_txMeterRow) {
+        m_txMeterRow->setEnabled(smart);
+    }
 
     if (m_showExtremesChk) {
         m_showExtremesChk->setEnabled(smart);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -310,6 +310,12 @@ private:
     // Inline selector row revealed by clicking the meter strip (not a popup),
     // shown between the meter and the tab bar.
     QWidget* m_meterMenuRow{nullptr};
+    // Explicit open-state for the selector. The paintEvent underline gates on
+    // this rather than m_meterMenuRow->isVisible(): in GPU flag mode the flag is
+    // hidden and rasterized into a sprite, where the child's isVisible() reads
+    // false even with the selector open — which dropped the underline from the
+    // sprite. The selector is one of the controls that should stay visible.
+    bool m_meterMenuOpen{false};
     QPushButton* m_sMeterOptBtn{nullptr};
     QPushButton* m_smartMtrOptBtn{nullptr};
     // SmartMTR-only display options, shown vertically below the selector
@@ -325,9 +331,12 @@ private:
     // row is disabled so the disabled state is obvious (the custom combo
     // stylesheet has no :disabled variant).  Matched to the disabled-checkbox
     // label dimming.
-    QGraphicsOpacityEffect* m_extremesSpeedFade{nullptr};
-    QGraphicsOpacityEffect* m_showValuesFade{nullptr};
-    QGraphicsOpacityEffect* m_txMeterFade{nullptr};
+    // The three SmartMTR option rows (label + combo). Disabled as a unit when the
+    // option doesn't apply; the label/combo dim via their :disabled stylesheet —
+    // render()-compatible, so they stay dimmed (not blank) in GPU flag sprites.
+    QWidget* m_speedRow{nullptr};
+    QWidget* m_valuesRow{nullptr};
+    QWidget* m_txMeterRow{nullptr};
     // Enable/disable the SmartMTR-only options per the current meter view and
     // the "Show extremes" checkbox state (see implementation for the rules).
     void syncSmartMtrSettingsState();

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -327,10 +327,6 @@ private:
     // Which meter to show while transmitting: None (stay on RX signal) or Mic
     // Level. Disabled while the standard S-meter is selected.
     QComboBox* m_txMeterCmb{nullptr};
-    // Opacity effects over each select row (label + combo), dimmed when the
-    // row is disabled so the disabled state is obvious (the custom combo
-    // stylesheet has no :disabled variant).  Matched to the disabled-checkbox
-    // label dimming.
     // The three SmartMTR option rows (label + combo). Disabled as a unit when the
     // option doesn't apply; the label/combo dim via their :disabled stylesheet —
     // render()-compatible, so they stay dimmed (not blank) in GPU flag sprites.


### PR DESCRIPTION
Closes #3762.

Two GPU-flag-sprite rendering bugs in the SmartMTR meter view (from #3723). When the cursor leaves a VFO flag it's rasterized into a static GPU sprite via `QWidget::render()`, and two things didn't survive that path.

## 1. Extremes value labels never drew (#3762) — `37a05526`
`drawSmartMtrLabels()` gated on `m_smartMtrWidget->isVisible()`, which is false in GPU flag mode (the flag QWidget is hidden and drawn as a sprite). The triangle markers ride along inside the grabbed sprite, but the value numbers are drawn separately in the spectrum overlay and were skipped — so the min/max numbers appeared only on the brief "live"/hover frames, or not at all. Gate on the meter having a real size instead (the same condition the flag sprite is drawn under). Labels use the same `extremesOpacity()` as the markers, so they fade/disappear together.

## 2. Meter selector vanished from the sprite — `87e73757`
`QWidget::render()` can't draw widgets carrying a `QGraphicsEffect`. The selector dimmed its option rows with `QGraphicsOpacityEffect` and the underline gated on the (hidden) row's `isVisible()`, so the option combos and the underline disappeared from the sprite — unlike tab underlines / filter buttons, which stay. Made the selector render-compatible:

- the underline gates on an explicit `m_meterMenuOpen` flag, not `isVisible()`;
- the option rows drop the opacity effects and dim via `:disabled` stylesheet rules, disabled as a unit, so combos + labels stay visible **and** keep their disabled dimming in the sprite.

Effect-based controls that are *meant* to disappear in the sprite (e.g. the DSP filter-level slider) keep their `QGraphicsOpacityEffect` and are unaffected.

### Note for reviewer
The `QComboBox:disabled` rule lives in the shared combo template (`ComboStyle.h`), so disabled combos dim app-wide. Today the base rule sets an explicit colour that overrides Qt's native disabled greying, so disabled combos render as if enabled — this corrects that latent inconsistency. Small and additive, but flagging it since it's not SmartMTR-scoped.

## Test
macOS, against a FlexRadio (6000-series). Built clean; verified by hand: value labels track the markers in the sprite; selector + underline stay visible and correctly dimmed when inapplicable; DSP NRS level slider still disappears as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
