### PR TITLE
feat(gui): stacked-trace spectrum stream panadapter render mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,7 @@ set(GUI_SOURCES
     src/gui/ConnectedStationsDialog.cpp
     src/gui/SpectrumWidget.cpp
     src/gui/SpectrumOverlayMenu.cpp
+    src/gui/DssRenderer.cpp
     src/gui/FrequencyEntryParser.cpp
     src/gui/SliceColorManager.cpp
     src/gui/SliceLabel.cpp
@@ -1297,6 +1298,8 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/overlay.frag
             resources/shaders/spectrum.vert
             resources/shaders/spectrum.frag
+            resources/shaders/dss_mesh.vert
+            resources/shaders/dss_mesh.frag
     )
 endif()
 

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -1,0 +1,48 @@
+#version 440
+
+// Companion to dss_mesh.vert. Fill vertices (edge >= 0) are coloured by a
+// floor->peak palette LUT with a vertical gradient (ridge = signal colour,
+// floor = floor colour) and hazed toward the background with depth. Outline
+// vertices (edge < 0) draw a dim, depth-faded hairline along each ridge — the
+// per-row trace line.
+
+layout(location = 0) in float vLut;
+layout(location = 1) in float vDepth;
+layout(location = 2) in float vEdge;
+
+layout(std140, binding = 0) uniform U {
+    float rowOffset;
+    float floorDbm;
+    float rangeDb;
+    float zCurve;
+    float backWidthFrac;
+    float depthSpanFrac;
+    float frontMaxRidgeFrac;
+    float haze;
+    float texCols;
+    float pad0;
+    float pad1;
+    float pad2;
+    vec4  bgFill;
+};
+
+layout(binding = 2) uniform sampler2D paletteLut;  // 256x1 RGBA8, floor(0)->peak(1)
+
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
+
+    if (vEdge < -0.5) {
+        // Dim trace outline — light hairline, brighter at the front, fading back.
+        vec3  oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
+        float a  = 0.12 + 0.5 * fade;
+        fragColor = vec4(oc, a);
+        return;
+    }
+
+    vec3 c = texture(paletteLut, vec2(clamp(vLut, 0.0, 1.0), 0.5)).rgb;
+    c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
+    fragColor = vec4(c, 1.0);
+}

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -1,0 +1,63 @@
+#version 440
+
+// 3DSS GPU height-map mesh. Each vertex carries its grid position (u = column,
+// v = row/depth) and an edge tag. The height comes from a ring-buffered dBm
+// texture; geometry is a receding perspective trapezoid built entirely on the
+// GPU, so pan/zoom never rebuild any vertices. Outputs NDC directly (matching
+// spectrum.vert); occlusion is by back-to-front draw order, not a depth test.
+
+layout(location = 0) in vec3 inVert;   // x = u [0,1] col, y = v [0,1) row(0=front), z = edge
+
+layout(std140, binding = 0) uniform U {
+    float rowOffset;          // (headRow + 0.5) / rows — ring scroll + half texel
+    float floorDbm;           // dBm mapped to the baseline (strength 0)
+    float rangeDb;            // dB span from floor to full ridge
+    float zCurve;             // <1 expands the floor region (more floor visible)
+    float backWidthFrac;      // back row width as a fraction of the front
+    float depthSpanFrac;      // how far up the plot the back row recedes
+    float frontMaxRidgeFrac;  // max ridge height (front) as a fraction of plot H
+    float haze;               // atmospheric fade toward bgFill with depth
+    float texCols;            // height-texture width, for column texel-centre sampling
+    float pad0;
+    float pad1;
+    float pad2;
+    vec4  bgFill;             // plot background colour (for haze)
+};
+
+layout(binding = 1) uniform sampler2D heightTex;  // R16F, dBm, ring-buffered rows
+
+layout(location = 0) out float vLut;    // palette lookup coord (floor->peak gradient)
+layout(location = 1) out float vDepth;  // row depth 0..1 for haze/fade
+layout(location = 2) out float vEdge;   // edge tag passthrough
+
+void main()
+{
+    float u    = inVert.x;
+    float v    = inVert.y;     // 0 = front/newest .. ~1 = back/oldest
+    float edge = inVert.z;     // 0 = ridge, 1 = floor, -1 = outline
+
+    // Sample texel CENTRES on both axes so Nearest filtering can't pick up the
+    // neighbouring row/column. rowOffset already carries the row half-texel; the
+    // column maps geometry u in [0,1] onto centre (u*(cols-1)+0.5)/cols.
+    float texY = fract(rowOffset + v);
+    float texU = (texCols > 1.0) ? (u * (texCols - 1.0) + 0.5) / texCols : 0.5;
+    float dbm  = texture(heightTex, vec2(texU, texY)).r;
+    // Linear strength drives COLOUR (LUT[sLin] = dbmToRgb(floor+sLin*range),
+    // matching the CPU path); the zCurve lift applies to HEIGHT only.
+    float sLin = clamp((dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
+    float sH   = pow(sLin, max(zCurve, 0.05));   // non-linear Z: lift floor band
+
+    // Receding perspective trapezoid in plot space [0,1] (0,0 = top-left).
+    float w     = mix(1.0, backWidthFrac, v);          // narrows with depth
+    float plotX = 0.5 + (u - 0.5) * w;
+    float baseY = mix(1.0, 1.0 - depthSpanFrac, v);    // baseline rises with depth
+    float ridge = sH * frontMaxRidgeFrac * w;          // far ridges shorter
+    float topY  = baseY - ridge;                       // up = smaller y
+    float plotY = (edge > 0.5) ? 1.0 : topY;           // floor edge -> plot bottom
+
+    gl_Position = vec4(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0, 0.0, 1.0);
+
+    vLut   = (edge > 0.5) ? 0.0 : sLin;  // ridge = signal colour, floor = floor colour
+    vDepth = v;
+    vEdge  = edge;
+}

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -57,7 +57,10 @@ void main()
 
     gl_Position = vec4(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0, 0.0, 1.0);
 
-    vLut   = (edge > 0.5) ? 0.0 : sLin;  // ridge = signal colour, floor = floor colour
+    // Ridge carries the full signal colour; the floor edge keeps a dimmer share
+    // of it (not pure palette[0]) so the whole curtain stays tinted by the
+    // colormap instead of fading to black between the white trace lines.
+    vLut   = (edge > 0.5) ? sLin * 0.6 : sLin;
     vDepth = v;
     vEdge  = edge;
 }

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -1,0 +1,260 @@
+#include "DssRenderer.h"
+
+#include <QPainter>
+#include <QPolygonF>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// CPU-only tunables. The perspective geometry (back-width / depth-span /
+// front-ridge / haze) lives in DssRenderer.h as shared constants so the GPU
+// mesh uses the same values; these are extra CPU-render touches the GPU frag
+// doesn't replicate (depth dimming floor, smoothing, slope shading).
+constexpr double kMinDim        = 0.50;  // depth dimming never falls below this
+constexpr float  kTemporalAlpha = 0.60f; // temporal IIR: fraction of the new row
+constexpr double kSlopeGain     = 0.55;  // slope shading strength
+constexpr double kShadeLo       = 0.68;
+constexpr double kShadeHi       = 1.32;
+
+inline int chan(double v) { return static_cast<int>(std::clamp(v, 0.0, 255.0)); }
+
+inline float median3(float a, float b, float c)
+{
+    return std::max(std::min(a, b), std::min(std::max(a, b), c));
+}
+
+inline QColor scaled(const QColor& c, double f)
+{
+    f = std::max(0.0, f);
+    return QColor(chan(c.red() * f), chan(c.green() * f), chan(c.blue() * f));
+}
+
+// Linear blend c -> t by f in [0,1].
+inline QColor lerpColor(const QColor& c, const QColor& t, double f)
+{
+    f = std::clamp(f, 0.0, 1.0);
+    return QColor(chan(c.red()   + (t.red()   - c.red())   * f),
+                  chan(c.green() + (t.green() - c.green()) * f),
+                  chan(c.blue()  + (t.blue()  - c.blue())  * f));
+}
+
+} // namespace
+
+void DssRenderer::clear()
+{
+    m_head  = 0;
+    m_count = 0;
+    m_dirty = true;
+    m_rawHistCount = 0;
+}
+
+const std::array<float, DssRenderer::kCols>&
+DssRenderer::rowAt(int age) const
+{
+    const int idx = (m_head + age) % kRows;
+    return m_rows[idx];
+}
+
+void DssRenderer::pushRow(const QVector<float>& binsDbm)
+{
+    const int n = binsDbm.size();
+    std::array<float, kCols> nr;
+
+    if (n <= 0) {
+        nr.fill(-200.0f);
+    } else {
+        std::array<float, kCols> raw;
+        const double step = static_cast<double>(n) / kCols;
+        for (int c = 0; c < kCols; ++c) {
+            // Peak-preserving downsample: take the strongest bin in the source
+            // span so signals survive as ridges. Upsampling (n < kCols)
+            // collapses the span to a single source bin.
+            int i0 = static_cast<int>(std::floor(c * step));
+            int i1 = static_cast<int>(std::ceil((c + 1) * step));
+            i0 = std::clamp(i0, 0, n - 1);
+            i1 = std::clamp(i1, i0 + 1, n);
+            float mx = binsDbm[i0];
+            for (int i = i0 + 1; i < i1; ++i) {
+                mx = std::max(mx, binsDbm[i]);
+            }
+            raw[c] = mx;
+        }
+
+        // Temporal median-of-3 impulse rejection. A strong broadband
+        // interference burst lasts only ~1 FFT frame but, once stored, becomes a
+        // full-height "wall" that recedes (and flickers) across the whole
+        // surface. As the outlier of {this, prev, prev2}, such a 1-frame spike
+        // is discarded here before it ever enters the height history. Steady
+        // signals are the median of ~equal values, so they pass through
+        // unchanged (this is an outlier rejector, not a low-pass).
+        if (m_rawHistCount >= 2) {
+            for (int c = 0; c < kCols; ++c) {
+                nr[c] = median3(raw[c], m_rawPrev1[c], m_rawPrev2[c]);
+            }
+        } else {
+            nr = raw;
+        }
+        // Shift the raw history (store the ORIGINAL raw row, not the median).
+        m_rawPrev2 = m_rawPrev1;
+        m_rawPrev1 = raw;
+        m_rawHistCount = std::min(m_rawHistCount + 1, 2);
+
+        // Spatial 3-tap low-pass — the textbook cure for the peak-detector
+        // "comb" striping (a video-bandwidth analogue).
+        std::array<float, kCols> sm = nr;
+        for (int c = 0; c < kCols; ++c) {
+            const float a = nr[std::max(0, c - 1)];
+            const float b = nr[c];
+            const float d = nr[std::min(kCols - 1, c + 1)];
+            sm[c] = 0.25f * a + 0.5f * b + 0.25f * d;
+        }
+        nr = sm;
+    }
+
+    // Temporal IIR against the current newest row → fluid scroll + denoise.
+    if (m_count > 0) {
+        const auto& prev = m_rows[m_head];
+        for (int c = 0; c < kCols; ++c) {
+            nr[c] = kTemporalAlpha * nr[c] + (1.0f - kTemporalAlpha) * prev[c];
+        }
+    }
+
+    m_head = (m_head - 1 + kRows) % kRows;
+    m_rows[m_head] = nr;
+    m_count = std::min(m_count + 1, kRows);
+    m_dirty = true;
+}
+
+const QImage& DssRenderer::image(const QSize& px, int scaleStripPx,
+                                 float floorDbm, float rangeDb, float zCurve,
+                                 const PaletteFn& palette,
+                                 quint64 paletteToken,
+                                 const QColor& bgFill)
+{
+    const bool changed = m_dirty
+        || px != m_cacheSize
+        || scaleStripPx != m_cacheScaleStrip
+        || floorDbm != m_cacheFloor
+        || rangeDb != m_cacheRange
+        || zCurve != m_cacheZCurve
+        || paletteToken != m_cachePaletteToken;
+
+    if (changed) {
+        rebuild(px, scaleStripPx, floorDbm, rangeDb, zCurve, palette, bgFill);
+        ++m_generation;
+        m_cacheSize         = px;
+        m_cacheScaleStrip   = scaleStripPx;
+        m_cacheFloor        = floorDbm;
+        m_cacheRange        = rangeDb;
+        m_cacheZCurve       = zCurve;
+        m_cachePaletteToken = paletteToken;
+        m_dirty             = false;
+    }
+    return m_cache;
+}
+
+void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
+                          float rangeDb, float zCurve, const PaletteFn& palette,
+                          const QColor& bgFill)
+{
+    const int W = px.width();
+    const int Htot = px.height();
+    if (W <= 0 || Htot <= 0) {
+        m_cache = QImage();
+        return;
+    }
+
+    if (m_cache.size() != px || m_cache.format() != QImage::Format_RGBA8888_Premultiplied) {
+        m_cache = QImage(px, QImage::Format_RGBA8888_Premultiplied);
+    }
+    m_cache.fill(Qt::transparent);
+
+    // Plot region is everything above the (transparent) scale strip.
+    const double H = std::max(1, Htot - std::max(0, scaleStripPx));
+
+    QPainter p(&m_cache);
+    p.fillRect(QRectF(0, 0, W, H), bgFill);
+
+    if (m_count <= 0 || !palette || rangeDb <= 0.0f) {
+        return;
+    }
+
+    const double zc            = std::max(0.05, static_cast<double>(zCurve));
+    const double bottomY       = H;                       // plot floor
+    const double depthSpan     = H * kDepthSpanFrac;
+    const double frontMaxRidge = H * kFrontMaxRidgeFrac;
+    // Match dss_mesh.vert's depth parametrization exactly (v = rr / rows), so
+    // the CPU fallback and the GPU mesh place rows at the same depth.
+    const double denom         = kRows;
+
+    std::array<QPointF, kCols> pts;
+    std::array<QColor, kCols>  cols;   // depth/slope-shaded fill colour per column
+
+    QPolygonF poly;                    // reused (clear keeps capacity → no realloc)
+    poly.reserve(4);
+    QPen ridgePen;
+    ridgePen.setCosmetic(true);
+    ridgePen.setCapStyle(Qt::RoundCap);
+    ridgePen.setJoinStyle(Qt::RoundJoin);
+
+    // Back (oldest) → front (newest): painter's algorithm. Nearer traces are
+    // wider, sit lower, and fill to the floor, so they occlude farther ones.
+    for (int age = m_count - 1; age >= 0; --age) {
+        const double depthFrac    = age / denom;
+        const double rowWidthFrac = 1.0 - depthFrac * (1.0 - kBackWidthFrac);
+        const double inset        = W * (1.0 - rowWidthFrac) * 0.5;
+        const double rowW         = W - 2.0 * inset;
+        const double baselineY    = bottomY - depthFrac * depthSpan;
+        const double maxRidge     = frontMaxRidge * rowWidthFrac;
+        const double dim          = kMinDim + (1.0 - kMinDim) * (1.0 - depthFrac);
+
+        const auto& row = rowAt(age);
+        // Pass 1: geometry — noise-floor-anchored ridge heights, with the same
+        // pow(s, zCurve) floor-lift the GPU shader applies.
+        for (int c = 0; c < kCols; ++c) {
+            const double x = inset + (kCols > 1 ? double(c) / (kCols - 1) : 0.0) * rowW;
+            const float dbm = row[c];
+            double strength = std::clamp((dbm - floorDbm) / rangeDb, 0.0f, 1.0f);
+            strength = std::pow(strength, zc);
+            pts[c] = QPointF(x, baselineY - strength * maxRidge);
+        }
+        // Pass 2: colour — palette by amplitude, hazed by depth, lit by slope.
+        const double slopeScale = (maxRidge > 1.0) ? maxRidge : 1.0;
+        for (int c = 0; c < kCols; ++c) {
+            const int cl = std::max(0, c - 1);
+            const int cr = std::min(kCols - 1, c + 1);
+            const double slope = (pts[cl].y() - pts[cr].y()) / slopeScale; // +: rises to right
+            const double shade = std::clamp(1.0 + kSlopeGain * slope, kShadeLo, kShadeHi);
+            QColor base = QColor(palette(row[c]));
+            base = lerpColor(base, bgFill, depthFrac * kHaze);
+            cols[c] = scaled(base, dim * shade);
+        }
+
+        // Fill — flat per-column trapezoid to the floor. AA off so adjacent
+        // columns tile without seams; the AA ridge line on top hides the
+        // jagged upper edge. No per-column gradient → no per-column allocs.
+        p.setRenderHint(QPainter::Antialiasing, false);
+        p.setPen(Qt::NoPen);
+        for (int c = 0; c < kCols - 1; ++c) {
+            poly.clear();
+            poly << pts[c] << pts[c + 1]
+                 << QPointF(pts[c + 1].x(), bottomY)
+                 << QPointF(pts[c].x(), bottomY);
+            p.setBrush(cols[c]);
+            p.drawPolygon(poly);
+        }
+
+        // Ridge line — bright per-amplitude rim, AA on for a crisp crest.
+        p.setRenderHint(QPainter::Antialiasing, true);
+        ridgePen.setWidthF(age == 0 ? 1.6 : 1.0);
+        for (int c = 0; c < kCols - 1; ++c) {
+            QColor rc = QColor(palette(row[c])).lighter(165);
+            rc = lerpColor(rc, bgFill, depthFrac * kHaze);
+            ridgePen.setColor(scaled(rc, dim));
+            p.setPen(ridgePen);
+            p.drawLine(pts[c], pts[c + 1]);
+        }
+    }
+}

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <QColor>
+#include <QImage>
+#include <QSize>
+#include <QVector>
+
+#include <array>
+#include <functional>
+
+// ─── Stacked-trace spectrum stream surface ──────────────────────────────────
+//
+// Renders a perspective stacked-trace spectrum stream: a rolling history of FFT
+// rows drawn back-to-front (painter's algorithm) as a receding trapezoid. The
+// newest trace spans the full width across the front; older traces recede into
+// a narrower, higher trapezoid. Each ridge is filled down to the plot floor so
+// nearer traces occlude farther ones. Fill colour follows amplitude via an
+// injected palette and dims with depth for atmospheric perspective; a bright
+// per-amplitude line tops each ridge.
+//
+// The rendered surface is cached in a QImage and rebuilt ONLY when a new row
+// arrives, the target size changes, or the amplitude mapping / palette changes.
+// This keeps it cheap enough to paint on the CPU and composite through the
+// existing QRhi overlay pipeline (no new shaders). The renderer is standalone
+// and knows nothing about SpectrumWidget or QRhi.
+class DssRenderer
+{
+public:
+    static constexpr int kRows = 96;   // history depth (front → back)
+    static constexpr int kCols = 768;  // resampled columns per row
+
+    // Perspective geometry of the surface, shared by this CPU renderer and the
+    // GPU mesh UBO (SpectrumWidget::renderGpuFrame). dss_mesh.vert applies the
+    // SAME formulas with these values passed as uniforms — single source of
+    // truth so the CPU fallback and the GPU mesh can't drift apart.
+    static constexpr float kBackWidthFrac     = 0.60f;  // back row width / front
+    static constexpr float kDepthSpanFrac     = 0.58f;  // baseline rise to the back
+    static constexpr float kFrontMaxRidgeFrac = 0.46f;  // front ridge height / plot H
+    static constexpr float kHaze              = 0.28f;  // fade toward bg with depth
+
+    // Maps a dBm value to an RGB colour using the host's panadapter palette.
+    using PaletteFn = std::function<QRgb(float dbm)>;
+
+    // Push one freshly-decoded FFT row (any bin count, dBm). Peak-preserving
+    // downsample to kCols and store it as the newest (front) trace.
+    void pushRow(const QVector<float>& binsDbm);
+
+    // Return the cached surface sized to px. The plot region (everything above
+    // the bottom scaleStripPx) is painted opaque over bgFill; the scale strip
+    // is left transparent so the host can composite a scale on top.
+    //
+    // Ridge HEIGHT is anchored to the noise floor: a column maps to
+    // strength = clamp((dbm - floorDbm) / rangeDb, 0, 1), so floorDbm sits at
+    // the baseline (≈0 height) and floorDbm+rangeDb reaches the full ridge. The
+    // host supplies floorDbm from its measured-noise-floor estimate and rangeDb
+    // from the Ref-derived span, mirroring the 2D auto-noise-floor behaviour.
+    // Colour comes from palette(dbm), independent of height. paletteToken lets
+    // the host signal palette changes without us inspecting them. Rebuilds only
+    // when something relevant changed.
+    // zCurve (<1) lifts the floor→signal band, matching dss_mesh.vert's
+    // pow(s, zCurve) so the CPU fallback surfaces the noise floor like the GPU.
+    const QImage& image(const QSize& px, int scaleStripPx,
+                        float floorDbm, float rangeDb, float zCurve,
+                        const PaletteFn& palette, quint64 paletteToken,
+                        const QColor& bgFill);
+
+    void invalidate() { m_dirty = true; }
+    bool hasData() const { return m_count > 0; }
+    void clear();
+
+    // ── Data-model accessors for the GPU mesh path ──────────────────────────
+    // The renderer doubles as the smoothed dBm ring store that the GPU height-map
+    // mesh uploads from (one new row per frame). Indices are RING indices.
+    int cols() const { return kCols; }
+    int rows() const { return kRows; }
+    int rowCount() const { return m_count; }     // valid rows (0..kRows)
+    int headRing() const { return m_head; }       // ring index of the newest row
+    const float* rowDataRing(int ringIndex) const { return m_rows[ringIndex].data(); }
+
+    // Increments on every cache rebuild — lets the GPU path upload the texture
+    // only when the surface actually changed.
+    quint64 generation() const { return m_generation; }
+
+private:
+    void rebuild(const QSize& px, int scaleStripPx, float floorDbm,
+                 float rangeDb, float zCurve, const PaletteFn& palette,
+                 const QColor& bgFill);
+
+    // Returns the dBm row at the given age (0 = newest/front).
+    const std::array<float, kCols>& rowAt(int age) const;
+
+    // Circular store: m_head indexes the newest row.
+    std::array<std::array<float, kCols>, kRows> m_rows{};
+    int     m_head  = 0;         // index of the newest row
+    int     m_count = 0;         // number of valid rows (0..kRows)
+    bool    m_dirty = true;
+    quint64 m_generation = 0;    // bumped on each rebuild
+
+    // Last two RAW (pre-smoothing) resampled rows, for temporal median-of-3
+    // impulse rejection of broadband interference bursts.
+    std::array<float, kCols> m_rawPrev1{};
+    std::array<float, kCols> m_rawPrev2{};
+    int m_rawHistCount = 0;
+
+    // Cache + the parameters it was built for (rebuild on any change).
+    QImage  m_cache;
+    QSize   m_cacheSize;
+    int     m_cacheScaleStrip   = -1;
+    float   m_cacheFloor        = 0.0f;
+    float   m_cacheRange        = 0.0f;
+    float   m_cacheZCurve       = 0.0f;
+    quint64 m_cachePaletteToken = ~0ull;
+};

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -36,7 +36,7 @@ public:
     static constexpr float kBackWidthFrac     = 0.60f;  // back row width / front
     static constexpr float kDepthSpanFrac     = 0.58f;  // baseline rise to the back
     static constexpr float kFrontMaxRidgeFrac = 0.46f;  // front ridge height / plot H
-    static constexpr float kHaze              = 0.28f;  // fade toward bg with depth
+    static constexpr float kHaze              = 0.16f;  // fade toward bg with depth
 
     // Maps a dBm value to an RGB colour using the host's panadapter palette.
     using PaletteFn = std::function<QRgb(float dbm)>;

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -707,7 +707,8 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
                 spectrum->noiseFloorEnabled(), spectrum->fftHeatMap(),
                 spectrum->wfColorScheme(), spectrum->showGrid(),
                 spectrum->fftLineWidth(), spectrum->wfAutoBlackRadioSide(),
-                spectrum->spectrumRenderMode(), spectrum->dssFloorDepth());
+                spectrum->spectrumRenderMode(), spectrum->dssFloorDepth(),
+                spectrum->dssGain());
         }
         return;
     }

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -706,7 +706,8 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
                 spectrum->wfLineDuration(), spectrum->noiseFloorPosition(),
                 spectrum->noiseFloorEnabled(), spectrum->fftHeatMap(),
                 spectrum->wfColorScheme(), spectrum->showGrid(),
-                spectrum->fftLineWidth());
+                spectrum->fftLineWidth(), spectrum->wfAutoBlackRadioSide(),
+                spectrum->spectrumRenderMode(), spectrum->dssFloorDepth());
         }
         return;
     }

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1104,6 +1104,8 @@ void MainWindow::wirePanLifecycle()
                 s.value(sw->settingsKey("DisplaySpectrumRenderMode"), "0").toInt());
             sw->setDssFloorDepth(
                 s.value(sw->settingsKey("Display3DFloorDepth"), "6").toInt());
+            sw->setDssGain(
+                s.value(sw->settingsKey("Display3DGain"), "70").toInt());
             // Nudge rate to force waterfall tile re-sync
             if (!m_adaptiveThrottleActive) {
                 QTimer::singleShot(500, this, [this, rate]() {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1089,7 +1089,7 @@ void MainWindow::wirePanLifecycle()
             sw->overlayMenu()->setWnbState(wnbOn, wnbLevel);
             sw->overlayMenu()->setRfGain(rfGain);
             QString bgPath = s.value(sw->settingsKey("BackgroundImage")).toString();
-            if (!bgPath.isEmpty())
+            if (!bgPath.isEmpty() && bgPath != "none")
                 sw->setBackgroundImage(bgPath);
             int bgOpacity = s.value(sw->settingsKey("BackgroundOpacity"), "80").toInt();
             sw->setBackgroundOpacity(bgOpacity);
@@ -1097,6 +1097,13 @@ void MainWindow::wirePanLifecycle()
                                   "#0a0a14").toString());
             if (bgFill.isValid())
                 sw->setBackgroundFillColor(bgFill);
+            // Restore the spectrum render mode (2D / 3D stacked trace) + 3D floor
+            // depth per pan, like the other Display settings above, so a pan set
+            // to 3D survives a restart / pan re-attach.
+            sw->setSpectrumRenderMode(
+                s.value(sw->settingsKey("DisplaySpectrumRenderMode"), "0").toInt());
+            sw->setDssFloorDepth(
+                s.value(sw->settingsKey("Display3DFloorDepth"), "6").toInt());
             // Nudge rate to force waterfall tile re-sync
             if (!m_adaptiveThrottleActive) {
                 QTimer::singleShot(500, this, [this, rate]() {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2243,6 +2243,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setSpectrumRenderMode);
     connect(menu, &SpectrumOverlayMenu::dssFloorDepthChanged,
             sw, &SpectrumWidget::setDssFloorDepth);
+    connect(menu, &SpectrumOverlayMenu::dssGainChanged,
+            sw, &SpectrumWidget::setDssGain);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
         if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
@@ -2508,12 +2510,14 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayNoiseFloorPosition"),  "75");
         s.setValue(sw->settingsKey("DisplaySpectrumRenderMode"),  "0");
         s.setValue(sw->settingsKey("Display3DFloorDepth"),        "6");
+        s.setValue(sw->settingsKey("Display3DGain"),        "70");
         s.save();
 
         // Apply the render-mode + 3D-floor reset to the widget too (the keys
         // above only update settings, not the live SpectrumWidget).
         sw->setSpectrumRenderMode(0);
         sw->setDssFloorDepth(6);
+        sw->setDssGain(70);
 
         // Sync all Display panel UI controls (incl. the 2D/3D combo + 3D Floor).
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2239,6 +2239,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::wfColorSchemeChanged,
             sw, &SpectrumWidget::setWfColorScheme);
+    connect(menu, &SpectrumOverlayMenu::spectrumRenderModeChanged,
+            sw, &SpectrumWidget::setSpectrumRenderMode);
+    connect(menu, &SpectrumOverlayMenu::dssFloorDepthChanged,
+            sw, &SpectrumWidget::setDssFloorDepth);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
         if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
@@ -2400,6 +2404,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("BackgroundImage"), ":/bg-default.jpg");
         s.save();
     });
+    // Right-click "Clear": turn the background off entirely (no image, just the
+    // fill colour) and persist as "none" so it stays off across restarts.
+    connect(menu, &SpectrumOverlayMenu::backgroundImageDisabled,
+            this, [sw] {
+        sw->setBackgroundImage(QString());
+        auto& s = AppSettings::instance();
+        s.setValue(sw->settingsKey("BackgroundImage"), "none");
+        s.save();
+    });
     connect(menu, &SpectrumOverlayMenu::backgroundOpacityChanged,
             this, [sw](int pct) {
         sw->setBackgroundOpacity(pct);
@@ -2493,12 +2506,19 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayFreqGridSpacing"),     "0");
         s.setValue(sw->settingsKey("DisplayNoiseFloorEnable"),    "False");
         s.setValue(sw->settingsKey("DisplayNoiseFloorPosition"),  "75");
+        s.setValue(sw->settingsKey("DisplaySpectrumRenderMode"),  "0");
+        s.setValue(sw->settingsKey("Display3DFloorDepth"),        "6");
         s.save();
 
-        // Sync all Display panel UI controls
+        // Apply the render-mode + 3D-floor reset to the widget too (the keys
+        // above only update settings, not the live SpectrumWidget).
+        sw->setSpectrumRenderMode(0);
+        sw->setDssFloorDepth(6);
+
+        // Sync all Display panel UI controls (incl. the 2D/3D combo + 3D Floor).
         menu->syncDisplaySettings(0, 25, 70, false, QColor(0x00, 0xe5, 0xff),
                                   50, 15, true, 50, 100, 75, false, true, 0,
-                                  true, 2.0f, false);
+                                  true, 2.0f, false, 0, 6);
         menu->syncExtraDisplaySettings(false, 1.15f, 80, 0,
                                        QColor(0x0a, 0x0a, 0x14));
     });

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1526,28 +1526,16 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         auto* clearBtn = new QPushButton("Clear");
         clearBtn->setFixedHeight(18);
         clearBtn->setStyleSheet(btnStyle);
-        clearBtn->setToolTip("Revert to the default logo background");
+        clearBtn->setToolTip("Left-click: revert to the default logo background.\n"
+                             "Right-click: turn the background off entirely.");
         connect(clearBtn, &QPushButton::clicked, this, [this] {
             emit backgroundImageCleared();
         });
+        // Right-click clears the background completely (no image, just the fill).
+        clearBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(clearBtn, &QWidget::customContextMenuRequested, this,
+                [this](const QPoint&) { emit backgroundImageDisabled(); });
         grid->addWidget(clearBtn, row, 3);
-        ++row;
-    }
-
-    // ── Lean render mode toggle (#3283) ─────────────────────────────────
-    // Global low-overhead render mode: opaque panadapter + VFO, capped
-    // repaint, WAVE scope off, throttled meters. Lives under Display, just
-    // below the background chooser. Drives the app-wide toggle.
-    {
-        m_leanBtn = new QPushButton("Lean Mode");
-        m_leanBtn->setCheckable(true);
-        m_leanBtn->setStyleSheet(btnStyle);
-        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped "
-                              "repaint, WAVE scope off, throttled meters. "
-                              "Reduces CPU/GPU load. Persists across restarts.");
-        connect(m_leanBtn, &QPushButton::toggled, this,
-                [this](bool on) { emit leanModeToggled(on); });
-        grid->addWidget(m_leanBtn, row, 0, 1, 4);
         ++row;
     }
 
@@ -1601,6 +1589,51 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         grid->addWidget(m_colorSchemeCmb, row, 1, 1, 3);
         connect(m_colorSchemeCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
                 this, [this](int idx) { emit wfColorSchemeChanged(idx); });
+        ++row;
+    }
+
+    // ── Spectrum render mode (2D waterfall vs 3DSS) ───────────────────────
+    {
+        auto* lbl = new QLabel("Spectrum:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
+        m_renderModeCmb = new QComboBox;
+        m_renderModeCmb->setObjectName("spectrumRenderModeCombo");  // bridge-addressable
+        m_renderModeCmb->setFixedHeight(18);
+        applyComboStyle(m_renderModeCmb);
+        m_renderModeCmb->addItem("2D Waterfall");       // SpectrumRenderMode::Mode2D
+        m_renderModeCmb->addItem("3D Stacked Trace");   // SpectrumRenderMode::Mode3D
+        m_renderModeCmb->setToolTip(
+            "2D: FFT trace + waterfall.\n"
+            "3D: perspective stacked-trace spectrum stream.");
+        grid->addWidget(m_renderModeCmb, row, 1, 1, 3);
+        connect(m_renderModeCmb, QOverload<int>::of(&QComboBox::currentIndexChanged),
+                this, [this](int idx) { emit spectrumRenderModeChanged(idx); });
+        ++row;
+    }
+
+    // ── 3D floor depth — how far below the noise floor to surface (dB) ────
+    makeRow("3D Floor:", 0, 24, 6, m_dssFloorSlider, m_dssFloorLabel);
+    if (m_dssFloorSlider) m_dssFloorSlider->setObjectName("dssFloorDepthSlider");
+    connect(m_dssFloorSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (m_dssFloorLabel) m_dssFloorLabel->setText(QString::number(v));
+        emit dssFloorDepthChanged(v);
+    });
+
+    // ── Lean render mode toggle (#3283) ─────────────────────────────────
+    // Global low-overhead render mode: opaque panadapter + VFO, capped
+    // repaint, WAVE scope off, throttled meters. Grouped with the spectrum
+    // render controls, below the 3D Floor slider. Drives the app-wide toggle.
+    {
+        m_leanBtn = new QPushButton("Lean Mode");
+        m_leanBtn->setCheckable(true);
+        m_leanBtn->setStyleSheet(btnStyle);
+        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped "
+                              "repaint, WAVE scope off, throttled meters. "
+                              "Reduces CPU/GPU load. Persists across restarts.");
+        connect(m_leanBtn, &QPushButton::toggled, this,
+                [this](bool on) { emit leanModeToggled(on); });
+        grid->addWidget(m_leanBtn, row, 0, 1, 4);
         ++row;
     }
 
@@ -1752,7 +1785,9 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                bool heatMap, int colorScheme,
                                                bool showGrid,
                                                float lineWidth,
-                                               bool autoBlackRadioSide)
+                                               bool autoBlackRadioSide,
+                                               int renderMode,
+                                               int dssFloorDepth)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -1808,6 +1843,15 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
     if (m_colorSchemeCmb) {
         QSignalBlocker bc(m_colorSchemeCmb);
         m_colorSchemeCmb->setCurrentIndex(colorScheme);
+    }
+    if (m_renderModeCmb) {
+        QSignalBlocker br(m_renderModeCmb);
+        m_renderModeCmb->setCurrentIndex(renderMode);
+    }
+    if (m_dssFloorSlider) {
+        QSignalBlocker bf(m_dssFloorSlider);
+        m_dssFloorSlider->setValue(dssFloorDepth);
+        if (m_dssFloorLabel) m_dssFloorLabel->setText(QString::number(dssFloorDepth));
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1620,6 +1620,20 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         emit dssFloorDepthChanged(v);
     });
 
+    // ── 3D gain — how far down the strength range the colormap reaches ────
+    makeRow("3D Gain:", 0, 100, 70, m_dssGainSlider, m_dssGainLabel);
+    if (m_dssGainSlider) {
+        m_dssGainSlider->setObjectName("dssGainSlider");
+        m_dssGainSlider->setToolTip(
+            "3D surface colour gain: how far down the signal range the colormap "
+            "reaches.\nHigher = colour down toward the noise floor; lower = "
+            "colour only on the strongest signals.");
+    }
+    connect(m_dssGainSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (m_dssGainLabel) m_dssGainLabel->setText(QString::number(v));
+        emit dssGainChanged(v);
+    });
+
     // ── Lean render mode toggle (#3283) ─────────────────────────────────
     // Global low-overhead render mode: opaque panadapter + VFO, capped
     // repaint, WAVE scope off, throttled meters. Grouped with the spectrum
@@ -1787,7 +1801,8 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
                                                float lineWidth,
                                                bool autoBlackRadioSide,
                                                int renderMode,
-                                               int dssFloorDepth)
+                                               int dssFloorDepth,
+                                               int dssGain)
 {
     if (!m_avgSlider) return;  // panel not built yet
 
@@ -1852,6 +1867,11 @@ void SpectrumOverlayMenu::syncDisplaySettings(int avg, int fps, int fillPct,
         QSignalBlocker bf(m_dssFloorSlider);
         m_dssFloorSlider->setValue(dssFloorDepth);
         if (m_dssFloorLabel) m_dssFloorLabel->setText(QString::number(dssFloorDepth));
+    }
+    if (m_dssGainSlider) {
+        QSignalBlocker bc(m_dssGainSlider);
+        m_dssGainSlider->setValue(dssGain);
+        if (m_dssGainLabel) m_dssGainLabel->setText(QString::number(dssGain));
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -51,7 +51,9 @@ public:
                              bool heatMap = true, int colorScheme = 0,
                              bool showGrid = true,
                              float lineWidth = 2.0f,
-                             bool autoBlackRadioSide = false);
+                             bool autoBlackRadioSide = false,
+                             int renderMode = 0,
+                             int dssFloorDepth = 6);
     void syncWfLineDuration(int rate);
     void syncKiwiWaterfallSettings(int cellDb, int floorDb, int rate);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
@@ -140,6 +142,8 @@ signals:
     void kiwiWaterfallFloorChanged(int floorDb);
     void kiwiWaterfallRateChanged(int rate);
     void wfColorSchemeChanged(int scheme);
+    void spectrumRenderModeChanged(int mode);
+    void dssFloorDepthChanged(int dB);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
     // Emitted when user selects a band from the sub-panel.  stackKeyHint is
@@ -167,6 +171,9 @@ signals:
     void wfBlankerThresholdChanged(float threshold);
     void backgroundImageRequested();
     void backgroundImageCleared();
+    // Right-click "Clear": turn the background off entirely (no image, just the
+    // fill colour) and persist it.
+    void backgroundImageDisabled();
     void backgroundOpacityChanged(int pct);
     void backgroundFillColorChanged(const QColor& color);
     void displaySettingsReset();
@@ -286,6 +293,9 @@ private:
     int          m_blackManualValue{15};
     int          m_blackAutoOffsetValue{50};
     QComboBox*   m_colorSchemeCmb{nullptr};
+    QComboBox*   m_renderModeCmb{nullptr};
+    QSlider*     m_dssFloorSlider{nullptr};  // 3DSS floor depth (dB below floor)
+    QLabel*      m_dssFloorLabel{nullptr};
     QComboBox*   m_gpuCombo{nullptr};   // render-GPU selector (multi-GPU only)
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -53,7 +53,8 @@ public:
                              float lineWidth = 2.0f,
                              bool autoBlackRadioSide = false,
                              int renderMode = 0,
-                             int dssFloorDepth = 6);
+                             int dssFloorDepth = 6,
+                             int dssGain = 70);
     void syncWfLineDuration(int rate);
     void syncKiwiWaterfallSettings(int cellDb, int floorDb, int rate);
     // Sync blanker/cursor/opacity controls not covered by syncDisplaySettings.
@@ -144,6 +145,7 @@ signals:
     void wfColorSchemeChanged(int scheme);
     void spectrumRenderModeChanged(int mode);
     void dssFloorDepthChanged(int dB);
+    void dssGainChanged(int pct);
     void noiseFloorPositionChanged(int pos);
     void noiseFloorEnableChanged(bool on);
     // Emitted when user selects a band from the sub-panel.  stackKeyHint is
@@ -296,6 +298,8 @@ private:
     QComboBox*   m_renderModeCmb{nullptr};
     QSlider*     m_dssFloorSlider{nullptr};  // 3DSS floor depth (dB below floor)
     QLabel*      m_dssFloorLabel{nullptr};
+    QSlider*     m_dssGainSlider{nullptr};  // 3DSS colour floor (0-100)
+    QLabel*      m_dssGainLabel{nullptr};
     QComboBox*   m_gpuCombo{nullptr};   // render-GPU selector (multi-GPU only)
     QSlider*     m_rateSlider{nullptr};
     QLabel*      m_rateLabel{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2789,6 +2789,19 @@ void SpectrumWidget::setDssFloorDepth(int dB) {
     update();
 }
 
+void SpectrumWidget::setDssGain(int pct) {
+    pct = std::clamp(pct, 0, 100);
+    if (pct != m_dssGain) {
+        m_dssGain = pct;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("Display3DGain"), QString::number(pct));
+        s.save();
+        m_dssLutToken = ~0ull;  // force the GPU palette LUT to re-bake next frame
+        m_dss.invalidate();     // CPU fallback surface re-colours too
+    }
+    update();
+}
+
 void SpectrumWidget::setSpectrumRenderMode(int mode) {
     auto clamped = static_cast<SpectrumRenderMode>(
         std::clamp(mode, 0, static_cast<int>(SpectrumRenderMode::Count) - 1));
@@ -7472,11 +7485,25 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
     return interpolateGradient(t, stops, n);
 }
 
+QRgb SpectrumWidget::dssStrengthToRgb(float s) const
+{
+    // gamma in [0.25 .. 4]: gain=100 -> 0.25 (colour lifted to the noise floor),
+    // gain=50 -> 1.0 (linear), gain=0 -> 4 (colour only on the strongest peaks).
+    const float gamma = std::pow(4.0f, (50.0f - m_dssGain) / 50.0f);
+    int n = 0;
+    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
+    return interpolateGradient(std::pow(std::clamp(s, 0.0f, 1.0f), gamma),
+                               stops, n);
+}
+
 quint64 SpectrumWidget::dssPaletteToken() const
 {
-    // Fold the dbmToRgb() inputs so the cached surface recolours when any of
-    // them changes (scheme/gain/black-level/min-dBm).
+    // Fold the inputs that define the 3DSS surface colour so the cached image
+    // recolours when any change. The surface now maps strength through the
+    // scheme + "3D Gain" (dssStrengthToRgb); the waterfall gain/black/min are
+    // kept here too since they still affect the 2D/waterfall colour path.
     quint64 t = static_cast<quint64>(m_wfColorScheme);
+    t = t * 131 + static_cast<quint64>(m_dssGain);
     t = t * 131 + static_cast<quint64>(m_wfColorGain);
     t = t * 131 + static_cast<quint64>(m_wfBlackLevel);
     t = t * 131 + static_cast<quint64>(qRound(m_wfMinDbm));
@@ -7515,7 +7542,12 @@ const QImage& SpectrumWidget::buildDssImage(const QSize& px, int scaleStripPx)
     const float floorDbm = dssFloorDbm();
     const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
 
-    auto palette = [this](float dbm) { return dbmToRgb(dbm); };
+    // Same mapping as the GPU mesh: full colormap over the strength axis, gamma-
+    // shaped by "3D Gain" (NOT dbmToRgb, which clipped the low range to black).
+    auto palette = [this, floorDbm, rangeDb](float dbm) {
+        const float r = (rangeDb > 0.0f) ? rangeDb : 1.0f;
+        return dssStrengthToRgb((dbm - floorDbm) / r);
+    };
     return m_dss.image(px, scaleStripPx, floorDbm, rangeDb, m_dssZCurve,
                        palette, dssPaletteToken(), m_bgFillColor);
 }
@@ -7983,24 +8015,25 @@ void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
     if (!m_dssPaletteTex || !batch) {
         return;
     }
-    // Bake the LUT through dbmToRgb() — the SAME mapping the 2D trace and the
-    // CPU 3D path use — so colour-gain / black-level / min-dBm reach the GPU
-    // surface and the same data renders the same colour on GPU and CPU. The LUT
-    // is indexed by the mesh's linear strength s = (dbm-floor)/range, so entry i
-    // is the colour of dBm = floor + (i/255)*range. Keyed on dssPaletteToken()
-    // plus the (quantised) floor/range that define that dBm mapping.
-    quint64 token = dssPaletteToken();
-    token = token * 131 + static_cast<quint64>(qRound(floorDbm * 2.0f));
-    token = token * 131 + static_cast<quint64>(qRound(rangeDb * 2.0f));
+    // The 3D surface maps its strength axis (noise floor -> ref level) across the
+    // FULL colormap gradient, bypassing dbmToRgb()'s waterfall black-level window
+    // (which forced everything below ~(min + (125-black)*0.4) dBm to black, so
+    // only the strongest signals showed any colour). The "3D Color" control
+    // gamma-shapes the strength before the lookup: higher = colour reaches down
+    // toward the noise floor; lower = colour only on the strongest signals.
+    // Colour depends only on the scheme + that control (NOT the per-frame floor/
+    // range, which jitter every frame), so the LUT re-bakes only on a real change.
+    Q_UNUSED(floorDbm);
+    Q_UNUSED(rangeDb);
+    const quint64 token = static_cast<quint64>(m_wfColorScheme) * 131
+                        + static_cast<quint64>(m_dssGain);
     if (token == m_dssLutToken) {
         return;  // unchanged
     }
 
-    const float range = (rangeDb > 0.0f) ? rangeDb : 1.0f;
     QImage lut(256, 1, QImage::Format_RGBA8888);  // owns its data
     for (int i = 0; i < 256; ++i) {
-        const float dbm = floorDbm + (i / 255.0f) * range;
-        const QRgb c = dbmToRgb(dbm);
+        const QRgb c = dssStrengthToRgb(i / 255.0f);
         lut.setPixelColor(i, 0, QColor(qRed(c), qGreen(c), qBlue(c)));
     }
     QRhiTextureSubresourceUploadDescription desc(lut);
@@ -8016,14 +8049,14 @@ void SpectrumWidget::initDssMeshPipeline()
     // R16F height texture is the cleanest dBm store; if unsupported, fall back
     // to the cached-image quad path (no mesh).
     if (!r->isTextureFormatSupported(QRhiTexture::R16F, {})) {
-        qWarning() << "SpectrumWidget: R16F unsupported — stacked-trace mesh disabled (CPU fallback)";
+        qCWarning(lcGui) << "SpectrumWidget: R16F unsupported — stacked-trace mesh disabled (CPU fallback)";
         return;
     }
 
     QShader vs = loadShader(":/shaders/resources/shaders/dss_mesh.vert.qsb");
     QShader fs = loadShader(":/shaders/resources/shaders/dss_mesh.frag.qsb");
     if (!vs.isValid() || !fs.isValid()) {
-        qWarning() << "SpectrumWidget: dss_mesh shader load failed — stacked-trace mesh disabled";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh shader load failed — stacked-trace mesh disabled";
         return;
     }
 
@@ -8039,14 +8072,14 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer,
                                 kDssMeshUboFloats * sizeof(float));
     if (!m_dssMeshVbo->create() || !m_dssMeshLineVbo->create() || !m_dssMeshUbo->create()) {
-        qWarning() << "SpectrumWidget: dss_mesh buffer create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh buffer create failed";
         return;
     }
 
     m_dssHeightTex  = r->newTexture(QRhiTexture::R16F, QSize(cols, rows));
     m_dssPaletteTex = r->newTexture(QRhiTexture::RGBA8, QSize(256, 1));
     if (!m_dssHeightTex->create() || !m_dssPaletteTex->create()) {
-        qWarning() << "SpectrumWidget: dss_mesh texture create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh texture create failed";
         return;
     }
 
@@ -8057,7 +8090,7 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssPaletteSampler = r->newSampler(QRhiSampler::Linear, QRhiSampler::Linear,
         QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     if (!m_dssHeightSampler->create() || !m_dssPaletteSampler->create()) {
-        qWarning() << "SpectrumWidget: dss_mesh sampler create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh sampler create failed";
         return;
     }
 
@@ -8072,7 +8105,7 @@ void SpectrumWidget::initDssMeshPipeline()
             QRhiShaderResourceBinding::FragmentStage, m_dssPaletteTex, m_dssPaletteSampler),
     });
     if (!m_dssMeshSrb->create()) {
-        qWarning() << "SpectrumWidget: dss_mesh SRB create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh SRB create failed";
         return;
     }
 
@@ -8104,7 +8137,7 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshLinePipeline->setTargetBlends({lblend});
 
     if (!m_dssMeshFillPipeline->create() || !m_dssMeshLinePipeline->create()) {
-        qWarning() << "SpectrumWidget: dss_mesh pipeline create failed";
+        qCWarning(lcGui) << "SpectrumWidget: dss_mesh pipeline create failed";
         return;
     }
 
@@ -8635,16 +8668,19 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     : (m_dssMeshHeadUploaded - head + rows) % rows;
                 newRows = std::clamp(newRows, 0, valid);
                 QVarLengthArray<QRhiTextureUploadEntry, DssRenderer::kRows> entries;
+                m_dssRowScratch.resize(cols * int(sizeof(qfloat16)));
                 for (int n = 0; n < newRows; ++n) {
                     const int ring = (head + n) % rows;  // head..head+newRows-1
                     const float* srcRow = m_dss.rowDataRing(ring);
-                    QByteArray bytes(cols * int(sizeof(qfloat16)), Qt::Uninitialized);
-                    qfloat16* dst = reinterpret_cast<qfloat16*>(bytes.data());
+                    // Reuse the member buffer: setData() holds a COW ref, so the
+                    // common single-new-row frame reuses it with no allocation,
+                    // while a multi-row catch-up detaches per row (still correct).
+                    qfloat16* dst = reinterpret_cast<qfloat16*>(m_dssRowScratch.data());
                     for (int c = 0; c < cols; ++c) {
                         dst[c] = qfloat16(srcRow[c]);
                     }
                     QRhiTextureSubresourceUploadDescription rowDesc;
-                    rowDesc.setData(bytes);  // descriptor keeps the bytes alive
+                    rowDesc.setData(m_dssRowScratch);  // descriptor keeps the bytes alive
                     rowDesc.setSourceSize(QSize(cols, 1));
                     rowDesc.setDestinationTopLeft(QPoint(0, ring));
                     entries.append(QRhiTextureUploadEntry(0, 0, rowDesc));
@@ -8686,13 +8722,15 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                               / static_cast<float>(qMax(1, w));
             const int specPwDev = qMax(1, qRound(specRect.width() * fbDpr));
             const int specPhDev = qMax(1, qRound(specH * fbDpr));
-            constexpr int kDssMaxW = 1024, kDssMaxH = 512;
             const double sc = qMin(1.0, qMin(double(kDssMaxW) / specPwDev,
                                              double(kDssMaxH) / specPhDev));
             const int dssW = qMax(2, static_cast<int>(specPwDev * sc));
             const int dssH = qMax(2, static_cast<int>(specPhDev * sc));
             const QImage& surf = buildDssImage(QSize(dssW, dssH), 0);
-            if (!surf.isNull()) {
+            // m_dssGpuTex/m_dssSrb/m_ovSampler come from initOverlayPipeline();
+            // guard against a partial GPU init (OOM / device loss) so the
+            // fallback never dereferences a null resource.
+            if (!surf.isNull() && m_dssGpuTex && m_dssSrb && m_ovSampler) {
                 if (m_dssTexW != dssW || m_dssTexH != dssH) {
                     m_dssTexW = dssW;
                     m_dssTexH = dssH;
@@ -9226,8 +9264,6 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         // Cap the software surface (like the GPU path) so a HiDPI/maximized
         // window doesn't rebuild a multi-megapixel QImage every frame; the
         // surface is intrinsically low-res, so stretch it on draw.
-        constexpr int kDssMaxW = 1024;
-        constexpr int kDssMaxH = 512;
         const QImage& surf =
             buildDssImage(specRect.size().boundedTo(QSize(kDssMaxW, kDssMaxH)), 0);
         if (!surf.isNull()) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2796,7 +2796,9 @@ void SpectrumWidget::setDssGain(int pct) {
         auto& s = AppSettings::instance();
         s.setValue(settingsKey("Display3DGain"), QString::number(pct));
         s.save();
+#ifdef AETHER_GPU_SPECTRUM
         m_dssLutToken = ~0ull;  // force the GPU palette LUT to re-bake next frame
+#endif
         m_dss.invalidate();     // CPU fallback surface re-colours too
     }
     update();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -51,6 +51,7 @@
 #include <QTimeZone>
 #include <QElapsedTimer>
 #include <QVarLengthArray>
+#include <QtCore/qfloat16.h>
 #include "core/LogManager.h"
 #include "core/PerfTelemetry.h"
 #include <QSoundEffect>
@@ -1244,6 +1245,11 @@ void SpectrumWidget::loadSettings()
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
                    0, static_cast<int>(WfColorScheme::Count) - 1));
+    m_spectrumRenderMode = static_cast<SpectrumRenderMode>(
+        std::clamp(s.value(settingsKey("DisplaySpectrumRenderMode"), "0").toInt(),
+                   0, static_cast<int>(SpectrumRenderMode::Count) - 1));
+    m_dssFloorOffsetDb = -static_cast<float>(
+        std::clamp(s.value(settingsKey("Display3DFloorDepth"), "6").toInt(), 0, 24));
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
     m_showTuneGuides  = s.value("ShowTuneGuides", "False").toString() == "True";
     m_extendedFrequencyLine = s.value("ExtendedFrequencyLine", "False").toString() == "True";
@@ -1267,7 +1273,8 @@ void SpectrumWidget::loadSettings()
             m_wfLineDuration,
             m_noiseFloorPosition, m_noiseFloorEnable,
             m_fftHeatMap, static_cast<int>(m_wfColorScheme), m_showGrid,
-            m_fftLineWidth, m_wfAutoBlackRadioSide);
+            m_fftLineWidth, m_wfAutoBlackRadioSide,
+            static_cast<int>(m_spectrumRenderMode), dssFloorDepth());
         m_overlayMenu->syncExtraDisplaySettings(m_wfBlankerEnabled,
             m_wfBlankerThreshold, m_bgOpacity, m_freqGridSpacingKhz, m_bgFillColor,
             m_freqScaleFontPt);
@@ -2765,6 +2772,39 @@ void SpectrumWidget::setWfColorScheme(int scheme) {
         auto& s = AppSettings::instance();
         s.setValue(settingsKey("DisplayWfColorScheme"), QString::number(static_cast<int>(m_wfColorScheme)));
         s.save();
+    }
+    update();
+}
+
+void SpectrumWidget::setDssFloorDepth(int dB) {
+    dB = std::clamp(dB, 0, 24);
+    const float off = -static_cast<float>(dB);
+    if (off != m_dssFloorOffsetDb) {
+        m_dssFloorOffsetDb = off;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("Display3DFloorDepth"), QString::number(dB));
+        s.save();
+        m_dss.invalidate();   // CPU fallback cache; mesh re-reads each frame
+    }
+    update();
+}
+
+void SpectrumWidget::setSpectrumRenderMode(int mode) {
+    auto clamped = static_cast<SpectrumRenderMode>(
+        std::clamp(mode, 0, static_cast<int>(SpectrumRenderMode::Count) - 1));
+    if (clamped != m_spectrumRenderMode) {
+        m_spectrumRenderMode = clamped;
+        auto& s = AppSettings::instance();
+        s.setValue(settingsKey("DisplaySpectrumRenderMode"),
+                   QString::number(static_cast<int>(m_spectrumRenderMode)));
+        s.save();
+        // Force a full rebuild of the 3DSS surface + its GPU texture, and the
+        // overlay (grid/scales differ between modes).
+        m_dss.invalidate();
+#ifdef AETHER_GPU_SPECTRUM
+        m_dssTexNeedsUpload = true;
+#endif
+        markOverlayDirty();
     }
     update();
 }
@@ -4849,6 +4889,15 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = *spectrumBins;
 
+    // Feed the rolling history every frame (not only in 3D) so toggling to 3D
+    // shows a populated surface immediately instead of filling over ~96 frames.
+    // The resample is cheap; the renderer only rebuilds its cache when the 3D
+    // surface is drawn. KiwiSDR feeds via updateKiwiSdrWaterfallRow() instead.
+    // Raw bins (renderer does its own spatial/temporal smoothing + impulse reject).
+    if (!m_kiwiSdrWaterfallActive && !m_bins.isEmpty()) {
+        m_dss.pushRow(m_bins);
+    }
+
     if (!m_kiwiSdrWaterfallActive) {
         // ── Live noise floor measurement (two-pass trimmed mean) ─────────
         // Same technique as the waterfall auto-black: compute the mean of ALL
@@ -5308,6 +5357,10 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     if (binsDbm.isEmpty()) {
         return;
     }
+
+    // Feed the 3D rolling history from the KiwiSDR FFT rows too (the Flex path
+    // feeds from updateSpectrum), so the stacked-trace surface works on KiwiSDR.
+    m_dss.pushRow(binsDbm);
 
     const bool visibleStream = beginWaterfallStreamWrite(true);
     auto restoreStream = qScopeGuard([&] {
@@ -7419,6 +7472,54 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
     return interpolateGradient(t, stops, n);
 }
 
+quint64 SpectrumWidget::dssPaletteToken() const
+{
+    // Fold the dbmToRgb() inputs so the cached surface recolours when any of
+    // them changes (scheme/gain/black-level/min-dBm).
+    quint64 t = static_cast<quint64>(m_wfColorScheme);
+    t = t * 131 + static_cast<quint64>(m_wfColorGain);
+    t = t * 131 + static_cast<quint64>(m_wfBlackLevel);
+    t = t * 131 + static_cast<quint64>(qRound(m_wfMinDbm));
+    return t;
+}
+
+float SpectrumWidget::dssFloorDbm() const
+{
+    // Pick the measured noise floor for whichever source is live so the 3D-Floor
+    // slider behaves the same on Flex and KiwiSDR; fall back to the Ref window
+    // bottom only before a measurement exists. Quantise to 0.5 dB so per-frame
+    // floor jitter doesn't force needless rebuilds/uploads.
+    float floor;
+    if (m_kiwiSdrWaterfallActive && m_kiwiSdrAutoRangeValid) {
+        floor = m_kiwiSdrAutoFloorDbm;
+    } else if (m_measuredNoiseFloorDbm > -500.0f) {
+        floor = m_measuredNoiseFloorDbm;
+    } else {
+        floor = m_refLevel - m_dynamicRange;
+    }
+    floor += m_dssFloorOffsetDb;
+    return std::round(floor * 2.0f) / 2.0f;
+}
+
+float SpectrumWidget::dssSpanDb() const
+{
+    // Span from the noise floor up to the Ref level. Ref drag still controls
+    // vertical zoom; the clamp keeps the wide 100-130 dB Flex window from
+    // flattening signals, and a small floor keeps weak bands legible.
+    const float span = m_refLevel - dssFloorDbm();
+    return std::clamp(span, 45.0f, 120.0f);
+}
+
+const QImage& SpectrumWidget::buildDssImage(const QSize& px, int scaleStripPx)
+{
+    const float floorDbm = dssFloorDbm();
+    const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
+
+    auto palette = [this](float dbm) { return dbmToRgb(dbm); };
+    return m_dss.image(px, scaleStripPx, floorDbm, rangeDb, m_dssZCurve,
+                       palette, dssPaletteToken(), m_bgFillColor);
+}
+
 QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
 {
     // Kiwi direct W/F bytes are decoded to the server's wrapped negative dB
@@ -7788,6 +7889,21 @@ void SpectrumWidget::initOverlayPipeline()
     m_overlayBg.setDevicePixelRatio(dpr);
     m_overlayBg.fill(Qt::transparent);
 
+    // 3DSS surface layer — parallel texture + SRB so the overlay pipeline can
+    // paint the cached 3D image as a full-screen quad in 3D mode. The image is
+    // built/uploaded on demand in renderGpuFrame().
+    m_dssGpuTex = r->newTexture(QRhiTexture::RGBA8, QSize(pw, ph));
+    m_dssGpuTex->create();
+    m_dssTexW = pw;
+    m_dssTexH = ph;
+    m_dssSrb = r->newShaderResourceBindings();
+    m_dssSrb->setBindings({
+        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_dssGpuTex, m_ovSampler),
+    });
+    m_dssSrb->create();
+    m_dssTexNeedsUpload = true;
+    m_dssLastUploadedGen = ~0ull;
+
     qDebug() << "SpectrumWidget: overlay pipeline created" << pw << "x" << ph << "dpr:" << dpr;
 }
 
@@ -7861,6 +7977,143 @@ void SpectrumWidget::initSpectrumPipeline()
     qDebug() << "SpectrumWidget: spectrum pipeline created (vertex-colored)";
 }
 
+void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
+                                         float floorDbm, float rangeDb)
+{
+    if (!m_dssPaletteTex || !batch) {
+        return;
+    }
+    // Bake the LUT through dbmToRgb() — the SAME mapping the 2D trace and the
+    // CPU 3D path use — so colour-gain / black-level / min-dBm reach the GPU
+    // surface and the same data renders the same colour on GPU and CPU. The LUT
+    // is indexed by the mesh's linear strength s = (dbm-floor)/range, so entry i
+    // is the colour of dBm = floor + (i/255)*range. Keyed on dssPaletteToken()
+    // plus the (quantised) floor/range that define that dBm mapping.
+    quint64 token = dssPaletteToken();
+    token = token * 131 + static_cast<quint64>(qRound(floorDbm * 2.0f));
+    token = token * 131 + static_cast<quint64>(qRound(rangeDb * 2.0f));
+    if (token == m_dssLutToken) {
+        return;  // unchanged
+    }
+
+    const float range = (rangeDb > 0.0f) ? rangeDb : 1.0f;
+    QImage lut(256, 1, QImage::Format_RGBA8888);  // owns its data
+    for (int i = 0; i < 256; ++i) {
+        const float dbm = floorDbm + (i / 255.0f) * range;
+        const QRgb c = dbmToRgb(dbm);
+        lut.setPixelColor(i, 0, QColor(qRed(c), qGreen(c), qBlue(c)));
+    }
+    QRhiTextureSubresourceUploadDescription desc(lut);
+    batch->uploadTexture(m_dssPaletteTex, QRhiTextureUploadEntry(0, 0, desc));
+    m_dssLutToken = token;
+}
+
+void SpectrumWidget::initDssMeshPipeline()
+{
+    QRhi* r = rhi();
+    m_dssMeshReady = false;
+
+    // R16F height texture is the cleanest dBm store; if unsupported, fall back
+    // to the cached-image quad path (no mesh).
+    if (!r->isTextureFormatSupported(QRhiTexture::R16F, {})) {
+        qWarning() << "SpectrumWidget: R16F unsupported — stacked-trace mesh disabled (CPU fallback)";
+        return;
+    }
+
+    QShader vs = loadShader(":/shaders/resources/shaders/dss_mesh.vert.qsb");
+    QShader fs = loadShader(":/shaders/resources/shaders/dss_mesh.frag.qsb");
+    if (!vs.isValid() || !fs.isValid()) {
+        qWarning() << "SpectrumWidget: dss_mesh shader load failed — stacked-trace mesh disabled";
+        return;
+    }
+
+    const int cols = m_dss.cols();
+    const int rows = m_dss.rows();
+    const int fillVerts = rows * cols * 2;  // ridge + floor per (col,row)
+    const int lineVerts = rows * cols;      // ridge-only outline
+
+    m_dssMeshVbo = r->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
+                                fillVerts * 3 * sizeof(float));
+    m_dssMeshLineVbo = r->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
+                                    lineVerts * 3 * sizeof(float));
+    m_dssMeshUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer,
+                                kDssMeshUboFloats * sizeof(float));
+    if (!m_dssMeshVbo->create() || !m_dssMeshLineVbo->create() || !m_dssMeshUbo->create()) {
+        qWarning() << "SpectrumWidget: dss_mesh buffer create failed";
+        return;
+    }
+
+    m_dssHeightTex  = r->newTexture(QRhiTexture::R16F, QSize(cols, rows));
+    m_dssPaletteTex = r->newTexture(QRhiTexture::RGBA8, QSize(256, 1));
+    if (!m_dssHeightTex->create() || !m_dssPaletteTex->create()) {
+        qWarning() << "SpectrumWidget: dss_mesh texture create failed";
+        return;
+    }
+
+    // Height sampled in the vertex stage; Nearest is enough (the grid is as dense
+    // as the texture). Palette is Linear for a smooth floor->peak gradient.
+    m_dssHeightSampler = r->newSampler(QRhiSampler::Nearest, QRhiSampler::Nearest,
+        QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_dssPaletteSampler = r->newSampler(QRhiSampler::Linear, QRhiSampler::Linear,
+        QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    if (!m_dssHeightSampler->create() || !m_dssPaletteSampler->create()) {
+        qWarning() << "SpectrumWidget: dss_mesh sampler create failed";
+        return;
+    }
+
+    m_dssMeshSrb = r->newShaderResourceBindings();
+    m_dssMeshSrb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(0,
+            QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+            m_dssMeshUbo),
+        QRhiShaderResourceBinding::sampledTexture(1,
+            QRhiShaderResourceBinding::VertexStage, m_dssHeightTex, m_dssHeightSampler),
+        QRhiShaderResourceBinding::sampledTexture(2,
+            QRhiShaderResourceBinding::FragmentStage, m_dssPaletteTex, m_dssPaletteSampler),
+    });
+    if (!m_dssMeshSrb->create()) {
+        qWarning() << "SpectrumWidget: dss_mesh SRB create failed";
+        return;
+    }
+
+    QRhiVertexInputLayout layout;
+    layout.setBindings({{3 * sizeof(float)}});
+    layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});  // u, v, edge
+
+    // Fill pipeline — opaque triangle strips (occlusion via back-to-front order).
+    m_dssMeshFillPipeline = r->newGraphicsPipeline();
+    m_dssMeshFillPipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
+    m_dssMeshFillPipeline->setVertexInputLayout(layout);
+    m_dssMeshFillPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    m_dssMeshFillPipeline->setShaderResourceBindings(m_dssMeshSrb);
+    m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+
+    // Outline pipeline — alpha-blended line strips (the dim trace line).
+    QRhiGraphicsPipeline::TargetBlend lblend;
+    lblend.enable = true;
+    lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
+    lblend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+    lblend.srcAlpha = QRhiGraphicsPipeline::One;
+    lblend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+    m_dssMeshLinePipeline = r->newGraphicsPipeline();
+    m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
+    m_dssMeshLinePipeline->setVertexInputLayout(layout);
+    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::LineStrip);
+    m_dssMeshLinePipeline->setShaderResourceBindings(m_dssMeshSrb);
+    m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+    m_dssMeshLinePipeline->setTargetBlends({lblend});
+
+    if (!m_dssMeshFillPipeline->create() || !m_dssMeshLinePipeline->create()) {
+        qWarning() << "SpectrumWidget: dss_mesh pipeline create failed";
+        return;
+    }
+
+    m_dssMeshHeadUploaded = -1;
+    m_dssLutToken = ~0ull;
+    m_dssMeshReady = true;
+    qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created" << cols << "x" << rows;
+}
+
 void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
 {
     if (m_rhiInitialized) return;
@@ -7879,10 +8132,35 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     initWaterfallPipeline();
     initOverlayPipeline();
     initSpectrumPipeline();
+    initDssMeshPipeline();
 
     // Upload VBO data
     batch->uploadStaticBuffer(m_wfVbo, kQuadData);
     batch->uploadStaticBuffer(m_ovVbo, kQuadData);
+
+    // 3DSS mesh: build the static perspective grid once (geometry never changes —
+    // height comes from the ring-buffered texture sampled per-vertex).
+    if (m_dssMeshReady) {
+        const int cols = m_dss.cols();
+        const int rows = m_dss.rows();
+        QVector<float> fill;
+        QVector<float> line;
+        fill.reserve(rows * cols * 2 * 3);
+        line.reserve(rows * cols * 3);
+        for (int rr = 0; rr < rows; ++rr) {
+            const float v = static_cast<float>(rr) / rows;   // 0 front .. ~1 back
+            for (int cc = 0; cc < cols; ++cc) {
+                const float u = (cols > 1) ? static_cast<float>(cc) / (cols - 1) : 0.0f;
+                fill << u << v << 0.0f;    // ridge vertex
+                fill << u << v << 1.0f;    // floor vertex (down to plot bottom)
+                line << u << v << -1.0f;   // outline vertex
+            }
+        }
+        batch->uploadStaticBuffer(m_dssMeshVbo, fill.constData());
+        batch->uploadStaticBuffer(m_dssMeshLineVbo, line.constData());
+        // The palette LUT is baked from the live floor/range on the first 3D
+        // frame (renderGpuFrame) before the surface is drawn — no init upload.
+    }
 
     // Initial full waterfall texture upload (convert RGB32→RGBA8)
     if (!m_waterfall.isNull()) {
@@ -7957,6 +8235,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const QRect wfRect(0, wfY, w, wfH);
     int fftTracePointCount = 0;
     int fftLineStripVertexCount = 0;
+
+    // 3DSS replaces only the spectrum trace: the surface fills specRect and the
+    // waterfall, divider, freq scale, and all overlays keep their normal 2D
+    // positions. Everything below is identical to 2D except the FFT trace is
+    // swapped for the 3DSS surface quad inside specRect.
+    const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
 
     // Detect display state changes that may bypass markOverlayDirty()
     {
@@ -8132,7 +8416,6 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
             // Divider bar
             p.fillRect(0, specH, w, DIVIDER_H, AetherSDR::ThemeManager::instance().color("color.background.2"));
-
             drawFreqScale(p, QRect(0, specH + DIVIDER_H, w, freqScaleH()));
             drawTnfMarkers(p, specRect);
             if (m_showSpots || m_showSHistory)
@@ -8142,9 +8425,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawSmartMtrValueLabels(p);
             drawOffScreenSlices(p, specRect);
 
-            drawAutoSqlFloor(p, specRect);
-
-            drawSquelchLine(p, specRect);
+            // The auto-SQL floor and squelch line are anchored to the 2D
+            // dynamic-range y-axis, which doesn't map onto the 3D surface — only
+            // the (frequency) x-axis carries over there. Suppress them in 3D.
+            if (!is3D) {
+                drawAutoSqlFloor(p, specRect);
+                drawSquelchLine(p, specRect);
+            }
 
             // WNB / RF gain / Prop forecast indicators (top-right of spectrum)
             {
@@ -8290,7 +8577,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawConnectionAnimation(p, specRect);
             drawKiwiSdrConnectionOverlay(
                 p, QRect(0, 0, qMax(0, w - DBM_STRIP_W), h));
-            drawDbmScale(p, specRect);
+            // The dBm strip is the 2D vertical scale; it doesn't apply to the 3D
+            // surface (height = floor→ref strength, not linear dBm). Keep the
+            // time scale — the waterfall below is unchanged.
+            if (!is3D) {
+                drawDbmScale(p, specRect);
+            }
             drawTimeScale(p, wfRect);
 
             m_overlayStaticDirty = false;
@@ -8313,20 +8605,138 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             m_overlayBgNeedsUpload = false;
         }
 
+        // 3DSS surface texture — 3D mode only, rebuilt/uploaded only when the
+        // cached surface actually changed (generation bump). Rendered at a
+        // CAPPED resolution (the surface is intrinsically 56x256, so a smaller
+        // texture is visually free via the Linear overlay sampler) and stretched
+        // to the specRect viewport. This keeps the per-frame QPainter rebuild and
+        // texture upload an order of magnitude cheaper than a full-widget image.
+        if (is3D && m_dssMeshReady) {
+            // GPU mesh path: keep the palette LUT current, upload every height
+            // row pushed since the last frame into the ring texture, and refresh
+            // the uniforms. Geometry is static — pan/zoom rebuild nothing.
+            const float floorDbm = dssFloorDbm();
+            const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
+            uploadDssPaletteLut(batch, floorDbm, rangeDb);
+
+            const int cols = m_dss.cols();
+            const int rows = m_dss.rows();
+            const int head = m_dss.headRing();
+            const int valid = m_dss.rowCount();
+            // Catch-up upload: pushRow runs per FFT block (often faster than
+            // vsync), so the ring head can advance by >1 between frames. Upload
+            // every new ring slot from the last-uploaded head up to the current
+            // head — uploading only the newest would draw the skipped rows stale.
+            if (valid > 0 && head != m_dssMeshHeadUploaded) {
+                static_assert(DssRenderer::kCols <= 65536,
+                              "qfloat16 row fits a texture width");
+                int newRows = (m_dssMeshHeadUploaded < 0)
+                    ? valid
+                    : (m_dssMeshHeadUploaded - head + rows) % rows;
+                newRows = std::clamp(newRows, 0, valid);
+                QVarLengthArray<QRhiTextureUploadEntry, DssRenderer::kRows> entries;
+                for (int n = 0; n < newRows; ++n) {
+                    const int ring = (head + n) % rows;  // head..head+newRows-1
+                    const float* srcRow = m_dss.rowDataRing(ring);
+                    QByteArray bytes(cols * int(sizeof(qfloat16)), Qt::Uninitialized);
+                    qfloat16* dst = reinterpret_cast<qfloat16*>(bytes.data());
+                    for (int c = 0; c < cols; ++c) {
+                        dst[c] = qfloat16(srcRow[c]);
+                    }
+                    QRhiTextureSubresourceUploadDescription rowDesc;
+                    rowDesc.setData(bytes);  // descriptor keeps the bytes alive
+                    rowDesc.setSourceSize(QSize(cols, 1));
+                    rowDesc.setDestinationTopLeft(QPoint(0, ring));
+                    entries.append(QRhiTextureUploadEntry(0, 0, rowDesc));
+                }
+                if (!entries.isEmpty()) {
+                    QRhiTextureUploadDescription desc;
+                    desc.setEntries(entries.cbegin(), entries.cend());
+                    batch->uploadTexture(m_dssHeightTex, desc);
+                    if (perfEnabled) {
+                        PerfTelemetry::instance().recordGpuUpload(
+                            PerfTelemetry::GpuUploadKind::Overlay);
+                    }
+                }
+                m_dssMeshHeadUploaded = head;
+            }
+
+            // rowOffset carries a half-texel so the shader (texY = fract(rowOffset
+            // + v), v = rr/rows) samples row (head+rr) CENTRES, not boundaries —
+            // avoids Nearest off-by-one. Column centring uses texCols in the shader.
+            const float rowOffset = rows > 0
+                ? (static_cast<float>(head) + 0.5f) / static_cast<float>(rows)
+                : 0.0f;
+            float ubo[kDssMeshUboFloats] = {
+                rowOffset,
+                floorDbm, rangeDb, m_dssZCurve,
+                DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
+                DssRenderer::kFrontMaxRidgeFrac, DssRenderer::kHaze,
+                static_cast<float>(cols), 0.0f, 0.0f, 0.0f,   // texCols + std140 pad
+                static_cast<float>(m_bgFillColor.redF()),
+                static_cast<float>(m_bgFillColor.greenF()),
+                static_cast<float>(m_bgFillColor.blueF()),
+                1.0f,                                         // bgFill vec4
+            };
+            batch->updateDynamicBuffer(m_dssMeshUbo, 0, sizeof(ubo), ubo);
+        } else if (is3D) {
+            // CPU cached-image fallback (no mesh pipeline). Rendered at a capped
+            // resolution and stretched to the specRect viewport.
+            const float fbDpr = static_cast<float>(renderTarget()->pixelSize().width())
+                              / static_cast<float>(qMax(1, w));
+            const int specPwDev = qMax(1, qRound(specRect.width() * fbDpr));
+            const int specPhDev = qMax(1, qRound(specH * fbDpr));
+            constexpr int kDssMaxW = 1024, kDssMaxH = 512;
+            const double sc = qMin(1.0, qMin(double(kDssMaxW) / specPwDev,
+                                             double(kDssMaxH) / specPhDev));
+            const int dssW = qMax(2, static_cast<int>(specPwDev * sc));
+            const int dssH = qMax(2, static_cast<int>(specPhDev * sc));
+            const QImage& surf = buildDssImage(QSize(dssW, dssH), 0);
+            if (!surf.isNull()) {
+                if (m_dssTexW != dssW || m_dssTexH != dssH) {
+                    m_dssTexW = dssW;
+                    m_dssTexH = dssH;
+                    m_dssGpuTex->setPixelSize(QSize(dssW, dssH));
+                    m_dssGpuTex->create();
+                    m_dssSrb->setBindings({
+                        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_dssGpuTex, m_ovSampler),
+                    });
+                    m_dssSrb->create();
+                    m_dssTexNeedsUpload = true;
+                }
+                if (m_dssTexNeedsUpload
+                    || m_dss.generation() != m_dssLastUploadedGen) {
+                    QRhiTextureSubresourceUploadDescription dssDesc(surf);
+                    batch->uploadTexture(m_dssGpuTex, QRhiTextureUploadEntry(0, 0, dssDesc));
+                    if (perfEnabled)
+                        PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
+                    m_dssLastUploadedGen = m_dss.generation();
+                    m_dssTexNeedsUpload = false;
+                }
+            }
+        }
+
         // Position the flags for THIS frame so a dragged flag's sprite is drawn at
         // the current marker position (no one-frame lag).  (Live-flag selection
         // runs OUTSIDE the render callback — from the refresh timer / mouse move —
         // because it shows/raises widgets, which must not happen mid-render.)
         repositionVfoFlags(specRect);
 
-        // Generate FFT spectrum vertices with baked colors
-        const QVector<float>& fftBins =
-            buildFftDisplayTrace(displaySpectrumBins(),
-                                 qMax(2, specRect.width() * kFftDisplayOversample));
-        const int n = qMin(fftBins.size(), kMaxFftBins);
+        // Generate FFT spectrum vertices with baked colors. 2D only — in 3D the
+        // surface replaces the trace, so skip the trace build + vertex write
+        // entirely (they were previously built and then discarded every frame).
+        const QVector<float>* fftBinsPtr = nullptr;
+        int n = 0;
+        if (!is3D) {
+            fftBinsPtr = &buildFftDisplayTrace(
+                displaySpectrumBins(),
+                qMax(2, specRect.width() * kFftDisplayOversample));
+            n = qMin(fftBinsPtr->size(), kMaxFftBins);
+        }
         // n >= 2 also guards the 1/(n-1) position step and the central-difference
         // normal (pts[i±1]) below against a degenerate 1-bin spectrum.
         if (n >= 2 && m_fftLineVbo && m_fftFillVbo) {
+            const QVector<float>& fftBins = *fftBinsPtr;
             fftTracePointCount = n;
             const float minDbm = m_refLevel - m_dynamicRange;
             const float maxDbm = m_refLevel;
@@ -8523,7 +8933,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const QSize outputSize = renderTarget()->pixelSize();
     const float dpr = outputSize.width() / static_cast<float>(qMax(1, w));
 
-    // Draw waterfall quad — viewport restricted to waterfall rect
+    // Draw waterfall quad — viewport restricted to waterfall rect. Always drawn:
+    // 3DSS replaces only the spectrum trace, the waterfall stays below it.
     if (m_wfPipeline) {
         cb->setGraphicsPipeline(m_wfPipeline);
         cb->setShaderResources(m_wfSrb);
@@ -8554,8 +8965,52 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         cb->draw(4);
     }
 
-    // Draw FFT spectrum — viewport restricted to spectrum rect
-    if (m_fftFillPipeline && m_fftLinePipeline && fftTracePointCount > 0) {
+    // Draw the 3DSS surface in the SPECTRUM viewport (FFT z-slot; waterfall + bg
+    // below, static overlay on top).
+    if (is3D && m_dssMeshReady && m_dssMeshFillPipeline) {
+        // GPU height-map mesh: static grid, height from the ring texture.
+        const QRhiViewport vp(static_cast<float>(specRect.x()) * dpr,
+                              static_cast<float>(h - specRect.bottom() - 1) * dpr,
+                              static_cast<float>(specRect.width()) * dpr,
+                              static_cast<float>(specRect.height()) * dpr);
+        const int cols = m_dss.cols();
+        const int drawnRows = m_dss.rowCount();
+
+        // Opaque fill curtains, back (oldest) -> front (newest) for occlusion.
+        cb->setGraphicsPipeline(m_dssMeshFillPipeline);
+        cb->setShaderResources(m_dssMeshSrb);
+        cb->setViewport(vp);
+        {
+            const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshVbo, 0);
+            cb->setVertexInput(0, 1, &vbuf);
+            for (int rr = drawnRows - 1; rr >= 0; --rr)
+                cb->draw(2 * cols, 1, rr * 2 * cols, 0);
+        }
+        // Dim per-row trace outline on top.
+        cb->setGraphicsPipeline(m_dssMeshLinePipeline);
+        cb->setShaderResources(m_dssMeshSrb);
+        cb->setViewport(vp);
+        {
+            const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);
+            cb->setVertexInput(0, 1, &vbuf);
+            for (int rr = drawnRows - 1; rr >= 0; --rr)
+                cb->draw(cols, 1, rr * cols, 0);
+        }
+    } else if (is3D && m_ovPipeline && m_dssSrb && m_dssTexW > 0) {
+        // Cached-image fallback quad, stretched to the specRect viewport.
+        cb->setGraphicsPipeline(m_ovPipeline);
+        cb->setShaderResources(m_dssSrb);
+        cb->setViewport({static_cast<float>(specRect.x()) * dpr,
+                         static_cast<float>(h - specRect.bottom() - 1) * dpr,
+                         static_cast<float>(specRect.width()) * dpr,
+                         static_cast<float>(specRect.height()) * dpr});
+        const QRhiCommandBuffer::VertexInput vbuf(m_ovVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        cb->draw(4);
+    }
+
+    // Draw FFT spectrum — viewport restricted to spectrum rect (2D only)
+    if (!is3D && m_fftFillPipeline && m_fftLinePipeline && fftTracePointCount > 0) {
         const int n = fftTracePointCount;
         float specVpX = static_cast<float>(specRect.x()) * dpr;
         float specVpY = static_cast<float>(h - specRect.bottom() - 1) * dpr;
@@ -8693,6 +9148,28 @@ void SpectrumWidget::releaseResources()
     delete m_bgSrb;          m_bgSrb = nullptr;
     delete m_bgGpuTex;       m_bgGpuTex = nullptr;
 
+    // 3DSS surface layer — same lifecycle as the overlay scaffolding.
+    delete m_dssSrb;         m_dssSrb = nullptr;
+    delete m_dssGpuTex;      m_dssGpuTex = nullptr;
+    m_dssTexW = m_dssTexH = 0;
+    m_dssTexNeedsUpload = true;
+    m_dssLastUploadedGen = ~0ull;
+
+    // 3DSS GPU mesh.
+    delete m_dssMeshFillPipeline; m_dssMeshFillPipeline = nullptr;
+    delete m_dssMeshLinePipeline; m_dssMeshLinePipeline = nullptr;
+    delete m_dssMeshSrb;          m_dssMeshSrb = nullptr;
+    delete m_dssMeshVbo;          m_dssMeshVbo = nullptr;
+    delete m_dssMeshLineVbo;      m_dssMeshLineVbo = nullptr;
+    delete m_dssMeshUbo;          m_dssMeshUbo = nullptr;
+    delete m_dssHeightTex;        m_dssHeightTex = nullptr;
+    delete m_dssPaletteTex;       m_dssPaletteTex = nullptr;
+    delete m_dssHeightSampler;    m_dssHeightSampler = nullptr;
+    delete m_dssPaletteSampler;   m_dssPaletteSampler = nullptr;
+    m_dssMeshReady = false;
+    m_dssMeshHeadUploaded = -1;
+    m_dssLutToken = ~0ull;
+
     delete m_fftLinePipeline; m_fftLinePipeline = nullptr;
     delete m_fftFillPipeline; m_fftFillPipeline = nullptr;
     delete m_fftSrb;          m_fftSrb = nullptr;
@@ -8740,12 +9217,26 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     const QRect scaleRect(0, scaleY,  width(), freqScaleH());
     const QRect wfRect   (0, wfY,     width(), wfH);
 
-    {
-        // Software fallback: full QPainter rendering.  Composition z-order:
-        //   bottom: m_bgFillColor (user-pickable, default #0a0a14)
-        //   middle: bg image at opacity (1 - m_bgOpacity/100) so the fill
-        //           bleeds through as the slider moves toward 100
-        //   above:  grid → FFT trace → band plan → markers
+    const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
+
+    // Spectrum region: the 3DSS surface, or the classic bg + grid + FFT trace.
+    // 3DSS replaces ONLY the spectrum trace — the divider, freq scale, waterfall,
+    // overlays, and scales below run identically in both modes.
+    if (is3D) {
+        // Cap the software surface (like the GPU path) so a HiDPI/maximized
+        // window doesn't rebuild a multi-megapixel QImage every frame; the
+        // surface is intrinsically low-res, so stretch it on draw.
+        constexpr int kDssMaxW = 1024;
+        constexpr int kDssMaxH = 512;
+        const QImage& surf =
+            buildDssImage(specRect.size().boundedTo(QSize(kDssMaxW, kDssMaxH)), 0);
+        if (!surf.isNull()) {
+            p.drawImage(specRect, surf);
+        } else {
+            p.fillRect(specRect, m_bgFillColor);
+        }
+    } else {
+        // Composition z-order: bg fill → bg image → grid → FFT trace.
         p.fillRect(specRect, m_bgFillColor);
         if (!m_leanMode && !m_bgImage.isNull()) {
             if (m_bgScaledSize != specRect.size()) {
@@ -8762,29 +9253,32 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         }
         drawGrid(p, specRect);
         drawSpectrum(p, specRect);
-        if (m_bandPlanFontSize > 0) drawBandPlan(p, specRect);
-
-        p.fillRect(divRect, AetherSDR::ThemeManager::instance().color("color.background.1"));
-        p.setPen(QColor(m_draggingDivider ? 0x00b4d8 : 0x304050));
-        p.drawLine(divRect.left(), divRect.center().y(), divRect.right(), divRect.center().y());
-
-        drawFreqScale(p, scaleRect);
-        drawWaterfall(p, wfRect);
-        drawTnfMarkers(p, specRect);
-        if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
-        drawSwrSweep(p, specRect);
-        drawSliceMarkers(p, specRect, wfRect);
-        drawSmartMtrValueLabels(p);
-        drawOffScreenSlices(p, specRect);
-
-        drawAutoSqlFloor(p, specRect);
-
-        drawSquelchLine(p, specRect);
-
-        drawConnectionAnimation(p, specRect);
-        drawKiwiSdrConnectionOverlay(
-            p, QRect(0, 0, qMax(0, width() - DBM_STRIP_W), height()));
     }
+
+    if (m_bandPlanFontSize > 0) drawBandPlan(p, specRect);
+
+    p.fillRect(divRect, AetherSDR::ThemeManager::instance().color("color.background.1"));
+    p.setPen(QColor(m_draggingDivider ? 0x00b4d8 : 0x304050));
+    p.drawLine(divRect.left(), divRect.center().y(), divRect.right(), divRect.center().y());
+
+    drawFreqScale(p, scaleRect);
+    drawWaterfall(p, wfRect);
+    drawTnfMarkers(p, specRect);
+    if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
+    drawSwrSweep(p, specRect);
+    drawSliceMarkers(p, specRect, wfRect);
+    drawSmartMtrValueLabels(p);
+    drawOffScreenSlices(p, specRect);
+
+    // dB-axis overlays don't map onto the 3D surface (see GPU path) — suppress.
+    if (!is3D) {
+        drawAutoSqlFloor(p, specRect);
+        drawSquelchLine(p, specRect);
+    }
+
+    drawConnectionAnimation(p, specRect);
+    drawKiwiSdrConnectionOverlay(
+        p, QRect(0, 0, qMax(0, width() - DBM_STRIP_W), height()));
 
     // Reposition all VFO widgets — deconflict flags so they fly away from each other
     // Split pairs always face each other: RX←  →TX
@@ -8979,7 +9473,10 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         p.drawText(lx + 4, ly + fm.ascent() + 2, label);
     }
 
-    drawDbmScale(p, specRect);
+    // dBm strip is the 2D vertical scale — not meaningful on the 3D surface.
+    if (!is3D) {
+        drawDbmScale(p, specRect);
+    }
     drawTimeScale(p, wfRect);
 
     if (PerfTelemetry::instance().enabled()) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1027,6 +1027,12 @@ private:
     // own colour) up off the baseline so you see floor -> peak, not just crests.
     float m_dssFloorOffsetDb{-6.0f};
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
+    // Consumed by BOTH the GPU mesh and the CPU fallback surface, so these stay
+    // outside the AETHER_GPU_SPECTRUM block below — the CPU paint path needs them
+    // even when GPU spectrum rendering is disabled (older Qt / -DAETHER_GPU_SPECTRUM=OFF).
+    float m_dssZCurve{0.70f};               // <1 expands the floor band (more floor)
+    static constexpr int kDssMaxW = 1024;   // 3DSS surface texture/image caps
+    static constexpr int kDssMaxH = 512;
 
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     // Radio's per-tile auto-black level (raw uint16). Preferred over the client
@@ -1428,12 +1434,6 @@ private:
     int  m_dssMeshHeadUploaded{-1};          // ring head last uploaded to heightTex
     quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked
     QByteArray m_dssRowScratch;              // reused qfloat16 row buffer (mesh upload)
-    float m_dssZCurve{0.70f};           // <1 expands the floor band (more floor)
-    // Cap for the 3DSS surface texture/image (GPU mesh fallback + CPU paint).
-    // The surface is intrinsically low-res, so a smaller texture is visually
-    // free via the linear sampler and keeps the per-frame rebuild/upload cheap.
-    static constexpr int kDssMaxW = 1024;
-    static constexpr int kDssMaxH = 512;
 
     void initDssMeshPipeline();
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -387,6 +387,11 @@ public:
     // lifting the floor carpet into view. Persisted per-panadapter.
     void setDssFloorDepth(int dB);
     int  dssFloorDepth() const { return static_cast<int>(std::lround(-m_dssFloorOffsetDb)); }
+    // 3DSS colour floor (0-100): how far down the strength range the colormap
+    // reaches. Higher lifts colour toward the noise floor; lower keeps colour on
+    // strong signals only (gamma-shapes the palette lookup). Persisted per-pan.
+    void setDssGain(int pct);
+    int  dssGain() const { return m_dssGain; }
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
@@ -831,6 +836,12 @@ private:
     QRgb dbmToRgb(float dbm) const;
     QRgb kiwiSdrLevelToRgb(float level) const;
     QRgb intensityToRgb(float intensity) const;  // for native waterfall tiles
+    // 3DSS surface colour for a normalised strength s in [0,1] (0 = noise floor,
+    // 1 = ref). The full colormap gradient, gamma-shaped by the "3D Gain"
+    // control. Shared by the GPU LUT bake and the CPU fallback so both paths
+    // colour identically (deliberately NOT dbmToRgb(), whose waterfall
+    // black-level window clipped the lower range to black).
+    QRgb dssStrengthToRgb(float s) const;
 
     // 3DSS — rebuild/return the cached perspective surface for the given pixel
     // size (scaleStripPx = transparent frequency-scale strip at the bottom).
@@ -1007,11 +1018,15 @@ private:
     // 3DSS — perspective stacked-trace render mode. m_dss owns the rolling
     // history + cached surface image; consumed by both the CPU and GPU paths.
     SpectrumRenderMode m_spectrumRenderMode{SpectrumRenderMode::Mode2D};
+    // GUI-thread only: pushRow() (updateSpectrum / updateKiwiSdrWaterfallRow) and
+    // the renderGpuFrame/paint reads all run on the GUI thread, so m_dss needs no
+    // lock. Do NOT call pushRow() from a worker/audio thread without adding one.
     DssRenderer   m_dss;
     // 3DSS height anchor: the measured noise floor maps this many dB below the
     // trace baseline. A few dB negative lifts the noisy floor carpet (with its
     // own colour) up off the baseline so you see floor -> peak, not just crests.
     float m_dssFloorOffsetDb{-6.0f};
+    int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
 
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     // Radio's per-tile auto-black level (raw uint16). Preferred over the client
@@ -1412,7 +1427,13 @@ private:
     bool m_dssMeshReady{false};
     int  m_dssMeshHeadUploaded{-1};          // ring head last uploaded to heightTex
     quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked
+    QByteArray m_dssRowScratch;              // reused qfloat16 row buffer (mesh upload)
     float m_dssZCurve{0.70f};           // <1 expands the floor band (more floor)
+    // Cap for the 3DSS surface texture/image (GPU mesh fallback + CPU paint).
+    // The surface is intrinsically low-res, so a smaller texture is visually
+    // free via the linear sampler and keeps the per-frame rebuild/upload cheap.
+    static constexpr int kDssMaxW = 1024;
+    static constexpr int kDssMaxH = 512;
 
     void initDssMeshPipeline();
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -14,6 +14,8 @@
 #include <QTimer>
 #include <QLabel>
 
+#include "DssRenderer.h"
+
 class QVariantAnimation;
 class QSoundEffect;
 
@@ -57,6 +59,13 @@ const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count);
 
 // Returns the display name for a color scheme.
 const char* wfSchemeName(WfColorScheme scheme);
+
+// Spectrum render mode for the panadapter surface.
+enum class SpectrumRenderMode : int {
+    Mode2D = 0,    // FFT trace + scrolling waterfall (classic)
+    Mode3D,        // 3DSS perspective stacked-trace surface
+    Count          // sentinel
+};
 
 // Panadapter / spectrum display widget.
 //
@@ -370,6 +379,14 @@ public:
     void setWfAutoBlackRadioSide(bool radioSide);
     void setWfLineDuration(int ms);
     void setWfColorScheme(int scheme);
+    // Spectrum render mode: 2D (FFT trace + waterfall) or 3D (3DSS stacked
+    // perspective trace surface). Persisted per-panadapter.
+    void setSpectrumRenderMode(int mode);
+    int  spectrumRenderMode() const { return static_cast<int>(m_spectrumRenderMode); }
+    // 3DSS floor depth: how far below the measured noise floor to surface (dB),
+    // lifting the floor carpet into view. Persisted per-panadapter.
+    void setDssFloorDepth(int dB);
+    int  dssFloorDepth() const { return static_cast<int>(std::lround(-m_dssFloorOffsetDb)); }
     void resetWfTimeScale();
     int   wfColorGain() const          { return m_wfColorGain; }
     int   wfBlackLevel() const         { return m_wfBlackLevel; }
@@ -815,6 +832,20 @@ private:
     QRgb kiwiSdrLevelToRgb(float level) const;
     QRgb intensityToRgb(float intensity) const;  // for native waterfall tiles
 
+    // 3DSS — rebuild/return the cached perspective surface for the given pixel
+    // size (scaleStripPx = transparent frequency-scale strip at the bottom).
+    const QImage& buildDssImage(const QSize& px, int scaleStripPx);
+    // Token folding the dbmToRgb() palette inputs so the 3DSS cache rebuilds
+    // when the colour mapping (scheme/gain/floor) changes.
+    quint64 dssPaletteToken() const;
+    // Unified noise-floor anchor (dBm, quantised) for the 3D surface — uses the
+    // measured floor for the active source (Flex or KiwiSDR), offset by the
+    // user's 3D Floor depth, so the floor sits at the baseline consistently.
+    float dssFloorDbm() const;
+    // dB span shown above the noise floor — Ref-derived, clamped so the wide
+    // Flex window can't flatten signals.
+    float dssSpanDb() const;
+
     // Pixel x coordinate for a given frequency in MHz (0 = left edge).
     int mhzToX(double mhz) const;
     // Convert pixel x back to MHz.
@@ -972,6 +1003,16 @@ private:
     // legacy look); true = the radio's per-tile auto-black level.
     bool  m_wfAutoBlackRadioSide{false};
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
+
+    // 3DSS — perspective stacked-trace render mode. m_dss owns the rolling
+    // history + cached surface image; consumed by both the CPU and GPU paths.
+    SpectrumRenderMode m_spectrumRenderMode{SpectrumRenderMode::Mode2D};
+    DssRenderer   m_dss;
+    // 3DSS height anchor: the measured noise floor maps this many dB below the
+    // trace baseline. A few dB negative lifts the noisy floor carpet (with its
+    // own colour) up off the baseline so you see floor -> peak, not just crests.
+    float m_dssFloorOffsetDb{-6.0f};
+
     float m_autoBlackThresh{145.0f}; // client-side auto-black: tracked noise floor
     // Radio's per-tile auto-black level (raw uint16). Preferred over the client
     // estimate when non-zero; matches FlexLib's auto-level pipeline.
@@ -1339,6 +1380,42 @@ private:
     QRhiTexture* m_bgGpuTex{nullptr};
     QImage m_overlayBg;
     bool m_overlayBgNeedsUpload{true};
+
+    // 3DSS surface layer — the cached 3D image uploaded as a texture and drawn
+    // through the overlay pipeline (overlay.frag, premultiplied alpha) as a
+    // full-screen quad, above the 2D layers and below the static overlay. Reuses
+    // m_ovPipeline / m_ovVbo / m_ovSampler; only the texture + SRB are dedicated.
+    QRhiShaderResourceBindings* m_dssSrb{nullptr};
+    QRhiTexture* m_dssGpuTex{nullptr};
+    bool m_dssTexNeedsUpload{true};
+    quint64 m_dssLastUploadedGen{~0ull};  // DssRenderer generation last uploaded
+    int m_dssTexW{0};
+    int m_dssTexH{0};
+
+    // 3DSS GPU height-map mesh (preferred path). The DssRenderer ring store
+    // feeds a ring-buffered R16F height texture; a static perspective grid samples
+    // it in dss_mesh.vert. Geometry never rebuilds, so pan/zoom are free. Falls
+    // back to the cached-image quad above when the pipeline can't be created.
+    QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // TriangleStrip, opaque
+    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // LineStrip, alpha (outline)
+    QRhiShaderResourceBindings* m_dssMeshSrb{nullptr};
+    QRhiBuffer* m_dssMeshVbo{nullptr};       // curtain verts (ridge+floor), static
+    QRhiBuffer* m_dssMeshLineVbo{nullptr};   // ridge-only verts (outline), static
+    QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
+    // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
+    // ubo[] writer in renderGpuFrame(). 8 scalars + texCols + 3 pad + vec4 bgFill.
+    static constexpr int kDssMeshUboFloats = 16;
+    QRhiTexture* m_dssHeightTex{nullptr};    // R16F ring heightmap (cols x rows)
+    QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT
+    QRhiSampler* m_dssHeightSampler{nullptr};
+    QRhiSampler* m_dssPaletteSampler{nullptr};
+    bool m_dssMeshReady{false};
+    int  m_dssMeshHeadUploaded{-1};          // ring head last uploaded to heightTex
+    quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked
+    float m_dssZCurve{0.70f};           // <1 expands the floor band (more floor)
+
+    void initDssMeshPipeline();
+    void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);
 
     void initWaterfallPipeline();
     void initOverlayPipeline();


### PR DESCRIPTION
<img width="1733" height="1190" alt="Screenshot 2026-06-28 at 10 57 21 PM" src="https://github.com/user-attachments/assets/7f812d69-f10b-4440-ae4c-90b51e65af4b" />

## Summary

Adds a **stacked-trace spectrum stream** as a panadapter render mode, selectable from the Display pane (**Spectrum: 2D / 3D**). In 3D the spectrum region becomes a perspective stacked-trace surface — a rolling history of FFT traces receding into the distance — while the waterfall, frequency scale, and all overlays keep working underneath. The 2D path is unchanged. Built on the project's existing Qt + QRhi infrastructure and designed to run on **macOS, Windows, and Linux**.

## Features

- **Perspective stacked-trace surface.** A rolling history (96 rows × 768 columns) drawn back-to-front: the newest trace spans the full width across the front; older traces recede into a narrower, higher trapezoid; each ridge fills to the plot floor so nearer traces occlude farther ones.
- **GPU height-map mesh.** A static vertex grid samples a ring-buffered height texture, so pan/zoom/resize rebuild **no geometry** — panning stays fluid. Each new FFT frame uploads a single texture row (~1.5 KB) instead of re-rasterizing the surface.
- **Noise-floor-anchored amplitude with a floor→peak colour gradient.** Ridge height is anchored to the measured noise floor (the same estimator the 2D auto-floor uses), with a non-linear floor-expansion curve, so the floor is visible *and* coloured up through the peaks rather than only the crests. A **3D Floor** depth slider controls how far below the floor to surface. The colour palette follows the existing waterfall colour-scheme selector.
- **Dim per-row trace outline.** A depth-faded hairline traces each receding ridge.
- **Broadband impulse rejection.** A temporal median rejects 1-frame interference bursts before they enter the height history, so a strong transient doesn't become a full-height artifact that recedes across the surface.
- **Overlays preserved.** Spots, memories, slice/VFO markers, navigation hints, band plan, and the dBm/time/frequency scales all render exactly as in 2D — the 3D surface replaces only the spectrum trace.
- **Controls** (Display pane, persisted per-panadapter): the 2D/3D selector and the 3D Floor depth slider.
- **Display-pane background control** (small, self-contained): right-clicking the background **Clear** button turns the spectrum background off entirely (no image, just the fill colour) and persists it; left-click still reverts to the default logo.

## Cross-platform

- **No platform-specific shader code.** The two new shaders are plain GLSL 440 and are baked by Qt's shader tool (`qsb`) to the full variant set — SPIR-V (Vulkan), GLSL (OpenGL/GLES), HLSL (Direct3D 11), and MSL (Metal) — the same set the existing spectrum shaders produce.
- **Backend selection is unchanged.** The QRhi API is chosen exactly as the existing GPU spectrum already does it: Metal on macOS (`#ifdef Q_OS_MAC`), the platform default elsewhere (Direct3D 11 on Windows, OpenGL/Vulkan on Linux). The new surface rides the same `QRhiWidget`.
- **Portable feature choices.** No geometry/tessellation shaders; occlusion is by back-to-front draw order (no depth-attachment dependency); 1-px lines; the R16F height texture is guarded by a capability check.
- **Graceful degradation.** GPU mesh → GPU cached-image quad (RGBA8) → CPU `QPainter` surface, so it still renders where the height texture or QRhi itself isn't available (including older-Qt builds where the GPU spectrum is compiled out).
- Compiles in CI on Windows and Linux alongside macOS.

## Verification

- Live-tested RX on hardware (macOS / Metal): dense, smooth surface; noise floor visible with the floor→peak gradient; dim trace outlines; fluid pan; impulse bursts rejected; perf healthy (full FFT rate, ~1 ms UI-thread lag, 0% frame loss). The 2D trace + waterfall round-trips unchanged.
- The impulse rejection was additionally verified with a standalone render harness (a 1-frame broadband burst injected mid-history produces no artifact).
- Runtime rendering on Windows/Linux GPU backends has not yet been eyeballed — CI covers the build + shader bake, and the QRhi/NDC plumbing matches the existing cross-platform spectrum pipelines. A quick visual check on those platforms is welcome.

---
💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat

