### PR TITLE
fix(gui): stop New Panadapter Cancel button overlapping the layout grid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2460,6 +2460,23 @@ target_link_libraries(flex_control_dialog_size_test PRIVATE
 )
 set_target_properties(flex_control_dialog_size_test PROPERTIES AUTOMOC ON)
 
+add_executable(pan_layout_dialog_size_test
+    tests/pan_layout_dialog_size_test.cpp
+    src/gui/PanLayoutDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+    src/core/ThemeManager.cpp
+    src/core/AppSettings.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(pan_layout_dialog_size_test PRIVATE src)
+target_link_libraries(pan_layout_dialog_size_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(pan_layout_dialog_size_test PROPERTIES AUTOMOC ON)
+
 add_executable(device_diagnostics_test
     tests/device_diagnostics_test.cpp
 )

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4285,6 +4285,8 @@ void MainWindow::buildUI()
         hbox->addSpacing(8);
 
         auto* addPanBtn = new QLabel;
+        addPanBtn->setObjectName("addPanadapterButton");
+        addPanBtn->setAccessibleName("Add Panadapter");
         addPanBtn->setPixmap(pm);
         addPanBtn->setCursor(Qt::PointingHandCursor);
         addPanBtn->setToolTip("Add Panadapter");

--- a/src/gui/PanLayoutDialog.cpp
+++ b/src/gui/PanLayoutDialog.cpp
@@ -113,9 +113,11 @@ PanLayoutDialog::PanLayoutDialog(int maxPans, const QString& currentLayout,
     theme::setContainer(this, QStringLiteral("dialog/panLayout"));
     AetherSDR::ThemeManager::instance().applyStyleSheet(this, "QDialog { background: {{color.background.0}}; }"
                   "QLabel { color: {{color.text.primary}}; }");
-    // Fixed-size grid of thumbnails — body content is the same regardless of
-    // chrome state; the dialog wraps it.  Modal dialog; no geometry persist.
-    bodyWidget()->setFixedSize(560, 502);
+    // Fixed body width keeps the 3-column thumbnail grid centred; the height is
+    // left to the layout so the Cancel button always sits below the grid rather
+    // than being clipped up over the bottom thumbnail row when the grid is tall.
+    // Modal dialog; no geometry persist.
+    bodyWidget()->setFixedWidth(560);
     buildUI(maxPans, currentLayout);
 }
 

--- a/tests/pan_layout_dialog_size_test.cpp
+++ b/tests/pan_layout_dialog_size_test.cpp
@@ -1,0 +1,99 @@
+// Standalone test harness guarding the "New Panadapter" layout picker
+// (PanLayoutDialog) against the Cancel button overlapping the thumbnail grid.
+//
+// The dialog used to pin its body to a fixed 560x502, but the 3-column grid of
+// twelve 115 px-tall layout buttons plus the title and Cancel button needs far
+// more than 502 px of vertical room. The fixed height clipped the layout, so
+// the bottom-anchored Cancel button was drawn up over the last row of
+// thumbnails. The fix lets the body height follow its content.
+//
+// Invariant under test: the Cancel button sits entirely below every layout
+// thumbnail button (no vertical overlap), and stays within the dialog bounds.
+//
+// Build: CMake target `pan_layout_dialog_size_test`. Exit 0 = pass.
+
+#include "gui/PanLayoutDialog.h"
+
+#include <QApplication>
+#include <QPushButton>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+// Top-left y of a descendant widget expressed in the dialog's own coordinates.
+int topInRoot(QWidget* w, QWidget* root)
+{
+    return w->mapTo(root, QPoint(0, 0)).y();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    std::printf("PanLayoutDialog Cancel-button overlap test harness\n\n");
+
+    // maxPans = 8 enables every layout (the tallest grid — worst case).
+    PanLayoutDialog dialog(/*maxPans*/ 8, /*currentLayout*/ "1");
+    dialog.show();
+    QApplication::processEvents();
+
+    QPushButton* cancel = nullptr;
+    std::vector<QPushButton*> thumbs;
+    for (QPushButton* b : dialog.findChildren<QPushButton*>()) {
+        if (b->text() == QStringLiteral("Cancel")) {
+            cancel = b;
+        } else if (b->text().isEmpty() && b->height() >= 100) {
+            // The layout thumbnails are empty-text buttons fixed at 130x115;
+            // the frameless title bar's window buttons are shorter, so the
+            // height filter keeps them out of the grid set.
+            thumbs.push_back(b);
+        }
+    }
+
+    report("Cancel button exists", cancel != nullptr);
+    report("twelve layout thumbnail buttons present", thumbs.size() == 12,
+           "count=" + std::to_string(thumbs.size()));
+    if (!cancel || thumbs.empty()) {
+        dialog.hide();
+        return 1;
+    }
+
+    // Bottom edge of the lowest thumbnail button, in dialog coordinates.
+    int gridBottom = 0;
+    for (QPushButton* b : thumbs)
+        gridBottom = std::max(gridBottom, topInRoot(b, &dialog) + b->height());
+
+    const int cancelTop = topInRoot(cancel, &dialog);
+    const int cancelBottom = cancelTop + cancel->height();
+
+    report("Cancel button starts below the thumbnail grid (no overlap)",
+           cancelTop >= gridBottom,
+           "cancelTop=" + std::to_string(cancelTop)
+               + " gridBottom=" + std::to_string(gridBottom));
+
+    report("Cancel button stays within the dialog bounds",
+           cancelBottom <= dialog.height(),
+           "cancelBottom=" + std::to_string(cancelBottom)
+               + " dialogH=" + std::to_string(dialog.height()));
+
+    dialog.hide();
+
+    std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

In the **New Panadapter** window (the layout picker opened from the *Add Panadapter* button), the **Cancel** button at the bottom overlapped the layout thumbnail grid — it was drawn on top of the bottom row of layouts and their labels.

## Root cause

`PanLayoutDialog` pinned its body to a **fixed 560×502**:

```cpp
bodyWidget()->setFixedSize(560, 502);
```

But the content — the title, a 3-column grid of **twelve 115 px-tall** layout thumbnails (4 rows), and the Cancel button — needs ~575 px of vertical room. The 502 px floor clipped the layout, so the bottom-anchored Cancel button was pushed up over the last thumbnail row.

## Fix

Keep the body **width** fixed at 560 (so the grid stays centred) but let the **height follow the content**:

```cpp
bodyWidget()->setFixedWidth(560);
```

The Cancel button now sits 8 px below the grid — the layout's own spacing — instead of overlapping it.

Also in this PR:
- The *Add Panadapter* toolbar label gets an `objectName`/`accessibleName` (`addPanadapterButton` / "Add Panadapter") so the agent automation bridge and a11y tooling can target it.
- **New standalone regression test** `pan_layout_dialog_size_test` (mirrors `flex_control_dialog_size_test`, #3662): asserts the Cancel button sits below the thumbnail grid and within the dialog bounds. It **fails** on the old fixed-height code (6 px overlap) and **passes** after the fix.

## Proof (agent automation bridge)

Driven live against a **FLEX-8400M** — opened the dialog via the bridge (`drag addPanadapterButton`), then read widget geometry from `dumpTree` and grabbed the window:

| | dialog height | Cancel top vs grid bottom |
|---|---|---|
| **Before** | 502 px | 692 < 698 → **6 px overlap** |
| **After** | 557 px | 720 > 712 → **8 px gap** |

### Before
![before](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/newpan-close-button-overlap/newpan-cancel-before.png)

### After
![after](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/newpan-close-button-overlap/newpan-cancel-after.png)

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
