### PR TITLE
fix(spectrum): free the waterfall stream when closing a panafall (#3843)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Closing a panafall-created panadapter now frees its waterfall stream on the
+  radio.** The close path sent only `display pan remove` and never the matching
+  `display panafall remove`, so the waterfall stream was left allocated on the
+  radio (the FlexLib-correct teardown is the pair Panadapter.Close +
+  Waterfall.Close). `RadioModel::removePanadapter` now sends both commands
+  (capturing the waterfall id before the removal echo deletes the model), and the
+  GUI X-button and layout-shrink close paths both route through it as the single
+  source of truth — replacing the dead, bogus `display pan close` it used to
+  issue. (#3843)
+
+### Changed
+
+- **Agent automation bridge:** the `pan close` verb now drives the production
+  `RadioModel::removePanadapter` instead of duplicating the teardown commands, so
+  it exercises the real GUI close path. (#3843)
+
 ## [v26.6.4] — 2026-06-23
 
 ### KiwiSDR public-receiver browser + SmartMTR meter view + agent automation bridge + GPU-composite flags + accessibility

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2714,12 +2714,12 @@ QJsonObject AutomationServer::doShowMenu(const QString& target) const
 // `pan create|add` opens an independent panadapter; `pan center <mhz>` recenters
 // the active pan (the band-change lever — a plain `tune` only moves the slice and
 // clamps to the pan's RF range, #292); `pan close|remove <panId|index|active|all>`
-// tears one down regardless of how it was opened. Close sends the FlexLib-correct
-// pair `display pan remove` AND `display panafall remove` (panId + waterfallId),
-// so a panafall-created pan closes without the slice-removal workaround — the
-// production `RadioModel::removePanadapter` sends only `display pan close` and
-// leaves the waterfall behind (see #3843). Create is async (radio assigns the
-// pan_id), so a caller re-reads `get pans`.
+// tears one down regardless of how it was opened. Close routes through the
+// production RadioModel::removePanadapter, which sends the FlexLib-correct pair
+// `display pan remove` AND `display panafall remove` (panId + waterfallId), so a
+// panafall-created pan closes — waterfall and all — without the slice-removal
+// workaround (#3843). Create is async (radio assigns the pan_id), so a caller
+// re-reads `get pans`.
 QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
 {
     if (!m_radioModel)
@@ -2782,10 +2782,11 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
         for (const QString& pid : panIds) {
             const PanadapterModel* p = radio->panadapter(pid);
             const QString wfId = p ? p->waterfallId() : QString();
-            // FlexLib-correct teardown: the panadapter stream AND its waterfall.
-            radio->sendCommand(QStringLiteral("display pan remove ") + pid);
-            if (!wfId.isEmpty())
-                radio->sendCommand(QStringLiteral("display panafall remove ") + wfId);
+            // Single source of truth: drive the production teardown so this verb
+            // exercises the exact GUI close path. removePanadapter sends the
+            // FlexLib-correct pair "display pan remove" + "display panafall
+            // remove" for a panafall, so the waterfall is freed too. (#3843)
+            radio->removePanadapter(pid);
             QJsonObject o{{QStringLiteral("panId"), pid},
                           {QStringLiteral("resolved"), p != nullptr}};
             if (!wfId.isEmpty())

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -196,8 +196,9 @@ private:
     QJsonObject doShowMenu(const QString& target) const;
     // pan close <panId|index|active|all>: tear down a panadapter regardless of
     // how it was opened. Sends `display pan remove` AND `display panafall remove`
-    // (the FlexLib-correct pair) so a panafall-created pan closes too — the plain
-    // `display pan close` in removePanadapter leaves the waterfall behind. (#3646)
+    // (the FlexLib-correct pair) so a panafall-created pan closes too. The
+    // production GUI close path now does the same via RadioModel::removePanadapter
+    // (#3843). (#3646)
     QJsonObject doPan(const QString& action, const QString& arg);
     QJsonObject doGet(const QString& model, const QString& selector,
                       const QString& property) const;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7636,8 +7636,10 @@ void MainWindow::applyPanLayout(const QString& layoutId)
             QString panId = applet->panId();
             if (panId == "default") continue;
             qDebug() << "applyPanLayout: closing pan" << panId;
-            m_radioModel.sendCommand(
-                QString("display pan remove %1").arg(panId));
+            // Route through removePanadapter so a layout-shrink tears down the
+            // waterfall too ("display pan remove" + "display panafall remove"),
+            // not just the panadapter stream. (#3843)
+            m_radioModel.removePanadapter(panId);
             // Radio will send "removed" status → panadapterRemoved signal
             // → PanadapterStack::removePanadapter()
             --toRemove;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1772,7 +1772,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, [this](const QString& panId) {
         // Don't close the last pan
         if (m_panStack->count() <= 1) return;
-        m_radioModel.sendCommand(QString("display pan remove %1").arg(panId));
+        // Single source of truth for teardown: removePanadapter sends the
+        // FlexLib-correct "display pan remove" + "display panafall remove"
+        // pair, so a panafall-created pan also frees its waterfall. (#3843)
+        m_radioModel.removePanadapter(panId);
     });
 
     // ── User drag actions from spectrum → radio (per-pan) ──────────────────

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1836,8 +1836,24 @@ void RadioModel::createPanadapter()
 
 void RadioModel::removePanadapter(const QString& panId)
 {
-    qCDebug(lcProtocol) << "RadioModel::removePanadapter:" << panId;
-    sendCmd(QString("display pan close %1").arg(panId));
+    // A panafall (display panafall create) allocates BOTH a panadapter stream
+    // and a waterfall stream, and the radio does NOT free the waterfall when
+    // only the panadapter is removed. So the FlexLib-correct teardown is the
+    // pair Panadapter.Close() + Waterfall.Close() — "display pan remove" AND
+    // "display panafall remove" (FlexLib v4.2.18). Sending only the first (or
+    // the bogus "display pan close", which is not a command at all) leaves the
+    // waterfall stream alive on the radio. (#3843)
+    //
+    // Capture the waterfall id BEFORE sending: the "display pan <id> removed"
+    // echo deletes the PanadapterModel in onStatusReceived, so reading it
+    // afterwards would race the teardown.
+    const PanadapterModel* pan = m_panadapters.value(panId, nullptr);
+    const QString wfId = pan ? pan->waterfallId() : QString();
+    qCDebug(lcProtocol) << "RadioModel::removePanadapter:" << panId
+                        << "waterfall:" << (wfId.isEmpty() ? QStringLiteral("(none)") : wfId);
+    sendCommand(QStringLiteral("display pan remove ") + panId);
+    if (!wfId.isEmpty())
+        sendCommand(QStringLiteral("display panafall remove ") + wfId);
     // Radio will send "display pan <id> removed" → handled in onStatusReceived
 }
 


### PR DESCRIPTION
## What

Closing a **panafall-created** panadapter never freed its **waterfall stream on the radio**. The FlexLib-correct teardown is the pair `Panadapter.Close()` + `Waterfall.Close()` — i.e. **both** `display pan remove 0x<panId>` **and** `display panafall remove 0x<wfStreamId>` (FlexLib v4.2.18) — but the close path sent only the first.

Two defects from the issue, both addressed:

1. **Dead + bogus public API.** `RadioModel::removePanadapter` issued `display pan close`, which is **not a FlexLib command at all**, and had **zero callers** — a latent trap.
2. **Live close path omitted the waterfall removal.** The GUI X-button and the layout-shrink path each sent an inline `display pan remove` only, so the panafall's waterfall stream was left allocated on the radio.

The client-side cleanup was already complete (the `display pan <id> removed` echo unregisters *both* streams), so `get pans` always read clean — which is precisely why this radio-side leak went unnoticed.

Fixes #3843.

## The fix

- **`RadioModel::removePanadapter`** now captures the waterfall id **before** sending (the removal echo deletes the `PanadapterModel`, which would otherwise race the read) and sends `display pan remove` **plus** `display panafall remove` when a waterfall is present.
- **Single source of truth:** the X-button handler (`MainWindow_Wiring`) and the layout-shrink path (`MainWindow::applyPanLayout`) both route through `removePanadapter` instead of inlining `display pan remove`.
- The automation bridge **`pan close`** verb now also drives `removePanadapter`, so it exercises the exact production teardown (and DRYs up the duplicated command pair).

Tightly scoped to the close-path bug. A radio-side **stream-inventory diagnostic** to make this class of leak directly observable (and to catch *resource-level* lingering / duplicate pans) is split out into its own feature request so this fix stays minimal and low-risk.

## How the agent automation bridge proved it

Driven against a **live FLEX-8400M (firmware 4.2.18)**. A leak-repro build (panafall-remove omitted) and the fixed build were each driven through the **production** close path (`pan close` → `removePanadapter`), capturing the radio command stream:

| Build | `display pan remove` | `display panafall remove` |
|---|---|---|
| **Broken baseline** | ✅ `display pan remove 0x40000001` | ❌ **absent** |
| **Fixed** | ✅ `display pan remove 0x40000001` | ✅ **`display panafall remove 0x42000001`** |

Broken-build capture:
```
RadioModel::removePanadapter: "0x40000001" waterfall: "0x42000001"
RadioModel::sendCommand: "display pan remove 0x40000001"
(no display panafall remove)
```
Fixed-build capture:
```
RadioModel::removePanadapter: "0x40000001" waterfall: "0x42000001"
RadioModel::sendCommand: "display pan remove 0x40000001"
RadioModel::sendCommand: "display panafall remove 0x42000001"
```

**Firmware note:** on this radio the waterfall UDP stops on pan-removal regardless, so the leak here is the waterfall *object* left allocated rather than continued UDP — the command-level capture above is the decisive evidence that the radio is now correctly *told* to free it. Continued-UDP waterfall leaks do occur on older (#268-class) firmware.

## Test plan

- [x] Builds clean (Ninja, RelWithDebInfo, arm64).
- [x] Live FLEX-8400M: production close path sends the FlexLib-correct command pair (before/after capture above).
- [ ] Maintainer review (label present on the issue).

## Related
- #268 — distinct glitch-corruption Multi-Flex case (Pan 2 FFT blank, stuck); different root cause.
- #269 — restored broken pan state on restart.
- #3212 — duplicate-panadapter on reconnect (fixed via `SliceRecreatePolicy`).
- PR #3842 — automation-bridge `pan close` verb that first proved the correct teardown.
- Follow-up: radio-side stream-inventory / leak-detection feature request (filed separately).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
