### PR TITLE
fix(bridge): main build break — dspEngineSnapshot uses removed AudioEngine bnr* API

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3,6 +3,7 @@
 #include "AppSettings.h"          // StationName (restore the user's real station name)
 #include "TxKeyingMarker.h"       // kTxKeyingProperty — authoritative TX-guard marker
 #include "AudioEngine.h"
+#include "NvidiaBnrSettings.h"   // BNR intensity (in-process AFX, #3902)
 #include "ClientTxTestTone.h"     // testtone() verb — client-side TX test tone
 #include "QsoRecorder.h"          // record() verb — Client-Side QSO recorder
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
@@ -1232,8 +1233,8 @@ QJsonObject dspEngineSnapshot(const AudioEngine* a)
                                    false},
 #endif
         {"RN2",  a->rn2Enabled(),  true},
-        {"BNR",  a->bnrEnabled(),
-#ifdef HAVE_BNR
+        {"BNR",  a->nvAfxEnabled(),
+#ifdef HAVE_NVIDIA_AFX
                                    true},
 #else
                                    false},
@@ -1255,10 +1256,10 @@ QJsonObject dspEngineSnapshot(const AudioEngine* a)
         QJsonObject{{QStringLiteral("strength"), a->mnrStrength()}};
     tuning[QStringLiteral("dfnr")] =
         QJsonObject{{QStringLiteral("attenLimitDb"), a->dfnrAttenLimit()}};
+    // BNR is now the in-process NVIDIA AFX denoiser (#3902): no container, so
+    // the old address/connected fields are gone; report the persisted intensity.
     tuning[QStringLiteral("bnr")] =
-        QJsonObject{{QStringLiteral("intensity"), a->bnrIntensity()},
-                    {QStringLiteral("address"), a->bnrAddress()},
-                    {QStringLiteral("connected"), a->bnrConnected()}};
+        QJsonObject{{QStringLiteral("intensity"), NvidiaBnrSettings::intensity()}};
 
     return QJsonObject{{QStringLiteral("active"), active},
                        {QStringLiteral("methods"), methods},


### PR DESCRIPTION
## 🔴 `main` does not compile

`AutomationServer.cpp::dspEngineSnapshot()` (added in #3920) calls `AudioEngine::bnrEnabled()` / `bnrIntensity()` / `bnrAddress()` / `bnrConnected()`, but **#3902 removed those** when it replaced the containerized Maxine-NIM BNR with the in-process AFX denoiser (`AudioEngine` now exposes `nvAfxEnabled()` etc.).

```
AutomationServer.cpp(1235): error C2039: 'bnrEnabled': is not a member of 'AudioEngine'
AutomationServer.cpp(1259): error C2039: 'bnrIntensity' ...
AutomationServer.cpp(1260): error C2039: 'bnrAddress' ...
AutomationServer.cpp(1261): error C2039: 'bnrConnected' ...
```

These are platform-independent member errors, so **every** build is red. #3920 was CI-green against a pre-#3902 base, so the semantic conflict slipped through on merge (no re-CI of the merged result).

## Fix
- `a->bnrEnabled()` → `a->nvAfxEnabled()` (always present, even on non-AFX builds), and the availability guard `HAVE_BNR` → `HAVE_NVIDIA_AFX` (`HAVE_BNR` is no longer defined anywhere).
- The in-process AFX has no container, so `address`/`connected` are dropped from the `bnr` tuning; report the persisted `NvidiaBnrSettings::intensity()` instead.

One file, no behavior change beyond the snapshot's BNR fields. All other `bnr*` references in the tree were checked — these four were the only stale ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)