### PR TITLE
fix(nets): route cross-band net tune through canonical tune policy (#3918)

### DIFF
--- a/src/gui/MainWindow_Nets.cpp
+++ b/src/gui/MainWindow_Nets.cpp
@@ -120,45 +120,27 @@ void MainWindow::tuneToNet(const NetEntry& entry)
         return;
 
     const double freqMhz = entry.preset.freq;
-    const QString slicePanId = slice->panId();
 
-    // If the net is on a different band than the slice currently sits on,
-    // preselect that band's stack memory first — a bare `slice tune` will not
-    // move the panadapter across bands, which is why a cross-band net appears
-    // "not to tune". Same preselect path as a memory recall.
-    if (freqMhz > 0.0) {
-        const QString netBand = BandSettings::bandForFrequency(freqMhz);
-        const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
-        if (netBand != currentBand) {
-            const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
-            const auto stackKeyResult =
-                XvtrPolicy::resolveBandStackKey(netBand, xvtrs, m_radioModel.capabilities());
-            if (stackKeyResult.isSupported()) {
-                clearSwrSweepForBandChange(-1, slicePanId, netBand);
-                m_bandSettings.setCurrentBand(netBand);
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 band=%2").arg(slicePanId, stackKeyResult.key));
-                QTimer::singleShot(300, this, [this, slicePanId]() {
-                    reassertUnmutedSliceAudioForPan(slicePanId);
-                });
-            } else {
-                statusBar()->showMessage(
-                    QString("Can't tune %1 — %2 isn't available on this radio.")
-                        .arg(entry.name, netBand),
-                    5000);
-            }
-        }
-    }
+    // Route the net's frequency change through the canonical tune-and-recenter
+    // policy — the same AbsoluteJump path a DX-cluster spot uses to jump to an
+    // arbitrary frequency on any band. applyTuneRequest() moves the slice with
+    // `slice tune <freq>` (which the radio echoes back as a slice RF_frequency
+    // status, so the VFO display tracks it) and recenters the panadapter on the
+    // target, crossing bands as needed.
+    //
+    // The previous bespoke path issued `display pan set <pan> band=<key>` first,
+    // which reloaded the band stack: the radio retuned the slice to that band's
+    // *last-used* frequency (and echoed it), then emitted no status echo for the
+    // subsequent net retune — so the VFO display stuck on the band frequency
+    // while RX/TX ran on the net's (#3918). Reusing applyTuneRequest avoids the
+    // band-stack reload entirely and keeps the display radio-authoritative.
+    if (freqMhz > 0.0)
+        applyTuneRequest(slice, freqMhz, TuneIntent::AbsoluteJump, "net-tune");
 
-    // Reuse the memory-recall command builders for the retune + repeater/tone
-    // fixup, and set mode/filter/step directly (a net has no radio-side memory
-    // slot to "memory apply").
-    const QString retune = buildMemoryRecallRetuneCommand(sliceId, entry.preset);
-    if (!retune.isEmpty())
-        m_radioModel.sendCommand(retune);
+    // Net-specific slice settings the tune policy doesn't cover (a net has no
+    // radio-side memory slot to "memory apply").
     if (!entry.preset.mode.isEmpty())
-        m_radioModel.sendCommand(
-            QString("slice set %1 mode=%2").arg(sliceId).arg(entry.preset.mode));
+        slice->setMode(entry.preset.mode);
     if (entry.preset.rxFilterLow != entry.preset.rxFilterHigh) {
         m_radioModel.sendCommand(QString("filt %1 %2 %3")
                                      .arg(sliceId)
@@ -170,15 +152,6 @@ void MainWindow::tuneToNet(const NetEntry& entry)
     const QString fixup = buildMemoryRecallSliceFixupCommand(sliceId, entry.preset);
     if (!fixup.isEmpty())
         m_radioModel.sendCommand(fixup);
-
-    // After the band change + retune settle, recenter the panadapter on the net
-    // frequency if it ended up off-screen (mirrors the memory-recall reveal).
-    QTimer::singleShot(750, this, [this, sliceId, freqMhz]() {
-        if (auto* s = m_radioModel.slice(sliceId)) {
-            const double revealMhz = freqMhz > 0.0 ? freqMhz : s->frequency();
-            revealFrequencyIfNeeded(s, revealMhz, TuneIntent::CommandedTargetCenter, "net-tune");
-        }
-    });
 
     statusBar()->showMessage(QString("Tuned to %1").arg(entry.name), 3000);
 }
@@ -214,7 +187,11 @@ void MainWindow::onNetReminderDue(const NetEntry& entry, const QDateTime& occurr
                             break;
                         }
                     }
-                    showNormal();
+                    // Bring the window forward without disturbing its state.
+                    // showNormal() would clear a Maximized/FullScreen window
+                    // (#3918) — only un-minimize if actually minimized.
+                    if (isMinimized())
+                        showNormal();
                     raise();
                     activateWindow();
                 });
@@ -230,7 +207,9 @@ void MainWindow::onNetReminderDue(const NetEntry& entry, const QDateTime& occurr
         m_trayIcon->setToolTip(QStringLiteral("AetherSDR"));
         m_trayIcon->show();
         connect(m_trayIcon, &QSystemTrayIcon::messageClicked, this, [this] {
-            showNormal();
+            // Raise without un-maximizing the window (#3918).
+            if (isMinimized())
+                showNormal();
             raise();
             activateWindow();
         });


### PR DESCRIPTION
Fixes #3918.

## Summary

Two defects in the Net Scheduler's cross-band **"Tune Now"** path (`MainWindow_Nets.cpp`), both reproduced and verified against a live FLEX radio with the **agent automation bridge**.

### Bug 1 — slice display desync (safety)

A cross-band net tune left the VFO display stuck on the band's last-used frequency while RX/TX ran on the net frequency. The GUI misreports the actual TX QRG — an operating hazard.

**Root cause (deeper than the original triage).** `tuneToNet()` preselected the band stack with `display pan set <pan> band=<key>` before retuning. That band-stack reload retuned the slice to the band's *last-used* frequency **and echoed it**, but the radio then emitted **no slice `RF_frequency` status** for the subsequent `slice tune <netFreq>` — so the display stuck on the band frequency.

The triage's "echo-ordering race" theory was **wrong**: there is no net-frequency echo to be overwritten. The bridge made this provable — on the fixed-with-a-500ms-defer build the display was *still* wrong, which ruled the ordering theory out.

**Fix.** Route the net's frequency change through the existing `applyTuneRequest(slice, freq, TuneIntent::AbsoluteJump, "net-tune")` policy — the same path a DX-cluster spot uses to jump to an arbitrary cross-band frequency. It moves the slice with `slice tune <freq>` (echoed back as a slice status, so the display stays radio-authoritative) and recenters the panadapter, **with no band-stack reload**. Net-specific mode/filter/step and repeater/tone fixup are applied around it. Net change: **−21 lines** (reuses policy instead of a bespoke path).

### Bug 2 — window drops out of Maximized

The reminder banner's `tuneRequested` handler and the tray `messageClicked` handler called `showNormal()` on the `MainWindow`, which clears a Maximized/FullScreen window (the reporter's "un-maximizes to a smaller window" symptom). Both now guard behind `isMinimized()`, so raising the window never un-maximizes it.

## How the agent automation bridge proved it

A one-time net was seeded to fire a reminder, then **"Tune Now"** was clicked on the in-app banner (a real click — the bridge's TX-safety guard currently false-positives on the word "tune", see gaps below). Slice 0 was parked on 20m beforehand so the 40m net (7.175 MHz) is cross-band.

| Build | Commands issued | Slice display ends on |
|---|---|---|
| **Broken** (unfixed) | `display pan set band=40` + synchronous `slice tune 7.175` | **7.225** (40m band stack) ✗ — `0` net echoes |
| **Fixed** (this PR) | `slice tune 0 7.175 autopan=0` + `display pan set center=…` (no `band=`) | **7.175** (net) ✓ |

The broken reading was captured live on this radio (FLEX-8400M) and matches the reporter's attached FLEX-6400 log (display stuck on 7.150). After the fix, the radio echoes (`transmit band 5 band_name=40`, `transmit freq=7.175000`, `apd slice=0 freq=7.175000`) confirm the band context and op-freq are correct, and `get slice` reads the net frequency.

> Bug 2 could not be proved through the bridge (it has no verb to enter the Maximized state or read window state — see gaps), so that half is fix-by-inspection: `showNormal()` documented to clear `WindowMaximized`.

## Agent automation bridge — gaps found

- **TX-safety guard false-positive.** `isTransmitControl()`'s button-name fallback denies any button whose name contains the token **"tune"**, so it blocks the Net Scheduler "Tune Now" button (RX frequency tuning, not TX keying). The QAction path was already narrowed to drop "tune" for exactly this reason; the QWidget-button path wasn't. Forced a manual click for the proof. *Fix: drop "tune"/"atu" from the button `kDeny`, or mark genuinely-keying buttons explicitly.*
- **No item-view row-select verb.** `invoke` can't select a row in a `QTableWidget`/`QListWidget`, so the Net Scheduler dialog's row-scoped actions (Tune Now / Edit / Remove / Disable) can't be driven. Worked around via the reminder banner. *Fix: add a `selectRow`/`setCurrentRow` action.*
- **No window-state read or maximize verb.** `dumpTree` exposes no `windowState`, and `resize` only sets explicit geometry — so a Maximized→Normal regression (Bug 2) can't be set up or observed through the bridge. *Fix: expose `isMaximized` in `dumpTree` and a `maximize` verb.*

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
