### PR TITLE
fix(model): platform-based capability gating from FlexLib ModelInfo (#2177)

### DIFF
--- a/src/core/FirmwareStager.cpp
+++ b/src/core/FirmwareStager.cpp
@@ -2,6 +2,7 @@
 #include "CabExtractor.h"
 #include "LogManager.h"
 #include "OleCompoundFile.h"
+#include "models/ModelCapabilities.h"   // RadioPlatform for firmware-family routing
 
 #include <QCryptographicHash>
 #include <QDir>
@@ -32,15 +33,16 @@ QString FirmwareStager::stagingDir()
 
 QString FirmwareStager::modelToFamily(const QString& model)
 {
-    // Platform codenames (from FlexLib ModelInfo.cs):
-    //   Microburst  = FLEX-6300, 6500, 6700, 6700R       → FLEX-6x00 firmware
-    //   DeepEddy    = FLEX-6400, 6400M, 6600, 6600M      → FLEX-6x00 firmware
-    //   BigBend     = FLEX-8400, 8400M, 8600, 8600M,     → FLEX-6x00 firmware
-    //                 AU-510, AU-510M, AU-520, AU-520M
-    //   DragonFire  = FLEX-9600 (government only)         → FLEX-9600 firmware
+    // Firmware family follows the FlexLib RadioPlatform (Principle I), NOT a
+    // model-string substring:
+    //   Microburst / DeepEddy / BigBend  -> FLEX-6x00 firmware (all consumer
+    //     radios, including 8400/8600 and the AU-/ML-/MLS-/CL-/CLS- series)
+    //   DragonFire (RT-2122, government)  -> FLEX-9600 firmware
     //
-    // ALL consumer radios use FLEX-6x00 firmware.
-    if (model.contains("9600"))
+    // The old contains("9600") test misrouted both directions: ML-9600 /
+    // ML-9600W (BigBend) were sent to the government 9600 family, while RT-2122
+    // (the actual DragonFire radio) fell through to the 6x00 family.
+    if (capabilitiesFor(model).platform == RadioPlatform::DragonFire)
         return "9600";
     return "6x00";
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1404,16 +1404,19 @@ MainWindow::MainWindow(QWidget* parent)
     // the wrong state (#1356 for SmartSDR+, #1503 for DIV).
     connect(&m_radioModel, &RadioModel::infoChanged, this, [this]() {
         const bool hasPlus = m_radioModel.licenseSubscription().contains("SmartSDR+");
-        const QString& model = m_radioModel.model();
-        const bool divAllowed = model.contains("6500") || model.contains("6600")
-                             || model.contains("6700") || model.contains("8600")
-                             || model.contains("AU-520");
+        const bool divAllowed = m_radioModel.isDiversityAllowed();
+        // Refresh extended-DSP (NRL/NRS/RNN/NRF) visibility here too: onSliceAdded
+        // pushes it once at slice creation, but if the `model` status arrives after
+        // the slice (e.g. GUIClientID session restore) that one-shot value is stale
+        // — the AU-510 symptom where the extended filters never appeared. (#2177)
+        const bool hasExtendedDsp = m_radioModel.hasExtendedDspFilters();
         if (m_panStack) {
             for (auto* applet : m_panStack->allApplets()) {
                 auto* sw = applet->spectrumWidget();
                 for (auto* vfo : sw->findChildren<VfoWidget*>()) {
                     vfo->setSmartSdrPlus(hasPlus);
                     vfo->setDiversityAllowed(divAllowed);
+                    vfo->setHasExtendedDsp(hasExtendedDsp);
                 }
             }
         }
@@ -4886,12 +4889,9 @@ void MainWindow::onConnectionStateChanged(bool connected)
         // Slice tab toggle is initialized from infoChanged when radio
         // reports its actual slice capacity (#1278).
 
-        // Show DIV button on dual-SCU radios
+        // Show DIV button on dual-SCU radios (ModelCapabilities table, Principle I)
         {
-            const QString& model = m_radioModel.model();
-            bool divAllowed = model.contains("6500") || model.contains("6600")
-                           || model.contains("6700") || model.contains("8600")
-                           || model.contains("AU-520");
+            const bool divAllowed = m_radioModel.isDiversityAllowed();
             // Set diversity allowed on all existing VFO widgets (including Slice A at startup) (#1503)
             if (m_panStack) {
                 for (auto* pan : m_radioModel.panadapters()) {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -837,14 +837,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
         activateFdvDisplay(s->sliceId());
 #endif
 
-    // Show DIV button on dual-SCU radios
-    {
-        const QString& model = m_radioModel.model();
-        bool divAllowed = model.contains("6500") || model.contains("6600")
-                       || model.contains("6700") || model.contains("8600")
-                       || model.contains("AU-520");
-        vfo->setDiversityAllowed(divAllowed);
-    }
+    // Show DIV button on dual-SCU radios (ModelCapabilities table, Principle I)
+    vfo->setDiversityAllowed(m_radioModel.isDiversityAllowed());
 
     // Feed S-meter per-slice — only this VFO's slice level
     const int sid = s->sliceId();

--- a/src/models/ModelCapabilities.cpp
+++ b/src/models/ModelCapabilities.cpp
@@ -23,26 +23,26 @@ struct Entry {
 // entries (ML-9600, AU-510, AU-520) intentionally catch their W/X/M
 // variants (ML-9600W, AU-510M, ...) by substring.
 constexpr Entry kTable[] = {
-    // model key      platform                   4m     2m     LoopA  LoopB  Diversity
-    {"FLEX-6300",  {RadioPlatform::Microburst, false, false, false, false, false}},
-    {"FLEX-6400M", {RadioPlatform::DeepEddy,   false, false, false, false, false}},
-    {"FLEX-6400",  {RadioPlatform::DeepEddy,   false, false, false, false, false}},
-    {"FLEX-6500",  {RadioPlatform::Microburst, true,  false, true,  false, false}},  // Region 1 4m mod, LoopA only; single-SCU, no diversity
-    {"FLEX-6600M", {RadioPlatform::DeepEddy,   false, false, false, false, true }},
-    {"FLEX-6600",  {RadioPlatform::DeepEddy,   false, false, false, false, true }},
-    {"FLEX-6700R", {RadioPlatform::Microburst, false, false, false, false, true }},  // Receive-only, per FlexLib
-    {"FLEX-6700",  {RadioPlatform::Microburst, true,  true,  true,  true,  true }},  // Both built-in, LoopA + LoopB
-    {"FLEX-8400M", {RadioPlatform::BigBend,    false, false, false, false, false}},
-    {"FLEX-8400",  {RadioPlatform::BigBend,    false, false, false, false, false}},
-    {"FLEX-8600M", {RadioPlatform::BigBend,    false, false, false, false, true }},
-    {"FLEX-8600",  {RadioPlatform::BigBend,    false, false, false, false, true }},
-    {"MLS-9601",   {RadioPlatform::BigBend,    false, false, false, false, true }},  // before ML-9600
-    {"ML-9600",    {RadioPlatform::BigBend,    false, false, false, false, true }},  // catches ML-9600W / ML-9600X
-    {"CLS-9301",   {RadioPlatform::BigBend,    false, false, false, false, true }},  // before CL-9300
-    {"CL-9300",    {RadioPlatform::BigBend,    false, false, false, false, true }},
-    {"AU-510",     {RadioPlatform::BigBend,    false, false, false, false, false}},  // catches AU-510M
-    {"AU-520",     {RadioPlatform::BigBend,    false, false, false, false, true }},  // catches AU-520M
-    {"RT-2122",    {RadioPlatform::DragonFire, false, false, false, false, false}},
+    // model key      platform                   4m     2m     LoopA  LoopB  Diversity  Slices
+    {"FLEX-6300",  {RadioPlatform::Microburst, false, false, false, false, false,     2}},
+    {"FLEX-6400M", {RadioPlatform::DeepEddy,   false, false, false, false, false,     2}},
+    {"FLEX-6400",  {RadioPlatform::DeepEddy,   false, false, false, false, false,     2}},
+    {"FLEX-6500",  {RadioPlatform::Microburst, true,  false, true,  false, false,     4}},  // Region 1 4m mod, LoopA only; single-SCU, no diversity
+    {"FLEX-6600M", {RadioPlatform::DeepEddy,   false, false, false, false, true,      4}},
+    {"FLEX-6600",  {RadioPlatform::DeepEddy,   false, false, false, false, true,      4}},
+    {"FLEX-6700R", {RadioPlatform::Microburst, false, false, false, false, true,      8}},  // Receive-only, per FlexLib
+    {"FLEX-6700",  {RadioPlatform::Microburst, true,  true,  true,  true,  true,      8}},  // Both built-in, LoopA + LoopB
+    {"FLEX-8400M", {RadioPlatform::BigBend,    false, false, false, false, false,     2}},
+    {"FLEX-8400",  {RadioPlatform::BigBend,    false, false, false, false, false,     2}},
+    {"FLEX-8600M", {RadioPlatform::BigBend,    false, false, false, false, true,      4}},
+    {"FLEX-8600",  {RadioPlatform::BigBend,    false, false, false, false, true,      4}},
+    {"MLS-9601",   {RadioPlatform::BigBend,    false, false, false, false, true,      4}},  // before ML-9600
+    {"ML-9600",    {RadioPlatform::BigBend,    false, false, false, false, true,      4}},  // catches ML-9600W / ML-9600X
+    {"CLS-9301",   {RadioPlatform::BigBend,    false, false, false, false, true,      4}},  // before CL-9300
+    {"CL-9300",    {RadioPlatform::BigBend,    false, false, false, false, true,      4}},
+    {"AU-510",     {RadioPlatform::BigBend,    false, false, false, false, false,     2}},  // catches AU-510M
+    {"AU-520",     {RadioPlatform::BigBend,    false, false, false, false, true,      4}},  // catches AU-520M
+    {"RT-2122",    {RadioPlatform::DragonFire, false, false, false, false, false,     2}},
 };
 
 } // namespace

--- a/src/models/ModelCapabilities.cpp
+++ b/src/models/ModelCapabilities.cpp
@@ -9,32 +9,40 @@ struct Entry {
     ModelCapabilities caps;
 };
 
-// Mirrors FlexLib/ModelInfo.cs Has4Meters / Has2Meters / HasLoopA /
-// HasLoopB columns.  Keep this table in sync with FlexLib when Flex
-// ships a new model — the tests/model_capabilities_test harness will
-// fail loudly if a flag drifts away from the upstream source.
+// Mirrors FlexLib/ModelInfo.cs Platform / Has4Meters / Has2Meters /
+// HasLoopA / HasLoopB columns (Principle I — FlexLib is the model
+// authority).  Keep this table in sync with FlexLib when Flex ships a
+// new model — the tests/model_capabilities_test harness will fail loudly
+// if a flag drifts away from the upstream source.
 //
-// Ordering matters: capabilitiesFor() returns the first substring
-// match, so longer/suffix variants (FLEX-6400M, FLEX-6700R) must come
-// before their base model (FLEX-6400, FLEX-6700) so that an exact
-// "FLEX-6700R" status string doesn't match "FLEX-6700" first.
+// Ordering matters: capabilitiesFor() returns the first substring match,
+// so longer/suffix variants must come before their base model — an exact
+// "FLEX-6700R" status string must not match "FLEX-6700" first, and the
+// "S" server variants ("MLS-9601", "CLS-9301") must precede the base
+// "ML-9600"/"CL-9300" families they'd otherwise be mistaken for.  Family
+// entries (ML-9600, AU-510, AU-520) intentionally catch their W/X/M
+// variants (ML-9600W, AU-510M, ...) by substring.
 constexpr Entry kTable[] = {
-    {"FLEX-6300",  {false, false, false, false}},
-    {"FLEX-6400M", {false, false, false, false}},
-    {"FLEX-6400",  {false, false, false, false}},
-    {"FLEX-6500",  {true,  false, true,  false}},  // Region 1 4m mod, LoopA only
-    {"FLEX-6600M", {false, false, false, false}},
-    {"FLEX-6600",  {false, false, false, false}},
-    {"FLEX-6700R", {false, false, false, false}},  // Receive-only, per FlexLib
-    {"FLEX-6700",  {true,  true,  true,  true }},  // Both built-in, LoopA + LoopB
-    {"FLEX-8400M", {false, false, false, false}},
-    {"FLEX-8400",  {false, false, false, false}},
-    {"FLEX-8600M", {false, false, false, false}},
-    {"FLEX-8600",  {false, false, false, false}},
-    {"AU-520",     {false, false, false, false}},
-    {"ML-380",     {false, false, false, false}},
-    {"CL-200",     {false, false, false, false}},
-    {"RT-100",     {false, false, false, false}},
+    // model key      platform                   4m     2m     LoopA  LoopB  Diversity
+    {"FLEX-6300",  {RadioPlatform::Microburst, false, false, false, false, false}},
+    {"FLEX-6400M", {RadioPlatform::DeepEddy,   false, false, false, false, false}},
+    {"FLEX-6400",  {RadioPlatform::DeepEddy,   false, false, false, false, false}},
+    {"FLEX-6500",  {RadioPlatform::Microburst, true,  false, true,  false, false}},  // Region 1 4m mod, LoopA only; single-SCU, no diversity
+    {"FLEX-6600M", {RadioPlatform::DeepEddy,   false, false, false, false, true }},
+    {"FLEX-6600",  {RadioPlatform::DeepEddy,   false, false, false, false, true }},
+    {"FLEX-6700R", {RadioPlatform::Microburst, false, false, false, false, true }},  // Receive-only, per FlexLib
+    {"FLEX-6700",  {RadioPlatform::Microburst, true,  true,  true,  true,  true }},  // Both built-in, LoopA + LoopB
+    {"FLEX-8400M", {RadioPlatform::BigBend,    false, false, false, false, false}},
+    {"FLEX-8400",  {RadioPlatform::BigBend,    false, false, false, false, false}},
+    {"FLEX-8600M", {RadioPlatform::BigBend,    false, false, false, false, true }},
+    {"FLEX-8600",  {RadioPlatform::BigBend,    false, false, false, false, true }},
+    {"MLS-9601",   {RadioPlatform::BigBend,    false, false, false, false, true }},  // before ML-9600
+    {"ML-9600",    {RadioPlatform::BigBend,    false, false, false, false, true }},  // catches ML-9600W / ML-9600X
+    {"CLS-9301",   {RadioPlatform::BigBend,    false, false, false, false, true }},  // before CL-9300
+    {"CL-9300",    {RadioPlatform::BigBend,    false, false, false, false, true }},
+    {"AU-510",     {RadioPlatform::BigBend,    false, false, false, false, false}},  // catches AU-510M
+    {"AU-520",     {RadioPlatform::BigBend,    false, false, false, false, true }},  // catches AU-520M
+    {"RT-2122",    {RadioPlatform::DragonFire, false, false, false, false, false}},
 };
 
 } // namespace

--- a/src/models/ModelCapabilities.h
+++ b/src/models/ModelCapabilities.h
@@ -4,22 +4,48 @@
 
 namespace AetherSDR {
 
-// Per-model feature flags mirroring FlexLib/ModelInfo.cs (Has2Meters,
-// Has4Meters, HasLoopA, HasLoopB, ...).  Authority for any UI surface
-// that varies by model capability — the band selector in the Spectrum
-// Overlay Band menu is the first consumer (#695), additional flags
-// should be added here as more `model.contains("6700")`-style checks
-// get migrated.
+// Hardware platform generations, mirroring FlexLib/ModelInfo.cs's
+// RadioPlatform enum (Principle I — FlexLib is the protocol/model
+// authority).  The extended firmware DSP filters (NRL/NRS/RNN/NRF) are a
+// BigBend + DragonFire capability; the earlier Microburst/DeepEddy
+// 6000-series platforms don't expose them, which is why the UI hides
+// those toggles there. (#2177)
+enum class RadioPlatform {
+    Unknown,     // model not yet reported, or not in the table
+    Microburst,  // FLEX-6300 / 6500 / 6700 / 6700R
+    DeepEddy,    // FLEX-6400(M) / 6600(M)
+    BigBend,     // FLEX-8400(M) / 8600(M), ML-/MLS-/CL-/CLS-/AU- series
+    DragonFire,  // RT-2122
+};
+
+// Per-model feature flags mirroring FlexLib/ModelInfo.cs (Platform,
+// Has2Meters, Has4Meters, HasLoopA, HasLoopB, ...).  Authority for any UI
+// surface that varies by model capability — the band selector in the
+// Spectrum Overlay Band menu (#695) and the per-slice extended-DSP
+// toggles (#2177) are consumers; additional flags should be added here as
+// more `model.contains("6700")`-style checks get migrated.
 struct ModelCapabilities {
+    RadioPlatform platform{RadioPlatform::Unknown};
     bool has4Meters{false};  // Built-in 70 MHz transverter (FLEX-6500 Region 1, FLEX-6700)
     bool has2Meters{false};  // Built-in 144 MHz transverter (FLEX-6700)
     bool hasLoopA{false};    // RX loop/preselector path (FLEX-6500, FLEX-6700)
     bool hasLoopB{false};    // Second RX loop path (FLEX-6700)
+    bool isDiversityAllowed{false};  // 2-SCU diversity RX (FlexLib IsDiversityAllowed)
+
+    // Extended firmware DSP filters (NRL / NRS / RNN / NRF) exist on the
+    // BigBend and DragonFire platforms.  Unknown (pre-discovery) and the
+    // Microburst/DeepEddy 6000-series resolve to false so the toggles stay
+    // hidden rather than showing controls the firmware would no-op. (#2177)
+    bool hasExtendedDsp() const {
+        return platform == RadioPlatform::BigBend
+            || platform == RadioPlatform::DragonFire;
+    }
 };
 
 // Returns capabilities for the given model string.  Uses substring match
-// (case-insensitive) so vendor suffixes like "FLEX-6700/A" still resolve
-// to the 6700 entry.  Unknown models default to all-false — forward-
+// (case-insensitive) so vendor suffixes like "FLEX-6700/A" and the M
+// variants ("AU-510M") still resolve to their family entry.  Unknown
+// models default to Unknown platform + all-false flags — forward-
 // compatible for radios released after this build.
 ModelCapabilities capabilitiesFor(const QString& model);
 

--- a/src/models/ModelCapabilities.h
+++ b/src/models/ModelCapabilities.h
@@ -31,6 +31,12 @@ struct ModelCapabilities {
     bool hasLoopA{false};    // RX loop/preselector path (FLEX-6500, FLEX-6700)
     bool hasLoopB{false};    // Second RX loop path (FLEX-6700)
     bool isDiversityAllowed{false};  // 2-SCU diversity RX (FlexLib IsDiversityAllowed)
+    // Max independent receivers (FlexLib SliceList size).  Also the max
+    // panadapter count — pan capacity tracks the radio's SCU/slice capacity,
+    // which is identical across every current model.  Default 2 mirrors
+    // FlexLib's DEFAULT entry (SliceList {A,B}); the radio's live "slices=N"
+    // status overrides this initial estimate once connected.
+    int maxSlices{2};
 
     // Extended firmware DSP filters (NRL / NRS / RNN / NRF) exist on the
     // BigBend and DragonFire platforms.  Unknown (pre-discovery) and the

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -649,7 +649,8 @@ int RadioModel::maxSlicesForModel(const QString& model)
             || normalized.contains("8600") || normalized.contains("AU-520"))
         return 4;
     if (normalized.contains("6300") || normalized.contains("6400")
-            || normalized.contains("8400") || normalized.contains("AU-510"))
+            || normalized.contains("8400") || normalized.contains("AU-510")
+            || normalized.contains("RT-2122"))  // DragonFire, SliceList {A,B}
         return 2;
     return 4;
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -641,18 +641,12 @@ bool RadioModel::isConnected() const
 
 int RadioModel::maxSlicesForModel(const QString& model)
 {
-    const QString normalized = model.toUpper();
-    // FlexRadio lists slice capacity as independent receivers per model family.
-    if (normalized.contains("6700"))
-        return 8;
-    if (normalized.contains("6600") || normalized.contains("6500")
-            || normalized.contains("8600") || normalized.contains("AU-520"))
-        return 4;
-    if (normalized.contains("6300") || normalized.contains("6400")
-            || normalized.contains("8400") || normalized.contains("AU-510")
-            || normalized.contains("RT-2122"))  // DragonFire, SliceList {A,B}
-        return 2;
-    return 4;
+    // Slice capacity per model comes from the FlexLib-sourced ModelCapabilities
+    // table (SliceList size, Principle I) — the single source of model truth,
+    // shared with maxPanadapters(), diversity, and extended-DSP gating.  This is
+    // only the pre-connection estimate; the radio's live "slices=N" status
+    // overrides m_maxSlices once connected.
+    return capabilitiesFor(model).maxSlices;
 }
 
 SliceModel* RadioModel::slice(int id) const

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -147,13 +147,24 @@ public:
     }
 
     // Returns true for BigBend/DragonFire-platform radios (8400, 8600,
-    // AU-series, ML-series, CL-series, RT-series) that support the extended
+    // AU-/ML-/MLS-/CL-/CLS- series, RT-2122) that support the extended
     // firmware DSP filters (NRL, NRS, RNN, NRF).  6000-series radios don't
     // expose these filters and the UI hides them when this returns false. (#2177)
+    //
+    // Delegates to the FlexLib-sourced ModelCapabilities platform table
+    // (Principle I) instead of ad-hoc substring checks — the old prefix form
+    // silently missed the "S" server variants (MLS-9601 doesn't contain "ML-";
+    // CLS-9301 doesn't contain "CL-") and was case-sensitive.
     bool hasExtendedDspFilters() const {
-        return m_model.contains("8400") || m_model.contains("8600")
-            || m_model.contains("AU-")  || m_model.contains("ML-")
-            || m_model.contains("CL-")  || m_model.contains("RT-");
+        return capabilitiesFor(m_model).hasExtendedDsp();
+    }
+
+    // True for 2-SCU radios that support diversity RX, from the FlexLib-sourced
+    // ModelCapabilities table (Principle I).  Replaces the hand-maintained
+    // contains("6500")|... checks, which wrongly enabled diversity on the
+    // single-SCU FLEX-6500 and omitted the ML-/MLS-/CL-/CLS- dual-SCU models.
+    bool isDiversityAllowed() const {
+        return capabilitiesFor(m_model).isDiversityAllowed;
     }
 
     // Max panadapters supported by this radio model.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -167,17 +167,15 @@ public:
         return capabilitiesFor(m_model).isDiversityAllowed;
     }
 
-    // Max panadapters supported by this radio model.
-    // FLEX-6700: 8 (dual SCU, high-capacity)
-    // FLEX-6600 / FLEX-6500 / FLEX-8600 / AU-520: 4 (dual SCU)
-    // All single-SCU models (6300, 6400, etc.): 2
+    // Max panadapters supported by this radio model.  Panadapter capacity
+    // tracks the radio's SCU/slice capacity (identical across every current
+    // model), so this comes from the same FlexLib-sourced ModelCapabilities
+    // table (Principle I) rather than an ad-hoc contains() list — the old list
+    // omitted the dual-SCU ML-/MLS-/CL-/CLS- models, capping them at 2 pans
+    // instead of 4.  Examples: FLEX-6700 -> 8; 6600/6500/8600/AU-520/ML/CL -> 4;
+    // 6300/6400/8400/AU-510/RT-2122 -> 2.
     int maxPanadapters() const {
-        if (m_model.contains("6700"))
-            return 8;
-        if (m_model.contains("6600") || m_model.contains("6500")
-                || m_model.contains("8600") || m_model.contains("AU-520"))
-            return 4;
-        return 2;
+        return capabilitiesFor(m_model).maxSlices;
     }
 
     // Panadapter bandwidth limits by radio model (MHz).

--- a/tests/model_capabilities_test.cpp
+++ b/tests/model_capabilities_test.cpp
@@ -51,31 +51,32 @@ int main()
         bool hasLoopA;
         bool hasLoopB;
         bool diversity;
+        int  slices;   // FlexLib SliceList size == max slices == max panadapters
     };
     const Row kExpected[] = {
-        {"FLEX-6300",  RadioPlatform::Microburst, false, false, false, false, false},
-        {"FLEX-6400",  RadioPlatform::DeepEddy,   false, false, false, false, false},
-        {"FLEX-6400M", RadioPlatform::DeepEddy,   false, false, false, false, false},
-        {"FLEX-6500",  RadioPlatform::Microburst, true,  false, true,  false, false},
-        {"FLEX-6600",  RadioPlatform::DeepEddy,   false, false, false, false, true },
-        {"FLEX-6600M", RadioPlatform::DeepEddy,   false, false, false, false, true },
-        {"FLEX-6700",  RadioPlatform::Microburst, true,  true,  true,  true,  true },
-        {"FLEX-6700R", RadioPlatform::Microburst, false, false, false, false, true },
-        {"FLEX-8400",  RadioPlatform::BigBend,    false, false, false, false, false},
-        {"FLEX-8400M", RadioPlatform::BigBend,    false, false, false, false, false},
-        {"FLEX-8600",  RadioPlatform::BigBend,    false, false, false, false, true },
-        {"FLEX-8600M", RadioPlatform::BigBend,    false, false, false, false, true },
-        {"ML-9600",    RadioPlatform::BigBend,    false, false, false, false, true },
-        {"ML-9600W",   RadioPlatform::BigBend,    false, false, false, false, true },
-        {"ML-9600X",   RadioPlatform::BigBend,    false, false, false, false, true },
-        {"MLS-9601",   RadioPlatform::BigBend,    false, false, false, false, true },
-        {"CL-9300",    RadioPlatform::BigBend,    false, false, false, false, true },
-        {"CLS-9301",   RadioPlatform::BigBend,    false, false, false, false, true },
-        {"RT-2122",    RadioPlatform::DragonFire, false, false, false, false, false},
-        {"AU-510",     RadioPlatform::BigBend,    false, false, false, false, false},
-        {"AU-510M",    RadioPlatform::BigBend,    false, false, false, false, false},
-        {"AU-520",     RadioPlatform::BigBend,    false, false, false, false, true },
-        {"AU-520M",    RadioPlatform::BigBend,    false, false, false, false, true },
+        {"FLEX-6300",  RadioPlatform::Microburst, false, false, false, false, false, 2},
+        {"FLEX-6400",  RadioPlatform::DeepEddy,   false, false, false, false, false, 2},
+        {"FLEX-6400M", RadioPlatform::DeepEddy,   false, false, false, false, false, 2},
+        {"FLEX-6500",  RadioPlatform::Microburst, true,  false, true,  false, false, 4},
+        {"FLEX-6600",  RadioPlatform::DeepEddy,   false, false, false, false, true,  4},
+        {"FLEX-6600M", RadioPlatform::DeepEddy,   false, false, false, false, true,  4},
+        {"FLEX-6700",  RadioPlatform::Microburst, true,  true,  true,  true,  true,  8},
+        {"FLEX-6700R", RadioPlatform::Microburst, false, false, false, false, true,  8},
+        {"FLEX-8400",  RadioPlatform::BigBend,    false, false, false, false, false, 2},
+        {"FLEX-8400M", RadioPlatform::BigBend,    false, false, false, false, false, 2},
+        {"FLEX-8600",  RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"FLEX-8600M", RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"ML-9600",    RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"ML-9600W",   RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"ML-9600X",   RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"MLS-9601",   RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"CL-9300",    RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"CLS-9301",   RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"RT-2122",    RadioPlatform::DragonFire, false, false, false, false, false, 2},
+        {"AU-510",     RadioPlatform::BigBend,    false, false, false, false, false, 2},
+        {"AU-510M",    RadioPlatform::BigBend,    false, false, false, false, false, 2},
+        {"AU-520",     RadioPlatform::BigBend,    false, false, false, false, true,  4},
+        {"AU-520M",    RadioPlatform::BigBend,    false, false, false, false, true,  4},
     };
 
     for (const auto& row : kExpected) {
@@ -89,11 +90,27 @@ int main()
         check(caps.hasLoopA == row.hasLoopA, m + ": hasLoopA");
         check(caps.hasLoopB == row.hasLoopB, m + ": hasLoopB");
         check(caps.isDiversityAllowed == row.diversity, m + ": isDiversityAllowed");
+        check(caps.maxSlices == row.slices,
+              m + ": maxSlices == " + std::to_string(row.slices)
+                  + " (got " + std::to_string(caps.maxSlices) + ")");
         // Extended firmware DSP (NRL/NRS/RNN/NRF) = BigBend | DragonFire.
         const bool expectExt = row.platform == RadioPlatform::BigBend
                             || row.platform == RadioPlatform::DragonFire;
         check(caps.hasExtendedDsp() == expectExt, m + ": hasExtendedDsp");
     }
+
+    // Regression: the dual-SCU ML-/MLS-/CL-/CLS- models must report 4 slices/
+    // panadapters (SliceList {A,B,C,D}); the old maxPanadapters() contains()
+    // list omitted them and capped them at 2. AU-510 (2) vs AU-520 (4) confirm
+    // the M-variant families resolve to the right capacity.
+    for (const char* m : {"ML-9600", "MLS-9601", "CL-9300", "CLS-9301"}) {
+        check(capabilitiesFor(QString::fromLatin1(m)).maxSlices == 4,
+              std::string(m) + " reports 4 slices/pans (was capped at 2)");
+    }
+    check(capabilitiesFor(QStringLiteral("AU-510M")).maxSlices == 2,
+          "AU-510M reports 2 slices/pans");
+    check(capabilitiesFor(QStringLiteral("AU-520M")).maxSlices == 4,
+          "AU-520M reports 4 slices/pans");
 
     // Regression: the "S" server variants must NOT be lost the way the old
     // contains("ML-")/contains("CL-") prefix logic dropped them (MLS-9601 has
@@ -159,8 +176,9 @@ int main()
         check(caps.platform == RadioPlatform::Unknown
                   && !caps.has4Meters && !caps.has2Meters
                   && !caps.hasLoopA && !caps.hasLoopB
-                  && !caps.hasExtendedDsp(),
-              "Unknown model returns default Unknown/all-false capabilities");
+                  && !caps.hasExtendedDsp()
+                  && caps.maxSlices == 2,   // FlexLib DEFAULT SliceList {A,B}
+              "Unknown model returns default Unknown/all-false/2-slice capabilities");
     }
 
     // Empty / disconnected state should not crash and should return default

--- a/tests/model_capabilities_test.cpp
+++ b/tests/model_capabilities_test.cpp
@@ -1,21 +1,34 @@
 // Verifies the per-model feature-flag table in ModelCapabilities mirrors
-// FlexLib/ModelInfo.cs row-for-row for Has4Meters / Has2Meters and
-// HasLoopA / HasLoopB (#695).
+// FlexLib/ModelInfo.cs row-for-row for Platform, Has4Meters / Has2Meters
+// and HasLoopA / HasLoopB (#695, #2177).
 // Catches drift if FlexLib ever flips a flag — re-sync the C++ table
 // and update this test together.
 
 #include "models/ModelCapabilities.h"
 
 #include <iostream>
+#include <string>
 
 using namespace AetherSDR;
 
 namespace {
 
-bool expect(bool condition, const char* label)
+bool expect(bool condition, const std::string& label)
 {
     std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
     return condition;
+}
+
+const char* platformName(RadioPlatform p)
+{
+    switch (p) {
+        case RadioPlatform::Unknown:    return "Unknown";
+        case RadioPlatform::Microburst: return "Microburst";
+        case RadioPlatform::DeepEddy:   return "DeepEddy";
+        case RadioPlatform::BigBend:    return "BigBend";
+        case RadioPlatform::DragonFire: return "DragonFire";
+    }
+    return "?";
 }
 
 } // namespace
@@ -23,90 +36,140 @@ bool expect(bool condition, const char* label)
 int main()
 {
     int failures = 0;
+    auto check = [&](bool cond, const std::string& label) {
+        if (!expect(cond, label)) ++failures;
+    };
 
-    // Exact model strings from FlexLib/ModelInfo.cs.  Expected flags
-    // copied directly from that file's Has4Meters / Has2Meters /
-    // HasLoopA / HasLoopB columns.
+    // Exact model strings from FlexLib/ModelInfo.cs.  Expected columns
+    // copied directly from that file: Platform / Has4Meters / Has2Meters /
+    // HasLoopA / HasLoopB.  hasExtendedDsp is derived (BigBend|DragonFire).
     struct Row {
         const char* model;
+        RadioPlatform platform;
         bool has4m;
         bool has2m;
         bool hasLoopA;
         bool hasLoopB;
+        bool diversity;
     };
-    constexpr Row kExpected[] = {
-        {"FLEX-6300",  false, false, false, false},
-        {"FLEX-6400",  false, false, false, false},
-        {"FLEX-6400M", false, false, false, false},
-        {"FLEX-6500",  true,  false, true,  false},
-        {"FLEX-6600",  false, false, false, false},
-        {"FLEX-6600M", false, false, false, false},
-        {"FLEX-6700",  true,  true,  true,  true },
-        {"FLEX-6700R", false, false, false, false},
-        {"FLEX-8400",  false, false, false, false},
-        {"FLEX-8400M", false, false, false, false},
-        {"FLEX-8600",  false, false, false, false},
-        {"FLEX-8600M", false, false, false, false},
-        {"AU-520",     false, false, false, false},
-        {"ML-380",     false, false, false, false},
-        {"CL-200",     false, false, false, false},
-        {"RT-100",     false, false, false, false},
+    const Row kExpected[] = {
+        {"FLEX-6300",  RadioPlatform::Microburst, false, false, false, false, false},
+        {"FLEX-6400",  RadioPlatform::DeepEddy,   false, false, false, false, false},
+        {"FLEX-6400M", RadioPlatform::DeepEddy,   false, false, false, false, false},
+        {"FLEX-6500",  RadioPlatform::Microburst, true,  false, true,  false, false},
+        {"FLEX-6600",  RadioPlatform::DeepEddy,   false, false, false, false, true },
+        {"FLEX-6600M", RadioPlatform::DeepEddy,   false, false, false, false, true },
+        {"FLEX-6700",  RadioPlatform::Microburst, true,  true,  true,  true,  true },
+        {"FLEX-6700R", RadioPlatform::Microburst, false, false, false, false, true },
+        {"FLEX-8400",  RadioPlatform::BigBend,    false, false, false, false, false},
+        {"FLEX-8400M", RadioPlatform::BigBend,    false, false, false, false, false},
+        {"FLEX-8600",  RadioPlatform::BigBend,    false, false, false, false, true },
+        {"FLEX-8600M", RadioPlatform::BigBend,    false, false, false, false, true },
+        {"ML-9600",    RadioPlatform::BigBend,    false, false, false, false, true },
+        {"ML-9600W",   RadioPlatform::BigBend,    false, false, false, false, true },
+        {"ML-9600X",   RadioPlatform::BigBend,    false, false, false, false, true },
+        {"MLS-9601",   RadioPlatform::BigBend,    false, false, false, false, true },
+        {"CL-9300",    RadioPlatform::BigBend,    false, false, false, false, true },
+        {"CLS-9301",   RadioPlatform::BigBend,    false, false, false, false, true },
+        {"RT-2122",    RadioPlatform::DragonFire, false, false, false, false, false},
+        {"AU-510",     RadioPlatform::BigBend,    false, false, false, false, false},
+        {"AU-510M",    RadioPlatform::BigBend,    false, false, false, false, false},
+        {"AU-520",     RadioPlatform::BigBend,    false, false, false, false, true },
+        {"AU-520M",    RadioPlatform::BigBend,    false, false, false, false, true },
     };
 
     for (const auto& row : kExpected) {
         const ModelCapabilities caps = capabilitiesFor(QString::fromLatin1(row.model));
-        if (!expect(caps.has4Meters == row.has4m,
-                    (std::string(row.model) + ": has4Meters").c_str()))
-            ++failures;
-        if (!expect(caps.has2Meters == row.has2m,
-                    (std::string(row.model) + ": has2Meters").c_str()))
-            ++failures;
-        if (!expect(caps.hasLoopA == row.hasLoopA,
-                    (std::string(row.model) + ": hasLoopA").c_str()))
-            ++failures;
-        if (!expect(caps.hasLoopB == row.hasLoopB,
-                    (std::string(row.model) + ": hasLoopB").c_str()))
-            ++failures;
+        const std::string m = row.model;
+        check(caps.platform == row.platform,
+              m + ": platform == " + platformName(row.platform)
+                  + " (got " + platformName(caps.platform) + ")");
+        check(caps.has4Meters == row.has4m,  m + ": has4Meters");
+        check(caps.has2Meters == row.has2m,  m + ": has2Meters");
+        check(caps.hasLoopA == row.hasLoopA, m + ": hasLoopA");
+        check(caps.hasLoopB == row.hasLoopB, m + ": hasLoopB");
+        check(caps.isDiversityAllowed == row.diversity, m + ": isDiversityAllowed");
+        // Extended firmware DSP (NRL/NRS/RNN/NRF) = BigBend | DragonFire.
+        const bool expectExt = row.platform == RadioPlatform::BigBend
+                            || row.platform == RadioPlatform::DragonFire;
+        check(caps.hasExtendedDsp() == expectExt, m + ": hasExtendedDsp");
     }
 
-    // Substring match — vendor suffixes like "FLEX-6700/A" should still
-    // resolve to the 6700 row.
+    // Regression: the "S" server variants must NOT be lost the way the old
+    // contains("ML-")/contains("CL-") prefix logic dropped them (MLS-9601 has
+    // no "ML-" substring; CLS-9301 has no "CL-").
+    check(capabilitiesFor(QStringLiteral("MLS-9601")).hasExtendedDsp(),
+          "MLS-9601 reports extended DSP (was missed by contains(\"ML-\"))");
+    check(capabilitiesFor(QStringLiteral("CLS-9301")).hasExtendedDsp(),
+          "CLS-9301 reports extended DSP (was missed by contains(\"CL-\"))");
+
+    // Regression: the AU-510 must report extended DSP regardless of case —
+    // the reported user symptom.  FlexLib matches exact upper-case, but the
+    // gate must not depend on that.
+    check(capabilitiesFor(QStringLiteral("AU-510")).hasExtendedDsp(),
+          "AU-510 reports extended DSP");
+    check(capabilitiesFor(QStringLiteral("au-510")).hasExtendedDsp(),
+          "au-510 (lowercase) reports extended DSP");
+    check(capabilitiesFor(QStringLiteral("AU-510M")).hasExtendedDsp(),
+          "AU-510M reports extended DSP");
+
+    // 6000-series (Microburst/DeepEddy) must NOT report extended DSP.
+    for (const char* m : {"FLEX-6300", "FLEX-6400", "FLEX-6500",
+                          "FLEX-6600", "FLEX-6700", "FLEX-6700R"}) {
+        check(!capabilitiesFor(QString::fromLatin1(m)).hasExtendedDsp(),
+              std::string(m) + " does NOT report extended DSP");
+    }
+
+    // Diversity regressions vs the old contains() gate:
+    //  - FLEX-6500 is single-SCU -> diversity must be FALSE (old gate wrongly
+    //    listed contains("6500") as diversity-allowed).
+    check(!capabilitiesFor(QStringLiteral("FLEX-6500")).isDiversityAllowed,
+          "FLEX-6500 diversity is FALSE (old gate false-positive)");
+    //  - the ML-/MLS-/CL-/CLS- dual-SCU models are diversity-allowed but the
+    //    old gate never listed them.
+    for (const char* m : {"ML-9600", "ML-9600W", "MLS-9601", "CL-9300", "CLS-9301"}) {
+        check(capabilitiesFor(QString::fromLatin1(m)).isDiversityAllowed,
+              std::string(m) + " diversity is TRUE (old gate false-negative)");
+    }
+    //  - RT-2122 (DragonFire, single-SCU) is NOT diversity-allowed.
+    check(!capabilitiesFor(QStringLiteral("RT-2122")).isDiversityAllowed,
+          "RT-2122 diversity is FALSE");
+
+    // Substring match — vendor suffixes like "FLEX-6700/A" resolve to 6700.
     {
         const auto caps = capabilitiesFor(QStringLiteral("FLEX-6700/A"));
-        if (!expect(caps.has4Meters && caps.has2Meters
-                        && caps.hasLoopA && caps.hasLoopB,
-                    "FLEX-6700/A resolves to 6700 row"))
-            ++failures;
+        check(caps.has4Meters && caps.has2Meters
+                  && caps.hasLoopA && caps.hasLoopB,
+              "FLEX-6700/A resolves to 6700 row");
     }
 
-    // Case-insensitive — the model string the radio reports is upper-
-    // case today but downstream code shouldn't have to rely on that.
+    // Case-insensitive — the model string is upper-case today but downstream
+    // code shouldn't rely on that.
     {
         const auto caps = capabilitiesFor(QStringLiteral("flex-6700"));
-        if (!expect(caps.has4Meters && caps.has2Meters
-                        && caps.hasLoopA && caps.hasLoopB,
-                    "lowercase model resolves to 6700 row"))
-            ++failures;
+        check(caps.has4Meters && caps.has2Meters
+                  && caps.hasLoopA && caps.hasLoopB,
+              "lowercase model resolves to 6700 row");
     }
 
-    // Unknown model — default-init capabilities, no UI surfaces.
+    // Unknown model — Unknown platform, all-false, no extended DSP.
     // Forward-compat for radios released after this build.
     {
         const auto caps = capabilitiesFor(QStringLiteral("FLEX-9999"));
-        if (!expect(!caps.has4Meters && !caps.has2Meters
-                        && !caps.hasLoopA && !caps.hasLoopB,
-                    "Unknown model returns default-false capabilities"))
-            ++failures;
+        check(caps.platform == RadioPlatform::Unknown
+                  && !caps.has4Meters && !caps.has2Meters
+                  && !caps.hasLoopA && !caps.hasLoopB
+                  && !caps.hasExtendedDsp(),
+              "Unknown model returns default Unknown/all-false capabilities");
     }
 
-    // Empty / disconnected state should not crash and should return
-    // default capabilities.
+    // Empty / disconnected state should not crash and should return default
+    // (Unknown) capabilities — no extended DSP before the model is known
+    // (avoids a pre-discovery button flash).
     {
         const auto caps = capabilitiesFor(QString());
-        if (!expect(!caps.has4Meters && !caps.has2Meters
-                        && !caps.hasLoopA && !caps.hasLoopB,
-                    "Empty model string returns default-false capabilities"))
-            ++failures;
+        check(caps.platform == RadioPlatform::Unknown && !caps.hasExtendedDsp(),
+              "Empty model string returns Unknown, no extended DSP");
     }
 
     if (failures == 0) {

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -138,11 +138,11 @@ void testBandStackKeysUseNativeVhfOnlyWhenCapable()
     };
 
     expectBandKey("FLEX-6700 native 2m strips UI suffix",
-                  "2m", {}, "2", {false, true});
+                  "2m", {}, "2", {.has2Meters = true});
     expectBandKey("FLEX-6500/6700 native 4m strips UI suffix",
-                  "4m", {}, "4", {true, false});
+                  "4m", {}, "4", {.has4Meters = true});
     expectBandKey("native 2m wins over same-named XVTR on capable radio",
-                  "2m", xvtrs, "2", {false, true});
+                  "2m", xvtrs, "2", {.has2Meters = true});
     expectBandKey("without 2m capability, same-named XVTR still resolves",
                   "2m", xvtrs, "X12");
 }


### PR DESCRIPTION
## Problem

A user with an **AU-510** reported that the **NRS / RNN / NRF** extended-DSP toggles never appear in the VFO DSP menu (NRL, which isn't extended-gated, does show). Investigating surfaced a whole class of model-capability bugs from hand-maintained `model.contains(...)` sniffing that had drifted out of sync with FlexLib.

## Root cause (two-fold for AU-510)

- **Classification** — `hasExtendedDspFilters()` used substring checks (`contains("ML-")`/`"CL-"`/`"AU-"`) that silently missed the **"S" server variants** (`MLS-9601` has no `"ML-"`; `CLS-9301` has no `"CL-"`) and was case-sensitive.
- **Timing** — `setHasExtendedDsp()` was pushed **once** at `onSliceAdded`, so if the `model` status arrived *after* the slice (GUIClientID session restore), the flag stayed at its `false` default and never refreshed.

## Fix

Migrate extended-DSP and diversity gating to the FlexLib-sourced **`ModelCapabilities`** table — **Constitution Principle I (FlexLib is the model authority)** — and close the gaps:

- **`ModelCapabilities`** gains a `RadioPlatform` enum (Microburst / DeepEddy / BigBend / DragonFire), a `platform` field, an `isDiversityAllowed` flag, and a `hasExtendedDsp()` helper. The table is corrected (`ML-380`/`CL-200`/`RT-100` placeholders → real `ML-9600`/`CL-9300`/`RT-2122`) and completed (`MLS-9601`, `CLS-9301`, `AU-510`) — all **23** current FlexLib models resolve.
- **Extended DSP** now derives from platform (`BigBend | DragonFire`), fixing MLS-9601 / CLS-9301 and case-sensitivity.
- **Timing** — extended-DSP is now also refreshed on `RadioModel::infoChanged` (mirroring the SmartSDR+/diversity refresh), so a late `model` status corrects the flag.
- **Diversity** was the same anti-pattern, triplicated across 3 call sites and wrong **both directions** vs FlexLib `IsDiversityAllowed`:
  - `FLEX-6500` (single-SCU) was wrongly **granted** diversity → now false.
  - `ML-`/`MLS-`/`CL-`/`CLS-` (dual-SCU) were wrongly **denied** it → now true.
  - All three sites now call `RadioModel::isDiversityAllowed()`.
- **`RT-2122`** (DragonFire, `SliceList {A,B}`) now reports **2** slices instead of defaulting to 4.

## Verification

- `model_capabilities_test` asserts **platform + 4m/2m/loop + diversity + extended-DSP** for all 23 models, with explicit regressions for MLS/CLS extended-DSP, `au-510` (lowercase), `FLEX-6500` diversity-false, ML/CL diversity-true, RT-2122 diversity-false. Passes locally (`ctest -R model_capabilities_test`).
- Full `AetherSDR` build links clean.

## Note

The reported AU-510 symptom is most likely the **timing** half (FlexLib does exact-match uppercase, so the wire string is `AU-510` and the old `contains("AU-")` *would* have matched once the model was known). Both halves are fixed here so the class of bug is closed regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)