### PR TITLE
feat(usb): Cable Type selector + LDPA support (#4034)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2497,6 +2497,15 @@ if(UNIX)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
 
+add_executable(usb_cable_model_test
+    tests/usb_cable_model_test.cpp
+    src/models/UsbCableModel.cpp
+)
+target_include_directories(usb_cable_model_test PRIVATE src)
+target_link_libraries(usb_cable_model_test PRIVATE Qt6::Core Qt6::Test)
+set_target_properties(usb_cable_model_test PROPERTIES AUTOMOC ON)
+add_test(NAME usb_cable_model_test COMMAND usb_cable_model_test)
+
 add_executable(async_log_writer_test
     tests/async_log_writer_test.cpp
     src/core/AsyncLogWriter.cpp

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -50,6 +50,7 @@
 #include <QCheckBox>
 #include <QDoubleValidator>
 #include <QTimer>
+#include <QVector>
 #include <QDesktopServices>
 #include <QUrl>
 #include <QMediaDevices>
@@ -3733,6 +3734,141 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         QComboBox* flow{nullptr};
     };
 
+    // Cable Type combo: values match FlexLib's UsbCableType enum, listed here
+    // in enum order as the single source of truth for the combo's item
+    // order, the proto string sent on the wire, and the index recovered when
+    // a status arrives — collapses what used to be three hand-synced lists
+    // (combo item order, typeIndexToProto, protoToTypeIndex) into one.
+    // "Invalid" is the unconfigured sentinel, not a menu entry. Selecting
+    // BCD sends bare type=bcd; the existing bcdTypeCombo refines the specific
+    // bcd/vbcd/bcd_vbcd sub-type afterward (matches FlexLib's own default-
+    // then-refine behavior for this exact transition).
+    struct CableTypeEntry { QString proto; QString label; };
+    static const QVector<CableTypeEntry> kCableTypes = {
+        {"cat",         "CAT"},
+        {"bit",         "Bit"},
+        {"bcd",         "BCD"},
+        {"ldpa",        "LDPA"},
+        {"passthrough", "Passthrough"},
+    };
+    // Helper: create Cable Type combo (shared across all pages). Guarded
+    // against accidental wheel-scroll retyping a live cable (#570/#676-style
+    // hazard — this combo's value change sends a destructive command).
+    auto makeTypeCombo = []() {
+        auto* combo = new GuardedComboBox;
+        for (const auto& entry : kCableTypes) {
+            combo->addItem(entry.label);
+        }
+        combo->setStyleSheet(kCombo);
+        combo->setAccessibleName("Cable Type");
+        combo->setAccessibleDescription(
+            "Selects this cable's protocol type: CAT, Bit, BCD, LDPA, or Passthrough");
+        return combo;
+    };
+    auto typeIndexToProto = [](int idx) -> QString {
+        if (idx >= 0 && idx < kCableTypes.size()) {
+            return kCableTypes[idx].proto;
+        }
+        return kCableTypes[0].proto;  // default: CAT
+    };
+    auto protoToTypeIndex = [](const QString& proto) -> int {
+        // bcd/vbcd/bcd_vbcd are one family in FlexLib's UsbCableType — collapse
+        // before lookup so any of the three sub-types selects the BCD entry.
+        const QString family = (proto == "vbcd" || proto == "bcd_vbcd") ? "bcd" : proto;
+        for (int i = 0; i < kCableTypes.size(); ++i) {
+            if (kCableTypes[i].proto == family) {
+                return i;
+            }
+        }
+        return -1;  // invalid / unrecognized — leave the combo unset
+    };
+
+    // Helper: build the "Cable Settings" header group (Name/[Enabled]/Status/
+    // Type) shared by all six cable pages. `includeEnabled` is false only for
+    // the Unconfigured page, which has no enable state to toggle yet.
+    struct CableHeaderWidgets {
+        QGroupBox* group{nullptr};
+        QLineEdit* nameEdit{nullptr};
+        QCheckBox* enabledCheck{nullptr};  // nullptr when !includeEnabled
+        QLabel*    statusLabel{nullptr};
+        QComboBox* typeCombo{nullptr};
+    };
+    auto makeCableHeader = [makeTypeCombo](bool includeEnabled) -> CableHeaderWidgets {
+        auto* group = new QGroupBox("Cable Settings");
+        group->setStyleSheet(kGroupStyle);
+        auto* hg = new QGridLayout(group);
+        hg->setSpacing(4);
+
+        int row = 0;
+        hg->addWidget(new QLabel("Name:"), row, 0);
+        auto* nameEdit = new QLineEdit;
+        nameEdit->setStyleSheet(kEdit);
+        hg->addWidget(nameEdit, row, 1);
+        ++row;
+
+        QCheckBox* enabledCheck = nullptr;
+        if (includeEnabled) {
+            enabledCheck = new QCheckBox("Enabled");
+            AetherSDR::ThemeManager::instance().applyStyleSheet(enabledCheck, kCheck);
+            hg->addWidget(enabledCheck, row, 0, 1, 2);
+            ++row;
+        }
+
+        auto* statusLabel = new QLabel("Unplugged");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            statusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
+        hg->addWidget(new QLabel("Status:"), row, 0);
+        hg->addWidget(statusLabel, row, 1);
+        ++row;
+
+        hg->addWidget(new QLabel("Type:"), row, 0);
+        auto* typeCombo = makeTypeCombo();
+        hg->addWidget(typeCombo, row, 1);
+
+        return CableHeaderWidgets{group, nameEdit, enabledCheck, statusLabel, typeCombo};
+    };
+
+    // Tracks the serial number of a cable currently being retyped, so the
+    // cableAdded handler (fired once the radio's fresh status for the new
+    // type arrives — see "Wire model signals" below) knows to reselect it
+    // and repopulate the detail panel. Without this, a successful retype
+    // leaves the panel stuck on the empty-state page until manually
+    // re-clicked, since a type change tears the old cable entry down and
+    // rebuilds it fresh (UsbCableModel::applyStatus).
+    //
+    // Cleared two ways beyond the normal matching-cableAdded path, so a
+    // rejected/never-echoed retype can't hijack a later unplug/replug's
+    // selection: (1) cableRemoved for this serial defers a clear via a 0ms
+    // timer — harmless for a genuine retype, since its own cableAdded fires
+    // synchronously first (in the same applyStatus() call) and clears the
+    // pointer before the deferred callback runs; (2) a bounded timeout armed
+    // on send, in case the radio never echoes back at all.
+    auto pendingTypeChangeSn = std::make_shared<QString>();
+    auto sendCableType = [cableModel, cableList, pendingTypeChangeSn](const QString& proto) {
+        auto* item = cableList->currentItem();
+        if (!item) {
+            return;
+        }
+        const QString sn = item->data(Qt::UserRole).toString();
+        *pendingTypeChangeSn = sn;
+        cableModel->sendSet(sn, "type", proto);
+        QTimer::singleShot(5000, [pendingTypeChangeSn, sn]() {
+            if (*pendingTypeChangeSn == sn) {
+                pendingTypeChangeSn->clear();
+            }
+        });
+    };
+    // Wires a Cable Type combo's index changes to sendCableType — collapses
+    // what used to be six copy-pasted connect() blocks into one call site.
+    auto wireTypeCombo = [this, sendCableType, typeIndexToProto](QComboBox* combo) {
+        connect(combo, &QComboBox::currentIndexChanged, this,
+                [sendCableType, typeIndexToProto](int idx) {
+            if (idx >= 0) {
+                sendCableType(typeIndexToProto(idx));
+            }
+        });
+    };
+
     // Helper: serial parameter group (shared by CAT and Passthrough)
     auto makeSerialGroup = [](const QString& title) -> SerialWidgets {
         auto* group = new QGroupBox(title);
@@ -3784,28 +3920,19 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     QComboBox* catSourceCombo;
     QCheckBox* catAutoReportCheck;
     SerialWidgets catSerialWidgets;
+    QComboBox* catTypeCombo;
     {
         catPage = new QWidget;
         auto* vbox = new QVBoxLayout(catPage);
         vbox->setSpacing(6);
 
         // Common header
-        auto* headerGroup = new QGroupBox("Cable Settings");
-        headerGroup->setStyleSheet(kGroupStyle);
-        auto* hg = new QGridLayout(headerGroup);
-        hg->setSpacing(4);
-        hg->addWidget(new QLabel("Name:"), 0, 0);
-        catNameEdit = new QLineEdit;
-        catNameEdit->setStyleSheet(kEdit);
-        hg->addWidget(catNameEdit, 0, 1);
-        catEnabledCheck = new QCheckBox("Enabled");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(catEnabledCheck, kCheck);
-        hg->addWidget(catEnabledCheck, 1, 0, 1, 2);
-        catStatusLabel = new QLabel("Unplugged");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(catStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
-        hg->addWidget(new QLabel("Status:"), 2, 0);
-        hg->addWidget(catStatusLabel, 2, 1);
-        vbox->addWidget(headerGroup);
+        auto catHeader = makeCableHeader(/*includeEnabled=*/true);
+        catNameEdit = catHeader.nameEdit;
+        catEnabledCheck = catHeader.enabledCheck;
+        catStatusLabel = catHeader.statusLabel;
+        catTypeCombo = catHeader.typeCombo;
+        vbox->addWidget(catHeader.group);
 
         // Serial params
         catSerialWidgets = makeSerialGroup("Serial Parameters");
@@ -3836,27 +3963,18 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     QComboBox* bcdSourceCombo;
     QComboBox* bcdTypeCombo;
     QComboBox* bcdPolarityCombo;
+    QComboBox* bcdCableTypeCombo;
     {
         bcdPage = new QWidget;
         auto* vbox = new QVBoxLayout(bcdPage);
         vbox->setSpacing(6);
 
-        auto* headerGroup = new QGroupBox("Cable Settings");
-        headerGroup->setStyleSheet(kGroupStyle);
-        auto* hg = new QGridLayout(headerGroup);
-        hg->setSpacing(4);
-        hg->addWidget(new QLabel("Name:"), 0, 0);
-        bcdNameEdit = new QLineEdit;
-        bcdNameEdit->setStyleSheet(kEdit);
-        hg->addWidget(bcdNameEdit, 0, 1);
-        bcdEnabledCheck = new QCheckBox("Enabled");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(bcdEnabledCheck, kCheck);
-        hg->addWidget(bcdEnabledCheck, 1, 0, 1, 2);
-        bcdStatusLabel = new QLabel("Unplugged");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(bcdStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
-        hg->addWidget(new QLabel("Status:"), 2, 0);
-        hg->addWidget(bcdStatusLabel, 2, 1);
-        vbox->addWidget(headerGroup);
+        auto bcdHeader = makeCableHeader(/*includeEnabled=*/true);
+        bcdNameEdit = bcdHeader.nameEdit;
+        bcdEnabledCheck = bcdHeader.enabledCheck;
+        bcdStatusLabel = bcdHeader.statusLabel;
+        bcdCableTypeCombo = bcdHeader.typeCombo;
+        vbox->addWidget(bcdHeader.group);
 
         auto* bcdGroup = new QGroupBox("BCD Settings");
         bcdGroup->setStyleSheet(kGroupStyle);
@@ -3910,27 +4028,18 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     };
     BitWidgets bitWidgets;
     auto currentBit = std::make_shared<int>(0);
+    QComboBox* bitTypeCombo;
     {
         bitPage = new QWidget;
         auto* vbox = new QVBoxLayout(bitPage);
         vbox->setSpacing(6);
 
-        auto* headerGroup = new QGroupBox("Cable Settings");
-        headerGroup->setStyleSheet(kGroupStyle);
-        auto* hg = new QGridLayout(headerGroup);
-        hg->setSpacing(4);
-        hg->addWidget(new QLabel("Name:"), 0, 0);
-        bitNameEdit = new QLineEdit;
-        bitNameEdit->setStyleSheet(kEdit);
-        hg->addWidget(bitNameEdit, 0, 1);
-        bitEnabledCheck = new QCheckBox("Enabled");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(bitEnabledCheck, kCheck);
-        hg->addWidget(bitEnabledCheck, 1, 0, 1, 2);
-        bitStatusLabel = new QLabel("Unplugged");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(bitStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
-        hg->addWidget(new QLabel("Status:"), 2, 0);
-        hg->addWidget(bitStatusLabel, 2, 1);
-        vbox->addWidget(headerGroup);
+        auto bitHeader = makeCableHeader(/*includeEnabled=*/true);
+        bitNameEdit = bitHeader.nameEdit;
+        bitEnabledCheck = bitHeader.enabledCheck;
+        bitStatusLabel = bitHeader.statusLabel;
+        bitTypeCombo = bitHeader.typeCombo;
+        vbox->addWidget(bitHeader.group);
 
         auto* bitSplit = new QHBoxLayout;
 
@@ -4099,33 +4208,99 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     QCheckBox* ptEnabledCheck;
     QLabel*    ptStatusLabel;
     SerialWidgets ptSerialWidgets;
+    QComboBox* ptTypeCombo;
     {
         ptPage = new QWidget;
         auto* vbox = new QVBoxLayout(ptPage);
         vbox->setSpacing(6);
 
-        auto* headerGroup = new QGroupBox("Cable Settings");
-        headerGroup->setStyleSheet(kGroupStyle);
-        auto* hg = new QGridLayout(headerGroup);
-        hg->setSpacing(4);
-        hg->addWidget(new QLabel("Name:"), 0, 0);
-        ptNameEdit = new QLineEdit;
-        ptNameEdit->setStyleSheet(kEdit);
-        hg->addWidget(ptNameEdit, 0, 1);
-        ptEnabledCheck = new QCheckBox("Enabled");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(ptEnabledCheck, kCheck);
-        hg->addWidget(ptEnabledCheck, 1, 0, 1, 2);
-        ptStatusLabel = new QLabel("Unplugged");
-        AetherSDR::ThemeManager::instance().applyStyleSheet(ptStatusLabel, "QLabel { color: {{color.text.label}}; font-size: 11px; }");
-        hg->addWidget(new QLabel("Status:"), 2, 0);
-        hg->addWidget(ptStatusLabel, 2, 1);
-        vbox->addWidget(headerGroup);
+        auto ptHeader = makeCableHeader(/*includeEnabled=*/true);
+        ptNameEdit = ptHeader.nameEdit;
+        ptEnabledCheck = ptHeader.enabledCheck;
+        ptStatusLabel = ptHeader.statusLabel;
+        ptTypeCombo = ptHeader.typeCombo;
+        vbox->addWidget(ptHeader.group);
 
         ptSerialWidgets = makeSerialGroup("Serial Parameters");
         vbox->addWidget(ptSerialWidgets.group);
 
         vbox->addStretch();
         stack->addWidget(ptPage);  // index 4
+    }
+
+    // Page 5: LDPA cable
+    QWidget* ldpaPage;
+    QLineEdit* ldpaNameEdit;
+    QCheckBox* ldpaEnabledCheck;
+    QLabel*    ldpaStatusLabel;
+    QComboBox* ldpaTypeCombo;
+    QComboBox* ldpaBandCombo;
+    QCheckBox* ldpaPreampCheck;
+    QComboBox* ldpaSourceCombo;
+    {
+        ldpaPage = new QWidget;
+        auto* vbox = new QVBoxLayout(ldpaPage);
+        vbox->setSpacing(6);
+
+        auto ldpaHeader = makeCableHeader(/*includeEnabled=*/true);
+        ldpaNameEdit = ldpaHeader.nameEdit;
+        ldpaEnabledCheck = ldpaHeader.enabledCheck;
+        ldpaStatusLabel = ldpaHeader.statusLabel;
+        ldpaTypeCombo = ldpaHeader.typeCombo;
+        vbox->addWidget(ldpaHeader.group);
+
+        auto* ldpaGroup = new QGroupBox("LDPA Settings");
+        ldpaGroup->setStyleSheet(kGroupStyle);
+        auto* lg = new QGridLayout(ldpaGroup);
+        lg->setSpacing(4);
+        lg->addWidget(new QLabel("Band:"), 0, 0);
+        ldpaBandCombo = new QComboBox;
+        ldpaBandCombo->addItems({"2m", "4m"});
+        ldpaBandCombo->setStyleSheet(kCombo);
+        lg->addWidget(ldpaBandCombo, 0, 1);
+        ldpaPreampCheck = new QCheckBox("Preamp");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(ldpaPreampCheck, kCheck);
+        lg->addWidget(ldpaPreampCheck, 1, 0, 1, 2);
+        lg->addWidget(new QLabel("Source:"), 2, 0);
+        ldpaSourceCombo = makeSourceCombo();
+        lg->addWidget(ldpaSourceCombo, 2, 1);
+        vbox->addWidget(ldpaGroup);
+
+        vbox->addStretch();
+        stack->addWidget(ldpaPage);  // index 5
+    }
+
+    // Page 6: Unconfigured cable (type is "invalid" or otherwise unrecognized —
+    // a real, present cable that hasn't been assigned a type yet, distinct
+    // from "nothing plugged in" at index 0)
+    QWidget* unconfiguredPage;
+    QLineEdit* unconfiguredNameEdit;
+    QLabel*    unconfiguredStatusLabel;
+    QComboBox* unconfiguredTypeCombo;
+    QPushButton* unconfiguredRemoveBtn;
+    {
+        unconfiguredPage = new QWidget;
+        auto* vbox = new QVBoxLayout(unconfiguredPage);
+        vbox->setSpacing(6);
+
+        auto unconfiguredHeader = makeCableHeader(/*includeEnabled=*/false);
+        unconfiguredNameEdit = unconfiguredHeader.nameEdit;
+        unconfiguredStatusLabel = unconfiguredHeader.statusLabel;
+        unconfiguredTypeCombo = unconfiguredHeader.typeCombo;
+        unconfiguredTypeCombo->setCurrentIndex(-1);  // force a real choice, no default
+        vbox->addWidget(unconfiguredHeader.group);
+
+        auto* note = new QLabel("Select a cable type to configure this device.");
+        note->setStyleSheet("QLabel { color: #606880; font-size: 12px; }");
+        note->setWordWrap(true);
+        vbox->addWidget(note);
+
+        unconfiguredRemoveBtn = new QPushButton("Remove This Cable");
+        unconfiguredRemoveBtn->setAutoDefault(false);
+        vbox->addWidget(unconfiguredRemoveBtn);
+
+        vbox->addStretch();
+        stack->addWidget(unconfiguredPage);  // index 6
     }
 
     hbox->addWidget(stack, 1);
@@ -4167,10 +4342,11 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
 
         if (t == "cat") {
             stack->setCurrentIndex(1);
-            QSignalBlocker b1(catNameEdit), b2(catEnabledCheck), b3(catSourceCombo), b4(catAutoReportCheck);
-            QSignalBlocker b5(catSerialWidgets.speed), b6(catSerialWidgets.data),
-                           b7(catSerialWidgets.parity), b8(catSerialWidgets.stop),
-                           b9(catSerialWidgets.flow);
+            QSignalBlocker b1(catNameEdit), b2(catEnabledCheck), b3(catSourceCombo),
+                           b4(catAutoReportCheck), b5(catTypeCombo);
+            QSignalBlocker b6(catSerialWidgets.speed), b7(catSerialWidgets.data),
+                           b8(catSerialWidgets.parity), b9(catSerialWidgets.stop),
+                           b10(catSerialWidgets.flow);
             catNameEdit->setText(cable.name);
             catEnabledCheck->setChecked(cable.enabled);
             catStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
@@ -4179,7 +4355,8 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
                 : "QLabel { color: #808080; font-size: 11px; }");
             catSourceCombo->setCurrentIndex(protoToSource(cable.source));
             catAutoReportCheck->setChecked(cable.autoReport);
-            
+            catTypeCombo->setCurrentIndex(protoToTypeIndex(t));
+
             catSerialWidgets.speed->setCurrentText(QString::number(cable.speed));
             catSerialWidgets.data->setCurrentText(QString::number(cable.dataBits));
             catSerialWidgets.parity->setCurrentText(cable.parity);
@@ -4188,7 +4365,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         } else if (t == "bcd" || t == "vbcd" || t == "bcd_vbcd") {
             stack->setCurrentIndex(2);
             QSignalBlocker b1(bcdNameEdit), b2(bcdEnabledCheck), b3(bcdSourceCombo),
-                           b4(bcdTypeCombo), b5(bcdPolarityCombo);
+                           b4(bcdTypeCombo), b5(bcdPolarityCombo), b6(bcdCableTypeCombo);
             bcdNameEdit->setText(cable.name);
             bcdEnabledCheck->setChecked(cable.enabled);
             bcdStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
@@ -4200,15 +4377,17 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
             else if (t == "bcd_vbcd") bcdTypeCombo->setCurrentIndex(2);
             else bcdTypeCombo->setCurrentIndex(0);
             bcdPolarityCombo->setCurrentIndex(cable.activeHigh ? 0 : 1);
+            bcdCableTypeCombo->setCurrentIndex(protoToTypeIndex(t));
         } else if (t == "bit") {
             stack->setCurrentIndex(3);
-            QSignalBlocker b1(bitNameEdit), b2(bitEnabledCheck);
+            QSignalBlocker b1(bitNameEdit), b2(bitEnabledCheck), b3(bitTypeCombo);
             bitNameEdit->setText(cable.name);
             bitEnabledCheck->setChecked(cable.enabled);
             bitStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
             bitStatusLabel->setStyleSheet(cable.present
                 ? "QLabel { color: #30d050; font-size: 11px; }"
                 : "QLabel { color: #808080; font-size: 11px; }");
+            bitTypeCombo->setCurrentIndex(protoToTypeIndex(t));
             if (bitIndexList->currentRow() < 0) {
                 QSignalBlocker blk(bitIndexList);
                 bitIndexList->setCurrentRow(0);
@@ -4216,24 +4395,50 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
             refreshBitDetail();
         } else if (t == "passthrough") {
             stack->setCurrentIndex(4);
-            QSignalBlocker b1(ptNameEdit), b2(ptEnabledCheck);
-            QSignalBlocker b3(ptSerialWidgets.speed), b4(ptSerialWidgets.data),
-                           b5(ptSerialWidgets.parity), b6(ptSerialWidgets.stop),
-                           b7(ptSerialWidgets.flow);
+            QSignalBlocker b1(ptNameEdit), b2(ptEnabledCheck), b3(ptTypeCombo);
+            QSignalBlocker b4(ptSerialWidgets.speed), b5(ptSerialWidgets.data),
+                           b6(ptSerialWidgets.parity), b7(ptSerialWidgets.stop),
+                           b8(ptSerialWidgets.flow);
             ptNameEdit->setText(cable.name);
             ptEnabledCheck->setChecked(cable.enabled);
             ptStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
             ptStatusLabel->setStyleSheet(cable.present
                 ? "QLabel { color: #30d050; font-size: 11px; }"
                 : "QLabel { color: #808080; font-size: 11px; }");
-            
+            ptTypeCombo->setCurrentIndex(protoToTypeIndex(t));
+
             ptSerialWidgets.speed->setCurrentText(QString::number(cable.speed));
             ptSerialWidgets.data->setCurrentText(QString::number(cable.dataBits));
             ptSerialWidgets.parity->setCurrentText(cable.parity);
             ptSerialWidgets.stop->setCurrentText(QString::number(cable.stopBits));
             ptSerialWidgets.flow->setCurrentText(cable.flowControl);
+        } else if (t == "ldpa") {
+            stack->setCurrentIndex(5);
+            QSignalBlocker b1(ldpaNameEdit), b2(ldpaEnabledCheck), b3(ldpaTypeCombo),
+                           b4(ldpaBandCombo), b5(ldpaPreampCheck), b6(ldpaSourceCombo);
+            ldpaNameEdit->setText(cable.name);
+            ldpaEnabledCheck->setChecked(cable.enabled);
+            ldpaStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
+            ldpaStatusLabel->setStyleSheet(cable.present
+                ? "QLabel { color: #30d050; font-size: 11px; }"
+                : "QLabel { color: #808080; font-size: 11px; }");
+            ldpaTypeCombo->setCurrentIndex(protoToTypeIndex(t));
+            ldpaBandCombo->setCurrentIndex(cable.ldpaBand == "4" ? 1 : 0);
+            ldpaPreampCheck->setChecked(cable.preamp);
+            ldpaSourceCombo->setCurrentIndex(protoToSource(cable.source));
         } else {
-            stack->setCurrentIndex(0);
+            // "invalid" or any other unrecognized type: a real, present cable
+            // that hasn't been assigned a type yet — distinct from "nothing
+            // plugged in" (index 0), which is handled by the isEmpty()/
+            // not-found guard above and by the cableRemoved handler.
+            stack->setCurrentIndex(6);
+            QSignalBlocker b1(unconfiguredNameEdit), b2(unconfiguredTypeCombo);
+            unconfiguredNameEdit->setText(cable.name);
+            unconfiguredStatusLabel->setText(cable.present ? "Plugged In" : "Unplugged");
+            unconfiguredStatusLabel->setStyleSheet(cable.present
+                ? "QLabel { color: #30d050; font-size: 11px; }"
+                : "QLabel { color: #808080; font-size: 11px; }");
+            unconfiguredTypeCombo->setCurrentIndex(-1);
         }
     };
 
@@ -4244,12 +4449,43 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     });
 
     // ── Wire model signals ──────────────────────────────────────────────
-    connect(cableModel, &UsbCableModel::cableAdded, this, [refreshList](const QString&) {
+    connect(cableModel, &UsbCableModel::cableAdded, this,
+            [refreshList, cableList, showCableProps, pendingTypeChangeSn](const QString& sn) {
         refreshList();
+        // A retype tears the old cable entry down and rebuilds it fresh
+        // (UsbCableModel::applyStatus), which drops the list selection along
+        // the way (see the cableRemoved handler below). Reselect and
+        // repopulate the detail panel so a successful retype doesn't leave
+        // it stuck on the empty-state page until manually re-clicked.
+        if (*pendingTypeChangeSn == sn) {
+            pendingTypeChangeSn->clear();
+            for (int i = 0; i < cableList->count(); ++i) {
+                if (cableList->item(i)->data(Qt::UserRole).toString() == sn) {
+                    cableList->setCurrentItem(cableList->item(i));
+                    break;
+                }
+            }
+            showCableProps(sn);
+        }
     });
-    connect(cableModel, &UsbCableModel::cableRemoved, this, [refreshList, stack](const QString&) {
+    connect(cableModel, &UsbCableModel::cableRemoved, this,
+            [refreshList, stack, pendingTypeChangeSn](const QString& sn) {
         refreshList();
         stack->setCurrentIndex(0);
+        // Defer the clear to the next event-loop tick: a genuine retype's own
+        // cableAdded for this serial fires synchronously right after this
+        // handler returns (same applyStatus() call) and clears the pointer
+        // itself first, so this is a no-op for that case. It only matters for
+        // a standalone removal unrelated to any pending retype, preventing a
+        // later unplug/replug's cableAdded from being mistaken for a retype
+        // completion.
+        if (*pendingTypeChangeSn == sn) {
+            QTimer::singleShot(0, [pendingTypeChangeSn, sn]() {
+                if (*pendingTypeChangeSn == sn) {
+                    pendingTypeChangeSn->clear();
+                }
+            });
+        }
     });
     connect(cableModel, &UsbCableModel::cableChanged, this,
             [refreshList, cableList, showCableProps](const QString& sn) {
@@ -4279,6 +4515,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     connect(catAutoReportCheck, &QCheckBox::toggled, this, [sendCatProp](bool on) {
         sendCatProp("auto_report", on ? "1" : "0");
     });
+    wireTypeCombo(catTypeCombo);
 
     connect(catSerialWidgets.speed, &QComboBox::currentTextChanged, this, [sendCatProp](const QString& val) { sendCatProp("speed", val); });
     connect(catSerialWidgets.data, &QComboBox::currentTextChanged, this, [sendCatProp](const QString& val) { sendCatProp("data_bits", val); });
@@ -4311,6 +4548,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
             [sendBcdProp, sourceToProto](const QString& text) {
         sendBcdProp("source", sourceToProto(text));
     });
+    wireTypeCombo(bcdCableTypeCombo);
 
     // Bit cable header (whole-cable name/enable, cableModel->sendSet)
     auto sendBitProp = [cableModel, cableList](const QString& key, const QString& val) {
@@ -4324,6 +4562,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     connect(bitEnabledCheck, &QCheckBox::toggled, this, [sendBitProp](bool on) {
         sendBitProp("enable", on ? "1" : "0");
     });
+    wireTypeCombo(bitTypeCombo);
 
     // Bit detail fields (per-bit, cableModel->sendSetBit against *currentBit)
     auto sendBitFieldProp = [cableModel, cableList, currentBit](const QString& key, const QString& val) {
@@ -4394,6 +4633,49 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     });
     connect(ptEnabledCheck, &QCheckBox::toggled, this, [sendPtProp](bool on) {
         sendPtProp("enable", on ? "1" : "0");
+    });
+    wireTypeCombo(ptTypeCombo);
+
+    // LDPA
+    auto sendLdpaProp = [cableModel, cableList](const QString& key, const QString& val) {
+        auto* item = cableList->currentItem();
+        if (!item) return;
+        cableModel->sendSet(item->data(Qt::UserRole).toString(), key, val);
+    };
+    connect(ldpaNameEdit, &QLineEdit::editingFinished, this, [ldpaNameEdit, sendLdpaProp]() {
+        sendLdpaProp("name", QString(ldpaNameEdit->text()).replace(' ', QChar(0x7F)));
+    });
+    connect(ldpaEnabledCheck, &QCheckBox::toggled, this, [sendLdpaProp](bool on) {
+        sendLdpaProp("enable", on ? "1" : "0");
+    });
+    wireTypeCombo(ldpaTypeCombo);
+    connect(ldpaBandCombo, &QComboBox::currentIndexChanged, this,
+            [sendLdpaProp](int idx) {
+        sendLdpaProp("band", idx == 1 ? "4" : "2");
+    });
+    connect(ldpaPreampCheck, &QCheckBox::toggled, this, [sendLdpaProp](bool on) {
+        sendLdpaProp("preamp", on ? "1" : "0");
+    });
+    connect(ldpaSourceCombo, &QComboBox::currentTextChanged, this,
+            [sendLdpaProp, sourceToProto](const QString& text) {
+        sendLdpaProp("source", sourceToProto(text));
+    });
+
+    // Unconfigured cable
+    auto sendUnconfiguredProp = [cableModel, cableList](const QString& key, const QString& val) {
+        auto* item = cableList->currentItem();
+        if (!item) return;
+        cableModel->sendSet(item->data(Qt::UserRole).toString(), key, val);
+    };
+    connect(unconfiguredNameEdit, &QLineEdit::editingFinished, this,
+            [unconfiguredNameEdit, sendUnconfiguredProp]() {
+        sendUnconfiguredProp("name", QString(unconfiguredNameEdit->text()).replace(' ', QChar(0x7F)));
+    });
+    wireTypeCombo(unconfiguredTypeCombo);
+    connect(unconfiguredRemoveBtn, &QPushButton::clicked, this, [cableModel, cableList]() {
+        auto* item = cableList->currentItem();
+        if (!item) return;
+        cableModel->sendRemove(item->data(Qt::UserRole).toString());
     });
 
     connect(ptSerialWidgets.speed, &QComboBox::currentTextChanged, this, [sendPtProp](const QString& val) { sendPtProp("speed", val); });

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3699,10 +3699,16 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
 
     // Helper: create source combo (shared across CAT, BCD, Bit)
     auto makeSourceCombo = []() {
-        auto* combo = new QComboBox;
+        // GuardedComboBox: this combo lives in the scroll-wrapped USB Cables
+        // tab and sends a destructive `source=` set on change, so a stray
+        // wheel-scroll must not silently re-route a live cable's source.
+        auto* combo = new GuardedComboBox;
         combo->addItems({"None", "TX Pan", "TX Slice", "Active Slice",
                          "TX Ant", "RX Ant", "Ordinal Slice"});
         combo->setStyleSheet(kCombo);
+        combo->setAccessibleName("Cable source");
+        combo->setAccessibleDescription(
+            "Signal source routed to this cable");
         return combo;
     };
     // Map source display name → protocol value
@@ -3803,6 +3809,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         hg->addWidget(new QLabel("Name:"), row, 0);
         auto* nameEdit = new QLineEdit;
         nameEdit->setStyleSheet(kEdit);
+        nameEdit->setAccessibleName("Cable name");
         hg->addWidget(nameEdit, row, 1);
         ++row;
 
@@ -3844,16 +3851,26 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
     // pointer before the deferred callback runs; (2) a bounded timeout armed
     // on send, in case the radio never echoes back at all.
     auto pendingTypeChangeSn = std::make_shared<QString>();
-    auto sendCableType = [cableModel, cableList, pendingTypeChangeSn](const QString& proto) {
+    // Generation counter so the bounded timeout can't clear a *newer* pending.
+    // Each send bumps the generation; the timer captures its own generation and
+    // only clears if it's still current. Without this, retyping the same serial
+    // twice within 5s would let the first timer clear the second retype's
+    // pending (QTimer::singleShot is fire-and-forget and can't be cancelled),
+    // reintroducing the stuck-panel bug on exactly the lossy radios the timeout
+    // exists to protect.
+    auto pendingTypeChangeGen = std::make_shared<quint64>(0);
+    auto sendCableType = [cableModel, cableList, pendingTypeChangeSn,
+                          pendingTypeChangeGen](const QString& proto) {
         auto* item = cableList->currentItem();
         if (!item) {
             return;
         }
         const QString sn = item->data(Qt::UserRole).toString();
         *pendingTypeChangeSn = sn;
+        const quint64 gen = ++(*pendingTypeChangeGen);
         cableModel->sendSet(sn, "type", proto);
-        QTimer::singleShot(5000, [pendingTypeChangeSn, sn]() {
-            if (*pendingTypeChangeSn == sn) {
+        QTimer::singleShot(5000, [pendingTypeChangeSn, pendingTypeChangeGen, gen]() {
+            if (*pendingTypeChangeGen == gen) {
                 pendingTypeChangeSn->clear();
             }
         });
@@ -3981,14 +3998,23 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         auto* bg = new QGridLayout(bcdGroup);
         bg->setSpacing(4);
         bg->addWidget(new QLabel("BCD Type:"), 0, 0);
-        bcdTypeCombo = new QComboBox;
+        // GuardedComboBox: scroll-wrapped tab + destructive `type=` on change.
+        // NB this sub-type combo sends `type=` via sendBcdProp, which does NOT
+        // arm pendingTypeChangeSn. That is correct only because
+        // UsbCableModel::normalizeTypeFamily() collapses bcd/vbcd/bcd_vbcd to
+        // one family, so a sub-type change updates in place (cableChanged) and
+        // never triggers the remove+recreate path that would need a reselect.
+        // If that invariant ever changes, route this through sendCableType.
+        bcdTypeCombo = new GuardedComboBox;
         bcdTypeCombo->addItems({"HF (bcd)", "VHF (vbcd)", "HF+VHF (bcd_vbcd)"});
         bcdTypeCombo->setStyleSheet(kCombo);
+        bcdTypeCombo->setAccessibleName("BCD sub-type");
         bg->addWidget(bcdTypeCombo, 0, 1);
         bg->addWidget(new QLabel("Polarity:"), 1, 0);
-        bcdPolarityCombo = new QComboBox;
+        bcdPolarityCombo = new GuardedComboBox;  // destructive polarity= on change
         bcdPolarityCombo->addItems({"Active High", "Active Low"});
         bcdPolarityCombo->setStyleSheet(kCombo);
+        bcdPolarityCombo->setAccessibleName("BCD polarity");
         bg->addWidget(bcdPolarityCombo, 1, 1);
         bg->addWidget(new QLabel("Source:"), 2, 0);
         bcdSourceCombo = makeSourceCombo();
@@ -4073,6 +4099,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         };
 
         bitWidgets.enabled = new QCheckBox;
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bitWidgets.enabled, kCheck);
         addRow("Enabled:", bitWidgets.enabled);
 
         bitWidgets.source = makeSourceCombo();
@@ -4109,6 +4136,7 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         addRow("Polarity:", bitWidgets.polarity);
 
         bitWidgets.pttDependent = new QCheckBox;
+        AetherSDR::ThemeManager::instance().applyStyleSheet(bitWidgets.pttDependent, kCheck);
         addRow("PTT Dependent:", bitWidgets.pttDependent);
 
         bitWidgets.pttDelay = new QSpinBox;
@@ -4254,9 +4282,12 @@ QWidget* RadioSetupDialog::buildUsbCablesTab()
         auto* lg = new QGridLayout(ldpaGroup);
         lg->setSpacing(4);
         lg->addWidget(new QLabel("Band:"), 0, 0);
-        ldpaBandCombo = new QComboBox;
+        // GuardedComboBox: scroll-wrapped tab + destructive `band=` on change.
+        ldpaBandCombo = new GuardedComboBox;
         ldpaBandCombo->addItems({"2m", "4m"});
         ldpaBandCombo->setStyleSheet(kCombo);
+        ldpaBandCombo->setAccessibleName("LDPA band");
+        ldpaBandCombo->setAccessibleDescription("LDPA amplifier band (2m or 4m)");
         lg->addWidget(ldpaBandCombo, 0, 1);
         ldpaPreampCheck = new QCheckBox("Preamp");
         AetherSDR::ThemeManager::instance().applyStyleSheet(ldpaPreampCheck, kCheck);

--- a/src/models/UsbCableModel.cpp
+++ b/src/models/UsbCableModel.cpp
@@ -209,6 +209,12 @@ void UsbCableModel::parseLdpaStatus(UsbCable& cable, const QMap<QString, QString
         } else if (k == "preamp") {
             cable.preamp = (v == "1");
         } else if (k == "source") {
+            // AetherSDR extension beyond the FlexLib authority (Principle I):
+            // FlexLib's UsbLdpaCable.cs writes source= on set but does NOT
+            // parse it back from status (only band/preamp are read). We read it
+            // in case the radio echoes it, but the value is unverified against
+            // the reference client — harmless if the radio never sends it. See
+            // the CAT/BCD/Bit paths, where FlexLib does round-trip source=.
             cable.source = v;
         } else if (k == "source_rx_ant") {
             cable.sourceRxAnt = v;

--- a/src/models/UsbCableModel.cpp
+++ b/src/models/UsbCableModel.cpp
@@ -12,14 +12,56 @@ QString UsbCableModel::decodeSpaces(const QString& s)
     return QString(s).replace(QChar(0x7F), ' ');
 }
 
+QString UsbCableModel::normalizeTypeFamily(const QString& type)
+{
+    if (type == "bcd" || type == "vbcd" || type == "bcd_vbcd") {
+        return "bcd";
+    }
+    return type;
+}
+
 // ── Status parsing ──────────────────────────────────────────────────────────
 
 void UsbCableModel::applyStatus(const QString& serialNumber,
                                  const QMap<QString, QString>& kvs)
 {
     bool isNew = !m_cables.contains(serialNumber);
+
+    // A type change on an already-known cable is a distinct lifecycle event,
+    // not an in-place mutation — mirrors FlexLib's UsbCable.CableType setter,
+    // which removes the old cable object and lets the radio's next status
+    // reconstruct a brand-new one of the new type (UsbCable.cs / Radio.cs
+    // ParseUsbCableStatus). Without this, stale fields from the old type
+    // (e.g. cable.band, cable.bits[]) would survive into the new type's page.
+    // Compared by family (normalizeTypeFamily) so a BCD sub-type change
+    // (bcd <-> vbcd <-> bcd_vbcd) doesn't trip a spurious recreate — FlexLib's
+    // setter compares UsbCableType, where all three are the same value.
+    UsbCable preservedBase;
+    bool isFamilyChange = false;
+    if (!isNew && kvs.contains("type") &&
+        normalizeTypeFamily(kvs["type"]) != normalizeTypeFamily(m_cables[serialNumber].type)) {
+        isFamilyChange = true;
+        preservedBase = m_cables[serialNumber];
+        m_cables.remove(serialNumber);
+        emit cableRemoved(serialNumber);
+        isNew = true;
+    }
+
     auto& cable = m_cables[serialNumber];
     cable.serialNumber = serialNumber;
+
+    // Radio-assigned identity fields survive a type-change recreate — FlexLib's
+    // Radio.cs ParseUsbCableStatus reuses these across the change rather than
+    // blanking them, so a partial retype-confirmation status (missing
+    // name=/enable=) doesn't clear the user's cable name/enabled flag until a
+    // full status arrives. parseBaseStatus() below overwrites these if the
+    // status does carry fresh values.
+    if (isFamilyChange) {
+        cable.name = preservedBase.name;
+        cable.enabled = preservedBase.enabled;
+        cable.present = preservedBase.present;
+        cable.loggingEnabled = preservedBase.loggingEnabled;
+    }
 
     // Detect type on first status
     if (kvs.contains("type")) {
@@ -66,6 +108,9 @@ void UsbCableModel::applyStatus(const QString& serialNumber,
              cable.type == "bcd_vbcd")    parseBcdStatus(cable, kvs);
     else if (cable.type == "bit")         parseBitStatus(cable, kvs);
     else if (cable.type == "passthrough") parsePassthroughStatus(cable, kvs);
+    else if (cable.type == "ldpa") {
+        parseLdpaStatus(cable, kvs);
+    }
 
     if (isNew) {
         qDebug() << "UsbCableModel: new cable" << serialNumber << "type:" << cable.type
@@ -151,6 +196,27 @@ void UsbCableModel::parsePassthroughStatus(UsbCable& cable, const QMap<QString, 
         else if (k == "parity")         cable.parity = v;
         else if (k == "stop_bits")      cable.stopBits = v.toInt();
         else if (k == "flow_control")   cable.flowControl = v;
+    }
+}
+
+void UsbCableModel::parseLdpaStatus(UsbCable& cable, const QMap<QString, QString>& kvs)
+{
+    for (auto it = kvs.begin(); it != kvs.end(); ++it) {
+        const QString& k = it.key();
+        const QString& v = it.value();
+        if (k == "band") {
+            cable.ldpaBand = v;  // "2" or "4"
+        } else if (k == "preamp") {
+            cable.preamp = (v == "1");
+        } else if (k == "source") {
+            cable.source = v;
+        } else if (k == "source_rx_ant") {
+            cable.sourceRxAnt = v;
+        } else if (k == "source_tx_ant") {
+            cable.sourceTxAnt = v;
+        } else if (k == "source_slice") {
+            cable.sourceSlice = v;
+        }
     }
 }
 

--- a/src/models/UsbCableModel.h
+++ b/src/models/UsbCableModel.h
@@ -92,8 +92,14 @@ private:
     void parseBcdStatus(UsbCable& cable, const QMap<QString, QString>& kvs);
     void parseBitStatus(UsbCable& cable, const QMap<QString, QString>& kvs);
     void parsePassthroughStatus(UsbCable& cable, const QMap<QString, QString>& kvs);
+    void parseLdpaStatus(UsbCable& cable, const QMap<QString, QString>& kvs);
 
     static QString decodeSpaces(const QString& s);
+
+    // Collapses BCD's sub-types (bcd/vbcd/bcd_vbcd) to one family so a
+    // sub-type change isn't mistaken for a type change — matches FlexLib's
+    // StringToUsbCableType, which maps all three to UsbCableType.BCD.
+    static QString normalizeTypeFamily(const QString& type);
 
     QMap<QString, UsbCable> m_cables;
 };

--- a/tests/usb_cable_model_test.cpp
+++ b/tests/usb_cable_model_test.cpp
@@ -1,0 +1,148 @@
+#include "models/UsbCableModel.h"
+
+#include <QCoreApplication>
+#include <QMap>
+#include <QSignalSpy>
+#include <QString>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+QMap<QString, QString> kv(std::initializer_list<std::pair<QString, QString>> pairs)
+{
+    QMap<QString, QString> m;
+    for (const auto& p : pairs) m.insert(p.first, p.second);
+    return m;
+}
+
+void testTypeChangeEmitsRemovedThenAdded()
+{
+    UsbCableModel model;
+    QSignalSpy addedSpy(&model, &UsbCableModel::cableAdded);
+    QSignalSpy removedSpy(&model, &UsbCableModel::cableRemoved);
+    QSignalSpy changedSpy(&model, &UsbCableModel::cableChanged);
+
+    model.applyStatus("SN1", kv({{"type", "invalid"}, {"name", "New Cable"}}));
+    report("first status for a new cable emits cableAdded",
+           addedSpy.count() == 1 && removedSpy.count() == 0);
+
+    addedSpy.clear();
+    model.applyStatus("SN1", kv({{"type", "cat"}, {"speed", "9600"}}));
+    report("retyping an existing cable emits cableRemoved then cableAdded, not cableChanged",
+           removedSpy.count() == 1 && addedSpy.count() == 1 && changedSpy.count() == 0);
+}
+
+void testStaleFieldsDoNotSurviveRetype()
+{
+    UsbCableModel model;
+
+    model.applyStatus("SN1", kv({{"type", "cat"}, {"auto_report", "0"}, {"speed", "38400"}}));
+    report("cat cable initial fields set (auto_report=0, speed=38400)",
+           !model.cables()["SN1"].autoReport && model.cables()["SN1"].speed == 38400);
+
+    model.applyStatus("SN1", kv({{"type", "bit"}}));
+    const auto& cable = model.cables()["SN1"];
+    report("retype to bit resets autoReport to struct default (true)", cable.autoReport == true);
+    report("retype to bit resets speed to struct default (9600)", cable.speed == 9600);
+    report("retype to bit updates cable.type", cable.type == "bit");
+}
+
+void testRoutineResyncOnlyEmitsChanged()
+{
+    UsbCableModel model;
+    model.applyStatus("SN1", kv({{"type", "cat"}, {"speed", "9600"}}));
+
+    QSignalSpy addedSpy(&model, &UsbCableModel::cableAdded);
+    QSignalSpy removedSpy(&model, &UsbCableModel::cableRemoved);
+    QSignalSpy changedSpy(&model, &UsbCableModel::cableChanged);
+
+    // Radio re-sends the same type on a routine status resync — no churn.
+    model.applyStatus("SN1", kv({{"type", "cat"}, {"speed", "19200"}}));
+    report("identical type= on resync only emits cableChanged",
+           changedSpy.count() == 1 && addedSpy.count() == 0 && removedSpy.count() == 0);
+    report("resync still applies the updated field", model.cables()["SN1"].speed == 19200);
+}
+
+void testLdpaStatusParsing()
+{
+    UsbCableModel model;
+    model.applyStatus("SN1", kv({
+        {"type", "ldpa"},
+        {"band", "4"},
+        {"preamp", "1"},
+        {"source", "active_slice"},
+    }));
+
+    const auto& cable = model.cables()["SN1"];
+    report("ldpa band parsed", cable.ldpaBand == "4");
+    report("ldpa preamp parsed", cable.preamp == true);
+    report("ldpa source parsed", cable.source == "active_slice");
+}
+
+void testBcdSubtypeChangeDoesNotRecreate()
+{
+    UsbCableModel model;
+    model.applyStatus("SN1", kv({{"type", "bcd"}, {"name", "My BCD"}}));
+
+    QSignalSpy addedSpy(&model, &UsbCableModel::cableAdded);
+    QSignalSpy removedSpy(&model, &UsbCableModel::cableRemoved);
+    QSignalSpy changedSpy(&model, &UsbCableModel::cableChanged);
+
+    // bcd/vbcd/bcd_vbcd are one UsbCableType family in FlexLib
+    // (StringToUsbCableType collapses all three to BCD) -- a sub-type change
+    // between them must not trigger a remove/recreate.
+    model.applyStatus("SN1", kv({{"type", "vbcd"}, {"polarity", "active_low"}}));
+    report("bcd sub-type change only emits cableChanged, not remove/recreate",
+           changedSpy.count() == 1 && addedSpy.count() == 0 && removedSpy.count() == 0);
+    report("bcd sub-type change updates cable.type", model.cables()["SN1"].type == "vbcd");
+    report("bcd sub-type change preserves unrelated fields (name)",
+           model.cables()["SN1"].name == "My BCD");
+}
+
+void testBaseFieldsSurvivePartialRetypeConfirm()
+{
+    UsbCableModel model;
+    model.applyStatus("SN1", kv({
+        {"type", "cat"}, {"name", "My Cable"},
+        {"enable", "1"}, {"plugged_in", "1"}, {"log", "1"},
+    }));
+
+    // A real type-family change (cat -> bit), but the confirming status is
+    // partial and omits name=/enable=/plugged_in=/log= -- FlexLib's Radio.cs
+    // ParseUsbCableStatus reuses these base identity fields across a type
+    // change rather than blanking them, so they must survive the recreate.
+    model.applyStatus("SN1", kv({{"type", "bit"}}));
+    const auto& cable = model.cables()["SN1"];
+    report("partial retype confirm preserves name", cable.name == "My Cable");
+    report("partial retype confirm preserves enabled", cable.enabled == true);
+    report("partial retype confirm preserves present", cable.present == true);
+    report("partial retype confirm preserves loggingEnabled", cable.loggingEnabled == true);
+    report("partial retype confirm still updates type", cable.type == "bit");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    testTypeChangeEmitsRemovedThenAdded();
+    testStaleFieldsDoNotSurviveRetype();
+    testRoutineResyncOnlyEmitsChanged();
+    testLdpaStatusParsing();
+    testBcdSubtypeChangeDoesNotRecreate();
+    testBaseFieldsSurvivePartialRetypeConfirm();
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4034 — Settings → USB Cables had no way to set or change a cable's type. The only place `type=` was ever sent was the BCD page's sub-type combo (bcd/vbcd/bcd_vbcd — a sub-type *within* BCD, not a top-level selector). A freshly-plugged, never-configured cable comes up as `invalid`, and because the dialog didn't recognize that type, it fell through to the same "No USB cables detected" empty-state page shown when nothing is plugged in at all — even though the cable correctly appeared in the cable list.

Adds a "Cable Type:" selector (CAT/Bit/BCD/LDPA/Passthrough) to every cable page, a new Unconfigured page for untyped cables, and a new LDPA page (previously entirely unhandled, despite its status fields already existing on the model struct).

Verified against FlexRadio's actual FlexLib C# SDK (version-matched to our test radio's firmware, 4.2.20.41343) — this project's protocol authority per `CONSTITUTION.md` Principle I. Confirmed:
- `UsbCableType` is a 5-value user-facing enum (`CAT, Bit, BCD, LDPA, Passthrough`); `Invalid` is the unconfigured sentinel, not a menu entry.
- FlexLib's `CableType` setter never mutates a cable's type in place — it removes the old cable object first, and the radio's next status for that serial number is parsed as a brand-new object. `UsbCableModel::applyStatus()` mirrors this now instead of mutating the existing struct in place (which would have let stale fields from the old type leak into the new type's page).
- Switching to BCD sends bare `type=bcd`, letting the existing `bcdTypeCombo` refine the sub-type afterward — matches FlexLib's own documented default-then-refine behavior.

## Constitution principle honored

Principle I — "FlexLib Is The Protocol Authority." The type-change lifecycle behavior (remove old object, reconstruct fresh on next status) is verified directly against FlexLib's `UsbCable.cs`/`Radio.cs` rather than inferred from AetherSDR's existing (and, it turned out, divergent) in-place-mutation behavior.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio — **not yet**. No USB cable available on our end to exercise a live retype against; will need the same "share a build artifact with a volunteer tester" path used for #3607/#4033 before merging.
- [x] Existing tests pass (CI) — full local suite (58/58) green, including the new `usb_cable_model_test`
- [x] New test coverage: `tests/usb_cable_model_test.cpp` — remove/recreate lifecycle on retype, stale-field clearing, routine-resync no-churn, LDPA status parsing (11/11 assertions)
- [x] Reproduction steps documented (see #4034)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no persistence added, all state lives in the existing per-cable radio-side model
- [x] Code is clean-room — FlexLib reference is the project's own sanctioned protocol authority (Principle I), not decompiled/reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — n/a, no meter UI touched
- [ ] Documentation updated if user-visible behavior changed — not done; can add if reviewers want a docs note
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a