### PR TITLE
feat(modem): APRS message-services picker on the Recipient field (#3569)

### DIFF
--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -3074,10 +3074,10 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
     // and "aprsSvc" + "Wx…" spells "…svcWX…" → a false "cwx" hit that would block
     // the (RX-only) weather entry. The spelled-out prefix avoids that collision.
     static const AprsServiceEntry kAprsServices[] = {
-        {"SMS", "SMSGTE — text an SMS to a phone", "aprsServiceSmsgte",
-         "SMSGTE", "@",
-         "SMSGTE: \"@<10-digit-number> <message>\" (~67 chars). Replies return as "
-         "APRS. Register an alias with \"#mynumber add <number>\" to save text."},
+        {"SMS", "SMS — text an SMS to a phone", "aprsServiceSms",
+         "SMS", "@",
+         "SMS (NA7Q gateway): \"@<10-digit-number> <message>\" (~67 chars). Replies "
+         "return as APRS. Make an alias with \"#alias #add <name> <number>\"."},
         {"Email", "EMAIL-2 — send an email", "aprsServiceEmail2",
          "EMAIL-2", "",
          "EMAIL-2: \"<email@address> <message>\" (~67 chars). Send your own address "

--- a/src/gui/Ax25HfPacketDecodeDialog.cpp
+++ b/src/gui/Ax25HfPacketDecodeDialog.cpp
@@ -67,6 +67,7 @@
 #include <QStyle>
 #include <QTableWidget>
 #include <QTimeZone>
+#include <QToolButton>
 #include <QUrl>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -3049,6 +3050,91 @@ void Ax25HfPacketDecodeDialog::buildAprsUi(QWidget* page, QVBoxLayout* pageLayou
     m_aprsMsgTo->setPlaceholderText(QStringLiteral("To (N0CALL-7)"));
     m_aprsMsgTo->setMaximumWidth(150);
     msgLayout->addWidget(m_aprsMsgTo);
+
+    // Message-services picker (#3569): a caret button next to the To field that
+    // addresses well-known APRS gateways (SMS, email, Winlink, weather) and
+    // seeds the matching command template, so operators don't have to memorize
+    // callsigns and syntax. The ISS/satellite entry is routing-only — it shows a
+    // path hint rather than mutating the To field or the TX path, which is more
+    // surprising to undo (see the issue's "path coupling" note). The body must
+    // NOT be uppercased anywhere on the send path: EMAIL-2 addresses and SMSGTE
+    // aliases are case-sensitive (sendAprsMessageFromUi only uppercases the
+    // addressee).
+    struct AprsServiceEntry {
+        const char* section;    // category header; empty reuses the prior one
+        const char* label;      // menu item text
+        const char* objectName; // stable id for the agent automation bridge (#3646)
+        const char* addressee;  // To callsign; empty = routing-only (hint only)
+        const char* body;       // seed for the message field; cursor lands at end
+        const char* hint;       // one-line "what this does" + char limit
+    };
+    // objectName scheme is the full word "aprsService…" (not an "aprsSvc…"
+    // abbreviation) on purpose: the agent automation bridge's TX-safety guard
+    // (#3646) does an unanchored substring match for the CW-keying token "cwx",
+    // and "aprsSvc" + "Wx…" spells "…svcWX…" → a false "cwx" hit that would block
+    // the (RX-only) weather entry. The spelled-out prefix avoids that collision.
+    static const AprsServiceEntry kAprsServices[] = {
+        {"SMS", "SMSGTE — text an SMS to a phone", "aprsServiceSmsgte",
+         "SMSGTE", "@",
+         "SMSGTE: \"@<10-digit-number> <message>\" (~67 chars). Replies return as "
+         "APRS. Register an alias with \"#mynumber add <number>\" to save text."},
+        {"Email", "EMAIL-2 — send an email", "aprsServiceEmail2",
+         "EMAIL-2", "",
+         "EMAIL-2: \"<email@address> <message>\" (~67 chars). Send your own address "
+         "once to register; \"get\" to EMAIL-2 retrieves held replies (~24h)."},
+        {"Winlink", "WLNK-1 — APRSLink help (?)", "aprsServiceWlnkHelp",
+         "WLNK-1", "?",
+         "WLNK-1 APRSLink: send \"?\" for the command list (L, R#, SP, SMS, …)."},
+        {"", "WLNK-1 — one-line email/SMS", "aprsServiceWlnkSms",
+         "WLNK-1", "SMS ",
+         "WLNK-1: \"SMS <email-or-callsign> <message>\" sends a one-line message "
+         "over the Winlink radio-email bridge."},
+        {"Weather", "WXBOT — forecast / METAR", "aprsServiceWxbot",
+         "WXBOT", "",
+         "WXBOT: \"Boston,MA\", \"KJFK\" (ICAO→METAR), a Maidenhead grid, or blank "
+         "for your last-heard position. Comma required for City,ST."},
+        {"Satellite / ISS", "ISS / ARISS digipeater — path hint", "aprsServiceIss",
+         "", "",
+         "ISS/ARISS digi (145.825 MHz): set TX PATH to \"ARISS\" (RS0ISS), not "
+         "WIDE1-1,WIDE2-1. Keep messages ≤~60 chars; best on passes >30°."},
+    };
+
+    auto* serviceMenu = new QMenu(msgFrame);
+    QString lastSection;
+    for (const AprsServiceEntry& e : kAprsServices) {
+        const QString section = QString::fromLatin1(e.section);
+        if (!section.isEmpty() && section != lastSection) {
+            serviceMenu->addSection(section);
+            lastSection = section;
+        }
+        QAction* act = serviceMenu->addAction(QString::fromLatin1(e.label));
+        act->setObjectName(QString::fromLatin1(e.objectName));
+        act->setToolTip(QString::fromLatin1(e.hint));
+        const QString addressee = QString::fromLatin1(e.addressee);
+        const QString body = QString::fromLatin1(e.body);
+        const QString hint = QString::fromLatin1(e.hint);
+        connect(act, &QAction::triggered, this,
+                [this, addressee, body, hint] { seedAprsService(addressee, body, hint); });
+    }
+
+    m_aprsServiceButton = new QToolButton(msgFrame);
+    m_aprsServiceButton->setObjectName(QStringLiteral("AprsServiceMenuButton"));
+    m_aprsServiceButton->setAccessibleName(QStringLiteral("APRS message services"));
+    m_aprsServiceButton->setText(QStringLiteral("▾"));
+    m_aprsServiceButton->setToolTip(QStringLiteral(
+        "Address a common APRS service: SMS, email, Winlink, weather, ISS"));
+    m_aprsServiceButton->setMenu(serviceMenu);
+    m_aprsServiceButton->setPopupMode(QToolButton::InstantPopup);
+    // A human mouse press opens the menu via Qt's built-in InstantPopup path.
+    // We deliberately do NOT wire clicked()→open for the agent automation bridge
+    // (#3646): a synthetic click arrives inside the bridge's socket-read callback,
+    // and showing the menu's native popup window from there re-enters the macOS
+    // GUI stack and segfaults intermittently (QMenu::popup → QCocoaWindow::
+    // setVisible → QWindow::geometry). Driving this dropdown is a documented
+    // bridge gap; the menu actions still carry stable objectNames so the bridge
+    // can verify the seeded fields structurally.
+    msgLayout->addWidget(m_aprsServiceButton);
+
     m_aprsMsgText = new QLineEdit(msgFrame);
     m_aprsMsgText->setPlaceholderText(
         QStringLiteral("Message text (sent with ack request, retries until acked)"));
@@ -3500,6 +3586,23 @@ void Ax25HfPacketDecodeDialog::sendAprsMessageFromUi()
         return;
     }
     m_aprsMsgText->clear();
+}
+
+void Ax25HfPacketDecodeDialog::seedAprsService(const QString& addressee,
+                                               const QString& body,
+                                               const QString& hint)
+{
+    // Routing-only entries (ISS/satellite) carry no addressee: leave the To and
+    // message fields untouched and just surface the hint, so we don't clobber
+    // whatever the operator was composing.
+    if (!addressee.isEmpty()) {
+        m_aprsMsgTo->setText(addressee);
+        m_aprsMsgText->setText(body);
+        m_aprsMsgText->setFocus();
+        m_aprsMsgText->setCursorPosition(body.length());
+    }
+    if (!hint.isEmpty())
+        appendSystemLine(hint);
 }
 
 void Ax25HfPacketDecodeDialog::updateAprsEnvelopeButton()

--- a/src/gui/Ax25HfPacketDecodeDialog.h
+++ b/src/gui/Ax25HfPacketDecodeDialog.h
@@ -24,6 +24,7 @@ class QStackedWidget;
 class QTableWidget;
 class QTextEdit;
 class QTimer;
+class QToolButton;
 class QVBoxLayout;
 
 namespace AetherSDR {
@@ -128,6 +129,11 @@ private:
     void showAprsStationInfo(const QString& call);
     void openAprsMessagesDialog();
     void sendAprsMessageFromUi();
+    // APRS message-services picker (#3569): seed the To/text fields from a
+    // well-known gateway service (SMS, email, Winlink, weather), or just show a
+    // routing hint for ISS/satellite work. Empty addressee → hint only.
+    void seedAprsService(const QString& addressee, const QString& body,
+                         const QString& hint);
     void updateAprsEnvelopeButton();
     void handleGpsUpdate();
 
@@ -274,6 +280,7 @@ private:
     QLineEdit* m_aprsManualLat{nullptr};
     QLineEdit* m_aprsManualLon{nullptr};
     QLineEdit* m_aprsMsgTo{nullptr};
+    QToolButton* m_aprsServiceButton{nullptr};
     QLineEdit* m_aprsMsgText{nullptr};
     QPushButton* m_aprsMsgSend{nullptr};
     QPushButton* m_aprsEnvelope{nullptr};


### PR DESCRIPTION
## What & why

Closes #3569. Adds an **APRS message-services picker** — a small ▾ caret button
next to the "To" field on the AetherModem **APRS** tab. It addresses the
well-known APRS gateway/auto-responder services without operators having to
memorize their callsigns and message-text syntax. These services already work
by manually typing the right destination + body; the picker just makes them one
tap away (the discoverability/usability win the issue asks for).

Selecting an entry:
1. sets the destination callsign in **To**,
2. seeds the **message text** with the correct command template and drops the
   cursor right after the prefix, and
3. prints a one-line hint (what it does + the ~67-char limit) to the system log.

### Services (grouped by category)

| Category | To | Seeded body | Notes |
|---|---|---|---|
| SMS | `SMS` | `@` | NA7Q gateway, `@<10-digit#> <msg>`; replies return as APRS (SMSGTE is shut down) |
| Email | `EMAIL-2` | *(empty)* | `<email> <msg>`; register by sending your address once |
| Winlink | `WLNK-1` | `?` | APRSLink help / command list |
| Winlink | `WLNK-1` | `SMS ` | one-line `SMS <email-or-call> <msg>` |
| Weather | `WXBOT` | *(empty)* | `City,ST` / `KICAO` / grid / blank = last position |
| Satellite / ISS | *(unchanged)* | *(unchanged)* | **routing-only** — shows an ARISS/RS0ISS path hint, does not touch To or the TX path |

Per the maintainer triage on the issue, the ISS/satellite entry deliberately
**does not** mutate the To field or the TX `PATH` — changing the path is more
intrusive and easy to forget to revert — it only surfaces a hint.


> **Gateway note:** the original issue specified `SMSGTE`, but that service has been
> temporarily shut down over spam. The active global APRS↔SMS gateway is now NA7Q's,
> addressed to **`SMS`** (same `@<number> <message>` body). Shipped with `SMS`.

## Scope

All changes are local to `Ax25HfPacketDecodeDialog` (`.cpp` + `.h`); no
encoder/protocol change. The send path keeps **not** uppercasing the message
body (`sendAprsMessageFromUi` only uppercases the addressee), so case-sensitive
`EMAIL-2` addresses and `SMSGTE` aliases survive intact — the service templates
rely on that.

## How the agent automation bridge proved it

Built `RelWithDebInfo`, launched with `AETHER_AUTOMATION=1`, and drove the
picker entries by `objectName` (RX-only — no TX; MODEM stayed in **Standby**).
The bridge triggers each menu action and reads the resulting `To` / message
fields back via `dumpTree`. Before→after, all crash-free on one running
instance:

```
BEFORE        : ['', '']                  (To, message text)
SMS       ->   ['SMS', '@']
EMAIL-2   ->   ['EMAIL-2', '']
WLNK help ->   ['WLNK-1', '?']
WLNK sms  ->   ['WLNK-1', 'SMS ']
WXBOT     ->   ['WXBOT', '']

ISS routing-only no-clobber:
  before ISS = ['WLNK-1', 'SMS ']
  after  ISS = ['WLNK-1', 'SMS ']   UNCHANGED = True
```

Hints reached the system log (`lcAx25`), e.g.:
`WLNK-1 APRSLink: send "?" for the command list (L, R#, SP, SMS, …)` and
`ISS/ARISS digi (145.825 MHz): set TX PATH to "ARISS" (RS0ISS)…`.

Screenshot of the new ▾ picker in the APRS **MESSAGE** row (fields seeded from
the bridge; MODEM Standby):

<!-- aprs-services-picker.png attached below -->

### Agent automation bridge — two gaps found (and worked around)

Dogfooding the bridge surfaced two real issues; the feature is shipped to dodge
both, and they're worth fixing in the bridge so the next feature doesn't have to:

1. **TX-guard deny-word `cwx` is an unanchored substring match.** The guard
   flagged a weather (RX-only) menu entry as transmit-keying because the
   abbreviated objectName `aprsSvcWXBOT`.toLower() = `aprssvc`**`wx`**`bot`
   contains the trigram `cwx` (the `c` from `svc` + `wx` from `wxbot`).
   *Workaround:* objectNames use the spelled-out `aprsService…` prefix.
   *Proposed fix:* anchor the `cwx`/`mox`/`ptt`/`transmit` deny-words to word
   boundaries (or require an explicit TX marker) instead of bare `contains()`.

2. **The bridge can't safely open a `QToolButton` popup menu on macOS.** A
   programmatic `click()` runs synchronously inside the socket-read callback;
   showing the menu's native popup window from there re-enters the Cocoa GUI
   stack and segfaults intermittently (`QMenu::popup → QCocoaWindow::setVisible
   → QWindow::geometry`). Deferring the popup with `singleShot(0)` did not help
   — showing the native window is the hazard, not the call site.
   *Workaround:* ship pure `InstantPopup` (human press uses Qt's built-in path)
   with **no** synthetic-click affordance; the bridge still verifies seeding by
   triggering the menu actions while the menu is *closed*
   (`triggerMenuAction` then skips the popup path and just calls
   `action->trigger()` — crash-free, which is exactly how the proof above runs).
   *Proposed fix:* an `openMenu`/`showMenu` verb for button popups that posts
   the show onto the GUI event loop, and/or defer widget `click()` like QAction
   triggers are already deferred.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
