### PR TITLE
ci(tests): register dialog-size regression tests with ctest — Principle VIII.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2470,6 +2470,7 @@ target_link_libraries(flex_control_dialog_size_test PRIVATE
     Qt6::Core Qt6::Widgets Qt6::Test
 )
 set_target_properties(flex_control_dialog_size_test PROPERTIES AUTOMOC ON)
+add_test(NAME flex_control_dialog_size_test COMMAND flex_control_dialog_size_test)
 
 add_executable(pan_layout_dialog_size_test
     tests/pan_layout_dialog_size_test.cpp
@@ -2487,6 +2488,7 @@ target_link_libraries(pan_layout_dialog_size_test PRIVATE
     Qt6::Core Qt6::Widgets Qt6::Test
 )
 set_target_properties(pan_layout_dialog_size_test PROPERTIES AUTOMOC ON)
+add_test(NAME pan_layout_dialog_size_test COMMAND pan_layout_dialog_size_test)
 
 add_executable(device_diagnostics_test
     tests/device_diagnostics_test.cpp


### PR DESCRIPTION
Fixes #3952

## Summary

`flex_control_dialog_size_test` and `pan_layout_dialog_size_test` get built but were never registered with `add_test()`, so `ctest --test-dir build` skipped them and both dialog-size guards only ever proved the code compiles. This adds the two missing registrations, same bare `add_test(NAME x COMMAND x)` pattern as the rest of the file.

No environment wiring needed: the sanitizers workflow already exports `QT_QPA_PLATFORM=offscreen` for the ctest step, which is how the other QApplication-based tests (`vfo_flag_placement_test` etc.) already run headless.

Kept out of scope on purpose: there are a couple dozen *other* test binaries that are built but never registered (`help_dialog_test` sits right above these two, for example). Which of those are actually meant to run in CI seems like a maintainer call, so I stuck to the two the issue names.

## Constitution principle honored

Principle VIII — both guards asserted regression protection with no CI evidence behind it. Now ctest actually runs them.

## Test plan

- [x] Existing tests pass (CI) — I ran the sanitizers workflow on my fork with this change: https://github.com/pelazas/AetherSDR/actions/runs/28699936881. ctest now runs 57 tests instead of 55, and both new tests pass under ASan+UBSan (57/57 green) and under TSan. The TSan job itself came back red, but the two failures (`audio_device_negotiator_test`, `audio_output_router_test`) are the pre-existing weekly TSan failure tracked in #3462 — same fingerprint, and neither is touched by this change.
- [ ] Local build passes — being upfront: I don't have a Qt dev setup on this machine, so I leaned on the fork CI run above instead of a local build.
- [ ] Behavior verified on a real radio — n/a, CMake-only change, nothing user-facing.
- [x] Reproduction steps documented — before: `ctest --test-dir build -N` lists neither test. After: both listed and executed.

## Checklist

- [x] Commits are signed
- [x] No new flat-key `AppSettings` calls — no source changes at all
- [x] Code is clean-room

One admin note: AGENTS.md says to self-assign the issue before working on it, but GitHub wouldn't let me (assignment looks restricted for outside contributors), so I claimed #3952 with a comment there instead.
