### PR TITLE
fix(gui): DX spot tooltip blocked by passband hit-test (#3887)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6690,13 +6690,6 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                         foundCursor = true;
                     }
                 }
-                if (!foundCursor) {
-                    Qt::CursorShape cursorShape = Qt::ArrowCursor;
-                    if (sliceCursorShapeAt(pos, cursorShape)) {
-                        setSpectrumCursor(cursorShape);
-                        foundCursor = true;
-                    }
-                }
                 if (!foundCursor && m_showSpots) {
                     bool spotHover = false;
                     for (const auto& hr : m_spotClickRects) {
@@ -6724,6 +6717,13 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                                 break;
                             }
                         }
+                    }
+                }
+                if (!foundCursor) {
+                    Qt::CursorShape cursorShape = Qt::ArrowCursor;
+                    if (sliceCursorShapeAt(pos, cursorShape)) {
+                        setSpectrumCursor(cursorShape);
+                        foundCursor = true;
                     }
                 }
                 // Prop forecast overlay click target


### PR DESCRIPTION
## Summary
- Hovering over a DX spot inside the active slice passband showed no
  tooltip because `sliceCursorShapeAt` (passband body → `OpenHandCursor`)
  set `foundCursor = true` before the spot rect loop had a chance to run.
- Fix: move `m_spotClickRects` check ahead of `sliceCursorShapeAt` in
  `mouseMoveEvent`. 7-line block reorder, zero logic changes.
- Mirrors the existing press path (`spectrumDefaultsToCrosshairAt`,
  line 5578) which already returns `false` early for spot rects —
  click and hover now behave consistently.

## Test plan
- [ ] Enable SpotHub; tune a spot fully inside the active slice passband — tooltip appears on hover
- [ ] Same spot moved outside the passband — tooltip still works
- [ ] Filter edge resize zones (`kFilterEdgeGrabPx` grab strips) still respond correctly
- [ ] Spot cluster indicators inside passband show `PointingHandCursor`
- [ ] Tested: macOS 15, FLEX-6600, v26.6.5 build

Fixes #3887
Closes #3901