### PR TITLE
docs(changelog): add Local D-STAR waveform (#3956) to v26.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ from FlexLib and a broad wave of audio, spectrum, and UI fixes.
   continuous file holds both across SSB↔CW switches — usable at last for contest
   CW review. Client-Side recording is now the out-of-box default (Radio Side
   stays selectable). Scope is AetherSDR-keyed CW (keyboard / paddle / CWX). (#3895)
+- **Local D-STAR waveform.** AetherSDR builds and runs a bundled
+  `aether-dstar-waveform` helper against the connected radio via the Flex
+  waveform API, with Local D-STAR controls in the Waveforms window and
+  auto-detection of an attached **ThumbDV / DV3000** vocoder (required —
+  software AMBE is intentionally not bundled). Also hardens waveform
+  install/management: protocol-token validation, bounded package reads, escaped
+  radio/user strings, and the frameless install dialog. Built on public
+  GPL-compatible SmartSDR-DSP sources (clean-room, Principle IV). (#3956)
 - **KiwiSDR protocol metadata scaffolding.** Richer read-only receiver metadata,
   protocol/capability handling, and monitor/camping state for public KiwiSDR
   receivers, with new `get kiwi` / `get kiwisdr` automation-bridge snapshots.


### PR DESCRIPTION
Adds the **Local D-STAR waveform** entry (#3956) to the `v26.7.1` CHANGELOG `### Added` section, ahead of the v26.7.1 tag.

#3956 (rfoust) is landing in this release. It does **not** touch `CHANGELOG.md` itself, so this changelog line is added on `main` independently and will not conflict when #3956 merges.

**Release-coordination notes:**
- #3956 is currently ~3 commits behind `main` and its CI is still running — it should be updated to `main` and green before merge.
- Tag `v26.7.1` only after #3956 has landed (per the release plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)