### PR TITLE
fix(gui): enable GPS-grid conveniences from live gps status, not model name (#3996)

### DIFF
--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -205,10 +205,16 @@ public:
     bool    extPresent()   const { return m_extPresent; }
     bool    gpsdoPresent() const { return m_gpsdoPresent; }
 
-    // Returns true for FLEX-8000 class (8400, 8600) and Aurora, which have GPS hardware.
+    // True when the radio delivers GPS data: FLEX-8000 class (8400, 8600) and
+    // Aurora by model, or any radio whose "gps" status object has arrived — a
+    // 6000-series with the optional GPSDO reports the same object (and sends
+    // no gpsdo_present oscillator flag, so presence is only detectable from
+    // the data itself).
     bool hasGpsHardware() const {
         return m_model.contains("8400") || m_model.contains("8600")
-               || m_model.startsWith("AU-");
+               || m_model.startsWith("AU-")
+               || (!m_gpsStatus.isEmpty()
+                   && m_gpsStatus != QLatin1String("Not Present"));
     }
     bool    tcxoPresent()  const { return m_tcxoPresent; }
     bool    binauralRx()   const { return m_binauralRx; }


### PR DESCRIPTION
## Summary

`RadioModel::hasGpsHardware()` gated the GPS-grid conveniences (SpotHub → FreeDV QSO Reporter "Use GPS" checkbox, RADE reporter grid auto-fill, reporter-dialog distance/heading grid) on the model name (8400/8600/AU-), so a 6000-series radio with a locked GPSDO never got them — even though it delivers the identical `gps` status object (#3994/#3995). This widens the check to also trust the radio's own evidence: a received `gps` status that is non-empty and not `Not Present`.

## Why

- Live capture off a FLEX-6700 v4.2.20.41343 with GPSDO: `gps …#grid=DM33un#…#status=Locked` pushed at 1 Hz — the data these features need is right there (#3996)
- The same capture shows the 6700's oscillator status carries **no `gpsdo_present`/`gnss_present` flag** (`radio oscillator state=ocxo_gpsdo setting=ocxo_gpsdo locked=1`), so no capability flag can replace the model check — the `gps` status object itself is the only reliable presence signal
- `RadioSetupDialog` already uses exactly this test for its "GPS is installed" label, so the runtime signal has in-repo precedent

## Scope

- 8 insertions / 2 deletions in one file (`src/models/RadioModel.h`), inline function only
- No protocol / persistence / UX change for radios without GPS: every call site keeps its `!gpsGrid().isEmpty()` guard, and radios without GPS hardware never receive a `gps` status (the `sub gps all` subscription errors), so the new clause stays false for them
- Known pre-existing edge (unchanged by this PR): the SpotHub checkbox is created at dialog construction, so a dialog opened before the first `gps` status arrives (status is pushed at 1 Hz from connect) would still miss it until reopened — same timing dependency the model-name check has on the first `radio` status

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** Whether GPS data is available is live radio state; the client should believe the radio's reported `gps` status over its own model-name assumption. The fix replaces a client-side capability guess with the radio's own report.

## Test plan

- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] Manual smoke: SpotHub → FreeDV QSO Reporter shows the "Use GPS" checkbox and auto-fills `DM33un` on a GPSDO-equipped FLEX-6700 (K6OZY verified live, A/B against an unpatched upstream-main build where the checkbox is absent)

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — no meter UI touched

Closes #3996

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)

