### PR TITLE
fix(nets): restore 'band not available' feedback when net-tuning an unconfigured transverter band (#3930)

### DIFF
--- a/src/gui/MainWindow_Nets.cpp
+++ b/src/gui/MainWindow_Nets.cpp
@@ -14,6 +14,7 @@
 #include "NetSchedulerDialog.h"
 
 #include "core/AppSettings.h"
+#include "core/LogManager.h"
 #include "core/MemoryRecallPolicy.h"
 #include "core/NetScheduleStore.h"
 #include "core/NetScheduler.h"
@@ -120,6 +121,41 @@ void MainWindow::tuneToNet(const NetEntry& entry)
         return;
 
     const double freqMhz = entry.preset.freq;
+
+    // Nets can sit on transverter-only bands. applyTuneRequest() runs the
+    // band-stack preselect (home of the XVTR support check and its "band isn't
+    // available" feedback) only for CommandedTargetCenter, so an AbsoluteJump
+    // net tune would silently move the slice onto a band this radio can't
+    // reach (#3930). Mirror the preselectBandStackForTune() guard here and
+    // refuse before touching the radio.
+    if (freqMhz > 54.0 || slice->frequency() > 54.0) {
+        const QString targetBand = BandSettings::bandForFrequency(freqMhz);
+        const QString currentBand = BandSettings::bandForFrequency(slice->frequency());
+        if (targetBand != currentBand) {
+            const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
+            const auto stackKeyResult = XvtrPolicy::resolveBandStackKey(
+                targetBand, xvtrs, m_radioModel.capabilities());
+            if (!stackKeyResult.isSupported()) {
+                QString reason = stackKeyResult.unsupportedReason;
+                if (freqMhz > 54.0 && xvtrs.isEmpty()) {
+                    reason = QString("Band %1 requires a configured XVTR before "
+                                     "Aether can tune it.")
+                                 .arg(targetBand);
+                }
+                qCWarning(lcProtocol).noquote().nospace()
+                    << "MainWindow: net tune cannot preselect band stack"
+                    << " source=net-tune net=" << entry.name
+                    << " from_band=" << currentBand
+                    << " to_band=" << targetBand
+                    << " freq_mhz=" << QString::number(freqMhz, 'f', 6)
+                    << " reason=" << reason
+                    << " available_xvtrs=" << xvtrListSummary(xvtrs);
+                statusBar()->showMessage(
+                    QString("Can't tune %1 — %2").arg(entry.name, reason), 5000);
+                return;
+            }
+        }
+    }
 
     // Route the net's frequency change through the canonical tune-and-recenter
     // policy — the same AbsoluteJump path a DX-cluster spot uses to jump to an

--- a/tests/xvtr_policy_test.cpp
+++ b/tests/xvtr_policy_test.cpp
@@ -147,6 +147,34 @@ void testBandStackKeysUseNativeVhfOnlyWhenCapable()
                   "2m", xvtrs, "X12");
 }
 
+// #3930 — the tuneToNet() pre-check refuses a net tune when the target band
+// resolves unsupported. Pin the decision core it relies on, using the band
+// names BandSettings::bandForFrequency() actually produces (432.1 MHz → "440",
+// 144.2 MHz → "2m", 7.2 MHz → "40m" per BandDefs.h).
+void testNetTunePrecheckBandSupport()
+{
+    const QVector<XvtrPolicy::Transverter> xvtrs = {
+        xvtr(4, 7, "440", 432.0, 28.0),
+    };
+
+    // The repro: 432.1 MHz net, no XVTR configured, no native 70 cm on any
+    // model — must resolve unsupported with a non-empty reason.
+    expectUnsupportedBand("net tune 440 with no XVTR is unsupported",
+                          "440", {}, "has no Flex display pan band= mapping");
+
+    // Same band with a covering XVTR entry — must tune, not refuse.
+    expectBandKey("net tune 440 with covering XVTR resolves",
+                  "440", xvtrs, "X4");
+
+    // FLEX-6700 does 2 m natively (has2Meters) — the pre-check must not
+    // over-block a band the model covers without any XVTR.
+    expectBandKey("net tune 2m on 6700-class radio is native",
+                  "2m", {}, "2", {.has2Meters = true});
+
+    // Plain HF control.
+    expectBandKey("net tune 40m HF is always native", "40m", {}, "40");
+}
+
 void testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan()
 {
     const QVector<XvtrPolicy::Transverter> xvtrs = {
@@ -284,6 +312,7 @@ int main()
     testBandStackKeysUseFlexIndex();
     testBandStackKeysRefuseGuesses();
     testBandStackKeysUseNativeVhfOnlyWhenCapable();
+    testNetTunePrecheckBandSupport();
     testHfWaterfallDoesNotShiftWhenTileLagsByOneSpan();
     testXvtrWaterfallMapsIfToRfBands();
     testXvtrWaterfallGuardrails();


### PR DESCRIPTION
## Summary

PR #3921 correctly routed `tuneToNet()` through `applyTuneRequest(..., TuneIntent::AbsoluteJump, "net-tune")` to fix the VFO-display desync — but `applyTuneRequest()` only runs `preselectBandStackForTune()` (home of the `XvtrPolicy` support check and its "band isn't available" status-bar feedback) for `CommandedTargetCenter`. A net scheduled on a band the radio can't reach (no native coverage, no matching XVTR) therefore silently issued the `slice tune` + recenter with **no feedback**. This implements the issue's **Option 1**: a scoped pre-check in `tuneToNet()` that mirrors the `preselectBandStackForTune()` guard exactly and refuses — with the status-bar message — *before* touching the radio.

## Why

- Restores the pre-#3921 "Can't tune … — Band …" feedback family for net tunes without re-introducing the band-stack-reload desync that #3921 fixed.
- The guard is a faithful mirror of `MainWindow::preselectBandStackForTune()`: same HF↔HF and same-band early-outs, same `XvtrPolicy::resolveBandStackKey()` decision (capabilities-aware, so 2 m on a FLEX-6700 stays native and is never over-blocked), same no-XVTR wording, same `lcProtocol` warning shape.
- Deliberately scoped to the net path (Option 1). The DX-cluster spot path (`MainWindow_Menus.cpp`, same `AbsoluteJump`, same gap) and typed-VFO consolidation into the canonical tune policy (the issue's Option 2) are a natural follow-up.

## Scope

- +36 lines in `src/gui/MainWindow_Nets.cpp` (pre-check + `core/LogManager.h` include for `lcProtocol`)
- +29 lines in `tests/xvtr_policy_test.cpp` (new `testNetTunePrecheckBandSupport()` pinning the decision matrix)
- No protocol / persistence / UX-layout change; one new user-visible status-bar message on the refusal path (pre-#3921 wording family)

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Bug and fix verified A/B on a live FLEX-6700 (via the automation bridge, RX-only), plus new unit tests pinning the decision core.

## Test plan

- [x] `xvtr_policy_test` green (37/37 incl. 4 new cases: 440-no-XVTR unsupported, 440-with-XVTR resolves, 2m native on `has2Meters` models, HF control)
- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] Live A/B on a FLEX-6700 (SmartSDR v1.4.0.0), nets seeded at 432.100 FM / 7.200 LSB / 144.200 USB, slice parked on 20 m:

| Net (Tune Now) | Baseline v26.7.1 tip | This PR |
|---|---|---|
| 432.100 (no usable XVTR mapping) | **silently tunes to 432.1** — no message | **refuses**, slice unchanged, status bar: "Can't tune 70cm Test Net — Band 440 has no Flex display pan band= mapping" + `lcProtocol` warning |
| 7.200 (HF control) | tunes | tunes (early-out, check skipped) |
| 144.200 (native 2 m on 6700) | tunes | tunes (native-band branch — no over-blocking) |

- [x] Manual GUI repro against a real FlexRadio: verified on Linux (Nobara 43) against the FLEX-6700 — baseline v26.7.1 reproduces the silent 432.1 jump; this branch refuses with the status-bar message; the 7.200 and 144.200 nets tune normally on both builds


**Observed while verifying, pre-existing and unchanged by this PR:** `resolveBandStackKey()` matches XVTR entries by *name* against the `BandSettings` band name — the lab 6700 reports an XVTR entry named `70CM`, which does not match band `440`, so the tune refuses on the canonical preselect path too (typed VFO, spot recall). Whether name-matching should become frequency-range matching is a separate policy question worth its own issue.

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — n/a, no meter code touched

Closes #3930

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)

