### PR TITLE
refactor(build): aetherd RFC step 1 — extract libaethercore + IRadioBackend prep (#3849)

### DIFF
--- a/.github/workflows/engine-boundary.yml
+++ b/.github/workflows/engine-boundary.yml
@@ -1,0 +1,37 @@
+name: Engine Boundary Check
+
+# aetherd-migration ratchet (docs/aetherd-headless-engine-design.md §10):
+# the engine (src/core/ + src/models/) must never depend on the UI —
+# no gui/ header includes, no QtWidgets. Known legacy offenders are
+# tracked in tools/check_engine_boundary.py and warn without blocking;
+# NEW violations fail the job (--strict). The legacy lists only shrink.
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "src/core/**"
+      - "src/models/**"
+      - "tools/check_engine_boundary.py"
+      - ".github/workflows/engine-boundary.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  engine-boundary:
+    name: Engine/UI dependency direction
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      # Full-tree scan (fast, stdlib-only): findings annotate inline;
+      # only non-legacy violations fail the job.
+      - name: Run engine-boundary check
+        run: python tools/check_engine_boundary.py --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ When helping with AetherSDR:
 - Flag any proposal that would break slice 0 RX flow
 - If unsure about protocol behavior → ask for logs/wireshark captures first
 - **Use `AppSettings`, never `QSettings`** — see "Settings Persistence" below
+- **New engine code goes in `libaethercore`** (`src/core/` or `src/models/`),
+  exposed to the UI through models — never via a new gui→core header include.
+  See "Build targets" and "In-flight: aetherd" under Architecture Overview.
 - **Read `CONTRIBUTING.md`** for full contributor guidelines, coding conventions,
   and the AI-to-AI debugging protocol (open a GitHub issue for cross-agent coordination)
 - **Sign every commit you author.** `main` enforces `required_signatures`, so a
@@ -230,7 +233,26 @@ The accepted RFC at
 (tracking issue #3849) splits this codebase into an engine library
 (`libaethercore`), a headless engine daemon (`aetherd`), and thin UI
 clients, with pluggable radio backends (`IRadioBackend`). Implementation
-follows the RFC's §10 staged order; **no step has landed yet**.
+follows the RFC's §10 staged order; **step 1 (`libaethercore`) has
+landed** — the engine is a static library, the app is a shell that links
+it. Steps 2+ have not landed.
+
+**Build targets (post-RFC step 1):**
+
+| Target | Contents | May link |
+|---|---|---|
+| `libaethercore` (`aethercore`) | `src/core/` + `src/models/` — the engine | Qt Core/Network/Multimedia/WebSockets/SerialPort/DBus, the DSP + third-party libs. **Never `gui/`; QtWidgets only via the tracked-legacy files below, shrinking to zero** |
+| `AetherSDR` | `src/gui/` + `main.cpp` — the desktop app | `aethercore` + Qt Widgets + qgeoview + QRhi private |
+
+The engine→gui dependency direction is CI-enforced
+(`tools/check_engine_boundary.py`, `engine-boundary.yml`, `--strict`): no
+`core/`/`models/` file may include a `gui/` header (**EB1 — now zero,
+any finding is an error**), nor use QtWidgets (**EB2** — a shrinking
+tracked-legacy set warns, new usage errors). If your change trips the
+check, restructure the change — do not move the file, weaken the check,
+or add an exemption. Engine code that needs a UI callback defines a
+gui-free interface in `core/` (e.g. `IConnectionAutomation`) that the gui
+implements — never a `gui/` include.
 
 **Until migration rules appear in this file, nothing changes for you.**
 Do not pre-emptively restructure code toward the RFC — no new engine/UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,28 @@ full thread diagram, data flow, cross-thread signal map, and GPU rendering notes
 Worker threads communicate exclusively via auto-queued signals. Never hold
 a mutex in the audio callback.
 
+### In-flight: aetherd engine/UI decoupling (RFC accepted 2026-07-04)
+
+The accepted RFC at
+[`docs/aetherd-headless-engine-design.md`](docs/aetherd-headless-engine-design.md)
+(tracking issue #3849) splits this codebase into an engine library
+(`libaethercore`), a headless engine daemon (`aetherd`), and thin UI
+clients, with pluggable radio backends (`IRadioBackend`). Implementation
+follows the RFC's §10 staged order; **no step has landed yet**.
+
+**Until migration rules appear in this file, nothing changes for you.**
+Do not pre-emptively restructure code toward the RFC — no new engine/UI
+seams, no backend interfaces, no speculative library targets. Each
+migration step lands together with an update to this file stating the new
+rules (pre-drafted in
+[`docs/aetherd-agents-md-staging.md`](docs/aetherd-agents-md-staging.md));
+if a rule isn't in this file, its step hasn't landed. Architecture changes
+ahead of the RFC steps remain maintainer-only (see Autonomous Agent
+Boundaries above). One rule is already CI-enforced: the engine
+(`src/core/` + `src/models/`) must not gain new `gui/` includes or
+QtWidgets usage (`tools/check_engine_boundary.py`, warning for tracked
+legacy files, error for new ones).
+
 ---
 
 ## SmartSDR Protocol (v1.4.0.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1255,9 +1255,16 @@ if(Qt6WebSockets_FOUND)
 endif()
 
 if(Qt6Keychain_FOUND)
-    # PUBLIC: gui setup tabs test HAVE_KEYCHAIN; the library links the backend.
+    # PUBLIC (both): gui setup tabs test HAVE_KEYCHAIN *and* MqttApplet.cpp /
+    # MqttSettingsDialog.cpp include <qt6keychain/keychain.h> directly, so the
+    # exe's gui TUs need the imported target's INTERFACE_INCLUDE_DIRECTORIES.
+    # A PRIVATE link on a static lib propagates only $<LINK_ONLY:...> — the
+    # include dir would be lost and the gui TU fails to find the header on any
+    # platform where qtkeychain is not on a default include path (e.g. the
+    # bundled third_party/qtkeychain on Windows). Matches Qt6::SerialPort /
+    # Qt6::WebSockets, which are PUBLIC for the same reason.
     target_compile_definitions(aethercore PUBLIC HAVE_KEYCHAIN)
-    target_link_libraries(aethercore PRIVATE Qt6Keychain::Qt6Keychain)
+    target_link_libraries(aethercore PUBLIC Qt6Keychain::Qt6Keychain)
     # Local Windows builds run straight from the build dir with no packaging
     # step — windeployqt, which stages qt6keychain.dll for the installer, isn't
     # involved — so the DLL needs to land next to the exe or the app fails to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,7 +1032,7 @@ endif()
 
 qt_add_resources(RESOURCES resources/resources.qrc)
 
-# aetherd RFC step 1 (dry run): engine static library — src/core + src/models
+# aetherd RFC step 1: engine static library — src/core + src/models
 # plus the vendored C/C++ sources those engine files compile against
 # (rnnoise, ggmorse, RADE, specbleach; mosquitto/rtmidi are appended below in
 # their feature blocks). Qt resources (resources.qrc, DFNR model qrc) stay on
@@ -1205,10 +1205,12 @@ target_include_directories(aethercore PUBLIC
     ${CMAKE_SOURCE_DIR}/third_party/r8brain
 )
 
-# Engine dependency surface. NOTE (dry run): Qt6::Widgets is linked into the
-# engine because five core files still use QtWidgets (TxKeyingMarker.h,
-# ThemeManager.cpp, AutomationServer.cpp, ShortcutManager.cpp,
-# SettingsHelpers.cpp). A real step-1 PR must relocate/split those first.
+# Engine dependency surface. Qt6::Widgets is still linked into the engine
+# because five core files use QtWidgets (TxKeyingMarker.h, ThemeManager.cpp,
+# AutomationServer.cpp, ShortcutManager.cpp, SettingsHelpers.cpp). These are
+# tracked as EB2 legacy in tools/check_engine_boundary.py (per-file baseline
+# counts that may only shrink) and split out in step 3 — AutomationServer's
+# widget-facing dumpTree/grab half is the bulk of it.
 target_link_libraries(aethercore PUBLIC
     Qt6::Core
     Qt6::Concurrent
@@ -1569,7 +1571,14 @@ if(RADE_FOUND)
     if(RADE_WAV_TAP)
         set(RADE_TAP_DIR "${CMAKE_BINARY_DIR}/rade_taps"
             CACHE PATH "Output directory for RADE WAV tap files")
-        target_compile_definitions(aethercore PRIVATE RADE_WAV_TAP
+        # PUBLIC: RADEEngine.h guards two QByteArray members with
+        # #ifdef RADE_WAV_TAP mid-class, so the flag changes sizeof(RADEEngine)
+        # and every later member offset. A gui TU allocates it
+        # (MainWindow_DigitalModes.cpp `new RADEEngine`); a PRIVATE define would
+        # give the exe a smaller layout than the constructor compiled here →
+        # ODR violation / heap corruption under -DRADE_WAV_TAP=ON. Matches the
+        # sibling HAVE_RADE/HAVE_OPUS defines.
+        target_compile_definitions(aethercore PUBLIC RADE_WAV_TAP
             RADE_TAP_DIR="${RADE_TAP_DIR}")
     endif()
     target_include_directories(aethercore PRIVATE ${RADE_DIR}/src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1527,7 +1527,13 @@ if(FFTW3_FOUND)
         # declarations; define FFTW_DLL so fftw3.h emits __declspec(dllimport)
         # and the linker can resolve __imp_fftwf_* symbols from the import lib.
         $<$<BOOL:${WIN32}>:FFTW_DLL>)
-    target_include_directories(aethercore PRIVATE ${FFTW3_INCLUDE_DIRS})
+    # PUBLIC: core/SpectralNR.h includes <fftw3.h> under HAVE_FFTW3 (also
+    # PUBLIC), and SpectralNR.h is pulled in by AudioEngine.h — a header many
+    # gui TUs include. A PRIVATE include dir is lost to the exe, so those gui
+    # TUs fail to find fftw3.h wherever it is off the default path (Windows
+    # bundled third_party/fftw3). The library link stays PRIVATE (symbols reach
+    # the exe transitively through the static lib).
+    target_include_directories(aethercore PUBLIC ${FFTW3_INCLUDE_DIRS})
     target_link_directories(aethercore PRIVATE ${FFTW3_LIBRARY_DIRS})
     target_link_libraries(aethercore PRIVATE ${FFTW3_LIBRARIES})
     # Copy DLL to build dir on Windows
@@ -1542,7 +1548,10 @@ endif()
 
 if(ORT_FOUND)
     target_compile_definitions(aethercore PUBLIC HAVE_ONNX)
-    target_include_directories(aethercore PRIVATE ${ORT_INCLUDE_DIRS})
+    # PUBLIC include dir: core/SignalClassifier.h includes onnxruntime under
+    # HAVE_ONNX (PUBLIC) and is pulled in by gui/MainWindow.h. Same transitive
+    # leak as FFTW3 above. Library link stays PRIVATE (transitive via the lib).
+    target_include_directories(aethercore PUBLIC ${ORT_INCLUDE_DIRS})
     target_link_libraries(aethercore PRIVATE ${ORT_LIBRARIES})
     if(WIN32 AND ORT_DLLS)
         foreach(_ort_dll IN LISTS ORT_DLLS)
@@ -1597,13 +1606,15 @@ if(ENABLE_SPECBLEACH)
             message(WARNING "fftw3f.lib not found — run scripts/setup/setup-fftw.ps1 and gen-fftw3f-lib.bat")
         endif()
     else()
-        # libspecbleach C sources include <fftw3.h> directly — ensure it's findable
+        # libspecbleach C sources include <fftw3.h> directly — ensure it's
+        # findable. PUBLIC for the same transitive reason as the main FFTW3
+        # block above (AudioEngine.h -> SpectralNR.h -> <fftw3.h> reaches gui).
         if(FFTW3_INCLUDE_DIRS)
-            target_include_directories(aethercore PRIVATE ${FFTW3_INCLUDE_DIRS})
+            target_include_directories(aethercore PUBLIC ${FFTW3_INCLUDE_DIRS})
         else()
             find_path(FFTW3_H_DIR fftw3.h HINTS ${CMAKE_SOURCE_DIR}/third_party/fftw3/include)
             if(FFTW3_H_DIR)
-                target_include_directories(aethercore PRIVATE ${FFTW3_H_DIR})
+                target_include_directories(aethercore PUBLIC ${FFTW3_H_DIR})
             endif()
         endif()
         # libspecbleach uses fftwf (float precision FFTW3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -842,13 +842,6 @@ set(GUI_SOURCES
     src/gui/CompactColorPicker.cpp
 )
 
-set(ALL_SOURCES
-    src/main.cpp
-    ${CORE_SOURCES}
-    ${MODEL_SOURCES}
-    ${GUI_SOURCES}
-)
-
 # Bundled RNNoise (Mozilla/Xiph BSD-3) — client-side neural noise suppression
 set(RNNOISE_DIR ${CMAKE_SOURCE_DIR}/third_party/rnnoise)
 set(RNNOISE_SOURCES
@@ -1039,18 +1032,39 @@ endif()
 
 qt_add_resources(RESOURCES resources/resources.qrc)
 
-add_executable(AetherSDR ${ALL_SOURCES} ${RNNOISE_SOURCES} ${GGMORSE_SOURCES} ${RADE_SOURCES} ${SPECBLEACH_SOURCES} ${RESOURCES} ${DFNR_RESOURCES})
+# aetherd RFC step 1 (dry run): engine static library — src/core + src/models
+# plus the vendored C/C++ sources those engine files compile against
+# (rnnoise, ggmorse, RADE, specbleach; mosquitto/rtmidi are appended below in
+# their feature blocks). Qt resources (resources.qrc, DFNR model qrc) stay on
+# the executable: rcc registration runs from the exe's static initializers and
+# is process-global, so core code reading ":/..." keeps working.
+add_library(aethercore STATIC
+    ${CORE_SOURCES}
+    ${MODEL_SOURCES}
+    ${RNNOISE_SOURCES}
+    ${GGMORSE_SOURCES}
+    ${RADE_SOURCES}
+    ${SPECBLEACH_SOURCES}
+)
+
+add_executable(AetherSDR
+    src/main.cpp
+    ${GUI_SOURCES}
+    ${RESOURCES}
+    ${DFNR_RESOURCES}
+)
+target_link_libraries(AetherSDR PRIVATE aethercore)
 
 if (USE_SYSTEM_ZLIB)
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::zlib)
+    target_link_libraries(aethercore PRIVATE PkgConfig::zlib)      # core: ZipArchive
 else()
-    target_link_libraries(AetherSDR PRIVATE zlibstatic) # bundled third_party/zlib 1.3.1
+    target_link_libraries(aethercore PRIVATE zlibstatic) # bundled third_party/zlib 1.3.1
 endif()
 
 if (USE_SYSTEM_MSPACK)
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::libmspack)
+    target_link_libraries(aethercore PRIVATE PkgConfig::libmspack) # core: CabExtractor
 else()
-    target_link_libraries(AetherSDR PRIVATE mspack_static)
+    target_link_libraries(aethercore PRIVATE mspack_static)
 endif()
 
 # Link the system libmosquitto target only when MQTT is enabled — the
@@ -1059,7 +1073,7 @@ endif()
 # (ENABLE_MQTT=OFF + USE_SYSTEM_LIBMOSQUITTO=ON) would configure cleanly
 # then fail at link time with a missing target.
 if (ENABLE_MQTT AND USE_SYSTEM_LIBMOSQUITTO)
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::libmosquitto)
+    target_link_libraries(aethercore PRIVATE PkgConfig::libmosquitto) # core: MqttClient
 endif()
 
 # Optionally change binary name to lower case on Linux
@@ -1134,8 +1148,8 @@ if(APPLE)
         MACOSX_BUNDLE_ICON_FILE "AetherSDR.icns"
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/packaging/macos/Info.plist.in"
     )
-    target_link_libraries(AetherSDR PRIVATE "-framework AVFoundation" "-framework Accelerate")
-    target_sources(AetherSDR PRIVATE src/core/MacNRFilter.cpp)
+    target_link_libraries(aethercore PRIVATE "-framework AVFoundation" "-framework Accelerate") # core: MacNRFilter/VirtualAudioBridge
+    target_sources(aethercore PRIVATE src/core/MacNRFilter.cpp)
 
     # Generate AetherSDR.icns at build time from docs/assets/logo-circle.png so local
     # builds get an app icon without any extra setup (sips and iconutil are
@@ -1180,7 +1194,10 @@ elseif(WIN32)
     endif()
 endif()
 
-target_include_directories(AetherSDR PRIVATE
+# PUBLIC: src/ is the project include root for both layers ("core/..." and
+# "gui/..." includes); the vendored include dirs leak into headers used by
+# gui translation units today (e.g. hidapi via MainWindow_Controllers.cpp).
+target_include_directories(aethercore PUBLIC
     src/
     ${RNNOISE_DIR}/include
     ${RNNOISE_DIR}/src
@@ -1188,7 +1205,11 @@ target_include_directories(AetherSDR PRIVATE
     ${CMAKE_SOURCE_DIR}/third_party/r8brain
 )
 
-target_link_libraries(AetherSDR PRIVATE
+# Engine dependency surface. NOTE (dry run): Qt6::Widgets is linked into the
+# engine because five core files still use QtWidgets (TxKeyingMarker.h,
+# ThemeManager.cpp, AutomationServer.cpp, ShortcutManager.cpp,
+# SettingsHelpers.cpp). A real step-1 PR must relocate/split those first.
+target_link_libraries(aethercore PUBLIC
     Qt6::Core
     Qt6::Concurrent
     Qt6::Gui
@@ -1197,36 +1218,46 @@ target_link_libraries(AetherSDR PRIVATE
     Qt6::Multimedia
     aether_libmodem_core
     aether_afskdemod
-    qgeoview
+    ${CMAKE_DL_LIBS}   # NvidiaAfxFilter dlopen
+)
+
+target_link_libraries(AetherSDR PRIVATE
+    qgeoview           # gui/map only
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
 
 if (USE_SYSTEM_LIQUID_DSP)
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::liquid-dsp)
+    target_link_libraries(aethercore PRIVATE PkgConfig::liquid-dsp)
 else()
     # bundled third_party/liquid-dsp (#3043) — non-MSVC only; see CMakeLists
     # block above for the liquid-dsp/MSVC C99 _Complex incompatibility.
-    target_link_libraries(AetherSDR PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:liquid-static>)
+    target_link_libraries(aethercore PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:liquid-static>)
 endif()
 
 if(Qt6SerialPort_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_SERIALPORT)
-    target_link_libraries(AetherSDR PRIVATE Qt6::SerialPort)
+    # PUBLIC: gui (MainWindow.cpp, RadioSetupDialog.cpp) uses QSerialPort and
+    # #ifdef HAVE_SERIALPORT directly.
+    target_compile_definitions(aethercore PUBLIC HAVE_SERIALPORT)
+    target_link_libraries(aethercore PUBLIC Qt6::SerialPort)
 endif()
 
 if(Qt6WebSockets_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_WEBSOCKETS)
-    target_sources(AetherSDR PRIVATE
+    # PUBLIC: gui (MainWindow_Spots.cpp) uses QWebSocket directly.
+    target_compile_definitions(aethercore PUBLIC HAVE_WEBSOCKETS)
+    target_sources(aethercore PRIVATE
         src/core/FreeDvClient.cpp
+    )
+    target_sources(AetherSDR PRIVATE
         src/gui/FreeDvReporterDialog.cpp
         src/gui/FreeDvReporterModel.cpp
     )
-    target_link_libraries(AetherSDR PRIVATE Qt6::WebSockets)
+    target_link_libraries(aethercore PUBLIC Qt6::WebSockets)
 endif()
 
 if(Qt6Keychain_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_KEYCHAIN)
-    target_link_libraries(AetherSDR PRIVATE Qt6Keychain::Qt6Keychain)
+    # PUBLIC: gui setup tabs test HAVE_KEYCHAIN; the library links the backend.
+    target_compile_definitions(aethercore PUBLIC HAVE_KEYCHAIN)
+    target_link_libraries(aethercore PRIVATE Qt6Keychain::Qt6Keychain)
     # Local Windows builds run straight from the build dir with no packaging
     # step — windeployqt, which stages qt6keychain.dll for the installer, isn't
     # involved — so the DLL needs to land next to the exe or the app fails to
@@ -1241,12 +1272,15 @@ if(Qt6Keychain_FOUND)
 endif()
 
 if(Qt6DBus_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_DBUS)
-    target_link_libraries(AetherSDR PRIVATE Qt6::DBus)
+    target_compile_definitions(aethercore PUBLIC HAVE_DBUS)
+    target_link_libraries(aethercore PRIVATE Qt6::DBus)
 endif()
 
 if(AETHER_GPU_SPECTRUM)
-    target_compile_definitions(AetherSDR PRIVATE AETHER_GPU_SPECTRUM)
+    # PUBLIC on the engine: src/core/AutomationServer.cpp compiles QRhiWidget
+    # grab paths under #ifdef AETHER_GPU_SPECTRUM (QRhiWidget is public
+    # QtWidgets API on Qt 6.7+, so no GuiPrivate needed engine-side).
+    target_compile_definitions(aethercore PUBLIC AETHER_GPU_SPECTRUM)
 
     # Apply the manual private-include paths now that AetherSDR exists. Covers
     # Debian multi-arch and Windows/macOS aqt installs that lack the Qt6::GuiPrivate
@@ -1309,36 +1343,40 @@ endif()
 
 # Bundled RtMidi (MIT license) — MIDI controller support on all platforms
 message(STATUS "MIDI controller support enabled (RtMidi)")
-target_compile_definitions(AetherSDR PRIVATE HAVE_MIDI)
-target_sources(AetherSDR PRIVATE
+target_compile_definitions(aethercore PUBLIC HAVE_MIDI) # gui MidiMappingDialog + MainWindow check it too
+target_sources(aethercore PRIVATE
     src/core/MidiControlManager.cpp
-    src/core/MidiSettings.cpp
+    src/core/MidiSettings.cpp)
+target_sources(AetherSDR PRIVATE
     src/gui/MidiMappingDialog.cpp)
 if (USE_SYSTEM_RTMIDI)
     find_package(PkgConfig REQUIRED)
     if(PkgConfig_FOUND)
         pkg_check_modules(rtmidi REQUIRED IMPORTED_TARGET rtmidi)
     endif()
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::rtmidi)
+    target_link_libraries(aethercore PRIVATE PkgConfig::rtmidi)
 else()
-    target_sources(AetherSDR PRIVATE third_party/rtmidi/RtMidi.cpp)
-    target_include_directories(AetherSDR PRIVATE third_party/rtmidi)
+    target_sources(aethercore PRIVATE third_party/rtmidi/RtMidi.cpp)
+    # PUBLIC: MidiControlManager.h includes RtMidi.h
+    target_include_directories(aethercore PUBLIC third_party/rtmidi)
 endif()
 
 if(APPLE)
-    target_compile_definitions(AetherSDR PRIVATE __MACOSX_CORE__)
-    target_link_libraries(AetherSDR PRIVATE "-framework CoreMIDI" "-framework CoreAudio" "-framework CoreFoundation" "-framework IOKit")
+    # RtMidi backend selectors — PUBLIC because MidiControlManager.h includes
+    # RtMidi.h (its class layout is backend-conditional in places).
+    target_compile_definitions(aethercore PUBLIC __MACOSX_CORE__)
+    target_link_libraries(aethercore PRIVATE "-framework CoreMIDI" "-framework CoreAudio" "-framework CoreFoundation" "-framework IOKit")
 elseif(WIN32)
-    target_compile_definitions(AetherSDR PRIVATE __WINDOWS_MM__)
-    target_link_libraries(AetherSDR PRIVATE winmm)
-    target_link_libraries(AetherSDR PRIVATE dxgi)  # GpuSelector adapter enumeration
+    target_compile_definitions(aethercore PUBLIC __WINDOWS_MM__)
+    target_link_libraries(aethercore PRIVATE winmm)
+    target_link_libraries(aethercore PRIVATE dxgi)  # GpuSelector adapter enumeration
 else()
-    target_compile_definitions(AetherSDR PRIVATE __LINUX_ALSA__)
+    target_compile_definitions(aethercore PUBLIC __LINUX_ALSA__)
     find_package(PkgConfig REQUIRED)
     if(PkgConfig_FOUND)
         pkg_check_modules(alsa REQUIRED IMPORTED_TARGET alsa)
     endif()
-    target_link_libraries(AetherSDR PRIVATE PkgConfig::alsa)
+    target_link_libraries(aethercore PRIVATE PkgConfig::alsa)
 endif()
 
 # hidapi — USB HID encoder support (Stream Deck, Icom RC-28, Griffin PowerMate, Contour Shuttle)
@@ -1371,37 +1409,41 @@ endif()
 # expose the same Qt signal contract (see UlanziDialBackend.h); the
 # mapper dialog and MainWindow dispatcher are unchanged across
 # platforms.  See #3232 for the design.
+target_sources(aethercore PRIVATE
+    src/core/UlanziDialBackend.h)   # header-only Q_OBJECT — listed so AUTOMOC mocs it in the engine
 target_sources(AetherSDR PRIVATE
-    src/core/UlanziDialBackend.h
     src/gui/UlanziDialMapperDialog.cpp
     src/gui/UlanziDialMapperDialog.h)
 if(UNIX AND NOT APPLE)
-    target_sources(AetherSDR PRIVATE
+    target_sources(aethercore PRIVATE
         src/core/EvdevEncoderManager.cpp
         src/core/EvdevEncoderManager.h)
 endif()
 if(WIN32)
-    target_sources(AetherSDR PRIVATE
+    target_sources(aethercore PRIVATE
         src/core/UlanziDialWindowsManager.cpp
         src/core/UlanziDialWindowsManager.h)
 endif()
 if(APPLE)
-    target_sources(AetherSDR PRIVATE
+    target_sources(aethercore PRIVATE
         src/core/UlanziDialMacOSManager.cpp
         src/core/UlanziDialMacOSManager.h)
-    target_link_libraries(AetherSDR PRIVATE
+    target_link_libraries(aethercore PRIVATE
         "-framework IOKit"
         "-framework CoreFoundation")
 endif()
 
 if(HIDAPI_FOUND)
     message(STATUS "hidapi found — USB HID encoder support enabled")
-    target_compile_definitions(AetherSDR PRIVATE HAVE_HIDAPI)
-    target_sources(AetherSDR PRIVATE
+    # PUBLIC: gui (MainWindow_Controllers.cpp) includes hidapi.h and checks
+    # HAVE_HIDAPI directly.
+    target_compile_definitions(aethercore PUBLIC HAVE_HIDAPI)
+    target_sources(aethercore PRIVATE
         src/core/HidEncoderManager.cpp
         src/core/HidEncoderManager.h
         src/core/HidDeviceParser.cpp
-        src/core/HidDeviceParser.h
+        src/core/HidDeviceParser.h)
+    target_sources(AetherSDR PRIVATE
         src/gui/RC28MappingDialog.cpp
         src/gui/RC28MappingDialog.h)
     set(HIDAPI_NORMALIZED_INCLUDE_DIRS ${HIDAPI_INCLUDE_DIRS})
@@ -1415,8 +1457,8 @@ if(HIDAPI_FOUND)
         endif()
     endforeach()
     list(REMOVE_DUPLICATES HIDAPI_NORMALIZED_INCLUDE_DIRS)
-    target_include_directories(AetherSDR PRIVATE ${HIDAPI_NORMALIZED_INCLUDE_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${HIDAPI_LIBRARIES})
+    target_include_directories(aethercore PUBLIC ${HIDAPI_NORMALIZED_INCLUDE_DIRS})
+    target_link_libraries(aethercore PRIVATE ${HIDAPI_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND HIDAPI_DLL)
         add_custom_command(TARGET AetherSDR POST_BUILD
@@ -1465,22 +1507,22 @@ else()
 endif()
 
 if(PORTAUDIO_FOUND)
-    target_sources(AetherSDR PRIVATE src/core/CwSidetonePortAudioSink.cpp)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_PORTAUDIO)
-    target_include_directories(AetherSDR PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
-    target_link_directories(AetherSDR PRIVATE ${PORTAUDIO_LIBRARY_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${PORTAUDIO_LIBRARIES})
+    target_sources(aethercore PRIVATE src/core/CwSidetonePortAudioSink.cpp)
+    target_compile_definitions(aethercore PUBLIC HAVE_PORTAUDIO)
+    target_include_directories(aethercore PRIVATE ${PORTAUDIO_INCLUDE_DIRS})
+    target_link_directories(aethercore PRIVATE ${PORTAUDIO_LIBRARY_DIRS})
+    target_link_libraries(aethercore PRIVATE ${PORTAUDIO_LIBRARIES})
 endif()
 
 if(FFTW3_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_FFTW3
+    target_compile_definitions(aethercore PUBLIC HAVE_FFTW3
         # On Windows lld-link (used by ClangCL) requires explicit dllimport
         # declarations; define FFTW_DLL so fftw3.h emits __declspec(dllimport)
         # and the linker can resolve __imp_fftwf_* symbols from the import lib.
         $<$<BOOL:${WIN32}>:FFTW_DLL>)
-    target_include_directories(AetherSDR PRIVATE ${FFTW3_INCLUDE_DIRS})
-    target_link_directories(AetherSDR PRIVATE ${FFTW3_LIBRARY_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${FFTW3_LIBRARIES})
+    target_include_directories(aethercore PRIVATE ${FFTW3_INCLUDE_DIRS})
+    target_link_directories(aethercore PRIVATE ${FFTW3_LIBRARY_DIRS})
+    target_link_libraries(aethercore PRIVATE ${FFTW3_LIBRARIES})
     # Copy DLL to build dir on Windows
     if(WIN32 AND FFTW3_DLL)
         add_custom_command(TARGET AetherSDR POST_BUILD
@@ -1492,9 +1534,9 @@ if(FFTW3_FOUND)
 endif()
 
 if(ORT_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_ONNX)
-    target_include_directories(AetherSDR PRIVATE ${ORT_INCLUDE_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${ORT_LIBRARIES})
+    target_compile_definitions(aethercore PUBLIC HAVE_ONNX)
+    target_include_directories(aethercore PRIVATE ${ORT_INCLUDE_DIRS})
+    target_link_libraries(aethercore PRIVATE ${ORT_LIBRARIES})
     if(WIN32 AND ORT_DLLS)
         foreach(_ort_dll IN LISTS ORT_DLLS)
             add_custom_command(TARGET AetherSDR POST_BUILD
@@ -1506,38 +1548,39 @@ if(ORT_FOUND)
 endif()
 
 if(RADE_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_RADE HAVE_OPUS IS_BUILDING_RADE_API=1)
+    # PUBLIC defines: gui (RadeApplet etc.) checks HAVE_RADE/HAVE_OPUS.
+    target_compile_definitions(aethercore PUBLIC HAVE_RADE HAVE_OPUS IS_BUILDING_RADE_API=1)
     if(RADE_WAV_TAP)
         set(RADE_TAP_DIR "${CMAKE_BINARY_DIR}/rade_taps"
             CACHE PATH "Output directory for RADE WAV tap files")
-        target_compile_definitions(AetherSDR PRIVATE RADE_WAV_TAP
+        target_compile_definitions(aethercore PRIVATE RADE_WAV_TAP
             RADE_TAP_DIR="${RADE_TAP_DIR}")
     endif()
-    target_include_directories(AetherSDR PRIVATE ${RADE_DIR}/src)
+    target_include_directories(aethercore PRIVATE ${RADE_DIR}/src)
     if(WIN32)
-        target_link_libraries(AetherSDR PRIVATE opus)
+        target_link_libraries(aethercore PRIVATE opus)
     else()
-        target_link_libraries(AetherSDR PRIVATE opus m)
+        target_link_libraries(aethercore PRIVATE opus m)
     endif()
 elseif(OPUS_FOUND)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_OPUS)
-    target_include_directories(AetherSDR PRIVATE ${OPUS_INCLUDE_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${OPUS_LIBRARIES})
+    target_compile_definitions(aethercore PUBLIC HAVE_OPUS)
+    target_include_directories(aethercore PRIVATE ${OPUS_INCLUDE_DIRS})
+    target_link_libraries(aethercore PRIVATE ${OPUS_LIBRARIES})
 endif()
 
 if(ENABLE_SPECBLEACH)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_SPECBLEACH)
-    target_include_directories(AetherSDR PRIVATE
+    target_compile_definitions(aethercore PUBLIC HAVE_SPECBLEACH)
+    target_include_directories(aethercore PRIVATE
         ${CMAKE_SOURCE_DIR}/third_party/libspecbleach/include
         ${CMAKE_SOURCE_DIR}/third_party/libspecbleach/src)
     if(MSVC AND SPECBLEACH_STATIC_LIB)
         # Link pre-built clang-cl static lib
-        add_dependencies(AetherSDR specbleach_build)
-        target_link_libraries(AetherSDR PRIVATE ${SPECBLEACH_STATIC_LIB})
+        add_dependencies(aethercore specbleach_build)
+        target_link_libraries(aethercore PRIVATE ${SPECBLEACH_STATIC_LIB})
         # fftw3f (float precision) for Windows
         set(FFTW3F_LIB "${CMAKE_SOURCE_DIR}/third_party/fftw3/lib/fftw3f.lib")
         if(EXISTS ${FFTW3F_LIB})
-            target_link_libraries(AetherSDR PRIVATE ${FFTW3F_LIB})
+            target_link_libraries(aethercore PRIVATE ${FFTW3F_LIB})
             set(FFTW3F_DLL "${CMAKE_SOURCE_DIR}/third_party/fftw3/bin/libfftw3f-3.dll")
             add_custom_command(TARGET AetherSDR POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -1549,17 +1592,17 @@ if(ENABLE_SPECBLEACH)
     else()
         # libspecbleach C sources include <fftw3.h> directly — ensure it's findable
         if(FFTW3_INCLUDE_DIRS)
-            target_include_directories(AetherSDR PRIVATE ${FFTW3_INCLUDE_DIRS})
+            target_include_directories(aethercore PRIVATE ${FFTW3_INCLUDE_DIRS})
         else()
             find_path(FFTW3_H_DIR fftw3.h HINTS ${CMAKE_SOURCE_DIR}/third_party/fftw3/include)
             if(FFTW3_H_DIR)
-                target_include_directories(AetherSDR PRIVATE ${FFTW3_H_DIR})
+                target_include_directories(aethercore PRIVATE ${FFTW3_H_DIR})
             endif()
         endif()
         # libspecbleach uses fftwf (float precision FFTW3)
         find_library(FFTW3F_LIB fftw3f HINTS /opt/homebrew/lib /usr/local/lib ${CMAKE_SOURCE_DIR}/third_party/fftw3/lib)
         if(FFTW3F_LIB)
-            target_link_libraries(AetherSDR PRIVATE ${FFTW3F_LIB})
+            target_link_libraries(aethercore PRIVATE ${FFTW3F_LIB})
         else()
             message(WARNING "fftw3f not found — NR4 will fail to link")
         endif()
@@ -1569,17 +1612,17 @@ if(ENABLE_SPECBLEACH)
 endif()
 
 if(ENABLE_DFNR)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_DFNR)
-    target_include_directories(AetherSDR PRIVATE ${DEEPFILTER_DIR}/include)
-    target_link_libraries(AetherSDR PRIVATE ${DFNR_LIB})
+    target_compile_definitions(aethercore PUBLIC HAVE_DFNR)
+    target_include_directories(aethercore PRIVATE ${DEEPFILTER_DIR}/include)
+    target_link_libraries(aethercore PRIVATE ${DFNR_LIB})
     if(WIN32)
-        target_link_libraries(AetherSDR PRIVATE ws2_32 bcrypt userenv ntdll)
+        target_link_libraries(aethercore PRIVATE ws2_32 bcrypt userenv ntdll)
     elseif(APPLE)
         # Rust runtime deps on macOS
-        target_link_libraries(AetherSDR PRIVATE "-framework Security" "-framework CoreFoundation")
+        target_link_libraries(aethercore PRIVATE "-framework Security" "-framework CoreFoundation")
     else()
         # Rust runtime deps on Linux
-        target_link_libraries(AetherSDR PRIVATE pthread dl m)
+        target_link_libraries(aethercore PRIVATE pthread dl m)
     endif()
     # Copy DLL and model to build directory
     if(DFNR_DLL AND EXISTS ${DFNR_DLL})
@@ -1623,11 +1666,12 @@ if(ENABLE_NVIDIA_AFX)
     # Pi etc. — which also have no NVIDIA GPU) and macOS get the DFNR fallback,
     # not BNR. The arch guard means BNR is simply absent there (no dead button).
     if(((UNIX AND NOT APPLE) OR WIN32) AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
-        target_compile_definitions(AetherSDR PRIVATE HAVE_NVIDIA_AFX)
+        # PUBLIC: gui surfaces the BNR button under #ifdef HAVE_NVIDIA_AFX.
+        target_compile_definitions(aethercore PUBLIC HAVE_NVIDIA_AFX)
         # Linux loads the AFX runtime via libdl; Windows uses the Win32
         # LoadLibrary family from kernel32 (linked by default).
         if(UNIX)
-            target_link_libraries(AetherSDR PRIVATE ${CMAKE_DL_LIBS})
+            target_link_libraries(aethercore PRIVATE ${CMAKE_DL_LIBS})
         endif()
         message(STATUS "NVIDIA AFX GPU denoiser enabled (runtime-loaded)")
     else()
@@ -1639,71 +1683,76 @@ if(ENABLE_MQTT)
     # HAVE_MQTT gates the project's MQTT client code (MqttApplet,
     # RadioModel plumbing) — must be set regardless of whether
     # libmosquitto is the bundled or the system copy.
-    target_compile_definitions(AetherSDR PRIVATE HAVE_MQTT)
+    target_compile_definitions(aethercore PUBLIC HAVE_MQTT) # gui MqttApplet checks it
     if (USE_SYSTEM_LIBMOSQUITTO)
         # System libmosquitto is conventionally built with TLS support on
         # distro packages — assume HAVE_MQTT_TLS unless the packager
         # explicitly opted out via -DMQTT_TLS=OFF.
         if(MQTT_TLS)
-            target_compile_definitions(AetherSDR PRIVATE HAVE_MQTT_TLS)
+            target_compile_definitions(aethercore PUBLIC HAVE_MQTT_TLS)
         endif()
     else()
-        target_include_directories(AetherSDR PRIVATE
+        target_include_directories(aethercore PRIVATE
             ${MOSQUITTO_DIR}/include
             ${MOSQUITTO_DIR}/src)
-        target_sources(AetherSDR PRIVATE ${MOSQUITTO_SOURCES})
+        target_sources(aethercore PRIVATE ${MOSQUITTO_SOURCES})
         if(OpenSSL_FOUND)
             set(MQTT_TLS_FLAG " -DWITH_TLS")
-            target_compile_definitions(AetherSDR PRIVATE HAVE_MQTT_TLS)
-            target_link_libraries(AetherSDR PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+            target_compile_definitions(aethercore PUBLIC HAVE_MQTT_TLS)
+            target_link_libraries(aethercore PRIVATE OpenSSL::SSL OpenSSL::Crypto)
         else()
             set(MQTT_TLS_FLAG "")
         endif()
         if(WIN32)
             set_source_files_properties(${MOSQUITTO_SOURCES} PROPERTIES
                 COMPILE_FLAGS "-w -DLIBMOSQUITTO_STATIC -DLIBMOSQCOMMON_STATIC${MQTT_TLS_FLAG}")
-            target_compile_definitions(AetherSDR PRIVATE LIBMOSQUITTO_STATIC LIBMOSQCOMMON_STATIC)
+            target_compile_definitions(aethercore PRIVATE LIBMOSQUITTO_STATIC LIBMOSQCOMMON_STATIC)
         else()
             set_source_files_properties(${MOSQUITTO_SOURCES} PROPERTIES
                 COMPILE_FLAGS "-w -DWITH_THREADING${MQTT_TLS_FLAG}")
         endif()
     endif()
     if(NOT WIN32)
-        target_link_libraries(AetherSDR PRIVATE pthread)
+        target_link_libraries(aethercore PRIVATE pthread)
     endif()
 endif()
 
 if(HAVE_PIPEWIRE)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_PIPEWIRE)
+    target_compile_definitions(aethercore PUBLIC HAVE_PIPEWIRE) # gui checks HAVE_PIPEWIRE too
     message(STATUS "Linux DAX bridge enabled (PulseAudio pipe modules)")
 endif()
 
 if(HAVE_PIPEWIRE_NATIVE)
-    target_compile_definitions(AetherSDR PRIVATE HAVE_PIPEWIRE_NATIVE)
-    target_include_directories(AetherSDR PRIVATE ${PIPEWIRE_NATIVE_INCLUDE_DIRS})
-    target_link_libraries(AetherSDR PRIVATE ${PIPEWIRE_NATIVE_LIBRARIES})
-    target_compile_options(AetherSDR PRIVATE ${PIPEWIRE_NATIVE_CFLAGS_OTHER})
+    target_compile_definitions(aethercore PUBLIC HAVE_PIPEWIRE_NATIVE)
+    target_include_directories(aethercore PRIVATE ${PIPEWIRE_NATIVE_INCLUDE_DIRS})
+    target_link_libraries(aethercore PRIVATE ${PIPEWIRE_NATIVE_LIBRARIES})
+    target_compile_options(aethercore PRIVATE ${PIPEWIRE_NATIVE_CFLAGS_OTHER})
     message(STATUS "Linux DAX RX uses native pw_stream (libpipewire-0.3 ${PIPEWIRE_NATIVE_VERSION})")
 endif()
 
-# Pass project version to code
-target_compile_definitions(AetherSDR PRIVATE
+# Pass project version to code — PUBLIC so main.cpp and gui (About dialog,
+# Ax25HfPacketDecodeDialog) see it as before.
+target_compile_definitions(aethercore PUBLIC
     AETHERSDR_VERSION="${PROJECT_VERSION}"
 )
 
-# Compiler warnings
-if(MSVC)
-    target_compile_options(AetherSDR PRIVATE /W3 /Zc:__cplusplus /permissive- /utf-8 /bigobj)
-else()
-    target_compile_options(AetherSDR PRIVATE
-        -Wall -Wextra -Wpedantic
-        $<$<CONFIG:Debug>:-g3 -fsanitize=address>
-        $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
-    )
-    target_link_options(AetherSDR PRIVATE
-        $<$<CONFIG:Debug>:-fsanitize=address>
-    )
-endif()
+# Compiler warnings — same flags for both first-party targets. Vendored
+# sources compiled into aethercore keep their per-source -w COMPILE_FLAGS,
+# which land after these target options and win (unchanged from monolith).
+foreach(_aether_tgt aethercore AetherSDR)
+    if(MSVC)
+        target_compile_options(${_aether_tgt} PRIVATE /W3 /Zc:__cplusplus /permissive- /utf-8 /bigobj)
+    else()
+        target_compile_options(${_aether_tgt} PRIVATE
+            -Wall -Wextra -Wpedantic
+            $<$<CONFIG:Debug>:-g3 -fsanitize=address>
+            $<$<CONFIG:Debug>:-fno-omit-frame-pointer>
+        )
+        target_link_options(${_aether_tgt} PRIVATE
+            $<$<CONFIG:Debug>:-fsanitize=address>
+        )
+    endif()
+endforeach()
 
 
 # ── Unit test harnesses ──────────────────────────────────────────────────────

--- a/docs/aetherd-agents-md-staging.md
+++ b/docs/aetherd-agents-md-staging.md
@@ -23,7 +23,12 @@ describes — never earlier, never later.
 
 ---
 
-## Block 1 — land with RFC step 1 (`libaethercore` extraction)
+## Block 1 — LANDED 2026-07-04 with RFC step 1 (`libaethercore` extraction)
+
+> This block has been merged into `AGENTS.md` (In-flight subsection +
+> build-targets table + agent-guidelines bullet), reconciled to the real
+> target name (`aethercore`) and the EB1-now-zero state. Kept here for
+> history; delete on the next staging-doc edit.
 
 ### 1a. In the "In-flight: aetherd engine/UI decoupling" subsection, replace the status sentence
 

--- a/docs/aetherd-agents-md-staging.md
+++ b/docs/aetherd-agents-md-staging.md
@@ -1,0 +1,169 @@
+# AGENTS.md staged updates — aetherd migration
+
+Pre-drafted `AGENTS.md` blocks for the aetherd migration
+([`aetherd-headless-engine-design.md`](aetherd-headless-engine-design.md)).
+`AGENTS.md` is executable law for this repo's AI contributors: it must
+describe the tree as it **is**, never as the RFC hopes it will be. So each
+block below lands in `AGENTS.md` **in the same PR** as the milestone it
+describes — never earlier, never later.
+
+**Landing rules:**
+
+1. **Atomic.** A milestone PR that changes structure without its
+   `AGENTS.md` block is incomplete and must not merge.
+2. **Reconcile before landing.** File names, script names, and CI check
+   names below are proposals. If the implementation chose different names,
+   fix the block, not the code.
+3. **Burn down.** When a block lands in `AGENTS.md`, delete it from this
+   file. When this file is empty, delete it and drop the pointer to it
+   from `AGENTS.md` and the RFC.
+4. **Track the RFC.** If a §10 step changes shape during sign-off or
+   implementation, update its block here in the same PR that changes
+   the RFC.
+
+---
+
+## Block 1 — land with RFC step 1 (`libaethercore` extraction)
+
+### 1a. In the "In-flight: aetherd engine/UI decoupling" subsection, replace the status sentence
+
+> Implementation follows the RFC's §10 staged order; **step 1
+> (`libaethercore`) has landed** — the engine is a library, the app is a
+> shell that links it. Steps 2+ have not landed.
+
+### 1b. Append to "Architecture Overview"
+
+```markdown
+**Build targets (post-RFC step 1):**
+
+| Target | Contents | May link |
+|---|---|---|
+| `libaethercore` | `src/core/` + `src/models/` — the engine | Qt Core/Network/Multimedia/WebSockets, DSP libs. **Never `gui/`, never Qt Widgets** |
+| `AetherSDR` | `src/gui/` + `main.cpp` — the desktop app | `libaethercore` + Qt Widgets |
+
+The engine→gui dependency direction is now CI-enforced
+(`tools/check_engine_boundary.py`, warning-free build required): no file
+under `core/` or `models/` may include a `gui/` header, and
+`libaethercore` may not link `Qt6::Widgets`. If your change trips the
+check, restructure the change — do not move the file, weaken the check,
+or add an exemption.
+```
+
+### 1c. Append one bullet to "AI Agent Guidelines"
+
+```markdown
+- **New engine code goes in `libaethercore`** (`src/core/` or
+  `src/models/`), exposed to the UI through models — never via a new
+  gui→core header include. See "Build targets" under Architecture
+  Overview.
+```
+
+---
+
+## Block 2 — land with RFC step 2 (`IRadioBackend` seam)
+
+### 2a. In the "In-flight" subsection, replace the status sentence
+
+> Implementation follows the RFC's §10 staged order; **steps 1–2 have
+> landed** — `libaethercore` and the `IRadioBackend` seam exist, and the
+> SmartSDR stack lives in `FlexBackend`. The versioned protocol (step 3+)
+> has NOT landed: UI code still calls models directly, and that remains
+> correct.
+
+### 2b. New top-level section, placed after "Adding code to MainWindow"
+
+```markdown
+### Engine boundary & radio backends (aetherd migration)
+
+**Status:** RFC steps 1–2 landed. `libaethercore` + `IRadioBackend`
+exist; the SmartSDR stack is `FlexBackend`
+(`src/core/backends/flex/`). The versioned protocol has NOT landed —
+UI code still consumes models directly, and that remains correct.
+
+Full design:
+[`docs/aetherd-headless-engine-design.md`](docs/aetherd-headless-engine-design.md).
+Touchpoint burndown:
+[`docs/architecture/aetherd-touchpoints.md`](docs/architecture/aetherd-touchpoints.md).
+
+Route your change:
+
+| Your change | Goes |
+|---|---|
+| Code speaking a vendor wire protocol (commands, discovery, stream parsing) | that family's backend under `src/core/backends/<family>/`, behind `IRadioBackend` — never in models, never in `gui/` |
+| A new radio family | a new `IRadioBackend` implementation — requires an approved design doc naming its open protocol authority (Constitution Principles I & IV apply per backend) |
+| New engine feature | `libaethercore`, exposed through models — never via a new gui→core header |
+| A new gui→engine touchpoint | **don't create one** — consume an existing model surface; if none fits, stop and flag the maintainer (it's a protocol-surface decision, RFC §2) |
+| Converting an enumerated touchpoint | claim it first (below); one touchpoint per PR; run the verification recipe |
+
+**Ratchets (CI-enforced — restructure your change rather than working
+around them):**
+
+- `core/`+`models/` include no `gui/` headers; `libaethercore` never
+  links `Qt6::Widgets` (`tools/check_engine_boundary.py`)
+- Only backends touch vendor wire protocols; models hold normalized
+  state only
+- The touchpoint manifest's "converted" column only ever grows
+
+**Claiming a touchpoint:** the Issue/PR Claim Protocol (above) applies
+at touchpoint granularity. Assign yourself on the migration tracking
+issue and mark the manifest row "in progress" in your PR's first
+commit. One touchpoint per PR. If you step away, revert the row and
+unassign — claims are mortal (Principle X).
+
+**Verification recipe (required in every conversion PR):** conversions
+must be behavior-neutral. Build, launch with `AETHER_AUTOMATION=1`, and
+run `tools/verify_slice0_rx.py` (bridge-driven: connect, assert
+slice-0 frequency/mode/filter round-trip via `get`, `grab` the
+panadapter) before and after your change. Paste the script's summary
+in the PR body. "It compiles" is not evidence (Principle VIII).
+```
+
+### 2c. Amend "Autonomous Agent Boundaries"
+
+In the "must NOT autonomously change" list, extend the
+**Architecture** bullet:
+
+```markdown
+- **Architecture** — adding new threads, changing signal routing, new
+  dependencies. *One carve-out:* converting an already-enumerated
+  touchpoint per the approved aetherd RFC **is** authorized mechanical
+  work (claimed via the manifest, behavior-neutral, bridge-verified —
+  see "Engine boundary & radio backends"). Creating new protocol
+  surface, new touchpoints, new backends, or reordering RFC steps
+  remains maintainer-only.
+```
+
+---
+
+## Block 3 — land with RFC steps 3–5 (protocol, TX arbitration, data plane)
+
+### 3a. In the "Engine boundary & radio backends" section, replace the status paragraph
+
+> **Status:** RFC steps 1–5 landed. The versioned control protocol,
+> engine-side TX arbitration, and the binary data plane exist. Subsystems
+> are converting to the protocol surface one at a time — **check the
+> manifest before writing UI code.**
+
+### 3b. Add two rows to the routing table
+
+```markdown
+| UI feature code in a **converted** subsystem (per the manifest) | consume the protocol surface (subscribe / verbs / data-plane frames) — do not add direct model calls back |
+| UI feature code in an **unconverted** subsystem | the legacy direct-model path is still correct — do NOT half-convert a subsystem as a side effect of a feature PR |
+```
+
+### 3c. Add a TX must-know bullet to the section
+
+```markdown
+- **TX keying goes through engine-side arbitration only** (RFC §6):
+  single-holder TX lock, per-client auth, fail-closed. Never add a
+  keying path that bypasses the guard; backends translate the engine's
+  keying decision, they never self-key. Anything TX-adjacent gets the
+  `safety` label and maintainer review — same rule as today, one layer
+  down.
+```
+
+### 3d. In the "In-flight" subsection (top of Architecture Overview)
+
+Replace the whole subsection with two sentences: the migration is in its
+conversion phase, rules live in "Engine boundary & radio backends", and
+the burndown manifest is the source of truth for per-subsystem status.

--- a/docs/aetherd-headless-engine-design.md
+++ b/docs/aetherd-headless-engine-design.md
@@ -1,0 +1,560 @@
+# AetherD — Headless Engine & UI Decoupling — Design (RFC)
+
+**Status:** **Accepted** — 2026-07-04, Jeremy/KK7GWY. All 17 decisions
+approved as recommended; record in
+[`aetherd-rfc-signoff.md`](aetherd-rfc-signoff.md). Implementation proceeds
+per §10.
+**Author:** Claude (Opus 4.8) with architecture direction by @ten9876
+**Date:** 2026-06-26 (revised 2026-07-04: pluggable radio backends)
+**Scope:** Split AetherSDR into a headless engine daemon (`aetherd`) that owns the
+radio connection and all of `core/`+`models/`, plus thin UI clients (Qt desktop,
+browser/web, TUI, scripting) that speak a versioned protocol — so the UI can be
+radically changed, replaced, or remoted **without rebuilding the engine**, and
+new radio families can be added below the same boundary **without touching any
+client** (§5.5).
+
+> Per [`GOVERNANCE.md`](../GOVERNANCE.md#rfc-process) this is an **architecture
+> change** (threading, signal routing, process model) and therefore requires an
+> approved RFC before a PR is opened.
+
+---
+
+## 0. Open decisions (need maintainer sign-off)
+
+Bias for all decisions: **successful, consistent operation for every operator
+skill level**, and **TX safety is never weakened by the split** (Principle VI).
+
+| # | Decision | Recommendation | §  |
+|---|----------|----------------|----|
+| Goal scope | What problem are we actually solving? | **Remote/web/multi-client** — if it's only desktop re-styling, prefer QML (§9, Alternative A) | §1 |
+| Process model | One daemon, many clients? | **Yes** — `aetherd` owns the radio; UIs are peers | §3 |
+| Local transport | Control plane on same box | **`QLocalServer`** (already used by the bridge) | §4.1 |
+| Remote transport | Control plane off box / browser | **WebSocket** (already linked: `Qt6::WebSockets`) | §4.1 |
+| Remote security | Protecting off-box access | **Ship with WireGuard** — tunnel supplies encryption + peer identity; engine auth maps peers to capability grants | §6, §8 |
+| Data plane (local) | FFT/audio same box | **Shared-memory ring buffer** (zero-copy) | §4.2 |
+| Data plane (remote) | FFT/audio off box | **Binary frames + Opus** (reuse `OpusCodec`/VITA framing) | §4.2 |
+| TX arbitration | Multiple UIs, who keys? | **Single-holder TX lock + per-client auth**, enforced in engine | §6 |
+| Multi-client view | Shared or per-client view state? | **Per-client projection over shared radio state** | §5 |
+| Radio backends | One radio family, or pluggable? | **Pluggable `IRadioBackend`** below the models; the SmartSDR stack becomes the first backend | §5.5 |
+| Capabilities | Clients face radios with different feature sets | **Capability descriptor in `welcome`** — clients render what the radio reports, no hard-coded assumptions | §4.1 |
+| Multi-session | One daemon, many radios? | **Session-namespaced protocol** over the existing `RadioSession` aggregate | §5 |
+| Repo layout | Separate repo for `aetherd`? | **Monorepo** — engine + desktop client stay in this repo permanently; revisit only for far-side clients (web UI, SDKs) after protocol v1 stabilizes | §10 |
+
+**Flagged tension:** a decoupled/scriptable UI is a new path to the
+transmitter. Mitigation is non-negotiable and load-bearing: **the entire TX
+guard lives in `aetherd`, below the protocol boundary; the client is never
+trusted** (§6).
+
+---
+
+## 1. Problem
+
+The UI cannot be changed without rebuilding the whole app, and there is no way
+to run a different UI technology (web, remote thin client, TUI) against the
+engine. Today AetherSDR is a **single monolithic executable** —
+`add_executable(AetherSDR ${ALL_SOURCES})` compiles `models/`+`core/`+`gui/`
+into one binary — and the UI is **100% imperative QWidget** (128 `QWidget`
+subclasses, 0 QML). Any UI change relinks everything, and "a different UI"
+isn't expressible at all.
+
+The same hard-wiring exists on the radio side of the engine. `RadioModel`
+directly owns `RadioConnection` (SmartSDR TCP text) and `PanadapterStream`
+(FlexLib VITA-49 parsing); there is no abstraction between the models and the
+vendor wire protocol, so supporting any other radio family today would mean
+threading a second protocol through the same monolith. Two exhibits show what
+the missing seam forces on people:
+
+- **In-tree**: the one non-Flex source (the receive-only KiwiSDR path) had to
+  bypass the architecture with per-source side-channels
+  (`AudioEngine::feedKiwiSdrAudioData`,
+  `SpectrumWidget::updateKiwiSdrWaterfallRow`) — ad-hoc injection is the only
+  option the current structure offers.
+- **Out-of-tree**: the community bridges non-Flex hardware (IC-9700, TS-450S
+  via Aether-gate/flex-sim, PR #4027) by **impersonating a Flex model and then
+  patching the lies with protocol-extension keys** (`bands=`). The
+  impersonation is structurally leaky — capability truth splits between the
+  fake model string and the patch keys, and the client resolves commands
+  against whichever it consults first (PR #4027's review found band-stack keys
+  that depend on the *impersonated* model's capability flags). A real radio
+  family needs to be a first-class backend (§5.5) declaring its own
+  capabilities (§4.1), not a Flex costume.
+
+We want a boundary such that the engine runs headless and **any** front end —
+including a browser on another device — drives it over a stable protocol; and
+such that the radio-facing side of the engine is equally pluggable: **any**
+radio family, speaking its own wire protocol, presents itself through the same
+models and streams (§5.5).
+
+---
+
+## 2. Background: what already exists (the load-bearing facts)
+
+This RFC is viable *specifically because* four of the five hard pieces are
+already in the tree:
+
+1. **A clean engine boundary is (almost) already enforced.** The dependency
+   arrow points gui→core with exactly one tracked exception
+   (`AutomationServer.cpp` includes `gui/ConnectionPanel.h`) plus five engine
+   files that use QtWidgets — all six are step-1 relocation/seam work, and
+   `tools/check_engine_boundary.py` (CI: `engine-boundary.yml`) now blocks any
+   *new* leakage while that legacy set shrinks to zero. The engine can
+   otherwise already run with no UI attached. This is the expensive invariant
+   most codebases never hold.
+2. **A model-aware control protocol already exists.** `AutomationServer`
+   (`src/core/AutomationServer.cpp`) speaks JSON over a `QLocalServer`:
+   `{"cmd":"get|set|invoke", "model":…, "selector":…, "property":…, "value":…}`
+   → `{"ok":true|false, "error":…}`, plus `dumpTree` introspection. It already
+   does property get/set by selector (frequency, `masterVolume`, per-slice) and
+   `invoke` on actions. It is used for test automation today, but it is a real
+   RPC surface, not click-simulation.
+3. **Streaming radio data over a wire is already solved.** `PanadapterStream`
+   decodes VITA-49 (`PCC 0x8003 → FFT bins → spectrumReady()`;
+   see [`docs/architecture/vita49-format.md`](architecture/vita49-format.md)),
+   and `SmartLinkClient`/`WanConnection`/`TgxlConnection`/`OpusCodec` already
+   relay spectrum + audio across a network.
+4. **The models are the state.** 29 `QObject` models in `src/models/` with
+   change signals — they *are* the thing to serialize.
+
+The **missing fifth piece** is the bulk of the work: the GUI currently reaches
+into the engine through **127 distinct `core/`/`models/` headers** (measured
+2026-07-04; regenerate with `tools/gen_touchpoint_manifest.py`, which emits the
+burndown manifest at `docs/architecture/aetherd-touchpoints.md`). Each of
+those touchpoints must become an enumerated protocol message. Cataloguing that
+surface *is* the project.
+
+That catalogue should be made once, not twice: as each touchpoint is
+enumerated, tag it **universal** (frequency, mode, filter, meters, pan bins —
+things every radio has) or **vendor-specific** (Multi-Flex handles, ATU,
+amplifier control, GUIClientID session restore). The universal set becomes the
+protocol's **core profile**; the rest become namespaced vendor extensions
+(§4.1, §5.5). The same enumeration that defines what clients may call downward
+defines what a radio backend must provide upward — one sweep, two contracts.
+
+The first full tagging pass ran 2026-07-04 (results in the manifest's tags
+sidecar): of 127 headers, **43 universal, 16 mixed** (core-profile protocol
+surface: 54), **26 vendor** (22 flex, 4 kiwi — encapsulate behind the §5.5
+seam, no client protocol needed), and **42 ui-support** (settings, theming,
+device/OS plumbing, control surfaces — need engine-vs-shell home decisions,
+not protocol messages). The protocol-message workload is therefore roughly
+half the raw touchpoint count.
+
+---
+
+## 3. Proposed architecture
+
+```
+  radio hardware ──vendor wire protocols──►  radio backends (IRadioBackend)
+   (FlexRadio via VITA-49 / SmartLink;            │
+    other families via their own           normalized models
+    protocols, added over time)            + frames (§4.2 format)
+                                                  ▼
+                                     aetherd core  (canonical models,
+                                     AudioEngine/DSP, TX guard + arbitration)
+                                                  │
+                                  ┌───────────────┼────────────────┐
+                             control plane     data plane      (both versioned)
+                              JSON-RPC        binary frames
+                                  │               │
+                         ┌────────┴──────┬────────┴────────┐
+                     Qt desktop UI    web UI (browser)   TUI / scripts
+```
+
+`aetherd` is a long-lived process linking a new **`libaethercore`** (all of
+`core/`+`models/`, extracted from the monolith). It owns the radio
+connection(s) and every engine-side object. Inside the library, everything
+radio-facing sits behind an **`IRadioBackend`** seam (§5.5); the engine core,
+the protocol, and every client see only normalized models and frames, never a
+vendor wire protocol. UI clients hold **no** engine state; they render a
+projection of it and send intents.
+
+**Non-goals (explicit):**
+- Not a SmartSDR-protocol reimplementation; this is AetherSDR's *own* boundary.
+- Not a rewrite of the desktop UI as a precondition — the existing QWidget UI
+  becomes the *first* thin client, migrated incrementally.
+- Not a replacement for SmartLink (radio↔engine). `aetherd` is engine↔UI; the
+  two compose (§8).
+- Not a lowest-common-denominator radio abstraction: vendor-specific features
+  surface as namespaced extensions via the capability descriptor (§4.1, §5.5),
+  never silently dropped.
+
+---
+
+## 4. The two channels
+
+The control plane is ~80% built; the data plane is the real engineering.
+
+### 4.1 Control / state plane (easy — extend `AutomationServer`)
+
+Promote the existing JSON command channel into a versioned API with three
+message kinds:
+
+- **request/response** — extend today's `cmd` set, add a correlation `id`.
+- **subscriptions** — a client subscribes to model changes; the engine pushes
+  deltas (`event` frames). This is the genuinely new part: today the bridge is
+  poll/command, but a live UI needs `propertyChanged` pushed to it.
+- **snapshot-on-connect** — a late-joining client receives full state, then
+  deltas, so reconnection and multi-client are consistent.
+
+Version handshake on connect (`hello`/`welcome` with a protocol `version`), so
+old clients fail closed against a newer engine rather than misbehaving.
+`welcome` also carries a **capability descriptor** per connected radio session:
+receiver/slice count, sample-rate range, TX capability and power range,
+tuner/amplifier presence, the **tunable band set** (canonical, region-neutral
+band identifiers — the descriptor is the single source of band truth for
+*every* band surface: menus, keyboard shortcuts, controller band-cycling), and
+the vendor-extension namespaces the backend implements (§5.5). Clients render
+against what the radio *reports*, not against hard-coded assumptions — a
+control the radio doesn't have is disabled or absent, and an unknown extension
+namespace is safely ignorable. Capability state is session-scoped by
+construction: the descriptor arrives in `welcome` and dies with the session,
+so one radio's capabilities can never leak into the next connection.
+
+(The band-set field, and the session-scoping and all-surfaces requirements
+around it, were surfaced by PR #4027 — @nigelfenton's `bands=` discovery-key
+proposal for gateway-bridged non-Flex rigs. That PR is the demand evidence for
+this descriptor; its review findings — stale declarations across sessions,
+only one of four band surfaces gated, silent parse drops, US-only band names —
+are requirements this design must satisfy.)
+
+Sketch:
+```jsonc
+// client → engine
+{ "id": 42, "cmd": "subscribe", "model": "slice", "selector": "0",
+  "properties": ["frequency", "mode", "filterLow", "filterHigh"] }
+// engine → client (snapshot, then deltas)
+{ "id": 42, "ok": true, "snapshot": { "frequency": 14074000, "mode": "DIGU", … } }
+{ "event": "changed", "model": "slice", "selector": "0",
+  "changes": { "frequency": 14074500 } }
+```
+Transport: `QLocalServer` for local clients (already used), **WebSocket** for
+remote/browser (project already links `Qt6::WebSockets`). Same message schema
+on both.
+
+**Scope note — `AutomationServer` splits; it does not move wholesale.** Only
+its *model-facing* half is promoted into the engine: the `get`-by-selector
+machinery, selector resolution, and the TX-guard policy (the seed of §6). Its
+*widget-facing* half — `dumpTree`/`grab`/`invoke` and the connection-flow
+facade — is inherently QtWidgets and stays with the Qt client as a client-side
+test bridge, which keeps its full value after the split (the thin client's own
+rendering/behavior still needs agent-drivable verification). Splitting along
+this internal seam is also what retires the class's tracked entries in the
+engine-boundary checker's legacy lists.
+
+### 4.2 Data plane (hard — new work)
+
+`spectrumReady()` FFT frames (up to ~30fps over a wide bin array), waterfall
+history, audio, and meters cannot ride JSON. Two routes, both wanted:
+
+- **Local: shared-memory ring buffer.** Engine writes FFT/audio frames; clients
+  `mmap` and read latest-frame-wins. Zero-copy, lowest latency. The control
+  channel carries only a handle + format descriptor.
+- **Remote: compact binary frames** over the socket/WebSocket — reuse VITA-style
+  framing for FFT and `OpusCodec` for audio (already in tree). Accepts
+  compression cost + latency.
+
+**Backpressure is mandatory** (this is the failure class behind #3811's
+SO_RCVBUF/adaptive-throttle work): per-client bounded queues, latest-frame-wins
+for spectrum/waterfall, so a slow UI can never stall the engine or the radio
+drain.
+
+---
+
+## 5. Multi-client semantics
+
+FlexRadio is itself multi-client (multiple slices/pans). `aetherd` adopts
+**per-client projection over shared radio state**: there is one authoritative
+engine state (the radio's slices/pans/meters), and each connected UI chooses
+which slices/pans it renders and how. Clients do not get private engine state;
+they get private *views*. Two UIs watching slice 0 see identical data; either
+can request a change, and the resulting `changed` event fans out to both.
+
+**Sessions.** The engine already aggregates per-radio state in `RadioSession`
+(model + TCI + CAT, #3445). The protocol namespaces every subscription and verb
+by session id, so one daemon can host several radios — of the same or different
+families — concurrently, and a client chooses which sessions it projects. The
+per-client-projection rule above applies unchanged within each session.
+
+Open sub-question for sign-off: whether a client may *create/destroy* pans/slices
+(engine-global, affects all clients) or only attach to existing ones. Default
+recommendation: creation allowed but treated as a shared mutation, announced to
+all clients.
+
+---
+
+## 5.5 Pluggable radio backends (`IRadioBackend`)
+
+The engine↔UI boundary is model-shaped, not vendor-shaped — nothing in §4's
+protocol names a wire format. The same discipline is applied on the radio side:
+inside `libaethercore`, everything that touches a vendor protocol sits behind
+one interface. An `IRadioBackend` implementation owns, per radio family:
+
+- **Discovery** — however that family announces itself (broadcast, directory,
+  manual endpoint), normalized to one discovered-radio record for the picker.
+- **Connection lifecycle** — connect/teardown/reconnect against the vendor
+  transport.
+- **Intents down** — the engine's canonical verbs (tune, mode, filter, gain,
+  key/unkey, …) translated to vendor commands.
+- **State and streams up** — vendor status normalized into the canonical
+  models, and spectrum/waterfall/audio/meter data delivered in the §4.2 frame
+  format, whatever the radio actually sends.
+
+**Where DSP runs is a backend property, invisible above the seam.** Some radio
+families demodulate and compute FFTs on the hardware — that backend is mostly
+a protocol decoder. Others deliver raw IQ and expect the client to do the work
+— that backend owns an engine-side DSP chain (demodulation, AGC, S-meter,
+panadapter FFT; the building blocks — liquid-dsp, FFTW, the `WfmDsp` pattern —
+are already in the tree). Either way the models and frames above the interface
+are identical, so no client can tell the difference. This is also why the
+backend seam belongs in the *engine*: DSP-heavy backends make the §8 topology
+(engine at the shack, thin clients remote) the natural deployment for radio
+families that have no native remote transport of their own.
+
+**The SmartSDR stack becomes the first backend.** `FlexBackend` wraps the
+existing `RadioConnection` + `PanadapterStream` + `RadioDiscovery` classes with
+**zero behavior change** — a pure seam-extraction refactor, verified
+byte-identical on the slice-0 RX flow. The KiwiSDR path and its side-channels
+are a candidate to migrate into a second, receive-only backend once the seam
+exists, retiring the per-source injection API.
+
+**Canonical core vs vendor extensions.** Every backend must implement the core
+profile (§2's universal set) and may register namespaced extensions, surfaced
+through the capability descriptor (§4.1). The core profile versions with the
+protocol; extensions version independently per backend.
+
+---
+
+## 6. TX safety across the boundary (Principle VI — non-negotiable)
+
+This is the most important section. A decoupled or scriptable UI is a new path
+to the transmitter, so:
+
+1. **The guard lives in the engine, below the protocol.** The
+   `kTxKeyingProperty` marker + `AETHER_AUTOMATION_ALLOW_TX` logic that
+   `AutomationServer` already enforces must gate *every* TX-keying verb in
+   `aetherd`. The client is never trusted to self-police. A protocol request to
+   key TX is checked engine-side exactly as a local widget action is today.
+   The guard is also **backend-agnostic**: it sits above the `IRadioBackend`
+   seam (§5.5), so there is exactly one arbitration/guard path no matter how a
+   given radio family is keyed (command verb, in-stream flag bit, hardware
+   line). A backend translates the engine's single keying decision to its
+   vendor mechanism; no backend implements its own guard.
+2. **TX arbitration.** With multiple clients, exactly **one** may hold the TX
+   lock at a time; others are read-only for keying or denied. Acquiring/
+   releasing the lock is an explicit, audited protocol verb. No client may key
+   without holding it.
+3. **Per-client authentication.** Remote clients authenticate before any
+   control verb; TX capability is a separate grant from RX/observe. A
+   read-only/observer client (e.g. a public dashboard) can never key.
+   Transport security ships as **WireGuard** (§8): `aetherd` binds its remote
+   listeners to localhost and the WireGuard interface only, so off-box
+   clients reach the engine exclusively through the tunnel, which supplies
+   encryption and cryptographic peer identity. The engine's own auth layer
+   then maps a peer to its capability grant — the tunnel authenticates the
+   *device*, `aetherd` authorizes the *client*. Browser clients that cannot
+   ride a VPN use WebSocket over TLS with the same capability grants; both
+   paths fail closed.
+4. **Fail closed.** Unknown protocol version, lost lock, dropped auth, or
+   ambiguous state → TX denied + force-unkey, mirroring the existing watchdog
+   (`forceUnkey()`), including the CWX-buffer abort (#3646). For radio families
+   keyed by a continuous TX stream, force-unkey additionally halts that stream,
+   so any hardware-side keep-alive watchdog provides a second, independent
+   unkey path. Because the guard runs in the engine, fail-closed is **local to
+   the radio** in the §8 shack topology: a lost remote client is detected and
+   unkeyed engine-side — no unkey command has to survive the dying WAN link.
+
+The acceptance bar: **a malicious or buggy client must not be able to key the
+transmitter.** Any design that can't guarantee that is rejected.
+
+---
+
+## 7. The hard problems (honest cost)
+
+1. **Enumerating the surface.** The 127 gui→engine header dependencies each map
+   to protocol messages. Mechanical but large; this is the bulk of the effort.
+   The non-mechanical part is the §2 tagging pass: deciding, touchpoint by
+   touchpoint, what is core profile and what is a vendor extension. The models
+   grew up around one vendor's semantics, so canonicalizing them is design
+   work, not transcription.
+2. **Data-plane latency/throughput.** 30fps wide FFT + low-latency audio. Solved
+   locally by shm; remotely it's a compression/latency budget.
+3. **State sync & reconnection.** Snapshot-on-connect, delta consistency,
+   client reconnect without engine restart.
+4. **Lifecycle.** Daemon start/stop, crash recovery, socket discovery, the
+   desktop UI auto-spawning a local `aetherd`.
+5. **Backpressure** (see §4.2).
+
+---
+
+## 8. Relationship to SmartLink
+
+SmartLink relays **radio↔engine** over WAN. `aetherd` relays **engine↔UI**. They
+compose, and the composition unlocks a better topology: run `aetherd` *at the
+shack* next to the radio (e.g. on a Pi), keeping the heavy VITA hop on the LAN,
+and send only the (cheaper, already-compressed) UI stream over the WAN to thin
+clients anywhere. SmartLink remains the radio-discovery/relay layer; `aetherd`
+sits above it.
+
+The same topology is *more* valuable for radio families that have no native
+remote transport at all — and for DSP-heavy backends (§5.5) whose raw sample
+streams are too fat for a WAN: the engine at the shack reduces them to the same
+compact frames every other radio sends, so remote operation falls out of the
+architecture instead of being re-solved per radio family.
+
+**Why engine-at-the-shack** (the operator-facing case, informing §12 Q4):
+
+- **WAN trouble degrades the picture, not the radio.** The §4.2 backpressure
+  rules (per-client bounded queues, latest-frame-wins) apply to a lossy WAN
+  exactly as to a slow UI: frames drop and the waterfall thins momentarily,
+  but the radio drain and the audio pipeline stay LAN-local and never stall.
+  A remote *thick* client puts WAN jitter directly on the timing-critical
+  radio streams; this topology structurally cannot.
+- **TX fail-closed executes at the radio.** The §6 guard runs in the engine,
+  physically at the shack — a dropped or misbehaving WAN client is detected
+  and force-unkeyed locally, with no unkey command needing to survive the
+  dying link.
+- **The session outlives the client.** The engine holds the radio connection
+  continuously; snapshot-on-connect (§4.1) means an operator can sleep the
+  laptop, switch to a tablet, or ride out a WAN drop and reconnect to a live,
+  fully-current session — the radio side never resets.
+- **Thin clients are genuinely thin.** All DSP runs engine-side (§5.5), so the
+  remote device only renders frames and plays Opus — browser/tablet-class
+  hardware suffices, with no per-device DSP setup to keep consistent.
+
+**Remote access ships with WireGuard.** `aetherd` does not invent transport
+security: packaging bundles WireGuard (kernel-native on Linux, official apps
+on every client OS, `wireguard-go` as fallback) plus provisioning helpers —
+engine-side key generation and per-client peer-config/QR export — so
+"operate remotely" is a first-run workflow, not a networking project. The
+protocol listeners bind only to localhost and the WireGuard interface
+(default-deny toward the WAN); §6's per-client capability grants ride inside
+the tunnel. WireGuard is GPLv2/MIT (license-compatible) and cross-platform,
+consistent with §11.
+
+---
+
+## 9. Alternatives considered
+
+- **Alternative A — QML on `libaethercore` (in-process).** Extract the engine
+  library, expose models via `Q_PROPERTY`/`Q_INVOKABLE`, rebuild the UI in QML
+  loaded at runtime (hot-reloadable, no C++ recompile to restyle). **Far
+  cheaper** because it skips the entire data-plane serialization problem
+  (in-process shared memory is free). **Recommended if the goal is desktop
+  re-styling only.** Note: models are not QML-ready yet (only 2/29 use
+  `Q_PROPERTY`, 0 `Q_INVOKABLE`), so step one is the same property work.
+  Backend pluggability (§5.5) is orthogonal: the `IRadioBackend` seam lives in
+  `libaethercore` and works identically under this alternative.
+- **Alternative B — UI plugin `.so` via `QPluginLoader`.** Swap a compiled UI
+  plugin without rebuilding core. Less friendly than QML (plugin is still
+  compiled C++), keeps native QWidget. Middle ground; weak "no rebuild" payoff.
+- **`aetherd` (this RFC)** is the maximal-decoupling option and the **only** one
+  that delivers web/remote/multi-client/headless. Its cost is concentrated in
+  the data plane; pay it only if that remote/web/multi-client story is the real
+  objective.
+
+**Decision rule:** choose `aetherd` iff the goal includes
+web/remote/multi-client/headless — including remote operation of radio families
+with no native remote transport (§8). Otherwise choose Alternative A. Pluggable
+backends (§5.5) are reachable either way; only the UI boundary differs.
+
+---
+
+## 10. Staged plan
+
+1. **Extract `libaethercore`.** Split the monolith into an engine library +
+   thin gui shell. **Rehearsed 2026-07-04** — the split configures, builds,
+   and passes all 56 tests on Linux
+   ([dry-run findings](architecture/aetherd-step1-dryrun.md)). Verdict:
+   ~95% a CMake change, not 100% — one source edit is unavoidable (a
+   moc-jumbo-TU incomplete-type bug the monolith masks) plus the
+   `AutomationServer`↔`ConnectionPanel` dependency inversion; the
+   `HAVE_*`-defines-PUBLIC judgment calls and ranked risks are in the
+   findings doc. Speeds nothing by itself (isolation, not raw speed) but is
+   the shared prerequisite for *both* this RFC and Alternative A.
+2. **Extract the `IRadioBackend` seam** (§5.5): wrap the existing SmartSDR
+   stack (`RadioConnection`, `PanadapterStream`, `RadioDiscovery`) in a
+   `FlexBackend` with zero behavior change, verified byte-identical on the
+   slice-0 RX flow. From this point a new radio family is a new backend —
+   shippable in-process in the desktop app immediately, and served through the
+   daemon automatically once the later steps land. Additional backends proceed
+   in parallel with steps 3–7 without touching them.
+3. **Promote `AutomationServer`** into the versioned control protocol:
+   `hello`/`welcome` handshake with capability descriptor, `subscribe`,
+   snapshot-on-connect, `event` deltas (§4.1).
+4. **Engine-side TX arbitration + per-client auth** (§6) — landed *with* step 3,
+   never after.
+5. **Binary data plane** (§4.2): shm ring buffer for local first, then
+   binary-frame-over-WebSocket for remote.
+6. **One reference thin client** — port a slice of the existing Qt UI to talk
+   protocol instead of direct calls, to prove the surface is complete.
+7. **Web UI / additional clients** fall out of the proven protocol.
+
+**Repo layout: monorepo, for the whole migration and beyond.** `aetherd` is
+another CMake target (`libaethercore` + a headless executable) alongside the
+existing app target, in the pattern the repo already uses for `hal-plugin/`
+and `plugins/`. The reasons are structural, not preference:
+
+- Steps 1–6 carve the boundary out of 127 shared touchpoints; nearly every PR
+  in that window touches engine and desktop client together. One repo keeps
+  each conversion an atomic, revertable commit with one CI run — two repos
+  mean paired PRs and protocol-version skew between checkouts.
+- The desktop app auto-spawns its local engine, so the two ship and version as
+  a unit (one CalVer, one CHANGELOG, one release pipeline).
+- Governance is repo-scoped and load-bearing here: the constitution, agent
+  guides, signed-commit/CODEOWNERS protection, CI image, and the step-4 rule
+  ("TX arbitration lands *with* the protocol, never after") are enforceable by
+  review in one repo but become cross-repo coordination promises in two.
+- The engine/client separation is enforced the same way core/→gui/ already is:
+  by dependency direction (`aetherd` must never link QtWidgets), checked
+  cheaply in CI — a directory boundary, not a repo boundary.
+
+**Agent-guide discipline.** AetherSDR's contributors are predominantly AI
+agents that read `AGENTS.md` before every change, so each milestone PR above
+must update `AGENTS.md` **in the same PR** — the routing rules, ratchets, and
+claim/verification recipes for each step are pre-drafted in
+[`docs/aetherd-agents-md-staging.md`](aetherd-agents-md-staging.md) and land
+atomically with their step. A milestone PR that changes structure without its
+`AGENTS.md` block is incomplete.
+
+The natural fracture line for future splits is the **protocol, not the
+process**: once protocol v1 is stable, far-side clients with different
+toolchains and contributor bases (web UI, third-party client SDKs, a
+standalone protocol spec for external authors) may earn their own repos. The
+engine, the models, and the Qt desktop client stay together permanently. A
+shack-appliance build (the §8 topology on a small ARM box) is packaging work
+in `packaging/`, not a repo split.
+
+---
+
+## 11. Constitution compliance
+
+- **Principle VI (TX safety):** the entire guard moves *into* the engine below
+  the boundary; arbitration + auth + fail-closed (§6). No client is trusted.
+- **Principle V (settings):** protocol/engine config persists as nested JSON
+  under a single key; no new flat `AppSettings`.
+- **Principle IV (clean-room):** the protocol is AetherSDR's own design, not
+  derived from any proprietary binary or wire format.
+- **Principles I & IV, per backend (§5.5):** FlexLib remains the sole protocol
+  authority for the SmartSDR backend. Any additional backend must name its own
+  authoritative, openly documented protocol reference in its design doc and
+  implement from that documentation — the clean-room rule applies
+  backend-by-backend.
+- **Cross-platform (operator feedback):** `QLocalServer`/WebSocket/shared-memory
+  are all Qt-portable; no platform-specific surface in the boundary.
+
+---
+
+## 12. Open questions for reviewers
+
+1. Is the real goal remote/web/multi-client (→ `aetherd`) or desktop re-styling
+   (→ Alternative A)? This determines everything.
+2. Pan/slice creation by clients: shared mutation, or attach-only? (§5)
+3. Auth model for remote clients — transport security is decided (WireGuard,
+   §6/§8); still open: are capability grants a separate `aetherd` credential
+   or a reuse of SmartLink identity, and what credential carries the
+   browser/TLS path where a VPN isn't practical?
+4. Is a headless-at-the-shack topology (§8) a target use case, or is local-only
+   sufficient for v1?
+5. Multi-session (several radios under one engine, §5): required for v1, or
+   does v1 ship single-session with the namespacing reserved in the protocol?
+6. Should the core-profile / vendor-extension split (§2, §5.5) be ratified as
+   part of protocol v1, or grown incrementally as the second backend lands?

--- a/docs/aetherd-headless-engine-design.md
+++ b/docs/aetherd-headless-engine-design.md
@@ -116,7 +116,7 @@ already in the tree:
    change signals — they *are* the thing to serialize.
 
 The **missing fifth piece** is the bulk of the work: the GUI currently reaches
-into the engine through **127 distinct `core/`/`models/` headers** (measured
+into the engine through **140 distinct `core/`/`models/` headers** (measured
 2026-07-04; regenerate with `tools/gen_touchpoint_manifest.py`, which emits the
 burndown manifest at `docs/architecture/aetherd-touchpoints.md`). Each of
 those touchpoints must become an enumerated protocol message. Cataloguing that
@@ -131,9 +131,9 @@ protocol's **core profile**; the rest become namespaced vendor extensions
 defines what a radio backend must provide upward — one sweep, two contracts.
 
 The first full tagging pass ran 2026-07-04 (results in the manifest's tags
-sidecar): of 127 headers, **43 universal, 16 mixed** (core-profile protocol
-surface: 54), **26 vendor** (22 flex, 4 kiwi — encapsulate behind the §5.5
-seam, no client protocol needed), and **42 ui-support** (settings, theming,
+sidecar): of 140 headers, **53 universal, 16 mixed** (core-profile protocol
+surface: 69), **26 vendor** (22 flex, 4 kiwi — encapsulate behind the §5.5
+seam, no client protocol needed), and **45 ui-support** (settings, theming,
 device/OS plumbing, control surfaces — need engine-vs-shell home decisions,
 not protocol messages). The protocol-message workload is therefore roughly
 half the raw touchpoint count.
@@ -369,7 +369,7 @@ transmitter.** Any design that can't guarantee that is rejected.
 
 ## 7. The hard problems (honest cost)
 
-1. **Enumerating the surface.** The 127 gui→engine header dependencies each map
+1. **Enumerating the surface.** The 140 gui→engine header dependencies each map
    to protocol messages. Mechanical but large; this is the bulk of the effort.
    The non-mechanical part is the §2 tagging pass: deciding, touchpoint by
    touchpoint, what is core profile and what is a vendor extension. The models
@@ -493,7 +493,7 @@ another CMake target (`libaethercore` + a headless executable) alongside the
 existing app target, in the pattern the repo already uses for `hal-plugin/`
 and `plugins/`. The reasons are structural, not preference:
 
-- Steps 1–6 carve the boundary out of 127 shared touchpoints; nearly every PR
+- Steps 1–6 carve the boundary out of 140 shared touchpoints; nearly every PR
   in that window touches engine and desktop client together. One repo keeps
   each conversion an atomic, revertable commit with one CI run — two repos
   mean paired PRs and protocol-version skew between checkouts.

--- a/docs/aetherd-rfc-signoff.md
+++ b/docs/aetherd-rfc-signoff.md
@@ -1,0 +1,209 @@
+# aetherd RFC — maintainer sign-off packet
+
+Companion to [`aetherd-headless-engine-design.md`](aetherd-headless-engine-design.md).
+Every open decision from the RFC's §0 table and §12 questions, one entry
+each: recommendation, why, and what changes if vetoed. Check a box (or
+strike it and note the override) — when all entries are resolved, flip
+the RFC's **Status** line from Draft to Accepted and implementation can
+begin per §10.
+
+Bias inherited from the RFC: successful, consistent operation for every
+operator skill level; TX safety is never weakened by the split.
+
+---
+
+## D1 — Goal scope (§1, §12 Q1)
+
+**Recommendation: `aetherd` (the daemon split), not Alternative A (QML
+restyling).**
+The goals on the table — remote operation, thin/browser clients,
+multi-client, headless shack box, and pluggable radio families including
+DSP-heavy ones with no native remote transport — are exactly the set the
+RFC's own decision rule says only `aetherd` delivers. Alternative A
+solves only desktop restyling.
+*If vetoed:* stop after `libaethercore` + `IRadioBackend` (steps 1–2,
+which Alternative A needs anyway) and reassess.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D2 — Process model (§3)
+
+**Recommendation: one long-lived `aetherd` daemon; all UIs are peer
+clients.** The desktop app auto-spawns a local engine, so ordinary users
+never see the daemon.
+*If vetoed:* the RFC collapses to Alternative A/B — see D1.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D3 — Local transport (§4.1)
+
+**Recommendation: `QLocalServer`** — already proven by the automation
+bridge, portable, zero new dependencies.
+*If vetoed:* localhost TCP/WebSocket works but gives up filesystem-
+permission access control.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D4 — Remote transport (§4.1)
+
+**Recommendation: WebSocket** — already linked (`Qt6::WebSockets`),
+browser-compatible, one schema shared with the local path.
+*If vetoed:* raw TCP framing loses the browser story.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D5 — Remote security (§6, §8)
+
+**Recommendation: ship with WireGuard.** Remote listeners bind to
+localhost + the WireGuard interface only (default-deny toward the WAN);
+packaging bundles provisioning helpers (keygen, per-client peer-config/QR
+export). The tunnel authenticates the device; `aetherd` capability grants
+authorize the client. Browser/TLS path is an explicit opt-in for the
+no-VPN case.
+*Consequence to be aware of:* out of the box there is NO internet-exposed
+`aetherd` port at all.
+*If vetoed:* TLS + credential auth on the open WebSocket becomes the
+primary surface — more exposed, more to audit.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D6 — Data plane, local (§4.2)
+
+**Recommendation: shared-memory ring buffer**, latest-frame-wins;
+zero-copy FFT/waterfall/audio to local clients. Precedent in-tree:
+the DAX HAL plugin's shm ring.
+*If vetoed:* frames over the local socket — simpler, measurable CPU cost
+at 60 fps panadapter rates.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D7 — Data plane, remote (§4.2)
+
+**Recommendation: binary frames over the WebSocket + Opus audio**,
+reusing the in-tree VITA-style framing and `OpusCodec`. Mandatory
+per-client backpressure, latest-frame-wins.
+*If vetoed:* no realistic alternative at 30 fps spectrum over WAN; this
+one is effectively load-bearing.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D8 — TX arbitration (§6)
+
+**Recommendation: single-holder TX lock + per-client auth, enforced in
+the engine, backend-agnostic, fail-closed (force-unkey local to the
+radio).** Acceptance bar: a malicious or buggy client cannot key the
+transmitter. Lands *with* the protocol (step 4), never after.
+*If vetoed:* no acceptable alternative exists; a veto here should reject
+the RFC instead.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D9 — Multi-client view semantics (§5)
+
+**Recommendation: per-client projection over shared radio state.**
+Two UIs watching slice 0 see identical truth; either may mutate; changes
+fan out to all.
+*If vetoed:* per-client private state forks reality between screens —
+recommend against.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D10 — Pan/slice creation by clients (§5, §12 Q2)
+
+**Recommendation: creation allowed, treated as a shared mutation
+announced to all clients** (matches how multiple SmartSDR clients already
+behave against one radio). Observer-grade clients (D5/D8 grants) cannot
+create/destroy.
+*If vetoed (attach-only):* simpler, but a remote client could never open
+a new pan — hurts the primary remote-operation use case.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D11 — Radio backends (§5.5)
+
+**Recommendation: pluggable `IRadioBackend` inside `libaethercore`;
+SmartSDR stack becomes `FlexBackend` (zero behavior change) in step 2.**
+Where DSP runs is a backend property invisible above the seam; KiwiSDR
+migrates to a backend later, retiring its side-channels.
+*If vetoed:* every future radio family threads through the monolith —
+the touchpoint audit (121 headers, 26 already vendor-specific) argues
+this is the cheapest moment to cut the seam.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D12 — Capability descriptor (§4.1)
+
+**Recommendation: per-session capability descriptor in `welcome`**
+(slice count, sample rates, TX power range, tuner/amp presence, extension
+namespaces); clients render what the radio reports.
+*If vetoed:* clients hard-code radio assumptions and every new backend
+breaks every client.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D13 — Multi-session (§5, §12 Q5)
+
+**Recommendation: reserve session namespacing in protocol v1, ship
+single-session first.** The message shape carries a session id from day
+one (cheap now, breaking change later); the engine hosts one radio until
+multi-radio work is actually scheduled.
+*If vetoed toward full multi-session v1:* adds engine lifecycle work to
+the critical path for little immediate gain.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D14 — Repo layout (§10)
+
+**Recommendation: monorepo, permanently for engine + models + Qt client;
+future splits happen at the protocol line only** (web UI, SDKs, spec).
+Rationale in RFC §10 (atomic migration commits, ship-as-a-unit
+versioning, repo-scoped governance, CI-enforced dependency direction).
+*If vetoed:* paired-PR coordination overhead lands on every migration
+change at 5–10 PRs/day.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D15 — Auth credential model (§12 Q3, remainder)
+
+**Recommendation: a separate `aetherd` credential** (per-client identity
++ capability grant: observe / control / TX), NOT SmartLink identity.
+SmartLink authenticates *radio↔engine*; reusing it for *engine↔UI* would
+couple the boundary to one vendor's account system — wrong for a
+multi-backend engine. The same credential rides the browser/TLS opt-in
+path.
+*If vetoed toward SmartLink reuse:* simpler for Flex-only users, blocks
+vendor-neutral remote operation.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D16 — Shack topology as v1 target (§8, §12 Q4)
+
+**Recommendation: yes — engine-at-the-shack is a v1 target**, not a
+later nicety. The operator-facing case is §8's list (WAN loss degrades
+the view not the radio; TX fail-closed executes at the radio; sessions
+outlive clients; thin clients stay thin). Concretely: `aetherd` must run
+headless on small ARM hardware (Pi-class) from v1, and CI should build
+for it.
+*If vetoed (local-only v1):* remote work compresses into "later," and
+D5's shipping decision loses its main consumer.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+## D17 — Core-profile ratification (§2, §5.5, §12 Q6)
+
+**Recommendation: grow incrementally; ratify at protocol v1.0.** The
+2026-07-04 tagging pass (121 headers: 38 universal / 16 mixed / 26 vendor
+/ 41 ui-support) is the provisional core-profile draft; it hardens as
+touchpoints convert and freezes when protocol v1.0 does. Ratifying a
+final core profile before any conversion experience would be
+speculation.
+*If vetoed toward ratify-first:* adds a design phase before step 3 can
+start.
+
+- [x] Approved — 2026-07-04, KK7GWY (all recommendations as written)
+
+---
+
+**When all boxes are resolved:** flip the RFC Status line to Accepted
+(record date + any overrides), announce the step-1 move window, and start
+the §10 sequence.

--- a/docs/architecture/aetherd-step1-dryrun.md
+++ b/docs/architecture/aetherd-step1-dryrun.md
@@ -1,0 +1,122 @@
+# aetherd step 1 dry run — `libaethercore` split rehearsal
+
+**Date:** 2026-07-04 · **Platform proven:** Linux (Arch, GCC, Ninja,
+RelWithDebInfo) · **Status:** throwaway rehearsal, nothing committed.
+The modified `CMakeLists.txt` + two-file `AutomationServer` edit live in
+the git worktree `worktree-agent-a1f77800bf9381e8b`
+(`.claude/worktrees/agent-a1f77800bf9381e8b`) for the step-1 implementer
+to consult; the worktree is disposable — this document is the durable
+artifact.
+
+## Verdict
+
+**The split works**: `libaethercore.a` (235 MB, 277 objects — src/core +
+src/models + vendored rnnoise/ggmorse/RADE/specbleach/mosquitto/rtmidi)
+plus `AetherSDR` (363 MB, 173 objects — src/gui + main.cpp + qrc/shaders)
+linking it. Full test suite passes: **56/56** (`QT_QPA_PLATFORM=offscreen`).
+But the RFC's step-1 claim needs one correction: it is **95% CMake,
+not 100%** — one source edit was unavoidable (below).
+
+## The headline finding: the moc jumbo-TU trap
+
+`AutomationServer.h` has an inline setter assigning into
+`QPointer<ConnectionPanel>` with only a forward declaration. The monolith
+builds this **by accident**: AUTOMOC aggregates every moc into one
+`mocs_compilation.cpp`, and `moc_ConnectionPanel.cpp` happens to complete
+the type earlier in that same TU, so the template instantiation at
+end-of-TU succeeds. Split the targets and the type is never completed →
+hard error. Fix: out-line the setter into the .cpp (+6/−1, behavior
+identical).
+
+Consequences:
+- **Step 1 requires a (tiny) source change**, and the monolith cannot
+  even detect this class of latent bug — expect more as boundaries
+  tighten. GCC already warns (`-Wsfinae-incomplete`) about the same
+  pattern core-internally in `RadioConnection`/`SmartCatSession`.
+- The dry run left `AutomationServer.cpp`'s `gui/ConnectionPanel.h`
+  include in place (EB1, tracked): the archive carries four **undefined
+  `ConnectionPanel::automation*` symbols** (verified via `nm`) that only
+  resolve because the panel is an exe object. The real step-1 PR must
+  invert this: an `IConnectionAutomation` facade defined in core,
+  implemented by `ConnectionPanel` in gui. Relocating AutomationServer
+  wholesale to gui would also work but is wrong for aetherd — its
+  model-facing half is the control-plane seed (RFC §4.1 scope note).
+
+## What the real step-1 PR must contain
+
+1. The mechanical CMake split (target lists, dep retargeting, warning
+   flags over both targets) — see the worktree diff.
+2. The `AutomationServer` out-lined setter + `IConnectionAutomation`
+   dependency inversion (the only true refactor).
+3. Judgment-call items, each a review point:
+   - **All `HAVE_*` feature defines PUBLIC on aethercore** — gui TUs test
+     every one (HAVE_MIDI/MQTT/RADE/HIDAPI/SERIALPORT/WEBSOCKETS/
+     KEYCHAIN/NVIDIA_AFX/PIPEWIRE/SPECBLEACH). A missed one **compiles
+     silently and drops UI features** — the nastiest failure mode here.
+     Recommend a CI assert comparing define sets or built-in feature
+     lists before/after.
+   - `AETHER_GPU_SPECTRUM` must be PUBLIC too (AutomationServer's
+     QRhiWidget grab path) — a GUI render flag reaching the engine is
+     itself a boundary smell to fix when the class splits.
+   - Third-party include dirs PUBLIC (gui includes `RtMidi.h`/`hidapi.h`
+     directly); Qt6::SerialPort/WebSockets PUBLIC (gui uses them
+     directly).
+   - **qrc/shaders/DFNR resources stay on the exe** — rcc registration is
+     process-global; putting resources in a static lib is a linker-elision
+     trap.
+   - `UlanziDialBackend.h` (header-only Q_OBJECT) must ride the engine
+     target's sources or its metaobject vanishes.
+
+## Dependency surfaces (measured, Linux)
+
+- **libaethercore:** Qt6 Core, Concurrent, Gui (QImage/QColor —
+  load-bearing everywhere), Network, Multimedia (AudioEngine),
+  SerialPort, WebSockets, DBus, Qt6Keychain, **and Widgets** (the tracked
+  legacy files; drops to Widgets-free once the step-1 relocations/splits
+  land). Effectively the *entire* third-party pile: zlib, mspack,
+  mosquitto+OpenSSL, opus/RADE, fftw3(+f), specbleach, DFNR, rnnoise,
+  ggmorse, liquid-dsp, rtmidi+alsa, hidapi, portaudio, pipewire, modem
+  libs.
+- **AetherSDR exe:** just qgeoview, Qt6::GuiPrivate/ShaderTools (QRhi),
+  dl — everything else arrives transitively. The exe surface is tiny,
+  which is exactly what the RFC wants.
+
+## Timings (32 threads, no ccache)
+
+| Step | Time |
+|---|---|
+| Configure | 8.1 s |
+| Full build (1,297 edges incl. tests) | ≈131 s |
+| Null build | 0.07 s |
+| Incremental, gui .cpp touched | 19.0 s (dominated by 363 MB debug link) |
+| Incremental, core .cpp touched | 18.0 s (13.7 s compile+ar, 4.4 s relink) |
+
+Full-build cost unchanged vs monolith (same TUs + one `ar`). The win is
+**isolation** — gui edits no longer re-scan the 277-object engine, and a
+future `aetherd` builds core without gui/QtPrivate/qgeoview — not raw
+speed. Incrementals are link-dominated either way.
+
+## Ranked risks for the move-window PR
+
+1. EB1 dependency inversion (AutomationServer ↔ ConnectionPanel) —
+   touches the automation surface agents themselves use; needs behavior
+   tests.
+2. PUBLIC/PRIVATE define misplacement — silent feature loss; add the CI
+   define-set assert.
+3. Widgets-in-engine relocations/splits (the tracked legacy set; e.g.
+   ThemeManager splits into token resolution vs QApplication styling).
+4. macOS/Windows platform blocks retargeted by reasoning only — this dry
+   run proves Linux; CI matrix must prove the rest.
+5. Latent moc-completeness landmines (`RadioConnection`,
+   `SmartCatSession`) — any further target splitting can trip them.
+6. Test-target drift — 70+ test executables compile core sources
+   directly; they should eventually link libaethercore or they'll mask
+   boundary regressions.
+
+## Checker follow-ups from this run
+
+- `QRhiWidget` added to `tools/check_engine_boundary.py`'s QtWidgets
+  class set (AutomationServer.cpp includes it; the file was already
+  tracked, the class name wasn't detected).
+- Future ratchet idea once the split lands: `nm`-audit `libaethercore.a`
+  in CI for undefined symbols in the `AetherSDR::` gui namespace.

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -1,0 +1,764 @@
+{
+ "core/AdaptiveFilterEngine.h": {
+  "tag": "universal",
+  "note": "GUI-thread adaptive RX passband coordinator over SliceModel/spectrum frames; canonical radio state, no vendor ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/AgcTCalibrator.h": {
+  "tag": "universal",
+  "note": "Engine algo sweeping slice AGC threshold vs audio RMS/S-meter to recommend a value; only canonical state.",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/AppSettings.h": {
+  "tag": "ui-support",
+  "note": "Client-side XML settings store (SSDR.settings-style key/value persistence); app plumbing, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/AudioEngine.h": {
+  "tag": "mixed(flex)",
+  "note": "Client audio I/O + full RX/TX DSP chain (universal) fused with Flex VITA-49/DAX/Opus TX and Kiwi buffering",
+  "split": "Core: RX/TX volume/mute/pan, NR (NR2/RN2/NR4/DFNR/AFX), client EQ/Comp/Gate/DeEss/Tube/Pudu/Reverb/limiter chains, CW sidetone/keying, metering/scopes, device selection. Vendor 'flex': VITA-49 TX packetization (FLEX_OUI, PCC codes), DAX TX stream IDs/routes, Opus SmartLink TX, PanadapterStream feed. Vendor 'kiwi': feedKiwiSdrAudioData + per-source Kiwi buffers/gain/pan/delay.",
+  "confidence": "high"
+ },
+ "core/AudioOutputRouter.h": {
+  "tag": "ui-support",
+  "note": "Registry fanning the user-selected QAudioDevice to local playback sinks; OS device plumbing, no radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/AutomationServer.h": {
+  "tag": "ui-support",
+  "note": "QLocalServer GUI-automation/test bridge (dumpTree/grab/invoke on QWidgets); dev tooling, stays in gui shell",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/BandStackSettings.h": {
+  "tag": "universal",
+  "note": "Per-radio band-stack memories (freq/mode/filter/AGC/NB-NR) \u2014 canonical radio state; only the XML store is client-side",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CallsignInfo.h": {
+  "tag": "universal",
+  "note": "Callsign lookup result struct (name/QTH/grid, JSON cache form); radio-agnostic spot/logging data.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CallsignLookupService.h": {
+  "tag": "universal",
+  "note": "Orchestrates QRZ/cty.dat callsign lookups + cache; radio-agnostic spot/logging integration.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CallsignUtils.h": {
+  "tag": "universal",
+  "note": "Stateless callsign parsing/validation helpers; radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CatPort.h": {
+  "tag": "ui-support",
+  "note": "CAT server (TCP+PTY, rigctld/TS-2000/FlexCAT dialects) for external apps; desktop integration, needs a home",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ChannelStripPresets.h": {
+  "tag": "universal",
+  "note": "Named-preset save/recall/import-export for the engine audio DSP chain; operates on core-profile DSP state.",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/ClientComp.h": {
+  "tag": "universal",
+  "note": "Client-side TX dynamics DSP (compressor/limiter/drive/phase rotator + GR meters); radio-agnostic engine DSP.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientDeEss.h": {
+  "tag": "universal",
+  "note": "Client TX DSP de-esser (sidechain bandpass + dynamics, meters); radio-agnostic engine DSP chain stage",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientEq.h": {
+  "tag": "universal",
+  "note": "Client-side parametric EQ DSP in AudioEngine (RX/TX paths); radio-agnostic engine DSP, no vendor protocol ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientFinalLimiter.h": {
+  "tag": "universal",
+  "note": "Final-stage brickwall limiter in client TX DSP chain (ceiling/trim/DC-block + meters); radio-agnostic DSP.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientGate.h": {
+  "tag": "universal",
+  "note": "Client TX-chain downward expander/noise gate DSP (thresh/ratio/hold + meters) \u2014 radio-agnostic engine DSP.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientPudu.h": {
+  "tag": "universal",
+  "note": "Client-side TX audio exciter (PooDoo dual-band DSP) \u2014 engine TX DSP chain module, no radio-family coupling",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientPuduMonitor.h": {
+  "tag": "universal",
+  "note": "TX-audio monitor: record/replay post-DSP client TX chain output without keying; radio-agnostic DSP feature",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientQuindarTone.h": {
+  "tag": "universal",
+  "note": "Engine-side TX DSP stage: Quindar tone/Morse intro-outro on PTT; works over any radio's TX audio path.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientReverb.h": {
+  "tag": "universal",
+  "note": "Client TX-chain Freeverb DSP (size/decay/damping/predelay/mix + meters); radio-agnostic engine DSP feature.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientTube.h": {
+  "tag": "universal",
+  "note": "Client TX-chain tube saturator DSP (drive/tone/env follower); radio-agnostic engine DSP, no vendor ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ClientTxTestTone.h": {
+  "tag": "universal",
+  "note": "1 kHz TX test-tone generator injected at head of client TX DSP chain; radio-agnostic engine DSP feature",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CommandParser.h": {
+  "tag": "vendor(flex)",
+  "note": "Stateless parser/builder for SmartSDR TCP wire lines (V/H/C/R/S/M, FlexLib semantics) \u2014 pure Flex protocol.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CwCallsignSpotter.h": {
+  "tag": "universal",
+  "note": "Spots callsigns from the client-side CW decoder stream; radio-agnostic engine feature.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CwDecoder.h": {
+  "tag": "universal",
+  "note": "Client-side CW/Morse decoder (ggmorse) over generic 24kHz PCM; radio-agnostic engine DSP feature.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CwSidetoneGenerator.h": {
+  "tag": "universal",
+  "note": "Engine-side low-latency CW sidetone DSP driven by keying intent; radio-agnostic (DAX only in comment).",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CwTrace.h": {
+  "tag": "ui-support",
+  "note": "Header-only helpers minting monotonic ms timestamps + trace IDs for CW keying latency diagnostics, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/CwxLocalKeyer.h": {
+  "tag": "universal",
+  "note": "Local CW sidetone keyer: text+WPM in, key-down edges out; radio-agnostic despite Flex 'CWX' naming.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/DaxTxPolicy.h": {
+  "tag": "vendor(flex)",
+  "note": "Policy deciding when to claim a Flex dax_tx stream vs deferring to SmartSDR DAX2; whole surface is DAX/VITA-49.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/DeviceDiagnostics.h": {
+  "tag": "ui-support",
+  "note": "Host audio-device diagnostics (Qt device BT/USB heuristics, JSON snapshots for troubleshooting), not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/DvkWavTransfer.h": {
+  "tag": "vendor(flex)",
+  "note": "DVK WAV upload/download via SmartSDR 'dvk' verbs + ad-hoc TCP port streaming; FlexLib 5MB limit baked in",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/DxClusterClient.h": {
+  "tag": "universal",
+  "note": "Telnet DX cluster spot client (Spider/AR/CC); emits radio-agnostic DxSpot on canonical freq state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/DxccColorProvider.h": {
+  "tag": "universal",
+  "note": "DXCC worked-status from ADIF log, colors cluster spots by call/freq/mode; radio-agnostic spot/logging feature",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/FirmwareStager.h": {
+  "tag": "vendor(flex)",
+  "note": "Downloads SmartSDR installers from flexradio.com, extracts .ssdr firmware for 6x00/9600 upload \u2014 pure Flex",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/FirmwareUploader.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR firmware upload: 'file upload' cmd, .ssdr files, Flex TCP ports 4995/42607 \u2014 pure Flex protocol",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/FlexControlManager.h": {
+  "tag": "vendor(flex)",
+  "note": "FlexControl USB knob serial driver (VID 0x2192); Flex ecosystem hardware but client-side input, home=gui shell",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/FreeDvClient.h": {
+  "tag": "universal",
+  "note": "FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/GpuSelector.h": {
+  "tag": "ui-support",
+  "note": "GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/HidEncoderManager.h": {
+  "tag": "ui-support",
+  "note": "USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/IambicKeyer.h": {
+  "tag": "universal",
+  "note": "Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/KiwiPublicDirectory.h": {
+  "tag": "vendor(kiwi)",
+  "note": "Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/KiwiSdrClient.h": {
+  "tag": "vendor(kiwi)",
+  "note": "KiwiSDR WebSocket protocol client (SND/WF streams, ADPCM, camp/monitor states) \u2014 the kiwi backend itself",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/KiwiSdrManager.h": {
+  "tag": "vendor(kiwi)",
+  "note": "KiwiSDR connection/profile manager: Kiwi protocol state, telemetry, waterfall/audio streams; vendor extension.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/KiwiSdrProtocol.h": {
+  "tag": "vendor(kiwi)",
+  "note": "KiwiSDR websocket wire protocol: SND/W/F frame decode, ADPCM, MSG tokens, camp/auth, kiwi command formatting",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/LogManager.h": {
+  "tag": "ui-support",
+  "note": "App-wide diagnostic logging: category registry, log file/retention, runtime toggles. Plumbing, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MacMicPermission.h": {
+  "tag": "ui-support",
+  "note": "macOS mic permission dialog at app startup; OS permission plumbing, no radio state \u2014 belongs in the client app",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MaidenheadLocator.h": {
+  "tag": "ui-support",
+  "note": "Header-only Maidenhead grid/lat-lon/distance/bearing math; stateless shared utility, not a protocol surface",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MemoryCsvCompat.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR memory-CSV import/export codec (exact 22-col format); Flex ecosystem interchange, not core protocol.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MemoryFieldValues.h": {
+  "tag": "mixed(flex)",
+  "note": "Canonical memory-channel value lists + sanitizers; concepts universal, wire forms mirror FlexLib protocol",
+  "split": "Memory-field vocab (modes, offset dirs, tone modes, CTCSS tones, tuning steps) is core-profile; wire-form casing, 0x7f-space encoding, and mode set mirrored from FlexLib Slice.cs/Memory.cs are flex extension",
+  "confidence": "high"
+ },
+ "core/MemoryRecallPolicy.h": {
+  "tag": "mixed(flex)",
+  "note": "Memory-recall intent (offset/tone math) is core, but builders emit SmartSDR slice command strings (flex)",
+  "split": "memoryRepeaterTxOffsetFreq (repeater offset semantics) is core-profile; buildMemoryRecall*Command emit literal SmartSDR \"slice tune/set\" wire strings \u2014 flex encoding",
+  "confidence": "high"
+ },
+ "core/MidiControlManager.h": {
+  "tag": "ui-support",
+  "note": "RtMidi input-device manager (ports, bindings, MIDI Learn) driving client setters; control-surface plumbing",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MidiSettings.h": {
+  "tag": "ui-support",
+  "note": "MIDI controller binding/profile persistence (XML files) \u2014 client input-device config, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MqttAntennaAlias.h": {
+  "tag": "ui-support",
+  "note": "MQTT topic parsing/queue for antenna-alias pushes from a broker; external integration plumbing, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MqttClient.h": {
+  "tag": "ui-support",
+  "note": "Generic libmosquitto MQTT pub/sub wrapper for external integrations; no radio state, needs a home not a protocol msg",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/MqttSettings.h": {
+  "tag": "ui-support",
+  "note": "Settings store for the MQTT broker bridge (conn config, topics, buttons, keychain); external integration plumbing",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NetRecurrence.h": {
+  "tag": "ui-support",
+  "note": "Pure RRULE math for net reminders; NetEntry is operator-scoped client state, so aligns with NetScheduler/NetEntry",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NetScheduleStore.h": {
+  "tag": "ui-support",
+  "note": "Local JSON persistence of NetEntry, which its header calls operator-scoped client state \u2014 not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NetScheduler.h": {
+  "tag": "ui-support",
+  "note": "Timer engine firing net-reminder alerts from NetEntry list; pure client calendar plumbing, no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NetworkPathResolver.h": {
+  "tag": "ui-support",
+  "note": "Local NIC/IPv4 enumeration + interface-pick helper for connection setup; host networking plumbing, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NetworkSettings.h": {
+  "tag": "ui-support",
+  "note": "AppSettings JSON wrapper persisting VITA-49 SO_RCVBUF tuning; settings storage, not radio state \u2014 engine config knob, no protocol msg",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NvidiaAfxPack.h": {
+  "tag": "ui-support",
+  "note": "Download/install manager for NVIDIA AFX BNR runtime pack (CUDA/TensorRT); deployment plumbing, no radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/NvidiaBnrSettings.h": {
+  "tag": "ui-support",
+  "note": "AppSettings-backed JSON store for Maxine BNR intensity + licence acceptance; persistence, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PanadapterStream.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR VITA-49 UDP receiver (FlexLib PCCs, DAX/IQ routing, SmartLink WAN reg); emits core-profile data",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PerfTelemetry.h": {
+  "tag": "ui-support",
+  "note": "Singleton perf-instrumentation logger for client render/UDP/input timing; diagnostics, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PeripheralSettings.h": {
+  "tag": "ui-support",
+  "note": "Client settings blob (AutoReconnect + legacy-key migration) for peripheral devices atop AppSettings; no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PgxlConnection.h": {
+  "tag": "vendor(flex)",
+  "note": "Direct TCP client (port 9008) for 4O3A Power Genius XL amp telemetry \u2014 Flex-ecosystem accessory protocol.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PipeWireAudioBridge.h": {
+  "tag": "mixed(flex)",
+  "note": "Linux virtual-audio bridge to WSJT-X etc.; audio routing is core, DAX channel model/rates are flex",
+  "split": "Streaming demod RX / TX mic audio to host apps via OS virtual devices is core-profile (any backend can feed it, and the PipeWire/PulseAudio device plumbing is vendor-neutral engine-host code); the 4-channel DAX model, 24 kHz DAX rates, and \"AetherSDR DAX 1-4\" naming are Flex DAX extensions.",
+  "confidence": "high"
+ },
+ "core/PotaClient.h": {
+  "tag": "universal",
+  "note": "POTA spot poller (api.pota.app) emitting DxSpot frequency/mode spots; radio-agnostic spot feature, no vendor ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ProfileTransfer.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR .ssdr_cfg database import/export over Flex TCP transfer protocol (meta_subset, ports 4995/42607)",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PropForecastClient.h": {
+  "tag": "ui-support",
+  "note": "Web client fetching NOAA SWPC/hamqsl propagation data for dashboards; no radio state, external integration",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/PskReporterClient.h": {
+  "tag": "ui-support",
+  "note": "pskreporter.info HTTP/MQTT fetcher for reception reports of our call; external service feed for a map dialog, no radio state",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/QrzLookupSettings.h": {
+  "tag": "ui-support",
+  "note": "QRZ credential/settings holder (keychain-backed); client-side settings plumbing, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/QsoRecorder.h": {
+  "tag": "universal",
+  "note": "QSO WAV recorder gated by MOX using canonical slice freq/mode + audio streams; no vendor protocol ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/RADEEngine.h": {
+  "tag": "universal",
+  "note": "Engine-side RADE/FreeDV digital-voice codec (PCM in/out, EOO, sync/SNR); DAX mentions are just audio plumbing",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/RadioConnection.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR TCP text-protocol connection (commands/replies/status) \u2014 Flex wire protocol, per calibration anchor",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/RadioDiscovery.h": {
+  "tag": "mixed(flex)",
+  "note": "Device-discovery list/events are core-profile; SmartSDR UDP:4992 parsing + Multi-Flex/license fields are flex",
+  "split": "Discovered-device list surface (name/model/serial/address/status, discovered/updated/lost events) is core-profile; SmartSDR UDP 4992 broadcast parsing, multi-Flex/GUI-client fields (guiClient*, mf_enable), maxLicensedVersion/turfRegion, and bind/re-bind churn tied to SmartSDR discovery are flex vendor extension.",
+  "confidence": "high"
+ },
+ "core/ReceivePresentationSync.h": {
+  "tag": "mixed(flex)",
+  "note": "Cross-source RX latency sync (queues + GCC-PHAT); mechanism is core, but API hardcodes Flex/KiwiSdr pair",
+  "split": "Core-profile: presentation delay queue, per-surface delay/due-time model, sync settings/status, GCC-PHAT audio delay estimator \u2014 all generalize to N sources. Vendor: hardcoded Flex/KiwiSdr source and reference enums, Flex-vs-Kiwi offset polarity, and flex/kiwi audio-pair selection (kiwiProfileId, flexSliceId) \u2014 should become generic source IDs with flex/kiwi bindings.",
+  "confidence": "high"
+ },
+ "core/RttyDecoder.h": {
+  "tag": "universal",
+  "note": "Radio-agnostic RTTY (Baudot) DSP decoder over generic 24 kHz PCM; engine-side digital-mode decode feature.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SerialPortController.h": {
+  "tag": "ui-support",
+  "note": "USB-serial DTR/RTS PTT + CTS/DSR/DCD key/paddle input; local hardware I/O device, emits intent only",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SettingsHelpers.h": {
+  "tag": "ui-support",
+  "note": "QSlider live/persist debounce wiring for AppSettings saves; pure Qt client plumbing, no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ShortcutManager.h": {
+  "tag": "ui-support",
+  "note": "Keyboard shortcut registry: QShortcut bindings, persistence, conflict checks \u2014 client input plumbing, no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SignalClassifier.h": {
+  "tag": "universal",
+  "note": "ONNX CNN voice/carrier classifier over spectrogram patches; radio-agnostic engine DSP/analysis feature",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SmartLinkClient.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartLink WAN client: FlexRadio Auth0 login + TLS to smartlink.flexradio.com, WAN radio list/hole-punch.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SpectrogramBuffer.h": {
+  "tag": "universal",
+  "note": "Ring buffer of FFT frames per panadapter feeding CNN classifier patches; pure spectrum data, radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SpotCollectorClient.h": {
+  "tag": "ui-support",
+  "note": "UDP listener for DXLab SpotCollector desktop app; external integration feeding DxSpot, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SpotCommandPolicy.h": {
+  "tag": "ui-support",
+  "note": "Settings-backed passive-spots toggle gating whether client emits spot-add cmds; pure AppSettings policy, no radio state",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/SpotModeResolver.h": {
+  "tag": "universal",
+  "note": "Maps DX-cluster spot mode/comment/band-plan to canonical radio mode; pure spot-to-state logic, no vendor ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/StreamStatus.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR stream-status parsing: client_handle ownership, DAX RX/TX orphan-stream firmware quirks \u2014 pure Flex wire logic",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/SupportBundle.h": {
+  "tag": "ui-support",
+  "note": "Diagnostics bundle: archives logs/sysinfo and opens email client; client-side support tooling, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/TciServer.h": {
+  "tag": "mixed(flex)",
+  "note": "TCI WebSocket server for WSJT-X et al: protocol surface is canonical radio state, but audio/IQ rides Flex DAX",
+  "split": "TCI gateway over canonical slice/mode/TX/meter/audio state = core-profile engine service; DAX stream ownership/auto-assign, DAX RX/IQ audio plumbing (ownsDaxChannel, m_tciDax*, onDaxAudioReady/onIqDataReady, rearmDaxForProfileLoad) = flex extension",
+  "confidence": "high"
+ },
+ "core/TgxlConnection.h": {
+  "tag": "vendor(flex)",
+  "note": "Direct TCP client for 4O3A Tuner Genius XL port-9010 protocol (relay/autotune); Flex-ecosystem accessory.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/ThemeManager.h": {
+  "tag": "ui-support",
+  "note": "Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) \u2014 pure client GUI plumbing, no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/TxKeyingMarker.h": {
+  "tag": "ui-support",
+  "note": "QWidget property marker guarding TX-keying controls from the automation bridge; GUI-shell plumbing, no radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/UlanziDialBackend.h": {
+  "tag": "ui-support",
+  "note": "Platform alias for Ulanzi Dial HID knob backend (evdev/hidapi); physical input device for client, not radio state",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/UpdateChecker.h": {
+  "tag": "ui-support",
+  "note": "App self-update checker polling GitHub releases API; pure client plumbing, no radio state \u2014 belongs in gui shell.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/VersionNumber.h": {
+  "tag": "ui-support",
+  "note": "Semver parse/compare utility used by update checker and What's New dialog; app plumbing, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/VirtualAudioBridge.h": {
+  "tag": "mixed(flex)",
+  "note": "POSIX-shm virtual audio device bridge feeding digi-mode apps; routing is generic, semantics are Flex DAX",
+  "split": "Core: route RX/TX PCM to external apps via virtual audio devices, per-channel gain, RMS level signals (client-host plumbing). Flex: DAX channel model (4 RX + 1 TX), /aethersdr-dax-* shm names, 24 kHz FLEX-8600 native DAX rate, DAX TX stream wiring.",
+  "confidence": "high"
+ },
+ "core/VoiceSignalDetector.h": {
+  "tag": "universal",
+  "note": "Engine-side DSP: detects voice signals in FFT bins using band-plan segments; radio-agnostic spectrum analysis",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/WanConnection.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartLink TLS transport speaking SmartSDR V/H/R/S/M protocol with wan validate handshake + TOFU cert pinning",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/WaveformInstaller.h": {
+  "tag": "vendor(flex)",
+  "note": "Uploads Docker waveform images via SmartSDR fw 4.2.18 'file upload' TCP protocol \u2014 Flex-only ecosystem.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/WfmDemodulator.h": {
+  "tag": "mixed(flex)",
+  "note": "WFM demod around WfmDsp: demod/Doppler-offset intent is core; IQ source is DAX IQ + SmartSDR cmds (flex)",
+  "split": "WFM demod capability + freq-offset/volume intent = core-profile; DAX IQ capture device/channel, DaxIqModel wiring, SmartSDR commandReady = flex",
+  "confidence": "high"
+ },
+ "core/WfmSettings.h": {
+  "tag": "ui-support",
+  "note": "Client-side settings blob (AppSettings JSON) storing WFM audio output device id + legacy-key migration.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/WsjtxClient.h": {
+  "tag": "ui-support",
+  "note": "UDP listener for local WSJT-X app decodes/status; desktop-side integration feeding the universal spot surface",
+  "split": "",
+  "confidence": "medium"
+ },
+ "models/AntennaGeniusModel.h": {
+  "tag": "vendor(flex)",
+  "note": "4O3A Antenna Genius switch client: UDP discovery + SmartSDR-like TCP protocol; Flex-ecosystem accessory",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/BandDefs.h": {
+  "tag": "universal",
+  "note": "Static ARRL band plan table (edges, default freq/mode, GEN/WWV); canonical band-plan data, no vendor ties.",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/BandPlanManager.h": {
+  "tag": "universal",
+  "note": "Band-plan overlay data (segments/spots/license classes, region merge) from JSON; radio-agnostic canon",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/BandSettings.h": {
+  "tag": "universal",
+  "note": "Per-band save/restore of canonical state (freq/mode/filter/AGC/WNB/display range) \u2014 band memories, no vendor fields",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/CwxModel.h": {
+  "tag": "universal",
+  "note": "CW keyer intent: WPM/delay/QSK, 12 macros, send/erase, sent-index progress. Generic despite Flex 'CWX' name.",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/DaxIqModel.h": {
+  "tag": "vendor(flex)",
+  "note": "Flex DAX IQ streams: dax_iq stream create/rate cmds, 4-ch DAX model, pipes to SDR apps \u2014 DAX is Flex-only",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/DvkModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Voice keyer slots/commands are core-profile; status parsing + FlexLib SsdrErrors mapping are flex.",
+  "split": "Core: voice-keyer slots/status + rec/preview/playback intent. Vendor: SmartSDR status parsing, SsdrErrors code mapping, reply correlation.",
+  "confidence": "high"
+ },
+ "models/EqualizerModel.h": {
+  "tag": "universal",
+  "note": "8-band TX/RX audio EQ state (enable + band gains) \u2014 core capability; SmartSDR wire parsing/cmds move to flex adapter",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/FlexWaveformModel.h": {
+  "tag": "vendor(flex)",
+  "note": "FlexLib waveform/WFP container management: parses SmartSDR waveform status, emits Flex protocol commands",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/MemoryEntry.h": {
+  "tag": "universal",
+  "note": "POD memory-channel record (freq/mode/offset/tone/squelch/filter/digital offsets) \u2014 canonical memories surface",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/MeterModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Meter registry+values are core-profile; VITA-49 raw scaling, TGXL/PGXL amp routing, COMPPEAK quirks are Flex",
+  "split": "Core: meter defs/values, S-meter, TX pwr/SWR, mic/ALC, telemetry. Flex: VITA-49 scaling, TGXL/PGXL handles, COMPPEAK slice quirks",
+  "confidence": "high"
+ },
+ "models/NetEntry.h": {
+  "tag": "ui-support",
+  "note": "Net scheduler entry: RRULE/timezone/reminder metadata, operator-scoped local JSON; radio state only via embedded MemoryEntry",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/PanadapterModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Per-pan display state is core-profile; DAX IQ ch, client_handle, VITA stream IDs, SmartSDR kv parsing are flex.",
+  "split": "Core: center/bandwidth, dBm range, antenna list, RF gain, WNB, fps/waterfall cadence. Flex ext: daxiqChannel, clientHandle, VITA-49 stream IDs, loopA/B, preamp string, applyPanStatus/applyWaterfallStatus kv parsing of SmartSDR status.",
+  "confidence": "high"
+ },
+ "models/ProfileLoadCommand.h": {
+  "tag": "vendor(flex)",
+  "note": "Parses SmartSDR 'profile global/tx/mic load' wire command + recall-hold timing/suppression sentinels; Flex-only",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/RadioModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Central radio aggregate: core slice/pan/TX/meter/memory state fused with Flex protocol, DAX, SmartLink, Multi-Flex",
+  "split": "Core: slices/pans/meters/TX/memories/audio levels/CW keying/GPS/antennas/network quality. Flex: SmartLink WAN, Multi-Flex client handles, DAX/NetCW streams, PGXL amp, licenses, USB cables, waveforms, profiles, SmartSDR protocol plumbing.",
+  "confidence": "high"
+ },
+ "models/RadioSession.h": {
+  "tag": "universal",
+  "note": "Per-radio session aggregate: owns RadioModel + id/label; session concept is core-profile, no vendor surface",
+  "split": "",
+  "confidence": "medium"
+ },
+ "models/RadioStatusOwnership.h": {
+  "tag": "vendor(flex)",
+  "note": "SmartSDR status parsing helpers: Flex hex handles, client_handle ownership, remote_audio_rx, interlock gate",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/SliceModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Slice state (freq/mode/filter/DSP) is core-profile; DAX, index_letter, SmartSDR status KVs are flex ext",
+  "split": "Core: freq/mode/filter, RIT/XIT, AGC, squelch, NB/NR/ANF DSP, FM repeater, antennas, record/play. Flex: daxChannel, index_letter, panId handle, SmartSDR applyStatus KVs, speex NRS profile workaround, ESC/diversity, RTTY/DIG offsets as Flex slice params. External-receive (kiwi) audio-replacement shims are backend-adapter glue.",
+  "confidence": "high"
+ },
+ "models/SpotModel.h": {
+  "tag": "universal",
+  "note": "Panadapter spot store (callsign/freq/mode/lifetime/priority) on canonical state; kv ingest is trivially generic",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/TnfModel.h": {
+  "tag": "universal",
+  "note": "Tracking notch filter state (freq/width/depth/permanent, global enable) \u2014 generic DSP notch surface; kv parse is transport detail",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/TransmitModel.h": {
+  "tag": "mixed(flex)",
+  "note": "TX state model: power/MOX/VOX/CW/filter are core-profile; ATU, DAX, APD, profiles, interlock are Flex.",
+  "split": "Core: RF/tune power, MOX/PTT+Quindar, VOX, mic level/proc, CW params, TX filter, monitor. Flex: ATU, DAX, APD samplers, TX/mic profiles, interlock ACC/RCA delays+polarity, SmartSDR status-kv parsing/commands.",
+  "confidence": "high"
+ },
+ "models/TunerModel.h": {
+  "tag": "vendor(flex)",
+  "note": "4o3a TGXL tuner state/commands via SmartSDR 'atu'/'tgxl' TCP verbs + direct port-9010 relay control",
+  "split": "",
+  "confidence": "high"
+ },
+ "models/XvtrPolicy.h": {
+  "tag": "mixed(flex)",
+  "note": "XVTR policy: transverter list/freq translation is core; waterfall-tile offset + FLEX model power clamps are flex",
+  "split": "Core: Transverter struct, RF/IF frequency mapping intent. Flex: ModelCapabilities-based band-stack keys, waterfall tile offset matching, FLEX-64/6600 max-power dBm ranges.",
+  "confidence": "high"
+ }
+}

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -239,6 +239,12 @@
   "split": "",
   "confidence": "high"
  },
+ "core/IConnectionAutomation.h": {
+  "tag": "ui-support",
+  "note": "Gui-free connect/disconnect/dialog hook the automation bridge drives; bridge plumbing, not radio state.",
+  "split": "",
+  "confidence": "high"
+ },
  "core/IambicKeyer.h": {
   "tag": "universal",
   "note": "Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling.",
@@ -620,6 +626,78 @@
  "core/WsjtxClient.h": {
   "tag": "ui-support",
   "note": "UDP listener for local WSJT-X app decodes/status; desktop-side integration feeding the universal spot surface",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/aprs/AprsBeacon.h": {
+  "tag": "universal",
+  "note": "APRS position/status beacon composition; radio-agnostic packet operating feature.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/aprs/AprsMessenger.h": {
+  "tag": "universal",
+  "note": "APRS messaging (send/ack/retry) over canonical TX path; radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/aprs/AprsPacket.h": {
+  "tag": "universal",
+  "note": "APRS/AX.25 packet parse+encode data types; radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/aprs/AprsSettings.h": {
+  "tag": "ui-support",
+  "note": "APRS client settings holder (callsign/SSID/paths); client-side settings, not radio state.",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/aprs/AprsStationList.h": {
+  "tag": "universal",
+  "note": "Heard-APRS-station model (calls/positions/last-heard); radio-agnostic spot-like data.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/pms/PmsMailbox.h": {
+  "tag": "universal",
+  "note": "Packet personal-message-system mailbox store/logic; radio-agnostic operating feature.",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/tnc/AetherAx25LibmodemShim.h": {
+  "tag": "universal",
+  "note": "AX.25 modem shim bridging the client AFSK/libmodem demod to the TNC; radio-agnostic DSP glue.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/tnc/Ax25.h": {
+  "tag": "universal",
+  "note": "AX.25 frame data types/constants; radio-agnostic protocol layer.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/tnc/Ax25FrameFormatter.h": {
+  "tag": "universal",
+  "note": "AX.25 frame human-formatting; radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/tnc/HeardList.h": {
+  "tag": "universal",
+  "note": "Heard-station list for the packet monitor; radio-agnostic.",
+  "split": "",
+  "confidence": "high"
+ },
+ "core/tnc/KissTncServer.h": {
+  "tag": "ui-support",
+  "note": "KISS-over-TCP server exposing the TNC to external apps; external integration, needs a home (cf CatPort/TciServer).",
+  "split": "",
+  "confidence": "medium"
+ },
+ "core/tnc/TncTerminal.h": {
+  "tag": "universal",
+  "note": "Packet terminal session model (command/monitor); radio-agnostic operating feature.",
   "split": "",
   "confidence": "medium"
  },

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -4,7 +4,7 @@
 
 Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine-design.md) §2, §10). One row per engine header the UI includes; converting a touchpoint means the UI reaches that surface through the versioned protocol instead of the header.
 
-**Totals:** 127 touchpoint headers (104 core, 23 models) — 127/127 tagged, 0/127 converted.
+**Totals:** 128 touchpoint headers (105 core, 23 models) — 127/128 tagged, 0/128 converted.
 
 | Header | Includers | Tag | Status |
 |---|---:|---|---|
@@ -48,6 +48,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/FreeDvClient.h` | 4 | universal — FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR | unconverted |
 | `core/GpuSelector.h` | 2 | ui-support — GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing | unconverted |
 | `core/HidEncoderManager.h` | 2 | ui-support — USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state | unconverted |
+| `core/IConnectionAutomation.h` | 1 | — | unconverted |
 | `core/IambicKeyer.h` | 3 | universal — Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling. | unconverted |
 | `core/KiwiPublicDirectory.h` | 1 | vendor(kiwi) — Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only. | unconverted |
 | `core/KiwiSdrClient.h` | 2 | vendor(kiwi) — KiwiSDR WebSocket protocol client (SND/WF streams, ADPCM, camp/monitor states) — the kiwi backend itself | unconverted |

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -1,0 +1,139 @@
+# aetherd migration — gui→engine touchpoint manifest
+
+<!-- GENERATED FILE — regenerate with `python tools/gen_touchpoint_manifest.py`. Edit the tags/status JSON sidecars, never this table. -->
+
+Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine-design.md) §2, §10). One row per engine header the UI includes; converting a touchpoint means the UI reaches that surface through the versioned protocol instead of the header.
+
+**Totals:** 127 touchpoint headers (104 core, 23 models) — 127/127 tagged, 0/127 converted.
+
+| Header | Includers | Tag | Status |
+|---|---:|---|---|
+| `core/AdaptiveFilterEngine.h` | 1 | universal — GUI-thread adaptive RX passband coordinator over SliceModel/spectrum frames; canonical radio state, no vendor ties. | unconverted |
+| `core/AgcTCalibrator.h` | 1 | universal — Engine algo sweeping slice AGC threshold vs audio RMS/S-meter to recommend a value; only canonical state. | unconverted |
+| `core/AppSettings.h` | 90 | ui-support — Client-side XML settings store (SSDR.settings-style key/value persistence); app plumbing, not radio state. | unconverted |
+| `core/AudioEngine.h` | 44 | mixed(flex) — Client audio I/O + full RX/TX DSP chain (universal) fused with Flex VITA-49/DAX/Opus TX and Kiwi buffering | unconverted |
+| `core/AudioOutputRouter.h` | 1 | ui-support — Registry fanning the user-selected QAudioDevice to local playback sinks; OS device plumbing, no radio state | unconverted |
+| `core/AutomationServer.h` | 1 | ui-support — QLocalServer GUI-automation/test bridge (dumpTree/grab/invoke on QWidgets); dev tooling, stays in gui shell | unconverted |
+| `core/BandStackSettings.h` | 4 | universal — Per-radio band-stack memories (freq/mode/filter/AGC/NB-NR) — canonical radio state; only the XML store is client-side | unconverted |
+| `core/CallsignInfo.h` | 1 | universal — Callsign lookup result struct (name/QTH/grid, JSON cache form); radio-agnostic spot/logging data. | unconverted |
+| `core/CallsignLookupService.h` | 3 | universal — Orchestrates QRZ/cty.dat callsign lookups + cache; radio-agnostic spot/logging integration. | unconverted |
+| `core/CallsignUtils.h` | 1 | universal — Stateless callsign parsing/validation helpers; radio-agnostic. | unconverted |
+| `core/CatPort.h` | 2 | ui-support — CAT server (TCP+PTY, rigctld/TS-2000/FlexCAT dialects) for external apps; desktop integration, needs a home | unconverted |
+| `core/ChannelStripPresets.h` | 1 | universal — Named-preset save/recall/import-export for the engine audio DSP chain; operates on core-profile DSP state. | unconverted |
+| `core/ClientComp.h` | 12 | universal — Client-side TX dynamics DSP (compressor/limiter/drive/phase rotator + GR meters); radio-agnostic engine DSP. | unconverted |
+| `core/ClientDeEss.h` | 10 | universal — Client TX DSP de-esser (sidechain bandpass + dynamics, meters); radio-agnostic engine DSP chain stage | unconverted |
+| `core/ClientEq.h` | 14 | universal — Client-side parametric EQ DSP in AudioEngine (RX/TX paths); radio-agnostic engine DSP, no vendor protocol ties. | unconverted |
+| `core/ClientFinalLimiter.h` | 1 | universal — Final-stage brickwall limiter in client TX DSP chain (ceiling/trim/DC-block + meters); radio-agnostic DSP. | unconverted |
+| `core/ClientGate.h` | 12 | universal — Client TX-chain downward expander/noise gate DSP (thresh/ratio/hold + meters) — radio-agnostic engine DSP. | unconverted |
+| `core/ClientPudu.h` | 11 | universal — Client-side TX audio exciter (PooDoo dual-band DSP) — engine TX DSP chain module, no radio-family coupling | unconverted |
+| `core/ClientPuduMonitor.h` | 1 | universal — TX-audio monitor: record/replay post-DSP client TX chain output without keying; radio-agnostic DSP feature | unconverted |
+| `core/ClientQuindarTone.h` | 1 | universal — Engine-side TX DSP stage: Quindar tone/Morse intro-outro on PTT; works over any radio's TX audio path. | unconverted |
+| `core/ClientReverb.h` | 7 | universal — Client TX-chain Freeverb DSP (size/decay/damping/predelay/mix + meters); radio-agnostic engine DSP feature. | unconverted |
+| `core/ClientTube.h` | 11 | universal — Client TX-chain tube saturator DSP (drive/tone/env follower); radio-agnostic engine DSP, no vendor ties. | unconverted |
+| `core/ClientTxTestTone.h` | 1 | universal — 1 kHz TX test-tone generator injected at head of client TX DSP chain; radio-agnostic engine DSP feature | unconverted |
+| `core/CommandParser.h` | 2 | vendor(flex) — Stateless parser/builder for SmartSDR TCP wire lines (V/H/C/R/S/M, FlexLib semantics) — pure Flex protocol. | unconverted |
+| `core/CwCallsignSpotter.h` | 1 | universal — Spots callsigns from the client-side CW decoder stream; radio-agnostic engine feature. | unconverted |
+| `core/CwDecoder.h` | 1 | universal — Client-side CW/Morse decoder (ggmorse) over generic 24kHz PCM; radio-agnostic engine DSP feature. | unconverted |
+| `core/CwSidetoneGenerator.h` | 2 | universal — Engine-side low-latency CW sidetone DSP driven by keying intent; radio-agnostic (DAX only in comment). | unconverted |
+| `core/CwTrace.h` | 4 | ui-support — Header-only helpers minting monotonic ms timestamps + trace IDs for CW keying latency diagnostics, not radio state | unconverted |
+| `core/CwxLocalKeyer.h` | 2 | universal — Local CW sidetone keyer: text+WPM in, key-down edges out; radio-agnostic despite Flex 'CWX' naming. | unconverted |
+| `core/DaxTxPolicy.h` | 1 | vendor(flex) — Policy deciding when to claim a Flex dax_tx stream vs deferring to SmartSDR DAX2; whole surface is DAX/VITA-49. | unconverted |
+| `core/DeviceDiagnostics.h` | 1 | ui-support — Host audio-device diagnostics (Qt device BT/USB heuristics, JSON snapshots for troubleshooting), not radio state | unconverted |
+| `core/DvkWavTransfer.h` | 2 | vendor(flex) — DVK WAV upload/download via SmartSDR 'dvk' verbs + ad-hoc TCP port streaming; FlexLib 5MB limit baked in | unconverted |
+| `core/DxClusterClient.h` | 3 | universal — Telnet DX cluster spot client (Spider/AR/CC); emits radio-agnostic DxSpot on canonical freq state. | unconverted |
+| `core/DxccColorProvider.h` | 2 | universal — DXCC worked-status from ADIF log, colors cluster spots by call/freq/mode; radio-agnostic spot/logging feature | unconverted |
+| `core/FirmwareStager.h` | 1 | vendor(flex) — Downloads SmartSDR installers from flexradio.com, extracts .ssdr firmware for 6x00/9600 upload — pure Flex | unconverted |
+| `core/FirmwareUploader.h` | 1 | vendor(flex) — SmartSDR firmware upload: 'file upload' cmd, .ssdr files, Flex TCP ports 4995/42607 — pure Flex protocol | unconverted |
+| `core/FlexControlManager.h` | 2 | vendor(flex) — FlexControl USB knob serial driver (VID 0x2192); Flex ecosystem hardware but client-side input, home=gui shell | unconverted |
+| `core/FreeDvClient.h` | 4 | universal — FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR | unconverted |
+| `core/GpuSelector.h` | 2 | ui-support — GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing | unconverted |
+| `core/HidEncoderManager.h` | 2 | ui-support — USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state | unconverted |
+| `core/IambicKeyer.h` | 3 | universal — Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling. | unconverted |
+| `core/KiwiPublicDirectory.h` | 1 | vendor(kiwi) — Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only. | unconverted |
+| `core/KiwiSdrClient.h` | 2 | vendor(kiwi) — KiwiSDR WebSocket protocol client (SND/WF streams, ADPCM, camp/monitor states) — the kiwi backend itself | unconverted |
+| `core/KiwiSdrManager.h` | 8 | vendor(kiwi) — KiwiSDR connection/profile manager: Kiwi protocol state, telemetry, waterfall/audio streams; vendor extension. | unconverted |
+| `core/KiwiSdrProtocol.h` | 9 | vendor(kiwi) — KiwiSDR websocket wire protocol: SND/W/F frame decode, ADPCM, MSG tokens, camp/auth, kiwi command formatting | unconverted |
+| `core/LogManager.h` | 21 | ui-support — App-wide diagnostic logging: category registry, log file/retention, runtime toggles. Plumbing, not radio state. | unconverted |
+| `core/MacMicPermission.h` | 1 | ui-support — macOS mic permission dialog at app startup; OS permission plumbing, no radio state — belongs in the client app | unconverted |
+| `core/MaidenheadLocator.h` | 4 | ui-support — Header-only Maidenhead grid/lat-lon/distance/bearing math; stateless shared utility, not a protocol surface | unconverted |
+| `core/MemoryCsvCompat.h` | 1 | vendor(flex) — SmartSDR memory-CSV import/export codec (exact 22-col format); Flex ecosystem interchange, not core protocol. | unconverted |
+| `core/MemoryFieldValues.h` | 2 | mixed(flex) — Canonical memory-channel value lists + sanitizers; concepts universal, wire forms mirror FlexLib protocol | unconverted |
+| `core/MemoryRecallPolicy.h` | 2 | mixed(flex) — Memory-recall intent (offset/tone math) is core, but builders emit SmartSDR slice command strings (flex) | unconverted |
+| `core/MidiControlManager.h` | 3 | ui-support — RtMidi input-device manager (ports, bindings, MIDI Learn) driving client setters; control-surface plumbing | unconverted |
+| `core/MidiSettings.h` | 3 | ui-support — MIDI controller binding/profile persistence (XML files) — client input-device config, not radio state. | unconverted |
+| `core/MqttAntennaAlias.h` | 3 | ui-support — MQTT topic parsing/queue for antenna-alias pushes from a broker; external integration plumbing, not radio state | unconverted |
+| `core/MqttClient.h` | 3 | ui-support — Generic libmosquitto MQTT pub/sub wrapper for external integrations; no radio state, needs a home not a protocol msg | unconverted |
+| `core/MqttSettings.h` | 6 | ui-support — Settings store for the MQTT broker bridge (conn config, topics, buttons, keychain); external integration plumbing | unconverted |
+| `core/NetRecurrence.h` | 1 | ui-support — Pure RRULE math for net reminders; NetEntry is operator-scoped client state, so aligns with NetScheduler/NetEntry | unconverted |
+| `core/NetScheduleStore.h` | 2 | ui-support — Local JSON persistence of NetEntry, which its header calls operator-scoped client state — not radio state | unconverted |
+| `core/NetScheduler.h` | 1 | ui-support — Timer engine firing net-reminder alerts from NetEntry list; pure client calendar plumbing, no radio state. | unconverted |
+| `core/NetworkPathResolver.h` | 1 | ui-support — Local NIC/IPv4 enumeration + interface-pick helper for connection setup; host networking plumbing, not radio state | unconverted |
+| `core/NetworkSettings.h` | 1 | ui-support — AppSettings JSON wrapper persisting VITA-49 SO_RCVBUF tuning; settings storage, not radio state — engine config knob, no protocol msg | unconverted |
+| `core/NvidiaAfxPack.h` | 1 | ui-support — Download/install manager for NVIDIA AFX BNR runtime pack (CUDA/TensorRT); deployment plumbing, no radio state | unconverted |
+| `core/NvidiaBnrSettings.h` | 1 | ui-support — AppSettings-backed JSON store for Maxine BNR intensity + licence acceptance; persistence, not radio state | unconverted |
+| `core/PanadapterStream.h` | 4 | vendor(flex) — SmartSDR VITA-49 UDP receiver (FlexLib PCCs, DAX/IQ routing, SmartLink WAN reg); emits core-profile data | unconverted |
+| `core/PerfTelemetry.h` | 3 | ui-support — Singleton perf-instrumentation logger for client render/UDP/input timing; diagnostics, not radio state. | unconverted |
+| `core/PeripheralSettings.h` | 3 | ui-support — Client settings blob (AutoReconnect + legacy-key migration) for peripheral devices atop AppSettings; no radio state. | unconverted |
+| `core/PgxlConnection.h` | 2 | vendor(flex) — Direct TCP client (port 9008) for 4O3A Power Genius XL amp telemetry — Flex-ecosystem accessory protocol. | unconverted |
+| `core/PipeWireAudioBridge.h` | 3 | mixed(flex) — Linux virtual-audio bridge to WSJT-X etc.; audio routing is core, DAX channel model/rates are flex | unconverted |
+| `core/PotaClient.h` | 2 | universal — POTA spot poller (api.pota.app) emitting DxSpot frequency/mode spots; radio-agnostic spot feature, no vendor ties. | unconverted |
+| `core/ProfileTransfer.h` | 1 | vendor(flex) — SmartSDR .ssdr_cfg database import/export over Flex TCP transfer protocol (meta_subset, ports 4995/42607) | unconverted |
+| `core/PropForecastClient.h` | 3 | ui-support — Web client fetching NOAA SWPC/hamqsl propagation data for dashboards; no radio state, external integration | unconverted |
+| `core/PskReporterClient.h` | 1 | ui-support — pskreporter.info HTTP/MQTT fetcher for reception reports of our call; external service feed for a map dialog, no radio state | unconverted |
+| `core/QrzLookupSettings.h` | 1 | ui-support — QRZ credential/settings holder (keychain-backed); client-side settings plumbing, not radio state. | unconverted |
+| `core/QsoRecorder.h` | 1 | universal — QSO WAV recorder gated by MOX using canonical slice freq/mode + audio streams; no vendor protocol ties. | unconverted |
+| `core/RADEEngine.h` | 4 | universal — Engine-side RADE/FreeDV digital-voice codec (PCM in/out, EOO, sync/SNR); DAX mentions are just audio plumbing | unconverted |
+| `core/RadioConnection.h` | 2 | vendor(flex) — SmartSDR TCP text-protocol connection (commands/replies/status) — Flex wire protocol, per calibration anchor | unconverted |
+| `core/RadioDiscovery.h` | 3 | mixed(flex) — Device-discovery list/events are core-profile; SmartSDR UDP:4992 parsing + Multi-Flex/license fields are flex | unconverted |
+| `core/ReceivePresentationSync.h` | 1 | mixed(flex) — Cross-source RX latency sync (queues + GCC-PHAT); mechanism is core, but API hardcodes Flex/KiwiSdr pair | unconverted |
+| `core/RttyDecoder.h` | 1 | universal — Radio-agnostic RTTY (Baudot) DSP decoder over generic 24 kHz PCM; engine-side digital-mode decode feature. | unconverted |
+| `core/SerialPortController.h` | 2 | ui-support — USB-serial DTR/RTS PTT + CTS/DSR/DCD key/paddle input; local hardware I/O device, emits intent only | unconverted |
+| `core/SettingsHelpers.h` | 2 | ui-support — QSlider live/persist debounce wiring for AppSettings saves; pure Qt client plumbing, no radio state. | unconverted |
+| `core/ShortcutManager.h` | 4 | ui-support — Keyboard shortcut registry: QShortcut bindings, persistence, conflict checks — client input plumbing, no radio state. | unconverted |
+| `core/SignalClassifier.h` | 1 | universal — ONNX CNN voice/carrier classifier over spectrogram patches; radio-agnostic engine DSP/analysis feature | unconverted |
+| `core/SmartLinkClient.h` | 3 | vendor(flex) — SmartLink WAN client: FlexRadio Auth0 login + TLS to smartlink.flexradio.com, WAN radio list/hole-punch. | unconverted |
+| `core/SpectrogramBuffer.h` | 1 | universal — Ring buffer of FFT frames per panadapter feeding CNN classifier patches; pure spectrum data, radio-agnostic. | unconverted |
+| `core/SpotCollectorClient.h` | 2 | ui-support — UDP listener for DXLab SpotCollector desktop app; external integration feeding DxSpot, not radio state | unconverted |
+| `core/SpotCommandPolicy.h` | 4 | ui-support — Settings-backed passive-spots toggle gating whether client emits spot-add cmds; pure AppSettings policy, no radio state | unconverted |
+| `core/SpotModeResolver.h` | 4 | universal — Maps DX-cluster spot mode/comment/band-plan to canonical radio mode; pure spot-to-state logic, no vendor ties. | unconverted |
+| `core/StreamStatus.h` | 1 | vendor(flex) — SmartSDR stream-status parsing: client_handle ownership, DAX RX/TX orphan-stream firmware quirks — pure Flex wire logic | unconverted |
+| `core/SupportBundle.h` | 1 | ui-support — Diagnostics bundle: archives logs/sysinfo and opens email client; client-side support tooling, not radio state | unconverted |
+| `core/TciServer.h` | 3 | mixed(flex) — TCI WebSocket server for WSJT-X et al: protocol surface is canonical radio state, but audio/IQ rides Flex DAX | unconverted |
+| `core/TgxlConnection.h` | 2 | vendor(flex) — Direct TCP client for 4O3A Tuner Genius XL port-9010 protocol (relay/autotune); Flex-ecosystem accessory. | unconverted |
+| `core/ThemeManager.h` | 119 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
+| `core/TxKeyingMarker.h` | 4 | ui-support — QWidget property marker guarding TX-keying controls from the automation bridge; GUI-shell plumbing, no radio state. | unconverted |
+| `core/UlanziDialBackend.h` | 3 | ui-support — Platform alias for Ulanzi Dial HID knob backend (evdev/hidapi); physical input device for client, not radio state | unconverted |
+| `core/UpdateChecker.h` | 3 | ui-support — App self-update checker polling GitHub releases API; pure client plumbing, no radio state — belongs in gui shell. | unconverted |
+| `core/VersionNumber.h` | 3 | ui-support — Semver parse/compare utility used by update checker and What's New dialog; app plumbing, not radio state. | unconverted |
+| `core/VirtualAudioBridge.h` | 3 | mixed(flex) — POSIX-shm virtual audio device bridge feeding digi-mode apps; routing is generic, semantics are Flex DAX | unconverted |
+| `core/VoiceSignalDetector.h` | 1 | universal — Engine-side DSP: detects voice signals in FFT bins using band-plan segments; radio-agnostic spectrum analysis | unconverted |
+| `core/WanConnection.h` | 2 | vendor(flex) — SmartLink TLS transport speaking SmartSDR V/H/R/S/M protocol with wan validate handshake + TOFU cert pinning | unconverted |
+| `core/WaveformInstaller.h` | 1 | vendor(flex) — Uploads Docker waveform images via SmartSDR fw 4.2.18 'file upload' TCP protocol — Flex-only ecosystem. | unconverted |
+| `core/WfmDemodulator.h` | 1 | mixed(flex) — WFM demod around WfmDsp: demod/Doppler-offset intent is core; IQ source is DAX IQ + SmartSDR cmds (flex) | unconverted |
+| `core/WfmSettings.h` | 1 | ui-support — Client-side settings blob (AppSettings JSON) storing WFM audio output device id + legacy-key migration. | unconverted |
+| `core/WsjtxClient.h` | 2 | ui-support — UDP listener for local WSJT-X app decodes/status; desktop-side integration feeding the universal spot surface | unconverted |
+| `models/AntennaGeniusModel.h` | 4 | vendor(flex) — 4O3A Antenna Genius switch client: UDP discovery + SmartSDR-like TCP protocol; Flex-ecosystem accessory | unconverted |
+| `models/BandDefs.h` | 4 | universal — Static ARRL band plan table (edges, default freq/mode, GEN/WWV); canonical band-plan data, no vendor ties. | unconverted |
+| `models/BandPlanManager.h` | 7 | universal — Band-plan overlay data (segments/spots/license classes, region merge) from JSON; radio-agnostic canon | unconverted |
+| `models/BandSettings.h` | 4 | universal — Per-band save/restore of canonical state (freq/mode/filter/AGC/WNB/display range) — band memories, no vendor fields | unconverted |
+| `models/CwxModel.h` | 1 | universal — CW keyer intent: WPM/delay/QSK, 12 macros, send/erase, sent-index progress. Generic despite Flex 'CWX' name. | unconverted |
+| `models/DaxIqModel.h` | 1 | vendor(flex) — Flex DAX IQ streams: dax_iq stream create/rate cmds, 4-ch DAX model, pipes to SDR apps — DAX is Flex-only | unconverted |
+| `models/DvkModel.h` | 1 | mixed(flex) — Voice keyer slots/commands are core-profile; status parsing + FlexLib SsdrErrors mapping are flex. | unconverted |
+| `models/EqualizerModel.h` | 2 | universal — 8-band TX/RX audio EQ state (enable + band gains) — core capability; SmartSDR wire parsing/cmds move to flex adapter | unconverted |
+| `models/FlexWaveformModel.h` | 1 | vendor(flex) — FlexLib waveform/WFP container management: parses SmartSDR waveform status, emits Flex protocol commands | unconverted |
+| `models/MemoryEntry.h` | 1 | universal — POD memory-channel record (freq/mode/offset/tone/squelch/filter/digital offsets) — canonical memories surface | unconverted |
+| `models/MeterModel.h` | 6 | mixed(flex) — Meter registry+values are core-profile; VITA-49 raw scaling, TGXL/PGXL amp routing, COMPPEAK quirks are Flex | unconverted |
+| `models/NetEntry.h` | 2 | ui-support — Net scheduler entry: RRULE/timezone/reminder metadata, operator-scoped local JSON; radio state only via embedded MemoryEntry | unconverted |
+| `models/PanadapterModel.h` | 2 | mixed(flex) — Per-pan display state is core-profile; DAX IQ ch, client_handle, VITA stream IDs, SmartSDR kv parsing are flex. | unconverted |
+| `models/ProfileLoadCommand.h` | 1 | vendor(flex) — Parses SmartSDR 'profile global/tx/mic load' wire command + recall-hold timing/suppression sentinels; Flex-only | unconverted |
+| `models/RadioModel.h` | 39 | mixed(flex) — Central radio aggregate: core slice/pan/TX/meter/memory state fused with Flex protocol, DAX, SmartLink, Multi-Flex | unconverted |
+| `models/RadioSession.h` | 1 | universal — Per-radio session aggregate: owns RadioModel + id/label; session concept is core-profile, no vendor surface | unconverted |
+| `models/RadioStatusOwnership.h` | 1 | vendor(flex) — SmartSDR status parsing helpers: Flex hex handles, client_handle ownership, remote_audio_rx, interlock gate | unconverted |
+| `models/SliceModel.h` | 28 | mixed(flex) — Slice state (freq/mode/filter/DSP) is core-profile; DAX, index_letter, SmartSDR status KVs are flex ext | unconverted |
+| `models/SpotModel.h` | 1 | universal — Panadapter spot store (callsign/freq/mode/lifetime/priority) on canonical state; kv ingest is trivially generic | unconverted |
+| `models/TnfModel.h` | 1 | universal — Tracking notch filter state (freq/width/depth/permanent, global enable) — generic DSP notch surface; kv parse is transport detail | unconverted |
+| `models/TransmitModel.h` | 14 | mixed(flex) — TX state model: power/MOX/VOX/CW/filter are core-profile; ATU, DAX, APD, profiles, interlock are Flex. | unconverted |
+| `models/TunerModel.h` | 3 | vendor(flex) — 4o3a TGXL tuner state/commands via SmartSDR 'atu'/'tgxl' TCP verbs + direct port-9010 relay control | unconverted |
+| `models/XvtrPolicy.h` | 5 | mixed(flex) — XVTR policy: transverter list/freq translation is core; waterfall-tile offset + FLEX model power clamps are flex | unconverted |
+
+**Tag legend:** `universal` = core-profile surface every radio family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a namespaced extension; `mixed` = header carries both (split candidates noted); `ui-support` = not radio state at all (settings, theming, app plumbing) — needs a home decision, not a protocol message.

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -4,7 +4,7 @@
 
 Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine-design.md) §2, §10). One row per engine header the UI includes; converting a touchpoint means the UI reaches that surface through the versioned protocol instead of the header.
 
-**Totals:** 128 touchpoint headers (105 core, 23 models) — 127/128 tagged, 0/128 converted.
+**Totals:** 140 touchpoint headers (117 core, 23 models) — 140/140 tagged, 0/140 converted.
 
 | Header | Includers | Tag | Status |
 |---|---:|---|---|
@@ -48,7 +48,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/FreeDvClient.h` | 4 | universal — FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR | unconverted |
 | `core/GpuSelector.h` | 2 | ui-support — GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing | unconverted |
 | `core/HidEncoderManager.h` | 2 | ui-support — USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state | unconverted |
-| `core/IConnectionAutomation.h` | 1 | — | unconverted |
+| `core/IConnectionAutomation.h` | 1 | ui-support — Gui-free connect/disconnect/dialog hook the automation bridge drives; bridge plumbing, not radio state. | unconverted |
 | `core/IambicKeyer.h` | 3 | universal — Radio-agnostic software iambic state machine for local sidetone + CW paddle/keying intent; no vendor coupling. | unconverted |
 | `core/KiwiPublicDirectory.h` | 1 | vendor(kiwi) — Fetches/parses kiwisdr.com/public directory + per-sysop ext_api policy; KiwiSDR ecosystem discovery only. | unconverted |
 | `core/KiwiSdrClient.h` | 2 | vendor(kiwi) — KiwiSDR WebSocket protocol client (SND/WF streams, ADPCM, camp/monitor states) — the kiwi backend itself | unconverted |
@@ -113,6 +113,18 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/WfmDemodulator.h` | 1 | mixed(flex) — WFM demod around WfmDsp: demod/Doppler-offset intent is core; IQ source is DAX IQ + SmartSDR cmds (flex) | unconverted |
 | `core/WfmSettings.h` | 1 | ui-support — Client-side settings blob (AppSettings JSON) storing WFM audio output device id + legacy-key migration. | unconverted |
 | `core/WsjtxClient.h` | 2 | ui-support — UDP listener for local WSJT-X app decodes/status; desktop-side integration feeding the universal spot surface | unconverted |
+| `core/aprs/AprsBeacon.h` | 1 | universal — APRS position/status beacon composition; radio-agnostic packet operating feature. | unconverted |
+| `core/aprs/AprsMessenger.h` | 2 | universal — APRS messaging (send/ack/retry) over canonical TX path; radio-agnostic. | unconverted |
+| `core/aprs/AprsPacket.h` | 2 | universal — APRS/AX.25 packet parse+encode data types; radio-agnostic. | unconverted |
+| `core/aprs/AprsSettings.h` | 2 | ui-support — APRS client settings holder (callsign/SSID/paths); client-side settings, not radio state. | unconverted |
+| `core/aprs/AprsStationList.h` | 1 | universal — Heard-APRS-station model (calls/positions/last-heard); radio-agnostic spot-like data. | unconverted |
+| `core/pms/PmsMailbox.h` | 1 | universal — Packet personal-message-system mailbox store/logic; radio-agnostic operating feature. | unconverted |
+| `core/tnc/AetherAx25LibmodemShim.h` | 1 | universal — AX.25 modem shim bridging the client AFSK/libmodem demod to the TNC; radio-agnostic DSP glue. | unconverted |
+| `core/tnc/Ax25.h` | 1 | universal — AX.25 frame data types/constants; radio-agnostic protocol layer. | unconverted |
+| `core/tnc/Ax25FrameFormatter.h` | 1 | universal — AX.25 frame human-formatting; radio-agnostic. | unconverted |
+| `core/tnc/HeardList.h` | 1 | universal — Heard-station list for the packet monitor; radio-agnostic. | unconverted |
+| `core/tnc/KissTncServer.h` | 1 | ui-support — KISS-over-TCP server exposing the TNC to external apps; external integration, needs a home (cf CatPort/TciServer). | unconverted |
+| `core/tnc/TncTerminal.h` | 1 | universal — Packet terminal session model (command/monitor); radio-agnostic operating feature. | unconverted |
 | `models/AntennaGeniusModel.h` | 4 | vendor(flex) — 4O3A Antenna Genius switch client: UDP discovery + SmartSDR-like TCP protocol; Flex-ecosystem accessory | unconverted |
 | `models/BandDefs.h` | 4 | universal — Static ARRL band plan table (edges, default freq/mode, GEN/WWV); canonical band-plan data, no vendor ties. | unconverted |
 | `models/BandPlanManager.h` | 7 | universal — Band-plan overlay data (segments/spots/license classes, region merge) from JSON; radio-agnostic canon | unconverted |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -9,7 +9,7 @@
 #include "CallsignLookupService.h" // qrz() verb — QRZ lookup cache/service
 #include "CallsignUtils.h"
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
-#include "gui/ConnectionPanel.h" // ConnectionPanel automation facade
+#include "IConnectionAutomation.h" // gui-free connect/disconnect/dialog hook
 
 #include <QAction>
 #include <QLocalServer>
@@ -3005,13 +3005,13 @@ QJsonObject AutomationServer::doConnect(const QString& action,
         return err(QStringLiteral("connect dialog requires show|hide"));
     }
 
-    ConnectionPanel* panel = m_connectionPanel;
-    if (!panel) {
+    IConnectionAutomation* conn = m_connection;
+    if (!conn) {
         return err(QStringLiteral("connection panel unavailable"));
     }
 
     if (a == QLatin1String("list")) {
-        const QList<RadioInfo> radios = panel->automationLocalRadios();
+        const QList<RadioInfo> radios = conn->automationLocalRadios();
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("count"), radios.size()},
@@ -3024,7 +3024,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
     }
 
     if (a == QLatin1String("local")) {
-        const QList<RadioInfo> radios = panel->automationLocalRadios();
+        const QList<RadioInfo> radios = conn->automationLocalRadios();
         if (radios.isEmpty()) {
             return err(QStringLiteral("no local radios have been discovered"));
         }
@@ -3038,13 +3038,13 @@ QJsonObject AutomationServer::doConnect(const QString& action,
                 return err(QStringLiteral("first discovered local radio has no serial"));
             }
 
-            QPointer<ConnectionPanel> guardedPanel = panel;
-            QTimer::singleShot(0, qApp, [guardedPanel, selectedSerial] {
-                if (!guardedPanel) {
+            QPointer<QObject> guard(conn->asQObject());
+            QTimer::singleShot(0, qApp, [guard, conn, selectedSerial] {
+                if (!guard) {
                     return;
                 }
                 QString error;
-                if (!guardedPanel->automationConnectLocalSerial(selectedSerial, &error)) {
+                if (!conn->automationConnectLocalSerial(selectedSerial, &error)) {
                     qCWarning(lcAutomation).noquote()
                         << "connect local first failed after scheduling:" << error;
                 }
@@ -3068,13 +3068,13 @@ QJsonObject AutomationServer::doConnect(const QString& action,
                     continue;
                 }
 
-                QPointer<ConnectionPanel> guardedPanel = panel;
-                QTimer::singleShot(0, qApp, [guardedPanel, serial] {
-                    if (!guardedPanel) {
+                QPointer<QObject> guard(conn->asQObject());
+                QTimer::singleShot(0, qApp, [guard, conn, serial] {
+                    if (!guard) {
                         return;
                     }
                     QString error;
-                    if (!guardedPanel->automationConnectLocalSerial(serial, &error)) {
+                    if (!conn->automationConnectLocalSerial(serial, &error)) {
                         qCWarning(lcAutomation).noquote()
                             << "connect local serial failed after scheduling:" << error;
                     }
@@ -3102,13 +3102,13 @@ QJsonObject AutomationServer::doConnect(const QString& action,
             return err(QStringLiteral("connect ip requires a host or IP address"));
         }
 
-        QPointer<ConnectionPanel> guardedPanel = panel;
-        QTimer::singleShot(0, qApp, [guardedPanel, target] {
-            if (!guardedPanel) {
+        QPointer<QObject> guard(conn->asQObject());
+        QTimer::singleShot(0, qApp, [guard, conn, target] {
+            if (!guard) {
                 return;
             }
             QString error;
-            if (!guardedPanel->automationConnectByIp(target, &error)) {
+            if (!conn->automationConnectByIp(target, &error)) {
                 qCWarning(lcAutomation).noquote()
                     << "connect ip failed after scheduling:" << error;
             }
@@ -3135,15 +3135,15 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
     }
 
     QObject* host = m_connectionDialogHost;
-    ConnectionPanel* panel = m_connectionPanel;
-    if (!host && !panel) {
+    IConnectionAutomation* conn = m_connection;
+    if (!host && !conn) {
         return err(QStringLiteral("connection dialog unavailable"));
     }
 
-    const bool wasVisible = panel && panel->isVisible();
+    const bool wasVisible = conn && conn->automationDialogVisible();
     QPointer<QObject> guardedHost = host;
-    QPointer<ConnectionPanel> guardedPanel = panel;
-    QTimer::singleShot(0, qApp, [guardedHost, guardedPanel, show] {
+    QPointer<QObject> guard(conn ? conn->asQObject() : nullptr);
+    QTimer::singleShot(0, qApp, [guardedHost, guard, conn, show] {
         if (guardedHost) {
             const char* method = show ? "showConnectionDialog" : "hideConnectionDialog";
             if (QMetaObject::invokeMethod(guardedHost, method, Qt::DirectConnection)) {
@@ -3154,16 +3154,10 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
                 << "- falling back to direct panel visibility";
         }
 
-        if (!guardedPanel) {
+        if (!guard) {
             return;
         }
-        if (show) {
-            guardedPanel->show();
-            guardedPanel->raise();
-            guardedPanel->activateWindow();
-        } else {
-            guardedPanel->hide();
-        }
+        conn->automationSetDialogVisible(show);
     });
 
     return QJsonObject{
@@ -3177,21 +3171,21 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
 
 QJsonObject AutomationServer::doDisconnect()
 {
-    ConnectionPanel* panel = m_connectionPanel;
-    if (!panel) {
+    IConnectionAutomation* conn = m_connection;
+    if (!conn) {
         return err(QStringLiteral("connection panel unavailable"));
     }
     if (!m_radioModel || !m_radioModel->isConnected()) {
         return err(QStringLiteral("not connected to a radio"));
     }
 
-    QPointer<ConnectionPanel> guardedPanel = panel;
-    QTimer::singleShot(0, qApp, [guardedPanel] {
-        if (!guardedPanel) {
+    QPointer<QObject> guard(conn->asQObject());
+    QTimer::singleShot(0, qApp, [guard, conn] {
+        if (!guard) {
             return;
         }
         QString error;
-        if (!guardedPanel->automationDisconnect(&error)) {
+        if (!conn->automationDisconnect(&error)) {
             qCWarning(lcAutomation).noquote()
                 << "disconnect failed after scheduling:" << error;
         }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3005,7 +3005,7 @@ QJsonObject AutomationServer::doConnect(const QString& action,
         return err(QStringLiteral("connect dialog requires show|hide"));
     }
 
-    IConnectionAutomation* conn = m_connection;
+    IConnectionAutomation* conn = connection();
     if (!conn) {
         return err(QStringLiteral("connection panel unavailable"));
     }
@@ -3135,7 +3135,7 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
     }
 
     QObject* host = m_connectionDialogHost;
-    IConnectionAutomation* conn = m_connection;
+    IConnectionAutomation* conn = connection();
     if (!host && !conn) {
         return err(QStringLiteral("connection dialog unavailable"));
     }
@@ -3171,7 +3171,7 @@ QJsonObject AutomationServer::doConnectDialog(const QString& action)
 
 QJsonObject AutomationServer::doDisconnect()
 {
-    IConnectionAutomation* conn = m_connection;
+    IConnectionAutomation* conn = connection();
     if (!conn) {
         return err(QStringLiteral("connection panel unavailable"));
     }

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -26,7 +26,7 @@ class QTimer;
 namespace AetherSDR {
 
 class RadioModel;
-class ConnectionPanel;
+class IConnectionAutomation;
 class AudioEngine;
 class QsoRecorder;
 
@@ -206,10 +206,13 @@ public:
     void setAudioEngine(AudioEngine* audio) { m_audioEngine = audio; }
     // QSO recorder handle for the record() verb (start/stop/status/path).
     void setQsoRecorder(QsoRecorder* rec) { m_qsoRecorder = rec; }
-    // Real connection dialog hook for the connect/disconnect verbs. The bridge
-    // asks ConnectionPanel to emit the same signals the visible buttons do, so
-    // automation exercises the normal MainWindow/RadioModel connection path.
-    void setConnectionPanel(ConnectionPanel* panel) { m_connectionPanel = panel; }
+    // Real connection hook for the connect/disconnect/dialog verbs. The bridge
+    // asks the implementor (the GUI's ConnectionPanel) to drive the same path
+    // the visible buttons do, so automation exercises the normal
+    // MainWindow/RadioModel connection flow. The engine holds only the
+    // gui-free IConnectionAutomation interface (aetherd RFC step 1 / EB1
+    // boundary); lifetime across deferred calls is guarded via asQObject().
+    void setConnectionAutomation(IConnectionAutomation* conn) { m_connection = conn; }
     void setConnectionDialogHost(QObject* host) { m_connectionDialogHost = host; }
     void setSliceReceiveSourceHandler(
         std::function<QJsonObject(const QString&)> handler)
@@ -403,7 +406,7 @@ private:
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<QsoRecorder> m_qsoRecorder;          // for record(); may be null
-    QPointer<ConnectionPanel> m_connectionPanel;  // for connect/disconnect verbs
+    IConnectionAutomation* m_connection = nullptr;  // connect/disconnect verbs; guard via asQObject()
     QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
     std::function<QJsonObject(const QString&)> m_sliceReceiveSourceHandler;
     std::function<QJsonObject()> m_receiveSyncSnapshotHandler;

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -18,6 +18,8 @@ class QWebSocket;
 #include <memory>
 #include <vector>
 
+#include "IConnectionAutomation.h"  // complete type: inline setter calls asQObject()
+
 class QLocalServer;
 class QLocalSocket;
 class QWidget;
@@ -26,7 +28,6 @@ class QTimer;
 namespace AetherSDR {
 
 class RadioModel;
-class IConnectionAutomation;
 class AudioEngine;
 class QsoRecorder;
 
@@ -212,7 +213,14 @@ public:
     // MainWindow/RadioModel connection flow. The engine holds only the
     // gui-free IConnectionAutomation interface (aetherd RFC step 1 / EB1
     // boundary); lifetime across deferred calls is guarded via asQObject().
-    void setConnectionAutomation(IConnectionAutomation* conn) { m_connection = conn; }
+    void setConnectionAutomation(IConnectionAutomation* conn)
+    {
+        m_connection = conn;
+        // Guard on the implementor's QObject so a destroyed panel reads back as
+        // null, preserving the old QPointer<ConnectionPanel> safety net (the
+        // raw interface pointer alone cannot auto-null). See connection().
+        m_connectionGuard = conn ? conn->asQObject() : nullptr;
+    }
     void setConnectionDialogHost(QObject* host) { m_connectionDialogHost = host; }
     void setSliceReceiveSourceHandler(
         std::function<QJsonObject(const QString&)> handler)
@@ -406,7 +414,15 @@ private:
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<QsoRecorder> m_qsoRecorder;          // for record(); may be null
-    IConnectionAutomation* m_connection = nullptr;  // connect/disconnect verbs; guard via asQObject()
+    IConnectionAutomation* m_connection = nullptr;  // connect/disconnect verbs
+    QPointer<QObject> m_connectionGuard;            // auto-nulls when the impl is destroyed
+    // Returns the connection hook only while its implementor is alive, so every
+    // synchronous use fails closed ("unavailable") after the panel is gone —
+    // exactly as the former QPointer<ConnectionPanel> member did.
+    IConnectionAutomation* connection() const
+    {
+        return m_connectionGuard ? m_connection : nullptr;
+    }
     QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
     std::function<QJsonObject(const QString&)> m_sliceReceiveSourceHandler;
     std::function<QJsonObject()> m_receiveSyncSnapshotHandler;

--- a/src/core/IConnectionAutomation.h
+++ b/src/core/IConnectionAutomation.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+
+#include "core/RadioDiscovery.h"  // RadioInfo
+
+class QObject;
+
+namespace AetherSDR {
+
+// Engine-side interface for the automation bridge's connect/disconnect verbs.
+//
+// AutomationServer lives in libaethercore (aetherd RFC step 1) and must not
+// include any gui/ header, but the connect/disconnect/dialog verbs still need
+// to drive the real connection UI so automation exercises the same
+// MainWindow/RadioModel path a human does. The GUI's ConnectionPanel
+// implements this interface; the engine holds only an IConnectionAutomation*.
+//
+// Lifetime: the implementor is a QObject (ConnectionPanel is a QWidget). Verbs
+// that defer work onto the GUI event loop guard against destruction with
+// QPointer<QObject>(asQObject()) — hence asQObject().
+class IConnectionAutomation {
+public:
+    virtual ~IConnectionAutomation() = default;
+
+    // Discovered local radios, for the `connect list`/`connect local` verbs.
+    virtual QList<RadioInfo> automationLocalRadios() const = 0;
+
+    // Drive the normal connect path. Return false + fill *error on failure.
+    virtual bool automationConnectLocalSerial(const QString& serial,
+                                              QString* error = nullptr) = 0;
+    virtual bool automationConnectByIp(const QString& hostOrIp,
+                                       QString* error = nullptr) = 0;
+    virtual bool automationDisconnect(QString* error = nullptr) = 0;
+
+    // Connect-dialog visibility (fallback when no invokable dialog host is set).
+    virtual bool automationDialogVisible() const = 0;
+    virtual void automationSetDialogVisible(bool visible) = 0;
+
+    // The implementing object, for QPointer lifetime guarding across the
+    // deferred (QTimer::singleShot) calls the verbs schedule.
+    virtual QObject* asQObject() = 0;
+};
+
+}  // namespace AetherSDR

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -2,6 +2,7 @@
 
 #include "core/RadioDiscovery.h"
 #include "core/SmartLinkClient.h"
+#include "core/IConnectionAutomation.h"
 
 #include <QWidget>
 #include <QListWidget>
@@ -20,7 +21,7 @@ class QVBoxLayout;
 namespace AetherSDR {
 
 // Novice-first dialog for local, SmartLink, and manual/VPN radio connections.
-class ConnectionPanel : public QWidget {
+class ConnectionPanel : public QWidget, public IConnectionAutomation {
     Q_OBJECT
 
 public:
@@ -30,10 +31,24 @@ public:
     void setConnected(bool connected);
     void setStatusText(const QString& text);
     void probeRadio(const QString& ip);
-    QList<RadioInfo> automationLocalRadios() const;
-    bool automationConnectLocalSerial(const QString& serial, QString* error = nullptr);
-    bool automationConnectByIp(const QString& hostOrIp, QString* error = nullptr);
-    bool automationDisconnect(QString* error = nullptr);
+
+    // IConnectionAutomation — engine-facing connect/disconnect/dialog hook.
+    QList<RadioInfo> automationLocalRadios() const override;
+    bool automationConnectLocalSerial(const QString& serial, QString* error = nullptr) override;
+    bool automationConnectByIp(const QString& hostOrIp, QString* error = nullptr) override;
+    bool automationDisconnect(QString* error = nullptr) override;
+    bool automationDialogVisible() const override { return isVisible(); }
+    void automationSetDialogVisible(bool visible) override
+    {
+        if (visible) {
+            show();
+            raise();
+            activateWindow();
+        } else {
+            hide();
+        }
+    }
+    QObject* asQObject() override { return this; }
 
 protected:
     void paintEvent(QPaintEvent* event) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char* argv[])
             automation->setAudioEngine(window.audioEngine());
             automation->setQsoRecorder(window.qsoRecorder());  // for the record() verb
             automation->setConnectionDialogHost(&window);
-            automation->setConnectionPanel(
+            automation->setConnectionAutomation(
                 window.findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
             automation->setSliceReceiveSourceHandler(
                 [&window](const QString& arg) {

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -39,9 +39,10 @@ GUI_DIR = REPO / "src" / "gui"
 
 # Legacy boundary violations inside the engine, tracked for relocation
 # or seam-extraction in RFC step 1. Shrink these lists; never grow them.
-KNOWN_GUI_INCLUDE_LEGACY = {
-    "src/core/AutomationServer.cpp",  # gui/ConnectionPanel.h
-}
+# EB1 is now clear: no engine file includes a gui/ header (AutomationServer's
+# ConnectionPanel dependency was inverted behind IConnectionAutomation in the
+# step-1 PR). Any EB1 finding is now a hard error.
+KNOWN_GUI_INCLUDE_LEGACY = set()
 KNOWN_WIDGETS_LEGACY = {
     "src/core/TxKeyingMarker.h",
     "src/core/ThemeManager.cpp",

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+AetherSDR engine-boundary static checker (aetherd migration ratchet).
+
+Guards the dependency direction the aetherd RFC
+(docs/aetherd-headless-engine-design.md) is built on:
+
+  EB1  No file under src/core/ or src/models/ may include a src/gui/
+       header. One legacy offender exists (AutomationServer.cpp →
+       ConnectionPanel.h) and is tracked for seam-extraction in RFC
+       step 1; any OTHER occurrence is an error.
+
+  EB2  No file under src/core/ or src/models/ may include a QtWidgets
+       class header. Five legacy offenders are known and tracked for
+       relocation during RFC step 1 (KNOWN_WIDGETS_LEGACY below); they
+       warn as "known". Any OTHER file warns as NEW leakage.
+
+Exit 0 always in default mode (annotation/warning stage, like
+check_a11y.py). --strict exits 1 on any non-legacy EB1/EB2 finding —
+new leakage blocks immediately while the tracked legacy set shrinks
+to zero during step 1. Shrink the legacy lists; never grow them.
+
+Usage:
+    python tools/check_engine_boundary.py [file1 file2 ...]
+    python tools/check_engine_boundary.py            # scan all engine files
+    python tools/check_engine_boundary.py --strict
+
+stdlib only; no third-party dependencies.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ENGINE_DIRS = [REPO / "src" / "core", REPO / "src" / "models"]
+GUI_DIR = REPO / "src" / "gui"
+
+# Legacy boundary violations inside the engine, tracked for relocation
+# or seam-extraction in RFC step 1. Shrink these lists; never grow them.
+KNOWN_GUI_INCLUDE_LEGACY = {
+    "src/core/AutomationServer.cpp",  # gui/ConnectionPanel.h
+}
+KNOWN_WIDGETS_LEGACY = {
+    "src/core/TxKeyingMarker.h",
+    "src/core/ThemeManager.cpp",
+    "src/core/AutomationServer.cpp",
+    "src/core/ShortcutManager.cpp",
+    "src/core/SettingsHelpers.cpp",
+}
+
+GUI_INCLUDE_RE = re.compile(
+    r'^\s*#\s*include\s+"(?:\.\./)*(?:gui/)?(?P<name>[A-Za-z0-9_]+\.h)"'
+)
+GUI_PREFIXED_RE = re.compile(r'^\s*#\s*include\s+"(?:\.\./)*gui/')
+
+# Common QtWidgets class headers (curated; QShortcut/QAction/QUndoStack
+# and QFileSystemModel live in QtGui in Qt 6 and are deliberately absent).
+QTWIDGETS_CLASSES = {
+    "QWidget", "QApplication", "QDialog", "QMainWindow", "QLabel",
+    "QPushButton", "QToolButton", "QCheckBox", "QComboBox", "QSpinBox",
+    "QDoubleSpinBox", "QSlider", "QLineEdit", "QTextEdit",
+    "QPlainTextEdit", "QMenu", "QMenuBar", "QToolBar", "QStatusBar",
+    "QMessageBox", "QFileDialog", "QColorDialog", "QFontDialog",
+    "QInputDialog", "QScrollArea", "QScrollBar", "QSplitter",
+    "QStackedWidget", "QTabWidget", "QTabBar", "QTableWidget",
+    "QTableView", "QTreeWidget", "QTreeView", "QListWidget", "QListView",
+    "QHeaderView", "QGroupBox", "QRadioButton", "QProgressBar", "QFrame",
+    "QGraphicsView", "QGraphicsScene", "QBoxLayout", "QHBoxLayout",
+    "QVBoxLayout", "QGridLayout", "QFormLayout", "QLayout", "QSizePolicy",
+    "QStyle", "QStyleOption", "QStylePainter", "QProxyStyle", "QToolTip",
+    "QWhatsThis", "QCompleter", "QSystemTrayIcon", "QDockWidget",
+    "QWizard", "QCalendarWidget", "QDial", "QLCDNumber", "QFontComboBox",
+    "QKeySequenceEdit", "QDateTimeEdit", "QRhiWidget", "QAbstractItemView",
+    "QAbstractButton", "QAbstractScrollArea", "QAbstractSpinBox",
+    "QAbstractSlider", "QButtonGroup", "QRubberBand", "QSplashScreen",
+    "QToolBox", "QWidgetAction",
+}
+QT_INCLUDE_RE = re.compile(
+    r"^\s*#\s*include\s+<(?:QtWidgets/)?(?P<name>Q[A-Za-z0-9]+)>"
+)
+QTWIDGETS_MODULE_RE = re.compile(r"^\s*#\s*include\s+<QtWidgets(?:/|>)")
+
+
+def annotate(sev, filepath, line, title, message):
+    print(f"::{sev} file={filepath},line={line},title={title}::{message}")
+
+
+def collect_files(args):
+    if args:
+        files = []
+        for a in args:
+            p = (REPO / a) if not Path(a).is_absolute() else Path(a)
+            if p.suffix in (".h", ".cpp") and p.is_file():
+                rel = p.resolve().relative_to(REPO)
+                if any(str(rel).startswith(f"src/{d}/") for d in ("core", "models")):
+                    files.append(p.resolve())
+        return files
+    files = []
+    for d in ENGINE_DIRS:
+        files.extend(p for p in sorted(d.rglob("*")) if p.suffix in (".h", ".cpp"))
+    return files
+
+
+def check_file(path):
+    """Yield (severity, line_no, rule, message) findings for one file."""
+    rel = path.relative_to(REPO).as_posix()
+    text = path.read_text(errors="replace")
+    for i, line in enumerate(text.splitlines(), 1):
+        # EB1 — engine file includes a gui header
+        m = GUI_INCLUDE_RE.match(line)
+        if m and (GUI_PREFIXED_RE.match(line) or (GUI_DIR / m.group("name")).is_file()):
+            # Bare-name includes only count when the header exists in gui/
+            # and not beside the engine file (sibling engine includes are fine).
+            if GUI_PREFIXED_RE.match(line) or not (path.parent / m.group("name")).is_file():
+                if rel in KNOWN_GUI_INCLUDE_LEGACY:
+                    yield ("warning", i, "EB1-known",
+                           f"{rel} includes gui header {m.group('name')} — "
+                           "known legacy, tracked for seam-extraction in "
+                           "RFC step 1; do not add further gui includes")
+                else:
+                    yield ("error", i, "EB1",
+                           f"{rel} includes gui header {m.group('name')} — "
+                           "the engine must never depend on the UI "
+                           "(aetherd RFC §2/§10; gui→core only)")
+        # EB2 — engine file includes QtWidgets
+        qm = QT_INCLUDE_RE.match(line)
+        is_widgets = QTWIDGETS_MODULE_RE.match(line) or (
+            qm and qm.group("name") in QTWIDGETS_CLASSES
+        )
+        if is_widgets:
+            what = qm.group("name") if qm else "QtWidgets"
+            if rel in KNOWN_WIDGETS_LEGACY:
+                yield ("warning", i, "EB2-known",
+                       f"{rel} uses QtWidgets ({what}) — known legacy, "
+                       "tracked for relocation in RFC step 1; do not add "
+                       "further widget code here")
+            else:
+                yield ("warning", i, "EB2",
+                       f"{rel} uses QtWidgets ({what}) — engine code must "
+                       "not depend on QtWidgets (libaethercore must link "
+                       "without it, aetherd RFC §10); put UI code in "
+                       "src/gui/")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="*")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on EB1 or non-legacy EB2 findings")
+    args = ap.parse_args()
+
+    files = collect_files(args.files)
+    blocking = 0
+    total = 0
+    for f in files:
+        for sev, line, rule, msg in check_file(f):
+            annotate(sev, f.relative_to(REPO).as_posix(), line, rule, msg)
+            total += 1
+            if rule in ("EB1", "EB2"):
+                blocking += 1
+
+    print(f"engine-boundary: {len(files)} file(s) scanned, "
+          f"{total} finding(s), {blocking} would block under --strict")
+    if args.strict and blocking:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -37,24 +37,36 @@ REPO = Path(__file__).resolve().parent.parent
 ENGINE_DIRS = [REPO / "src" / "core", REPO / "src" / "models"]
 GUI_DIR = REPO / "src" / "gui"
 
+# Scanned source suffixes. Includes .mm (Objective-C++, e.g. MacMicPermission.mm)
+# and .hpp/.cc so no engine TU is a blind spot for gui/QtWidgets leakage.
+ENGINE_SUFFIXES = (".h", ".hpp", ".cpp", ".cc", ".mm")
+
 # Legacy boundary violations inside the engine, tracked for relocation
-# or seam-extraction in RFC step 1. Shrink these lists; never grow them.
+# or seam-extraction in RFC step 1. Shrink these; never grow them.
 # EB1 is now clear: no engine file includes a gui/ header (AutomationServer's
 # ConnectionPanel dependency was inverted behind IConnectionAutomation in the
 # step-1 PR). Any EB1 finding is now a hard error.
 KNOWN_GUI_INCLUDE_LEGACY = set()
+# EB2 is a per-file BASELINE COUNT, not a whole-file exemption: a tracked file
+# may keep its known QtWidgets usages but any INCREASE fails --strict, so new
+# leakage into the actively-migrating files (e.g. AutomationServer.cpp) is
+# caught. Counts may only drop; when a file hits 0, remove it.
 KNOWN_WIDGETS_LEGACY = {
-    "src/core/TxKeyingMarker.h",
-    "src/core/ThemeManager.cpp",
-    "src/core/AutomationServer.cpp",
-    "src/core/ShortcutManager.cpp",
-    "src/core/SettingsHelpers.cpp",
+    "src/core/TxKeyingMarker.h": 1,
+    "src/core/ThemeManager.cpp": 1,
+    "src/core/AutomationServer.cpp": 20,
+    "src/core/ShortcutManager.cpp": 1,
+    "src/core/SettingsHelpers.cpp": 1,
 }
 
+# Matches gui includes in "..." OR <...>, optional space, optional gui/ prefix,
+# and SUBDIR paths (name group carries '/'), so angle-bracket, no-space, and
+# bare-subpath forms (the tree uses e.g. "containers/ContainerManager.h") can't
+# slip an engine->gui dependency past --strict.
 GUI_INCLUDE_RE = re.compile(
-    r'^\s*#\s*include\s+"(?:\.\./)*(?:gui/)?(?P<name>[A-Za-z0-9_]+\.h)"'
+    r'^\s*#\s*include\s*[<"](?:\.\./)*(?:gui/)?(?P<name>[A-Za-z0-9_./]+\.h)[>"]'
 )
-GUI_PREFIXED_RE = re.compile(r'^\s*#\s*include\s+"(?:\.\./)*gui/')
+GUI_PREFIXED_RE = re.compile(r'^\s*#\s*include\s*[<"](?:\.\./)*gui/')
 
 # Common QtWidgets class headers (curated; QShortcut/QAction/QUndoStack
 # and QFileSystemModel live in QtGui in Qt 6 and are deliberately absent).
@@ -79,9 +91,9 @@ QTWIDGETS_CLASSES = {
     "QToolBox", "QWidgetAction",
 }
 QT_INCLUDE_RE = re.compile(
-    r"^\s*#\s*include\s+<(?:QtWidgets/)?(?P<name>Q[A-Za-z0-9]+)>"
+    r'^\s*#\s*include\s*[<"](?:QtWidgets/)?(?P<name>Q[A-Za-z0-9]+)[>"]'
 )
-QTWIDGETS_MODULE_RE = re.compile(r"^\s*#\s*include\s+<QtWidgets(?:/|>)")
+QTWIDGETS_MODULE_RE = re.compile(r'^\s*#\s*include\s*[<"]QtWidgets(?:/|[>"])')
 
 
 def annotate(sev, filepath, line, title, message):
@@ -93,56 +105,69 @@ def collect_files(args):
         files = []
         for a in args:
             p = (REPO / a) if not Path(a).is_absolute() else Path(a)
-            if p.suffix in (".h", ".cpp") and p.is_file():
+            if p.suffix in ENGINE_SUFFIXES and p.is_file():
                 rel = p.resolve().relative_to(REPO)
                 if any(str(rel).startswith(f"src/{d}/") for d in ("core", "models")):
                     files.append(p.resolve())
         return files
     files = []
     for d in ENGINE_DIRS:
-        files.extend(p for p in sorted(d.rglob("*")) if p.suffix in (".h", ".cpp"))
+        files.extend(p for p in sorted(d.rglob("*")) if p.suffix in ENGINE_SUFFIXES)
     return files
 
 
 def check_file(path):
-    """Yield (severity, line_no, rule, message) findings for one file."""
+    """Return a list of (severity, line_no, rule, message) findings for one
+    file. EB1 is per-line; EB2 is per-file (baseline-count) so growth in a
+    tracked legacy file is caught, not exempted."""
     rel = path.relative_to(REPO).as_posix()
     text = path.read_text(errors="replace")
-    for i, line in enumerate(text.splitlines(), 1):
-        # EB1 — engine file includes a gui header
+    lines = text.splitlines()
+    findings = []
+    widget_hits = []  # (line_no, class-name) across the whole file
+    for i, line in enumerate(lines, 1):
+        # EB1 — engine file includes a gui header (per line)
         m = GUI_INCLUDE_RE.match(line)
         if m and (GUI_PREFIXED_RE.match(line) or (GUI_DIR / m.group("name")).is_file()):
             # Bare-name includes only count when the header exists in gui/
             # and not beside the engine file (sibling engine includes are fine).
             if GUI_PREFIXED_RE.match(line) or not (path.parent / m.group("name")).is_file():
                 if rel in KNOWN_GUI_INCLUDE_LEGACY:
-                    yield ("warning", i, "EB1-known",
-                           f"{rel} includes gui header {m.group('name')} — "
-                           "known legacy, tracked for seam-extraction in "
-                           "RFC step 1; do not add further gui includes")
+                    findings.append(("warning", i, "EB1-known",
+                        f"{rel} includes gui header {m.group('name')} — known "
+                        "legacy; do not add further gui includes"))
                 else:
-                    yield ("error", i, "EB1",
-                           f"{rel} includes gui header {m.group('name')} — "
-                           "the engine must never depend on the UI "
-                           "(aetherd RFC §2/§10; gui→core only)")
-        # EB2 — engine file includes QtWidgets
+                    findings.append(("error", i, "EB1",
+                        f"{rel} includes gui header {m.group('name')} — the "
+                        "engine must never depend on the UI (aetherd RFC "
+                        "§2/§10; gui→core only)"))
+        # EB2 — collect QtWidgets includes; verdict is per-file below
         qm = QT_INCLUDE_RE.match(line)
-        is_widgets = QTWIDGETS_MODULE_RE.match(line) or (
-            qm and qm.group("name") in QTWIDGETS_CLASSES
-        )
-        if is_widgets:
-            what = qm.group("name") if qm else "QtWidgets"
-            if rel in KNOWN_WIDGETS_LEGACY:
-                yield ("warning", i, "EB2-known",
-                       f"{rel} uses QtWidgets ({what}) — known legacy, "
-                       "tracked for relocation in RFC step 1; do not add "
-                       "further widget code here")
-            else:
-                yield ("warning", i, "EB2",
-                       f"{rel} uses QtWidgets ({what}) — engine code must "
-                       "not depend on QtWidgets (libaethercore must link "
-                       "without it, aetherd RFC §10); put UI code in "
-                       "src/gui/")
+        if QTWIDGETS_MODULE_RE.match(line) or (
+                qm and qm.group("name") in QTWIDGETS_CLASSES):
+            widget_hits.append((i, qm.group("name") if qm else "QtWidgets"))
+
+    baseline = KNOWN_WIDGETS_LEGACY.get(rel)
+    if baseline is None:
+        # Untracked file: every QtWidgets use is a blocking EB2.
+        for i, what in widget_hits:
+            findings.append(("warning", i, "EB2",
+                f"{rel} uses QtWidgets ({what}) — engine code must not depend "
+                "on QtWidgets (libaethercore must link without it, aetherd "
+                "RFC §10); put UI code in src/gui/"))
+    else:
+        for i, what in widget_hits:
+            findings.append(("warning", i, "EB2-known",
+                f"{rel} uses QtWidgets ({what}) — tracked legacy "
+                f"(baseline {baseline}); the count may only shrink"))
+        if len(widget_hits) > baseline:
+            # New widget leakage into a tracked, actively-migrating file.
+            findings.append(("error", widget_hits[-1][0], "EB2",
+                f"{rel} QtWidgets usage grew to {len(widget_hits)} (baseline "
+                f"{baseline}) — the tracked count may only shrink; move new "
+                "widget code to src/gui/ (or lower the baseline if you removed "
+                "some)"))
+    return findings
 
 
 def main():
@@ -153,13 +178,26 @@ def main():
     args = ap.parse_args()
 
     files = collect_files(args.files)
+
+    # Floor check: a full-tree scan that finds no engine files means the
+    # directory layout moved and the ratchet silently disarmed. Fail loudly
+    # rather than pass vacuously. (Skipped when specific files are passed.)
+    if not args.files and len(files) < 50:
+        annotate("error", "tools/check_engine_boundary.py", 1, "EB0",
+                 f"only {len(files)} engine files found scanning "
+                 f"{[str(d.relative_to(REPO)) for d in ENGINE_DIRS]} — the "
+                 "engine tree moved; the boundary ratchet is disarmed. Fix "
+                 "ENGINE_DIRS.")
+        print(f"engine-boundary: {len(files)} file(s) scanned — FLOOR TRIPPED")
+        return 1
+
     blocking = 0
     total = 0
     for f in files:
         for sev, line, rule, msg in check_file(f):
             annotate(sev, f.relative_to(REPO).as_posix(), line, rule, msg)
             total += 1
-            if rule in ("EB1", "EB2"):
+            if rule in ("EB1", "EB2", "EB0"):
                 blocking += 1
 
     print(f"engine-boundary: {len(files)} file(s) scanned, "

--- a/tools/gen_touchpoint_manifest.py
+++ b/tools/gen_touchpoint_manifest.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+AetherSDR aetherd-migration touchpoint manifest generator.
+
+Scans the UI side of the tree (src/gui/ + src/main.cpp) for #include
+dependencies on engine headers (src/core/, src/models/) and regenerates
+the touchpoint burndown manifest used by the aetherd migration
+(docs/aetherd-headless-engine-design.md, RFC step 2+).
+
+The manifest is GENERATED — do not hand-edit the table. Two sidecar
+files carry the human/agent-authored state and survive regeneration:
+
+  docs/architecture/aetherd-touchpoint-tags.json
+      Semantic tags per header: core-profile ("universal") vs
+      vendor-specific vs mixed, with rationale. Produced by the
+      classification pass; merged into the manifest when present.
+
+  docs/architecture/aetherd-touchpoint-status.json
+      Conversion status per header ("unconverted" | "in progress:<who>"
+      | "converted:<PR#>"). Updated by conversion PRs. The check that
+      the converted list only grows compares this file across commits.
+
+Usage:
+    python tools/gen_touchpoint_manifest.py            # regenerate
+    python tools/gen_touchpoint_manifest.py --check    # exit 1 if stale
+
+Exit 0 on success; --check exits 1 if the committed manifest differs
+from what would be generated (used to keep the manifest honest in CI).
+
+stdlib only; no third-party dependencies.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+UI_ROOTS = [REPO / "src" / "gui", REPO / "src" / "main.cpp"]
+ENGINE_DIRS = {"core": REPO / "src" / "core", "models": REPO / "src" / "models"}
+
+MANIFEST_MD = REPO / "docs" / "architecture" / "aetherd-touchpoints.md"
+TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
+STATUS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-status.json"
+
+# Matches: #include "core/Foo.h" | "models/Foo.h" | "../core/Foo.h" | "Foo.h"
+INCLUDE_RE = re.compile(
+    r'^\s*#\s*include\s+"(?P<path>(?:\.\./)*(?:(?P<mod>core|models)/)?'
+    r'(?P<name>[A-Za-z0-9_]+\.h))"'
+)
+
+
+def ui_files():
+    for root in UI_ROOTS:
+        if root.is_file():
+            yield root
+        elif root.is_dir():
+            yield from sorted(
+                p for p in root.rglob("*") if p.suffix in (".h", ".cpp")
+            )
+
+
+def resolve_engine_header(mod, name):
+    """Return (module, header-name) if the include resolves into the
+    engine, else None. Bare includes are resolved against core/ and
+    models/ only when no same-named gui header exists (gui files
+    include siblings by bare name)."""
+    if mod:
+        return (mod, name) if (ENGINE_DIRS[mod] / name).is_file() else None
+    if (REPO / "src" / "gui" / name).is_file():
+        return None
+    for m, d in ENGINE_DIRS.items():
+        if (d / name).is_file():
+            return (m, name)
+    return None
+
+
+def scan():
+    touchpoints = {}  # (module, header) -> sorted set of includer rel-paths
+    for f in ui_files():
+        rel = f.relative_to(REPO).as_posix()
+        try:
+            text = f.read_text(errors="replace")
+        except OSError as e:
+            print(f"warning: unreadable {rel}: {e}", file=sys.stderr)
+            continue
+        for line in text.splitlines():
+            m = INCLUDE_RE.match(line)
+            if not m:
+                continue
+            hit = resolve_engine_header(m.group("mod"), m.group("name"))
+            if hit:
+                touchpoints.setdefault(hit, set()).add(rel)
+    return {k: sorted(v) for k, v in sorted(touchpoints.items())}
+
+
+def load_json(path):
+    if path.is_file():
+        return json.loads(path.read_text())
+    return {}
+
+
+def render(touchpoints, tags, status):
+    total = len(touchpoints)
+    by_mod = {"core": 0, "models": 0}
+    for (mod, _name) in touchpoints:
+        by_mod[mod] += 1
+    tagged = sum(1 for (m, n) in touchpoints if f"{m}/{n}" in tags)
+    converted = sum(
+        1
+        for (m, n) in touchpoints
+        if str(status.get(f"{m}/{n}", "")).startswith("converted")
+    )
+
+    lines = [
+        "# aetherd migration — gui→engine touchpoint manifest",
+        "",
+        "<!-- GENERATED FILE — regenerate with"
+        " `python tools/gen_touchpoint_manifest.py`."
+        " Edit the tags/status JSON sidecars, never this table. -->",
+        "",
+        "Burndown manifest for the engine/UI decoupling"
+        " ([RFC](../aetherd-headless-engine-design.md) §2, §10)."
+        " One row per engine header the UI includes; converting a"
+        " touchpoint means the UI reaches that surface through the"
+        " versioned protocol instead of the header.",
+        "",
+        f"**Totals:** {total} touchpoint headers"
+        f" ({by_mod['core']} core, {by_mod['models']} models) —"
+        f" {tagged}/{total} tagged, {converted}/{total} converted.",
+        "",
+        "| Header | Includers | Tag | Status |",
+        "|---|---:|---|---|",
+    ]
+    for (mod, name), includers in touchpoints.items():
+        key = f"{mod}/{name}"
+        tag = tags.get(key, {})
+        tag_txt = tag.get("tag", "—")
+        if tag.get("note"):
+            tag_txt += f" — {tag['note']}"
+        lines.append(
+            f"| `{key}` | {len(includers)} |"
+            f" {tag_txt} | {status.get(key, 'unconverted')} |"
+        )
+    lines += [
+        "",
+        "**Tag legend:** `universal` = core-profile surface every radio"
+        " family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a"
+        " namespaced extension; `mixed` = header carries both (split"
+        " candidates noted); `ui-support` = not radio state at all"
+        " (settings, theming, app plumbing) — needs a home decision,"
+        " not a protocol message.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the committed manifest is stale")
+    args = ap.parse_args()
+
+    touchpoints = scan()
+    out = render(touchpoints, load_json(TAGS_JSON), load_json(STATUS_JSON))
+
+    if args.check:
+        current = MANIFEST_MD.read_text() if MANIFEST_MD.is_file() else ""
+        if current != out:
+            print("::error::aetherd-touchpoints.md is stale — run"
+                  " `python tools/gen_touchpoint_manifest.py`")
+            return 1
+        print("manifest up to date")
+        return 0
+
+    MANIFEST_MD.parent.mkdir(parents=True, exist_ok=True)
+    MANIFEST_MD.write_text(out)
+    print(f"wrote {MANIFEST_MD.relative_to(REPO)}: "
+          f"{len(touchpoints)} touchpoint headers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/gen_touchpoint_manifest.py
+++ b/tools/gen_touchpoint_manifest.py
@@ -99,9 +99,14 @@ def scan():
 
 
 def load_json(path):
-    if path.is_file():
+    if not path.is_file():
+        return {}
+    try:
         return json.loads(path.read_text())
-    return {}
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"warning: {path.name} is not valid JSON ({e}); treating as "
+              "empty", file=sys.stderr)
+        return {}
 
 
 def render(touchpoints, tags, status):

--- a/tools/gen_touchpoint_manifest.py
+++ b/tools/gen_touchpoint_manifest.py
@@ -44,11 +44,9 @@ MANIFEST_MD = REPO / "docs" / "architecture" / "aetherd-touchpoints.md"
 TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
 STATUS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-status.json"
 
-# Matches: #include "core/Foo.h" | "models/Foo.h" | "../core/Foo.h" | "Foo.h"
-INCLUDE_RE = re.compile(
-    r'^\s*#\s*include\s+"(?P<path>(?:\.\./)*(?:(?P<mod>core|models)/)?'
-    r'(?P<name>[A-Za-z0-9_]+\.h))"'
-)
+# Matches any quoted .h include; resolution (incl. core/models subdirs like
+# core/aprs/AprsPacket.h) happens in resolve_engine_header.
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"(?P<inc>[^"]+\.h)"')
 
 
 def ui_files():
@@ -61,18 +59,23 @@ def ui_files():
             )
 
 
-def resolve_engine_header(mod, name):
-    """Return (module, header-name) if the include resolves into the
-    engine, else None. Bare includes are resolved against core/ and
-    models/ only when no same-named gui header exists (gui files
-    include siblings by bare name)."""
-    if mod:
-        return (mod, name) if (ENGINE_DIRS[mod] / name).is_file() else None
-    if (REPO / "src" / "gui" / name).is_file():
+def resolve_engine_header(inc):
+    """Return (module, relpath) if an include resolves into the engine, else
+    None. Handles module-qualified paths WITH subdirectories
+    (core/aprs/AprsPacket.h -> ("core", "aprs/AprsPacket.h")) and bare-name
+    sibling includes (resolved against core/ and models/ only when no
+    same-named gui header exists — gui files include siblings by bare name)."""
+    p = re.sub(r"^(?:\.\./)+", "", inc)  # strip any leading ../
+    if p.startswith(("core/", "models/")):
+        mod, rest = p.split("/", 1)
+        return (mod, rest) if (ENGINE_DIRS[mod] / rest).is_file() else None
+    if "/" in p:  # a subdir path that isn't under core/ or models/
+        return None
+    if (REPO / "src" / "gui" / p).is_file():
         return None
     for m, d in ENGINE_DIRS.items():
-        if (d / name).is_file():
-            return (m, name)
+        if (d / p).is_file():
+            return (m, p)
     return None
 
 
@@ -89,7 +92,7 @@ def scan():
             m = INCLUDE_RE.match(line)
             if not m:
                 continue
-            hit = resolve_engine_header(m.group("mod"), m.group("name"))
+            hit = resolve_engine_header(m.group("inc"))
             if hit:
                 touchpoints.setdefault(hit, set()).add(rel)
     return {k: sorted(v) for k, v in sorted(touchpoints.items())}

--- a/tools/verify_slice0_rx.py
+++ b/tools/verify_slice0_rx.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+AetherSDR slice-0 RX verification harness (aetherd migration regression check).
+
+Drives a running AetherSDR instance through the automation bridge and asserts
+the core connect -> slice-0 RX pipeline is intact, plus the TX-safety guard.
+Built for the aetherd RFC (docs/aetherd-headless-engine-design.md): run it
+before and after a structural change (the libaethercore split, the
+IRadioBackend seam, a touchpoint conversion) to prove behaviour is preserved.
+
+It exercises exactly the surface the migration puts at risk:
+  * connect verbs resolve through IConnectionAutomation (step 1 inversion)
+  * RadioModel / SliceModel / PanadapterModel / TransmitModel resolve through
+    the (possibly split) engine library
+  * the TX-keying guard still refuses a keying invoke without ALLOW_TX
+
+It does NOT key the transmitter and does NOT require ALLOW_TX. The one place
+it touches TX is to assert a keying control is *refused*.
+
+Usage:
+    # Against an already-running bridge (auto-discovers the socket):
+    python3 tools/verify_slice0_rx.py
+
+    # Launch a throwaway instance, verify, tear it down:
+    python3 tools/verify_slice0_rx.py --launch ./build/AetherSDR
+
+    # Emit a JSON snapshot for before/after diffing across a refactor:
+    python3 tools/verify_slice0_rx.py --json > before.json
+    #   ...apply the change, rebuild...
+    python3 tools/verify_slice0_rx.py --json > after.json
+    #   the "assertions" block should be identical; model values may drift
+    #   with live band conditions, so diff assertions, not frequencies.
+
+Exit 0 iff every assertion passes. Requires a radio reachable by the running
+instance (real or simulator); with no radio, connect is skipped and the run
+reports SKIPPED (exit 0) rather than failing — a headless CI box has no radio.
+
+Reuses tools/automation_probe.py as the transport (no new socket code).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PROBE = REPO / "tools" / "automation_probe.py"
+
+
+def probe(*args, socket=None):
+    """Run one automation_probe verb, return parsed JSON (or {} on non-JSON)."""
+    cmd = [sys.executable, str(PROBE)]
+    if socket:
+        cmd += ["--socket", socket]
+    cmd += list(args)
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "probe timeout"}
+    try:
+        return json.loads(out)
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": False, "error": "non-json", "raw": out[:200]}
+
+
+class Report:
+    def __init__(self):
+        self.assertions = []
+        self.snapshot = {}
+
+    def check(self, name, ok, detail=""):
+        self.assertions.append({"name": name, "pass": bool(ok), "detail": detail})
+        mark = "PASS" if ok else "FAIL"
+        # Progress goes to stderr so --json keeps stdout pure JSON.
+        print(f"  [{mark}] {name}" + (f" — {detail}" if detail else ""),
+              file=sys.stderr)
+        return ok
+
+    @property
+    def passed(self):
+        return all(a["pass"] for a in self.assertions)
+
+
+def run(socket, want_grab, grab_path):
+    r = Report()
+
+    # 1. Bridge reachable + model-facing get resolves (engine lib linked).
+    radio = probe("get", "radio", socket=socket)
+    if not r.check("bridge reachable + get radio ok", radio.get("ok"),
+                   radio.get("error", "")):
+        return r, "bridge unreachable"
+    rm = radio.get("radio", radio)
+
+    connected = bool(rm.get("connected"))
+    r.snapshot["radio"] = {"connected": connected, "model": rm.get("model")}
+
+    # 2. If not already connected, drive the inverted connect path.
+    if not connected:
+        radios = probe("connect", "list", socket=socket)
+        n = radios.get("count", 0)
+        if n == 0:
+            r.check("connect list resolves (IConnectionAutomation)",
+                    radios.get("ok"), "no radios discovered — RX checks SKIPPED")
+            print("  [SKIP] no radio reachable; connect/RX assertions skipped", file=sys.stderr)
+            return r, "skipped-no-radio"
+        r.check("connect list resolves (IConnectionAutomation)", radios.get("ok"),
+                f"{n} radio(s)")
+        probe("connect", "local", "first", socket=socket)
+        # Wait for the connect + slice-0 status to arrive.
+        for _ in range(20):
+            time.sleep(1)
+            if probe("get", "radio", socket=socket).get("radio", {}).get("connected"):
+                break
+        rm = probe("get", "radio", socket=socket).get("radio", {})
+        connected = bool(rm.get("connected"))
+
+    r.check("radio connected", connected, rm.get("model", ""))
+    if not connected:
+        return r, "connect failed"
+
+    # 3. Slice-0 RX state present and well-formed (SliceModel through engine).
+    slices = probe("get", "slices", socket=socket).get("slices", [])
+    r.check("slice-0 exists", len(slices) >= 1, f"{len(slices)} slice(s)")
+    if slices:
+        s0 = slices[0]
+        mode = s0.get("mode")
+        flo, fhi = s0.get("filterLow"), s0.get("filterHigh")
+        r.check("slice-0 has a mode", bool(mode), str(mode))
+        r.check("slice-0 has a valid RX filter",
+                isinstance(flo, (int, float)) and isinstance(fhi, (int, float))
+                and flo < fhi, f"[{flo}, {fhi}]")
+        r.snapshot["slice0"] = {"mode": mode, "filterLow": flo, "filterHigh": fhi,
+                                "frequency": s0.get("frequency")}
+
+    # 4. PanadapterModel resolves (RX data pipeline through engine).
+    pans = probe("get", "pans", socket=socket).get("pans", [])
+    r.check("panadapter model present", len(pans) >= 1, f"{len(pans)} pan(s)")
+
+    # 5. TransmitModel resolves (does not key).
+    tx = probe("get", "transmit", socket=socket)
+    r.check("transmit model resolves", tx.get("ok"), "")
+
+    # 6. TX-safety guard: a keying invoke must be REFUSED without ALLOW_TX.
+    #    (This asserts the guard, it does not key.)
+    mox = probe("invoke", "MOX", "toggle", socket=socket)
+    refused = (not mox.get("ok")) and "TX" in str(mox.get("error", ""))
+    r.check("TX-keying guard refuses MOX (no ALLOW_TX)", refused,
+            mox.get("error", "")[:60])
+
+    # 7. Optional: prove the GPU panadapter renders (needs a real display;
+    #    offscreen returns an empty image, which we report as SKIP not FAIL).
+    if want_grab:
+        g = probe("grab", "SpectrumWidget", grab_path, socket=socket)
+        if g.get("bytes", 0) > 0:
+            r.check("panadapter GPU grab non-empty", True, f"{g['bytes']} bytes")
+        else:
+            print("  [SKIP] panadapter grab empty (offscreen / no GPU context)", file=sys.stderr)
+
+    return r, "ok"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--socket", help="bridge socket override (else auto-discover)")
+    ap.add_argument("--launch", metavar="BINARY",
+                    help="launch this AetherSDR binary (offscreen) for the run "
+                         "and tear it down after")
+    ap.add_argument("--grab", action="store_true",
+                    help="also attempt a panadapter GPU framebuffer grab "
+                         "(needs a real display; offscreen -> SKIP)")
+    ap.add_argument("--grab-path", default="/tmp/aether_verify_pan.png")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the assertions+snapshot as JSON to stdout")
+    args = ap.parse_args()
+
+    app = None
+    env = dict(os.environ)
+    socket = args.socket
+    if args.launch:
+        env["AETHER_AUTOMATION"] = "1"
+        env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        app = subprocess.Popen([args.launch], env=env,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(10)  # let the bridge come up + auto-connect
+
+    try:
+        if not args.json:
+            print("slice-0 RX verification (aetherd migration regression check)", file=sys.stderr)
+        report, status = run(socket, args.grab, args.grab_path)
+    finally:
+        if app:
+            app.terminate()
+            try:
+                app.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                app.kill()
+
+    if args.json:
+        print(json.dumps({"status": status,
+                          "passed": report.passed,
+                          "assertions": report.assertions,
+                          "snapshot": report.snapshot}, indent=1))
+    else:
+        print(f"\nRESULT: {'PASS' if report.passed else 'FAIL'} ({status})")
+
+    # A skipped run (no radio) is not a failure.
+    if status == "skipped-no-radio":
+        return 0
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_slice0_rx.py
+++ b/tools/verify_slice0_rx.py
@@ -143,12 +143,17 @@ def run(socket, want_grab, grab_path):
     tx = probe("get", "transmit", socket=socket)
     r.check("transmit model resolves", tx.get("ok"), "")
 
-    # 6. TX-safety guard: a keying invoke must be REFUSED without ALLOW_TX.
-    #    (This asserts the guard, it does not key.)
+    # 6. TX-safety guard: a keying invoke must be REFUSED *by the guard*
+    #    without ALLOW_TX. (This asserts the guard; it does not key.)
+    #    Match the specific guard phrasing, not a bare "TX" substring — an
+    #    unrelated failure like "unknown control TX_MOX" would false-pass and
+    #    the guard would never have run.
     mox = probe("invoke", "MOX", "toggle", socket=socket)
-    refused = (not mox.get("ok")) and "TX" in str(mox.get("error", ""))
-    r.check("TX-keying guard refuses MOX (no ALLOW_TX)", refused,
-            mox.get("error", "")[:60])
+    err = str(mox.get("error", "")).lower()
+    refused_by_guard = (not mox.get("ok")) and (
+        "transmit-keying" in err or "tx-safety" in err or "allow_tx" in err)
+    r.check("TX-keying guard refuses MOX (no ALLOW_TX)", refused_by_guard,
+            mox.get("error", "")[:70])
 
     # 7. Optional: prove the GPU panadapter renders (needs a real display;
     #    offscreen returns an empty image, which we report as SKIP not FAIL).


### PR DESCRIPTION
First staged step of the accepted **aetherd RFC** (#3849, §10 step 1). Splits the monolith into an engine static library `libaethercore` (`src/core/` + `src/models/`) and a thin `AetherSDR` executable (`src/gui/` + `main.cpp`) that links it. **No source files move; behavior is unchanged.**

### What's in here
- **`libaethercore` / `AetherSDR` CMake split.** All `HAVE_*` / `AETHER_GPU_SPECTRUM` defines are `PUBLIC` on the engine (gui TUs test them — verified identical define sets on gui and core TUs); Qt SerialPort/WebSockets and third-party include dirs `PUBLIC`; qrc/shaders stay on the exe (process-global rcc).
- **Engine boundary now fully clean (EB1 = 0).** `AutomationServer`'s lone gui dependency (`gui/ConnectionPanel.h`) is inverted behind a new gui-free `core/IConnectionAutomation.h` that `ConnectionPanel` implements. This also removes the `QPointer<ConnectionPanel>` member whose end-of-TU template instantiation the monolith's AUTOMOC jumbo-TU was silently completing — the incomplete-type trap the [step-1 dry run](docs/architecture/aetherd-step1-dryrun.md) hit is gone at the root, not merely out-lined.
- **CI ratchet** (`tools/check_engine_boundary.py` + `engine-boundary.yml`, `--strict`): new gui-includes/QtWidgets in the engine fail; `AutomationServer` stays tracked for EB2 (its widget-facing `dumpTree`/`grab` half splits out in step 3).
- **Touchpoint burndown** (`tools/gen_touchpoint_manifest.py` → `docs/architecture/aetherd-touchpoints.md`): 140 headers, 140/140 tagged (53 universal / 16 mixed / 26 vendor / 45 ui-support).
- **AGENTS.md** staged Block 1 landed (build-targets table + new-engine-code rule).

### Verification
Configure clean · full build · **61/61 tests pass** (`QT_QPA_PLATFORM=offscreen`) · `boundary --strict` green · live automation-bridge run against a real **FLEX-8600**: connect → slice-0 RX (7.225 LSB), PanadapterModel + TransmitModel resolve through the split lib, TX-keying refusal enforced (MOX blocked), inverted connect/disconnect/show/hide verbs all ok, and the **GPU panadapter render confirmed by framebuffer grab** on a windowed instance.

### Heads-up for the queue
This is the **coordinated move-window PR** (RFC §10): it rewrites `CMakeLists.txt` target wiring, so please **rebase open branches once** after this merges. Auto-squash-merge is enabled — the two commits (docs/tooling, code split) collapse to one on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)