### PR TITLE
fix(flexcontrol): clamp AetherControl window to the screen height (#3662)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2389,6 +2389,29 @@ target_link_libraries(help_dialog_test PRIVATE
 )
 set_target_properties(help_dialog_test PROPERTIES AUTOMOC ON)
 
+# Regression guard for #3662: the AetherControl window must never demand a
+# minimum height taller than the screen (auto-engages compact when it would).
+add_executable(flex_control_dialog_size_test
+    tests/flex_control_dialog_size_test.cpp
+    src/gui/FlexControlDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/gui/SliceLabel.cpp
+    src/gui/DragValuePopup.cpp
+    src/models/SliceModel.cpp
+    src/core/KiwiSdrProtocol.cpp
+    src/core/ThemeManager.cpp
+    src/core/AppSettings.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(flex_control_dialog_size_test PRIVATE src)
+target_link_libraries(flex_control_dialog_size_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(flex_control_dialog_size_test PROPERTIES AUTOMOC ON)
+
 add_executable(device_diagnostics_test
     tests/device_diagnostics_test.cpp
 )

--- a/src/gui/FlexControlDialog.cpp
+++ b/src/gui/FlexControlDialog.cpp
@@ -25,6 +25,7 @@
 #include <QPainter>
 #include <QPushButton>
 #include <QRadialGradient>
+#include <QScreen>
 #include <QShortcut>
 #include <QSignalBlocker>
 #include <QSizePolicy>
@@ -1732,11 +1733,40 @@ void FlexControlDialog::updateCompactMode()
             applyCompactWindowSize();
         });
     } else {
-        const QSize required = minimumSizeHint().expandedTo(QSize(430, 0));
+        QSize required = minimumSizeHint().expandedTo(QSize(430, 0));
+
+        // Never demand more vertical space than the display can show (#3662).
+        // The full (non-compact) layout is ~1100 px tall; on a short or
+        // DPI-scaled screen that exceeds the available workspace, so pinning
+        // it as a hard minimum opens the window taller than the screen with
+        // its bottom clipped and no way to shrink it back. Fall back to the
+        // existing compact layout, which fits, rather than clipping.
+        const int availH = availableScreenHeight();
+        if (availH > 0 && required.height() > availH
+            && m_compactButton && !m_compactButton->isChecked()) {
+            const QSignalBlocker blocker(m_compactButton);
+            m_compactButton->setChecked(true);
+            updateCompactMode();
+            return;
+        }
+        // Backstop: even when compact mode is unavailable, never enforce a
+        // minimum taller than the screen.
+        if (availH > 0 && required.height() > availH)
+            required.setHeight(availH);
+
         setMinimumSize(required);
         if (isVisible() && (width() < required.width() || height() < required.height()))
             resize(size().expandedTo(required));
     }
+}
+
+// Available (taskbar-excluded) height of the screen this dialog lives on, or 0
+// if it can't be determined. Used to keep the window from demanding more
+// vertical space than the display offers (#3662).
+int FlexControlDialog::availableScreenHeight() const
+{
+    const QScreen* scr = screen();
+    return scr ? scr->availableGeometry().height() : 0;
 }
 
 void FlexControlDialog::applyCompactWindowSize()
@@ -1753,7 +1783,14 @@ void FlexControlDialog::applyCompactWindowSize()
     if (auto* bodyLayout = bodyWidget()->layout())
         bodyLayout->activate();
 
-    const QSize required = minimumSizeHint().expandedTo(QSize(410, 0));
+    QSize required = minimumSizeHint().expandedTo(QSize(410, 0));
+    // Backstop (#3662): never pin a window taller than the screen, even in
+    // compact mode. On a screen shorter than the compact layout's own minimum
+    // the body may need to scroll, but the window stays fully on-screen and
+    // resizable rather than clipping off the bottom edge.
+    const int availH = availableScreenHeight();
+    if (availH > 0 && required.height() > availH)
+        required.setHeight(availH);
     setMinimumSize(required);
     setFixedHeight(required.height());
     if (isVisible()) {

--- a/src/gui/FlexControlDialog.h
+++ b/src/gui/FlexControlDialog.h
@@ -68,6 +68,7 @@ private:
     void updateOptionButtons();
     void updateCompactMode();
     void applyCompactWindowSize();
+    int availableScreenHeight() const;
     void setCaptureHintActive(bool active);
 
     QPointer<SliceModel> m_slice;

--- a/tests/flex_control_dialog_size_test.cpp
+++ b/tests/flex_control_dialog_size_test.cpp
@@ -1,0 +1,106 @@
+// Standalone test harness for the AetherControl (FlexControlDialog) window
+// never demanding more vertical space than the screen can show (issue #3662).
+//
+// The non-compact layout has a ~1066 px intrinsic minimum height. On a screen
+// whose available (taskbar/menu-bar-excluded) height is smaller than that --
+// e.g. a 1920x1080 panel after the Windows taskbar, or any DPI-scaled laptop --
+// the old code pinned that intrinsic minimum as a hard floor, so the window
+// opened taller than the screen with its bottom clipped and no way to shrink
+// it. The fix auto-engages the existing compact layout (which fits) whenever
+// the full layout would exceed the available screen height.
+//
+// Invariant under test: the dialog's enforced minimum height is never greater
+// than the available height of the screen it lives on. On a screen too short
+// for the full layout, compact mode must auto-engage.
+//
+// Build: CMake target `flex_control_dialog_size_test`. Exit 0 = pass.
+
+#include "gui/FlexControlDialog.h"
+
+#include <QApplication>
+#include <QPushButton>
+#include <QScreen>
+#include <cstdio>
+#include <string>
+
+#include "core/AppSettings.h"
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+// The non-compact stack (header 70 + knob panel 420 + control strip ~110 +
+// status frame 148 + aux grid ~200 + title bar 18 + margins) floors around
+// 1066 px. Any screen shorter than this exercises the auto-compact fallback.
+constexpr int kFullLayoutFloor = 1000;
+
+QPushButton* findCompactButton(FlexControlDialog& dialog)
+{
+    const auto buttons = dialog.findChildren<QPushButton*>();
+    for (QPushButton* b : buttons) {
+        if (b->text() == QStringLiteral("Compact"))
+            return b;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    std::printf("FlexControlDialog screen-fit test harness (#3662)\n\n");
+
+    // Start from the non-compact layout so the auto-engage path is exercised.
+    AppSettings::instance().setValue("FlexControlCompactMode", "False");
+
+    const QScreen* scr = QApplication::primaryScreen();
+    const int availH = scr ? scr->availableGeometry().height() : 0;
+    report("primary screen reports an available height", availH > 0,
+           "availH=" + std::to_string(availH));
+    if (availH <= 0)
+        return 1;
+
+    FlexControlDialog dialog;
+
+    QPushButton* compact = findCompactButton(dialog);
+    report("compact toggle is present", compact != nullptr);
+
+    const int minH = dialog.minimumHeight();
+    const bool engaged = compact && compact->isChecked();
+
+    // Headline invariant: the window can never force a minimum height taller
+    // than the screen offers. Pre-fix this is the intrinsic ~1066 px and fails
+    // on any screen shorter than that.
+    report("enforced minimum height fits the screen", minH <= availH,
+           "minH=" + std::to_string(minH) + " availH=" + std::to_string(availH));
+
+    // On a screen too short for the full layout, compact must auto-engage so
+    // nothing is clipped.
+    if (availH < kFullLayoutFloor) {
+        report("compact auto-engaged on a short screen", engaged,
+               "availH=" + std::to_string(availH) + " < floor "
+                   + std::to_string(kFullLayoutFloor));
+    } else {
+        std::printf("[info] screen is tall enough (availH=%d >= %d); "
+                    "non-compact layout retained, no auto-engage expected\n",
+                    availH, kFullLayoutFloor);
+    }
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Issue

[#3662](https://github.com/aethersdr/AetherSDR/issues/3662) — the **AetherControl** window opens taller than the screen and its bottom (control strip / status readout) is clipped off, with no way to shrink it back. Reported on a Flex 6400, Windows 10, 1920×1080 @ 100% UI scale.

## Root cause

The AetherControl dialog (`FlexControlDialog`) non-compact layout is a tall stack — header (70) + knob panel (420) + control strip (~110) + status frame (148) + aux grid (~200) + frameless title bar (18) + margins — with a **~1114 px intrinsic minimum height** (measured).

At the end of `updateCompactMode()` the non-compact branch pinned that intrinsic minimum as a **hard floor** with no screen clamp:

```cpp
const QSize required = minimumSizeHint().expandedTo(QSize(430, 0));
setMinimumSize(required);   // required.height() ≈ 1114, never bounded to the screen
```

On any display whose available (taskbar/menu-bar-excluded) height is below ~1114 px the window is forced taller than the screen and clips off the bottom — and because the minimum is hard-pinned, it can't be resized smaller to recover. A 1920×1080 panel after the Windows taskbar leaves ~1040 px usable; DPI scaling (125 %/150 %) shrinks that further. Compact mode produces a window that fits but was never auto-engaged, so a first-time user just saw a cut-off window.

## Fix

- When the full (non-compact) layout would exceed the available screen height, **auto-engage the existing compact layout** (which fits) instead of pinning an oversized minimum.
- Add a **screen-height backstop** to *both* the non-compact and compact paths (`availableScreenHeight()` helper) so the enforced minimum never exceeds the display in either mode — on a screen even shorter than the compact layout, the window stays fully on-screen and resizable rather than clipping.

Minimal and local to `FlexControlDialog.cpp` (+ one private helper). No protocol/FlexLib involvement.

## Proof

The agent automation bridge could **not** open the dialog itself — AetherControl is launched only from a closed `Settings` menu, and the bridge has no verb to open a top-level menu or trigger a non-visible menu action (gap recorded below). Instead the fix is proven by a new standalone runtime regression test, **`flex_control_dialog_size_test`**, which constructs `FlexControlDialog` on the real screen and asserts the enforced minimum height never exceeds the available screen height.

Run on this 871 px-tall display (shorter than the reporter's, so it reproduces the bug harder):

| Build | enforced min height | screen avail | compact auto-engaged | result |
|---|---|---|---|---|
| **Unfixed** | **1114 px** | 871 px | no | 243 px taller than the screen → **clipped** ❌ |
| **Fixed** | **871 px** | 871 px | yes | fits, fully on-screen ✅ |

```
[ OK ] primary screen reports an available height           availH=871
[ OK ] compact toggle is present
[ OK ] enforced minimum height fits the screen              minH=871 availH=871
[ OK ] compact auto-engaged on a short screen               availH=871 < floor 1000
All tests passed.
```

On the reporter's 1920×1080 (~1040 px usable), the 1114 px non-compact minimum overflows exactly as reported; the fix engages compact (887 px intrinsic), which fits comfortably.

## Agent automation bridge — gap found

- **Opening a menu-launched dialog** — the AetherControl window is reachable only via `Settings → AetherControl…`. The bridge's `invoke` only matches **visible** menu actions, and there is no verb to open a top-level menu or trigger a menu action by name while its menu is closed. So no menu-only dialog (AetherControl, Network, MQTT, …) can be opened through the bridge alone. Proposed: an `openMenu <name>` verb, or let `invoke <action>` resolve and `trigger()` a named `QAction` anywhere in the menu bar even when its menu isn't shown. (This run fell back to a standalone GUI regression test for the proof.)

Fixes #3662

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
