### PR TITLE
fix(audio): QsoRecorder playback stuck-mute on sink open failure (#3306 audit)

### DIFF
--- a/src/core/QsoRecorder.cpp
+++ b/src/core/QsoRecorder.cpp
@@ -449,6 +449,24 @@ void QsoRecorder::startPlayback()
             this, &QsoRecorder::onPlaybackSinkState);
     m_playSink->start(&m_playBuffer);
 
+    // Detect an immediate open failure (e.g. a WASAPI/CoreAudio device that
+    // false-positives isFormatSupported() then refuses at start()) BEFORE we
+    // mute live RX. If start() failed synchronously, the stateChanged handler
+    // already ran stopPlayback() but it no-op'd (m_playing was still false), so
+    // we must clean up here. Crucially we return *before* emitting
+    // muteRxRequested(true), so a failed playback can never strand live RX in a
+    // muted state (#3230 invariant) — mirrors ClientPuduMonitor::startPlayback().
+    if (m_playSink->state() == QAudio::StoppedState
+        && m_playSink->error() != QAudio::NoError) {
+        qCWarning(lcAudio) << "QsoRecorder: playback sink failed to start (error"
+                           << m_playSink->error() << ") — aborting, RX left live";
+        m_playSink->disconnect(this);
+        m_playSink->deleteLater();
+        m_playSink = nullptr;
+        if (m_playBuffer.isOpen()) m_playBuffer.close();
+        return;
+    }
+
     m_playing = true;
     emit muteRxRequested(true);
     emit playbackStarted();


### PR DESCRIPTION
## Bug (P0 — dead RX audio)

`QsoRecorder::startPlayback()` mutes live RX (`muteRxRequested(true)`) but never checked whether the playback `QAudioSink` actually opened. If `start()` fails **synchronously** — e.g. a WASAPI/CoreAudio device that false-positives `isFormatSupported()` then refuses at open — the `stateChanged` handler runs `stopPlayback()` while `m_playing` is still `false`, so its `if (!m_playing) return` guard skips the `muteRxRequested(false)`. Execution then falls through and mutes RX anyway. **Live RX stays dead until the app is restarted.**

This violates the #3230 "unmute-on-bail" invariant (any sink that mutes RX must unmute on every failure path).

## Fix

Add the immediate post-`start()` error check that `ClientPuduMonitor::startPlayback()` already has (lines 319-332): on `StoppedState` + error, tear the sink down and **return before** emitting `muteRxRequested(true)`. Because QSO playback mutes only *after* a successful open (and QSO does not pre-mute during recording), the failure path simply returns with RX left live — no stuck mute, no spurious unmute.

## Provenance

Found by a multi-agent **audio-sink mute/negotiation audit** (adversarially verified, 3/3 skeptics confirmed). This is the slice-flag QSO recorder hotspot.

## Test / build

Full macOS app builds & links clean; the headless audio tests (negotiation 28/28, device wrapper 8/8, router 14/14) pass. The fix mirrors the already-merged `ClientPuduMonitor` pattern. A live repro needs a device that fails open mid-playback (WASAPI false-positive); recommend a Windows soak.

Refs #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat