### PR TITLE
[codex] Fix FFT edge smoothing during pan/zoom

### DIFF
--- a/src/gui/KiwiSdrTraceMath.h
+++ b/src/gui/KiwiSdrTraceMath.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QVector>
+#include <QtGlobal>
 
 #include <algorithm>
 #include <cmath>
@@ -114,6 +115,36 @@ inline QVector<float> mapRowToTrace(const QVector<float>& rowBins,
                                      srcCenter, fallback);
     }
     return trace;
+}
+
+inline QVector<quint8> mapRowCoverageMask(int sourceBins,
+                                          int destWidth,
+                                          double rowCenterMhz,
+                                          double rowBandwidthMhz,
+                                          double viewCenterMhz,
+                                          double viewBandwidthMhz)
+{
+    if (sourceBins <= 0 || destWidth <= 0
+        || rowBandwidthMhz <= 0.0 || viewBandwidthMhz <= 0.0) {
+        return {};
+    }
+
+    QVector<quint8> coverage(destWidth, quint8(0));
+    const double rowLowMhz = rowCenterMhz - rowBandwidthMhz * 0.5;
+    const double viewLowMhz = viewCenterMhz - viewBandwidthMhz * 0.5;
+    for (int x = 0; x < destWidth; ++x) {
+        const double freqMhz = viewLowMhz
+            + (static_cast<double>(x) + 0.5)
+                * viewBandwidthMhz / static_cast<double>(destWidth);
+        const double srcCenter =
+            ((freqMhz - rowLowMhz) / rowBandwidthMhz)
+                * static_cast<double>(sourceBins) - 0.5;
+        if (srcCenter >= -0.5
+            && srcCenter <= static_cast<double>(sourceBins) - 0.5) {
+            coverage[x] = quint8(1);
+        }
+    }
+    return coverage;
 }
 
 inline float estimateTraceFloorDbm(const QVector<float>& bins,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -53,6 +53,7 @@
 #include "models/SliceModel.h"
 
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <QFileDialog>
 #include <QPointer>
 #include <QSet>
@@ -73,6 +74,7 @@ constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 
 constexpr double kMemoryRevealTargetToleranceMhz = 0.000001;
 constexpr int kPanDimensionDecoderFallbackMs = 650;
+constexpr int kKiwiGestureViewUpdateMs = 100;
 constexpr qint64 kProfileLoadDimensionSettleMs = kPanDimensionDecoderFallbackMs + 100;
 
 int currentAutoSqlMarginDb()
@@ -1627,15 +1629,33 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
     };
 
+    auto kiwiGestureLastViewUpdate = std::make_shared<QElapsedTimer>();
+    const auto updateKiwiWaterfallViewForGesture =
+        [updateKiwiWaterfallView,
+         kiwiGestureLastViewUpdate](double centerMhz, double bandwidthMhz) {
+            const bool updateDue =
+                !kiwiGestureLastViewUpdate->isValid()
+                || kiwiGestureLastViewUpdate->elapsed()
+                       >= kKiwiGestureViewUpdateMs;
+            if (!updateDue) {
+                return;
+            }
+            updateKiwiWaterfallView(centerMhz, bandwidthMhz);
+            kiwiGestureLastViewUpdate->restart();
+        };
+
     const auto updateKiwiWaterfallViewUnlessDeferred =
-        [updateKiwiWaterfallView, sw](double centerMhz, double bandwidthMhz) {
+        [updateKiwiWaterfallView, updateKiwiWaterfallViewForGesture, sw,
+         kiwiGestureLastViewUpdate](double centerMhz, double bandwidthMhz) {
             if (sw && sw->waterfallViewUpdateDeferred()) {
                 return;
             }
             if (sw && sw->frequencyRangeGestureActive()) {
+                updateKiwiWaterfallViewForGesture(centerMhz, bandwidthMhz);
                 return;
             }
             updateKiwiWaterfallView(centerMhz, bandwidthMhz);
+            kiwiGestureLastViewUpdate->invalidate();
         };
 
     connect(sw, &SpectrumWidget::frequencyRangeChanged,
@@ -1643,20 +1663,36 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     connect(sw, &SpectrumWidget::frequencyRangeChangeRequested,
             this, updateKiwiWaterfallViewUnlessDeferred);
     connect(sw, &SpectrumWidget::centerChangeRequested,
-            this, [updateKiwiWaterfallView, sw](double centerMhz) {
+            this, [updateKiwiWaterfallView, updateKiwiWaterfallViewForGesture,
+                   sw, kiwiGestureLastViewUpdate](double centerMhz) {
                 if (!sw) {
                     return;
                 }
-                if (sw->panDragActive()
-                    || sw->frequencyRangeGestureActive()) {
+                if (sw->frequencyRangeGestureActive()) {
+                    return;
+                }
+                if (sw->panDragActive()) {
+                    updateKiwiWaterfallViewForGesture(centerMhz,
+                                                      sw->bandwidthMhz());
                     return;
                 }
                 updateKiwiWaterfallView(centerMhz, sw->bandwidthMhz());
+                kiwiGestureLastViewUpdate->invalidate();
             });
     connect(sw, &SpectrumWidget::panDragSettled,
-            this, updateKiwiWaterfallView);
+            this, [updateKiwiWaterfallView,
+                   kiwiGestureLastViewUpdate](double centerMhz,
+                                              double bandwidthMhz) {
+                updateKiwiWaterfallView(centerMhz, bandwidthMhz);
+                kiwiGestureLastViewUpdate->invalidate();
+            });
     connect(sw, &SpectrumWidget::frequencyRangeSettled,
-            this, updateKiwiWaterfallView);
+            this, [updateKiwiWaterfallView,
+                   kiwiGestureLastViewUpdate](double centerMhz,
+                                              double bandwidthMhz) {
+                updateKiwiWaterfallView(centerMhz, bandwidthMhz);
+                kiwiGestureLastViewUpdate->invalidate();
+            });
 
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3596,6 +3596,7 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_wfRowsSinceRateChange = 0;
     m_prevTileScanline.clear();
     m_kiwiSdrFftTrace.clear();
+    m_kiwiSdrFftFallbackSeedMask.clear();
     m_kiwiSdrLastWaterfallBins.clear();
     m_kiwiSdrLastWaterfallCenterMhz = 0.0;
     m_kiwiSdrLastWaterfallBandwidthMhz = 0.0;
@@ -3692,6 +3693,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.rowsSinceRateChange = m_wfRowsSinceRateChange;
     updated.prevTileScanline = std::move(m_prevTileScanline);
     updated.kiwiFftTrace = std::move(m_kiwiSdrFftTrace);
+    updated.kiwiFftFallbackSeedMask = std::move(m_kiwiSdrFftFallbackSeedMask);
     updated.kiwiLastWaterfallBins = std::move(m_kiwiSdrLastWaterfallBins);
     updated.kiwiLastWaterfallCenterMhz = m_kiwiSdrLastWaterfallCenterMhz;
     updated.kiwiLastWaterfallBandwidthMhz = m_kiwiSdrLastWaterfallBandwidthMhz;
@@ -3754,6 +3756,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_wfRowsSinceRateChange = restored.rowsSinceRateChange;
     m_prevTileScanline = std::move(restored.prevTileScanline);
     m_kiwiSdrFftTrace = std::move(restored.kiwiFftTrace);
+    m_kiwiSdrFftFallbackSeedMask = std::move(restored.kiwiFftFallbackSeedMask);
     m_kiwiSdrLastWaterfallBins = std::move(restored.kiwiLastWaterfallBins);
     m_kiwiSdrLastWaterfallCenterMhz = restored.kiwiLastWaterfallCenterMhz;
     m_kiwiSdrLastWaterfallBandwidthMhz = restored.kiwiLastWaterfallBandwidthMhz;
@@ -4260,6 +4263,8 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
         || !m_kiwiSdrFftTrace.isEmpty();
     if (oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
         m_resetFftSmoothingOnNextFrame = m_resetFftSmoothingOnNextFrame || hadSpectrum;
+        m_fftFallbackSeedMask.clear();
+        m_kiwiSdrFftFallbackSeedMask.clear();
         return hadSpectrum;
     }
 
@@ -4274,17 +4279,37 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
         // frame. Keep the last trace visible until the next real FFT row instead
         // of flashing the line off for one frame.
         m_resetFftSmoothingOnNextFrame = m_resetFftSmoothingOnNextFrame || hadSpectrum;
+        m_fftFallbackSeedMask.clear();
+        m_kiwiSdrFftFallbackSeedMask.clear();
         return hadSpectrum;
     }
 
-    auto reprojectBins = [&](QVector<float>& bins, float fallback) {
+    auto reprojectBins = [&](QVector<float>& bins, float fallback,
+                             QVector<quint8>* fallbackSeedMask = nullptr,
+                             bool extendFallbackEdges = false) {
         const int binCount = bins.size();
         if (binCount <= 0) {
+            if (fallbackSeedMask) {
+                fallbackSeedMask->clear();
+            }
             return;
         }
 
+        QVector<quint8> oldFallbackSeedMask;
+        if (fallbackSeedMask) {
+            oldFallbackSeedMask = std::move(*fallbackSeedMask);
+        }
+        const bool hadFallbackSeedMask = oldFallbackSeedMask.size() == binCount;
+
         const QVector<float> oldBins = std::move(bins);
         QVector<float> reprojected(binCount, fallback);
+        QVector<quint8> reprojectedFallbackSeedMask;
+        if (fallbackSeedMask) {
+            reprojectedFallbackSeedMask = QVector<quint8>(binCount, quint8(1));
+        }
+
+        int firstProjected = -1;
+        int lastProjected = -1;
 
         for (int dst = 0; dst < binCount; ++dst) {
             const double dstFrac = (static_cast<double>(dst) + 0.5) / binCount;
@@ -4299,19 +4324,51 @@ bool SpectrumWidget::reprojectSpectrum(double oldCenterMhz, double oldBandwidthM
             if (srcLeft < 0 || srcRight >= binCount) {
                 const int src = std::clamp(static_cast<int>(std::round(srcPos)), 0, binCount - 1);
                 reprojected[dst] = oldBins[src];
+                if (fallbackSeedMask) {
+                    reprojectedFallbackSeedMask[dst] =
+                        hadFallbackSeedMask ? oldFallbackSeedMask[src] : quint8(0);
+                }
+                if (firstProjected < 0) {
+                    firstProjected = dst;
+                }
+                lastProjected = dst;
                 continue;
             }
 
             const float t = static_cast<float>(srcPos - srcLeft);
             reprojected[dst] = oldBins[srcLeft] * (1.0f - t) + oldBins[srcRight] * t;
+            if (fallbackSeedMask) {
+                reprojectedFallbackSeedMask[dst] =
+                    hadFallbackSeedMask
+                    ? quint8(oldFallbackSeedMask[srcLeft] || oldFallbackSeedMask[srcRight])
+                    : quint8(0);
+            }
+            if (firstProjected < 0) {
+                firstProjected = dst;
+            }
+            lastProjected = dst;
+        }
+
+        if (extendFallbackEdges && firstProjected >= 0) {
+            for (int dst = 0; dst < firstProjected; ++dst) {
+                reprojected[dst] = reprojected[firstProjected];
+            }
+            for (int dst = lastProjected + 1; dst < binCount; ++dst) {
+                reprojected[dst] = reprojected[lastProjected];
+            }
         }
 
         bins = std::move(reprojected);
+        if (fallbackSeedMask) {
+            *fallbackSeedMask = std::move(reprojectedFallbackSeedMask);
+        }
     };
 
     reprojectBins(m_bins, m_refLevel - m_dynamicRange);
-    reprojectBins(m_smoothed, m_refLevel - m_dynamicRange);
-    reprojectBins(m_kiwiSdrFftTrace, kKiwiSdrWaterfallMinDbm);
+    reprojectBins(m_smoothed, m_refLevel - m_dynamicRange,
+                  &m_fftFallbackSeedMask, true);
+    reprojectBins(m_kiwiSdrFftTrace, kKiwiSdrWaterfallMinDbm,
+                  &m_kiwiSdrFftFallbackSeedMask, true);
     return !m_bins.isEmpty() || !m_smoothed.isEmpty()
         || !m_kiwiSdrFftTrace.isEmpty();
 }
@@ -5010,11 +5067,22 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     if (m_resetFftSmoothingOnNextFrame) {
         m_smoothed = *spectrumBins;
         m_resetFftSmoothingOnNextFrame = false;
+        m_fftFallbackSeedMask.clear();
     } else if (m_smoothed.size() != spectrumBins->size()) {
         m_smoothed = *spectrumBins;
+        m_fftFallbackSeedMask.clear();
     } else {
-        for (int i = 0; i < spectrumBins->size(); ++i)
-            m_smoothed[i] = SMOOTH_ALPHA * (*spectrumBins)[i] + (1.0f - SMOOTH_ALPHA) * m_smoothed[i];
+        const bool seedFallbackBins =
+            m_fftFallbackSeedMask.size() == spectrumBins->size();
+        for (int i = 0; i < spectrumBins->size(); ++i) {
+            if (seedFallbackBins && m_fftFallbackSeedMask[i]) {
+                m_smoothed[i] = (*spectrumBins)[i];
+            } else {
+                m_smoothed[i] = SMOOTH_ALPHA * (*spectrumBins)[i]
+                    + (1.0f - SMOOTH_ALPHA) * m_smoothed[i];
+            }
+        }
+        m_fftFallbackSeedMask.clear();
     }
     m_bins = *spectrumBins;
 
@@ -5374,6 +5442,7 @@ void SpectrumWidget::clearKiwiSdrWaterfallRows()
     m_kiwiWaterfallState = WaterfallStreamState{};
     m_kiwiProfileWaterfallStates.clear();
     m_kiwiSdrFftTrace.clear();
+    m_kiwiSdrFftFallbackSeedMask.clear();
     m_kiwiSdrFftTraceFloorDbm = -1000.0f;
     m_kiwiSdrFftTraceFloorValid = false;
     if (m_kiwiSdrWaterfallActive) {
@@ -5552,13 +5621,51 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
         QVector<float> kiwiTrace = KiwiSdrTraceMath::mapRowToTrace(
             smoothedBins, destWidth, rowCenterMhz, rowBandwidthMhz,
             m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
+        const QVector<quint8> kiwiTraceCoverage =
+            KiwiSdrTraceMath::mapRowCoverageMask(
+                smoothedBins.size(), destWidth, rowCenterMhz, rowBandwidthMhz,
+                m_centerMhz, m_bandwidthMhz);
         stabilizeKiwiSdrFftTrace(kiwiTrace, rowCanDriveAutoLevel);
         if (m_kiwiSdrFftTrace.size() != kiwiTrace.size()) {
             m_kiwiSdrFftTrace = kiwiTrace;
+            m_kiwiSdrFftFallbackSeedMask.clear();
         } else {
+            const bool seedFallbackBins =
+                m_kiwiSdrFftFallbackSeedMask.size() == kiwiTrace.size();
+            const bool hasCoverageMask = kiwiTraceCoverage.size() == kiwiTrace.size();
+            QVector<quint8> nextFallbackSeedMask;
+            if (seedFallbackBins) {
+                nextFallbackSeedMask = m_kiwiSdrFftFallbackSeedMask;
+            }
             for (int i = 0; i < kiwiTrace.size(); ++i) {
-                m_kiwiSdrFftTrace[i] = SMOOTH_ALPHA * kiwiTrace[i]
-                    + (1.0f - SMOOTH_ALPHA) * m_kiwiSdrFftTrace[i];
+                const bool pendingFallback =
+                    seedFallbackBins && m_kiwiSdrFftFallbackSeedMask[i];
+                if (hasCoverageMask && !kiwiTraceCoverage[i] && pendingFallback) {
+                    continue;
+                }
+                if (pendingFallback) {
+                    m_kiwiSdrFftTrace[i] = kiwiTrace[i];
+                    nextFallbackSeedMask[i] = quint8(0);
+                } else {
+                    m_kiwiSdrFftTrace[i] = SMOOTH_ALPHA * kiwiTrace[i]
+                        + (1.0f - SMOOTH_ALPHA) * m_kiwiSdrFftTrace[i];
+                }
+            }
+            if (seedFallbackBins) {
+                bool hasPendingFallback = false;
+                for (quint8 pending : nextFallbackSeedMask) {
+                    if (pending) {
+                        hasPendingFallback = true;
+                        break;
+                    }
+                }
+                if (hasPendingFallback) {
+                    m_kiwiSdrFftFallbackSeedMask = std::move(nextFallbackSeedMask);
+                } else {
+                    m_kiwiSdrFftFallbackSeedMask.clear();
+                }
+            } else {
+                m_kiwiSdrFftFallbackSeedMask.clear();
             }
         }
         if (!m_kiwiSdrFftTrace.isEmpty()) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -753,6 +753,7 @@ private:
         int rowsSinceRateChange{0};
         QVector<QRgb> prevTileScanline;
         QVector<float> kiwiFftTrace;
+        QVector<quint8> kiwiFftFallbackSeedMask;
         QVector<float> kiwiLastWaterfallBins;
         double kiwiLastWaterfallCenterMhz{0.0};
         double kiwiLastWaterfallBandwidthMhz{0.0};
@@ -895,9 +896,11 @@ private:
 
     QVector<float> m_bins;       // raw FFT frame (dBm)
     QVector<float> m_smoothed;   // exponential-smoothed for visual stability
+    QVector<quint8> m_fftFallbackSeedMask; // 1 = replace from next real FFT frame
     mutable QVector<float> m_fftDisplaySmoothScratch;
     mutable QVector<float> m_fftDisplayTraceScratch;
     QVector<float> m_kiwiSdrFftTrace;  // Kiwi-derived FFT trace, kept separate from Flex FFT
+    QVector<quint8> m_kiwiSdrFftFallbackSeedMask; // 1 = replace from next real Kiwi row
     bool m_shutdownPrepared{false};
     bool m_kiwiSdrWaterfallAvailable{false};
     bool m_kiwiSdrWaterfallActive{false};

--- a/tests/kiwi_sdr_trace_math_test.cpp
+++ b/tests/kiwi_sdr_trace_math_test.cpp
@@ -108,6 +108,19 @@ int main()
         return fail("3D-width Kiwi trace should align to the viewport frequency frame");
     }
 
+    const QVector<quint8> narrowCoverage = mapRowCoverageMask(
+        256, 128,
+        14.0, 0.5,
+        14.0, 1.0);
+    if (narrowCoverage.size() != 128
+        || narrowCoverage[0] != 0
+        || narrowCoverage[32] == 0
+        || narrowCoverage[64] == 0
+        || narrowCoverage[95] == 0
+        || narrowCoverage[127] != 0) {
+        return fail("narrow Kiwi row coverage should mark only bins covered by the server row");
+    }
+
     QVector<float> adaptingTrace(128, -80.0f);
     TraceFloorState adaptingFloor{-100.0f, true};
     stabilizeTraceFloor(adaptingTrace, adaptingFloor, true, kMinDbm, kMaxDbm);


### PR DESCRIPTION
## Summary

Fixes a spectrum trace artifact during pan/zoom where newly exposed FFT bins at the left or right edge could appear from the display floor and rise into place. Flex FFT reprojection now extends the nearest existing smoothed trace into temporary edge bins, then seeds only those placeholders from the next real FFT frame.

KiwiSDR uses the same idea with a separate trace mask, plus coverage-aware row updates so zoomed-out views do not treat uncovered server-row edges as real floor-level data before Kiwi sends rows for the wider span. KiwiSDR waterfall view requests are also sent during active pan/zoom gestures at a bounded cadence, so the server can start filling newly exposed edges before the mouse/trackpad gesture settles.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The change is limited to FFT trace reprojection/smoothing, KiwiSDR trace mapping, and bounded KiwiSDR waterfall-view updates during active pan/zoom gestures, with a focused regression test for narrow Kiwi rows inside a wider zoomed-out view.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR kiwi_sdr_trace_math_test --parallel`)
- [x] Behavior verified on KiwiSDR pan/zoom by user testing
- [x] Existing tests pass (`./build/kiwi_sdr_trace_math_test`)
- [x] Reproduction steps documented if user-reported bug

Additional validation:

- [x] `git diff --check`
- [x] `python3 tools/check_a11y.py` exits 0 with existing unrelated warning-only findings
- [x] Patch applies cleanly on top of PR #3975 merge checkout
- [x] GitHub reports the updated commit signature as verified

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
      (No docs needed for this transient rendering fix.)
- [x] Security-sensitive changes reference a GHSA if applicable
      (Not security-sensitive.)
