### PR TITLE
Add Kiwi receive sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,7 @@ set(CORE_SOURCES
     src/core/KiwiSdrRedirectPolicy.cpp
     src/core/KiwiSdrClient.cpp
     src/core/KiwiSdrManager.cpp
+    src/core/ReceivePresentationSync.cpp
     src/core/KiwiPublicDirectory.cpp
     src/core/WanConnection.cpp
     src/core/DxClusterClient.cpp
@@ -707,6 +708,7 @@ set(GUI_SOURCES
     src/gui/MainWindow_SwrSweep.cpp
     src/gui/MainWindow_Wiring.cpp
     src/gui/MainWindow_Nets.cpp
+    src/gui/MainWindow_ReceiveSync.cpp
     src/gui/MainWindow_KiwiSdr.cpp
     src/gui/map/MapView.cpp
     src/gui/map/MapMarkerItem.cpp
@@ -1936,6 +1938,14 @@ add_executable(kiwi_sdr_redirect_policy_test
 target_include_directories(kiwi_sdr_redirect_policy_test PRIVATE src)
 target_link_libraries(kiwi_sdr_redirect_policy_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_redirect_policy_test COMMAND kiwi_sdr_redirect_policy_test)
+
+add_executable(receive_presentation_sync_test
+    tests/receive_presentation_sync_test.cpp
+    src/core/ReceivePresentationSync.cpp
+)
+target_include_directories(receive_presentation_sync_test PRIVATE src)
+target_link_libraries(receive_presentation_sync_test PRIVATE Qt6::Core)
+add_test(NAME receive_presentation_sync_test COMMAND receive_presentation_sync_test)
 
 # Public-directory parser + external-API (ext_api) policy honoring.
 add_executable(kiwi_public_directory_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 # — became available.  Binary distributions bundle Qt 6.7+ for QRhiWidget.
 find_package(Qt6 6.2 REQUIRED COMPONENTS
     Core
+    Concurrent
     Widgets
     Network
     Multimedia
@@ -1208,6 +1209,7 @@ target_include_directories(AetherSDR PRIVATE
 
 target_link_libraries(AetherSDR PRIVATE
     Qt6::Core
+    Qt6::Concurrent
     Qt6::Gui
     Qt6::Widgets
     Qt6::Network

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -304,6 +304,22 @@ connects).
 Add a trailing **property** name to any single-object form to get just that
 field: `get slice active mode` → `{"value":"LSB"}`.
 
+### `slice rxsource`
+Selects the receive source for a slice through the same virtual-Kiwi path as
+the GUI RX antenna menus. The source selector is not a static list: it resolves
+against the operator's saved Kiwi receiver profiles by configured name, display
+name, profile id, virtual antenna token, or endpoint. Use `flex`, `none`, or
+`clear` to return the slice to Flex audio.
+
+```json
+→ {"cmd":"slice","action":"rxsource","value":"7 K4JK"}
+← {"ok":true,"slice":"rxsource","id":7,"source":"kiwi",
+   "profileName":"K4JK","requested":true}
+
+→ {"cmd":"slice","action":"rxsource","value":"7 flex"}
+← {"ok":true,"slice":"rxsource","id":7,"source":"flex","requested":true}
+```
+
 ### `close`
 Close the target's **top-level window**. Resolves `target` like `grab`, then
 closes `target->window()` — so a child control closes its dialog. This reaches
@@ -475,6 +491,57 @@ measurement.
 
 All `streams` actions are read-only / RX; none sends a radio command or keys the
 transmitter.
+
+### `get sync`
+Read the Receive Sync state used by the spectrum overlay and Auto Assist.
+
+```json
+→ {"cmd":"get","model":"sync"}
+← {"ok":true,"model":"sync","status":"locked",
+   "effectiveOffsetMs":470,"candidateResidualMs":0,
+   "candidateConfidence":0.54,"candidatePeakCorrelation":0.77}
+```
+
+Useful fields:
+
+| field | meaning |
+|---|---|
+| `status` / `statusText` | `searching`, `locked`, `coasting`, etc. |
+| `effectiveOffsetMs` | Applied presentation offset; positive delays Flex relative to Kiwi |
+| `candidateResidualMs` | Latest measured residual at the output-stage estimator point |
+| `candidateAbsoluteOffsetMs` | Current applied offset plus residual candidate |
+| `candidateConfidence` / `candidatePeakCorrelation` | Matcher quality for the latest estimate |
+| `stableEstimateCount` | Count of consecutive near-equal candidate offsets |
+| `lastAcceptedLock` | Whether the latest estimator pass changed/confirmed the applied lock |
+| `flex*BufferMs`, `kiwi*BufferMs`, `playbackQueuedMs` | Current live-to-ear staging counters |
+
+### `audioCapture`
+Bounded, automation-only PCM capture for receive-sync diagnostics. It is active
+only inside an `AETHER_AUTOMATION=1` process, is read-only, and does not change
+audio routing or playback buffers.
+
+```json
+→ {"cmd":"audioCapture","action":"start","value":"5000 raw,post,output,final"}
+← {"ok":true,"active":true,"durationMs":5000,
+   "raw":true,"post":true,"output":true,"final":true}
+
+→ {"cmd":"audioCapture","action":"read","path":"/tmp/aether-audio-capture.json"}
+← {"ok":true,"path":"/tmp/aether-audio-capture.json","chunkCount":812,"capturedBytes":4874240}
+```
+
+Capture points:
+
+| point | contents |
+|---|---|
+| `raw` | Flex/Kiwi float32 stereo PCM as it enters AudioEngine, useful for arrival-timing diagnostics |
+| `post` | Source-tagged Flex/Kiwi float32 stereo after client DSP/resampling, just before each source output FIFO |
+| `output` | Source-tagged Flex/Kiwi float32 stereo as the final mixer consumes each source FIFO; this is the Auto Assist estimator timing point |
+| `final` | Final mixed float32 stereo bytes accepted by the RX audio sink |
+
+The JSON file contains chunks with `point`, `source`, optional `sourceId`,
+`sampleRate`, `channels`, `format: "float32le"`, `startNs`, `frames`, and
+base64 `pcmBase64`. Use `audioCapture status` for metadata only and
+`audioCapture stop` to stop early.
 
 ### Errors
 Every failure is a one-line object: `{"ok":false,"error":"<message>"}` — e.g.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -59,6 +59,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStringList>
+#include <QtGlobal>
 #include <algorithm>
 #include <cstring>
 #include <optional>
@@ -806,8 +807,6 @@ void AudioEngine::setReceivePresentationDelays(
     const int kiwiDelay = qBound(0, kiwiDelayMs, 5000);
     const QString externalKiwiDelayId = externalKiwiDelaySourceId.trimmed();
     const int legacyKiwiDelay = externalKiwiDelayId.isEmpty() ? kiwiDelay : 0;
-    m_externalKiwiReceivePresentationDelaySourceId = externalKiwiDelayId;
-    m_externalKiwiReceivePresentationDelayMs = kiwiDelay;
 
     const int previousFlex =
         m_flexReceivePresentationDelayMs.exchange(flexDelay,
@@ -815,6 +814,10 @@ void AudioEngine::setReceivePresentationDelays(
     const int previousKiwi =
         m_kiwiReceivePresentationDelayMs.exchange(legacyKiwiDelay,
                                                   std::memory_order_relaxed);
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    m_externalKiwiReceivePresentationDelaySourceId = externalKiwiDelayId;
+    m_externalKiwiReceivePresentationDelayMs = kiwiDelay;
 
     const int outputRate = std::max(1, m_rxOutputRate.load());
     const auto hasFlexQueuedAudio = [this]() {
@@ -1922,6 +1925,14 @@ QJsonObject AudioEngine::startAutomationAudioCapture(
     int durationMs,
     const QStringList& points)
 {
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("audioCapture requires AETHER_AUTOMATION=1")},
+        };
+    }
+
     QStringList normalizedPoints;
     normalizedPoints.reserve(points.size());
     for (const QString& point : points) {

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -23,6 +23,7 @@
 #endif
 #include "LogManager.h"
 #include "OpusCodec.h"
+#include "ReceivePresentationSync.h"
 #include "SpectralNR.h"
 #ifdef HAVE_SPECBLEACH
 #include "SpecbleachFilter.h"
@@ -42,6 +43,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <QIODevice>
@@ -82,6 +84,16 @@ constexpr qint64 kTxPostChainEmitMinIntervalMs = 8;
 // blocks).  The shared scopeSamplesReady throttle stays at 25 ms for
 // the floating WaveApplet which doesn't need this fidelity.
 constexpr qint64 kRxPostChainEmitMinIntervalMs = 8;
+constexpr int kAutomationAudioCaptureMaxDurationMs = 15000;
+constexpr qsizetype kAutomationAudioCaptureMaxBytes = 64 * 1024 * 1024;
+
+qint64 steadyNowNs()
+{
+    using Clock = std::chrono::steady_clock;
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               Clock::now().time_since_epoch())
+        .count();
+}
 
 bool devicePresent(const QList<QAudioDevice>& devices, const QAudioDevice& target)
 {
@@ -121,6 +133,175 @@ void trimAudioPacketQueue(std::deque<QByteArray>& packets, qsizetype maxBytes)
         packets.pop_front();
     }
 }
+
+qsizetype alignedStereoFloatBytes(qsizetype bytes)
+{
+    constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
+    return (std::max<qsizetype>(0, bytes) / kFrameBytes) * kFrameBytes;
+}
+
+qsizetype audioBytesForMsAtRate(int sampleRate, int ms)
+{
+    if (sampleRate <= 0 || ms <= 0) {
+        return 0;
+    }
+
+    return alignedStereoFloatBytes(
+        static_cast<qsizetype>(sampleRate) * 2
+        * static_cast<qsizetype>(sizeof(float)) * ms / 1000);
+}
+
+qsizetype rawEquivalentAudioBytes(qsizetype bytes, int sampleRate)
+{
+    if (bytes <= 0 || sampleRate <= 0) {
+        return 0;
+    }
+
+    return alignedStereoFloatBytes(
+        bytes * AudioEngine::DEFAULT_SAMPLE_RATE / sampleRate);
+}
+
+qsizetype quietStereoFloatTrimPoint(const QByteArray& buffer,
+                                    qsizetype requestedBytes,
+                                    int sampleRate)
+{
+    constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
+    constexpr int kTrimSearchMs = 6;
+    const qsizetype frames = alignedStereoFloatBytes(buffer.size()) / kFrameBytes;
+    if (frames <= 0) {
+        return 0;
+    }
+
+    qsizetype requestedFrame =
+        alignedStereoFloatBytes(requestedBytes) / kFrameBytes;
+    requestedFrame = std::clamp<qsizetype>(requestedFrame, 0, frames);
+    if (requestedFrame <= 0 || requestedFrame >= frames) {
+        return requestedFrame * kFrameBytes;
+    }
+
+    const qsizetype searchFrames =
+        std::max<qsizetype>(1, sampleRate * kTrimSearchMs / 1000);
+    const qsizetype begin =
+        std::max<qsizetype>(1, requestedFrame - searchFrames);
+    const qsizetype end =
+        std::min<qsizetype>(frames - 1, requestedFrame + searchFrames);
+    const auto* samples = reinterpret_cast<const float*>(buffer.constData());
+
+    qsizetype bestFrame = requestedFrame;
+    double bestScore = std::numeric_limits<double>::infinity();
+    for (qsizetype frame = begin; frame <= end; ++frame) {
+        const float left = samples[frame * 2];
+        const float right = samples[frame * 2 + 1];
+        const double amplitude =
+            std::fabs(std::isfinite(left) ? left : 0.0f)
+            + std::fabs(std::isfinite(right) ? right : 0.0f);
+        const double distancePenalty =
+            static_cast<double>(std::abs(frame - requestedFrame)) * 1.0e-6;
+        const double score = amplitude + distancePenalty;
+        if (score < bestScore) {
+            bestScore = score;
+            bestFrame = frame;
+        }
+    }
+    return bestFrame * kFrameBytes;
+}
+
+void fadeInStereoFloatFront(QByteArray& buffer, int sampleRate)
+{
+    constexpr qsizetype kFrameBytes = 2 * static_cast<qsizetype>(sizeof(float));
+    constexpr int kTrimFadeMs = 2;
+    const qsizetype frames = alignedStereoFloatBytes(buffer.size()) / kFrameBytes;
+    if (frames <= 0 || sampleRate <= 0) {
+        return;
+    }
+
+    const qsizetype fadeFrames =
+        std::min<qsizetype>(
+            frames,
+            std::max<qsizetype>(1, sampleRate * kTrimFadeMs / 1000));
+    auto* samples = reinterpret_cast<float*>(buffer.data());
+    for (qsizetype frame = 0; frame < fadeFrames; ++frame) {
+        const float gain =
+            static_cast<float>(frame + 1) / static_cast<float>(fadeFrames);
+        samples[frame * 2] *= gain;
+        samples[frame * 2 + 1] *= gain;
+    }
+}
+
+void dropAudioBufferFront(QByteArray& buffer, qsizetype bytes, int sampleRate)
+{
+    const qsizetype dropBytes =
+        std::min(quietStereoFloatTrimPoint(buffer, bytes, sampleRate),
+                 alignedStereoFloatBytes(buffer.size()));
+    if (dropBytes > 0) {
+        buffer.remove(0, dropBytes);
+        fadeInStereoFloatFront(buffer, sampleRate);
+    }
+}
+
+void trimReceivePresentationBuffers(QByteArray& rawBuffer,
+                                    std::deque<QByteArray>& rawPackets,
+                                    QByteArray& outputBuffer,
+                                    int outputRate,
+                                    qsizetype targetRawBytes)
+{
+    targetRawBytes = alignedStereoFloatBytes(targetRawBytes);
+    const auto totalRawBytes = [&]() {
+        return alignedStereoFloatBytes(rawBuffer.size())
+               + queuedAudioBytes(rawPackets)
+               + rawEquivalentAudioBytes(outputBuffer.size(), outputRate);
+    };
+
+    qsizetype excessRawBytes = totalRawBytes() - targetRawBytes;
+    if (excessRawBytes <= 0) {
+        return;
+    }
+
+    if (!outputBuffer.isEmpty()) {
+        const qsizetype outputDropBytes =
+            outputRate > 0
+                ? alignedStereoFloatBytes(
+                      excessRawBytes * outputRate
+                      / AudioEngine::DEFAULT_SAMPLE_RATE)
+                : excessRawBytes;
+        dropAudioBufferFront(outputBuffer, outputDropBytes, outputRate);
+        excessRawBytes = totalRawBytes() - targetRawBytes;
+    }
+
+    if (excessRawBytes > 0 && !rawBuffer.isEmpty()) {
+        dropAudioBufferFront(rawBuffer, excessRawBytes,
+                             AudioEngine::DEFAULT_SAMPLE_RATE);
+        excessRawBytes = totalRawBytes() - targetRawBytes;
+    }
+
+    if (excessRawBytes > 0 && !rawPackets.empty()) {
+        const qsizetype packetBudget =
+            std::max<qsizetype>(
+                0,
+                targetRawBytes
+                    - alignedStereoFloatBytes(rawBuffer.size())
+                    - rawEquivalentAudioBytes(outputBuffer.size(), outputRate));
+        trimAudioPacketQueue(rawPackets, packetBudget);
+    }
+}
+
+int audioBytesToMs(qsizetype bytes, int sampleRate)
+{
+    if (bytes <= 0 || sampleRate <= 0) {
+        return 0;
+    }
+
+    const qint64 bytesPerSecond =
+        static_cast<qint64>(sampleRate) * 2
+        * static_cast<qint64>(sizeof(float));
+    if (bytesPerSecond <= 0) {
+        return 0;
+    }
+
+    return static_cast<int>(
+        (static_cast<qint64>(bytes) * 1000) / bytesPerSecond);
+}
+
 QString audioErrorName(QAudio::Error error)
 {
     switch (error) {
@@ -538,23 +719,224 @@ void AudioEngine::emitTncRxTapFromFloat32Stereo(const QByteArray& pcm, int sampl
 
 void AudioEngine::updateRxBufferStats()
 {
+    const qsizetype flexRawBytes =
+        m_rxBuffer.size() + queuedAudioBytes(m_rxPackets);
+    const qsizetype kiwiSdrRawBytes =
+        m_kiwiSdrRxBuffer.size() + queuedAudioBytes(m_kiwiSdrRxPackets);
+    const qsizetype flexOutputBytes = m_rxOutputBuffer.size();
+    const qsizetype kiwiSdrOutputBytes = m_kiwiSdrOutputBuffer.size();
     qsizetype externalTotal = 0;
+    qsizetype externalRawBytes = 0;
+    qsizetype externalOutputBytes = 0;
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
             continue;
         }
-        externalTotal += source->rxBuffer.size()
-                       + queuedAudioBytes(source->rxPackets)
-                       + source->outputBuffer.size();
+        const qsizetype sourceRawBytes =
+            source->rxBuffer.size() + queuedAudioBytes(source->rxPackets);
+        const qsizetype sourceOutputBytes = source->outputBuffer.size();
+        externalTotal += sourceRawBytes + sourceOutputBytes;
+        if (externalKiwiSourceAudible(*source)) {
+            externalRawBytes = std::max(externalRawBytes, sourceRawBytes);
+            externalOutputBytes =
+                std::max(externalOutputBytes, sourceOutputBytes);
+        }
     }
 
     const qsizetype total =
-        m_rxBuffer.size() + queuedAudioBytes(m_rxPackets)
-        + m_kiwiSdrRxBuffer.size() + queuedAudioBytes(m_kiwiSdrRxPackets)
-        + m_rxOutputBuffer.size() + m_kiwiSdrOutputBuffer.size()
+        flexRawBytes + kiwiSdrRawBytes + flexOutputBytes + kiwiSdrOutputBytes
         + m_radeRxBuffer.size() + externalTotal;
     m_rxBufferBytes.store(total);
     m_rxBufferPeakBytes.store(std::max(m_rxBufferPeakBytes.load(), total));
+
+    const int outputRate = std::max(1, m_rxOutputRate.load());
+    m_receivePresentationPlaybackQueuedMs.store(
+        m_rxPlaybackQueuedMs.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
+    m_receivePresentationFlexRawBufferMs.store(
+        audioBytesToMs(flexRawBytes, DEFAULT_SAMPLE_RATE),
+        std::memory_order_relaxed);
+    m_receivePresentationFlexOutputBufferMs.store(
+        audioBytesToMs(flexOutputBytes, outputRate),
+        std::memory_order_relaxed);
+    m_receivePresentationKiwiSdrRawBufferMs.store(
+        audioBytesToMs(kiwiSdrRawBytes, DEFAULT_SAMPLE_RATE),
+        std::memory_order_relaxed);
+    m_receivePresentationKiwiSdrOutputBufferMs.store(
+        audioBytesToMs(kiwiSdrOutputBytes, outputRate),
+        std::memory_order_relaxed);
+    m_receivePresentationExternalKiwiRawBufferMs.store(
+        audioBytesToMs(externalRawBytes, DEFAULT_SAMPLE_RATE),
+        std::memory_order_relaxed);
+    m_receivePresentationExternalKiwiOutputBufferMs.store(
+        audioBytesToMs(externalOutputBytes, outputRate),
+        std::memory_order_relaxed);
+}
+
+AudioEngine::ReceivePresentationAudioQueues
+AudioEngine::receivePresentationAudioQueues() const
+{
+    ReceivePresentationAudioQueues queues;
+    queues.playbackQueuedMs = m_receivePresentationPlaybackQueuedMs.load(
+        std::memory_order_relaxed);
+    queues.flexRawBufferMs = m_receivePresentationFlexRawBufferMs.load(
+        std::memory_order_relaxed);
+    queues.flexOutputBufferMs = m_receivePresentationFlexOutputBufferMs.load(
+        std::memory_order_relaxed);
+    queues.kiwiSdrRawBufferMs = m_receivePresentationKiwiSdrRawBufferMs.load(
+        std::memory_order_relaxed);
+    queues.kiwiSdrOutputBufferMs =
+        m_receivePresentationKiwiSdrOutputBufferMs.load(
+            std::memory_order_relaxed);
+    queues.externalKiwiRawBufferMs =
+        m_receivePresentationExternalKiwiRawBufferMs.load(
+            std::memory_order_relaxed);
+    queues.externalKiwiOutputBufferMs =
+        m_receivePresentationExternalKiwiOutputBufferMs.load(
+            std::memory_order_relaxed);
+    return queues;
+}
+
+void AudioEngine::setReceivePresentationDelays(
+    int flexDelayMs,
+    int kiwiDelayMs,
+    const QString& externalKiwiDelaySourceId)
+{
+    const int flexDelay = qBound(0, flexDelayMs, 5000);
+    const int kiwiDelay = qBound(0, kiwiDelayMs, 5000);
+    const QString externalKiwiDelayId = externalKiwiDelaySourceId.trimmed();
+    const int legacyKiwiDelay = externalKiwiDelayId.isEmpty() ? kiwiDelay : 0;
+    m_externalKiwiReceivePresentationDelaySourceId = externalKiwiDelayId;
+    m_externalKiwiReceivePresentationDelayMs = kiwiDelay;
+
+    const int previousFlex =
+        m_flexReceivePresentationDelayMs.exchange(flexDelay,
+                                                  std::memory_order_relaxed);
+    const int previousKiwi =
+        m_kiwiReceivePresentationDelayMs.exchange(legacyKiwiDelay,
+                                                  std::memory_order_relaxed);
+
+    const int outputRate = std::max(1, m_rxOutputRate.load());
+    const auto hasFlexQueuedAudio = [this]() {
+        return !m_rxBuffer.isEmpty() || !m_rxPackets.empty()
+               || !m_rxOutputBuffer.isEmpty();
+    };
+    const auto hasLegacyKiwiQueuedAudio = [this]() {
+        return !m_kiwiSdrRxBuffer.isEmpty() || !m_kiwiSdrRxPackets.empty()
+               || !m_kiwiSdrOutputBuffer.isEmpty();
+    };
+    const auto hasExternalSourceQueuedAudio =
+        [](const ExternalRxAudioSourceState& source) {
+            return !source.rxBuffer.isEmpty() || !source.rxPackets.empty()
+                   || !source.outputBuffer.isEmpty();
+        };
+    if (flexDelay < previousFlex) {
+        trimReceivePresentationBuffers(
+            m_rxBuffer, m_rxPackets, m_rxOutputBuffer, outputRate,
+            audioBytesForMsAtRate(DEFAULT_SAMPLE_RATE, flexDelay));
+    }
+    if (legacyKiwiDelay < previousKiwi) {
+        const qsizetype targetBytes =
+            audioBytesForMsAtRate(DEFAULT_SAMPLE_RATE, legacyKiwiDelay);
+        trimReceivePresentationBuffers(
+            m_kiwiSdrRxBuffer, m_kiwiSdrRxPackets, m_kiwiSdrOutputBuffer,
+            outputRate, targetBytes);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        const int previousSourceDelay = source->presentationDelayMs;
+        const int sourceDelay = receivePresentationExternalKiwiDelayMs(
+            source->id, externalKiwiDelayId, kiwiDelay);
+        source->presentationDelayMs = sourceDelay;
+        if (sourceDelay < previousSourceDelay) {
+            const qsizetype targetBytes =
+                audioBytesForMsAtRate(DEFAULT_SAMPLE_RATE, sourceDelay);
+            trimReceivePresentationBuffers(
+                source->rxBuffer, source->rxPackets, source->outputBuffer,
+                outputRate, targetBytes);
+        }
+        if (receivePresentationShouldPrebufferAfterDelayChange(
+                previousSourceDelay, sourceDelay,
+                externalKiwiSourceAudible(*source),
+                hasExternalSourceQueuedAudio(*source))) {
+            source->prebuffering = true;
+        } else if (sourceDelay <= 0) {
+            source->prebuffering = false;
+        }
+    }
+
+    if (receivePresentationShouldPrebufferAfterDelayChange(
+            previousFlex, flexDelay, true, hasFlexQueuedAudio())) {
+        m_rxPresentationPrebuffering.store(true, std::memory_order_relaxed);
+    } else if (flexDelay <= 0) {
+        m_rxPresentationPrebuffering.store(false, std::memory_order_relaxed);
+    }
+
+    if (receivePresentationShouldPrebufferAfterDelayChange(
+            previousKiwi, legacyKiwiDelay, kiwiSdrAudioActive(),
+            hasLegacyKiwiQueuedAudio())) {
+        m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
+    } else if (legacyKiwiDelay <= 0) {
+        m_kiwiSdrPrebuffering.store(false, std::memory_order_relaxed);
+    }
+    updateRxBufferStats();
+}
+
+void AudioEngine::resetReceivePresentationAudioBuffers()
+{
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+
+    m_rxBuffer.clear();
+    m_rxPackets.clear();
+    m_rxOutputBuffer.clear();
+    m_kiwiSdrRxBuffer.clear();
+    m_kiwiSdrRxPackets.clear();
+    m_kiwiSdrOutputBuffer.clear();
+    m_radeRxBuffer.clear();
+
+    const bool flexPrebuffer =
+        m_flexReceivePresentationDelayMs.load(std::memory_order_relaxed) > 0;
+    m_rxPresentationPrebuffering.store(flexPrebuffer,
+                                       std::memory_order_relaxed);
+    m_kiwiSdrPrebuffering.store(kiwiSdrAudioActive(),
+                                std::memory_order_relaxed);
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->prebuffering = externalKiwiSourceAudible(*source);
+    }
+
+    updateRxBufferStats();
+}
+
+void AudioEngine::resetReceivePresentationAudioBuffersForKiwiSource(
+    const QString& sourceId)
+{
+    const QString id = sourceId.trimmed();
+    if (id.isEmpty()) {
+        return;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    for (const auto& source : m_externalKiwiSources) {
+        if (!source || source->id != id) {
+            continue;
+        }
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->prebuffering =
+            source->presentationDelayMs > 0
+            && externalKiwiSourceAudible(*source);
+        updateRxBufferStats();
+        return;
+    }
 }
 
 AudioEngine::ExternalRxAudioSourceState*
@@ -578,6 +960,9 @@ AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
 
     auto source = std::make_unique<ExternalRxAudioSourceState>();
     source->id = id;
+    source->presentationDelayMs = receivePresentationExternalKiwiDelayMs(
+        id, m_externalKiwiReceivePresentationDelaySourceId,
+        m_externalKiwiReceivePresentationDelayMs);
     source->prebuffering = true;
     if (m_nr2Enabled.load(std::memory_order_relaxed) && m_kiwiSdrNr2) {
         source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
@@ -798,41 +1183,48 @@ AudioEngine::AudioEngine(QObject* parent)
         const bool externalKiwiAudio = anyExternalKiwiAudioEnabled();
         const bool anyKiwiAudio = kiwiAudio || externalKiwiAudio;
         const int configuredBufMs = m_rxBufferCapMs.load();
-        const int effectiveBufMs = anyKiwiAudio
-            ? std::max(configuredBufMs, kKiwiSdrBufferCapMs)
-            : configuredBufMs;
+        const int flexPresentationDelayMs =
+            m_flexReceivePresentationDelayMs.load(std::memory_order_relaxed);
+        const int kiwiPresentationDelayMs =
+            m_kiwiReceivePresentationDelayMs.load(std::memory_order_relaxed);
+        int externalKiwiPresentationDelayMs = 0;
+        for (const auto& source : m_externalKiwiSources) {
+            if (source && externalKiwiSourceAudible(*source)) {
+                externalKiwiPresentationDelayMs =
+                    std::max(externalKiwiPresentationDelayMs,
+                             source->presentationDelayMs);
+            }
+        }
+        const int kiwiPresentationBufferMs =
+            anyKiwiAudio
+                ? std::max(kiwiPresentationDelayMs,
+                           externalKiwiPresentationDelayMs)
+                : 0;
+        const int presentationBufMs =
+            std::max(flexPresentationDelayMs, kiwiPresentationBufferMs);
+        const int effectiveBufMs =
+            std::max({configuredBufMs,
+                      anyKiwiAudio ? kKiwiSdrBufferCapMs : configuredBufMs,
+                      presentationBufMs > 0 ? presentationBufMs + 100 : 0});
         const qsizetype sourceMaxBufBytes =
             DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
             * effectiveBufMs / 1000;
         const qsizetype outputMaxBufBytes =
             sampleRate * 2 * static_cast<qsizetype>(sizeof(float))
             * effectiveBufMs / 1000;
-        trimAudioPacketQueue(m_rxPackets, sourceMaxBufBytes);
-        if (m_rxBuffer.size() > sourceMaxBufBytes) {
-            // Drop oldest samples to keep latency bounded
-            m_rxBuffer.remove(0, m_rxBuffer.size() - sourceMaxBufBytes);
-        }
-        if (m_kiwiSdrRxBuffer.size() > sourceMaxBufBytes) {
-            m_kiwiSdrRxBuffer.remove(0, m_kiwiSdrRxBuffer.size() - sourceMaxBufBytes);
-        }
-        if (m_rxOutputBuffer.size() > outputMaxBufBytes) {
-            m_rxOutputBuffer.remove(0, m_rxOutputBuffer.size() - outputMaxBufBytes);
-        }
-        if (m_kiwiSdrOutputBuffer.size() > outputMaxBufBytes) {
-            m_kiwiSdrOutputBuffer.remove(
-                0, m_kiwiSdrOutputBuffer.size() - outputMaxBufBytes);
-        }
+        trimReceivePresentationBuffers(
+            m_rxBuffer, m_rxPackets, m_rxOutputBuffer, sampleRate,
+            sourceMaxBufBytes);
+        trimReceivePresentationBuffers(
+            m_kiwiSdrRxBuffer, m_kiwiSdrRxPackets, m_kiwiSdrOutputBuffer,
+            sampleRate, sourceMaxBufBytes);
         for (const auto& source : m_externalKiwiSources) {
             if (!source) {
                 continue;
             }
-            if (source->rxBuffer.size() > sourceMaxBufBytes) {
-                source->rxBuffer.remove(0, source->rxBuffer.size() - sourceMaxBufBytes);
-            }
-            if (source->outputBuffer.size() > outputMaxBufBytes) {
-                source->outputBuffer.remove(
-                    0, source->outputBuffer.size() - outputMaxBufBytes);
-            }
+            trimReceivePresentationBuffers(
+                source->rxBuffer, source->rxPackets, source->outputBuffer,
+                sampleRate, sourceMaxBufBytes);
         }
         if (m_radeRxBuffer.size() > outputMaxBufBytes) {
             m_radeRxBuffer.remove(0, m_radeRxBuffer.size() - outputMaxBufBytes);
@@ -847,7 +1239,7 @@ AudioEngine::AudioEngine(QObject* parent)
             && m_radeRxBuffer.isEmpty()
             && !anyExternalKiwiBufferQueued()) {
             if (anyKiwiAudio) {
-                m_kiwiSdrPrebuffering = true;
+                m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
                 for (const auto& source : m_externalKiwiSources) {
                     if (source && externalKiwiSourceAudible(*source)) {
                         source->prebuffering = true;
@@ -856,7 +1248,46 @@ AudioEngine::AudioEngine(QObject* parent)
             } else {
                 m_rxBufferUnderrunCount.fetch_add(1);
             }
+            if (flexPresentationDelayMs > 0) {
+                m_rxPresentationPrebuffering.store(true,
+                                                   std::memory_order_relaxed);
+            }
         }
+
+        // Align to stereo float32 frame boundaries before any arithmetic.
+        const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
+        const qsizetype frameBytes = 2 * floatBytes;
+        const qsizetype freeFrames = freeBytes / frameBytes;
+        const bool nr2PacketMode = m_nr2Enabled.load(std::memory_order_relaxed);
+        const qsizetype flexPrebufferBytes =
+            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+            * flexPresentationDelayMs / 1000;
+        const qsizetype kiwiPresentationDelayBytes =
+            DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+            * kiwiPresentationDelayMs / 1000;
+        const auto externalKiwiPresentationDelayBytes =
+            [](const ExternalRxAudioSourceState& source) {
+                return DEFAULT_SAMPLE_RATE * 2
+                       * static_cast<qsizetype>(sizeof(float))
+                       * source.presentationDelayMs / 1000;
+            };
+        if (flexPresentationDelayMs <= 0) {
+            m_rxPresentationPrebuffering.store(false,
+                                               std::memory_order_relaxed);
+        } else if (m_rxPresentationPrebuffering.load(std::memory_order_relaxed)) {
+            const qsizetype flexQueuedBytes =
+                nr2PacketMode ? queuedAudioBytes(m_rxPackets) : m_rxBuffer.size();
+            if (flexQueuedBytes >= flexPrebufferBytes) {
+                m_rxPresentationPrebuffering.store(false,
+                                                   std::memory_order_relaxed);
+            }
+        } else if (m_rxBuffer.isEmpty() && m_rxPackets.empty()
+                   && m_rxOutputBuffer.isEmpty()) {
+            m_rxPresentationPrebuffering.store(true,
+                                               std::memory_order_relaxed);
+        }
+        const bool flexPresentationPrebuffering =
+            m_rxPresentationPrebuffering.load(std::memory_order_relaxed);
 
         // Zombie sink watchdog: if we have data waiting but the sink reports
         // zero bytes free for ~2 seconds, the WASAPI handle is likely stale
@@ -910,14 +1341,32 @@ AudioEngine::AudioEngine(QObject* parent)
             return;
         }
 
-        if (m_nr2Enabled.load(std::memory_order_relaxed)) {
+        if (nr2PacketMode) {
             std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-            while (!m_rxPackets.empty()) {
+            auto queuedRawEquivalent = [sampleRate](qsizetype rawBytes,
+                                                    qsizetype outputBytes) {
+                return rawBytes
+                       + rawEquivalentAudioBytes(outputBytes, sampleRate);
+            };
+            while (!flexPresentationPrebuffering
+                   && !m_rxPackets.empty()
+                   && (m_rxOutputBuffer.size() / frameBytes) < freeFrames
+                   && (flexPrebufferBytes <= 0
+                       || queuedRawEquivalent(queuedAudioBytes(m_rxPackets),
+                                             m_rxOutputBuffer.size())
+                              > flexPrebufferBytes)) {
                 QByteArray packet = std::move(m_rxPackets.front());
                 m_rxPackets.pop_front();
                 processMixedRxAudioData(packet, RxDspSource::Main);
             }
-            while (kiwiAudio && !m_kiwiSdrRxPackets.empty()) {
+            while (kiwiAudio
+                   && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
+                   && !m_kiwiSdrRxPackets.empty()
+                   && (m_kiwiSdrOutputBuffer.size() / frameBytes) < freeFrames
+                   && queuedAudioBytes(m_kiwiSdrRxPackets)
+                          + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
+                                                    sampleRate)
+                          > kiwiPresentationDelayBytes) {
                 QByteArray packet = std::move(m_kiwiSdrRxPackets.front());
                 m_kiwiSdrRxPackets.pop_front();
                 processMixedRxAudioData(packet, RxDspSource::KiwiSdr);
@@ -926,7 +1375,15 @@ AudioEngine::AudioEngine(QObject* parent)
                 if (!source || !externalKiwiSourceAudible(*source)) {
                     continue;
                 }
-                while (!source->rxPackets.empty()) {
+                const qsizetype sourcePresentationDelayBytes =
+                    externalKiwiPresentationDelayBytes(*source);
+                while (!source->prebuffering
+                       && !source->rxPackets.empty()
+                       && (source->outputBuffer.size() / frameBytes) < freeFrames
+                       && queuedAudioBytes(source->rxPackets)
+                              + rawEquivalentAudioBytes(source->outputBuffer.size(),
+                                                        sampleRate)
+                              > sourcePresentationDelayBytes) {
                     QByteArray packet = std::move(source->rxPackets.front());
                     source->rxPackets.pop_front();
                     processMixedRxAudioData(packet, RxDspSource::KiwiSdr, source.get());
@@ -934,25 +1391,26 @@ AudioEngine::AudioEngine(QObject* parent)
             }
         }
 
-        if (kiwiAudio && m_kiwiSdrPrebuffering) {
+        if (kiwiAudio
+            && m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)) {
             // KiwiSDR uncompressed audio is observed as 512-sample 12 kHz
             // blocks (~43 ms), but WebSocket delivery bunches frames with
             // >100 ms gaps. Hold only the Kiwi jitter buffer before mixing;
             // the normal Flex RX buffer must keep draining while Kiwi fills.
             const int prebufferMs = std::min(
-                kKiwiSdrJitterTargetMs,
-                std::max(50, effectiveBufMs / 2));
+                std::max(kKiwiSdrJitterTargetMs, kiwiPresentationDelayMs),
+                effectiveBufMs);
             const qsizetype prebufferBytes =
-                (m_nr2Enabled.load(std::memory_order_relaxed)
-                     ? sampleRate
-                     : DEFAULT_SAMPLE_RATE)
-                * 2 * static_cast<qsizetype>(sizeof(float)) * prebufferMs / 1000;
+                DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+                * prebufferMs / 1000;
             const qsizetype bufferedBytes =
-                m_nr2Enabled.load(std::memory_order_relaxed)
-                    ? m_kiwiSdrOutputBuffer.size()
+                nr2PacketMode
+                    ? queuedAudioBytes(m_kiwiSdrRxPackets)
+                          + rawEquivalentAudioBytes(m_kiwiSdrOutputBuffer.size(),
+                                                    sampleRate)
                     : m_kiwiSdrRxBuffer.size();
             if (bufferedBytes >= prebufferBytes) {
-                m_kiwiSdrPrebuffering = false;
+                m_kiwiSdrPrebuffering.store(false, std::memory_order_relaxed);
             }
         }
         for (const auto& source : m_externalKiwiSources) {
@@ -961,48 +1419,56 @@ AudioEngine::AudioEngine(QObject* parent)
                 continue;
             }
             const int prebufferMs = std::min(
-                kKiwiSdrJitterTargetMs,
-                std::max(50, effectiveBufMs / 2));
+                std::max(kKiwiSdrJitterTargetMs,
+                         source->presentationDelayMs),
+                effectiveBufMs);
             const qsizetype prebufferBytes =
-                (m_nr2Enabled.load(std::memory_order_relaxed)
-                     ? sampleRate
-                     : DEFAULT_SAMPLE_RATE)
-                * 2 * static_cast<qsizetype>(sizeof(float)) * prebufferMs / 1000;
+                DEFAULT_SAMPLE_RATE * 2 * static_cast<qsizetype>(sizeof(float))
+                * prebufferMs / 1000;
             const qsizetype bufferedBytes =
-                m_nr2Enabled.load(std::memory_order_relaxed)
-                    ? source->outputBuffer.size()
+                nr2PacketMode
+                    ? queuedAudioBytes(source->rxPackets)
+                          + rawEquivalentAudioBytes(source->outputBuffer.size(),
+                                                    sampleRate)
                     : source->rxBuffer.size();
             if (bufferedBytes >= prebufferBytes) {
                 source->prebuffering = false;
             }
         }
 
-        // Align to stereo float32 frame boundaries before any arithmetic.
-        const qsizetype floatBytes = static_cast<qsizetype>(sizeof(float));
-        const qsizetype frameBytes = 2 * floatBytes;
-        const bool nr2PacketMode = m_nr2Enabled.load(std::memory_order_relaxed);
         const bool kiwiNr2PacketMode = kiwiAudio && nr2PacketMode;
-        if (kiwiNr2PacketMode && !m_kiwiSdrPrebuffering
-            && m_kiwiSdrOutputBuffer.isEmpty()) {
-            m_kiwiSdrPrebuffering = true;
+        // Queued packets below the delay target are intentional delay growth,
+        // not an underrun; keep playback state live while the queue catches up.
+        if (kiwiNr2PacketMode
+            && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed)
+            && m_kiwiSdrOutputBuffer.isEmpty()
+            && m_kiwiSdrRxPackets.empty()) {
+            m_kiwiSdrPrebuffering.store(true, std::memory_order_relaxed);
         }
         const bool kiwiMixActive =
-            kiwiAudio && !kiwiNr2PacketMode && !m_kiwiSdrPrebuffering;
+            kiwiAudio && !kiwiNr2PacketMode
+            && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed);
         for (const auto& source : m_externalKiwiSources) {
             if (!source || !externalKiwiSourceAudible(*source)
                 || source->prebuffering) {
                 continue;
             }
+            // Same as the legacy Kiwi path: packets held for presentation delay
+            // should not flip an already-live source back into prebuffering.
             const bool sourceEmpty =
-                nr2PacketMode ? source->outputBuffer.isEmpty()
-                              : source->rxBuffer.isEmpty();
+                nr2PacketMode
+                    ? source->outputBuffer.isEmpty()
+                          && source->rxPackets.empty()
+                    : source->rxBuffer.isEmpty();
             if (sourceEmpty) {
                 source->prebuffering = true;
             }
         }
         const qsizetype kiwiMixBytes =
-            kiwiMixActive ? m_kiwiSdrRxBuffer.size() : 0;
-        const qsizetype freeFrames = freeBytes / frameBytes;
+            kiwiMixActive
+                ? std::max<qsizetype>(
+                      0, m_kiwiSdrRxBuffer.size() - kiwiPresentationDelayBytes)
+                : 0;
         // Fill each post-DSP FIFO independently. A prebuffered Kiwi FIFO must
         // not make the timer skip Flex processing, otherwise Flex only leaks
         // into the final mix when the Kiwi FIFO briefly drains.
@@ -1014,11 +1480,13 @@ AudioEngine::AudioEngine(QObject* parent)
                 ? (wantedMainOutputFrames * DEFAULT_SAMPLE_RATE) / sampleRate
                 : wantedMainOutputFrames;
         const qsizetype wantedMainNativeBytes = wantedMainNativeFrames * frameBytes;
+        const qsizetype availableMainBytes =
+            (!nr2PacketMode && !flexPresentationPrebuffering)
+                ? std::max<qsizetype>(0, m_rxBuffer.size() - flexPrebufferBytes)
+                : 0;
         const qsizetype mainBytes =
-            nr2PacketMode
-                ? 0
-                : (std::min(wantedMainNativeBytes, m_rxBuffer.size()) / frameBytes)
-                    * frameBytes;
+            (std::min(wantedMainNativeBytes, availableMainBytes) / frameBytes)
+            * frameBytes;
         if (mainBytes > 0) {
             const QByteArray mainPcm = m_rxBuffer.left(mainBytes);
             m_rxBuffer.remove(0, mainBytes);
@@ -1071,8 +1539,13 @@ AudioEngine::AudioEngine(QObject* parent)
                         : wantedSourceOutputFrames;
                 const qsizetype wantedSourceNativeBytes =
                     wantedSourceNativeFrames * frameBytes;
+                const qsizetype availableSourceBytes =
+                    std::max<qsizetype>(
+                        0,
+                        source->rxBuffer.size()
+                            - externalKiwiPresentationDelayBytes(*source));
                 const qsizetype sourceBytes =
-                    (std::min(wantedSourceNativeBytes, source->rxBuffer.size())
+                    (std::min(wantedSourceNativeBytes, availableSourceBytes)
                      / frameBytes) * frameBytes;
                 if (sourceBytes <= 0) {
                     continue;
@@ -1086,10 +1559,12 @@ AudioEngine::AudioEngine(QObject* parent)
         }
 
         const qsizetype kiwiOutputBytes =
-            (kiwiAudio && !m_kiwiSdrPrebuffering)
+            (kiwiAudio
+             && !m_kiwiSdrPrebuffering.load(std::memory_order_relaxed))
                 ? m_kiwiSdrOutputBuffer.size()
                 : 0;
-        const qsizetype externalKiwiOutputBytes = externalKiwiOutputBufferBytes();
+        const qsizetype externalKiwiOutputBytes =
+            externalKiwiOutputBufferBytes();
         const qsizetype aggregateKiwiOutputBytes =
             std::max(kiwiOutputBytes, externalKiwiOutputBytes);
         qsizetype len = (freeBytes / frameBytes) * frameBytes;
@@ -1100,16 +1575,29 @@ AudioEngine::AudioEngine(QObject* parent)
         if (len > 0)
         {
             QByteArray chunk;
+            auto emitOutputSource = [this, sampleRate](
+                                        const QString& source,
+                                        const QString& sourceId,
+                                        const QByteArray& pcm) {
+                if (!pcm.isEmpty()) {
+                    captureAutomationAudio(QStringLiteral("output"), source,
+                                           sourceId, pcm, sampleRate, 2);
+                    emit receivePresentationOutputAudioReady(
+                        source, sourceId, pcm, sampleRate);
+                }
+            };
             if (m_radeRxBuffer.isEmpty() && aggregateKiwiOutputBytes <= 0) {
                 // Fast path: no decoded overlay active -- write the
                 // already-processed RX output directly.
                 chunk = m_rxOutputBuffer.left(len);
                 m_rxOutputBuffer.remove(0, chunk.size());
+                emitOutputSource(QStringLiteral("flex"), QString(), chunk);
             } else if (m_rxOutputBuffer.isEmpty() && m_radeRxBuffer.isEmpty()
                        && kiwiOutputBytes > 0 && externalKiwiOutputBytes <= 0) {
                 // Fast path: only Kiwi decoded audio is active.
                 chunk = m_kiwiSdrOutputBuffer.left(len);
                 m_kiwiSdrOutputBuffer.remove(0, chunk.size());
+                emitOutputSource(QStringLiteral("kiwi"), QString(), chunk);
             } else {
                 // Mix path: add post-DSP Flex, every post-DSP Kiwi stream,
                 // and decoded RADE sample-wise at the output device rate.
@@ -1122,8 +1610,9 @@ AudioEngine::AudioEngine(QObject* parent)
                     (std::min(len, m_rxOutputBuffer.size()) / floatBytes)
                     * floatBytes;
                 if (rxTake > 0) {
+                    const QByteArray rxChunk = m_rxOutputBuffer.left(rxTake);
                     const auto* rx =
-                        reinterpret_cast<const float*>(m_rxOutputBuffer.constData());
+                        reinterpret_cast<const float*>(rxChunk.constData());
                     const qsizetype rxSamples = rxTake / floatBytes;
                     bool sourceActive = false;
                     for (qsizetype i = 0; i < rxSamples; ++i) {
@@ -1135,14 +1624,17 @@ AudioEngine::AudioEngine(QObject* parent)
                         ++activeOutputSources;
                     }
                     m_rxOutputBuffer.remove(0, rxTake);
+                    emitOutputSource(QStringLiteral("flex"), QString(), rxChunk);
                 }
 
                 const qsizetype kiwiTake =
                     (std::min(len, kiwiOutputBytes) / floatBytes)
                     * floatBytes;
                 if (kiwiTake > 0) {
+                    const QByteArray kiwiChunk =
+                        m_kiwiSdrOutputBuffer.left(kiwiTake);
                     const auto* kiwi =
-                        reinterpret_cast<const float*>(m_kiwiSdrOutputBuffer.constData());
+                        reinterpret_cast<const float*>(kiwiChunk.constData());
                     const qsizetype kiwiSamples = kiwiTake / floatBytes;
                     bool sourceActive = false;
                     for (qsizetype i = 0; i < kiwiSamples; ++i) {
@@ -1154,6 +1646,7 @@ AudioEngine::AudioEngine(QObject* parent)
                         ++activeOutputSources;
                     }
                     m_kiwiSdrOutputBuffer.remove(0, kiwiTake);
+                    emitOutputSource(QStringLiteral("kiwi"), QString(), kiwiChunk);
                 }
 
                 for (const auto& source : m_externalKiwiSources) {
@@ -1167,8 +1660,11 @@ AudioEngine::AudioEngine(QObject* parent)
                     if (sourceTake <= 0) {
                         continue;
                     }
+                    QByteArray sourceChunk = source->outputBuffer.left(sourceTake);
                     const auto* kiwi =
-                        reinterpret_cast<const float*>(source->outputBuffer.constData());
+                        reinterpret_cast<const float*>(sourceChunk.constData());
+                    auto* capturedKiwi =
+                        reinterpret_cast<float*>(sourceChunk.data());
                     const qsizetype kiwiSamples = sourceTake / floatBytes;
                     bool sourceActive = false;
                     for (qsizetype i = 0; i < kiwiSamples; ++i) {
@@ -1176,11 +1672,14 @@ AudioEngine::AudioEngine(QObject* parent)
                         sourceActive = sourceActive
                             || std::fabs(sample) > kOutputSilenceThreshold;
                         out[i] += sample;
+                        capturedKiwi[i] = sample;
                     }
                     if (sourceActive) {
                         ++activeOutputSources;
                     }
                     source->outputBuffer.remove(0, sourceTake);
+                    emitOutputSource(QStringLiteral("kiwi"), source->id,
+                                     sourceChunk);
                 }
 
                 const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
@@ -1213,6 +1712,17 @@ AudioEngine::AudioEngine(QObject* parent)
             }
 
             len = m_audioDevice->write(chunk);
+            if (len > 0) {
+                const qsizetype capturedBytes =
+                    alignedStereoFloatBytes(
+                        std::min<qsizetype>(len, chunk.size()));
+                if (capturedBytes > 0) {
+                    captureAutomationAudio(
+                        QStringLiteral("final"), QStringLiteral("mix"),
+                        QString(), chunk.left(capturedBytes),
+                        sampleRate, 2);
+                }
+            }
 
             // Stale session watchdog: if we're writing data but processedUSecs()
             // hasn't advanced, the WASAPI session is silently discarding audio
@@ -1235,6 +1745,21 @@ AudioEngine::AudioEngine(QObject* parent)
                 m_rxStaleTickCount = 0;
                 m_lastProcessedUSecs = processed;
             }
+        }
+
+        if (m_audioSink && sampleRate > 0) {
+            const qsizetype sinkBufferBytes = m_audioSink->bufferSize();
+            const qsizetype sinkFreeBytes = m_audioSink->bytesFree();
+            const qsizetype sinkQueuedBytes =
+                std::clamp(sinkBufferBytes - sinkFreeBytes,
+                           static_cast<qsizetype>(0),
+                           std::max<qsizetype>(0, sinkBufferBytes));
+            const int playbackQueuedMs =
+                qBound(0, audioBytesToMs(sinkQueuedBytes, sampleRate), 1000);
+            m_rxPlaybackQueuedMs.store(playbackQueuedMs,
+                                       std::memory_order_relaxed);
+        } else {
+            m_rxPlaybackQueuedMs.store(0, std::memory_order_relaxed);
         }
 
         updateRxBufferStats();
@@ -1294,6 +1819,31 @@ QJsonArray AudioEngine::audioEndpointDiagnostics() const
     rx["buffer_bytes"] = static_cast<double>(m_rxBufferBytes.load());
     rx["buffer_peak_bytes"] = static_cast<double>(m_rxBufferPeakBytes.load());
     rx["underrun_count"] = static_cast<double>(m_rxBufferUnderrunCount.load());
+    QJsonObject presentation;
+    presentation["flex_delay_ms"] =
+        m_flexReceivePresentationDelayMs.load(std::memory_order_relaxed);
+    presentation["kiwi_sdr_delay_ms"] =
+        m_kiwiReceivePresentationDelayMs.load(std::memory_order_relaxed);
+    presentation["flex_prebuffering"] =
+        m_rxPresentationPrebuffering.load(std::memory_order_relaxed);
+    presentation["kiwi_sdr_prebuffering"] =
+        m_kiwiSdrPrebuffering.load(std::memory_order_relaxed);
+    const ReceivePresentationAudioQueues queues =
+        receivePresentationAudioQueues();
+    presentation["playback_queued_ms"] = queues.playbackQueuedMs;
+    presentation["flex_raw_buffer_ms"] =
+        queues.flexRawBufferMs;
+    presentation["flex_output_buffer_ms"] =
+        queues.flexOutputBufferMs;
+    presentation["kiwi_sdr_raw_buffer_ms"] =
+        queues.kiwiSdrRawBufferMs;
+    presentation["kiwi_sdr_output_buffer_ms"] =
+        queues.kiwiSdrOutputBufferMs;
+    presentation["external_kiwi_raw_buffer_ms"] =
+        queues.externalKiwiRawBufferMs;
+    presentation["external_kiwi_output_buffer_ms"] =
+        queues.externalKiwiOutputBufferMs;
+    rx["receive_presentation"] = presentation;
     endpoints.append(rx);
 
     const bool txRunning = m_audioSource != nullptr;
@@ -1366,6 +1916,206 @@ QJsonArray AudioEngine::audioEndpointDiagnostics() const
     endpoints.append(quindar);
 
     return endpoints;
+}
+
+QJsonObject AudioEngine::startAutomationAudioCapture(
+    int durationMs,
+    const QStringList& points)
+{
+    QStringList normalizedPoints;
+    normalizedPoints.reserve(points.size());
+    for (const QString& point : points) {
+        const QString normalized = point.trimmed().toLower();
+        if (!normalized.isEmpty()) {
+            normalizedPoints.append(normalized);
+        }
+    }
+
+    const bool allPoints =
+        normalizedPoints.isEmpty()
+        || normalizedPoints.contains(QStringLiteral("all"));
+    const bool captureRaw =
+        allPoints || normalizedPoints.contains(QStringLiteral("raw"));
+    const bool capturePost =
+        allPoints || normalizedPoints.contains(QStringLiteral("post"));
+    const bool captureOutput =
+        allPoints || normalizedPoints.contains(QStringLiteral("output"));
+    const bool captureFinal =
+        allPoints || normalizedPoints.contains(QStringLiteral("final"));
+    if (!captureRaw && !capturePost && !captureOutput && !captureFinal) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("audioCapture start points must include raw, post, output, final, or all")},
+        };
+    }
+
+    const int boundedDurationMs =
+        qBound(100, durationMs, kAutomationAudioCaptureMaxDurationMs);
+    const qint64 nowNs = steadyNowNs();
+
+    std::lock_guard<std::mutex> lock(m_automationAudioCaptureMutex);
+    m_automationCaptureChunks.clear();
+    m_automationCaptureBytes = 0;
+    m_automationCaptureMaxBytes = kAutomationAudioCaptureMaxBytes;
+    m_automationCaptureRaw = captureRaw;
+    m_automationCapturePost = capturePost;
+    m_automationCaptureOutput = captureOutput;
+    m_automationCaptureFinal = captureFinal;
+    m_automationCaptureStartNs = nowNs;
+    m_automationCaptureEndNs =
+        nowNs + static_cast<qint64>(boundedDurationMs) * 1000000;
+    m_automationAudioCaptureActive.store(true, std::memory_order_relaxed);
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("active"), true},
+        {QStringLiteral("durationMs"), boundedDurationMs},
+        {QStringLiteral("raw"), captureRaw},
+        {QStringLiteral("post"), capturePost},
+        {QStringLiteral("output"), captureOutput},
+        {QStringLiteral("final"), captureFinal},
+        {QStringLiteral("maxBytes"),
+         static_cast<double>(m_automationCaptureMaxBytes)},
+    };
+}
+
+QJsonObject AudioEngine::stopAutomationAudioCapture()
+{
+    m_automationAudioCaptureActive.store(false, std::memory_order_relaxed);
+    return automationAudioCaptureSnapshot(false);
+}
+
+QJsonObject AudioEngine::automationAudioCaptureSnapshot(bool includePcm) const
+{
+    const qint64 nowNs = steadyNowNs();
+    QVector<AutomationAudioCaptureChunk> chunksCopy;
+    bool captureRaw = false;
+    bool capturePost = false;
+    bool captureOutput = false;
+    bool captureFinal = false;
+    qint64 captureStartNs = 0;
+    qint64 captureEndNs = 0;
+    qsizetype captureBytes = 0;
+    qsizetype captureMaxBytes = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_automationAudioCaptureMutex);
+        chunksCopy = m_automationCaptureChunks;
+        captureRaw = m_automationCaptureRaw;
+        capturePost = m_automationCapturePost;
+        captureOutput = m_automationCaptureOutput;
+        captureFinal = m_automationCaptureFinal;
+        captureStartNs = m_automationCaptureStartNs;
+        captureEndNs = m_automationCaptureEndNs;
+        captureBytes = m_automationCaptureBytes;
+        captureMaxBytes = m_automationCaptureMaxBytes;
+    }
+
+    QJsonArray chunks;
+    for (const AutomationAudioCaptureChunk& chunk : chunksCopy) {
+        QJsonObject item{
+            {QStringLiteral("point"), chunk.point},
+            {QStringLiteral("source"), chunk.source},
+            {QStringLiteral("sourceId"), chunk.sourceId},
+            {QStringLiteral("sampleRate"), chunk.sampleRate},
+            {QStringLiteral("channels"), chunk.channels},
+            {QStringLiteral("format"), QStringLiteral("float32le")},
+            {QStringLiteral("startNs"), static_cast<double>(chunk.startNs)},
+            {QStringLiteral("bytes"), chunk.pcm.size()},
+            {QStringLiteral("frames"),
+             chunk.channels > 0
+                 ? chunk.pcm.size()
+                       / (chunk.channels
+                          * static_cast<int>(sizeof(float)))
+                 : 0},
+        };
+        if (includePcm) {
+            item[QStringLiteral("pcmBase64")] =
+                QString::fromLatin1(chunk.pcm.toBase64());
+        }
+        chunks.append(item);
+    }
+
+    const bool active =
+        m_automationAudioCaptureActive.load(std::memory_order_relaxed)
+        && nowNs < captureEndNs;
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("active"), active},
+        {QStringLiteral("raw"), captureRaw},
+        {QStringLiteral("post"), capturePost},
+        {QStringLiteral("output"), captureOutput},
+        {QStringLiteral("final"), captureFinal},
+        {QStringLiteral("elapsedMs"),
+         captureStartNs > 0
+             ? static_cast<double>((nowNs - captureStartNs)
+                                   / 1000000)
+             : 0.0},
+        {QStringLiteral("capturedBytes"),
+         static_cast<double>(captureBytes)},
+        {QStringLiteral("maxBytes"),
+         static_cast<double>(captureMaxBytes)},
+        {QStringLiteral("chunkCount"), chunks.size()},
+        {QStringLiteral("chunks"), chunks},
+    };
+}
+
+void AudioEngine::captureAutomationAudio(const QString& point,
+                                         const QString& source,
+                                         const QString& sourceId,
+                                         const QByteArray& pcm,
+                                         int sampleRate,
+                                         int channels)
+{
+    if (!m_automationAudioCaptureActive.load(std::memory_order_relaxed)
+        || pcm.isEmpty() || channels <= 0 || sampleRate <= 0) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(m_automationAudioCaptureMutex);
+    if (!m_automationAudioCaptureActive.load(std::memory_order_relaxed)) {
+        return;
+    }
+    if ((point == QLatin1String("raw") && !m_automationCaptureRaw)
+        || (point == QLatin1String("post") && !m_automationCapturePost)
+        || (point == QLatin1String("output") && !m_automationCaptureOutput)
+        || (point == QLatin1String("final") && !m_automationCaptureFinal)) {
+        return;
+    }
+
+    const qint64 nowNs = steadyNowNs();
+    if (nowNs >= m_automationCaptureEndNs) {
+        m_automationAudioCaptureActive.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+    const qsizetype frameBytes =
+        channels * static_cast<qsizetype>(sizeof(float));
+    const qsizetype alignedBytes =
+        (std::max<qsizetype>(0, pcm.size()) / frameBytes) * frameBytes;
+    const qsizetype remainingBytes =
+        m_automationCaptureMaxBytes - m_automationCaptureBytes;
+    const qsizetype captureBytes =
+        (std::min(alignedBytes, remainingBytes) / frameBytes) * frameBytes;
+    if (captureBytes <= 0) {
+        m_automationAudioCaptureActive.store(false, std::memory_order_relaxed);
+        return;
+    }
+
+    m_automationCaptureChunks.append(
+        AutomationAudioCaptureChunk{
+            .point = point,
+            .source = source,
+            .sourceId = sourceId,
+            .sampleRate = sampleRate,
+            .channels = channels,
+            .startNs = nowNs - m_automationCaptureStartNs,
+            .pcm = pcm.left(captureBytes),
+        });
+    m_automationCaptureBytes += captureBytes;
+    if (m_automationCaptureBytes >= m_automationCaptureMaxBytes) {
+        m_automationAudioCaptureActive.store(false, std::memory_order_relaxed);
+    }
 }
 
 // ─── RX stream ───────────────────────────────────────────────────────────────
@@ -1621,6 +2371,7 @@ void AudioEngine::stopRxStream()
     m_rxBufferBytes.store(0);
     m_rxBufferPeakBytes.store(0);
     m_rxBufferSampleRate.store(DEFAULT_SAMPLE_RATE);
+    m_rxPlaybackQueuedMs.store(0, std::memory_order_relaxed);
 
     if (m_audioSink) {
         // Null out m_audioSink BEFORE stopping so that the stateChanged
@@ -1882,6 +2633,8 @@ QByteArray AudioEngine::resampleStereo(const QByteArray& pcm,
 
 void AudioEngine::feedAudioData(const QByteArray& pcm)
 {
+    captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("flex"),
+                           QString(), pcm, DEFAULT_SAMPLE_RATE, 2);
     processRxAudioData(pcm, true);
 }
 
@@ -1907,6 +2660,8 @@ void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
         alignedBytes == pcm24kStereoFloat.size()
             ? pcm24kStereoFloat
             : pcm24kStereoFloat.left(alignedBytes);
+    captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("kiwi"),
+                           QString(), alignedPcm, DEFAULT_SAMPLE_RATE, 2);
 
     if (m_nr2Enabled.load(std::memory_order_relaxed)) {
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
@@ -1942,6 +2697,8 @@ void AudioEngine::feedKiwiSdrAudioData(const QString& sourceId,
         alignedBytes == pcm24kStereoFloat.size()
             ? pcm24kStereoFloat
             : pcm24kStereoFloat.left(alignedBytes);
+    captureAutomationAudio(QStringLiteral("raw"), QStringLiteral("kiwi"),
+                           sourceId, alignedPcm, DEFAULT_SAMPLE_RATE, 2);
 
     if (m_nr2Enabled.load(std::memory_order_relaxed)) {
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
@@ -1972,7 +2729,8 @@ void AudioEngine::setKiwiSdrAudioEnabled(bool on)
     if (m_nr2Enabled && m_kiwiSdrNr2) {
         m_kiwiSdrNr2->reset();
     }
-    m_kiwiSdrPrebuffering = on && !kiwiSdrAudioTransmitMuted();
+    m_kiwiSdrPrebuffering.store(on && !kiwiSdrAudioTransmitMuted(),
+                                std::memory_order_relaxed);
     updateRxBufferStats();
 }
 
@@ -2069,8 +2827,9 @@ void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
     if (m_nr2Enabled && m_kiwiSdrNr2) {
         m_kiwiSdrNr2->reset();
     }
-    m_kiwiSdrPrebuffering = !muted
-        && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed);
+    m_kiwiSdrPrebuffering.store(
+        !muted && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
 
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
@@ -2396,6 +3155,17 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             ? externalSource->outputBuffer
             : (source == RxDspSource::KiwiSdr ? m_kiwiSdrOutputBuffer
                                                : m_rxOutputBuffer);
+        captureAutomationAudio(
+            QStringLiteral("post"),
+            source == RxDspSource::KiwiSdr ? QStringLiteral("kiwi")
+                                           : QStringLiteral("flex"),
+            externalSource ? externalSource->id : QString(),
+            *output, scopeSampleRate, 2);
+        emit receivePresentationPostDspAudioReady(
+            source == RxDspSource::KiwiSdr ? QStringLiteral("kiwi")
+                                           : QStringLiteral("flex"),
+            externalSource ? externalSource->id : QString(),
+            *output, scopeSampleRate);
         outputBuffer.append(*output);
         emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
@@ -4421,7 +5191,8 @@ void AudioEngine::setNr2Enabled(bool on)
     m_kiwiSdrNr2Mono.clear();
     m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
-    m_kiwiSdrPrebuffering = kiwiSdrAudioActive();
+    m_kiwiSdrPrebuffering.store(kiwiSdrAudioActive(),
+                                std::memory_order_relaxed);
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
             continue;

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -7,8 +7,10 @@
 #include <QAudioFormat>
 #include <QIODevice>
 #include <QJsonArray>
+#include <QJsonObject>
 #include <QUdpSocket>
 #include <QTimer>
+#include <QVector>
 #include <atomic>
 #include <cstdint>
 #include <mutex>
@@ -17,6 +19,7 @@
 #include <QElapsedTimer>
 #include <QPointer>
 #include <QString>
+#include <QStringList>
 
 #include "TxMicChannelNormalizer.h"
 #include "SpectralNR.h"
@@ -24,6 +27,7 @@
 class QMediaDevices;
 
 #include <functional>
+#include <algorithm>
 #include <memory>
 #include <deque>
 #include <vector>
@@ -72,6 +76,28 @@ class AudioEngine : public QObject {
 
 public:
     static constexpr int DEFAULT_SAMPLE_RATE = 24000;
+
+    struct ReceivePresentationAudioQueues {
+        int playbackQueuedMs{0};
+        int flexRawBufferMs{0};
+        int flexOutputBufferMs{0};
+        int kiwiSdrRawBufferMs{0};
+        int kiwiSdrOutputBufferMs{0};
+        int externalKiwiRawBufferMs{0};
+        int externalKiwiOutputBufferMs{0};
+
+        int flexTotalQueuedMs() const
+        {
+            return flexRawBufferMs + flexOutputBufferMs + playbackQueuedMs;
+        }
+
+        int kiwiTotalQueuedMs() const
+        {
+            return std::max(kiwiSdrRawBufferMs + kiwiSdrOutputBufferMs,
+                            externalKiwiRawBufferMs + externalKiwiOutputBufferMs)
+                   + playbackQueuedMs;
+        }
+    };
 
     explicit AudioEngine(QObject* parent = nullptr);
     ~AudioEngine() override;
@@ -122,6 +148,13 @@ public:
     int  rxPan() const { return m_rxPan.load(); }
     void  setRxBufferCapMs(int ms) { m_rxBufferCapMs.store(qBound(50, ms, 1000)); }
     int   rxBufferCapMs() const { return m_rxBufferCapMs.load(); }
+    void setReceivePresentationDelays(
+        int flexDelayMs,
+        int kiwiDelayMs,
+        const QString& externalKiwiDelaySourceId = QString());
+    void resetReceivePresentationAudioBuffers();
+    void resetReceivePresentationAudioBuffersForKiwiSource(
+        const QString& sourceId);
 
     bool isMuted() const       { return m_muted.load(); }
     void setMuted(bool m);
@@ -133,6 +166,10 @@ public:
     bool txInputResamplingTo24k() const { return m_txNeedsResample; }
     bool rxOutputResamplingActive() const { return m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE; }
     QJsonArray audioEndpointDiagnostics() const;
+    QJsonObject startAutomationAudioCapture(int durationMs,
+                                            const QStringList& points);
+    QJsonObject stopAutomationAudioCapture();
+    QJsonObject automationAudioCaptureSnapshot(bool includePcm) const;
 
     // Client-side PC mic gain (0-100 → 0.0-1.0, applied before Opus encoding)
     void setPcMicGain(int level) { m_pcMicGain.store(qBound(0, level, 100) / 100.0f); }
@@ -452,6 +489,11 @@ public:
     qsizetype rxBufferPeakBytes() const { return m_rxBufferPeakBytes.load(); }
     quint64 rxBufferUnderrunCount() const { return m_rxBufferUnderrunCount.load(); }
     int rxBufferSampleRate() const { return m_rxBufferSampleRate.load(); }
+    int rxPlaybackQueuedMs() const
+    {
+        return m_rxPlaybackQueuedMs.load(std::memory_order_relaxed);
+    }
+    ReceivePresentationAudioQueues receivePresentationAudioQueues() const;
 
     // Local CW sidetone generator — accessor used by RadioModel signal
     // routing and PhoneCwApplet UI bindings.
@@ -524,6 +566,14 @@ signals:
     // RX panStream::audioDataReady() path so CwDecoder::feedAudio()
     // accepts it without a separate adapter.
     void txDecodeAudioReady(const QByteArray& pcm24kStereoFloat);
+    void receivePresentationPostDspAudioReady(const QString& source,
+                                              const QString& sourceId,
+                                              const QByteArray& pcmStereoFloat,
+                                              int sampleRate);
+    void receivePresentationOutputAudioReady(const QString& source,
+                                             const QString& sourceId,
+                                             const QByteArray& pcmStereoFloat,
+                                             int sampleRate);
 
     void pcMicLevelChanged(float peakDbfs, float avgDbfs);  // client-side PC mic metering
     void scopeSamplesReady(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
@@ -580,10 +630,21 @@ private:
         QByteArray bnrOutBuf;
         float gain{1.0f};
         int pan{50};
+        int presentationDelayMs{0};
         bool enabled{false};
         bool muted{false};
         bool prebuffering{false};
         bool bnrPrimed{false};
+    };
+
+    struct AutomationAudioCaptureChunk {
+        QString point;
+        QString source;
+        QString sourceId;
+        int sampleRate{DEFAULT_SAMPLE_RATE};
+        int channels{2};
+        qint64 startNs{0};
+        QByteArray pcm;
     };
 
     QAudioFormat makeFormat() const;
@@ -605,6 +666,12 @@ private:
     void processMixedRxAudioData(const QByteArray& pcm,
                                  RxDspSource source = RxDspSource::Main,
                                  ExternalRxAudioSourceState* externalSource = nullptr);
+    void captureAutomationAudio(const QString& point,
+                                const QString& source,
+                                const QString& sourceId,
+                                const QByteArray& pcm,
+                                int sampleRate,
+                                int channels);
     void processNr2(const QByteArray& stereoPcm,
                     RxDspSource source = RxDspSource::Main,
                     ExternalRxAudioSourceState* externalSource = nullptr);
@@ -966,12 +1033,37 @@ private:
     QByteArray    m_radeRxBuffer;  // decoded RADE speech at output device rate
     std::atomic<bool> m_kiwiSdrAudioEnabled{false};
     std::atomic<bool> m_kiwiSdrAudioTransmitMuted{false};
-    bool          m_kiwiSdrPrebuffering{false};
+    std::atomic<int>  m_flexReceivePresentationDelayMs{0};
+    std::atomic<int>  m_kiwiReceivePresentationDelayMs{0};
+    QString           m_externalKiwiReceivePresentationDelaySourceId;
+    int               m_externalKiwiReceivePresentationDelayMs{0};
+    std::atomic<bool> m_rxPresentationPrebuffering{false};
+    std::atomic<bool> m_kiwiSdrPrebuffering{false};
     std::vector<std::unique_ptr<ExternalRxAudioSourceState>> m_externalKiwiSources;
     std::atomic<qsizetype> m_rxBufferBytes{0};
     std::atomic<qsizetype> m_rxBufferPeakBytes{0};
     std::atomic<quint64>   m_rxBufferUnderrunCount{0};
     std::atomic<int>       m_rxBufferSampleRate{DEFAULT_SAMPLE_RATE};
+    std::atomic<int>       m_rxPlaybackQueuedMs{0};
+    // Cached on the audio thread; diagnostics may read from GUI/automation.
+    std::atomic<int>       m_receivePresentationPlaybackQueuedMs{0};
+    std::atomic<int>       m_receivePresentationFlexRawBufferMs{0};
+    std::atomic<int>       m_receivePresentationFlexOutputBufferMs{0};
+    std::atomic<int>       m_receivePresentationKiwiSdrRawBufferMs{0};
+    std::atomic<int>       m_receivePresentationKiwiSdrOutputBufferMs{0};
+    std::atomic<int>       m_receivePresentationExternalKiwiRawBufferMs{0};
+    std::atomic<int>       m_receivePresentationExternalKiwiOutputBufferMs{0};
+    mutable std::mutex     m_automationAudioCaptureMutex;
+    std::atomic<bool>      m_automationAudioCaptureActive{false};
+    bool                   m_automationCaptureRaw{false};
+    bool                   m_automationCapturePost{false};
+    bool                   m_automationCaptureOutput{false};
+    bool                   m_automationCaptureFinal{false};
+    qint64                 m_automationCaptureStartNs{0};
+    qint64                 m_automationCaptureEndNs{0};
+    qsizetype              m_automationCaptureBytes{0};
+    qsizetype              m_automationCaptureMaxBytes{0};
+    QVector<AutomationAudioCaptureChunk> m_automationCaptureChunks;
     static constexpr int   kKiwiSdrJitterTargetMs = 360;
     static constexpr int   kKiwiSdrBufferCapMs = 1000;
     void resetRxChainStateForSourceSwitch();

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1115,6 +1115,8 @@ QJsonObject audioSnapshot(const AudioEngine* audio)
             static_cast<double>(audio->rxBufferUnderrunCount())},
         {QStringLiteral("rxBufferSampleRate"),
             audio->rxBufferSampleRate()},
+        {QStringLiteral("endpoints"),
+            audio->audioEndpointDiagnostics()},
     };
 }
 
@@ -1381,7 +1383,7 @@ bool AutomationServer::start(const QString& serverName)
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
-        << "txtest, atu, slice, tune, pan, streams, txwaterfall, key, cwx, station, resize,"
+        << "txtest, atu, slice, tune, pan, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
         << "menu, close, drag, showMenu, whoami, log, mark)";
     return true;
 }
@@ -1614,7 +1616,12 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         } else if (cmd == QLatin1String("txtest") || cmd == QLatin1String("atu")) {
             action = tok(1);  // e.g. "txtest twotone", "atu bypass"
         } else if (cmd == QLatin1String("slice")) {
-            action = tok(1); value = tok(2);  // "slice add 14.2", "slice remove 1"
+            action = tok(1);
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) {
+                rest << tok(i);
+            }
+            value = rest.join(QLatin1Char(' '));  // "slice add 14.2", "slice rxsource 7 K4JK"
         } else if (cmd == QLatin1String("tune")) {
             value = tok(1);   // "tune 3.7"
         } else if (cmd == QLatin1String("log")) {
@@ -1635,6 +1642,13 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
         } else if (cmd == QLatin1String("streams")) {
             action = tok(1);  // "" (Layer A UDP-orphan) | "radio" (Layer B) | "reset"
+        } else if (cmd == QLatin1String("audioCapture")) {
+            action = tok(1);  // start | stop | read | status
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) {
+                rest << tok(i);
+            }
+            value = rest.join(QLatin1Char(' '));
         } else if (cmd == QLatin1String("txwaterfall")) {
             value = tok(1);                   // on | off
         } else if (cmd == QLatin1String("key")) {
@@ -1740,7 +1754,7 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("slice")) {
         if (action.isEmpty())
-            return err(QStringLiteral("slice requires an action (add|remove|select|tx|txant)"));
+            return err(QStringLiteral("slice requires an action (add|remove|select|tx|txant|rxant|rxsource)"));
         return doSlice(action, value);
     }
     if (cmd == QLatin1String("tune")) {
@@ -1757,6 +1771,9 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("streams"))
         return doStreams(action);
+    if (cmd == QLatin1String("audioCapture"))
+        return doAudioCapture(action.isEmpty() ? QStringLiteral("status") : action,
+                              value, path);
     if (cmd == QLatin1String("txwaterfall")) {
         // Radio-authoritative display flag (`transmit set show_tx_in_waterfall`)
         // that gates whether keyed-up TX renders FFT-derived rows in the
@@ -2317,6 +2334,16 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                            {QStringLiteral("model"), model},
                            {QStringLiteral("audio"), data}};
     }
+    if (model == QLatin1String("sync")
+        || model == QLatin1String("receiveSync")) {
+        if (!m_receiveSyncSnapshotHandler) {
+            return err(QStringLiteral("receive sync snapshot unavailable"));
+        }
+        QJsonObject data = m_receiveSyncSnapshotHandler();
+        data[QStringLiteral("ok")] = true;
+        data[QStringLiteral("model")] = model;
+        return data;
+    }
 
     RadioModel* radio = m_radioModel;
     if (!radio)
@@ -2368,7 +2395,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use audio|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {
@@ -2904,7 +2931,13 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
                            {tx ? QStringLiteral("txAntenna") : QStringLiteral("rxAntenna"), ant},
                            {QStringLiteral("requested"), true}};
     }
-    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select|tx|txant|rxant)"));
+    if (action == QLatin1String("rxsource") || action == QLatin1String("source")) {
+        if (!m_sliceReceiveSourceHandler) {
+            return err(QStringLiteral("slice rxsource is unavailable in this app instance"));
+        }
+        return m_sliceReceiveSourceHandler(arg);
+    }
+    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select|tx|txant|rxant|rxsource)"));
 }
 
 // ── VFO tuning (#3646) ──────────────────────────────────────────────────────
@@ -3580,6 +3613,101 @@ QJsonObject AutomationServer::doStreams(const QString& action)
         {QStringLiteral("orphanStreams"), orphans},
         {QStringLiteral("orphanCount"), orphans.size()},
     };
+}
+
+QJsonObject AutomationServer::doAudioCapture(const QString& action,
+                                             const QString& arg,
+                                             const QString& path) const
+{
+    if (!m_audioEngine) {
+        return err(QStringLiteral("no audio engine available"));
+    }
+
+    auto compactSnapshot = [this]() {
+        QJsonObject snapshot =
+            m_audioEngine->automationAudioCaptureSnapshot(false);
+        snapshot[QStringLiteral("chunksOmitted")] =
+            snapshot.value(QStringLiteral("chunkCount"));
+        snapshot.remove(QStringLiteral("chunks"));
+        return snapshot;
+    };
+
+    const QString normalizedAction = action.trimmed().toLower();
+    if (normalizedAction == QLatin1String("start")) {
+        const QStringList parts =
+            arg.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        int durationMs = 5000;
+        int pointStart = 0;
+        if (!parts.isEmpty()) {
+            bool ok = false;
+            const int parsed = parts.constFirst().toInt(&ok);
+            if (ok) {
+                durationMs = parsed;
+                pointStart = 1;
+            }
+        }
+
+        QStringList points;
+        for (int i = pointStart; i < parts.size(); ++i) {
+            const QStringList split =
+                parts.at(i).split(QLatin1Char(','),
+                                  Qt::SkipEmptyParts);
+            for (const QString& point : split) {
+                points.append(point);
+            }
+        }
+        return m_audioEngine->startAutomationAudioCapture(durationMs, points);
+    }
+
+    if (normalizedAction == QLatin1String("stop")) {
+        m_audioEngine->stopAutomationAudioCapture();
+        return compactSnapshot();
+    }
+
+    if (normalizedAction == QLatin1String("status")) {
+        return compactSnapshot();
+    }
+
+    if (normalizedAction == QLatin1String("read")) {
+        const QString outPath =
+            !path.trimmed().isEmpty() ? path.trimmed() : arg.trimmed();
+        if (outPath.isEmpty()) {
+            return compactSnapshot();
+        }
+
+        const QJsonObject capture =
+            m_audioEngine->automationAudioCaptureSnapshot(true);
+        QFile out(outPath);
+        const QFileInfo info(outPath);
+        if (!info.absoluteDir().exists()
+            && !QDir().mkpath(info.absolutePath())) {
+            return err(QStringLiteral("failed to create audio capture directory: ")
+                       + info.absolutePath());
+        }
+        if (!out.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            return err(QStringLiteral("failed to write audio capture: ")
+                       + out.errorString());
+        }
+        const QByteArray json = QJsonDocument(capture).toJson(
+            QJsonDocument::Compact);
+        if (out.write(json) != json.size()) {
+            return err(QStringLiteral("failed to write complete audio capture"));
+        }
+        out.close();
+
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("path"), outPath},
+            {QStringLiteral("bytes"), json.size()},
+            {QStringLiteral("active"), capture.value(QStringLiteral("active"))},
+            {QStringLiteral("capturedBytes"),
+             capture.value(QStringLiteral("capturedBytes"))},
+            {QStringLiteral("chunkCount"),
+             capture.value(QStringLiteral("chunkCount"))},
+        };
+    }
+
+    return err(QStringLiteral("audioCapture action must be start, stop, status, or read"));
 }
 
 QJsonObject AutomationServer::doWhoami() const

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -6,16 +6,17 @@
 #include <QByteArray>
 #include <QElapsedTimer>
 #include <QMutex>
+#include <QJsonObject>
 #include <QString>
 
 #include <deque>
+#include <functional>
 #include <memory>
 #include <vector>
 
 class QLocalServer;
 class QLocalSocket;
 class QWidget;
-class QJsonObject;
 class QTimer;
 
 namespace AetherSDR {
@@ -175,6 +176,15 @@ public:
     // automation exercises the normal MainWindow/RadioModel connection path.
     void setConnectionPanel(ConnectionPanel* panel) { m_connectionPanel = panel; }
     void setConnectionDialogHost(QObject* host) { m_connectionDialogHost = host; }
+    void setSliceReceiveSourceHandler(
+        std::function<QJsonObject(const QString&)> handler)
+    {
+        m_sliceReceiveSourceHandler = std::move(handler);
+    }
+    void setReceiveSyncSnapshotHandler(std::function<QJsonObject()> handler)
+    {
+        m_receiveSyncSnapshotHandler = std::move(handler);
+    }
 
 private slots:
     void onNewConnection();
@@ -239,6 +249,9 @@ private:
     //                     resource-level lingering Layer A can't see.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
+    QJsonObject doAudioCapture(const QString& action,
+                               const QString& arg,
+                               const QString& path) const;
     QJsonObject doGet(const QString& model, const QString& selector,
                       const QString& property) const;
     QJsonObject doConnect(const QString& action, const QString& arg, QLocalSocket* sock);
@@ -304,6 +317,8 @@ private:
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<ConnectionPanel> m_connectionPanel;  // for connect/disconnect verbs
     QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
+    std::function<QJsonObject(const QString&)> m_sliceReceiveSourceHandler;
+    std::function<QJsonObject()> m_receiveSyncSnapshotHandler;
 
     // Agent station identity (#3646). The bridge sets the per-GUI-client station
     // name to the agent's name on connect and restores the user's real name on

--- a/src/core/ReceivePresentationSync.cpp
+++ b/src/core/ReceivePresentationSync.cpp
@@ -1,0 +1,841 @@
+#include "ReceivePresentationSync.h"
+
+#include <numeric>
+
+namespace AetherSDR {
+namespace {
+
+constexpr float kEpsilon = 1.0e-12f;
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr int kEnvelopeFrameMs = 10;
+constexpr int kEnvelopeWaveformAgreementMs = 80;
+constexpr float kEnvelopeOverrideConfidenceRatio = 1.15f;
+constexpr int kAutoOffsetDeadbandMs = 15;
+constexpr int kAutoOffsetMaxStepMs = 20;
+
+int clampInt(int value, int low, int high)
+{
+    return std::clamp(value, low, high);
+}
+
+qint64 absoluteFrequencyDeltaHz(qint64 lhs, qint64 rhs)
+{
+    return lhs >= rhs ? lhs - rhs : rhs - lhs;
+}
+
+int nextPowerOfTwo(int value)
+{
+    int n = 1;
+    while (n < value) {
+        n <<= 1;
+    }
+    return n;
+}
+
+int overlapSamplesForOffset(int flexSize, int kiwiSize, int offsetSamples)
+{
+    const int flexStart = offsetSamples >= 0 ? 0 : -offsetSamples;
+    const int kiwiStart = offsetSamples >= 0 ? offsetSamples : 0;
+    return std::min(flexSize - flexStart, kiwiSize - kiwiStart);
+}
+
+double signalEnergy(const QVector<float>& signal)
+{
+    double energy = 0.0;
+    for (float sample : signal) {
+        energy += static_cast<double>(sample) * static_cast<double>(sample);
+    }
+    return energy;
+}
+
+struct FeatureVector {
+    QVector<float> samples;
+    int sampleRateHz{1};
+};
+
+QVector<float> normalizedCopy(const QVector<float>& input)
+{
+    QVector<float> out = input;
+    if (out.isEmpty()) {
+        return out;
+    }
+
+    double mean = 0.0;
+    for (float sample : out) {
+        mean += sample;
+    }
+    mean /= static_cast<double>(out.size());
+
+    double energy = 0.0;
+    for (float& sample : out) {
+        sample = static_cast<float>(sample - mean);
+        energy += static_cast<double>(sample) * static_cast<double>(sample);
+    }
+
+    if (energy <= kEpsilon) {
+        out.fill(0.0f);
+        return out;
+    }
+
+    const float scale = static_cast<float>(1.0 / std::sqrt(energy));
+    for (float& sample : out) {
+        sample *= scale;
+    }
+    return out;
+}
+
+float normalizedCorrelationAt(const QVector<float>& flex,
+                              const QVector<float>& kiwi,
+                              int offsetSamples,
+                              int minOverlapSamples)
+{
+    const int flexSize = flex.size();
+    const int kiwiSize = kiwi.size();
+    if (flexSize <= 0 || kiwiSize <= 0) {
+        return 0.0f;
+    }
+
+    const int flexStart = offsetSamples >= 0 ? 0 : -offsetSamples;
+    const int kiwiStart = offsetSamples >= 0 ? offsetSamples : 0;
+    const int overlap = std::min(flexSize - flexStart, kiwiSize - kiwiStart);
+    if (overlap < minOverlapSamples) {
+        return 0.0f;
+    }
+
+    double dot = 0.0;
+    double flexEnergy = 0.0;
+    double kiwiEnergy = 0.0;
+    for (int i = 0; i < overlap; ++i) {
+        const float f = flex[flexStart + i];
+        const float k = kiwi[kiwiStart + i];
+        dot += static_cast<double>(f) * static_cast<double>(k);
+        flexEnergy += static_cast<double>(f) * static_cast<double>(f);
+        kiwiEnergy += static_cast<double>(k) * static_cast<double>(k);
+    }
+
+    const double denom = std::sqrt(flexEnergy * kiwiEnergy);
+    if (denom <= kEpsilon) {
+        return 0.0f;
+    }
+    return static_cast<float>(dot / denom);
+}
+
+void copyWindowedSignal(const QVector<float>& input,
+                        std::vector<std::complex<double>>& output)
+{
+    if (input.isEmpty()) {
+        return;
+    }
+
+    double mean = 0.0;
+    for (float sample : input) {
+        mean += static_cast<double>(sample);
+    }
+    mean /= static_cast<double>(input.size());
+
+    const double denom =
+        static_cast<double>(std::max<qsizetype>(1, input.size() - 1));
+    for (int i = 0; i < input.size(); ++i) {
+        const double window =
+            0.5 - 0.5 * std::cos((2.0 * kPi * static_cast<double>(i)) / denom);
+        output[static_cast<size_t>(i)] =
+            std::complex<double>((static_cast<double>(input[i]) - mean) * window,
+                                 0.0);
+    }
+}
+
+FeatureVector envelopeFeatures(const QVector<float>& input, int sampleRateHz)
+{
+    FeatureVector result;
+    const int frameSamples =
+        std::max(1, (sampleRateHz * kEnvelopeFrameMs) / 1000);
+    result.sampleRateHz = std::max(1, sampleRateHz / frameSamples);
+    if (input.size() < frameSamples) {
+        return result;
+    }
+
+    result.samples.reserve(input.size() / frameSamples);
+    for (int start = 0; start + frameSamples <= input.size();
+         start += frameSamples) {
+        double energy = 0.0;
+        for (int i = 0; i < frameSamples; ++i) {
+            const float sample = input[start + i];
+            energy += static_cast<double>(sample)
+                      * static_cast<double>(sample);
+        }
+        const double rms =
+            std::sqrt(energy / static_cast<double>(frameSamples));
+        result.samples.append(
+            static_cast<float>(std::log1p(16.0 * rms)));
+    }
+
+    return result;
+}
+
+ReceiveAudioDelayEstimate estimateByNormalizedScan(
+    const QVector<float>& flex,
+    const QVector<float>& kiwi,
+    int sampleRateHz,
+    int maxOffsetMs,
+    int minOverlapMs,
+    float minPeakCorrelation,
+    float minConfidence)
+{
+    ReceiveAudioDelayEstimate result;
+    if (flex.isEmpty() || kiwi.isEmpty()) {
+        return result;
+    }
+    if (signalEnergy(flex) <= kEpsilon || signalEnergy(kiwi) <= kEpsilon) {
+        return result;
+    }
+
+    const QVector<float> normalizedFlex = normalizedCopy(flex);
+    const QVector<float> normalizedKiwi = normalizedCopy(kiwi);
+    const int maxOffsetSamples =
+        (maxOffsetMs * sampleRateHz) / 1000;
+    const int minOverlapSamples =
+        std::max(1, (minOverlapMs * sampleRateHz) / 1000);
+    const int guardSamples =
+        std::max(1, (sampleRateHz * 20) / 1000);
+
+    double bestScore = -std::numeric_limits<double>::infinity();
+    double scoreSum = 0.0;
+    int scoreCount = 0;
+    int bestOffsetSamples = 0;
+    std::vector<double> scores;
+    scores.reserve(static_cast<size_t>(maxOffsetSamples * 2 + 1));
+    for (int offset = -maxOffsetSamples; offset <= maxOffsetSamples; ++offset) {
+        if (overlapSamplesForOffset(flex.size(), kiwi.size(), offset)
+            < minOverlapSamples) {
+            continue;
+        }
+
+        const double score = std::abs(
+            normalizedCorrelationAt(normalizedFlex, normalizedKiwi,
+                                    offset, minOverlapSamples));
+        scores.push_back(score);
+        scoreSum += score;
+        ++scoreCount;
+        if (score > bestScore) {
+            bestScore = score;
+            bestOffsetSamples = offset;
+        }
+    }
+
+    if (!std::isfinite(bestScore) || scoreCount <= 0) {
+        return result;
+    }
+
+    double secondScore = 0.0;
+    for (int offset = -maxOffsetSamples; offset <= maxOffsetSamples; ++offset) {
+        if (std::abs(offset - bestOffsetSamples) <= guardSamples
+            || overlapSamplesForOffset(flex.size(), kiwi.size(), offset)
+                   < minOverlapSamples) {
+            continue;
+        }
+        secondScore = std::max(
+            secondScore,
+            static_cast<double>(std::abs(
+                normalizedCorrelationAt(normalizedFlex, normalizedKiwi,
+                                        offset, minOverlapSamples))));
+    }
+
+    std::sort(scores.begin(), scores.end());
+    const double backgroundScore =
+        scores.empty()
+            ? 0.0
+            : scores[static_cast<size_t>(
+                std::clamp<int>(
+                    static_cast<int>(std::lround(
+                        static_cast<double>(scores.size() - 1) * 0.95)),
+                    0,
+                    static_cast<int>(scores.size() - 1)))];
+    const double meanScore = scoreSum / static_cast<double>(scoreCount);
+    const double peakLift =
+        bestScore > kEpsilon
+            ? std::clamp((bestScore - meanScore) / bestScore, 0.0, 1.0)
+            : 0.0;
+    const double backgroundSeparation =
+        bestScore > kEpsilon
+            ? std::clamp((bestScore - backgroundScore) / bestScore, 0.0, 1.0)
+            : 0.0;
+    const double sideLobeSeparation =
+        bestScore > kEpsilon
+            ? std::clamp((bestScore - secondScore) / bestScore, 0.0, 1.0)
+            : 0.0;
+    const float confidence =
+        std::clamp(static_cast<float>(
+                       bestScore
+                       * std::max(backgroundSeparation,
+                                  0.5 * sideLobeSeparation)
+                       * (0.65 + 0.35 * peakLift)),
+                   0.0f, 1.0f);
+
+    result.offsetMs =
+        static_cast<int>(std::lround(
+            static_cast<double>(bestOffsetSamples) * 1000.0
+            / static_cast<double>(sampleRateHz)));
+    result.peakCorrelation = std::clamp(
+        static_cast<float>(bestScore), 0.0f, 1.0f);
+    result.confidence = confidence;
+    result.valid = result.peakCorrelation >= minPeakCorrelation
+                   && confidence >= minConfidence;
+    return result;
+}
+
+} // namespace
+
+QString receivePresentationVisualQueueKey(ReceivePresentationSource source,
+                                          ReceivePresentationSurface surface,
+                                          const QString& sourceId)
+{
+    const QString sourceText =
+        source == ReceivePresentationSource::Flex
+            ? QStringLiteral("flex")
+            : QStringLiteral("kiwi");
+    QString surfaceText;
+    switch (surface) {
+    case ReceivePresentationSurface::Audio:
+        surfaceText = QStringLiteral("audio");
+        break;
+    case ReceivePresentationSurface::Waterfall:
+        surfaceText = QStringLiteral("waterfall");
+        break;
+    case ReceivePresentationSurface::Spectrum:
+        surfaceText = QStringLiteral("spectrum");
+        break;
+    case ReceivePresentationSurface::Meter:
+        surfaceText = QStringLiteral("meter");
+        break;
+    case ReceivePresentationSurface::Analyzer:
+        surfaceText = QStringLiteral("analyzer");
+        break;
+    case ReceivePresentationSurface::Decoder:
+        surfaceText = QStringLiteral("decoder");
+        break;
+    case ReceivePresentationSurface::Recording:
+        surfaceText = QStringLiteral("recording");
+        break;
+    }
+
+    const QString trimmedSourceId = sourceId.trimmed();
+    if (trimmedSourceId.isEmpty()) {
+        return sourceText + QLatin1Char(':') + surfaceText;
+    }
+    return sourceText + QLatin1Char(':') + surfaceText
+           + QLatin1Char(':') + trimmedSourceId;
+}
+
+int receivePresentationExternalKiwiDelayMs(
+    const QString& sourceId,
+    const QString& delaySourceId,
+    int kiwiDelayMs)
+{
+    const int delayMs = std::max(0, kiwiDelayMs);
+    const QString id = sourceId.trimmed();
+    const QString delayId = delaySourceId.trimmed();
+    if (delayId.isEmpty()) {
+        return delayMs;
+    }
+    if (id.isEmpty() || id != delayId) {
+        return 0;
+    }
+    return delayMs;
+}
+
+bool receivePresentationShouldPrebufferAfterDelayChange(int previousDelayMs,
+                                                        int nextDelayMs,
+                                                        bool sourceAudible,
+                                                        bool hasQueuedAudio)
+{
+    return nextDelayMs > previousDelayMs && sourceAudible && !hasQueuedAudio;
+}
+
+ReceiveSyncAudioPairSelection selectReceiveSyncAudioPair(
+    const QVector<ReceiveSyncAudioPairEndpoint>& flexCandidates,
+    const QVector<ReceiveSyncAudioPairEndpoint>& kiwiCandidates,
+    qint64 frequencyToleranceHz)
+{
+    ReceiveSyncAudioPairSelection selection;
+    selection.audibleFlexCount = flexCandidates.size();
+    selection.audibleKiwiCount = kiwiCandidates.size();
+
+    if (flexCandidates.isEmpty()) {
+        selection.reason = QStringLiteral("noAudibleFlex");
+        return selection;
+    }
+    if (flexCandidates.size() > 1) {
+        selection.state = ReceiveSyncAudioPairSelection::State::Ambiguous;
+        selection.reason = QStringLiteral("multipleAudibleFlex");
+        return selection;
+    }
+    if (kiwiCandidates.isEmpty()) {
+        selection.reason = QStringLiteral("noAudibleKiwi");
+        return selection;
+    }
+
+    const ReceiveSyncAudioPairEndpoint flex = flexCandidates.constFirst();
+    QVector<ReceiveSyncAudioPairEndpoint> matches;
+    for (const ReceiveSyncAudioPairEndpoint& kiwi : kiwiCandidates) {
+        if (absoluteFrequencyDeltaHz(flex.frequencyHz, kiwi.frequencyHz)
+            <= frequencyToleranceHz) {
+            matches.append(kiwi);
+        }
+    }
+
+    selection.matchingPairCount = matches.size();
+    if (matches.isEmpty()) {
+        selection.reason = QStringLiteral("noFrequencyMatch");
+        return selection;
+    }
+    if (matches.size() > 1) {
+        selection.state = ReceiveSyncAudioPairSelection::State::Ambiguous;
+        selection.reason = QStringLiteral("multipleFrequencyMatches");
+        return selection;
+    }
+
+    const ReceiveSyncAudioPairEndpoint kiwi = matches.constFirst();
+    selection.state = ReceiveSyncAudioPairSelection::State::Usable;
+    selection.kiwiProfileId = kiwi.kiwiProfileId;
+    selection.flexSliceId = flex.sliceId;
+    selection.kiwiSliceId = kiwi.sliceId;
+    selection.frequencyHz = flex.frequencyHz;
+    selection.reason = QStringLiteral("matchedFrequency");
+    return selection;
+}
+
+void ReceivePresentationSync::setSettings(
+    const ReceivePresentationSettings& settings)
+{
+    m_settings = settings;
+    m_settings.baseLatencyMs =
+        clampInt(m_settings.baseLatencyMs, kMinBaseLatencyMs, kMaxBaseLatencyMs);
+    m_settings.maxOffsetMs =
+        clampInt(std::abs(m_settings.maxOffsetMs), 0, kMaxOffsetMs);
+    m_settings.manualOffsetMs =
+        clampedOffset(m_settings.manualOffsetMs, m_settings.maxOffsetMs);
+    if (m_settings.autoEstimate.valid) {
+        m_settings.autoEstimate.offsetMs =
+            clampedOffset(m_settings.autoEstimate.offsetMs,
+                          m_settings.maxOffsetMs);
+        m_settings.autoEstimate.confidence =
+            std::clamp(m_settings.autoEstimate.confidence, 0.0f, 1.0f);
+    }
+    m_settings.autoLockConfidence =
+        std::clamp(m_settings.autoLockConfidence, 0.0f, 1.0f);
+}
+
+void ReceivePresentationSync::setEnabled(bool enabled)
+{
+    m_settings.enabled = enabled;
+}
+
+void ReceivePresentationSync::setMode(ReceiveSyncMode mode)
+{
+    m_settings.mode = mode;
+}
+
+void ReceivePresentationSync::setManualOffsetMs(int offsetMs)
+{
+    m_settings.manualOffsetMs = clampedOffset(offsetMs, m_settings.maxOffsetMs);
+}
+
+void ReceivePresentationSync::setBaseLatencyMs(int latencyMs)
+{
+    m_settings.baseLatencyMs =
+        clampInt(latencyMs, kMinBaseLatencyMs, kMaxBaseLatencyMs);
+}
+
+void ReceivePresentationSync::setMaxOffsetMs(int maxOffsetMs)
+{
+    m_settings.maxOffsetMs =
+        clampInt(std::abs(maxOffsetMs), 0, kMaxOffsetMs);
+    m_settings.manualOffsetMs =
+        clampedOffset(m_settings.manualOffsetMs, m_settings.maxOffsetMs);
+    if (m_settings.autoEstimate.valid) {
+        m_settings.autoEstimate.offsetMs =
+            clampedOffset(m_settings.autoEstimate.offsetMs,
+                          m_settings.maxOffsetMs);
+    }
+}
+
+void ReceivePresentationSync::setAutoEstimate(const ReceiveSyncEstimate& estimate)
+{
+    m_settings.autoEstimate = estimate;
+    m_settings.autoEstimate.offsetMs =
+        clampedOffset(m_settings.autoEstimate.offsetMs, m_settings.maxOffsetMs);
+    m_settings.autoEstimate.confidence =
+        std::clamp(m_settings.autoEstimate.confidence, 0.0f, 1.0f);
+}
+
+void ReceivePresentationSync::clearAutoEstimate()
+{
+    m_settings.autoEstimate = {};
+}
+
+ReceiveDelayBreakdown ReceivePresentationSync::delayBreakdown() const
+{
+    ReceiveDelayBreakdown result;
+    if (!m_settings.enabled) {
+        return result;
+    }
+
+    result.effectiveOffsetMs = effectiveOffsetMs();
+    result.flexDelayMs = m_settings.baseLatencyMs
+                         + std::max(0, result.effectiveOffsetMs);
+    result.kiwiDelayMs = m_settings.baseLatencyMs
+                         + std::max(0, -result.effectiveOffsetMs);
+
+    if (m_settings.mode == ReceiveSyncMode::Manual) {
+        result.status = ReceiveSyncStatus::Manual;
+    } else if (!m_settings.autoEstimate.valid) {
+        result.status = ReceiveSyncStatus::Searching;
+    } else if (m_settings.autoEstimate.held) {
+        result.status = ReceiveSyncStatus::Holding;
+    } else if (m_settings.autoEstimate.confidence
+               >= m_settings.autoLockConfidence) {
+        result.status = ReceiveSyncStatus::Locked;
+    } else {
+        result.status = ReceiveSyncStatus::LowConfidence;
+    }
+
+    return result;
+}
+
+int ReceivePresentationSync::delayMs(ReceivePresentationSource source,
+                                     ReceivePresentationSurface surface) const
+{
+    switch (surface) {
+    case ReceivePresentationSurface::Audio:
+    case ReceivePresentationSurface::Waterfall:
+    case ReceivePresentationSurface::Spectrum:
+    case ReceivePresentationSurface::Meter:
+        break;
+    case ReceivePresentationSurface::Analyzer:
+    case ReceivePresentationSurface::Decoder:
+    case ReceivePresentationSurface::Recording:
+        return 0;
+    }
+
+    const ReceiveDelayBreakdown breakdown = delayBreakdown();
+    switch (source) {
+    case ReceivePresentationSource::Flex:
+        return breakdown.flexDelayMs;
+    case ReceivePresentationSource::KiwiSdr:
+        return breakdown.kiwiDelayMs;
+    }
+    return 0;
+}
+
+qint64 ReceivePresentationSync::dueTimeMs(ReceivePresentationSource source,
+                                          ReceivePresentationSurface surface,
+                                          qint64 arrivalMs) const
+{
+    return arrivalMs + delayMs(source, surface);
+}
+
+int ReceivePresentationSync::adjustedAutoOffsetMs(int currentOffsetMs,
+                                                  int candidateOffsetMs,
+                                                  bool reset)
+{
+    if (reset) {
+        return candidateOffsetMs;
+    }
+
+    const int deltaMs = candidateOffsetMs - currentOffsetMs;
+    if (std::abs(deltaMs) <= kAutoOffsetDeadbandMs) {
+        return currentOffsetMs;
+    }
+
+    return currentOffsetMs
+           + clampInt(deltaMs, -kAutoOffsetMaxStepMs, kAutoOffsetMaxStepMs);
+}
+
+int ReceivePresentationSync::clampedOffset(int offsetMs, int maxAbsMs)
+{
+    const int maxOffset = clampInt(std::abs(maxAbsMs), 0, kMaxOffsetMs);
+    return clampInt(offsetMs, -maxOffset, maxOffset);
+}
+
+int ReceivePresentationSync::effectiveOffsetMs() const
+{
+    if (m_settings.mode != ReceiveSyncMode::AutoAssist) {
+        return m_settings.manualOffsetMs;
+    }
+    if (!m_settings.autoEstimate.valid) {
+        return m_settings.manualOffsetMs;
+    }
+    if (!m_settings.autoEstimate.held
+        && m_settings.autoEstimate.confidence < m_settings.autoLockConfidence) {
+        return m_settings.manualOffsetMs;
+    }
+    return clampedOffset(m_settings.autoEstimate.offsetMs,
+                         m_settings.maxOffsetMs);
+}
+
+ReceiveAudioDelayEstimator::ReceiveAudioDelayEstimator()
+{
+    setConfig(Config{});
+}
+
+ReceiveAudioDelayEstimator::ReceiveAudioDelayEstimator(Config config)
+{
+    setConfig(config);
+}
+
+void ReceiveAudioDelayEstimator::setConfig(const Config& config)
+{
+    m_config = config;
+    m_config.sampleRateHz = std::max(1, m_config.sampleRateHz);
+    m_config.maxOffsetMs = std::max(0, m_config.maxOffsetMs);
+    m_config.minOverlapMs = std::max(1, m_config.minOverlapMs);
+    m_config.minPeakCorrelation =
+        std::clamp(m_config.minPeakCorrelation, 0.0f, 1.0f);
+    m_config.minConfidence =
+        std::clamp(m_config.minConfidence, 0.0f, 1.0f);
+}
+
+void ReceiveAudioDelayEstimator::fft(
+    std::vector<std::complex<double>>& data,
+    bool inverse)
+{
+    const int n = static_cast<int>(data.size());
+    for (int i = 1, j = 0; i < n; ++i) {
+        int bit = n >> 1;
+        for (; (j & bit) != 0; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            std::swap(data[static_cast<size_t>(i)],
+                      data[static_cast<size_t>(j)]);
+        }
+    }
+
+    for (int len = 2; len <= n; len <<= 1) {
+        const double angle =
+            (inverse ? 2.0 : -2.0) * kPi / static_cast<double>(len);
+        const std::complex<double> wlen(std::cos(angle), std::sin(angle));
+        for (int i = 0; i < n; i += len) {
+            std::complex<double> w(1.0, 0.0);
+            const int half = len / 2;
+            for (int j = 0; j < half; ++j) {
+                const std::complex<double> u =
+                    data[static_cast<size_t>(i + j)];
+                const std::complex<double> v =
+                    data[static_cast<size_t>(i + j + half)] * w;
+                data[static_cast<size_t>(i + j)] = u + v;
+                data[static_cast<size_t>(i + j + half)] = u - v;
+                w *= wlen;
+            }
+        }
+    }
+
+    if (inverse) {
+        const double scale = 1.0 / static_cast<double>(n);
+        for (std::complex<double>& value : data) {
+            value *= scale;
+        }
+    }
+}
+
+ReceiveAudioDelayEstimate ReceiveAudioDelayEstimator::estimate(
+    const QVector<float>& flexMono,
+    const QVector<float>& kiwiMono) const
+{
+    const auto estimateAtRate =
+        [](const QVector<float>& flex,
+           const QVector<float>& kiwi,
+           int sampleRateHz,
+           int maxOffsetMs,
+           int minOverlapMs,
+           float minPeakCorrelation,
+           float minConfidence) {
+            ReceiveAudioDelayEstimate result;
+            if (flex.isEmpty() || kiwi.isEmpty()) {
+                return result;
+            }
+            if (signalEnergy(flex) <= kEpsilon || signalEnergy(kiwi) <= kEpsilon) {
+                return result;
+            }
+
+            const int maxOffsetSamples =
+                (maxOffsetMs * sampleRateHz) / 1000;
+            const int minOverlapSamples =
+                std::max(1, (minOverlapMs * sampleRateHz) / 1000);
+            const int fftSize =
+                nextPowerOfTwo(flex.size() + kiwi.size());
+
+            std::vector<std::complex<double>> flexSpectrum(
+                static_cast<size_t>(fftSize));
+            std::vector<std::complex<double>> kiwiSpectrum(
+                static_cast<size_t>(fftSize));
+            copyWindowedSignal(flex, flexSpectrum);
+            copyWindowedSignal(kiwi, kiwiSpectrum);
+            fft(flexSpectrum, false);
+            fft(kiwiSpectrum, false);
+
+            for (int i = 0; i < fftSize; ++i) {
+                std::complex<double> cross =
+                    std::conj(flexSpectrum[static_cast<size_t>(i)])
+                    * kiwiSpectrum[static_cast<size_t>(i)];
+                const double mag = std::abs(cross);
+                flexSpectrum[static_cast<size_t>(i)] =
+                    mag > static_cast<double>(kEpsilon)
+                        ? cross / mag
+                        : std::complex<double>();
+            }
+            fft(flexSpectrum, true);
+
+            double bestScore = -std::numeric_limits<double>::infinity();
+            double scoreSum = 0.0;
+            int scoreCount = 0;
+            int bestOffsetSamples = 0;
+
+            for (int offset = -maxOffsetSamples;
+                 offset <= maxOffsetSamples; ++offset) {
+                if (overlapSamplesForOffset(flex.size(), kiwi.size(), offset)
+                    < minOverlapSamples) {
+                    continue;
+                }
+
+                const int index = offset >= 0 ? offset : fftSize + offset;
+                if (index < 0 || index >= fftSize) {
+                    continue;
+                }
+
+                const double score =
+                    std::abs(flexSpectrum[static_cast<size_t>(index)]);
+                scoreSum += score;
+                ++scoreCount;
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestOffsetSamples = offset;
+                }
+            }
+
+            if (!std::isfinite(bestScore) || scoreCount <= 0) {
+                return result;
+            }
+
+            double secondScore = 0.0;
+            const int guardSamples =
+                std::max(1, (sampleRateHz * 20) / 1000);
+            for (int offset = -maxOffsetSamples;
+                 offset <= maxOffsetSamples; ++offset) {
+                if (std::abs(offset - bestOffsetSamples) <= guardSamples
+                    || overlapSamplesForOffset(flex.size(), kiwi.size(), offset)
+                           < minOverlapSamples) {
+                    continue;
+                }
+                const int index = offset >= 0 ? offset : fftSize + offset;
+                if (index < 0 || index >= fftSize) {
+                    continue;
+                }
+                secondScore =
+                    std::max(secondScore,
+                             std::abs(flexSpectrum[static_cast<size_t>(index)]));
+            }
+
+            const QVector<float> normalizedFlex = normalizedCopy(flex);
+            const QVector<float> normalizedKiwi = normalizedCopy(kiwi);
+            const float refinedCorrelation = std::abs(
+                normalizedCorrelationAt(normalizedFlex, normalizedKiwi,
+                                        bestOffsetSamples,
+                                        minOverlapSamples));
+            const double meanScore = scoreSum / static_cast<double>(scoreCount);
+            const double peakLift =
+                bestScore > kEpsilon
+                    ? std::clamp((bestScore - meanScore) / bestScore,
+                                 0.0, 1.0)
+                    : 0.0;
+            const double sideLobeSeparation =
+                bestScore > kEpsilon
+                    ? std::clamp((bestScore - secondScore) / bestScore,
+                                 0.0, 1.0)
+                    : 0.0;
+            const float confidence =
+                std::clamp(static_cast<float>(
+                               refinedCorrelation
+                               * (0.55 + 0.45 * peakLift)
+                               * (0.35 + 0.65 * sideLobeSeparation)),
+                           0.0f, 1.0f);
+
+            result.offsetMs =
+                static_cast<int>(std::lround(
+                    static_cast<double>(bestOffsetSamples) * 1000.0
+                    / static_cast<double>(sampleRateHz)));
+            result.peakCorrelation =
+                std::clamp(refinedCorrelation, 0.0f, 1.0f);
+            result.confidence = confidence;
+            result.valid = result.peakCorrelation >= minPeakCorrelation
+                           && confidence >= minConfidence;
+            return result;
+        };
+
+    ReceiveAudioDelayEstimate result;
+    if (flexMono.isEmpty() || kiwiMono.isEmpty()) {
+        return result;
+    }
+    if (signalEnergy(flexMono) <= kEpsilon || signalEnergy(kiwiMono) <= kEpsilon) {
+        return result;
+    }
+
+    const ReceiveAudioDelayEstimate waveform =
+        estimateAtRate(flexMono, kiwiMono, m_config.sampleRateHz,
+                       m_config.maxOffsetMs, m_config.minOverlapMs,
+                       m_config.minPeakCorrelation, m_config.minConfidence);
+
+    const FeatureVector flexEnvelope =
+        envelopeFeatures(flexMono, m_config.sampleRateHz);
+    const FeatureVector kiwiEnvelope =
+        envelopeFeatures(kiwiMono, m_config.sampleRateHz);
+    const ReceiveAudioDelayEstimate envelopePhat =
+        estimateAtRate(flexEnvelope.samples, kiwiEnvelope.samples,
+                       flexEnvelope.sampleRateHz, m_config.maxOffsetMs,
+                       m_config.minOverlapMs,
+                       std::min(m_config.minPeakCorrelation, 0.12f),
+                       std::min(m_config.minConfidence, 0.08f));
+    const ReceiveAudioDelayEstimate envelopeScan =
+        estimateByNormalizedScan(flexEnvelope.samples, kiwiEnvelope.samples,
+                                 flexEnvelope.sampleRateHz,
+                                 m_config.maxOffsetMs,
+                                 m_config.minOverlapMs,
+                                 std::min(m_config.minPeakCorrelation, 0.12f),
+                                 std::min(m_config.minConfidence, 0.08f));
+    ReceiveAudioDelayEstimate envelope = envelopePhat;
+    if (envelopeScan.valid) {
+        if (!envelope.valid) {
+            envelope = envelopeScan;
+        } else if (std::abs(envelopeScan.offsetMs - envelope.offsetMs)
+                   <= kEnvelopeWaveformAgreementMs) {
+            envelope.confidence =
+                std::max(envelope.confidence, envelopeScan.confidence);
+            envelope.peakCorrelation =
+                std::max(envelope.peakCorrelation,
+                         envelopeScan.peakCorrelation);
+        } else if (envelopeScan.confidence
+                   >= envelope.confidence * kEnvelopeOverrideConfidenceRatio) {
+            envelope = envelopeScan;
+        }
+    }
+
+    if (envelope.valid && !waveform.valid) {
+        return envelope;
+    }
+    if (envelope.valid && waveform.valid) {
+        const bool estimatesAgree =
+            std::abs(envelope.offsetMs - waveform.offsetMs)
+            <= kEnvelopeWaveformAgreementMs;
+        if (estimatesAgree) {
+            return waveform;
+        }
+        if (envelope.confidence
+            >= waveform.confidence * kEnvelopeOverrideConfidenceRatio) {
+            return envelope;
+        }
+    }
+    return waveform;
+}
+
+} // namespace AetherSDR

--- a/src/core/ReceivePresentationSync.h
+++ b/src/core/ReceivePresentationSync.h
@@ -1,0 +1,263 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <optional>
+#include <vector>
+
+namespace AetherSDR {
+
+enum class ReceivePresentationSource {
+    Flex,
+    KiwiSdr,
+};
+
+enum class ReceivePresentationSurface {
+    Audio,
+    Waterfall,
+    Spectrum,
+    Meter,
+    Analyzer,
+    Decoder,
+    Recording,
+};
+
+enum class ReceiveSyncMode {
+    Manual,
+    AutoAssist,
+};
+
+enum class ReceiveSyncReference {
+    Auto,
+    Flex,
+    KiwiSdr,
+};
+
+enum class ReceiveSyncStatus {
+    Off,
+    Manual,
+    Searching,
+    Holding,
+    Locked,
+    LowConfidence,
+};
+
+struct ReceiveSyncEstimate {
+    int offsetMs{0};          // Positive values delay Flex relative to KiwiSDR.
+    float confidence{0.0f};   // 0.0-1.0, estimator-specific.
+    bool valid{false};
+    int driftPpm{0};
+    bool held{false};
+};
+
+struct ReceivePresentationSettings {
+    bool enabled{false};
+    ReceiveSyncMode mode{ReceiveSyncMode::Manual};
+    ReceiveSyncReference reference{ReceiveSyncReference::Auto};
+    int baseLatencyMs{360};
+    int manualOffsetMs{0};    // Positive values delay Flex relative to KiwiSDR.
+    int maxOffsetMs{3000};
+    float autoLockConfidence{0.35f};
+    ReceiveSyncEstimate autoEstimate;
+};
+
+struct ReceiveDelayBreakdown {
+    int flexDelayMs{0};
+    int kiwiDelayMs{0};
+    int effectiveOffsetMs{0};
+    ReceiveSyncStatus status{ReceiveSyncStatus::Off};
+};
+
+QString receivePresentationVisualQueueKey(ReceivePresentationSource source,
+                                          ReceivePresentationSurface surface,
+                                          const QString& sourceId = QString());
+int receivePresentationExternalKiwiDelayMs(
+    const QString& sourceId,
+    const QString& delaySourceId,
+    int kiwiDelayMs);
+bool receivePresentationShouldPrebufferAfterDelayChange(int previousDelayMs,
+                                                        int nextDelayMs,
+                                                        bool sourceAudible,
+                                                        bool hasQueuedAudio);
+
+struct ReceiveSyncAudioPairEndpoint {
+    int sliceId{-1};
+    qint64 frequencyHz{0};
+    QString kiwiProfileId;
+};
+
+struct ReceiveSyncAudioPairSelection {
+    enum class State {
+        None,
+        Usable,
+        Ambiguous,
+    };
+
+    State state{State::None};
+    QString kiwiProfileId;
+    int flexSliceId{-1};
+    int kiwiSliceId{-1};
+    qint64 frequencyHz{0};
+    int audibleFlexCount{0};
+    int audibleKiwiCount{0};
+    int matchingPairCount{0};
+    QString reason;
+
+    bool usable() const { return state == State::Usable; }
+    bool ambiguous() const { return state == State::Ambiguous; }
+};
+
+ReceiveSyncAudioPairSelection selectReceiveSyncAudioPair(
+    const QVector<ReceiveSyncAudioPairEndpoint>& flexCandidates,
+    const QVector<ReceiveSyncAudioPairEndpoint>& kiwiCandidates,
+    qint64 frequencyToleranceHz);
+
+class ReceivePresentationSync {
+public:
+    static constexpr int kMinBaseLatencyMs = 0;
+    static constexpr int kMaxBaseLatencyMs = 5000;
+    static constexpr int kMinOffsetMs = -5000;
+    static constexpr int kMaxOffsetMs = 5000;
+
+    ReceivePresentationSettings settings() const { return m_settings; }
+    void setSettings(const ReceivePresentationSettings& settings);
+
+    void setEnabled(bool enabled);
+    void setMode(ReceiveSyncMode mode);
+    void setManualOffsetMs(int offsetMs);
+    void setBaseLatencyMs(int latencyMs);
+    void setMaxOffsetMs(int maxOffsetMs);
+    void setAutoEstimate(const ReceiveSyncEstimate& estimate);
+    void clearAutoEstimate();
+
+    ReceiveDelayBreakdown delayBreakdown() const;
+    int delayMs(ReceivePresentationSource source,
+                ReceivePresentationSurface surface) const;
+    qint64 dueTimeMs(ReceivePresentationSource source,
+                     ReceivePresentationSurface surface,
+                     qint64 arrivalMs) const;
+    ReceiveSyncStatus status() const { return delayBreakdown().status; }
+    static int adjustedAutoOffsetMs(int currentOffsetMs,
+                                    int candidateOffsetMs,
+                                    bool reset);
+
+private:
+    static int clampedOffset(int offsetMs, int maxAbsMs);
+    int effectiveOffsetMs() const;
+
+    ReceivePresentationSettings m_settings;
+};
+
+struct ReceiveAudioDelayEstimate {
+    int offsetMs{0};             // Positive values delay Flex relative to KiwiSDR.
+    float confidence{0.0f};
+    float peakCorrelation{0.0f}; // Absolute normalized correlation at the GCC-PHAT peak.
+    bool valid{false};
+};
+
+class ReceiveAudioDelayEstimator {
+public:
+    struct Config {
+        int sampleRateHz{12000};
+        int maxOffsetMs{3000};
+        int minOverlapMs{750};
+        float minPeakCorrelation{0.20f};
+        float minConfidence{0.18f};
+    };
+
+    ReceiveAudioDelayEstimator();
+    explicit ReceiveAudioDelayEstimator(Config config);
+
+    Config config() const { return m_config; }
+    void setConfig(const Config& config);
+
+    ReceiveAudioDelayEstimate estimate(const QVector<float>& flexMono,
+                                       const QVector<float>& kiwiMono) const;
+
+private:
+    static void fft(std::vector<std::complex<double>>& data, bool inverse);
+
+    Config m_config;
+};
+
+template <typename Payload>
+struct ReceivePresentationQueuedItem {
+    ReceivePresentationSource source{ReceivePresentationSource::Flex};
+    ReceivePresentationSurface surface{ReceivePresentationSurface::Audio};
+    QString sourceId;
+    qint64 arrivalMs{0};
+    qint64 dueMs{0};
+    quint64 sequence{0};
+    Payload payload;
+};
+
+template <typename Payload>
+class ReceivePresentationQueue {
+public:
+    using Item = ReceivePresentationQueuedItem<Payload>;
+
+    void enqueue(Item item)
+    {
+        const auto insertAt = std::upper_bound(
+            m_items.begin(), m_items.end(), item,
+            [](const Item& incoming, const Item& existing) {
+                if (incoming.dueMs != existing.dueMs) {
+                    return incoming.dueMs < existing.dueMs;
+                }
+                return incoming.sequence < existing.sequence;
+            });
+        m_items.insert(insertAt, std::move(item));
+    }
+
+    QVector<Item> releaseDue(
+        qint64 nowMs,
+        qsizetype maxItems = std::numeric_limits<qsizetype>::max())
+    {
+        QVector<Item> released;
+        while (!m_items.isEmpty() && m_items.constFirst().dueMs <= nowMs
+               && released.size() < maxItems) {
+            released.append(std::move(m_items.first()));
+            m_items.removeFirst();
+        }
+        return released;
+    }
+
+    void clear() { m_items.clear(); }
+    bool isEmpty() const { return m_items.isEmpty(); }
+    qsizetype size() const { return m_items.size(); }
+    template <typename Predicate>
+    qsizetype removeIf(Predicate predicate)
+    {
+        const qsizetype before = m_items.size();
+        const auto firstRemoved =
+            std::remove_if(m_items.begin(), m_items.end(), predicate);
+        m_items.erase(firstRemoved, m_items.end());
+        return before - m_items.size();
+    }
+
+    void trimToSize(qsizetype maxItems)
+    {
+        maxItems = std::max<qsizetype>(0, maxItems);
+        while (m_items.size() > maxItems) {
+            m_items.removeFirst();
+        }
+    }
+
+    std::optional<qint64> nextDueMs() const
+    {
+        if (m_items.isEmpty()) {
+            return std::nullopt;
+        }
+        return m_items.constFirst().dueMs;
+    }
+
+private:
+    QVector<Item> m_items;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -973,6 +973,7 @@ MainWindow::MainWindow(QWidget* parent)
     if (m_leanMode) {
         QTimer::singleShot(0, this, [this]() { applyLeanMode(true); });
     }
+    initReceivePresentationSync();
 
     m_audioThread->setObjectName("AudioEngine");
     m_audio = new AudioEngine;  // no parent — will be moved to thread
@@ -984,6 +985,7 @@ MainWindow::MainWindow(QWidget* parent)
         AppSettings::instance().value("AudioBufferMs", "200").toInt());
     m_audio->moveToThread(m_audioThread);
     m_audioThread->start();
+    syncReceivePresentationDelaysToAudioEngine();
     setupAudioDeviceChangeMonitor();
 
     // QSO audio recorder (#1297) — lives on main thread, audio feeds are thread-safe
@@ -1251,6 +1253,14 @@ MainWindow::MainWindow(QWidget* parent)
     // audioDataReady(); we feed that directly to the QAudioSink.
     connect(m_radioModel.panStream(), &PanadapterStream::audioDataReady,
             m_audio, &AudioEngine::feedAudioData);
+    connect(m_audio, &AudioEngine::receivePresentationOutputAudioReady,
+            this, [this](const QString& source, const QString& sourceId,
+                         const QByteArray& pcm, int sampleRate) {
+        const ReceivePresentationSource syncSource =
+            source == QLatin1String("kiwi") ? ReceivePresentationSource::KiwiSdr
+                                            : ReceivePresentationSource::Flex;
+        feedReceivePresentationSyncAudio(syncSource, pcm, sourceId, sampleRate);
+    });
 
     // KiwiSDR is a receive-only alternate source for the active slice.
     // Wiring is local-only: no Flex radio commands are sent from this path.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -15,6 +15,7 @@
 #include "core/CommandParser.h"   // MessageSeverity for onRadioMessage slot
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
+#include "core/ReceivePresentationSync.h"
 #include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/TciServer.h"
@@ -73,8 +74,10 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QEvent>
 #include <atomic>
+#include <functional>
 
 class QAbstractSlider;
 class QMediaDevices;
@@ -185,6 +188,8 @@ public:
     AudioEngine* audioEngine() const { return m_audio; }
     Q_INVOKABLE void showConnectionDialog();
     Q_INVOKABLE void hideConnectionDialog();
+    QJsonObject automationSetSliceReceiveSource(const QString& arg);
+    QJsonObject automationReceiveSyncSnapshot() const;
 
 protected:
     void showEvent(QShowEvent* event) override;
@@ -348,6 +353,67 @@ private:
     bool autoSquelchShouldRunOnSpectrum(const QString& panId,
                                         const SpectrumWidget* spectrum) const;
     void syncActiveSliceAutoSquelchToSpectrums();
+    void initReceivePresentationSync(); // MainWindow_ReceiveSync.cpp
+    void syncReceivePresentationDelaysToAudioEngine(
+        bool clearVisualQueueOnAbruptDelayChange = true);
+    ReceivePresentationSettings receivePresentationSettings() const;
+    ReceiveDelayBreakdown receivePresentationDelayBreakdown() const;
+    QString receivePresentationOverlayStatsText() const;
+    void setReceivePresentationSyncEnabled(bool enabled);
+    void setReceivePresentationSyncMode(ReceiveSyncMode mode);
+    void adjustReceivePresentationManualOffsetMs(int deltaMs);
+    void resetReceivePresentationManualOffset();
+    void setReceivePresentationLatencyMs(int latencyMs);
+    int receivePresentationDelayMs(
+        ReceivePresentationSource source,
+        ReceivePresentationSurface surface,
+        const QString& sourceId = QString()) const;
+    void deferReceivePresentation(ReceivePresentationSource source,
+                                  ReceivePresentationSurface surface,
+                                  std::function<void()> apply,
+                                  const QString& sourceId = QString());
+    bool receivePresentationHasUsableSyncTarget() const;
+    void resetReceivePresentationAudioBuffers();
+    void resetReceivePresentationAudioBuffersForKiwiSource(
+        const QString& sourceId);
+    void clearReceivePresentationVisualQueue();
+    void clearReceivePresentationVisualQueueForSource(
+        ReceivePresentationSource source,
+        const QString& sourceId = QString());
+    void scheduleReceivePresentationVisualQueue();
+    void drainReceivePresentationVisualQueue();
+    struct ReceiveSyncTarget {
+        enum class State {
+            None,
+            Usable,
+            Ambiguous,
+        };
+        State state{State::None};
+        QString kiwiProfileId;
+        int flexSliceId{-1};
+        int kiwiSliceId{-1};
+        qint64 frequencyHz{0};
+        int audibleFlexCount{0};
+        int audibleKiwiCount{0};
+        int matchingPairCount{0};
+        QString reason;
+
+        bool usable() const { return state == State::Usable; }
+        bool ambiguous() const { return state == State::Ambiguous; }
+    };
+    ReceiveSyncTarget resolveReceiveSyncTarget() const;
+    QString receiveSyncKiwiProfileId() const;
+    QString receiveSyncDelayKiwiProfileId() const;
+    qint64 receiveSyncTunedFrequencyHz() const;
+    void holdReceivePresentationAutoAssistLock(bool clearVisualQueue = true);
+    void resetReceivePresentationAutoAssistState(bool clearEstimate,
+                                                 bool clearVisualQueue = true);
+    void feedReceivePresentationSyncAudio(ReceivePresentationSource source,
+                                          const QByteArray& pcm24kStereoFloat,
+                                          const QString& sourceId = QString(),
+                                          int sampleRateHz =
+                                              AudioEngine::DEFAULT_SAMPLE_RATE);
+    void runReceivePresentationAutoAssist();
     SliceModel* kiwiSdrDisplaySliceForPan(const QString& panId) const;
     QString kiwiSdrProfileForPan(const QString& panId) const;
     QString kiwiSdrOverlayProfileForPan(const QString& panId) const;
@@ -811,6 +877,30 @@ private:
     bool             m_kiwiSdrAudioTransmitMuted{false};
     QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
     QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
+    ReceivePresentationSync m_receivePresentationSync;
+    ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
+    ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;
+    QHash<QString, qint64> m_receivePresentationVisualLastDueMs;
+    QTimer* m_receivePresentationVisualTimer{nullptr};
+    quint64 m_receivePresentationVisualSequence{0};
+    int m_receivePresentationLastFlexAudioDelayMs{-1};
+    int m_receivePresentationLastKiwiAudioDelayMs{-1};
+    QVector<float> m_receiveSyncFlexAudio;
+    QVector<float> m_receiveSyncKiwiAudio;
+    QString m_receiveSyncKiwiProfileId;
+    QElapsedTimer m_receiveSyncEstimateTimer;
+    QElapsedTimer m_receiveSyncDriftTimer;
+    int m_receiveSyncLastEstimateOffsetMs{0};
+    int m_receiveSyncStableEstimateCount{0};
+    ReceiveAudioDelayEstimate m_receiveSyncLastCandidate;
+    int m_receiveSyncLastCandidateAbsoluteOffsetMs{0};
+    bool m_receiveSyncLastCandidateAvailable{false};
+    bool m_receiveSyncLastAcceptedLock{false};
+    bool m_receiveSyncLastNearAppliedLock{false};
+    bool m_receiveSyncLastFarRelockEligible{false};
+    qint64 m_receiveSyncLastFrequencyHz{0};
+    bool m_receiveSyncHaveLastEstimate{false};
+    bool m_receiveSyncTargetUnavailable{false};
 
     // Modeless dialogs
     QPointer<DxClusterDialog> m_spotHubDialog;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -414,6 +414,8 @@ private:
                                           int sampleRateHz =
                                               AudioEngine::DEFAULT_SAMPLE_RATE);
     void runReceivePresentationAutoAssist();
+    void applyReceivePresentationAutoAssistEstimate(
+        const ReceiveAudioDelayEstimate& estimate);
     SliceModel* kiwiSdrDisplaySliceForPan(const QString& panId) const;
     QString kiwiSdrProfileForPan(const QString& panId) const;
     QString kiwiSdrOverlayProfileForPan(const QString& panId) const;
@@ -890,6 +892,8 @@ private:
     QString m_receiveSyncKiwiProfileId;
     QElapsedTimer m_receiveSyncEstimateTimer;
     QElapsedTimer m_receiveSyncDriftTimer;
+    quint64 m_receiveSyncEstimateGeneration{0};
+    bool m_receiveSyncEstimateInFlight{false};
     int m_receiveSyncLastEstimateOffsetMs{0};
     int m_receiveSyncStableEstimateCount{0};
     ReceiveAudioDelayEstimate m_receiveSyncLastCandidate;

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -19,6 +19,8 @@
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
 
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QMetaObject>
 #include <QSet>
 #include <QTimer>
@@ -28,7 +30,6 @@
 namespace AetherSDR {
 namespace {
 
-constexpr int kKiwiSdrMeterDisplayDelayMs = 520;
 constexpr double kKiwiSdrWaterfallFullBandwidthMhz = 30.0;
 
 const SliceModel* kiwiSliceForPan(const RadioModel& radioModel,
@@ -279,6 +280,108 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
     if (!panId.isEmpty()) {
         syncKiwiSdrPanadapterUiState(panId);
     }
+}
+
+QJsonObject MainWindow::automationSetSliceReceiveSource(const QString& arg)
+{
+    auto error = [](const QString& message) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), message},
+        };
+    };
+
+    if (!m_kiwiSdrManager) {
+        return error(QStringLiteral("KiwiSDR manager is unavailable"));
+    }
+
+    QStringList parts = arg.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (parts.isEmpty()) {
+        return error(QStringLiteral(
+            "slice rxsource requires '<slice-id|active> <profile-name|profile-id|flex>'"));
+    }
+
+    int sliceId = -1;
+    bool okId = false;
+    const int parsedSliceId = parts.first().toInt(&okId);
+    if (okId) {
+        sliceId = parsedSliceId;
+        parts.removeFirst();
+    } else if (parts.first().compare(QStringLiteral("active"),
+                                     Qt::CaseInsensitive) == 0) {
+        sliceId = m_activeSliceId;
+        parts.removeFirst();
+    } else {
+        sliceId = m_activeSliceId;
+    }
+
+    SliceModel* slice = m_radioModel.slice(sliceId);
+    if (!slice || !m_radioModel.sliceMayBelongToUs(sliceId)) {
+        return error(QStringLiteral("no controllable slice for rxsource"));
+    }
+    if (parts.isEmpty()) {
+        return error(QStringLiteral("slice rxsource requires a receive source"));
+    }
+
+    const QString selector = parts.join(QLatin1Char(' ')).trimmed();
+    const QString lower = selector.toLower();
+    if (lower == QLatin1String("flex") || lower == QLatin1String("none")
+        || lower == QLatin1String("clear")) {
+        clearKiwiSdrVirtualAntennaForSlice(sliceId);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("slice"), QStringLiteral("rxsource")},
+            {QStringLiteral("id"), sliceId},
+            {QStringLiteral("source"), QStringLiteral("flex")},
+            {QStringLiteral("requested"), true},
+        };
+    }
+
+    QString profileId =
+        m_kiwiSdrManager->profileIdForVirtualAntennaToken(selector);
+    if (profileId.isEmpty()) {
+        for (const KiwiSdrAntennaProfile& profile :
+             m_kiwiSdrManager->profiles()) {
+            if (profile.id.compare(selector, Qt::CaseInsensitive) == 0
+                || profile.name.compare(selector, Qt::CaseInsensitive) == 0
+                || m_kiwiSdrManager->displayName(profile.id)
+                       .compare(selector, Qt::CaseInsensitive) == 0
+                || profile.endpoint.compare(selector, Qt::CaseInsensitive) == 0) {
+                profileId = profile.id;
+                break;
+            }
+        }
+    }
+
+    if (profileId.isEmpty()) {
+        QJsonArray profiles;
+        for (const KiwiSdrAntennaProfile& profile :
+             m_kiwiSdrManager->profiles()) {
+            profiles.append(QJsonObject{
+                {QStringLiteral("id"), profile.id},
+                {QStringLiteral("name"), m_kiwiSdrManager->displayName(profile.id)},
+                {QStringLiteral("endpoint"), profile.endpoint},
+            });
+        }
+        QJsonObject response = error(
+            QStringLiteral("unknown KiwiSDR receive source '") + selector
+            + QStringLiteral("'"));
+        response.insert(QStringLiteral("profiles"), profiles);
+        return response;
+    }
+
+    setKiwiSdrVirtualAntennaForSlice(sliceId, profileId);
+    const KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(profileId);
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("slice"), QStringLiteral("rxsource")},
+        {QStringLiteral("id"), sliceId},
+        {QStringLiteral("source"), QStringLiteral("kiwi")},
+        {QStringLiteral("profileId"), profileId},
+        {QStringLiteral("profileName"), m_kiwiSdrManager->displayName(profileId)},
+        {QStringLiteral("endpoint"), profile.endpoint},
+        {QStringLiteral("requested"), true},
+    };
 }
 
 SliceModel* MainWindow::flexRxPanSourceSlice() const
@@ -939,11 +1042,30 @@ void MainWindow::wireKiwiSdr()
                 return;
             }
 
-            if (SpectrumWidget* sw = spectrumForSlice(slice)) {
-                sw->setKiwiSdrWaterfallProfile(profileId);
-                sw->updateKiwiSdrWaterfallRow(binsDbm, lowFreqMhz,
-                                              highFreqMhz, timecode);
-            }
+            deferReceivePresentation(
+                ReceivePresentationSource::KiwiSdr,
+                ReceivePresentationSurface::Waterfall,
+                [this, profileId, sliceId, binsDbm, lowFreqMhz, highFreqMhz,
+                 timecode]() {
+                    if (!m_kiwiSdrManager
+                        || m_kiwiSdrManager->assignedProfileForSlice(sliceId)
+                            != profileId) {
+                        return;
+                    }
+                    SliceModel* delayedSlice = m_radioModel.slice(sliceId);
+                    if (!delayedSlice
+                        || !m_radioModel.sliceMayBelongToUs(sliceId)
+                        || kiwiSdrProfileForPan(delayedSlice->panId())
+                            != profileId) {
+                        return;
+                    }
+                    if (SpectrumWidget* sw = spectrumForSlice(delayedSlice)) {
+                        sw->setKiwiSdrWaterfallProfile(profileId);
+                        sw->updateKiwiSdrWaterfallRow(binsDbm, lowFreqMhz,
+                                                      highFreqMhz, timecode);
+                    }
+                },
+                profileId);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::meterReadingReady,
                 this, [this](const QString& profileId,
@@ -992,14 +1114,13 @@ void MainWindow::wireKiwiSdr()
                 return;
             }
 
-            // Kiwi audio intentionally prebuffers before mixing to avoid
-            // WebSocket jitter. Delay visual meter samples by the same target
-            // so the S-meter follows the audio the operator is hearing.
-            QTimer::singleShot(
-                kKiwiSdrMeterDisplayDelayMs, this,
+            deferReceivePresentation(
+                ReceivePresentationSource::KiwiSdr,
+                ReceivePresentationSurface::Meter,
                 [profileId, reading, applyMeterReading]() {
                     applyMeterReading(profileId, reading, true);
-                });
+                },
+                profileId);
         });
         connect(m_kiwiSdrManager, &KiwiSdrManager::sliceAssignmentChanged,
                 this, [this](int sliceId, const QString& profileId) {
@@ -1010,6 +1131,40 @@ void MainWindow::wireKiwiSdr()
                                   | KiwiSdrUiSyncDiversityEsc);
             if (m_appletPanel) {
                 m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
+            }
+            const ReceivePresentationSettings syncSettings =
+                m_receivePresentationSync.settings();
+            if (syncSettings.enabled
+                && syncSettings.mode == ReceiveSyncMode::AutoAssist) {
+                const QString previousSyncProfile = m_receiveSyncKiwiProfileId;
+                const QString currentSyncProfile = receiveSyncKiwiProfileId();
+                if (previousSyncProfile != currentSyncProfile) {
+                    if (currentSyncProfile.isEmpty()
+                        && !previousSyncProfile.isEmpty()) {
+                        if (!m_receiveSyncTargetUnavailable) {
+                            holdReceivePresentationAutoAssistLock(false);
+                            clearReceivePresentationVisualQueueForSource(
+                                ReceivePresentationSource::KiwiSdr,
+                                previousSyncProfile);
+                            resetReceivePresentationAudioBuffersForKiwiSource(
+                                previousSyncProfile);
+                            m_receiveSyncTargetUnavailable = true;
+                            syncReceivePresentationDelaysToAudioEngine();
+                        }
+                    } else {
+                        resetReceivePresentationAutoAssistState(true, false);
+                        if (!previousSyncProfile.isEmpty()) {
+                            clearReceivePresentationVisualQueueForSource(
+                                ReceivePresentationSource::KiwiSdr,
+                                previousSyncProfile);
+                            resetReceivePresentationAudioBuffersForKiwiSource(
+                                previousSyncProfile);
+                        }
+                        m_receiveSyncKiwiProfileId = currentSyncProfile;
+                        m_receiveSyncTargetUnavailable = false;
+                        syncReceivePresentationDelaysToAudioEngine();
+                    }
+                }
             }
             if (!profileId.isEmpty()) {
                 syncKiwiSdrPanadapterUiState(panId);
@@ -1057,6 +1212,37 @@ void MainWindow::wireKiwiSdr()
                 if (SliceModel* slice = m_radioModel.slice(sliceId)) {
                     panId = slice->panId();
                 }
+            }
+            const ReceivePresentationSettings syncSettings =
+                m_receivePresentationSync.settings();
+            if (syncSettings.enabled
+                && syncSettings.mode == ReceiveSyncMode::AutoAssist) {
+                const QString previousSyncProfile = m_receiveSyncKiwiProfileId;
+                const QString currentSyncProfile = receiveSyncKiwiProfileId();
+                if (previousSyncProfile != currentSyncProfile) {
+                    if (currentSyncProfile.isEmpty()
+                        && !previousSyncProfile.isEmpty()) {
+                        holdReceivePresentationAutoAssistLock(false);
+                        clearReceivePresentationVisualQueueForSource(
+                            ReceivePresentationSource::KiwiSdr,
+                            previousSyncProfile);
+                        resetReceivePresentationAudioBuffersForKiwiSource(
+                            previousSyncProfile);
+                        m_receiveSyncTargetUnavailable = true;
+                    } else {
+                        resetReceivePresentationAutoAssistState(true, false);
+                        if (!previousSyncProfile.isEmpty()) {
+                            clearReceivePresentationVisualQueueForSource(
+                                ReceivePresentationSource::KiwiSdr,
+                                previousSyncProfile);
+                            resetReceivePresentationAudioBuffersForKiwiSource(
+                                previousSyncProfile);
+                        }
+                        m_receiveSyncKiwiProfileId = currentSyncProfile;
+                        m_receiveSyncTargetUnavailable = false;
+                    }
+                }
+                syncReceivePresentationDelaysToAudioEngine();
             }
             scheduleKiwiSdrUiSync(KiwiSdrUiSyncWaterfallAvailability
                                   | KiwiSdrUiSyncDiversityEsc

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -59,6 +59,8 @@
 #include <QVBoxLayout>
 #include <QWidgetAction>
 
+#include <cmath>
+
 namespace AetherSDR {
 
 void MainWindow::buildMenuBar()
@@ -114,6 +116,163 @@ void MainWindow::buildMenuBar()
     auto* networkAction = settingsMenu->addAction("Network...");
     connect(networkAction, &QAction::triggered, this, [this] {
         showNetworkDiagnosticsDialog();
+    });
+
+    auto* receiveSyncMenu = settingsMenu->addMenu("Receive Sync");
+    auto* receiveSyncEnabledAct =
+        receiveSyncMenu->addAction("Sync Kiwi Audio && Display");
+    receiveSyncEnabledAct->setCheckable(true);
+    receiveSyncEnabledAct->setChecked(receivePresentationSettings().enabled);
+
+    auto* receiveSyncModeGroup = new QActionGroup(receiveSyncMenu);
+    receiveSyncModeGroup->setExclusive(true);
+    auto* receiveSyncManualAct = receiveSyncMenu->addAction("Manual Offset");
+    receiveSyncManualAct->setCheckable(true);
+    receiveSyncModeGroup->addAction(receiveSyncManualAct);
+    auto* receiveSyncAutoAct = receiveSyncMenu->addAction("Auto Assist");
+    receiveSyncAutoAct->setCheckable(true);
+    receiveSyncModeGroup->addAction(receiveSyncAutoAct);
+    receiveSyncMenu->addSeparator();
+
+    auto* receiveSyncOffsetLabel = receiveSyncMenu->addAction(QString());
+    receiveSyncOffsetLabel->setEnabled(false);
+    auto* receiveSyncOffsetMinus =
+        receiveSyncMenu->addAction("Delay KiwiSDR 50 ms");
+    auto* receiveSyncOffsetPlus =
+        receiveSyncMenu->addAction("Delay Flex 50 ms");
+    auto* receiveSyncOffsetReset = receiveSyncMenu->addAction("Reset Offset");
+    receiveSyncMenu->addSeparator();
+
+    auto* receiveSyncLatencyMenu = receiveSyncMenu->addMenu("Latency");
+    auto* receiveSyncLatencyGroup = new QActionGroup(receiveSyncLatencyMenu);
+    receiveSyncLatencyGroup->setExclusive(true);
+    auto* receiveSyncLatencyNormal =
+        receiveSyncLatencyMenu->addAction("Normal (360 ms)");
+    receiveSyncLatencyNormal->setCheckable(true);
+    receiveSyncLatencyGroup->addAction(receiveSyncLatencyNormal);
+    auto* receiveSyncLatencyStable =
+        receiveSyncLatencyMenu->addAction("More Stable (520 ms)");
+    receiveSyncLatencyStable->setCheckable(true);
+    receiveSyncLatencyGroup->addAction(receiveSyncLatencyStable);
+    auto* receiveSyncLatencyHigh =
+        receiveSyncLatencyMenu->addAction("High Jitter (1000 ms)");
+    receiveSyncLatencyHigh->setCheckable(true);
+    receiveSyncLatencyGroup->addAction(receiveSyncLatencyHigh);
+    receiveSyncMenu->addSeparator();
+    auto* receiveSyncStatusLabel = receiveSyncMenu->addAction(QString());
+    receiveSyncStatusLabel->setEnabled(false);
+
+    auto refreshReceiveSyncMenu = [this, receiveSyncEnabledAct,
+                                   receiveSyncManualAct, receiveSyncAutoAct,
+                                   receiveSyncOffsetLabel,
+                                   receiveSyncLatencyNormal,
+                                   receiveSyncLatencyStable,
+                                   receiveSyncLatencyHigh,
+                                   receiveSyncStatusLabel]() {
+        const ReceivePresentationSettings settings =
+            receivePresentationSettings();
+        const ReceiveDelayBreakdown delays =
+            receivePresentationDelayBreakdown();
+        receiveSyncEnabledAct->setChecked(settings.enabled);
+        receiveSyncManualAct->setChecked(settings.mode == ReceiveSyncMode::Manual);
+        receiveSyncAutoAct->setChecked(settings.mode == ReceiveSyncMode::AutoAssist);
+        receiveSyncOffsetLabel->setText(
+            QStringLiteral("Offset: %1%2 ms")
+                .arg(settings.manualOffsetMs >= 0 ? QStringLiteral("+")
+                                                  : QString())
+                .arg(settings.manualOffsetMs));
+        receiveSyncLatencyNormal->setChecked(settings.baseLatencyMs == 360);
+        receiveSyncLatencyStable->setChecked(settings.baseLatencyMs == 520);
+        receiveSyncLatencyHigh->setChecked(settings.baseLatencyMs == 1000);
+        QString status = QStringLiteral("Off");
+        switch (delays.status) {
+        case ReceiveSyncStatus::Off:
+            status = QStringLiteral("Off");
+            break;
+        case ReceiveSyncStatus::Manual:
+            status = QStringLiteral("Manual");
+            break;
+        case ReceiveSyncStatus::Searching:
+            status = QStringLiteral("Searching");
+            break;
+        case ReceiveSyncStatus::Holding:
+            status = QStringLiteral("Coasting");
+            break;
+        case ReceiveSyncStatus::Locked:
+            status = QStringLiteral("Locked");
+            break;
+        case ReceiveSyncStatus::LowConfidence:
+            status = QStringLiteral("Low confidence");
+            break;
+        }
+        QString statusText =
+            QStringLiteral("Status: %1, Flex %2 ms, KiwiSDR %3 ms")
+                .arg(status)
+                .arg(delays.flexDelayMs)
+                .arg(delays.kiwiDelayMs);
+        if (settings.mode == ReceiveSyncMode::AutoAssist
+            && settings.autoEstimate.valid) {
+            statusText += QStringLiteral(", est %1%2 ms, conf %3%, drift %4%5 ppm")
+                              .arg(settings.autoEstimate.offsetMs >= 0
+                                       ? QStringLiteral("+")
+                                       : QString())
+                              .arg(settings.autoEstimate.offsetMs)
+                              .arg(static_cast<int>(std::lround(
+                                  settings.autoEstimate.confidence * 100.0f)))
+                              .arg(settings.autoEstimate.driftPpm >= 0
+                                       ? QStringLiteral("+")
+                                       : QString())
+                              .arg(settings.autoEstimate.driftPpm);
+        }
+        receiveSyncStatusLabel->setText(statusText);
+    };
+    refreshReceiveSyncMenu();
+    connect(receiveSyncMenu, &QMenu::aboutToShow, this, refreshReceiveSyncMenu);
+
+    connect(receiveSyncEnabledAct, &QAction::toggled, this,
+            [this, refreshReceiveSyncMenu](bool enabled) {
+        setReceivePresentationSyncEnabled(enabled);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncManualAct, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        setReceivePresentationSyncMode(ReceiveSyncMode::Manual);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncAutoAct, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        setReceivePresentationSyncMode(ReceiveSyncMode::AutoAssist);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncOffsetMinus, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        adjustReceivePresentationManualOffsetMs(-50);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncOffsetPlus, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        adjustReceivePresentationManualOffsetMs(50);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncOffsetReset, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        resetReceivePresentationManualOffset();
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncLatencyNormal, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        setReceivePresentationLatencyMs(360);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncLatencyStable, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        setReceivePresentationLatencyMs(520);
+        refreshReceiveSyncMenu();
+    });
+    connect(receiveSyncLatencyHigh, &QAction::triggered, this,
+            [this, refreshReceiveSyncMenu]() {
+        setReceivePresentationLatencyMs(1000);
+        refreshReceiveSyncMenu();
     });
 #ifdef HAVE_MQTT
     auto* mqttAction = settingsMenu->addAction("MQTT...");

--- a/src/gui/MainWindow_ReceiveSync.cpp
+++ b/src/gui/MainWindow_ReceiveSync.cpp
@@ -1,0 +1,1263 @@
+#include "MainWindow.h"
+
+#include "core/AudioEngine.h"
+#include "core/AppSettings.h"
+#include "core/KiwiSdrManager.h"
+#include "models/SliceModel.h"
+
+#include <QDateTime>
+#include <QJsonDocument>
+#include <QMetaObject>
+#include <QJsonObject>
+#include <QSet>
+#include <QStringList>
+#include <QTimer>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace AetherSDR {
+namespace {
+
+constexpr int kDefaultReceivePresentationLatencyMs = 520;
+constexpr int kDefaultReceivePresentationMaxOffsetMs = 3000;
+constexpr int kReceiveSyncAnalysisRateHz = 12000;
+constexpr int kReceiveSyncAnalysisWindowMs = 5000;
+constexpr int kReceiveSyncEstimateIntervalMs = 1000;
+constexpr int kReceiveSyncStableToleranceMs = 120;
+constexpr int kReceiveSyncAppliedSettledToleranceMs = 25;
+constexpr int kReceiveSyncCorrectionDeadbandMs = 35;
+constexpr int kReceiveSyncFarRelockResidualMs = 250;
+constexpr int kReceiveSyncStableLockCount = 3;
+constexpr int kReceiveSyncWeakStableLockCount = 6;
+constexpr int kReceiveSyncFarRelockCount = 6;
+constexpr qint64 kReceiveSyncFrequencyToleranceHz = 50;
+constexpr float kReceiveSyncStableLockMinConfidence = 0.18f;
+constexpr float kReceiveSyncStableLockMinPeakCorrelation = 0.20f;
+constexpr float kReceiveSyncWeakStableLockMinConfidence = 0.06f;
+constexpr float kReceiveSyncWeakStableLockMinPeakCorrelation = 0.28f;
+constexpr float kReceiveSyncImmediateLockMinConfidence = 0.55f;
+constexpr float kReceiveSyncImmediateLockMinPeakCorrelation = 0.35f;
+constexpr int kReceivePresentationAudioDrainGuardMs = 10;
+constexpr int kReceivePresentationMaxPlaybackCompensationMs = 1000;
+constexpr int kKiwiSdrMeterSndBlockCompensationMs = 45;
+constexpr int kReceivePresentationAbruptDelayChangeMs = 250;
+constexpr qsizetype kReceivePresentationVisualQueueMaxItems = 600;
+constexpr qsizetype kReceivePresentationVisualMaxReleaseBatch = 24;
+constexpr const char* kReceivePresentationSyncSettingsKey =
+    "ReceivePresentationSync";
+constexpr const char* kLegacyReceivePresentationSyncEnabledKey =
+    "ReceivePresentationSyncEnabled";
+constexpr const char* kLegacyReceivePresentationSyncModeKey =
+    "ReceivePresentationSyncMode";
+constexpr const char* kLegacyReceivePresentationSyncOffsetMsKey =
+    "ReceivePresentationSyncOffsetMs";
+constexpr const char* kLegacyReceivePresentationSyncLatencyMsKey =
+    "ReceivePresentationSyncLatencyMs";
+constexpr const char* kLegacyReceivePresentationSyncMaxOffsetMsKey =
+    "ReceivePresentationSyncMaxOffsetMs";
+
+bool settingIsTrue(const QString& value)
+{
+    return value.compare(QStringLiteral("True"), Qt::CaseInsensitive) == 0;
+}
+
+ReceiveSyncMode syncModeFromSetting(const QString& value)
+{
+    return value.compare(QStringLiteral("AutoAssist"), Qt::CaseInsensitive) == 0
+        ? ReceiveSyncMode::AutoAssist
+        : ReceiveSyncMode::Manual;
+}
+
+QString syncModeSettingValue(ReceiveSyncMode mode)
+{
+    return mode == ReceiveSyncMode::AutoAssist
+        ? QStringLiteral("AutoAssist")
+        : QStringLiteral("Manual");
+}
+
+ReceivePresentationSettings defaultReceivePresentationSettings()
+{
+    ReceivePresentationSettings settings;
+    settings.enabled = true;
+    settings.mode = ReceiveSyncMode::AutoAssist;
+    settings.baseLatencyMs = kDefaultReceivePresentationLatencyMs;
+    settings.manualOffsetMs = 0;
+    settings.maxOffsetMs = kDefaultReceivePresentationMaxOffsetMs;
+    return settings;
+}
+
+QJsonObject receivePresentationSettingsToJson(
+    const ReceivePresentationSettings& settings)
+{
+    QJsonObject object;
+    object.insert(QStringLiteral("enabled"), settings.enabled);
+    object.insert(QStringLiteral("mode"), syncModeSettingValue(settings.mode));
+    object.insert(QStringLiteral("manualOffsetMs"), settings.manualOffsetMs);
+    object.insert(QStringLiteral("baseLatencyMs"), settings.baseLatencyMs);
+    object.insert(QStringLiteral("maxOffsetMs"), settings.maxOffsetMs);
+    return object;
+}
+
+QJsonObject parseReceivePresentationSettingsJson(const QString& value)
+{
+    QJsonParseError error;
+    const QJsonDocument doc =
+        QJsonDocument::fromJson(value.trimmed().toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+        return {};
+    }
+    return doc.object();
+}
+
+ReceivePresentationSettings receivePresentationSettingsFromJson(
+    const QJsonObject& object)
+{
+    ReceivePresentationSettings settings = defaultReceivePresentationSettings();
+    if (object.contains(QStringLiteral("enabled"))) {
+        settings.enabled = object.value(QStringLiteral("enabled")).toBool(
+            settings.enabled);
+    }
+    const QString mode =
+        object.value(QStringLiteral("mode")).toString(syncModeSettingValue(
+            settings.mode));
+    settings.mode = syncModeFromSetting(mode);
+    settings.manualOffsetMs =
+        object.value(QStringLiteral("manualOffsetMs")).toInt(
+            settings.manualOffsetMs);
+    settings.baseLatencyMs =
+        object.value(QStringLiteral("baseLatencyMs")).toInt(
+            settings.baseLatencyMs);
+    settings.maxOffsetMs =
+        object.value(QStringLiteral("maxOffsetMs")).toInt(
+            settings.maxOffsetMs);
+    return settings;
+}
+
+bool hasLegacyReceivePresentationSettings(const AppSettings& settings)
+{
+    return settings.contains(kLegacyReceivePresentationSyncEnabledKey)
+        || settings.contains(kLegacyReceivePresentationSyncModeKey)
+        || settings.contains(kLegacyReceivePresentationSyncOffsetMsKey)
+        || settings.contains(kLegacyReceivePresentationSyncLatencyMsKey)
+        || settings.contains(kLegacyReceivePresentationSyncMaxOffsetMsKey);
+}
+
+ReceivePresentationSettings receivePresentationSettingsFromLegacy(
+    const AppSettings& settings)
+{
+    ReceivePresentationSettings receiveSettings =
+        defaultReceivePresentationSettings();
+    receiveSettings.enabled =
+        settingIsTrue(settings.value(kLegacyReceivePresentationSyncEnabledKey,
+                                     receiveSettings.enabled ? "True" : "False")
+                          .toString());
+    receiveSettings.mode = syncModeFromSetting(
+        settings.value(kLegacyReceivePresentationSyncModeKey,
+                       syncModeSettingValue(receiveSettings.mode))
+            .toString());
+    receiveSettings.baseLatencyMs =
+        settings.value(kLegacyReceivePresentationSyncLatencyMsKey,
+                       QString::number(receiveSettings.baseLatencyMs))
+            .toInt();
+    receiveSettings.manualOffsetMs =
+        settings.value(kLegacyReceivePresentationSyncOffsetMsKey,
+                       QString::number(receiveSettings.manualOffsetMs))
+            .toInt();
+    receiveSettings.maxOffsetMs =
+        settings.value(kLegacyReceivePresentationSyncMaxOffsetMsKey,
+                       QString::number(receiveSettings.maxOffsetMs))
+            .toInt();
+    return receiveSettings;
+}
+
+void removeLegacyReceivePresentationSettings(AppSettings& settings)
+{
+    settings.remove(kLegacyReceivePresentationSyncEnabledKey);
+    settings.remove(kLegacyReceivePresentationSyncModeKey);
+    settings.remove(kLegacyReceivePresentationSyncOffsetMsKey);
+    settings.remove(kLegacyReceivePresentationSyncLatencyMsKey);
+    settings.remove(kLegacyReceivePresentationSyncMaxOffsetMsKey);
+}
+
+void saveReceivePresentationSettings(
+    const ReceivePresentationSettings& settings)
+{
+    AppSettings& appSettings = AppSettings::instance();
+    const QJsonDocument doc(receivePresentationSettingsToJson(settings));
+    appSettings.setValue(kReceivePresentationSyncSettingsKey,
+                         QString::fromUtf8(
+                             doc.toJson(QJsonDocument::Compact)));
+    appSettings.save();
+}
+
+bool surfaceFollowsAudioPlayback(ReceivePresentationSurface surface)
+{
+    return surface == ReceivePresentationSurface::Waterfall
+        || surface == ReceivePresentationSurface::Spectrum
+        || surface == ReceivePresentationSurface::Meter;
+}
+
+bool surfaceUsesOrderedVisualQueue(ReceivePresentationSurface surface)
+{
+    return surface == ReceivePresentationSurface::Waterfall
+        || surface == ReceivePresentationSurface::Spectrum
+        || surface == ReceivePresentationSurface::Meter;
+}
+
+int sourceSurfaceCompensationMs(ReceivePresentationSource source,
+                                ReceivePresentationSurface surface)
+{
+    if (source == ReceivePresentationSource::KiwiSdr
+        && surface == ReceivePresentationSurface::Meter) {
+        // The SND metadata meter describes the audio block that follows it.
+        // Hold the GUI meter one observed 512-sample/12 kHz block so it lands
+        // on the audible block instead of its WebSocket arrival time.
+        return kKiwiSdrMeterSndBlockCompensationMs;
+    }
+    return 0;
+}
+
+bool kiwiPresentationSurface(ReceivePresentationSource source,
+                             ReceivePresentationSurface surface)
+{
+    return source == ReceivePresentationSource::KiwiSdr
+        && (surface == ReceivePresentationSurface::Audio
+            || surface == ReceivePresentationSurface::Waterfall
+            || surface == ReceivePresentationSurface::Spectrum
+            || surface == ReceivePresentationSurface::Meter);
+}
+
+bool estimateMaintainsAutoLock(const ReceiveSyncEstimate& estimate,
+                               float autoLockConfidence)
+{
+    return estimate.valid
+        && (estimate.held || estimate.confidence >= autoLockConfidence);
+}
+
+qint64 receiveSyncSliceFrequencyHz(const SliceModel* slice)
+{
+    if (!slice) {
+        return 0;
+    }
+    return static_cast<qint64>(
+        std::llround(slice->frequency() * 1000000.0));
+}
+
+bool receiveSyncAudioAudible(bool muted, float gain)
+{
+    return !muted && gain > 0.0f;
+}
+
+QString receiveSyncStatusOverlayText(ReceiveSyncStatus status)
+{
+    switch (status) {
+    case ReceiveSyncStatus::Off:
+        return QStringLiteral("Off");
+    case ReceiveSyncStatus::Manual:
+        return QStringLiteral("Manual");
+    case ReceiveSyncStatus::Searching:
+        return QStringLiteral("Searching");
+    case ReceiveSyncStatus::Holding:
+        return QStringLiteral("Coasting");
+    case ReceiveSyncStatus::Locked:
+        return QStringLiteral("Locked");
+    case ReceiveSyncStatus::LowConfidence:
+        return QStringLiteral("Low conf");
+    }
+    return QStringLiteral("Off");
+}
+
+QString receiveSyncStatusName(ReceiveSyncStatus status)
+{
+    switch (status) {
+    case ReceiveSyncStatus::Off:
+        return QStringLiteral("off");
+    case ReceiveSyncStatus::Manual:
+        return QStringLiteral("manual");
+    case ReceiveSyncStatus::Searching:
+        return QStringLiteral("searching");
+    case ReceiveSyncStatus::Holding:
+        return QStringLiteral("coasting");
+    case ReceiveSyncStatus::Locked:
+        return QStringLiteral("locked");
+    case ReceiveSyncStatus::LowConfidence:
+        return QStringLiteral("lowConfidence");
+    }
+    return QStringLiteral("off");
+}
+
+} // namespace
+
+void MainWindow::initReceivePresentationSync()
+{
+    AppSettings& s = AppSettings::instance();
+
+    ReceivePresentationSettings settings = defaultReceivePresentationSettings();
+    bool migratedLegacySettings = false;
+    const QString persisted =
+        s.value(kReceivePresentationSyncSettingsKey, QString{}).toString();
+    const QJsonObject persistedObject =
+        parseReceivePresentationSettingsJson(persisted);
+    if (!persistedObject.isEmpty()) {
+        settings = receivePresentationSettingsFromJson(persistedObject);
+    } else if (hasLegacyReceivePresentationSettings(s)) {
+        settings = receivePresentationSettingsFromLegacy(s);
+        migratedLegacySettings = true;
+    }
+
+    m_receivePresentationSync.setSettings(settings);
+    if (migratedLegacySettings) {
+        removeLegacyReceivePresentationSettings(s);
+        saveReceivePresentationSettings(m_receivePresentationSync.settings());
+    }
+    m_receiveAudioDelayEstimator.setConfig(
+        ReceiveAudioDelayEstimator::Config{
+            .sampleRateHz = kReceiveSyncAnalysisRateHz,
+            .maxOffsetMs = settings.maxOffsetMs,
+            .minOverlapMs = 750,
+            .minPeakCorrelation = 0.12f,
+                .minConfidence = 0.08f});
+    m_receiveSyncEstimateTimer.start();
+    m_receiveSyncDriftTimer.start();
+    if (!m_receivePresentationVisualTimer) {
+        m_receivePresentationVisualTimer = new QTimer(this);
+        m_receivePresentationVisualTimer->setSingleShot(true);
+        connect(m_receivePresentationVisualTimer, &QTimer::timeout,
+                this, &MainWindow::drainReceivePresentationVisualQueue);
+    }
+}
+
+ReceivePresentationSettings MainWindow::receivePresentationSettings() const
+{
+    return m_receivePresentationSync.settings();
+}
+
+ReceiveDelayBreakdown MainWindow::receivePresentationDelayBreakdown() const
+{
+    return m_receivePresentationSync.delayBreakdown();
+}
+
+QString MainWindow::receivePresentationOverlayStatsText() const
+{
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    if (!settings.enabled) {
+        return {};
+    }
+
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    const bool hasHeldDelayTarget =
+        settings.mode == ReceiveSyncMode::AutoAssist
+        && !receiveSyncDelayKiwiProfileId().isEmpty()
+        && estimateMaintainsAutoLock(settings.autoEstimate,
+                                     settings.autoLockConfidence);
+    if (!target.usable() && !hasHeldDelayTarget) {
+        return {};
+    }
+
+    const ReceiveDelayBreakdown delays =
+        m_receivePresentationSync.delayBreakdown();
+
+    const int delayMs = std::abs(delays.effectiveOffsetMs);
+    const double delaySeconds = static_cast<double>(delayMs) / 1000.0;
+
+    return QStringLiteral("Audio Sync: %1 / %2 sec delay")
+        .arg(receiveSyncStatusOverlayText(delays.status))
+        .arg(delaySeconds, 0, 'f', 2);
+}
+
+void MainWindow::setReceivePresentationSyncEnabled(bool enabled)
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    settings.enabled = enabled;
+    settings.autoEstimate = {};
+    m_receivePresentationSync.setSettings(settings);
+    resetReceivePresentationAutoAssistState(false);
+    clearReceivePresentationVisualQueue();
+
+    saveReceivePresentationSettings(m_receivePresentationSync.settings());
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+void MainWindow::setReceivePresentationSyncMode(ReceiveSyncMode mode)
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    settings.mode = mode;
+    settings.autoEstimate = {};
+    m_receivePresentationSync.setSettings(settings);
+    resetReceivePresentationAutoAssistState(false);
+    clearReceivePresentationVisualQueue();
+
+    saveReceivePresentationSettings(m_receivePresentationSync.settings());
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+void MainWindow::adjustReceivePresentationManualOffsetMs(int deltaMs)
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    settings.manualOffsetMs += deltaMs;
+    m_receivePresentationSync.setSettings(settings);
+    settings = m_receivePresentationSync.settings();
+
+    saveReceivePresentationSettings(settings);
+    clearReceivePresentationVisualQueue();
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+void MainWindow::resetReceivePresentationManualOffset()
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    settings.manualOffsetMs = 0;
+    m_receivePresentationSync.setSettings(settings);
+
+    saveReceivePresentationSettings(m_receivePresentationSync.settings());
+    clearReceivePresentationVisualQueue();
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+void MainWindow::setReceivePresentationLatencyMs(int latencyMs)
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    settings.baseLatencyMs = latencyMs;
+    m_receivePresentationSync.setSettings(settings);
+    settings = m_receivePresentationSync.settings();
+
+    saveReceivePresentationSettings(settings);
+    clearReceivePresentationVisualQueue();
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+MainWindow::ReceiveSyncTarget MainWindow::resolveReceiveSyncTarget() const
+{
+    ReceiveSyncTarget target;
+    if (!m_kiwiSdrManager) {
+        target.reason = QStringLiteral("noKiwiManager");
+        return target;
+    }
+
+    QVector<ReceiveSyncAudioPairEndpoint> flexCandidates;
+    QVector<ReceiveSyncAudioPairEndpoint> kiwiCandidates;
+    QSet<QString> seenKiwiProfiles;
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice || !m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            continue;
+        }
+
+        const qint64 frequencyHz = receiveSyncSliceFrequencyHz(slice);
+        if (frequencyHz <= 0) {
+            continue;
+        }
+
+        const QString profile =
+            m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId());
+        if (!profile.isEmpty()) {
+            if (seenKiwiProfiles.contains(profile)
+                || !m_kiwiSdrManager->isConnected(profile)
+                || !receiveSyncAudioAudible(slice->audioMute(),
+                                            slice->audioGain())) {
+                continue;
+            }
+            seenKiwiProfiles.insert(profile);
+            kiwiCandidates.append({.sliceId = slice->sliceId(),
+                                   .frequencyHz = frequencyHz,
+                                   .kiwiProfileId = profile});
+            continue;
+        }
+
+        if (receiveSyncAudioAudible(slice->flexAudioMute(),
+                                    slice->flexAudioGain())) {
+            flexCandidates.append({.sliceId = slice->sliceId(),
+                                   .frequencyHz = frequencyHz});
+        }
+    }
+
+    const ReceiveSyncAudioPairSelection selection =
+        selectReceiveSyncAudioPair(flexCandidates, kiwiCandidates,
+                                   kReceiveSyncFrequencyToleranceHz);
+    switch (selection.state) {
+    case ReceiveSyncAudioPairSelection::State::None:
+        target.state = ReceiveSyncTarget::State::None;
+        break;
+    case ReceiveSyncAudioPairSelection::State::Usable:
+        target.state = ReceiveSyncTarget::State::Usable;
+        break;
+    case ReceiveSyncAudioPairSelection::State::Ambiguous:
+        target.state = ReceiveSyncTarget::State::Ambiguous;
+        break;
+    }
+    target.kiwiProfileId = selection.kiwiProfileId;
+    target.flexSliceId = selection.flexSliceId;
+    target.kiwiSliceId = selection.kiwiSliceId;
+    target.frequencyHz = selection.frequencyHz;
+    target.audibleFlexCount = selection.audibleFlexCount;
+    target.audibleKiwiCount = selection.audibleKiwiCount;
+    target.matchingPairCount = selection.matchingPairCount;
+    target.reason = selection.reason;
+    return target;
+}
+
+QString MainWindow::receiveSyncKiwiProfileId() const
+{
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    return target.usable() ? target.kiwiProfileId : QString();
+}
+
+QString MainWindow::receiveSyncDelayKiwiProfileId() const
+{
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    if (target.usable()) {
+        return target.kiwiProfileId;
+    }
+
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    if (settings.mode != ReceiveSyncMode::AutoAssist
+        || m_receiveSyncKiwiProfileId.isEmpty()
+        || !estimateMaintainsAutoLock(settings.autoEstimate,
+                                      settings.autoLockConfidence)) {
+        return {};
+    }
+
+    const int sliceId =
+        m_kiwiSdrManager
+            ? m_kiwiSdrManager->assignedSliceForProfile(m_receiveSyncKiwiProfileId)
+            : -1;
+    const SliceModel* slice = m_radioModel.slice(sliceId);
+    if (!slice || !m_radioModel.sliceMayBelongToUs(sliceId)
+        || !m_kiwiSdrManager->isConnected(m_receiveSyncKiwiProfileId)
+        || !receiveSyncAudioAudible(slice->audioMute(), slice->audioGain())) {
+        return {};
+    }
+
+    return m_receiveSyncKiwiProfileId;
+}
+
+qint64 MainWindow::receiveSyncTunedFrequencyHz() const
+{
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    if (target.usable()) {
+        return target.frequencyHz;
+    }
+
+    return 0;
+}
+
+void MainWindow::holdReceivePresentationAutoAssistLock(bool clearVisualQueue)
+{
+    ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    if (estimateMaintainsAutoLock(settings.autoEstimate,
+                                  settings.autoLockConfidence)
+        && !settings.autoEstimate.held) {
+        settings.autoEstimate.held = true;
+        m_receivePresentationSync.setSettings(settings);
+    }
+
+    m_receiveSyncFlexAudio.clear();
+    m_receiveSyncKiwiAudio.clear();
+    m_receiveSyncHaveLastEstimate = false;
+    m_receiveSyncStableEstimateCount = 0;
+    if (clearVisualQueue) {
+        clearReceivePresentationVisualQueue();
+    }
+    m_receiveSyncEstimateTimer.restart();
+    m_receiveSyncDriftTimer.restart();
+}
+
+void MainWindow::resetReceivePresentationAutoAssistState(bool clearEstimate,
+                                                        bool clearVisualQueue)
+{
+    if (clearEstimate) {
+        ReceivePresentationSettings settings =
+            m_receivePresentationSync.settings();
+        settings.autoEstimate = {};
+        m_receivePresentationSync.setSettings(settings);
+    }
+
+    m_receiveSyncFlexAudio.clear();
+    m_receiveSyncKiwiAudio.clear();
+    m_receiveSyncKiwiProfileId.clear();
+    m_receiveSyncHaveLastEstimate = false;
+    m_receiveSyncStableEstimateCount = 0;
+    m_receiveSyncLastCandidate = {};
+    m_receiveSyncLastCandidateAbsoluteOffsetMs = 0;
+    m_receiveSyncLastCandidateAvailable = false;
+    m_receiveSyncLastAcceptedLock = false;
+    m_receiveSyncLastNearAppliedLock = false;
+    m_receiveSyncLastFarRelockEligible = false;
+    m_receiveSyncLastFrequencyHz = 0;
+    m_receiveSyncTargetUnavailable = false;
+    if (clearVisualQueue) {
+        clearReceivePresentationVisualQueue();
+    }
+    m_receiveSyncEstimateTimer.restart();
+    m_receiveSyncDriftTimer.restart();
+}
+
+void MainWindow::feedReceivePresentationSyncAudio(
+    ReceivePresentationSource source,
+    const QByteArray& pcmStereoFloat,
+    const QString& sourceId,
+    int sampleRateHz)
+{
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    if (!settings.enabled || settings.mode != ReceiveSyncMode::AutoAssist) {
+        return;
+    }
+
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    if (!target.usable()) {
+        if (!m_receiveSyncKiwiProfileId.isEmpty()
+            && !m_receiveSyncTargetUnavailable) {
+            const bool transientFrequencyMismatch =
+                target.reason == QLatin1String("noFrequencyMatch")
+                && m_receiveSyncLastFrequencyHz > 0;
+            holdReceivePresentationAutoAssistLock(false);
+            m_receiveSyncTargetUnavailable = true;
+            syncReceivePresentationDelaysToAudioEngine(
+                !transientFrequencyMismatch);
+        }
+        return;
+    }
+
+    if (source == ReceivePresentationSource::KiwiSdr
+        && sourceId != target.kiwiProfileId) {
+        return;
+    }
+
+    if (m_receiveSyncKiwiProfileId != target.kiwiProfileId) {
+        const QString previousSyncProfile = m_receiveSyncKiwiProfileId;
+        resetReceivePresentationAutoAssistState(true, false);
+        if (!previousSyncProfile.isEmpty()) {
+            clearReceivePresentationVisualQueueForSource(
+                ReceivePresentationSource::KiwiSdr, previousSyncProfile);
+            resetReceivePresentationAudioBuffersForKiwiSource(
+                previousSyncProfile);
+        }
+        m_receiveSyncKiwiProfileId = target.kiwiProfileId;
+        m_receiveSyncTargetUnavailable = false;
+        syncReceivePresentationDelaysToAudioEngine();
+    } else if (m_receiveSyncTargetUnavailable) {
+        m_receiveSyncTargetUnavailable = false;
+        m_receiveSyncFlexAudio.clear();
+        m_receiveSyncKiwiAudio.clear();
+        m_receiveSyncHaveLastEstimate = false;
+        m_receiveSyncStableEstimateCount = 0;
+        m_receiveSyncEstimateTimer.restart();
+        m_receiveSyncDriftTimer.restart();
+    }
+
+    const qint64 tunedFrequencyHz = receiveSyncTunedFrequencyHz();
+    if (tunedFrequencyHz > 0) {
+        if (m_receiveSyncLastFrequencyHz == 0) {
+            m_receiveSyncLastFrequencyHz = tunedFrequencyHz;
+        } else if (m_receiveSyncLastFrequencyHz != tunedFrequencyHz) {
+            holdReceivePresentationAutoAssistLock(false);
+            m_receiveSyncLastFrequencyHz = tunedFrequencyHz;
+            // A VFO knob can emit many small retunes per second. Flushing the
+            // presentation audio buffers here forces repeated prebuffering, so
+            // the operator hears dropouts while tuning. Clearing delayed visual
+            // frames here also stalls the waterfall/FFT during knob movement.
+            // Keep presentation queues flowing and only clear analysis state.
+            syncReceivePresentationDelaysToAudioEngine(false);
+            return;
+        }
+    }
+
+    constexpr qsizetype kFrameBytes =
+        2 * static_cast<qsizetype>(sizeof(float));
+    const qsizetype frameCount = pcmStereoFloat.size() / kFrameBytes;
+    if (frameCount <= 0) {
+        return;
+    }
+    sampleRateHz = std::max(1, sampleRateHz);
+
+    QVector<float>& dst =
+        source == ReceivePresentationSource::Flex
+            ? m_receiveSyncFlexAudio
+            : m_receiveSyncKiwiAudio;
+    const auto* samples =
+        reinterpret_cast<const float*>(pcmStereoFloat.constData());
+    const qsizetype outputSamples =
+        std::max<qsizetype>(
+            1,
+            (frameCount * kReceiveSyncAnalysisRateHz) / sampleRateHz);
+    dst.reserve(std::min<qsizetype>(
+        dst.size() + outputSamples + 1,
+        kReceiveSyncAnalysisRateHz * kReceiveSyncAnalysisWindowMs / 1000));
+
+    for (qsizetype out = 0; out < outputSamples; ++out) {
+        const qsizetype frameStart =
+            (out * sampleRateHz) / kReceiveSyncAnalysisRateHz;
+        qsizetype frameEnd =
+            ((out + 1) * sampleRateHz) / kReceiveSyncAnalysisRateHz;
+        frameEnd = std::clamp<qsizetype>(frameEnd, frameStart + 1, frameCount);
+        const qsizetype clampedStart =
+            std::clamp<qsizetype>(frameStart, 0, frameCount - 1);
+        float monoSum = 0.0f;
+        qsizetype count = 0;
+        for (qsizetype frame = clampedStart; frame < frameEnd; ++frame) {
+            const float left = samples[frame * 2];
+            const float right = samples[frame * 2 + 1];
+            monoSum += (std::isfinite(left) ? left : 0.0f) * 0.5f
+                     + (std::isfinite(right) ? right : 0.0f) * 0.5f;
+            ++count;
+        }
+        const float mono = count > 0 ? monoSum / static_cast<float>(count)
+                                     : 0.0f;
+        dst.append(std::clamp(mono, -1.0f, 1.0f));
+    }
+
+    const int maxSamples =
+        kReceiveSyncAnalysisRateHz * kReceiveSyncAnalysisWindowMs / 1000;
+    if (dst.size() > maxSamples) {
+        dst.remove(0, dst.size() - maxSamples);
+    }
+
+    runReceivePresentationAutoAssist();
+}
+
+void MainWindow::runReceivePresentationAutoAssist()
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    if (!settings.enabled || settings.mode != ReceiveSyncMode::AutoAssist) {
+        return;
+    }
+    if (!m_receiveSyncEstimateTimer.isValid()) {
+        m_receiveSyncEstimateTimer.start();
+    }
+    if (m_receiveSyncEstimateTimer.elapsed() < kReceiveSyncEstimateIntervalMs) {
+        return;
+    }
+
+    const int minSamples = kReceiveSyncAnalysisRateHz;
+    if (m_receiveSyncFlexAudio.size() < minSamples
+        || m_receiveSyncKiwiAudio.size() < minSamples) {
+        return;
+    }
+
+    m_receiveSyncEstimateTimer.restart();
+    const ReceiveAudioDelayEstimate estimate =
+        m_receiveAudioDelayEstimator.estimate(m_receiveSyncFlexAudio,
+                                              m_receiveSyncKiwiAudio);
+    const ReceiveSyncEstimate previousEstimate = settings.autoEstimate;
+    const bool hadAppliedAutoLock =
+        estimateMaintainsAutoLock(previousEstimate,
+                                  settings.autoLockConfidence);
+    const int currentAppliedOffsetMs =
+        m_receivePresentationSync.delayBreakdown().effectiveOffsetMs;
+    const int maxCandidateOffsetMs =
+        std::clamp(std::abs(settings.maxOffsetMs), 0,
+                   ReceivePresentationSync::kMaxOffsetMs);
+    const bool candidateAvailable =
+        estimate.valid
+        || estimate.peakCorrelation >= kReceiveSyncStableLockMinPeakCorrelation;
+    int offsetMs = candidateAvailable
+        ? std::clamp(currentAppliedOffsetMs + estimate.offsetMs,
+                     -maxCandidateOffsetMs, maxCandidateOffsetMs)
+        : settings.manualOffsetMs;
+    m_receiveSyncLastCandidate = estimate;
+    m_receiveSyncLastCandidateAvailable = candidateAvailable;
+    m_receiveSyncLastCandidateAbsoluteOffsetMs = offsetMs;
+    float confidence = estimate.confidence;
+    int driftPpm = 0;
+    bool acceptedLock = false;
+    bool farRelockEligible = false;
+    bool moderateCorrectionEligible = false;
+    bool nearAppliedLock = !hadAppliedAutoLock;
+    if (candidateAvailable) {
+        bool stable = false;
+        if (m_receiveSyncHaveLastEstimate && m_receiveSyncDriftTimer.isValid()) {
+            stable =
+                std::abs(offsetMs - m_receiveSyncLastEstimateOffsetMs)
+                <= kReceiveSyncStableToleranceMs;
+            const qint64 elapsedMs = m_receiveSyncDriftTimer.elapsed();
+            if (elapsedMs > 0) {
+                const int deltaMs =
+                    offsetMs - m_receiveSyncLastEstimateOffsetMs;
+                driftPpm = static_cast<int>(std::lround(
+                    static_cast<double>(deltaMs) * 1000000.0
+                    / static_cast<double>(elapsedMs)));
+            }
+        }
+        m_receiveSyncStableEstimateCount =
+            stable ? std::min(m_receiveSyncStableEstimateCount + 1,
+                              kReceiveSyncFarRelockCount)
+                   : 1;
+        const bool stableLockEligible =
+            m_receiveSyncStableEstimateCount >= kReceiveSyncStableLockCount
+            && estimate.confidence >= kReceiveSyncStableLockMinConfidence
+            && estimate.peakCorrelation >= kReceiveSyncStableLockMinPeakCorrelation;
+        const bool weakStableLockEligible =
+            m_receiveSyncStableEstimateCount >= kReceiveSyncWeakStableLockCount
+            && estimate.confidence >= kReceiveSyncWeakStableLockMinConfidence
+            && estimate.peakCorrelation
+                   >= kReceiveSyncWeakStableLockMinPeakCorrelation;
+        const bool immediateLockEligible =
+            estimate.confidence >= kReceiveSyncImmediateLockMinConfidence
+            && estimate.peakCorrelation >= kReceiveSyncImmediateLockMinPeakCorrelation;
+        nearAppliedLock =
+            !hadAppliedAutoLock
+            || std::abs(offsetMs - previousEstimate.offsetMs)
+                   <= kReceiveSyncStableToleranceMs;
+        farRelockEligible =
+            hadAppliedAutoLock
+            && !nearAppliedLock
+            && m_receiveSyncStableEstimateCount >= kReceiveSyncFarRelockCount
+            && std::abs(estimate.offsetMs) >= kReceiveSyncFarRelockResidualMs
+            && (immediateLockEligible || stableLockEligible);
+        moderateCorrectionEligible =
+            hadAppliedAutoLock
+            && !nearAppliedLock
+            && !farRelockEligible
+            && std::abs(estimate.offsetMs) < kReceiveSyncFarRelockResidualMs
+            && stableLockEligible;
+        if (stableLockEligible || weakStableLockEligible) {
+            confidence = std::max(confidence, settings.autoLockConfidence);
+        } else if (!immediateLockEligible
+                   && confidence >= settings.autoLockConfidence) {
+            confidence = std::max(0.0f, settings.autoLockConfidence - 0.01f);
+        }
+        acceptedLock =
+             (!hadAppliedAutoLock
+              && (immediateLockEligible || stableLockEligible))
+             || (hadAppliedAutoLock
+                 && nearAppliedLock
+                 && (stableLockEligible
+                     || (weakStableLockEligible
+                         && std::abs(estimate.offsetMs)
+                                <= kReceiveSyncCorrectionDeadbandMs)))
+             || moderateCorrectionEligible
+             || farRelockEligible;
+        if (!acceptedLock
+            && confidence >= settings.autoLockConfidence) {
+            confidence = std::max(0.0f, settings.autoLockConfidence - 0.01f);
+        }
+        m_receiveSyncLastEstimateOffsetMs = offsetMs;
+        m_receiveSyncHaveLastEstimate = true;
+        m_receiveSyncDriftTimer.restart();
+    } else {
+        m_receiveSyncStableEstimateCount = 0;
+        m_receiveSyncHaveLastEstimate = false;
+        m_receiveSyncDriftTimer.restart();
+    }
+    m_receiveSyncLastAcceptedLock = acceptedLock;
+    m_receiveSyncLastNearAppliedLock = nearAppliedLock;
+    m_receiveSyncLastFarRelockEligible = farRelockEligible;
+    if (acceptedLock) {
+        const bool resetAppliedOffset =
+            !hadAppliedAutoLock || farRelockEligible;
+        const bool keepAppliedOffset =
+            hadAppliedAutoLock
+            && std::abs(estimate.offsetMs) <= kReceiveSyncCorrectionDeadbandMs;
+        const int appliedOffsetMs =
+            keepAppliedOffset
+                ? previousEstimate.offsetMs
+                : ReceivePresentationSync::adjustedAutoOffsetMs(
+                      previousEstimate.offsetMs, offsetMs, resetAppliedOffset);
+        const bool stillSettling =
+            !keepAppliedOffset
+            && std::abs(offsetMs - appliedOffsetMs)
+            > kReceiveSyncAppliedSettledToleranceMs;
+        settings.autoEstimate = ReceiveSyncEstimate{
+            .offsetMs = appliedOffsetMs,
+            .confidence = confidence,
+            .valid = true,
+            .driftPpm = driftPpm,
+            .held = stillSettling,
+        };
+    } else if (hadAppliedAutoLock) {
+        settings.autoEstimate = previousEstimate;
+        settings.autoEstimate.held = true;
+    } else {
+        settings.autoEstimate = ReceiveSyncEstimate{
+            .offsetMs = offsetMs,
+            .confidence = confidence,
+            .valid = candidateAvailable,
+            .driftPpm = driftPpm,
+            .held = false,
+        };
+    }
+    m_receivePresentationSync.setSettings(settings);
+    syncReceivePresentationDelaysToAudioEngine();
+}
+
+QJsonObject MainWindow::automationReceiveSyncSnapshot() const
+{
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    const ReceiveDelayBreakdown delays =
+        m_receivePresentationSync.delayBreakdown();
+    const ReceiveSyncTarget target = resolveReceiveSyncTarget();
+    const AudioEngine::ReceivePresentationAudioQueues queues =
+        m_audio ? m_audio->receivePresentationAudioQueues()
+                : AudioEngine::ReceivePresentationAudioQueues{};
+    const int flexDelayMs =
+        receivePresentationDelayMs(ReceivePresentationSource::Flex,
+                                   ReceivePresentationSurface::Audio);
+    const int kiwiDelayMs =
+        receivePresentationDelayMs(ReceivePresentationSource::KiwiSdr,
+                                   ReceivePresentationSurface::Audio);
+
+    return QJsonObject{
+        {QStringLiteral("enabled"), settings.enabled},
+        {QStringLiteral("mode"),
+         settings.mode == ReceiveSyncMode::AutoAssist
+             ? QStringLiteral("autoAssist")
+             : QStringLiteral("manual")},
+        {QStringLiteral("status"), receiveSyncStatusName(delays.status)},
+        {QStringLiteral("statusText"),
+         receiveSyncStatusOverlayText(delays.status)},
+        {QStringLiteral("baseLatencyMs"), settings.baseLatencyMs},
+        {QStringLiteral("manualOffsetMs"), settings.manualOffsetMs},
+        {QStringLiteral("maxOffsetMs"), settings.maxOffsetMs},
+        {QStringLiteral("autoLockConfidence"),
+         settings.autoLockConfidence},
+        {QStringLiteral("effectiveOffsetMs"), delays.effectiveOffsetMs},
+        {QStringLiteral("flexDelayMs"), flexDelayMs},
+        {QStringLiteral("kiwiDelayMs"), kiwiDelayMs},
+        {QStringLiteral("rawFlexDelayMs"), delays.flexDelayMs},
+        {QStringLiteral("rawKiwiDelayMs"), delays.kiwiDelayMs},
+        {QStringLiteral("usableTarget"), target.usable()},
+        {QStringLiteral("targetAmbiguous"), target.ambiguous()},
+        {QStringLiteral("targetReason"), target.reason},
+        {QStringLiteral("targetFlexSliceId"), target.flexSliceId},
+        {QStringLiteral("targetKiwiSliceId"), target.kiwiSliceId},
+        {QStringLiteral("targetResolvedKiwiProfileId"), target.kiwiProfileId},
+        {QStringLiteral("targetDelayKiwiProfileId"),
+         receiveSyncDelayKiwiProfileId()},
+        {QStringLiteral("audibleFlexSliceCount"), target.audibleFlexCount},
+        {QStringLiteral("audibleKiwiSliceCount"), target.audibleKiwiCount},
+        {QStringLiteral("matchingPairCount"), target.matchingPairCount},
+        {QStringLiteral("autoOffsetMs"), settings.autoEstimate.offsetMs},
+        {QStringLiteral("autoConfidence"),
+         settings.autoEstimate.confidence},
+        {QStringLiteral("autoValid"), settings.autoEstimate.valid},
+        {QStringLiteral("autoHeld"), settings.autoEstimate.held},
+        {QStringLiteral("autoDriftPpm"), settings.autoEstimate.driftPpm},
+        {QStringLiteral("candidateAvailable"),
+         m_receiveSyncLastCandidateAvailable},
+        {QStringLiteral("candidateResidualMs"),
+         m_receiveSyncLastCandidate.offsetMs},
+        {QStringLiteral("candidateAbsoluteOffsetMs"),
+         m_receiveSyncLastCandidateAbsoluteOffsetMs},
+        {QStringLiteral("candidateConfidence"),
+         m_receiveSyncLastCandidate.confidence},
+        {QStringLiteral("candidatePeakCorrelation"),
+         m_receiveSyncLastCandidate.peakCorrelation},
+        {QStringLiteral("candidateValid"),
+         m_receiveSyncLastCandidate.valid},
+        {QStringLiteral("stableEstimateCount"),
+         m_receiveSyncStableEstimateCount},
+        {QStringLiteral("lastAcceptedLock"), m_receiveSyncLastAcceptedLock},
+        {QStringLiteral("lastNearAppliedLock"),
+         m_receiveSyncLastNearAppliedLock},
+        {QStringLiteral("lastFarRelockEligible"),
+         m_receiveSyncLastFarRelockEligible},
+        {QStringLiteral("haveLastEstimate"), m_receiveSyncHaveLastEstimate},
+        {QStringLiteral("lastEstimateOffsetMs"),
+         m_receiveSyncLastEstimateOffsetMs},
+        {QStringLiteral("targetUnavailable"),
+         m_receiveSyncTargetUnavailable},
+        {QStringLiteral("targetKiwiProfileId"), m_receiveSyncKiwiProfileId},
+        {QStringLiteral("frequencyHz"),
+         static_cast<double>(m_receiveSyncLastFrequencyHz)},
+        {QStringLiteral("flexAnalysisSamples"), m_receiveSyncFlexAudio.size()},
+        {QStringLiteral("kiwiAnalysisSamples"), m_receiveSyncKiwiAudio.size()},
+        {QStringLiteral("flexRawBufferMs"), queues.flexRawBufferMs},
+        {QStringLiteral("flexOutputBufferMs"), queues.flexOutputBufferMs},
+        {QStringLiteral("kiwiRawBufferMs"),
+         std::max(queues.kiwiSdrRawBufferMs,
+                  queues.externalKiwiRawBufferMs)},
+        {QStringLiteral("kiwiOutputBufferMs"),
+         std::max(queues.kiwiSdrOutputBufferMs,
+                  queues.externalKiwiOutputBufferMs)},
+        {QStringLiteral("playbackQueuedMs"), queues.playbackQueuedMs},
+        {QStringLiteral("estimateTimerMs"),
+         m_receiveSyncEstimateTimer.isValid()
+             ? static_cast<int>(m_receiveSyncEstimateTimer.elapsed())
+             : -1},
+        {QStringLiteral("driftTimerMs"),
+         m_receiveSyncDriftTimer.isValid()
+             ? static_cast<int>(m_receiveSyncDriftTimer.elapsed())
+             : -1},
+    };
+}
+
+bool MainWindow::receivePresentationHasUsableSyncTarget() const
+{
+    return resolveReceiveSyncTarget().usable();
+}
+
+void MainWindow::resetReceivePresentationAudioBuffers()
+{
+    if (!m_audio) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(
+        m_audio,
+        [audio = m_audio]() {
+            audio->resetReceivePresentationAudioBuffers();
+        },
+        Qt::QueuedConnection);
+}
+
+void MainWindow::resetReceivePresentationAudioBuffersForKiwiSource(
+    const QString& sourceId)
+{
+    if (!m_audio || sourceId.trimmed().isEmpty()) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(
+        m_audio,
+        [audio = m_audio, sourceId]() {
+            audio->resetReceivePresentationAudioBuffersForKiwiSource(
+                sourceId);
+        },
+        Qt::QueuedConnection);
+}
+
+int MainWindow::receivePresentationDelayMs(
+    ReceivePresentationSource source,
+    ReceivePresentationSurface surface,
+    const QString& sourceId) const
+{
+    const auto defaultKiwiDelayMs = [this, source, surface]() {
+        int delayMs = kDefaultReceivePresentationLatencyMs;
+        if (surfaceFollowsAudioPlayback(surface) && m_audio) {
+            delayMs += std::clamp(m_audio->rxPlaybackQueuedMs()
+                                      + kReceivePresentationAudioDrainGuardMs,
+                                  0,
+                                  kReceivePresentationMaxPlaybackCompensationMs);
+        }
+        delayMs += sourceSurfaceCompensationMs(source, surface);
+        return delayMs;
+    };
+
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    if (settings.enabled) {
+        if (settings.mode == ReceiveSyncMode::AutoAssist) {
+            const QString delayKiwiProfileId = receiveSyncDelayKiwiProfileId();
+            if (delayKiwiProfileId.isEmpty()) {
+                return 0;
+            }
+            const QString trimmedSourceId = sourceId.trimmed();
+            if (kiwiPresentationSurface(source, surface)
+                && !trimmedSourceId.isEmpty()
+                && trimmedSourceId != delayKiwiProfileId) {
+                return defaultKiwiDelayMs();
+            }
+        }
+        int delayMs = m_receivePresentationSync.delayMs(source, surface);
+        if (surfaceFollowsAudioPlayback(surface) && m_audio) {
+            delayMs += std::clamp(m_audio->rxPlaybackQueuedMs()
+                                      + kReceivePresentationAudioDrainGuardMs,
+                                  0,
+                                  kReceivePresentationMaxPlaybackCompensationMs);
+        }
+        delayMs += sourceSurfaceCompensationMs(source, surface);
+        return delayMs;
+    }
+
+    // KiwiSDR audio is intentionally jitter-buffered before the final mix.
+    // Even when cross-source sync is off, Kiwi visual surfaces should follow
+    // that same presentation point instead of rendering directly on arrival.
+    if (kiwiPresentationSurface(source, surface)) {
+        return defaultKiwiDelayMs();
+    }
+
+    return 0;
+}
+
+void MainWindow::clearReceivePresentationVisualQueue()
+{
+    m_receivePresentationVisualQueue.clear();
+    m_receivePresentationVisualLastDueMs.clear();
+    if (m_receivePresentationVisualTimer) {
+        m_receivePresentationVisualTimer->stop();
+    }
+}
+
+void MainWindow::clearReceivePresentationVisualQueueForSource(
+    ReceivePresentationSource source,
+    const QString& sourceId)
+{
+    const QString trimmedSourceId = sourceId.trimmed();
+    QSet<QString> sourceKeys;
+    if (!trimmedSourceId.isEmpty()) {
+        for (ReceivePresentationSurface surface :
+             {ReceivePresentationSurface::Waterfall,
+              ReceivePresentationSurface::Spectrum,
+              ReceivePresentationSurface::Meter}) {
+            sourceKeys.insert(
+                receivePresentationVisualQueueKey(source, surface,
+                                                  trimmedSourceId));
+        }
+    }
+
+    const auto matchesSource = [&](const QString& key) {
+        if (trimmedSourceId.isEmpty()) {
+            const QString prefix =
+                source == ReceivePresentationSource::Flex
+                    ? QStringLiteral("flex:")
+                    : QStringLiteral("kiwi:");
+            return key.startsWith(prefix);
+        }
+        return sourceKeys.contains(key);
+    };
+
+    m_receivePresentationVisualQueue.removeIf(
+        [&](const ReceivePresentationQueuedItem<std::function<void()>>& item) {
+            return item.source == source && matchesSource(item.sourceId);
+        });
+
+    QStringList dueKeysToRemove;
+    for (auto it = m_receivePresentationVisualLastDueMs.cbegin();
+         it != m_receivePresentationVisualLastDueMs.cend(); ++it) {
+        if (matchesSource(it.key())) {
+            dueKeysToRemove.append(it.key());
+        }
+    }
+    for (const QString& key : dueKeysToRemove) {
+        m_receivePresentationVisualLastDueMs.remove(key);
+    }
+    scheduleReceivePresentationVisualQueue();
+}
+
+void MainWindow::scheduleReceivePresentationVisualQueue()
+{
+    if (m_receivePresentationVisualQueue.isEmpty()) {
+        if (m_receivePresentationVisualTimer) {
+            m_receivePresentationVisualTimer->stop();
+        }
+        return;
+    }
+    if (!m_receivePresentationVisualTimer) {
+        m_receivePresentationVisualTimer = new QTimer(this);
+        m_receivePresentationVisualTimer->setSingleShot(true);
+        connect(m_receivePresentationVisualTimer, &QTimer::timeout,
+                this, &MainWindow::drainReceivePresentationVisualQueue);
+    }
+
+    const std::optional<qint64> nextDue =
+        m_receivePresentationVisualQueue.nextDueMs();
+    if (!nextDue.has_value()) {
+        m_receivePresentationVisualTimer->stop();
+        return;
+    }
+
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    const int intervalMs = static_cast<int>(
+        std::clamp<qint64>(*nextDue - nowMs, 0, 60000));
+    m_receivePresentationVisualTimer->start(intervalMs);
+}
+
+void MainWindow::drainReceivePresentationVisualQueue()
+{
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    const auto dueItems = m_receivePresentationVisualQueue.releaseDue(
+        nowMs, kReceivePresentationVisualMaxReleaseBatch);
+    for (const auto& item : dueItems) {
+        if (item.payload) {
+            item.payload();
+        }
+    }
+    scheduleReceivePresentationVisualQueue();
+}
+
+void MainWindow::deferReceivePresentation(ReceivePresentationSource source,
+                                          ReceivePresentationSurface surface,
+                                          std::function<void()> apply,
+                                          const QString& sourceId)
+{
+    if (!apply) {
+        return;
+    }
+
+    const int delayMs = receivePresentationDelayMs(source, surface, sourceId);
+    if (delayMs <= 0) {
+        apply();
+        return;
+    }
+
+    if (surfaceUsesOrderedVisualQueue(surface)) {
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        const QString key =
+            receivePresentationVisualQueueKey(source, surface, sourceId);
+        qint64 dueMs = nowMs + delayMs;
+        const qint64 previousDueMs =
+            m_receivePresentationVisualLastDueMs.value(key, 0);
+        if (previousDueMs > 0 && dueMs <= previousDueMs) {
+            dueMs = previousDueMs + 1;
+        }
+        m_receivePresentationVisualLastDueMs.insert(key, dueMs);
+        m_receivePresentationVisualQueue.enqueue(
+            {.source = source,
+             .surface = surface,
+             .sourceId = key,
+             .arrivalMs = nowMs,
+             .dueMs = dueMs,
+             .sequence = ++m_receivePresentationVisualSequence,
+             .payload = std::move(apply)});
+        m_receivePresentationVisualQueue.trimToSize(
+            kReceivePresentationVisualQueueMaxItems);
+        scheduleReceivePresentationVisualQueue();
+        return;
+    }
+
+    QTimer::singleShot(delayMs, this, [apply = std::move(apply)]() {
+        apply();
+    });
+}
+
+void MainWindow::syncReceivePresentationDelaysToAudioEngine(
+    bool clearVisualQueueOnAbruptDelayChange)
+{
+    if (!m_audio) {
+        return;
+    }
+
+    const int flexDelayMs =
+        receivePresentationDelayMs(ReceivePresentationSource::Flex,
+                                   ReceivePresentationSurface::Audio);
+    const int kiwiDelayMs =
+        receivePresentationDelayMs(ReceivePresentationSource::KiwiSdr,
+                                   ReceivePresentationSurface::Audio);
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
+    const QString kiwiDelaySourceId =
+        settings.enabled && settings.mode == ReceiveSyncMode::AutoAssist
+            ? receiveSyncDelayKiwiProfileId()
+            : QString();
+    if (m_receivePresentationLastFlexAudioDelayMs >= 0
+        && clearVisualQueueOnAbruptDelayChange) {
+        if (std::abs(flexDelayMs - m_receivePresentationLastFlexAudioDelayMs)
+            > kReceivePresentationAbruptDelayChangeMs) {
+            clearReceivePresentationVisualQueueForSource(
+                ReceivePresentationSource::Flex);
+        }
+        if (std::abs(kiwiDelayMs - m_receivePresentationLastKiwiAudioDelayMs)
+            > kReceivePresentationAbruptDelayChangeMs) {
+            clearReceivePresentationVisualQueueForSource(
+                ReceivePresentationSource::KiwiSdr, kiwiDelaySourceId);
+        }
+    }
+    m_receivePresentationLastFlexAudioDelayMs = flexDelayMs;
+    m_receivePresentationLastKiwiAudioDelayMs = kiwiDelayMs;
+
+    QMetaObject::invokeMethod(
+        m_audio,
+        [audio = m_audio, flexDelayMs, kiwiDelayMs, kiwiDelaySourceId]() {
+            audio->setReceivePresentationDelays(
+                flexDelayMs, kiwiDelayMs, kiwiDelaySourceId);
+        },
+        Qt::QueuedConnection);
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_ReceiveSync.cpp
+++ b/src/gui/MainWindow_ReceiveSync.cpp
@@ -6,11 +6,13 @@
 #include "models/SliceModel.h"
 
 #include <QDateTime>
+#include <QFutureWatcher>
 #include <QJsonDocument>
 #include <QMetaObject>
 #include <QJsonObject>
 #include <QSet>
 #include <QStringList>
+#include <QtConcurrent/QtConcurrentRun>
 #include <QTimer>
 
 #include <algorithm>
@@ -557,6 +559,7 @@ void MainWindow::holdReceivePresentationAutoAssistLock(bool clearVisualQueue)
 
     m_receiveSyncFlexAudio.clear();
     m_receiveSyncKiwiAudio.clear();
+    ++m_receiveSyncEstimateGeneration;
     m_receiveSyncHaveLastEstimate = false;
     m_receiveSyncStableEstimateCount = 0;
     if (clearVisualQueue) {
@@ -578,6 +581,7 @@ void MainWindow::resetReceivePresentationAutoAssistState(bool clearEstimate,
 
     m_receiveSyncFlexAudio.clear();
     m_receiveSyncKiwiAudio.clear();
+    ++m_receiveSyncEstimateGeneration;
     m_receiveSyncKiwiProfileId.clear();
     m_receiveSyncHaveLastEstimate = false;
     m_receiveSyncStableEstimateCount = 0;
@@ -722,7 +726,8 @@ void MainWindow::feedReceivePresentationSyncAudio(
 
 void MainWindow::runReceivePresentationAutoAssist()
 {
-    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    const ReceivePresentationSettings settings =
+        m_receivePresentationSync.settings();
     if (!settings.enabled || settings.mode != ReceiveSyncMode::AutoAssist) {
         return;
     }
@@ -738,11 +743,44 @@ void MainWindow::runReceivePresentationAutoAssist()
         || m_receiveSyncKiwiAudio.size() < minSamples) {
         return;
     }
+    if (m_receiveSyncEstimateInFlight) {
+        return;
+    }
 
     m_receiveSyncEstimateTimer.restart();
-    const ReceiveAudioDelayEstimate estimate =
-        m_receiveAudioDelayEstimator.estimate(m_receiveSyncFlexAudio,
-                                              m_receiveSyncKiwiAudio);
+    m_receiveSyncEstimateInFlight = true;
+    const quint64 generation = ++m_receiveSyncEstimateGeneration;
+    const QVector<float> flexAudio = m_receiveSyncFlexAudio;
+    const QVector<float> kiwiAudio = m_receiveSyncKiwiAudio;
+    const ReceiveAudioDelayEstimator::Config config =
+        m_receiveAudioDelayEstimator.config();
+
+    auto* watcher = new QFutureWatcher<ReceiveAudioDelayEstimate>(this);
+    connect(watcher, &QFutureWatcher<ReceiveAudioDelayEstimate>::finished,
+            this, [this, watcher, generation]() {
+        const ReceiveAudioDelayEstimate estimate = watcher->result();
+        watcher->deleteLater();
+        m_receiveSyncEstimateInFlight = false;
+        if (generation != m_receiveSyncEstimateGeneration) {
+            return;
+        }
+        applyReceivePresentationAutoAssistEstimate(estimate);
+    });
+    watcher->setFuture(QtConcurrent::run(
+        [config, flexAudio, kiwiAudio]() {
+            ReceiveAudioDelayEstimator estimator(config);
+            return estimator.estimate(flexAudio, kiwiAudio);
+        }));
+}
+
+void MainWindow::applyReceivePresentationAutoAssistEstimate(
+    const ReceiveAudioDelayEstimate& estimate)
+{
+    ReceivePresentationSettings settings = m_receivePresentationSync.settings();
+    if (!settings.enabled || settings.mode != ReceiveSyncMode::AutoAssist) {
+        return;
+    }
+
     const ReceiveSyncEstimate previousEstimate = settings.autoEstimate;
     const bool hadAppliedAutoLock =
         estimateMaintainsAutoLock(previousEstimate,

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -909,31 +909,44 @@ void MainWindow::wirePanLifecycle()
                 PerfTelemetry::FrameKind::Panadapter,
                 static_cast<double>(PerfTelemetry::nowNs() - emittedNs) / 1000000.0);
         }
-        for (auto* pan : m_radioModel.panadapters()) {
-            if (pan->panStreamId() == streamId) {
-                if (auto* sw = m_panStack->spectrum(pan->panId())) {
-                    if (!profileLoadFrameReady(pan->panId(), sw, bins.size())) {
+        deferReceivePresentation(
+            ReceivePresentationSource::Flex,
+            ReceivePresentationSurface::Spectrum,
+            [this, profileLoadFrameReady, streamId, bins]() {
+                if (m_shuttingDown || !m_panStack) {
+                    return;
+                }
+                for (auto* pan : m_radioModel.panadapters()) {
+                    if (pan->panStreamId() == streamId) {
+                        if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                            if (!profileLoadFrameReady(pan->panId(), sw,
+                                                       bins.size())) {
+                                return;
+                            }
+                            sw->updateSpectrum(bins);
+                            finishPanadapterConnectionAnimation();
+                        }
                         return;
                     }
-                    sw->updateSpectrum(bins);
-                    finishPanadapterConnectionAnimation();
                 }
-                return;
-            }
-        }
-        // Fallback: active spectrum only before any radio-owned pan has been
-        // claimed. During profile loads/removals, queued frames from streams
-        // that were just removed can arrive after their model is gone; drawing
-        // them into the current active pane produces a brief bogus trace.
-        if (m_radioModel.panadapters().isEmpty() && !profileLoadRadioStateWritesHeld()) {
-            if (auto* sw = spectrum()) {
-                sw->updateSpectrum(bins);
-                finishPanadapterConnectionAnimation();
-            }
-        } else {
-            qCDebug(lcProtocol) << "MainWindow: dropped unmatched FFT stream"
-                                << QStringLiteral("0x%1").arg(streamId, 0, 16);
-        }
+                // Fallback: active spectrum only before any radio-owned pan has
+                // been claimed. During profile loads/removals, queued frames
+                // from streams that were just removed can arrive after their
+                // model is gone; drawing them into the current active pane
+                // produces a brief bogus trace.
+                if (m_radioModel.panadapters().isEmpty()
+                    && !profileLoadRadioStateWritesHeld()) {
+                    if (auto* sw = spectrum()) {
+                        sw->updateSpectrum(bins);
+                        finishPanadapterConnectionAnimation();
+                    }
+                } else {
+                    qCDebug(lcProtocol)
+                        << "MainWindow: dropped unmatched FFT stream"
+                        << QStringLiteral("0x%1").arg(streamId, 0, 16);
+                }
+            },
+            QString::number(streamId));
     });
     // ── S History Markers — tap into FFT frames for voice signal detection ──
     connect(m_radioModel.panStream(), &PanadapterStream::spectrumReady,
@@ -954,55 +967,76 @@ void MainWindow::wirePanLifecycle()
                 PerfTelemetry::FrameKind::Waterfall,
                 static_cast<double>(PerfTelemetry::nowNs() - emittedNs) / 1000000.0);
         }
-        for (auto* pan : m_radioModel.panadapters()) {
-            if (pan->wfStreamId() == streamId) {
-                const double panCenter = pan->centerMhz();
-                if (XvtrPolicy::isWaterfallTileOutsidePan(low, high, panCenter)) {
-                    // Only reinterpret non-overlapping tile ranges for real XVTR
-                    // IF/RF translation. Ordinary HF pans can briefly see stale
-                    // tile centers while dragging; shifting those corrupts rows.
-                    const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
-                    const auto match = XvtrPolicy::matchWaterfallTileTransverterOffset(
-                        low, high, panCenter, xvtrs);
-                    bool hasXvtrSliceAntenna = false;
-                    if (!match.matched) {
-                        for (auto* slice : m_radioModel.slices()) {
-                            if (!slice || slice->panId() != pan->panId())
-                                continue;
-                            if (slice->rxAntenna().startsWith(QStringLiteral("XVT"),
-                                                               Qt::CaseInsensitive)) {
-                                hasXvtrSliceAntenna = true;
-                                break;
-                            }
-                        }
-                    }
-                    const auto mapped = XvtrPolicy::mapWaterfallTileRange(
-                        low, high, panCenter, xvtrs, hasXvtrSliceAntenna);
-                    logXvtrWaterfallDecision(streamId, pan->panId(), panCenter,
-                                             low, high, mapped, match,
-                                             hasXvtrSliceAntenna, xvtrs);
-                    low = mapped.lowMhz;
-                    high = mapped.highMhz;
+        deferReceivePresentation(
+            ReceivePresentationSource::Flex,
+            ReceivePresentationSurface::Waterfall,
+            [this, profileLoadFrameReady, streamId, bins, low, high, tc]() {
+                if (m_shuttingDown || !m_panStack) {
+                    return;
                 }
-                if (auto* sw = m_panStack->spectrum(pan->panId())) {
-                    if (!profileLoadFrameReady(pan->panId(), sw, bins.size())) {
+                for (auto* pan : m_radioModel.panadapters()) {
+                    if (pan->wfStreamId() == streamId) {
+                        double rowLow = low;
+                        double rowHigh = high;
+                        const double panCenter = pan->centerMhz();
+                        if (XvtrPolicy::isWaterfallTileOutsidePan(rowLow, rowHigh,
+                                                                  panCenter)) {
+                            // Only reinterpret non-overlapping tile ranges for
+                            // real XVTR IF/RF translation. Ordinary HF pans can
+                            // briefly see stale tile centers while dragging;
+                            // shifting those corrupts rows.
+                            const auto xvtrs =
+                                xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+                            const auto match =
+                                XvtrPolicy::matchWaterfallTileTransverterOffset(
+                                    rowLow, rowHigh, panCenter, xvtrs);
+                            bool hasXvtrSliceAntenna = false;
+                            if (!match.matched) {
+                                for (auto* slice : m_radioModel.slices()) {
+                                    if (!slice || slice->panId() != pan->panId()) {
+                                        continue;
+                                    }
+                                    if (slice->rxAntenna().startsWith(
+                                            QStringLiteral("XVT"),
+                                            Qt::CaseInsensitive)) {
+                                        hasXvtrSliceAntenna = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            const auto mapped = XvtrPolicy::mapWaterfallTileRange(
+                                rowLow, rowHigh, panCenter, xvtrs,
+                                hasXvtrSliceAntenna);
+                            logXvtrWaterfallDecision(
+                                streamId, pan->panId(), panCenter, rowLow, rowHigh,
+                                mapped, match, hasXvtrSliceAntenna, xvtrs);
+                            rowLow = mapped.lowMhz;
+                            rowHigh = mapped.highMhz;
+                        }
+                        if (auto* sw = m_panStack->spectrum(pan->panId())) {
+                            if (!profileLoadFrameReady(pan->panId(), sw,
+                                                       bins.size())) {
+                                return;
+                            }
+                            sw->updateWaterfallRow(bins, rowLow, rowHigh, tc);
+                            finishPanadapterConnectionAnimation();
+                        }
                         return;
                     }
-                    sw->updateWaterfallRow(bins, low, high, tc);
-                    finishPanadapterConnectionAnimation();
                 }
-                return;
-            }
-        }
-        if (m_radioModel.panadapters().isEmpty() && !profileLoadRadioStateWritesHeld()) {
-            if (auto* sw = spectrum()) {
-                sw->updateWaterfallRow(bins, low, high, tc);
-                finishPanadapterConnectionAnimation();
-            }
-        } else {
-            qCDebug(lcProtocol) << "MainWindow: dropped unmatched waterfall stream"
-                                << QStringLiteral("0x%1").arg(streamId, 0, 16);
-        }
+                if (m_radioModel.panadapters().isEmpty()
+                    && !profileLoadRadioStateWritesHeld()) {
+                    if (auto* sw = spectrum()) {
+                        sw->updateWaterfallRow(bins, low, high, tc);
+                        finishPanadapterConnectionAnimation();
+                    }
+                } else {
+                    qCDebug(lcProtocol)
+                        << "MainWindow: dropped unmatched waterfall stream"
+                        << QStringLiteral("0x%1").arg(streamId, 0, 16);
+                }
+            },
+            QString::number(streamId));
     });
     connect(m_radioModel.panStream(), &PanadapterStream::waterfallAutoBlackLevel,
             this, [this](quint32 streamId, quint32 autoBlack) {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -55,6 +55,7 @@
 
 #include <QDateTime>
 #include <QFileDialog>
+#include <QPointer>
 #include <QSet>
 #include <QTimer>
 
@@ -838,19 +839,41 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // Feed S-meter per-slice — only this VFO's slice level
     const int sid = s->sliceId();
+    const QPointer<VfoWidget> vfoPtr(vfo);
     connect(&m_radioModel.meterModel(), &MeterModel::sLevelChanged,
-            vfo, [this, vfo, sid](int sliceIndex, float dbm) {
+            vfo, [this, vfoPtr, sid](int sliceIndex, float dbm) {
         if (sliceIndex == sid
             && (!m_kiwiSdrManager
                 || m_kiwiSdrManager->assignedProfileForSlice(sid).isEmpty())) {
-            vfo->setSignalLevel(dbm);
+            deferReceivePresentation(
+                ReceivePresentationSource::Flex,
+                ReceivePresentationSurface::Meter,
+                [this, vfoPtr, sid, dbm]() {
+                    if (!vfoPtr
+                        || (m_kiwiSdrManager
+                            && !m_kiwiSdrManager
+                                    ->assignedProfileForSlice(sid).isEmpty())) {
+                        return;
+                    }
+                    vfoPtr->setSignalLevel(dbm);
+                },
+                QString::number(sid));
         }
     });
     // Feed ESC meter per-slice — signal strength after ESC processing
     connect(&m_radioModel.meterModel(), &MeterModel::escLevelChanged,
-            vfo, [vfo, sid](int sliceIndex, float dbm) {
-        if (sliceIndex == sid)
-            vfo->setEscLevel(dbm);
+            vfo, [this, vfoPtr, sid](int sliceIndex, float dbm) {
+        if (sliceIndex == sid) {
+            deferReceivePresentation(
+                ReceivePresentationSource::Flex,
+                ReceivePresentationSurface::Meter,
+                [vfoPtr, dbm]() {
+                    if (vfoPtr) {
+                        vfoPtr->setEscLevel(dbm);
+                    }
+                },
+                QString::number(sid));
+        }
     });
     // Feed the SmartMTR TX scales: mic level + compression (dBFS / dB) from
     // micMetersChanged, and forward power + SWR from txMetersChanged. The VFO
@@ -1564,6 +1587,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     if (m_appletPanel && m_appletPanel->rxApplet()) {
         QObject::disconnect(m_appletPanel->rxApplet(), nullptr, sw, nullptr);
     }
+    sw->setFpsMeterSyncStatsProvider([this]() {
+        return receivePresentationOverlayStatsText();
+    });
 
     auto updateKiwiWaterfallView = [this, applet, sw](double centerMhz,
                                                       double bandwidthMhz) {
@@ -3387,12 +3413,26 @@ void MainWindow::wireMeters()
             && (!m_kiwiSdrManager
                 || m_kiwiSdrManager
                        ->assignedProfileForSlice(sliceIndex).isEmpty())) {
-            m_appletPanel->sMeterWidget()->setLevel(dbm);
+            deferReceivePresentation(
+                ReceivePresentationSource::Flex,
+                ReceivePresentationSurface::Meter,
+                [this, sliceIndex, dbm]() {
+                    if (!m_appletPanel
+                        || sliceIndex != m_activeSliceId
+                        || (m_kiwiSdrManager
+                            && !m_kiwiSdrManager
+                                    ->assignedProfileForSlice(sliceIndex)
+                                    .isEmpty())) {
+                        return;
+                    }
+                    m_appletPanel->sMeterWidget()->setLevel(dbm);
 #ifdef HAVE_HIDAPI
-            m_tmate2SmeterDbm = dbm;
-            updateTMate2Display();
-            updateTMate2Indicators();
+                    m_tmate2SmeterDbm = dbm;
+                    updateTMate2Display();
+                    updateTMate2Indicators();
 #endif
+                },
+                QString::number(sliceIndex));
         }
     });
     // Symmetric with the amp-side guard at line ~3654 and the PGXL TCP path

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -34,6 +34,7 @@
 #include <QAction>
 #include <QFontMetrics>
 #include <QPainter>
+#include <QPointer>
 #include <QWheelEvent>
 #include <QKeyEvent>
 #include <QStyle>
@@ -394,21 +395,30 @@ void RxApplet::buildUI()
             "font-size: 10px; font-weight: bold; padding: 0 2px; }"
             "QPushButton:hover { color: #66aaff; }");
         connect(m_rxAntBtn, &QPushButton::clicked, this, [this] {
-            QMenu menu(this);
-            const QString cur = m_slice ? m_slice->rxAntenna() : "";
-            const QStringList options = m_slice && !m_slice->rxAntennaList().isEmpty()
-                ? m_slice->rxAntennaList()
-                : m_antList;
-            QStringList menuOptions = options;
+            if (!m_slice) {
+                return;
+            }
+            QPointer<SliceModel> slice = m_slice;
+            const QString cur = slice->rxAntenna();
+            QStringList menuOptions = rxAntennaOptions();
             if (m_kiwiSdrManager) {
-                menuOptions.append(m_kiwiSdrManager->virtualAntennaTokens());
+                for (const QString& ant : m_kiwiSdrManager->virtualAntennaTokens()) {
+                    if (!ant.isEmpty() && !menuOptions.contains(ant)) {
+                        menuOptions.append(ant);
+                    }
+                }
+            }
+            if (menuOptions.isEmpty()) {
+                menuOptions << QStringLiteral("ANT1") << QStringLiteral("ANT2");
             }
             const QString activeKiwiProfile =
-                (m_kiwiSdrManager && m_slice)
-                    ? m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId())
+                m_kiwiSdrManager
+                    ? m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
                     : QString();
+            QMenu* menu = new QMenu(m_rxAntBtn);
+            connect(menu, &QMenu::aboutToHide, menu, &QObject::deleteLater);
             for (const QString& ant : menuOptions) {
-                QAction* act = menu.addAction(antennaMenuLabel(ant, menuOptions));
+                QAction* act = menu->addAction(antennaMenuLabel(ant, menuOptions));
                 act->setData(ant);
                 act->setCheckable(true);
                 const QString profileId = m_kiwiSdrManager
@@ -420,20 +430,23 @@ void RxApplet::buildUI()
                 act->setToolTip(ant);
                 act->setStatusTip(ant);
             }
-            const QAction* sel = menu.exec(
-                m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())));
-            if (sel && m_slice) {
+            connect(menu, &QMenu::triggered, this, [this, slice](QAction* sel) {
+                if (!sel || !slice) {
+                    return;
+                }
                 const QString token = sel->data().toString();
                 const QString profileId = m_kiwiSdrManager
                     ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(token)
                     : QString();
                 if (!profileId.isEmpty()) {
-                    emit kiwiRxAntennaSelected(m_slice->sliceId(), profileId);
+                    emit kiwiRxAntennaSelected(slice->sliceId(), profileId);
                 } else {
-                    emit flexRxAntennaSelected(m_slice->sliceId());
-                    m_slice->setRxAntenna(token);
+                    emit flexRxAntennaSelected(slice->sliceId());
+                    slice->setRxAntenna(token);
                 }
-            }
+            });
+            menu->popup(
+                m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())));
         });
         row->addWidget(m_rxAntBtn);
 
@@ -1863,6 +1876,37 @@ QString RxApplet::antennaMenuLabel(const QString& token,
         token, m_radioModel->antennaAliasNeedsDisambiguation(token, options));
 }
 
+QStringList RxApplet::rxAntennaOptions() const
+{
+    QStringList options;
+    auto append = [&options](const QString& token) {
+        if (!token.isEmpty() && !options.contains(token)) {
+            options.append(token);
+        }
+    };
+
+    if (m_slice) {
+        for (const QString& ant : m_slice->rxAntennaList()) {
+            append(ant);
+        }
+    }
+
+    for (const QString& ant : m_antList) {
+        append(ant);
+    }
+
+    if (m_radioModel) {
+        for (const QString& ant : m_radioModel->knownAntennaTokens()) {
+            append(ant);
+        }
+    }
+
+    if (m_slice) {
+        append(m_slice->rxAntenna());
+    }
+    return options;
+}
+
 QStringList RxApplet::txAntennaOptions() const
 {
     QStringList options;
@@ -1986,6 +2030,8 @@ void RxApplet::connectSlice(SliceModel* s)
     connect(s, &SliceModel::rxAntennaChanged, this, [this](const QString& ant) {
         updateAntennaButton(m_rxAntBtn, ant, false);
     });
+    connect(s, &SliceModel::rxAntennaListChanged,
+            this, [this](const QStringList&) { updateAntennaButtons(); });
 
     // TX antenna
     updateAntennaButton(m_txAntBtn, s->txAntenna(), true);

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -32,6 +32,7 @@
 #include <QFormLayout>
 #include "core/AppSettings.h"
 #include <QAction>
+#include <QAccessible>
 #include <QFontMetrics>
 #include <QPainter>
 #include <QPointer>
@@ -328,6 +329,19 @@ RxApplet::RxApplet(QWidget* parent) : QWidget(parent)
     m_sqlManualLevel = std::clamp(
         AppSettings::instance().value("LastManualSquelchLevel", "20").toInt(),
         0, 100);
+    m_accessibleFrequencyTimer.setSingleShot(true);
+    connect(&m_accessibleFrequencyTimer, &QTimer::timeout, this, [this]() {
+        if (!QAccessible::isActive() || !m_freqLabel) {
+            return;
+        }
+        if (m_pendingAccessibleFrequencyText == m_lastAccessibleFrequencyText) {
+            return;
+        }
+        m_lastAccessibleFrequencyText = m_pendingAccessibleFrequencyText;
+        QAccessibleValueChangeEvent event(m_freqLabel,
+                                          m_pendingAccessibleFrequencyText);
+        QAccessible::updateAccessibility(&event);
+    });
     buildUI();
 }
 
@@ -3016,7 +3030,15 @@ void RxApplet::updateFreqLabel()
         return;
 
     if (m_slice->isLockedFeedbackActive()) {
+        m_accessibleFrequencyTimer.stop();
         m_freqLabel->setText(QStringLiteral("LOCKED"));
+        if (QAccessible::isActive()
+            && m_lastAccessibleFrequencyText != QStringLiteral("LOCKED")) {
+            m_lastAccessibleFrequencyText = QStringLiteral("LOCKED");
+            QAccessibleValueChangeEvent event(m_freqLabel,
+                                              QStringLiteral("LOCKED"));
+            QAccessible::updateAccessibility(&event);
+        }
         return;
     }
 
@@ -3024,10 +3046,21 @@ void RxApplet::updateFreqLabel()
     int mhzPart  = static_cast<int>(hz / 1000000);
     int khzPart  = static_cast<int>((hz / 1000) % 1000);
     int hzPart   = static_cast<int>(hz % 1000);
-    m_freqLabel->setText(QString("%1.%2.%3")
+    const QString freqText = QString("%1.%2.%3")
         .arg(mhzPart)
         .arg(khzPart, 3, 10, QChar('0'))
-        .arg(hzPart, 3, 10, QChar('0')));
+        .arg(hzPart, 3, 10, QChar('0'));
+    m_freqLabel->setText(freqText);
+    scheduleFrequencyAnnouncement(freqText);
+}
+
+void RxApplet::scheduleFrequencyAnnouncement(const QString& text)
+{
+    if (!QAccessible::isActive()) {
+        return;
+    }
+    m_pendingAccessibleFrequencyText = text;
+    m_accessibleFrequencyTimer.start(300);
 }
 
 void RxApplet::refreshAllMutedDim()

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -159,6 +159,7 @@ private:
     void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
     void updateAntennaButtons();
     void updateFreqLabel();
+    void scheduleFrequencyAnnouncement(const QString& text);
     QStringList rxAntennaOptions() const;
     QStringList txAntennaOptions() const;
     QString antennaMenuLabel(const QString& token, const QStringList& options) const;
@@ -220,6 +221,9 @@ private:
     QLabel*      m_freqLabel{nullptr};     // frequency readout e.g. "14.289.510"
     QLineEdit*   m_freqEdit{nullptr};
     QStackedWidget* m_freqStack{nullptr};
+    QTimer       m_accessibleFrequencyTimer;
+    QString      m_pendingAccessibleFrequencyText;
+    QString      m_lastAccessibleFrequencyText;
 
     // Filter presets (Hz widths) — per-mode, swapped on mode change
     QVector<int>            m_filterWidths{1800, 2100, 2400, 2700, 3300, 6000};

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -159,6 +159,7 @@ private:
     void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
     void updateAntennaButtons();
     void updateFreqLabel();
+    QStringList rxAntennaOptions() const;
     QStringList txAntennaOptions() const;
     QString antennaMenuLabel(const QString& token, const QStringList& options) const;
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -771,12 +771,36 @@ void SpectrumOverlayMenu::refreshAntennaCombo()
     if (!m_rxAntCmb)
         return;
     const QString cur = currentRxAntennaToken();
-    QStringList options = m_antList;
+    QStringList options;
+    auto append = [&options](const QString& token) {
+        if (!token.isEmpty() && !options.contains(token)) {
+            options.append(token);
+        }
+    };
+
+    SliceModel* targetSlice =
+        antennaTargetSliceForPan(m_radioModel, m_slice, m_panId);
+    if (targetSlice) {
+        for (const QString& token : targetSlice->rxAntennaList()) {
+            append(token);
+        }
+    }
+    for (const QString& token : m_antList) {
+        append(token);
+    }
+    if (m_radioModel) {
+        for (const QString& token : m_radioModel->knownAntennaTokens()) {
+            append(token);
+        }
+    }
+    append(cur);
+    if (options.isEmpty()) {
+        append(QStringLiteral("ANT1"));
+        append(QStringLiteral("ANT2"));
+    }
     if (m_kiwiSdrManager) {
         for (const QString& token : m_kiwiSdrManager->virtualAntennaTokens()) {
-            if (!options.contains(token)) {
-                options.append(token);
-            }
+            append(token);
         }
     }
     QSignalBlocker sb(m_rxAntCmb);
@@ -2270,6 +2294,16 @@ bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
         if (event->type() == QEvent::Wheel
             || event->type() == QEvent::MouseButtonPress
             || event->type() == QEvent::MouseButtonRelease) {
+            if (auto* panel = qobject_cast<QWidget*>(obj)) {
+                if (auto* mouseEvent = dynamic_cast<QMouseEvent*>(event);
+                    mouseEvent && panel->childAt(mouseEvent->pos())) {
+                    return QWidget::eventFilter(obj, event);
+                }
+                if (auto* wheelEvent = dynamic_cast<QWheelEvent*>(event);
+                    wheelEvent && panel->childAt(wheelEvent->position().toPoint())) {
+                    return QWidget::eventFilter(obj, event);
+                }
+            }
             return true;  // consumed
         }
     }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1459,6 +1459,12 @@ void SpectrumWidget::setShowFpsMeters(bool on) {
         }
     }
 }
+
+void SpectrumWidget::setFpsMeterSyncStatsProvider(std::function<QString()> provider) {
+    m_fpsMeterSyncStatsProvider = std::move(provider);
+    updateFpsMeterSyncStatsLabel(true);
+}
+
 void SpectrumWidget::applyFpsMeterVisibility(bool on) {
     m_showFpsMeters = on;
     resetFpsMeterWindow();
@@ -1469,6 +1475,7 @@ void SpectrumWidget::applyFpsMeterVisibility(bool on) {
             m_fpsMeterTimer->stop();
     }
     updateFpsMeterLabels();
+    updateFpsMeterSyncStatsLabel(true);
     markOverlayDirty();
 }
 void SpectrumWidget::resetFpsMeterWindow() {
@@ -1502,8 +1509,10 @@ void SpectrumWidget::updateFpsMeterValues() {
     updateFpsMeterLabels();
 }
 void SpectrumWidget::recordPanadapterFrame() {
-    if (m_showFpsMeters)
+    if (m_showFpsMeters) {
         ++m_panadapterFrameCount;
+        updateFpsMeterSyncStatsLabel();
+    }
 }
 void SpectrumWidget::recordWaterfallFrame(int rows) {
     if (m_showFpsMeters && rows > 0)
@@ -1540,11 +1549,13 @@ void SpectrumWidget::createFpsMeterLabels() {
 
     m_panFpsMeterLabel = makeLabel();
     m_wfFpsMeterLabel = makeLabel();
+    m_syncFpsMeterLabel = makeLabel();
+    m_syncFpsMeterLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     updateFpsMeterLabels();
 }
 
 void SpectrumWidget::updateFpsMeterLabels() {
-    if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel) {
+    if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel || !m_syncFpsMeterLabel) {
         return;
     }
 
@@ -1558,6 +1569,37 @@ void SpectrumWidget::updateFpsMeterLabels() {
     m_wfFpsMeterLabel->setText(QStringLiteral("WF %1 FPS").arg(visibleWaterfallFps, 0, 'f', 1));
     m_panFpsMeterLabel->adjustSize();
     m_wfFpsMeterLabel->adjustSize();
+    updateFpsMeterSyncStatsLabel(true);
+    positionFpsMeterLabels();
+}
+
+void SpectrumWidget::updateFpsMeterSyncStatsLabel(bool force) {
+    if (!m_syncFpsMeterLabel) {
+        return;
+    }
+    if (!force && m_syncFpsMeterUpdateTimer.isValid()
+        && m_syncFpsMeterUpdateTimer.elapsed() < 200) {
+        return;
+    }
+    m_syncFpsMeterUpdateTimer.restart();
+
+    if (!m_showFpsMeters || !m_fpsMeterSyncStatsProvider) {
+        m_syncFpsMeterLabel->clear();
+        m_syncFpsMeterLabel->hide();
+        return;
+    }
+
+    const QString text = m_fpsMeterSyncStatsProvider();
+    if (text.isEmpty()) {
+        m_syncFpsMeterLabel->clear();
+        m_syncFpsMeterLabel->hide();
+        return;
+    }
+
+    if (m_syncFpsMeterLabel->text() != text) {
+        m_syncFpsMeterLabel->setText(text);
+        m_syncFpsMeterLabel->adjustSize();
+    }
     positionFpsMeterLabels();
 }
 
@@ -1569,13 +1611,14 @@ int SpectrumWidget::spectrumPixelHeight() const
 }
 
 void SpectrumWidget::positionFpsMeterLabels() {
-    if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel) {
+    if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel || !m_syncFpsMeterLabel) {
         return;
     }
 
     auto hideMeters = [this]() {
         m_panFpsMeterLabel->hide();
         m_wfFpsMeterLabel->hide();
+        m_syncFpsMeterLabel->hide();
     };
 
     if (!m_showFpsMeters || width() <= 0 || height() <= 0) {
@@ -1596,17 +1639,17 @@ void SpectrumWidget::positionFpsMeterLabels() {
     const QRect wfRect(0, wfY, width(), height() - wfY);
 
     auto positionMeter = [](QLabel* label, const QRect& area,
-                            int bottomInset, int rightInset) {
+                            int bottomInset, int rightInset) -> QRect {
         if (area.width() < 56 || area.height() < 18) {
             label->hide();
-            return;
+            return {};
         }
 
         const QSize labelSize = label->sizeHint();
         if (area.width() < labelSize.width() + rightInset + 12
             || area.height() < labelSize.height() + 8) {
             label->hide();
-            return;
+            return {};
         }
 
         const int plotRight = area.right() - rightInset;
@@ -1627,12 +1670,39 @@ void SpectrumWidget::positionFpsMeterLabels() {
 
         label->move(x, y);
         label->show();
+        return QRect(QPoint(x, y), labelSize);
     };
 
     const int panBottomInset = (m_bandPlanFontSize > 0)
         ? m_bandPlanFontSize + 12
         : 6;
-    positionMeter(m_panFpsMeterLabel, specRect, panBottomInset, DBM_STRIP_W);
+    const QRect panMeterRect =
+        positionMeter(m_panFpsMeterLabel, specRect, panBottomInset, DBM_STRIP_W);
+    if (m_syncFpsMeterLabel->text().isEmpty() || panMeterRect.isEmpty()) {
+        m_syncFpsMeterLabel->hide();
+    } else {
+        const QSize syncSize = m_syncFpsMeterLabel->sizeHint();
+        const int gap = 6;
+        const int minX = specRect.left() + 4;
+        const int minY = specRect.top() + 4;
+        const int maxBottom = specRect.bottom() - 4;
+        const int x = panMeterRect.left() - syncSize.width() - gap;
+        int y = panMeterRect.bottom() - syncSize.height() + 1;
+        if (y < minY) {
+            y = minY;
+        }
+        if (y + syncSize.height() > maxBottom) {
+            y = maxBottom - syncSize.height();
+        }
+
+        if (x < minX || y < minY
+            || specRect.height() < syncSize.height() + 8) {
+            m_syncFpsMeterLabel->hide();
+        } else {
+            m_syncFpsMeterLabel->move(x, y);
+            m_syncFpsMeterLabel->show();
+        }
+    }
     positionMeter(m_wfFpsMeterLabel, wfRect, 6, waterfallStripWidth());
     if (m_overlayMenu) {
         m_overlayMenu->raiseAll();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <QHash>
 #include <QWidget>
 #include <QPushButton>
@@ -304,6 +305,7 @@ public:
     bool showCursorFreq() const { return m_showCursorFreq; }
     void setShowFpsMeters(bool on);
     bool showFpsMeters() const { return m_showFpsMeters; }
+    void setFpsMeterSyncStatsProvider(std::function<QString()> provider);
     void setShowTuneGuides(bool on);
     bool showTuneGuides() const { return m_showTuneGuides; }
     void setExtendedFrequencyLine(bool on);
@@ -651,6 +653,7 @@ private:
     void drawWaterfall(QPainter& p, const QRect& r);
     void createFpsMeterLabels();
     void updateFpsMeterLabels();
+    void updateFpsMeterSyncStatsLabel(bool force = false);
     void positionFpsMeterLabels();
     void positionZoomButtons();
     void drawFreqScale(QPainter& p, const QRect& r);
@@ -1226,6 +1229,9 @@ private:
     double m_kiwiSdrWaterfallFps{0.0};
     QLabel* m_panFpsMeterLabel{nullptr};
     QLabel* m_wfFpsMeterLabel{nullptr};
+    QLabel* m_syncFpsMeterLabel{nullptr};
+    QElapsedTimer m_syncFpsMeterUpdateTimer;
+    std::function<QString()> m_fpsMeterSyncStatsProvider;
     qint64 m_lastMouseMoveNs{0};
 
     // ── TNF markers ────────────────────────────────────────────────────

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -19,9 +19,11 @@
 #include "InteractionSettings.h"
 
 #include <QDateTime>
+#include <QAction>
 #include <QPainter>
 #include <QPainterPath>
 #include <QPushButton>
+#include <QPointer>
 #include <QStyle>
 #include <QStyleOptionSlider>
 #include <QTimer>
@@ -572,44 +574,56 @@ void VfoWidget::buildUI()
     m_rxAntBtn->setFlat(true);
     m_rxAntBtn->setStyleSheet(kFlatBtn + "QPushButton { color: #4488ff; }");
     connect(m_rxAntBtn, &QPushButton::clicked, this, [this] {
-        if (!m_slice) return;
-        QMenu menu(this);
-        const QStringList options = !m_slice->rxAntennaList().isEmpty()
-            ? m_slice->rxAntennaList()
-            : m_antList;
-        QStringList menuOptions = options;
+        if (!m_slice) {
+            return;
+        }
+        QPointer<SliceModel> slice = m_slice;
+        QStringList menuOptions = rxAntennaOptions();
         if (m_kiwiSdrManager) {
-            menuOptions.append(m_kiwiSdrManager->virtualAntennaTokens());
+            for (const QString& ant : m_kiwiSdrManager->virtualAntennaTokens()) {
+                if (!ant.isEmpty() && !menuOptions.contains(ant)) {
+                    menuOptions.append(ant);
+                }
+            }
+        }
+        if (menuOptions.isEmpty()) {
+            menuOptions << QStringLiteral("ANT1") << QStringLiteral("ANT2");
         }
         const QString activeKiwiProfile =
             m_kiwiSdrManager
-                ? m_kiwiSdrManager->assignedProfileForSlice(m_slice->sliceId())
+                ? m_kiwiSdrManager->assignedProfileForSlice(slice->sliceId())
                 : QString();
+        QMenu* menu = new QMenu(m_rxAntBtn);
+        connect(menu, &QMenu::aboutToHide, menu, &QObject::deleteLater);
         for (const QString& ant : menuOptions) {
-            auto* act = menu.addAction(antennaMenuLabel(ant, menuOptions));
+            auto* act = menu->addAction(antennaMenuLabel(ant, menuOptions));
             act->setData(ant);
             act->setCheckable(true);
             const QString profileId = m_kiwiSdrManager
                 ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(ant)
                 : QString();
             act->setChecked(profileId.isEmpty()
-                ? ant == m_slice->rxAntenna() && activeKiwiProfile.isEmpty()
+                ? ant == slice->rxAntenna() && activeKiwiProfile.isEmpty()
                 : profileId == activeKiwiProfile);
             act->setToolTip(ant);
             act->setStatusTip(ant);
         }
-        if (auto* sel = menu.exec(m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())))) {
+        connect(menu, &QMenu::triggered, this, [this, slice](QAction* sel) {
+            if (!sel || !slice) {
+                return;
+            }
             const QString token = sel->data().toString();
             const QString profileId = m_kiwiSdrManager
                 ? m_kiwiSdrManager->profileIdForVirtualAntennaToken(token)
                 : QString();
             if (!profileId.isEmpty()) {
-                emit kiwiRxAntennaSelected(m_slice->sliceId(), profileId);
+                emit kiwiRxAntennaSelected(slice->sliceId(), profileId);
             } else {
-                emit flexRxAntennaSelected(m_slice->sliceId());
-                m_slice->setRxAntenna(token);
+                emit flexRxAntennaSelected(slice->sliceId());
+                slice->setRxAntenna(token);
             }
-        }
+        });
+        menu->popup(m_rxAntBtn->mapToGlobal(QPoint(0, m_rxAntBtn->height())));
     });
     hdr->addWidget(m_rxAntBtn);
 
@@ -3989,6 +4003,8 @@ void VfoWidget::setSlice(SliceModel* slice)
     connect(m_slice, &SliceModel::txAntennaChanged, this, [this](const QString& ant) {
         m_updatingFromModel = true; updateAntennaButton(m_txAntBtn, ant, true); m_updatingFromModel = false;
     });
+    connect(m_slice, &SliceModel::rxAntennaListChanged,
+            this, [this](const QStringList&) { updateAntennaButtons(); });
     connect(m_slice, &SliceModel::txAntennaListChanged,
             this, [this](const QStringList&) { updateAntennaButtons(); });
     // TX slice — toggle between red (active TX) and grey (clickable to set TX)
@@ -5549,6 +5565,37 @@ QString VfoWidget::antennaMenuLabel(const QString& token,
         return token;
     return m_radioModel->antennaDisplayName(
         token, m_radioModel->antennaAliasNeedsDisambiguation(token, options));
+}
+
+QStringList VfoWidget::rxAntennaOptions() const
+{
+    QStringList options;
+    auto append = [&options](const QString& token) {
+        if (!token.isEmpty() && !options.contains(token)) {
+            options.append(token);
+        }
+    };
+
+    if (m_slice) {
+        for (const QString& ant : m_slice->rxAntennaList()) {
+            append(ant);
+        }
+    }
+
+    for (const QString& ant : m_antList) {
+        append(ant);
+    }
+
+    if (m_radioModel) {
+        for (const QString& ant : m_radioModel->knownAntennaTokens()) {
+            append(ant);
+        }
+    }
+
+    if (m_slice) {
+        append(m_slice->rxAntenna());
+    }
+    return options;
 }
 
 QStringList VfoWidget::txAntennaOptions() const

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -311,6 +311,7 @@ private:
     void updateAgcSliderFromSlice();
     void updateAntennaButton(QPushButton* button, const QString& token, bool tx);
     void updateAntennaButtons();
+    QStringList rxAntennaOptions() const;
     QStringList txAntennaOptions() const;
     QString antennaMenuLabel(const QString& token, const QStringList& options) const;
     static QString formatFilterLabel(int hz);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,6 +430,14 @@ int main(int argc, char* argv[])
             automation->setConnectionDialogHost(&window);
             automation->setConnectionPanel(
                 window.findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
+            automation->setSliceReceiveSourceHandler(
+                [&window](const QString& arg) {
+                    return window.automationSetSliceReceiveSource(arg);
+                });
+            automation->setReceiveSyncSnapshotHandler(
+                [&window]() {
+                    return window.automationReceiveSyncSnapshot();
+                });
             if (!automation->start(sockName))
                 automation.reset();
         }

--- a/tests/antenna_alias_test.cpp
+++ b/tests/antenna_alias_test.cpp
@@ -82,6 +82,17 @@ int main(int argc, char** argv)
                                                        QStringLiteral("XVTR")}),
                  "slice parses tx_ant_list");
 
+    slice.applyStatus({{QStringLiteral("rx_ant_list"), QStringLiteral("ANT1,RX_A,RX_B")}});
+    ok &= expect(slice.rxAntennaList() == QStringList({QStringLiteral("ANT1"),
+                                                       QStringLiteral("RX_A"),
+                                                       QStringLiteral("RX_B")}),
+                 "slice parses rx_ant_list");
+
+    slice.setRxAntenna(QStringLiteral("RX_B"));
+    ok &= expect(commands == QStringList({QStringLiteral("slice set 3 rxant=RX_B")}),
+                 "slice RX antenna command keeps canonical token");
+    commands.clear();
+
     slice.setTxAntenna(QStringLiteral("XVTR"));
     ok &= expect(commands == QStringList({QStringLiteral("slice set 3 txant=XVTR")}),
                  "slice TX antenna command keeps canonical token");

--- a/tests/receive_presentation_sync_test.cpp
+++ b/tests/receive_presentation_sync_test.cpp
@@ -1,0 +1,425 @@
+#include "core/ReceivePresentationSync.h"
+
+#include <QByteArray>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "receive_presentation_sync_test: %s\n", message);
+    return 1;
+}
+
+QVector<float> syntheticSignal(int samples)
+{
+    QVector<float> signal;
+    signal.reserve(samples);
+    quint32 state = 0x12345678u;
+    for (int i = 0; i < samples; ++i) {
+        state = state * 1664525u + 1013904223u;
+        const float noise =
+            static_cast<float>((state >> 8) & 0xffffu) / 32768.0f - 1.0f;
+        const float tone =
+            0.35f * std::sin(static_cast<float>(i) * 0.071f)
+            + 0.23f * std::sin(static_cast<float>(i) * 0.173f);
+        signal.append(tone + 0.08f * noise);
+    }
+    return signal;
+}
+
+float syntheticEnvelopeAt(int i)
+{
+    return 0.55f
+           + 0.24f * std::sin(static_cast<float>(i) * 0.009f)
+           + 0.16f * std::max(0.0f,
+                              std::sin(static_cast<float>(i) * 0.041f));
+}
+
+} // namespace
+
+int main()
+{
+    using namespace AetherSDR;
+
+    ReceivePresentationSync sync;
+    if (sync.delayMs(ReceivePresentationSource::Flex,
+                     ReceivePresentationSurface::Audio) != 0
+        || sync.status() != ReceiveSyncStatus::Off) {
+        return fail("disabled sync should not delay presentation");
+    }
+
+    ReceivePresentationSettings settings;
+    settings.enabled = true;
+    settings.baseLatencyMs = 250;
+    settings.manualOffsetMs = 120;
+    sync.setSettings(settings);
+    if (sync.status() != ReceiveSyncStatus::Manual
+        || sync.delayMs(ReceivePresentationSource::Flex,
+                        ReceivePresentationSurface::Waterfall) != 370
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Waterfall) != 250) {
+        return fail("positive manual offset should delay Flex");
+    }
+    if (sync.delayMs(ReceivePresentationSource::Flex,
+                     ReceivePresentationSurface::Decoder) != 0
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Recording) != 0) {
+        return fail("decoder and recording surfaces should stay raw");
+    }
+
+    sync.setManualOffsetMs(-80);
+    if (sync.delayMs(ReceivePresentationSource::Flex,
+                     ReceivePresentationSurface::Meter) != 250
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Meter) != 330) {
+        return fail("negative manual offset should delay KiwiSDR");
+    }
+
+    sync.setMode(ReceiveSyncMode::AutoAssist);
+    sync.setAutoEstimate(ReceiveSyncEstimate{.offsetMs = 640,
+                                             .confidence = 0.90f,
+                                             .valid = true});
+    if (sync.status() != ReceiveSyncStatus::Locked
+        || sync.delayMs(ReceivePresentationSource::Flex,
+                        ReceivePresentationSurface::Audio) != 890
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Audio) != 250) {
+        return fail("locked auto estimate should replace manual offset");
+    }
+
+    sync.setAutoEstimate(ReceiveSyncEstimate{.offsetMs = 640,
+                                             .confidence = 0.10f,
+                                             .valid = true});
+    if (sync.status() != ReceiveSyncStatus::LowConfidence
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Audio) != 330) {
+        return fail("low-confidence auto estimate should fall back to manual");
+    }
+
+    sync.setAutoEstimate(ReceiveSyncEstimate{.offsetMs = 640,
+                                             .confidence = 0.10f,
+                                             .valid = true,
+                                             .driftPpm = 0,
+                                             .held = true});
+    if (sync.status() != ReceiveSyncStatus::Holding
+        || sync.delayMs(ReceivePresentationSource::Flex,
+                        ReceivePresentationSurface::Audio) != 890
+        || sync.delayMs(ReceivePresentationSource::KiwiSdr,
+                        ReceivePresentationSurface::Audio) != 250) {
+        return fail("held auto lock should continue applying the last offset");
+    }
+
+    if (ReceivePresentationSync::adjustedAutoOffsetMs(500, 510, false) != 500) {
+        return fail("near accepted auto estimates should stay inside the deadband");
+    }
+    if (ReceivePresentationSync::adjustedAutoOffsetMs(500, 620, false) != 520) {
+        return fail("near-lock auto estimates should apply a bounded positive step");
+    }
+    if (ReceivePresentationSync::adjustedAutoOffsetMs(500, 360, false) != 480) {
+        return fail("near-lock auto estimates should apply a bounded negative step");
+    }
+    if (ReceivePresentationSync::adjustedAutoOffsetMs(500, 900, true) != 900) {
+        return fail("new locks should apply the candidate offset");
+    }
+
+    const QVector<ReceiveSyncAudioPairEndpoint> oneFlex{
+        ReceiveSyncAudioPairEndpoint{.sliceId = 1,
+                                     .frequencyHz = 14197000}};
+    const QVector<ReceiveSyncAudioPairEndpoint> oneMatchingOneUnmatchedKiwi{
+        ReceiveSyncAudioPairEndpoint{.sliceId = 2,
+                                     .frequencyHz = 14197000,
+                                     .kiwiProfileId = QStringLiteral("kiwi-a")},
+        ReceiveSyncAudioPairEndpoint{.sliceId = 3,
+                                     .frequencyHz = 14200000,
+                                     .kiwiProfileId = QStringLiteral("kiwi-b")}};
+    const ReceiveSyncAudioPairSelection ignoredUnmatched =
+        selectReceiveSyncAudioPair(oneFlex, oneMatchingOneUnmatchedKiwi, 50);
+    if (!ignoredUnmatched.usable()
+        || ignoredUnmatched.kiwiProfileId != QStringLiteral("kiwi-a")
+        || ignoredUnmatched.audibleKiwiCount != 2
+        || ignoredUnmatched.matchingPairCount != 1) {
+        return fail("pair selector should ignore unmatched Kiwi audio sources");
+    }
+
+    const QVector<ReceiveSyncAudioPairEndpoint> twoMatchingKiwis{
+        ReceiveSyncAudioPairEndpoint{.sliceId = 2,
+                                     .frequencyHz = 14197000,
+                                     .kiwiProfileId = QStringLiteral("kiwi-a")},
+        ReceiveSyncAudioPairEndpoint{.sliceId = 3,
+                                     .frequencyHz = 14197020,
+                                     .kiwiProfileId = QStringLiteral("kiwi-b")}};
+    const ReceiveSyncAudioPairSelection ambiguousKiwis =
+        selectReceiveSyncAudioPair(oneFlex, twoMatchingKiwis, 50);
+    if (!ambiguousKiwis.ambiguous()
+        || ambiguousKiwis.reason != QStringLiteral("multipleFrequencyMatches")) {
+        return fail("pair selector should reject multiple matching Kiwi sources");
+    }
+
+    const QVector<ReceiveSyncAudioPairEndpoint> twoFlex{
+        ReceiveSyncAudioPairEndpoint{.sliceId = 1,
+                                     .frequencyHz = 14197000},
+        ReceiveSyncAudioPairEndpoint{.sliceId = 4,
+                                     .frequencyHz = 14250000}};
+    const ReceiveSyncAudioPairSelection ambiguousFlex =
+        selectReceiveSyncAudioPair(twoFlex, oneMatchingOneUnmatchedKiwi, 50);
+    if (!ambiguousFlex.ambiguous()
+        || ambiguousFlex.reason != QStringLiteral("multipleAudibleFlex")) {
+        return fail("pair selector should reject mixed Flex audio");
+    }
+
+    if (receivePresentationVisualQueueKey(
+            ReceivePresentationSource::Flex,
+            ReceivePresentationSurface::Waterfall,
+            QStringLiteral("0x21"))
+            != QStringLiteral("flex:waterfall:0x21")
+        || receivePresentationVisualQueueKey(
+               ReceivePresentationSource::KiwiSdr,
+               ReceivePresentationSurface::Waterfall,
+               QStringLiteral("kiwi-a"))
+               != QStringLiteral("kiwi:waterfall:kiwi-a")
+        || receivePresentationVisualQueueKey(
+               ReceivePresentationSource::KiwiSdr,
+               ReceivePresentationSurface::Meter,
+               QStringLiteral("  "))
+               != QStringLiteral("kiwi:meter")) {
+        return fail("visual queue keys should include source-specific ids");
+    }
+    if (receivePresentationVisualQueueKey(
+            ReceivePresentationSource::KiwiSdr,
+            ReceivePresentationSurface::Waterfall,
+            QStringLiteral("kiwi-a"))
+        == receivePresentationVisualQueueKey(
+            ReceivePresentationSource::KiwiSdr,
+            ReceivePresentationSurface::Waterfall,
+            QStringLiteral("kiwi-b"))) {
+        return fail("different Kiwi profiles should use different visual queues");
+    }
+
+    if (receivePresentationExternalKiwiDelayMs(
+            QStringLiteral("kiwi-a"), QStringLiteral("kiwi-a"), 730)
+            != 730
+        || receivePresentationExternalKiwiDelayMs(
+               QStringLiteral("kiwi-b"), QStringLiteral("kiwi-a"), 730)
+               != 0
+        || receivePresentationExternalKiwiDelayMs(
+               QStringLiteral("kiwi-a"), QStringLiteral("kiwi-b"), 730)
+               != 0
+        || receivePresentationExternalKiwiDelayMs(
+               QStringLiteral("kiwi-b"), QStringLiteral("kiwi-b"), 730)
+               != 730) {
+        return fail("only the matched Kiwi profile should receive sync delay");
+    }
+    if (receivePresentationExternalKiwiDelayMs(
+            QStringLiteral("kiwi-a"), QString(), 730)
+            != 730
+        || receivePresentationExternalKiwiDelayMs(
+               QStringLiteral("kiwi-b"), QString(), 730)
+               != 730) {
+        return fail("untargeted Kiwi delay should apply to every external Kiwi profile");
+    }
+    if (receivePresentationExternalKiwiDelayMs(
+            QStringLiteral("kiwi-a"), QStringLiteral("kiwi-a"), -20)
+        != 0) {
+        return fail("external Kiwi delay routing should clamp negative delays");
+    }
+
+    if (!receivePresentationShouldPrebufferAfterDelayChange(120, 360, true,
+                                                            false)
+        || receivePresentationShouldPrebufferAfterDelayChange(120, 360, true,
+                                                             true)
+        || receivePresentationShouldPrebufferAfterDelayChange(360, 120, true,
+                                                             false)
+        || receivePresentationShouldPrebufferAfterDelayChange(120, 360, false,
+                                                             false)) {
+        return fail("delay growth should prebuffer only empty audible sources");
+    }
+
+    ReceivePresentationQueue<QByteArray> queue;
+    queue.enqueue({.source = ReceivePresentationSource::Flex,
+                   .surface = ReceivePresentationSurface::Audio,
+                   .sourceId = QStringLiteral("flex"),
+                   .arrivalMs = 1000,
+                   .dueMs = 1300,
+                   .sequence = 2,
+                   .payload = QByteArray("late")});
+    queue.enqueue({.source = ReceivePresentationSource::KiwiSdr,
+                   .surface = ReceivePresentationSurface::Meter,
+                   .sourceId = QStringLiteral("kiwi"),
+                   .arrivalMs = 1000,
+                   .dueMs = 1200,
+                   .sequence = 1,
+                   .payload = QByteArray("early")});
+    if (queue.releaseDue(1199).size() != 0) {
+        return fail("queue should hold items before their due time");
+    }
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> first =
+        queue.releaseDue(1200);
+    if (first.size() != 1 || first[0].payload != QByteArray("early")) {
+        return fail("queue should release earliest due item first");
+    }
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> second =
+        queue.releaseDue(1400);
+    if (second.size() != 1 || second[0].payload != QByteArray("late")) {
+        return fail("queue should release remaining due items");
+    }
+
+    ReceivePresentationQueue<QByteArray> orderedQueue;
+    orderedQueue.enqueue({.source = ReceivePresentationSource::Flex,
+                          .surface = ReceivePresentationSurface::Waterfall,
+                          .sourceId = QStringLiteral("flex:waterfall"),
+                          .arrivalMs = 1000,
+                          .dueMs = 1200,
+                          .sequence = 2,
+                          .payload = QByteArray("second")});
+    orderedQueue.enqueue({.source = ReceivePresentationSource::Flex,
+                          .surface = ReceivePresentationSurface::Waterfall,
+                          .sourceId = QStringLiteral("flex:waterfall"),
+                          .arrivalMs = 999,
+                          .dueMs = 1200,
+                          .sequence = 1,
+                          .payload = QByteArray("first")});
+    orderedQueue.enqueue({.source = ReceivePresentationSource::Flex,
+                          .surface = ReceivePresentationSurface::Waterfall,
+                          .sourceId = QStringLiteral("flex:waterfall"),
+                          .arrivalMs = 1001,
+                          .dueMs = 1200,
+                          .sequence = 3,
+                          .payload = QByteArray("third")});
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> orderedFirst =
+        orderedQueue.releaseDue(1200, 2);
+    if (orderedFirst.size() != 2
+        || orderedFirst[0].payload != QByteArray("first")
+        || orderedFirst[1].payload != QByteArray("second")) {
+        return fail("queue should preserve sequence for equal due times");
+    }
+    if (orderedQueue.size() != 1) {
+        return fail("limited queue release should leave remaining due items queued");
+    }
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> orderedSecond =
+        orderedQueue.releaseDue(1200);
+    if (orderedSecond.size() != 1
+        || orderedSecond[0].payload != QByteArray("third")) {
+        return fail("queue should release remaining equal-due item in order");
+    }
+
+    ReceivePresentationQueue<QByteArray> trimmedQueue;
+    trimmedQueue.enqueue({.dueMs = 1000, .sequence = 1,
+                          .payload = QByteArray("drop")});
+    trimmedQueue.enqueue({.dueMs = 1001, .sequence = 2,
+                          .payload = QByteArray("keep-a")});
+    trimmedQueue.enqueue({.dueMs = 1002, .sequence = 3,
+                          .payload = QByteArray("keep-b")});
+    trimmedQueue.trimToSize(2);
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> trimmed =
+        trimmedQueue.releaseDue(2000);
+    if (trimmed.size() != 2
+        || trimmed[0].payload != QByteArray("keep-a")
+        || trimmed[1].payload != QByteArray("keep-b")) {
+        return fail("queue trim should drop oldest pending visual items");
+    }
+
+    ReceivePresentationQueue<QByteArray> sourceQueue;
+    const QString kiwiAKey = receivePresentationVisualQueueKey(
+        ReceivePresentationSource::KiwiSdr,
+        ReceivePresentationSurface::Waterfall,
+        QStringLiteral("kiwi-a"));
+    const QString kiwiBKey = receivePresentationVisualQueueKey(
+        ReceivePresentationSource::KiwiSdr,
+        ReceivePresentationSurface::Waterfall,
+        QStringLiteral("kiwi-b"));
+    sourceQueue.enqueue({.source = ReceivePresentationSource::KiwiSdr,
+                         .surface = ReceivePresentationSurface::Waterfall,
+                         .sourceId = kiwiAKey,
+                         .dueMs = 1000,
+                         .sequence = 1,
+                         .payload = QByteArray("kiwi-a")});
+    sourceQueue.enqueue({.source = ReceivePresentationSource::KiwiSdr,
+                         .surface = ReceivePresentationSurface::Waterfall,
+                         .sourceId = kiwiBKey,
+                         .dueMs = 1001,
+                         .sequence = 2,
+                         .payload = QByteArray("kiwi-b")});
+    sourceQueue.enqueue({.source = ReceivePresentationSource::Flex,
+                         .surface = ReceivePresentationSurface::Waterfall,
+                         .sourceId = QStringLiteral("flex:waterfall:0x21"),
+                         .dueMs = 1002,
+                         .sequence = 3,
+                         .payload = QByteArray("flex")});
+    const qsizetype removed = sourceQueue.removeIf(
+        [&](const ReceivePresentationQueuedItem<QByteArray>& item) {
+            return item.source == ReceivePresentationSource::KiwiSdr
+                   && item.sourceId == kiwiAKey;
+        });
+    const QVector<ReceivePresentationQueuedItem<QByteArray>> remainingSources =
+        sourceQueue.releaseDue(2000);
+    if (removed != 1 || remainingSources.size() != 2
+        || remainingSources[0].payload != QByteArray("kiwi-b")
+        || remainingSources[1].payload != QByteArray("flex")) {
+        return fail("source-specific visual queue clear should keep other sources");
+    }
+
+    constexpr int sampleRate = 1000;
+    constexpr int delayMs = 120;
+    const QVector<float> flex = syntheticSignal(5000);
+    QVector<float> kiwi(flex.size(), 0.0f);
+    const int delaySamples = delayMs * sampleRate / 1000;
+    for (int i = 0; i + delaySamples < flex.size(); ++i) {
+        kiwi[i + delaySamples] = flex[i];
+    }
+
+    ReceiveAudioDelayEstimator estimator(
+        ReceiveAudioDelayEstimator::Config{.sampleRateHz = sampleRate,
+                                           .maxOffsetMs = 300,
+                                           .minOverlapMs = 150,
+                                           .minPeakCorrelation = 0.50f,
+                                           .minConfidence = 0.10f});
+    const ReceiveAudioDelayEstimate estimate = estimator.estimate(flex, kiwi);
+    if (!estimate.valid || std::abs(estimate.offsetMs - delayMs) > 2) {
+        return fail("audio estimator should recover a known positive delay");
+    }
+
+    QVector<float> flexEnvelopeSignal;
+    QVector<float> kiwiEnvelopeSignal(flex.size(), 0.0f);
+    flexEnvelopeSignal.reserve(flex.size());
+    for (int i = 0; i < flex.size(); ++i) {
+        const float env = syntheticEnvelopeAt(i);
+        flexEnvelopeSignal.append(
+            env * std::sin(static_cast<float>(i) * 0.071f));
+    }
+    for (int i = 0; i + delaySamples < flexEnvelopeSignal.size(); ++i) {
+        const float env = syntheticEnvelopeAt(i);
+        kiwiEnvelopeSignal[i + delaySamples] =
+            env * std::sin(static_cast<float>(i) * 0.113f + 0.7f);
+    }
+    ReceiveAudioDelayEstimator envelopeEstimator(
+        ReceiveAudioDelayEstimator::Config{.sampleRateHz = sampleRate,
+                                           .maxOffsetMs = 300,
+                                           .minOverlapMs = 150,
+                                           .minPeakCorrelation = 0.08f,
+                                           .minConfidence = 0.05f});
+    const ReceiveAudioDelayEstimate envelopeEstimate =
+        envelopeEstimator.estimate(flexEnvelopeSignal, kiwiEnvelopeSignal);
+    if (!envelopeEstimate.valid
+        || std::abs(envelopeEstimate.offsetMs - delayMs) > 15) {
+        return fail("audio estimator should recover envelope-matched delay");
+    }
+
+    QVector<float> unrelatedCarrier(flex.size(), 0.0f);
+    for (int i = 0; i < unrelatedCarrier.size(); ++i) {
+        unrelatedCarrier[i] =
+            std::sin(static_cast<float>(i) * 0.113f + 0.7f);
+    }
+    const ReceiveAudioDelayEstimate unrelatedEstimate =
+        envelopeEstimator.estimate(flexEnvelopeSignal, unrelatedCarrier);
+    if (unrelatedEstimate.confidence >= 0.18f
+        && unrelatedEstimate.peakCorrelation >= 0.20f) {
+        return fail("carrier-only mismatch should not be stable-lock eligible");
+    }
+
+    return 0;
+}

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -23,8 +23,11 @@ Usage:
     python tools/automation_probe.py connect show
     python tools/automation_probe.py connect local first
     python tools/automation_probe.py connect wait 30000
+    python tools/automation_probe.py get sync
     python tools/automation_probe.py grab SpectrumWidget /tmp/pan.png
     python tools/automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png
+    python tools/automation_probe.py audioCapture start 3000 raw,post,final
+    python tools/automation_probe.py audioCapture read /tmp/aether-audio.json
 """
 
 import argparse
@@ -97,20 +100,26 @@ def main():
                "  automation_probe.py connect local first\n"
                "  automation_probe.py connect wait 30000\n"
                "  automation_probe.py get radio\n"
+               "  automation_probe.py get sync\n"
                "  automation_probe.py get slice active frequency\n"
+               "  automation_probe.py slice rxsource 7 K4JK\n"
                "  automation_probe.py invoke 'Master volume' setValue 35\n"
+               "  automation_probe.py audioCapture start 3000 raw,post,final\n"
+               "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png",
         formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command", nargs="?", default="demo",
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
-                             "connect", "disconnect"],
+                             "connect", "disconnect", "slice", "audioCapture"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
                          "invoke <target> <action> [value] | "
                          "get <model> [selector] [property] | "
-                         "connect <list|show|hide|local|ip|wait> [args]")
+                         "connect <list|show|hide|local|ip|wait> [args] | "
+                         "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
+                         "audioCapture <start|stop|status|read> [args]")
     ap.add_argument("--socket", help="override the bridge socket path")
     ap.add_argument("--out", default=".", help="output dir for demo artifacts")
     args = ap.parse_args()
@@ -175,6 +184,24 @@ def main():
 
         elif args.command == "disconnect":
             print(json.dumps(bridge.request({"cmd": "disconnect"}), indent=2))
+
+        elif args.command == "slice":
+            if not args.rest:
+                sys.exit("error: slice needs an action")
+            req = {"cmd": "slice", "action": args.rest[0]}
+            if len(args.rest) > 1:
+                req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "audioCapture":
+            action = args.rest[0] if args.rest else "status"
+            req = {"cmd": "audioCapture", "action": action}
+            if len(args.rest) > 1:
+                if action == "read" and len(args.rest) == 2:
+                    req["path"] = args.rest[1]
+                else:
+                    req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
 
         else:  # demo: produce the Phase-0 deliverables
             os.makedirs(args.out, exist_ok=True)


### PR DESCRIPTION
## Summary

Adds Receive Sync support for aligning Flex and Kiwi receive audio with the matching visual presentation path. Auto Assist estimates the Flex/Kiwi offset from the received audio itself using local DSP time-delay estimation: Generalized Cross-Correlation with Phase Transform (GCC-PHAT) plus an envelope/normalized-correlation fallback. It applies bounded per-source presentation delays only to the matched audio-enabled Flex/Kiwi pair on the same frequency, leaves unmatched Kiwi audio sources out of the sync path, preserves held/coasting locks through temporary ambiguity, and avoids audio or waterfall interruptions while tuning or changing receive sources.

The change also adds source-specific visual queues for waterfall/FFT/meter timing, a minimal spectrum overlay status, the **Sync Kiwi Audio & Display** label with Auto Assist enabled by default for fresh settings, nested receive-sync settings persistence, focused regression coverage, and automation diagnostics for receive-sync troubleshooting. Automation updates include `get sync` bridge snapshots, bounded PCM `audioCapture` sampling at raw/post-DSP/output/final audio points, `slice rxsource` support for user-defined Kiwi receiver/profile names, `tools/automation_probe.py` updates, and automation bridge documentation.

## Constitution principle honored

Principle IV — KiwiSDR integration remains clean-room: this implementation uses observed protocol/app behavior and local audio correlation, not copied Kiwi server code or proprietary reverse-engineered sources.

Principle V — Receive Sync preferences are stored under one `AppSettings["ReceivePresentationSync"]` JSON object, with migration from temporary local flat keys used during development.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR receive_presentation_sync_test`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing focused tests pass (`ctest --test-dir build -R '^(receive_presentation_sync_test|kiwi_sdr_protocol_test|antenna_alias_test)$' --output-on-failure`)
- [x] Reproduction steps documented if user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
