### PR TITLE
fix(dax): break DAX RX stream create/remove storm that drops connection quality to red (#3626)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1124,8 +1124,12 @@ private:
     // up so the radio registers a DAX client for slices 1-3, not just slice 0.
     void wireDaxSlice(SliceModel* slice);
     void onDaxChannelChanged(SliceModel* slice, int newCh);
+    // #3626: defer + re-validate DAX RX stream teardown so a radio's transient
+    // dax=0 rebroadcast can't drive a create/remove storm. See the .cpp comment.
+    void scheduleDaxRxStreamRemoval(int ch);
     QList<QMetaObject::Connection> m_daxSliceConns;
     QHash<int, int> m_daxSliceLastCh;  // sliceId -> last-known DAX channel
+    QSet<int>       m_daxPendingRxRemoval;  // channels with a deferred teardown in flight (#3626)
 #endif
 };
 

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1132,6 +1132,12 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
         // Re-assert slice -> DAX mapping so the radio registers our stream as a
         // client. Without this dax_clients stays 0 and the radio sends silence
         // (the #1439 workaround, mirrored from TciServer::ensureDaxForTci).
+        // This is sent unconditionally (even when newCh is unchanged), so on the
+        // dax=<ch> rebroadcast edge it re-emits a same-value `slice set`. That
+        // does NOT re-enter this reconciler only because SliceModel's status
+        // path drops same-value echoes (`if (m_daxChannel != ch)` in
+        // SliceModel::applyStatus) — that equality guard is load-bearing for the
+        // #3626 storm fix; relaxing it would reopen the loop via this edge.
         m_radioModel.sendCommand(
             QString("slice set %1 dax=%2").arg(sliceId).arg(newCh));
     }
@@ -1170,7 +1176,12 @@ void MainWindow::scheduleDaxRxStreamRemoval(int ch)
 
     static constexpr int kDaxRxRemovalGraceMs = 1500;  // ≫ the ~80 ms rebroadcast cycle
     QTimer::singleShot(kDaxRxRemovalGraceMs, this, [this, ch]() {
-        m_daxPendingRxRemoval.remove(ch);
+        // QSet::remove() returns false when the key is gone, which means
+        // stopDax() cleared the pending set after this timer was armed — i.e. a
+        // stale fire from a previous DAX-bridge generation (off→on toggle inside
+        // the grace window). Treat the cleared set as an authoritative cancel so
+        // we never act against a freshly-recreated bridge's streams. (#3626)
+        if (!m_daxPendingRxRemoval.remove(ch)) return;
         if (!m_daxBridge) return;  // bridge torn down — stopDax() already cleared streams
         auto* ps = m_radioModel.panStream();
         if (!ps) return;

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1049,6 +1049,7 @@ void MainWindow::stopDax()
     }
     m_daxSliceConns.clear();
     m_daxSliceLastCh.clear();
+    m_daxPendingRxRemoval.clear();  // drop deferred teardowns; streams handled below (#3626)
 
     disconnect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
                m_daxBridge, nullptr);
@@ -1135,46 +1136,77 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
             QString("slice set %1 dax=%2").arg(sliceId).arg(newCh));
     }
 
-    // <old>:1..4 -> now released or moved: remove the old channel's stream if
-    // no other slice still references it.
-    if (oldCh >= 1 && oldCh <= 4) {
-        bool stillUsed = false;
+    // <old>:1..4 -> released or moved. Don't tear the stream down inline: on the
+    // FLEX-8600M every `stream create` provokes a transient dax=0 rebroadcast
+    // (see scheduleDaxRxStreamRemoval) that would read here as a de-assignment
+    // and start a create/remove storm. Defer + re-validate instead. (#3626)
+    if (oldCh >= 1 && oldCh <= 4)
+        scheduleDaxRxStreamRemoval(oldCh);
+}
+
+// #3626: On the FLEX-8600M (and likely other 8000-series radios), issuing
+// `stream create type=dax_rx dax_channel=<ch>` while the bound slice already
+// has dax=<ch> makes the radio momentarily detach the stream and re-broadcast
+// `slice <id> dax=0` immediately followed by `slice <id> dax=<ch>` again.
+// SliceModel mirrors every echo into daxChannelChanged (SliceModel.cpp ~846),
+// so the inline reconciler above would read the transient dax=0 as a real
+// de-assignment, remove the stream, then re-create it on the dax=<ch> that
+// lands ~80 ms later — a self-sustaining create/remove storm (observed at
+// 12-25 Hz in #3626 logs). The churn floods the radio's TCP command channel and
+// resets the DAX VITA-49 sequence every cycle, inflating packetErrorCount until
+// the network-quality monitor falls to POOR ("connection drops to red").
+//
+// Fix: defer the teardown and re-validate at fire time. The dax=<ch>
+// rebroadcast lands long before the grace window elapses, so a slice is back on
+// the channel and the removal is declined — the loop never starts. A genuine
+// user de-assignment has no follow-up rebroadcast, so the channel stays
+// unwanted and the stream is removed after the grace window. Full DAX RX
+// stream refcounting is tracked separately in #3305.
+void MainWindow::scheduleDaxRxStreamRemoval(int ch)
+{
+    if (ch < 1 || ch > 4) return;
+    if (m_daxPendingRxRemoval.contains(ch)) return;  // already pending — don't stack timers
+    m_daxPendingRxRemoval.insert(ch);
+
+    static constexpr int kDaxRxRemovalGraceMs = 1500;  // ≫ the ~80 ms rebroadcast cycle
+    QTimer::singleShot(kDaxRxRemovalGraceMs, this, [this, ch]() {
+        m_daxPendingRxRemoval.remove(ch);
+        if (!m_daxBridge) return;  // bridge torn down — stopDax() already cleared streams
+        auto* ps = m_radioModel.panStream();
+        if (!ps) return;
+
+        // Re-validate: if any slice still wants this channel, the transient
+        // dax=0 has already been undone by the dax=<ch> rebroadcast — keep it.
         for (auto* s : m_radioModel.slices()) {
-            if (s && s != slice && s->daxChannel() == oldCh) {
-                stillUsed = true;
-                break;
-            }
+            if (s && s->daxChannel() == ch) return;
         }
-        if (!stillUsed) {
-            const quint32 id = ps->daxStreamIdForChannel(oldCh);
-            // Ownership guard: the PanadapterStream DAX map is shared across
-            // every DAX consumer — the bridge, TCI (which borrows
-            // bridge-created streams, #1331/#1439), and RADE. Removing a stream
-            // another consumer is still using would silence WSJT-X or RADE
-            // audio — the mirror image of #3270. Only tear down a stream that
-            // no other consumer needs. (#2895)
-            const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(oldCh);
+
+        const quint32 id = ps->daxStreamIdForChannel(ch);
+        if (id == 0) return;
+        // Ownership guard: the PanadapterStream DAX map is shared across every
+        // DAX consumer — the bridge, TCI (which borrows bridge-created streams,
+        // #1331/#1439), and RADE. Removing a stream another consumer still uses
+        // would silence WSJT-X or RADE audio (the mirror image of #3270). (#2895)
+        const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(ch);
 #ifdef HAVE_RADE
-            const bool radeUsing = (id != 0 && id == m_radeDaxStreamId);
+        const bool radeUsing = (id == m_radeDaxStreamId);
 #else
-            const bool radeUsing = false;
+        const bool radeUsing = false;
 #endif
-            if (id != 0 && !tciUsing && !radeUsing) {
-                m_radioModel.sendCommand(
-                    QString("stream remove 0x%1").arg(id, 0, 16));
-                ps->unregisterDaxStream(id);
-                qCInfo(lcDax) << "MainWindow: removed DAX RX stream"
-                              << "0x" + QString::number(id, 16)
-                              << "for channel" << oldCh << "(#2895)";
-            } else if (id != 0) {
-                qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
-                              << "0x" + QString::number(id, 16)
-                              << "for channel" << oldCh
-                              << "— still used by" << (tciUsing ? "TCI" : "RADE")
-                              << "(#2895)";
-            }
+        if (tciUsing || radeUsing) {
+            qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
+                          << "0x" + QString::number(id, 16)
+                          << "for channel" << ch
+                          << "— still used by" << (tciUsing ? "TCI" : "RADE")
+                          << "(#3626)";
+            return;
         }
-    }
+        m_radioModel.sendCommand(QString("stream remove 0x%1").arg(id, 0, 16));
+        ps->unregisterDaxStream(id);
+        qCInfo(lcDax) << "MainWindow: removed DAX RX stream"
+                      << "0x" + QString::number(id, 16)
+                      << "for channel" << ch << "(#3626 deferred)";
+    });
 }
 #endif
 


### PR DESCRIPTION
Fixes #3626

## Symptom

On a FLEX-8600M (macOS), connection quality reads **EXCELLENT** for ~5–10 min
(sometimes ~30 s), then drops to **POOR / red** with the packet-loss graph
ramping up. While degraded, DAX recordings crackle and chop badly. A restart
resets the cycle. Multiple 8000-series users report the same.

## Root cause — a DAX RX stream create/remove storm

Traced entirely from the reporter's attached log (847k lines):

- AetherSDR sent **20,610 `stream create type=dax_rx`** and **20,609 `stream
  remove`** commands in one session — a tight loop running at **12–25 Hz**.
- Each cycle re-registered the DAX audio stream (**13,188 "first DAX packet
  seq=0"** resets in the log).

The loop is a feedback cycle specific to 8000-series radios:

1. `MainWindow::onDaxChannelChanged()` issues `stream create type=dax_rx
   dax_channel=1` for a slice that already has `dax=1`.
2. The radio momentarily **detaches** the stream and re-broadcasts `slice 0
   dax=0` immediately followed by `slice 0 dax=1` (confirmed in the log; same
   transient-rebroadcast behavior noted for #3669).
3. `SliceModel::applyStatus` mirrors **every** echo into `daxChannelChanged`
   (`SliceModel.cpp:846`), so the reconciler reads the transient `dax=0` as a
   real de-assignment → **`stream remove`**, then reads the `dax=1` that lands
   ~80 ms later as a new assignment → **`stream create` + `slice set`** → back
   to step 2.

### Why that turns the connection red

The storm floods the radio's TCP command channel and resets the DAX VITA-49
sequence on every recreate. Each reset is a sequence discontinuity counted in
`PanadapterStream::packetErrorCount()`, which feeds
`RadioModel::networkQualityTargetScore()` packet-loss term → the score falls →
`NetState` walks down to **POOR**. That is exactly the rising packet-loss graph
and red status the reporter screenshotted. (The variable 5–10 min / 30 s onset
matches a user action — band/profile/slice reconfiguration — kicking off the
first transient; in this capture the storm began at a panadapter
add/remove reconfiguration ~1h27m in.)

## Fix

Defer the DAX RX stream teardown in `onDaxChannelChanged` and re-validate at
fire time (`scheduleDaxRxStreamRemoval`):

- A transient `dax=0` schedules a removal **1.5 s** out instead of firing inline.
- The `dax=1` rebroadcast lands ~80 ms later, so when the timer fires a slice is
  back on the channel and the removal is **declined** — the loop never starts.
- Because the stream stays registered across the transient, the `dax=1` edge's
  `stream create` is skipped (already idempotent via `daxStreamIdForChannel`),
  so the create side is broken too.
- A genuine user de-assignment has no follow-up rebroadcast → the channel stays
  unwanted → the stream is removed after the grace window. Existing TCI/RADE
  ownership guards are preserved.

Minimal, contained change (2 files). Full DAX RX stream refcounting remains
tracked in #3305.

## Proof

**Broken baseline (reporter's log, build 26.6.3, FLEX-8600M):** 20,610 `stream
create type=dax_rx` + 20,609 `stream remove`, ramping 12 Hz → 25 Hz; 13,188 DAX
stream re-registrations; trim/packet-loss climbing into the red.

**Code trace:** the deferred + re-validated teardown collapses each transient
`dax=0`→`dax=1` rebroadcast to a single harmless `slice set` no-op, sending zero
`stream create` / `stream remove` — the storm cannot sustain.

**Agent automation bridge — could not drive the live path (gap, see below):**
the storm only runs when the DAX bridge is active (`m_daxBridge != null`), which
requires the macOS DAX HAL plugin. The plugin is **not installed** on the test
Mac (`startDax()` logs `DAX HAL plugin not installed` and bails), so
`onDaxChannelChanged` never runs. The fixed build was confirmed to build, launch,
and run RX-clean against a **FLEX-8400M** (same 8000-series family/firmware
4.2.18) via the bridge; the DAX-bridge code path itself could not be exercised
here. **Recommend validating on a machine with the DAX HAL plugin installed (or
by the reporter).**

## Out of scope (separate bug, filed separately)

The same logs show DAX RX audio delivered at ~**2× real-time** from session
start (reduced-BW packets `pcc=0x0123`, 128 samples/pkt × ~375 pkt/s = **48 kHz**
mono), but `VirtualAudioBridge`/HAL assume **24 kHz**, so ~50 % is trimmed every
second → the constant chop and "very quiet at 100 %" the reporter also reports.
That is a rate-assumption bug independent of this storm and needs its own change.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
