### PR TITLE
feat(cwx): inline speed modifiers — +word / -word per word in CWX macros (#272)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2323,6 +2323,15 @@ target_include_directories(tnc_terminal_test PRIVATE src)
 target_link_libraries(tnc_terminal_test PRIVATE Qt6::Core)
 add_test(NAME tnc_terminal_test COMMAND tnc_terminal_test)
 
+add_executable(cwx_speed_modifier_test
+    tests/cwx_speed_modifier_test.cpp
+    src/models/CwxModel.cpp
+    src/models/CwxModel.h
+)
+target_include_directories(cwx_speed_modifier_test PRIVATE src)
+target_link_libraries(cwx_speed_modifier_test PRIVATE Qt6::Core)
+add_test(NAME cwx_speed_modifier_test COMMAND cwx_speed_modifier_test)
+
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp
     src/gui/CwxPanel.cpp

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -34,8 +34,9 @@ QJsonObject readCwxPanelSettings()
 {
     const QString json = AetherSDR::AppSettings::instance()
         .value(kCwxPanelSettingsKey, QString{}).toString();
-    if (json.isEmpty())
+    if (json.isEmpty()) {
         return {};
+    }
     const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
     return doc.isObject() ? doc.object() : QJsonObject{};
 }
@@ -50,7 +51,10 @@ void writeCwxPanelSettings(const QJsonObject& obj)
 
 int readSpeedStep()
 {
-    return qBound(1, readCwxPanelSettings().value(kSpeedStepField).toInt(3), 20);
+    return qBound(AetherSDR::CwxModel::kMinSpeedStep,
+                  readCwxPanelSettings().value(kSpeedStepField)
+                      .toInt(AetherSDR::CwxModel::kDefaultSpeedStep),
+                  AetherSDR::CwxModel::kMaxSpeedStep);
 }
 
 void writeSpeedStep(int step)
@@ -66,8 +70,9 @@ QString bubbleTextFor(const QString& rawText, int baseWpm, int step)
 {
     const auto segs = AetherSDR::CwxModel::expandSpeedModifiers(rawText, baseWpm, step);
     QString result;
-    for (const auto& s : segs)
+    for (const auto& s : segs) {
         result += s.text;
+    }
     return result.isEmpty() ? rawText : result;
 }
 
@@ -243,8 +248,8 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     barLayout->addWidget(speedLabel);
 
     m_speedSpin = new QSpinBox;
-    m_speedSpin->setRange(5, 100);
-    m_speedSpin->setValue(20);
+    m_speedSpin->setRange(CwxModel::kMinWpm, CwxModel::kMaxWpm);
+    m_speedSpin->setValue(CwxModel::kDefaultWpm);
     m_speedSpin->setFixedWidth(50);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_speedSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 2px; font-size: 11px; padding: 2px; }");
@@ -458,7 +463,7 @@ void CwxPanel::buildSetupView()
 
     topRow->addWidget(new QLabel("Step:"));
     m_speedStepSpin = new QSpinBox;
-    m_speedStepSpin->setRange(1, 20);
+    m_speedStepSpin->setRange(CwxModel::kMinSpeedStep, CwxModel::kMaxSpeedStep);
     m_speedStepSpin->setValue(readSpeedStep());
     m_speedStepSpin->setSuffix(" wpm");
     m_speedStepSpin->setFixedWidth(60);
@@ -473,11 +478,20 @@ void CwxPanel::buildSetupView()
             this, [this](int v) { if (m_model) m_model->setDelay(v); });
     connect(m_qskBtn, &QPushButton::toggled,
             this, [this](bool on) { if (m_model) m_model->setQsk(on); });
+    // Live-update the model on every change (cheap, in-memory) but persist
+    // only on editingFinished (focus-out / Enter) so sweeping the arrows or
+    // wheel doesn't trigger one full atomic settings-file rewrite per tick.
     connect(m_speedStepSpin, QOverload<int>::of(&QSpinBox::valueChanged),
             this, [this](int v) {
-                if (m_model) m_model->setSpeedStep(v);
-                writeSpeedStep(v);
+                if (m_model) {
+                    m_model->setSpeedStep(v);
+                }
             });
+    connect(m_speedStepSpin, &QSpinBox::editingFinished, this, [this]() {
+        if (m_speedStepSpin) {
+            writeSpeedStep(m_speedStepSpin->value());
+        }
+    });
 
     // Style labels
     for (auto* lbl : m_setupPage->findChildren<QLabel*>())

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -79,8 +79,9 @@ namespace AetherSDR {
 // CwxBubble's class declaration lives in CwxPanel.h so the test target
 // can dynamic_cast bubbles out of the history container and verify the
 // strikeout state set by ESC abort (#3146).
-CwxBubble::CwxBubble(const QString& text, const QString& time, QWidget* parent)
-    : QWidget(parent), m_text(text), m_time(time)
+CwxBubble::CwxBubble(const QString& displayText, const QString& time,
+                     const QString& rawText, QWidget* parent)
+    : QWidget(parent), m_text(displayText), m_rawText(rawText), m_time(time)
 {
     recalcSize();
 }
@@ -312,8 +313,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
             // command so the snapshot of m_model->sentIndex() lines up
             // with the chars about to be keyed for this bubble. (#3146)
             const QString raw = m_model->macro(i);
-            appendHistoryBubble(
-                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
+            appendHistoryBubble(raw);
             m_model->sendMacro(i + 1);
         });
     }
@@ -514,8 +514,7 @@ void CwxPanel::buildSetupView()
         connect(label, &QPushButton::clicked, this, [this, i]() {
             if (!m_model) return;
             const QString raw = m_model->macro(i);
-            appendHistoryBubble(
-                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
+            appendHistoryBubble(raw);
             m_model->sendMacro(i + 1);
         });
 
@@ -555,20 +554,26 @@ void CwxPanel::sendBuffer()
     QString text = m_textEdit->toPlainText().trimmed();
     if (text.isEmpty()) return;
 
-    // Show keyed text (modifiers stripped) so the bubble's char count
-    // matches what the radio's sent=N counter advances against. (#272)
-    appendHistoryBubble(
-        bubbleTextFor(text, m_model->speed(), m_model->speedStep()));
+    // appendHistoryBubble paints the modifier-stripped text (so the bubble's
+    // char count matches the radio's sent=N counter) while retaining the raw
+    // text for Resend. (#272)
+    appendHistoryBubble(text);
     m_textEdit->clear();
 
     m_model->send(text);
 }
 
-void CwxPanel::appendHistoryBubble(const QString& text)
+void CwxPanel::appendHistoryBubble(const QString& rawText)
 {
-    if (!m_historyLayout || text.isEmpty()) return;
+    if (!m_historyLayout || rawText.isEmpty()) return;
+    // Paint the modifier-stripped text (so its length aligns with the radio's
+    // `sent=N` counter) but keep the raw text on the bubble so a later Resend
+    // re-expands the per-word speed modifiers instead of keying at base WPM.
+    const int baseWpm = m_model ? m_model->speed() : 0;
+    const int step    = m_model ? m_model->speedStep() : 0;
+    const QString displayText = bubbleTextFor(rawText, baseWpm, step);
     const QString ts = QDateTime::currentDateTime().toString("HH:mm:ss");
-    auto* bubble = new CwxBubble(text, ts, m_historyContainer);
+    auto* bubble = new CwxBubble(displayText, ts, rawText, m_historyContainer);
     bubble->installEventFilter(this);
     m_historyLayout->addWidget(bubble);
     // Snapshot the radio's global cumulative sent index at append time —
@@ -576,7 +581,7 @@ void CwxPanel::appendHistoryBubble(const QString& text)
     // progress.  `sent=N` in CWX.cs is global, not per-block. (#3146)
     m_pendingBubble     = bubble;
     m_pendingStartIndex = m_model ? m_model->sentIndex() : -1;
-    m_pendingText       = text;
+    m_pendingText       = displayText;
     QTimer::singleShot(10, this, [this]() {
         if (m_historyScroll) {
             auto* sb = m_historyScroll->verticalScrollBar();
@@ -677,7 +682,9 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
             QAction* clearAction  = menu.addAction("Clear History");
             QAction* chosen = menu.exec(ce->globalPos());
             if (chosen == resendAction) {
-                resendText(bubble->text());
+                // Resend the raw text (modifiers intact) so per-word speeds
+                // are preserved rather than re-keyed at base WPM. (#272)
+                resendText(bubble->rawText());
             } else if (chosen == clearAction) {
                 clearHistory();
             }

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -375,10 +375,12 @@ void CwxPanel::setModel(CwxModel* model)
             m_speedStepSpin->setValue(step);
         }
     });
-    // Sync step spin to model's current value (model may be set after construction)
+    // Push the persisted step (loaded into the spin from AppSettings in
+    // buildSetupView) INTO the model — a fresh model starts at its hardcoded
+    // default, so syncing model->spin here would discard the saved value every
+    // launch. The persisted value is authoritative at setup. (#3976 review)
     if (m_speedStepSpin && m_model->speedStep() != m_speedStepSpin->value()) {
-        QSignalBlocker b(m_speedStepSpin);
-        m_speedStepSpin->setValue(m_model->speedStep());
+        m_model->setSpeedStep(m_speedStepSpin->value());
     }
     connect(m_model, &CwxModel::qskChanged, this, [this](bool on) {
         if (m_qskBtn) {

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -1,26 +1,77 @@
 #include "CwxPanel.h"
+#include "core/AppSettings.h"
 #include "core/TxKeyingMarker.h"
 #include "models/CwxModel.h"
 
-#include <QVBoxLayout>
+#include <QContextMenuEvent>
+#include <QDateTime>
 #include <QHBoxLayout>
-#include <QPushButton>
-#include <QTextEdit>
-#include <QSpinBox>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
-#include <QStackedWidget>
-#include <QScrollArea>
-#include <QDateTime>
-#include <QKeyEvent>
-#include <QPainter>
-#include <QScrollBar>
-#include <QContextMenuEvent>
 #include <QMenu>
+#include <QPainter>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QSignalBlocker>
+#include <QSpinBox>
+#include <QStackedWidget>
+#include <QTextEdit>
 #include <QTimer>
+#include <QVBoxLayout>
 #include "core/ThemeManager.h"
+
+namespace {
+
+constexpr const char* kCwxPanelSettingsKey = "CwxPanel";
+constexpr const char* kSpeedStepField = "speedStep";
+
+QJsonObject readCwxPanelSettings()
+{
+    const QString json = AetherSDR::AppSettings::instance()
+        .value(kCwxPanelSettingsKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+void writeCwxPanelSettings(const QJsonObject& obj)
+{
+    auto& s = AetherSDR::AppSettings::instance();
+    s.setValue(kCwxPanelSettingsKey,
+        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+int readSpeedStep()
+{
+    return qBound(1, readCwxPanelSettings().value(kSpeedStepField).toInt(3), 20);
+}
+
+void writeSpeedStep(int step)
+{
+    QJsonObject obj = readCwxPanelSettings();
+    obj[kSpeedStepField] = step;
+    writeCwxPanelSettings(obj);
+}
+
+// Returns bubble-display text for a CW transmission: the text actually keyed
+// (speed modifier prefixes stripped, joined from expansion segments).
+QString bubbleTextFor(const QString& rawText, int baseWpm, int step)
+{
+    const auto segs = AetherSDR::CwxModel::expandSpeedModifiers(rawText, baseWpm, step);
+    QString result;
+    for (const auto& s : segs)
+        result += s.text;
+    return result.isEmpty() ? rawText : result;
+}
+
+} // namespace
 
 namespace AetherSDR {
 
@@ -260,7 +311,9 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
             // Log the macro text to the history feed BEFORE firing the
             // command so the snapshot of m_model->sentIndex() lines up
             // with the chars about to be keyed for this bubble. (#3146)
-            appendHistoryBubble(m_model->macro(i));
+            const QString raw = m_model->macro(i);
+            appendHistoryBubble(
+                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
             m_model->sendMacro(i + 1);
         });
     }
@@ -316,6 +369,17 @@ void CwxPanel::setModel(CwxModel* model)
             m_delaySpin->setValue(ms);
         }
     });
+    connect(m_model, &CwxModel::speedStepChanged, this, [this](int step) {
+        if (m_speedStepSpin) {
+            QSignalBlocker b(m_speedStepSpin);
+            m_speedStepSpin->setValue(step);
+        }
+    });
+    // Sync step spin to model's current value (model may be set after construction)
+    if (m_speedStepSpin && m_model->speedStep() != m_speedStepSpin->value()) {
+        QSignalBlocker b(m_speedStepSpin);
+        m_speedStepSpin->setValue(m_model->speedStep());
+    }
     connect(m_model, &CwxModel::qskChanged, this, [this](bool on) {
         if (m_qskBtn) {
             QSignalBlocker b(m_qskBtn);
@@ -374,13 +438,13 @@ void CwxPanel::buildSetupView()
     vbox->setContentsMargins(4, 4, 4, 4);
     vbox->setSpacing(4);
 
-    // Delay + QSK
+    // Delay + QSK + Speed Step
     auto* topRow = new QHBoxLayout;
     topRow->addWidget(new QLabel("Delay:"));
     m_delaySpin = new QSpinBox;
     m_delaySpin->setRange(0, 2000);
     m_delaySpin->setValue(5);
-    m_delaySpin->setFixedWidth(60);
+    m_delaySpin->setFixedWidth(52);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_delaySpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 2px; font-size: 11px; }");
     topRow->addWidget(m_delaySpin);
@@ -389,6 +453,17 @@ void CwxPanel::buildSetupView()
     m_qskBtn->setCheckable(true);
     m_qskBtn->setStyleSheet(kBtnStyle);
     topRow->addWidget(m_qskBtn);
+
+    topRow->addWidget(new QLabel("Step:"));
+    m_speedStepSpin = new QSpinBox;
+    m_speedStepSpin->setRange(1, 20);
+    m_speedStepSpin->setValue(readSpeedStep());
+    m_speedStepSpin->setSuffix(" wpm");
+    m_speedStepSpin->setFixedWidth(60);
+    m_speedStepSpin->setToolTip("WPM delta applied by each + or - speed modifier prefix");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_speedStepSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 2px; font-size: 11px; }");
+    topRow->addWidget(m_speedStepSpin);
     topRow->addStretch(1);
     vbox->addLayout(topRow);
 
@@ -396,6 +471,11 @@ void CwxPanel::buildSetupView()
             this, [this](int v) { if (m_model) m_model->setDelay(v); });
     connect(m_qskBtn, &QPushButton::toggled,
             this, [this](bool on) { if (m_model) m_model->setQsk(on); });
+    connect(m_speedStepSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, [this](int v) {
+                if (m_model) m_model->setSpeedStep(v);
+                writeSpeedStep(v);
+            });
 
     // Style labels
     for (auto* lbl : m_setupPage->findChildren<QLabel*>())
@@ -431,7 +511,9 @@ void CwxPanel::buildSetupView()
         // Click F-key label → log macro text to history, then send. (#3146)
         connect(label, &QPushButton::clicked, this, [this, i]() {
             if (!m_model) return;
-            appendHistoryBubble(m_model->macro(i));
+            const QString raw = m_model->macro(i);
+            appendHistoryBubble(
+                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
             m_model->sendMacro(i + 1);
         });
 
@@ -444,8 +526,11 @@ void CwxPanel::buildSetupView()
 
     vbox->addWidget(macroWidget, 1);
 
-    // Prosign legend
-    auto* legend = new QLabel("Prosigns: = (BT)  + (AR)  ( (KN)  & (BK)  $ (SK)");
+    // Prosign + speed-modifier legend
+    auto* legend = new QLabel(
+        "Prosigns: = (BT)  + (AR)  ( (KN)  & (BK)  $ (SK)\n"
+        "Speed: +word (faster)  -word (slower)  ++/-- (2\xc3\x97 step)\n"
+        "  + or - at word-start only; standalone + remains AR");
     AetherSDR::ThemeManager::instance().applyStyleSheet(legend, "QLabel { color: {{color.text.label}}; font-size: 9px; padding: 4px; }");
     legend->setWordWrap(true);
     vbox->addWidget(legend);
@@ -468,7 +553,10 @@ void CwxPanel::sendBuffer()
     QString text = m_textEdit->toPlainText().trimmed();
     if (text.isEmpty()) return;
 
-    appendHistoryBubble(text);
+    // Show keyed text (modifiers stripped) so the bubble's char count
+    // matches what the radio's sent=N counter advances against. (#272)
+    appendHistoryBubble(
+        bubbleTextFor(text, m_model->speed(), m_model->speedStep()));
     m_textEdit->clear();
 
     m_model->send(text);

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -123,6 +123,7 @@ private:
     QWidget*        m_setupPage{nullptr};
     QTextEdit*      m_macroEdits[12]{};
     QSpinBox*       m_delaySpin{nullptr};
+    QSpinBox*       m_speedStepSpin{nullptr};
     QPushButton*    m_qskBtn{nullptr};
 
     // Bottom bar

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -28,9 +28,15 @@ class CwxModel;
 // (#3146).
 class CwxBubble : public QWidget {
 public:
-    CwxBubble(const QString& text, const QString& time, QWidget* parent = nullptr);
+    // `displayText` is the modifier-stripped text that is painted and whose
+    // length the `sent=N` counter advances against; `rawText` is the original
+    // input (with `+`/`-` speed modifiers intact) so Resend can re-expand it
+    // at the correct per-word speeds rather than flattening to base WPM (#272).
+    CwxBubble(const QString& displayText, const QString& time,
+              const QString& rawText, QWidget* parent = nullptr);
 
     QString text() const { return m_text; }
+    QString rawText() const { return m_rawText; }
     int     sentCount() const { return m_sentCount; }
     bool    isAborted() const { return m_aborted; }
 
@@ -45,6 +51,7 @@ private:
     void recalcSize();
 
     QString m_text;
+    QString m_rawText;
     QString m_time;
     int     m_sentCount{0};
     bool    m_aborted{false};
@@ -96,7 +103,7 @@ private:
     void sendBuffer();
     void resendText(const QString& text);
     void clearHistory();
-    void appendHistoryBubble(const QString& text);
+    void appendHistoryBubble(const QString& rawText);
     void onKeyPress(const QString& text);
 
     CwxModel*       m_model{nullptr};

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -14,14 +14,103 @@ QString CwxModel::macro(int idx) const
     return m_macros[idx];
 }
 
+QVector<CwxModel::SpeedSegment>
+CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
+{
+    QVector<SpeedSegment> segs;
+    if (text.isEmpty())
+        return segs;
+
+    QString accumText;
+    int     accumWpm    = baseWpm;
+    bool    prevWasSpace = true;  // string start acts like after-space
+
+    for (int i = 0; i < text.size(); ) {
+        if (text[i] == ' ') {
+            accumText += ' ';
+            prevWasSpace = true;
+            ++i;
+            continue;
+        }
+
+        // Count +/- modifier prefix — only valid at a word boundary
+        int plus = 0, minus = 0;
+        int j = i;
+        if (prevWasSpace) {
+            while (j < text.size() && (text[j] == '+' || text[j] == '-')) {
+                if (text[j] == '+') ++plus; else ++minus;
+                ++j;
+            }
+            // Treat as modifier only when immediately followed by a word char
+            // (non-space, non-modifier).  Standalone +/- are prosigns/hyphens.
+            if (j >= text.size() || text[j] == ' ') {
+                plus = minus = 0;
+                j = i;
+            }
+        }
+
+        // Scan word body to end-of-word
+        const int wordStart = j;
+        while (j < text.size() && text[j] != ' ') ++j;
+        const QString wordBody = text.mid(wordStart, j - wordStart);
+
+        const bool hasModifier = (plus > 0 || minus > 0);
+        const int  delta   = (plus - minus) * step;
+        const int  wordWpm = hasModifier
+                           ? qBound(5, baseWpm + delta, 100)
+                           : baseWpm;
+
+        if (wordWpm != accumWpm) {
+            if (!accumText.isEmpty())
+                segs.append({accumText, accumWpm});
+            accumText.clear();
+            accumWpm = wordWpm;
+        }
+
+        accumText   += wordBody;
+        prevWasSpace = false;
+
+        if (hasModifier) {
+            // Speed resets to base after each modifier word
+            segs.append({accumText, accumWpm});
+            accumText.clear();
+            accumWpm = baseWpm;
+        }
+
+        i = j;
+    }
+
+    if (!accumText.isEmpty())
+        segs.append({accumText, accumWpm});
+
+    return segs;
+}
+
+void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
+{
+    int cmdWpm = m_speed;
+    for (const SpeedSegment& seg : segs) {
+        if (seg.wpm != cmdWpm) {
+            emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
+            cmdWpm = seg.wpm;
+        }
+        QString encoded = seg.text;
+        encoded.replace(' ', QChar(0x7f));
+        if (!encoded.isEmpty())
+            emit commandReady(
+                QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
+        if (!seg.text.isEmpty())
+            emit transmissionRequested(seg.text, seg.wpm);
+    }
+    // Restore authoritative WPM if transient changes were made
+    if (cmdWpm != m_speed)
+        emit commandReady(QString("cwx wpm %1").arg(m_speed));
+}
+
 void CwxModel::send(const QString& text)
 {
     if (text.isEmpty()) return;
-    // Encode spaces as DEL (0x7f) per FlexLib protocol
-    QString encoded = text;
-    encoded.replace(' ', QChar(0x7f));
-    emit commandReady(QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
-    emit transmissionRequested(text, m_speed);
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
 }
 
 void CwxModel::sendChar(const QString& ch)
@@ -36,12 +125,14 @@ void CwxModel::sendChar(const QString& ch)
 void CwxModel::sendMacro(int idx)
 {
     if (idx < 1 || idx > 12) return;
-    emit commandReady(QString("cwx macro send %1").arg(idx));
-    // Macro text lives in m_macros (0-based); fire local keyer with it
-    // so sidetone matches the radio's expansion.
     const QString text = m_macros[idx - 1];
-    if (!text.isEmpty())
-        emit transmissionRequested(text, m_speed);
+    if (text.isEmpty()) return;
+    // Expand speed modifiers client-side via cwx send blocks rather than
+    // cwx macro send N.  When no modifiers are present the result is a
+    // single cwx send identical in effect to the radio-side expansion, but
+    // the unified path ensures + / - prefixes are never forwarded to the
+    // radio where they would be misread as prosigns (AR / hyphen).
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
 }
 
 void CwxModel::saveMacro(int idx, const QString& text)
@@ -61,6 +152,9 @@ void CwxModel::erase(int numChars)
 
 void CwxModel::clearBuffer()
 {
+    // Re-anchor WPM before clearing so ESC can't leave the radio parked at
+    // a transient speed that was in-flight from an expandedSend sequence.
+    emit commandReady(QString("cwx wpm %1").arg(m_speed));
     emit commandReady("cwx clear");
     emit transmissionCancelled();
 }
@@ -72,6 +166,15 @@ void CwxModel::setSpeed(int wpm)
         m_speed = wpm;
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
         emit speedChanged(m_speed);
+    }
+}
+
+void CwxModel::setSpeedStep(int step)
+{
+    step = qBound(1, step, 20);
+    if (step != m_speedStep) {
+        m_speedStep = step;
+        emit speedStepChanged(m_speedStep);
     }
 }
 

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -26,7 +26,12 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
     bool    prevWasSpace = true;  // string start acts like after-space
 
     for (int i = 0; i < text.size(); ) {
-        if (text[i] == ' ') {
+        // Any whitespace (space, tab, newline) is a word boundary and keys as
+        // a word gap. Macros come from multi-line QTextEdit widgets, so a raw
+        // '\n'/'\t' must not be treated as a word char (it would bleed a
+        // modifier across the line and, un-DEL-encoded, corrupt the cwx send
+        // command). Normalize to a single space. (#3976 review)
+        if (text[i].isSpace()) {
             accumText += ' ';
             prevWasSpace = true;
             ++i;
@@ -43,7 +48,7 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
             }
             // Treat as modifier only when immediately followed by a word char
             // (non-space, non-modifier).  Standalone +/- are prosigns/hyphens.
-            if (j >= text.size() || text[j] == ' ') {
+            if (j >= text.size() || text[j].isSpace()) {
                 plus = minus = 0;
                 j = i;
             }
@@ -51,7 +56,9 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
 
         // Scan word body to end-of-word
         const int wordStart = j;
-        while (j < text.size() && text[j] != ' ') ++j;
+        while (j < text.size() && !text[j].isSpace()) {
+            ++j;
+        }
         const QString wordBody = text.mid(wordStart, j - wordStart);
 
         const bool hasModifier = (plus > 0 || minus > 0);
@@ -92,6 +99,7 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
     for (const SpeedSegment& seg : segs) {
         if (seg.wpm != cmdWpm) {
             emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
+            ++m_pendingWpmEchoes;   // swallow this transient's echo (#3976)
             cmdWpm = seg.wpm;
         }
         QString encoded = seg.text;
@@ -103,8 +111,10 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
             emit transmissionRequested(seg.text, seg.wpm);
     }
     // Restore authoritative WPM if transient changes were made
-    if (cmdWpm != m_speed)
+    if (cmdWpm != m_speed) {
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
+        ++m_pendingWpmEchoes;   // swallow the restore's echo too (#3976)
+    }
 }
 
 void CwxModel::send(const QString& text)
@@ -154,6 +164,7 @@ void CwxModel::clearBuffer()
 {
     // Re-anchor WPM before clearing so ESC can't leave the radio parked at
     // a transient speed that was in-flight from an expandedSend sequence.
+    m_pendingWpmEchoes = 0;   // abort — abandon any pending transient suppression (#3976)
     emit commandReady(QString("cwx wpm %1").arg(m_speed));
     emit commandReady("cwx clear");
     emit transmissionCancelled();
@@ -161,6 +172,7 @@ void CwxModel::clearBuffer()
 
 void CwxModel::setSpeed(int wpm)
 {
+    m_pendingWpmEchoes = 0;   // user set the base — abandon transient suppression (#3976)
     wpm = qBound(5, wpm, 100);
     if (wpm != m_speed) {
         m_speed = wpm;
@@ -221,9 +233,15 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
         } else if (key == "wpm") {
             bool ok;
             int v = val.toInt(&ok);
-            if (ok && v != m_speed) {
-                m_speed = v;
-                emit speedChanged(m_speed);
+            if (ok) {
+                if (m_pendingWpmEchoes > 0) {
+                    // Echo of a transient `cwx wpm` we emitted during an
+                    // expanded send — consume it, don't touch the base. (#3976)
+                    --m_pendingWpmEchoes;
+                } else if (v != m_speed) {
+                    m_speed = v;
+                    emit speedChanged(m_speed);
+                }
             }
         } else if (key == "break_in_delay") {
             bool ok;

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -18,8 +18,9 @@ QVector<CwxModel::SpeedSegment>
 CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
 {
     QVector<SpeedSegment> segs;
-    if (text.isEmpty())
+    if (text.isEmpty()) {
         return segs;
+    }
 
     QString accumText;
     int     accumWpm    = baseWpm;
@@ -43,7 +44,11 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
         int j = i;
         if (prevWasSpace) {
             while (j < text.size() && (text[j] == '+' || text[j] == '-')) {
-                if (text[j] == '+') ++plus; else ++minus;
+                if (text[j] == '+') {
+                    ++plus;
+                } else {
+                    ++minus;
+                }
                 ++j;
             }
             // Treat as modifier only when immediately followed by a word char
@@ -64,12 +69,13 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
         const bool hasModifier = (plus > 0 || minus > 0);
         const int  delta   = (plus - minus) * step;
         const int  wordWpm = hasModifier
-                           ? qBound(5, baseWpm + delta, 100)
+                           ? qBound(kMinWpm, baseWpm + delta, kMaxWpm)
                            : baseWpm;
 
         if (wordWpm != accumWpm) {
-            if (!accumText.isEmpty())
+            if (!accumText.isEmpty()) {
                 segs.append({accumText, accumWpm});
+            }
             accumText.clear();
             accumWpm = wordWpm;
         }
@@ -87,8 +93,9 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
         i = j;
     }
 
-    if (!accumText.isEmpty())
+    if (!accumText.isEmpty()) {
         segs.append({accumText, accumWpm});
+    }
 
     return segs;
 }
@@ -173,7 +180,7 @@ void CwxModel::clearBuffer()
 void CwxModel::setSpeed(int wpm)
 {
     m_pendingWpmEchoes = 0;   // user set the base — abandon transient suppression (#3976)
-    wpm = qBound(5, wpm, 100);
+    wpm = qBound(kMinWpm, wpm, kMaxWpm);
     if (wpm != m_speed) {
         m_speed = wpm;
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
@@ -183,7 +190,7 @@ void CwxModel::setSpeed(int wpm)
 
 void CwxModel::setSpeedStep(int step)
 {
-    step = qBound(1, step, 20);
+    step = qBound(kMinSpeedStep, step, kMaxSpeedStep);
     if (step != m_speedStep) {
         m_speedStep = step;
         emit speedStepChanged(m_speedStep);

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -11,11 +11,22 @@ class CwxModel : public QObject {
 public:
     explicit CwxModel(QObject* parent = nullptr);
 
+    // A contiguous run of text to be keyed at a single WPM.
+    // expandSpeedModifiers() returns a sequence of these.
+    struct SpeedSegment {
+        QString text;  // plain text (modifier prefix stripped, space=' ')
+        int     wpm;
+        bool operator==(const SpeedSegment& o) const {
+            return text == o.text && wpm == o.wpm;
+        }
+    };
+
     // State
-    int   speed()    const { return m_speed; }
-    int   delay()    const { return m_delay; }
-    bool  qskOn()    const { return m_qsk; }
-    bool  isLive()   const { return m_live; }
+    int   speed()     const { return m_speed; }
+    int   delay()     const { return m_delay; }
+    int   speedStep() const { return m_speedStep; }
+    bool  qskOn()     const { return m_qsk; }
+    bool  isLive()    const { return m_live; }
     int   sentIndex() const { return m_sentIndex; }
     QString macro(int idx) const;  // 0-based (0=F1, 11=F12)
 
@@ -28,15 +39,26 @@ public:
     void clearBuffer();
     void setSpeed(int wpm);
     void setDelay(int ms);
+    void setSpeedStep(int step);
     void setQsk(bool on);
     void setLive(bool on);
 
     // Status parsing (from radio)
     void applyStatus(const QMap<QString, QString>& kvs);
 
+    // Parses text for leading +/- speed modifiers on words.
+    // A +/- run at word-start (after space or string-start) immediately
+    // followed by a non-space, non-modifier character counts as a modifier.
+    // Standalone +/- not followed by word chars are prosigns/hyphens and
+    // pass through unchanged.  Speed resets to baseWpm after each modified
+    // word.  Returns a single segment at baseWpm when no modifiers found.
+    static QVector<SpeedSegment> expandSpeedModifiers(
+        const QString& text, int baseWpm, int step);
+
 signals:
     void commandReady(const QString& cmd);
     void speedChanged(int wpm);
+    void speedStepChanged(int step);
     void delayChanged(int ms);
     void qskChanged(bool on);
     void charSent(int index);           // character at index was keyed
@@ -52,8 +74,11 @@ signals:
     void queueEmpty();                   // radio CWX buffer drained — TX teardown required
 
 private:
+    void emitExpandedSend(const QVector<SpeedSegment>& segs);
+
     int     m_speed{20};
     int     m_delay{5};
+    int     m_speedStep{3};
     bool    m_qsk{false};
     bool    m_live{false};
     int     m_sentIndex{-1};

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -79,6 +79,11 @@ private:
     int     m_speed{20};
     int     m_delay{5};
     int     m_speedStep{3};
+    // Count of self-originated transient `cwx wpm` commands whose radio echoes
+    // must be swallowed in applyStatus so they don't clobber the authoritative
+    // base speed or flicker the UI. Reset on user setSpeed / clearBuffer so a
+    // dropped echo can't permanently suppress a real speed update. (#3976)
+    int     m_pendingWpmEchoes{0};
     bool    m_qsk{false};
     bool    m_live{false};
     int     m_sentIndex{-1};

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -11,6 +11,17 @@ class CwxModel : public QObject {
 public:
     explicit CwxModel(QObject* parent = nullptr);
 
+    // Single source of truth for the CWX speed clamps and defaults, shared by
+    // the model's setters, expandSpeedModifiers(), and the CwxPanel spin
+    // ranges so the [5,100] WPM / [1,20] step bounds and their defaults aren't
+    // duplicated as bare literals across files. (#3976 review)
+    static constexpr int kMinWpm         = 5;
+    static constexpr int kMaxWpm         = 100;
+    static constexpr int kDefaultWpm     = 20;
+    static constexpr int kMinSpeedStep   = 1;
+    static constexpr int kMaxSpeedStep   = 20;
+    static constexpr int kDefaultSpeedStep = 3;
+
     // A contiguous run of text to be keyed at a single WPM.
     // expandSpeedModifiers() returns a sequence of these.
     struct SpeedSegment {
@@ -76,9 +87,9 @@ signals:
 private:
     void emitExpandedSend(const QVector<SpeedSegment>& segs);
 
-    int     m_speed{20};
+    int     m_speed{kDefaultWpm};
     int     m_delay{5};
-    int     m_speedStep{3};
+    int     m_speedStep{kDefaultSpeedStep};
     // Count of self-originated transient `cwx wpm` commands whose radio echoes
     // must be swallowed in applyStatus so they don't clobber the authoritative
     // base speed or flicker the UI. Reset on user setSpeed / clearBuffer so a

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -11,6 +11,7 @@
 #include <QPushButton>
 #include <QStringList>
 #include <QTextEdit>
+#include <algorithm>
 #include <cstdio>
 #include <string>
 
@@ -170,6 +171,53 @@ void testSetupTurnsLiveOff()
            !f.model.isLive() && !live->isChecked() && setup->isChecked());
 }
 
+// Resend must re-send the raw (modifier-bearing) text, not the flattened
+// display text, so per-word speed variation survives a Resend. (#272 review)
+void testResendPreservesSpeedModifiers()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    input->setPlainText("+CQ");
+    send->click();
+
+    auto* bubble = f.panel.pendingBubble();
+    const bool haveBubble = bubble != nullptr;
+    report("modifier send creates an in-flight history bubble", haveBubble);
+    if (!haveBubble)
+        return;
+
+    report("bubble retains raw modifier text for Resend",
+           bubble->rawText() == QLatin1String("+CQ"));
+    report("bubble paints modifier-stripped display text",
+           bubble->text() == QLatin1String("CQ"));
+
+    auto emitsWpmChange = [](const QStringList& cmds) {
+        return std::any_of(cmds.begin(), cmds.end(), [](const QString& c) {
+            return c.startsWith(QLatin1String("cwx wpm"));
+        });
+    };
+
+    report("modifier send emits a per-word cwx wpm speed change",
+           emitsWpmChange(f.commands));
+
+    // Re-sending the stripped display text (the pre-fix Resend bug) drops the
+    // speed change — which is exactly why the raw text is kept on the bubble.
+    f.commands.clear();
+    f.model.send(bubble->text());
+    report("resending stripped text loses the speed change",
+           !emitsWpmChange(f.commands));
+
+    // Re-sending the raw text reproduces the speed change, so Resend is faithful.
+    f.commands.clear();
+    f.model.send(bubble->rawText());
+    report("resending raw text preserves the speed change",
+           emitsWpmChange(f.commands));
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -182,6 +230,7 @@ int main(int argc, char** argv)
     testEnterStillSendsWhenLiveOff();
     testSendButtonTurnsLiveOffWithoutDuplicateSend();
     testSetupTurnsLiveOff();
+    testResendPreservesSpeedModifiers();
 
     std::printf("\n%s\n",
                 g_failed == 0

--- a/tests/cwx_speed_modifier_test.cpp
+++ b/tests/cwx_speed_modifier_test.cpp
@@ -1,0 +1,134 @@
+// Unit tests for CwxModel::expandSpeedModifiers — the pure expansion function
+// that parses inline +/- speed modifier prefixes from CW macro / send text.
+// Run: ./build/cwx_speed_modifier_test
+
+#include "models/CwxModel.h"
+#include <QCoreApplication>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+using Segs = QVector<CwxModel::SpeedSegment>;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-64s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+void check(const char* name, const Segs& got, const Segs& want)
+{
+    if (got == want) { report(name, true); return; }
+    std::string d = "got[";
+    for (const auto& s : got)
+        d += "(" + s.text.toStdString() + "@" + std::to_string(s.wpm) + ")";
+    d += "] want[";
+    for (const auto& s : want)
+        d += "(" + s.text.toStdString() + "@" + std::to_string(s.wpm) + ")";
+    d += "]";
+    report(name, false, d);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    std::printf("CWX speed modifier expansion tests\n\n");
+
+    // ── No modifiers ──────────────────────────────────────────────────────
+    check("no modifiers: passthrough as single segment",
+          CwxModel::expandSpeedModifiers("CQ TEST", 20, 3),
+          Segs{{"CQ TEST", 20}});
+
+    check("empty string",
+          CwxModel::expandSpeedModifiers("", 20, 3),
+          Segs{});
+
+    // ── Reporter's exact example ──────────────────────────────────────────
+    check("reporter example: +ur 5nn 5nn -1234NH ++73",
+          CwxModel::expandSpeedModifiers("+ur 5nn 5nn -1234NH ++73", 20, 3),
+          Segs{{"ur", 23}, {" 5nn 5nn ", 20}, {"1234NH", 17}, {" ", 20}, {"73", 26}});
+
+    // ── Single-word modifiers ─────────────────────────────────────────────
+    check("single +word: sends word at base+step",
+          CwxModel::expandSpeedModifiers("+CQ", 20, 3),
+          Segs{{"CQ", 23}});
+
+    check("single -word: sends word at base-step",
+          CwxModel::expandSpeedModifiers("-CQ", 20, 3),
+          Segs{{"CQ", 17}});
+
+    check("double ++word: base + 2*step",
+          CwxModel::expandSpeedModifiers("++CQ", 20, 3),
+          Segs{{"CQ", 26}});
+
+    check("double --word: base - 2*step",
+          CwxModel::expandSpeedModifiers("--CQ", 20, 3),
+          Segs{{"CQ", 14}});
+
+    // ── Speed reset semantics ─────────────────────────────────────────────
+    check("speed resets to base after modified word",
+          CwxModel::expandSpeedModifiers("+CQ de", 20, 3),
+          Segs{{"CQ", 23}, {" de", 20}});
+
+    check("unmodified prefix, then modifier",
+          CwxModel::expandSpeedModifiers("de W1AW +CQ", 20, 3),
+          Segs{{"de W1AW ", 20}, {"CQ", 23}});
+
+    // ── Prosign / hyphen disambiguation ───────────────────────────────────
+    check("standalone + (AR prosign) — not a modifier",
+          CwxModel::expandSpeedModifiers("+", 20, 3),
+          Segs{{"+", 20}});
+
+    check("trailing + (AR prosign) stays in word body",
+          CwxModel::expandSpeedModifiers("73+", 20, 3),
+          Segs{{"73+", 20}});
+
+    check("+ followed by space = prosign, not modifier",
+          CwxModel::expandSpeedModifiers("+ ur", 20, 3),
+          Segs{{"+ ur", 20}});
+
+    check("standalone - (hyphen) — not a modifier",
+          CwxModel::expandSpeedModifiers("-", 20, 3),
+          Segs{{"-", 20}});
+
+    check("mid-word + stays as prosign",
+          CwxModel::expandSpeedModifiers("de+w1aw", 20, 3),
+          Segs{{"de+w1aw", 20}});
+
+    // ── WPM clamping ─────────────────────────────────────────────────────
+    check("wpm floor at 5",
+          CwxModel::expandSpeedModifiers("-word", 5, 3),
+          Segs{{"word", 5}});
+
+    check("wpm ceiling at 100",
+          CwxModel::expandSpeedModifiers("+word", 100, 3),
+          Segs{{"word", 100}});
+
+    check("large step: clamp at 100",
+          CwxModel::expandSpeedModifiers("+word", 95, 10),
+          Segs{{"word", 100}});
+
+    check("large negative step: clamp at 5",
+          CwxModel::expandSpeedModifiers("-word", 10, 10),
+          Segs{{"word", 5}});
+
+    // ── step=1 boundary ───────────────────────────────────────────────────
+    check("step=1 single modifier",
+          CwxModel::expandSpeedModifiers("+CQ", 20, 1),
+          Segs{{"CQ", 21}});
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/cwx_speed_modifier_test.cpp
+++ b/tests/cwx_speed_modifier_test.cpp
@@ -126,6 +126,17 @@ int main(int argc, char** argv)
           CwxModel::expandSpeedModifiers("+CQ", 20, 1),
           Segs{{"CQ", 21}});
 
+    // ── whitespace boundaries (#3976 review): macros come from multi-line
+    // QTextEdit, so \n / \t must act as word boundaries (normalized to a
+    // space), not word chars — otherwise a modifier bleeds across the break
+    // and a raw \n corrupts the cwx send command.
+    check("newline is a word boundary — no modifier bleed, normalized to space",
+          CwxModel::expandSpeedModifiers(QStringLiteral("+CQ CQ\nDE W1AW"), 20, 3),
+          Segs{{"CQ", 23}, {" CQ DE W1AW", 20}});
+    check("tab is a word boundary — modifier after tab is recognized",
+          CwxModel::expandSpeedModifiers(QStringLiteral("A\t+B"), 20, 3),
+          Segs{{"A ", 20}, {"B", 23}});
+
     std::printf("\n%s\n",
                 g_failed == 0
                     ? "All tests passed."


### PR DESCRIPTION
## Summary

Implements issue #272 — inline WPM speed modifiers for CWX macro and manual-send text.

**Syntax** (at word-start only):
| Token | Effect |
|-------|--------|
| `+word` | send *word* at base WPM + step, then reset |
| `-word` | send *word* at base WPM − step, then reset |
| `++word` | base + 2×step |
| `--word` | base − 2×step |

Reporter's exact example: `+ur 5nn 5nn -1234NH ++73`

**Design decisions:**

- `+` at word-start followed by word chars = speed modifier; standalone `+` (followed by space or string-end) = AR prosign — unchanged. Same disambiguation rule for `-` (hyphen prosign unchanged). The prosign legend is updated to document this.
- `sendMacro` now uses the client-side `cwx send` path instead of `cwx macro send N` so modifier prefixes are never forwarded to the radio where `+` would be interpreted as AR. For macros with no modifiers the result is a single `cwx send` block — functionally equivalent.
- `clearBuffer()` (ESC) emits `cwx wpm <base>` before `cwx clear` so the radio cannot be left parked at a transient speed.
- History bubble display text is derived from the expansion (modifiers stripped), keeping the `sent=N` counter in sync with the bubble's character count.
- The **Step** spin (1–20 WPM, default 3) in Setup view persists in AppSettings under `CwxPanel/speedStep`.

**Architecture:**

`CwxModel::expandSpeedModifiers(text, baseWpm, step)` is a pure `static` function returning `QVector<SpeedSegment>`. The model's `emitExpandedSend()` drives `cwx wpm` / `cwx send` sequences from those segments. Both `send()` and `sendMacro()` go through this single path.

**Testing:**

19 unit tests in `tests/cwx_speed_modifier_test.cpp` — all pass:
- Reporter's exact example
- Prosign disambiguation (standalone `+`, trailing `+`, `+ ` before space, mid-word `+`)
- WPM clamping at 5 and 100
- Speed-reset semantics (base WPM restored after each modified word)
- Double modifier (`++`, `--`)
- Empty input, step=1

Existing `cwx_panel_test` suite (14 tests) passes unchanged.

**Known limitation:** FlexRadio's `cwx wpm` is a global engine setting with no per-block WPM in the protocol. AetherSDR emits the full command sequence synchronously, so the WPM-restore command arrives at the radio within one TCP round-trip of the send — well before any human ESC. Concurrent SmartSDR sessions using F-key macro send (`cwx macro send N`) on modifier-containing macros will not expand correctly; that is a cross-client limitation outside AetherSDR's scope.

**Deviation from triage:** The triage agent proposed `+`/`-` but did not flag the `+` = AR prosign collision. This PR resolves it with a word-boundary rule (documented in the legend) rather than a different syntax. The wire protocol handling is otherwise identical to the triage proposal.

## Test plan

- [ ] Build `cwx_speed_modifier_test` and run — should show 19/19 pass
- [ ] Build `cwx_panel_test` — should show 14/14 pass
- [ ] In CWX Setup view, confirm "Step:" spin appears next to QSK button (range 1–20 wpm)
- [ ] Set a macro to `+CQ CQ de W1AW` and press F1 — CQ should key at base+3 WPM, then normal
- [ ] Set a macro to `+ur 5nn 5nn -1234NH ++73` and press F1 — verify speed transitions
- [ ] Type `73+` in the Send box and send — `+` should transmit as AR prosign (no speed change)
- [ ] Press ESC mid-macro — radio WPM should return to base, not stay at transient value
- [ ] Speed step persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)