### PR TITLE
perf(gui): per-pixel GPU FFT trace, present coalescing, 60 fps panadapters + get panstats bridge verb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1268,6 +1268,7 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/overlay.frag
             resources/shaders/spectrum.vert
             resources/shaders/spectrum.frag
+            resources/shaders/panscope.frag
             resources/shaders/dss_mesh.vert
             resources/shaders/dss_mesh.frag
     )

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -141,6 +141,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get dsp`](#get-dsp) | Client-side AetherDSP NR state (NR2…BNR). |
 | | [`get radio \| transmit \| eq \| meters`](#get) | Radio / TX-chain / EQ / meters snapshots. |
 | | [`get slice[s] \| pan[s]`](#get) | Slice & panadapter model snapshots. |
+| | [`get panstats`](#get-panstats) | Per-panadapter render-cost counters (profiling). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
 | **Connection** | [`connect …`](#connect--disconnect) | list / show / hide / local / ip / wait. |
 | | [`disconnect`](#connect--disconnect) | Normal user disconnect. |
@@ -409,9 +410,44 @@ connects).
 | `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, **squelch/squelchLevel, agcMode/agcThreshold, apf/apfLevel**, txSlice, …) |
 | `pans` | — | array of all panadapter snapshots |
 | `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps) |
+| `panstats` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter render-cost counters — see [`get panstats`](#get-panstats) |
 
 Add a trailing **property** name to any single-object form to get just that
 field: `get slice active mode` → `{"value":"LSB"}`.
+
+### `get panstats`
+Per-panadapter (SpectrumWidget) frame-cost counters — how much GUI-thread time
+each pan spends preparing frames, split by pipeline section, for before/after
+rendering-cost proofs without a profiler attach. Counters are always on and
+cost a few integer adds per frame.
+
+```json
+→ {"cmd":"get","model":"panstats"}
+← {"ok":true,"model":"panstats","pans":[{
+   "panIndex":0,"renderMode":"2D","renderer":"GPU QRhi (Metal; Apple M1 Ultra)",
+   "widthPx":2280,"heightPx":1302,"dpr":2.0,"leanMode":false,"sinceMs":60012,
+   "fftFramesPerSec":29.6,"ingestMsPerSec":8.1,
+   "gpuFramesPerSec":29.6,"gpuFrameMsPerSec":97.4,"avgGpuFrameUs":3290.0,
+   "fftBuildMsPerSec":64.2,"fftVboBytesPerSec":42049536.0,
+   "overlayRebuildsPerSec":0.1,"overlayRebuildMsPerSec":1.9,
+   "overlayUploadBytesPerSec":3964928.0,"wfUploadBytesPerSec":18240.0,
+   "paintsPerSec":0.0,"paintMsPerSec":0.0,
+   "overlayDirtyCauses":{"smartMtr":2,"detect":1,"other":3}}]}
+```
+
+| field | meaning |
+|---|---|
+| `gpuFrameMsPerSec` | **the headline number** — main-thread ms consumed per wall-second preparing + encoding this pan's GPU frames |
+| `ingestMsPerSec` | `updateSpectrum()` cost (EMA smoothing, noise floor, waterfall fallback pacing) |
+| `fftBuildMsPerSec` / `fftVboBytesPerSec` | FFT trace resample + vertex bake cost and VBO upload volume |
+| `overlayRebuilds*`, `overlayUploadBytesPerSec` | static-overlay QPainter repaints (should be ~0/s when idle) |
+| `overlayDirtyCauses` | first-cause attribution for each overlay rebuild (`smartMtr`, `detect`, `other`) |
+| `wfUploadBytesPerSec` | waterfall texture upload volume |
+| `paintsPerSec` / `paintMsPerSec` | software-QPainter path (non-zero only before QRhi init or in non-GPU builds) |
+
+`selector` filters by pan index (`get panstats 0`) or objectName. `property`
+`reset` zeroes the counters after the read so successive reads measure
+disjoint intervals: `get panstats 0 reset`.
 
 ### `get dsp`
 Client-side **AetherDSP** noise-reduction state — the counterpart to the

--- a/resources/shaders/panscope.frag
+++ b/resources/shaders/panscope.frag
@@ -1,0 +1,118 @@
+#version 440
+
+// 2D FFT spectrum trace, evaluated per-pixel from a width×1 R32F column
+// texture holding the display trace as normalized amplitude t (0 = bottom of
+// the dynamic range, 1 = ref level). Replaces the CPU vertex bake (two
+// feather/core triangle strips + a 2N fill strip re-generated and re-uploaded
+// every frame): the CPU now uploads ~one float per device pixel column and
+// this shader reproduces the same layers —
+//   1. fill under the trace (heat-map or solid-gradient, alpha from the
+//      fill slider; suppressed in lean mode),
+//   2. a feather stroke (line width + featherPx, low alpha),
+//   3. the core stroke (line width, high alpha),
+// with slope-corrected stroke width via screen-space derivatives so steep
+// peak flanks keep the same pixel width the old perpendicular-offset
+// geometry had. LINEAR column sampling interpolates between columns exactly
+// like the old per-point polyline. Emits PREMULTIPLIED color; the fill/line
+// layer composites over the waterfall + background quads.
+
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 fragColor;
+
+layout(binding = 1) uniform sampler2D columns;
+
+layout(std140, binding = 0) uniform U {
+    vec4 plot;       // wPx, hPx, columnCount, hasData
+    vec4 stroke;     // coreHalfWidthPx, featherPx, coreAlpha, featherAlpha
+    vec4 fillP;      // fillAlpha, heatMap (0/1), lean (0/1), pad
+    vec4 fillColor;  // straight rgb, a unused
+    vec4 darkColor;  // straight rgb (solid-mode base blend), a unused
+};
+
+// Straight color + coverage → premultiplied.
+vec4 pm(vec3 rgb, float a, float cov)
+{
+    float pa = clamp(a * cov, 0.0, 1.0);
+    return vec4(rgb * pa, pa);
+}
+
+// src OVER dst, both premultiplied.
+vec4 over(vec4 dst, vec4 src)
+{
+    return src + dst * (1.0 - src.a);
+}
+
+// Same 4-stop heat ramp the vertex bake used (blue → cyan → green → red).
+vec3 heatColor(float t)
+{
+    if (t < 0.25) {
+        return vec3(0.0, t / 0.25, 1.0);
+    } else if (t < 0.5) {
+        return vec3(0.0, 1.0, 1.0 - (t - 0.25) / 0.25);
+    } else if (t < 0.75) {
+        return vec3((t - 0.5) / 0.25, 1.0, 0.0);
+    }
+    return vec3(1.0, 1.0 - (t - 0.75) / 0.25, 0.0);
+}
+
+void main()
+{
+    vec4 outc = vec4(0.0);
+    if (plot.w < 0.5) {
+        fragColor = outc;
+        return;
+    }
+
+    float hPx = plot.y;
+    float py = v_uv.y * hPx;                       // y-down device px
+    float t = clamp(texture(columns, vec2(v_uv.x, 0.5)).r, 0.0, 1.0);
+    float yTrace = (1.0 - t) * hPx;                // trace top edge in px
+
+    bool heat = fillP.y > 0.5;
+    bool lean = fillP.z > 0.5;
+    float fa = lean ? 0.0 : fillP.x;
+
+    // ── Fill under the trace ────────────────────────────────────────────
+    if (fa > 0.0 && py >= yTrace) {
+        float g = (hPx > yTrace)
+            ? clamp((py - yTrace) / (hPx - yTrace), 0.0, 1.0) : 0.0;
+        vec3 rgb;
+        float a;
+        if (heat) {
+            // Heat: trace color at the line fading to dark blue at the base.
+            rgb = mix(heatColor(t), vec3(0.0, 0.0, 0.3), g);
+            a = mix(fa * 0.3, fa, g);
+        } else {
+            // Solid: bright at the line, darker + fainter toward the base,
+            // converging to a uniform solid as the slider rises (same
+            // topAlpha/botAlpha/colorBlend math as the old yColor bake).
+            vec3 topRgb = fillColor.rgb;
+            vec3 botRgb = mix(darkColor.rgb, fillColor.rgb, fa);
+            rgb = mix(topRgb, botRgb, g);
+            a = mix(fa, fa * fa, g);
+        }
+        outc = over(outc, pm(rgb, a, 1.0));
+    }
+
+    // ── Stroke (feather under core), slope-corrected width ─────────────
+    float coreHalf = stroke.x;
+    if (coreHalf > 0.0) {
+        // dFdx of the trace height gives the segment slope in px/px; scale
+        // the vertical distance to true perpendicular distance so steep
+        // flanks keep their stroke width (the old geometry offset vertices
+        // along the segment normal for the same reason).
+        float slope = dFdx(yTrace) / max(fwidth(v_uv.x) * plot.x, 1e-4);
+        float invLen = inversesqrt(1.0 + slope * slope);
+        float d = abs(py - yTrace) * invLen;
+
+        vec3 lineRgb = heat ? heatColor(t) : fillColor.rgb;
+        float featherHalf = coreHalf + stroke.y;
+        float aa = 0.75;
+        float covF = 1.0 - smoothstep(featherHalf - aa, featherHalf + aa, d);
+        outc = over(outc, pm(lineRgb, stroke.w, covF));
+        float covC = 1.0 - smoothstep(coreHalf - aa, coreHalf + aa, d);
+        outc = over(outc, pm(lineRgb, stroke.z, covC));
+    }
+
+    fragColor = outc;
+}

--- a/resources/shaders/panscope.frag
+++ b/resources/shaders/panscope.frag
@@ -65,7 +65,8 @@ void main()
 
     float hPx = plot.y;
     float py = v_uv.y * hPx;                       // y-down device px
-    float t = clamp(texture(columns, vec2(v_uv.x, 0.5)).r, 0.0, 1.0);
+    float texX = (v_uv.x * (plot.z - 1.0) + 0.5) / plot.z;
+    float t = clamp(texture(columns, vec2(texX, 0.5)).r, 0.0, 1.0);
     float yTrace = (1.0 - t) * hPx;                // trace top edge in px
 
     bool heat = fillP.y > 0.5;

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2600,6 +2600,53 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                            {QStringLiteral("model"), model},
                            {QStringLiteral("dsp"), data}};
     }
+    if (model == QLatin1String("panstats")) {
+        // Per-panadapter frame-cost counters from every SpectrumWidget, for
+        // before/after rendering-cost proofs without a profiler attach.
+        // selector filters by pan index or objectName; property "reset"
+        // zeroes the counters after the read so successive reads measure
+        // disjoint intervals. GUI-header-free: snapshotted via meta-call.
+        const bool reset = property == QLatin1String("reset");
+        bool selectorIsIndex = false;
+        const int wantIndex = selector.toInt(&selectorIsIndex);
+        QJsonArray pans;
+        // A floated container is reachable from two top-level roots, so the
+        // class walk can yield the same widget twice — dedupe by pointer.
+        QSet<QWidget*> seen;
+        const QList<QWidget*> widgets =
+            findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+        for (QWidget* w : widgets) {
+            if (seen.contains(w))
+                continue;
+            seen.insert(w);
+            if (!selector.isEmpty() && !selectorIsIndex
+                && w->objectName() != selector)
+                continue;
+            // Read without resetting first: index filtering needs the
+            // snapshot's own panIndex (panIndex() is a plain accessor, not a
+            // Q_PROPERTY), and a filtered-out pan must keep its counters.
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(w, "panstatsSnapshot",
+                                           Qt::DirectConnection,
+                                           Q_RETURN_ARG(QVariantMap, snap),
+                                           Q_ARG(bool, false)))
+                continue;
+            if (!selector.isEmpty() && selectorIsIndex
+                && snap.value(QStringLiteral("panIndex")).toInt() != wantIndex)
+                continue;
+            if (reset) {
+                QVariantMap discard;
+                QMetaObject::invokeMethod(w, "panstatsSnapshot",
+                                          Qt::DirectConnection,
+                                          Q_RETURN_ARG(QVariantMap, discard),
+                                          Q_ARG(bool, true));
+            }
+            pans.append(QJsonObject::fromVariantMap(snap));
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("pans"), pans}};
+    }
     if (model == QLatin1String("sync")
         || model == QLatin1String("receiveSync")) {
         if (!m_receiveSyncSnapshotHandler) {
@@ -2681,7 +2728,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans|kiwi)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans|panstats|kiwi)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -27,7 +27,9 @@ static void refreshAfterReparent(AetherSDR::SpectrumWidget* sw)
     if (QWindow* windowHandle = sw->windowHandle()) {
         windowHandle->destroy();
     }
-    sw->setAttribute(Qt::WA_NativeWindow);
+    if (AetherSDR::SpectrumWidget::nativeWindowPreferred()) {
+        sw->setAttribute(Qt::WA_NativeWindow);
+    }
     if (wasVisible) {
         sw->show();
     }

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1370,8 +1370,10 @@ void SpectrumOverlayMenu::buildDisplayPanel()
         emit fftAverageChanged(v);
     });
 
-    // FPS
-    makeRow("FFT FPS:", 5, 30, 25, m_fpsSlider, m_fpsLabel);
+    // FPS — 60 ceiling: the per-pixel trace path made per-frame prep cost
+    // width-flat (~120 µs), so the display, not the client, is the limit.
+    // The radio clamps what it will actually deliver.
+    makeRow("FFT FPS:", 5, 60, 25, m_fpsSlider, m_fpsLabel);
     m_fpsSlider->setObjectName("displayFftFpsSlider");
     connect(m_fpsSlider, &QSlider::valueChanged, this, [this](int v) {
         m_fpsLabel->setText(QString::number(v));

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -815,6 +815,56 @@ QString SpectrumWidget::rendererDescription() const
 #endif
 }
 
+QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
+{
+    const double secs = std::max(0.001, m_panStats.sinceMs() / 1000.0);
+    const auto msPerSec = [secs](quint64 us) { return (us / 1000.0) / secs; };
+
+    QVariantMap m;
+    m[QStringLiteral("panIndex")] = m_panIndex;
+    m[QStringLiteral("name")] = objectName();
+    m[QStringLiteral("visible")] = isVisible();
+    m[QStringLiteral("widthPx")] = width();
+    m[QStringLiteral("heightPx")] = height();
+    m[QStringLiteral("dpr")] = devicePixelRatioF();
+    m[QStringLiteral("renderMode")] =
+        m_spectrumRenderMode == SpectrumRenderMode::Mode3D
+            ? QStringLiteral("3D") : QStringLiteral("2D");
+    m[QStringLiteral("renderer")] = rendererDescription();
+    m[QStringLiteral("leanMode")] = m_leanMode;
+    m[QStringLiteral("sinceMs")] = static_cast<qlonglong>(m_panStats.sinceMs());
+
+    m[QStringLiteral("fftFramesPerSec")] = m_panStats.updateSpectrumCalls / secs;
+    m[QStringLiteral("ingestMsPerSec")] = msPerSec(m_panStats.updateSpectrumUs);
+    m[QStringLiteral("gpuFramesPerSec")] = m_panStats.gpuFrames / secs;
+    // Main-thread budget consumed preparing + encoding GPU frames, in
+    // "ms per wall second" — the single number to compare before/after.
+    m[QStringLiteral("gpuFrameMsPerSec")] = msPerSec(m_panStats.gpuFrameUs);
+    m[QStringLiteral("avgGpuFrameUs")] = m_panStats.gpuFrames
+        ? static_cast<double>(m_panStats.gpuFrameUs) / m_panStats.gpuFrames : 0.0;
+    m[QStringLiteral("fftBuildMsPerSec")] = msPerSec(m_panStats.fftBuildUs);
+    m[QStringLiteral("fftVboBytesPerSec")] =
+        static_cast<double>(m_panStats.fftVboBytes) / secs;
+    m[QStringLiteral("overlayRebuildsPerSec")] = m_panStats.overlayRebuilds / secs;
+    m[QStringLiteral("overlayRebuildMsPerSec")] = msPerSec(m_panStats.overlayRebuildUs);
+    m[QStringLiteral("overlayUploadBytesPerSec")] =
+        static_cast<double>(m_panStats.overlayUploadBytes) / secs;
+    m[QStringLiteral("wfUploadBytesPerSec")] =
+        static_cast<double>(m_panStats.wfUploadBytes) / secs;
+    m[QStringLiteral("paintsPerSec")] = m_panStats.paintEvents / secs;
+    m[QStringLiteral("paintMsPerSec")] = msPerSec(m_panStats.paintUs);
+
+    QVariantMap causes;
+    for (auto it = m_panStats.dirtyCauses.cbegin();
+         it != m_panStats.dirtyCauses.cend(); ++it)
+        causes[QString::fromLatin1(it.key())] = static_cast<qulonglong>(it.value());
+    m[QStringLiteral("overlayDirtyCauses")] = causes;
+
+    if (reset)
+        m_panStats.reset();
+    return m;
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
@@ -823,6 +873,8 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // through the "spectrum" scope chain.  Token migration into this
     // scope happens in step 4 of the refactor.
     theme::setContainer(this, QStringLiteral("spectrum"));
+
+    m_panStats.clock.start();  // panstats rates are meaningless without an epoch
 
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -835,9 +887,14 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // WA_NativeWindow forces Qt to create a dedicated native NSView for this widget.
     // Without it, QRhiWidget embedded in a QWidget hierarchy (especially one whose
     // backing store was created before this widget was added) fails to obtain a QRhi
-    // context because the parent window's surface type is RasterSurface, not MetalSurface.
-    // A native window gives QRhiWidget its own Metal-capable surface to render into.
-    setAttribute(Qt::WA_NativeWindow);
+    // context because the parent window's surface type is RasterSurface, not MetalSurface
+    // (#714, Qt 6.6 era). The native view is expensive, though: every present forces
+    // a raster flushSubWindow blend of the pan region on the GUI thread.
+    // AETHER_PAN_NO_NATIVE_WINDOW=1 skips it to validate the composited path on
+    // newer Qt, where the whole window flushes through one rhi swapchain.
+    if (nativeWindowPreferred()) {
+        setAttribute(Qt::WA_NativeWindow);
+    }
 #  else
     // Warn if running under XWayland — GLX context switching between the main
     // window and child dialogs (e.g. Radio Setup) can trigger BadAccess (#1233).
@@ -1321,7 +1378,7 @@ VfoWidget* SpectrumWidget::addVfoWidget(int sliceId)
     // The flag's SmartMTR value labels are painted in our overlay pass; refresh
     // the overlay whenever they change or the flag moves.
     connect(w, &VfoWidget::smartMtrLabelsChanged, this,
-            [this]() { markOverlayDirty(); });
+            [this]() { markOverlayDirty("smartMtr"); });
     m_vfoWidgets[sliceId] = w;
     w->show();
     w->raise();
@@ -4881,6 +4938,13 @@ void SpectrumWidget::setSliceInfo(int sliceId, bool isTxSlice)
 void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
 {
     PerfUpdateScope perfScope(PerfUpdateScope::Kind::Panadapter);
+    m_panStats.updateSpectrumCalls++;
+    struct IngestCost {
+        quint64& acc;
+        QElapsedTimer t;
+        explicit IngestCost(quint64& a) : acc(a) { t.start(); }
+        ~IngestCost() { acc += static_cast<quint64>(t.nsecsElapsed() / 1000); }
+    } panStatsIngestCost(m_panStats.updateSpectrumUs);
     if (!binsDbm.isEmpty()) {
         recordPanadapterFrame();
         if (PerfTelemetry::instance().enabled())
@@ -7227,14 +7291,34 @@ void SpectrumWidget::setLeanMode(bool on)
 
 void SpectrumWidget::leanCappedUpdate()
 {
-    if (m_leanMode) {
-        if (m_leanRepaintClock.isValid()
-            && m_leanRepaintClock.elapsed() < kLeanFrameMs) {
-            return;  // drop frames above ~30 Hz (kLeanFrameMs = 33)
-        }
-        m_leanRepaintClock.restart();
+    // Data-driven repaints (FFT frames, waterfall rows) coalesce into one
+    // present per slot; interactive paths still call update() directly so
+    // input latency is unaffected. Lean mode drops excess frames outright
+    // (~30 Hz cap); normal mode never drops — a trailing update presents
+    // whatever arrived inside the slot.
+    const int slotMs = m_leanMode ? kLeanFrameMs : kPresentCoalesceMs;
+    if (!m_leanRepaintClock.isValid()) {
+        m_leanRepaintClock.start();
+        update();
+        return;
     }
-    update();
+    const qint64 sinceMs = m_leanRepaintClock.elapsed();
+    if (sinceMs >= slotMs) {
+        m_leanRepaintClock.restart();
+        update();
+        return;
+    }
+    if (m_leanMode) {
+        return;  // drop frames above ~30 Hz (kLeanFrameMs = 33)
+    }
+    if (!m_presentPending) {
+        m_presentPending = true;
+        QTimer::singleShot(static_cast<int>(slotMs - sinceMs), this, [this]() {
+            m_presentPending = false;
+            m_leanRepaintClock.restart();
+            update();
+        });
+    }
 }
 
 void SpectrumWidget::setBackgroundImage(const QString& path)
@@ -8048,70 +8132,73 @@ void SpectrumWidget::initSpectrumPipeline()
 {
     QRhi* r = rhi();
 
-    // Dynamic vertex buffers: two 2N triangle-strip line passes (feather + core)
-    // and one 2N triangle-strip fill.
-    m_fftLineVbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
-                                 kMaxFftBins * 4 * kFftVertStride * sizeof(float));
-    m_fftLineVbo->create();
+    // Column texture is (re)created at the spectrum viewport width in
+    // renderGpuFrame; only the fixed resources are built here. R32F is
+    // universal on the desktop backends; fall back to R16F (mandatory
+    // linear-filterable since GLES3) for anything that lacks it.
+    m_fftColFormat = r->isTextureFormatSupported(QRhiTexture::R32F)
+        ? QRhiTexture::R32F : QRhiTexture::R16F;
+    m_fftScopeUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer,
+                                 5 * 4 * sizeof(float));
+    m_fftScopeUbo->create();
 
-    m_fftFillVbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
-                                 kMaxFftBins * 2 * kFftVertStride * sizeof(float));
-    m_fftFillVbo->create();
+    // LINEAR column sampling interpolates the trace between device pixel
+    // columns exactly like the old per-point polyline did between vertices.
+    m_fftColSampler = r->newSampler(QRhiSampler::Linear, QRhiSampler::Linear,
+                                    QRhiSampler::None,
+                                    QRhiSampler::ClampToEdge,
+                                    QRhiSampler::ClampToEdge);
+    m_fftColSampler->create();
 
-    // No uniforms — color is per-vertex
-    m_fftSrb = r->newShaderResourceBindings();
-    m_fftSrb->setBindings({});
-    m_fftSrb->create();
-
-    QShader vs = loadShader(":/shaders/resources/shaders/spectrum.vert.qsb");
-    QShader fs = loadShader(":/shaders/resources/shaders/spectrum.frag.qsb");
+    QShader vs = loadShader(":/shaders/resources/shaders/overlay.vert.qsb");
+    QShader fs = loadShader(":/shaders/resources/shaders/panscope.frag.qsb");
     if (!vs.isValid() || !fs.isValid()) {
-        qWarning() << "SpectrumWidget: spectrum shader load failed";
+        qWarning() << "SpectrumWidget: panscope shader load failed";
         return;
     }
 
+    // Same full-viewport quad layout as the overlay pipeline (reuses m_ovVbo).
     QRhiVertexInputLayout layout;
-    layout.setBindings({{kFftVertStride * sizeof(float)}});  // stride: 7 floats
+    layout.setBindings({{4 * sizeof(float)}});
     layout.setAttributes({
-        {0, 0, QRhiVertexInputAttribute::Float2, 0},                     // position
-        {0, 1, QRhiVertexInputAttribute::Float4, 2 * sizeof(float)},     // color
-        {0, 2, QRhiVertexInputAttribute::Float,  6 * sizeof(float)},     // edge
+        {0, 0, QRhiVertexInputAttribute::Float2, 0},                   // position
+        {0, 1, QRhiVertexInputAttribute::Float2, 2 * sizeof(float)},   // texcoord
     });
 
+    // panscope.frag emits premultiplied color.
     QRhiGraphicsPipeline::TargetBlend blend;
     blend.enable = true;
-    blend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
+    blend.srcColor = QRhiGraphicsPipeline::One;
     blend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
     blend.srcAlpha = QRhiGraphicsPipeline::One;
     blend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
 
-    // Fill pipeline (triangle strip)
-    m_fftFillPipeline = r->newGraphicsPipeline();
-    m_fftFillPipeline->setShaderStages({
+    m_fftScopePipeline = r->newGraphicsPipeline();
+    m_fftScopePipeline->setShaderStages({
         {QRhiShaderStage::Vertex, vs},
         {QRhiShaderStage::Fragment, fs},
     });
-    m_fftFillPipeline->setVertexInputLayout(layout);
-    m_fftFillPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
-    m_fftFillPipeline->setShaderResourceBindings(m_fftSrb);
-    m_fftFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
-    m_fftFillPipeline->setTargetBlends({blend});
-    m_fftFillPipeline->create();
-
-    // Line pipeline (line strip)
-    m_fftLinePipeline = r->newGraphicsPipeline();
-    m_fftLinePipeline->setShaderStages({
-        {QRhiShaderStage::Vertex, vs},
-        {QRhiShaderStage::Fragment, fs},
+    m_fftScopePipeline->setVertexInputLayout(layout);
+    m_fftScopePipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    // Placeholder-width column texture so the SRB is valid from the first
+    // frame; renderGpuFrame recreates it at the real viewport width.
+    m_fftColTexW = 16;
+    m_fftColTex = r->newTexture(m_fftColFormat, QSize(m_fftColTexW, 1));
+    m_fftColTex->create();
+    m_fftScopeSrb = r->newShaderResourceBindings();
+    m_fftScopeSrb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(
+            0, QRhiShaderResourceBinding::FragmentStage, m_fftScopeUbo),
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage, m_fftColTex, m_fftColSampler),
     });
-    m_fftLinePipeline->setVertexInputLayout(layout);
-    m_fftLinePipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
-    m_fftLinePipeline->setShaderResourceBindings(m_fftSrb);
-    m_fftLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
-    m_fftLinePipeline->setTargetBlends({blend});
-    m_fftLinePipeline->create();
+    m_fftScopeSrb->create();
+    m_fftScopePipeline->setShaderResourceBindings(m_fftScopeSrb);
+    m_fftScopePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+    m_fftScopePipeline->setTargetBlends({blend});
+    m_fftScopePipeline->create();
 
-    qDebug() << "SpectrumWidget: spectrum pipeline created (vertex-colored)";
+    qDebug() << "SpectrumWidget: spectrum pipeline created (per-pixel columns)";
 }
 
 void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
@@ -8371,6 +8458,15 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const bool perfEnabled = PerfTelemetry::instance().enabled();
     const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
 
+    // panstats: whole CPU-side frame prep + encode (RAII catches every exit).
+    m_panStats.gpuFrames++;
+    struct FrameCost {
+        quint64& acc;
+        QElapsedTimer t;
+        explicit FrameCost(quint64& a) : acc(a) { t.start(); }
+        ~FrameCost() { acc += static_cast<quint64>(t.nsecsElapsed() / 1000); }
+    } panStatsFrameCost(m_panStats.gpuFrameUs);
+
     const int chromeH = freqScaleH() + DIVIDER_H;
     const int contentH = h - chromeH;
     const int specH = static_cast<int>(contentH * m_spectrumFrac);
@@ -8379,7 +8475,6 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const QRect specRect(0, 0, w, specH);
     const QRect wfRect(0, wfY, w, wfH);
     int fftTracePointCount = 0;
-    int fftLineStripVertexCount = 0;
 
     // 3DSS replaces only the spectrum trace: the surface fills specRect and the
     // waterfall, divider, freq scale, and all overlays keep their normal 2D
@@ -8403,7 +8498,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             m_rfGainValue != m_lastDetectRfGain ||
             m_wideActive != m_lastDetectWide ||
             dssFloor != m_lastDetectDssFloor) {
-            markOverlayDirty();
+            markOverlayDirty("detect");
             m_lastDetectCenter = m_centerMhz; m_lastDetectBw = m_bandwidthMhz;
             m_lastDetectRef = m_refLevel; m_lastDetectDyn = m_dynamicRange;
             m_lastDetectFrac = m_spectrumFrac;
@@ -8438,6 +8533,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
             QRhiTextureSubresourceUploadDescription desc(rgba);
             batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
+            m_panStats.wfUploadBytes += static_cast<quint64>(rgba.sizeInBytes());
             if (perfEnabled)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
             m_wfLastUploadedRow = m_wfWriteRow;
@@ -8472,6 +8568,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             if (!entries.isEmpty()) {
                 uploadDesc.setEntries(entries.begin(), entries.end());
                 batch->uploadTexture(m_wfGpuTex, uploadDesc);
+                m_panStats.wfUploadBytes +=
+                    static_cast<quint64>(entries.size()) * m_wfGpuTexW * 4;
                 if (perfEnabled) {
                     PerfTelemetry::instance().recordGpuUpload(
                         PerfTelemetry::GpuUploadKind::WaterfallIncremental);
@@ -8518,6 +8616,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // panadapter resize doesn't touch them — their quads just reposition.
             m_overlayStaticDirty = true;
         }
+
+        // panstats: time the bg + static QPainter repaints as one rebuild.
+        const bool panStatsOvRebuild = m_overlayStaticDirty;
+        QElapsedTimer panStatsOvTimer;
+        if (panStatsOvRebuild)
+            panStatsOvTimer.start();
 
         // Background-image layer — kept separate from the static overlay so
         // it can render BELOW the FFT trace (parity with software paint).
@@ -8743,10 +8847,17 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             m_overlayNeedsUpload = true;
         }
 
+        if (panStatsOvRebuild) {
+            m_panStats.overlayRebuilds++;
+            m_panStats.overlayRebuildUs +=
+                static_cast<quint64>(panStatsOvTimer.nsecsElapsed() / 1000);
+        }
+
         // Upload overlay texture only when content changed
         if (m_overlayNeedsUpload) {
             QRhiTextureSubresourceUploadDescription ovDesc(m_overlayStatic);
             batch->uploadTexture(m_ovGpuTex, QRhiTextureUploadEntry(0, 0, ovDesc));
+            m_panStats.overlayUploadBytes += static_cast<quint64>(m_overlayStatic.sizeInBytes());
             if (perfEnabled)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
             m_overlayNeedsUpload = false;
@@ -8754,6 +8865,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         if (m_overlayBgNeedsUpload) {
             QRhiTextureSubresourceUploadDescription bgDesc(m_overlayBg);
             batch->uploadTexture(m_bgGpuTex, QRhiTextureUploadEntry(0, 0, bgDesc));
+            m_panStats.overlayUploadBytes += static_cast<quint64>(m_overlayBg.sizeInBytes());
             if (perfEnabled)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
             m_overlayBgNeedsUpload = false;
@@ -8908,206 +9020,95 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         // because it shows/raises widgets, which must not happen mid-render.)
         repositionVfoFlags(specRect);
 
-        // Generate FFT spectrum vertices with baked colors. 2D only — in 3D the
-        // surface replaces the trace, so skip the trace build + vertex write
-        // entirely (they were previously built and then discarded every frame).
-        const QVector<float>* fftBinsPtr = nullptr;
-        int n = 0;
-        if (!is3D) {
-            fftBinsPtr = &buildFftDisplayTrace(
-                displaySpectrumBins(),
-                qMax(2, specRect.width() * kFftDisplayOversample));
-            n = qMin(fftBinsPtr->size(), kMaxFftBins);
+        // FFT trace columns. 2D only — in 3D the surface replaces the trace.
+        // The display trace (spatially smoothed + Catmull-Rom resampled by
+        // buildFftDisplayTrace) is sampled at one point per DEVICE pixel
+        // column, normalized to the dynamic range, and uploaded as a width×1
+        // R32F texture; panscope.frag evaluates fill + feather + core stroke
+        // per pixel. This replaces the per-frame feather/core/fill vertex
+        // bake and its ~1.4 MB/frame VBO uploads.
+        QElapsedTimer panStatsFftTimer;
+        panStatsFftTimer.start();
+        if (!is3D && m_fftScopePipeline && m_fftColTex) {
+            const float fbDpr = static_cast<float>(renderTarget()->pixelSize().width())
+                              / static_cast<float>(qMax(1, w));
+            const int cols = std::clamp(
+                static_cast<int>(std::lround(specRect.width() * fbDpr)),
+                2, kMaxFftDisplayTracePoints);
+            const QVector<float>& trace =
+                buildFftDisplayTrace(displaySpectrumBins(), cols);
+            const int n = trace.size();
+            if (n >= 2) {
+                fftTracePointCount = n;
+                if (m_fftColTexW != n) {
+                    m_fftColTexW = n;
+                    m_fftColTex->setPixelSize(QSize(n, 1));
+                    m_fftColTex->create();
+                    m_fftScopeSrb->setBindings({
+                        QRhiShaderResourceBinding::uniformBuffer(
+                            0, QRhiShaderResourceBinding::FragmentStage, m_fftScopeUbo),
+                        QRhiShaderResourceBinding::sampledTexture(
+                            1, QRhiShaderResourceBinding::FragmentStage,
+                            m_fftColTex, m_fftColSampler),
+                    });
+                    m_fftScopeSrb->create();
+                }
+
+                const float minDbm = m_refLevel - m_dynamicRange;
+                const float range = qMax(1e-3f, m_dynamicRange);
+                if (m_fftColFormat == QRhiTexture::R32F) {
+                    m_fftColScratch.resize(n * int(sizeof(float)));
+                    float* colData = reinterpret_cast<float*>(m_fftColScratch.data());
+                    for (int i = 0; i < n; ++i) {
+                        colData[i] = qBound(0.0f, (trace[i] - minDbm) / range, 1.0f);
+                    }
+                } else {  // R16F fallback (GL without float32 filtering)
+                    m_fftColScratch.resize(n * int(sizeof(qfloat16)));
+                    qfloat16* colData = reinterpret_cast<qfloat16*>(m_fftColScratch.data());
+                    for (int i = 0; i < n; ++i) {
+                        colData[i] = qfloat16(
+                            qBound(0.0f, (trace[i] - minDbm) / range, 1.0f));
+                    }
+                }
+                QRhiTextureSubresourceUploadDescription colDesc;
+                colDesc.setData(m_fftColScratch);
+                colDesc.setSourceSize(QSize(n, 1));
+                batch->uploadTexture(m_fftColTex, QRhiTextureUploadEntry(0, 0, colDesc));
+                m_panStats.fftVboBytes += static_cast<quint64>(m_fftColScratch.size());
+
+                // UBO — see panscope.frag's U block.
+                const QColor dk = m_fftFillColor.darker(300);
+                const float fa = m_fftFillAlpha;
+                const float ubo[20] = {
+                    static_cast<float>(specRect.width()) * fbDpr,   // plot: wPx
+                    static_cast<float>(specH) * fbDpr,              // hPx
+                    static_cast<float>(n),                          // columnCount
+                    1.0f,                                           // hasData
+                    // Match the old vertex bake: stroke half-widths were
+                    // DEVICE-pixel offsets with no dpr scaling.
+                    m_fftLineWidth,                                 // coreHalfWidthPx
+                    kFftLineFeatherPx,                              // featherPx
+                    kFftLineCoreAlpha,
+                    kFftLineFeatherAlpha,
+                    fa,                                             // fillAlpha
+                    m_fftHeatMap ? 1.0f : 0.0f,
+                    m_leanMode ? 1.0f : 0.0f,
+                    0.0f,
+                    static_cast<float>(m_fftFillColor.redF()),
+                    static_cast<float>(m_fftFillColor.greenF()),
+                    static_cast<float>(m_fftFillColor.blueF()),
+                    1.0f,
+                    static_cast<float>(dk.redF()),
+                    static_cast<float>(dk.greenF()),
+                    static_cast<float>(dk.blueF()),
+                    1.0f,
+                };
+                batch->updateDynamicBuffer(m_fftScopeUbo, 0, sizeof(ubo), ubo);
+            }
         }
-        // n >= 2 also guards the 1/(n-1) position step and the central-difference
-        // normal (pts[i±1]) below against a degenerate 1-bin spectrum.
-        if (n >= 2 && m_fftLineVbo && m_fftFillVbo) {
-            const QVector<float>& fftBins = *fftBinsPtr;
-            fftTracePointCount = n;
-            const float minDbm = m_refLevel - m_dynamicRange;
-            const float maxDbm = m_refLevel;
-            const float range = maxDbm - minDbm;
-            const float yBot = -1.0f;
-            const float yTop = 1.0f;
-
-            // Colors from settings
-            const float fr = m_fftFillColor.redF();
-            const float fg = m_fftFillColor.greenF();
-            const float fb = m_fftFillColor.blueF();
-            const float fa = m_leanMode ? 0.0f : m_fftFillAlpha;
-
-            // Solid fill: slider sweeps from translucent gradient to solid.
-            // At low slider: soft glow under curve (bright top, dark faint base)
-            // At high slider: converges to uniform solid fill color
-            const QColor dk = m_fftFillColor.darker(300);
-            const float topAlpha = fa;
-            const float botAlpha = fa * fa;
-            // Blend bottom color from darker(300) toward fill color as slider increases
-            const float colorBlend = fa;  // 0=full dark, 1=same as top
-            const float dr = fr + (1.0f - colorBlend) * (dk.redF() - fr);
-            const float dg = fg + (1.0f - colorBlend) * (dk.greenF() - fg);
-            const float db = fb + (1.0f - colorBlend) * (dk.blueF() - fb);
-            const float gradRange = yTop - yBot;
-
-            auto yColor = [&](float vy, float* out) {
-                const float gt = (gradRange > 0)
-                    ? qBound(0.0f, (yTop - vy) / gradRange, 1.0f) : 0.0f;
-                out[0] = fr + gt * (dr - fr);
-                out[1] = fg + gt * (dg - fg);
-                out[2] = fb + gt * (db - fb);
-                out[3] = topAlpha + gt * (botAlpha - topAlpha);
-            };
-
-            // Line vertices: two 2N triangle strips. The first is a faint,
-            // wider feather that softens QRhi triangle edges on steep peaks;
-            // the second is the normal core line.
-            fftLineStripVertexCount = n * 2;
-            m_fftLineScratch.resize(n * 4 * kFftVertStride);
-            QVector<float>& lineVerts = m_fftLineScratch;
-            // Fill vertices: 2N × (x, y, r, g, b, a, edge)
-            m_fftFillScratch.resize(n * 2 * kFftVertStride);
-            QVector<float>& fillVerts = m_fftFillScratch;
-
-            // Pre-compute positions for normal calculation
-            m_fftPtScratch.resize(n);
-            QVector<FftScratchPt>& pts = m_fftPtScratch;
-            for (int i = 0; i < n; ++i) {
-                pts[i].x = 2.0f * i / (n - 1) - 1.0f;
-                float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
-                pts[i].y = yBot + t * (yTop - yBot);
-            }
-
-            // Compute the perpendicular normal in pixel space so the line
-            // width is a true pixel measurement regardless of the spectrum
-            // viewport's aspect ratio. The trace is predominantly horizontal,
-            // so the normal almost always points along Y; using a single
-            // NDC half-width based on width() collapses the offset to a
-            // sub-pixel value once specH is much smaller than width().
-            const QSize framePixelSize = renderTarget()->pixelSize();
-            const float frameDpr =
-                static_cast<float>(framePixelSize.width()) / static_cast<float>(qMax(1, width()));
-            const float wPx = static_cast<float>(qMax(1, specRect.width())) * frameDpr;
-            const float hPx = static_cast<float>(qMax(1, specH)) * frameDpr;
-
-            auto heatColorComponents = [this, fr, fg, fb](float t,
-                                                          float* cr,
-                                                          float* cg,
-                                                          float* cb2) {
-                if (m_fftHeatMap) {
-                    if (t < 0.25f) {
-                        const float s = t / 0.25f;
-                        *cr = 0.0f; *cg = s; *cb2 = 1.0f;
-                    } else if (t < 0.5f) {
-                        const float s = (t - 0.25f) / 0.25f;
-                        *cr = 0.0f; *cg = 1.0f; *cb2 = 1.0f - s;
-                    } else if (t < 0.75f) {
-                        const float s = (t - 0.5f) / 0.25f;
-                        *cr = s; *cg = 1.0f; *cb2 = 0.0f;
-                    } else {
-                        const float s = (t - 0.75f) / 0.25f;
-                        *cr = 1.0f; *cg = 1.0f - s; *cb2 = 0.0f;
-                    }
-                } else {
-                    *cr = fr; *cg = fg; *cb2 = fb;
-                }
-            };
-
-            auto writeLineVertex = [&](int vertexIndex, const FftScratchPt& pt,
-                                       float offsetX, float offsetY,
-                                       float t, float alpha, float edge) {
-                float cr, cg, cb2;
-                heatColorComponents(t, &cr, &cg, &cb2);
-                const int li = vertexIndex * kFftVertStride;
-                lineVerts[li]     = pt.x + offsetX;
-                lineVerts[li + 1] = pt.y + offsetY;
-                lineVerts[li + 2] = cr;
-                lineVerts[li + 3] = cg;
-                lineVerts[li + 4] = cb2;
-                lineVerts[li + 5] = alpha;
-                lineVerts[li + 6] = edge;
-            };
-
-            auto writeLineStrip = [&](int stripIndex, float halfWidthPx, float alpha) {
-                for (int i = 0; i < n; ++i) {
-                    const float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
-
-                    // Compute perpendicular normal from adjacent points.
-                    float dx, dy;
-                    if (i == 0) {
-                        dx = pts[1].x - pts[0].x;
-                        dy = pts[1].y - pts[0].y;
-                    } else if (i == n - 1) {
-                        dx = pts[n - 1].x - pts[n - 2].x;
-                        dy = pts[n - 1].y - pts[n - 2].y;
-                    } else {
-                        dx = pts[i + 1].x - pts[i - 1].x;
-                        dy = pts[i + 1].y - pts[i - 1].y;
-                    }
-                    const float dxPx = dx * wPx * 0.5f;
-                    const float dyPx = dy * hPx * 0.5f;
-                    float lenPx = std::sqrt(dxPx * dxPx + dyPx * dyPx);
-                    if (lenPx < 1e-8f) {
-                        lenPx = 1e-8f;
-                    }
-                    const float nxPx = -dyPx / lenPx * halfWidthPx;
-                    const float nyPx =  dxPx / lenPx * halfWidthPx;
-                    const float nx = nxPx * 2.0f / wPx;
-                    const float ny = nyPx * 2.0f / hPx;
-
-                    const int baseVertex = stripIndex * fftLineStripVertexCount + i * 2;
-                    writeLineVertex(baseVertex, pts[i], nx, ny, t, alpha, 1.0f);
-                    writeLineVertex(baseVertex + 1, pts[i], -nx, -ny, t, alpha, -1.0f);
-                }
-            };
-
-            auto writeFillVertex = [&](int vertexIndex, float x, float y,
-                                       float cr, float cg, float cb2, float alpha) {
-                const int fi = vertexIndex * kFftVertStride;
-                fillVerts[fi]     = x;
-                fillVerts[fi + 1] = y;
-                fillVerts[fi + 2] = cr;
-                fillVerts[fi + 3] = cg;
-                fillVerts[fi + 4] = cb2;
-                fillVerts[fi + 5] = alpha;
-                fillVerts[fi + 6] = 0.0f;
-            };
-
-            if (m_fftLineWidth > 0.0f) {
-                writeLineStrip(0, m_fftLineWidth + kFftLineFeatherPx, kFftLineFeatherAlpha);
-                writeLineStrip(1, m_fftLineWidth, kFftLineCoreAlpha);
-            }
-
-            for (int i = 0; i < n; ++i) {
-                const float t = qBound(0.0f, (fftBins[i] - minDbm) / range, 1.0f);
-
-                float cr, cg, cb2;
-                heatColorComponents(t, &cr, &cg, &cb2);
-
-                if (m_fftHeatMap) {
-                    // Heatmap: line color at top, fade to dark blue at base
-                    writeFillVertex(i * 2, pts[i].x, pts[i].y, cr, cg, cb2, fa * 0.3f);
-                    writeFillVertex(i * 2 + 1, pts[i].x, yBot, 0.0f, 0.0f, 0.3f, fa);
-                } else {
-                    // Solid: Y-based gradient (bright at line, dark+faint at base)
-                    float topColor[4];
-                    float bottomColor[4];
-                    yColor(pts[i].y, topColor);
-                    yColor(yBot, bottomColor);
-                    writeFillVertex(i * 2, pts[i].x, pts[i].y,
-                                    topColor[0], topColor[1], topColor[2], topColor[3]);
-                    writeFillVertex(i * 2 + 1, pts[i].x, yBot,
-                                    bottomColor[0], bottomColor[1], bottomColor[2],
-                                    bottomColor[3]);
-                }
-            }
-
-            if (m_fftLineWidth > 0.0f) {
-                batch->updateDynamicBuffer(m_fftLineVbo, 0,
-                    n * 4 * kFftVertStride * sizeof(float), lineVerts.constData());
-            }
-            batch->updateDynamicBuffer(m_fftFillVbo, 0,
-                n * 2 * kFftVertStride * sizeof(float), fillVerts.constData());
-        }
+        if (!is3D)
+            m_panStats.fftBuildUs +=
+                static_cast<quint64>(panStatsFftTimer.nsecsElapsed() / 1000);
     }
 
     cb->resourceUpdate(batch);
@@ -9199,33 +9200,20 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         cb->draw(4);
     }
 
-    // Draw FFT spectrum — viewport restricted to spectrum rect (2D only)
-    if (!is3D && m_fftFillPipeline && m_fftLinePipeline && fftTracePointCount > 0) {
-        const int n = fftTracePointCount;
+    // Draw FFT spectrum — viewport restricted to spectrum rect (2D only).
+    // One full-viewport quad; panscope.frag evaluates fill + feather + core
+    // stroke per pixel from the column texture.
+    if (!is3D && m_fftScopePipeline && m_ovVbo && fftTracePointCount > 0) {
         float specVpX = static_cast<float>(specRect.x()) * dpr;
         float specVpY = static_cast<float>(h - specRect.bottom() - 1) * dpr;
         float specVpW = static_cast<float>(specRect.width()) * dpr;
         float specVpH = static_cast<float>(specRect.height()) * dpr;
-        QRhiViewport specVp(specVpX, specVpY, specVpW, specVpH);
-
-        // Fill pass
-        cb->setGraphicsPipeline(m_fftFillPipeline);
-        cb->setShaderResources(m_fftSrb);
-        cb->setViewport(specVp);
-        const QRhiCommandBuffer::VertexInput fillVbuf(m_fftFillVbo, 0);
-        cb->setVertexInput(0, 1, &fillVbuf);
-        cb->draw(n * 2);
-
-        // Line pass (skip when line width is 0 = "Off")
-        if (m_fftLineWidth > 0.0f) {
-            cb->setGraphicsPipeline(m_fftLinePipeline);
-            cb->setShaderResources(m_fftSrb);
-            cb->setViewport(specVp);
-            const QRhiCommandBuffer::VertexInput lineVbuf(m_fftLineVbo, 0);
-            cb->setVertexInput(0, 1, &lineVbuf);
-            cb->draw(fftLineStripVertexCount);
-            cb->draw(fftLineStripVertexCount, 1, fftLineStripVertexCount, 0);
-        }
+        cb->setGraphicsPipeline(m_fftScopePipeline);
+        cb->setShaderResources(m_fftScopeSrb);
+        cb->setViewport({specVpX, specVpY, specVpW, specVpH});
+        const QRhiCommandBuffer::VertexInput vbuf(m_ovVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        cb->draw(4);
     }
 
     // Draw overlay quad — on top of FFT fill/line
@@ -9361,11 +9349,12 @@ void SpectrumWidget::releaseResources()
     m_dssMeshRowGenUploaded = ~0ull;
     m_dssLutToken = ~0ull;
 
-    delete m_fftLinePipeline; m_fftLinePipeline = nullptr;
-    delete m_fftFillPipeline; m_fftFillPipeline = nullptr;
-    delete m_fftSrb;          m_fftSrb = nullptr;
-    delete m_fftLineVbo;      m_fftLineVbo = nullptr;
-    delete m_fftFillVbo;      m_fftFillVbo = nullptr;
+    delete m_fftScopePipeline; m_fftScopePipeline = nullptr;
+    delete m_fftScopeSrb;      m_fftScopeSrb = nullptr;
+    delete m_fftScopeUbo;      m_fftScopeUbo = nullptr;
+    delete m_fftColTex;        m_fftColTex = nullptr;
+    delete m_fftColSampler;    m_fftColSampler = nullptr;
+    m_fftColTexW = 0;
 
     m_rhiInitialized = false;
     qDebug() << "SpectrumWidget: QRhi resources released";
@@ -9386,6 +9375,16 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         return;
     }
 #endif
+
+    // panstats: software-path paint cost (GPU builds only reach here before
+    // QRhi init or after GPU teardown).
+    m_panStats.paintEvents++;
+    struct PaintCost {
+        quint64& acc;
+        QElapsedTimer t;
+        explicit PaintCost(quint64& a) : acc(a) { t.start(); }
+        ~PaintCost() { acc += static_cast<quint64>(t.nsecsElapsed() / 1000); }
+    } panStatsPaintCost(m_panStats.paintUs);
     Q_UNUSED(ev);
 
     QElapsedTimer frameTimer;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -11,6 +11,7 @@
 #include <QColor>
 #include <QDateTime>
 #include <QElapsedTimer>
+#include <QVariant>
 #include <QTimer>
 #include <QLabel>
 
@@ -112,6 +113,19 @@ public:
     void prepareForTopLevelChange(); // unregister QRhiWidget from the current backing-store QRhi
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     QString rendererDescription() const;
+    // macOS: whether the pan gets its own native NSView (historical default —
+    // #714). AETHER_PAN_NO_NATIVE_WINDOW=1 opts out to validate the cheaper
+    // composited path (no per-present raster flushSubWindow blend).
+    static bool nativeWindowPreferred() {
+        static const bool noNative =
+            qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") == 1;
+        return !noNative;
+    }
+    // panstats (automation bridge): per-widget frame-cost counters — what the
+    // GUI thread spends preparing this panadapter's frames, split by section,
+    // plus a cause breakdown of static-overlay rebuilds. `reset` zeroes the
+    // counters after the read so successive reads measure disjoint intervals.
+    Q_INVOKABLE QVariantMap panstatsSnapshot(bool reset);
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void setKiwiSdrConnectionOverlay(bool visible,
                                      const QString& detail = {},
@@ -1139,13 +1153,22 @@ private:
     int m_filterDragStartHz{0};     // filter edge Hz at grab time (#764)
     // Lean render mode state (#3283).
     bool m_leanMode{false};
-    QElapsedTimer m_leanRepaintClock;       // repaint cap in lean mode
+    QElapsedTimer m_leanRepaintClock;       // data-repaint coalescing clock
     // Each panadapter present forces a full-window backing-store→GPU texture
     // re-upload (the dominant pooled cost on large/5K windows — #3283), so the
     // present rate ~= the flush rate. 33 ms (~30 Hz) roughly halves that upload
     // load vs 60 Hz while staying visually smooth for a low-overhead mode.
     static constexpr int kLeanFrameMs = 33;
-    void leanCappedUpdate();                // update(), throttled when lean
+    // Normal-mode coalescing window: FFT frames and waterfall rows arrive as
+    // separate UDP events, so without coalescing a narrow pan schedules up to
+    // ~56 window flushes/s (30 fps FFT + 26 rows/s WF) — over the display's
+    // 60 Hz budget once WAVE/meters add theirs, which starves the swapchain
+    // drawable pool and blocks the GUI thread in nextDrawable (#3938 class).
+    // One present per 16 ms slot keeps every data frame (a trailing update
+    // fires at the slot edge) while capping flushes at ~60/s.
+    static constexpr int kPresentCoalesceMs = 16;
+    bool m_presentPending{false};           // trailing update scheduled
+    void leanCappedUpdate();                // update(), coalesced / lean-capped
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     int  m_vfoDragOffsetHz{0};  // Hz offset from VFO at grab point (#1120)
@@ -1467,29 +1490,64 @@ private:
     void initSpectrumPipeline();
     void renderGpuFrame(QRhiCommandBuffer* cb);
 
-    // FFT spectrum GPU resources — vertex color, no uniforms
-    QRhiGraphicsPipeline* m_fftLinePipeline{nullptr};
-    QRhiGraphicsPipeline* m_fftFillPipeline{nullptr};
-    QRhiShaderResourceBindings* m_fftSrb{nullptr};
-    QRhiBuffer* m_fftLineVbo{nullptr};    // dynamic, feather + core line strips
-    QRhiBuffer* m_fftFillVbo{nullptr};    // dynamic, 2N × (vec2 pos + vec4 color + edge)
-    static constexpr int kMaxFftBins = 8192;
-    static constexpr int kFftVertStride = 7; // x, y, r, g, b, a, edge
-    // Reused per-frame scratch for GPU FFT-trace vertex generation — avoids a
-    // heap (re)alloc of up to 4*kMaxFftBins*kFftVertStride floats every frame on
-    // the GUI thread (renderGpuFrame). resize() keeps capacity, so steady state
-    // is alloc-free.
-    struct FftScratchPt { float x, y; };
-    QVector<float> m_fftLineScratch;
-    QVector<float> m_fftFillScratch;
-    QVector<FftScratchPt> m_fftPtScratch;
+    // FFT spectrum GPU resources — the trace is evaluated per-pixel by
+    // panscope.frag from a width×1 R32F column texture (normalized amplitude
+    // per device pixel column), drawn as one full-viewport quad. The CPU per
+    // frame only resamples the display trace to device columns and uploads
+    // ~4 bytes/column, replacing the old per-frame feather/core/fill vertex
+    // bake (~1.4 MB of VBO writes per frame at a 2140 px pan).
+    QRhiGraphicsPipeline* m_fftScopePipeline{nullptr};
+    QRhiShaderResourceBindings* m_fftScopeSrb{nullptr};
+    QRhiBuffer* m_fftScopeUbo{nullptr};
+    QRhiTexture* m_fftColTex{nullptr};
+    QRhiSampler* m_fftColSampler{nullptr};
+    QRhiTexture::Format m_fftColFormat{QRhiTexture::R32F};
+    int m_fftColTexW{0};
+    QByteArray m_fftColScratch;  // reused per-frame column staging buffer
 #endif
 
+    // ── panstats: per-widget frame-cost counters (automation bridge) ─────────
+    // Always-on: a handful of integer adds per frame plus one QElapsedTimer
+    // read per instrumented section. Snapshot/reset via panstatsSnapshot().
+    struct PanStats {
+        QElapsedTimer clock;              // wall interval since last reset
+        quint64 updateSpectrumCalls{0};   // FFT frames ingested
+        quint64 updateSpectrumUs{0};      // smoothing + floor + ingest cost
+        quint64 gpuFrames{0};             // renderGpuFrame invocations
+        quint64 gpuFrameUs{0};            // whole CPU-side frame prep + encode
+        quint64 fftBuildUs{0};            // trace resample + vertex bake
+        quint64 fftVboBytes{0};           // vertex bytes uploaded
+        quint64 overlayRebuilds{0};       // static+bg QPainter repaints
+        quint64 overlayRebuildUs{0};
+        quint64 overlayUploadBytes{0};    // static+bg texture bytes uploaded
+        quint64 wfUploadBytes{0};         // waterfall texture bytes uploaded
+        quint64 paintEvents{0};           // software-path paints
+        quint64 paintUs{0};
+        QHash<QByteArray, quint64> dirtyCauses;  // why the overlay rebuilt
+        void noteDirty(const char* cause) {
+            dirtyCauses[QByteArray(cause ? cause : "other")]++;
+        }
+        qint64 sinceMs() {
+            if (!clock.isValid())
+                clock.start();
+            return clock.elapsed();
+        }
+        void reset() {
+            *this = PanStats{};
+            clock.start();
+        }
+    } m_panStats;
+
     // Mark the static overlay for repaint and schedule a frame update.
-    // In non-GPU mode this is just update().
-    void markOverlayDirty() {
+    // In non-GPU mode this is just update(). `cause` feeds the panstats
+    // dirty-cause breakdown — annotate call sites that can fire at frame rate.
+    void markOverlayDirty(const char* cause = nullptr) {
 #ifdef AETHER_GPU_SPECTRUM
+        if (!m_overlayStaticDirty)
+            m_panStats.noteDirty(cause);
         m_overlayStaticDirty = true;
+#else
+        m_panStats.noteDirty(cause);
 #endif
         update();
     }


### PR DESCRIPTION
## Summary

2D panadapter rendering-path optimization, profiled first and proven after with the agent automation bridge (live FLEX-8400M session, Mac Studio M2 Ultra, Retina 2×, 2140×651 pan).

- **`panscope.frag` — per-pixel FFT trace.** The spectrum trace (gradient/heat-map fill + feather + core stroke) is now evaluated per pixel from a width×1 R32F column texture (R16F fallback where float32 isn't filterable), drawn as one quad. This replaces the per-frame CPU vertex bake — two antialiased triangle-strip line passes plus a 2N fill strip, rebuilt and re-uploaded every frame (~1.4 MB/frame at a 2140 px pan). `buildFftDisplayTrace`'s spatial smoothing + Catmull-Rom interpolation is unchanged, now sampled at exactly one point per device pixel column; stroke width is slope-corrected in the shader via screen-space derivatives so steep peak flanks keep their width, matching the old perpendicular-offset geometry. Cross-platform via `qt_add_shaders` (SPIR-V / GLSL / HLSL / MSL).
- **Present coalescing.** FFT frames and waterfall rows arrive as separate UDP events, each scheduling its own window flush — a narrow pan alone generated ~83 flushes/s (57 FFT + 26 rows), which together with the other animated widgets starves the swapchain drawable pool and blocks the GUI thread in `CAMetalLayer nextDrawable` (the #3938 mechanism). Data-driven repaints now coalesce into one present per 16 ms slot with a trailing update (no frame is dropped); interactive paths still repaint immediately. Lean mode keeps its ~30 Hz cap.
- **FFT FPS ceiling 30 → 60.** The 30 fps limit was purely the client slider — the FLEX-8400M delivers ~57 frames/s when asked. With the flat per-pixel path, 57 fps costs **+5.8 whole-process CPU points** over 30 fps.
- **`get panstats` bridge verb** (`get panstats [<panIndex>|<objectName>] [reset]`): per-SpectrumWidget frame-cost counters — `gpuFrameMsPerSec` (headline main-thread budget), FFT build/upload volume, overlay rebuilds with first-cause attribution (`smartMtr`/`detect`/`other`), waterfall upload volume — for profiler-free before/after proofs. Documented in `docs/automation-bridge.md`.
- **`AETHER_PAN_NO_NATIVE_WINDOW=1` diagnostic** to probe the composited (non-native) QRhiWidget path on macOS. Result: still fails to obtain a QRhi on Qt 6.9 (#714 behavior — parent surface is raster), so the native NSView stays the default; the probe documents the finding for a future Qt.

## Measurements

`get panstats 0 reset` → 40 s → read; identical 2140×651 pan, 2D, 30 fps, idle RX, interleaved same hour:

| metric | before | after |
|---|---:|---:|
| pan main-thread frame prep (`gpuFrameMsPerSec`) | 17.9 ms/s | **3.6 ms/s** |
| avg prep per frame | 601 µs | **118 µs** |
| FFT trace build (`fftBuildMsPerSec`) | 14.2 ms/s | **0.8 ms/s** |
| trace GPU upload | 40.9 MB/s | **0.5 MB/s** |
| ingest / overlay / waterfall | 0.45 / ~0 / ~0 ms/s | unchanged |

Whole-process CPU (cputime delta / 40 s, same session, big window 2400×1300):

| config | CPU |
|---|---:|
| optimized @ 30 fps | 117.1 % |
| optimized @ 57 fps delivered | **122.9 %** |
| baseline @ 30 fps (same hour) | 120–131 % |

Honest reading: at matched 30 fps, whole-process CPU is at parity-to-slightly-better — the pan's own prep was ~18 ms/s of a ~450 ms/s main thread, and the freed time is partly reabsorbed by other animated widgets that were previously starved behind drawable waits (main-thread `sample` shows `renderGpuFrame` dropping 243 → 30 samples/10 s while WAVE/S-meter paints rise). The structural wins are: the pan's cost is now **width- and fps-flat**, ~2× the frame rate costs ~6 CPU points, and two pans at 57 fps present at ~41–44 frames/s each with <6 ms/s prep each. The remaining window-level costs (raster `flushSubWindow` blends from the flag/menu widgets over the native pan view, WAVE's QPainter paints) are outside this path — WAVE is addressed by #3955, and the native-window blend tax is documented via the new probe.

## Screenshots

Per-pixel trace, 2D + heat-map fill, band plan/scales/markers intact (visual parity with the vertex path):

![Per-pixel FFT trace](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets/pan-2d-perpixel-trace.png)

Running at 57 delivered FFT frames/s (slider at 60):

![60 fps panadapter](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets/pan-60fps-final.png)

RX recovery immediately after an ANT2 dummy-load TX key/unkey cycle:

![RX after TX](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets/pan-rx-after-tx.png)

## TX / regression proofs (agent automation bridge, live radio)

- PTT key on ANT2 dummy load → `transmitting:true`, pan keeps rendering; unkey → instant RX trace + waterfall recovery (grabs above).
- `pan create` → both pans on the GPU path (~41–44 presents/s each, <6 ms/s prep each; coalescer merges 57 FFT + 26 WF events/s correctly) → `pan close 1` clean.
- 2D ↔ 3D stacked-trace toggle unaffected (trace build/draw skipped in 3D exactly as before).
- Lean mode, line-width 0 ("Off"), heat-map and solid fill modes all handled in-shader with the old constants (`kFftLineFeatherPx`, core α 0.90, feather α 0.22).
- Software (non-GPU-build) QPainter path untouched.

## New automation verbs that helped / follow-ups

- `get panstats` (this PR) made every number above reproducible without a profiler.
- Follow-up candidates: a `stats window` verb exposing per-window flush/drawable-wait counters (would make the #3938 contention measurable directly), and a `wavestats`-style counter for `SMeterWidget`/`VfoWidget` paint rates.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat

🤖 Generated with [Claude Code](https://claude.com/claude-code)