### PR TITLE
[codex] Fix Kiwi waterfall pan and zoom stalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1913,6 +1913,13 @@ target_include_directories(kiwi_sdr_protocol_test PRIVATE src)
 target_link_libraries(kiwi_sdr_protocol_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_protocol_test COMMAND kiwi_sdr_protocol_test)
 
+add_executable(kiwi_sdr_trace_math_test
+    tests/kiwi_sdr_trace_math_test.cpp
+)
+target_include_directories(kiwi_sdr_trace_math_test PRIVATE src)
+target_link_libraries(kiwi_sdr_trace_math_test PRIVATE Qt6::Core)
+add_test(NAME kiwi_sdr_trace_math_test COMMAND kiwi_sdr_trace_math_test)
+
 # Public-directory parser + external-API (ext_api) policy honoring.
 add_executable(kiwi_public_directory_test
     tests/kiwi_public_directory_test.cpp

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1806,7 +1806,7 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
         parseWaterfallFrameHeader(frame, &frameStart, &frameZoom);
     const bool requestHasUsableRange =
         m_waterfallRequestValid
-        && m_waterfallRequestLowMhz > 0.0
+        && m_waterfallRequestLowMhz >= 0.0
         && m_waterfallRequestHighMhz > m_waterfallRequestLowMhz;
     if (!hasExtendedHeader && !requestHasUsableRange) {
         return;

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -43,8 +43,8 @@ constexpr int kZoomedWaterfallPrefixBytes = 5;
 constexpr int kDefaultWaterfallZoomCap = 14;
 constexpr int kDefaultWaterfallFftBins = 1024;
 constexpr quint64 kMaxSequenceGapPaddingFrames = 8;
+constexpr int kWaterfallGuiMinIntervalMs = 33;
 constexpr double kWaterfallStartFixedPointScale = 16777216.0; // 2^24
-constexpr quint32 kWaterfallStartServerSnapTolerance = 16;
 constexpr quint64 kWebSocketSessionIdBase = 1ULL << 62;
 
 QString trKiwiSdrClient(const char* sourceText)
@@ -386,6 +386,11 @@ KiwiSdrClient::KiwiSdrClient(QObject* parent)
         setState(State::Error, setupTimeoutDetail());
         cleanupSockets();
     });
+
+    m_waterfallRowFlushTimer = new QTimer(this);
+    m_waterfallRowFlushTimer->setSingleShot(true);
+    connect(m_waterfallRowFlushTimer, &QTimer::timeout,
+            this, &KiwiSdrClient::flushPendingWaterfallRow);
 }
 
 KiwiSdrClient::~KiwiSdrClient()
@@ -467,6 +472,16 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
     m_lastWaterfallLowMhz = 0.0;
     m_lastWaterfallHighMhz = 0.0;
     m_lastWaterfallRowValid = false;
+    m_waterfallRowPending = false;
+    m_pendingWaterfallPanId.clear();
+    m_pendingWaterfallBins.clear();
+    m_pendingWaterfallLowMhz = 0.0;
+    m_pendingWaterfallHighMhz = 0.0;
+    m_pendingWaterfallTimecode = 0;
+    m_lastWaterfallRowEmitUtcMs = 0;
+    if (m_waterfallRowFlushTimer) {
+        m_waterfallRowFlushTimer->stop();
+    }
     m_waterfallServerCenterMhz = kDefaultWaterfallCenterMhz;
     m_waterfallServerBandwidthMhz = kDefaultWaterfallBandwidthMhz;
     m_waterfallZoomCap = kDefaultWaterfallZoomCap;
@@ -985,6 +1000,16 @@ void KiwiSdrClient::cleanupSockets()
     m_lastWaterfallLowMhz = 0.0;
     m_lastWaterfallHighMhz = 0.0;
     m_lastWaterfallRowValid = false;
+    m_waterfallRowPending = false;
+    m_pendingWaterfallPanId.clear();
+    m_pendingWaterfallBins.clear();
+    m_pendingWaterfallLowMhz = 0.0;
+    m_pendingWaterfallHighMhz = 0.0;
+    m_pendingWaterfallTimecode = 0;
+    m_lastWaterfallRowEmitUtcMs = 0;
+    if (m_waterfallRowFlushTimer) {
+        m_waterfallRowFlushTimer->stop();
+    }
     m_waterfallAvailable = true;
     m_waterfallAvailabilityDetail.clear();
     m_waterfallRxChannel = -1;
@@ -1779,23 +1804,12 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
     int frameZoom = 0;
     const bool hasExtendedHeader =
         parseWaterfallFrameHeader(frame, &frameStart, &frameZoom);
-    if (!m_waterfallRequestValid
-        || m_waterfallRequestLowMhz <= 0.0
-        || m_waterfallRequestHighMhz <= m_waterfallRequestLowMhz) {
+    const bool requestHasUsableRange =
+        m_waterfallRequestValid
+        && m_waterfallRequestLowMhz > 0.0
+        && m_waterfallRequestHighMhz > m_waterfallRequestLowMhz;
+    if (!hasExtendedHeader && !requestHasUsableRange) {
         return;
-    }
-    if (hasExtendedHeader
-        && frameZoom != m_waterfallRequestZoom) {
-        return;
-    }
-    if (hasExtendedHeader) {
-        const quint32 startDelta =
-            frameStart > m_waterfallRequestStart
-                ? frameStart - m_waterfallRequestStart
-                : m_waterfallRequestStart - frameStart;
-        if (startDelta > kWaterfallStartServerSnapTolerance) {
-            return;
-        }
     }
 
     const QVector<float> bins = decodeWaterfallFrame(frame);
@@ -1831,6 +1845,8 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
         rowHighMhz = rowLowMhz
             + std::min(fullBandwidthMhz,
                        waterfallRowSpanMhz(fullBandwidthMhz, frameZoom));
+    } else if (!requestHasUsableRange) {
+        return;
     }
     const quint64 padRows = std::min(sequenceGaps,
                                      kMaxSequenceGapPaddingFrames);
@@ -1839,13 +1855,13 @@ void KiwiSdrClient::handleWaterfallFrame(const QByteArray& frame)
         && std::abs(m_lastWaterfallLowMhz - rowLowMhz) <= 1.0e-9
         && std::abs(m_lastWaterfallHighMhz - rowHighMhz) <= 1.0e-9) {
         for (quint64 i = 0; i < padRows; ++i) {
-            emit waterfallRowReady(panId, m_lastWaterfallBins,
-                                   m_lastWaterfallLowMhz,
-                                   m_lastWaterfallHighMhz,
-                                   0);
+            queueWaterfallRow(panId, m_lastWaterfallBins,
+                              m_lastWaterfallLowMhz,
+                              m_lastWaterfallHighMhz,
+                              0);
         }
     }
-    emit waterfallRowReady(panId, bins, rowLowMhz, rowHighMhz, 0);
+    queueWaterfallRow(panId, bins, rowLowMhz, rowHighMhz, 0);
     m_lastWaterfallBins = bins;
     m_lastWaterfallPanId = panId;
     m_lastWaterfallLowMhz = rowLowMhz;
@@ -2259,8 +2275,69 @@ void KiwiSdrClient::emitTelemetryChanged()
     m_telemetryPending = true;
     QTimer::singleShot(0, this, [this]() {
         m_telemetryPending = false;
-        emit telemetryChanged();
+        emit telemetryChanged(m_telemetry);
     });
+}
+
+void KiwiSdrClient::queueWaterfallRow(const QString& panId,
+                                      const QVector<float>& binsDbm,
+                                      double lowFreqMhz,
+                                      double highFreqMhz,
+                                      quint32 timecode)
+{
+    const qint64 nowUtcMs = QDateTime::currentMSecsSinceEpoch();
+    if (m_lastWaterfallRowEmitUtcMs == 0
+        || nowUtcMs - m_lastWaterfallRowEmitUtcMs >= kWaterfallGuiMinIntervalMs) {
+        if (m_waterfallRowFlushTimer) {
+            m_waterfallRowFlushTimer->stop();
+        }
+        m_waterfallRowPending = false;
+        emitWaterfallRowNow(panId, binsDbm, lowFreqMhz, highFreqMhz, timecode);
+        return;
+    }
+
+    m_waterfallRowPending = true;
+    m_pendingWaterfallPanId = panId;
+    m_pendingWaterfallBins = binsDbm;
+    m_pendingWaterfallLowMhz = lowFreqMhz;
+    m_pendingWaterfallHighMhz = highFreqMhz;
+    m_pendingWaterfallTimecode = timecode;
+    const int delayMs = std::max<qint64>(
+        1,
+        kWaterfallGuiMinIntervalMs - (nowUtcMs - m_lastWaterfallRowEmitUtcMs));
+    if (m_waterfallRowFlushTimer && !m_waterfallRowFlushTimer->isActive()) {
+        m_waterfallRowFlushTimer->start(delayMs);
+    }
+}
+
+void KiwiSdrClient::flushPendingWaterfallRow()
+{
+    if (!m_waterfallRowPending) {
+        return;
+    }
+
+    const QString panId = m_pendingWaterfallPanId;
+    const QVector<float> binsDbm = m_pendingWaterfallBins;
+    const double lowFreqMhz = m_pendingWaterfallLowMhz;
+    const double highFreqMhz = m_pendingWaterfallHighMhz;
+    const quint32 timecode = m_pendingWaterfallTimecode;
+    m_waterfallRowPending = false;
+    m_pendingWaterfallPanId.clear();
+    m_pendingWaterfallBins.clear();
+    m_pendingWaterfallLowMhz = 0.0;
+    m_pendingWaterfallHighMhz = 0.0;
+    m_pendingWaterfallTimecode = 0;
+    emitWaterfallRowNow(panId, binsDbm, lowFreqMhz, highFreqMhz, timecode);
+}
+
+void KiwiSdrClient::emitWaterfallRowNow(const QString& panId,
+                                        const QVector<float>& binsDbm,
+                                        double lowFreqMhz,
+                                        double highFreqMhz,
+                                        quint32 timecode)
+{
+    m_lastWaterfallRowEmitUtcMs = QDateTime::currentMSecsSinceEpoch();
+    emit waterfallRowReady(panId, binsDbm, lowFreqMhz, highFreqMhz, timecode);
 }
 
 void KiwiSdrClient::sendWaterfallRateToServer()

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -112,7 +112,7 @@ signals:
                            quint32 timecode);
     void meterReadingReady(
         const AetherSDR::KiwiSdrProtocol::MeterReading& reading);
-    void telemetryChanged();
+    void telemetryChanged(const AetherSDR::KiwiSdrReceiverTelemetry& telemetry);
     void waterfallAvailabilityChanged(bool available, const QString& detail);
     void recoverableDisconnect(const QString& detail);
 
@@ -176,6 +176,13 @@ private:
     void updateSoundTelemetry(const QByteArray& frame);
     void updateWaterfallTelemetry(const QByteArray& frame);
     void emitTelemetryChanged();
+    void queueWaterfallRow(const QString& panId, const QVector<float>& binsDbm,
+                           double lowFreqMhz, double highFreqMhz,
+                           quint32 timecode);
+    void flushPendingWaterfallRow();
+    void emitWaterfallRowNow(const QString& panId, const QVector<float>& binsDbm,
+                             double lowFreqMhz, double highFreqMhz,
+                             quint32 timecode);
     void sendWaterfallRateToServer();
     void markSoundAudioReady();
     QString logEndpoint() const;
@@ -296,6 +303,14 @@ private:
     bool m_lastWaterfallRowValid{false};
     QTimer* m_keepaliveTimer{nullptr};
     QTimer* m_audioReadyTimer{nullptr};
+    QTimer* m_waterfallRowFlushTimer{nullptr};
+    bool m_waterfallRowPending{false};
+    QString m_pendingWaterfallPanId;
+    QVector<float> m_pendingWaterfallBins;
+    double m_pendingWaterfallLowMhz{0.0};
+    double m_pendingWaterfallHighMhz{0.0};
+    quint32 m_pendingWaterfallTimecode{0};
+    qint64 m_lastWaterfallRowEmitUtcMs{0};
 
 #ifdef HAVE_WEBSOCKETS
     QNetworkAccessManager* m_statusNetworkAccessManager{nullptr};
@@ -313,3 +328,4 @@ private:
 } // namespace AetherSDR
 
 Q_DECLARE_METATYPE(AetherSDR::KiwiSdrReceiverTelemetry)
+Q_DECLARE_METATYPE(AetherSDR::KiwiSdrClient::State)

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -6,6 +6,9 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMetaObject>
+#include <QMetaType>
+#include <QThread>
 #include <QTimer>
 #include <QUuid>
 
@@ -31,12 +34,33 @@ QString normalizedProfileEndpoint(const QString& endpoint)
 KiwiSdrManager::KiwiSdrManager(QObject* parent)
     : QObject(parent)
 {
+    qRegisterMetaType<AetherSDR::KiwiSdrClient::State>(
+        "AetherSDR::KiwiSdrClient::State");
+    qRegisterMetaType<AetherSDR::KiwiSdrReceiverTelemetry>(
+        "AetherSDR::KiwiSdrReceiverTelemetry");
+    qRegisterMetaType<AetherSDR::KiwiSdrProtocol::MeterReading>(
+        "AetherSDR::KiwiSdrProtocol::MeterReading");
+    qRegisterMetaType<QVector<float>>("QVector<float>");
     loadSettings();
 }
 
 KiwiSdrManager::~KiwiSdrManager()
 {
     disconnectAll();
+    const QStringList ids = m_clients.keys();
+    for (const QString& id : ids) {
+        destroyClient(id, true);
+    }
+    if (m_clientThread) {
+        m_clientThread->quit();
+        if (!m_clientThread->wait(3000)) {
+            qCWarning(lcKiwiSdr)
+                << "KiwiSDR client thread did not stop during manager teardown";
+            m_clientThread->setParent(nullptr);
+            connect(m_clientThread, &QThread::finished,
+                    m_clientThread, &QObject::deleteLater);
+        }
+    }
 }
 
 KiwiSdrAntennaProfile KiwiSdrManager::profile(const QString& id) const
@@ -96,10 +120,7 @@ QStringList KiwiSdrManager::virtualAntennaLabels() const
 
 KiwiSdrClient::State KiwiSdrManager::state(const QString& id) const
 {
-    if (KiwiSdrClient* c = client(id)) {
-        return c->state();
-    }
-    return KiwiSdrClient::State::Disconnected;
+    return m_states.value(id, KiwiSdrClient::State::Disconnected);
 }
 
 QString KiwiSdrManager::stateDetail(const QString& id) const
@@ -109,34 +130,22 @@ QString KiwiSdrManager::stateDetail(const QString& id) const
 
 KiwiSdrReceiverTelemetry KiwiSdrManager::telemetry(const QString& id) const
 {
-    if (KiwiSdrClient* c = client(id)) {
-        return c->telemetry();
-    }
     return m_telemetry.value(id);
 }
 
 bool KiwiSdrManager::waterfallAvailable(const QString& id) const
 {
-    if (KiwiSdrClient* c = client(id)) {
-        return c->waterfallAvailable();
-    }
     return m_waterfallAvailable.value(id, true);
 }
 
 QString KiwiSdrManager::waterfallDetail(const QString& id) const
 {
-    if (KiwiSdrClient* c = client(id)) {
-        return c->waterfallAvailabilityDetail();
-    }
     return m_waterfallDetails.value(id);
 }
 
 bool KiwiSdrManager::isConnected(const QString& id) const
 {
-    if (KiwiSdrClient* c = client(id)) {
-        return c->isConnected();
-    }
-    return false;
+    return state(id) == KiwiSdrClient::State::Connected;
 }
 
 QString KiwiSdrManager::assignedProfileForSlice(int sliceId) const
@@ -199,15 +208,24 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
     }
 
     if (KiwiSdrClient* c = client(updated.id)) {
-        c->setWaterfallDisplayAdjustments(updated.waterfallCellDb,
-                                          updated.waterfallFloorDb);
-        c->setWaterfallRateOverride(updated.waterfallRate);
-        if (endpointChanged && c->state() != KiwiSdrClient::State::Disconnected) {
-            c->disconnectFromEndpoint();
-            if (!updated.endpoint.isEmpty()) {
-                c->connectToEndpoint(updated.endpoint);
+        Q_UNUSED(c);
+        invokeClient(updated.id, [cellDb = updated.waterfallCellDb,
+                                  floorDb = updated.waterfallFloorDb,
+                                  rate = updated.waterfallRate,
+                                  endpointChanged,
+                                  endpoint = updated.endpoint,
+                                  reconnect = state(updated.id)
+                                      != KiwiSdrClient::State::Disconnected](
+                                     KiwiSdrClient* client) {
+            client->setWaterfallDisplayAdjustments(cellDb, floorDb);
+            client->setWaterfallRateOverride(rate);
+            if (endpointChanged && reconnect) {
+                client->disconnectFromEndpoint();
+                if (!endpoint.isEmpty()) {
+                    client->connectToEndpoint(endpoint);
+                }
             }
-        }
+        });
     }
     emit profilesChanged();
 }
@@ -222,9 +240,7 @@ void KiwiSdrManager::removeProfile(const QString& id)
     qCInfo(lcKiwiSdr).noquote() << "Profile removed" << displayName(id) << "id=" << id;
     cancelReconnect(id);
     disconnectProfile(id);
-    if (KiwiSdrClient* c = m_clients.take(id)) {
-        c->deleteLater();
-    }
+    destroyClient(id);
     if (QTimer* timer = m_reconnectTimers.take(id)) {
         timer->deleteLater();
     }
@@ -237,14 +253,16 @@ void KiwiSdrManager::removeProfile(const QString& id)
     }
 
     m_stateDetails.remove(id);
+    m_states.remove(id);
+    m_clientHasTrackedSlice.remove(id);
     m_telemetry.remove(id);
     m_waterfallAvailable.remove(id);
     m_waterfallDetails.remove(id);
     m_profiles.removeAt(idx);
     saveSettings();
-    // The client is already deleted above, so no further audio will be fed for
-    // this id; free its audio-engine source state (disable alone leaves the
-    // per-source entry allocated — #3668 review).
+    // The client deletion is already scheduled above, so no further audio will
+    // be fed for this id; free its audio-engine source state (disable alone
+    // leaves the per-source entry allocated — #3668 review).
     emit audioSourceRemoved(id);
     emit profilesChanged();
 }
@@ -261,33 +279,47 @@ void KiwiSdrManager::connectProfile(const QString& id)
     if (!c || m_profiles[idx].endpoint.isEmpty()) {
         return;
     }
-    if (c->state() == KiwiSdrClient::State::Connecting
-        || c->state() == KiwiSdrClient::State::Connected) {
+    if (state(id) == KiwiSdrClient::State::Connecting
+        || state(id) == KiwiSdrClient::State::Connected) {
         return;
     }
-    c->setOperatorCallsign(m_operatorCallsign);
-    c->setWaterfallDisplayAdjustments(m_profiles[idx].waterfallCellDb,
-                                      m_profiles[idx].waterfallFloorDb);
-    c->setWaterfallRateOverride(m_profiles[idx].waterfallRate);
+    invokeClient(id, [callsign = m_operatorCallsign,
+                      cellDb = m_profiles[idx].waterfallCellDb,
+                      floorDb = m_profiles[idx].waterfallFloorDb,
+                      rate = m_profiles[idx].waterfallRate](
+                         KiwiSdrClient* client) {
+        client->setOperatorCallsign(callsign);
+        client->setWaterfallDisplayAdjustments(cellDb, floorDb);
+        client->setWaterfallRateOverride(rate);
+    });
     if (assignedSliceForProfile(id) < 0) {
-        c->setTrackedSlice(-1, 0.0, QString(), 0, 0, QString());
+        m_clientHasTrackedSlice.insert(id, false);
+        invokeClient(id, [](KiwiSdrClient* client) {
+            client->setTrackedSlice(-1, 0.0, QString(), 0, 0, QString());
+        });
         emit profileNeedsInitialTracking(id);
     }
-    if (!c->hasTrackedSlice()) {
+    if (!m_clientHasTrackedSlice.value(id, false)) {
         return;
     }
     qCInfo(lcKiwiSdr).noquote()
         << "Connecting" << m_profiles[idx].name
         << "->" << m_profiles[idx].endpoint;
-    c->connectToEndpoint(m_profiles[idx].endpoint);
+    m_states.insert(id, KiwiSdrClient::State::Connecting);
+    invokeClient(id, [endpoint = m_profiles[idx].endpoint](KiwiSdrClient* client) {
+        client->connectToEndpoint(endpoint);
+    });
 }
 
 void KiwiSdrManager::disconnectProfile(const QString& id)
 {
     cancelReconnect(id);
     if (KiwiSdrClient* c = client(id)) {
+        Q_UNUSED(c);
         qCInfo(lcKiwiSdr).noquote() << "Disconnecting" << displayName(id);
-        c->disconnectFromEndpoint();
+        invokeClient(id, [](KiwiSdrClient* client) {
+            client->disconnectFromEndpoint();
+        });
     }
     emit audioSourceEnabledChanged(id, false);
 }
@@ -299,20 +331,20 @@ void KiwiSdrManager::disconnectAll()
             timer->stop();
         }
     }
-    for (KiwiSdrClient* c : std::as_const(m_clients)) {
-        if (c) {
-            c->disconnectFromEndpoint();
-        }
+    for (auto it = m_clients.constBegin(); it != m_clients.constEnd(); ++it) {
+        invokeClient(it.key(), [](KiwiSdrClient* client) {
+            client->disconnectFromEndpoint();
+        });
     }
 }
 
 void KiwiSdrManager::setOperatorCallsign(const QString& callsign)
 {
     m_operatorCallsign = callsign;
-    for (KiwiSdrClient* c : std::as_const(m_clients)) {
-        if (c) {
-            c->setOperatorCallsign(callsign);
-        }
+    for (auto it = m_clients.constBegin(); it != m_clients.constEnd(); ++it) {
+        invokeClient(it.key(), [callsign](KiwiSdrClient* client) {
+            client->setOperatorCallsign(callsign);
+        });
     }
 }
 
@@ -340,12 +372,18 @@ void KiwiSdrManager::primeProfileTracking(const QString& id, int sliceId,
     }
 
     if (KiwiSdrClient* c = ensureClient(id)) {
-        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                           filterHighHz, panId);
-        c->setWaterfallLineDurationMs(lineDurationMs);
-        if (!panId.isEmpty() && centerMhz > 0.0 && bandwidthMhz > 0.0) {
-            c->setWaterfallView(panId, centerMhz, bandwidthMhz);
-        }
+        Q_UNUSED(c);
+        m_clientHasTrackedSlice.insert(id, true);
+        invokeClient(id, [sliceId, frequencyMhz, mode, filterLowHz,
+                          filterHighHz, panId, lineDurationMs,
+                          centerMhz, bandwidthMhz](KiwiSdrClient* client) {
+            client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                                    filterHighHz, panId);
+            client->setWaterfallLineDurationMs(lineDurationMs);
+            if (!panId.isEmpty() && centerMhz > 0.0 && bandwidthMhz > 0.0) {
+                client->setWaterfallView(panId, centerMhz, bandwidthMhz);
+            }
+        });
     }
 }
 
@@ -364,7 +402,10 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
     if (!previousProfile.isEmpty() && previousProfile != profileId) {
         emit audioSourceEnabledChanged(previousProfile, false);
         if (KiwiSdrClient* previousClient = client(previousProfile)) {
-            previousClient->setAudioActive(false);
+            Q_UNUSED(previousClient);
+            invokeClient(previousProfile, [](KiwiSdrClient* client) {
+                client->setAudioActive(false);
+            });
         }
     }
 
@@ -384,9 +425,16 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
     emit sliceAssignmentChanged(sliceId, profileId);
 
     if (KiwiSdrClient* c = ensureClient(profileId)) {
-        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                           filterHighHz, panId);
-        c->setAudioActive(c->isConnected());
+        Q_UNUSED(c);
+        m_clientHasTrackedSlice.insert(profileId, sliceId >= 0 && frequencyMhz > 0.0);
+        const bool connected = state(profileId) == KiwiSdrClient::State::Connected;
+        invokeClient(profileId, [sliceId, frequencyMhz, mode, filterLowHz,
+                                 filterHighHz, panId, connected](
+                                    KiwiSdrClient* client) {
+            client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                                    filterHighHz, panId);
+            client->setAudioActive(connected);
+        });
     }
     connectProfile(profileId);
     emit audioSourceEnabledChanged(profileId, true);
@@ -403,7 +451,10 @@ void KiwiSdrManager::clearSliceAssignment(int sliceId)
         << "Slice" << sliceId << "cleared from" << displayName(previousProfile);
     emit audioSourceEnabledChanged(previousProfile, false);
     if (KiwiSdrClient* c = client(previousProfile)) {
-        c->setAudioActive(false);
+        Q_UNUSED(c);
+        invokeClient(previousProfile, [](KiwiSdrClient* client) {
+            client->setAudioActive(false);
+        });
     }
     emit sliceAssignmentChanged(sliceId, QString());
 }
@@ -418,8 +469,14 @@ void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,
         return;
     }
     if (KiwiSdrClient* c = ensureClient(profileId)) {
-        c->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                           filterHighHz, panId);
+        Q_UNUSED(c);
+        m_clientHasTrackedSlice.insert(profileId, sliceId >= 0 && frequencyMhz > 0.0);
+        invokeClient(profileId, [sliceId, frequencyMhz, mode,
+                                 filterLowHz, filterHighHz, panId](
+                                    KiwiSdrClient* client) {
+            client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
+                                    filterHighHz, panId);
+        });
     }
 }
 
@@ -432,8 +489,12 @@ void KiwiSdrManager::updateWaterfallView(int sliceId, const QString& panId,
         return;
     }
     if (KiwiSdrClient* c = ensureClient(profileId)) {
-        c->setWaterfallLineDurationMs(lineDurationMs);
-        c->setWaterfallView(panId, centerMhz, bandwidthMhz);
+        Q_UNUSED(c);
+        invokeClient(profileId, [panId, centerMhz, bandwidthMhz,
+                                 lineDurationMs](KiwiSdrClient* client) {
+            client->setWaterfallLineDurationMs(lineDurationMs);
+            client->setWaterfallView(panId, centerMhz, bandwidthMhz);
+        });
     }
 }
 
@@ -446,7 +507,10 @@ void KiwiSdrManager::setReceiverControlsForSlice(
     }
 
     if (KiwiSdrClient* c = ensureClient(profileId)) {
-        c->setReceiverControls(controls);
+        Q_UNUSED(c);
+        invokeClient(profileId, [controls](KiwiSdrClient* client) {
+            client->setReceiverControls(controls);
+        });
     }
 }
 
@@ -475,12 +539,21 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
         return nullptr;
     }
 
-    auto* c = new KiwiSdrClient(this);
+    ensureClientThread();
+    auto* c = new KiwiSdrClient;
     c->setDecodeAudioWhenInactive(false);
     c->setOperatorCallsign(m_operatorCallsign);
+    c->moveToThread(m_clientThread);
+    connect(m_clientThread, &QThread::finished, c, &QObject::deleteLater);
     m_clients.insert(id, c);
+    m_states.insert(id, KiwiSdrClient::State::Disconnected);
+    m_clientHasTrackedSlice.insert(id, false);
     connect(c, &KiwiSdrClient::stateChanged,
             this, [this, id, c](KiwiSdrClient::State state, const QString& detail) {
+        if (client(id) != c) {
+            return;
+        }
+        m_states.insert(id, state);
         m_stateDetails.insert(id, detail);
         qCInfo(lcKiwiSdr).noquote()
             << "State" << displayName(id) << "->" << static_cast<int>(state)
@@ -494,13 +567,23 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
         }
         if (state == KiwiSdrClient::State::Connected) {
             const int idx = profileIndex(id);
-            if (idx >= 0) {
-                c->setWaterfallDisplayAdjustments(m_profiles[idx].waterfallCellDb,
-                                                  m_profiles[idx].waterfallFloorDb);
-                c->setWaterfallRateOverride(m_profiles[idx].waterfallRate);
+            const bool hasAssignedSlice = assignedSliceForProfile(id) >= 0;
+            if (idx >= 0 || hasAssignedSlice) {
+                const int cellDb = idx >= 0 ? m_profiles[idx].waterfallCellDb : 0;
+                const int floorDb = idx >= 0 ? m_profiles[idx].waterfallFloorDb : 0;
+                const int rate = idx >= 0 ? m_profiles[idx].waterfallRate : 0;
+                invokeClient(id, [idx, cellDb, floorDb, rate, hasAssignedSlice](
+                                     KiwiSdrClient* client) {
+                    if (idx >= 0) {
+                        client->setWaterfallDisplayAdjustments(cellDb, floorDb);
+                        client->setWaterfallRateOverride(rate);
+                    }
+                    if (hasAssignedSlice) {
+                        client->setAudioActive(true);
+                    }
+                });
             }
-            if (assignedSliceForProfile(id) >= 0) {
-                c->setAudioActive(true);
+            if (hasAssignedSlice) {
                 emit audioSourceEnabledChanged(id, true);
             }
         } else if (state == KiwiSdrClient::State::Disconnected
@@ -513,17 +596,27 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
                     detail));
         }
         emit profileStateChanged(id, state, detail);
-    });
+    }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::recoverableDisconnect,
-            this, [this, id](const QString&) {
+            this, [this, id, c](const QString&) {
+        if (client(id) != c) {
+            return;
+        }
         scheduleReconnect(id);
-    });
-    connect(c, &KiwiSdrClient::telemetryChanged, this, [this, id, c]() {
-        m_telemetry.insert(id, c->telemetry());
-        emit profileTelemetryChanged(id, m_telemetry.value(id));
-    });
+    }, Qt::QueuedConnection);
+    connect(c, &KiwiSdrClient::telemetryChanged, this,
+            [this, id, c](const KiwiSdrReceiverTelemetry& telemetry) {
+        if (client(id) != c) {
+            return;
+        }
+        m_telemetry.insert(id, telemetry);
+        emit profileTelemetryChanged(id, telemetry);
+    }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::waterfallAvailabilityChanged,
-            this, [this, id](bool available, const QString& detail) {
+            this, [this, id, c](bool available, const QString& detail) {
+        if (client(id) != c) {
+            return;
+        }
         m_waterfallAvailable.insert(id, available);
         if (detail.isEmpty()) {
             m_waterfallDetails.remove(id);
@@ -531,28 +624,86 @@ KiwiSdrClient* KiwiSdrManager::ensureClient(const QString& id)
             m_waterfallDetails.insert(id, detail);
         }
         emit profileWaterfallAvailabilityChanged(id, available, detail);
-    });
+    }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::decodedAudioReady,
-            this, [this, id](const QByteArray& pcm) {
+            this, [this, id, c](const QByteArray& pcm) {
+        if (client(id) != c) {
+            return;
+        }
         emit decodedAudioReady(id, pcm);
-    });
+    }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::waterfallRowReady,
-            this, [this, id](const QString& panId, const QVector<float>& binsDbm,
+            this, [this, id, c](const QString& panId, const QVector<float>& binsDbm,
                              double lowFreqMhz, double highFreqMhz,
                              quint32 timecode) {
+        if (client(id) != c) {
+            return;
+        }
         emit waterfallRowReady(id, panId, binsDbm, lowFreqMhz, highFreqMhz,
                                timecode);
-    });
+    }, Qt::QueuedConnection);
     connect(c, &KiwiSdrClient::meterReadingReady,
-            this, [this, id](const KiwiSdrProtocol::MeterReading& reading) {
+            this, [this, id, c](const KiwiSdrProtocol::MeterReading& reading) {
+        if (client(id) != c) {
+            return;
+        }
         emit meterReadingReady(id, reading);
-    });
+    }, Qt::QueuedConnection);
     return c;
 }
 
 KiwiSdrClient* KiwiSdrManager::client(const QString& id) const
 {
     return m_clients.value(id, nullptr);
+}
+
+void KiwiSdrManager::ensureClientThread()
+{
+    if (m_clientThread) {
+        return;
+    }
+
+    m_clientThread = new QThread(this);
+    m_clientThread->setObjectName(QStringLiteral("KiwiSdrClients"));
+    m_clientThread->start();
+}
+
+void KiwiSdrManager::invokeClient(
+    const QString& id,
+    std::function<void(KiwiSdrClient*)> fn)
+{
+    KiwiSdrClient* c = client(id);
+    if (!c) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(c, [c, fn = std::move(fn)]() {
+        fn(c);
+    }, Qt::QueuedConnection);
+}
+
+void KiwiSdrManager::destroyClient(const QString& id, bool blocking)
+{
+    KiwiSdrClient* c = m_clients.take(id);
+    if (!c) {
+        return;
+    }
+
+    c->disconnect(this);
+    m_states.remove(id);
+    m_stateDetails.remove(id);
+    m_clientHasTrackedSlice.remove(id);
+    m_telemetry.remove(id);
+    m_waterfallAvailable.remove(id);
+    m_waterfallDetails.remove(id);
+    const Qt::ConnectionType connectionType =
+        blocking && c->thread() != QThread::currentThread()
+            ? Qt::BlockingQueuedConnection
+            : Qt::QueuedConnection;
+    QMetaObject::invokeMethod(c, [c]() {
+        c->disconnectFromEndpoint();
+        c->deleteLater();
+    }, connectionType);
 }
 
 int KiwiSdrManager::profileIndex(const QString& id) const

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -7,7 +7,10 @@
 #include <QString>
 #include <QVector>
 
+#include <functional>
+
 class QTimer;
+class QThread;
 
 namespace AetherSDR {
 
@@ -110,12 +113,17 @@ private:
     void loadSettings();
     void saveSettings() const;
     bool shouldMaintainProfileConnection(const QString& id) const;
+    void ensureClientThread();
+    void invokeClient(const QString& id, std::function<void(KiwiSdrClient*)> fn);
+    void destroyClient(const QString& id, bool blocking = false);
     void scheduleReconnect(const QString& id);
     void cancelReconnect(const QString& id);
     static QString sanitizedName(const QString& name, const QString& endpoint);
 
     QVector<KiwiSdrAntennaProfile> m_profiles;
     QHash<QString, KiwiSdrClient*> m_clients;
+    QHash<QString, KiwiSdrClient::State> m_states;
+    QHash<QString, bool> m_clientHasTrackedSlice;
     QHash<QString, QTimer*> m_reconnectTimers;
     QHash<QString, QString> m_stateDetails;
     QHash<QString, KiwiSdrReceiverTelemetry> m_telemetry;
@@ -123,6 +131,7 @@ private:
     QHash<QString, QString> m_waterfallDetails;
     QHash<int, QString> m_sliceAssignments;
     QString m_operatorCallsign;
+    QThread* m_clientThread{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/KiwiSdrTraceMath.h
+++ b/src/gui/KiwiSdrTraceMath.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::KiwiSdrTraceMath {
+
+struct TraceFloorState {
+    float floorDbm{-1000.0f};
+    bool valid{false};
+};
+
+inline float interpolatedBinSample(const QVector<float>& bins,
+                                   double srcCenter,
+                                   float fallback)
+{
+    const int n = bins.size();
+    if (n <= 0) {
+        return fallback;
+    }
+    if (n == 1) {
+        return std::isfinite(bins[0]) ? bins[0] : fallback;
+    }
+
+    const double clamped = std::clamp(srcCenter, 0.0, static_cast<double>(n - 1));
+    const int left = std::clamp(static_cast<int>(std::floor(clamped)), 0, n - 1);
+    const int right = std::min(left + 1, n - 1);
+    const float leftValue = std::isfinite(bins[left]) ? bins[left] : fallback;
+    const float rightValue = std::isfinite(bins[right]) ? bins[right] : leftValue;
+    const float frac = static_cast<float>(clamped - static_cast<double>(left));
+    return leftValue + frac * (rightValue - leftValue);
+}
+
+inline float averagedBinSample(const QVector<float>& bins,
+                               double srcLeft,
+                               double srcRight,
+                               double srcCenter,
+                               float fallback)
+{
+    const int n = bins.size();
+    if (n <= 0 || srcRight <= 0.0 || srcLeft >= static_cast<double>(n)) {
+        return fallback;
+    }
+
+    const double clampedLeft = std::clamp(srcLeft, 0.0, static_cast<double>(n));
+    const double clampedRight = std::clamp(srcRight, 0.0, static_cast<double>(n));
+    if (clampedRight - clampedLeft <= 1.0) {
+        return interpolatedBinSample(bins, srcCenter, fallback);
+    }
+
+    const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)), 0, n - 1);
+    const int last = std::clamp(static_cast<int>(std::ceil(clampedRight)) - 1, 0, n - 1);
+    double weightedSum = 0.0;
+    double totalWeight = 0.0;
+    for (int i = first; i <= last; ++i) {
+        const float value = bins[i];
+        if (!std::isfinite(value)) {
+            continue;
+        }
+
+        const double binLeft = static_cast<double>(i);
+        const double binRight = binLeft + 1.0;
+        const double weight =
+            std::max(0.0, std::min(clampedRight, binRight)
+                - std::max(clampedLeft, binLeft));
+        if (weight <= 0.0) {
+            continue;
+        }
+        weightedSum += static_cast<double>(value) * weight;
+        totalWeight += weight;
+    }
+
+    if (totalWeight <= 0.0) {
+        return interpolatedBinSample(bins, srcCenter, fallback);
+    }
+    return static_cast<float>(weightedSum / totalWeight);
+}
+
+inline QVector<float> mapRowToTrace(const QVector<float>& rowBins,
+                                    int destWidth,
+                                    double rowCenterMhz,
+                                    double rowBandwidthMhz,
+                                    double viewCenterMhz,
+                                    double viewBandwidthMhz,
+                                    float fallback)
+{
+    if (rowBins.isEmpty() || destWidth <= 0
+        || rowBandwidthMhz <= 0.0 || viewBandwidthMhz <= 0.0) {
+        return {};
+    }
+
+    QVector<float> trace(destWidth, fallback);
+    const double rowLowMhz = rowCenterMhz - rowBandwidthMhz * 0.5;
+    const double viewLowMhz = viewCenterMhz - viewBandwidthMhz * 0.5;
+    const int srcSize = rowBins.size();
+    for (int x = 0; x < destWidth; ++x) {
+        const double freqMhz = viewLowMhz
+            + (static_cast<double>(x) + 0.5)
+                * viewBandwidthMhz / static_cast<double>(destWidth);
+        const double srcCenter =
+            ((freqMhz - rowLowMhz) / rowBandwidthMhz)
+                * static_cast<double>(srcSize) - 0.5;
+        if (srcCenter < -0.5
+            || srcCenter > static_cast<double>(srcSize) - 0.5) {
+            continue;
+        }
+
+        const double srcLeft = std::max(0.0, srcCenter - 0.5);
+        const double srcRight =
+            std::min(static_cast<double>(srcSize), srcCenter + 0.5);
+        trace[x] = averagedBinSample(rowBins, srcLeft, srcRight,
+                                     srcCenter, fallback);
+    }
+    return trace;
+}
+
+inline float estimateTraceFloorDbm(const QVector<float>& bins,
+                                   float minDbm,
+                                   int maxSamples = 512)
+{
+    if (bins.isEmpty()) {
+        return -1000.0f;
+    }
+
+    const int stride = std::max(1, static_cast<int>(bins.size() / maxSamples));
+    const float blankThreshold = minDbm + 0.5f;
+    float sum = 0.0f;
+    int count = 0;
+    for (int i = 0; i < bins.size(); i += stride) {
+        const float value = bins[i];
+        if (std::isfinite(value) && value > blankThreshold) {
+            sum += value;
+            ++count;
+        }
+    }
+    if (count < 8) {
+        return -1000.0f;
+    }
+
+    const float mean = sum / static_cast<float>(count);
+    float floorSum = 0.0f;
+    int floorCount = 0;
+    for (int i = 0; i < bins.size(); i += stride) {
+        const float value = bins[i];
+        if (std::isfinite(value) && value > blankThreshold
+            && value <= mean) {
+            floorSum += value;
+            ++floorCount;
+        }
+    }
+    return (floorCount > 0)
+        ? floorSum / static_cast<float>(floorCount)
+        : mean;
+}
+
+inline void stabilizeTraceFloor(QVector<float>& bins,
+                                TraceFloorState& state,
+                                bool allowFloorAdapt,
+                                float minDbm,
+                                float maxDbm)
+{
+    const float frameFloor = estimateTraceFloorDbm(bins, minDbm);
+    if (frameFloor <= -500.0f || !std::isfinite(frameFloor)) {
+        return;
+    }
+
+    if (!state.valid
+        || !std::isfinite(state.floorDbm)
+        || state.floorDbm <= -500.0f) {
+        state.floorDbm = frameFloor;
+        state.valid = true;
+    } else if (allowFloorAdapt) {
+        const float delta = frameFloor - state.floorDbm;
+        const float alpha = delta > 0.0f ? 0.03f : 0.12f;
+        state.floorDbm += delta * alpha;
+    }
+
+    const float offset = state.floorDbm - frameFloor;
+    if (std::abs(offset) < 0.05f) {
+        return;
+    }
+
+    const float blankThreshold = minDbm + 0.5f;
+    for (float& value : bins) {
+        if (std::isfinite(value) && value > blankThreshold) {
+            value = std::clamp(value + offset, minDbm, maxDbm);
+        }
+    }
+}
+
+} // namespace AetherSDR::KiwiSdrTraceMath

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5841,10 +5841,6 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
     centerMhz = std::max(centerMhz, bandwidthMhz / 2.0);
 
     if (!kiwiSdrProfileForPan(panId).isEmpty()) {
-        qDebug() << "Pan range request:" << source
-                 << "center" << centerMhz
-                 << "bandwidth" << bandwidthMhz
-                 << "local=kiwi";
         return;
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5840,6 +5840,14 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
 
     centerMhz = std::max(centerMhz, bandwidthMhz / 2.0);
 
+    if (!kiwiSdrProfileForPan(panId).isEmpty()) {
+        qDebug() << "Pan range request:" << source
+                 << "center" << centerMhz
+                 << "bandwidth" << bandwidthMhz
+                 << "local=kiwi";
+        return;
+    }
+
     auto* pan = m_radioModel.panadapter(panId);
     const QString centerStr = QString::number(centerMhz, 'f', 6);
     const QString bandwidthStr = QString::number(bandwidthMhz, 'f', 6);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -351,6 +351,13 @@ private:
     void syncKiwiSdrDiversityEscControls();
     void syncKiwiSdrPanadapterUiState(const QString& panId);
     void syncKiwiSdrPanadapterUiStates();
+    enum KiwiSdrUiSyncFlag {
+        KiwiSdrUiSyncAppletReceivers = 0x01,
+        KiwiSdrUiSyncWaterfallAvailability = 0x02,
+        KiwiSdrUiSyncDiversityEsc = 0x04,
+        KiwiSdrUiSyncPanadapterStates = 0x08,
+    };
+    void scheduleKiwiSdrUiSync(int flags);
     void wirePanadapter(PanadapterApplet* applet);
     void wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* pan);
     void schedulePanFpsReconcile(const QString& panId, int reportedFps);
@@ -789,6 +796,8 @@ private:
     AppletPanel*     m_appletPanel{nullptr};
     KiwiSdrManager*  m_kiwiSdrManager{nullptr};
     KiwiSdrClient*   m_kiwiSdrClient{nullptr};
+    int              m_kiwiSdrUiSyncFlags{0};
+    bool             m_kiwiSdrUiSyncPending{false};
     int              m_kiwiSdrTrackedSliceId{-1};
     int              m_kiwiSdrAudioSliceId{-1};
     bool             m_kiwiSdrAudioPreviousMute{false};

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -578,9 +578,6 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
     if (profileId.isEmpty()) {
         spectrum->setBandwidthLimits(m_radioModel.minPanBandwidthMhz(),
                                      m_radioModel.maxPanBandwidthMhz());
-        if (const PanadapterModel* pan = m_radioModel.panadapter(panId)) {
-            spectrum->setFrequencyRange(pan->centerMhz(), pan->bandwidthMhz());
-        }
         const QString overlayProfileId = kiwiSdrOverlayProfileForPan(panId);
         if (!overlayProfileId.isEmpty()) {
             spectrum->setKiwiSdrConnectionOverlay(

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -28,6 +28,7 @@ namespace AetherSDR {
 namespace {
 
 constexpr int kKiwiSdrMeterDisplayDelayMs = 520;
+constexpr double kKiwiSdrWaterfallFullBandwidthMhz = 30.0;
 
 const SliceModel* kiwiSliceForPan(const RadioModel& radioModel,
                                   const QString& panId,
@@ -216,7 +217,6 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
     syncActiveSliceSquelchLineToSpectrums();
     syncActiveSliceAutoSquelchToSpectrums();
     syncFlexRxPanToAudioEngine();
-    syncKiwiSdrDiversityEscControls();
 
     if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
         if (kiwiSdrDisplaySliceForPan(slice->panId()) == slice) {
@@ -240,7 +240,8 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
     }
     syncKiwiSdrPanadapterUiState(slice->panId());
     syncActiveSliceAutoSquelchToSpectrums();
-    refreshKiwiSdrWaterfallAvailability();
+    scheduleKiwiSdrUiSync(KiwiSdrUiSyncDiversityEsc
+                          | KiwiSdrUiSyncWaterfallAvailability);
 }
 
 void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
@@ -272,8 +273,8 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
     syncFlexRxPanToAudioEngine();
     syncActiveSliceSquelchLineToSpectrums();
     syncActiveSliceAutoSquelchToSpectrums();
-    syncKiwiSdrDiversityEscControls();
-    refreshKiwiSdrWaterfallAvailability();
+    scheduleKiwiSdrUiSync(KiwiSdrUiSyncDiversityEsc
+                          | KiwiSdrUiSyncWaterfallAvailability);
     if (!panId.isEmpty()) {
         syncKiwiSdrPanadapterUiState(panId);
     }
@@ -575,6 +576,11 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
 
     SpectrumOverlayMenu* menu = spectrum->overlayMenu();
     if (profileId.isEmpty()) {
+        spectrum->setBandwidthLimits(m_radioModel.minPanBandwidthMhz(),
+                                     m_radioModel.maxPanBandwidthMhz());
+        if (const PanadapterModel* pan = m_radioModel.panadapter(panId)) {
+            spectrum->setFrequencyRange(pan->centerMhz(), pan->bandwidthMhz());
+        }
         const QString overlayProfileId = kiwiSdrOverlayProfileForPan(panId);
         if (!overlayProfileId.isEmpty()) {
             spectrum->setKiwiSdrConnectionOverlay(
@@ -603,6 +609,11 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
         }
         return;
     }
+
+    spectrum->setBandwidthLimits(
+        m_radioModel.minPanBandwidthMhz(),
+        std::max(m_radioModel.maxPanBandwidthMhz(),
+                 kKiwiSdrWaterfallFullBandwidthMhz));
 
     const KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(profileId);
     const KiwiSdrClient::State state = m_kiwiSdrManager->state(profileId);
@@ -649,6 +660,41 @@ void MainWindow::syncKiwiSdrPanadapterUiStates()
         }
         syncKiwiSdrPanadapterUiState(applet->panId());
     }
+}
+
+void MainWindow::scheduleKiwiSdrUiSync(int flags)
+{
+    if (flags == 0) {
+        return;
+    }
+
+    m_kiwiSdrUiSyncFlags |= flags;
+    if (m_kiwiSdrUiSyncPending) {
+        return;
+    }
+
+    m_kiwiSdrUiSyncPending = true;
+    QTimer::singleShot(0, this, [this]() {
+        const int flags = m_kiwiSdrUiSyncFlags;
+        m_kiwiSdrUiSyncFlags = 0;
+        m_kiwiSdrUiSyncPending = false;
+
+        if ((flags & KiwiSdrUiSyncAppletReceivers) != 0) {
+            refreshKiwiSdrAppletReceivers();
+        }
+        if ((flags & KiwiSdrUiSyncDiversityEsc) != 0) {
+            syncKiwiSdrDiversityEscControls();
+        }
+        const bool refreshedWaterfall =
+            (flags & KiwiSdrUiSyncWaterfallAvailability) != 0;
+        if (refreshedWaterfall) {
+            refreshKiwiSdrWaterfallAvailability();
+        }
+        if (!refreshedWaterfall
+            && (flags & KiwiSdrUiSyncPanadapterStates) != 0) {
+            syncKiwiSdrPanadapterUiStates();
+        }
+    });
 }
 
 void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice)
@@ -922,8 +968,8 @@ void MainWindow::wireKiwiSdr()
             const QString panId = m_radioModel.slice(sliceId)
                 ? m_radioModel.slice(sliceId)->panId()
                 : QString();
-            refreshKiwiSdrAppletReceivers();
-            syncKiwiSdrDiversityEscControls();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncAppletReceivers
+                                  | KiwiSdrUiSyncDiversityEsc);
             if (m_appletPanel) {
                 m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
             }
@@ -948,8 +994,8 @@ void MainWindow::wireKiwiSdr()
                     spectrum->setKiwiSdrWaterfallProfile(QString());
                 }
             }
-            refreshKiwiSdrWaterfallAvailability();
-            syncKiwiSdrDiversityEscControls();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncWaterfallAvailability
+                                  | KiwiSdrUiSyncDiversityEsc);
             syncKiwiSdrPanadapterUiState(panId);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::profileStateChanged,
@@ -974,26 +1020,22 @@ void MainWindow::wireKiwiSdr()
                     panId = slice->panId();
                 }
             }
-            refreshKiwiSdrWaterfallAvailability();
-            syncKiwiSdrDiversityEscControls();
-            refreshKiwiSdrAppletReceivers();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncWaterfallAvailability
+                                  | KiwiSdrUiSyncDiversityEsc
+                                  | KiwiSdrUiSyncAppletReceivers);
             if (!panId.isEmpty()) {
                 syncKiwiSdrPanadapterUiState(panId);
             }
         });
         connect(m_kiwiSdrManager,
                 &KiwiSdrManager::profileWaterfallAvailabilityChanged,
-                this, [this](const QString& profileId, bool, const QString&) {
+                this, [this](const QString&, bool, const QString&) {
             if (!m_kiwiSdrManager) {
                 return;
             }
 
-            const int sliceId =
-                m_kiwiSdrManager->assignedSliceForProfile(profileId);
-            if (SliceModel* slice = m_radioModel.slice(sliceId)) {
-                syncKiwiSdrPanadapterUiState(slice->panId());
-            }
-            refreshKiwiSdrAppletReceivers();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncAppletReceivers
+                                  | KiwiSdrUiSyncPanadapterStates);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::profileStreamReset,
                 this, [this](const QString& profileId) {
@@ -1006,13 +1048,13 @@ void MainWindow::wireKiwiSdr()
                         ->clearKiwiSdrWaterfallRowsForProfile(profileId);
                 }
             }
-            syncKiwiSdrPanadapterUiStates();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncPanadapterStates);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::profilesChanged,
                 this, [this] {
-            refreshKiwiSdrWaterfallAvailability();
-            refreshKiwiSdrAppletReceivers();
-            syncKiwiSdrPanadapterUiStates();
+            scheduleKiwiSdrUiSync(KiwiSdrUiSyncWaterfallAvailability
+                                  | KiwiSdrUiSyncAppletReceivers
+                                  | KiwiSdrUiSyncPanadapterStates);
         });
     }
     m_kiwiSdrClient->setOperatorCallsign(m_radioModel.callsign());
@@ -1031,8 +1073,8 @@ void MainWindow::wireKiwiSdr()
     if (m_kiwiSdrManager) {
         QTimer::singleShot(0, m_kiwiSdrManager, &KiwiSdrManager::startAutoConnect);
     }
-    syncKiwiSdrPanadapterUiStates();
-    syncKiwiSdrDiversityEscControls();
+    scheduleKiwiSdrUiSync(KiwiSdrUiSyncPanadapterStates
+                          | KiwiSdrUiSyncDiversityEsc);
 }
 
 void MainWindow::refreshKiwiSdrAppletReceivers()

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1578,17 +1578,36 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             applet->panId(), centerMhz, bandwidthMhz);
     };
 
+    const auto updateKiwiWaterfallViewUnlessDeferred =
+        [updateKiwiWaterfallView, sw](double centerMhz, double bandwidthMhz) {
+            if (sw && sw->waterfallViewUpdateDeferred()) {
+                return;
+            }
+            if (sw && sw->frequencyRangeGestureActive()) {
+                return;
+            }
+            updateKiwiWaterfallView(centerMhz, bandwidthMhz);
+        };
+
     connect(sw, &SpectrumWidget::frequencyRangeChanged,
-            this, updateKiwiWaterfallView);
+            this, updateKiwiWaterfallViewUnlessDeferred);
     connect(sw, &SpectrumWidget::frequencyRangeChangeRequested,
-            this, updateKiwiWaterfallView);
+            this, updateKiwiWaterfallViewUnlessDeferred);
     connect(sw, &SpectrumWidget::centerChangeRequested,
             this, [updateKiwiWaterfallView, sw](double centerMhz) {
                 if (!sw) {
                     return;
                 }
+                if (sw->panDragActive()
+                    || sw->frequencyRangeGestureActive()) {
+                    return;
+                }
                 updateKiwiWaterfallView(centerMhz, sw->bandwidthMhz());
             });
+    connect(sw, &SpectrumWidget::panDragSettled,
+            this, updateKiwiWaterfallView);
+    connect(sw, &SpectrumWidget::frequencyRangeSettled,
+            this, updateKiwiWaterfallView);
 
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);
@@ -1739,11 +1758,17 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(sw, &SpectrumWidget::bandwidthChangeRequested,
             this, [this, applet](double bw) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         m_radioModel.sendCommand(
             QString("display pan set %1 bandwidth=%2").arg(applet->panId()).arg(bw, 0, 'f', 6));
     });
     connect(sw, &SpectrumWidget::centerChangeRequested,
             this, [this, applet](double center) {
+        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+            return;
+        }
         if (const auto* pan = m_radioModel.panadapter(applet->panId()))
             center = std::max(center, pan->bandwidthMhz() / 2.0);
         m_radioModel.sendCommand(

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5126,7 +5126,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
 
     double rowLowMhz = lowFreqMhz;
     double rowHighMhz = highFreqMhz;
-    if (rowHighMhz <= rowLowMhz || rowLowMhz <= 0.0 || m_bandwidthMhz <= 0.0) {
+    if (rowHighMhz <= rowLowMhz || rowLowMhz < 0.0 || m_bandwidthMhz <= 0.0) {
         return;
     }
     const double rowCenterMhz = (rowLowMhz + rowHighMhz) * 0.5;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,4 +1,5 @@
 #include "SpectrumWidget.h"
+#include "KiwiSdrTraceMath.h"
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "SliceColors.h"
@@ -78,6 +79,10 @@ static constexpr float kKiwiSdrWaterfallMaxDbm = 0.0f;
 static constexpr int kNativeWaterfallFallbackMinTimeoutMs = 2000;
 static constexpr int kNativeWaterfallFallbackMaxTimeoutMs = 20000;
 static constexpr int kNativeWaterfallRateChangeGraceMaxMs = 14000;
+static constexpr int kPanDragFrameMs = 33;
+static constexpr int kPanDragCommandMs = 33;
+static constexpr int kPanDragSettleMs = 160;
+static constexpr int kFrequencyRangeSettleMs = 300;
 static constexpr int kDbmReleaseHoldFrames = 10;
 static constexpr int kDbmReleaseErrorSampleCount = 256;
 static constexpr float kDbmReleasePreviewChangeThresholdDb = 0.05f;
@@ -90,6 +95,11 @@ static constexpr const char* kSliceCursorOverrideHadCursorProperty =
     "_aetherSliceCursorOverrideHadCursor";
 static constexpr const char* kSliceCursorOverrideShapeProperty =
     "_aetherSliceCursorOverrideShape";
+
+static bool mhzNearlyEqual(double a, double b)
+{
+    return std::abs(a - b) <= 1.0e-6;
+}
 
 static Qt::CursorShape normalizedSpectrumCursorShape(Qt::CursorShape shape)
 {
@@ -709,6 +719,25 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
             m_vfoDragEdgePanTimer->stop();
         }
     });
+    m_panDragSettleTimer = new QTimer(this);
+    m_panDragSettleTimer->setSingleShot(true);
+    m_panDragSettleTimer->setInterval(kPanDragSettleMs);
+    connect(m_panDragSettleTimer, &QTimer::timeout, this, [this]() {
+        if (m_draggingPan) {
+            emit panDragSettled(m_centerMhz, m_bandwidthMhz);
+        }
+    });
+    m_frequencyRangeSettleTimer = new QTimer(this);
+    m_frequencyRangeSettleTimer->setSingleShot(true);
+    m_frequencyRangeSettleTimer->setInterval(kFrequencyRangeSettleMs);
+    connect(m_frequencyRangeSettleTimer, &QTimer::timeout, this, [this]() {
+        if (!m_frequencyRangeSettlePending) {
+            return;
+        }
+        m_frequencyRangeSettlePending = false;
+        m_frequencyRangePendingValid = false;
+        emit frequencyRangeSettled(m_centerMhz, m_bandwidthMhz);
+    });
 
     // Load display settings (panIndex 0 by default — loadSettings() can be
     // called again after setPanIndex() for multi-pan)
@@ -780,6 +809,7 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         m_bandwidthMhz = newBw;
         resetNoiseFloorBaseline();
         markOverlayDirty();
+        scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
         emit frequencyRangeChangeRequested(newCenter, newBw);
     };
     connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
@@ -1748,6 +1778,27 @@ float SpectrumWidget::estimateKiwiSdrVisualNoiseFloorDbm(
     const int middle = finite.size() / 2;
     std::nth_element(finite.begin(), finite.begin() + middle, finite.end());
     return finite[middle];
+}
+
+float SpectrumWidget::estimateKiwiSdrTraceFloorDbm(
+    const QVector<float>& bins) const
+{
+    return KiwiSdrTraceMath::estimateTraceFloorDbm(
+        bins, kKiwiSdrWaterfallMinDbm);
+}
+
+void SpectrumWidget::stabilizeKiwiSdrFftTrace(QVector<float>& bins,
+                                              bool allowFloorAdapt)
+{
+    KiwiSdrTraceMath::TraceFloorState state{
+        m_kiwiSdrFftTraceFloorDbm,
+        m_kiwiSdrFftTraceFloorValid
+    };
+    KiwiSdrTraceMath::stabilizeTraceFloor(
+        bins, state, allowFloorAdapt,
+        kKiwiSdrWaterfallMinDbm, kKiwiSdrWaterfallMaxDbm);
+    m_kiwiSdrFftTraceFloorDbm = state.floorDbm;
+    m_kiwiSdrFftTraceFloorValid = state.valid;
 }
 
 void SpectrumWidget::updateKiwiSdrSquelchVisualFloor(float floorDbm)
@@ -3289,9 +3340,45 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_kiwiSdrAutoFloorDbm = kKiwiSdrWaterfallMinDbm;
     m_kiwiSdrAutoCeilDbm = kKiwiSdrWaterfallMaxDbm;
     m_kiwiSdrAutoRangeValid = false;
+    m_kiwiSdrFftTraceFloorDbm = -1000.0f;
+    m_kiwiSdrFftTraceFloorValid = false;
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
+}
+
+void SpectrumWidget::resetCurrentWaterfallRowsForSize(
+    const QSize& waterfallSize,
+    const QSize& historySize)
+{
+    if (!waterfallSize.isEmpty()) {
+        m_waterfall = QImage(waterfallSize, QImage::Format_RGB32);
+        m_waterfallStreamSizeHint = waterfallSize;
+    } else {
+        m_waterfall = QImage();
+        m_waterfallStreamSizeHint = QSize();
+    }
+
+    QSize desiredHistorySize = historySize;
+    if (desiredHistorySize.isEmpty() && !waterfallSize.isEmpty()) {
+        desiredHistorySize =
+            QSize(waterfallSize.width(), waterfallHistoryCapacityRows());
+    }
+    if (!desiredHistorySize.isEmpty()) {
+        m_waterfallHistory = QImage(desiredHistorySize, QImage::Format_RGB32);
+        m_waterfallHistoryStreamSizeHint = desiredHistorySize;
+        m_wfHistoryTimestamps = QVector<qint64>(desiredHistorySize.height(), 0);
+        m_wfHistoryRowCenterMhz = QVector<double>(desiredHistorySize.height(), 0.0);
+        m_wfHistoryRowBwMhz = QVector<double>(desiredHistorySize.height(), 0.0);
+    } else {
+        m_waterfallHistory = QImage();
+        m_waterfallHistoryStreamSizeHint = QSize();
+        m_wfHistoryTimestamps.clear();
+        m_wfHistoryRowCenterMhz.clear();
+        m_wfHistoryRowBwMhz.clear();
+    }
+
+    clearCurrentWaterfallRows();
 }
 
 void SpectrumWidget::clearWaterfallRows()
@@ -3315,27 +3402,43 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     WaterfallStreamState& state = m_kiwiSdrWaterfallActive
         ? activeKiwiWaterfallState()
         : m_nativeWaterfallState;
-    state.waterfall = m_waterfall;
-    state.wfWriteRow = m_wfWriteRow;
-    state.waterfallHistory = m_waterfallHistory;
-    state.historyTimestamps = m_wfHistoryTimestamps;
-    state.historyWriteRow = m_wfHistoryWriteRow;
-    state.historyRowCount = m_wfHistoryRowCount;
-    state.historyOffsetRows = m_wfHistoryOffsetRows;
-    state.historyRowCenterMhz = m_wfHistoryRowCenterMhz;
-    state.historyRowBwMhz = m_wfHistoryRowBwMhz;
-    state.live = m_wfLive;
-    state.rowsSinceRateChange = m_wfRowsSinceRateChange;
-    state.prevTileScanline = m_prevTileScanline;
-    state.kiwiFftTrace = m_kiwiSdrFftTrace;
-    state.kiwiLastWaterfallBins = m_kiwiSdrLastWaterfallBins;
-    state.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
-    state.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
-    state.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
-    state.kiwiAutoFloorDbm = m_kiwiSdrAutoFloorDbm;
-    state.kiwiAutoCeilDbm = m_kiwiSdrAutoCeilDbm;
-    state.kiwiAutoRangeValid = m_kiwiSdrAutoRangeValid;
-    state.valid = true;
+
+    if (!m_waterfall.isNull()) {
+        m_waterfallStreamSizeHint = m_waterfall.size();
+    }
+    if (!m_waterfallHistory.isNull()) {
+        m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
+    }
+
+    // Transfer ownership between the visible stream and saved stream state.
+    // QImage assignment would COW-share the large waterfall history, making the
+    // next scanline write detach and copy the whole image on the GUI thread.
+    WaterfallStreamState updated;
+    updated.waterfall = std::move(m_waterfall);
+    updated.wfWriteRow = m_wfWriteRow;
+    updated.waterfallHistory = std::move(m_waterfallHistory);
+    updated.historyTimestamps = std::move(m_wfHistoryTimestamps);
+    updated.historyWriteRow = m_wfHistoryWriteRow;
+    updated.historyRowCount = m_wfHistoryRowCount;
+    updated.historyOffsetRows = m_wfHistoryOffsetRows;
+    updated.historyRowCenterMhz = std::move(m_wfHistoryRowCenterMhz);
+    updated.historyRowBwMhz = std::move(m_wfHistoryRowBwMhz);
+    updated.live = m_wfLive;
+    updated.rowsSinceRateChange = m_wfRowsSinceRateChange;
+    updated.prevTileScanline = std::move(m_prevTileScanline);
+    updated.kiwiFftTrace = std::move(m_kiwiSdrFftTrace);
+    updated.kiwiLastWaterfallBins = std::move(m_kiwiSdrLastWaterfallBins);
+    updated.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
+    updated.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
+    updated.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
+    updated.kiwiAutoFloorDbm = m_kiwiSdrAutoFloorDbm;
+    updated.kiwiAutoCeilDbm = m_kiwiSdrAutoCeilDbm;
+    updated.kiwiAutoRangeValid = m_kiwiSdrAutoRangeValid;
+    updated.kiwiFftTraceFloorDbm = m_kiwiSdrFftTraceFloorDbm;
+    updated.kiwiFftTraceFloorValid = m_kiwiSdrFftTraceFloorValid;
+    updated.valid = !updated.waterfall.isNull();
+
+    state = std::move(updated);
 }
 
 void SpectrumWidget::restoreCurrentWaterfallStreamState()
@@ -3343,41 +3446,57 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     WaterfallStreamState& state = m_kiwiSdrWaterfallActive
         ? activeKiwiWaterfallState()
         : m_nativeWaterfallState;
-    const QSize currentSize = m_waterfall.size();
-    const QSize currentHistorySize = m_waterfallHistory.size();
-    if (!state.valid
-        || (!currentSize.isEmpty() && !state.waterfall.isNull()
-            && state.waterfall.size() != currentSize)
-        || (!currentHistorySize.isEmpty() && !state.waterfallHistory.isNull()
-            && state.waterfallHistory.size() != currentHistorySize)) {
-        clearCurrentWaterfallRows();
+    const QSize currentSize = !m_waterfall.isNull()
+        ? m_waterfall.size()
+        : m_waterfallStreamSizeHint;
+    const QSize currentHistorySize = !m_waterfallHistory.isNull()
+        ? m_waterfallHistory.size()
+        : m_waterfallHistoryStreamSizeHint;
+
+    const bool stateHasWrongWaterfall =
+        !currentSize.isEmpty()
+        && (state.waterfall.isNull() || state.waterfall.size() != currentSize);
+    const bool stateHasWrongHistory =
+        !currentHistorySize.isEmpty()
+        && (state.waterfallHistory.isNull()
+            || state.waterfallHistory.size() != currentHistorySize);
+    if (!state.valid || stateHasWrongWaterfall || stateHasWrongHistory) {
+        state = WaterfallStreamState{};
+        resetCurrentWaterfallRowsForSize(currentSize, currentHistorySize);
         return;
     }
 
-    if (!state.waterfall.isNull()) {
-        m_waterfall = state.waterfall;
+    WaterfallStreamState restored = std::move(state);
+    state = WaterfallStreamState{};
+
+    m_waterfall = std::move(restored.waterfall);
+    if (!m_waterfall.isNull()) {
+        m_waterfallStreamSizeHint = m_waterfall.size();
     }
-    m_wfWriteRow = state.wfWriteRow;
-    if (!state.waterfallHistory.isNull()) {
-        m_waterfallHistory = state.waterfallHistory;
+    m_wfWriteRow = restored.wfWriteRow;
+    m_waterfallHistory = std::move(restored.waterfallHistory);
+    if (!m_waterfallHistory.isNull()) {
+        m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
     }
-    m_wfHistoryTimestamps = state.historyTimestamps;
-    m_wfHistoryWriteRow = state.historyWriteRow;
-    m_wfHistoryRowCount = state.historyRowCount;
-    m_wfHistoryOffsetRows = state.historyOffsetRows;
-    m_wfHistoryRowCenterMhz = state.historyRowCenterMhz;
-    m_wfHistoryRowBwMhz = state.historyRowBwMhz;
-    m_wfLive = state.live;
-    m_wfRowsSinceRateChange = state.rowsSinceRateChange;
-    m_prevTileScanline = state.prevTileScanline;
-    m_kiwiSdrFftTrace = state.kiwiFftTrace;
-    m_kiwiSdrLastWaterfallBins = state.kiwiLastWaterfallBins;
-    m_kiwiSdrLastWaterfallCenterMhz = state.kiwiLastWaterfallCenterMhz;
-    m_kiwiSdrLastWaterfallBandwidthMhz = state.kiwiLastWaterfallBandwidthMhz;
-    m_kiwiSdrLastWaterfallFrameValid = state.kiwiLastWaterfallFrameValid;
-    m_kiwiSdrAutoFloorDbm = state.kiwiAutoFloorDbm;
-    m_kiwiSdrAutoCeilDbm = state.kiwiAutoCeilDbm;
-    m_kiwiSdrAutoRangeValid = state.kiwiAutoRangeValid;
+    m_wfHistoryTimestamps = std::move(restored.historyTimestamps);
+    m_wfHistoryWriteRow = restored.historyWriteRow;
+    m_wfHistoryRowCount = restored.historyRowCount;
+    m_wfHistoryOffsetRows = restored.historyOffsetRows;
+    m_wfHistoryRowCenterMhz = std::move(restored.historyRowCenterMhz);
+    m_wfHistoryRowBwMhz = std::move(restored.historyRowBwMhz);
+    m_wfLive = restored.live;
+    m_wfRowsSinceRateChange = restored.rowsSinceRateChange;
+    m_prevTileScanline = std::move(restored.prevTileScanline);
+    m_kiwiSdrFftTrace = std::move(restored.kiwiFftTrace);
+    m_kiwiSdrLastWaterfallBins = std::move(restored.kiwiLastWaterfallBins);
+    m_kiwiSdrLastWaterfallCenterMhz = restored.kiwiLastWaterfallCenterMhz;
+    m_kiwiSdrLastWaterfallBandwidthMhz = restored.kiwiLastWaterfallBandwidthMhz;
+    m_kiwiSdrLastWaterfallFrameValid = restored.kiwiLastWaterfallFrameValid;
+    m_kiwiSdrAutoFloorDbm = restored.kiwiAutoFloorDbm;
+    m_kiwiSdrAutoCeilDbm = restored.kiwiAutoCeilDbm;
+    m_kiwiSdrAutoRangeValid = restored.kiwiAutoRangeValid;
+    m_kiwiSdrFftTraceFloorDbm = restored.kiwiFftTraceFloorDbm;
+    m_kiwiSdrFftTraceFloorValid = restored.kiwiFftTraceFloorValid;
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
@@ -3883,14 +4002,14 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
         return false;
     }
 
-    auto reprojectBins = [&](QVector<float>& bins) {
+    auto reprojectBins = [&](QVector<float>& bins, float fallback) {
         const int binCount = bins.size();
         if (binCount <= 0) {
             return;
         }
 
         const QVector<float> oldBins = std::move(bins);
-        QVector<float> reprojected(binCount, m_refLevel - m_dynamicRange);
+        QVector<float> reprojected(binCount, fallback);
 
         for (int dst = 0; dst < binCount; ++dst) {
             const double dstFrac = (static_cast<double>(dst) + 0.5) / binCount;
@@ -3915,15 +4034,36 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
         bins = std::move(reprojected);
     };
 
-    reprojectBins(m_bins);
-    reprojectBins(m_smoothed);
-    return !m_bins.isEmpty() || !m_smoothed.isEmpty();
+    reprojectBins(m_bins, m_refLevel - m_dynamicRange);
+    reprojectBins(m_smoothed, m_refLevel - m_dynamicRange);
+    reprojectBins(m_kiwiSdrFftTrace, kKiwiSdrWaterfallMinDbm);
+    return !m_bins.isEmpty() || !m_smoothed.isEmpty()
+        || !m_kiwiSdrFftTrace.isEmpty();
 }
 
 void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
 {
     if (centerMhz == m_centerMhz && bandwidthMhz == m_bandwidthMhz)
         return;
+
+    // While the user is actively panning, the local drag path owns the visual
+    // center and sends throttled range commands. Radio echoes for intermediate
+    // drag positions are stale by the time they arrive and would force extra
+    // waterfall reprojections back through old frames.
+    if (m_draggingPan && mhzNearlyEqual(bandwidthMhz, m_bandwidthMhz)) {
+        return;
+    }
+
+    // While a local zoom/range gesture is settling, the widget owns the visual
+    // center and bandwidth. Flex can echo older center-only statuses after a
+    // combined center+bandwidth command; accepting those stale centers retargets
+    // the local view and can churn remote Kiwi W/F zoom/start requests.
+    if (m_frequencyRangeSettlePending
+        && m_frequencyRangePendingValid
+        && !mhzNearlyEqual(centerMhz, m_centerMhz)
+        && !mhzNearlyEqual(centerMhz, m_frequencyRangePendingCenterMhz)) {
+        return;
+    }
 
     const double oldCenterMhz = m_centerMhz;
     const double oldBandwidthMhz = m_bandwidthMhz;
@@ -4912,6 +5052,8 @@ void SpectrumWidget::clearKiwiSdrWaterfallRows()
     m_kiwiWaterfallState = WaterfallStreamState{};
     m_kiwiProfileWaterfallStates.clear();
     m_kiwiSdrFftTrace.clear();
+    m_kiwiSdrFftTraceFloorDbm = -1000.0f;
+    m_kiwiSdrFftTraceFloorValid = false;
     if (m_kiwiSdrWaterfallActive) {
         clearCurrentWaterfallRows();
         leanCappedUpdate();
@@ -4994,6 +5136,23 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     const bool sameWaterfallFrame = m_kiwiSdrLastWaterfallFrameValid
         && std::abs(rowCenterMhz - m_kiwiSdrLastWaterfallCenterMhz) <= centerToleranceMhz
         && std::abs(rowBandwidthMhz - m_kiwiSdrLastWaterfallBandwidthMhz) <= bandwidthToleranceMhz;
+    const double rowLowBoundMhz = rowCenterMhz - rowBandwidthMhz * 0.5;
+    const double rowHighBoundMhz = rowCenterMhz + rowBandwidthMhz * 0.5;
+    const double viewLowBoundMhz = m_centerMhz - m_bandwidthMhz * 0.5;
+    const double viewHighBoundMhz = m_centerMhz + m_bandwidthMhz * 0.5;
+    const double overlapMhz = std::max(
+        0.0,
+        std::min(rowHighBoundMhz, viewHighBoundMhz)
+            - std::max(rowLowBoundMhz, viewLowBoundMhz));
+    const double viewCoverage = (m_bandwidthMhz > 0.0)
+        ? overlapMhz / m_bandwidthMhz
+        : 0.0;
+    const bool rowHasUsableTraceCoverage = viewCoverage >= 0.05;
+    const bool rowCanDriveAutoLevel =
+        viewCoverage >= 0.98
+        && !m_draggingPan
+        && !m_draggingBandwidth
+        && !m_frequencyRangeSettlePending;
     if (!sameWaterfallFrame) {
         m_kiwiSdrLastWaterfallBins.clear();
         m_kiwiSdrLastWaterfallCenterMhz = rowCenterMhz;
@@ -5002,29 +5161,14 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     }
 
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
-    if (m_kiwiSdrWaterfallActive && destWidth > 0) {
-        QVector<float> kiwiTrace(destWidth, kKiwiSdrWaterfallMinDbm);
-        const double rowLow = rowCenterMhz - rowBandwidthMhz * 0.5;
-        const double viewLow = m_centerMhz - m_bandwidthMhz * 0.5;
-        const int srcSize = smoothedBins.size();
-        for (int x = 0; x < destWidth; ++x) {
-            const double freqMhz = viewLow
-                + (static_cast<double>(x) + 0.5)
-                    * m_bandwidthMhz / static_cast<double>(destWidth);
-            const double srcCenter =
-                ((freqMhz - rowLow) / rowBandwidthMhz)
-                    * static_cast<double>(srcSize) - 0.5;
-            if (srcCenter < -0.5
-                || srcCenter > static_cast<double>(srcSize) - 0.5) {
-                continue;
-            }
-            const double srcLeft = std::max(0.0, srcCenter - 0.5);
-            const double srcRight =
-                std::min(static_cast<double>(srcSize), srcCenter + 0.5);
-            kiwiTrace[x] = peakPreservedBinSample(
-                smoothedBins, srcLeft, srcRight, srcCenter,
-                kKiwiSdrWaterfallMinDbm);
-        }
+    if (m_kiwiSdrWaterfallActive && destWidth > 0 && rowHasUsableTraceCoverage) {
+        // The waterfall preserves narrow peaks, but the FFT line must not rise
+        // just because a pan/zoom step changes the sampled row window. Average
+        // the covered bins and normalize the row below.
+        QVector<float> kiwiTrace = KiwiSdrTraceMath::mapRowToTrace(
+            smoothedBins, destWidth, rowCenterMhz, rowBandwidthMhz,
+            m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
+        stabilizeKiwiSdrFftTrace(kiwiTrace, rowCanDriveAutoLevel);
         if (m_kiwiSdrFftTrace.size() != kiwiTrace.size()) {
             m_kiwiSdrFftTrace = kiwiTrace;
         } else {
@@ -5034,30 +5178,32 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             }
         }
         if (!m_kiwiSdrFftTrace.isEmpty()) {
-            const float previousMeasuredNoiseFloorDbm = m_measuredNoiseFloorDbm;
-            const float frameFloor = estimateNoiseFloorDbm(m_kiwiSdrFftTrace);
-            const float visualFloor =
-                estimateKiwiSdrVisualNoiseFloorDbm(m_kiwiSdrFftTrace);
-            updateKiwiSdrSquelchVisualFloor(visualFloor);
-            constexpr float kAlpha = 0.05f;
-            m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
-                ? frameFloor
-                : m_measuredNoiseFloorDbm * (1.0f - kAlpha)
-                    + frameFloor * kAlpha;
-            if (m_kiwiSdrSquelchLineVisible
-                && (previousMeasuredNoiseFloorDbm <= -500.0f
-                    || std::abs(previousMeasuredNoiseFloorDbm
-                                - m_measuredNoiseFloorDbm) > 0.25f)) {
-                markOverlayDirty();
-            }
+            if (rowCanDriveAutoLevel) {
+                const float previousMeasuredNoiseFloorDbm = m_measuredNoiseFloorDbm;
+                const float frameFloor = estimateNoiseFloorDbm(m_kiwiSdrFftTrace);
+                const float visualFloor =
+                    estimateKiwiSdrVisualNoiseFloorDbm(m_kiwiSdrFftTrace);
+                updateKiwiSdrSquelchVisualFloor(visualFloor);
+                constexpr float kAlpha = 0.05f;
+                m_measuredNoiseFloorDbm = (m_measuredNoiseFloorDbm <= -500.0f)
+                    ? frameFloor
+                    : m_measuredNoiseFloorDbm * (1.0f - kAlpha)
+                        + frameFloor * kAlpha;
+                if (m_kiwiSdrSquelchLineVisible
+                    && (previousMeasuredNoiseFloorDbm <= -500.0f
+                        || std::abs(previousMeasuredNoiseFloorDbm
+                                    - m_measuredNoiseFloorDbm) > 0.25f)) {
+                    markOverlayDirty();
+                }
 
-            const bool useFreshLockFrame = m_noiseFloorFreshFrameCount > 0;
-            const bool noiseFloorFrameConsumed =
-                updateNoiseFloorBaseline(m_kiwiSdrFftTrace, useFreshLockFrame);
-            if (useFreshLockFrame && noiseFloorFrameConsumed) {
-                --m_noiseFloorFreshFrameCount;
+                const bool useFreshLockFrame = m_noiseFloorFreshFrameCount > 0;
+                const bool noiseFloorFrameConsumed =
+                    updateNoiseFloorBaseline(m_kiwiSdrFftTrace, useFreshLockFrame);
+                if (useFreshLockFrame && noiseFloorFrameConsumed) {
+                    --m_noiseFloorFreshFrameCount;
+                }
+                updateAutoSquelchFromBins(m_kiwiSdrFftTrace);
             }
-            updateAutoSquelchFromBins(m_kiwiSdrFftTrace);
         }
     }
     pushKiwiSdrWaterfallRow(smoothedBins, destWidth,
@@ -5380,9 +5526,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                 return;
             }
 
-            m_draggingPan = true;
-            m_panDragStartX = static_cast<int>(ev->position().x());
-            m_panDragStartCenter = m_centerMhz;
+            beginPanDrag(static_cast<int>(ev->position().x()));
             setSpectrumCursor(Qt::ClosedHandCursor);
             ev->accept();
             return;
@@ -5766,9 +5910,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     }
 
     // Click in FFT area → start pan drag (tune on double-click only)
-    m_draggingPan = true;
-    m_panDragStartX = static_cast<int>(ev->position().x());
-    m_panDragStartCenter = m_centerMhz;
+    beginPanDrag(static_cast<int>(ev->position().x()));
     setSpectrumCursor(Qt::ClosedHandCursor);
     ev->accept();
 }
@@ -5882,6 +6024,119 @@ void SpectrumWidget::edgePanVelocityStep()
         << " dMhz=" << deltaMhz << " center=" << m_centerMhz
         << " sliceX=" << sliceX << " sliceMhz=" << sliceFreq;
     emit edgePanTuneRequested(newCenter, sliceFreq);
+}
+
+void SpectrumWidget::schedulePanDragDeferredUpdate()
+{
+    if (m_panDragDeferredUpdateScheduled) {
+        return;
+    }
+
+    m_panDragDeferredUpdateScheduled = true;
+    QTimer::singleShot(kPanDragFrameMs, this, [this]() {
+        m_panDragDeferredUpdateScheduled = false;
+        if (!m_draggingPan || !m_panDragPendingCenterValid) {
+            return;
+        }
+        applyPanDragCenter(m_panDragPendingCenterMhz, false);
+    });
+}
+
+void SpectrumWidget::schedulePanDragSettleUpdate()
+{
+    if (m_panDragSettleTimer) {
+        m_panDragSettleTimer->start(kPanDragSettleMs);
+    }
+}
+
+void SpectrumWidget::scheduleFrequencyRangeSettleUpdate(double centerMhz,
+                                                        double bandwidthMhz)
+{
+    m_frequencyRangeSettlePending = true;
+    if (std::isfinite(centerMhz) && std::isfinite(bandwidthMhz)
+        && centerMhz > 0.0 && bandwidthMhz > 0.0) {
+        m_frequencyRangePendingValid = true;
+        m_frequencyRangePendingCenterMhz = centerMhz;
+    }
+    if (m_frequencyRangeSettleTimer) {
+        m_frequencyRangeSettleTimer->start(kFrequencyRangeSettleMs);
+    }
+}
+
+void SpectrumWidget::finishFrequencyRangeSettleUpdate()
+{
+    if (m_frequencyRangeSettleTimer) {
+        m_frequencyRangeSettleTimer->stop();
+    }
+    m_frequencyRangeSettlePending = false;
+    m_frequencyRangePendingValid = false;
+    emit frequencyRangeSettled(m_centerMhz, m_bandwidthMhz);
+}
+
+void SpectrumWidget::beginPanDrag(int startX)
+{
+    m_draggingPan = true;
+    m_panDragStartX = startX;
+    m_panDragStartCenter = m_centerMhz;
+    m_panDragWaterfallFrameCenterMhz = m_centerMhz;
+    m_panDragLastCommandCenterMhz = m_centerMhz;
+    m_panDragPendingCenterMhz = m_centerMhz;
+    m_panDragPendingCenterValid = false;
+    m_panDragDeferredUpdateScheduled = false;
+    m_panDragWaterfallClock.invalidate();
+    m_panDragCommandClock.invalidate();
+    if (m_panDragSettleTimer) {
+        m_panDragSettleTimer->stop();
+    }
+}
+
+void SpectrumWidget::applyPanDragCenter(double newCenterMhz, bool force)
+{
+    if (!std::isfinite(newCenterMhz)) {
+        return;
+    }
+
+    bool needsDeferredFlush = false;
+    const bool waterfallChanged =
+        !mhzNearlyEqual(newCenterMhz, m_panDragWaterfallFrameCenterMhz);
+    const bool waterfallDue = force || !m_panDragWaterfallClock.isValid()
+        || m_panDragWaterfallClock.elapsed() >= kPanDragFrameMs;
+    if (waterfallChanged && waterfallDue) {
+        handleWaterfallFrequencyFrameChange(m_panDragWaterfallFrameCenterMhz,
+                                            m_bandwidthMhz,
+                                            newCenterMhz,
+                                            m_bandwidthMhz);
+        m_panDragWaterfallFrameCenterMhz = newCenterMhz;
+        m_panDragWaterfallClock.restart();
+    } else if (waterfallChanged) {
+        needsDeferredFlush = true;
+    }
+    if (waterfallChanged) {
+        reprojectSpectrum(m_centerMhz, m_bandwidthMhz,
+                          newCenterMhz, m_bandwidthMhz);
+    }
+
+    m_centerMhz = newCenterMhz;
+    markOverlayDirty();
+
+    const bool commandChanged =
+        !mhzNearlyEqual(newCenterMhz, m_panDragLastCommandCenterMhz);
+    const bool commandDue = force || !m_panDragCommandClock.isValid()
+        || m_panDragCommandClock.elapsed() >= kPanDragCommandMs;
+    if (commandChanged && commandDue) {
+        emit centerChangeRequested(newCenterMhz);
+        m_panDragLastCommandCenterMhz = newCenterMhz;
+        m_panDragCommandClock.restart();
+    } else if (commandChanged) {
+        needsDeferredFlush = true;
+    }
+
+    if (force || !needsDeferredFlush) {
+        m_panDragPendingCenterValid = false;
+        return;
+    }
+
+    schedulePanDragDeferredUpdate();
 }
 
 void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
@@ -6083,6 +6338,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         // Keep center and bandwidth coupled while dragging. Sending only the
         // bandwidth and waiting to send center on release caused the radio and
         // client waterfall to diverge under trackpad-heavy zoom workflows.
+        scheduleFrequencyRangeSettleUpdate(zoomCenter, newBw);
         emit frequencyRangeChangeRequested(zoomCenter, newBw);
         ev->accept();
         return;
@@ -6126,11 +6382,10 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         const double deltaMhz = -(static_cast<double>(dx) / width()) * m_bandwidthMhz;
         const double newCenter = std::max(m_panDragStartCenter + deltaMhz,
                                           m_bandwidthMhz / 2.0);
-        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
-                                            newCenter, m_bandwidthMhz);
-        m_centerMhz = newCenter;
-        markOverlayDirty();
-        emit centerChangeRequested(newCenter);
+        m_panDragPendingCenterMhz = newCenter;
+        m_panDragPendingCenterValid = true;
+        applyPanDragCenter(newCenter, false);
+        schedulePanDragSettleUpdate();
         if (s_starstruckMode && s_starstruckSound
             && s_starstruckSound->isLoaded() && !s_starstruckSound->isPlaying()) {
             s_starstruckSound->play();
@@ -6359,7 +6614,9 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         setSpectrumCursor(Qt::CrossCursor);
         // Re-send the final combined range so the release lands on the same
         // coherent center/bandwidth pair as the in-flight drag updates.
+        scheduleFrequencyRangeSettleUpdate(m_centerMhz, m_bandwidthMhz);
         emit frequencyRangeChangeRequested(m_centerMhz, m_bandwidthMhz);
+        finishFrequencyRangeSettleUpdate();
         ev->accept();
         return;
     }
@@ -6380,6 +6637,15 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingPan) {
         m_draggingPan = false;
+        if (m_panDragSettleTimer) {
+            m_panDragSettleTimer->stop();
+        }
+        applyPanDragCenter(m_centerMhz, true);
+        emit panDragSettled(m_centerMhz, m_bandwidthMhz);
+        m_panDragPendingCenterValid = false;
+        m_panDragDeferredUpdateScheduled = false;
+        m_panDragWaterfallClock.invalidate();
+        m_panDragCommandClock.invalidate();
         setSpectrumCursor(Qt::CrossCursor);
         if (s_starstruckSound) s_starstruckSound->stop();
 
@@ -6650,6 +6916,7 @@ bool SpectrumWidget::event(QEvent* ev)
             m_centerMhz = newCenter;
             resetNoiseFloorBaseline();
             markOverlayDirty();
+            scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
             emit frequencyRangeChangeRequested(newCenter, newBw);
             return true;
         }
@@ -6826,6 +7093,7 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         m_bandwidthMhz = newBw;
         resetNoiseFloorBaseline();
         markOverlayDirty();
+        scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
         emit frequencyRangeChangeRequested(newCenter, newBw);
         ev->accept();
         return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -322,6 +322,15 @@ public:
     int   fftAverage() const           { return m_fftAverage; }
     int   fftFps() const               { return m_fftFps; }
     bool  fftWeightedAvg() const       { return m_fftWeightedAvg; }
+    bool panDragActive() const { return m_draggingPan; }
+    bool frequencyRangeGestureActive() const
+    {
+        return m_draggingBandwidth || m_frequencyRangeSettlePending;
+    }
+    bool waterfallViewUpdateDeferred() const
+    {
+        return m_draggingPan;
+    }
 
     // Waterfall controls (save to AppSettings on each change)
     void setWfColorGain(int gain);
@@ -525,6 +534,12 @@ signals:
     void segmentZoomRequested();
     // Emitted when the user drags the waterfall to pan the center frequency.
     void centerChangeRequested(double newCenterMhz);
+    // Emitted when waterfall pan-dragging pauses or ends. Remote waterfall
+    // providers use this to avoid resetting their stream on every drag step.
+    void panDragSettled(double centerMhz, double bandwidthMhz);
+    // Emitted when zoom/range interaction pauses or ends. Remote waterfall
+    // providers use this to avoid resetting their stream on every zoom step.
+    void frequencyRangeSettled(double centerMhz, double bandwidthMhz);
     // Emitted when the user drags a filter edge to resize the passband.
     void filterChangeRequested(int lowHz, int highHz);
     // Emitted when the user adjusts the dBm scale (drag or arrows).
@@ -637,6 +652,12 @@ private:
                                              double oldBandwidthMhz,
                                              double newCenterMhz,
                                              double newBandwidthMhz);
+    void applyPanDragCenter(double newCenterMhz, bool force);
+    void beginPanDrag(int startX);
+    void schedulePanDragDeferredUpdate();
+    void schedulePanDragSettleUpdate();
+    void scheduleFrequencyRangeSettleUpdate(double centerMhz, double bandwidthMhz);
+    void finishFrequencyRangeSettleUpdate();
     struct WaterfallStreamState {
         QImage waterfall;
         int wfWriteRow{0};
@@ -658,9 +679,13 @@ private:
         float kiwiAutoFloorDbm{-130.0f};
         float kiwiAutoCeilDbm{-50.0f};
         bool kiwiAutoRangeValid{false};
+        float kiwiFftTraceFloorDbm{-1000.0f};
+        bool kiwiFftTraceFloorValid{false};
         bool valid{false};
     };
     void clearCurrentWaterfallRows();
+    void resetCurrentWaterfallRowsForSize(const QSize& waterfallSize,
+                                          const QSize& historySize);
     void saveCurrentWaterfallStreamState();
     void restoreCurrentWaterfallStreamState();
     WaterfallStreamState& activeKiwiWaterfallState();
@@ -703,6 +728,8 @@ private:
     // so brief upward spikes (lightning crashes) don't pull the lock.
     bool updateNoiseFloorBaseline(const QVector<float>& bins, bool forceBaseline);
     float estimateKiwiSdrVisualNoiseFloorDbm(const QVector<float>& bins) const;
+    float estimateKiwiSdrTraceFloorDbm(const QVector<float>& bins) const;
+    void stabilizeKiwiSdrFftTrace(QVector<float>& bins, bool allowFloorAdapt);
     void updateKiwiSdrSquelchVisualFloor(float floorDbm);
     void pinKiwiSdrManualSquelchLine();
     // Adjust m_refLevel toward the target so the smoothed noise floor
@@ -779,6 +806,8 @@ private:
     float m_kiwiSdrAutoFloorDbm{-130.0f};
     float m_kiwiSdrAutoCeilDbm{-50.0f};
     bool m_kiwiSdrAutoRangeValid{false};
+    float m_kiwiSdrFftTraceFloorDbm{-1000.0f};
+    bool m_kiwiSdrFftTraceFloorValid{false};
     int m_kiwiSdrWaterfallCellDb{0};
     int m_kiwiSdrWaterfallFloorDb{0};
 
@@ -921,6 +950,8 @@ private:
     QImage m_waterfall;
     int    m_wfWriteRow{0};  // ring buffer: next row to write (newest at top)
     QImage m_waterfallHistory;
+    QSize  m_waterfallStreamSizeHint;
+    QSize  m_waterfallHistoryStreamSizeHint;
     QVector<qint64> m_wfHistoryTimestamps;
     int    m_wfHistoryWriteRow{0};
     int    m_wfHistoryRowCount{0};
@@ -970,10 +1001,22 @@ private:
     int  m_bwDragStartX{0};
     double m_bwDragStartBw{0.0};
     double m_bwDragAnchorMhz{0.0};
+    bool m_frequencyRangeSettlePending{false};
+    bool m_frequencyRangePendingValid{false};
+    double m_frequencyRangePendingCenterMhz{0.0};
+    QTimer* m_frequencyRangeSettleTimer{nullptr};
     // Waterfall pan drag state
     bool m_draggingPan{false};
     int  m_panDragStartX{0};
     double m_panDragStartCenter{0.0};
+    double m_panDragWaterfallFrameCenterMhz{0.0};
+    double m_panDragLastCommandCenterMhz{0.0};
+    double m_panDragPendingCenterMhz{0.0};
+    bool m_panDragPendingCenterValid{false};
+    bool m_panDragDeferredUpdateScheduled{false};
+    QElapsedTimer m_panDragWaterfallClock;
+    QElapsedTimer m_panDragCommandClock;
+    QTimer* m_panDragSettleTimer{nullptr};
     // Filter edge drag state
     enum class FilterEdge { None, Low, High };
     FilterEdge m_draggingFilter{FilterEdge::None};

--- a/tests/kiwi_sdr_trace_math_test.cpp
+++ b/tests/kiwi_sdr_trace_math_test.cpp
@@ -69,6 +69,17 @@ int main()
         return fail("mapped gesture row should keep the FFT trace floor anchored");
     }
 
+    QVector<float> dcEdgeRow(1024, -90.0f);
+    dcEdgeRow[512] = -45.0f;
+    const QVector<float> dcEdgeTrace = mapRowToTrace(
+        dcEdgeRow, 128,
+        7.5, 15.0,
+        7.436213, 14.543089,
+        kMinDbm);
+    if (dcEdgeTrace.isEmpty() || floorOf(dcEdgeTrace) <= kMinDbm) {
+        return fail("DC-edge Kiwi row should map into the visible trace");
+    }
+
     QVector<float> adaptingTrace(128, -80.0f);
     TraceFloorState adaptingFloor{-100.0f, true};
     stabilizeTraceFloor(adaptingTrace, adaptingFloor, true, kMinDbm, kMaxDbm);

--- a/tests/kiwi_sdr_trace_math_test.cpp
+++ b/tests/kiwi_sdr_trace_math_test.cpp
@@ -1,0 +1,88 @@
+#include "gui/KiwiSdrTraceMath.h"
+
+#include <QVector>
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+constexpr float kMinDbm = -200.0f;
+constexpr float kMaxDbm = 0.0f;
+
+bool nearlyEqual(float a, float b, float epsilon = 0.001f)
+{
+    return std::fabs(a - b) <= epsilon;
+}
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "kiwi_sdr_trace_math_test: %s\n", message);
+    return 1;
+}
+
+float floorOf(const QVector<float>& bins)
+{
+    return AetherSDR::KiwiSdrTraceMath::estimateTraceFloorDbm(bins, kMinDbm);
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR::KiwiSdrTraceMath;
+
+    QVector<float> trace(128, -100.0f);
+    for (int i = 0; i < 8; ++i) {
+        trace[i] = kMinDbm;
+    }
+    for (int i = 96; i < 112; ++i) {
+        trace[i] = -45.0f;
+    }
+    if (!nearlyEqual(floorOf(trace), -100.0f)) {
+        return fail("floor estimate should ignore blanks and signals");
+    }
+
+    QVector<float> gestureTrace(128, -80.0f);
+    gestureTrace[10] = kMinDbm;
+    gestureTrace[64] = -50.0f;
+    TraceFloorState lockedFloor{-100.0f, true};
+    stabilizeTraceFloor(gestureTrace, lockedFloor, false, kMinDbm, kMaxDbm);
+    if (!nearlyEqual(lockedFloor.floorDbm, -100.0f)
+        || !nearlyEqual(floorOf(gestureTrace), -100.0f)
+        || !nearlyEqual(gestureTrace[64], -70.0f)
+        || !nearlyEqual(gestureTrace[10], kMinDbm)) {
+        return fail("gesture-time stabilization should keep the FFT floor anchored");
+    }
+
+    QVector<float> mappedRow(256, -80.0f);
+    mappedRow[128] = -50.0f;
+    QVector<float> mappedTrace = mapRowToTrace(
+        mappedRow, 128,
+        14.0, 1.0,
+        14.0, 0.5,
+        kMinDbm);
+    TraceFloorState mappedFloor{-100.0f, true};
+    stabilizeTraceFloor(mappedTrace, mappedFloor, false, kMinDbm, kMaxDbm);
+    if (!nearlyEqual(mappedFloor.floorDbm, -100.0f)
+        || !nearlyEqual(floorOf(mappedTrace), -100.0f)) {
+        return fail("mapped gesture row should keep the FFT trace floor anchored");
+    }
+
+    QVector<float> adaptingTrace(128, -80.0f);
+    TraceFloorState adaptingFloor{-100.0f, true};
+    stabilizeTraceFloor(adaptingTrace, adaptingFloor, true, kMinDbm, kMaxDbm);
+    if (!nearlyEqual(adaptingFloor.floorDbm, -99.4f)
+        || !nearlyEqual(floorOf(adaptingTrace), -99.4f)) {
+        return fail("full-coverage upward floor adaptation should be gradual");
+    }
+
+    const QVector<float> bins{0.0f, 10.0f, 20.0f, 30.0f};
+    const float averaged =
+        averagedBinSample(bins, 0.5, 2.5, 1.5, kMinDbm);
+    if (!nearlyEqual(averaged, 10.0f)) {
+        return fail("averaged bin sampler should weight the covered source span");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #3816. Moves KiwiSDR receiver/network work off the GUI thread, coalesces Kiwi waterfall row delivery, and changes pan/zoom handling so AetherSDR keeps the local panadapter responsive while avoiding repeated remote Kiwi waterfall window resets during gestures. This also stabilizes the Kiwi FFT trace math so partial/stale waterfall rows during pan or zoom no longer re-anchor the FFT floor and make the trace jump upward.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The change is backed by a focused KiwiSDR trace-math regression test, local builds, focused Kiwi test runs, and live receiver testing against the reported pan/zoom behavior.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR kiwi_sdr_trace_math_test`)
- [x] Behavior verified on a real receiver: Kiwi pan left/right no longer freezes, and fast zoom behavior was iterated against live logs/user testing
- [x] Focused Kiwi tests pass (`ctest --test-dir build -R 'kiwi_sdr_trace_math_test|kiwi' --output-on-failure`)
- [x] `git diff --check` passes
- [x] A11y checker passes with existing warning-only findings (`python3 tools/check_a11y.py`)
- [x] Reproduction steps documented: drag or zoom a Kiwi-backed panadapter and watch for waterfall/FFT freezes or FFT trace vertical jumps

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
