### PR TITLE
ci(windows): bundle .appxsym debug symbols into the MSIX upload package

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -95,7 +95,15 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DMQTT_TLS=OFF -DREQUIRE_KEYCHAIN=ON -DENABLE_NVIDIA_AFX=ON -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
+          # RelWithDebInfo (not Release): MSVC's Release config omits /Zi and
+          # /DEBUG, so build/AetherSDR.pdb never gets produced and the
+          # create-msix.ps1 -CreateUpload step silently ships .msixupload
+          # packages with no symbols. RelWithDebInfo keeps -O2 optimization
+          # (Ob1 vs Release's Ob2 — a negligible inlining difference) while
+          # emitting a full PDB, which is what create-msix.ps1 bundles as
+          # .appxsym for Partner Center crash symbolication (and what we keep
+          # as a standalone artifact for our own WinDbg use).
+          cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMQTT_TLS=OFF -DREQUIRE_KEYCHAIN=ON -DENABLE_NVIDIA_AFX=ON -DCMAKE_TOOLCHAIN_FILE="$env:CMAKE_TOOLCHAIN_FILE" -DVCPKG_TARGET_TRIPLET="$env:VCPKG_TARGET_TRIPLET"
 
       - name: Build Opus (RADE dependency)
         # ExternalProject dependency ordering via BUILD_BYPRODUCTS is correct,
@@ -190,7 +198,7 @@ jobs:
           AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR: ${{ vars.AETHERSDR_MSIX_INSTALLER_BACKGROUND_COLOR }}
         run: |
           . .\packaging\windows\store-identity.ps1
-          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel
+          powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel -RequirePdb
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -201,6 +209,19 @@ jobs:
             AetherSDR-*-setup.exe
             AetherSDR-*.msix
             AetherSDR-*.msixupload
+            AetherSDR-*.appxsym
+
+      # Standalone PDB, kept separately from the .msixupload bundle above so
+      # maintainers can pull matching debug symbols for WinDbg/Visual Studio
+      # without unzipping a Store submission package — same PDB that's zipped
+      # into the .appxsym for Partner Center's crash symbolication.
+      - name: Upload debug symbols
+        if: hashFiles('build/AetherSDR.pdb') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: Windows-Symbols
+          path: build/AetherSDR.pdb
+          retention-days: 90
 
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/')

--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -77,12 +77,43 @@ Already automatable:
 - Store identity injection from `packaging/windows/store-identity.ps1`, with
   optional GitHub repository variable overrides.
 - Signing from GitHub secrets when a development/test PFX exists.
-- `.msixupload` creation for Partner Center.
+- `.msixupload` creation for Partner Center, with bundled `.appxsym` debug
+  symbols for crash decoding (see below).
 
 Not fully automatable until account setup:
 
 - Final Store submission unless Partner Center API credentials are created and
   stored as secrets.
+
+## Debug Symbols (.appxsym / PDB)
+
+Microsoft Store crash reports in Partner Center only resolve to a symbolized
+stack trace if the submitted `.msixupload` carries matching debug symbols.
+There is no separate "upload symbols" step in Partner Center — the symbols
+travel *inside* the upload package as a `.appxsym` file (a zip of the PDB),
+which Partner Center auto-ingests on submission.
+
+The Windows installer workflow produces this automatically:
+
+1. **Configure** builds with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, not
+   `Release`. Plain MSVC `Release` does not emit `/Zi`/`/DEBUG`, so
+   `build/AetherSDR.pdb` would never exist. `RelWithDebInfo` keeps the same
+   `-O2` optimization level (only the inliner threshold, `/Ob1` vs. `/Ob2`,
+   differs) while producing a full PDB.
+2. `create-msix.ps1 -CreateUpload -RequirePdb` zips `build/AetherSDR.pdb` into
+   `<package>.appxsym` (`New-AppxSym`) and bundles it alongside the `.msix`
+   into `<package>.msixupload` (`New-MsixUpload`). `-RequirePdb` makes the
+   step fail the build if no PDB was found, instead of silently shipping a
+   symbol-less upload package — CI passes it; local dev builds can omit it.
+3. CI uploads `build/AetherSDR.pdb` as its own **Windows-Symbols** artifact
+   (90-day retention) and the standalone `.appxsym` alongside the other
+   Windows-Installer artifacts, so a maintainer can pull matching symbols for
+   local WinDbg/Visual Studio debugging without unzipping a `.msixupload`.
+
+Submitting the `.msixupload` to Partner Center (manually today, or via the
+automated draft-staging flow below) is the only "publish" step needed —
+Partner Center decodes future crash stacks against the bundled `.appxsym`
+automatically, with no further action required.
 
 ## Known WACK Follow-Ups
 

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -36,6 +36,7 @@ param(
     [string]$PdbPath = "build/AetherSDR.pdb",
     [switch]$CreateUpload,
     [switch]$ExcludeDfnrModel,
+    [switch]$RequirePdb,
 
     [string]$CertificateFile = $env:AETHERSDR_MSIX_CERTIFICATE_FILE,
     [string]$CertificatePassword = $env:AETHERSDR_MSIX_CERTIFICATE_PASSWORD,
@@ -461,6 +462,9 @@ else {
 $appxSymPath = $null
 if ($CreateUpload) {
     $appxSymPath = New-AppxSym -InputPdbPath $resolvedPdbPath -OutputPath (Join-Path $resolvedOutputDir "$packageBaseName.appxsym")
+    if (-not $appxSymPath -and $RequirePdb) {
+        throw "RequirePdb was specified but no PDB was found at $resolvedPdbPath. The .msixupload would ship without crash symbols for Partner Center. Build with -DCMAKE_BUILD_TYPE=RelWithDebInfo (or otherwise ensure the PDB is emitted) before packaging, or drop -RequirePdb for a deliberately symbol-less dev package."
+    }
     $uploadPath = Join-Path $resolvedOutputDir "$packageBaseName.msixupload"
     New-MsixUpload -MsixPath $msixPath -AppxSymPath $appxSymPath -OutputPath $uploadPath
     Write-Host "Created Store upload package: $uploadPath"


### PR DESCRIPTION
## Use case

We ship AetherSDR through the Microsoft Store and periodically get crash reports in the Partner Center dashboard — but they come back as **raw, unsymbolicated stack traces** with no function names or line numbers, which makes them nearly useless for diagnosis.

Partner Center *can* decode those stacks, but only if the submitted `.msixupload` carries matching debug symbols. There is no separate "upload symbols" step in Partner Center — the symbols travel **inside** the upload package as a `.appxsym` file (a zip of the PDB), which Partner Center auto-ingests on submission.

The plumbing for that already existed in `create-msix.ps1` (`New-AppxSym` → `New-MsixUpload`), **but it was silently doing nothing**:

- The `Windows Installer` workflow configured CMake with `-DCMAKE_BUILD_TYPE=Release`.
- Plain MSVC `Release` does **not** emit `/Zi` / `/DEBUG`, so `build/AetherSDR.pdb` was never produced.
- `New-AppxSym` no-ops with just a `Write-Host` warning when the PDB is missing — no build failure.

Net result: recent `.msixupload` packages have very likely gone to the Store **with no symbols at all**, which is exactly why the crash traces don't decode.

## Changes

- **`.github/workflows/windows-installer.yml`**
  - Configure the Windows Release build with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` instead of `Release`, so `build/AetherSDR.pdb` is actually generated. Same `-O2` optimization level — the only difference is inliner threshold (`/Ob1` vs `/Ob2`) plus the added `/Zi` + `/DEBUG` needed for the PDB.
  - Pass `-RequirePdb` to `create-msix.ps1` so CI **fails loudly** if the PDB is ever missing again, instead of silently shipping a symbol-less upload package.
  - Upload the standalone `.pdb` (new `Windows-Symbols` artifact, 90-day retention) and the `.appxsym` so maintainers can pull matching symbols for local WinDbg / Visual Studio debugging without unzipping a Store submission.
- **`packaging/windows/create-msix.ps1`**
  - Add a `-RequirePdb` switch: when `-CreateUpload` is set and no PDB is found, throw instead of continuing. Local dev builds can omit it for a deliberately symbol-less package.
- **`docs/WINDOWS-STORE-MSIX.md`**
  - New "Debug Symbols (.appxsym / PDB)" section documenting how symbols get generated, bundled, and consumed by Partner Center for crash decoding.

## How symbols reach the Store

The `.msixupload` is the only thing submitted to Partner Center (manually today, or via the already-wired draft-staging flow). Once it contains the `.appxsym`, Partner Center decodes **future** crash stacks against it automatically — no further action needed. (Symbols are matched by build GUID, so they apply to crashes from that specific build going forward, not retroactively to already-collected dumps.)

## Testing

- YAML validated (`yaml.safe_load`).
- PowerShell changes are additive (new switch + one guard) and can't be run locally on macOS (no `pwsh`/Windows SDK); they'll be exercised by the next tagged CI run, which will now fail fast if the PDB regresses rather than silently shipping unsymbolicated packages.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat