### PR TITLE
fix(audio): rename mislabeled TCI TX input48k soak telemetry (#3914)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -924,7 +924,7 @@ void TciServer::onBinaryMessage(const QByteArray& data)
 
     if (pcm.isEmpty()) return;
 
-    int inputFrames48k = 0;
+    int inputFramesSrcRate = 0;
     bool duplicatedStereo = false;
 
     // ─── TX resampling: client-declared rate → 24kHz (radio native DAX) ──
@@ -972,17 +972,17 @@ void TciServer::onBinaryMessage(const QByteArray& data)
         if (duplicatedStereo) {
             // WSJT-X fills `length` floats as stereo pairs in-place.
             int stereoFrames = totalFloats / 2;
-            inputFrames48k = stereoFrames;
+            inputFramesSrcRate = stereoFrames;
             pcm = m_txResampler->processStereoToStereo(fSrc, stereoFrames);
         } else if (totalFloats <= declaredSamples) {
             // True mono: upmix to stereo then resample.
             int monoFrames = totalFloats;
-            inputFrames48k = monoFrames;
+            inputFramesSrcRate = monoFrames;
             pcm = m_txResampler->processMonoToStereo(fSrc, monoFrames);
         } else {
             // Explicit stereo: resample directly.
             int stereoFrames = totalFloats / 2;
-            inputFrames48k = stereoFrames;
+            inputFramesSrcRate = stereoFrames;
             pcm = m_txResampler->processStereoToStereo(fSrc, stereoFrames);
         }
         if (pcm.isEmpty()) return;
@@ -1040,7 +1040,7 @@ void TciServer::onBinaryMessage(const QByteArray& data)
     }
 
     ++m_txAudioBlocks;
-    m_txInputFrames += inputFrames48k;
+    m_txInputFrames += inputFramesSrcRate;
     m_txOutputFrames += outputStereoFrames;
     m_txClipSamples += clipSamples;
     m_txAudioSampleCount += outputSamples;
@@ -1780,7 +1780,7 @@ void TciServer::logTxAudioSummary(const char* reason)
         << " gain=" << m_txGain
         << " blocks=" << m_txAudioBlocks
         << " requested48k=" << m_txChronoRequestedFrames
-        << " input48k=" << m_txInputFrames
+        << " inputFramesSrc=" << m_txInputFrames
         << " output24k=" << m_txOutputFrames
         << " effective48k=" << effectiveRate48k
         << " peak=" << m_txAudioPeak


### PR DESCRIPTION
## Summary

Low-severity / cosmetic follow-up to #3892 (`fix(audio): TCI TX resamples from client-declared rate`). **Telemetry-naming only — no audio or timing impact.**

Before #3892, the TCI TX path always resampled from a hardcoded 48 kHz, so the per-session input-frame counter `m_txInputFrames` (and the `inputFrames48k` local that feeds it) genuinely held 48 kHz frame counts. #3892 correctly switched the resampler to each frame's declared rate (`hdr.sampleRate`) but left the `48k` naming in place, so for a client that negotiates a non-48 kHz `audio_samplerate` (8/12/24 kHz) the counter now accumulates **source-rate** frames under a `48k` label — making the `input48k=N` soak diagnostic imply the wrong wall-clock duration (a 24 kHz client reads ~2× its real input duration).

## Root cause

`src/core/TciServer.cpp` — `inputFrames48k` is assigned the *input* frame count at the declared rate in all three layout branches (duplicated-stereo / mono / explicit-stereo), accumulated into `m_txInputFrames`, and emitted as the `input48k=` soak field. `m_txInputFrames` is **diagnostic-only**: its only consumers are the reset in `startTxChrono`, the increment, and the soak log line — nothing in the audio/timing path reads it. WSJT-X negotiates 48 kHz, so the common path reads correctly either way.

## Fix (pure rename, no behavior change)

| before | after |
|---|---|
| `int inputFrames48k` (local) | `int inputFramesSrcRate` |
| soak field `" input48k="` | `" inputFramesSrc="` |

`inputFramesSrcRate` makes the rate-relative semantics explicit and avoids future re-confusion with the genuinely 48k-anchored fields. The sibling soak fields are left untouched because they remain correct:
- `requested48k=` / `effective48k=` — anchored to the 48 kHz chrono request loop.
- `output24k=` — the fixed 24 kHz DAX native output rate.

## How the agent automation bridge proved it

This is a TX-only soak-log telemetry rename (`logTxAudioSummary`), with **no runtime UI/meter/control state** to read — the only observable is the emitted log string, which requires a live TCI client streaming TX audio to produce. Proof is therefore artifact-level on the freshly built `RelWithDebInfo` bundle:

```
$ strings AetherSDR | grep -nE 'input48k=|inputFramesSrc=|requested48k=|output24k=|effective48k='
303686: requested48k=
303687: inputFramesSrc=     # ← renamed field, in soak-log emission order
303688: output24k=
303689: effective48k=
# input48k=  → no match (old label fully gone)
```

The renamed label is compiled into the bundle in the exact emission order between `requested48k=` and `output24k=`; the old `input48k=` is gone; sibling fields intact. Full build (`cmake --build`, 24 cores) succeeds, confirming the identifier rename is consistent across all five source sites.

### Agent automation bridge — gap found
- **Driving a TCI TX audio session** — the soak line only emits after a TCI client streams TX audio and unkeys. The bridge can `key`/`get transmit` but has no verb to feed a synthetic TCI TX audio stream, so a live before→after of the emitted `inputFramesSrc=N` log line is not reachable. For a diagnostic-only label rename this is acceptable (artifact proof suffices), but a `tci injectTxAudio <rate> <frames>` verb (or a logwatch-backed soak-summary assertion) would let the bridge prove this whole class of TCI TX telemetry behavior end-to-end.

Fixes #3914
Refs #3892, #3306

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
