### PR TITLE
fix(spectrum): reset FFT trace EMA on TX→RX so the floor doesn't linger (#3804)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4269,6 +4269,15 @@ void SpectrumWidget::setTransmitting(bool tx)
         m_txEndMs = QDateTime::currentMSecsSinceEpoch(); // post-TX blanking (#2117)
         m_wfBlankerRingCount = 0;                        // reset stale blanker baseline
         m_wfLastGoodRow.clear();                          // forget any TX-era last-good scanline
+        // Drop the FFT trace's client-side EMA so the first clean RX frame is
+        // taken raw instead of weighted against TX-contaminated history. During
+        // the UNKEY_REQUESTED window the radio keeps streaming TX-contaminated
+        // FFT frames (#1927); those poison m_smoothed, and at SMOOTH_ALPHA=0.35
+        // the EMA otherwise takes ~5-7 frames (~200-300 ms at 25 fps) to wash
+        // out, leaving the displayed floor visibly elevated after key-up (#3804).
+        // This does not address the radio firmware's own averaging buffer, which
+        // is the dominant slow-decay source and is not client-fixable.
+        m_resetFftSmoothingOnNextFrame = true;
         endTxDbmRangeFreeze();
     }
     m_transmitting = tx;


### PR DESCRIPTION
## Issue

[#3804](https://github.com/aethersdr/AetherSDR/issues/3804): after TX the FFT noise floor takes a long time to drop back to its pre-TX level.

## Root cause

`SpectrumWidget::setTransmitting(false)` resets every other TX→RX display state — the waterfall blanker (`m_txEndMs`, #2117), the native-tile wait, the dBm-range freeze — but never the FFT **trace** EMA, `m_smoothed`.

During the radio's UNKEY_REQUESTED window the panadapter keeps streaming TX-contaminated FFT frames (the same behaviour called out for the waterfall in #1927). Those frames feed `updateSpectrum()` and poison `m_smoothed`; at `SMOOTH_ALPHA = 0.35` the EMA then needs ~5–7 frames (~200–300 ms at 25 fps) to wash back out, so the displayed floor stays visibly elevated right after key-up.

## Fix

One line in `setTransmitting(false)`: set `m_resetFftSmoothingOnNextFrame = true` so the first clean RX frame is taken raw instead of being weighted against TX-era history. This reuses the exact mechanism already used on the lock / retune / dBm-range-change paths.

## Scope

This addresses the **client-side** contributor only. The triage on the issue identifies the radio firmware's own FFT averaging buffer (`display pan average` / `weighted_average`) as the **dominant** slow-decay source — that is firmware-side and not client-fixable (workaround: lower Average + Wt Avg off).

## Testing

Verified live on a FLEX radio (fw 4.1.5) using the agent automation bridge. To do this at all, the bridge first had to gain numeric FFT-floor observability and deterministic antenna/CWX/pan control — that work is the companion PR #3832. The fix was A/B'd by building it behind a temporary env-gate (since stripped) so baseline-vs-fixed could be measured on the same binary.

**Harness.** A `floors` bridge verb samples the panadapter's measured display floor (`displayFloorDbm`, off `m_smoothed`) at ~20–25 Hz — fast enough to resolve the ~300 ms client-EMA transient (`dumpTree` at ~3.5 Hz is not). Every keying was gated on a live `txAntenna == ANT2` readback (dummy load) and confirmed `transmitting == false` afterward.

**Findings**

| Scenario | Result |
|---|---|
| Two-tone TX, dummy load | Display floor flat — `peak during TX +0.00 dB`, `peak after unkey +0.11 dB` |
| CWX morse, 40m (slice A, ANT2 rx/tx, 18 wpm) | baseline −125.7 dBm, **peak +1.79 dB**, never crossed +2 dB; safe |
| CWX morse, 20m (slice B on a 2nd panadapter, ANT2 rx/tx) | baseline −109.2 dBm, **+0.07 dB**; TX correctly isolated to slice B (live TX freq read 14.06 MHz for 74/75 samples); the non-TX 40m pan stayed flat; safe |
| Baseline build vs fixed build (env-gate A/B) | Both stayed flat on the dummy load — see honesty note |

This exercised the change across two bands, two panadapters, two-tone + CW, and multi-slice TX routing, with a hard ANT2 safety gate and post-run `transmitting=false` confirmation on every pass. No regression, no stuck/elevated floor, no TX-safety violation.

**Honesty note — what this does *not* prove.** On a clean dummy-load RX, no TX-contaminated frames reach the client, so the displayed floor stays flat on **both** the unfixed and fixed builds — there was nothing to wash out to measure a delta against. The original report is from a live-RF environment that this bench (dummy load) does not reproduce. So the bench result is **"builds, stays level, no regression, TX-safe"**, not a measured shrink of the multi-second tail. The change remains a low-risk correctness completion of the existing TX→RX reset block, matching the lock/retune/dBm-range paths.

## Build

Builds clean standalone (Ninja, RelWithDebInfo) off `origin/main`; the only file touched is `SpectrumWidget.cpp` (+9 incl. comment).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat