### PR TITLE
feat(automation): bridge fidelity — slice tx, key/PTT, menu reachability, lineedit submit, resize, multi-instance + station identity

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1442,9 +1442,26 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         const QString text = actionDisplayText(menuAction);
         const QString data = actionDataText(menuAction);
         bool done = false;
+        bool deferred = false;
         if (action == QLatin1String("trigger") || action == QLatin1String("click")
             || action == QLatin1String("toggle")) {
-            done = triggerMenuAction(menuAction, menu);
+            // CRASH-SAFETY: a menu action can open a MODAL dialog (dlg.exec() —
+            // Configure Shortcuts, Slice Troubleshooting, Memory, Profile
+            // Manager, …). exec() spins a nested event loop; running it
+            // synchronously here would re-enter the event loop INSIDE the
+            // QLocalSocket read callback (qt_mac_socket_callback ->
+            // canReadNotification -> handleLine), corrupting the socket notifier
+            // and segfaulting on a later readyRead. It would also block the
+            // response until the dialog closed. Defer the trigger to a clean
+            // main-loop turn so any nested dialog loop runs on a normal stack.
+            // (#3646 fidelity — re-entrancy crash fix)
+            QPointer<QAction> ag = menuAction;
+            QPointer<QMenu> mg = menu;
+            QTimer::singleShot(0, qApp, [ag, mg]() {
+                if (ag) triggerMenuAction(ag, mg);
+            });
+            done = true;
+            deferred = true;
         } else if (action == QLatin1String("setChecked")) {
             if (!menuAction->isCheckable()) {
                 return err(QStringLiteral("action '") + target
@@ -1476,7 +1493,12 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         if (!data.isEmpty()) {
             r[QStringLiteral("data")] = data;
         }
-        if (actionGuard) {
+        if (deferred) {
+            // The trigger runs on the next main-loop turn (it may open a modal
+            // dialog), so any post-state must be re-read (dumpTree / menu list)
+            // rather than trusted from this synchronous reply.
+            r[QStringLiteral("deferred")] = true;
+        } else if (actionGuard) {
             const QString nv = actionValue(actionGuard);
             if (!nv.isNull()) {
                 r[QStringLiteral("newValue")] = nv;

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1,5 +1,6 @@
 #include "AutomationServer.h"
 #include "LogManager.h"
+#include "AppSettings.h"          // StationName (restore the user's real station name)
 #include "TxKeyingMarker.h"       // kTxKeyingProperty — authoritative TX-guard marker
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 
@@ -8,8 +9,11 @@
 #include <QLocalSocket>
 #include <QApplication>
 #include <QWidget>
+#include <QMainWindow>
 #include <QMenu>
+#include <QMenuBar>
 #include <QMouseEvent>
+#include <QSysInfo>
 #include <QPointer>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -25,6 +29,7 @@
 #include <QStandardPaths>
 #include <QCoreApplication>
 #include <QRegularExpression>
+#include <QSet>
 #include <QTimer>
 #include <QDateTime>
 #include <QTime>
@@ -366,6 +371,70 @@ ResolvedAction resolveVisibleAction(const QString& target)
     return {};
 }
 
+// Walk a QMenu's actions WITHOUT the isVisible() gate, descending into
+// submenus, so a menu-bar leaf action is reachable even while its menu is
+// closed. The owning QMenu is returned so triggerMenuAction() can route through
+// the closed-menu (action->trigger()) path. (#3646 fidelity — items 5 + 7)
+ResolvedAction matchMenuActionUnconditional(QMenu* menu, const QString& target)
+{
+    for (QAction* action : menu->actions()) {
+        if (action->isSeparator())
+            continue;
+        if (actionMatchesTarget(action, target))
+            return {action, menu};
+        if (QMenu* submenu = action->menu()) {
+            const ResolvedAction match = matchMenuActionUnconditional(submenu, target);
+            if (match.action)
+                return match;
+        }
+    }
+    return {};
+}
+
+// Resolve a QAction anywhere in any top-level window's menu bar, regardless of
+// whether the menu is currently open. This is what lets `invoke` drive
+// menu-launched dialogs (AetherControl…/Network…/MQTT…/Radio Setup…/Connect…)
+// and View→UI Scale→Zoom without the user first popping the menu.
+ResolvedAction resolveMenuBarAction(const QString& target)
+{
+    const QWidgetList tops = QApplication::topLevelWidgets();
+    // 1. Any QMainWindow's menu bar (Windows/Linux, and macOS when the actions
+    //    remain on the bar). Searched unconditionally so a CLOSED menu resolves.
+    for (QWidget* tlw : tops) {
+        auto* mw = qobject_cast<QMainWindow*>(tlw);
+        if (!mw)
+            continue;
+        QMenuBar* mb = mw->menuBar();
+        if (!mb)
+            continue;
+        for (QAction* topAction : mb->actions()) {
+            // A top-level menu title (e.g. "Settings") matches but has no owning
+            // QMenu to route through; its submenu is what carries the leaves.
+            if (actionMatchesTarget(topAction, target))
+                return {topAction, nullptr};
+            if (QMenu* submenu = topAction->menu()) {
+                const ResolvedAction match = matchMenuActionUnconditional(submenu, target);
+                if (match.action)
+                    return match;
+            }
+        }
+    }
+    // 2. macOS NATIVE menu bar: Qt reparents each top menu to a TOP-LEVEL QMenu
+    //    that is NOT under a queryable QMenuBar, so the menu-bar walk above finds
+    //    nothing. Walk every top-level QMenu unconditionally to reach those. A
+    //    transient context-menu/combo-popup QMenu won't carry our dialog/zoom
+    //    labels, so the exact-text match stays unambiguous.
+    for (QWidget* tlw : tops) {
+        auto* menu = qobject_cast<QMenu*>(tlw);
+        if (!menu)
+            continue;
+        const ResolvedAction match = matchMenuActionUnconditional(menu, target);
+        if (match.action)
+            return match;
+    }
+    return {};
+}
+
 // Capture a widget to an image. The QRhi panadapter needs a framebuffer
 // readback (QWidget::grab() would return empty/garbage for a GPU surface),
 // so route QRhiWidget through its own grab().
@@ -483,14 +552,14 @@ bool isTransmitAction(const QAction* action, const QMenu* owner)
 
 bool triggerMenuAction(QAction* action, QMenu* menu)
 {
-    if (!action || !menu) {
+    if (!action) {
         return false;
     }
 
     QPointer<QAction> actionGuard = action;
     QPointer<QMenu> menuGuard = menu;
-    const QRect r = menu->actionGeometry(action);
-    if (menu->isVisible() && r.isValid() && !r.isEmpty()) {
+    const QRect r = menu ? menu->actionGeometry(action) : QRect();
+    if (menu && menu->isVisible() && r.isValid() && !r.isEmpty()) {
         const QPoint local = r.center();
         const QPoint global = menu->mapToGlobal(local);
         menu->setActiveAction(action);
@@ -812,18 +881,46 @@ bool AutomationServer::start(const QString& serverName)
     connect(m_server, &QLocalServer::newConnection,
             this, &AutomationServer::onNewConnection);
 
-    // Drop a discovery file so a driver can find the resolved endpoint without
-    // knowing the platform-specific socket path. Best-effort; not fatal.
-    m_discoveryFile = QDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation))
-                          .filePath(QStringLiteral("aethersdr-automation.json"));
+    // Drop discovery info so a driver can find the resolved endpoint without
+    // knowing the platform-specific socket path. Two forms, both best-effort:
+    //   1. A per-pid entry in a discovery DIRECTORY, so multiple concurrent
+    //      AETHER_AUTOMATION instances each own one file and can be ENUMERATED
+    //      (a driver lists the dir, reads {pid,socket,label}, picks the right
+    //      one). Each instance removes only its own entry on stop. (#3646)
+    //   2. A legacy single fixed file pointing at THIS instance, so existing
+    //      single-instance drivers keep working unchanged. On stop it is removed
+    //      only if it still points at our pid (so an exiting sibling can't blind
+    //      a survivor).
+    m_label = qEnvironmentVariable("AETHER_AUTOMATION_LABEL");
+    const QString tmp = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
     QJsonObject disc;
     disc[QStringLiteral("socket")]  = fullServerName();
     disc[QStringLiteral("name")]    = serverName;
-    disc[QStringLiteral("pid")]     = QCoreApplication::applicationPid();
+    disc[QStringLiteral("pid")]     = static_cast<qint64>(QCoreApplication::applicationPid());
     disc[QStringLiteral("version")] = QCoreApplication::applicationVersion();
+    if (!m_label.isEmpty())
+        disc[QStringLiteral("label")] = m_label;
+    disc[QStringLiteral("startedAt")] = QDateTime::currentMSecsSinceEpoch();
+    const QByteArray discJson = QJsonDocument(disc).toJson(QJsonDocument::Compact);
+
+    m_discoveryDir = QDir(tmp).filePath(QStringLiteral("aethersdr-automation"));
+    if (QDir().mkpath(m_discoveryDir)) {
+        m_discoveryEntry = QDir(m_discoveryDir)
+                               .filePath(QString::number(QCoreApplication::applicationPid())
+                                         + QStringLiteral(".json"));
+        QFile ef(m_discoveryEntry);
+        if (ef.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            ef.write(discJson);
+            ef.close();
+        } else {
+            m_discoveryEntry.clear();
+        }
+    }
+
+    m_discoveryFile = QDir(tmp).filePath(QStringLiteral("aethersdr-automation.json"));
     QFile df(m_discoveryFile);
     if (df.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        df.write(QJsonDocument(disc).toJson(QJsonDocument::Compact));
+        df.write(discJson);
         df.close();
     } else {
         m_discoveryFile.clear();
@@ -871,9 +968,31 @@ bool AutomationServer::start(const QString& serverName)
     m_logDrain->setInterval(50);
     connect(m_logDrain, &QTimer::timeout, this, &AutomationServer::onLogDrain);
 
+    // Agent station identity (#3646): announce the agent's name to other
+    // MultiFlex clients. Apply now if already connected; on every (re)connect —
+    // which re-runs the handshake's own `client station <user>` send — re-apply
+    // shortly after so the agent name is what sticks.
+    m_agentStation = qEnvironmentVariableIsSet("AETHER_AUTOMATION_STATION")
+                         ? qEnvironmentVariable("AETHER_AUTOMATION_STATION")
+                         : QStringLiteral("Claude");
+    if (m_radioModel) {
+        connect(m_radioModel, &RadioModel::connectionStateChanged, this,
+                [this](bool connected) {
+                    if (!connected || m_agentStation.isEmpty())
+                        return;
+                    QPointer<AutomationServer> self(this);
+                    QTimer::singleShot(1000, this, [self]() {
+                        if (self) self->applyAgentStation(self->m_agentStation);
+                    });
+                });
+        if (m_radioModel->isConnected())
+            applyAgentStation(m_agentStation);
+    }
+
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, grab, invoke, get, txtest, atu, slice, tune, log, mark)";
+        << "(verbs: ping, dumpTree, grab, invoke, get, txtest, atu, slice, tune,"
+        << "key, station, resize, menu, whoami, log, mark)";
     return true;
 }
 
@@ -885,6 +1004,10 @@ void AutomationServer::stop()
     // Safety: never leave the radio keyed when the bridge shuts down.
     if (m_txAllowed)
         forceUnkey("automation bridge stopping");
+
+    // Restore the user's real station name so live MultiFlex peers stop seeing
+    // the agent name immediately (don't wait for the disconnect to drop it).
+    restoreStation();
     if (m_txWatchdog) {
         m_txWatchdog->stop();
         m_txWatchdog->deleteLater();
@@ -910,8 +1033,22 @@ void AutomationServer::stop()
     m_server->deleteLater();
     m_server = nullptr;
 
+    // Our own per-pid entry is always ours to remove.
+    if (!m_discoveryEntry.isEmpty()) {
+        QFile::remove(m_discoveryEntry);
+        m_discoveryEntry.clear();
+    }
+    // The legacy shared pointer: remove it only if it still points at US, so an
+    // exiting sibling can't blind a still-running instance that owns it now.
     if (!m_discoveryFile.isEmpty()) {
-        QFile::remove(m_discoveryFile);
+        QFile lf(m_discoveryFile);
+        if (lf.open(QIODevice::ReadOnly)) {
+            const QJsonObject o = QJsonDocument::fromJson(lf.readAll()).object();
+            lf.close();
+            if (o.value(QStringLiteral("pid")).toVariant().toLongLong()
+                == QCoreApplication::applicationPid())
+                QFile::remove(m_discoveryFile);
+        }
         m_discoveryFile.clear();
     }
 }
@@ -1067,7 +1204,19 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             QStringList rest;
             for (int i = 1; i < p.size(); ++i) rest << tok(i);
             value = rest.join(QLatin1Char(' '));  // free-form annotation text
-        } else {  // grab and friends
+        } else if (cmd == QLatin1String("key")) {
+            action = tok(1); value = tok(2);  // "key ptt on", "key mox"
+        } else if (cmd == QLatin1String("station")) {
+            value = tok(1);   // "station Claude"
+        } else if (cmd == QLatin1String("resize")) {
+            value = tok(1) + QLatin1Char(' ') + tok(2);  // "resize 1920 1080 [target]"
+            target = tok(3);
+        } else if (cmd == QLatin1String("menu")) {
+            action = tok(1);  // list | open
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));  // "menu open Settings"
+        } else {  // grab, whoami and friends
             target = tok(1); path = tok(2);
         }
     }
@@ -1110,7 +1259,7 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("slice")) {
         if (action.isEmpty())
-            return err(QStringLiteral("slice requires an action (add|remove|select)"));
+            return err(QStringLiteral("slice requires an action (add|remove|select|tx)"));
         return doSlice(action, value);
     }
     if (cmd == QLatin1String("tune")) {
@@ -1118,6 +1267,22 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("tune requires a frequency in MHz"));
         return doTune(value);
     }
+    if (cmd == QLatin1String("key")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("key requires a name (ptt on|off, mox)"));
+        return doKey(action, value);
+    }
+    if (cmd == QLatin1String("station")) {
+        if (value.isEmpty())
+            return err(QStringLiteral("station requires a name"));
+        return doStation(value);
+    }
+    if (cmd == QLatin1String("resize"))
+        return doResize(value, target);
+    if (cmd == QLatin1String("menu"))
+        return doMenu(action.isEmpty() ? QStringLiteral("list") : action, value);
+    if (cmd == QLatin1String("whoami"))
+        return doWhoami();
     if (cmd == QLatin1String("log"))
         return doLog(action.isEmpty() ? QStringLiteral("categories") : action, value, sock);
     if (cmd == QLatin1String("mark")) {
@@ -1245,11 +1410,16 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
 {
     QWidget* w = resolveWidget(target);
     if (!w) {
-        const ResolvedAction resolved = resolveVisibleAction(target);
+        // An open menu wins (it carries live geometry for a real mouse trigger);
+        // otherwise reach the action in a CLOSED menu bar so menu-launched
+        // dialogs and Zoom are drivable without first popping the menu. (#3646)
+        ResolvedAction resolved = resolveVisibleAction(target);
+        if (!resolved.action)
+            resolved = resolveMenuBarAction(target);
         QAction* menuAction = resolved.action;
         QMenu* menu = resolved.menu;
         if (!menuAction) {
-            return err(QStringLiteral("widget or visible menu action not found: ") + target);
+            return err(QStringLiteral("widget or menu action not found: ") + target);
         }
 
         if (menuAction->isSeparator()) {
@@ -1386,6 +1556,18 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         }
     } else if (action == QLatin1String("setText")) {
         if (auto* le = qobject_cast<QLineEdit*>(w)) { le->setText(value); done = true; }
+    } else if (action == QLatin1String("submit")) {
+        // Commit a line edit: optionally set the value, then fire returnPressed —
+        // the signal that actually drives the action (a frequency retune, etc.).
+        // setText alone is intentionally side-effect-free, because other
+        // bridge-reachable fields (SmartLink login, manual-connect host, DX
+        // cluster command) attach irreversible actions to returnPressed; commit
+        // must be an explicit, opt-in verb. (#3646 fidelity — item 6)
+        if (auto* le = qobject_cast<QLineEdit*>(w)) {
+            if (!value.isEmpty()) le->setText(value);
+            emit le->returnPressed();
+            done = true;
+        }
     } else if (action == QLatin1String("setCurrentText")) {
         if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentText(value); done = true; }
     } else if (action == QLatin1String("setCurrentIndex")) {
@@ -1635,7 +1817,28 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("select")},
                            {QStringLiteral("id"), id}};
     }
-    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select)"));
+    if (action == QLatin1String("tx")) {
+        // Make slice <id> the TX slice — the literal external-split transition
+        // (rigctld set_split_vfo 1 VFOB) bottoms out here. Set-only via the same
+        // SliceModel chokepoint the CAT split path uses; the radio enforces
+        // single-TX and clears the prior TX slice, so we never clear it
+        // client-side (radio-authoritative). The txSlice flag flips only when
+        // the radio echoes status back, so callers re-poll `get slices`. (#3646)
+        bool okId = false;
+        const int id = arg.toInt(&okId);
+        if (!okId)
+            return err(QStringLiteral("slice tx requires a slice id"));
+        SliceModel* s = radio->slice(id);
+        if (!s)
+            return err(QStringLiteral("no slice with id ") + arg);
+        if (s->isTxSlice())
+            return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("tx")},
+                               {QStringLiteral("id"), id}, {QStringLiteral("alreadyTx"), true}};
+        s->setTxSlice(true);
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("slice"), QStringLiteral("tx")},
+                           {QStringLiteral("id"), id}, {QStringLiteral("requested"), true}};
+    }
+    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select|tx)"));
 }
 
 // ── VFO tuning (#3646) ──────────────────────────────────────────────────────
@@ -1663,6 +1866,282 @@ QJsonObject AutomationServer::doTune(const QString& value)
     s->setFrequency(mhz);
     return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
                        {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
+}
+
+// ── Semantic transmitter keying (#3646 fidelity — item 3) ───────────────────
+// `key ptt on|off` and `key mox` drive RadioModel::setTransmit — the exact
+// calls the space-bar PTT event filter (MainWindow_Shortcuts.cpp) and the
+// mox_toggle QShortcut make, which `invoke` cannot reach (one is an app-level
+// QKeyEvent filter, the other a global QShortcut — neither is a named widget).
+// We route to the model rather than synthesizing a QKeyEvent so it is
+// deterministic and focus-independent. KEYING is gated by the same
+// AETHER_AUTOMATION_ALLOW_TX rail as txtest/atu and arms the force-unkey
+// watchdog; UNKEY is always allowed (it only reduces TX risk).
+QJsonObject AutomationServer::doKey(const QString& name, const QString& arg)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    auto& tx = m_radioModel->transmitModel();
+    const QString n = name.trimmed().toLower();
+    const QString a = arg.trimmed().toLower();
+
+    auto keyOn = [&](const QString& what) -> QJsonObject {
+        if (!m_txAllowed)
+            return err(QStringLiteral("blocked: key '") + what
+                       + QStringLiteral("' keys the transmitter — set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
+        m_radioModel->setTransmit(true);               // == space-bar PTT press (Mox)
+        m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();  // arm watchdog window
+        qCInfo(lcAutomation).noquote() << "key" << what << "ON (ALLOW_TX)";
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("key"), what},
+                           {QStringLiteral("state"), QStringLiteral("on")}};
+    };
+    auto keyOff = [&](const QString& what) -> QJsonObject {
+        m_radioModel->setTransmit(false);              // == space-bar PTT release
+        m_txKeyedSinceMs = 0;
+        qCInfo(lcAutomation).noquote() << "key" << what << "OFF";
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("key"), what},
+                           {QStringLiteral("state"), QStringLiteral("off")}};
+    };
+
+    if (n == QLatin1String("ptt")) {
+        if (a == QLatin1String("off") || a == QLatin1String("0")
+            || a == QLatin1String("false") || a == QLatin1String("release"))
+            return keyOff(QStringLiteral("ptt"));
+        if (a.isEmpty() || a == QLatin1String("on") || a == QLatin1String("1")
+            || a == QLatin1String("true") || a == QLatin1String("press"))
+            return keyOn(QStringLiteral("ptt"));
+        return err(QStringLiteral("key ptt requires on|off"));
+    }
+    if (n == QLatin1String("mox") || n == QLatin1String("mox_toggle")) {
+        // mox_toggle is non-idempotent: toggling while keyed UNKEYS (ungated),
+        // toggling while idle KEYS (gated). Mirrors the QShortcut handler.
+        return tx.isTransmitting() ? keyOff(QStringLiteral("mox"))
+                                   : keyOn(QStringLiteral("mox"));
+    }
+    return err(QStringLiteral("unknown key '") + name
+               + QStringLiteral("' (use: ptt on|off, mox)"));
+}
+
+// ── Per-GUI-client station identity (#3646 fidelity — item 1) ───────────────
+// Set `client station <name>` so other MultiFlex clients see the agent's name.
+// This is the per-GUI-client station identity (FlexLib SetClientStationName),
+// orthogonal to the radio-wide callsign — we NEVER write `radio callsign`,
+// which is persisted on the radio's front panel. The station name is
+// session-scoped and the radio drops it when this client disconnects, so it is
+// inherently non-persistent; we additionally restore the user's real name on
+// bridge stop so any live peer reverts immediately.
+void AutomationServer::applyAgentStation(const QString& name)
+{
+    if (!m_radioModel || !m_radioModel->isConnected() || name.isEmpty())
+        return;
+    if (!m_stationApplied) {
+        // Capture the user's real station name once, to restore it later. Same
+        // fallback the connect handshake uses (AppSettings StationName → host).
+        m_priorStationName = AppSettings::instance().value("StationName", "").toString();
+        if (m_priorStationName.isEmpty())
+            m_priorStationName = QSysInfo::machineHostName();
+    }
+    m_radioModel->sendCommand(QStringLiteral("client station %1").arg(name));
+    m_stationApplied = true;
+    qCInfo(lcAutomation).noquote() << "station name set to" << name
+                                   << "(other MultiFlex clients will see this)";
+}
+
+void AutomationServer::restoreStation()
+{
+    if (!m_stationApplied || m_priorStationName.isEmpty())
+        return;
+    if (m_radioModel && m_radioModel->isConnected())
+        m_radioModel->sendCommand(QStringLiteral("client station %1").arg(m_priorStationName));
+    m_stationApplied = false;
+}
+
+QJsonObject AutomationServer::doStation(const QString& name)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+    const QString n = name.trimmed();
+    if (n.isEmpty())
+        return err(QStringLiteral("station requires a name"));
+    if (n.contains(QLatin1Char(' ')))
+        return err(QStringLiteral("station name must be a single token (no spaces)"));
+    if (!m_radioModel->isConnected())
+        return err(QStringLiteral("not connected — connect to a radio before setting the station name"));
+    m_agentStation = n;
+    applyAgentStation(n);
+    return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("station"), n}};
+}
+
+// ── Headless render size (#3646 fidelity — item 8) ──────────────────────────
+// Resize a top-level window so the panadapter x_pixels (== SpectrumWidget
+// width) propagates to a realistic value — under QT_QPA_PLATFORM=offscreen the
+// window collapses to the tiny virtual screen and x_pixels stalls near the
+// floor, so render-size-dependent code (FFT/waterfall stream rate, rhiFlush
+// composite cost, burst regressions) is never exercised. We resize the WINDOW
+// (not force xpixels via the radio command) so the local FFT decoder, the
+// dimensionsChanged debounce, and the radio stay in sync.
+QJsonObject AutomationServer::doResize(const QString& value, const QString& target) const
+{
+    int w = 0, h = 0;
+    const QString v = value.trimmed().toLower();
+    if (v.isEmpty() || v == QLatin1String("default") || v == QLatin1String("full")) {
+        w = 1920; h = 1080;   // realistic full size → SpectrumWidth ~1873
+    } else {
+        QString s = value;
+        s.replace(QLatin1Char('x'), QLatin1Char(' '));
+        s.replace(QLatin1Char('X'), QLatin1Char(' '));
+        const QStringList parts = s.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.size() >= 2) { w = parts.at(0).toInt(); h = parts.at(1).toInt(); }
+        else if (parts.size() == 1) { w = parts.at(0).toInt(); h = w * 9 / 16; }
+    }
+    if (w <= 0 || h <= 0)
+        return err(QStringLiteral("resize requires <width> <height> (e.g. 'resize 1920 1080', or 'full')"));
+
+    QWidget* win = nullptr;
+    if (!target.isEmpty()) {
+        QWidget* t = resolveWidget(target);
+        win = t ? t->window() : nullptr;
+        if (!win)
+            return err(QStringLiteral("window not found for target: ") + target);
+    } else {
+        const QWidgetList tops = QApplication::topLevelWidgets();
+        for (QWidget* tlw : tops) {           // prefer the QMainWindow
+            if (tlw->inherits("QMainWindow")) { win = tlw; break; }
+        }
+        if (!win) {                            // else first visible real window
+            for (QWidget* tlw : tops) {
+                if (tlw->objectName() == QLatin1String("qt_scrollarea_viewport"))
+                    continue;
+                if (qobject_cast<QMenu*>(tlw))
+                    continue;
+                if (tlw->isWindow() && tlw->isVisible()) { win = tlw; break; }
+            }
+        }
+    }
+    if (!win)
+        return err(QStringLiteral("no top-level window to resize"));
+
+    // The status-bar min-width recompute caps min width to the screen on a small
+    // offscreen virtual screen; drop the floor so the resize isn't re-clamped.
+    if (win->minimumWidth() > w)
+        win->setMinimumWidth(0);
+    win->resize(w, h);
+
+    QJsonObject r{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("requested"), QJsonObject{{QStringLiteral("w"), w}, {QStringLiteral("h"), h}}},
+        {QStringLiteral("actual"), QJsonObject{{QStringLiteral("w"), win->width()},
+                                               {QStringLiteral("h"), win->height()}}},
+    };
+    // Surface the panadapter width — that IS x_pixels, the thing an agent asserts
+    // on after the ~300ms dimensionsChanged debounce re-pushes it to the radio.
+    if (QWidget* sw = resolveWidget(QStringLiteral("SpectrumWidget")))
+        r[QStringLiteral("spectrumWidth")] = sw->width();
+    return r;
+}
+
+// ── Menu-bar discovery / popup (#3646 fidelity — items 5 + 7) ────────────────
+// `menu list` enumerates the menu-bar tree (so an agent can discover exact
+// labels to invoke); `menu open <name>` pops a top-level menu non-blocking so a
+// follow-up dumpTree/grab can snapshot it. Triggering a leaf is done via
+// `invoke <label> trigger` (resolveMenuBarAction), not here.
+namespace {
+QJsonArray describeMenuActions(QMenu* menu)
+{
+    QJsonArray arr;
+    for (QAction* a : menu->actions()) {
+        if (a->isSeparator())
+            continue;
+        QJsonObject o{{QStringLiteral("text"), actionDisplayText(a)},
+                      {QStringLiteral("enabled"), a->isEnabled()}};
+        if (a->isCheckable()) {
+            o[QStringLiteral("checkable")] = true;
+            o[QStringLiteral("checked")] = a->isChecked();
+        }
+        if (QMenu* sub = a->menu())
+            o[QStringLiteral("submenu")] = describeMenuActions(sub);
+        arr.append(o);
+    }
+    return arr;
+}
+
+// The app's top-level menus, coping with BOTH a regular QMenuBar and the macOS
+// NATIVE menu bar (where each menu is reparented to a top-level QMenu widget,
+// invisible to QMainWindow::menuBar()->actions()). De-duplicated, in discovery
+// order. On macOS this also surfaces submenus as their own entries — harmless.
+QList<QPair<QString, QMenu*>> collectTopMenus()
+{
+    QList<QPair<QString, QMenu*>> out;
+    QSet<QMenu*> seen;
+    const QWidgetList tops = QApplication::topLevelWidgets();
+    for (QWidget* tlw : tops) {
+        auto* mw = qobject_cast<QMainWindow*>(tlw);
+        if (!mw || !mw->menuBar())
+            continue;
+        for (QAction* a : mw->menuBar()->actions()) {
+            if (QMenu* sub = a->menu(); sub && !seen.contains(sub)) {
+                seen.insert(sub);
+                out.append({actionDisplayText(a), sub});
+            }
+        }
+    }
+    for (QWidget* tlw : tops) {
+        auto* menu = qobject_cast<QMenu*>(tlw);
+        if (!menu || seen.contains(menu))
+            continue;
+        const QString title = actionDisplayText(menu->menuAction());
+        if (title.isEmpty())
+            continue;   // a context/combo popup, not a named menu-bar menu
+        seen.insert(menu);
+        out.append({title, menu});
+    }
+    return out;
+}
+} // namespace
+
+QJsonObject AutomationServer::doMenu(const QString& action, const QString& arg) const
+{
+    const QList<QPair<QString, QMenu*>> menus = collectTopMenus();
+    if (menus.isEmpty())
+        return err(QStringLiteral("no menus found"));
+
+    if (action == QLatin1String("list")) {
+        QJsonArray arr;
+        for (const auto& m : menus)
+            arr.append(QJsonObject{{QStringLiteral("title"), m.first},
+                                   {QStringLiteral("actions"), describeMenuActions(m.second)}});
+        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("menus"), arr}};
+    }
+    if (action == QLatin1String("open")) {
+        if (arg.isEmpty())
+            return err(QStringLiteral("menu open requires a menu name"));
+        for (const auto& m : menus) {
+            if (m.first.compare(arg, Qt::CaseInsensitive) != 0
+                && !actionMatchesTarget(m.second->menuAction(), arg))
+                continue;
+            // popup() is non-blocking (unlike exec()), so it can't deadlock the
+            // socket handler on the GUI thread.
+            m.second->popup(QPoint(200, 200));
+            return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("menu"), QStringLiteral("open")},
+                               {QStringLiteral("title"), m.first}};
+        }
+        return err(QStringLiteral("menu not found: ") + arg);
+    }
+    return err(QStringLiteral("unknown menu action: ") + action + QStringLiteral(" (list|open)"));
+}
+
+QJsonObject AutomationServer::doWhoami() const
+{
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("pid"), static_cast<qint64>(QCoreApplication::applicationPid())},
+        {QStringLiteral("name"), m_serverName},
+        {QStringLiteral("socket"), fullServerName()},
+        {QStringLiteral("label"), m_label},
+        {QStringLiteral("station"), m_agentStation},
+        {QStringLiteral("txAllowed"), m_txAllowed},
+        {QStringLiteral("version"), QCoreApplication::applicationVersion()},
+    };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -60,6 +60,36 @@ class RadioModel;
 //                                     trailing property name, returns just that
 //                                     field. Assert on state without screenshots.
 //
+// Phase 2 verbs (fidelity — reach code paths invoke/get can't, #3646):
+//
+//   invoke <le> submit [value]     -> commit a QLineEdit: optional setText then
+//                                     fire returnPressed (the retune/login/send
+//                                     trigger). setText alone stays side-effect-
+//                                     free, so a plain value-set never logs in /
+//                                     connects / sends to a live cluster.
+//   invoke <label> trigger         -> now resolves a QAction anywhere in the menu
+//                                     bar even while its menu is CLOSED, so
+//                                     menu-launched dialogs (AetherControl…,
+//                                     Network…, MQTT…, Radio Setup…, Connect…)
+//                                     and Zoom are drivable headlessly.
+//   slice tx <id>                  -> make slice <id> the TX slice (the external-
+//                                     split transition). Set-only, radio-auth.
+//   key ptt on|off | key mox       -> drive PTT / MOX via the model — the space-
+//                                     bar PTT filter and mox_toggle shortcut that
+//                                     invoke can't target. KEYING is gated by
+//                                     AETHER_AUTOMATION_ALLOW_TX (unkey is not).
+//   station <name>                 -> set the per-GUI-client station name shown
+//                                     to other MultiFlex clients (never the radio
+//                                     callsign). Auto-applied to the agent name
+//                                     on connect, restored on stop.
+//   resize <w> <h> [target]        -> resize a top-level window (default full
+//                                     size) so the panadapter x_pixels reaches a
+//                                     realistic value for headless render tests.
+//   menu list | menu open <name>   -> enumerate the menu bar / pop a menu for a
+//                                     follow-up grab/dumpTree.
+//   whoami                         -> {pid, socket, label, station} — identify
+//                                     THIS instance among concurrent bridges.
+//
 // Requests are newline-delimited. Each line is either a bare command
 // ("dumpTree", "grab SpectrumWidget /tmp/pan.png", "invoke masterVolume
 // setValue 30", "get slice active") or a JSON object ({"cmd":"invoke",
@@ -125,9 +155,29 @@ private:
 
     void forceUnkey(const char* reason);  // emergency all-stop (tune/mox/two-tone)
 
-    // Slice lifecycle (add/remove/select) and VFO tuning — RX/config, no keying.
+    // Slice lifecycle (add/remove/select/tx) and VFO tuning — RX/config, no keying.
     QJsonObject doSlice(const QString& action, const QString& arg);
     QJsonObject doTune(const QString& value);
+    // Semantic transmitter keying (#3646 fidelity): `key ptt on|off` / `key mox`
+    // route to RadioModel::setTransmit — the exact calls the space-bar PTT filter
+    // and the mox_toggle shortcut make, but reachable headlessly. Keying is gated
+    // by AETHER_AUTOMATION_ALLOW_TX (the same rail as txtest/atu); unkey is not.
+    QJsonObject doKey(const QString& name, const QString& arg);
+    // Per-GUI-client station identity (#3646 fidelity). Sets `client station
+    // <name>` so other MultiFlex clients see the agent's name; NEVER the radio
+    // callsign. Auto-applied on connect, restored on stop. No keying.
+    QJsonObject doStation(const QString& name);
+    void applyAgentStation(const QString& name);  // capture prior + send
+    void restoreStation();                        // re-send the user's real name
+    // Resize a top-level window so the panadapter x_pixels (== SpectrumWidget
+    // width) propagates to a realistic value for headless render-size fidelity.
+    QJsonObject doResize(const QString& value, const QString& target) const;
+    // Menu-bar discovery/popup (#3646 fidelity): `menu list` enumerates the
+    // menu-bar tree; `menu open <name>` pops a top-level menu for grab/dumpTree.
+    QJsonObject doMenu(const QString& action, const QString& arg) const;
+    // Identity of THIS bridge instance — pid/socket/label — for multi-instance
+    // drivers that enumerate the per-pid discovery directory.
+    QJsonObject doWhoami() const;
     // Observability suite (#3646): runtime log-category control, ring-buffer
     // tail, push subscription, and timeline markers. All diagnostic, no keying.
     QJsonObject doLog(const QString& action, const QString& arg, QLocalSocket* sock);
@@ -141,9 +191,19 @@ private:
 
     QLocalServer* m_server{nullptr};
     QString       m_serverName;
-    QString       m_discoveryFile;
+    QString       m_discoveryFile;    // legacy single-instance pointer (back-compat)
+    QString       m_discoveryDir;     // <temp>/aethersdr-automation/ (per-pid entries)
+    QString       m_discoveryEntry;   // this instance's <pid>.json in m_discoveryDir
+    QString       m_label;            // AETHER_AUTOMATION_LABEL (human instance tag)
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
+
+    // Agent station identity (#3646). The bridge sets the per-GUI-client station
+    // name to the agent's name on connect and restores the user's real name on
+    // stop, so other MultiFlex clients can see an agent is driving.
+    QString m_agentStation;          // applied name (AETHER_AUTOMATION_STATION)
+    QString m_priorStationName;      // user's real station name, captured to restore
+    bool    m_stationApplied{false};
 
     // TX safety rails (active only when AETHER_AUTOMATION_ALLOW_TX is set).
     QTimer* m_txWatchdog{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4149,6 +4149,27 @@ void MainWindow::buildUI()
         return sep;
     };
 
+    // Automation indicator chip — visible ONLY when the agent automation bridge
+    // is active (AETHER_AUTOMATION). Mirrors the per-client station name the
+    // bridge announces to the radio (AETHER_AUTOMATION_STATION, default
+    // "Claude") so the operator can see at a glance that an agent is driving.
+    // Kept deliberately separate from the station-nickname label so it never
+    // fights radio status updates. (#3646)
+    if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        const QString agent = qEnvironmentVariableIsSet("AETHER_AUTOMATION_STATION")
+            ? qEnvironmentVariable("AETHER_AUTOMATION_STATION")
+            : QStringLiteral("Claude");
+        m_automationChip = new QLabel(QStringLiteral("\U0001F916 ") + agent);
+        m_automationChip->setStyleSheet(
+            "QLabel { color: #0b0e12; background: #f0a000; font-weight: bold;"
+            " font-size: 18px; border-radius: 4px; padding: 2px 10px; }");
+        m_automationChip->setToolTip(
+            QStringLiteral("Agent automation bridge active — other MultiFlex stations see this client as \"%1\"")
+                .arg(agent));
+        hbox->addWidget(m_automationChip);
+        addSep();
+    }
+
     // Hidden connection state label (used by connect/disconnect logic)
     m_connStatusLabel = new QLabel("", this);
     m_connStatusLabel->hide();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -864,6 +864,7 @@ private:
     QLabel* m_radioVersionLabel{nullptr};
     QLabel* m_stationLabel{nullptr};
     QLabel* m_stationNickLabel{nullptr};
+    QLabel* m_automationChip{nullptr};    // shown only under AETHER_AUTOMATION (#3646)
     QLabel* m_gpsLabel{nullptr};
     QLabel* m_gpsStatusLabel{nullptr};
     QLabel* m_bandStackIndicator{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -726,17 +726,22 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         "QPushButton:checked { background: rgba(0,180,216,210); color: #000; }"
         "QPushButton:pressed { background: #00b4d8; color: #000; }";
 
-    auto makeBtn = [&](const QString& text) {
+    // objectName + accessibleName let the automation bridge target these by a
+    // stable handle instead of the visible label \u2014 notably zoom-out, whose glyph
+    // is a U+2212 minus sign that is awkward to send as button text. (#3646)
+    auto makeBtn = [&](const QString& text, const QString& objName, const QString& a11y) {
         auto* btn = new QPushButton(text, this);
+        btn->setObjectName(objName);
+        btn->setAccessibleName(a11y);
         btn->setFixedSize(22, 22);
         btn->setStyleSheet(kZoomBtnStyle);
         btn->setCursor(Qt::PointingHandCursor);
         return btn;
     };
-    m_zoomSegBtn  = makeBtn("S");
-    m_zoomBandBtn = makeBtn("B");
-    m_zoomOutBtn  = makeBtn("\u2212");  // minus sign U+2212
-    m_zoomInBtn   = makeBtn("+");
+    m_zoomSegBtn  = makeBtn("S", QStringLiteral("panZoomSegBtn"),  QStringLiteral("Zoom to segment"));
+    m_zoomBandBtn = makeBtn("B", QStringLiteral("panZoomBandBtn"), QStringLiteral("Zoom to band"));
+    m_zoomOutBtn  = makeBtn("\u2212", QStringLiteral("panZoomOutBtn"), QStringLiteral("Zoom out"));  // minus sign U+2212
+    m_zoomInBtn   = makeBtn("+", QStringLiteral("panZoomInBtn"),   QStringLiteral("Zoom in"));
 
     // SmartSDR pcap: B sends "band_zoom=1", S sends "segment_zoom=1"
     connect(m_zoomBandBtn, &QPushButton::clicked, this, [this]() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -413,12 +413,16 @@ int main(int argc, char* argv[])
 
         // Agent-drivable automation bridge (#3646, Phase 0). Off in production;
         // starts only when AETHER_AUTOMATION is set. AETHER_AUTOMATION_SOCKET
-        // overrides the default QLocalServer name.
+        // overrides the QLocalServer name verbatim (explicit, for a driver that
+        // wants a known endpoint). Otherwise the default name is PID-suffixed so
+        // two concurrent automation instances don't steal each other's socket
+        // (QLocalServer::removeServer() unlinks a sibling's live socket on a
+        // shared name); drivers find the right one via the discovery file/dir.
         std::unique_ptr<AetherSDR::AutomationServer> automation;
         if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
             const QString sockName = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
                 ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
-                : QStringLiteral("aethersdr-automation");
+                : QStringLiteral("aethersdr-automation-%1").arg(QCoreApplication::applicationPid());
             automation = std::make_unique<AetherSDR::AutomationServer>();
             automation->setRadioModel(&window.radioModel());  // for the get() verb
             if (!automation->start(sockName))


### PR DESCRIPTION
## Summary

Phase-2 **fidelity** pass on the agent automation bridge (`AETHER_AUTOMATION`). It adds verbs that let an agent drive code paths `invoke`/`get` could not reach, hardens concurrent-instance discovery, and gives the bridge a visible identity — addressing 8 pieces of operator feedback collected from running 12 bug-fixes through a design → code → prove loop.

Builds on `origin/main` (which already carries the slice/observability/TX-rails work). **All 18 live checks pass on a FLEX-8400M into an ANT2 dummy load.**

## What's new

| # | Feedback | Change |
|---|---|---|
| 1 | No automation identity | `client station <name>` auto-applied on connect (default `Claude`, `AETHER_AUTOMATION_STATION`); propagates to other MultiFlex clients; restored on stop. **Never** touches the radio callsign. Plus a 🤖 status-bar chip. |
| 2 | No slice-TX verb | `slice tx <id>` → `SliceModel::setTxSlice(true)` — the external-split transition, set-only, radio-authoritative. |
| 3 | No key injection | `key ptt on\|off`, `key mox` → `RadioModel::setTransmit` (the spacebar-PTT filter + mox_toggle shortcut `invoke` can't target). **Keying gated by `AETHER_AUTOMATION_ALLOW_TX`** + force-unkey watchdog; unkey ungated. |
| 4 | Concurrent instances collide | Default socket is `aethersdr-automation-<pid>`; discovery written to a per-pid `<temp>/aethersdr-automation/<pid>.json` directory entry (enumerable) plus a back-compat legacy pointer that self-deletes only. `AETHER_AUTOMATION_LABEL` + `whoami`. |
| 5 + 7 | Menu/QAction unreachable | `invoke "<label>" trigger` now resolves a QAction **anywhere in the menu bar while the menu is closed** → opens AetherControl…/Network…/Radio Setup… etc. `menu list`/`menu open`. Zoom buttons got stable objectNames. |
| 6 | QLineEdit no commit | New `submit` action emits `returnPressed` (optional inline value). `setText` stays **side-effect-free** by design. |
| 8 | Headless render size | `resize <w> <h> [target]` resizes the window so panadapter `x_pixels` (== SpectrumWidth) reaches a realistic value; returns `spectrumWidth`. |

## Design decisions (two open questions from the feedback)

- **Should `setText` auto-commit?** No — kept it pure, added an explicit `submit`. Three other bridge-reachable line edits attach *irreversible* actions to `returnPressed` (SmartLink **login**, manual **connect**, live **DX-cluster/RBN send**); auto-commit would fire those from a plain value-set.
- **Headless: small render for tokens, or realistic size?** Realistic. `x_pixels` *is* the radio's FFT bin count / stream rate — the thing render-size-dependent code needs. Screenshot/token economy is a **separate axis** on the `grab` path, so we resize the window (not force `xpixels`, which would desync the local FFT decoder).

## Multi-instance: what PID isolation does and doesn't solve

The per-pid socket + discovery directory fix the **software** collision (two bridges no longer steal each other's socket — verified with two instances coexisting). They do **not** lift the radio's **hardware** limits: the MultiFlex GUI-client ceiling and the radio-wide slice cap are unchanged. Guidance: non-radio tests (UI/menu/dumpTree/grab) scale freely with PID isolation; radio-touching tests are bounded by MultiFlex and must serialize or target distinct radios; only one instance should hold `ALLOW_TX`.

## Notable fix found during live test

`menu list` returned 0 on macOS: AetherSDR doesn't set `AA_DontUseNativeMenuBar`, so Qt reparents menus to **top-level `QMenu` widgets** that `QMainWindow::menuBar()->actions()` never sees. The resolver now also walks top-level `QMenu`s unconditionally — confirmed by enumerating 9 menus and opening the AetherControl dialog from a closed menu.

## Safety

- All transmitter keying (`key ptt on`, `key mox`-to-key) is gated behind `AETHER_AUTOMATION_ALLOW_TX`, identical to `txtest`/`atu`, and arms the existing force-unkey watchdog; unkey is always allowed. No raw key-event injection verb (rejected as leakier).
- Station identity writes only the per-GUI-client `client station` name (session-scoped, dropped on disconnect), never the persisted radio callsign.

## Test plan / live results

Exercised end-to-end via the in-repo harness (`tools/automation_probe.py` + `automation_logwatch.py`) with a safety gate that asserts the TX antenna is the dummy load before any keying:

- **id/4** ping, `whoami` (pid/socket/label/station/txAllowed), radio connected, **TX-antenna safety gate**
- **1** 🤖 chip present, `whoami` station, `station <name>` verb
- **5** `menu list` (9 menus), `invoke "AetherControl…" trigger` opens dialog from closed menu
- **7** zoom buttons by objectName
- **2** `slice tx <id>` flips `txSlice` (radio-confirmed)
- **6** `setText` does **not** retune; `submit` retunes 3.6→3.63
- **8** `resize` → SpectrumWidth 1590
- **3** `key ptt on` → transmitting; `key ptt off` → unkeyed; `key mox` toggles; final unkeyed — all on ANT2

**18 / 18 PASS.** The gate also correctly *refused* to key in an earlier run when the TX antenna was still ANT1.

---

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
