### PR TITLE
fix(gui): show panadapter split-pair for externally-initiated split (#3726)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6146,14 +6146,56 @@ void MainWindow::disableSplit()
 
 void MainWindow::updateSplitState()
 {
-    auto* sw = spectrum();
-    if (!sw) return;
+    // Derive the split-pair visualization from model truth so the panadapter
+    // reflects split regardless of who initiated it — GUI button, rigctld, CAT,
+    // TCI, or front panel. A slice is "TX-in-split" when it is the TX slice and a
+    // distinct RX slice shares its panadapter; that RX slice is "RX-in-split".
+    // (#3726) This drops the rendering dependence on the GUI-only m_splitActive/
+    // m_splitTxSliceId/m_splitRxSliceId flags — those still drive the SWAP/teardown
+    // *actions*, which need the GUI-created TX slice id. Consistent with RFC #3715:
+    // consumers derive from the model, not per-consumer state.
+
+    // Resolve, per pan, the TX slice and its RX partner.
+    QHash<QString, SliceModel*> txByPan;     // panId -> TX slice
+    QHash<QString, SliceModel*> rxByPan;     // panId -> chosen RX partner
+    for (auto* s : m_radioModel.slices())
+        if (s && s->isTxSlice())
+            txByPan.insert(s->panId(), s);
+
     for (auto* s : m_radioModel.slices()) {
-        if (auto* w = sw->vfoWidget(s->sliceId())) {
-            bool isTxSlice = (m_splitActive && s->sliceId() == m_splitTxSliceId);
-            bool isRxSplit = (m_splitActive && s->sliceId() == m_splitRxSliceId);
+        if (!s || s->isTxSlice()) continue;       // RX candidates only
+        if (!txByPan.contains(s->panId())) continue;  // need a distinct TX slice here
+        auto*& chosen = rxByPan[s->panId()];      // default-inserts nullptr
+        // Prefer the GUI-tracked RX (exact pairing for the SPLIT button), then the
+        // active slice, otherwise the first distinct RX slice found on the pan.
+        if (!chosen) chosen = s;
+        else if (chosen->sliceId() == m_splitRxSliceId) continue;  // already best
+        else if (s->sliceId() == m_splitRxSliceId) chosen = s;
+        else if (s->sliceId() == m_activeSliceId)  chosen = s;
+    }
+
+    auto applyToSpectrum = [&](SpectrumWidget* sw) {
+        if (!sw) return;
+        int pairRxId = -1, pairTxId = -1;
+        for (auto* s : m_radioModel.slices()) {
+            auto* w = sw->vfoWidget(s->sliceId());
+            if (!w) continue;
+            auto* tx = txByPan.value(s->panId(), nullptr);
+            auto* rx = rxByPan.value(s->panId(), nullptr);
+            const bool paired   = (tx && rx);
+            const bool isTxSlice = paired && (s == tx);
+            const bool isRxSplit = paired && (s == rx);
             w->updateSplitBadge(isTxSlice, isRxSplit);
+            if (paired) { pairTxId = tx->sliceId(); pairRxId = rx->sliceId(); }
         }
+        sw->setSplitPair(pairRxId, pairTxId);
+    };
+
+    if (m_panStack) {
+        for (auto* applet : m_panStack->allApplets())
+            if (applet) applyToSpectrum(applet->spectrumWidget());
+    } else if (auto* sw = spectrum()) {
+        applyToSpectrum(sw);
     }
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -862,6 +862,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
     connect(&m_radioModel, &RadioModel::antListChanged,
             vfo, &VfoWidget::setAntennaList);
 
+    // Refresh the split-pair visualization whenever this slice's TX role changes,
+    // so an externally-initiated split (rigctld / CAT / TCI / front panel) is
+    // reflected on the panadapter, not just GUI-initiated split. (#3726)
+    connect(s, &SliceModel::txSliceChanged, this, [this](bool) { updateSplitState(); });
+
     // Reset band-stack auto-save dwell timer on every active-slice tune
     connect(s, &SliceModel::frequencyChanged, this, [this, s]() {
         if (s->sliceId() != m_activeSliceId) return;
@@ -924,6 +929,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
     refreshKiwiSdrSlices();
     refreshKiwiSdrWaterfallAvailability();
     syncKiwiSdrDiversityEscControls();
+
+    // A slice can arrive already flagged as the TX slice (e.g. external split
+    // created the TX slice out-of-band). Re-derive the split-pair from the model
+    // so the panadapter pairs it without a GUI action. (#3726)
+    updateSplitState();
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -1022,6 +1032,10 @@ void MainWindow::onSliceRemoved(int id)
     refreshKiwiSdrSlices();
     refreshKiwiSdrWaterfallAvailability();
     syncKiwiSdrDiversityEscControls();
+
+    // Removing one half of a split pair (e.g. external controller deletes the TX
+    // slice) must re-derive the panadapter split-pair from the model. (#3726)
+    updateSplitState();
 }
 
 void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,


### PR DESCRIPTION
## Problem

The panadapter's split-pair visualization — red **SPLIT** on the RX VFO, **SWAP** on the TX VFO, and the spectrum split-pair marker — only appeared when split was enabled from the in-app **SPLIT** button. When split was established by an **external controller** (rigctld / CAT / TCI / front panel), or was already present on **reconnect**, the panadapter showed nothing, even though TX was correctly on the split slice.

Fixes #3726.

## Root cause

`MainWindow::updateSplitState()` gated the split-pair styling on the GUI-only flag `m_splitActive` (plus `m_splitTxSliceId` / `m_splitRxSliceId`):

```cpp
bool isTxSlice = (m_splitActive && s->sliceId() == m_splitTxSliceId);
bool isRxSplit = (m_splitActive && s->sliceId() == m_splitRxSliceId);
```

`m_splitActive` is set true **only** by the three GUI-initiated split sites. An external split sets the *model's* TX slice via `SliceModel::setTxSlice(true)` but never touches the flag, so the renderer saw no split. The **TX** badge was correct only because it derives from model state (`isTxSlice()`) — the `SPLIT`/`SWAP` pair badges and spectrum pairing were flag-driven, so every non-GUI split was invisible to the panadapter.

Two compounding gaps: the rendering read GUI state instead of model truth, and nothing re-ran `updateSplitState()` when the model's TX slice changed out-of-band.

## Fix

Per **RFC #3715** (consumers derive from model truth, not per-consumer state):

1. **Derive from the model.** `updateSplitState()` now resolves, per panadapter, the TX slice and a distinct RX slice on the same pan; the TX slice renders **SWAP**, the RX slice renders red **SPLIT**, and `SpectrumWidget::setSplitPair()` is fed from the same derivation (multi-pan aware). The GUI flags still drive the SWAP/teardown **actions** (which need the GUI-created TX slice id) but no longer gate rendering. When the GUI tracks an RX slice it's preferred as the partner, so the **SPLIT**-button pairing is byte-for-byte unchanged.
2. **Re-trigger from the model.** `updateSplitState()` now also runs on each slice's `SliceModel::txSliceChanged`, and at the tail of `onSliceAdded`/`onSliceRemoved` — so an externally-initiated split (or one present on reconnect) repaints the panadapter without a GUI action.

## How the agent automation bridge proved it

RX-only (no TX keying), against the **fixed** build, isolated on a unique bridge socket (`AETHER_AUTOMATION_SOCKET`) so the parallel apps sharing the Flex couldn't be mistaken for it. The `Split mode` badge text is read via `dumpTree` (a `QPushButton`'s text is exposed as its `value`). **`m_splitActive == false` throughout — no SPLIT button was ever pressed.**

**Run A — model-only `slice add` (exercises the `sliceAdded` trigger):**

| Step | TX slice | Split badges (letter, value) |
|---|---|---|
| Before (1 slice) | A | `[(B, SPLIT)]` — ghosted, no pair |
| After bridge `slice add` | A | `[(B, SWAP), (A, SPLIT)]` — pair rendered |

**Run B — reconnect into an externally-present split (the literal bug):** on connect the model already had two slices (TX on A, RX on B), i.e. a split set up outside this GUI session:

| TX slice | Split badges |
|---|---|
| A | `[(B, SPLIT), (A, SWAP)]` — panadapter shows the pair immediately |

On the old build, with `m_splitActive == false`, both runs would leave every badge at the ghosted default `SPLIT` — no `SWAP`, no red, no pairing. (Old behavior confirmed by source inspection and the independent triage verification on the issue.)

### Agent automation bridge — gaps found
- **Spectrum split-pair marker is GPU-only.** The VFO `SWAP`/`SPLIT` badges are real widgets and read cleanly via `dumpTree`, but the spectrum's paired-overlay marker (`SliceOverlay::splitPartnerId`) is drawn in the `SpectrumWidget` GPU layer and isn't reflected in `dumpTree`. It can only be checked by pixel-grabbing `SpectrumWidget` — proposed: expose `splitPartnerId` (and similar overlay-derived state) in a `get pan`/`get slice` snapshot so split pairing is assertable without image diffing.
- **No bridge verb to set a slice's TX role.** The `slice` verb supports add/remove/select but not "make slice N the TX slice". The most literal rigctld repro (`set_split_vfo 1 VFOB` — move TX to an existing slice) had to be approximated by `slice add` (new TX-adjacent slice) and reconnect-into-split. Proposed: a `slice tx <id>` verb so the bridge can drive the exact external-split transition end-to-end.

## Behavioral note for review
By design the pair now renders whenever a pan has a TX slice **and** a distinct RX slice — which is exactly the maintainer-endorsed derivation in the issue. This means two slices on one panadapter with TX on one will now show SWAP/SPLIT even if the user didn't think of it as "split". That's functionally accurate (you RX on one, TX on the other) and matches #3715, but flagging it explicitly per the triage's open question.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat