### PR TITLE
feat(gui): °C/°F toggle and live numeric overlays for MtrApplet (#3886)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -204,6 +204,10 @@ Each `<node>`:
   "panIndex": 0,                           // SpectrumWidget only: pass to `grab pan`/`pan close`
   "noiseFloorDbm": -99.68,                 // SpectrumWidget only: measured floor (see `floors`)
   "displayFloorDbm": -99.17,               // SpectrumWidget only: display floor
+  "gaugeLabel": "71.3°C",                  // HGauge only: centred bar label (live overlay text)
+  "gaugeValue": 71.3,                      // HGauge only: current numeric value
+  "gaugeRange": { "min": 0, "max": 120, "redStart": 70, "yellowStart": 55 },  // HGauge only: scale + zones
+  "gaugeTicks": "0,30,55,70,90,120",       // HGauge only: comma-joined tick labels
   "sliceId": 0,                            // present on widgets tagged with a slice
   "keying": true,                          // present only on TX-keying controls (invoke refuses these)
   "actions": [ <action>, … ],              // QMenu only: popup actions and state
@@ -257,6 +261,16 @@ present.
   `"checked"`); `text` restores the identity.
 - `noiseFloorDbm` / `displayFloorDbm` — a `SpectrumWidget`'s live measured floors
   (the same values [`floors`](#floors) returns), for numeric floor assertions.
+- `gaugeLabel` / `gaugeValue` / `gaugeRange` / `gaugeTicks` — an `HGauge`'s
+  centred bar label, current numeric value, scale (`min`/`max`/`redStart`/`yellowStart`),
+  and tick labels. `HGauge` is a custom-painted widget with no `Q_OBJECT`, so it
+  otherwise serializes as a bare `QWidget` carrying only its `accessibleName`;
+  these fields make the horizontal bar gauges (PA temp / supply / fan on the
+  Radio Hardware applet, and the TX SWR / forward-power / ALC / mic / compression
+  meters) numerically assertable — e.g. proving the MtrApplet °C↔°F toggle
+  switches the PA-temp scale from `0–120` (ticks `0,30,55,70,90,120`) to `32–248`
+  (ticks `32,86,131,158,194,248`) and updates the live overlay text, without a
+  screenshot. Published only under `AETHER_AUTOMATION` (zero cost otherwise).
 
 ### `grab`
 PNG capture of a single widget.

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -355,6 +355,26 @@ QJsonObject describeWidget(const QWidget* w)
         }
     }
 
+    // Surface an HGauge's label/value/scale when the widget publishes them as
+    // dynamic properties (custom-painted, no Q_OBJECT, so read generically via
+    // the meta-object — same decoupled pattern as noiseFloorDbm above). Lets a
+    // driver assert the MtrApplet °C/°F range switch and the live numeric
+    // overlays (PA Temp, fan RPM) numerically, not by pixel-reading (#3886).
+    {
+        const QVariant gl = w->property("gaugeLabel");
+        if (gl.isValid()) {
+            o[QStringLiteral("gaugeLabel")] = gl.toString();
+            o[QStringLiteral("gaugeValue")] = w->property("gaugeValue").toDouble();
+            QJsonObject range;
+            range[QStringLiteral("min")] = w->property("gaugeMin").toDouble();
+            range[QStringLiteral("max")] = w->property("gaugeMax").toDouble();
+            range[QStringLiteral("redStart")] = w->property("gaugeRedStart").toDouble();
+            range[QStringLiteral("yellowStart")] = w->property("gaugeYellowStart").toDouble();
+            o[QStringLiteral("gaugeRange")] = range;
+            o[QStringLiteral("gaugeTicks")] = w->property("gaugeTicks").toString();
+        }
+    }
+
     QJsonArray kids;
     const QObjectList children = w->children();
     for (const QObject* child : children) {

--- a/src/gui/HGauge.h
+++ b/src/gui/HGauge.h
@@ -11,6 +11,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPoint>
+#include <QStringList>
 #include <QWidget>
 #include <QWheelEvent>
 #include <QTimer>
@@ -58,11 +59,13 @@ public:
                 m_animTimer.stop();
             update();
         });
+        publishAutomationState();
     }
 
     void setLabel(const QString& label) {
         if (m_label == label) return;
         m_label = label;
+        publishAutomationState();
         update();
     }
 
@@ -78,6 +81,7 @@ public:
             m_animElapsed.restart();
             m_animTimer.start();
         }
+        publishAutomationState();
         if (m_hovered)
             showHoverPopup(m_lastHoverGlobal);
     }
@@ -88,6 +92,7 @@ public:
         m_smooth.setTarget(
             qBound(0.0f, (v - m_min) / (m_max - m_min), 1.0f));
         m_smooth.snapToTarget();
+        publishAutomationState();
         update();
         if (m_hovered)
             showHoverPopup(m_lastHoverGlobal);
@@ -136,6 +141,7 @@ public:
         m_min = min; m_max = max; m_redStart = redStart;
         m_yellowStart = std::isnan(yellowStart) ? redStart : yellowStart;
         m_ticks = ticks;
+        publishAutomationState();
         update();
     }
 
@@ -304,6 +310,30 @@ protected:
     }
 
 private:
+    // ── Automation-bridge introspection ───────────────────────────────────
+    // HGauge is custom-painted and has no Q_OBJECT, so its label/value/scale
+    // are invisible to the automation bridge's dumpTree. Mirror the state into
+    // dynamic properties whenever it changes; the bridge reads them generically
+    // via the meta-object (the same decoupled pattern SpectrumWidget uses for
+    // noiseFloorDbm), so the °C/°F toggle and live overlay values become
+    // numerically assertable without pixel-reading. Gated on AETHER_AUTOMATION
+    // so production paints carry zero extra cost. (#3886 test support)
+    void publishAutomationState() {
+        static const bool kAutomation = qEnvironmentVariableIsSet("AETHER_AUTOMATION");
+        if (!kAutomation) return;
+        setProperty("gaugeLabel", m_label);
+        setProperty("gaugeValue", m_value);
+        setProperty("gaugeMin", m_min);
+        setProperty("gaugeMax", m_max);
+        setProperty("gaugeRedStart", m_redStart);
+        setProperty("gaugeYellowStart", m_yellowStart);
+        QStringList tickLabels;
+        tickLabels.reserve(m_ticks.size());
+        for (const auto& t : m_ticks)
+            tickLabels << t.label;
+        setProperty("gaugeTicks", tickLabels.join(QLatin1Char(',')));
+    }
+
     QString hoverValueText() const {
         if (m_hoverFormatter)
             return m_hoverFormatter(m_value);

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -1,16 +1,86 @@
 #include "MeterApplet.h"
 #include "HGauge.h"
+#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 #include "models/MeterModel.h"
 
-#include <QVBoxLayout>
+#include <QAccessible>
+#include <QHBoxLayout>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLabel>
+#include <QPushButton>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
+
+namespace {
 
 static const char* kSectionStyle =
     "QLabel { color: #8090a0; font-size: 10px; font-weight: bold; "
     "padding-top: 2px; }";
+
+constexpr const char* kMtrAppletSettingsKey = "MtrApplet";
+constexpr const char* kTempFahrenheitField  = "tempFahrenheit";
+
+QJsonObject readMtrAppletSettings()
+{
+    const QString json = AppSettings::instance()
+        .value(kMtrAppletSettingsKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+void writeMtrAppletSettings(const QJsonObject& obj)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(kMtrAppletSettingsKey,
+        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+bool readMtrTempFahrenheit()
+{
+    return readMtrAppletSettings()
+        .value(kTempFahrenheitField)
+        .toString(QStringLiteral("False")) == QStringLiteral("True");
+}
+
+void writeMtrTempFahrenheit(bool enabled)
+{
+    QJsonObject obj = readMtrAppletSettings();
+    obj[kTempFahrenheitField] =
+        enabled ? QStringLiteral("True") : QStringLiteral("False");
+    writeMtrAppletSettings(obj);
+}
+
+float toFahrenheit(float degC)
+{
+    return degC * 9.0f / 5.0f + 32.0f;
+}
+
+QString formatTemp(float degC, bool fahrenheit)
+{
+    const float disp = fahrenheit ? toFahrenheit(degC) : degC;
+    return QStringLiteral("%1°%2")
+        .arg(disp, 0, 'f', 1)
+        .arg(fahrenheit ? "F" : "C");
+}
+
+// °C scale ticks and the corresponding °F values (toFahrenheit of each)
+static const QVector<HGauge::Tick> kCelsiusTicks = {
+    {0.0f,   "0"},   {30.0f, "30"},   {55.0f,  "55"},
+    {70.0f, "70"},   {90.0f, "90"},  {120.0f, "120"}
+};
+
+static const QVector<HGauge::Tick> kFahrenheitTicks = {
+    {32.0f,  "32"},  {86.0f, "86"},  {131.0f, "131"},
+    {158.0f, "158"}, {194.0f, "194"}, {248.0f, "248"}
+};
+
+} // namespace
 
 MeterApplet::MeterApplet(QWidget* parent)
     : QWidget(parent)
@@ -20,22 +90,58 @@ MeterApplet::MeterApplet(QWidget* parent)
     vbox->setContentsMargins(4, 2, 4, 2);
     vbox->setSpacing(2);
 
+    // ── Header row: section label + °C/°F toggle ─────────────────────────────
+    m_tempFahrenheit = readMtrTempFahrenheit();
+
     auto* header = new QLabel("Radio Hardware");
     header->setStyleSheet(kSectionStyle);
-    vbox->addWidget(header);
 
+    m_tempUnitBtn = new QPushButton(m_tempFahrenheit ? "°F" : "°C", this);
+    m_tempUnitBtn->setObjectName(QStringLiteral("mtrTempUnitButton"));
+    m_tempUnitBtn->setFlat(true);
+    m_tempUnitBtn->setFocusPolicy(Qt::TabFocus);
+    m_tempUnitBtn->setCursor(Qt::PointingHandCursor);
+    m_tempUnitBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    m_tempUnitBtn->setAccessibleDescription(
+        "Toggles PA temperature display between Celsius and Fahrenheit");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tempUnitBtn,
+        "QPushButton { background: transparent; border: 1px solid transparent; "
+        "color: #8090a0; font-size: 10px; text-align: right; padding: 0 2px; }"
+        "QPushButton:hover { border-color: #203040; color: #ffffff; }"
+        "QPushButton:focus { border-color: #00b4d8; }");
+    connect(m_tempUnitBtn, &QPushButton::clicked, this, [this]() {
+        m_tempFahrenheit = !m_tempFahrenheit;
+        writeMtrTempFahrenheit(m_tempFahrenheit);
+        updatePaTempDisplay();
+    });
+
+    auto* headerRow = new QHBoxLayout;
+    headerRow->setSpacing(4);
+    headerRow->setContentsMargins(0, 0, 0, 0);
+    headerRow->addWidget(header);
+    headerRow->addStretch();
+    headerRow->addWidget(m_tempUnitBtn);
+    vbox->addLayout(headerRow);
+
+    // ── PA Temp gauge ─────────────────────────────────────────────────────────
     m_paTempGauge = new HGauge(0.0f, 120.0f, 70.0f, "PA Temp", "",
-        {{0, "0"}, {30, "30"}, {55, "55"}, {70, "70"}, {90, "90"}, {120, "120"}},
-        this, 55.0f);
+        kCelsiusTicks, this, 55.0f);
     m_paTempGauge->setAccessibleName(tr("PA temperature"));
     vbox->addWidget(m_paTempGauge);
 
+    // Apply persisted unit at startup so the saved preference takes effect
+    // before the first telemetry packet arrives.
+    if (m_tempFahrenheit)
+        m_paTempGauge->setRange(32.0f, 248.0f, 158.0f, kFahrenheitTicks, 131.0f);
+
+    // ── Supply voltage gauge ───────────────────────────────────────────────────
     m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "+13.8V", "",
         {{10.5f, "10.5"}, {12, "12"}, {13.8f, "13.8"}, {15, "15"}},
         this, 14.1f);
     m_supplyGauge->setAccessibleName(tr("Supply voltage"));
     vbox->addWidget(m_supplyGauge);
 
+    // ── Main Fan gauge ─────────────────────────────────────────────────────────
     m_fanGauge = new HGauge(0.0f, 3000.0f, 2500.0f, "Main Fan", "",
         {{0, "0"}, {500, "500"}, {1000, "1k"}, {1500, "1.5k"}, {2000, "2k"}, {3000, "3k"}},
         this, 2000.0f);
@@ -43,6 +149,8 @@ MeterApplet::MeterApplet(QWidget* parent)
     vbox->addWidget(m_fanGauge);
 
     vbox->addStretch();
+
+    updatePaTempDisplay();
 }
 
 void MeterApplet::setMeterModel(MeterModel* model)
@@ -51,7 +159,12 @@ void MeterApplet::setMeterModel(MeterModel* model)
 
     connect(model, &MeterModel::hwTelemetryChanged,
             this, [this](float paTemp, float supplyV) {
-        m_paTempGauge->setValue(paTemp);
+        m_paTemp    = paTemp;
+        m_hasPaTemp = true;
+        const float dispTemp = m_tempFahrenheit ? toFahrenheit(paTemp) : paTemp;
+        m_paTempGauge->setValue(dispTemp);
+        m_paTempGauge->setLabel(formatTemp(paTemp, m_tempFahrenheit));
+
         m_supplyGauge->setValue(supplyV);
         m_supplyGauge->setLabel(QString("+%1V").arg(supplyV, 0, 'f', 2));
     });
@@ -75,8 +188,45 @@ void MeterApplet::onMeterUpdated(int index, float value)
     if (!m_resolved)
         resolveIndices();
 
-    if (index == m_fanIdx && m_fanIdx >= 0)
+    if (index == m_fanIdx && m_fanIdx >= 0) {
+        m_fanRpm = value;
         m_fanGauge->setValue(value);
+        m_fanGauge->setLabel(QStringLiteral("%1 rpm").arg(static_cast<int>(value)));
+    }
+}
+
+void MeterApplet::updatePaTempDisplay()
+{
+    // Apply the correct scale — snapping avoids animating the fill bar
+    // across the °C→°F unit jump when the user toggles.
+    if (m_tempFahrenheit) {
+        m_paTempGauge->setRange(32.0f, 248.0f, 158.0f, kFahrenheitTicks, 131.0f);
+        if (m_hasPaTemp)
+            m_paTempGauge->setValueImmediate(toFahrenheit(m_paTemp));
+    } else {
+        m_paTempGauge->setRange(0.0f, 120.0f, 70.0f, kCelsiusTicks, 55.0f);
+        if (m_hasPaTemp)
+            m_paTempGauge->setValueImmediate(m_paTemp);
+    }
+
+    if (m_hasPaTemp)
+        m_paTempGauge->setLabel(formatTemp(m_paTemp, m_tempFahrenheit));
+
+    if (!m_tempUnitBtn)
+        return;
+
+    m_tempUnitBtn->setText(m_tempFahrenheit ? "°F" : "°C");
+    const QString nextUnit = m_tempFahrenheit ? tr("Celsius") : tr("Fahrenheit");
+    m_tempUnitBtn->setToolTip(
+        tr("PA temperature unit\nClick to show in %1").arg(nextUnit));
+    m_tempUnitBtn->setAccessibleName(
+        tr("PA temperature: %1 — click to switch to %2")
+            .arg(m_tempFahrenheit ? tr("Fahrenheit") : tr("Celsius"), nextUnit));
+
+    if (QAccessible::isActive()) {
+        QAccessibleEvent event(m_tempUnitBtn, QAccessible::NameChanged);
+        QAccessible::updateAccessibility(&event);
+    }
 }
 
 } // namespace AetherSDR

--- a/src/gui/MeterApplet.cpp
+++ b/src/gui/MeterApplet.cpp
@@ -129,11 +129,6 @@ MeterApplet::MeterApplet(QWidget* parent)
     m_paTempGauge->setAccessibleName(tr("PA temperature"));
     vbox->addWidget(m_paTempGauge);
 
-    // Apply persisted unit at startup so the saved preference takes effect
-    // before the first telemetry packet arrives.
-    if (m_tempFahrenheit)
-        m_paTempGauge->setRange(32.0f, 248.0f, 158.0f, kFahrenheitTicks, 131.0f);
-
     // ── Supply voltage gauge ───────────────────────────────────────────────────
     m_supplyGauge = new HGauge(10.0f, 16.0f, 15.0f, "+13.8V", "",
         {{10.5f, "10.5"}, {12, "12"}, {13.8f, "13.8"}, {15, "15"}},
@@ -189,7 +184,6 @@ void MeterApplet::onMeterUpdated(int index, float value)
         resolveIndices();
 
     if (index == m_fanIdx && m_fanIdx >= 0) {
-        m_fanRpm = value;
         m_fanGauge->setValue(value);
         m_fanGauge->setLabel(QStringLiteral("%1 rpm").arg(static_cast<int>(value)));
     }

--- a/src/gui/MeterApplet.h
+++ b/src/gui/MeterApplet.h
@@ -38,7 +38,6 @@ private:
     QPushButton* m_tempUnitBtn{nullptr};
 
     float m_paTemp{0.0f};
-    float m_fanRpm{0.0f};
     bool  m_hasPaTemp{false};
     bool  m_tempFahrenheit{false};
 

--- a/src/gui/MeterApplet.h
+++ b/src/gui/MeterApplet.h
@@ -2,6 +2,8 @@
 
 #include <QWidget>
 
+class QPushButton;
+
 namespace AetherSDR {
 
 class MeterModel;
@@ -25,12 +27,20 @@ public:
 private:
     void resolveIndices();
     void onMeterUpdated(int index, float value);
+    void updatePaTempDisplay();
 
     MeterModel* m_model{nullptr};
 
     HGauge* m_paTempGauge{nullptr};
     HGauge* m_supplyGauge{nullptr};
     HGauge* m_fanGauge{nullptr};
+
+    QPushButton* m_tempUnitBtn{nullptr};
+
+    float m_paTemp{0.0f};
+    float m_fanRpm{0.0f};
+    bool  m_hasPaTemp{false};
+    bool  m_tempFahrenheit{false};
 
     // Lazy-resolved meter index (-1 = not yet found)
     int m_fanIdx{-1};


### PR DESCRIPTION
## Summary

- Adds a **°C/°F toggle button** in the Radio Hardware header row so all three gauge bars remain the same full width (no inline crowding)
- On toggle, the PA Temp gauge **range, ticks, and bar position** all update instantly (`setValueImmediate` prevents an animated jump across the unit boundary)
- Preference is persisted in `AppSettings` under the `"MtrApplet"` JSON blob at key `"tempFahrenheit"`, and restored at startup before the first telemetry packet
- Live numeric values are now overlaid in each bar's centre label:
  - **PA Temp** → `"71.3°C"` / `"160.3°F"` (updates on every `hwTelemetryChanged`)
  - **Main Fan** → `"1234 rpm"` (updates on every `onMeterUpdated`)
  - **Supply** already showed `"+13.82V"` — unchanged
- Accessibility: toggle button gets `accessibleName`, `accessibleDescription`, and fires `QAccessible::NameChanged` on each toggle

Follows the established `AmpApplet` pattern throughout (JSON blob, anonymous-namespace helpers, `QPushButton` with flat/transparent style).

## Test plan

- [ ] Build cleanly — `ninja -C build CMakeFiles/AetherSDR.dir/src/gui/MeterApplet.cpp.o` passes with no errors
- [ ] Launch with a connected radio and confirm PA Temp and Fan RPM show live values in bar labels
- [ ] Click the `°C`/`°F` button — gauge ticks and bar fill position update without animation stutter
- [ ] Restart — confirm the saved unit preference is restored
- [ ] Tab through the applet with keyboard — toggle button is reachable and announces unit change to screen readers

> ⚠️ No FLEX-8600 hardware available for runtime testing; compile-only verified.

Fixes #3886

🤖 Generated with [Claude Code](https://claude.com/claude-code)