### PR TITLE
fix(shortcuts): cleared bindings no longer revert to default on restart (#3964)

### DIFF
--- a/src/core/ShortcutManager.cpp
+++ b/src/core/ShortcutManager.cpp
@@ -1,6 +1,7 @@
 #include "ShortcutManager.h"
 #include "AppSettings.h"
 #include <QHash>
+#include <QRegularExpression>
 #include <QWidget>
 #include <QDebug>
 
@@ -16,6 +17,15 @@ void ShortcutManager::registerAction(const QString& id, const QString& displayNa
                                      std::function<void()> handler,
                                      bool autoRepeat)
 {
+    // The id becomes part of the XML element name "Shortcut_<id>". AppSettings
+    // silently drops keys that fail ^[A-Za-z_][A-Za-z0-9_]*$ on save (qWarning
+    // only), so an id containing '.'/'-'/etc. would be contains()-true in-session
+    // yet never written — a cleared binding would resurrect after restart (the
+    // exact #3964 failure mode). Keep ids to [A-Za-z0-9_].
+    Q_ASSERT_X(QRegularExpression(QStringLiteral("^[A-Za-z0-9_]+$")).match(id).hasMatch(),
+               "ShortcutManager::registerAction",
+               "action id must match [A-Za-z0-9_]+ (it forms the XML key Shortcut_<id>)");
+
     // Prevent duplicate registration
     for (const auto& a : m_actions) {
         if (a.id == id) {
@@ -41,6 +51,7 @@ void ShortcutManager::setBinding(const QString& actionId, const QKeySequence& ke
     }
 
     a->currentKey = key;
+    a->persisted = true;
     saveBindings();
     emit bindingsChanged();
 }
@@ -50,14 +61,17 @@ void ShortcutManager::clearBinding(const QString& actionId)
     auto* a = action(actionId);
     if (!a) return;
     a->currentKey = QKeySequence();
+    a->persisted = true;   // user intent — an explicit "" must survive restart (#3964)
     saveBindings();
     emit bindingsChanged();
 }
 
 void ShortcutManager::resetToDefaults()
 {
-    for (auto& a : m_actions)
+    for (auto& a : m_actions) {
         a.currentKey = a.defaultKey;
+        a.persisted = false;   // back to default → drop from settings, track future defaults
+    }
     saveBindings();
     emit bindingsChanged();
 }
@@ -67,13 +81,25 @@ void ShortcutManager::loadBindings()
     auto& s = AppSettings::instance();
     for (auto& a : m_actions) {
         const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
-        QString val = s.value(key).toString();
-        if (!val.isNull())
-            a.currentKey = QKeySequence(val);
-        // else keep default
+        // A present key (even "") is explicit user intent — apply it and mark the
+        // action persisted; an absent key keeps the registered default. Presence,
+        // not the null-vs-"" value (which the XML round-trip flattens), is the
+        // correct sentinel (#3964). We need the presence bit itself to seed
+        // `persisted`, so this stays a contains() gate rather than a
+        // value(key, default) fallback.
+        if (s.contains(key)) {
+            a.currentKey = QKeySequence(s.value(key).toString());
+            a.persisted = true;
+        }
     }
 
-    bool normalized = false;
+    // Normalize duplicate key bindings for this session only. This clears the
+    // losing action's currentKey in memory but leaves its `persisted` flag
+    // untouched, so saveBindings() will NOT write the machine-initiated clear:
+    // the loser is recomputed from (defaults + persisted customizations) on every
+    // load. Persisting it would be indistinguishable from a user clear and would
+    // pin the loser to "" forever — suppressing a future release's default once
+    // the colliding registration is fixed (#3964 review).
     QHash<QString, int> ownerByKey;
     for (int i = 0; i < m_actions.size(); ++i) {
         auto& action = m_actions[i];
@@ -102,11 +128,7 @@ void ShortcutManager::loadBindings()
                        << "owned by" << incumbent.id;
             action.currentKey = QKeySequence();
         }
-        normalized = true;
     }
-
-    if (normalized)
-        saveBindings();
 }
 
 void ShortcutManager::saveBindings()
@@ -114,7 +136,18 @@ void ShortcutManager::saveBindings()
     auto& s = AppSettings::instance();
     for (const auto& a : m_actions) {
         const QString key = QStringLiteral("Shortcut_%1").arg(a.id);
-        s.setValue(key, a.currentKey.toString());
+        // Persist only actions the user explicitly touched. A set or cleared
+        // binding is marked persisted and written back — a cleared one round-trips
+        // as "" and loadBindings()'s presence gate honors it (#3964). Everything
+        // else (fresh at default, reset to default, or cleared only by the
+        // load-time duplicate-key normalization) is written absent: a future
+        // release's changed default reaches it instead of being pinned, and a
+        // machine-initiated normalization clear never sticks.
+        if (a.persisted) {
+            s.setValue(key, a.currentKey.toString());
+        } else {
+            s.remove(key);
+        }
     }
     s.save();
 }

--- a/src/core/ShortcutManager.h
+++ b/src/core/ShortcutManager.h
@@ -20,6 +20,7 @@ public:
         QKeySequence currentKey;
         std::function<void()> handler;
         bool autoRepeat{false};   // allow key-hold repeat (e.g. tuning)
+        bool persisted{false};    // explicit user intent (set/cleared) → written to settings
     };
 
     explicit ShortcutManager(QObject* parent = nullptr);

--- a/tests/shortcut_manager_test.cpp
+++ b/tests/shortcut_manager_test.cpp
@@ -94,6 +94,107 @@ int main(int argc, char** argv)
     ok &= expect(dah && dah->currentKey == QKeySequence(Qt::Key_F11),
                  "dah shortcut reloads");
 
+    // Regression #3964: a binding cleared by the user must stay empty after
+    // restart — not revert to the action's non-empty default key.
+    // The old loadBindings() used !val.isNull(); QXmlStreamReader::readElementText()
+    // returns a null QString for empty/self-closing elements, so the persisted ""
+    // was treated as "never written" and the default was silently restored.
+    {
+        ShortcutManager mgr;
+        // Register with a non-empty default so we can tell if it wrongly reverts.
+        mgr.registerAction(QStringLiteral("mox_toggle"), QStringLiteral("MOX Toggle"),
+                           QStringLiteral("TX"), QKeySequence(Qt::Key_Space), {});
+        mgr.loadBindings();               // no entry in settings yet → keeps Space
+        const auto* fresh = mgr.action(QStringLiteral("mox_toggle"));
+        ok &= expect(fresh && fresh->currentKey == QKeySequence(Qt::Key_Space),
+                     "absent key keeps non-empty default");
+        mgr.clearBinding(QStringLiteral("mox_toggle"));   // saves Shortcut_mox_toggle = ""
+
+        settings.reset();
+        settings.load();
+
+        ShortcutManager mgr2;
+        mgr2.registerAction(QStringLiteral("mox_toggle"), QStringLiteral("MOX Toggle"),
+                            QStringLiteral("TX"), QKeySequence(Qt::Key_Space), {});
+        mgr2.loadBindings();
+
+        const auto* mox = mgr2.action(QStringLiteral("mox_toggle"));
+        ok &= expect(mox && mox->currentKey.isEmpty(),
+                     "cleared binding stays empty after reload (not reverted to default Space)");
+    }
+
+    // Regression (#3983 review): saveBindings() must persist only customizations
+    // so a future release's changed default is delivered. An action left at — or
+    // reset to — its default is written absent; only user-changed keys stick.
+    {
+        settings.reset();
+
+        ShortcutManager mgr;
+        mgr.registerAction(QStringLiteral("band_up"), QStringLiteral("Band Up"),
+                           QStringLiteral("Band"), QKeySequence(), {});
+        mgr.registerAction(QStringLiteral("rit_toggle"), QStringLiteral("RIT Toggle"),
+                           QStringLiteral("RIT/XIT"), QKeySequence(Qt::Key_R), {});
+        mgr.loadBindings();
+        // Customize one action so a save runs; leave rit_toggle at its default.
+        mgr.setBinding(QStringLiteral("band_up"), QKeySequence(Qt::Key_PageUp));
+
+        settings.reset();
+        settings.load();
+
+        ok &= expect(!settings.contains(QStringLiteral("Shortcut_rit_toggle")),
+                     "action left at its default is not persisted");
+
+        // A later release changes rit_toggle's default — it must be delivered,
+        // not pinned to this release's Key_R.
+        ShortcutManager future;
+        future.registerAction(QStringLiteral("band_up"), QStringLiteral("Band Up"),
+                              QStringLiteral("Band"), QKeySequence(), {});
+        future.registerAction(QStringLiteral("rit_toggle"), QStringLiteral("RIT Toggle"),
+                              QStringLiteral("RIT/XIT"), QKeySequence(Qt::Key_G), {});
+        future.loadBindings();
+        const auto* rit = future.action(QStringLiteral("rit_toggle"));
+        ok &= expect(rit && rit->currentKey == QKeySequence(Qt::Key_G),
+                     "changed default delivered to an unpersisted action");
+        const auto* bu = future.action(QStringLiteral("band_up"));
+        ok &= expect(bu && bu->currentKey == QKeySequence(Qt::Key_PageUp),
+                     "persisted customization survives reload");
+    }
+
+    // Regression (#3983 review, consequence 2): the load-time duplicate-key
+    // normalization clears the losing action in memory but must NOT persist that
+    // machine decision. Two actions share a non-empty default; once a future
+    // release resolves the collision, the previously-cleared action must receive
+    // its new (non-colliding) default rather than staying pinned to "".
+    {
+        settings.reset();
+
+        ShortcutManager mgr;
+        mgr.registerAction(QStringLiteral("alpha"), QStringLiteral("Alpha"),
+                           QStringLiteral("TX"), QKeySequence(Qt::Key_F5), {});
+        mgr.registerAction(QStringLiteral("beta"), QStringLiteral("Beta"),
+                           QStringLiteral("TX"), QKeySequence(Qt::Key_F5), {});
+        mgr.loadBindings();   // normalization clears one of the two in memory
+        // Force a save so any (wrongly) persisted clear would land on disk.
+        mgr.setBinding(QStringLiteral("alpha"), QKeySequence(Qt::Key_F6));
+
+        settings.reset();
+        settings.load();
+
+        ok &= expect(!settings.contains(QStringLiteral("Shortcut_beta")),
+                     "normalization clear is not persisted");
+
+        // Future release moves beta's default off the collision.
+        ShortcutManager future;
+        future.registerAction(QStringLiteral("alpha"), QStringLiteral("Alpha"),
+                              QStringLiteral("TX"), QKeySequence(Qt::Key_F5), {});
+        future.registerAction(QStringLiteral("beta"), QStringLiteral("Beta"),
+                              QStringLiteral("TX"), QKeySequence(Qt::Key_F7), {});
+        future.loadBindings();
+        const auto* beta = future.action(QStringLiteral("beta"));
+        ok &= expect(beta && beta->currentKey == QKeySequence(Qt::Key_F7),
+                     "resolved-collision default delivered (normalization not pinned)");
+    }
+
     QDir(configRoot + "/AetherSDR").removeRecursively();
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Root cause

`ShortcutManager::loadBindings()` used `!val.isNull()` to decide whether to apply a stored binding. The intent was:

- *null* (`val.isNull() == true`) → key was never persisted → keep the action's default
- *empty* (`val.isNull() == false`, `val.isEmpty() == true`) → user explicitly cleared it → apply empty

But `QXmlStreamReader::readElementText()` returns a **null** `QString` for empty or self-closing XML elements (e.g. `<Shortcut_mox_toggle/>`). So a binding saved as `""` round-tripped back through the XML layer as `null` — indistinguishable from "never written" — and the default key was silently restored on the next launch.

Set and changed bindings are non-empty strings and survive the round-trip fine, which is why only *cleared* keys regressed.

## Fix

Gate on `AppSettings::contains()` instead of `!val.isNull()`:

```cpp
// Before
QString val = s.value(key).toString();
if (!val.isNull())
    a.currentKey = QKeySequence(val);

// After
if (s.contains(key))
    a.currentKey = QKeySequence(s.value(key).toString());
```

`contains()` checks `m_settings.contains(key)`, which is `true` whenever the element was present in the XML regardless of whether its text content came back null or empty. Key presence is the correct sentinel for "explicitly persisted"; the null/empty distinction in the value is irrelevant and not preserved by the XML layer.

## Regression test

Added to `tests/shortcut_manager_test.cpp`: register an action with a non-empty default (`Space`), clear it, save, reload — assert the binding stays empty rather than reverting to `Space`. This test would have failed against the old code.

## Test plan

- [ ] `cmake --build build --target shortcut_manager_test && ./build/tests/shortcut_manager_test` — all assertions pass including the new regression check
- [ ] Manual: assign a shortcut in the keyboard map dialog, clear it, restart — confirm the binding stays cleared

Fixes #3964

🤖 Generated with [Claude Code](https://claude.com/claude-code)