### PR TITLE
fix(wfm): relocate WFM toggle to the DAX pan menu so frequency digits don't clip

### DIFF
--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -27,6 +27,7 @@
 #include "MainWindowHelpers.h"
 #include "PanadapterApplet.h"
 #include "PanadapterStack.h"
+#include "SpectrumOverlayMenu.h"
 #include "SpectrumWidget.h"
 #include "WfmDeviceDialog.h"
 #ifdef HAVE_RADE
@@ -1350,17 +1351,15 @@ void MainWindow::deactivateWFM()
     reflectWfmButtons(false, deactivatedSliceId);
 }
 
-// Mirror the real demod state onto both per-slice WFM toggles. Each surface
-// self-gates on its own slice, so passing the affected sliceId is enough; the
-// setWfmActive() setters block their button's signal, so this never loops back
-// through the wfmActivated handlers.
+// Mirror the real demod state onto the WFM toggle in the spectrum overlay DAX
+// menu (the single WFM surface). It self-gates on its own slice, so passing the
+// affected sliceId is enough; setWfmActive() blocks the button's signal, so this
+// never loops back through the wfm handler.
 void MainWindow::reflectWfmButtons(bool on, int sliceId)
 {
-    if (auto* rx = m_appletPanel ? m_appletPanel->rxApplet() : nullptr)
-        rx->setWfmActive(on, sliceId);
     if (auto* sw = spectrumForSlice(m_radioModel.slice(sliceId))) {
-        if (auto* vfo = sw->vfoWidget(sliceId))
-            vfo->setWfmActive(on, sliceId);
+        if (auto* menu = sw->overlayMenu())
+            menu->setWfmActive(on, sliceId);
     }
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2128,6 +2128,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 .arg(applet->panId()).arg(channel));
     });
 
+    // WFM software-demod toggle from the DAX panel. Acts on the menu's slice;
+    // WFM is mode-independent (raw IQ from this pan's DAX stream). Mirrors the
+    // VFO-flag toggle's deactivate guard: only the WFM slice may deactivate,
+    // and not during the activation cooldown. (#3853)
+    connect(menu, &SpectrumOverlayMenu::wfmToggleRequested,
+            this, [this](bool on, int sliceId) {
+        if (on) activateWFM(sliceId);
+        else if (sliceId == m_wfmSliceId && !m_wfmCooldown) deactivateWFM();
+    });
+
     // Sync DAX IQ combo from radio status + restore saved assignment (#1221)
     {
         auto* pan = m_radioModel.panadapter(applet->panId());
@@ -3260,11 +3270,8 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
 #endif
 
-    connect(w, &VfoWidget::wfmActivated, this, [this](bool on, int sliceId) {
-        if (on) activateWFM(sliceId);
-        // Same policy as the RxApplet handler: slice-gated, cooldown-debounced.
-        else if (sliceId == m_wfmSliceId && !m_wfmCooldown) deactivateWFM();
-    });
+    // WFM is toggled from the spectrum overlay DAX menu (wired in the per-pan
+    // setup beside daxIqChannelChanged), not the flag — no connect here. (#3853)
 
     // AetherDSP button on the per-slice DSP tab — same entry point as the
     // Settings menu action and the RX chain double-click; reuses the

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -520,8 +520,8 @@ void RxApplet::buildUI()
             QString mode = m_modeCombo->currentText();
             // Selecting a real radio mode tears down the WFM software-demod
             // overlay if it was running on this slice. ("WFM" is never an
-            // entry in m_modeCombo — it has its own toggle button — so there
-            // is no "turn WFM on" branch here.)
+            // entry in m_modeCombo — it is toggled from the VFO-flag WFM
+            // button — so there is no "turn WFM on" branch here.)
             emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
 #ifdef HAVE_RADE
             if (mode == "RADE") {
@@ -538,24 +538,6 @@ void RxApplet::buildUI()
             if (m_slice) m_slice->setMode(mode);
         });
         m_freqRow->addWidget(m_modeCombo);
-
-        m_wfmButton = new QPushButton("WFM");
-        m_wfmButton->setCheckable(true);
-        m_wfmButton->setFixedSize(36, 20);
-        m_wfmButton->setToolTip("Software FM demodulator via DAX IQ → Hi-Fi Cable");
-        m_wfmButton->setStyleSheet(
-            "QPushButton { background: #444; color: #ccc; border: 1px solid #666;"
-            " border-radius: 3px; font-size: 10px; font-weight: bold; padding: 0 2px; }"
-            "QPushButton:checked { background: #2a7; color: #fff; border-color: #2a7; }"
-            "QPushButton:hover { background: #555; }");
-        connect(m_wfmButton, &QPushButton::toggled, this, [this](bool on) {
-            if (on) {
-                emit wfmActivated(true, m_slice ? m_slice->sliceId() : -1);
-            } else {
-                emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
-            }
-        });
-        m_freqRow->addWidget(m_wfmButton);
 
         m_freqStack = new QStackedWidget;
         m_freqStack->setFixedHeight(34);
@@ -1453,13 +1435,6 @@ void RxApplet::setAfGain(int pct)
 {
     QSignalBlocker b(m_afSlider);
     m_afSlider->setValue(pct);
-}
-
-void RxApplet::setWfmActive(bool on, int sliceId)
-{
-    if (!m_wfmButton || !m_slice || m_slice->sliceId() != sliceId) return;
-    QSignalBlocker b(m_wfmButton);
-    m_wfmButton->setChecked(on);
 }
 
 // ─── Slice wiring ─────────────────────────────────────────────────────────────

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -143,13 +143,6 @@ signals:
     void wfmActivated(bool on, int sliceId);
 
 public:
-    // Reflect the real WFM demodulator state (owned by MainWindow) back onto
-    // the WFM toggle button, WITHOUT re-emitting wfmActivated. Self-gated on
-    // this applet's slice so a state change on another slice is ignored.
-    // Keeps the RxApplet and VfoWidget WFM buttons from desyncing when the
-    // demod is toggled from the other surface or torn down by a mode change.
-    void setWfmActive(bool on, int sliceId);
-
     void setInitialStepSize(int hz);
 
     // Mode-aware filter width formatter, shared with VfoWidget so the two
@@ -223,7 +216,6 @@ private:
     QHBoxLayout* m_freqRow{nullptr};       // frequency display row
     QPushButton* m_txBadge{nullptr};       // TX slice indicator (click to set as TX slice)
     QComboBox*   m_modeCombo{nullptr};     // mode selector (USB, LSB, CW, etc.)
-    QPushButton* m_wfmButton{nullptr};     // WFM software demodulator toggle
     QLabel*      m_freqLabel{nullptr};     // frequency readout e.g. "14.289.510"
     QLineEdit*   m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -900,8 +900,40 @@ void SpectrumOverlayMenu::buildDaxPanel()
             emit daxIqChannelChanged(idx);
     });
 
+    // WFM software demodulator toggle. WFM demodulates this pan's DAX IQ stream
+    // on the PC (mode-independent, raw IQ) for the menu's slice — so it lives
+    // here, right below the IQ-channel selector it depends on. (#3853)
+    m_wfmBtn = new QPushButton("WFM");
+    m_wfmBtn->setCheckable(true);
+    m_wfmBtn->setToolTip(
+        tr("Software FM demodulator (DAX IQ → Hi-Fi Cable). Demodulates this "
+           "pan's DAX IQ stream for the active slice; mode-independent."));
+    m_wfmBtn->setStyleSheet(
+        "QPushButton { background: #444; color: #ccc; border: 1px solid #666;"
+        " border-radius: 3px; font-size: 11px; font-weight: bold; padding: 2px 8px; }"
+        "QPushButton:checked { background: #2a7; color: #fff; border-color: #2a7; }"
+        "QPushButton:hover { background: #555; }");
+    connect(m_wfmBtn, &QPushButton::toggled, this, [this](bool on) {
+        if (m_updatingFromModel) return;
+        if (!m_slice) {
+            // No slice to demod — un-stick the toggle without emitting.
+            QSignalBlocker sb(m_wfmBtn);
+            m_wfmBtn->setChecked(false);
+            return;
+        }
+        emit wfmToggleRequested(on, m_slice->sliceId());
+    });
+    vb->addWidget(m_wfmBtn);
+
     m_daxPanel->setFixedWidth(140);
     m_daxPanel->adjustSize();
+}
+
+void SpectrumOverlayMenu::setWfmActive(bool on, int sliceId)
+{
+    if (!m_wfmBtn || !m_slice || m_slice->sliceId() != sliceId) return;
+    QSignalBlocker sb(m_wfmBtn);
+    m_wfmBtn->setChecked(on);
 }
 
 void SpectrumOverlayMenu::syncDaxPanel()

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -88,6 +88,10 @@ public:
     // VHF row will disappear.  Triggers a band-panel rebuild. (#695)
     void setRadioCapabilities(ModelCapabilities caps);
     void syncDaxIqChannel(int channel);
+    // Reflect the real WFM demodulator state onto the DAX-panel WFM toggle
+    // WITHOUT re-emitting wfmToggleRequested. Self-gated on this menu's slice,
+    // so a state change on another slice is ignored. (#3853)
+    void setWfmActive(bool on, int sliceId);
     // DSP button accessors and the DSP sub-panel were removed — radio-
     // side DSP lives on VfoWidget only, client-side DSP lives on the
     // AetherDSP applet only.
@@ -104,6 +108,9 @@ signals:
     void memoryActivated(int memoryIndex, const QString& panId);
     void quickAddMemoryRequested(const QString& panId);
     void daxIqChannelChanged(int channel);  // 0=Off, 1-4
+    // WFM software-demod toggle in the DAX panel. Acts on this menu's slice;
+    // WFM is mode-independent (raw IQ from this pan's DAX stream). (#3853)
+    void wfmToggleRequested(bool on, int sliceId);
     void addPanClicked();
     void daxClicked();
     // DSP-related signals (nr2Toggled / rn2Toggled / bnrToggled /
@@ -237,9 +244,10 @@ private:
     QPushButton* m_swrClearBtn{nullptr};
 
     // DAX sub-panel
-    QWidget*   m_daxPanel{nullptr};
-    bool       m_daxPanelVisible{false};
-    QComboBox* m_daxIqCmb{nullptr};
+    QWidget*     m_daxPanel{nullptr};
+    bool         m_daxPanelVisible{false};
+    QComboBox*   m_daxIqCmb{nullptr};
+    QPushButton* m_wfmBtn{nullptr};   // WFM software-demod toggle (#3853)
 
     // Memory browse sub-panel
     MemoryBrowsePanel* m_memoryPanel{nullptr};

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2285,17 +2285,9 @@ void VfoWidget::buildTabContent()
             modeRow->addWidget(btn, 1);
         }
 
-        // WFM software demodulator toggle (DAX IQ → Hi-Fi Cable)
-        m_wfmBtn = new QPushButton("WFM");
-        m_wfmBtn->setCheckable(true);
-        m_wfmBtn->setFixedHeight(26);
-        m_wfmBtn->setVisible(false);
-        m_wfmBtn->setToolTip("Software FM demodulator: DAX IQ → Hi-Fi Cable Input");
-        m_wfmBtn->setStyleSheet(kModeBtn);
-        connect(m_wfmBtn, &QPushButton::toggled, this, [this](bool on) {
-            emit wfmActivated(on, m_slice ? m_slice->sliceId() : -1);
-        });
-        modeRow->addWidget(m_wfmBtn, 1);
+        // WFM software-demod toggle lives in the spectrum overlay DAX menu
+        // (mode-independent, beside the IQ-channel selector it consumes); it is
+        // no longer on the flag. (#3853)
 
         vb->addLayout(modeRow);
 
@@ -2947,13 +2939,6 @@ void VfoWidget::setAfGain(int pct)
         m_afGainSlider->setValue(pct);
         m_updatingFromModel = false;
     }
-}
-
-void VfoWidget::setWfmActive(bool on, int sliceId)
-{
-    if (!m_wfmBtn || !m_slice || m_slice->sliceId() != sliceId) return;
-    QSignalBlocker sb(m_wfmBtn);
-    m_wfmBtn->setChecked(on);
 }
 
 void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
@@ -3943,12 +3928,6 @@ void VfoWidget::setSlice(SliceModel* slice)
         bool isFdv  = mode.startsWith("FDV");  // FDVU, FDVM, etc.
         // Swap DSP tab label to OPT for FM modes
         m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
-        if (!isFm && m_wfmBtn->isChecked()) {
-            QSignalBlocker sb(m_wfmBtn);
-            m_wfmBtn->setChecked(false);
-            emit wfmActivated(false, m_slice ? m_slice->sliceId() : -1);
-        }
-        m_wfmBtn->setVisible(isFm);
         m_rttyContainer->setVisible(isRtty);
         m_apfContainer->setVisible(isCw);
         m_digContainer->setVisible(isDig && !isFdv && mode != "NT");
@@ -4522,12 +4501,6 @@ void VfoWidget::syncFromSlice()
     bool isDig = (m_slice->mode() == "DIGL" || m_slice->mode() == "DIGU" || m_slice->mode() == "NT");
     bool isFm = (m_slice->mode() == "FM" || m_slice->mode() == "NFM");
     m_tabBtns[1]->setText(isFm ? "OPT" : "DSP");
-    if (!isFm && m_wfmBtn->isChecked()) {
-        QSignalBlocker sb(m_wfmBtn);
-        m_wfmBtn->setChecked(false);
-        emit wfmActivated(false, m_slice->sliceId());
-    }
-    m_wfmBtn->setVisible(isFm);
     m_apfBtn->setVisible(isCw);
     m_anfBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);
     m_anflBtn->setVisible(!isRtty && !isCw && !isDig && !isFm);

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -4804,6 +4804,17 @@ void VfoWidget::updateModeTab()
         m_filterCustomHi.fill(INT_MIN, m_filterWidths.size());
     }
     rebuildFilterButtons();
+
+    // The filter-preset grid's row count changes with mode (FM has no preset
+    // grid; voice modes have 2+ rows). Rebuilding it here changes the mode-tab
+    // page height, but the synchronous relayout on the same turn can read a
+    // stale page sizeHint before the new grid geometry settles — leaving the
+    // panel too short when growing back (FM -> LSB/USB), so the filter rows
+    // overflow the flag. Defer a relayout to the next event-loop turn, once the
+    // rebuilt grid is fully laid out, so the panel resizes to fit. (#3853)
+    if (m_tabStack && m_tabStack->isVisible()) {
+        QTimer::singleShot(0, this, [this] { relayoutToCurrentContent(); });
+    }
 }
 
 void VfoWidget::updateQuickModeButtons()

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -137,13 +137,6 @@ public:
     void setRadeCallsign(const QString& callsign);
 #endif
 
-    // Reflect the real WFM demodulator state (owned by MainWindow) back onto
-    // the WFM toggle button, WITHOUT re-emitting wfmActivated. Self-gated on
-    // this widget's slice so a state change on another slice is ignored.
-    // Keeps the VfoWidget and RxApplet WFM buttons from desyncing when the
-    // demod is toggled from the other surface or torn down by a mode change.
-    void setWfmActive(bool on, int sliceId);
-
 Q_SIGNALS:
     void afGainChanged(int value);
     void audioMuteToggled(bool on);   // per-slice AF mute changed by user (#1560)
@@ -155,7 +148,6 @@ Q_SIGNALS:
 #ifdef HAVE_RADE
     void radeActivated(bool on, int sliceId);
 #endif
-    void wfmActivated(bool on, int sliceId);
     void recordToggled(bool on);
     void playToggled(bool on);
     void aetherDspRequested();     // user clicked the ADSP button on the DSP tab
@@ -493,7 +485,6 @@ private:
     QComboBox* m_modeCombo{nullptr};
     QPushButton* m_quickModeBtns[3]{};
     QString      m_quickModeAssign[3];  // e.g. "USB", "CW", "SSB", "DIG"
-    QPushButton* m_wfmBtn{nullptr};
     void updateQuickModeButtons();
     QGridLayout* m_filterGrid{nullptr};
     QVector<QPushButton*> m_filterBtns;


### PR DESCRIPTION
## Summary

Two related flag fixes:

1. **WFM → single surface in the DAX pan menu.** Removes the WFM toggle from the RxApplet frequency row (where it clipped the frequency digits) and the FM-gated VFO flag, and adds a single toggle in the DAX pan overlay menu, directly below the **"IQ Ch"** selector — the natural home, since WFM demodulates that pan's DAX IQ stream and is mode-independent (always reachable).

2. **Flag mode-tab regrow fix** (pre-existing, surfaced during the WFM work). Switching **FM → LSB/USB** with the flag's Mode tab open left the panel too short, so the filter-preset grid overflowed/clipped.

## WFM relocation

WFM is **slice-keyed but pan-sourced**: it demodulates the slice's pan's DAX IQ stream on the PC (NCO → 48 kHz → discriminator → FIR → stereo to a VAC), with software Doppler. The "IQ Ch" dropdown selects exactly that stream, so the toggle belongs beside it.

- **RxApplet**: drop the WFM button + vestigial `setWfmActive()`; keep the mode-combo `wfmActivated(false)` teardown.
- **VfoWidget**: remove the FM-gated WFM button, its `setWfmActive()` reflector, the `wfmActivated` signal, and the FM gating.
- **SpectrumOverlayMenu**: add the WFM toggle below "IQ Ch"; emit `wfmToggleRequested(on, sliceId)`; self-gated `setWfmActive()` reflector.
- **MainWindow_Wiring**: route the toggle to `activateWFM`/`deactivateWFM`.
- **reflectWfmButtons**: drive the single DAX-menu toggle.

## Flag mode-tab regrow fix

Root cause: `updateModeTab()` rebuilds the filter-preset grid (FM has no grid; voice modes have 2+ rows), but the **synchronous** relayout on the same turn read a stale page `sizeHint` before the new grid geometry settled — so growing FM→voice landed at the FM height. Fix: defer one `relayoutToCurrentContent()` to the next event-loop turn from `updateModeTab()`, covering both mode-change paths.

**Verified via the automation bridge** driving USB→FM→USB with the Mode tab open:

| Transition | Before | After | Correct |
|---|---|---|---|
| → FM | 234 (didn't shrink) | 178 | 178 ✓ |
| FM → USB | 178 ❌ | 234 ✅ | 234 ✓ |
| FM → LSB | 178 ❌ | 234 ✅ | 234 ✓ |

## Behavior notes

- Frequency digits no longer clip; WFM reachable from the DAX pan menu in any mode.
- With WFM no longer FM-gated, leaving FM on the flag no longer auto-tears-down the demod (raw-IQ, mode-independent); an explicit RxApplet mode change still tears it down.

## Test plan

- [x] Builds clean (`cmake --build build --target AetherSDR`)
- [x] FLEX-8600: digits no longer clip; WFM toggles from DAX menu; FM↔voice flag panel resizes correctly (bridge-verified heights above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
