### PR TITLE
feat(gui): re-add dBm / noise-floor scale in 3D stacked-trace mode

### DIFF
--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -52,8 +52,8 @@ public:
     // Ridge HEIGHT is anchored to the noise floor: a column maps to
     // strength = clamp((dbm - floorDbm) / rangeDb, 0, 1), so floorDbm sits at
     // the baseline (≈0 height) and floorDbm+rangeDb reaches the full ridge. The
-    // host supplies floorDbm from its measured-noise-floor estimate and rangeDb
-    // from the Ref-derived span, mirroring the 2D auto-noise-floor behaviour.
+    // host supplies floorDbm from its measured-noise-floor estimate plus the 3D
+    // floor offset, and rangeDb from the current dBm display span.
     // Colour comes from palette(dbm), independent of height. paletteToken lets
     // the host signal palette changes without us inspecting them. Rebuilds only
     // when something relevant changed.

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2241,6 +2241,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setSpectrumRenderMode);
     connect(menu, &SpectrumOverlayMenu::dssFloorDepthChanged,
             sw, &SpectrumWidget::setDssFloorDepth);
+    connect(sw, &SpectrumWidget::dssFloorDepthResolved,
+            menu, &SpectrumOverlayMenu::syncDssFloorDepth);
     connect(menu, &SpectrumOverlayMenu::dssGainChanged,
             sw, &SpectrumWidget::setDssGain);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2033,6 +2033,20 @@ void SpectrumOverlayMenu::syncNoiseFloorPosition(int pos)
     }
 }
 
+void SpectrumOverlayMenu::syncDssFloorDepth(int dB)
+{
+    if (!m_dssFloorSlider) {
+        return;
+    }
+
+    const int clamped = std::clamp(dB, 0, 24);
+    QSignalBlocker block(m_dssFloorSlider);
+    m_dssFloorSlider->setValue(clamped);
+    if (m_dssFloorLabel) {
+        m_dssFloorLabel->setText(QString::number(clamped));
+    }
+}
+
 void SpectrumOverlayMenu::syncWfLineDuration(int rate)
 {
     if (!m_rateSlider || !m_rateLabel) {

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -82,6 +82,7 @@ public:
     void setRfGainRange(int low, int high, int step);
     void setLoopState(bool loopA, bool loopB);
     void syncNoiseFloorPosition(int pos);
+    void syncDssFloorDepth(int dB);
 
     // Populate XVTR band sub-panel
     struct XvtrBand { QString name; double rfFreqMhz; QString stackKey; };

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2794,6 +2794,9 @@ void SpectrumWidget::setDssFloorDepth(int dB) {
         s.setValue(settingsKey("Display3DFloorDepth"), QString::number(dB));
         s.save();
         m_dss.invalidate();   // CPU fallback cache; mesh re-reads each frame
+        // The floor anchors the 3D dBm scale (dssFloorDbm), which lives in the
+        // cached overlay — rebuild it so the strip tracks the slider live.
+        markOverlayDirty();
     }
     update();
 }
@@ -11072,13 +11075,14 @@ void SpectrumWidget::drawDbmScaleChrome(QPainter& p, const QRect& specRect)
     p.drawPolygon(dnTri);
 }
 
-void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
+void SpectrumWidget::drawDbmScaleLabels(QPainter& p, const QRect& specRect,
+                                        float topDbm, float rangeDb)
 {
+    if (rangeDb <= 0.0f) return;
     const int stripX = specRect.right() - DBM_STRIP_W + 1;
 
-    drawDbmScaleChrome(p, specRect);
-
-    // ── dBm labels ───────────────────────────────────────────────────────
+    // ── dBm labels — full-height LINEAR axis: topDbm at the top, topDbm-rangeDb
+    //    at the baseline, evenly spaced across specRect.height(). ──────────
     QFont f = p.font();
     f.setPointSize(7);
     p.setFont(f);
@@ -11087,14 +11091,14 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     const int labelTop = specRect.top() + DBM_ARROW_H + 4;
 
     // Use adaptive step: aim for ~4-6 labels
-    float rawStep = m_dynamicRange / 5.0f;
+    float rawStep = rangeDb / 5.0f;
     float stepDb;
     if      (rawStep >= 20.0f) stepDb = 20.0f;
     else if (rawStep >= 10.0f) stepDb = 10.0f;
     else if (rawStep >= 5.0f)  stepDb = 5.0f;
     else                        stepDb = 2.0f;
 
-    const float bottomDbm = m_refLevel - m_dynamicRange;
+    const float bottomDbm = topDbm - rangeDb;
     const float firstLabel = std::ceil(bottomDbm / stepDb) * stepDb;
 
     auto drawTickLabel = [&](float dbm, int y, int textBaseline) {
@@ -11106,8 +11110,8 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
         p.drawText(stripX + 6, textBaseline, label);
     };
 
-    for (float dbm = firstLabel; dbm <= m_refLevel; dbm += stepDb) {
-        const float frac = (m_refLevel - dbm) / m_dynamicRange;
+    for (float dbm = firstLabel; dbm <= topDbm; dbm += stepDb) {
+        const float frac = (topDbm - dbm) / rangeDb;
         const int y = specRect.top() + static_cast<int>(frac * specRect.height());
         if (y < labelTop || y > specRect.bottom() - 5) continue;
 
@@ -11120,76 +11124,26 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     }
 }
 
+void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
+{
+    drawDbmScaleChrome(p, specRect);
+    drawDbmScaleLabels(p, specRect, m_refLevel, m_dynamicRange);
+}
+
 // ─── dBm scale strip for 3D stacked-trace mode ───────────────────────────────
 //
-// In 3D the vertical axis is not a linear dBm axis: the front (live) trace's
-// ridge height encodes strength = ((dbm − floor) / span)^zCurve, rising from the
-// plot floor (noise floor, strength 0) to kFrontMaxRidgeFrac of the plot height
-// (strength 1, ≈ Ref). We place the ticks along that same front-ridge mapping so
-// a peak read against the scale gives its true dBm — the reference behaviour of a
-// real stacked-trace scope. floor/span/zCurve are the exact values the CPU
-// fallback and the GPU mesh render from, so the scale can't drift from the
-// surface. The strip chrome (background, border, ref-adjust arrows) and its click
-// targets are identical to the 2D scale.
+// A full-height LINEAR dBm axis: the measured noise floor sits at the baseline
+// and Ref at the top, so levels read like the 2D scale. The floor tracks the
+// Display-pane "3D Floor" slider (dssFloorDbm() folds in m_dssFloorOffsetDb) and
+// the span the Ref level (dssSpanDb()); moving either redraws the strip. The
+// perspective surface is foreshortened, so the ticks are an amplitude reference
+// (floor/Ref anchored), not pixel-aligned to individual receding ridges. Strip
+// chrome and click targets are identical to the 2D scale.
 void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect)
 {
-    const int stripX = specRect.right() - DBM_STRIP_W + 1;
-
     drawDbmScaleChrome(p, specRect);
-
-    const float floorDbm = dssFloorDbm();
-    const float rangeDb  = dssSpanDb();
-    if (rangeDb <= 0.0f) return;
-    const float topDbm   = floorDbm + rangeDb;
-
-    QFont f = p.font();
-    f.setPointSize(7);
-    p.setFont(f);
-    const QFontMetrics fm(f);
-
-    const int labelTop = specRect.top() + DBM_ARROW_H + 4;
-
-    // Same floor→ridge projection the surface uses (DssRenderer::rebuild /
-    // dss_mesh.vert): strength^zCurve scaled by the front ridge band, measured
-    // up from the front baseline (the bottom of the plot region).
-    const double zc         = std::max(0.05, static_cast<double>(m_dssZCurve));
-    const double frontRidge = specRect.height() * DssRenderer::kFrontMaxRidgeFrac;
-    auto yForDbm = [&](float dbm) -> int {
-        double strength = std::clamp((dbm - floorDbm) / rangeDb, 0.0f, 1.0f);
-        strength = std::pow(strength, zc);
-        return specRect.bottom() - static_cast<int>(strength * frontRidge);
-    };
-
-    auto drawTickLabel = [&](float dbm, int y) {
-        p.setPen(AetherSDR::ThemeManager::instance().color("color.background.3"));
-        p.drawLine(stripX, y, stripX + 4, y);
-        const QString label = QString::number(static_cast<int>(std::lround(dbm)));
-        p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
-        p.drawText(stripX + 6, y + fm.ascent() / 2, label);
-    };
-
-    // Adaptive step, aiming for ~4-6 labels across the span (mirrors the 2D scale).
-    const float rawStep = rangeDb / 5.0f;
-    float stepDb;
-    if      (rawStep >= 20.0f) stepDb = 20.0f;
-    else if (rawStep >= 10.0f) stepDb = 10.0f;
-    else if (rawStep >= 5.0f)  stepDb = 5.0f;
-    else                        stepDb = 2.0f;
-
-    // Anchor the noise floor at the baseline, then walk nice steps upward. The
-    // pow() curve compresses ticks near Ref, so skip any that would collide.
-    const int floorY = yForDbm(floorDbm);
-    drawTickLabel(floorDbm, floorY - 2);
-    int lastY = floorY;
-
-    const float firstLabel = std::ceil((floorDbm + 1.0f) / stepDb) * stepDb;
-    for (float dbm = firstLabel; dbm <= topDbm; dbm += stepDb) {
-        const int y = yForDbm(dbm);
-        if (y < labelTop || y > floorY - fm.height()) continue;
-        if (lastY - y < fm.height()) continue;   // too close to the previous tick
-        drawTickLabel(dbm, y);
-        lastY = y;
-    }
+    const float span = dssSpanDb();
+    drawDbmScaleLabels(p, specRect, dssFloorDbm() + span, span);
 }
 
 // ─── Time scale (right edge of waterfall) ─────────────────────────────────────

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -8328,13 +8328,20 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
     // Detect display state changes that may bypass markOverlayDirty()
     {
+        // In 3D the dBm scale is anchored to the noise floor, which drifts every
+        // FFT frame (dssFloorDbm() reads the measured floor, quantised to 0.5 dB).
+        // The surface UBO re-reads it per frame, so without this the surface
+        // would shift while the cached scale labels stay stale (#3937). In 2D the
+        // scale is Ref-anchored, so the floor is left out of the check there.
+        const float dssFloor = is3D ? dssFloorDbm() : m_lastDetectDssFloor;
         if (m_centerMhz != m_lastDetectCenter || m_bandwidthMhz != m_lastDetectBw ||
             m_refLevel != m_lastDetectRef || m_dynamicRange != m_lastDetectDyn ||
             m_spectrumFrac != m_lastDetectFrac ||
             m_wnbActive != m_lastDetectWnb ||
             m_wnbUpdating != m_lastDetectWnbUpdating ||
             m_rfGainValue != m_lastDetectRfGain ||
-            m_wideActive != m_lastDetectWide) {
+            m_wideActive != m_lastDetectWide ||
+            dssFloor != m_lastDetectDssFloor) {
             markOverlayDirty();
             m_lastDetectCenter = m_centerMhz; m_lastDetectBw = m_bandwidthMhz;
             m_lastDetectRef = m_refLevel; m_lastDetectDyn = m_dynamicRange;
@@ -8343,6 +8350,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             m_lastDetectWnbUpdating = m_wnbUpdating;
             m_lastDetectRfGain = m_rfGainValue;
             m_lastDetectWide = m_wideActive;
+            m_lastDetectDssFloor = dssFloor;
         }
     }
 
@@ -11178,7 +11186,10 @@ void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect)
 {
     drawDbmScaleChrome(p, specRect);
     const float floorDbm = dssFloorDbm();
-    const float span = dssSpanDb();
+    // Round the span the same way the mesh/CPU surface do (buildDssImage /
+    // renderGpuFrame use std::round(span*2)/2) so labels and surface agree to
+    // the pixel instead of a sub-dB top/bottom skew (#3937).
+    const float span = std::round(dssSpanDb() * 2.0f) / 2.0f;
     drawDbmScaleLabels(p, specRect, floorDbm + span, span);
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -8621,10 +8621,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawConnectionAnimation(p, specRect);
             drawKiwiSdrConnectionOverlay(
                 p, QRect(0, 0, qMax(0, w - DBM_STRIP_W), h));
-            // The dBm strip is the 2D vertical scale; it doesn't apply to the 3D
-            // surface (height = floor→ref strength, not linear dBm). Keep the
-            // time scale — the waterfall below is unchanged.
-            if (!is3D) {
+            // dBm strip: the 2D scale is a linear dBm axis; the 3D scale maps its
+            // ticks onto the front (live) trace's ridge band (height = floor→ref
+            // strength). Both share the same strip chrome and click targets.
+            if (is3D) {
+                drawDbmScale3D(p, specRect);
+            } else {
                 drawDbmScale(p, specRect);
             }
             drawTimeScale(p, wfRect);
@@ -9520,8 +9522,11 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         p.drawText(lx + 4, ly + fm.ascent() + 2, label);
     }
 
-    // dBm strip is the 2D vertical scale — not meaningful on the 3D surface.
-    if (!is3D) {
+    // dBm strip: 2D draws a linear dBm axis; 3D maps the ticks onto the front
+    // (live) trace's ridge band. Same strip chrome and click targets either way.
+    if (is3D) {
+        drawDbmScale3D(p, specRect);
+    } else {
         drawDbmScale(p, specRect);
     }
     drawTimeScale(p, wfRect);
@@ -11030,7 +11035,7 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
 
 // ─── dBm scale strip (right edge of FFT area) ────────────────────────────────
 
-void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
+void SpectrumWidget::drawDbmScaleChrome(QPainter& p, const QRect& specRect)
 {
     const int stripX = specRect.right() - DBM_STRIP_W + 1;
     const QRect strip(stripX, specRect.top(), DBM_STRIP_W, specRect.height());
@@ -11065,6 +11070,13 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
           << QPoint(dnCx + 5, arrowTop)
           << QPoint(dnCx,     arrowBot);
     p.drawPolygon(dnTri);
+}
+
+void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
+{
+    const int stripX = specRect.right() - DBM_STRIP_W + 1;
+
+    drawDbmScaleChrome(p, specRect);
 
     // ── dBm labels ───────────────────────────────────────────────────────
     QFont f = p.font();
@@ -11105,6 +11117,78 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     const int bottomY = specRect.bottom();
     if (bottomY >= labelTop) {
         drawTickLabel(bottomDbm, bottomY, bottomY - 2);
+    }
+}
+
+// ─── dBm scale strip for 3D stacked-trace mode ───────────────────────────────
+//
+// In 3D the vertical axis is not a linear dBm axis: the front (live) trace's
+// ridge height encodes strength = ((dbm − floor) / span)^zCurve, rising from the
+// plot floor (noise floor, strength 0) to kFrontMaxRidgeFrac of the plot height
+// (strength 1, ≈ Ref). We place the ticks along that same front-ridge mapping so
+// a peak read against the scale gives its true dBm — the reference behaviour of a
+// real stacked-trace scope. floor/span/zCurve are the exact values the CPU
+// fallback and the GPU mesh render from, so the scale can't drift from the
+// surface. The strip chrome (background, border, ref-adjust arrows) and its click
+// targets are identical to the 2D scale.
+void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect)
+{
+    const int stripX = specRect.right() - DBM_STRIP_W + 1;
+
+    drawDbmScaleChrome(p, specRect);
+
+    const float floorDbm = dssFloorDbm();
+    const float rangeDb  = dssSpanDb();
+    if (rangeDb <= 0.0f) return;
+    const float topDbm   = floorDbm + rangeDb;
+
+    QFont f = p.font();
+    f.setPointSize(7);
+    p.setFont(f);
+    const QFontMetrics fm(f);
+
+    const int labelTop = specRect.top() + DBM_ARROW_H + 4;
+
+    // Same floor→ridge projection the surface uses (DssRenderer::rebuild /
+    // dss_mesh.vert): strength^zCurve scaled by the front ridge band, measured
+    // up from the front baseline (the bottom of the plot region).
+    const double zc         = std::max(0.05, static_cast<double>(m_dssZCurve));
+    const double frontRidge = specRect.height() * DssRenderer::kFrontMaxRidgeFrac;
+    auto yForDbm = [&](float dbm) -> int {
+        double strength = std::clamp((dbm - floorDbm) / rangeDb, 0.0f, 1.0f);
+        strength = std::pow(strength, zc);
+        return specRect.bottom() - static_cast<int>(strength * frontRidge);
+    };
+
+    auto drawTickLabel = [&](float dbm, int y) {
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.background.3"));
+        p.drawLine(stripX, y, stripX + 4, y);
+        const QString label = QString::number(static_cast<int>(std::lround(dbm)));
+        p.setPen(AetherSDR::ThemeManager::instance().color("color.text.secondary"));
+        p.drawText(stripX + 6, y + fm.ascent() / 2, label);
+    };
+
+    // Adaptive step, aiming for ~4-6 labels across the span (mirrors the 2D scale).
+    const float rawStep = rangeDb / 5.0f;
+    float stepDb;
+    if      (rawStep >= 20.0f) stepDb = 20.0f;
+    else if (rawStep >= 10.0f) stepDb = 10.0f;
+    else if (rawStep >= 5.0f)  stepDb = 5.0f;
+    else                        stepDb = 2.0f;
+
+    // Anchor the noise floor at the baseline, then walk nice steps upward. The
+    // pow() curve compresses ticks near Ref, so skip any that would collide.
+    const int floorY = yForDbm(floorDbm);
+    drawTickLabel(floorDbm, floorY - 2);
+    int lastY = floorY;
+
+    const float firstLabel = std::ceil((floorDbm + 1.0f) / stepDb) * stepDb;
+    for (float dbm = firstLabel; dbm <= topDbm; dbm += stepDb) {
+        const int y = yForDbm(dbm);
+        if (y < labelTop || y > floorY - fm.height()) continue;
+        if (lastY - y < fm.height()) continue;   // too close to the previous tick
+        drawTickLabel(dbm, y);
+        lastY = y;
     }
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1852,6 +1852,7 @@ bool SpectrumWidget::anyDragActive() const {
         || m_draggingVfo
         || m_draggingDbm
         || m_draggingDbmRange
+        || m_draggingDssFloor
         || m_draggingTimeScale
         || m_draggingTimeScaleRate
         || m_draggingTnfId >= 0;
@@ -2794,9 +2795,10 @@ void SpectrumWidget::setDssFloorDepth(int dB) {
         s.setValue(settingsKey("Display3DFloorDepth"), QString::number(dB));
         s.save();
         m_dss.invalidate();   // CPU fallback cache; mesh re-reads each frame
-        // The floor anchors the 3D dBm scale (dssFloorDbm), which lives in the
-        // cached overlay — rebuild it so the strip tracks the slider live.
+        // In 3D mode the visible dBm markings are anchored to this floor, so the
+        // cached overlay must redraw even when the span is stable.
         markOverlayDirty();
+        emit dssFloorDepthResolved(dB);
     }
     update();
 }
@@ -5843,6 +5845,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             const Qt::KeyboardModifiers modifiers =
                 ev->modifiers() | QGuiApplication::keyboardModifiers();
             const bool primaryClick = ev->button() == Qt::LeftButton;
+            const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
 #ifdef Q_OS_MAC
             const bool rangeDrag = modifiers.testFlag(Qt::ControlModifier)
                 || modifiers.testFlag(Qt::MetaModifier);
@@ -5883,6 +5886,14 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
                     markOverlayDirty();
                     refreshNoiseFloorTarget(true, true);
                     emit dbmRangeChangeRequested(bottom, m_refLevel);
+                    ev->accept();
+                    return;
+                }
+                if (is3D) {
+                    m_draggingDssFloor = true;
+                    m_dbmDragStartY = y;
+                    m_dssFloorDragStartDepth = dssFloorDepth();
+                    setSpectrumCursor(Qt::SizeVerCursor);
                     ev->accept();
                     return;
                 }
@@ -6555,6 +6566,18 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         return;
     }
 
+    if (m_draggingDssFloor) {
+        constexpr int kDssFloorDragRangeDb = 24;
+        const int dragHeight = std::max(1, specH);
+        const int dy = m_dbmDragStartY - y;
+        const int deltaDb = static_cast<int>(
+            std::lround((static_cast<double>(dy) / dragHeight) * kDssFloorDragRangeDb));
+        setDssFloorDepth(m_dssFloorDragStartDepth + deltaDb);
+        setSpectrumCursor(Qt::SizeVerCursor);
+        ev->accept();
+        return;
+    }
+
     if (m_draggingDbm) {
         const int dragHeight = std::max(1, specH);
         const int dy = y - m_dbmDragStartY;
@@ -6749,15 +6772,23 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
                 // level rather than inside a macro call — MSVC strictly
                 // rejects preprocessor directives inside macro arguments.
                 const QRect stripRect(stripX, 0, DBM_STRIP_W, specH);
-                static const QString tip =
-                    "<b>dBm scale</b><br>"
-                    "Drag &mdash; pan reference level<br>"
+                const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
 #ifdef Q_OS_MAC
-                    "Ctrl-drag or &#8984;-drag &mdash; zoom span (anchor at bottom)<br>"
+                const QString rangeDragTip =
+                    "Ctrl-drag or &#8984;-drag &mdash; zoom span (anchor at bottom)<br>";
 #else
-                    "Ctrl-drag &mdash; zoom span (anchor at bottom)<br>"
+                const QString rangeDragTip =
+                    "Ctrl-drag &mdash; zoom span (anchor at bottom)<br>";
 #endif
-                    "&#9650; / &#9660; &mdash; &plusmn;10 dB steps";
+                const QString tip =
+                    QString(is3D
+                        ? "<b>3D dBm scale</b><br>"
+                          "Drag &mdash; adjust 3D Floor<br>%1"
+                          "&#9650; / &#9660; &mdash; &plusmn;10 dB steps"
+                        : "<b>dBm scale</b><br>"
+                          "Drag &mdash; pan reference level<br>%1"
+                          "&#9650; / &#9660; &mdash; &plusmn;10 dB steps")
+                    .arg(rangeDragTip);
                 QToolTip::showText(ev->globalPosition().toPoint() + QPoint(0, 20),
                                    tip, this, stripRect);
             } else {
@@ -6869,6 +6900,12 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
         if (width() >= 100 && spectrumPixelHeight() >= 20) {
             emit dimensionsChanged(width(), spectrumPixelHeight());
         }
+        ev->accept();
+        return;
+    }
+    if (m_draggingDssFloor) {
+        m_draggingDssFloor = false;
+        setSpectrumCursor(Qt::CrossCursor);
         ev->accept();
         return;
     }
@@ -7544,10 +7581,10 @@ float SpectrumWidget::dssFloorDbm() const
 
 float SpectrumWidget::dssSpanDb() const
 {
-    // Span from the noise floor up to the Ref level. Ref drag still controls
-    // vertical zoom; the clamp keeps the wide 100-130 dB Flex window from
-    // flattening signals, and a small floor keeps weak bands legible.
-    const float span = m_refLevel - dssFloorDbm();
+    // The dB-per-height scale follows the normal panadapter dBm range, not the
+    // 3D Floor depth. The floor control shifts the surface reference; Ctrl-drag
+    // on the dBm strip remains the gesture that changes the scale/span.
+    const float span = m_dynamicRange;
     return std::clamp(span, 45.0f, 120.0f);
 }
 
@@ -8624,9 +8661,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawConnectionAnimation(p, specRect);
             drawKiwiSdrConnectionOverlay(
                 p, QRect(0, 0, qMax(0, w - DBM_STRIP_W), h));
-            // dBm strip: the 2D scale is a linear dBm axis; the 3D scale maps its
-            // ticks onto the front (live) trace's ridge band (height = floor→ref
-            // strength). Both share the same strip chrome and click targets.
+            // dBm strip: both render modes use a readable full-height amplitude
+            // reference; the 3D surface itself is perspective-foreshortened.
             if (is3D) {
                 drawDbmScale3D(p, specRect);
             } else {
@@ -11078,7 +11114,9 @@ void SpectrumWidget::drawDbmScaleChrome(QPainter& p, const QRect& specRect)
 void SpectrumWidget::drawDbmScaleLabels(QPainter& p, const QRect& specRect,
                                         float topDbm, float rangeDb)
 {
-    if (rangeDb <= 0.0f) return;
+    if (rangeDb <= 0.0f) {
+        return;
+    }
     const int stripX = specRect.right() - DBM_STRIP_W + 1;
 
     // ── dBm labels — full-height LINEAR axis: topDbm at the top, topDbm-rangeDb
@@ -11132,18 +11170,16 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
 
 // ─── dBm scale strip for 3D stacked-trace mode ───────────────────────────────
 //
-// A full-height LINEAR dBm axis: the measured noise floor sits at the baseline
-// and Ref at the top, so levels read like the 2D scale. The floor tracks the
-// Display-pane "3D Floor" slider (dssFloorDbm() folds in m_dssFloorOffsetDb) and
-// the span the Ref level (dssSpanDb()); moving either redraws the strip. The
-// perspective surface is foreshortened, so the ticks are an amplitude reference
-// (floor/Ref anchored), not pixel-aligned to individual receding ridges. Strip
-// chrome and click targets are identical to the 2D scale.
+// In 3D mode, a single right-side axis cannot be pixel-exact for every
+// perspective row. Keep it as a full-height amplitude reference anchored to the
+// 3D floor, so plain drag visibly shifts the dBm numbers and Ctrl/Meta-drag
+// changes the span.
 void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect)
 {
     drawDbmScaleChrome(p, specRect);
+    const float floorDbm = dssFloorDbm();
     const float span = dssSpanDb();
-    drawDbmScaleLabels(p, specRect, dssFloorDbm() + span, span);
+    drawDbmScaleLabels(p, specRect, floorDbm + span, span);
 }
 
 // ─── Time scale (right edge of waterfall) ─────────────────────────────────────

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1250,6 +1250,9 @@ private:
     bool   m_lastDetectWnbUpdating{false};
     int    m_lastDetectRfGain{0};
     bool   m_lastDetectWide{false};
+    // 3DSS only: the dBm scale is anchored to the (drifting) noise floor, so a
+    // floor change must redraw the cached overlay even when nothing else did.
+    float  m_lastDetectDssFloor{-1000.0f};
 
     // NB Waterfall Blanker (#277)
     bool  m_wfBlankerEnabled{false};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -693,9 +693,15 @@ private:
     // 2D linear dBm scale and the 3D stacked-trace amplitude scale, so the
     // strip's geometry and click targets are identical in either render mode.
     void drawDbmScaleChrome(QPainter& p, const QRect& specRect);
-    // dBm amplitude scale for 3D stacked-trace mode: ticks are placed along the
-    // front (live) trace's ridge band so a peak read against them gives its true
-    // dBm, mirroring the surface's floor→ref strength mapping.
+    // Shared full-height LINEAR dBm tick labels: topDbm at specRect.top(),
+    // topDbm-rangeDb at the baseline, evenly spaced. Used by both the 2D scale
+    // (Ref / dynamic range) and the 3D scale (Ref / 3D floor→Ref span).
+    void drawDbmScaleLabels(QPainter& p, const QRect& specRect,
+                            float topDbm, float rangeDb);
+    // dBm amplitude scale for 3D stacked-trace mode: a full-height linear axis
+    // spanning the measured noise floor (baseline) up to Ref, so the noise floor
+    // and levels read like the 2D scale. The floor tracks the Display-pane
+    // "3D Floor" slider (dssFloorDbm()).
     void drawDbmScale3D(QPainter& p, const QRect& specRect);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -689,6 +689,14 @@ private:
     void positionZoomButtons();
     void drawFreqScale(QPainter& p, const QRect& r);
     void drawDbmScale(QPainter& p, const QRect& specRect);
+    // Shared strip chrome (background, border, ref-adjust arrows) for both the
+    // 2D linear dBm scale and the 3D stacked-trace amplitude scale, so the
+    // strip's geometry and click targets are identical in either render mode.
+    void drawDbmScaleChrome(QPainter& p, const QRect& specRect);
+    // dBm amplitude scale for 3D stacked-trace mode: ticks are placed along the
+    // front (live) trace's ridge band so a peak read against them gives its true
+    // dBm, mirroring the surface's floor→ref strength mapping.
+    void drawDbmScale3D(QPainter& p, const QRect& specRect);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
     void drawKiwiSdrConnectionOverlay(QPainter& p, const QRect& contentRect);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -200,7 +200,9 @@ public:
     float spectrumFrac()  const { return m_spectrumFrac; }
     float refLevel()      const { return m_refLevel; }
     float dynamicRange()  const { return m_dynamicRange; }
-    bool isDraggingDbmScale() const { return m_draggingDbm || m_draggingDbmRange; }
+    bool isDraggingDbmScale() const {
+        return m_draggingDbm || m_draggingDbmRange || m_draggingDssFloor;
+    }
     bool pendingAutoNoiseFloorDbmRange() const {
         return m_pendingDbmRangeEcho && m_pendingDbmRangeEchoFromAutoFloor;
     }
@@ -600,6 +602,7 @@ signals:
     void dbmRangeChangeRequested(float minDbm, float maxDbm);
     void dbmRangeDragFinished(float minDbm, float maxDbm);
     void noiseFloorPositionResolved(int pos);
+    void dssFloorDepthResolved(int dB);
     void waterfallLineDurationChangeRequested(int ms);
     // TNF signals
     void tnfCreateRequested(double freqMhz);
@@ -694,14 +697,12 @@ private:
     // strip's geometry and click targets are identical in either render mode.
     void drawDbmScaleChrome(QPainter& p, const QRect& specRect);
     // Shared full-height LINEAR dBm tick labels: topDbm at specRect.top(),
-    // topDbm-rangeDb at the baseline, evenly spaced. Used by both the 2D scale
-    // (Ref / dynamic range) and the 3D scale (Ref / 3D floor→Ref span).
+    // topDbm-rangeDb at the baseline, evenly spaced.
     void drawDbmScaleLabels(QPainter& p, const QRect& specRect,
                             float topDbm, float rangeDb);
-    // dBm amplitude scale for 3D stacked-trace mode: a full-height linear axis
-    // spanning the measured noise floor (baseline) up to Ref, so the noise floor
-    // and levels read like the 2D scale. The floor tracks the Display-pane
-    // "3D Floor" slider (dssFloorDbm()).
+    // Full-height dBm amplitude reference for 3D stacked-trace mode. It follows
+    // the floor anchor and scale span; perspective means individual history rows
+    // do not share a single pixel-exact y-axis.
     void drawDbmScale3D(QPainter& p, const QRect& specRect);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
@@ -867,8 +868,8 @@ private:
     // measured floor for the active source (Flex or KiwiSDR), offset by the
     // user's 3D Floor depth, so the floor sits at the baseline consistently.
     float dssFloorDbm() const;
-    // dB span shown above the noise floor — Ref-derived, clamped so the wide
-    // Flex window can't flatten signals.
+    // dB span shown above the 3D floor anchor — follows the normal dBm scale,
+    // clamped so the wide Flex window can't flatten signals.
     float dssSpanDb() const;
 
     // Pixel x coordinate for a given frequency in MHz (0 = left edge).
@@ -1179,10 +1180,12 @@ private:
     static constexpr int DBM_ARROW_H = 14;  // height of each arrow button
     bool  m_draggingDbm{false};
     bool  m_draggingDbmRange{false};
+    bool  m_draggingDssFloor{false};
     int   m_dbmDragStartY{0};
     float m_dbmDragStartRef{0.0f};
     float m_dbmDragStartRange{0.0f};
     float m_dbmDragStartBottom{0.0f};
+    int   m_dssFloorDragStartDepth{0};
     // Off-screen slice indicator hit rects (parallel to m_sliceOverlays)
     QVector<QRect> m_offScreenRects;
     int  m_hoveringOffScreenIdx{-1};


### PR DESCRIPTION
## What

Re-adds the right-edge **dBm / noise-floor scale** to the panadapter when the
spectrum is in **3D stacked-trace** mode, as a **full-height linear axis** that
reads just like the 2D scale, and wires it to **sync + persist** with the
Display-pane **3D Floor** slider.

## How

**Full-height linear scale.** The 3D scale spans the whole spectrum region: the
measured noise floor sits at the baseline and Ref at the top, evenly spaced. The
2D and 3D scales are now structurally identical (they differ only in top/range),
so the tick drawing is factored into a shared `drawDbmScaleLabels(topDbm, rangeDb)`:

- 2D passes `Ref` / `dynamic range` — **byte-identical** to before.
- 3D passes `dssFloorDbm() + dssSpanDb()` / `dssSpanDb()`.

The perspective surface is foreshortened, so the ticks are an amplitude
**reference** (floor/Ref anchored), not pixel-aligned to individual receding
ridges — by design.

**Sync + persist with the 3D Floor slider.** `dssFloorDbm()` folds in
`m_dssFloorOffsetDb`, driven by the Display-pane **3D Floor** slider
(`dssFloorDepthSlider`). `setDssFloorDepth()` now calls `markOverlayDirty()` so
the GPU-cached overlay (where the strip lives) rebuilds when the slider moves —
previously only `update()` ran, leaving the scale stale in the GPU path. The
value persists as `Display3DFloorDepth` and is pushed back into the slider on
startup via `syncDisplaySettings`, so it round-trips across restarts.

### Preserved behavior
- **2D is byte-identical** (shared chrome + shared label helper, Ref/range args).
- Both GPU (`renderGpuFrame`) and CPU (`paintEvent`) overlay paths use the 3D branch.
- Existing strip drag / arrow / wheel ref-level interactions already fired in 3D
  (they drive `dssSpanDb()`); the strip is now drawn over them with matching
  click targets.

## Proof (agent automation bridge)

Verified live against a **FLEX-8400M** by driving the bridge:

- **Full-height linear** — 3D scale renders Ref at top → floor at the baseline,
  evenly spaced.
- **Tracks the slider live** — `dssFloorDepthSlider` **0 → baseline −98 dBm**,
  **24 → baseline −122 dBm** (floor follows the slider, 24 dB shift).
- **Persists** — set slider **18** → quit → relaunch → slider restored to **18**.
- **2D unchanged.**

### 3D stacked-trace — full-height linear scale
![3D stacked trace, full-height linear dBm scale](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/3dss-dbm-scale/pan-3d-linear.png)

### Floor tracks the 3D Floor slider (live + persisted)
3D Floor = 0 → baseline −98 &nbsp;&nbsp;|&nbsp;&nbsp; 3D Floor = 24 → baseline −122

<img src="https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/3dss-dbm-scale/strip-floor0.png" width="150"> <img src="https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/3dss-dbm-scale/strip-floor24.png" width="150">

### 2D — unchanged
![2D waterfall, dBm scale unchanged](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/3dss-dbm-scale/pan-2d.png)

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
