### PR TITLE
feat(smeter): config context menu + needle pivot cover with backlight glow

### DIFF
--- a/resources/themes/default-dark.json
+++ b/resources/themes/default-dark.json
@@ -67,6 +67,9 @@
             "thresh": "{color.amber.500}",
             "peak":   "{color.gray.50}",
             "gainReduction": "#f2c14e",
+            "pivot.fill": "#050509",
+            "pivot.rim":  "#3a3e48",
+            "pivot.glow": "#ffb060",
             "bar.fill": "#405060",
             "bar.fillGradient": {
               "type": "linear-gradient",

--- a/resources/themes/default-light.json
+++ b/resources/themes/default-light.json
@@ -68,6 +68,9 @@
             "thresh": "{color.amber.500}",
             "peak":   "{color.gray.50}",
             "gainReduction": "#a06010",
+            "pivot.fill": "#14181c",
+            "pivot.rim":  "#3a4250",
+            "pivot.glow": "#ff9a40",
             "bar.fill": "{color.gray.700}",
             "bar.fillGradient": {
               "type": "linear-gradient",

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -408,6 +408,10 @@ void ThemeManager::seedBuiltinDefaults()
     m_tokens.insert("color.meter.peak",          QString("#e6f0fa"));
     m_tokens.insert("color.meter.gainReduction", QString("#f2c14e"));
     m_tokens.insert("color.meter.bar.fill",      QString("#405060"));
+    // S-meter needle-pivot moulding cover + warm backlight glow (paint code only).
+    m_tokens.insert("color.meter.pivot.fill",    QString("#050509"));
+    m_tokens.insert("color.meter.pivot.rim",     QString("#3a3e48"));
+    m_tokens.insert("color.meter.pivot.glow",    QString("#ffb060"));
     // Vertical (bottom→top, angle 0°) green→amber→red ramp painted by
     // ClientLevelMeter / ClientCompMeter into the level bar.  Seeded so
     // a missing theme file doesn't fall back to whatever the meter

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -39,6 +39,9 @@
 #include "MqttApplet.h"
 #endif
 #include "models/SliceModel.h"
+#include <QAction>
+#include <QActionGroup>
+#include <QWidgetAction>
 #include <QComboBox>
 #include <QContextMenuEvent>
 #include <QLabel>
@@ -283,111 +286,12 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_sMeter->setAccessibleDescription("Signal strength meter, shows S-units or TX power");
     contentLayout->addWidget(m_sMeter);
 
-    // ── TX / RX meter select row ──────────────────────────────────────────
-    auto* selectRow = new QWidget(sMeterContent);
-    auto* selectLayout = new QHBoxLayout(selectRow);
-    selectLayout->setContentsMargins(4, 2, 4, 2);
-    selectLayout->setSpacing(6);
-
-    const QString labelStyle = QStringLiteral(
-        "color: #8090a0; font-size: 10px; font-weight: bold;");
-
-    auto* txLabel = new QLabel("TX Select", selectRow);
-    txLabel->setStyleSheet(labelStyle);
-    txLabel->setAlignment(Qt::AlignCenter);
-    m_txSelect = new GuardedComboBox(selectRow);
-    m_txSelect->addItems({"Power", "SWR", "Level", "Compression"});
-    m_txSelect->setAccessibleName("TX meter mode");
-    m_txSelect->setAccessibleDescription("Select which TX parameter the S-meter displays");
-    AetherSDR::applyComboStyle(m_txSelect);
-
-    auto* txCol = new QVBoxLayout;
-    txCol->setSpacing(1);
-    txCol->addWidget(txLabel);
-    txCol->addWidget(m_txSelect);
-
-    auto* rxLabel = new QLabel("RX Select", selectRow);
-    rxLabel->setStyleSheet(labelStyle);
-    rxLabel->setAlignment(Qt::AlignCenter);
-    m_rxSelect = new GuardedComboBox(selectRow);
-    m_rxSelect->addItems({"S-Meter", "S-Meter Peak"});
-    m_rxSelect->setCurrentIndex(0);
-    m_rxSelect->setAccessibleName("RX meter mode");
-    m_rxSelect->setAccessibleDescription("Select which RX parameter the S-meter displays");
-    AetherSDR::applyComboStyle(m_rxSelect);
-
-    auto* rxCol = new QVBoxLayout;
-    rxCol->setSpacing(1);
-    rxCol->addWidget(rxLabel);
-    rxCol->addWidget(m_rxSelect);
-
-    selectLayout->addLayout(txCol, 1);
-    selectLayout->addLayout(rxCol, 1);
-    contentLayout->addWidget(selectRow);
-
-    connect(m_txSelect, &QComboBox::currentTextChanged,
-            m_sMeter, &SMeterWidget::setTxMode);
-    connect(m_rxSelect, &QComboBox::currentTextChanged,
-            m_sMeter, &SMeterWidget::setRxMode);
-
-    // Restore saved TX/RX meter selections AFTER connecting signals
-    // so setTxMode/setRxMode are called with the restored values (#809)
-    int txIdx = AppSettings::instance().value("SMeter_TxSelect", 0).toInt();
-    int rxIdx = AppSettings::instance().value("SMeter_RxSelect", 0).toInt();
-    if (txIdx >= 0 && txIdx < m_txSelect->count())
-        m_txSelect->setCurrentIndex(txIdx);
-    if (rxIdx >= 0 && rxIdx < m_rxSelect->count())
-        m_rxSelect->setCurrentIndex(rxIdx);
-
-    // Persist TX/RX meter selections on change (#809)
-    connect(m_txSelect, &QComboBox::currentIndexChanged,
-            this, [](int idx) {
-        AppSettings::instance().setValue("SMeter_TxSelect", idx);
-    });
-    connect(m_rxSelect, &QComboBox::currentIndexChanged,
-            this, [](int idx) {
-        AppSettings::instance().setValue("SMeter_RxSelect", idx);
-    });
-
-    // ── Peak hold line controls (#840) ────────────────────────────────────
-    auto* peakRow = new QWidget(sMeterContent);
-    auto* peakLayout = new QHBoxLayout(peakRow);
-    peakLayout->setContentsMargins(4, 2, 4, 2);
-    peakLayout->setSpacing(6);
-
-    auto* peakBtn = new QPushButton("Peak Hold", peakRow);
-    peakBtn->setCheckable(true);
-    peakBtn->setChecked(AppSettings::instance().value("PeakHoldEnabled", "False") == "True");
-    peakBtn->setAccessibleName("Peak hold");
-    peakBtn->setAccessibleDescription("Toggle peak hold line on S-meter");
-    peakBtn->setFixedHeight(20);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(peakBtn, "QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
-        "border-radius: 3px; font-size: 10px; padding: 0 6px; } "
-        "QPushButton:checked { background: #0a3060; color: {{color.accent}}; border-color: {{color.accent}}; }");
-
-    auto* decayLabel = new QLabel("Decay", peakRow);
-    decayLabel->setStyleSheet(labelStyle);
-    auto* decayCombo = new GuardedComboBox(peakRow);
-    decayCombo->addItems({"Fast", "Medium", "Slow"});
-    decayCombo->setAccessibleName("Peak decay rate");
-    decayCombo->setAccessibleDescription("Speed at which peak hold marker decays");
-    decayCombo->setCurrentText(
-        AppSettings::instance().value("PeakDecayRate", "Medium").toString());
-    AetherSDR::applyComboStyle(decayCombo);
-
-    auto* resetBtn = new QPushButton("RST", peakRow);
-    resetBtn->setFixedSize(32, 20);
-    resetBtn->setToolTip("Reset peak hold");
-    resetBtn->setAccessibleName("Reset peak hold");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(resetBtn, "QPushButton { background: {{color.background.0}}; color: {{color.text.secondary}}; border: 1px solid #334; "
-        "border-radius: 3px; font-size: 10px; padding: 0 4px; } "
-        "QPushButton:pressed { background: #2a2a4e; color: {{color.text.primary}}; }");
-
-    peakLayout->addWidget(peakBtn);
-    peakLayout->addWidget(decayLabel);
-    peakLayout->addWidget(decayCombo, 1);
-    peakLayout->addWidget(resetBtn);
-    contentLayout->addWidget(peakRow);
+    // ── S-meter config → right-click context menu on the gauge ────────────
+    // The applet body is just the gauge now; TX/RX meter select, peak-hold
+    // toggle, decay speed, and reset all live in the right-click menu so the
+    // VU applet stays compact. The menu reads/writes the same AppSettings keys
+    // (SMeter_TxSelect/RxSelect, PeakHoldEnabled, PeakDecayRate) it always has,
+    // so state survives and stays in sync.
 
     // Apply decay preset: also sets the hold time (Fast=200ms, Medium=500ms, Slow=1000ms)
     auto applyDecayPreset = [this](const QString& rate) {
@@ -397,21 +301,113 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         else                       m_sMeter->setPeakHoldTimeMs(500);
     };
 
-    m_sMeter->setPeakHoldEnabled(peakBtn->isChecked());
-    applyDecayPreset(decayCombo->currentText());
+    static const QStringList kTxMeterItems{"Power", "SWR", "Level", "Compression"};
+    static const QStringList kRxMeterItems{"S-Meter", "S-Meter Peak"};
+    static const QStringList kDecayItems{"Fast", "Medium", "Slow"};
 
-    connect(peakBtn, &QPushButton::toggled, this, [this](bool on) {
-        m_sMeter->setPeakHoldEnabled(on);
-        AppSettings::instance().setValue("PeakHoldEnabled", on ? "True" : "False");
-        AppSettings::instance().save();
+    // Restore saved state onto the gauge at startup (#809, #840).
+    {
+        auto& s = AppSettings::instance();
+        const int txIdx = qBound(0, s.value("SMeter_TxSelect", 0).toInt(),
+                                 static_cast<int>(kTxMeterItems.size()) - 1);
+        const int rxIdx = qBound(0, s.value("SMeter_RxSelect", 0).toInt(),
+                                 static_cast<int>(kRxMeterItems.size()) - 1);
+        m_sMeter->setTxMode(kTxMeterItems[txIdx]);
+        m_sMeter->setRxMode(kRxMeterItems[rxIdx]);
+        m_sMeter->setPeakHoldEnabled(s.value("PeakHoldEnabled", "False") == "True");
+        applyDecayPreset(s.value("PeakDecayRate", "Medium").toString());
+    }
+
+    m_sMeter->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_sMeter, &QWidget::customContextMenuRequested, this,
+            [this, applyDecayPreset](const QPoint& pos) {
+        auto& s = AppSettings::instance();
+        QMenu menu(m_sMeter);
+
+        // Section header rows. QMenu::addSection() doesn't render its text under
+        // the app's menu styling (only the separator shows), so use a disabled
+        // QWidgetAction + styled QLabel so the section titles are always visible.
+        bool firstHeader = true;
+        auto addHeader = [&menu, &firstHeader](const QString& text) {
+            if (!firstHeader)
+                menu.addSeparator();
+            firstHeader = false;
+            auto* lbl = new QLabel(text);
+            lbl->setStyleSheet(
+                "color:#8090a0; font-size:10px; font-weight:bold; "
+                "padding:4px 8px 2px 8px;");
+            auto* wa = new QWidgetAction(&menu);
+            wa->setDefaultWidget(lbl);
+            wa->setEnabled(false);
+            menu.addAction(wa);
+        };
+
+        // TX Select (exclusive)
+        addHeader("TX Select");
+        auto* txGroup = new QActionGroup(&menu);
+        const int txCur = s.value("SMeter_TxSelect", 0).toInt();
+        for (int i = 0; i < kTxMeterItems.size(); ++i) {
+            QAction* a = menu.addAction(kTxMeterItems[i]);
+            a->setCheckable(true);
+            a->setChecked(i == txCur);
+            txGroup->addAction(a);
+            connect(a, &QAction::triggered, this, [this, i] {
+                m_sMeter->setTxMode(kTxMeterItems[i]);
+                AppSettings::instance().setValue("SMeter_TxSelect", i);
+                AppSettings::instance().save();
+            });
+        }
+
+        // RX Select (exclusive)
+        addHeader("RX Select");
+        auto* rxGroup = new QActionGroup(&menu);
+        const int rxCur = s.value("SMeter_RxSelect", 0).toInt();
+        for (int i = 0; i < kRxMeterItems.size(); ++i) {
+            QAction* a = menu.addAction(kRxMeterItems[i]);
+            a->setCheckable(true);
+            a->setChecked(i == rxCur);
+            rxGroup->addAction(a);
+            connect(a, &QAction::triggered, this, [this, i] {
+                m_sMeter->setRxMode(kRxMeterItems[i]);
+                AppSettings::instance().setValue("SMeter_RxSelect", i);
+                AppSettings::instance().save();
+            });
+        }
+
+        // Peak Hold (toggle)
+        addHeader("Peak Hold");
+        QAction* peakAct = menu.addAction("Enabled");
+        peakAct->setCheckable(true);
+        peakAct->setChecked(s.value("PeakHoldEnabled", "False") == "True");
+        connect(peakAct, &QAction::toggled, this, [this](bool on) {
+            m_sMeter->setPeakHoldEnabled(on);
+            AppSettings::instance().setValue("PeakHoldEnabled", on ? "True" : "False");
+            AppSettings::instance().save();
+        });
+
+        // Decay speed (exclusive)
+        addHeader("Decay speed");
+        auto* decayGroup = new QActionGroup(&menu);
+        const QString decayCur = s.value("PeakDecayRate", "Medium").toString();
+        for (const QString& d : kDecayItems) {
+            QAction* a = menu.addAction(d);
+            a->setCheckable(true);
+            a->setChecked(d == decayCur);
+            decayGroup->addAction(a);
+            connect(a, &QAction::triggered, this, [this, d, applyDecayPreset] {
+                applyDecayPreset(d);
+                AppSettings::instance().setValue("PeakDecayRate", d);
+                AppSettings::instance().save();
+            });
+        }
+
+        // Reset Peak Hold
+        menu.addSeparator();
+        QAction* rstAct = menu.addAction("Reset Peak Hold");
+        connect(rstAct, &QAction::triggered, m_sMeter, &SMeterWidget::resetPeak);
+
+        menu.exec(m_sMeter->mapToGlobal(pos));
     });
-    connect(decayCombo, &QComboBox::currentTextChanged,
-            this, [this, applyDecayPreset](const QString& rate) {
-        applyDecayPreset(rate);
-        AppSettings::instance().setValue("PeakDecayRate", rate);
-        AppSettings::instance().save();
-    });
-    connect(resetBtn, &QPushButton::clicked, m_sMeter, &SMeterWidget::resetPeak);
 
     // One-shot migration: legacy Applet_ANLG visibility key → Applet_VU.
     // Run before reading Applet_VU so the first launch after upgrade

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -255,8 +255,6 @@ private:
     ContainerWidget* m_sMeterContainer{nullptr};
     QPushButton*     m_vuBtn{nullptr};
     SMeterWidget*    m_sMeter{nullptr};
-    QComboBox*    m_txSelect{nullptr};
-    QComboBox*    m_rxSelect{nullptr};
     RxApplet*    m_rxApplet{nullptr};
     TunerApplet* m_tunerApplet{nullptr};
     AmpApplet*   m_ampApplet{nullptr};

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -612,6 +612,28 @@ void SMeterWidget::paintEvent(QPaintEvent*)
     }
     }
 
+    // Pivot cover radius — shared by the backlight glow and the cover itself.
+    const float pivotCoverR = qMax(13.5f, w * 0.0975f);
+
+    // -- Pivot backlight glow -------------------------------------------------
+    // A warm radial glow behind the pivot, as if a lamp sits behind the mask.
+    // Drawn before the needle/cover; the cover masks the bright centre, leaving
+    // a soft halo spilling out from behind the moulding.
+    {
+        const float glowR = pivotCoverR * 3.4f;
+        const float edge = pivotCoverR / glowR;
+        const float mid  = edge + (1.0f - edge) * 0.45f;
+        QRadialGradient glow(QPointF(cx, h), glowR, QPointF(cx, h));
+        glow.setColorAt(0.0f,  QColor(0xff, 0xb0, 0x60, 80));
+        glow.setColorAt(edge,  QColor(0xff, 0xb0, 0x60, 80));
+        glow.setColorAt(mid,   QColor(0xff, 0xb0, 0x60, 28));
+        glow.setColorAt(1.0f,  QColor(0xff, 0xb0, 0x60, 0));
+        p.setPen(Qt::NoPen);
+        p.setBrush(glow);
+        p.drawChord(QRectF(cx - glowR, h - glowR, glowR * 2.0f, glowR * 2.0f),
+                    0, 180 * 16);
+    }
+
     // -- Draw needle ----------------------------------------------------------
     // Needle originates from needleCy (just below widget) rather than the
     // arc center, so the pivot is barely out of frame.
@@ -631,6 +653,22 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         // Needle
         p.setPen(QPen(QColor(0xff, 0xff, 0xff), 2));
         p.drawLine(QPointF(cx, needleCy), QPointF(tipX, tipY));
+    }
+
+    // -- Needle pivot cover ---------------------------------------------------
+    // A filled half-disc at the bottom-centre hides where the needle pivots,
+    // like the moulded bump on a classic analog VU meter. Drawn after the
+    // needle so it masks the base; the needle appears to emerge from under it.
+    {
+        const float coverR = pivotCoverR;
+        const QRectF coverRect(cx - coverR, h - coverR, coverR * 2.0f, coverR * 2.0f);
+        p.setPen(Qt::NoPen);
+        p.setBrush(QColor(0x05, 0x05, 0x09));     // near-black moulding
+        p.drawChord(coverRect, 0, 180 * 16);       // upper half-disc (flat edge at bottom)
+        // Subtle glossy rim along the curved top edge.
+        p.setBrush(Qt::NoBrush);
+        p.setPen(QPen(QColor(0x3a, 0x3e, 0x48), 1));
+        p.drawArc(coverRect, 0, 180 * 16);
     }
 
     // Draw peak marker (small triangle) — only in RX S-Meter Peak mode

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -1,5 +1,6 @@
 #include "SMeterWidget.h"
 #include "MeterSmoother.h"  // shared lean-mode repaint gate (#3283)
+#include "core/ThemeManager.h"
 
 #include <QAccessible>
 #include <QPainter>
@@ -623,11 +624,18 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         const float glowR = pivotCoverR * 3.4f;
         const float edge = pivotCoverR / glowR;
         const float mid  = edge + (1.0f - edge) * 0.45f;
+        QColor glowColor =
+            ThemeManager::instance().color(QStringLiteral("color.meter.pivot.glow"));
+        auto glowAlpha = [&glowColor](int a) {
+            QColor c = glowColor;
+            c.setAlpha(a);
+            return c;
+        };
         QRadialGradient glow(QPointF(cx, h), glowR, QPointF(cx, h));
-        glow.setColorAt(0.0f,  QColor(0xff, 0xb0, 0x60, 80));
-        glow.setColorAt(edge,  QColor(0xff, 0xb0, 0x60, 80));
-        glow.setColorAt(mid,   QColor(0xff, 0xb0, 0x60, 28));
-        glow.setColorAt(1.0f,  QColor(0xff, 0xb0, 0x60, 0));
+        glow.setColorAt(0.0f,  glowAlpha(80));
+        glow.setColorAt(edge,  glowAlpha(80));
+        glow.setColorAt(mid,   glowAlpha(28));
+        glow.setColorAt(1.0f,  glowAlpha(0));
         p.setPen(Qt::NoPen);
         p.setBrush(glow);
         p.drawChord(QRectF(cx - glowR, h - glowR, glowR * 2.0f, glowR * 2.0f),
@@ -663,11 +671,13 @@ void SMeterWidget::paintEvent(QPaintEvent*)
         const float coverR = pivotCoverR;
         const QRectF coverRect(cx - coverR, h - coverR, coverR * 2.0f, coverR * 2.0f);
         p.setPen(Qt::NoPen);
-        p.setBrush(QColor(0x05, 0x05, 0x09));     // near-black moulding
-        p.drawChord(coverRect, 0, 180 * 16);       // upper half-disc (flat edge at bottom)
+        p.setBrush(ThemeManager::instance().color(
+            QStringLiteral("color.meter.pivot.fill")));   // moulding
+        p.drawChord(coverRect, 0, 180 * 16);              // upper half-disc (flat edge at bottom)
         // Subtle glossy rim along the curved top edge.
         p.setBrush(Qt::NoBrush);
-        p.setPen(QPen(QColor(0x3a, 0x3e, 0x48), 1));
+        p.setPen(QPen(ThemeManager::instance().color(
+            QStringLiteral("color.meter.pivot.rim")), 1));
         p.drawArc(coverRect, 0, 180 * 16);
     }
 


### PR DESCRIPTION
## Summary

Two VU/S-meter changes:

1. **Config → right-click context menu.** Moves all of the applet's inline config controls (TX Select + RX Select combos, Peak Hold button, Decay combo, RST) into a right-click context menu on the gauge, so the applet body is just the meter.
2. **Needle pivot cover + backlight glow.** Masks the needle's origin behind a moulded half-disc with a warm, diffuse backlight glow, like a classic analog VU meter.

## Config context menu

Right-click the S-meter → a `QMenu` with five labelled sections:

- **TX Select** — Power / SWR / Level / Compression (exclusive)
- **RX Select** — S-Meter / S-Meter Peak (exclusive)
- **Peak Hold** — Enabled (toggle)
- **Decay speed** — Fast / Medium / Slow (exclusive)
- **Reset Peak Hold** — action

Exclusive groups use `QActionGroup`. Section headers are disabled `QWidgetAction` + styled `QLabel` rows, because `QMenu::addSection()`'s text doesn't render under the app's menu styling (only its separator shows) — see #3858 for the bridge follow-up.

No behavior change: the menu reads/writes the same AppSettings keys (`SMeter_TxSelect`, `SMeter_RxSelect`, `PeakHoldEnabled`, `PeakDecayRate`) and calls the same `SMeterWidget` methods; startup restores saved state directly onto the gauge. Removed the now-unused `m_txSelect`/`m_rxSelect` members.

## Pivot cover + glow

- A filled half-disc at the bottom-centre (near-black moulding + subtle glossy rim) hides where the needle pivots; the needle appears to emerge from under it.
- A warm radial backlight glow behind the cover — the cover masks the bright centre, leaving a soft, diffuse amber halo spilling out from behind the moulding. Drawn behind the needle so the needle stays crisp.

## Test plan

- [x] Builds clean (`cmake --build build --target AetherSDR`)
- [x] Bridge-verified: inline controls removed, gauge intact, no crash
- [x] FLEX-8600: right-click menu (with section headers) works and selections persist; pivot cover + glow look correct

## Note

UX change (controls → context menu) + visual change (pivot cover/glow); both at maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
