### PR TITLE
fix(dax): centralize DAX RX stream ownership in PanadapterStream (#3305) — kills the #4009 re-assert storm class

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -996,8 +996,8 @@ dependency for TCI/DAX lifecycle testing. Requires the TCI server to be
 running (toggle via `invoke tciEnable click` if needed).
 
 ```json
-→ {"cmd":"tci","action":"start"}            // optional value = port (default: TciPort setting)
-← {"ok":true,"action":"start","port":40001}
+→ {"cmd":"tci","action":"start"}            // optional value = port
+← {"ok":true,"action":"start","port":50001} // default = the TciPort setting (50001 unless changed)
 
 → {"cmd":"tci","action":"status"}
 ← {"ok":true,"running":true,"connected":true,"ready":true,"audioStarted":true,

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -146,6 +146,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get clients`](#get-clients) | Radio client roster + foreign-pan-write forensics (#3977). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
 | | [`get wavestats`](#get-wavestats) | WAVE/strip scope paint-cost counters. |
+| | [`get dax`](#get-dax) | DAX RX channel-ownership table (holders/streams, #3305). |
 | **Connection** | [`connect …`](#connect--disconnect) | list / show / hide / local / ip / wait. |
 | | [`disconnect`](#connect--disconnect) | Normal user disconnect. |
 | **Tuning & slices** | [`tune <mhz>`](#tune) | Set the active slice frequency (VFO; not keying). |
@@ -153,6 +154,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | **Display / pans** | [`pan <action>`](#pan) | create / center / close a panadapter. |
 | | [`streams [radio\|resync\|reset]`](#streams) | Radio-side display-stream leak detector. |
 | | [`txwaterfall on\|off`](#txwaterfall) | Toggle "show TX in waterfall". |
+| **DAX / TCI** | [`tci start\|status\|stop`](#tci) | In-process TCI client simulator (WSJT-X-shaped). |
 | **Observability** | [`log <action>`](#log) | Runtime log-category control + ring-buffer tail/subscribe. |
 | | [`mark <text>`](#mark) | Drop a sequenced timeline marker. |
 | | [`audioCapture <action>`](#audiocapture) | Bounded PCM capture for sync diagnostics. |
@@ -431,6 +433,7 @@ connects).
 | `panstats` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter render-cost counters — see [`get panstats`](#get-panstats) |
 | `wavestats` | `—` / scope objectName | waveform-scope paint/append counters — see [`get wavestats`](#get-wavestats) |
 | `clients` | — | connected-client roster, per-pan ownership, foreign dBm-write counters and evictions — see [`get clients`](#get-clients) |
+| `dax` | — | DAX RX channel-ownership table — see [`get dax`](#get-dax) |
 
 Add a trailing **property** name to any single-object form to get just that
 field: `get slice active mode` → `{"value":"LSB"}`.
@@ -961,6 +964,55 @@ toggle — it does **not** key the transmitter.
 
 Accepts `on`/`off` (also `1`/`0`, `true`/`false`, `enable`/`disable`). The radio
 echoes the change asynchronously — re-read with `get transmit showTxInWaterfall`.
+
+### `get dax`
+Read the centralized DAX RX channel-ownership table (#3305): which consumers
+(`bridge` / `tci` / `rade`) hold each channel, the radio-side stream id, and
+whether a `stream create` is in flight — plus each slice's `dax=` assignment.
+This is the assertion surface for DAX/TCI lifecycle tests: storm regressions
+(#4009), co-hold survival across a bridge or TCI teardown (#3363), and
+grace-window stream removal, all without log-grepping.
+
+```json
+→ {"cmd":"get","model":"dax"}
+← {"ok":true,"model":"dax",
+   "channels":[{"channel":1,"streamId":"0x4000008","createPending":false,
+                "holders":["bridge","tci"]}],
+   "slices":[{"sliceId":0,"daxChannel":1}]}
+```
+
+Semantics to assert against: a channel with holders and `streamId=0x0` +
+`createPending=true` is mid-create; a channel with a stream and **no** holders
+is inside the 1.5 s removal grace window (it disappears once the removal
+lands); a channel entry that persists with holders across a consumer teardown
+proves the co-hold path.
+
+### `tci`
+In-process TCI **client** simulator. Connects to this app's own TCI server
+over loopback and speaks the WSJT-X dialect: drain the init burst until
+`ready;`, then send `audio_samplerate:48000;` + `audio_start:0;`, then count
+the binary audio frames the server pushes. Removes the external-WebSocket
+dependency for TCI/DAX lifecycle testing. Requires the TCI server to be
+running (toggle via `invoke tciEnable click` if needed).
+
+```json
+→ {"cmd":"tci","action":"start"}            // optional value = port (default: TciPort setting)
+← {"ok":true,"action":"start","port":40001}
+
+→ {"cmd":"tci","action":"status"}
+← {"ok":true,"running":true,"connected":true,"ready":true,"audioStarted":true,
+   "binaryFrames":412,"binaryBytes":1687552,"textMessages":37,"msSinceLastFrame":18}
+
+→ {"cmd":"tci","action":"stop","value":"abrupt"}   // omit value for graceful audio_stop + close
+← {"ok":true,"action":"stop","abrupt":true,"binaryFrames":412, …}
+```
+
+`stop abrupt` closes the socket without `audio_stop` — the WSJT-X
+watchdog-reconnect shape — so a test can assert the server's debounced DAX
+release and the manager's grace-window `stream remove` (watch with `get dax`).
+`binaryFrames` climbing at a steady rate (~47/s at 48 kHz) is the "audio is
+actually flowing" assertion; `msSinceLastFrame` spiking while `audioStarted`
+is true means the stream went silent.
 
 ### `get sync`
 Read the Receive Sync state used by the spectrum overlay and Auto Assist

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -4541,17 +4541,25 @@ QJsonObject AutomationServer::doTci(const QString& action, const QString& value)
         QJsonObject o = status();
         m_tciSimCloseReason = abrupt ? QStringLiteral("client abort (abrupt)")
                                      : QStringLiteral("client stop");
-        if (abrupt) {
-            m_tciSim->abort();
-        } else {
-            if (m_tciSimAudioStarted)
-                m_tciSim->sendTextMessage(QStringLiteral("audio_stop:0;"));
-            m_tciSim->close();
-        }
-        m_tciSim->deleteLater();
+        // Null m_tciSim BEFORE abort()/close(). abort() emits QWebSocket::
+        // disconnected synchronously (same-thread direct delivery), re-entering
+        // the disconnected lambda; if m_tciSim were still set there it would
+        // deleteLater()+null it, and the deleteLater() below would then fire on
+        // a dangling pointer. Nulling first makes the lambda's sock==m_tciSim
+        // guard fail so it no-ops, and we own the teardown here (#4017).
+        QWebSocket* sim = m_tciSim;
+        const bool wasAudioStarted = m_tciSimAudioStarted;
         m_tciSim = nullptr;
         m_tciSimReady = false;
         m_tciSimAudioStarted = false;
+        if (abrupt) {
+            sim->abort();
+        } else {
+            if (wasAudioStarted)
+                sim->sendTextMessage(QStringLiteral("audio_stop:0;"));
+            sim->close();
+        }
+        sim->deleteLater();
         o[QStringLiteral("action")] = QStringLiteral("stop");
         o[QStringLiteral("abrupt")] = abrupt;
         qCInfo(lcAutomation) << "tci sim: stopped" << (abrupt ? "(abrupt)" : "(graceful)");

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -4511,6 +4511,20 @@ QJsonObject AutomationServer::doTci(const QString& action, const QString& value)
         connect(m_tciSim, &QWebSocket::disconnected, this, [this]() {
             if (m_tciSimCloseReason.isEmpty())
                 m_tciSimCloseReason = QStringLiteral("server closed");
+            // Tear down so `tci status` reports running=false and a later
+            // `tci start` isn't rejected as "already running" after a
+            // server/radio-side close (PR #4017 review item 5). The stop path
+            // nulls m_tciSim before its own close lands — only reap here when
+            // the disconnect came from the socket we still track.
+            if (auto* sock = qobject_cast<QWebSocket*>(sender());
+                    sock && sock == m_tciSim) {
+                m_tciSim->deleteLater();
+                m_tciSim = nullptr;
+                m_tciSimReady = false;
+                m_tciSimAudioStarted = false;
+                qCInfo(lcAutomation) << "tci sim: torn down after server-side close"
+                                     << m_tciSimCloseReason;
+            }
         });
         m_tciSim->open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(port)));
         qCInfo(lcAutomation) << "tci sim: connecting to ws://127.0.0.1:" << port;

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -62,6 +62,9 @@
 #include <QToolButton>   // doShowMenu: QToolButton::menu()
 #include <QWidgetAction>  // describeAction: header rows (disabled QWidgetAction + QLabel)
 #include <QContextMenuEvent>  // doContextMenu: synthesize a right-click menu trigger
+#ifdef HAVE_WEBSOCKETS
+#include <QWebSocket>         // doTci: in-process TCI client simulator (#3305)
+#endif
 
 #include <QScrollArea>   // doScrollTo: ensureWidgetVisible on the ancestor
 #include <QScrollBar>    // doScrollTo: echo the resulting scrollbar positions
@@ -2004,6 +2007,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("streams"))
         return doStreams(action);
+    if (cmd == QLatin1String("tci")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("tci requires an action (start [port] | status | stop [abrupt])"));
+        return doTci(action, value);
+    }
     if (cmd == QLatin1String("audioCapture"))
         return doAudioCapture(action.isEmpty() ? QStringLiteral("status") : action,
                               value, path);
@@ -2741,6 +2749,41 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
             {QStringLiteral("clients"), clients},
             {QStringLiteral("foreignPanWrites"), foreign},
             {QStringLiteral("evictedHandles"), evicted}};
+    }
+    if (model == QLatin1String("dax")) {
+        // Centralized DAX RX channel-ownership snapshot (#3305): who holds
+        // which channel, the radio-side stream id, and whether a create is in
+        // flight — plus each slice's dax assignment. This is the direct
+        // assertion surface for DAX/TCI lifecycle tests (storm regression,
+        // co-hold survival, grace-window removal) that previously required
+        // log-grepping.
+        if (!m_radioModel)
+            return err(QStringLiteral("no radio model available"));
+        auto* ps = m_radioModel->panStream();
+        if (!ps)
+            return err(QStringLiteral("no panadapter stream available"));
+        QJsonArray channels;
+        for (const auto& c : ps->daxChannelSnapshot()) {
+            channels.append(QJsonObject{
+                {QStringLiteral("channel"),       c.channel},
+                {QStringLiteral("streamId"),      QStringLiteral("0x")
+                     + QString::number(c.streamId, 16)},
+                {QStringLiteral("createPending"), c.createPending},
+                {QStringLiteral("holders"),       QJsonArray::fromStringList(c.holders)},
+            });
+        }
+        QJsonArray sliceDax;
+        for (const SliceModel* s : m_radioModel->slices()) {
+            if (!s) continue;
+            sliceDax.append(QJsonObject{
+                {QStringLiteral("sliceId"),    s->sliceId()},
+                {QStringLiteral("daxChannel"), s->daxChannel()},
+            });
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("channels"), channels},
+                           {QStringLiteral("slices"), sliceDax}};
     }
     if (model == QLatin1String("panstats")) {
         // Per-panadapter frame-cost counters from every SpectrumWidget, for
@@ -4391,6 +4434,120 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
 //                              with leaked waterfalls (parent pan gone) — catches
 //                              resource-level lingering that emits no UDP (#3843).
 // `streams reset` clears the Layer-A orphan tally to re-baseline a before/after.
+// `tci start [port] | status | stop [abrupt]` — in-process TCI client
+// simulator (#3305/#4009). Speaks the same WebSocket dialect as WSJT-X: drain
+// the init burst until `ready;`, then `audio_samplerate` + `audio_start`, then
+// count the binary audio frames the server pushes back. `stop abrupt` closes
+// the socket without `audio_stop` (the WSJT-X watchdog-reconnect shape) so
+// tests can assert the debounced release + grace-window stream removal.
+QJsonObject AutomationServer::doTci(const QString& action, const QString& value)
+{
+#ifndef HAVE_WEBSOCKETS
+    Q_UNUSED(action);
+    Q_UNUSED(value);
+    return err(QStringLiteral("TCI is not built into this binary (HAVE_WEBSOCKETS off)"));
+#else
+    const auto status = [this]() {
+        QJsonObject o{{QStringLiteral("ok"), true},
+                      {QStringLiteral("running"), m_tciSim != nullptr}};
+        if (m_tciSim) {
+            o[QStringLiteral("connected")]    = m_tciSim->state() == QAbstractSocket::ConnectedState;
+            o[QStringLiteral("ready")]        = m_tciSimReady;
+            o[QStringLiteral("audioStarted")] = m_tciSimAudioStarted;
+        }
+        o[QStringLiteral("binaryFrames")] = m_tciSimBinaryFrames;
+        o[QStringLiteral("binaryBytes")]  = m_tciSimBinaryBytes;
+        o[QStringLiteral("textMessages")] = m_tciSimTextMsgs;
+        o[QStringLiteral("msSinceLastFrame")] =
+            (m_tciSimLastFrameMs >= 0 && m_tciSimTimer.isValid())
+                ? m_tciSimTimer.elapsed() - m_tciSimLastFrameMs : -1;
+        if (!m_tciSimCloseReason.isEmpty())
+            o[QStringLiteral("closeReason")] = m_tciSimCloseReason;
+        return o;
+    };
+
+    if (action == QLatin1String("status"))
+        return status();
+
+    if (action == QLatin1String("start")) {
+        if (m_tciSim)
+            return err(QStringLiteral("tci sim already running — `tci stop` first"));
+        bool okPort = false;
+        int port = value.trimmed().toInt(&okPort);
+        if (!okPort || port <= 0)
+            port = AppSettings::instance().value("TciPort", "50001").toInt();
+        m_tciSimReady = false;
+        m_tciSimAudioStarted = false;
+        m_tciSimBinaryFrames = 0;
+        m_tciSimBinaryBytes = 0;
+        m_tciSimTextMsgs = 0;
+        m_tciSimLastFrameMs = -1;
+        m_tciSimCloseReason.clear();
+        m_tciSimTimer.start();
+        m_tciSim = new QWebSocket(QStringLiteral("aether-automation-tci-sim"),
+                                  QWebSocketProtocol::VersionLatest, this);
+        connect(m_tciSim, &QWebSocket::textMessageReceived,
+                this, [this](const QString& msg) {
+            ++m_tciSimTextMsgs;
+            if (m_tciSimReady) return;
+            const QStringList cmds = msg.split(QLatin1Char(';'));
+            for (const QString& c : cmds) {
+                if (c.trimmed() == QLatin1String("ready")) {
+                    m_tciSimReady = true;
+                    m_tciSim->sendTextMessage(QStringLiteral("audio_samplerate:48000;"));
+                    m_tciSim->sendTextMessage(QStringLiteral("audio_start:0;"));
+                    m_tciSimAudioStarted = true;
+                    qCInfo(lcAutomation) << "tci sim: ready received — audio_start sent";
+                    break;
+                }
+            }
+        });
+        connect(m_tciSim, &QWebSocket::binaryMessageReceived,
+                this, [this](const QByteArray& b) {
+            ++m_tciSimBinaryFrames;
+            m_tciSimBinaryBytes += b.size();
+            m_tciSimLastFrameMs = m_tciSimTimer.elapsed();
+        });
+        connect(m_tciSim, &QWebSocket::disconnected, this, [this]() {
+            if (m_tciSimCloseReason.isEmpty())
+                m_tciSimCloseReason = QStringLiteral("server closed");
+        });
+        m_tciSim->open(QUrl(QStringLiteral("ws://127.0.0.1:%1").arg(port)));
+        qCInfo(lcAutomation) << "tci sim: connecting to ws://127.0.0.1:" << port;
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("action"), QStringLiteral("start")},
+                           {QStringLiteral("port"), port}};
+    }
+
+    if (action == QLatin1String("stop")) {
+        if (!m_tciSim)
+            return err(QStringLiteral("tci sim is not running"));
+        const bool abrupt = value.trimmed().compare(QLatin1String("abrupt"),
+                                                    Qt::CaseInsensitive) == 0;
+        QJsonObject o = status();
+        m_tciSimCloseReason = abrupt ? QStringLiteral("client abort (abrupt)")
+                                     : QStringLiteral("client stop");
+        if (abrupt) {
+            m_tciSim->abort();
+        } else {
+            if (m_tciSimAudioStarted)
+                m_tciSim->sendTextMessage(QStringLiteral("audio_stop:0;"));
+            m_tciSim->close();
+        }
+        m_tciSim->deleteLater();
+        m_tciSim = nullptr;
+        m_tciSimReady = false;
+        m_tciSimAudioStarted = false;
+        o[QStringLiteral("action")] = QStringLiteral("stop");
+        o[QStringLiteral("abrupt")] = abrupt;
+        qCInfo(lcAutomation) << "tci sim: stopped" << (abrupt ? "(abrupt)" : "(graceful)");
+        return o;
+    }
+
+    return err(QStringLiteral("tci requires an action (start [port] | status | stop [abrupt])"));
+#endif
+}
+
 QJsonObject AutomationServer::doStreams(const QString& action)
 {
     if (!m_radioModel)

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -9,6 +9,10 @@
 #include <QJsonObject>
 #include <QString>
 
+#ifdef HAVE_WEBSOCKETS
+class QWebSocket;
+#endif
+
 #include <deque>
 #include <functional>
 #include <memory>
@@ -309,6 +313,7 @@ private:
     //                     waterfall the client view had already purged.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
+    QJsonObject doTci(const QString& action, const QString& value);
     QJsonObject doAudioCapture(const QString& action,
                                const QString& arg,
                                const QString& path) const;
@@ -410,6 +415,23 @@ private:
     QString m_agentStation;          // applied name (AETHER_AUTOMATION_STATION)
     QString m_priorStationName;      // user's real station name, captured to restore
     bool    m_stationApplied{false};
+
+#ifdef HAVE_WEBSOCKETS
+    // In-process TCI client simulator (`tci start|status|stop`, #3305/#4009).
+    // Connects to the app's own TCI server over loopback exactly like WSJT-X
+    // (init burst → ready → audio_samplerate + audio_start) so agents can
+    // exercise the TCI/DAX lifecycle — including abrupt-disconnect reaping —
+    // without an external WebSocket client.
+    QWebSocket* m_tciSim{nullptr};
+    bool    m_tciSimReady{false};
+    bool    m_tciSimAudioStarted{false};
+    qint64  m_tciSimBinaryFrames{0};
+    qint64  m_tciSimBinaryBytes{0};
+    qint64  m_tciSimTextMsgs{0};
+    qint64  m_tciSimLastFrameMs{-1};
+    QString m_tciSimCloseReason;
+    QElapsedTimer m_tciSimTimer;
+#endif
 
     // TX safety rails (active only when AETHER_AUTOMATION_ALLOW_TX is set).
     QTimer* m_txWatchdog{nullptr};

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1423,7 +1423,20 @@ void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
     }
     m_daxStreamIds[streamId] = channel;
     m_loggedDaxPacketStreams.remove(streamId);
+    // Ownership table (#3305): the create we requested has materialized (or a
+    // leftover stream from a previous arm was adopted). If nobody holds the
+    // channel, start the grace clock — an unheld stream is an orphan-in-waiting.
+    {
+        auto& st = m_daxChannelStates[channel];
+        st.streamId = streamId;
+        st.createPending = false;
+        st.generation = ++m_daxGenCounter;
+        if (st.holders == 0)
+            scheduleDaxRemovalLocked(channel);
+    }
     qCDebug(lcVita49) << "PanadapterStream: registered DAX stream" << Qt::hex << streamId << "-> channel" << channel;
+    lock.unlock();
+    emit daxStreamRegistered(channel, streamId);
 }
 
 quint32 PanadapterStream::daxStreamIdForChannel(int channel) const
@@ -1438,19 +1451,188 @@ quint32 PanadapterStream::daxStreamIdForChannel(int channel) const
 
 void PanadapterStream::unregisterDaxStream(quint32 streamId)
 {
-    QMutexLocker lock(&m_streamMutex);
-    m_daxStreamIds.remove(streamId);
-    m_loggedDaxPacketStreams.remove(streamId);
-    // DAX audio streams use the PLC path too; drop the per-stream PLC
-    // entry so it doesn't outlive the stream itself (#2738).
-    m_audioPlc.remove(streamId);
-    qCDebug(lcVita49) << "PanadapterStream: unregistered DAX stream" << Qt::hex << streamId;
+    int channel = 0;
+    {
+        QMutexLocker lock(&m_streamMutex);
+        m_daxStreamIds.remove(streamId);
+        m_loggedDaxPacketStreams.remove(streamId);
+        // DAX audio streams use the PLC path too; drop the per-stream PLC
+        // entry so it doesn't outlive the stream itself (#2738).
+        m_audioPlc.remove(streamId);
+        // Ownership table (#3305): if the radio tore the stream down while
+        // consumers still hold the channel (profile load / slice teardown),
+        // schedule a re-create. Our own removals erase the entry first, so
+        // this only fires for radio-initiated teardown.
+        for (auto it = m_daxChannelStates.begin(); it != m_daxChannelStates.end(); ++it) {
+            if (it->streamId == streamId) {
+                channel = it.key();
+                it->streamId = 0;
+                it->generation = ++m_daxGenCounter;
+                if (it->holders != 0)
+                    scheduleDaxRecreateLocked(it.key());
+                else
+                    m_daxChannelStates.erase(it);
+                break;
+            }
+        }
+        qCDebug(lcVita49) << "PanadapterStream: unregistered DAX stream" << Qt::hex << streamId;
+    }
+    if (channel)
+        emit daxStreamUnregistered(channel, streamId);
 }
 
 QList<quint32> PanadapterStream::daxStreamIds() const
 {
     QMutexLocker lock(&m_streamMutex);
     return m_daxStreamIds.keys();
+}
+
+// ---- Centralized DAX RX channel ownership (#3305) ----
+
+const char* PanadapterStream::daxConsumerName(DaxConsumer who)
+{
+    switch (who) {
+    case DaxConsumer::Bridge: return "bridge";
+    case DaxConsumer::Tci:    return "tci";
+    case DaxConsumer::Rade:   return "rade";
+    }
+    return "?";
+}
+
+static inline quint8 daxHolderBit(PanadapterStream::DaxConsumer who)
+{
+    return quint8(1u << quint8(who));
+}
+
+quint32 PanadapterStream::acquireDaxChannel(int channel, DaxConsumer who)
+{
+    if (channel < 1 || channel > 4) return 0;
+    bool needCreate = false;
+    quint32 streamId = 0;
+    {
+        QMutexLocker lock(&m_streamMutex);
+        auto& st = m_daxChannelStates[channel];
+        const quint8 bit = daxHolderBit(who);
+        const bool alreadyHeld = st.holders & bit;
+        st.holders |= bit;
+        // Any acquire invalidates a pending deferred removal.
+        st.generation = ++m_daxGenCounter;
+        if (st.streamId == 0 && !st.createPending) {
+            st.createPending = true;
+            needCreate = true;
+        }
+        streamId = st.streamId;
+        if (!alreadyHeld) {
+            qCInfo(lcVita49) << "PanadapterStream: DAX ch" << channel
+                             << "acquired by" << daxConsumerName(who)
+                             << "holders=0x" + QString::number(st.holders, 16)
+                             << (needCreate ? "(creating stream)" : "");
+        }
+    }
+    if (needCreate)
+        emit daxStreamCreateNeeded(channel);
+    return streamId;
+}
+
+void PanadapterStream::releaseDaxChannel(int channel, DaxConsumer who)
+{
+    if (channel < 1 || channel > 4) return;
+    QMutexLocker lock(&m_streamMutex);
+    auto it = m_daxChannelStates.find(channel);
+    if (it == m_daxChannelStates.end()) return;
+    const quint8 bit = daxHolderBit(who);
+    if (!(it->holders & bit)) return;
+    it->holders &= ~bit;
+    it->generation = ++m_daxGenCounter;
+    qCInfo(lcVita49) << "PanadapterStream: DAX ch" << channel
+                     << "released by" << daxConsumerName(who)
+                     << "holders=0x" + QString::number(it->holders, 16);
+    if (it->holders == 0)
+        scheduleDaxRemovalLocked(channel);
+}
+
+void PanadapterStream::releaseAllDaxChannels(DaxConsumer who)
+{
+    for (int ch = 1; ch <= 4; ++ch)
+        releaseDaxChannel(ch, who);
+}
+
+bool PanadapterStream::daxChannelHeldBy(int channel, DaxConsumer who) const
+{
+    QMutexLocker lock(&m_streamMutex);
+    auto it = m_daxChannelStates.constFind(channel);
+    return it != m_daxChannelStates.constEnd() && (it->holders & daxHolderBit(who));
+}
+
+void PanadapterStream::resetDaxChannelsForDisconnect()
+{
+    QMutexLocker lock(&m_streamMutex);
+    // Radio reaps every stream of a disconnected client itself
+    // (state-machines.md §4.2) — no removal commands, just forget. Bump every
+    // generation via the counter so in-flight deferred lambdas expire.
+    ++m_daxGenCounter;
+    m_daxChannelStates.clear();
+    qCDebug(lcVita49) << "PanadapterStream: DAX channel ownership reset for disconnect";
+}
+
+// m_streamMutex held. Last holder left: remove the radio-side stream after a
+// grace window. The window absorbs the radio's transient unbind/rebind
+// dax=0/dax=<ch> status pairs (#3626) — a re-acquire inside the window bumps
+// the generation and the removal quietly expires.
+void PanadapterStream::scheduleDaxRemovalLocked(int channel)
+{
+    auto it = m_daxChannelStates.find(channel);
+    if (it == m_daxChannelStates.end()) return;
+    const quint32 gen = it->generation;
+    QTimer::singleShot(kDaxRemovalGraceMs, this, [this, channel, gen]() {
+        quint32 removeId = 0;
+        {
+            QMutexLocker lock(&m_streamMutex);
+            auto it = m_daxChannelStates.find(channel);
+            if (it == m_daxChannelStates.end()) return;
+            if (it->generation != gen) return;      // state changed — expired
+            if (it->holders != 0) return;           // re-acquired
+            removeId = it->streamId;
+            m_daxChannelStates.erase(it);
+        }
+        if (removeId) {
+            qCInfo(lcVita49) << "PanadapterStream: DAX ch" << channel
+                             << "unheld past grace — removing stream"
+                             << Qt::hex << removeId << "(#3305)";
+            unregisterDaxStream(removeId);   // entry already erased: no recreate
+            emit daxStreamUnregistered(channel, removeId);
+            emit daxStreamRemoveNeeded(removeId, channel);
+        }
+    });
+}
+
+// m_streamMutex held. The radio destroyed a stream we still hold (profile
+// load / slice teardown replaces dax_rx streams without a TCI/bridge
+// disconnect — the #3476 "switched profile, never came back" failure).
+// Re-create after a short backoff so a genuine teardown storm can't turn
+// into a create storm.
+void PanadapterStream::scheduleDaxRecreateLocked(int channel)
+{
+    auto it = m_daxChannelStates.find(channel);
+    if (it == m_daxChannelStates.end()) return;
+    const quint32 gen = it->generation;
+    QTimer::singleShot(kDaxRecreateDelayMs, this, [this, channel, gen]() {
+        bool needCreate = false;
+        {
+            QMutexLocker lock(&m_streamMutex);
+            auto it = m_daxChannelStates.find(channel);
+            if (it == m_daxChannelStates.end()) return;
+            if (it->generation != gen) return;
+            if (it->holders == 0 || it->streamId != 0 || it->createPending) return;
+            it->createPending = true;
+            needCreate = true;
+        }
+        if (needCreate) {
+            qCInfo(lcVita49) << "PanadapterStream: DAX ch" << channel
+                             << "still held after radio-side removal — re-creating (#3476)";
+            emit daxStreamCreateNeeded(channel);
+        }
+    });
 }
 
 void PanadapterStream::registerIqStream(quint32 streamId, int channel)

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1435,8 +1435,6 @@ void PanadapterStream::registerDaxStream(quint32 streamId, int channel)
             scheduleDaxRemovalLocked(channel);
     }
     qCDebug(lcVita49) << "PanadapterStream: registered DAX stream" << Qt::hex << streamId << "-> channel" << channel;
-    lock.unlock();
-    emit daxStreamRegistered(channel, streamId);
 }
 
 quint32 PanadapterStream::daxStreamIdForChannel(int channel) const
@@ -1547,8 +1545,62 @@ void PanadapterStream::releaseDaxChannel(int channel, DaxConsumer who)
     qCInfo(lcVita49) << "PanadapterStream: DAX ch" << channel
                      << "released by" << daxConsumerName(who)
                      << "holders=0x" + QString::number(it->holders, 16);
-    if (it->holders == 0)
-        scheduleDaxRemovalLocked(channel);
+    if (it->holders == 0) {
+        if (it->streamId != 0) {
+            scheduleDaxRemovalLocked(channel);
+        } else if (!it->createPending) {
+            m_daxChannelStates.erase(it);
+        }
+        // else: a create is in flight for a channel nobody wants anymore.
+        // Keep the entry so registerDaxStream() finds it when the status
+        // lands, sees holders==0, and schedules ONE deterministic removal —
+        // erasing here would make the registration re-insert a fresh entry
+        // and bounce through create→remove churn (review #4017 item 3).
+    }
+}
+
+void PanadapterStream::notifyDaxCreateFailed(int channel)
+{
+    if (channel < 1 || channel > 4) return;
+    bool retryArmed = false;
+    {
+        QMutexLocker lock(&m_streamMutex);
+        auto it = m_daxChannelStates.find(channel);
+        if (it == m_daxChannelStates.end() || it->streamId != 0) return;
+        it->createPending = false;
+        it->generation = ++m_daxGenCounter;
+        if (it->holders == 0) {
+            m_daxChannelStates.erase(it);
+        } else {
+            // Still wanted: retry on a gentle cadence. Each cycle re-enters
+            // this method on failure, so a persistent condition (DAX slots
+            // exhausted on the radio) costs one command per kDaxCreateRetryMs
+            // — and heals the moment a slot frees or the connection is up.
+            const quint32 gen = it->generation;
+            QTimer::singleShot(kDaxCreateRetryMs, this, [this, channel, gen]() {
+                bool needCreate = false;
+                {
+                    QMutexLocker lock(&m_streamMutex);
+                    auto it = m_daxChannelStates.find(channel);
+                    if (it == m_daxChannelStates.end()) return;
+                    if (it->generation != gen) return;
+                    if (it->holders == 0 || it->streamId != 0 || it->createPending) return;
+                    it->createPending = true;
+                    it->generation = ++m_daxGenCounter;
+                    needCreate = true;
+                }
+                if (needCreate) {
+                    qCInfo(lcVita49) << "PanadapterStream: retrying DAX ch" << channel
+                                     << "stream create after failure (#3305)";
+                    emit daxStreamCreateNeeded(channel);
+                }
+            });
+            retryArmed = true;
+        }
+    }
+    qCWarning(lcVita49) << "PanadapterStream: DAX ch" << channel
+                        << "stream create failed/dropped —"
+                        << (retryArmed ? "retry armed" : "channel unheld, entry dropped");
 }
 
 void PanadapterStream::releaseAllDaxChannels(DaxConsumer who)
@@ -1648,6 +1700,7 @@ void PanadapterStream::scheduleDaxRecreateLocked(int channel)
             if (it->generation != gen) return;
             if (it->holders == 0 || it->streamId != 0 || it->createPending) return;
             it->createPending = true;
+            it->generation = ++m_daxGenCounter;  // keep the mutation⇒generation-bump invariant
             needCreate = true;
         }
         if (needCreate) {

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1564,6 +1564,29 @@ bool PanadapterStream::daxChannelHeldBy(int channel, DaxConsumer who) const
     return it != m_daxChannelStates.constEnd() && (it->holders & daxHolderBit(who));
 }
 
+QVector<PanadapterStream::DaxChannelSnapshot> PanadapterStream::daxChannelSnapshot() const
+{
+    QMutexLocker lock(&m_streamMutex);
+    QVector<DaxChannelSnapshot> out;
+    out.reserve(m_daxChannelStates.size());
+    for (auto it = m_daxChannelStates.constBegin(); it != m_daxChannelStates.constEnd(); ++it) {
+        DaxChannelSnapshot s;
+        s.channel = it.key();
+        s.streamId = it->streamId;
+        s.createPending = it->createPending;
+        for (DaxConsumer who : {DaxConsumer::Bridge, DaxConsumer::Tci, DaxConsumer::Rade}) {
+            if (it->holders & daxHolderBit(who))
+                s.holders << QString::fromLatin1(daxConsumerName(who));
+        }
+        out.append(s);
+    }
+    std::sort(out.begin(), out.end(),
+              [](const DaxChannelSnapshot& a, const DaxChannelSnapshot& b) {
+        return a.channel < b.channel;
+    });
+    return out;
+}
+
 void PanadapterStream::resetDaxChannelsForDisconnect()
 {
     QMutexLocker lock(&m_streamMutex);

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -112,6 +112,46 @@ public:
     QList<quint32> daxStreamIds() const;
     quint32 daxStreamIdForChannel(int channel) const;
 
+    // ---- Centralized DAX RX channel ownership (#3305) ----
+    //
+    // Every in-process consumer of a dax_rx channel (the virtual-audio bridge,
+    // TCI, RADE) acquires/releases the channel here instead of tracking stream
+    // ids and peeking at each other's state. PanadapterStream keeps the
+    // channel → (streamId, holders) table and is the ONLY place that decides
+    // when a radio-side stream must exist:
+    //
+    //   acquire, first holder  → emit daxStreamCreateNeeded(ch)
+    //   release, last holder   → deferred (grace + revalidate) →
+    //                            emit daxStreamRemoveNeeded(id, ch)
+    //   radio removed a stream we still hold (profile load, slice teardown)
+    //                           → deferred → re-emit daxStreamCreateNeeded(ch)
+    //
+    // The actual `stream create` / `stream remove` commands are sent by
+    // RadioModel (the command plane), wired to these signals. Decisions are
+    // NEVER made on status-echo edges (the #4009 storm class): acquire/release
+    // are idempotent per holder, and the grace window absorbs the radio's
+    // transient unbind/rebind dax=0/dax=<ch> pairs (#3626) — see
+    // docs/architecture/flex-protocol/state-machines.md §7.
+    enum class DaxConsumer : quint8 {
+        Bridge = 0,   // DAX virtual-audio bridge (macOS CoreAudio / PipeWire)
+        Tci    = 1,   // TCI server audio clients (WSJT-X etc.)
+        Rade   = 2,   // RADE digital-voice engine
+    };
+    static const char* daxConsumerName(DaxConsumer who);
+
+    // Add `who` as a holder of `channel` (1-4). Requests stream creation when
+    // the channel gains its first holder. Idempotent per holder. Returns the
+    // channel's current stream id (0 while creation is in flight).
+    quint32 acquireDaxChannel(int channel, DaxConsumer who);
+    // Drop `who` as a holder. When the last holder leaves, stream removal is
+    // requested after a grace window (cancelled by a re-acquire).
+    void releaseDaxChannel(int channel, DaxConsumer who);
+    void releaseAllDaxChannels(DaxConsumer who);
+    bool daxChannelHeldBy(int channel, DaxConsumer who) const;
+    // Drop the whole table without emitting removals — the radio reaps all of
+    // a client's streams itself on TCP disconnect (state-machines.md §4.2).
+    void resetDaxChannelsForDisconnect();
+
     // DAX IQ stream routing
     void registerIqStream(quint32 streamId, int channel);
     void unregisterIqStream(quint32 streamId);
@@ -138,6 +178,15 @@ public:
     int grantedReceiveBufferBytes() const { return m_grantedRcvBufBytes.load(); }
 
 signals:
+    // Centralized DAX ownership (#3305): command-plane requests, connected to
+    // RadioModel which sends `stream create type=dax_rx dax_channel=<ch>` /
+    // `stream remove 0x<id>` (plus the one-shot #1439 re-assert on create).
+    void daxStreamCreateNeeded(int channel);
+    void daxStreamRemoveNeeded(quint32 streamId, int channel);
+    // Observability for consumers (e.g. TCI invalidates its channel→trx cache).
+    void daxStreamRegistered(int channel, quint32 streamId);
+    void daxStreamUnregistered(int channel, quint32 streamId);
+
     void daxAudioReady(int channel, const QByteArray& pcm);
     void iqDataReady(int channel, const QByteArray& rawPayload, int sampleRate);
     void spectrumReady(quint32 streamId, const QVector<float>& binsDbm, qint64 emittedNs);
@@ -352,6 +401,22 @@ private:
 
     // DAX stream routing: stream ID → DAX channel (1-4)
     QMap<quint32, int> m_daxStreamIds;
+    // Centralized DAX RX channel ownership (#3305), guarded by m_streamMutex.
+    // `generation` invalidates in-flight deferred removal/recreate lambdas
+    // whenever the channel's state changes (re-acquire cancels a pending
+    // removal; disconnect reset cancels everything).
+    struct DaxChannelState {
+        quint32 streamId{0};
+        bool    createPending{false};
+        quint8  holders{0};       // bitmask of DaxConsumer
+        quint32 generation{0};
+    };
+    QHash<int, DaxChannelState> m_daxChannelStates;
+    quint32 m_daxGenCounter{0};   // monotonic; entries never reuse a generation
+    static constexpr int kDaxRemovalGraceMs  = 1500;  // ≫ the ~80 ms transient rebroadcast cycle (#3626)
+    static constexpr int kDaxRecreateDelayMs = 500;   // radio-removed-but-still-held re-create backoff (#3476)
+    void scheduleDaxRemovalLocked(int channel);       // call with m_streamMutex held
+    void scheduleDaxRecreateLocked(int channel);      // call with m_streamMutex held
     // DAX IQ stream routing: stream ID → IQ channel (1-4)
     QMap<quint32, int> m_iqStreamIds;
     QSet<quint32> m_loggedDaxPacketStreams;

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -143,6 +143,12 @@ public:
     // the channel gains its first holder. Idempotent per holder. Returns the
     // channel's current stream id (0 while creation is in flight).
     quint32 acquireDaxChannel(int channel, DaxConsumer who);
+    // Command plane reports a failed/dropped `stream create` (radio error
+    // reply, or emitted while disconnected). Clears the create latch and — if
+    // the channel is still held — arms a deferred retry, so a transient
+    // failure (DAX slots busy, connect-gap drop) cannot wedge the channel
+    // with `createPending` stuck true (the #3669 wedge class).
+    void notifyDaxCreateFailed(int channel);
     // Drop `who` as a holder. When the last holder leaves, stream removal is
     // requested after a grace window (cancelled by a re-acquire).
     void releaseDaxChannel(int channel, DaxConsumer who);
@@ -190,10 +196,11 @@ signals:
     // Centralized DAX ownership (#3305): command-plane requests, connected to
     // RadioModel which sends `stream create type=dax_rx dax_channel=<ch>` /
     // `stream remove 0x<id>` (plus the one-shot #1439 re-assert on create).
+    // RadioModel reports create failures back via notifyDaxCreateFailed().
     void daxStreamCreateNeeded(int channel);
     void daxStreamRemoveNeeded(quint32 streamId, int channel);
-    // Observability for consumers (e.g. TCI invalidates its channel→trx cache).
-    void daxStreamRegistered(int channel, quint32 streamId);
+    // A channel's radio-side stream went away (our removal or radio-initiated).
+    // TCI uses this to invalidate its channel→trx routing cache.
     void daxStreamUnregistered(int channel, quint32 streamId);
 
     void daxAudioReady(int channel, const QByteArray& pcm);
@@ -424,6 +431,7 @@ private:
     quint32 m_daxGenCounter{0};   // monotonic; entries never reuse a generation
     static constexpr int kDaxRemovalGraceMs  = 1500;  // ≫ the ~80 ms transient rebroadcast cycle (#3626)
     static constexpr int kDaxRecreateDelayMs = 500;   // radio-removed-but-still-held re-create backoff (#3476)
+    static constexpr int kDaxCreateRetryMs   = 2000;  // failed-create retry cadence while the channel stays held
     void scheduleDaxRemovalLocked(int channel);       // call with m_streamMutex held
     void scheduleDaxRecreateLocked(int channel);      // call with m_streamMutex held
     // DAX IQ stream routing: stream ID → IQ channel (1-4)

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -151,6 +151,15 @@ public:
     // Drop the whole table without emitting removals — the radio reaps all of
     // a client's streams itself on TCP disconnect (state-machines.md §4.2).
     void resetDaxChannelsForDisconnect();
+    // Read-only snapshot of the ownership table for diagnostics and the
+    // automation bridge (`get dax`). Safe from any thread.
+    struct DaxChannelSnapshot {
+        int         channel{0};
+        quint32     streamId{0};
+        bool        createPending{false};
+        QStringList holders;   // daxConsumerName() strings
+    };
+    QVector<DaxChannelSnapshot> daxChannelSnapshot() const;
 
     // DAX IQ stream routing
     void registerIqStream(quint32 streamId, int channel);

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -129,61 +129,17 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
     // Capture DAX RX stream creation responses so we can register them
     // in PanadapterStream for VITA-49 routing (#1331).
     if (m_model) {
-        connect(m_model, &RadioModel::statusReceived,
-                this, [this](const QString& obj, const QMap<QString,QString>& kvs) {
-            if (!obj.startsWith("stream ")) return;
-            const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-            if (parts.size() < 2) return;
-            bool ok = false;
-            quint32 streamId = parts[1].toUInt(&ok, 0);
-            if (!ok || streamId == 0) return;
-            const bool removed = parts.contains(QStringLiteral("removed")) || kvs.contains(QStringLiteral("removed"));
-            if (removed) {
-                for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
-                    if (it.value() == streamId) {
-                        qCInfo(lcCat) << "TCI: radio removed DAX RX stream" << Qt::hex << streamId
-                                      << "for channel" << it.key()
-                                      << "— clearing cache entry so re-arm recreates it (#3476)";
-                        // Erase (not zero) the entry. Leaving a key behind keeps
-                        // ensureDaxForTci()'s `contains(ch)` guard true, so after a
-                        // profile load / slice teardown — which destroys the radio's
-                        // dax_rx stream without a TCI disconnect — the sliceAdded
-                        // re-arm skips `stream create` and TCI RX stays silent until
-                        // a full reconnect. That is the #3476/#3364 "switched profile,
-                        // never came back" failure. Pending creates (value 0) are
-                        // never matched here (streamId != 0), so an in-flight request
-                        // is safe.
-                        m_tciDaxBorrowedChannels.remove(it.key());
-                        m_tciDaxStreamIds.erase(it);
-                        break;
-                    }
-                }
-                if (m_model->panStream())
-                    m_model->panStream()->unregisterDaxStream(streamId);
-                return;
-            }
-            if (kvs.value("type") != "dax_rx") return;
-            if (!streamStatusBelongsToUs(kvs, m_model->ourClientHandle())) {
-                qCDebug(lcCat) << "TCI: ignoring DAX RX stream for another client"
-                               << "stream=0x" + QString::number(streamId, 16)
-                               << "owner=" << kvs.value("client_handle");
-                return;
-            }
-            int ch = kvs.value("dax_channel").toInt();
-            if (!streamId || ch < 1 || ch > 4) return;
-            // Only register if this channel is one we requested (placeholder = 0)
-            if (!m_tciDaxStreamIds.contains(ch)) return;
-            if (m_tciDaxStreamIds[ch] != 0) return; // already registered
-            m_tciDaxStreamIds[ch] = streamId;
-            if (m_model->panStream()) {
-                m_model->panStream()->registerDaxStream(streamId, ch);
-                qCDebug(lcCat) << "TCI: registered DAX RX stream"
-                               << "0x" + QString::number(streamId, 16)
-                               << "for channel" << ch;
-                qCInfo(lcCat) << "TCI: registered DAX RX stream" << Qt::hex << streamId
-                              << "for channel" << ch << "(#1331)";
-            }
-        });
+        // Stream registration + radio-side-removal recovery now live in the
+        // centralized DAX channel manager (RadioModel::handleDaxRxStreamRegistry
+        // + PanadapterStream refcounting, #3305). The #3476 "profile load
+        // destroyed the stream, never came back" recreate is automatic there.
+        // TCI only keeps its channel→trx routing cache truthful (#3669/#3766).
+        if (m_model->panStream()) {
+            connect(m_model->panStream(), &PanadapterStream::daxStreamUnregistered,
+                    this, [this](int ch, quint32) {
+                m_channelTrx.remove(ch);
+            });
+        }
 
         // Re-trigger DAX setup when the radio (re)connects or a slice
         // is added AFTER a TCI client has already requested audio.  Without
@@ -198,33 +154,16 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         connect(m_model, &RadioModel::connectionStateChanged,
                 this, [this](bool connected) {
             if (!connected) {
-                // Radio dropped: our DAX RX streams are dead server-side, but
-                // an unexpected disconnect sends no `stream … removed` status,
-                // so m_tciDaxStreamIds keeps stale IDs. Without clearing them,
-                // ensureDaxForTci() on reconnect hits its `contains(ch)` guard
-                // and skips `stream create`, leaving WSJT-X RX silent — the
-                // very symptom #3270 targets. Unregister the streams we own
-                // (skip borrowed — the DAX bridge owns those and tears them
-                // down itself) and reset so the reconnect re-arm starts clean.
-                // (#3270)
-                if (m_model->panStream()) {
-                    for (auto it = m_tciDaxStreamIds.cbegin();
-                         it != m_tciDaxStreamIds.cend(); ++it) {
-                        if (it.value() != 0
-                                && !m_tciDaxBorrowedChannels.contains(it.key())) {
-                            m_model->panStream()->unregisterDaxStream(it.value());
-                        }
-                    }
-                }
-                m_tciDaxStreamIds.clear();
-                m_tciDaxBorrowedChannels.clear();
-                m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3766)
-                // Also drop the slice-assignment bookkeeping: slices are being
-                // destroyed with the connection, and a releaseDaxForTci() that
-                // runs later (e.g. the debounced grace timer firing after a
-                // quick radio reconnect) must not setDaxChannel(0) on the
-                // RECREATED slices — that would strip a profile-restored DAX
-                // assignment from a slice we no longer manage.
+                // Radio dropped: RadioModel resets the DAX channel manager
+                // (the radio reaps our streams server-side, #3305). Drop the
+                // routing cache and the slice-assignment bookkeeping: slices
+                // are being destroyed with the connection, and a
+                // releaseDaxForTci() that runs later (e.g. the debounced grace
+                // timer firing after a quick radio reconnect) must not
+                // setDaxChannel(0) on the RECREATED slices — that would strip
+                // a profile-restored DAX assignment from a slice we no longer
+                // manage.
+                m_channelTrx.clear();
                 m_tciDaxSlices.clear();
                 return;
             }
@@ -2001,44 +1940,21 @@ void TciServer::ensureDaxForTci()
         }
     }
 
-    // Create DAX RX streams for channels that need them.  If an existing stream
-    // is already registered in PanadapterStream (e.g. created by DaxBridge or
-    // left over from a previous session), reuse it rather than stacking a
-    // second subscription — duplicate streams cause daxAudioReady to fire
-    // twice per period, doubling the apparent audio speed at the TCI client.
-    for (int ch : channelsNeeded) {
-        if (m_tciDaxStreamIds.contains(ch)) continue; // already have/pending
-        quint32 existingId = m_model->panStream()
-                           ? m_model->panStream()->daxStreamIdForChannel(ch)
-                           : 0;
-        if (existingId != 0) {
-            m_tciDaxStreamIds[ch] = existingId;
-            m_tciDaxBorrowedChannels.insert(ch);
-            qCDebug(lcCat) << "TCI: reusing existing DAX RX stream"
-                           << "0x" + QString::number(existingId, 16)
-                           << "for channel" << ch;
-            qCInfo(lcCat) << "TCI: reusing existing DAX RX stream" << Qt::hex << existingId
-                          << "for channel" << ch << "(#1331)";
-        } else {
-            m_tciDaxStreamIds[ch] = 0;
-            m_model->sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
-            qCDebug(lcCat) << "TCI: creating DAX RX stream for channel" << ch;
-            qCInfo(lcCat) << "TCI: creating DAX RX stream for channel" << ch << "(#1331)";
-        }
-    }
-
-    // Re-assert slice → DAX channel mapping so the radio registers our
-    // stream as a client.  Without this, dax_clients stays 0 and the
-    // radio sends silence instead of demodulated audio. (#1439)
-    for (auto* s : m_model->slices()) {
-        int ch = s->daxChannel();
-        if (ch > 0 && channelsNeeded.contains(ch)) {
-            m_model->sendCommand(QString("slice set %1 dax=%2")
-                .arg(s->sliceId()).arg(ch));
-            qCDebug(lcCat) << "TCI: re-asserting DAX channel" << ch
-                           << "on slice" << s->sliceId();
-            qCInfo(lcCat) << "TCI: re-asserting dax=" << ch
-                          << "on slice" << s->sliceId();
+    // Acquire the needed channels from the centralized manager (#3305). It
+    // creates the radio-side stream only when the channel gains its FIRST
+    // holder — never a duplicate subscription (duplicate streams made
+    // daxAudioReady fire twice per period, doubling apparent audio speed) —
+    // and reuses anything the DAX bridge or a previous arm already created.
+    // Acquire is idempotent, so re-arm paths can call this freely.
+    //
+    // The #1439 dax_clients re-assert is a one-shot in RadioModel tied to the
+    // actual `stream create`. The unconditional re-assert that used to live
+    // here re-asserted LIVE bindings, which the radio answers with a transient
+    // unbind/rebind dax=0/dax=<ch> pair — the seed of the #4009 storm.
+    if (m_model->panStream()) {
+        for (int ch : channelsNeeded) {
+            m_model->panStream()->acquireDaxChannel(
+                ch, PanadapterStream::DaxConsumer::Tci);
         }
     }
 }
@@ -2052,8 +1968,8 @@ void TciServer::scheduleDaxRelease()
     // permanent silence (#3363 / #3476 / Tune-ATU). Defer it; a reconnecting
     // client that re-arms audio cancels the timer (cancelDaxRelease()), so the
     // stream survives and audio resumes with no recreate. If the radio actually
-    // destroyed the streams meanwhile (profile slice recreate), the reactive
-    // "stream removed" handler keeps m_tciDaxStreamIds truthful regardless.
+    // destroyed the streams meanwhile (profile slice recreate), the centralized
+    // manager's removed-status recovery re-creates them (#3305).
     if (!m_daxReleaseTimer) { releaseDaxForTci(); return; }
     qCWarning(lcCat) << "TCI: last audio client gone — deferring DAX RX release"
                      << kDaxReleaseGraceMs << "ms (cancelled if a client reconnects)";
@@ -2085,19 +2001,11 @@ void TciServer::rearmDaxForProfileLoad()
         return;
     }
 
-    if (m_model->panStream()) {
-        for (auto it = m_tciDaxStreamIds.cbegin(); it != m_tciDaxStreamIds.cend(); ++it) {
-            if (it.value() != 0 && !m_tciDaxBorrowedChannels.contains(it.key())) {
-                m_model->sendCommand(QString("stream remove 0x%1")
-                    .arg(it.value(), 8, 16, QChar('0')));
-                m_model->panStream()->unregisterDaxStream(it.value());
-            }
-        }
-    }
-
-    m_tciDaxStreamIds.clear();
-    m_tciDaxBorrowedChannels.clear();
-    m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3669)
+    // Streams the profile load destroyed radio-side are re-created
+    // automatically by the DAX channel manager's removed-status recovery
+    // (#3305/#3476); we only need to refresh the routing cache and re-run the
+    // slice policy (idempotent acquires).
+    m_channelTrx.clear();   // routing cache stale across a profile load (#3669)
     m_tciDaxSlices.clear();
 
     qCInfo(lcCat) << "TCI: profile load completed - re-arming DAX for active audio client";
@@ -2111,32 +2019,19 @@ void TciServer::releaseDaxForTci()
     // DIAG (qCWarning so it survives default log levels): this is the path that
     // silences WSJT-X RX on a client disconnect / audio_stop. It ran invisibly
     // in the 26.6.2 repro because qCInfo(lcCat) is suppressed below warning.
-    qCWarning(lcCat) << "TCI: releaseDaxForTci() tearing down DAX RX —"
-                     << m_tciDaxStreamIds.size() << "stream(s),"
+    qCWarning(lcCat) << "TCI: releaseDaxForTci() releasing DAX RX —"
                      << m_tciDaxSlices.size() << "slice assignment(s);"
                      << "RX audio stops until the next audio_start re-arms it";
 
-    // Remove DAX RX streams we created (skip borrowed streams — owned by DaxBridge
-    // or pre-existing; removing them would break other audio consumers).
-    for (auto it = m_tciDaxStreamIds.begin(); it != m_tciDaxStreamIds.end(); ++it) {
-        int ch = it.key();
-        quint32 streamId = it.value();
-        if (m_tciDaxBorrowedChannels.contains(ch)) continue;
-        if (streamId != 0) {
-            if (m_model->panStream()) {
-                m_model->panStream()->unregisterDaxStream(streamId);
-            }
-            if (m_model->isConnected()) {
-                m_model->sendCommand(QString("stream remove 0x%1")
-                    .arg(streamId, 8, 16, QChar('0')));
-            }
-            qCWarning(lcCat) << "TCI: removed DAX RX stream" << Qt::hex << streamId
-                             << "channel" << ch << "(#1331)";
-        }
+    // Release TCI's hold on every channel. The centralized manager removes a
+    // radio-side stream only when the LAST holder releases (after a grace
+    // window), so a channel the DAX bridge or RADE still uses survives — the
+    // old "skip borrowed" bookkeeping, enforced structurally (#3305).
+    if (m_model->panStream()) {
+        m_model->panStream()->releaseAllDaxChannels(
+            PanadapterStream::DaxConsumer::Tci);
     }
-    m_tciDaxStreamIds.clear();
-    m_tciDaxBorrowedChannels.clear();
-    m_channelTrx.clear();   // routing cache stale once the channel→stream map is torn down (#3669)
+    m_channelTrx.clear();   // routing cache stale once the channel holds are dropped (#3669)
 
     // Release DAX channel assignments we made
     for (int sliceId : m_tciDaxSlices) {

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -187,6 +187,32 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 }
             }
         });
+        // A removed slice never fires daxChannelChanged, so without this the
+        // Tci hold on its channel stays set forever and the dax_rx stream
+        // lingers until the TCI client disconnects (pre-existing orphan,
+        // closed alongside #3305 per PR #4017 review item 4). Release any
+        // Tci-held channel that no remaining slice carries; the sliceAdded
+        // re-arm above re-acquires when a replacement slice appears.
+        connect(m_model, &RadioModel::sliceRemoved,
+                this, [this](int sliceId) {
+            m_tciDaxSlices.remove(sliceId);
+            auto* ps = m_model ? m_model->panStream() : nullptr;
+            if (!ps) return;
+            for (int ch = 1; ch <= 4; ++ch) {
+                if (!ps->daxChannelHeldBy(ch, PanadapterStream::DaxConsumer::Tci))
+                    continue;
+                bool stillWanted = false;
+                for (auto* s : m_model->slices()) {
+                    if (s && s->daxChannel() == ch) { stillWanted = true; break; }
+                }
+                if (!stillWanted) {
+                    qCInfo(lcCat) << "TCI: releasing DAX channel" << ch
+                                  << "after slice" << sliceId << "removal (#3305)";
+                    ps->releaseDaxChannel(ch, PanadapterStream::DaxConsumer::Tci);
+                    m_channelTrx.remove(ch);
+                }
+            }
+        });
     }
 
     // Periodic status broadcast (200ms — S-meter, TX sensors, TX state)

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -55,12 +55,9 @@ public:
     quint16 port() const;
     int clientCount() const { return m_clients.size(); }
 
-    // True if TCI currently owns or borrows a DAX RX stream on this channel
-    // (created or reused for an active audio client). Other DAX consumers —
-    // notably the DAX virtual-audio bridge — must consult this before removing
-    // a stream on the shared PanadapterStream map, so they don't silence a
-    // channel WSJT-X is decoding on (the mirror image of #3270). (#2895)
-    bool ownsDaxChannel(int channel) const { return m_tciDaxStreamIds.contains(channel); }
+    // (ownsDaxChannel() and the cross-consumer peeking it existed for were
+    // replaced by per-consumer holds in PanadapterStream's centralized DAX
+    // channel manager — see acquireDaxChannel/releaseDaxChannel. #3305)
 
     // Snapshot of all currently connected clients (endpoint + subscriptions).
     // Cheap to call; intended for the Radio Setup → TCI tab on demand and
@@ -209,8 +206,6 @@ private:
     QWebSocketServer* m_server{nullptr};
     QList<ClientState> m_clients;
     QSet<int>         m_tciDaxSlices;   // slice IDs where we auto-assigned DAX (#1331)
-    QMap<int, quint32> m_tciDaxStreamIds;      // DAX channel → stream ID created or borrowed by TCI
-    QSet<int>          m_tciDaxBorrowedChannels; // channels where TCI reused an existing stream
     QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
     QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
     QTimer*           m_daxReleaseTimer{nullptr}; // debounced DAX RX teardown

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1227,6 +1227,7 @@ private:
     int  m_radeSliceId{-1};
     bool m_radePrevMute{false};
     int m_radeDaxChannel{0};  // DAX channel RADE holds via PanadapterStream (#3305)
+    QMetaObject::Connection m_radeDaxReconcileConn;  // RADE slice dax= change → move the Rade hold
     QMetaObject::Connection m_freedvMoxConn;
     QMetaObject::Connection m_radeMoxFallbackConn;
     QString m_lastRadeRxCallsign;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1226,8 +1226,7 @@ private:
     QThread*    m_radeThread{nullptr};
     int  m_radeSliceId{-1};
     bool m_radePrevMute{false};
-    quint32 m_radeDaxStreamId{0};
-    QMetaObject::Connection m_radeDaxStreamConn;
+    int m_radeDaxChannel{0};  // DAX channel RADE holds via PanadapterStream (#3305)
     QMetaObject::Connection m_freedvMoxConn;
     QMetaObject::Connection m_radeMoxFallbackConn;
     QString m_lastRadeRxCallsign;
@@ -1287,12 +1286,8 @@ private:
     // up so the radio registers a DAX client for slices 1-3, not just slice 0.
     void wireDaxSlice(SliceModel* slice);
     void onDaxChannelChanged(SliceModel* slice, int newCh);
-    // #3626: defer + re-validate DAX RX stream teardown so a radio's transient
-    // dax=0 rebroadcast can't drive a create/remove storm. See the .cpp comment.
-    void scheduleDaxRxStreamRemoval(int ch);
     QList<QMetaObject::Connection> m_daxSliceConns;
     QHash<int, int> m_daxSliceLastCh;  // sliceId -> last-known DAX channel
-    QSet<int>       m_daxPendingRxRemoval;  // channels with a deferred teardown in flight (#3626)
 #endif
 };
 

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -418,35 +418,18 @@ void MainWindow::activateRADE(int sliceId)
     connect(m_radeEngine, &RADEEngine::rxSpeechReady,
             m_audio, &AudioEngine::feedDecodedSpeech, Qt::QueuedConnection);
 
-    // If TCI or another path already registered a stream — RADE rides it.
+    // Hold the RADE slice's DAX channel via the centralized manager (#3305).
+    // It creates the radio-side stream only if no other consumer (TCI, the
+    // DAX bridge) already holds the channel; registration comes from
+    // RadioModel's central status path — RADE's old private registration hook
+    // had no client_handle filter and could adopt a foreign client's stream.
     {
         SliceModel* radeSlice = m_radioModel.slice(sliceId);
         int daxCh = radeSlice ? radeSlice->daxChannel() : 0;
         if (daxCh >= 1 && daxCh <= 4) {
-            quint32 existing = m_radioModel.panStream()->daxStreamIdForChannel(daxCh);
-            if (existing) {
-                // TCI or another path already registered a stream — RADE rides it.
-                qCDebug(lcRade) << "MainWindow: RADE reusing existing dax_rx ch" << daxCh
-                                << "stream" << Qt::hex << existing;
-            } else {
-                m_radeDaxStreamConn = connect(
-                    &m_radioModel, &RadioModel::statusReceived,
-                    this, [this, daxCh](const QString& obj, const QMap<QString,QString>& kvs) {
-                        if (!obj.startsWith("stream ")) return;
-                        if (kvs.value("type") != "dax_rx") return;
-                        quint32 streamId = obj.mid(7).toUInt(nullptr, 16);
-                        int ch = kvs.value("dax_channel").toInt();
-                        if (streamId && ch == daxCh) {
-                            m_radioModel.panStream()->registerDaxStream(streamId, ch);
-                            m_radeDaxStreamId = streamId;
-                            disconnect(m_radeDaxStreamConn);
-                            qCDebug(lcRade) << "MainWindow: RADE registered dax_rx ch" << ch
-                                            << "stream" << Qt::hex << streamId;
-                        }
-                    });
-                m_radioModel.sendCommand(
-                    QString("stream create type=dax_rx dax_channel=%1").arg(daxCh));
-            }
+            m_radeDaxChannel = daxCh;
+            m_radioModel.panStream()->acquireDaxChannel(
+                daxCh, PanadapterStream::DaxConsumer::Rade);
         } else {
             qWarning() << "MainWindow: RADE slice" << sliceId
                        << "has no DAX channel assigned — RX audio will not flow";
@@ -583,28 +566,15 @@ void MainWindow::deactivateRADE()
                    this, nullptr);
         disconnect(m_radeEngine, &RADEEngine::eooCallsignReceived,
                    this, nullptr);
-        if (m_radeDaxStreamId) {
-            // Only send stream remove if TCI has no active clients. If TCI is
-            // connected it may have borrowed this stream — removing it would
-            // silently kill TCI audio. Leave TCI responsible for cleanup in
-            // that case. TODO: replace with proper ref-counting in PanadapterStream
-            // so any creator/borrower can safely release independently (#stream-lifecycle).
-            bool tciActive = tciServer() && tciServer()->clientCount() > 0;
-            bool daxBridgeActive = false;
-#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
-            daxBridgeActive = (m_daxBridge != nullptr);
-#endif
-            if (!tciActive && !daxBridgeActive) {
-                m_radioModel.panStream()->unregisterDaxStream(m_radeDaxStreamId);
-                if (m_radioModel.isConnected()) {
-                    m_radioModel.sendCommand(
-                        QString("stream remove 0x%1")
-                            .arg(m_radeDaxStreamId, 8, 16, QChar('0')));
-                }
-            }
-            m_radeDaxStreamId = 0;
+        if (m_radeDaxChannel >= 1 && m_radeDaxChannel <= 4) {
+            // Release RADE's hold; the centralized manager removes the
+            // radio-side stream only when the LAST holder (TCI / DAX bridge /
+            // RADE) releases — the ref-counting the old TODO here asked for
+            // (#3305).
+            m_radioModel.panStream()->releaseDaxChannel(
+                m_radeDaxChannel, PanadapterStream::DaxConsumer::Rade);
+            m_radeDaxChannel = 0;
         }
-        disconnect(m_radeDaxStreamConn);
         // Stop on the worker thread, then shut down the thread
         QMetaObject::invokeMethod(m_radeEngine, &RADEEngine::stop,
                                   Qt::BlockingQueuedConnection);
@@ -911,42 +881,11 @@ bool MainWindow::startDax()
         return false;
     }
 
-    // Listen for DAX stream status messages to register them in PanadapterStream.
-    // The radio sends "stream 0xNNNNNNNN type=dax_rx dax_channel=N" status lines
-    // in response to our stream create commands.
-    connect(&m_radioModel, &RadioModel::statusReceived,
-            m_daxBridge, [this](const QString& obj, const QMap<QString,QString>& kvs) {
-        if (!obj.startsWith("stream ")) return;
-        const QStringList parts = obj.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-        if (parts.size() < 2) return;
-        bool ok = false;
-        quint32 streamId = parts[1].toUInt(&ok, 0);
-        if (!ok) return;
-        const bool removed = parts.contains(QStringLiteral("removed")) || kvs.contains(QStringLiteral("removed"));
-        if (removed) {
-            m_radioModel.panStream()->unregisterDaxStream(streamId);
-            qCDebug(lcDax) << "MainWindow: unregistered removed DAX RX stream"
-                           << "0x" + QString::number(streamId, 16);
-            return;
-        }
-        QString type = kvs.value("type");
-        if (type == "dax_rx") {
-            if (!streamStatusBelongsToUs(kvs, m_radioModel.ourClientHandle())) {
-                qCDebug(lcDax) << "MainWindow: ignoring DAX RX stream for another client"
-                                << "stream=0x" + QString::number(streamId, 16)
-                                << "owner=" << kvs.value("client_handle");
-                return;
-            }
-            int ch = kvs.value("dax_channel").toInt();
-            if (streamId && ch >= 1 && ch <= 4) {
-                m_radioModel.panStream()->registerDaxStream(streamId, ch);
-                qCDebug(lcDax) << "MainWindow: registered DAX RX ch" << ch
-                                << "stream=0x" + QString::number(streamId, 16);
-            }
-        }
-    });
+    // Stream status registration now lives in ONE place —
+    // RadioModel::handleDaxRxStreamRegistry (#3305) — instead of per-consumer
+    // statusReceived hooks with divergent filtering.
 
-    // Create DAX RX streams only for channels with slices assigned.
+    // Acquire DAX channels only for slices with a channel assigned.
     // FlexLib creates streams on demand, not all 4 unconditionally.
     // Creating unused streams causes the radio to round-robin audio
     // across all of them, starving the active channels.
@@ -955,8 +894,8 @@ bool MainWindow::startDax()
         int ch = s->daxChannel();
         m_daxSliceLastCh[s->sliceId()] = ch;
         if (ch >= 1 && ch <= 4) {
-            m_radioModel.sendCommand(
-                QString("stream create type=dax_rx dax_channel=%1").arg(ch));
+            m_radioModel.panStream()->acquireDaxChannel(
+                ch, PanadapterStream::DaxConsumer::Bridge);
         }
     }
 
@@ -984,6 +923,20 @@ bool MainWindow::startDax()
         if (s->daxChannel() >= 1 && s->daxChannel() <= 4) {
             onDaxChannelChanged(s, s->daxChannel());
         }
+    }));
+    // A slice removed out from under us (pan close, foreign client, profile
+    // load) never fires daxChannelChanged — release its channel here or the
+    // bridge holds it until stopDax (a silent radio-side orphan, #3305).
+    m_daxSliceConns.append(connect(&m_radioModel, &RadioModel::sliceRemoved,
+                                   this, [this](int sliceId) {
+        if (!m_daxBridge) return;
+        const int ch = m_daxSliceLastCh.take(sliceId);
+        if (ch < 1 || ch > 4) return;
+        for (auto* s : m_radioModel.slices()) {
+            if (s && s->daxChannel() == ch) return;  // channel hopped slices
+        }
+        m_radioModel.panStream()->releaseDaxChannel(
+            ch, PanadapterStream::DaxConsumer::Bridge);
     }));
 
     // Wire DAX RX: PanadapterStream routes registered DAX streams here
@@ -1055,38 +1008,19 @@ void MainWindow::stopDax()
     }
     m_daxSliceConns.clear();
     m_daxSliceLastCh.clear();
-    m_daxPendingRxRemoval.clear();  // drop deferred teardowns; streams handled below (#3626)
 
     disconnect(m_radioModel.panStream(), &PanadapterStream::daxAudioReady,
                m_daxBridge, nullptr);
     disconnect(m_daxBridge, &DaxBridge::txAudioReady,
                this, nullptr);
 
-    // Remove DAX RX streams from the radio — but only channels no other
-    // consumer still needs. TCI borrows bridge-created streams (#1331/#1439)
-    // and RADE may hold one; unconditionally removing every registered stream
-    // here silenced WSJT-X / RADE the instant the DAX bridge (or mute) was
-    // toggled off — the #3363 / #2886 failure. Mirror the ownership guard in
-    // onDaxChannelChanged(); full refcounting is tracked in #3305.
-    auto* ps = m_radioModel.panStream();
-    for (int ch = 1; ch <= 4; ++ch) {
-        const quint32 id = ps->daxStreamIdForChannel(ch);
-        if (id == 0) continue;
-        const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(ch);
-#ifdef HAVE_RADE
-        const bool radeUsing = (id == m_radeDaxStreamId);
-#else
-        const bool radeUsing = false;
-#endif
-        if (tciUsing || radeUsing) {
-            qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
-                          << "0x" + QString::number(id, 16) << "for channel" << ch
-                          << "— still used by" << (tciUsing ? "TCI" : "RADE") << "(#3363)";
-            continue;
-        }
-        m_radioModel.sendCommand(QString("stream remove 0x%1").arg(id, 0, 16));
-        ps->unregisterDaxStream(id);
-    }
+    // Release every channel the bridge holds. PanadapterStream removes a
+    // radio-side stream only when the LAST holder releases, so a channel TCI
+    // or RADE still uses survives a bridge teardown — the #3363/#2886 failure
+    // class, now enforced structurally instead of by cross-consumer peeking
+    // (#3305).
+    m_radioModel.panStream()->releaseAllDaxChannels(
+        PanadapterStream::DaxConsumer::Bridge);
 
     // Restore original mic selection
     if (!m_savedMicSelection.isEmpty() && m_savedMicSelection != "PC")
@@ -1112,8 +1046,19 @@ void MainWindow::wireDaxSlice(SliceModel* slice)
 
 // Handle a slice's DAX channel transitioning. daxChannelChanged only fires on
 // an actual value change (SliceModel guards equality), and arrives from both
-// the local UI setter and the radio status echo — both are safe here because
-// the stream create is made idempotent by the daxStreamIdForChannel() guard.
+// the local UI setter and the radio status echo.
+//
+// #3305/#4009: this reconciler translates slice→channel transitions into
+// refcounted acquire/release on PanadapterStream and NOTHING ELSE. It must
+// never send commands itself: the radio answers a re-assert of a live binding
+// with a transient unbind/rebind dax=0/dax=<ch> status pair
+// (state-machines.md §7.4), so any command emitted from this echo path feeds
+// a self-sustaining storm — the ~12-15 Hz `slice set dax` loop of #4009 and
+// the create/remove churn of #3626. Acquire/release are idempotent and the
+// manager's grace window absorbs the transient pair, so this path is
+// loop-free by construction. The #1439 dax_clients re-assert still exists,
+// but as a one-shot tied to `stream create` in RadioModel — command-initiated,
+// never echo-initiated.
 void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
 {
     if (!slice || !m_daxBridge) return;
@@ -1123,108 +1068,29 @@ void MainWindow::onDaxChannelChanged(SliceModel* slice, int newCh)
     const int sliceId = slice->sliceId();
     const int oldCh = m_daxSliceLastCh.value(sliceId, 0);
     if (oldCh == newCh) return;
+    // Record every transition, including 0: the tracker mirrors the slice's
+    // channel so a genuine off→on retoggle is seen as 0→N and re-acquires.
     m_daxSliceLastCh[sliceId] = newCh;
 
-    // 0 -> 1..4 (or 1..4 -> different 1..4): ensure the new channel has a
-    // radio-registered DAX RX stream. The stream status echo will register the
-    // stream id in PanadapterStream via the dax_rx handler wired in startDax().
-    if (newCh >= 1 && newCh <= 4) {
-        if (ps->daxStreamIdForChannel(newCh) == 0) {
-            m_radioModel.sendCommand(
-                QString("stream create type=dax_rx dax_channel=%1").arg(newCh));
-            qCInfo(lcDax) << "MainWindow: creating DAX RX stream for channel"
-                          << newCh << "(slice" << sliceId << ", #2895)";
-        }
-        // Re-assert slice -> DAX mapping so the radio registers our stream as a
-        // client. Without this dax_clients stays 0 and the radio sends silence
-        // (the #1439 workaround, mirrored from TciServer::ensureDaxForTci).
-        // This is sent unconditionally (even when newCh is unchanged), so on the
-        // dax=<ch> rebroadcast edge it re-emits a same-value `slice set`. That
-        // does NOT re-enter this reconciler only because SliceModel's status
-        // path drops same-value echoes (`if (m_daxChannel != ch)` in
-        // SliceModel::applyStatus) — that equality guard is load-bearing for the
-        // #3626 storm fix; relaxing it would reopen the loop via this edge.
-        m_radioModel.sendCommand(
-            QString("slice set %1 dax=%2").arg(sliceId).arg(newCh));
-    }
-
-    // <old>:1..4 -> released or moved. Don't tear the stream down inline: on the
-    // FLEX-8600M every `stream create` provokes a transient dax=0 rebroadcast
-    // (see scheduleDaxRxStreamRemoval) that would read here as a de-assignment
-    // and start a create/remove storm. Defer + re-validate instead. (#3626)
-    if (oldCh >= 1 && oldCh <= 4)
-        scheduleDaxRxStreamRemoval(oldCh);
-}
-
-// #3626: On the FLEX-8600M (and likely other 8000-series radios), issuing
-// `stream create type=dax_rx dax_channel=<ch>` while the bound slice already
-// has dax=<ch> makes the radio momentarily detach the stream and re-broadcast
-// `slice <id> dax=0` immediately followed by `slice <id> dax=<ch>` again.
-// SliceModel mirrors every echo into daxChannelChanged (SliceModel.cpp ~846),
-// so the inline reconciler above would read the transient dax=0 as a real
-// de-assignment, remove the stream, then re-create it on the dax=<ch> that
-// lands ~80 ms later — a self-sustaining create/remove storm (observed at
-// 12-25 Hz in #3626 logs). The churn floods the radio's TCP command channel and
-// resets the DAX VITA-49 sequence every cycle, inflating packetErrorCount until
-// the network-quality monitor falls to POOR ("connection drops to red").
-//
-// Fix: defer the teardown and re-validate at fire time. The dax=<ch>
-// rebroadcast lands long before the grace window elapses, so a slice is back on
-// the channel and the removal is declined — the loop never starts. A genuine
-// user de-assignment has no follow-up rebroadcast, so the channel stays
-// unwanted and the stream is removed after the grace window. Full DAX RX
-// stream refcounting is tracked separately in #3305.
-void MainWindow::scheduleDaxRxStreamRemoval(int ch)
-{
-    if (ch < 1 || ch > 4) return;
-    if (m_daxPendingRxRemoval.contains(ch)) return;  // already pending — don't stack timers
-    m_daxPendingRxRemoval.insert(ch);
-
-    static constexpr int kDaxRxRemovalGraceMs = 1500;  // ≫ the ~80 ms rebroadcast cycle
-    QTimer::singleShot(kDaxRxRemovalGraceMs, this, [this, ch]() {
-        // QSet::remove() returns false when the key is gone, which means
-        // stopDax() cleared the pending set after this timer was armed — i.e. a
-        // stale fire from a previous DAX-bridge generation (off→on toggle inside
-        // the grace window). Treat the cleared set as an authoritative cancel so
-        // we never act against a freshly-recreated bridge's streams. (#3626)
-        if (!m_daxPendingRxRemoval.remove(ch)) return;
-        if (!m_daxBridge) return;  // bridge torn down — stopDax() already cleared streams
-        auto* ps = m_radioModel.panStream();
-        if (!ps) return;
-
-        // Re-validate: if any slice still wants this channel, the transient
-        // dax=0 has already been undone by the dax=<ch> rebroadcast — keep it.
+    if (newCh >= 1 && newCh <= 4)
+        ps->acquireDaxChannel(newCh, PanadapterStream::DaxConsumer::Bridge);
+    if (oldCh >= 1 && oldCh <= 4) {
+        // The Bridge's hold is per-channel, not per-slice: only release when
+        // no slice references the old channel anymore (a channel can hop
+        // between slices, and the moves can arrive in either order).
+        bool stillWanted = false;
         for (auto* s : m_radioModel.slices()) {
-            if (s && s->daxChannel() == ch) return;
+            if (s && s->daxChannel() == oldCh) { stillWanted = true; break; }
         }
-
-        const quint32 id = ps->daxStreamIdForChannel(ch);
-        if (id == 0) return;
-        // Ownership guard: the PanadapterStream DAX map is shared across every
-        // DAX consumer — the bridge, TCI (which borrows bridge-created streams,
-        // #1331/#1439), and RADE. Removing a stream another consumer still uses
-        // would silence WSJT-X or RADE audio (the mirror image of #3270). (#2895)
-        const bool tciUsing = tciServer() && tciServer()->ownsDaxChannel(ch);
-#ifdef HAVE_RADE
-        const bool radeUsing = (id == m_radeDaxStreamId);
-#else
-        const bool radeUsing = false;
-#endif
-        if (tciUsing || radeUsing) {
-            qCInfo(lcDax) << "MainWindow: keeping DAX RX stream"
-                          << "0x" + QString::number(id, 16)
-                          << "for channel" << ch
-                          << "— still used by" << (tciUsing ? "TCI" : "RADE")
-                          << "(#3626)";
-            return;
-        }
-        m_radioModel.sendCommand(QString("stream remove 0x%1").arg(id, 0, 16));
-        ps->unregisterDaxStream(id);
-        qCInfo(lcDax) << "MainWindow: removed DAX RX stream"
-                      << "0x" + QString::number(id, 16)
-                      << "for channel" << ch << "(#3626 deferred)";
-    });
+        if (!stillWanted)
+            ps->releaseDaxChannel(oldCh, PanadapterStream::DaxConsumer::Bridge);
+    }
 }
+
+// (#3626's deferred-removal + revalidation and #2895's cross-consumer
+// ownership guards were absorbed into PanadapterStream's refcounted DAX
+// channel manager — grace-window removal at last-holder release, per-consumer
+// holds instead of tciUsing/radeUsing peeking. #3305)
 #endif
 
 // registerMidiParams() lives in MainWindow_Controllers.cpp (#3351 Phase 1a).

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -434,6 +434,31 @@ void MainWindow::activateRADE(int sliceId)
             qWarning() << "MainWindow: RADE slice" << sliceId
                        << "has no DAX channel assigned — RX audio will not flow";
         }
+        // Follow mid-session dax= changes on the RADE slice: RADE stays active
+        // across a channel edit (only a mode change deactivates it), and its
+        // RX filter already retargets live via s->daxChannel() — so the Rade
+        // hold must move with it or the old channel's stream leaks and the
+        // new one is never created. Independent of the DAX bridge's
+        // reconciler, which is Bridge-only and absent on Windows.
+        // (PR #4017 review item 2)
+        if (radeSlice) {
+            m_radeDaxReconcileConn = connect(
+                radeSlice, &SliceModel::daxChannelChanged,
+                this, [this](int newCh) {
+                auto* ps = m_radioModel.panStream();
+                if (!ps) return;
+                const int oldCh = m_radeDaxChannel;
+                m_radeDaxChannel = (newCh >= 1 && newCh <= 4) ? newCh : 0;
+                if (m_radeDaxChannel)
+                    ps->acquireDaxChannel(m_radeDaxChannel,
+                                          PanadapterStream::DaxConsumer::Rade);
+                if (oldCh >= 1 && oldCh <= 4 && oldCh != m_radeDaxChannel)
+                    ps->releaseDaxChannel(oldCh,
+                                          PanadapterStream::DaxConsumer::Rade);
+                qCInfo(lcRade) << "MainWindow: RADE dax hold moved"
+                               << oldCh << "->" << m_radeDaxChannel;
+            });
+        }
     }
 
     // Restore client-side mic gain for RADE. The radio's mic input is unused in
@@ -566,6 +591,7 @@ void MainWindow::deactivateRADE()
                    this, nullptr);
         disconnect(m_radeEngine, &RADEEngine::eooCallsignReceived,
                    this, nullptr);
+        disconnect(m_radeDaxReconcileConn);
         if (m_radeDaxChannel >= 1 && m_radeDaxChannel <= 4) {
             // Release RADE's hold; the centralized manager removes the
             // radio-side stream only when the LAST holder (TCI / DAX bridge /

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1447,9 +1447,14 @@ void MainWindow::runProfileLoadRecoveryPass(const QString& profileType,
 #if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)
     if (m_daxBridge) {
         auto* panStream = m_radioModel.panStream();
-        QSet<int> requestedChannels;
         bool txSliceIsDigital = false;
 
+        // Post-profile-load reconcile (#3305): reseed the slice→channel shadow
+        // and (re)acquire whatever the restored slices carry. The manager
+        // dedupes against live streams, and streams the radio destroyed during
+        // the load are re-created automatically by its removed-status recreate
+        // path — no manual stream remove/create here anymore. Channels held by
+        // TCI or RADE are simply co-held; nothing is stomped.
         for (auto* slice : m_radioModel.slices()) {
             if (!slice) {
                 continue;
@@ -1469,34 +1474,9 @@ void MainWindow::runProfileLoadRecoveryPass(const QString& profileType,
             if (channel < 1 || channel > 4) {
                 continue;
             }
-
-#ifdef HAVE_WEBSOCKETS
-            const bool tciUsingChannel = tciServer() && tciServer()->ownsDaxChannel(channel);
-#else
-            const bool tciUsingChannel = false;
-#endif
-#ifdef HAVE_RADE
-            const bool radeUsingChannel =
-                (m_radeDaxStreamId != 0 && panStream
-                 && m_radeDaxStreamId == panStream->daxStreamIdForChannel(channel));
-#else
-            const bool radeUsingChannel = false;
-#endif
-            quint32 existingStream = panStream ? panStream->daxStreamIdForChannel(channel) : 0;
-            if (!tciUsingChannel && panStream && resetDaxRxStreams) {
-                if (existingStream != 0 && !radeUsingChannel) {
-                    m_radioModel.sendCommand(
-                        QString("stream remove 0x%1").arg(existingStream, 0, 16));
-                    panStream->unregisterDaxStream(existingStream);
-                    existingStream = 0;
-                }
-            }
-
-            if (!tciUsingChannel && !radeUsingChannel && existingStream == 0
-                    && !requestedChannels.contains(channel)) {
-                m_radioModel.sendCommand(
-                    QString("stream create type=dax_rx dax_channel=%1").arg(channel));
-                requestedChannels.insert(channel);
+            if (panStream) {
+                panStream->acquireDaxChannel(
+                    channel, PanadapterStream::DaxConsumer::Bridge);
             }
         }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -405,8 +405,23 @@ RadioModel::RadioModel(QObject* parent)
     // bridge/TCI/RADE); RadioModel is the command plane that makes it so.
     connect(m_panStream, &PanadapterStream::daxStreamCreateNeeded,
             this, [this](int ch) {
-        if (!isConnected()) return;
-        sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
+        if (!isConnected()) {
+            // Dropped create (connect gap): tell the manager so the latch
+            // clears and its retry cadence re-fires — otherwise the channel
+            // wedges with createPending stuck true (the #3669 wedge class).
+            m_panStream->notifyDaxCreateFailed(ch);
+            return;
+        }
+        sendCmd(QString("stream create type=dax_rx dax_channel=%1").arg(ch),
+                [this, ch](int code, const QString& body) {
+            if (code != 0) {
+                qCWarning(lcDax) << "RadioModel: dax_rx stream create for channel"
+                                 << ch << "failed, code" << Qt::hex << code << body;
+                m_panStream->notifyDaxCreateFailed(ch);
+            }
+            // Success needs no action here: the stream status registers the
+            // id (registerDaxStream clears the latch).
+        });
         // One-shot #1439 client-registration re-assert: if a slice already
         // carries this channel, nudge dax_clients once. Modern firmware
         // auto-binds stream↔slice at create (state-machines.md §7.2); this

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -420,19 +420,25 @@ RadioModel::RadioModel(QObject* parent)
                 m_panStream->notifyDaxCreateFailed(ch);
                 return;
             }
-            // One-shot #1439 client-registration re-assert, gated on the
-            // create SUCCEEDING: if a slice carries this channel, nudge
-            // dax_clients once per confirmed stream. Modern firmware
-            // auto-binds stream↔slice at create (state-machines.md §7.2);
-            // this covers older firmware. Success-gating keeps the failure
-            // retry loop (notifyDaxCreateFailed, 2 s cadence) from
-            // re-asserting a live binding every cycle — the radio answers
-            // same-value re-asserts with a transient unbind/rebind pair
-            // (§7.4), which is noise we never want to emit repeatedly.
-            // Tied to a command we initiated, never to a status echo, so it
-            // cannot oscillate (#4009).
+            // One-shot #1439 client-registration re-assert — LEGACY FALLBACK
+            // ONLY. Gated on (a) the create succeeding and (b) the radio NOT
+            // having auto-bound the stream to the slice already: statuses
+            // precede this reply (state-machines.md §1.3), so by now the
+            // registration status has told us (slice=<letter>) whether modern
+            // firmware married them. When it did — the captured behavior on
+            // ≥4.2.18 — re-asserting would be a same-value `slice set dax=`,
+            // which the radio answers with the transient dax=0/dax=<ch> pair
+            // AND a real stream unbind/rebind (an audio blip, §7.4). Tied to
+            // a command we initiated, never a status echo: cannot oscillate.
+            if (m_daxRxBoundObserved.value(ch, false)) {
+                qCDebug(lcDax) << "RadioModel: dax_rx ch" << ch
+                               << "auto-bound by firmware — #1439 nudge skipped";
+                return;
+            }
             for (auto* s : slices()) {
                 if (s && s->daxChannel() == ch) {
+                    qCInfo(lcDax) << "RadioModel: dax_rx ch" << ch
+                                  << "not auto-bound — sending #1439 nudge";
                     sendCommand(QString("slice set %1 dax=%2").arg(s->sliceId()).arg(ch));
                     break;
                 }
@@ -2982,6 +2988,7 @@ void RadioModel::onDisconnected()
     // ownership table without emitting removals (#3305). Consumers re-acquire
     // on their reconnect re-arm paths.
     m_panStream->resetDaxChannelsForDisconnect();
+    m_daxRxBoundObserved.clear();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
     m_forcedDisconnectInProgress = false;
@@ -4478,8 +4485,17 @@ void RadioModel::handleDaxRxStreamRegistry(const QString& object,
         return;
     }
     const int ch = kvs.value(QStringLiteral("dax_channel")).toInt();
-    if (ch >= 1 && ch <= 4)
+    if (ch >= 1 && ch <= 4) {
+        // Record whether the radio already married stream↔slice (slice=<letter>
+        // non-empty). Modern firmware auto-binds at create (captured: the
+        // registration status carries slice=A immediately); when it did, the
+        // #1439 nudge is skipped — a same-value `slice set dax=` re-assert is
+        // exactly the transient-pair + stream unbind/rebind trigger
+        // (state-machines.md §7.4) and would blip audio once per create.
+        m_daxRxBoundObserved[ch] =
+            !kvs.value(QStringLiteral("slice")).trimmed().isEmpty();
         m_panStream->registerDaxStream(stream.streamId, ch);
+    }
 }
 
 void RadioModel::onStatusReceived(const QString& object,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -400,6 +400,32 @@ RadioModel::RadioModel(QObject* parent)
     connect(m_networkThread, &QThread::started, m_panStream, &PanadapterStream::init);
     m_networkThread->start();
 
+    // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
+    // WHEN a dax_rx stream must exist (refcounted acquire/release from the
+    // bridge/TCI/RADE); RadioModel is the command plane that makes it so.
+    connect(m_panStream, &PanadapterStream::daxStreamCreateNeeded,
+            this, [this](int ch) {
+        if (!isConnected()) return;
+        sendCommand(QString("stream create type=dax_rx dax_channel=%1").arg(ch));
+        // One-shot #1439 client-registration re-assert: if a slice already
+        // carries this channel, nudge dax_clients once. Modern firmware
+        // auto-binds stream↔slice at create (state-machines.md §7.2); this
+        // covers older firmware. Sent once per create — tied to a command we
+        // initiated, never to a status echo, so it cannot oscillate (#4009).
+        for (auto* s : slices()) {
+            if (s && s->daxChannel() == ch) {
+                sendCommand(QString("slice set %1 dax=%2").arg(s->sliceId()).arg(ch));
+                break;
+            }
+        }
+    });
+    connect(m_panStream, &PanadapterStream::daxStreamRemoveNeeded,
+            this, [this](quint32 streamId, int ch) {
+        Q_UNUSED(ch);
+        if (!isConnected()) return;
+        sendCommand(QString("stream remove 0x%1").arg(streamId, 0, 16));
+    });
+
     // RadioConnection runs on its own worker thread (#502) so TCP I/O
     // (including ping RTT measurement) is never blocked by paintEvent.
     m_connThread = new QThread(this);
@@ -2932,6 +2958,10 @@ void RadioModel::onDisconnected()
     m_announcedClientConnections.clear();
     m_startupClientConnections.clear();
     m_clientConnectionNoticeTimer.invalidate();
+    // The radio reaps all our streams on TCP disconnect; drop the DAX channel
+    // ownership table without emitting removals (#3305). Consumers re-acquire
+    // on their reconnect re-arm paths.
+    m_panStream->resetDaxChannelsForDisconnect();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
     m_forcedDisconnectInProgress = false;
@@ -4403,6 +4433,35 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
         << QStringLiteral("keys=%1").arg(kvs.keys().join(QLatin1Char(',')));
 }
 
+// Single registration path for dax_rx streams (#3305): every consumer used to
+// run its own statusReceived hook (bridge / TCI / RADE) with subtly different
+// filtering — RADE's had no client_handle check at all, so an external DAX
+// app's broadcast stream status could shadow the channel and suppress our own
+// `stream create` (state-machines.md §7.2: stream statuses go to ALL clients).
+void RadioModel::handleDaxRxStreamRegistry(const QString& object,
+                                           const QMap<QString, QString>& kvs)
+{
+    const auto stream = parseStreamObject(object, QStringLiteral("stream"));
+    if (!stream.valid) return;
+    if (streamStatusRemoved(stream, kvs)) {
+        // The removed form carries no type= (state-machines.md §7.6) — route
+        // by id; a non-dax_rx id is a harmless no-op in the registry.
+        m_panStream->unregisterDaxStream(stream.streamId);
+        return;
+    }
+    if (kvs.value(QStringLiteral("type")) != QStringLiteral("dax_rx")) return;
+    if (!streamStatusBelongsToUs(kvs, ourClientHandle())) {
+        qCDebug(lcDax).noquote()
+            << "RadioModel: ignoring foreign DAX RX stream"
+            << QStringLiteral("stream=%1").arg(hexId(stream.streamId))
+            << QStringLiteral("owner=%1").arg(kvs.value(QStringLiteral("client_handle")));
+        return;
+    }
+    const int ch = kvs.value(QStringLiteral("dax_channel")).toInt();
+    if (ch >= 1 && ch <= 4)
+        m_panStream->registerDaxStream(stream.streamId, ch);
+}
+
 void RadioModel::onStatusReceived(const QString& object,
                                   const QMap<QString, QString>& kvs)
 {
@@ -4411,6 +4470,7 @@ void RadioModel::onStatusReceived(const QString& object,
 
     handleRemoteAudioRxStreamStatus(object, kvs);
     traceDaxStreamStatus(object, kvs);
+    handleDaxRxStreamRegistry(object, kvs);
 
     if (object == "radio") {
         handleRadioStatus(kvs);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -420,29 +420,14 @@ RadioModel::RadioModel(QObject* parent)
                 m_panStream->notifyDaxCreateFailed(ch);
                 return;
             }
-            // One-shot #1439 client-registration re-assert — LEGACY FALLBACK
-            // ONLY. Gated on (a) the create succeeding and (b) the radio NOT
-            // having auto-bound the stream to the slice already: statuses
-            // precede this reply (state-machines.md §1.3), so by now the
-            // registration status has told us (slice=<letter>) whether modern
-            // firmware married them. When it did — the captured behavior on
-            // ≥4.2.18 — re-asserting would be a same-value `slice set dax=`,
-            // which the radio answers with the transient dax=0/dax=<ch> pair
-            // AND a real stream unbind/rebind (an audio blip, §7.4). Tied to
-            // a command we initiated, never a status echo: cannot oscillate.
-            if (m_daxRxBoundObserved.value(ch, false)) {
-                qCDebug(lcDax) << "RadioModel: dax_rx ch" << ch
-                               << "auto-bound by firmware — #1439 nudge skipped";
-                return;
-            }
-            for (auto* s : slices()) {
-                if (s && s->daxChannel() == ch) {
-                    qCInfo(lcDax) << "RadioModel: dax_rx ch" << ch
-                                  << "not auto-bound — sending #1439 nudge";
-                    sendCommand(QString("slice set %1 dax=%2").arg(s->sliceId()).arg(ch));
-                    break;
-                }
-            }
+            // Success needs no action here. The #1439 legacy client-
+            // registration nudge is decided in handleDaxRxStreamRegistry, when
+            // the registration status has definitively told us whether the
+            // radio auto-bound the stream (slice=<letter>) — deciding here
+            // would race that status: on WAN/SmartLink (and any firmware that
+            // binds after the create reply) the binding isn't known yet, so a
+            // reply-first ordering would fire a same-value `slice set dax=`
+            // re-assert and blip audio, the very thing the gate avoids (#4017).
         });
     });
     connect(m_panStream, &PanadapterStream::daxStreamRemoveNeeded,
@@ -2988,7 +2973,6 @@ void RadioModel::onDisconnected()
     // ownership table without emitting removals (#3305). Consumers re-acquire
     // on their reconnect re-arm paths.
     m_panStream->resetDaxChannelsForDisconnect();
-    m_daxRxBoundObserved.clear();
     emit otherClientsChanged(0, {});
     emit connectionStateChanged(false);
     m_forcedDisconnectInProgress = false;
@@ -4486,15 +4470,29 @@ void RadioModel::handleDaxRxStreamRegistry(const QString& object,
     }
     const int ch = kvs.value(QStringLiteral("dax_channel")).toInt();
     if (ch >= 1 && ch <= 4) {
-        // Record whether the radio already married stream↔slice (slice=<letter>
-        // non-empty). Modern firmware auto-binds at create (captured: the
-        // registration status carries slice=A immediately); when it did, the
-        // #1439 nudge is skipped — a same-value `slice set dax=` re-assert is
-        // exactly the transient-pair + stream unbind/rebind trigger
-        // (state-machines.md §7.4) and would blip audio once per create.
-        m_daxRxBoundObserved[ch] =
-            !kvs.value(QStringLiteral("slice")).trimmed().isEmpty();
         m_panStream->registerDaxStream(stream.streamId, ch);
+        // #1439 client-registration re-assert — LEGACY FALLBACK ONLY, decided
+        // here (not in the create reply) because this status is the moment the
+        // stream↔slice binding is definitively known: a non-empty slice=<letter>
+        // means the radio already auto-bound them (modern firmware, ≥4.2.18) and
+        // no nudge is needed. Only when it did NOT auto-bind AND a slice carries
+        // this channel do we re-assert `slice set dax=`. Deciding here is
+        // race-free across transports (the create reply can precede this status
+        // on WAN/SmartLink); tied to a stream we own and initiated, never a
+        // status echo, so it cannot oscillate (#4009/#3305).
+        const bool autoBound =
+            !kvs.value(QStringLiteral("slice")).trimmed().isEmpty();
+        if (!autoBound && isConnected()) {
+            for (auto* s : slices()) {
+                if (s && s->daxChannel() == ch) {
+                    qCInfo(lcDax) << "RadioModel: dax_rx ch" << ch
+                                  << "not auto-bound — sending #1439 nudge";
+                    sendCommand(QString("slice set %1 dax=%2")
+                                    .arg(s->sliceId()).arg(ch));
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -418,21 +418,26 @@ RadioModel::RadioModel(QObject* parent)
                 qCWarning(lcDax) << "RadioModel: dax_rx stream create for channel"
                                  << ch << "failed, code" << Qt::hex << code << body;
                 m_panStream->notifyDaxCreateFailed(ch);
+                return;
             }
-            // Success needs no action here: the stream status registers the
-            // id (registerDaxStream clears the latch).
+            // One-shot #1439 client-registration re-assert, gated on the
+            // create SUCCEEDING: if a slice carries this channel, nudge
+            // dax_clients once per confirmed stream. Modern firmware
+            // auto-binds stream↔slice at create (state-machines.md §7.2);
+            // this covers older firmware. Success-gating keeps the failure
+            // retry loop (notifyDaxCreateFailed, 2 s cadence) from
+            // re-asserting a live binding every cycle — the radio answers
+            // same-value re-asserts with a transient unbind/rebind pair
+            // (§7.4), which is noise we never want to emit repeatedly.
+            // Tied to a command we initiated, never to a status echo, so it
+            // cannot oscillate (#4009).
+            for (auto* s : slices()) {
+                if (s && s->daxChannel() == ch) {
+                    sendCommand(QString("slice set %1 dax=%2").arg(s->sliceId()).arg(ch));
+                    break;
+                }
+            }
         });
-        // One-shot #1439 client-registration re-assert: if a slice already
-        // carries this channel, nudge dax_clients once. Modern firmware
-        // auto-binds stream↔slice at create (state-machines.md §7.2); this
-        // covers older firmware. Sent once per create — tied to a command we
-        // initiated, never to a status echo, so it cannot oscillate (#4009).
-        for (auto* s : slices()) {
-            if (s && s->daxChannel() == ch) {
-                sendCommand(QString("slice set %1 dax=%2").arg(s->sliceId()).arg(ch));
-                break;
-            }
-        }
     });
     connect(m_panStream, &PanadapterStream::daxStreamRemoveNeeded,
             this, [this](quint32 streamId, int ch) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -595,6 +595,7 @@ private:
     void handleProfileStatus(const QString& object, const QMap<QString, QString>& kvs);
     void handleProfileStatusRaw(const QString& profileType, const QString& rawBody);
     void traceDaxStreamStatus(const QString& object, const QMap<QString, QString>& kvs);
+    void handleDaxRxStreamRegistry(const QString& object, const QMap<QString, QString>& kvs);
     bool handleRemoteAudioRxStreamStatus(const QString& object,
                                          const QMap<QString, QString>& kvs);
     void scheduleRxAudioStreamEnsure(const QString& reason);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -942,9 +942,6 @@ private:
     QSet<quint32> m_deadDaxRxSeen;
     QSet<quint32> m_externalDaxTxSeen;
     QSet<quint32> m_externalDaxRxSeen;
-    // dax_rx channel → firmware auto-bound stream↔slice at registration
-    // (slice=<letter> in the status). Gates the legacy #1439 nudge (#3305).
-    QHash<int, bool> m_daxRxBoundObserved;
     WanConnection* m_wanConn{nullptr};  // non-null when connected via SmartLink
     QString  m_wanPublicIp;
     quint16  m_wanUdpPort{4991};

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -942,6 +942,9 @@ private:
     QSet<quint32> m_deadDaxRxSeen;
     QSet<quint32> m_externalDaxTxSeen;
     QSet<quint32> m_externalDaxRxSeen;
+    // dax_rx channel → firmware auto-bound stream↔slice at registration
+    // (slice=<letter> in the status). Gates the legacy #1439 nudge (#3305).
+    QHash<int, bool> m_daxRxBoundObserved;
     WanConnection* m_wanConn{nullptr};  // non-null when connected via SmartLink
     QString  m_wanPublicIp;
     quint16  m_wanUdpPort{4991};

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -112,7 +112,7 @@ def main():
     ap.add_argument("command", nargs="?", default="demo",
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect", "slice", "audioCapture",
-                             "record", "testtone"],
+                             "record", "testtone", "tci"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
@@ -204,8 +204,9 @@ def main():
                     req["value"] = " ".join(args.rest[1:])
             print(json.dumps(bridge.request(req), indent=2))
 
-        elif args.command in ("record", "testtone"):
+        elif args.command in ("record", "testtone", "tci"):
             # record <start|stop|status|path|dir [path]> | testtone <on [hz] [db]|off>
+            # tci <start [port]|status|stop [abrupt]>
             req = {"cmd": args.command}
             if args.rest:
                 req["action"] = args.rest[0]


### PR DESCRIPTION
## Summary

Implements #3305: replaces the three hand-rolled, mutually-peeking DAX RX ownership trackers (DAX bridge, TCI, RADE) with **refcounted `acquireDaxChannel(ch, consumer)` / `releaseDaxChannel(ch, consumer)` in `PanadapterStream`** — the single decider of when a radio-side `dax_rx` stream exists. `RadioModel` becomes the command plane (`stream create`/`stream remove` + a one-shot #1439 `dax_clients` nudge tied to the create) and the single, `client_handle`-filtered stream-status registrar.

**Closes #3305. Fixes #4009. Fixes #3669.** Supersedes #4010.

- #4009 — the re-assert storm: eliminated by construction (details below); live-proven.
- #3669 — TCI audio not starting on connect / not recovering on DAX toggle / dying when another client connects: every implicated mechanism (stale `m_tciDaxStreamIds` guard wedging `stream create`, live-binding re-asserts silencing via the radio's unbind/rebind transient, toggle-blind channel tracking) is rebuilt by this PR — acquire is idempotent, radio-side stream death auto-recreates, and no command is ever echo-triggered. **@reporter verification on 26.7.x requested** — if the FLEX-6400/Win11 repro survives, please reopen.

Related, intentionally left open: #3715 (slice-lifecycle single-authority RFC — the slice-side sibling of this stream-side change) and #3366 (previously diagnosed as a WSJT-X-side watchdog/format contract issue, not stream ownership).

## Root cause this eliminates

The radio answers a re-assert of a **live** dax binding with a transient unbind/rebind `dax=0`/`dax=<ch>` status pair. The old code sent unconditional `slice set <n> dax=<ch>` re-asserts *from status-echo edges* (`onDaxChannelChanged`, `ensureDaxForTci`) — turning that transient pair into a self-sustaining oscillator: the ~12–15 Hz `slice set dax` storm of #4009, and the create/remove churn of #3626 before it. The invariant this PR enforces: **no commands are ever emitted from status-echo edges.** Acquire/release are idempotent, and the manager's removal grace window (1.5 s, cancelled by re-acquire) absorbs the transient pairs, so the loop is impossible by construction — not patched around.

Why not #4010's tracker patches: they break the loop but leave the echo-triggered re-assert in place and regress two paths — DAX off→on retoggle goes silent (stale tracker early-returns after the stream was removed), and slices arriving with DAX pre-assigned (profile restore / reconnect replay) never get a stream (the seeded tracker defeats the `sliceAdded` 0→ch transition). Details in the #4010 review discussion.

## Design

| Event | Manager behavior |
|---|---|
| First holder acquires a channel | `daxStreamCreateNeeded(ch)` → RadioModel sends `stream create type=dax_rx dax_channel=<ch>` + one-shot `slice set <id> dax=<ch>` (#1439, command-initiated, cannot oscillate) |
| Last holder releases | Deferred removal after 1.5 s grace (subsumes #3626's defer+revalidate); re-acquire cancels |
| Radio destroys a held stream (profile load / slice teardown) | Auto re-create after 500 ms backoff (#3476's re-arm, now universal — `rearmDaxForProfileLoad` no longer hand-removes streams) |
| TCP disconnect | Table reset, **no commands** — the radio reaps all of a client's streams itself; consumers re-acquire on their reconnect re-arm paths |
| Slice removed with DAX active | Bridge releases the channel (previously leaked a silent radio-side stream until stopDax) |

Deleted: the unconditional re-assert in `onDaxChannelChanged` (the #4009 gain element), `scheduleDaxRxStreamRemoval`, every `tciUsing`/`radeUsing` cross-consumer peek (`stopDax`, `deactivateRADE`, the profile recovery pass), `TciServer::ownsDaxChannel` + `m_tciDaxStreamIds` + `m_tciDaxBorrowedChannels`, `m_radeDaxStreamId`, and RADE's private stream-status hook — which had **no `client_handle` filter** and could adopt a foreign client's broadcast stream status, silently shadowing the channel. Ownership coordination goes from O(consumers²) peeking to one enum value per consumer.

## New automation bridge verbs (second commit)

This PR also adds the test surface that proves it, so the storm/co-hold/grace assertions are reproducible by any agent without log-grepping:

- **`get dax`** — snapshot of the ownership table: per-channel `holders` (`bridge`/`tci`/`rade`), `streamId`, `createPending`, plus each slice's `dax=` assignment.
- **`tci start|status|stop [abrupt]`** — in-process TCI client simulator speaking the WSJT-X dialect (init burst → `ready;` → `audio_samplerate` + `audio_start`, binary-frame counting). `stop abrupt` reproduces the WSJT-X watchdog-reconnect shape for teardown/reap tests.

Documented in `docs/automation-bridge.md`; `tools/automation_probe.py` gained the `tci` command.

## Live proof (FLEX-8400M, fw 4.2.18, as a second MultiFlex station)

| Scenario | Result |
|---|---|
| TCI `audio_start` (#4009 trigger) | Exactly **1** `stream create` + **1** one-shot re-assert; **0** storm commands in the window (pre-fix: 12–15/s) |
| DAX bridge enabled during a live TCI stream | `DAX ch 1 acquired by bridge holders=0x3` — co-hold, no duplicate create, no re-assert |
| DAX bridge disabled during a live TCI stream | `released by bridge holders=0x2` — **no stream remove**, TCI audio uninterrupted (2106 frames, steady ~47/s) — the #3363/#2886 failure class |
| TCI client killed (last holder) | grace → exactly **1** `stream remove` |
| Verb-driven re-run (`tci start` → `get dax` → `tci stop abrupt` → `get dax`) | `holders:["tci"]` with live stream id → after abrupt stop: debounce → release → grace → single `stream remove` → channel table drains to `[]` |
| App exit | Radio session fully released; discovery clean |

Log excerpt:

```
19:32:52 INF PanadapterStream: DAX ch 1 acquired by bridge holders=0x3
19:33:00 INF PanadapterStream: DAX ch 1 released by bridge holders=0x2   ← no stream remove
19:33:26 INF PanadapterStream: DAX ch 1 released by tci holders=0x0
19:33:28 INF PanadapterStream: DAX ch 1 unheld past grace — removing stream 4000008 (#3305)
```

Note: code comments cite `docs/architecture/flex-protocol/state-machines.md` (the wire-level contract, including captures of the transient unbind/rebind pair); that guide lands in a separate docs PR.

## Constitution principles honored

**Principle II — The Radio Is Authoritative On Live State.** Status echoes are treated purely as state carriers; the client never re-asserts state in response to them.

## Test plan

- [x] Clean build (ninja, macOS, RelWithDebInfo); no new warnings in changed TUs
- [x] Full ctest: 53/54 pass; `theme_manager_test` failure is pre-existing/environmental (reads the developer's live settings file; unrelated to this change)
- [x] Live-tested against FLEX-8400M via the agent automation bridge as a second MultiFlex station (table above), including full session cleanup
- [x] New `get dax` + `tci` verbs live-proven end-to-end (start → frames flowing → abrupt stop → grace removal → table drained)
- [ ] CI (on push)
- [ ] Reporter validation welcome: #4009 hardware (Linux/PipeWire) — @NF0T; #3669 (FLEX-6400, Win11)

## Checklist

- [x] Commits are signed (SSH)
- [x] No new flat-key `AppSettings` entries (Principle V)
- [x] Clean-room implementation — no proprietary source referenced (Principle IV)
- [x] No `MeterSmoother` changes
- [x] No transmit path modified (Principle VI) — dax_tx handling untouched
- [x] Automation docs updated for the new verbs (`docs/automation-bridge.md`)
- [x] No GHSA advisory needed

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
