### PR TITLE
fix(dax/tci): prevent re-assert storm when WSJT-X connects via TCI with DAX active

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -2030,15 +2030,24 @@ void TciServer::ensureDaxForTci()
     // Re-assert slice → DAX channel mapping so the radio registers our
     // stream as a client.  Without this, dax_clients stays 0 and the
     // radio sends silence instead of demodulated audio. (#1439)
+    // Skip borrowed channels: the DAX bridge already owns those streams and
+    // has dax_clients >= 1. Re-asserting on a live binding triggers the radio's
+    // transient dax=0/dax=<ch> broadcast, which — when the DAX bridge is also
+    // active — drives onDaxChannelChanged and can seed a re-assert storm.
     for (auto* s : m_model->slices()) {
         int ch = s->daxChannel();
-        if (ch > 0 && channelsNeeded.contains(ch)) {
+        if (ch > 0 && channelsNeeded.contains(ch)
+                && !m_tciDaxBorrowedChannels.contains(ch)) {
             m_model->sendCommand(QString("slice set %1 dax=%2")
                 .arg(s->sliceId()).arg(ch));
             qCDebug(lcCat) << "TCI: re-asserting DAX channel" << ch
                            << "on slice" << s->sliceId();
             qCInfo(lcCat) << "TCI: re-asserting dax=" << ch
                           << "on slice" << s->sliceId();
+        } else if (ch > 0 && channelsNeeded.contains(ch)) {
+            qCDebug(lcCat) << "TCI: skipping re-assert for borrowed DAX channel" << ch
+                           << "on slice" << s->sliceId()
+                           << "(bridge already owns the client slot)";
         }
     }
 }

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1103,6 +1103,13 @@ void MainWindow::stopDax()
 void MainWindow::wireDaxSlice(SliceModel* slice)
 {
     if (!slice) return;
+    // Seed the tracker with the slice's current channel before connecting the
+    // signal. Without this, m_daxSliceLastCh starts at 0 even when the slice
+    // already has dax=<ch> from the radio profile. The first ensureDaxForTci()
+    // re-assert then triggers the transient dax=0/dax=<ch> broadcast, and the
+    // dax=<ch> recovery sees oldCh=0 rather than oldCh==newCh, firing one
+    // spurious re-assert before the storm guard (below) stabilises things.
+    m_daxSliceLastCh[slice->sliceId()] = slice->daxChannel();
     m_daxSliceConns.append(connect(slice, &SliceModel::daxChannelChanged,
                                    this, [this, slice](int newCh) {
         if (!m_daxBridge) return;  // bridge torn down — ignore late signals
@@ -1123,7 +1130,16 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
     const int sliceId = slice->sliceId();
     const int oldCh = m_daxSliceLastCh.value(sliceId, 0);
     if (oldCh == newCh) return;
-    m_daxSliceLastCh[sliceId] = newCh;
+    // Don't record the transient dax=0 the radio emits after every
+    // `slice set dax=<ch>` (all 8000-series radios). Updating the tracker to 0
+    // corrupts oldCh so the subsequent dax=<ch> recovery looks like a fresh
+    // 0→N assignment, re-triggers the re-assert below, and creates a
+    // self-sustaining storm. Leaving the tracker at the last real channel means
+    // the recovery sees oldCh==newCh and early-returns with no re-assert.
+    // This is the loop-prevention mechanism for the ensureDaxForTci() re-assert
+    // path; the stream create/remove path is handled by scheduleDaxRxStreamRemoval.
+    if (newCh != 0)
+        m_daxSliceLastCh[sliceId] = newCh;
 
     // 0 -> 1..4 (or 1..4 -> different 1..4): ensure the new channel has a
     // radio-registered DAX RX stream. The stream status echo will register the
@@ -1136,14 +1152,8 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
                           << newCh << "(slice" << sliceId << ", #2895)";
         }
         // Re-assert slice -> DAX mapping so the radio registers our stream as a
-        // client. Without this dax_clients stays 0 and the radio sends silence
-        // (the #1439 workaround, mirrored from TciServer::ensureDaxForTci).
-        // This is sent unconditionally (even when newCh is unchanged), so on the
-        // dax=<ch> rebroadcast edge it re-emits a same-value `slice set`. That
-        // does NOT re-enter this reconciler only because SliceModel's status
-        // path drops same-value echoes (`if (m_daxChannel != ch)` in
-        // SliceModel::applyStatus) — that equality guard is load-bearing for the
-        // #3626 storm fix; relaxing it would reopen the loop via this edge.
+        // client. Without this dax_clients stays 0 and the radio sends silence.
+        // (#1439, mirrored from TciServer::ensureDaxForTci)
         m_radioModel.sendCommand(
             QString("slice set %1 dax=%2").arg(sliceId).arg(newCh));
     }


### PR DESCRIPTION
## Summary

Fixes #4009

Stops the ~12–15 Hz `slice set N dax=<ch>` feedback loop that occurs when WSJT-X
connects via TCI while a DAX channel is already active on a slice. Three targeted
changes across two files:

- **`onDaxChannelChanged()` (`MainWindow_DigitalModes.cpp`):** Do not update
  `m_daxSliceLastCh` when `newCh == 0`. The radio emits a transient `dax=0` after
  every `slice set dax=<ch>` command; recording that 0 corrupts the tracker so the
  subsequent `dax=<ch>` recovery looks like a fresh 0→N transition and fires another
  re-assert. Leaving the tracker at the last real channel means the recovery sees
  `oldCh == newCh` and early-returns with no re-assert.

- **`wireDaxSlice()` (`MainWindow_DigitalModes.cpp`):** Seed `m_daxSliceLastCh`
  with the slice's current channel *before* connecting the signal. Without this the
  tracker starts at 0 even when the slice already has a live DAX channel, so the
  first TCI re-assert triggers the transient broadcast and the `dax=<ch>` recovery
  immediately fires a spurious re-assert before the storm guard can stabilize.

- **`ensureDaxForTci()` (`TciServer.cpp`):** Skip re-assert for channels already in
  `m_tciDaxBorrowedChannels`. When the DAX bridge already owns the stream,
  `dax_clients` is ≥ 1; re-asserting triggers the radio's transient dax=0/dax=<ch>
  broadcast, which seeds the storm through the bridge's active `wireDaxSlice`
  connection.

Affects Linux and macOS only — Windows has no `DaxBridge` type and the entire
reconciler block is absent from that build.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** The storm was a
feedback loop between the client's command path (`ensureDaxForTci` re-assert) and
the radio's truth path (status echo). This fix breaks that loop by ensuring the
client treats the radio's `dax=<ch>` status echo as authoritative confirmation
rather than a trigger for another command.

## Test plan

- [x] Build clean (`ninja`, no warnings in changed TUs) on Debian 13 / Qt 6.x
- [x] Verified against FLEX-8400 firmware v4.2.20.41343: single `slice set 0 dax=1`
      on WSJT-X TCI connect; no repeating storm; WSJT-X waterfall stable
- [x] Closing WSJT-X no longer leaves a residual spam loop in the log
- [ ] CI (triggered on push)

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` entries (Principle V)
- [x] Clean-room implementation — no proprietary source referenced (Principle IV)
- [x] No `MeterSmoother` changes
- [x] No transmit path modified (Principle VI)
- [x] No documentation changes required (internal reconciler logic only)
- [x] No GHSA advisory needed (no security surface affected)