### PR TITLE
fix(spectrum): default slice flags to live widgets, GPU sprites opt-in (#3777)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -594,14 +594,23 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
 #ifdef AETHER_GPU_SPECTRUM
     // #3617: GPU-composite the slice flags instead of letting them composite as
     // translucent raster QWidget siblings over the QRhiWidget (which pegs the
-    // main thread re-blending them on every ~30 Hz waterfall frame).  On by
-    // default; set AETHER_NO_GPU_FLAGS=1 to fall back to the legacy live-widget
-    // flags (A/B comparison).  The flag panels are rendered into a dedicated
-    // GPU texture (see renderGpuFrame); the small external buttons stay live
-    // widgets.  This refresh timer re-snapshots the flags so live content
-    // (S-meter, freq) keeps updating — ~12 Hz is smooth for a meter and far
-    // cheaper than the per-frame composite it replaces.
-    m_gpuFlagMode = !qEnvironmentVariableIsSet("AETHER_NO_GPU_FLAGS");
+    // main thread re-blending them on every ~30 Hz waterfall frame).  The flag
+    // panels are rendered into a dedicated GPU texture (see renderGpuFrame); the
+    // small external buttons stay live widgets.  This refresh timer re-snapshots
+    // the flags so live content (S-meter, freq) keeps updating — ~12 Hz is smooth
+    // for a meter and far cheaper than the per-frame composite it replaces.
+    //
+    // #3777: DEFAULT FLIPPED to legacy live-widget flags.  The GPU-sprite path
+    // rasterizes idle flags off-screen, where Qt's raster engine emits only
+    // grayscale (never subpixel/ClearType) text AA — so idle flag text reads
+    // softer than the live, hovered flag on Windows, and the live↔sprite swap
+    // also drives input-routing regressions (e.g. Diversity-mode RX-antenna
+    // selection).  Live widgets are crisp and interaction-correct at the cost of
+    // the ~+0.37-core main-thread composite #3695 removed.  The GPU path is kept
+    // intact behind an opt-IN env var so the trade can still be A/B-measured:
+    // set AETHER_GPU_FLAGS=1 to re-enable GPU-composited flags.  (The legacy
+    // AETHER_NO_GPU_FLAGS toggle is now redundant — live is the default.)
+    m_gpuFlagMode = qEnvironmentVariableIsSet("AETHER_GPU_FLAGS");
     m_flagRefreshTimer = new QTimer(this);
     m_flagRefreshTimer->setInterval(80);
     connect(m_flagRefreshTimer, &QTimer::timeout, this, [this]() {


### PR DESCRIPTION
## Summary

**Strategy A** of the GPU-flag reversion plan attached to #3777. Flips the slice-flag compositing **default from GPU sprites to legacy live widgets**, so idle flag text is crisp again and the live↔sprite input regressions go away — without deleting anything.

One line, at [SpectrumWidget.cpp:613](src/gui/SpectrumWidget.cpp#L613):

```cpp
// before: m_gpuFlagMode = !qEnvironmentVariableIsSet("AETHER_NO_GPU_FLAGS");  // GPU default
m_gpuFlagMode = qEnvironmentVariableIsSet("AETHER_GPU_FLAGS");                 // live default, GPU opt-in
```

Every sprite code path is already gated on `m_gpuFlagMode`, and the live-widget path is the documented A/B baseline — so this is a genuine behavioral revert with **zero** machinery removed. The GPU-sprite path stays fully intact behind **`AETHER_GPU_FLAGS=1`** for measurement. (The old `AETHER_NO_GPU_FLAGS` toggle is now redundant — live is the default — and pre-existing users of it still get live flags.)

## What this fixes
- **#3777** — idle VFO-flag text blur: live flags paint to the native window surface → ClearType subpixel AA → crisp.
- **Diversity-mode RX-antenna regression** (chibondking) — an input/popup-off-a-swapped-widget failure of the live↔sprite swap; gone with always-live flags.

## The trade-off (stated plainly)
Live widgets re-introduce the **#3617** main-thread composite cost that #3695 removed — **0.82 vs 0.45 cores, +0.37 ≈ +45% main-thread** (#3695's own measurement). This is **separate from #3797** and likely **stacks on it** on multi-panadapter setups. Per the plan, the **4-panadapter re-profile is the decision gate** for whether **Strategy B** (full excision of the sprite machinery) follows.

## Why a flip, not an excision (yet)
So the −45% optimization isn't deleted on the strength of a cosmetic + interaction complaint until the cost is measured in the very area (#3797) that's currently most painful. Reversible in one line if the measurement argues against it.

## Test plan
- [x] Builds clean (`cmake --build build --target AetherSDR`)
- [ ] Visual: idle VFO flag text is crisp on Windows (no hover-pop)
- [ ] Diversity-mode RX-antenna selection works
- [ ] **4-panadapter main-thread CPU re-profile** (decision gate for Strategy B) — and confirm dragging a flag doesn't reintroduce audio crackle/the re-raster crash #3695 noted
- [ ] `AETHER_GPU_FLAGS=1` still brings back GPU sprites (A/B hatch intact)

Refs #3777, #3617. Plan: see the #3777 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
