### PR TITLE
fix(gui): RX Controls hero frequency + sizing fix + layout reorg (#3839 follow-up)

### DIFF
--- a/src/gui/FreqLabelFit.h
+++ b/src/gui/FreqLabelFit.h
@@ -8,21 +8,23 @@
 // than the box silently clips its leading (most-significant) digits — the box
 // is right-aligned, so the overflow falls off the LEFT edge (#3463/#3515).
 //
-// Qt detail this relies on: a stylesheet that sets `font-size` OVERRIDES
-// QWidget::setFont(), but a stylesheet that sets only `font-family` lets
-// setFont() win for the size.  So the callers drop `font-size` from the freq
-// label's QSS and drive the (width-fitted) pixel size through setFont() here.
+// IMPORTANT Qt detail (learned the hard way): you CANNOT drive the size with
+// QWidget::setFont() when the label also has a stylesheet that sets
+// `font-family`.  A stylesheet that names any font property makes Qt recompute
+// the widget font from the QSS on every re-polish, discarding setFont() and
+// falling back to the default app size.  So the size MUST go through the
+// stylesheet too — the callers re-apply their freq label QSS with a literal
+// `font-size: <fitFreqPixelSize(...)>px`.
 
 #include <QFont>
 #include <QFontMetrics>
-#include <QLabel>
 #include <QString>
 
 namespace AetherSDR {
 
 // Largest pixel size in [minPx, maxPx] for which `text` rendered bold in
 // `family` advances no wider than `availW`.  Caps at maxPx so the digits never
-// grow beyond the theme's nominal size — it only shrinks to avoid clipping.
+// grow beyond the requested size — it only shrinks to avoid clipping.
 // availW <= 0 (not laid out yet) or empty text returns maxPx unchanged.
 inline int fitFreqPixelSize(const QString& family, const QString& text,
                             int availW, int maxPx, int minPx = 10)
@@ -39,22 +41,6 @@ inline int fitFreqPixelSize(const QString& family, const QString& text,
             return px;
     }
     return minPx;
-}
-
-// Fit `label`'s font to its own width so the current text never clips.
-// `family` is font.family.freq, `maxPx` is font.size.freq (the theme nominal),
-// `pad` reserves border+padding+safety so the glyphs clear the box edge.  The
-// label's QSS must set font-family but NOT font-size for this to take effect.
-inline void applyFittedFreqFont(QLabel* label, const QString& family,
-                                int maxPx, int pad)
-{
-    if (!label)
-        return;
-    QFont f(family.isEmpty() ? label->font().family() : family);
-    f.setBold(true);
-    const int availW = label->width() - pad;
-    f.setPixelSize(fitFreqPixelSize(f.family(), label->text(), availW, maxPx));
-    label->setFont(f);
 }
 
 }  // namespace AetherSDR

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -465,14 +465,6 @@ void RxApplet::buildUI()
 
         row->addStretch(1);
 
-        // Filter width label (e.g. "2.7K") — centered between ANT and QSK
-        m_filterWidthLbl = new QLabel("2.7K");
-        m_filterWidthLbl->setAlignment(Qt::AlignCenter);
-        AetherSDR::ThemeManager::instance().applyStyleSheet(m_filterWidthLbl, "QLabel { color: {{color.accent.bright}}; font-size: 11px; font-weight: bold; }");
-        row->addWidget(m_filterWidthLbl);
-
-        row->addStretch(1);
-
         // QSK indicator (read-only — controlled via CW applet Breakin button)
         m_qskBtn = new QPushButton("QSK");
         m_qskBtn->setCheckable(true);
@@ -486,13 +478,18 @@ void RxApplet::buildUI()
         root->addLayout(row);
     }
 
-    // ── Frequency row ──────────────────────────────────────────────────────
+    // ── Hero frequency row: [mode][big frequency] (#3463 redesign) ──────────
+    // The frequency is the panel's primary readout, so it gets its own line at
+    // full size. The mode selector sits to its left; TX/WFM/band/bandwidth move
+    // to the compact context strip below. (Previously TX/mode/WFM shared this
+    // row and squeezed the digits into ~124px, clipping the leading MHz — #3463.)
     {
         m_freqRow = new QHBoxLayout;
         m_freqRow->setContentsMargins(0, 0, 0, 0);
         m_freqRow->setSpacing(0);
 
-        // TX slice indicator badge — click to set this slice as TX
+        // TX slice indicator badge — click to set this slice as TX. Created
+        // here, placed in the context strip below.
         m_txBadge = new QPushButton("TX");
         m_txBadge->setFixedSize(20, 20);
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_txBadge, "QPushButton { background: {{color.meter.bar.fill}}; color: {{color.text.primary}}; "
@@ -502,10 +499,8 @@ void RxApplet::buildUI()
         connect(m_txBadge, &QPushButton::clicked, this, [this] {
             if (m_slice) m_slice->setTxSlice(!m_slice->isTxSlice());
         });
-        m_freqRow->addWidget(m_txBadge);
-        m_freqRow->addSpacing(4);
 
-        // Mode selector combo
+        // Mode selector combo — left element of the hero frequency row
         m_modeCombo = new GuardedComboBox;
         m_modeCombo->setFixedHeight(20);
         m_modeCombo->addItems({"USB", "LSB", "CW", "AM", "SAM", "FM",
@@ -538,8 +533,10 @@ void RxApplet::buildUI()
 #endif
             if (m_slice) m_slice->setMode(mode);
         });
-        m_freqRow->addWidget(m_modeCombo);
+        // Mode combo is placed in the context strip below — keeping it off the
+        // hero row frees the full applet width for the largest frequency digits.
 
+        // WFM toggle — created here, placed in the context strip below.
         m_wfmButton = new QPushButton("WFM");
         m_wfmButton->setCheckable(true);
         m_wfmButton->setFixedSize(36, 20);
@@ -556,11 +553,10 @@ void RxApplet::buildUI()
                 emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
             }
         });
-        m_freqRow->addWidget(m_wfmButton);
 
         m_freqStack = new QStackedWidget;
-        m_freqStack->setFixedHeight(34);
-        // Fill the remaining column width (after TX/mode/WFM) with a stable,
+        m_freqStack->setFixedHeight(44);  // tall hero row for the big digits
+        // Fill the remaining row width (after the mode selector) with a stable,
         // font-independent box, so applyFreqFit() fits to a width that does not
         // change when the font shrinks (avoids a fit↔reflow oscillation).
         m_freqStack->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -640,6 +636,26 @@ void RxApplet::buildUI()
                 this, &RxApplet::applyFreqFit);
     }
 
+    // ── Context strip: mode ……… TX  WFM (#3463 redesign) ───────────────────
+    // Compact line under the hero frequency holding just the slice's controls —
+    // mode selector, TX-slice and WFM toggles (relocated off the old freq row).
+    // The band and filter-bandwidth readouts were dropped: the band is obvious
+    // from the large frequency, and the bandwidth is already shown by the lit
+    // filter-preset button and the passband graph.
+    {
+        auto* ctx = new QHBoxLayout;
+        ctx->setContentsMargins(0, 0, 0, 0);
+        ctx->setSpacing(6);
+
+        ctx->addWidget(m_modeCombo);  // mode selector (relocated off the hero row)
+        ctx->addStretch(1);
+        ctx->addWidget(m_txBadge);
+        ctx->addSpacing(4);
+        ctx->addWidget(m_wfmButton);
+
+        root->addLayout(ctx);
+    }
+
     // ── Two-column area ─────────────────────────────────────────────────────
     auto* columns = new QHBoxLayout;
     columns->setSpacing(4);
@@ -689,7 +705,8 @@ void RxApplet::buildUI()
         row->addWidget(m_stepDown);
         row->addWidget(m_stepLabel, 1);
         row->addWidget(m_stepUp);
-        leftCol->addLayout(row);
+        // Placed in the right column below (grouped with balance + squelch).
+        m_stepRow = row;
     }
 
     // Filter presets (dynamically rebuilt on mode change)
@@ -851,6 +868,9 @@ void RxApplet::buildUI()
     auto* rightCol = new QVBoxLayout;
     rightCol->setSpacing(2);
 
+    // STEP — moved here from the left column to group with balance + squelch.
+    rightCol->addLayout(m_stepRow);
+
     // AF gain
     {
         auto* row = new QHBoxLayout;
@@ -893,7 +913,9 @@ void RxApplet::buildUI()
             if (m_slice) m_slice->setAudioGain(v);
             emit afGainChanged(v);
         });
-        rightCol->addLayout(row);
+        // Hoisted to a full-width row directly under the mode selector (added to
+        // root, not rightCol), so the volume slider spans the whole applet.
+        root->addLayout(row);
     }
 
     // Audio pan (L ←→ R)
@@ -1035,7 +1057,9 @@ void RxApplet::buildUI()
                 }
             }
         });
-        rightCol->addWidget(m_agcContainer);
+        // Hoisted to a full-width row under the volume bar (added to root, not
+        // rightCol), so the AGC slider spans the whole applet.
+        root->addWidget(m_agcContainer);
     }
 
     rightCol->addStretch(1);
@@ -1177,7 +1201,6 @@ void RxApplet::buildUI()
     m_rxAntBtn->setAccessibleDescription("Select receive antenna port");
     m_txAntBtn->setAccessibleName("TX antenna");
     m_txAntBtn->setAccessibleDescription("Select transmit antenna port");
-    m_filterWidthLbl->setAccessibleName("Filter width");
     m_qskBtn->setAccessibleName("QSK indicator");
     m_qskBtn->setAccessibleDescription("Full break-in CW indicator");
     m_txBadge->setAccessibleName("TX slice selector");
@@ -2035,9 +2058,6 @@ void RxApplet::connectSlice(SliceModel* s)
     connect(s, &SliceModel::txAntennaListChanged,
             this, [this](const QStringList&) { updateAntennaButtons(); });
 
-    // Filter width label
-    m_filterWidthLbl->setText(formatFilterWidth(s->filterLow(), s->filterHigh(), s->mode()));
-
     // QSK
     {
         QSignalBlocker b(m_qskBtn);
@@ -2127,13 +2147,10 @@ void RxApplet::connectSlice(SliceModel* s)
     m_filterPassband->setMode(s->mode());
     connect(s, &SliceModel::filterChanged, this, [this](int lo, int hi) {
         updateFilterButtons();
-        m_filterWidthLbl->setText(formatFilterWidth(lo, hi, m_slice ? m_slice->mode() : QString()));
         m_filterPassband->setFilter(lo, hi);
     });
     connect(s, &SliceModel::modeChanged, this, [this](const QString& mode) {
         m_filterPassband->setMode(mode);
-        if (m_slice)
-            m_filterWidthLbl->setText(formatFilterWidth(m_slice->filterLow(), m_slice->filterHigh(), mode));
     });
 
     // AGC mode
@@ -3037,12 +3054,30 @@ void RxApplet::applyFreqFit()
     if (!m_freqLabel)
         return;
     auto& tm = AetherSDR::ThemeManager::instance();
-    int maxPx = tm.value("font.size.freq").toInt();
-    if (maxPx <= 0)
-        maxPx = 20;
-    // pad: no border/padding on this label — 4px safety from the box edge.
-    AetherSDR::applyFittedFreqFont(m_freqLabel, tm.value("font.family.freq"),
-                                   maxPx, /*pad=*/4);
+    int themeMax = tm.value("font.size.freq").toInt();
+    if (themeMax <= 0)
+        themeMax = 20;
+    // The frequency is this panel's hero readout and owns the full applet
+    // width, so let the digits grow large (derived from the hero row height,
+    // not the theme nominal); fitFreqPixelSize then width-fits them down so they
+    // never clip. Floor at the theme size so a user who picks a larger
+    // font.size.freq still gets at least that.
+    const int heroMax = m_freqStack ? m_freqStack->height() - 10 : themeMax;
+    const int maxPx = qMax(themeMax, heroMax);
+    // pad: no border/padding on this label — small safety from the box edge.
+    const int px = AetherSDR::fitFreqPixelSize(tm.value("font.family.freq"),
+                                               m_freqLabel->text(),
+                                               m_freqLabel->width() - 6, maxPx);
+    if (px == m_freqFitPx)
+        return;  // size unchanged — avoid a needless restyle/re-polish
+    m_freqFitPx = px;
+    // Drive the size through the stylesheet (a literal font-size), NOT setFont:
+    // a QSS that names font-family discards setFont() on re-polish (see
+    // FreqLabelFit.h). applyStyleSheet keeps the colour/family theme-reactive.
+    tm.applyStyleSheet(m_freqLabel, QStringLiteral(
+        "QLabel { color: {{color.text.primary}}; font-weight: bold;"
+        " font-family: \"{{font.family.freq}}\"; font-size: %1px;"
+        " background: transparent; padding: 0; margin: 0; }").arg(px));
 }
 
 void RxApplet::refreshAllMutedDim()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -221,9 +221,10 @@ private:
     QPushButton* m_lockBtn{nullptr};      // tune-lock toggle
     QPushButton* m_rxAntBtn{nullptr};     // RX antenna dropdown (blue)
     QPushButton* m_txAntBtn{nullptr};     // TX antenna dropdown (red)
-    QLabel*      m_filterWidthLbl{nullptr}; // current filter width e.g. "2.7K"
+    int          m_freqFitPx{-1};          // last applied freq font px (skip restyle if unchanged)
     QPushButton* m_qskBtn{nullptr};       // QSK toggle
     QHBoxLayout* m_freqRow{nullptr};       // frequency display row
+    QHBoxLayout* m_stepRow{nullptr};       // STEP row — built in left section, placed in right column
     QPushButton* m_txBadge{nullptr};       // TX slice indicator (click to set as TX slice)
     QComboBox*   m_modeCombo{nullptr};     // mode selector (USB, LSB, CW, etc.)
     QPushButton* m_wfmButton{nullptr};     // WFM software demodulator toggle

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -4533,8 +4533,19 @@ void VfoWidget::applyFreqFit()
     if (maxPx <= 0)
         maxPx = 20;
     // pad: 1px border each side + 2px left padding + 2px safety.
-    AetherSDR::applyFittedFreqFont(m_freqLabel, tm.value("font.family.freq"),
-                                   maxPx, /*pad=*/6);
+    const int px = AetherSDR::fitFreqPixelSize(tm.value("font.family.freq"),
+                                               m_freqLabel->text(),
+                                               m_freqLabel->width() - 6, maxPx);
+    if (px == m_freqFitPx)
+        return;  // size unchanged — avoid a needless restyle/re-polish
+    m_freqFitPx = px;
+    // Size goes through the stylesheet (literal font-size), NOT setFont — a QSS
+    // that names font-family discards setFont() on re-polish (see FreqLabelFit.h).
+    tm.applyStyleSheet(m_freqLabel, QStringLiteral("QLabel { background: transparent;"
+        " border: 1px solid rgba(255,255,255,80); border-radius: 3px;"
+        " color: {{color.text.primary}}; font-weight: bold;"
+        " font-family: \"{{font.family.freq}}\"; font-size: %1px;"
+        " padding: 0 0 0 2px; }").arg(px));
 }
 
 void VfoWidget::scheduleFrequencyAnnouncement(const QString& text)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -285,6 +285,7 @@ private:
 
     // Frequency / meter
     QLabel* m_freqLabel{nullptr};
+    int     m_freqFitPx{-1};  // last applied freq font px (skip restyle if unchanged)
     QLineEdit* m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
     QLabel* m_dbmLabel{nullptr};


### PR DESCRIPTION
Follow-up to #3839. That change stopped the frequency clipping, but two things were still off — and the panel earned a tidy-up around the fix.

1. **The digits rendered tiny (~13px).** #3839 drove the fitted pixel size via `QWidget::setFont()`, but a `QLabel` whose stylesheet names `font-family` makes Qt recompute the font from the QSS on every re-polish and **discard `setFont()`**, falling back to the ~13px app default — the "frequency is tiny by default" symptom.
2. **The frequency was cramped** sharing a row with TX/mode/WFM (~124px), so even sized correctly it couldn't be large.

## What this PR does

- **Applies the fitted size through the stylesheet as a literal `font-size`** (which always wins over the cascade), colour/family still from theme tokens so it stays theme-reactive. The last size is cached to skip a re-polish on every tune step, and each freq box is a stable, font-independent width so the fit can't oscillate. `FreqLabelFit.h` keeps `fitFreqPixelSize()`; the dead `setFont`-based helper is removed.
- **Makes the frequency the hero** — its own full-width row at **~34px**, with the mode selector and TX/WFM toggles on a compact context strip beneath it. The redundant band + filter-bandwidth labels are dropped (band is obvious from the large frequency; bandwidth is shown by the lit preset button + passband graph).
- **Reorganises the controls** — volume and AGC are promoted to **full-width sliders** directly under the mode selector, and **STEP** moves into the right control group with balance (pan) and squelch. Net top-to-bottom flow: frequency → mode/TX/WFM → volume → AGC → two-column grid (filter presets + passband · STEP, pan, SQL, RIT, XIT).
- **VFO flag**: same literal-QSS sizing at the theme-nominal size (unchanged look, now deterministic).

## Proof — agent automation bridge (live on a FLEX‑8400M)

`tune` + `grab`, before vs after, both themes. Left = before this work (clipped + ~13px); right = hero ~34px with the reorganized controls.

**RX Controls — default dark, 21.074 MHz**
![dark before/after](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-vfo-freq-clip/pr-v2-dark.png)

**RX Controls — light theme, 21.074 MHz**
![light before/after](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-vfo-freq-clip/pr-v2-light.png)

**VFO slice flag — unchanged (theme nominal, no clip)**
![vfo flag](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-vfo-freq-clip/rebasecheck-flag.png)

## Files

- `src/gui/FreqLabelFit.h` — `fitFreqPixelSize()` (drops the `setFont` helper)
- `src/gui/RxApplet.{h,cpp}` — hero frequency row, context strip, literal-QSS sizing, full-width volume/AGC, STEP regrouped
- `src/gui/VfoWidget.{h,cpp}` — literal-QSS sizing + re-fit hooks

Refs #3515, #3463 (#3839 follow-up).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
