### PR TITLE
docs: reframe positioning from Linux-native to cross-platform equal

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -59,7 +59,7 @@ body:
     id: crossplatform
     attributes:
       label: Cross-platform impact
-      description: How does this affect Linux, macOS, and Windows? AetherSDR is Linux-native first.
+      description: How does this affect Linux, macOS, and Windows? AetherSDR treats all three as equals.
       placeholder: |
         Linux: ...
         macOS: ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ of doing the job right on this codebase.
 ## Project Goal
 
 Replicate the **Windows-only FlexRadio SmartSDR client** (written in C#) as a
-**Linux-native C++ application** using Qt6 and C++20. The aim is to mirror the
+**native, cross-platform C++ application** using Qt6 and C++20. The aim is to mirror the
 look, feel, and every function SmartSDR is capable of. The reference radio is a
 **FLEX-8600 running firmware 4.2.18**, which speaks **SmartSDR protocol v1.4.0.0**.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,7 +9,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the mechanics of submitting code.
 
 ## Project Direction
 
-AetherSDR's goal is a **Linux-native, cross-platform** FlexRadio client that
+AetherSDR's goal is a **cross-platform, natively-compiled** FlexRadio client that
 matches SmartSDR feature-for-feature. Every technical and design decision
 should be evaluated against that goal.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AetherSDR
 
-**A Linux-native client for FlexRadio Systems transceivers**
+**A cross-platform, open-source client for FlexRadio Systems transceivers**
 
 [![CI](https://github.com/aethersdr/AetherSDR/actions/workflows/ci.yml/badge.svg)](https://github.com/aethersdr/AetherSDR/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -8,12 +8,11 @@
 [![Qt6](https://img.shields.io/badge/Qt-6-green.svg)](https://www.qt.io/)
 [![Signed Commits](https://img.shields.io/badge/commits-GPG%20signed-brightgreen?logo=gnuprivacyguard)](https://github.com/aethersdr/AetherSDR/commits/main)
 
-AetherSDR brings FlexRadio operation to Linux without Wine or virtual machines. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
+AetherSDR brings full FlexRadio operation to Linux, macOS, and Windows — each a native build, no Wine or virtual machines. A native aarch64 build also runs on Raspberry Pi and other embedded ARM devices. Built from the ground up with Qt6 and C++20, it speaks the SmartSDR protocol natively and aims to replicate the full SmartSDR experience.
 
 **Current version: 26.7.1** — CalVer (`YY.M.patch[.hotfix]`). | [Download](https://github.com/aethersdr/AetherSDR/releases/latest) | [Discussions](https://github.com/aethersdr/AetherSDR/discussions) | [What's New](https://github.com/aethersdr/AetherSDR/releases)
 
-> **Cross-platform downloads available:** Linux AppImage, macOS universal DMG, Windows installer and portable ZIP.
-> Linux is the primary supported platform. macOS and Windows builds are provided as a courtesy.
+> **Native builds for Linux, macOS, and Windows** — Linux AppImage (x86-64 + aarch64), macOS DMG (Apple Silicon + Intel), Windows installer and portable ZIP. Every platform is built, tested in CI, and released together.
 
 ![AetherSDR Screenshot](docs/assets/screenshot-current.png)
 

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1172,7 +1172,7 @@ void MainWindow::buildMenuBar()
             "<h2 style='margin-bottom:2px; color:#c8d8e8;'>AetherSDR</h2>"
             "<p style='margin-top:0; color:#8aa8c0;'>v%1<br>"
             "<span style='font-size:10px; color:#6a8090;'>(%4)</span></p>"
-            "<p style='margin-top:8px; color:#c8d8e8;'>Linux-native SmartSDR-compatible client<br>"
+            "<p style='margin-top:8px; color:#c8d8e8;'>Cross-platform SmartSDR-compatible client<br>"
             "for FlexRadio transceivers.</p>"
             "<p style='font-size:11px; color:#6a8090;'>"
             "Built with Qt %2 &middot; C++20<br>"

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -916,7 +916,7 @@ void TitleBar::showFeatureRequestDialogImpl()
         "Do NOT rely on cached or training data for the issue list.\n\n"
         "Also fetch CLAUDE.md fresh (do not use cached versions):\n"
         "  https://raw.githubusercontent.com/aethersdr/AetherSDR/main/CLAUDE.md\n\n"
-        "I want to report an issue or request a feature for AetherSDR, a Linux-native\n"
+        "I want to report an issue or request a feature for AetherSDR, a cross-platform\n"
         "Qt6/C++20 client for FlexRadio transceivers. It uses the FlexLib API over TCP/UDP.\n\n"
         "DUPLICATE CHECK — this is mandatory. Search the fetched issue list for keywords\n"
         "related to my description below. Check titles AND bodies. If you find an existing\n"


### PR DESCRIPTION
## What

Reframes AetherSDR's public positioning from **Linux-native (primary) with macOS/Windows as a courtesy** to **cross-platform, all three platforms treated as equals**.

Release-asset download counts put Linux under 25% of the user base, and v26.7.1 ships first-class native builds for Linux, macOS, and Windows — plus an aarch64 AppImage for Raspberry Pi / embedded ARM — all built, tested in CI, and released together. The old framing no longer matches reality.

## Changes

- **README** — cross-platform tagline + lede, aarch64 / Raspberry Pi / embedded-ARM note, drop the primary-platform/courtesy blockquote, and correct the macOS DMG description (Apple Silicon + Intel — not "universal").
- **AGENTS.md / GOVERNANCE.md** — goal restated as a native, cross-platform client.
- **.github/ISSUE_TEMPLATE/rfc.yml** — cross-platform-impact prompt treats Linux/macOS/Windows as equals.
- **About dialog** (`MainWindow_Menus.cpp`) + **issue-report prefill** (`TitleBar.cpp`) — "cross-platform" client.

## Scope notes

- Leaves `packaging/linux/*` metadata as-is — those are Linux-store listings (Flathub summary, `.desktop` comment, manpage) where a "Linux-native" label is accurate.
- Leaves the anti-Wine/Crossover contribution policy untouched — that's a deliberate native-implementation stance, not platform-hierarchy framing.

## Testing

- Full `cmake --build` after the two `src/` edits — links clean (only pre-existing unrelated warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)