### PR TITLE
fix(kiwi): release KiwiSDR connection when a slice stops using it (Fixes #3950)

### DIFF
--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -455,6 +455,15 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
         << "freq=" << frequencyMhz << "MHz mode=" << mode;
     emit sliceAssignmentChanged(sliceId, profileId);
 
+    // Switching this slice to a different Kiwi: release the previous one if no
+    // other slice still uses it and it isn't auto-connect, so we don't squat the
+    // receiver's user slot / burn its per-IP time budget (#3950). Must come after
+    // the insert() above so shouldMaintainProfileConnection() sees the new map.
+    if (!previousProfile.isEmpty() && previousProfile != profileId
+        && !shouldMaintainProfileConnection(previousProfile)) {
+        disconnectProfile(previousProfile);
+    }
+
     if (KiwiSdrClient* c = ensureClient(profileId)) {
         Q_UNUSED(c);
         m_clientHasTrackedSlice.insert(profileId, sliceId >= 0 && frequencyMhz > 0.0);
@@ -489,6 +498,14 @@ void KiwiSdrManager::clearSliceAssignment(int sliceId)
         });
     }
     emit sliceAssignmentChanged(sliceId, QString());
+
+    // The slice no longer uses this Kiwi (antenna reverted to Flex, or the slice
+    // was closed). Release it once nothing else needs it, so it stops holding the
+    // receiver's user slot / per-IP time budget (#3950). take() above already
+    // updated the map, so shouldMaintainProfileConnection() reflects reality here.
+    if (!shouldMaintainProfileConnection(previousProfile)) {
+        disconnectProfile(previousProfile);
+    }
 }
 
 void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -227,6 +227,7 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
     updated.waterfallRate =
         std::clamp(updated.waterfallRate, 0, kKiwiSdrWaterfallRateMax);
     const QString oldEndpoint = m_profiles[idx].endpoint;
+    const bool wasAutoConnect = m_profiles[idx].autoConnect;
     m_profiles[idx] = updated;
     saveSettings();
     const bool endpointChanged = oldEndpoint != updated.endpoint;
@@ -255,6 +256,18 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
             }
         });
     }
+
+    // Turning off auto-connect on a profile that no slice is using leaves it
+    // "no longer in use" (no assigned slice, not auto-connect) — release it so
+    // it stops squatting the receiver's user slot / per-IP time budget, the same
+    // disconnect-when-idle invariant as the slice-transition paths (#3950).
+    // Scoped to the true->false transition so plain name/endpoint edits and
+    // manually-connected profiles are left untouched.
+    if (wasAutoConnect && !updated.autoConnect
+        && !shouldMaintainProfileConnection(updated.id)) {
+        disconnectProfile(updated.id);
+    }
+
     emit profilesChanged();
 }
 


### PR DESCRIPTION
## What & why

A KiwiSDR connection was only **muted**, never **closed**, when a slice stopped using it — switching the slice to a different Kiwi, reverting its RX antenna back to the Flex, or closing the slice. The WebSocket stayed open (sub-menu kept showing **Connected**), so the app kept occupying one of that receiver's limited user slots and burning its per-IP time budget (e.g. 1 hr/day) until app quit.

Real-world impact (from #3950):
- **Squats a slot** on every public Kiwi you A/B through — denying other operators access even though you're no longer using those receivers.
- **Time-limit lockout** — the per-IP budget keeps draining while idle, so you can be locked out from reconnecting.

## The fix

Release the previously-assigned Kiwi on the idle transitions, reusing the existing teardown that already does the right thing:

- **`assignSliceToProfile()`** — after the map is updated to point the slice at the new Kiwi, disconnect the previous profile.
- **`clearSliceAssignment()`** — after `take()` removes the assignment, disconnect the previous profile.
- **`updateProfile()`** — when a profile's **auto-connect is turned off** (true→false) and no slice uses it, disconnect it. This is a third idle trigger (found in review): unticking "Auto" on an unassigned-but-connected Kiwi previously left it connected because the toggle only updated the flag and saved settings, never re-evaluating the connection. Scoped to the true→false transition so plain name/endpoint edits and manually-connected/still-assigned profiles are untouched.

All three are gated on the existing policy verdict:

```cpp
if (!shouldMaintainProfileConnection(previousProfile))
    disconnectProfile(previousProfile);
```

`disconnectProfile()` already does the correct teardown (`cancelReconnect()`, `client->disconnectFromEndpoint()` → closes the WebSocket → frees the slot, mutes audio) and **leaves the saved profile in place** so it can be re-selected later. Because the guard is `shouldMaintainProfileConnection()`, this naturally:

- keeps **auto-connect** Kiwis connected,
- keeps a Kiwi still assigned to **another** slice connected,
- disconnects only a genuinely idle Kiwi.

This is the immediate-disconnect variant discussed in the issue. It's a large behavioral improvement over the status quo; a short grace-timer refinement (for rapid A/B flipping) can be layered later without changing the invariant.

## Invariant carried forward

Per the issue: *releasing an idle Kiwi must hold whichever way this is implemented.* If the KiwiSDR path is later reworked under RFC #3894 (standalone receive sessions, which lists "stop provider network clients" as a teardown invariant), this `file:line` fix should be dropped in favor of that design — but the "disconnect when no longer in use" requirement must be preserved.

## Testing

**Build:** full app builds & links clean (Linux, CMake+Ninja, Qt 6.8.3). All 4 Kiwi unit tests pass (`ctest -R kiwi` → 4/4), confirming no regression (they don't cover the lifecycle path directly).

**Functional on FLEX-8400** — confirmed manually: switching a slice between Kiwis disconnects the old one; reverting the slice's RX antenna to ANT1 disconnects it.

**Automation Bridge (`AETHER_AUTOMATION=1`, `get kiwi` snapshot)** — deterministic before/after on the real radio, asserting each profile's `state` + `assignedSlice`:

| Step | `get kiwi` result | Path exercised |
|---|---|---|
| Assign Kiwi A (Point Reyes) to slice 0 | A `connected`, slice 0 | — |
| Switch slice 0 → Kiwi B (San Jose) | B `connected` slice 0; **A → `disconnected` / `-1`** | `assignSliceToProfile()` release |
| Revert slice 0 to ANT1 | **B → `disconnected` / `-1`**; all idle | `clearSliceAssignment()` release |
| **Neg. control:** mark A `autoConnect`, assign to slice 0, switch slice away | **A stays `connected`** (`assignedSlice=-1`); B `connected` | `shouldMaintainProfileConnection()` gate — no over-disconnect |
| **Auto-connect trigger:** A connected + idle + `autoConnect=true`, then untick "Auto" | **A → `disconnected` / `-1`** immediately | `updateProfile()` release |

The neg. control is the identical switch-away as row 2 but with `autoConnect=true`, and A stays up — proving the release fires only for genuinely-idle Kiwis and leaves protected ones alone. The last row is the mirror: once that protection (`autoConnect`) is removed from an idle Kiwi, it's released at once.

Fixes #3950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
