### PR TITLE
[codex] Fix Kiwi 3D trace alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1937,6 +1937,14 @@ target_include_directories(kiwi_sdr_trace_math_test PRIVATE src)
 target_link_libraries(kiwi_sdr_trace_math_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_trace_math_test COMMAND kiwi_sdr_trace_math_test)
 
+add_executable(dss_renderer_test
+    tests/dss_renderer_test.cpp
+    src/gui/DssRenderer.cpp
+)
+target_include_directories(dss_renderer_test PRIVATE src)
+target_link_libraries(dss_renderer_test PRIVATE Qt6::Core Qt6::Gui)
+add_test(NAME dss_renderer_test COMMAND dss_renderer_test)
+
 add_executable(kiwi_sdr_redirect_policy_test
     tests/kiwi_sdr_redirect_policy_test.cpp
     src/core/KiwiSdrRedirectPolicy.cpp

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -40,6 +40,102 @@ inline QColor lerpColor(const QColor& c, const QColor& t, double f)
                   chan(c.blue()  + (t.blue()  - c.blue())  * f));
 }
 
+float rowSample(const std::array<float, DssRenderer::kCols>& row,
+                double srcLeft, double srcRight, double srcCenter,
+                float fallback)
+{
+    if (srcRight <= 0.0 || srcLeft >= DssRenderer::kCols) {
+        return fallback;
+    }
+
+    const double clampedLeft =
+        std::clamp(srcLeft, 0.0, static_cast<double>(DssRenderer::kCols));
+    const double clampedRight =
+        std::clamp(srcRight, 0.0, static_cast<double>(DssRenderer::kCols));
+    if (clampedRight <= clampedLeft) {
+        return fallback;
+    }
+
+    if (clampedRight - clampedLeft <= 1.0) {
+        const double clampedCenter =
+            std::clamp(srcCenter, 0.0, static_cast<double>(DssRenderer::kCols - 1));
+        const int left = std::clamp(static_cast<int>(std::floor(clampedCenter)),
+                                    0, DssRenderer::kCols - 1);
+        const int right = std::min(left + 1, DssRenderer::kCols - 1);
+        const float leftValue = std::isfinite(row[left]) ? row[left] : fallback;
+        const float rightValue = std::isfinite(row[right]) ? row[right] : leftValue;
+        const float frac = static_cast<float>(clampedCenter - left);
+        return leftValue + frac * (rightValue - leftValue);
+    }
+
+    const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)),
+                                 0, DssRenderer::kCols - 1);
+    const int last = std::clamp(static_cast<int>(std::ceil(clampedRight)) - 1,
+                                0, DssRenderer::kCols - 1);
+    double weightedSum = 0.0;
+    double totalWeight = 0.0;
+    for (int i = first; i <= last; ++i) {
+        if (!std::isfinite(row[i])) {
+            continue;
+        }
+        const double binLeft = static_cast<double>(i);
+        const double binRight = binLeft + 1.0;
+        const double weight =
+            std::max(0.0, std::min(clampedRight, binRight)
+                - std::max(clampedLeft, binLeft));
+        if (weight <= 0.0) {
+            continue;
+        }
+        weightedSum += row[i] * weight;
+        totalWeight += weight;
+    }
+    return totalWeight > 0.0
+        ? static_cast<float>(weightedSum / totalWeight)
+        : fallback;
+}
+
+std::array<float, DssRenderer::kCols> reprojectRow(
+    const std::array<float, DssRenderer::kCols>& row,
+    double oldCenterMhz,
+    double oldBandwidthMhz,
+    double newCenterMhz,
+    double newBandwidthMhz,
+    float fallback)
+{
+    std::array<float, DssRenderer::kCols> remapped;
+    remapped.fill(fallback);
+    if (oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
+        return remapped;
+    }
+
+    const double oldStartMhz = oldCenterMhz - oldBandwidthMhz * 0.5;
+    const double oldEndMhz = oldCenterMhz + oldBandwidthMhz * 0.5;
+    const double newStartMhz = newCenterMhz - newBandwidthMhz * 0.5;
+    const double srcWidthBins = newBandwidthMhz / oldBandwidthMhz;
+    for (int dst = 0; dst < DssRenderer::kCols; ++dst) {
+        const double dstFrac =
+            (static_cast<double>(dst) + 0.5) / DssRenderer::kCols;
+        const double freqMhz = newStartMhz + dstFrac * newBandwidthMhz;
+        if (freqMhz < oldStartMhz || freqMhz > oldEndMhz) {
+            continue;
+        }
+
+        const double srcCenter =
+            ((freqMhz - oldStartMhz) / oldBandwidthMhz)
+                * DssRenderer::kCols - 0.5;
+        if (srcCenter < -0.5
+            || srcCenter > static_cast<double>(DssRenderer::kCols) - 0.5) {
+            continue;
+        }
+        remapped[dst] = rowSample(row,
+                                  srcCenter - srcWidthBins * 0.5,
+                                  srcCenter + srcWidthBins * 0.5,
+                                  srcCenter,
+                                  fallback);
+    }
+    return remapped;
+}
+
 } // namespace
 
 void DssRenderer::clear()
@@ -66,20 +162,26 @@ void DssRenderer::pushRow(const QVector<float>& binsDbm)
         nr.fill(-200.0f);
     } else {
         std::array<float, kCols> raw;
-        const double step = static_cast<double>(n) / kCols;
-        for (int c = 0; c < kCols; ++c) {
-            // Peak-preserving downsample: take the strongest bin in the source
-            // span so signals survive as ridges. Upsampling (n < kCols)
-            // collapses the span to a single source bin.
-            int i0 = static_cast<int>(std::floor(c * step));
-            int i1 = static_cast<int>(std::ceil((c + 1) * step));
-            i0 = std::clamp(i0, 0, n - 1);
-            i1 = std::clamp(i1, i0 + 1, n);
-            float mx = binsDbm[i0];
-            for (int i = i0 + 1; i < i1; ++i) {
-                mx = std::max(mx, binsDbm[i]);
+        if (n == kCols) {
+            for (int c = 0; c < kCols; ++c) {
+                raw[c] = binsDbm[c];
             }
-            raw[c] = mx;
+        } else {
+            const double step = static_cast<double>(n) / kCols;
+            for (int c = 0; c < kCols; ++c) {
+                // Peak-preserving downsample: take the strongest bin in the source
+                // span so signals survive as ridges. Upsampling (n < kCols)
+                // collapses the span to a single source bin.
+                int i0 = static_cast<int>(std::floor(c * step));
+                int i1 = static_cast<int>(std::ceil((c + 1) * step));
+                i0 = std::clamp(i0, 0, n - 1);
+                i1 = std::clamp(i1, i0 + 1, n);
+                float mx = binsDbm[i0];
+                for (int i = i0 + 1; i < i1; ++i) {
+                    mx = std::max(mx, binsDbm[i]);
+                }
+                raw[c] = mx;
+            }
         }
 
         // Temporal median-of-3 impulse rejection. A strong broadband
@@ -125,6 +227,41 @@ void DssRenderer::pushRow(const QVector<float>& binsDbm)
     m_rows[m_head] = nr;
     m_count = std::min(m_count + 1, kRows);
     m_dirty = true;
+    ++m_rowGeneration;
+}
+
+void DssRenderer::reprojectFrequencyFrame(double oldCenterMhz,
+                                          double oldBandwidthMhz,
+                                          double newCenterMhz,
+                                          double newBandwidthMhz,
+                                          float fallbackDbm)
+{
+    if (m_count <= 0 || oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
+        return;
+    }
+
+    for (int age = 0; age < m_count; ++age) {
+        const int ring = (m_head + age) % kRows;
+        m_rows[ring] = reprojectRow(m_rows[ring],
+                                    oldCenterMhz, oldBandwidthMhz,
+                                    newCenterMhz, newBandwidthMhz,
+                                    fallbackDbm);
+    }
+    if (m_rawHistCount >= 1) {
+        m_rawPrev1 = reprojectRow(m_rawPrev1,
+                                  oldCenterMhz, oldBandwidthMhz,
+                                  newCenterMhz, newBandwidthMhz,
+                                  fallbackDbm);
+    }
+    if (m_rawHistCount >= 2) {
+        m_rawPrev2 = reprojectRow(m_rawPrev2,
+                                  oldCenterMhz, oldBandwidthMhz,
+                                  newCenterMhz, newBandwidthMhz,
+                                  fallbackDbm);
+    }
+
+    m_dirty = true;
+    ++m_rowGeneration;
 }
 
 const QImage& DssRenderer::image(const QSize& px, int scaleStripPx,

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -44,6 +44,9 @@ public:
     // Push one freshly-decoded FFT row (any bin count, dBm). Peak-preserving
     // downsample to kCols and store it as the newest (front) trace.
     void pushRow(const QVector<float>& binsDbm);
+    void reprojectFrequencyFrame(double oldCenterMhz, double oldBandwidthMhz,
+                                 double newCenterMhz, double newBandwidthMhz,
+                                 float fallbackDbm);
 
     // Return the cached surface sized to px. The plot region (everything above
     // the bottom scaleStripPx) is painted opaque over bgFill; the scale strip
@@ -76,6 +79,7 @@ public:
     int rowCount() const { return m_count; }     // valid rows (0..kRows)
     int headRing() const { return m_head; }       // ring index of the newest row
     const float* rowDataRing(int ringIndex) const { return m_rows[ringIndex].data(); }
+    quint64 rowGeneration() const { return m_rowGeneration; }
 
     // Increments on every cache rebuild — lets the GPU path upload the texture
     // only when the surface actually changed.
@@ -95,6 +99,7 @@ private:
     int     m_count = 0;         // number of valid rows (0..kRows)
     bool    m_dirty = true;
     quint64 m_generation = 0;    // bumped on each rebuild
+    quint64 m_rowGeneration = 0; // bumped whenever stored row contents change
 
     // Last two RAW (pre-smoothing) resampled rows, for temporal median-of-3
     // impulse rejection of broadband interference bursts.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -68,6 +68,23 @@ QSoundEffect* SpectrumWidget::s_starstruckSound = nullptr;
 
 namespace {
 
+constexpr int kDssMaxIncrementalUploadRows = 8;
+
+constexpr int dssFillVerticesPerRow()
+{
+    return (DssRenderer::kCols - 1) * 6;
+}
+
+constexpr int dssLineVerticesPerRow()
+{
+    return (DssRenderer::kCols - 1) * 2;
+}
+
+void appendDssVertex(QVector<float>& vertices, float u, float v, float edge)
+{
+    vertices << u << v << edge;
+}
+
 struct VfoPos {
     int sliceId;
     int x;
@@ -3423,6 +3440,13 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
         }
         reprojectWaterfall(oldCenterMhz, oldBandwidthMhz,
                            newCenterMhz, newBandwidthMhz);
+        const float dssFallback = kiwiStream
+            ? kKiwiSdrWaterfallMinDbm
+            : m_refLevel - m_dynamicRange;
+        m_dss.reprojectFrequencyFrame(oldCenterMhz, oldBandwidthMhz,
+                                      newCenterMhz, newBandwidthMhz,
+                                      dssFallback);
+        resetDssUploadState();
     };
 
     // #3668 (KiwiSDR integration) replaced #3578's single per-pan reproject with
@@ -3519,6 +3543,8 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_kiwiSdrAutoRangeValid = false;
     m_kiwiSdrFftTraceFloorDbm = -1000.0f;
     m_kiwiSdrFftTraceFloorValid = false;
+    m_dss.clear();
+    resetDssUploadState();
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
@@ -3608,6 +3634,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
     updated.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
     updated.kiwiLastWaterfallFrameValid = m_kiwiSdrLastWaterfallFrameValid;
+    updated.dss = std::move(m_dss);
     updated.kiwiAutoFloorDbm = m_kiwiSdrAutoFloorDbm;
     updated.kiwiAutoCeilDbm = m_kiwiSdrAutoCeilDbm;
     updated.kiwiAutoRangeValid = m_kiwiSdrAutoRangeValid;
@@ -3669,11 +3696,13 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_kiwiSdrLastWaterfallCenterMhz = restored.kiwiLastWaterfallCenterMhz;
     m_kiwiSdrLastWaterfallBandwidthMhz = restored.kiwiLastWaterfallBandwidthMhz;
     m_kiwiSdrLastWaterfallFrameValid = restored.kiwiLastWaterfallFrameValid;
+    m_dss = std::move(restored.dss);
     m_kiwiSdrAutoFloorDbm = restored.kiwiAutoFloorDbm;
     m_kiwiSdrAutoCeilDbm = restored.kiwiAutoCeilDbm;
     m_kiwiSdrAutoRangeValid = restored.kiwiAutoRangeValid;
     m_kiwiSdrFftTraceFloorDbm = restored.kiwiFftTraceFloorDbm;
     m_kiwiSdrFftTraceFloorValid = restored.kiwiFftTraceFloorValid;
+    resetDssUploadState();
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
@@ -4165,8 +4194,11 @@ void SpectrumWidget::reprojectWaterfall(double oldCenterMhz, double oldBandwidth
 bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthMhz,
                                        double newCenterMhz, double newBandwidthMhz)
 {
+    const bool hadSpectrum = !m_bins.isEmpty() || !m_smoothed.isEmpty()
+        || !m_kiwiSdrFftTrace.isEmpty();
     if (oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
-        return false;
+        m_resetFftSmoothingOnNextFrame = m_resetFftSmoothingOnNextFrame || hadSpectrum;
+        return hadSpectrum;
     }
 
     const double oldStartMhz = oldCenterMhz - oldBandwidthMhz / 2.0;
@@ -4176,7 +4208,11 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
     const double overlapStartMhz = std::max(oldStartMhz, newStartMhz);
     const double overlapEndMhz = std::min(oldEndMhz, newEndMhz);
     if (overlapEndMhz <= overlapStartMhz) {
-        return false;
+        // Large gesture jumps can have no overlap with the previous spectrum
+        // frame. Keep the last trace visible until the next real FFT row instead
+        // of flashing the line off for one frame.
+        m_resetFftSmoothingOnNextFrame = m_resetFftSmoothingOnNextFrame || hadSpectrum;
+        return hadSpectrum;
     }
 
     auto reprojectBins = [&](QVector<float>& bins, float fallback) {
@@ -5382,10 +5418,6 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
         return;
     }
 
-    // Feed the 3D rolling history from the KiwiSDR FFT rows too (the Flex path
-    // feeds from updateSpectrum), so the stacked-trace surface works on KiwiSDR.
-    m_dss.pushRow(binsDbm);
-
     const bool visibleStream = beginWaterfallStreamWrite(true);
     auto restoreStream = qScopeGuard([&] {
         endWaterfallStreamWrite(true, visibleStream);
@@ -5433,6 +5465,17 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     }
 
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
+    if (m_kiwiSdrWaterfallActive && rowHasUsableTraceCoverage) {
+        // 3DSS rows must be in the visible panadapter frequency frame. Raw Kiwi
+        // rows often span a wider quantized server window, so feeding them
+        // directly makes the stacked trace drift away from the remapped waterfall.
+        const QVector<float> kiwiDssTrace = KiwiSdrTraceMath::mapRowToTrace(
+            smoothedBins, DssRenderer::kCols, rowCenterMhz, rowBandwidthMhz,
+            m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
+        if (!kiwiDssTrace.isEmpty()) {
+            m_dss.pushRow(kiwiDssTrace);
+        }
+    }
     if (m_kiwiSdrWaterfallActive && destWidth > 0 && rowHasUsableTraceCoverage) {
         // The waterfall preserves narrow peaks, but the FFT line must not rise
         // just because a pan/zoom step changes the sampled row window. Average
@@ -7563,6 +7606,17 @@ const QImage& SpectrumWidget::buildDssImage(const QSize& px, int scaleStripPx)
                        palette, dssPaletteToken(), m_bgFillColor);
 }
 
+void SpectrumWidget::resetDssUploadState()
+{
+    m_dss.invalidate();
+#ifdef AETHER_GPU_SPECTRUM
+    m_dssTexNeedsUpload = true;
+    m_dssLastUploadedGen = ~0ull;
+    m_dssMeshHeadUploaded = -1;
+    m_dssMeshRowGenUploaded = ~0ull;
+#endif
+}
+
 QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
 {
     // Kiwi direct W/F bytes are decoded to the server's wrapped negative dB
@@ -8073,8 +8127,8 @@ void SpectrumWidget::initDssMeshPipeline()
 
     const int cols = m_dss.cols();
     const int rows = m_dss.rows();
-    const int fillVerts = rows * cols * 2;  // ridge + floor per (col,row)
-    const int lineVerts = rows * cols;      // ridge-only outline
+    const int fillVerts = rows * dssFillVerticesPerRow();
+    const int lineVerts = rows * dssLineVerticesPerRow();
 
     m_dssMeshVbo = r->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
                                 fillVerts * 3 * sizeof(float));
@@ -8124,15 +8178,15 @@ void SpectrumWidget::initDssMeshPipeline()
     layout.setBindings({{3 * sizeof(float)}});
     layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});  // u, v, edge
 
-    // Fill pipeline — opaque triangle strips (occlusion via back-to-front order).
+    // Fill pipeline — opaque triangle lists (occlusion via back-to-front order).
     m_dssMeshFillPipeline = r->newGraphicsPipeline();
     m_dssMeshFillPipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
     m_dssMeshFillPipeline->setVertexInputLayout(layout);
-    m_dssMeshFillPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    m_dssMeshFillPipeline->setTopology(QRhiGraphicsPipeline::Triangles);
     m_dssMeshFillPipeline->setShaderResourceBindings(m_dssMeshSrb);
     m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
 
-    // Outline pipeline — alpha-blended line strips (the dim trace line).
+    // Outline pipeline — alpha-blended line segments (the dim trace line).
     QRhiGraphicsPipeline::TargetBlend lblend;
     lblend.enable = true;
     lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
@@ -8142,7 +8196,7 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshLinePipeline = r->newGraphicsPipeline();
     m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
     m_dssMeshLinePipeline->setVertexInputLayout(layout);
-    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::LineStrip);
+    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::Lines);
     m_dssMeshLinePipeline->setShaderResourceBindings(m_dssMeshSrb);
     m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
     m_dssMeshLinePipeline->setTargetBlends({lblend});
@@ -8153,6 +8207,7 @@ void SpectrumWidget::initDssMeshPipeline()
     }
 
     m_dssMeshHeadUploaded = -1;
+    m_dssMeshRowGenUploaded = ~0ull;
     m_dssLutToken = ~0ull;
     m_dssMeshReady = true;
     qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created" << cols << "x" << rows;
@@ -8189,15 +8244,21 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         const int rows = m_dss.rows();
         QVector<float> fill;
         QVector<float> line;
-        fill.reserve(rows * cols * 2 * 3);
-        line.reserve(rows * cols * 3);
-        for (int rr = 0; rr < rows; ++rr) {
+        fill.reserve(rows * dssFillVerticesPerRow() * 3);
+        line.reserve(rows * dssLineVerticesPerRow() * 3);
+        for (int rr = rows - 1; rr >= 0; --rr) {
             const float v = static_cast<float>(rr) / rows;   // 0 front .. ~1 back
-            for (int cc = 0; cc < cols; ++cc) {
-                const float u = (cols > 1) ? static_cast<float>(cc) / (cols - 1) : 0.0f;
-                fill << u << v << 0.0f;    // ridge vertex
-                fill << u << v << 1.0f;    // floor vertex (down to plot bottom)
-                line << u << v << -1.0f;   // outline vertex
+            for (int cc = 0; cc + 1 < cols; ++cc) {
+                const float u0 = static_cast<float>(cc) / (cols - 1);
+                const float u1 = static_cast<float>(cc + 1) / (cols - 1);
+                appendDssVertex(fill, u0, v, 0.0f);   // ridge
+                appendDssVertex(fill, u0, v, 1.0f);   // floor
+                appendDssVertex(fill, u1, v, 0.0f);   // next ridge
+                appendDssVertex(fill, u1, v, 0.0f);
+                appendDssVertex(fill, u0, v, 1.0f);
+                appendDssVertex(fill, u1, v, 1.0f);   // next floor
+                appendDssVertex(line, u0, v, -1.0f);
+                appendDssVertex(line, u1, v, -1.0f);
             }
         }
         batch->uploadStaticBuffer(m_dssMeshVbo, fill.constData());
@@ -8667,45 +8728,72 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             const int rows = m_dss.rows();
             const int head = m_dss.headRing();
             const int valid = m_dss.rowCount();
+            const quint64 rowGeneration = m_dss.rowGeneration();
             // Catch-up upload: pushRow runs per FFT block (often faster than
-            // vsync), so the ring head can advance by >1 between frames. Upload
-            // every new ring slot from the last-uploaded head up to the current
-            // head — uploading only the newest would draw the skipped rows stale.
-            if (valid > 0 && head != m_dssMeshHeadUploaded) {
+            // vsync), so the ring head can advance by >1 between frames. Small
+            // catch-ups upload only changed ring slots; large catch-ups refresh the
+            // full height texture in one entry to avoid many per-row uploads right
+            // when the GUI is already behind.
+            if (valid > 0 && rowGeneration != m_dssMeshRowGenUploaded) {
                 static_assert(DssRenderer::kCols <= 65536,
                               "qfloat16 row fits a texture width");
-                int newRows = (m_dssMeshHeadUploaded < 0)
+                const quint64 rowsSinceUpload =
+                    (m_dssMeshRowGenUploaded == ~0ull
+                     || rowGeneration < m_dssMeshRowGenUploaded)
+                    ? static_cast<quint64>(valid)
+                    : rowGeneration - m_dssMeshRowGenUploaded;
+                int newRows = (m_dssMeshHeadUploaded < 0
+                               || rowsSinceUpload >= static_cast<quint64>(rows))
                     ? valid
-                    : (m_dssMeshHeadUploaded - head + rows) % rows;
+                    : static_cast<int>(rowsSinceUpload);
                 newRows = std::clamp(newRows, 0, valid);
-                QVarLengthArray<QRhiTextureUploadEntry, DssRenderer::kRows> entries;
-                m_dssRowScratch.resize(cols * int(sizeof(qfloat16)));
-                for (int n = 0; n < newRows; ++n) {
-                    const int ring = (head + n) % rows;  // head..head+newRows-1
-                    const float* srcRow = m_dss.rowDataRing(ring);
-                    // Reuse the member buffer: setData() holds a COW ref, so the
-                    // common single-new-row frame reuses it with no allocation,
-                    // while a multi-row catch-up detaches per row (still correct).
-                    qfloat16* dst = reinterpret_cast<qfloat16*>(m_dssRowScratch.data());
-                    for (int c = 0; c < cols; ++c) {
-                        dst[c] = qfloat16(srcRow[c]);
+                if (newRows > kDssMaxIncrementalUploadRows) {
+                    const int rowBytes = cols * int(sizeof(qfloat16));
+                    m_dssTextureScratch.resize(rows * rowBytes);
+                    char* textureData = m_dssTextureScratch.data();
+                    for (int ring = 0; ring < rows; ++ring) {
+                        qfloat16* dst = reinterpret_cast<qfloat16*>(textureData + ring * rowBytes);
+                        const float* srcRow = m_dss.rowDataRing(ring);
+                        for (int c = 0; c < cols; ++c) {
+                            dst[c] = qfloat16(srcRow[c]);
+                        }
                     }
-                    QRhiTextureSubresourceUploadDescription rowDesc;
-                    rowDesc.setData(m_dssRowScratch);  // descriptor keeps the bytes alive
-                    rowDesc.setSourceSize(QSize(cols, 1));
-                    rowDesc.setDestinationTopLeft(QPoint(0, ring));
-                    entries.append(QRhiTextureUploadEntry(0, 0, rowDesc));
-                }
-                if (!entries.isEmpty()) {
-                    QRhiTextureUploadDescription desc;
-                    desc.setEntries(entries.cbegin(), entries.cend());
-                    batch->uploadTexture(m_dssHeightTex, desc);
+                    QRhiTextureSubresourceUploadDescription fullDesc;
+                    fullDesc.setData(m_dssTextureScratch);
+                    fullDesc.setSourceSize(QSize(cols, rows));
+                    batch->uploadTexture(m_dssHeightTex, QRhiTextureUploadEntry(0, 0, fullDesc));
                     if (perfEnabled) {
                         PerfTelemetry::instance().recordGpuUpload(
                             PerfTelemetry::GpuUploadKind::Overlay);
                     }
+                } else {
+                    QVarLengthArray<QRhiTextureUploadEntry, kDssMaxIncrementalUploadRows> entries;
+                    m_dssRowScratch.resize(cols * int(sizeof(qfloat16)));
+                    for (int n = 0; n < newRows; ++n) {
+                        const int ring = (head + n) % rows;  // head..head+newRows-1
+                        const float* srcRow = m_dss.rowDataRing(ring);
+                        qfloat16* dst = reinterpret_cast<qfloat16*>(m_dssRowScratch.data());
+                        for (int c = 0; c < cols; ++c) {
+                            dst[c] = qfloat16(srcRow[c]);
+                        }
+                        QRhiTextureSubresourceUploadDescription rowDesc;
+                        rowDesc.setData(m_dssRowScratch);  // descriptor keeps the bytes alive
+                        rowDesc.setSourceSize(QSize(cols, 1));
+                        rowDesc.setDestinationTopLeft(QPoint(0, ring));
+                        entries.append(QRhiTextureUploadEntry(0, 0, rowDesc));
+                    }
+                    if (!entries.isEmpty()) {
+                        QRhiTextureUploadDescription desc;
+                        desc.setEntries(entries.cbegin(), entries.cend());
+                        batch->uploadTexture(m_dssHeightTex, desc);
+                        if (perfEnabled) {
+                            PerfTelemetry::instance().recordGpuUpload(
+                                PerfTelemetry::GpuUploadKind::Overlay);
+                        }
+                    }
                 }
                 m_dssMeshHeadUploaded = head;
+                m_dssMeshRowGenUploaded = rowGeneration;
             }
 
             // rowOffset carries a half-texel so the shader (texY = fract(rowOffset
@@ -9022,28 +9110,32 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                               static_cast<float>(h - specRect.bottom() - 1) * dpr,
                               static_cast<float>(specRect.width()) * dpr,
                               static_cast<float>(specRect.height()) * dpr);
-        const int cols = m_dss.cols();
         const int drawnRows = m_dss.rowCount();
 
-        // Opaque fill curtains, back (oldest) -> front (newest) for occlusion.
-        cb->setGraphicsPipeline(m_dssMeshFillPipeline);
-        cb->setShaderResources(m_dssMeshSrb);
-        cb->setViewport(vp);
-        {
-            const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshVbo, 0);
-            cb->setVertexInput(0, 1, &vbuf);
-            for (int rr = drawnRows - 1; rr >= 0; --rr)
-                cb->draw(2 * cols, 1, rr * 2 * cols, 0);
-        }
-        // Dim per-row trace outline on top.
-        cb->setGraphicsPipeline(m_dssMeshLinePipeline);
-        cb->setShaderResources(m_dssMeshSrb);
-        cb->setViewport(vp);
-        {
-            const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);
-            cb->setVertexInput(0, 1, &vbuf);
-            for (int rr = drawnRows - 1; rr >= 0; --rr)
-                cb->draw(cols, 1, rr * cols, 0);
+        if (drawnRows > 0) {
+            // Opaque fill curtains, back (oldest) -> front (newest) for occlusion.
+            // The static VBO is already ordered back-to-front for all rows; drawing
+            // only the valid suffix keeps startup frames short while the history fills.
+            const int skippedRows = m_dss.rows() - drawnRows;
+            cb->setGraphicsPipeline(m_dssMeshFillPipeline);
+            cb->setShaderResources(m_dssMeshSrb);
+            cb->setViewport(vp);
+            {
+                const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshVbo, 0);
+                cb->setVertexInput(0, 1, &vbuf);
+                cb->draw(drawnRows * dssFillVerticesPerRow(), 1,
+                         skippedRows * dssFillVerticesPerRow(), 0);
+            }
+            // Dim per-row trace outline on top.
+            cb->setGraphicsPipeline(m_dssMeshLinePipeline);
+            cb->setShaderResources(m_dssMeshSrb);
+            cb->setViewport(vp);
+            {
+                const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);
+                cb->setVertexInput(0, 1, &vbuf);
+                cb->draw(drawnRows * dssLineVerticesPerRow(), 1,
+                         skippedRows * dssLineVerticesPerRow(), 0);
+            }
         }
     } else if (is3D && m_ovPipeline && m_dssSrb && m_dssTexW > 0) {
         // Cached-image fallback quad, stretched to the specRect viewport.
@@ -9217,6 +9309,7 @@ void SpectrumWidget::releaseResources()
     delete m_dssPaletteSampler;   m_dssPaletteSampler = nullptr;
     m_dssMeshReady = false;
     m_dssMeshHeadUploaded = -1;
+    m_dssMeshRowGenUploaded = ~0ull;
     m_dssLutToken = ~0ull;
 
     delete m_fftLinePipeline; m_fftLinePipeline = nullptr;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -728,6 +728,7 @@ private:
         double kiwiLastWaterfallCenterMhz{0.0};
         double kiwiLastWaterfallBandwidthMhz{0.0};
         bool kiwiLastWaterfallFrameValid{false};
+        DssRenderer dss;
         float kiwiAutoFloorDbm{-130.0f};
         float kiwiAutoCeilDbm{-50.0f};
         bool kiwiAutoRangeValid{false};
@@ -846,6 +847,7 @@ private:
     // 3DSS — rebuild/return the cached perspective surface for the given pixel
     // size (scaleStripPx = transparent frequency-scale strip at the bottom).
     const QImage& buildDssImage(const QSize& px, int scaleStripPx);
+    void resetDssUploadState();
     // Token folding the dbmToRgb() palette inputs so the 3DSS cache rebuilds
     // when the colour mapping (scheme/gain/floor) changes.
     quint64 dssPaletteToken() const;
@@ -1417,11 +1419,11 @@ private:
     // feeds a ring-buffered R16F height texture; a static perspective grid samples
     // it in dss_mesh.vert. Geometry never rebuilds, so pan/zoom are free. Falls
     // back to the cached-image quad above when the pipeline can't be created.
-    QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // TriangleStrip, opaque
-    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // LineStrip, alpha (outline)
+    QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // Triangles, opaque
+    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // Lines, alpha (outline)
     QRhiShaderResourceBindings* m_dssMeshSrb{nullptr};
-    QRhiBuffer* m_dssMeshVbo{nullptr};       // curtain verts (ridge+floor), static
-    QRhiBuffer* m_dssMeshLineVbo{nullptr};   // ridge-only verts (outline), static
+    QRhiBuffer* m_dssMeshVbo{nullptr};       // batched curtain triangles, static
+    QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge line segments, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
     // ubo[] writer in renderGpuFrame(). 8 scalars + texCols + 3 pad + vec4 bgFill.
@@ -1432,8 +1434,10 @@ private:
     QRhiSampler* m_dssPaletteSampler{nullptr};
     bool m_dssMeshReady{false};
     int  m_dssMeshHeadUploaded{-1};          // ring head last uploaded to heightTex
+    quint64 m_dssMeshRowGenUploaded{~0ull};  // DssRenderer rowGeneration uploaded
     quint64 m_dssLutToken{~0ull};            // token of the palette LUT last baked
     QByteArray m_dssRowScratch;              // reused qfloat16 row buffer (mesh upload)
+    QByteArray m_dssTextureScratch;          // reused qfloat16 full texture buffer
 
     void initDssMeshPipeline();
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -1,0 +1,58 @@
+#include "gui/DssRenderer.h"
+
+#include <QVector>
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "dss_renderer_test: %s\n", message);
+    return 1;
+}
+
+int strongestBin(const DssRenderer& renderer)
+{
+    const float* row = renderer.rowDataRing(renderer.headRing());
+    int strongest = 0;
+    for (int i = 1; i < renderer.cols(); ++i) {
+        if (row[i] > row[strongest]) {
+            strongest = i;
+        }
+    }
+    return strongest;
+}
+
+} // namespace
+
+int main()
+{
+    DssRenderer renderer;
+    QVector<float> bins(DssRenderer::kCols, -100.0f);
+    bins[DssRenderer::kCols / 2] = -40.0f;
+    renderer.pushRow(bins);
+
+    const int beforeCount = renderer.rowCount();
+    const quint64 beforeGeneration = renderer.rowGeneration();
+    renderer.reprojectFrequencyFrame(
+        14.0, 1.0,
+        14.25, 1.0,
+        -200.0f);
+
+    if (renderer.rowCount() != beforeCount) {
+        return fail("frequency reprojection must preserve DSS history rows");
+    }
+    if (renderer.rowGeneration() <= beforeGeneration) {
+        return fail("frequency reprojection must mark rows changed for GPU upload");
+    }
+
+    const int expectedBin = DssRenderer::kCols / 4;
+    const int actualBin = strongestBin(renderer);
+    if (std::abs(actualBin - expectedBin) > 3) {
+        return fail("frequency reprojection should shift history into the new viewport");
+    }
+
+    return 0;
+}

--- a/tests/kiwi_sdr_trace_math_test.cpp
+++ b/tests/kiwi_sdr_trace_math_test.cpp
@@ -80,6 +80,34 @@ int main()
         return fail("DC-edge Kiwi row should map into the visible trace");
     }
 
+    QVector<float> wideServerRow(1024, -100.0f);
+    const double serverLowMhz = 10.0;
+    const double serverBandwidthMhz = 10.0;
+    const double carrierMhz = 14.25;
+    const int sourceBin = static_cast<int>(
+        ((carrierMhz - serverLowMhz) / serverBandwidthMhz)
+        * wideServerRow.size());
+    wideServerRow[sourceBin] = -45.0f;
+    const QVector<float> dssMappedTrace = mapRowToTrace(
+        wideServerRow, 768,
+        15.0, serverBandwidthMhz,
+        14.0, 1.0,
+        kMinDbm);
+    if (dssMappedTrace.isEmpty()) {
+        return fail("3D-width Kiwi trace should map into the visible trace");
+    }
+    const int expectedViewportBin = static_cast<int>(
+        ((carrierMhz - 13.5) / 1.0) * dssMappedTrace.size());
+    int strongestBin = 0;
+    for (int i = 1; i < dssMappedTrace.size(); ++i) {
+        if (dssMappedTrace[i] > dssMappedTrace[strongestBin]) {
+            strongestBin = i;
+        }
+    }
+    if (std::abs(strongestBin - expectedViewportBin) > 2) {
+        return fail("3D-width Kiwi trace should align to the viewport frequency frame");
+    }
+
     QVector<float> adaptingTrace(128, -80.0f);
     TraceFloorState adaptingFloor{-100.0f, true};
     stabilizeTraceFloor(adaptingTrace, adaptingFloor, true, kMinDbm, kMaxDbm);


### PR DESCRIPTION
## Summary

Fixes the KiwiSDR 3D Stacked Trace FFT/waterfall synchronization issue by preserving and reprojecting DSS history when the visible frequency frame changes, instead of clearing or letting history remain in the old frame during pan/zoom. This keeps the 3D FFT trace aligned with the waterfall data on Kiwi receivers. Also keeps the FFT trace visible during no-overlap pan/zoom jumps to avoid a one-frame line flash, and reduces 3D trace render overhead by batching DSS mesh draw calls and bounding texture catch-up uploads. Adds focused renderer/math regression coverage for history-preserving reprojection and Kiwi viewport alignment.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The change includes deterministic renderer/math regression tests, focused local CTest coverage, a full local build, and automation-bridge smoke verification of the panadapter/3D trace UI surface.

## Test plan

- [x] Local build passes (`cmake --build build -j$(sysctl -n hw.ncpu)`)
- [x] Behavior verified on a real radio if applicable
  - User manually re-tested KiwiSDR pan/zoom after the patch and confirmed the reset/flash behavior is fixed.
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
  - In 3D Stacked Trace mode on a KiwiSDR receiver, pan left/right or zoom in/out; DSS history should remain visible/aligned with the waterfall and the FFT line should not flash blank.

Additional local validation:
- `ctest --test-dir build --output-on-failure -R 'dss_renderer_test|kiwi_sdr_trace_math_test|perf_telemetry_test'`
- `AETHER_AUTOMATION=1 AETHER_AUTOMATION_LABEL=codex-dss-regression QT_QPA_PLATFORM=offscreen ./build/AetherSDR.app/Contents/MacOS/AetherSDR`
- Automation bridge: `ping`, `get pans`, targeted `dumpTree`, `grab pan-visible 0`, `grab pan-visible 1`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
  - N/A: bug fix only, no new user-facing setting or workflow.
- [x] Security-sensitive changes reference a GHSA if applicable
  - N/A: rendering/receiver-display fix only.
