### PR TITLE
feat(gui): PROF (Profile Switcher) applet — live Global/TX/Mic profile selection (#3376)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,6 +755,7 @@ set(GUI_SOURCES
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
     src/gui/MeterApplet.cpp
+    src/gui/ProfileSwitcherApplet.cpp
     src/gui/RadeApplet.cpp
     src/gui/HealthApplet.cpp
     src/gui/PersistentDialog.cpp

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -29,6 +29,7 @@
 #include "AntennaGeniusApplet.h"
 #include "ShackSwitchApplet.h"
 #include "MeterApplet.h"
+#include "ProfileSwitcherApplet.h"
 #include "HealthApplet.h"
 #include "KiwiSdrApplet.h"
 #ifdef HAVE_RADE
@@ -72,7 +73,7 @@
 namespace AetherSDR {
 
 const QStringList AppletPanel::kDefaultOrder = {
-    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "KSDR", "HLTH", "AG", "SS"
+    "RX", "TUN", "AMP", "TX", "PHNE", "P/CW", "EQ", "WAVE", "TXDSP", "CAT", "DAX", "TCI", "IQ", "MTR", "PROF", "KSDR", "HLTH", "AG", "SS"
 };
 
 // ── Drop-aware scroll area ──────────────────────────────────────────────────
@@ -856,6 +857,9 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_meterApplet = new MeterApplet;
     m_appletOrder.append(makeEntry("MTR", "Meters", m_meterApplet, false, m_drawer, m_drawerLayout));
 
+    m_profApplet = new ProfileSwitcherApplet;
+    m_appletOrder.append(makeEntry("PROF", "Profile Switcher", m_profApplet, false, m_drawer, m_drawerLayout));
+
     m_kiwiSdrApplet = new KiwiSdrApplet;
     m_appletOrder.append(makeEntry("KSDR", "KiwiSDR", m_kiwiSdrApplet, false,
                                    m_drawer, m_drawerLayout));
@@ -1368,7 +1372,7 @@ QStringList AppletPanel::defaultButtonOrder() const
     QStringList out = {"VU", "RX", "TX", "P/CW", "WAVE"};
     const QStringList rest = {
         "LCK", "PHNE", "EQ", "TXDSP",
-        "CAT", "DAX", "TCI", "IQ", "MTR", "SS", "MQTT"
+        "CAT", "DAX", "TCI", "IQ", "MTR", "PROF", "SS", "MQTT"
     };
     for (const auto& id : rest)
         if (!out.contains(id)) out.append(id);

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -50,6 +50,7 @@ class DaxIqApplet;
 class AntennaGeniusApplet;
 class ShackSwitchApplet;
 class MeterApplet;
+class ProfileSwitcherApplet;
 class HealthApplet;
 class MqttApplet;
 class KiwiSdrApplet;
@@ -122,6 +123,7 @@ public:
     AntennaGeniusApplet* agApplet()  { return m_agApplet; }
     ShackSwitchApplet*   ssApplet()  { return m_ssApplet; }
     MeterApplet*  meterApplet()  { return m_meterApplet; }
+    ProfileSwitcherApplet* profileSwitcherApplet() { return m_profApplet; }
     HealthApplet* healthApplet() { return m_healthApplet; }
     KiwiSdrApplet* kiwiSdrApplet() { return m_kiwiSdrApplet; }
 #ifdef HAVE_RADE
@@ -285,6 +287,7 @@ private:
     AntennaGeniusApplet* m_agApplet{nullptr};
     ShackSwitchApplet*   m_ssApplet{nullptr};
     MeterApplet* m_meterApplet{nullptr};
+    ProfileSwitcherApplet* m_profApplet{nullptr};
     HealthApplet* m_healthApplet{nullptr};
     KiwiSdrApplet* m_kiwiSdrApplet{nullptr};
 #ifdef HAVE_RADE

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -30,6 +30,7 @@
 #include "AmpApplet.h"
 #include "HealthApplet.h"
 #include "MeterApplet.h"
+#include "ProfileSwitcherApplet.h"
 #include "SMeterWidget.h"
 #include "TunerApplet.h"
 #include "TxApplet.h"
@@ -3604,6 +3605,9 @@ void MainWindow::wireMeters()
 
     // ── Meter applet: all meters consolidated ──────────────────────────────
     m_appletPanel->meterApplet()->setMeterModel(&m_radioModel.meterModel());
+
+    // ── PROF applet: Global / TX / Mic profile switcher (#3376) ─────────────
+    m_appletPanel->profileSwitcherApplet()->setRadioModel(&m_radioModel);
 
     // ── HLTH applet: same meter model — derives antenna-health state from
     //    SWR / power trends across radio / tuner / amp sources.

--- a/src/gui/ProfileSwitcherApplet.cpp
+++ b/src/gui/ProfileSwitcherApplet.cpp
@@ -1,0 +1,173 @@
+#include "ProfileSwitcherApplet.h"
+#include "core/ThemeManager.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+#include <QComboBox>
+#include <QGridLayout>
+#include <QLabel>
+#include <QSignalBlocker>
+
+namespace AetherSDR {
+
+static const char* kRowLabelStyle =
+    "QLabel { color: #8090a0; font-size: 10px; font-weight: bold; }";
+
+namespace {
+
+// Rebuild a combo from a fresh profile list, restoring the active selection.
+// Signals are blocked so the repopulation never looks like a user choice — the
+// applet drives loads off currentTextChanged(), so without the blocker this
+// repopulation would spuriously re-issue a profile load.
+void rebuildCombo(QComboBox* combo, const QStringList& profiles, const QString& active)
+{
+    const QSignalBlocker block(combo);
+    combo->clear();
+    combo->addItems(profiles);
+    const int idx = combo->findText(active);
+    combo->setCurrentIndex(idx >= 0 ? idx : (profiles.isEmpty() ? -1 : 0));
+    combo->setEnabled(!profiles.isEmpty());
+}
+
+// Update only the highlighted selection (no list rebuild) — used for the
+// high-frequency TX/Mic state signals.  Guarded so it is a no-op unless the
+// active profile actually moved.
+void syncCombo(QComboBox* combo, const QString& active)
+{
+    if (active.isEmpty() || combo->currentText() == active)
+        return;
+    const int idx = combo->findText(active);
+    if (idx >= 0) {
+        const QSignalBlocker block(combo);
+        combo->setCurrentIndex(idx);
+    }
+}
+
+} // namespace
+
+ProfileSwitcherApplet::ProfileSwitcherApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    theme::setContainer(this, QStringLiteral("applet/prof"));
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+    auto* grid = new QGridLayout(this);
+    grid->setContentsMargins(4, 3, 4, 3);
+    grid->setHorizontalSpacing(6);
+    grid->setVerticalSpacing(3);
+    grid->setColumnStretch(1, 1);
+
+    auto makeRow = [&](int row, const QString& text, const QString& accessible,
+                       const char* objName) -> QComboBox* {
+        auto* lbl = new QLabel(text, this);
+        lbl->setStyleSheet(QString::fromLatin1(kRowLabelStyle));
+        auto* combo = new QComboBox(this);
+        combo->setObjectName(QString::fromLatin1(objName));
+        combo->setAccessibleName(accessible);
+        combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+        combo->setMinimumContentsLength(8);
+        combo->setEnabled(false);  // until a model + profiles arrive
+        grid->addWidget(lbl, row, 0);
+        grid->addWidget(combo, row, 1);
+        return combo;
+    };
+
+    m_globalCombo = makeRow(0, tr("Global"), tr("Global profile"), "profGlobalCombo");
+    m_txCombo     = makeRow(1, tr("TX"),     tr("TX profile"),     "profTxCombo");
+    m_micCombo    = makeRow(2, tr("Mic"),    tr("Mic profile"),    "profMicCombo");
+
+    setAccessibleName(tr("Profile switcher"));
+}
+
+void ProfileSwitcherApplet::setRadioModel(RadioModel* model)
+{
+    m_model = model;
+    if (!m_model)
+        return;
+
+    auto& tx = m_model->transmitModel();
+
+    // List + active for Global both arrive via globalProfilesChanged().
+    connect(m_model, &RadioModel::globalProfilesChanged,
+            this, &ProfileSwitcherApplet::refreshGlobal);
+
+    // TX: full list on profileListChanged(); active selection on stateChanged().
+    connect(&tx, &TransmitModel::profileListChanged,
+            this, &ProfileSwitcherApplet::refreshTx);
+    connect(&tx, &TransmitModel::stateChanged,
+            this, &ProfileSwitcherApplet::syncTxCurrent);
+
+    // Mic: full list on micProfileListChanged(); active on micStateChanged().
+    connect(&tx, &TransmitModel::micProfileListChanged,
+            this, &ProfileSwitcherApplet::refreshMic);
+    connect(&tx, &TransmitModel::micStateChanged,
+            this, &ProfileSwitcherApplet::syncMicCurrent);
+
+    // Apply live whenever the selection changes.  currentTextChanged() fires
+    // for both user picks and programmatic setCurrentText() (e.g. the agent
+    // automation bridge's invoke verb), which is exactly what we want — an
+    // automated "select" should load too.  Every *internal* mutation
+    // (rebuildCombo / syncCombo) is wrapped in a QSignalBlocker, so the only
+    // changes that reach these slots are genuine selections — there is no
+    // select→load→refresh→load feedback loop.
+    //
+    // Command strings mirror the proven ProfileManagerDialog paths: the radio
+    // *status* verb is "tx"/"mic" but the *load* command is "transmit"/"mic".
+    connect(m_globalCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
+        if (!name.isEmpty())
+            m_model->loadGlobalProfile(name);
+    });
+    connect(m_txCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
+        if (!name.isEmpty())
+            m_model->sendCommand(QStringLiteral("profile transmit load \"%1\"").arg(name));
+    });
+    connect(m_micCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
+        if (!name.isEmpty())
+            m_model->sendCommand(QStringLiteral("profile mic load \"%1\"").arg(name));
+    });
+
+    // Seed from whatever the model already holds (handles late wiring after a
+    // connection is already up).
+    refreshGlobal();
+    refreshTx();
+    refreshMic();
+}
+
+void ProfileSwitcherApplet::refreshGlobal()
+{
+    if (!m_model)
+        return;
+    rebuildCombo(m_globalCombo, m_model->globalProfiles(), m_model->activeGlobalProfile());
+}
+
+void ProfileSwitcherApplet::refreshTx()
+{
+    if (!m_model)
+        return;
+    const auto& tx = m_model->transmitModel();
+    rebuildCombo(m_txCombo, tx.profileList(), tx.activeProfile());
+}
+
+void ProfileSwitcherApplet::refreshMic()
+{
+    if (!m_model)
+        return;
+    const auto& tx = m_model->transmitModel();
+    rebuildCombo(m_micCombo, tx.micProfileList(), tx.activeMicProfile());
+}
+
+void ProfileSwitcherApplet::syncTxCurrent()
+{
+    if (!m_model)
+        return;
+    syncCombo(m_txCombo, m_model->transmitModel().activeProfile());
+}
+
+void ProfileSwitcherApplet::syncMicCurrent()
+{
+    if (!m_model)
+        return;
+    syncCombo(m_micCombo, m_model->transmitModel().activeMicProfile());
+}
+
+} // namespace AetherSDR

--- a/src/gui/ProfileSwitcherApplet.cpp
+++ b/src/gui/ProfileSwitcherApplet.cpp
@@ -25,6 +25,10 @@ void rebuildCombo(QComboBox* combo, const QStringList& profiles, const QString& 
     combo->clear();
     combo->addItems(profiles);
     const int idx = combo->findText(active);
+    // If the radio hasn't reported an active profile yet (or it isn't in the
+    // list), fall back to index 0 so the control isn't blank.  This is purely
+    // cosmetic — the set is signal-blocked, so it never issues a load, and the
+    // next *Changed/state signal corrects the highlight once active arrives.
     combo->setCurrentIndex(idx >= 0 ? idx : (profiles.isEmpty() ? -1 : 0));
     combo->setEnabled(!profiles.isEmpty());
 }
@@ -111,19 +115,21 @@ void ProfileSwitcherApplet::setRadioModel(RadioModel* model)
     // changes that reach these slots are genuine selections — there is no
     // select→load→refresh→load feedback loop.
     //
-    // Command strings mirror the proven ProfileManagerDialog paths: the radio
-    // *status* verb is "tx"/"mic" but the *load* command is "transmit"/"mic".
+    // All three rows delegate to the model load helpers (loadGlobalProfile /
+    // loadProfile / loadMicProfile) rather than hand-rolling command strings,
+    // so the radio command verbs live in exactly one place (the models) — same
+    // source of truth ProfileManagerDialog now relies on.
     connect(m_globalCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
         if (!name.isEmpty())
             m_model->loadGlobalProfile(name);
     });
     connect(m_txCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
         if (!name.isEmpty())
-            m_model->sendCommand(QStringLiteral("profile transmit load \"%1\"").arg(name));
+            m_model->transmitModel().loadProfile(name);
     });
     connect(m_micCombo, &QComboBox::currentTextChanged, this, [this](const QString& name) {
         if (!name.isEmpty())
-            m_model->sendCommand(QStringLiteral("profile mic load \"%1\"").arg(name));
+            m_model->transmitModel().loadMicProfile(name);
     });
 
     // Seed from whatever the model already holds (handles late wiring after a

--- a/src/gui/ProfileSwitcherApplet.h
+++ b/src/gui/ProfileSwitcherApplet.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <QWidget>
+
+class QComboBox;
+
+namespace AetherSDR {
+
+class RadioModel;
+
+// PROF — Profile Switcher applet.  A compact three-row selector for the
+// radio's Global / TX / Mic profiles.  Each row is a dropdown that enumerates
+// the profiles the radio currently knows about; choosing one applies it live.
+// The lists and the active selections refresh automatically whenever the radio
+// reports a new or changed profile (e.g. after a profile is saved through the
+// Profile Manager), so the applet always reflects what the radio actually has.
+// See issue #3376.
+class ProfileSwitcherApplet : public QWidget {
+    Q_OBJECT
+public:
+    explicit ProfileSwitcherApplet(QWidget* parent = nullptr);
+
+    void setRadioModel(RadioModel* model);
+
+private:
+    void refreshGlobal();   // rebuild Global list + current
+    void refreshTx();       // rebuild TX list + current
+    void refreshMic();      // rebuild Mic list + current
+    void syncTxCurrent();   // update only the TX active selection
+    void syncMicCurrent();  // update only the Mic active selection
+
+    RadioModel* m_model{nullptr};
+
+    QComboBox* m_globalCombo{nullptr};
+    QComboBox* m_txCombo{nullptr};
+    QComboBox* m_micCombo{nullptr};
+};
+
+} // namespace AetherSDR


### PR DESCRIPTION
## What

Adds a new compact, dedicated **PROF (Profile Switcher)** applet to the right-hand applet panel — the persistent, always-available quick-access profile selector requested in #3376. No more opening the full Profile Manager dialog just to switch profiles.

The applet is three tight rows — **Global / TX / Mic** — each a small label paired with a dropdown that enumerates every profile the radio currently reports. The current item tracks the radio's active profile, and selecting an entry **applies it live**.


## Why

The protocol plumbing for all three profile families already existed (`RadioModel::globalProfiles()/loadGlobalProfile()`, `TransmitModel::profileList()/micProfileList()` + their `*Changed` signals), and the full list is exposed in the Profiles menu and `ProfileManagerDialog`. What was missing — per the issue — is a *persistent, low-training surface* for fast switching. This delivers exactly that as a panel tile the user can enable and dock wherever they like.

## How

- **New widget** `src/gui/ProfileSwitcherApplet.{h,cpp}` — a `QGridLayout` of three label+`QComboBox` rows, tight margins, `Fixed` vertical size policy so it stays small.
- **Live apply** on `currentTextChanged()`:
  - Global → `RadioModel::loadGlobalProfile()` (`profile global load`)
  - TX → `transmitModel().loadProfile()` (`profile tx load`)
  - Mic → `transmitModel().loadMicProfile()` (`profile mic load`)

  All three rows delegate to the model load helpers, so the radio command verbs live in one place (the models) — the same source of truth `ProfileManagerDialog` uses (`profile tx load` / `profile mic load`).
- **Auto-refresh** — the lists and active selections rebuild on `globalProfilesChanged()`, `profileListChanged()`, `micProfileListChanged()`, and the active highlight stays in sync via `stateChanged()`/`micStateChanged()`. So a newly saved profile appears with no manual refresh.
- **No feedback loop** — every internal repopulation (`rebuildCombo`/`syncCombo`) is wrapped in a `QSignalBlocker`, so only genuine selections reach the load slots. Using `currentTextChanged()` (rather than the user-only `textActivated()`) means the agent automation bridge's `invoke setCurrentText` can also drive a live load.
- **Registration** mirrors `MeterApplet`: id `PROF`, label `Profile Switcher`, off by default, added to `kDefaultOrder` and the button picker's drawer. Combos carry `objectName` (`profGlobalCombo`/`profTxCombo`/`profMicCombo`) and `accessibleName` for the automation bridge and screen readers.

## Proof (agent automation bridge, live FLEX-8400M)

- `dumpTree` showed all three combos populated and **enabled**, each `value` reflecting the radio's active profile: **Global=`ssb`, TX=`Default`, Mic=`Default`**.
- The radio reported the full enumerated lists the applet was built from: **5 global** (`ft8, iOS_default_Profile, macOS_default_Profile, SO2RDefault, ssb`), **11 tx**, and **many mic** profiles.
- Driving the dropdowns emitted the expected commands (`profile global load`, `profile tx load`, `profile mic load`) and switched the active profile live — confirmed working end-to-end.

### Agent automation bridge — gap found
- **Can't enumerate `QComboBox` items** — `dumpTree` reports a combo's `currentText` as `value` but not its option list, so the bridge can prove *which* profile is active but not the *full set of choices* without stepping the selection (which would apply each one). Proposed: have `dumpTree` include an `items: [...]` array for `QComboBox` nodes (and/or a `get combo <target> items` accessor) so option lists can be verified non-destructively.

Closes #3376

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat