### PR TITLE
feat(automation): radio-side display-stream inventory + leak detection (streams verb) (#3856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **Agent automation bridge:** the `pan close` verb now drives the production
   `RadioModel::removePanadapter` instead of duplicating the teardown commands, so
   it exercises the real GUI close path. (#3843)
+- **Agent automation bridge — radio-side display-stream inventory + leak
+  detection (`streams` verb).** Makes leaked/duplicate panadapter & waterfall
+  streams on the radio directly observable — a class of bug `get pans` can't show,
+  because the client always cleans up its own view. Two layers: `streams` reports
+  the VITA-49 UDP truth (streams the radio is still transmitting for an id we no
+  longer own — the #268 continued-stream class), and `streams radio` reports the
+  radio-authoritative display-object set classified ours/foreign/orphan with
+  leaked waterfalls (parent panadapter gone) — catching resource-level lingering
+  that emits no UDP (the #3843 class on firmware that stops the stream on
+  pan-removal). `streams reset` re-baselines. RX/observe only. See
+  `docs/automation-bridge.md`. (#3856)
 
 ## [v26.6.4] — 2026-06-23
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2086,6 +2086,14 @@ target_include_directories(slice_recreate_policy_test PRIVATE src)
 target_link_libraries(slice_recreate_policy_test PRIVATE Qt6::Core)
 add_test(NAME slice_recreate_policy_test COMMAND slice_recreate_policy_test)
 
+# #3856 — radio-side display inventory policy (Layer B leak classification)
+add_executable(display_inventory_policy_test
+    tests/display_inventory_policy_test.cpp
+)
+target_include_directories(display_inventory_policy_test PRIVATE src)
+target_link_libraries(display_inventory_policy_test PRIVATE Qt6::Core)
+add_test(NAME display_inventory_policy_test COMMAND display_inventory_policy_test)
+
 add_executable(shortcut_manager_test
     tests/shortcut_manager_test.cpp
     src/core/ShortcutManager.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -404,6 +404,62 @@ connects. `connect wait <timeout_ms>` holds that request's response until
 `RadioModel::connectionStateChanged(true)` or timeout, which is the preferred
 unattended "request then assert" flow.
 
+### `streams`
+Radio-side display-stream inventory + leak detector (#3856). `get pans` can never
+show a radio-side leak — the client tears down its own view on the radio's
+`removed` echo, so it always looks clean. This verb reports two **independent
+radio-authoritative** views, plus a reset:
+
+**`streams` — Layer A (VITA-49 UDP truth).** Streams the radio is *still
+transmitting* for an id the client no longer owns: a stream we once registered
+and let go of that keeps arriving (e.g. a panafall closed without `display
+panafall remove`, on firmware that keeps streaming — the #268 class).
+
+```json
+→ {"cmd":"streams"}
+← {"ok":true,"scope":"udp",
+   "registeredPanStreams":["0x40000000"],
+   "registeredWfStreams":["0x42000000"],
+   "orphanStreams":[{"streamId":"0x42000001","kind":"waterfall","packets":214,"age_ms":48}],
+   "orphanCount":1}
+```
+An orphan whose `packets` climbs across reads with small `age_ms` is a **live
+leak**; one that stops growing was a brief in-flight tail. (Keyed off
+*ever-registered ∧ not-now-registered*, so it stays detectable after `pan close
+all` and never mis-flags a freshly-created stream's registration lag.)
+
+**`streams radio` — Layer B (status-bookkeeping truth).** The radio's full
+display-object set (every pan + waterfall it reports, accumulated from status and
+pruned on `removed`), classified `ours` / `foreign` / `orphan`, with **leaked
+waterfalls** = those whose parent panadapter no longer exists. This catches the
+resource-level lingering Layer A *can't* see — a waterfall the radio keeps
+allocated but no longer streams (the #3843 case on firmware that stops the UDP on
+pan-removal).
+
+```json
+→ {"cmd":"streams","action":"radio"}
+← {"ok":true,"scope":"radio",
+   "pans":[{"panId":"0x40000000","clientHandle":"0x5a3","ownership":"ours"}],
+   "waterfalls":[
+     {"waterfallId":"0x42000000","clientHandle":"0x5a3","ownership":"ours","parentPanId":"0x40000000","parentMissing":false},
+     {"waterfallId":"0x42000001","clientHandle":"0x5a3","ownership":"orphan","parentPanId":"0x40000001","parentMissing":true}],
+   "radioPanCount":1,"radioWaterfallCount":2,
+   "orphanPanCount":0,"orphanWaterfallCount":1,"foreignPanCount":0,"foreignWaterfallCount":0,
+   "leakedWaterfalls":["0x42000001"],"leakCount":1}
+```
+
+**`streams reset`** — clear the Layer-A orphan tally to re-baseline a before/after
+measurement.
+
+| `action` | layer | effect |
+|---|---|---|
+| — (default) | A | UDP-orphan inventory: registered streams + orphan streams (`streamId`, `kind`, `packets`, `age_ms`) |
+| `radio` (alias `inventory`) | B | radio-authoritative display-object set: pans + waterfalls classified ours/foreign/orphan, plus `leakedWaterfalls` |
+| `reset` | A | clear the orphan tally |
+
+All `streams` actions are read-only / RX; none sends a radio command or keys the
+transmitter.
+
 ### Errors
 Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
 `widget not found: Foo`, `blocked: '…' looks transmit-related …`,

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1228,8 +1228,8 @@ bool AutomationServer::start(const QString& serverName)
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, invoke, get, connect, disconnect,"
-        << "txtest, atu, slice, tune, pan, txwaterfall, key, cwx, station, resize, menu,"
-        << "close, drag, showMenu, whoami, log, mark)";
+        << "txtest, atu, slice, tune, pan, streams, txwaterfall, key, cwx, station, resize,"
+        << "menu, close, drag, showMenu, whoami, log, mark)";
     return true;
 }
 
@@ -1480,6 +1480,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));  // "cwx send CQ CQ DE ...", "cwx speed 18"
         } else if (cmd == QLatin1String("pan")) {
             action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
+        } else if (cmd == QLatin1String("streams")) {
+            action = tok(1);  // "" (Layer A UDP-orphan) | "radio" (Layer B) | "reset"
         } else if (cmd == QLatin1String("txwaterfall")) {
             value = tok(1);                   // on | off
         } else if (cmd == QLatin1String("key")) {
@@ -1595,6 +1597,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("pan requires an action (create|add|remove|close|center)"));
         return doPan(action, value);
     }
+    if (cmd == QLatin1String("streams"))
+        return doStreams(action);
     if (cmd == QLatin1String("txwaterfall")) {
         // Radio-authoritative display flag (`transmit set show_tx_in_waterfall`)
         // that gates whether keyed-up TX renders FFT-derived rows in the
@@ -3234,6 +3238,110 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
 
     return err(QStringLiteral("unknown pan action: ") + action
                + QStringLiteral(" (create|add|remove|close|center)"));
+}
+
+// ── Radio-side display-stream inventory / leak detector (#3856) ──────────────
+// `get pans` can never show a radio-side leak: the client tears down its own
+// view on the "removed" echo, so it always looks clean. This verb reports two
+// independent radio-authoritative views:
+//   Layer A (`streams`)      — VITA-49 UDP truth: streams the radio is STILL
+//                              transmitting for an id we no longer own (catches
+//                              continued-UDP leaks, the #268 class).
+//   Layer B (`streams radio`)— status-bookkeeping truth: the radio's full
+//                              display-object set classified ours/foreign/orphan,
+//                              with leaked waterfalls (parent pan gone) — catches
+//                              resource-level lingering that emits no UDP (#3843).
+// `streams reset` clears the Layer-A orphan tally to re-baseline a before/after.
+QJsonObject AutomationServer::doStreams(const QString& action)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+
+    const auto hex = [](quint32 id) {
+        return QStringLiteral("0x") + QString::number(id, 16);
+    };
+    const auto ownStr = [](DisplayInventory::Ownership o) {
+        switch (o) {
+        case DisplayInventory::Ownership::Ours:    return QStringLiteral("ours");
+        case DisplayInventory::Ownership::Foreign: return QStringLiteral("foreign");
+        default:                                   return QStringLiteral("orphan");
+        }
+    };
+
+    // Layer B — radio-authoritative display-object inventory.
+    if (action.compare(QLatin1String("radio"), Qt::CaseInsensitive) == 0
+        || action.compare(QLatin1String("inventory"), Qt::CaseInsensitive) == 0) {
+        const DisplayInventory::Report rep = m_radioModel->displayInventoryReport();
+        QJsonArray pans;
+        for (const auto& p : rep.pans)
+            pans.append(QJsonObject{{QStringLiteral("panId"), p.id},
+                                    {QStringLiteral("clientHandle"), hex(p.clientHandle)},
+                                    {QStringLiteral("ownership"), ownStr(p.ownership)}});
+        QJsonArray wfs;
+        for (const auto& w : rep.waterfalls) {
+            QJsonObject o{{QStringLiteral("waterfallId"), w.id},
+                          {QStringLiteral("clientHandle"), hex(w.clientHandle)},
+                          {QStringLiteral("ownership"), ownStr(w.ownership)},
+                          {QStringLiteral("parentMissing"), w.parentMissing}};
+            if (!w.parentPanId.isEmpty())
+                o[QStringLiteral("parentPanId")] = w.parentPanId;
+            wfs.append(o);
+        }
+        QJsonArray leaked;
+        for (const auto& id : rep.leakedWaterfalls) leaked.append(id);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("scope"), QStringLiteral("radio")},
+            {QStringLiteral("pans"), pans},
+            {QStringLiteral("waterfalls"), wfs},
+            {QStringLiteral("radioPanCount"), rep.pans.size()},
+            {QStringLiteral("radioWaterfallCount"), rep.waterfalls.size()},
+            {QStringLiteral("orphanPanCount"), rep.orphanPanCount},
+            {QStringLiteral("orphanWaterfallCount"), rep.orphanWfCount},
+            {QStringLiteral("foreignPanCount"), rep.foreignPanCount},
+            {QStringLiteral("foreignWaterfallCount"), rep.foreignWfCount},
+            {QStringLiteral("leakedWaterfalls"), leaked},
+            {QStringLiteral("leakCount"), leaked.size()},
+        };
+    }
+
+    // Layer A — VITA-49 UDP-orphan detector (needs the stream receiver).
+    PanadapterStream* ps = m_radioModel->panStream();
+    if (!ps)
+        return err(QStringLiteral("no panadapter stream available"));
+
+    if (action.compare(QLatin1String("reset"), Qt::CaseInsensitive) == 0) {
+        ps->resetOrphanStreams();
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("streams"), QStringLiteral("reset")}};
+    }
+    if (!action.isEmpty())
+        return err(QStringLiteral("unknown streams action: ") + action
+                   + QStringLiteral(" (use '' for UDP-orphan, 'radio' for inventory, or 'reset')"));
+
+    QJsonArray panReg;
+    for (quint32 id : ps->registeredPanStreams()) panReg.append(hex(id));
+    QJsonArray wfReg;
+    for (quint32 id : ps->registeredWfStreams()) wfReg.append(hex(id));
+
+    QJsonArray orphans;
+    for (const auto& o : ps->orphanStreams())
+        orphans.append(QJsonObject{
+            {QStringLiteral("streamId"), hex(o.streamId)},
+            {QStringLiteral("kind"), o.waterfall ? QStringLiteral("waterfall")
+                                                 : QStringLiteral("panadapter")},
+            {QStringLiteral("packets"), static_cast<qint64>(o.packets)},
+            {QStringLiteral("age_ms"), o.ageMs},
+        });
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("scope"), QStringLiteral("udp")},
+        {QStringLiteral("registeredPanStreams"), panReg},
+        {QStringLiteral("registeredWfStreams"), wfReg},
+        {QStringLiteral("orphanStreams"), orphans},
+        {QStringLiteral("orphanCount"), orphans.size()},
+    };
 }
 
 QJsonObject AutomationServer::doWhoami() const

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -220,6 +220,15 @@ private:
     // production GUI close path now does the same via RadioModel::removePanadapter
     // (#3843). (#3646)
     QJsonObject doPan(const QString& action, const QString& arg);
+    // Radio-side display-stream inventory / leak detector (#3856).
+    //   streams        — Layer A: registered pan/wf streams + UDP "orphan"
+    //                     streams the radio is still transmitting that we let go.
+    //   streams radio   — Layer B: the radio-authoritative display-object set
+    //                     (pans + waterfalls) classified ours/foreign/orphan,
+    //                     plus leaked waterfalls (parent pan gone) — catches the
+    //                     resource-level lingering Layer A can't see.
+    //   streams reset   — clear the Layer-A orphan tally to re-baseline.
+    QJsonObject doStreams(const QString& action);
     QJsonObject doGet(const QString& model, const QString& selector,
                       const QString& property) const;
     QJsonObject doConnect(const QString& action, const QString& arg, QLocalSocket* sock);

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -415,6 +415,8 @@ void PanadapterStream::registerPanStream(quint32 streamId)
 {
     QMutexLocker lock(&m_streamMutex);
     m_knownPanStreams.insert(streamId);
+    m_everRegisteredPanStreams.insert(streamId);   // arms leak detection (#3856)
+    m_orphanStreams.remove(streamId);              // reclaim drops stale orphan
     qCDebug(lcVita49) << "PanadapterStream: registered pan stream 0x" + QString::number(streamId, 16);
 }
 
@@ -422,6 +424,8 @@ void PanadapterStream::registerWfStream(quint32 streamId)
 {
     QMutexLocker lock(&m_streamMutex);
     m_knownWfStreams.insert(streamId);
+    m_everRegisteredWfStreams.insert(streamId);    // arms leak detection (#3856)
+    m_orphanStreams.remove(streamId);              // reclaim drops stale orphan
     qCDebug(lcVita49) << "PanadapterStream: registered wf stream 0x" + QString::number(streamId, 16);
 }
 
@@ -458,8 +462,41 @@ void PanadapterStream::clearRegisteredStreams()
     // the disconnect-time reset hook, so anything keyed by VITA-49 stream
     // id can be cleared safely (#2738).
     m_audioPlc.clear();
+    m_orphanStreams.clear();
+    m_everRegisteredPanStreams.clear();   // new session — re-arm from scratch (#3856)
+    m_everRegisteredWfStreams.clear();
     resetAudioStreamStats();
     qCDebug(lcVita49) << "PanadapterStream: cleared all registered streams";
+}
+
+QVector<PanadapterStream::OrphanStream> PanadapterStream::orphanStreams() const
+{
+    QMutexLocker lock(&m_streamMutex);
+    const qint64 now = m_orphanClock.isValid() ? m_orphanClock.elapsed() : 0;
+    QVector<OrphanStream> out;
+    out.reserve(m_orphanStreams.size());
+    for (auto it = m_orphanStreams.cbegin(); it != m_orphanStreams.cend(); ++it)
+        out.push_back(OrphanStream{it.key(), it->waterfall, it->packets,
+                                   now - it->lastSeenMs});
+    return out;
+}
+
+QVector<quint32> PanadapterStream::registeredPanStreams() const
+{
+    QMutexLocker lock(&m_streamMutex);
+    return QVector<quint32>(m_knownPanStreams.cbegin(), m_knownPanStreams.cend());
+}
+
+QVector<quint32> PanadapterStream::registeredWfStreams() const
+{
+    QMutexLocker lock(&m_streamMutex);
+    return QVector<quint32>(m_knownWfStreams.cbegin(), m_knownWfStreams.cend());
+}
+
+void PanadapterStream::resetOrphanStreams()
+{
+    QMutexLocker lock(&m_streamMutex);
+    m_orphanStreams.clear();
 }
 
 void PanadapterStream::setDbmRange(quint32 streamId, float minDbm, float maxDbm, bool waitForEcho)
@@ -602,6 +639,35 @@ void PanadapterStream::processDatagram(const QByteArray& data)
         }
         isPan = m_knownPanStreams.isEmpty() || m_knownPanStreams.contains(streamId);
         isWf  = m_knownWfStreams.isEmpty() || m_knownWfStreams.contains(streamId);
+
+        // #3856 Layer A leak detector: a display packet for a stream we ONCE
+        // registered but no longer own is a stream the radio is still sending
+        // after we let it go — e.g. a waterfall left alive by a panafall close
+        // that omitted "display panafall remove". Keying off "ever-registered
+        // AND not-now-registered" keeps the leak detectable even after the live
+        // set empties (`pan close all`), and never flags a freshly-created
+        // stream still in its registration-lag window. DAX/IQ are excluded.
+        if (daxChannel < 0 && iqChannel < 0) {
+            const bool wfOrphan  = pcc == PCC_WATERFALL
+                                   && m_everRegisteredWfStreams.contains(streamId)
+                                   && !m_knownWfStreams.contains(streamId);
+            const bool fftOrphan = pcc == PCC_FFT
+                                   && m_everRegisteredPanStreams.contains(streamId)
+                                   && !m_knownPanStreams.contains(streamId);
+            if (wfOrphan || fftOrphan) {
+                if (!m_orphanClock.isValid())
+                    m_orphanClock.start();
+                auto it = m_orphanStreams.find(streamId);
+                if (it == m_orphanStreams.end()
+                    && m_orphanStreams.size() < kMaxOrphanStreams)
+                    it = m_orphanStreams.insert(streamId, OrphanRec{});
+                if (it != m_orphanStreams.end()) {
+                    it->waterfall  = wfOrphan;
+                    it->packets   += 1;
+                    it->lastSeenMs = m_orphanClock.elapsed();
+                }
+            }
+        }
     }
 
     if (logFirstDaxPacket || logFirstIqPacket) {

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -658,14 +658,25 @@ void PanadapterStream::processDatagram(const QByteArray& data)
                 if (!m_orphanClock.isValid())
                     m_orphanClock.start();
                 auto it = m_orphanStreams.find(streamId);
-                if (it == m_orphanStreams.end()
-                    && m_orphanStreams.size() < kMaxOrphanStreams)
+                if (it == m_orphanStreams.end()) {
+                    // At capacity, evict the least-recently-seen entry rather
+                    // than dropping the new one: a live leak keeps updating its
+                    // lastSeenMs so it's never the stalest, while a long-quiet
+                    // (already-stopped) orphan is the right one to discard. This
+                    // keeps an actively-streaming leak from being lost behind 32
+                    // transient entries. (#3856 review)
+                    if (m_orphanStreams.size() >= kMaxOrphanStreams) {
+                        auto stalest = m_orphanStreams.begin();
+                        for (auto e = m_orphanStreams.begin(); e != m_orphanStreams.end(); ++e)
+                            if (e->lastSeenMs < stalest->lastSeenMs)
+                                stalest = e;
+                        m_orphanStreams.erase(stalest);
+                    }
                     it = m_orphanStreams.insert(streamId, OrphanRec{});
-                if (it != m_orphanStreams.end()) {
-                    it->waterfall  = wfOrphan;
-                    it->packets   += 1;
-                    it->lastSeenMs = m_orphanClock.elapsed();
                 }
+                it->waterfall  = wfOrphan;
+                it->packets   += 1;
+                it->lastSeenMs = m_orphanClock.elapsed();
             }
         }
     }

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -7,6 +7,7 @@
 #include <QHostAddress>
 #include <QVector>
 #include <QMap>
+#include <QHash>
 #include <QSet>
 #include <QTimer>
 #include <QElapsedTimer>
@@ -82,6 +83,28 @@ public:
     void unregisterPanStream(quint32 streamId);
     void unregisterWfStream(quint32 streamId);
     void clearRegisteredStreams();
+
+    // ── Layer A: radio-side UDP-orphan leak detector (#3856) ────────────────
+    // The client view always looks clean after a close because the "removed"
+    // echo unregisters both streams locally. But if the radio was never told to
+    // free a stream (e.g. a panafall closed without "display panafall remove")
+    // it KEEPS transmitting tiles for an id we no longer own. processDatagram()
+    // records any FFT/waterfall packet whose stream id was EVER registered this
+    // session AND is no longer registered — a stream we once owned and let go of
+    // that the radio still streams. (A never-yet-registered id in its
+    // registration-lag window is deliberately ignored.) A growing orphan packet
+    // count with a small age is direct, radio-authoritative proof of a leaked,
+    // still-streaming display stream — the kind seen on older firmware (#268).
+    struct OrphanStream {
+        quint32 streamId{0};
+        bool    waterfall{false};  // true = waterfall tile stream, false = FFT
+        quint64 packets{0};        // packets seen since the stream went orphan
+        qint64  ageMs{0};          // ms since the most recent orphan packet
+    };
+    QVector<OrphanStream> orphanStreams() const;
+    QVector<quint32>      registeredPanStreams() const;
+    QVector<quint32>      registeredWfStreams() const;
+    void                  resetOrphanStreams();   // clear the orphan tally
 
     // DAX stream routing
     void registerDaxStream(quint32 streamId, int channel);
@@ -252,6 +275,22 @@ private:
     mutable QMutex  m_streamMutex;
     QSet<quint32>   m_knownPanStreams;     // registered pan stream IDs
     QSet<quint32>   m_knownWfStreams;     // registered wf stream IDs
+
+    // Stream ids that have EVER been registered this session (never pruned on
+    // unregister; cleared only on disconnect). The orphan detector keys off
+    // these, not the live known-sets: a leaked stream is one we ONCE owned and
+    // have since let go of but the radio keeps sending — which stays detectable
+    // after the live set empties (e.g. `pan close all`), while a never-yet-
+    // registered stream in its registration-lag window is never mis-flagged.
+    QSet<quint32>   m_everRegisteredPanStreams;   // (#3856)
+    QSet<quint32>   m_everRegisteredWfStreams;
+
+    // Orphan (radio-side-leaked) display streams — see OrphanStream above (#3856).
+    // Guarded by m_streamMutex. Bounded to kMaxOrphanStreams to cap memory.
+    struct OrphanRec { bool waterfall{false}; quint64 packets{0}; qint64 lastSeenMs{0}; };
+    static constexpr int kMaxOrphanStreams = 32;
+    QHash<quint32, OrphanRec> m_orphanStreams;
+    QElapsedTimer             m_orphanClock;   // monotonic source for lastSeenMs
     QUdpSocket*     m_socket{nullptr};
     quint16         m_localPort{0};
     QMap<quint32, QPair<float,float>> m_dbmRanges;  // streamId → (min, max)

--- a/src/models/DisplayInventoryPolicy.h
+++ b/src/models/DisplayInventoryPolicy.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QSet>
+
+// DisplayInventoryPolicy — classifies the radio-authoritative set of display
+// objects (panadapters + waterfalls, as accumulated from "display pan" /
+// "display waterfall" status) against what this client actually owns.
+//
+// This is the Layer-B half of the #3856 leak detector. Unlike the Layer-A
+// UDP-orphan detector (which sees streams the radio is still *transmitting*),
+// this works purely from status bookkeeping, so it catches the case the
+// packet-based detector cannot: a display object the radio keeps *allocated*
+// but no longer streams — e.g. a waterfall left behind by a panafall close that
+// omitted "display panafall remove" (#3843), on firmware that stops the
+// waterfall UDP on pan-removal. The headline signal is a waterfall whose parent
+// panadapter no longer exists on the radio.
+//
+// Pulled into a pure, header-only function (mirroring RadioStatusOwnership and
+// SliceRecreatePolicy) so it is unit-testable without a live radio: RadioModel
+// feeds it the accumulated radio-side maps + the owned set, and acts on the
+// returned Report.
+
+namespace AetherSDR::DisplayInventory {
+
+// One display object exactly as the RADIO reports it, regardless of ownership.
+struct RadioPan { QString id; quint32 clientHandle{0}; };
+struct RadioWf  { QString id; quint32 clientHandle{0}; QString parentPanId; };
+
+enum class Ownership {
+    Ours,     // this client holds a live model for it
+    Foreign,  // a different Multi-Flex client owns it (client_handle mismatch)
+    Orphan,   // no live owner on this client — leaked / crashed-session / unclaimed
+};
+
+struct PanVerdict { QString id; quint32 clientHandle{0}; Ownership ownership{Ownership::Orphan}; };
+struct WfVerdict  {
+    QString   id;
+    quint32   clientHandle{0};
+    Ownership ownership{Ownership::Orphan};
+    QString   parentPanId;
+    bool      parentMissing{false};   // radio has this waterfall but not its parent pan
+};
+
+struct Inputs {
+    QVector<RadioPan> radioPans;          // every pan the radio currently reports
+    QVector<RadioWf>  radioWaterfalls;    // every waterfall the radio currently reports
+    QSet<QString>     ownedPanIds;        // panIds this client holds (m_panadapters)
+    QSet<QString>     ownedWaterfallIds;  // the waterfallIds those pans reference
+    quint32           ourHandle{0};       // this client's handle (0 if unknown)
+};
+
+struct Report {
+    QVector<PanVerdict> pans;
+    QVector<WfVerdict>  waterfalls;
+    int oursPanCount{0},   foreignPanCount{0},   orphanPanCount{0};
+    int oursWfCount{0},    foreignWfCount{0},     orphanWfCount{0};
+    // The headline #3843 fingerprint: waterfalls the radio still holds whose
+    // parent panadapter no longer exists — a leaked waterfall stream.
+    QVector<QString>    leakedWaterfalls;
+};
+
+inline Ownership classifyOwnership(const QString& id, quint32 handle,
+                                   const QSet<QString>& owned, quint32 ourHandle)
+{
+    if (owned.contains(id))
+        return Ownership::Ours;
+    // A non-zero handle that isn't ours marks another Multi-Flex client. We
+    // only assert "foreign" when we actually know our own handle, otherwise a
+    // mismatch is unprovable and we fall through to Orphan.
+    if (handle != 0 && ourHandle != 0 && handle != ourHandle)
+        return Ownership::Foreign;
+    return Ownership::Orphan;
+}
+
+inline Report classify(const Inputs& in)
+{
+    Report r;
+    QSet<QString> radioPanIds;
+    radioPanIds.reserve(in.radioPans.size());
+    for (const auto& p : in.radioPans)
+        radioPanIds.insert(p.id);
+
+    for (const auto& p : in.radioPans) {
+        const Ownership o = classifyOwnership(p.id, p.clientHandle,
+                                              in.ownedPanIds, in.ourHandle);
+        r.pans.push_back(PanVerdict{p.id, p.clientHandle, o});
+        if (o == Ownership::Ours)         ++r.oursPanCount;
+        else if (o == Ownership::Foreign) ++r.foreignPanCount;
+        else                              ++r.orphanPanCount;
+    }
+
+    for (const auto& w : in.radioWaterfalls) {
+        const Ownership o = classifyOwnership(w.id, w.clientHandle,
+                                              in.ownedWaterfallIds, in.ourHandle);
+        const bool parentMissing =
+            !w.parentPanId.isEmpty() && !radioPanIds.contains(w.parentPanId);
+        r.waterfalls.push_back(WfVerdict{w.id, w.clientHandle, o,
+                                         w.parentPanId, parentMissing});
+        if (o == Ownership::Ours)         ++r.oursWfCount;
+        else if (o == Ownership::Foreign) ++r.foreignWfCount;
+        else                              ++r.orphanWfCount;
+        // A waterfall whose parent pan is gone is a leak no matter who nominally
+        // owned it — the radio is holding a display resource with no panadapter.
+        if (parentMissing)
+            r.leakedWaterfalls.push_back(w.id);
+    }
+    return r;
+}
+
+}  // namespace AetherSDR::DisplayInventory

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4511,9 +4511,26 @@ void RadioModel::onStatusReceived(const QString& object,
             // (presence + owner), independent of whether we end up owning it —
             // foreign and unclaimed pans are tracked too. Pruned on "removed".
             {
-                auto& e = m_radioDisplayPans[normalizePanadapterId(panId)];
+                const QString nPanId = normalizePanadapterId(panId);
+                auto& e = m_radioDisplayPans[nPanId];
                 if (kvs.contains(QStringLiteral("client_handle")))
                     e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
+                // Capture the pan-side waterfall link and stamp it onto the
+                // waterfall entry's parentPanId. Some firmware conveys the
+                // pan↔waterfall link only here (the pan's `waterfall=` key) and
+                // omits `panadapter=` from the waterfall status — without this
+                // backfill the waterfall's parent stays unknown, so a leaked
+                // waterfall (parent pan removed) could never be flagged. Stamping
+                // the persistent waterfall entry means the link survives the
+                // pan's removal, which is exactly when the leak shows. (#3856)
+                const QString wf =
+                    normalizePanadapterId(kvs.value(QStringLiteral("waterfall")));
+                if (!wf.isEmpty()) {
+                    e.waterfallId = wf;
+                    auto wit = m_radioDisplayWaterfalls.find(wf);
+                    if (wit != m_radioDisplayWaterfalls.end() && wit->parentPanId.isEmpty())
+                        wit->parentPanId = nPanId;
+                }
             }
 
             // Preamp is shared antenna hardware — apply to ALL our pans
@@ -4620,13 +4637,27 @@ void RadioModel::onStatusReceived(const QString& object,
             // it carries no client_handle and we don't own it. Normalize the key
             // so it compares equal to owned/parent ids regardless of hex case.
             {
-                auto& e = m_radioDisplayWaterfalls[normalizePanadapterId(wfId)];
+                const QString nWfId = normalizePanadapterId(wfId);
+                auto& e = m_radioDisplayWaterfalls[nWfId];
                 if (kvs.contains(QStringLiteral("client_handle")))
                     e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
                 const QString parent =
                     normalizePanadapterId(kvs.value(QStringLiteral("panadapter")));
-                if (!parent.isEmpty())
+                if (!parent.isEmpty()) {
                     e.parentPanId = parent;
+                } else if (e.parentPanId.isEmpty()) {
+                    // Firmware omitted `panadapter=` on the waterfall status:
+                    // backfill the parent from the pan that already reported this
+                    // waterfall via its `waterfall=` link (handles pan-status-
+                    // first ordering; the pan-status path covers the reverse). (#3856)
+                    for (auto pit = m_radioDisplayPans.cbegin();
+                         pit != m_radioDisplayPans.cend(); ++pit) {
+                        if (pit.value().waterfallId == nWfId) {
+                            e.parentPanId = pit.key();
+                            break;
+                        }
+                    }
+                }
             }
             // Check if this waterfall belongs to one of our panadapters.
             // The waterfallId is set on PanadapterModel by the "display pan" status

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1869,6 +1869,24 @@ PanadapterModel* RadioModel::panadapter(const QString& panId) const
     return m_panadapters.value(panId, nullptr);
 }
 
+DisplayInventory::Report RadioModel::displayInventoryReport() const
+{
+    DisplayInventory::Inputs in;
+    in.ourHandle = clientHandle();
+    for (auto it = m_radioDisplayPans.cbegin(); it != m_radioDisplayPans.cend(); ++it)
+        in.radioPans.push_back({it.key(), it.value().clientHandle});
+    for (auto it = m_radioDisplayWaterfalls.cbegin();
+         it != m_radioDisplayWaterfalls.cend(); ++it)
+        in.radioWaterfalls.push_back({it.key(), it.value().clientHandle,
+                                      it.value().parentPanId});
+    for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it) {
+        in.ownedPanIds.insert(it.key());
+        if (it.value() && !it.value()->waterfallId().isEmpty())
+            in.ownedWaterfallIds.insert(it.value()->waterfallId());
+    }
+    return DisplayInventory::classify(in);
+}
+
 double RadioModel::panCenterMhz() const
 {
     auto* p = activePanadapter();
@@ -2865,6 +2883,8 @@ void RadioModel::onDisconnected()
     // restoreEnabledChannels() skip persisted channels on reconnect. (#3522)
     m_daxIqModel.handleDisconnect();
     m_pendingPanStatuses.clear();
+    m_radioDisplayPans.clear();           // #3856 Layer B — radio re-dumps on reconnect
+    m_radioDisplayWaterfalls.clear();
 
     m_tnfModel.clear();
     m_flexWaveformModel.clear();
@@ -4457,6 +4477,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // Handle pan removal — "display pan 0x40000001 removed" arrives
             // with no '=' so the parser puts the whole string in 'object'
             if (kvs.contains("removed") || object.endsWith("removed")) {
+                m_radioDisplayPans.remove(panId);   // #3856 Layer B inventory
                 m_pendingPanStatuses.remove(panId);
                 m_panTransmitInhibitReasons.remove(panId);
                 auto* pan = m_panadapters.take(panId);
@@ -4475,6 +4496,15 @@ void RadioModel::onStatusReceived(const QString& object,
                                                             : m_panadapters.firstKey();
                 }
                 return;
+            }
+
+            // #3856 Layer B: record into the radio-authoritative pan inventory
+            // (presence + owner), independent of whether we end up owning it —
+            // foreign and unclaimed pans are tracked too. Pruned on "removed".
+            {
+                auto& e = m_radioDisplayPans[panId];
+                if (kvs.contains(QStringLiteral("client_handle")))
+                    e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
             }
 
             // Preamp is shared antenna hardware — apply to ALL our pans
@@ -4556,9 +4586,34 @@ void RadioModel::onStatusReceived(const QString& object,
     // Only process status for OUR waterfall (matching client_handle).
     static const QRegularExpression wfRe(R"(^display waterfall\s+(0x[0-9A-Fa-f]+)$)");
     if (object.startsWith("display waterfall")) {
+        // #3856 Layer B: prune the radio-side waterfall inventory on removal.
+        // "display waterfall 0x42… removed" has no '=', so wfRe (anchored on a
+        // bare id) won't match it — handle it explicitly here.
+        if (object.endsWith(QLatin1String("removed"))) {
+            static const QRegularExpression wfRemovedRe(R"(^display waterfall\s+(0x[0-9A-Fa-f]+))");
+            const auto rm = wfRemovedRe.match(object);
+            if (rm.hasMatch()) {
+                m_radioDisplayWaterfalls.remove(rm.captured(1));
+                qCDebug(lcProtocol) << "RadioModel: waterfall removed (inventory)" << rm.captured(1);
+            }
+            return;
+        }
         const auto m = wfRe.match(object);
         if (m.hasMatch()) {
             const QString wfId = m.captured(1);
+            // #3856 Layer B: record into the radio-authoritative waterfall
+            // inventory (presence + owner + parent pan), before the ownership
+            // early-returns below — a leaked waterfall must be tracked even when
+            // it carries no client_handle and we don't own it.
+            {
+                auto& e = m_radioDisplayWaterfalls[wfId];
+                if (kvs.contains(QStringLiteral("client_handle")))
+                    e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
+                const QString parent =
+                    normalizePanadapterId(kvs.value(QStringLiteral("panadapter")));
+                if (!parent.isEmpty())
+                    e.parentPanId = parent;
+            }
             // Check if this waterfall belongs to one of our panadapters.
             // The waterfallId is set on PanadapterModel by the "display pan" status
             // message which contains "waterfall=0x42xxxxxx".

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1879,11 +1879,20 @@ DisplayInventory::Report RadioModel::displayInventoryReport() const
          it != m_radioDisplayWaterfalls.cend(); ++it)
         in.radioWaterfalls.push_back({it.key(), it.value().clientHandle,
                                       it.value().parentPanId});
-    for (auto it = m_panadapters.cbegin(); it != m_panadapters.cend(); ++it) {
-        in.ownedPanIds.insert(it.key());
-        if (it.value() && !it.value()->waterfallId().isEmpty())
-            in.ownedWaterfallIds.insert(it.value()->waterfallId());
-    }
+    // Owned sets — normalize the waterfall id so it compares equal to the
+    // 0x-prefixed inventory keys regardless of hex case (#3856 review).
+    // Include m_stalePanadapters: during the reconnect reclaim window our own
+    // pans live there (not yet moved to m_panadapters), and the radio re-dumps
+    // their status — without this they'd transiently report as orphan.
+    const auto addOwned = [&in](const QMap<QString, PanadapterModel*>& m) {
+        for (auto it = m.cbegin(); it != m.cend(); ++it) {
+            in.ownedPanIds.insert(normalizePanadapterId(it.key()));
+            if (it.value() && !it.value()->waterfallId().isEmpty())
+                in.ownedWaterfallIds.insert(normalizePanadapterId(it.value()->waterfallId()));
+        }
+    };
+    addOwned(m_panadapters);
+    addOwned(m_stalePanadapters);
     return DisplayInventory::classify(in);
 }
 
@@ -4477,7 +4486,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // Handle pan removal — "display pan 0x40000001 removed" arrives
             // with no '=' so the parser puts the whole string in 'object'
             if (kvs.contains("removed") || object.endsWith("removed")) {
-                m_radioDisplayPans.remove(panId);   // #3856 Layer B inventory
+                m_radioDisplayPans.remove(normalizePanadapterId(panId));   // #3856 Layer B inventory
                 m_pendingPanStatuses.remove(panId);
                 m_panTransmitInhibitReasons.remove(panId);
                 auto* pan = m_panadapters.take(panId);
@@ -4502,7 +4511,7 @@ void RadioModel::onStatusReceived(const QString& object,
             // (presence + owner), independent of whether we end up owning it —
             // foreign and unclaimed pans are tracked too. Pruned on "removed".
             {
-                auto& e = m_radioDisplayPans[panId];
+                auto& e = m_radioDisplayPans[normalizePanadapterId(panId)];
                 if (kvs.contains(QStringLiteral("client_handle")))
                     e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
             }
@@ -4587,14 +4596,18 @@ void RadioModel::onStatusReceived(const QString& object,
     static const QRegularExpression wfRe(R"(^display waterfall\s+(0x[0-9A-Fa-f]+)$)");
     if (object.startsWith("display waterfall")) {
         // #3856 Layer B: prune the radio-side waterfall inventory on removal.
-        // "display waterfall 0x42… removed" has no '=', so wfRe (anchored on a
-        // bare id) won't match it — handle it explicitly here.
-        if (object.endsWith(QLatin1String("removed"))) {
+        // Removal arrives in two wire forms (mirroring the pan branch): bare
+        // "display waterfall 0x42… removed" (no '=', lands in `object`) and the
+        // kv form "display waterfall 0x42… removed=1" (lands in `kvs`). Handle
+        // both — the bare form won't match wfRe, and the kv form WOULD match
+        // wfRe and be mis-recorded as an add if not caught first.
+        if (kvs.contains(QStringLiteral("removed")) || object.endsWith(QLatin1String("removed"))) {
             static const QRegularExpression wfRemovedRe(R"(^display waterfall\s+(0x[0-9A-Fa-f]+))");
             const auto rm = wfRemovedRe.match(object);
             if (rm.hasMatch()) {
-                m_radioDisplayWaterfalls.remove(rm.captured(1));
-                qCDebug(lcProtocol) << "RadioModel: waterfall removed (inventory)" << rm.captured(1);
+                const QString wfId = normalizePanadapterId(rm.captured(1));
+                m_radioDisplayWaterfalls.remove(wfId);
+                qCDebug(lcProtocol) << "RadioModel: waterfall removed (inventory)" << wfId;
             }
             return;
         }
@@ -4604,9 +4617,10 @@ void RadioModel::onStatusReceived(const QString& object,
             // #3856 Layer B: record into the radio-authoritative waterfall
             // inventory (presence + owner + parent pan), before the ownership
             // early-returns below — a leaked waterfall must be tracked even when
-            // it carries no client_handle and we don't own it.
+            // it carries no client_handle and we don't own it. Normalize the key
+            // so it compares equal to owned/parent ids regardless of hex case.
             {
-                auto& e = m_radioDisplayWaterfalls[wfId];
+                auto& e = m_radioDisplayWaterfalls[normalizePanadapterId(wfId)];
                 if (kvs.contains(QStringLiteral("client_handle")))
                     e.clientHandle = parseClientHandle(kvs.value(QStringLiteral("client_handle")));
                 const QString parent =

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -24,6 +24,7 @@
 #include "MemoryEntry.h"
 #include "ModelCapabilities.h"
 #include "RadioStatusOwnership.h"
+#include "DisplayInventoryPolicy.h"
 
 #include <QObject>
 #include <QString>
@@ -282,6 +283,11 @@ public:
     PanadapterModel* activePanadapter() const;
     PanadapterModel* panadapter(const QString& panId) const;
     QList<PanadapterModel*> panadapters() const { return m_panadapters.values(); }
+
+    // Radio-authoritative display inventory vs what we own (#3856 Layer B).
+    // Built from the accumulated "display pan"/"display waterfall" status maps;
+    // surfaces leaked waterfalls (parent pan gone), foreign and orphan objects.
+    DisplayInventory::Report displayInventoryReport() const;
 
     QList<SliceModel*> slices() const { return m_slices; }
     SliceModel* slice(int id) const;
@@ -719,6 +725,18 @@ private:
     QMap<QString, PanadapterModel*> m_panadapters;  // panId → model
     QMap<QString, PanadapterModel*> m_stalePanadapters;  // previous session, kept alive for UI reuse
     QString m_activePanId;       // currently active panadapter
+
+    // Radio-authoritative display inventory (#3856 Layer B). Accumulated from
+    // ALL "display pan"/"display waterfall" status (ours, foreign, and orphan),
+    // pruned on the matching "removed" — independent of m_panadapters, which only
+    // holds objects WE own. A leaked waterfall (panafall closed without
+    // "display panafall remove") therefore lingers here after its pan is pruned,
+    // making it detectable even when the radio has stopped streaming it.
+    // Main-thread only (written in onStatusReceived, read in the bridge).
+    struct RadioDisplayPan { quint32 clientHandle{0}; };
+    struct RadioDisplayWf  { quint32 clientHandle{0}; QString parentPanId; };
+    QMap<QString, RadioDisplayPan> m_radioDisplayPans;        // panId → entry
+    QMap<QString, RadioDisplayWf>  m_radioDisplayWaterfalls;  // wfId  → entry
     // Deferred "display pan" status pending ownership confirmation. Paired
     // with QDateTime::currentSecsSinceEpoch() at insert so a sweep on insert
     // can drop entries that the radio never resolved with a client_handle

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -733,7 +733,7 @@ private:
     // "display panafall remove") therefore lingers here after its pan is pruned,
     // making it detectable even when the radio has stopped streaming it.
     // Main-thread only (written in onStatusReceived, read in the bridge).
-    struct RadioDisplayPan { quint32 clientHandle{0}; };
+    struct RadioDisplayPan { quint32 clientHandle{0}; QString waterfallId; };
     struct RadioDisplayWf  { quint32 clientHandle{0}; QString parentPanId; };
     QMap<QString, RadioDisplayPan> m_radioDisplayPans;        // panId → entry
     QMap<QString, RadioDisplayWf>  m_radioDisplayWaterfalls;  // wfId  → entry

--- a/tests/display_inventory_policy_test.cpp
+++ b/tests/display_inventory_policy_test.cpp
@@ -1,0 +1,141 @@
+// Unit tests for DisplayInventoryPolicy (#3856 Layer B).
+//
+// The radio-authoritative display inventory classifies every pan/waterfall the
+// radio reports against what this client owns, and flags the #3843 fingerprint:
+// a waterfall the radio still holds whose parent panadapter is gone (a leaked
+// display resource). These tests pin the classification so a real leak can't be
+// silently reported as clean and normal multi-client state isn't mis-flagged.
+
+#include "models/DisplayInventoryPolicy.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+using namespace AetherSDR::DisplayInventory;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+// Helper: does the leaked list contain id?
+bool leaked(const Report& r, const QString& id)
+{
+    return r.leakedWaterfalls.contains(id);
+}
+
+// Healthy single-pan session: one owned pan + its waterfall, parent present.
+void testCleanSinglePan()
+{
+    Inputs in;
+    in.ourHandle = 0x11111111u;
+    in.radioPans = {{"0x40000000", 0x11111111u}};
+    in.radioWaterfalls = {{"0x42000000", 0x11111111u, "0x40000000"}};
+    in.ownedPanIds = {"0x40000000"};
+    in.ownedWaterfallIds = {"0x42000000"};
+
+    const Report r = classify(in);
+    check(r.oursPanCount == 1 && r.oursWfCount == 1, "clean: both ours");
+    check(r.orphanPanCount == 0 && r.orphanWfCount == 0, "clean: no orphans");
+    check(r.leakedWaterfalls.isEmpty(), "clean: no leaks");
+}
+
+// The #3843 leak: pan removed (gone from radio), waterfall lingers with a parent
+// that no longer exists, and we no longer own it.
+void testLeakedWaterfallParentGone()
+{
+    Inputs in;
+    in.ourHandle = 0x11111111u;
+    in.radioPans = {{"0x40000000", 0x11111111u}};           // only the first pan survives
+    in.radioWaterfalls = {
+        {"0x42000000", 0x11111111u, "0x40000000"},          // healthy, parent present
+        {"0x42000001", 0x11111111u, "0x40000001"},          // LEAK: parent 0x40000001 gone
+    };
+    in.ownedPanIds = {"0x40000000"};
+    in.ownedWaterfallIds = {"0x42000000"};                  // we no longer hold the leaked wf
+
+    const Report r = classify(in);
+    check(leaked(r, "0x42000001"), "leak: parent-gone waterfall flagged");
+    check(!leaked(r, "0x42000000"), "leak: healthy waterfall not flagged");
+    check(r.leakedWaterfalls.size() == 1, "leak: exactly one leak");
+    check(r.orphanWfCount == 1, "leak: lingering wf is orphan (not ours/foreign)");
+}
+
+// A foreign Multi-Flex client's pan + waterfall must classify as foreign, not
+// orphan, and a foreign waterfall with its own parent present is not a leak.
+void testForeignNotOrphan()
+{
+    Inputs in;
+    in.ourHandle = 0x11111111u;
+    in.radioPans = {
+        {"0x40000000", 0x11111111u},   // ours
+        {"0x40000005", 0x22222222u},   // foreign
+    };
+    in.radioWaterfalls = {
+        {"0x42000000", 0x11111111u, "0x40000000"},
+        {"0x42000005", 0x22222222u, "0x40000005"},
+    };
+    in.ownedPanIds = {"0x40000000"};
+    in.ownedWaterfallIds = {"0x42000000"};
+
+    const Report r = classify(in);
+    check(r.foreignPanCount == 1 && r.foreignWfCount == 1, "foreign: counted as foreign");
+    check(r.orphanPanCount == 0 && r.orphanWfCount == 0, "foreign: not orphan");
+    check(r.leakedWaterfalls.isEmpty(), "foreign: own parent present, no leak");
+}
+
+// A waterfall with no parent reported (empty parentPanId) can't be proven leaked,
+// so it must NOT be flagged (avoid false positives on incomplete status).
+void testNoParentReportedNotLeaked()
+{
+    Inputs in;
+    in.ourHandle = 0x11111111u;
+    in.radioPans = {{"0x40000000", 0x11111111u}};
+    in.radioWaterfalls = {{"0x42000000", 0x11111111u, ""}};  // parent unknown
+    in.ownedPanIds = {"0x40000000"};
+    in.ownedWaterfallIds = {"0x42000000"};
+
+    const Report r = classify(in);
+    check(r.leakedWaterfalls.isEmpty(), "no-parent: not flagged as leak");
+}
+
+// Without knowing our own handle, a handle mismatch is unprovable → Orphan, not
+// Foreign (we must not assert another client owns it).
+void testUnknownOurHandleFallsToOrphan()
+{
+    Inputs in;
+    in.ourHandle = 0;   // unknown
+    in.radioPans = {{"0x40000005", 0x22222222u}};
+    in.radioWaterfalls = {};
+    // we own nothing
+    const Report r = classify(in);
+    check(r.orphanPanCount == 1 && r.foreignPanCount == 0,
+          "unknown-handle: mismatch is orphan, not foreign");
+}
+
+}  // namespace
+
+int main()
+{
+    testCleanSinglePan();
+    testLeakedWaterfallParentGone();
+    testForeignNotOrphan();
+    testNoParentReportedNotLeaked();
+    testUnknownOurHandleFallsToOrphan();
+
+    if (failures == 0) {
+        std::printf("\nAll display_inventory_policy tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d display_inventory_policy test(s) FAILED.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## What

Implements the radio-side display-stream **inventory + leak detection** feature requested in #3856. It makes leaked / duplicate / lingering panadapter & waterfall streams *on the radio* directly observable — a class of bug `get pans` can never surface, because the client always cleans up its own view on the radio's `removed` echo.

Two independent radio-authoritative layers behind one `streams` bridge verb:

### Layer A — `streams` (VITA-49 UDP truth)
`PanadapterStream` records any FFT/waterfall packet for a stream id that was **ever registered this session but is no longer registered** — a stream we once owned and let go of that the radio keeps transmitting. Keyed off *ever-registered ∧ not-now-registered* (not "live set non-empty"), so it stays detectable after `pan close all` and never mis-flags a freshly-created stream's registration-lag window. Catches **continued-stream** leaks (the #268 class). `streams reset` re-baselines.

### Layer B — `streams radio` (status-bookkeeping truth)
`RadioModel` now accumulates the radio-authoritative display-object set (`m_radioDisplayPans` / `m_radioDisplayWaterfalls`) from **all** `display pan` / `display waterfall` status — ours, foreign, and orphan — pruned on the matching `removed`, independent of `m_panadapters` (which only holds objects *we* own). The pure `DisplayInventory::classify()` labels each object `ours` / `foreign` / `orphan` and flags **leaked waterfalls** (parent panadapter gone) — the #3843 fingerprint. This catches **resource-level lingering that emits no UDP**, which Layer A cannot see.

`DisplayInventoryPolicy` is a pure, header-only function (mirroring `RadioStatusOwnership` / `SliceRecreatePolicy`), with a unit test (`display_inventory_policy_test`, 12 assertions) covering clean, leaked-parent-gone, foreign-vs-orphan, no-parent-reported, and unknown-own-handle cases.

Closes #3856.

## Bridge surface

| action | layer | effect |
|---|---|---|
| `streams` | A | `registeredPanStreams`, `registeredWfStreams`, `orphanStreams` (`streamId`, `kind`, `packets`, `age_ms`) |
| `streams radio` (alias `inventory`) | B | radio display-object set classified ours/foreign/orphan + `leakedWaterfalls` |
| `streams reset` | A | clear the orphan tally |

All `streams` actions are RX/observe only — none sends a radio command or keys TX. Docs in `docs/automation-bridge.md`.

## Proven on a live FLEX-8400M (firmware 4.2.18)

`streams radio` tracked the inventory **exactly** across an add/close cycle, every object `ownership: ours`, no false-positive leaks:

```
baseline:   radioPanCount=1 radioWaterfallCount=1   leakCount=0
after add:  radioPanCount=2 radioWaterfallCount=2   leakCount=0   (both ours, parentMissing=false)
after close:radioPanCount=1 radioWaterfallCount=1   leakCount=0
```

**Key firmware finding (answers the open #3843 question):** on this radio, `display pan remove` **alone** makes the radio *also* remove the waterfall — it echoes `display waterfall <id> removed`. A leak-repro build that deliberately omitted `display panafall remove` produced the **same clean result** (`leakedWaterfalls=[]`, waterfall count 2→1, removal echo observed). So **neither #3843 symptom — continued UDP nor lingering resource — reproduces on 8000-series / 4.2.18**: the radio auto-cascades. The #3855 close-path fix remains correct per FlexLib and matters for firmware that does **not** cascade (the #268 class).

Because this firmware never leaves an orphan, **Layer B's positive leak detection is covered by the unit test** (synthetic parent-gone waterfall → flagged); live, it correctly reads clean with no false positives. Layer A likewise reads `orphanCount:0` here (this firmware stops the UDP), and is the guard for firmware that keeps streaming.

## Test plan

- [x] `display_inventory_policy_test` — 12/12 pass (pure classification logic, incl. the leaked-waterfall case).
- [x] Full app builds clean (Ninja, RelWithDebInfo, arm64).
- [x] Live FLEX-8400M: `streams` + `streams radio` inventory accurate across add/close; no false-positive leaks; firmware cascade behavior characterized.
- [ ] Maintainer review.

## Notes / follow-ups
- The empirical cascade finding means Layer B's live positive-catch can only be demonstrated on #268-class firmware (which leaves the orphan). The detection logic is unit-tested.
- Layer B is positioned to plug into reconnect/duplicate-pan reconciliation (#3429) — surfacing a radio-side pan the client doesn't own — as a future step.

## Related
- #3856 — this feature request.
- #3855 / #3843 — the panafall close-path fix this observability complements (the *send* side; this is the *observe* side).
- #268 — continued-UDP waterfall leak on older firmware (the case Layer A guards).
- #3429 — reconnect reconciliation (future Layer B integration point).

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
