### PR TITLE
[codex] Fix KiwiSDR proxy redirect transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,7 @@ set(CORE_SOURCES
     src/core/CatPort.cpp
     src/core/SmartLinkClient.cpp
     src/core/KiwiSdrProtocol.cpp
+    src/core/KiwiSdrRedirectPolicy.cpp
     src/core/KiwiSdrClient.cpp
     src/core/KiwiSdrManager.cpp
     src/core/KiwiPublicDirectory.cpp
@@ -1920,6 +1921,14 @@ add_executable(kiwi_sdr_trace_math_test
 target_include_directories(kiwi_sdr_trace_math_test PRIVATE src)
 target_link_libraries(kiwi_sdr_trace_math_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_trace_math_test COMMAND kiwi_sdr_trace_math_test)
+
+add_executable(kiwi_sdr_redirect_policy_test
+    tests/kiwi_sdr_redirect_policy_test.cpp
+    src/core/KiwiSdrRedirectPolicy.cpp
+)
+target_include_directories(kiwi_sdr_redirect_policy_test PRIVATE src)
+target_link_libraries(kiwi_sdr_redirect_policy_test PRIVATE Qt6::Core)
+add_test(NAME kiwi_sdr_redirect_policy_test COMMAND kiwi_sdr_redirect_policy_test)
 
 # Public-directory parser + external-API (ext_api) policy honoring.
 add_executable(kiwi_public_directory_test

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1,5 +1,6 @@
 #include "KiwiSdrClient.h"
 
+#include "KiwiSdrRedirectPolicy.h"
 #include "KiwiSdrProtocol.h"
 #include "LogManager.h"
 #include "Resampler.h"
@@ -331,69 +332,6 @@ int soundPayloadOffset(const QByteArray& frame)
 }
 
 #ifdef HAVE_WEBSOCKETS
-QString canonicalRedirectHost(QString host)
-{
-    host = host.trimmed().toLower();
-    while (host.endsWith(QLatin1Char('.'))) {
-        host.chop(1);
-    }
-    return host;
-}
-
-QString kiwiProxyReceiverAlias(const QString& host)
-{
-    constexpr QLatin1StringView kProxySuffix{".proxy.kiwisdr.com"};
-    constexpr QLatin1StringView kProxy2Suffix{".proxy2.kiwisdr.com"};
-    if (host.endsWith(kProxySuffix) && host.size() > kProxySuffix.size()) {
-        return host.left(host.size() - kProxySuffix.size());
-    }
-    if (host.endsWith(kProxy2Suffix) && host.size() > kProxy2Suffix.size()) {
-        return host.left(host.size() - kProxy2Suffix.size());
-    }
-    return {};
-}
-
-bool isAllowedKiwiStatusRedirect(const QUrl& from,
-                                 const QUrl& to,
-                                 QString* detail)
-{
-    const QString scheme = to.scheme().toLower();
-    if (scheme != QStringLiteral("http") && scheme != QStringLiteral("https")) {
-        if (detail) {
-            *detail = QStringLiteral("unsupported scheme %1").arg(to.scheme());
-        }
-        return false;
-    }
-
-    const QString fromHost = canonicalRedirectHost(from.host());
-    const QString toHost = canonicalRedirectHost(to.host());
-    if (fromHost.isEmpty() || toHost.isEmpty()) {
-        if (detail) {
-            *detail = QStringLiteral("missing redirect host");
-        }
-        return false;
-    }
-
-    if (fromHost == toHost) {
-        return true;
-    }
-
-    // Kiwi's public proxy can migrate one receiver alias from proxy to proxy2.
-    // Keep that exception exact so a status page cannot move the WebSocket
-    // target to an unrelated host after the policy preflight succeeds.
-    const QString fromAlias = kiwiProxyReceiverAlias(fromHost);
-    const QString toAlias = kiwiProxyReceiverAlias(toHost);
-    if (!fromAlias.isEmpty() && fromAlias == toAlias) {
-        return true;
-    }
-
-    if (detail) {
-        *detail = QStringLiteral("cross-domain redirect from %1 to %2")
-                      .arg(fromHost, toHost);
-    }
-    return false;
-}
-
 QString webSocketOrigin(const QString& scheme, const QString& host, quint16 port)
 {
     const QString originScheme = scheme == QStringLiteral("wss")
@@ -634,7 +572,8 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
         if (redirectUrl.isEmpty()) {
             setState(
                 State::Error,
-                tr("This KiwiSDR's status page redirected without a target, so AetherSDR won't connect."));
+                tr("This KiwiSDR's status page returned unsupported HTTP %1 without a redirect target, so AetherSDR won't connect.")
+                    .arg(httpStatus));
             cleanupSockets();
             return;
         }
@@ -645,8 +584,8 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
             redirectDetail = QStringLiteral("too many redirects");
         } else {
             const bool allowed =
-                isAllowedKiwiStatusRedirect(requestUrl, nextUrl,
-                                            &redirectDetail);
+                KiwiSdrRedirectPolicy::isAllowedStatusRedirect(
+                    requestUrl, nextUrl, &redirectDetail);
             if (allowed) {
                 redirectDetail.clear();
             }

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -30,6 +30,7 @@ namespace {
 constexpr int kAudioReadyTimeoutMs = 12000;
 constexpr int kKeepaliveIntervalMs = 10000;
 constexpr int kStatusPreflightTimeoutMs = 5000;
+constexpr int kStatusPreflightMaxRedirects = 8;
 constexpr quint16 kDefaultKiwiSdrPort = 8073;
 constexpr double kDefaultWaterfallCenterMhz = 15.0;
 constexpr double kDefaultWaterfallBandwidthMhz = 30.0;
@@ -330,6 +331,69 @@ int soundPayloadOffset(const QByteArray& frame)
 }
 
 #ifdef HAVE_WEBSOCKETS
+QString canonicalRedirectHost(QString host)
+{
+    host = host.trimmed().toLower();
+    while (host.endsWith(QLatin1Char('.'))) {
+        host.chop(1);
+    }
+    return host;
+}
+
+QString kiwiProxyReceiverAlias(const QString& host)
+{
+    constexpr QLatin1StringView kProxySuffix{".proxy.kiwisdr.com"};
+    constexpr QLatin1StringView kProxy2Suffix{".proxy2.kiwisdr.com"};
+    if (host.endsWith(kProxySuffix) && host.size() > kProxySuffix.size()) {
+        return host.left(host.size() - kProxySuffix.size());
+    }
+    if (host.endsWith(kProxy2Suffix) && host.size() > kProxy2Suffix.size()) {
+        return host.left(host.size() - kProxy2Suffix.size());
+    }
+    return {};
+}
+
+bool isAllowedKiwiStatusRedirect(const QUrl& from,
+                                 const QUrl& to,
+                                 QString* detail)
+{
+    const QString scheme = to.scheme().toLower();
+    if (scheme != QStringLiteral("http") && scheme != QStringLiteral("https")) {
+        if (detail) {
+            *detail = QStringLiteral("unsupported scheme %1").arg(to.scheme());
+        }
+        return false;
+    }
+
+    const QString fromHost = canonicalRedirectHost(from.host());
+    const QString toHost = canonicalRedirectHost(to.host());
+    if (fromHost.isEmpty() || toHost.isEmpty()) {
+        if (detail) {
+            *detail = QStringLiteral("missing redirect host");
+        }
+        return false;
+    }
+
+    if (fromHost == toHost) {
+        return true;
+    }
+
+    // Kiwi's public proxy can migrate one receiver alias from proxy to proxy2.
+    // Keep that exception exact so a status page cannot move the WebSocket
+    // target to an unrelated host after the policy preflight succeeds.
+    const QString fromAlias = kiwiProxyReceiverAlias(fromHost);
+    const QString toAlias = kiwiProxyReceiverAlias(toHost);
+    if (!fromAlias.isEmpty() && fromAlias == toAlias) {
+        return true;
+    }
+
+    if (detail) {
+        *detail = QStringLiteral("cross-domain redirect from %1 to %2")
+                      .arg(fromHost, toHost);
+    }
+    return false;
+}
+
 QString webSocketOrigin(const QString& scheme, const QString& host, quint16 port)
 {
     const QString originScheme = scheme == QStringLiteral("wss")
@@ -435,6 +499,7 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
     m_endpoint = QStringLiteral("%1:%2").arg(host).arg(port);
     m_host = host;
     m_port = port;
+    m_webSocketPort = 0;
     m_secureWebSocket = false;
     m_secureWebSocketRetryAttempted = false;
     m_soundSocketConnected = false;
@@ -506,25 +571,28 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
 
 #ifdef HAVE_WEBSOCKETS
     m_statusPreflightSecure = false;  // try http first, then https
+    m_statusPreflightRedirectCount = 0;
     m_statusPreflightFirstHttpStatus = 0;
     m_statusPreflightFirstError.clear();
-    startStatusPreflight();
+    startStatusPreflight(kiwiStatusUrl(m_host, m_port, m_statusPreflightSecure));
 #else
     setState(State::Error, tr("Qt WebSockets support is required for KiwiSDR."));
 #endif
 }
 
 #ifdef HAVE_WEBSOCKETS
-void KiwiSdrClient::startStatusPreflight()
+void KiwiSdrClient::startStatusPreflight(const QUrl& url)
 {
     if (!m_statusNetworkAccessManager) {
         m_statusNetworkAccessManager = new QNetworkAccessManager(this);
     }
 
-    QNetworkRequest request{kiwiStatusUrl(m_host, m_port, m_statusPreflightSecure)};
+    QNetworkRequest request{url};
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       QStringLiteral("AetherSDR"));
     request.setTransferTimeout(kStatusPreflightTimeoutMs);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::ManualRedirectPolicy);
 
     qCInfo(lcKiwiSdr).noquote()
         << "KiwiSDR status preflight"
@@ -548,14 +616,63 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
 
     m_statusReply = nullptr;
     const QUrl url = reply->url();
+    const QUrl requestUrl = reply->request().url();
     const bool ok = reply->error() == QNetworkReply::NoError;
-    const QByteArray payload = ok ? reply->readAll() : QByteArray();
     const int httpStatus =
         reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     const QString errorText = reply->errorString();
+    const QUrl redirectUrl =
+        reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+    const QByteArray payload = ok ? reply->readAll() : QByteArray();
     reply->deleteLater();
 
     if (m_userDisconnecting || m_state != State::Connecting) {
+        return;
+    }
+
+    if (httpStatus >= 300 && httpStatus < 400) {
+        if (redirectUrl.isEmpty()) {
+            setState(
+                State::Error,
+                tr("This KiwiSDR's status page redirected without a target, so AetherSDR won't connect."));
+            cleanupSockets();
+            return;
+        }
+
+        const QUrl nextUrl = requestUrl.resolved(redirectUrl);
+        QString redirectDetail;
+        if (m_statusPreflightRedirectCount >= kStatusPreflightMaxRedirects) {
+            redirectDetail = QStringLiteral("too many redirects");
+        } else {
+            const bool allowed =
+                isAllowedKiwiStatusRedirect(requestUrl, nextUrl,
+                                            &redirectDetail);
+            if (allowed) {
+                redirectDetail.clear();
+            }
+        }
+
+        if (!redirectDetail.isEmpty()) {
+            qCWarning(lcKiwiSdr).noquote()
+                << "KiwiSDR status preflight rejected redirect"
+                << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                << "from=" << requestUrl.toString()
+                << "to=" << nextUrl.toString()
+                << "reason=" << redirectDetail;
+            setState(
+                State::Error,
+                tr("This KiwiSDR's status page redirected outside its trusted KiwiSDR proxy host, so AetherSDR won't connect."));
+            cleanupSockets();
+            return;
+        }
+
+        ++m_statusPreflightRedirectCount;
+        qCInfo(lcKiwiSdr).noquote()
+            << "KiwiSDR status preflight redirect"
+            << QStringLiteral("endpoint=%1").arg(logEndpoint())
+            << "from=" << requestUrl.toString()
+            << "to=" << nextUrl.toString();
+        startStatusPreflight(nextUrl);
         return;
     }
 
@@ -608,6 +725,42 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
             cleanupSockets();
             return;
         }
+
+        const QString resolvedScheme = url.scheme().toLower();
+        if (resolvedScheme == QStringLiteral("http")
+            || resolvedScheme == QStringLiteral("https")) {
+            const QString resolvedHost = url.host();
+            const bool resolvedSecure = resolvedScheme == QStringLiteral("https");
+            const int resolvedPort = url.port(resolvedSecure ? 443 : 80);
+            if (!resolvedHost.isEmpty() && resolvedPort > 0 && resolvedPort <= 65535) {
+                const quint16 currentSocketPort = m_webSocketPort > 0
+                    ? m_webSocketPort
+                    : (m_secureWebSocket ? 443 : m_port);
+                const bool changed =
+                    m_secureWebSocket != resolvedSecure
+                    || currentSocketPort != static_cast<quint16>(resolvedPort)
+                    || m_host.compare(resolvedHost, Qt::CaseInsensitive) != 0;
+                if (changed) {
+                    qCInfo(lcKiwiSdr).noquote()
+                        << "KiwiSDR status preflight resolved transport"
+                        << QStringLiteral("endpoint=%1").arg(logEndpoint())
+                        << "status_url=" << url.toString()
+                        << "websocket="
+                        << QStringLiteral("%1://%2:%3")
+                               .arg(resolvedSecure ? QStringLiteral("wss")
+                                                   : QStringLiteral("ws"))
+                               .arg(resolvedHost)
+                               .arg(resolvedPort);
+                }
+                m_host = resolvedHost;
+                m_port = static_cast<quint16>(resolvedPort);
+                m_webSocketPort = static_cast<quint16>(resolvedPort);
+                m_secureWebSocket = resolvedSecure;
+                if (resolvedSecure) {
+                    m_secureWebSocketRetryAttempted = true;
+                }
+            }
+        }
     } else {
         qCInfo(lcKiwiSdr).noquote()
             << "KiwiSDR status preflight unavailable"
@@ -622,7 +775,9 @@ void KiwiSdrClient::handleStatusPreflightFinished(QNetworkReply* reply)
             m_statusPreflightFirstHttpStatus = httpStatus;
             m_statusPreflightFirstError = errorText;
             m_statusPreflightSecure = true;
-            startStatusPreflight();
+            m_statusPreflightRedirectCount = 0;
+            startStatusPreflight(
+                kiwiStatusUrl(m_host, m_port, m_statusPreflightSecure));
             return;
         }
 
@@ -654,7 +809,9 @@ void KiwiSdrClient::openWebSockets()
     const QString scheme = m_secureWebSocket
         ? QStringLiteral("wss")
         : QStringLiteral("ws");
-    const quint16 socketPort = m_secureWebSocket ? 443 : m_port;
+    const quint16 socketPort = m_webSocketPort > 0
+        ? m_webSocketPort
+        : (m_secureWebSocket ? 443 : m_port);
     // Clean black-box observation against KiwiSDR v1.842 showed the current
     // web client using /ws/kiwi/<session>/<stream>. Some servers still upgrade
     // /<session>/<stream> but never emit MSG or stream frames on that path.
@@ -2726,6 +2883,7 @@ bool KiwiSdrClient::retryWithSecureWebSocket(bool transportEstablished)
 
     m_secureWebSocketRetryAttempted = true;
     m_secureWebSocket = true;
+    m_webSocketPort = 443;
     m_soundSocketConnected = false;
     m_waterfallSocketConnected = false;
     m_soundAudioReady = false;

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -17,6 +17,7 @@ class QTimer;
 #ifdef HAVE_WEBSOCKETS
 class QNetworkAccessManager;
 class QNetworkReply;
+class QUrl;
 class QWebSocket;
 #endif
 
@@ -209,7 +210,7 @@ private:
 
 #ifdef HAVE_WEBSOCKETS
     void handleSocketError(const QString& detail, bool transportEstablished);
-    void startStatusPreflight();
+    void startStatusPreflight(const QUrl& url);
     void handleStatusPreflightFinished(QNetworkReply* reply);
     void openWebSockets();
     bool retryWithSecureWebSocket(bool transportEstablished);
@@ -223,6 +224,7 @@ private:
     QString m_lastSoundIdentityCallsign;
     QString m_lastWaterfallIdentityCallsign;
     quint16 m_port{0};
+    quint16 m_webSocketPort{0};
     bool m_audioActive{false};
     KiwiSdrReceiverControls m_receiverControls;
     KiwiSdrReceiverTelemetry m_telemetry;
@@ -318,6 +320,7 @@ private:
     // Status preflight tries http first, then https (proxied/TLS-only Kiwis)
     // before giving up.  ext_api can't be confirmed unless one succeeds.
     bool m_statusPreflightSecure{false};
+    int m_statusPreflightRedirectCount{0};
     int m_statusPreflightFirstHttpStatus{0};
     QString m_statusPreflightFirstError;
     QWebSocket* m_soundSocket{nullptr};

--- a/src/core/KiwiSdrRedirectPolicy.cpp
+++ b/src/core/KiwiSdrRedirectPolicy.cpp
@@ -1,0 +1,68 @@
+#include "KiwiSdrRedirectPolicy.h"
+
+#include <QUrl>
+
+namespace AetherSDR::KiwiSdrRedirectPolicy {
+
+QString canonicalHost(QString host)
+{
+    host = host.trimmed().toLower();
+    while (host.endsWith(QLatin1Char('.'))) {
+        host.chop(1);
+    }
+    return host;
+}
+
+QString proxyReceiverAlias(const QString& host)
+{
+    constexpr QLatin1StringView kProxySuffix{".proxy.kiwisdr.com"};
+    constexpr QLatin1StringView kProxy2Suffix{".proxy2.kiwisdr.com"};
+    if (host.endsWith(kProxySuffix) && host.size() > kProxySuffix.size()) {
+        return host.left(host.size() - kProxySuffix.size());
+    }
+    if (host.endsWith(kProxy2Suffix) && host.size() > kProxy2Suffix.size()) {
+        return host.left(host.size() - kProxy2Suffix.size());
+    }
+    return {};
+}
+
+bool isAllowedStatusRedirect(const QUrl& from, const QUrl& to, QString* detail)
+{
+    const QString scheme = to.scheme().toLower();
+    if (scheme != QStringLiteral("http") && scheme != QStringLiteral("https")) {
+        if (detail) {
+            *detail = QStringLiteral("unsupported scheme %1").arg(to.scheme());
+        }
+        return false;
+    }
+
+    const QString fromHost = canonicalHost(from.host());
+    const QString toHost = canonicalHost(to.host());
+    if (fromHost.isEmpty() || toHost.isEmpty()) {
+        if (detail) {
+            *detail = QStringLiteral("missing redirect host");
+        }
+        return false;
+    }
+
+    if (fromHost == toHost) {
+        return true;
+    }
+
+    // Kiwi's public proxy can migrate one receiver alias from proxy to proxy2.
+    // Keep that exception exact so a status page cannot move the WebSocket
+    // target to an unrelated host after the policy preflight succeeds.
+    const QString fromAlias = proxyReceiverAlias(fromHost);
+    const QString toAlias = proxyReceiverAlias(toHost);
+    if (!fromAlias.isEmpty() && fromAlias == toAlias) {
+        return true;
+    }
+
+    if (detail) {
+        *detail = QStringLiteral("cross-domain redirect from %1 to %2")
+                      .arg(fromHost, toHost);
+    }
+    return false;
+}
+
+} // namespace AetherSDR::KiwiSdrRedirectPolicy

--- a/src/core/KiwiSdrRedirectPolicy.h
+++ b/src/core/KiwiSdrRedirectPolicy.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QString>
+
+class QUrl;
+
+namespace AetherSDR::KiwiSdrRedirectPolicy {
+
+QString canonicalHost(QString host);
+QString proxyReceiverAlias(const QString& host);
+bool isAllowedStatusRedirect(const QUrl& from, const QUrl& to,
+                             QString* detail = nullptr);
+
+} // namespace AetherSDR::KiwiSdrRedirectPolicy

--- a/tests/kiwi_sdr_redirect_policy_test.cpp
+++ b/tests/kiwi_sdr_redirect_policy_test.cpp
@@ -1,0 +1,74 @@
+#include "core/KiwiSdrRedirectPolicy.h"
+
+#include <QUrl>
+
+#include <cstdio>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "kiwi_sdr_redirect_policy_test: %s\n", message);
+    return 1;
+}
+
+bool allowed(const char* from, const char* to)
+{
+    return AetherSDR::KiwiSdrRedirectPolicy::isAllowedStatusRedirect(
+        QUrl(QString::fromLatin1(from)),
+        QUrl(QString::fromLatin1(to)));
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR::KiwiSdrRedirectPolicy;
+
+    if (canonicalHost(QStringLiteral("  EXAMPLE.com.  "))
+        != QStringLiteral("example.com")) {
+        return fail("canonical host normalization should trim, lowercase, and drop trailing dots");
+    }
+
+    if (proxyReceiverAlias(QStringLiteral("21042.proxy.kiwisdr.com"))
+            != QStringLiteral("21042")
+        || proxyReceiverAlias(QStringLiteral("21042.proxy2.kiwisdr.com"))
+               != QStringLiteral("21042")
+        || !proxyReceiverAlias(QStringLiteral("proxy.kiwisdr.com")).isEmpty()) {
+        return fail("Kiwi proxy receiver alias extraction is wrong");
+    }
+
+    if (!allowed("http://Example.com.:8073/status",
+                 "http://example.com:8074/status")) {
+        return fail("same canonical host redirect should be allowed");
+    }
+
+    if (!allowed("http://21042.proxy.kiwisdr.com:8073/status",
+                 "http://21042.proxy2.kiwisdr.com/status")
+        || !allowed("http://21042.proxy2.kiwisdr.com/status",
+                    "http://21042.proxy2.kiwisdr.com:8073/status")
+        || !allowed("http://21042.proxy2.kiwisdr.com/status",
+                    "http://21042.proxy.kiwisdr.com:8073/status")) {
+        return fail("matching Kiwi proxy receiver alias redirects should be allowed");
+    }
+
+    QString detail;
+    if (allowed("http://21042.proxy.kiwisdr.com:8073/status",
+                "http://evil.example.com/status")) {
+        return fail("cross-domain redirects should be rejected");
+    }
+    if (allowed("http://21042.proxy.kiwisdr.com:8073/status",
+                "http://21043.proxy2.kiwisdr.com/status")) {
+        return fail("mismatched Kiwi proxy aliases should be rejected");
+    }
+    if (isAllowedStatusRedirect(
+            QUrl(QStringLiteral("http://21042.proxy.kiwisdr.com/status")),
+            QUrl(QStringLiteral("ftp://21042.proxy.kiwisdr.com/status")),
+            &detail)
+        || !detail.contains(QStringLiteral("unsupported scheme"))) {
+        return fail("unsupported redirect schemes should be rejected with a detail");
+    }
+
+    std::printf("kiwi_sdr_redirect_policy_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #3790. KiwiSDR `/status` preflight now follows validated redirects and uses the final validated status endpoint for WebSocket transport, so proxied receivers such as `21042.proxy.kiwisdr.com:8073` can connect after Kiwi's `proxy` -> `proxy2` split.

Redirect handling is manual and fail-closed: same-host redirects are allowed, and the only cross-host exception is the matching Kiwi proxy receiver alias, such as `21042.proxy.kiwisdr.com` -> `21042.proxy2.kiwisdr.com`. Redirects to unrelated domains or mismatched proxy aliases are rejected before WebSockets open.

## Constitution principle honored

Principle VII — Boundary Input Validation. The redirected `/status` URL is validated before it can become the WebSocket authority.

## Test plan

- [x] Local build passes: `cmake --build build -j10`
- [x] Existing Kiwi tests pass:
  - `ctest --test-dir build -R 'kiwi_sdr_protocol_test|kiwi_sdr_trace_math_test|kiwi_public_directory_test' --output-on-failure`
- [x] Reproduction endpoint redirect chain verified:
  - `curl -sSIL --max-time 10 http://21042.proxy.kiwisdr.com:8073/status`
  - observed `21042.proxy.kiwisdr.com:8073` -> `21042.proxy2.kiwisdr.com` -> `21042.proxy2.kiwisdr.com:8073` -> `200 OK`
- [x] Redirected status body verified to report `ext_api=3`
- [x] `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter UI touched)
- [x] Documentation updated if user-visible behavior changed (not applicable; bug fix only)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)