### PR TITLE
fix(gui): fill the floating window for width-capped applets (#3451)

### DIFF
--- a/src/gui/containers/ContainerTitleBar.cpp
+++ b/src/gui/containers/ContainerTitleBar.cpp
@@ -80,6 +80,9 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
     m_pinBtn->setStyleSheet(kPinBtnStyle);
     m_pinBtn->setFixedSize(16, 16);
     m_pinBtn->setCheckable(true);
+    // Accessible names so the agent automation bridge can drive the
+    // title-bar controls (scoped by the container's objectName). (#3646)
+    m_pinBtn->setAccessibleName(QStringLiteral("containerPin"));
     m_pinBtn->setToolTip("Always on top");
     m_pinBtn->setCursor(Qt::ArrowCursor);
     m_pinBtn->setVisible(false);  // shown only in float mode
@@ -93,6 +96,7 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
     m_floatBtn = new QPushButton(QString::fromUtf8("\xe2\xa7\x89"));  // ⧉ two joined squares (#2430 follow-up)
     m_floatBtn->setStyleSheet(kFloatBtnStyle);
     m_floatBtn->setFixedSize(18, 18);
+    m_floatBtn->setAccessibleName(QStringLiteral("containerFloatToggle"));
     m_floatBtn->setToolTip("Pop out into a floating window");
     m_floatBtn->setCursor(Qt::ArrowCursor);
     connect(m_floatBtn, &QPushButton::clicked,
@@ -102,6 +106,7 @@ ContainerTitleBar::ContainerTitleBar(const QString& title, QWidget* parent)
     m_closeBtn = new QPushButton(QString::fromUtf8("\xc3\x97"));  // ×
     m_closeBtn->setStyleSheet(kBtnStyle);
     m_closeBtn->setFixedSize(16, 16);
+    m_closeBtn->setAccessibleName(QStringLiteral("containerClose"));
     m_closeBtn->setToolTip("Hide this container");
     m_closeBtn->setCursor(Qt::ArrowCursor);
     connect(m_closeBtn, &QPushButton::clicked,

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -13,6 +13,11 @@ ContainerWidget::ContainerWidget(const QString& id, const QString& title,
     : QWidget(parent)
     , m_id(id)
 {
+    // objectName mirrors the stable container id ("AG", "AMP", "SS", …) so
+    // the agent automation bridge can scope title-bar controls to a specific
+    // container, e.g. invoke "AG/containerFloatToggle". (#3646)
+    setObjectName(id);
+
     auto* outer = new QVBoxLayout(this);
     outer->setContentsMargins(0, 0, 0, 0);
     outer->setSpacing(0);
@@ -52,6 +57,7 @@ QWidget* ContainerWidget::setContent(QWidget* content)
 {
     QWidget* previous = m_content;
     if (previous && m_bodyLayout) {
+        restoreWidthPolicy(previous);
         m_bodyLayout->removeWidget(previous);
         previous->setParent(nullptr);
     }
@@ -60,6 +66,7 @@ QWidget* ContainerWidget::setContent(QWidget* content)
         m_content->setParent(m_body);
         m_bodyLayout->addWidget(m_content, 1);
         m_content->show();
+        applyWidthPolicyTo(m_content);
     }
     return previous;
 }
@@ -80,11 +87,13 @@ void ContainerWidget::insertChildWidget(int index, QWidget* child)
         index = m_bodyLayout->count();
     m_bodyLayout->insertWidget(index, child);
     child->show();
+    applyWidthPolicyTo(child);
 }
 
 void ContainerWidget::removeChildWidget(QWidget* child)
 {
     if (!child || !m_bodyLayout) return;
+    restoreWidthPolicy(child);
     m_bodyLayout->removeWidget(child);
     child->setParent(nullptr);
 }
@@ -126,7 +135,38 @@ void ContainerWidget::setDockMode(DockMode mode)
     if (mode == m_dockMode) return;
     m_dockMode = mode;
     if (m_titleBar) m_titleBar->setFloatingState(mode == DockMode::Floating);
+    // Re-apply the width policy to every body child for the new mode:
+    // floating lifts width caps so content fills the window; docking
+    // restores each child's original cap. (#3451)
+    if (m_bodyLayout) {
+        for (int i = 0; i < m_bodyLayout->count(); ++i) {
+            if (QWidget* child = m_bodyLayout->itemAt(i)->widget())
+                applyWidthPolicyTo(child);
+        }
+    }
     emit dockModeChanged(mode);
+}
+
+void ContainerWidget::applyWidthPolicyTo(QWidget* child)
+{
+    if (!child) return;
+    if (m_dockMode == DockMode::Floating) {
+        // Remember the docked cap once, then lift it so width-capped
+        // applets fill the floating window instead of hugging the left
+        // edge.  Uncapped content (maximumWidth == QWIDGETSIZE_MAX) is a
+        // no-op here. (#3451)
+        if (!m_savedMaxWidths.contains(child))
+            m_savedMaxWidths.insert(child, child->maximumWidth());
+        child->setMaximumWidth(QWIDGETSIZE_MAX);
+    } else {
+        restoreWidthPolicy(child);
+    }
+}
+
+void ContainerWidget::restoreWidthPolicy(QWidget* child)
+{
+    if (child && m_savedMaxWidths.contains(child))
+        child->setMaximumWidth(m_savedMaxWidths.take(child));
 }
 
 void ContainerWidget::onTitleBarFloatToggle()

--- a/src/gui/containers/ContainerWidget.h
+++ b/src/gui/containers/ContainerWidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QHash>
 #include <QString>
 #include <QWidget>
 
@@ -137,6 +138,16 @@ private:
     friend class FloatingContainerWindow;
     void setDockMode(DockMode mode);
 
+    // Width-capped applets (Antenna Genius, ShackSwitch, RX-DSP) clamp their
+    // own maximumWidth so they sit tidily in the narrow docked strip.  When
+    // the container floats into its own window that cap leaves the content
+    // hugging the left edge with dead space to the right (#3451).  While
+    // floating we lift the cap so the content fills the window; on re-dock we
+    // restore each child's original cap.  m_savedMaxWidths remembers the
+    // docked cap per child for the duration of a float.
+    void applyWidthPolicyTo(QWidget* child);
+    void restoreWidthPolicy(QWidget* child);
+
     QString            m_id;
     QString            m_dragId;   // empty → dragId() returns m_id (#3057)
     ContainerTitleBar* m_titleBar{nullptr};
@@ -145,6 +156,7 @@ private:
     QWidget*           m_content{nullptr};
     DockMode           m_dockMode{DockMode::PanelDocked};
     bool               m_visible{true};
+    QHash<QWidget*, int> m_savedMaxWidths;  // child → docked maximumWidth (#3451)
 };
 
 } // namespace AetherSDR

--- a/tests/container_widget_test.cpp
+++ b/tests/container_widget_test.cpp
@@ -136,6 +136,41 @@ void testFloatDockCycle()
     win2.releaseContainer();
 }
 
+// #3451: a width-capped applet (e.g. Antenna Genius, max 260) should have its
+// cap lifted while floating so it fills the window instead of hugging the left
+// edge, and have the cap restored when it docks back into the panel strip.
+void testFloatingWidthPolicy()
+{
+    ContainerWidget c("id", "T");
+    auto* body = new QLabel("payload");
+    body->setMaximumWidth(260);   // mimic a width-capped applet
+    c.setContent(body);
+
+    report("docked content keeps its width cap",
+           body->maximumWidth() == 260);
+
+    FloatingContainerWindow win;
+    win.takeContainer(&c);
+    report("floating content cap is lifted to fill the window",
+           body->maximumWidth() == QWIDGETSIZE_MAX);
+
+    win.releaseContainer();
+    report("docked-again content cap is restored",
+           body->maximumWidth() == 260);
+
+    // An uncapped applet (e.g. the Amplifier) stays uncapped throughout.
+    ContainerWidget c2("id2", "T2");
+    auto* body2 = new QLabel("uncapped");
+    c2.setContent(body2);
+    FloatingContainerWindow win2;
+    win2.takeContainer(&c2);
+    report("uncapped content stays uncapped while floating",
+           body2->maximumWidth() == QWIDGETSIZE_MAX);
+    win2.releaseContainer();
+    report("uncapped content stays uncapped after docking",
+           body2->maximumWidth() == QWIDGETSIZE_MAX);
+}
+
 void testCloseSignal()
 {
     ContainerWidget c("id", "T");
@@ -167,6 +202,7 @@ int main(int argc, char** argv)
     testSetContent();
     testVisibilitySignal();
     testFloatDockCycle();
+    testFloatingWidthPolicy();
     testCloseSignal();
     testTitlebarCloseButtonToggle();
 


### PR DESCRIPTION
## What & why

Fixes #3451. When a width-capped applet is popped out of the docked strip into its own floating window, its content stayed pinned to the left edge with a growing dead zone on the right — the "left-justified" look the reporter showed for **Antenna Genius**.

**Root cause.** Several applets clamp their own `maximumWidth` so they sit tidily in the narrow right-hand strip:

- `AntennaGeniusApplet.cpp:55` — `setMaximumWidth(260)`
- `ShackSwitchApplet.cpp:82` — `setMaximumWidth(260)`
- `ClientRxDspApplet.cpp:17` — `setMaximumWidth(250)`

That cap is right when docked, but `FloatingContainerWindow` opens at 300 px (and is freely resizable) with a plain `QVBoxLayout` and no alignment, so the 260-px content hugs the left edge. The wider the user drags the window, the bigger the dead zone.

**Fix.** `ContainerWidget` now tracks dock state for its body content: while **floating** it lifts each child's width cap so the content fills the window; on **re-dock** it restores the original cap (remembered per child). Rather than *centering* the capped content — which only makes the wasted space symmetric — the content now actually **uses the real estate**, which is what was asked for here.

The **Amplifier / Power Genius** applet has no width cap, so it already filled the window; the change is a verified no-op for it (see below). The same fix also covers ShackSwitch and the RX-DSP applet.

## Screenshots — affected applets (floated, widened to 440 px)

### Antenna Genius — the reported applet (fixed)
![Antenna Genius before/after](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-3451/AG-comparison.png)

Before, the controls stop at 260 px; after, the device combo, **Connect**, **Manual IP**, the **AUTO** bars and the Port A/B rows all stretch to the window edge. (Shown disconnected, so the per-antenna button grid is empty — when connected that 4-column grid fills the extra width too.)

### Power Genius / Amplifier — checked, already effective
![Amplifier before/after](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-3451/AMP-comparison.png)

You flagged this one too. I checked it: it has no width cap, so the PWR/SWR/Id gauges already span the full width. Before and after pixels are byte-identical — no change needed. So among the two named applets, only Antenna Genius had the dead-space bug.

## How the agent automation bridge proved it

The fix was verified headlessly with the agent automation bridge on an isolated, non-connecting instance (no radio contention):

| Step | Verb | Result |
|---|---|---|
| Safety | `get radio` | `connected: false` (offline, no radio touched) |
| Float AG | `invoke AG/containerFloatToggle click` | `ok, newValue: ↙` |
| Widen | `resize AG 440 560` | `actual 440×560` |
| Capture | `grab AG` | PNG — content fills 440 px (after) vs 260 px (before) |

This relied on two small bridge-reachability additions in this PR: every `ContainerWidget` now carries an `objectName` equal to its stable id (`AG`, `AMP`, `SS`, …), and the title-bar float/pin/close buttons carry accessible names — so a driver can scope a control to one container (`AG/containerFloatToggle`). Closes a real gap (#3646): before this, no floating container's title-bar controls were addressable.

## Tests

`tests/container_widget_test.cpp` gains coverage: docked content keeps its cap → floating lifts it to `QWIDGETSIZE_MAX` → re-docking restores it; uncapped content is untouched in both states. All container tests pass.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
