### PR TITLE
feat(cw): resizable CW decode panel + adjustable, persistent font size (#3628)

### DIFF
--- a/src/gui/CwDecodeSettings.h
+++ b/src/gui/CwDecodeSettings.h
@@ -41,6 +41,27 @@ public:
     // should be visible at all (regardless of which direction is fed).
     static bool anyEnabled() { return rxEnabled() || txEnabled(); }
 
+    // Decoded-text display font size (px) and panel height (px), persisted
+    // so operators can tune readability and history depth (#3628).  Stored
+    // in the same nested blob alongside the rx/tx toggles.
+    static int  fontPx()      { return readObj().value("fontPx").toInt(13); }
+    static int  panelHeight() { return readObj().value("panelHeight").toInt(80); }
+
+    static void setFontPx(int px)
+    {
+        QJsonObject o = readObj();
+        o["fontPx"] = px;
+        ensureToggles(o);
+        write(o);
+    }
+    static void setPanelHeight(int h)
+    {
+        QJsonObject o = readObj();
+        o["panelHeight"] = h;
+        ensureToggles(o);
+        write(o);
+    }
+
     // One-shot migration from the legacy "CwDecodeOverlay" flat key.  Run
     // at startup before any caller reads the new blob.  Safe to call
     // repeatedly: returns immediately if the new blob already exists.
@@ -57,6 +78,13 @@ public:
     }
 
 private:
+    // Keep the rx/tx toggles present when writing display-only keys so a
+    // fontPx/panelHeight change never drops a user's enable state.
+    static void ensureToggles(QJsonObject& o)
+    {
+        if (!o.contains("rx")) o["rx"] = QStringLiteral("True");
+        if (!o.contains("tx")) o["tx"] = QStringLiteral("False");
+    }
     static QJsonObject readObj()
     {
         const QString json =

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,4 +1,5 @@
 #include "PanadapterApplet.h"
+#include "CwDecodeSettings.h"
 #include "FramelessMoveHelper.h"
 #include "GuardedSlider.h"
 #include "RangeSlider.h"
@@ -23,6 +24,8 @@
 #include <QGuiApplication>
 #include <QClipboard>
 #include "core/ThemeManager.h"
+
+#include <algorithm>
 
 namespace AetherSDR {
 
@@ -109,15 +112,34 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     layout->addWidget(m_spectrum, 1);
 
     // ── CW decode panel (hidden by default, shown in CW mode) ─────────
+    // Restore persisted display preferences (#3628): font size and panel
+    // height are user-tunable for readability and history depth.
+    m_cwFontPx     = std::clamp(CwDecodeSettings::fontPx(), 8, 32);
+    m_cwPanelHeight = std::clamp(CwDecodeSettings::panelHeight(), 60, 600);
+
     m_cwPanel = new QWidget(this);
+    m_cwPanel->setObjectName("cwDecodePanel");  // addressable for automation (#3628/#3646)
     m_cwPanel->setCursor(Qt::ArrowCursor);  // prevent invisible cursor from native-window parent (#1096)
-    m_cwPanel->setFixedHeight(80);
+    m_cwPanel->setFixedHeight(m_cwPanelHeight);
     m_cwPanel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwPanel, "QWidget { background: {{color.background.0}}; border-top: 1px solid {{color.background.1}}; }");
 
     auto* cwLayout = new QVBoxLayout(m_cwPanel);
-    cwLayout->setContentsMargins(4, 2, 4, 2);
+    cwLayout->setContentsMargins(4, 0, 4, 2);
     cwLayout->setSpacing(1);
+
+    // Drag-grip along the top edge — drag up/down to resize the panel and
+    // reveal more decoded-text history (#3628).  A thin strip rather than a
+    // QSplitter so the GPU SpectrumWidget (QRhiWidget) is never reparented.
+    m_cwGrip = new QWidget(m_cwPanel);
+    m_cwGrip->setObjectName("cwResizeGrip");
+    m_cwGrip->setFixedHeight(4);
+    m_cwGrip->setCursor(Qt::SizeVerCursor);
+    m_cwGrip->setToolTip("Drag to resize the CW decode panel");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwGrip,
+        "QWidget { background: {{color.background.2}}; }");
+    m_cwGrip->installEventFilter(this);
+    cwLayout->addWidget(m_cwGrip);
 
     // Stats bar: pitch, speed, clear button
     auto* cwBar = new QHBoxLayout;
@@ -223,6 +245,21 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     });
     cwBar->addWidget(copyVisBtn);
 
+    // Font-size controls — adjust and persist the decoded-text size (#3628).
+    auto* fontDownBtn = new QPushButton("A-");
+    fontDownBtn->setObjectName("cwFontDown");
+    fontDownBtn->setToolTip("Decrease decoded-text font size");
+    fontDownBtn->setStyleSheet(cwBtnStyle);
+    connect(fontDownBtn, &QPushButton::clicked, this, [this] { adjustCwFont(-1); });
+    cwBar->addWidget(fontDownBtn);
+
+    auto* fontUpBtn = new QPushButton("A+");
+    fontUpBtn->setObjectName("cwFontUp");
+    fontUpBtn->setToolTip("Increase decoded-text font size");
+    fontUpBtn->setStyleSheet(cwBtnStyle);
+    connect(fontUpBtn, &QPushButton::clicked, this, [this] { adjustCwFont(+1); });
+    cwBar->addWidget(fontUpBtn);
+
     auto* clearBtn = new QPushButton("CLR");
     clearBtn->setStyleSheet(cwBtnStyle);
     connect(clearBtn, &QPushButton::clicked, this, &PanadapterApplet::clearCwText);
@@ -246,17 +283,16 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
     m_cwText = new QTextEdit;
     m_cwText->setReadOnly(true);
     m_cwText->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwText, "QTextEdit { background: {{color.background.0}}; color: {{color.accent.success}}; border: none;"
-        " font-family: monospace; font-size: 13px; font-weight: bold; }"
-        "QScrollBar:vertical { width: 6px; background: {{color.background.0}}; }"
-        "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
-        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }");
+    applyCwFont();  // font-size driven by persisted m_cwFontPx (#3628)
     m_cwText->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_cwText->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_cwText->setWordWrapMode(QTextOption::WrapAnywhere);
     m_cwText->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_cwText, &QWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
         QMenu *menu = m_cwText->createStandardContextMenu();
+        menu->addSeparator();
+        menu->addAction(tr("Increase font size"), this, [this] { adjustCwFont(+1); });
+        menu->addAction(tr("Decrease font size"), this, [this] { adjustCwFont(-1); });
         menu->addSeparator();
         menu->addAction(tr("Clear"), this, &PanadapterApplet::clearCwText);
         menu->exec(m_cwText->mapToGlobal(pos));
@@ -520,6 +556,38 @@ void PanadapterApplet::setCwPanelVisible(bool visible)
     m_cwPanel->setVisible(visible);
 }
 
+void PanadapterApplet::applyCwFont()
+{
+    // Re-apply the decoded-text stylesheet with the current font size.  The
+    // inserted runs use colour-only <span>s, so the widget font governs them.
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_cwText,
+        QStringLiteral(
+            "QTextEdit { background: {{color.background.0}}; color: {{color.accent.success}}; border: none;"
+            " font-family: monospace; font-size: %1px; font-weight: bold; }"
+            "QScrollBar:vertical { width: 6px; background: {{color.background.0}}; }"
+            "QScrollBar::handle:vertical { background: {{color.background.2}}; border-radius: 3px; }"
+            "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0; }")
+            .arg(m_cwFontPx));
+}
+
+void PanadapterApplet::adjustCwFont(int delta)
+{
+    const int next = std::clamp(m_cwFontPx + delta, 8, 32);
+    if (next == m_cwFontPx)
+        return;
+    m_cwFontPx = next;
+    applyCwFont();
+    CwDecodeSettings::setFontPx(m_cwFontPx);
+}
+
+void PanadapterApplet::setCwPanelHeight(int h)
+{
+    // Live apply only — persistence happens once on grip release to avoid
+    // writing settings on every mouse-move during a drag.
+    m_cwPanelHeight = std::clamp(h, 60, 600);
+    m_cwPanel->setFixedHeight(m_cwPanelHeight);
+}
+
 int PanadapterApplet::speedRangeLow()  const
 {
     return m_speedRangeSlider ? m_speedRangeSlider->low() : 15;
@@ -611,6 +679,30 @@ void PanadapterApplet::clearCwText()
 
 bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
 {
+    // CW panel resize grip — drag the top edge to grow/shrink the decode
+    // panel (and reveal more decoded-text history) (#3628).
+    if (obj == m_cwGrip) {
+        if (ev->type() == QEvent::MouseButtonPress) {
+            auto* me = static_cast<QMouseEvent*>(ev);
+            if (me->button() == Qt::LeftButton) {
+                m_cwResizing     = true;
+                m_cwResizeStartY = me->globalPosition().toPoint().y();
+                m_cwResizeStartH = m_cwPanel->height();
+                return true;
+            }
+        } else if (ev->type() == QEvent::MouseMove && m_cwResizing) {
+            auto* me = static_cast<QMouseEvent*>(ev);
+            // Dragging up (smaller Y) enlarges the panel.
+            const int dy = m_cwResizeStartY - me->globalPosition().toPoint().y();
+            setCwPanelHeight(m_cwResizeStartH + dy);
+            return true;
+        } else if (ev->type() == QEvent::MouseButtonRelease && m_cwResizing) {
+            m_cwResizing = false;
+            CwDecodeSettings::setPanelHeight(m_cwPanelHeight);
+            return true;
+        }
+    }
+
     if (obj == m_titleBar && m_isFloating && ev->type() == QEvent::MouseMove) {
         return FramelessMoveHelper::move(m_titleBar, static_cast<QMouseEvent*>(ev));
     }

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -84,6 +84,13 @@ protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
 
 private:
+    // Re-apply the decoded-text stylesheet at the current font size (#3628).
+    void applyCwFont();
+    // Change the decoded-text font size by `delta` px, clamp, and persist (#3628).
+    void adjustCwFont(int delta);
+    // Persist + clamp the CW panel height after a grip drag (#3628).
+    void setCwPanelHeight(int h);
+
     QString         m_panId;
     SpectrumWidget* m_spectrum{nullptr};
     QWidget*        m_titleBar{nullptr};
@@ -95,6 +102,7 @@ private:
 
     // CW decode
     QWidget*      m_cwPanel{nullptr};
+    QWidget*      m_cwGrip{nullptr};
     QTextEdit*    m_cwText{nullptr};
     QLabel*       m_cwStatsLabel{nullptr};
     QSlider*      m_cwSensSlider{nullptr};
@@ -103,6 +111,13 @@ private:
     RangeSlider*  m_pitchRangeSlider{nullptr};
     RangeSlider*  m_speedRangeSlider{nullptr};
     float         m_cwCostThreshold{0.70f};
+
+    // Adjustable, persisted decoded-text display (#3628)
+    int           m_cwFontPx{13};
+    int           m_cwPanelHeight{80};
+    bool          m_cwResizing{false};
+    int           m_cwResizeStartY{0};
+    int           m_cwResizeStartH{0};
 
     enum class CwTextSource { None, Rx, Tx };
     CwTextSource  m_lastCwTextSource{CwTextSource::None};


### PR DESCRIPTION
## Summary

Makes the CW decode panel **vertically resizable** with an **adjustable, persistent font size** — closing #3628.

Previously the panel was locked to a hardcoded `setFixedHeight(80)` with a hardcoded `13px` monospace font and no persistence, which is hard to read on high-DPI displays and can't show more decoded-text history. The panel already retains full scrollback (`m_cwText` has no `setMaximumBlockCount`/trimming), so the only blockers were the fixed height and font — no decoder changes are needed.

## Changes (all client-side; no FlexLib/protocol/decoder changes)

- **Resizable height** — a thin drag-grip (`cwResizeGrip`) along the panel's top edge resizes it vertically, clamped **60–600px**. A grip strip rather than a `QSplitter` deliberately: wrapping the layout in a splitter would reparent the GPU `SpectrumWidget` (`QRhiWidget`), which carries native-window risk (cf. #1096). The grip leaves the spectrum surface untouched.
- **Font-size control** — `A-`/`A+` buttons (`cwFontDown`/`cwFontUp`) in the CW toolbar **and** "Increase/Decrease font size" actions in the decode-text context menu, clamped **8–32px**.
- **Persistence** — both `fontPx` and `panelHeight` are stored in the existing nested `CwDecoder` settings blob via `CwDecodeSettings` (constitution Principle V) and restored in the applet constructor on launch. A new `ensureToggles()` helper keeps the rx/tx enable state intact when only a display key changes.
- **Addressability** — the panel gains `objectName "cwDecodePanel"` so the agent automation bridge can address and read it.

A taller panel immediately reveals more already-decoded history. Existing decode functionality is unchanged.

## Files
- `src/gui/PanadapterApplet.cpp` / `.h` — grip + drag handling in `eventFilter`, font buttons/menu, `applyCwFont`/`adjustCwFont`/`setCwPanelHeight`, restore on construct.
- `src/gui/CwDecodeSettings.h` — `fontPx()`/`panelHeight()` getters + setters.

## How the agent automation bridge proved it

RX-only proof (no TX), against a live FlexRadio panadapter on the `fix/3628-cw-resize` build:

**1 — Panel-height persistence + restore-on-launch.** Seeded `panelHeight=220` into the settings file, launched, and read the tree back:

```
dumpTree → cwDecodePanel: { "class":"QWidget", "geometry": { "h": 220, ... } }
```
The panel height read back **220** (the hardcoded value was 80) — the persisted height is honored on launch.

**2 — Font control reachable + adjusts + persists.** Invoked the new button via the bridge three times and watched the on-disk `CwDecoder` blob:

```
blob BEFORE : {"rx":"True","tx":"False","panelHeight":220}
invoke cwFontUp click  ×3   (each ok=true, resolved=cwFontUp)
blob AFTER  : {"fontPx":16,"panelHeight":220,"rx":"True","tx":"False"}
```
`fontPx` went **13 → 16** (three +1 increments) and persisted to disk.

dumpTree also confirmed `cwFontUp`, `cwFontDown`, and `cwResizeGrip` are present in the applet tree. The radio was left untouched (RX-only) and the local settings file was restored afterward.

### Agent automation bridge — gap found
- **No mouse-drag / gesture synthesis verb** — the bridge can `invoke` button-style actions but cannot synthesize a press-move-release drag, so the resize **grip drag itself** could not be exercised end-to-end through the bridge. I proved the persistence/restore path (seed → `dumpTree` height read-back) and the font path (`invoke` → disk), but not the literal drag gesture. Proposed: a `drag <target> dx dy` (or `mouse <target> down/move/up`) verb so grip/slider-handle drags become provable.

Fixes #3628

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
