### PR TITLE
fix(spectrum): make AETHER_NO_GPU select OpenGL backend on Windows (#3597)

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -896,6 +896,17 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         setAttribute(Qt::WA_NativeWindow);
     }
 #  else
+    // AETHER_NO_GPU / QT_OPENGL=software: force the OpenGL QRhi backend so the
+    // software OpenGL rasterizer requested in main.cpp actually takes effect.
+    // Without this, QRhiWidget defaults to D3D11 on Windows and ignores
+    // QT_OPENGL entirely, making the flag a silent no-op there (#3597). On Linux
+    // the default backend is already OpenGL, so this is a harmless explicit
+    // restatement that keeps the two platforms on the same code path.
+    if (qtSoftwareOpenGlRequested()) {
+        setApi(QRhiWidget::Api::OpenGL);
+        qInfo() << "SpectrumWidget: AETHER_NO_GPU/QT_OPENGL=software — forcing "
+                   "OpenGL QRhi backend (software rasterizer) instead of D3D11";
+    }
     // Warn if running under XWayland — GLX context switching between the main
     // window and child dialogs (e.g. Radio Setup) can trigger BadAccess (#1233).
     // main.cpp normally forces native Wayland, but log it if we ended up here.


### PR DESCRIPTION
## Summary

`AETHER_NO_GPU=1` is documented as the runtime escape hatch to force software rendering, but **on Windows it is a silent no-op**. `main.cpp` only sets `QT_OPENGL=software`, which is an OpenGL-context hint — but the spectrum is a `QRhiWidget` that has no `setApi()` call on Windows, so it defaults to the **D3D11** backend and ignores `QT_OPENGL` entirely. There is no runtime path to move the spectrum off the GPU.

This surfaced in #3597: on a weak GPU (reporter's GeForce GT 220, a 2009 DX10.1 part) the D3D11 QRhi spectrum + waterfall + overlay pipeline saturates the GPU (~89%), and setting `AETHER_NO_GPU=1` changed nothing — confirmed by the reporter.

## Change

In the `SpectrumWidget` constructor's non-macOS branch, when software OpenGL is requested (`qtSoftwareOpenGlRequested()`), explicitly `setApi(QRhiWidget::Api::OpenGL)`. Combined with the `QT_OPENGL=software` set in `main.cpp`, this drives the spectrum through the software OpenGL rasterizer instead of D3D11.

- The bundled `.qsb` shaders already contain GLSL variants (GLSL 100es/120/150 alongside SPIR-V/HLSL/MSL), so pipeline creation succeeds on the OpenGL backend.
- **No behavior change on Linux**, whose `QRhiWidget` default backend is already OpenGL — this just makes the two platforms share one explicit code path.

`src/gui/SpectrumWidget.cpp` — 1 file, ~10 lines (comment + guarded `setApi`).

## Scope / what this does NOT claim

- This makes the `AETHER_NO_GPU=1` flag **functional on Windows** (review suggestion #1 from #3597). It does **not** by itself resolve the performance complaint on weak GPU **and** CPU hardware — software-rendering a 60 fps per-pixel GPU FFT pipeline on a 2009 CPU will likely just move saturation from GPU to CPU. The proper lever for that (an FFT-FPS cap / present throttle, suggestion #2) remains tracked separately.

## Testing

- ⚠️ **Windows-specific and unverifiable in CI / on Linux** — the failure only occurs on Windows (D3D11 default); on Linux the flag already works because the backend defaults to OpenGL.
- Needs the #3597 reporter (@EA7JQA, GeForce GT 220) to launch with `AETHER_NO_GPU=1` and confirm the panadapter renders and the renderer reports the OpenGL/software backend (visible in panstats `renderer`), and to report the resulting CPU/GPU load.

Refs #3597

🤖 Generated with [Claude Code](https://claude.com/claude-code)