### PR TITLE
fix(gui): route keyboard/space PTT through the Quindar coordinator (#3610)

### DIFF
--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -287,12 +287,21 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
             && !textInputCaptured()
             && m_radioModel.isConnected()) {
             if (m_keyboardShortcutsEnabled) {
+                // Route through the PTT coordinator (not the raw
+                // setTransmit() path) so the Quindar intro/outro runs for
+                // space-bar PTT just like it does for the GUI MOX button.
+                // requestPttOn/Off still terminate in an `xmit` command, so
+                // the interlock/gating in RadioModel's xmit handler is
+                // preserved; the coordinator's preflight applies the same
+                // local interlock check. (#3610)
                 if (event->type() == QEvent::KeyPress && !m_spacePttActive) {
                     m_spacePttActive = true;
-                    m_radioModel.setTransmit(true);
+                    m_radioModel.transmitModel().requestPttOn(
+                        TransmitModel::PttSource::Mox);
                 } else if (event->type() == QEvent::KeyRelease && m_spacePttActive) {
                     m_spacePttActive = false;
-                    m_radioModel.setTransmit(false);
+                    m_radioModel.transmitModel().requestPttOff(
+                        TransmitModel::PttSource::Mox);
                 }
             }
             return true;  // always consume Space to prevent button activation
@@ -667,7 +676,13 @@ void MainWindow::registerShortcutActions()
     m_shortcutManager.registerAction("mox_toggle", "MOX Toggle", "TX",
         QKeySequence(Qt::Key_T), [this]() {
             if (!m_radioModel.isConnected()) return;
-            m_radioModel.setTransmit(!m_radioModel.transmitModel().isTransmitting());
+            // Route through the PTT coordinator so Quindar tones fire for the
+            // keyboard MOX toggle, matching the GUI MOX button. (#3610)
+            auto& tx = m_radioModel.transmitModel();
+            if (tx.isTransmitting())
+                tx.requestPttOff(TransmitModel::PttSource::Mox);
+            else
+                tx.requestPttOn(TransmitModel::PttSource::Mox);
         });
     // PTT (Hold) via Space is handled by the app-level event filter
     // because QShortcut has no "released" signal. Register with null


### PR DESCRIPTION
## Issue

[#3610](https://github.com/aethersdr/AetherSDR/issues/3610) — Quindar tones fire for the GUI MOX button but **not** for space-bar PTT or the keyboard MOX/TX shortcut (`T`). The radio keys and mic audio is sent; only the Quindar intro/outro is missing. Confirmed by the reporter on a real station (QUIN enabled, USB/phone mode).

## Root cause

There were two divergent PTT paths and only one drove the Quindar state machine:

- **GUI MOX button** (`TxApplet.cpp`) and **TCI hardware PTT** (`TciServer.cpp`) call `TransmitModel::requestPttOn/Off()` — the single coordinator that sequences the tone around the MOX edge (`startIntro()` before key-up; `startOutro()` with the unkey deferred by the outro duration).
- **Space-bar PTT** and the **`mox_toggle` shortcut** (`MainWindow_Shortcuts.cpp`) called `RadioModel::setTransmit()` → `TransmitModel::setTransmitting()`, the raw state setter that emits `xmit 0/1` and `moxChanged` but **never touches the Quindar coordinator**.

So with QUIN enabled on a phone mode, keyboard PTT keyed the radio with no tone, while the MOX button worked — exactly the reported behaviour. (`PttSource::Footswitch` was defined but never wired, consistent with the reporter's read that this routing was intended but unfinished.)

## Fix

Point the space-bar event-filter path and the `mox_toggle` shortcut at `requestPttOn/Off(PttSource::Mox)` — the same coordinator the working MOX button uses. Minimal, signal-routing only; no FlexLib protocol change.

No gating is lost by the redirect: `requestPttOn/Off` still terminate in an `xmit 0/1` command, and `RadioModel`'s `xmit` handler applies the identical interlock-arm / `m_txRequested` / `txAudioGate`-teardown gating that `setTransmit()` did inline. The coordinator's preflight runs the same local interlock check (`localPttInterlockMessage`). The only added behaviour is the Quindar intro/outro.

```diff
-                    m_radioModel.setTransmit(true);
+                    m_radioModel.transmitModel().requestPttOn(TransmitModel::PttSource::Mox);
...
-                    m_radioModel.setTransmit(false);
+                    m_radioModel.transmitModel().requestPttOff(TransmitModel::PttSource::Mox);
```

## How the agent automation bridge proved it

The fix makes the keyboard path call the **identical** `requestPttOff(PttSource::Mox)` the MOX button calls. The MOX button is reachable from the bridge, so I exercised that exact coordinator path on live hardware (**FLEX-8400M**, TX slice on **LSB**, TX antenna **ANT1** dummy load — re-confirmed from live state before keying; force-unkeyed and verified `transmitting == false` after each cycle).

The coordinator's observable, bridge-readable effect is the **deferred unkey**: `requestPttOff` holds the radio keyed for the outro window before sending `xmit 0`, so `get transmit → transmitting` stays `true` after the unkey command. Driving `invoke MOX transmit setChecked` while polling `transmitting`:

| Condition | UNKEY command → `transmitting:false` |
|---|---|
| QUIN **disabled** (coordinator falls straight through) | **23 ms** — immediate |
| QUIN **enabled** (outro sequenced) | **535 ms** — deferred outro window |

The ~0.5 s deferral with QUIN on vs. immediate with QUIN off confirms the Quindar outro sequencing runs on this build over real hardware. Since the patched space-bar / `mox_toggle` paths now call that same `requestPttOff(PttSource::Mox)`, they inherit that behaviour — the previously-silent keyboard PTT now drives the full intro/outro.

### Agent automation bridge — gaps found

A direct empirical "press the physical Space bar and watch Quindar" check was **not** possible through the bridge. Surfacing these so we can close them:

- **No key-event injection.** The bridge `invoke` targets named widgets / visible menu actions; the space-bar PTT is an application-level `QKeyEvent` filter and `mox_toggle` is a global `QShortcut` — neither is reachable, so the bridge can't drive the exact code path this fix changes. (Drove the equivalent `requestPttOff` via the MOX button instead.)
- **Quindar firing isn't observable.** No `quindar` phase/active field in any `get` snapshot and `ClientQuindarTone` has no log category. The only proxy is the deferred-unkey timing; the tone itself and the `quindarActiveChanged` chip flash can't be read. *Proposed:* add `quindarPhase`/`quindarActive` to the `transmit` snapshot, or an `lcQuindar` log line on intro/outro start.
- **QUIN enable chip not in `dumpTree`.** The chip is an unnamed checkable `QPushButton`, so the bridge can't read or toggle Quindar state. *Proposed:* give it an `accessibleName`.
- **Concurrent automation instances collide.** Multiple `AETHER_AUTOMATION` instances share one fixed `QLocalServer` name + one discovery file (`<temp>/aethersdr-automation.json`) and `removeServer()` each other's socket; they also share the settings file and log dir. Worked around with `AETHER_AUTOMATION_SOCKET=<unique>` and a direct socket connect. *Proposed:* make the discovery file / socket name per-PID, or index the discovery file by pid.

## Scope note

Other client-handled PTT sources share this root cause (MIDI, RC-28, FlexControl MOX, the serial footswitch — `PttSource::Footswitch`'s intended home). They're left as a deliberate follow-up: they need their respective hardware to verify, and CAT/rigctl/TCI-digital paths (`PttSource::Dax`) should **not** get the deferred unkey (programmatic, timing-sensitive). As the reporter noted, PTT commanded directly to the radio over FlexLib with no client involvement (external footswitch box) can't get a true client-generated outro — worth a line in the QUIN editor dialog.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
