### PR TITLE
feat(network): VITA-49 RX buffer — raise default to 4 MiB + operator-adjustable slider (#3810)

### DIFF
--- a/src/core/NetworkSettings.h
+++ b/src/core/NetworkSettings.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "AppSettings.h"
+
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <algorithm>
+
+namespace AetherSDR {
+
+// Persistent network-tuning settings, stored as nested JSON under the single
+// AppSettings "Network" key (Principle V — no new flat keys). Currently holds
+// the VITA-49 UDP receive-buffer (SO_RCVBUF) request; extend the object for
+// future network knobs rather than adding sibling flat keys.
+class NetworkSettings {
+public:
+    // SO_RCVBUF request bounds for the VITA-49 stream socket. The slider snaps
+    // to the presets below; the kernel additionally clamps the granted size at
+    // net.core.rmem_max (surfaced via PanadapterStream::receiveBufferApplied).
+    static constexpr int kDefaultRcvBufBytes = 4 * 1024 * 1024; // 4 MiB
+    static constexpr int kMinRcvBufBytes     = 256 * 1024;      // 256 KiB
+    static constexpr int kMaxRcvBufBytes     = 4 * 1024 * 1024; // 4 MiB
+
+    static int vitaReceiveBufferBytes()
+    {
+        const int v = readObj()
+                          .value(QStringLiteral("vitaReceiveBufferBytes"))
+                          .toInt(kDefaultRcvBufBytes);
+        return std::clamp(v, kMinRcvBufBytes, kMaxRcvBufBytes);
+    }
+    static void setVitaReceiveBufferBytes(int bytes)
+    {
+        QJsonObject o = readObj();
+        o[QStringLiteral("vitaReceiveBufferBytes")] =
+            std::clamp(bytes, kMinRcvBufBytes, kMaxRcvBufBytes);
+        write(o);
+    }
+
+private:
+    static QJsonObject readObj()
+    {
+        const QString json =
+            AppSettings::instance().value(QStringLiteral("Network"), QString{}).toString();
+        if (json.isEmpty())
+            return {};
+        return QJsonDocument::fromJson(json.toUtf8()).object();
+    }
+    static void write(const QJsonObject& o)
+    {
+        auto& s = AppSettings::instance();
+        s.setValue(QStringLiteral("Network"),
+                   QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)));
+        s.save();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -156,6 +156,34 @@ bool PanadapterStream::isRunning() const
     return m_socket && m_socket->state() == QAbstractSocket::BoundState;
 }
 
+void PanadapterStream::applyReceiveBufferSize()
+{
+    if (!m_socket)
+        return;
+    // The VITA-49 streams (panadapter FFT + waterfall tiles + audio + meters)
+    // burst well above the OS default receive buffer (~208 KB on Linux). A burst
+    // — or a brief worker-thread drain stall while the host is loaded — then
+    // overflows the kernel buffer, and the kernel silently drops the excess
+    // datagrams. Those drops surface as VITA-49 sequence gaps, which the network
+    // monitor reads as packet loss and the adaptive throttle reacts to by capping
+    // the radio's pan FPS — a visible "network stats dropped" event. Request a
+    // generous SO_RCVBUF so normal bursts are absorbed. The kernel caps the grant
+    // at net.core.rmem_max; we log the granted size so an undersized rmem_max is
+    // visible in the logs rather than silently limiting us. (#3810)
+    constexpr int kDesiredRcvBufBytes = 4 * 1024 * 1024; // 4 MiB
+    m_socket->setSocketOption(QAbstractSocket::ReceiveBufferSizeSocketOption,
+                              kDesiredRcvBufBytes);
+    const int granted =
+        m_socket->socketOption(QAbstractSocket::ReceiveBufferSizeSocketOption).toInt();
+    qCInfo(lcVita49).noquote()
+        << "PanadapterStream: VITA UDP receive buffer"
+        << QStringLiteral("requested=%1").arg(kDesiredRcvBufBytes)
+        << QStringLiteral("granted=%1").arg(granted)
+        << (granted < kDesiredRcvBufBytes
+                ? QStringLiteral("(capped by net.core.rmem_max — raise it for more headroom)")
+                : QString());
+}
+
 bool PanadapterStream::start(RadioConnection* conn)
 {
     if (isRunning()) stop();  // clean up previous session before rebinding (#561)
@@ -188,6 +216,7 @@ bool PanadapterStream::start(RadioConnection* conn)
         return false;
     }
 
+    applyReceiveBufferSize();   // #3810 — absorb VITA-49 bursts so they don't drop
     m_localAddress = m_socket->localAddress();
     m_localPort = m_socket->localPort();
     qCDebug(lcVita49) << "PanadapterStream: local UDP endpoint"
@@ -256,6 +285,7 @@ bool PanadapterStream::rebindToEphemeralPort(RadioConnection* conn)
         return false;
     }
 
+    applyReceiveBufferSize();   // #3810 — absorb VITA-49 bursts so they don't drop
     m_localAddress = m_socket->localAddress();
     m_localPort = m_socket->localPort();
     m_radioAddress = conn ? conn->radioAddress() : QHostAddress();
@@ -304,6 +334,7 @@ bool PanadapterStream::startWan(const QHostAddress& radioAddr, quint16 radioUdpP
         return false;
     }
 
+    applyReceiveBufferSize();   // #3810 — absorb VITA-49 bursts so they don't drop
     m_localPort = m_socket->localPort();
     m_localAddress = m_socket->localAddress();
     m_radioAddress = radioAddr;

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -2,6 +2,7 @@
 #include "AppSettings.h"
 #include "AudioEngine.h"
 #include "LogManager.h"
+#include "NetworkSettings.h"
 #include "OpusCodec.h"
 #include "PerfTelemetry.h"
 #include "RadioConnection.h"
@@ -111,6 +112,10 @@ void PanadapterStream::init()
         AppSettings::instance().value("AudioPacketLossConcealment", "True")
             .toString() == "True");
 
+    // Seed the receive-buffer request from the persisted operator setting; each
+    // bind path then applies it via applyReceiveBufferSize(). (#3810)
+    m_desiredRcvBufBytes = NetworkSettings::vitaReceiveBufferBytes();
+
     connect(m_socket, &QUdpSocket::readyRead,
             this, &PanadapterStream::onDatagramReady);
 
@@ -169,19 +174,30 @@ void PanadapterStream::applyReceiveBufferSize()
     // the radio's pan FPS — a visible "network stats dropped" event. Request a
     // generous SO_RCVBUF so normal bursts are absorbed. The kernel caps the grant
     // at net.core.rmem_max; we log the granted size so an undersized rmem_max is
-    // visible in the logs rather than silently limiting us. (#3810)
-    constexpr int kDesiredRcvBufBytes = 4 * 1024 * 1024; // 4 MiB
-    m_socket->setSocketOption(QAbstractSocket::ReceiveBufferSizeSocketOption,
-                              kDesiredRcvBufBytes);
+    // visible in the logs rather than silently limiting us. The requested size
+    // is operator-adjustable (Radio Setup → Advanced); default 4 MiB. (#3810)
+    const int requested = m_desiredRcvBufBytes;
+    m_socket->setSocketOption(QAbstractSocket::ReceiveBufferSizeSocketOption, requested);
     const int granted =
         m_socket->socketOption(QAbstractSocket::ReceiveBufferSizeSocketOption).toInt();
+    m_grantedRcvBufBytes.store(granted);
     qCInfo(lcVita49).noquote()
         << "PanadapterStream: VITA UDP receive buffer"
-        << QStringLiteral("requested=%1").arg(kDesiredRcvBufBytes)
+        << QStringLiteral("requested=%1").arg(requested)
         << QStringLiteral("granted=%1").arg(granted)
-        << (granted < kDesiredRcvBufBytes
+        << (granted < requested
                 ? QStringLiteral("(capped by net.core.rmem_max — raise it for more headroom)")
                 : QString());
+    emit receiveBufferApplied(requested, granted);
+}
+
+void PanadapterStream::setReceiveBufferSizeBytes(int bytes)
+{
+    m_desiredRcvBufBytes = bytes;
+    // Re-apply live if we already have a bound socket; otherwise the next bind
+    // picks it up via applyReceiveBufferSize().
+    if (m_socket && m_socket->state() == QAbstractSocket::BoundState)
+        applyReceiveBufferSize();
 }
 
 bool PanadapterStream::start(RadioConnection* conn)

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -126,6 +126,11 @@ private slots:
 
 private:
     void processDatagram(const QByteArray& data);
+    // Raise the kernel receive buffer (SO_RCVBUF) on the bound VITA-49 socket so
+    // bursts / brief drain stalls don't overflow it and surface as false
+    // sequence-loss (which the adaptive throttle would react to). Logs the
+    // granted size — the kernel caps the request at net.core.rmem_max. (#3810)
+    void applyReceiveBufferSize();
     void decodeFFT(const uchar* raw, int totalBytes, bool hasTrailer, quint32 streamId);
     void decodeWaterfallTile(const uchar* raw, int totalBytes, bool hasTrailer, quint32 streamId);
     void decodeNarrowAudio(const uchar* raw, int totalBytes, bool hasTrailer, quint32 streamId);

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -105,6 +105,15 @@ public:
     Q_INVOKABLE void setPacketLossConcealment(bool on);
     bool packetLossConcealment() const { return m_plcEnabled.load(); }
 
+    // Live-set the VITA-49 socket receive buffer (SO_RCVBUF) request, in bytes.
+    // Re-applies immediately if the socket is bound. Q_INVOKABLE: must run on
+    // the network worker thread (the socket lives there). Persistence is the
+    // caller's responsibility (NetworkSettings, on the GUI thread). (#3810)
+    Q_INVOKABLE void setReceiveBufferSizeBytes(int bytes);
+    // Kernel-granted SO_RCVBUF after the last apply (may be < requested when
+    // capped by net.core.rmem_max). 0 until the first bind. Safe from any thread.
+    int grantedReceiveBufferBytes() const { return m_grantedRcvBufBytes.load(); }
+
 signals:
     void daxAudioReady(int channel, const QByteArray& pcm);
     void iqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
@@ -120,6 +129,9 @@ signals:
     void audioDataReady(const QByteArray& pcm);
     // Meter data: parallel arrays of (meter_index, raw_int16_value).
     void meterDataReady(const QVector<quint16>& ids, const QVector<qint16>& vals);
+    // Emitted after the receive buffer is (re)applied on a bind or a live
+    // setReceiveBufferSizeBytes(). granted < requested ⇒ capped by rmem_max.
+    void receiveBufferApplied(int requestedBytes, int grantedBytes);
 
 private slots:
     void onDatagramReady();
@@ -143,6 +155,12 @@ private:
     // declared above.
     QMap<quint32, AudioPlcState> m_audioPlc;
     std::atomic<bool> m_plcEnabled{true};
+
+    // VITA-49 receive-buffer (SO_RCVBUF) request + last kernel-granted size.
+    // m_desiredRcvBufBytes is seeded from NetworkSettings at init and updated by
+    // setReceiveBufferSizeBytes(); applyReceiveBufferSize() requests it on bind.
+    int m_desiredRcvBufBytes{4 * 1024 * 1024};
+    std::atomic<int> m_grantedRcvBufBytes{0};
 
     // PacketClassCodes (from FlexLib VitaFlex.cs)
     static constexpr quint16 PCC_IF_NARROW         = 0x03E3u; // float32 stereo, big-endian

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6,6 +6,8 @@
 #include "models/RadioModel.h"
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
+#include "core/NetworkSettings.h"
+#include "core/PanadapterStream.h"
 #include "core/KiwiSdrManager.h"
 #include "KiwiPublicReceiverPicker.h"
 #include "core/LogManager.h"
@@ -1098,6 +1100,84 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             AppSettings::instance().save();
         });
         grid->addWidget(mtuSpin, 1, 1);
+
+        // VITA-49 UDP receive buffer (SO_RCVBUF). Snap-to-preset slider; the
+        // kernel clamps the grant at net.core.rmem_max, so we show the granted
+        // size live (PanadapterStream::receiveBufferApplied) — the slider never
+        // claims more than the system actually gives. (#3810)
+        static const int kRcvBufPresets[] = {
+            256 * 1024, 512 * 1024, 1024 * 1024, 2 * 1024 * 1024, 4 * 1024 * 1024
+        };
+        constexpr int kRcvBufPresetCount = 5;
+        auto fmtBytes = [](int b) -> QString {
+            if (b >= 1024 * 1024)
+                return QStringLiteral("%1 MB").arg(
+                    QString::number(b / (1024.0 * 1024.0), 'g', 3));
+            return QStringLiteral("%1 KB").arg(b / 1024);
+        };
+
+        grid->addWidget(new QLabel("VITA-49 RX buffer:"), 2, 0);
+        auto* bufRow = new QWidget;
+        auto* bufLay = new QHBoxLayout(bufRow);
+        bufLay->setContentsMargins(0, 0, 0, 0);
+        bufLay->setSpacing(8);
+        auto* bufSlider = new QSlider(Qt::Horizontal);
+        bufSlider->setRange(0, kRcvBufPresetCount - 1);
+        bufSlider->setSingleStep(1);
+        bufSlider->setPageStep(1);
+        bufSlider->setTickPosition(QSlider::TicksBelow);
+        bufSlider->setTickInterval(1);
+        bufSlider->setToolTip(
+            "Kernel receive buffer for the VITA-49 stream socket.\n"
+            "Larger absorbs panadapter/waterfall bursts so they aren't dropped\n"
+            "(dropped packets look like network-stat dips). Default 4 MB.\n"
+            "The system caps this at net.core.rmem_max — see the granted size.");
+        // Initial position: smallest preset >= the persisted request.
+        {
+            const int cur = AetherSDR::NetworkSettings::vitaReceiveBufferBytes();
+            int idx = kRcvBufPresetCount - 1;
+            for (int i = 0; i < kRcvBufPresetCount; ++i)
+                if (kRcvBufPresets[i] >= cur) { idx = i; break; }
+            bufSlider->setValue(idx);
+        }
+        auto* bufValLabel = new QLabel(fmtBytes(kRcvBufPresets[bufSlider->value()]));
+        bufValLabel->setMinimumWidth(48);
+        bufLay->addWidget(bufSlider, 1);
+        bufLay->addWidget(bufValLabel);
+        grid->addWidget(bufRow, 2, 1);
+
+        auto* bufGrantedLabel = new QLabel;
+        if (m_model && m_model->panStream()) {
+            const int g = m_model->panStream()->grantedReceiveBufferBytes();
+            bufGrantedLabel->setText(g > 0 ? QString("granted: %1").arg(fmtBytes(g))
+                                           : QStringLiteral("granted: — (applies on connect)"));
+        }
+        grid->addWidget(bufGrantedLabel, 3, 1);
+
+        connect(bufSlider, &QSlider::valueChanged, this,
+                [this, bufValLabel, fmtBytes](int idx) {
+            const int bytes = kRcvBufPresets[std::clamp(idx, 0, kRcvBufPresetCount - 1)];
+            bufValLabel->setText(fmtBytes(bytes));
+            AetherSDR::NetworkSettings::setVitaReceiveBufferBytes(bytes);
+            // Re-apply live on the network worker thread (the socket lives there).
+            if (m_model && m_model->panStream()) {
+                QMetaObject::invokeMethod(
+                    m_model->panStream(),
+                    [stream = m_model->panStream(), bytes]() {
+                        stream->setReceiveBufferSizeBytes(bytes);
+                    });
+            }
+        });
+        // Live granted-size feedback (cross-thread → queued).
+        if (m_model && m_model->panStream()) {
+            connect(m_model->panStream(), &PanadapterStream::receiveBufferApplied, this,
+                    [bufGrantedLabel, fmtBytes](int requested, int granted) {
+                QString t = QString("granted: %1").arg(fmtBytes(granted));
+                if (granted < requested)
+                    t += QStringLiteral("  (capped by net.core.rmem_max)");
+                bufGrantedLabel->setText(t);
+            });
+        }
 
         for (auto* lbl : group->findChildren<QLabel*>())
             if (lbl->styleSheet().isEmpty()) lbl->setStyleSheet(kLabelStyle);


### PR DESCRIPTION
## Summary

Closes #3810. Raises `SO_RCVBUF` on the `PanadapterStream` VITA-49 UDP socket to **4 MiB**, fixing the "network stats drop at various times" symptom.

## Root cause
The stream socket never set `SO_RCVBUF`, so it used the OS default (~208 KB on Linux). VITA-49 bursts (panadapter FFT + waterfall tiles + audio + meters) — or a brief worker-thread drain stall under host load — overflow that buffer; the kernel drops the excess. Those drops surface as **VITA-49 sequence gaps** → `RadioModel::evaluateNetworkQuality()` reads them as packet loss → degrades the net state → the **adaptive throttle caps the radio's pan FPS** (down to 4 fps) → visible stat drop, held 5 s (min-dwell), then lifts → re-trips on the next burst.

**Live evidence:** a running session's stream socket showed **370 receive-buffer overflow drops** (`ss -m` → `d370`) against an `rb212992` (~208 KB) buffer, arriving in a burst, not a steady leak.

## Change
- New `applyReceiveBufferSize()` helper, called after a successful bind on **all three** paths (LAN `start`, ephemeral `rebindToEphemeralPort`, `startWan`).
- Requests 4 MiB and **logs the granted size** — the kernel caps the request at `net.core.rmem_max`, so an undersized `rmem_max` is now visible in the logs (`granted=… (capped by net.core.rmem_max …)`) instead of silently limiting the buffer.
- Cross-platform (`QAbstractSocket::ReceiveBufferSizeSocketOption`). +36 lines, one subsystem.

## Test plan
- [x] Builds clean
- [ ] On a live FLEX session: log shows `granted=` near 4 MiB; the stream socket's `ss -m` drop counter stops climbing across bursts/band-changes
- [ ] Network-stats panel no longer shows the periodic FPS-cap dips on a healthy LAN
- [ ] WAN path still binds/streams (the `startWan` call site)

## Relation to #3797
The pegged GUI thread (#3797) makes overflow more likely (it can stall the socket drain during bursts), so the two compound — but the buffer is the directly fixable root for this symptom; #3797 is the separate render-side bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
