### PR TITLE
fix(bnr): gracefully handle GPUs with no published AFX pack (Fixes #3933)

### DIFF
--- a/src/core/NvidiaAfxPack.cpp
+++ b/src/core/NvidiaAfxPack.cpp
@@ -139,17 +139,39 @@ QString NvidiaAfxPack::detectArch()
     return cached;
 }
 
-bool NvidiaAfxPack::hasSupportedGpu()
+// Compute capabilities (sm_<cc>) for which an afx-bits pack is actually published
+// on our releases. detectArch() can report a newer NVIDIA card — e.g. sm_120
+// (consumer Blackwell / RTX 50-series) — that clears the Ada+ bar but has no
+// published pack yet, so it must not dead-end at a Download that 404s. Keep this
+// in sync with the afx-bits release assets + the build-afx-bits ValidateSet. (#3933)
+static const QList<int> kPublishedComputeCaps = { 89 };   // sm_89 (Ada) — Linux + Windows
+
+// Compute capability of the detected NVIDIA GPU (89 for "sm_89"), or -1 if none.
+static int detectedComputeCap()
 {
-    // detectArch() returns "sm_<cc>" for Turing+ (>=75); but we only publish
-    // Ada-and-later packs, so require compute capability >= 8.9 (sm_89 = RTX
-    // 40-series). Earlier RTX (20/30) and non-NVIDIA machines fail this.
-    const QString arch = detectArch();
+    const QString arch = NvidiaAfxPack::detectArch();
     if (!arch.startsWith(QStringLiteral("sm_")))
-        return false;
+        return -1;
     bool ok = false;
     const int cc = QStringView{arch}.mid(3).toInt(&ok);   // "sm_89" -> 89
-    return ok && cc >= 89;
+    return ok ? cc : -1;
+}
+
+bool NvidiaAfxPack::isAfxCapableGpu()
+{
+    // detectArch() returns "sm_<cc>" for Turing+ (>=75); AFX itself needs Ada
+    // (sm_89 = RTX 40-series) or later. Earlier RTX (20/30) and non-NVIDIA
+    // machines fail this. This says nothing about whether a *pack* is published.
+    return detectedComputeCap() >= 89;
+}
+
+bool NvidiaAfxPack::hasSupportedGpu()
+{
+    // BNR is only usable when an afx-bits pack is actually published for the
+    // detected GPU's arch — not merely when the GPU is new enough for AFX. An
+    // AFX-capable card with no published pack (e.g. sm_120) is reported distinctly
+    // by the UI and steered to DFNR instead of a 404 Download. (#3933)
+    return isAfxCapableGpu() && kPublishedComputeCaps.contains(detectedComputeCap());
 }
 
 QString NvidiaAfxPack::cacheRoot()

--- a/src/core/NvidiaAfxPack.h
+++ b/src/core/NvidiaAfxPack.h
@@ -41,9 +41,14 @@ public:
     ~NvidiaAfxPack() override;
 
     static QString detectArch();          // "sm_89", or empty if no NVIDIA GPU
-    // True only if an NVIDIA GPU new enough for a published AFX pack is present
-    // (Ada / RTX 40-series or later, compute capability >= 8.9). Earlier GPUs
-    // (RTX 20/30) have no published pack, so the BNR UI gates on this.
+    // True if an NVIDIA GPU new enough for AFX at all is present — Ada /
+    // RTX 40-series or later (compute capability >= 8.9) — regardless of whether
+    // a pack is published for its exact arch. Broader than hasSupportedGpu():
+    // a card can be AFX-capable yet unpublished (e.g. sm_120 / RTX 50-series). (#3933)
+    static bool isAfxCapableGpu();
+    // True only if an afx-bits pack is actually published for the detected GPU's
+    // arch (a subset of isAfxCapableGpu()). The BNR UI enables the feature on this
+    // so an AFX-capable-but-unpublished card (sm_120) doesn't dead-end on a 404.
     static bool hasSupportedGpu();
     static QString cacheRoot();           // <AppLocalData>/nvidia-afx
     static QString installedPackDir();    // cacheRoot/current if usable, else empty

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -219,8 +219,17 @@ AetherDspWidget::AetherDspWidget(AudioEngine* audio, QWidget* parent)
 #else
         if (i == BNR && !NvidiaAfxPack::hasSupportedGpu()) {
             b->setEnabled(false);
-            b->setToolTip("BNR requires an NVIDIA RTX 40-series or later GPU.\n"
-                          "Use DFNR for AI noise removal on other hardware.");
+            if (NvidiaAfxPack::isAfxCapableGpu()) {
+                // Recent NVIDIA card, but no AFX pack is published for its arch
+                // yet (e.g. sm_120 / RTX 50-series). Don't imply the GPU is too
+                // old — say so plainly and point at DFNR. (#3933)
+                b->setToolTip(QStringLiteral("No BNR pack for your GPU (%1) yet — "
+                                             "DFNR remains available.")
+                                  .arg(NvidiaAfxPack::detectArch()));
+            } else {
+                b->setToolTip("BNR requires an NVIDIA RTX 40-series or later GPU.\n"
+                              "Use DFNR for AI noise removal on other hardware.");
+            }
         }
 #endif
         m_dspBtns[i] = b;
@@ -993,6 +1002,20 @@ void AetherDspWidget::updateBnrStatus()
                                      : partial ? tr("Resume download")
                                                : QStringLiteral("Download (~1 GB)"));
         m_bnrAfxDownloadBtn->setEnabled(true);
+#ifdef HAVE_NVIDIA_AFX
+        // If no afx-bits pack is published for this GPU's arch (e.g. sm_120 /
+        // RTX 50-series), don't offer a Download that would 404 — disable it and
+        // say why, steering the user to DFNR. (#3933)
+        if (!NvidiaAfxPack::hasSupportedGpu()) {
+            m_bnrAfxDownloadBtn->setEnabled(false);
+            if (NvidiaAfxPack::isAfxCapableGpu()) {
+                m_bnrAfxDownloadBtn->setText(tr("No pack for this GPU"));
+                m_bnrAfxDownloadBtn->setToolTip(
+                    QStringLiteral("No BNR pack for your GPU (%1) yet — use DFNR.")
+                        .arg(NvidiaAfxPack::detectArch()));
+            }
+        }
+#endif
     }
     if (m_bnrAfxIntensitySlider)
         m_bnrAfxIntensitySlider->setEnabled(installed);


### PR DESCRIPTION
## What & why

On an NVIDIA GPU new enough for AFX but with **no published denoiser pack for its exact arch** — notably **sm_120 (consumer Blackwell / RTX 50-series)** — the BNR button and its Download were offered and then **silently failed**: the per-arch `afx-bits` pack 404s (only `sm_89` is published today). BNR looked supported but could never install, with no message steering the user to DFNR (#3933).

Root cause: `hasSupportedGpu()` gated only on compute capability (`cc >= 89`), so `sm_120` (cc 120) passed the gate even though no pack exists for it.

## The fix

Split the GPU check into two questions:

- **`isAfxCapableGpu()`** — is the GPU new enough for AFX at all (Ada / RTX 40-series, `cc >= 89`)? Says nothing about pack availability.
- **`hasSupportedGpu()`** — is a pack *actually published* for the detected arch? Now `isAfxCapableGpu() && kPublishedComputeCaps.contains(cc)`, where `kPublishedComputeCaps = { 89 }` (kept in sync with the `afx-bits` release assets + the `build-afx-bits` ValidateSet).

The BNR UI enables the feature on `hasSupportedGpu()` (unchanged), but now uses `isAfxCapableGpu()` to tell apart *"GPU too old"* from *"AFX-capable but no pack yet"*:

- **DSP panel BNR selector** — disabled with *"No BNR pack for your GPU (sm_120) yet — DFNR remains available."* (vs. the old "requires RTX 40-series" message, which would wrongly imply the card is too old).
- **BNR Download button** — disabled, relabelled *"No pack for this GPU"*, tooltip points at DFNR — instead of a Download that 404s.

Scope: this is suggestion #1 from the issue (the part fully in AetherSDR's control). Publishing an actual `sm_120` pack (#3933 suggestion #2) is gated on NVIDIA shipping a consumer-Blackwell Maxine model to NGC and is out of scope here — when it lands, add `120` to `kPublishedComputeCaps` and upload the assets.

## Testing

**Build:** clean (Linux, `-DENABLE_NVIDIA_AFX=ON`, Qt 6.8.3). Only `hasSupportedGpu()`'s two callers exist, both in the DSP widget and both updated — no collateral behavior change (a machine with a published pack, e.g. `sm_89`, still reports `hasSupportedGpu()==true` and behaves exactly as before; an RTX 20/30 still gets the "too old" message).

**Live on the exact issue hardware — RTX 5060 Laptop GPU, compute_cap 12.0 (`sm_120`)** — via the Automation Bridge `dumpTree` (`detectArch()` reports `sm_120`):

| Widget (`objectName`) | `enabled` | Text / tooltip |
|---|---|---|
| BNR selector (`dspMethodBtnBNR`) | **false** | *"No BNR pack for your GPU (sm_120) yet — DFNR remains available."* |
| Download BNR runtime | **false** | text *"No pack for this GPU"*; tip *"…yet — use DFNR."* |

Both dead-end surfaces are now gated off with a clear message on the real GPU, instead of offering a 404 Download.

Fixes #3933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
