### PR TITLE
fix(gui): restore crisp 2D FFT trace — segment-clamped stroke, AA parity, plateau-gated smoothing (#3967, #3932)

### DIFF
--- a/resources/shaders/panscope.frag
+++ b/resources/shaders/panscope.frag
@@ -95,23 +95,45 @@ void main()
         outc = over(outc, pm(rgb, a, 1.0));
     }
 
-    // ── Stroke (feather under core), slope-corrected width ─────────────
+    // ── Stroke (feather under core), exact segment distance ────────────
+    // #3967: the first cut approximated stroke distance as the vertical
+    // distance scaled by a dFdx()-derived slope — distance to the segment's
+    // INFINITE line. On steep segments that line passes near the entire pixel
+    // column, so the stroke shot full-height spikes above and below the trace
+    // ("spiky both above and below the line"). Compute the true distance to
+    // the two polyline segments adjacent to this column instead (plus one
+    // neighbor each side so wide strokes bleed across columns like the old
+    // geometry quads did), clamped to the segment endpoints.
     float coreHalf = stroke.x;
     if (coreHalf > 0.0) {
-        // dFdx of the trace height gives the segment slope in px/px; scale
-        // the vertical distance to true perpendicular distance so steep
-        // flanks keep their stroke width (the old geometry offset vertices
-        // along the segment normal for the same reason).
-        float slope = dFdx(yTrace) / max(fwidth(v_uv.x) * plot.x, 1e-4);
-        float invLen = inversesqrt(1.0 + slope * slope);
-        float d = abs(py - yTrace) * invLen;
+        vec2 px = vec2(v_uv.x * plot.x, py);       // this fragment in device px
+        float nCols = max(plot.z, 2.0);
+        float colW = plot.x / nCols;               // px per column
+        float i0 = floor(px.x / colW - 0.5);
+        vec2 pt[4];
+        for (int k = 0; k < 4; ++k) {
+            float ci = clamp(i0 + float(k) - 1.0, 0.0, nCols - 1.0);
+            float ty = clamp(texture(columns, vec2((ci + 0.5) / nCols, 0.5)).r,
+                             0.0, 1.0);
+            pt[k] = vec2((ci + 0.5) * colW, (1.0 - ty) * hPx);
+        }
+        float d = 1e9;
+        for (int k = 0; k < 3; ++k) {
+            vec2 a = pt[k];
+            vec2 ab = pt[k + 1] - a;
+            float tt = clamp(dot(px - a, ab) / max(dot(ab, ab), 1e-6), 0.0, 1.0);
+            d = min(d, length(px - (a + tt * ab)));
+        }
 
+        // Falloff parity with the old vertex strips (spectrum.frag): solid
+        // out to halfWidth-1, a 1 px fade to halfWidth; the feather adds one
+        // more 1 px annulus at low alpha. The first cut's fixed ±0.75 px
+        // smoothstep band read as a soft "blurred" stroke at 1x DPI.
         vec3 lineRgb = heat ? heatColor(t) : fillColor.rgb;
         float featherHalf = coreHalf + stroke.y;
-        float aa = 0.75;
-        float covF = 1.0 - smoothstep(featherHalf - aa, featherHalf + aa, d);
+        float covF = 1.0 - smoothstep(coreHalf, featherHalf, d);
         outc = over(outc, pm(lineRgb, stroke.w, covF));
-        float covC = 1.0 - smoothstep(coreHalf - aa, coreHalf + aa, d);
+        float covC = 1.0 - smoothstep(max(coreHalf - 1.0, 0.0), coreHalf, d);
         outc = over(outc, pm(lineRgb, stroke.z, covC));
     }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5412,17 +5412,42 @@ const QVector<float>& SpectrumWidget::buildFftDisplayTrace(const QVector<float>&
 
     // Display-only spatial smoothing: m_smoothed is temporal, so it reduces
     // frame shimmer but leaves adjacent-bin stair steps intact.
+    //
+    // #3932/#3967: the 5-tap blend exists to melt the radio's RBW stair-steps
+    // when zoomed IN (bins repeat as plateaus once the span drops below the
+    // FFT's resolution). Applied unconditionally (#3836) it low-passes every
+    // trace — rounding off narrow carriers and defocusing the noise floor at
+    // wide spans ("out of focus", 26.6.5). Gate the blend on the measured
+    // plateau fraction so it only engages when stair-steps actually exist:
+    // zoomed-in plateaus (long equal runs, frac >~0.65) get the full blend,
+    // a busy wide span (frac <~0.35, adjacent noise bins rarely equal) gets
+    // none, and the ramp between avoids a visible mode flip while zooming.
+    int plateauPairs = 0;
+    for (int i = 1; i < srcCount; ++i) {
+        if (std::abs(bins[i] - bins[i - 1]) < 0.01f) {
+            ++plateauPairs;
+        }
+    }
+    const float plateauFrac =
+        static_cast<float>(plateauPairs) / static_cast<float>(srcCount - 1);
+    const float smoothBlend = kFftDisplaySpatialSmoothBlend
+        * std::clamp((plateauFrac - 0.35f) / 0.30f, 0.0f, 1.0f);
+
     QVector<float>& displayBins = m_fftDisplaySmoothScratch;
-    displayBins.resize(srcCount);
-    displayBins[0] = bins[0];
-    displayBins[srcCount - 1] = bins[srcCount - 1];
-    for (int i = 1; i < srcCount - 1; ++i) {
-        const float localSmooth = (i >= 2 && i + 2 < srcCount)
-            ? (bins[i - 2] + 4.0f * bins[i - 1] + 6.0f * bins[i]
-               + 4.0f * bins[i + 1] + bins[i + 2]) * 0.0625f
-            : (bins[i - 1] + 2.0f * bins[i] + bins[i + 1]) * 0.25f;
-        displayBins[i] = bins[i] * (1.0f - kFftDisplaySpatialSmoothBlend)
-            + localSmooth * kFftDisplaySpatialSmoothBlend;
+    if (smoothBlend <= 0.0f) {
+        displayBins = bins;
+    } else {
+        displayBins.resize(srcCount);
+        displayBins[0] = bins[0];
+        displayBins[srcCount - 1] = bins[srcCount - 1];
+        for (int i = 1; i < srcCount - 1; ++i) {
+            const float localSmooth = (i >= 2 && i + 2 < srcCount)
+                ? (bins[i - 2] + 4.0f * bins[i - 1] + 6.0f * bins[i]
+                   + 4.0f * bins[i + 1] + bins[i + 2]) * 0.0625f
+                : (bins[i - 1] + 2.0f * bins[i] + bins[i + 1]) * 0.25f;
+            displayBins[i] = bins[i] * (1.0f - smoothBlend)
+                + localSmooth * smoothBlend;
+        }
     }
 
     int dstCount = std::max(targetPoints, srcCount);
@@ -8133,11 +8158,14 @@ void SpectrumWidget::initSpectrumPipeline()
     QRhi* r = rhi();
 
     // Column texture is (re)created at the spectrum viewport width in
-    // renderGpuFrame; only the fixed resources are built here. R32F is
-    // universal on the desktop backends; fall back to R16F (mandatory
-    // linear-filterable since GLES3) for anything that lacks it.
-    m_fftColFormat = r->isTextureFormatSupported(QRhiTexture::R32F)
-        ? QRhiTexture::R32F : QRhiTexture::R16F;
+    // renderGpuFrame; only the fixed resources are built here. The column is
+    // sampled with LINEAR filtering, so the format must be linearly
+    // *filterable*, not merely creatable — isTextureFormatSupported() cannot
+    // distinguish the two, and float32 filtering is optional on GLES (and on
+    // some older GL drivers). R16F is filterable on every QRhi backend and
+    // half precision is ample for the normalized 0..1 amplitude stored here
+    // (same conclusion as PR #3968). Use it unconditionally.
+    m_fftColFormat = QRhiTexture::R16F;
     m_fftScopeUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer,
                                  5 * 4 * sizeof(float));
     m_fftScopeUbo->create();


### PR DESCRIPTION
## Summary

Fixes #3967. Also fixes #3932. Root-caused with per-commit builds (pre-#3836, post-#3836, 26.7.1-main, this fix) captured minutes apart against the same live AM broadcast band on a FLEX-8400M:

![4-way comparison](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets/pan-trace-regression-4way.png)

## The regression chain (two releases, two causes)

**26.6.5 — #3836's unconditional spatial smoothing ("out of focus", #3932).** `buildFftDisplayTrace`'s 5-tap binomial smooth at a fixed 0.75 blend exists to melt the radio's RBW stair-steps when zoomed in. Applied to every frame at every span, it rounds narrow carriers (visible height loss on AM carriers, panel 2) and defocuses the noise floor. **Fix:** gate the blend on the measured plateau fraction (adjacent equal-pixel bins). Zoomed-in plateau runs (frac ≳0.65) keep the full blend — #3836's stair-step fix is preserved; busy wide spans (frac ≲0.35) get zero — the pre-#3836 crispness returns; the ramp between prevents a visible mode flip while zooming.

**26.7.1 — #3958's per-pixel stroke ("spiky above and below the line", the rest of #3967).** The stroke distance was approximated as vertical distance scaled by a `dFdx`-derived slope — i.e. distance to the segment's **infinite line**. On steep segments that line passes near the entire pixel column, so the stroke drew full-height needles above and below the trace (panel 3), and the fixed ±0.75 px smoothstep band read as a soft fat stroke at 1× DPI. **Fix:** true endpoint-clamped distance to the three adjacent polyline segments (4 column samples — matches the coverage the old geometry quads had), plus falloff parity with the old `spectrum.frag`: solid to `halfWidth−1`, 1 px fade, 1 px feather annulus at α 0.22.

Also folds in #3968's R16F-unconditional column format as hardening (float32 linear filtering is optional on GLES and `isTextureFormatSupported()` can't detect filterability). Note it could **not** have caused #3967: the reporter's own About screenshot shows `D3D11; Intel(R) HD Graphics 520` — feature level 12.1 hardware where R32F linear filtering is mandatory. With this folded in, #3968 can be closed.

Not implicated (left untouched, documented for the record): #3836's `decodeFFT` over-range renormalization only fires on radio/client `y_pixels` mismatch (transient), and the DPR-scaled `x_pixels`/`y_pixels` requests are orthogonal to trace sharpness.

## Why our platforms missed it

The #3958 parity checks ran on 2× Retina, where the extra AA softness is half the logical size and the spike needles read as band activity in static grabs. The 4-way same-band comparison above is exactly the test that should have been run: panel 4 (this fix) restores panel 1 (pre-#3836).

## Verification

- 4-way live comparison above (same band, same radio pan, same display settings; three grabs per build).
- `get panstats 0`: frame prep unchanged at ~121 µs/frame, 58 presents/s, `fftBuildMsPerSec` 0.28 (plateau gate skips the smoothing copy on wide spans).
- 3D stacked-trace mode, lean mode, line-width 0, heat/solid fill: unaffected paths re-checked by inspection; the software (non-QRhi-build) QPainter renderer shares `buildFftDisplayTrace` and picks up the plateau gate automatically.

## Also on the #3967 thread (separate follow-ups, not in this PR)

- "3D option no longer exists": the 2D/3D combo is the **last row of the Display panel**, below Background — on short screens (768p laptops) it clips off the bottom of the panadapter. Needs a scrollable/compacted Display panel; the option itself ships fine in 26.7.1.
- The 60 fps FFT slider ceiling from #3958 is unrelated to this report but worth an explicit release-notes mention.

💻 Generated with Claude Code (claude-fable-5 7/2/26) with architecture by @jensenpat

🤖 Generated with [Claude Code](https://claude.com/claude-code)