### PR TITLE
fix(tci): clear DAX channel→TRX cache on disconnect teardown (#3766)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -218,6 +218,7 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 }
                 m_tciDaxStreamIds.clear();
                 m_tciDaxBorrowedChannels.clear();
+                m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3766)
                 // Also drop the slice-assignment bookkeeping: slices are being
                 // destroyed with the connection, and a releaseDaxForTci() that
                 // runs later (e.g. the debounced grace timer firing after a


### PR DESCRIPTION
## Summary

Closes #3766. Adds the missing third cache-clear for `m_channelTrx` (the DAX channel→TRX routing cache introduced in #3759).

#3759 clears the cache in `rearmDaxForProfileLoad()` and `releaseDaxForTci()` but not in the `connectionStateChanged(false)` disconnect handler — which already tears down the three sibling DAX maps (`m_tciDaxStreamIds` / `m_tciDaxBorrowedChannels` / `m_tciDaxSlices`). Per #3759's own invariant ("routing cache stale once the channel→stream map is torn down"), the disconnect path should clear it too: on a disconnect→reconnect where the slice topology differs, the cached `channel→trx` (a slice **index**) could be consulted while stale for the transient window before the first `dax!=0` re-resolves. Low impact (self-heals; channels bounded 1–4), but it closes the 2-of-3 inconsistency.

One line, alongside the existing sibling clears.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Behavior verified on a real radio if applicable — multi-receiver disconnect/reconnect; audio routes correctly after reconnect with changed slice topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)
