### PR TITLE
fix(cwx): gate F1-F12 macro/playback fire on panel visibility (#3514)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2331,6 +2331,29 @@ target_link_libraries(cwx_panel_test PRIVATE
     Qt6::Core Qt6::Widgets
 )
 
+add_executable(dvk_panel_test
+    tests/dvk_panel_test.cpp
+    # DvkPanel references DvkWavTransfer (upload/download + signals); the real
+    # impl pulls in RadioModel + the radio stack, so we link a no-op stub and
+    # let AUTOMOC generate the signal code from the header. (#3514)
+    tests/dvk_wav_transfer_stub.cpp
+    src/gui/DvkPanel.cpp
+    src/gui/DvkPanel.h
+    src/models/DvkModel.cpp
+    src/models/DvkModel.h
+    src/core/DvkWavTransfer.h
+    # DvkPanel.cpp calls ThemeManager::resolve(); pull in the manager + its
+    # logging deps so the test links (same set as cwx_panel_test).
+    src/core/ThemeManager.cpp
+    src/core/AppSettings.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(dvk_panel_test PRIVATE src)
+target_link_libraries(dvk_panel_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Network
+)
+
 add_executable(meter_model_test
     tests/meter_model_test.cpp
     src/models/MeterModel.cpp

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -508,17 +508,24 @@ void CwxPanel::setShortcutsEnabled(bool enabled)
 // ApplicationShortcuts and, directly, by the #3514 regression test.
 void CwxPanel::fireMacro(int index)
 {
-    if (!m_model || index < 0 || index >= 12) return;
+    if (!m_model || index < 0 || index >= 12) {
+        return;
+    }
     // #3514: a hidden CWX keyer must not transmit stored macros on an
-    // accidental F-key press. Gated here rather than in the shortcut
-    // enable state so the Qt "one enabled shortcut per key" invariant
-    // (#2464/#2582) stays intact — the shortcut still activates; the
-    // fire just returns early.
-    if (!isVisible()) return;
+    // accidental F-key press (keyboard F1-F12 path; the FlexControl/MIDI
+    // macro action is a deliberate physical press and fires at the model
+    // layer without this gate — see MainWindow_Controllers "CwxF"). Gated
+    // here rather than in the shortcut enable state so the Qt "one enabled
+    // shortcut per key" invariant (#2464/#2582) stays intact — the shortcut
+    // still activates; the fire just returns early.
+    if (!isVisible()) {
+        return;
+    }
     if (m_activeModeProvider) {
         const QString mode = m_activeModeProvider();
-        if (mode != QLatin1String("CW") && mode != QLatin1String("CWL"))
+        if (mode != QLatin1String("CW") && mode != QLatin1String("CWL")) {
             return;
+        }
     }
     // Log the macro text to the history feed BEFORE firing the command so
     // the snapshot of m_model->sentIndex() lines up with the chars about

--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -242,27 +242,20 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
     //
     //    Created disabled; MainWindow flips enable state based on the
     //    active slice's mode (mutually exclusive with DvkPanel's F1-F12
-    //    set) so the keys fire regardless of panel visibility, while
-    //    Qt still sees at most one enabled ApplicationShortcut per key
-    //    and never emits activatedAmbiguously. (#2464, #2582)
+    //    set) so Qt still sees at most one enabled ApplicationShortcut
+    //    per key and never emits activatedAmbiguously. (#2464, #2582)
+    //
+    //    The macro fire (fireMacro) is additionally gated on panel
+    //    visibility at fire time: a hidden CWX keyer must not transmit
+    //    stored macros on an accidental F-key press. The gate lives in
+    //    fireMacro rather than the enable state so the Qt-level "one
+    //    enabled shortcut per key" invariant above stays intact. (#3514)
     for (int i = 0; i < 12; ++i) {
         auto* sc = new QShortcut(Qt::Key_F1 + i, window());
         sc->setContext(Qt::ApplicationShortcut);
         sc->setEnabled(false);
         m_shortcuts.append(sc);
-        connect(sc, &QShortcut::activated, this, [this, i]() {
-            if (!m_model) return;
-            if (m_activeModeProvider) {
-                const QString mode = m_activeModeProvider();
-                if (mode != QLatin1String("CW") && mode != QLatin1String("CWL"))
-                    return;
-            }
-            // Log the macro text to the history feed BEFORE firing the
-            // command so the snapshot of m_model->sentIndex() lines up
-            // with the chars about to be keyed for this bubble. (#3146)
-            appendHistoryBubble(m_model->macro(i));
-            m_model->sendMacro(i + 1);
-        });
+        connect(sc, &QShortcut::activated, this, [this, i]() { fireMacro(i); });
     }
 
     // ── ESC — abort CW transmission.  Fires unconditionally: during a CW
@@ -509,6 +502,29 @@ int CwxPanel::historyBubbleCount() const
 void CwxPanel::setShortcutsEnabled(bool enabled)
 {
     for (auto* sc : m_shortcuts) sc->setEnabled(enabled);
+}
+
+// Fire the stored macro for F(index+1). Invoked by the F1-F12
+// ApplicationShortcuts and, directly, by the #3514 regression test.
+void CwxPanel::fireMacro(int index)
+{
+    if (!m_model || index < 0 || index >= 12) return;
+    // #3514: a hidden CWX keyer must not transmit stored macros on an
+    // accidental F-key press. Gated here rather than in the shortcut
+    // enable state so the Qt "one enabled shortcut per key" invariant
+    // (#2464/#2582) stays intact — the shortcut still activates; the
+    // fire just returns early.
+    if (!isVisible()) return;
+    if (m_activeModeProvider) {
+        const QString mode = m_activeModeProvider();
+        if (mode != QLatin1String("CW") && mode != QLatin1String("CWL"))
+            return;
+    }
+    // Log the macro text to the history feed BEFORE firing the command so
+    // the snapshot of m_model->sentIndex() lines up with the chars about
+    // to be keyed for this bubble. (#3146)
+    appendHistoryBubble(m_model->macro(index));
+    m_model->sendMacro(index + 1);
 }
 
 void CwxPanel::onCharSent(int index)

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -70,8 +70,10 @@ public:
     }
 
     // Enable/disable the F1-F12 and Esc ApplicationShortcuts. Driven by
-    // the active slice's mode in MainWindow, so the keys fire whether
-    // the panel is visible or not. (#2582)
+    // the active slice's mode in MainWindow. Esc (CW-abort) fires whether
+    // the panel is visible or not; the F1-F12 macro fires are additionally
+    // gated on panel visibility at fire time so a hidden keyer can't
+    // transmit stored macros. (#2582, #3514)
     void setShortcutsEnabled(bool enabled);
 
     // Inspection accessors for the in-flight bubble — used by tests to
@@ -79,6 +81,12 @@ public:
     // without re-walking the history container ourselves.
     CwxBubble* pendingBubble() const { return m_pendingBubble; }
     int        historyBubbleCount() const;
+
+    // Test seam: fire the F(index+1) macro exactly as its ApplicationShortcut
+    // does, including the visibility/mode guards, so the #3514 regression
+    // test can exercise the guard without Qt shortcut dispatch (which won't
+    // route to a hidden widget headlessly). (0-based: 0=F1, 11=F12)
+    void fireMacroForTest(int index) { fireMacro(index); }
 
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
@@ -89,6 +97,7 @@ private slots:
     void onTransmissionCancelled();
 
 private:
+    void fireMacro(int index);   // #3514: guarded F1-F12 macro fire (0-based)
     void buildSendView();
     void buildSetupView();
     void showSendView();
@@ -135,9 +144,9 @@ private:
     std::function<bool()>    m_transmittingProvider;
 
     // F1-F12 + ESC shortcuts — enabled by MainWindow based on the active
-    // slice's mode so they fire regardless of panel visibility, while
-    // staying mutually exclusive with DvkPanel's F1-F12 set to avoid Qt
-    // shortcut ambiguity (#2464, #2582).
+    // slice's mode, staying mutually exclusive with DvkPanel's F1-F12 set
+    // to avoid Qt shortcut ambiguity (#2464, #2582). The macro fires are
+    // additionally gated on panel visibility at fire time (#3514).
     QVector<QShortcut*> m_shortcuts;
 };
 

--- a/src/gui/DvkPanel.cpp
+++ b/src/gui/DvkPanel.cpp
@@ -222,24 +222,17 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
     // flips enable state based on the active slice's mode (mutually
     // exclusive with CwxPanel's F1-F12 set) so Qt still sees at most one
     // enabled shortcut per key and never emits activatedAmbiguously
-    // (#2464, #2582). The playback fire is additionally gated on panel
+    // (#2464, #2582). The playback START is additionally gated on panel
     // visibility at fire time so a hidden DVK can't transmit a stored
-    // voice message on an accidental F-key press. (#3514)
+    // voice message on an accidental F-key press; the STOP path stays
+    // reachable while hidden so an in-flight transmission can always be
+    // killed (see firePlayback). (#3514)
     for (int i = 0; i < 12; ++i) {
         auto* sc = new QShortcut(QKeySequence(Qt::Key_F1 + i), window());
         sc->setContext(Qt::ApplicationShortcut);
         sc->setEnabled(false);
         m_shortcuts.append(sc);
-        connect(sc, &QShortcut::activated, this, [this, i]() {
-            // #3514: don't fire stored voice messages when the panel is hidden.
-            if (!isVisible()) return;
-            int id = i + 1;
-            selectSlot(id);
-            if (m_model->status() == DvkModel::Playback && m_model->activeId() == id)
-                m_model->playbackStop(id);
-            else if (durationForSlot(id) > 0)
-                m_model->playbackStart(id);
-        });
+        connect(sc, &QShortcut::activated, this, [this, i]() { firePlayback(i + 1); });
     }
 
     // Escape: cancel rename if active, otherwise stop DVK operation.
@@ -274,6 +267,32 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
 void DvkPanel::setShortcutsEnabled(bool enabled)
 {
     for (auto* sc : m_shortcuts) sc->setEnabled(enabled);
+}
+
+// Fire the F(id) playback slot. Invoked by the F1-F12 ApplicationShortcuts
+// and, directly, by the #3514 regression test.
+void DvkPanel::firePlayback(int id)
+{
+    if (!m_model) {
+        return;
+    }
+    // #3514: a hidden DVK must not START a stored voice message on an
+    // accidental F-key press — but STOPPING an in-flight transmission must
+    // stay reachable regardless of visibility (same reasoning as the ungated
+    // ESC/CW-abort exemption, #1552: abort paths must always be usable).
+    // Gated here rather than in the shortcut enable state so the Qt "one
+    // enabled shortcut per key" invariant (#2464/#2582) stays intact.
+    const bool stopping = m_model->status() == DvkModel::Playback
+                          && m_model->activeId() == id;
+    if (!isVisible() && !stopping) {
+        return;
+    }
+    selectSlot(id);
+    if (stopping) {
+        m_model->playbackStop(id);
+    } else if (durationForSlot(id) > 0) {
+        m_model->playbackStart(id);
+    }
 }
 
 void DvkPanel::selectSlot(int id)

--- a/src/gui/DvkPanel.cpp
+++ b/src/gui/DvkPanel.cpp
@@ -220,15 +220,19 @@ DvkPanel::DvkPanel(DvkModel* model, QWidget* parent)
     // F1-F12 hotkeys (only play if slot has a recording).  Registered as
     // Qt::ApplicationShortcut on window() and created disabled — MainWindow
     // flips enable state based on the active slice's mode (mutually
-    // exclusive with CwxPanel's F1-F12 set) so the keys fire regardless of
-    // panel visibility while Qt still sees at most one enabled shortcut
-    // per key and never emits activatedAmbiguously. (#2464, #2582)
+    // exclusive with CwxPanel's F1-F12 set) so Qt still sees at most one
+    // enabled shortcut per key and never emits activatedAmbiguously
+    // (#2464, #2582). The playback fire is additionally gated on panel
+    // visibility at fire time so a hidden DVK can't transmit a stored
+    // voice message on an accidental F-key press. (#3514)
     for (int i = 0; i < 12; ++i) {
         auto* sc = new QShortcut(QKeySequence(Qt::Key_F1 + i), window());
         sc->setContext(Qt::ApplicationShortcut);
         sc->setEnabled(false);
         m_shortcuts.append(sc);
         connect(sc, &QShortcut::activated, this, [this, i]() {
+            // #3514: don't fire stored voice messages when the panel is hidden.
+            if (!isVisible()) return;
             int id = i + 1;
             selectSlot(id);
             if (m_model->status() == DvkModel::Playback && m_model->activeId() == id)

--- a/src/gui/DvkPanel.h
+++ b/src/gui/DvkPanel.h
@@ -28,6 +28,13 @@ public:
     // to avoid Qt shortcut ambiguity. (#2582)
     void setShortcutsEnabled(bool enabled);
 
+    // Test seam: fire the F(id) playback exactly as its ApplicationShortcut
+    // does, including the #3514 visibility guard (and its stop-exemption), so
+    // the regression test can exercise the guarded path without Qt shortcut
+    // dispatch (which won't route to a hidden widget headlessly). Mirrors
+    // CwxPanel::fireMacroForTest. (1-based: 1=F1, 12=F12)
+    void firePlaybackForTest(int id) { firePlayback(id); }
+
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
 
@@ -66,6 +73,7 @@ private:
     QVector<QShortcut*> m_shortcuts;
 
     void selectSlot(int id);
+    void firePlayback(int id);   // #3514: guarded F1-F12 playback fire (1-based)
     void showContextMenu(int id, const QPoint& globalPos);
     void startRename(int id);
     void commitRename();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7464,9 +7464,12 @@ void MainWindow::updateKeyerAvailability(const QString& mode)
                   || mode == "FM" || mode == "NFM" || mode == "DFM");
 
     // F1-F12 / Esc ApplicationShortcuts: enable the set that matches the
-    // active slice's mode, regardless of panel visibility.  The two sets
-    // are mutually exclusive so Qt never sees two enabled shortcuts for
-    // the same key and won't emit activatedAmbiguously (#2464, #2582).
+    // active slice's mode.  The two sets are mutually exclusive so Qt
+    // never sees two enabled shortcuts for the same key and won't emit
+    // activatedAmbiguously (#2464, #2582).  The F1-F12 macro/playback
+    // fires are additionally gated on panel visibility inside each panel
+    // so a hidden keyer can't transmit on an accidental press (#3514);
+    // Esc (CW-abort) still fires whenever the slice is in a CW mode.
     if (m_cwxPanel) m_cwxPanel->setShortcutsEnabled(isCw);
     if (m_dvkPanel) m_dvkPanel->setShortcutsEnabled(isSsb);
 

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -170,6 +170,47 @@ void testSetupTurnsLiveOff()
            !f.model.isLive() && !live->isChecked() && setup->isChecked());
 }
 
+// #3514: the F1-F12 macro fire must not transmit a stored macro when the
+// CWX panel is hidden, even though the active slice is in a CW mode (so the
+// ApplicationShortcut is enabled). The guard lives in fireMacro(), not in
+// the shortcut enable state, so the "one enabled shortcut per key" invariant
+// (#2464/#2582) stays intact — the shortcut still activates while hidden;
+// the fire just returns early.
+//
+// We drive fireMacroForTest() directly rather than synthesizing an F-key
+// press. In the real app the shortcut's owner is window() == MainWindow,
+// which stays visible when the panel is hidden, so the ApplicationShortcut
+// still dispatches and the fireMacro() guard is what blocks the transmit.
+// In this test the panel has no parent, so window() resolves to the panel
+// itself; hiding it hides the shortcut owner and suppresses dispatch
+// entirely — a key-event test would then pass whether or not the guard
+// exists (a false pass). The seam exercises the exact guarded path.
+void testMacroBlockedWhenPanelHidden()
+{
+    Fixture f;
+    f.panel.setActiveModeProvider([]() { return QString("CW"); });
+    f.panel.setShortcutsEnabled(true);   // as MainWindow does in CW mode
+
+    // Panel hidden (never shown): F1 must NOT fire the macro.
+    f.panel.fireMacroForTest(0);
+    report("F1 does not fire macro when CWX panel hidden", f.commands.isEmpty(),
+           f.commands.isEmpty() ? "" : ("fired: " + f.commands.join(',').toStdString()));
+
+    // Panel visible + CW: F1 fires the macro.
+    f.panel.show();
+    f.panel.fireMacroForTest(0);
+    report("F1 fires macro when CWX panel visible",
+           f.commands == QStringList{"cwx macro send 1"},
+           f.commands.join(',').toStdString());
+    f.commands.clear();
+
+    // Panel visible but active slice not in a CW mode: still blocked.
+    f.panel.setActiveModeProvider([]() { return QString("USB"); });
+    f.panel.fireMacroForTest(0);
+    report("F1 does not fire macro in non-CW mode", f.commands.isEmpty(),
+           f.commands.isEmpty() ? "" : ("fired: " + f.commands.join(',').toStdString()));
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -182,6 +223,7 @@ int main(int argc, char** argv)
     testEnterStillSendsWhenLiveOff();
     testSendButtonTurnsLiveOffWithoutDuplicateSend();
     testSetupTurnsLiveOff();
+    testMacroBlockedWhenPanelHidden();
 
     std::printf("\n%s\n",
                 g_failed == 0

--- a/tests/dvk_panel_test.cpp
+++ b/tests/dvk_panel_test.cpp
@@ -1,0 +1,145 @@
+// Focused DVK panel behavior tests.
+// Run: ./build/dvk_panel_test
+
+#include "gui/DvkPanel.h"
+#include "models/DvkModel.h"
+
+#include <QApplication>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-56s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) ++g_failed;
+}
+
+struct Fixture {
+    DvkModel model;
+    DvkPanel panel{&model};
+    QStringList commands;
+
+    Fixture()
+    {
+        // Playback commands are emitted via replyCommandReady (they need
+        // response correlation); capture the raw command string.
+        QObject::connect(&model, &DvkModel::replyCommandReady,
+                         [this](const QString& cmd, const QString&, int) {
+                             commands.push_back(cmd);
+                         });
+    }
+
+    // Give slot `id` a recording so durationForSlot(id) > 0 — otherwise the
+    // START branch is a no-op regardless of the visibility guard.
+    void addRecording(int id, int durationMs)
+    {
+        QMap<QString, QString> kvs;
+        kvs.insert("id", QString::number(id));
+        kvs.insert("duration", QString::number(durationMs));
+        model.applyStatus("dvk", kvs);
+    }
+
+    // Drive the model into Playback state for slot `id`, as a radio status
+    // push would (dvk status=playback id=N enabled=1).
+    void setPlaying(int id)
+    {
+        QMap<QString, QString> kvs;
+        kvs.insert("status", "playback");
+        kvs.insert("id", QString::number(id));
+        kvs.insert("enabled", "1");
+        model.applyStatus("dvk", kvs);
+    }
+};
+
+// #3514: the F1-F12 playback fire must not START a stored voice message when
+// the DVK panel is hidden, even though the active slice's mode leaves the
+// ApplicationShortcut enabled. The guard lives in firePlayback(), not in the
+// shortcut enable state, so the "one enabled shortcut per key" invariant
+// (#2464/#2582) stays intact — the shortcut still activates while hidden; the
+// fire just returns early.
+//
+// We drive firePlaybackForTest() directly rather than synthesizing an F-key
+// press, for the same reason cwx_panel_test does: the panel is unparented, so
+// window() resolves to the panel itself; hiding it hides the shortcut owner
+// and suppresses dispatch entirely — a key-event test would then pass whether
+// or not the guard exists (a false pass). The seam exercises the guarded path.
+void testPlaybackBlockedWhenPanelHidden()
+{
+    Fixture f;
+    f.addRecording(1, 5000);
+    f.panel.setShortcutsEnabled(true);  // as MainWindow does when enabled
+
+    // Panel hidden (never shown): F1 must NOT start playback.
+    f.panel.firePlaybackForTest(1);
+    report("F1 does not start playback when DVK panel hidden",
+           f.commands.isEmpty(),
+           f.commands.isEmpty() ? "" : ("fired: " + f.commands.join(',').toStdString()));
+
+    // Panel visible: F1 starts playback of the stored slot.
+    f.panel.show();
+    f.panel.firePlaybackForTest(1);
+    report("F1 starts playback when DVK panel visible",
+           f.commands == QStringList{"dvk playback_start id=1"},
+           f.commands.join(',').toStdString());
+    f.commands.clear();
+}
+
+// #3514 (review follow-up): STOPPING an in-flight transmission must stay
+// reachable even with the panel hidden — otherwise a voice message started
+// while visible can no longer be F-key-stopped after the panel is closed,
+// and the radio keeps transmitting. This mirrors the ungated ESC/CW-abort
+// exemption (#1552): abort paths must always be usable.
+void testPlaybackStopReachableWhenHidden()
+{
+    Fixture f;
+    f.addRecording(1, 5000);
+    f.panel.setShortcutsEnabled(true);
+    f.panel.show();
+
+    // Start playback while visible.
+    f.panel.firePlaybackForTest(1);
+    report("playback started while visible",
+           f.commands == QStringList{"dvk playback_start id=1"},
+           f.commands.join(',').toStdString());
+    f.commands.clear();
+
+    // Radio confirms it is now playing slot 1, then the panel is hidden.
+    f.setPlaying(1);
+    f.panel.hide();
+
+    // F1 while hidden must STOP the in-flight transmission, not be swallowed.
+    f.panel.firePlaybackForTest(1);
+    report("F1 stops in-flight playback even when DVK panel hidden",
+           f.commands == QStringList{"dvk playback_stop id=1"},
+           f.commands.isEmpty() ? "(nothing fired — stop was swallowed)"
+                                : f.commands.join(',').toStdString());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    std::printf("DVK panel behavior test harness\n\n");
+
+    testPlaybackBlockedWhenPanelHidden();
+    testPlaybackStopReachableWhenHidden();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : (std::to_string(g_failed) + " test(s) failed.").c_str());
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/dvk_wav_transfer_stub.cpp
+++ b/tests/dvk_wav_transfer_stub.cpp
@@ -1,0 +1,38 @@
+// Minimal DvkWavTransfer stub for dvk_panel_test.
+//
+// DvkPanel references DvkWavTransfer (upload/download + its signals), but the
+// real implementation drags in RadioModel + RadioConnection + the whole radio
+// command stack. The #3514 playback-visibility regression never touches WAV
+// transfer, so we satisfy the linker with no-op definitions and let AUTOMOC
+// generate the signal/metaobject code from the header. This keeps the test's
+// link list as light as cwx_panel_test's.
+#include "core/DvkWavTransfer.h"
+
+namespace AetherSDR {
+
+DvkWavTransfer::DvkWavTransfer(RadioModel* model, QObject* parent)
+    : QObject(parent), m_model(model)
+{
+}
+
+DvkWavTransfer::~DvkWavTransfer() = default;
+
+void DvkWavTransfer::download(int, const QString&) {}
+void DvkWavTransfer::upload(int, const QString&) {}
+void DvkWavTransfer::cancel() {}
+bool DvkWavTransfer::validateWavFile(const QString&, QString&) { return false; }
+
+void DvkWavTransfer::onDownloadPortReceived(int, const QString&) {}
+void DvkWavTransfer::onNewConnection() {}
+void DvkWavTransfer::onReadyRead() {}
+void DvkWavTransfer::onDownloadFinished() {}
+void DvkWavTransfer::onDownloadError() {}
+void DvkWavTransfer::onUploadPortReceived(int, const QString&) {}
+void DvkWavTransfer::onUploadConnected() {}
+void DvkWavTransfer::onUploadBytesWritten(qint64) {}
+void DvkWavTransfer::onUploadError() {}
+void DvkWavTransfer::sendNextChunk() {}
+void DvkWavTransfer::cleanup(bool) {}
+void DvkWavTransfer::finish(bool, const QString&, bool) {}
+
+} // namespace AetherSDR


### PR DESCRIPTION
Fixes #3514.

## Problem
The F1–F12 macro shortcuts are `Qt::ApplicationShortcut`s owned by `window()` (the MainWindow), so they dispatch whenever the **active slice** is in a CW mode — independent of whether the CWX panel is open. Pressing F1 with the panel closed fired the stored macro and keyed TX (the reporter's "I accidentally pressed F1 and it started sending"). `DvkPanel` had the identical pattern for voice-message playback.

## Fix
Gate the fire on the panel's own `isVisible()` **at fire time**, inside the fire path (`CwxPanel::fireMacro` / `DvkPanel`'s F-key lambda) rather than in the shortcut enable state.

- Keeps the Qt "one enabled shortcut per key" / `activatedAmbiguously` invariant (#2464/#2582) intact — the shortcut still activates; the fire just returns early. Gating on the enable state (bundled with ESC in `m_shortcuts`) would have disturbed that invariant and required re-running `updateKeyerAvailability()` on every panel toggle, which the indicator handler doesn't currently do.
- **ESC (CW-abort) is deliberately left firing** whenever the slice is in a CW mode, per #1552, so an in-flight macro can still be aborted with the panel hidden.
- Symmetric guard applied to DVK (voice playback) since it shares the pattern.
- Corrected the now-stale "fire regardless of panel visibility" comments in `CwxPanel.{h,cpp}`, `DvkPanel.cpp`, and `MainWindow.cpp`.

## Tests
Added a deterministic regression test to `cwx_panel_test.cpp` driving a `fireMacroForTest` seam: hidden → no fire; visible+CW → fires; visible+non-CW → no fire. Verified by **mutation** that the hidden-case assertion fails when the `isVisible()` guard is removed. `cwx_panel_test` builds, links, and passes.

## Notes / limitations
- I could **not** run the full app end-to-end: the main `AetherSDR` binary link fails on a pre-existing missing `/usr/lib64/libasan.so.8.0.0` (ASan runtime absent in my environment), unrelated to this change. All edited translation units compile cleanly; the logic is exercised by `cwx_panel_test`.
- DVK has no test harness, so its symmetric guard rests on code review + the CWX test proving the pattern.
- **Behavior change:** anyone who relied on macros firing with the panel hidden loses that. If maintainers prefer to preserve it, the fallback is an opt-in setting ("fire when CWX hidden", default off).
- **Out of scope:** panel *visible but in Setup mode* still fires — adjacent to this report; candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)