### PR TITLE
fix(automation): tighten mark→tail log correlation (doMark seq race + tail eviction-gap signal) (#3756)

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -53,6 +53,19 @@ struct ResolvedAction {
     QPointer<QMenu> menu;
 };
 
+// mark→tail correlation (#3756): doMark needs the seq/mono the log tap assigns
+// to the MARK message itself, not whatever m_logSeq/back() read afterward — a
+// concurrent logging thread can push between the qCInfo() and the re-lock. The
+// tap runs synchronously on doMark's thread, so a thread_local sink lets only
+// that thread's own tap call publish the marker's identity. Loggers on other
+// threads see a null sink and leave it untouched.
+struct MarkCapture {
+    quint64 seq{0};
+    qint64  monoUs{0};
+    bool    set{false};
+};
+thread_local MarkCapture* g_markSink = nullptr;
+
 QString actionDisplayText(const QAction* action)
 {
     QString text = action->text();
@@ -863,6 +876,14 @@ bool AutomationServer::start(const QString& serverName)
             e.type   = static_cast<int>(type);
             e.cat    = cat;
             e.msg    = msg;
+            // If doMark armed a capture sink on this thread, this is the MARK's
+            // own tap call (#3756) — publish the seq/mono we just assigned so the
+            // caller bracket can't be skewed by a concurrent push afterward.
+            if (g_markSink) {
+                g_markSink->seq    = e.seq;
+                g_markSink->monoUs = e.monoUs;
+                g_markSink->set    = true;
+            }
             m_logRing.push_back(std::move(e));
             while (m_logRing.size() > static_cast<size_t>(kLogRingMax))
                 m_logRing.pop_front();
@@ -1758,9 +1779,15 @@ QJsonObject AutomationServer::doLog(const QString& action, const QString& arg,
         if (n <= 0) n = 100;
         QJsonArray arr;
         quint64 curSeq;
+        quint64 oldest;
         {
             QMutexLocker lk(&m_logMutex);
             curSeq = m_logSeq;
+            // Oldest seq still resident in the ring. A driver can compare its
+            // `since` against this to detect eviction: `since < oldest` means
+            // earlier matching events were dropped (#3756) and the window is a
+            // truncated suffix, not a complete bracket.
+            oldest = m_logRing.empty() ? curSeq : m_logRing.front().seq;
             for (const auto& e : m_logRing)
                 if (e.seq > since)
                     arr.append(logEventToJson(e));
@@ -1769,7 +1796,8 @@ QJsonObject AutomationServer::doLog(const QString& action, const QString& arg,
             arr.removeFirst();
         return QJsonObject{{QStringLiteral("ok"), true},
                            {QStringLiteral("events"), arr},
-                           {QStringLiteral("seq"), static_cast<qint64>(curSeq)}};
+                           {QStringLiteral("seq"), static_cast<qint64>(curSeq)},
+                           {QStringLiteral("oldest"), static_cast<qint64>(oldest)}};
     }
 
     if (action == QLatin1String("subscribe")) {
@@ -1800,14 +1828,26 @@ QJsonObject AutomationServer::doLog(const QString& action, const QString& arg,
 QJsonObject AutomationServer::doMark(const QString& text)
 {
     // qCInfo runs the installed handler synchronously on this (main) thread, so
-    // by the time it returns the tap has already assigned the marker its seq —
-    // letting a driver bracket actions with `mark` then `log tail since=<seq>`.
+    // the tap that assigns the marker its seq fires *inside* the call below.
+    // Capture that seq/mono via a thread_local sink (#3756) instead of re-reading
+    // m_logSeq/back() afterward — a concurrent logging thread could push in the
+    // re-lock gap and hand back a later event's seq, which `log tail since=<seq>`
+    // would then skip, defeating the mark→tail bracket.
+    MarkCapture cap;
+    g_markSink = &cap;
     qCInfo(lcAutomation).noquote() << "MARK" << text;
-    QMutexLocker lk(&m_logMutex);
-    const qint64 mono = m_logRing.empty() ? 0 : m_logRing.back().monoUs;
+    g_markSink = nullptr;
+
+    if (!cap.set) {
+        // Tap didn't fire (lcAutomation info logging disabled): fall back to the
+        // resident tail so callers still get a usable, if approximate, anchor.
+        QMutexLocker lk(&m_logMutex);
+        cap.seq    = m_logSeq;
+        cap.monoUs = m_logRing.empty() ? 0 : m_logRing.back().monoUs;
+    }
     return QJsonObject{{QStringLiteral("ok"), true},
-                       {QStringLiteral("seq"), static_cast<qint64>(m_logSeq)},
-                       {QStringLiteral("mono_us"), mono},
+                       {QStringLiteral("seq"), static_cast<qint64>(cap.seq)},
+                       {QStringLiteral("mono_us"), cap.monoUs},
                        {QStringLiteral("text"), text}};
 }
 

--- a/tools/automation_logwatch.py
+++ b/tools/automation_logwatch.py
@@ -10,7 +10,9 @@ exposes when launched with AETHER_AUTOMATION=1:
   log set <cat> <on|off>         toggle a category at runtime (no restart)
   log set all <on|off>           toggle every category
   log reset                      restore the operator's persisted prefs
-  log tail [n] [since=<seq>]     pull recent ring events (default newest 100)
+  log tail [n] [since=<seq>]     pull recent ring events (default newest 100);
+                                 response carries oldest=<seq> still resident —
+                                 if since < oldest, earlier events were evicted
   log subscribe / unsubscribe    push: stream events as they occur
   mark <text>                    annotate the timeline; returns {seq, mono_us}
 
@@ -65,8 +67,24 @@ class LogClient:
         return self.b.request({"cmd": "mark", "value": text})
 
     def tail(self, n=100, since=None):
+        return self.tail_window(n, since).get("events", [])
+
+    def tail_window(self, n=100, since=None):
+        """Full tail response: {events, seq, oldest}.
+
+        `oldest` is the lowest seq still resident in the ring (#3756). When
+        `since` is given and `since < oldest`, events between `since` and
+        `oldest` were evicted before this call — the returned window is a
+        truncated suffix, not a complete bracket. Check `gap_after(...)`.
+        """
         val = str(n) + (f" since={since}" if since is not None else "")
-        return self.b.request({"cmd": "log", "action": "tail", "value": val}).get("events", [])
+        return self.b.request({"cmd": "log", "action": "tail", "value": val})
+
+    @staticmethod
+    def gap_after(resp, since):
+        """True if events logged after `since` were evicted before the tail."""
+        oldest = resp.get("oldest")
+        return oldest is not None and since is not None and since < oldest
 
 
 class LogStream:


### PR DESCRIPTION
## Summary

Fast-follow to #3738 fixing two accuracy edges in the **agent automation bridge**'s log-correlation helpers (`mark` / `tail`). Both live in `src/core/AutomationServer.cpp` and only affect the *precision* of the `mark → tail` bracketing pattern — neither touches the radio, TX safety, or the captured log data. Severity: low.

## Bug 1 — `doMark` could return a `seq`/`mono_us` belonging to a *later* event (race)

`doMark` injected the marker via `qCInfo()` — which runs the log tap synchronously and assigns the marker its sequence — then re-read `m_logSeq` / `m_logRing.back()` on the next line after re-acquiring `m_logMutex`. A concurrent logging thread pushing in that unlocked gap bumps `m_logSeq` and appends a newer event, so **both** the returned `seq` and `mono_us` could belong to an event logged *after* the mark. `log tail since=<seq>` would then **skip whatever was logged immediately after the mark** — exactly what the bracket is meant to capture.

**Fix:** capture the marker's own seq/mono *inside* the tap via a `thread_local` sink (`g_markSink`). Because `qCInfo()` runs the tap synchronously on `doMark`'s thread, only that thread's own tap call populates the sink; loggers on other threads see a null sink and leave it untouched (no member-flag race). Falls back to the resident tail only if the tap never fired (i.e. `lcAutomation` info logging disabled).

## Bug 2 — `tail since=<seq>` under-reported silently after ring eviction

The ring caps at `kLogRingMax = 8000`. A `tail since=<old_seq>` whose seq had already been evicted returned only the resident suffix with **no signal** that earlier matching events were dropped — a driver could mistake a truncated window for a complete one.

**Fix:** include the **oldest retained seq** (`oldest`) in the `tail` response, computed under the same lock. A driver detects a gap whenever `since < oldest`. Additive field, no behavior change for existing callers. `tools/automation_logwatch.py` exposes it via `tail_window()` + `gap_after()` (`tail()` unchanged for compatibility) and documents it.

## How the agent automation bridge proved it

Built `RelWithDebInfo`, launched with `AETHER_AUTOMATION=1` (RX-only, no radio, zero TX), and drove the `mark`/`tail` path through `tools/`:

**Bug 1 — bracket integrity**
```
mark('FB3756-A') -> seq 10616
emit 25 post-mark log lines
tail(since=10616) captured 25 / 25  -> PASS
  first captured seq 10617 > mark seq 10616
  event at seq==mark_seq is the MARK line itself ('MARK FB3756-BRACKET')
```

**Bug 2 — real eviction signal**
```
hold since0 = 10642
generate 8600 marks (overflow the 8000-deep ring)
tail() -> seq 20790, oldest 12791
since0(10642) < oldest(12791)  -> gap_after = True
  driver can now DETECT the eviction; before this fix it was silent
```

Before this PR the `tail` response had only `{ok, events, seq}` — `oldest` was absent, so the gap was undetectable.

Fixes #3756. Refs #3738, #3646.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
