### PR TITLE
refactor(spectrum): remove dead m_overlayDynamic image

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -7295,9 +7295,6 @@ void SpectrumWidget::initOverlayPipeline()
 
     m_overlayStatic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
     m_overlayStatic.setDevicePixelRatio(dpr);
-    m_overlayDynamic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
-    m_overlayDynamic.setDevicePixelRatio(dpr);
-    m_overlayDynamic.fill(Qt::transparent);
 
     // Background-image layer — parallel texture + SRB so the same overlay
     // pipeline can paint a separate quad BEFORE the FFT pass.  The image
@@ -7581,9 +7578,6 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         if (m_overlayStatic.size() != QSize(pw, ph)) {
             m_overlayStatic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
             m_overlayStatic.setDevicePixelRatio(dpr);
-            m_overlayDynamic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
-            m_overlayDynamic.setDevicePixelRatio(dpr);
-            m_overlayDynamic.fill(Qt::transparent);
             m_ovGpuTex->setPixelSize(QSize(pw, ph));
             m_ovGpuTex->create();
             m_ovSrb->setBindings({

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1260,7 +1260,6 @@ private:
     QRhiTexture* m_ovGpuTex{nullptr};
     QRhiSampler* m_ovSampler{nullptr};
     QImage m_overlayStatic;     // grid, band plan, scales, markers — drawn ABOVE FFT
-    QImage m_overlayDynamic;    // FFT spectrum — repainted every frame
     bool m_overlayStaticDirty{true};
     bool m_overlayNeedsUpload{true};
 


### PR DESCRIPTION
## Summary

Fixes #3783.

Removes the dead `m_overlayDynamic` member. It is a full-framebuffer-sized `QImage(Format_RGBA8888_Premultiplied)` allocated in `resetGpuResources()` and re-allocated on every resize, but never painted, uploaded, or drawn — the only references are its declaration and six allocation/setup lines.

It is vestigial from the original QRhi spectrum bring-up (#391 / #698), where the FFT was to be rasterized into it (hence the stale comment *"FFT spectrum — repainted every frame"*); the FFT trace later moved to the GPU triangle-strip VBO path (#1116), orphaning the image. Removing it frees a framebuffer-sized RGBA8888 allocation (several MB at 4K / Retina) per panadapter, plus the same on every resize, with no behavior change — the overlay renders via `m_overlayStatic` and `m_overlayBg`, neither touched.

## Constitution principle honored

**Principle IX — Surface Only What Survives** (removes dead state that no code path consumes).

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3, GPU path on)
- [x] App launches and renders normally after removal — `renderP95` unchanged (~0.3 ms), no crash/assert; `grep` confirms zero remaining references
- [ ] Existing tests pass (CI)
- [x] No behavior change

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A)
- [x] Documentation updated if user-visible behavior changed (N/A)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
