### PR TITLE
fix(smartmtr): TX meter + audio gate engage on VOX-keyed transmit

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4887,14 +4887,15 @@ void RadioModel::onStatusReceived(const QString& object,
             // tune. SW source still requires m_txRequested so the optimistic
             // local-unkey behaviour from the TX_SYNC_FIX_REPORT is preserved
             // (a stale state=TRANSMITTING after setTransmit(false) on SW
-            // source still falls through to the force-off branch).
-            const bool hardwarePtt = (m_lastInterlockSource == "MIC"
-                                      || m_lastInterlockSource == "ACC"
-                                      || m_lastInterlockSource == "RCA");
-
-            if (!m_txOwnedByUs ||
-                (!m_txRequested && !m_cwKeyActive && !m_cwxActive
-                 && !m_transmitModel.isTuning() && !hardwarePtt)) {
+            // source still falls through to the force-off branch). VOX also
+            // keys the radio autonomously (no setTransmit()); when VOX is
+            // enabled and we own TX, treat it as an owned-TX path like
+            // hardware PTT so the SmartMtr TX meter and audio gate engage
+            // (#3861). See RadioStatusOwnership::interlockKeepsLocalTxOn.
+            if (!RadioStatusOwnership::interlockKeepsLocalTxOn(
+                    m_txOwnedByUs, m_txRequested, m_cwKeyActive, m_cwxActive,
+                    m_transmitModel.isTuning(), m_lastInterlockSource,
+                    m_transmitModel.voxEnable())) {
                 // Another client owns TX, or local unkey requested:
                 // force local TX/audio gate off through all interlock states.
                 m_transmitModel.setTransmitting(false);

--- a/src/models/RadioStatusOwnership.h
+++ b/src/models/RadioStatusOwnership.h
@@ -91,6 +91,26 @@ inline bool statusRemoved(const StreamObjectParts& stream,
         || kvs.value(QStringLiteral("in_use")) == QStringLiteral("0");
 }
 
+// Decide whether an interlock status update should keep local TX (SmartMtr TX
+// meter + TX audio gate) ON. Returns false => force off. Mirrors the gate in
+// RadioModel's interlock handler. VOX keys the radio autonomously (no
+// setTransmit(), so txRequested stays false); when VOX is enabled and we own
+// the transmitter, treat it as a legitimate owned-TX path like hardware PTT.
+// voxEnabled has zero effect when false, so all non-VOX behavior is unchanged.
+inline bool interlockKeepsLocalTxOn(bool txOwnedByUs, bool txRequested,
+                                    bool cwKeyActive, bool cwxActive, bool tuning,
+                                    const QString& lastInterlockSource,
+                                    bool voxEnabled)
+{
+    if (!txOwnedByUs)
+        return false;  // another client owns TX — always force off
+    const bool hardwarePtt = (lastInterlockSource == QLatin1String("MIC")
+                              || lastInterlockSource == QLatin1String("ACC")
+                              || lastInterlockSource == QLatin1String("RCA"));
+    return txRequested || cwKeyActive || cwxActive || tuning
+           || hardwarePtt || voxEnabled;
+}
+
 enum class OwnedStatusAction {
     Defer,
     Claim,

--- a/tests/radio_status_ownership_test.cpp
+++ b/tests/radio_status_ownership_test.cpp
@@ -43,6 +43,49 @@ void testPanadapterOwnershipDecisions()
           "pan removal wins over ownership uncertainty");
 }
 
+void testInterlockTxGate()
+{
+    // VOX keys the radio autonomously, so txRequested stays false. With VOX
+    // enabled and TX owned, local TX must stay ON regardless of the interlock
+    // source token (#3861).
+    check(interlockKeepsLocalTxOn(true, false, false, false, false,
+                                  QString(), true),
+          "VOX-enabled owned TX keeps local TX on with absent source token");
+    check(interlockKeepsLocalTxOn(true, false, false, false, false,
+                                  QStringLiteral("VOX"), true),
+          "VOX-enabled owned TX keeps local TX on with source=VOX");
+
+    // Regression guards: behavior with VOX disabled must be unchanged.
+    check(!interlockKeepsLocalTxOn(true, false, false, false, false,
+                                   QStringLiteral("SW"), false),
+          "VOX-off SW source without txRequested still forces off (optimistic unkey)");
+    check(!interlockKeepsLocalTxOn(true, false, false, false, false,
+                                   QString(), false),
+          "VOX-off owned TX without any key path forces off");
+
+    // Foreign TX owner always forces off, even with VOX enabled.
+    check(!interlockKeepsLocalTxOn(false, false, false, false, false,
+                                   QStringLiteral("VOX"), true),
+          "foreign TX owner forces off even with VOX enabled");
+
+    // Existing owned-TX paths unchanged with VOX off.
+    check(interlockKeepsLocalTxOn(true, true, false, false, false,
+                                  QStringLiteral("SW"), false),
+          "SW MOX with txRequested keeps local TX on");
+    check(interlockKeepsLocalTxOn(true, false, false, false, false,
+                                  QStringLiteral("MIC"), false),
+          "hardware MIC PTT keeps local TX on");
+    check(interlockKeepsLocalTxOn(true, false, false, false, false,
+                                  QStringLiteral("ACC"), false),
+          "hardware ACC PTT keeps local TX on");
+    check(interlockKeepsLocalTxOn(true, false, true, false, false,
+                                  QString(), false),
+          "CW key keeps local TX on");
+    check(interlockKeepsLocalTxOn(true, false, false, false, true,
+                                  QString(), false),
+          "tune keeps local TX on");
+}
+
 void testRemoteAudioRxTracking()
 {
     constexpr quint32 ours = 0x12345678;
@@ -300,6 +343,7 @@ int main()
 {
     std::printf("Radio status ownership tests\n\n");
     testPanadapterOwnershipDecisions();
+    testInterlockTxGate();
     testRemoteAudioRxTracking();
     testStreamStatusOwnershipCompatibility();
     testDaxTxStatusOwnership();


### PR DESCRIPTION
Closes #3861

## Problem
The SmartMtr TX meter (and the TX audio gate) did not engage when transmit was keyed via **VOX**, though it worked for MOX/PTT, hardware PTT (MIC/ACC/RCA), CW, and Tune.

## Root cause
VOX keys the radio autonomously, so the client never calls `setTransmit()` and `m_txRequested` stays `false`. The interlock gate in `RadioModel` only treated `m_txRequested`, CW key, CWX, Tune, or hardware PTT sources (`MIC/ACC/RCA`) as legitimate owned-TX paths. A VOX-keyed `state=TRANSMITTING` matched none of them, so the force-off branch ran `setTransmitting(false)` — `moxChanged` never fired, the SmartMtr stayed on the RX Signal scale, and the TX audio gate stayed closed.

The recognized sources (`SW/MIC/ACC/RCA/TUNE`) come from FlexLib `ParsePTTSource` (added in #2373 for the analogous hardware-PTT case); VOX was never added.

## Fix
Extract the force-off decision into a pure helper `RadioStatusOwnership::interlockKeepsLocalTxOn(...)` and add VOX as an owned-TX path **gated on `TransmitModel::voxEnable()`**.

Gating on `voxEnable()` (which the radio echoes via `transmit ... vox_enable=1`) rather than matching a `source=="VOX"` token is correct regardless of the interlock source string the radio emits, and cannot mis-fire:
- still ANDed with `m_txOwnedByUs`, so foreign-TX force-off wins first;
- non-TX interlock states still fall through to the existing release path, so VOX-enabled does **not** stick TX on — TX only engages on an actual `state=TRANSMITTING`.

## Non-breaking
When VOX is off, the boolean is **bit-identical** to before, so MOX/PTT, hardware PTT, CW, CWX, Tune, and the SW optimistic local-unkey behaviour are unchanged.

## Tests
Adds `testInterlockTxGate()` with VOX cases plus regression guards (SW unkey, foreign-owner force-off, hardware PTT, CW, Tune, MOX). The interlock gate had no unit coverage before; extracting the decision makes it testable.

- New gate cases: 10/10 pass
- Full app builds and links
- Full suite: 50/50 pass (incl. `transmit_model_test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)