### PR TITLE
feat(bridge): get dsp, streams resync, selectRow/window verbs, TX-guard fix + a11y (#3856, #3918)

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -271,6 +271,17 @@ QJsonObject describeWidget(const QWidget* w)
     if (!val.isNull())
         o[QStringLiteral("value")] = val;
 
+    // A checkable button reports its value as "checked"/"unchecked", which hides
+    // the label that says *which* control it is (the six DSP method buttons —
+    // NR2 … BNR — were indistinguishable without a screenshot). Surface the
+    // button text and a boolean check-state so a driver can read both the
+    // identity and the on/off state from dumpTree alone (#3856).
+    if (auto* b = qobject_cast<const QAbstractButton*>(w); b && b->isCheckable()) {
+        if (!b->text().isEmpty())
+            o[QStringLiteral("text")] = b->text();
+        o[QStringLiteral("checked")] = b->isChecked();
+    }
+
     // Range for numeric controls — lets a driver validate against the real
     // bounds (scale) and detect wrapping/circular sliders without guessing
     // extremes (#3646).
@@ -1157,6 +1168,90 @@ QJsonObject audioSnapshotOnObjectThread(AudioEngine* audio, bool* ok)
         [audio, &snapshot]() {
             snapshot = audioSnapshot(audio);
         },
+        Qt::BlockingQueuedConnection);
+    *ok = invoked;
+    return snapshot;
+}
+
+// Client-side AetherDSP noise-reduction state (#3856). `get slice` reports the
+// radio-side nr/nb/anf; this is the missing model for the six client-side
+// AudioEngine modules (NR2 / NR4 / MNR / DFNR / RN2 / BNR) so a driver can
+// assert which method is active and read its tuning without a screenshot of the
+// AetherDSP applet. The modules are mutually exclusive, so `active` names the one
+// enabled module (or "none"). `available` reflects compile-time backend gating —
+// the same guards the selector buttons use to dim an unbuildable method.
+// Engine-only portion (enable flags + engine-owned tuning getters); the NR2/NR4
+// slider params live in AppSettings and are merged in by the caller on the main
+// thread. Runs on the AudioEngine thread (m_bnr/m_dfnr are not main-thread safe).
+QJsonObject dspEngineSnapshot(const AudioEngine* a)
+{
+    struct Mod { const char* name; bool enabled; bool available; };
+    const Mod mods[] = {
+        {"NR2",  a->nr2Enabled(),  true},
+        {"NR4",  a->nr4Enabled(),
+#ifdef HAVE_SPECBLEACH
+                                   true},
+#else
+                                   false},
+#endif
+        {"MNR",  a->mnrEnabled(),
+#ifdef Q_OS_MAC
+                                   true},
+#else
+                                   false},
+#endif
+        {"DFNR", a->dfnrEnabled(),
+#ifdef HAVE_DFNR
+                                   true},
+#else
+                                   false},
+#endif
+        {"RN2",  a->rn2Enabled(),  true},
+        {"BNR",  a->bnrEnabled(),
+#ifdef HAVE_BNR
+                                   true},
+#else
+                                   false},
+#endif
+    };
+
+    QJsonObject methods;
+    QString active = QStringLiteral("none");
+    for (const Mod& m : mods) {
+        methods[QLatin1String(m.name)] =
+            QJsonObject{{QStringLiteral("enabled"), m.enabled},
+                        {QStringLiteral("available"), m.available}};
+        if (m.enabled) active = QLatin1String(m.name);
+    }
+
+    // Engine-owned tuning (the slider params that have live engine getters).
+    QJsonObject tuning;
+    tuning[QStringLiteral("mnr")] =
+        QJsonObject{{QStringLiteral("strength"), a->mnrStrength()}};
+    tuning[QStringLiteral("dfnr")] =
+        QJsonObject{{QStringLiteral("attenLimitDb"), a->dfnrAttenLimit()}};
+    tuning[QStringLiteral("bnr")] =
+        QJsonObject{{QStringLiteral("intensity"), a->bnrIntensity()},
+                    {QStringLiteral("address"), a->bnrAddress()},
+                    {QStringLiteral("connected"), a->bnrConnected()}};
+
+    return QJsonObject{{QStringLiteral("active"), active},
+                       {QStringLiteral("methods"), methods},
+                       {QStringLiteral("tuning"), tuning}};
+}
+
+QJsonObject dspSnapshotOnObjectThread(AudioEngine* audio, bool* ok)
+{
+    *ok = false;
+    if (!audio) return {};
+    if (!audio->thread() || audio->thread() == QThread::currentThread()) {
+        *ok = true;
+        return dspEngineSnapshot(audio);
+    }
+    QJsonObject snapshot;
+    const bool invoked = QMetaObject::invokeMethod(
+        audio,
+        [audio, &snapshot]() { snapshot = dspEngineSnapshot(audio); },
         Qt::BlockingQueuedConnection);
     *ok = invoked;
     return snapshot;
@@ -2361,6 +2456,56 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                            {QStringLiteral("model"), model},
                            {QStringLiteral("audio"), data}};
     }
+    if (model == QLatin1String("dsp")) {
+        AudioEngine* audio = m_audioEngine;
+        if (!audio)
+            return err(QStringLiteral("no audio engine available"));
+        bool snapshotOk = false;
+        QJsonObject data = dspSnapshotOnObjectThread(audio, &snapshotOk);
+        if (!snapshotOk)
+            return err(QStringLiteral("dsp snapshot unavailable"));
+        // Merge the NR2/NR4/DFNR-beta slider params, which the AetherDSP applet
+        // persists in AppSettings rather than the engine. Read on the main
+        // thread (where the bridge runs); defaults mirror the applet's.
+        AppSettings& s = AppSettings::instance();
+        QJsonObject tuning = data.value(QStringLiteral("tuning")).toObject();
+        tuning[QStringLiteral("nr2")] = QJsonObject{
+            {QStringLiteral("gainMax"),    s.value("NR2GainMax", "1.50").toFloat()},
+            {QStringLiteral("gainSmooth"), s.value("NR2GainSmooth", "0.85").toFloat()},
+            {QStringLiteral("qspp"),       s.value("NR2Qspp", "0.20").toFloat()},
+            {QStringLiteral("gainMethod"), s.value("NR2GainMethod", "2").toInt()},
+            {QStringLiteral("npeMethod"),  s.value("NR2NpeMethod", "0").toInt()},
+            {QStringLiteral("aeFilter"),
+                s.value("NR2AeFilter", "True").toString() == QLatin1String("True")},
+        };
+        tuning[QStringLiteral("nr4")] = QJsonObject{
+            {QStringLiteral("reductionDb"),  s.value("NR4ReductionAmount", "100").toFloat()},
+            {QStringLiteral("smoothing"),    s.value("NR4SmoothingFactor", "0").toFloat()},
+            {QStringLiteral("whitening"),    s.value("NR4WhiteningFactor", "0").toFloat()},
+            {QStringLiteral("maskingDepth"), s.value("NR4MaskingDepth", "50").toFloat()},
+            {QStringLiteral("suppression"),  s.value("NR4SuppressionStrength", "50").toFloat()},
+            {QStringLiteral("noiseMethod"),  s.value("NR4NoiseEstimationMethod", "0").toInt()},
+            {QStringLiteral("adaptiveNoise"),
+                s.value("NR4AdaptiveNoise", "True").toString() == QLatin1String("True")},
+        };
+        QJsonObject dfnr = tuning.value(QStringLiteral("dfnr")).toObject();
+        dfnr[QStringLiteral("postFilterBeta")] =
+            s.value("DfnrPostFilterBeta", "0.0").toFloat();
+        tuning[QStringLiteral("dfnr")] = dfnr;
+        data[QStringLiteral("tuning")] = tuning;
+        if (!property.isEmpty()) {
+            if (!data.contains(property))
+                return err(QStringLiteral("unknown property '") + property
+                           + QStringLiteral("' for dsp"));
+            return QJsonObject{{QStringLiteral("ok"), true},
+                               {QStringLiteral("model"), model},
+                               {QStringLiteral("property"), property},
+                               {QStringLiteral("value"), data.value(property)}};
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("dsp"), data}};
+    }
     if (model == QLatin1String("sync")
         || model == QLatin1String("receiveSync")) {
         if (!m_receiveSyncSnapshotHandler) {
@@ -2422,7 +2567,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans)"));
     }
 
     if (!property.isEmpty()) {
@@ -3677,6 +3822,26 @@ QJsonObject AutomationServer::doStreams(const QString& action)
         };
     }
 
+    // `streams resync` — force the radio to re-dump its authoritative display
+    // set, then re-poll `streams radio` after a moment. Closes the gap where a
+    // waterfall lingers as a radio resource but no longer emits UDP (Layer A
+    // can't see it) and the client already purged its view (Layer B looked
+    // clean). The re-dump is async, so this just triggers and the driver reads
+    // the refreshed inventory on the next `streams radio`.
+    if (action.compare(QLatin1String("resync"), Qt::CaseInsensitive) == 0
+        || action.compare(QLatin1String("refresh"), Qt::CaseInsensitive) == 0) {
+        const bool sent = m_radioModel->resyncDisplayInventory();
+        if (!sent)
+            return err(QStringLiteral("not connected — cannot resync display inventory"));
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("scope"), QStringLiteral("radio")},
+            {QStringLiteral("resync"), QStringLiteral("requested")},
+            {QStringLiteral("hint"),
+             QStringLiteral("re-poll 'streams radio' after ~500ms for the refreshed set")},
+        };
+    }
+
     // Layer A — VITA-49 UDP-orphan detector (needs the stream receiver).
     PanadapterStream* ps = m_radioModel->panStream();
     if (!ps)
@@ -3689,7 +3854,8 @@ QJsonObject AutomationServer::doStreams(const QString& action)
     }
     if (!action.isEmpty())
         return err(QStringLiteral("unknown streams action: ") + action
-                   + QStringLiteral(" (use '' for UDP-orphan, 'radio' for inventory, or 'reset')"));
+                   + QStringLiteral(" (use '' for UDP-orphan, 'radio' for inventory,"
+                                    " 'resync' to force a re-dump, or 'reset')"));
 
     QJsonArray panReg;
     for (quint32 id : ps->registeredPanStreams()) panReg.append(hex(id));

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -44,6 +44,8 @@
 // Best-effort value extraction for common control types.
 #include <QAbstractButton>
 #include <QAbstractSlider>
+#include <QAbstractItemView>   // invoke selectRow: QTableWidget/QTreeWidget/QListWidget row select
+#include <QItemSelectionModel>
 #include <QComboBox>
 #include <QLineEdit>
 #include <QLabel>
@@ -266,6 +268,19 @@ QJsonObject describeWidget(const QWidget* w)
     geo[QStringLiteral("w")] = w->width();
     geo[QStringLiteral("h")] = w->height();
     o[QStringLiteral("geometry")] = geo;
+
+    // Window state for top-level windows — lets a driver assert a maximize /
+    // restore / minimize without screenshotting, and prove the `window` verb
+    // (resize only ever set explicit geometry, so an un-maximize was previously
+    // unverifiable). (#3918)
+    if (w->isWindow()) {
+        const Qt::WindowStates st = w->windowState();
+        const char* ws = "normal";
+        if (st & Qt::WindowMinimized)       ws = "minimized";
+        else if (st & Qt::WindowFullScreen) ws = "fullscreen";
+        else if (st & Qt::WindowMaximized)  ws = "maximized";
+        o[QStringLiteral("windowState")] = QLatin1String(ws);
+    }
 
     const QString val = widgetValue(w);
     if (!val.isNull())
@@ -838,10 +853,18 @@ bool isTransmitControl(const QWidget* w)
     if (!btn)
         return false;  // sliders / combos / spinboxes can't trigger TX
 
+    // Keep the fallback deny-list narrow and aligned with isTransmitAction():
+    // only words that unambiguously mean "keys TX". "tune"/"atu"/"vox" were
+    // dropped because they false-positive on RX-only controls — the "Tune Now"
+    // button (net/spot retune) and "Tune to <spot>" only move the VFO, and a VOX
+    // toggle arms TX rather than keying it. The genuine keying TUNE/ATU buttons
+    // (TxApplet, AtuPreTuneDialog) all carry the authoritative markTxKeying()
+    // marker, which the positive check above already honors, so removing them
+    // here loses no real protection — it just stops blocking RX-only buttons
+    // that happen to contain "tune". (#3918 — "Tune Now" false-positive)
     static const QStringList kDeny = {
-        QStringLiteral("mox"), QStringLiteral("ptt"), QStringLiteral("tune"),
-        QStringLiteral("transmit"), QStringLiteral("vox"), QStringLiteral("cwx"),
-        QStringLiteral("atu"),
+        QStringLiteral("mox"), QStringLiteral("ptt"),
+        QStringLiteral("transmit"), QStringLiteral("cwx"),
     };
     const QStringList hay{w->objectName(), w->accessibleName(), btn->text()};
     if (matchesTxDenyToken(hay, kDeny)) {
@@ -1772,6 +1795,9 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         } else if (cmd == QLatin1String("resize")) {
             value = tok(1) + QLatin1Char(' ') + tok(2);  // "resize 1920 1080 [target]"
             target = tok(3);
+        } else if (cmd == QLatin1String("window")) {
+            action = tok(1);  // maximize | restore | minimize | fullscreen
+            target = tok(2);  // optional window target
         } else if (cmd == QLatin1String("menu")) {
             action = tok(1);  // list | open
             QStringList rest;
@@ -1926,6 +1952,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("resize"))
         return doResize(value, target);
+    if (cmd == QLatin1String("window"))
+        return doWindow(action, target);
     if (cmd == QLatin1String("menu"))
         return doMenu(action.isEmpty() ? QStringLiteral("list") : action, value);
     if (cmd == QLatin1String("whoami"))
@@ -2318,6 +2346,8 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
 
     bool done = false;
     bool deferred = false;
+    QString selectedRowText;   // selectRow: first-column text of the chosen row
+    int     selectedRow = -1;
     if (action == QLatin1String("click") || action == QLatin1String("toggle")) {
         // CRASH-SAFETY: a button click can open a popup menu (a QToolButton with
         // a dropdown) or a modal dialog, both of which spin a NESTED event loop.
@@ -2399,6 +2429,38 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentText(value); done = true; }
     } else if (action == QLatin1String("setCurrentIndex")) {
         if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentIndex(value.toInt()); done = true; }
+    } else if (action == QLatin1String("selectRow")) {
+        // Select a whole row in an item view (QTableWidget / QTreeWidget /
+        // QListWidget / any QAbstractItemView) so the dialog's row-scoped
+        // buttons (Tune / Edit / Remove / Disable) — which read the view's
+        // current row or selection — become drivable. invoke click on those
+        // buttons was useless without first selecting a row. (#3918)
+        if (auto* view = qobject_cast<QAbstractItemView*>(w)) {
+            QAbstractItemModel* m = view->model();
+            if (!m) return err(QStringLiteral("view has no model"));
+            bool okRow = false;
+            const int row = value.toInt(&okRow);
+            if (!okRow) return err(QStringLiteral("selectRow needs an integer row index"));
+            const int rows = m->rowCount();
+            if (row < 0 || row >= rows)
+                return err(QStringLiteral("row %1 out of range [0,%2)")
+                               .arg(row).arg(rows));
+            const QModelIndex first = m->index(row, 0);
+            const int lastCol = m->columnCount() > 0 ? m->columnCount() - 1 : 0;
+            const QModelIndex last = m->index(row, lastCol);
+            // Set both the current index and a full-row selection so handlers
+            // that read currentRow()/currentItem() AND those that read
+            // selectedItems()/selectionModel() all see the choice.
+            if (QItemSelectionModel* sm = view->selectionModel())
+                sm->select(QItemSelection(first, last),
+                           QItemSelectionModel::ClearAndSelect
+                               | QItemSelectionModel::Rows);
+            view->setCurrentIndex(first);
+            view->scrollTo(first);
+            selectedRow = row;
+            selectedRowText = m->data(first, Qt::DisplayRole).toString();
+            done = true;
+        }
     } else {
         return err(QStringLiteral("unknown action: ") + action);
     }
@@ -2421,6 +2483,12 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         // dialog), so any post-state must be re-read (get / dumpTree) rather than
         // trusted from this synchronous reply.
         r[QStringLiteral("deferred")] = true;
+    } else if (selectedRow >= 0) {
+        // selectRow: echo the chosen row + its first-column text so the driver
+        // can confirm the right entry is selected before firing a row action.
+        r[QStringLiteral("selectedRow")] = selectedRow;
+        if (!selectedRowText.isEmpty())
+            r[QStringLiteral("selectedRowText")] = selectedRowText;
     } else {
         const QString nv = widgetValue(w);   // round-trip confirmation
         if (!nv.isNull())
@@ -3286,6 +3354,74 @@ QJsonObject AutomationServer::doStation(const QString& name)
     return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("station"), n}};
 }
 
+// Resolve the top-level window a window-scoped verb acts on: the target's
+// window() when given, else the QMainWindow (or first visible real top-level).
+// Skips scroll-area viewports and popup QMenus so the main window wins. Shared by
+// doResize and doWindow.
+QWidget* AutomationServer::topLevelWindowForTarget(const QString& target)
+{
+    if (!target.isEmpty()) {
+        QWidget* t = resolveWidget(target);
+        return t ? t->window() : nullptr;
+    }
+    const QWidgetList tops = QApplication::topLevelWidgets();
+    for (QWidget* tlw : tops)                 // prefer the QMainWindow
+        if (tlw->inherits("QMainWindow")) return tlw;
+    for (QWidget* tlw : tops) {               // else first visible real window
+        if (tlw->objectName() == QLatin1String("qt_scrollarea_viewport")) continue;
+        if (qobject_cast<QMenu*>(tlw)) continue;
+        if (tlw->isWindow() && tlw->isVisible()) return tlw;
+    }
+    return nullptr;
+}
+
+// ── Window state (#3918) ─────────────────────────────────────────────────────
+// Drive a top-level window's state so an agent can maximize / restore / minimize
+// / fullscreen and prove it via dumpTree's `windowState`. resize only set
+// explicit geometry, so an un-maximize (restore) was previously unverifiable.
+// State changes don't spin a nested event loop, so they're safe to run
+// synchronously here (unlike click/menu, which defer).
+QJsonObject AutomationServer::doWindow(const QString& action, const QString& target) const
+{
+    const QString a = action.trimmed().toLower();
+    if (a.isEmpty())
+        return err(QStringLiteral("window needs an action "
+                                  "(maximize|restore|minimize|fullscreen)"));
+    if (!target.isEmpty() && !resolveWidget(target))
+        return err(QStringLiteral("window not found for target: ") + target);
+    QWidget* win = topLevelWindowForTarget(target);
+    if (!win)
+        return err(QStringLiteral("no top-level window to drive"));
+
+    if (a == QLatin1String("maximize") || a == QLatin1String("max")) {
+        win->showMaximized();
+    } else if (a == QLatin1String("restore") || a == QLatin1String("normal")
+               || a == QLatin1String("unmaximize")) {
+        win->showNormal();
+    } else if (a == QLatin1String("minimize") || a == QLatin1String("min")) {
+        win->showMinimized();
+    } else if (a == QLatin1String("fullscreen") || a == QLatin1String("full")) {
+        win->showFullScreen();
+    } else {
+        return err(QStringLiteral("unknown window action: ") + action
+                   + QStringLiteral(" (maximize|restore|minimize|fullscreen)"));
+    }
+
+    const Qt::WindowStates st = win->windowState();
+    const char* ws = "normal";
+    if (st & Qt::WindowMinimized)       ws = "minimized";
+    else if (st & Qt::WindowFullScreen) ws = "fullscreen";
+    else if (st & Qt::WindowMaximized)  ws = "maximized";
+    qCInfo(lcAutomation).noquote() << "window" << a << "->" << ws;
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("action"), a},
+        {QStringLiteral("windowState"), QLatin1String(ws)},
+        {QStringLiteral("geometry"), QJsonObject{{QStringLiteral("w"), win->width()},
+                                                 {QStringLiteral("h"), win->height()}}},
+    };
+}
+
 // ── Headless render size (#3646 fidelity — item 8) ──────────────────────────
 // Resize a top-level window so the panadapter x_pixels (== SpectrumWidget
 // width) propagates to a realistic value — under QT_QPA_PLATFORM=offscreen the
@@ -3311,27 +3447,9 @@ QJsonObject AutomationServer::doResize(const QString& value, const QString& targ
     if (w <= 0 || h <= 0)
         return err(QStringLiteral("resize requires <width> <height> (e.g. 'resize 1920 1080', or 'full')"));
 
-    QWidget* win = nullptr;
-    if (!target.isEmpty()) {
-        QWidget* t = resolveWidget(target);
-        win = t ? t->window() : nullptr;
-        if (!win)
-            return err(QStringLiteral("window not found for target: ") + target);
-    } else {
-        const QWidgetList tops = QApplication::topLevelWidgets();
-        for (QWidget* tlw : tops) {           // prefer the QMainWindow
-            if (tlw->inherits("QMainWindow")) { win = tlw; break; }
-        }
-        if (!win) {                            // else first visible real window
-            for (QWidget* tlw : tops) {
-                if (tlw->objectName() == QLatin1String("qt_scrollarea_viewport"))
-                    continue;
-                if (qobject_cast<QMenu*>(tlw))
-                    continue;
-                if (tlw->isWindow() && tlw->isVisible()) { win = tlw; break; }
-            }
-        }
-    }
+    if (!target.isEmpty() && !resolveWidget(target))
+        return err(QStringLiteral("window not found for target: ") + target);
+    QWidget* win = topLevelWindowForTarget(target);
     if (!win)
         return err(QStringLiteral("no top-level window to resize"));
 

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -49,16 +49,22 @@ class AudioEngine;
 //
 //   invoke <target> <action> [v]   -> drive a control deterministically:
 //                                     click / toggle / setChecked / setValue /
-//                                     setText / setCurrentText / setCurrentIndex.
-//                                     SAFETY: refuses any control marked as
-//                                     transmit-keying (markTxKeying() / the
-//                                     "aetherTxKeying" property — MOX/PTT, TUNE,
-//                                     ATU, CWX send, packet/APRS send) unless
-//                                     AETHER_AUTOMATION_ALLOW_TX is set, so the
-//                                     bridge can never key a live radio by
-//                                     accident. A button-scoped name heuristic
-//                                     is a logged fallback; setpoint
+//                                     setText / setCurrentText / setCurrentIndex /
+//                                     selectRow. SAFETY: refuses any control
+//                                     marked as transmit-keying (markTxKeying() /
+//                                     the "aetherTxKeying" property — MOX/PTT,
+//                                     TUNE, ATU, CWX send, packet/APRS send)
+//                                     unless AETHER_AUTOMATION_ALLOW_TX is set, so
+//                                     the bridge can never key a live radio by
+//                                     accident. A button-scoped name heuristic is
+//                                     a logged fallback, kept narrow (mox/ptt/
+//                                     transmit/cwx) so RX-only buttons like "Tune
+//                                     Now" aren't false-blocked (#3918); setpoint
 //                                     sliders/combos are never blocked.
+//   invoke <view> selectRow <n>    -> select row n of an item view (QTableWidget /
+//                                     QTreeWidget / QListWidget) so the dialog's
+//                                     row-scoped buttons (Tune/Edit/Remove/Disable)
+//                                     become drivable; echoes selectedRow[Text].
 //   get <model> [selector] [prop]  -> live JSON snapshot of a model:
 //                                     audio | dsp | radio | transmit |
 //                                     slice <id|active|tx> | slices |
@@ -109,6 +115,11 @@ class AudioEngine;
 //   resize <w> <h> [target]        -> resize a top-level window (default full
 //                                     size) so the panadapter x_pixels reaches a
 //                                     realistic value for headless render tests.
+//   window <state> [target]        -> drive a window's state: maximize | restore
+//                                     | minimize | fullscreen. resize only set
+//                                     explicit geometry, so an un-maximize was
+//                                     unprovable; dumpTree now carries
+//                                     `windowState` to assert it (#3918).
 //   menu list | menu open <name>   -> enumerate the menu bar / pop a menu for a
 //                                     follow-up grab/dumpTree.
 //   whoami                         -> {pid, socket, label, station} — identify
@@ -317,6 +328,14 @@ private:
     // Resize a top-level window so the panadapter x_pixels (== SpectrumWidget
     // width) propagates to a realistic value for headless render-size fidelity.
     QJsonObject doResize(const QString& value, const QString& target) const;
+    // window <maximize|restore|minimize|fullscreen> [target]: drive a top-level
+    // window's state (resize only ever set explicit geometry, so an un-maximize
+    // was unverifiable). dumpTree now also carries `windowState`. (#3918)
+    QJsonObject doWindow(const QString& action, const QString& target) const;
+    // Resolve the top-level window a window-scoped verb (resize/window) acts on:
+    // the target's window() if given, else the QMainWindow (or first visible real
+    // top-level). Shared by doResize and doWindow.
+    static QWidget* topLevelWindowForTarget(const QString& target);
     // Menu-bar discovery/popup (#3646 fidelity): `menu list` enumerates the
     // menu-bar tree; `menu open <name>` pops a top-level menu for grab/dumpTree.
     QJsonObject doMenu(const QString& action, const QString& arg) const;

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -60,11 +60,17 @@ class AudioEngine;
 //                                     is a logged fallback; setpoint
 //                                     sliders/combos are never blocked.
 //   get <model> [selector] [prop]  -> live JSON snapshot of a model:
-//                                     audio | radio | transmit |
+//                                     audio | dsp | radio | transmit |
 //                                     slice <id|active|tx> | slices |
 //                                     pan <panId|active> | pans. With a trailing
 //                                     property name, returns just that field.
 //                                     Assert on state without screenshots.
+//                                     `dsp` is the client-side AetherDSP state:
+//                                     the six AudioEngine noise-reduction modules
+//                                     (NR2/NR4/MNR/DFNR/RN2/BNR) with active
+//                                     method, per-module enabled/available, and
+//                                     tuning values — the client-side counterpart
+//                                     to the radio-side nr/nb/anf in `get slice`.
 //   connect list                   -> list currently discovered local radios
 //   connect show                   -> show/raise the Connect to Radio dialog
 //   connect hide                   -> hide the Connect to Radio dialog
@@ -141,7 +147,12 @@ class AudioEngine;
 //   dumpTree (extended)            -> nodes now carry toolTip, and QComboBox
 //                                     nodes carry items[]/currentIndex and pans
 //                                     carry panIndex, all assertable without
-//                                     stepping a control.
+//                                     stepping a control. A checkable button
+//                                     also carries its text + a checked bool, so
+//                                     the six DSP method buttons (NR2 … BNR) are
+//                                     identifiable and readable from the tree
+//                                     instead of every one reporting only
+//                                     "checked"/"unchecked" (#3856).
 //
 // Requests are newline-delimited. Each line is either a bare command
 // ("dumpTree", "grab SpectrumWidget /tmp/pan.png", "invoke masterVolume
@@ -259,6 +270,11 @@ private:
     //                     (pans + waterfalls) classified ours/foreign/orphan,
     //                     plus leaked waterfalls (parent pan gone) — catches the
     //                     resource-level lingering Layer A can't see.
+    //   streams resync  — re-subscribe (sub pan all) to force the radio to
+    //                     re-dump every allocated display object, refreshing the
+    //                     Layer-B maps to the radio's present-tense set; re-poll
+    //                     `streams radio` after it settles to confirm a lingering
+    //                     waterfall the client view had already purged.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
     QJsonObject doAudioCapture(const QString& action,

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -165,6 +165,14 @@ AetherDspWidget::AetherDspWidget(AudioEngine* audio, QWidget* parent)
         auto* b = makeToggle(kLabels[i]);
         b->setFixedSize(38, 22);
         b->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        // Name each selector for screen readers and the automation bridge.
+        // Checkable buttons report value as "checked"/"unchecked", so without
+        // an objectName/accessibleName a driver (or assistive tech) can't tell
+        // NR2 from BNR — only a screenshot could. Stable objectName lets a
+        // driver target a specific method; accessibleName carries the label.
+        b->setObjectName(QStringLiteral("dspMethodBtn") + QLatin1String(kLabels[i]));
+        b->setAccessibleName(QString::fromLatin1(kLabels[i])
+                             + QStringLiteral(" noise-reduction method"));
         // MNR (MMSE-Wiener spectral NR) is implemented only on macOS —
         // dim the selector on Windows / Linux so users can see it exists
         // but can't enable a path the engine has no backend for.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1896,6 +1896,22 @@ DisplayInventory::Report RadioModel::displayInventoryReport() const
     return DisplayInventory::classify(in);
 }
 
+bool RadioModel::resyncDisplayInventory()
+{
+    if (!isConnected()) return false;
+    // Re-subscribing to the pan domain makes the radio re-send the status of
+    // every currently-allocated panadapter + waterfall. Those replies flow
+    // through the same `display pan`/`display panafall` status parser that
+    // maintains m_radioDisplayPans/Waterfalls, so the Layer-B inventory
+    // refreshes to the radio's authoritative current set — the only way to
+    // observe a resource-level lingering waterfall that no longer emits UDP
+    // (#3856). We intentionally do NOT clear the maps first: a re-dump can
+    // only re-add/confirm objects, so a no-op on firmware that doesn't re-dump
+    // leaves the inventory intact rather than wiping it.
+    sendCmd("sub pan all");
+    return true;
+}
+
 double RadioModel::panCenterMhz() const
 {
     auto* p = activePanadapter();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -289,6 +289,15 @@ public:
     // surfaces leaked waterfalls (parent pan gone), foreign and orphan objects.
     DisplayInventory::Report displayInventoryReport() const;
 
+    // Force the radio to re-dump every currently-allocated display object by
+    // re-subscribing to the pan/display domain. The status replies refresh the
+    // Layer-B inventory maps (m_radioDisplayPans/Waterfalls) to the radio's
+    // authoritative present-tense set — re-adding a resource-level lingering
+    // waterfall that stopped emitting UDP and whose client view we already tore
+    // down. Async: callers re-poll displayInventoryReport() after the re-dump
+    // settles (#3856). Returns true if the re-subscribe was sent.
+    bool resyncDisplayInventory();
+
     QList<SliceModel*> slices() const { return m_slices; }
     SliceModel* slice(int id) const;
     int activeTxSliceNum() const;


### PR DESCRIPTION
## What

A batch of **agent automation bridge** improvements and a11y fixes surfaced while dogfooding the bridge against the radio-display, client-DSP, and net-scheduler subsystems (#3856, #3918). All in `src/core/AutomationServer.{cpp,h}` plus one GUI a11y change.

### `get dsp` — the missing client-side AetherDSP model
`get slice` reports the **radio-side** `nr`/`nb`/`anf`; there was no model for the **client-side** AudioEngine modules. `get dsp` reports all six (NR2 / NR4 / MNR / DFNR / RN2 / BNR): `active` (the one enabled, mutually exclusive, or `"none"`), `methods.<N>.{enabled, available}` (`available` = compile-time backend gating), and `tuning` (engine getters read on the AudioEngine thread; NR2/NR4/DFNR-beta slider params merged from `AppSettings`).

### `streams resync` — force the radio's authoritative display re-dump
Layer A (continued-UDP) and Layer B (`streams radio`, cached) couldn't see a waterfall that lingers as a radio resource but stopped UDP **and** whose client view was already purged. `streams resync` re-subscribes (`sub pan all`) to force the radio to re-dump every allocated display object, refreshing the Layer-B maps; re-poll `streams radio` after it settles. Doesn't pre-clear the maps, so firmware that doesn't re-dump leaves the inventory intact.

### `invoke <view> selectRow <n>` — item-view row selection
`invoke` couldn't select a `QTableWidget` row, so a dialog's row-scoped actions (Tune/Edit/Remove/Disable) weren't drivable. `selectRow` sets the current index **and** a full-row selection (covers handlers reading `currentRow()` or `selectedItems()`), bounds-checked, echoing `selectedRow` + `selectedRowText`.

### `window <maximize|restore|minimize|fullscreen> [target]` + `windowState`
`resize` only ever set explicit geometry, so an un-maximize was unverifiable. The `window` verb drives top-level window state and `dumpTree` now carries `windowState` to assert it.

### TX-guard false-positive on "tune" (#3918)
`isTransmitControl()`'s button-name fallback denied any button whose tokens included `tune`/`atu`/`vox`, blocking the **RX-only "Tune Now"** button (net/spot retune — no keying). The QAction path had already narrowed to `mox/ptt/transmit/cwx`; the button path hadn't. Aligned them. Every genuine keying TUNE/ATU button (`TxApplet`, `AtuPreTuneDialog`) carries the authoritative `markTxKeying()` marker, which the positive check still honors — so no real protection is lost.

### a11y: name the six DSP method buttons + dumpTree check-state
The selector buttons (NR2 … BNR) are checkable, so `dumpTree` reported every one as `value:"checked"/"unchecked"` with no label/`accessibleName`. They now set a stable `objectName` (`dspMethodBtnNR2` …) + descriptive `accessibleName` (satisfies `tools/check_a11y.py`), and `dumpTree` now surfaces a checkable button's `text` + `checked` bool (helps every checkable button).

## Proof — all verbs proven live (headless, `QT_QPA_PLATFORM=offscreen`, no radio)

| Verb | Result |
|---|---|
| `window maximize`/`restore`/`fullscreen` | response **and** dumpTree `windowState` both flip `maximized`/`normal`/`fullscreen`; bad action → error |
| `invoke "Scheduled nets" selectRow 0` | `ok, selectedRow:0, selectedRowText:"✓"`; out-of-range → `row 0 out of range [0,0)` |
| `invoke "Tune Now"` (no `ALLOW_TX`) | `ok` (deferred) — **no longer blocked**; was a TX-guard false-positive |
| `get dsp` | `active:"none"`, per-method `enabled`/`available`, full `tuning` block |
| `dumpTree` DSP buttons | all six carry `objectName=dspMethodBtn*`, `accessibleName`, `text`, `checked` |

The TX-guard + selectRow proof drove the real Net Scheduler dialog end-to-end (add a test net → `selectRow 0` → "Tune Now" now enabled + invokable → removed the test net), leaving the user's schedule empty. Built clean (`RelWithDebInfo`).

## Files
- `src/core/AutomationServer.{cpp,h}` — `get dsp`, `streams resync`, `selectRow`, `window`, `windowState`, TX-guard fix, dumpTree check-state, docstrings
- `src/models/RadioModel.{cpp,h}` — `resyncDisplayInventory()`
- `src/gui/AetherDspWidget.cpp` — objectName/accessibleName on the six DSP buttons

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
