### PR TITLE
fix(gui): deregister QRhiWidget cleanup callback on all GPU platforms (Windows multi-pan crash, #3714)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1078,13 +1078,22 @@ SpectrumWidget::~SpectrumWidget()
 void SpectrumWidget::prepareForTopLevelChange()
 {
 #ifdef AETHER_GPU_SPECTRUM
-#ifdef Q_OS_MAC
     // QRhiWidget registers a cleanup callback with the current top-level
     // backing-store QRhi. Direct splitter/floating-window reparenting can miss
-    // Qt's internal notification, leaving the old QRhi with a stale callback.
+    // Qt's internal notification, leaving the old QRhi with a stale callback;
+    // when that QRhi is later torn down, runCleanup() fires against a stale
+    // QRhiWidgetPrivate and crashes during deferred event delivery (#2495).
+    //
+    // QEvent::WindowAboutToChangeInternal is cross-platform Qt machinery —
+    // QRhiWidgetPrivate deregisters the callback the same way on Metal,
+    // D3D/Vulkan and OpenGL — so this must fire on every GPU platform, not
+    // just macOS. It was originally gated to Q_OS_MAC because #2495 was first
+    // reproduced there; leaving Windows ungated let the identical crash slip
+    // through on connect-time multi-panadapter restore (#3714). The send must
+    // happen exactly once, before the reparent (refreshAfterReparent must not
+    // re-send it — see PanadapterStack.cpp).
     QEvent event(QEvent::WindowAboutToChangeInternal);
     QCoreApplication::sendEvent(this, &event);
-#endif
 #endif
 }
 


### PR DESCRIPTION
## Summary

Fixes the Windows crash in #3714: AetherSDR comes up for a few seconds then crashes on **every** launch once the radio restores a saved **2-panadapter** session (the reporter is on a Flex-6600, Win 11). The workaround that already protects this path on macOS was gated `#ifdef Q_OS_MAC` and never extended to Windows.

## Root cause

`SpectrumWidget` (a `QRhiWidget` under `AETHER_GPU_SPECTRUM`) registers a **cleanup callback on the top-level window's backing-store `QRhi`**. Before any reparent, `SpectrumWidget::prepareForTopLevelChange()` sends `QEvent::WindowAboutToChangeInternal` so `QRhiWidgetPrivate` deregisters that callback from the *old* QRhi. **That send was wrapped in `#ifdef Q_OS_MAC`, so on Windows it was a no-op.**

On connect, the radio reports the saved 2 pans and the debounced layout-restore timer fires `PanadapterStack::rearrangeLayout()`, which does `setParent(nullptr)` on each applet (a momentary top-level change) and rebuilds the `QSplitter`. On Windows the stale callback stayed registered against the old QRhi; when that QRhi was torn down during the rebuild, `QRhi::runCleanup()` fired against a now-stale `QRhiWidgetPrivate` **during deferred event delivery** and crashed. This is the same crash class documented for #2495 — just on the one platform where the fix was never applied.

This matches the reporter's MS Store crash dump exactly: it is unsymbolized (no shipped PDB), but the one resolved frame is **`QWindowsGuiEventDispatcher::sendPostedEvents`** with ~16 frames of app code beneath it — i.e. the fault is in deferred main-thread event delivery, precisely where a stale QRhi cleanup callback fires.

## Fix

Drop the inner `#ifdef Q_OS_MAC` in `prepareForTopLevelChange()` so the deregistration fires on **every** GPU platform. `WindowAboutToChangeInternal` is cross-platform Qt machinery — `QRhiWidget` handles it identically on Metal/D3D/Vulkan/GL — so the macOS gate was historical, not architectural (the crash was first reproduced on macOS in #2495 and the guard was never broadened).

Because **every** reparent site already routes through this one helper (`rearrangeLayout`, `floatPanadapter`, `dockPanadapter`, and the shutdown path), this single change closes the whole reparent-race class on Windows — no scattered edits. It is a **runtime no-op on macOS** (which already sent the event), so there is zero macOS regression risk.

```diff
 void SpectrumWidget::prepareForTopLevelChange()
 {
 #ifdef AETHER_GPU_SPECTRUM
-#ifdef Q_OS_MAC
-    // ... mac-only ...
+    // ... cross-platform: fire on Metal, D3D/Vulkan and OpenGL alike ...
     QEvent event(QEvent::WindowAboutToChangeInternal);
     QCoreApplication::sendEvent(this, &event);
-#endif
 #endif
 }
```

## How the agent automation bridge proved it

The crash is **Windows/D3D-specific** and cannot be reproduced on the macOS bridge (macOS already had the fix, so it never crashed there). Proof is therefore split:

- **Root cause** — by inspection, corroborated by the Windows crash dump (`sendPostedEvents`) and the matching #2495 history.
- **No-regression + path-health on macOS** — drove the exact touched path through the bridge on a fresh build of this branch (`get pans` → 1 → **`pan add`** → rearrange/reparent → `get pans` → 2, both render → **`pan close`** → back to 1). The app stayed responsive (`ping` ok) across both the build-up and teardown reparents, the log showed no crash/`runCleanup`/stale-callback markers, and the radio was restored to its original 1-pan state.

## Proof

2-panadapter stacked layout rendering healthy on this branch's build (the exact "stacked top/bottom" arrangement from the report), driven via the bridge — _screenshot attached below_.

## Bridge gaps

- **Cannot reproduce a Windows/D3D crash on macOS hardware.** The bridge proved the macOS reparent path is healthy and regression-free, but the Windows fix itself is verified by inspection + crash-dump correlation, not by a reproduced-then-fixed bridge run. Closing that loop would need a Windows bridge host (or CI) able to restore a recorded 2-pan session on connect.
- **Symbolication**: the MS Store crash TSV was unsymbolized because the shipped build carries no PDB. A symbol-server / PDB upload step would let future Store dumps name the faulting frame directly.

## Follow-ups (not in this PR)

- `refreshAfterReparent()`'s post-move native-handle recreation (`windowHandle()->destroy()` + `WA_NativeWindow`) is still macOS-only. The crash fix doesn't need it (the existing `resetGpuResources()` handles Windows rebind via Qt's normal reparent machinery), but generalizing it to Windows is a candidate hardening that needs a Windows test before shipping.
- Wiki Troubleshooting: add the `<GUIClientID>` reset recovery step (per the reporter's suggestion in the thread).

Fixes #3714

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
