### PR TITLE
fix(audio): TCI TX resamples from client-declared rate, not hardcoded 48k (#3306)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -927,7 +927,27 @@ void TciServer::onBinaryMessage(const QByteArray& data)
     int inputFrames48k = 0;
     bool duplicatedStereo = false;
 
-    // ─── TX resampling: 48kHz (TCI) → 24kHz (radio native DAX) ───────────
+    // ─── TX resampling: client-declared rate → 24kHz (radio native DAX) ──
+    // Resample from the rate the client declared in THIS frame (hdr.sampleRate),
+    // not a hardcoded 48k. WSJT-X sends 48 kHz — the common path, unchanged — but
+    // a client that negotiated 8/12/24 kHz (audio_samplerate) sends at that rate
+    // and must be resampled from it, or every tone is mis-pitched and digital
+    // decodes fail (#3306). Rebuild the per-session resampler only if the
+    // declared rate changes (rare, mid-stream); a 24 kHz client gets a 1:1
+    // resampler so the mono/stereo canonicalization below still runs.
+    {
+        const int declaredRate = static_cast<int>(hdr.sampleRate);
+        const int txSrcRate = (declaredRate == 8000 || declaredRate == 12000
+                               || declaredRate == 24000 || declaredRate == 48000)
+                                  ? declaredRate
+                                  : 48000;   // default/garbage -> WSJT-X-compatible 48k
+        if (!m_txResampler
+            || static_cast<int>(m_txResampler->srcRate()) != txSrcRate) {
+            m_txResampler = std::make_unique<Resampler>(
+                static_cast<double>(txSrcRate), 24000.0, 4096);
+        }
+    }
+
     // Detect mono vs stereo from payload layout.
     //
     // WSJT-X's TCI modulator writes the first `hdr.length` floats as duplicated
@@ -1669,7 +1689,9 @@ void TciServer::startTxChrono(QWebSocket* client, int trx)
         m_audio->setDaxTxMode(true);
     }
 
-    // Create TX resampler: 48kHz (TCI client) → 24kHz (radio DAX/native rate)
+    // Create the TX resampler with the 48 kHz default (WSJT-X). onBinaryMessage
+    // re-derives the source rate from each frame's hdr.sampleRate and rebuilds
+    // this if a client transmits at a non-48k negotiated rate (#3306).
     m_txResampler = std::make_unique<Resampler>(48000.0, 24000.0, 4096);
     if (m_model) {
         // Always dax=1 for TCI TX. The DaxTxLowLatency flag only controls


### PR DESCRIPTION
## Bug

`TciServer`'s TX path created `m_txResampler = Resampler(48000, 24000)` and resampled every incoming `TX_AUDIO_STREAM` block as if it were 48 kHz. TCI clients negotiate `audio_samplerate` (8/12/24/48 kHz) and the per-client **RX** path honours it, but **TX** ignored it: a client that negotiated a non-48k rate and then transmitted had its audio **mis-pitched** (tones offset, digital decodes fail).

## Fix

Resample from the rate the client declares in each frame's header (`hdr.sampleRate`) instead of a hardcoded 48k:
- WSJT-X sends 48 kHz — the common path, **byte-identical**.
- A client at 8/12/24 kHz now resamples from its actual declared rate.
- A 24 kHz client gets a 1:1 resampler so the existing mono/stereo canonicalization (the WSJT-X duplicated-stereo detection) still runs.
- The per-session resampler is rebuilt only if the declared rate changes (rare, mid-stream).

Reading the incoming frame's declared rate is robust regardless of whether a client sends at its negotiated rate or the TX_CHRONO-advertised rate.

## Provenance / scope

Closes out the **TCI-TX** item of the audio sink factory (#3306); confirmed by the audio-sink negotiation audit. Self-contained (1 file, +24/-2). Soak: a non-48k TCI client transmitting (rare; WSJT-X is 48k so unaffected).

Refs #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat