### PR TITLE
feat(theme): make MOX idle accent independently themable (follows #3763)

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -45,6 +45,10 @@
           "accent.success": "{color.green.500}",
           "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.500}",
+          "tx.mox.border":       "#d08020",
+          "tx.mox.text":         "#f0c890",
+          "tx.mox.border.hover": "#e09030",
+          "tx.mox.text.hover":   "#ffd8a0",
           "text": {
             "primary":   "{color.gray.200}",
             "secondary": "{color.gray.400}",

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -46,6 +46,10 @@
           "accent.success": "{color.green.500}",
           "waterfall.live":    "{color.red.500}",
           "waterfall.history": "{color.gray.300}",
+          "tx.mox.border":       "#d08020",
+          "tx.mox.text":         "#f0c890",
+          "tx.mox.border.hover": "#e09030",
+          "tx.mox.text.hover":   "#ffd8a0",
           "text": {
             "primary":   "{color.gray.50}",
             "secondary": "{color.gray.100}",

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -378,6 +378,15 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("color.waterfall.live",    QString("#ff4d4d"));
     m_tokens.insert("color.waterfall.history", QString("#506070"));
 
+    // MOX idle accent — dedicated so the "this is the transmit button" amber
+    // can be recolored independently of the shared button styling (#3663).
+    // Defaults mirror the prior hardcoded literals; the same values seed both
+    // presets, so the appearance is theme-agnostic exactly as before.
+    m_tokens.insert("color.tx.mox.border",       QString("#d08020"));
+    m_tokens.insert("color.tx.mox.text",         QString("#f0c890"));
+    m_tokens.insert("color.tx.mox.border.hover", QString("#e09030"));
+    m_tokens.insert("color.tx.mox.text.hover",   QString("#ffd8a0"));
+
     // Text (4 tiers — label and disabled distinct for Phase 4 contrast
     // tuning).  text.primary aligned to the dominant codebase body-text
     // value (#c8d8e8, 367 refs across applets / dialogs / labels).

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -24,6 +24,21 @@
 
 namespace AetherSDR {
 
+// MOX idle "this is the transmit button" accent — amber border/text, distinct
+// from the neutral btnStyle of its TUNE/ATU/MEM neighbors (#3663).  Tokenized
+// (color.tx.mox.*) so the accent is editable in the Theme Editor, mirroring the
+// waterfall LIVE chip (#3761).  Shared between construction and the moxChanged
+// return-to-idle branch so the two can't drift; background / hover-background /
+// disabled colors stay literal (structural, shared with the neighbor buttons).
+static const char* const kMoxIdleStyle =
+    "QPushButton { background: #1a3a5a; border: 1px solid {{color.tx.mox.border}}; "
+    "border-radius: 3px; color: {{color.tx.mox.text}}; font-size: 10px; font-weight: bold; "
+    "padding: 2px; }"
+    "QPushButton:hover { background: #204060; border: 1px solid {{color.tx.mox.border.hover}}; "
+    "color: {{color.tx.mox.text.hover}}; }"
+    "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
+    "border: 1px solid #2a3040; }";
+
 
 
 // ── Styled indicator label (small coloured-dot + text) ──────────────────────
@@ -232,14 +247,7 @@ void TxApplet::buildUI()
 
         m_moxBtn = new QPushButton("MOX");
         markTxKeying(m_moxBtn);    // manual transmit (PTT) — keys TX (#3646)
-        const char* moxIdleStyle =
-            "QPushButton { background: #1a3a5a; border: 1px solid #d08020; "
-            "border-radius: 3px; color: #f0c890; font-size: 10px; font-weight: bold; "
-            "padding: 2px; }"
-            "QPushButton:hover { background: #204060; border: 1px solid #e09030; color: #ffd8a0; }"
-            "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
-            "border: 1px solid #2a3040; }";
-        m_moxBtn->setStyleSheet(moxIdleStyle);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(m_moxBtn, kMoxIdleStyle);
         m_moxBtn->setCheckable(true);
         m_moxBtn->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
         m_moxBtn->setFixedHeight(22);
@@ -424,16 +432,18 @@ void TxApplet::setTransmitModel(TransmitModel* model)
     connect(m_model, &TransmitModel::moxChanged, this, [this](bool tx) {
         m_updatingFromModel = true;
         m_moxBtn->setChecked(tx);
-        m_moxBtn->setStyleSheet(tx
-            ? "QPushButton { background: #cc2222; border: 1px solid #ff4444; "
-              "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; "
-              "padding: 2px; }"
-            : "QPushButton { background: #1a3a5a; border: 1px solid #d08020; "
-              "border-radius: 3px; color: #f0c890; font-size: 10px; font-weight: bold; "
-              "padding: 2px; }"
-              "QPushButton:hover { background: #204060; border: 1px solid #e09030; color: #ffd8a0; }"
-              "QPushButton:disabled { background-color: #1a1a2a; color: #556070; "
-              "border: 1px solid #2a3040; }");
+        // Both branches go through applyStyleSheet so the tracked template
+        // matches the current visual state — otherwise a Theme Editor change
+        // mid-transmit would re-resolve the stale idle template over the red.
+        // Active red stays literal (byte-identical to the prior appearance).
+        if (tx) {
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_moxBtn,
+                "QPushButton { background: #cc2222; border: 1px solid #ff4444; "
+                "border-radius: 3px; color: #ffffff; font-size: 10px; font-weight: bold; "
+                "padding: 2px; }");
+        } else {
+            AetherSDR::ThemeManager::instance().applyStyleSheet(m_moxBtn, kMoxIdleStyle);
+        }
         m_updatingFromModel = false;
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #3763, mirroring the waterfall LIVE chip (#3761). #3763 gave the idle MOX button a distinct amber accent so it reads as the primary transmit control — but with hardcoded hex literals duplicated across its two styling sites. This tokenizes that accent behind dedicated `color.tx.mox.*` tokens so it becomes **editable in the Theme Editor**:

| Token | Default | Role |
|---|---|---|
| `color.tx.mox.border` | `#d08020` | idle amber border |
| `color.tx.mox.text` | `#f0c890` | idle amber text |
| `color.tx.mox.border.hover` | `#e09030` | hover border |
| `color.tx.mox.text.hover` | `#ffd8a0` | hover text |

### What changed

- Both MOX styling sites (construction + the `moxChanged` return-to-idle branch) now share a single `kMoxIdleStyle` template via `ThemeManager::applyStyleSheet()`, which also removes the **duplicated-literal drift risk** the #3763 review flagged.
- The **active-TX red branch** is converted from `setStyleSheet()` to `applyStyleSheet()` as well. Its template stays byte-identical literal hex, but routing it through the tracked path fixes a latent bug: a Theme Editor recolor *mid-transmit* would otherwise re-resolve the stale idle template over the active red. (The TUNE button already uses `applyStyleSheet` for both states for exactly this reason.)
- Seed defaults (`ThemeManager::seedBuiltinDefaults`) and **both** preset JSONs carry the same literal values the buttons used before. The buttons don't respond to theme today (hardcoded hex), so seeding both presets identically preserves the rendered appearance exactly — only the editability is new.

Background / hover-background / disabled colors stay literal (structural, shared with the neutral TUNE/ATU/MEM `btnStyle`); only the amber **accent** that defines MOX's identity is tokenized — the same focused scope as #3761.

## Constitution

- **Principle VI** — appearance-only; no transmit-keying, interlock, or model path touched.
- **Principle IV** — tokens and templates are original.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Both preset JSONs validate (`json.load`)
- [ ] Visual: idle MOX renders amber identically to #3763; pressing MOX still shows solid red; releasing returns to amber; recoloring `color.tx.mox.border` in the Theme Editor moves only the MOX accent (and updates live, including while transmitting)

Refs #3663. Follows #3763, #3761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
