### PR TITLE
Restore BNR Intensity slider and make it take effect (Fixes #3815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- **BNR Intensity slider restored and now functional.** The #2297 DSP refactor
+  removed the slider (it lived in the since-removed Spectrum Overlay DSP panel)
+  and it was never re-created, so BNR ran pinned at 100% and the BNR tab still
+  pointed users to the gone overlay menu. The slider is back on the AetherDSP →
+  BNR tab (0–100%, mirroring DFNR), persisted as `BnrIntensity` with a Reset
+  Defaults (100%). Two backend defects that made intensity inert are also fixed:
+  enabling BNR now applies the persisted intensity as the stream's first-message
+  config (it previously connected at the hardcoded 1.0 default), and a live
+  change reopens the stream so it takes effect — the Maxine BNR container reads
+  `intensity_ratio` only from the first message and ignored the mid-stream config
+  the client used to send. (#3815)
 - **Closing a panafall-created panadapter now frees its waterfall stream on the
   radio.** The close path sent only `display pan remove` and never the matching
   `display panafall remove`, so the waterfall stream was left allocated on the

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -5523,6 +5523,13 @@ void AudioEngine::setBnrEnabled(bool on)
         connect(m_bnr.get(), &NvidiaBnrFilter::connectionChanged,
                 this, &AudioEngine::bnrConnectionChanged);
 
+        // Restore the persisted denoising intensity so the stream opens with it
+        // (the BNR container reads intensity_ratio only from the first message).
+        m_bnrIntensity = std::clamp(
+            AppSettings::instance().value("BnrIntensity", "100").toFloat() / 100.0f,
+            0.0f, 1.0f);
+        m_bnr->setIntensityRatio(m_bnrIntensity);
+
         // Resamplers: 24kHz mono ↔ 48kHz mono
         // BNR returns variable-sized chunks (up to 200ms = 9600 samples at 48kHz),
         // so use a large maxBlockSamples to avoid r8brain buffer overflow.
@@ -5593,12 +5600,36 @@ void AudioEngine::setBnrAddress(const QString& addr)
 
 void AudioEngine::setBnrIntensity(float ratio)
 {
-    if (m_bnr) m_bnr->setIntensityRatio(ratio);
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    m_bnrIntensity = std::clamp(ratio, 0.0f, 1.0f);
+    if (!m_bnr) return;
+    m_bnr->setIntensityRatio(m_bnrIntensity);
+    // A live change only takes effect on a fresh stream — reopen it (debounced
+    // so dragging the slider coalesces into a single reconnect).
+    if (m_bnrEnabled.load() && m_bnr->isConnected())
+        scheduleBnrReconnect();
+}
+
+void AudioEngine::scheduleBnrReconnect()
+{
+    if (!m_bnrReconnectTimer) {
+        m_bnrReconnectTimer = new QTimer(this);
+        m_bnrReconnectTimer->setSingleShot(true);
+        m_bnrReconnectTimer->setInterval(250);
+        connect(m_bnrReconnectTimer, &QTimer::timeout, this, [this]() {
+            std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+            if (!m_bnrEnabled.load() || !m_bnr) return;
+            m_bnr->disconnect();
+            m_bnr->setIntensityRatio(m_bnrIntensity);
+            m_bnr->connectToServer(m_bnrAddress);
+        });
+    }
+    m_bnrReconnectTimer->start();
 }
 
 float AudioEngine::bnrIntensity() const
 {
-    return m_bnr ? m_bnr->intensityRatio() : 1.0f;
+    return m_bnrIntensity;
 }
 
 bool AudioEngine::bnrConnected() const

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -878,6 +878,11 @@ private:
     std::unique_ptr<Resampler> m_kiwiSdrBnrDown;
     std::atomic<bool> m_bnrEnabled{false};
     QString m_bnrAddress{"localhost:8001"};
+    float m_bnrIntensity{1.0f};            // desired denoising strength 0..1
+    QTimer* m_bnrReconnectTimer{nullptr};  // debounces live intensity changes
+    // The BNR container reads intensity_ratio only from the first message of a
+    // stream, so a live change is applied by reopening the stream (debounced).
+    void scheduleBnrReconnect();
     QByteArray m_bnrOutBuf;  // jitter buffer: denoised 24kHz stereo int16
     QByteArray m_kiwiSdrBnrOutBuf;
     bool m_bnrPrimed{false}; // true after enough denoised data accumulated

--- a/src/core/NvidiaBnrFilter.cpp
+++ b/src/core/NvidiaBnrFilter.cpp
@@ -110,8 +110,9 @@ bool NvidiaBnrFilter::isConnected() const
 
 void NvidiaBnrFilter::setIntensityRatio(float ratio)
 {
+    // Applied as the first-message config when the stream is (re)opened;
+    // the container does not honor config sent mid-stream.
     m_intensityRatio = std::clamp(ratio, 0.0f, 1.0f);
-    m_configDirty.store(true);
 }
 
 QByteArray NvidiaBnrFilter::process(const float* samples, int numSamples)
@@ -145,14 +146,6 @@ void NvidiaBnrFilter::workerLoop()
     // pushes to m_outBuf. All gRPC I/O happens here, never on audio/main thread.
 
     while (!m_stopping.load()) {
-        // Send config update if intensity changed
-        if (m_configDirty.exchange(false)) {
-            nvidia::maxine::bnr::v1::EnhanceAudioRequest configReq;
-            auto* config = configReq.mutable_config();
-            config->set_intensity_ratio(m_intensityRatio);
-            m_stream->Write(configReq);
-        }
-
         // Pull a frame from input buffer
         QByteArray frame;
         {

--- a/src/core/NvidiaBnrFilter.h
+++ b/src/core/NvidiaBnrFilter.h
@@ -60,7 +60,6 @@ private:
     std::thread m_workerThread;
     std::atomic<bool> m_connected{false};
     std::atomic<bool> m_stopping{false};
-    std::atomic<bool> m_configDirty{false};
 
     // Input buffer: audio thread writes, worker thread reads
     QMutex m_inMutex;

--- a/src/gui/AetherDspDialog.cpp
+++ b/src/gui/AetherDspDialog.cpp
@@ -43,6 +43,8 @@ AetherDspDialog::AetherDspDialog(AudioEngine* audio, QWidget* parent)
             this,    &AetherDspDialog::dfnrAttenLimitChanged);
     connect(m_widget, &AetherDspWidget::dfnrPostFilterBetaChanged,
             this,    &AetherDspDialog::dfnrPostFilterBetaChanged);
+    connect(m_widget, &AetherDspWidget::bnrIntensityChanged,
+            this,    &AetherDspDialog::bnrIntensityChanged);
     connect(m_widget, &AetherDspWidget::nr4ReductionChanged,
             this,    &AetherDspDialog::nr4ReductionChanged);
     connect(m_widget, &AetherDspWidget::nr4SmoothingChanged,

--- a/src/gui/AetherDspDialog.h
+++ b/src/gui/AetherDspDialog.h
@@ -42,6 +42,8 @@ signals:
     // DFNR parameter changes
     void dfnrAttenLimitChanged(float dB);
     void dfnrPostFilterBetaChanged(float beta);
+    // BNR parameter changes
+    void bnrIntensityChanged(float ratio);
     // NR4 parameter changes
     void nr4ReductionChanged(float dB);
     void nr4SmoothingChanged(float pct);

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -323,8 +323,10 @@ void AetherDspWidget::resetCurrentTab()
     } else if (name == "DFNR") {
         if (m_dfnrAttenSlider) m_dfnrAttenSlider->setValue(100);
         if (m_dfnrBetaSlider)  m_dfnrBetaSlider->setValue(0);
+    } else if (name == "BNR") {
+        if (m_bnrIntensitySlider) m_bnrIntensitySlider->setValue(100);
     }
-    // RN2 / BNR have no adjustable parameters — Reset Defaults is a no-op.
+    // RN2 has no adjustable parameters — Reset Defaults is a no-op.
 }
 
 void AetherDspWidget::setCompactMode(bool on)
@@ -340,11 +342,13 @@ void AetherDspWidget::setCompactMode(bool on)
                        m_nr4ReductionLabel, m_nr4SmoothingLabel, m_nr4WhiteningLabel,
                        m_nr4MaskingLabel, m_nr4SuppressionLabel,
                        m_mnrStrengthLabel,
-                       m_dfnrAttenLabel, m_dfnrBetaLabel }) {
+                       m_dfnrAttenLabel, m_dfnrBetaLabel,
+                       m_bnrIntensityLabel }) {
         if (lbl) lbl->setMinimumWidth(valWidth);
     }
     if (m_dfnrAttenLabel) m_dfnrAttenLabel->setFixedWidth(valWidth);
     if (m_dfnrBetaLabel)  m_dfnrBetaLabel->setFixedWidth(valWidth);
+    if (m_bnrIntensityLabel) m_bnrIntensityLabel->setFixedWidth(valWidth);
 }
 
 void AetherDspWidget::setDialogMode(bool on)
@@ -919,15 +923,62 @@ QWidget* AetherDspWidget::buildBnrPage()
 {
     auto* page = new QWidget;
     auto* vbox = new QVBoxLayout(page);
-    auto* lbl = new QLabel(
-        "NVIDIA Broadcast — GPU-accelerated AI noise removal.  Strongest "
-        "against non-stationary noise (typing, traffic, dogs barking).  "
-        "Requires an NVIDIA GPU with the Broadcast SDK.  Intensity is "
-        "controlled from the slice overlay menu.");
-    lbl->setWordWrap(true);
-    lbl->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(lbl, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
-    vbox->addWidget(lbl);
+    // Match the DFNR tab: 20 px top breathing room between the DSP
+    // selector buttons and the info paragraph; 10 px left margin.
+    vbox->setContentsMargins(10, 20, 0, 0);
+
+    auto* grid = new QGridLayout;
+    grid->setColumnStretch(1, 1);
+
+    auto& s = AppSettings::instance();
+
+    auto* info = new QLabel(
+        "NVIDIA — GPU-accelerated AI noise removal. Strongest against "
+        "non-stationary noise (typing, traffic, dogs barking). Requires an "
+        "NVIDIA GPU and the Maxine BNR container.");
+    info->setWordWrap(true);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(info, "QLabel { color: {{color.text.secondary}}; font-size: 12px; }");
+    {
+        auto* infoRow = new QHBoxLayout;
+        infoRow->setContentsMargins(0, 0, 10, 0);
+        infoRow->addWidget(info);
+        vbox->addLayout(infoRow);
+    }
+
+    {
+        auto* resetRow = new QHBoxLayout;
+        resetRow->setContentsMargins(0, 10, 10, 0);
+        resetRow->addStretch(1);
+        auto* bnrResetBtn = makeResetIconButton();
+        connect(bnrResetBtn, &QPushButton::clicked,
+                this, &AetherDspWidget::resetCurrentTab);
+        resetRow->addWidget(bnrResetBtn);
+        vbox->addLayout(resetRow);
+    }
+
+    grid->addWidget(new QLabel("Intensity"), 1, 0);
+    m_bnrIntensitySlider = new QSlider(Qt::Horizontal);
+    m_bnrIntensitySlider->setRange(0, 100);
+    m_bnrIntensitySlider->setValue(static_cast<int>(s.value("BnrIntensity", "100").toFloat()));
+    m_bnrIntensitySlider->setAccessibleName("BNR Intensity");
+    applyPrimarySliderStyle(m_bnrIntensitySlider);
+    m_bnrIntensitySlider->setToolTip("Denoising strength sent to the BNR engine.\n"
+                                     "0% = passthrough (no denoising)\n"
+                                     "100% = maximum noise removal");
+    grid->addWidget(m_bnrIntensitySlider, 1, 1);
+    m_bnrIntensityLabel = new QLabel(QString::number(m_bnrIntensitySlider->value()) + "%");
+    m_bnrIntensityLabel->setFixedWidth(40);
+    grid->addWidget(m_bnrIntensityLabel, 1, 2);
+
+    connect(m_bnrIntensitySlider, &QSlider::valueChanged, this, [this](int v) {
+        m_bnrIntensityLabel->setText(QString::number(v) + "%");
+        auto& s = AppSettings::instance();
+        s.setValue("BnrIntensity", QString::number(v));
+        s.save();
+        emit bnrIntensityChanged(v / 100.0f);
+    });
+
+    vbox->addLayout(grid);
     vbox->addStretch();
     return page;
 }
@@ -1104,6 +1155,11 @@ void AetherDspWidget::syncFromEngine()
         int beta = static_cast<int>(s.value("DfnrPostFilterBeta", "0.0").toFloat() * 100);
         m_dfnrBetaSlider->setValue(beta);
         m_dfnrBetaLabel->setText(QString::number(beta / 100.0f, 'f', 2));
+    }
+    if (m_bnrIntensitySlider) {
+        int intensity = static_cast<int>(s.value("BnrIntensity", "100").toFloat());
+        m_bnrIntensitySlider->setValue(intensity);
+        m_bnrIntensityLabel->setText(QString::number(intensity) + "%");
     }
 }
 

--- a/src/gui/AetherDspWidget.h
+++ b/src/gui/AetherDspWidget.h
@@ -68,6 +68,8 @@ signals:
     // DFNR parameter changes
     void dfnrAttenLimitChanged(float dB);
     void dfnrPostFilterBetaChanged(float beta);
+    // BNR parameter changes
+    void bnrIntensityChanged(float ratio);
     // NR4 parameter changes
     void nr4ReductionChanged(float dB);
     void nr4SmoothingChanged(float pct);
@@ -92,7 +94,7 @@ private:
     QWidget* buildDfnrPage();
 
     // Restore defaults for the currently-selected DSP page.  No-op for
-    // RN2 / BNR which expose no adjustable parameters.
+    // RN2 which exposes no adjustable parameters.
     void resetCurrentTab();
 
     // Click handler for the per-DSP selector buttons.  index = DspId.
@@ -142,6 +144,10 @@ private:
     QLabel*       m_dfnrAttenLabel{nullptr};
     QSlider*      m_dfnrBetaSlider{nullptr};
     QLabel*       m_dfnrBetaLabel{nullptr};
+
+    // BNR controls
+    QSlider*      m_bnrIntensitySlider{nullptr};
+    QLabel*       m_bnrIntensityLabel{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -366,6 +366,10 @@ void MainWindow::wireAetherDspWidget(AetherDspWidget* w)
     connect(w, &AetherDspWidget::dfnrPostFilterBetaChanged, this, [this](float v) {
         QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setDfnrPostFilterBeta(v); });
     });
+    // BNR
+    connect(w, &AetherDspWidget::bnrIntensityChanged, this, [this](float v) {
+        QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setBnrIntensity(v); });
+    });
     // MNR
     connect(w, &AetherDspWidget::mnrEnabledChanged, this, [this](bool on) {
         QMetaObject::invokeMethod(m_audio, [this, on]() { m_audio->setMnrEnabled(on); });


### PR DESCRIPTION
## Summary

Restores the BNR **Intensity** slider removed in the #2297 DSP refactor — and fixes the backend so it actually works. Restoring the GUI control alone wasn't enough: the BNR path never honored intensity at runtime.

Fixes #3815.

## Root cause (two backend defects)

1. **Enable ignored the saved value.** `AudioEngine::setBnrEnabled` builds a fresh `NvidiaBnrFilter` at its `1.0` default and connects without applying the persisted intensity — so BNR always opened at 100% regardless of the slider.
2. **Live changes were dropped.** A slider change only wrote an `EnhanceAudioConfig` *mid-stream*, but the Maxine BNR container reads `intensity_ratio` only from the **first** message of a stream (see `src/core/proto/bnr.proto`) and ignores later config. So dragging the slider did nothing.

## Changes

- **GUI** (`AetherDspWidget`, `AetherDspDialog`, `MainWindow_Wiring`): restore the Intensity slider (0–100%, mirrors the DFNR tab), persist as `BnrIntensity`, restore in `syncFromEngine()`, add Reset Defaults (100%), and fix the stale "slice overlay menu" text.
- **`AudioEngine`**: owns the intensity (`m_bnrIntensity`); applies it as the first-message config when the stream opens; on a live change, reopens the stream (debounced 250 ms so a slider drag coalesces into one reconnect).
- **`NvidiaBnrFilter`**: removes the dead mid-stream config write (and `m_configDirty`) the container ignored.
- **CHANGELOG**: entry under Unreleased → Fixed.

## Testing

Built with `-DENABLE_BNR=ON` (Qt 6.8.3, GCC) and tested on a **FLEX-8400** (Ubuntu 24.04, RTX 5060, `maxine-bnr:1.0.0` container):

- 100% = full denoising, ~50% = partial, **0% = passthrough** ✅
- Enabling BNR with a saved value reconnects at that strength ✅
- Setting persists across restart ✅
- Reset Defaults → 100% ✅

There's a brief (~¼ s) audio reconnect when the intensity settles — that's the only way the container accepts a new value (first-message-only config), and it's debounced so a drag triggers just one.

## Scope / review tier

All touched files are Tier-3 (`@aethersdr/reviewers`): `src/gui/*` and `src/core/{AudioEngine,NvidiaBnrFilter}.*`, plus `CHANGELOG.md` (Tier-2). No protocol or build-config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
