### PR TITLE
fix(cwx): detect queue drain via reply radio_index instead of broken cwx queue= (#3949)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2505,6 +2505,15 @@ target_include_directories(tnc_terminal_test PRIVATE src)
 target_link_libraries(tnc_terminal_test PRIVATE Qt6::Core)
 add_test(NAME tnc_terminal_test COMMAND tnc_terminal_test)
 
+add_executable(cwx_speed_modifier_test
+    tests/cwx_speed_modifier_test.cpp
+    src/models/CwxModel.cpp
+    src/models/CwxModel.h
+)
+target_include_directories(cwx_speed_modifier_test PRIVATE src)
+target_link_libraries(cwx_speed_modifier_test PRIVATE Qt6::Core)
+add_test(NAME cwx_speed_modifier_test COMMAND cwx_speed_modifier_test)
+
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp
     src/gui/CwxPanel.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2509,10 +2509,30 @@ add_executable(cwx_speed_modifier_test
     tests/cwx_speed_modifier_test.cpp
     src/models/CwxModel.cpp
     src/models/CwxModel.h
+    # CwxModel now logs via lcCw (qCWarning) — pull in the logging category.
+    # LogManager depends on AsyncLogWriter (member) + AppSettings (retention
+    # config), so both come along to satisfy the link. (#3949)
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
 )
 target_include_directories(cwx_speed_modifier_test PRIVATE src)
 target_link_libraries(cwx_speed_modifier_test PRIVATE Qt6::Core)
 add_test(NAME cwx_speed_modifier_test COMMAND cwx_speed_modifier_test)
+
+# Queue-drain watch state machine: epoch guard, live-char arming, and the
+# CwxModel-side invariant the RadioModel flicker-immune release latch relies on. (#3949)
+add_executable(cwx_drain_watch_test
+    tests/cwx_drain_watch_test.cpp
+    src/models/CwxModel.cpp
+    src/models/CwxModel.h
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(cwx_drain_watch_test PRIVATE src)
+target_link_libraries(cwx_drain_watch_test PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME cwx_drain_watch_test COMMAND cwx_drain_watch_test)
 
 add_executable(cwx_panel_test
     tests/cwx_panel_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -143,6 +143,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get dsp`](#get-dsp) | Client-side AetherDSP NR state (NR2…BNR). |
 | | [`get radio \| transmit \| eq \| meters`](#get) | Radio / TX-chain / EQ / meters snapshots. |
 | | [`get slice[s] \| pan[s]`](#get) | Slice & panadapter model snapshots. |
+| | [`get cwx`](#get-cwx) | CWX keyer state + queue-drain watch (#3949). |
 | | [`get panstats`](#get-panstats) | Per-panadapter render-cost counters (profiling). |
 | | [`get clients`](#get-clients) | Radio client roster + foreign-pan-write forensics (#3977). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
@@ -434,6 +435,7 @@ connects).
 | `dsp` | — | client-side AetherDSP noise-reduction state — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
+| `cwx` | — | CWX keyer + queue-drain watch — see [`get cwx`](#get-cwx) |
 | `equalizer` (or `eq`) | — | 8-band RX+TX graphic EQ: `rxEnabled`/`txEnabled` and `rx`/`tx` band maps keyed by label (`63`…`8k`). Validate EQ-applet slider changes. |
 | `meters` | — | `{all:[…]}` — every radio meter with `name`, `value`, `unit`, `low`/`high`, `description`, and **`age_ms`** (staleness): a meter that updates has small `age_ms` and a tracking `value`. |
 | `slices` | — | array of all slice snapshots |
@@ -447,6 +449,39 @@ connects).
 
 Add a trailing **property** name to any single-object form to get just that
 field: `get slice active mode` → `{"value":"LSB"}`.
+
+### `get cwx`
+CWX keyer state, including the **queue-drain watch** that the #3949 fix relies
+on. Firmware never emits `cwx queue=`, so the client detects a drained CWX buffer
+by capturing the `radio_index` from the final `cwx send` reply (the batch-end
+char position) and firing `queueEmpty()` — which releases TX — once the live
+`cwx sent=` counter reaches it. None of that state has a widget, so this is the
+only non-hardware-poll way to assert the mechanism (cf. [`get dsp`](#get-dsp)).
+
+```json
+→ {"cmd":"get","model":"cwx"}
+← {"ok":true,"model":"cwx","cwx":{
+   "active":true,"tracking":true,"cwxEndIndex":14,"sentIndex":6,
+   "speed":25,"speedStep":5,"delay":5,"qsk":false,"live":false}}
+```
+
+| field | meaning |
+|---|---|
+| `active` | `RadioModel::cwxActive` — a `cwx send` batch is in flight (TX keyed for it) |
+| `tracking` | `true` while a queue-drain watch is armed (`cwxEndIndex >= 0`) |
+| `cwxEndIndex` | the batch-end `radio_index` captured from the last `cwx send` reply; the value `sentIndex` must reach to release TX (`-1` = idle) |
+| `sentIndex` | the radio's live `cwx sent=` counter (last char keyed) |
+| `speed` / `speedStep` / `delay` / `qsk` / `live` | keyer settings |
+
+**The drain proof:** on a keyed macro, `cwxEndIndex` jumps to N when the send
+reply arrives, `sentIndex` climbs 0→N as the radio keys each char, and the frame
+it reaches N `tracking` flips back to `false` and `active` clears (queueEmpty →
+`xmit 0`). Watching `cwxEndIndex` and `sentIndex` converge is the direct evidence
+that `radio_index` is the **end** of the batch, not the start — the load-bearing
+assumption of the fix. ESC mid-macro ([`cwx stop`](#cwx) / `clearBuffer`) resets
+`cwxEndIndex` to `-1` so an aborted macro never triggers a spurious release. A
+trailing property narrows it: `get cwx cwxEndIndex` → `{"value":14}`. Fields are
+zero/`-1`/idle until a radio connects.
 
 ### `get panstats`
 Per-panadapter (SpectrumWidget) frame-cost counters — how much GUI-thread time

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -453,10 +453,13 @@ field: `get slice active mode` → `{"value":"LSB"}`.
 ### `get cwx`
 CWX keyer state, including the **queue-drain watch** that the #3949 fix relies
 on. Firmware never emits `cwx queue=`, so the client detects a drained CWX buffer
-by capturing the `radio_index` from the final `cwx send` reply (the batch-end
-char position) and firing `queueEmpty()` — which releases TX — once the live
-`cwx sent=` counter reaches it. None of that state has a widget, so this is the
-only non-hardware-poll way to assert the mechanism (cf. [`get dsp`](#get-dsp)).
+by capturing the `radio_index` from the final `cwx send` reply and firing
+`queueEmpty()` — which releases TX — once the live `cwx sent=` counter reaches the
+batch end. `radio_index` is the batch's **first-char** queue position (verified on
+FLEX-6500 fw 4.2.20.41343 — a 23-char send at `sent=48` replied `radio_index=49`
+and `sent=` then climbed to 71), so `cwxEndIndex` is stored as
+`radio_index + nChars - 1`. None of that state has a widget, so this is the only
+non-hardware-poll way to assert the mechanism (cf. [`get dsp`](#get-dsp)).
 
 ```json
 → {"cmd":"get","model":"cwx"}
@@ -469,16 +472,17 @@ only non-hardware-poll way to assert the mechanism (cf. [`get dsp`](#get-dsp)).
 |---|---|
 | `active` | `RadioModel::cwxActive` — a `cwx send` batch is in flight (TX keyed for it) |
 | `tracking` | `true` while a queue-drain watch is armed (`cwxEndIndex >= 0`) |
-| `cwxEndIndex` | the batch-end `radio_index` captured from the last `cwx send` reply; the value `sentIndex` must reach to release TX (`-1` = idle) |
+| `cwxEndIndex` | the batch-end index = `radio_index + nChars - 1`, the value `sentIndex` must reach to release TX (`-1` = idle) |
 | `sentIndex` | the radio's live `cwx sent=` counter (last char keyed) |
 | `speed` / `speedStep` / `delay` / `qsk` / `live` | keyer settings |
 
-**The drain proof:** on a keyed macro, `cwxEndIndex` jumps to N when the send
-reply arrives, `sentIndex` climbs 0→N as the radio keys each char, and the frame
-it reaches N `tracking` flips back to `false` and `active` clears (queueEmpty →
-`xmit 0`). Watching `cwxEndIndex` and `sentIndex` converge is the direct evidence
-that `radio_index` is the **end** of the batch, not the start — the load-bearing
-assumption of the fix. ESC mid-macro ([`cwx stop`](#cwx) / `clearBuffer`) resets
+**The drain proof:** on a keyed macro, `cwxEndIndex` jumps to the batch-end N when
+the send reply arrives, `sentIndex` climbs to N as the radio keys each char, and
+the frame it reaches N `tracking` flips back to `false` and `active` clears
+(queueEmpty → `xmit 0`). Watching `cwxEndIndex` hold while `sentIndex` climbs to
+meet it — over the full keying duration, not after one char — is the direct
+evidence the batch-end index is right (radio_index is the batch **start**, so the
+end is `radio_index + nChars - 1`). ESC mid-macro ([`cwx stop`](#cwx) / `clearBuffer`) resets
 `cwxEndIndex` to `-1` so an aborted macro never triggers a spurious release. A
 trailing property narrows it: `get cwx cwxEndIndex` → `{"value":14}`. Fields are
 zero/`-1`/idle until a radio connects.

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1340,6 +1340,27 @@ QJsonObject transmitSnapshot(const TransmitModel* t)
     };
 }
 
+// CWX keyer snapshot — the queue-drain watch that the #3949 fix rests on.
+// `cwxEndIndex` is the radio_index of the last char in the batch we're waiting
+// to drain (-1 = not tracking); `sentIndex` is the radio's live `cwx sent=`
+// counter. When sentIndex reaches cwxEndIndex, queueEmpty() fires and TX is
+// released. There is no widget exposing this state, so this is the only
+// non-hardware-poll way to assert the fix (cf. `get dsp`).
+QJsonObject cwxSnapshot(const CwxModel* c, bool active)
+{
+    return QJsonObject{
+        {QStringLiteral("active"),      active},           // TX in flight (RadioModel::cwxActive)
+        {QStringLiteral("tracking"),    c->cwxEndIndex() >= 0},
+        {QStringLiteral("cwxEndIndex"), c->cwxEndIndex()}, // batch-end radio_index being watched
+        {QStringLiteral("sentIndex"),   c->sentIndex()},   // live `cwx sent=` counter
+        {QStringLiteral("speed"),       c->speed()},
+        {QStringLiteral("speedStep"),   c->speedStep()},
+        {QStringLiteral("delay"),       c->delay()},
+        {QStringLiteral("qsk"),         c->qskOn()},
+        {QStringLiteral("live"),        c->isLive()},
+    };
+}
+
 QJsonObject audioSnapshot(const AudioEngine* audio)
 {
     return QJsonObject{
@@ -3123,6 +3144,8 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = radioSnapshot(radio);
     } else if (model == QLatin1String("transmit")) {
         data = transmitSnapshot(&radio->transmitModel());
+    } else if (model == QLatin1String("cwx")) {
+        data = cwxSnapshot(&radio->cwxModel(), radio->cwxActive());
     } else if (model == QLatin1String("equalizer") || model == QLatin1String("eq")) {
         data = equalizerSnapshot(&radio->equalizerModel());
     } else if (model == QLatin1String("meters")) {
@@ -3163,7 +3186,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p, radio->ourClientHandle());
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|equalizer|meters|slice|slices|pan|pans|panstats|clients|kiwi|wavestats)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|panstats|clients|kiwi|wavestats)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -371,10 +371,14 @@ void CwxPanel::setModel(CwxModel* model)
             m_speedStepSpin->setValue(step);
         }
     });
-    // Sync step spin to model's current value (model may be set after construction)
+    // The persisted speed step was loaded into the spin (readSpeedStep) in
+    // buildSetupView, before the model was attached — so the spin, not the
+    // model's default, holds the saved value. Push it INTO the model so the
+    // persisted step drives +/- expansion. The old direction (model → spin)
+    // overwrote the spin with the model default and discarded the saved value
+    // on every launch. (#3949 review)
     if (m_speedStepSpin && m_model->speedStep() != m_speedStepSpin->value()) {
-        QSignalBlocker b(m_speedStepSpin);
-        m_speedStepSpin->setValue(m_model->speedStep());
+        m_model->setSpeedStep(m_speedStepSpin->value());
     }
     connect(m_model, &CwxModel::qskChanged, this, [this](bool on) {
         if (m_qskBtn) {
@@ -452,6 +456,7 @@ void CwxPanel::buildSetupView()
 
     topRow->addWidget(new QLabel("Step:"));
     m_speedStepSpin = new QSpinBox;
+    m_speedStepSpin->setObjectName("cwxSpeedStepSpin");  // addressable via automation bridge
     m_speedStepSpin->setRange(1, 20);
     m_speedStepSpin->setValue(readSpeedStep());
     m_speedStepSpin->setSuffix(" wpm");

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -1,26 +1,77 @@
 #include "CwxPanel.h"
+#include "core/AppSettings.h"
 #include "core/TxKeyingMarker.h"
 #include "models/CwxModel.h"
 
-#include <QVBoxLayout>
+#include <QContextMenuEvent>
+#include <QDateTime>
 #include <QHBoxLayout>
-#include <QPushButton>
-#include <QTextEdit>
-#include <QSpinBox>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
-#include <QStackedWidget>
-#include <QScrollArea>
-#include <QDateTime>
-#include <QKeyEvent>
-#include <QPainter>
-#include <QScrollBar>
-#include <QContextMenuEvent>
 #include <QMenu>
+#include <QPainter>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QSignalBlocker>
+#include <QSpinBox>
+#include <QStackedWidget>
+#include <QTextEdit>
 #include <QTimer>
+#include <QVBoxLayout>
 #include "core/ThemeManager.h"
+
+namespace {
+
+constexpr const char* kCwxPanelSettingsKey = "CwxPanel";
+constexpr const char* kSpeedStepField = "speedStep";
+
+QJsonObject readCwxPanelSettings()
+{
+    const QString json = AetherSDR::AppSettings::instance()
+        .value(kCwxPanelSettingsKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+void writeCwxPanelSettings(const QJsonObject& obj)
+{
+    auto& s = AetherSDR::AppSettings::instance();
+    s.setValue(kCwxPanelSettingsKey,
+        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+int readSpeedStep()
+{
+    return qBound(1, readCwxPanelSettings().value(kSpeedStepField).toInt(3), 20);
+}
+
+void writeSpeedStep(int step)
+{
+    QJsonObject obj = readCwxPanelSettings();
+    obj[kSpeedStepField] = step;
+    writeCwxPanelSettings(obj);
+}
+
+// Returns bubble-display text for a CW transmission: the text actually keyed
+// (speed modifier prefixes stripped, joined from expansion segments).
+QString bubbleTextFor(const QString& rawText, int baseWpm, int step)
+{
+    const auto segs = AetherSDR::CwxModel::expandSpeedModifiers(rawText, baseWpm, step);
+    QString result;
+    for (const auto& s : segs)
+        result += s.text;
+    return result.isEmpty() ? rawText : result;
+}
+
+} // namespace
 
 namespace AetherSDR {
 
@@ -256,7 +307,9 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
             // Log the macro text to the history feed BEFORE firing the
             // command so the snapshot of m_model->sentIndex() lines up
             // with the chars about to be keyed for this bubble. (#3146)
-            appendHistoryBubble(m_model->macro(i));
+            const QString raw = m_model->macro(i);
+            appendHistoryBubble(
+                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
             m_model->sendMacro(i + 1);
         });
     }
@@ -312,6 +365,17 @@ void CwxPanel::setModel(CwxModel* model)
             m_delaySpin->setValue(ms);
         }
     });
+    connect(m_model, &CwxModel::speedStepChanged, this, [this](int step) {
+        if (m_speedStepSpin) {
+            QSignalBlocker b(m_speedStepSpin);
+            m_speedStepSpin->setValue(step);
+        }
+    });
+    // Sync step spin to model's current value (model may be set after construction)
+    if (m_speedStepSpin && m_model->speedStep() != m_speedStepSpin->value()) {
+        QSignalBlocker b(m_speedStepSpin);
+        m_speedStepSpin->setValue(m_model->speedStep());
+    }
     connect(m_model, &CwxModel::qskChanged, this, [this](bool on) {
         if (m_qskBtn) {
             QSignalBlocker b(m_qskBtn);
@@ -370,13 +434,13 @@ void CwxPanel::buildSetupView()
     vbox->setContentsMargins(4, 4, 4, 4);
     vbox->setSpacing(4);
 
-    // Delay + QSK
+    // Delay + QSK + Speed Step
     auto* topRow = new QHBoxLayout;
     topRow->addWidget(new QLabel("Delay:"));
     m_delaySpin = new QSpinBox;
     m_delaySpin->setRange(0, 2000);
     m_delaySpin->setValue(5);
-    m_delaySpin->setFixedWidth(60);
+    m_delaySpin->setFixedWidth(52);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_delaySpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
         "border-radius: 2px; font-size: 11px; }");
     topRow->addWidget(m_delaySpin);
@@ -385,6 +449,17 @@ void CwxPanel::buildSetupView()
     m_qskBtn->setCheckable(true);
     m_qskBtn->setStyleSheet(kBtnStyle);
     topRow->addWidget(m_qskBtn);
+
+    topRow->addWidget(new QLabel("Step:"));
+    m_speedStepSpin = new QSpinBox;
+    m_speedStepSpin->setRange(1, 20);
+    m_speedStepSpin->setValue(readSpeedStep());
+    m_speedStepSpin->setSuffix(" wpm");
+    m_speedStepSpin->setFixedWidth(60);
+    m_speedStepSpin->setToolTip("WPM delta applied by each + or - speed modifier prefix");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_speedStepSpin, "QSpinBox { background: {{color.background.1}}; color: {{color.text.primary}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 2px; font-size: 11px; }");
+    topRow->addWidget(m_speedStepSpin);
     topRow->addStretch(1);
     vbox->addLayout(topRow);
 
@@ -392,6 +467,11 @@ void CwxPanel::buildSetupView()
             this, [this](int v) { if (m_model) m_model->setDelay(v); });
     connect(m_qskBtn, &QPushButton::toggled,
             this, [this](bool on) { if (m_model) m_model->setQsk(on); });
+    connect(m_speedStepSpin, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, [this](int v) {
+                if (m_model) m_model->setSpeedStep(v);
+                writeSpeedStep(v);
+            });
 
     // Style labels
     for (auto* lbl : m_setupPage->findChildren<QLabel*>())
@@ -427,7 +507,9 @@ void CwxPanel::buildSetupView()
         // Click F-key label → log macro text to history, then send. (#3146)
         connect(label, &QPushButton::clicked, this, [this, i]() {
             if (!m_model) return;
-            appendHistoryBubble(m_model->macro(i));
+            const QString raw = m_model->macro(i);
+            appendHistoryBubble(
+                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
             m_model->sendMacro(i + 1);
         });
 
@@ -440,8 +522,11 @@ void CwxPanel::buildSetupView()
 
     vbox->addWidget(macroWidget, 1);
 
-    // Prosign legend
-    auto* legend = new QLabel("Prosigns: = (BT)  + (AR)  ( (KN)  & (BK)  $ (SK)");
+    // Prosign + speed-modifier legend
+    auto* legend = new QLabel(
+        "Prosigns: = (BT)  + (AR)  ( (KN)  & (BK)  $ (SK)\n"
+        "Speed: +word (faster)  -word (slower)  ++/-- (2\xc3\x97 step)\n"
+        "  + or - at word-start only; standalone + remains AR");
     AetherSDR::ThemeManager::instance().applyStyleSheet(legend, "QLabel { color: {{color.text.label}}; font-size: 9px; padding: 4px; }");
     legend->setWordWrap(true);
     vbox->addWidget(legend);
@@ -464,7 +549,10 @@ void CwxPanel::sendBuffer()
     QString text = m_textEdit->toPlainText().trimmed();
     if (text.isEmpty()) return;
 
-    appendHistoryBubble(text);
+    // Show keyed text (modifiers stripped) so the bubble's char count
+    // matches what the radio's sent=N counter advances against. (#272)
+    appendHistoryBubble(
+        bubbleTextFor(text, m_model->speed(), m_model->speedStep()));
     m_textEdit->clear();
 
     m_model->send(text);

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -123,6 +123,7 @@ private:
     QWidget*        m_setupPage{nullptr};
     QTextEdit*      m_macroEdits[12]{};
     QSpinBox*       m_delaySpin{nullptr};
+    QSpinBox*       m_speedStepSpin{nullptr};
     QPushButton*    m_qskBtn{nullptr};
 
     // Bottom bar

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -14,14 +14,103 @@ QString CwxModel::macro(int idx) const
     return m_macros[idx];
 }
 
+QVector<CwxModel::SpeedSegment>
+CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
+{
+    QVector<SpeedSegment> segs;
+    if (text.isEmpty())
+        return segs;
+
+    QString accumText;
+    int     accumWpm    = baseWpm;
+    bool    prevWasSpace = true;  // string start acts like after-space
+
+    for (int i = 0; i < text.size(); ) {
+        if (text[i] == ' ') {
+            accumText += ' ';
+            prevWasSpace = true;
+            ++i;
+            continue;
+        }
+
+        // Count +/- modifier prefix — only valid at a word boundary
+        int plus = 0, minus = 0;
+        int j = i;
+        if (prevWasSpace) {
+            while (j < text.size() && (text[j] == '+' || text[j] == '-')) {
+                if (text[j] == '+') ++plus; else ++minus;
+                ++j;
+            }
+            // Treat as modifier only when immediately followed by a word char
+            // (non-space, non-modifier).  Standalone +/- are prosigns/hyphens.
+            if (j >= text.size() || text[j] == ' ') {
+                plus = minus = 0;
+                j = i;
+            }
+        }
+
+        // Scan word body to end-of-word
+        const int wordStart = j;
+        while (j < text.size() && text[j] != ' ') ++j;
+        const QString wordBody = text.mid(wordStart, j - wordStart);
+
+        const bool hasModifier = (plus > 0 || minus > 0);
+        const int  delta   = (plus - minus) * step;
+        const int  wordWpm = hasModifier
+                           ? qBound(5, baseWpm + delta, 100)
+                           : baseWpm;
+
+        if (wordWpm != accumWpm) {
+            if (!accumText.isEmpty())
+                segs.append({accumText, accumWpm});
+            accumText.clear();
+            accumWpm = wordWpm;
+        }
+
+        accumText   += wordBody;
+        prevWasSpace = false;
+
+        if (hasModifier) {
+            // Speed resets to base after each modifier word
+            segs.append({accumText, accumWpm});
+            accumText.clear();
+            accumWpm = baseWpm;
+        }
+
+        i = j;
+    }
+
+    if (!accumText.isEmpty())
+        segs.append({accumText, accumWpm});
+
+    return segs;
+}
+
+void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
+{
+    int cmdWpm = m_speed;
+    for (const SpeedSegment& seg : segs) {
+        if (seg.wpm != cmdWpm) {
+            emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
+            cmdWpm = seg.wpm;
+        }
+        QString encoded = seg.text;
+        encoded.replace(' ', QChar(0x7f));
+        if (!encoded.isEmpty())
+            emit commandReady(
+                QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
+        if (!seg.text.isEmpty())
+            emit transmissionRequested(seg.text, seg.wpm);
+    }
+    // Restore authoritative WPM if transient changes were made
+    if (cmdWpm != m_speed)
+        emit commandReady(QString("cwx wpm %1").arg(m_speed));
+}
+
 void CwxModel::send(const QString& text)
 {
     if (text.isEmpty()) return;
-    // Encode spaces as DEL (0x7f) per FlexLib protocol
-    QString encoded = text;
-    encoded.replace(' ', QChar(0x7f));
-    emit commandReady(QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
-    emit transmissionRequested(text, m_speed);
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
 }
 
 void CwxModel::sendChar(const QString& ch)
@@ -36,12 +125,14 @@ void CwxModel::sendChar(const QString& ch)
 void CwxModel::sendMacro(int idx)
 {
     if (idx < 1 || idx > 12) return;
-    emit commandReady(QString("cwx macro send %1").arg(idx));
-    // Macro text lives in m_macros (0-based); fire local keyer with it
-    // so sidetone matches the radio's expansion.
     const QString text = m_macros[idx - 1];
-    if (!text.isEmpty())
-        emit transmissionRequested(text, m_speed);
+    if (text.isEmpty()) return;
+    // Expand speed modifiers client-side via cwx send blocks rather than
+    // cwx macro send N.  When no modifiers are present the result is a
+    // single cwx send identical in effect to the radio-side expansion, but
+    // the unified path ensures + / - prefixes are never forwarded to the
+    // radio where they would be misread as prosigns (AR / hyphen).
+    emitExpandedSend(expandSpeedModifiers(text, m_speed, m_speedStep));
 }
 
 void CwxModel::saveMacro(int idx, const QString& text)
@@ -61,6 +152,9 @@ void CwxModel::erase(int numChars)
 
 void CwxModel::clearBuffer()
 {
+    // Re-anchor WPM before clearing so ESC can't leave the radio parked at
+    // a transient speed that was in-flight from an expandedSend sequence.
+    emit commandReady(QString("cwx wpm %1").arg(m_speed));
     emit commandReady("cwx clear");
     emit transmissionCancelled();
 }
@@ -72,6 +166,15 @@ void CwxModel::setSpeed(int wpm)
         m_speed = wpm;
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
         emit speedChanged(m_speed);
+    }
+}
+
+void CwxModel::setSpeedStep(int step)
+{
+    step = qBound(1, step, 20);
+    if (step != m_speedStep) {
+        m_speedStep = step;
+        emit speedStepChanged(m_speedStep);
     }
 }
 

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -110,7 +110,10 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
             const QString cmd =
                 QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++);
             if (i == lastNonEmpty)
-                emit replyCommandReady(cmd, m_drainEpoch);
+                // Segments queue contiguously, so the last segment's start
+                // (radio_index) + its length - 1 is the last char of the whole
+                // message — the correct batch-end index to watch. (#3949)
+                emit replyCommandReady(cmd, m_drainEpoch, seg.text.length());
             else
                 emit commandReady(cmd);
         }
@@ -139,7 +142,7 @@ void CwxModel::sendChar(const QString& ch)
     // and chars typed after a macro would be truncated by a stale watch. (#3949)
     emit replyCommandReady(
         QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++),
-        m_drainEpoch);
+        m_drainEpoch, ch.length());
     emit transmissionRequested(ch, m_speed);
 }
 
@@ -197,7 +200,7 @@ void CwxModel::resetDrainWatch()
     m_cwxEndIndex = -1;
 }
 
-void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch)
+void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, int nChars)
 {
     // Stale-reply guard: a reply for a batch that was aborted (ESC/clear/
     // disconnect) after the command was sent carries the pre-abort epoch and
@@ -211,8 +214,6 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch)
         return;
     }
     // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83.
-    // radio_index is the absolute char-queue position of the last char in
-    // this batch; queueEmpty() fires when cwx sent= reaches that value.
     const QString indexStr = body.split(',').first().trimmed();
     bool ok = false;
     const int radioIndex = indexStr.toInt(&ok);
@@ -220,14 +221,22 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch)
         qCWarning(lcCw) << "CwxModel: failed to parse radio_index from reply body:" << body;
         return;
     }
+    // radio_index is the FIRST-char (insertion-start) queue position of this
+    // batch, so the last char — the value cwx sent= must reach to release TX —
+    // is radio_index + nChars - 1. Verified on FLEX-6500 fw 4.2.20.41343 (see
+    // handleSendReply() doc in the header). nChars is always >= 1 for a real
+    // send; guard defensively so an empty batch can't retract the index. (#3949)
+    if (nChars < 1)
+        return;
+    const int endIndex = radioIndex + nChars - 1;
     // Only ever advance the watch, never retract it. cwx send replies on the
     // single command socket are normally ordered, but if two back-to-back
-    // macros' replies arrive out of order, a smaller radio_index must not
+    // macros' replies arrive out of order, a smaller end index must not
     // overwrite a larger one — that would release TX while the later batch
     // still has chars queued. m_cwxEndIndex is -1 while idle, so the first
     // reply of a batch always takes. (#3949)
-    if (radioIndex > m_cwxEndIndex) {
-        m_cwxEndIndex = radioIndex;
+    if (endIndex > m_cwxEndIndex) {
+        m_cwxEndIndex = endIndex;
     }
 }
 

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -1,4 +1,5 @@
 #include "CwxModel.h"
+#include "core/LogManager.h"
 #include <QDebug>
 #include <QMap>
 
@@ -109,7 +110,7 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
             const QString cmd =
                 QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++);
             if (i == lastNonEmpty)
-                emit replyCommandReady(cmd);
+                emit replyCommandReady(cmd, m_drainEpoch);
             else
                 emit commandReady(cmd);
         }
@@ -132,7 +133,13 @@ void CwxModel::sendChar(const QString& ch)
     if (ch.isEmpty()) return;
     QString encoded = ch;
     encoded.replace(' ', QChar(0x7f));
-    emit commandReady(QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
+    // Live-mode chars go via the reply path (not fire-and-forget commandReady)
+    // so each char's radio_index advances the drain watch. Without this a
+    // live-typing-only session arms no watch and the ~60 s stuck-TX survives,
+    // and chars typed after a macro would be truncated by a stale watch. (#3949)
+    emit replyCommandReady(
+        QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++),
+        m_drainEpoch);
     emit transmissionRequested(ch, m_speed);
 }
 
@@ -160,13 +167,19 @@ void CwxModel::saveMacro(int idx, const QString& text)
 
 void CwxModel::erase(int numChars)
 {
+    // KNOWN GAP (needs hardware / #3949 item 4): erase removes queued chars, so
+    // an armed drain watch at m_cwxEndIndex may point past the new tail — sent=
+    // could then never reach it and TX would stick for the full interlock
+    // timeout. The correct adjustment depends on the radio's post-erase sent=
+    // semantics, which aren't yet confirmed on the 8600. Left unchanged (bare
+    // commandReady) pending that observation rather than guessing an offset.
     emit commandReady(QString("cwx erase %1").arg(numChars));
     emit transmissionCancelled();
 }
 
 void CwxModel::clearBuffer()
 {
-    m_cwxEndIndex = -1;   // abort any pending queue-drain watch (#3949)
+    resetDrainWatch();    // abort pending watch + bump epoch (#3949)
     // Re-anchor WPM before clearing so ESC can't leave the radio parked at
     // a transient speed that was in-flight from an expandedSend sequence.
     emit commandReady(QString("cwx wpm %1").arg(m_speed));
@@ -174,10 +187,27 @@ void CwxModel::clearBuffer()
     emit transmissionCancelled();
 }
 
-void CwxModel::handleSendReply(int resultCode, const QString& body)
+void CwxModel::resetDrainWatch()
 {
+    // Bumping the epoch invalidates any in-flight cwx-send reply so it can't
+    // re-arm the watch for a batch the radio has discarded. Clearing the end
+    // index also releases the monotonic guard in handleSendReply(), so a fresh
+    // session after reconnect can arm at a smaller radio_index. (#3949)
+    ++m_drainEpoch;
+    m_cwxEndIndex = -1;
+}
+
+void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch)
+{
+    // Stale-reply guard: a reply for a batch that was aborted (ESC/clear/
+    // disconnect) after the command was sent carries the pre-abort epoch and
+    // must not re-arm the watch. Without this, a late reply arriving after ESC
+    // — easy over SmartLink latency — would arm at an index the radio already
+    // discarded, causing a spurious mid-message xmit 0 later. (#3949)
+    if (epoch != m_drainEpoch)
+        return;
     if (resultCode != 0) {
-        qWarning() << "CwxModel: cwx send failed, result=" << resultCode;
+        qCWarning(lcCw) << "CwxModel: cwx send failed, result=" << resultCode;
         return;
     }
     // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83.
@@ -187,7 +217,7 @@ void CwxModel::handleSendReply(int resultCode, const QString& body)
     bool ok = false;
     const int radioIndex = indexStr.toInt(&ok);
     if (!ok || radioIndex < 0) {
-        qWarning() << "CwxModel: failed to parse radio_index from reply body:" << body;
+        qCWarning(lcCw) << "CwxModel: failed to parse radio_index from reply body:" << body;
         return;
     }
     // Only ever advance the watch, never retract it. cwx send replies on the

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -5,6 +5,13 @@
 
 namespace AetherSDR {
 
+namespace {
+// CWX keyer speed is clamped to the FlexLib-supported 5–100 wpm range at every
+// entry point (user setSpeed and +/- modifier expansion) — one definition so
+// the two clamp sites can't drift. (#3949 review)
+inline int clampWpm(int wpm) { return qBound(5, wpm, 100); }
+}
+
 CwxModel::CwxModel(QObject* parent)
     : QObject(parent)
 {}
@@ -58,7 +65,7 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
         const bool hasModifier = (plus > 0 || minus > 0);
         const int  delta   = (plus - minus) * step;
         const int  wordWpm = hasModifier
-                           ? qBound(5, baseWpm + delta, 100)
+                           ? clampWpm(baseWpm + delta)
                            : baseWpm;
 
         if (wordWpm != accumWpm) {
@@ -150,7 +157,18 @@ void CwxModel::sendMacro(int idx)
 {
     if (idx < 1 || idx > 12) return;
     const QString text = m_macros[idx - 1];
-    if (text.isEmpty()) return;
+    if (text.isEmpty()) {
+        // Local copy not yet synced (the macroN= status is still pending in the
+        // first seconds after connect) — fall back to radio-side expansion so an
+        // early F-key press still transmits instead of silently keying nothing.
+        // The radio is authoritative for stored macros (Principle II).
+        // Caveat: this fire-and-forget path can't arm the reply-driven drain
+        // watch (no client-side char count), so a macro keyed before sync
+        // completes relies on the radio's own break-in for TX release. It's a
+        // narrow first-few-seconds window; keying something beats keying nothing.
+        emit commandReady(QString("cwx macro send %1").arg(idx));
+        return;
+    }
     // Expand speed modifiers client-side via cwx send blocks rather than
     // cwx macro send N.  When no modifiers are present the result is a
     // single cwx send identical in effect to the radio-side expansion, but
@@ -162,8 +180,19 @@ void CwxModel::sendMacro(int idx)
 void CwxModel::saveMacro(int idx, const QString& text)
 {
     if (idx < 0 || idx >= 12) return;
-    m_macros[idx] = text;
-    QString encoded = text;
+    m_macros[idx] = text;   // keep the raw +/- text for our own client-side expansion
+    // Strip the client-only +/- speed-modifier prefixes before writing to the
+    // radio's shared macro store. The +/- syntax is an AetherSDR extension; a
+    // Multi-Flex peer (SmartSDR/Maestro) that plays this stored slot would key a
+    // leading '+' as the AR prosign (CWX.cs HandleSpecialStrings maps " + " ↔
+    // " AR "). Store the plain keyed text so shared slots stay portable.
+    // (Principle VII: sanitise at the boundary where the bytes leave.) The strip
+    // reuses expandSpeedModifiers — its segment text has the modifier prefixes
+    // already removed; joining the segments reconstructs the plain message.
+    QString plain;
+    for (const auto& seg : expandSpeedModifiers(text, m_speed, m_speedStep))
+        plain += seg.text;
+    QString encoded = plain;
     encoded.replace(' ', QChar(0x7f));
     emit commandReady(QString("cwx macro save %1 \"%2\"").arg(idx + 1).arg(encoded));
 }
@@ -242,7 +271,7 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, i
 
 void CwxModel::setSpeed(int wpm)
 {
-    wpm = qBound(5, wpm, 100);
+    wpm = clampWpm(wpm);
     if (wpm != m_speed) {
         m_speed = wpm;
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
@@ -335,8 +364,11 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
                 if (ok1 && ok2) emit erased(start, stop);
             }
         } else if (key == "queue") {
-            // Empty queue= means the radio's CWX buffer has drained.
-            // Signal RadioModel to release MOX (required when sync_cwx=1).
+            // Legacy path: an empty queue= would mean the radio's CWX buffer has
+            // drained. Firmware doesn't actually emit this (confirmed on FLEX-6500
+            // fw 4.2.20.41343 — the reply-radio_index watch exists precisely
+            // because queue= never arrives), so this is a belt-and-suspenders
+            // fallback should a future firmware start sending it. (#3949)
             if (val.isEmpty() || val == "0")
                 emit queueEmpty();
         } else if (key.startsWith("macro") && key.length() > 5) {

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -88,17 +88,31 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
 
 void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
 {
+    // Find last segment with non-empty text — that block's cwx send goes via
+    // replyCommandReady so RadioModel can capture the radio_index and detect
+    // queue drain via sent= status instead of the broken queue= path. (#3949)
+    int lastNonEmpty = -1;
+    for (int i = segs.size() - 1; i >= 0; --i) {
+        if (!segs[i].text.isEmpty()) { lastNonEmpty = i; break; }
+    }
+
     int cmdWpm = m_speed;
-    for (const SpeedSegment& seg : segs) {
+    for (int i = 0; i < segs.size(); ++i) {
+        const SpeedSegment& seg = segs[i];
         if (seg.wpm != cmdWpm) {
             emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
             cmdWpm = seg.wpm;
         }
         QString encoded = seg.text;
         encoded.replace(' ', QChar(0x7f));
-        if (!encoded.isEmpty())
-            emit commandReady(
-                QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++));
+        if (!encoded.isEmpty()) {
+            const QString cmd =
+                QString("cwx send \"%1\" %2").arg(encoded).arg(m_nextBlock++);
+            if (i == lastNonEmpty)
+                emit replyCommandReady(cmd);
+            else
+                emit commandReady(cmd);
+        }
         if (!seg.text.isEmpty())
             emit transmissionRequested(seg.text, seg.wpm);
     }
@@ -152,11 +166,31 @@ void CwxModel::erase(int numChars)
 
 void CwxModel::clearBuffer()
 {
+    m_cwxEndIndex = -1;   // abort any pending queue-drain watch (#3949)
     // Re-anchor WPM before clearing so ESC can't leave the radio parked at
     // a transient speed that was in-flight from an expandedSend sequence.
     emit commandReady(QString("cwx wpm %1").arg(m_speed));
     emit commandReady("cwx clear");
     emit transmissionCancelled();
+}
+
+void CwxModel::handleSendReply(int resultCode, const QString& body)
+{
+    if (resultCode != 0) {
+        qWarning() << "CwxModel: cwx send failed, result=" << resultCode;
+        return;
+    }
+    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83.
+    // radio_index is the absolute char-queue position of the last char in
+    // this batch; queueEmpty() fires when cwx sent= reaches that value.
+    const QString indexStr = body.split(',').first().trimmed();
+    bool ok = false;
+    const int radioIndex = indexStr.toInt(&ok);
+    if (!ok || radioIndex < 0) {
+        qWarning() << "CwxModel: failed to parse radio_index from reply body:" << body;
+        return;
+    }
+    m_cwxEndIndex = radioIndex;
 }
 
 void CwxModel::setSpeed(int wpm)
@@ -217,6 +251,13 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
             if (ok) {
                 m_sentIndex = idx;
                 emit charSent(idx);
+                // Queue drain detection: radio_index captured from cwx send
+                // reply tells us the last char position of the queued batch.
+                // Fire queueEmpty() so RadioModel can release MOX. (#3949)
+                if (m_cwxEndIndex >= 0 && idx >= m_cwxEndIndex) {
+                    m_cwxEndIndex = -1;
+                    emit queueEmpty();
+                }
             }
         } else if (key == "wpm") {
             bool ok;

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -368,7 +368,9 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
             // drained. Firmware doesn't actually emit this (confirmed on FLEX-6500
             // fw 4.2.20.41343 — the reply-radio_index watch exists precisely
             // because queue= never arrives), so this is a belt-and-suspenders
-            // fallback should a future firmware start sending it. (#3949)
+            // fallback should a future firmware start sending it. If it does, the
+            // reply-radio_index machinery can be retired in favour of this path —
+            // tracked in #4028 (protocol/upstream). (#3949)
             if (val.isEmpty() || val == "0")
                 emit queueEmpty();
         } else if (key.startsWith("macro") && key.length() > 5) {

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -190,7 +190,15 @@ void CwxModel::handleSendReply(int resultCode, const QString& body)
         qWarning() << "CwxModel: failed to parse radio_index from reply body:" << body;
         return;
     }
-    m_cwxEndIndex = radioIndex;
+    // Only ever advance the watch, never retract it. cwx send replies on the
+    // single command socket are normally ordered, but if two back-to-back
+    // macros' replies arrive out of order, a smaller radio_index must not
+    // overwrite a larger one — that would release TX while the later batch
+    // still has chars queued. m_cwxEndIndex is -1 while idle, so the first
+    // reply of a batch always takes. (#3949)
+    if (radioIndex > m_cwxEndIndex) {
+        m_cwxEndIndex = radioIndex;
+    }
 }
 
 void CwxModel::setSpeed(int wpm)

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -11,11 +11,22 @@ class CwxModel : public QObject {
 public:
     explicit CwxModel(QObject* parent = nullptr);
 
+    // A contiguous run of text to be keyed at a single WPM.
+    // expandSpeedModifiers() returns a sequence of these.
+    struct SpeedSegment {
+        QString text;  // plain text (modifier prefix stripped, space=' ')
+        int     wpm;
+        bool operator==(const SpeedSegment& o) const {
+            return text == o.text && wpm == o.wpm;
+        }
+    };
+
     // State
-    int   speed()    const { return m_speed; }
-    int   delay()    const { return m_delay; }
-    bool  qskOn()    const { return m_qsk; }
-    bool  isLive()   const { return m_live; }
+    int   speed()     const { return m_speed; }
+    int   delay()     const { return m_delay; }
+    int   speedStep() const { return m_speedStep; }
+    bool  qskOn()     const { return m_qsk; }
+    bool  isLive()    const { return m_live; }
     int   sentIndex() const { return m_sentIndex; }
     QString macro(int idx) const;  // 0-based (0=F1, 11=F12)
 
@@ -28,15 +39,26 @@ public:
     void clearBuffer();
     void setSpeed(int wpm);
     void setDelay(int ms);
+    void setSpeedStep(int step);
     void setQsk(bool on);
     void setLive(bool on);
 
     // Status parsing (from radio)
     void applyStatus(const QMap<QString, QString>& kvs);
 
+    // Parses text for leading +/- speed modifiers on words.
+    // A +/- run at word-start (after space or string-start) immediately
+    // followed by a non-space, non-modifier character counts as a modifier.
+    // Standalone +/- not followed by word chars are prosigns/hyphens and
+    // pass through unchanged.  Speed resets to baseWpm after each modified
+    // word.  Returns a single segment at baseWpm when no modifiers found.
+    static QVector<SpeedSegment> expandSpeedModifiers(
+        const QString& text, int baseWpm, int step);
+
 signals:
     void commandReady(const QString& cmd);
     void speedChanged(int wpm);
+    void speedStepChanged(int step);
     void delayChanged(int ms);
     void qskChanged(bool on);
     void charSent(int index);           // character at index was keyed
@@ -52,8 +74,11 @@ signals:
     void queueEmpty();                   // radio CWX buffer drained — TX teardown required
 
 private:
+    void emitExpandedSend(const QVector<SpeedSegment>& segs);
+
     int     m_speed{20};
     int     m_delay{5};
+    int     m_speedStep{3};
     bool    m_qsk{false};
     bool    m_live{false};
     int     m_sentIndex{-1};

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -33,6 +33,10 @@ public:
     // Exposed for the automation bridge's `get cwx` snapshot so the queue-drain
     // watch is observable (#3949).
     int   cwxEndIndex() const { return m_cwxEndIndex; }
+    // Generation counter for the drain watch. Bumped by resetDrainWatch() (ESC/
+    // clear/disconnect) so a late cwx-send reply for a discarded batch can be
+    // recognised as stale and ignored rather than re-arming the watch. (#3949)
+    int   drainEpoch()  const { return m_drainEpoch; }
     QString macro(int idx) const;  // 0-based (0=F1, 11=F12)
 
     // Actions
@@ -42,6 +46,11 @@ public:
     void saveMacro(int idx, const QString& text); // 0-based
     void erase(int numChars);
     void clearBuffer();
+    // Abort any in-flight queue-drain watch and bump the epoch so replies for
+    // the discarded batch are rejected. Called on ESC/clear and on disconnect
+    // (via RadioModel::onDisconnected) so a stale m_cwxEndIndex can't wedge the
+    // monotonic guard across a reconnect. (#3949)
+    void resetDrainWatch();
     void setSpeed(int wpm);
     void setDelay(int ms);
     void setSpeedStep(int step);
@@ -51,8 +60,11 @@ public:
     // Status parsing (from radio)
     void applyStatus(const QMap<QString, QString>& kvs);
     // Invoked by RadioModel with the reply to the final cwx send command.
-    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83. (#3949)
-    void handleSendReply(int resultCode, const QString& body);
+    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83. The
+    // epoch is the drainEpoch() snapshot taken when the command was emitted;
+    // a reply whose epoch no longer matches belongs to a batch that was since
+    // aborted (ESC/clear/disconnect) and is ignored. (#3949)
+    void handleSendReply(int resultCode, const QString& body, int epoch);
 
     // Parses text for leading +/- speed modifiers on words.
     // A +/- run at word-start (after space or string-start) immediately
@@ -65,10 +77,12 @@ public:
 
 signals:
     void commandReady(const QString& cmd);
-    // Emitted for the final cwx send of a macro/send block so RadioModel can
-    // capture the radio_index from the reply and know when that block is fully
-    // transmitted.  See handleSendReply(). (#3949)
-    void replyCommandReady(const QString& cmd);
+    // Emitted for the final cwx send of a macro/send block, and for every
+    // live-mode char, so RadioModel can capture the radio_index from the reply
+    // and know when that block is fully transmitted.  The epoch is snapshotted
+    // at emit time and passed back to handleSendReply() so a reply for an
+    // aborted batch is discarded.  See handleSendReply(). (#3949)
+    void replyCommandReady(const QString& cmd, int epoch);
     void speedChanged(int wpm);
     void speedStepChanged(int step);
     void delayChanged(int ms);
@@ -96,6 +110,7 @@ private:
     int     m_sentIndex{-1};
     int     m_nextBlock{1};
     int     m_cwxEndIndex{-1};   // radio_index to watch for; -1 = not tracking
+    int     m_drainEpoch{0};     // bumped on ESC/clear/disconnect (#3949)
     QString m_macros[12];
 };
 

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -45,6 +45,9 @@ public:
 
     // Status parsing (from radio)
     void applyStatus(const QMap<QString, QString>& kvs);
+    // Invoked by RadioModel with the reply to the final cwx send command.
+    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83. (#3949)
+    void handleSendReply(int resultCode, const QString& body);
 
     // Parses text for leading +/- speed modifiers on words.
     // A +/- run at word-start (after space or string-start) immediately
@@ -57,6 +60,10 @@ public:
 
 signals:
     void commandReady(const QString& cmd);
+    // Emitted for the final cwx send of a macro/send block so RadioModel can
+    // capture the radio_index from the reply and know when that block is fully
+    // transmitted.  See handleSendReply(). (#3949)
+    void replyCommandReady(const QString& cmd);
     void speedChanged(int wpm);
     void speedStepChanged(int step);
     void delayChanged(int ms);
@@ -83,6 +90,7 @@ private:
     bool    m_live{false};
     int     m_sentIndex{-1};
     int     m_nextBlock{1};
+    int     m_cwxEndIndex{-1};   // radio_index to watch for; -1 = not tracking
     QString m_macros[12];
 };
 

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -28,6 +28,11 @@ public:
     bool  qskOn()     const { return m_qsk; }
     bool  isLive()    const { return m_live; }
     int   sentIndex() const { return m_sentIndex; }
+    // radio_index of the last char in the queued batch we are waiting to drain,
+    // or -1 when not tracking. queueEmpty() fires once sentIndex() reaches this.
+    // Exposed for the automation bridge's `get cwx` snapshot so the queue-drain
+    // watch is observable (#3949).
+    int   cwxEndIndex() const { return m_cwxEndIndex; }
     QString macro(int idx) const;  // 0-based (0=F1, 11=F12)
 
     // Actions

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -60,11 +60,18 @@ public:
     // Status parsing (from radio)
     void applyStatus(const QMap<QString, QString>& kvs);
     // Invoked by RadioModel with the reply to the final cwx send command.
-    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83. The
-    // epoch is the drainEpoch() snapshot taken when the command was emitted;
+    // Body format is "<radio_index>,<block>" per FlexLib CWX.cs:54-83.
+    //
+    // radio_index is the INSERTION-START (first-char) queue position of the
+    // batch, NOT the last char — confirmed on FLEX-6500 fw 4.2.20.41343: a
+    // 23-char send into a queue at sent=48 replied radio_index=49 (=48+1), and
+    // `cwx sent=` then climbed 48→71 as the radio keyed. So the batch-end index
+    // to watch is radio_index + nChars - 1 (49+23-1 = 71, matching the observed
+    // final sent=). nChars is the char count of this send (spaces included).
+    // The epoch is the drainEpoch() snapshot taken when the command was emitted;
     // a reply whose epoch no longer matches belongs to a batch that was since
     // aborted (ESC/clear/disconnect) and is ignored. (#3949)
-    void handleSendReply(int resultCode, const QString& body, int epoch);
+    void handleSendReply(int resultCode, const QString& body, int epoch, int nChars);
 
     // Parses text for leading +/- speed modifiers on words.
     // A +/- run at word-start (after space or string-start) immediately
@@ -79,10 +86,12 @@ signals:
     void commandReady(const QString& cmd);
     // Emitted for the final cwx send of a macro/send block, and for every
     // live-mode char, so RadioModel can capture the radio_index from the reply
-    // and know when that block is fully transmitted.  The epoch is snapshotted
-    // at emit time and passed back to handleSendReply() so a reply for an
-    // aborted batch is discarded.  See handleSendReply(). (#3949)
-    void replyCommandReady(const QString& cmd, int epoch);
+    // and know when that block is fully transmitted.  epoch is snapshotted at
+    // emit time (stale-batch guard) and nChars is the char count of this send
+    // (spaces included) — handleSendReply() watches radio_index + nChars - 1
+    // because radio_index is the batch's first-char position, not its last.
+    // See handleSendReply(). (#3949)
+    void replyCommandReady(const QString& cmd, int epoch, int nChars);
     void speedChanged(int wpm);
     void speedStepChanged(int step);
     void delayChanged(int ms);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -731,6 +731,16 @@ RadioModel::RadioModel(QObject* parent)
             m_cwxActive = false;
         sendCmd(cmd);
     });
+    // Final cwx send of each macro/text block goes via replyCommandReady so we
+    // can capture the radio_index from the reply.  CwxModel::handleSendReply
+    // stores it; applyStatus fires queueEmpty() when cwx sent= reaches it.
+    // This replaces the broken cwx queue= path — firmware never sends it. (#3949)
+    connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd){
+        m_cwxActive = true;
+        sendCmd(cmd, [this](int respVal, const QString& body){
+            m_cwxModel.handleSendReply(respVal, body);
+        });
+    });
     // When the radio signals its CWX buffer is drained, release TX. (#2450)
     // The radio's break-in timer fires but sync_cwx=1 still requires an
     // explicit xmit 0 from the client — without it the radio holds TX for

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -727,26 +727,41 @@ RadioModel::RadioModel(QObject* parent)
         // CWX TX and doesn't force the audio gate off. (#2047, #2097)
         if (cmd.startsWith("cwx send") || cmd.startsWith("cwx macro send"))
             m_cwxActive = true;
-        else if (cmd.startsWith("cwx clear"))
+        else if (cmd.startsWith("cwx clear")) {
             m_cwxActive = false;
+            m_cwxDrainArmed = false;  // ESC/clear aborts the drain watch (#3949)
+        }
         sendCmd(cmd);
     });
     // Final cwx send of each macro/text block goes via replyCommandReady so we
     // can capture the radio_index from the reply.  CwxModel::handleSendReply
     // stores it; applyStatus fires queueEmpty() when cwx sent= reaches it.
     // This replaces the broken cwx queue= path — firmware never sends it. (#3949)
-    connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd){
+    connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd, int epoch){
         m_cwxActive = true;
-        sendCmd(cmd, [this](int respVal, const QString& body){
-            m_cwxModel.handleSendReply(respVal, body);
+        // Arm the drain-release latch. Unlike m_cwxActive (which the interlock
+        // handler clears on every TRANSMITTING→READY flicker during a macro),
+        // m_cwxDrainArmed is owned solely by the CWX send/drain lifecycle, so
+        // the queueEmpty release below survives QSK break-in flicker. (#3949)
+        m_cwxDrainArmed = true;
+        sendCmd(cmd, [this, epoch](int respVal, const QString& body){
+            m_cwxModel.handleSendReply(respVal, body, epoch);
         });
     });
     // When the radio signals its CWX buffer is drained, release TX. (#2450)
     // The radio's break-in timer fires but sync_cwx=1 still requires an
     // explicit xmit 0 from the client — without it the radio holds TX for
     // its full hardware interlock timeout (~60 s).
+    //
+    // Gated on m_cwxDrainArmed, NOT m_cwxActive: setMox(false) unconditionally
+    // emits `xmit 0`, so the release must only fire for a CWX batch we armed,
+    // but the gate must not be the interlock-flicker-vulnerable m_cwxActive or
+    // the release would be skipped mid-macro and TX would stick. queueEmpty()
+    // itself only fires from CwxModel's armed watch (or a legacy queue= that
+    // firmware never sends), so this pairing is the drain-release authority. (#3949)
     connect(&m_cwxModel, &CwxModel::queueEmpty, this, [this]() {
-        if (!m_cwxActive) return;
+        if (!m_cwxDrainArmed) return;
+        m_cwxDrainArmed = false;
         m_cwxActive = false;
         m_transmitModel.setMox(false);
     });
@@ -3032,6 +3047,10 @@ void RadioModel::onDisconnected()
     m_txRequested = false;
     m_cwKeyActive = false;
     m_cwxActive = false;
+    m_cwxDrainArmed = false;
+    // Reset the CWX drain watch and bump its epoch so a watch armed mid-macro
+    // at disconnect can't wedge the monotonic guard after reconnect. (#3949)
+    m_cwxModel.resetDrainWatch();
     m_lastInterlockSource.clear();
     m_lastInterlockNotificationKey.clear();
     m_lastInterlockNotificationMs = 0;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -737,15 +737,15 @@ RadioModel::RadioModel(QObject* parent)
     // can capture the radio_index from the reply.  CwxModel::handleSendReply
     // stores it; applyStatus fires queueEmpty() when cwx sent= reaches it.
     // This replaces the broken cwx queue= path — firmware never sends it. (#3949)
-    connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd, int epoch){
+    connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd, int epoch, int nChars){
         m_cwxActive = true;
         // Arm the drain-release latch. Unlike m_cwxActive (which the interlock
         // handler clears on every TRANSMITTING→READY flicker during a macro),
         // m_cwxDrainArmed is owned solely by the CWX send/drain lifecycle, so
         // the queueEmpty release below survives QSK break-in flicker. (#3949)
         m_cwxDrainArmed = true;
-        sendCmd(cmd, [this, epoch](int respVal, const QString& body){
-            m_cwxModel.handleSendReply(respVal, body, epoch);
+        sendCmd(cmd, [this, epoch, nChars](int respVal, const QString& body){
+            m_cwxModel.handleSendReply(respVal, body, epoch, nChars);
         });
     });
     // When the radio signals its CWX buffer is drained, release TX. (#2450)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -736,7 +736,8 @@ RadioModel::RadioModel(QObject* parent)
     // Final cwx send of each macro/text block goes via replyCommandReady so we
     // can capture the radio_index from the reply.  CwxModel::handleSendReply
     // stores it; applyStatus fires queueEmpty() when cwx sent= reaches it.
-    // This replaces the broken cwx queue= path — firmware never sends it. (#3949)
+    // This replaces the broken cwx queue= path — firmware never sends it
+    // (observed on FLEX-6500 fw 4.2.20.41343; the 8600 target runs 4.2.18). (#3949)
     connect(&m_cwxModel, &CwxModel::replyCommandReady, this, [this](const QString& cmd, int epoch, int nChars){
         m_cwxActive = true;
         // Arm the drain-release latch. Unlike m_cwxActive (which the interlock

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -780,6 +780,7 @@ private:
     bool        m_txRequested{false}; // local MOX command intent (for edge sync)
     bool        m_cwKeyActive{false}; // true while CW key/paddle is held (#1379)
     bool        m_cwxActive{false};   // true while CWX send is in flight (#2047, #2097)
+    bool        m_cwxDrainArmed{false}; // CWX drain-release latch, immune to interlock flicker (#3949)
     bool        m_txAudioGate{false}; // actual TX audio gate state
     bool        m_radioTransmitting{false}; // raw interlock TX state, any owner
     QString     m_lastInterlockNotificationKey;

--- a/tests/cwx_drain_watch_test.cpp
+++ b/tests/cwx_drain_watch_test.cpp
@@ -188,6 +188,34 @@ int main(int argc, char** argv)
                "queueEmpty count=" + std::to_string(emptySpy.count()));
     }
 
+    // ── Cleanup: saveMacro strips client-only +/- before the shared radio store ─
+    {
+        CwxModel m;
+        QSignalSpy cmdSpy(&m, &CwxModel::commandReady);
+        m.saveMacro(0, "+CQ TEST");   // F1, raw text carries a speed modifier
+        report("saveMacro keeps the raw +/- text client-side (for our expansion)",
+               m.macro(0) == QStringLiteral("+CQ TEST"),
+               "macro(0)=" + m.macro(0).toStdString());
+        // radio-side command must have the '+' stripped and space -> 0x7f
+        const QString expected =
+            QStringLiteral("cwx macro save 1 \"CQ%1TEST\"").arg(QChar(0x7f));
+        const QString got = cmdSpy.isEmpty() ? QString() : cmdSpy.last().at(0).toString();
+        report("saveMacro strips +/- from the shared `cwx macro save` payload",
+               got == expected,
+               "got=" + got.toStdString());
+    }
+
+    // ── Cleanup: sendMacro falls back to radio-side expansion when unsynced ────
+    {
+        CwxModel m;
+        QSignalSpy cmdSpy(&m, &CwxModel::commandReady);
+        m.sendMacro(1);   // F1 not yet synced (m_macros[0] empty) — must not no-op
+        const QString got = cmdSpy.isEmpty() ? QString() : cmdSpy.last().at(0).toString();
+        report("sendMacro (unsynced) falls back to `cwx macro send N`, not silence",
+               got == QStringLiteral("cwx macro send 1"),
+               "got=" + got.toStdString());
+    }
+
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASSED" : "FAILURES PRESENT");
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/cwx_drain_watch_test.cpp
+++ b/tests/cwx_drain_watch_test.cpp
@@ -1,0 +1,165 @@
+// Regression tests for the CWX queue-drain watch state machine (#3949).
+//
+// These cover the three blocking correctness items from the PR #3979 review:
+//   Item 3 — epoch/generation guard: a late cwx-send reply for a batch aborted
+//            by ESC/clear/disconnect must not re-arm the watch; a disconnect
+//            reset must let a fresh session arm at a *smaller* radio_index
+//            (the monotonic guard must not wedge across reconnect).
+//   Item 2 — live-mode sendChar arms the watch: a live-typing session must
+//            advance and drain the watch (previously it armed nothing and the
+//            ~60 s stuck-TX survived).
+//   Item 1 — (CwxModel-side invariant) queueEmpty() fires purely from the armed
+//            watch draining, independent of any interleaved status. This is the
+//            guarantee the RadioModel flicker-immune release latch relies on;
+//            the latch lifecycle itself lives in RadioModel wiring, which is not
+//            unit-instantiable in this suite and is covered by the hardware test
+//            plan (item 4) and code review.
+//
+// Run: ./build/cwx_drain_watch_test
+
+#include "models/CwxModel.h"
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-70s %s\n", ok ? "[ OK ]" : "[FAIL]", name, detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+// Deliver a `cwx sent=<idx>` status, the mechanism that drains the watch.
+void feedSent(CwxModel& m, int idx)
+{
+    m.applyStatus({{QStringLiteral("sent"), QString::number(idx)}});
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    std::printf("CWX drain-watch state-machine tests\n\n");
+
+    // ── Item 3: stale reply after clear must not re-arm (epoch guard) ─────────
+    {
+        CwxModel m;
+        const int epoch0 = m.drainEpoch();
+        m.send("CQ");                       // emits replyCommandReady(cmd, epoch0)
+        m.handleSendReply(0, "42,1", epoch0); // reply arrives → arm at 42
+        report("item3: reply arms watch at radio_index",
+               m.cwxEndIndex() == 42,
+               "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
+
+        m.clearBuffer();                    // ESC: resetDrainWatch bumps epoch, endIndex=-1
+        report("item3: clearBuffer aborts watch",
+               m.cwxEndIndex() == -1, "");
+        report("item3: clearBuffer bumps epoch",
+               m.drainEpoch() != epoch0, "");
+
+        // Late reply for the discarded batch carries the pre-clear epoch.
+        m.handleSendReply(0, "99,2", epoch0);
+        report("item3: stale (pre-clear epoch) reply is rejected, no re-arm",
+               m.cwxEndIndex() == -1,
+               "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
+    }
+
+    // ── Item 3: disconnect reset lets a new session arm at a smaller index ────
+    {
+        CwxModel m;
+        const int epochA = m.drainEpoch();
+        m.send("LONG MESSAGE");
+        m.handleSendReply(0, "500,1", epochA);   // armed high, mid-macro
+        report("item3: armed at 500 before disconnect",
+               m.cwxEndIndex() == 500, "");
+
+        m.resetDrainWatch();                     // simulates onDisconnected()
+        const int epochB = m.drainEpoch();
+        report("item3: resetDrainWatch clears index + bumps epoch",
+               m.cwxEndIndex() == -1 && epochB != epochA, "");
+
+        // New session's first reply has a smaller radio_index than the stale 500.
+        m.send("CQ");
+        m.handleSendReply(0, "10,1", epochB);
+        report("item3: post-reconnect smaller index arms cleanly (guard not wedged)",
+               m.cwxEndIndex() == 10,
+               "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
+    }
+
+    // ── Item 3: monotonic advance-only still holds within a session ───────────
+    {
+        CwxModel m;
+        const int e = m.drainEpoch();
+        m.send("A"); m.handleSendReply(0, "50,1", e);   // arm at 50
+        m.send("B"); m.handleSendReply(0, "30,2", e);   // out-of-order smaller
+        report("item3: smaller in-session reply does not retract the watch",
+               m.cwxEndIndex() == 50,
+               "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
+    }
+
+    // ── Item 2: live-mode sendChar arms and drains the watch ──────────────────
+    {
+        CwxModel m;
+        QSignalSpy replySpy(&m, &CwxModel::replyCommandReady);
+        QSignalSpy emptySpy(&m, &CwxModel::queueEmpty);
+        m.setLive(true);
+
+        const int e = m.drainEpoch();
+        m.sendChar("A");
+        report("item2: sendChar emits via reply path (not fire-and-forget)",
+               replySpy.count() == 1,
+               "replyCommandReady count=" + std::to_string(replySpy.count()));
+
+        m.handleSendReply(0, "5,1", e);
+        report("item2: live char arms the watch",
+               m.cwxEndIndex() == 5, "");
+
+        feedSent(m, 5);
+        report("item2: live char drains → queueEmpty fires",
+               emptySpy.count() == 1,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+        report("item2: watch cleared after drain",
+               m.cwxEndIndex() == -1, "");
+    }
+
+    // ── Item 1 (CwxModel invariant): watch drains via sent= despite noise ─────
+    {
+        CwxModel m;
+        QSignalSpy emptySpy(&m, &CwxModel::queueEmpty);
+        const int e = m.drainEpoch();
+        m.send("CQ");
+        m.handleSendReply(0, "10,1", e);         // arm at 10
+
+        // Interleaved unrelated status (as arrives during interlock flicker).
+        m.applyStatus({{QStringLiteral("wpm"), QStringLiteral("25")}});
+        feedSent(m, 7);                          // partial — not yet drained
+        report("item1: queueEmpty not fired before sent reaches end index",
+               emptySpy.count() == 0,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+
+        feedSent(m, 10);                         // reaches the watched index
+        report("item1: queueEmpty fires exactly when sent reaches end index",
+               emptySpy.count() == 1,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+    }
+
+    // ── Guard: sent= while idle (no armed watch) must not fire queueEmpty ─────
+    {
+        CwxModel m;
+        QSignalSpy emptySpy(&m, &CwxModel::queueEmpty);
+        feedSent(m, 100);                        // no watch armed
+        report("idle: sent= with no armed watch does not fire queueEmpty",
+               emptySpy.count() == 0,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+    }
+
+    std::printf("\n%s\n", g_failed == 0 ? "ALL PASSED" : "FAILURES PRESENT");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/cwx_drain_watch_test.cpp
+++ b/tests/cwx_drain_watch_test.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
         CwxModel m;
         const int epoch0 = m.drainEpoch();
         m.send("CQ");                       // emits replyCommandReady(cmd, epoch0)
-        m.handleSendReply(0, "42,1", epoch0); // reply arrives → arm at 42
+        m.handleSendReply(0, "42,1", epoch0, 1); // reply arrives → arm at end 42 (1-char batch)
         report("item3: reply arms watch at radio_index",
                m.cwxEndIndex() == 42,
                "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
                m.drainEpoch() != epoch0, "");
 
         // Late reply for the discarded batch carries the pre-clear epoch.
-        m.handleSendReply(0, "99,2", epoch0);
+        m.handleSendReply(0, "99,2", epoch0, 1);
         report("item3: stale (pre-clear epoch) reply is rejected, no re-arm",
                m.cwxEndIndex() == -1,
                "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
         CwxModel m;
         const int epochA = m.drainEpoch();
         m.send("LONG MESSAGE");
-        m.handleSendReply(0, "500,1", epochA);   // armed high, mid-macro
+        m.handleSendReply(0, "500,1", epochA, 1);   // armed high, mid-macro
         report("item3: armed at 500 before disconnect",
                m.cwxEndIndex() == 500, "");
 
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 
         // New session's first reply has a smaller radio_index than the stale 500.
         m.send("CQ");
-        m.handleSendReply(0, "10,1", epochB);
+        m.handleSendReply(0, "10,1", epochB, 1);
         report("item3: post-reconnect smaller index arms cleanly (guard not wedged)",
                m.cwxEndIndex() == 10,
                "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
@@ -97,8 +97,8 @@ int main(int argc, char** argv)
     {
         CwxModel m;
         const int e = m.drainEpoch();
-        m.send("A"); m.handleSendReply(0, "50,1", e);   // arm at 50
-        m.send("B"); m.handleSendReply(0, "30,2", e);   // out-of-order smaller
+        m.send("A"); m.handleSendReply(0, "50,1", e, 1);   // arm at end 50
+        m.send("B"); m.handleSendReply(0, "30,2", e, 1);   // out-of-order smaller
         report("item3: smaller in-session reply does not retract the watch",
                m.cwxEndIndex() == 50,
                "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
                replySpy.count() == 1,
                "replyCommandReady count=" + std::to_string(replySpy.count()));
 
-        m.handleSendReply(0, "5,1", e);
+        m.handleSendReply(0, "5,1", e, 1);   // single live char: end == radio_index
         report("item2: live char arms the watch",
                m.cwxEndIndex() == 5, "");
 
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
         QSignalSpy emptySpy(&m, &CwxModel::queueEmpty);
         const int e = m.drainEpoch();
         m.send("CQ");
-        m.handleSendReply(0, "10,1", e);         // arm at 10
+        m.handleSendReply(0, "10,1", e, 1);      // arm at end 10
 
         // Interleaved unrelated status (as arrives during interlock flicker).
         m.applyStatus({{QStringLiteral("wpm"), QStringLiteral("25")}});
@@ -146,6 +146,34 @@ int main(int argc, char** argv)
 
         feedSent(m, 10);                         // reaches the watched index
         report("item1: queueEmpty fires exactly when sent reaches end index",
+               emptySpy.count() == 1,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+    }
+
+    // ── Item 4a: radio_index is the FIRST char; end = radio_index + nChars-1 ──
+    // Reproduces the FLEX-6500 fw 4.2.20 observation: a 23-char send into a
+    // queue at sent=48 replied radio_index=49 (first char), and sent= climbed
+    // to 71 as it keyed. The watch must fire at 71, NOT at 49 — releasing at 49
+    // would truncate the release ~22 chars early (the pre-fix bug Jeremy caught).
+    {
+        CwxModel m;
+        QSignalSpy emptySpy(&m, &CwxModel::queueEmpty);
+        const int e = m.drainEpoch();
+        m.send("PARIS PARIS PARIS PARIS");          // 23 chars
+        m.handleSendReply(0, "49,1", e, 23);        // radio_index=49 (first char)
+        report("item4a: end index = radio_index + nChars - 1 (49+23-1)",
+               m.cwxEndIndex() == 71,
+               "cwxEndIndex=" + std::to_string(m.cwxEndIndex()));
+
+        feedSent(m, 49);                            // first char keyed — NOT drained
+        report("item4a: no release when sent reaches only the first char (49)",
+               emptySpy.count() == 0,
+               "queueEmpty count=" + std::to_string(emptySpy.count()));
+        feedSent(m, 60);                            // mid-message — still not drained
+        report("item4a: no release mid-message (60)",
+               emptySpy.count() == 0, "");
+        feedSent(m, 71);                            // last char keyed — drained
+        report("item4a: release exactly when sent reaches the last char (71)",
                emptySpy.count() == 1,
                "queueEmpty count=" + std::to_string(emptySpy.count()));
     }

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -61,9 +61,9 @@ struct Fixture {
                              commands.push_back(command);
                          });
         // replyCommandReady carries the final cwx send of each macro block, and
-        // every live-mode char, plus the drain-watch epoch (#3949)
+        // every live-mode char, plus the drain-watch epoch + batch char count (#3949)
         QObject::connect(&model, &CwxModel::replyCommandReady,
-                         [this](const QString& command, int /*epoch*/) {
+                         [this](const QString& command, int /*epoch*/, int /*nChars*/) {
                              commands.push_back(command);
                          });
     }

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -60,9 +60,10 @@ struct Fixture {
                          [this](const QString& command) {
                              commands.push_back(command);
                          });
-        // replyCommandReady carries the final cwx send of each macro block (#3949)
+        // replyCommandReady carries the final cwx send of each macro block, and
+        // every live-mode char, plus the drain-watch epoch (#3949)
         QObject::connect(&model, &CwxModel::replyCommandReady,
-                         [this](const QString& command) {
+                         [this](const QString& command, int /*epoch*/) {
                              commands.push_back(command);
                          });
     }

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -60,6 +60,11 @@ struct Fixture {
                          [this](const QString& command) {
                              commands.push_back(command);
                          });
+        // replyCommandReady carries the final cwx send of each macro block (#3949)
+        QObject::connect(&model, &CwxModel::replyCommandReady,
+                         [this](const QString& command) {
+                             commands.push_back(command);
+                         });
     }
 };
 

--- a/tests/cwx_speed_modifier_test.cpp
+++ b/tests/cwx_speed_modifier_test.cpp
@@ -1,0 +1,134 @@
+// Unit tests for CwxModel::expandSpeedModifiers — the pure expansion function
+// that parses inline +/- speed modifier prefixes from CW macro / send text.
+// Run: ./build/cwx_speed_modifier_test
+
+#include "models/CwxModel.h"
+#include <QCoreApplication>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+using Segs = QVector<CwxModel::SpeedSegment>;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-64s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+void check(const char* name, const Segs& got, const Segs& want)
+{
+    if (got == want) { report(name, true); return; }
+    std::string d = "got[";
+    for (const auto& s : got)
+        d += "(" + s.text.toStdString() + "@" + std::to_string(s.wpm) + ")";
+    d += "] want[";
+    for (const auto& s : want)
+        d += "(" + s.text.toStdString() + "@" + std::to_string(s.wpm) + ")";
+    d += "]";
+    report(name, false, d);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    std::printf("CWX speed modifier expansion tests\n\n");
+
+    // ── No modifiers ──────────────────────────────────────────────────────
+    check("no modifiers: passthrough as single segment",
+          CwxModel::expandSpeedModifiers("CQ TEST", 20, 3),
+          Segs{{"CQ TEST", 20}});
+
+    check("empty string",
+          CwxModel::expandSpeedModifiers("", 20, 3),
+          Segs{});
+
+    // ── Reporter's exact example ──────────────────────────────────────────
+    check("reporter example: +ur 5nn 5nn -1234NH ++73",
+          CwxModel::expandSpeedModifiers("+ur 5nn 5nn -1234NH ++73", 20, 3),
+          Segs{{"ur", 23}, {" 5nn 5nn ", 20}, {"1234NH", 17}, {" ", 20}, {"73", 26}});
+
+    // ── Single-word modifiers ─────────────────────────────────────────────
+    check("single +word: sends word at base+step",
+          CwxModel::expandSpeedModifiers("+CQ", 20, 3),
+          Segs{{"CQ", 23}});
+
+    check("single -word: sends word at base-step",
+          CwxModel::expandSpeedModifiers("-CQ", 20, 3),
+          Segs{{"CQ", 17}});
+
+    check("double ++word: base + 2*step",
+          CwxModel::expandSpeedModifiers("++CQ", 20, 3),
+          Segs{{"CQ", 26}});
+
+    check("double --word: base - 2*step",
+          CwxModel::expandSpeedModifiers("--CQ", 20, 3),
+          Segs{{"CQ", 14}});
+
+    // ── Speed reset semantics ─────────────────────────────────────────────
+    check("speed resets to base after modified word",
+          CwxModel::expandSpeedModifiers("+CQ de", 20, 3),
+          Segs{{"CQ", 23}, {" de", 20}});
+
+    check("unmodified prefix, then modifier",
+          CwxModel::expandSpeedModifiers("de W1AW +CQ", 20, 3),
+          Segs{{"de W1AW ", 20}, {"CQ", 23}});
+
+    // ── Prosign / hyphen disambiguation ───────────────────────────────────
+    check("standalone + (AR prosign) — not a modifier",
+          CwxModel::expandSpeedModifiers("+", 20, 3),
+          Segs{{"+", 20}});
+
+    check("trailing + (AR prosign) stays in word body",
+          CwxModel::expandSpeedModifiers("73+", 20, 3),
+          Segs{{"73+", 20}});
+
+    check("+ followed by space = prosign, not modifier",
+          CwxModel::expandSpeedModifiers("+ ur", 20, 3),
+          Segs{{"+ ur", 20}});
+
+    check("standalone - (hyphen) — not a modifier",
+          CwxModel::expandSpeedModifiers("-", 20, 3),
+          Segs{{"-", 20}});
+
+    check("mid-word + stays as prosign",
+          CwxModel::expandSpeedModifiers("de+w1aw", 20, 3),
+          Segs{{"de+w1aw", 20}});
+
+    // ── WPM clamping ─────────────────────────────────────────────────────
+    check("wpm floor at 5",
+          CwxModel::expandSpeedModifiers("-word", 5, 3),
+          Segs{{"word", 5}});
+
+    check("wpm ceiling at 100",
+          CwxModel::expandSpeedModifiers("+word", 100, 3),
+          Segs{{"word", 100}});
+
+    check("large step: clamp at 100",
+          CwxModel::expandSpeedModifiers("+word", 95, 10),
+          Segs{{"word", 100}});
+
+    check("large negative step: clamp at 5",
+          CwxModel::expandSpeedModifiers("-word", 10, 10),
+          Segs{{"word", 5}});
+
+    // ── step=1 boundary ───────────────────────────────────────────────────
+    check("step=1 single modifier",
+          CwxModel::expandSpeedModifiers("+CQ", 20, 1),
+          Segs{{"CQ", 21}});
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
> **⚠️ Rebased & stacked (2026-07-04) — please re-review from the new head.**
>
> - **Stacked on #3976** (`feat/272-cwx-inline-speed-modifiers`). The queue-drain
>   fix builds on the `SpeedSegment` / `expandSpeedModifiers` machinery from #3976
>   (`emitExpandedSend()` attaches the `replyCommandReady` callback to the last
>   non-empty segment), so this branch sits on top of it. **Merge order: #3976 → #3979.**
>   GitHub can't retarget the base cross-fork, so the diff-vs-`main` still shows the
>   speed-modifier commit; once #3976 lands, rebasing this branch onto `main` drops it
>   automatically. The delta unique to this PR is `CwxModel` (drain logic), `RadioModel`
>   (reply wiring), the `get cwx` bridge verb, docs, and `cwx_panel_test`.
> - **Dropped the RC-28 #3313 change** — superseded by merged #3978, which also carries
>   the `m_lastRC28LedByte = 0xFF` reconnect reset this branch's copy was missing.
>   `MainWindow.{h}`, `MainWindow_Controllers.cpp`, `TransmitModel.{h,cpp}` are no longer
>   touched here.
> - **Dropped the MeterApplet °C/°F #3886 change** — already merged via #3974 (upstream's
>   copy additionally removes the dead `m_fanRpm` member). `MeterApplet.{h,cpp}` are no
>   longer touched here.
> - Rebased onto current `upstream/main`; builds clean (`AetherSDR` links) and CWX tests pass.
>
> The blocking drain-watch correctness items from the last review (interlock-flicker raze
> of `m_cwxActive`, live-mode chars not advancing the watch, stale-reply/disconnect re-arm,
> and the two on-air protocol assumptions) are **not yet addressed** — tracked as follow-up.

## Summary

- **Root cause**: Firmware never sends `cwx queue=` status, so `queueEmpty()` never fired, leaving the radio locked in TX for the full ~60 s hardware interlock timeout after CWX macros finished.
- **Fix**: The final `cwx send` of each macro/text block now goes via a new `replyCommandReady` signal instead of the fire-and-forget `commandReady`. `RadioModel` captures the `radio_index` from the reply body (`<radio_index>,<block>` per FlexLib CWX.cs:54-83), stores it in `CwxModel::m_cwxEndIndex`, and `applyStatus` fires `queueEmpty()` when `cwx sent=` reaches that value.
- `clearBuffer()` / ESC resets `m_cwxEndIndex = -1` so an aborted macro never triggers a spurious TX release.
- Stacked macros work correctly: each new `cwx send` reply overwrites `m_cwxEndIndex` with the radio's absolute queue position for the latest batch.

## Files changed

| File | Change |
|------|--------|
| `src/models/CwxModel.h` | Add `replyCommandReady(cmd)` signal, `handleSendReply(resultCode, body)` method, `m_cwxEndIndex` member |
| `src/models/CwxModel.cpp` | `emitExpandedSend`: last segment → `replyCommandReady`; `applyStatus`: fire `queueEmpty()` on sent= match; add `handleSendReply` |
| `src/models/RadioModel.cpp` | Wire `replyCommandReady` → `sendCmd` with reply callback → `handleSendReply` |
| `tests/cwx_panel_test.cpp` | Fixture captures `replyCommandReady` alongside `commandReady` so command assertions stay valid |

## Test plan

- [ ] All existing `cwx_panel_test` unit tests pass (verified locally — all 14 green)
- [ ] On hardware: send a CWX macro (F1–F12); radio should drop TX within ~100 ms of the last dit/dah completing instead of holding TX for 60 s
- [ ] On hardware: press ESC mid-macro; TX should drop immediately with no delayed `xmit 0` from the aborted watch
- [ ] On hardware: rapid-fire two macros before first finishes; RX audio should restore correctly after second macro completes

Closes #3949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
