### PR TITLE
feat(swr): export SWR sweep data to CSV (#2241)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -593,6 +593,7 @@ private:
     void restoreBandState(const BandSnapshot& snap);
     void startSwrSweep(int requestedSliceId = -1, int sweepPowerWatts = 1);
     void clearSwrSweepPlot();
+    void saveSwrSweepCsv();
     void advanceSwrSweep();
     void finishSwrSweep(bool aborted, const QString& reason = {});
     void beginSwrSweepRf();

--- a/src/gui/MainWindow_SwrSweep.cpp
+++ b/src/gui/MainWindow_SwrSweep.cpp
@@ -24,7 +24,14 @@
 #include "models/SliceModel.h"
 
 #include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileDialog>
 #include <QMessageBox>
+#include <QRegularExpression>
+#include <QStandardPaths>
+#include <QTextStream>
 #include <QTimer>
 
 #include <algorithm>
@@ -68,6 +75,70 @@ void MainWindow::clearSwrSweepPlot()
             sw->clearSwrSweepPoints();
     }
     statusBar()->showMessage(QStringLiteral("SWR sweep plot cleared"), 2500);
+}
+
+// Export the most recent completed sweep to a CSV (Frequency (Hz),SWR). The
+// samples + band name persist in m_swrSweep after a sweep finishes (only an
+// explicit clear or a band change drops them), so this is available whenever a
+// trace is on the panadapter. Filename defaults to
+// swr_sweep_<band>_<YYYYMMDD>_<HHMMSS>.csv. #2241.
+void MainWindow::saveSwrSweepCsv()
+{
+    if (m_swrSweep.running) {
+        statusBar()->showMessage(
+            QStringLiteral("Wait for the SWR sweep to finish before saving."), 2500);
+        return;
+    }
+    if (m_swrSweep.samples.isEmpty()) {
+        statusBar()->showMessage(
+            QStringLiteral("No SWR sweep data to save — run a sweep first."), 2500);
+        return;
+    }
+
+    // Sanitise the band name for use in a filename (e.g. "20m" stays, but guard
+    // against any separators a band label might carry).
+    QString band = m_swrSweep.originalBandName;
+    band.replace(QRegularExpression(QStringLiteral("[^A-Za-z0-9_-]")),
+                 QStringLiteral("_"));
+    if (band.isEmpty())
+        band = QStringLiteral("band");
+
+    const QString stamp =
+        QDateTime::currentDateTime().toString(QStringLiteral("yyyyMMdd_HHmmss"));
+    const QString suggestedName =
+        QStringLiteral("swr_sweep_%1_%2.csv").arg(band, stamp);
+    const QString dir =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    const QString suggestedPath =
+        dir.isEmpty() ? suggestedName : QDir(dir).filePath(suggestedName);
+
+    const QString path = QFileDialog::getSaveFileName(
+        this, QStringLiteral("Save SWR Sweep CSV"), suggestedPath,
+        QStringLiteral("CSV files (*.csv);;All files (*)"));
+    if (path.isEmpty())
+        return;  // user cancelled
+
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
+        QMessageBox::warning(
+            this, QStringLiteral("Save SWR Sweep CSV"),
+            QStringLiteral("Could not open file for writing:\n%1").arg(path));
+        return;
+    }
+
+    QTextStream out(&file);
+    out << "Frequency (Hz),SWR\n";
+    for (const SwrSweepSample& s : m_swrSweep.samples) {
+        const qint64 freqHz = static_cast<qint64>(llround(s.freqMhz * 1.0e6));
+        out << freqHz << ',' << QString::number(s.swr, 'f', 3) << '\n';
+    }
+    file.close();
+
+    statusBar()->showMessage(
+        QStringLiteral("Saved %1 SWR points to %2")
+            .arg(m_swrSweep.samples.size())
+            .arg(QDir::toNativeSeparators(path)),
+        4000);
 }
 
 void MainWindow::clearSwrSweepForBandChange(int sliceId, const QString& panId,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2887,6 +2887,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             this, &MainWindow::startSwrSweep);
     connect(menu, &SpectrumOverlayMenu::swrSweepClearRequested,
             this, &MainWindow::clearSwrSweepPlot);
+    connect(menu, &SpectrumOverlayMenu::swrSweepSaveCsvRequested,
+            this, &MainWindow::saveSwrSweepCsv);
 
     // Client-side DSP toggles (NR2 / RN2 / NR4 / MNR / BNR / DFNR) now
     // live exclusively in the AetherDSP applet; the spectrum overlay menu

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -625,6 +625,11 @@ void SpectrumOverlayMenu::buildAntPanel()
     sweepRow->addWidget(m_swrClearBtn, 1);
     vbox->addLayout(sweepRow);
 
+    m_swrSaveBtn = new QPushButton("Save CSV");
+    m_swrSaveBtn->setMinimumHeight(22);
+    m_swrSaveBtn->setStyleSheet(sweepBtnStyle);
+    vbox->addWidget(m_swrSaveBtn);
+
     connect(m_swrStartBtn, &QPushButton::clicked, this, [this]() {
         const int sliceId = m_slice ? m_slice->sliceId() : -1;
         hideAllSubPanels();
@@ -633,6 +638,10 @@ void SpectrumOverlayMenu::buildAntPanel()
     connect(m_swrClearBtn, &QPushButton::clicked, this, [this]() {
         hideAllSubPanels();
         emit swrSweepClearRequested();
+    });
+    connect(m_swrSaveBtn, &QPushButton::clicked, this, [this]() {
+        hideAllSubPanels();
+        emit swrSweepSaveCsvRequested();
     });
 
     // ANT panel tooltips
@@ -644,6 +653,7 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_wnbSlider->setToolTip("Adjusts WNB threshold. Higher values blank more aggressively.");
     m_swrStartBtn->setToolTip("Run a low-power tune sweep across the current TX band and plot SWR on the panadapter.");
     m_swrClearBtn->setToolTip("Clear the displayed SWR sweep trace.");
+    m_swrSaveBtn->setToolTip("Export the most recent SWR sweep (frequency + SWR) to a CSV file.");
 
     m_antPanel->setFixedWidth(180);
     updateLoopButtonVisibility();

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -159,6 +159,7 @@ signals:
     void rfGainChanged(int gain);
     void swrSweepStartRequested(int sliceId, int sweepPowerWatts);
     void swrSweepClearRequested();
+    void swrSweepSaveCsvRequested();
     void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
     void flexRxAntennaSelected(int sliceId);
     // NB Waterfall Blanker (#277)
@@ -242,6 +243,7 @@ private:
     QLabel*      m_wnbLabel{nullptr};
     QPushButton* m_swrStartBtn{nullptr};
     QPushButton* m_swrClearBtn{nullptr};
+    QPushButton* m_swrSaveBtn{nullptr};
 
     // DAX sub-panel
     QWidget*     m_daxPanel{nullptr};


### PR DESCRIPTION
Implements the CSV-export portion of #2241.

Adds a **Save CSV** button to the SWR sweep controls in the spectrum overlay menu. After a sweep finishes, the samples (frequency + SWR) and band name already persist in `m_swrSweep`, so the export is available whenever a trace is on the panadapter.

- Button → new `swrSweepSaveCsvRequested()` signal → `MainWindow::saveSwrSweepCsv()`.
- Opens a save dialog pre-filled with `swr_sweep_<band>_<YYYYMMDD>_<HHMMSS>.csv` (defaults to Documents).
- Writes a `Frequency (Hz),SWR` header followed by one row per sample.
- Guards for an in-progress sweep, an empty dataset, and a failed file open, each with a status-bar message.

**Tested** live on a FLEX-6600: ran a 20 m sweep, exported, and confirmed the file opens correctly in a spreadsheet (18 points, resonant dip ~14.31 MHz).

Scope is deliberately limited to CSV export. The resonance/bandwidth markers and user-bounded sweep range remain as separate follow-ups.