### PR TITLE
fix(recorder): guard QsoRecorder slice ref against use-after-free (#4003)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1878,6 +1878,27 @@ target_include_directories(audio_output_router_test PRIVATE src)
 target_link_libraries(audio_output_router_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME audio_output_router_test COMMAND audio_output_router_test)
 
+# Regression test for #4003 — QsoRecorder must not dereference a SliceModel that
+# was freed (reconnect prune) before recording starts. QPointer auto-nulls the
+# reference; the test deletes the slice and asserts the metadata is cleared.
+add_executable(qso_recorder_slice_lifetime_test
+    tests/qso_recorder_slice_lifetime_test.cpp
+    src/core/QsoRecorder.cpp
+    src/core/AppSettings.cpp
+    src/core/AudioDeviceNegotiator.cpp
+    src/core/AudioFormatNegotiator.cpp
+    src/core/LogManager.cpp
+    src/core/AsyncLogWriter.cpp
+    src/core/Resampler.cpp
+    src/models/SliceModel.cpp
+)
+target_include_directories(qso_recorder_slice_lifetime_test PRIVATE
+    src
+    ${CMAKE_SOURCE_DIR}/third_party/r8brain
+)
+target_link_libraries(qso_recorder_slice_lifetime_test PRIVATE Qt6::Core Qt6::Multimedia)
+add_test(NAME qso_recorder_slice_lifetime_test COMMAND qso_recorder_slice_lifetime_test)
+
 add_executable(profile_transfer_test
     tests/profile_transfer_test.cpp
 )

--- a/src/core/QsoRecorder.h
+++ b/src/core/QsoRecorder.h
@@ -7,6 +7,7 @@
 #include <QDateTime>
 #include <QFile>
 #include <QObject>
+#include <QPointer>
 #include <QString>
 #include <QTimer>
 #include <atomic>
@@ -149,8 +150,10 @@ private:
     bool        m_includeFreq{true};
     bool        m_includeMode{true};
 
-    // Slice metadata (captured at recording start)
-    SliceModel* m_slice{nullptr};
+    // Slice metadata (captured at recording start). QPointer auto-nulls when the
+    // SliceModel is destroyed (slice removal / reconnect prune), so startFile()'s
+    // guard can't dereference a freed pointer (#4003).
+    QPointer<SliceModel> m_slice;
     double      m_freqMhz{0.0};
     QString     m_mode;
 

--- a/tests/qso_recorder_slice_lifetime_test.cpp
+++ b/tests/qso_recorder_slice_lifetime_test.cpp
@@ -1,0 +1,103 @@
+// Regression test for #4003 — heap-use-after-free in QsoRecorder::startFile().
+//
+// QsoRecorder holds the active slice via QPointer<SliceModel>, which auto-nulls
+// when the SliceModel is destroyed (slice removal / radio-reconnect prune).
+// Before the fix it was a raw SliceModel*, so startFile()'s `if (m_slice)`
+// guard passed on a freed pointer and dereferenced garbage frequency/mode.
+//
+// The meaningful assertion isn't "doesn't crash" (that only fails under ASan) —
+// it's that after the slice is destroyed the captured metadata is *cleared*
+// (freq 0 / empty mode), so the built filename drops the freq/mode components.
+// That is deterministic with the fix and impossible to satisfy with the bug.
+
+#include "core/QsoRecorder.h"
+#include "models/SliceModel.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+#include <QTemporaryDir>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define EXPECT_EQ(actual, expected) do { \
+    const QString a_ = (actual); const QString e_ = (expected); \
+    if (a_ != e_) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected \"%s\", got \"%s\"\n", \
+                     __FILE__, __LINE__, \
+                     e_.toUtf8().constData(), a_.toUtf8().constData()); \
+        ++g_failures; \
+    } \
+} while (0)
+
+#define EXPECT_TRUE(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  expected true: %s\n", \
+                     __FILE__, __LINE__, #cond); \
+        ++g_failures; \
+    } \
+} while (0)
+
+// Configure a recorder to emit a deterministic, freq/mode-only filename.
+static void configure(QsoRecorder& rec, const QString& dir)
+{
+    rec.setRecordingDir(dir);
+    rec.setIncludeDate(false);
+    rec.setIncludeTime(false);
+    rec.setIncludeFrequency(true);
+    rec.setIncludeMode(true);
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    QTemporaryDir tmp;
+    EXPECT_TRUE(tmp.isValid());
+
+    // ── Sanity: a live slice contributes its freq + mode to the filename. This
+    // is the behavior the crash path was trying to deliver.
+    {
+        QsoRecorder rec;
+        configure(rec, tmp.path());
+        SliceModel slice(0);
+        slice.setFrequency(14.250);
+        slice.setMode("USB");
+        rec.setSlice(&slice);
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        EXPECT_EQ(QFileInfo(rec.recordingFilePath()).fileName(),
+                  QStringLiteral("14.250MHz_USB.wav"));
+        rec.stopRecording();
+    }
+
+    // ── #4003: a slice destroyed before startRecording() must not be
+    // dereferenced. QPointer nulls synchronously on delete, so startFile() takes
+    // the else branch → freq 0 / empty mode → filename collapses to "QSO.wav".
+    // With the old raw pointer this either aborted (ASan) or wrote a garbage
+    // frequency into the name.
+    {
+        QsoRecorder rec;
+        configure(rec, tmp.path());
+        auto* slice = new SliceModel(0);
+        slice->setFrequency(14.250);
+        slice->setMode("USB");
+        rec.setSlice(slice);
+        delete slice;  // simulates reconnect prune freeing the slice
+        rec.startRecording();
+        EXPECT_TRUE(rec.isRecording());
+        EXPECT_EQ(QFileInfo(rec.recordingFilePath()).fileName(),
+                  QStringLiteral("QSO.wav"));
+        rec.stopRecording();
+    }
+
+    if (g_failures == 0) {
+        std::printf("qso_recorder_slice_lifetime_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("qso_recorder_slice_lifetime_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Fixes #4003.

## Problem

`QsoRecorder` stored the active slice as a raw `SliceModel* m_slice` (`src/core/QsoRecorder.h`). Nothing cleared it when the `SliceModel` was destroyed (slice removal / radio-reconnect prune), so `startFile()`'s `if (m_slice)` guard passed on a **freed** pointer — the check only tested non-nullness — and then dereferenced it for frequency/mode:

```cpp
if (m_slice) {                       // non-null, but the object is gone
    m_freqMhz = m_slice->frequency();  // heap-use-after-free
    m_mode    = m_slice->mode();
}
```

ASan abort on instrumented builds; a silent UAF (garbage frequency in the filename) on release. Reproducible by starting a recording shortly after a reconnect churned the slices, as hit via the automation bridge.

## Fix

Store the slice as `QPointer<SliceModel>`, which auto-nulls on `QObject` destruction. The existing `if (m_slice)` guard now genuinely tests liveness. This is the idiomatic Qt approach the issue suggested.

All access is on the GUI thread — `AutomationServer::doRecord` runs there (matching the manual record button), and the `SliceModel` is a GUI model destroyed on the same thread — so `QPointer`'s non-thread-safe auto-null is sufficient. Checked the sibling sink `ClientPuduMonitor`: it holds no slice pointer, so no twin of this bug.

## Test

New `qso_recorder_slice_lifetime_test`:
- deletes the slice **before** `startRecording()` and asserts the captured metadata clears — the filename collapses to `QSO.wav` instead of `14.250MHz_USB.wav`. This is deterministic with the fix and locks in the exact behavior the bug violated (a plain "doesn't crash" assertion would only fail under ASan).
- a positive case confirms a live slice still contributes its freq/mode.

Verified the test **aborts** against the old raw pointer and passes with the fix. Main `AetherSDR` target compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)