### PR TITLE
fix(audio): cut RX speaker latency for USB and local audio (#3193)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1170,7 +1170,7 @@ AudioEngine::AudioEngine(QObject* parent)
 
     // RX pacing timer -- processes source queues through their RX DSP paths
     // and drains speaker-ready output into QAudioSink at regular intervals.
-    // Includes latency management: caps buffer at ~200ms to prevent unbounded
+    // Includes latency management: caps buffer at ~100ms to prevent unbounded
     // growth when network packets arrive in bursts (common on Windows WASAPI
     // with virtual audio routers like Voicemeeter).
     m_rxTimer = new QTimer(this);
@@ -1179,7 +1179,7 @@ AudioEngine::AudioEngine(QObject* parent)
     connect(m_rxTimer, &QTimer::timeout, this, [this]() {
         if (!m_audioSink || !m_audioDevice || !m_audioDevice->isOpen() || m_audioSink->state() == QAudio::StoppedState) return;
 
-        // Cap buffer to bound latency. Default 200ms, user-adjustable for
+        // Cap buffer to bound latency. Default 100ms, user-adjustable for
         // high-jitter connections (VPN, SmartLink) where drops cause choppy audio.
         const int sampleRate = m_rxOutputRate.load();
         const bool kiwiAudio = kiwiSdrAudioActive();
@@ -2264,6 +2264,18 @@ bool AudioEngine::startRxStream()
         noteRxAttempt(candidate);
         auto* sink = new QAudioSink(dev, candidate, this);
         sink->setVolume(m_muted.load() ? 0.0f : m_rxVolume.load());
+#ifdef Q_OS_WIN
+        // Constrain the WASAPI shared-mode ring buffer (#3193). Without an explicit
+        // size, class-compliant USB interfaces (Scarlett, Focusrite, etc.) inherit
+        // their driver's default ring of 100-300 ms, which stacks on top of the
+        // app-side m_rxBufferCapMs cap and produces 300-500 ms+ speaker latency.
+        // A 50 ms device buffer is comfortably fed by the 10 ms RX drain timer and
+        // mirrors the explicit buffers already used for the sidetone/Quindar sinks.
+        constexpr int kWinRxDeviceBufferMs = 50;
+        const qint64 winRxBufBytes = candidate.bytesForDuration(kWinRxDeviceBufferMs * 1000LL);
+        if (winRxBufBytes > 0)
+            sink->setBufferSize(static_cast<qsizetype>(winRxBufBytes));
+#endif
         QIODevice* io = sink->start();   // push-mode
         if (io) {
             m_audioSink = sink;

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -735,7 +735,7 @@ private:
     QPointer<QIODevice> m_audioDevice;   // sink-owned device, may vanish on hot-unplug
 
     // Dedicated low-latency sink for the local CW sidetone — kept separate
-    // from the RX sink so the RX path keeps its 200 ms jitter cushion.
+    // from the RX sink so the RX path keeps its 100 ms jitter cushion.
     // Backend chosen at start time: PortAudio when HAVE_PORTAUDIO and not
     // disabled by AppSettings["CwSidetoneBackend"]=="QAudioSink"; QAudioSink
     // (push mode, 2 ms timer, 50 ms buffer) otherwise.  See CwSidetoneSinkBackend.h.
@@ -804,7 +804,7 @@ private:
     std::atomic<bool>  m_rxBoost{false};  // 50% software gain boost (#1445)
     std::atomic<float> m_rxOutputTrimDb{0.0f};  // ±12 dB linear trim, post-boost
     std::atomic<int>   m_rxPan{50};       // 0=left, 50=centre, 100=right (#1460)
-    std::atomic<int>   m_rxBufferCapMs{200}; // RX buffer cap in ms (#1505)
+    std::atomic<int>   m_rxBufferCapMs{100}; // RX buffer cap in ms (#1505; default lowered 200->100 for #3193)
     std::atomic<bool>  m_muted{false};
     // RX sink device rate (negotiated via AudioFormatNegotiator). Audio is
     // resampled from the 24k canonical rate up to this when they differ (#3306).

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1009,7 +1009,7 @@ MainWindow::MainWindow(QWidget* parent)
     m_audio->setRxOutputTrimDb(
         AppSettings::instance().value("RxOutputTrimDb", "0.0").toFloat());
     m_audio->setRxBufferCapMs(
-        AppSettings::instance().value("AudioBufferMs", "200").toInt());
+        AppSettings::instance().value("AudioBufferMs", "100").toInt());
     m_audio->moveToThread(m_audioThread);
     m_audioThread->start();
     syncReceivePresentationDelaysToAudioEngine();

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -2414,7 +2414,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         auto* bufLabel = new QLabel("Audio Buffer:");
         bufLabel->setStyleSheet(kLabelStyle);
         bufLabel->setFixedWidth(90);
-        int bufMs = AppSettings::instance().value("AudioBufferMs", "200").toInt();
+        int bufMs = AppSettings::instance().value("AudioBufferMs", "100").toInt();
         auto* bufEdit = new QLineEdit(QString::number(bufMs));
         bufEdit->setStyleSheet(kEditStyle);
         bufEdit->setFixedWidth(50);


### PR DESCRIPTION
## Problem

RX speaker latency is higher than it needs to be, most visibly for Windows users on external class-compliant USB audio interfaces (#3193), where the TX→RX transition and general monitoring lag by 300–500 ms+. Two independent code paths contribute:

1. **App-side RX buffer cap is conservative.** `m_rxBufferCapMs` has defaulted to **200 ms** since it was introduced (#1505) as a cushion for high-jitter links. For the common wired/LAN case that is avoidable latency.

2. **The Windows RX sink never constrains its device buffer.** `startRxStream()` constructs the RX `QAudioSink` and calls `start()` with no prior `setBufferSize()`. WASAPI shared mode then applies the device's *default* ring buffer, which for USB interfaces (Scarlett Solo, Focusrite, etc.) is typically **100–300 ms**. That stacks on top of the app-side cap.

## Changes

**1. Lower the RX buffer cap default 200 ms → 100 ms.**
The setting remains fully user-adjustable (50–1000 ms) for VPN/SmartLink users who need a larger cushion — only the default changes, and existing users who have set their own value keep it. Updated consistently in three places: the engine default (`AudioEngine.h`), the settings load (`MainWindow.cpp`), and the Radio Setup dialog field (`RadioSetupDialog.cpp`).

**2. Set an explicit 50 ms device buffer on the Windows RX path.**
Before `start()`, on `Q_OS_WIN`, we call `setBufferSize(candidate.bytesForDuration(50 ms))`. 50 ms is comfortably fed by the existing 10 ms RX drain timer and mirrors the explicit buffers already used by the sidetone and Quindar sinks. macOS/Linux are unchanged (guarded by `#ifdef`).

Combined, these take the worst-case Windows USB path from ~300–500 ms toward ~150 ms, without touching the high-jitter escape hatch.

## Credit

The Windows device-buffer approach (change 2) revives the RX half of the original fix proposed by **@M7HNF-Ian** in #3194, which was never merged pending on-hardware validation. Ian is credited as a co-author on the commit. (The CW-sidetone half of #3194 shipped separately as #3241.)

## Testing

- Built clean on macOS (RelWithDebInfo, Qt 6 / Homebrew). The Windows device-buffer block is `#ifdef Q_OS_WIN` and not exercised by the macOS build.
- **Needs Windows on-hardware validation** with a USB interface (the #3193 reporter's Scarlett Solo Gen4 is ideal) to confirm the latency reduction and that 50 ms does not introduce underruns. Left as **draft** pending that.

Addresses #3193.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat