### PR TITLE
feat(gui): mouse-over numeric readout on TX meters (SWR/power/ALC/level/compression)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2529,6 +2529,7 @@ set_target_properties(container_widget_test PROPERTIES AUTOMOC ON)
 add_executable(amp_applet_test
     tests/amp_applet_test.cpp
     src/gui/AmpApplet.cpp
+    src/gui/DragValuePopup.cpp
     src/core/AppSettings.cpp
     src/core/ThemeManager.cpp
     src/core/LogManager.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -349,6 +349,27 @@ computed once from the press point (a `QSizeGrip` moves as the window resizes, s
 re-mapping mid-drag would overshoot) — a `140 90` grip drag grows the window by
 exactly 140×90.
 
+### `hover`
+Synthesize a pointer **hover** over a widget (no button pressed, unlike `drag`)
+so hover-driven UI is provable end-to-end. The bare form fires a `QEnterEvent`
+plus a no-button `QMouseMove` at the widget centre; the `leave` form fires a
+`QEvent::Leave` so a driver can watch a fade-after-exit timer.
+
+```json
+→ {"cmd":"hover","target":"Forward power gauge"}
+← {"ok":true,"target":"Forward power gauge","class":"QWidget","action":"enter","x":1572,"y":993}
+→ {"cmd":"hover","target":"Forward power gauge","action":"leave"}
+← {"ok":true,"target":"Forward power gauge","class":"QWidget","action":"leave", ...}
+```
+
+Used to prove the TX meter mouse-over value readout: the SWR / forward-power /
+ALC / mic-level / compression `HGauge`s pop a `DragValuePopup` badge (the same
+one the sliders flash) showing the live numeric value while hovered, which fades
+one second after the pointer leaves. Grab the badge with `grab DragValuePopup`
+— note each `HGauge` owns its own popup, so with several meters hovered the name
+resolves to the first-created one; hover a single meter per instance for an
+unambiguous grab.
+
 ### `showMenu` (alias `openMenu`)
 Pop a `QToolButton`/`QPushButton` drop-down menu. The show is posted onto the GUI
 event loop with the owning window raised + activated first — showing the native

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -17,6 +17,7 @@
 #include <QMainWindow>
 #include <QMenu>
 #include <QMenuBar>
+#include <QEnterEvent>
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <QSysInfo>
@@ -1524,7 +1525,7 @@ bool AutomationServer::start(const QString& serverName)
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
         << "txtest, atu, slice, tune, pan, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
-        << "menu, close, drag, showMenu, contextMenu, whoami, log, mark)";
+        << "menu, close, drag, hover, showMenu, contextMenu, whoami, log, mark)";
     return true;
 }
 
@@ -1833,6 +1834,9 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         } else if (cmd == QLatin1String("drag") || cmd == QLatin1String("mouse")) {
             target = tok(1);
             value = tok(2) + QLatin1Char(' ') + tok(3);  // "drag sizeGrip 80 60"
+        } else if (cmd == QLatin1String("hover")) {
+            target = tok(1);
+            action = tok(2);  // optional "leave" → fade after exit
         } else if (cmd == QLatin1String("contextMenu")) {
             target = tok(1);
             value = tok(2) + QLatin1Char(' ') + tok(3);  // "contextMenu SMeterWidget [x y]"
@@ -1868,6 +1872,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         if (target.isEmpty())
             return err(QStringLiteral("close requires a target widget/window"));
         return doClose(target);
+    }
+    if (cmd == QLatin1String("hover")) {
+        if (target.isEmpty())
+            return err(QStringLiteral("hover requires a target widget"));
+        return doHover(target, action);
     }
     if (cmd == QLatin1String("drag") || cmd == QLatin1String("mouse")) {
         if (target.isEmpty())
@@ -3768,6 +3777,50 @@ QJsonObject AutomationServer::doDrag(const QString& target, const QString& value
         {QStringLiteral("class"), wp ? shortClassName(wp) : QStringLiteral("(deleted)")},
         {QStringLiteral("dx"), dx},
         {QStringLiteral("dy"), dy},
+    };
+}
+
+// hover <target> [leave]: synthesize pointer hover so hover-driven UI is
+// provable. Bare form fires QEnterEvent + a no-button QMouseMove at the widget
+// centre (mouse tracking is on for hover-aware widgets), which is what the
+// HGauge meter readout listens for. The 'leave' form fires QEvent::Leave so a
+// driver can watch the value badge fade one second after the pointer exits.
+QJsonObject AutomationServer::doHover(const QString& target, const QString& action) const
+{
+    QWidget* w = resolveWidget(target);
+    if (!w)
+        return err(QStringLiteral("widget or window not found: ") + target);
+    if (!w->isVisible())
+        return err(QStringLiteral("refused: '") + target + QStringLiteral("' is not visible"));
+
+    const QPoint center(w->width() / 2, w->height() / 2);
+    const QPoint global = w->mapToGlobal(center);
+    const bool leave = (action == QLatin1String("leave"));
+
+    const QPointF localF = QPointF(center);
+    const QPointF globalF = QPointF(global);
+    if (leave) {
+        QEvent ev(QEvent::Leave);
+        QCoreApplication::sendEvent(w, &ev);
+    } else {
+        QEnterEvent enter(localF, localF, globalF);
+        QCoreApplication::sendEvent(w, &enter);
+        QMouseEvent move(QEvent::MouseMove, localF, localF, globalF,
+                         Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+        QCoreApplication::sendEvent(w, &move);
+    }
+
+    qCInfo(lcAutomation).noquote()
+        << "hover" << target << (leave ? "leave" : "enter") << "at" << global;
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("target"), target},
+        {QStringLiteral("class"), shortClassName(w)},
+        {QStringLiteral("action"), leave ? QStringLiteral("leave")
+                                         : QStringLiteral("enter")},
+        {QStringLiteral("x"), global.x()},
+        {QStringLiteral("y"), global.y()},
     };
 }
 

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -259,6 +259,13 @@ private:
     // press → move → release gesture so resize grips and slider handles are
     // provable end-to-end, not just via seed + read-back. (#3646 fidelity)
     QJsonObject doDrag(const QString& target, const QString& value) const;
+    // hover <target> [leave]: synthesize pointer hover over a widget so
+    // hover-driven UI (e.g. the HGauge mouse-over value readout on the TX
+    // SWR/power/ALC meters) is provable end-to-end. Bare form sends a
+    // QEnterEvent + QMouseMove at the widget centre; the 'leave' form sends a
+    // QEvent::Leave so the fade-after-exit timer can be observed. Unlike drag,
+    // no button is pressed, matching a real hover.
+    QJsonObject doHover(const QString& target, const QString& action) const;
     // showMenu <target>: pop a QToolButton/QPushButton drop-down menu, posted
     // onto the GUI event loop with the owning window raised — showing the native
     // popup from inside the socket-read callback re-enters Cocoa and segfaults on

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -1,17 +1,23 @@
 #pragma once
 
+#include "DragValuePopup.h"
 #include "MeterSmoother.h"
 
 #include <QAccessible>
 #include <QAccessibleWidget>
+#include <QEnterEvent>
+#include <QEvent>
 #include <QKeyEvent>
+#include <QMouseEvent>
 #include <QPainter>
+#include <QPoint>
 #include <QWidget>
 #include <QWheelEvent>
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QVector>
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <utility>
 
@@ -72,6 +78,8 @@ public:
             m_animElapsed.restart();
             m_animTimer.start();
         }
+        if (m_hovered)
+            showHoverPopup(m_lastHoverGlobal);
     }
 
     void setValueImmediate(float v) {
@@ -81,6 +89,8 @@ public:
             qBound(0.0f, (v - m_min) / (m_max - m_min), 1.0f));
         m_smooth.snapToTarget();
         update();
+        if (m_hovered)
+            showHoverPopup(m_lastHoverGlobal);
     }
 
     void setPeakValue(float v) {
@@ -129,7 +139,49 @@ public:
         update();
     }
 
+    // ── Hover value readout ───────────────────────────────────────────────
+    // Opt-in floating popup that shows the gauge's current numeric value
+    // while the pointer hovers over the bar, reusing the same DragValuePopup
+    // badge the sliders flash on keyboard/drag adjustment.  Handy on the TX
+    // meters (SWR / forward power / ALC) where the bar scale alone doesn't
+    // give an exact reading.  The badge lingers briefly after the pointer
+    // leaves so a quick glance-and-move still registers. (#feat meter readout)
+    using HoverValueFormatter = std::function<QString(float)>;
+
+    void setHoverValueFormatter(HoverValueFormatter formatter) {
+        m_hoverFormatter = std::move(formatter);
+    }
+
+    void setHoverValuePopupEnabled(bool enabled) {
+        m_hoverPopupEnabled = enabled;
+        setMouseTracking(enabled);
+        if (!enabled && m_hoverPopup)
+            m_hoverPopup->hideNow();
+    }
+
 protected:
+    void enterEvent(QEnterEvent* ev) override {
+        QWidget::enterEvent(ev);
+        m_hovered = true;
+        m_lastHoverGlobal = ev->globalPosition().toPoint();
+        showHoverPopup(m_lastHoverGlobal);
+    }
+
+    void mouseMoveEvent(QMouseEvent* ev) override {
+        QWidget::mouseMoveEvent(ev);
+        m_lastHoverGlobal = ev->globalPosition().toPoint();
+        if (m_hovered)
+            showHoverPopup(m_lastHoverGlobal);
+    }
+
+    void leaveEvent(QEvent* ev) override {
+        QWidget::leaveEvent(ev);
+        m_hovered = false;
+        // Fade the readout one second after the pointer leaves the bar.
+        if (m_hoverPopup)
+            m_hoverPopup->linger(kHoverLingerMs);
+    }
+
     void paintEvent(QPaintEvent*) override {
         QPainter p(this);
         p.setRenderHint(QPainter::Antialiasing);
@@ -239,6 +291,23 @@ protected:
     }
 
 private:
+    QString hoverValueText() const {
+        if (m_hoverFormatter)
+            return m_hoverFormatter(m_value);
+        QString text = QString::number(m_value, 'f', 1);
+        if (!m_unit.isEmpty())
+            text += QLatin1Char(' ') + m_unit;
+        return text;
+    }
+
+    void showHoverPopup(const QPoint& globalAnchor) {
+        if (!m_hoverPopupEnabled)
+            return;
+        if (!m_hoverPopup)
+            m_hoverPopup = new AetherSDR::DragValuePopup(this);
+        m_hoverPopup->showValue(globalAnchor, hoverValueText());
+    }
+
     float m_min, m_max, m_redStart, m_yellowStart;
     float m_value{0.0f};
     float m_peakValue{0.0f};
@@ -247,6 +316,14 @@ private:
     bool  m_fillFromRight{false};
     QString m_label, m_unit;
     QVector<Tick> m_ticks;
+
+    // Hover value readout state (see setHoverValuePopupEnabled).
+    static constexpr int kHoverLingerMs = 1000;
+    HoverValueFormatter m_hoverFormatter;
+    AetherSDR::DragValuePopup* m_hoverPopup{nullptr};
+    bool m_hoverPopupEnabled{false};
+    bool m_hovered{false};
+    QPoint m_lastHoverGlobal;
 
     // Shared meter ballistics — see MeterSmoother.h.
     MeterSmoother m_smooth;

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -145,7 +145,7 @@ public:
     // badge the sliders flash on keyboard/drag adjustment.  Handy on the TX
     // meters (SWR / forward power / ALC) where the bar scale alone doesn't
     // give an exact reading.  The badge lingers briefly after the pointer
-    // leaves so a quick glance-and-move still registers. (#feat meter readout)
+    // leaves so a quick glance-and-move still registers. (#3936)
     using HoverValueFormatter = std::function<QString(float)>;
 
     void setHoverValueFormatter(HoverValueFormatter formatter) {
@@ -318,7 +318,20 @@ private:
             return;
         if (!m_hoverPopup)
             m_hoverPopup = new AetherSDR::DragValuePopup(this);
-        m_hoverPopup->showValue(globalAnchor, hoverValueText());
+        // setValue() fires at ballistics-animation rate while hovered, but the
+        // badge text and anchor are usually identical frame-to-frame. showValue()
+        // re-runs adjustSize()/resize()/move()/raise() every call, so skip it
+        // when nothing changed and the popup is already up. (isVisible() gates
+        // the re-enter case, where the cache may still match but the popup was
+        // hidden by leaveEvent/hideEvent and must be shown again.)
+        const QString text = hoverValueText();
+        if (m_hoverPopup->isVisible()
+            && text == m_lastPopupText
+            && globalAnchor == m_lastPopupAnchor)
+            return;
+        m_lastPopupText = text;
+        m_lastPopupAnchor = globalAnchor;
+        m_hoverPopup->showValue(globalAnchor, text);
     }
 
     float m_min, m_max, m_redStart, m_yellowStart;
@@ -337,6 +350,8 @@ private:
     bool m_hoverPopupEnabled{false};
     bool m_hovered{false};
     QPoint m_lastHoverGlobal;
+    QString m_lastPopupText;    // last badge text/anchor pushed to the popup —
+    QPoint m_lastPopupAnchor;   // used to skip redundant per-frame re-layouts
 
     // Shared meter ballistics — see MeterSmoother.h.
     MeterSmoother m_smooth;

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -182,6 +182,19 @@ protected:
             m_hoverPopup->linger(kHoverLingerMs);
     }
 
+    void hideEvent(QHideEvent* ev) override {
+        QWidget::hideEvent(ev);
+        // Qt does not guarantee a leaveEvent when the gauge is hidden or
+        // reparented while the pointer is still over it (tab switch, applet
+        // float/dock, window minimize). The popup is a top-level Qt::ToolTip
+        // window, so without this it could linger orphaned on screen — close
+        // it immediately and clear the hover state so it can't reappear stale
+        // when the gauge is shown again.
+        m_hovered = false;
+        if (m_hoverPopup)
+            m_hoverPopup->hideNow();
+    }
+
     void paintEvent(QPaintEvent*) override {
         QPainter p(this);
         p.setRenderHint(QPainter::Antialiasing);

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -97,6 +97,16 @@ static constexpr const char* kInsetEditStyle =
 
 static constexpr float kAlcGaugeFloorDbfs = -20.0f;
 
+// Mouse-over readout formatter for the ALC gauges — one decimal of dBFS so a
+// transmitting operator can read the exact SSB-peak level off the bar rather
+// than eyeballing it against the -20…0 scale. (#feat meter readout)
+static HGauge::HoverValueFormatter alcHoverFormatter()
+{
+    return [](float v) {
+        return QStringLiteral("%1 dBFS").arg(QString::number(v, 'f', 1));
+    };
+}
+
 
 // ── PhoneCwApplet ────────────────────────────────────────────────────────────
 
@@ -137,6 +147,11 @@ void PhoneCwApplet::buildPhonePanel()
         nullptr, -10.0f);
     m_levelGauge->setAccessibleName("Microphone level gauge");
     m_levelGauge->setAccessibleDescription("Microphone input level in dBFS");
+    // Mouse-over readout: exact mic peak in dB. (#feat meter readout)
+    m_levelGauge->setHoverValueFormatter([](float v) {
+        return QStringLiteral("%1 dB").arg(QString::number(v, 'f', 1));
+    });
+    m_levelGauge->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_levelGauge);
 
     // ── Compression gauge (dB: -25 to 0, fills right-to-left) ───────────
@@ -145,6 +160,12 @@ void PhoneCwApplet::buildPhonePanel()
     m_compGauge->setReversed(true);
     m_compGauge->setAccessibleName("Compression gauge");
     m_compGauge->setAccessibleDescription("Speech compression amount in dB");
+    // Mouse-over readout: the gauge stores compression as a negative offset
+    // (-25…0); report it as a positive "amount of compression" in dB. (#feat)
+    m_compGauge->setHoverValueFormatter([](float v) {
+        return QStringLiteral("%1 dB").arg(QString::number(-v, 'f', 1));
+    });
+    m_compGauge->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_compGauge);
 
     // ── ALC gauge (post-SW-ALC SSB-peak, dBFS) ──────────────────────────
@@ -157,6 +178,8 @@ void PhoneCwApplet::buildPhonePanel()
     m_alcGaugePhone->setValueImmediate(kAlcGaugeFloorDbfs);
     m_alcGaugePhone->setAccessibleName("ALC gauge (Phone)");
     m_alcGaugePhone->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
+    m_alcGaugePhone->setHoverValueFormatter(alcHoverFormatter());
+    m_alcGaugePhone->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_alcGaugePhone);
     vbox->addSpacing(4);
 
@@ -379,6 +402,8 @@ void PhoneCwApplet::buildCwPanel()
     m_alcGaugeCw->setValueImmediate(kAlcGaugeFloorDbfs);
     m_alcGaugeCw->setAccessibleName("ALC gauge (CW)");
     m_alcGaugeCw->setAccessibleDescription("Automatic level control — post-software-ALC SSB peak (dBFS)");
+    m_alcGaugeCw->setHoverValueFormatter(alcHoverFormatter());
+    m_alcGaugeCw->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_alcGaugeCw);
     vbox->addSpacing(2);
 

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -99,7 +99,7 @@ static constexpr float kAlcGaugeFloorDbfs = -20.0f;
 
 // Mouse-over readout formatter for the ALC gauges — one decimal of dBFS so a
 // transmitting operator can read the exact SSB-peak level off the bar rather
-// than eyeballing it against the -20…0 scale. (#feat meter readout)
+// than eyeballing it against the -20…0 scale. (#3936)
 static HGauge::HoverValueFormatter alcHoverFormatter()
 {
     return [](float v) {
@@ -147,7 +147,7 @@ void PhoneCwApplet::buildPhonePanel()
         nullptr, -10.0f);
     m_levelGauge->setAccessibleName("Microphone level gauge");
     m_levelGauge->setAccessibleDescription("Microphone input level in dBFS");
-    // Mouse-over readout: exact mic peak in dB. (#feat meter readout)
+    // Mouse-over readout: exact mic peak in dB. (#3936)
     m_levelGauge->setHoverValueFormatter([](float v) {
         return QStringLiteral("%1 dB").arg(QString::number(v, 'f', 1));
     });
@@ -161,7 +161,7 @@ void PhoneCwApplet::buildPhonePanel()
     m_compGauge->setAccessibleName("Compression gauge");
     m_compGauge->setAccessibleDescription("Speech compression amount in dB");
     // Mouse-over readout: the gauge stores compression as a negative offset
-    // (-25…0); report it as a positive "amount of compression" in dB. (#feat)
+    // (-25…0); report it as a positive "amount of compression" in dB. (#3936)
     m_compGauge->setHoverValueFormatter([](float v) {
         return QStringLiteral("%1 dB").arg(QString::number(-v, 'f', 1));
     });

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -135,7 +135,7 @@ void TxApplet::buildUI()
     m_fwdGauge->setAccessibleName("Forward power gauge");
     m_fwdGauge->setAccessibleDescription("RF forward power in watts");
     // Mouse-over readout: exact watts, so the operator isn't left estimating
-    // between the 40 W tick marks while transmitting. (#feat meter readout)
+    // between the 40 W tick marks while transmitting. (#3936)
     static_cast<HGauge*>(m_fwdGauge)->setHoverValueFormatter([](float v) {
         return QStringLiteral("%1 W").arg(QString::number(std::lround(v)));
     });

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -134,6 +134,12 @@ void TxApplet::buildUI()
         this, 80.0f);
     m_fwdGauge->setAccessibleName("Forward power gauge");
     m_fwdGauge->setAccessibleDescription("RF forward power in watts");
+    // Mouse-over readout: exact watts, so the operator isn't left estimating
+    // between the 40 W tick marks while transmitting. (#feat meter readout)
+    static_cast<HGauge*>(m_fwdGauge)->setHoverValueFormatter([](float v) {
+        return QStringLiteral("%1 W").arg(QString::number(std::lround(v)));
+    });
+    static_cast<HGauge*>(m_fwdGauge)->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_fwdGauge);
 
     // ── SWR gauge (1.0–3.0, red > 2.5) ─────────────────────────────────────
@@ -142,6 +148,11 @@ void TxApplet::buildUI()
         this, 2.0f);
     m_swrGauge->setAccessibleName("SWR gauge");
     m_swrGauge->setAccessibleDescription("Standing wave ratio");
+    // Mouse-over readout: exact ratio in the conventional N.N:1 form.
+    static_cast<HGauge*>(m_swrGauge)->setHoverValueFormatter([](float v) {
+        return QStringLiteral("%1:1").arg(QString::number(v, 'f', 2));
+    });
+    static_cast<HGauge*>(m_swrGauge)->setHoverValuePopupEnabled(true);
     vbox->addWidget(m_swrGauge);
 
     // ── RF Power slider ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Mouse-over numeric readout on the TX meters

While transmitting, the **SWR**, **forward-power** and **ALC** bar meters — and now the mic **Level** and **Compression** meters — only told you a value by *how far the bar filled against its scale*. You had to eyeball it. This adds a hover readout: mouse over any of those meters and a floating badge shows the exact numeric value.

![Meter mouse-over value readouts](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets/meter-value-readout.png)

*Proven live over the automation bridge against a FLEX-8400M, transmitting a two-tone into the **ANT2 dummy load**. Forward power, SWR and ALC show real keyed values; Mic Level and Compression are shown idle because two-tone bypasses the mic/speech path.*

### What it does
- Hovering a TX meter pops a floating badge with its exact value:
  - Forward power → `12 W`
  - SWR → `1.12 : 1`
  - ALC → `-6.4 dBFS`
  - Mic Level → `-12.5 dB`
  - Compression → `6.0 dB` (reported as a positive amount of compression)
- The badge **reuses the existing `DragValuePopup`** — the *same* widget the sliders flash when you adjust them by keyboard/drag (20 px, weight-800, rounded cyan-bordered badge) — so font, size and style match exactly, as requested.
- It follows the pointer, updates **live** as the meter value changes while hovered, and **fades one second after the pointer leaves** the bar.

### Implementation
- **`HGauge`** gains an opt-in hover readout: `setHoverValuePopupEnabled(bool)` + `setHoverValueFormatter(...)`. Mouse tracking plus enter/move/leave events drive a per-gauge `DragValuePopup`; `leave` lingers for 1000 ms. Default **off**, so the telemetry gauges (PA temp, supply, fan) are untouched.
- **`TxApplet`** enables it on the forward-power and SWR gauges with unit-aware formatters.
- **`PhoneCwApplet`** enables it on the ALC, mic-Level and Compression gauges.

### Automation bridge (testing support)
- New **`hover <target> [leave]`** verb synthesizes a real hover (`QEnterEvent` + no-button `QMouseMove`; `leave` fires `QEvent::Leave`) so hover-driven UI is provable end-to-end. Documented in `docs/automation-bridge.md`.
- `amp_applet_test` now links `DragValuePopup.cpp` (pulled in transitively by `HGauge.h`).

### Verification
Driven entirely through the automation bridge:

| Meter | Badge | Live meter reading | State |
|---|---|---|---|
| Forward power | `12 W` | ~11.7 W | keyed two-tone, ANT2 |
| SWR | `1.12 : 1` | 1.11 | keyed two-tone, ANT2 |
| ALC | `-6.4 dBFS` | −6.39 dBFS | keyed two-tone, ANT2 |
| Mic Level | `-150.0 dB` | floor | idle (mic-path) |
| Compression | `0.0 dB` | 0 | idle (mic-path) |

- **Safety:** the TX antenna was hard-verified as `ANT2` (dummy load) via `dumpTree` before any keying; tune power held at ~15–20 %; the transmitter was unkeyed and state restored after capture (`transmitting == false` confirmed).
- **Fade timing:** the badge was confirmed still visible 0.4 s after mouse-leave and gone by 1.2 s — i.e. the 1-second linger.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
