### PR TITLE
[codex] Add local D-STAR waveform support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,6 +556,7 @@ set(CORE_SOURCES
     src/core/PgxlConnection.cpp
     src/core/FirmwareUploader.cpp
     src/core/WaveformInstaller.cpp
+    src/core/DStarWaveformProcess.cpp
     src/core/DvkWavTransfer.cpp
     src/core/ZipArchive.cpp
     src/core/ProfileTransfer.cpp
@@ -1106,6 +1107,78 @@ endif()
 # of this ecosystem-standard approach).
 if(DEFINED ENV{SOURCE_DATE_EPOCH})
     message(STATUS "Reproducible build: honoring SOURCE_DATE_EPOCH=$ENV{SOURCE_DATE_EPOCH}")
+endif()
+
+if(UNIX)
+    set(DSTAR_WAVEFORM_DIR "${CMAKE_SOURCE_DIR}/third_party/smartsdr-dsp")
+    set(DSTAR_WAVEFORM_SOURCES
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/cmd_basics.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/cmd_engine.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/discovery_client.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/hal_buffer.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/hal_listener.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/hal_vita.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/io_utils.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/sched_waveform.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/smartsdr_dsp_api.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/status_processor.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/traffic_cop.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/utils.c
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/vita_output.c
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV/bit_pattern_matcher.c
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV/dstar.c
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV/gmsk_modem.c
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV/slow_data.c
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV/thumbDV.c
+        ${DSTAR_WAVEFORM_DIR}/aether_vocoder_backend.cpp
+        ${DSTAR_WAVEFORM_DIR}/aether_sem_compat.c
+        ${DSTAR_WAVEFORM_DIR}/aether_serial_compat.c
+        ${DSTAR_WAVEFORM_DIR}/circular_buffer.c
+        ${DSTAR_WAVEFORM_DIR}/main.c
+        ${DSTAR_WAVEFORM_DIR}/resampler.c
+    )
+
+    add_executable(aether-dstar-waveform ${DSTAR_WAVEFORM_SOURCES})
+    set_target_properties(aether-dstar-waveform PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+    )
+    target_compile_definitions(aether-dstar-waveform PRIVATE _DEFAULT_SOURCE)
+    target_include_directories(aether-dstar-waveform BEFORE PRIVATE
+        ${DSTAR_WAVEFORM_DIR}/compat
+        ${DSTAR_WAVEFORM_DIR}/include
+        ${DSTAR_WAVEFORM_DIR}
+        ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface
+        ${DSTAR_WAVEFORM_DIR}/ThumbDV
+    )
+    find_package(Threads REQUIRED)
+    target_link_libraries(aether-dstar-waveform PRIVATE Threads::Threads m)
+    if(APPLE)
+        target_link_libraries(aether-dstar-waveform PRIVATE "-framework IOKit")
+        set(DSTAR_WAVEFORM_RUNTIME_DIR "${CMAKE_BINARY_DIR}/AetherSDR.app/Contents/MacOS")
+    else()
+        set(DSTAR_WAVEFORM_RUNTIME_DIR "${CMAKE_BINARY_DIR}")
+    endif()
+    set_target_properties(aether-dstar-waveform PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${DSTAR_WAVEFORM_RUNTIME_DIR}"
+    )
+    if(NOT MSVC)
+        target_compile_options(aether-dstar-waveform PRIVATE -w)
+    endif()
+    add_custom_command(TARGET aether-dstar-waveform POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${DSTAR_WAVEFORM_DIR}/config/ThumbDV.cfg"
+            "$<TARGET_FILE_DIR:aether-dstar-waveform>/ThumbDV.cfg"
+        COMMENT "Copying ThumbDV waveform config"
+    )
+    add_test(NAME aether_dstar_waveform_no_args
+        COMMAND ${CMAKE_COMMAND}
+            -DHELPER=$<TARGET_FILE:aether-dstar-waveform>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_dstar_waveform_no_args.cmake
+    )
+    add_dependencies(AetherSDR aether-dstar-waveform)
 endif()
 
 # Windows: GUI app (no console window) + icon resource
@@ -2054,6 +2127,17 @@ add_executable(flex_waveform_model_test
 target_include_directories(flex_waveform_model_test PRIVATE src)
 target_link_libraries(flex_waveform_model_test PRIVATE Qt6::Core Qt6::Test)
 
+add_executable(dstar_waveform_process_test
+    tests/dstar_waveform_process_test.cpp
+    src/core/DStarWaveformProcess.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(dstar_waveform_process_test PRIVATE src)
+target_link_libraries(dstar_waveform_process_test PRIVATE Qt6::Core Qt6::Network)
+add_test(NAME dstar_waveform_process_test COMMAND dstar_waveform_process_test)
+
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp
     src/core/OleCompoundFile.cpp
@@ -2638,10 +2722,26 @@ if(APPLE)
     install(TARGETS AetherSDR
         BUNDLE DESTINATION .
     )
+    if(TARGET aether-dstar-waveform)
+        install(PROGRAMS "$<TARGET_FILE:aether-dstar-waveform>"
+            DESTINATION AetherSDR.app/Contents/MacOS
+        )
+        install(FILES third_party/smartsdr-dsp/config/ThumbDV.cfg
+            DESTINATION AetherSDR.app/Contents/MacOS
+        )
+    endif()
 else()
     install(TARGETS AetherSDR
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
+    if(TARGET aether-dstar-waveform)
+        install(TARGETS aether-dstar-waveform
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+        install(FILES third_party/smartsdr-dsp/config/ThumbDV.cfg
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif()
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/packaging/linux/AetherSDR.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(USE_SYSTEM_LIQUID_DSP   "Use system liquid-dsp"   OFF)
 option(REQUIRE_SERIALPORT "Fail if Qt6 SerialPort is not found (use for release builds)" OFF)
 option(REQUIRE_KEYCHAIN "Fail if Qt6Keychain is not found (use for release builds)" OFF)
 option(ENABLE_RADE "Build with RADE digital voice support (uses vendored Opus snapshot)" ON)
+option(ENABLE_DSTAR "Build the local D-STAR waveform helper (vendored smartsdr-dsp/ThumbDV; Unix only)" ON)
 option(AETHER_GPU_SPECTRUM "Enable QRhi GPU spectrum rendering" ON)
 option(ENABLE_SPECBLEACH "Enable NR4 spectral bleach noise reduction" ON)
 option(ENABLE_DFNR "Enable DFNR DeepFilterNet3 noise reduction" ON)
@@ -1109,7 +1110,7 @@ if(DEFINED ENV{SOURCE_DATE_EPOCH})
     message(STATUS "Reproducible build: honoring SOURCE_DATE_EPOCH=$ENV{SOURCE_DATE_EPOCH}")
 endif()
 
-if(UNIX)
+if(UNIX AND ENABLE_DSTAR)
     set(DSTAR_WAVEFORM_DIR "${CMAKE_SOURCE_DIR}/third_party/smartsdr-dsp")
     set(DSTAR_WAVEFORM_SOURCES
         ${DSTAR_WAVEFORM_DIR}/SmartSDR_Interface/cmd_basics.c

--- a/README.md
+++ b/README.md
@@ -262,3 +262,4 @@ See [docs/VERIFYING-RELEASES.md](docs/VERIFYING-RELEASES.md) for full instructio
 AetherSDR is free and open-source software licensed under the [GNU General Public License v3](LICENSE).
 
 *AetherSDR is an independent project and is not affiliated with or endorsed by FlexRadio Systems.*
+*D-STAR is a registered trademark of Icom Inc. AetherSDR is not affiliated with or endorsed by Icom Inc.*

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -273,3 +273,20 @@ Redistributed / downloaded components:
             The full license texts ship inside the downloaded pack
             (licenses/ + NOTICE.txt) and the user must accept them on first use.
   Source:   https://developer.nvidia.com/maxine  (NGC: nvidia/maxine)
+
+
+18. SmartSDR-DSP ThumbDV Waveform Helper
+-----------------------------------------
+Bundled at third_party/smartsdr-dsp/ as a local helper executable for D-Star
+waveform operation with a ThumbDV/DV3000U attached to the user's computer. The
+import is trimmed to the ThumbDV waveform runtime sources from the public
+`thumbDV_support` branch. The historical FTDI D2XX header, static library,
+Windows GUI, IDE files, and packaged `.ssdr_waveform` binary are not bundled.
+AetherSDR replaces the D2XX calls used by the helper with a POSIX termios serial
+compatibility shim and starts the helper as a separate process.
+
+  Copyright (C) 2014 FlexRadio Systems
+  License: GPL-3.0-or-later
+  Source:  https://github.com/n5ac/smartsdr-dsp
+  Import:  thumbDV_support commit 762297a7d56f9e37c661c550e4b1cbd8b78091f1
+  Patches: third_party/smartsdr-dsp/AETHERSDR-PATCHES.md

--- a/docs/architecture/dstar-thumbdv-waveform.md
+++ b/docs/architecture/dstar-thumbdv-waveform.md
@@ -1,0 +1,85 @@
+# D-STAR Local Waveform
+
+AetherSDR starts the D-STAR waveform as a local helper process. The helper
+talks to the radio over the Flex waveform network API and uses a ThumbDV or
+DV3000U over the operating system serial device for AMBE voice encode/decode.
+The ThumbDV stays attached to the computer running AetherSDR; it does not need
+to be plugged into the radio.
+
+Software AMBE encode/decode is intentionally not bundled at this time because
+of patent review concerns.
+
+## App-To-Helper Contract
+
+The default helper executable name is `aether-dstar-waveform`. On macOS and
+Linux, AetherSDR builds this helper from the bundled
+`third_party/smartsdr-dsp` ThumbDV waveform sources and places it beside the
+main executable. Windows can still run an externally configured helper, but the
+bundled helper is currently POSIX/termios based.
+
+AetherSDR starts the helper with the radio address and configured ThumbDV
+serial device:
+
+```text
+--host <radio-ip> --vocoder thumbdv --serial <thumbdv-device> --mode DSTR --underlying-mode DFM
+```
+
+AetherSDR also runs the helper from its executable directory so it can read the
+bundled `ThumbDV.cfg`, and sets these environment variables for helpers that
+follow the Waveform Processor convention or prefer environment configuration:
+
+```text
+SSDR_RADIO_ADDRESS=<radio-ip>
+AETHER_DSTAR_VOCODER=thumbdv
+AETHER_DSTAR_THUMBDV_SERIAL=<thumbdv-device>
+AETHER_DSTAR_FAIL_FAST=1
+AETHER_DSTAR_MODE=DSTR
+AETHER_DSTAR_UNDERLYING_MODE=DFM
+```
+
+The helper registers the mode with the radio through the Flex waveform API. The
+bundled `ThumbDV.cfg` uses this shape:
+
+```text
+waveform create name=ThumbDV mode=DSTR underlying_mode=DFM version=1.1.0
+waveform set ThumbDV tx=1
+waveform set ThumbDV rx_filter low_cut=-3500
+waveform set ThumbDV rx_filter high_cut=3500
+waveform set ThumbDV tx_filter low_cut=0
+waveform set ThumbDV tx_filter high_cut=4800
+waveform set ThumbDV udpport=5000
+```
+
+## Data Path
+
+With `underlying_mode=DFM`, the radio performs the FM discriminator stage and
+the helper receives demodulated L/R sample packets. The helper then performs
+D-STAR symbol/frame recovery, passes AMBE voice frames to the ThumbDV, and
+sends decoded PCM back to the radio as speaker data.
+
+Using `RAW` would move FM/GMSK demodulation into the helper and require I/Q
+data. That is not required for the DFM D-STAR path above.
+
+On transmit, the radio supplies microphone sample packets when the operator
+intentionally keys the DSTR slice. The helper sends speech to the ThumbDV for
+voice encoding, builds D-STAR/GMSK transmitter samples, and sends transmitter
+data packets back to the radio. AetherSDR does not key the transmitter to start
+the helper.
+
+## Dependency Boundary
+
+The helper is a separate executable, not part of the main Qt GUI binary. Flex's
+current `waveform-sdk` is LGPL-3.0 and normally comes from their waveform
+development container. The bundled helper instead uses the public GPL-3.0
+SmartSDR-DSP ThumbDV waveform sources listed in `THIRD_PARTY_LICENSES`.
+
+The historical SmartSDR-DSP branch carried legacy FTDI D2XX headers and a
+static library; those are intentionally not bundled. `aether_serial_compat.c`
+provides the small D2XX call surface that the ThumbDV code uses on top of
+normal OS serial ports.
+
+## Trademark Note
+
+D-STAR is a registered trademark of Icom Inc. AetherSDR uses the term only to
+identify compatibility with the D-STAR amateur-radio protocol and is not
+affiliated with or endorsed by Icom Inc.

--- a/src/core/DStarWaveformProcess.cpp
+++ b/src/core/DStarWaveformProcess.cpp
@@ -1,0 +1,237 @@
+#include "DStarWaveformProcess.h"
+
+#include "DStarWaveformSettings.h"
+#include "LogManager.h"
+
+#include <QCoreApplication>
+#include <QByteArray>
+#include <QDir>
+#include <QFileInfo>
+#include <QList>
+#include <QProcessEnvironment>
+#include <QStandardPaths>
+
+namespace AetherSDR {
+
+DStarWaveformProcess& DStarWaveformProcess::instance()
+{
+    static DStarWaveformProcess process;
+    return process;
+}
+
+DStarWaveformProcess::DStarWaveformProcess(QObject* parent)
+    : QObject(parent)
+{
+    m_process.setProcessChannelMode(QProcess::SeparateChannels);
+
+    connect(&m_process, &QProcess::started, this, [this] {
+        const QString suffix = m_runningBackendLabel.isEmpty()
+            ? QString{}
+            : tr(" (%1)").arg(m_runningBackendLabel);
+        setState(State::Running, tr("Running%1").arg(suffix));
+    });
+    connect(&m_process, &QProcess::readyReadStandardOutput, this, [this] {
+        drainOutput(QProcess::StandardOutput);
+    });
+    connect(&m_process, &QProcess::readyReadStandardError, this, [this] {
+        drainOutput(QProcess::StandardError);
+    });
+    connect(&m_process,
+            qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+            this,
+            [this](int exitCode, QProcess::ExitStatus status) {
+        drainOutput(QProcess::StandardOutput);
+        drainOutput(QProcess::StandardError);
+
+        if (m_state == State::Stopping) {
+            setState(State::Stopped, tr("Stopped"));
+            return;
+        }
+
+        if (status == QProcess::CrashExit) {
+            fail(tr("D-STAR waveform process crashed"));
+            return;
+        }
+        if (exitCode != 0) {
+            fail(tr("D-STAR waveform process exited with code %1").arg(exitCode));
+            return;
+        }
+        setState(State::Stopped, tr("Stopped"));
+    });
+    connect(&m_process, &QProcess::errorOccurred, this, [this](QProcess::ProcessError error) {
+        if (error == QProcess::FailedToStart) {
+            fail(tr("Failed to start D-STAR waveform process: %1").arg(m_process.errorString()));
+        }
+    });
+}
+
+QString DStarWaveformProcess::stateName(State state)
+{
+    switch (state) {
+    case State::Stopped:  return QStringLiteral("Stopped");
+    case State::Starting: return QStringLiteral("Starting");
+    case State::Running:  return QStringLiteral("Running");
+    case State::Stopping: return QStringLiteral("Stopping");
+    case State::Failed:   return QStringLiteral("Failed");
+    }
+    return QStringLiteral("Unknown");
+}
+
+QString DStarWaveformProcess::defaultExecutablePath()
+{
+    const QString appDir = QCoreApplication::applicationDirPath();
+#if defined(Q_OS_MAC)
+    const QString bundled = QDir(appDir).filePath(QStringLiteral("aether-dstar-waveform"));
+#else
+    const QString bundled = QDir(appDir).filePath(QStringLiteral("aether-dstar-waveform"));
+#endif
+    if (QFileInfo(bundled).isExecutable()) {
+        return bundled;
+    }
+
+    const QString fromPath = QStandardPaths::findExecutable(QStringLiteral("aether-dstar-waveform"));
+    if (!fromPath.isEmpty()) {
+        return fromPath;
+    }
+
+    return bundled;
+}
+
+QString DStarWaveformProcess::resolveExecutablePath(const QString& configuredPath)
+{
+    const QString trimmed = configuredPath.trimmed();
+    if (!trimmed.isEmpty()) {
+        return trimmed;
+    }
+    return defaultExecutablePath();
+}
+
+bool DStarWaveformProcess::startForRadio(const QHostAddress& radioAddress)
+{
+    if (isActive()) {
+        return true;
+    }
+
+    m_lastError.clear();
+
+    if (radioAddress.isNull()) {
+        fail(tr("No connected radio address is available"));
+        return false;
+    }
+
+    const QString executable =
+        resolveExecutablePath(DStarWaveformSettings::executablePath());
+    const QFileInfo exeInfo(executable);
+    if (!exeInfo.exists() || !exeInfo.isFile() || !exeInfo.isExecutable()) {
+        fail(tr("D-STAR waveform executable is not available: %1").arg(executable));
+        return false;
+    }
+
+    const DStarWaveformSettings::Backend backend = DStarWaveformSettings::backend();
+    const QString backendArg = DStarWaveformSettings::backendArgument(backend);
+    const QString serialPort = DStarWaveformSettings::serialPort();
+    if (DStarWaveformSettings::backendRequiresSerial(backend) && serialPort.isEmpty()) {
+        fail(tr("ThumbDV serial port is not configured"));
+        return false;
+    }
+
+    m_runningBackendLabel = DStarWaveformSettings::backendLabel(backend);
+    setState(State::Starting, tr("Starting"));
+    m_process.setProgram(executable);
+    m_process.setArguments(launchArguments(radioAddress));
+    m_process.setWorkingDirectory(exeInfo.absolutePath());
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert(QStringLiteral("SSDR_RADIO_ADDRESS"), radioAddress.toString());
+    env.insert(QStringLiteral("AETHER_DSTAR_VOCODER"), backendArg);
+    if (!serialPort.isEmpty()) {
+        env.insert(QStringLiteral("AETHER_DSTAR_THUMBDV_SERIAL"), serialPort);
+    }
+    env.insert(QStringLiteral("AETHER_DSTAR_FAIL_FAST"), QStringLiteral("1"));
+    env.insert(QStringLiteral("AETHER_DSTAR_MODE"), QStringLiteral("DSTR"));
+    env.insert(QStringLiteral("AETHER_DSTAR_UNDERLYING_MODE"), QStringLiteral("DFM"));
+    m_process.setProcessEnvironment(env);
+    qCInfo(lcWaveform) << "DStarWaveformProcess: starting" << executable
+                       << m_process.arguments();
+    m_process.start();
+    return true;
+}
+
+void DStarWaveformProcess::stop()
+{
+    if (m_state == State::Stopped) {
+        return;
+    }
+    if (m_state == State::Failed && m_process.state() == QProcess::NotRunning) {
+        setState(State::Stopped, tr("Stopped"));
+        return;
+    }
+
+    setState(State::Stopping, tr("Stopping"));
+    if (m_process.state() == QProcess::NotRunning) {
+        setState(State::Stopped, tr("Stopped"));
+        return;
+    }
+    m_process.terminate();
+    if (!m_process.waitForFinished(1500)) {
+        qCWarning(lcWaveform) << "DStarWaveformProcess: terminate timed out; killing process";
+        m_process.kill();
+    }
+}
+
+void DStarWaveformProcess::setState(State state, const QString& statusText)
+{
+    const bool didChangeState = m_state != state;
+    m_state = state;
+
+    const QString text = statusText.isEmpty() ? stateName(state) : statusText;
+    if (m_statusText != text) {
+        m_statusText = text;
+        emit statusTextChanged(m_statusText);
+    }
+    if (didChangeState) {
+        emit stateChanged(m_state);
+    }
+}
+
+void DStarWaveformProcess::fail(const QString& message)
+{
+    m_lastError = message;
+    m_runningBackendLabel.clear();
+    qCWarning(lcWaveform) << "DStarWaveformProcess:" << message;
+    setState(State::Failed, message);
+}
+
+QStringList DStarWaveformProcess::launchArguments(const QHostAddress& radioAddress) const
+{
+    const DStarWaveformSettings::Backend backend = DStarWaveformSettings::backend();
+    QStringList args {
+        QStringLiteral("--host"), radioAddress.toString(),
+        QStringLiteral("--vocoder"), DStarWaveformSettings::backendArgument(backend),
+        QStringLiteral("--mode"), QStringLiteral("DSTR"),
+        QStringLiteral("--underlying-mode"), QStringLiteral("DFM")
+    };
+    if (DStarWaveformSettings::backendRequiresSerial(backend)) {
+        args << QStringLiteral("--serial") << DStarWaveformSettings::serialPort();
+    }
+    return args;
+}
+
+void DStarWaveformProcess::drainOutput(QProcess::ProcessChannel channel)
+{
+    m_process.setReadChannel(channel);
+    const QByteArray output = m_process.readAll();
+    const QList<QByteArray> lines = output.split('\n');
+    for (const QByteArray& rawLine : lines) {
+        QString line = QString::fromLocal8Bit(rawLine).trimmed();
+        if (line.isEmpty()) {
+            continue;
+        }
+        if (line.size() > 1000) {
+            line = line.left(1000);
+        }
+        qCInfo(lcWaveform).noquote() << "DStarWaveformProcess:" << line;
+        emit processOutput(line);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/core/DStarWaveformProcess.h
+++ b/src/core/DStarWaveformProcess.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <QHostAddress>
+#include <QObject>
+#include <QProcess>
+#include <QString>
+
+namespace AetherSDR {
+
+class DStarWaveformProcess : public QObject
+{
+    Q_OBJECT
+
+public:
+    enum class State {
+        Stopped,
+        Starting,
+        Running,
+        Stopping,
+        Failed
+    };
+    Q_ENUM(State)
+
+    static DStarWaveformProcess& instance();
+
+    State state() const { return m_state; }
+    bool isActive() const { return m_state == State::Starting || m_state == State::Running; }
+    QString statusText() const { return m_statusText; }
+    QString lastError() const { return m_lastError; }
+
+    static QString stateName(State state);
+    static QString defaultExecutablePath();
+    static QString resolveExecutablePath(const QString& configuredPath);
+
+public slots:
+    bool startForRadio(const QHostAddress& radioAddress);
+    void stop();
+
+signals:
+    void stateChanged(AetherSDR::DStarWaveformProcess::State state);
+    void statusTextChanged(const QString& text);
+    void processOutput(const QString& line);
+
+private:
+    explicit DStarWaveformProcess(QObject* parent = nullptr);
+
+    void setState(State state, const QString& statusText = {});
+    void fail(const QString& message);
+    QStringList launchArguments(const QHostAddress& radioAddress) const;
+    void drainOutput(QProcess::ProcessChannel channel);
+
+    QProcess m_process;
+    State m_state{State::Stopped};
+    QString m_statusText;
+    QString m_lastError;
+    QString m_runningBackendLabel;
+};
+
+} // namespace AetherSDR

--- a/src/core/DStarWaveformSettings.h
+++ b/src/core/DStarWaveformSettings.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QString>
+
+namespace AetherSDR {
+
+class DStarWaveformSettings
+{
+public:
+    enum class Backend {
+        ThumbDv
+    };
+
+    static Backend backend()
+    {
+        return backendFromString(readObj().value(QStringLiteral("Backend")).toString());
+    }
+
+    static void setBackend(Backend backend)
+    {
+        QJsonObject obj = readObj();
+        obj[QStringLiteral("Backend")] = backendId(backend);
+        write(obj);
+    }
+
+    static QString backendId(Backend backend)
+    {
+        switch (backend) {
+        case Backend::ThumbDv:
+            return QStringLiteral("ThumbDV");
+        }
+        return QStringLiteral("ThumbDV");
+    }
+
+    static QString backendArgument(Backend backend)
+    {
+        switch (backend) {
+        case Backend::ThumbDv:
+            return QStringLiteral("thumbdv");
+        }
+        return QStringLiteral("thumbdv");
+    }
+
+    static QString backendLabel(Backend backend)
+    {
+        switch (backend) {
+        case Backend::ThumbDv:
+            return QStringLiteral("ThumbDV / DV3000");
+        }
+        return QStringLiteral("ThumbDV / DV3000");
+    }
+
+    static Backend backendFromString(const QString& value)
+    {
+        Q_UNUSED(value);
+        return Backend::ThumbDv;
+    }
+
+    static bool backendRequiresSerial(Backend backend)
+    {
+        Q_UNUSED(backend);
+        return true;
+    }
+
+    static bool autoStart()
+    {
+        return readObj().value(QStringLiteral("AutoStart")).toBool(false);
+    }
+
+    static void setAutoStart(bool on)
+    {
+        QJsonObject obj = readObj();
+        obj[QStringLiteral("AutoStart")] = on;
+        write(obj);
+    }
+
+    static QString executablePath()
+    {
+        return readObj().value(QStringLiteral("ExecutablePath")).toString().trimmed();
+    }
+
+    static void setExecutablePath(const QString& path)
+    {
+        QJsonObject obj = readObj();
+        const QString trimmed = path.trimmed();
+        if (trimmed.isEmpty()) {
+            obj.remove(QStringLiteral("ExecutablePath"));
+        } else {
+            obj[QStringLiteral("ExecutablePath")] = trimmed;
+        }
+        write(obj);
+    }
+
+    static QString serialPort()
+    {
+        return readObj().value(QStringLiteral("SerialPort")).toString().trimmed();
+    }
+
+    static void setSerialPort(const QString& port)
+    {
+        QJsonObject obj = readObj();
+        const QString trimmed = port.trimmed();
+        if (trimmed.isEmpty()) {
+            obj.remove(QStringLiteral("SerialPort"));
+        } else {
+            obj[QStringLiteral("SerialPort")] = trimmed;
+        }
+        write(obj);
+    }
+
+private:
+    static constexpr const char* kRootKey = "DStarWaveform";
+
+    static QJsonObject readObj()
+    {
+        const QString json =
+            AppSettings::instance().value(kRootKey, QString{}).toString();
+        if (json.isEmpty()) {
+            return {};
+        }
+
+        QJsonParseError error{};
+        const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &error);
+        if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+            return {};
+        }
+        return doc.object();
+    }
+
+    static void write(const QJsonObject& obj)
+    {
+        AppSettings::instance().setValue(kRootKey,
+            QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+        AppSettings::instance().save();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -72,7 +72,7 @@ LogManager::LogManager()
         {"aether.cw",         "CW / netCW",    "CW keying, MIDI paddle, iambic, and netCW timing"},
         {"aether.shistory",   "S History",     "Past-Signals voice detection: noise floor, region width, band-plan filter"},
         {"aether.ax25",       "AetherModem", "AX.25 modem lifecycle, RX/TX audio, demod, framing, and packet diagnostics"},
-        {"aether.waveform",   "Waveform",    "Docker waveform image install upload"},
+        {"aether.waveform",   "Waveform",    "Docker waveform image install upload and local waveform helper lifecycle"},
         {"aether.kiwisdr",    "KiwiSDR",     "KiwiSDR remote RX antennas: connect, handshake, audio/waterfall negotiation, reconnect, profile lifecycle"},
         {"aether.kiwisdr.audio", "KiwiSDR Audio/DSP", "Verbose KiwiSDR receive audio: frame decode, resampler, jitter/FIFO under/overrun, mixing (high-rate; off by default)"},
         {"aether.automation", "Automation Bridge", "Agent-drivable test bridge (#3646): QLocalServer verbs, widget snapshots, captures (AETHER_AUTOMATION only)"},

--- a/src/core/WaveformInstaller.cpp
+++ b/src/core/WaveformInstaller.cpp
@@ -9,6 +9,32 @@
 
 namespace AetherSDR {
 
+namespace {
+
+bool isSafeUploadFileName(const QString& fileName)
+{
+    if (fileName.isEmpty() || fileName.size() > 255) {
+        return false;
+    }
+
+    for (const QChar ch : fileName) {
+        const ushort c = ch.unicode();
+        const bool allowed =
+            (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+            || (c >= '0' && c <= '9')
+            || c == '.'
+            || c == '_'
+            || c == '-';
+        if (!allowed) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
 WaveformInstaller::WaveformInstaller(RadioModel* model, QObject* parent)
     : QObject(parent), m_model(model)
 {
@@ -19,8 +45,33 @@ WaveformInstaller::WaveformInstaller(RadioModel* model, QObject* parent)
 
 void WaveformInstaller::install(const QString& filePath)
 {
+    installDockerWaveform(filePath);
+}
+
+void WaveformInstaller::installLegacyWaveform(const QString& filePath)
+{
+    beginInstall(filePath, PackageKind::Legacy);
+}
+
+void WaveformInstaller::installDockerWaveform(const QString& filePath)
+{
+    beginInstall(filePath, PackageKind::Docker);
+}
+
+void WaveformInstaller::beginInstall(const QString& filePath, PackageKind kind)
+{
     if (m_installing) {
         emit finished(false, tr("Install already in progress"));
+        return;
+    }
+
+    const QFileInfo fileInfo(filePath);
+    const QString fileName = fileInfo.fileName();
+
+    if (!isSafeUploadFileName(fileName)) {
+        emit finished(false, tr("Waveform package filename contains characters "
+                                "that cannot be sent safely to the radio. "
+                                "Use letters, numbers, dots, dashes, and underscores."));
         return;
     }
 
@@ -30,52 +81,81 @@ void WaveformInstaller::install(const QString& filePath)
         return;
     }
 
-    // Validate file format: accept gzip-compressed tars (magic 0x1F 0x8B) and
-    // plain uncompressed tars (POSIX "ustar" magic at byte 257).
-    // FlexRadio waveform packages may use either format — newer releases ship
-    // Docker OCI image layout tars without gzip compression despite a .tar.gz
-    // extension (confirmed with freedv-waveform-2.4.0-dev-7132.tar.gz).
-    const QByteArray header = file.read(262);
-    const bool isGzip = header.size() >= 2
-                        && static_cast<quint8>(header[0]) == 0x1F
-                        && static_cast<quint8>(header[1]) == 0x8B;
-    const bool isTar  = header.size() >= 262
-                        && header.mid(257, 5) == QByteArray("ustar", 5);
-    if (!isGzip && !isTar) {
-        emit finished(false, tr("Not a valid waveform image (expected a .tar.gz or tar archive)"));
-        return;
+    if (kind == PackageKind::Legacy) {
+        if (fileInfo.suffix().compare(QStringLiteral("ssdr_waveform"),
+                                      Qt::CaseInsensitive) != 0) {
+            emit finished(false, tr("Not a legacy SmartSDR waveform package "
+                                    "(expected .ssdr_waveform)"));
+            return;
+        }
+    } else {
+        // Validate file format: accept gzip-compressed tars (magic 0x1F 0x8B)
+        // and plain uncompressed tars (POSIX "ustar" magic at byte 257).
+        // FlexRadio Docker waveform packages may use either format — newer
+        // releases ship Docker OCI image layout tars without gzip compression
+        // despite a .tar.gz extension.
+        const QByteArray header = file.read(262);
+        const bool isGzip = header.size() >= 2
+                            && static_cast<quint8>(header[0]) == 0x1F
+                            && static_cast<quint8>(header[1]) == 0x8B;
+        const bool isTar  = header.size() >= 262
+                            && header.mid(257, 5) == QByteArray("ustar", 5);
+        if (!isGzip && !isTar) {
+            emit finished(false, tr("Not a valid Docker waveform image "
+                                    "(expected a .tar.gz or tar archive)"));
+            return;
+        }
+        file.seek(0);
     }
-    file.seek(0);
 
-    m_fileData = file.readAll();
-    file.close();
-
-    if (m_fileData.isEmpty()) {
+    const qint64 fileSize = fileInfo.size();
+    if (fileSize <= 0) {
         emit finished(false, tr("File is empty"));
         return;
     }
 
-    if (m_fileData.size() > MAX_FILE_BYTES) {
+    if (fileSize > MAX_FILE_BYTES) {
         emit finished(false, tr("File too large (> 500 MB)"));
         return;
     }
 
-    m_fileName   = QFileInfo(filePath).fileName();
-    m_bytesSent  = 0;
-    m_uploadPort = -1;
-    m_installing = true;
-    m_cancelled  = false;
+    m_fileData = file.readAll();
+    file.close();
+
+    if (m_fileData.size() != fileSize) {
+        emit finished(false, tr("Could not read the complete waveform package"));
+        m_fileData.clear();
+        return;
+    }
+
+    m_fileName    = fileName;
+    m_packageKind = kind;
+    m_bytesSent   = 0;
+    m_uploadPort  = -1;
+    m_installing  = true;
+    m_cancelled   = false;
 
     emit progressChanged(0, tr("Requesting upload port…"));
 
-    // Single command — filename is embedded directly (no separate "file filename" step).
-    // Protocol confirmed by pcap 4.2.18-waveform-install.pcapng frame 4496.
-    m_model->sendCmdPublic(
-        QStringLiteral("file upload %1 waveform_docker_image %2")
-            .arg(m_fileData.size()).arg(m_fileName),
-        [this](int code, const QString& body) {
-            onUploadPortReceived(code, body);
-        });
+    if (kind == PackageKind::Legacy) {
+        // FlexLib Radio.cs SendSSDRWaveformFile sends the filename first, then
+        // requests an upload port with upload kind "new_waveform".
+        m_model->sendCmdPublic(QStringLiteral("file filename ") + m_fileName, nullptr);
+        m_model->sendCmdPublic(
+            QStringLiteral("file upload %1 new_waveform").arg(m_fileData.size()),
+            [this](int code, const QString& body) {
+                onUploadPortReceived(code, body);
+            });
+    } else {
+        // Docker images embed the filename in the upload command.
+        // Protocol confirmed by pcap 4.2.18-waveform-install.pcapng frame 4496.
+        m_model->sendCmdPublic(
+            QStringLiteral("file upload %1 waveform_docker_image %2")
+                .arg(m_fileData.size()).arg(m_fileName),
+            [this](int code, const QString& body) {
+                onUploadPortReceived(code, body);
+            });
+    }
 }
 
 void WaveformInstaller::cancel()
@@ -137,7 +217,9 @@ void WaveformInstaller::onConnected()
     if (m_cancelled) return;
 
     qCDebug(lcWaveform) << "WaveformInstaller: connected, sending" << m_fileData.size() << "bytes";
-    emit progressChanged(0, tr("Uploading waveform image…"));
+    emit progressChanged(0, m_packageKind == PackageKind::Legacy
+                             ? tr("Uploading legacy waveform…")
+                             : tr("Uploading Docker waveform image…"));
 
     const qint64 toSend = qMin(static_cast<qint64>(CHUNK_SIZE),
                                 m_fileData.size() - m_bytesSent);
@@ -162,8 +244,11 @@ void WaveformInstaller::onBytesWritten(qint64 bytes)
         m_installing = false;
         m_fileData.clear();
         emit progressChanged(100, tr("Upload complete — installing on radio…"));
-        emit finished(true, tr("Waveform image uploaded successfully. "
-                               "The radio will install it momentarily."));
+        emit finished(true, m_packageKind == PackageKind::Legacy
+                      ? tr("Legacy waveform uploaded successfully. "
+                           "The radio will install it momentarily.")
+                      : tr("Docker waveform image uploaded successfully. "
+                           "The radio will install it momentarily."));
         return;
     }
 

--- a/src/core/WaveformInstaller.h
+++ b/src/core/WaveformInstaller.h
@@ -9,10 +9,15 @@ namespace AetherSDR {
 
 class RadioModel;
 
-// Installs a Docker waveform container image on the radio via the file upload
-// protocol introduced in firmware 4.2.18.
+// Installs radio waveform packages via the Flex file upload protocol.
 //
-// Protocol (confirmed by pcap 4.2.18-waveform-install.pcapng, frame 4496):
+// Legacy protocol (FlexLib Radio.cs SendSSDRWaveformFile):
+//   1. Client -> Radio: "file filename <filename>"
+//   2. Client -> Radio: "file upload <size> new_waveform"
+//   3. Radio  -> Client: R<seq>|0|<port>
+//   4. Client connects TCP to radio:<port> and streams raw .ssdr_waveform bytes
+//
+// Docker protocol (confirmed by pcap 4.2.18-waveform-install.pcapng, frame 4496):
 //   1. Client → Radio: "file upload <size> waveform_docker_image <filename>"
 //   2. Radio  → Client: R<seq>|0|<port>   (radio opens TCP server on <port>)
 //   3. Radio  → Client: S0|file server active
@@ -30,9 +35,16 @@ class WaveformInstaller : public QObject {
 public:
     explicit WaveformInstaller(RadioModel* model, QObject* parent = nullptr);
 
-    // Begin installing the .tar.gz waveform image at filePath.
-    // Emits progressChanged() during transfer and finished() on completion.
+    // Backward-compatible Docker install entry point.
     void install(const QString& filePath);
+
+    // Begin installing a legacy .ssdr_waveform package at filePath.
+    // Emits progressChanged() during transfer and finished() on completion.
+    void installLegacyWaveform(const QString& filePath);
+
+    // Begin installing a Docker .tar/.tar.gz/.tgz waveform image at filePath.
+    // Emits progressChanged() during transfer and finished() on completion.
+    void installDockerWaveform(const QString& filePath);
 
     // Abort an in-progress install.
     void cancel();
@@ -44,6 +56,12 @@ signals:
     void finished(bool success, const QString& message);
 
 private:
+    enum class PackageKind {
+        Legacy,
+        Docker
+    };
+
+    void beginInstall(const QString& filePath, PackageKind kind);
     void onUploadPortReceived(int code, const QString& body);
     void onConnected();
     void onBytesWritten(qint64 bytes);
@@ -53,6 +71,7 @@ private:
     QTcpSocket  m_socket;
     QByteArray  m_fileData;
     QString     m_fileName;
+    PackageKind m_packageKind{PackageKind::Docker};
     qint64      m_bytesSent{0};
     int         m_uploadPort{-1};
     bool        m_installing{false};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -213,6 +213,8 @@
 #include <QToolTip>
 #include <QMediaDevices>
 #include "core/AppSettings.h"
+#include "core/DStarWaveformProcess.h"
+#include "core/DStarWaveformSettings.h"
 #include "core/SpotCommandPolicy.h"
 #include "core/SpotModeResolver.h"
 #ifdef HAVE_RADE
@@ -5024,6 +5026,14 @@ void MainWindow::onConnectionStateChanged(bool connected)
             });
         }
 #endif
+        if (DStarWaveformSettings::autoStart()) {
+            QTimer::singleShot(3000, this, [this]() {
+                if (!m_radioModel.isConnected()) {
+                    return;
+                }
+                DStarWaveformProcess::instance().startForRadio(m_radioModel.radioAddress());
+            });
+        }
         // Auto-connect DX cluster if enabled
         {
             auto& cs = AppSettings::instance();
@@ -5126,6 +5136,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
         updateTMate2Status();
 #endif
     } else {
+        DStarWaveformProcess::instance().stop();
+
         // Radio disconnected: trim CAT ports back to 1 so apps on channel A
         // stay connected through brief reconnects, higher channels stop cleanly.
         applyCatPortCount();  // catPortTargetCount() returns 1 when !connected

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2983,6 +2983,14 @@ void MainWindow::closeEvent(QCloseEvent* event)
     m_tgxlConn.disconnect();
     m_pgxlConn.disconnect();
 
+    // Same reason as the TGXL/PGXL sockets above: the D-STAR helper is stopped
+    // by the queued RadioModel::connectionStateChanged(false) handler, which
+    // does not run during close (the event loop isn't pumped here). Without an
+    // explicit stop, quitting while the radio is connected orphans the helper
+    // subprocess — it keeps holding the ThumbDV serial port and can block the
+    // next AetherSDR launch from reacquiring it.
+    DStarWaveformProcess::instance().stop();
+
     preparePanadapterUiForShutdown();
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -2007,8 +2007,8 @@ void MainWindow::registerMidiParams()
 
     // ── Mode triggers (mirror Mode/* keyboard shortcuts) ───────────────
     static const char* kModes[] = {"USB", "LSB", "CW", "CWL",
-                                    "AM", "SAM", "FM", "NFM",
-                                    "DFM", "DIGU", "DIGL", "RTTY"};
+                                   "AM", "SAM", "FM", "NFM",
+                                   "DFM", "DSTR", "DIGU", "DIGL", "RTTY"};
     for (const char* m : kModes) {
         const QString idShort = QString("mode_%1").arg(QString(m).toLower());
         const QString idMidi  = QString("global.mode%1").arg(m);

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1245,6 +1245,9 @@ void MainWindow::buildMenuBar()
             "<p style='font-size:10px; color:#6a8090;'>"
             "SmartSDR protocol &copy; FlexRadio Systems</p>"
             "<p style='font-size:10px; color:#6a8090;'>"
+            "D-STAR is a registered trademark of Icom Inc.<br>"
+            "AetherSDR is not affiliated with or endorsed by Icom Inc.</p>"
+            "<p style='font-size:10px; color:#6a8090;'>"
             "HF propagation forecasts provided by "
             "<a href='https://www.hamqsl.com/' style='color:#8aa8c0;'>hamqsl.com</a></p>"
             "</div>");

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -802,7 +802,7 @@ void MainWindow::registerShortcutActions()
     }
 
     // ── Mode ────────────────────────────────────────────────────────────
-    static const char* modes[] = {"USB", "LSB", "CW", "CWL", "AM", "SAM", "FM", "NFM", "DFM", "DIGU", "DIGL", "RTTY"};
+    static const char* modes[] = {"USB", "LSB", "CW", "CWL", "AM", "SAM", "FM", "NFM", "DFM", "DSTR", "DIGU", "DIGL", "RTTY"};
     for (const char* mode : modes) {
         QString m = mode;
         m_shortcutManager.registerAction(

--- a/src/gui/NetSchedulerDialog.cpp
+++ b/src/gui/NetSchedulerDialog.cpp
@@ -41,7 +41,7 @@ const char* const kWeekdayLong[7] = {"Monday",   "Tuesday", "Wednesday", "Thursd
 QStringList commonModes()
 {
     return {"LSB", "USB", "CW", "CWL", "CWU", "AM", "SAM",
-            "FM", "NFM", "DIGL", "DIGU", "RTTY", "FDV"};
+            "FM", "NFM", "DFM", "DSTR", "DIGL", "DIGU", "RTTY", "FDV"};
 }
 
 // Friendly one-line preview of the next firing, e.g.

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -535,7 +535,7 @@ void RxApplet::buildUI()
         m_modeCombo = new GuardedComboBox;
         m_modeCombo->setFixedHeight(20);
         m_modeCombo->addItems({"USB", "LSB", "CW", "AM", "SAM", "FM",
-                               "NFM", "DFM", "DIGU", "DIGL", "RTTY"});
+                               "NFM", "DFM", "DSTR", "DIGU", "DIGL", "RTTY"});
 #ifdef HAVE_RADE
         m_modeCombo->addItem("RADE");
 #endif

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2199,7 +2199,7 @@ void VfoWidget::buildTabContent()
         m_modeCombo->setFixedHeight(26);
         // Default modes — replaced dynamically when slice connects and sends mode_list
         m_modeCombo->addItems({"USB", "LSB", "CW", "AM", "SAM", "FM",
-                                "NFM", "DFM", "DIGU", "DIGL", "RTTY"});
+                                "NFM", "DFM", "DSTR", "DIGU", "DIGL", "RTTY"});
 #ifdef HAVE_RADE
         m_modeCombo->addItem("RADE");
 #endif
@@ -2275,7 +2275,7 @@ void VfoWidget::buildTabContent()
             connect(btn, &QPushButton::customContextMenuRequested, this, [this, i, btn](const QPoint& pos) {
                 QMenu menu;
                 for (const char* m : {"USB", "LSB", "SSB", "CW", "AM", "SAM",
-                                      "FM", "NFM", "DFM", "RTTY", "DIGU", "DIGL", "DIG"}) {
+                                      "FM", "NFM", "DFM", "DSTR", "RTTY", "DIGU", "DIGL", "DIG"}) {
                     menu.addAction(m, [this, i, m] {
                         m_quickModeAssign[i] = m;
                         AppSettings::instance().setValue(

--- a/src/gui/WaveformsDialog.cpp
+++ b/src/gui/WaveformsDialog.cpp
@@ -1,53 +1,499 @@
 #include "WaveformsDialog.h"
+#include "core/DStarWaveformProcess.h"
+#include "core/DStarWaveformSettings.h"
 #include "core/ThemeManager.h"
 #include "core/WaveformInstaller.h"
 #include "models/FlexWaveformModel.h"
 #include "models/RadioModel.h"
 
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDir>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QMessageBox>
-#include <QProgressDialog>
+#include <QLineEdit>
+#include <QMenu>
+#include <QProgressBar>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QSet>
+#include <QSignalBlocker>
+#include <QToolButton>
 #include <QVBoxLayout>
 
+#ifdef HAVE_SERIALPORT
+#include <QSerialPortInfo>
+#endif
+
+#include <algorithm>
+
 namespace AetherSDR {
+
+namespace {
+
+struct SerialPortOption {
+    QString path;
+    QString label;
+    int score{0};
+};
+
+void applyComboHeight(QComboBox* combo)
+{
+    const int minHeight = qMax(combo->sizeHint().height(),
+                               combo->fontMetrics().height() + 12);
+    combo->setMinimumHeight(minHeight);
+}
+
+void addSerialOption(QList<SerialPortOption>& options,
+                     QSet<QString>& seen,
+                     const QString& path,
+                     const QString& label,
+                     int score)
+{
+    const QString trimmedPath = path.trimmed();
+    if (trimmedPath.isEmpty() || seen.contains(trimmedPath)) {
+        return;
+    }
+    seen.insert(trimmedPath);
+    options.push_back({trimmedPath, label.trimmed().isEmpty() ? trimmedPath : label, score});
+}
+
+int pathScore(const QString& path)
+{
+    const QString lower = path.toLower();
+    int score = 0;
+    if (lower.contains(QStringLiteral("thumbdv"))
+            || lower.contains(QStringLiteral("dv3000"))) {
+        score += 100;
+    }
+    if (lower.contains(QStringLiteral("usbserial"))
+            || lower.contains(QStringLiteral("usb-serial"))
+            || lower.contains(QStringLiteral("ftdi"))) {
+        score += 40;
+    }
+    if (lower.contains(QStringLiteral("usbmodem"))
+            || lower.contains(QStringLiteral("ttyusb"))
+            || lower.contains(QStringLiteral("ttyacm"))
+            || lower.contains(QStringLiteral("wchusbserial"))
+            || lower.contains(QStringLiteral("slab_usbtouart"))) {
+        score += 20;
+    }
+    return score;
+}
+
+QList<SerialPortOption> detectedSerialPorts()
+{
+    QList<SerialPortOption> options;
+    QSet<QString> seen;
+
+#ifdef HAVE_SERIALPORT
+    for (const QSerialPortInfo& info : QSerialPortInfo::availablePorts()) {
+        QString path = info.systemLocation();
+        if (path.isEmpty()) {
+            path = info.portName();
+        }
+
+        QStringList details;
+        if (!info.description().trimmed().isEmpty()) {
+            details << info.description().trimmed();
+        }
+        if (!info.manufacturer().trimmed().isEmpty()
+                && !details.contains(info.manufacturer().trimmed())) {
+            details << info.manufacturer().trimmed();
+        }
+
+        int score = pathScore(path);
+        const QString detailText = details.join(QStringLiteral(", "));
+        if (detailText.contains(QStringLiteral("thumbdv"), Qt::CaseInsensitive)
+                || detailText.contains(QStringLiteral("dv3000"), Qt::CaseInsensitive)) {
+            score += 100;
+        }
+        if (detailText.contains(QStringLiteral("ftdi"), Qt::CaseInsensitive)) {
+            score += 40;
+        }
+        if (info.hasVendorIdentifier() && info.vendorIdentifier() == 0x0403) {
+            score += 40;
+        }
+
+        const QString label = path;
+        addSerialOption(options, seen, path, label, score);
+    }
+#endif
+
+#if defined(Q_OS_MAC)
+    const QStringList patterns {
+        QStringLiteral("cu.usbserial*"),
+        QStringLiteral("cu.usbmodem*"),
+        QStringLiteral("cu.SLAB_USBtoUART*"),
+        QStringLiteral("cu.wchusbserial*")
+    };
+    QDir dev(QStringLiteral("/dev"));
+    for (const QString& pattern : patterns) {
+        for (const QFileInfo& info : dev.entryInfoList({pattern}, QDir::System | QDir::Files)) {
+            addSerialOption(options, seen, info.absoluteFilePath(), info.absoluteFilePath(),
+                            pathScore(info.absoluteFilePath()));
+        }
+    }
+#elif defined(Q_OS_LINUX)
+    QDir byId(QStringLiteral("/dev/serial/by-id"));
+    for (const QFileInfo& info : byId.entryInfoList(QDir::System | QDir::Files | QDir::NoDotAndDotDot)) {
+        addSerialOption(options, seen, info.absoluteFilePath(), info.absoluteFilePath(),
+                        pathScore(info.absoluteFilePath()) + 30);
+    }
+    QDir dev(QStringLiteral("/dev"));
+    for (const QString& pattern : {QStringLiteral("ttyUSB*"), QStringLiteral("ttyACM*")}) {
+        for (const QFileInfo& info : dev.entryInfoList({pattern}, QDir::System | QDir::Files)) {
+            addSerialOption(options, seen, info.absoluteFilePath(), info.absoluteFilePath(),
+                            pathScore(info.absoluteFilePath()));
+        }
+    }
+#endif
+
+    std::sort(options.begin(), options.end(), [](const SerialPortOption& lhs,
+                                                 const SerialPortOption& rhs) {
+        if (lhs.score != rhs.score) {
+            return lhs.score > rhs.score;
+        }
+        return lhs.path < rhs.path;
+    });
+    return options;
+}
+
+void showDockerWfpNotReadyDialog(QWidget* parent, const QString& statusText)
+{
+    PersistentDialog dialog(QObject::tr("Radio WFP Not Ready"), QString(), parent);
+    theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/wfpNotReady"));
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.setModal(true);
+    dialog.setMinimumWidth(420);
+
+    auto* root = new QVBoxLayout(dialog.bodyWidget());
+    root->setSpacing(10);
+
+    auto* message = new QLabel(
+        QObject::tr("AetherSDR can upload a Docker waveform image only after the radio "
+                    "reports its Waveform Processor is ON and READY.\n\n"
+                    "Current WFP status: %1.\n\n"
+                    "Use Install > Legacy Waveform... for .ssdr_waveform packages.")
+            .arg(statusText));
+    message->setTextFormat(Qt::PlainText);
+    message->setWordWrap(true);
+    message->setAccessibleName(QObject::tr("Docker waveform install status"));
+    root->addWidget(message);
+
+    auto* buttons = new QHBoxLayout;
+    buttons->addStretch();
+    auto* okButton = new QPushButton(QObject::tr("OK"));
+    okButton->setAccessibleName(QObject::tr("Close Docker waveform status"));
+    okButton->setDefault(true);
+    QObject::connect(okButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+    buttons->addWidget(okButton);
+    root->addLayout(buttons);
+
+    dialog.exec();
+}
+
+bool confirmRadioWaveformRemoval(QWidget* parent, const QString& name, bool isContainer)
+{
+    const QString title = isContainer
+        ? QObject::tr("Remove Docker Container")
+        : QObject::tr("Uninstall Radio Waveform");
+    const QString question = isContainer
+        ? QObject::tr("Remove the Docker container \"%1\" from the radio?").arg(name)
+        : QObject::tr("Uninstall the waveform \"%1\" from the radio?").arg(name);
+    const QString confirmText = isContainer
+        ? QObject::tr("Remove")
+        : QObject::tr("Uninstall");
+
+    PersistentDialog dialog(title, QString(), parent);
+    theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/removeConfirm"));
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.setModal(true);
+    dialog.setMinimumWidth(380);
+
+    auto* root = new QVBoxLayout(dialog.bodyWidget());
+    root->setSpacing(10);
+
+    auto* message = new QLabel(question);
+    message->setTextFormat(Qt::PlainText);
+    message->setWordWrap(true);
+    message->setAccessibleName(QObject::tr("Radio waveform removal confirmation"));
+    root->addWidget(message);
+
+    auto* buttons = new QHBoxLayout;
+    buttons->addStretch();
+
+    auto* cancelButton = new QPushButton(QObject::tr("Cancel"));
+    cancelButton->setAccessibleName(QObject::tr("Cancel radio waveform removal"));
+    cancelButton->setDefault(true);
+    QObject::connect(cancelButton, &QPushButton::clicked, &dialog, &QDialog::reject);
+    buttons->addWidget(cancelButton);
+
+    auto* confirmButton = new QPushButton(confirmText);
+    confirmButton->setAccessibleName(confirmText);
+    QObject::connect(confirmButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+    buttons->addWidget(confirmButton);
+
+    root->addLayout(buttons);
+
+    return dialog.exec() == QDialog::Accepted;
+}
+
+void showWaveformInstallResultDialog(QWidget* parent,
+                                     const QString& title,
+                                     const QString& messageText)
+{
+    PersistentDialog dialog(title, QString(), parent);
+    theme::setContainer(&dialog, QStringLiteral("dialog/waveforms/installResult"));
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.setModal(true);
+    dialog.setMinimumWidth(420);
+
+    auto* root = new QVBoxLayout(dialog.bodyWidget());
+    root->setSpacing(10);
+
+    auto* message = new QLabel(messageText);
+    message->setTextFormat(Qt::PlainText);
+    message->setWordWrap(true);
+    message->setAccessibleName(QObject::tr("Waveform install result"));
+    root->addWidget(message);
+
+    auto* buttons = new QHBoxLayout;
+    buttons->addStretch();
+    auto* okButton = new QPushButton(QObject::tr("OK"));
+    okButton->setAccessibleName(QObject::tr("Close waveform install result"));
+    okButton->setDefault(true);
+    QObject::connect(okButton, &QPushButton::clicked, &dialog, &QDialog::accept);
+    buttons->addWidget(okButton);
+    root->addLayout(buttons);
+
+    dialog.exec();
+}
+
+} // namespace
 
 WaveformsDialog::WaveformsDialog(RadioModel* model, QWidget* parent)
     : PersistentDialog(tr("Waveforms"), QStringLiteral("WaveformsDialogGeometry"), parent)
     , m_radioModel(model)
 {
     theme::setContainer(this, QStringLiteral("dialog/waveforms"));
-    setMinimumSize(440, 200);
+    setMinimumSize(740, 420);
 
     auto* root = new QVBoxLayout(bodyWidget());
-    root->setSpacing(8);
-    root->setContentsMargins(10, 8, 10, 10);
+    root->setSpacing(10);
+    root->setContentsMargins(12, 10, 12, 12);
 
     // ── WFP status bar ────────────────────────────────────────────────────────
     auto* statusFrame = new QFrame;
     statusFrame->setFrameShape(QFrame::StyledPanel);
     auto* statusRow = new QHBoxLayout(statusFrame);
-    statusRow->setContentsMargins(8, 4, 8, 4);
+    statusRow->setContentsMargins(10, 6, 10, 6);
 
     m_statusLabel = new QLabel;
     m_statusLabel->setTextFormat(Qt::RichText);
-    statusRow->addWidget(m_statusLabel);
-    statusRow->addStretch();
-
-    m_installBtn = new QPushButton(tr("Install…"));
-    m_installBtn->setAccessibleName(tr("Install Docker Waveform"));
-    m_installBtn->setFixedWidth(80);
-    m_installBtn->setEnabled(false);  // enabled once WFP is powered and ready
-    connect(m_installBtn, &QPushButton::clicked, this, &WaveformsDialog::onInstallClicked);
-    statusRow->addWidget(m_installBtn);
+    statusRow->addWidget(m_statusLabel, 1);
 
     root->addWidget(statusFrame);
 
+    auto* contentRow = new QHBoxLayout;
+    contentRow->setSpacing(10);
+    root->addLayout(contentRow, 1);
+
+    // ── Local D-STAR waveform process ────────────────────────────────────────
+    auto* dstarFrame = new QFrame;
+    dstarFrame->setObjectName(QStringLiteral("localDStarPanel"));
+    dstarFrame->setFrameShape(QFrame::StyledPanel);
+    dstarFrame->setMinimumWidth(320);
+    auto* dstarRoot = new QVBoxLayout(dstarFrame);
+    dstarRoot->setContentsMargins(10, 8, 10, 10);
+    dstarRoot->setSpacing(8);
+
+    auto* dstarHeader = new QHBoxLayout;
+    auto* dstarTitle = new QLabel(tr("<b>Local D-STAR</b>"));
+    dstarTitle->setTextFormat(Qt::RichText);
+    dstarHeader->addWidget(dstarTitle);
+    dstarHeader->addStretch();
+
+    m_dstarStartStopBtn = new QPushButton;
+    m_dstarStartStopBtn->setObjectName(QStringLiteral("dstarWaveformStartStop"));
+    m_dstarStartStopBtn->setAccessibleName(tr("Start or stop D-STAR waveform"));
+    connect(m_dstarStartStopBtn, &QPushButton::clicked,
+            this, &WaveformsDialog::onDStarStartStopClicked);
+    dstarHeader->addWidget(m_dstarStartStopBtn);
+    dstarRoot->addLayout(dstarHeader);
+
+    m_dstarStatusLabel = new QLabel;
+    m_dstarStatusLabel->setObjectName(QStringLiteral("dstarWaveformStatus"));
+    m_dstarStatusLabel->setAccessibleName(tr("D-STAR waveform status"));
+    m_dstarStatusLabel->setTextFormat(Qt::RichText);
+    dstarRoot->addWidget(m_dstarStatusLabel);
+
+    m_dstarAutoStartCheck = new QCheckBox(tr("Auto-start"));
+    m_dstarAutoStartCheck->setObjectName(QStringLiteral("dstarWaveformAutoStart"));
+    m_dstarAutoStartCheck->setAccessibleName(tr("Auto-start D-STAR waveform"));
+    m_dstarAutoStartCheck->setChecked(DStarWaveformSettings::autoStart());
+    connect(m_dstarAutoStartCheck, &QCheckBox::toggled,
+            this, &WaveformsDialog::saveDStarSettings);
+    dstarRoot->addWidget(m_dstarAutoStartCheck);
+
+    auto* backendRow = new QWidget;
+    backendRow->setObjectName(QStringLiteral("dstarVocoderBackend"));
+    auto* backendLayout = new QHBoxLayout(backendRow);
+    backendLayout->setContentsMargins(0, 0, 0, 0);
+    backendLayout->setSpacing(6);
+    auto* backendLabel = new QLabel(tr("Vocoder"));
+    backendLayout->addWidget(backendLabel);
+    auto* backendValue = new QLabel(
+        DStarWaveformSettings::backendLabel(DStarWaveformSettings::Backend::ThumbDv));
+    backendValue->setAccessibleName(tr("D-STAR vocoder backend"));
+    backendValue->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    backendLayout->addWidget(backendValue, 1);
+    dstarRoot->addWidget(backendRow);
+
+    m_dstarSerialLabel = new QLabel(tr("ThumbDV device"));
+    dstarRoot->addWidget(m_dstarSerialLabel);
+
+    m_dstarSerialRow = new QWidget;
+    auto* serialLayout = new QHBoxLayout(m_dstarSerialRow);
+    serialLayout->setContentsMargins(0, 0, 0, 0);
+    serialLayout->setSpacing(6);
+    m_dstarSerialCombo = new QComboBox;
+    m_dstarSerialCombo->setEditable(true);
+    m_dstarSerialCombo->setInsertPolicy(QComboBox::NoInsert);
+    m_dstarSerialCombo->setObjectName(QStringLiteral("dstarThumbDvSerialPort"));
+    m_dstarSerialCombo->setAccessibleName(tr("ThumbDV serial port"));
+    applyComboHeight(m_dstarSerialCombo);
+    m_dstarSerialLabel->setBuddy(m_dstarSerialCombo);
+#if defined(Q_OS_WIN)
+    m_dstarSerialCombo->lineEdit()->setPlaceholderText(tr("COM3"));
+#elif defined(Q_OS_MAC)
+    m_dstarSerialCombo->lineEdit()->setPlaceholderText(tr("/dev/cu.usbserial-*"));
+#else
+    m_dstarSerialCombo->lineEdit()->setPlaceholderText(tr("/dev/ttyUSB0"));
+#endif
+    populateDStarSerialPorts(DStarWaveformSettings::serialPort());
+    connect(m_dstarSerialCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &WaveformsDialog::saveDStarSettings);
+    connect(m_dstarSerialCombo->lineEdit(), &QLineEdit::editingFinished,
+            this, &WaveformsDialog::saveDStarSettings);
+    serialLayout->addWidget(m_dstarSerialCombo, 1);
+    m_dstarSerialMenuBtn = new QToolButton;
+    m_dstarSerialMenuBtn->setArrowType(Qt::DownArrow);
+    m_dstarSerialMenuBtn->setAccessibleName(tr("Open ThumbDV device choices"));
+    m_dstarSerialMenuBtn->setToolTip(tr("Open ThumbDV device choices"));
+    m_dstarSerialMenuBtn->setMinimumHeight(m_dstarSerialCombo->minimumHeight());
+    m_dstarSerialMenuBtn->setFixedWidth(m_dstarSerialCombo->minimumHeight());
+    connect(m_dstarSerialMenuBtn, &QToolButton::clicked,
+            m_dstarSerialCombo, qOverload<>(&QComboBox::showPopup));
+    serialLayout->addWidget(m_dstarSerialMenuBtn);
+    m_dstarSerialRefreshBtn = new QPushButton(tr("Refresh"));
+    m_dstarSerialRefreshBtn->setAccessibleName(tr("Refresh ThumbDV serial ports"));
+    m_dstarSerialRefreshBtn->setMinimumHeight(m_dstarSerialCombo->minimumHeight());
+    connect(m_dstarSerialRefreshBtn, &QPushButton::clicked, this, [this] {
+        populateDStarSerialPorts(selectedDStarSerialPort());
+        saveDStarSettings();
+    });
+    serialLayout->addWidget(m_dstarSerialRefreshBtn);
+    dstarRoot->addWidget(m_dstarSerialRow);
+
+    m_dstarAdvancedBtn = new QToolButton;
+    m_dstarAdvancedBtn->setText(tr("Advanced"));
+    m_dstarAdvancedBtn->setAccessibleName(tr("Show advanced D-STAR waveform settings"));
+    m_dstarAdvancedBtn->setCheckable(true);
+    m_dstarAdvancedBtn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    m_dstarAdvancedBtn->setChecked(!DStarWaveformSettings::executablePath().trimmed().isEmpty());
+    m_dstarAdvancedBtn->setArrowType(
+        m_dstarAdvancedBtn->isChecked() ? Qt::DownArrow : Qt::RightArrow);
+    dstarRoot->addWidget(m_dstarAdvancedBtn);
+
+    m_dstarAdvancedPanel = new QWidget;
+    auto* advancedLayout = new QVBoxLayout(m_dstarAdvancedPanel);
+    advancedLayout->setContentsMargins(0, 0, 0, 0);
+    advancedLayout->setSpacing(4);
+
+    auto* exeRow = new QWidget;
+    auto* exeLayout = new QHBoxLayout(exeRow);
+    exeLayout->setContentsMargins(0, 0, 0, 0);
+    exeLayout->setSpacing(6);
+    m_dstarExecutableEdit = new QLineEdit(DStarWaveformSettings::executablePath());
+    m_dstarExecutableEdit->setObjectName(QStringLiteral("dstarWaveformExecutable"));
+    m_dstarExecutableEdit->setAccessibleName(tr("D-STAR waveform executable"));
+    const QString defaultExecutablePath = DStarWaveformProcess::defaultExecutablePath();
+    const QString defaultExecutableName = QFileInfo(defaultExecutablePath).fileName();
+    m_dstarExecutableEdit->setPlaceholderText(
+        tr("Default: %1").arg(defaultExecutableName.isEmpty()
+            ? defaultExecutablePath
+            : defaultExecutableName));
+    auto updateExecutableHint = [this, defaultExecutablePath](const QString& path) {
+        const QString trimmed = path.trimmed();
+        const QString hint = trimmed.isEmpty()
+            ? tr("Leave blank to use the default executable: %1").arg(defaultExecutablePath)
+            : trimmed;
+        m_dstarExecutableEdit->setToolTip(hint);
+        m_dstarExecutableEdit->setAccessibleDescription(hint);
+    };
+    updateExecutableHint(m_dstarExecutableEdit->text());
+    m_dstarExecutableEdit->setCursorPosition(m_dstarExecutableEdit->text().size());
+    connect(m_dstarExecutableEdit, &QLineEdit::textChanged,
+            this, updateExecutableHint);
+    connect(m_dstarExecutableEdit, &QLineEdit::editingFinished,
+            this, &WaveformsDialog::saveDStarSettings);
+    exeLayout->addWidget(m_dstarExecutableEdit, 1);
+    m_dstarBrowseBtn = new QPushButton(tr("Browse..."));
+    m_dstarBrowseBtn->setAccessibleName(tr("Browse for D-STAR waveform executable"));
+    connect(m_dstarBrowseBtn, &QPushButton::clicked,
+            this, &WaveformsDialog::onDStarBrowseClicked);
+    exeLayout->addWidget(m_dstarBrowseBtn);
+    auto* executableLabel = new QLabel(tr("Executable"));
+    executableLabel->setBuddy(m_dstarExecutableEdit);
+    advancedLayout->addWidget(executableLabel);
+    advancedLayout->addWidget(exeRow);
+    m_dstarAdvancedPanel->setVisible(m_dstarAdvancedBtn->isChecked());
+    connect(m_dstarAdvancedBtn, &QToolButton::toggled, this, [this](bool checked) {
+        m_dstarAdvancedBtn->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
+        m_dstarAdvancedPanel->setVisible(checked);
+        if (checked) {
+            m_dstarExecutableEdit->setCursorPosition(m_dstarExecutableEdit->text().size());
+        }
+    });
+    dstarRoot->addWidget(m_dstarAdvancedPanel);
+    dstarRoot->addStretch();
+
+    contentRow->addWidget(dstarFrame, 0);
+
     // ── Waveform list (scrollable) ────────────────────────────────────────────
+    auto* installedFrame = new QFrame;
+    installedFrame->setObjectName(QStringLiteral("installedWaveformsPanel"));
+    installedFrame->setFrameShape(QFrame::StyledPanel);
+    auto* installedRoot = new QVBoxLayout(installedFrame);
+    installedRoot->setContentsMargins(10, 8, 10, 10);
+    installedRoot->setSpacing(8);
+
+    auto* installedHeader = new QHBoxLayout;
+    auto* installedTitle = new QLabel(tr("<b>Radio Waveforms</b>"));
+    installedTitle->setTextFormat(Qt::RichText);
+    installedHeader->addWidget(installedTitle);
+    installedHeader->addStretch();
+
+    m_installBtn = new QToolButton;
+    m_installBtn->setText(tr("Install..."));
+    m_installBtn->setAccessibleName(tr("Install radio waveform"));
+    m_installBtn->setPopupMode(QToolButton::InstantPopup);
+    m_installBtn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    m_installBtn->setFixedWidth(104);
+    m_installBtn->setEnabled(false);  // updated after installer state is known
+    auto* installMenu = new QMenu(m_installBtn);
+    installMenu->addAction(tr("Legacy Waveform..."),
+                           this, &WaveformsDialog::onInstallLegacyClicked);
+    installMenu->addAction(tr("Docker Waveform..."),
+                           this, &WaveformsDialog::onInstallDockerClicked);
+    m_installBtn->setMenu(installMenu);
+    installedHeader->addWidget(m_installBtn);
+    installedRoot->addLayout(installedHeader);
+
     auto* scroll = new QScrollArea;
     scroll->setWidgetResizable(true);
     scroll->setFrameShape(QFrame::NoFrame);
@@ -59,7 +505,8 @@ WaveformsDialog::WaveformsDialog(RadioModel* model, QWidget* parent)
     m_listLayout->addStretch();
 
     scroll->setWidget(m_listContainer);
-    root->addWidget(scroll, 1);
+    installedRoot->addWidget(scroll, 1);
+    contentRow->addWidget(installedFrame, 1);
 
     // ── Wire model + theme signals ────────────────────────────────────────────
     FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
@@ -73,70 +520,179 @@ WaveformsDialog::WaveformsDialog(RadioModel* model, QWidget* parent)
             this, &WaveformsDialog::refreshStatus);
     connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
             this, &WaveformsDialog::refreshWaveformList);
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, &WaveformsDialog::refreshDStarStatus);
+    connect(&DStarWaveformProcess::instance(), &DStarWaveformProcess::stateChanged,
+            this, &WaveformsDialog::refreshDStarStatus);
+    connect(&DStarWaveformProcess::instance(), &DStarWaveformProcess::statusTextChanged,
+            this, &WaveformsDialog::refreshDStarStatus);
+    connect(m_radioModel, &RadioModel::connectionStateChanged,
+            this, &WaveformsDialog::updateDStarControls);
+    connect(m_radioModel, &RadioModel::connectionStateChanged,
+            this, &WaveformsDialog::updateInstallButtonState);
 
     refreshStatus();
     updateInstallButtonState();
     refreshWaveformList();
+    refreshDStarStatus();
 }
 
 void WaveformsDialog::updateInstallButtonState()
 {
-    const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
-    const bool wfpUp = wfModel.wfpPowered() && wfModel.wfpReady();
     const bool busy  = m_installer && m_installer->isInstalling();
-    m_installBtn->setEnabled(wfpUp && !busy);
+    m_installBtn->setEnabled(!busy && m_radioModel && m_radioModel->isConnected());
 }
 
-void WaveformsDialog::onInstallClicked()
+void WaveformsDialog::onInstallLegacyClicked()
 {
+    installWaveformFile(
+        tr("Select Legacy Waveform Package"),
+        tr("SmartSDR Waveforms (*.ssdr_waveform);;All Files (*)"),
+        false);
+}
+
+void WaveformsDialog::onInstallDockerClicked()
+{
+    const FlexWaveformModel& wfModel = m_radioModel->flexWaveformModel();
+    if (!wfModel.wfpStatusSeen() || !wfModel.wfpPowered() || !wfModel.wfpReady()) {
+        const QString powerText = wfModel.wfpPowered() ? tr("ON") : tr("OFF");
+        const QString readyText = wfModel.wfpReady() ? tr("READY") : tr("NOT READY");
+        const QString statusText = wfModel.wfpStatusSeen()
+            ? tr("%1, %2").arg(powerText, readyText)
+            : tr("not reported by this radio");
+        showDockerWfpNotReadyDialog(this, statusText);
+        return;
+    }
+
+    installWaveformFile(
+        tr("Select Docker Waveform Image"),
+        tr("Docker Waveform Images (*.tar *.tar.gz *.tgz);;All Files (*)"),
+        true);
+}
+
+void WaveformsDialog::installWaveformFile(const QString& title,
+                                          const QString& filter,
+                                          bool docker)
+{
+    if (!m_radioModel || !m_radioModel->isConnected()) {
+        return;
+    }
+
     const QString path = QFileDialog::getOpenFileName(
         this,
-        tr("Select Waveform Image"),
+        title,
         {},
-        tr("Waveform Images (*.tar.gz *.tgz);;All Files (*)"));
+        filter);
 
-    if (path.isEmpty())
+    if (path.isEmpty()) {
         return;
+    }
 
-    if (!m_installer)
+    if (!m_installer) {
         m_installer = new WaveformInstaller(m_radioModel, this);
+    }
 
-    if (m_installer->isInstalling())
+    if (m_installer->isInstalling()) {
         return;
+    }
 
     m_installBtn->setEnabled(false);
 
-    auto* progress = new QProgressDialog(
-        tr("Installing waveform…"), tr("Cancel"), 0, 100, this);
+    auto* progress = new PersistentDialog(
+        docker ? tr("Installing Docker Waveform")
+               : tr("Installing Legacy Waveform"),
+        QString(),
+        this);
+    theme::setContainer(progress, QStringLiteral("dialog/waveforms/installProgress"));
     progress->setWindowModality(Qt::WindowModal);
-    progress->setMinimumDuration(0);
-    progress->setValue(0);
-    ThemeManager::instance().applyStyleSheet(progress,
-        QStringLiteral("QProgressBar { text-align: center; "
-                       "background: {{color.background.0}}; "
-                       "color: {{color.text.primary}}; }"));
+    progress->setModal(true);
+    progress->setMinimumWidth(420);
+
+    auto* progressRoot = new QVBoxLayout(progress->bodyWidget());
+    progressRoot->setSpacing(10);
+
+    auto* progressLabel = new QLabel(
+        docker ? tr("Installing Docker waveform...")
+               : tr("Installing legacy waveform..."));
+    progressLabel->setTextFormat(Qt::PlainText);
+    progressLabel->setWordWrap(true);
+    progressLabel->setAccessibleName(tr("Waveform install progress"));
+    progressRoot->addWidget(progressLabel);
+
+    auto* progressBar = new QProgressBar;
+    progressBar->setRange(0, 100);
+    progressBar->setValue(0);
+    progressBar->setTextVisible(true);
+    progressBar->setAccessibleName(tr("Waveform install progress value"));
+    progressRoot->addWidget(progressBar);
+
+    auto* progressButtons = new QHBoxLayout;
+    progressButtons->addStretch();
+    auto* cancelButton = new QPushButton(tr("Cancel"));
+    cancelButton->setAccessibleName(tr("Cancel waveform install"));
+    progressButtons->addWidget(cancelButton);
+    progressRoot->addLayout(progressButtons);
 
     connect(m_installer, &WaveformInstaller::progressChanged,
-            progress, [progress](int pct, const QString& msg) {
-                progress->setValue(pct);
-                progress->setLabelText(msg);
+            progress, [progressBar, progressLabel](int pct, const QString& msg) {
+                progressBar->setValue(pct);
+                progressLabel->setText(msg);
             });
 
-    connect(progress, &QProgressDialog::canceled,
-            m_installer, &WaveformInstaller::cancel);
+    connect(cancelButton, &QPushButton::clicked,
+            progress, &QDialog::reject);
+    connect(progress, &QDialog::rejected, this, [this] {
+        if (m_installer && m_installer->isInstalling()) {
+            m_installer->cancel();
+        }
+    });
 
     connect(m_installer, &WaveformInstaller::finished,
             this, [this, progress](bool ok, const QString& msg) {
                 progress->close();
                 progress->deleteLater();
                 updateInstallButtonState();
-                if (ok)
-                    QMessageBox::information(this, tr("Install Complete"), msg);
-                else
-                    QMessageBox::warning(this, tr("Install Failed"), msg);
+                showWaveformInstallResultDialog(
+                    this,
+                    ok ? tr("Install Complete") : tr("Install Failed"),
+                    msg);
             }, Qt::SingleShotConnection);
 
-    m_installer->install(path);
+    progress->show();
+
+    if (docker) {
+        m_installer->installDockerWaveform(path);
+    } else {
+        m_installer->installLegacyWaveform(path);
+    }
+}
+
+void WaveformsDialog::onDStarStartStopClicked()
+{
+    saveDStarSettings();
+
+    DStarWaveformProcess& process = DStarWaveformProcess::instance();
+    if (process.isActive()) {
+        process.stop();
+    } else {
+        process.startForRadio(m_radioModel->radioAddress());
+    }
+    refreshDStarStatus();
+}
+
+void WaveformsDialog::onDStarBrowseClicked()
+{
+    const QString path = QFileDialog::getOpenFileName(
+        this,
+        tr("Select D-STAR Waveform Executable"),
+        m_dstarExecutableEdit->text().trimmed());
+    if (path.isEmpty()) {
+        return;
+    }
+    m_dstarExecutableEdit->setText(path);
+    m_dstarExecutableEdit->setCursorPosition(path.size());
+    m_dstarExecutableEdit->setFocus();
+    saveDStarSettings();
 }
 
 void WaveformsDialog::refreshStatus()
@@ -147,14 +703,25 @@ void WaveformsDialog::refreshStatus()
     const QString onColor  = tm.color(this, QStringLiteral("color.accent")).name();
     const QString offColor = tm.color(this, QStringLiteral("color.text.secondary")).name();
 
+    if (!wfModel.wfpStatusSeen()) {
+        m_statusLabel->setText(
+            QStringLiteral("WFP:&nbsp;&nbsp;"
+                           "<font color='%1'>&#9679;</font> %2"
+                           "&nbsp;&nbsp;&nbsp;"
+                           "IP: %3")
+                .arg(offColor, tr("unavailable"), tr("none")));
+        return;
+    }
+
     const QString powerColor = wfModel.wfpPowered() ? onColor : offColor;
     const QString readyColor = wfModel.wfpReady()   ? onColor : offColor;
     const QString powerText  = wfModel.wfpPowered() ? tr("ON")    : tr("OFF");
     const QString readyText  = wfModel.wfpReady()   ? tr("READY") : tr("NOT READY");
 
     QString ip = wfModel.wfpIpAddress();
-    if (ip.isEmpty())
-        ip = QStringLiteral("--");
+    if (ip.isEmpty()) {
+        ip = tr("none");
+    }
 
     m_statusLabel->setText(
         QStringLiteral("WFP:&nbsp;&nbsp;"
@@ -163,7 +730,112 @@ void WaveformsDialog::refreshStatus()
                        "<font color='%3'>&#9679;</font> %4"
                        "&nbsp;&nbsp;&nbsp;"
                        "IP: %5")
-            .arg(powerColor, powerText, readyColor, readyText, ip));
+            .arg(powerColor,
+                 powerText.toHtmlEscaped(),
+                 readyColor,
+                 readyText.toHtmlEscaped(),
+                 ip.toHtmlEscaped()));
+}
+
+void WaveformsDialog::refreshDStarStatus()
+{
+    const DStarWaveformProcess& process = DStarWaveformProcess::instance();
+    auto& tm = ThemeManager::instance();
+    const QString onColor  = tm.color(this, QStringLiteral("color.accent")).name();
+    const QString offColor = tm.color(this, QStringLiteral("color.text.secondary")).name();
+    const QString failColor = tm.color(this, QStringLiteral("color.accent.warning")).name();
+
+    QString color = offColor;
+    if (process.state() == DStarWaveformProcess::State::Running
+            || process.state() == DStarWaveformProcess::State::Starting) {
+        color = onColor;
+    } else if (process.state() == DStarWaveformProcess::State::Failed) {
+        color = failColor;
+    }
+
+    const QString text = process.statusText().isEmpty()
+        ? DStarWaveformProcess::stateName(process.state())
+        : process.statusText();
+    m_dstarStatusLabel->setText(
+        QStringLiteral("<font color='%1'>&#9679;</font> %2")
+            .arg(color, text.toHtmlEscaped()));
+
+    updateDStarControls();
+}
+
+void WaveformsDialog::updateDStarControls()
+{
+    const DStarWaveformProcess& process = DStarWaveformProcess::instance();
+    const bool active = process.isActive();
+    m_dstarStartStopBtn->setText(active ? tr("Stop") : tr("Start"));
+    m_dstarStartStopBtn->setEnabled(active || m_radioModel->isConnected());
+    m_dstarExecutableEdit->setEnabled(true);
+    m_dstarExecutableEdit->setReadOnly(active);
+    m_dstarBrowseBtn->setEnabled(!active);
+    m_dstarSerialLabel->setVisible(true);
+    m_dstarSerialRow->setVisible(true);
+    m_dstarSerialCombo->setEnabled(!active);
+    m_dstarSerialMenuBtn->setEnabled(!active);
+    m_dstarSerialRefreshBtn->setEnabled(!active);
+}
+
+void WaveformsDialog::saveDStarSettings()
+{
+    DStarWaveformSettings::setAutoStart(m_dstarAutoStartCheck->isChecked());
+    DStarWaveformSettings::setBackend(DStarWaveformSettings::Backend::ThumbDv);
+    DStarWaveformSettings::setExecutablePath(m_dstarExecutableEdit->text());
+    DStarWaveformSettings::setSerialPort(selectedDStarSerialPort());
+    updateDStarControls();
+}
+
+void WaveformsDialog::populateDStarSerialPorts(const QString& preferredPort)
+{
+    const QString preferred = preferredPort.trimmed();
+    const QSignalBlocker comboBlocker(m_dstarSerialCombo);
+    const QSignalBlocker editBlocker(m_dstarSerialCombo->lineEdit());
+
+    m_dstarSerialCombo->clear();
+    const QList<SerialPortOption> options = detectedSerialPorts();
+
+    int selectedIndex = -1;
+    for (const SerialPortOption& option : options) {
+        m_dstarSerialCombo->addItem(option.label, option.path);
+        const int index = m_dstarSerialCombo->count() - 1;
+        m_dstarSerialCombo->setItemData(index, option.path, Qt::ToolTipRole);
+        if (!preferred.isEmpty() && option.path == preferred) {
+            selectedIndex = index;
+        }
+    }
+
+    if (!preferred.isEmpty() && selectedIndex < 0) {
+        m_dstarSerialCombo->insertItem(0, preferred, preferred);
+        selectedIndex = 0;
+    } else if (preferred.isEmpty() && !options.isEmpty()) {
+        selectedIndex = 0;
+    }
+
+    if (selectedIndex >= 0) {
+        m_dstarSerialCombo->setCurrentIndex(selectedIndex);
+    } else {
+        m_dstarSerialCombo->lineEdit()->clear();
+    }
+}
+
+QString WaveformsDialog::selectedDStarSerialPort() const
+{
+    if (!m_dstarSerialCombo) {
+        return {};
+    }
+
+    const int index = m_dstarSerialCombo->currentIndex();
+    const QString editText = m_dstarSerialCombo->currentText().trimmed();
+    if (index >= 0 && editText == m_dstarSerialCombo->itemText(index)) {
+        const QString path = m_dstarSerialCombo->itemData(index).toString().trimmed();
+        if (!path.isEmpty()) {
+            return path;
+        }
+    }
+    return editText;
 }
 
 void WaveformsDialog::refreshWaveformList()
@@ -180,7 +852,7 @@ void WaveformsDialog::refreshWaveformList()
     const QList<FlexWaveformEntry>& waveforms = wfModel.waveforms();
 
     if (waveforms.isEmpty()) {
-        auto* placeholder = new QLabel(tr("No waveforms installed"));
+        auto* placeholder = new QLabel(tr("No radio waveforms installed"));
         placeholder->setAlignment(Qt::AlignCenter);
         ThemeManager::instance().applyStyleSheet(placeholder,
             QStringLiteral("QLabel { color: {{color.text.secondary}}; }"));
@@ -200,39 +872,40 @@ void WaveformsDialog::refreshWaveformList()
 
         // Name + version
         auto* nameLabel = new QLabel(
-            QStringLiteral("<b>%1</b> %2").arg(name, entry.version));
+            QStringLiteral("<b>%1</b> %2")
+                .arg(name.toHtmlEscaped(), entry.version.toHtmlEscaped()));
         nameLabel->setTextFormat(Qt::RichText);
         rowLayout->addWidget(nameLabel, 1);
 
         // Type badge
-        const QString badgeText = isContainer ? tr("Container") : tr("Waveform");
+        const QString badgeText = isContainer ? tr("Docker") : tr("Legacy");
         auto* typeLabel = new QLabel(QStringLiteral("[%1]").arg(badgeText));
         ThemeManager::instance().applyStyleSheet(typeLabel,
             QStringLiteral("QLabel { color: {{color.text.secondary}}; }"));
         rowLayout->addWidget(typeLabel);
 
-        // Restart button
-        auto* restartBtn = new QPushButton(tr("Restart"));
-        restartBtn->setFixedWidth(70);
-        connect(restartBtn, &QPushButton::clicked, this, [this, name]() {
-            m_radioModel->flexWaveformModel().requestRestart(name);
-        });
-        rowLayout->addWidget(restartBtn);
+        if (isContainer) {
+            auto* restartBtn = new QPushButton(tr("Restart"));
+            restartBtn->setFixedWidth(70);
+            connect(restartBtn, &QPushButton::clicked, this, [this, name]() {
+                m_radioModel->flexWaveformModel().requestRestart(name);
+            });
+            rowLayout->addWidget(restartBtn);
+        }
 
         // Remove / Uninstall button
         const QString removeLabel = isContainer ? tr("Remove") : tr("Uninstall");
         auto* removeBtn = new QPushButton(removeLabel);
         removeBtn->setFixedWidth(70);
         connect(removeBtn, &QPushButton::clicked, this, [this, name, isContainer]() {
-            const QString question = isContainer
-                ? tr("Remove the Docker container \"%1\" from the radio?").arg(name)
-                : tr("Uninstall the waveform \"%1\" from the radio?").arg(name);
-            if (QMessageBox::question(this, tr("Confirm"), question) != QMessageBox::Yes)
+            if (!confirmRadioWaveformRemoval(this, name, isContainer)) {
                 return;
-            if (isContainer)
+            }
+            if (isContainer) {
                 m_radioModel->flexWaveformModel().requestRemoveContainer(name);
-            else
+            } else {
                 m_radioModel->flexWaveformModel().requestUninstall(name);
+            }
         });
         rowLayout->addWidget(removeBtn);
 

--- a/src/gui/WaveformsDialog.h
+++ b/src/gui/WaveformsDialog.h
@@ -3,7 +3,11 @@
 #include "PersistentDialog.h"
 
 class QLabel;
+class QCheckBox;
+class QComboBox;
+class QLineEdit;
 class QPushButton;
+class QToolButton;
 class QVBoxLayout;
 
 namespace AetherSDR {
@@ -14,8 +18,8 @@ class WaveformInstaller;
 // Non-modal dialog for WFP status and waveform management (File → Waveforms).
 // Mirrors the SmartSDR File → Waveforms panel: shows WFP power/ready/IP at the
 // top and one row per installed waveform with Restart and Remove/Uninstall
-// buttons.  An Install… button at the top-right lets the user upload a Docker
-// waveform image (.tar.gz) via WaveformInstaller.
+// buttons.  The install menu supports legacy .ssdr_waveform packages and
+// Docker waveform images via WaveformInstaller.
 //
 // Takes RadioModel* so it can construct WaveformInstaller (which needs
 // sendCmdPublic and radioAddress()) while still connecting to FlexWaveformModel
@@ -27,19 +31,41 @@ public:
     explicit WaveformsDialog(RadioModel* model, QWidget* parent = nullptr);
 
 private slots:
-    void onInstallClicked();
+    void onInstallLegacyClicked();
+    void onInstallDockerClicked();
+    void onDStarStartStopClicked();
+    void onDStarBrowseClicked();
 
 private:
     void refreshStatus();
     void refreshWaveformList();
     void updateInstallButtonState();
+    void refreshDStarStatus();
+    void updateDStarControls();
+    void saveDStarSettings();
+    void populateDStarSerialPorts(const QString& preferredPort = {});
+    QString selectedDStarSerialPort() const;
+    void installWaveformFile(const QString& title, const QString& filter, bool docker);
 
     RadioModel*        m_radioModel{nullptr};
     QLabel*            m_statusLabel{nullptr};
-    QPushButton*       m_installBtn{nullptr};
+    QToolButton*       m_installBtn{nullptr};
     QWidget*           m_listContainer{nullptr};
     QVBoxLayout*       m_listLayout{nullptr};
     WaveformInstaller* m_installer{nullptr};
+
+    QLabel*      m_dstarStatusLabel{nullptr};
+    QCheckBox*   m_dstarAutoStartCheck{nullptr};
+    QLineEdit*   m_dstarExecutableEdit{nullptr};
+    QPushButton* m_dstarBrowseBtn{nullptr};
+    QToolButton* m_dstarAdvancedBtn{nullptr};
+    QWidget*     m_dstarAdvancedPanel{nullptr};
+    QLabel*      m_dstarSerialLabel{nullptr};
+    QWidget*     m_dstarSerialRow{nullptr};
+    QComboBox*   m_dstarSerialCombo{nullptr};
+    QToolButton* m_dstarSerialMenuBtn{nullptr};
+    QPushButton* m_dstarSerialRefreshBtn{nullptr};
+    QPushButton* m_dstarStartStopBtn{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/models/FlexWaveformModel.cpp
+++ b/src/models/FlexWaveformModel.cpp
@@ -3,6 +3,32 @@
 
 namespace AetherSDR {
 
+namespace {
+
+bool isSafeWaveformCommandName(const QString& name)
+{
+    if (name.isEmpty() || name.size() > 64) {
+        return false;
+    }
+
+    for (const QChar ch : name) {
+        const ushort c = ch.unicode();
+        const bool allowed =
+            (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+            || (c >= '0' && c <= '9')
+            || c == '.'
+            || c == '_'
+            || c == '-';
+        if (!allowed) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
 FlexWaveformModel::FlexWaveformModel(QObject* parent)
     : QObject(parent)
 {}
@@ -85,7 +111,8 @@ void FlexWaveformModel::handleContainerStatus(const QMap<QString, QString>& kvs)
 // FlexLib Radio.cs ParseWfpStatus (line 11292).
 void FlexWaveformModel::handleWfpStatus(const QMap<QString, QString>& kvs)
 {
-    bool changed = false;
+    bool changed = !m_wfpStatusSeen;
+    m_wfpStatusSeen = true;
 
     if (kvs.contains(QStringLiteral("power"))) {
         const bool powered = kvs[QStringLiteral("power")].compare(
@@ -111,13 +138,15 @@ void FlexWaveformModel::handleWfpStatus(const QMap<QString, QString>& kvs)
         }
     }
 
-    if (changed)
+    if (changed) {
         emit wfpStatusChanged();
+    }
 }
 
 void FlexWaveformModel::clear()
 {
     m_waveforms.clear();
+    m_wfpStatusSeen = false;
     m_wfpPowered   = false;
     m_wfpReady     = false;
     m_wfpIpAddress.clear();
@@ -129,16 +158,28 @@ void FlexWaveformModel::clear()
 
 void FlexWaveformModel::requestUninstall(const QString& name)
 {
+    if (!isSafeWaveformCommandName(name)) {
+        qWarning() << "FlexWaveformModel: refusing unsafe waveform uninstall name:" << name;
+        return;
+    }
     emit commandReady(QStringLiteral("waveform uninstall ") + name);
 }
 
 void FlexWaveformModel::requestRemoveContainer(const QString& name)
 {
+    if (!isSafeWaveformCommandName(name)) {
+        qWarning() << "FlexWaveformModel: refusing unsafe waveform container removal name:" << name;
+        return;
+    }
     emit commandReady(QStringLiteral("waveform remove_container ") + name);
 }
 
 void FlexWaveformModel::requestRestart(const QString& name)
 {
+    if (!isSafeWaveformCommandName(name)) {
+        qWarning() << "FlexWaveformModel: refusing unsafe waveform restart name:" << name;
+        return;
+    }
     emit commandReady(QStringLiteral("waveform restart ") + name);
 }
 

--- a/src/models/FlexWaveformModel.h
+++ b/src/models/FlexWaveformModel.h
@@ -35,6 +35,7 @@ public:
 
     // ── Accessors ─────────────────────────────────────────────────────────────
     const QList<FlexWaveformEntry>& waveforms()    const { return m_waveforms; }
+    bool    wfpStatusSeen() const { return m_wfpStatusSeen; }
     bool    wfpPowered()   const { return m_wfpPowered; }
     bool    wfpReady()     const { return m_wfpReady; }
     QString wfpIpAddress() const { return m_wfpIpAddress; }
@@ -62,6 +63,7 @@ signals:
 
 private:
     QList<FlexWaveformEntry> m_waveforms;
+    bool    m_wfpStatusSeen{false};
     bool    m_wfpPowered{false};
     bool    m_wfpReady{false};
     QString m_wfpIpAddress;

--- a/tests/dstar_waveform_process_test.cpp
+++ b/tests/dstar_waveform_process_test.cpp
@@ -1,0 +1,82 @@
+// Standalone test harness for DStarWaveformProcess lifecycle helpers.
+//
+// Build: produced by CMake as `dstar_waveform_process_test`.
+// Run:   ./build/dstar_waveform_process_test
+// Exit:  0 = pass, 1 = fail.
+
+#include "core/DStarWaveformProcess.h"
+#include "core/DStarWaveformSettings.h"
+
+#include <QCoreApplication>
+#include <QHostAddress>
+
+#include <cstdio>
+
+using AetherSDR::DStarWaveformProcess;
+using AetherSDR::DStarWaveformSettings;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = {})
+{
+    std::printf("%s %-60s %s\n", ok ? "[ OK ]" : "[FAIL]", name,
+                detail.toUtf8().constData());
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    report("stateName: stopped",
+           DStarWaveformProcess::stateName(DStarWaveformProcess::State::Stopped)
+               == QStringLiteral("Stopped"));
+    report("stateName: failed",
+           DStarWaveformProcess::stateName(DStarWaveformProcess::State::Failed)
+               == QStringLiteral("Failed"));
+
+    report("resolveExecutablePath: trims configured path",
+           DStarWaveformProcess::resolveExecutablePath(QStringLiteral("  /tmp/aether-dstar-waveform  "))
+               == QStringLiteral("/tmp/aether-dstar-waveform"));
+    report("resolveExecutablePath: empty falls back to default",
+           !DStarWaveformProcess::resolveExecutablePath(QString()).isEmpty());
+
+    report("backendFromString: empty uses ThumbDV backend",
+           DStarWaveformSettings::backendFromString(QString())
+               == DStarWaveformSettings::Backend::ThumbDv);
+    report("backendFromString: ThumbDV maps to serial backend",
+           DStarWaveformSettings::backendFromString(QStringLiteral("ThumbDV"))
+               == DStarWaveformSettings::Backend::ThumbDv);
+    report("backendRequiresSerial: ThumbDV requires serial",
+           DStarWaveformSettings::backendRequiresSerial(
+               DStarWaveformSettings::Backend::ThumbDv));
+    report("backendArgument: ThumbDV CLI argument",
+           DStarWaveformSettings::backendArgument(
+               DStarWaveformSettings::Backend::ThumbDv)
+               == QStringLiteral("thumbdv"));
+
+    DStarWaveformProcess& process = DStarWaveformProcess::instance();
+    process.stop();
+    const bool started = process.startForRadio(QHostAddress());
+    report("startForRadio: null radio fails", !started);
+    report("startForRadio: null radio sets failed state",
+           process.state() == DStarWaveformProcess::State::Failed);
+    report("startForRadio: null radio stores useful error",
+           process.lastError().contains(QStringLiteral("No connected radio address")));
+    process.stop();
+    report("stop: failed/not-running resets state",
+           process.state() == DStarWaveformProcess::State::Stopped);
+
+    if (g_failed == 0) {
+        std::printf("\nAll DStarWaveformProcess tests passed.\n");
+    } else {
+        std::printf("\n%d test(s) failed.\n", g_failed);
+    }
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/flex_waveform_model_test.cpp
+++ b/tests/flex_waveform_model_test.cpp
@@ -108,6 +108,7 @@ int main(int argc, char** argv)
         m.handleWfpStatus(makeKvs({{"power", "on"}, {"ready", "true"}, {"ipaddr", "192.168.1.10"}}));
 
         report("wfpStatus: wfpStatusChanged emitted",       spy.size() == 1);
+        report("wfpStatus: status seen",                    m.wfpStatusSeen());
         report("wfpStatus: power=on → wfpPowered=true",     m.wfpPowered());
         report("wfpStatus: ready=true → wfpReady=true",     m.wfpReady());
         report("wfpStatus: ipaddr stored",                  m.wfpIpAddress() == "192.168.1.10");
@@ -129,9 +130,27 @@ int main(int argc, char** argv)
         m.clear();
 
         report("clear: waveforms empty",                    m.waveforms().isEmpty());
+        report("clear: wfpStatusSeen false",                !m.wfpStatusSeen());
         report("clear: wfpPowered false",                   !m.wfpPowered());
         report("clear: wfpReady false",                     !m.wfpReady());
         report("clear: wfpIpAddress empty",                 m.wfpIpAddress().isEmpty());
+    }
+
+    // ── command names are protocol-safe tokens ─────────────────────────────
+    {
+        FlexWaveformModel m;
+        QSignalSpy spy(&m, &FlexWaveformModel::commandReady);
+
+        m.requestRestart(QStringLiteral("ThumbDV"));
+        report("command: safe name emits command", spy.size() == 1);
+        report("command: restart command text",
+               spy.takeFirst().at(0).toString() == QStringLiteral("waveform restart ThumbDV"));
+
+        m.requestRemoveContainer(QStringLiteral("Bad\nName"));
+        report("command: newline name rejected", spy.isEmpty());
+
+        m.requestUninstall(QStringLiteral("Bad Name"));
+        report("command: whitespace name rejected", spy.isEmpty());
     }
 
     if (g_failed == 0)

--- a/tests/run_dstar_waveform_no_args.cmake
+++ b/tests/run_dstar_waveform_no_args.cmake
@@ -1,0 +1,24 @@
+if(NOT DEFINED HELPER OR HELPER STREQUAL "")
+    message(FATAL_ERROR "HELPER is required")
+endif()
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E env
+        "SSDR_RADIO_ADDRESS="
+        "AETHER_DSTAR_THUMBDV_SERIAL="
+        "${HELPER}"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+)
+
+set(combined "${output}${error}")
+if(result EQUAL 0)
+    message(FATAL_ERROR "Expected helper to fail without --host")
+endif()
+
+if(NOT combined MATCHES "Missing --host/SSDR_RADIO_ADDRESS")
+    message(FATAL_ERROR "Expected missing-host diagnostic, got: ${combined}")
+endif()
+
+message(STATUS "helper failed without --host as expected")

--- a/third_party/smartsdr-dsp/AETHERSDR-PATCHES.md
+++ b/third_party/smartsdr-dsp/AETHERSDR-PATCHES.md
@@ -1,8 +1,21 @@
-# AetherSDR Patches
+# AetherSDR SmartSDR-DSP Adopted Fork Notes
 
-This directory contains the GPL-3.0 `thumbDV_support` branch of
-`n5ac/smartsdr-dsp`, trimmed to the ThumbDV waveform runtime sources needed by
-AetherSDR's `aether-dstar-waveform` helper.
+This directory is an adopted, in-tree fork of the GPL-3.0
+`thumbDV_support` branch of `n5ac/smartsdr-dsp`, trimmed to the ThumbDV
+waveform runtime sources needed by AetherSDR's `aether-dstar-waveform` helper.
+
+The upstream repository is inactive for AetherSDR's purposes: the public
+`n5ac/smartsdr-dsp` repository has not received code updates since 2019, and
+this tree was imported from the tip of the historical `thumbDV_support` branch.
+AetherSDR does not treat this directory as a patch stack to reapply during
+future upstream resyncs. It is maintained in place under `third_party/` so the
+original license, attribution, and source boundary remain visible.
+
+Future changes to compiled vendored files should stay narrowly scoped, keep
+upstream copyright/license headers intact, and be recorded in git history. When
+the modification is material, update the local change summary below so the
+repository itself remains the provenance and change notice for this maintained
+fork.
 
 Imported source:
 

--- a/third_party/smartsdr-dsp/AETHERSDR-PATCHES.md
+++ b/third_party/smartsdr-dsp/AETHERSDR-PATCHES.md
@@ -1,0 +1,32 @@
+# AetherSDR Patches
+
+This directory contains the GPL-3.0 `thumbDV_support` branch of
+`n5ac/smartsdr-dsp`, trimmed to the ThumbDV waveform runtime sources needed by
+AetherSDR's `aether-dstar-waveform` helper.
+
+Imported source:
+
+- Repository: https://github.com/n5ac/smartsdr-dsp
+- Branch: `thumbDV_support`
+- Commit: `762297a7d56f9e37c661c550e4b1cbd8b78091f1`
+
+Local changes:
+
+- Removed the bundled FTDI D2XX static library and replaced the D2XX API surface
+  used by ThumbDV with `aether_serial_compat.c`, a POSIX termios serial backend.
+- Replaced the original embedded-radio `main.c` with a small command-line entry
+  point that accepts AetherSDR's `--host` and `--serial` arguments.
+- Changed startup to connect directly to the supplied radio IP address instead
+  of waiting for a matching discovery packet.
+- Added compatibility headers for Linux-only `sys/prctl.h` and `linux/*`
+  includes so the helper builds on macOS and Linux.
+- Added an Apple-only unnamed semaphore shim because Darwin exposes `sem_init`
+  but does not provide usable unnamed POSIX semaphores.
+- Added `aether_vocoder_backend.*` as a thin ThumbDV-only wrapper for the
+  vocoder calls used by the local helper.
+- Applied CodeQL hardening to vendored runtime code that is compiled into the
+  helper: widened command argument loops, promoted buffer byte-count
+  multiplication before allocation/copy, matched printf format types, and opened
+  the waveform config directly instead of checking it with `stat()` first.
+- Build only the local helper executable; the historical Windows GUI,
+  `.ssdr_waveform` package, IDE metadata, and binary artifacts are not vendored.

--- a/third_party/smartsdr-dsp/LICENSE
+++ b/third_party/smartsdr-dsp/LICENSE
@@ -1,0 +1,674 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/cmd.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/cmd.h
@@ -1,0 +1,81 @@
+/* *****************************************************************************
+ *	cmd.h															2014 AUG 31
+ *
+ *		Header file for cmd_engine.c and cmd_basics.c
+ *
+ *		date March 30, 2012
+ * 		author Stephen Hicks, N5AC
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#ifndef CMD_H_
+#define CMD_H_
+
+#include "datatypes.h"
+
+
+#define ACCESS_GUEST			0x0
+#define ACCESS_SERIAL 			0x1
+#define ACCESS_TCP 				0x2
+#define ACCESS_SERIAL_TCP 		0x3
+#define SVC_SER					1
+#define SVC_TCP					2
+#define SVC_BOT					3
+
+#define MAX_ARGC 				16
+#define MAX_ARGC_STATUS         100
+
+// #define PROMPT "\033[92mSmartSDR> \033[m"
+
+extern char* CMD_UNRECOGNIZED;
+extern char* EEPROM_BAD_BYTE;
+extern char* EEPROM_TOO_LARGE;
+extern char* EEPROM_USAGE;
+
+
+/* ------------------------------------------------------------------------ *
+ *     						   	Prototypes                                 	*
+ * ------------------------------------------------------------------------ */
+
+unsigned int command (void);
+void tokenize (char *line, int *pargc, char **argv, int max_arguments);
+//void process_command  (int fd, char line[]);
+uint32 process_command(char* command_txt);
+
+uint32 cmd_banner();
+uint32 cmd_cls(int requester_fd, int argc,char **argv);
+uint32 cmd_date(int requester_fd, int argc,char **argv);
+uint32 cmd_exit(int requester_fd, int argc,char **argv);
+uint32 cmd_help(int requester_fd, int argc, char **argv);
+uint32 cmd_slice(int requester_fd, int argc,char **argv);
+uint32 cmd_time(int requester_fd, int argc,char **argv);
+// uint32 cmd_register(int requester_fd, int argc,char **argv);
+uint32 cmd_undefined(int requester_fd, int argc,char **argv);
+
+void get_line(char* line, int maxlen);
+
+char getch(void);	// Read 1 character
+char getche(void);	// Read 1 character with echo
+
+
+#endif /* CMD_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/cmd_basics.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/cmd_basics.c
@@ -1,0 +1,312 @@
+/* *****************************************************************************
+ *	cmd_basics.c													2014 AUG 30
+ *
+ *		Uses header file cmd.h
+ *
+ *   	Basic commands for the command_engine
+ *			Display the sign-on banner
+ *			Clear Screen
+ *			Process Exit
+ *			Display time
+ *			Display date
+ *			Display help
+ *			Display "undefined"
+ *
+ *
+ *		\author Terry Gerdes, AB5K
+ *		\author Stephen Hicks, N5AC
+ *		\author Graham / KE9H
+ *
+ *******************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <time.h>
+
+#include "common.h"
+#include "main.h"
+#include "cmd.h"
+
+#include "main.h"
+#include "sched_waveform.h"
+
+
+/* *****************************************************************************
+ *	uint32 cmd_banner(void)
+ *
+ *		Print a banner
+ *
+ */
+
+uint32 cmd_banner()
+{
+	char *build_date = __DATE__;
+	char *build_time = __TIME__;
+	uint32 ip = net_get_ip();
+
+	output(ANSI_GREEN "*\n");
+    output("*  This program is free software: you can redistribute it and/or modify\n");
+    output("*  it under the terms of the GNU General Public License as published by\n");
+    output("*  the Free Software Foundation, either version 3 of the License, or\n");
+    output("*  (at your option) any later version.\n");
+    output("*  This program is distributed in the hope that it will be useful,\n");
+    output("*  but WITHOUT ANY WARRANTY; without even the implied warranty of\n");
+    output("*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the\n");
+    output("*  GNU General Public License for more details.\n");
+    output("*  You should have received a copy of the GNU General Public License\n");
+    output("*  along with this program. If not, see <http://www.gnu.org/licenses/>.\n*\n");
+    output("*  Contact Information:\n");
+    output("*  email: gpl<at>flexradiosystems.com\n");
+    output("*  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728\n*\n");
+
+    output("\033[92m");
+	output("**************************************************************************\r\n");
+	output("*                                                                          \r\n");
+	output("*   *  *  *    *   *       *  ******   ******   ****   *****    **   **       \r\n");
+	output("*   *  *  *   * *   *     *   *        *       *    *  *    *   * * * *       \r\n");
+	output("*   *  *  *  *****   *   *    *****    ****    *    *  ****     *  *  *       \r\n");
+	output("*    ** **  *     *   * *     *        *       *    *  *   *    *     *       \r\n");
+	output("*     * *  *       *   *      ******   *        ****   *    *   *     *       \r\n");
+	output("*\r\n");
+	output("*  FlexRadio Systems\r\n");
+	output("*  Copyright (C) 2014 FlexRadio Systems.  All Rights Reserved.\r\n");
+	output("*  www.flexradio.com\r\n");
+	output("**************************************************************************\r\n");
+
+	//output("\033[32mSoftware version : \033[m%s\r\n", software_version);
+	output("\033[32mBuild Date & Time: \033[m%s %s\r\n",build_date, build_time);
+	output("\033[32mIP Address       : \033[m%d.%d.%d.%d\r\n", ip & 0xFF, (ip >> 8) & 0xFF, (ip >> 16) & 0xFF, ip >> 24);
+	output("\033[32mType <help> for options\r\n\n\033[m");
+
+	return SUCCESS;
+}
+
+
+/* *****************************************************************************
+ *	uint32 cmd_cls(int requester_fd, int argc,char **argv)
+ *
+ *		HANDLE:  command_cls
+ *		ANSI escape sequence to go to home position in screen
+ *			and clear remainder of screen
+ */
+
+uint32 cmd_cls(int requester_fd, int argc,char **argv)
+{
+    static char *CLS = "\033[H\033[2J";
+	write(requester_fd, CLS, strlen(CLS));
+	return SUCCESS;
+}
+
+
+/* *****************************************************************************
+ *	uint32 cmd_exit(int requester_fd, int argc,char **argv)
+ *
+ *		Exit the application
+ */
+
+uint32 cmd_exit(int requester_fd, int argc,char **argv)
+{
+	const char string1[] = "\n\033[92m73 de WaveForm !!!\033[m\n";
+
+	write(requester_fd, string1, strlen(string1));
+
+	_exit(0);
+	return SUCCESS;
+}
+
+
+/* *****************************************************************************
+ *	uint32 cmd_time(int requester_fd, int argc,char **argv)
+ *
+ *		Display the time
+ */
+
+uint32 cmd_time(int requester_fd, int argc,char **argv)
+{
+    time_t t = time(NULL);
+    struct tm time = *localtime(&t);
+
+//   client_response(SUCCESS,"%02d:%02d:%02dZ",time.tm_hour,time.tm_min,time.tm_sec);
+    output("%02d:%02d:%02dZ \n",time.tm_hour,time.tm_min,time.tm_sec);
+//	char *time_string = 0;
+//
+//	time_string = drv_Bq32000AsciiTime();
+//	strcat(time_string,"\n");
+//
+//	write(requester_fd, time_string, strlen(time_string));
+	return SUCCESS;
+}
+
+
+/* *****************************************************************************
+ *	uint32 cmd_date(int requester_fd, int argc,char **argv)
+ *
+ *		Display the date
+ */
+
+uint32 cmd_date(int requester_fd, int argc,char **argv)
+{
+    time_t t = time(NULL);
+    struct tm time = *localtime(&t);
+
+//   client_response(SUCCESS,"%d-%d-%d",time.tm_year+1900,time.tm_mon+1,time.tm_mday);
+    output("%d-%d-%d \n",time.tm_year+1900,time.tm_mon+1,time.tm_mday);
+//	char *time_string = 0;
+//
+//	time_string = drv_Bq32000AsciiDatetime();
+//	strcat(time_string,"\n");
+//
+//	write(requester_fd, time_string, strlen(time_string));
+	return SUCCESS;
+}
+
+//
+// Command Description displayed from HELP menu.
+//
+
+const char* commandDescriptionBasic[]  =
+{
+	0,
+	"b             Display banner",
+	"banner        Display the WaveForm banner",
+	"cls           Clear screen",
+	"date          Display the Date",
+	"exit          Exit the process",
+	"quit          Exit the process",
+	"time          Display the Time",
+	"help|?        View this menu",
+  0
+};
+
+
+/* *****************************************************************************
+ *	uint32 cmd_help(int requester_fd, int argc, char **argv)
+ *
+ *		HANDLE:  help
+ */
+
+uint32 cmd_help(int requester_fd, int argc, char **argv)
+{
+	int i;
+
+    i=1;
+
+    output("==========================================================\n\r");
+    while(commandDescriptionBasic[i] != 0)
+    {
+        write(requester_fd, commandDescriptionBasic[i], strlen(
+                commandDescriptionBasic[i]));
+        output("  %s\n\r", commandDescriptionBasic[i++]);
+    }
+
+    return SUCCESS;
+}
+
+
+/* *****************************************************************************
+ *	uint32 cmd_undefined(int requester_fd, int argc, char **argv)
+ *
+ *		Undefined
+ */
+
+uint32 cmd_undefined(int requester_fd, int argc, char **argv)
+{
+    //debug(LOG_CERROR, TRUE, SL_R_UNKNOWN_COMMAND);
+	//client_response(SL_UNKNOWN_COMMAND, NULL);
+	output("I have no idea what you are talking about !!!\n");
+	return SL_UNKNOWN_COMMAND;
+}
+
+uint32 cmd_slice(int requester_fd, int argc, char **argv)
+{
+    uint32 slc = INVALID_SLICE_RX;
+
+    if (strcmp(argv[0], "slice") == 0)
+    {
+        if(argc < 3)
+        {
+            return SL_BAD_COMMAND;
+        }
+
+        // get the slice number
+        errno = 0;
+        slc = strtoul(argv[1], NULL, 0);
+        if(errno)
+        {
+            output(ANSI_RED "Unable to parse slice number (%s)\n", argv[1]);
+            return SL_BAD_COMMAND;
+        }
+
+        if(strncmp(argv[2], "set", strlen("set")) == 0)
+        {
+            // charReplace(new_string, (char) 0x7F, ' ');
+
+            int i = 0;
+            for ( i = 3 ; i < argc ; i++ ) {
+
+                if ( strncmp(argv[i], "destination_rptr", strlen("destination_rptr") )  == 0 ) {
+
+                    char * rptr = argv[i] + strlen("destination_rptr") + 1;
+                    sched_waveform_setDestinationRptr(slc, rptr);
+
+                } else if ( strncmp(argv[i], "departure_rptr", strlen("departure_rptr") )  == 0 ) {
+
+                    char * rptr = argv[i] + strlen("departure_rptr") + 1;
+                    sched_waveform_setDepartureRptr(slc, rptr);
+
+                } else if ( strncmp(argv[i], "companion_call", strlen("companion_call") )  == 0 ) {
+                    char * call = argv[i] + strlen("companion_call") + 1;
+                    sched_waveform_setCompanionCall(slc, call);
+
+                } else if ( strncmp(argv[i], "own_call1", strlen("own_call1") )  == 0 ) {
+                    char * call = argv[i] + strlen("own_call1") + 1;
+                    sched_waveform_setOwnCall1(slc, call);
+
+                } else if ( strncmp(argv[i], "own_call2", strlen("own_call2") )  == 0 ) {
+                    char * call = argv[i] + strlen("own_call2") + 1;
+                    sched_waveform_setOwnCall2(slc, call);
+                } else if ( strncmp(argv[i], "message", strlen("message")) == 0 ) {
+                    char * message = argv[i] + strlen("message") + 1;
+                    sched_waveform_setMessage(slc, message);
+                }
+
+
+
+            }
+
+            return SUCCESS;
+        }
+        else if (strncmp(argv[2], "status", strlen("status")) == 0 )
+        {
+            sched_waveform_sendStatus(slc);
+        }
+    }
+
+    return SUCCESS;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/cmd_engine.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/cmd_engine.c
@@ -1,0 +1,346 @@
+/* *****************************************************************************
+ *	cmd_engine.c
+ *
+ *   \brief Command Engine - Command processing
+ *
+ *
+ * 	\author Terry, AB5K
+ * 	\author Stephen Hicks, N5AC
+ * 	\date   23-AUG-2011
+ *
+ *	Instructions for adding a new command:
+ *	1. Add a reference in the "command_defs commands[]" array below
+ *	2. If help is needed, add a reference to lpszCommandDescriptionBasic[] in the cmd_basics.c file.
+ *
+ *******************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <sys/termios.h>
+
+#include "../common.h"
+#include "datatypes.h"
+
+#include "cmd.h"
+#include "main.h"
+
+static struct termios old, new;		// For Terminal IO
+
+//#include "drv_bq32000.h"
+//#include "messages.h"
+//#include "client_manager.h"
+//#include "radio.h"
+
+char *CMD_UNRECOGNIZED	= "Unrecognized command \"%s\".\r\n";
+
+// Command Function Pointer called by the interpreter.
+typedef uint32 handler(int, int, char**);
+
+static char PrevLine[80];
+
+typedef struct _command_def
+{
+	const char* commandName;
+	handler *pFunction;
+} command_def;
+
+
+static command_def commands[] =
+{
+        {   0,                      cmd_undefined               },  // Space Holder
+        {   "b",                    cmd_banner                  },  // Display Banner
+        {   "banner",               cmd_banner                  },  // Display Banner
+        {   "cls",                  cmd_cls                     },  // Clear Screen
+        {   "date",                 cmd_date                    },  // Print the date/time
+        {   "exit",                 cmd_exit                    },  // Exit the program
+        {   "help",                 cmd_help                    },  // Help Menu
+        {   "quit",                 cmd_exit                    },  // Exit the program
+        {   "slice",                cmd_slice                   },  // Handle slice changes
+        {   "time",                 cmd_time                    },  // Print the time
+        {   "?",                    cmd_help                    },  // Display Help
+        {   0,                      cmd_undefined               },  // Undefined - must be last in the list
+
+};
+
+//long execute_command(int requester_fd, int cmd_num, int argc, char *argv);
+
+// #################################################################
+// ##
+// ##  Command Interpreter
+// ##
+// #################################################################
+unsigned int command(void)
+{
+	char line[512];
+	char *pLine = line;
+	get_line(pLine, 512 * sizeof(char));
+
+	process_command(line);
+
+	return (1);
+}
+
+uint32 process_command(char* command_txt)
+{
+	uint32 cmd_ret = SUCCESS;
+	int cmd_num;
+	int argc;
+	char *argv[MAX_ARGC + 1];		//Add one extra so we can null terminate the array
+
+	output("CMD Received = '%s'\n", command_txt);
+
+	tokenize(command_txt, &argc, argv, MAX_ARGC);
+
+	if (argc > 0)
+	{
+		cmd_num = 1;
+
+		while (cmd_num > 0)
+		{
+			if ((commands[cmd_num].commandName == 0) || (strcmp(argv[0], commands[cmd_num].commandName) == 0))
+			{
+			    //Execute the requested command
+                cmd_ret = commands[cmd_num].pFunction(1, argc, argv);
+				cmd_num = 0;
+			}
+			else
+			{
+				cmd_num++;
+			}
+		}
+	}
+	return cmd_ret;
+}
+
+
+// #################################################################
+// ##
+// ##  void tokenize(char*, int*, char**, max_arguments);
+// ##
+// ##  Breaks a single character string into an array of tokens.
+// #################################################################
+
+void tokenize(
+	char*	line,            // Input String
+	int*	pargc,           // Number of arguments
+	char**	argv,            // Array of strings holding tokens
+	int     max_arguments    // Maximum Tokens allowed
+)
+{
+	BOOL inside_string = FALSE;
+	BOOL inside_token = FALSE;
+	char* readp;
+
+	*pargc = 0;
+
+		// Read through the entire string searching for tokens
+	for (readp = line; *readp; readp++)
+	{
+			// Search for start of token
+		if (!inside_token)
+		{
+			// Ignore white spaces
+			if ((*readp == ' ') || (*readp == '\t'))
+			{
+				;
+			}
+			// Start of a new token
+			else
+			{
+				if (*readp == '\"')
+				{
+					inside_string = TRUE;
+				}
+				else
+				{
+		inside_token = TRUE;
+				argv[*pargc] = readp;
+					(*pargc)++;
+
+					if(*pargc > max_arguments)
+						break;
+				}
+			}
+		}
+
+		// We are inside the token
+		else
+		{ // inside token
+
+			// Found the end of the token
+			if ( (!inside_string && ((*readp == ' ') || (*readp == '\t'))) |
+			     (inside_string && (*readp == '\"'))
+			   )
+			{
+					inside_string = FALSE;
+				inside_token = FALSE;
+				*readp = 0;
+			}
+		}
+	}
+
+	// End of input line terminates a token
+	if (inside_token)
+	{
+		*readp = 0;
+		readp++;
+	}
+
+	argv[*pargc] = 0; // Null-terminate just to be nice
+}
+
+
+
+// #################################################################
+// ##
+// ##  void command_get_line(char *, int)
+// ##
+// #################################################################
+void get_line(char * line, int maxlen)
+{
+	char *pLine = line;
+	char *pPrevLine = PrevLine;
+	char   c = 0;
+
+	*pLine = 0;
+	for (;;) {
+		c = getch();
+
+		// Escape Sequences
+		if (c == '\033') {
+			while (pLine > line) {
+
+				printf("\b \b");
+				pLine--;
+				*pLine = 0;
+			}
+			c = getch();
+
+			if (c == '[') {
+				c = getch();
+
+				if (c == 'A') {
+					// Restore previous command
+					pLine = line;
+					pPrevLine = PrevLine;
+					while(*pPrevLine) {
+
+						*pLine = *pPrevLine;
+						pLine++;
+						pPrevLine++;
+					}
+					*pLine = 0;
+					printf("%s",line);
+				}
+			}
+		}
+
+		else if ((c == '\n') || (c == '\r')) {
+			printf("\r\n");
+			break;
+		}
+
+		// Check for backspace or delete key.
+		else if ((c == '\b') || (c == 0x7F)) {
+			if (pLine > line) {
+				printf("\b \b");
+				pLine--;
+				*pLine = 0;
+			}
+		}
+
+		// Check for escape key or control-U.
+		else if (c == 0x15) {
+			while (pLine > line) {
+				printf("\b \b");
+				pLine--;
+				*pLine = 0;
+			}
+		}
+
+		else if (c > 0) {
+			printf("%c",c);
+			*pLine = c;
+			pLine++;
+			*pLine = 0;
+		}
+	}
+
+	*pLine = 0;
+
+	pLine = line;
+	pPrevLine = PrevLine;
+	while(*pLine) {
+		*pPrevLine = *pLine;
+		pLine++;
+		pPrevLine++;
+	}
+	*pPrevLine = 0;
+}
+
+
+/* *****************************************************************************
+ *  getch() and getche() functionality for UNIX,
+ * 	based on termios (terminal handling functions)
+ *
+ *  This code snippet was written by Wesley Stessens (wesley@ubuntu.com)
+ *  It is released in the Public Domain.
+ */
+
+/* Initialize new terminal i/o settings */
+void initTermios(int echo) {
+    int n = tcgetattr(0, &old); /* grab old terminal i/o settings */
+	if (n == -1) return;
+
+    new = old; /* make new settings same as old settings */
+    new.c_lflag &= ~ICANON; /* disable buffered i/o */
+    new.c_lflag &= echo ? ECHO : ~ECHO; /* set echo mode */
+    tcsetattr(0, TCSANOW, &new); /* use these new terminal i/o settings now */
+}
+
+/* Restore old terminal i/o settings */
+void resetTermios(void) {
+	tcsetattr(0, TCSANOW, &old);
+}
+
+/* Read 1 character - echo defines echo mode */
+char getch_(int echo) {
+    char ch;
+    initTermios(echo);
+    ch = (char)getchar();
+    resetTermios();
+    return ch;
+}
+
+/* Read 1 character without echo */
+char getch(void) {
+    return getch_(0);
+}
+
+/* Read 1 character with echo */
+char getche(void) {
+    return getch_(1);
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/complex.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/complex.h
@@ -1,0 +1,61 @@
+/* *****************************************************************************
+ * 	complex.h
+ *
+ *  \date Mar 31, 2012
+ *  \author Bob / N4HY
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef COMPLEX_H_
+#define COMPLEX_H_
+
+#include <math.h>
+
+#include "datatypes.h"
+
+typedef struct _complex {
+  float real; // left
+  float imag; // right
+} Complex;
+
+#define CReal(x) ((x.real))
+#define CImag(x) ((x.imag))
+
+extern Complex Cplx(float x, float y);
+
+extern Complex ComplexAdd(Complex x, Complex y);
+
+extern Complex ComplexSub(Complex x, Complex y);
+
+extern Complex ComplexMul(Complex x, Complex y);
+
+extern Complex ComplexDiv(Complex x, Complex y);
+
+extern Complex ComplexScl(Complex x, float scl);
+
+extern Complex ComplexCjg(Complex x);
+
+extern float ComplexPwr(Complex x);
+
+extern float ComplexMag(Complex x);
+
+#endif /* COMPLEX_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/datatypes.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/datatypes.h
@@ -1,0 +1,65 @@
+/* *****************************************************************************
+ * 	datatypes.h
+ *
+ *		datatypes definition file
+ *
+ *
+ *     \date Sep 15, 2011
+ *	\author Eric
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#ifndef _DATATYPES_H
+#define _DATATYPES_H
+
+
+typedef unsigned char  uint8;
+typedef unsigned short uint16;
+typedef unsigned int   uint32;
+typedef unsigned long long uint64;
+
+typedef signed char int8;
+typedef signed short int16;
+typedef signed int int32;
+typedef signed long long int64;
+
+typedef uint8 BOOL;
+
+/// VITA-49 format frequency data
+typedef int64 VITAfrequency;
+typedef int16 VITAfrequency_trunc;
+typedef int32 VITAdb;
+typedef int16 VITAdb_trunc;
+typedef uint32 packedVITAcalPoint;
+typedef int32 VITAtemp;
+typedef int16 VITAtemp_trunc;
+
+
+typedef uint32 ant_port_id_type;
+
+#define TRUE (uint8)1
+#define FALSE (uint8)0
+
+#define INVALID -1
+
+#endif // _DATATYPES_H

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/discovery_client.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/discovery_client.c
@@ -1,0 +1,359 @@
+/* *****************************************************************************
+ *	discovery_client.c
+ *
+ *   \brief Discovery Client - Receives and parses discovery packets
+ *
+ *
+ * 	\author Eric Wachsmann, KE5DTO
+ * 	\date   2014-09-01
+ *
+ *******************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ***************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h> // for malloc
+#include <string.h> // for memset
+#include <sys/socket.h>
+#include <netinet/in.h> // for htonl, htons, IPPROTO_UDP
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <errno.h> // for errno
+#include <unistd.h>
+
+#include <sys/prctl.h>
+
+#include "common.h"
+#include "discovery_client.h"
+#include "cmd.h" // for tokenize
+#include "io_utils.h"
+
+
+static int _dc_sock;
+static pthread_t _dc_thread;
+static BOOL _dc_abort = FALSE;
+static char * _restrict_ip = NULL;
+
+
+void printRadio(Radio radio)
+{
+	output("discovery_protocol_version=%s model=%s serial=%s version=%s nickname=%s callsign=%s ip=%s port=%s status=%s\n",
+			radio->discovery_protocol_version,
+			radio->model,
+			radio->serial,
+			radio->version,
+			radio->nickname,
+			radio->callsign,
+			radio->ip,
+			radio->port,
+			radio->status);
+}
+
+	char* protocol_version;
+	char* model;
+	char* serial;
+	char* version;
+	char* nickname;
+	char* callsign;
+	char* ip;
+	char* port;
+	char* status;
+
+static void _dc_RadioFound(Radio radio)
+{
+
+	BOOL radio_found = FALSE;
+
+	if ( _restrict_ip != NULL ) {
+		if ( getIP(radio->ip) == getIP(_restrict_ip)) {
+			/* We have found the radio that we are restricted to */
+			output("We found a radio that maches our _restrict_ip - '%s'\n", _restrict_ip);
+			radio_found = TRUE;
+		}
+	} else if ( FALSE ) { /* Are we running within a radio? */
+
+		if(getIP(radio->ip) == ntohl(net_get_ip())) {
+			radio_found = TRUE;
+			output("We found a radio that is running on the same box as us - '%s'\n", radio->ip);
+		}
+
+	} else { /* Simply connect to first radio we find */
+		radio_found = TRUE;
+		output("We are attaching to the first radio we see");
+	}
+
+	if ( radio_found ) {
+		output("Radio found\n");
+		// yes -- connect and stop looking for more radios
+		// TODO: connect
+		    // start a keepalive to keep the channel open and know when it dies
+		tc_Init(radio->ip, radio->port);
+
+		usleep(250000);
+		hal_Listener_Init();
+
+		dc_Exit();
+	}
+
+	// print the content of the object
+	//printRadio(radio);
+
+	// because the radio object is malloc'ed, we need to recover the memory
+	safe_free(radio);
+	radio = 0;
+}
+
+static void _dc_ListenerParsePacket(uint8* packet, int32 length, struct sockaddr_in* sender)
+{
+	//output("_dc_ListenerParsePacket\n");
+
+	// is this packet long enough to inspect for VITA header info?
+	if(length < 16)
+	{
+		// no -- discard the packet
+		//output("_dc_ListenerParsePacket: packet too short\n");
+		return;
+	}
+
+	// cast the incoming packet as a VITA packet
+	VitaIFData p = (VitaIFData)packet;
+
+	// does this packet have our OUI?
+	if(ntohl(p->class_id_h) != 0x00001C2D)
+	{
+		// no -- discard this packet
+		output("_dc_ListenerParsePacket: wrong OUI (0x%08X)\n", htonl(p->class_id_h));
+		return;
+	}
+
+	// is this packet an extended data packet?
+	if((ntohl(p->header) & VITA_HEADER_PACKET_TYPE_MASK) != VITA_PACKET_TYPE_EXT_DATA_WITH_STREAM_ID)
+	{
+		// no -- discard this packet
+		output("_dc_ListenerParsePacket: wrong packet type (0x%08X)\n", p->header & VITA_HEADER_PACKET_TYPE_MASK);
+		return;
+	}
+
+	// is this packet marked as a SL_VITA_DISCOVERY_CLASS?
+	if((ntohl(p->class_id_l) & VITA_CLASS_ID_PACKET_CLASS_MASK) != 0xFFFF)
+	{
+		// no -- discard this packet
+		output("_dc_ListenerParsePacket: wrong packet class (0x%04X)\n", p->class_id_l & VITA_CLASS_ID_PACKET_CLASS_MASK);
+		return;
+	}
+
+	// if we made it this far, then we can safely assume this is a
+	// discovery packet and we will attempt to split the payload up
+	// similar to a command on spaces and parse the data
+
+	int argc, i;
+	char *argv[MAX_ARGC + 1];		//Add one extra so we can null terminate the array
+
+	// split the payload string up
+	tokenize((char*)p->payload, &argc, argv, MAX_ARGC);
+
+	//output("_dc_ListenerParsePacket: payload: %s\n", p->payload);
+	//output("_dc_ListenerParsePacket: tokenize argc=%u\n", argc);
+
+	Radio radio = (Radio)safe_malloc(sizeof(radioType));
+	if(!radio)
+	{
+		output("_dc_ListenerParsePacket: Out of memory!\n");
+		return;
+	}
+
+	// clear the newly allocated memory
+	memset(radio, 0, sizeof(radioType));
+
+	// for each token, process the string
+	for(i=0; i<argc; i++)
+	{
+		if(strncmp(argv[i], "discovery_protocol_version", strlen("discovery_protocol_version")) == 0)
+			radio->discovery_protocol_version = argv[i]+strlen("discovery_protocol_version=");
+		else if(strncmp(argv[i], "model", strlen("model")) == 0)
+			radio->model = argv[i]+strlen("model=");
+		else if(strncmp(argv[i], "serial", strlen("serial")) == 0)
+			radio->serial = argv[i]+strlen("serial=");
+		else if(strncmp(argv[i], "version", strlen("version")) == 0)
+			radio->version = argv[i]+strlen("version=");
+		else if(strncmp(argv[i], "nickname", strlen("nickname")) == 0)
+			radio->nickname = argv[i]+strlen("nickname=");
+		else if(strncmp(argv[i], "callsign", strlen("callsign")) == 0)
+			radio->callsign = argv[i]+strlen("callsign=");
+		else if(strncmp(argv[i], "ip", strlen("ip")) == 0)
+			radio->ip = argv[i]+strlen("ip=");
+		else if(strncmp(argv[i], "port", strlen("port")) == 0)
+			radio->port = argv[i]+strlen("port=");
+		else if(strncmp(argv[i], "status", strlen("status")) == 0)
+			radio->status = argv[i]+strlen("status=");
+	}
+
+	// did we get at least an IP, port, and version?
+	if(radio->ip != 0 && radio->port != 0 && radio->version != 0) {
+		// yes -- report the radio as found
+		_dc_RadioFound(radio);
+	} else {
+		safe_free(radio);
+	}
+}
+
+static struct timeval timeout;
+//! Allocates a buffer and receives one packet.
+//! /param buffer Buffer to be allocated and populated with packet data
+//! /returns Number of bytes read if successful, otherwise an error (recvfrom)
+static BOOL _dc_ListenerRecv(uint8* buffer, int32* len, struct sockaddr_in* sender_addr)
+{
+	//output("_dc_ListenerRecv\n");
+
+	uint32 addr_len = sizeof(struct sockaddr_in);
+
+	// we will wait up to 1 second for data in case someone is trying to abort us
+
+	timeout.tv_sec = 1;
+	timeout.tv_usec = 0;
+	fd_set socks;
+	FD_ZERO(&socks);
+	FD_SET(_dc_sock, &socks);
+
+	// see if there is data in the socket (but timeout if none)
+	select(_dc_sock + 1, &socks, NULL, NULL, &timeout);
+	if (FD_ISSET(_dc_sock, &socks))
+	{
+		// yes there is data -- get it
+		*len = recvfrom(_dc_sock, buffer, ETH_FRAME_LEN, 0, (struct sockaddr*)sender_addr, &addr_len);
+		//precisionTimerLap("HAL Listener Recv");
+		if(*len < 0)
+			output("_dc_ListenerRecv: recvfrom returned -1  errno=%08X\n", errno);
+		//else
+			//output("_hal_ListenerRecv: Error len=%d sender=%s:%u\n", len, inet_ntoa(sender_addr.sin_addr), htons(sender_addr.sin_port));
+
+		// TODO: May need to filter here to handle security (packet injection)
+		return TRUE;
+	}
+
+	*len = 0;
+	return FALSE;
+}
+
+static void* _dc_ListenerLoop(void* param)
+{
+	//printf("_dc_ListenerLoop\n");
+    prctl(PR_SET_NAME, "DV-ListenerLoop");
+
+	struct sockaddr_in sender;
+	uint8 buf[ETH_FRAME_LEN];
+
+	while(!_dc_abort)
+	{
+		// get some data
+		int32 length = 0;
+		BOOL success = FALSE;
+
+		while (!success && !_dc_abort)
+		{
+			memset(&sender,0,sizeof(struct sockaddr_in));
+			memset(&buf,0,ETH_FRAME_LEN);
+			success = _dc_ListenerRecv(buf, &length, &sender);
+		}
+
+		if (!_dc_abort)
+		{
+			if(length == 0) // socket has been closed
+			{
+				output("_dc_ListenerLoop error: socket closed\n");
+				break;
+			}
+
+			if(length < 0)
+			{
+				output("_dc_ListenerLoop error: loop stopped\n");
+				break;
+			}
+
+			// length was reasonable -- lets try to parse the packet
+			//precisionTimerLap("HAL Listener Parse Packet");
+			_dc_ListenerParsePacket(buf, length, &sender);
+		}
+	}
+
+	if ( _restrict_ip ) {
+		safe_free(_restrict_ip);
+		_restrict_ip = NULL;
+	}
+
+	return NULL;
+}
+
+void dc_Init(const char * radio_ip)
+{
+	output("Discovery Client Init: Opening socket");
+	int true = TRUE;
+	if((_dc_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1)
+	{
+		output("...failed! (socket call returned -1)\n");
+		return;
+	}
+
+	// set up destination address
+	struct sockaddr_in addr;
+
+	memset(&addr,0,sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_ANY); // this is where we could limit to one IP
+	addr.sin_port=htons(DISCOVERY_PORT);
+
+	/* If you're running on the same box as the smartsdr firmware this is necessary so
+	 * that both processes can bind to the same VITA port
+	 */
+	errno = 0;
+	setsockopt(_dc_sock, SOL_SOCKET, SO_REUSEADDR, &true, sizeof(true));
+	if (errno)
+	{
+		output("error with reuse option: errno=%d",errno);
+	}
+
+	// bind the socket to the port and/or IP
+	output("...binding");
+	errno = 0;
+	if(bind(_dc_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1)
+	{
+		output("...failed! (bind call returned -1: errno:%d)\n", errno);
+		return;
+	}
+	output("\n");
+
+	if ( _restrict_ip ) {
+		safe_free(_restrict_ip );
+		_restrict_ip = NULL;
+	}
+
+	if ( radio_ip != NULL ) {
+		_restrict_ip = safe_malloc(strlen(radio_ip) + 1 );
+		strncpy(_restrict_ip, radio_ip, strlen(radio_ip) + 1);
+	}
+
+	// start the listener thread
+	pthread_create(&_dc_thread, NULL, &_dc_ListenerLoop, NULL);
+}
+
+void dc_Exit(void)
+{
+	_dc_abort = TRUE;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/discovery_client.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/discovery_client.h
@@ -1,0 +1,54 @@
+/* *****************************************************************************
+ *	discovery_client.h
+ *
+ *   \brief Discovery Client - Receives and parses discovery packets
+ *
+ *
+ * 	\author Eric Wachsmann, KE5DTO
+ * 	\date   2014-09-01
+ *
+ *******************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef DISCOVERY_CLIENT_H_
+#define DISCOVERY_CLIENT_H_
+
+typedef struct _radio
+{
+	char* discovery_protocol_version;
+	char* model;
+	char* serial;
+	char* version;
+	char* nickname;
+	char* callsign;
+	char* ip;
+	char* port;
+	char* status;
+
+} radioType, *Radio;
+
+void dc_Init(const char * radio_ip);
+void dc_Exit(void);
+
+void printRadio(Radio radio);
+
+
+#endif // DISCOVERY_CLIENT_H_

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_buffer.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_buffer.c
@@ -1,0 +1,136 @@
+/* *****************************************************************************
+ *	hal_buffer.c
+ *
+ *		Buffer structures to support getting samples from the right stream to
+ *    		the DSP.
+ *
+ *
+ *	\date 29-MAR-2012
+ *	\author Eric & Steve
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // for memset
+#include <math.h>
+
+#include "common.h"
+//#include "platform.h"
+#include "hal_buffer.h"
+
+BufferDescriptor hal_BufferRequest(uint32 num_samples, uint32 sample_size)
+{
+	// allocate memory for the new object
+//	BufferDescriptor buf = (BufferDescriptor)safe_malloc(sizeof(buffer_descriptor));
+	BufferDescriptor buf = (BufferDescriptor)safe_malloc(sizeof(buffer_descriptor));		// substitute non-thread-safe malloc
+//	debug(LOG_DEV, TRUE, "\033[32m+ buf_desc alloc: %08X %04X\033[m", (uint32)buf, sizeof(buffer_descriptor));
+	if(!buf)
+	{
+//		debug(LOG_DEV, TRUE, "Error allocating buffer descriptor (size=%u)", sizeof(buffer_descriptor));
+		return 0;
+	}
+
+	// clear memory of new descriptor object
+	memset(buf, 0, sizeof(buffer_descriptor));
+
+	// initialize size and allocate buffer
+	buf->num_samples = num_samples;
+	buf->sample_size = sample_size;
+	const size_t buffer_bytes = (size_t)num_samples * sample_size;
+//	buf->buf_ptr = safe_malloc(num_samples * sample_size);
+	buf->buf_ptr = safe_malloc(buffer_bytes);	// substitute non-thread-safe malloc
+//	debug(LOG_DEV, TRUE, "\033[35m+     buf alloc: %08X, %04X\033[m", (uint32)buf->buf_ptr, num_samples * sample_size);
+	if(!buf->buf_ptr)
+	{
+//		debug(LOG_DEV, TRUE, "Error allocating buffer descriptor (size=%u)", num_samples * sample_size);
+//		safe_free(buf); // prevent memory leak
+		free(buf);		// un-thread-safe free
+		buf = NULL;
+		return NULL;
+	}
+
+	// clear memory of new buffer object
+	memset(buf->buf_ptr, 0, buffer_bytes);
+
+	return buf;
+}
+
+void hal_BufferRelease(BufferDescriptor *buf_desc)
+{
+	if(*buf_desc)
+	{
+		if((*buf_desc)->buf_ptr != NULL)
+		{
+//			debug(LOG_DEV, TRUE, "\033[35m-     releasing buf: %08X\033[m", (uint32)(*buf_desc)->buf_ptr);
+//			safe_free((*buf_desc)->buf_ptr);
+			free((*buf_desc)->buf_ptr);		// un-thread-safe free
+			(*buf_desc)->buf_ptr = NULL;
+		}
+
+//		debug(LOG_DEV, TRUE, "\033[32m- releasing buf_desc: %08X\033[m", (uint32)*buf_desc);
+//		safe_free(*buf_desc);
+		free(*buf_desc);		// un-thread-safe free
+		*buf_desc = NULL;
+	}
+}
+
+BufferDescriptor hal_BufferClone(BufferDescriptor buf)
+{
+	BufferDescriptor new_buf = hal_BufferRequest(buf->num_samples, buf->sample_size);
+	if(!new_buf)
+	{
+//		debug(LOG_DEV, TRUE, "Error allocating new buffer");
+		return 0;
+	}
+
+	// copy member variables
+	new_buf->stream_id = buf->stream_id;
+	new_buf->timestamp_int = buf->timestamp_int;
+	new_buf->timestamp_frac_h = buf->timestamp_frac_h;
+	new_buf->timestamp_frac_l = buf->timestamp_frac_l;
+
+	// copy the actual buffer
+	memcpy(new_buf->buf_ptr,
+		   buf->buf_ptr,
+		   (size_t)buf->num_samples * buf->sample_size);
+
+	return new_buf;
+}
+
+void hal_BufferPrint(BufferDescriptor buf_desc)
+{
+	int i;
+	for(i=0; i<16; i++)
+		printf("%.2f ", ((float*)buf_desc->buf_ptr)[i]);
+}
+
+float hal_BufferMag(BufferDescriptor buf_desc)
+{
+	int i;
+	float sum = 0.0f;
+
+	for(i=0; i<buf_desc->num_samples*2; i++)
+		sum += fabs(((float*)buf_desc->buf_ptr)[i]);
+
+	return sum;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_buffer.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_buffer.h
@@ -1,0 +1,83 @@
+/* *****************************************************************************
+ *	hal_buffer.h
+ *
+ *		Buffer structures to support getting samples from the right stream to
+ *			the DSP.
+ *
+ *	\date Mar 29, 2012
+ *	\author Eric & Steve
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef _BUFFER_H
+#define _BUFFER_H
+
+#include <pthread.h>
+
+#include "datatypes.h"
+
+#pragma pack(4)
+
+///@{
+//! buffer_descriptor
+//! \brief describes a VITA-49 buffer received for processing and decomposed
+typedef struct _buffer_descriptor
+{
+	//! stream id showing where this buffer came from
+	uint32 stream_id;
+	//! number of samples stored in the buffer
+	uint32 num_samples; // in frames
+	//! size in bytes of the sample
+	uint32 sample_size;
+	//! pointer to the buffer containing the samples
+	void* buf_ptr; // pointer to the actual buffer
+	//! integer timestamp for the first sample in the buffer (see VITA-49 spec)
+	uint32 timestamp_int;
+	//! high 32-bits of fractional portion of the timestamp
+	uint32 timestamp_frac_h;
+	//! low 32-bits of the fractional portion of the timestamp
+	uint32 timestamp_frac_l;
+	//! pointer to next buffer descriptor
+	struct _buffer_descriptor* next;
+	//! pointer to previous buffer descriptor
+	struct _buffer_descriptor* prev;
+} buffer_descriptor, *BufferDescriptor;
+///@}
+
+#pragma pack()
+
+//! Requests a Buffer to be used in the DSP
+//! \param size Number of frames to allocate
+BufferDescriptor hal_BufferRequest(uint32 size, uint32 sample_size);
+
+//! To be called once finished with the buffer (cleanup)
+//! \param buf Buffer that is no longer in use
+void hal_BufferRelease(BufferDescriptor *buf);
+
+//! Does a deep copy of the buffer descriptor including the buffer
+//! \param buf The buffer descriptor to copy
+BufferDescriptor hal_BufferClone(BufferDescriptor buf);
+
+void hal_BufferPrint(BufferDescriptor buf_desc);
+float hal_BufferMag(BufferDescriptor buf_desc);
+
+#endif // _BUFFER_H

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_listener.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_listener.c
@@ -1,0 +1,569 @@
+///*!	\file hal_listener.c
+// *	\brief Listener for VITA-49 packets
+// *
+// *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date 28-MAR-2012
+// *	\author Eric & Steve
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <string.h> // for memset
+#include <sys/socket.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <netinet/in.h> // for htonl, htons
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <errno.h> // for errno
+#include <unistd.h>			// for usleep
+#include <netdb.h>
+#include <sys/prctl.h>
+
+// #define LOG_MODULE LOG_MODULE_HAL_LISTENER
+
+#include "vita.h"
+#include "hal_vita.h"
+#include "common.h"
+
+#include "stream.h"
+#include "vita_output.h"
+#include "hal_buffer.h"
+#include "sched_waveform.h"
+
+extern int errno;
+
+// static local variables
+static int fpga_sock;
+static BOOL hal_listen_abort;
+
+static pthread_t _hal_listen_thread;
+//static Thread _hal_counter_thread;
+
+// prototypes
+static void _hal_ListenerParsePacket(uint8* packet, int32 length, struct sockaddr_in* sender);
+static void _hal_ListenerProcessWaveformPacket(VitaIFData p, uint32 stream_id, int32 length, struct sockaddr_in* sender);
+
+#define MAX_COUNTED_STREAMS 100
+#define COUNTER_INTERVAL_MS 1000
+//static stream_count_type current_counters[MAX_COUNTED_STREAMS];
+//static stream_count_type report_counters[MAX_COUNTED_STREAMS];
+//static uint32 _end_count, _report_count;
+
+//void HAL_update_count(uint32 stream_id, uint32 class_id_h, uint32 class_id_l, uint32 size, uint32 status, StreamDirection direction, ShortStreamType strm_type, uint32 ip, uint16 port)
+//{
+//	acquireLocalLock(_counter_lock, LOCAL_LOCK_WRITE);
+//	int i;
+//	for (i = 0; i < _end_count; i++)
+//	{
+//		if (stream_id == current_counters[i].stream_id &&
+//			class_id_h == current_counters[i].class_id_h &&
+//			class_id_l == current_counters[i].class_id_l &&
+//			direction == current_counters[i].direction &&
+//			strm_type == current_counters[i].stream_type &&
+//			ip == current_counters[i].ip &&
+//			port == current_counters[i].port)
+//		{
+//			current_counters[i].count++;
+//			current_counters[i].size += size;
+//			goto end;
+//		}
+//	}
+//	if (_end_count == MAX_COUNTED_STREAMS) return;
+//	current_counters[_end_count].direction = direction;
+//	current_counters[_end_count].stream_type = strm_type;
+//	current_counters[_end_count].class_id_h = class_id_h;
+//	current_counters[_end_count].class_id_l = class_id_l;
+//	current_counters[_end_count].count = 1;
+//	current_counters[_end_count].size = size;
+//	current_counters[_end_count].stream_id = stream_id;
+//	current_counters[_end_count].status = status;
+//	current_counters[_end_count].ip = ip;
+//	current_counters[_end_count].port = port;
+//	_end_count++;
+//
+//end:
+//	releaseLocalLock(_counter_lock);
+//}
+
+//static void _hal_reset_count(void)
+//{
+//	int i;
+//
+////	acquireLocalLock(_print_lock, LOCAL_LOCK_WRITE);
+////	acquireLocalLock(_counter_lock, LOCAL_LOCK_WRITE);
+//	// make a backup copy of the counters for reporting
+//	memcpy(report_counters, current_counters, sizeof(stream_count_type)*_end_count);
+//	_report_count = _end_count;
+//
+//	for (i = 0; i < _report_count; i++)
+//	{
+//		report_counters[i].speed = (float)report_counters[i].size / COUNTER_INTERVAL_MS * 0.008;
+//		report_counters[i].count = (int)(report_counters[i].count * 1000 / COUNTER_INTERVAL_MS);
+//		report_counters[i].printed = FALSE;
+//	}
+//	// clear out the current current_counters
+//	memset(current_counters, 0, sizeof(stream_count_type)*_end_count);
+//	_end_count = 0;
+//	releaseLocalLock(_counter_lock);
+//	releaseLocalLock(_print_lock);
+//}
+
+//static void* _hal_counter_loop(void* param)
+//{
+//	// show that we are running
+//	thread_setRunning(_hal_counter_thread);
+//
+//	while (!hal_listen_abort)
+//	{
+//		// sleep for the designated time
+//		usleep (COUNTER_INTERVAL_MS * 1000);
+//		_hal_reset_count();
+//	}
+//
+//	destroyLocalLock(&_counter_lock);
+//	thread_done(_hal_counter_thread);
+//	return NULL;
+//}
+
+char* _hal_getStreamType(ShortStreamType strm_type)
+{
+	switch (strm_type)
+	{
+		case FFT: return "FFT";
+		case MMX: return "MMX";
+		case AUD: return "AUD";
+		case MET: return "MET";
+		case DSC: return "DSC";
+		case IQD: return "IQD";
+		case TXD: return "TXD";
+		case PAN: return "PAN";
+		case WFL: return "WFL";
+		case WFM: return "WFM";
+		case XXX: return "---";
+	}
+	return "---";
+}
+//
+//void _hal_showStreamLine(uint32 i)
+//{
+//	char* status;
+//	switch(report_counters[i].status)
+//	{
+//	case HAL_STATUS_PROCESSED:			status = "\033[32mProcessing          \033[m"; break;
+//	case HAL_STATUS_INVALID_OUI:		status = "\033[91mInvalid OUI         \033[m"; break;
+//	case HAL_STATUS_NO_DESC:			status = "\033[33mNo Descriptor       \033[m"; break;
+//	case HAL_STATUS_UNSUPPORTED_SAMP:	status = "\033[31mUnsupported MMX Rate\033[m"; break;
+//	case HAL_STATUS_UNSUPPORTED_FFT:	status = "\033[31mUnsupported FFT Rate\033[m"; break;
+//	case HAL_STATUS_BAD_TYPE:			status = "\033[33mBad Type            \033[m"; break;
+//	case HAL_STATUS_OUTPUT_OK:			status = "\033[32mPacket Sent OK      \033[m"; break;
+//	case HAL_STATUS_TX_SKIP:			status = "\033[32mSkipping, in TX     \033[m"; break;
+//	case HAL_STATUS_TX_ZERO:			status = "\033[32mSending Zero, in TX \033[m"; break;
+//	case HAL_STATUS_WFM_SIZE_WRONG:		status = "\033[91mWFM packet size bad \033[m"; break;
+//	case HAL_STATUS_WFM_NO_STREAM:		status = "\033[33mNo WFM stream       \033[m"; break;
+//	case HAL_STATUS_UNK_STREAM:			status = "\033[33mUnknown Stream ID   \033[m"; break;
+//	default:							status = "\033[35mUnknown             \033[m"; break;
+//	}
+//
+////	if (report_counters[i].direction == INPUT)
+////	{
+////		output("%s %s 0x%08X   0x%08X %08X   %5u   %s   %6.3f Mbps\n",
+////				(report_counters[i].direction == INPUT) ? " IN" : "OUT",
+////				_hal_getStreamType(report_counters[i].stream_type),
+////				report_counters[i].stream_id,
+////				report_counters[i].class_id_h,
+////				report_counters[i].class_id_l,
+////				report_counters[i].count,
+////				status,
+////				report_counters[i].speed);
+////	}
+////	else
+//	{
+//		uint32 ip = htonl(report_counters[i].ip);
+//		uint16 port = htons(report_counters[i].port);
+//		if (ip == 0xAC1E0102)
+//		{
+//		output("%s %s 0x%08X   0x%08X %08X   %5u   %s   %6.3f Mbps   \033[33mFPGA\033[m\n",
+//				(report_counters[i].direction == INPUT) ? " IN" : "OUT",
+//				_hal_getStreamType(report_counters[i].stream_type),
+//				report_counters[i].stream_id,
+//				report_counters[i].class_id_h,
+//				report_counters[i].class_id_l,
+//				report_counters[i].count,
+//				status,
+//				report_counters[i].speed);
+//		}
+//		else
+//		{
+//			output("%s %s 0x%08X   0x%08X %08X   %5u   %s   %6.3f Mbps   %u.%u.%u.%u:%u  ",
+//					(report_counters[i].direction == INPUT) ? " IN" : "OUT",
+//					_hal_getStreamType(report_counters[i].stream_type),
+//					report_counters[i].stream_id,
+//					report_counters[i].class_id_h,
+//					report_counters[i].class_id_l,
+//					report_counters[i].count,
+//					status,
+//					report_counters[i].speed,
+//					ip>>24, (ip>>16)&0xFF, (ip>>8)&0xFF, ip&0xFF, port);
+//
+//			//output("(%s)",getHost(ip));
+//			//char* program = client_getClientProgram(htonl(report_counters[i].ip), htons(report_counters[i].port));
+//			//if (program != NULL) output("  %s",program);
+//			output ("\n");
+//		}
+//	}
+//}
+//
+//void hal_showStreamReport(void)
+//{
+//	int i;
+//	float input_total = 0, output_total = 0;
+//	uint32 input_packet_rate = 0, output_packet_rate = 0;
+//
+////	acquireLocalLock(_print_lock, LOCAL_LOCK_WRITE);
+//
+//	output("\033[96mDIR TYP Stream ID    Class ID              Count   Status              Rate (includes VITA o/h)\033[m\n");
+//
+//	// output sorted list of input streams
+//	uint32 min_stream_id;
+//	do
+//	{
+//		min_stream_id = 0xFFFFFFFF;
+//		for (i = 0; i < _report_count; i++)
+//		{
+//			if (report_counters[i].direction == INPUT &&
+//				!report_counters[i].printed &&
+//				report_counters[i].stream_id < min_stream_id)
+//			{
+//				min_stream_id = report_counters[i].stream_id;
+//			}
+//		}
+//		for (i = 0; i < _report_count; i++)
+//		{
+//			if ((report_counters[i].stream_id == min_stream_id) && !report_counters[i].printed)
+//			{
+//				_hal_showStreamLine(i);
+//				input_total += report_counters[i].speed;
+//				input_packet_rate += report_counters[i].count;
+//				report_counters[i].printed = TRUE;
+//			}
+//		}
+//	}
+//	while (min_stream_id != 0xFFFFFFFF);
+//
+//
+//	uint32 percent = (uint32)(input_total + 0.5);
+//	output("\033[32mAggregate input rate: \033[m%u packets/s, %.3f Mbps (%u%%)\n\n",input_packet_rate,input_total,percent);
+//
+//
+//	do
+//	{
+//		min_stream_id = 0xFFFFFFFF;
+//		for (i = 0; i < _report_count; i++)
+//		{
+//			if (report_counters[i].direction == OUTPUT &&
+//				!report_counters[i].printed &&
+//				report_counters[i].stream_id < min_stream_id)
+//			{
+//				min_stream_id = report_counters[i].stream_id;
+//			}
+//		}
+//		for (i = 0; i < _report_count; i++)
+//		{
+//			if (report_counters[i].stream_id == min_stream_id && !report_counters[i].printed)
+//			{
+//				_hal_showStreamLine(i);
+//				output_total += report_counters[i].speed;
+//				output_packet_rate += report_counters[i].count;
+//				report_counters[i].printed = TRUE;
+//			}
+//		}
+//	}
+//	while (min_stream_id != 0xFFFFFFFF);
+//
+//	// clear the print flags
+//	for (i = 0; i < _report_count; i++)
+//	{
+//		report_counters[i].printed = FALSE;
+//	}
+//
+////	releaseLocalLock(_print_lock);
+//
+//	output("\033[32mAggregate output rate: \033[m%u packets/s, %.3f Mbps\n",output_packet_rate,output_total);
+//}
+//
+//float hal_getStreamRate(uint32 stream_id)
+//{
+//	int i;
+//	for (i = 0; i < _report_count; i++)
+//	{
+//		if (report_counters[i].stream_id == stream_id)
+//		{
+//			return report_counters[i].speed;
+//		}
+//	}
+//	return 0.0f;
+//
+//}
+
+
+static void _hal_ListenerProcessWaveformPacket(VitaIFData p, uint32 stream_id, int32 length, struct sockaddr_in* sender)
+{
+	/*TODO: Make the buffer size a define*/
+
+	BufferDescriptor buf_desc;
+	buf_desc = hal_BufferRequest(HAL_RX_BUFFER_SIZE, sizeof(Complex));
+
+//	BufferDescriptor buf_desc = s->buf_desc_ptr;
+//
+//	if(buf_desc == NULL) {
+//		output( "buf_desc was null. race?)");
+//		return;
+//	}
+//	/*  set timestamp for start of buffer if necessary */
+	if(!buf_desc->timestamp_int)
+	{
+		buf_desc->timestamp_int = htonl(p->timestamp_int);
+		buf_desc->timestamp_frac_h = htonl(p->timestamp_frac_h);
+		buf_desc->timestamp_frac_l = htonl(p->timestamp_frac_l);
+	}
+
+
+	// calculate number of samples in the buffer
+	uint32 packet_frames = hal_VitaIFPacketPayloadSize(p)/buf_desc->sample_size;
+
+	// verify the frames fit in the actual packet size
+	if(packet_frames * 8 > length - 28)
+	{
+		output( "\033[91mIncoming packet size (%d) smaller than vita header claims\033[m\n", length);
+		//HAL_update_count(htonl(p->stream_id), htonl(p->class_id_h), htonl(p->class_id_l),length,HAL_STATUS_WFM_SIZE_WRONG, INPUT, AUD, sender->sin_addr.s_addr, sender->sin_port);
+		hal_BufferRelease(&buf_desc);
+		return;
+	}
+
+	//output("Packet frames = %d\n", packet_frames);
+
+	//HAL_update_count(buf_desc->stream_id, htonl(p->class_id_h), htonl(p->class_id_l), length,HAL_STATUS_PROCESSED, INPUT, AUD, sender->sin_addr.s_addr, sender->sin_port);
+
+	// figure out how many frames it would take to fill the buffer
+	//uint32 buf_frames_left = buf_desc->num_samples - s->sample_count;
+		// figure out how many frames to copy to the buffer
+	uint32 frames_to_copy = packet_frames;
+
+	//output("Buffer mag before memcpy %.6g\n", hal_BufferMag(buf_desc));
+	// copy the frames from the packet into the buffer
+	memcpy(buf_desc->buf_ptr, // dest
+			p->payload, // src
+			(size_t)frames_to_copy * buf_desc->sample_size); // number of bytes to copy
+
+	//output("Buffer mag after memcpy %.6g\n", hal_BufferMag(buf_desc));
+	/* We now require a full frame to arrive in each packet so we don't handle segmentation of data across packets */
+	buf_desc->stream_id = ntohl(p->stream_id);
+	// send off the buffer to processor that handles giving it to the correct waveform
+	sched_waveform_Schedule(buf_desc);
+
+}
+
+
+static struct timeval timeout;
+//! Allocates a buffer and receives one packet.
+//! /param buffer Buffer to be allocated and populated with packet data
+//! /returns Number of bytes read if successful, otherwise an error (recvfrom)
+static BOOL _hal_ListenerRecv(uint8* buffer, int32* len, struct sockaddr_in* sender_addr)
+{
+	uint32 addr_len = sizeof(struct sockaddr_in);
+
+	// we will wait up to 1 second for data in case someone is trying to abort us
+
+	timeout.tv_sec = 1;
+	timeout.tv_usec = 0;
+	fd_set socks;
+	FD_ZERO(&socks);
+	FD_SET(fpga_sock, &socks);
+
+	// see if there is data in the socket (but timeout if none)
+	select(fpga_sock + 1, &socks, NULL, NULL, &timeout);
+	if (FD_ISSET(fpga_sock, &socks))
+	{
+		// yes there is data -- get it
+		*len = recvfrom(fpga_sock, buffer, ETH_FRAME_LEN, 0, (struct sockaddr*)sender_addr, &addr_len);
+		//precisionTimerLap("HAL Listener Recv");
+		if(*len < 0)
+			output("_hal_ListenerRecv: recvfrom returned -1  errno=%08X\n", errno);
+		//else
+			//output("_hal_ListenerRecv: Error len=%d sender=%s:%u\n", len, inet_ntoa(sender_addr.sin_addr), htons(sender_addr.sin_port));
+
+		// TODO: May need to filter here to handle security (packet injection)
+		return TRUE;
+	}
+
+	*len = 0;
+	return FALSE;
+}
+
+static void* _hal_ListenerLoop(void* param)
+{
+	// show that we are running
+//	thread_setRunning(_hal_listen_thread);
+
+	struct sockaddr_in sender;
+	uint8 buf[ETH_FRAME_LEN];
+	prctl(PR_SET_NAME, "DV-halListener");
+
+	while(!hal_listen_abort)
+	{
+		// get some data
+		int32 length = 0;
+		BOOL success = FALSE;
+
+		while (!success && !hal_listen_abort)
+		{
+			memset(&sender,0,sizeof(struct sockaddr_in));
+			memset(&buf,0,ETH_FRAME_LEN);
+			success = _hal_ListenerRecv(buf, &length, &sender);
+		}
+
+		if (!hal_listen_abort)
+		{
+			if(length == 0) // socket has been closed
+			{
+				output("_hal_ListenerLoop error: socket closed\n");
+				break;
+			}
+
+			if(length < 0)
+			{
+				output("_hal_ListenerLoop error: loop stopped\n");
+				break;
+			}
+
+			// length was reasonable -- lets try to parse the packet
+			//precisionTimerLap("HAL Listener Parse Packet");
+			_hal_ListenerParsePacket(buf, length, &sender);
+		}
+	}
+
+	//thread_done(_hal_listen_thread);
+	return NULL;
+}
+
+static void _hal_ListenerParsePacket(uint8* packet, int32 length, struct sockaddr_in* sender)
+{
+	//Stream s;
+
+	// make sure packet is long enough to inspect for VITA header info
+	if(length < 28)
+		return;
+
+	VitaIFData p = (VitaIFData) packet;
+
+	// does this packet have our OUI?
+	if(htonl(p->class_id_h) != 0x00001C2D)
+	{
+		//HAL_update_count(htonl(p->stream_id), htonl(p->class_id_h), htonl(p->class_id_l),length,HAL_STATUS_INVALID_OUI, INPUT, XXX, sender->sin_addr.s_addr, sender->sin_port);
+		return;
+	}
+
+	// verify the length of the packet matches the VITA header
+	//uint32 vita_length = (htonl(p->header) & VITA_HEADER_PACKET_SIZE_MASK) * 4;
+	/*
+	if(vita_length != length - vitaPacketOffset)
+	{
+		output("_hal_ListenerParsePacket: Vita packet size (%u*4=%u) and packet length (%u) do not match\n",
+				vita_length/4, vita_length, length - vitaPacketOffset);
+		return;
+	}
+	*/
+
+	// what kind of Vita Packet is this?
+
+	//if(!(htonl(p->header) & VITA_HEADER_PACKET_TYPE_MASK) == VITA_PACKET_TYPE_IF_DATA_WITH_STREAM_ID)
+	//		output("_hal_ListenerParsePacket: received ext data packet from unexpected packet tpe (0x%08X)\n", htonl(p->header) & VITA_HEADER_PACKET_TYPE_MASK);
+
+//	lockBits locks;
+
+	switch(htonl(p->stream_id) & STREAM_BITS_MASK)
+	{
+		case STREAM_BITS_WAVEFORM | STREAM_BITS_IN:
+
+			//output("Received a STREAM_BITS_WAVEFORM | STREAM_BITS_IN buffer!!! wooo!!!!");
+//			if ( s->buf_desc_ptr == NULL)
+//			{
+//				HAL_update_count(htonl(p->stream_id), htonl(p->class_id_h), htonl(p->class_id_l),length,HAL_STATUS_NO_DESC, INPUT, WFM, sender->sin_addr.s_addr, sender->sin_port);
+//			}
+//			else
+//			{
+				_hal_ListenerProcessWaveformPacket(p, p->stream_id, length, sender);
+//			}
+
+		break;
+
+		default:
+		//	HAL_update_count(htonl(p->stream_id), htonl(p->class_id_h), htonl(p->class_id_l),length,HAL_STATUS_UNK_STREAM, INPUT, XXX, sender->sin_addr.s_addr, sender->sin_port);
+			output("Undefined stream in %08X", p->stream_id);
+			break;
+	}
+}
+
+void hal_Listener_Init(void)
+{
+	output("Vita Listener Init: Opening socket");
+
+	errno = 0;
+	if((fpga_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1)
+	{
+		output("...failed! (socket call returned -1) - errno = %d\n", errno);
+		return;
+	}
+
+	// set up destination address
+	struct sockaddr_in addr;
+
+	memset(&addr,0,sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_ANY); // this is where we could limit to one IP
+	addr.sin_port=htons(VITA_49_PORT);
+
+	// bind the socket to the port and/or IP
+	output("...binding");
+	if(bind(fpga_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1)
+	{
+		output("...failed! (bind call returned -1)\n");
+		return;
+	}
+	output("\n");
+
+	_hal_listen_thread = (pthread_t) NULL;
+	pthread_create(&_hal_listen_thread, NULL, &_hal_ListenerLoop, NULL);
+
+//	_hal_counter_thread = NULL;
+//	_hal_counter_thread = thread_add(locks, "HALSTATS", "Monitors System I/O", _hal_counter_loop, SCHED_OTHER, 0);
+//	if (action == THREAD_START)
+//	{
+//		thread_start(locks, _hal_counter_thread, NULL);
+//	}
+
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_listener.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_listener.h
@@ -1,0 +1,115 @@
+///*! \file hal_listener.h
+// *	\brief Listener for VITA-49 packets
+// *
+// *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date Mar 28, 2012
+// *	\author Eric & Steve
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef _LISTENER_H
+#define _LISTENER_H
+
+#include "../common.h"
+// #include "hal_display.h"
+// #include "display_list.h"
+#include "datatypes.h"
+
+#define HAL_RX_BUFFER_SIZE	128
+#define HAL_TX_BUFFER_SIZE	HAL_RX_BUFFER_SIZE
+#define HAL_SAMPLE_SIZE	sizeof(Complex);
+
+enum STREAM_DIRECTION
+{
+	INPUT 	= 1,
+	OUTPUT  = 2
+};
+typedef enum STREAM_DIRECTION StreamDirection;
+
+enum STREAM_TYPEX
+{
+	FFT = 1,
+	MMX = 2,
+	IQD = 3,
+	AUD = 4,
+	MET = 5,
+	DSC = 6,
+	TXD = 7,
+	PAN = 8,
+	WFL = 9,
+	WFM = 10,
+	XXX = 99
+};
+typedef enum STREAM_TYPEX ShortStreamType;
+//
+//typedef struct _stream_counters
+//{
+//	uint32 stream_id;
+//	StreamDirection direction;
+//	ShortStreamType stream_type;
+//	uint32 class_id_h;
+//	uint32 class_id_l;
+//	uint32 size;
+//	uint32 count;
+//	uint32 status;
+//	float speed;
+//	BOOL printed;
+//	uint32 ip;
+//	uint16 port;
+//} stream_count_type, *StreamCount;
+
+void hal_Listener_Init(void);
+//DisplayClient hal_ListenerGetFFTClient();
+//void hal_showStreamReport(void);
+//float hal_getStreamRate(uint32 stread_id);
+//void HAL_update_count(uint32 stream_id, uint32 class_id_h, uint32 class_id_l, uint32 size, uint32 status, StreamDirection direction, ShortStreamType strm_type, uint32 ip, uint16 port);
+
+
+
+#define HAL_STATUS_PROCESSED 1
+#define HAL_STATUS_INVALID_OUI 2
+#define HAL_STATUS_NO_DESC 3
+#define HAL_STATUS_UNSUPPORTED_SAMP 4
+#define HAL_STATUS_UNSUPPORTED_FFT 5
+#define HAL_STATUS_BAD_TYPE 6
+#define HAL_STATUS_FFT_NO_STREAM 7
+#define HAL_STATUS_IQ_NO_STREAM 8
+#define HAL_STATUS_OUTPUT_OK 9
+#define HAL_STATUS_DSP_NO_STREAM 10
+#define HAL_STATUS_DAX_NO_STREAM 11
+#define HAL_STATUS_DAX_SIZE_WRONG 12
+#define HAL_STATUS_DAX_WRONG_CHAN 13
+#define HAL_STATUS_TX_SKIP 14
+#define HAL_STATUS_TX_ZERO 15
+#define HAL_STATUS_UNK_STREAM 16
+
+
+/* Waveform defines */
+#define HAL_STATUS_WFM_SIZE_WRONG 17
+#define HAL_STATUS_WFM_NO_STREAM 18
+
+
+#endif // _LISTENER_H

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_vita.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_vita.c
@@ -1,0 +1,67 @@
+///*!	\file hal_vita.c
+// *	\brief Structure to support VITA-49 packets
+// *
+// *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date 29-MAR-2012
+// *	\author Eric & Steve
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+#include <stdio.h>
+#include <netinet/in.h> // htonl
+
+#include "common.h"
+#include "hal_vita.h"
+
+uint32 hal_VitaIFPacketPayloadSize(VitaIFData packet)
+{
+	uint32 header = htonl(packet->header);
+	uint32 bytes = (header & VITA_HEADER_PACKET_SIZE_MASK)*4; // packet size is in 32-bit words
+
+	switch(header & VITA_HEADER_PACKET_TYPE_MASK)
+	{
+		case VITA_PACKET_TYPE_IF_DATA: // do nothing
+			break;
+		case VITA_PACKET_TYPE_IF_DATA_WITH_STREAM_ID:
+			bytes -= 4; // account for stream ID
+			break;
+		default: // wrong kind of packet here
+			//output("Called with wrong type of packet (%X)\n", header>>28);
+			break;
+	}
+
+	bytes -= 4; // account for header
+
+	if(header & VITA_HEADER_C_MASK) bytes -= 8; // account for class ID
+	if(header & VITA_HEADER_T_MASK) bytes -= 4; // account for trailer
+
+	if((header & VITA_HEADER_TSI_MASK) != VITA_TSI_NONE)
+		bytes -= 4;
+
+	if((header & VITA_HEADER_TSF_MASK) != VITA_TSF_NONE)
+		bytes -= 8;
+
+	return bytes;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/hal_vita.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/hal_vita.h
@@ -1,0 +1,39 @@
+/* *****************************************************************************
+ *	vita.h
+ *
+ *		Describes VITA 49 structures
+ *
+ *	\date 28-MAR-2012
+ *	\author Eric Wachsmann, KE5DTO
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef _HAL_VITA_H
+#define _HAL_VITA_H
+
+#include "datatypes.h"
+#include "vita.h"
+
+//! gets the size of the payload in bytes based on the header
+uint32 hal_VitaIFPacketPayloadSize(VitaIFData packet);
+
+#endif /* _HAL_VITA_H */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/io_utils.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/io_utils.c
@@ -1,0 +1,58 @@
+///*!	\file io_utils.c
+// *	\brief Module that contains various IO utilities
+// *
+// *	\copyright	Copyright 2011-2012 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date 9-NOV-2011
+// *    \author Terry Gerdes, AB5K
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "common.h"
+
+uint32 net_get_ip()
+{
+    struct ifaddrs* ifAddrStruct = NULL;
+    struct ifaddrs* ifa = NULL;
+    uint32 ip = 0;
+
+    getifaddrs(&ifAddrStruct);
+
+    ifa = ifAddrStruct->ifa_next->ifa_next->ifa_next->ifa_next; // skip to 4th interface
+    ip = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr.s_addr;
+
+    freeifaddrs(ifAddrStruct);
+
+    return ip;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/io_utils.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/io_utils.h
@@ -1,0 +1,50 @@
+///*! \file io_utils.h
+// *	\brief \\TODO Add summary description of this module
+// *
+// *	Copyright 2011 FlexRadio Systems.  All Rights Reserved.
+// *
+// *  Unauthorized use, duplication or distribution of this software is
+// *  strictly prohibited by law.
+// *
+// *     \date Nov 9, 2011
+// *	\author Terry - AB5K
+// *
+// *  Date:   23-AUG-2011
+// *
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef IO_UTILS_H_
+#define IO_UTILS_H_
+
+#include <sys/socket.h>
+#include "datatypes.h"
+
+/* ------------------------------------------------------------------------ *
+ *  Prototypes                                                              *
+ * ------------------------------------------------------------------------ */
+
+uint32 net_get_ip();
+
+#endif /* IO_UTILS_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/sched_waveform.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/sched_waveform.c
@@ -1,0 +1,743 @@
+///*!   \file sched_waveform.c
+// *    \brief Schedule Wavefrom Streams
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 29-AUG-2014
+// *    \author 	Ed Gonzalez
+// *    \mangler 	Graham / KE9H
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <string.h>		// for memset
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <sys/prctl.h>
+
+#include "common.h"
+#include "datatypes.h"
+#include "hal_buffer.h"
+#include "sched_waveform.h"
+#include "vita_output.h"
+#include "aether_vocoder_backend.h"
+#include "bit_pattern_matcher.h"
+#include "dstar.h"
+#include "DStarDefines.h"
+#include "slow_data.h"
+#include "ftd2xx.h"
+
+//static Queue sched_fft_queue;
+static pthread_rwlock_t _list_lock;
+static BufferDescriptor _root;
+
+static pthread_t _waveform_thread;
+static BOOL _waveform_thread_abort = FALSE;
+
+static sem_t sched_waveform_sem;
+
+static void _dsp_convertBufEndian( BufferDescriptor buf_desc ) {
+    int i;
+
+    if ( buf_desc->sample_size != 8 ) {
+        //TODO: horrendous error here
+        return;
+    }
+
+    for ( i = 0; i < buf_desc->num_samples * 2; i++ )
+        ( ( int32 * )buf_desc->buf_ptr )[i] = htonl( ( ( int32 * )buf_desc->buf_ptr )[i] );
+}
+
+static BufferDescriptor _WaveformList_UnlinkHead( void ) {
+    BufferDescriptor buf_desc = NULL;
+    pthread_rwlock_wrlock( &_list_lock );
+
+    if ( _root == NULL || _root->next == NULL ) {
+        output( "Attempt to unlink from a NULL head" );
+        pthread_rwlock_unlock( &_list_lock );
+        return NULL;
+    }
+
+    if ( _root->next != _root )
+        buf_desc = _root->next;
+
+    if ( buf_desc != NULL ) {
+        // make sure buffer exists and is actually linked
+        if ( !buf_desc || !buf_desc->prev || !buf_desc->next ) {
+            output( "Invalid buffer descriptor" );
+            buf_desc = NULL;
+        } else {
+            buf_desc->next->prev = buf_desc->prev;
+            buf_desc->prev->next = buf_desc->next;
+            buf_desc->next = NULL;
+            buf_desc->prev = NULL;
+        }
+    }
+
+    pthread_rwlock_unlock( &_list_lock );
+    return buf_desc;
+}
+
+static void _WaveformList_LinkTail( BufferDescriptor buf_desc ) {
+    pthread_rwlock_wrlock( &_list_lock );
+    buf_desc->next = _root;
+    buf_desc->prev = _root->prev;
+    _root->prev->next = buf_desc;
+    _root->prev = buf_desc;
+    pthread_rwlock_unlock( &_list_lock );
+}
+
+void sched_waveform_Schedule( BufferDescriptor buf_desc ) {
+    _WaveformList_LinkTail( buf_desc );
+    sem_post( &sched_waveform_sem );
+}
+
+void sched_waveform_signal() {
+    sem_post( &sched_waveform_sem );
+}
+
+static void _dstar_copy_padded_field( char * destination, uint32 field_len, const char * source )
+{
+    if ( destination == NULL || field_len == 0U ) {
+        return;
+    }
+
+    memset( destination, ' ', field_len );
+    destination[field_len] = '\0';
+
+    if ( source == NULL ) {
+        return;
+    }
+
+    uint32 i = 0;
+    for ( i = 0; i < field_len && source[i] != '\0'; i++ ) {
+        destination[i] = ( ( unsigned char )source[i] == 0x7FU ) ? ' ' : source[i];
+    }
+}
+
+/* *********************************************************************************************
+ * *********************************************************************************************
+ * *********************                                                 ***********************
+ * *********************  LOCATION OF MODULATOR / DEMODULATOR INTERFACE  ***********************
+ * *********************                                                 ***********************
+ * *********************************************************************************************
+ * ****************************************************************************************** */
+
+#include <stdio.h>
+#include "circular_buffer.h"
+#include "resampler.h"
+
+#include "gmsk_modem.h"
+
+#define PACKET_SAMPLES  128
+#define DV_PACKET_SAMPLES 160
+
+#define SCALE_AMBE      32767.0f
+//
+//#define SCALE_RX_IN      32767.0f   // Multiplier   // Was 16000 GGH Jan 30, 2015
+//#define SCALE_RX_OUT     32767.0f       // Divisor
+//#define SCALE_TX_IN     32767.0f    // Multiplier   // Was 16000 GGH Jan 30, 2015
+//#define SCALE_TX_OUT    32767.0f    // Divisor
+
+#define SCALE_RX_IN     SCALE_AMBE*2.0
+#define SCALE_TX_OUT    SCALE_AMBE
+
+
+#define SCALE_RX_OUT    SCALE_AMBE*2.0
+#define SCALE_TX_IN     SCALE_AMBE
+
+
+#define FILTER_TAPS	48
+#define DECIMATION_FACTOR 	3
+
+/* These are offsets for the input buffers to decimator */
+#define MEM_24		FILTER_TAPS					   /* Memory required in 24kHz buffer */
+#define MEM_8		FILTER_TAPS/DECIMATION_FACTOR   /* Memory required in 8kHz buffer */
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//	Circular Buffer Declarations
+
+short RX3_buff[( DV_PACKET_SAMPLES * 12 ) + 1];		// RX3 Vocoder output buffer
+float RX4_buff[( DV_PACKET_SAMPLES * 12 * 40 ) + 1];		// RX4 Packet output Buffer
+
+float TX1_buff[( DV_PACKET_SAMPLES * 12 ) + 1];		// TX1 Packet Input Buffer
+short TX2_buff[( DV_PACKET_SAMPLES * 12 ) + 1];		// TX2 Vocoder input buffer
+short TX3_buff[( DV_PACKET_SAMPLES * 12 ) + 1];		// TX3 Vocoder output buffer
+float TX4_buff[( DV_PACKET_SAMPLES * 12 * 40 ) + 1];		// TX4 Packet output Buffer
+
+circular_short_buffer rx3_cb;
+Circular_Short_Buffer RX3_cb = &rx3_cb;
+circular_float_buffer rx4_cb;
+Circular_Float_Buffer RX4_cb = &rx4_cb;
+
+circular_float_buffer tx1_cb;
+Circular_Float_Buffer TX1_cb = &tx1_cb;
+circular_short_buffer tx2_cb;
+Circular_Short_Buffer TX2_cb = &tx2_cb;
+circular_short_buffer tx3_cb;
+Circular_Short_Buffer TX3_cb = &tx3_cb;
+circular_float_buffer tx4_cb;
+Circular_Float_Buffer TX4_cb = &tx4_cb;
+
+static FT_HANDLE _dv_serial_handle = 0;
+
+static GMSK_DEMOD _gmsk_demod = NULL;
+static GMSK_MOD   _gmsk_mod = NULL;
+static DSTAR_MACHINE _dstar = NULL;
+static BOOL _end_of_transmission = FALSE;
+
+#define FREEDV_NSAMPLES 160
+
+void sched_waveform_sendStatus( uint32 slice ) {
+    dstar_updateStatus( _dstar, slice, STATUS_TX );
+}
+
+void sched_waveform_setDestinationRptr( uint32 slice , const char * destination_rptr ) {
+    /* Ignore slice for now */
+    if ( _dstar == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->outgoing_header.destination_rptr, 8, destination_rptr );
+
+    if ( strncmp( _dstar->outgoing_header.destination_rptr, "DIRECT", strlen( "DIRECT" ) ) != 0 ) {
+        _dstar->outgoing_header.flag1 = 0x1 << 6;
+    } else {
+        _dstar->outgoing_header.flag1 = 0;
+    }
+
+    dstar_dumpHeader( &( _dstar->outgoing_header ) );
+}
+
+void sched_waveform_setDepartureRptr( uint32 slice , const char * departure_rptr ) {
+    /* Ignore slice for now */
+    if ( _dstar == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->outgoing_header.departure_rptr, 8, departure_rptr );
+
+    dstar_dumpHeader( &( _dstar->outgoing_header ) );
+}
+
+void sched_waveform_setCompanionCall( uint32 slice, const char * companion_call ) {
+    /* Ignore slice for now */
+    if ( _dstar == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->outgoing_header.companion_call, 8, companion_call );
+
+    dstar_dumpHeader( &( _dstar->outgoing_header ) );
+}
+
+void sched_waveform_setOwnCall1( uint32 slice , const char * owncall1 ) {
+    /* Ignore slice for now */
+    if ( _dstar == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->outgoing_header.own_call1, 8, owncall1 );
+
+    dstar_dumpHeader( &( _dstar->outgoing_header ) );
+}
+
+void sched_waveform_setOwnCall2( uint32 slice , const char * owncall2 ) {
+    /* Ignore slice for now */
+    if ( _dstar == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->outgoing_header.own_call2, 4, owncall2 );
+
+    dstar_dumpHeader( &( _dstar->outgoing_header ) );
+}
+
+void sched_waveform_setMessage( uint32 slice, const char * message)
+{
+    /* Ignore slice for now */
+    if ( _dstar == NULL || _dstar->slow_encoder == NULL ) {
+        return;
+    }
+
+    _dstar_copy_padded_field( _dstar->slow_encoder->message,
+                              SLOW_DATA_MESSAGE_LENGTH_BYTES,
+                              message );
+
+    output( "TX Message: '%s' : strlen() = %zu \n", _dstar->slow_encoder->message , strlen(_dstar->slow_encoder->message));
+}
+
+void sched_waveform_setHandle( FT_HANDLE * handle ) {
+    _dv_serial_handle = *handle;
+}
+
+void sched_waveform_setEndOfTX( BOOL end_of_transmission ) {
+    _end_of_transmission = TRUE;
+}
+
+void sched_waveform_setDSTARSlice( uint32 slice )
+{
+    if ( _dstar != NULL ) {
+        _dstar->slice = slice;
+    }
+}
+
+static void * _sched_waveform_thread( void * param ) {
+
+    prctl(PR_SET_NAME, "DV-SchedWav");
+    int 	nout;
+
+    int		i;			// for loop counter
+    float	fsample;	// a float sample
+//    float   Sig2Noise;	// Signal to noise ratio
+
+    // Flags ...
+    int		initial_tx = TRUE; 		// Flags for TX circular buffer, clear if starting transmit
+    int		initial_rx = TRUE;			// Flags for RX circular buffer, clear if starting receive
+
+    // VOCODER I/O BUFFERS
+    short	speech_in[DV_PACKET_SAMPLES];
+    short 	speech_out[DV_PACKET_SAMPLES];
+    //short 	demod_in[FREEDV_NSAMPLES];
+    unsigned char 	mod_out[DV_PACKET_SAMPLES];
+
+    //unsigned char packet_out[FREEDV_NSAMPLES];
+
+    // RX RESAMPLER I/O BUFFERS
+    float 	float_in_8k[DV_PACKET_SAMPLES + FILTER_TAPS];
+    //float 	float_out_8k[DV_PACKET_SAMPLES];
+
+    float 	float_in_24k[DV_PACKET_SAMPLES * DECIMATION_FACTOR + FILTER_TAPS];
+    float 	float_out_24k[DV_PACKET_SAMPLES * DECIMATION_FACTOR ];
+
+    // TX RESAMPLER I/O BUFFERS
+    float 	tx_float_in_8k[DV_PACKET_SAMPLES + FILTER_TAPS];
+    float 	tx_float_out_8k[DV_PACKET_SAMPLES];
+
+    float 	tx_float_in_24k[DV_PACKET_SAMPLES * DECIMATION_FACTOR + FILTER_TAPS];
+
+    BOOL inhibit_tx = FALSE;
+    BOOL flush_tx = FALSE;
+
+    // =======================  Initialization Section =========================
+
+    aether_vocoder_init( &_dv_serial_handle );
+
+    // Initialize the Circular Buffers
+
+    RX3_cb->size  = DV_PACKET_SAMPLES * 12 + 1;		// size = no.elements in array+1
+    RX3_cb->start = 0;
+    RX3_cb->end	  = 0;
+    RX3_cb->elems = RX3_buff;
+    strncpy( RX3_cb->name, "RX3", 4 );
+
+    RX4_cb->size  = DV_PACKET_SAMPLES * ( 12 * 40 ) + 1;		// size = no.elements in array+1
+    RX4_cb->start = 0;
+    RX4_cb->end	  = 0;
+    RX4_cb->elems = RX4_buff;
+    strncpy( RX4_cb->name, "RX4", 4 );
+
+    TX1_cb->size  = DV_PACKET_SAMPLES * 12 + 1;		// size = no.elements in array+1
+    TX1_cb->start = 0;
+    TX1_cb->end	  = 0;
+    TX1_cb->elems = TX1_buff;
+    strncpy( TX1_cb->name, "TX1", 4 );
+
+    TX2_cb->size  = DV_PACKET_SAMPLES * 12 + 1;		// size = no.elements in array+1
+    TX2_cb->start = 0;
+    TX2_cb->end	  = 0;
+    TX2_cb->elems = TX2_buff;
+    strncpy( TX2_cb->name, "TX2", 4 );
+
+    TX3_cb->size  = DV_PACKET_SAMPLES * 12 + 1;		// size = no.elements in array+1
+    TX3_cb->start = 0;
+    TX3_cb->end	  = 0;
+    TX3_cb->elems = TX3_buff;
+    strncpy( TX3_cb->name, "TX3", 4 );
+
+    TX4_cb->size  = DV_PACKET_SAMPLES * ( 12 * 40 ) + 1;		// size = no.elements in array+1
+    TX4_cb->start = 0;
+    TX4_cb->end	  = 0;
+    TX4_cb->elems = TX4_buff;
+    strncpy( TX4_cb->name, "TX4", 4 );
+
+    initial_tx = TRUE;
+    initial_rx = TRUE;
+    BOOL initial_tx_flush = FALSE;
+    uint32 dstar_tx_frame_count = 0;
+
+    // show that we are running
+    BufferDescriptor buf_desc;
+
+    while ( !_waveform_thread_abort ) {
+        // wait for a buffer descriptor to get posted
+        sem_wait( &sched_waveform_sem );
+
+        if ( !_waveform_thread_abort ) {
+            do {
+                buf_desc = _WaveformList_UnlinkHead();
+
+                // if we got signalled, but there was no new data, something's wrong
+                // and we'll just wait for the next packet
+                if ( buf_desc == NULL ) {
+                    //output( "We were signaled that there was another buffer descriptor, but there's not one here");
+                    break;
+                } else {
+                    // convert the buffer to little endian
+                    _dsp_convertBufEndian( buf_desc );
+
+                    //output(" \"Processed\" buffer stream id = 0x%08X\n", buf_desc->stream_id);
+
+                    if ( ( buf_desc->stream_id & 1 ) == 0 ) { //RX BUFFER
+                        //	If 'initial_rx' flag, clear buffers RX1, RX2, RX3, RX4
+                        if ( initial_rx ) {
+                            RX3_cb->start = 0;
+                            RX3_cb->end	  = 0;
+                            RX4_cb->start = 0;
+                            RX4_cb->end	  = 0;
+
+
+                            /* Clear filter memory */
+                            memset( float_in_24k, 0, MEM_24 * sizeof( float ) );
+                            memset( float_in_8k, 0, MEM_8 * sizeof( float ) );
+
+                            aether_vocoder_flush_lists();
+                            /* Requires us to set initial_rx to FALSE which we do at the end of
+                             * the first loop
+                             */
+                        }
+
+                        //	Set the transmit 'initial' flag
+                        initial_tx = TRUE;
+                        inhibit_tx = FALSE;
+                        flush_tx = FALSE;
+                        _end_of_transmission = FALSE;
+                        gmsk_resetMODFilter( _gmsk_mod );
+
+                        enum DEMOD_STATE state = DEMOD_UNKNOWN;
+
+                        for ( i = 0 ; i < PACKET_SAMPLES ; i++ ) {
+                            state = gmsk_decode( _gmsk_demod, ( ( Complex * )buf_desc->buf_ptr )[i].real );
+
+                            unsigned char ambe_out[9] = {0};
+                            BOOL ambe_packet_out = FALSE;
+
+                            if ( state == DEMOD_TRUE ) {
+                                ambe_packet_out = dstar_rxStateMachine( _dstar, TRUE, ambe_out, 9 );
+                            } else if ( state == DEMOD_FALSE ) {
+                                ambe_packet_out = dstar_rxStateMachine( _dstar, FALSE, ambe_out, 9 );
+                            } else {
+                                /* Nothing to do since we have not "locked" a bit out yet */
+                            }
+
+                            if ( ambe_packet_out == TRUE ) {
+                                aether_vocoder_decode( _dv_serial_handle, ambe_out, 9 );
+                            }
+
+                            if ( aether_vocoder_get_decode_list_buffering() == FALSE)
+                            {
+                                // There is something in the decoded list - fetch audio
+                                nout = 0;
+                                nout = aether_vocoder_unlink_audio(speech_out);
+                                uint32 j = 0;
+
+                                for ( j = 0 ; j < nout ; j++ )
+                                {
+                                    cbWriteShort( RX3_cb, speech_out[j] );
+                                }
+                            }
+
+                        }
+
+
+                        // Check for >= 160 samples in RX3_cb, convert to floats
+                        //	and spin the upsampler. Move output to RX4_cb.
+
+                        if ( csbContains( RX3_cb ) >= DV_PACKET_SAMPLES ) {
+                            for ( i = 0 ; i < DV_PACKET_SAMPLES ; i++ ) {
+                                float_in_8k[i + MEM_8] = ( ( float )( cbReadShort( RX3_cb ) / SCALE_RX_OUT ) );
+                            }
+
+                            fdmdv_8_to_24( float_out_24k, &float_in_8k[MEM_8], DV_PACKET_SAMPLES );
+
+                            for ( i = 0 ; i < DV_PACKET_SAMPLES * DECIMATION_FACTOR ; i++ ) {
+                                cbWriteFloat( RX4_cb, float_out_24k[i] );
+                            }
+                        }
+
+                        // Check for >= 128 samples in RX4_cb. Form packet and
+                        //	export.
+
+                        uint32 check_samples = PACKET_SAMPLES;
+
+                        if ( cfbContains( RX4_cb ) >= check_samples ) {
+                            for ( i = 0 ; i < PACKET_SAMPLES ; i++ ) {
+                                // Set up the outbound packet
+                                fsample = cbReadFloat( RX4_cb );
+//								// put the fsample into the outbound packet
+
+                                ( ( Complex * )buf_desc->buf_ptr )[i].real = fsample;
+                                ( ( Complex * )buf_desc->buf_ptr )[i].imag = fsample;
+
+                            }
+                        } else {
+                            memset( buf_desc->buf_ptr, 0, PACKET_SAMPLES * sizeof( Complex ) );
+                        }
+
+                        if ( initial_rx )
+                            initial_rx = FALSE;
+
+                        emit_waveform_output( buf_desc );
+
+                    } else if ( ( buf_desc->stream_id & 1 ) == 1 ) { //TX BUFFER
+                        //	If 'initial_rx' flag, clear buffers TX1, TX2, TX3, TX4
+                        if ( initial_tx ) {
+                            TX1_cb->start = 0;	// Clear buffers RX1, RX2, RX3, RX4
+                            TX1_cb->end	  = 0;
+                            TX2_cb->start = 0;
+                            TX2_cb->end	  = 0;
+                            TX3_cb->start = 0;
+                            TX3_cb->end	  = 0;
+                            TX4_cb->start = 0;
+                            TX4_cb->end	  = 0;
+
+
+                            /* Clear filter memory */
+
+                            memset( tx_float_in_24k, 0, MEM_24 * sizeof( float ) );
+                            memset( tx_float_in_8k, 0, MEM_8 * sizeof( float ) );
+
+                            aether_vocoder_flush_lists();
+
+                            /* Requires us to set initial_rx to FALSE which we do at the end of
+                             * the first loop
+                             */
+                        }
+
+
+                        initial_rx = TRUE;
+                        // Check for new receiver input packet & move to TX1_cb.
+
+                        if ( !inhibit_tx ) {
+
+
+                            for ( i = 0 ; i < PACKET_SAMPLES ; i++ ) {
+                                //output("Outputting ")
+                                //	fsample = Get next float from packet;
+                                cbWriteFloat( TX1_cb, ( ( Complex * )buf_desc->buf_ptr )[i].real );
+
+                            }
+
+//
+                            // Check for >= 384 samples in TX1_cb and spin downsampler
+                            //	Convert to shorts and move to TX2_cb.
+                            if ( cfbContains( TX1_cb ) >= DV_PACKET_SAMPLES * DECIMATION_FACTOR ) {
+                                for ( i = 0 ; i < DV_PACKET_SAMPLES * DECIMATION_FACTOR ; i++ ) {
+                                    tx_float_in_24k[i + MEM_24] = cbReadFloat( TX1_cb );
+                                }
+
+                                fdmdv_24_to_8( tx_float_out_8k, &tx_float_in_24k[MEM_24], DV_PACKET_SAMPLES );
+
+                                for ( i = 0 ; i < DV_PACKET_SAMPLES ; i++ ) {
+                                    cbWriteShort( TX2_cb, ( short )( tx_float_out_8k[i]*SCALE_TX_IN ) );
+                                }
+
+                            }
+
+//
+//						// Check for >= 320 samples in TX2_cb and spin vocoder
+                            // 	Move output to TX3_cb.
+
+                            uint32 decode_out  = 0;
+
+                            if ( csbContains( TX2_cb ) >= DV_PACKET_SAMPLES ) {
+                                for ( i = 0 ; i < DV_PACKET_SAMPLES ; i++ ) {
+                                    speech_in[i] = cbReadShort( TX2_cb );
+                                }
+
+                                /* DECODE */
+                                decode_out = aether_vocoder_encode( _dv_serial_handle, speech_in, mod_out, DV_PACKET_SAMPLES );
+                            }
+
+                            if ( initial_tx ) {
+
+                                initial_tx = FALSE;
+
+                                _dstar->tx_state = BIT_FRAME_SYNC;
+
+                                dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, NULL);
+
+                                _dstar->tx_state = HEADER_PROCESSING;
+
+                                dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, NULL);
+
+                                slow_data_createEncodeBytes(_dstar);
+
+                                initial_tx_flush = TRUE;
+
+                                dstar_tx_frame_count = 0;
+                            } else {
+                                /* Data and Voice */
+
+                                if ( decode_out != 0 ) {
+                                    _dstar->tx_state = VOICE_FRAME;
+                                    dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, mod_out);
+
+                                    if ( dstar_tx_frame_count % 21 == 0 ) {
+                                        _dstar->tx_state = DATA_SYNC_FRAME;
+                                        dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, NULL);
+                                        if ( _dstar->slow_encoder->encode_state == HEADER_TX )
+                                            _dstar->slow_encoder->header_index = 0;
+                                    } else {
+
+                                        _dstar->tx_state = DATA_FRAME;
+                                        dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, NULL);
+                                    }
+
+                                    dstar_tx_frame_count++;
+                                }
+                            }
+
+                            if ( _end_of_transmission && !inhibit_tx ) {
+
+                                _dstar->tx_state = END_PATTERN;
+
+                                dstar_txStateMachine(_dstar, _gmsk_mod, TX4_cb, NULL);
+
+                                flush_tx = TRUE;
+                                initial_tx_flush = TRUE;
+                            }
+
+                        }
+
+                        if ( !inhibit_tx ) {
+                            uint32 tx_check_samples = PACKET_SAMPLES;
+
+                            if ( cfbContains( TX4_cb ) >= tx_check_samples ) {
+                                for ( i = 0 ; i < PACKET_SAMPLES ; i++ ) {
+                                    // Set up the outbound packet
+                                    fsample = cbReadFloat( TX4_cb );
+
+                                    // put the fsample into the outbound packet
+                                    ( ( Complex * )buf_desc->buf_ptr )[i].real = fsample;
+                                    ( ( Complex * )buf_desc->buf_ptr )[i].imag = fsample;
+                                }
+                            } else {
+                                memset( buf_desc->buf_ptr, 0, PACKET_SAMPLES * sizeof( Complex ) );
+                            }
+
+                            emit_waveform_output( buf_desc );
+
+                            if ( flush_tx && initial_tx_flush ) {
+                                initial_tx_flush = FALSE;
+                                inhibit_tx = TRUE;
+
+                                //output("TX4_cb has %d samples\n", cfbContains(TX4_cb));
+                                while ( cfbContains( TX4_cb ) > 0 ) {
+
+                                    if ( cfbContains( TX4_cb ) > PACKET_SAMPLES ) {
+                                        for ( i = 0 ; i < PACKET_SAMPLES ; i++ ) {
+                                            // Set up the outbound packet
+                                            fsample = cbReadFloat( TX4_cb );
+
+                                            // put the fsample into the outbound packet
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].real = fsample;
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].imag = fsample;
+                                        }
+                                    } else {
+                                        int end_index = 0;
+
+                                        for ( i = 0 ; i <= cfbContains( TX4_cb ); i++ ) {
+                                            fsample = cbReadFloat( TX4_cb );
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].real = fsample;
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].imag = fsample;
+                                            end_index = i + 1;
+                                        }
+
+                                        for ( i = end_index ; i < PACKET_SAMPLES ; i++ ) {
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].real = 0.0f;
+                                            ( ( Complex * )buf_desc->buf_ptr )[i].imag = 0.0f;
+                                        }
+
+                                    }
+
+                                    emit_waveform_output( buf_desc );
+
+                                }
+                            }
+
+                        }
+                    }
+
+                    hal_BufferRelease( &buf_desc );
+                }
+            } while ( 1 ); // Seems infinite loop but will exit once there are no longer any buffers linked in _Waveformlist
+        }
+    }
+
+    _waveform_thread_abort = TRUE;
+
+    gmsk_destroyDemodulator( _gmsk_demod );
+    gmsk_destroyModulator( _gmsk_mod );
+    dstar_destroyMachine( _dstar );
+
+    return NULL;
+}
+
+void sched_waveform_Init( void ) {
+
+    _dstar = dstar_createMachine();
+
+    _gmsk_demod = gmsk_createDemodulator();
+    _gmsk_mod = gmsk_createModulator();
+    _gmsk_mod->m_invert = TRUE;
+
+    pthread_rwlock_init( &_list_lock, NULL );
+
+    pthread_rwlock_wrlock( &_list_lock );
+    _root = ( BufferDescriptor )safe_malloc( sizeof( buffer_descriptor ) );
+    memset( _root, 0, sizeof( buffer_descriptor ) );
+    _root->next = _root;
+    _root->prev = _root;
+    pthread_rwlock_unlock( &_list_lock );
+
+    sem_init( &sched_waveform_sem, 0, 0 );
+
+    pthread_create( &_waveform_thread, NULL, &_sched_waveform_thread, NULL );
+
+    struct sched_param fifo_param;
+    fifo_param.sched_priority = 30;
+    pthread_setschedparam( _waveform_thread, SCHED_FIFO, &fifo_param );
+}
+
+void sched_waveformThreadExit() {
+    _waveform_thread_abort = TRUE;
+    sem_post( &sched_waveform_sem );
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/sched_waveform.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/sched_waveform.h
@@ -1,0 +1,56 @@
+///*!   \file sched_waveform.h
+// *    \brief Schedule Wavefrom Streams
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 29-AUG-2014
+// *    \author Ed Gonzalez
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef SCHED_WAVEFORM_H_
+#define SCHED_WAVEFORM_H_
+
+#include "hal_buffer.h"
+#include "ftd2xx.h"
+
+void sched_waveform_Schedule(BufferDescriptor buf);
+void sched_waveform_Init(void);
+void sched_waveform_signal(void);
+void sched_waveformTreadExit(void);
+
+void sched_waveform_setDestinationRptr(uint32 slice , const char * destination_rptr );
+void sched_waveform_setDepartureRptr(uint32 slice , const char * departure_rptr );
+void sched_waveform_setCompanionCall( uint32 slice, const char * companion_call);
+void sched_waveform_setOwnCall1( uint32 slice , const char * owncall1 );
+void sched_waveform_setOwnCall2(uint32 slice , const char * owncall2 );
+void sched_waveform_setMessage( uint32 slice, const char * message);
+
+void sched_waveform_sendStatus(uint32 slice);
+void sched_waveform_setHandle( FT_HANDLE * handle );
+void sched_waveform_setEndOfTX(BOOL end_of_transmission);
+void sched_waveform_setDSTARSlice( uint32 slice );
+#endif /* SCHED_WAVEFORM_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/smartsdr_dsp_api.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/smartsdr_dsp_api.c
@@ -1,0 +1,317 @@
+///*    \file smartsdr_dsp_api.c
+// *    \brief Main SmartSDR DSP API Entry point
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// *    \author Graham Haddock, KE9H
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <semaphore.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <sys/prctl.h>
+#include <fcntl.h>          // File Control functions
+
+#include "common.h"
+#include "traffic_cop.h"
+#include "discovery_client.h"
+#include "sched_waveform.h"
+
+//#define CONSOLE_THREAD /* Use when we need a console thread. Cannot be defined for customer card */
+
+static uint32 _api_version;
+static uint32 _handle;
+static pthread_t _console_thread_ID;
+
+static BOOL console_thread_abort = FALSE;
+#define PROMPT "\n\033[92mWaveform -->\033[33m"
+static sem_t _startup_sem, _communications_sem;
+
+extern const char* APP_NAME;
+extern char * cfg_path;
+
+void api_setVersion(uint32 version)
+{
+    _api_version = version;
+    output(ANSI_MAGENTA "version = %d.%d.%d.%d\n",_api_version >> 24,_api_version >> 16 & 0xFF,
+            _api_version >> 8 & 0xFF,_api_version & 0xFF);
+}
+
+uint32 api_getVersion(void)
+{
+    return _api_version;
+}
+
+void api_setHandle(uint32 handle)
+{
+    _handle = handle;
+    output(ANSI_MAGENTA "handle = 0x%08X\n",handle);
+
+    // let everyone know we've established communications with the radio
+    sem_post(&_communications_sem);
+}
+
+uint32 api_getHandle(void)
+{
+    return _handle;
+}
+
+void SmartSDR_API_Shutdown(void)
+{
+    // stop the keepalive thread if we are done
+    tc_abort();
+}
+
+void* _console_thread(void* param)
+{
+    prctl(PR_SET_NAME, "DV-Console");
+    cmd_banner();
+    output(PROMPT);
+    // let everybody know we're through printing
+    sem_post(&_startup_sem);
+    sem_wait(&_communications_sem);
+    while (!console_thread_abort)
+    {
+        command();
+        output(PROMPT);
+    }
+
+    SmartSDR_API_Shutdown();
+    return NULL;
+}
+
+void SmartSDR_API_Init(BOOL enable_console, const char * radio_ip)
+{
+    sem_init(&_startup_sem,0,0);
+    sem_init(&_communications_sem,0,0);
+
+    // initialize printed output
+    lock_printf_init();
+    lock_malloc_init();
+
+    sched_waveform_Init();
+
+    // Start the console thread
+    if ( enable_console ) {
+		pthread_create(&_console_thread_ID, NULL, &_console_thread, NULL);
+    // wait for the console to print out all it's stuff
+		sem_wait(&_startup_sem);
+    }
+
+    if ( radio_ip != NULL && radio_ip[0] != '\0' ) {
+        output("Connecting directly to radio %s\n", radio_ip);
+        tc_Init(radio_ip, SMARTSDR_API_PORT);
+        usleep(250000);
+        hal_Listener_Init();
+        return;
+    }
+
+    /* Initialize the discovery client
+     * When a radio is found then the Traffic Cop is Started
+     */
+    dc_Init(radio_ip);
+}
+
+/* *****************************************************************************
+ *  uint32 register_mode(void)
+ *
+ *      Transmits configuration information from ConfigFile.cfg
+ *      Expected file contents are ASCII text.
+ */
+
+uint32 register_mode(void)
+{
+    FILE* cfgStream;        // Stream ID for config file when opened
+    ssize_t numRead;        // Number of bytes read by getline()
+
+    size_t nbytes = 120;    // Default size of input buffer
+    char *inputBuffer;      // The input buffer
+    // ssize_t result;          // strncmp() result
+    char* charptr;          // pointer returned by strstr()
+    BOOL readFlag;          // file readflag  [TRUE -> continue]
+    char MinRadioVerString[40];
+
+    // Open the config file directly; a separate stat() introduces a TOCTOU race.
+    char cfg_file[1024];
+    int cfg_len = snprintf(cfg_file, sizeof(cfg_file), "%s%s%s", cfg_path, APP_NAME, ".cfg");
+    if (cfg_len < 0 || (size_t)cfg_len >= sizeof(cfg_file))
+    {
+        output(ANSI_RED"CONFIGURATION FILE PATH IS TOO LONG.\n");
+        usleep(1000000);
+        return 999;
+    }
+
+    output("READING CONFIG FILE '%s' \n", cfg_file);
+    cfgStream = fopen(cfg_file, "r");
+    if (cfgStream == NULL)
+    {
+        output(ANSI_YELLOW"Error opening file %s \n", cfg_file);
+        usleep(1000000);
+        return 999;
+    }
+    /* Transfer data expecting to encounter end of input (or an error) */
+    inputBuffer = (char *) safe_malloc (nbytes + 1); // Initial buffer size
+
+    readFlag = TRUE;
+    while(readFlag)     // Look for the start of the [header]
+    {
+        numRead = getline(&inputBuffer, &nbytes, cfgStream);
+        if (numRead == -1)
+        {
+            output(ANSI_YELLOW"Error reading config file %s\n", cfg_file);
+            safe_free(inputBuffer);
+            return 999;
+        }
+
+        // Process it here
+        charptr = strstr(inputBuffer, "[header]");
+        if(charptr != NULL)
+        {
+            output(ANSI_CYAN "FreeDV: Start of [header] found.\n");
+            readFlag = FALSE;
+        }
+        else
+        {
+            if (ferror(cfgStream))
+            {
+                output(ANSI_YELLOW"Read error %s, reached end of file, [header] not found. \n", cfg_file);
+                return 999;   // should return a fail    return -1;
+            }
+        }
+    }
+
+    readFlag = TRUE;
+    while(readFlag)     // Look for the minimum version
+    {
+        numRead = getline(&inputBuffer, &nbytes, cfgStream);
+        if (numRead == -1)
+        {
+            output(ANSI_YELLOW"Error reading config file %s\n", cfg_file);
+            // TODO return here?
+        }
+
+        // Process it here
+        charptr = strstr(inputBuffer, "Minimum-SmartSDR-Version:");
+        if(charptr != NULL)
+        {
+            output(ANSI_CYAN "FreeDV: Minimum Version found.\n");
+            charptr += strlen("Minimum-SmartSDR-Version:");
+            strcpy(MinRadioVerString, charptr );
+            readFlag = FALSE;
+        }
+        else
+        {
+            if (ferror(cfgStream))
+            {
+                output(ANSI_YELLOW"Read error %s, minimum version not found, reached end of file. \n", cfg_file);
+                return 999;
+            }
+        }
+    }
+
+    readFlag = TRUE;
+    while(readFlag)     // Find the start of the [setup] section
+    {
+        numRead = getline(&inputBuffer, &nbytes, cfgStream);
+        if (numRead == -1)
+        {
+            output(ANSI_YELLOW"Error reading config file %s\n", cfg_file);
+            return 999;
+        }
+
+        // Process it here
+        charptr = strstr(inputBuffer, "[setup]");
+        if(charptr != NULL)
+        {
+            output(ANSI_CYAN "FreeDV: Start of [setup] found.\n");
+            readFlag = FALSE;
+        }
+        else
+        {
+            if (ferror(cfgStream))
+            {
+                output(ANSI_YELLOW"Read error %s, [setup] not found. \n", cfg_file);
+                return 999;   // should return a fail    return -1;
+            }
+        }
+    }
+
+    readFlag = TRUE;
+    while(readFlag)     // Export the setup configuration information
+    {                   //  Stop on "[end]" or EOF
+
+        numRead = getline(&inputBuffer, &nbytes, cfgStream);
+        if (numRead == -1)
+        {
+            output("Error reading config file %s\n", cfg_file);
+            return 999;
+        }
+
+        // turn trailing 'carriage returns" to nulls.
+        charptr = strstr(inputBuffer, "\r");
+        if(charptr != NULL)
+            *charptr = 0;
+
+
+        charptr = strstr(inputBuffer, "[end]");
+        if(strlen(inputBuffer) == 0)
+        {
+            output(ANSI_CYAN "FreeDV: Blank line, not sent. \n");
+        }
+        else if(charptr != NULL)
+        {
+            output(ANSI_CYAN "FreeDV: Script end marker [end] found.\n");
+            readFlag = FALSE;
+        }
+        else if (ferror(cfgStream))
+        {
+            output("End of file %s, reached. \n\n", cfg_file);
+            readFlag = FALSE;
+        }
+        else
+        {
+            // Process it here
+            output(ANSI_CYAN "FreeDV: %s \n", inputBuffer);
+            tc_sendSmartSDRcommand(inputBuffer, FALSE, NULL);
+        }
+    }
+
+    if (fclose(cfgStream) == EOF)
+    {
+        output(ANSI_YELLOW"Error closing config file %s\n", cfg_file);
+    }
+    else
+    {
+        output(ANSI_CYAN "FreeDV: SUCCESS, closed config file %s\n", cfg_file);
+    }
+
+    return SUCCESS;
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/smartsdr_dsp_api.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/smartsdr_dsp_api.h
@@ -1,0 +1,52 @@
+///*    \file smartsdr_dsp_api.c
+// *    \brief Main SmartSDR DSP API Entry point
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef SMARTSDR_DSP_API_H_
+#define SMARTSDR_DSP_API_H_
+
+#include "common.h"
+#include "traffic_cop.h"
+
+static const int MAX_API_COMMAND_SIZE = 1024;
+static const int RECV_BUF_SIZE = 8192;
+static const int RECV_BUF_SIZE_TO_GET = 2048;
+
+void api_setVersion(uint32 version);
+uint32 api_getVersion(void);
+void api_setHandle(uint32 handle);
+uint32 api_getHandle(void);
+void SmartSDR_API_Shutdown(void);
+void SmartSDR_API_Init(BOOL enable_console, const char * radio_ip);
+uint32 register_mode(void);
+
+
+#endif /* SMARTSDR_DSP_API_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/status_processor.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/status_processor.c
@@ -1,0 +1,240 @@
+///*    \file status_processor.c
+// *    \brief Main SmartSDR DSP API Entry point
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "common.h"
+#include "traffic_cop.h"
+#include "sched_waveform.h"
+
+static char* _status_value( char * token, const char * key )
+{
+    size_t key_len = strlen( key );
+    if ( token == NULL || strncmp( token, key, key_len ) != 0 || token[key_len] != '=' ) {
+        return NULL;
+    }
+
+    return token + key_len + 1;
+}
+
+static void _handle_status(char* string)
+{
+    int argc;
+    uint32 slc; // slice number
+    char *argv[MAX_ARGC_STATUS + 1];       //Add one extra so we can null terminate the array
+
+    // get the actual status message -- we don't care about the handle
+    char* save = 0;
+    char* start = strtok_r(string,"|",&save);
+    start = strtok_r(NULL,"|",&save);
+    if ( start == NULL ) {
+        return;
+    }
+
+    // first let's look for a slice status -- these are most important
+    if (strncmp(start, "slice", strlen("slice")) == 0)
+    {
+        tokenize(start, &argc, argv, MAX_ARGC);
+
+        if (argc < 3)
+        {
+            // bad slice status ... ignoring it
+            return;
+        }
+
+        errno = 0;
+        slc = strtoul(argv[1], NULL, 0);
+        if(errno)
+        {
+            output(ANSI_RED "Unable to parse slice number (%s)\n", argv[1]);
+            return;
+        }
+        int i;
+        for (i = 2; i < argc; i++)
+        {
+            char* smode = _status_value( argv[i], "mode" );
+            if(smode != NULL)
+            {
+                errno = 0;
+                if (strncmp(smode,"DSTR", strlen("DSTR")) == 0)
+                {
+                    // we are now in DSTR mode
+                    output(ANSI_MAGENTA "slice %d is now in DSTR mode\n",slc);
+                    char cmd[512] = {0};
+                    snprintf(cmd, sizeof(cmd), "slice s %d fm_deviation=1200 post_demod_low=0 post_demod_high=6000 dfm_pre_de_emphasis=0 post_demod_bypass=1 squelch=0", slc);
+                    tc_sendSmartSDRcommand(cmd,FALSE, NULL);
+
+                    sched_waveform_setDSTARSlice(slc);
+
+                }
+                else
+                {
+                    // we have left DSTR mode
+                    output(ANSI_MAGENTA "slice %d is in %s mode\n",slc,smode);
+                }
+            }
+            char* in_use_value = _status_value( argv[i], "in_use" );
+            if(in_use_value != NULL)
+            {
+                errno = 0;
+                int in_use = strtoul(in_use_value, NULL, 0);
+                if (!in_use)
+                {
+                    output(ANSI_MAGENTA "slice %d has been removed\n",slc);
+
+                }
+            }
+            char* tx_value = _status_value( argv[i], "tx" );
+            if(tx_value != NULL)
+            {
+                errno = 0;
+                int tx = strtoul(tx_value, NULL, 0);
+                if (tx)
+                {
+                    output(ANSI_MAGENTA "slice %d is the transmit slice\n",slc);
+                }
+                else
+                {
+                    output(ANSI_MAGENTA "slice %d is NOT transmit slice\n",slc);
+                }
+            }
+        }
+
+    }
+    else if (strncmp(start, "interlock", strlen("interlock")) == 0)
+    {
+        tokenize(start, &argc, argv, MAX_ARGC);
+
+        if (argc < 2)
+        {
+            // bad interlock status ... ignoring it
+            return;
+        }
+
+        int i;
+        for (i = 1; i < argc; i++)
+        {
+            char* state = _status_value( argv[i], "state" );
+            if(state != NULL)
+            {
+                errno = 0;
+                if (strncmp(state,"PTT_REQUESTED",strlen("PTT_REQUESTED")) == 0)
+                {
+                    output(ANSI_MAGENTA "we are transmitting\n");
+                }
+                else if (strncmp(state,"READY",strlen("READY")) == 0 ||
+                    strncmp(state,"NOT_READY",strlen("NOT_READY")) == 0)
+                {
+                    output(ANSI_MAGENTA "we are receiving\n");
+                }
+                else if ( strncmp(state, "UNKEY_REQUESTED", strlen("UNKEY_REQUESTED")) == 0 )
+                {
+                    output(ANSI_MAGENTA "unkey requested - sending end bits\n");
+                    sched_waveform_setEndOfTX(TRUE);
+                }
+
+            }
+        }
+
+    }
+
+    // now we could check for other statuses that were interesting
+
+
+}
+
+
+void status_processor(char* string)
+{
+    switch (*string)
+    {
+        case 'V': // version
+        {
+            string++;
+            uint32 version = getIP(string);
+            api_setVersion(version);
+            break;
+        }
+        case 'H': // handle
+        {
+            string++;
+            uint32 val;
+            sscanf(string, "%08X", &val);
+            api_setHandle(val);
+            break;
+        }
+        case 'R': // response
+        {
+            char* save = NULL;
+            string++;
+            uint32 val;
+            sscanf(string, "%i", &val);
+            char* response = strtok_r(string, "|", &save);
+            response = strtok_r(NULL, "", &save);
+            tc_commandList_respond(val, response);
+            break;
+        }
+        case 'C': // command
+        {
+            char* save = NULL;
+            string++;
+            uint32 val;
+            sscanf(string, "%i", &val);
+            char* cmd = strtok_r(string, "|", &save);
+            cmd = strtok_r(NULL, "", &save);
+#ifdef DEBUG
+            output("\033[32mExecuting command from SmartSDR: \033[m%s\n",cmd);
+#endif
+            uint32 ret = process_command(cmd);
+            char response[1024];
+            sprintf(response, "waveform response %d|%d", val, ret);
+            tc_sendSmartSDRcommand(response, FALSE, NULL );
+            break;
+        }
+        case 'S': // status
+        {
+            // here we translate from SmartSDR status message we are interested in
+            // and the corresponding commands we want to execute
+            _handle_status(string);
+            break;
+        }
+        case 'M': // message
+
+            break;
+        default:
+            output(ANSI_YELLOW "Status Processor: unknown status \033[m%s\n",string);
+            break;
+    }
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/status_processor.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/status_processor.h
@@ -1,0 +1,40 @@
+///*    \file status_processor.h
+// *    \brief Main SmartSDR DSP API Entry point
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef STATUS_PROCESSOR_H_
+#define STATUS_PROCESSOR_H_
+
+#include "common.h"
+
+void status_processor(char* string);
+
+#endif /* STATUS_PROCESSOR_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/stream.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/stream.h
@@ -1,0 +1,69 @@
+/* *****************************************************************************
+ *	file stream.h
+ *	\brief Collection for system streams
+ *
+ *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+ *				Unauthorized use, duplication or distribution of this software is
+ *				strictly prohibited by law.
+ *
+ *	\date Mar 29, 2012
+ *	\author Eric & Steve
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef _STREAM_H
+#define _STREAM_H
+
+#include "../common.h"
+
+#define STREAM_BITS_IN			0x80000000
+#define STREAM_BITS_OUT		    0x00000000
+
+#define STREAM_BITS_METER		0x08000000
+#define STREAM_BITS_WAVEFORM    0x01000000
+
+#define STREAM_BITS_MASK	    (STREAM_BITS_IN | STREAM_BITS_OUT | STREAM_BITS_METER | \
+							        STREAM_BITS_WAVEFORM)
+
+#define STREAM_PREFIX           0x7700
+
+enum STREAM_TYPE
+{
+	STREAM_NULL = STREAM_PREFIX,
+	STREAM_IN_RF_IQ,
+	STREAM_IN_AUDIO,
+	STREAM_IN_RF_NAR,
+	STREAM_IN_FFT,
+	STREAM_OUT_RF_IQ,
+	STREAM_OUT_PANADAPTER,
+	STREAM_OUT_WATERFALL,
+	STREAM_OUT_AUDIO,
+	STREAM_OUT_METER,
+	STREAM_IN_WAVEFORM,
+	STREAM_OUT_WAVEFORM
+};
+
+typedef enum STREAM_TYPE STREAMtype;
+
+typedef uint32 Stream_ID;
+
+#endif // _STREAM_H

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/traffic_cop.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/traffic_cop.c
@@ -1,0 +1,696 @@
+///*    \file traffic_cop.c
+// *    \brief TCP Communications Server
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <linux/tcp.h>
+#include <pthread.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <time.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <ifaddrs.h>
+#include <sys/prctl.h>
+
+#include "common.h"
+#include "traffic_cop.h"
+#include "status_processor.h"
+
+static pthread_t _tc_thread_id;
+static pthread_t _keepalive_thread_id;
+
+static __thread receive_data __local;
+//! address of the host to connect to -- defaults to 127.0.0.1
+//! but this is generally provided by discovery
+static char _hostname[32] = "127.0.0.1";
+static char _api_port[32] = SMARTSDR_API_PORT;
+
+//const char* gai_strerror(int ecode);
+static BOOL _abort = FALSE;
+static int _socket;
+static BOOL _abort_keepalive = FALSE;
+static const char* _abort_reason = "unspecified";
+static uint32 _sequence = 0;
+static Command _root;
+static pthread_mutex_t _commandList_mutex;
+
+// get sockaddr, IPv4 or IPv6:
+void *get_in_addr(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET) {
+        return &(((struct sockaddr_in*)sa)->sin_addr);
+    }
+
+    return &(((struct sockaddr_in6*)sa)->sin6_addr);
+}
+
+static void _tc_openSocket(void)
+{
+    struct addrinfo hints, *servinfo, *p;
+    int rv;
+    char s[INET6_ADDRSTRLEN];
+
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    if ((rv = getaddrinfo(_hostname, SMARTSDR_API_PORT, &hints, &servinfo)) != 0) {
+        output(ANSI_RED "getaddrinfo: %s\n", gai_strerror(rv));
+        // this is fatal
+        exit(1);
+    }
+
+    // loop through all the results and connect to the first we can
+    for(p = servinfo; p != NULL; p = p->ai_next) {
+        if ((_socket = socket(p->ai_family, p->ai_socktype,
+                p->ai_protocol)) == -1) {
+            output(ANSI_RED "Traffic Cop: socket error\n");
+            continue;
+        }
+
+        if (connect(_socket, p->ai_addr, p->ai_addrlen) == -1) {
+            close(_socket);
+            output(ANSI_RED "Traffic Cop: connect error\n");
+            continue;
+        }
+
+        break;
+    }
+
+    if (p == NULL) {
+        output(ANSI_RED "Traffic Cop: failed to connect\n");
+        exit(2);
+    }
+
+    inet_ntop(p->ai_family, get_in_addr((struct sockaddr *)p->ai_addr),
+            s, sizeof s);
+    output(ANSI_GREEN "Traffic Cop: connecting to %s\n", s);
+
+    freeaddrinfo(servinfo); // all done with this structure
+}
+
+static BOOL _have_terminate_char(void)
+{
+    if (__local.recv_buf[0] == 3) return TRUE;  // ctrl-c
+    if (__local.recv_buf[0] == 4) return TRUE;  // ctrl-d
+    if (__local.recv_buf[0] == 26) return TRUE; // ctrl-z
+    return FALSE;
+}
+
+static void _eat_characters(int n)
+{
+    //output("eating %u characters\n",n);
+    if (n >= __local.buf_len)
+    {
+        // if we are trying to eat more than is in the buffer, just clear the buffer
+        memset(__local.recv_buf,  0, n+1);
+        //output("zeroing buffer\n");
+        __local.read_ptr = __local.recv_buf;
+        __local.buf_len = 0;
+    }
+    else if (n > 0)
+    {
+        char* to = __local.recv_buf;
+        char* from = __local.recv_buf + n;
+
+        // move the rest of the buffer over the stuff we are eating
+        int i;
+        for (i = 0; i < (__local.buf_len - n); i++)
+        {
+            //output("moving a 0x%02X '%c'\n",*from,*from);
+            *to++ = *from;
+            *from++ = 0;
+        }
+        // correct length to show we ate some characters
+        __local.buf_len -= n;
+        //output("new buf len = %u\n",__local.buf_len);
+        // set where we will read in the next data
+        __local.read_ptr = (__local.recv_buf + __local.buf_len);
+        //output("new read ptr = 0x%08X\n",__local.read_ptr);
+        //output("next character = 0x%02X '%c'\n",*__local.recv_buf, *__local.recv_buf);
+    }
+}
+
+static void _eat_crlf(void)
+{
+    BOOL done_eating = FALSE;
+    // check for tasty morsels
+    while (!done_eating)
+    {
+        // don't overeat -- it's bad for you
+        if (__local.buf_len == 0)
+        {
+            done_eating = TRUE;
+        }
+        else if (__local.recv_buf[0] == '\n' || __local.recv_buf[0] == '\r' || __local.recv_buf[0] == 0x0)
+        {
+            _eat_characters(1);
+        }
+        else
+        {
+            done_eating = TRUE;
+        }
+    }
+}
+
+static void _skip_esc_sequences(void)
+{
+    // is the first character a telnet escape character (see RFC 2877)
+    while (__local.recv_buf[0] == 0xFF)
+    {
+        _eat_characters(3);
+    }
+}
+
+static BOOL _check_for_timeout(void)
+{
+    // if keepalive is not turned on, just say everything is AOK
+    if (!__local.keepalive_enabled) return TRUE;
+    // bail if we're uninitialized
+    if (__local.last_ping.tv_sec == 0) return TRUE;
+
+    // find out how long it has been since the last ping
+    uint32 since = usSince(__local.last_ping);
+
+    // 500% margin -- we should get a ping once per second
+    if (since > 5000000) return FALSE;
+    return TRUE;
+}
+
+static uint32 _read_more_data(void)
+{
+    int read_len, errsv;
+
+    BOOL done = FALSE;
+    // loop ignoring any timeout errors that occur
+    while (!done)
+    {
+        read_len = recv(_socket, __local.read_ptr, RECV_BUF_SIZE_TO_GET, 0);
+        errsv = errno;
+        // if read_len is zero and er got EAGAIN, it means the client closed the socket
+        if ( read_len == 0 && (errsv == EAGAIN || errsv == EPIPE || errsv == EBADF ) )
+        {
+//          debug(LOG_DEV, TRUE, "socket error: read_len = %d, errno = %d",read_len,errsv);
+            return SL_CLOSE_CLIENT;
+        }
+
+        // if we got new text from the socket OR we have an error other than timeout, exit the loop
+        if (read_len > 0) done = TRUE;
+        // EINTR seems to get asserted with breakpoint adds when debugging, so let's just
+        // read again if we see that too
+        if (read_len == -1 && errsv != EAGAIN && errsv != EINTR)
+        {
+//          debug(LOG_DEV, TRUE, "socket error: read_len = %d, errno = %d",read_len,errsv);
+            return SL_CLOSE_CLIENT;
+        }
+        // see if we have keepalive enabled and if so and we've not received a ping, terminate
+        // this client
+        if (!_check_for_timeout())
+        {
+            output(ANSI_RED "\nTraffic Cop has failed keepalive test; terminating\n");
+//            hal_listen_abort = TRUE;
+        }
+
+        // if someone wants to shutdown the system, we will terminate this thread
+        if (_abort) return SL_TERMINATE;
+    }
+
+    if (read_len <= 0 || read_len > RECV_BUF_SIZE_TO_GET)
+    {
+        // ok we're done here -- time to go
+        return SL_CLOSE_CLIENT;
+    }
+    else
+    {
+        __local.buf_len += read_len;
+        //output("total text length = %u\n",__local.buf_len);
+        return SUCCESS;
+    }
+}
+
+static uint32 _get_string_len(void)
+{
+    uint32 len;
+    BOOL found_terminator = FALSE;
+    for (len = 0; len < __local.buf_len; len++)
+    {
+        if (*(__local.recv_buf+len) == '\r' ||
+            *(__local.recv_buf+len) == '\n' ||
+            *(__local.recv_buf+len) == 0)
+        {
+            found_terminator = TRUE;
+            break;
+        }
+    }
+    if (found_terminator)
+    {
+        return len;
+    }
+    else
+    {
+        // prevent tight CPU loops waiting on data
+        usleep(500);
+        return 0;
+    }
+}
+
+static uint32 _get_command(void)
+{
+    BOOL got_command = FALSE;
+    while (!got_command && !_abort)
+    {
+        // if there something in the buffer
+        if (__local.buf_len != 0)
+        {
+            if (_have_terminate_char()) return SL_TERMINATE;
+            _skip_esc_sequences();
+            _eat_crlf();
+
+            uint32 len = _get_string_len();
+            if (len != 0)
+            {
+
+                __local.command = (char*)safe_malloc(len+1);
+                if(!__local.command)
+                {
+                    //output("Error allocating command (size=%u)\n", len+1);
+                    __local.command = NULL;
+                    return SL_OUT_OF_MEMORY;
+                }
+
+                // clear the newly allocated memory
+                memset(__local.command, 0, len+1);
+
+                memcpy(__local.command, __local.recv_buf, len);
+
+                _eat_characters(len);
+                got_command = TRUE;
+            }
+        }
+        if (!got_command)
+        {
+            uint32 ret_val = _read_more_data();
+            if (ret_val != SUCCESS) return ret_val;
+        }
+    }
+    return SUCCESS;
+}
+
+void process_status(char* string)
+{
+#ifdef DEBUG
+    output(ANSI_GREEN "Traffic Cop: received \033[m'%s'\n",string);
+#endif
+    status_processor(string);
+}
+
+
+//! main traffic cop receiver thread
+static void* _tc_thread(void* arg)
+{
+    uint32 result;
+
+    prctl(PR_SET_NAME, "DV-TrafficCop");
+
+    memset(&__local, 0, sizeof(receive_data));
+    __local.last_ping.tv_sec = 0;
+    __local.recv_buf = safe_malloc(RECV_BUF_SIZE);
+    memset(__local.recv_buf, 0, RECV_BUF_SIZE);
+    __local.buf_len = RECV_BUF_SIZE;
+
+    // make a connection to SmartSDR
+    // if this fails, the program just exits
+    _tc_openSocket();
+
+    result = register_mode();
+    if (result != SUCCESS)  {
+		output("** Could not register mode **\n");
+        _abort_reason = "register mode failed";
+		tc_abort();
+    }
+
+    tc_sendSmartSDRcommand("sub slice all", FALSE, NULL);
+
+    /* Initialize UDP connections for TX */
+    vita_output_Init(_hostname);
+
+    tc_startKeepalive();
+
+    // loop receiving data from SmartSDR and sending it where it should go
+    while (!_abort)
+    {
+        result = _get_command();
+        if (result == SUCCESS)
+        {
+            if(__local.command != NULL)
+            {
+                process_status(__local.command);
+                safe_free(__local.command);
+                __local.command = NULL;
+            }
+        }
+        else if (result == SL_TERMINATE)
+        {
+            output("Traffic Cop: terminate requested by byte 0x%02X\n",
+                   (unsigned char)__local.recv_buf[0]);
+            _abort = TRUE;
+            // close(client->sd); -- it's actually closed after the end: label
+            //debug(LOG_DEV,TRUE,"Client asked to close connection with a termination character");
+        }
+        else if (result == SL_CLOSE_CLIENT)
+        {
+            output("Traffic Cop: radio closed TCP API socket\n");
+            _abort = TRUE;
+            //close(client->sd); -- it's actually closed after the end: label
+            //debug(LOG_DEV,TRUE,"An error on the port has forced the client to close");
+        }
+    }
+
+    close(_socket);
+    safe_free(__local.recv_buf);
+
+    return NULL;
+}
+
+void _commandList_LinkHead(Command cmd)
+{
+    pthread_mutex_lock(&_commandList_mutex);
+    cmd->prev = _root;
+    cmd->next = _root->next;
+    _root->next->prev = cmd;
+    _root->next = cmd;
+    pthread_mutex_unlock(&_commandList_mutex);
+}
+
+void _commandList_LinkTail(Command cmd)
+{
+    pthread_mutex_lock(&_commandList_mutex);
+    cmd->next = _root;
+    cmd->prev = _root->prev;
+    _root->prev->next = cmd;
+    _root->prev = cmd;
+    pthread_mutex_unlock(&_commandList_mutex);
+}
+
+void _commandList_Unlink(Command cmd)
+{
+    // list should already be locked with entering!
+    // ensure not root
+    if(cmd == _root) return;
+
+    // make sure cmd exists and is actually linked
+    if(!cmd || !cmd->prev || !cmd->next) return;
+
+    cmd->next->prev = cmd->prev;
+    cmd->prev->next = cmd->next;
+    cmd->next = NULL;
+    cmd->prev = NULL;
+}
+
+void _commandList_Init()
+{
+    _root = (Command)safe_malloc(sizeof(command_type));
+    memset(_root, 0, sizeof(command_type));
+    _root->next = _root;
+    _root->prev = _root;
+    pthread_mutex_init(&_commandList_mutex, NULL);
+}
+
+Command tc_commandList_respond(uint32 sequence, char* response)
+{
+#ifdef DEBUG
+    output("response for %d: '%s'\n",sequence,response);
+#endif
+    pthread_mutex_lock(&_commandList_mutex);
+    Command iterator = _root;
+    while(iterator->next != _root)
+    {
+        iterator = iterator->next;
+        if (iterator->sequence != sequence) continue;
+
+        uint32 len = strlen(response);
+        char* resp = safe_malloc(len+1);
+        strncpy(resp, response, len+1);
+        iterator->response = resp;
+
+#ifdef DEBUG
+        // let the thread blocking on this know that we now have it
+        output("posting %d...\n",sequence);
+#endif
+        sem_post(&iterator->semaphore);
+        break;
+    }
+    pthread_mutex_unlock(&_commandList_mutex);
+    return NULL;
+}
+
+char* _tc_commandList_getResponse(uint32 sequence)
+{
+    pthread_mutex_lock(&_commandList_mutex);
+    Command iterator = _root;
+    while(iterator->next != _root)
+    {
+        iterator = iterator->next;
+        if (iterator->sequence != sequence) continue;
+
+        pthread_mutex_unlock(&_commandList_mutex);
+        sem_wait(&iterator->semaphore);
+#ifdef DEBUG
+        output("received post %d...\n",sequence);
+#endif
+        sem_destroy(&iterator->semaphore);
+        _commandList_Unlink(iterator);
+        char* response = iterator->response;
+        free(iterator);
+        return response;
+    }
+    pthread_mutex_unlock(&_commandList_mutex);
+    return NULL;
+}
+
+static void _tc_commandList_add(uint32 sequence)
+{
+    Command cmd = safe_malloc(sizeof(command_type));
+    memset(cmd, 0, sizeof(command_type));
+    sem_init(&cmd->semaphore,0,0);
+    cmd->sequence = sequence;
+    _commandList_LinkTail(cmd);
+}
+
+static uint32 _sendAPIcommand(char* command, uint32* sequence, BOOL block)
+{
+    int result;
+    uint32 ret_val;
+
+    char* mpointer = NULL;
+    char* message = safe_malloc(MAX_API_COMMAND_SIZE);
+    memset(message, 0, MAX_API_COMMAND_SIZE);
+
+    _sequence++;
+    *sequence = _sequence;
+
+    if (block) _tc_commandList_add(*sequence);
+
+    // first, we need to put the status header on the front of the string
+    int len = snprintf(message, MAX_API_COMMAND_SIZE, "C%d|", *sequence);
+    mpointer = message + len;
+
+    len += strlen(command) + 1;
+
+    strncat(mpointer, command, MAX_API_COMMAND_SIZE);
+    strncat(mpointer, "\n", MAX_API_COMMAND_SIZE);
+
+    errno = 0;
+    result = write(_socket, message, len);
+    *(message+len-1) = 0;
+    // output what we're sending as long as it is not a ping
+    // if (strstr(message, "ping") == 0)
+        //output(ANSI_GREEN "-> SmartSDR: \033[33m%s\033[m\n",command);
+    if (result == len)
+    {
+        ret_val = SUCCESS;
+    }
+    else
+    {
+        output(ANSI_RED "Traffic Cop: error writing to TCP API socket: %s\n",strerror(errno));
+        ret_val = SL_ERROR_BASE;
+        _abort_reason = "TCP API write failed";
+        tc_abort();
+    }
+    safe_free(message);
+    return ret_val;
+}
+
+//! send a command to the SmartSDR API (radio) and wait for a response
+//! this is a blocking call on the radio and will not return if the SmartSDR
+//! process is not running or not responding
+uint32 tc_sendSmartSDRcommand(char* command, BOOL block, char** response)
+{
+    if (response) *response = NULL;
+    uint32 sequence = 0;
+
+   // if (strcmp(command, "ping") != 0)
+   //     output(ANSI_GREEN "sending command: \033[m%s\n",command);
+    uint32 result = _sendAPIcommand(command, &sequence, block);
+
+    // if we're not waiting for a response, just return
+    if (!block) return SUCCESS;
+
+    // if the send wasn't successful, let's not wait for the result ;-)
+    if (result != SUCCESS && response) *response = NULL;
+
+    // wait for result here for sequence
+    if (response) *response = _tc_commandList_getResponse(sequence);
+
+    return SUCCESS;
+}
+
+static void* _keepalive_thread(void* param)
+{
+    char* response;
+
+    prctl(PR_SET_NAME, "DV-KeepAlive");
+
+    /* Sleep 2 seconds */
+    usleep(2000000);
+
+    // enable the keepalive mechanism in SmartSDR
+    uint32 ret_val = tc_sendSmartSDRcommand("keepalive enable", TRUE, &response);
+    if (ret_val != SUCCESS)
+    {
+        _abort_reason = "keepalive enable failed";
+        tc_abort();
+        return NULL;
+    }
+    if (response) free(response);
+
+    while (!_abort_keepalive)
+    {
+        // wait a second
+        usleep(1000000);
+        uint32 ret_val = tc_sendSmartSDRcommand("ping", FALSE, &response);
+        // must free the response if we got one
+        if (response) free (response);
+        // if we can't send a ping, all is lost and we must exit
+        if (ret_val != SUCCESS)
+        {
+            _abort_reason = "ping write failed";
+            tc_abort();
+            break;
+        }
+    }
+    output("Keep thread closing\n");
+    return NULL;
+}
+
+void tc_startKeepalive(void)
+{
+    // Start the keepalive thread
+    pthread_create(&_keepalive_thread_id, NULL, &_keepalive_thread, NULL);
+}
+
+void tc_abort(void)
+{
+    output(ANSI_RED "stopping Traffic Cop: %s ...\n", _abort_reason);
+    // stop the keepalive thread
+    _abort_keepalive = TRUE;
+    // stop the main TC thread
+    _abort = TRUE;
+    usleep(1000000);
+    exit(1);
+}
+
+void tc_Init(const char * hostname, const char * api_port)
+{
+    _commandList_Init();
+    output("\033[32mStarting Traffic Cop...\n\033[m");
+
+    if ( hostname == NULL || api_port == NULL) {
+		output("NULL Hostname - tc_setHostname()\n");
+		return;
+	}
+    struct ifaddrs *ifaddr, *ifa;
+    int family, s, n;
+    char host[NI_MAXHOST];
+    BOOL use_loopback = FALSE;
+
+    if ( getifaddrs(&ifaddr) == -1 ) {
+		output("Error getting local interface addrs. Using ip supplied in discovery packet\n");
+    } else {
+		/* Walk through linked list of interfaces. */
+		ifa = ifaddr;
+		for ( n = 0; ifa != NULL; ifa = ifa->ifa_next, n++ ) {
+			if ( ifa->ifa_addr == NULL )
+				continue;
+
+			family = ifa->ifa_addr->sa_family;
+
+			/* Only care about IPV4 adresses */
+			if ( family == AF_INET ) {
+				s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+				if ( s != 0 ) {
+					output("getnameinfo() failed: %s\n", gai_strerror(s));
+					continue;
+				} else {
+
+					/* We are on the same IP in the waveform and the radio hence we'll use local loopback interface instead
+					 * of the radios IP
+					 */
+					if ( strncmp(hostname, host, NI_MAXHOST) == 0 ) {
+						use_loopback = TRUE;
+						output("We are on the same IP as the radio. Using loopback interface\n");
+						break;
+					}
+				}
+			} else {
+				continue;
+			}
+		}
+    }
+
+    if ( !use_loopback )
+		strncpy(_hostname, hostname, 31);
+    else
+		strncpy(_hostname, "127.0.0.1", 31);
+
+	strncpy(_api_port, api_port, 31);
+
+
+    uint32 ret_val = pthread_create(&_tc_thread_id, NULL, &_tc_thread, NULL);
+    if (ret_val != 0) output("failed to start Traffic Cop thread\n");
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/traffic_cop.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/traffic_cop.h
@@ -1,0 +1,67 @@
+///*    \file traffic_cop.h
+// *    \brief TCP Communications Server
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef TRAFFIC_COP_H_
+#define TRAFFIC_COP_H_
+
+#include <semaphore.h>
+#include "datatypes.h"
+#include <time.h>
+
+typedef struct _recieve
+{
+    char* recv_buf;
+    char* read_ptr;
+    uint32 buf_len;
+    char* command;
+    BOOL keepalive_enabled;
+    struct timespec last_ping;
+} receive_data;
+
+typedef struct _cmd
+{
+    uint32 sequence;
+    sem_t semaphore;
+    char* response;
+    struct _cmd *next;
+    struct _cmd *prev;
+} command_type, *Command;
+
+//! ask the TCP/IP command client to abort
+void tc_startKeepalive(void);
+void tc_abort(void);
+void tc_Init(const char * hostname, const char * api_port);
+
+uint32 tc_sendSmartSDRcommand(char* command, BOOL block, char** response);
+Command tc_commandList_respond(uint32 sequence, char* response);
+
+#endif /* TRAFFIC_COP_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/utils.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/utils.c
@@ -1,0 +1,166 @@
+///*    \file utils.c
+// *    \brief Utility Functions
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <unistd.h> // for usleep
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <pthread.h>
+#include <ctype.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <inttypes.h>
+#include <stdarg.h>
+#include <semaphore.h>
+
+#include "common.h"
+
+static pthread_mutex_t _printf_mutex;
+static pthread_mutex_t _malloc_mutex;
+
+void lock_printf_init(void)
+{
+    pthread_mutex_init(&_printf_mutex, NULL);
+}
+
+static void _output_stdio(const char *fmt, va_list args)
+{
+    pthread_mutex_lock(&_printf_mutex);
+    vprintf(fmt, args);
+    pthread_mutex_unlock(&_printf_mutex);
+}
+
+void output(const char *fmt,...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    _output_stdio(fmt, args);
+    va_end(args);
+}
+
+int32 tsSubtract(struct timespec time1, struct timespec time2)
+{
+    int64 result;
+    result = (time1.tv_sec - time2.tv_sec) * 1000ll;
+    result += (time1.tv_nsec - time2.tv_nsec) / 1000000ll;
+    return (int32)result;
+}
+
+float tsfSubtract(struct timespec time1, struct timespec time2)
+{
+    float result;
+    result = (time1.tv_sec - time2.tv_sec) * 1000.0;
+    result += (time1.tv_nsec - time2.tv_nsec) / 1000000.0;
+    return result;
+}
+
+
+//! get time since a certain time in microseconds
+uint32 usSince(struct timespec time)
+{
+    struct timespec delay;
+    clock_gettime(CLOCK_MONOTONIC, &delay);
+    uint32 diff_us = (uint32)(tsfSubtract(delay, time) * 1000.0);
+    return diff_us;
+}
+
+uint32 msSince(struct timespec time)
+{
+    struct timespec delay;
+    clock_gettime(CLOCK_MONOTONIC, &delay);
+    uint32 diff_ms = (uint32)(tsSubtract(delay, time));
+    return diff_ms;
+}
+
+uint32 getIP(char* text)
+{
+    uint32 ip;
+    int a,b,c,d;
+    // get IP address
+    sscanf(text, "%d.%d.%d.%d", &a,&b,&c,&d);
+    ip = (a << 24) + (b << 16) + (c << 8) + d;
+    return ip;
+}
+
+void lock_malloc_init(void)
+{
+    pthread_mutex_init(&_malloc_mutex, NULL);
+}
+
+// thread-safe malloc
+void* safe_malloc(size_t size)
+{
+    void* pmem;
+    pthread_mutex_lock(&_malloc_mutex);
+    pmem = malloc(size);
+    pthread_mutex_unlock(&_malloc_mutex);
+    return pmem;
+}
+
+// thread-safe free
+void safe_free(void* ptr)
+{
+    pthread_mutex_lock(&_malloc_mutex);
+    if (ptr != NULL)
+    {
+        free(ptr);
+    }
+    else
+    {
+        output(ANSI_RED "Utils: attempt to free a NULL pointer\n");
+    }
+    pthread_mutex_unlock(&_malloc_mutex);
+}
+
+void printIP(uint32 ip)
+{
+	output("%d.%d.%d.%d\n",((ip>>24)& 0xFF),((ip>>16)& 0xFF),((ip>>8)& 0xFF),(ip & 0xFF));
+}
+
+void charReplace( char * string, char oldChar, char newChar )
+{
+	if ( string == NULL ) {
+		output("Null string passed to charReplace\n");
+		return ;
+	}
+
+	while (*string != 0 ) {
+		if ( *string == oldChar )
+			*string = newChar;
+
+		string++;
+	}
+
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/utils.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/utils.h
@@ -1,0 +1,51 @@
+///*    \file utils.h
+// *    \brief Utility Functions
+// *
+// *    \copyright  Copyright 2011-2013 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 31-AUG-2014
+// *    \author Stephen Hicks, N5AC
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef UTILS_H_
+#define UTILS_H_
+
+#include "common.h"
+
+void lock_printf_init(void);
+void output(const char *fmt,...);
+void tsAdd(struct timespec* time1, struct timespec time2);
+float tsfSubtract(struct timespec time1, struct timespec time2);
+uint32 usSince(struct timespec time);
+uint32 msSince(struct timespec time);
+uint32 getIP(char* text);
+void lock_malloc_init(void);
+void* safe_malloc(size_t size);
+void safe_free(void* ptr);
+void printIP(uint32 ip);
+void charReplace( char * string, char oldChar, char newChar );
+
+#endif /* UTILS_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/vita.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/vita.h
@@ -1,0 +1,138 @@
+/* *****************************************************************************
+ *  vita.h                                                          2014 AUG 31
+ *
+ *      Describes VITA 49 structures
+ *
+ *  \date 2012-03-28
+ *  \author Eric Wachsmann, KE5DTO
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef _VITA_H
+#define _VITA_H
+
+#include <linux/if_ether.h>
+
+#include "datatypes.h"
+
+/* Packet Header Definitions */
+#define VITA_HEADER_PACKET_TYPE_MASK                0xF0000000
+#define VITA_PACKET_TYPE_IF_DATA                    0x00000000
+#define VITA_PACKET_TYPE_IF_DATA_WITH_STREAM_ID     0x10000000
+#define VITA_PACKET_TYPE_EXT_DATA                   0x20000000
+#define VITA_PACKET_TYPE_EXT_DATA_WITH_STREAM_ID    0x30000000
+#define VITA_PACKET_TYPE_CONTEXT                    0x40000000
+#define VITA_PACKET_TYPE_EXT_CONTEXT                0x50000000
+
+#define VITA_HEADER_C_MASK                          0x08000000
+#define VITA_HEADER_CLASS_ID_PRESENT                0x08000000
+
+#define VITA_HEADER_T_MASK                          0x04000000
+#define VITA_HEADER_TRAILER_PRESENT                 0x04000000
+
+#define VITA_HEADER_TSI_MASK                        0x00C00000
+#define VITA_TSI_NONE                               0x00000000
+#define VITA_TSI_UTC                                0x00400000
+#define VITA_TSI_GPS                                0x00800000
+#define VITA_TSI_OTHER                              0x00C00000
+
+#define VITA_HEADER_TSF_MASK                        0x00300000
+#define VITA_TSF_NONE                               0x00000000
+#define VITA_TSF_SAMPLE_COUNT                       0x00100000
+#define VITA_TSF_REAL_TIME                          0x00200000
+#define VITA_TSF_FREE_RUNNING                       0x00300000
+
+#define VITA_HEADER_PACKET_COUNT_MASK               0x000F0000
+#define VITA_HEADER_PACKET_SIZE_MASK                0x0000FFFF
+
+#define VITA_CLASS_ID_OUI_MASK                      0x00FFFFFF
+#define VITA_CLASS_ID_INFORMATION_CLASS_MASK        0xFFFF0000
+#define VITA_CLASS_ID_PACKET_CLASS_MASK             0x0000FFFF
+
+#pragma pack(4)
+
+// 16 ip header
+#define MAX_TCP_DATA_SIZE (ETH_DATA_LEN-16)
+
+// 16 ip header, 6 udp header
+#define MAX_UDP_DATA_SIZE (2048)
+
+#define MAX_IF_DATA_PAYLOAD_SIZE (MAX_UDP_DATA_SIZE) //-28)
+typedef struct _vita_if_data
+{
+    uint32 header;
+    uint32 stream_id;
+    uint32 class_id_h;
+    uint32 class_id_l;
+    uint32 timestamp_int;
+    uint32 timestamp_frac_h;
+    uint32 timestamp_frac_l;
+    uint8  payload[MAX_IF_DATA_PAYLOAD_SIZE];
+} vita_if_data, *VitaIFData;
+
+#define MAX_METER_DATA_PAYLOAD_SIZE (MAX_UDP_DATA_SIZE) //-28)
+typedef struct _vita_meter_data
+{
+    uint32 header;
+    uint32 stream_id;
+    uint32 class_id_h;
+    uint32 class_id_l;
+    uint32 timestamp_int;
+    uint32 timestamp_frac_h;
+    uint32 timestamp_frac_l;
+    uint8  payload[MAX_METER_DATA_PAYLOAD_SIZE];
+} vita_meter_data, *VitaMeterData;
+
+#define MAX_METER_PAYLOAD_SIZE (MAX_UDP_DATA_SIZE) //-36)
+typedef struct _vita_ext_data_meter
+{
+    uint32 header;
+    uint32 streamID;
+    uint32 classID_1;
+    uint32 classID_2;
+    uint32 integer_seconds;
+    uint64 frac_seconds;
+    uint32 extended_packet_type; // = 1 is meter
+    uint32 number_of_meters;
+    uint8  payload[MAX_METER_PAYLOAD_SIZE];
+} vita_ext_data_meter, *VitaExtDataMeter;
+
+typedef struct _vita_timestamp
+{
+    uint32 ts_int;
+    union
+    {
+        struct
+        {
+            uint32 ts_frac_h;
+            uint32 ts_frac_l;
+        };
+        uint64 ts_frac;
+    };
+
+} vita_timestamp, *VitaTimestamp;
+
+typedef uint32 vita_date;
+
+#pragma pack()
+
+#endif /* _VITA_H */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/vita49_context.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/vita49_context.h
@@ -1,0 +1,127 @@
+/* *****************************************************************************
+ * 	vita49_context.h
+ *
+ *		VITA49 context
+ *
+ *	\date 12-FEB-2011
+ *	\author Stephen Hicks, N5AC
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef VITA49_CONTEXT_H_
+#define VITA49_CONTEXT_H_
+
+#include "../common.h"
+
+#define VITA_C_CONTEXT_FIELD_CHG_INDICATOR	0x80000000
+#define VITA_C_REFERENCE_POINT_IDENTIFIER	0x40000000
+#define VITA_C_BANDWIDTH					0x20000000
+#define VITA_C_IF_REFERENCE_FREQ			0x10000000
+#define VITA_C_RF_REFERENCE_FREQ			0x08000000
+#define VITA_C_RF_REFERENCE_FREQ_OFFSET		0x04000000
+#define VITA_C_IF_BAND_OFFSET				0x02000000
+#define VITA_C_REFERENCE_LEVEL				0x01000000
+#define VITA_C_GAIN							0x00800000
+#define VITA_C_OVER_RANGE_COUNT				0x00400000
+#define VITA_C_SAMPLE_RATE					0x00200000
+#define VITA_C_TIMESTAMP_ADJUSTMENT			0x00100000
+#define VITA_C_TIMESTAMP_CALIBRATION_TIME	0x00080000
+#define VITA_C_TEMPERATURE					0x00040000
+#define VITA_C_DEVICE_IDENTIFIER			0x00020000
+#define VITA_C_STATE_AND_EVENT_INDICATORS	0x00010000
+#define VITA_C_DATA_PACKET_PAYLOAD_FORMAT	0x00008000
+#define VITA_C_FORMATTED_GPS_GEOLOCATION	0x00004000
+#define VITA_C_FORMATTED_INS_LOCATION		0x00002000
+#define VITA_C_ECEF_EPHEMERIS				0x00001000
+#define VITA_C_RELATIVE_EPHEMERIS			0x00000800
+#define VITA_C_EPHEMERIS_REFERENCE_IND		0x00000400
+#define VITA_C_GPS_ASCII					0x00000200
+#define VITA_C_CONTEXT_ASSOCIATION_LISTS	0x00000100
+#define VITA_C_RESERVED						0x000000FF
+
+// bit positions for status and indicator fields
+#define VITA_S_CALIBRATED_TIME_E			0x80000000
+#define VITA_S_VALID_DATA_E					0x40000000
+#define VITA_S_REFERENCE_LOCK_E				0x20000000
+#define VITA_S_AGC_INDICATOR_E				0x10000000
+#define VITA_S_DETECTED_SIGNAL_E			0x08000000
+#define VITA_S_SPECTRAL_INVERSION_E			0x04000000
+#define VITA_S_OVER_RANGE_E					0x02000000
+#define VITA_S_SAMPLE_LOSS_E				0x01000000
+#define VITA_S_CALIBRATED_TIME_I			0x00080000
+#define VITA_S_VALID_DATA_I					0x00040000
+#define VITA_S_REFERENCE_LOCK_I				0x00020000
+#define VITA_S_AGC_INDICATOR_I				0x00010000
+#define VITA_S_DETECTED_SIGNAL_I			0x00008000
+#define VITA_S_SPECTRAL_INVERSION_I			0x00004000
+#define VITA_S_OVER_RANGE_I					0x00002000
+#define VITA_S_SAMPLE_LOSS_I				0x00001000
+
+#define VITA_P_PACKING_METHOD				0x0 << 31	 	// we are processing efficient
+#define VITA_P_REAL_COMPLEX					0x1 << 28		// complex cartesian
+#define VITA_P_DATA_ITEM_FORMAT				0x00 << 24		// signed, fixed point
+#define VITA_P_SAMPLE_REPEAT				0x0 << 23		// no sample-component repeating
+#define VITA_P_EVENT_TAG_SIZE				0x0 << 20		// no event tags
+#define VITA_P_CHANNEL_TAG_SIZE				0x0 << 18		// no channel tags
+#define VITA_P_ITEM_PACKING_FIELD_SIZE		32 << 6			// 32-bit fields
+#define VITA_P_DATA_ITEM_SIZE				24				// 24-bits per item
+#define VITA_P_REPEAT_COUNT					0 << 16			// no repeating
+#define VITA_P_VECTOR_SIZE					0				// no vectors
+
+
+#define VITA_P_PACKING_H	VITA_P_PACKING_METHOD | \
+							VITA_P_REAL_COMPLEX | \
+							VITA_P_DATA_ITEM_FORMAT | \
+							VITA_P_SAMPLE_REPEAT | \
+							VITA_P_EVENT_TAG_SIZE | \
+							VITA_P_CHANNEL_TAG_SIZE | \
+							VITA_P_ITEM_PACKING_FIELD_SIZE | \
+							VITA_P_DATA_ITEM_SIZE
+#define VITA_P_PACKING_L	VITA_P_REPEAT_COUNT | \
+							VITA_P_VECTOR_SIZE
+
+#define VITA_PERIODIC 1000 // send out packets once per second even if no changes (in ms)
+
+typedef struct _context
+{
+	uint32 header;
+	uint32 streamID;
+	uint32 classID_H;
+	uint32 classID_L;
+//	uint32 timestamp_sec; // we'll add these later
+//	uint64 timestamp_frac;
+	uint32 context_indicator;
+	uint64 bandwidth;
+	uint64 if_reference;
+	uint64 rf_reference;
+	uint32 reference_level;
+	uint16 gain2;
+	uint16 gain1;
+	uint64 sample_rate;
+	uint32 state_event_ind;
+	uint32 packet_format_H;
+	uint32 packet_format_L;
+} vitacontext_type, *VITACONTEXT;
+
+
+
+#endif /* VITA49_CONTEXT_H_ */

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/vita_output.c
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/vita_output.c
@@ -1,0 +1,197 @@
+///*!	\file vita_output.c
+// *	\brief transmit vita packets to the Ethernet
+// *
+// *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date 2-APR-2012
+// *	\author Stephen Hicks, N5AC
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <sys/socket.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h> // for write, usleep
+#include <errno.h>
+
+#include "vita_output.h"
+#include "common.h"
+#include "hal_listener.h"
+
+extern int errno;
+
+#define FORMAT_DBFS 0
+#define FORMAT_DBM 1
+
+#define VITA_CLASS_ID_1			(uint32)VITA_OUI
+#define VITA_CLASS_ID_2			SL_VITA_INFO_CLASS << 16 | SL_VITA_IF_DATA_CLASS
+
+#define MAX_SAMPLES_PER_PACKET	(MAX_IF_DATA_PAYLOAD_SIZE/8)
+#define MAX_BINS_PER_PACKET 700
+
+// local variable declarations
+static vita_if_data waveform_packet;
+
+static int vita_sock;
+static struct sockaddr_in vita_sLocalAddr;
+static uint32 _local_ip_addr;
+static uint16 _dest_port;
+
+void vita_output_Init(const char * ip )
+{
+	output("\033[32mInitializing VITA-49 output engine...\n\033[m");
+
+	vita_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (vita_sock < 0)
+	{
+		output(ANSI_RED " Failed to initialize VITA socket\n");
+		return;
+	}
+	errno = 0;
+	bind(vita_sock, (struct sockaddr *)&vita_sLocalAddr, sizeof(vita_sLocalAddr));
+	if (errno)
+	{
+		output(ANSI_RED "error binding socket: errno=%d\n",errno);
+	}
+
+	struct in_addr addr;
+
+	if ( ip == NULL ) {
+		output(ANSI_RED "NULL IP Supplied!!\n");
+		tc_abort();
+	}
+	if ( inet_aton(ip, &addr) == 0) {
+		output(ANSI_RED "Could not convert local addr to binary\n");
+	} else {
+		_local_ip_addr = ntohl(addr.s_addr);
+	}
+	_dest_port = 4991;
+	// output("host = %d.%d.%d.%d : %d", ip>>24, (ip>>16)&0xFF, (ip>>8)&0xFF, ip&0xFF, _dest_port);
+
+	output("Vita Output Init - ip = '%s' port = %d\n", ip,_dest_port);
+}
+
+void UDPSendByIPandPort(void* packet, uint32 num_bytes, uint32 ip_address, uint16 udp_port)
+{
+	struct sockaddr_in sock;
+	sock.sin_family = AF_INET;
+	sock.sin_addr.s_addr = htonl(ip_address);
+	sock.sin_port = htons(udp_port);
+	errno = 0;
+	int32 ret_val = sendto(vita_sock, packet, num_bytes, 0, (struct sockaddr*)&sock, sizeof(sock));
+	if ( errno || ret_val < 0) {
+		output( "Error sending packet: errno%d \n", errno);
+	}
+
+}
+
+static void _vita_formatWaveformPacket(Complex* buffer, uint32 samples, uint32 stream_id, uint32 packet_count,
+		uint32 class_id_h, uint32 class_id_l, uint32 ip_addr, uint16 port)
+{
+	waveform_packet.header = htonl(
+			VITA_PACKET_TYPE_IF_DATA_WITH_STREAM_ID |
+			VITA_HEADER_CLASS_ID_PRESENT |
+			VITA_TSI_OTHER |
+			VITA_TSF_SAMPLE_COUNT |
+			(packet_count << 16) |
+			(7+samples*2));
+	waveform_packet.stream_id = htonl(stream_id);
+	waveform_packet.class_id_h =  htonl(class_id_h);
+	waveform_packet.class_id_l =  htonl(class_id_l);
+	waveform_packet.timestamp_int = 0;
+	waveform_packet.timestamp_frac_h = 0;
+	waveform_packet.timestamp_frac_l = 0;
+
+	memcpy(waveform_packet.payload, buffer, samples * sizeof(Complex));
+	//HAL_update_count(stream_id, class_id_h, class_id_l, samples * 8 + 28, HAL_STATUS_OUTPUT_OK, OUTPUT, WFM, ip_addr, port);
+}
+
+static uint32 _waveform_packet_count = 0;
+
+void emit_waveform_output(BufferDescriptor buf_desc_out)
+{
+	int samples_sent, samples_to_send;
+	Complex * buf_pointer;
+
+	if (buf_desc_out == NULL)
+	{
+		output(ANSI_RED "buf_desc_out is NULL\n");
+		return;
+	}
+	if (buf_desc_out->buf_ptr == NULL)
+	{
+		output(ANSI_RED "buf_desc_out->buf_ptr is NULL\n");
+		return;
+	}
+
+	Complex* out_buffer = (Complex*)buf_desc_out->buf_ptr;
+	uint32 buf_size = buf_desc_out->num_samples;
+
+
+	// convert to big endian for network
+	int i;
+	for(i=0; i<buf_size; i++)
+	{
+		*(uint32*)&out_buffer[i].real = htonl(*(uint32*)&out_buffer[i].real);
+		*(uint32*)&out_buffer[i].imag = htonl(*(uint32*)&out_buffer[i].imag);
+	}
+
+	samples_sent = 0;
+	buf_pointer = out_buffer;
+	uint32 preferred_samples_per_packet = buf_size;
+	//output("samples_to_send: %d\n", preferred_samples_per_packet);
+
+	while (samples_sent < buf_size)
+	{
+		if ((buf_size - samples_sent) > preferred_samples_per_packet)
+		{
+			samples_to_send = preferred_samples_per_packet;
+		}
+		else
+		{
+			samples_to_send =  buf_size - samples_sent;
+		}
+		//output("samples_to_send: %d\n", samples_to_send);
+		_vita_formatWaveformPacket(
+				buf_pointer,
+				samples_to_send,
+				buf_desc_out->stream_id,
+				_waveform_packet_count++ & 0xF,
+				(uint32) FLEXRADIO_OUI,
+				SL_VITA_SLICE_AUDIO_CLASS,
+				_local_ip_addr,
+				4991);
+		buf_pointer += samples_to_send;
+		samples_sent += samples_to_send;
+		vita_sLocalAddr.sin_port = htons(VITA_49_SOURCE_PORT);
+		UDPSendByIPandPort(&waveform_packet, samples_to_send * 8 + 28, _local_ip_addr, _dest_port);
+	}
+}

--- a/third_party/smartsdr-dsp/SmartSDR_Interface/vita_output.h
+++ b/third_party/smartsdr-dsp/SmartSDR_Interface/vita_output.h
@@ -1,0 +1,50 @@
+///*!	\file vita_output.h
+// *	\brief transmit vita packets to the Ethernet
+// *
+// *	\copyright	Copyright 2012-2013 FlexRadio Systems.  All Rights Reserved.
+// *				Unauthorized use, duplication or distribution of this software is
+// *				strictly prohibited by law.
+// *
+// *	\date 2-APR-2012
+// *	\author Stephen Hicks, N5AC
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+#ifndef VITA_OUTPUT_H_
+#define VITA_OUTPUT_H_
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "common.h"
+#include "complex.h"
+#include "hal_buffer.h"
+
+void vita_output_Init(const char * ip );
+
+void UDPSendByIPandPort(void* packet, uint32 num_bytes, uint32 ip_address, uint16 udp_port);
+
+void emit_waveform_output(BufferDescriptor buf_desc_out);
+
+
+#endif /* VITA_OUTPUT_H_ */

--- a/third_party/smartsdr-dsp/ThumbDV/DStarDefines.h
+++ b/third_party/smartsdr-dsp/ThumbDV/DStarDefines.h
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (C) 2009,2012 by Jonathan Naylor, G4KLX
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; version 2 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  Modified for FlexRadio WaveformAPI by Ed Gonzalez KG5FBT
+ */
+
+/* THUMBDV_DSTARDEFINES_H_ */
+#ifndef THUMBDV_DSTARDEFINES_H_
+#define THUMBDV_DSTARDEFINES_H_
+
+#include "datatypes.h"
+
+#define DSTAR_GMSK_SYMBOL_RATE  4800U
+#define DSTAR_GMSK_BT           0.5F
+
+static const BOOL BIT_SYNC_BITS[]    = {TRUE, FALSE, TRUE, FALSE};
+#define BIT_SYNC_LENGTH_BITS = 4U;
+
+static const BOOL FRAME_SYNC_BITS[]  = {TRUE, TRUE,  TRUE, FALSE, TRUE,  TRUE,  FALSE, FALSE,
+                                 TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE};
+#define FRAME_SYNC_LENGTH_BITS  15U
+
+//static const unsigned char DATA_SYNC_BYTES[] = {0x55, 0x2D, 0x16};
+static const unsigned char DATA_SYNC_BYTES[] = {0xAA, 0xB4, 0x68};
+
+static const BOOL DATA_SYNC_BITS[]   = {TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+                                 TRUE,  FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE,
+                                 FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE};
+
+//static const unsigned char END_PATTERN_BYTES[] = {0x55, 0x55, 0x55, 0x55, 0xC8, 0x7A};
+static const unsigned char END_PATTERN_BYTES[] = {0xAA, 0xAA, 0xAA, 0xAA, 0x13, 0x5E};
+static const BOOL END_PATTERN_BITS[] = {TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+                                 TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+                                 TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+                                 TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+                                 FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,
+                                 FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE};
+
+#define END_PATTERN_LENGTH_BITS  48U
+#define END_PATTERN_LENGTH_BYTES (END_PATTERN_LENGTH_BITS / 8U)
+
+static const unsigned char NULL_AMBE_DATA_BYTES[] = {0x9E, 0x8D, 0x32, 0x88, 0x26, 0x1A, 0x3F, 0x61, 0xE8};
+static const BOOL NULL_AMBE_DATA_BITS[] = {FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,
+                                    TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,
+                                    FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE,
+                                    FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,
+                                    FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE,
+                                    FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE,
+                                    TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE,
+                                    TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE,
+                                    FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE};
+
+// Note that these are already scrambled, 0x66 0x66 0x66 otherwise
+static const BOOL NULL_SLOW_DATA_BITS[] = {FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE,
+                                    FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,
+                                    TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE};
+
+#define VOICE_FRAME_LENGTH_BITS  72U
+#define VOICE_FRAME_LENGTH_BYTES  (VOICE_FRAME_LENGTH_BITS / 8U)
+
+#define DATA_FRAME_LENGTH_BITS   24U
+#define DATA_FRAME_LENGTH_BYTES  (DATA_FRAME_LENGTH_BITS / 8U)
+
+#define DV_FRAME_LENGTH_BITS     (VOICE_FRAME_LENGTH_BITS + DATA_FRAME_LENGTH_BITS)
+#define DV_FRAME_LENGTH_BYTES    (VOICE_FRAME_LENGTH_BYTES + DATA_FRAME_LENGTH_BYTES)
+
+#define FEC_SECTION_LENGTH_BITS    660U
+
+#define RADIO_HEADER_LENGTH_BITS    330U
+#define RADIO_HEADER_LENGTH_BYTES   42U
+
+#define DATA_BLOCK_SIZE_BITS    (21U * DV_FRAME_LENGTH_BITS)
+#define DATA_BLOCK_SIZE_BYTES   (21U * DV_FRAME_LENGTH_BYTES)
+
+#define SLOW_DATA_TYPE_MASK      0xF0
+#define SLOW_DATA_TYPE_GPSDATA   0x30
+#define SLOW_DATA_TYPE_MESSAGE   0x40
+#define SLOW_DATA_TYPE_HEADER    0x50
+#define SLOW_DATA_TYPE_SQUELCH   0xC0
+#define SLOW_DATA_LENGTH_MASK    0x0F
+
+#define DSTAR_AUDIO_BLOCK_SIZE    160U
+#define DSTAR_AUDIO_BLOCK_BYTES   (DSTAR_AUDIO_BLOCK_SIZE * 2U)
+
+#define DSTAR_RADIO_SAMPLE_RATE   24000
+#define DSTAR_RADIO_BLOCK_SIZE    960U
+
+#define LONG_CALLSIGN_LENGTH    8U
+#define SHORT_CALLSIGN_LENGTH   4U
+
+#define SLOW_DATA_MESSAGE_LENGTH_BYTES    20U
+#define SLOW_DATA_PACKET_LEN_BYTES          3
+
+
+#define DATA_MASK             0x80U
+#define REPEATER_MASK         0x40U
+#define INTERRUPTED_MASK      0x20U
+#define CONTROL_SIGNAL_MASK   0x10U
+#define URGENT_MASK           0x08U
+
+#define REPEATER_CONTROL_MASK   0x07U
+#define REPEATER_CONTROL        0x07U
+#define AUTO_REPLY              0x06U
+#define RESEND_REQUESTED        0x04U
+#define ACK_FLAG                0x03U
+#define NO_RESPONSE             0x02U
+#define RELAY_UNAVAILABLE       0x01U
+
+#define  DSTAR_BLEEP_FREQ    2000U
+#define  DSTAR_BLEEP_LENGTH   100U
+#define  DSTAR_BLEEP_AMPL       0.5F
+
+#define DSTAR_RADIO_BIT_LENGTH  (DSTAR_RADIO_SAMPLE_RATE / DSTAR_GMSK_SYMBOL_RATE)
+
+#define  FRAME_TIME_MS 20U
+
+#define  FRAMES_BETWEEN_SYNC 20U
+
+#define TICKS_PER_SEC = 50U
+
+#endif

--- a/third_party/smartsdr-dsp/ThumbDV/bit_pattern_matcher.c
+++ b/third_party/smartsdr-dsp/ThumbDV/bit_pattern_matcher.c
@@ -1,0 +1,135 @@
+///*!   \file bit_pattern_matcher.c
+// *    \brief Allows matching of a pattern in an array ob gits.
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 26-MAY-2015
+// *    \author     Ed Gonzalez
+// *
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "bit_pattern_matcher.h"
+
+BIT_PM bitPM_create( const BOOL * to_match, uint32 length ) {
+    BIT_PM bpm = ( BIT_PM ) safe_malloc( sizeof( bit_pm ) );
+
+    bpm->pattern = ( BOOL * ) safe_malloc( sizeof( BOOL ) * length );
+    bpm->data = ( BOOL * ) safe_malloc( sizeof( BOOL ) * length );
+    bpm->length = length;
+    bpm->data_length = 0;
+
+    /* We have to put the pattern in reverse since
+     * the samples are fed left to right
+     */
+    uint32 i = 0;
+    uint32 n = length - 1;
+
+    for ( i = 0 ; i < length; i++ ) {
+        bpm->pattern[n--] = to_match[i];
+    }
+
+    output( "Creating pattern matcher !!!!!\n" );
+
+    for ( i = 0 ; i < length ; i++ ) {
+        output( "%d", bpm->pattern[i] );
+    }
+
+    output( "\n" );
+
+    for ( i = 0 ; i < length ; i++ ) {
+        output( "%d", to_match[i] );
+    }
+
+    output( "\n" );
+
+
+    memset( bpm->data, 0, length * sizeof( BOOL ) );
+
+    return bpm;
+}
+
+void bitPM_destroy( BIT_PM bpm ) {
+    safe_free( bpm->data );
+    safe_free( bpm->pattern );
+    safe_free( bpm );
+}
+
+void bitPM_reset( BIT_PM bpm ) {
+    bpm->data_length = 0;
+    memset( bpm->data, 0, bpm->length * sizeof( BOOL ) );
+}
+
+BOOL bitPM_addBit( BIT_PM bpm, BOOL bit ) {
+    uint32 i = 0;
+
+    /* Shift the existing buffer to make space for new bit */
+    for ( i = bpm->length - 1; i >= 1 ; i-- ) {
+        bpm->data[i] = bpm->data[i - 1];
+    }
+
+    bpm->data[0] = bit;
+
+    if ( bpm->data_length < bpm->length ) {
+        bpm->data_length++;
+    }
+
+    if ( bpm->data_length != bpm->length ) {
+        /* If not enough data has accumulated then simply return FALSE */
+        return FALSE;
+    }
+
+    for ( i = 0; i < bpm->length ; i++ ) {
+        if ( bpm->pattern[i] != bpm->data[i] ) {
+            return FALSE;
+        }
+    }
+
+#ifdef DEBUG_BIT_PM
+    output( ANSI_GREEN "Match Found\nPat: " );
+
+    for ( i = 0; i < bpm->length ; i++ ) {
+        output( "%d ", bpm->pattern[i] );
+    }
+
+    output( "\nMat: " );
+
+    for ( i = 0; i < bpm->length ; i++ ) {
+        output( "%d ", bpm->data[i] );
+    }
+
+    output( "\n" );
+
+
+#endif
+
+    /* If we make it here all checks have passed */
+    return TRUE;
+}

--- a/third_party/smartsdr-dsp/ThumbDV/bit_pattern_matcher.h
+++ b/third_party/smartsdr-dsp/ThumbDV/bit_pattern_matcher.h
@@ -1,0 +1,54 @@
+///*!   \file bit_pattern_matcher.h
+// *    \brief Allows matching of a pattern in an array ob gits.
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 26-MAY-2015
+// *    \author     Ed Gonzalez
+// *
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#ifndef THUMBDV_BIT_PATTERN_MATCHER_H_
+#define THUMBDV_BIT_PATTERN_MATCHER_H_
+
+#include "datatypes.h"
+
+typedef struct _bit_pattern_matcher {
+    BOOL * pattern;
+    BOOL * data;
+    uint32 length;
+    uint32 data_length;
+} bit_pm, * BIT_PM;
+
+void bitPM_destroy( BIT_PM bpm );
+BIT_PM bitPM_create( const BOOL * to_match, uint32 length );
+
+BOOL bitPM_addBit( BIT_PM bpm, BOOL bit );
+void bitPM_reset( BIT_PM bpm );
+
+#endif /* THUMBDV_BIT_PATTERN_MATCHER_H_ */

--- a/third_party/smartsdr-dsp/ThumbDV/dstar.c
+++ b/third_party/smartsdr-dsp/ThumbDV/dstar.c
@@ -1,0 +1,1212 @@
+///*!   \file dstar.c
+// *
+// *    Handles all DSTAR states
+// *
+// *    \date 02-JUN-2015
+// *    \author Ed Gonzalez KG5FBT modified from original in OpenDV code (C) 2009 Jonathan Naylor, G4KLX
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "DStarDefines.h"
+#include "gmsk_modem.h"
+#include "bit_pattern_matcher.h"
+#include "thumbDV.h"
+#include "dstar.h"
+#include "slow_data.h"
+#include "circular_buffer.h"
+
+#define SCRAMBLER_TABLE_BITS_LENGTH     720U
+#define SCRAMBLER_TABLE_BYTES_LENGTH    90U
+
+static const BOOL SCRAMBLER_TABLE_BITS[] = {
+    FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE,
+    TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE,
+    FALSE, FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE,
+    TRUE,  FALSE, TRUE,  TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE,
+    TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,
+    TRUE,  FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE,
+    TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,
+    TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE,
+    FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,
+    TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE,
+    FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,
+    FALSE, TRUE,  TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,
+    TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,
+    FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,
+    TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,
+    FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE,
+    FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,
+    FALSE, FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE,
+    TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE,
+    TRUE,  TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,
+    FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE,
+    TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  TRUE,
+    TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE,
+    TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE,
+    FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE,
+    FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,
+    FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE,
+    TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE,
+    TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,
+    TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,
+    TRUE,  TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,
+    TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE,
+    TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE,
+    TRUE,  FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE,
+    FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE,  TRUE,
+    FALSE, TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,
+    FALSE, TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,
+    FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,
+    TRUE,  FALSE, TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,  TRUE,
+    TRUE,  FALSE, FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, TRUE,
+    TRUE,  TRUE,  FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,
+    FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, FALSE,
+    TRUE,  TRUE,  FALSE, FALSE, FALSE, TRUE,  FALSE, TRUE,  TRUE,  TRUE,  FALSE, TRUE,  FALSE, TRUE,  TRUE,  FALSE,
+    TRUE,  TRUE,  FALSE, FALSE, FALSE, FALSE, FALSE, TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  FALSE, TRUE,  FALSE,
+    TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  FALSE, FALSE, TRUE,  TRUE,  TRUE,  TRUE,  FALSE, TRUE,  TRUE,  FALSE
+};
+
+
+
+static const unsigned char SCRAMBLER_TABLE_BYTES[] = {
+    0x0e, 0xf2, 0xc9, 0x02, 0x26, 0x2e, 0xb6, 0x0c, 0xd4, 0xe7, 0xb4, 0x2a, 0xfa, 0x51, 0xb8, 0xfe,
+    0x1d, 0xe5, 0x92, 0x04, 0x4c, 0x5d, 0x6c, 0x19, 0xa9, 0xcf, 0x68, 0x55, 0xf4, 0xa3, 0x71, 0xfc,
+    0x3b, 0xcb, 0x24, 0x08, 0x98, 0xba, 0xd8, 0x33, 0x53, 0x9e, 0xd0, 0xab, 0xe9, 0x46, 0xe3, 0xf8,
+    0x77, 0x96, 0x48, 0x11, 0x31, 0x75, 0xb0, 0x66, 0xa7, 0x3d, 0xa1, 0x57, 0xd2, 0x8d, 0xc7, 0xf0,
+    0xef, 0x2c, 0x90, 0x22, 0x62, 0xeb, 0x60, 0xcd, 0x4e, 0x7b, 0x42, 0xaf, 0xa5, 0x1b, 0x8f, 0xe1,
+    0xde, 0x59, 0x20, 0x44, 0xc5, 0xd6, 0xc1, 0x9a, 0x9c, 0xf6
+};
+
+
+static const unsigned int INTERLEAVE_TABLE[] = {
+    0, 28, 56, 84, 112, 140, 168, 196, 224, 252, 280, 308, 336, 363, 390, 417, 444,
+    471, 498, 525, 552, 579, 606, 633, 1, 29, 57, 85, 113, 141, 169, 197, 225, 253,
+    281, 309, 337, 364, 391, 418, 445, 472, 499, 526, 553, 580, 607, 634, 2, 30, 58,
+    86, 114, 142, 170, 198, 226, 254, 282, 310, 338, 365, 392, 419, 446, 473, 500,
+    527, 554, 581, 608, 635, 3, 31, 59, 87, 115, 143, 171, 199, 227, 255, 283, 311,
+    339, 366, 393, 420, 447, 474, 501, 528, 555, 582, 609, 636, 4, 32, 60, 88, 116,
+    144, 172, 200, 228, 256, 284, 312, 340, 367, 394, 421, 448, 475, 502, 529, 556,
+    583, 610, 637, 5, 33, 61, 89, 117, 145, 173, 201, 229, 257, 285, 313, 341, 368,
+    395, 422, 449, 476, 503, 530, 557, 584, 611, 638, 6, 34, 62, 90, 118, 146, 174,
+    202, 230, 258, 286, 314, 342, 369, 396, 423, 450, 477, 504, 531, 558, 585, 612,
+    639, 7, 35, 63, 91, 119, 147, 175, 203, 231, 259, 287, 315, 343, 370, 397, 424,
+    451, 478, 505, 532, 559, 586, 613, 640, 8, 36, 64, 92, 120, 148, 176, 204, 232,
+    260, 288, 316, 344, 371, 398, 425, 452, 479, 506, 533, 560, 587, 614, 641, 9,
+    37, 65, 93, 121, 149, 177, 205, 233, 261, 289, 317, 345, 372, 399, 426, 453, 480,
+    507, 534, 561, 588, 615, 642, 10, 38, 66, 94, 122, 150, 178, 206, 234, 262, 290,
+    318, 346, 373, 400, 427, 454, 481, 508, 535, 562, 589, 616, 643, 11, 39, 67, 95,
+    123, 151, 179, 207, 235, 263, 291, 319, 347, 374, 401, 428, 455, 482, 509, 536,
+    563, 590, 617, 644, 12, 40, 68, 96, 124, 152, 180, 208, 236, 264, 292, 320, 348,
+    375, 402, 429, 456, 483, 510, 537, 564, 591, 618, 645, 13, 41, 69, 97, 125, 153,
+    181, 209, 237, 265, 293, 321, 349, 376, 403, 430, 457, 484, 511, 538, 565, 592,
+    619, 646, 14, 42, 70, 98, 126, 154, 182, 210, 238, 266, 294, 322, 350, 377, 404,
+    431, 458, 485, 512, 539, 566, 593, 620, 647, 15, 43, 71, 99, 127, 155, 183, 211,
+    239, 267, 295, 323, 351, 378, 405, 432, 459, 486, 513, 540, 567, 594, 621, 648,
+    16, 44, 72, 100, 128, 156, 184, 212, 240, 268, 296, 324, 352, 379, 406, 433, 460,
+    487, 514, 541, 568, 595, 622, 649, 17, 45, 73, 101, 129, 157, 185, 213, 241, 269,
+    297, 325, 353, 380, 407, 434, 461, 488, 515, 542, 569, 596, 623, 650, 18, 46, 74,
+    102, 130, 158, 186, 214, 242, 270, 298, 326, 354, 381, 408, 435, 462, 489, 516,
+    543, 570, 597, 624, 651, 19, 47, 75, 103, 131, 159, 187, 215, 243, 271, 299, 327,
+    355, 382, 409, 436, 463, 490, 517, 544, 571, 598, 625, 652, 20, 48, 76, 104, 132,
+    160, 188, 216, 244, 272, 300, 328, 356, 383, 410, 437, 464, 491, 518, 545, 572,
+    599, 626, 653, 21, 49, 77, 105, 133, 161, 189, 217, 245, 273, 301, 329, 357, 384,
+    411, 438, 465, 492, 519, 546, 573, 600, 627, 654, 22, 50, 78, 106, 134, 162, 190,
+    218, 246, 274, 302, 330, 358, 385, 412, 439, 466, 493, 520, 547, 574, 601, 628,
+    655, 23, 51, 79, 107, 135, 163, 191, 219, 247, 275, 303, 331, 359, 386, 413, 440,
+    467, 494, 521, 548, 575, 602, 629, 656, 24, 52, 80, 108, 136, 164, 192, 220, 248,
+    276, 304, 332, 360, 387, 414, 441, 468, 495, 522, 549, 576, 603, 630, 657, 25, 53,
+    81, 109, 137, 165, 193, 221, 249, 277, 305, 333, 361, 388, 415, 442, 469, 496, 523,
+    550, 577, 604, 631, 658, 26, 54, 82, 110, 138, 166, 194, 222, 250, 278, 306, 334,
+    362, 389, 416, 443, 470, 497, 524, 551, 578, 605, 632, 659, 27, 55, 83, 111, 139,
+    167, 195, 223, 251, 279, 307, 335
+};
+
+static const unsigned short ccittTab[] = {
+    0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,
+    0x8c48, 0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7,
+    0x1081, 0x0108, 0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e,
+    0x9cc9, 0x8d40, 0xbfdb, 0xae52, 0xdaed, 0xcb64, 0xf9ff, 0xe876,
+    0x2102, 0x308b, 0x0210, 0x1399, 0x6726, 0x76af, 0x4434, 0x55bd,
+    0xad4a, 0xbcc3, 0x8e58, 0x9fd1, 0xeb6e, 0xfae7, 0xc87c, 0xd9f5,
+    0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e, 0x54b5, 0x453c,
+    0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd, 0xc974,
+    0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9, 0x2732, 0x36bb,
+    0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3,
+    0x5285, 0x430c, 0x7197, 0x601e, 0x14a1, 0x0528, 0x37b3, 0x263a,
+    0xdecd, 0xcf44, 0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72,
+    0x6306, 0x728f, 0x4014, 0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9,
+    0xef4e, 0xfec7, 0xcc5c, 0xddd5, 0xa96a, 0xb8e3, 0x8a78, 0x9bf1,
+    0x7387, 0x620e, 0x5095, 0x411c, 0x35a3, 0x242a, 0x16b1, 0x0738,
+    0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862, 0x9af9, 0x8b70,
+    0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e, 0xf0b7,
+    0x0840, 0x19c9, 0x2b52, 0x3adb, 0x4e64, 0x5fed, 0x6d76, 0x7cff,
+    0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036,
+    0x18c1, 0x0948, 0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e,
+    0xa50a, 0xb483, 0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5,
+    0x2942, 0x38cb, 0x0a50, 0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd,
+    0xb58b, 0xa402, 0x9699, 0x8710, 0xf3af, 0xe226, 0xd0bd, 0xc134,
+    0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7, 0x6e6e, 0x5cf5, 0x4d7c,
+    0xc60c, 0xd785, 0xe51e, 0xf497, 0x8028, 0x91a1, 0xa33a, 0xb2b3,
+    0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72, 0x3efb,
+    0xd68d, 0xc704, 0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232,
+    0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a,
+    0xe70e, 0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1,
+    0x6b46, 0x7acf, 0x4854, 0x59dd, 0x2d62, 0x3ceb, 0x0e70, 0x1ff9,
+    0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330,
+    0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
+};
+
+void icom_byteToBits( unsigned char byte, BOOL * bits ) {
+    unsigned char mask = 0x01;
+    uint32 i = 0;
+
+    for ( i = 0 ; i < 8 ; i++, mask <<= 1 ) {
+        bits[i] = ( byte & mask ) ? TRUE : FALSE;
+    }
+}
+
+void dstar_scramble( BOOL * in, BOOL * out, uint32 length, uint32 * scramble_count ) {
+    if ( out == NULL || in == NULL || scramble_count == NULL ) {
+        output( "Null inOut pointer\n" );
+        return;
+    }
+
+    uint32 i = 0;
+
+    for ( i = 0 ; i < length ; i++ ) {
+        out[i] = in[i] ^ SCRAMBLER_TABLE_BITS[( *scramble_count )++];
+
+        if ( *scramble_count >= SCRAMBLER_TABLE_BITS_LENGTH )
+            *scramble_count = 0U;
+    }
+}
+
+
+void dstar_interleave( const BOOL * in, BOOL * out, unsigned int length ) {
+    if ( in == NULL || out == NULL ) {
+        output( ANSI_RED "Null in or out in interleave\n" ANSI_WHITE );
+        return;
+    }
+
+    if ( length != FEC_SECTION_LENGTH_BITS ) {
+        output( ANSI_RED "Wrong leangth in interleave\n" ANSI_WHITE );
+    }
+
+    memset( out, 0, FEC_SECTION_LENGTH_BITS * sizeof( BOOL ) );
+    uint32 i = 0;
+
+    for ( i = 0 ; i < FEC_SECTION_LENGTH_BITS ; i++ ) {
+        if ( in[i] ) {
+            unsigned int newi = INTERLEAVE_TABLE[i];
+
+            if ( newi >= FEC_SECTION_LENGTH_BITS ) {
+                output( ANSI_RED "Out of range index interleave\n" ANSI_WHITE );
+            }
+
+            out[newi] = TRUE;
+        }
+
+    }
+}
+
+void dstar_deinterleave( const BOOL * in, BOOL * out, unsigned int length ) {
+
+    memset( out, 0, FEC_SECTION_LENGTH_BITS * sizeof( BOOL ) );
+
+    uint32 k = 0;
+    uint32 i = 0;
+
+    for ( i = 0 ; i < length ; i++ ) {
+        if ( k >=  FEC_SECTION_LENGTH_BITS ) {
+            output( ANSI_RED "k greater than FEC_SECTION_LENGTH_BITS - deinterleave\n" ANSI_WHITE );
+        }
+
+        if ( in[i] )
+            out[k] = TRUE;
+        else
+            out[k] = FALSE;
+
+        k += 24U;
+
+        if ( k >= 672U )
+            k -= 671U;
+        else if ( k >= 660U )
+            k -= 647U;
+    }
+}
+
+
+/****** FEC DECOE ************/
+
+enum FEC_STATE {
+    S0,
+    S1,
+    S2,
+    S3
+};
+
+
+void dstar_FECacs( DSTAR_FEC fec, unsigned int n, int * metric ) {
+    //output("ACS\n");
+    int tempMetric[4];
+
+    // Pres. state = S0, Prev. state = S0 & S2
+    int m1 = metric[0] + fec->metric[0];
+    int m2 = metric[4] + fec->metric[2];
+
+    if ( m1 < m2 ) {
+        fec->mem0[n] = FALSE;
+        tempMetric[0]    = m1;
+    } else {
+        fec->mem0[n] = TRUE;
+        tempMetric[0]    = m2;
+    }
+
+    // Pres. state = S1, Prev. state = S0 & S2
+    m1 = metric[1] + fec->metric[0];
+    m2 = metric[5] + fec->metric[2];
+
+    if ( m1 < m2 ) {
+        fec->mem1[n] = FALSE;
+        tempMetric[1]    = m1;
+    } else {
+        fec->mem1[n] = TRUE;
+        tempMetric[1]    = m2;
+    }
+
+    // Pres. state = S2, Prev. state = S2 & S3
+    m1 = metric[2] + fec->metric[1];
+    m2 = metric[6] + fec->metric[3];
+
+    if ( m1 < m2 ) {
+        fec->mem2[n] = FALSE;
+        tempMetric[2]    = m1;
+    } else {
+        fec->mem2[n] = TRUE;
+        tempMetric[2]    = m2;
+    }
+
+    // Pres. state = S3, Prev. state = S1 & S3
+    m1 = metric[3] + fec->metric[1];
+    m2 = metric[7] + fec->metric[3];
+
+    if ( m1 < m2 ) {
+        fec->mem3[n] = FALSE;
+        tempMetric[3]    = m1;
+    } else {
+        fec->mem3[n] = TRUE;
+        tempMetric[3]    = m2;
+    }
+
+    uint32 i = 0;
+
+    for ( i = 0 ; i < 4 ; i++ )
+        fec->metric[i] = tempMetric[i];
+}
+
+
+void dstar_FECtraceBack( DSTAR_FEC fec, BOOL * out, unsigned int * length ) {
+    //output("traceBack\n");
+    // Start from the S0, t=31
+    enum FEC_STATE state = S0;
+
+    *length = 0U;
+    int i = 0;
+
+    for ( i = 329 ; i >= 0 ; i--, ( *length )++ ) {
+        switch ( state ) {
+        case S0: // if state = S0
+
+            //output("i = %d\n");
+            if ( fec->mem0[i] )
+                state = S2;             // lower path
+            else
+                state = S0;             // upper path
+
+            out[i] = FALSE;
+            break;
+
+        case S1: // if state = S1
+            if ( fec->mem1[i] )
+                state = S2;             // lower path
+            else
+                state = S0;             // upper path
+
+            out[i] = TRUE;
+            break;
+
+        case S2: // if state = S2
+            if ( fec->mem2[i] )
+                state = S3;             // lower path
+            else
+                state = S1;             // upper path
+
+            out[i] = FALSE;
+            break;
+
+        case S3: // if state = S3
+            if ( fec->mem3[i] )
+                state = S3;             // lower path
+            else
+                state = S1;             // upper path
+
+            out[i] = TRUE;
+            break;
+        }
+    }
+}
+
+
+void dstar_FECviterbiDecode( DSTAR_FEC fec, unsigned int n, int * data ) {
+    //output("ViterbiDecode\n");
+    int metric[8];
+
+    metric[0] = ( data[1] ^ 0 ) + ( data[0] ^ 0 );
+    metric[1] = ( data[1] ^ 1 ) + ( data[0] ^ 1 );
+    metric[2] = ( data[1] ^ 1 ) + ( data[0] ^ 0 );
+    metric[3] = ( data[1] ^ 0 ) + ( data[0] ^ 1 );
+    metric[4] = ( data[1] ^ 1 ) + ( data[0] ^ 1 );
+    metric[5] = ( data[1] ^ 0 ) + ( data[0] ^ 0 );
+    metric[6] = ( data[1] ^ 0 ) + ( data[0] ^ 1 );
+    metric[7] = ( data[1] ^ 1 ) + ( data[0] ^ 0 );
+
+    dstar_FECacs( fec, n, metric );
+}
+
+
+BOOL dstar_FECdecode( DSTAR_FEC fec, const BOOL * in, BOOL * out, unsigned int inLen, unsigned int * outLen ) {
+    if ( in == NULL || out == NULL ) {
+        output( ANSI_RED "NULL in or out in FECDecode\n" ANSI_WHITE );
+        return FALSE;
+    }
+
+    uint32 i = 0;
+
+    for ( i = 0U; i < 4U; i++ )
+        fec->metric[i] = 0;
+
+    unsigned int n = 0U;
+
+    for ( i = 0U; i < FEC_SECTION_LENGTH_BITS; i += 2U, n++ ) {
+        int data[2];
+
+        if ( in[i + 0U] )
+            data[1] = 1;
+        else
+            data[1] = 0;
+
+        if ( in[i + 1U] )
+            data[0] = 1;
+        else
+            data[0] = 0;
+
+        dstar_FECviterbiDecode( fec, n, data );
+    }
+
+    dstar_FECtraceBack( fec, out, outLen );
+
+    // Swap endian-ness
+    for ( i = 0U; i < RADIO_HEADER_LENGTH_BITS; i += 8U ) {
+        BOOL temp;
+        temp = out[i + 0U];
+        out[i + 0U] = out[i + 7U];
+        out[i + 7U] = temp;
+        temp = out[i + 1U];
+        out[i + 1U] = out[i + 6U];
+        out[i + 6U] = temp;
+        temp = out[i + 2U];
+        out[i + 2U] = out[i + 5U];
+        out[i + 5U] = temp;
+        temp = out[i + 3U];
+        out[i + 3U] = out[i + 4U];
+        out[i + 4U] = temp;
+    }
+
+    return TRUE;
+}
+
+
+void dstar_FECencode( const BOOL * in, BOOL * out, unsigned int inLen, unsigned int * outLen ) {
+
+    *outLen = 0U;
+    int d1 = 0;
+    int d2 = 0;
+    uint32 i = 0;
+    int32 j = 0;
+
+    for ( i = 0U; i < 42U; i++ ) {
+        for ( j = 7; j >= 0; j-- ) {
+            int d = in[i * 8U + j] ? 1 : 0;
+
+            int g0 = ( d + d2 ) % 2;
+            int g1 = ( d + d1 + d2 ) % 2;
+
+            d2 = d1;
+            d1 = d;
+
+            out[( *outLen )++] = g1 == 1;
+            out[( *outLen )++] = g0 == 1;
+        }
+    }
+}
+
+
+void dstar_createTestHeader( DSTAR_HEADER header ) {
+    strcpy( header->departure_rptr, "DIRECT  " );
+    strcpy( header->destination_rptr, "DIRECT  " );
+    strcpy( header->companion_call, "CQCQCQ  " );
+    strcpy( header->own_call1, "CALLSIGN" );
+    strcpy( header->own_call2, "    " );
+}
+
+DSTAR_MACHINE dstar_createMachine( void ) {
+    DSTAR_MACHINE machine = safe_malloc( sizeof( dstar_machine ) );
+    memset( machine, 0, sizeof( dstar_machine ) );
+
+    machine->rx_state = BIT_FRAME_SYNC;
+    machine->tx_state = BIT_FRAME_SYNC;
+
+    BOOL syn_bits[15 + 4] = {0};
+    uint32 i = 0;
+
+    syn_bits[0] = TRUE;
+    syn_bits[1] = FALSE;
+    syn_bits[2] = TRUE;
+    syn_bits[3] = FALSE;
+
+
+    BOOL frame_bits[] = {TRUE, TRUE,  TRUE, FALSE, TRUE,  TRUE,  FALSE, FALSE,
+                         TRUE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE
+                        };
+
+    for ( i = 4 ; i < 15 + 4 ; i++ ) {
+        syn_bits[i] = frame_bits[i - 4];
+    }
+
+    machine->syn_pm = bitPM_create( syn_bits, 15 + 4 );
+    machine->data_sync_pm = bitPM_create( DATA_SYNC_BITS, 24 );
+    machine->end_pm = bitPM_create( END_PATTERN_BITS, END_PATTERN_LENGTH_BITS );
+
+
+    dstar_createTestHeader( &( machine->outgoing_header ) );
+
+    machine->slow_decoder = safe_malloc(sizeof(slow_data_decoder));
+    machine->slow_encoder = safe_malloc(sizeof(slow_data_encoder));
+
+    machine->slice = 0;
+
+    return machine;
+}
+
+void dstar_destroyMachine( DSTAR_MACHINE machine ) {
+    bitPM_destroy( machine->syn_pm );
+    bitPM_destroy( machine->data_sync_pm );
+    bitPM_destroy( machine->end_pm );
+
+    safe_free(machine->slow_decoder);
+    safe_free(machine->slow_encoder);
+
+    safe_free( machine );
+}
+
+void dstar_dumpHeader( DSTAR_HEADER header ) {
+    output( "HEADER:\n" );
+    output( "Flag1: 0x%08X\n", header->flag1 );
+    output( "Flag2: 0x%08X\n", header->flag2 );
+    output( "Flag3: 0x%08X\n", header->flag3 );
+    output( "Destination RPTR: '%s'\n", header->destination_rptr );
+    output( "Departure RPTR: '%s'\n", header->departure_rptr );
+    output( "Companion Call: '%s'\n", header->companion_call );
+    output( "Own Call 1: '%s'\n", header->own_call1 );
+    output( "Own Call 2: '%s'\n", header->own_call2 );
+}
+
+void dstar_headerToBytes( DSTAR_HEADER header, unsigned char * bytes ) {
+    memset( bytes, 0, 39 * sizeof( unsigned char ) );
+
+    bytes[0] = header->flag1;
+    bytes[1] = header->flag2;
+    bytes[2] = header->flag3;
+
+    memcpy( &bytes[3], header->destination_rptr, 8 );
+    memcpy( &bytes[3 + 8], header->departure_rptr, 8 );
+    memcpy( &bytes[3 + 8 + 8], header->companion_call, 8 );
+    memcpy( &bytes[3 + 8 + 8 + 8], header->own_call1, 8 );
+    memcpy( &bytes[3 + 8 + 8 + 8 + 8], header->own_call2, 4 );
+}
+
+void dstar_processHeader( unsigned char * bytes, DSTAR_HEADER header ) {
+    /* Takes in an array of bytes and parses out each header field */
+    memset( header, 0, sizeof( dstar_header ) );
+
+    header->flag1 = bytes[0];
+    header->flag2 = bytes[1];
+    header->flag3 = bytes[2];
+
+    memcpy( header->destination_rptr, &bytes[3], 8 );
+    memcpy( header->departure_rptr, &bytes[3 + 8], 8 );
+    memcpy( header->companion_call, &bytes[3 + 8 + 8], 8 );
+    memcpy( header->own_call1, &bytes[3 + 8 + 8 + 8], 8 );
+    memcpy( header->own_call2, &bytes[3 + 8 + 8 + 8 + 8], 4 );
+
+    dstar_dumpHeader( header );
+}
+
+static unsigned char icom_bitsToByte( const BOOL * bits ) {
+    uint32 l = 0;
+
+    unsigned char val = 0x00;
+
+    for ( l = 0 ; l < 8 ; l++ ) {
+        val >>= 1;
+
+        if ( bits[l] ) {
+            val |= 0x80;
+        }
+    }
+
+    return val;
+}
+
+void dstar_updateStatus( DSTAR_MACHINE machine, uint32 slice,  enum STATUS_TYPE type ) {
+    if ( machine == NULL ) {
+        output( ANSI_RED "NULL dStar machine %d\n" ANSI_WHITE, __LINE__ );
+        return;
+    }
+
+    char status[200] = {0};
+    char header_string[256] = {0};
+	char message_string[21];
+
+
+    /* Make copy to replace spaces with special char */
+    dstar_header h;
+
+    switch ( type ) {
+
+    case STATUS_RX:
+        memcpy( &h, &( machine->incoming_header ), sizeof( dstar_header ) );
+
+        charReplace( ( char * )h.destination_rptr, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.departure_rptr, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.companion_call, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.own_call1, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.own_call2, ' ', ( char ) 0x7F );
+
+        sprintf( header_string, "destination_rptr_rx=%s departure_rptr_rx=%s companion_call_rx=%s own_call1_rx=%s own_call2_rx=%s",
+                 h.destination_rptr, h.departure_rptr, h.companion_call, h.own_call1, h.own_call2 );
+
+        sprintf( status, "waveform status slice=%d %s", slice, header_string );
+
+        tc_sendSmartSDRcommand( status, FALSE, NULL );
+        break;
+
+    case STATUS_TX:
+
+        memcpy( &h, &( machine->outgoing_header ), sizeof( dstar_header ) );
+
+        charReplace( ( char * )h.destination_rptr, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.departure_rptr, ' ', ( char ) 0x7F );
+		charReplace((char *) h.companion_call, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.own_call1, ' ', ( char ) 0x7F );
+        charReplace( ( char * )h.own_call2, ' ', ( char ) 0x7F );
+
+        sprintf( header_string, "destination_rptr_tx=%s departure_rptr_tx=%s companion_call_tx=%s own_call1_tx=%s own_call2_tx=%s",
+                 h.destination_rptr, h.departure_rptr, h.companion_call, h.own_call1, h.own_call2 );
+
+        if (machine->slow_encoder != NULL && machine->slow_encoder->message[0] != 0)
+        {
+            memcpy( message_string, machine->slow_encoder->message, sizeof( message_string ) );
+            message_string[sizeof( message_string ) - 1] = 0;
+            charReplace( message_string, ' ', ( char ) 0x7F );
+		sprintf( header_string + strlen(header_string), " message_tx=%s", message_string);
+        }
+
+        sprintf( status, "waveform status slice=%d %s", slice, header_string );
+
+        tc_sendSmartSDRcommand( status, FALSE, NULL );
+        break;
+    case STATUS_SLOW_DATA_MESSAGE:
+        memcpy( message_string, machine->slow_decoder->message_string, sizeof( message_string ) );
+        message_string[sizeof( message_string ) - 1] = 0;
+        charReplace( message_string, ' ', ( char ) 0x7F );
+        sprintf( status, "waveform status slice=%d message=%s", slice, message_string);
+        tc_sendSmartSDRcommand( status, FALSE, NULL );
+        break;
+    case STATUS_END_RX:
+    {
+        char msg[64];
+        sprintf( msg, "waveform status slice=%d RX=END", machine->slice);
+        tc_sendSmartSDRcommand( msg, FALSE, NULL );
+    }
+        break;
+
+    }
+}
+
+void dstar_txStateMachine( DSTAR_MACHINE machine, GMSK_MOD gmsk_mod, Circular_Float_Buffer tx_cb, unsigned char * mod_audio)
+{
+    uint32 i = 0;
+    uint32 j = 0;
+    float buf[DSTAR_RADIO_BIT_LENGTH];
+    dstar_pfcs pfcs;
+#ifdef DUMP_GMSK_MOD
+    static FILE * dump_file = NULL;
+
+    if ( dump_file == NULL ) {
+        dump_file = fopen("/tmp/gmsk_encoding.dat", "w");
+    }
+#endif
+
+    switch ( machine->tx_state ) {
+    case BIT_FRAME_SYNC:
+        /* Create Sync */
+        for ( i = 0 ; i < 64 * 5; i += 2 ) {
+            gmsk_encode( gmsk_mod, TRUE, buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+
+            gmsk_encode( gmsk_mod, FALSE, buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+        }
+
+        for ( i = 0 ; i < FRAME_SYNC_LENGTH_BITS ; i++ ) {
+            gmsk_encode( gmsk_mod, FRAME_SYNC_BITS[i], buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+        }
+        break;
+    case HEADER_PROCESSING:
+
+        pfcs.crc16 = 0xFFFF;
+
+        unsigned char header_bytes[RADIO_HEADER_LENGTH_BITS] = {0};
+        dstar_headerToBytes( &( machine->outgoing_header ), header_bytes );
+        dstar_pfcsUpdateBuffer( &pfcs, header_bytes, 312 / 8 );
+        dstar_pfcsResult( &pfcs, header_bytes + 312 / 8 );
+
+        output( "Main: PFCS Bytes: 0x%08X 0x%08X\n", *( header_bytes + 312 / 8 ), *( header_bytes + 320 / 8 ) );
+
+        BOOL bits[FEC_SECTION_LENGTH_BITS] = {0};
+
+        gmsk_bytesToBits( header_bytes, bits, 328 );
+        BOOL encoded[RADIO_HEADER_LENGTH_BITS * 2] = {0};
+        BOOL interleaved[RADIO_HEADER_LENGTH_BITS * 2] = {0};
+        BOOL scrambled[RADIO_HEADER_LENGTH_BITS * 2] = {0};
+        uint32 outLen = 0;
+        dstar_FECencode( bits, encoded, RADIO_HEADER_LENGTH_BITS, &outLen );
+        //output("Encode outLen = %d\n", outLen);
+
+        outLen = FEC_SECTION_LENGTH_BITS;
+        dstar_interleave( encoded, interleaved, outLen );
+
+        uint32 count = 0;
+        dstar_scramble( interleaved, scrambled, outLen, &count );
+        //output( "Count = %d\n", count );
+
+        for ( i = 0 ; i < count ; i++ ) {
+            gmsk_encode( gmsk_mod, scrambled[i], buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+        }
+        break;
+    case VOICE_FRAME:
+    {
+        BOOL bits[8] = {0} ;
+        uint32 k = 0;
+
+        for ( i = 0 ; i < VOICE_FRAME_LENGTH_BYTES ; i++ ) {
+            icom_byteToBits( mod_audio[i], bits );
+
+            for ( j = 0 ; j < 8 ; j++ ) {
+                gmsk_encode( gmsk_mod, bits[j], buf, DSTAR_RADIO_BIT_LENGTH );
+
+                for ( k = 0 ; k < DSTAR_RADIO_BIT_LENGTH ; k++ ) {
+                    cbWriteFloat( tx_cb, buf[k] );
+#ifdef DUMP_GMSK_MOD
+                    fprintf(dump_file, "%6.6f\n", buf[k]);
+#endif
+                }
+            }
+        }
+        break;
+    }
+    case DATA_FRAME:
+    {
+        unsigned char encode_bytes[SLOW_DATA_PACKET_LEN_BYTES] = {0};
+        BOOL encode_bits[DATA_FRAME_LENGTH_BITS] = {0};
+        BOOL encode_bits_scrambled[DATA_FRAME_LENGTH_BITS] = {0};
+        unsigned char encode_bytes_scrambled[SLOW_DATA_PACKET_LEN_BYTES] = {0};
+        uint32 count = 0;
+        float data_buf[DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH ] = {0};
+
+        slow_data_getEncodeBytes(machine, encode_bytes, SLOW_DATA_PACKET_LEN_BYTES);
+
+        for ( i = 0, j = 0 ; i < SLOW_DATA_PACKET_LEN_BYTES ; i++, j += 8 ) {
+            icom_byteToBits( encode_bytes[i], encode_bits + j);
+        }
+
+        dstar_scramble(encode_bits, encode_bits_scrambled, DATA_FRAME_LENGTH_BITS, &count);
+
+
+        gmsk_bitsToBytes(encode_bits_scrambled, encode_bytes_scrambled, DATA_FRAME_LENGTH_BITS);
+
+        gmsk_encodeBuffer(gmsk_mod, encode_bytes_scrambled, DATA_FRAME_LENGTH_BITS, data_buf, DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH);
+
+        for ( i = 0 ; i < DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH ; i++ ) {
+            cbWriteFloat(tx_cb, data_buf[i]);
+#ifdef DUMP_GMSK_MOD
+            fprintf(dump_file, "%6.6f\n", data_buf[i]);
+#endif
+        }
+
+        break;
+    }
+    case DATA_SYNC_FRAME:
+    {
+        /* Sync Bits */
+        unsigned char sync_bytes[3] = {0};
+        float sync_buf[DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH] = {0};
+        memcpy( sync_bytes, DATA_SYNC_BYTES, 3 );
+        gmsk_encodeBuffer( gmsk_mod, sync_bytes, DATA_FRAME_LENGTH_BITS, sync_buf, DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH );
+
+        for ( i = 0 ; i < DATA_FRAME_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH ; i++ ) {
+            cbWriteFloat( tx_cb, sync_buf[i] );
+#ifdef DUMP_GMSK_MOD
+            fprintf(dump_file, "%6.6f\n", sync_buf[i]);
+#endif
+        }
+
+        break;
+    }
+    case END_PATTERN:
+    {
+        float end_buf[END_PATTERN_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH] = {0.0};
+        unsigned char end_bytes[END_PATTERN_LENGTH_BYTES] = {0};
+        memcpy( end_bytes, END_PATTERN_BYTES, END_PATTERN_LENGTH_BYTES * sizeof( unsigned char ) );
+        gmsk_encodeBuffer( gmsk_mod, end_bytes, END_PATTERN_LENGTH_BITS, end_buf, END_PATTERN_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH );
+
+        for ( i = 0 ; i < END_PATTERN_LENGTH_BITS * DSTAR_RADIO_BIT_LENGTH ; i++ ) {
+            cbWriteFloat( tx_cb, end_buf[i] );
+#ifdef DUMP_GMSK_MOD
+            fprintf(dump_file, "%6.6f\n", end_buf[i]);
+#endif
+        }
+
+        for ( i = 0 ; i <  22 ; i += 2 ) {
+            gmsk_encode( gmsk_mod, TRUE, buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+
+            gmsk_encode( gmsk_mod, FALSE, buf, DSTAR_RADIO_BIT_LENGTH );
+
+            for ( j = 0 ; j < DSTAR_RADIO_BIT_LENGTH ; j++ ) {
+                cbWriteFloat( tx_cb, buf[j] );
+#ifdef DUMP_GMSK_MOD
+                fprintf(dump_file, "%6.6f\n", buf[j]);
+#endif
+            }
+        }
+
+#ifdef DUMP_GMSK_MOD
+      fclose(dump_file);
+      dump_file = NULL;
+#endif
+
+        slow_data_resetEncoder(machine);
+
+        break;
+    }
+    }
+}
+
+BOOL dstar_rxStateMachine( DSTAR_MACHINE machine, BOOL in_bit, unsigned char * ambe_out, uint32 ambe_buf_len ) {
+    BOOL have_audio_packet = FALSE;
+    BOOL found_syn_bits = FALSE;
+    BOOL found_end_bits = FALSE;
+    BOOL * header = machine->header;
+    BOOL * voice_bits = machine->voice_bits;
+    BOOL * data_bits = machine->data_bits;
+
+    unsigned char bytes[FEC_SECTION_LENGTH_BITS / 8 + 1];
+
+    switch ( machine->rx_state ) {
+    case BIT_FRAME_SYNC:
+        found_syn_bits = bitPM_addBit( machine->syn_pm, in_bit );
+        BOOL found_data_sync = bitPM_addBit( machine->data_sync_pm, in_bit );
+
+        machine->slow_decoder->decode_state = FIRST_FRAME;
+        machine->slow_decoder->header_array_index = 0;
+
+        if ( found_syn_bits ) {
+            output( "FOUND SYN BITS\n" );
+            bitPM_reset( machine->syn_pm );
+            bitPM_reset( machine->data_sync_pm );
+            machine->rx_state = HEADER_PROCESSING;
+            machine->bit_count = 0;
+        } else if ( found_data_sync ) {
+            output( "FOUND DATA SYNC BITS instead of header\n" );
+            bitPM_reset( machine->syn_pm );
+            bitPM_reset( machine->data_sync_pm );
+            machine->rx_state = VOICE_FRAME;
+            machine->bit_count = 0;
+            machine->frame_count++;
+        }
+        break;
+
+    case HEADER_PROCESSING:
+        header[machine->bit_count++] = in_bit;
+
+        if ( machine->bit_count == FEC_SECTION_LENGTH_BITS ) {
+            // output("Found 660 bits - descrambling\n");
+            /* Found 660 bits of header */
+
+//                gmsk_bitsToBytes(header, bytes, FEC_SECTION_LENGTH_BITS);
+//                thumbDV_dump("RAW:", bytes, FEC_SECTION_LENGTH_BITS/8);
+
+            uint32 scramble_count = 0;
+            BOOL descrambled[FEC_SECTION_LENGTH_BITS] = {0};
+            dstar_scramble( header, descrambled, FEC_SECTION_LENGTH_BITS, &scramble_count );
+//                gmsk_bitsToBytes(descrambled, bytes, FEC_SECTION_LENGTH_BITS);
+//                thumbDV_dump("DESCRAMBLE:", bytes, FEC_SECTION_LENGTH_BITS/8);
+
+            BOOL out[FEC_SECTION_LENGTH_BITS] = {0};
+            dstar_deinterleave( descrambled, out, FEC_SECTION_LENGTH_BITS );
+//                gmsk_bitsToBytes(out, bytes, FEC_SECTION_LENGTH_BITS);
+//                thumbDV_dump("DEINTERLEAVE:", bytes, FEC_SECTION_LENGTH_BITS/8);
+            dstar_fec fec;
+            memset( &fec, 0, sizeof( dstar_fec ) );
+            unsigned int outLen = FEC_SECTION_LENGTH_BITS;
+            BOOL decoded[RADIO_HEADER_LENGTH_BITS] = {0};
+            dstar_FECdecode( &fec, out, decoded, FEC_SECTION_LENGTH_BITS, &outLen );
+//                output("outLen = %d\n" ,outLen);
+            gmsk_bitsToBytes( decoded, bytes, outLen );
+//                thumbDV_dump("FEC: ", bytes, outLen/8);
+            uint32 i = 0;
+            dstar_pfcs pfcs;
+            pfcs.crc16 = 0xFFFF;
+
+            for ( i = 0 ; i < 312 ; i += 8 ) {
+                dstar_pfcsUpdate( &pfcs, decoded + i );
+            }
+
+            BOOL pfcs_match = FALSE;
+            pfcs_match = dstar_pfcsCheck( &pfcs, decoded + 312 );
+
+            if ( pfcs_match ) {
+                output( ANSI_GREEN "P_FCS Matches!\n" ANSI_WHITE );
+
+                dstar_processHeader( bytes, &machine->incoming_header );
+
+                dstar_updateStatus( machine, machine->slice, STATUS_RX );
+
+                machine->rx_state = VOICE_FRAME;
+                machine->bit_count = 0;
+                machine->frame_count = 0;
+
+
+            } else {
+                output( ANSI_RED "P_FCS Does Not Match!\n" ANSI_WHITE );
+
+                machine->rx_state = BIT_FRAME_SYNC;
+                machine->bit_count = 0;
+            }
+
+            /* STATE CHANGE */
+
+        }
+
+        break;
+
+    case VOICE_FRAME:
+        voice_bits[machine->bit_count++] = in_bit;
+
+        found_end_bits = bitPM_addBit( machine->end_pm, in_bit );
+
+        if ( found_end_bits ) {
+            machine->rx_state = END_PATTERN;
+            machine->bit_count = 0;
+        } else if ( machine->bit_count == VOICE_FRAME_LENGTH_BITS ) {
+            memset( bytes, 0, VOICE_FRAME_LENGTH_BYTES );
+            uint32 n = 0;
+            uint32 i = 0 ;
+
+            for ( i = 0, n = 0 ; i < VOICE_FRAME_LENGTH_BYTES ; i++, n += 8 ) {
+                bytes[i] = icom_bitsToByte( voice_bits + n );
+            }
+
+            //thumbDV_dump("ICOM Order: " , bytes, VOICE_FRAME_LENGTH_BITS / 8);
+            memcpy( ambe_out, bytes, VOICE_FRAME_LENGTH_BITS / 8 );
+            have_audio_packet = TRUE;
+
+            /* STATE CHANGE */
+            if ( machine->frame_count % 21 == 0 ) {
+                /* Expecting a SYNC FRAME */
+                machine->rx_state = DATA_SYNC_FRAME;
+            } else {
+                machine->rx_state = DATA_FRAME;
+            }
+
+            machine->bit_count = 0;
+        }
+
+        break;
+
+    case DATA_FRAME:
+        data_bits[machine->bit_count++] = in_bit;
+
+        found_end_bits = bitPM_addBit( machine->end_pm, in_bit );
+
+        if ( found_end_bits ) {
+            machine->rx_state = END_PATTERN;
+            machine->bit_count = 0;
+        } else if ( machine->bit_count == DATA_FRAME_LENGTH_BITS ) {
+
+            BOOL out[DATA_FRAME_LENGTH_BITS] = {0};
+            uint32 scramble_count = 0;
+            dstar_scramble( data_bits, out,  DATA_FRAME_LENGTH_BITS, &scramble_count );
+
+            uint32 i = 0 ;
+            uint32 n = 0;
+
+            for ( i = 0, n = 0  ; i < DATA_FRAME_LENGTH_BYTES ; i++, n += 8 ) {
+                bytes[i]  = icom_bitsToByte( out + n );
+            }
+
+            slow_data_addDecodeData(machine, bytes, DATA_FRAME_LENGTH_BYTES);
+
+            machine->frame_count++;
+
+            /* STATE CHANGE */
+            machine->rx_state = VOICE_FRAME;
+            machine->bit_count = 0;
+        }
+
+        break;
+
+    case DATA_SYNC_FRAME: {
+        BOOL found_sync = FALSE;
+        found_sync = bitPM_addBit( machine->data_sync_pm, in_bit );
+        machine->bit_count++;
+
+        found_end_bits = bitPM_addBit( machine->end_pm, in_bit );
+
+        if ( found_sync ) {
+            output( "Found Sync\n" );
+
+            machine->frame_count++;
+
+            bitPM_reset( machine->data_sync_pm );
+            /* STATE CHANGE */
+            machine->rx_state = VOICE_FRAME;
+            machine->bit_count = 0;
+        } else if ( found_end_bits ) {
+            machine->rx_state = END_PATTERN;
+            machine->bit_count = 0;
+        } else if ( machine->bit_count > ( ( DATA_FRAME_LENGTH_BITS + VOICE_FRAME_LENGTH_BITS ) * 42 ) ) {
+            /* Function as a timeout if we don't find the sync bits */
+            output( "Could not find SYNC\n" );
+
+            bitPM_reset( machine->data_sync_pm );
+
+            dstar_updateStatus(machine, machine->slice, STATUS_END_RX);
+            /* STATE CHANGE */
+            machine->rx_state = BIT_FRAME_SYNC;
+            machine->bit_count = 0;
+        }
+
+        slow_data_resetDecoder(machine);
+
+        break;
+    }
+
+    case END_PATTERN:
+
+        output( "Found end pattern bits -- sending status update\n" );
+
+        dstar_updateStatus(machine, machine->slice, STATUS_END_RX);
+
+        bitPM_reset( machine->end_pm );
+        bitPM_reset( machine->syn_pm );
+
+        /* STATE CHANGE */
+        machine->rx_state = BIT_FRAME_SYNC;
+        machine->bit_count = 0;
+
+        break;
+
+    default:
+        output( ANSI_YELLOW "Unhandled rx_state - dstar_stateMachine. State = 0x%08X" ANSI_WHITE, machine->rx_state );
+        break;
+    }
+
+    return have_audio_packet;
+}
+
+void dstar_pfcsUpdateBuffer( DSTAR_PFCS pfcs, unsigned char * bytes, uint32 length ) {
+    uint32 i = 0;
+
+    for ( i = 0 ; i < length ; i++ ) {
+        pfcs->crc16 = ( uint16 )( pfcs->crc8[1] ) ^ ccittTab[pfcs->crc8[0] ^ bytes[i]];
+    }
+}
+
+void dstar_pfcsUpdate( DSTAR_PFCS pfcs, BOOL * bits ) {
+    unsigned char byte;
+    gmsk_bitsToByte( bits, &byte );
+
+    pfcs->crc16 = ( uint16 )pfcs->crc8[1] ^ ccittTab[ pfcs->crc8[0] ^ byte ];
+}
+
+void dstar_pfcsResult( DSTAR_PFCS pfcs, unsigned char * chksum ) {
+    pfcs->crc16 = ~ pfcs->crc16;
+
+    chksum[0] = pfcs->crc8[0];
+    chksum[1] = pfcs->crc8[1];
+
+}
+
+void dstar_pfcsResultBits( DSTAR_PFCS pfcs, BOOL * bits ) {
+    pfcs->crc16 = ~pfcs->crc16;
+
+    unsigned char mask = 0x80;
+    uint32 i = 0;
+
+    for ( i = 0 ; i < 8 ; i++, mask >>= 1 ) {
+        bits[i + 0] = ( pfcs->crc8[0] & mask ) ? TRUE : FALSE;
+    }
+
+    mask = 0x80;
+
+    for ( i = 0 ; i < 8 ; i++ , mask >>= 1 ) {
+        bits[i + 8] = ( pfcs->crc8[1] & mask ) ? TRUE : FALSE;
+    }
+}
+
+BOOL dstar_pfcsCheck( DSTAR_PFCS pfcs, BOOL * bits ) {
+    uint32 i = 0;
+    BOOL sum[16];
+    dstar_pfcsResultBits( pfcs, sum );
+
+    for ( i = 0 ; i < 16 ; i++ ) {
+        if ( sum[i] != bits[i] ) {
+            return FALSE;
+        }
+    }
+
+    return TRUE;
+}
+
+
+
+void dstar_FECTest( void ) {
+    unsigned char bytes[660 / 8] = {0};
+    BOOL test[330] = {0};
+    BOOL encoded[330 * 2] = {0};
+    BOOL interleaved[330 * 2] = {0};
+    BOOL deinterleaved[330 * 2] = {0};
+    BOOL scrambled[330 * 2] = {0};
+    BOOL descrambled[330 * 2] = {0};
+    BOOL decoded[330] = {0};
+    uint32 i = 0;
+
+    for ( i = 0 ; i < 327 - 1 ; i += 2 ) {
+        test[i] = TRUE;//(rand() & 0x01) ? TRUE:FALSE;
+        test[i + 1] = FALSE; //( rand() & 0x01 ) ? TRUE:FALSE ;
+    }
+
+    gmsk_bitsToBytes( test, bytes, 330 );
+    thumbDV_dump( "TEST FEC IN:", bytes, 330 / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+    uint32 outLen = 0;
+    dstar_FECencode( test, encoded, 300, &outLen );
+    output( "Encode outLen = %d\n", outLen );
+    outLen = 660;
+    gmsk_bitsToBytes( encoded, bytes, outLen );
+    thumbDV_dump( "TEST FEC ENCODE", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+    dstar_interleave( encoded, interleaved, outLen );
+    gmsk_bitsToBytes( interleaved, bytes, outLen );
+    thumbDV_dump( "TEST INTERLEAVE", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+    uint32 count = 0;
+    dstar_scramble( interleaved, scrambled, outLen, &count );
+    gmsk_bitsToBytes( scrambled, bytes, outLen );
+    thumbDV_dump( "TEST SCRAMBLE", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+    count = 0;
+    dstar_scramble( scrambled, descrambled, outLen, &count );
+    gmsk_bitsToBytes( descrambled, bytes, outLen );
+    thumbDV_dump( "TEST DE-SCRAMBLE", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+    dstar_deinterleave( descrambled, deinterleaved, outLen );
+    gmsk_bitsToBytes( deinterleaved, bytes, outLen );
+    thumbDV_dump( "TEST DE-INTELEAVE", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+
+
+    dstar_fec fec;
+    memset( &fec, 0, sizeof( dstar_fec ) );
+    output( "outLen = %d\n", outLen );
+    dstar_FECdecode( &fec, deinterleaved, decoded, outLen, &outLen );
+    output( "Decode outLen = %d\n", outLen );
+    gmsk_bitsToBytes( decoded, bytes, outLen );
+    thumbDV_dump( "TEST FEC Decode", bytes, outLen / 8 );
+    memset( bytes, 0, 660 / 8 * sizeof( unsigned char ) );
+}

--- a/third_party/smartsdr-dsp/ThumbDV/dstar.h
+++ b/third_party/smartsdr-dsp/ThumbDV/dstar.h
@@ -1,0 +1,161 @@
+///*!   \file dstar.h
+// *
+// *    Handles all DSTAR States
+// *
+// *    \date 02-JUN-2015
+// *    \author Ed Gonzalez KG5FBT modified from original in OpenDV code(C) 2009 Jonathan Naylor, G4KLX
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef THUMBDV_DSTAR_H_
+#define THUMBDV_DSTAR_H_
+
+#include "bit_pattern_matcher.h"
+#include "DStarDefines.h"
+#include "dstar.h"
+#include "gmsk_modem.h"
+#include "circular_buffer.h"
+
+enum _slow_data_decode_state {
+    FIRST_FRAME = 0,
+    HEADER_SECOND_FRAME,
+    MESSAGE_SECOND_FRAME
+};
+
+enum _slow_data_encode_state {
+    MESSAGE_TX = 0,
+    HEADER_TX
+};
+
+typedef struct _slow_data_decoder {
+    enum _slow_data_decode_state decode_state;
+    unsigned char header_bytes[RADIO_HEADER_LENGTH_BYTES];
+    uint32 header_array_index;
+    unsigned char message[4][5];
+    uint32 message_index;
+    char message_string[21];
+} slow_data_decoder, * SLOW_DATA_DECODER;
+
+
+typedef struct _slow_data_encoder {
+    enum _slow_data_encode_state encode_state;
+    unsigned char message_bytes[SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC];
+    uint32 message_index;
+    unsigned char header_bytes[SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC];
+    uint32 header_index;
+    char message[SLOW_DATA_MESSAGE_LENGTH_BYTES + 1];
+} slow_data_encoder, * SLOW_DATA_ENCODER;
+
+enum DSTAR_RX_STATE {
+    BIT_FRAME_SYNC = 0x1,
+    HEADER_PROCESSING,
+    VOICE_FRAME,
+    DATA_FRAME,
+    DATA_SYNC_FRAME,
+    END_PATTERN
+};
+
+enum STATUS_TYPE {
+    STATUS_RX = 0,
+    STATUS_TX,
+    STATUS_SLOW_DATA_MESSAGE,
+    STATUS_END_RX
+};
+
+typedef struct _dstar_header {
+    unsigned char flag1;
+    unsigned char flag2;
+    unsigned char flag3;
+    char destination_rptr[9];
+    char departure_rptr[9];
+    char companion_call[9];
+    char own_call1[9];
+    char own_call2[5];
+    uint16  p_fcs;
+} dstar_header, * DSTAR_HEADER;
+
+typedef struct _dstar_machine {
+    enum DSTAR_RX_STATE rx_state;
+    enum DSTAR_RX_STATE tx_state;
+    dstar_header incoming_header;
+    dstar_header outgoing_header;
+
+    uint32 bit_count;
+    uint32 frame_count;
+
+    /* BIT Pattern Matcher */
+    BIT_PM  syn_pm;
+    BIT_PM  data_sync_pm;
+    BIT_PM  end_pm;
+
+    /* Bit Buffers */
+    BOOL header[FEC_SECTION_LENGTH_BITS];
+    BOOL voice_bits[VOICE_FRAME_LENGTH_BITS];
+    BOOL data_bits[DATA_FRAME_LENGTH_BITS];
+
+    SLOW_DATA_DECODER slow_decoder;
+    SLOW_DATA_ENCODER slow_encoder;
+
+    uint32 slice;
+
+} dstar_machine, * DSTAR_MACHINE;
+
+typedef struct _dstar_fec {
+    BOOL mem0[RADIO_HEADER_LENGTH_BITS];
+    BOOL mem1[RADIO_HEADER_LENGTH_BITS];
+    BOOL mem2[RADIO_HEADER_LENGTH_BITS];
+    BOOL mem3[RADIO_HEADER_LENGTH_BITS];
+    int metric[4];
+} dstar_fec, * DSTAR_FEC;
+
+typedef union _dstar_pfcs {
+    uint16 crc16;
+    uint8 crc8[2];
+} dstar_pfcs, * DSTAR_PFCS;
+
+void icom_byteToBits( unsigned char byte, BOOL * bits );
+
+void dstar_updateStatus( DSTAR_MACHINE machine, uint32 slice , enum STATUS_TYPE type );
+DSTAR_MACHINE dstar_createMachine( void );
+void dstar_destroyMachine( DSTAR_MACHINE machine );
+BOOL dstar_rxStateMachine( DSTAR_MACHINE machine, BOOL in_bit, unsigned char * ambe_out, uint32 ambe_buf_len );
+void dstar_txStateMachine( DSTAR_MACHINE machine, GMSK_MOD gmsk_mod, Circular_Float_Buffer tx_cb, unsigned char * mod_audio);
+
+void dstar_dumpHeader( DSTAR_HEADER header );
+
+void dstar_processHeader( unsigned char * bytes, DSTAR_HEADER header );
+void dstar_pfcsUpdate( DSTAR_PFCS pfcs, BOOL * bits );
+BOOL dstar_pfcsCheck( DSTAR_PFCS pfcs, BOOL * bits );
+void dstar_pfcsResult( DSTAR_PFCS pfcs, unsigned char * chksum );
+void dstar_pfcsResultBits( DSTAR_PFCS pfcs, BOOL * bits );
+void dstar_pfcsUpdateBuffer( DSTAR_PFCS pfcs, unsigned char * bytes, uint32 length );
+void dstar_headerToBytes( DSTAR_HEADER header, unsigned char * bytes );
+
+void dstar_FECTest( void );
+void dstar_scramble( BOOL * in, BOOL * out, uint32 length, uint32 * scramble_count );
+void dstar_interleave( const BOOL * in, BOOL * out, unsigned int length );
+void dstar_deinterleave( const BOOL * in, BOOL * out, unsigned int length );
+BOOL dstar_FECdecode( DSTAR_FEC fec, const BOOL * in, BOOL * out, unsigned int inLen, unsigned int * outLen );
+void dstar_FECencode( const BOOL * in, BOOL * out, unsigned int inLen, unsigned int * outLen );
+
+#endif /* THUMBDV_DSTAR_H_ */

--- a/third_party/smartsdr-dsp/ThumbDV/gmsk_modem.c
+++ b/third_party/smartsdr-dsp/ThumbDV/gmsk_modem.c
@@ -1,0 +1,555 @@
+///*!   \file gmsk_modem.c
+// *    \date 02-JUN-2015
+// *    \author Ed Gonzalez KG5FBT
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "DStarDefines.h"
+#include "gmsk_modem.h"
+#include "bit_pattern_matcher.h"
+
+/* Filters */
+
+void gmsk_bitsToByte( BOOL * bits, unsigned char * byte ) {
+    if ( bits == NULL || byte == NULL ) {
+        output( ANSI_RED "NULL Pointer in bitsToByte\n" ANSI_WHITE );
+        return;
+    }
+
+    unsigned char new_byte = 0x0;
+    uint32 i = 0;
+
+    for ( i = 0 ; i < 8; i++ ) {
+        new_byte <<= 1;
+
+        if ( bits[i] ) {
+            new_byte |= 0x01;
+        }
+    }
+
+    *byte = new_byte;
+}
+
+void gmsk_bitsToBytes( BOOL * bits, unsigned char * bytes, uint32 num_of_bits ) {
+    if ( bits == NULL || bytes == NULL ) {
+        output( ANSI_RED "NULL Pointer in bitsToBytes\n" ANSI_WHITE );
+        return;
+    }
+
+    uint32 i = 0;
+
+    for ( i = 0 ; i < num_of_bits / 8 ; i++ ) {
+        gmsk_bitsToByte( &bits[i * 8], &bytes[i] );
+    }
+
+}
+
+void gmsk_byteToBits( unsigned char byte, BOOL * bits, uint32 num_bits ) {
+    if ( bits == NULL ) {
+        output( ANSI_RED "NULL Pointer in byteToBits\n" ANSI_WHITE );
+        return;
+    }
+
+    uint32 i = 0;
+    unsigned char mask = 0x80;
+
+    for ( i = 0; i < num_bits; i++ , mask >>= 1 ) {
+        bits[i] = ( byte & mask ) ? TRUE : FALSE;
+    }
+}
+
+void gmsk_bytesToBits( unsigned char * bytes, BOOL * bits, uint32 num_bits ) {
+    if ( bytes == NULL || bits == NULL ) {
+        output( ANSI_RED "NULL pointers in bytesToBits\n" ANSI_WHITE );
+        return;
+    }
+
+    int32 bits_left = num_bits;
+    uint32 byte_idx = 0;
+
+    while ( bits_left > 0 ) {
+        gmsk_byteToBits( bytes[byte_idx], &bits[byte_idx * 8], bits_left > 8 ? 8 : bits_left );
+        byte_idx++;
+        bits_left -= 8;
+    }
+
+//
+//    uint32 i = 0;
+//    output("Bytes: ");
+//    for ( i = 0 ; i < num_bits / 8U ; i++ ) {
+//        output(" 0x%02X", bytes[i]);
+//    }
+//    output("\nBits: ");
+//    for ( i = 0 ; i < num_bits ; i++ ) {
+//        output("%s ", bits[i] ? "1":"0");
+//        if ( (i+1) % 4 == 0 ) {
+//            output("   ");
+//        }
+//    }
+//    output("\n");
+
+}
+
+float gmsk_FilterProcessSingle( FIR_FILTER filter, float val ) {
+    if ( filter == NULL ) {
+        output( ANSI_RED "NULL FIlter object\n"ANSI_WHITE ) ;
+        return val;
+    }
+
+    float * ptr = filter->buffer + filter->pointer++;
+
+    *ptr = val;
+
+    float * a = ptr - filter->length;
+    float * b = filter->taps;
+
+    float out = 0.0F;
+    uint32 i = 0;
+
+    for ( i = 0U; i < filter->length; i++ )
+        out += ( *a++ ) * ( *b++ );
+
+    if ( filter->pointer == filter->buf_len ) {
+        memcpy( filter->buffer, filter->buffer + filter->buf_len - filter->length, filter->length * sizeof( float ) );
+        filter->pointer = filter->length;
+    }
+
+    return out;
+}
+
+void gmsk_FilterProcessBuffer( FIR_FILTER filter, float * buffer, uint32 buffer_len ) {
+    if ( filter == NULL ) {
+        output( ANSI_RED "NULL FIlter object\n"ANSI_WHITE ) ;
+        return;
+    }
+
+    uint32 i = 0;
+
+    for ( i = 0 ; i < buffer_len; i++ ) {
+        buffer[i] = gmsk_FilterProcessSingle( filter, buffer[i] );
+    }
+}
+
+/* Demod Section */
+
+#define PLLMAX  0x10000U
+#define PLLINC      ( PLLMAX / DSTAR_RADIO_BIT_LENGTH) // 2000
+#define INC  32U
+
+
+enum DEMOD_STATE gmsk_decode( GMSK_DEMOD demod, float val ) {
+    enum DEMOD_STATE state = DEMOD_UNKNOWN;
+
+    /* FIlter process */
+    float out = val;//gmsk_FilterProcessSingle(demod->filter, val);
+
+    BOOL bit = out > 0.0F;
+
+    if ( bit != demod->m_prev ) {
+        if ( demod->m_pll < ( PLLMAX / 2U ) ) {
+            demod->m_pll += PLLINC / INC;
+        } else {
+            demod->m_pll -= PLLINC / INC;
+        }
+    }
+
+    demod->m_prev = bit;
+
+    demod->m_pll += PLLINC;
+
+    if ( demod->m_pll >= PLLMAX ) {
+        if ( demod->m_invert )
+            state = bit ? DEMOD_TRUE : DEMOD_FALSE;
+        else
+            state = bit ? DEMOD_FALSE : DEMOD_TRUE;
+
+        demod->m_pll -= PLLMAX;
+    }
+
+    return state;
+}
+
+void gmskDemod_reset( GMSK_DEMOD demod ) {
+    demod->m_pll  = 0U;
+    demod->m_prev = FALSE;
+}
+
+void gmsk_decodeBuffer( GMSK_DEMOD demod, float * buffer, uint32 buf_len, unsigned char * bytes, uint32 num_bits ) {
+    if ( num_bits * DSTAR_RADIO_BIT_LENGTH != buf_len ) {
+        output( ANSI_RED "Mismatched buf_len to number of encoded bits. buf_len = %d, required %d\n" ANSI_WHITE, buf_len, num_bits * DSTAR_RADIO_BIT_LENGTH );
+        return;
+    }
+
+    BOOL bits[num_bits];
+    memset( bits, 0, num_bits * sizeof( BOOL ) );
+    uint32 i = 0;
+    uint32 bit = 0;
+    enum DEMOD_STATE state;
+
+    for ( i = 0; i < buf_len ; i++ ) {
+        state = gmsk_decode( demod, buffer[i] );
+
+        if ( state == DEMOD_TRUE ) {
+            bits[bit] = TRUE;
+            bit++;
+        } else if ( state == DEMOD_FALSE ) {
+            bits[bit] = FALSE;
+            bit++;
+        } else {
+            //output("UNKNOWN DEMOD STATE");
+            //bits[bit] = 0x00;
+        }
+    }
+
+    for ( i = 0; i < bit; i++ ) {
+        output( "%d", bits[i] ? 1 : 0 );
+
+        if ( ( i + 1 ) % 4 == 0 ) output( "  " );
+    }
+
+    output( "\n" );
+
+//    FILE * f = fopen("gmsk_demod.dat", "w");
+//    for ( i = 0 ; i < num_bits ; i++ ) {
+//        fprintf(f,"%d %d\n", i, bits[i]);
+//    }
+//    fclose(f);
+
+    for ( i = 0 ; i < num_bits / 8 ; i++ ) {
+        gmsk_bitsToByte( &bits[i * 8], &bytes[i] );
+    }
+}
+
+/* Mod Section */
+
+
+// Generated by
+// gaussfir(0.5, 4, 10)
+const float MOD_COEFFS_TABLE[] = {
+    1.01839713019626E-50, 6.78135172681677E-46, 2.55482745053591E-41,
+    5.44569202979357E-37, 6.56735934398859E-33, 4.48099730728277E-29,
+    1.72983542063190E-25, 3.77816645793944E-22, 4.66878194148063E-19,
+    3.26416641874238E-16, 1.29118120144693E-13, 2.88967031267069E-11,
+    3.65894261059669E-09, 2.62125395740380E-07, 1.06245073266054E-05,
+    2.43643428039816E-04, 3.16116236025481E-03, 2.32051886177988E-02,
+    9.63761566612470E-02, 2.26464589054118E-01, 3.01076739115701E-01,
+    2.26464589054118E-01, 9.63761566612468E-02, 2.32051886177989E-02,
+    3.16116236025481E-03, 2.43643428039816E-04, 1.06245073266054E-05,
+    2.62125395740378E-07, 3.65894261059672E-09, 2.88967031267069E-11,
+    1.29118120144693E-13, 3.26416641874238E-16, 4.66878194148056E-19,
+    3.77816645793952E-22, 1.72983542063190E-25, 4.48099730728277E-29,
+    6.56735934398859E-33, 5.44569202979341E-37, 2.55482745053598E-41,
+    6.78135172681677E-46, 1.01839713019626E-50
+};
+
+#define MOD_COEFFS_LENGTH 41U
+
+#define eiline(n) (iir->in_line[(n)])
+#define eoline(n) (iir->out_line[(n)])
+
+static float _process_iir_filter(IIR_FILTER iir, float sample)
+{
+
+    float * a = iir->a;
+    float * b = iir->b;
+    float N = 16.0f; // Scaling value for IIR Filter Realization
+    float N_IV = 1.0f / N;
+    float N_2 = N / 2.0f;
+
+    float local_out;
+    //Shift Input Line
+    eiline( 2) = eiline( 1);
+    eiline( 1) = eiline( 0);
+
+    eiline( 0) = sample;
+
+    eoline( 2) = eoline( 1);
+    eoline( 1) = eoline( 0);
+
+    local_out = 0.0f;
+
+
+    local_out = 2.0f * ((-a[1]*0.5f * eoline(
+                                1)) - (a[2]*0.5f * eoline( 2))
+                               + N_2 * ((b[0]*N_IV * eiline( 0)) + (b[1]*N_IV
+                                       * eiline( 1)) + (b[2]*N_IV * eiline( 2))));
+
+    eoline(0) = local_out;
+    return local_out;
+}
+
+uint32 gmsk_encode( GMSK_MOD mod, BOOL bit, float * buffer, unsigned int length ) {
+
+    if ( length != DSTAR_RADIO_BIT_LENGTH ) {
+        output( ANSI_RED "Length!= DSTAR_RADIO_BIT_LENGTH" ANSI_WHITE );
+    }
+
+    if ( mod->m_invert )
+        bit = !bit;
+
+    uint32 i = 0;
+
+    for ( i = 0; i < DSTAR_RADIO_BIT_LENGTH; i++ ) {
+        if ( bit ) {
+            buffer[i] = gmsk_FilterProcessSingle( mod->filter, -0.75f );
+        } else {
+            buffer[i] = gmsk_FilterProcessSingle( mod->filter, 0.75f );
+        }
+
+        buffer[i] = _process_iir_filter(mod->iir, buffer[i]);
+
+    }
+
+    return DSTAR_RADIO_BIT_LENGTH;
+}
+
+BOOL gmsk_encodeBuffer( GMSK_MOD mod, unsigned char * bytes, uint32 num_bits, float * buffer, uint32 buf_len ) {
+    if ( num_bits * DSTAR_RADIO_BIT_LENGTH != buf_len ) {
+        output( ANSI_RED "Mismatched buf_len to number of encoded bits. buf_len = %d, required %d\n" ANSI_WHITE, buf_len, num_bits * DSTAR_RADIO_BIT_LENGTH );
+        return FALSE;
+    }
+
+    uint32 i = 0;
+    float * idx = &buffer[0];
+
+    BOOL bits[num_bits];
+    memset( bits, 0, num_bits * sizeof( BOOL ) );
+
+    gmsk_bytesToBits( bytes, bits, num_bits );
+
+    for ( i = 0 ; i < num_bits ; i++, idx += DSTAR_RADIO_BIT_LENGTH ) {
+        gmsk_encode( mod, bits[i], idx, DSTAR_RADIO_BIT_LENGTH );
+    }
+
+    return TRUE;
+}
+
+
+/* Init */
+
+void gmsk_resetMODFilter( GMSK_MOD mod ) {
+    memset( mod->filter->buffer, 0, mod->filter->buf_len * sizeof( float ) );
+    mod->filter->pointer = mod->filter->length;
+}
+
+FIR_FILTER gmsk_createFilter( const float * taps, uint32 length ) {
+    FIR_FILTER filter = ( FIR_FILTER ) safe_malloc( sizeof( fir_filter ) );
+
+    filter->length = length;
+    filter->buf_len = 20 * length;
+    filter->taps = ( float * ) safe_malloc( length * sizeof( float ) );
+    memcpy( filter->taps, taps, length * sizeof( float ) );
+
+    filter->buffer = ( float * ) safe_malloc( filter->buf_len * sizeof( float ) );
+    filter->pointer = length;
+
+    return filter;
+}
+
+void gmsk_destroyFilter( FIR_FILTER filter ) {
+    if ( filter == NULL ) {
+        output( ANSI_RED "NULL FIlter object\n"ANSI_WHITE ) ;
+        return;
+    }
+
+    safe_free( filter->taps );
+    safe_free( filter->buffer );
+    safe_free( filter );
+
+}
+
+GMSK_DEMOD gmsk_createDemodulator( void ) {
+    GMSK_DEMOD demod = ( GMSK_DEMOD ) safe_malloc( sizeof( gmsk_demod ) );
+    demod->m_pll = 0;
+    demod->m_prev = FALSE;
+    demod->m_invert = FALSE;
+
+    return demod;
+}
+
+
+float convertVITAdbToFloat(VITAdb vita)
+{
+    int32 db = (int32)((int16)(vita & 0xFFFF));
+    return (float)db / 128.0;
+}
+// always assume the float is in dB (see the parameter name)
+VITAdb convertFloatToVITAdb(float db)
+{
+    return ((int32)(db * 128) & 0xFFFF);
+}
+
+GMSK_MOD gmsk_createModulator( void ) {
+    GMSK_MOD mod = ( GMSK_MOD ) safe_malloc( sizeof( gmsk_mod ) );
+    mod->m_invert = FALSE;
+
+    mod->filter = gmsk_createFilter( MOD_COEFFS_TABLE, MOD_COEFFS_LENGTH );
+
+
+    mod->iir = safe_malloc(sizeof(iir_filter));
+
+    IIR_FILTER filter = mod->iir;
+
+    float * a = filter->a;
+    float * b = filter->b;
+    uint32 freq_hz = 4800;
+    uint32 sample_rate_hz = 24000;
+    uint32 level = 10;
+    float q_level = 0.2;
+        float w0 = 2.0 * M_PI * freq_hz/
+                                      (float)sample_rate_hz;
+        VITAdb db_gain = convertFloatToVITAdb(level);
+        float q_factor;
+        if ( level > 0 ) {
+            q_factor = q_level;
+        } else {
+            q_factor = 4.0f * q_level;
+        }
+        float A = pow(10, convertVITAdbToFloat(db_gain) / 40);
+        float alpha = sin(w0) / (2 * A * q_factor);
+        //flex_printf(LOG_ALWAYS, "w0 = %lf, A = %lf, alpha = %lf", w0, A, alpha);
+
+        //float linearGain = pow(10,  convertVITAdbToFloat(db_gain) / 20);
+
+        if (level != 0 ) {
+            // Peaking EQ from AUDIO COOKBOOK
+            b[0] = 1 + alpha * A;
+            b[1] = -2 * cos(w0);
+            b[2] = 1 - alpha * A;
+
+            a[0] = 1 + alpha/A;
+            a[1] = -2 * cos(w0);
+            a[2] = 1 - alpha / A;
+        } else {
+            b[0] = 0;
+            b[1] = 0;
+            b[2] = 0;
+            a[0] = 1;
+            a[1] = 0;
+            a[2] = 0;
+        }
+
+        // Normalize by a[0] so that a[0] = 1
+        b[0] = b[0]  / a[0];
+        b[1] = b[1]  / a[0];
+        b[2] = b[2]  / a[0];
+
+        a[1] = a[1]  / a[0];
+        a[2] = a[2]  / a[0];
+        a[0] = a[0]  / a[0];
+
+
+    return mod;
+}
+
+void gmsk_destroyDemodulator( GMSK_DEMOD demod ) {
+    if ( demod == NULL ) {
+        output( ANSI_RED "NULL GMSK_DEMOD\n" ANSI_WHITE );
+        return;
+    }
+
+    safe_free( demod );
+}
+
+void gmsk_destroyModulator( GMSK_MOD mod ) {
+
+    if ( mod == NULL ) {
+        output( ANSI_RED "NULL GMSK_MOD\n" ANSI_WHITE );
+        return;
+    }
+
+    gmsk_destroyFilter( mod->filter );
+    safe_free(mod->iir);
+    safe_free( mod );
+
+}
+
+void gmsk_testBitsAndEncodeDecode( void ) {
+    GMSK_DEMOD _gmsk_demod = gmsk_createDemodulator();
+    GMSK_MOD _gmsk_mod = gmsk_createModulator();
+
+    unsigned char pattern[1] = {0xAA};
+    BOOL pattern_bits[8] = {0};
+    gmsk_bytesToBits( pattern, pattern_bits, 8 );
+
+    BIT_PM _bit_pm  = bitPM_create( pattern_bits, 8 );
+
+    float test_buffer[160 * 2];
+    unsigned char test_coded[8] =  {0xAA, 0xAA, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00};
+    unsigned char output_bytes[8] = {0};
+    uint32 i = 0;
+
+
+    BOOL bits[64] = {0};
+    gmsk_bytesToBits( test_coded, bits, 32 );
+    gmsk_byteToBits( 0xF0, bits, 8 );
+    output( "0xF0 = " );
+
+    for ( i = 0 ; i < 8; i++ ) {
+        output( "%d ", bits[i] );
+    }
+
+    output( "\n" );
+    unsigned char test[4] = {0xAA, 0xAA, 0xAA, 0xAA};
+    gmsk_bytesToBits( test, bits, 32 );
+
+    for ( i = 0 ; i < 32 / 8 ; i++ ) {
+        gmsk_bitsToByte( &bits[i * 8], &output_bytes[i] );
+        output( "Byte = 0x%02X\n", output_bytes[i] );
+    }
+
+    gmsk_encodeBuffer( _gmsk_mod, test_coded, 32 * 2, test_buffer, 160 * 2 );
+    FILE * dat = fopen( "gmsk.dat", "w" );
+
+    for ( i = 0 ; i < 160 * 2 ; i++ ) {
+        fprintf( dat, "%d %.12f\n", i, test_buffer[i] );
+        //output("%.12f,", test_buffer[i]);
+    }
+
+    fclose( dat );
+
+    gmsk_decodeBuffer( _gmsk_demod, test_buffer, 160 * 2, output_bytes, 32 * 2 );
+
+    gmsk_bytesToBits( output_bytes, bits, 32 * 2 );
+    output( "STARTING PATTERN MATCH TEST \n" );
+
+    for ( i = 0 ; i < 32 * 2; i++ ) {
+        output( "%d ", bits[i] );
+
+        if ( bitPM_addBit( _bit_pm, bits[i] ) ) {
+            output( "MATCH!\n" );
+            bitPM_reset( _bit_pm );
+        }
+
+    }
+
+    bitPM_destroy( _bit_pm );
+    gmsk_destroyDemodulator( _gmsk_demod );
+    gmsk_destroyModulator( _gmsk_mod );
+
+}

--- a/third_party/smartsdr-dsp/ThumbDV/gmsk_modem.h
+++ b/third_party/smartsdr-dsp/ThumbDV/gmsk_modem.h
@@ -1,0 +1,93 @@
+///*!   \file gmsk_modem.h
+// *    \date 02-JUN-2015
+// *    \author Ed Gonzalez KG5FBT
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef THUMBDV_GMSK_MODEM_H_
+#define THUMBDV_GMSK_MODEM_H_
+
+#include "common.h"
+
+enum DEMOD_STATE {
+    DEMOD_FALSE,
+    DEMOD_TRUE,
+    DEMOD_UNKNOWN
+};
+
+#define SC_EQ_MAX_DEPTH     3
+#define SC_EQ_FILTER_LEN    3
+
+typedef struct _iir_filter
+{
+    float in_line[SC_EQ_FILTER_LEN];
+    float out_line[SC_EQ_FILTER_LEN];
+    float a[SC_EQ_FILTER_LEN];
+    float b[SC_EQ_FILTER_LEN];
+} iir_filter, * IIR_FILTER;
+
+typedef struct _fir_filter {
+    float * taps;
+    uint32   length;
+    float  * buffer;
+    uint32   buf_len;
+    uint32   pointer;
+} fir_filter, * FIR_FILTER ;
+
+/* Used to hold state information for a GMSK Demodulator object */
+typedef struct _gmsk_demod {
+    uint32  m_pll;
+    BOOL    m_prev;
+    BOOL    m_invert;
+} gmsk_demod, * GMSK_DEMOD;
+
+typedef struct _gmsk_mod {
+    BOOL m_invert;
+
+    FIR_FILTER filter;
+    IIR_FILTER iir;
+} gmsk_mod, * GMSK_MOD;
+
+void gmsk_testBitsAndEncodeDecode( void );
+
+void gmsk_bitsToByte( BOOL * bits, unsigned char * byte );
+void gmsk_bitsToBytes( BOOL * bits, unsigned char * bytes, uint32 num_of_bits );
+void gmsk_byteToBits( unsigned char byte, BOOL * bits, uint32 num_bits );
+void gmsk_bytesToBits( unsigned char * bytes, BOOL * bits, uint32 num_bits );
+
+BOOL gmsk_encodeBuffer( GMSK_MOD mod, unsigned char * bytes, uint32 num_bits, float * buffer, uint32 buf_len );
+void gmsk_decodeBuffer( GMSK_DEMOD demod, float * buffer, uint32 buf_len, unsigned char * bytes, uint32 num_bits );
+
+void gmsk_resetMODFilter( GMSK_MOD mod );
+
+uint32 gmsk_encode( GMSK_MOD mod, BOOL bit, float * buffer, unsigned int length );
+enum DEMOD_STATE gmsk_decode( GMSK_DEMOD demod, float val );
+
+void gmskDemod_reset( GMSK_DEMOD demod );
+
+GMSK_MOD gmsk_createModulator( void );
+GMSK_DEMOD gmsk_createDemodulator( void );
+void gmsk_destroyModulator( GMSK_MOD mod );
+void gmsk_destroyDemodulator( GMSK_DEMOD demod );
+
+#endif /* THUMBDV_GMSK_MODEM_H_ */

--- a/third_party/smartsdr-dsp/ThumbDV/slow_data.c
+++ b/third_party/smartsdr-dsp/ThumbDV/slow_data.c
@@ -1,0 +1,321 @@
+///*!   \file slow_data.c
+// *
+// *    Handles scrambling and descrambling of DSTAR Header
+// *
+// *    \date 25-AUG-2015
+// *    \author Ed Gonzalez KG5FBT
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "slow_data.h"
+#include "DStarDefines.h"
+#include "dstar.h"
+#include "gmsk_modem.h"
+#include "thumbDV.h"
+
+uint32 slow_data_createDecoder(SLOW_DATA_DECODER slow_decoder)
+{
+    SLOW_DATA_DECODER decoder = ( SLOW_DATA_DECODER ) safe_malloc(sizeof(slow_data_decoder)) ;
+
+    if ( decoder == NULL ) {
+        output("Could not allocate slow data decoder\n");
+        return FAIL;
+    }
+
+    memset(decoder, 0, sizeof(slow_data_decoder));
+
+    decoder->decode_state = FIRST_FRAME;
+
+    slow_decoder = decoder;
+    return SUCCESS;
+}
+
+static void _slow_data_processHeaderBytes(DSTAR_MACHINE dstar)
+{
+    uint32 i = 0;
+    dstar_pfcs pfcs;
+    pfcs.crc16 = 0xFFFF;
+
+    SLOW_DATA_DECODER slow_decoder = (SLOW_DATA_DECODER) dstar->slow_decoder;
+
+    BOOL bits[RADIO_HEADER_LENGTH_BITS] = {0};
+    gmsk_bytesToBits(slow_decoder->header_bytes, bits, RADIO_HEADER_LENGTH_BITS);
+
+    for ( i = 0 ; i < 312 ; i += 8 ) {
+      dstar_pfcsUpdate( &pfcs, bits + i);
+    }
+
+    BOOL pfcs_match = FALSE;
+    pfcs_match = dstar_pfcsCheck( &pfcs, bits + 312 );
+
+    if ( pfcs_match ) {
+        output("SLOW DATA HEADER PARSED\n");
+
+      dstar_processHeader(slow_decoder->header_bytes, &dstar->incoming_header);
+      dstar_updateStatus( dstar, dstar->slice, STATUS_RX );
+    }
+
+    slow_data_resetDecoder(dstar);
+}
+
+static void _slow_data_processMessage(DSTAR_MACHINE dstar)
+{
+    char message[21];
+    uint32 i, j;
+    for ( i = 0 ; i < 4 ; i++ ) {
+        for ( j = 0 ; j < 5 ; j++ ) {
+            message[(i*5) + j] = dstar->slow_decoder->message[i][j];
+        }
+    }
+
+    message[20] = '\0';
+    strncpy(dstar->slow_decoder->message_string, message, 21);
+    output("SLOW DATA MESSAGE PARSED = '%s'\n", message);
+    dstar_updateStatus(dstar, dstar->slice, STATUS_SLOW_DATA_MESSAGE);
+
+    slow_data_resetDecoder(dstar);
+}
+
+void slow_data_createEncodeBytes(DSTAR_MACHINE dstar)
+{
+    uint32 i = 0;
+    uint32 j = 0;
+    SLOW_DATA_ENCODER encoder = dstar->slow_encoder;
+    uint32 message_index = 0;
+    dstar_pfcs pfcs;
+
+    /* Set all bytes to 0x66 */
+    memset(encoder->message_bytes, 0x66, SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC);
+
+    /* Generate Message Bytes */
+    for ( i = 0 ; i < 4 ; i++ ) {
+        encoder->message_bytes[(i * 6)] = SLOW_DATA_TYPE_MESSAGE | i;
+        for ( j = 1 ; j < 6 ; j++ ) {
+            encoder->message_bytes[(i * 6) + j] = encoder->message[message_index++];
+        }
+    }
+
+    thumbDV_dump("MESSAGE BYTES", encoder->message_bytes, SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC);
+
+    /* Generate HEADER Bytes */
+    /* Set all bytes to 0x66 */
+    memset(encoder->header_bytes, 0x66, SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC);
+    uint32 header_index = 0;
+
+    unsigned char header_bytes[RADIO_HEADER_LENGTH_BYTES] = {0};
+    dstar_headerToBytes(&dstar->outgoing_header, header_bytes);
+    pfcs.crc16 = 0xFFFF;
+    dstar_pfcsUpdateBuffer( &pfcs, header_bytes, 312 / 8 );
+    dstar_pfcsResult( &pfcs, header_bytes + 312 / 8 );
+
+    uint32 bits_left = RADIO_HEADER_LENGTH_BYTES;
+    uint32 second_loop_limit = 0;
+    for ( i = 0 ; i < RADIO_HEADER_LENGTH_BYTES / 5 + 1; i++ ) {
+        if ( bits_left >= 5 )
+            second_loop_limit = 6;
+        else
+            second_loop_limit = bits_left;
+        encoder->header_bytes[(i * 6)] = SLOW_DATA_TYPE_HEADER | (second_loop_limit - 1);
+        for ( j = 1 ; j < second_loop_limit ; j++ ) {
+            encoder->header_bytes[(i * 6) + j] = header_bytes[header_index++];
+        }
+
+        bits_left -= 5;
+    }
+
+    thumbDV_dump("Header bytes", encoder->header_bytes, SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC);
+
+
+    slow_data_resetEncoder(dstar);
+
+
+}
+
+void slow_data_getEncodeBytes( DSTAR_MACHINE dstar, unsigned char * bytes , uint32 num_bytes)
+{
+    uint32 i = 0;
+    memset(bytes, 0x66, num_bytes);
+
+    SLOW_DATA_ENCODER encoder = dstar->slow_encoder;
+    switch ( encoder->encode_state ) {
+    case MESSAGE_TX:
+        if ( encoder->message_index != 0 &&  encoder->message_index % 3 != 0 ) {
+            output("Message indexing problem. message_index = %d\n", encoder->message_index);
+            slow_data_resetEncoder(dstar);
+            break;
+        }
+
+        for ( i = 0 ; i < SLOW_DATA_PACKET_LEN_BYTES ; i++ ) {
+            bytes[i] = encoder->message_bytes[encoder->message_index++];
+        }
+
+        if ( encoder->message_index >= SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC ) {
+            /* Done sending the message change to header state */
+            encoder->message_index = 0;
+            encoder->encode_state = HEADER_TX;
+        }
+
+        break;
+    case HEADER_TX:
+        if ( encoder->header_index != 0 &&  encoder->header_index % 3 != 0 ) {
+            output("Header indexing problem. header_index = %d\n", encoder->header_index);
+            slow_data_resetEncoder(dstar);
+            break;
+        }
+
+        for ( i = 0 ; i < SLOW_DATA_PACKET_LEN_BYTES ; i++ ) {
+            bytes[i] = encoder->header_bytes[encoder->header_index++];
+        }
+
+        if ( encoder->header_index >= SLOW_DATA_PACKET_LEN_BYTES * FRAMES_BETWEEN_SYNC ) {
+            /* Done sending header. Reset index and keep sending header slow data */
+            encoder->header_index = 0;
+        }
+    break;
+    }
+}
+
+void slow_data_resetEncoder(DSTAR_MACHINE dstar)
+{
+    dstar->slow_encoder->encode_state = MESSAGE_TX;
+    dstar->slow_encoder->message_index = 0;
+    dstar->slow_encoder->header_index = 0;
+}
+
+void slow_data_resetDecoder(DSTAR_MACHINE dstar)
+{
+    dstar->slow_decoder->decode_state = FIRST_FRAME;
+    dstar->slow_decoder->header_array_index = 0;
+    dstar->slow_decoder->message_index = 0;
+}
+
+void slow_data_addDecodeData(DSTAR_MACHINE dstar, unsigned char * data, uint32 data_len)
+{
+    if ( data_len != SLOW_DATA_PACKET_LEN_BYTES ) {
+        output("Invalid data length - slow_data_addData\n");
+        return;
+    }
+
+    SLOW_DATA_DECODER slow_decoder = (SLOW_DATA_DECODER) (dstar->slow_decoder);
+
+    if ( slow_decoder == NULL ) {
+        output("NULL slow_decoder\n");
+        return;
+    }
+
+    uint32 i = 0;
+
+    switch(slow_decoder->decode_state) {
+    case FIRST_FRAME:
+    {
+        //output("FIRST FRAME\n");
+        switch(data[0] & SLOW_DATA_TYPE_MASK ) {
+        case SLOW_DATA_TYPE_HEADER:
+        {
+            for ( i = 1 ; i < 3 ; i++ ) {
+                slow_decoder->header_bytes[slow_decoder->header_array_index++] =
+                        data[i];
+                if ( slow_decoder->header_array_index >= RADIO_HEADER_LENGTH_BYTES )
+                {
+                    _slow_data_processHeaderBytes(dstar);
+                    break;
+                }
+            }
+
+            slow_decoder->decode_state = HEADER_SECOND_FRAME;
+
+
+            break;
+        }
+        case SLOW_DATA_TYPE_MESSAGE:
+        {
+
+            uint32 message_index = data[0] & SLOW_DATA_LENGTH_MASK;
+
+            if ( message_index != slow_decoder->message_index ) {
+                output("Out of order SLOW DATA MESSAGE setting to new index\n");
+                slow_decoder->message_index = message_index;
+                break;
+            }
+
+            for ( i = 1 ; i < 3 ; i++ ) {
+                slow_decoder->message[message_index][i - 1 ] = data[i];
+            }
+
+            slow_decoder->decode_state = MESSAGE_SECOND_FRAME;
+
+            break;
+        }
+        default:
+            //output("SLOW DATA BYTES 0x%X 0x%X  0x%X \n", data[0], data[1], data[2]);
+            break;
+        }
+        break;
+    }
+    case HEADER_SECOND_FRAME:
+    {
+        //output("HEADER SECOND FRAME\n");
+        if ( slow_decoder->header_array_index == 0 ) {
+            /* We reached the end of the array so we need to reset and find the first frame again */
+            slow_decoder->decode_state = FIRST_FRAME;
+            break;
+        }
+
+        for ( i = 0 ; i < 3 ; i++ ) {
+           slow_decoder->header_bytes[slow_decoder->header_array_index++] =
+                   data[i];
+           if ( slow_decoder->header_array_index >= RADIO_HEADER_LENGTH_BYTES )
+           {
+               _slow_data_processHeaderBytes(dstar);
+               break;
+           }
+        }
+
+        slow_decoder->decode_state = FIRST_FRAME;
+
+        break;
+    }
+    case MESSAGE_SECOND_FRAME:
+    {
+        for ( i = 0 ; i < 3 ; i++ ) {
+            slow_decoder->message[slow_decoder->message_index][i+2] = data[i];
+        }
+
+        slow_decoder->message_index++;
+
+        if ( slow_decoder->message_index >= 4 ) {
+            _slow_data_processMessage(dstar);
+        }
+
+        slow_decoder->decode_state = FIRST_FRAME;
+
+        break;
+    }
+    }
+
+}

--- a/third_party/smartsdr-dsp/ThumbDV/slow_data.h
+++ b/third_party/smartsdr-dsp/ThumbDV/slow_data.h
@@ -1,0 +1,42 @@
+///*!   \file slow_data.h
+// *
+// *    Handles scrambling and descrambling of DSTAR Header
+// *
+// *    \date 25-AUG-2015
+// *    \author Ed Gonzalez KG5FBT
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2012-2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef THUMBDV_SLOW_DATA_H_
+#define THUMBDV_SLOW_DATA_H_
+
+#include "dstar.h"
+#include "common.h"
+#include "DStarDefines.h"
+
+void slow_data_addDecodeData(DSTAR_MACHINE dstar, unsigned char * data, uint32 data_len);
+void slow_data_resetDecoder(DSTAR_MACHINE dstar);
+void slow_data_resetEncoder(DSTAR_MACHINE dstar);
+void slow_data_getEncodeBytes( DSTAR_MACHINE dstar, unsigned char * bytes, uint32 num_bytes );
+void slow_data_createEncodeBytes(DSTAR_MACHINE dstar);
+#endif /* THUMBDV_SLOW_DATA_H_*/

--- a/third_party/smartsdr-dsp/ThumbDV/thumbDV.c
+++ b/third_party/smartsdr-dsp/ThumbDV/thumbDV.c
@@ -1,0 +1,898 @@
+///*!   \file thumbdv.c
+// *    \brief Functions required to communicate and decode packets from ThumbDV
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 26-MAY-2015
+// *    \author     Ed Gonzalez
+// *
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <errno.h>
+#include <termios.h>
+#include <string.h>
+#include <fcntl.h>
+#include <pthread.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/prctl.h>
+
+#include <netinet/in.h>
+
+#include "common.h"
+#include "datatypes.h"
+#include "hal_buffer.h"
+
+#include "vita_output.h"
+#include "thumbDV.h"
+#include "sched_waveform.h"
+#include "ftd2xx.h"
+
+#define AMBE3000_HEADER_LEN     4U
+#define AMBE3000_START_BYTE     0x61U
+
+#define AMBE3000_SPEECHD_HEADER_LEN 3U
+
+#define AMBE3000_CTRL_PKT_TYPE      0x00
+#define AMBE3000_SPEECH_PKT_TYPE    0x02
+#define AMBE3000_CHAN_PKT_TYPE      0x01
+
+#define BUFFER_LENGTH           400U
+#define THUMBDV_MAX_PACKET_LEN  2048U
+#define THUMBDV_DSTAR_PCM_SAMPLES 160U
+#define THUMBDV_DSTAR_AMBE_BYTES 9U
+
+static pthread_t _read_thread;
+static pthread_t _connect_thread;
+BOOL _readThreadAbort = FALSE;
+BOOL _connectThreadAbort = FALSE;
+
+static uint32 _buffering_target = 0;
+static uint32 _encode_buffering_target = 4;
+
+static pthread_rwlock_t _encoded_list_lock;
+static BufferDescriptor _encoded_root;
+static BOOL _encoded_buffering = TRUE;
+static uint32 _encoded_count = 0;
+
+static pthread_rwlock_t _decoded_list_lock;
+static BufferDescriptor _decoded_root;
+static BOOL _decoded_buffering = TRUE;
+static uint32 _decoded_count = 0;
+
+static sem_t _read_sem;
+
+//static void * _thumbDV_readThread( void * param );
+
+BOOL allowedToRead = TRUE;
+
+static BufferDescriptor _thumbDVEncodedList_UnlinkHead(void ) {
+    BufferDescriptor buf_desc = NULL;
+    pthread_rwlock_wrlock( &_encoded_list_lock );
+
+
+    if ( _encoded_root == NULL || _encoded_root->next == NULL ) {
+        output( "Attempt to unlink from a NULL head" );
+        pthread_rwlock_unlock( &_encoded_list_lock );
+        return NULL;
+    }
+
+    if ( _encoded_buffering ) {
+        pthread_rwlock_unlock( &_encoded_list_lock );
+        return NULL;
+    }
+
+    if ( _encoded_root->next != _encoded_root )
+        buf_desc = _encoded_root->next;
+
+    if ( buf_desc != NULL ) {
+        // make sure buffer exists and is actually linked
+        if ( !buf_desc || !buf_desc->prev || !buf_desc->next ) {
+            output( "Invalid buffer descriptor" );
+            buf_desc = NULL;
+        } else {
+            buf_desc->next->prev = buf_desc->prev;
+            buf_desc->prev->next = buf_desc->next;
+            buf_desc->next = NULL;
+            buf_desc->prev = NULL;
+
+            if ( _encoded_count > 0 ) _encoded_count--;
+        }
+    } else {
+        if ( !_encoded_buffering ) output( "Encoded list now buffering\n" );
+
+        _encoded_buffering = TRUE;
+    }
+
+    pthread_rwlock_unlock( &_encoded_list_lock );
+    return buf_desc;
+}
+
+static void _thumbDVEncodedList_LinkTail( BufferDescriptor buf_desc ) {
+    pthread_rwlock_wrlock( &_encoded_list_lock );
+    buf_desc->next = _encoded_root;
+    buf_desc->prev = _encoded_root->prev;
+    _encoded_root->prev->next = buf_desc;
+    _encoded_root->prev = buf_desc;
+    _encoded_count++;
+
+    if ( _encoded_count > _encode_buffering_target ) {
+        if ( _encoded_buffering ) output( "Encoded Buffering is now FALSE\n" );
+
+        _encoded_buffering = FALSE;
+    }
+
+    pthread_rwlock_unlock( &_encoded_list_lock );
+}
+
+static BufferDescriptor _thumbDVDecodedList_UnlinkHead( void ) {
+    BufferDescriptor buf_desc = NULL;
+    pthread_rwlock_wrlock( &_decoded_list_lock );
+
+    if ( _decoded_root == NULL || _decoded_root->next == NULL ) {
+        output( "Attempt to unlink from a NULL head" );
+        pthread_rwlock_unlock( &_decoded_list_lock );
+        return NULL;
+    }
+
+    if ( _decoded_buffering ) {
+        pthread_rwlock_unlock( &_decoded_list_lock );
+        return NULL;
+    }
+
+    if ( _decoded_root->next != _decoded_root ) {
+        buf_desc = _decoded_root->next;
+    }
+
+    if ( buf_desc != NULL ) {
+        //output("0");
+        // make sure buffer exists and is actually linked
+        if ( !buf_desc || !buf_desc->prev || !buf_desc->next ) {
+            output( "Invalid buffer descriptor" );
+            buf_desc = NULL;
+        } else {
+            buf_desc->next->prev = buf_desc->prev;
+            buf_desc->prev->next = buf_desc->next;
+            buf_desc->next = NULL;
+            buf_desc->prev = NULL;
+
+            if ( _decoded_count > 0 ) _decoded_count--;
+        }
+    } else {
+        if ( !_decoded_buffering )
+            //output( "DecodedList now Buffering \n" );
+
+        _decoded_buffering = TRUE;
+    }
+
+    pthread_rwlock_unlock( &_decoded_list_lock );
+    return buf_desc;
+}
+
+static void _thumbDVDecodedList_LinkTail( BufferDescriptor buf_desc ) {
+    pthread_rwlock_wrlock( &_decoded_list_lock );
+    buf_desc->next = _decoded_root;
+    buf_desc->prev = _decoded_root->prev;
+    _decoded_root->prev->next = buf_desc;
+    _decoded_root->prev = buf_desc;
+
+    _decoded_count++;
+
+    if ( _decoded_count > _buffering_target ) {
+       // if ( _decoded_buffering ) output( "Decoded Buffering is now FALSE\n" );
+
+        _decoded_buffering = FALSE;
+    }
+
+    pthread_rwlock_unlock( &_decoded_list_lock );
+}
+
+BOOL thumbDV_getDecodeListBuffering(void)
+{
+    return _decoded_buffering;
+}
+
+static void delay( unsigned int delay ) {
+    struct timespec tim, tim2;
+    tim.tv_sec = 0;
+    tim.tv_nsec = delay * 1000UL;
+    nanosleep( &tim, &tim2 );
+};
+
+void thumbDV_flushLists(void)
+{
+    BufferDescriptor buf_desc = NULL;
+
+    do
+    {
+        buf_desc = _thumbDVEncodedList_UnlinkHead();
+        if ( buf_desc != NULL )
+            hal_BufferRelease(&buf_desc);
+    } while (buf_desc != NULL );
+
+
+    do
+    {
+        buf_desc = _thumbDVDecodedList_UnlinkHead();
+        if ( buf_desc != NULL )
+            hal_BufferRelease(&buf_desc);
+    } while (buf_desc != NULL );
+}
+
+void thumbDV_dump( char * text, unsigned char * data, unsigned int length ) {
+    unsigned int offset = 0U;
+    unsigned int i;
+
+    output( "%s", text );
+    output( "\n" );
+
+    while ( length > 0U ) {
+        unsigned int bytes = ( length > 16U ) ? 16U : length;
+
+        output( "%04X:  ", offset );
+
+        for ( i = 0U; i < bytes; i++ )
+            output( "%02X ", data[offset + i] );
+
+        for ( i = bytes; i < 16U; i++ )
+            output( "   " );
+
+        output( "   *" );
+
+        for ( i = 0U; i < bytes; i++ ) {
+            unsigned char c = data[offset + i];
+
+            if ( isprint( c ) )
+                output( "%c", c );
+            else
+                output( "." );
+        }
+
+        output( "*\n" );
+
+        offset += 16U;
+
+        if ( length >= 16U )
+            length -= 16U;
+        else
+            length = 0U;
+    }
+}
+
+static int thumbDV_writeSerial( FT_HANDLE handle , unsigned char * buffer, uint32 bytes )
+{
+    FT_STATUS status = FT_OK;
+    DWORD written = 0;
+
+    if ( handle != NULL )
+    {
+		//FT_SetRts(handle);
+        status = FT_Write(handle, buffer, bytes, &written);
+
+        if ( status != FT_OK || written != bytes ) {
+            output( ANSI_RED "Could not write to serial port. status = %d\n", status );
+            return status;
+        }
+        //FT_ClrRts(handle);
+    }
+    else
+    {
+        output( ANSI_RED "Could not write to serial port. Timeout\n" ANSI_WHITE );
+    }
+
+    return status;
+}
+
+static int _check_serial( FT_HANDLE handle )
+{
+	int ret  = 0;
+    unsigned char reset[5] = { 0x61, 0x00, 0x01, 0x00, 0x33 };
+
+    thumbDV_writeSerial( handle, reset, 5 );
+    ret = thumbDV_processSerial(handle);
+
+    if ( ret != 0 )
+    {
+        output( "Could not reset serial port FD = %p \n", (void*)handle );
+        return -1;
+    }
+
+    unsigned char get_prodID[5] = {0x61, 0x00, 0x01, 0x00, 0x30 };
+    thumbDV_writeSerial( handle, get_prodID, 5 );
+    ret = thumbDV_processSerial(handle);
+
+    if ( ret != 0 )
+    {
+        output( "Could not reset serial port FD = %p \n", (void*)handle );
+        return -1;
+    }
+
+    return 0 ;
+}
+
+FT_HANDLE thumbDV_openSerial( FT_DEVICE_LIST_INFO_NODE device )
+{
+    //struct termios tty;
+    FT_HANDLE handle = NULL;
+    FT_STATUS status = FT_OK;
+    UCHAR latency = 5;
+
+    output("Trying to open serial port %s \n", device.SerialNumber);
+
+    status = FT_OpenEx(device.SerialNumber, FT_OPEN_BY_SERIAL_NUMBER, &handle);
+
+    if ( status != FT_OK || handle == NULL )
+    {
+        if ( device.SerialNumber )
+            output("Error opening device %s - error 0x%X\n", device.SerialNumber, status);
+        else
+            output("Error opening device - error 0x%X\n", status);
+
+        return NULL;
+    }
+
+    FT_SetBaudRate(handle, FT_BAUD_460800);
+    FT_SetDataCharacteristics(handle, FT_BITS_8, FT_STOP_BITS_1, FT_PARITY_NONE);
+    FT_SetTimeouts(handle, 0, 0);
+    FT_SetFlowControl(handle, FT_FLOW_RTS_CTS, 0, 0);
+
+/*
+    tty.c_cflag = ( tty.c_cflag & ~CSIZE ) | CS8;
+    tty.c_iflag &= ~IGNBRK;
+    tty.c_lflag = 0;
+
+    tty.c_oflag = 0;
+    tty.c_cc[VMIN]  = 1;
+    tty.c_cc[VTIME] = 5;
+
+    tty.c_iflag &= ~( IXON | IXOFF | IXANY );
+
+    tty.c_cflag |= ( CLOCAL | CREAD );
+
+    tty.c_cflag &= ~( PARENB | PARODD );
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag &= ~CRTSCTS;
+
+    if ( tcsetattr( fd, TCSANOW, &tty ) != 0 ) {
+        output( "ThumbDV: error %d from tcsetattr\n", errno );
+        close( fd );
+        return -1;
+    }
+*/
+    if ( _check_serial(handle) != 0 ) {
+        output( "Could not detect ThumbDV at 460800 Baud. Trying 230400\n" );
+        FT_Close(handle);
+        handle = (FT_HANDLE)NULL;
+    } else {
+        return handle;
+    }
+
+    status = FT_OpenEx(device.SerialNumber, FT_OPEN_BY_SERIAL_NUMBER, &handle);
+
+    if ( status != FT_OK || handle == NULL )
+    {
+        if ( device.SerialNumber )
+            output("Error opening device %s - error 0x%X\n", device.SerialNumber, status);
+        else
+            output("Error opening device - error 0x%X\n", status);
+
+        return NULL;
+    }
+
+    FT_SetBaudRate(handle, FT_BAUD_230400 );
+    FT_SetDataCharacteristics(handle, FT_BITS_8, FT_STOP_BITS_1, FT_PARITY_NONE);
+    FT_SetTimeouts(handle, 0, 0);
+    FT_SetFlowControl(handle, FT_FLOW_NONE, 0, 0);
+    FT_SetLatencyTimer(handle, latency);
+
+    if ( _check_serial( handle ) != 0 ) {
+        output( "Could not detect THumbDV at 230400 Baud\n" );
+        FT_Close(handle);
+        handle = NULL;
+        return NULL;
+    }
+
+    return handle;
+}
+
+int thumbDV_processSerial( FT_HANDLE handle )
+{
+    unsigned char buffer[BUFFER_LENGTH];
+    unsigned int respLen;
+
+    unsigned char packet_type;
+    FT_STATUS status = FT_OK;
+    DWORD rx_bytes = 0;
+    DWORD tx_bytes = 0 ;
+    DWORD event_word = 0;
+    uint32 max_us_sleep = 100000; // 100 ms
+    uint32 us_slept = 0;
+    do
+    {
+        status = FT_GetStatus(handle, &rx_bytes, &tx_bytes, &event_word);
+
+        if ( rx_bytes >= AMBE3000_HEADER_LEN )
+            break;
+
+        usleep(100);
+
+        us_slept += 100;
+
+        if ( us_slept > max_us_sleep )
+        {
+            output("TimeOut #1\n");
+            return FT_OTHER_ERROR;
+        }
+
+    } while (rx_bytes < AMBE3000_HEADER_LEN && status == FT_OK );
+
+    status = FT_Read(handle, buffer, AMBE3000_HEADER_LEN, &rx_bytes);
+
+    if ( status != FT_OK || rx_bytes != AMBE3000_HEADER_LEN)
+    {
+        output( ANSI_RED "ThumbDV: Process serial. error when reading from the serial port, len = %d, status=%d\n" ANSI_WHITE, rx_bytes, status );
+        return 1;
+    }
+
+    if ( buffer[0U] != AMBE3000_START_BYTE ) {
+        output( ANSI_RED "ThumbDV: unknown byte from the DV3000, 0x%02X\n" ANSI_WHITE, buffer[0U] );
+        return FT_OTHER_ERROR;
+    }
+
+    respLen = buffer[1U] * 256U + buffer[2U];
+    if ( respLen > BUFFER_LENGTH - AMBE3000_HEADER_LEN ) {
+        output( ANSI_RED "ThumbDV: serial packet too large, len=%u max=%u\n" ANSI_WHITE,
+                respLen, BUFFER_LENGTH - AMBE3000_HEADER_LEN );
+        return FT_OTHER_ERROR;
+    }
+
+    us_slept = 0;
+    do
+    {
+        status = FT_GetStatus(handle, &rx_bytes, &tx_bytes, &event_word);
+
+        if ( rx_bytes >= respLen )
+            break;
+
+        usleep(100);
+
+        us_slept += 100 ;
+
+        if ( us_slept > max_us_sleep )
+        {
+            output("TimeOut #2 \n");
+            return FT_OTHER_ERROR;
+        }
+
+    } while (rx_bytes < respLen && status == FT_OK);
+
+    status = FT_Read(handle, buffer + AMBE3000_HEADER_LEN , respLen, &rx_bytes);
+
+    if ( status != FT_OK || rx_bytes != respLen )
+    {
+        output( ANSI_RED "ThumbDV: Process serial. error when reading from the serial port, len = %d, status=%d\n" ANSI_WHITE, rx_bytes, status );
+    }
+
+    respLen += AMBE3000_HEADER_LEN;
+
+    BufferDescriptor desc = NULL;
+    packet_type = buffer[3];
+
+    //thumbDV_dump("Serial data", buffer, respLen);
+    if ( packet_type == AMBE3000_CTRL_PKT_TYPE ) {
+        thumbDV_dump( ANSI_YELLOW "Serial data" ANSI_WHITE, buffer, respLen );
+    } else if ( packet_type == AMBE3000_CHAN_PKT_TYPE ) {
+        desc = hal_BufferRequest( respLen, sizeof( unsigned char ) );
+        memcpy( desc->buf_ptr, buffer, respLen );
+        //thumbDV_dump(ANSI_BLUE "Coded Packet" ANSI_WHITE, buffer, respLen);
+        /* Encoded data */
+        _thumbDVEncodedList_LinkTail( desc );
+    } else if ( packet_type == AMBE3000_SPEECH_PKT_TYPE ) {
+        desc = hal_BufferRequest( respLen, sizeof( unsigned char ) );
+        memcpy( desc->buf_ptr, buffer, respLen );
+        //thumbDV_dump("SPEECH Packet", buffer, respLen);
+        /* Speech data */
+        _thumbDVDecodedList_LinkTail( desc );
+
+    } else {
+        output( ANSI_RED "Unrecognized packet type 0x%02X ", packet_type );
+        return FT_OTHER_ERROR;
+
+    }
+
+
+    return FT_OK;
+}
+
+int thumbDV_unlinkAudio(short * speech_out)
+{
+    int32 samples_returned = 0;
+    if ( speech_out == NULL ) {
+        return samples_returned;
+    }
+
+    BufferDescriptor desc = _thumbDVDecodedList_UnlinkHead();
+    uint32 samples_in_speech_packet = 0;
+    uint32 length = 0;
+
+    if ( desc != NULL ) {
+        if ( desc->num_samples < 6U ) {
+            output( ANSI_YELLOW "ThumbDV: dropping short speech packet, len=%u\n" ANSI_WHITE,
+                    desc->num_samples );
+            hal_BufferRelease(&desc);
+            return samples_returned;
+        }
+
+        length = ( ( ( unsigned char * )desc->buf_ptr )[1] << 8 ) + ( ( unsigned char * )desc->buf_ptr )[2];;
+
+        if ( length != 0x142 ) {
+            output( ANSI_YELLOW, "WARNING LENGHT DOESN'T Match %d " ANSI_WHITE, length );
+            thumbDV_dump( "MISMATHCED", ( ( unsigned char * ) desc->buf_ptr ), desc->num_samples );
+        }
+
+        samples_in_speech_packet = ( ( unsigned char * )desc->buf_ptr )[5];
+        uint32 max_samples_in_packet = ( desc->num_samples - 6U ) / 2U;
+        if ( samples_in_speech_packet > max_samples_in_packet ) {
+            output( ANSI_YELLOW "ThumbDV: clipping speech packet samples from %u to %u\n" ANSI_WHITE,
+                    samples_in_speech_packet, max_samples_in_packet );
+            samples_in_speech_packet = max_samples_in_packet;
+        }
+        if ( samples_in_speech_packet > THUMBDV_DSTAR_PCM_SAMPLES ) {
+            output( ANSI_YELLOW "ThumbDV: clipping speech output samples from %u to %u\n" ANSI_WHITE,
+                    samples_in_speech_packet, THUMBDV_DSTAR_PCM_SAMPLES );
+            samples_in_speech_packet = THUMBDV_DSTAR_PCM_SAMPLES;
+        }
+
+        unsigned char * idx = &( ( ( unsigned char * )desc->buf_ptr )[6] );
+        uint32 i = 0;
+
+        for ( i = 0; i < samples_in_speech_packet; i++, idx += 2 ) {
+            speech_out[i] = ( idx[0] << 8 ) + idx[1];
+        }
+
+        samples_returned = samples_in_speech_packet;
+
+        if ( samples_returned != 160 ) output( "Rate Mismatch expected %d got %d\n", 160, samples_returned );
+
+//        safe_free( desc );
+        hal_BufferRelease(&desc);
+    } else {
+        /* Do nothing for now */
+    }
+
+    return samples_returned;
+}
+
+void thumbDV_decode( FT_HANDLE handle, unsigned char * packet_in, uint8 bytes_in_packet ) {
+    uint32 i = 0;
+
+    unsigned char full_packet[15] = {0};
+
+    if ( packet_in != NULL && handle != NULL ) {
+        full_packet[0] = 0x61;
+        full_packet[1] = 0x00;
+        full_packet[2] = 0x0B;
+        full_packet[3] = 0x01;
+        full_packet[4] = 0x01;
+        full_packet[5] = 0x48;
+        uint32 j = 0;
+
+        for ( i = 0, j = 8  ; i < 9 ; i++ , j-- ) {
+            full_packet[i + 6] = packet_in[i];
+        }
+
+//        thumbDV_dump("Just AMBE", packet_in, 9);
+//        thumbDV_dump("Encoded packet:", full_packet, 15);
+        thumbDV_writeSerial( handle, full_packet, 15 );
+        sem_post(&_read_sem);
+    }
+}
+
+int thumbDV_encode( FT_HANDLE handle, short * speech_in, unsigned char * packet_out, uint8 num_of_samples )
+{
+    if ( speech_in == NULL || packet_out == NULL || num_of_samples == 0U ) {
+        return 0;
+    }
+
+    unsigned char packet[THUMBDV_MAX_PACKET_LEN];
+    uint16 speech_d_bytes = num_of_samples * sizeof( uint16 ); /* Should be 2 times the number of samples */
+
+    /* Calculate length of packet NOT including the full header just the type field*/
+    uint16 length = 0;
+    /* Includes Channel Field and SpeechD Field Header */
+    length += AMBE3000_SPEECHD_HEADER_LEN;
+    length += speech_d_bytes;
+
+    /* Will be used to write fields into packet */
+    unsigned char * idx = &packet[0];
+
+    *( idx++ ) = AMBE3000_START_BYTE;
+    /* Length split into two bytes */
+    *( idx++ ) = length >> 8;
+    *( idx++ ) = length & 0xFF;
+    /* SPEECHD Type */
+    *( idx++ ) = AMBE3000_SPEECH_PKT_TYPE;
+    /* Channel0 Identifier */
+    *( idx++ ) = 0x40;
+    /* SPEEECHD Identifier */
+    *( idx++ ) = 0x00;
+    /* SPEECHD No of Samples */
+    *( idx++ ) = num_of_samples;
+    uint32 i = 0;
+//    output("Num of Samples = 0x%X\n", num_of_samples);
+
+#ifdef WOOT
+    output( "Encode Packet Header = " );
+    unsigned char * p = &packet[0];
+    i = 0;
+
+    for ( i = 0 ; i < 7 ; i++ ) {
+
+        output( "%02X ", *p );
+        p++;
+    }
+
+    output( "\n" );
+
+#endif
+    //memcpy(idx, speech_in, speech_d_bytes);
+    i = 0;
+
+    for ( i = 0 ; i < num_of_samples ; i++, idx += 2 ) {
+        idx[0] = speech_in[i] >> 8;
+        idx[1] = ( speech_in[i] & 0x00FF ) ;
+    }
+
+    if ( handle != NULL )
+    {
+        thumbDV_writeSerial( handle, packet, length + AMBE3000_HEADER_LEN );
+		sem_post(&_read_sem);
+    }
+
+    int32 samples_returned = 0;
+    BufferDescriptor desc = _thumbDVEncodedList_UnlinkHead();
+
+    if ( desc != NULL ) {
+        if ( desc->num_samples > 6U ) {
+            uint32 encoded_bytes = desc->sample_size * ( desc->num_samples - 6U );
+            if ( encoded_bytes > num_of_samples ) {
+                output( ANSI_YELLOW "ThumbDV: clipping encoded AMBE bytes from %u to %u\n" ANSI_WHITE,
+                        encoded_bytes, num_of_samples );
+                encoded_bytes = num_of_samples;
+            }
+            if ( encoded_bytes > THUMBDV_DSTAR_AMBE_BYTES ) {
+                output( ANSI_YELLOW "ThumbDV: clipping encoded D-Star AMBE bytes from %u to %u\n" ANSI_WHITE,
+                        encoded_bytes, THUMBDV_DSTAR_AMBE_BYTES );
+                encoded_bytes = THUMBDV_DSTAR_AMBE_BYTES;
+            }
+            memcpy( packet_out, desc->buf_ptr + 6, encoded_bytes );
+            samples_returned = encoded_bytes;
+        } else {
+            output( ANSI_YELLOW "ThumbDV: dropping short encoded packet, len=%u\n" ANSI_WHITE,
+                    desc->num_samples );
+        }
+        //safe_free( desc );
+        hal_BufferRelease(&desc);
+        //thumbDV_dump(ANSI_BLUE "Coded Packet" ANSI_WHITE, packet_out, desc->num_samples - 6);
+
+    } else {
+        /* Do nothing for now */
+    }
+
+    return samples_returned;
+
+}
+
+static void _connectSerial( FT_HANDLE * ftHandle )
+{
+    int i = 0 ;
+
+    output("ConnectSerial\n");
+
+    DWORD numDevs = 0;
+    FT_DEVICE_LIST_INFO_NODE *devInfo = NULL;
+    FT_STATUS status = FT_OK;
+
+    do {
+
+        status = FT_CreateDeviceInfoList(&numDevs);
+        if (status != FT_OK)
+        {
+            output("Unable to create Device Info \n");
+        }
+
+        devInfo = (FT_DEVICE_LIST_INFO_NODE *) safe_malloc(sizeof(FT_DEVICE_LIST_INFO_NODE) * numDevs);
+
+        status = FT_GetDeviceInfoList(devInfo, &numDevs);
+        if (status != FT_OK)
+        {
+            output("Unable to fetch Device Info \n");
+        }
+
+        for ( i = 0 ; i < numDevs ; i++ )
+        {
+
+            *ftHandle = thumbDV_openSerial(devInfo[i]);
+
+            if ( *ftHandle != NULL )
+            {
+                /* We opened a valid port and detected the ThumbDV */
+                break;
+            }
+        }
+        safe_free(devInfo);
+
+        if ( *ftHandle == NULL ) {
+            const char * fail_fast = getenv("AETHER_DSTAR_FAIL_FAST");
+            if ( fail_fast != NULL && strcmp(fail_fast, "0") != 0 ) {
+                output( "Could not open ThumbDV serial device; exiting because fail-fast is enabled.\n" );
+                exit(3);
+            }
+            output( "Could not open serial. Waiting 1 second before trying again.\n" );
+            usleep( 1000 * 1000 );
+        }
+    } while ( *ftHandle == NULL ) ;
+
+    // Reset and Product ID printout are done in thumbDV_openSerial() which calls _check_serial()
+
+    unsigned char disable_parity[6] = {0x61, 0x00, 0x02, 0x00, 0x3F, 0x00};
+    thumbDV_writeSerial( *ftHandle, disable_parity, 6 );
+    thumbDV_processSerial(*ftHandle);
+
+    unsigned char get_version[5] = {0x61, 0x00, 0x01, 0x00, 0x31};
+    unsigned char read_cfg[5] = {0x61, 0x00, 0x01, 0x00, 0x37};
+    unsigned char dstar_mode[17] = {0x61, 0x00, 0x0D, 0x00, 0x0A, 0x01, 0x30, 0x07, 0x63, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48};
+
+    thumbDV_writeSerial( *ftHandle, get_version, 5 );
+    thumbDV_processSerial(*ftHandle);
+    thumbDV_writeSerial( *ftHandle, read_cfg, 5 );
+    thumbDV_processSerial(*ftHandle);
+    thumbDV_writeSerial( *ftHandle, dstar_mode, 17 );
+    thumbDV_processSerial(*ftHandle);
+
+////    /* Init */
+    unsigned char pkt_init[6] = { 0x61, 0x00, 0x02, 0x00, 0x0B, 0x07 };
+    thumbDV_writeSerial( *ftHandle, pkt_init, 6 );
+    thumbDV_processSerial(*ftHandle);
+
+    /* PKT GAIN - set to 0dB */
+    unsigned char pkt_gain[7] = { 0x61, 0x00, 0x03, 0x00, 0x4B, 0x00, 0x00 };
+    thumbDV_writeSerial( *ftHandle, pkt_gain, 7 );
+    thumbDV_processSerial(*ftHandle);
+
+    /* Companding off so it uses 16bit linear */
+    unsigned char pkt_compand[6] = { 0x61, 0x00, 0x02, 0x00, 0x32, 0x00 };
+    thumbDV_writeSerial( *ftHandle, pkt_compand, 6 );
+    thumbDV_processSerial(*ftHandle);
+
+    unsigned char pkt_fmt[7] = {0x61, 0x00, 0x3, 0x00, 0x15, 0x00, 0x00};
+    thumbDV_writeSerial( *ftHandle, pkt_fmt, 7 );
+    thumbDV_processSerial(*ftHandle);
+
+}
+
+static void * _thumbDV_readThread( void * param )
+{
+    FT_STATUS status = FT_OK;
+    FT_HANDLE handle = *(FT_HANDLE *) param;
+
+    prctl(PR_SET_NAME, "DV-Read");
+
+    while ( !_readThreadAbort )
+    {
+        sem_wait(&_read_sem);
+
+        if (!allowedToRead)
+        {
+            break;
+        }
+        else
+        {
+            thumbDV_processSerial(handle);
+        }
+    }
+    output( ANSI_YELLOW "thumbDV_readThread has exited\n" ANSI_WHITE );
+    return 0;
+}
+
+static void * _thumbDV_connectThread( void * param )
+{
+    int ret;
+    DWORD rx_bytes;
+    DWORD tx_bytes;
+    DWORD event_dword;
+
+    FT_STATUS status = FT_OK;
+    FT_HANDLE handle = *(FT_HANDLE *) param;
+
+    while ( !_connectThreadAbort ) {
+
+        //waits 1 second before checking status to prevent CPU hogging
+        usleep(1000000);
+        ret = FT_GetStatus(handle, &rx_bytes, &tx_bytes, &event_dword);
+
+        if (ret != FT_OK) {
+
+            //clear out read buffer and stop read thread
+            sem_post(&_read_sem);
+            allowedToRead = FALSE;
+
+            output("Serial is disconnected\n");
+
+             //Set invalid FD in sched_waveform so we don't call write functions
+            handle = NULL;
+            sched_waveform_setHandle(&handle);
+             //This function hangs until a new connection is made
+            _connectSerial(&handle);
+             //Update the sched_waveform to new valid serial
+            sched_waveform_setHandle(&handle);
+
+            //Start read thread again
+            allowedToRead = TRUE;
+            pthread_create( &_read_thread, NULL, &_thumbDV_readThread, &handle );
+        }
+    }
+}
+
+void thumbDV_init( FT_HANDLE * handle ) {
+    pthread_rwlock_init( &_encoded_list_lock, NULL );
+    pthread_rwlock_init( &_decoded_list_lock, NULL );
+
+    sem_init(&_read_sem, 0, 0);
+
+    pthread_rwlock_wrlock( &_encoded_list_lock );
+    _encoded_root = ( BufferDescriptor )safe_malloc( sizeof( buffer_descriptor ) );
+    memset( _encoded_root, 0, sizeof( buffer_descriptor ) );
+    _encoded_root->next = _encoded_root;
+    _encoded_root->prev = _encoded_root;
+    pthread_rwlock_unlock( &_encoded_list_lock );
+
+    pthread_rwlock_wrlock( &_decoded_list_lock );
+    _decoded_root = ( BufferDescriptor )safe_malloc( sizeof( buffer_descriptor ) );
+    memset( _decoded_root, 0, sizeof( buffer_descriptor ) );
+    _decoded_root->next = _decoded_root;
+    _decoded_root->prev = _decoded_root;
+    pthread_rwlock_unlock( &_decoded_list_lock );
+
+    _connectSerial(handle);
+
+    pthread_create( &_connect_thread, NULL, &_thumbDV_connectThread, handle );
+    pthread_create( &_read_thread, NULL, &_thumbDV_readThread, handle );
+
+    struct sched_param fifo_param;
+    fifo_param.sched_priority = 30;
+    pthread_setschedparam( _read_thread, SCHED_FIFO, &fifo_param );
+
+}

--- a/third_party/smartsdr-dsp/ThumbDV/thumbDV.h
+++ b/third_party/smartsdr-dsp/ThumbDV/thumbDV.h
@@ -1,0 +1,53 @@
+///*!   \file thumbdv.h
+// *    \brief Functions required to communicate and decode packets from ThumbDV
+// *
+// *    \copyright  Copyright 2012-2014 FlexRadio Systems.  All Rights Reserved.
+// *                Unauthorized use, duplication or distribution of this software is
+// *                strictly prohibited by law.
+// *
+// *    \date 26-MAY-2015
+// *    \author     Ed Gonzalez
+// *
+// *
+// */
+
+/* *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+
+#ifndef THUMBDV_THUMBDV_H_
+#define THUMBDV_THUMBDV_H_
+
+#include "ftd2xx.h"
+
+void thumbDV_init( FT_HANDLE * serial_fd );
+FT_HANDLE thumbDV_openSerial( FT_DEVICE_LIST_INFO_NODE device );
+int thumbDV_processSerial( FT_HANDLE handle );
+
+int thumbDV_encode( FT_HANDLE handle, short * speech_in, unsigned char * packet_out, uint8 num_of_samples );
+void thumbDV_decode( FT_HANDLE handle, unsigned char * packet_in, uint8 bytes_in_packet );
+
+void thumbDV_dump( char * text, unsigned char * data, unsigned int length );
+void thumbDV_flushLists(void);
+
+BOOL thumbDV_getDecodeListBuffering(void);
+int thumbDV_unlinkAudio(short * speech_out);
+#endif /* THUMBDV_THUMBDV_ */

--- a/third_party/smartsdr-dsp/aether_sem_compat.c
+++ b/third_party/smartsdr-dsp/aether_sem_compat.c
@@ -1,0 +1,113 @@
+/*
+ * Minimal unnamed POSIX semaphore compatibility for macOS.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifdef __APPLE__
+
+#include <errno.h>
+#include <pthread.h>
+#include <semaphore.h>
+
+typedef struct AetherSemaphore {
+    int inUse;
+    unsigned int value;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+} AetherSemaphore;
+
+static pthread_mutex_t registryMutex = PTHREAD_MUTEX_INITIALIZER;
+static AetherSemaphore registry[128];
+
+static AetherSemaphore* lookupSemaphore(sem_t* sem)
+{
+    if (sem == NULL || *sem <= 0 || *sem > (int)(sizeof(registry) / sizeof(registry[0]))) {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    AetherSemaphore* entry = &registry[*sem - 1];
+    if (!entry->inUse) {
+        errno = EINVAL;
+        return NULL;
+    }
+    return entry;
+}
+
+int sem_init(sem_t* sem, int pshared, unsigned int value)
+{
+    if (sem == NULL || pshared != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    pthread_mutex_lock(&registryMutex);
+    for (int i = 0; i < (int)(sizeof(registry) / sizeof(registry[0])); ++i) {
+        if (registry[i].inUse) {
+            continue;
+        }
+
+        registry[i].inUse = 1;
+        registry[i].value = value;
+        pthread_mutex_init(&registry[i].mutex, NULL);
+        pthread_cond_init(&registry[i].cond, NULL);
+        *sem = i + 1;
+        pthread_mutex_unlock(&registryMutex);
+        return 0;
+    }
+    pthread_mutex_unlock(&registryMutex);
+
+    errno = ENOSPC;
+    return -1;
+}
+
+int sem_destroy(sem_t* sem)
+{
+    pthread_mutex_lock(&registryMutex);
+    AetherSemaphore* entry = lookupSemaphore(sem);
+    if (entry == NULL) {
+        pthread_mutex_unlock(&registryMutex);
+        return -1;
+    }
+
+    pthread_mutex_destroy(&entry->mutex);
+    pthread_cond_destroy(&entry->cond);
+    entry->inUse = 0;
+    *sem = 0;
+    pthread_mutex_unlock(&registryMutex);
+    return 0;
+}
+
+int sem_post(sem_t* sem)
+{
+    AetherSemaphore* entry = lookupSemaphore(sem);
+    if (entry == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&entry->mutex);
+    ++entry->value;
+    pthread_cond_signal(&entry->cond);
+    pthread_mutex_unlock(&entry->mutex);
+    return 0;
+}
+
+int sem_wait(sem_t* sem)
+{
+    AetherSemaphore* entry = lookupSemaphore(sem);
+    if (entry == NULL) {
+        return -1;
+    }
+
+    pthread_mutex_lock(&entry->mutex);
+    while (entry->value == 0) {
+        pthread_cond_wait(&entry->cond, &entry->mutex);
+    }
+    --entry->value;
+    pthread_mutex_unlock(&entry->mutex);
+    return 0;
+}
+
+#endif

--- a/third_party/smartsdr-dsp/aether_serial_compat.c
+++ b/third_party/smartsdr-dsp/aether_serial_compat.c
@@ -1,0 +1,259 @@
+/*
+ * Minimal FTDI D2XX-compatible serial shim used by the ThumbDV helper.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "ftd2xx.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#ifdef __APPLE__
+#include <IOKit/serial/ioss.h>
+#endif
+
+typedef struct AetherSerialHandle {
+    int fd;
+    char path[256];
+} AetherSerialHandle;
+
+static const char* serial_path(void)
+{
+    const char* path = getenv("AETHER_DSTAR_THUMBDV_SERIAL");
+    if (path == NULL || path[0] == '\0') {
+        path = getenv("THUMBDV_SERIAL");
+    }
+    return (path != NULL && path[0] != '\0') ? path : NULL;
+}
+
+static speed_t baud_constant(ULONG baud)
+{
+    switch (baud) {
+    case 230400:
+#ifdef B230400
+        return B230400;
+#else
+        return B115200;
+#endif
+    case 460800:
+#ifdef B460800
+        return B460800;
+#else
+        return B230400;
+#endif
+    default:
+        return B115200;
+    }
+}
+
+static FT_STATUS configure_baud(AetherSerialHandle* h, ULONG baud)
+{
+    struct termios tty;
+    if (tcgetattr(h->fd, &tty) != 0) {
+        return FT_IO_ERROR;
+    }
+    cfmakeraw(&tty);
+    tty.c_cflag |= (CLOCAL | CREAD);
+#ifdef CRTSCTS
+    tty.c_cflag &= ~CRTSCTS;
+#endif
+    tty.c_cflag &= ~PARENB;
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8;
+    tty.c_cc[VMIN] = 0;
+    tty.c_cc[VTIME] = 0;
+    speed_t speed = baud_constant(baud);
+    cfsetispeed(&tty, speed);
+    cfsetospeed(&tty, speed);
+    if (tcsetattr(h->fd, TCSANOW, &tty) != 0) {
+        return FT_IO_ERROR;
+    }
+#ifdef __APPLE__
+    speed_t custom = (speed_t)baud;
+    if (ioctl(h->fd, IOSSIOSPEED, &custom) == -1 && baud == 460800) {
+        return FT_IO_ERROR;
+    }
+#endif
+    tcflush(h->fd, TCIOFLUSH);
+    return FT_OK;
+}
+
+FT_STATUS FT_CreateDeviceInfoList(DWORD* numDevs)
+{
+    if (numDevs == NULL) {
+        return FT_INVALID_PARAMETER;
+    }
+    *numDevs = serial_path() ? 1U : 0U;
+    return FT_OK;
+}
+
+FT_STATUS FT_GetDeviceInfoList(FT_DEVICE_LIST_INFO_NODE* dest, DWORD* numDevs)
+{
+    const char* path = serial_path();
+    if (numDevs == NULL) {
+        return FT_INVALID_PARAMETER;
+    }
+    if (path == NULL) {
+        *numDevs = 0;
+        return FT_OK;
+    }
+    if (dest == NULL || *numDevs == 0) {
+        *numDevs = 1;
+        return FT_INVALID_PARAMETER;
+    }
+    memset(dest, 0, sizeof(*dest));
+    snprintf(dest->SerialNumber, sizeof(dest->SerialNumber), "%s", path);
+    snprintf(dest->Description, sizeof(dest->Description), "ThumbDV serial port");
+    *numDevs = 1;
+    return FT_OK;
+}
+
+FT_STATUS FT_OpenEx(void* arg, DWORD flags, FT_HANDLE* handle)
+{
+    (void)flags;
+    if (handle == NULL) {
+        return FT_INVALID_PARAMETER;
+    }
+    *handle = NULL;
+    const char* path = (const char*)arg;
+    if (path == NULL || path[0] == '\0') {
+        path = serial_path();
+    }
+    if (path == NULL) {
+        return FT_DEVICE_NOT_FOUND;
+    }
+    int fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) {
+        return FT_DEVICE_NOT_FOUND;
+    }
+    AetherSerialHandle* h = calloc(1, sizeof(*h));
+    if (h == NULL) {
+        close(fd);
+        return FT_INSUFFICIENT_RESOURCES;
+    }
+    h->fd = fd;
+    snprintf(h->path, sizeof(h->path), "%s", path);
+    *handle = h;
+    return FT_OK;
+}
+
+FT_STATUS FT_Close(FT_HANDLE handle)
+{
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (h == NULL) {
+        return FT_INVALID_HANDLE;
+    }
+    close(h->fd);
+    free(h);
+    return FT_OK;
+}
+
+FT_STATUS FT_Read(FT_HANDLE handle, void* buffer, DWORD bytesToRead, DWORD* bytesReturned)
+{
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (bytesReturned) { *bytesReturned = 0; }
+    if (h == NULL || buffer == NULL || bytesReturned == NULL) {
+        return FT_INVALID_PARAMETER;
+    }
+    ssize_t n = read(h->fd, buffer, bytesToRead);
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return FT_OK;
+        }
+        return FT_IO_ERROR;
+    }
+    *bytesReturned = (DWORD)n;
+    return FT_OK;
+}
+
+FT_STATUS FT_Write(FT_HANDLE handle, void* buffer, DWORD bytesToWrite, DWORD* bytesWritten)
+{
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (bytesWritten) { *bytesWritten = 0; }
+    if (h == NULL || buffer == NULL || bytesWritten == NULL) {
+        return FT_INVALID_PARAMETER;
+    }
+    ssize_t n = write(h->fd, buffer, bytesToWrite);
+    if (n < 0) {
+        return FT_IO_ERROR;
+    }
+    *bytesWritten = (DWORD)n;
+    return (n == (ssize_t)bytesToWrite) ? FT_OK : FT_IO_ERROR;
+}
+
+FT_STATUS FT_SetBaudRate(FT_HANDLE handle, ULONG baudRate)
+{
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (h == NULL) {
+        return FT_INVALID_HANDLE;
+    }
+    return configure_baud(h, baudRate);
+}
+
+FT_STATUS FT_SetDataCharacteristics(FT_HANDLE handle, UCHAR wordLength, UCHAR stopBits, UCHAR parity)
+{
+    (void)handle; (void)wordLength; (void)stopBits; (void)parity;
+    return FT_OK;
+}
+
+FT_STATUS FT_SetTimeouts(FT_HANDLE handle, ULONG readTimeout, ULONG writeTimeout)
+{
+    (void)handle; (void)readTimeout; (void)writeTimeout;
+    return FT_OK;
+}
+
+FT_STATUS FT_SetFlowControl(FT_HANDLE handle, USHORT flowControl, UCHAR xon, UCHAR xoff)
+{
+    (void)xon; (void)xoff;
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (h == NULL) {
+        return FT_INVALID_HANDLE;
+    }
+#ifdef CRTSCTS
+    struct termios tty;
+    if (tcgetattr(h->fd, &tty) != 0) {
+        return FT_IO_ERROR;
+    }
+    if (flowControl == FT_FLOW_RTS_CTS) {
+        tty.c_cflag |= CRTSCTS;
+    } else {
+        tty.c_cflag &= ~CRTSCTS;
+    }
+    if (tcsetattr(h->fd, TCSANOW, &tty) != 0) {
+        return FT_IO_ERROR;
+    }
+#else
+    (void)flowControl;
+#endif
+    return FT_OK;
+}
+
+FT_STATUS FT_SetLatencyTimer(FT_HANDLE handle, UCHAR timer)
+{
+    (void)handle; (void)timer;
+    return FT_OK;
+}
+
+FT_STATUS FT_GetStatus(FT_HANDLE handle, DWORD* rxBytes, DWORD* txBytes, DWORD* eventWord)
+{
+    AetherSerialHandle* h = (AetherSerialHandle*)handle;
+    if (rxBytes) { *rxBytes = 0; }
+    if (txBytes) { *txBytes = 0; }
+    if (eventWord) { *eventWord = 0; }
+    if (h == NULL) {
+        return FT_INVALID_HANDLE;
+    }
+    int available = 0;
+    if (ioctl(h->fd, FIONREAD, &available) != 0) {
+        return FT_IO_ERROR;
+    }
+    if (rxBytes) { *rxBytes = available > 0 ? (DWORD)available : 0; }
+    return FT_OK;
+}

--- a/third_party/smartsdr-dsp/aether_vocoder_backend.cpp
+++ b/third_party/smartsdr-dsp/aether_vocoder_backend.cpp
@@ -1,0 +1,98 @@
+/*
+ * ThumbDV vocoder backend for AetherSDR's local D-STAR waveform helper.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "aether_vocoder_backend.h"
+
+#include <string>
+
+extern "C" {
+#include "datatypes.h"
+#include "thumbDV.h"
+}
+
+namespace {
+
+std::string normalizedName(const char* name)
+{
+    if (name == nullptr) {
+        return {};
+    }
+
+    std::string normalized;
+    for (const char* p = name; *p != '\0'; ++p) {
+        const char ch = *p;
+        if (ch == '-' || ch == '_' || ch == ' ' || ch == '/') {
+            continue;
+        }
+        if (ch >= 'A' && ch <= 'Z') {
+            normalized.push_back(static_cast<char>(ch - 'A' + 'a'));
+        } else {
+            normalized.push_back(ch);
+        }
+    }
+    return normalized;
+}
+
+} // namespace
+
+extern "C" int aether_vocoder_set_kind_from_name(const char* name)
+{
+    const std::string normalized = normalizedName(name);
+    if (normalized.empty()
+            || normalized == "thumbdv"
+            || normalized == "dv3000"
+            || normalized == "hardware") {
+        return 0;
+    }
+    return -1;
+}
+
+extern "C" const char* aether_vocoder_name(void)
+{
+    return "thumbdv";
+}
+
+extern "C" int aether_vocoder_requires_serial(void)
+{
+    return 1;
+}
+
+extern "C" void aether_vocoder_init(FT_HANDLE* serial_handle)
+{
+    thumbDV_init(serial_handle);
+}
+
+extern "C" void aether_vocoder_flush_lists(void)
+{
+    thumbDV_flushLists();
+}
+
+extern "C" unsigned int aether_vocoder_encode(FT_HANDLE handle,
+                                              short* speech_in,
+                                              unsigned char* packet_out,
+                                              unsigned int num_samples)
+{
+    return static_cast<unsigned int>(
+        thumbDV_encode(handle, speech_in, packet_out, static_cast<uint8>(num_samples)));
+}
+
+extern "C" void aether_vocoder_decode(FT_HANDLE handle,
+                                      unsigned char* packet_in,
+                                      unsigned int bytes_in_packet)
+{
+    thumbDV_decode(handle, packet_in, static_cast<uint8>(bytes_in_packet));
+}
+
+extern "C" int aether_vocoder_get_decode_list_buffering(void)
+{
+    return thumbDV_getDecodeListBuffering();
+}
+
+extern "C" int aether_vocoder_unlink_audio(short* speech_out)
+{
+    return thumbDV_unlinkAudio(speech_out);
+}

--- a/third_party/smartsdr-dsp/aether_vocoder_backend.h
+++ b/third_party/smartsdr-dsp/aether_vocoder_backend.h
@@ -1,0 +1,35 @@
+/*
+ * ThumbDV vocoder backend for AetherSDR's local D-STAR waveform helper.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "ftd2xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int aether_vocoder_set_kind_from_name(const char* name);
+const char* aether_vocoder_name(void);
+int aether_vocoder_requires_serial(void);
+
+void aether_vocoder_init(FT_HANDLE* serial_handle);
+void aether_vocoder_flush_lists(void);
+
+unsigned int aether_vocoder_encode(FT_HANDLE handle,
+                                   short* speech_in,
+                                   unsigned char* packet_out,
+                                   unsigned int num_samples);
+void aether_vocoder_decode(FT_HANDLE handle,
+                           unsigned char* packet_in,
+                           unsigned int bytes_in_packet);
+int aether_vocoder_get_decode_list_buffering(void);
+int aether_vocoder_unlink_audio(short* speech_out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/third_party/smartsdr-dsp/circular_buffer.c
+++ b/third_party/smartsdr-dsp/circular_buffer.c
@@ -1,0 +1,257 @@
+/* *****************************************************************************
+ *	circular_float_buffer.c											2014 AUG 20
+ *
+ *	General Purpose Circular Buffer Function Set
+ *
+ *  Created on: Aug 21, 2014
+ *      Author: Graham / KE9H
+ *
+ * *****************************************************************************
+ *
+ *	Copyright (C) 2014 FlexRadio Systems.
+ *	This program is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *	GNU General Public License for more details.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *******************************************************************************
+ *
+ *	Example usage:
+ *
+ *	Circular buffer object, declared in circular_buffer.h
+ *
+ * 		typedef struct {
+ *			unsigned int  size;		// Maximum number of elements + 1
+ *			unsigned int  start;	// Index of oldest element
+ *			unsigned int  end;		// Index at which to write new element
+ *			unsigned char *elems;	// Vector of elements
+ *		} circular_buffer, *Circular_Buffer;
+ *
+ *
+ *	Circular Buffer Declaration
+ *
+ *		unsigned char CL_Buff[2048];		// Example: Command Line Buffer
+ *		Note: Make sure declaration matches data size
+ *
+ *		circular_buffer CommandLine_cb;
+ *
+ *		Circular_Buffer CL_cb = &CommandLine_cb;
+ *
+ *
+ *	Initialize circular buffer for Command Line buffer
+ *	// Includes one empty element
+ *		CL_cb->size	 = 2048;		// size = no.elements in array
+ *		CL_cb->start = 0;
+ *		CL_cb->end	 = 0;
+ *		CL_cb->elems = CL_Buff;
+ *
+ *	Call Read or Write function, appropriate to the data size
+ *
+ **************************************************************************** */
+
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "circular_buffer.h"
+#include "utils.h"
+
+
+
+/* *****************************************************************************
+ *	BOOL cfbIsFull(Circular_Float_Buffer cb)
+ *		Test to check if the buffer is FULL
+ *		Returns TRUE if full
+ */
+
+bool cfbIsFull(Circular_Float_Buffer cb)
+{
+	return ((cb->end + 1) % cb->size == cb->start);
+}
+
+
+/* *****************************************************************************
+ *	BOOL cfbIsEmpty(Circular_Float_Buffer cb)
+ *		Test to check if the buffer is EMPTY
+ *		Returns TRUE if empty
+ */
+
+bool cfbIsEmpty(Circular_Float_Buffer cb)
+{
+	return cb->end == cb->start;
+}
+
+
+/* *****************************************************************************
+ *	void cbWriteChar(Circular_Buffer cb, unsigned char temp)
+ *		Write an element, overwriting oldest element if buffer is full.
+ *		App can choose to avoid the overwrite by checking cbIsFull().
+ */
+
+void cbWriteFloat(Circular_Float_Buffer cb, float sample)
+{
+	cb->elems[cb->end] = sample;
+	cb->end = (cb->end + 1) % cb->size;
+	if (cb->end == cb->start) {
+		cb->start = (cb->start + 1) % cb->size;		/* full, overwrite */
+		output(ANSI_RED "Overwrite! in Circular Float Buffer - Name %s\n"
+		        "Size %d Start %d End %d\n "ANSI_WHITE, cb->name, cb->size, cb->start, cb->end);
+
+	}
+}
+
+
+/* *****************************************************************************
+ *	unsigned char cbReadChar(CircularBuffer *cb)
+ *		Returns oldest element.
+ *		Calling function must ensure [cbIsEmpty() != TRUE], first.
+ */
+
+float cbReadFloat(Circular_Float_Buffer cb)
+{
+	float temp;
+
+	temp = cb->elems[cb->start];
+	cb->start = (cb->start + 1) % cb->size;
+	return temp;
+}
+
+
+/* *****************************************************************************
+ *	void zero_cfb(Circular_Float_Buffer cb)
+ *
+ *		Empties circular buffer
+ */
+
+void zero_cfb(Circular_Float_Buffer cb)
+{
+	cb->start = 0;
+	cb->end	 = 0;
+}
+
+
+/* *****************************************************************************
+ *	int cfbContains(Circular_Float_Buffer cb)
+ *
+ *		Returns the number of samples in the circular buffer
+ *
+ */
+
+int cfbContains(Circular_Float_Buffer cb)
+{
+	int contains;
+
+	contains = (cb->end - cb->start);
+	if (contains < 0)
+		contains += cb->size;
+
+	return contains;
+}
+
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  SHORT BUFFER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+/* *****************************************************************************
+ *	BOOL cfbIsFull(Circular_Float_Buffer cb)
+ *		Test to check if the buffer is FULL
+ *		Returns TRUE if full
+ */
+
+bool csbIsFull(Circular_Short_Buffer cb)
+{
+	return ((cb->end + 1) % cb->size == cb->start);
+}
+
+
+/* *****************************************************************************
+ *	BOOL csbIsEmpty(Circular_Short_Buffer cb)
+ *		Test to check if the buffer is EMPTY
+ *		Returns TRUE if empty
+ */
+
+bool csbIsEmpty(Circular_Short_Buffer cb)
+{
+	return cb->end == cb->start;
+}
+
+
+/* *****************************************************************************
+ *	void cbWriteChar(Circular_Buffer cb, unsigned char temp)
+ *		Write an element, overwriting oldest element if buffer is full.
+ *		App can choose to avoid the overwrite by checking cbIsFull().
+ */
+
+void cbWriteShort(Circular_Short_Buffer cb, short sample)
+{
+	cb->elems[cb->end] = sample;
+	cb->end = (cb->end + 1) % cb->size;
+	if (cb->end == cb->start) {
+		cb->start = (cb->start + 1) % cb->size;		/* full, overwrite */
+		output(ANSI_RED "Overwrite! in Circular Short Buffer - Name %s\n" ANSI_WHITE, cb->name);
+	}
+}
+
+
+/* *****************************************************************************
+ *	unsigned char cbReadShort(Circular_Short_Buffer *cb)
+ *		Returns oldest element.
+ *		Calling function must ensure [csbIsEmpty() != TRUE], first.
+ */
+
+short cbReadShort(Circular_Short_Buffer cb)
+{
+	short temp;
+
+	temp = cb->elems[cb->start];
+	cb->start = (cb->start + 1) % cb->size;
+	return temp;
+}
+
+
+/* *****************************************************************************
+ *	void zero_cfb(Circular_Short_Buffer cb)
+ *
+ *		Empties circular buffer
+ */
+
+void zero_csb(Circular_Short_Buffer cb)
+{
+	cb->start = 0;
+	cb->end	 = 0;
+}
+
+
+/* *****************************************************************************
+ *	int csbContains(Circular_Short_Buffer cb)
+ *
+ *		Returns the number of samples in the circular buffer
+ *
+ */
+
+int csbContains(Circular_Short_Buffer cb)
+{
+	int contains;
+
+	contains = (cb->end - cb->start);
+	if (contains < 0)
+		contains += cb->size;
+
+		return contains;
+}
+
+
+// EoF =====-----

--- a/third_party/smartsdr-dsp/circular_buffer.h
+++ b/third_party/smartsdr-dsp/circular_buffer.h
@@ -1,0 +1,84 @@
+/* *****************************************************************************
+ *	circular_buffer.h									  			2014 AUG 23
+ *
+ * 	General Purpose Circular Buffer Function Set
+ *		Includes Circular Buffers for floats and shorts
+ *
+ *  Created on: Aug 21, 2014
+ *      Author: Graham / KE9H
+ *
+ * *****************************************************************************
+ *
+ *	Copyright (C) 2014 FlexRadio Systems.
+ *	This program is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *	GNU General Public License for more details.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************** */
+
+
+#ifndef CIRCULAR_BUFFER_H_
+#define CIRCULAR_BUFFER_H_
+
+
+#include <stdbool.h>
+
+
+/* Circular buffer objects */
+typedef struct {
+    unsigned int   size;    // Maximum number of elements + 1
+    unsigned int   start;   // Index of oldest element
+    unsigned int   end;     // Index at which to write new element
+    short         *elems;   // Vector of elements
+    char name[20];
+} circular_short_buffer, *Circular_Short_Buffer;
+
+typedef struct {
+    unsigned int   size;    // Maximum number of elements + 1
+    unsigned int   start;   // Index of oldest element
+    unsigned int   end;     // Index at which to write new element
+    float         *elems;   // Vector of elements
+    char name[20];
+} circular_float_buffer, *Circular_Float_Buffer;
+
+
+/* *****************************************************************************
+ *  Prototype Declarations
+ */
+
+//  Returns TRUE if buffer is full
+bool cfbIsFull(Circular_Float_Buffer cb);
+bool csbIsFull(Circular_Short_Buffer cb);
+
+//  Returns TRUE if buffer is empty
+bool cfbIsEmpty(Circular_Float_Buffer cb);
+bool csbIsEmpty(Circular_Short_Buffer cb);
+
+//  Write an element, overwriting oldest element if buffer is full.
+//  App can choose to avoid the overwrite by checking cbIsFull().
+void cbWriteFloat(Circular_Float_Buffer cb, float sample);
+void cbWriteShort(Circular_Short_Buffer cb, short sample);
+
+//Read oldest element. App must ensure !cbIsEmpty() first.
+float cbReadFloat(Circular_Float_Buffer cb);
+short cbReadShort(Circular_Short_Buffer cb);
+
+// Clear buffer
+void zero_cfb(Circular_Float_Buffer cb);
+void zero_csb(Circular_Short_Buffer cb);
+
+// Returns number of samples in buffer
+int cfbContains(Circular_Float_Buffer cb);
+int csbContains(Circular_Short_Buffer cb);
+
+
+#endif /* CIRCULAR_BUFFER_H_ */
+
+// EoF =====-----

--- a/third_party/smartsdr-dsp/common.h
+++ b/third_party/smartsdr-dsp/common.h
@@ -1,0 +1,86 @@
+/* *****************************************************************************
+ * common.h															2015 JAN 27
+ *
+ *  Created on: Aug 28, 2014
+ *      Author: Graham / KE9H
+ *
+ * 	Included common project headers
+ *
+ * *****************************************************************************
+ *
+ *  Copyright (C) 2014 FlexRadio Systems.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  Contact Information:
+ *  email: gpl<at>flexradiosystems.com
+ *  Mail:  FlexRadio Systems, Suite 1-150, 4616 W. Howard LN, Austin, TX 78728
+ *
+ * ************************************************************************** */
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#include <pthread.h>
+
+#include "datatypes.h"
+#include "hal_listener.h"
+#include "io_utils.h"
+#include "vita_output.h"
+#include "vita49_context.h"
+#include "smartsdr_dsp_api.h"
+#include "utils.h"
+#include "main.h"
+#include "vita.h"
+#include "cmd.h"
+
+
+#define SUCCESS 0
+#define FAIL    1
+
+#define SMARTSDR_API_PORT           "4992"
+#define VITA_49_PORT                5000
+#define VITA_49_SOURCE_PORT			VITA_49_PORT
+#define VITA_49_FFT_SOURCE_PORT		30003
+#define VITA_49_METER_SOURCE_PORT	30002
+#define VITA_49_STATUS_PORT			VITA_49_PORT
+#define DISCOVERY_PORT				4992
+#define FLEXRADIO_OUI               0x001C2D
+#define INVALID_SLICE_RX            0xFFFF0000
+#define SL_BAD_COMMAND              0x50000FFF
+
+#define SL_VITA_INFO_CLASS			0x534C
+
+#define SL_CLASS_SAMPLING_24KHZ		0x03
+#define SL_CLASS_32BPS				(3 << 5)
+#define SL_CLASS_AUDIO_STEREO		(0x3 << 7)
+#define SL_CLASS_IEEE_754			(0x1 << 9)
+#define SL_VITA_SLICE_AUDIO_CLASS	(SL_VITA_INFO_CLASS << 16) | SL_CLASS_SAMPLING_24KHZ | SL_CLASS_32BPS | SL_CLASS_AUDIO_STEREO | SL_CLASS_IEEE_754
+
+#define SL_ERROR_BASE                   0x50000000
+#define SL_OUT_OF_MEMORY                SL_ERROR_BASE + 0x00B
+#define SL_UNKNOWN_COMMAND              SL_ERROR_BASE + 0x015
+#define SL_TERMINATE                    SL_ERROR_BASE + 0x037
+#define SL_CLOSE_CLIENT                 SL_ERROR_BASE + 0x03A
+
+#define ANSI_ESC                "\033["
+#define ANSI_RED 	ANSI_ESC  	"91m"
+#define ANSI_GREEN 	ANSI_ESC 	"92m"
+#define ANSI_YELLOW ANSI_ESC    "93m"
+#define ANSI_BLUE 	ANSI_ESC  	"94m"
+#define ANSI_MAGENTA ANSI_ESC   "95m"
+#define ANSI_CYAN 	ANSI_ESC 	"96m"
+#define ANSI_WHITE 	ANSI_ESC	"97m"
+#define CLR_WHT 	"\033[97m"
+#define ANSI_COLOR_OFF ANSI_ESC "m"
+
+#endif /* COMMON_H_ */

--- a/third_party/smartsdr-dsp/compat/linux/if_ether.h
+++ b/third_party/smartsdr-dsp/compat/linux/if_ether.h
@@ -1,0 +1,17 @@
+/*
+ * Minimal Linux Ethernet constants used by SmartSDR-DSP packet buffers.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+#ifndef ETH_DATA_LEN
+#define ETH_DATA_LEN 1500
+#endif
+#ifndef ETH_FRAME_LEN
+#define ETH_FRAME_LEN 1514
+#endif

--- a/third_party/smartsdr-dsp/compat/linux/if_packet.h
+++ b/third_party/smartsdr-dsp/compat/linux/if_packet.h
@@ -1,0 +1,8 @@
+/*
+ * Empty compatibility header for SmartSDR-DSP Linux packet-socket include.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once

--- a/third_party/smartsdr-dsp/compat/linux/tcp.h
+++ b/third_party/smartsdr-dsp/compat/linux/tcp.h
@@ -1,0 +1,9 @@
+/*
+ * Compatibility wrapper for the Linux TCP include used by SmartSDR-DSP.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#include <netinet/tcp.h>

--- a/third_party/smartsdr-dsp/compat/sys/prctl.h
+++ b/third_party/smartsdr-dsp/compat/sys/prctl.h
@@ -1,0 +1,20 @@
+/*
+ * Compatibility shim for the Linux prctl thread-name call used by SmartSDR-DSP.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+#define PR_SET_NAME 15
+#ifdef __APPLE__
+#include <pthread.h>
+static inline int aether_prctl(int option, const char* name) {
+    (void)option;
+    if (name) { pthread_setname_np(name); }
+    return 0;
+}
+#else
+static inline int aether_prctl(int option, const char* name) { (void)option; (void)name; return 0; }
+#endif
+#define prctl(option, name) aether_prctl((option), (name))

--- a/third_party/smartsdr-dsp/config/ThumbDV.cfg
+++ b/third_party/smartsdr-dsp/config/ThumbDV.cfg
@@ -1,0 +1,22 @@
+[header]
+Name: ThumbDV
+Version: "1.2.0"
+Minimum-SmartSDR-Version: 1.10.3.0
+Author: FlexRadio Systems
+Support-email: support@flexradio.com
+Support-phone: 512-535-4713
+License: GPL7.3
+Executable: "thumbdv"
+
+[setup]
+waveform create name=ThumbDV mode=DSTR underlying_mode=DFM version=1.1.0
+waveform set ThumbDV tx=1
+waveform set ThumbDV rx_filter low_cut=-3500
+waveform set ThumbDV rx_filter high_cut=3500
+waveform set ThumbDV rx_filter depth=2
+waveform set ThumbDV tx_filter low_cut=0
+waveform set ThumbDV tx_filter high_cut=4800
+waveform set ThumbDV tx_filter depth=2
+waveform set ThumbDV udpport=5000
+
+[end]

--- a/third_party/smartsdr-dsp/include/ftd2xx.h
+++ b/third_party/smartsdr-dsp/include/ftd2xx.h
@@ -1,0 +1,69 @@
+/*
+ * Minimal D2XX type/function declarations implemented by aether_serial_compat.c.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+typedef unsigned int DWORD;
+typedef unsigned int ULONG;
+typedef unsigned short USHORT;
+typedef unsigned char UCHAR;
+typedef unsigned char BOOL;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* FT_HANDLE;
+typedef ULONG FT_STATUS;
+
+enum {
+    FT_OK = 0,
+    FT_INVALID_HANDLE = 1,
+    FT_DEVICE_NOT_FOUND = 2,
+    FT_DEVICE_NOT_OPENED = 3,
+    FT_IO_ERROR = 4,
+    FT_INSUFFICIENT_RESOURCES = 5,
+    FT_INVALID_PARAMETER = 6,
+    FT_INVALID_BAUD_RATE = 7,
+    FT_OTHER_ERROR = 18
+};
+
+#define FT_OPEN_BY_SERIAL_NUMBER 1
+#define FT_BAUD_230400 230400
+#define FT_BAUD_460800 460800
+#define FT_BITS_8 ((UCHAR)8)
+#define FT_STOP_BITS_1 ((UCHAR)0)
+#define FT_PARITY_NONE ((UCHAR)0)
+#define FT_FLOW_NONE 0x0000
+#define FT_FLOW_RTS_CTS 0x0100
+
+typedef struct _ft_device_list_info_node {
+    ULONG Flags;
+    ULONG Type;
+    ULONG ID;
+    DWORD LocId;
+    char SerialNumber[256];
+    char Description[128];
+    FT_HANDLE ftHandle;
+} FT_DEVICE_LIST_INFO_NODE;
+
+FT_STATUS FT_CreateDeviceInfoList(DWORD* numDevs);
+FT_STATUS FT_GetDeviceInfoList(FT_DEVICE_LIST_INFO_NODE* dest, DWORD* numDevs);
+FT_STATUS FT_OpenEx(void* arg, DWORD flags, FT_HANDLE* handle);
+FT_STATUS FT_Close(FT_HANDLE handle);
+FT_STATUS FT_Read(FT_HANDLE handle, void* buffer, DWORD bytesToRead, DWORD* bytesReturned);
+FT_STATUS FT_Write(FT_HANDLE handle, void* buffer, DWORD bytesToWrite, DWORD* bytesWritten);
+FT_STATUS FT_SetBaudRate(FT_HANDLE handle, ULONG baudRate);
+FT_STATUS FT_SetDataCharacteristics(FT_HANDLE handle, UCHAR wordLength, UCHAR stopBits, UCHAR parity);
+FT_STATUS FT_SetTimeouts(FT_HANDLE handle, ULONG readTimeout, ULONG writeTimeout);
+FT_STATUS FT_SetFlowControl(FT_HANDLE handle, USHORT flowControl, UCHAR xon, UCHAR xoff);
+FT_STATUS FT_SetLatencyTimer(FT_HANDLE handle, UCHAR timer);
+FT_STATUS FT_GetStatus(FT_HANDLE handle, DWORD* rxBytes, DWORD* txBytes, DWORD* eventWord);
+
+#ifdef __cplusplus
+}
+#endif

--- a/third_party/smartsdr-dsp/main.c
+++ b/third_party/smartsdr-dsp/main.c
@@ -1,0 +1,105 @@
+/*
+ * AetherSDR D-Star waveform helper entry point.
+ *
+ * Copyright (C) 2026 AetherSDR contributors.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "smartsdr_dsp_api.h"
+#include "aether_vocoder_backend.h"
+#include "common.h"
+
+const char* APP_NAME = "ThumbDV";
+char * cfg_path = NULL;
+static volatile sig_atomic_t shutdown_requested = 0;
+
+static void on_signal(int signo)
+{
+    (void)signo;
+    shutdown_requested = 1;
+}
+
+static const char* value_arg(int* i, int argc, char** argv, const char* arg, const char* option)
+{
+    const size_t option_len = strlen(option);
+    if (strncmp(arg, option, option_len) == 0 && arg[option_len] == '=') {
+        return arg + option_len + 1;
+    }
+    if (strcmp(arg, option) == 0 && *i + 1 < argc) {
+        (*i)++;
+        return argv[*i];
+    }
+    return NULL;
+}
+
+int main(int argc, char* argv[])
+{
+    BOOL enable_console = FALSE;
+    const char* radio_ip = NULL;
+    const char* vocoder = NULL;
+
+    signal(SIGINT, on_signal);
+    signal(SIGTERM, on_signal);
+    signal(SIGPIPE, SIG_IGN);
+
+    for (int i = 1; i < argc; ++i) {
+        const char* arg = argv[i];
+        const char* value = NULL;
+        if (strcmp(arg, "--console") == 0) {
+            enable_console = TRUE;
+        } else if ((value = value_arg(&i, argc, argv, arg, "--host")) != NULL
+                   || (value = value_arg(&i, argc, argv, arg, "--ip")) != NULL) {
+            radio_ip = value;
+        } else if ((value = value_arg(&i, argc, argv, arg, "--serial")) != NULL) {
+            setenv("AETHER_DSTAR_THUMBDV_SERIAL", value, 1);
+        } else if ((value = value_arg(&i, argc, argv, arg, "--vocoder")) != NULL
+                   || (value = value_arg(&i, argc, argv, arg, "--backend")) != NULL) {
+            vocoder = value;
+        } else if ((value = value_arg(&i, argc, argv, arg, "--cfg_path")) != NULL) {
+            cfg_path = strdup(value);
+        } else if (value_arg(&i, argc, argv, arg, "--mode") != NULL
+                   || value_arg(&i, argc, argv, arg, "--underlying-mode") != NULL) {
+            continue;
+        } else {
+            output("Unknown parameter - '%s'\n", arg);
+        }
+    }
+
+    if (vocoder == NULL || vocoder[0] == '\0') {
+        vocoder = getenv("AETHER_DSTAR_VOCODER");
+    }
+    if (aether_vocoder_set_kind_from_name(vocoder) != 0) {
+        output("Unknown D-Star vocoder backend '%s'\n", vocoder);
+        return 2;
+    }
+
+    if (radio_ip == NULL || radio_ip[0] == '\0') {
+        radio_ip = getenv("SSDR_RADIO_ADDRESS");
+    }
+    if (radio_ip == NULL || radio_ip[0] == '\0') {
+        output("Missing --host/SSDR_RADIO_ADDRESS\n");
+        return 2;
+    }
+    if (aether_vocoder_requires_serial() && getenv("AETHER_DSTAR_THUMBDV_SERIAL") == NULL) {
+        output("Missing --serial/AETHER_DSTAR_THUMBDV_SERIAL\n");
+        return 2;
+    }
+    if (cfg_path == NULL) {
+        cfg_path = strdup("./");
+    }
+
+    output("D-Star vocoder backend: %s\n", aether_vocoder_name());
+    SmartSDR_API_Init(enable_console, radio_ip);
+    while (!shutdown_requested) {
+        pause();
+    }
+    SmartSDR_API_Shutdown();
+    free(cfg_path);
+    return 0;
+}

--- a/third_party/smartsdr-dsp/main.h
+++ b/third_party/smartsdr-dsp/main.h
@@ -1,0 +1,31 @@
+/* *****************************************************************************
+ *	main.h															2014 AUG 23
+ *
+ *  Author: Graham / KE9H
+ *
+ *	Date created: August 5, 2014
+ *
+ *	Wrapper program for "Embedded FreeDV" including CODEC2
+ *
+ * *****************************************************************************
+ *
+ *	Copyright (C) 2014 FlexRadio Systems.
+ *	This program is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *	GNU General Public License for more details.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************** */
+
+#ifndef MAIN_H_
+#define MAIN_H_
+
+void freedv_set_string(uint32 slice, char* string);
+
+#endif /* MAIN_H_ */

--- a/third_party/smartsdr-dsp/resampler.c
+++ b/third_party/smartsdr-dsp/resampler.c
@@ -1,0 +1,175 @@
+/* *****************************************************************************
+ *	resampler.c														2014 AUG 23
+ *
+ *	Upsampler and downsampler by integer 3
+ *		for translation to/from 8 ksps from/to 24 ksps
+ *
+ *	Includes 4 kHz Low Pass filter in each instance
+ *
+ *	Derived from code released by David Rowe as part of FreeDV/CODEC2 project
+ *	Adapted by Graham / KE9H
+ *
+ * *****************************************************************************
+ *
+ *	Copyright (C) 2014 FlexRadio Systems.
+ *	This program is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *	GNU General Public License for more details.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************** */
+
+
+#include "resampler.h"
+
+
+// For 8 to 24 kHz sample rate conversion */
+
+#define FDMDV_OS                 3   	// oversampling rate
+#define FDMDV_OS_TAPS           48  	// number of OS filter taps
+
+
+
+/* *****************************************************************************
+ *	Coefficients for 4 kHz low pass filter at 24 ksps for 48 tap FIR filter
+ *
+ * 	Generated using fir1(47, 1/3) in MatLab (Octave)
+ */
+
+const float fdmdv_os24_filter[]= {
+	-0.000565842330864509,
+	-0.00119184233667459,
+	-0.000686550128357081,
+	 0.000939738560355487,
+	 0.00235824811185176,
+	 0.00149083509882116,
+	-0.00207002114214581,
+	-0.00516284617910486,
+	-0.00318858060009128,
+	 0.00422846062091092,
+	 0.0102371199934064,
+	 0.00615820273645780,
+	-0.00786127965697296,
+	-0.0187253107816201,
+	-0.0111560475540299,
+	 0.0139752338625282,
+	 0.0334879967920482,
+	 0.0202917237268834,
+	-0.0258029481868858,
+	-0.0651503052036609,
+	-0.0430343789277145,
+	 0.0624453219256916,
+	 0.210663786004670,
+	 0.318319285594497,
+	 0.318319285594497,
+	 0.210663786004670,
+	 0.0624453219256916,
+	-0.0430343789277145,
+	-0.0651503052036609,
+	-0.0258029481868858,
+	 0.0202917237268834,
+	 0.0334879967920482,
+	 0.0139752338625282,
+	-0.0111560475540299,
+	-0.0187253107816201,
+	-0.00786127965697296,
+	 0.00615820273645780,
+	 0.0102371199934064,
+	 0.00422846062091092,
+	-0.00318858060009128,
+	-0.00516284617910486,
+	-0.00207002114214581,
+	 0.00149083509882116,
+	 0.00235824811185176,
+	 0.000939738560355487,
+	-0.000686550128357081,
+	-0.00119184233667459,
+	-0.000565842330864509
+};
+
+
+/* *****************************************************************************
+ *	void fdmdv_8_to_24(float out24k[], float in8k[], int n)
+ *
+ *	Changes the sample rate of a signal from 8 to 24 kHz.
+ *	8 ksps is the native sampling rate of the CODEC2 vocoder.
+ *  24 ksps is the native audio/baseband sampling rate for the FLEX-6000 series.
+ *
+ *	n is the number of samples at the 8 ksps rate.
+ *	There are  (FDMDV_OS * n)  samples at the 24 ksps rate.
+ *	A memory of FDMDV_OS_TAPS/FDMDV_OS samples is required for in8k[]
+ *		(see [David Rowe] t48_8.c unit test as example).
+ *
+ *	This is a classic polyphase upsampler.  We take the 8 ksps samples
+ *	and insert (FDMDV_OS - 1) zeroes between each sample, then
+ *	FDMDV_OS_TAPS FIR low pass filter the signal at 4kHz.  As most of
+ *	the input samples are zeroes, we only need to multiply non-zero
+ *	input samples by filter coefficients.  The zero insertion and
+ *	filtering are combined in the code below.
+ *
+ **************************************************************************** */
+
+void fdmdv_8_to_24(float out24k[], float in8k[], int n)
+{
+    int i,j,k,l;
+
+    /* make sure n is an integer multiple of the oversampling rate, otherwise
+       this function breaks */
+
+    // assert((n % FDMDV_OS) == 0);
+
+    for(i=0; i<n; i++)
+    {
+		for(j=0; j<FDMDV_OS; j++)
+		{
+			out24k[i*FDMDV_OS+j] = 0.0;
+			for(k=0,l=0; k<FDMDV_OS_TAPS; k+=FDMDV_OS,l++)
+			out24k[i*FDMDV_OS+j] += fdmdv_os24_filter[k+j]*in8k[i-l];
+			out24k[i*FDMDV_OS+j] *= FDMDV_OS;
+		}
+    }
+
+    /* update filter memory */
+    for(i=-(FDMDV_OS_TAPS/FDMDV_OS); i<0; i++)
+	in8k[i] = in8k[i + n];
+}
+
+
+/* *****************************************************************************
+ *	void fdmdv_24_to_8(float out8k[], float in24k[], int n)
+ *
+ *	Changes the sample rate of a signal from 24 to 8 kHz.
+ *
+ *	n is the number of samples at the 8 kHz rate, there are FDMDV_OS*n
+ *	samples at the 24 kHz rate.  As above however a memory of
+ *	FDMDV_OS_TAPS samples is reqd for in24k[] (see t48_8.c unit test as example).
+ *
+ *	Low pass filter the 24 ksps signal at 4 kHz using the same filter as
+ *	the upsampler, then just output every FDMDV_OS-th filtered sample.
+ *
+ **************************************************************************** */
+
+void fdmdv_24_to_8(float out8k[], float in24k[], int n)
+{
+    int i,j;
+
+    for(i=0; i<n; i++)
+    {
+		out8k[i] = 0.0;
+		for(j=0; j<FDMDV_OS_TAPS; j++)
+			out8k[i] += fdmdv_os24_filter[j]*in24k[i*FDMDV_OS-j];
+    }
+
+    /* update filter memory */
+    for(i=-FDMDV_OS_TAPS; i<0; i++)
+	in24k[i] = in24k[i + n*FDMDV_OS];
+}
+
+
+// EoF =====-----

--- a/third_party/smartsdr-dsp/resampler.h
+++ b/third_party/smartsdr-dsp/resampler.h
@@ -1,0 +1,41 @@
+/* *****************************************************************************
+ *	resampler.h														2014 AUG 23
+ *
+ *	Upsampler and downsampler by integer 3
+ *		for translation to/from 8 ksps from/to 24 ksps
+ *
+ *	Includes 4 kHz Low Pass filter in each instance
+ *
+ *	Derived from code released by David Rowe as part of FreeDV/CODEC2 project
+ *	Adapted by Graham / KE9H
+ *
+ * *****************************************************************************
+ *
+ *	Copyright (C) 2014 FlexRadio Systems.
+ *	This program is free software: you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation, either version 3 of the License, or
+ *	(at your option) any later version.
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *	GNU General Public License for more details.
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************** */
+
+
+#ifndef RESAMPLER_H_
+#define RESAMPLER_H_
+
+
+#define RESAMPLES	384		// Must be divisible by 3
+
+void fdmdv_8_to_24(float out24k[], float in8k[], int n);
+void fdmdv_24_to_8(float out8k[], float in24k[], int n);
+
+
+#endif /* RESAMPLER_H_ */
+
+// EoF =====-----


### PR DESCRIPTION
## Summary

Adds local D-STAR waveform support to AetherSDR through the Flex waveform API with ThumbDV/DV3000 vocoder support. AetherSDR now builds and launches a bundled `aether-dstar-waveform` helper, exposes Local D-STAR controls in the Waveforms window, auto-detects likely ThumbDV serial devices, and runs the helper locally against the connected radio.

This also hardens radio waveform management: install/restart/remove commands validate protocol tokens, waveform package reads are bounded before loading file data, radio/user-provided strings are escaped or rendered as plain text, Docker waveform installs are gated on WFP readiness, and install progress/result dialogs now use the app's frameless dialog pattern.

### Potential concerns addressed

- **Software AMBE removed:** Software AMBE encode/decode is intentionally not bundled in this PR due to patent review concerns. `third_party/droidstar-vocoder/` was removed, the helper rejects `--vocoder software`, and the UI no longer offers a software vocoder option.
- **ThumbDV dependency:** D-STAR currently requires a ThumbDV/DV3000 attached to the computer running AetherSDR. The app auto-detects likely serial devices so users do not need to type `/dev/cu.*` paths manually.
- **Radio vs local execution:** The D-STAR helper runs locally on the AetherSDR computer and talks to the radio through the Flex waveform API; the ThumbDV plugs into the local computer, not the radio.
- **I/Q requirements:** The helper uses `underlying_mode=DFM`, so the radio performs the FM discriminator stage and the helper receives demodulated waveform samples. Raw I/Q is not required for this path.
- **Transmit safety:** Starting the helper does not key the transmitter. TX data is only produced when the operator intentionally keys a DSTR slice.
- **License boundary:** Bundled sources are documented in `THIRD_PARTY_LICENSES`. The helper uses public GPL-compatible SmartSDR-DSP ThumbDV waveform sources and does not bundle proprietary FTDI D2XX binaries or DroidStar vocoder code.
- **Trademark boundary:** UI/docs use `D-STAR` descriptively for protocol compatibility and add an Icom trademark/no-endorsement notice.
- **Install security:** Radio command names and upload filenames are validated as protocol-safe tokens, large package reads are bounded before `readAll()`, radio/user-provided strings are escaped or rendered as plain text, and vendored helper code has CodeQL hardening for integer-width, allocation-size, format-string, and config-file-open findings.
- **Latest review feedback:** The latest push addresses the three remaining GitHub Advanced Security format-string threads in `ThumbDV/dstar.c` and `ThumbDV/thumbDV.c`; those old review anchors now show as outdated pending the next CodeQL run.

## Constitution principle honored

Principle IV - the waveform integration is based on public GPL-compatible source, with patch boundaries documented, and does not use decompiled or reverse-engineered proprietary binaries.

Principle VII - waveform install and management paths validate boundary inputs before constructing radio commands or rendering UI text, and the vendored helper CodeQL findings are addressed.

Principle V - D-STAR client settings are stored under one feature-owned JSON settings root rather than scattered flat keys.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR dstar_waveform_process_test flex_waveform_model_test -j8`)
- [x] Latest focused helper rebuild passes (`cmake --build build --target aether-dstar-waveform dstar_waveform_process_test flex_waveform_model_test -j8`)
- [x] Behavior verified with the automation bridge
  - Automation bridge opened the Waveforms window.
  - Verified Local D-STAR UI state.
  - Verified the vocoder display is fixed to `ThumbDV / DV3000`.
  - Verified the ThumbDV serial-port combo is visible and auto-selected a detected `/dev/cu.usbserial-*` device.
  - Verified no `AetherDV` or `Software AMBE` UI text appears in the Waveforms window.
  - No RF transmit test was performed.
- [x] Focused local tests pass
  - `./build/dstar_waveform_process_test`
  - `./build/flex_waveform_model_test`
  - `ctest --test-dir build -R aether_dstar_waveform_no_args --output-on-failure`
  - `./build/AetherSDR.app/Contents/MacOS/aether-dstar-waveform --vocoder software --host 127.0.0.1 --serial /dev/null` exits 2 with `Unknown D-Star vocoder backend 'software'`
  - `git diff --check`
  - `python3 tools/check_a11y.py` exits 0 with existing warning-only findings outside `WaveformsDialog`
- [ ] Existing tests pass (CI)
  - Waiting for GitHub checks to be reported after latest push `76e46a65`.
- [x] Reproduction steps documented if user-reported bug
  - Feature behavior and data path documented in `docs/architecture/dstar-thumbdv-waveform.md`.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room - not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
  - Not applicable; this is not a GHSA fix.
