### PR TITLE
feat(radio): radio-declared band capability via optional bands= discovery/status key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,6 +646,7 @@ endif()
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/DeclaredBands.cpp
     src/models/RadioSession.cpp
     src/models/ModelCapabilities.cpp
     src/models/AntennaAliasStore.cpp
@@ -1920,6 +1921,14 @@ add_executable(model_capabilities_test
 target_include_directories(model_capabilities_test PRIVATE src)
 target_link_libraries(model_capabilities_test PRIVATE Qt6::Core)
 add_test(NAME model_capabilities_test COMMAND model_capabilities_test)
+
+add_executable(declared_bands_test
+    tests/declared_bands_test.cpp
+    src/models/DeclaredBands.cpp
+)
+target_include_directories(declared_bands_test PRIVATE src)
+target_link_libraries(declared_bands_test PRIVATE Qt6::Core)
+add_test(NAME declared_bands_test COMMAND declared_bands_test)
 
 add_executable(radio_discovery_test
     tests/radio_discovery_test.cpp

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -219,6 +219,8 @@ RadioInfo RadioDiscovery::parseDiscoveryPacket(const QByteArray& data) const
             info.isSystemModel = (value == "1");
         } else if (key == "turf_region") {
             info.turfRegion = value;
+        } else if (key == "bands") {
+            info.bands = value;
         } else if (key == "gui_client_stations") {
             info.guiClientStations = splitDiscoveryListValue(rawValue, true);
         } else if (key == "gui_client_handles") {

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -65,6 +65,12 @@ struct RadioInfo {
     bool isRouted{false};
     bool isSystemModel{false};
     QString turfRegion;
+    // Optional: bands the radio itself supports, e.g. "2m,440,23cm"
+    // (names from BandDefs).  Real Flex radios don't send this — band
+    // capability then derives from the model string as before.  Gateways
+    // presenting non-Flex hardware use it to declare their true band set
+    // instead of inheriting the impersonated model's bands.
+    QString bands;
     RadioBindSettings bindSettings;
     QHostAddress sessionBindAddress;
 

--- a/src/core/backends/RadioDelta.h
+++ b/src/core/backends/RadioDelta.h
@@ -26,6 +26,7 @@ struct RadioDelta {
     std::optional<QString> nickname;
     std::optional<QString> region;
     std::optional<QString> radioOptions;
+    std::optional<QString> bandsRaw;          // optional "bands=" declaration (validated model-side; see RadioModel::declaredBands())
 
     // Global flags
     std::optional<bool>    remoteOnEnabled;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -767,6 +767,7 @@ void FlexBackend::decodeRadioStatus(const QMap<QString, QString>& kvs)
     carry(kvs, "nickname", d.nickname);
     carry(kvs, "region", d.region);
     carry(kvs, "radio_options", d.radioOptions);
+    carry(kvs, "bands", d.bandsRaw);   // optional radio-declared bands (gateway/non-Flex); validated in RadioModel
     // Global flags
     carry(kvs, "remote_on_enabled", d.remoteOnEnabled);
     carry(kvs, "mf_enable", d.multiFlexEnabled);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5050,9 +5050,11 @@ void MainWindow::onConnectionStateChanged(bool connected)
                     xvtrBands.append({x.name, x.rfFreq, QString("X%1").arg(x.index)});
             }
             const ModelCapabilities caps = m_radioModel.capabilities();
+            const QStringList declaredBands = m_radioModel.declaredBands();
             for (auto* applet : m_panStack->allApplets()) {
                 auto* menu = applet->spectrumWidget()->overlayMenu();
                 menu->setRadioCapabilities(caps);
+                menu->setDeclaredBands(declaredBands);
                 menu->setXvtrBands(xvtrBands);
             }
         };

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1146,6 +1146,7 @@ void MainWindow::wirePanLifecycle()
                 menu->setPanId(pan->panId());
                 menu->setRadioModel(&m_radioModel);
                 menu->setRadioCapabilities(m_radioModel.capabilities());
+                menu->setDeclaredBands(m_radioModel.declaredBands());
                 connect(pan, &PanadapterModel::infoChanged,
                         sw, &SpectrumWidget::setFrequencyRange);
                 connect(pan, &PanadapterModel::infoChanged,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3522,6 +3522,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             // and honours these keys (e.g. band=440 on an IC-9700 gateway).
             // Real Flex radios never declare bands, so their unsupported-band
             // refusal below is unchanged.
+            //
+            // NB the resolveBandStackKey() attempt above runs FIRST, so a
+            // declared band that ALSO matches the impersonated model's native
+            // capability resolves natively and never reaches here — e.g. a
+            // gateway advertising FLEX-6700 (has2Meters) + bands=2m,440,23cm
+            // sends the bare native key `2` for 2m, but the declared tokens
+            // `440`/`23cm` for the bands the model has no native slot for. A
+            // declaring bridge must therefore honour both the bare Flex keys
+            // and its declared tokens, per band.
             stackKey = bandName;
         }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3515,6 +3515,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             unsupportedBandReason = stackKeyResult.unsupportedReason;
         }
 
+        if (stackKey.isEmpty() && m_radioModel.declaredBands().contains(bandName)) {
+            // Radio-declared band (see RadioModel::declaredBands): the radio
+            // told us it tunes this natively, so pass the declared name
+            // through as the band-stack key — the declaring radio defines
+            // and honours these keys (e.g. band=440 on an IC-9700 gateway).
+            // Real Flex radios never declare bands, so their unsupported-band
+            // refusal below is unchanged.
+            stackKey = bandName;
+        }
+
         if (stackKey.isEmpty()) {
             qCWarning(lcProtocol).noquote().nospace()
                 << "MainWindow: refusing unsupported band change band=" << bandName

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2257,6 +2257,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     menu->setRadioModel(&m_radioModel);
     menu->setKiwiSdrManager(m_kiwiSdrManager);
     menu->setRadioCapabilities(m_radioModel.capabilities());
+    menu->setDeclaredBands(m_radioModel.declaredBands());
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2350,6 +2350,15 @@ void SpectrumOverlayMenu::setRadioCapabilities(ModelCapabilities caps)
     setXvtrBands(m_lastXvtrBands);
 }
 
+void SpectrumOverlayMenu::setDeclaredBands(const QStringList& bands)
+{
+    if (bands == m_declaredBands)
+        return;  // No change — skip the rebuild.
+    m_declaredBands = bands;
+    // Same full-rebuild delegation as a capability change (above).
+    setXvtrBands(m_lastXvtrBands);
+}
+
 void SpectrumOverlayMenu::updateLoopButtonVisibility()
 {
     const bool showLoopA = m_radioCapabilities.hasLoopA;
@@ -2452,26 +2461,58 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     };
 
     int row = 0;
-    for (int r = 0; r < 4; ++r) {
-        for (int col = 0; col < 3; ++col) {
-            int idx = hfLayout[r][col];
-            if (idx < 0) continue;
-            grid->addWidget(makeBandBtn(idx), row, col);
-        }
-        ++row;
-    }
-
-    // Built-in transverter bands (4m / 2m) — surfaced for radios that
-    // report the corresponding capability flag (FLEX-6500 Region 1: 4m;
-    // FLEX-6700: 4m + 2m).  Styled identically to HF bands per #695
-    // (these are native radio hardware, not user-configured XVTRs).
-    if (m_radioCapabilities.has4Meters || m_radioCapabilities.has2Meters) {
+    if (!m_declaredBands.isEmpty()) {
+        // The radio declared its own band set ("bands=" discovery/status
+        // key — gateways presenting non-Flex hardware).  Build the grid
+        // from the declaration in BandDefs order instead of the HF layout
+        // + model capability flags: the radio said what it can do, so the
+        // menu offers exactly that (an IC-9700 gets 2m/440/23cm, not an
+        // HF grid it can't tune).  Utility and XVTR rows are unaffected.
+        // NB buttons are built from BandDefs here, not via makeBandBtn():
+        // BAND_GRID only carries the curated HF-menu entries, so declared
+        // VHF/UHF names (440, 23cm, ...) have no BAND_GRID row to reuse.
         int col = 0;
-        if (m_radioCapabilities.has4Meters)
-            grid->addWidget(makeBandBtn(kBandIdx4m), row, col++);
-        if (m_radioCapabilities.has2Meters)
-            grid->addWidget(makeBandBtn(kBandIdx2m), row, col++);
-        ++row;
+        for (const auto& def : kBands) {
+            const QString bandName = QString::fromLatin1(def.name);
+            if (!m_declaredBands.contains(bandName))
+                continue;
+            auto* btn = new QPushButton(bandName, m_bandPanel);
+            btn->setFixedSize(BAND_BTN_W, BAND_BTN_H);
+            btn->setStyleSheet(bandBtnStyle);
+            const double  freq = def.defaultFreqMhz;
+            const QString mode = QString::fromLatin1(def.defaultMode);
+            connect(btn, &QPushButton::clicked, this, [this, bandName, freq, mode]() {
+                hideAllSubPanels();
+                emit bandSelected(bandName, freq, mode);
+            });
+            grid->addWidget(btn, row, col % 3);
+            if (++col % 3 == 0)
+                ++row;
+        }
+        if (col % 3)
+            ++row;
+    } else {
+        for (int r = 0; r < 4; ++r) {
+            for (int col = 0; col < 3; ++col) {
+                int idx = hfLayout[r][col];
+                if (idx < 0) continue;
+                grid->addWidget(makeBandBtn(idx), row, col);
+            }
+            ++row;
+        }
+
+        // Built-in transverter bands (4m / 2m) — surfaced for radios that
+        // report the corresponding capability flag (FLEX-6500 Region 1: 4m;
+        // FLEX-6700: 4m + 2m).  Styled identically to HF bands per #695
+        // (these are native radio hardware, not user-configured XVTRs).
+        if (m_radioCapabilities.has4Meters || m_radioCapabilities.has2Meters) {
+            int col = 0;
+            if (m_radioCapabilities.has4Meters)
+                grid->addWidget(makeBandBtn(kBandIdx4m), row, col++);
+            if (m_radioCapabilities.has2Meters)
+                grid->addWidget(makeBandBtn(kBandIdx2m), row, col++);
+            ++row;
+        }
     }
 
     // XVTR bands (inserted between HF and utility)

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -91,6 +91,14 @@ public:
     // a default-constructed value when disconnected — the conditional
     // VHF row will disappear.  Triggers a band-panel rebuild. (#695)
     void setRadioCapabilities(ModelCapabilities caps);
+
+    // Bands the radio itself declared (optional "bands=" discovery/status
+    // key, names from BandDefs).  Non-empty: the band grid is built from
+    // this list instead of the HF layout + model capability flags, so a
+    // gateway presenting non-Flex hardware offers its true band set (e.g.
+    // an IC-9700's 2m/440/23cm).  Empty (all real Flex radios): the grid
+    // is unchanged.  Triggers a band-panel rebuild on change.
+    void setDeclaredBands(const QStringList& bands);
     void syncDaxIqChannel(int channel);
     // Reflect the real WFM demodulator state onto the DAX-panel WFM toggle
     // WITHOUT re-emitting wfmToggleRequested. Self-gated on this menu's slice,
@@ -241,6 +249,7 @@ private:
     // without the caller needing to re-supply the other half. (#695)
     QVector<XvtrBand>  m_lastXvtrBands;
     ModelCapabilities  m_radioCapabilities;
+    QStringList        m_declaredBands;   // radio-declared band set (see setDeclaredBands)
 
     // ANT sub-panel
     QWidget*     m_antPanel{nullptr};

--- a/src/models/DeclaredBands.cpp
+++ b/src/models/DeclaredBands.cpp
@@ -1,0 +1,25 @@
+#include "DeclaredBands.h"
+
+#include "BandDefs.h"
+
+namespace AetherSDR {
+
+QStringList parseDeclaredBands(const QString& csv)
+{
+    QStringList out;
+    const QStringList parts = csv.split(',', Qt::SkipEmptyParts);
+    for (const QString& part : parts) {
+        const QString name = part.trimmed();
+        for (const auto& def : kBands) {
+            const QString canon = QString::fromLatin1(def.name);
+            if (name.compare(canon, Qt::CaseInsensitive) == 0) {
+                if (!out.contains(canon))
+                    out.append(canon);
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+} // namespace AetherSDR

--- a/src/models/DeclaredBands.h
+++ b/src/models/DeclaredBands.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Parse a radio-declared band set ("bands=2m,440,23cm" from discovery/status)
+// into a canonical band-name list. Names are validated against BandDefs,
+// deduplicated, and case-folded, so a malformed or hostile declaration cannot
+// inject junk into the band UI; unknown names are dropped (Principle VII —
+// untrusted input validated at the boundary). An empty/absent value yields an
+// empty list, which is the real-Flex path (band UI unchanged).
+QStringList parseDeclaredBands(const QString& csv);
+
+} // namespace AetherSDR

--- a/src/models/DeclaredBands.h
+++ b/src/models/DeclaredBands.h
@@ -6,11 +6,12 @@
 namespace AetherSDR {
 
 // Parse a radio-declared band set ("bands=2m,440,23cm" from discovery/status)
-// into a canonical band-name list. Names are validated against BandDefs,
-// deduplicated, and case-folded, so a malformed or hostile declaration cannot
-// inject junk into the band UI; unknown names are dropped (Principle VII —
-// untrusted input validated at the boundary). An empty/absent value yields an
-// empty list, which is the real-Flex path (band UI unchanged).
+// into a validated band-name list (input order preserved). Each name is
+// validated against BandDefs, deduplicated, and case-folded to its BandDefs
+// spelling, so a malformed or hostile declaration cannot inject junk into the
+// band UI; unknown names are dropped (Principle VII — untrusted input
+// validated at the boundary). An empty/absent value yields an empty list,
+// which is the real-Flex path (band UI unchanged).
 QStringList parseDeclaredBands(const QString& csv);
 
 } // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2,6 +2,7 @@
 #include "AntennaAliasStore.h"
 #include "BandDefs.h"
 #include "BandSettings.h"
+#include "DeclaredBands.h"
 #include "core/CommandParser.h"
 #include "core/backends/flex/FlexBackend.h"   // aetherd RFC 2.2 radio-facing seam
 #include "core/AppSettings.h"
@@ -38,26 +39,9 @@ constexpr int kSessionRestorePruneDelayMs = 5000;
 constexpr int kWaterfallLineDurationMinMs = 1;
 constexpr int kWaterfallLineDurationMaxMs = 100;
 
-// "bands=2m,440,23cm" (discovery/status) -> canonical band-name list.
-// Names are validated against BandDefs and deduplicated, so a malformed
-// declaration can't inject junk into the band UI; unknown names are dropped.
-QStringList parseDeclaredBands(const QString& csv)
-{
-    QStringList out;
-    const QStringList parts = csv.split(',', Qt::SkipEmptyParts);
-    for (const QString& part : parts) {
-        const QString name = part.trimmed();
-        for (const auto& def : kBands) {
-            const QString canon = QString::fromLatin1(def.name);
-            if (name.compare(canon, Qt::CaseInsensitive) == 0) {
-                if (!out.contains(canon))
-                    out.append(canon);
-                break;
-            }
-        }
-    }
-    return out;
-}
+// parseDeclaredBands() moved to DeclaredBands.{h,cpp} so the Principle-VII
+// validation (allow-list against BandDefs, dedup, case-fold) has a light,
+// dependency-free test target (declared_bands_test). Behaviour unchanged.
 
 QJsonArray toJsonArray(const QStringList& values)
 {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,5 +1,6 @@
 #include "RadioModel.h"
 #include "AntennaAliasStore.h"
+#include "BandDefs.h"
 #include "BandSettings.h"
 #include "core/CommandParser.h"
 #include "core/backends/flex/FlexBackend.h"   // aetherd RFC 2.2 radio-facing seam
@@ -36,6 +37,27 @@ constexpr int kDefaultPanDimensionThreshold = 100;
 constexpr int kSessionRestorePruneDelayMs = 5000;
 constexpr int kWaterfallLineDurationMinMs = 1;
 constexpr int kWaterfallLineDurationMaxMs = 100;
+
+// "bands=2m,440,23cm" (discovery/status) -> canonical band-name list.
+// Names are validated against BandDefs and deduplicated, so a malformed
+// declaration can't inject junk into the band UI; unknown names are dropped.
+QStringList parseDeclaredBands(const QString& csv)
+{
+    QStringList out;
+    const QStringList parts = csv.split(',', Qt::SkipEmptyParts);
+    for (const QString& part : parts) {
+        const QString name = part.trimmed();
+        for (const auto& def : kBands) {
+            const QString canon = QString::fromLatin1(def.name);
+            if (name.compare(canon, Qt::CaseInsensitive) == 0) {
+                if (!out.contains(canon))
+                    out.append(canon);
+                break;
+            }
+        }
+    }
+    return out;
+}
 
 QJsonArray toJsonArray(const QStringList& values)
 {
@@ -1596,6 +1618,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_name    = info.name;
     m_model   = info.model;
     m_version = info.version;
+    m_declaredBands = parseDeclaredBands(info.bands);   // empty for real Flex
     m_maxSlices = maxSlicesForModel(m_model);
     if (reloadAntennaAliases())
         emit antennaAliasesChanged();
@@ -5962,6 +5985,19 @@ void RadioModel::applyRadioChanges(const RadioDelta& d)
             m_maxSlices = updatedMax;
         }
         changed = true;
+    }
+    if (d.bandsRaw) {
+        // Radio-declared band set (gateway/non-Flex hardware; see
+        // declaredBands()).  Also accepted on the status path so a radio
+        // connected by IP (no discovery packet seen) can still declare. The
+        // raw "bands=" string rides through RadioDelta and is validated here
+        // (parseDeclaredBands + BandDefs) — a model concern, matching how other
+        // text fields decode model-side under aetherd RFC 2.3.
+        const QStringList declared = parseDeclaredBands(*d.bandsRaw);
+        if (declared != m_declaredBands) {
+            m_declaredBands = declared;
+            changed = true;
+        }
     }
     if (d.callsign) {
         if (*d.callsign != m_callsign) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -157,6 +157,14 @@ public:
         return capabilitiesFor(m_model);
     }
 
+    // Bands the radio itself declared via the optional discovery/status
+    // key "bands=2m,440,23cm" (names validated against BandDefs).  Empty
+    // for real Flex radios — the band UI then falls back to the model
+    // capability flags.  Lets a gateway presenting non-Flex hardware
+    // (e.g. an Icom IC-9700 shown as a FLEX-6700) offer its true band
+    // set rather than the impersonated model's.
+    QStringList declaredBands() const { return m_declaredBands; }
+
     // Returns true for BigBend/DragonFire-platform radios (8400, 8600,
     // AU-/ML-/MLS-/CL-/CLS- series, RT-2122) that support the extended
     // firmware DSP filters (NRL, NRS, RNN, NRF).  6000-series radios don't
@@ -739,6 +747,7 @@ private:
 
     QString     m_name;
     QString     m_model;
+    QStringList m_declaredBands;    // optional "bands=" declaration (see declaredBands())
     int         m_maxSlices{4};
     QString     m_version;          // software version from discovery (e.g. "4.1.5")
     QString     m_protocolVersion;  // protocol version from V line (e.g. "1.4.0.0")

--- a/tests/declared_bands_test.cpp
+++ b/tests/declared_bands_test.cpp
@@ -1,0 +1,86 @@
+// Unit tests for parseDeclaredBands() — the Principle-VII boundary validation
+// behind the radio-declared bands= key. Locks in: allow-list against BandDefs
+// (unknown names dropped), dedup, case-fold, whitespace tolerance, and the
+// empty/absent -> empty-list real-Flex path.
+
+#include "models/DeclaredBands.h"
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok)
+        ++g_failed;
+}
+
+bool eq(const QStringList& got, const QStringList& want)
+{
+    return got == want;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // Absent / empty -> empty list (real Flex radios never send the key; the
+    // band UI must be unchanged, which relies on this being empty).
+    report("empty string -> empty list",
+           parseDeclaredBands(QString()).isEmpty());
+    report("blank/commas-only -> empty list",
+           parseDeclaredBands(QStringLiteral(" , ,")).isEmpty());
+
+    // The happy path: a real gateway declaration.
+    report("2m,440,23cm -> [2m,440,23cm]",
+           eq(parseDeclaredBands(QStringLiteral("2m,440,23cm")),
+              {QStringLiteral("2m"), QStringLiteral("440"), QStringLiteral("23cm")}));
+
+    // Unknown names dropped (allow-list is BandDefs only) — the core
+    // Principle-VII guarantee: junk can't reach the band UI.
+    report("unknown name dropped (2m,junk,440 -> [2m,440])",
+           eq(parseDeclaredBands(QStringLiteral("2m,junk,440")),
+              {QStringLiteral("2m"), QStringLiteral("440")}));
+    report("all-unknown -> empty list",
+           parseDeclaredBands(QStringLiteral("999cm,banana,-1")).isEmpty());
+
+    // Dedup.
+    report("dedup (440,440 -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("440,440")),
+              {QStringLiteral("440")}));
+
+    // Case-fold to the canonical BandDefs spelling.
+    report("case-fold (2M,23CM -> [2m,23cm])",
+           eq(parseDeclaredBands(QStringLiteral("2M,23CM")),
+              {QStringLiteral("2m"), QStringLiteral("23cm")}));
+
+    // Whitespace around tokens is tolerated.
+    report("whitespace trimmed ( 2m , 440 -> [2m,440])",
+           eq(parseDeclaredBands(QStringLiteral(" 2m , 440 ")),
+              {QStringLiteral("2m"), QStringLiteral("440")}));
+
+    // Canonical (BandDefs) order is preserved on output, and dedup keeps the
+    // first occurrence, so a mixed/duplicated input yields a clean set.
+    report("dedup keeps set, drops repeats (2m,440,2m -> [2m,440])",
+           eq(parseDeclaredBands(QStringLiteral("2m,440,2m")),
+              {QStringLiteral("2m"), QStringLiteral("440")}));
+
+    if (g_failed == 0) {
+        std::printf("\nAll %d declared-bands tests passed.\n", g_total);
+        return 0;
+    }
+    std::printf("\n%d of %d declared-bands tests failed.\n", g_failed, g_total);
+    return 1;
+}

--- a/tests/declared_bands_test.cpp
+++ b/tests/declared_bands_test.cpp
@@ -71,8 +71,8 @@ int main(int argc, char** argv)
            eq(parseDeclaredBands(QStringLiteral(" 2m , 440 ")),
               {QStringLiteral("2m"), QStringLiteral("440")}));
 
-    // Canonical (BandDefs) order is preserved on output, and dedup keeps the
-    // first occurrence, so a mixed/duplicated input yields a clean set.
+    // Output preserves input order; dedup keeps the first occurrence, so a
+    // mixed/duplicated input yields a clean set.
     report("dedup keeps set, drops repeats (2m,440,2m -> [2m,440])",
            eq(parseDeclaredBands(QStringLiteral("2m,440,2m")),
               {QStringLiteral("2m"), QStringLiteral("440")}));

--- a/tests/radio_discovery_test.cpp
+++ b/tests/radio_discovery_test.cpp
@@ -71,6 +71,24 @@ int main(int argc, char** argv)
                && info.inUse
                && info.multiFlexEnabled);
 
+    report("no bands key -> empty declaration (real Flex radios)",
+           info.bands.isEmpty());
+
+    // Radio-declared band set: a gateway presenting non-Flex hardware
+    // declares what it can actually tune (validation/dedup against BandDefs
+    // happens in RadioModel; discovery just carries the raw value).
+    QByteArray gatewayPacket("model=FLEX-6700 serial=GATE9700 nickname=Icom-IC-9700 "
+                             "ip=192.0.2.20 port=4992 status=Available "
+                             "bands=2m,440,23cm callsign=SDRSIM");
+    const RadioInfo gateway = RadioDiscoveryParserTest::parse(discovery, gatewayPacket);
+
+    report("bands= discovery key captured verbatim",
+           gateway.bands == QStringLiteral("2m,440,23cm"));
+    report("bands= does not disturb neighbouring fields",
+           gateway.model == QStringLiteral("FLEX-6700")
+               && gateway.nickname == QStringLiteral("Icom-IC-9700")
+               && gateway.callsign == QStringLiteral("SDRSIM"));
+
     if (g_failed == 0) {
         std::printf("\nAll %d radio-discovery tests passed.\n", g_total);
         return 0;


### PR DESCRIPTION
## Summary

A radio may now declare the band set it can actually tune with an optional discovery/status key:

```
bands=2m,440,23cm
```

Names come from the existing `BandDefs` vocabulary; they are validated, deduplicated and case-folded on parse, so a malformed declaration cannot inject junk into the band UI. When the key is present, the band selector is built from the declaration (in `BandDefs` order) instead of the HF layout + `ModelCapabilities` flags. When it is absent — **every real Flex radio** — parsing yields an empty list and the band UI is unchanged, bit for bit. The key is accepted on both the discovery packet and the radio status line (so a direct-IP connect with no discovery packet can still declare), and a mid-session change propagates through the existing `infoChanged` refresh.

## Why

Gateways and emulators present non-Flex hardware to AetherSDR as a Flex model, and the model string then drives a band menu the hardware cannot honour. Two live examples from my bench, bridged through **Aether-gate** — a universal radio→Flex bridge I have built on top of my public [flex-sim](https://github.com/nigelfenton/flex-sim) core (the Aether-gate repository goes public alongside this feature):

- an **Icom IC-9700** (2 m / 70 cm / 23 cm) must present as a FLEX-6700 to reach 2 m at all — and then gets a full HF grid it cannot tune;
- a **Kenwood TS-450S** (HF only) presents as a FLEX-6600 and is offered 6 m / 2 m / XVTR entries it has no hardware for.

With `bands=`, each declares its truth. Same IC-9700, stock vs this branch:

**Before — stock, offered the full HF grid it cannot tune:**

<!-- BEFORE screenshot: drag here -->

**After — exactly 2m / 440 / 23cm:**

<!-- AFTER screenshot: drag here -->

## Scope / non-goals

- Narrows the **band selector** only. Slice capacity and other capabilities still derive from the model string — `ModelCapabilities` remains the single source of model truth.
- Utility rows (WWV / GEN / 2200 / 630) and the user-configured XVTR row are deliberately untouched — application features, not hardware band claims.
- Unknown band names are dropped, not invented: the vocabulary is exactly `BandDefs`.
- Self-contained and engine-agnostic — the declared-band set is model-layer state on `RadioModel`, and the only `gui/` touch is the menu build.

## Constitution principle honored

- **Principle VII — Untrusted Input Is Validated At The Boundary.** `bands=` is untrusted wire input (discovery / status). `parseDeclaredBands` validates every name against `BandDefs` at the parse boundary, deduplicates, and drops anything unrecognised, so the band UI can never be driven by a malformed or hostile declaration. Absent / empty ⇒ the real-Flex path, unchanged.
- **Principle I — FlexLib Authority.** The declaration narrows the band *selector* only; slice capacity and model capabilities still derive from `ModelCapabilities` / the model string. No FlexLib-sourced model truth is overridden.
- **Principle IV — Clean-Room.** This AetherSDR-side code is written against AetherSDR's own headers; nothing is decompiled, disassembled, or reverse-engineered.

## Test plan

- [x] Local build passes (`cmake --build build`) — **Windows 11 (MSVC / Ninja)** and **Ubuntu 24.04 (GCC / Ninja)**
- [x] Behavior verified on a real radio — live IC-9700 and TS-450S bridges; band-menu narrowing and tuning confirmed in AE (screenshots above)
- [x] Existing tests pass — `radio_discovery_test` (with 3 new checks for the key), `model_capabilities_test` (212), `xvtr_policy_test` (38), all green on both platforms
- [x] N/A — not a user-reported bug

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`) — ED25519, verified
- [x] No new flat-key `AppSettings` calls (Principle V) — *N/A: no settings surface in this change*
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` — *N/A: no meter UI in this change*
- [x] Documentation updated if user-visible behavior changed — the `bands=` key is documented in the discovery-field handling and the commit messages; happy to add a dedicated docs note if reviewers prefer
- [x] Security-sensitive changes reference a GHSA if applicable — *N/A*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
