### PR TITLE
Keep KiwiSDR waterfall rows sharp

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5602,6 +5602,8 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
         m_kiwiSdrLastWaterfallFrameValid = true;
     }
 
+    // Keep the trace/3DSS smoothing local to those consumers; the scrolling
+    // waterfall below uses decoded bins so narrow Kiwi carriers stay sharp.
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
     if (m_kiwiSdrWaterfallActive && rowHasUsableTraceCoverage) {
         // 3DSS rows must be in the visible panadapter frequency frame. Raw Kiwi
@@ -5697,7 +5699,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             }
         }
     }
-    pushKiwiSdrWaterfallRow(smoothedBins, destWidth,
+    pushKiwiSdrWaterfallRow(binsDbm, destWidth,
                             rowCenterMhz, rowBandwidthMhz);
     if (visibleStream) {
         leanCappedUpdate();


### PR DESCRIPTION
## Summary

Fixes a KiwiSDR waterfall clarity regression where decoded waterfall rows were painted after the same horizontal/temporal smoothing used for the FFT trace and 3DSS. The trace/3DSS path still uses smoothed bins for stability, but the scrolling waterfall now paints from the raw decoded Kiwi row so narrow carriers stay crisp.

## Constitution principle honored

Principle IV — the change stays within AetherSDR's clean-room KiwiSDR implementation and uses only local decoded protocol data, not upstream Kiwi source.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real receiver if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local validation:
- `cmake --build build --target AetherSDR kiwi_sdr_protocol_test kiwi_sdr_trace_math_test dss_renderer_test -- -j4`
- `ctest --test-dir build -R '^(kiwi_sdr_protocol_test|kiwi_sdr_trace_math_test|dss_renderer_test)$' --output-on-failure`
- `git diff --check HEAD~1 HEAD`
- `python3 tools/check_a11y.py` exits 0 with pre-existing warnings outside this change

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed (not needed: visual bug fix only)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)
