### PR TITLE
fix(rc28): sync wheel accumulator to snapped frequency after auto-snap fires

### DIFF
--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -2426,8 +2426,10 @@ void MainWindow::wireExternalControllers()
         if (auto* s = activeSlice()) {
             if (s->isLocked()) return;
             const double snapped = std::round(s->frequency() * 1000.0) / 1000.0;
-            if (std::abs(snapped - s->frequency()) > 1e-9)
+            if (std::abs(snapped - s->frequency()) > 1e-9) {
                 applyTuneRequest(s, snapped, TuneIntent::IncrementalTune, "rc28-autosnap");
+                m_flexTargetMhz = snapped;
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- After the 600 ms auto-snap timer rounds the slice frequency to the nearest 1 kHz, `m_flexTargetMhz` was left pointing at the pre-snap value.
- The re-base guard in `applyFlexControlWheelAction` only fires when the delta exceeds 1 kHz, so a sub-kHz snap (e.g. 200 Hz) was invisible to it — the next knob tick would resume from the stale pre-snap target, effectively undoing the snap.
- Setting `m_flexTargetMhz = snapped` immediately after `applyTuneRequest` keeps the accumulator in sync with the displayed frequency.

Fixes #3939.

## Test plan
- [x] Manually reproduced the auto-snap-then-knob-tick sequence and confirmed the snap now sticks
- [x] Verified no regression on normal (non-snap) incremental tuning via the control wheel