### PR TITLE
feat(swr): optional manual sweep range (#2241)

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -602,7 +602,8 @@ private:
 
     BandSnapshot captureCurrentBandState() const;
     void restoreBandState(const BandSnapshot& snap);
-    void startSwrSweep(int requestedSliceId = -1, int sweepPowerWatts = 1);
+    void startSwrSweep(int requestedSliceId = -1, int sweepPowerWatts = 1,
+                       double customLowMhz = 0.0, double customHighMhz = 0.0);
     void clearSwrSweepPlot();
     void saveSwrSweepCsv();
     void advanceSwrSweep();

--- a/src/gui/MainWindow_SwrSweep.cpp
+++ b/src/gui/MainWindow_SwrSweep.cpp
@@ -262,7 +262,8 @@ void MainWindow::beginSwrSweepRf()
         5000);
 }
 
-void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
+void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts,
+                               double customLowMhz, double customHighMhz)
 {
     if (m_swrSweep.running)
         return;
@@ -350,6 +351,33 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
         return;
     }
 
+    // Optional manual range. The operator-entered bounds can only narrow the
+    // sweep: they are intersected with the in-region safe range above, so a
+    // custom range never transmits outside what the band plan already permits.
+    // Both 0 means no manual range was requested → full band.
+    double sweepLow = safeLow;
+    double sweepHigh = safeHigh;
+    if (customLowMhz > 0.0 || customHighMhz > 0.0) {
+        // Reject a positive-but-inverted (or zero-width) range up front instead
+        // of silently falling through to a full-band sweep — confining a sweep
+        // to your privileges and getting the whole band is a wrong-direction
+        // surprise for the exact use case this targets.
+        if (customLowMhz <= 0.0 || customHighMhz <= customLowMhz) {
+            QMessageBox::warning(this, tr("SWR Sweep"),
+                                 tr("Enter a sweep start frequency below the stop "
+                                    "frequency."));
+            return;
+        }
+        sweepLow = std::max(safeLow, customLowMhz);
+        sweepHigh = std::min(safeHigh, customHighMhz);
+        if (sweepHigh - sweepLow < kSwrSweepStepMhz) {
+            QMessageBox::warning(this, tr("SWR Sweep"),
+                                 tr("The chosen sweep range does not overlap the band by "
+                                    "enough to take a measurement. Widen the range."));
+            return;
+        }
+    }
+
     const double displayBw = (band.highMhz - band.lowMhz) + 2.0 * kSwrSweepPanPaddingMhz;
     if (displayBw > m_radioModel.maxPanBandwidthMhz()) {
         QMessageBox::warning(this, tr("SWR Sweep"),
@@ -358,7 +386,7 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts)
     }
 
     QVector<double> sweepFreqs;
-    for (double f = safeLow; f <= safeHigh + 1.0e-9; f += kSwrSweepStepMhz)
+    for (double f = sweepLow; f <= sweepHigh + 1.0e-9; f += kSwrSweepStepMhz)
         sweepFreqs.append(std::round(f * 1.0e6) / 1.0e6);
     if (sweepFreqs.isEmpty()) {
         QMessageBox::warning(this, tr("SWR Sweep"),

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -8,6 +8,7 @@
 #include "core/GpuSelector.h"
 #include "models/SliceModel.h"
 #include "models/BandDefs.h"
+#include "models/BandSettings.h"
 #include "core/AppSettings.h"
 #include "core/KiwiSdrManager.h"
 
@@ -16,6 +17,8 @@
 #include <QStandardItemModel>
 #include <QSlider>
 #include <QLabel>
+#include <QCheckBox>
+#include <QDoubleSpinBox>
 #include <QGridLayout>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -630,10 +633,84 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_swrSaveBtn->setStyleSheet(sweepBtnStyle);
     vbox->addWidget(m_swrSaveBtn);
 
+    // Optional manual sweep range. Off by default → full-band sweep (unchanged
+    // behaviour). When ticked, the From/To fields bound the sweep so operators
+    // can confine it to their licence sub-band or a slice of interest. The
+    // values are clamped to the in-region band edges receiver-side, so this can
+    // only ever narrow the sweep. (#2241)
+    m_swrRangeCheck = new QCheckBox("Limit range");
+    m_swrRangeCheck->setStyleSheet(
+        "QCheckBox { color: #ffd070; font-size: 10px; font-weight: bold; }");
+    vbox->addWidget(m_swrRangeCheck);
+
+    auto* rangeRow = new QHBoxLayout;
+    rangeRow->setSpacing(4);
+    const QString spinStyle =
+        "QDoubleSpinBox { background: rgba(38, 34, 24, 235); "
+        "border: 1px solid #705820; border-radius: 2px; "
+        "color: #ffd070; font-size: 10px; padding: 0 2px; }"
+        "QDoubleSpinBox:disabled { color: #706858; border-color: #403828; }";
+    auto makeFreqSpin = [&]() {
+        auto* spin = new QDoubleSpinBox;
+        spin->setRange(0.0, 60.0);
+        spin->setDecimals(3);
+        spin->setSingleStep(0.001);
+        spin->setSuffix(" MHz");
+        spin->setStyleSheet(spinStyle);
+        spin->setEnabled(false);
+        return spin;
+    };
+    auto* fromLabel = new QLabel("From");
+    fromLabel->setStyleSheet("QLabel { color: #b0a080; font-size: 10px; }");
+    auto* toLabel = new QLabel("To");
+    toLabel->setStyleSheet("QLabel { color: #b0a080; font-size: 10px; }");
+    m_swrLowSpin = makeFreqSpin();
+    m_swrHighSpin = makeFreqSpin();
+    rangeRow->addWidget(fromLabel);
+    rangeRow->addWidget(m_swrLowSpin, 1);
+    rangeRow->addWidget(toLabel);
+    rangeRow->addWidget(m_swrHighSpin, 1);
+    vbox->addLayout(rangeRow);
+
+    // Seed the From/To fields with the current band's edges so they start at a
+    // sensible in-band range the operator can narrow.
+    auto seedSwrRangeFromBand = [this]() {
+        if (!m_slice)
+            return;
+        const QString band = BandSettings::bandForFrequency(m_slice->frequency());
+        const BandDef& def = BandSettings::bandDef(band);
+        if (def.lowMhz <= 0.0 || def.highMhz <= def.lowMhz)
+            return;
+        m_swrLowSpin->setValue(def.lowMhz);
+        m_swrHighSpin->setValue(def.highMhz);
+    };
+    connect(m_swrRangeCheck, &QCheckBox::toggled, this,
+            [this, seedSwrRangeFromBand](bool on) {
+        m_swrLowSpin->setEnabled(on);
+        m_swrHighSpin->setEnabled(on);
+        if (!on || !m_slice)
+            return;
+        // (Re)seed when the fields are empty or no longer lie within the active
+        // band — e.g. the operator changed band since the last seed — so the
+        // range always opens from a sensible in-band starting point. A range
+        // the operator narrowed *within* the current band is preserved.
+        const QString band = BandSettings::bandForFrequency(m_slice->frequency());
+        const BandDef& def = BandSettings::bandDef(band);
+        const bool empty = m_swrLowSpin->value() <= 0.0 || m_swrHighSpin->value() <= 0.0;
+        const bool inBand = def.lowMhz > 0.0
+            && m_swrLowSpin->value() >= def.lowMhz
+            && m_swrHighSpin->value() <= def.highMhz;
+        if (empty || !inBand)
+            seedSwrRangeFromBand();
+    });
+
     connect(m_swrStartBtn, &QPushButton::clicked, this, [this]() {
         const int sliceId = m_slice ? m_slice->sliceId() : -1;
+        const bool limit = m_swrRangeCheck->isChecked();
+        const double low = limit ? m_swrLowSpin->value() : 0.0;
+        const double high = limit ? m_swrHighSpin->value() : 0.0;
         hideAllSubPanels();
-        emit swrSweepStartRequested(sliceId, 1);
+        emit swrSweepStartRequested(sliceId, 1, low, high);
     });
     connect(m_swrClearBtn, &QPushButton::clicked, this, [this]() {
         hideAllSubPanels();
@@ -654,6 +731,9 @@ void SpectrumOverlayMenu::buildAntPanel()
     m_swrStartBtn->setToolTip("Run a low-power tune sweep across the current TX band and plot SWR on the panadapter.");
     m_swrClearBtn->setToolTip("Clear the displayed SWR sweep trace.");
     m_swrSaveBtn->setToolTip("Export the most recent SWR sweep (frequency + SWR) to a CSV file.");
+    m_swrRangeCheck->setToolTip("Limit the sweep to a manual frequency range instead of the whole band. Clamped to your in-region band edges.");
+    m_swrLowSpin->setToolTip("Sweep start frequency (clamped to the band).");
+    m_swrHighSpin->setToolTip("Sweep stop frequency (clamped to the band).");
 
     m_antPanel->setFixedWidth(180);
     updateLoopButtonVisibility();

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -15,6 +15,8 @@ class QPushButton;
 class QComboBox;
 class QSlider;
 class QLabel;
+class QCheckBox;
+class QDoubleSpinBox;
 
 namespace AetherSDR {
 
@@ -157,7 +159,12 @@ signals:
     void wnbLevelChanged(int level);
     // Emitted when RF gain slider changes (panadapter-level).
     void rfGainChanged(int gain);
-    void swrSweepStartRequested(int sliceId, int sweepPowerWatts);
+    // customLowMhz/customHighMhz bound the sweep when the operator has ticked
+    // "Limit range" (else both 0 = sweep the full band). The values are clamped
+    // to the in-region band edges receiver-side, so they can only ever narrow
+    // the sweep, never widen it past what the band plan already permits.
+    void swrSweepStartRequested(int sliceId, int sweepPowerWatts,
+                                double customLowMhz, double customHighMhz);
     void swrSweepClearRequested();
     void swrSweepSaveCsvRequested();
     void kiwiRxAntennaSelected(int sliceId, const QString& profileId);
@@ -244,6 +251,9 @@ private:
     QPushButton* m_swrStartBtn{nullptr};
     QPushButton* m_swrClearBtn{nullptr};
     QPushButton* m_swrSaveBtn{nullptr};
+    QCheckBox* m_swrRangeCheck{nullptr};
+    QDoubleSpinBox* m_swrLowSpin{nullptr};
+    QDoubleSpinBox* m_swrHighSpin{nullptr};
 
     // DAX sub-panel
     QWidget*     m_daxPanel{nullptr};


### PR DESCRIPTION
Adds the user-bounded sweep range from #2241 (rnash2's request to "manually set the start and end sweep frequency to respect his operating privileges").

A **Limit range** checkbox with **From**/**To** fields in the SWR sweep controls lets an operator confine a sweep to a licence sub-band or a slice of interest instead of always sweeping the whole band.

- **Off by default** — full-band sweep behaviour is unchanged.
- Ticking the box enables the fields and **seeds them with the current band's edges** (via `BandSettings`) as a starting point to narrow from.
- The bounds pass through `swrSweepStartRequested()` to `startSwrSweep()`, where they are **intersected with the existing in-region safe range** — so they can only ever *narrow* the sweep, never widen it past what the regional band plan already permits (#2800). The out-of-region transmit guard is preserved.
- A range that doesn't overlap the band by at least one step is rejected with a warning.

**Tested** live on a FLEX-6600: ticked Limit range (auto-seeded 14.000–14.350 on 20 m), narrowed To to 14.150, and confirmed the sweep trace covered only 14.000–14.150 instead of the full band.

Note: the resonance/bandwidth-marker portion of #2241 already landed in #2320, so this completes the remaining actionable scope.