### PR TITLE
fix(ui): make Radio Settings checkboxes visible in dark mode

### DIFF
--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3338,8 +3338,9 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 autoCheck->setText("Auto");
                 autoCheck->setChecked(profile.autoConnect);
                 autoCheck->setAccessibleName("Auto connect KiwiSDR antenna");
-                autoCheck->setStyleSheet(
-                    "QCheckBox { color: #c8d8e8; font-size: 12px; spacing: 4px; }");
+                AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck,
+                    "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+                    + kCheckBoxIndicator);
                 rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
 
                 const KiwiSdrClient::State kiwiState =
@@ -3442,8 +3443,9 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             auto* autoCheck = new QCheckBox;
             autoCheck->setText("Auto");
             autoCheck->setAccessibleName("Auto connect new KiwiSDR antenna");
-            autoCheck->setStyleSheet(
-                "QCheckBox { color: #c8d8e8; font-size: 12px; spacing: 4px; }");
+            AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck,
+                "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+                + kCheckBoxIndicator);
             rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
 
             auto committed = std::make_shared<bool>(false);
@@ -3655,8 +3657,12 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     static const QString kSpin =
         "QSpinBox { background: #1a2a3a; border: 1px solid #304050; "
         "color: #c8d8e8; font-size: 11px; padding: 2px; }";
+    // Token template (applied via applyStyleSheet) so the indicator is visible
+    // in dark mode, matching the other checkboxes in this dialog. #c8d8e8 is
+    // exactly {{color.text.primary}}, so the text colour is unchanged (#4012).
     static const QString kCheck =
-        "QCheckBox { color: #c8d8e8; font-size: 11px; }";
+        "QCheckBox { color: {{color.text.primary}}; font-size: 11px; spacing: 8px; }"
+        + kCheckBoxIndicator;
 
     // ── Left: cable list ────────────────────────────────────────────────
     auto* listGroup = new QGroupBox("Cables");
@@ -3784,7 +3790,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         catNameEdit->setStyleSheet(kEdit);
         hg->addWidget(catNameEdit, 0, 1);
         catEnabledCheck = new QCheckBox("Enabled");
-        catEnabledCheck->setStyleSheet(kCheck);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(catEnabledCheck, kCheck);
         hg->addWidget(catEnabledCheck, 1, 0, 1, 2);
         catStatusLabel = new QLabel("Unplugged");
         AetherSDR::ThemeManager::instance().applyStyleSheet(catStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
@@ -3805,7 +3811,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         catSourceCombo = makeSourceCombo();
         sg->addWidget(catSourceCombo, 0, 1);
         catAutoReportCheck = new QCheckBox("Auto Report");
-        catAutoReportCheck->setStyleSheet(kCheck);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(catAutoReportCheck, kCheck);
         sg->addWidget(catAutoReportCheck, 1, 0, 1, 2);
         vbox->addWidget(srcGroup);
 
@@ -3835,7 +3841,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         bcdNameEdit->setStyleSheet(kEdit);
         hg->addWidget(bcdNameEdit, 0, 1);
         bcdEnabledCheck = new QCheckBox("Enabled");
-        bcdEnabledCheck->setStyleSheet(kCheck);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bcdEnabledCheck, kCheck);
         hg->addWidget(bcdEnabledCheck, 1, 0, 1, 2);
         bcdStatusLabel = new QLabel("Unplugged");
         AetherSDR::ThemeManager::instance().applyStyleSheet(bcdStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
@@ -3885,7 +3891,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         bitNameEdit->setStyleSheet(kEdit);
         hg->addWidget(bitNameEdit, 0, 1);
         bitEnabledCheck = new QCheckBox("Enabled");
-        bitEnabledCheck->setStyleSheet(kCheck);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bitEnabledCheck, kCheck);
         hg->addWidget(bitEnabledCheck, 1, 0, 1, 2);
         bitStatusLabel = new QLabel("Unplugged");
         AetherSDR::ThemeManager::instance().applyStyleSheet(bitStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
@@ -3996,7 +4002,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         ptNameEdit->setStyleSheet(kEdit);
         hg->addWidget(ptNameEdit, 0, 1);
         ptEnabledCheck = new QCheckBox("Enabled");
-        ptEnabledCheck->setStyleSheet(kCheck);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(ptEnabledCheck, kCheck);
         hg->addWidget(ptEnabledCheck, 1, 0, 1, 2);
         ptStatusLabel = new QLabel("Unplugged");
         AetherSDR::ThemeManager::instance().applyStyleSheet(ptStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
@@ -4239,7 +4245,8 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         auto* ulanziEnable = new QCheckBox("Enable Ulanzi Dial");
         AetherSDR::ThemeManager::instance().applyStyleSheet(
-            ulanziEnable, "QCheckBox { color: {{color.text.primary}}; }");
+            ulanziEnable, "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         ulanziEnable->setChecked(
             settings.value("UlanziDialEnabled", "False").toString() == "True");
         connect(ulanziEnable, &QCheckBox::toggled, this, [this](bool on) {
@@ -4254,7 +4261,8 @@ QWidget* RadioSetupDialog::buildSerialTab()
         auto* hidEnable = new QCheckBox(
             "Enable HID encoders / StreamDeck+ (RC-28, PowerMate, ShuttleXpress, …)");
         AetherSDR::ThemeManager::instance().applyStyleSheet(
-            hidEnable, "QCheckBox { color: {{color.text.primary}}; }");
+            hidEnable, "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         hidEnable->setChecked(
             settings.value("HidEncoderEnabled", "False").toString() == "True");
         connect(hidEnable, &QCheckBox::toggled, this, [this](bool on) {
@@ -5886,7 +5894,8 @@ QWidget* RadioSetupDialog::buildUiEnhancementsTab()
 
         auto* reverseChk = new QCheckBox("Reverse mouse-wheel tuning direction");
         AetherSDR::ThemeManager::instance().applyStyleSheet(reverseChk,
-            "QCheckBox { color: {{color.text.primary}}; font-size: 12px; }");
+            "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+            + kCheckBoxIndicator);
         {
             auto& s = AppSettings::instance();
             reverseChk->setChecked(s.value("ReverseMouseWheel", false).toBool());

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -119,6 +119,16 @@ static const QString kKiwiIconButtonStyle =
     "QPushButton:hover { background: #20465e; }"
     "QPushButton:pressed { background: #132c3d; }";
 
+// Shared indicator block for all QCheckBox instances in this dialog.
+// Uses ThemeManager tokens (Low Latency architecture) with hover + disabled
+// pseudo-states (FreeDV Reporter pattern) so boxes are visible in dark mode.
+static const QString kCheckBoxIndicator =
+    "QCheckBox::indicator { width: 14px; height: 14px; "
+    "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
+    "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
+    "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
+    "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
+
 static constexpr int kInfoLeftLabelWidth = 112;
 static constexpr int kInfoRightLabelWidth = 160;
 
@@ -2359,7 +2369,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     {
         auto* plcCheck = new QCheckBox(
             "Smooth packet loss (conceal dropped audio packets)");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(plcCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(plcCheck,
+            "QCheckBox { color: {{color.text.primary}}; font-size: 11px; spacing: 8px; }"
+            + kCheckBoxIndicator);
         plcCheck->setToolTip(
             "When the radio's audio stream loses a UDP packet, fade the gap\n"
             "to silence (uncompressed) or synthesize a perceptually smooth\n"
@@ -2392,7 +2404,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     // ── Prevent Sleep ───────────────────────────────────────────────────
     {
         auto* sleepCheck = new QCheckBox("Prevent system sleep while connected");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(sleepCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(sleepCheck,
+            "QCheckBox { color: {{color.text.primary}}; font-size: 11px; spacing: 8px; }"
+            + kCheckBoxIndicator);
         sleepCheck->setToolTip("Hold a system power assertion to prevent idle sleep\n"
                                "while connected to a radio. Keeps TCP/UDP/audio\n"
                                "streams alive during long sessions.");
@@ -2449,7 +2463,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
     pcLayout->addLayout(outRow);
 
     auto* promptCheck = new QCheckBox("Prompt on Audio Device Changes");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(promptCheck, "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(promptCheck,
+        "QCheckBox { color: {{color.text.primary}}; font-size: 11px; spacing: 8px; }"
+        + kCheckBoxIndicator);
     promptCheck->setToolTip("Show the Audio Device Detected dialog when a new PC audio device appears.");
     const bool suppressAudioDeviceNotifications =
         AppSettings::instance()
@@ -2647,7 +2663,9 @@ QWidget* RadioSetupDialog::buildAudioTab()
         // Auto-record on TX
         auto* autoRow = new QHBoxLayout;
         auto* autoCheck = new QCheckBox("Auto-record on TX");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck, "QCheckBox { color: {{color.text.primary}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck,
+            "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         autoCheck->setChecked(settings.value("QsoRecordingAutoRecord", "False").toString() == "True");
         connect(autoCheck, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -2790,10 +2808,9 @@ QWidget* RadioSetupDialog::buildFiltersTab()
 
         auto* chk = new QCheckBox("Use Low Latency Filters for Digital Modes");
         chk->setChecked(m_model->lowLatencyDigital());
-        AetherSDR::ThemeManager::instance().applyStyleSheet(chk, "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
-            "QCheckBox::indicator { width: 16px; height: 16px; "
-            "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
-            "QCheckBox::indicator:checked { background: {{color.background.2}}; border: 2px solid #00a0e0; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(chk,
+            "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+            + kCheckBoxIndicator);
         connect(chk, &QCheckBox::toggled, this, [this](bool on) {
             m_model->sendCommand(
                 QString("radio set low_latency_digital_modes=%1").arg(on ? 1 : 0));
@@ -4486,7 +4503,9 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Paddle swap
         auto* swapCb = new QCheckBox("Paddle Swap (swap dit/dah)");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(swapCb, "QCheckBox { color: {{color.text.primary}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(swapCb,
+            "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         swapCb->setChecked(AppSettings::instance().value("SerialPaddleSwap", "False").toString() == "True");
         connect(swapCb, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -4559,7 +4578,9 @@ QWidget* RadioSetupDialog::buildSerialTab()
         vbox->addLayout(row);
 
         auto* autoOpen = new QCheckBox("Auto-open serial port on startup");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(autoOpen, "QCheckBox { color: {{color.text.primary}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoOpen,
+            "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         autoOpen->setChecked(settings.value("SerialAutoOpen", "False").toString() == "True");
         connect(autoOpen, &QCheckBox::toggled, this, [](bool on) {
             auto& s = AppSettings::instance();
@@ -4687,7 +4708,9 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Auto-detect checkbox
         auto* autoDetect = new QCheckBox("Auto-detect on startup");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(autoDetect, "QCheckBox { color: {{color.text.primary}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(autoDetect,
+            "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         autoDetect->setChecked(settings.value("FlexControlAutoDetect", "True").toString() == "True");
         connect(autoDetect, &QCheckBox::toggled, this, [this](bool on) {
             auto& s = AppSettings::instance();
@@ -4698,7 +4721,9 @@ QWidget* RadioSetupDialog::buildSerialTab()
         grid->addWidget(autoDetect, 5, 0, 1, 3);
 
         auto* invertDir = new QCheckBox("Invert tuning direction");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(invertDir, "QCheckBox { color: {{color.text.primary}}; }");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(invertDir,
+            "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+            + kCheckBoxIndicator);
         invertDir->setChecked(settings.value("FlexControlInvertDir", "False").toString() == "True");
         m_flexControlInvertCheck = invertDir;
         connect(invertDir, &QCheckBox::toggled, this, [this](bool on) {
@@ -5454,7 +5479,8 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
     // Auto-reconnect checkbox
     auto* reconnectCheck = new QCheckBox("Auto-reconnect to peripherals on connection drop");
     AetherSDR::ThemeManager::instance().applyStyleSheet(reconnectCheck,
-        "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }");
+        "QCheckBox { color: {{color.text.primary}}; font-size: 11px; spacing: 8px; }"
+        + kCheckBoxIndicator);
     const bool autoReconnect = PeripheralSettings::autoReconnect();
     reconnectCheck->setChecked(autoReconnect);
     connect(reconnectCheck, &QCheckBox::toggled, this, [this](bool on) {


### PR DESCRIPTION
## Summary

Fixes #3998, Fixes #4011

All `QCheckBox` instances in `RadioSetupDialog` that applied only a text colour via
`applyStyleSheet` had no `QCheckBox::indicator` rules, leaving the indicator box
invisible against dark backgrounds until clicked — exactly the "click blindly to the
left of the text" behaviour reported.

**Root cause:** Nine checkboxes used the pattern
`"QCheckBox { color: {{color.text.primary}}; ... }"` with no indicator block. The
Low Latency Filters checkbox at line 2793 was the one correctly-styled example in
the file; it already had indicator rules but lacked `:hover` and `:disabled` states.

**Fix:** Introduce `kCheckBoxIndicator` — a shared indicator CSS block in the
file-scope `AetherSDR` namespace — using ThemeManager tokens (`{{color.background.*}}`,
`{{color.accent}}`) with the full set of pseudo-states cherry-picked from the FreeDV
Reporter pattern: `:hover`, `:checked`, and `:disabled`. Apply it to all ten affected
checkboxes. The Low Latency Filters checkbox is updated in the same pass, replacing
its partial inline indicator block and gaining the missing states.

Affected checkboxes:
- Smooth packet loss (PLC)
- Prevent system sleep while connected
- Prompt on Audio Device Changes
- Auto-record on TX
- Use Low Latency Filters for Digital Modes *(already visible; gains :hover/:disabled)*
- Paddle Swap (swap dit/dah)
- Auto-open serial port on startup
- Auto-detect on startup (FlexControl)
- Invert tuning direction (FlexControl)
- **Auto-reconnect to peripherals on connection drop** ← originally reported

One file changed: `src/gui/RadioSetupDialog.cpp`.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** The fix was verified by UI inspection on
Linux (Debian 13, Qt 6.x) against a FLEX-8400 fw 4.2.20.41343: all ten checkboxes
render a visible bordered indicator in both unchecked and checked states, with
correct hover highlighting. Checked-state appearance on Linux is consistent with the
pre-existing Low Latency Filters checkbox.

## Test plan

- [x] Build clean (`ninja`, no warnings in changed TU beyond pre-existing)
- [x] UI tested on Linux — all ten checkboxes show a visible bordered indicator in
      unchecked state; checked and hover states render correctly
- [x] Checked appearance is consistent with the Low Latency Filters checkbox
      (the one already-correct reference in this dialog)
- [ ] CI (triggered on push)
- [ ] Visual verification on macOS and Windows welcome — native platforms render
      their own indicator geometry, so the token colours apply to border/background
      only on those targets

## Checklist

- [x] Commits are signed (SSH)
- [x] No new `AppSettings` keys (Principle V)
- [x] Clean-room — no proprietary source referenced (Principle IV)
- [x] No `MeterSmoother` changes
- [x] No transmit path modified (Principle VI)
- [x] No documentation changes required
- [x] No GHSA advisory needed