### PR TITLE
refactor(vfo): m_meterMenuOpen as meter-selector open-state source of truth (#3773)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -522,7 +522,7 @@ void VfoWidget::mousePressEvent(QMouseEvent* ev)
     if (ev->button() == Qt::LeftButton && m_meterStack
         && m_meterStack->geometry().contains(ev->pos())) {
         if (m_meterMenuRow) {
-            setMeterMenuOpen(!m_meterMenuRow->isVisible());
+            setMeterMenuOpen(!m_meterMenuOpen);   // #3773 — m_meterMenuOpen is the open-state source of truth
         }
         return;
     }
@@ -2511,7 +2511,7 @@ void VfoWidget::showTab(int index)
         m_tabStack->setCurrentIndex(index);
         m_tabStack->show();
         // Mutual exclusion: opening a tab closes the meter selector.
-        if (m_meterMenuRow && m_meterMenuRow->isVisible()) {
+        if (m_meterMenuOpen) {   // #3773 — single source of truth (the row may be hidden mid-sprite)
             setMeterMenuOpen(false);
         }
     }


### PR DESCRIPTION
## Summary

Closes #3773. Consistency follow-up to #3771.

#3771 introduced `m_meterMenuOpen` as the explicit open-state for the SmartMTR meter selector and switched the `paintEvent` underline onto it (the child `m_meterMenuRow->isVisible()` reads false while the flag is hidden and rasterized into a GPU sprite). This retires the two remaining `m_meterMenuRow->isVisible()` reads of the same logical open-state:

- [VfoWidget.cpp:525](src/gui/VfoWidget.cpp#L525) — meter-strip click-to-toggle → `setMeterMenuOpen(!m_meterMenuOpen)`
- [VfoWidget.cpp:2514](src/gui/VfoWidget.cpp#L2514) — open-a-tab-closes-the-selector → `if (m_meterMenuOpen)`

Both are live-flag interaction paths, so `isVisible()` was accurate there and there is **no behavior change** — this just makes `m_meterMenuOpen` the single source of truth so the two reads can't ever disagree with the flag the way `paintEvent` did.

The null-guard dropped at the tab path is safe: `setMeterMenuOpen()` early-returns on a null `m_meterMenuRow`, and `m_meterMenuOpen` is only set true *after* that guard, so a true value implies the row exists.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [ ] Existing tests pass (CI)
- [ ] Manual: meter-strip click toggles the selector; opening a tab still closes it; underline unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
