### PR TITLE
fix(gui) Allow DAX TX Audio in voice modes (#3805)

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -468,6 +468,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // because doing so parks DAX2's TX Stream in Busy. (#2315)
     auto updateDaxTxMode = [this]() {
         bool isDigital = false;
+        bool voiceMode = false;
         int txSliceId = -1;
         for (auto* sl : m_radioModel.slices()) {
             if (sl->isTxSlice()) {
@@ -475,6 +476,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 const QString& m = sl->mode();
                 isDigital = (m == "DIGU" || m == "DIGL" || m == "RTTY"
                           || m == "DFM"  || m == "NFM"  || m == "NT");
+                voiceMode = (m == "USB" || m == "LSB" || m == "AM"
+                          || m == "SAM" || m == "FM" );
                 break;
             }
         }
@@ -492,10 +495,11 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // the user re-arms it from the DAX2 window.  Let the user manage that
         // state via DAX2 — matches SmartSDR Console behavior. (#2315)
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
-        m_audio->setDaxTxMode(isDigital);
+        bool allowDaxTx = isDigital || voiceMode;
+        m_audio->setDaxTxMode(allowDaxTx);
         if (!profileLoadRadioStateWritesHeld()) {
-            m_radioModel.transmitModel().setDax(isDigital);
-            if (isDigital) {
+            m_radioModel.transmitModel().setDax(allowDaxTx);
+            if (allowDaxTx) {
                 m_radioModel.ensureDaxTxStream(DaxTxRequestReason::HostedDaxBridge);
             }
         }


### PR DESCRIPTION
fixes #3805 

## Summary

When transmitting audio through the AetherSDR DAX TX PipeWire device (aethersdr-tx), the DAX TX path appears to receive audio correctly, but no RF modulation occurs in SSB modes.

Specifically:

* The DAX TX PipeWire node accepts audio.
* The DAX TX level meter inside AetherSDR responds correctly.
* Monitoring the DAX TX stream through PipeWire confirms that the transmitted audio is present and intelligible.
* The exact same audio path successfully produces RF in DIGU mode.
* In USB/LSB, the transmitter keys normally, but no audio reaches the RF output.

## Fix

Add a check for voice modes to determine if DAX TX is allowed.

## Rationale

In SmartSDR, the behavior is:

* if the `DAX` button is enabled on the `Phone/CW` panel, then voice modes will transmit DAX audio when the transmitter is keyed.
* if not, then DAX audio is not transmitted.

This suggests that the "opt in" suggested in #3805 is actually that `DAX` button, and doesn't need to be a separate setting. This patch replicates the exact behavior seen in SmartSDR while leaving the Windows path un-touched.

## Checklist

- [X] Verified on live radio (flex 6300)
- [X] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [X] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [X] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)

## Note

This is my very first attempt at contributing to a project I discovered about a week ago. My apologies if I've missed a step. I am always open to feedback.