### PR TITLE
fix(core): QRZ login broken end-to-end since #3990

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1224,6 +1224,17 @@ endif()
 if(Qt6Keychain_FOUND)
     target_compile_definitions(AetherSDR PRIVATE HAVE_KEYCHAIN)
     target_link_libraries(AetherSDR PRIVATE Qt6Keychain::Qt6Keychain)
+    # Local Windows builds run straight from the build dir with no packaging
+    # step — windeployqt, which stages qt6keychain.dll for the installer, isn't
+    # involved — so the DLL needs to land next to the exe or the app fails to
+    # start with "qt6keychain.dll was not found".
+    if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/third_party/qtkeychain/bin/qt6keychain.dll")
+        add_custom_command(TARGET AetherSDR POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${CMAKE_SOURCE_DIR}/third_party/qtkeychain/bin/qt6keychain.dll"
+                "$<TARGET_FILE_DIR:AetherSDR>"
+        )
+    endif()
 endif()
 
 if(Qt6DBus_FOUND)

--- a/README.md
+++ b/README.md
@@ -184,13 +184,19 @@ binaries ship 6.8.3 LTS).
 :: 2. Generate the single-precision FFTW import lib (needed by NR4/libspecbleach)
 powershell -File scripts\setup\setup-fftw.ps1
 
-:: 3. Configure. Ninja is required: the default Visual Studio generator is
+:: 3. Build qtkeychain (needed for QRZ/SmartLink credential persistence).
+::    Downloads source and builds it against your Qt kit into third_party\qtkeychain\.
+::    Skip this step and the build still succeeds, but QRZ/SmartLink passwords
+::    won't be saved between runs.
+powershell -File scripts\setup\setup-qtkeychain.ps1
+
+:: 4. Configure. Ninja is required: the default Visual Studio generator is
 ::    multi-config (it ignores CMAKE_BUILD_TYPE) and takes a different
 ::    manifest-embed path. Point CMAKE_PREFIX_PATH at your Qt kit so
 ::    find_package(Qt6) resolves.
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="C:/Qt/6.8.3/msvc2022_64"
 
-:: 4. Build
+:: 5. Build
 cmake --build build --target AetherSDR
 ```
 

--- a/src/core/QrzClient.cpp
+++ b/src/core/QrzClient.cpp
@@ -218,6 +218,10 @@ QrzClient::ParsedResponse QrzClient::parseXml(const QByteArray& xml)
             const auto name = r.name();
             if (name == QLatin1String("Session")) { block = Block::Session; continue; }
             if (name == QLatin1String("Callsign")) { block = Block::Callsign; continue; }
+            if (block == Block::None)
+                continue;  // outside any recognized block (e.g. the <QRZDatabase> root) —
+                           // readElementText() would read to ITS end tag and swallow every
+                           // child, including <Session>/<Callsign>, before we ever see them
 
             const QString text = r.readElementText(QXmlStreamReader::SkipChildElements).trimmed();
             if (block == Block::Session) {


### PR DESCRIPTION
## What was broken

PR #3990 added QRZ callsign lookup, but the login path was broken end-to-end — verified by testing against a real QRZ.com account.

### 1. Every QRZ XML response failed to parse (`src/core/QrzClient.cpp`)

`QrzClient::parseXml()` walks `QXmlStreamReader` tokens, special-casing `<Session>` and `<Callsign>` start tags. Every other start tag falls through to `r.readElementText(QXmlStreamReader::SkipChildElements)`.

The problem: every QRZ response is wrapped in a root `<QRZDatabase>` element. That root tag is the *first* `StartElement` the loop sees, and it doesn't match `"Session"` or `"Callsign"` — so the loop calls `readElementText(SkipChildElements)` on the **root itself**. Per Qt's docs that reads "until the corresponding `EndElement`", i.e. it consumes and discards the entire rest of the document (including the nested `<Session><Key>…</Key></Session>` block) before the loop ever gets a chance to inspect it.

Net effect: `sessionKey`/`sessionError`/`info` come back empty for *every* login and lookup response, valid credentials or not, so every login attempt reported `"QRZ login rejected (no session key)"`.

Fix: skip start tags encountered before entering a recognized block instead of feeding them to `readElementText`, so the root wrapper is passed over rather than consumed.

Note: `tests/qrz_callsign_test.cpp` (added in #3990) covers callsign regex/spotter logic but never exercises `parseXml()` against a realistic root-wrapped response, which is how this shipped.

### 2. Windows source builds silently compiled out credential persistence, and even with it enabled, the app couldn't find the DLL

Found while confirming fix #1 on a real Windows 11 build:

- The README's "Windows 11" build steps never run `scripts/setup/setup-qtkeychain.ps1`, so `find_package(Qt6Keychain)` fails silently (`REQUIRE_KEYCHAIN` defaults `OFF`), `HAVE_KEYCHAIN` never gets defined, and the QRZ password is never saved — `CallsignLookupService::savePassword()`/`loadPasswordFromKeychain()` become no-ops. The Setup dialog's "Test Login" button still worked because it bypasses the keychain and tests raw typed credentials directly, which masked the gap: real lookups (`View → Callsign Lookup`) always got `AuthFailed` (empty password) and silently fell back to offline `cty.dat` prefix data, appearing as "QRZ.com unavailable".
- After staging qtkeychain and confirming `Qt6Keychain found` in the CMake configure log, running straight from the build directory still failed with "qt6keychain.dll was not found" — `windeployqt` (which the Windows installer CI job manually feeds the DLL through, see `.github/workflows/windows-installer.yml`) isn't part of a plain local build, so nothing put the DLL next to the exe.

Fix: add the `setup-qtkeychain.ps1` step to the README's Windows instructions, and add a `WIN32`-guarded `POST_BUILD` step in `CMakeLists.txt` that copies `qt6keychain.dll` next to the built exe when present, so a local dev build gets working persistence without a manual copy.

## Test plan

- [x] Built on Windows 11 (MSVC 2022, Qt 6.8.3) with qtkeychain staged via `setup-qtkeychain.ps1`
- [x] Radio Setup → QRZ tab → Test Login succeeds with a real QRZ.com account (previously always failed with "no session key")
- [x] Password persists across closing/reopening the Setup dialog (previously lost every time — confirmed root cause was the missing keychain DLL/build step, not app logic)
- [x] View → Callsign Lookup → enter callsign → Lookup returns real QRZ.com data (previously always fell back to "QRZ.com unavailable" prefix-only data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)