### PR TITLE
fix(kiwisdr): release idle KiwiSDR connections when a slice unassigns (#3950)

### DIFF
--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -455,6 +455,15 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
         << "freq=" << frequencyMhz << "MHz mode=" << mode;
     emit sliceAssignmentChanged(sliceId, profileId);
 
+    // Release the previous Kiwi's user slot once nothing uses it. Checked
+    // after the insert above: shouldMaintainProfileConnection() reads
+    // m_sliceAssignments, which still mapped sliceId -> previousProfile at
+    // the mute block.
+    if (!previousProfile.isEmpty() && previousProfile != profileId
+        && !shouldMaintainProfileConnection(previousProfile)) {
+        disconnectProfile(previousProfile);
+    }
+
     if (KiwiSdrClient* c = ensureClient(profileId)) {
         Q_UNUSED(c);
         m_clientHasTrackedSlice.insert(profileId, sliceId >= 0 && frequencyMhz > 0.0);
@@ -489,6 +498,12 @@ void KiwiSdrManager::clearSliceAssignment(int sliceId)
         });
     }
     emit sliceAssignmentChanged(sliceId, QString());
+
+    // The take() above already dropped this slice's mapping, so the
+    // predicate only keeps the Kiwi alive for auto-connect or another slice.
+    if (!shouldMaintainProfileConnection(previousProfile)) {
+        disconnectProfile(previousProfile);
+    }
 }
 
 void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,


### PR DESCRIPTION
## Summary
Switching a slice off a Kiwi profile — or clearing the Kiwi RX antenna entirely — only muted the previous profile's audio; its WebSocket stayed open until app quit, squatting one of the receiver's limited user slots (4–8 on most public Kiwis) and silently burning the operator's per-IP daily time budget. This PR gates an idle-disconnect on the existing `shouldMaintainProfileConnection()` policy in both unassign paths, reusing the existing `disconnectProfile()` teardown. 15 lines, no new code paths.

## Why
- Public Kiwis have small user caps — an idle squatted slot denies other operators access.
- Many enforce per-IP time limits; a never-released connection keeps consuming the budget while idle and can lock the operator out of reconnecting.
- The policy predicate and the teardown primitive both already existed; they simply weren't consulted when an assignment went away.

## Scope
- 15 insertions in `src/core/KiwiSdrManager.cpp`, two call sites:
  - `clearSliceAssignment()` — the `take()` at the top already dropped the mapping, so the gated disconnect sits at the end of the function.
  - `assignSliceToProfile()` — **placement matters**: the predicate reads `m_sliceAssignments`, which still maps `sliceId → previousProfile` at the mute block, so the gated disconnect goes after the `insert()` (per the ordering caveat in the issue triage). At the mute block it would always be suppressed.
- No protocol / persistence / UX change. Auto-connect profiles keep their connection by design (predicate short-circuit).
- Follow-up candidate (per issue discussion, deliberately not in this PR): a short grace timer so rapid A/B comparison doesn't pay the slow Kiwi handshake (#3816) on every flip.

## Constitution principle honored
**Principle XI — Fixes Are Demonstrated.** The fix is proven with a live before/after A/B on real public KiwiSDRs (below), asserting on OS socket tables and the bridge's `get kiwi` state — not on the patch reading correctly. Also serves **VIII (Evidence Over Assertion)**.

## Test plan
- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] **Live A/B, driven headless via the automation bridge** (`slice rxsource`, `QT_QPA_PLATFORM=offscreen`) against a FLEX-6700 (SmartSDR v1.4.0.0) and two `ext_api`-permitting public Kiwis (Cassine IT, Carlow IE), asserting `ss` socket tables + `get kiwi` state:

| Step | v26.7.1 baseline | patched |
|---|---|---|
| assign Kiwi A | A connected (SND+WF sockets) | same |
| switch slice A→B | **4 sockets — A leaked**, `state=connected, assignedSlice=-1` | **2 sockets — "Disconnecting TestKiwiA"**, A `disconnected` |
| clear to Flex | **4 sockets — both squatting** | **0 sockets — both released** |

- [x] **Auto-connect guard:** with `autoConnect=true` on Kiwi A, it survives both switch-away and clear (slot intentionally kept); the plain profile still releases immediately.
- [x] Kiwi operators' `ext_api` policy preflight unaffected (verified a disallowing Kiwi still refuses cleanly).
- [ ] Optional maintainer smoke: A/B two Kiwis from the GUI RX-antenna menu; the previous Kiwi's user count on its `/users` page drops on switch.

## Checklist
- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — n/a, no meter UI touched

Closes #3950

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — drafted with Don, our VP of Engineering agent, on Linux dev stack (`nobara-dell`), live-verified against a FLEX-6700 and public KiwiSDRs. (model: claude-fable-5)