### PR TITLE
fix(spectrum): QPointer the flag-timer window watcher (#3769)

### DIFF
--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -8,6 +8,7 @@
 #include <QMap>
 #include <QImage>
 #include <QColor>
+#include <QPointer>
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QTimer>
@@ -1217,7 +1218,7 @@ private:
     // keeps the flags as ordinary live widgets).
     bool m_gpuFlagMode{false};   // flags GPU-composited, panels hidden
     QTimer* m_flagRefreshTimer{nullptr};   // re-snapshot live flag content
-    QWidget* m_flagTimerFilteredWindow{nullptr};   // #3746 — top-level watched for minimize/restore
+    QPointer<QWidget> m_flagTimerFilteredWindow;   // #3746/#3769 — top-level watched for minimize/restore (QPointer: auto-nulls if the window is destroyed out from under us)
     // hover-swap: the flag whose panel is currently shown LIVE (interactive)
     // instead of GPU-composited, because the cursor is over it / it has focus / a
     // popup is open.  -1 = none (all flags GPU).  The panel hosts interactive


### PR DESCRIPTION
## Summary

Closes #3769. Defensive hardening raised in the #3764 review.

`SpectrumWidget::m_flagTimerFilteredWindow` — the top-level window watched for minimize/restore (added in #3764 for the #3746 idle-pause) — was a raw `QWidget*`. It's safe on today's teardown paths: `prepareForTopLevelChange()` detaches the event filter and nulls it, and Qt auto-removes the filter when either object is destroyed. But the `removeEventFilter()` calls in `attachFlagTimerWindowWatcher()` and `prepareForTopLevelChange()` would be UB if a future code path ever destroyed the watched window *without* first routing through `prepareForTopLevelChange()` — the raw pointer would dangle non-null and pass the `if (m_flagTimerFilteredWindow && ...)` guard.

`QPointer<QWidget>` fixes that for ~zero cost: a destroyed window reads back as null, so the guarded `removeEventFilter()` calls become automatic no-ops.

## What changed

- `src/gui/SpectrumWidget.h` — `m_flagTimerFilteredWindow` is now `QPointer<QWidget>`; added `#include <QPointer>`.
- No `.cpp` changes: every site (`== window()`, `!= this`, `= top`, `= nullptr`, `->removeEventFilter`, `watched == ...`) works unchanged via QPointer's implicit conversion to `QWidget*`.

No behavior change — purely a dangling-pointer safety improvement.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`) — all comparison/assignment sites compile unchanged
- [ ] Existing tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
