### PR TITLE
[codex] Mute KiwiSDR audio during non-FDX transmit

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -277,7 +277,8 @@ connects).
 
 | `model` | `selector` | returns |
 |---|---|---|
-| `radio` | — | radio snapshot (name, model, version, connected, transmitting, txPower, paTemp, slice/pan counts) |
+| `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, KiwiSDR TX mute gate) |
+| `radio` | — | radio snapshot (name, model, version, connected, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
 | `equalizer` (or `eq`) | — | 8-band RX+TX graphic EQ: `rxEnabled`/`txEnabled` and `rx`/`tx` band maps keyed by label (`63`…`8k`). Validate EQ-applet slider changes. |
 | `slices` | — | array of all slice snapshots |

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -593,10 +593,27 @@ AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
     return m_externalKiwiSources.back().get();
 }
 
+bool AudioEngine::kiwiSdrAudioTransmitMuted() const
+{
+    return m_kiwiSdrAudioTransmitMuted.load(std::memory_order_relaxed);
+}
+
+bool AudioEngine::kiwiSdrAudioActive() const
+{
+    return m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed)
+        && !kiwiSdrAudioTransmitMuted();
+}
+
+bool AudioEngine::externalKiwiSourceAudible(
+    const ExternalRxAudioSourceState& source) const
+{
+    return source.enabled && !source.muted && !kiwiSdrAudioTransmitMuted();
+}
+
 bool AudioEngine::anyExternalKiwiAudioEnabled() const
 {
     for (const auto& source : m_externalKiwiSources) {
-        if (source && source->enabled && !source->muted) {
+        if (source && externalKiwiSourceAudible(*source)) {
             return true;
         }
     }
@@ -606,7 +623,7 @@ bool AudioEngine::anyExternalKiwiAudioEnabled() const
 bool AudioEngine::anyExternalKiwiBufferQueued() const
 {
     for (const auto& source : m_externalKiwiSources) {
-        if (source && !source->muted
+        if (source && !source->muted && !kiwiSdrAudioTransmitMuted()
             && (!source->rxBuffer.isEmpty() || !source->rxPackets.empty()
                 || !source->outputBuffer.isEmpty())) {
             return true;
@@ -619,7 +636,7 @@ qsizetype AudioEngine::externalKiwiOutputBufferBytes() const
 {
     qsizetype maxBytes = 0;
     for (const auto& source : m_externalKiwiSources) {
-        if (source && source->enabled && !source->muted
+        if (source && externalKiwiSourceAudible(*source)
             && !source->prebuffering) {
             maxBytes = std::max(maxBytes, source->outputBuffer.size());
         }
@@ -777,8 +794,7 @@ AudioEngine::AudioEngine(QObject* parent)
         // Cap buffer to bound latency. Default 200ms, user-adjustable for
         // high-jitter connections (VPN, SmartLink) where drops cause choppy audio.
         const int sampleRate = m_rxOutputRate.load();
-        const bool kiwiAudio =
-            m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+        const bool kiwiAudio = kiwiSdrAudioActive();
         const bool externalKiwiAudio = anyExternalKiwiAudioEnabled();
         const bool anyKiwiAudio = kiwiAudio || externalKiwiAudio;
         const int configuredBufMs = m_rxBufferCapMs.load();
@@ -833,7 +849,7 @@ AudioEngine::AudioEngine(QObject* parent)
             if (anyKiwiAudio) {
                 m_kiwiSdrPrebuffering = true;
                 for (const auto& source : m_externalKiwiSources) {
-                    if (source && source->enabled) {
+                    if (source && externalKiwiSourceAudible(*source)) {
                         source->prebuffering = true;
                     }
                 }
@@ -907,7 +923,7 @@ AudioEngine::AudioEngine(QObject* parent)
                 processMixedRxAudioData(packet, RxDspSource::KiwiSdr);
             }
             for (const auto& source : m_externalKiwiSources) {
-                if (!source || !source->enabled || source->muted) {
+                if (!source || !externalKiwiSourceAudible(*source)) {
                     continue;
                 }
                 while (!source->rxPackets.empty()) {
@@ -940,7 +956,8 @@ AudioEngine::AudioEngine(QObject* parent)
             }
         }
         for (const auto& source : m_externalKiwiSources) {
-            if (!source || !source->enabled || !source->prebuffering) {
+            if (!source || !externalKiwiSourceAudible(*source)
+                || !source->prebuffering) {
                 continue;
             }
             const int prebufferMs = std::min(
@@ -972,7 +989,8 @@ AudioEngine::AudioEngine(QObject* parent)
         const bool kiwiMixActive =
             kiwiAudio && !kiwiNr2PacketMode && !m_kiwiSdrPrebuffering;
         for (const auto& source : m_externalKiwiSources) {
-            if (!source || !source->enabled || source->muted || source->prebuffering) {
+            if (!source || !externalKiwiSourceAudible(*source)
+                || source->prebuffering) {
                 continue;
             }
             const bool sourceEmpty =
@@ -1036,7 +1054,7 @@ AudioEngine::AudioEngine(QObject* parent)
         // them unless the applet-level Kiwi Audio toggle is also enabled.
         if (!nr2PacketMode) {
             for (const auto& source : m_externalKiwiSources) {
-                if (!source || !source->enabled || source->muted
+                if (!source || !externalKiwiSourceAudible(*source)
                     || source->prebuffering) {
                     continue;
                 }
@@ -1139,7 +1157,7 @@ AudioEngine::AudioEngine(QObject* parent)
                 }
 
                 for (const auto& source : m_externalKiwiSources) {
-                    if (!source || !source->enabled || source->muted
+                    if (!source || !externalKiwiSourceAudible(*source)
                         || source->prebuffering) {
                         continue;
                     }
@@ -1873,6 +1891,9 @@ void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
         return;
     }
     m_lastAudioFeedTime.start();
+    if (kiwiSdrAudioTransmitMuted()) {
+        return;
+    }
 
     constexpr qsizetype kFrameBytes =
         2 * static_cast<qsizetype>(sizeof(float));
@@ -1901,10 +1922,13 @@ void AudioEngine::feedKiwiSdrAudioData(const QString& sourceId,
                                        const QByteArray& pcm24kStereoFloat)
 {
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
-    if (!source || !source->enabled || source->muted) {
+    if (!source || !source->enabled) {
         return;
     }
     m_lastAudioFeedTime.start();
+    if (source->muted || kiwiSdrAudioTransmitMuted()) {
+        return;
+    }
 
     constexpr qsizetype kFrameBytes =
         2 * static_cast<qsizetype>(sizeof(float));
@@ -1948,7 +1972,7 @@ void AudioEngine::setKiwiSdrAudioEnabled(bool on)
     if (m_nr2Enabled && m_kiwiSdrNr2) {
         m_kiwiSdrNr2->reset();
     }
-    m_kiwiSdrPrebuffering = on;
+    m_kiwiSdrPrebuffering = on && !kiwiSdrAudioTransmitMuted();
     updateRxBufferStats();
 }
 
@@ -2021,7 +2045,52 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
     source->bnrDown.reset();
     source->bnrOutBuf.clear();
     source->bnrPrimed = false;
-    source->prebuffering = !muted && source->enabled;
+    source->prebuffering =
+        !muted && source->enabled && !kiwiSdrAudioTransmitMuted();
+    updateRxBufferStats();
+}
+
+void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
+{
+    if (m_kiwiSdrAudioTransmitMuted.exchange(
+            muted, std::memory_order_relaxed) == muted) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_kiwiSdrNr2Mono.clear();
+    m_kiwiSdrNr2Processed.clear();
+    m_kiwiSdrNr2Output.clear();
+    m_kiwiSdrBnrOutBuf.clear();
+    m_kiwiSdrBnrPrimed = false;
+    if (m_nr2Enabled && m_kiwiSdrNr2) {
+        m_kiwiSdrNr2->reset();
+    }
+    m_kiwiSdrPrebuffering = !muted
+        && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Mono.clear();
+        source->nr2Processed.clear();
+        source->nr2Output.clear();
+        source->bnrUp.reset();
+        source->bnrDown.reset();
+        source->bnrOutBuf.clear();
+        source->bnrPrimed = false;
+        if (m_nr2Enabled && source->nr2) {
+            source->nr2->reset();
+        }
+        source->prebuffering = !muted && source->enabled && !source->muted;
+    }
     updateRxBufferStats();
 }
 
@@ -2096,7 +2165,7 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
         if (m_nr2Enabled && source->nr2) {
             source->nr2->reset();
         }
-        source->prebuffering = source->enabled && !source->muted;
+        source->prebuffering = externalKiwiSourceAudible(*source);
     }
 
     if (m_clientEqRx) {
@@ -4352,7 +4421,7 @@ void AudioEngine::setNr2Enabled(bool on)
     m_kiwiSdrNr2Mono.clear();
     m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
-    m_kiwiSdrPrebuffering = m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+    m_kiwiSdrPrebuffering = kiwiSdrAudioActive();
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
             continue;
@@ -4365,7 +4434,7 @@ void AudioEngine::setNr2Enabled(bool on)
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
-        source->prebuffering = source->enabled && !source->muted;
+        source->prebuffering = externalKiwiSourceAudible(*source);
     }
     if (on) {
         // Disable all other NR modes — they're mutually exclusive
@@ -4423,7 +4492,7 @@ void AudioEngine::setNr2Enabled(bool on)
             source->outputBuffer.clear();
             source->rxResampler.reset();
             source->rxResamplerR.reset();
-            source->prebuffering = source->enabled && !source->muted;
+            source->prebuffering = externalKiwiSourceAudible(*source);
         }
     }
     qCDebug(lcAudio) << "AudioEngine: NR2" << (on ? "enabled" : "disabled");

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -127,6 +127,7 @@ public:
     void setMuted(bool m);
     bool isRxStreaming() const { return m_audioSink != nullptr; }
     bool isTxStreaming() const { return m_audioSource != nullptr; }
+    bool kiwiSdrAudioTransmitMuted() const;
     int  txInputSampleRate() const { return m_txInputRate; }
     int  txInputChannelCount() const { return m_txInputChannels; }
     bool txInputResamplingTo24k() const { return m_txNeedsResample; }
@@ -493,6 +494,7 @@ public slots:
     void setKiwiSdrAudioSourceGain(const QString& sourceId, float gainPercent);
     void setKiwiSdrAudioSourceMuted(const QString& sourceId, bool muted);
     void setKiwiSdrAudioSourcePan(const QString& sourceId, int pan);
+    void setKiwiSdrAudioTransmitMuted(bool muted);
     void removeKiwiSdrAudioSource(const QString& sourceId);
 
 signals:
@@ -609,6 +611,8 @@ private:
     void updateRxBufferStats();
     ExternalRxAudioSourceState* externalKiwiSource(const QString& sourceId,
                                                    bool create);
+    bool kiwiSdrAudioActive() const;
+    bool externalKiwiSourceAudible(const ExternalRxAudioSourceState& source) const;
     bool anyExternalKiwiAudioEnabled() const;
     bool anyExternalKiwiBufferQueued() const;
     qsizetype externalKiwiOutputBufferBytes() const;
@@ -961,6 +965,7 @@ private:
     QByteArray    m_kiwiSdrOutputBuffer;  // post-DSP Kiwi speaker audio at output device rate
     QByteArray    m_radeRxBuffer;  // decoded RADE speech at output device rate
     std::atomic<bool> m_kiwiSdrAudioEnabled{false};
+    std::atomic<bool> m_kiwiSdrAudioTransmitMuted{false};
     bool          m_kiwiSdrPrebuffering{false};
     std::vector<std::unique_ptr<ExternalRxAudioSourceState>> m_externalKiwiSources;
     std::atomic<qsizetype> m_rxBufferBytes{0};

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -32,6 +32,7 @@
 #include <QCoreApplication>
 #include <QRegularExpression>
 #include <QSet>
+#include <QThread>
 #include <QTimer>
 #include <QDateTime>
 #include <QTime>
@@ -1007,6 +1008,29 @@ QJsonObject audioSnapshot(const AudioEngine* audio)
         {QStringLiteral("rxBufferSampleRate"),
             audio->rxBufferSampleRate()},
     };
+}
+
+QJsonObject audioSnapshotOnObjectThread(AudioEngine* audio, bool* ok)
+{
+    *ok = false;
+    if (!audio) {
+        return {};
+    }
+
+    if (!audio->thread() || audio->thread() == QThread::currentThread()) {
+        *ok = true;
+        return audioSnapshot(audio);
+    }
+
+    QJsonObject snapshot;
+    const bool invoked = QMetaObject::invokeMethod(
+        audio,
+        [audio, &snapshot]() {
+            snapshot = audioSnapshot(audio);
+        },
+        Qt::BlockingQueuedConnection);
+    *ok = invoked;
+    return snapshot;
 }
 
 // 8-band graphic EQ (RX + TX). Lets a scenario assert EQ-applet slider changes
@@ -2103,13 +2127,19 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
 {
     if (model == QLatin1String("audio")) {
         AudioEngine* audio = m_audioEngine;
-        if (!audio)
+        if (!audio) {
             return err(QStringLiteral("no audio engine available"));
-        QJsonObject data = audioSnapshot(audio);
+        }
+        bool snapshotOk = false;
+        QJsonObject data = audioSnapshotOnObjectThread(audio, &snapshotOk);
+        if (!snapshotOk) {
+            return err(QStringLiteral("audio engine snapshot unavailable"));
+        }
         if (!property.isEmpty()) {
-            if (!data.contains(property))
+            if (!data.contains(property)) {
                 return err(QStringLiteral("unknown property '") + property
                            + QStringLiteral("' for audio"));
+            }
             return QJsonObject{{QStringLiteral("ok"), true},
                                {QStringLiteral("model"), model},
                                {QStringLiteral("property"), property},

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2,6 +2,7 @@
 #include "LogManager.h"
 #include "AppSettings.h"          // StationName (restore the user's real station name)
 #include "TxKeyingMarker.h"       // kTxKeyingProperty — authoritative TX-guard marker
+#include "AudioEngine.h"
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 #include "gui/ConnectionPanel.h" // ConnectionPanel automation facade
 
@@ -909,6 +910,7 @@ QJsonObject radioSnapshot(const RadioModel* r)
         {QStringLiteral("callsign"),     r->callsign()},
         {QStringLiteral("nickname"),     r->nickname()},
         {QStringLiteral("connected"),    r->isConnected()},
+        {QStringLiteral("fullDuplex"),   r->fullDuplexEnabled()},
         {QStringLiteral("transmitting"), r->isRadioTransmitting()},
         {QStringLiteral("txPower"),      r->txPower()},
         {QStringLiteral("paTemp"),       r->paTemp()},
@@ -985,6 +987,25 @@ QJsonObject transmitSnapshot(const TransmitModel* t)
         {QStringLiteral("atuStatus"),       atuStatusName(t->atuStatus())},
         {QStringLiteral("apdEnabled"),      t->apdEnabled()},
         {QStringLiteral("showTxInWaterfall"), t->showTxInWaterfall()},
+    };
+}
+
+QJsonObject audioSnapshot(const AudioEngine* audio)
+{
+    return QJsonObject{
+        {QStringLiteral("muted"), audio->isMuted()},
+        {QStringLiteral("rxStreaming"), audio->isRxStreaming()},
+        {QStringLiteral("txStreaming"), audio->isTxStreaming()},
+        {QStringLiteral("kiwiSdrTransmitMuted"),
+            audio->kiwiSdrAudioTransmitMuted()},
+        {QStringLiteral("rxBufferBytes"),
+            static_cast<qint64>(audio->rxBufferBytes())},
+        {QStringLiteral("rxBufferPeakBytes"),
+            static_cast<qint64>(audio->rxBufferPeakBytes())},
+        {QStringLiteral("rxBufferUnderrunCount"),
+            static_cast<double>(audio->rxBufferUnderrunCount())},
+        {QStringLiteral("rxBufferSampleRate"),
+            audio->rxBufferSampleRate()},
     };
 }
 
@@ -2080,6 +2101,25 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
 QJsonObject AutomationServer::doGet(const QString& model, const QString& selector,
                                     const QString& property) const
 {
+    if (model == QLatin1String("audio")) {
+        AudioEngine* audio = m_audioEngine;
+        if (!audio)
+            return err(QStringLiteral("no audio engine available"));
+        QJsonObject data = audioSnapshot(audio);
+        if (!property.isEmpty()) {
+            if (!data.contains(property))
+                return err(QStringLiteral("unknown property '") + property
+                           + QStringLiteral("' for audio"));
+            return QJsonObject{{QStringLiteral("ok"), true},
+                               {QStringLiteral("model"), model},
+                               {QStringLiteral("property"), property},
+                               {QStringLiteral("value"), data.value(property)}};
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("audio"), data}};
+    }
+
     RadioModel* radio = m_radioModel;
     if (!radio)
         return err(QStringLiteral("no radio model available"));
@@ -2130,7 +2170,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use audio|radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -22,6 +22,7 @@ namespace AetherSDR {
 
 class RadioModel;
 class ConnectionPanel;
+class AudioEngine;
 
 // In-app, agent-first automation bridge (issue #3646, Phases 0-1).
 //
@@ -58,10 +59,11 @@ class ConnectionPanel;
 //                                     is a logged fallback; setpoint
 //                                     sliders/combos are never blocked.
 //   get <model> [selector] [prop]  -> live JSON snapshot of a model:
-//                                     radio | transmit | slice <id|active|tx> |
-//                                     slices | pan <panId|active> | pans. With a
-//                                     trailing property name, returns just that
-//                                     field. Assert on state without screenshots.
+//                                     audio | radio | transmit |
+//                                     slice <id|active|tx> | slices |
+//                                     pan <panId|active> | pans. With a trailing
+//                                     property name, returns just that field.
+//                                     Assert on state without screenshots.
 //   connect list                   -> list currently discovered local radios
 //   connect show                   -> show/raise the Connect to Radio dialog
 //   connect hide                   -> hide the Connect to Radio dialog
@@ -163,6 +165,7 @@ public:
     // MainWindow's active-session RadioModel; may be null (get() then reports
     // "no radio model" rather than crashing).
     void setRadioModel(RadioModel* model) { m_radioModel = model; }
+    void setAudioEngine(AudioEngine* audio) { m_audioEngine = audio; }
     // Real connection dialog hook for the connect/disconnect verbs. The bridge
     // asks ConnectionPanel to emit the same signals the visible buttons do, so
     // automation exercises the normal MainWindow/RadioModel connection path.
@@ -291,6 +294,7 @@ private:
     QString       m_label;            // AETHER_AUTOMATION_LABEL (human instance tag)
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
+    QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<ConnectionPanel> m_connectionPanel;  // for connect/disconnect verbs
     QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -182,6 +182,7 @@ public:
     // (#3646) to read live model state via get(); keep it read-oriented.
     RadioModel& radioModel() { return m_radioModel; }
     const RadioModel& radioModel() const { return m_radioModel; }
+    AudioEngine* audioEngine() const { return m_audio; }
     Q_INVOKABLE void showConnectionDialog();
     Q_INVOKABLE void hideConnectionDialog();
 
@@ -334,6 +335,8 @@ private:
     bool setKiwiSdrAudioRouting(bool active);
     bool applyKiwiSdrSliceMute();
     void restoreKiwiSdrSliceMute();
+    bool kiwiSdrTransmitMuteRequired() const;
+    void syncKiwiSdrTransmitMute();
     void setKiwiSdrVirtualAntennaForSlice(int sliceId, const QString& profileId);
     void clearKiwiSdrVirtualAntennaForSlice(int sliceId);
     void updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice);
@@ -805,6 +808,7 @@ private:
     bool             m_kiwiSdrAudioPreviousMute{false};
     bool             m_kiwiSdrAudioMuteApplied{false};
     bool             m_kiwiSdrAudioMuteChanging{false};
+    bool             m_kiwiSdrAudioTransmitMuted{false};
     QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
     QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
 

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -342,6 +342,7 @@ void MainWindow::activateRADE(int sliceId)
             return;
         }
         m_radeEooPending = true;
+        syncKiwiSdrTransmitMute();
         qCDebug(lcRade) << "MainWindow: PttOffHook — intercepted requestPttOff, deferring for RADE EOO";
         QMetaObject::invokeMethod(m_radeEngine, [this]() {
             m_radeEngine->setEooRequested(true);
@@ -358,6 +359,7 @@ void MainWindow::activateRADE(int sliceId)
         }
         m_radeEooPending = false;
         m_radeTxActive = false;
+        syncKiwiSdrTransmitMute();
 
         // Post setTransmitting(false) AFTER the queued txModemReady(eoo/silence)
         // signals so the audio gate closes only after EOO is in the UDP send buffer.
@@ -388,6 +390,7 @@ void MainWindow::activateRADE(int sliceId)
         if (tx) {
             m_radeEooPending = false;
             m_radeTxActive = true;
+            syncKiwiSdrTransmitMute();
             QMetaObject::invokeMethod(m_radeEngine, [this]() {
                 m_radeEngine->resetTx();
             }, Qt::QueuedConnection);
@@ -395,6 +398,7 @@ void MainWindow::activateRADE(int sliceId)
         } else if (!m_radeEooPending && m_radeTxActive) {
             qCDebug(lcRade) << "MainWindow: moxChanged(false) fallback — unintercepted PTT release, requesting EOO";
             m_radeEooPending = true;
+            syncKiwiSdrTransmitMute();
             QMetaObject::invokeMethod(m_radeEngine, [this]() {
                 m_radeEngine->setEooRequested(true);
             }, Qt::QueuedConnection);
@@ -542,6 +546,7 @@ void MainWindow::deactivateRADE()
     disconnect(m_radeMoxFallbackConn);
     m_radeEooPending = false;
     m_radeTxActive = false;
+    syncKiwiSdrTransmitMute();
 
     m_audio->setRadeMode(false);
     m_radioModel.setDigitalVoiceTxSlice(-1);

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -17,6 +17,7 @@
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "models/TransmitModel.h"
 
 #include <QMetaObject>
 #include <QSet>
@@ -832,6 +833,38 @@ bool MainWindow::setKiwiSdrAudioRouting(bool active)
     return routed;
 }
 
+bool MainWindow::kiwiSdrTransmitMuteRequired() const
+{
+    if (m_radioModel.fullDuplexEnabled()) {
+        return false;
+    }
+
+    const TransmitModel& tx = m_radioModel.transmitModel();
+    bool txActive = tx.isTransmitting() || tx.isTuning()
+        || m_radioModel.isRadioTransmitting();
+#ifdef HAVE_RADE
+    txActive = txActive || m_radeEooPending;
+#endif
+    return txActive;
+}
+
+void MainWindow::syncKiwiSdrTransmitMute()
+{
+    if (!m_audio) {
+        return;
+    }
+
+    const bool muted = kiwiSdrTransmitMuteRequired();
+    if (m_kiwiSdrAudioTransmitMuted == muted) {
+        return;
+    }
+
+    m_kiwiSdrAudioTransmitMuted = muted;
+    QMetaObject::invokeMethod(m_audio, [audio = m_audio, muted]() {
+        audio->setKiwiSdrAudioTransmitMuted(muted);
+    }, Qt::QueuedConnection);
+}
+
 void MainWindow::wireKiwiSdr()
 {
     if (!m_appletPanel || !m_appletPanel->kiwiSdrApplet() || m_kiwiSdrClient) {
@@ -875,6 +908,14 @@ void MainWindow::wireKiwiSdr()
                 audio->removeKiwiSdrAudioSource(id);
             }, Qt::QueuedConnection);
         }
+        connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
+                this, [this](bool) { syncKiwiSdrTransmitMute(); });
+        connect(&m_radioModel.transmitModel(), &TransmitModel::tuneChanged,
+                this, [this](bool) { syncKiwiSdrTransmitMute(); });
+        connect(&m_radioModel, &RadioModel::radioTransmittingChanged,
+                this, [this](bool) { syncKiwiSdrTransmitMute(); });
+        connect(&m_radioModel, &RadioModel::infoChanged,
+                this, [this]() { syncKiwiSdrTransmitMute(); });
         connect(m_kiwiSdrManager, &KiwiSdrManager::waterfallRowReady,
                 this, [this](const QString& profileId, const QString&,
                              const QVector<float>& binsDbm,
@@ -1066,6 +1107,7 @@ void MainWindow::wireKiwiSdr()
             });
     refreshKiwiSdrSlices();
     refreshKiwiSdrWaterfallAvailability();
+    syncKiwiSdrTransmitMute();
 
     if (m_kiwiSdrManager) {
         QTimer::singleShot(0, m_kiwiSdrManager, &KiwiSdrManager::startAutoConnect);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -426,6 +426,7 @@ int main(int argc, char* argv[])
                 : QStringLiteral("aethersdr-automation-%1").arg(QCoreApplication::applicationPid());
             automation = std::make_unique<AetherSDR::AutomationServer>();
             automation->setRadioModel(&window.radioModel());  // for the get() verb
+            automation->setAudioEngine(window.audioEngine());
             automation->setConnectionDialogHost(&window);
             automation->setConnectionPanel(
                 window.findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));


### PR DESCRIPTION
## Summary

When Flex full duplex is disabled, mute KiwiSDR audio output while the radio is transmitting, then automatically unmute when TX ends. This mirrors Flex RX audio behavior without pausing or disconnecting Kiwi streams. The mute predicate follows radio-authoritative full-duplex and TX/interlock state, so MOX/PTT, tune, hardware/interlock TX, DAX/TCI-driven TX paths, and RADE EOO holdoff are covered.

## Constitution principle honored

Principle II - radio-authoritative live state. The Kiwi mute gate is driven from `RadioModel` full-duplex and transmit/interlock state rather than persisted client assumptions.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR`)
- [x] Existing focused tests pass: `ctest --test-dir build -R "kiwi|rade|transmit|audio|automation" --output-on-failure`
- [x] `git diff --check`
- [x] `python3 tools/check_a11y.py` ran; only existing warning-only findings in unrelated GUI files
- [x] Behavior verified on a real radio via automation bridge:
  - confirmed `fullDuplex: false`
  - confirmed TX slice `txAntenna: ANT1`
  - confirmed RF power was 10 W
  - before PTT: `kiwiSdrTransmitMuted: false`
  - during short ANT1-only PTT: radio `transmitting: true`, `kiwiSdrTransmitMuted: true`
  - after PTT off: radio `transmitting: false`, `kiwiSdrTransmitMuted: false`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room - not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention; N/A, no meter UI touched)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable (N/A)
