### PR TITLE
feat(shortcuts): add Master Volume Up/Down configurable keyboard shortcuts (#3791)

### DIFF
--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -27,6 +27,7 @@
 #include "RxApplet.h"
 #include "SpectrumOverlayMenu.h"
 #include "SpectrumWidget.h"
+#include "TitleBar.h"
 #include "VfoWidget.h"
 #include "MainWindowShortcutState.h"
 #include "core/AppSettings.h"
@@ -739,6 +740,24 @@ void MainWindow::registerShortcutActions()
         QKeySequence(), [this]() {
             m_audio->setMuted(!m_audio->isMuted());
         });
+    // Master volume up/down — mirrors the Aether Control "VolumeUp"/"VolumeDown"
+    // dispatch (MainWindow_Controllers.cpp): clamp MasterVolume ±5 in [0,100],
+    // update the title-bar slider, and push to the audio path. No default key
+    // (Up/Down are taken by per-slice AF Gain); the user binds keys themselves.
+    m_shortcutManager.registerAction("master_volume_up", "Master Volume Up", "Audio",
+        QKeySequence(), [this]() {
+            const int next = std::clamp(
+                AppSettings::instance().value("MasterVolume", "100").toInt() + 5, 0, 100);
+            if (m_titleBar) m_titleBar->setMasterVolume(next);
+            applyMasterVolume(next);
+        }, /*autoRepeat=*/true);
+    m_shortcutManager.registerAction("master_volume_down", "Master Volume Down", "Audio",
+        QKeySequence(), [this]() {
+            const int next = std::clamp(
+                AppSettings::instance().value("MasterVolume", "100").toInt() - 5, 0, 100);
+            if (m_titleBar) m_titleBar->setMasterVolume(next);
+            applyMasterVolume(next);
+        }, /*autoRepeat=*/true);
     m_shortcutManager.registerAction("squelch_toggle", "Squelch Toggle", "Audio",
         QKeySequence(), [this]() {
             auto* s = activeSlice();


### PR DESCRIPTION
## Summary

Adds **Master Volume Up** and **Master Volume Down** to the configurable keyboard-shortcut list (Audio category), as requested in #3791.

## Root cause

`MainWindow::registerShortcutActions()` (`src/gui/MainWindow_Shortcuts.cpp`) registers the Audio category with per-slice AF Gain Up/Down, mute/mute-all, master mute, and squelch — but **no master volume up/down**. The user is correct that this is simply a gap: the identical nudge logic already ships for external controllers (the Aether Control / StreamDeck `"VolumeUp"` / `"VolumeDown"` dispatch in `MainWindow_Controllers.cpp`).

## Fix

Register `master_volume_up` / `master_volume_down` in the Audio category, reusing that exact, already-shipped path:

- clamp `MasterVolume` ±5 into `[0,100]`,
- update the title-bar slider via `TitleBar::setMasterVolume()`,
- push to the audio path via `applyMasterVolume()` — keeping GUI, persistence, and TCI in sync.

Registered with **no default key** (Up/Down are taken by per-slice AF Gain, and master volume is a distinct concept — the user binds keys themselves) and **`autoRepeat=true`** so holding the bound key ramps continuously (consistent with `rf_gain_up/down` and the tune actions). Single TU; one added include (`TitleBar.h`, needed for the `setMasterVolume` call since `MainWindow.h` only forward-declares it).

## How the agent automation bridge proved it

Built and driven through the bridge (`AETHER_AUTOMATION=1`). The two new entries had to be shown to actually appear in the **Configure Shortcuts…** list.

Reaching that dialog needed the bridge fidelity work in #3819 (closed-menu `QAction` trigger + per-pid sockets), so the proof was captured against a local merge of this branch with `feat/automation-bridge-fidelity`. This branch itself is the single-file change above.

**1 — machine-readable.** The dialog's Action selector is a non-editable `QComboBox` populated directly from `ShortcutManager::actions()`. `setCurrentText` only takes if the item exists, so an exact echo is proof of registration:

```
invoke AetherSDR::ShortcutDialog/QComboBox setCurrentText "[Audio] Master Volume Up"
  -> newValue="[Audio] Master Volume Up"   PROVEN
invoke AetherSDR::ShortcutDialog/QComboBox setCurrentText "[Audio] Master Volume Down"
  -> newValue="[Audio] Master Volume Down" PROVEN
```

**2 — visual.** With the dialog's search filter set to `Master Volume`, a `grab` of `AetherSDR::ShortcutDialog` shows exactly two rows — **Master Volume Up** and **Master Volume Down**, both **Audio** category, both with empty Current/Default Key (no default binding, as designed).

| Field | Detail |
|---|---|
| Issue | #3791 — add master volume up/down to configurable shortcuts |
| Root cause | feature simply not registered in the Audio shortcut table (`MainWindow_Shortcuts.cpp`) |
| Fix | +2 `registerAction` entries reusing the shipped controller `VolumeUp/Down` nudge; +1 include |
| Bridge proof | non-editable action-combo `setCurrentText` exact-echo (both entries) + filtered dialog `grab` showing both Audio rows |
| Build | clean (Ninja, all cores) |

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
