### PR TITLE
fix(gui): make the Display overlay panel scroll when the window is short (#3969)

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -25,6 +25,9 @@
 #include <QSignalBlocker>
 #include <QEvent>
 #include <QFrame>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QStyle>
 #include <QColorDialog>
 #include <QRegularExpression>
 #include <QColorDialog>
@@ -1220,7 +1223,30 @@ void SpectrumOverlayMenu::buildDisplayPanel()
                                    "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_displayPanel->hide();
 
-    auto* grid = new QGridLayout(m_displayPanel);
+    // #3969: the panel's ~24 rows exceed a short window's height, so the grid
+    // lives on a content widget inside a scroll area (same pattern as
+    // RadioSetupDialog::wrapTabInScrollArea) and toggleDisplayPanel() clamps
+    // the shown height. The explicit transparent styles stop the panel-level
+    // QWidget stylesheet above from cascading a second background/border onto
+    // the scroll machinery.
+    auto* panelLayout = new QVBoxLayout(m_displayPanel);
+    panelLayout->setContentsMargins(1, 1, 1, 1);  // keep the 1px panel border visible
+    m_displayScroll = new QScrollArea;
+    m_displayScroll->setObjectName(QStringLiteral("displayPanelScroll"));
+    m_displayScroll->verticalScrollBar()->setObjectName(
+        QStringLiteral("displayPanelScrollBar"));
+    m_displayScroll->setWidgetResizable(true);
+    m_displayScroll->setFrameShape(QFrame::NoFrame);
+    m_displayScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_displayScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_displayScroll->setStyleSheet("QScrollArea { background: transparent; border: none; }");
+    m_displayScroll->viewport()->setStyleSheet("background: transparent; border: none;");
+    auto* displayContent = new QWidget;
+    displayContent->setStyleSheet("background: transparent; border: none;");
+    m_displayScroll->setWidget(displayContent);
+    panelLayout->addWidget(m_displayScroll);
+
+    auto* grid = new QGridLayout(displayContent);
     grid->setContentsMargins(8, 6, 8, 6);
     grid->setSpacing(4);
     grid->setColumnStretch(1, 1);
@@ -1915,7 +1941,8 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     if (m_floorEnableBtn) m_floorEnableBtn->setToolTip("Shows a noise floor reference line on the spectrum display.");
     if (m_floorSlider) m_floorSlider->setToolTip("Vertical position of the noise floor reference line (% from top).");
 
-    m_displayPanel->adjustSize();
+    // No adjustSize() here: toggleDisplayPanel() sizes the panel from the
+    // scroll content's hint (clamped to the parent) on every show.
 }
 
 // Apply a 3-way auto-black mode to the single cycle button + shared Black slider.
@@ -2202,7 +2229,20 @@ void SpectrumOverlayMenu::toggleDisplayPanel()
     if (!wasVisible) {
         m_displayPanelVisible = true;
         int menuBottom = y() + height();
-        int panelH = m_displayPanel->sizeHint().height();
+        // Size from the scroll content's hint — QScrollArea::sizeHint() is
+        // font-metric-capped, not content-sized — then clamp to the parent
+        // height so short windows scroll instead of clipping (#3969).
+        const QSize contentHint = m_displayScroll->widget()->sizeHint();
+        int panelW = contentHint.width() + 2;   // panelLayout 1px margins
+        int panelH = contentHint.height() + 2;
+        const QWidget* host = m_displayPanel->parentWidget();
+        const int maxH = host ? host->height() : panelH;
+        if (panelH > maxH) {
+            panelH = maxH;
+            panelW += m_displayPanel->style()->pixelMetric(
+                QStyle::PM_ScrollBarExtent, nullptr, m_displayScroll);
+        }
+        m_displayPanel->resize(panelW, panelH);
         int panelY = menuBottom - panelH;
         m_displayPanel->move(x() + width(), std::max(0, panelY));
         m_displayPanel->raise();

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -17,6 +17,7 @@ class QSlider;
 class QLabel;
 class QCheckBox;
 class QDoubleSpinBox;
+class QScrollArea;
 
 namespace AetherSDR {
 
@@ -277,6 +278,7 @@ private:
 
     // Display sub-panel
     QWidget*     m_displayPanel{nullptr};
+    QScrollArea* m_displayScroll{nullptr};
     bool         m_displayPanelVisible{false};
     QSlider*     m_avgSlider{nullptr};
     QLabel*      m_avgLabel{nullptr};


### PR DESCRIPTION
## Summary
The Display flyout (spectrum overlay menu → **Display**) rendered its ~24-row settings grid at full `sizeHint()` height and only clamped its Y position, so on a short/minimized window the lower groups — APPEARANCE, 3D VIEW, SYSTEM (GPU selector), Reset to Defaults — spilled past the window edge and were unreachable. The grid now lives inside a `QScrollArea` (the `RadioSetupDialog::wrapTabInScrollArea()` pattern) and `toggleDisplayPanel()` clamps the shown height to the parent, so short windows get a vertical scrollbar instead of clipping.

## Why
- Exactly what the reporter's screenshots show: on a minimized window the panel's bottom half simply doesn't exist for the user.
- The triage analysis on #3969 identified both the root cause and this fix shape; this PR implements it with three refinements found during implementation (below).

## Scope
- 45 insertions / 3 deletions in `src/gui/SpectrumOverlayMenu.{cpp,h}` — layout structure only; no protocol / persistence change, no behavior change at normal window sizes.
- Implementation notes beyond the triage sketch:
  - Sizing reads the scroll **content** widget's hint — `QScrollArea::sizeHint()` is font-metric-capped, not content-sized, so using it would collapse the panel even with space available.
  - When clamped, the panel widens by `PM_ScrollBarExtent` so the scrollbar doesn't squeeze the grid columns.
  - The scroll area/viewport/content get explicit transparent-borderless styles — the panel-level `QWidget` stylesheet cascades to descendants and would otherwise paint a second background+border.
  - The scroll area and its vertical scrollbar carry objectNames (`displayPanelScroll` / `displayPanelScrollBar`) so the automation bridge and a11y tooling can target them deterministically.

## Constitution principle honored
**Principle XI — Fixes Are Demonstrated.** Verified live against a FLEX-6700 with driven-GUI before/after captures at the reporter's window size (below), not by reading the patch. Also serves **VIII (Evidence Over Assertion)**.

## Test plan
- [x] Incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] **Driven headless via the automation bridge** (`resize 686 304` → `invoke Display click` → `grab`), connected to a FLEX-6700:
  - **Baseline v26.7.1:** panel clipped mid-BACKGROUND at the window edge, no scrollbar, SYSTEM group unreachable.
  - **Patched, short window:** panel ends flush with the window, vertical scrollbar present; `invoke displayPanelScrollBar setValue max` scrolls to show APPEARANCE / 3D VIEW / SYSTEM / Reset fully usable.
  - **Patched, full window (1600×1000):** natural height, **no scrollbar** (`ScrollBarAsNeeded`), identical styling — zero regression for users who never hit the clipping.
- [x] Style: single border/background preserved (cascade neutralized); panel visuals byte-identical at the top of the grid vs baseline capture.
- [ ] Maintainer smoke: open Display on a small window, scroll, resize live.

Screenshots (before / after-top / after-scrolled / full-size) captured — attaching in a follow-up comment.

## Checklist
- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — n/a, no meter UI touched

Closes #3969

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)