### PR TITLE
[codex] Add automation radio connect command

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -350,10 +350,66 @@ Panadapter lifecycle — create or tear down a pan regardless of how it was open
 All are async (the radio echoes the change) — re-poll `get pans`. Every `pan`
 action is RX/config only; none keys the transmitter.
 
+### `connect` / `disconnect`
+Connect through the same dialog and model path as the visible **Connect to
+Radio** workflow. Requests are scheduled onto the next Qt event-loop turn so
+the bridge does not run modal connection-conflict UI inside the local-socket
+read callback.
+
+```json
+→ {"cmd":"connect","action":"list"}
+← {"ok":true,"count":1,"radios":[{"serial":"1234-5678","model":"FLEX-8600",
+   "address":"192.168.1.50","port":4992,"status":"Available"}]}
+
+→ {"cmd":"connect","action":"show"}
+← {"ok":true,"connect":"show","requested":true,"deferred":true,"wasVisible":false}
+
+→ {"cmd":"connect","action":"local","value":"serial 1234-5678"}
+← {"ok":true,"connect":"local","selector":"serial","serial":"1234-5678",
+   "requested":true,"deferred":true}
+
+→ {"cmd":"connect","action":"ip","value":"10.0.0.25"}
+← {"ok":true,"connect":"ip","target":"10.0.0.25","requested":true,"deferred":true}
+
+→ {"cmd":"connect","action":"wait","value":30000}
+← {"ok":true,"connected":true,"elapsedMs":4210,"radio":{"connected":true,...}}
+
+→ {"cmd":"disconnect"}
+← {"ok":true,"disconnect":true,"requested":true,"deferred":true}
+```
+
+Bare-line forms are also accepted:
+
+```text
+connect list
+connect show
+connect hide
+connect local first
+connect local serial 1234-5678
+connect ip 10.0.0.25
+connect wait 30000
+disconnect
+```
+
+`connect show` and `connect hide` idempotently show/raise or hide the
+modeless **Connect to Radio** dialog for visual debugging; they do not toggle,
+so `connect show` is safe when the dialog is already open. `connect local first`
+captures the first currently discovered local radio's serial before scheduling
+the request, so the response and deferred connect target stay consistent.
+`connect local serial <serial>` selects by discovery serial. `connect ip
+<host-or-ip>` uses the manual **Connect by IP** probe path; if the probe finds a
+radio, the panel emits its normal `connectRequested` signal and `MainWindow`
+performs the standard Multi-Flex/client-slot checks before `RadioModel`
+connects. `connect wait <timeout_ms>` holds that request's response until
+`RadioModel::connectionStateChanged(true)` or timeout, which is the preferred
+unattended "request then assert" flow.
+
 ### Errors
 Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
 `widget not found: Foo`, `blocked: '…' looks transmit-related …`,
-`no slice for selector 'tx'`, `unknown action: x`, `unknown command: x`.
+`no slice for selector 'tx'`, `no local radios have been discovered`,
+`timed out waiting for radio connection`, `unknown action: x`,
+`unknown command: x`.
 
 ---
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3,6 +3,7 @@
 #include "AppSettings.h"          // StationName (restore the user's real station name)
 #include "TxKeyingMarker.h"       // kTxKeyingProperty — authoritative TX-guard marker
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
+#include "gui/ConnectionPanel.h" // ConnectionPanel automation facade
 
 #include <QAction>
 #include <QLocalServer>
@@ -34,6 +35,7 @@
 #include <QDateTime>
 #include <QTime>
 
+#include <algorithm>
 #include <limits>
 
 // Best-effort value extraction for common control types.
@@ -547,6 +549,78 @@ QJsonObject err(const QString& msg)
 {
     return QJsonObject{{QStringLiteral("ok"), false},
                        {QStringLiteral("error"), msg}};
+}
+
+QJsonObject deferredResponse()
+{
+    return QJsonObject{{QStringLiteral("_deferred"), true}};
+}
+
+bool isDeferredResponse(const QJsonObject& response)
+{
+    return response.value(QStringLiteral("_deferred")).toBool(false);
+}
+
+bool writeJsonResponse(QLocalSocket* socket, const QJsonObject& response)
+{
+    if (!socket || socket->state() == QLocalSocket::UnconnectedState) {
+        return false;
+    }
+
+    QByteArray payload = QJsonDocument(response).toJson(QJsonDocument::Compact);
+    payload.append('\n');
+    if (socket->write(payload) < 0) {
+        qCWarning(lcAutomation) << "failed to write automation response:"
+                                << socket->errorString();
+        return false;
+    }
+    socket->flush();
+    return true;
+}
+
+QJsonObject connectionRadioToJson(const RadioInfo& radio)
+{
+    QJsonObject o{
+        {QStringLiteral("name"), radio.name},
+        {QStringLiteral("model"), radio.model},
+        {QStringLiteral("serial"), radio.serial},
+        {QStringLiteral("version"), radio.version},
+        {QStringLiteral("nickname"), radio.nickname},
+        {QStringLiteral("callsign"), radio.callsign},
+        {QStringLiteral("address"), radio.address.toString()},
+        {QStringLiteral("port"), radio.port},
+        {QStringLiteral("status"), radio.status},
+        {QStringLiteral("inUse"), radio.inUse},
+        {QStringLiteral("multiFlexEnabled"), radio.multiFlexEnabled},
+        {QStringLiteral("routed"), radio.isRouted},
+    };
+
+    QJsonArray stations;
+    for (const QString& station : radio.guiClientStations) {
+        stations.append(station);
+    }
+    if (!stations.isEmpty()) {
+        o[QStringLiteral("stations")] = stations;
+    }
+
+    QJsonArray handles;
+    for (const QString& handle : radio.guiClientHandles) {
+        handles.append(handle);
+    }
+    if (!handles.isEmpty()) {
+        o[QStringLiteral("clientHandles")] = handles;
+    }
+
+    return o;
+}
+
+QJsonArray connectionRadioListToJson(const QList<RadioInfo>& radios)
+{
+    QJsonArray array;
+    for (const RadioInfo& radio : radios) {
+        array.append(connectionRadioToJson(radio));
+    }
+    return array;
 }
 
 // Parse a textual boolean from an invoke value: 1/true/on/yes/checked → true.
@@ -1153,9 +1227,9 @@ bool AutomationServer::start(const QString& serverName)
 
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, floors, grab, grab pan, invoke, get, txtest, atu,"
-        << "slice, tune, pan, txwaterfall, key, cwx, station, resize, menu, close, drag,"
-        << "showMenu, whoami, log, mark)";
+        << "(verbs: ping, dumpTree, floors, grab, grab pan, invoke, get, connect, disconnect,"
+        << "txtest, atu, slice, tune, pan, txwaterfall, key, cwx, station, resize, menu,"
+        << "close, drag, showMenu, whoami, log, mark)";
     return true;
 }
 
@@ -1187,6 +1261,19 @@ void AutomationServer::stop()
         m_logDrain = nullptr;
     }
     m_logSubscribers.clear();
+    for (const std::shared_ptr<ConnectWait>& wait : m_connectWaits) {
+        if (!wait) {
+            continue;
+        }
+        if (wait->timer) {
+            wait->timer->stop();
+            wait->timer->deleteLater();
+            wait->timer = nullptr;
+        }
+        QObject::disconnect(wait->connection);
+        wait->complete = true;
+    }
+    m_connectWaits.clear();
 
     for (auto it = m_buffers.constBegin(); it != m_buffers.constEnd(); ++it)
         it.key()->deleteLater();
@@ -1286,14 +1373,13 @@ void AutomationServer::onReadyRead()
             return;
         }
 
-        QByteArray payload = QJsonDocument(resp).toJson(QJsonDocument::Compact);
-        payload.append('\n');
-        if (socket->write(payload) < 0) {
-            qCWarning(lcAutomation) << "failed to write automation response:"
-                                    << socket->errorString();
+        if (isDeferredResponse(resp)) {
+            continue;
+        }
+
+        if (!writeJsonResponse(socket, resp)) {
             return;
         }
-        socket->flush();
     }
 }
 
@@ -1305,6 +1391,21 @@ void AutomationServer::onDisconnected()
     m_buffers.remove(sock);
     if (m_logSubscribers.remove(sock) && m_logSubscribers.isEmpty() && m_logDrain)
         m_logDrain->stop();
+    const auto newEnd = std::remove_if(
+        m_connectWaits.begin(), m_connectWaits.end(),
+        [sock](const std::shared_ptr<ConnectWait>& wait) {
+            if (!wait || wait->socket != sock) {
+                return false;
+            }
+            if (wait->timer) {
+                wait->timer->stop();
+                wait->timer->deleteLater();
+            }
+            QObject::disconnect(wait->connection);
+            wait->complete = true;
+            return true;
+        });
+    m_connectWaits.erase(newEnd, m_connectWaits.end());
     sock->deleteLater();
     qCDebug(lcAutomation) << "client disconnected;" << m_buffers.size() << "active";
 }
@@ -1352,6 +1453,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));
         } else if (cmd == QLatin1String("get")) {
             model = tok(1); selector = tok(2); property = tok(3);
+        } else if (cmd == QLatin1String("connect")) {
+            action = tok(1);  // list | local | ip | wait
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));  // "serial 1234", "10.0.0.25", "30000"
         } else if (cmd == QLatin1String("txtest") || cmd == QLatin1String("atu")) {
             action = tok(1);  // e.g. "txtest twotone", "atu bypass"
         } else if (cmd == QLatin1String("slice")) {
@@ -1452,6 +1558,15 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         if (model.isEmpty())
             return err(QStringLiteral("get requires a model (radio|transmit|meters|slice|slices|pan|pans)"));
         return doGet(model, selector, property);
+    }
+    if (cmd == QLatin1String("connect")) {
+        if (action.isEmpty()) {
+            return err(QStringLiteral("connect requires an action (list|show|hide|local|ip|wait)"));
+        }
+        return doConnect(action, value, sock);
+    }
+    if (cmd == QLatin1String("disconnect")) {
+        return doDisconnect();
     }
     if (cmd == QLatin1String("txtest")) {
         if (action.isEmpty())
@@ -2030,6 +2145,320 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         {QStringLiteral("model"), model},
         {model, data},   // keyed by model name: "radio" / "slice" / "pan"
     };
+}
+
+QJsonObject AutomationServer::doConnect(const QString& action,
+                                        const QString& arg,
+                                        QLocalSocket* sock)
+{
+    const QString a = action.trimmed().toLower();
+
+    if (a == QLatin1String("wait")) {
+        bool ok = false;
+        const int requestedTimeoutMs = arg.trimmed().isEmpty()
+            ? 30000
+            : arg.trimmed().toInt(&ok);
+        if (!ok && !arg.trimmed().isEmpty()) {
+            return err(QStringLiteral("connect wait requires a timeout in milliseconds"));
+        }
+        return doConnectWait(requestedTimeoutMs, sock);
+    }
+    if (a == QLatin1String("show") || a == QLatin1String("hide")) {
+        return doConnectDialog(a);
+    }
+    if (a == QLatin1String("dialog")) {
+        const QString dialogAction = arg.trimmed().toLower();
+        if (dialogAction == QLatin1String("show") || dialogAction == QLatin1String("hide")) {
+            return doConnectDialog(dialogAction);
+        }
+        return err(QStringLiteral("connect dialog requires show|hide"));
+    }
+
+    ConnectionPanel* panel = m_connectionPanel;
+    if (!panel) {
+        return err(QStringLiteral("connection panel unavailable"));
+    }
+
+    if (a == QLatin1String("list")) {
+        const QList<RadioInfo> radios = panel->automationLocalRadios();
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("count"), radios.size()},
+            {QStringLiteral("radios"), connectionRadioListToJson(radios)},
+        };
+    }
+
+    if (m_radioModel && m_radioModel->isConnected()) {
+        return err(QStringLiteral("already connected to a radio"));
+    }
+
+    if (a == QLatin1String("local")) {
+        const QList<RadioInfo> radios = panel->automationLocalRadios();
+        if (radios.isEmpty()) {
+            return err(QStringLiteral("no local radios have been discovered"));
+        }
+
+        const QString selector = arg.trimmed();
+        const QString selectorLower = selector.toLower();
+        if (selector.isEmpty() || selectorLower == QLatin1String("first")) {
+            const RadioInfo selected = radios.first();
+            const QString selectedSerial = selected.serial.trimmed();
+            if (selectedSerial.isEmpty()) {
+                return err(QStringLiteral("first discovered local radio has no serial"));
+            }
+
+            QPointer<ConnectionPanel> guardedPanel = panel;
+            QTimer::singleShot(0, qApp, [guardedPanel, selectedSerial] {
+                if (!guardedPanel) {
+                    return;
+                }
+                QString error;
+                if (!guardedPanel->automationConnectLocalSerial(selectedSerial, &error)) {
+                    qCWarning(lcAutomation).noquote()
+                        << "connect local first failed after scheduling:" << error;
+                }
+            });
+            return QJsonObject{
+                {QStringLiteral("ok"), true},
+                {QStringLiteral("connect"), QStringLiteral("local")},
+                {QStringLiteral("selector"), QStringLiteral("first")},
+                {QStringLiteral("serial"), selectedSerial},
+                {QStringLiteral("requested"), true},
+                {QStringLiteral("deferred"), true},
+                {QStringLiteral("radio"), connectionRadioToJson(selected)},
+            };
+        }
+
+        static const QString kSerialPrefix = QStringLiteral("serial ");
+        if (selectorLower.startsWith(kSerialPrefix)) {
+            const QString serial = selector.mid(kSerialPrefix.size()).trimmed();
+            for (const RadioInfo& radio : radios) {
+                if (radio.serial.compare(serial, Qt::CaseInsensitive) != 0) {
+                    continue;
+                }
+
+                QPointer<ConnectionPanel> guardedPanel = panel;
+                QTimer::singleShot(0, qApp, [guardedPanel, serial] {
+                    if (!guardedPanel) {
+                        return;
+                    }
+                    QString error;
+                    if (!guardedPanel->automationConnectLocalSerial(serial, &error)) {
+                        qCWarning(lcAutomation).noquote()
+                            << "connect local serial failed after scheduling:" << error;
+                    }
+                });
+                return QJsonObject{
+                    {QStringLiteral("ok"), true},
+                    {QStringLiteral("connect"), QStringLiteral("local")},
+                    {QStringLiteral("selector"), QStringLiteral("serial")},
+                    {QStringLiteral("serial"), serial},
+                    {QStringLiteral("requested"), true},
+                    {QStringLiteral("deferred"), true},
+                    {QStringLiteral("radio"), connectionRadioToJson(radio)},
+                };
+            }
+
+            return err(QStringLiteral("no discovered local radio has serial '%1'").arg(serial));
+        }
+
+        return err(QStringLiteral("connect local requires first or serial <serial>"));
+    }
+
+    if (a == QLatin1String("ip")) {
+        const QString target = arg.trimmed();
+        if (target.isEmpty()) {
+            return err(QStringLiteral("connect ip requires a host or IP address"));
+        }
+
+        QPointer<ConnectionPanel> guardedPanel = panel;
+        QTimer::singleShot(0, qApp, [guardedPanel, target] {
+            if (!guardedPanel) {
+                return;
+            }
+            QString error;
+            if (!guardedPanel->automationConnectByIp(target, &error)) {
+                qCWarning(lcAutomation).noquote()
+                    << "connect ip failed after scheduling:" << error;
+            }
+        });
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("connect"), QStringLiteral("ip")},
+            {QStringLiteral("target"), target},
+            {QStringLiteral("requested"), true},
+            {QStringLiteral("deferred"), true},
+        };
+    }
+
+    return err(QStringLiteral("unknown connect action: ") + action
+               + QStringLiteral(" (use list|show|hide|local|ip|wait)"));
+}
+
+QJsonObject AutomationServer::doConnectDialog(const QString& action)
+{
+    const bool show = action == QLatin1String("show");
+    const bool hide = action == QLatin1String("hide");
+    if (!show && !hide) {
+        return err(QStringLiteral("connect dialog requires show|hide"));
+    }
+
+    QObject* host = m_connectionDialogHost;
+    ConnectionPanel* panel = m_connectionPanel;
+    if (!host && !panel) {
+        return err(QStringLiteral("connection dialog unavailable"));
+    }
+
+    const bool wasVisible = panel && panel->isVisible();
+    QPointer<QObject> guardedHost = host;
+    QPointer<ConnectionPanel> guardedPanel = panel;
+    QTimer::singleShot(0, qApp, [guardedHost, guardedPanel, show] {
+        if (guardedHost) {
+            const char* method = show ? "showConnectionDialog" : "hideConnectionDialog";
+            if (QMetaObject::invokeMethod(guardedHost, method, Qt::DirectConnection)) {
+                return;
+            }
+            qCWarning(lcAutomation).noquote()
+                << "connection dialog host missing invokable" << method
+                << "- falling back to direct panel visibility";
+        }
+
+        if (!guardedPanel) {
+            return;
+        }
+        if (show) {
+            guardedPanel->show();
+            guardedPanel->raise();
+            guardedPanel->activateWindow();
+        } else {
+            guardedPanel->hide();
+        }
+    });
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("connect"), action},
+        {QStringLiteral("requested"), true},
+        {QStringLiteral("deferred"), true},
+        {QStringLiteral("wasVisible"), wasVisible},
+    };
+}
+
+QJsonObject AutomationServer::doDisconnect()
+{
+    ConnectionPanel* panel = m_connectionPanel;
+    if (!panel) {
+        return err(QStringLiteral("connection panel unavailable"));
+    }
+    if (!m_radioModel || !m_radioModel->isConnected()) {
+        return err(QStringLiteral("not connected to a radio"));
+    }
+
+    QPointer<ConnectionPanel> guardedPanel = panel;
+    QTimer::singleShot(0, qApp, [guardedPanel] {
+        if (!guardedPanel) {
+            return;
+        }
+        QString error;
+        if (!guardedPanel->automationDisconnect(&error)) {
+            qCWarning(lcAutomation).noquote()
+                << "disconnect failed after scheduling:" << error;
+        }
+    });
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("disconnect"), true},
+        {QStringLiteral("requested"), true},
+        {QStringLiteral("deferred"), true},
+    };
+}
+
+QJsonObject AutomationServer::doConnectWait(int timeoutMs, QLocalSocket* sock)
+{
+    if (!m_radioModel) {
+        return err(QStringLiteral("no radio model available"));
+    }
+    if (m_radioModel->isConnected()) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("connected"), true},
+            {QStringLiteral("elapsedMs"), 0},
+            {QStringLiteral("radio"), radioSnapshot(m_radioModel)},
+        };
+    }
+    if (!sock) {
+        return err(QStringLiteral("connect wait requires a live automation client"));
+    }
+
+    const int boundedTimeoutMs = std::clamp(timeoutMs, 1, 300000);
+    auto wait = std::make_shared<ConnectWait>();
+    wait->socket = sock;
+    wait->timeoutMs = boundedTimeoutMs;
+    wait->elapsed.start();
+    wait->timer = new QTimer(this);
+    wait->timer->setSingleShot(true);
+
+    wait->connection = connect(m_radioModel, &RadioModel::connectionStateChanged,
+                               this, [this, wait](bool connected) {
+        if (connected) {
+            finishConnectWait(wait, false);
+        }
+    });
+    connect(wait->timer, &QTimer::timeout, this, [this, wait] {
+        finishConnectWait(wait, true);
+    });
+
+    m_connectWaits.push_back(wait);
+    wait->timer->start(boundedTimeoutMs);
+    return deferredResponse();
+}
+
+void AutomationServer::finishConnectWait(const std::shared_ptr<ConnectWait>& wait,
+                                         bool timedOut)
+{
+    if (!wait || wait->complete) {
+        return;
+    }
+
+    wait->complete = true;
+    if (wait->timer) {
+        wait->timer->stop();
+        wait->timer->deleteLater();
+        wait->timer = nullptr;
+    }
+    QObject::disconnect(wait->connection);
+
+    const auto newEnd = std::remove(m_connectWaits.begin(), m_connectWaits.end(), wait);
+    m_connectWaits.erase(newEnd, m_connectWaits.end());
+
+    QLocalSocket* socket = wait->socket;
+    if (!socket || m_buffers.find(socket) == m_buffers.end()
+        || socket->state() == QLocalSocket::UnconnectedState) {
+        qCDebug(lcAutomation)
+            << "dropping connect wait response because client disconnected";
+        return;
+    }
+
+    const bool connected = m_radioModel && m_radioModel->isConnected();
+    QJsonObject response{
+        {QStringLiteral("ok"), connected},
+        {QStringLiteral("connected"), connected},
+        {QStringLiteral("elapsedMs"), static_cast<int>(wait->elapsed.elapsed())},
+        {QStringLiteral("timeoutMs"), wait->timeoutMs},
+    };
+    if (connected) {
+        response[QStringLiteral("radio")] = radioSnapshot(m_radioModel);
+    } else if (timedOut) {
+        response[QStringLiteral("timeout")] = true;
+        response[QStringLiteral("error")] =
+            QStringLiteral("timed out waiting for radio connection");
+    } else {
+        response[QStringLiteral("error")] =
+            QStringLiteral("radio connection did not complete");
+    }
+
+    writeJsonResponse(socket, response);
 }
 
 // ── TX test-signal control (#3646) ──────────────────────────────────────────

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -9,6 +9,8 @@
 #include <QString>
 
 #include <deque>
+#include <memory>
+#include <vector>
 
 class QLocalServer;
 class QLocalSocket;
@@ -19,6 +21,7 @@ class QTimer;
 namespace AetherSDR {
 
 class RadioModel;
+class ConnectionPanel;
 
 // In-app, agent-first automation bridge (issue #3646, Phases 0-1).
 //
@@ -59,6 +62,18 @@ class RadioModel;
 //                                     slices | pan <panId|active> | pans. With a
 //                                     trailing property name, returns just that
 //                                     field. Assert on state without screenshots.
+//   connect list                   -> list currently discovered local radios
+//   connect show                   -> show/raise the Connect to Radio dialog
+//   connect hide                   -> hide the Connect to Radio dialog
+//   connect local first            -> request a real local-radio connection via
+//                                     ConnectionPanel/MainWindow/RadioModel
+//   connect local serial <serial>  -> same, selecting by discovered serial
+//   connect ip <host-or-ip>        -> route through the manual Connect by IP
+//                                     probe path, then connect if the probe finds
+//                                     a radio
+//   connect wait <timeout_ms>      -> hold the response until RadioModel reports
+//                                     connected or the timeout expires
+//   disconnect                     -> request the normal user disconnect path
 //
 // Phase 2 verbs (fidelity — reach code paths invoke/get can't, #3646):
 //
@@ -148,6 +163,11 @@ public:
     // MainWindow's active-session RadioModel; may be null (get() then reports
     // "no radio model" rather than crashing).
     void setRadioModel(RadioModel* model) { m_radioModel = model; }
+    // Real connection dialog hook for the connect/disconnect verbs. The bridge
+    // asks ConnectionPanel to emit the same signals the visible buttons do, so
+    // automation exercises the normal MainWindow/RadioModel connection path.
+    void setConnectionPanel(ConnectionPanel* panel) { m_connectionPanel = panel; }
+    void setConnectionDialogHost(QObject* host) { m_connectionDialogHost = host; }
 
 private slots:
     void onNewConnection();
@@ -201,6 +221,12 @@ private:
     QJsonObject doPan(const QString& action, const QString& arg);
     QJsonObject doGet(const QString& model, const QString& selector,
                       const QString& property) const;
+    QJsonObject doConnect(const QString& action, const QString& arg, QLocalSocket* sock);
+    QJsonObject doConnectDialog(const QString& action);
+    QJsonObject doDisconnect();
+    QJsonObject doConnectWait(int timeoutMs, QLocalSocket* sock);
+    struct ConnectWait;
+    void finishConnectWait(const std::shared_ptr<ConnectWait>& wait, bool timedOut);
     // TX test-signal control (two-tone) and ATU control. Both gated by
     // AETHER_AUTOMATION_ALLOW_TX where they key the transmitter.
     QJsonObject doTxTest(const QString& action);
@@ -255,6 +281,8 @@ private:
     QString       m_label;            // AETHER_AUTOMATION_LABEL (human instance tag)
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
+    QPointer<ConnectionPanel> m_connectionPanel;  // for connect/disconnect verbs
+    QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
 
     // Agent station identity (#3646). The bridge sets the per-GUI-client station
     // name to the agent's name on connect and restores the user's real name on
@@ -287,6 +315,16 @@ private:
     QHash<QLocalSocket*, quint64> m_logSubscribers;  // sock -> last seq sent
     QTimer*        m_logDrain{nullptr};
     static constexpr int kLogRingMax = 8000;
+
+    struct ConnectWait {
+        QPointer<QLocalSocket> socket;
+        QTimer* timer{nullptr};
+        QMetaObject::Connection connection;
+        QElapsedTimer elapsed;
+        int timeoutMs{0};
+        bool complete{false};
+    };
+    std::vector<std::shared_ptr<ConnectWait>> m_connectWaits;
 };
 
 } // namespace AetherSDR

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -57,6 +57,13 @@ QString normalizeManualIp(const QString& ip)
     return address.toString();
 }
 
+void setAutomationError(QString* error, const QString& text)
+{
+    if (error) {
+        *error = text;
+    }
+}
+
 QStringList sanitizeRecentManualIps(const QStringList& ips)
 {
     QStringList sanitized;
@@ -183,6 +190,9 @@ QString normalizedStatus(QString status)
 ConnectionPanel::ConnectionPanel(QWidget* parent)
     : QWidget(parent)
 {
+    setObjectName(QStringLiteral("connectionPanel"));
+    setAccessibleName(tr("Connect to Radio"));
+
     theme::setContainer(this, QStringLiteral("panel/connection"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "ConnectionPanel { background: {{color.background.0}}; }"
         "QGroupBox { border: 1px solid {{color.background.2}}; border-radius: 7px; margin-top: 10px; "
@@ -316,6 +326,10 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     auto* localGroup = new QGroupBox("Available radios", localListPage);
     auto* localGroupLayout = new QVBoxLayout(localGroup);
     m_radioList = new QListWidget(localGroup);
+    m_radioList->setObjectName(QStringLiteral("connectionLocalRadioList"));
+    m_radioList->setAccessibleName(tr("Available local radios"));
+    m_radioList->setAccessibleDescription(
+        tr("Discovered FlexRadio radios on the local network"));
     m_radioList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_radioList->setWordWrap(true);
     m_radioList->setSpacing(2);
@@ -326,6 +340,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     auto* localActionRow = new QHBoxLayout;
     localActionRow->addStretch();
     m_localConnectBtn = new QPushButton("Connect Selected Radio", localListPage);
+    m_localConnectBtn->setObjectName(QStringLiteral("connectionLocalConnectButton"));
+    m_localConnectBtn->setAccessibleName(tr("Connect selected local radio"));
     m_localConnectBtn->setEnabled(false);
     localActionRow->addWidget(m_localConnectBtn);
     localListLayout->addLayout(localActionRow);
@@ -439,6 +455,10 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     auto* remoteLayout = new QVBoxLayout(remoteGroup);
     remoteLayout->setSpacing(10);
     m_wanList = new QListWidget(remoteGroup);
+    m_wanList->setObjectName(QStringLiteral("connectionSmartLinkRadioList"));
+    m_wanList->setAccessibleName(tr("Available SmartLink radios"));
+    m_wanList->setAccessibleDescription(
+        tr("Remote FlexRadio radios available through SmartLink"));
     m_wanList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_wanList->setWordWrap(true);
     m_wanList->setSpacing(2);
@@ -458,6 +478,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     wanActionRow->setSpacing(10);
     wanActionRow->addStretch();
     m_wanConnectBtn = new QPushButton("Connect Remote Radio", wanActionBar);
+    m_wanConnectBtn->setObjectName(QStringLiteral("connectionSmartLinkConnectButton"));
+    m_wanConnectBtn->setAccessibleName(tr("Connect selected SmartLink radio"));
     m_wanConnectBtn->setEnabled(false);
     m_wanConnectBtn->setMinimumWidth(190);
     wanActionRow->addWidget(m_wanConnectBtn);
@@ -483,11 +505,19 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     manualForm->setHorizontalSpacing(8);
     manualForm->setVerticalSpacing(6);
     m_manualIpCombo = new QComboBox(manualGroup);
+    m_manualIpCombo->setObjectName(QStringLiteral("connectionManualIpCombo"));
+    m_manualIpCombo->setAccessibleName(tr("Radio IP address"));
+    m_manualIpCombo->setAccessibleDescription(
+        tr("IP address or host name for a routed or VPN radio connection"));
     m_manualIpCombo->setEditable(true);
     m_manualIpCombo->setInsertPolicy(QComboBox::NoInsert);
     m_manualIpCombo->setMaxVisibleItems(kMaxRecentManualIps);
     m_manualIpCombo->setStyleSheet(comboStyle);
     m_manualIpEdit = m_manualIpCombo->lineEdit();
+    m_manualIpEdit->setObjectName(QStringLiteral("connectionManualIp"));
+    m_manualIpEdit->setAccessibleName(tr("Radio IP address"));
+    m_manualIpEdit->setAccessibleDescription(
+        tr("IP address or host name for a routed or VPN radio connection"));
     m_manualIpEdit->setClearButtonEnabled(true);
     m_manualIpEdit->setPlaceholderText("Example: 10.0.0.25");
     manualForm->addRow("Radio IP:", m_manualIpCombo);
@@ -498,6 +528,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     manualActionRow->addWidget(manualDiagnosticsBtn);
     manualActionRow->addStretch();
     m_manualConnectBtn = new QPushButton("Connect by IP", manualGroup);
+    m_manualConnectBtn->setObjectName(QStringLiteral("connectionManualConnectButton"));
+    m_manualConnectBtn->setAccessibleName(tr("Connect by IP"));
     manualActionRow->addWidget(m_manualConnectBtn);
     manualGroupLayout->addLayout(manualActionRow);
 
@@ -525,6 +557,10 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     sourceRow->setContentsMargins(0, 0, 0, 0);
     sourceRow->addWidget(new QLabel("Source path:", m_manualAdvancedWidget));
     m_manualSourceCombo = new QComboBox(m_manualAdvancedWidget);
+    m_manualSourceCombo->setObjectName(QStringLiteral("connectionManualSourcePath"));
+    m_manualSourceCombo->setAccessibleName(tr("Manual connection source path"));
+    m_manualSourceCombo->setAccessibleDescription(
+        tr("Network interface or source address to use for the routed radio connection"));
     sourceRow->addWidget(m_manualSourceCombo, 1);
     manualAdvancedLayout->addLayout(sourceRow);
     m_manualSourceWarningLabel = makeWrappedLabel(QString(), kErrorLabelStyle);
@@ -594,6 +630,8 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_statusLabel = makeWrappedLabel("Choose how you want to connect.", kHintLabelStyle);
     footerRow->addWidget(m_statusLabel, 1);
     m_disconnectBtn = new QPushButton("Disconnect", this);
+    m_disconnectBtn->setObjectName(QStringLiteral("connectionDisconnectButton"));
+    m_disconnectBtn->setAccessibleName(tr("Disconnect from radio"));
     m_disconnectBtn->setVisible(false);
     footerRow->addWidget(m_disconnectBtn, 0, Qt::AlignRight);
     root->addLayout(footerRow);
@@ -718,6 +756,68 @@ void ConnectionPanel::setConnected(bool connected)
 void ConnectionPanel::setStatusText(const QString& text)
 {
     m_statusLabel->setText(text);
+}
+
+QList<RadioInfo> ConnectionPanel::automationLocalRadios() const
+{
+    return m_radios;
+}
+
+bool ConnectionPanel::automationConnectLocalSerial(const QString& serial, QString* error)
+{
+    const QString wanted = serial.trimmed();
+    if (wanted.isEmpty()) {
+        setAutomationError(error, QStringLiteral("local serial selector is empty"));
+        return false;
+    }
+    if (m_connected) {
+        setAutomationError(error, QStringLiteral("already connected to a radio"));
+        return false;
+    }
+
+    for (int i = 0; i < m_radios.size(); ++i) {
+        if (m_radios[i].serial.compare(wanted, Qt::CaseInsensitive) == 0) {
+            setCurrentMode(LocalMode);
+            m_radioList->setCurrentRow(i);
+            onLocalConnectClicked();
+            return true;
+        }
+    }
+
+    setAutomationError(
+        error,
+        QStringLiteral("no discovered local radio has serial '%1'").arg(wanted));
+    return false;
+}
+
+bool ConnectionPanel::automationConnectByIp(const QString& hostOrIp, QString* error)
+{
+    const QString target = hostOrIp.trimmed();
+    if (target.isEmpty()) {
+        setAutomationError(error, QStringLiteral("connect ip requires an address"));
+        return false;
+    }
+    if (m_connected) {
+        setAutomationError(error, QStringLiteral("already connected to a radio"));
+        return false;
+    }
+
+    setCurrentMode(ManualMode);
+    m_manualIpCombo->setCurrentText(target);
+    m_manualIpEdit->setText(target);
+    onManualConnectClicked();
+    return true;
+}
+
+bool ConnectionPanel::automationDisconnect(QString* error)
+{
+    if (!m_connected) {
+        setAutomationError(error, QStringLiteral("not connected to a radio"));
+        return false;
+    }
+
+    emit disconnectRequested();
+    return true;
 }
 
 void ConnectionPanel::saveLowBandwidthPreference(bool enabled)
@@ -1385,11 +1485,16 @@ void ConnectionPanel::probeRadio(const QString& ip)
 
         // Build RadioInfo from collected status and emit the connect signal.
         auto finishProbe = [this, sock, trimmedIp, bindSettings, version, statusLines, localSrc] {
+            QHostAddress targetAddress(trimmedIp);
+            if (targetAddress.isNull()) {
+                targetAddress = sock->peerAddress();
+            }
+
             sock->disconnectFromHost();
             sock->deleteLater();
 
             RadioInfo info;
-            info.address  = QHostAddress(trimmedIp);
+            info.address  = targetAddress;
             info.port     = 4992;
             info.version  = *version;
             info.status   = QStringLiteral("Available");

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -30,6 +30,10 @@ public:
     void setConnected(bool connected);
     void setStatusText(const QString& text);
     void probeRadio(const QString& ip);
+    QList<RadioInfo> automationLocalRadios() const;
+    bool automationConnectLocalSerial(const QString& serial, QString* error = nullptr);
+    bool automationConnectByIp(const QString& hostOrIp, QString* error = nullptr);
+    bool automationDisconnect(QString* error = nullptr);
 
 protected:
     void paintEvent(QPaintEvent* event) override;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3242,7 +3242,16 @@ void MainWindow::showPropDashboard()
 void MainWindow::toggleConnectionDialog()
 {
     if (m_connPanel->isVisible()) {
-        m_connPanel->hide();
+        hideConnectionDialog();
+        return;
+    }
+
+    showConnectionDialog();
+}
+
+void MainWindow::showConnectionDialog()
+{
+    if (!m_connPanel) {
         return;
     }
 
@@ -3272,6 +3281,13 @@ void MainWindow::toggleConnectionDialog()
     m_connPanel->show();
     m_connPanel->raise();
     m_connPanel->activateWindow();
+}
+
+void MainWindow::hideConnectionDialog()
+{
+    if (m_connPanel) {
+        m_connPanel->hide();
+    }
 }
 
 void MainWindow::showMemoryDialog()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -182,6 +182,8 @@ public:
     // (#3646) to read live model state via get(); keep it read-oriented.
     RadioModel& radioModel() { return m_radioModel; }
     const RadioModel& radioModel() const { return m_radioModel; }
+    Q_INVOKABLE void showConnectionDialog();
+    Q_INVOKABLE void hideConnectionDialog();
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "gui/MainWindow.h"
+#include "gui/ConnectionPanel.h"
 #include "gui/SliceColorManager.h"
 #include "core/AppSettings.h"
 #include "core/GpuSelector.h"
@@ -425,6 +426,9 @@ int main(int argc, char* argv[])
                 : QStringLiteral("aethersdr-automation-%1").arg(QCoreApplication::applicationPid());
             automation = std::make_unique<AetherSDR::AutomationServer>();
             automation->setRadioModel(&window.radioModel());  // for the get() verb
+            automation->setConnectionDialogHost(&window);
+            automation->setConnectionPanel(
+                window.findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
             if (!automation->start(sockName))
                 automation.reset();
         }

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -19,6 +19,10 @@ Usage:
     AETHER_AUTOMATION=1 ./AetherSDR &        # launch the app with the bridge on
     python tools/automation_probe.py         # snapshot + panadapter grab
     python tools/automation_probe.py ping
+    python tools/automation_probe.py connect list
+    python tools/automation_probe.py connect show
+    python tools/automation_probe.py connect local first
+    python tools/automation_probe.py connect wait 30000
     python tools/automation_probe.py grab SpectrumWidget /tmp/pan.png
 """
 
@@ -87,18 +91,24 @@ def main():
         description="Drive the AetherSDR automation bridge",
         epilog="examples:\n"
                "  automation_probe.py demo\n"
+               "  automation_probe.py connect list\n"
+               "  automation_probe.py connect show\n"
+               "  automation_probe.py connect local first\n"
+               "  automation_probe.py connect wait 30000\n"
                "  automation_probe.py get radio\n"
                "  automation_probe.py get slice active frequency\n"
                "  automation_probe.py invoke 'Master volume' setValue 35\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png",
         formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command", nargs="?", default="demo",
-                    choices=["demo", "ping", "dumpTree", "grab", "invoke", "get"],
+                    choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
+                             "connect", "disconnect"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | "
                          "invoke <target> <action> [value] | "
-                         "get <model> [selector] [property]")
+                         "get <model> [selector] [property] | "
+                         "connect <list|show|hide|local|ip|wait> [args]")
     ap.add_argument("--socket", help="override the bridge socket path")
     ap.add_argument("--out", default=".", help="output dir for demo artifacts")
     args = ap.parse_args()
@@ -146,6 +156,17 @@ def main():
             if len(args.rest) > 2:
                 req["property"] = args.rest[2]
             print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "connect":
+            if not args.rest:
+                sys.exit("error: connect needs <list|local|ip|wait> [args]")
+            req = {"cmd": "connect", "action": args.rest[0]}
+            if len(args.rest) > 1:
+                req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "disconnect":
+            print(json.dumps(bridge.request({"cmd": "disconnect"}), indent=2))
 
         else:  # demo: produce the Phase-0 deliverables
             os.makedirs(args.out, exist_ok=True)


### PR DESCRIPTION
## Summary

Adds semantic automation-bridge support for showing the **Connect to Radio** dialog and for connecting/disconnecting through the real **Connect to Radio** workflow. The bridge now supports `connect list`, `connect show`, `connect hide`, `connect local first`, `connect local serial <serial>`, `connect ip <host-or-ip>`, `connect wait <timeout_ms>`, and `disconnect`, all routed through `ConnectionPanel` / `MainWindow` / `RadioModel` instead of bypassing application logic. Also adds stable object/accessibility names to connection-panel controls and documents the new commands in the automation bridge guide.

## Constitution principle honored

Principle VII — boundary input validation. The new automation commands validate selectors, timeouts, and connection state at the bridge boundary, then route only valid requests through the existing connection UI/model path.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR --parallel`)
- [x] Behavior verified on a real radio if applicable
  - Visible app run connected to a local FLEX-6700 through `connect local serial <serial>`, verified `connected:true`, then disconnected and verified `connected:false`. Local serial/IP details intentionally omitted from the public PR body.
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
  - Verified both offscreen and visible automation flows with bridge smoke checks.

Additional local validation:
- [x] `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- [x] `cmake --build build --parallel`
- [x] `cmake --build build --target AetherSDR --parallel`
- [x] `python3 -m py_compile tools/automation_probe.py`
- [x] `python3 tools/check_a11y.py src/gui/ConnectionPanel.cpp src/gui/MainWindow.cpp`
- [x] `git diff --check`
- [x] Offscreen bridge smoke:
  - `tools/automation_probe.py ping`
  - `tools/automation_probe.py connect list`
  - `tools/automation_probe.py connect show`
  - `tools/automation_probe.py connect hide`
  - `tools/automation_probe.py connect wait 5`
- [x] Visible bridge smoke:
  - `tools/automation_probe.py connect local serial <serial>`
  - `tools/automation_probe.py connect wait 30000`
  - `tools/automation_probe.py get radio`
  - `tools/automation_probe.py disconnect`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
  - Not applicable: no meter UI changed.
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
  - Not applicable.