### PR TITLE
perf(spectrum): skip overlay re-bake on cursor move when no readout shown

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5121,7 +5121,15 @@ void SpectrumWidget::updateTrackedCursorState(const QPoint& localPos, bool insid
         }
     }
 
-    if (m_cursorPos != oldCursorPos
+    // A bare cursor-position change only changes the static overlay when the
+    // cursor-frequency readout (#726) or a tune guide is actually drawn there.
+    // With both off (the default) re-baking on every mouse-move produces a
+    // byte-identical overlay and needlessly defeats the GPU overlay-upload cache
+    // (#719) — measured ~6 ms/frame of pure waste while the cursor moves over the
+    // panadapter. TNF-hover and tune-guide-visibility changes are genuine content
+    // changes and still invalidate unconditionally.
+    const bool cursorReadoutShown = m_showCursorFreq || m_tuneGuideVisible;
+    if ((m_cursorPos != oldCursorPos && cursorReadoutShown)
         || m_hoveredTnfId != oldHoveredTnfId
         || m_tuneGuideVisible != oldTuneGuideVisible) {
         markOverlayDirty();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -282,7 +282,7 @@ public:
     bool bandPlanShowSpots() const { return m_bandPlanShowSpots; }
     void setBandPlanManager(class BandPlanManager* mgr);
     void setSingleClickTune(bool on) { m_singleClickTune = on; }
-    void setShowCursorFreq(bool on) { m_showCursorFreq = on; update(); }
+    void setShowCursorFreq(bool on) { m_showCursorFreq = on; markOverlayDirty(); }
     bool showCursorFreq() const { return m_showCursorFreq; }
     void setShowFpsMeters(bool on);
     bool showFpsMeters() const { return m_showFpsMeters; }


### PR DESCRIPTION
## Summary

Fixes #3779.

`updateTrackedCursorState()` called `markOverlayDirty()` on **every** cursor-position change over the panadapter, which re-bakes the entire static overlay (band plan, freq/dBm/time scales, spot/slice/TNF markers, SWR sweep) and re-uploads the static + background framebuffer-sized overlay textures. But the only static-overlay content that depends on `m_cursorPos` is the cursor-frequency readout (#726) and the tune-guide line — both **off by default**. With them off the re-baked overlay is byte-identical, so moving the mouse re-rastered and re-uploaded the whole overlay every frame for nothing, defeating the GPU overlay-upload cache added for macOS in #719.

**Fix:** gate the bare cursor-position term on `(m_showCursorFreq || m_tuneGuideVisible)`. TNF-hover and tune-guide-visibility changes are genuine content changes and still invalidate unconditionally — so the readouts still track the cursor when enabled.

Also routes `setShowCursorFreq()` through `markOverlayDirty()` instead of `update()` (mirroring the existing `setShowTuneGuides()`), so toggling the readout off re-bakes immediately on the GPU path. Without this, gating the cursor-move dirty would reintroduce #952 (the cursor-frequency label persisting after it's switched off), which previously relied on the next cursor-move re-bake to clear it.

## Measurements

i9-13900K / RTX 4090, GPU path, 2 panadapters, dummy load, cursor-freq + tune-guides OFF (default); gated `aether.perf` plus a temporary static-rebake counter (added to measure, reverted before commit). Stimulus: real mouse moving continuously over the panadapter.

| condition | static overlay re-bakes /s | renderP95 (ms) | overlay uploads /s |
|---|---|---|---|
| idle (both) | 0 | 0.3 | 44 *(flag sprites)* |
| **moving — before** | ~55 (every frame) | **6.2** | ~150 |
| **moving — after** | **0** | **0.3** | 44 |

~20× render-time reduction during mouse motion; the win grows with overlay content (spots / SWR sweep). **Regression check (readout active):** with tune guides enabled, the re-bake correctly returns (~55/s while moving) so the guide tracks the cursor — verified visually ("works flawlessly") and in the counter.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Before/after measured one variable at a time behind the gated `aether.perf` category (table above), including the readout-active regression check. **Principle VIII — Evidence Over Assertion** (the root cause was confirmed by instrumented measurement, not static reasoning alone — an early "noise-floor churn" hypothesis was disproven by the data).

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3, GPU path on)
- [x] Behavior verified on a real radio / dummy load — measured before/after; readout-active path re-checked (tune guides on → re-bake returns, guide tracks cursor)
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented in the linked issue
- [ ] macOS / Linux: same `QRhiWidget` overlay-cache path; this restores #719's intended caching — cross-platform numbers welcome

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A — no meter changes)
- [x] Documentation updated if user-visible behavior changed (N/A — removes wasted work; no visible behavior change with defaults, and #952's toggle-off clear is hardened)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
