### PR TITLE
fix(gui): Profile Switcher non-editable combo focus swallows first Space PTT / CW key (#3908)

### DIFF
--- a/src/gui/MainWindowShortcutState.h
+++ b/src/gui/MainWindowShortcutState.h
@@ -29,7 +29,15 @@ extern bool s_keyboardShortcutsEnabled;
 extern bool s_sliderShortcutLeaseActive;
 
 // True when a text-input widget has focus (line edit, spin box, …).
+// Includes non-editable combos so arrow shortcuts stay suppressed while a
+// combo is focused (the arrows navigate its list).
 bool textInputCaptured();
+
+// True when a text-*entry* widget has focus (line edit, spin box, editable
+// combo). Unlike textInputCaptured(), a focused non-editable combo does NOT
+// count — used to gate TX keying (Space PTT / CW keys) so a combo that keeps
+// focus after its popup closes can't swallow the keypress (#3908).
+bool textEntryCaptured();
 
 // textInputCaptured() plus the slider lease.
 bool shortcutInputCaptured();

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -73,6 +73,26 @@ bool textInputCaptured()
         || qobject_cast<QComboBox*>(w);
 }
 
+// Like textInputCaptured(), but for TX *keying* (Space PTT / CW keys),
+// which must fire regardless of a focused **non-editable** combo —
+// matching the app-level Space filter's stated intent that "buttons,
+// combos, etc. won't steal Space".  A non-editable QComboBox keeps
+// keyboard focus after its popup closes (#3908) but consumes no typed
+// text, so it must not swallow a keying press.  It is still treated as
+// capturing by textInputCaptured() above, so arrow shortcuts stay
+// suppressed and Up/Down/Left/Right navigate the list as usual.  An
+// editable QComboBox exposes its internal QLineEdit as the focus widget,
+// so it is caught by the QLineEdit branch and still captures text.
+bool textEntryCaptured()
+{
+    auto* w = QApplication::focusWidget();
+    if (!w) return false;
+    if (auto* combo = qobject_cast<QComboBox*>(w))
+        return combo->isEditable();
+    return qobject_cast<QLineEdit*>(w) || qobject_cast<QTextEdit*>(w)
+        || qobject_cast<QPlainTextEdit*>(w) || qobject_cast<QSpinBox*>(w);
+}
+
 bool shortcutInputCaptured()
 {
     if (s_sliderShortcutLeaseActive)
@@ -156,10 +176,10 @@ bool MainWindow::handleCwMomentaryShortcut(QKeyEvent* keyEvent, QEvent::Type eve
         cwAction == CwAction::LeftPaddle ? m_cwLeftPaddleActive :
                                            m_cwRightPaddleActive;
 
-    if (press && (!m_keyboardShortcutsEnabled || textInputCaptured()))
+    if (press && (!m_keyboardShortcutsEnabled || textEntryCaptured()))
         return false;
     if (!press && !currentlyActive)
-        return m_keyboardShortcutsEnabled && !textInputCaptured();
+        return m_keyboardShortcutsEnabled && !textEntryCaptured();
 
     const quint64 sourceMs = cwTraceNowMs();
     const quint64 traceId = nextCwTraceId();
@@ -214,7 +234,10 @@ bool MainWindow::handlePttHoldShortcut(QKeyEvent* keyEvent, QEvent::Type eventTy
     // Mirror the prior Space behavior: only key while connected and not typing
     // into a text field. When those gates fail, do not consume the key — let it
     // fall through (matching the old `&& m_radioModel.isConnected()` guard).
-    if (textInputCaptured() || !m_radioModel.isConnected())
+    // Use textEntryCaptured() (not textInputCaptured()) so a focused
+    // non-editable combo — which keeps focus after its popup closes (#3908) —
+    // doesn't swallow the first Space/PTT press.
+    if (textEntryCaptured() || !m_radioModel.isConnected())
         return false;
 
     if (m_keyboardShortcutsEnabled) {


### PR DESCRIPTION
## Summary

After selecting a profile from the Profile Switcher (or any other non-editable `QComboBox` in the app), the first Space press doesn't key PTT — it opens the combo's dropdown instead. A second Space is needed to actually transmit.

## Root cause

`textInputCaptured()` (`src/gui/MainWindow_Shortcuts.cpp`) treats *any* focused `QComboBox` as a text-input widget:

```cpp
bool textInputCaptured()
{
    auto* w = QApplication::focusWidget();
    if (!w) return false;
    return qobject_cast<QLineEdit*>(w) || qobject_cast<QTextEdit*>(w)
        || qobject_cast<QPlainTextEdit*>(w) || qobject_cast<QSpinBox*>(w)
        || qobject_cast<QComboBox*>(w);
}
```

`handlePttHoldShortcut()` and `handleCwMomentaryShortcut()` both bail out (return `false`, don't consume the key) when this predicate is true. A non-editable `QComboBox` (like the Profile Switcher's Global/TX/Mic rows) keeps keyboard focus after its popup closes from a mouse selection. So:

1. First Space → combo still focused → `textInputCaptured()` true → handler returns `false` → Qt's default `QComboBox` behavior opens the dropdown instead of keying TX.
2. Second Space → closes the popup → next Space reaches the handler → TX keys.

The same guard sits in the CW momentary-key handler, so CW keying is swallowed the same way after a profile selection.

## Fix

Add `textEntryCaptured()`, a narrower predicate that only counts widgets that actually consume typed text: `QLineEdit`, `QTextEdit`, `QPlainTextEdit`, `QSpinBox`, and an **editable** `QComboBox` (its line edit is the real focus target, so it's still caught). A non-editable combo no longer counts.

Use `textEntryCaptured()` to gate the PTT-hold and CW-momentary keying handlers. Leave `textInputCaptured()` (and everywhere else it's used, e.g. arrow-key tune/gain shortcuts) unchanged, so Up/Down/Left/Right still navigate a focused combo's list instead of double-firing as global tune/gain shortcuts.

## Files changed

- `src/gui/MainWindowShortcutState.h` — declare `textEntryCaptured()`
- `src/gui/MainWindow_Shortcuts.cpp` — define `textEntryCaptured()`; switch `handlePttHoldShortcut()` and `handleCwMomentaryShortcut()` to use it instead of `textInputCaptured()`

## Test plan

- [x] Built RelWithDebInfo, all warnings pre-existing/unrelated
- [ ] Maintainer/CI verification on hardware

Fixes #3908

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat