### PR TITLE
feat(vfo): accent ADSP launcher when a client NR module is active (#3800)

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3221,6 +3221,28 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
         ensureAetherDspDialog();
     });
 
+    // Accent the ADSP launcher whenever any client-side NR module is active, so
+    // the reporter's gap — "enable NR4 and nothing on the main surface shows it"
+    // — is closed without opening the applet (#3800). The client modules are
+    // global AudioEngine state, so every slice's ADSP button tracks the same OR
+    // of the six *Enabled() flags. Bound to w so it drops when the slice closes.
+    if (m_audio) {
+        auto syncAetherDsp = [this, w] {
+            if (!m_audio) return;
+            const bool active = m_audio->nr2Enabled() || m_audio->nr4Enabled()
+                             || m_audio->mnrEnabled() || m_audio->bnrEnabled()
+                             || m_audio->dfnrEnabled() || m_audio->rn2Enabled();
+            w->setAetherDspActive(active);
+        };
+        connect(m_audio, &AudioEngine::nr2EnabledChanged,  w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        connect(m_audio, &AudioEngine::nr4EnabledChanged,  w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        connect(m_audio, &AudioEngine::mnrEnabledChanged,  w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        connect(m_audio, &AudioEngine::bnrEnabledChanged,  w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        connect(m_audio, &AudioEngine::dfnrEnabledChanged, w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        connect(m_audio, &AudioEngine::rn2EnabledChanged,  w, [syncAetherDsp](bool){ syncAetherDsp(); });
+        syncAetherDsp();  // apply current state to this freshly-wired slice
+    }
+
     // AetherVoice button on the per-slice DSP tab — toggles the Aetherial
     // Audio Channel Strip, matching the existing menu / chain entry points.
     connect(w, &VfoWidget::aetherVoiceRequested,

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -255,6 +255,15 @@ static const QString kDspToggle =
     "QPushButton:checked { background: #1a6030; color: #ffffff; border: 1px solid #20a040; }"
     "QPushButton:hover { border: 1px solid #0090e0; }";
 
+// Active-accent variant for the non-checkable ADSP launcher: mirrors the
+// green "active" look the radio-side toggles get via :checked, so a client-side
+// NR module being on (NR2 / NR4 / MNR / BNR / DFNR / RN2) is visible on the VFO
+// grid without opening the AetherDSP applet. (#3800)
+static const QString kDspToggleActive =
+    "QPushButton { background: #1a6030; border: 1px solid #20a040; border-radius: 2px; "
+    "color: #ffffff; font-size: 13px; font-weight: bold; padding: 2px 4px; }"
+    "QPushButton:hover { border: 1px solid #0090e0; }";
+
 static const QString kModeBtn =
     "QPushButton { background: #1a2a3a; border: 1px solid #304050; border-radius: 2px; "
     "color: #c8d8e8; font-size: 13px; font-weight: bold; padding: 3px; }"
@@ -1638,6 +1647,7 @@ void VfoWidget::buildTabContent()
         // single-cell width as the radio-side toggles, but non-checkable.
         // Placed by relayoutDspGrid() at the end of the radio-side toggle list.
         m_aetherDspBtn = new QPushButton("ADSP");
+        m_aetherDspBtn->setObjectName("aetherDspBtn");
         m_aetherDspBtn->setCheckable(false);
         m_aetherDspBtn->setMinimumHeight(22);
         m_aetherDspBtn->setStyleSheet(kDspToggle);
@@ -2849,6 +2859,24 @@ void VfoWidget::setSmartSdrPlus(bool has)
 void VfoWidget::setHasExtendedDsp(bool has)
 {
     m_hasExtendedDsp = has;
+}
+
+// Accent the ADSP launcher when any client-side NR module is active (#3800).
+// The client modules (NR2 / NR4 / MNR / BNR / DFNR / RN2) live behind this
+// button, so without a cue here the only way to tell one is on is to reopen the
+// applet. We mirror the green "active" look the radio-side toggles get, and
+// fold the state into the accessible name so screen readers — and the agent
+// automation bridge — can read it without a screenshot.
+void VfoWidget::setAetherDspActive(bool active)
+{
+    if (m_aetherDspActive == active)
+        return;
+    m_aetherDspActive = active;
+    if (!m_aetherDspBtn)
+        return;
+    m_aetherDspBtn->setStyleSheet(active ? kDspToggleActive : kDspToggle);
+    m_aetherDspBtn->setAccessibleName(active ? QStringLiteral("AetherDSP Settings (NR active)")
+                                             : QStringLiteral("AetherDSP Settings"));
 }
 
 // ── Per-slice VFO marker display prefs (#1526) ───────────────────────────────

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -397,6 +397,12 @@ public:
     void setSmartSdrPlus(bool has);
     void setHasExtendedDsp(bool has);
 
+    // Reflect whether any client-side AetherDSP NR module (NR2 / NR4 / MNR /
+    // BNR / DFNR / RN2) is active by accenting the ADSP launcher, so the cue is
+    // visible on the VFO grid without opening the applet. Driven by MainWindow
+    // from the AudioEngine *EnabledChanged signals. (#3800)
+    void setAetherDspActive(bool active);
+
     // Per-slice VFO marker display prefs, persisted by slice ID (#1526).
     // markerWidth: 0 = off, 1 = 1 px, 3 = 3 px.
     int  markerWidth() const { return m_markerWidth; }
@@ -431,6 +437,7 @@ private:
     QPushButton* m_anftBtn{nullptr};
     QPushButton* m_apfBtn{nullptr};
     QPushButton* m_aetherDspBtn{nullptr};    // launches AetherDSP Settings dialog
+    bool         m_aetherDspActive{false};   // any client NR module on (#3800)
     QPushButton* m_aetherVoiceBtn{nullptr};  // toggles Aetherial Audio Channel Strip
 
     // Shared DSP-level row at the bottom of the DSP grid: one slider whose


### PR DESCRIPTION
## Problem (#3800)

> "if you turn on NR4, there is no visual indication even if you select DSP. You need to dig deeper and click on ADSP to see which one is active … at least HIGHLIGHT the DSP button if any DSP NR function is activated."

AetherSDR's client-side NR modules (**NR2 / NR4 / MNR / BNR / DFNR / RN2**) are global `AudioEngine` state that lives *behind* the **ADSP** launcher. That button is created `setCheckable(false)` with a fixed `kDspToggle` stylesheet, so it never changes appearance — enabling NR4 left **no cue anywhere on the main surface**. The radio-side toggles (NR/NRL/NRS/…) at least look pressed; the client modules had nothing.

## Fix

Accent the ADSP launcher whenever **any** of the six client NR modules is on:

- New `kDspToggleActive` stylesheet — the same green "active" look the radio-side toggles get via `:checked` — applied to `m_aetherDspBtn` when active, reverted to `kDspToggle` when all are off.
- The active state is folded into the button's **accessibleName** (`"AetherDSP Settings (NR active)"`), so screen readers — and the agent automation bridge — can read the cue without a screenshot. A stable `objectName` (`aetherDspBtn`) keeps programmatic targeting independent of that now-dynamic name.
- `MainWindow::wireVfoWidget()` connects the six `AudioEngine::*EnabledChanged` signals (the modules are global engine state) to every slice's `VfoWidget` and syncs the current state when a slice is created. Connections are bound to the widget so they drop when the slice closes.

Minimal and self-contained: `VfoWidget.{h,cpp}` + `MainWindow_Wiring.cpp`, 57 insertions, no behavior change to the launcher's click action. The "ideal" top-right on-screen NR badge from the issue remains a follow-up (it's a two-render-path SpectrumWidget change).

## How the agent automation bridge proved it

Built on a FLEX-8400M (KI6BCJ) and driven through the bridge (`tools/automation_probe.py`) — RX-only, no TX:

**State read (`dumpTree` of `aetherDspBtn.accessibleName`):**

| Step | bridge action | ADSP accessibleName |
|---|---|---|
| baseline | — | `AetherDSP Settings` |
| NR4 on | `invoke NR4 click` → `checked` | `AetherDSP Settings (NR active)` |
| NR4 off | `invoke NR4 click` → `unchecked` | `AetherDSP Settings` |

**OR-of-modules (RN2):** RN2 on → active; NR2 toggled while RN2 still on → **stays** active; RN2 off → inactive. Confirms the indicator tracks the OR, not a single module.

**Visual (`grab aetherDspBtn`):** active = green accent, inactive = default navy.

| inactive | active (NR4 on) |
|---|---|
| navy `kDspToggle` | green `kDspToggleActive` |

Final state verified clean: indicator inactive (all client NR off), `transmitting == false`.

> The bridge fidelity work used to drive this proof (per-PID socket discovery, `grab` of a specific widget) is **not** included in this PR.

Closes #3800

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat