### PR TITLE
fix(controllers): resync RC-28 accumulator when slice is already on 1 kHz grid (#3948)

### DIFF
--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -2426,10 +2426,9 @@ void MainWindow::wireExternalControllers()
         if (auto* s = activeSlice()) {
             if (s->isLocked()) return;
             const double snapped = std::round(s->frequency() * 1000.0) / 1000.0;
-            if (std::abs(snapped - s->frequency()) > 1e-9) {
+            if (std::abs(snapped - s->frequency()) > 1e-9)
                 applyTuneRequest(s, snapped, TuneIntent::IncrementalTune, "rc28-autosnap");
-                m_flexTargetMhz = snapped;
-            }
+            m_flexTargetMhz = snapped;
         }
     });
 


### PR DESCRIPTION
## Summary

- Fixes the stale-accumulator edge case described in #3948
- `m_flexTargetMhz = snapped` was inside the `|Δ| > 1e-9` guard, so if a MIDI controller moved the slice onto the 1 kHz grid before the 600 ms RC-28 snap timer fired, the guard no-op'd and the accumulator was left pointing at the old base frequency
- The next RC-28 tick would then compute `old_base + step` instead of `current_freq + step`, jumping the frequency backward
- Fix: move the resync line outside the guard so the accumulator always catches up when the snap timer fires, regardless of whether a snap move was needed

## Test plan

- [ ] Turn RC-28 wheel to set `m_flexTargetMhz` (e.g. 5.099500 MHz), leaving the snap timer armed
- [ ] Before the timer fires, nudge a MIDI tune knob to land the slice exactly on 5.100000 MHz
- [ ] Wait for the 600 ms snap timer to fire (no frequency movement expected — already on grid)
- [ ] Turn RC-28 one step forward (+100 Hz) — should land at 5.100100 MHz, not jump backward
- [ ] Verify normal RC-28 incremental tuning and the #3939 sub-kHz-snap case are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)