### PR TITLE
perf(spectrum): reuse GPU FFT-trace vertex scratch buffers + guard 1-bin spectrum

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -7941,8 +7941,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
         // Generate FFT spectrum vertices with baked colors
         const QVector<float>& fftBins = displaySpectrumBins();
-        if (!fftBins.isEmpty() && m_fftLineVbo && m_fftFillVbo) {
-            const int n = qMin(fftBins.size(), kMaxFftBins);
+        const int n = qMin(fftBins.size(), kMaxFftBins);
+        // n >= 2 also guards the 1/(n-1) position step and the central-difference
+        // normal (pts[i±1]) below against a degenerate 1-bin spectrum.
+        if (n >= 2 && m_fftLineVbo && m_fftFillVbo) {
             const float minDbm = m_refLevel - m_dynamicRange;
             const float maxDbm = m_refLevel;
             const float range = maxDbm - minDbm;
@@ -7978,14 +7980,18 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             };
 
             // Line vertices: 2N × (x, y, r, g, b, a) — triangle strip expansion
-            // for variable-width lines on GPU (LineStrip is fixed at 1px)
-            QVector<float> lineVerts(n * 2 * kFftVertStride);
+            // for variable-width lines on GPU (LineStrip is fixed at 1px).
+            // Reused member scratch; resize() keeps capacity so steady state is
+            // alloc-free (no per-frame heap churn on the GUI thread).
+            m_fftLineScratch.resize(n * 2 * kFftVertStride);
+            QVector<float>& lineVerts = m_fftLineScratch;
             // Fill vertices: 2N × (x, y, r, g, b, a)
-            QVector<float> fillVerts(n * 2 * kFftVertStride);
+            m_fftFillScratch.resize(n * 2 * kFftVertStride);
+            QVector<float>& fillVerts = m_fftFillScratch;
 
             // Pre-compute positions for normal calculation
-            struct Pt { float x, y; };
-            QVector<Pt> pts(n);
+            m_fftPtScratch.resize(n);
+            QVector<FftScratchPt>& pts = m_fftPtScratch;
             for (int i = 0; i < n; ++i) {
                 pts[i].x = 2.0f * i / (n - 1) - 1.0f;
                 float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
@@ -8175,8 +8181,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
     // Draw FFT spectrum — viewport restricted to spectrum rect
     const QVector<float>& fftDrawBins = displaySpectrumBins();
-    if (m_fftFillPipeline && m_fftLinePipeline && !fftDrawBins.isEmpty()) {
-        const int n = qMin(fftDrawBins.size(), kMaxFftBins);
+    const int n = qMin(fftDrawBins.size(), kMaxFftBins);
+    if (n >= 2 && m_fftFillPipeline && m_fftLinePipeline) {
         float specVpX = static_cast<float>(specRect.x()) * dpr;
         float specVpY = static_cast<float>(h - specRect.bottom() - 1) * dpr;
         float specVpW = static_cast<float>(specRect.width()) * dpr;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1308,6 +1308,14 @@ private:
     QRhiBuffer* m_fftFillVbo{nullptr};    // dynamic, 2N × (vec2 pos + vec4 color)
     static constexpr int kMaxFftBins = 8192;
     static constexpr int kFftVertStride = 6; // x, y, r, g, b, a
+    // Reused per-frame scratch for GPU FFT-trace vertex generation — avoids a
+    // heap (re)alloc of up to 2*kMaxFftBins*kFftVertStride floats every frame on
+    // the GUI thread (renderGpuFrame). resize() keeps capacity, so steady state
+    // is alloc-free.
+    struct FftScratchPt { float x, y; };
+    QVector<float> m_fftLineScratch;
+    QVector<float> m_fftFillScratch;
+    QVector<FftScratchPt> m_fftPtScratch;
 #endif
 
     // Mark the static overlay for repaint and schedule a frame update.


### PR DESCRIPTION
## Summary

Fixes #3781.

Two low-risk hardening changes to the GPU FFT-trace vertex generation in `renderGpuFrame()`:

1. **Reuse vertex scratch buffers across frames.** The line/fill vertex arrays (up to `2*kMaxFftBins*kFftVertStride` floats each) and the point array were allocated and freed every frame — up to ~850 KB of heap alloc+free per frame on the GUI thread. Hoisted to reused members (`m_fftLineScratch` / `m_fftFillScratch` / `m_fftPtScratch`); `resize()` keeps capacity, so steady state is allocation-free. Output is mechanically identical (every element is overwritten each frame as before).

2. **Guard `n >= 2`.** For a 1-bin spectrum the generator divides by `(n - 1)` and reads `pts[1]` out of bounds (central-difference normal). `n` is always ≫ 2 in practice; this is defensive boundary validation. Applied to both the generation and draw blocks.

## Measurements

renderP95 unchanged at 0.3 ms (i9-13900K / RTX 4090, GPU path) — the allocation was already sub-millisecond, so this is **not** a frame-time win, reported honestly. The value is removing per-frame GUI-thread heap traffic + closing the degenerate-input UB.

A parallel per-row allocation in `updateWaterfallRow()` was considered and deliberately left alone: `m_prevTileScanline = scanline` shares the buffer into a persistent member each row, so a member-hoist would detach (re-allocate) on the next `resize()` regardless — zero reuse — and `wfUpdateP95` is 0.1 ms for the whole function. Not worth the COW/aliasing risk.

## Constitution principle honored

**Principle VII — Untrusted Input Is Validated At The Boundary** (the `n >= 2` guard validates the incoming bin count before indexing). **Principle XI — Fixes Are Demonstrated** (measured before/after; reported as within-noise rather than overstated).

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3, GPU path on)
- [x] FFT trace renders correctly after the change (visual check; metrics unchanged, no regression)
- [ ] Existing tests pass (CI)
- [x] No behavior change — same vertices generated each frame

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A)
- [x] Documentation updated if user-visible behavior changed (N/A — no visible change)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
