### PR TITLE
[codex] Fix VFO flag-side pan following

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1730,6 +1730,13 @@ target_include_directories(slice_label_test PRIVATE src)
 target_link_libraries(slice_label_test PRIVATE Qt6::Gui)
 add_test(NAME slice_label_test COMMAND slice_label_test)
 
+add_executable(vfo_flag_placement_test
+    tests/vfo_flag_placement_test.cpp
+)
+target_include_directories(vfo_flag_placement_test PRIVATE src)
+target_link_libraries(vfo_flag_placement_test PRIVATE Qt6::Widgets)
+add_test(NAME vfo_flag_placement_test COMMAND vfo_flag_placement_test)
+
 add_executable(slice_model_letter_test
     tests/slice_model_letter_test.cpp
     src/models/SliceModel.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -191,14 +191,28 @@ PNG capture of a single widget.
   framebuffer readback for it, so the capture is the *real* rendered spectrum,
   not a blank.
 
-**`grab pan <index> [path]`** captures a *specific* pan's spectrum surface in a
-multi-pan layout, keyed on the `panIndex` from `dumpTree`. Plain
+**`grab pan <index> [path]`** captures a *specific* pan's raw spectrum surface
+in a multi-pan layout, keyed on the `panIndex` from `dumpTree`. Plain
 `grab SpectrumWidget` always resolves the first one, so it can't reach pan 1+.
+This is the GPU framebuffer only; child overlays such as VFO flags are not part
+of this image.
 
 ```json
 → {"cmd":"grab","target":"pan","selector":"1","path":"/tmp/pan1.png"}
 ← {"ok":true,"target":"pan1","class":"SpectrumWidget","panIndex":1,
    "path":"/tmp/pan1.png","width":2280,"height":686}
+```
+
+**`grab pan-visible <index> [path]`** captures the operator-visible pan applet,
+including the indexed pan's spectrum surface and child overlays such as VFO
+flags. Use this for screenshots of what the user sees. `pan-composite` is an
+alias.
+
+```json
+→ {"cmd":"grab","target":"pan-visible","selector":"1","path":"/tmp/pan1-visible.png"}
+← {"ok":true,"target":"pan-visible1","class":"PanadapterApplet","panIndex":1,
+   "surfaceClass":"SpectrumWidget","path":"/tmp/pan1-visible.png",
+   "width":2280,"height":710}
 ```
 
 An unknown index returns `{"ok":false,"error":"no pan with index N","available":[0]}`.
@@ -228,6 +242,7 @@ the no-op is an explicit, assertable signal.
 | `toggle` | any `QAbstractButton` (checkable → toggle, else click) | — |
 | `setChecked` | checkable button | `true`/`false`/`on`/`off`/`1`/`0` |
 | `setValue` | slider / scrollbar / spinbox | integer (or number for double-spin) |
+| `wheel` | any visible widget | one wheel notch: `-1` or `1` |
 | `setText` | `QLineEdit` | the text |
 | `setCurrentText` | `QComboBox` | item text |
 | `setCurrentIndex` | `QComboBox` | integer index |
@@ -473,22 +488,26 @@ Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.
 
 `grab` and `invoke` resolve a `target` string in this order — first match wins:
 
-0. **Scoped `"<scope>/<name>"`** — disambiguates a control whose
+0. **VFO shortcuts** — `"vfo slice 1"` or `"vfo:slice:1"` targets the VFO
+   flag for slice 1. `"vfo 1"` or `"vfo:1"` targets the first VFO flag inside
+   the `SpectrumWidget` whose `panIndex` is 1, mirroring `grab pan 1`.
+   Prefer the slice form when a pan contains multiple VFOs.
+1. **Scoped `"<scope>/<name>"`** — disambiguates a control whose
    `accessibleName` appears in more than one applet (e.g. `"AF gain"` and
    `"Squelch threshold"` exist in **both** `RxApplet` and `PanadapterApplet`).
    `<scope>` matches an ancestor by objectName, class, or accessibleName;
    `<name>` is resolved within that subtree. Use `"RxApplet/AF gain"` vs
    `"PanadapterApplet/AF gain"`. Falls through to flat matching if it doesn't
    resolve, so a literal `/` in a name still works.
-1. **Exact `objectName`** — the most stable handle. Prefer this.
-2. **Class name** — full (`AetherSDR::SpectrumWidget`) or short
+2. **Exact `objectName`** — the most stable handle. Prefer this.
+3. **Class name** — full (`AetherSDR::SpectrumWidget`) or short
    (`SpectrumWidget`). Handy when a widget has no objectName (the panadapter is
    targeted as `SpectrumWidget`).
-3. **`accessibleName`** — e.g. `"Panadapter spectrum display"`,
+4. **`accessibleName`** — e.g. `"Panadapter spectrum display"`,
    `"Master volume"`.
-4. **Button text** — last resort, e.g. `"Send"`, `"Transmit"`. Lowest priority,
+5. **Button text** — last resort, e.g. `"Send"`, `"Transmit"`. Lowest priority,
    so a real objectName/accessibleName always wins; first match in tree order.
-5. **Visible popup-menu action** — exact `QAction` objectName, visible text,
+6. **Visible popup-menu action** — exact `QAction` objectName, visible text,
    tooltip, status tip, or data value. Use `invoke <label-or-data> trigger` to
    choose a menu item.
 
@@ -549,8 +568,10 @@ lands.
   `connected` first.
 - **GPU panadapter capture.** `SpectrumWidget` is a `QRhiWidget` when built with
   `AETHER_GPU_SPECTRUM` (the default). The bridge uses
-  `QRhiWidget::grabFramebuffer()` for it — plain `QWidget::grab()` returns an
-  empty surface for a GPU widget, so don't reimplement capture that way.
+  `QRhiWidget::grabFramebuffer()` for raw `SpectrumWidget`/`grab pan` captures
+  because plain `QWidget::grab()` returns an empty surface for a GPU widget.
+  For screenshots that must include child overlays such as VFO flags, use
+  `grab pan-visible <index>`.
 - **Live spectrum isn't golden-able.** Pixels off a live radio are noise.
   Deterministic visual diffs need the recorded-fixture replay mode (Phase 2).
 - **Stale socket after a crash.** On a hard kill the C++ destructor may not run,

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -14,6 +14,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QMouseEvent>
+#include <QWheelEvent>
 #include <QSysInfo>
 #include <QPointer>
 #include <QJsonObject>
@@ -278,6 +279,12 @@ QJsonObject describeWidget(const QWidget* w)
     // will refuse before trying them (#3646).
     if (w->property(kTxKeyingProperty).toBool())
         o[QStringLiteral("keying")] = true;
+    {
+        const QVariant sliceId = w->property("sliceId");
+        if (sliceId.isValid()) {
+            o[QStringLiteral("sliceId")] = sliceId.toInt();
+        }
+    }
 
     // Surface the spectrum's measured FFT noise floor (dBm) when a widget
     // exposes it as a Q_PROPERTY (SpectrumWidget). Read generically via the
@@ -401,6 +408,101 @@ QString panIdForIndex(int index)
         }
     }
     return QString();
+}
+
+QWidget* panSpectrumWidgetForIndex(int index, QJsonArray* available = nullptr)
+{
+    const QList<QWidget*> spectra = findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+    QWidget* match = nullptr;
+    for (QWidget* sw : spectra) {
+        const QVariant pi = sw->property("panIndex");
+        if (!pi.isValid()) {
+            continue;
+        }
+        if (available) {
+            available->append(pi.toInt());
+        }
+        // Prefer a visible surface if duplicate indices ever coexist (e.g. mid
+        // float/dock reparent); otherwise the first index match wins below.
+        if (pi.toInt() == index && (!match || sw->isVisible())) {
+            match = sw;
+        }
+    }
+    return match;
+}
+
+QWidget* panadapterAppletForSpectrum(QWidget* spectrum)
+{
+    for (QWidget* a = spectrum; a; a = a->parentWidget()) {
+        if (shortClassName(a) == QLatin1String("PanadapterApplet")) {
+            return a;
+        }
+    }
+    return nullptr;
+}
+
+QWidget* vfoWidgetForPanIndex(int index)
+{
+    const QList<QWidget*> vfos = findWidgetsByClass(QStringLiteral("VfoWidget"));
+    for (QWidget* vfo : vfos) {
+        for (QWidget* a = vfo; a; a = a->parentWidget()) {
+            if (shortClassName(a) != QLatin1String("SpectrumWidget")) {
+                continue;
+            }
+            const QVariant pi = a->property("panIndex");
+            if (pi.isValid() && pi.toInt() == index) {
+                return vfo;
+            }
+            break;
+        }
+    }
+    return nullptr;
+}
+
+QWidget* vfoWidgetForSliceId(int sliceId)
+{
+    const QList<QWidget*> vfos = findWidgetsByClass(QStringLiteral("VfoWidget"));
+    QWidget* fallback = nullptr;
+    for (QWidget* vfo : vfos) {
+        const QVariant sid = vfo->property("sliceId");
+        if (!sid.isValid() || sid.toInt() != sliceId) {
+            continue;
+        }
+        if (vfo->isVisible()) {
+            return vfo;
+        }
+        if (!fallback) {
+            fallback = vfo;
+        }
+    }
+    return fallback;
+}
+
+QWidget* resolveVfoSelector(const QString& target)
+{
+    static const QRegularExpression sliceRe(
+        QStringLiteral("^vfo(?:\\s+|:)slice(?:\\s+|:)(\\d+)$"),
+        QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch sliceMatch = sliceRe.match(target.trimmed());
+    if (sliceMatch.hasMatch()) {
+        bool ok = false;
+        const int sliceId = sliceMatch.captured(1).toInt(&ok);
+        return ok ? vfoWidgetForSliceId(sliceId) : nullptr;
+    }
+
+    static const QRegularExpression re(
+        QStringLiteral("^vfo(?:\\s+|:)(\\d+)$"),
+        QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch m = re.match(target.trimmed());
+    if (!m.hasMatch()) {
+        return nullptr;
+    }
+    bool ok = false;
+    const int index = m.captured(1).toInt(&ok);
+    if (!ok) {
+        return nullptr;
+    }
+    return vfoWidgetForPanIndex(index);
 }
 
 bool actionMatchesTarget(const QAction* action, const QString& target)
@@ -1227,7 +1329,7 @@ bool AutomationServer::start(const QString& serverName)
 
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, floors, grab, grab pan, invoke, get, connect, disconnect,"
+        << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
         << "txtest, atu, slice, tune, pan, streams, txwaterfall, key, cwx, station, resize,"
         << "menu, close, drag, showMenu, whoami, log, mark)";
     return true;
@@ -1498,8 +1600,10 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));  // "menu open Settings"
         } else if (cmd == QLatin1String("grab")) {
             target = tok(1);
-            if (target == QLatin1String("pan")) {
-                selector = tok(2);   // pan index → "grab pan 1 [path]"
+            if (target == QLatin1String("pan")
+                || target == QLatin1String("pan-visible")
+                || target == QLatin1String("pan-composite")) {
+                selector = tok(2);   // pan index → "grab pan-visible 1 [path]"
                 path = tok(3);
             } else {
                 path = tok(2);       // "grab SpectrumWidget [path]"
@@ -1534,6 +1638,9 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("grab requires a target widget"));
         if (target == QLatin1String("pan"))
             return doGrabPan(selector, path);
+        if (target == QLatin1String("pan-visible")
+            || target == QLatin1String("pan-composite"))
+            return doGrabPanVisible(selector, path);
         return doGrab(target, path);
     }
     if (cmd == QLatin1String("close")) {
@@ -1714,19 +1821,8 @@ QJsonObject AutomationServer::doGrabPan(const QString& indexStr, const QString& 
         return err(QStringLiteral("grab pan requires a non-negative pan index "
                                   "(e.g. 'grab pan 1')"));
 
-    const QList<QWidget*> spectra = findWidgetsByClass(QStringLiteral("SpectrumWidget"));
     QJsonArray available;
-    QWidget* match = nullptr;
-    for (QWidget* sw : spectra) {
-        const QVariant pi = sw->property("panIndex");
-        if (!pi.isValid())
-            continue;
-        available.append(pi.toInt());
-        // Prefer a visible surface if duplicate indices ever coexist (e.g. mid
-        // float/dock reparent); otherwise the first index match wins below.
-        if (pi.toInt() == index && (!match || sw->isVisible()))
-            match = sw;
-    }
+    QWidget* match = panSpectrumWidgetForIndex(index, &available);
     if (!match) {
         return QJsonObject{{QStringLiteral("ok"), false},
                            {QStringLiteral("error"),
@@ -1737,6 +1833,48 @@ QJsonObject AutomationServer::doGrabPan(const QString& indexStr, const QString& 
     QJsonObject r = saveWidgetGrab(match, QStringLiteral("pan") + QString::number(index), path);
     if (r.value(QStringLiteral("ok")).toBool())
         r[QStringLiteral("panIndex")] = index;
+    return r;
+}
+
+// Capture the whole visible pan applet by index, not just the raw GPU surface.
+// This is the screenshot agents usually want for UI overlays: VFO flags,
+// side buttons, and child widgets are painted above the SpectrumWidget and are
+// therefore absent from `grab pan`, which intentionally returns only the
+// QRhiWidget framebuffer.
+QJsonObject AutomationServer::doGrabPanVisible(const QString& indexStr,
+                                               const QString& path) const
+{
+    bool okIdx = false;
+    const int index = indexStr.toInt(&okIdx);
+    if (!okIdx || index < 0) {
+        return err(QStringLiteral("grab pan-visible requires a non-negative pan index "
+                                  "(e.g. 'grab pan-visible 1')"));
+    }
+
+    QJsonArray available;
+    QWidget* spectrum = panSpectrumWidgetForIndex(index, &available);
+    if (!spectrum) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("no pan with index ") + QString::number(index)},
+                           {QStringLiteral("available"), available}};
+    }
+
+    QWidget* applet = panadapterAppletForSpectrum(spectrum);
+    if (!applet) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("pan ") + QString::number(index)
+                                + QStringLiteral(" has no PanadapterApplet ancestor")}};
+    }
+
+    QJsonObject r = saveWidgetGrab(applet,
+                                   QStringLiteral("pan-visible") + QString::number(index),
+                                   path);
+    if (r.value(QStringLiteral("ok")).toBool()) {
+        r[QStringLiteral("panIndex")] = index;
+        r[QStringLiteral("surfaceClass")] = shortClassName(spectrum);
+    }
     return r;
 }
 
@@ -1787,6 +1925,13 @@ QJsonObject AutomationServer::saveWidgetGrab(QWidget* w, const QString& label,
 QWidget* AutomationServer::resolveWidget(const QString& target)
 {
     const QWidgetList tops = QApplication::topLevelWidgets();
+
+    // VFO shortcuts: "vfo slice 1" resolves the flag for slice 1, and
+    // "vfo 1" resolves the first flag inside pan index 1. The slice form is
+    // preferred when a pan contains multiple VFOs.
+    if (QWidget* vfo = resolveVfoSelector(target)) {
+        return vfo;
+    }
 
     // 0. Scoped target "<scope>/<name>" disambiguates duplicate accessibleNames
     //    across applets — e.g. "RxApplet/AF gain" vs "PanadapterApplet/AF gain",
@@ -2029,6 +2174,23 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
             if (!okD) return err(QStringLiteral("setValue needs a number"));
             ds->setValue(d); done = true;
         }
+    } else if (action == QLatin1String("wheel")) {
+        bool okNum = false;
+        const int steps = value.isEmpty() ? 1 : value.toInt(&okNum);
+        if (!value.isEmpty() && !okNum) {
+            return err(QStringLiteral("wheel needs an integer step count"));
+        }
+        if (steps == 0 || steps < -1 || steps > 1) {
+            return err(QStringLiteral("wheel accepts one notch per call (-1 or 1)"));
+        }
+        const QPoint pos(w->width() / 2, w->height() / 2);
+        const QPoint globalPos = w->mapToGlobal(pos);
+        QWheelEvent ev(QPointF(pos), QPointF(globalPos),
+                       QPoint(), QPoint(0, steps * 120),
+                       Qt::NoButton, Qt::NoModifier,
+                       Qt::ScrollUpdate, false);
+        QCoreApplication::sendEvent(w, &ev);
+        done = true;
     } else if (action == QLatin1String("setText")) {
         if (auto* le = qobject_cast<QLineEdit*>(w)) { le->setText(value); done = true; }
     } else if (action == QLatin1String("submit")) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -444,6 +444,7 @@ QWidget* panadapterAppletForSpectrum(QWidget* spectrum)
 QWidget* vfoWidgetForPanIndex(int index)
 {
     const QList<QWidget*> vfos = findWidgetsByClass(QStringLiteral("VfoWidget"));
+    QWidget* fallback = nullptr;
     for (QWidget* vfo : vfos) {
         for (QWidget* a = vfo; a; a = a->parentWidget()) {
             if (shortClassName(a) != QLatin1String("SpectrumWidget")) {
@@ -451,12 +452,17 @@ QWidget* vfoWidgetForPanIndex(int index)
             }
             const QVariant pi = a->property("panIndex");
             if (pi.isValid() && pi.toInt() == index) {
-                return vfo;
+                if (vfo->isVisible()) {
+                    return vfo;
+                }
+                if (!fallback) {
+                    fallback = vfo;
+                }
             }
             break;
         }
     }
-    return nullptr;
+    return fallback;
 }
 
 QWidget* vfoWidgetForSliceId(int sliceId)

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -107,10 +107,14 @@ class ConnectionPanel;
 //
 // Phase 2b verbs (observability + reach, this batch — #3646):
 //
-//   grab pan <index> [path]        -> capture a SPECIFIC pan's spectrum surface
-//                                     (by SpectrumWidget::panIndex) in a multi-
-//                                     pan layout; plain `grab SpectrumWidget`
-//                                     only ever returns the first one.
+//   grab pan <index> [path]        -> capture a SPECIFIC pan's raw spectrum
+//                                     surface (by SpectrumWidget::panIndex) in
+//                                     a multi-pan layout; plain `grab
+//                                     SpectrumWidget` only ever returns the
+//                                     first one.
+//   grab pan-visible <index> [path]-> capture the operator-visible pan applet,
+//                                     including VFO/flag child overlays above
+//                                     the GPU surface.
 //   close <target>                 -> close the target's top-level window
 //                                     (deferred; reaches the frameless title-bar
 //                                     close that invoke-click can't).
@@ -191,10 +195,13 @@ private:
     QJsonObject doDumpTree() const;
     QJsonObject doFloors() const;
     QJsonObject doGrab(const QString& target, const QString& path) const;
-    // grab pan <index> [path]: capture the SpectrumWidget for a specific pan
-    // (by SpectrumWidget::panIndex) in a multi-pan layout — plain `grab
-    // SpectrumWidget` only ever resolves the first one (#3646).
+    // grab pan <index> [path]: capture the raw SpectrumWidget framebuffer for a
+    // specific pan (by SpectrumWidget::panIndex) in a multi-pan layout — plain
+    // `grab SpectrumWidget` only ever resolves the first one (#3646).
     QJsonObject doGrabPan(const QString& indexStr, const QString& path) const;
+    // grab pan-visible <index> [path]: capture the enclosing PanadapterApplet so
+    // overlay child widgets such as VFO flags appear in the PNG too.
+    QJsonObject doGrabPanVisible(const QString& indexStr, const QString& path) const;
     // Shared "save this widget to a PNG and describe it" tail for grab/grab pan.
     QJsonObject saveWidgetGrab(QWidget* w, const QString& label,
                                const QString& path) const;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3012,10 +3012,10 @@ MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
     // against the *outer edge of the flag* rather than the slice frequency
     // itself — so the flag panel doesn't clip the pan edge before the pan
     // starts to scroll.  Split pairs (LockLeft + LockRight rendered on the
-    // same marker) extend the trigger on *both* sides; single-flag slices
-    // extend only on the side the flag currently renders on.  Non-flagged
-    // and compact-mode slices fall through to the original slice-frequency
-    // comparison (both offsets stay 0.0).
+    // same marker) extend the trigger on *both* sides; non-split slices extend
+    // on the side the flag placement rules predict for the new frequency.
+    // Non-flagged and compact-mode slices fall through to the original
+    // slice-frequency comparison (both offsets stay 0.0).
     double leftFlagOffsetMhz  = 0.0;
     double rightFlagOffsetMhz = 0.0;
     if (auto* sw = spectrumForSlice(s)) {
@@ -3030,7 +3030,8 @@ MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
                     // Split pair: LockLeft + LockRight, flags on both sides.
                     leftFlagOffsetMhz  = flagWidthMhz;
                     rightFlagOffsetMhz = flagWidthMhz;
-                } else if (vfo->onLeft()) {
+                } else if (sw->vfoFlagOnLeftForSlice(
+                               s->sliceId(), mhz, vfo->width(), vfo->onLeft())) {
                     leftFlagOffsetMhz  = flagWidthMhz;
                 } else {
                     rightFlagOffsetMhz = flagWidthMhz;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -65,6 +65,51 @@ namespace AetherSDR {
 bool SpectrumWidget::s_starstruckMode = false;
 QSoundEffect* SpectrumWidget::s_starstruckSound = nullptr;
 
+namespace {
+
+struct VfoPos {
+    int sliceId;
+    int x;
+    VfoWidget* w;
+    int splitPartner;
+    const SpectrumWidget::SliceOverlay* overlay;
+};
+
+VfoWidget::FlagDir singleVfoFlagDirectionForOverlay(
+    const SpectrumWidget::SliceOverlay& overlay,
+    VfoWidget* widget,
+    int markerX,
+    int spectrumWidth)
+{
+    if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+        return VfoWidget::ForceRight;
+    }
+
+    const bool defaultOnLeft = VfoWidget::defaultFlagOnLeftForMode(overlay.mode);
+    const bool previousOnLeft = widget ? widget->onLeft() : defaultOnLeft;
+    return VfoWidget::autoDirectionForSingleFlag(
+        markerX, widget ? widget->width() : 0, spectrumWidth,
+        defaultOnLeft, previousOnLeft);
+}
+
+VfoWidget::FlagDir deconflictedVfoFlagDirection(
+    const QVector<VfoPos>& vfos, int index, int panelWidth, int spectrumWidth)
+{
+    const int previousMarkerX = index > 0 ? vfos[index - 1].x : 0;
+    const int nextMarkerX = index + 1 < vfos.size() ? vfos[index + 1].x : 0;
+    const bool previousOnLeft = vfos[index].w ? vfos[index].w->onLeft() : true;
+    return VfoWidget::autoDirectionForDeconflictedFlag(
+        index, vfos.size(), vfos[index].x, previousMarkerX, nextMarkerX,
+        panelWidth, spectrumWidth, previousOnLeft);
+}
+
+bool flagDirectionOnLeft(VfoWidget::FlagDir dir)
+{
+    return dir == VfoWidget::ForceLeft || dir == VfoWidget::LockLeft;
+}
+
+} // namespace
+
 inline QColor kAetherBrandBlue() { return AetherSDR::ThemeManager::instance().color("color.accent"); }
 inline QColor kAetherBrandGreen() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
 inline QColor kConnectionTextColor() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
@@ -964,6 +1009,84 @@ bool SpectrumWidget::sliceHasSplitPartner(int sliceId) const
     return false;
 }
 
+bool SpectrumWidget::vfoFlagOnLeftForSlice(
+    int sliceId, double freqMhz, int panelWidth, bool previousOnLeft) const
+{
+    QVector<VfoPos> vfos;
+    for (const SliceOverlay& overlay : m_sliceOverlays) {
+        if (VfoWidget* widget = m_vfoWidgets.value(overlay.sliceId, nullptr)) {
+            const double markerMhz = overlay.sliceId == sliceId ? freqMhz : overlay.freqMhz;
+            int x = mhzToX(markerMhz);
+            if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+                const double hiMhz = markerMhz + overlay.filterHighHz / 1.0e6;
+                x = mhzToX(hiMhz) + 4;
+            }
+            vfos.append({overlay.sliceId, x, widget, overlay.splitPartnerId, &overlay});
+        }
+    }
+    if (vfos.isEmpty()) {
+        return previousOnLeft;
+    }
+    std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
+        return a.x < b.x;
+    });
+
+    int targetIndex = -1;
+    for (int i = 0; i < vfos.size(); ++i) {
+        if (vfos[i].sliceId == sliceId) {
+            targetIndex = i;
+            break;
+        }
+    }
+    if (targetIndex < 0 || !vfos[targetIndex].overlay) {
+        return previousOnLeft;
+    }
+
+    QMap<int, VfoWidget::FlagDir> dirMap;
+    for (int i = 0; i < vfos.size(); ++i) {
+        if (vfos[i].splitPartner < 0) {
+            continue;
+        }
+        if (dirMap.contains(vfos[i].sliceId)) {
+            continue;
+        }
+        int partnerIndex = -1;
+        for (int j = 0; j < vfos.size(); ++j) {
+            if (vfos[j].sliceId == vfos[i].splitPartner) {
+                partnerIndex = j;
+                break;
+            }
+        }
+        if (partnerIndex < 0) {
+            continue;
+        }
+        const int leftIndex = (vfos[i].x <= vfos[partnerIndex].x) ? i : partnerIndex;
+        const int rightIndex = (leftIndex == i) ? partnerIndex : i;
+        dirMap[vfos[leftIndex].sliceId] = VfoWidget::LockLeft;
+        dirMap[vfos[rightIndex].sliceId] = VfoWidget::LockRight;
+    }
+
+    const SliceOverlay& overlay = *vfos[targetIndex].overlay;
+    if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+        return false;
+    }
+    if (dirMap.contains(sliceId)) {
+        return flagDirectionOnLeft(dirMap[sliceId]);
+    }
+
+    VfoWidget::FlagDir dir = VfoWidget::Auto;
+    if (vfos.size() == 1) {
+        const bool defaultOnLeft = VfoWidget::defaultFlagOnLeftForMode(overlay.mode);
+        dir = VfoWidget::autoDirectionForSingleFlag(
+            vfos[targetIndex].x, panelWidth, width(), defaultOnLeft, previousOnLeft);
+    } else {
+        const int deconflictPanelWidth = vfos.first().w ? vfos.first().w->width() : panelWidth;
+        dir = deconflictedVfoFlagDirection(
+            vfos, targetIndex, deconflictPanelWidth, width());
+    }
+    return flagDirectionOnLeft(dir);
+}
+
 QString SpectrumWidget::settingsKey(const QString& base) const
 {
     if (m_panIndex == 0)
@@ -1065,6 +1188,7 @@ VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
         return m_vfoWidgets[sliceId];
 
     auto* w = new VfoWidget(this);
+    w->setProperty("sliceId", sliceId);
     installVfoCursorEventFilter(w);
     // The flag's SmartMTR value labels are painted in our overlay pass; refresh
     // the overlay whenever they change or the flag moves.
@@ -8275,7 +8399,6 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 // is rasterized at this frame's position (no one-frame lag).  (#3617)
 void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
 {
-    struct VfoPos { int sliceId; int x; VfoWidget* w; int splitPartner; };
     QVector<VfoPos> vfos;
     for (const auto& so : m_sliceOverlays) {
         if (auto* vw = m_vfoWidgets.value(so.sliceId, nullptr)) {
@@ -8284,7 +8407,7 @@ void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
                 double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
                 x = mhzToX(hiMhz) + 4;
             }
-            vfos.append({so.sliceId, x, vw, so.splitPartnerId});
+            vfos.append({so.sliceId, x, vw, so.splitPartnerId, &so});
         }
     }
     std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
@@ -8323,28 +8446,18 @@ void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
 
     if (vfos.size() == 1) {
         VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
+        if (!dirMap.contains(vfos[0].sliceId) && vfos[0].overlay) {
+            dir = singleVfoFlagDirectionForOverlay(
+                *vfos[0].overlay, vfos[0].w, vfos[0].x, specW);
+        }
         vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
     } else {
         for (int i = 0; i < vfos.size(); ++i) {
             VfoWidget::FlagDir dir = VfoWidget::Auto;
             if (dirMap.contains(vfos[i].sliceId)) {
                 dir = dirMap[vfos[i].sliceId];
-            } else if (vfos.size() == 2) {
-                dir = (i == 0) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                if (i == 0 && vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                if (i == 1 && vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
             } else {
-                if (i == 0) {
-                    dir = VfoWidget::ForceLeft;
-                    if (vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                } else if (i == vfos.size() - 1) {
-                    dir = VfoWidget::ForceRight;
-                    if (vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
-                } else {
-                    const int gapLeft  = vfos[i].x - vfos[i-1].x;
-                    const int gapRight = vfos[i+1].x - vfos[i].x;
-                    dir = (gapLeft >= gapRight) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                }
+                dir = deconflictedVfoFlagDirection(vfos, i, panelW, specW);
             }
             vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);
         }
@@ -8481,7 +8594,6 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     // Split pairs always face each other: RX←  →TX
     {
         // Collect visible VFOs sorted by screen X position
-        struct VfoPos { int sliceId; int x; VfoWidget* w; int splitPartner; };
         QVector<VfoPos> vfos;
         for (const auto& so : m_sliceOverlays) {
             if (auto* w = m_vfoWidgets.value(so.sliceId, nullptr)) {
@@ -8492,7 +8604,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
                     double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
                     x = mhzToX(hiMhz) + 4;  // 4px padding past filter edge
                 }
-                vfos.append({so.sliceId, x, w, so.splitPartnerId});
+                vfos.append({so.sliceId, x, w, so.splitPartnerId, &so});
             }
         }
         std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
@@ -8537,6 +8649,10 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
         if (vfos.size() == 1) {
             VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
+            if (!dirMap.contains(vfos[0].sliceId) && vfos[0].overlay) {
+                dir = singleVfoFlagDirectionForOverlay(
+                    *vfos[0].overlay, vfos[0].w, vfos[0].x, specW);
+            }
             vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
         } else {
             for (int i = 0; i < vfos.size(); ++i) {
@@ -8545,22 +8661,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
                 if (dirMap.contains(vfos[i].sliceId)) {
                     // Split pair or RTTY: use pre-assigned direction
                     dir = dirMap[vfos[i].sliceId];
-                } else if (vfos.size() == 2) {
-                    dir = (i == 0) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                    if (i == 0 && vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                    if (i == 1 && vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
                 } else {
-                    if (i == 0) {
-                        dir = VfoWidget::ForceLeft;
-                        if (vfos[i].x < panelW) dir = VfoWidget::ForceRight;
-                    } else if (i == vfos.size() - 1) {
-                        dir = VfoWidget::ForceRight;
-                        if (vfos[i].x + panelW > specW) dir = VfoWidget::ForceLeft;
-                    } else {
-                        int gapLeft = vfos[i].x - vfos[i-1].x;
-                        int gapRight = vfos[i+1].x - vfos[i].x;
-                        dir = (gapLeft >= gapRight) ? VfoWidget::ForceLeft : VfoWidget::ForceRight;
-                    }
+                    dir = deconflictedVfoFlagDirection(vfos, i, panelW, specW);
                 }
 
                 vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -234,6 +234,8 @@ public:
     VfoWidget* addVfoWidget(int sliceId);
     void       removeVfoWidget(int sliceId);
     void       setActiveVfoWidget(int sliceId);
+    bool vfoFlagOnLeftForSlice(int sliceId, double freqMhz,
+                               int panelWidth, bool previousOnLeft) const;
     // True if the slice has a split partner whose own VFO flag is rendered on
     // the opposite side via LockLeft / LockRight.  panFollowVfo() uses this
     // to extend the pan-follow trigger on both sides so neither flag clips

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2957,12 +2957,7 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
         onLeft = false;
     } else {
         // Auto: use mode-based default
-        bool lowerSideband = false;
-        if (m_slice) {
-            const QString mode = m_slice->mode();
-            lowerSideband = (mode == "LSB" || mode == "DIGL" || mode == "CWL");
-        }
-        onLeft = !lowerSideband;
+        onLeft = !m_slice || defaultFlagOnLeftForMode(m_slice->mode());
     }
 
     // 20px dead-band: only flip side when the widget clearly overruns the edge.
@@ -3834,6 +3829,7 @@ void VfoWidget::setSlice(SliceModel* slice)
     if (m_slice)
         m_slice->disconnect(this);
     m_slice = slice;
+    setProperty("sliceId", m_slice ? m_slice->sliceId() : -1);
     if (!m_slice) {
         updateFreqLabel();
         return;

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -10,6 +10,9 @@
 #include <QTimer>
 #include <QElapsedTimer>
 
+#include <algorithm>
+#include <cmath>
+
 #include "core/KiwiSdrProtocol.h"
 
 class QPushButton;
@@ -87,6 +90,90 @@ public:
 
     // Reposition relative to VFO marker x coordinate.
     void updatePosition(int vfoX, int specTop, FlagDir dir = Auto);
+
+    static bool defaultFlagOnLeftForMode(const QString& mode)
+    {
+        const bool lowerSideband = (mode == "LSB" || mode == "DIGL" || mode == "CWL");
+        return !lowerSideband;
+    }
+
+    static FlagDir autoDirectionForSingleFlag(int markerX, int panelWidth,
+                                              int spectrumWidth,
+                                              bool defaultOnLeft,
+                                              bool previousOnLeft)
+    {
+        if (panelWidth <= 0 || spectrumWidth <= 0) {
+            return defaultOnLeft ? ForceLeft : ForceRight;
+        }
+
+        constexpr int kEdgeHysteresis = 20;
+        constexpr double kPanFollowTriggerMarginFrac = 0.05; // matches incremental pan-follow
+        const int guardPx = std::max(
+            kEdgeHysteresis,
+            static_cast<int>(std::round(spectrumWidth * kPanFollowTriggerMarginFrac)));
+
+        if (defaultOnLeft) {
+            const int flipEnter = panelWidth + guardPx;
+            const int flipExit = flipEnter + kEdgeHysteresis;
+            const bool shouldStayRight = !previousOnLeft && markerX < flipExit;
+            return (markerX <= flipEnter || shouldStayRight) ? ForceRight : ForceLeft;
+        }
+
+        const int flipEnter = spectrumWidth - panelWidth - guardPx;
+        const int flipExit = flipEnter - kEdgeHysteresis;
+        const bool shouldStayLeft = previousOnLeft && markerX > flipExit;
+        return (markerX >= flipEnter || shouldStayLeft) ? ForceLeft : ForceRight;
+    }
+
+    static FlagDir autoDirectionForDeconflictedFlag(int index, int count,
+                                                    int markerX,
+                                                    int previousMarkerX,
+                                                    int nextMarkerX,
+                                                    int panelWidth,
+                                                    int spectrumWidth,
+                                                    bool previousOnLeft)
+    {
+        if (index < 0 || index >= count || count <= 0) {
+            return Auto;
+        }
+        if (count == 1) {
+            return Auto;
+        }
+
+        constexpr int kEdgeHysteresis = 20;
+        constexpr double kPanFollowTriggerMarginFrac = 0.05; // matches incremental pan-follow
+        const int guardPx = std::max(
+            kEdgeHysteresis,
+            static_cast<int>(std::round(spectrumWidth * kPanFollowTriggerMarginFrac)));
+
+        auto leftEdgeFlagDirection = [&]() {
+            const int flipEnter = panelWidth + guardPx;
+            const int flipExit = flipEnter + kEdgeHysteresis;
+            const bool shouldStayRight = !previousOnLeft && markerX < flipExit;
+            return (markerX <= flipEnter || shouldStayRight) ? ForceRight : ForceLeft;
+        };
+        auto rightEdgeFlagDirection = [&]() {
+            const int flipEnter = spectrumWidth - panelWidth - guardPx;
+            const int flipExit = flipEnter - kEdgeHysteresis;
+            const bool shouldStayLeft = previousOnLeft && markerX > flipExit;
+            return (markerX >= flipEnter || shouldStayLeft) ? ForceLeft : ForceRight;
+        };
+
+        if (count == 2) {
+            return index == 0 ? leftEdgeFlagDirection() : rightEdgeFlagDirection();
+        }
+
+        if (index == 0) {
+            return leftEdgeFlagDirection();
+        }
+        if (index == count - 1) {
+            return rightEdgeFlagDirection();
+        }
+
+        const int gapLeft = markerX - previousMarkerX;
+        const int gapRight = nextMarkerX - markerX;
+        return (gapLeft >= gapRight) ? ForceLeft : ForceRight;
+    }
 
     // Draw this flag's SmartMTR extremes value labels (min/max or current signal,
     // gated by the meter options) onto the spectrum painter, in the band just

--- a/tests/vfo_flag_placement_test.cpp
+++ b/tests/vfo_flag_placement_test.cpp
@@ -1,0 +1,145 @@
+#include "gui/VfoWidget.h"
+
+#include <cstdio>
+
+using AetherSDR::VfoWidget;
+
+namespace {
+
+int g_failures = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+void expectDir(const char* name, VfoWidget::FlagDir actual, VfoWidget::FlagDir expected)
+{
+    report(name, actual == expected);
+}
+
+} // namespace
+
+int main()
+{
+    constexpr int kSpectrumWidth = 1000;
+    constexpr int kPanelWidth = 200;
+
+    report("USB defaults to left",
+           VfoWidget::defaultFlagOnLeftForMode(QStringLiteral("USB")));
+    report("LSB defaults to right",
+           !VfoWidget::defaultFlagOnLeftForMode(QStringLiteral("LSB")));
+    report("CWL defaults to right",
+           !VfoWidget::defaultFlagOnLeftForMode(QStringLiteral("CWL")));
+    report("DIGL defaults to right",
+           !VfoWidget::defaultFlagOnLeftForMode(QStringLiteral("DIGL")));
+
+    expectDir("default-left stays left in middle",
+              VfoWidget::autoDirectionForSingleFlag(
+                  500, kPanelWidth, kSpectrumWidth, true, true),
+              VfoWidget::ForceLeft);
+    expectDir("default-left flips right before left pan-follow guard",
+              VfoWidget::autoDirectionForSingleFlag(
+                  240, kPanelWidth, kSpectrumWidth, true, true),
+              VfoWidget::ForceRight);
+    expectDir("default-left flips right at left pan-follow guard",
+              VfoWidget::autoDirectionForSingleFlag(
+                  250, kPanelWidth, kSpectrumWidth, true, true),
+              VfoWidget::ForceRight);
+    expectDir("default-left holds right through hysteresis",
+              VfoWidget::autoDirectionForSingleFlag(
+                  260, kPanelWidth, kSpectrumWidth, true, false),
+              VfoWidget::ForceRight);
+    expectDir("default-left returns left after hysteresis",
+              VfoWidget::autoDirectionForSingleFlag(
+                  280, kPanelWidth, kSpectrumWidth, true, false),
+              VfoWidget::ForceLeft);
+
+    expectDir("default-right stays right in middle",
+              VfoWidget::autoDirectionForSingleFlag(
+                  500, kPanelWidth, kSpectrumWidth, false, false),
+              VfoWidget::ForceRight);
+    expectDir("default-right flips left before right pan-follow guard",
+              VfoWidget::autoDirectionForSingleFlag(
+                  760, kPanelWidth, kSpectrumWidth, false, false),
+              VfoWidget::ForceLeft);
+    expectDir("default-right flips left at right pan-follow guard",
+              VfoWidget::autoDirectionForSingleFlag(
+                  750, kPanelWidth, kSpectrumWidth, false, false),
+              VfoWidget::ForceLeft);
+    expectDir("default-right holds left through hysteresis",
+              VfoWidget::autoDirectionForSingleFlag(
+                  740, kPanelWidth, kSpectrumWidth, false, true),
+              VfoWidget::ForceLeft);
+    expectDir("default-right returns right after hysteresis",
+              VfoWidget::autoDirectionForSingleFlag(
+                  720, kPanelWidth, kSpectrumWidth, false, true),
+              VfoWidget::ForceRight);
+
+    expectDir("two-vfo leftmost flips right at left edge",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  0, 2, 240, 0, 760, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceRight);
+    expectDir("two-vfo leftmost flips right at pan-follow guard",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  0, 2, 250, 0, 760, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceRight);
+    expectDir("two-vfo leftmost holds right through hysteresis",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  0, 2, 260, 0, 760, kPanelWidth, kSpectrumWidth, false),
+              VfoWidget::ForceRight);
+    expectDir("two-vfo leftmost returns left after hysteresis",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  0, 2, 280, 0, 760, kPanelWidth, kSpectrumWidth, false),
+              VfoWidget::ForceLeft);
+    expectDir("two-vfo rightmost flips left at right edge",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 2, 760, 240, 0, kPanelWidth, kSpectrumWidth, false),
+              VfoWidget::ForceLeft);
+    expectDir("two-vfo rightmost flips left at pan-follow guard",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 2, 750, 240, 0, kPanelWidth, kSpectrumWidth, false),
+              VfoWidget::ForceLeft);
+    expectDir("two-vfo rightmost holds left through hysteresis",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 2, 740, 240, 0, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceLeft);
+    expectDir("two-vfo rightmost returns right after hysteresis",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 2, 720, 240, 0, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceRight);
+
+    expectDir("three-vfo first flips right at left edge",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  0, 3, 240, 0, 500, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceRight);
+    expectDir("three-vfo last flips left at right edge",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  2, 3, 760, 500, 0, kPanelWidth, kSpectrumWidth, false),
+              VfoWidget::ForceLeft);
+    expectDir("three-vfo interior uses larger left gap",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 3, 500, 300, 620, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceLeft);
+    expectDir("three-vfo interior uses larger right gap",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  1, 3, 500, 380, 800, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::ForceRight);
+    expectDir("invalid deconflicted index falls back to auto",
+              VfoWidget::autoDirectionForDeconflictedFlag(
+                  -1, 2, 0, 0, 0, kPanelWidth, kSpectrumWidth, true),
+              VfoWidget::Auto);
+
+    expectDir("invalid geometry preserves default left",
+              VfoWidget::autoDirectionForSingleFlag(0, 0, 0, true, false),
+              VfoWidget::ForceLeft);
+    expectDir("invalid geometry preserves default right",
+              VfoWidget::autoDirectionForSingleFlag(0, 0, 0, false, true),
+              VfoWidget::ForceRight);
+
+    std::printf("%s\n", g_failures == 0 ? "All tests passed." : "Test failures.");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -24,6 +24,7 @@ Usage:
     python tools/automation_probe.py connect local first
     python tools/automation_probe.py connect wait 30000
     python tools/automation_probe.py grab SpectrumWidget /tmp/pan.png
+    python tools/automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png
 """
 
 import argparse
@@ -98,14 +99,15 @@ def main():
                "  automation_probe.py get radio\n"
                "  automation_probe.py get slice active frequency\n"
                "  automation_probe.py invoke 'Master volume' setValue 35\n"
-               "  automation_probe.py grab SpectrumWidget /tmp/pan.png",
+               "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
+               "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png",
         formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command", nargs="?", default="demo",
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
-                    help="verb args: grab <target> [path] | "
+                    help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
                          "invoke <target> <action> [value] | "
                          "get <model> [selector] [property] | "
                          "connect <list|show|hide|local|ip|wait> [args]")
@@ -134,7 +136,13 @@ def main():
             if not args.rest:
                 sys.exit("error: grab requires a target widget name")
             req = {"cmd": "grab", "target": args.rest[0]}
-            if len(args.rest) > 1:
+            if args.rest[0] in ("pan", "pan-visible", "pan-composite"):
+                if len(args.rest) < 2:
+                    sys.exit(f"error: grab {args.rest[0]} requires a pan index")
+                req["selector"] = args.rest[1]
+                if len(args.rest) > 2:
+                    req["path"] = args.rest[2]
+            elif len(args.rest) > 1:
                 req["path"] = args.rest[1]
             print(json.dumps(bridge.request(req), indent=2))
 


### PR DESCRIPTION
## Summary

Fixes #3840. Pan Follows VFO now predicts the side a slice flag will occupy after the next tune step instead of using the stale current flag side. That prevents normal wheel tuning near a pan edge from forcing a pan recenter when the flag can flip inward and remain fully visible.

This also adds deterministic multi-VFO flag placement helpers, keeps mode-specific split and RTTY defaults, and extends the agent automation bridge with VFO targeting, wheel events, and `grab pan-visible <index>` for operator-visible pan screenshots that include VFO flag overlays.

## Root Cause

The pan-follow reveal guard used the current `VfoWidget::onLeft()` value before `VfoWidget::updatePosition()` had a chance to recompute the flag side for the new frequency. When the next frequency would make the flag flip inward, the guard still treated the old outward side as authoritative and recentered the pan unnecessarily.

## Constitution principle honored

Principle VIII - Evidence Over Assertion. The placement logic has a focused helper test, and the behavior was verified with the visible agent automation bridge against a real FLEX-6700 without enabling TX automation.

## Test plan

- [x] Local build passes: `cmake --build build --target AetherSDR vfo_flag_placement_test -j16`
- [x] Targeted test passes: `ctest --test-dir build -R ^vfo_flag_placement_test$ --output-on-failure`
- [x] Diff whitespace check passes: `git diff --check`
- [x] Automation probe wrapper syntax check passes: `python3 -m py_compile tools/automation_probe.py`
- [x] Accessibility checker run: `python3 tools/check_a11y.py` exits 0 with existing warning-only findings
- [x] Behavior verified on a real radio through the visible agent automation bridge

Bridge evidence:

- Target slice: `1`
- Target pan index: `1`
- Target pan id: `0x40000001`
- Same-pan slices: `[1, 2]`
- Original/restored slice 1 frequency: `14.2196 MHz`
- Wheel-tuned frequency: `14.2184 MHz`
- Target pan center stayed at `14.236363 MHz`
- TX before/after/end: `false / false / false`
- `grab pan-visible 1` returned `class: PanadapterApplet`, `surfaceClass: SpectrumWidget`, `762x724`
- Raw `grab pan 1` still returned `class: SpectrumWidget`, `762x708`

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` or is not meter UI
- [x] Documentation updated for new automation bridge behavior
- [x] Security-sensitive changes reference a GHSA if applicable: N/A

Generated with OpenAI Codex.