### PR TITLE
fix(spectrum): Pan Lock stands down during slice drag, recenters on release

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -8293,6 +8293,11 @@ void MainWindow::setPanFollow(bool on)
 {
     disconnect(m_panFollowConn);
     disconnect(m_panFollowSliceConn);
+    m_panFollowActive = on;
+    // Toggling Pan Lock clears any drag-suppress state — a defensive reset in
+    // case a slice drag was ever abandoned without a mouse-release (e.g. the pane
+    // was removed mid-drag), which would otherwise leave Pan Follow suppressed.
+    m_sliceDragInProgress = false;
 
     if (!on) return;
 
@@ -8309,30 +8314,9 @@ void MainWindow::setPanFollow(bool on)
             return;
         }
 
-        auto centerPan = [this, s]() {
-            const QString panId = s->panId();
-            if (panId.isEmpty()) return;
-            // WFM holds its pan fixed: Doppler rides the demodulator's NCO,
-            // and recentring underneath it would desync the NCO offset until
-            // the next slice retune. While WFM is active on this pan, WFM
-            // wins and Pan Follow stands down. (Precedence is a UX call —
-            // flagged for maintainer review in the WFM PR.)
-            if (m_wfmSliceId >= 0) {
-                auto* wfmSlice = m_radioModel.slice(m_wfmSliceId);
-                if (wfmSlice && wfmSlice->panId() == panId) return;
-            }
-            const double freq = s->frequency();
-            auto* pan = m_radioModel.panadapter(panId);
-            if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
-            const QString freqStr = QString::number(freq, 'f', 6);
-            if (pan) pan->applyPanStatus({{"center", freqStr}});
-            m_radioModel.sendCommand(
-                QString("display pan set %1 center=%2").arg(panId, freqStr));
-        };
-
-        centerPan();
+        recenterPanFollowOnSlice0();
         m_panFollowConn = connect(s, &SliceModel::frequencyChanged,
-                                  this, [centerPan](double) { centerPan(); });
+                                  this, [this](double) { recenterPanFollowOnSlice0(); });
     };
 
     attachToSlice0();
@@ -8342,6 +8326,38 @@ void MainWindow::setPanFollow(bool on)
         this, [this, attachToSlice0](SliceModel* s) {
             if (s && s->sliceId() == 0) attachToSlice0();
         });
+}
+
+// Pan Follow ("Pan Lock"): recenter the panadapter on Slice A (slice 0). Called
+// on enable, on every slice-0 frequency change, and once when a slice drag ends.
+void MainWindow::recenterPanFollowOnSlice0()
+{
+    if (!m_panFollowActive) return;   // Pan Lock off — never move the pan
+    // A slice is being dragged (in-window tune or edge auto-pan): the drag owns
+    // the pan center, so stand down rather than fight it with a per-tick recenter
+    // (that conflict caused ~0.33 MHz pan lurches + jumping). The drag-end handler
+    // calls this once with the flag cleared, so Pan Lock re-asserts on release.
+    // (user-reported)
+    if (m_sliceDragInProgress) return;
+    auto* s = m_radioModel.slice(0);
+    if (!s) return;
+    const QString panId = s->panId();
+    if (panId.isEmpty()) return;
+    // WFM holds its pan fixed: Doppler rides the demodulator's NCO, and
+    // recentring underneath it would desync the NCO offset until the next slice
+    // retune. While WFM is active on this pan, WFM wins and Pan Follow stands
+    // down. (Precedence is a UX call — flagged for maintainer review in the WFM PR.)
+    if (m_wfmSliceId >= 0) {
+        auto* wfmSlice = m_radioModel.slice(m_wfmSliceId);
+        if (wfmSlice && wfmSlice->panId() == panId) return;
+    }
+    const double freq = s->frequency();
+    auto* pan = m_radioModel.panadapter(panId);
+    if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+    const QString freqStr = QString::number(freq, 'f', 6);
+    if (pan) pan->applyPanStatus({{"center", freqStr}});
+    m_radioModel.sendCommand(
+        QString("display pan set %1 center=%2").arg(panId, freqStr));
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1099,7 +1099,15 @@ private:
     // Pan Follow — keeps the panadapter centered on Slice A frequency
     QMetaObject::Connection m_panFollowConn;
     QMetaObject::Connection m_panFollowSliceConn;
+    bool m_panFollowActive{false};   // Pan Lock / Pan-Follows-VFO toggle state
+    // While a slice is being dragged (in-window tune OR edge auto-pan) Pan Follow
+    // stands down so it doesn't fight the drag with per-tick recenters — that
+    // conflict caused ~0.33 MHz pan lurches/jumping, and suppressing it only
+    // mid-tick made Pan Lock appear to "fall out" after the drag. The drag-end
+    // handler recenters once so Pan Lock re-asserts. (user-reported)
+    bool m_sliceDragInProgress{false};
     void setPanFollow(bool on);
+    void recenterPanFollowOnSlice0();
 
     WfmDemodulator* m_wfmDemod{nullptr};
     int             m_wfmSliceId{-1};

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2469,6 +2469,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         target->setFrequency(sliceFreqMhz);
         mirrorDiversityChildFrequency(target, sliceFreqMhz);  // keep diversity child in step
     });
+    // Pan Follow ("Pan Lock") stands down for the whole duration of a slice drag
+    // so it doesn't fight the drag (in-window tune or edge auto-pan) with per-tick
+    // recenters; on release it recenters once so Pan Lock re-asserts. (user-reported)
+    connect(sw, &SpectrumWidget::sliceDragActiveChanged, this, [this](bool active) {
+        m_sliceDragInProgress = active;
+        if (!active) {
+            recenterPanFollowOnSlice0();   // re-assert Pan Lock on release (self-guards if off)
+        }
+    });
 
     // ── Spot trigger — notify the radio/TCI clients when a spot label is clicked (#341)
     connect(sw, &SpectrumWidget::spotTriggered, this, [this, applet](int spotIndex) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5716,6 +5716,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             if (mx >= left && mx <= right) {
                 emit sliceClicked(so.sliceId);
                 m_draggingVfo = true;
+                emit sliceDragActiveChanged(true);
                 m_vfoDragLastX = mx;
                 m_vfoDragOffsetHz = static_cast<int>(
                     std::round((xToMhz(mx) - so.freqMhz) * 1.0e6));
@@ -5752,6 +5753,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         // Click inside the filter passband → start VFO drag (#404)
         if (filterPassbandBodyHitAtPixel(mx, loX, hiX, kFilterEdgeGrabPx)) {
             m_draggingVfo = true;
+            emit sliceDragActiveChanged(true);
             m_vfoDragLastX = mx;
             m_vfoDragOffsetHz = static_cast<int>(std::round((xToMhz(mx) - ao->freqMhz) * 1.0e6));
             setSpectrumCursor(Qt::ClosedHandCursor);
@@ -6360,6 +6362,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingVfo) {
         m_draggingVfo = false;
+        emit sliceDragActiveChanged(false);
         if (m_vfoDragEdgePanTimer)
             m_vfoDragEdgePanTimer->stop();
         m_vfoDragEdgeHoldTicks = 0;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -511,6 +511,10 @@ signals:
     // already accounted for by the explicit center).  Keeps the dragged slice
     // pinned under the cursor while the band scrolls.  (user-reported)
     void edgePanTuneRequested(double newCenterMhz, double sliceFreqMhz);
+    // Emitted when a slice drag (in-window tune or edge auto-pan) starts (true)
+    // and ends (false), so Pan Follow can stand down for the drag's duration and
+    // recenter once on release. (user-reported)
+    void sliceDragActiveChanged(bool active);
     void spotTriggered(int spotIndex);
     // Emitted when the user changes both center and bandwidth as one explicit
     // pan/zoom operation and the radio should apply them coherently. Splitting


### PR DESCRIPTION
## Summary

Fixes #3785.

With **Pan Lock** on, dragging a slice made the panadapter jump in large lurching steps instead of scrolling smoothly, and afterwards Pan Lock stopped keeping the slice centered (button lit) until toggled off/on. Two independently-developed features both drive the pan center and fought each other:

- **Pan Lock** (#3408) recenters on every slice-0 `frequencyChanged` (*slice at center*).
- **Edge auto-pan** (#3581) advances the center smoothly and parks the slice at the edge (*slice at edge*).

The edge-pan path tried to *"avoid pan-follow"* but the bypass was incomplete — it still calls `setFrequency()`, which emits `frequencyChanged`, and Pan Lock is wired straight to that signal, so both fired each tick with opposite intents. The in-window drag had the matching symptom (slice snapping back to center instead of following the cursor).

**Fix:** Pan Lock stands down for the **whole duration of a slice drag** (in-window tune *and* edge auto-pan), then **recenters once on release** so Pan Lock re-asserts. `SpectrumWidget` emits `sliceDragActiveChanged(bool)` on slice-drag start/end; `MainWindow` suppresses the recenter while the flag is set and recenters on release. The recenter logic is extracted into `MainWindow::recenterPanFollowOnSlice0()` (called on enable, on slice-0 `frequencyChanged`, and once on drag-end), self-guarded on the Pan Lock toggle state. This mirrors the existing WFM precedence (WFM already makes Pan Lock stand down).

This is a UX precedence choice (during a drag the slice follows the cursor / the band scrolls; on release the slice snaps back to center). Flagged for maintainer confirmation, consistent with the WFM-precedence note already in the code.

## Measurements

i9-13900K / RTX 4090, GPU path, dummy load, Pan Lock on; gated `aether.perf` `drag=1` windows + the `SliceDrag` center trace.

| | before | after |
|---|---|---|
| in-window drag — `panCenterCmdRate` | ~34 / s (Pan Lock fights every move) | **0–2 / s** (stands down) |
| in-window drag — pan center | snaps to slice each move | **stable** (slice follows cursor) |
| edge drag — pan center steps | **~0.33 MHz lurches** | **smooth** (single controller) |
| on release | `panCenterCmds=0` → slice left off-centre | **exactly 1** recenter → slice re-centered |

Verified on real hardware: no jumping during in-window or edge drag, and Pan Lock stays active after release (no toggle needed).

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated** (before/after measured via gated `aether.perf`, table above). **Principle VIII — Evidence Over Assertion** (root cause and fix confirmed by instrumented measurement on real hardware).

## Test plan

- [x] Local build passes (Windows, Qt 6.8.3, GPU path on)
- [x] Behavior verified on a real radio / dummy load — in-window + edge drag smooth; Pan Lock re-asserts on release; normal tuning still recenters; WFM precedence intact
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented in the linked issue

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` calls (N/A)
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (N/A — no meter changes)
- [x] Documentation updated if user-visible behavior changed (N/A — restores intended Pan Lock behavior; no new user-facing controls)
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
