### PR TITLE
refactor(ui): migrate FreeDV/SpotHub checkboxes to ThemeManager tokens

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1612,6 +1612,21 @@ QString ThemeManager::resolve(const QString& stylesheetTemplate) const
     return resolveFor(nullptr, stylesheetTemplate);
 }
 
+QString ThemeManager::checkBoxIndicatorStyle()
+{
+    // Single source of truth for the checkbox indicator used across dialogs
+    // (RadioSetupDialog, DxClusterDialog, FreeDvReporterDialog).  Kept as an
+    // unresolved token template so applyStyleSheet() expands it per widget
+    // and it re-paints on theme switches.
+    static const QString kStyle =
+        "QCheckBox::indicator { width: 14px; height: 14px; "
+        "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
+        "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
+        "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
+        "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
+    return kStyle;
+}
+
 QString ThemeManager::resolveFor(const QWidget* widget,
                                  const QString& stylesheetTemplate) const
 {

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -165,6 +165,15 @@ public:
     // dangling pointers.
     void applyStyleSheet(QWidget* widget, const QString& stylesheetTemplate);
 
+    // Shared QCheckBox::indicator style fragment — ThemeManager tokens plus
+    // the full hover/checked/disabled pseudo-state set — so every dialog gets
+    // a visible, theme-reactive indicator in dark mode without hand-rolling
+    // the block per file (#4013).  Concatenate it onto the caller's
+    // "QCheckBox { ... }" template and pass the result to applyStyleSheet();
+    // it returns an unresolved template, so setStyleSheet() would NOT expand
+    // the {{tokens}} — use applyStyleSheet().
+    static QString checkBoxIndicatorStyle();
+
     // Stop tracking a widget — its recorded stylesheet template is
     // dropped and it no longer re-paints on themeChanged.  Useful for
     // widgets that want to take over stylesheet management themselves

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -35,6 +35,15 @@
 
 namespace AetherSDR {
 
+// Shared indicator block — ThemeManager tokens + full pseudo-state set.
+// Apply via applyStyleSheet(); setStyleSheet() will not resolve {{tokens}}.
+static const QString kCheckBoxIndicator =
+    "QCheckBox::indicator { width: 14px; height: 14px; "
+    "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
+    "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
+    "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
+    "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
+
 // GuardedSlider variant that resets to a stored default on left
 // double-click.  Used for the Filter Match Window slider (#2609) so
 // the operator can snap back to the 1 kHz default without dragging.
@@ -1164,8 +1173,9 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
     AetherSDR::ThemeManager::instance().applyStyleSheet(filterLabel, "QLabel { color: {{color.text.label}}; font-size: 14px; }");
     filterRow->addWidget(filterLabel);
 
-    QString cbStyle = "QCheckBox { color: #a0b0c0; font-size: 14px; spacing: 3px; }"
-                      "QCheckBox::indicator { width: 14px; height: 14px; }";
+    const QString cbStyle =
+        "QCheckBox { color: {{color.text.secondary}}; font-size: 14px; spacing: 3px; }"
+        + kCheckBoxIndicator;
     auto swatchStyle = [](const QColor& c) {
         return QString("QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
                        "QPushButton:hover { border-color: #c8d8e8; }").arg(c.name());
@@ -1188,7 +1198,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
 
     m_wsjtxFilterCQ = new QCheckBox("CQ");
     m_wsjtxFilterCQ->setChecked(s.value("WsjtxFilterCQ", "True").toString() == "True");
-    m_wsjtxFilterCQ->setStyleSheet(cbStyle);
+    ThemeManager::instance().applyStyleSheet(m_wsjtxFilterCQ, cbStyle);
     connect(m_wsjtxFilterCQ, &QCheckBox::toggled, this, [this](bool on) {
         if (on) m_wsjtxFilterPOTA->setChecked(false);
         auto& s = AppSettings::instance();
@@ -1214,7 +1224,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
 
     m_wsjtxFilterPOTA = new QCheckBox("CQ POTA");
     m_wsjtxFilterPOTA->setChecked(s.value("WsjtxFilterPOTA", "True").toString() == "True");
-    m_wsjtxFilterPOTA->setStyleSheet(cbStyle);
+    ThemeManager::instance().applyStyleSheet(m_wsjtxFilterPOTA, cbStyle);
     connect(m_wsjtxFilterPOTA, &QCheckBox::toggled, this, [this](bool on) {
         if (on) m_wsjtxFilterCQ->setChecked(false);
         auto& s = AppSettings::instance();
@@ -1240,7 +1250,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
 
     m_wsjtxFilterCallingMe = new QCheckBox("Calling Me");
     m_wsjtxFilterCallingMe->setChecked(s.value("WsjtxFilterCallingMe", "True").toString() == "True");
-    m_wsjtxFilterCallingMe->setStyleSheet(cbStyle);
+    ThemeManager::instance().applyStyleSheet(m_wsjtxFilterCallingMe, cbStyle);
     connect(m_wsjtxFilterCallingMe, &QCheckBox::toggled, this, [](bool on) {
         auto& s = AppSettings::instance();
         s.setValue("WsjtxFilterCallingMe", on ? "True" : "False");
@@ -1642,17 +1652,14 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     int frow = 0;
 
     const QString fdvCheckStyle =
-        "QCheckBox { color: #d7e4f2; spacing: 8px; background: transparent; border: none; }"
-        "QCheckBox::indicator { width: 14px; height: 14px; border: 2px solid #5d748d; border-radius: 3px; background: #0b1520; }"
-        "QCheckBox::indicator:hover { border-color: #81abd9; background: #142130; }"
-        "QCheckBox::indicator:checked { border: 2px solid #8cc8ff; background: #2f71b6; }"
-        "QCheckBox::indicator:disabled { border-color: #405262; background: #10161d; }";
+        "QCheckBox { color: {{color.text.primary}}; spacing: 8px; background: transparent; border: none; }"
+        + kCheckBoxIndicator;
 
     // Enable checkbox spans all columns so it sits reliably inside the grid,
     // not above it (avoids group-box title margin clipping on dark themes).
     m_fdvReportCheck = new QCheckBox("Enable FreeDV Reporter reporting when RADE is active");
     m_fdvReportCheck->setChecked(s.value("FreeDvAutoReport", "False").toString() == "True");
-    m_fdvReportCheck->setStyleSheet(fdvCheckStyle);
+    ThemeManager::instance().applyStyleSheet(m_fdvReportCheck, fdvCheckStyle);
     connect(m_fdvReportCheck, &QCheckBox::toggled, this, [this](bool on) {
         if (on) {
             // Resolve the effective callsign and grid the same way
@@ -1721,7 +1728,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     m_fdvUseRadioCallsignCheck = new QCheckBox("Use radio");
     m_fdvUseRadioCallsignCheck->setChecked(
         s.value("FreeDvUseRadioCallsign", "True").toString() == "True");
-    m_fdvUseRadioCallsignCheck->setStyleSheet(fdvCheckStyle);
+    ThemeManager::instance().applyStyleSheet(m_fdvUseRadioCallsignCheck, fdvCheckStyle);
     connect(m_fdvUseRadioCallsignCheck, &QCheckBox::toggled, this, [this](bool on) {
         auto& as = AppSettings::instance();
         as.setValue("FreeDvUseRadioCallsign", on ? "True" : "False");
@@ -1756,7 +1763,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
     // GPS checkbox — only on FLEX-8000 class and Aurora, which have GPS hardware
     if (m_radioModel->hasGpsHardware()) {
         m_fdvUseGpsCheck = new QCheckBox("Use GPS");
-        m_fdvUseGpsCheck->setStyleSheet(fdvCheckStyle);
+        ThemeManager::instance().applyStyleSheet(m_fdvUseGpsCheck, fdvCheckStyle);
         bool useGps = s.value("FreeDvUseGpsGrid", "True").toString() == "True";
         m_fdvUseGpsCheck->setChecked(useGps);
         m_fdvGridEdit->setReadOnly(useGps);
@@ -1875,9 +1882,9 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     static constexpr const char* bands[] = {
         "160m", "80m", "60m", "40m", "30m", "20m", "17m", "15m", "12m", "10m", "6m"
     };
-    QString cbStyle =
-        "QCheckBox { color: #a0b0c0; font-size: 12px; spacing: 3px; }"
-        "QCheckBox::indicator { width: 13px; height: 13px; }";
+    const QString cbStyle =
+        "QCheckBox { color: {{color.text.secondary}}; font-size: 12px; spacing: 3px; }"
+        + kCheckBoxIndicator;
     auto& sf = AppSettings::instance();
     for (const char* band : bands) {
         auto* cb = new QCheckBox(band);
@@ -1886,7 +1893,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
         cb->setChecked(on);
         if (!on)
             m_proxyModel->setBandVisible(QString(band), false);
-        cb->setStyleSheet(cbStyle);
+        ThemeManager::instance().applyStyleSheet(cb, cbStyle);
         connect(cb, &QCheckBox::toggled, this, [this, b = QString(band), key](bool on) {
             m_proxyModel->setBandVisible(b, on);
             auto& s = AppSettings::instance();

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -35,15 +35,6 @@
 
 namespace AetherSDR {
 
-// Shared indicator block — ThemeManager tokens + full pseudo-state set.
-// Apply via applyStyleSheet(); setStyleSheet() will not resolve {{tokens}}.
-static const QString kCheckBoxIndicator =
-    "QCheckBox::indicator { width: 14px; height: 14px; "
-    "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
-    "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
-    "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
-    "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
-
 // GuardedSlider variant that resets to a stored default on left
 // double-click.  Used for the Filter Match Window slider (#2609) so
 // the operator can snap back to the 1 kHz default without dragging.
@@ -1175,7 +1166,7 @@ void DxClusterDialog::buildWsjtxTab(QTabWidget* tabs)
 
     const QString cbStyle =
         "QCheckBox { color: {{color.text.secondary}}; font-size: 14px; spacing: 3px; }"
-        + kCheckBoxIndicator;
+        + ThemeManager::checkBoxIndicatorStyle();
     auto swatchStyle = [](const QColor& c) {
         return QString("QPushButton { background: %1; border: 2px solid #405060; border-radius: 3px; }"
                        "QPushButton:hover { border-color: #c8d8e8; }").arg(c.name());
@@ -1653,7 +1644,7 @@ void DxClusterDialog::buildFreeDvTab(QTabWidget* tabs)
 
     const QString fdvCheckStyle =
         "QCheckBox { color: {{color.text.primary}}; spacing: 8px; background: transparent; border: none; }"
-        + kCheckBoxIndicator;
+        + ThemeManager::checkBoxIndicatorStyle();
 
     // Enable checkbox spans all columns so it sits reliably inside the grid,
     // not above it (avoids group-box title margin clipping on dark themes).
@@ -1884,7 +1875,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     };
     const QString cbStyle =
         "QCheckBox { color: {{color.text.secondary}}; font-size: 12px; spacing: 3px; }"
-        + kCheckBoxIndicator;
+        + ThemeManager::checkBoxIndicatorStyle();
     auto& sf = AppSettings::instance();
     for (const char* band : bands) {
         auto* cb = new QCheckBox(band);

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -23,6 +23,13 @@
 
 namespace AetherSDR {
 
+static const QString kCheckBoxIndicator =
+    "QCheckBox::indicator { width: 14px; height: 14px; "
+    "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
+    "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
+    "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
+    "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
+
 // ── Proxy ──────────────────────────────────────────────────────────────────
 
 class FreeDvReporterProxy : public QSortFilterProxyModel {
@@ -177,7 +184,8 @@ void FreeDvReporterDialog::buildBody()
 
     m_trackCheck = new QCheckBox("Track");
     ThemeManager::instance().applyStyleSheet(m_trackCheck,
-        "QCheckBox { color: {{color.text.primary}}; }");
+        "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
+        + kCheckBoxIndicator);
     bottom->addWidget(m_trackCheck);
 
     m_bandRadio = new QRadioButton("Band");

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -23,13 +23,6 @@
 
 namespace AetherSDR {
 
-static const QString kCheckBoxIndicator =
-    "QCheckBox::indicator { width: 14px; height: 14px; "
-    "border: 2px solid {{color.background.3}}; border-radius: 3px; background: {{color.background.0}}; }"
-    "QCheckBox::indicator:hover { border-color: {{color.accent}}; background: {{color.background.1}}; }"
-    "QCheckBox::indicator:checked { border: 2px solid {{color.accent}}; background: {{color.background.2}}; }"
-    "QCheckBox::indicator:disabled { border-color: {{color.background.2}}; background: {{color.background.0}}; }";
-
 // ── Proxy ──────────────────────────────────────────────────────────────────
 
 class FreeDvReporterProxy : public QSortFilterProxyModel {
@@ -185,7 +178,7 @@ void FreeDvReporterDialog::buildBody()
     m_trackCheck = new QCheckBox("Track");
     ThemeManager::instance().applyStyleSheet(m_trackCheck,
         "QCheckBox { color: {{color.text.primary}}; spacing: 8px; }"
-        + kCheckBoxIndicator);
+        + ThemeManager::checkBoxIndicatorStyle());
     bottom->addWidget(m_trackCheck);
 
     m_bandRadio = new QRadioButton("Band");


### PR DESCRIPTION
## Summary

Closes #4013

Follow-up to #4012. Migrates the remaining hardcoded-hex checkbox stylesheets in
`DxClusterDialog` and `FreeDvReporterDialog` to ThemeManager token strings applied
via `applyStyleSheet()`, bringing them into line with the pattern established for
`RadioSetupDialog` in #4012.

**Root cause of the technical debt:** These checkboxes used `setStyleSheet()` with
literal hex colours that happen to match the current dark theme. `setStyleSheet()`
does not run through the ThemeManager resolver, so `{{token}}` substitution never
fires — meaning a theme change would leave these widgets stranded on the old palette
while the rest of the UI adapts.

**Changes per file:**

`src/gui/DxClusterDialog.cpp` — adds `kCheckBoxIndicator` to the `AetherSDR`
namespace and converts three groups:
- **WSJT-X filter checkboxes** (`m_wsjtxFilterCQ`, `m_wsjtxFilterPOTA`,
  `m_wsjtxFilterCallingMe`): `#a0b0c0` → `{{color.text.secondary}}`; bare
  unstyled indicator → `kCheckBoxIndicator`; `setStyleSheet` → `applyStyleSheet`.
- **Band filter checkboxes** (loop-created per band): same conversion, `font-size:
  12px` path.
- **FreeDV station reporting checkboxes** (`m_fdvReportCheck`,
  `m_fdvUseRadioCallsignCheck`, `m_fdvUseGpsCheck`): replace five-line
  `fdvCheckStyle` with `{{color.text.primary}}` + `kCheckBoxIndicator`;
  `setStyleSheet` → `applyStyleSheet`. Checked-state background harmonised to
  `{{color.background.2}}` (consistent with all other checkboxes in the app).

`src/gui/FreeDvReporterDialog.cpp` — adds `kCheckBoxIndicator` and appends it to
the Track checkbox, which already used `applyStyleSheet` but was missing indicator
rules (invisible in dark mode until clicked — same class of defect as #3998).

No behaviour change on the current dark theme. Two files, no new classes, no new
settings.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** Changes verified by UI inspection on
Linux (Debian 13, Qt 6.x) against a FLEX-8400 fw 4.2.20.41343: all affected
checkboxes render a visible bordered indicator with correct hover and checked states,
consistent with the `RadioSetupDialog` checkboxes fixed in #4012.

## Test plan

- [x] Build clean (`ninja`, no warnings in changed TUs)
- [x] UI tested on Linux — WSJT-X filter checkboxes, band filter checkboxes, FreeDV
      station reporting checkboxes, and FreeDV Reporter Track checkbox all render
      visible indicators in unchecked, hover, and checked states
- [x] Checked appearance is visually consistent with RadioSetupDialog checkboxes
      from #4012
- [ ] CI (triggered on push)
- [ ] Verification on macOS / Windows welcome — no behaviour change expected on
      current dark theme, but token resolution path is now correct for both

## Checklist

- [x] Commits are signed (SSH)
- [x] No new `AppSettings` keys (Principle V)
- [x] Clean-room — no proprietary source referenced (Principle IV)
- [x] No `MeterSmoother` changes
- [x] No transmit path modified (Principle VI)
- [x] No documentation changes required
- [x] No GHSA advisory needed