### PR TITLE
[codex] Stabilize diversity VFO flag placement

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -301,6 +301,32 @@ void setStatusBarStationText(QLabel* label, const QString& text)
     label->setMinimumWidth(label->sizeHint().width() + 2);
 }
 
+QString vfoFrequencyText(double mhz)
+{
+    const long long hz = static_cast<long long>(std::round(mhz * 1e6));
+    return QString("%1.%2.%3")
+        .arg(static_cast<int>(hz / 1000000))
+        .arg(static_cast<int>((hz / 1000) % 1000), 3, 10, QChar('0'))
+        .arg(static_cast<int>(hz % 1000), 3, 10, QChar('0'));
+}
+
+bool sameDiversityReceivePair(const SliceModel* slice, const SliceModel* other)
+{
+    if (!slice || !other || slice == other
+        || !slice->diversity() || !other->diversity()) {
+        return false;
+    }
+
+    const bool parentChildPair =
+        (slice->isDiversityParent() && other->isDiversityChild())
+        || (slice->isDiversityChild() && other->isDiversityParent());
+    if (parentChildPair) {
+        return true;
+    }
+
+    return !slice->panId().isEmpty() && slice->panId() == other->panId();
+}
+
 #ifdef HAVE_HIDAPI
 // tmate2*DefaultAction helpers moved to MainWindow_Controllers.cpp (#3351 Phase 2a).
 #endif
@@ -5673,31 +5699,44 @@ void MainWindow::logTunePolicyDecision(const char* source, TuneIntent intent,
         << " animationMs=" << result.animationDurationMs;
 }
 
-void MainWindow::mirrorDiversityChildFrequency(SliceModel* slice, double mhz)
+void MainWindow::pushSliceFrequencyToOverlays(SliceModel* slice, double mhz)
 {
-    if (!slice || !slice->isDiversityParent())
+    if (!slice) {
         return;
+    }
 
-    long long hz = static_cast<long long>(std::round(mhz * 1e6));
-    const QString freqStr = QString("%1.%2.%3")
-        .arg(static_cast<int>(hz / 1000000))
-        .arg(static_cast<int>((hz / 1000) % 1000), 3, 10, QChar('0'))
-        .arg(static_cast<int>(hz % 1000), 3, 10, QChar('0'));
-
-    for (auto* other : m_radioModel.slices()) {
-        if (!other->isDiversityChild() || other->sliceId() == slice->sliceId())
-            continue;
-        auto* sw = spectrumForSlice(other);
-        if (!sw)
-            continue;
-        if (auto* vfo = sw->vfoWidget(other->sliceId()))
+    const QString freqStr = vfoFrequencyText(mhz);
+    auto pushOne = [this, mhz, &freqStr](SliceModel* s) {
+        if (!s) {
+            return;
+        }
+        SpectrumWidget* sw = spectrumForSlice(s);
+        if (!sw) {
+            return;
+        }
+        if (VfoWidget* vfo = sw->vfoWidget(s->sliceId())) {
             vfo->freqLabel()->setText(freqStr);
-        sw->setSliceOverlay(other->sliceId(), mhz,
-            other->filterLow(), other->filterHigh(),
-            other->isTxSlice(), false,
-            other->mode(), other->rttyMark(), other->rttyShift(),
-            other->ritOn(), other->ritFreq(),
-            other->xitOn(), other->xitFreq());
+        }
+        sw->setSliceOverlay(s->sliceId(), mhz,
+            s->filterLow(), s->filterHigh(),
+            s->isTxSlice(), s->sliceId() == m_activeSliceId,
+            s->mode(), s->rttyMark(), s->rttyShift(),
+            s->ritOn(), s->ritFreq(),
+            s->xitOn(), s->xitFreq(),
+            s->diversity(), s->isDiversityParent(),
+            s->isDiversityChild(), s->diversityIndex());
+    };
+
+    pushOne(slice);
+    if (!slice->diversity()) {
+        return;
+    }
+
+    for (SliceModel* other : m_radioModel.slices()) {
+        if (!sameDiversityReceivePair(slice, other)) {
+            continue;
+        }
+        pushOne(other);
     }
 }
 
@@ -5765,7 +5804,7 @@ bool MainWindow::tuneBlockedByGuards(SliceModel* slice)
         auto* sw = spectrumForSlice(slice);
         if (slice->sliceId() == m_activeSliceId && sw) {
             m_updatingFromModel = true;
-            sw->setVfoFrequency(slice->frequency());
+            pushSliceFrequencyToOverlays(slice, slice->frequency());
             m_updatingFromModel = false;
         }
         return true;
@@ -5782,7 +5821,6 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
         return;
 
     const double oldFreqMhz = slice->frequency();
-    auto* sw = spectrumForSlice(slice);
 
     // Absolute-target intents (typed VFO entry, spectrum click, spot recall,
     // bandstack recall) must invalidate any in-flight encoder accumulator.
@@ -5799,16 +5837,14 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
 #endif
     }
 
-    if (slice->sliceId() == m_activeSliceId && sw)
-        sw->setVfoFrequency(mhz);
+    pushSliceFrequencyToOverlays(slice, mhz);
 
     const BandStackPreselectResult bandPreselect =
         (intent == TuneIntent::CommandedTargetCenter)
             ? preselectBandStackForTune(slice, mhz, source)
             : BandStackPreselectResult::NotNeeded;
     if (bandPreselect == BandStackPreselectResult::Unsupported) {
-        if (slice->sliceId() == m_activeSliceId && sw)
-            sw->setVfoFrequency(oldFreqMhz);
+        pushSliceFrequencyToOverlays(slice, oldFreqMhz);
         return;
     }
 
@@ -5819,12 +5855,8 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
             auto* pendingSlice = m_radioModel.slice(sliceId);
             if (!pendingSlice || pendingSlice->isLocked() || m_swrSweep.running)
                 return;
-            if (pendingSlice->sliceId() == m_activeSliceId) {
-                if (auto* pendingSw = spectrumForSlice(pendingSlice))
-                    pendingSw->setVfoFrequency(mhz);
-            }
+            pushSliceFrequencyToOverlays(pendingSlice, mhz);
             pendingSlice->tuneAndRecenter(mhz);
-            mirrorDiversityChildFrequency(pendingSlice, mhz);
 
             const QByteArray sourceUtf8 = sourceName.toUtf8();
             const char* delayedSource = sourceUtf8.constData();
@@ -5839,7 +5871,6 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
     }
 
     slice->setFrequency(mhz);
-    mirrorDiversityChildFrequency(slice, mhz);
 
     const TuneCenteringResult result =
         (intent == TuneIntent::IncrementalTune)
@@ -5964,7 +5995,9 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
             sw->setSliceOverlay(sl->sliceId(), sl->frequency(),
                 sl->filterLow(), sl->filterHigh(), sl->isTxSlice(), isActive,
                 sl->mode(), sl->rttyMark(), sl->rttyShift(),
-                sl->ritOn(), sl->ritFreq(), sl->xitOn(), sl->xitFreq());
+                sl->ritOn(), sl->ritFreq(), sl->xitOn(), sl->xitFreq(),
+                sl->diversity(), sl->isDiversityParent(),
+                sl->isDiversityChild(), sl->diversityIndex());
     }
 
     // QSO recorder: track active slice for frequency/mode metadata (#1297)
@@ -6128,7 +6161,9 @@ void MainWindow::pushSliceOverlay(SliceModel* s)
         s->filterLow(), s->filterHigh(), s->isTxSlice(),
         s->sliceId() == m_activeSliceId,
         s->mode(), s->rttyMark(), s->rttyShift(),
-        s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());
+        s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq(),
+        s->diversity(), s->isDiversityParent(),
+        s->isDiversityChild(), s->diversityIndex());
 }
 
 void MainWindow::syncTxWaterfallSliceToSpectrums()
@@ -7453,7 +7488,7 @@ void MainWindow::centerActiveSliceInPanadapter(bool forceRadioCenter, double cen
     // Keep the local spectrum centered immediately so the active slice marker
     // is visible before the radio's status echo arrives.
     sw->setFrequencyRange(targetMhz, bandwidthMhz);
-    sw->setVfoFrequency(targetMhz);
+    pushSliceFrequencyToOverlays(s, targetMhz);
 
     if (forceRadioCenter && m_radioModel.isConnected()) {
         m_radioModel.sendCommand(

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -310,23 +310,6 @@ QString vfoFrequencyText(double mhz)
         .arg(static_cast<int>(hz % 1000), 3, 10, QChar('0'));
 }
 
-bool sameDiversityReceivePair(const SliceModel* slice, const SliceModel* other)
-{
-    if (!slice || !other || slice == other
-        || !slice->diversity() || !other->diversity()) {
-        return false;
-    }
-
-    const bool parentChildPair =
-        (slice->isDiversityParent() && other->isDiversityChild())
-        || (slice->isDiversityChild() && other->isDiversityParent());
-    if (parentChildPair) {
-        return true;
-    }
-
-    return !slice->panId().isEmpty() && slice->panId() == other->panId();
-}
-
 #ifdef HAVE_HIDAPI
 // tmate2*DefaultAction helpers moved to MainWindow_Controllers.cpp (#3351 Phase 2a).
 #endif
@@ -454,6 +437,24 @@ int windowsResizeBorderThickness(HWND hwnd)
 // Pure formatting / parsing helpers formerly defined here as file-scope
 // statics now live in MainWindowHelpers.{h,cpp} (#3351 Phase 0). Only
 // helpers coupled to the mutable shortcut-lease state below remain.
+
+bool MainWindow::isSameDiversityReceivePair(const SliceModel* slice,
+                                            const SliceModel* other)
+{
+    if (!slice || !other || slice == other
+        || !slice->diversity() || !other->diversity()) {
+        return false;
+    }
+
+    const bool parentChildPair =
+        (slice->isDiversityParent() && other->isDiversityChild())
+        || (slice->isDiversityChild() && other->isDiversityParent());
+    if (parentChildPair) {
+        return true;
+    }
+
+    return !slice->panId().isEmpty() && slice->panId() == other->panId();
+}
 
 // ─── Shortcut guard (file-scope for use as std::function<bool()>) ───────────
 
@@ -5733,7 +5734,7 @@ void MainWindow::pushSliceFrequencyToOverlays(SliceModel* slice, double mhz)
     }
 
     for (SliceModel* other : m_radioModel.slices()) {
-        if (!sameDiversityReceivePair(slice, other)) {
+        if (!isSameDiversityReceivePair(slice, other)) {
             continue;
         }
         pushOne(other);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -298,6 +298,8 @@ private:
                                double oldFreqMhz, double newFreqMhz,
                                const TuneCenteringResult& result) const;
     void pushSliceFrequencyToOverlays(SliceModel* slice, double mhz);
+    static bool isSameDiversityReceivePair(const SliceModel* slice,
+                                           const SliceModel* other);
     // Pan-follow-VFO (#989): if mhz is outside the visible pan window, apply
     // the new center locally (immediate repaint) and send the radio command.
     TuneCenteringResult panFollowVfo(SliceModel* s, double mhz, const char* source);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -297,7 +297,7 @@ private:
     void logTunePolicyDecision(const char* source, TuneIntent intent,
                                double oldFreqMhz, double newFreqMhz,
                                const TuneCenteringResult& result) const;
-    void mirrorDiversityChildFrequency(SliceModel* slice, double mhz);
+    void pushSliceFrequencyToOverlays(SliceModel* slice, double mhz);
     // Pan-follow-VFO (#989): if mhz is outside the visible pan window, apply
     // the new center locally (immediate repaint) and send the radio command.
     TuneCenteringResult panFollowVfo(SliceModel* s, double mhz, const char* source);
@@ -1122,6 +1122,9 @@ private:
     // mid-tick made Pan Lock appear to "fall out" after the drag. The drag-end
     // handler recenters once so Pan Lock re-asserts. (user-reported)
     bool m_sliceDragInProgress{false};
+    int m_sliceDragTargetSliceId{-1};
+    double m_sliceDragTargetMhz{0.0};
+    qint64 m_sliceDragEchoHoldUntilMs{0};
     void setPanFollow(bool on);
     void recenterPanFollowOnSlice0();
 

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1354,7 +1354,7 @@ void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
             m_flexTargetMhz = snapped / 1e6;
         }
         m_flexTargetMhz += steps * stepHz / 1e6;
-        if (sw) sw->setVfoFrequency(m_flexTargetMhz);
+        pushSliceFrequencyToOverlays(s, m_flexTargetMhz);
         if (!m_flexCoalesceTimer.isActive())
             m_flexCoalesceTimer.start();
     } else if (actionId == "WheelRit") {
@@ -2367,7 +2367,7 @@ void MainWindow::wireExternalControllers()
                 m_midiTuneTargetMhz = snapped / 1e6;
             }
             m_midiTuneTargetMhz += steps * stepHz / 1e6;
-            if (spectrum()) spectrum()->setVfoFrequency(m_midiTuneTargetMhz);
+            pushSliceFrequencyToOverlays(s, m_midiTuneTargetMhz);
             m_midiTuneIdleTimer.start();
             applyTuneRequest(s, m_midiTuneTargetMhz, TuneIntent::IncrementalTune,
                              "midi-relative");

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -573,16 +573,72 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // HID encoder frequency tuning routes through applyFlexControlWheelAction,
         // so m_flexCoalesceTimer above already covers it.
         const bool memoryRevealPending = (m_pendingMemoryRevealSliceId == s->sliceId());
-        if (activeTuning && s->sliceId() == m_activeSliceId && !memoryRevealPending)
+        const bool activeDiversityPartner = [this, s]() {
+            SliceModel* active = m_radioModel.slice(m_activeSliceId);
+            if (!active || active == s || !active->diversity() || !s->diversity()) {
+                return false;
+            }
+
+            const bool parentChildPair =
+                (active->isDiversityParent() && s->isDiversityChild())
+                || (active->isDiversityChild() && s->isDiversityParent());
+            if (parentChildPair) {
+                return true;
+            }
+
+            return !active->panId().isEmpty() && active->panId() == s->panId();
+        }();
+        const bool dragDiversityPartner = [this, s]() {
+            SliceModel* dragTarget = m_radioModel.slice(m_sliceDragTargetSliceId);
+            if (!dragTarget || dragTarget == s
+                || !dragTarget->diversity() || !s->diversity()) {
+                return false;
+            }
+
+            const bool parentChildPair =
+                (dragTarget->isDiversityParent() && s->isDiversityChild())
+                || (dragTarget->isDiversityChild() && s->isDiversityParent());
+            if (parentChildPair) {
+                return true;
+            }
+
+            return !dragTarget->panId().isEmpty() && dragTarget->panId() == s->panId();
+        }();
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        const bool dragEchoHoldActive =
+            m_sliceDragInProgress
+            || (m_sliceDragEchoHoldUntilMs > 0 && nowMs < m_sliceDragEchoHoldUntilMs);
+        const bool dragTargetSlice =
+            m_sliceDragTargetSliceId >= 0
+            && (s->sliceId() == m_sliceDragTargetSliceId || dragDiversityPartner);
+        if (dragEchoHoldActive && dragTargetSlice
+            && m_sliceDragTargetMhz > 0.0 && !memoryRevealPending) {
+            const int sliceId = s->sliceId();
+            const double displayMhz = m_sliceDragTargetMhz;
+            QTimer::singleShot(0, this, [this, sliceId, displayMhz]() {
+                if (m_sliceDragTargetMhz <= 0.0) {
+                    return;
+                }
+                if (!m_sliceDragInProgress
+                    && QDateTime::currentMSecsSinceEpoch() >= m_sliceDragEchoHoldUntilMs) {
+                    return;
+                }
+                SliceModel* slice = m_radioModel.slice(sliceId);
+                if (!slice) {
+                    return;
+                }
+                pushSliceFrequencyToOverlays(slice, displayMhz);
+            });
             return;
+        }
+        if (activeTuning
+            && (s->sliceId() == m_activeSliceId || activeDiversityPartner)
+            && !memoryRevealPending) {
+            return;
+        }
 
         m_updatingFromModel = true;
-        if (auto* sw = spectrumForSlice(s))
-            sw->setSliceOverlay(s->sliceId(), mhz,
-                s->filterLow(), s->filterHigh(), s->isTxSlice(),
-                s->sliceId() == m_activeSliceId,
-                s->mode(), s->rttyMark(), s->rttyShift(),
-                s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());
+        pushSliceFrequencyToOverlays(s, mhz);
         m_updatingFromModel = false;
         if (s->isTxSlice())
             syncTxWaterfallSliceToSpectrums();
@@ -636,7 +692,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
         sw->setSliceOverlay(s->sliceId(), s->frequency(),
             lo, hi, s->isTxSlice(), s->sliceId() == m_activeSliceId,
             s->mode(), s->rttyMark(), s->rttyShift(),
-            s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());
+            s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq(),
+            s->diversity(), s->isDiversityParent(),
+            s->isDiversityChild(), s->diversityIndex());
         if (s->isTxSlice())
             syncTxWaterfallSliceToSpectrums();
     });
@@ -687,7 +745,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 s->filterLow(), s->filterHigh(), tx,
                 s->sliceId() == m_activeSliceId,
                 s->mode(), s->rttyMark(), s->rttyShift(),
-                s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq());
+                s->ritOn(), s->ritFreq(), s->xitOn(), s->xitFreq(),
+                s->diversity(), s->isDiversityParent(),
+                s->isDiversityChild(), s->diversityIndex());
         syncTxWaterfallSliceToSpectrums();
         updateSplitState();
 
@@ -2531,15 +2591,31 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
         }
         queueActiveSliceForSpectrumTarget(target->sliceId());
+        m_sliceDragTargetSliceId = target->sliceId();
+        m_sliceDragTargetMhz = sliceFreqMhz;
+        m_sliceDragEchoHoldUntilMs = 0;
+        pushSliceFrequencyToOverlays(target, sliceFreqMhz);
         target->setFrequency(sliceFreqMhz);
-        mirrorDiversityChildFrequency(target, sliceFreqMhz);  // keep diversity child in step
     });
     // Pan Follow ("Pan Lock") stands down for the whole duration of a slice drag
     // so it doesn't fight the drag (in-window tune or edge auto-pan) with per-tick
     // recenters; on release it recenters once so Pan Lock re-asserts. (user-reported)
     connect(sw, &SpectrumWidget::sliceDragActiveChanged, this, [this](bool active) {
         m_sliceDragInProgress = active;
+        if (active) {
+            m_sliceDragTargetSliceId = -1;
+            m_sliceDragTargetMhz = 0.0;
+            m_sliceDragEchoHoldUntilMs = 0;
+            return;
+        }
         if (!active) {
+            if (m_sliceDragTargetSliceId >= 0 && m_sliceDragTargetMhz > 0.0) {
+                if (SliceModel* target = m_radioModel.slice(m_sliceDragTargetSliceId)) {
+                    pushSliceFrequencyToOverlays(target, m_sliceDragTargetMhz);
+                    target->setFrequency(m_sliceDragTargetMhz);
+                }
+                m_sliceDragEchoHoldUntilMs = QDateTime::currentMSecsSinceEpoch() + 350;
+            }
             recenterPanFollowOnSlice0();   // re-assert Pan Lock on release (self-guards if off)
         }
     });
@@ -3127,7 +3203,8 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
                 m_radioModel.slice(sliceId));
         }
     });
-    connect(s, &SliceModel::diversityChanged, this, [this](bool) {
+    connect(s, &SliceModel::diversityChanged, this, [this, s](bool) {
+        pushSliceOverlay(s);
         syncKiwiSdrDiversityEscControls();
     });
     connect(w, &VfoWidget::closeSliceRequested, this, [this, sliceId]() {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -573,37 +573,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
         // HID encoder frequency tuning routes through applyFlexControlWheelAction,
         // so m_flexCoalesceTimer above already covers it.
         const bool memoryRevealPending = (m_pendingMemoryRevealSliceId == s->sliceId());
-        const bool activeDiversityPartner = [this, s]() {
-            SliceModel* active = m_radioModel.slice(m_activeSliceId);
-            if (!active || active == s || !active->diversity() || !s->diversity()) {
-                return false;
-            }
-
-            const bool parentChildPair =
-                (active->isDiversityParent() && s->isDiversityChild())
-                || (active->isDiversityChild() && s->isDiversityParent());
-            if (parentChildPair) {
-                return true;
-            }
-
-            return !active->panId().isEmpty() && active->panId() == s->panId();
-        }();
-        const bool dragDiversityPartner = [this, s]() {
-            SliceModel* dragTarget = m_radioModel.slice(m_sliceDragTargetSliceId);
-            if (!dragTarget || dragTarget == s
-                || !dragTarget->diversity() || !s->diversity()) {
-                return false;
-            }
-
-            const bool parentChildPair =
-                (dragTarget->isDiversityParent() && s->isDiversityChild())
-                || (dragTarget->isDiversityChild() && s->isDiversityParent());
-            if (parentChildPair) {
-                return true;
-            }
-
-            return !dragTarget->panId().isEmpty() && dragTarget->panId() == s->panId();
-        }();
+        SliceModel* active = m_radioModel.slice(m_activeSliceId);
+        const bool activeDiversityPartner = isSameDiversityReceivePair(active, s);
+        SliceModel* dragTarget = m_radioModel.slice(m_sliceDragTargetSliceId);
+        const bool dragDiversityPartner = isSameDiversityReceivePair(dragTarget, s);
         const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
         const bool dragEchoHoldActive =
             m_sliceDragInProgress
@@ -614,9 +587,9 @@ void MainWindow::onSliceAdded(SliceModel* s)
         if (dragEchoHoldActive && dragTargetSlice
             && m_sliceDragTargetMhz > 0.0 && !memoryRevealPending) {
             const int sliceId = s->sliceId();
-            const double displayMhz = m_sliceDragTargetMhz;
-            QTimer::singleShot(0, this, [this, sliceId, displayMhz]() {
-                if (m_sliceDragTargetMhz <= 0.0) {
+            QTimer::singleShot(0, this, [this, sliceId]() {
+                const double displayMhz = m_sliceDragTargetMhz;
+                if (displayMhz <= 0.0) {
                     return;
                 }
                 if (!m_sliceDragInProgress

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -108,6 +108,123 @@ bool flagDirectionOnLeft(VfoWidget::FlagDir dir)
     return dir == VfoWidget::ForceLeft || dir == VfoWidget::LockLeft;
 }
 
+bool overlayIsDiversityPairCandidate(const SpectrumWidget::SliceOverlay& overlay)
+{
+    return overlay.diversity;
+}
+
+bool overlaysAreAttachedDiversityPair(const SpectrumWidget::SliceOverlay* active,
+                                      const SpectrumWidget::SliceOverlay& overlay)
+{
+    if (!active || active->sliceId == overlay.sliceId
+        || !active->diversity || !overlay.diversity) {
+        return false;
+    }
+
+    const bool parentChildPair =
+        (active->diversityParent && overlay.diversityChild)
+        || (active->diversityChild && overlay.diversityParent);
+    if (parentChildPair) {
+        return true;
+    }
+
+    if (active->diversityIndex >= 0 && overlay.diversityIndex >= 0) {
+        return active->diversityIndex != overlay.diversityIndex;
+    }
+
+    return true;
+}
+
+int diversityOrderKeyForVfo(const VfoPos& vfo)
+{
+    if (!vfo.overlay) {
+        return 1000 + std::max(vfo.sliceId, 0);
+    }
+
+    return VfoWidget::diversityPairOrderKey(
+        vfo.overlay->diversityParent,
+        vfo.overlay->diversityChild,
+        vfo.overlay->diversityIndex,
+        vfo.sliceId);
+}
+
+void assignSplitPairDirections(const QVector<VfoPos>& vfos,
+                               QMap<int, VfoWidget::FlagDir>& dirMap)
+{
+    for (int i = 0; i < vfos.size(); ++i) {
+        if (vfos[i].splitPartner < 0) {
+            continue;
+        }
+        if (dirMap.contains(vfos[i].sliceId)) {
+            continue;
+        }
+
+        int partnerIndex = -1;
+        for (int j = 0; j < vfos.size(); ++j) {
+            if (vfos[j].sliceId == vfos[i].splitPartner) {
+                partnerIndex = j;
+                break;
+            }
+        }
+        if (partnerIndex < 0) {
+            continue;
+        }
+        if (dirMap.contains(vfos[partnerIndex].sliceId)) {
+            continue;
+        }
+
+        // Split partners stay locked to opposite sides regardless of edge
+        // proximity (#2663).  Flipping a partner near an edge collapses both
+        // panels onto the same side and makes the RX/TX pair overlap.
+        const int leftIndex = (vfos[i].x <= vfos[partnerIndex].x) ? i : partnerIndex;
+        const int rightIndex = (leftIndex == i) ? partnerIndex : i;
+        dirMap[vfos[leftIndex].sliceId] = VfoWidget::LockLeft;
+        dirMap[vfos[rightIndex].sliceId] = VfoWidget::LockRight;
+    }
+}
+
+void assignDiversityPairDirections(const QVector<VfoPos>& vfos,
+                                   QMap<int, VfoWidget::FlagDir>& dirMap)
+{
+    QVector<int> diversityIndices;
+    for (int i = 0; i < vfos.size(); ++i) {
+        if (!vfos[i].overlay || dirMap.contains(vfos[i].sliceId)) {
+            continue;
+        }
+        if (!overlayIsDiversityPairCandidate(*vfos[i].overlay)) {
+            continue;
+        }
+        diversityIndices.append(i);
+    }
+
+    if (diversityIndices.size() != 2) {
+        return;
+    }
+
+    std::sort(diversityIndices.begin(), diversityIndices.end(),
+              [&vfos](int lhs, int rhs) {
+        const int lhsKey = diversityOrderKeyForVfo(vfos[lhs]);
+        const int rhsKey = diversityOrderKeyForVfo(vfos[rhs]);
+        if (lhsKey != rhsKey) {
+            return lhsKey < rhsKey;
+        }
+        return vfos[lhs].sliceId < vfos[rhs].sliceId;
+    });
+
+    dirMap[vfos[diversityIndices[0]].sliceId] = VfoWidget::LockLeft;
+    dirMap[vfos[diversityIndices[1]].sliceId] = VfoWidget::LockRight;
+}
+
+void assignModeForcedDirections(const QVector<SpectrumWidget::SliceOverlay>& overlays,
+                                QMap<int, VfoWidget::FlagDir>& dirMap)
+{
+    for (const SpectrumWidget::SliceOverlay& overlay : overlays) {
+        if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
+            dirMap[overlay.sliceId] = VfoWidget::ForceRight;
+        }
+    }
+}
+
 } // namespace
 
 inline QColor kAetherBrandBlue() { return AetherSDR::ThemeManager::instance().color("color.accent"); }
@@ -1043,33 +1160,11 @@ bool SpectrumWidget::vfoFlagOnLeftForSlice(
     }
 
     QMap<int, VfoWidget::FlagDir> dirMap;
-    for (int i = 0; i < vfos.size(); ++i) {
-        if (vfos[i].splitPartner < 0) {
-            continue;
-        }
-        if (dirMap.contains(vfos[i].sliceId)) {
-            continue;
-        }
-        int partnerIndex = -1;
-        for (int j = 0; j < vfos.size(); ++j) {
-            if (vfos[j].sliceId == vfos[i].splitPartner) {
-                partnerIndex = j;
-                break;
-            }
-        }
-        if (partnerIndex < 0) {
-            continue;
-        }
-        const int leftIndex = (vfos[i].x <= vfos[partnerIndex].x) ? i : partnerIndex;
-        const int rightIndex = (leftIndex == i) ? partnerIndex : i;
-        dirMap[vfos[leftIndex].sliceId] = VfoWidget::LockLeft;
-        dirMap[vfos[rightIndex].sliceId] = VfoWidget::LockRight;
-    }
+    assignDiversityPairDirections(vfos, dirMap);
+    assignSplitPairDirections(vfos, dirMap);
+    assignModeForcedDirections(m_sliceOverlays, dirMap);
 
     const SliceOverlay& overlay = *vfos[targetIndex].overlay;
-    if (overlay.mode == "RTTY" || overlay.mode == "DIGL") {
-        return false;
-    }
     if (dirMap.contains(sliceId)) {
         return flagDirectionOnLeft(dirMap[sliceId]);
     }
@@ -1197,6 +1292,7 @@ VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
     m_vfoWidgets[sliceId] = w;
     w->show();
     w->raise();
+    applyActiveVfoZOrder();
     m_overlayMenu->raiseAll();  // keep overlay + panels on top of all VFO widgets
     if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible())
         m_interlockNotificationLabel->raise();
@@ -1262,11 +1358,34 @@ void SpectrumWidget::removeVfoWidget(int sliceId)
 void SpectrumWidget::setActiveVfoWidget(int sliceId)
 {
     m_vfoWidget = m_vfoWidgets.value(sliceId, nullptr);
+    applyActiveVfoZOrder();
+}
+
+void SpectrumWidget::applyActiveVfoZOrder()
+{
+    const SliceOverlay* active = activeOverlay();
+    if (active && active->diversity) {
+        for (const SliceOverlay& overlay : m_sliceOverlays) {
+            if (overlay.sliceId == active->sliceId) {
+                continue;
+            }
+            if (overlaysAreAttachedDiversityPair(active, overlay)) {
+                if (VfoWidget* partner = m_vfoWidgets.value(overlay.sliceId, nullptr)) {
+                    partner->raise();
+                }
+            }
+        }
+    }
+
     if (m_vfoWidget) {
         m_vfoWidget->raise();
+    }
+
+    if (m_overlayMenu) {
         m_overlayMenu->raiseAll();  // keep overlay above VFO
-        if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible())
-            m_interlockNotificationLabel->raise();
+    }
+    if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible()) {
+        m_interlockNotificationLabel->raise();
     }
 }
 
@@ -3970,11 +4089,15 @@ void SpectrumWidget::setFrequencyRange(double centerMhz, double bandwidthMhz)
     if (centerMhz == m_centerMhz && bandwidthMhz == m_bandwidthMhz)
         return;
 
-    // While the user is actively panning, the local drag path owns the visual
-    // center and sends throttled range commands. Radio echoes for intermediate
-    // drag positions are stale by the time they arrive and would force extra
-    // waterfall reprojections back through old frames.
-    if (m_draggingPan && mhzNearlyEqual(bandwidthMhz, m_bandwidthMhz)) {
+    // While the user is actively dragging the pan or a VFO/slice, the local
+    // drag path owns the visual center. Radio echoes for intermediate drag
+    // positions are stale by the time they arrive and would force the flag and
+    // waterfall back through old frames.
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    const bool vfoDragPanEchoHold =
+        m_vfoDragPanEchoHoldUntilMs > 0 && nowMs < m_vfoDragPanEchoHoldUntilMs;
+    if ((m_draggingPan || m_draggingVfo || vfoDragPanEchoHold)
+        && mhzNearlyEqual(bandwidthMhz, m_bandwidthMhz)) {
         return;
     }
 
@@ -4461,7 +4584,9 @@ void SpectrumWidget::setSliceOverlay(int sliceId, double freq, int fLow, int fHi
                                      bool tx, bool active, const QString& mode,
                                      int rttyMark, int rttyShift,
                                      bool ritOn, int ritFreq,
-                                     bool xitOn, int xitFreq)
+                                     bool xitOn, int xitFreq,
+                                     bool diversity, bool diversityParent,
+                                     bool diversityChild, int diversityIndex)
 {
     int idx = overlayIndex(sliceId);
     if (idx < 0) {
@@ -4469,6 +4594,10 @@ void SpectrumWidget::setSliceOverlay(int sliceId, double freq, int fLow, int fHi
         o.sliceId = sliceId; o.freqMhz = freq;
         o.filterLowHz = fLow; o.filterHighHz = fHigh;
         o.isTxSlice = tx; o.isActive = active;
+        o.diversity = diversity;
+        o.diversityParent = diversityParent;
+        o.diversityChild = diversityChild;
+        o.diversityIndex = diversityIndex;
         o.mode = mode; o.rttyMark = rttyMark; o.rttyShift = rttyShift;
         o.ritOn = ritOn; o.ritFreq = ritFreq;
         o.xitOn = xitOn; o.xitFreq = xitFreq;
@@ -4480,10 +4609,16 @@ void SpectrumWidget::setSliceOverlay(int sliceId, double freq, int fLow, int fHi
             o.isTxSlice == tx && o.isActive == active && o.mode == mode &&
             o.rttyMark == rttyMark && o.rttyShift == rttyShift &&
             o.ritOn == ritOn && o.ritFreq == ritFreq &&
-            o.xitOn == xitOn && o.xitFreq == xitFreq)
+            o.xitOn == xitOn && o.xitFreq == xitFreq &&
+            o.diversity == diversity && o.diversityParent == diversityParent &&
+            o.diversityChild == diversityChild && o.diversityIndex == diversityIndex)
             return;
         o.freqMhz = freq; o.filterLowHz = fLow; o.filterHighHz = fHigh;
         o.isTxSlice = tx; o.isActive = active;
+        o.diversity = diversity;
+        o.diversityParent = diversityParent;
+        o.diversityChild = diversityChild;
+        o.diversityIndex = diversityIndex;
         o.mode = mode; o.rttyMark = rttyMark; o.rttyShift = rttyShift;
         o.ritOn = ritOn; o.ritFreq = ritFreq;
         o.xitOn = xitOn; o.xitFreq = xitFreq;
@@ -5303,8 +5438,12 @@ bool SpectrumWidget::sliceCursorShapeAt(const QPoint& localPos,
         return false;
     }
 
+    const SliceOverlay* ao = activeOverlay();
     for (const auto& so : m_sliceOverlays) {
         if (so.isActive) {
+            continue;
+        }
+        if (overlaysAreAttachedDiversityPair(ao, so)) {
             continue;
         }
         const int sliceX = mhzToX(so.freqMhz);
@@ -5329,7 +5468,7 @@ bool SpectrumWidget::sliceCursorShapeAt(const QPoint& localPos,
         }
     }
 
-    if (const auto* ao = activeOverlay()) {
+    if (ao) {
         const int loX = mhzToX(ao->freqMhz + ao->filterLowHz / 1.0e6);
         const int hiX = mhzToX(ao->freqMhz + ao->filterHighHz / 1.0e6);
         if (filterEdgeHitAtPixel(mx, loX, hiX, kFilterEdgeGrabPx) != 0) {
@@ -5835,8 +5974,14 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
     // interaction targets the clicked slice's passband/marker.
     if (y < specH) {
         const int mx = static_cast<int>(ev->position().x());
+        const SliceOverlay* ao = activeOverlay();
         for (const auto& so : m_sliceOverlays) {
-            if (so.isActive) continue;
+            if (so.isActive) {
+                continue;
+            }
+            if (overlaysAreAttachedDiversityPair(ao, so)) {
+                continue;
+            }
             const int sliceX = mhzToX(so.freqMhz);
             const int loX = mhzToX(so.freqMhz + so.filterLowHz / 1.0e6);
             const int hiX = mhzToX(so.freqMhz + so.filterHighHz / 1.0e6);
@@ -5870,6 +6015,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             if (mx >= left && mx <= right) {
                 emit sliceClicked(so.sliceId);
                 m_draggingVfo = true;
+                m_vfoDragPanEchoHoldUntilMs = 0;
                 emit sliceDragActiveChanged(true);
                 m_vfoDragLastX = mx;
                 m_vfoDragOffsetHz = static_cast<int>(
@@ -5907,6 +6053,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         // Click inside the filter passband → start VFO drag (#404)
         if (filterPassbandBodyHitAtPixel(mx, loX, hiX, kFilterEdgeGrabPx)) {
             m_draggingVfo = true;
+            m_vfoDragPanEchoHoldUntilMs = 0;
             emit sliceDragActiveChanged(true);
             m_vfoDragLastX = mx;
             m_vfoDragOffsetHz = static_cast<int>(std::round((xToMhz(mx) - ao->freqMhz) * 1.0e6));
@@ -6638,6 +6785,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     }
     if (m_draggingVfo) {
         m_draggingVfo = false;
+        m_vfoDragPanEchoHoldUntilMs = QDateTime::currentMSecsSinceEpoch() + 350;
         emit sliceDragActiveChanged(false);
         if (m_vfoDragEdgePanTimer)
             m_vfoDragEdgePanTimer->stop();
@@ -8418,31 +8566,9 @@ void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
     const int specW  = specRect.width();
 
     QMap<int, VfoWidget::FlagDir> dirMap;
-    for (int i = 0; i < vfos.size(); ++i) {
-        if (vfos[i].splitPartner < 0) continue;
-        if (dirMap.contains(vfos[i].sliceId)) continue;
-        int pi = -1;
-        for (int j = 0; j < vfos.size(); ++j) {
-            if (vfos[j].sliceId == vfos[i].splitPartner) { pi = j; break; }
-        }
-        if (pi < 0) continue;
-        // Split partners stay locked to opposite sides regardless of
-        // edge proximity (#2663).  Flipping a partner when near an
-        // edge would collapse both panels onto the same side and the
-        // RX/TX panels would visually overlap; the panadapter is the
-        // user's spatial frame and the side-locking is the whole point
-        // of the split affordance.  The outward-facing panel may clip
-        // the pan edge — the user pans toward center to read it.
-        int leftIdx  = (vfos[i].x <= vfos[pi].x) ? i : pi;
-        int rightIdx = (leftIdx == i) ? pi : i;
-        dirMap[vfos[leftIdx].sliceId]  = VfoWidget::LockLeft;
-        dirMap[vfos[rightIdx].sliceId] = VfoWidget::LockRight;
-    }
-
-    for (const auto& so : m_sliceOverlays) {
-        if (so.mode == "RTTY" || so.mode == "DIGL")
-            dirMap[so.sliceId] = VfoWidget::ForceRight;
-    }
+    assignDiversityPairDirections(vfos, dirMap);
+    assignSplitPairDirections(vfos, dirMap);
+    assignModeForcedDirections(m_sliceOverlays, dirMap);
 
     if (vfos.size() == 1) {
         VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
@@ -8614,38 +8740,14 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
         const int specW = specRect.width();
 
-        // First pass: assign directions for split pairs
+        // First pass: assign directions for role-locked pairs
         QMap<int, VfoWidget::FlagDir> dirMap;  // sliceId → direction
-        for (int i = 0; i < vfos.size(); ++i) {
-            if (vfos[i].splitPartner < 0) continue;
-            if (dirMap.contains(vfos[i].sliceId)) continue;  // already assigned
+        assignDiversityPairDirections(vfos, dirMap);
+        assignSplitPairDirections(vfos, dirMap);
 
-            // Find partner index
-            int pi = -1;
-            for (int j = 0; j < vfos.size(); ++j) {
-                if (vfos[j].sliceId == vfos[i].splitPartner) { pi = j; break; }
-            }
-            if (pi < 0) continue;
-
-            // Left partner flies left, right partner flies right.
-            // Split partners stay locked to opposite sides regardless of
-            // edge proximity (#2663).  Flipping a partner when near an
-            // edge would collapse both panels onto the same side and the
-            // RX/TX panels would visually overlap.  The outward-facing
-            // panel may clip the pan edge — the user pans toward center
-            // to read it.  Mirrors the GPU path block above.
-            int leftIdx  = (vfos[i].x <= vfos[pi].x) ? i : pi;
-            int rightIdx = (leftIdx == i) ? pi : i;
-            dirMap[vfos[leftIdx].sliceId]  = VfoWidget::LockLeft;
-            dirMap[vfos[rightIdx].sliceId] = VfoWidget::LockRight;
-        }
-
-        // Second pass: assign remaining (non-split) VFOs
+        // Second pass: assign remaining mode-forced VFOs
         // In RTTY/DIGL, force flag to fly right so it doesn't cover M/S passband
-        for (const auto& so : m_sliceOverlays) {
-            if (so.mode == "RTTY" || so.mode == "DIGL")
-                dirMap[so.sliceId] = VfoWidget::ForceRight;
-        }
+        assignModeForcedDirections(m_sliceOverlays, dirMap);
 
         if (vfos.size() == 1) {
             VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
@@ -8670,12 +8772,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         }
     }
     // Active widget on top, but overlay stays above all
-    if (m_vfoWidget) {
-        m_vfoWidget->raise();
-        m_overlayMenu->raiseAll();
-        if (m_interlockNotificationLabel && m_interlockNotificationLabel->isVisible())
-            m_interlockNotificationLabel->raise();
-    }
+    applyActiveVfoZOrder();
 
     // ── WNB / RF Gain / Prop Forecast indicators (top-right of FFT area) ────
     {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -391,6 +391,10 @@ public:
         bool   isTxSlice{false};
         bool   isActive{false};
         int    splitPartnerId{-1};  // slice ID of split partner, -1 if not in split
+        bool   diversity{false};
+        bool   diversityParent{false};
+        bool   diversityChild{false};
+        int    diversityIndex{-1};
         QString mode;               // "RTTY", "USB", etc.
         int    rttyMark{2125};      // RTTY mark audio offset (Hz)
         int    rttyShift{170};      // RTTY shift (Hz)
@@ -412,7 +416,11 @@ public:
                          bool tx, bool active, const QString& mode = {},
                          int rttyMark = 2125, int rttyShift = 170,
                          bool ritOn = false, int ritFreq = 0,
-                         bool xitOn = false, int xitFreq = 0);
+                         bool xitOn = false, int xitFreq = 0,
+                         bool diversity = false,
+                         bool diversityParent = false,
+                         bool diversityChild = false,
+                         int diversityIndex = -1);
     // Update just the frequency on an existing overlay (for optimistic scroll-to-tune)
     void setSliceOverlayFreq(int sliceId, double freqMhz);
     // Update the per-client letter on an existing overlay; safe to call
@@ -642,6 +650,7 @@ private:
     void installVfoCursorEventFilter(VfoWidget* widget);
     void setVfoCursorOverride(Qt::CursorShape shape);
     void clearVfoCursorOverride();
+    void applyActiveVfoZOrder();
 #ifdef AETHER_GPU_SPECTRUM
     void repositionVfoFlags(const QRect& specRect);  // #3617 — shared flag positioner
 #endif
@@ -1071,6 +1080,7 @@ private:
     QTimer* m_vfoDragEdgePanTimer{nullptr};
     int  m_vfoDragLastX{0};                 // last cursor X during VFO drag (px)
     int  m_vfoDragEdgeHoldTicks{0};         // ticks held in edge zone (ramp)
+    qint64 m_vfoDragPanEchoHoldUntilMs{0};  // ignore stale center echoes briefly after drag
     bool m_vfoDragEdgePanDisabled{false};   // AETHER_NO_DRAG_EDGEPAN=1 escape hatch
     // Velocity knobs, env-tunable so the feel can be swept WITHOUT rebuilding:
     //   AETHER_DRAG_EDGEPAN_VMAX     — top speed, % of span width per second

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2944,49 +2944,14 @@ void VfoWidget::setAfGain(int pct)
 void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
 {
     const int w = width();
-    bool onLeft = true;
-    // Split pairs pass LockLeft/LockRight so the panels stay on their
-    // outward-facing sides even when one is near a pan edge. Without
-    // the lock, the edge-clip flip below would collapse both panels
-    // onto the same side and they would visually overlap (#2663).
-    const bool lockedSide = (dir == LockLeft || dir == LockRight);
-
-    if (dir == ForceLeft || dir == LockLeft) {
-        onLeft = true;
-    } else if (dir == ForceRight || dir == LockRight) {
-        onLeft = false;
-    } else {
-        // Auto: use mode-based default
-        onLeft = !m_slice || defaultFlagOnLeftForMode(m_slice->mode());
-    }
-
-    // 20px dead-band: only flip side when the widget clearly overruns the edge.
-    // Without this, the flip threshold can oscillate frame-to-frame while
-    // m_centerMhz is animating, snapping the VFO panel back and forth.
-    constexpr int kEdgeHysteresis = 20;
-
-    int x;
-    if (onLeft) {
-        x = vfoX - w;
-        // Flip to right only when clearly clipping the left edge.
-        // Split pairs (lockedSide) skip the flip so RX/TX stay opposite.
-        if (!lockedSide && x < -kEdgeHysteresis) {
-            x = vfoX;
-            onLeft = false;
-        }
-    } else {
-        x = vfoX;
-        // Flip to left only when clearly clipping the right edge.
-        // Split pairs (lockedSide) skip the flip so RX/TX stay opposite.
-        const int parentW = parentWidget() ? parentWidget()->width() : INT_MAX;
-        if (!lockedSide && x + w > parentW + kEdgeHysteresis) {
-            x = vfoX - w;
-            onLeft = true;
-        }
-    }
+    const bool defaultOnLeft = !m_slice || defaultFlagOnLeftForMode(m_slice->mode());
+    const int parentW = parentWidget() ? parentWidget()->width() : 0;
+    const FlagPlacement placement = placementForMarker(
+        vfoX, specTop, w, height(), parentW, dir, defaultOnLeft);
+    const bool onLeft = placement.onLeft;
 
     // Skip all moves if position unchanged — prevents repaint cascade on QRhiWidget
-    const QPoint newPos(x, specTop);
+    const QPoint newPos = placement.rect.topLeft();
     if (pos() == newPos && m_lastOnLeft == onLeft)
         return;
     m_lastOnLeft = onLeft;
@@ -3006,11 +2971,11 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
         const int gap = 2;
         int btnX;
         if (onLeft)
-            btnX = x - btnSize - gap;  // left of VFO widget
+            btnX = newPos.x() - btnSize - gap;  // left of VFO widget
         else
-            btnX = x + w + gap;        // right of VFO widget
+            btnX = newPos.x() + w + gap;        // right of VFO widget
 
-        int btnY = specTop;
+        int btnY = newPos.y();
         if (!m_collapsed) {
             m_closeSliceBtn->move(btnX, btnY);
             btnY += btnSize + gap;
@@ -3033,12 +2998,12 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
         const int freqGap = 2;
         int freqX;
         int freqH = m_collapsedFreqLabel->sizeHint().height();
-        int freqY = specTop + (height() - freqH) / 2;  // vertically centered
+        int freqY = newPos.y() + (height() - freqH) / 2;  // vertically centered
         int freqW = m_collapsedFreqLabel->sizeHint().width();
         if (onLeft) {
-            freqX = x - freqW - freqGap;
+            freqX = newPos.x() - freqW - freqGap;
         } else {
-            freqX = x + w + freqGap;
+            freqX = newPos.x() + w + freqGap;
         }
         m_collapsedFreqLabel->move(freqX, freqY);
     }

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "core/KiwiSdrProtocol.h"
 
@@ -85,8 +86,15 @@ public:
     //   LockLeft/LockRight disable that flip and hold the requested side
     //   even if the panel overruns the edge. Used by split pairs so the
     //   RX/TX panels stay on their opposite sides instead of collapsing
-    //   onto the same side when the pair is near a pan edge (#2663).
+    //   onto the same side when the pair is near a pan edge (#2663). Also used
+    //   by attached diversity pairs, whose two flags must keep opposite sides
+    //   while overlapping nearby ordinary slices by z-order.
     enum FlagDir { Auto, ForceLeft, ForceRight, LockLeft, LockRight };
+
+    struct FlagPlacement {
+        QRect rect;
+        bool onLeft{true};
+    };
 
     // Reposition relative to VFO marker x coordinate.
     void updatePosition(int vfoX, int specTop, FlagDir dir = Auto);
@@ -173,6 +181,64 @@ public:
         const int gapLeft = markerX - previousMarkerX;
         const int gapRight = nextMarkerX - markerX;
         return (gapLeft >= gapRight) ? ForceLeft : ForceRight;
+    }
+
+    static int diversityPairOrderKey(bool diversityParent,
+                                     bool diversityChild,
+                                     int diversityIndex,
+                                     int sliceId)
+    {
+        if (diversityIndex >= 0) {
+            return diversityIndex;
+        }
+        if (diversityParent) {
+            return 0;
+        }
+        if (diversityChild) {
+            return 1;
+        }
+        return 1000 + std::max(sliceId, 0);
+    }
+
+    static FlagPlacement placementForMarker(int markerX,
+                                            int specTop,
+                                            int widgetWidth,
+                                            int widgetHeight,
+                                            int parentWidth,
+                                            FlagDir dir,
+                                            bool defaultOnLeft)
+    {
+        bool onLeft = defaultOnLeft;
+        const bool lockedSide = (dir == LockLeft || dir == LockRight);
+
+        if (dir == ForceLeft || dir == LockLeft) {
+            onLeft = true;
+        } else if (dir == ForceRight || dir == LockRight) {
+            onLeft = false;
+        }
+
+        constexpr int kEdgeHysteresis = 20;
+
+        int x = markerX;
+        if (onLeft) {
+            x = markerX - widgetWidth;
+            if (!lockedSide && x < -kEdgeHysteresis) {
+                x = markerX;
+                onLeft = false;
+            }
+        } else {
+            x = markerX;
+            const int effectiveParentWidth = parentWidth > 0
+                ? parentWidth
+                : std::numeric_limits<int>::max() - kEdgeHysteresis;
+            if (!lockedSide
+                && x + widgetWidth > effectiveParentWidth + kEdgeHysteresis) {
+                x = markerX - widgetWidth;
+                onLeft = true;
+            }
+        }
+
+        return {QRect(x, specTop, widgetWidth, widgetHeight), onLeft};
     }
 
     // Draw this flag's SmartMTR extremes value labels (min/max or current signal,

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -856,19 +856,28 @@ void SliceModel::applyStatus(const QMap<QString, QString>& kvs)
     }
     // Parse child/parent flags before emitting diversityChanged so handlers
     // can check isDiversityChild() to gate ESC panel visibility.
-    if (kvs.contains("diversity_child"))
+    const bool previousDiversityChild = m_diversityChild;
+    const bool previousDiversityParent = m_diversityParent;
+    const bool previousDiversity = m_diversity;
+    const int previousDiversityIndex = m_diversityIndex;
+    if (kvs.contains("diversity_child")) {
         m_diversityChild = kvs["diversity_child"] == "1";
-    if (kvs.contains("diversity_parent"))
-        m_diversityParent = kvs["diversity_parent"] == "1";
-    if (kvs.contains("diversity")) {
-        bool div = kvs["diversity"] == "1";
-        if (div != m_diversity) {
-            m_diversity = div;
-            emit diversityChanged(div);
-        }
     }
-    if (kvs.contains("diversity_index"))
+    if (kvs.contains("diversity_parent")) {
+        m_diversityParent = kvs["diversity_parent"] == "1";
+    }
+    if (kvs.contains("diversity")) {
+        m_diversity = kvs["diversity"] == "1";
+    }
+    if (kvs.contains("diversity_index")) {
         m_diversityIndex = kvs["diversity_index"].toInt();
+    }
+    if (m_diversityChild != previousDiversityChild
+        || m_diversityParent != previousDiversityParent
+        || m_diversity != previousDiversity
+        || m_diversityIndex != previousDiversityIndex) {
+        emit diversityChanged(m_diversity);
+    }
 
     // ESC (Enhanced Signal Clarity) — diversity beamforming
     if (kvs.contains("esc")) {

--- a/tests/vfo_flag_placement_test.cpp
+++ b/tests/vfo_flag_placement_test.cpp
@@ -140,6 +140,28 @@ int main()
               VfoWidget::autoDirectionForSingleFlag(0, 0, 0, false, true),
               VfoWidget::ForceRight);
 
+    const VfoWidget::FlagPlacement forcedAtLeftEdge =
+        VfoWidget::placementForMarker(10, 3, 200, 80, 1000,
+                                      VfoWidget::ForceLeft, true);
+    report("force-left geometry flips right at left edge",
+           forcedAtLeftEdge.rect.x() == 10 && !forcedAtLeftEdge.onLeft);
+
+    const VfoWidget::FlagPlacement lockedAtLeftEdge =
+        VfoWidget::placementForMarker(10, 3, 200, 80, 1000,
+                                      VfoWidget::LockLeft, true);
+    report("lock-left geometry stays left at left edge",
+           lockedAtLeftEdge.rect.x() == -190 && lockedAtLeftEdge.onLeft);
+
+    report("diversity index 0 orders before index 1",
+           VfoWidget::diversityPairOrderKey(false, false, 0, 5)
+               < VfoWidget::diversityPairOrderKey(false, false, 1, 4));
+    report("diversity parent orders before child without index",
+           VfoWidget::diversityPairOrderKey(true, false, -1, 5)
+               < VfoWidget::diversityPairOrderKey(false, true, -1, 4));
+    report("diversity unknown role orders by stable slice id",
+           VfoWidget::diversityPairOrderKey(false, false, -1, 3)
+               < VfoWidget::diversityPairOrderKey(false, false, -1, 4));
+
     std::printf("%s\n", g_failures == 0 ? "All tests passed." : "Test failures.");
     return g_failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes the diversity-receive VFO flag instability by making attached A/H diversity pair placement authoritative over transient screen position and split-pair deconfliction. The pair now keeps stable left/right flag sides, updates both member overlays together during tune/drag paths, suppresses stale radio echoes during fast drag, and resolves overlap with nearby ordinary slice flags by active-group z-order instead of pushing flags to a lower row.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The fix was validated with focused tests plus automation-bridge captures against a live A/H diversity pair with an additional slice on the same panadapter.

## Test plan

- [x] Local build passes (`cmake --build build --target vfo_flag_placement_test AetherSDR -j8`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Additional validation:
- `git diff --check`
- `ctest --test-dir build -R '^vfo_flag_placement_test$' --output-on-failure`
- Agent automation bridge: live A/H diversity pair plus B slice on pan `0x40000000`; selected B and A through `slice select`, captured visible panadapter screenshots, confirmed flags remain on the normal row and active group owns overlap z-order
- Agent automation bridge: TX idle with `transmitting=false`, `mox=false`, `tuning=false`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention; no new meter UI added)
- [x] Documentation updated if user-visible behavior changed (not needed; bugfix only)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
