### PR TITLE
feat(gui): QRZ callsign lookup — CW decoder contact card, lookup dialog, 7-day cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2141,6 +2141,7 @@ add_executable(qrz_callsign_test
     tests/qrz_callsign_test.cpp
     src/core/CwCallsignSpotter.cpp
     src/core/CallsignInfo.cpp
+    src/core/CtyDatParser.cpp
     # LogManager provides lcQrz (spotter's qCDebug category); it drags
     # AsyncLogWriter + AppSettings for its writer/ctor chain at link time.
     src/core/LogManager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,6 +567,10 @@ set(CORE_SOURCES
     src/core/RNNoiseFilter.cpp
     src/core/SpecbleachFilter.cpp
     src/core/CwDecoder.cpp
+    src/core/CwCallsignSpotter.cpp
+    src/core/CallsignInfo.cpp
+    src/core/QrzClient.cpp
+    src/core/CallsignLookupService.cpp
     src/core/RttyDecoder.cpp
     src/core/VoiceSignalDetector.cpp
     src/core/SpectrogramBuffer.cpp
@@ -677,6 +681,7 @@ set(GUI_SOURCES
     src/gui/MainWindow_SwrSweep.cpp
     src/gui/MainWindow_Wiring.cpp
     src/gui/MainWindow_Nets.cpp
+    src/gui/MainWindow_Callsign.cpp
     src/gui/MainWindow_ReceiveSync.cpp
     src/gui/MainWindow_KiwiSdr.cpp
     src/gui/map/MapView.cpp
@@ -720,6 +725,8 @@ set(GUI_SOURCES
     src/gui/DspParamPopup.cpp
     src/gui/DxClusterDialog.cpp
     src/gui/DxClusterStartupCommandsDialog.cpp
+    src/gui/CallsignCard.cpp
+    src/gui/CallsignLookupDialog.cpp
     src/gui/CwxPanel.cpp
     src/gui/BandStackPanel.cpp
     src/gui/FramelessWindowTitleBar.cpp
@@ -2127,6 +2134,22 @@ add_executable(display_inventory_policy_test
 target_include_directories(display_inventory_policy_test PRIVATE src)
 target_link_libraries(display_inventory_policy_test PRIVATE Qt6::Core)
 add_test(NAME display_inventory_policy_test COMMAND display_inventory_policy_test)
+
+# QRZ callsign lookup — spotter stream detection, callsign regex,
+# CallsignInfo JSON round-trip, 7-day cache TTL rule.
+add_executable(qrz_callsign_test
+    tests/qrz_callsign_test.cpp
+    src/core/CwCallsignSpotter.cpp
+    src/core/CallsignInfo.cpp
+    # LogManager provides lcQrz (spotter's qCDebug category); it drags
+    # AsyncLogWriter + AppSettings for its writer/ctor chain at link time.
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/AppSettings.cpp
+)
+target_include_directories(qrz_callsign_test PRIVATE src)
+target_link_libraries(qrz_callsign_test PRIVATE Qt6::Core Qt6::Test)
+add_test(NAME qrz_callsign_test COMMAND qrz_callsign_test)
 
 add_executable(shortcut_manager_test
     tests/shortcut_manager_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -155,6 +155,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`audioCapture <action>`](#audiocapture) | Bounded PCM capture for sync diagnostics. |
 | | [`record <action>`](#record) | Drive the client QSO WAV recorder. |
 | **Identity** | [`station <name>`](#station) | Set this client's MultiFlex station name. |
+| **QRZ lookup** | [`qrz <action>`](#qrz) | Callsign-lookup status / cache probe / lookup / CW-spot simulation. |
 | **Transmit ⚠️** | [`key ptt on\|off` / `key mox`](#key) | Key/unkey via PTT / MOX. |
 | | [`cwx send <text> \| speed <wpm> \| stop`](#cwx) | Drive the CWX CW keyer. |
 | | [`txtest twotone\|off`](#txtest) | Two-tone test signal. |
@@ -327,8 +328,8 @@ the no-op is an explicit, assertable signal.
 | `wheel` | any visible widget | one wheel notch: `-1` or `1` |
 | `setText` | `QLineEdit` | the text (side-effect-free — does **not** submit) |
 | `submit` | `QLineEdit` | optional text, then fires `returnPressed` (retune / login / send) |
-| `setCurrentText` | `QComboBox` | item text |
-| `setCurrentIndex` | `QComboBox` | integer index |
+| `setCurrentText` | `QComboBox` (item text) / `QTabBar` (tab label, case-insensitive — reaches deferred setup-dialog tabs) | text |
+| `setCurrentIndex` | `QComboBox` / `QTabBar` | integer index |
 | `selectRow` | `QAbstractItemView` (`QTableWidget`/`QTreeWidget`/`QListWidget`) | integer row index |
 | `trigger` / `click` / `toggle` | visible `QMenu` `QAction` | — |
 | `setChecked` | checkable visible `QMenu` `QAction` | `true`/`false`/`on`/`off`/`1`/`0` |
@@ -998,6 +999,40 @@ is persisted on the front panel.
 Must be a single token (no spaces) and requires a connected radio. The agent name
 is applied automatically on connect and the user's real name is restored when the
 bridge stops.
+
+### `qrz`
+QRZ.com callsign-lookup subsystem (CW decoder contact card + View → Callsign
+Lookup). Four actions; none touch the radio and none key TX.
+
+```json
+→ {"cmd":"qrz","action":"status"}
+← {"ok":true,"enabled":true,"hasCredentials":true,"cacheEntries":42}
+
+→ {"cmd":"qrz","action":"cached","value":"KI6BCJ"}
+← {"ok":true,"found":true,"entry":{"call":"KI6BCJ","nameFmt":"…","grid":"CM97",
+   "stale":false,"photoPath":"/…/qrz-photos/KI6BCJ.jpg", …}}
+
+→ {"cmd":"qrz","action":"lookup","value":"W1AW"}
+← {"ok":true,"queued":true,"call":"W1AW","note":"async — poll `qrz cached W1AW`…"}
+
+→ {"cmd":"qrz","action":"spottext","value":"CQ CQ DE KI6BCJ KI6BCJ K"}
+← {"ok":true,"fed":"CQ CQ DE KI6BCJ KI6BCJ K"}
+```
+
+- `status` — enable flag, credential presence, lookup-cache entry count.
+- `cached <call>` — cache probe; returns the entry (plus `stale`, 7-day TTL,
+  and `photoPath` when a photo is cached) or `found:false`. Never hits the
+  network — safe to poll after `lookup`.
+- `lookup <call>` — queue a real lookup through the service (cache-first;
+  network only on miss/stale). Async: poll `qrz cached <call>` for arrival.
+- `spottext <text>` — feed text into the **CW callsign spotter** as if the CW
+  decoder produced it. Drives the real detection path ("DE <call> <call>" →
+  service → contact card on the CW decode panel), so an agent can prove the
+  end-to-end screen-pop with no radio, no live CW, and — with a seeded cache —
+  no QRZ account. Verify with `grab callsignCard` / `dumpTree`.
+
+Bare-line forms: `qrz status`, `qrz cached KI6BCJ`, `qrz lookup W1AW`,
+`qrz spottext CQ CQ DE KI6BCJ KI6BCJ K`.
 
 ---
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1006,7 +1006,8 @@ Lookup). Four actions; none touch the radio and none key TX.
 
 ```json
 → {"cmd":"qrz","action":"status"}
-← {"ok":true,"enabled":true,"hasCredentials":true,"cacheEntries":42}
+← {"ok":true,"enabled":true,"hasCredentials":true,"cacheEntries":42,
+   "hasOwnLocation":true}
 
 → {"cmd":"qrz","action":"cached","value":"KI6BCJ"}
 ← {"ok":true,"found":true,"entry":{"call":"KI6BCJ","nameFmt":"…","grid":"CM97",
@@ -1019,7 +1020,9 @@ Lookup). Four actions; none touch the radio and none key TX.
 ← {"ok":true,"fed":"CQ CQ DE KI6BCJ KI6BCJ K"}
 ```
 
-- `status` — enable flag, credential presence, lookup-cache entry count.
+- `status` — enable flag, credential presence, lookup-cache entry count, and
+  whether an own position (radio GPS/grid, or the operator's own QRZ record)
+  is available for card distance/bearing.
 - `cached <call>` — cache probe; returns the entry (plus `stale`, 7-day TTL,
   and `photoPath` when a photo is cached) or `found:false`. Never hits the
   network — safe to poll after `lookup`.

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -6,6 +6,8 @@
 #include "NvidiaBnrSettings.h"   // BNR intensity (in-process AFX, #3902)
 #include "ClientTxTestTone.h"     // testtone() verb — client-side TX test tone
 #include "QsoRecorder.h"          // record() verb — Client-Side QSO recorder
+#include "CallsignLookupService.h" // qrz() verb — QRZ lookup cache/service
+#include "CallsignUtils.h"
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 #include "gui/ConnectionPanel.h" // ConnectionPanel automation facade
 
@@ -17,6 +19,7 @@
 #include <QMainWindow>
 #include <QMenu>
 #include <QMenuBar>
+#include <QTabBar>
 #include <QEnterEvent>
 #include <QMouseEvent>
 #include <QWheelEvent>
@@ -1791,6 +1794,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));  // "testtone on 1000 -6" -> freqHz levelDb
         } else if (cmd == QLatin1String("pan")) {
             action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
+        } else if (cmd == QLatin1String("qrz")) {
+            action = tok(1);  // status | cached | lookup | spottext
+            QStringList rest;
+            for (int i = 2; i < p.size(); ++i) rest << tok(i);
+            value = rest.join(QLatin1Char(' '));  // callsign, or free-form CW text
         } else if (cmd == QLatin1String("streams")) {
             action = tok(1);  // "" (Layer A UDP-orphan) | "radio" (Layer B) | "reset"
         } else if (cmd == QLatin1String("audioCapture")) {
@@ -1991,6 +1999,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("mark requires annotation text"));
         return doMark(value);
     }
+    if (cmd == QLatin1String("qrz"))
+        return doQrz(action.isEmpty() ? QStringLiteral("status") : action, value);
 
     return err(QStringLiteral("unknown command: ") + cmd);
 }
@@ -2453,8 +2463,22 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
         }
     } else if (action == QLatin1String("setCurrentText")) {
         if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentText(value); done = true; }
+        else if (auto* tb = qobject_cast<QTabBar*>(w)) {
+            // Select a tab by its label — the only way to reach deferred
+            // setup-dialog tabs (built on first selection) from the bridge.
+            for (int i = 0; i < tb->count(); ++i) {
+                if (tb->tabText(i).compare(value, Qt::CaseInsensitive) == 0) {
+                    tb->setCurrentIndex(i);
+                    done = true;
+                    break;
+                }
+            }
+            if (!done)
+                return err(QStringLiteral("no tab labeled '%1'").arg(value));
+        }
     } else if (action == QLatin1String("setCurrentIndex")) {
         if (auto* cb = qobject_cast<QComboBox*>(w)) { cb->setCurrentIndex(value.toInt()); done = true; }
+        else if (auto* tb = qobject_cast<QTabBar*>(w)) { tb->setCurrentIndex(value.toInt()); done = true; }
     } else if (action == QLatin1String("selectRow")) {
         // Select a whole row in an item view (QTableWidget / QTreeWidget /
         // QListWidget / any QAbstractItemView) so the dialog's row-scoped
@@ -3531,6 +3555,64 @@ QJsonObject AutomationServer::doStation(const QString& name)
     m_agentStation = n;
     applyAgentStation(n);
     return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("station"), n}};
+}
+
+// ── QRZ callsign lookup (#3646) ─────────────────────────────────────────────
+QJsonObject AutomationServer::doQrz(const QString& action, const QString& value)
+{
+    auto& svc = CallsignLookupService::instance();
+
+    if (action == QLatin1String("status")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("enabled"), svc.enabled()},
+            {QStringLiteral("hasCredentials"), svc.hasCredentials()},
+            {QStringLiteral("cacheEntries"), svc.cacheEntryCount()},
+        };
+    }
+    if (action == QLatin1String("cached")) {
+        const QString call = Callsigns::normalized(value);
+        if (call.isEmpty())
+            return err(QStringLiteral("qrz cached requires a callsign"));
+        const CallsignInfo info = svc.cachedEntry(call);
+        if (!info.isValid())
+            return QJsonObject{{QStringLiteral("ok"), true},
+                               {QStringLiteral("found"), false},
+                               {QStringLiteral("call"), call}};
+        QJsonObject o = info.toJson();
+        o.insert(QStringLiteral("stale"),
+                 info.isOlderThan(CallsignLookupService::kCacheTtlSec));
+        o.insert(QStringLiteral("photoPath"), svc.photoPathFor(call));
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("found"), true},
+                           {QStringLiteral("entry"), o}};
+    }
+    if (action == QLatin1String("lookup")) {
+        const QString call = Callsigns::normalized(value);
+        if (call.isEmpty())
+            return err(QStringLiteral("qrz lookup requires a callsign"));
+        svc.lookup(call);
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("queued"), true},
+                           {QStringLiteral("call"), call},
+                           {QStringLiteral("note"),
+                            QStringLiteral("async — poll `qrz cached %1` for the result").arg(call)}};
+    }
+    if (action == QLatin1String("spottext")) {
+        if (value.trimmed().isEmpty())
+            return err(QStringLiteral("qrz spottext requires CW text, e.g. \"CQ CQ DE KI6BCJ KI6BCJ K\""));
+        QWidget* mw = topLevelWindowForTarget({});
+        QObject* spotter = mw ? mw->findChild<QObject*>(QStringLiteral("cwCallsignSpotter"))
+                              : nullptr;
+        if (!spotter)
+            return err(QStringLiteral("CW callsign spotter not found (main window not up yet?)"));
+        const bool ok = QMetaObject::invokeMethod(spotter, "feedText",
+                                                  Qt::DirectConnection,
+                                                  Q_ARG(QString, value));
+        return QJsonObject{{QStringLiteral("ok"), ok},
+                           {QStringLiteral("fed"), value}};
+    }
+    return err(QStringLiteral("qrz requires status|cached|lookup|spottext"));
 }
 
 // Resolve the top-level window a window-scoped verb acts on: the target's

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3568,6 +3568,7 @@ QJsonObject AutomationServer::doQrz(const QString& action, const QString& value)
             {QStringLiteral("enabled"), svc.enabled()},
             {QStringLiteral("hasCredentials"), svc.hasCredentials()},
             {QStringLiteral("cacheEntries"), svc.cacheEntryCount()},
+            {QStringLiteral("hasOwnLocation"), svc.hasOwnLocation()},
         };
     }
     if (action == QLatin1String("cached")) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3592,6 +3592,11 @@ QJsonObject AutomationServer::doQrz(const QString& action, const QString& value)
         const QString call = Callsigns::normalized(value);
         if (call.isEmpty())
             return err(QStringLiteral("qrz lookup requires a callsign"));
+        // Shape-gate like the GUI dialog does: the bridge must not let an agent
+        // drive unbounded authenticated QRZ queries over arbitrary tokens (#3990).
+        if (!Callsigns::isLikelyCallsign(call))
+            return err(QStringLiteral("qrz lookup: '") + call
+                       + QStringLiteral("' is not a plausible callsign"));
         svc.lookup(call);
         return QJsonObject{{QStringLiteral("ok"), true},
                            {QStringLiteral("queued"), true},

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -349,6 +349,11 @@ private:
     QJsonObject doStation(const QString& name);
     void applyAgentStation(const QString& name);  // capture prior + send
     void restoreStation();                        // re-send the user's real name
+    // QRZ callsign lookup (status | cached <call> | lookup <call> |
+    // spottext <text>).  spottext feeds the CW callsign spotter the given
+    // text as if the decoder produced it — end-to-end card-pop proof with
+    // no radio or live CW required. No keying.
+    QJsonObject doQrz(const QString& action, const QString& value);
     // Resize a top-level window so the panadapter x_pixels (== SpectrumWidget
     // width) propagates to a realistic value for headless render-size fidelity.
     QJsonObject doResize(const QString& value, const QString& target) const;

--- a/src/core/CallsignInfo.cpp
+++ b/src/core/CallsignInfo.cpp
@@ -1,0 +1,84 @@
+#include "CallsignInfo.h"
+
+#include <QJsonValue>
+#include <QStringList>
+
+namespace AetherSDR {
+
+QString CallsignInfo::displayName() const
+{
+    if (!nameFmt.isEmpty())
+        return nameFmt;
+    const QString joined = QStringList{firstName, lastName}.join(QLatin1Char(' ')).trimmed();
+    if (!joined.isEmpty())
+        return joined;
+    return call;
+}
+
+QString CallsignInfo::displayLocation() const
+{
+    QStringList parts;
+    if (!city.isEmpty())    parts << city;
+    if (!state.isEmpty())   parts << state;
+    if (!country.isEmpty()) parts << country;
+    return parts.join(QStringLiteral(", "));
+}
+
+QJsonObject CallsignInfo::toJson() const
+{
+    QJsonObject o;
+    o[QStringLiteral("call")]      = call;
+    o[QStringLiteral("fname")]     = firstName;
+    o[QStringLiteral("lname")]     = lastName;
+    o[QStringLiteral("nameFmt")]   = nameFmt;
+    o[QStringLiteral("nickname")]  = nickname;
+    o[QStringLiteral("city")]      = city;
+    o[QStringLiteral("state")]     = state;
+    o[QStringLiteral("country")]   = country;
+    o[QStringLiteral("county")]    = county;
+    o[QStringLiteral("grid")]      = grid;
+    o[QStringLiteral("class")]     = licenseClass;
+    o[QStringLiteral("email")]     = email;
+    o[QStringLiteral("url")]       = url;
+    o[QStringLiteral("imageUrl")]  = imageUrl;
+    if (hasLatLon) {
+        o[QStringLiteral("lat")] = latitude;
+        o[QStringLiteral("lon")] = longitude;
+    }
+    o[QStringLiteral("lotw")]      = lotw;
+    o[QStringLiteral("eqsl")]      = eqsl;
+    o[QStringLiteral("mqsl")]      = mailQsl;
+    o[QStringLiteral("fetched")]   = static_cast<double>(fetchedUtc);
+    return o;
+}
+
+CallsignInfo CallsignInfo::fromJson(const QJsonObject& o)
+{
+    CallsignInfo info;
+    info.call         = o.value(QLatin1String("call")).toString();
+    info.firstName    = o.value(QLatin1String("fname")).toString();
+    info.lastName     = o.value(QLatin1String("lname")).toString();
+    info.nameFmt      = o.value(QLatin1String("nameFmt")).toString();
+    info.nickname     = o.value(QLatin1String("nickname")).toString();
+    info.city         = o.value(QLatin1String("city")).toString();
+    info.state        = o.value(QLatin1String("state")).toString();
+    info.country      = o.value(QLatin1String("country")).toString();
+    info.county       = o.value(QLatin1String("county")).toString();
+    info.grid         = o.value(QLatin1String("grid")).toString();
+    info.licenseClass = o.value(QLatin1String("class")).toString();
+    info.email        = o.value(QLatin1String("email")).toString();
+    info.url          = o.value(QLatin1String("url")).toString();
+    info.imageUrl     = o.value(QLatin1String("imageUrl")).toString();
+    info.hasLatLon    = o.contains(QLatin1String("lat")) && o.contains(QLatin1String("lon"));
+    if (info.hasLatLon) {
+        info.latitude  = o.value(QLatin1String("lat")).toDouble();
+        info.longitude = o.value(QLatin1String("lon")).toDouble();
+    }
+    info.lotw       = o.value(QLatin1String("lotw")).toBool();
+    info.eqsl       = o.value(QLatin1String("eqsl")).toBool();
+    info.mailQsl    = o.value(QLatin1String("mqsl")).toBool();
+    info.fetchedUtc = static_cast<qint64>(o.value(QLatin1String("fetched")).toDouble());
+    return info;
+}
+
+} // namespace AetherSDR

--- a/src/core/CallsignInfo.h
+++ b/src/core/CallsignInfo.h
@@ -33,6 +33,19 @@ struct CallsignInfo {
     bool    mailQsl{false};// returns paper QSL, QRZ <mqsl>
     qint64  fetchedUtc{0}; // epoch seconds when fetched from the provider
 
+    // ── Transient (never serialized to the cache) ───────────────────────
+    // prefixOnly: built from cty.dat prefix data because QRZ was
+    // unreachable/slow/unconfigured — country-level accuracy only.
+    bool    prefixOnly{false};
+    QString continent;         // cty.dat continent ("NA") for prefix cards
+    int     cqZone{0};         // cty.dat CQ zone for prefix cards
+    // Distance/bearing from the operator's own position, stamped by
+    // CallsignLookupService at emit time (own position changes; the cache
+    // entry must not bake it in).  distanceKm < 0 → unknown.
+    double  distanceKm{-1.0};
+    double  bearingDeg{-1.0};
+    bool    distanceApprox{false};  // position came from the DXCC country center
+
     bool isValid() const { return !call.isEmpty(); }
 
     // Age-based staleness against the lookup cache TTL.

--- a/src/core/CallsignInfo.h
+++ b/src/core/CallsignInfo.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QDateTime>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// One station's contact data as returned by a callsign-database lookup
+// (QRZ.com XML API today; the struct is provider-neutral so a future
+// HamQTH/hamdb backend can fill the same fields).  Instances round-trip
+// through JSON for the on-disk lookup cache.
+struct CallsignInfo {
+    QString call;          // canonical uppercase callsign
+    QString firstName;     // QRZ <fname>
+    QString lastName;      // QRZ <name> (last name)
+    QString nameFmt;       // QRZ <name_fmt> — provider-formatted full name
+    QString nickname;      // QRZ <nickname>
+    QString city;          // QRZ <addr2>
+    QString state;         // QRZ <state>
+    QString country;       // QRZ <country>
+    QString county;        // QRZ <county>
+    QString grid;          // Maidenhead locator, QRZ <grid>
+    QString licenseClass;  // QRZ <class>
+    QString email;         // QRZ <email>
+    QString url;           // QRZ <url> — station web page
+    QString imageUrl;      // QRZ <image> — station photo URL
+    double  latitude{0.0};
+    double  longitude{0.0};
+    bool    hasLatLon{false};
+    bool    lotw{false};   // accepts QSL via Logbook of The World
+    bool    eqsl{false};   // accepts QSL via eQSL
+    bool    mailQsl{false};// returns paper QSL, QRZ <mqsl>
+    qint64  fetchedUtc{0}; // epoch seconds when fetched from the provider
+
+    bool isValid() const { return !call.isEmpty(); }
+
+    // Age-based staleness against the lookup cache TTL.
+    bool isOlderThan(qint64 ttlSec, qint64 nowUtc = QDateTime::currentSecsSinceEpoch()) const
+    {
+        return fetchedUtc <= 0 || (nowUtc - fetchedUtc) > ttlSec;
+    }
+
+    // "Patrick Jensen" — name_fmt when the provider gives one, else
+    // first + last, else the bare callsign.
+    QString displayName() const;
+
+    // "San Jose, CA, United States" — skips empty parts.
+    QString displayLocation() const;
+
+    QJsonObject toJson() const;
+    static CallsignInfo fromJson(const QJsonObject& obj);
+};
+
+} // namespace AetherSDR

--- a/src/core/CallsignLookupService.cpp
+++ b/src/core/CallsignLookupService.cpp
@@ -1,0 +1,389 @@
+#include "CallsignLookupService.h"
+
+#include "CallsignUtils.h"
+#include "LogManager.h"
+#include "QrzClient.h"
+#include "QrzLookupSettings.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QStandardPaths>
+#include <QUrl>
+
+#ifdef HAVE_KEYCHAIN
+#include <qt6keychain/keychain.h>
+#endif
+
+namespace AetherSDR {
+
+namespace {
+constexpr const char* kKeychainService = "AetherSDR";
+constexpr const char* kKeychainKey     = "qrz_password";
+constexpr int  kSaveDebounceMs   = 2000;
+constexpr int  kMaxCacheEntries  = 1000;   // prune oldest beyond this
+constexpr int  kPhotoTimeoutMs   = 20000;
+} // namespace
+
+CallsignLookupService& CallsignLookupService::instance()
+{
+    static CallsignLookupService s;
+    return s;
+}
+
+CallsignLookupService::CallsignLookupService(QObject* parent)
+    : QObject(parent)
+{
+    m_client = new QrzClient(this);
+
+    connect(m_client, &QrzClient::lookupSucceeded, this, [this](const CallsignInfo& info) {
+        m_inFlight.remove(info.call);
+        m_cache.insert(info.call, info);
+        m_cacheDirty = true;
+        scheduleCacheSave();
+        emit infoReady(info, /*fromCache=*/false);
+        fetchPhoto(info);
+    });
+
+    connect(m_client, &QrzClient::lookupFailed, this,
+            [this](const QString& call, QrzClient::Error, const QString& message) {
+        m_inFlight.remove(call);
+        // Serve a stale cache entry rather than nothing — a 9-day-old
+        // name and city beat an error toast when the network is down.
+        const auto it = m_cache.constFind(call);
+        if (it != m_cache.constEnd()) {
+            qCDebug(lcQrz) << "lookup failed for" << call << "— serving stale cache entry";
+            emit infoReady(it.value(), /*fromCache=*/true);
+            return;
+        }
+        emit lookupFailed(call, message);
+    });
+
+    connect(m_client, &QrzClient::loginTestFinished,
+            this, &CallsignLookupService::loginTestFinished);
+
+    m_saveTimer.setSingleShot(true);
+    m_saveTimer.setInterval(kSaveDebounceMs);
+    connect(&m_saveTimer, &QTimer::timeout, this, &CallsignLookupService::saveCacheNow);
+
+    reloadConfiguration();
+}
+
+CallsignLookupService::~CallsignLookupService()
+{
+    saveCacheNow();
+}
+
+bool CallsignLookupService::hasCredentials() const
+{
+    return m_client->hasCredentials();
+}
+
+void CallsignLookupService::reloadConfiguration()
+{
+    m_enabled = QrzLookupSettings::enabled();
+    loadPasswordFromKeychain();
+}
+
+void CallsignLookupService::loadPasswordFromKeychain()
+{
+    const QString username = QrzLookupSettings::username();
+    if (username.isEmpty()) {
+        m_client->setCredentials({}, {});
+        emit configurationChanged();
+        return;
+    }
+#ifdef HAVE_KEYCHAIN
+    auto* job = new QKeychain::ReadPasswordJob(QLatin1String(kKeychainService));
+    job->setAutoDelete(true);
+    job->setKey(QLatin1String(kKeychainKey));
+    connect(job, &QKeychain::Job::finished, this, [this, username](QKeychain::Job* j) {
+        auto* readJob = static_cast<QKeychain::ReadPasswordJob*>(j);
+        if (j->error() != QKeychain::NoError || readJob->textData().isEmpty()) {
+            qCDebug(lcQrz) << "no stored QRZ password";
+            m_client->setCredentials(username, {});
+        } else {
+            m_client->setCredentials(username, readJob->textData());
+        }
+        emit configurationChanged();
+    });
+    job->start();
+#else
+    qCWarning(lcQrz) << "QRZ password persistence unavailable: built without QtKeychain";
+    m_client->setCredentials(username, {});
+    emit configurationChanged();
+#endif
+}
+
+void CallsignLookupService::savePassword(const QString& password)
+{
+#ifdef HAVE_KEYCHAIN
+    if (password.isEmpty()) {
+        auto* job = new QKeychain::DeletePasswordJob(QLatin1String(kKeychainService));
+        job->setAutoDelete(true);
+        job->setKey(QLatin1String(kKeychainKey));
+        connect(job, &QKeychain::Job::finished, this, [this](QKeychain::Job*) {
+            loadPasswordFromKeychain();
+        });
+        job->start();
+        return;
+    }
+    auto* job = new QKeychain::WritePasswordJob(QLatin1String(kKeychainService));
+    job->setAutoDelete(true);
+    job->setKey(QLatin1String(kKeychainKey));
+    job->setTextData(password);
+    connect(job, &QKeychain::Job::finished, this, [this](QKeychain::Job* j) {
+        if (j->error() != QKeychain::NoError)
+            qCWarning(lcQrz) << "keychain save failed:" << j->errorString();
+        loadPasswordFromKeychain();
+    });
+    job->start();
+#else
+    Q_UNUSED(password);
+    qCWarning(lcQrz) << "cannot save QRZ password: built without QtKeychain";
+#endif
+}
+
+void CallsignLookupService::readPassword(std::function<void(const QString&)> callback)
+{
+#ifdef HAVE_KEYCHAIN
+    auto* job = new QKeychain::ReadPasswordJob(QLatin1String(kKeychainService));
+    job->setAutoDelete(true);
+    job->setKey(QLatin1String(kKeychainKey));
+    connect(job, &QKeychain::Job::finished, this,
+            [callback = std::move(callback)](QKeychain::Job* j) {
+        auto* readJob = static_cast<QKeychain::ReadPasswordJob*>(j);
+        callback(j->error() == QKeychain::NoError ? readJob->textData() : QString());
+    });
+    job->start();
+#else
+    callback({});
+#endif
+}
+
+void CallsignLookupService::lookup(const QString& call, bool forceRefresh)
+{
+    const QString norm = Callsigns::normalized(call);
+    if (norm.isEmpty())
+        return;
+    if (!m_enabled) {
+        emit lookupFailed(norm, QStringLiteral("QRZ lookups are disabled"));
+        return;
+    }
+
+    ensureCacheLoaded();
+
+    const auto it = m_cache.constFind(norm);
+    const bool fresh = it != m_cache.constEnd() && !it.value().isOlderThan(kCacheTtlSec);
+    if (fresh && !forceRefresh) {
+        const CallsignInfo info = it.value();
+        // Queued so callers connecting right before lookup() still get it.
+        QMetaObject::invokeMethod(this, [this, info] {
+            emit infoReady(info, /*fromCache=*/true);
+            const QString photo = photoPathFor(info.call);
+            if (!photo.isEmpty())
+                emit photoReady(info.call, photo);
+            else
+                fetchPhoto(info);
+        }, Qt::QueuedConnection);
+        return;
+    }
+
+    if (m_inFlight.contains(norm))
+        return;  // coalesce — a busy net pileup is one request
+    m_inFlight.insert(norm);
+    qCDebug(lcQrz) << "QRZ lookup" << norm << (fresh ? "(forced refresh)" : "(cache miss/stale)");
+    m_client->lookup(norm);
+}
+
+void CallsignLookupService::testLogin(const QString& username, const QString& password)
+{
+    m_client->testLogin(username, password);
+}
+
+// ---------------------------------------------------------------- cache --
+
+QString CallsignLookupService::cacheFilePath() const
+{
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    return dir + QDir::separator() + QStringLiteral("qrz-callsign-cache.json");
+}
+
+QString CallsignLookupService::photoDirPath() const
+{
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    return dir + QDir::separator() + QStringLiteral("qrz-photos");
+}
+
+void CallsignLookupService::ensureCacheLoaded()
+{
+    if (m_cacheLoaded)
+        return;
+    m_cacheLoaded = true;
+
+    QFile f(cacheFilePath());
+    if (!f.open(QIODevice::ReadOnly))
+        return;
+    const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    const QJsonObject entries = doc.object().value(QLatin1String("entries")).toObject();
+    for (auto it = entries.constBegin(); it != entries.constEnd(); ++it) {
+        const CallsignInfo info = CallsignInfo::fromJson(it.value().toObject());
+        if (info.isValid())
+            m_cache.insert(info.call, info);
+    }
+    qCDebug(lcQrz) << "loaded" << m_cache.size() << "cached callsigns";
+}
+
+void CallsignLookupService::scheduleCacheSave()
+{
+    m_saveTimer.start();
+}
+
+void CallsignLookupService::saveCacheNow()
+{
+    if (!m_cacheDirty)
+        return;
+    m_cacheDirty = false;
+
+    // Prune far-expired entries (2× TTL) and cap total size by age so the
+    // cache file can't grow without bound on a contest weekend.
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+    QList<CallsignInfo> entries;
+    entries.reserve(m_cache.size());
+    for (const CallsignInfo& info : std::as_const(m_cache)) {
+        if (!info.isOlderThan(2 * kCacheTtlSec, now))
+            entries.append(info);
+    }
+    if (entries.size() > kMaxCacheEntries) {
+        std::sort(entries.begin(), entries.end(),
+                  [](const CallsignInfo& a, const CallsignInfo& b) {
+                      return a.fetchedUtc > b.fetchedUtc;
+                  });
+        entries = entries.mid(0, kMaxCacheEntries);
+    }
+
+    QJsonObject obj;
+    for (const CallsignInfo& info : std::as_const(entries))
+        obj.insert(info.call, info.toJson());
+    QJsonObject root;
+    root[QStringLiteral("saved")] = static_cast<double>(now);
+    root[QStringLiteral("entries")] = obj;
+
+    QDir().mkpath(QFileInfo(cacheFilePath()).absolutePath());
+    QFile f(cacheFilePath());
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcQrz) << "cannot write callsign cache:" << f.errorString();
+        return;
+    }
+    f.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+}
+
+int CallsignLookupService::cacheEntryCount()
+{
+    ensureCacheLoaded();
+    return m_cache.size();
+}
+
+bool CallsignLookupService::hasCachedEntry(const QString& call)
+{
+    ensureCacheLoaded();
+    return m_cache.contains(Callsigns::normalized(call));
+}
+
+CallsignInfo CallsignLookupService::cachedEntry(const QString& call)
+{
+    ensureCacheLoaded();
+    return m_cache.value(Callsigns::normalized(call));
+}
+
+void CallsignLookupService::clearCache()
+{
+    ensureCacheLoaded();
+    m_cache.clear();
+    m_cacheDirty = true;
+    saveCacheNow();
+    QDir photos(photoDirPath());
+    if (photos.exists())
+        photos.removeRecursively();
+    qCDebug(lcQrz) << "callsign cache cleared";
+}
+
+// --------------------------------------------------------------- photos --
+
+QString CallsignLookupService::photoPathFor(const QString& call) const
+{
+    const QString norm = Callsigns::normalized(call);
+    if (norm.isEmpty())
+        return {};
+    // Portable suffixes contain '/', which can't appear in a filename.
+    QString base = norm;
+    base.replace(QLatin1Char('/'), QLatin1Char('_'));
+    const QDir dir(photoDirPath());
+    for (const char* ext : {"jpg", "png", "gif"}) {
+        const QString path = dir.filePath(base + QLatin1Char('.') + QLatin1String(ext));
+        if (QFile::exists(path))
+            return path;
+    }
+    return {};
+}
+
+void CallsignLookupService::fetchPhoto(const CallsignInfo& info)
+{
+    if (info.imageUrl.isEmpty() || m_photoInFlight.contains(info.call))
+        return;
+    if (!photoPathFor(info.call).isEmpty()) {
+        emit photoReady(info.call, photoPathFor(info.call));
+        return;
+    }
+
+    const QUrl url(info.imageUrl);
+    if (!url.isValid() || (url.scheme() != QLatin1String("https")
+                           && url.scheme() != QLatin1String("http")))
+        return;
+
+    m_photoInFlight.insert(info.call);
+    QNetworkRequest req{url};
+    req.setHeader(QNetworkRequest::UserAgentHeader,
+                  QStringLiteral("AetherSDR/%1").arg(QCoreApplication::applicationVersion()));
+    req.setTransferTimeout(kPhotoTimeoutMs);
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                     QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    auto* reply = m_photoNam.get(req);
+    const QString call = info.call;
+    connect(reply, &QNetworkReply::finished, this, [this, reply, call, url] {
+        reply->deleteLater();
+        m_photoInFlight.remove(call);
+        if (reply->error() != QNetworkReply::NoError) {
+            qCDebug(lcQrz) << "photo fetch failed for" << call << reply->errorString();
+            return;
+        }
+        const QByteArray data = reply->readAll();
+        if (data.isEmpty())
+            return;
+
+        QString ext = QFileInfo(url.path()).suffix().toLower();
+        if (ext != QLatin1String("jpg") && ext != QLatin1String("png")
+            && ext != QLatin1String("gif"))
+            ext = QStringLiteral("jpg");
+        QString base = call;
+        base.replace(QLatin1Char('/'), QLatin1Char('_'));
+
+        QDir().mkpath(photoDirPath());
+        QFile f(QDir(photoDirPath()).filePath(base + QLatin1Char('.') + ext));
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            qCWarning(lcQrz) << "cannot write photo cache:" << f.errorString();
+            return;
+        }
+        f.write(data);
+        f.close();
+        emit photoReady(call, f.fileName());
+    });
+}
+
+} // namespace AetherSDR

--- a/src/core/CallsignLookupService.cpp
+++ b/src/core/CallsignLookupService.cpp
@@ -1,7 +1,9 @@
 #include "CallsignLookupService.h"
 
 #include "CallsignUtils.h"
+#include "CtyDatParser.h"
 #include "LogManager.h"
+#include "MaidenheadLocator.h"
 #include "QrzClient.h"
 #include "QrzLookupSettings.h"
 
@@ -43,10 +45,15 @@ CallsignLookupService::CallsignLookupService(QObject* parent)
 
     connect(m_client, &QrzClient::lookupSucceeded, this, [this](const CallsignInfo& info) {
         m_inFlight.remove(info.call);
+        m_fallbackShown.remove(info.call);
         m_cache.insert(info.call, info);
         m_cacheDirty = true;
         scheduleCacheSave();
-        emit infoReady(info, /*fromCache=*/false);
+        if (info.call == m_ownCallsign)
+            maybeAdoptOwnLocation(info);
+        CallsignInfo out = info;
+        stampGeo(out);
+        emit infoReady(out, /*fromCache=*/false);
         fetchPhoto(info);
     });
 
@@ -58,9 +65,15 @@ CallsignLookupService::CallsignLookupService(QObject* parent)
         const auto it = m_cache.constFind(call);
         if (it != m_cache.constEnd()) {
             qCDebug(lcQrz) << "lookup failed for" << call << "— serving stale cache entry";
-            emit infoReady(it.value(), /*fromCache=*/true);
+            m_fallbackShown.remove(call);
+            CallsignInfo out = it.value();
+            stampGeo(out);
+            emit infoReady(out, /*fromCache=*/true);
             return;
         }
+        // No cache either → country-level card from cty.dat prefix data.
+        if (emitPrefixFallback(call))
+            return;
         emit lookupFailed(call, message);
     });
 
@@ -181,7 +194,8 @@ void CallsignLookupService::lookup(const QString& call, bool forceRefresh)
     const auto it = m_cache.constFind(norm);
     const bool fresh = it != m_cache.constEnd() && !it.value().isOlderThan(kCacheTtlSec);
     if (fresh && !forceRefresh) {
-        const CallsignInfo info = it.value();
+        CallsignInfo info = it.value();
+        stampGeo(info);
         // Queued so callers connecting right before lookup() still get it.
         QMetaObject::invokeMethod(this, [this, info] {
             emit infoReady(info, /*fromCache=*/true);
@@ -197,8 +211,138 @@ void CallsignLookupService::lookup(const QString& call, bool forceRefresh)
     if (m_inFlight.contains(norm))
         return;  // coalesce — a busy net pileup is one request
     m_inFlight.insert(norm);
+    m_fallbackShown.remove(norm);   // new attempt → fallback allowed again
     qCDebug(lcQrz) << "QRZ lookup" << norm << (fresh ? "(forced refresh)" : "(cache miss/stale)");
+
+    // Slow-network stopgap: if QRZ hasn't answered in kPrefixFallbackMs,
+    // show the country-level prefix card now; the full card replaces it
+    // whenever the real answer lands.
+    QTimer::singleShot(kPrefixFallbackMs, this, [this, norm] {
+        if (m_inFlight.contains(norm))
+            emitPrefixFallback(norm);
+    });
+
     m_client->lookup(norm);
+}
+
+bool CallsignLookupService::canResolve(const QString& call)
+{
+    if (hasCredentials() || hasCachedEntry(call))
+        return true;
+    return m_ctyParser && m_ctyParser->entityForCallsign(Callsigns::normalized(call));
+}
+
+void CallsignLookupService::setOwnLocation(double lat, double lon)
+{
+    m_ownLat = lat;
+    m_ownLon = lon;
+    m_hasOwnLocation = true;
+    m_ownLocationFromGps = true;
+}
+
+void CallsignLookupService::setOwnCallsign(const QString& call)
+{
+    const QString norm = Callsigns::normalized(call);
+    if (norm.isEmpty() || norm == m_ownCallsign)
+        return;
+    m_ownCallsign = norm;
+    if (m_ownLocationFromGps)
+        return;  // GPS already supplied a better position
+
+    ensureCacheLoaded();
+    const auto it = m_cache.constFind(norm);
+    if (it != m_cache.constEnd()) {
+        maybeAdoptOwnLocation(it.value());
+        return;
+    }
+    // Not cached — fetch quietly; the lookupSucceeded path adopts it.
+    // (No card is pending for this call, so nothing pops visually.)
+    if (m_enabled && hasCredentials())
+        lookup(norm);
+}
+
+void CallsignLookupService::maybeAdoptOwnLocation(const CallsignInfo& info)
+{
+    if (m_ownLocationFromGps || info.prefixOnly)
+        return;  // GPS wins; a country center is useless as a home position
+    double lat = 0.0, lon = 0.0;
+    if (info.hasLatLon) {
+        lat = info.latitude;
+        lon = info.longitude;
+    } else if (info.grid.isEmpty()
+               || !MaidenheadLocator::toLatLon(info.grid, lat, lon)) {
+        return;
+    }
+    m_ownLat = lat;
+    m_ownLon = lon;
+    m_hasOwnLocation = true;
+    qCDebug(lcQrz) << "own position adopted from" << info.call << "QRZ record";
+}
+
+CallsignInfo CallsignLookupService::prefixInfo(const QString& call) const
+{
+    CallsignInfo info;
+    if (!m_ctyParser)
+        return info;
+    const DxccEntity* entity = m_ctyParser->entityForCallsign(call);
+    if (!entity)
+        return info;
+    info.call       = call;
+    info.country    = entity->name;
+    info.continent  = entity->continent;
+    info.cqZone     = entity->cqZone;
+    info.prefixOnly = true;
+    if (entity->hasLatLon) {
+        info.latitude  = entity->latitude;
+        info.longitude = entity->longitude;
+        info.hasLatLon = true;
+    }
+    info.fetchedUtc = QDateTime::currentSecsSinceEpoch();
+    return info;
+}
+
+bool CallsignLookupService::emitPrefixFallback(const QString& call)
+{
+    if (m_fallbackShown.contains(call))
+        return true;   // already showing the prefix card for this attempt
+    CallsignInfo info = prefixInfo(call);
+    if (!info.isValid())
+        return false;
+    m_fallbackShown.insert(call);
+    stampGeo(info);
+    qCDebug(lcQrz) << "prefix fallback for" << call << "→" << info.country;
+    // Deliberately NOT cached: a country-level stand-in must never mask a
+    // future full QRZ lookup.
+    emit infoReady(info, /*fromCache=*/false);
+    return true;
+}
+
+void CallsignLookupService::stampGeo(CallsignInfo& info) const
+{
+    info.distanceKm = -1.0;
+    info.bearingDeg = -1.0;
+    info.distanceApprox = false;
+    if (!m_hasOwnLocation)
+        return;
+
+    // Best available station position: exact lat/lon → grid center →
+    // (already folded into hasLatLon for prefix cards) country center.
+    double lat = 0.0, lon = 0.0;
+    bool have = false;
+    if (info.hasLatLon) {
+        lat = info.latitude;
+        lon = info.longitude;
+        have = true;
+        info.distanceApprox = info.prefixOnly;   // country center is coarse
+    } else if (!info.grid.isEmpty()
+               && MaidenheadLocator::toLatLon(info.grid, lat, lon)) {
+        have = true;
+    }
+    if (!have)
+        return;
+
+    info.distanceKm = MaidenheadLocator::distanceKm(m_ownLat, m_ownLon, lat, lon);
+    info.bearingDeg = MaidenheadLocator::bearingDeg(m_ownLat, m_ownLon, lat, lon);
 }
 
 void CallsignLookupService::testLogin(const QString& username, const QString& password)

--- a/src/core/CallsignLookupService.cpp
+++ b/src/core/CallsignLookupService.cpp
@@ -43,10 +43,14 @@ CallsignLookupService::CallsignLookupService(QObject* parent)
 {
     m_client = new QrzClient(this);
 
-    connect(m_client, &QrzClient::lookupSucceeded, this, [this](const CallsignInfo& info) {
-        m_inFlight.remove(info.call);
-        m_fallbackShown.remove(info.call);
-        m_cache.insert(info.call, info);
+    connect(m_client, &QrzClient::lookupSucceeded, this,
+            [this](const QString& call, const CallsignInfo& info) {
+        // Key on the queried form (call), not QRZ's base info.call — they
+        // differ for portable/prefixed queries, and keying on info.call leaks
+        // the in-flight entry (dead lookup) and misses the cache (#3990).
+        m_inFlight.remove(call);
+        m_fallbackShown.remove(call);
+        m_cache.insert(call, info);
         m_cacheDirty = true;
         scheduleCacheSave();
         if (info.call == m_ownCallsign)
@@ -486,8 +490,10 @@ void CallsignLookupService::fetchPhoto(const CallsignInfo& info)
     }
 
     const QUrl url(info.imageUrl);
-    if (!url.isValid() || (url.scheme() != QLatin1String("https")
-                           && url.scheme() != QLatin1String("http")))
+    // https only — the <image> URL is untrusted; permitting http (with the
+    // NoLessSafeRedirectPolicy below allowing cross-host) would let a crafted
+    // profile reach an internal host over cleartext (SSRF-lite). (#3990)
+    if (!url.isValid() || url.scheme() != QLatin1String("https"))
         return;
 
     m_photoInFlight.insert(info.call);
@@ -499,6 +505,15 @@ void CallsignLookupService::fetchPhoto(const CallsignInfo& info)
                      QNetworkRequest::NoLessSafeRedirectPolicy);
 
     auto* reply = m_photoNam.get(req);
+    // Cap the untrusted download so a decompression-bomb / huge image can't
+    // exhaust memory: abort as soon as the body (or advertised size) exceeds
+    // the cap; the abort trips reply->error() and the finished handler drops it. (#3990)
+    constexpr qint64 kMaxPhotoBytes = 8 * 1024 * 1024;
+    connect(reply, &QNetworkReply::downloadProgress, reply,
+            [reply](qint64 received, qint64 total) {
+        if (received > kMaxPhotoBytes || total > kMaxPhotoBytes)
+            reply->abort();
+    });
     const QString call = info.call;
     connect(reply, &QNetworkReply::finished, this, [this, reply, call, url] {
         reply->deleteLater();

--- a/src/core/CallsignLookupService.h
+++ b/src/core/CallsignLookupService.h
@@ -14,6 +14,7 @@
 namespace AetherSDR {
 
 class QrzClient;
+class CtyDatParser;
 
 // Application-wide callsign-lookup facade: QRZ client + lazy on-disk cache
 // + photo download.  Every consumer (CW decoder card, lookup dialog, and
@@ -41,8 +42,32 @@ public:
 
     static CallsignLookupService& instance();
 
+    static constexpr int kPrefixFallbackMs = 5000;
+
     bool enabled() const { return m_enabled; }
     bool hasCredentials() const;
+
+    // Loaded cty.dat parser (owned elsewhere — MainWindow's DxccColorProvider).
+    // Enables country-level prefix-fallback cards when QRZ can't answer.
+    void setCtyParser(const CtyDatParser* parser) { m_ctyParser = parser; }
+
+    // Operator's own position (radio GPS fix, or grid-square center) used to
+    // stamp distance/bearing onto every emitted CallsignInfo.  GPS-sourced
+    // positions take priority over the own-callsign fallback below.
+    void setOwnLocation(double lat, double lon);
+    void clearOwnLocation() { m_hasOwnLocation = false; }
+    bool hasOwnLocation() const { return m_hasOwnLocation; }
+
+    // Zero-config own-position fallback for radios without GPS: the
+    // operator's own QRZ record (or its cache entry) carries their grid, so
+    // a lookup of the radio's callsign supplies the missing home position.
+    // A GPS fix, when one exists, always overrides this.
+    void setOwnCallsign(const QString& call);
+
+    // Can lookup(call) produce *something* for this call — QRZ credentials,
+    // a cache entry, or at least cty.dat prefix data?  The CW screen-pop
+    // gates on this so a pending card can never sit unfillable.
+    bool canResolve(const QString& call);
 
     // Kick a lookup.  Fresh cache hit → infoReady fires (queued, so
     // connect-then-call ordering is safe).  Otherwise the network path
@@ -93,13 +118,32 @@ private:
     void fetchPhoto(const CallsignInfo& info);
     void loadPasswordFromKeychain();
 
+    // cty.dat country-level stand-in for `call`; !isValid() when the prefix
+    // doesn't resolve (or no parser was provided).
+    CallsignInfo prefixInfo(const QString& call) const;
+    // Emit the prefix stand-in for a call (at most once per lookup attempt).
+    // Returns false when no prefix data exists for the call.
+    bool emitPrefixFallback(const QString& call);
+    // Stamp distance/bearing from the operator's position onto an outgoing
+    // info (exact lat/lon > grid center > DXCC country center).
+    void stampGeo(CallsignInfo& info) const;
+    // Adopt the operator's own QRZ record as home position (unless GPS won).
+    void maybeAdoptOwnLocation(const CallsignInfo& info);
+
     QrzClient* m_client{nullptr};
     QNetworkAccessManager m_photoNam;
+    const CtyDatParser* m_ctyParser{nullptr};
     bool m_enabled{false};
     bool m_cacheLoaded{false};
     bool m_cacheDirty{false};
+    bool m_hasOwnLocation{false};
+    bool m_ownLocationFromGps{false};
+    double m_ownLat{0.0};
+    double m_ownLon{0.0};
+    QString m_ownCallsign;
     QHash<QString, CallsignInfo> m_cache;
     QSet<QString> m_inFlight;
+    QSet<QString> m_fallbackShown;   // calls already given a prefix card this attempt
     QSet<QString> m_photoInFlight;
     QTimer m_saveTimer;
 };

--- a/src/core/CallsignLookupService.h
+++ b/src/core/CallsignLookupService.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "CallsignInfo.h"
+
+#include <QHash>
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QTimer>
+
+#include <functional>
+
+namespace AetherSDR {
+
+class QrzClient;
+
+// Application-wide callsign-lookup facade: QRZ client + lazy on-disk cache
+// + photo download.  Every consumer (CW decoder card, lookup dialog, and
+// the future SSB voice-decoder card) goes through here so a busy net never
+// hits QRZ twice for the same station.
+//
+//   lookup("KI6BCJ")  →  infoReady(info, fromCache)   [+ photoReady later]
+//                     or lookupFailed(call, message)
+//
+// Cache: one JSON file in QStandardPaths::CacheLocation, entries expire
+// after kCacheTtlSec (7 days).  A stale entry is refreshed from the
+// network but still served as a fallback when the refresh fails (offline
+// operation keeps working).  Station photos land next to it under
+// qrz-photos/ and ride the same TTL.
+//
+// Credentials: username + enable flag in the AppSettings["QrzLookup"]
+// blob (QrzLookupSettings, Principle V), password in the OS keychain
+// (key "qrz_password") — never in the settings file.  Call
+// reloadConfiguration() after the setup tab changes any of them.
+class CallsignLookupService : public QObject {
+    Q_OBJECT
+
+public:
+    static constexpr qint64 kCacheTtlSec = 7 * 24 * 3600;
+
+    static CallsignLookupService& instance();
+
+    bool enabled() const { return m_enabled; }
+    bool hasCredentials() const;
+
+    // Kick a lookup.  Fresh cache hit → infoReady fires (queued, so
+    // connect-then-call ordering is safe).  Otherwise the network path
+    // runs; concurrent requests for the same call coalesce.
+    void lookup(const QString& call, bool forceRefresh = false);
+
+    // Local path of a cached station photo, or empty when none exists
+    // yet (photoReady announces late arrivals).
+    QString photoPathFor(const QString& call) const;
+
+    int  cacheEntryCount();
+    void clearCache();
+
+    // Cache probes (setup tab, CW-spot gating, automation bridge).
+    bool hasCachedEntry(const QString& call);
+    CallsignInfo cachedEntry(const QString& call);  // !isValid() when absent
+
+    // Async credential test for the setup tab; result via loginTestFinished.
+    void testLogin(const QString& username, const QString& password);
+
+    // Persist the QRZ password to the OS keychain (empty deletes the
+    // entry) and refresh the client's credentials when done.
+    void savePassword(const QString& password);
+
+    // Async keychain read for the setup tab's password field; the value
+    // arrives via the callback on the main thread ({} when none stored).
+    void readPassword(std::function<void(const QString&)> callback);
+
+    // Re-read AppSettings + keychain after the QRZ setup tab saves.
+    void reloadConfiguration();
+
+signals:
+    void infoReady(const AetherSDR::CallsignInfo& info, bool fromCache);
+    void lookupFailed(const QString& call, const QString& message);
+    void photoReady(const QString& call, const QString& imagePath);
+    void loginTestFinished(bool ok, const QString& message);
+    void configurationChanged();
+
+private:
+    explicit CallsignLookupService(QObject* parent = nullptr);
+    ~CallsignLookupService() override;
+
+    void ensureCacheLoaded();
+    void scheduleCacheSave();
+    void saveCacheNow();
+    QString cacheFilePath() const;
+    QString photoDirPath() const;
+    void fetchPhoto(const CallsignInfo& info);
+    void loadPasswordFromKeychain();
+
+    QrzClient* m_client{nullptr};
+    QNetworkAccessManager m_photoNam;
+    bool m_enabled{false};
+    bool m_cacheLoaded{false};
+    bool m_cacheDirty{false};
+    QHash<QString, CallsignInfo> m_cache;
+    QSet<QString> m_inFlight;
+    QSet<QString> m_photoInFlight;
+    QTimer m_saveTimer;
+};
+
+} // namespace AetherSDR

--- a/src/core/CallsignUtils.h
+++ b/src/core/CallsignUtils.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QString>
+
+namespace AetherSDR {
+namespace Callsigns {
+
+// Amateur callsign shape: optional prefix ("VP2E/"), 1-3 char prefix with at
+// least one letter, digit, suffix letters, optional portable designator
+// ("/P", "/7", "/QRP").  Deliberately permissive — validation gates a lookup,
+// it doesn't police licensing.  The pattern requires the base call to end in
+// a letter, which rejects most CW garble ("5NN", "73", "599").
+inline const QRegularExpression& regex()
+{
+    static const QRegularExpression re(
+        QStringLiteral("(?:[A-Z0-9]{1,4}/)?"                 // DX prefix
+                       "(?:[A-Z]{1,2}|[A-Z][0-9]|[0-9][A-Z])" // ITU prefix
+                       "[0-9][A-Z0-9]{0,3}[A-Z]"             // digit + suffix
+                       "(?:/[A-Z0-9]{1,4})?"));              // portable suffix
+    return re;
+}
+
+inline bool isLikelyCallsign(const QString& text)
+{
+    const QString s = text.trimmed().toUpper();
+    const QRegularExpressionMatch m = regex().match(s);
+    return m.hasMatch() && m.capturedStart() == 0 && m.capturedLength() == s.size();
+}
+
+// Canonical cache key / lookup form: uppercase, no whitespace.
+inline QString normalized(const QString& call)
+{
+    return call.trimmed().toUpper();
+}
+
+} // namespace Callsigns
+} // namespace AetherSDR

--- a/src/core/CtyDatParser.cpp
+++ b/src/core/CtyDatParser.cpp
@@ -116,7 +116,7 @@ void CtyDatParser::parse(const QStringList& lines)
     // Regex for header line: "Entity Name:  CQ:  ITU:  Cont:  lat:  lon:  tz:  Prefix:"
     // Fields are colon-separated on the first line.
     static const QRegularExpression headerRe(
-        R"(^([^:]+):\s*(\d+):\s*(\d+):\s*(\w+):\s*[\d\.\-]+:\s*[\d\.\-]+:\s*[\d\.\-]+:\s*([^:]+):)");
+        R"(^([^:]+):\s*(\d+):\s*(\d+):\s*(\w+):\s*([\d\.\-]+):\s*([\d\.\-]+):\s*[\d\.\-]+:\s*([^:]+):)");
 
     for (const QString& line : lines) {
         // Header line — doesn't start with whitespace
@@ -135,7 +135,19 @@ void CtyDatParser::parse(const QStringList& lines)
             current.cqZone       = m.captured(2).toInt();
             current.ituZone      = m.captured(3).toInt();
             current.continent    = m.captured(4).trimmed();
-            current.primaryPrefix = m.captured(5).trimmed().toUpper();
+            {
+                // cty.dat longitude is west-positive; flip to east-positive
+                // so it composes with everything else in the app.
+                bool okLat = false, okLon = false;
+                const double lat = m.captured(5).toDouble(&okLat);
+                const double lon = m.captured(6).toDouble(&okLon);
+                if (okLat && okLon) {
+                    current.latitude  = lat;
+                    current.longitude = -lon;
+                    current.hasLatLon = true;
+                }
+            }
+            current.primaryPrefix = m.captured(7).trimmed().toUpper();
             // Remove trailing slash variants like "3D2/c" -> use as-is (sub-entities get own primary prefix)
             inEntity = true;
             aliasBuffer.clear();
@@ -199,6 +211,13 @@ const DxccEntity* CtyDatParser::entityByPrefix(const QString& primaryPrefix) con
     auto it = m_entityByPrefix.find(primaryPrefix.toUpper());
     if (it == m_entityByPrefix.end()) return nullptr;
     return &it.value();
+}
+
+const DxccEntity* CtyDatParser::entityForCallsign(const QString& callsign) const
+{
+    const QString pfx = resolvePrimaryPrefix(callsign);
+    if (pfx.isEmpty()) return nullptr;
+    return entityByPrefix(pfx);
 }
 
 } // namespace AetherSDR

--- a/src/core/CtyDatParser.h
+++ b/src/core/CtyDatParser.h
@@ -12,6 +12,11 @@ struct DxccEntity {
     QString continent;       // e.g. "EU"
     int     cqZone{0};
     int     ituZone{0};
+    // Entity center from cty.dat, east-positive longitude (the file stores
+    // west-positive; the parser flips it).  hasLatLon false on parse issues.
+    double  latitude{0.0};
+    double  longitude{0.0};
+    bool    hasLatLon{false};
 };
 
 // ---------------------------------------------------------------------------
@@ -32,6 +37,10 @@ public:
 
     // Look up entity details by primary prefix.
     const DxccEntity* entityByPrefix(const QString& primaryPrefix) const;
+
+    // Convenience: resolve a callsign straight to its entity (longest-prefix
+    // match), or nullptr when nothing matches.
+    const DxccEntity* entityForCallsign(const QString& callsign) const;
 
     int entityCount() const { return m_entityByPrefix.size(); }
     bool isLoaded()   const { return !m_entityByPrefix.isEmpty(); }

--- a/src/core/CwCallsignSpotter.cpp
+++ b/src/core/CwCallsignSpotter.cpp
@@ -1,0 +1,95 @@
+#include "CwCallsignSpotter.h"
+
+#include "CallsignUtils.h"
+#include "LogManager.h"
+
+#include <QRegularExpression>
+
+namespace AetherSDR {
+
+namespace {
+// "DE <call> <call>" with the two calls identical.  The callsign shape
+// comes from Callsigns::regex(); \b keeps "MADE K1ABC..." from matching.
+const QRegularExpression& deRegex()
+{
+    static const QRegularExpression re(
+        QStringLiteral("\\bDE\\s+(%1)\\s+\\1\\b").arg(Callsigns::regex().pattern()));
+    return re;
+}
+} // namespace
+
+CwCallsignSpotter::CwCallsignSpotter(QObject* parent)
+    : QObject(parent)
+{
+    // An ID is often the last thing a station sends ("... 73 DE K1AB K1AB"
+    // then silence).  A match that touches the end of the window can't be
+    // accepted immediately — the second call might still be streaming in —
+    // so this timer re-scans once the stream has settled.
+    m_settleTimer.setSingleShot(true);
+    m_settleTimer.setInterval(kSettleMs);
+    connect(&m_settleTimer, &QTimer::timeout, this, [this] {
+        scanWindow(/*streamSettled=*/true);
+    });
+}
+
+void CwCallsignSpotter::clear()
+{
+    m_window.clear();
+    m_settleTimer.stop();
+}
+
+void CwCallsignSpotter::feedText(const QString& text)
+{
+    if (text.isEmpty())
+        return;
+
+    // Collapse whitespace runs so multi-chunk arrival ("DE KI6", "BCJ ")
+    // regexes the same as one string.
+    m_window.append(text.toUpper());
+    m_window.replace(QRegularExpression(QStringLiteral("\\s+")), QStringLiteral(" "));
+    if (m_window.size() > kWindowChars)
+        m_window.remove(0, m_window.size() - kWindowChars);
+
+    scanWindow(/*streamSettled=*/false);
+}
+
+void CwCallsignSpotter::scanWindow(bool streamSettled)
+{
+    const QRegularExpressionMatch m = deRegex().match(m_window);
+    if (!m.hasMatch()) {
+        m_settleTimer.stop();
+        return;
+    }
+    // A match that runs to the very end of the window may be incomplete
+    // ("...DE K1AB K1AB" now, "C" in the next chunk).  Hold it until either
+    // a following character arrives or the settle timer declares silence.
+    if (m.capturedEnd() >= m_window.size() && !streamSettled) {
+        m_settleTimer.start();
+        return;
+    }
+    m_settleTimer.stop();
+
+    const QString call = m.captured(1);
+    // Consume through the match so the same "DE X X" run can't re-fire as
+    // more text streams in behind it.
+    m_window.remove(0, m.capturedEnd());
+    emitSpot(call);
+
+    // A long chunk could contain a second full ID; keep scanning.
+    if (deRegex().match(m_window).hasMatch())
+        scanWindow(streamSettled);
+}
+
+void CwCallsignSpotter::emitSpot(const QString& call)
+{
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+    const qint64 last = m_lastSpotUtc.value(call, 0);
+    if (now - last < kReSpotSecs)
+        return;
+    m_lastSpotUtc.insert(call, now);
+
+    qCDebug(lcQrz) << "CW spotted callsign" << call;
+    emit callsignSpotted(call);
+}
+
+} // namespace AetherSDR

--- a/src/core/CwCallsignSpotter.h
+++ b/src/core/CwCallsignSpotter.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QDateTime>
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+namespace AetherSDR {
+
+// Watches a decoded-CW character stream for a station identifying itself
+// ("DE KI6BCJ KI6BCJ") and emits the callsign once per station.
+//
+// CW arrives a few characters at a time with decode errors sprinkled in,
+// so detection runs over a small rolling window of recent text and only
+// fires when the callsign after DE appears twice in a row — a single
+// garbled character breaks the repeat and correctly suppresses the spot.
+// The same spotter can watch any text stream that identifies stations
+// this way (the SSB voice-callsign decoder feeds its own path).
+class CwCallsignSpotter : public QObject {
+    Q_OBJECT
+
+public:
+    explicit CwCallsignSpotter(QObject* parent = nullptr);
+
+public slots:
+    // Slots so the automation bridge can drive detection end-to-end via
+    // QMetaObject::invokeMethod (`qrz spottext`) without a GUI include.
+
+    // Append decoded text (any chunk size). May emit callsignSpotted.
+    void feedText(const QString& text);
+
+    // Drop the rolling window — call on slice change / decoder reroute /
+    // panel clear so text from two stations never concatenates.
+    void clear();
+
+signals:
+    void callsignSpotted(const QString& call);
+
+private:
+    void scanWindow(bool streamSettled);
+    void emitSpot(const QString& call);
+
+    QString m_window;                       // recent decoded text, uppercase
+    QHash<QString, qint64> m_lastSpotUtc;   // per-call re-emit suppression
+    QTimer  m_settleTimer;                  // accepts an end-of-window match after silence
+
+    static constexpr int    kWindowChars   = 160;
+    static constexpr qint64 kReSpotSecs    = 120;  // same call fires again after this
+    static constexpr int    kSettleMs      = 3000;
+};
+
+} // namespace AetherSDR

--- a/src/core/DxccColorProvider.h
+++ b/src/core/DxccColorProvider.h
@@ -54,6 +54,10 @@ public:
     int  qsoCount()    const { return m_workedStatus.totalQsos(); }
     int  entityCount() const { return m_workedStatus.entityCount(); }
 
+    // The loaded cty.dat parser — shared with CallsignLookupService for
+    // prefix-fallback contact cards so cty.dat is parsed exactly once.
+    const CtyDatParser* ctyParser() const { return &m_ctyParser; }
+
     // Configurable colors (loaded/saved via AppSettings externally)
     QColor colorNewDxcc{0xFF, 0x30, 0x30};   // bright red
     QColor colorNewBand{0xFF, 0x8C, 0x00};   // orange

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -42,6 +42,7 @@ Q_LOGGING_CATEGORY(lcWaveform,   "aether.waveform",    QtWarningMsg)
 Q_LOGGING_CATEGORY(lcKiwiSdr,    "aether.kiwisdr",     QtDebugMsg)
 Q_LOGGING_CATEGORY(lcKiwiSdrAudio, "aether.kiwisdr.audio", QtWarningMsg)
 Q_LOGGING_CATEGORY(lcAutomation, "aether.automation",  QtInfoMsg)
+Q_LOGGING_CATEGORY(lcQrz,        "aether.qrz",         QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -76,6 +77,7 @@ LogManager::LogManager()
         {"aether.kiwisdr",    "KiwiSDR",     "KiwiSDR remote RX antennas: connect, handshake, audio/waterfall negotiation, reconnect, profile lifecycle"},
         {"aether.kiwisdr.audio", "KiwiSDR Audio/DSP", "Verbose KiwiSDR receive audio: frame decode, resampler, jitter/FIFO under/overrun, mixing (high-rate; off by default)"},
         {"aether.automation", "Automation Bridge", "Agent-drivable test bridge (#3646): QLocalServer verbs, widget snapshots, captures (AETHER_AUTOMATION only)"},
+        {"aether.qrz",        "QRZ Lookup",   "QRZ.com callsign lookups: session, cache, CW callsign spotting, photos"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -45,6 +45,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcWaveform)
 Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdr)
 Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdrAudio)
 Q_DECLARE_LOGGING_CATEGORY(lcAutomation)
+Q_DECLARE_LOGGING_CATEGORY(lcQrz)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/QrzClient.cpp
+++ b/src/core/QrzClient.cpp
@@ -1,0 +1,265 @@
+#include "QrzClient.h"
+
+#include "CallsignUtils.h"
+#include "LogManager.h"
+
+#include <QCoreApplication>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QXmlStreamReader>
+
+namespace AetherSDR {
+
+namespace {
+constexpr const char* kApiBase = "https://xmldata.qrz.com/xml/current/";
+constexpr int kTimeoutMs = 15000;
+
+bool isSessionInvalidError(const QString& err)
+{
+    // Server strings per the XML spec: "Session Timeout", "Invalid session key".
+    return err.contains(QLatin1String("session"), Qt::CaseInsensitive)
+        && (err.contains(QLatin1String("timeout"), Qt::CaseInsensitive)
+            || err.contains(QLatin1String("invalid"), Qt::CaseInsensitive));
+}
+} // namespace
+
+QrzClient::QrzClient(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void QrzClient::setCredentials(const QString& username, const QString& password)
+{
+    if (username == m_username && password == m_password)
+        return;
+    m_username = username;
+    m_password = password;
+    m_sessionKey.clear();  // force fresh login with the new credentials
+}
+
+QNetworkReply* QrzClient::getUrl(const QString& query)
+{
+    QUrl url{QString::fromLatin1(kApiBase)};
+    url.setQuery(query);
+    QNetworkRequest req{url};
+    req.setHeader(QNetworkRequest::UserAgentHeader,
+                  QStringLiteral("AetherSDR/%1").arg(QCoreApplication::applicationVersion()));
+    req.setTransferTimeout(kTimeoutMs);
+    return m_nam.get(req);
+}
+
+void QrzClient::lookup(const QString& call)
+{
+    const QString norm = Callsigns::normalized(call);
+    if (norm.isEmpty())
+        return;
+    if (!hasCredentials()) {
+        emit lookupFailed(norm, Error::AuthFailed,
+                          QStringLiteral("QRZ credentials are not configured"));
+        return;
+    }
+    if (!m_pending.contains(norm))
+        m_pending.enqueue(norm);
+    startNextLookup();
+}
+
+void QrzClient::startNextLookup()
+{
+    if (m_lookupInFlight || m_loginInFlight || m_pending.isEmpty())
+        return;
+    if (m_sessionKey.isEmpty()) {
+        startLogin();
+        return;
+    }
+
+    const QString call = m_pending.dequeue();
+    m_lookupInFlight = true;
+
+    QUrlQuery q;
+    q.addQueryItem(QStringLiteral("s"), m_sessionKey);
+    q.addQueryItem(QStringLiteral("callsign"), call);
+    auto* reply = getUrl(q.toString(QUrl::FullyEncoded));
+    const bool retried = m_retriedAfterRelogin.contains(call);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, call, retried] {
+        handleLookupReply(reply, call, retried);
+    });
+}
+
+void QrzClient::startLogin()
+{
+    if (m_loginInFlight)
+        return;
+    m_loginInFlight = true;
+
+    QUrlQuery q;
+    q.addQueryItem(QStringLiteral("username"), m_username);
+    q.addQueryItem(QStringLiteral("password"), m_password);
+    q.addQueryItem(QStringLiteral("agent"),
+                   QStringLiteral("AetherSDR%1").arg(QCoreApplication::applicationVersion()));
+    auto* reply = getUrl(q.toString(QUrl::FullyEncoded));
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        handleLoginReply(reply);
+    });
+}
+
+void QrzClient::handleLoginReply(QNetworkReply* reply)
+{
+    reply->deleteLater();
+    m_loginInFlight = false;
+
+    auto failAll = [this](Error error, const QString& message) {
+        qCWarning(lcQrz) << "QRZ login failed:" << message;
+        while (!m_pending.isEmpty())
+            emit lookupFailed(m_pending.dequeue(), error, message);
+    };
+
+    if (reply->error() != QNetworkReply::NoError) {
+        failAll(Error::Network, reply->errorString());
+        return;
+    }
+
+    const ParsedResponse resp = parseXml(reply->readAll());
+    if (resp.sessionKey.isEmpty()) {
+        const QString msg = resp.sessionError.isEmpty()
+            ? QStringLiteral("QRZ login rejected (no session key)")
+            : resp.sessionError;
+        failAll(Error::AuthFailed, msg);
+        return;
+    }
+
+    m_sessionKey = resp.sessionKey;
+    qCDebug(lcQrz) << "QRZ session established";
+    startNextLookup();
+}
+
+void QrzClient::handleLookupReply(QNetworkReply* reply, const QString& call,
+                                  bool retriedAfterRelogin)
+{
+    reply->deleteLater();
+    m_lookupInFlight = false;
+
+    if (reply->error() != QNetworkReply::NoError) {
+        emit lookupFailed(call, Error::Network, reply->errorString());
+        startNextLookup();
+        return;
+    }
+
+    ParsedResponse resp = parseXml(reply->readAll());
+
+    // A response without our session key means the server invalidated it.
+    // Re-login once and retry this callsign; a second failure is terminal
+    // for this lookup (avoids a login loop on flapping sessions).
+    if (resp.sessionKey.isEmpty() || isSessionInvalidError(resp.sessionError)) {
+        m_sessionKey.clear();
+        if (!retriedAfterRelogin && !resp.info.isValid()) {
+            qCDebug(lcQrz) << "QRZ session expired; re-authenticating for" << call;
+            m_retriedAfterRelogin.insert(call);
+            m_pending.prepend(call);
+            startNextLookup();
+            return;
+        }
+    }
+
+    m_retriedAfterRelogin.remove(call);
+    if (resp.info.isValid()) {
+        resp.info.fetchedUtc = QDateTime::currentSecsSinceEpoch();
+        emit lookupSucceeded(resp.info);
+    } else {
+        const QString err = resp.sessionError.isEmpty()
+            ? QStringLiteral("No data returned") : resp.sessionError;
+        const bool notFound = err.contains(QLatin1String("not found"), Qt::CaseInsensitive);
+        emit lookupFailed(call, notFound ? Error::NotFound : Error::Provider, err);
+    }
+    startNextLookup();
+}
+
+void QrzClient::testLogin(const QString& username, const QString& password)
+{
+    QUrlQuery q;
+    q.addQueryItem(QStringLiteral("username"), username);
+    q.addQueryItem(QStringLiteral("password"), password);
+    q.addQueryItem(QStringLiteral("agent"),
+                   QStringLiteral("AetherSDR%1").arg(QCoreApplication::applicationVersion()));
+    auto* reply = getUrl(q.toString(QUrl::FullyEncoded));
+    connect(reply, &QNetworkReply::finished, this, [this, reply] {
+        reply->deleteLater();
+        if (reply->error() != QNetworkReply::NoError) {
+            emit loginTestFinished(false, reply->errorString());
+            return;
+        }
+        const ParsedResponse resp = parseXml(reply->readAll());
+        if (resp.sessionKey.isEmpty()) {
+            emit loginTestFinished(false, resp.sessionError.isEmpty()
+                ? QStringLiteral("Login rejected") : resp.sessionError);
+        } else {
+            // SubExp arrives in sessionMessage when the server sends it —
+            // "non-subscriber" logins still get a key but limited fields.
+            emit loginTestFinished(true, resp.sessionMessage);
+        }
+    });
+}
+
+QrzClient::ParsedResponse QrzClient::parseXml(const QByteArray& xml)
+{
+    ParsedResponse resp;
+    QXmlStreamReader r(xml);
+
+    enum class Block { None, Session, Callsign };
+    Block block = Block::None;
+
+    while (!r.atEnd()) {
+        const QXmlStreamReader::TokenType tok = r.readNext();
+        if (tok == QXmlStreamReader::StartElement) {
+            const auto name = r.name();
+            if (name == QLatin1String("Session")) { block = Block::Session; continue; }
+            if (name == QLatin1String("Callsign")) { block = Block::Callsign; continue; }
+
+            const QString text = r.readElementText(QXmlStreamReader::SkipChildElements).trimmed();
+            if (block == Block::Session) {
+                if (name == QLatin1String("Key"))          resp.sessionKey = text;
+                else if (name == QLatin1String("Error"))   resp.sessionError = text;
+                else if (name == QLatin1String("Message")) resp.sessionMessage = text;
+                else if (name == QLatin1String("SubExp"))  {
+                    if (resp.sessionMessage.isEmpty())
+                        resp.sessionMessage = QStringLiteral("Subscription: %1").arg(text);
+                }
+            } else if (block == Block::Callsign) {
+                CallsignInfo& i = resp.info;
+                if (name == QLatin1String("call"))          i.call = text.toUpper();
+                else if (name == QLatin1String("fname"))    i.firstName = text;
+                else if (name == QLatin1String("name"))     i.lastName = text;
+                else if (name == QLatin1String("name_fmt")) i.nameFmt = text;
+                else if (name == QLatin1String("nickname")) i.nickname = text;
+                else if (name == QLatin1String("addr2"))    i.city = text;
+                else if (name == QLatin1String("state"))    i.state = text;
+                else if (name == QLatin1String("country"))  i.country = text;
+                else if (name == QLatin1String("county"))   i.county = text;
+                else if (name == QLatin1String("grid"))     i.grid = text;
+                else if (name == QLatin1String("class"))    i.licenseClass = text;
+                else if (name == QLatin1String("email"))    i.email = text;
+                else if (name == QLatin1String("url"))      i.url = text;
+                else if (name == QLatin1String("image"))    i.imageUrl = text;
+                else if (name == QLatin1String("lat")) {
+                    bool ok = false;
+                    const double v = text.toDouble(&ok);
+                    if (ok) { i.latitude = v; i.hasLatLon = true; }
+                } else if (name == QLatin1String("lon")) {
+                    bool ok = false;
+                    const double v = text.toDouble(&ok);
+                    if (ok) i.longitude = v;
+                }
+                else if (name == QLatin1String("lotw"))     i.lotw = (text == QLatin1String("1"));
+                else if (name == QLatin1String("eqsl"))     i.eqsl = (text == QLatin1String("1"));
+                else if (name == QLatin1String("mqsl"))     i.mailQsl = (text == QLatin1String("1"));
+            }
+        }
+    }
+    // lat without lon is useless; require both.
+    if (resp.info.hasLatLon && resp.info.longitude == 0.0 && resp.info.latitude == 0.0)
+        resp.info.hasLatLon = false;
+    return resp;
+}
+
+} // namespace AetherSDR

--- a/src/core/QrzClient.cpp
+++ b/src/core/QrzClient.cpp
@@ -111,6 +111,7 @@ void QrzClient::handleLoginReply(QNetworkReply* reply)
 
     auto failAll = [this](Error error, const QString& message) {
         qCWarning(lcQrz) << "QRZ login failed:" << message;
+        m_retriedAfterRelogin.clear();   // all pending are failing — don't leak retry flags (#3990)
         while (!m_pending.isEmpty())
             emit lookupFailed(m_pending.dequeue(), error, message);
     };
@@ -141,6 +142,7 @@ void QrzClient::handleLookupReply(QNetworkReply* reply, const QString& call,
     m_lookupInFlight = false;
 
     if (reply->error() != QNetworkReply::NoError) {
+        m_retriedAfterRelogin.remove(call);   // don't leak the retry flag (#3990)
         emit lookupFailed(call, Error::Network, reply->errorString());
         startNextLookup();
         return;
@@ -165,7 +167,7 @@ void QrzClient::handleLookupReply(QNetworkReply* reply, const QString& call,
     m_retriedAfterRelogin.remove(call);
     if (resp.info.isValid()) {
         resp.info.fetchedUtc = QDateTime::currentSecsSinceEpoch();
-        emit lookupSucceeded(resp.info);
+        emit lookupSucceeded(call, resp.info);
     } else {
         const QString err = resp.sessionError.isEmpty()
             ? QStringLiteral("No data returned") : resp.sessionError;
@@ -208,6 +210,7 @@ QrzClient::ParsedResponse QrzClient::parseXml(const QByteArray& xml)
 
     enum class Block { None, Session, Callsign };
     Block block = Block::None;
+    bool hasLat = false, hasLon = false;   // require BOTH before trusting geo (#3990)
 
     while (!r.atEnd()) {
         const QXmlStreamReader::TokenType tok = r.readNext();
@@ -244,11 +247,11 @@ QrzClient::ParsedResponse QrzClient::parseXml(const QByteArray& xml)
                 else if (name == QLatin1String("lat")) {
                     bool ok = false;
                     const double v = text.toDouble(&ok);
-                    if (ok) { i.latitude = v; i.hasLatLon = true; }
+                    if (ok) { i.latitude = v; hasLat = true; }
                 } else if (name == QLatin1String("lon")) {
                     bool ok = false;
                     const double v = text.toDouble(&ok);
-                    if (ok) i.longitude = v;
+                    if (ok) { i.longitude = v; hasLon = true; }
                 }
                 else if (name == QLatin1String("lotw"))     i.lotw = (text == QLatin1String("1"));
                 else if (name == QLatin1String("eqsl"))     i.eqsl = (text == QLatin1String("1"));
@@ -256,9 +259,9 @@ QrzClient::ParsedResponse QrzClient::parseXml(const QByteArray& xml)
             }
         }
     }
-    // lat without lon is useless; require both.
-    if (resp.info.hasLatLon && resp.info.longitude == 0.0 && resp.info.latitude == 0.0)
-        resp.info.hasLatLon = false;
+    // lat without lon (or vice-versa) is useless — a valid lat with a missing
+    // lon would otherwise leave a bogus (lat, 0.0). Require both. (#3990)
+    resp.info.hasLatLon = hasLat && hasLon;
     return resp;
 }
 

--- a/src/core/QrzClient.h
+++ b/src/core/QrzClient.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "CallsignInfo.h"
+
+#include <QNetworkAccessManager>
+#include <QObject>
+#include <QQueue>
+#include <QSet>
+#include <QString>
+
+class QNetworkReply;
+
+namespace AetherSDR {
+
+// Minimal QRZ.com XML API client (https://xmldata.qrz.com/xml/current/).
+//
+// Handles the session-key lifecycle the API requires: login with
+// username/password once, reuse the returned key for every lookup, and
+// transparently re-login + retry when the server invalidates the key
+// (keys have no guaranteed lifetime and die on IP change).  The session
+// key is memory-only; credentials live in AppSettings (username) and the
+// OS keychain (password) and are handed in via setCredentials().
+//
+// One lookup is in flight at a time; callers queue freely and results
+// come back per-callsign through lookupSucceeded/lookupFailed.  Callers
+// wanting caching or request coalescing use CallsignLookupService, not
+// this class directly.
+class QrzClient : public QObject {
+    Q_OBJECT
+
+public:
+    enum class Error {
+        Network,        // transport failure / timeout
+        AuthFailed,     // bad username/password
+        NotFound,       // callsign not in the QRZ database
+        Provider,       // any other server-reported error
+    };
+    Q_ENUM(Error)
+
+    explicit QrzClient(QObject* parent = nullptr);
+
+    void setCredentials(const QString& username, const QString& password);
+    bool hasCredentials() const { return !m_username.isEmpty() && !m_password.isEmpty(); }
+
+    // Queue a lookup for `call` (normalized internally).  Results arrive
+    // via lookupSucceeded/lookupFailed with the same normalized call.
+    void lookup(const QString& call);
+
+    // Standalone credential check for the setup tab's "Test" button —
+    // logs in with the given credentials without touching the client's
+    // stored session.  Result arrives via loginTestFinished.
+    void testLogin(const QString& username, const QString& password);
+
+signals:
+    void lookupSucceeded(const AetherSDR::CallsignInfo& info);
+    void lookupFailed(const QString& call, QrzClient::Error error, const QString& message);
+    void loginTestFinished(bool ok, const QString& message);
+
+private:
+    void startLogin();
+    void startNextLookup();
+    void handleLoginReply(QNetworkReply* reply);
+    void handleLookupReply(QNetworkReply* reply, const QString& call, bool retriedAfterRelogin);
+    QNetworkReply* getUrl(const QString& query);
+
+    // Parsed subset of a QRZ XML response — session block + callsign block.
+    struct ParsedResponse {
+        QString sessionKey;
+        QString sessionError;
+        QString sessionMessage;
+        CallsignInfo info;
+    };
+    static ParsedResponse parseXml(const QByteArray& xml);
+
+    QNetworkAccessManager m_nam;
+    QString m_username;
+    QString m_password;
+    QString m_sessionKey;
+    bool    m_loginInFlight{false};
+    bool    m_lookupInFlight{false};
+    QQueue<QString> m_pending;
+    QSet<QString>   m_retriedAfterRelogin;  // one relogin+retry per call, no loops
+};
+
+} // namespace AetherSDR

--- a/src/core/QrzClient.h
+++ b/src/core/QrzClient.h
@@ -52,7 +52,10 @@ public:
     void testLogin(const QString& username, const QString& password);
 
 signals:
-    void lookupSucceeded(const AetherSDR::CallsignInfo& info);
+    // `call` is the queried (normalized) form; `info.call` is QRZ's canonical
+    // base call, which can differ for portable/prefixed queries — consumers
+    // must key their in-flight/cache state on `call`, not info.call (#3990).
+    void lookupSucceeded(const QString& call, const AetherSDR::CallsignInfo& info);
     void lookupFailed(const QString& call, QrzClient::Error error, const QString& message);
     void loginTestFinished(bool ok, const QString& message);
 

--- a/src/core/QrzLookupSettings.h
+++ b/src/core/QrzLookupSettings.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "AppSettings.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+// Persistence helper for the QRZ callsign-lookup feature.
+//
+// One nested JSON blob under AppSettings["QrzLookup"], per the
+// config-as-single-object rule (constitution Principle V):
+//
+//   AppSettings["QrzLookup"] = {"enabled": "True", "username": "ki6bcj"}
+//
+// The password deliberately does NOT live here — it goes to the OS
+// keychain via CallsignLookupService (key "qrz_password"), so the
+// settings file never holds a credential.
+class QrzLookupSettings {
+public:
+    static bool enabled()
+    {
+        return readObj().value("enabled").toString("True") == "True";
+    }
+    static QString username()
+    {
+        return readObj().value("username").toString();
+    }
+
+    static void setEnabled(bool on)
+    {
+        QJsonObject o = readObj();
+        o["enabled"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+    static void setUsername(const QString& user)
+    {
+        QJsonObject o = readObj();
+        o["username"] = user;
+        if (!o.contains("enabled"))
+            o["enabled"] = QStringLiteral("True");
+        write(o);
+    }
+
+private:
+    static QJsonObject readObj()
+    {
+        const QString json =
+            AppSettings::instance().value("QrzLookup", QString{}).toString();
+        if (json.isEmpty()) return {};
+        return QJsonDocument::fromJson(json.toUtf8()).object();
+    }
+    static void write(const QJsonObject& o)
+    {
+        auto& s = AppSettings::instance();
+        s.setValue("QrzLookup",
+                   QString::fromUtf8(
+                       QJsonDocument(o).toJson(QJsonDocument::Compact)));
+        s.save();
+    }
+};
+
+} // namespace AetherSDR

--- a/src/gui/CallsignCard.cpp
+++ b/src/gui/CallsignCard.cpp
@@ -6,6 +6,7 @@
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QLocale>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
@@ -51,6 +52,21 @@ private:
                 QUrl(QStringLiteral("https://www.qrz.com/db/%1").arg(call)));
     }
 };
+
+// "2,412 mi @ 078°" / "3 881 km @ 078°" from the operator's position;
+// "~" marks a DXCC-country-center estimate.  Locale picks the unit.
+QString formatDistanceBearing(double km, double bearingDeg, bool approx)
+{
+    const bool imperial =
+        QLocale().measurementSystem() != QLocale::MetricSystem;
+    const double value = imperial ? km * 0.621371 : km;
+    const QString unit = imperial ? QStringLiteral("mi") : QStringLiteral("km");
+    return QStringLiteral("%1%L2 %3 @ %4°")
+        .arg(approx ? QStringLiteral("~") : QString())
+        .arg(qRound(value))
+        .arg(unit)
+        .arg(qRound(bearingDeg), 3, 10, QLatin1Char('0'));
+}
 
 // Rounded-corner copy of a station photo scaled to fill edge×edge.
 QPixmap roundedPhoto(const QPixmap& src, int edge, int radius)
@@ -257,15 +273,27 @@ void CallsignCard::showInfo(const CallsignInfo& info, bool fromCache)
 
     m_classChip->setText(info.licenseClass);
     m_classChip->setVisible(!info.licenseClass.isEmpty());
-    m_cacheHint->setText(fromCache ? QStringLiteral("cached") : QString());
-    m_cacheHint->setVisible(fromCache);
+    // One provenance hint slot: "cached" (7-day cache) or "prefix"
+    // (country-level cty.dat stand-in while QRZ is unreachable/slow).
+    m_cacheHint->setText(info.prefixOnly ? QStringLiteral("prefix")
+                         : fromCache     ? QStringLiteral("cached")
+                                         : QString());
+    m_cacheHint->setVisible(info.prefixOnly || fromCache);
 
-    m_nameLabel->setText(info.displayName());
+    // A prefix card has no operator name; the country line carries it.
+    m_nameLabel->setText(info.prefixOnly ? QString() : info.displayName());
     m_locationLabel->setText(info.displayLocation());
 
     QStringList meta;
     if (!info.grid.isEmpty())   meta << info.grid;
     if (!info.county.isEmpty()) meta << info.county;
+    if (info.prefixOnly) {
+        if (!info.continent.isEmpty()) meta << info.continent;
+        if (info.cqZone > 0) meta << QStringLiteral("CQ %1").arg(info.cqZone);
+    }
+    if (info.distanceKm >= 0.0)
+        meta << formatDistanceBearing(info.distanceKm, info.bearingDeg,
+                                      info.distanceApprox);
     if (m_variant == Variant::Large) {
         QStringList qsl;
         if (info.lotw)    qsl << QStringLiteral("LoTW");

--- a/src/gui/CallsignCard.cpp
+++ b/src/gui/CallsignCard.cpp
@@ -1,0 +1,292 @@
+#include "CallsignCard.h"
+
+#include "core/ThemeManager.h"
+
+#include <QDesktopServices>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
+#include <QPushButton>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+// QLabel that opens the station's QRZ page on click — gives the callsign a
+// link affordance without pulling in QTextBrowser.  Keyboard-activatable
+// per docs/a11y.md (interactive-QLabel anti-pattern): Space/Enter trigger.
+class CallsignLinkLabel : public QLabel {
+public:
+    using QLabel::QLabel;
+
+protected:
+    void mouseReleaseEvent(QMouseEvent* ev) override
+    {
+        if (ev->button() == Qt::LeftButton)
+            openQrzPage();
+        QLabel::mouseReleaseEvent(ev);
+    }
+    void keyPressEvent(QKeyEvent* ev) override
+    {
+        if (ev->key() == Qt::Key_Space || ev->key() == Qt::Key_Return
+            || ev->key() == Qt::Key_Enter) {
+            openQrzPage();
+            return;
+        }
+        QLabel::keyPressEvent(ev);
+    }
+
+private:
+    void openQrzPage()
+    {
+        const QString call = text().trimmed();
+        if (!call.isEmpty() && !call.contains(QLatin1Char(' ')))
+            QDesktopServices::openUrl(
+                QUrl(QStringLiteral("https://www.qrz.com/db/%1").arg(call)));
+    }
+};
+
+// Rounded-corner copy of a station photo scaled to fill edge×edge.
+QPixmap roundedPhoto(const QPixmap& src, int edge, int radius)
+{
+    const QPixmap scaled = src.scaled(edge, edge, Qt::KeepAspectRatioByExpanding,
+                                      Qt::SmoothTransformation);
+    QPixmap out(edge, edge);
+    out.fill(Qt::transparent);
+    QPainter p(&out);
+    p.setRenderHint(QPainter::Antialiasing);
+    QPainterPath path;
+    path.addRoundedRect(0, 0, edge, edge, radius, radius);
+    p.setClipPath(path);
+    const int x = (edge - scaled.width()) / 2;
+    const int y = (edge - scaled.height()) / 2;
+    p.drawPixmap(x, y, scaled);
+    return out;
+}
+
+} // namespace
+
+CallsignCard::CallsignCard(Variant variant, QWidget* parent)
+    : QFrame(parent), m_variant(variant)
+{
+    const bool large = (m_variant == Variant::Large);
+    setObjectName(large ? QStringLiteral("callsignCardLarge")
+                        : QStringLiteral("callsignCard"));
+    setAccessibleName(QStringLiteral("Station contact card"));
+    setAccessibleDescription(
+        QStringLiteral("Callsign, name, and location of the looked-up station"));
+
+    auto* outer = new QHBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
+
+    // The colored vertical line on the left edge — the card's signature.
+    m_accentBar = new QWidget(this);
+    m_accentBar->setFixedWidth(large ? 5 : 4);
+    outer->addWidget(m_accentBar);
+
+    auto* body = new QHBoxLayout;
+    const int pad = large ? 12 : 6;
+    body->setContentsMargins(pad, pad, pad, pad);
+    body->setSpacing(large ? 12 : 8);
+    outer->addLayout(body, 1);
+
+    m_photoLabel = new QLabel(this);
+    m_photoLabel->setFixedSize(photoEdge(), photoEdge());
+    m_photoLabel->setAlignment(Qt::AlignCenter);
+    m_photoLabel->setAccessibleName(QStringLiteral("Station photo"));
+    body->addWidget(m_photoLabel, 0, Qt::AlignTop);
+
+    auto* details = new QVBoxLayout;
+    details->setSpacing(large ? 3 : 1);
+    body->addLayout(details, 1);
+
+    auto* callRow = new QHBoxLayout;
+    callRow->setSpacing(6);
+    m_callLabel = new CallsignLinkLabel(this);
+    m_callLabel->setObjectName(QStringLiteral("callsignCardCall"));
+    m_callLabel->setAccessibleName(QStringLiteral("Callsign"));
+    m_callLabel->setCursor(Qt::PointingHandCursor);
+    m_callLabel->setFocusPolicy(Qt::TabFocus);
+    m_callLabel->setToolTip(QStringLiteral("Open this station's QRZ.com page"));
+    callRow->addWidget(m_callLabel);
+
+    m_classChip = new QLabel(this);
+    m_classChip->setObjectName(QStringLiteral("callsignCardClass"));
+    m_classChip->setAccessibleName(QStringLiteral("License class"));
+    callRow->addWidget(m_classChip);
+
+    m_cacheHint = new QLabel(this);
+    m_cacheHint->setObjectName(QStringLiteral("callsignCardCacheHint"));
+    callRow->addWidget(m_cacheHint);
+    callRow->addStretch();
+
+    m_closeBtn = new QPushButton(QStringLiteral("✕"), this);
+    m_closeBtn->setObjectName(QStringLiteral("callsignCardClose"));
+    m_closeBtn->setAccessibleName(QStringLiteral("Close contact card"));
+    m_closeBtn->setFixedSize(16, 16);
+    m_closeBtn->setToolTip(QStringLiteral("Hide the contact card"));
+    m_closeBtn->setVisible(false);
+    connect(m_closeBtn, &QPushButton::clicked, this, &CallsignCard::closeRequested);
+    callRow->addWidget(m_closeBtn, 0, Qt::AlignTop);
+    details->addLayout(callRow);
+
+    m_nameLabel = new QLabel(this);
+    m_nameLabel->setObjectName(QStringLiteral("callsignCardName"));
+    m_nameLabel->setAccessibleName(QStringLiteral("Operator name"));
+    details->addWidget(m_nameLabel);
+
+    m_locationLabel = new QLabel(this);
+    m_locationLabel->setObjectName(QStringLiteral("callsignCardLocation"));
+    m_locationLabel->setAccessibleName(QStringLiteral("Location"));
+    details->addWidget(m_locationLabel);
+
+    m_metaLabel = new QLabel(this);
+    m_metaLabel->setObjectName(QStringLiteral("callsignCardMeta"));
+    m_metaLabel->setAccessibleName(QStringLiteral("Grid and details"));
+    details->addWidget(m_metaLabel);
+
+    details->addStretch();
+
+    applyTheme();
+    connect(&ThemeManager::instance(), &ThemeManager::themeChanged,
+            this, &CallsignCard::applyTheme);
+
+    clearCard();
+}
+
+int CallsignCard::photoEdge() const
+{
+    return m_variant == Variant::Large ? 96 : 56;
+}
+
+void CallsignCard::applyTheme()
+{
+    const bool large = (m_variant == Variant::Large);
+    auto& tm = ThemeManager::instance();
+
+    tm.applyStyleSheet(this,
+        QStringLiteral("QFrame#%1 { background: {{color.background.1}};"
+                       " border: 1px solid {{color.border.strong}};"
+                       " border-radius: 4px; }").arg(objectName()));
+    tm.applyStyleSheet(m_accentBar,
+        "QWidget { background: {{color.accent}};"
+        " border-top-left-radius: 4px; border-bottom-left-radius: 4px; }");
+    tm.applyStyleSheet(m_callLabel,
+        QStringLiteral("QLabel { color: {{color.accent.bright}}; font-size: %1px;"
+                       " font-weight: bold; background: transparent; border: none; }"
+                       "QLabel:focus { text-decoration: underline; }")
+            .arg(large ? 22 : 15));
+    tm.applyStyleSheet(m_classChip,
+        QStringLiteral("QLabel { color: {{color.accent}};"
+                       " border: 1px solid {{color.accent.dim}}; border-radius: 3px;"
+                       " padding: 0px 4px; font-size: %1px; background: transparent; }")
+            .arg(large ? 11 : 9));
+    tm.applyStyleSheet(m_cacheHint,
+        QStringLiteral("QLabel { color: {{color.text.label}}; font-size: %1px;"
+                       " background: transparent; border: none; }").arg(large ? 10 : 8));
+    tm.applyStyleSheet(m_nameLabel,
+        QStringLiteral("QLabel { color: {{color.text.primary}}; font-size: %1px;"
+                       " background: transparent; border: none; }").arg(large ? 15 : 12));
+    tm.applyStyleSheet(m_locationLabel,
+        QStringLiteral("QLabel { color: {{color.text.secondary}}; font-size: %1px;"
+                       " background: transparent; border: none; }").arg(large ? 13 : 11));
+    tm.applyStyleSheet(m_metaLabel,
+        QStringLiteral("QLabel { color: {{color.text.label}}; font-size: %1px;"
+                       " background: transparent; border: none; }").arg(large ? 12 : 10));
+    tm.applyStyleSheet(m_photoLabel,
+        QStringLiteral("QLabel { background: {{color.background.2}};"
+                       " border: none; border-radius: 6px; color: {{color.text.label}};"
+                       " font-size: %1px; }").arg(photoEdge() / 2));
+    tm.applyStyleSheet(m_closeBtn,
+        "QPushButton { background: transparent; color: {{color.text.label}};"
+        " border: none; font-size: 10px; }"
+        "QPushButton:hover { color: {{color.accent.danger}}; }");
+}
+
+void CallsignCard::setPlaceholderPhoto()
+{
+    // Person-silhouette glyph on the themed placeholder background.
+    m_photoLabel->setPixmap(QPixmap());
+    m_photoLabel->setText(QStringLiteral("\U0001F464"));  // 👤
+}
+
+void CallsignCard::setCloseButtonVisible(bool visible)
+{
+    m_closeBtn->setVisible(visible);
+}
+
+void CallsignCard::clearCard()
+{
+    m_call.clear();
+    m_callLabel->setText({});
+    m_classChip->setVisible(false);
+    m_cacheHint->setVisible(false);
+    m_nameLabel->setText({});
+    m_locationLabel->setText({});
+    m_metaLabel->setText({});
+    setPlaceholderPhoto();
+}
+
+void CallsignCard::showPending(const QString& call)
+{
+    clearCard();
+    m_call = call;
+    m_callLabel->setText(call);
+    m_nameLabel->setText(QStringLiteral("Looking up…"));
+}
+
+void CallsignCard::showError(const QString& call, const QString& message)
+{
+    clearCard();
+    m_call = call;
+    m_callLabel->setText(call);
+    m_nameLabel->setText(message);
+}
+
+void CallsignCard::showInfo(const CallsignInfo& info, bool fromCache)
+{
+    m_call = info.call;
+    m_callLabel->setText(info.call);
+
+    m_classChip->setText(info.licenseClass);
+    m_classChip->setVisible(!info.licenseClass.isEmpty());
+    m_cacheHint->setText(fromCache ? QStringLiteral("cached") : QString());
+    m_cacheHint->setVisible(fromCache);
+
+    m_nameLabel->setText(info.displayName());
+    m_locationLabel->setText(info.displayLocation());
+
+    QStringList meta;
+    if (!info.grid.isEmpty())   meta << info.grid;
+    if (!info.county.isEmpty()) meta << info.county;
+    if (m_variant == Variant::Large) {
+        QStringList qsl;
+        if (info.lotw)    qsl << QStringLiteral("LoTW");
+        if (info.eqsl)    qsl << QStringLiteral("eQSL");
+        if (info.mailQsl) qsl << QStringLiteral("QSL");
+        if (!qsl.isEmpty()) meta << qsl.join(QLatin1Char('/'));
+    }
+    m_metaLabel->setText(meta.join(QStringLiteral(" · ")));
+
+    setPlaceholderPhoto();
+}
+
+void CallsignCard::setPhotoPath(const QString& imagePath)
+{
+    QPixmap pm(imagePath);
+    if (pm.isNull()) {
+        setPlaceholderPhoto();
+        return;
+    }
+    m_photoLabel->setText({});
+    m_photoLabel->setPixmap(roundedPhoto(pm, photoEdge(), 6));
+}
+
+} // namespace AetherSDR

--- a/src/gui/CallsignCard.cpp
+++ b/src/gui/CallsignCard.cpp
@@ -10,6 +10,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPainterPath>
+#include <QImageReader>
 #include <QPixmap>
 #include <QPushButton>
 #include <QUrl>
@@ -308,13 +309,22 @@ void CallsignCard::showInfo(const CallsignInfo& info, bool fromCache)
 
 void CallsignCard::setPhotoPath(const QString& imagePath)
 {
-    QPixmap pm(imagePath);
-    if (pm.isNull()) {
+    // Check dimensions before decoding so an image with a small file but huge
+    // pixel dimensions (decompression bomb) can't freeze/OOM the GUI. (#3990)
+    QImageReader reader(imagePath);
+    const QSize dim = reader.size();
+    if (dim.isValid() && (dim.width() > 4096 || dim.height() > 4096)) {
+        setPlaceholderPhoto();
+        return;
+    }
+    reader.setAutoTransform(true);
+    const QImage img = reader.read();
+    if (img.isNull()) {
         setPlaceholderPhoto();
         return;
     }
     m_photoLabel->setText({});
-    m_photoLabel->setPixmap(roundedPhoto(pm, photoEdge(), 6));
+    m_photoLabel->setPixmap(roundedPhoto(QPixmap::fromImage(img), photoEdge(), 6));
 }
 
 } // namespace AetherSDR

--- a/src/gui/CallsignCard.h
+++ b/src/gui/CallsignCard.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "core/CallsignInfo.h"
+
+#include <QFrame>
+
+class QLabel;
+class QPushButton;
+class QGridLayout;
+
+namespace AetherSDR {
+
+// Contact card for one station: colored vertical accent bar, photo on the
+// left, callsign / name / location details to the right.  One widget serves
+// every surface that shows "who is this station" — the CW decoder panel,
+// the Callsign Lookup dialog, and the future SSB voice-callsign decoder —
+// so the operator learns a single visual.
+//
+//   ┃ ┌────┐  KI6BCJ            Extra
+//   ┃ │ 📷 │  Patrick Jensen
+//   ┃ └────┘  San Jose, CA, United States
+//   ┃          CM97 · Santa Clara
+//
+// Compact fits the decoder strip at the bottom of a panadapter; Large is
+// the lookup-dialog variant with a bigger photo and extra detail rows.
+// Colors come from ThemeManager tokens and follow live theme switches.
+class CallsignCard : public QFrame {
+    Q_OBJECT
+
+public:
+    enum class Variant { Compact, Large };
+
+    explicit CallsignCard(Variant variant, QWidget* parent = nullptr);
+
+    // "Looking up KI6BCJ…" placeholder while the network round-trip runs.
+    void showPending(const QString& call);
+    // Fill from a lookup result. `fromCache` adds a subtle "cached" hint.
+    void showInfo(const CallsignInfo& info, bool fromCache);
+    // "KI6BCJ — not found" (or other provider error) terminal state.
+    void showError(const QString& call, const QString& message);
+    // Station photo arrived (path into the photo cache).
+    void setPhotoPath(const QString& imagePath);
+
+    void clearCard();
+
+    // Callsign currently displayed (pending, error, or filled).
+    QString currentCall() const { return m_call; }
+
+    // Compact cards embed a ✕ button; the host hides the card on this.
+    void setCloseButtonVisible(bool visible);
+
+signals:
+    void closeRequested();
+
+private:
+    void applyTheme();
+    void setPlaceholderPhoto();
+    int  photoEdge() const;
+
+    Variant m_variant;
+    QString m_call;
+
+    QWidget*     m_accentBar{nullptr};
+    QLabel*      m_photoLabel{nullptr};
+    QLabel*      m_callLabel{nullptr};
+    QLabel*      m_classChip{nullptr};
+    QLabel*      m_cacheHint{nullptr};
+    QLabel*      m_nameLabel{nullptr};
+    QLabel*      m_locationLabel{nullptr};
+    QLabel*      m_metaLabel{nullptr};
+    QPushButton* m_closeBtn{nullptr};
+};
+
+} // namespace AetherSDR

--- a/src/gui/CallsignLookupDialog.cpp
+++ b/src/gui/CallsignLookupDialog.cpp
@@ -1,0 +1,159 @@
+#include "CallsignLookupDialog.h"
+
+#include "CallsignCard.h"
+#include "core/CallsignLookupService.h"
+#include "core/CallsignUtils.h"
+#include "core/ThemeManager.h"
+
+#include <QDateTime>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+CallsignLookupDialog::CallsignLookupDialog(QWidget* parent)
+    : PersistentDialog(QStringLiteral("Callsign Lookup"),
+                       QStringLiteral("CallsignLookupDialogGeometry"), parent)
+{
+    setObjectName(QStringLiteral("CallsignLookupDialog"));
+    setMinimumSize(420, 260);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setContentsMargins(12, 12, 12, 12);
+    root->setSpacing(10);
+
+    auto* inputRow = new QHBoxLayout;
+    inputRow->setSpacing(8);
+
+    m_input = new QLineEdit(this);
+    m_input->setObjectName(QStringLiteral("callsignLookupInput"));
+    m_input->setAccessibleName(QStringLiteral("Callsign to look up"));
+    m_input->setPlaceholderText(QStringLiteral("Enter callsign — e.g. KI6BCJ"));
+    m_input->setMaxLength(14);
+    ThemeManager::instance().applyStyleSheet(m_input,
+        "QLineEdit { background: {{color.background.0}}; color: {{color.text.primary}};"
+        " border: 1px solid {{color.border.strong}}; border-radius: 3px;"
+        " padding: 5px 8px; font-size: 14px; font-weight: bold; }");
+    // Callsigns are uppercase; retype as the operator enters them.
+    connect(m_input, &QLineEdit::textEdited, this, [this](const QString& t) {
+        const QString up = t.toUpper();
+        if (up != t)
+            m_input->setText(up);
+    });
+    connect(m_input, &QLineEdit::returnPressed, this, [this] { startLookup(false); });
+    inputRow->addWidget(m_input, 1);
+
+    const QString btnStyle =
+        "QPushButton { background: {{color.background.2}}; color: {{color.text.primary}};"
+        " border: 1px solid {{color.border.strong}}; border-radius: 3px;"
+        " padding: 5px 14px; font-size: 12px; }"
+        "QPushButton:hover { border-color: {{color.accent}}; color: {{color.accent.bright}}; }"
+        "QPushButton:disabled { color: {{color.text.disabled}}; }";
+
+    m_lookupBtn = new QPushButton(QStringLiteral("Lookup"), this);
+    m_lookupBtn->setObjectName(QStringLiteral("callsignLookupGo"));
+    m_lookupBtn->setAccessibleName(QStringLiteral("Look up callsign"));
+    m_lookupBtn->setDefault(true);
+    ThemeManager::instance().applyStyleSheet(m_lookupBtn, btnStyle);
+    connect(m_lookupBtn, &QPushButton::clicked, this, [this] { startLookup(false); });
+    inputRow->addWidget(m_lookupBtn);
+
+    m_refreshBtn = new QPushButton(QStringLiteral("Refresh"), this);
+    m_refreshBtn->setObjectName(QStringLiteral("callsignLookupRefresh"));
+    m_refreshBtn->setAccessibleName(QStringLiteral("Refresh from QRZ, bypassing the cache"));
+    m_refreshBtn->setToolTip(QStringLiteral("Fetch fresh data from QRZ.com even if cached"));
+    ThemeManager::instance().applyStyleSheet(m_refreshBtn, btnStyle);
+    connect(m_refreshBtn, &QPushButton::clicked, this, [this] { startLookup(true); });
+    inputRow->addWidget(m_refreshBtn);
+
+    root->addLayout(inputRow);
+
+    m_card = new CallsignCard(CallsignCard::Variant::Large, this);
+    m_card->setVisible(false);
+    root->addWidget(m_card);
+
+    m_status = new QLabel(this);
+    m_status->setObjectName(QStringLiteral("callsignLookupStatus"));
+    m_status->setWordWrap(true);
+    ThemeManager::instance().applyStyleSheet(m_status,
+        "QLabel { color: {{color.text.label}}; font-size: 11px; background: transparent; }");
+    root->addWidget(m_status);
+
+    root->addStretch();
+
+    auto& svc = CallsignLookupService::instance();
+    connect(&svc, &CallsignLookupService::infoReady, this,
+            [this](const CallsignInfo& info, bool fromCache) {
+        if (info.call != m_pendingCall)
+            return;
+        m_card->setVisible(true);
+        m_card->showInfo(info, fromCache);
+        if (fromCache) {
+            const qint64 ageDays =
+                (QDateTime::currentSecsSinceEpoch() - info.fetchedUtc) / 86400;
+            setStatus(ageDays > 0
+                ? QStringLiteral("From cache — fetched %1 day(s) ago").arg(ageDays)
+                : QStringLiteral("From cache — fetched today"));
+        } else {
+            setStatus(QStringLiteral("Fetched from QRZ.com"));
+        }
+        const QString photo =
+            CallsignLookupService::instance().photoPathFor(info.call);
+        if (!photo.isEmpty())
+            m_card->setPhotoPath(photo);
+    });
+    connect(&svc, &CallsignLookupService::photoReady, this,
+            [this](const QString& call, const QString& imagePath) {
+        if (call == m_pendingCall)
+            m_card->setPhotoPath(imagePath);
+    });
+    connect(&svc, &CallsignLookupService::lookupFailed, this,
+            [this](const QString& call, const QString& message) {
+        if (call != m_pendingCall)
+            return;
+        m_card->setVisible(true);
+        m_card->showError(call, message);
+        setStatus(message);
+    });
+
+    if (!svc.hasCredentials()) {
+        setStatus(QStringLiteral(
+            "QRZ.com account not configured — add your username and password "
+            "in Radio Setup → QRZ."));
+    }
+}
+
+void CallsignLookupDialog::setStatus(const QString& text)
+{
+    m_status->setText(text);
+}
+
+void CallsignLookupDialog::lookupCallsign(const QString& call)
+{
+    m_input->setText(Callsigns::normalized(call));
+    startLookup(false);
+}
+
+void CallsignLookupDialog::startLookup(bool forceRefresh)
+{
+    const QString call = Callsigns::normalized(m_input->text());
+    if (call.isEmpty())
+        return;
+    if (!Callsigns::isLikelyCallsign(call)) {
+        m_pendingCall = call;
+        m_card->setVisible(true);
+        m_card->showError(call, QStringLiteral("Doesn't look like a callsign"));
+        setStatus({});
+        return;
+    }
+    m_pendingCall = call;
+    m_card->setVisible(true);
+    m_card->showPending(call);
+    setStatus({});
+    CallsignLookupService::instance().lookup(call, forceRefresh);
+}
+
+} // namespace AetherSDR

--- a/src/gui/CallsignLookupDialog.cpp
+++ b/src/gui/CallsignLookupDialog.cpp
@@ -91,7 +91,11 @@ CallsignLookupDialog::CallsignLookupDialog(QWidget* parent)
             return;
         m_card->setVisible(true);
         m_card->showInfo(info, fromCache);
-        if (fromCache) {
+        if (info.prefixOnly) {
+            setStatus(QStringLiteral(
+                "QRZ.com unavailable — showing country-level prefix data "
+                "(cty.dat). Full details will replace this if QRZ answers."));
+        } else if (fromCache) {
             const qint64 ageDays =
                 (QDateTime::currentSecsSinceEpoch() - info.fetchedUtc) / 86400;
             setStatus(ageDays > 0
@@ -121,8 +125,9 @@ CallsignLookupDialog::CallsignLookupDialog(QWidget* parent)
 
     if (!svc.hasCredentials()) {
         setStatus(QStringLiteral(
-            "QRZ.com account not configured — add your username and password "
-            "in Radio Setup → QRZ."));
+            "QRZ.com account not configured — lookups fall back to "
+            "country-level prefix data. Add your username and password in "
+            "Radio Setup → QRZ for full details."));
     }
 }
 

--- a/src/gui/CallsignLookupDialog.h
+++ b/src/gui/CallsignLookupDialog.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QLabel;
+class QLineEdit;
+class QPushButton;
+
+namespace AetherSDR {
+
+class CallsignCard;
+
+// View → Callsign Lookup: type a callsign, get the large contact card.
+// Results ride CallsignLookupService (same QRZ client + 7-day cache the
+// CW decoder card uses), so repeated lookups cost nothing and the two
+// surfaces always agree.
+class CallsignLookupDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit CallsignLookupDialog(QWidget* parent = nullptr);
+
+    // Pre-fill and immediately look up (context-menu entry points).
+    void lookupCallsign(const QString& call);
+
+private:
+    void startLookup(bool forceRefresh);
+    void setStatus(const QString& text);
+
+    QLineEdit*    m_input{nullptr};
+    QPushButton*  m_lookupBtn{nullptr};
+    QPushButton*  m_refreshBtn{nullptr};
+    CallsignCard* m_card{nullptr};
+    QLabel*       m_status{nullptr};
+    QString       m_pendingCall;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1264,6 +1264,11 @@ MainWindow::MainWindow(QWidget* parent)
     // works without a radio connected.
     initNetScheduler();
 
+    // QRZ callsign lookup: CW spotter → lookup service → contact card →
+    // wireCallsignLookup() (MainWindow_Callsign.cpp). Client-side; works
+    // without a radio connected.
+    wireCallsignLookup();
+
     // Radio-model + TX-audio-stream wiring → wireRadioModel()
     // (MainWindow_Session.cpp, #3351 Phase 2c).
     wireRadioModel();
@@ -6404,7 +6409,13 @@ void MainWindow::routeCwDecoderOutput()
                    &m_cwDecoder, &CwDecoder::stop);
         disconnect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
                    &m_cwDecoderTx, &CwDecoder::stop);
+        disconnect(m_cwDecoderApplet, &PanadapterApplet::cwRxTextDisplayed,
+                   &m_cwCallsignSpotter, &CwCallsignSpotter::feedText);
     }
+
+    // Text from the old applet's stream must never concatenate with the
+    // new one's — a station boundary, as far as the spotter is concerned.
+    m_cwCallsignSpotter.clear();
 
     m_cwDecoderApplet = target;
 
@@ -6441,6 +6452,8 @@ void MainWindow::routeCwDecoderOutput()
                 &m_cwDecoder, &CwDecoder::stop);
         connect(m_cwDecoderApplet, &PanadapterApplet::cwPanelCloseRequested,
                 &m_cwDecoderTx, &CwDecoder::stop);
+        connect(m_cwDecoderApplet, &PanadapterApplet::cwRxTextDisplayed,
+                &m_cwCallsignSpotter, &CwCallsignSpotter::feedText);
     }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -23,6 +23,7 @@
 #include "core/SmartLinkClient.h"
 #include "core/WanConnection.h"
 #include "core/CwDecoder.h"
+#include "core/CwCallsignSpotter.h"
 #include "core/RttyDecoder.h"
 #include "core/QsoRecorder.h"
 #include "core/ClientPuduMonitor.h"
@@ -119,6 +120,7 @@ class AetherDspDialog;
 class MqttSettingsDialog;
 class WaveformsDialog;
 class DxClusterDialog;
+class CallsignLookupDialog;
 class Ax25HfPacketDecodeDialog;
 class PskReporterMapDialog;
 class FlexControlDialog;
@@ -443,6 +445,11 @@ private:
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();
     void refreshCwDecodeState();
+    // QRZ callsign lookup (MainWindow_Callsign.cpp): CW-spotter → lookup
+    // service → contact card on the CW decode panel + lookup dialog.
+    void wireCallsignLookup();
+    void onCwCallsignSpotted(const QString& call);
+    void showCallsignLookupDialog(const QString& call = QString());
     void routeRttyDecoderOutput();
     void refreshRttyDecodeState();
     SpectrumWidget* spectrumForSlice(SliceModel* s) const;
@@ -697,6 +704,7 @@ private:
     float             m_cwLastPitchHz{0.0f};
     float             m_cwLastSpeedWpm{0.0f};
     CwDecoder         m_cwDecoderTx;
+    CwCallsignSpotter m_cwCallsignSpotter;
     RttyDecoder       m_rttyDecoder;
     DxClusterClient*   m_dxCluster{nullptr};
     DxClusterClient*   m_rbnClient{nullptr};
@@ -940,6 +948,7 @@ private:
 
     // Modeless dialogs
     QPointer<DxClusterDialog> m_spotHubDialog;
+    QPointer<CallsignLookupDialog> m_callsignLookupDialog;
     QPointer<RadioSetupDialog> m_radioSetupDialog;
     QPointer<NetworkDiagnosticsDialog> m_networkDiagnosticsDialog;
     QPointer<AgcCalibrationDialog> m_agcCalibrationDialog;

--- a/src/gui/MainWindow_Callsign.cpp
+++ b/src/gui/MainWindow_Callsign.cpp
@@ -19,8 +19,34 @@
 #include "PanadapterApplet.h"
 #include "core/CallsignLookupService.h"
 #include "core/LogManager.h"
+#include "core/MaidenheadLocator.h"
+#include "models/RadioModel.h"
 
 namespace AetherSDR {
+
+namespace {
+
+// Operator position for card distance/bearing: GPS fix when the radio has
+// one, else the radio's grid-locator center (same preference order as the
+// PSK Reporter map's home position).
+void pushOwnLocationFromRadio(RadioModel* radio)
+{
+    auto& svc = CallsignLookupService::instance();
+    if (!radio)
+        return;
+    bool ok = false;
+    double lat = radio->gpsLat().toDouble(&ok);
+    double lon = 0.0;
+    if (ok)
+        lon = radio->gpsLon().toDouble(&ok);
+    if (!ok || (lat == 0.0 && lon == 0.0)) {
+        if (!MaidenheadLocator::toLatLon(radio->gpsGrid(), lat, lon))
+            return;  // keep whatever the service already has
+    }
+    svc.setOwnLocation(lat, lon);
+}
+
+} // namespace
 
 void MainWindow::wireCallsignLookup()
 {
@@ -28,6 +54,24 @@ void MainWindow::wireCallsignLookup()
     // findChild and drive `qrz spottext` through the real detection path.
     m_cwCallsignSpotter.setParent(this);
     m_cwCallsignSpotter.setObjectName(QStringLiteral("cwCallsignSpotter"));
+
+    // Country-level prefix fallback data (cty.dat is parsed once, by the
+    // DXCC spot-coloring provider).
+    CallsignLookupService::instance().setCtyParser(m_dxccProvider.ctyParser());
+
+    // Distance/bearing needs the operator's own position; follow the
+    // radio's GPS (or grid) as it becomes available and as it updates.
+    connect(&m_radioModel, &RadioModel::gpsStatusChanged, this,
+            [this] { pushOwnLocationFromRadio(&m_radioModel); });
+    pushOwnLocationFromRadio(&m_radioModel);
+
+    // No GPS? The operator's own QRZ record carries their grid — the radio
+    // callsign keys that zero-config fallback (GPS overrides when present).
+    connect(&m_radioModel, &RadioModel::callsignChanged, this, [this] {
+        CallsignLookupService::instance().setOwnCallsign(m_radioModel.callsign());
+    });
+    if (!m_radioModel.callsign().isEmpty())
+        CallsignLookupService::instance().setOwnCallsign(m_radioModel.callsign());
 
     connect(&m_cwCallsignSpotter, &CwCallsignSpotter::callsignSpotted,
             this, &MainWindow::onCwCallsignSpotted);
@@ -70,10 +114,9 @@ void MainWindow::wireCallsignLookup()
 void MainWindow::onCwCallsignSpotted(const QString& call)
 {
     auto& svc = CallsignLookupService::instance();
-    // No account configured → no pending card that can never fill in.
-    // A cached entry can still fill the card without credentials, so
-    // cache hits pop regardless (also lets the offline case keep working).
-    if (!svc.enabled() || (!svc.hasCredentials() && !svc.hasCachedEntry(call)))
+    // Only pop a card that can actually fill in: QRZ credentials, a cache
+    // entry, or at least cty.dat prefix data (country-level fallback card).
+    if (!svc.enabled() || !svc.canResolve(call))
         return;
     if (!m_cwDecoderApplet)
         return;

--- a/src/gui/MainWindow_Callsign.cpp
+++ b/src/gui/MainWindow_Callsign.cpp
@@ -1,0 +1,97 @@
+// MainWindow_Callsign.cpp — QRZ callsign-lookup wiring for MainWindow.
+//
+// Connects the pieces of the callsign-lookup subsystem:
+//
+//   • CwCallsignSpotter — fed by the CW decode panel's RX text stream
+//     (routeCwDecoderOutput() re-targets the feed on slice change) — fires
+//     when a station identifies itself ("DE KI6BCJ KI6BCJ")
+//   • CallsignLookupService — QRZ.com XML client + 7-day on-disk cache
+//   • CallsignCard on the CW decode panel — the screen-pop
+//   • CallsignLookupDialog — View → Callsign Lookup manual lookups
+//
+// The service is surface-agnostic: the future SSB voice-callsign decoder
+// pops the same card from its own detection path.
+
+#include "MainWindow.h"
+
+#include "CallsignCard.h"
+#include "CallsignLookupDialog.h"
+#include "PanadapterApplet.h"
+#include "core/CallsignLookupService.h"
+#include "core/LogManager.h"
+
+namespace AetherSDR {
+
+void MainWindow::wireCallsignLookup()
+{
+    // Parent + objectName let the automation bridge find the spotter with
+    // findChild and drive `qrz spottext` through the real detection path.
+    m_cwCallsignSpotter.setParent(this);
+    m_cwCallsignSpotter.setObjectName(QStringLiteral("cwCallsignSpotter"));
+
+    connect(&m_cwCallsignSpotter, &CwCallsignSpotter::callsignSpotted,
+            this, &MainWindow::onCwCallsignSpotted);
+
+    auto& svc = CallsignLookupService::instance();
+
+    // Results → the CW decode panel's card.  Match on the card's current
+    // call so a dialog-initiated lookup for a different station doesn't
+    // repaint the decoder card (and vice versa — the dialog filters too).
+    connect(&svc, &CallsignLookupService::infoReady, this,
+            [this](const CallsignInfo& info, bool fromCache) {
+        if (!m_cwDecoderApplet)
+            return;
+        auto* card = m_cwDecoderApplet->cwCallsignCard();
+        if (!card || !card->isVisible() || card->currentCall() != info.call)
+            return;
+        card->showInfo(info, fromCache);
+        const QString photo = CallsignLookupService::instance().photoPathFor(info.call);
+        if (!photo.isEmpty())
+            card->setPhotoPath(photo);
+    });
+    connect(&svc, &CallsignLookupService::photoReady, this,
+            [this](const QString& call, const QString& imagePath) {
+        if (!m_cwDecoderApplet)
+            return;
+        auto* card = m_cwDecoderApplet->cwCallsignCard();
+        if (card && card->isVisible() && card->currentCall() == call)
+            card->setPhotoPath(imagePath);
+    });
+    connect(&svc, &CallsignLookupService::lookupFailed, this,
+            [this](const QString& call, const QString& message) {
+        if (!m_cwDecoderApplet)
+            return;
+        auto* card = m_cwDecoderApplet->cwCallsignCard();
+        if (card && card->isVisible() && card->currentCall() == call)
+            card->showError(call, message);
+    });
+}
+
+void MainWindow::onCwCallsignSpotted(const QString& call)
+{
+    auto& svc = CallsignLookupService::instance();
+    // No account configured → no pending card that can never fill in.
+    // A cached entry can still fill the card without credentials, so
+    // cache hits pop regardless (also lets the offline case keep working).
+    if (!svc.enabled() || (!svc.hasCredentials() && !svc.hasCachedEntry(call)))
+        return;
+    if (!m_cwDecoderApplet)
+        return;
+    auto* card = m_cwDecoderApplet->cwCallsignCard();
+    if (!card)
+        return;
+
+    qCDebug(lcQrz) << "CW station identified:" << call;
+    card->showPending(call);
+    card->setVisible(true);
+    svc.lookup(call);
+}
+
+void MainWindow::showCallsignLookupDialog(const QString& call)
+{
+    showOrRaisePersistent(m_callsignLookupDialog);
+    if (!call.isEmpty())
+        m_callsignLookupDialog->lookupCallsign(call);
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -921,6 +921,13 @@ void MainWindow::buildMenuBar()
     connect(pskMapAction, &QAction::triggered,
             this, &MainWindow::showPskReporterMapDialog);
 
+    auto* callsignLookupAct = viewMenu->addAction("Callsign Lookup...");
+    callsignLookupAct->setMenuRole(QAction::NoRole);
+    callsignLookupAct->setShortcut(QKeySequence("Ctrl+Shift+L"));
+    callsignLookupAct->setToolTip("Look up a callsign on QRZ.com");
+    connect(callsignLookupAct, &QAction::triggered,
+            this, [this] { showCallsignLookupDialog(); });
+
 #ifdef HAVE_WEBSOCKETS
     {
         auto* fdvReporterAct = viewMenu->addAction(tr("FreeDV Reporter..."));

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -1,4 +1,5 @@
 #include "PanadapterApplet.h"
+#include "CallsignCard.h"
 #include "CwDecodeSettings.h"
 #include "FramelessMoveHelper.h"
 #include "GuardedSlider.h"
@@ -298,7 +299,25 @@ PanadapterApplet::PanadapterApplet(QWidget* parent)
         menu->exec(m_cwText->mapToGlobal(pos));
         delete menu;
     });
-    cwLayout->addWidget(m_cwText);
+    // Decoded text + contact card side by side.  The card stays hidden
+    // until the QRZ wiring spots a station identifying itself in the RX
+    // stream ("DE <call> <call>") and fills it with the lookup result.
+    auto* cwTextRow = new QHBoxLayout;
+    cwTextRow->setContentsMargins(0, 0, 0, 0);
+    cwTextRow->setSpacing(4);
+    cwTextRow->addWidget(m_cwText, 1);
+    m_cwCallsignCard = new CallsignCard(CallsignCard::Variant::Compact, m_cwPanel);
+    m_cwCallsignCard->setCloseButtonVisible(true);
+    m_cwCallsignCard->setMinimumWidth(240);
+    m_cwCallsignCard->setMaximumWidth(320);
+    // Cap the height so the card stays card-shaped (not a full-height
+    // sidebar) when the operator drags the decode panel tall.
+    m_cwCallsignCard->setMaximumHeight(120);
+    m_cwCallsignCard->setVisible(false);
+    connect(m_cwCallsignCard, &CallsignCard::closeRequested,
+            m_cwCallsignCard, &QWidget::hide);
+    cwTextRow->addWidget(m_cwCallsignCard, 0, Qt::AlignTop);
+    cwLayout->addLayout(cwTextRow);
 
     m_cwPanel->hide();
     layout->addWidget(m_cwPanel);
@@ -638,6 +657,8 @@ void PanadapterApplet::appendCwText(const QString& text, float cost)
     m_cwText->insertHtml(QString("<span style=\"color:%1\">%2</span>")
         .arg(color, clean.toHtmlEscaped()));
     m_cwText->moveCursor(QTextCursor::End);
+
+    emit cwRxTextDisplayed(clean);
 }
 
 void PanadapterApplet::appendCwTextTx(const QString& text, float cost)

--- a/src/gui/PanadapterApplet.h
+++ b/src/gui/PanadapterApplet.h
@@ -12,6 +12,7 @@ class RangeSlider;
 namespace AetherSDR {
 
 class SpectrumWidget;
+class CallsignCard;
 
 // Container for a single panadapter display (FFT spectrum + waterfall).
 // Adds a title bar with placeholder min/max/close buttons above the
@@ -48,6 +49,9 @@ public:
     QPushButton* lockPitchButton()  const { return m_lockPitchBtn; }
     QPushButton* lockSpeedButton()  const { return m_lockSpeedBtn; }
     float        cwCostThreshold()  const { return m_cwCostThreshold; }
+    // Contact card beside the decoded text — MainWindow's QRZ wiring
+    // fills it when the CW stream identifies a station (hidden until then).
+    CallsignCard* cwCallsignCard() const { return m_cwCallsignCard; }
     int speedRangeLow()   const;
     int speedRangeHigh()  const;
     int pitchRangeLow()   const;
@@ -76,6 +80,9 @@ signals:
     void pitchRangeChanged(int minHz, int maxHz);
     void speedRangeChanged(int minWpm, int maxWpm);
     void cwPanelCloseRequested();
+    // RX text that passed the confidence filter and was rendered — the
+    // stream the CW callsign spotter watches for "DE <call> <call>".
+    void cwRxTextDisplayed(const QString& text);
 
     // RTTY
     void rttyMarkHzChanged(int hz);
@@ -108,6 +115,7 @@ private:
     QWidget*      m_cwPanel{nullptr};
     QWidget*      m_cwGrip{nullptr};
     QTextEdit*    m_cwText{nullptr};
+    CallsignCard* m_cwCallsignCard{nullptr};
     QLabel*       m_cwStatsLabel{nullptr};
     QSlider*      m_cwSensSlider{nullptr};
     QPushButton*  m_lockPitchBtn{nullptr};

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -26,6 +26,8 @@
 #include "core/TgxlConnection.h"
 #include "core/PgxlConnection.h"
 #include "core/WanConnection.h"   // PinnedCertInfo + WanCertCache (#2951)
+#include "core/CallsignLookupService.h"
+#include "core/QrzLookupSettings.h"
 #include "models/AntennaGeniusModel.h"
 
 #include <QCloseEvent>
@@ -627,6 +629,7 @@ RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
     addDeferred("Peripherals",     [this] { return buildPeripheralsTab(); });
     addDeferred("Themes",          [this] { return buildUiEnhancementsTab(); });
     addDeferred("SmartLink",       [this] { return buildSmartLinkTab(); });
+    addDeferred("QRZ",             [this] { return buildQrzTab(); });
 #ifdef HAVE_SERIALPORT
     addDeferred("Serial",          [this] { return buildSerialTab(); });
 #endif
@@ -6005,6 +6008,170 @@ void RadioSetupDialog::refreshPinnedCertsTable()
             : pin.pinnedAtIso.left(10);   // YYYY-MM-DD
         m_pinnedCertsTable->setItem(i, 2, new QTableWidgetItem(when));
     }
+}
+
+QWidget* RadioSetupDialog::buildQrzTab()
+{
+    auto* page = new QWidget;
+    auto* root = new QVBoxLayout(page);
+    root->setContentsMargins(16, 16, 16, 16);
+    root->setSpacing(12);
+
+    auto& svc = CallsignLookupService::instance();
+
+    // ---- Account group -------------------------------------------------
+    auto* acct = new QGroupBox("QRZ.com Account");
+    acct->setStyleSheet(kGroupStyle);
+    auto* acctLay = new QVBoxLayout(acct);
+    acctLay->setSpacing(8);
+
+    auto* desc = new QLabel(
+        "AetherSDR uses your QRZ.com account to look up station details — "
+        "name, location, grid, and photo — for callsigns heard in the CW "
+        "decoder and entered in View → Callsign Lookup. An XML Logbook Data "
+        "subscription returns full details; a free account returns limited "
+        "fields. Your password is stored in the operating system keychain, "
+        "never in the settings file.");
+    desc->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+    desc->setWordWrap(true);
+    acctLay->addWidget(desc);
+
+    auto* enableCheck = new QCheckBox("Enable QRZ callsign lookups");
+    enableCheck->setObjectName("qrzEnableCheck");
+    enableCheck->setAccessibleName("Enable QRZ callsign lookups");
+    enableCheck->setStyleSheet("QCheckBox { color: #c8d8e8; font-size: 12px; }");
+    enableCheck->setChecked(QrzLookupSettings::enabled());
+    connect(enableCheck, &QCheckBox::toggled, this, [](bool on) {
+        QrzLookupSettings::setEnabled(on);
+        CallsignLookupService::instance().reloadConfiguration();
+    });
+    acctLay->addWidget(enableCheck);
+
+    auto* grid = new QGridLayout;
+    grid->setSpacing(8);
+
+    auto* userLbl = new QLabel("Username (callsign):");
+    userLbl->setStyleSheet(kLabelStyle);
+    grid->addWidget(userLbl, 0, 0);
+    auto* userEdit = new QLineEdit(QrzLookupSettings::username());
+    userEdit->setObjectName("qrzUsernameEdit");
+    userEdit->setAccessibleName("QRZ username");
+    userEdit->setStyleSheet(kEditStyle);
+    userEdit->setMaxLength(64);
+    grid->addWidget(userEdit, 0, 1);
+
+    auto* passLbl = new QLabel("Password:");
+    passLbl->setStyleSheet(kLabelStyle);
+    grid->addWidget(passLbl, 1, 0);
+    auto* passEdit = new QLineEdit;
+    passEdit->setObjectName("qrzPasswordEdit");
+    passEdit->setAccessibleName("QRZ password");
+    passEdit->setStyleSheet(kEditStyle);
+    passEdit->setEchoMode(QLineEdit::Password);
+    passEdit->setMaxLength(128);
+    grid->addWidget(passEdit, 1, 1);
+    grid->setColumnStretch(1, 1);
+    acctLay->addLayout(grid);
+
+    // Populate the password field from the keychain (async).
+    QPointer<QLineEdit> passGuard(passEdit);
+    svc.readPassword([passGuard](const QString& pw) {
+        if (passGuard && passGuard->text().isEmpty())
+            passGuard->setText(pw);
+    });
+
+    connect(userEdit, &QLineEdit::editingFinished, this, [userEdit] {
+        QrzLookupSettings::setUsername(userEdit->text().trimmed());
+        CallsignLookupService::instance().reloadConfiguration();
+    });
+    connect(passEdit, &QLineEdit::editingFinished, this, [passEdit] {
+        CallsignLookupService::instance().savePassword(passEdit->text());
+    });
+
+    auto* testRow = new QHBoxLayout;
+    testRow->setSpacing(8);
+    auto* testBtn = new QPushButton("Test Login");
+    testBtn->setObjectName("qrzTestLoginBtn");
+    testBtn->setAccessibleName("Test QRZ login");
+    testBtn->setStyleSheet(
+        "QPushButton { background: #183548; border: 1px solid #28506a; "
+        "border-radius: 3px; color: #c8d8e8; font-size: 11px; padding: 4px 12px; }"
+        "QPushButton:hover { background: #1f4258; }"
+        "QPushButton:disabled { color: #506070; }");
+    testRow->addWidget(testBtn);
+    auto* testStatus = new QLabel;
+    testStatus->setObjectName("qrzTestStatus");
+    testStatus->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+    testStatus->setWordWrap(true);
+    testRow->addWidget(testStatus, 1);
+    acctLay->addLayout(testRow);
+
+    connect(testBtn, &QPushButton::clicked, this,
+            [testBtn, testStatus, userEdit, passEdit] {
+        const QString user = userEdit->text().trimmed();
+        const QString pass = passEdit->text();
+        if (user.isEmpty() || pass.isEmpty()) {
+            testStatus->setText("Enter a username and password first.");
+            return;
+        }
+        testBtn->setEnabled(false);
+        testStatus->setText("Contacting QRZ.com…");
+        CallsignLookupService::instance().testLogin(user, pass);
+    });
+    connect(&svc, &CallsignLookupService::loginTestFinished, this,
+            [testBtn, testStatus](bool ok, const QString& message) {
+        testBtn->setEnabled(true);
+        testStatus->setText(ok
+            ? (message.isEmpty() ? QStringLiteral("Login OK.")
+                                 : QStringLiteral("Login OK — %1").arg(message))
+            : QStringLiteral("Login failed: %1").arg(message));
+        testStatus->setStyleSheet(ok
+            ? "QLabel { color: #4dd87a; font-size: 11px; }"
+            : "QLabel { color: #ff6060; font-size: 11px; }");
+    });
+
+    root->addWidget(acct);
+
+    // ---- Cache group ----------------------------------------------------
+    auto* cache = new QGroupBox("Lookup Cache");
+    cache->setStyleSheet(kGroupStyle);
+    auto* cacheLay = new QVBoxLayout(cache);
+    cacheLay->setSpacing(8);
+
+    auto* cacheDesc = new QLabel(
+        "Looked-up callsigns are cached for 7 days so a busy net never asks "
+        "QRZ twice for the same station. Station photos are cached alongside.");
+    cacheDesc->setStyleSheet("QLabel { color: #7090a0; font-size: 11px; }");
+    cacheDesc->setWordWrap(true);
+    cacheLay->addWidget(cacheDesc);
+
+    auto* cacheRow = new QHBoxLayout;
+    cacheRow->setSpacing(8);
+    auto* cacheCount = new QLabel;
+    cacheCount->setObjectName("qrzCacheCount");
+    cacheCount->setStyleSheet(kValueStyle);
+    auto refreshCacheCount = [cacheCount] {
+        cacheCount->setText(QStringLiteral("%1 cached callsign(s)")
+            .arg(CallsignLookupService::instance().cacheEntryCount()));
+    };
+    refreshCacheCount();
+    cacheRow->addWidget(cacheCount);
+    cacheRow->addStretch();
+
+    auto* clearBtn = new QPushButton("Clear Cache");
+    clearBtn->setObjectName("qrzClearCacheBtn");
+    clearBtn->setAccessibleName("Clear QRZ lookup cache");
+    clearBtn->setStyleSheet(testBtn->styleSheet());
+    connect(clearBtn, &QPushButton::clicked, this, [refreshCacheCount] {
+        CallsignLookupService::instance().clearCache();
+        refreshCacheCount();
+    });
+    cacheRow->addWidget(clearBtn);
+    cacheLay->addLayout(cacheRow);
+
+    root->addWidget(cache);
+    root->addStretch();
+    return page;
 }
 
 } // namespace AetherSDR

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6075,7 +6075,9 @@ QWidget* RadioSetupDialog::buildQrzTab()
 
     // Populate the password field from the keychain (async).
     QPointer<QLineEdit> passGuard(passEdit);
-    svc.readPassword([passGuard](const QString& pw) {
+    auto passLoaded = std::make_shared<bool>(false);
+    svc.readPassword([passGuard, passLoaded](const QString& pw) {
+        *passLoaded = true;
         if (passGuard && passGuard->text().isEmpty())
             passGuard->setText(pw);
     });
@@ -6084,7 +6086,12 @@ QWidget* RadioSetupDialog::buildQrzTab()
         QrzLookupSettings::setUsername(userEdit->text().trimmed());
         CallsignLookupService::instance().reloadConfiguration();
     });
-    connect(passEdit, &QLineEdit::editingFinished, this, [passEdit] {
+    connect(passEdit, &QLineEdit::editingFinished, this, [passEdit, passLoaded] {
+        // Don't let a focus-out before the async keychain read completes delete
+        // a stored password: skip the save when the field is empty and the read
+        // hasn't landed yet (savePassword("") deletes the keychain entry). (#3990)
+        if (!*passLoaded && passEdit->text().isEmpty())
+            return;
         CallsignLookupService::instance().savePassword(passEdit->text());
     });
 

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -79,6 +79,10 @@ private:
     // (host, sha256 fingerprint, pinned date) with per-row Forget and a
     // Forget All button. Backed by WanCertCache in WanConnection.cpp.
     QWidget* buildSmartLinkTab();
+    // QRZ.com account for callsign lookups (CW decoder contact card +
+    // View → Callsign Lookup).  Username in AppSettings, password in the
+    // OS keychain, lookups cached 7 days by CallsignLookupService.
+    QWidget* buildQrzTab();
 
 public:
     // Public so MainWindow can refresh the table from outside this

--- a/tests/qrz_callsign_test.cpp
+++ b/tests/qrz_callsign_test.cpp
@@ -6,13 +6,17 @@
 
 #include "core/CallsignInfo.h"
 #include "core/CallsignUtils.h"
+#include "core/CtyDatParser.h"
 #include "core/CwCallsignSpotter.h"
+#include "core/MaidenheadLocator.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QSignalSpy>
+#include <QTemporaryFile>
 #include <QTimer>
 
+#include <cmath>
 #include <cstdio>
 
 using namespace AetherSDR;
@@ -174,6 +178,44 @@ int main(int argc, char** argv)
         info.lastName.clear();
         check(info.displayName() == "W1AW", "displayName falls back to call");
         check(info.displayLocation().isEmpty(), "empty location joins to empty");
+    }
+
+    // ── CtyDatParser: entity lat/lon for the prefix-fallback card ───────
+    {
+        // Two entities in AD1C cty.dat format.  NOTE: the file stores
+        // longitude WEST-positive; the parser must flip it east-positive.
+        QTemporaryFile f;
+        f.open();
+        f.write("United States:            5:  8:  NA:   37.53:    91.67:     5.0:  K:\n"
+                "    K,W,N,AA,AB,KI6,=W1AW;\n"
+                "England:                 14: 27:  EU:   52.77:     1.47:     0.0:  G:\n"
+                "    G,M,2E;\n");
+        f.close();
+
+        CtyDatParser cty;
+        check(cty.loadFromFile(f.fileName()), "cty.dat sample loads");
+        const DxccEntity* us = cty.entityForCallsign("KI6BCJ");
+        check(us && us->name == "United States", "KI6BCJ resolves to United States");
+        check(us && us->hasLatLon && std::abs(us->latitude - 37.53) < 0.01
+              && std::abs(us->longitude - (-91.67)) < 0.01,
+              "US lat/lon parsed, longitude flipped east-positive");
+        check(us && us->continent == "NA" && us->cqZone == 5,
+              "US continent + CQ zone parsed");
+        const DxccEntity* uk = cty.entityForCallsign("G4ABC");
+        check(uk && uk->name == "England" && uk->hasLatLon,
+              "G4ABC resolves to England with lat/lon");
+        check(cty.entityForCallsign("ZZ9ZZZ") == nullptr
+              || !cty.entityForCallsign("ZZ9ZZZ"),
+              "unknown prefix resolves to null");
+    }
+
+    // ── Distance + bearing sanity (San Jose CM97 → ARRL FN31) ───────────
+    {
+        double km = 0.0, brg = 0.0;
+        check(MaidenheadLocator::gridDistance("CM97", "FN31", km, brg),
+              "grid distance computes");
+        check(km > 4000 && km < 4400, "CM97→FN31 distance ≈ 4200 km");
+        check(brg > 55 && brg < 90, "CM97→FN31 initial bearing ≈ ENE");
     }
 
     // ── TTL staleness — the 7-day cache rule ────────────────────────────

--- a/tests/qrz_callsign_test.cpp
+++ b/tests/qrz_callsign_test.cpp
@@ -1,0 +1,195 @@
+// Tests for the QRZ callsign-lookup building blocks:
+//   • Callsigns:: regex/normalization helpers
+//   • CwCallsignSpotter "DE <call> <call>" stream detection (chunked
+//     arrival, end-of-stream settle timer, re-spot suppression, garble)
+//   • CallsignInfo JSON round-trip + TTL staleness (the 7-day cache rule)
+
+#include "core/CallsignInfo.h"
+#include "core/CallsignUtils.h"
+#include "core/CwCallsignSpotter.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QSignalSpy>
+#include <QTimer>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ── Callsigns helpers ───────────────────────────────────────────────
+    check(Callsigns::isLikelyCallsign("KI6BCJ"),   "plain US callsign");
+    check(Callsigns::isLikelyCallsign("W1AW"),     "short US callsign");
+    check(Callsigns::isLikelyCallsign("kk7gwy"),   "lowercase normalizes");
+    check(Callsigns::isLikelyCallsign("VE3ABC"),   "Canadian callsign");
+    check(Callsigns::isLikelyCallsign("VP2E/K1AB"),"prefixed portable");
+    check(Callsigns::isLikelyCallsign("K1AB/7"),   "portable district suffix");
+    check(!Callsigns::isLikelyCallsign("5NN"),     "CW report rejected");
+    check(!Callsigns::isLikelyCallsign("73"),      "numbers-only rejected");
+    check(!Callsigns::isLikelyCallsign("QTH"),     "no-digit word rejected");
+    check(!Callsigns::isLikelyCallsign(""),        "empty rejected");
+    check(Callsigns::normalized(" ki6bcj ") == "KI6BCJ", "normalized trims + uppercases");
+
+    // ── Spotter: basic doubled-call detection ───────────────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("CQ CQ CQ DE KI6BCJ KI6BCJ K");
+        check(spy.count() == 1, "doubled call after DE spots once");
+        check(spy.count() == 1 && spy.at(0).at(0).toString() == "KI6BCJ",
+              "spotted call is the callsign");
+    }
+
+    // ── Spotter: chunked (character-by-character) arrival ───────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        const QString stream = QStringLiteral("CQ DE W1AW W1AW K");
+        for (const QChar& c : stream)
+            spotter.feedText(QString(c));
+        check(spy.count() == 1, "char-by-char stream spots once");
+        check(spy.count() == 1 && spy.at(0).at(0).toString() == "W1AW",
+              "chunked spotted call correct");
+    }
+
+    // ── Spotter: single (undoubled) call must NOT spot ──────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("CQ CQ DE KI6BCJ K TU 73 ");
+        check(spy.count() == 0, "single call after DE does not spot");
+    }
+
+    // ── Spotter: garbled repeat must NOT spot ───────────────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("CQ DE KI6BCJ KI6BCX K ");
+        check(spy.count() == 0, "mismatched repeat does not spot");
+    }
+
+    // ── Spotter: "MADE" false positive guard ────────────────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("RIG HOMEMADE K1AB K1AB K ");
+        check(spy.count() == 0, "DE inside a word does not spot");
+    }
+
+    // ── Spotter: re-spot suppression for the same call ──────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("CQ DE W1AW W1AW K ");
+        spotter.feedText("CQ DE W1AW W1AW K ");
+        check(spy.count() == 1, "same call twice within window spots once");
+        spotter.feedText("CQ DE KI6BCJ KI6BCJ K ");
+        check(spy.count() == 2, "different call still spots");
+    }
+
+    // ── Spotter: ID at end of transmission (settle timer) ───────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("73 73 DE K1AB K1AB");  // stream ends here — no trailing char
+        check(spy.count() == 0, "end-of-stream match held until settle");
+        // The settle timer is 3 s; wait it out with a bounded event loop.
+        QSignalSpy settled(&spotter, &CwCallsignSpotter::callsignSpotted);
+        settled.wait(5000);
+        check(spy.count() == 1 && spy.at(0).at(0).toString() == "K1AB",
+              "end-of-stream ID spots after settle");
+    }
+
+    // ── Spotter: clear() drops a partial match ───────────────────────────
+    {
+        CwCallsignSpotter spotter;
+        QSignalSpy spy(&spotter, &CwCallsignSpotter::callsignSpotted);
+        spotter.feedText("CQ DE W1");
+        spotter.clear();                 // slice change mid-ID
+        spotter.feedText("AW W1AW K ");
+        check(spy.count() == 0, "clear() between chunks prevents cross-station splice");
+    }
+
+    // ── CallsignInfo: JSON round-trip ────────────────────────────────────
+    {
+        CallsignInfo info;
+        info.call = "KI6BCJ";
+        info.firstName = "Pat";
+        info.lastName = "Jensen";
+        info.nameFmt = "Pat Jensen";
+        info.city = "San Jose";
+        info.state = "CA";
+        info.country = "United States";
+        info.county = "Santa Clara";
+        info.grid = "CM97";
+        info.licenseClass = "E";
+        info.imageUrl = "https://example.org/photo.jpg";
+        info.latitude = 37.3;
+        info.longitude = -121.9;
+        info.hasLatLon = true;
+        info.lotw = true;
+        info.fetchedUtc = QDateTime::currentSecsSinceEpoch();
+
+        const CallsignInfo back = CallsignInfo::fromJson(info.toJson());
+        check(back.call == info.call, "round-trip call");
+        check(back.displayName() == "Pat Jensen", "displayName uses name_fmt");
+        check(back.displayLocation() == "San Jose, CA, United States",
+              "displayLocation joins city/state/country");
+        check(back.grid == "CM97" && back.county == "Santa Clara",
+              "round-trip grid + county");
+        check(back.hasLatLon && back.latitude == info.latitude
+              && back.longitude == info.longitude, "round-trip lat/lon");
+        check(back.lotw && !back.eqsl, "round-trip QSL flags");
+        check(back.fetchedUtc == info.fetchedUtc, "round-trip fetch time");
+    }
+
+    // ── CallsignInfo: display fallbacks ──────────────────────────────────
+    {
+        CallsignInfo info;
+        info.call = "W1AW";
+        info.firstName = "Hiram";
+        info.lastName = "Maxim";
+        check(info.displayName() == "Hiram Maxim", "displayName falls back to fname+name");
+        info.firstName.clear();
+        info.lastName.clear();
+        check(info.displayName() == "W1AW", "displayName falls back to call");
+        check(info.displayLocation().isEmpty(), "empty location joins to empty");
+    }
+
+    // ── TTL staleness — the 7-day cache rule ────────────────────────────
+    {
+        constexpr qint64 kTtl = 7 * 24 * 3600;
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        CallsignInfo info;
+        info.call = "W1AW";
+        info.fetchedUtc = now - 3 * 24 * 3600;
+        check(!info.isOlderThan(kTtl, now), "3-day-old entry is fresh");
+        info.fetchedUtc = now - 8 * 24 * 3600;
+        check(info.isOlderThan(kTtl, now), "8-day-old entry is stale");
+        info.fetchedUtc = 0;
+        check(info.isOlderThan(kTtl, now), "never-fetched entry is stale");
+    }
+
+    std::printf(failures ? "\n%d FAILURE(S)\n" : "\nALL PASS\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What this adds

A framework for pulling station contact information from QRZ.com and popping a themed **contact card** wherever AetherSDR identifies a station — starting with the CW decoder, designed so the upcoming AI SSB voice-callsign decoder pops the exact same card.

### Working CW: automatic screen-pop
When the CW decoder prints a station identifying itself — `DE KI6BCJ KI6BCJ` — a compact contact card pops beside the decoded text with callsign, license-class chip, name, location, grid/county, and the station photo. The **doubled call is the decode-confidence gate**: one garbled character breaks the repeat and correctly suppresses the spot. An ID sent at the very end of a transmission (`… 73 DE K1AB K1AB` then silence) still spots via a 3 s settle timer.

![CW decoder contact card](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/qrz-lookup-screenshots/cw-panel-card.png)

### View → Callsign Lookup… (Ctrl+Shift+L)
Manual lookups get a `PersistentDialog` with the large card variant, cache-age status line, and a force-refresh button.

![Callsign Lookup dialog](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/qrz-lookup-screenshots/lookup-dialog.png)

### Radio Setup → QRZ tab
Enable toggle, username, password (**OS keychain via QtKeychain — never in the settings file**), async Test Login, cache count + Clear Cache.

![QRZ setup tab](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets/qrz-lookup-screenshots/qrz-setup-tab.png)

## Architecture

| Piece | Role |
|---|---|
| `core/QrzClient` | QRZ XML API: session-key login (`agent=AetherSDR<ver>`), key reuse, transparent one-shot re-login + retry on expiry (per-call retry guard — no login loops) |
| `core/CallsignInfo` | Provider-neutral contact struct + JSON round-trip |
| `core/CallsignLookupService` | Singleton facade: **7-day TTL disk cache** (2×TTL prune, 1000-entry cap), photo download + cache, in-flight coalescing (a busy net asks QRZ once per station), stale-entry fallback when offline |
| `core/CwCallsignSpotter` | Rolling-window `DE <call> <call>` watcher; per-call re-emit suppression (120 s) |
| `core/QrzLookupSettings` | One `AppSettings["QrzLookup"]` nested blob (Principle V) |
| `gui/CallsignCard` | Reusable themed card (accent bar / photo / details), Compact + Large variants; ThemeManager tokens, live theme-switch, a11y names, callsign is keyboard-activatable and opens the QRZ page |
| `gui/MainWindow_Callsign.cpp` | Subsystem wiring (new sibling TU per the #3351 decomposition) |

## Agent automation bridge

New **`qrz`** verb group (docs updated): `status` / `cached <call>` / `lookup <call>` / `spottext <text>` — `spottext` feeds the real spotter → service → card path, so the end-to-end screen-pop is provable with no radio and no QRZ account (seeded cache). Bonus: `invoke setCurrentText/setCurrentIndex` now drive **QTabBar**, making deferred setup-dialog tabs reachable from the bridge for the first time.

## Testing

- `tests/qrz_callsign_test.cpp` — 36/36 PASS: callsign regex, spotter stream behavior (char-by-char arrival, settle timer, garbled-repeat rejection, dedup, cross-station splice guard), JSON round-trip, 7-day TTL rule.
- **Proven live via the bridge** against the FLEX-8400M (RX only, radio was Available/not in use): slice → CW mode, `qrz spottext "CQ CQ CQ DE KI6BCJ KI6BCJ K"` → card popped with cached data + photo (screenshots above are those captures); lookup dialog driven via menu action + `callsignLookupInput`/`callsignLookupGo`; QRZ tab via the new tab verb; enable-toggle round-trip verified through `qrz status`.
- Full ctest: all pass except `theme_manager_test`, which fails identically on `main` on this machine (it loads the operator's live user settings — pre-existing, unrelated).

## Notes for review

- Session keys are memory-only; QRZ password lives only in the keychain. XML from QRZ is parsed with `QXmlStreamReader`; callsigns are regex-validated at the boundary before any network request (Principle VII).
- Non-subscriber QRZ accounts get limited fields — the card degrades gracefully (name/callsign only).
- Cache serves stale entries when a refresh fails, so a net roster keeps working offline.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat