### PR TITLE
test(cwx): fix teardown heap-use-after-free in drift-test Fixture (#3740)

### DIFF
--- a/tests/cwx_local_keyer_drift_test.cpp
+++ b/tests/cwx_local_keyer_drift_test.cpp
@@ -89,8 +89,14 @@ private:
 };
 
 struct Fixture {
-    TestKeyer keyer;
+    // Declaration order is load-bearing: members destruct in reverse, so
+    // `states` (declared first) outlives `keyer` (declared last). A test that
+    // ends key-down leaves the keyer's dtor to call keyUpIfDown() ->
+    // emitKeyDown(false) -> this callback, which must write into a still-live
+    // `states`. Reversing these two lines reintroduces a heap-use-after-free at
+    // teardown that only the ASan/UBSan job catches (#3740).
     std::vector<int> states;
+    TestKeyer keyer;
 
     Fixture()
     {


### PR DESCRIPTION
## Summary
Fixes the weekly **ASan/UBSan** job failure in `cwx_local_keyer_drift_test` (#3740): a heap-use-after-free at `Fixture` teardown.

This is a **test-only** lifetime bug — no production code change.

## Root cause
`Fixture` members destruct in reverse declaration order. With `keyer` declared **before** `states`, `states` is freed **first**:

```cpp
struct Fixture {
    TestKeyer keyer;          // declared first  -> destroyed LAST
    std::vector<int> states;  // declared last   -> destroyed FIRST  (freed)
    Fixture() { keyer.setOnKeyDownChange([this](bool d){ states.push_back(d?1:0); }); }
};
```

When a test leaves the keyer **key-down** at teardown, the keyer's destructor still fires the callback into the already-freed vector:

`~CwxLocalKeyer()` (`CwxLocalKeyer.cpp:48`) → `keyUpIfDown()` (`:235`) → `emitKeyDown(false)` (`:229`) → installed callback → `states.push_back(0)` **into freed memory**.

`emitKeyDown` early-returns when the requested state already matches `m_lastEmittedKeyDown`, so only a test that ends **key-down** trips it. `testLateTicksShortenNextWait` starts `"S"`, ticks twice, and never drains or stops — leaving the key down — which is exactly the case the ASan trace points at.

## Fix
Reorder the two members so `states` is declared first (destroyed last) and outlives `keyer`. The destructor callback now writes into a live vector. Robust against any future test that leaves the keyer keyed-down.

## Why production is unaffected
- `MainWindow` resets the keyer **before** the audio sink it calls into.
- The sidetone callback is null-guarded.

So no runtime UAF is reachable — this only broke the sanitizer job (`priority: low`).

## Proof — agent automation bridge N/A; this is a sanitizer/unit-test bug
The automation bridge drives the running app and can't observe a unit-test teardown UAF, so the proof here is a direct **before → after** ASan run. The keyer's worker thread makes the live test's key-up/key-down state at teardown timing-dependent (hence a *weekly* flake); to make the proof deterministic I replicated the exact synchronous `TestKeyer(spawnWorker=false)` path and the `testLateTicksShortenNextWait` sequence (which leaves `states` at `size=3, cap=4` — matching the CI trace's "12 bytes inside of 16-byte region"):

**Before (buggy `states`-freed-first order)** — reproduces the CI stack frame-for-frame:
```
==ERROR: AddressSanitizer: heap-use-after-free ... WRITE of size 4
  #9  AetherSDR::CwxLocalKeyer::emitKeyDown(bool)  CwxLocalKeyer.cpp:229
  #10 AetherSDR::CwxLocalKeyer::keyUpIfDown()      CwxLocalKeyer.cpp:235
  #11 AetherSDR::CwxLocalKeyer::~CwxLocalKeyer()   CwxLocalKeyer.cpp:48
SUMMARY: AddressSanitizer: heap-use-after-free in std::vector<int>::emplace_back
exit=134
```

**After (fixed `states`-outlives-`keyer` order)** — clean:
```
states=3 key DOWN; teardown fires keyUpIfDown into LIVE states
OK: clean teardown
exit=0
```

**Real test, fixed, built with `-fsanitize=address`:** `54 OK, 0 FAIL`, no ASan report, `All tests passed.`

## Related
- #3740 (this issue) — `good first issue`, `sanitizer`, `asan-ubsan`, `CW`.

Fixes #3740

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat