### PR TITLE
fix(build): embed Windows manifest via target_sources, not /MANIFEST:EMBED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1159,12 +1159,14 @@ elseif(WIN32)
         target_sources(AetherSDR PRIVATE "${WIN_RC}")
     endif()
     if(MSVC)
-        # /MANIFESTINPUT requires /MANIFEST:EMBED per MSVC docs.  Newer MSVC
-        # toolsets (VS 18.x / 14.50+) enforce this strictly with LNK1220;
-        # older ones were lenient.  Be explicit.
-        target_link_options(AetherSDR PRIVATE
-            "/MANIFEST:EMBED"
-            "/MANIFESTINPUT:${CMAKE_SOURCE_DIR}/packaging/windows/AetherSDR.exe.manifest")
+        # Embed the application manifest the CMake-native way: list it as a
+        # source so CMake hands it to its own vs_link_exe/mt.exe embed step.
+        # Passing /MANIFEST:EMBED + /MANIFESTINPUT directly fights that
+        # machinery — link.exe embeds inline and emits no side-car manifest,
+        # so CMake's mt.exe step runs with an empty --manifests list and dies
+        # with c10100a7 (cmake 4.x) / LNK1220 the other way (#3237).
+        target_sources(AetherSDR PRIVATE
+            "${CMAKE_SOURCE_DIR}/packaging/windows/AetherSDR.exe.manifest")
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ cmake --build build -j$(nproc)
 RADE-enabled builds use a vendored Opus snapshot, so no additional Opus download
 is required during configure or build.
 
+### Windows 11
+
+Prerequisites: Visual Studio 2022 Build Tools (MSVC), CMake, Ninja, and Qt 6.8+
+(msvc2022_64).
+
+```bat
+:: 1. Activate the MSVC environment
+"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+
+:: 2. Generate the single-precision FFTW import lib (needed by NR4/libspecbleach)
+powershell -File scripts\setup\setup-fftw.ps1
+
+:: 3. Configure and build
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --target AetherSDR
+```
+
 ### Qt 6.7+ for GPU Spectrum Rendering
 
 GPU-accelerated spectrum/waterfall rendering requires Qt 6.7 or greater. If your distribution ships with an older version (e.g., Ubuntu 24.04, Debian 12, or Mint 21–22 include Qt 6.4.2), the build system automatically disables GPU rendering and falls back to the CPU-based `QPainter` path. (Release binaries ship Qt 6.8.3 LTS; the 6.7 floor is the source-build minimum for QRhi.)

--- a/README.md
+++ b/README.md
@@ -173,18 +173,25 @@ is required during configure or build.
 
 ### Windows 11
 
-Prerequisites: Visual Studio 2022 Build Tools (MSVC), CMake, Ninja, and Qt 6.8+
-(msvc2022_64).
+Prerequisites: Visual Studio 2022 (Build Tools, Community, or higher) with the
+MSVC C++ workload, CMake 3.25+, Ninja, and Qt 6.7+ (`msvc2022_64`; the release
+binaries ship 6.8.3 LTS).
 
 ```bat
-:: 1. Activate the MSVC environment
+:: 1. Activate the MSVC environment. Adjust the edition (BuildTools / Community /
+::    Professional / Enterprise) to match your install; run "vswhere" if unsure.
 "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 
 :: 2. Generate the single-precision FFTW import lib (needed by NR4/libspecbleach)
 powershell -File scripts\setup\setup-fftw.ps1
 
-:: 3. Configure and build
-cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+:: 3. Configure. Ninja is required: the default Visual Studio generator is
+::    multi-config (it ignores CMAKE_BUILD_TYPE) and takes a different
+::    manifest-embed path. Point CMAKE_PREFIX_PATH at your Qt kit so
+::    find_package(Qt6) resolves.
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="C:/Qt/6.8.3/msvc2022_64"
+
+:: 4. Build
 cmake --build build --target AetherSDR
 ```
 


### PR DESCRIPTION
## Summary
- CMake's Ninja `vs_link_exe` wrapper already owns MSVC manifest embedding (link.exe emits a side-car `.manifest`, then `mt.exe` merges/embeds it). Passing `/MANIFEST:EMBED` + `/MANIFESTINPUT` directly (added in #3237 to fix `LNK1220`) makes link.exe embed inline instead, so it emits no side-car manifest — CMake's `mt.exe` step then runs with an empty `--manifests` list and fails with `c10100a7` on cmake 4.x.
- Fix: list the `.manifest` file as a target source so CMake feeds it to its own `vs_link_exe`/`mt.exe` embed step natively, per the root-cause analysis in the `aethersdr-agent` triage comment on the issue.
- Also adds a Windows 11 build section to `README.md`'s "Building from Source" (the secondary ask in the issue), covering `vcvars64.bat` → `scripts/setup/setup-fftw.ps1` → configure/build.

## Test plan
- [x] I (the original reporter) reproduced the `c10100a7` link failure on cmake 4.3.2 / MSVC 14.44 / VS 2022 BuildTools, applied this fix locally, and confirmed the link succeeds (per Principle XI — reporter-confirmed fix).
- [x] Inspected the generated `build.ninja`: `LINK_FLAGS` no longer carries `/MANIFEST:EMBED`/`/MANIFESTINPUT`, and `MANIFESTS` now correctly lists `packaging/windows/AetherSDR.exe.manifest` for the `mt.exe` step.
- [ ] CI (`build`, `check-paths`, `check-windows`) green on this PR.

Fixes #3835