### PR TITLE
fix(rx): adaptive RX filter — remove re-engage restore (QSO swap #4049), + accuracy fixes & opt-in edge-het

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1984,6 +1984,22 @@ target_include_directories(waveform_scope_model_test PRIVATE src)
 target_link_libraries(waveform_scope_model_test PRIVATE Qt6::Core)
 add_test(NAME waveform_scope_model_test COMMAND waveform_scope_model_test)
 
+# Engine-level test: drives AdaptiveFilterEngine::processFrame through a real
+# SliceModel (signals only, no radio) with monotonic timestamps — covers the
+# wall-clock pacing / send-throttle / QSO-handoff logic the measurement test
+# can't reach. Both AdaptiveFilterEngine and SliceModel are Q_OBJECT (AUTOMOC).
+add_executable(adaptive_engine_test
+    tests/adaptive_engine_test.cpp
+    src/core/AdaptiveFilterEngine.cpp
+    src/core/OccupiedRegion.cpp
+    src/models/SliceModel.cpp
+    src/core/KiwiSdrProtocol.cpp
+)
+target_include_directories(adaptive_engine_test PRIVATE src)
+target_link_libraries(adaptive_engine_test PRIVATE Qt6::Core)
+set_target_properties(adaptive_engine_test PROPERTIES AUTOMOC ON)
+add_test(NAME adaptive_engine_test COMMAND adaptive_engine_test)
+
 add_executable(kiwi_sdr_protocol_test
     tests/kiwi_sdr_protocol_test.cpp
     src/core/KiwiSdrProtocol.cpp

--- a/src/core/AdaptiveFilterEngine.cpp
+++ b/src/core/AdaptiveFilterEngine.cpp
@@ -26,14 +26,21 @@ namespace {
     // (perf(gui) #3958), which would halve every dwell/hold/confidence window
     // in wall-clock time AND push the frame-counted send throttle to ~15
     // filt/s — violating RFC #3878 cond. 2 (<= ~8/s). Rather than re-express
-    // the whole pipeline in seconds (a redesign), frames arriving faster than
-    // kMinFrameSpacingMs are simply not accepted: a native ~30 fps stream
-    // (33 ms) passes untouched with jitter headroom, a 60 fps stream is paced
-    // down to ~30 — the calibration rate — and the measurement cost halves as
-    // a bonus. kMinSendSpacingMs additionally enforces the filt-rate condition
-    // directly in wall-clock, independent of any fps assumption.
-    constexpr qint64 kMinFrameSpacingNs = 25LL * 1000000LL;   // <= 40 fps accepted
-    constexpr qint64 kMinSendSpacingNs  = 125LL * 1000000LL;  // <= 8 filt/s
+    // the whole pipeline in seconds (a redesign), we DECIMATE to the ~30 fps
+    // the constants were calibrated at, using a fixed-period accumulator:
+    // st.lastFrameNs holds the scheduled PHASE of the last accepted frame (not
+    // its arrival), and a frame is accepted only once the phase clock has
+    // advanced a full kFramePeriodNs. Because the phase marches at a constant
+    // period regardless of input jitter, 40/60/90 fps (and jittery) sources all
+    // decimate to a stable ~30 fps average — unlike a min-spacing-vs-last-
+    // arrival gate, which snaps its reference to each accepted frame and so
+    // collapses intermediate rates into a 20-40 fps sawtooth. kFramePeriodNs is
+    // set just below the native 33.3 ms (30 fps) interval so a native-30 stream
+    // passes untouched with a couple ms of jitter headroom. kMinSendSpacingNs
+    // additionally enforces the filt-rate condition directly in wall-clock,
+    // independent of any fps assumption.
+    constexpr qint64 kFramePeriodNs    = 31LL * 1000000LL;   // ~30 fps target
+    constexpr qint64 kMinSendSpacingNs = 125LL * 1000000LL;  // <= 8 filt/s
 
     // ── Pipeline constants (in frames; paced to ~30 fps above) ──────────────
     // Biased toward LOCKING: once fitted, the passband should sit still and move
@@ -105,9 +112,11 @@ namespace {
     //     as the signal weakens (the level-invariant cap needs headroom it
     //     doesn't have down here), so a weak station's "narrow" reading is an
     //     SNR artifact: widen-only until the peak clears the floor by
-    //     kLowSnrNarrowFreezeDb. Deliberately above the strongest presence
-    //     preset (14 dB), so every preset has a widen-only band just above
-    //     engagement.
+    //     (minPeakDb + kNarrowFreezeMarginDb). Scaled to the ACTIVE presence
+    //     preset so the freeze always sits just ABOVE the engagement gate
+    //     (Sensitive 6->9, Normal 9->12, Strong 14->17); a fixed threshold
+    //     (was 16 dB) sat far above the Sensitive/Normal gates and made a
+    //     medium signal that engaged never able to narrow.
     //   * FADING — while the in-band reference is falling (QSB fade in
     //     progress) the measured width is shrinking with it; freeze narrowing
     //     until the level stabilises. Median-of-first vs median-of-last over a
@@ -115,20 +124,27 @@ namespace {
     // Both suppress only the narrowing COMMIT — measurement, dwell and
     // widening stay live, so a genuine width change commits the moment the
     // freeze lifts.
-    constexpr float  kLowSnrNarrowFreezeDb = 16.0f;
+    constexpr float  kNarrowFreezeMarginDb = 3.0f;   // over the presence gate
     constexpr int    kFadeWindowFrames     = 20;     // ~0.7 s at the paced rate
     constexpr int    kFadeEndFrames        = 6;      // median span at each end
     constexpr float  kFadeDropDb           = 2.5f;
-    // Re-engage restore: a deep fade releases AUTO (confidence decays) and the
-    // filter reverts to baseline; when the SAME station comes back the fresh
-    // engage fit is built from the first weak frames and lands narrow. Instead,
-    // a fit remembered at the dropout is restored verbatim if the slice is
-    // still on the same frequency and the gap was shorter than kRefitMemoryNs
-    // (HF QSB cycles run ~5-30 s; 20 s rides a deep fade but expires before
-    // "same frequency" plausibly means a different station). The normal
-    // pipeline then refines from there — widening is fast, narrowing takes the
-    // slow dwell, so a stale-wide restore is safe.
-    constexpr qint64 kRefitMemoryNs = 20LL * 1000000000LL;
+    // Sustained-step flush (kill the QSO width carry-over). In a QSO two
+    // operators alternate on ONE dial frequency; when op A (say 4 kHz) unkeys
+    // and op B (3.5 kHz) keys up, A's medians linger in the 75-frame peak-hold
+    // window and its 80th-pct high-cut stays applied to B for ~2 s. Counting
+    // "gap" frames does NOT work: the per-offset peak-hold envelope (avgEnv,
+    // ~1.1 s release) rides the PTT gap so the measurement stays VALID at A's
+    // width across it. But that same peak-hold means the measurement only reads
+    // sustainedly NARROWER than the applied filter when the signal itself is
+    // genuinely narrower (a different, narrower operator) — a brief word/sibilant
+    // gap keeps the envelope wide. So: when the instantaneous measured width
+    // sits more than kStepMarginHz inside the current target for kStepFlushFrames
+    // consecutive frames, retire the stale peak-hold (flushSmoothing) so B fits
+    // its own width promptly. kStepMarginHz is well above the deadband so only a
+    // real operator-sized step (not QSB jitter or a small legitimate narrowing,
+    // which the normal slow narrow-dwell handles) triggers it.
+    constexpr int    kStepFlushFrames = 20;   // ~0.67 s sustained (> a word gap)
+    constexpr int    kStepMarginHz    = 350;  // operator-sized step, not jitter
     constexpr int    kSnapHz        = 50;     // 50 Hz grid
     constexpr int    kMinBwHz       = 50;     // never narrower than this
     // Glide + send throttle (RFC #3878 cond. 2 — no filt command storm). Emit
@@ -220,27 +236,49 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
 
     SliceState& st = m_state[slice->sliceId()];
 
-    // ── Frame pacing: keep the pipeline at its ~30 fps calibration ──────────
+    // ── Frame pacing: decimate to the ~30 fps calibration (fixed-period phase)
     // Placed before any state update so a rejected frame is invisible — all
-    // frame counters keep their calibrated meaning. Frames without a timestamp
-    // (emittedNs <= 0) are accepted unpaced (no basis to space them).
+    // frame counters keep their calibrated meaning. st.lastFrameNs is the
+    // scheduled phase, advanced by exactly one period per accepted frame so the
+    // average accept rate is source-independent (see kFramePeriodNs). If the
+    // phase has fallen more than a period behind (a stall from a tune or the
+    // TX-suspend gap), re-phase to now so catch-up never bursts. Frames without
+    // a timestamp (emittedNs <= 0, e.g. unit tests) are accepted unpaced.
     if (emittedNs > 0) {
-        if (st.lastFrameNs != 0 && emittedNs - st.lastFrameNs < kMinFrameSpacingNs)
-            return;
-        st.lastFrameNs = emittedNs;
+        if (st.lastFrameNs == 0) {
+            st.lastFrameNs = emittedNs;                 // seed + accept first frame
+        } else if (emittedNs - st.lastFrameNs < kFramePeriodNs) {
+            return;                                     // too soon -> drop
+        } else {
+            st.lastFrameNs += kFramePeriodNs;
+            if (emittedNs - st.lastFrameNs >= kFramePeriodNs)
+                st.lastFrameNs = emittedNs;             // stalled -> re-phase
+        }
     }
 
-    // Clear the per-fit smoothing/measurement state for a fresh fit, WITHOUT
-    // touching the baseline (the operator's manual filter). Shared by the tune
-    // and mode-change resets so both always clear the same fields.
-    const auto clearFit = [](SliceState& s) {
+    // Flush the width MEMORY (smoothing/measurement inputs) without touching the
+    // live passband, baseline, or confidence/AUTO state. Used by the
+    // between-overs flush: hold tgt/cur through the dead air, but drop every
+    // input that would carry the previous operator's width or reference onto the
+    // next one (median/hold windows, candidate + dwell, the narrowing run, the
+    // fade trail, and the per-bin envelope so it re-seeds to the new signal).
+    const auto flushSmoothing = [](SliceState& s) {
         s.rawLow.clear(); s.rawHigh.clear();
         s.medLow.clear(); s.medHigh.clear();
         s.candLow = 0; s.candHigh = 0;
-        s.dwell = 0; s.refractory = 0; s.sinceWrite = 0;
-        s.confScore = 0; s.active = false;
+        s.dwell = 0; s.narrowRun = 0; s.stepRun = 0;
         s.avgEnv.clear();
         s.refTrail.clear();
+    };
+
+    // Clear the per-fit smoothing/measurement state for a fresh fit, WITHOUT
+    // touching the baseline (the operator's manual filter). Shared by the tune
+    // and mode-change resets so both always clear the same fields. This is the
+    // full reset (flushSmoothing plus the confidence/AUTO/dwell-settle state).
+    const auto clearFit = [&flushSmoothing](SliceState& s) {
+        flushSmoothing(s);
+        s.refractory = 0; s.sinceWrite = 0;
+        s.confScore = 0; s.active = false;
     };
 
     // ── Tune detection: re-fit fresh on a frequency jump ────────────────────
@@ -269,7 +307,6 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
         clearFit(st);
         st.haveBaseline = false;     // re-capture baseline from the new mode
         st.framesSinceTune = 0;
-        st.lastGoodLow = INT_MIN;    // signed convention flips — memory invalid
     }
     st.lastMode = mode;
 
@@ -313,9 +350,11 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
     const int maxHigh = slice->adaptiveMaxHighCut();
 
     // Operator-tunable presets: Minimum SNR + Splatter rejection -> measurement
-    // knobs; Response speed -> dwell/settle timing (below).
-    const OccupiedRegionParams params =
+    // knobs; Response speed -> dwell/settle timing (below); Het reject -> opt-in
+    // edge-het cut.
+    OccupiedRegionParams params =
         measureParams(slice->adaptiveMinSnr(), slice->adaptiveSplatter());
+    params.hetReject = slice->adaptiveHetReject();
     const ResponseTuning resp = responseTuning(slice->adaptiveResponse());
 
     // While idle (no confident fit — reverted to the operator's baseline), keep
@@ -335,21 +374,8 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
     // weak/marginal signal cannot flicker the badge between AUTO and the value.
     st.confScore = reg.valid ? std::min(st.confScore + kConfUp, kConfMax)
                              : std::max(st.confScore - kConfDown, 0);
-    if (!st.active && st.confScore >= kConfHigh) {
-        st.active = true;
-    } else if (st.active && st.confScore <= kConfLow) {
-        st.active = false;
-        // Genuine dropout (confidence fully decayed): remember the confident
-        // fit before the invalid branch reverts to baseline, so a return of
-        // the same station within kRefitMemoryNs restores it instead of
-        // re-fitting narrow from the first weak frames.
-        if (emittedNs > 0 && st.tgtLow != INT_MIN &&
-            !(st.tgtLow == st.baseLow && st.tgtHigh == st.baseHigh)) {
-            st.lastGoodLow = st.tgtLow; st.lastGoodHigh = st.tgtHigh;
-            st.lastGoodFreqMhz = freqMhz;
-            st.lastGoodNs = emittedNs;
-        }
-    }
+    if (!st.active && st.confScore >= kConfHigh)      st.active = true;
+    else if (st.active && st.confScore <= kConfLow)   st.active = false;
 
     if (!reg.valid) {
         // A momentary measurement gap (e.g. a speech pause). If we are
@@ -363,8 +389,28 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
             st.medLow.clear(); st.medHigh.clear();
             st.dwell = 0;
         }
+        st.stepRun = 0;   // an invalid frame is not a sustained step
         glideToward(slice, st, st.active, emittedNs);
         return;
+    }
+
+    // ── Sustained-step flush (QSO handoff; see kStepFlushFrames) ────────────
+    // The instantaneous measured width vs the applied target: only a genuinely
+    // narrower operator (not a word gap, which the peak-hold rides wide) reads
+    // narrower for kStepFlushFrames straight. When it does, retire the stale
+    // peak-hold and pre-load the narrowing confirmation (the step is already
+    // proven) so the new operator's width commits promptly instead of waiting
+    // out the 75-frame hold. Guarded to a real operator-sized step so QSB jitter
+    // and small legitimate narrowings fall through to the normal slow path.
+    {
+        const int regWidth = reg.highHz - reg.lowHz;
+        const int tgtWidthNow = (st.tgtHigh == INT_MIN) ? 0 : st.tgtHigh - st.tgtLow;
+        if (tgtWidthNow > 0 && regWidth < tgtWidthNow - kStepMarginHz) ++st.stepRun;
+        else st.stepRun = 0;
+        if (st.stepRun >= kStepFlushFrames) {
+            flushSmoothing(st);
+            st.narrowRun = resp.narrow;   // step already confirmed -> commit next
+        }
     }
 
     // Clamp to operator bounds AND fixed SSB-voice guardrails, enforce MIN_BW,
@@ -400,6 +446,9 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
     holdHigh = std::min(holdHigh, maxHigh);
 
     // ── Inertia: candidate must hold (deadband + dwell) before committing ────
+    // WIDENING / first-fit use candidate-proximity dwell: the peak-hold keeps a
+    // widening candidate stable, so requiring holdLow/holdHigh to sit within the
+    // deadband of the anchored candidate for needDwell frames is a good confirm.
     const bool sameCandidate = std::abs(holdLow - st.candLow) <= kDeadbandHz &&
                                std::abs(holdHigh - st.candHigh) <= kDeadbandHz;
     if (sameCandidate) {
@@ -421,17 +470,25 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
     const int wantWidth = wantHi - wantLo;
     const int curWidth  = (st.tgtHigh == INT_MIN) ? 0 : st.tgtHigh - st.tgtLow;
     const bool narrowing = wantWidth < curWidth - kDeadbandHz;
+    // NARROWING uses a DIRECTION-consistent counter instead of candidate
+    // proximity: as long as the want stays narrower than the applied filter the
+    // confirmation accrues, so QSB jitter that wobbles the exact edge by more
+    // than the deadband (which perpetually re-anchored the candidate and reset
+    // dwell, freezing narrowing forever) no longer blocks it. Any non-narrowing
+    // frame resets the run, so a signal merely oscillating around the current
+    // width never accrues and never ratchets narrow.
+    if (narrowing) ++st.narrowRun; else st.narrowRun = 0;
     // First fit out of idle: the passband is still parked at the operator's
     // baseline (nobody fitted yet — a transmission just started). Commit on the
-    // short engage dwell so the filter starts adapting promptly; later moves use
-    // the normal widen/narrow dwell so they stay calm.
+    // short engage dwell so the filter starts adapting promptly.
     const bool atBaseline = (st.tgtLow == st.baseLow && st.tgtHigh == st.baseHigh);
-    const int needDwell = atBaseline    ? resp.engage
-                        : narrowing     ? resp.narrow
-                                        : resp.widen;
-    // Narrowing-freeze inputs (see kLowSnrNarrowFreezeDb block): a weak peak
-    // or a falling in-band reference makes a narrower reading untrustworthy.
-    const bool lowSnr = (reg.peakDbm - reg.floorDbm) < kLowSnrNarrowFreezeDb;
+
+    // Narrowing-freeze inputs (see kNarrowFreezeMarginDb block): a weak peak or
+    // a falling in-band reference makes a narrower reading untrustworthy. The
+    // freeze threshold tracks the active presence preset so it sits just above
+    // engagement (never a dead band that blocks a medium signal from narrowing).
+    const float narrowFreezeDb = params.minPeakDb + kNarrowFreezeMarginDb;
+    const bool lowSnr = (reg.peakDbm - reg.floorDbm) < narrowFreezeDb;
     st.refTrail.append(reg.referenceDbm);
     if (st.refTrail.size() > kFadeWindowFrames) st.refTrail.removeFirst();
     bool fading = false;
@@ -440,32 +497,25 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
         const float late  = medianOfF(st.refTrail.mid(st.refTrail.size() - kFadeEndFrames));
         fading = (early - late) > kFadeDropDb;
     }
-    // Re-engage restore is possible only on the engage commit (passband still
-    // at baseline), same frequency, within the memory window.
-    const bool restorable = atBaseline && st.lastGoodLow != INT_MIN &&
-                            emittedNs > 0 &&
-                            emittedNs - st.lastGoodNs <= kRefitMemoryNs &&
-                            std::abs(freqMhz - st.lastGoodFreqMhz) <= 0.0003;
 
     // Settle after each change before allowing the next, so the filter feels
     // calm rather than continuously nudging.
     if (st.refractory > 0) --st.refractory;
-    if (differs && st.dwell >= needDwell && st.refractory == 0) {
-        if (restorable) {
-            // Same station back after a dropout: restore the pre-fade fit
-            // verbatim (the fresh candidate is built from the first weak
-            // frames and lands narrow); the pipeline refines from there.
-            st.tgtLow = st.lastGoodLow; st.tgtHigh = st.lastGoodHigh;
-            st.lastGoodLow = INT_MIN;   // consumed
-            st.dwell = 0;
-            st.refractory = resp.refractory;
-        } else if (narrowing && (lowSnr || fading)) {
-            // Widen-only: hold the target; dwell keeps accumulating so the
+    const auto commit = [&] {
+        st.tgtLow = wantLo; st.tgtHigh = wantHi;
+        st.dwell = 0; st.narrowRun = 0;
+        st.refractory = resp.refractory;
+    };
+    if (differs && st.refractory == 0) {
+        if (narrowing && (lowSnr || fading)) {
+            // Widen-only: hold the target; narrowRun keeps accruing so the
             // narrowing commits the moment the freeze lifts.
+        } else if (atBaseline) {
+            if (st.dwell >= resp.engage) commit();          // prompt first fit
+        } else if (narrowing) {
+            if (st.narrowRun >= resp.narrow) commit();       // slow, jitter-robust
         } else {
-            st.tgtLow = wantLo; st.tgtHigh = wantHi;
-            st.dwell = 0;
-            st.refractory = resp.refractory;
+            if (st.dwell >= resp.widen) commit();            // widen a live fit
         }
     }
 

--- a/src/core/AdaptiveFilterEngine.cpp
+++ b/src/core/AdaptiveFilterEngine.cpp
@@ -405,8 +405,24 @@ void AdaptiveFilterEngine::processFrame(SliceModel* slice, double centerMhz,
     {
         const int regWidth = reg.highHz - reg.lowHz;
         const int tgtWidthNow = (st.tgtHigh == INT_MIN) ? 0 : st.tgtHigh - st.tgtLow;
-        if (tgtWidthNow > 0 && regWidth < tgtWidthNow - kStepMarginHz) ++st.stepRun;
-        else st.stepRun = 0;
+        // Over-to-over handoff only: an ACTIVE, non-baseline fit that isn't
+        // commit-frozen. Otherwise stepRun recounts with tgt never moving (the
+        // low-SNR widen-only branch holds it) and the flush re-fires every
+        // kStepFlushFrames — churning avgEnv/refTrail and flickering AUTO — and
+        // it must not intrude on the first-fit engage from baseline. Once a
+        // non-frozen narrowing commits, tgt moves and stepRun stops re-accruing,
+        // so no separate latch is needed. (atBaseline/lowSnr are computed below;
+        // inline them here since the flush precedes them.)
+        const bool atBaselineNow =
+            (st.tgtLow == st.baseLow && st.tgtHigh == st.baseHigh);
+        const bool commitFrozen =
+            (reg.peakDbm - reg.floorDbm) < (params.minPeakDb + kNarrowFreezeMarginDb);
+        if (st.active && !atBaselineNow && !commitFrozen
+                && tgtWidthNow > 0 && regWidth < tgtWidthNow - kStepMarginHz) {
+            ++st.stepRun;
+        } else {
+            st.stepRun = 0;
+        }
         if (st.stepRun >= kStepFlushFrames) {
             flushSmoothing(st);
             st.narrowRun = resp.narrow;   // step already confirmed -> commit next

--- a/src/core/AdaptiveFilterEngine.h
+++ b/src/core/AdaptiveFilterEngine.h
@@ -61,13 +61,15 @@ private:
         quint64 lastUserEpoch{0};       // detect a manual filter edit -> disable
         int  framesSinceTune{1000};     // post-tune settle gate (starts "settled")
         QVector<float> avgEnv;          // temporal average (video averaging)
-        qint64 lastFrameNs{0};          // last ACCEPTED frame (pacing gate)
+        qint64 lastFrameNs{0};          // pacing accumulator: scheduled phase of
+                                        // the last ACCEPTED frame (not its arrival)
         qint64 lastSendNs{0};           // last filt send (wall-clock rate guard)
         QVector<float> refTrail;        // recent referenceDbm (fade detector)
-        int    lastGoodLow{INT_MIN};    // fit remembered at dropout (signed)
-        int    lastGoodHigh{INT_MIN};
-        double lastGoodFreqMhz{0.0};    // ...valid only for this frequency
-        qint64 lastGoodNs{0};           // ...and only for kRefitMemoryNs
+        int    stepRun{0};              // consecutive frames the measured width sits
+                                        // a full step inside the target (QSO handoff
+                                        // detector -> flush stale peak-hold)
+        int    narrowRun{0};            // consecutive direction-consistent narrowing
+                                        // frames (commit narrowing through QSB jitter)
     };
 
     // Commit a glide target and step the live passband toward it.

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1085,6 +1085,7 @@ QJsonObject sliceSnapshot(const SliceModel* s)
         {QStringLiteral("adaptiveMinSnr"),        s->adaptiveMinSnr()},
         {QStringLiteral("adaptiveResponse"),      s->adaptiveResponse()},
         {QStringLiteral("adaptiveSplatter"),      s->adaptiveSplatter()},
+        {QStringLiteral("adaptiveHetReject"),     s->adaptiveHetReject()},
         {QStringLiteral("adaptiveActive"),        s->adaptiveActive()},
     };
 }

--- a/src/core/OccupiedRegion.cpp
+++ b/src/core/OccupiedRegion.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cmath>
 
 namespace AetherSDR {
@@ -79,6 +80,31 @@ namespace {
     constexpr double kReanchorMaxStartHz = 2000.0;  // re-anchor only into lobes
                                              // starting by here (voice humps
                                              // rise by ~1.2-2 kHz)
+    // Cut-vs-reanchor hysteresis (F3): the cut ("separate stronger station")
+    // pivot was a single razor edge (runConfident at exactly floor+minPeakDb,
+    // plateau at exactly ref+kReboundDb), so a ~0.2 dB wiggle in a WEAK bass
+    // lobe flipped the high-cut by the whole treble-hump width (bistable ESSB
+    // amputation). Require BOTH the pre-gap run to clear the gate by a margin
+    // AND the resuming lobe to exceed the rebound by a margin before cutting;
+    // otherwise re-anchor (keeping a real signal is the safer error). Each
+    // margin is a dead-band a 0.2 dB perturbation cannot cross.
+    constexpr float  kRunConfidentHystDb = 2.0f;   // over the presence gate to CUT
+    constexpr float  kSeparateMarginDb   = 2.0f;   // over kReboundDb to CUT
+    // Weak-run re-anchor guard (F4): an UNCONFIDENT run bypasses the silence
+    // stop and scans to kScanHz, so without these a weak near-carrier blip plus
+    // an adjacent station 1.5-2 kHz up would re-anchor onto the neighbour. A
+    // re-anchor now additionally requires the INNER (pre-gap) lobe to be a real
+    // sustained lobe (>= kInnerReanchorMinWidthHz occupied AND >= floor +
+    // kEnvGateDb + kInnerReanchorMinDb), and the bridged at-floor gap to be
+    // bounded (kUnconfBridgeMaxHz — also an unconfident silence-stop so the
+    // scan no longer runs to kScanHz across dead air).
+    // Occupied width (above the gate) understates a weak lobe by ~2x the 300 Hz
+    // envelope smear, so a genuine ~600-700 Hz raw bass reads ~290-390 Hz here
+    // while a narrow carrier/het blip erodes to near zero — 250 Hz separates
+    // them with margin.
+    constexpr double kInnerReanchorMinWidthHz = 250.0;
+    constexpr float  kInnerReanchorMinDb      = 1.0f;   // over the occupied gate
+    constexpr double kUnconfBridgeMaxHz       = 1300.0;
     constexpr int    kReferencePct = 75;     // in-band reference = this percentile
                                              // of the kept extent (tracks a
                                              // treble hump; robust to a transient)
@@ -99,6 +125,23 @@ namespace {
     // near the floor — it cannot walk the edge far past the signal).
     constexpr float  kEnvAttackAlpha  = 0.30f;  // fast rise  (~0.1 s time constant)
     constexpr float  kEnvReleaseAlpha = 0.03f;  // slow fall  (~1.1 s time constant)
+
+    // ── Edge-het rejection (opt-in, OccupiedRegionParams::hetReject) ─────────
+    // A narrow strong interferer (het/carrier) near a passband edge shows up as
+    // a RAW bin far above the local SMOOTHED envelope (a broad voice hump lifts
+    // its own envelope, so raw-minus-env stays small; only a narrow spike has a
+    // large raw-minus-env). When enabled, a het found within kHetSearchHz of a
+    // cut pulls that cut kHetGuardHz inboard of the het (a filter skirt is not a
+    // brick wall, so cut BELOW it), never past the signal peak. Cross-frame
+    // stability (a het drifting/QSB-ing in and out) is provided by the engine's
+    // temporal pipeline (median + peak-hold + slow narrowing), so the detector
+    // here stays single-frame and stateless. A mid-band het (not near an edge)
+    // is left to the notch/ANF — a bandpass edge can't remove it without gutting
+    // voice. kHetExcessDb is high enough that a formant peak or a steep voice
+    // skirt is never mistaken for a het.
+    constexpr double kHetSearchHz = 300.0;   // scan this far in/out of each cut
+    constexpr float  kHetExcessDb = 15.0f;   // raw over local envelope = a het
+    constexpr double kHetGuardHz  = 150.0;   // place the cut this far below it
 
     // ── Per-frequency noise floor (spec Stage B) ────────────────────────────
     // A single scalar floor mis-thresholds a TILTED floor: with a global 10th-pct
@@ -421,11 +464,27 @@ OccupiedRegion measureOccupiedRegion(const QVector<float>& binsDbm,
                     refSoFar = w[idx];
                 }
                 if (plateau > std::max(preGapLevel, refSoFar) + kReboundDb) {
-                    const bool runConfident =
-                        runMaxEnv >= scalarFloor + params.minPeakDb;
-                    if (runConfident) break;   // separate stronger lobe -> cut
+                    // CUT as a separate station only when BOTH conditions clear
+                    // their dead-bands (F3) — a razor pivot flipped the high-cut
+                    // by the whole treble width on a ~0.2 dB bass wiggle.
+                    const bool runEstablished =
+                        runMaxEnv >= scalarFloor + params.minPeakDb + kRunConfidentHystDb;
+                    const bool clearlySeparate =
+                        plateau > std::max(preGapLevel, refSoFar) + kReboundDb + kSeparateMarginDb;
+                    if (runEstablished && clearlySeparate) break;   // separate stn -> cut
                     if (o * hzPerBin > kReanchorMaxStartHz) break;  // adjacent stn
-                    // else: re-anchor into the tuned signal's dominant hump
+                    // Re-anchor into the tuned signal's dominant hump — but for a
+                    // WEAK (unestablished) run guard against grabbing a neighbour
+                    // (F4): the inner pre-gap lobe must be a real sustained lobe,
+                    // not a near-carrier blip.
+                    if (!runEstablished) {
+                        const double innerWidthHz = (keptEndO - firstO) * hzPerBin;
+                        const bool innerReal =
+                            innerWidthHz >= kInnerReanchorMinWidthHz &&
+                            runMaxEnv >= scalarFloor + kEnvGateDb + kInnerReanchorMinDb;
+                        if (!innerReal) break;   // weak blip + neighbour -> don't grab
+                    }
+                    // else: re-anchor
                 }
             }
             keptEndO = o;
@@ -444,8 +503,12 @@ OccupiedRegion measureOccupiedRegion(const QVector<float>& binsDbm,
             // AUTO badge confidently showing a bass-only fit).
             if (v < floorGateAt(o)) {
                 silenceHz += hzPerBin;
-                if (silenceHz > kSilenceHz &&
-                    runMaxEnv >= scalarFloor + params.minPeakDb) break;
+                // Confident run: kSilenceHz of contiguous at-floor spectrum is a
+                // true band edge. Unconfident run: keep looking past a mid scoop
+                // for the dominant hump, but bound the bridge (kUnconfBridgeMaxHz,
+                // F4) so the scan can't run across dead air to a neighbour.
+                const bool confident = runMaxEnv >= scalarFloor + params.minPeakDb;
+                if (silenceHz > (confident ? kSilenceHz : kUnconfBridgeMaxHz)) break;
             } else {
                 silenceHz = 0.0;
             }
@@ -557,10 +620,48 @@ OccupiedRegion measureOccupiedRegion(const QVector<float>& binsDbm,
     }
     if (farO < nearO) farO = nearO;
 
+    // ── Edge-het rejection (opt-in) ─────────────────────────────────────────
+    // Find a narrow strong interferer (het/carrier) within kHetSearchHz of a
+    // finalised edge and record the audio frequency to cut at — applied AFTER
+    // the intelligibility margin below, so the margin cannot re-cross the het.
+    // Never cuts past the signal peak (a het inboard of the peak is left to the
+    // notch — a bandpass edge can't remove it without gutting voice).
+    int hetHighCutHz = INT_MAX;   // clamp audioHigh at/below this
+    int hetLowCutHz  = 0;         // clamp audioLow  at/above this
+    if (params.hetReject) {
+        const int searchBins = std::max(1, static_cast<int>(kHetSearchHz / hzPerBin));
+        const int hetGuard   = static_cast<int>(kHetGuardHz);
+        const auto isHet = [&](int o) -> bool {
+            return o >= 0 && o <= scanBins &&
+                   binsDbm[std::clamp(binAt(o), 0, N - 1)] - envAt(o) >= kHetExcessDb;
+        };
+        // High edge: the innermost het within reach of farO and above the peak.
+        for (int o = std::max(peakO + 1, farO - searchBins);
+             o <= std::min(scanBins, farO + searchBins); ++o) {
+            if (isHet(o)) {
+                hetHighCutHz = std::max(static_cast<int>(peakO * hzPerBin),
+                                        static_cast<int>(o * hzPerBin) - hetGuard);
+                break;
+            }
+        }
+        // Low edge: a het just above the low cut (below the peak) raises it.
+        for (int o = std::min(peakO - 1, nearO + searchBins);
+             o >= std::max(0, nearO - searchBins); --o) {
+            if (isHet(o)) {
+                hetLowCutHz = std::min(static_cast<int>(peakO * hzPerBin),
+                                       static_cast<int>(o * hzPerBin) + hetGuard);
+                break;
+            }
+        }
+    }
+
     // Offset indices -> audio cut magnitudes (Hz), plus intelligibility margin.
     int audioLow  = static_cast<int>(std::floor(nearO * hzPerBin)) - kMarginHz;
     int audioHigh = static_cast<int>(std::ceil (farO  * hzPerBin)) + kMarginHz;
     audioLow = std::max(0, audioLow);
+    // Edge-het cut wins over the margin (opt-in; sentinels no-op when disabled).
+    audioHigh = std::min(audioHigh, hetHighCutHz);
+    audioLow  = std::max(audioLow,  hetLowCutHz);
     if (audioHigh - audioLow < kMinBwHz) return r;
     // SSB-voice shape gate: the energy must start near the carrier. A band that
     // starts well above it (e.g. a 1600-4000 data/het signal) isn't the SSB

--- a/src/core/OccupiedRegion.h
+++ b/src/core/OccupiedRegion.h
@@ -37,6 +37,8 @@ struct OccupiedRegionParams {
                                        // noise floor by at least this (Min SNR)
     float  splatterDownDb  = 25.0f;    // outer-cap level below the in-band reference
     double splatterGuardHz = 3200.0;   // splatter cap engages only past this extent
+    bool   hetReject       = false;    // opt-in: pull a cut inboard of a narrow
+                                       // strong interferer sitting near the edge
 };
 
 // measureOccupiedRegion — a single-signal occupied-bandwidth edge-finder

--- a/src/gui/AdaptiveFilterControls.cpp
+++ b/src/gui/AdaptiveFilterControls.cpp
@@ -150,6 +150,9 @@ AdaptiveFilterControls::AdaptiveFilterControls(int sections, bool withHeader,
         for (const QString& o : {tr("Fast"), tr("Normal"), tr("Slow")}) m_response->addItem(o);
         std::tie(m_splatterRow, m_splatter) = makeRow(rightTarget, tr("Splat"), tr("Adaptive splatter rejection"));
         for (const QString& o : {tr("Tight"), tr("Normal"), tr("Wide")}) m_splatter->addItem(o);
+        std::tie(m_hetRow, m_hetReject) = makeRow(rightTarget, tr("Het"),
+            tr("Edge-het reject: narrow the passband to exclude a strong het near an edge (leaves a mid-band het to the notch)"));
+        for (const QString& o : {tr("Off"), tr("On")}) m_hetReject->addItem(o);
     }
 
     // Top-pack each column (the shorter one absorbs the slack at the bottom) so
@@ -180,6 +183,9 @@ AdaptiveFilterControls::AdaptiveFilterControls(int sections, bool withHeader,
     if (m_splatter) connect(m_splatter, &QComboBox::currentIndexChanged, this, [this](int i) {
         if (m_slice) { m_slice->setAdaptiveSplatter(i); savePrefs(m_slice); }
     });
+    if (m_hetReject) connect(m_hetReject, &QComboBox::currentIndexChanged, this, [this](int i) {
+        if (m_slice) { m_slice->setAdaptiveHetReject(i != 0); savePrefs(m_slice); }
+    });
 
     updateVisibility();
 }
@@ -198,6 +204,7 @@ void AdaptiveFilterControls::setSlice(SliceModel* slice)
     if (m_minSnr)   { QSignalBlocker b(m_minSnr);   m_minSnr->setCurrentIndex(std::clamp(slice->adaptiveMinSnr(), 0, 2)); }
     if (m_response) { QSignalBlocker b(m_response); m_response->setCurrentIndex(std::clamp(slice->adaptiveResponse(), 0, 2)); }
     if (m_splatter) { QSignalBlocker b(m_splatter); m_splatter->setCurrentIndex(std::clamp(slice->adaptiveSplatter(), 0, 2)); }
+    if (m_hetReject) { QSignalBlocker b(m_hetReject); m_hetReject->setCurrentIndex(slice->adaptiveHetReject() ? 1 : 0); }
 
     // Live sync: slice value changes (from any host, or the engine) -> controls.
     // Every instance tracks enabled (for visibility); the rest only if built.
@@ -226,6 +233,9 @@ void AdaptiveFilterControls::setSlice(SliceModel* slice)
     if (m_splatter) connect(slice, &SliceModel::adaptiveSplatterChanged, this, [this](int i) {
         QSignalBlocker b(m_splatter); m_splatter->setCurrentIndex(std::clamp(i, 0, 2));
     });
+    if (m_hetReject) connect(slice, &SliceModel::adaptiveHetRejectChanged, this, [this](bool on) {
+        QSignalBlocker b(m_hetReject); m_hetReject->setCurrentIndex(on ? 1 : 0);
+    });
 
     updateVisibility();
 }
@@ -236,7 +246,7 @@ void AdaptiveFilterControls::updateVisibility()
     // slice (source of truth) so it stays correct even when enabled is toggled
     // programmatically (e.g. the engine disabling adaptive on a manual edit).
     const bool on = m_slice && m_slice->adaptiveFilterEnabled();
-    for (QWidget* r : {m_loRow, m_hiRow, m_snrRow, m_responseRow, m_splatterRow})
+    for (QWidget* r : {m_loRow, m_hiRow, m_snrRow, m_responseRow, m_splatterRow, m_hetRow})
         if (r) r->setVisible(on);
 
     // Invalidate our own cached sizeHint so the host reads the new (shorter)
@@ -258,6 +268,7 @@ void AdaptiveFilterControls::loadPrefs(SliceModel* slice)
     slice->setAdaptiveMinSnr(o.value("minSnr").toInt(1));      // default Normal
     slice->setAdaptiveResponse(o.value("response").toInt(1));  // default Normal
     slice->setAdaptiveSplatter(o.value("splatter").toInt(1));  // default Normal
+    slice->setAdaptiveHetReject(o.value("hetReject").toBool(false));  // opt-in, off
     // Session-scoped by design: the adaptive filter always starts DISABLED and
     // the operator enables it explicitly each session. Only the config above
     // persists; the saved "enabled" value is deliberately not restored.
@@ -289,6 +300,7 @@ void AdaptiveFilterControls::savePrefs(SliceModel* slice)
     o["minSnr"]     = slice->adaptiveMinSnr();
     o["response"]   = slice->adaptiveResponse();
     o["splatter"]   = slice->adaptiveSplatter();
+    o["hetReject"]  = slice->adaptiveHetReject();
     root[QString::number(slice->sliceId())] = o;
     const QString after =
         QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));

--- a/src/gui/AdaptiveFilterControls.h
+++ b/src/gui/AdaptiveFilterControls.h
@@ -66,11 +66,13 @@ private:
     QComboBox* m_minSnr{nullptr};
     QComboBox* m_response{nullptr};
     QComboBox* m_splatter{nullptr};
+    QComboBox* m_hetReject{nullptr};
     QWidget*   m_loRow{nullptr};
     QWidget*   m_hiRow{nullptr};
     QWidget*   m_snrRow{nullptr};
     QWidget*   m_responseRow{nullptr};
     QWidget*   m_splatterRow{nullptr};
+    QWidget*   m_hetRow{nullptr};
 };
 
 } // namespace AetherSDR

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -146,6 +146,13 @@ void SliceModel::setAdaptiveSplatter(int level)
     emit adaptiveSplatterChanged(level);
 }
 
+void SliceModel::setAdaptiveHetReject(bool on)
+{
+    if (m_adaptiveHetReject == on) return;
+    m_adaptiveHetReject = on;
+    emit adaptiveHetRejectChanged(on);
+}
+
 void SliceModel::setAdaptiveActive(bool on)
 {
     if (m_adaptiveActive == on) return;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -51,6 +51,7 @@ public:
     int     adaptiveMinSnr()        const { return m_adaptiveMinSnr; }   // 0=Sensitive,1=Normal,2=Strong
     int     adaptiveResponse()      const { return m_adaptiveResponse; } // 0=Fast,1=Normal,2=Slow
     int     adaptiveSplatter()      const { return m_adaptiveSplatter; } // 0=Tight,1=Normal,2=Wide
+    bool    adaptiveHetReject()     const { return m_adaptiveHetReject; } // opt-in edge-het cut
     bool    adaptiveActive()        const { return m_adaptiveActive; }
     bool    isActive()   const { return m_active; }
     bool    isTxSlice()  const { return m_txSlice; }
@@ -161,6 +162,7 @@ public:
     void setAdaptiveMinSnr(int level);     // 0=Sensitive,1=Normal,2=Strong
     void setAdaptiveResponse(int level);   // 0=Fast,1=Normal,2=Slow
     void setAdaptiveSplatter(int level);   // 0=Tight,1=Normal,2=Wide
+    void setAdaptiveHetReject(bool on);    // opt-in edge-het cut
     void setAdaptiveActive(bool on);
     // Engine-driven passband write: same wire command as setFilterWidth, but
     // a distinct entry point so the engine can recognise its own writes (vs
@@ -270,6 +272,7 @@ signals:
     void adaptiveMinSnrChanged(int level);
     void adaptiveResponseChanged(int level);
     void adaptiveSplatterChanged(int level);
+    void adaptiveHetRejectChanged(bool on);
     void adaptiveActiveChanged(bool on);
     void activeChanged(bool active);
     void txSliceChanged(bool tx);
@@ -358,6 +361,7 @@ private:
     int     m_adaptiveMinSnr{1};         // 0=Sensitive,1=Normal,2=Strong
     int     m_adaptiveResponse{1};       // 0=Fast,1=Normal,2=Slow
     int     m_adaptiveSplatter{1};       // 0=Tight,1=Normal,2=Wide
+    bool    m_adaptiveHetReject{false};  // opt-in edge-het cut
     bool    m_adaptiveActive{false};     // a confident live fit is applied
     bool    m_active{false};
     bool    m_txSlice{false};

--- a/tests/adaptive_engine_test.cpp
+++ b/tests/adaptive_engine_test.cpp
@@ -122,8 +122,10 @@ int main(int argc, char** argv)
         char det[128];
         std::snprintf(det, sizeof det, "  sends=%d (%.1f/s) minGap=%.0fms",
                       sends, perSec, d.writes.size() > 1 ? minGap / 1e6 : 0.0);
+        // Require >= 2 sends so the rate lock can't pass vacuously (a future
+        // change that stops the glide sending entirely must fail, not go green).
         report("no filt storm at 60 fps: <=8/s and >=125ms spacing",
-               perSec <= 8.0 && (d.writes.size() < 2 || minGap >= 124'000'000), det);
+               perSec <= 8.0 && d.writes.size() >= 2 && minGap >= 124'000'000, det);
     }
 
     // ── 2. Engage tracks a single signal ────────────────────────────────────

--- a/tests/adaptive_engine_test.cpp
+++ b/tests/adaptive_engine_test.cpp
@@ -1,0 +1,195 @@
+// Engine-level test for the adaptive-RX-filter temporal pipeline
+// (AdaptiveFilterEngine::processFrame). Unlike adaptive_filter_test (which
+// drives the stateless measurement measureOccupiedRegion directly), this drives
+// the QObject engine through a real SliceModel in a headless QCoreApplication,
+// feeding synthetic panadapter frames WITH monotonic timestamps — the path that
+// the production caller (PanadapterStream -> onSpectrumReadyForAdaptiveFilter)
+// exercises and that no measurement test can cover. CMake target
+// `adaptive_engine_test`. Exit 0 = pass.
+//
+// SliceModel setters only emit signals (no radio/socket), so a real instance is
+// a faithful, cheap test double; the engine's applyAdaptiveFilter writes surface
+// as SliceModel::filterChanged, which we record.
+
+#include "core/AdaptiveFilterEngine.h"
+#include "models/SliceModel.h"
+
+#include <QCoreApplication>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <functional>
+#include <vector>
+
+using AetherSDR::AdaptiveFilterEngine;
+using AetherSDR::SliceModel;
+
+namespace {
+
+int g_failed = 0;
+void report(const char* name, bool ok, const char* detail = nullptr)
+{
+    std::printf("%s %-58s%s\n", ok ? "[ OK ]" : "[FAIL]", name, detail ? detail : "");
+    if (!ok) ++g_failed;
+}
+
+// ── Synthetic panadapter geometry (matches adaptive_filter_test) ────────────
+constexpr int    kN      = 2048;
+constexpr double kBwMhz  = 0.2;       // 200 kHz pan
+constexpr double kCenter = 14.200;    // MHz (carrier at centre)
+constexpr int    kCarrierBin = kN / 2;
+const double     kHzPerBin = kBwMhz * 1.0e6 / kN;   // ~97.66 Hz/bin
+constexpr qint64 kFps60Ns = 16'666'667;             // 60 fps input step
+
+// A USB voice hump [lowHz, highHz] at `level` dBm over a flat floor.
+QVector<float> humpSpectrum(float floorDbm, double lowHz, double highHz, float level)
+{
+    QVector<float> bins(kN, floorDbm);
+    for (int o = 0; o * kHzPerBin <= 6500.0; ++o) {
+        const double f = o * kHzPerBin;
+        if (f >= lowHz && f <= highHz) {
+            const int bin = kCarrierBin + o;
+            if (bin >= 0 && bin < kN) bins[bin] = level;
+        }
+    }
+    return bins;
+}
+
+QVector<float> noiseSpectrum(float floorDbm) { return QVector<float>(kN, floorDbm); }
+
+// A driver: an engine + slice + recorder of the applied (low,high) with the
+// timestamp of the frame that produced each write.
+struct Driver {
+    AdaptiveFilterEngine engine;
+    SliceModel slice{1};
+    struct Write { qint64 ns; int low; int high; };
+    std::vector<Write> writes;
+    qint64 curNs{0};
+
+    Driver(int baseLow, int baseHigh)
+    {
+        slice.setMode(QStringLiteral("USB"));
+        slice.setFrequency(kCenter);
+        slice.setAdaptiveMinLowCut(0);
+        slice.setAdaptiveMaxHighCut(6000);
+        slice.setAdaptiveMinSnr(1);      // Normal
+        slice.setAdaptiveResponse(1);    // Normal
+        slice.setAdaptiveSplatter(1);    // Normal
+        slice.setFilterWidth(baseLow, baseHigh);   // seed baseline (bumps epoch)
+        slice.setAdaptiveFilterEnabled(true);
+        QObject::connect(&slice, &SliceModel::filterChanged, &slice,
+                         [this](int lo, int hi) { writes.push_back({curNs, lo, hi}); });
+    }
+
+    void feed(const QVector<float>& bins, float floor, qint64 ns)
+    {
+        curNs = ns;
+        engine.processFrame(&slice, kCenter, kBwMhz, bins, floor, ns);
+    }
+    // Drive n frames of the same spectrum at 60 fps starting at startNs.
+    qint64 run(const QVector<float>& bins, float floor, int n, qint64 startNs)
+    {
+        qint64 ns = startNs;
+        for (int i = 0; i < n; ++i) { feed(bins, floor, ns); ns += kFps60Ns; }
+        return ns;
+    }
+    int lastHigh() const { return writes.empty() ? -1 : writes.back().high; }
+    int lastLow()  const { return writes.empty() ? -1 : writes.back().low; }
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ── 1. No filt-command storm at 60 fps (the dead-clock regression lock) ──
+    // With the wall-clock layer inert (emittedNs==0), a 60 fps pan sent ~15
+    // filt/s; paced + wall-clock-guarded it must stay <= ~8/s with >= 125 ms
+    // spacing (RFC #3878 cond. 2). Drive 2 s of 60 fps frames of a wide strong
+    // signal that forces the passband to glide well away from the baseline.
+    {
+        Driver d(0, 2700);
+        const auto sig = humpSpectrum(-110.0f, 300.0, 4000.0, -70.0f);
+        d.run(sig, -110.0f, 120, 0);   // 2 s @ 60 fps
+        // Count sends and the minimum spacing between consecutive sends.
+        qint64 minGap = 1'000'000'000; int sends = int(d.writes.size());
+        for (size_t i = 1; i < d.writes.size(); ++i)
+            minGap = std::min(minGap, d.writes[i].ns - d.writes[i - 1].ns);
+        const double perSec = sends / 2.0;
+        char det[128];
+        std::snprintf(det, sizeof det, "  sends=%d (%.1f/s) minGap=%.0fms",
+                      sends, perSec, d.writes.size() > 1 ? minGap / 1e6 : 0.0);
+        report("no filt storm at 60 fps: <=8/s and >=125ms spacing",
+               perSec <= 8.0 && (d.writes.size() < 2 || minGap >= 124'000'000), det);
+    }
+
+    // ── 2. Engage tracks a single signal ────────────────────────────────────
+    // A strong 300-3000 Hz signal from a 2700 baseline: the high-cut should
+    // settle near 3000 (within margin + snap) after ~2 s.
+    {
+        Driver d(0, 2700);
+        const auto sig = humpSpectrum(-110.0f, 300.0, 3000.0, -70.0f);
+        d.run(sig, -110.0f, 120, 0);
+        char det[96];
+        std::snprintf(det, sizeof det, "  high=%d low=%d", d.lastHigh(), d.lastLow());
+        report("engage: high-cut tracks a 3.0 kHz signal",
+               d.lastHigh() >= 2800 && d.lastHigh() <= 3400, det);
+    }
+
+    // ── 3. Word-gap HOLD: a short gap must NOT collapse the fit ──────────────
+    // Lock onto 300-4000, then 0.5 s of noise (below the between-overs flush
+    // threshold), then signal again — the high-cut must stay wide (~4000).
+    {
+        Driver d(0, 2700);
+        const auto sig = humpSpectrum(-110.0f, 300.0, 4000.0, -70.0f);
+        qint64 ns = d.run(sig, -110.0f, 150, 0);          // establish (2.5 s)
+        const int wide = d.lastHigh();
+        ns = d.run(noiseSpectrum(-110.0f), -110.0f, 30, ns);  // 0.5 s gap
+        d.run(sig, -110.0f, 30, ns);
+        char det[96];
+        std::snprintf(det, sizeof det, "  wide=%d afterGap=%d", wide, d.lastHigh());
+        report("word-gap HOLD: fit not collapsed by a 0.5 s gap",
+               wide >= 3800 && d.lastHigh() >= 3600, det);
+    }
+
+    // ── 4. QSO handoff: A (4 kHz) -> 1.2 s gap -> B (3.5 kHz) tracks B ───────
+    // The reported bug: operator A's width stayed applied to operator B. After
+    // the between-overs flush the returning operator must re-fit to its own
+    // width within ~2 s, not inherit A's.
+    {
+        Driver d(0, 2700);
+        const auto a = humpSpectrum(-110.0f, 300.0, 4000.0, -70.0f);
+        const auto b = humpSpectrum(-110.0f, 300.0, 3500.0, -70.0f);
+        qint64 ns = d.run(a, -110.0f, 180, 0);            // A establishes (3 s)
+        const int aHigh = d.lastHigh();
+        ns = d.run(noiseSpectrum(-110.0f), -110.0f, 72, ns);  // 1.2 s PTT gap
+        d.run(b, -110.0f, 150, ns);                       // B for 2.5 s
+        char det[112];
+        std::snprintf(det, sizeof det, "  A.high=%d B.high=%d", aHigh, d.lastHigh());
+        report("QSO handoff: B (3.5k) not stuck on A's (4k) width",
+               aHigh >= 3800 && d.lastHigh() <= 3700, det);
+    }
+
+    // ── 5. Manual filter edit auto-disables AUTO (RFC #3878 cond. 3) ─────────
+    // A genuine setFilterWidth on a settled station hands control back.
+    {
+        Driver d(0, 2700);
+        const auto sig = humpSpectrum(-110.0f, 300.0, 3000.0, -70.0f);
+        d.run(sig, -110.0f, 120, 0);
+        const bool onBefore = d.slice.adaptiveFilterEnabled();
+        d.slice.setFilterWidth(0, 2400);    // operator drags the filter
+        d.run(sig, -110.0f, 30, 120 * kFps60Ns);
+        char det[96];
+        std::snprintf(det, sizeof det, "  before=%d after=%d",
+                      onBefore ? 1 : 0, d.slice.adaptiveFilterEnabled() ? 1 : 0);
+        report("manual edit auto-disables adaptive",
+               onBefore && !d.slice.adaptiveFilterEnabled(), det);
+    }
+
+    std::printf("\n%s (%d failure%s)\n",
+                g_failed ? "FAILED" : "PASSED", g_failed, g_failed == 1 ? "" : "s");
+    return g_failed ? 1 : 0;
+}

--- a/tests/adaptive_filter_test.cpp
+++ b/tests/adaptive_filter_test.cpp
@@ -95,6 +95,15 @@ OccupiedRegion measure(const QVector<float>& bins, bool usb, float noiseFloorDbm
     return measureAt(kN, kBwMhz, bins, usb, noiseFloorDbm);
 }
 
+OccupiedRegion measureP(const QVector<float>& bins, bool usb, float noiseFloorDbm,
+                        const AetherSDR::OccupiedRegionParams& params)
+{
+    QVector<float> avgEnv;
+    return measureOccupiedRegion(bins, kCenter, kBwMhz, kCarrier,
+                                 usb ? QStringLiteral("USB") : QStringLiteral("LSB"),
+                                 noiseFloorDbm, avgEnv, params);
+}
+
 // A flat-topped voice "hump" between [lowHz, highHz] at `level`, else floor.
 std::function<float(double)> hump(double lowHz, double highHz, float level)
 {
@@ -461,6 +470,44 @@ int main()
             std::snprintf(d, sizeof d, "  [%s] valid=%d", tag(usb), r.valid ? 1 : 0);
             report("two-hump: distant lobe not re-anchored (reject)", !r.valid, d);
         }
+        // (h) F4 — a NARROW near-carrier carrier/het (not a real bass lobe) plus
+        // a neighbour ~1700 Hz up across a ~1400 Hz at-floor gap must NOT be
+        // grabbed: the inner lobe fails the width guard AND the gap exceeds the
+        // unconfident bridge, so the scan stops and only the blip is judged
+        // (fails presence -> reject).
+        {
+            const auto sig = [](double f) -> float {
+                if (f >= 250 && f <= 400)   return -111.0f;   // ~150 Hz carrier blip
+                if (f >= 1800 && f <= 3200) return -80.0f;    // strong neighbour
+                return -1000.0f;
+            };
+            const OccupiedRegion r = measure(
+                buildSpectrum(usb, -120.0f, 0.0f, sig), usb, -120.0f);
+            char d[64];
+            std::snprintf(d, sizeof d, "  [%s] valid=%d high=%d", tag(usb), r.valid ? 1 : 0, r.highHz);
+            report("two-hump F4: narrow blip + far neighbour not grabbed",
+                   !r.valid || r.highHz < 1500, d);
+        }
+        // (i) F3 boundary — a single voice whose weak bass hovers RIGHT at the
+        // Normal presence gate (floor+9) with a treble hump across an armed
+        // 400 Hz valley must resolve STABLY (re-anchor, keep the treble) across a
+        // +/-0.3 dB bass perturbation, not flip the high-cut by the whole hump.
+        {
+            const auto mk = [](float bassDb) {
+                return [bassDb](double f) -> float {
+                    if (f >= 300 && f <= 1100)  return bassDb;            // bass at the gate
+                    if (f >= 1500 && f <= 2900) return -95.0f;            // treble hump
+                    return -1000.0f;
+                };
+            };
+            const OccupiedRegion rlo = measure(buildSpectrum(usb, -120.0f, 0.0f, mk(-111.3f)), usb, -120.0f);
+            const OccupiedRegion rhi = measure(buildSpectrum(usb, -120.0f, 0.0f, mk(-110.7f)), usb, -120.0f);
+            char d[96];
+            std::snprintf(d, sizeof d, "  [%s] lo.high=%d hi.high=%d", tag(usb), rlo.highHz, rhi.highHz);
+            report("two-hump F3: bass-at-gate resolves stably (no flip)",
+                   rlo.valid && rhi.valid && rlo.highHz >= 2600 && rhi.highHz >= 2600 &&
+                   std::abs(rlo.highHz - rhi.highHz) <= 200, d);
+        }
     });
 
     // ── 15. Level-invariant outer edge — width must not track SNR ───────────
@@ -579,6 +626,44 @@ int main()
         // still produce a fit from the clipped-but-present energy.
         report("edge carrier: clipped scan measures without OOB access",
                r.valid && rf.valid, d);
+    });
+
+    // ── 19. Edge-het rejection (opt-in) — pull the cut inboard of a het ─────
+    // A ~3 kHz voice with a strong narrow het at ~2650 Hz (just inside the high
+    // edge). With hetReject OFF the het rides inside the passband (edge ~2.7 k+);
+    // with it ON the high-cut is pulled below the het (~2.5 k). A mid-band het
+    // (test-2 shape, het at 2 kHz) leaves the edges unmoved either way.
+    forEachMode([](bool usb) {
+        const auto sig = [](double f) -> float {
+            if (f >= 2600 && f <= 2700) return -45.0f;      // strong narrow het
+            if (f >= 300 && f <= 2900)  return -85.0f;      // voice hump
+            return -1000.0f;
+        };
+        const auto bins = buildSpectrum(usb, -115.0f, 0.0f, sig);
+        AetherSDR::OccupiedRegionParams on;  on.hetReject = true;
+        AetherSDR::OccupiedRegionParams off; off.hetReject = false;
+        const OccupiedRegion ron  = measureP(bins, usb, -115.0f, on);
+        const OccupiedRegion roff = measureP(bins, usb, -115.0f, off);
+        char d[112];
+        std::snprintf(d, sizeof d, "  [%s] on.high=%d off.high=%d", tag(usb), ron.highHz, roff.highHz);
+        report("edge-het: high-cut pulled below the het when enabled",
+               ron.valid && roff.valid && ron.highHz <= 2600 && roff.highHz > ron.highHz, d);
+    });
+    forEachMode([](bool usb) {
+        // Mid-band het (well inside the voice) must NOT move the edges — a
+        // bandpass edge can't exclude it, so leave it to the notch.
+        const auto sig = [](double f) -> float {
+            if (f >= 1950 && f <= 2050) return -45.0f;       // mid-band het
+            if (f >= 300 && f <= 2700)  return -85.0f;
+            return -1000.0f;
+        };
+        const auto bins = buildSpectrum(usb, -115.0f, 0.0f, sig);
+        AetherSDR::OccupiedRegionParams on; on.hetReject = true;
+        const OccupiedRegion r = measureP(bins, usb, -115.0f, on);
+        char d[96];
+        std::snprintf(d, sizeof d, "  [%s] low=%d high=%d", tag(usb), r.lowHz, r.highHz);
+        report("edge-het: mid-band het leaves edges unmoved",
+               r.valid && r.highHz >= 2400 && r.highHz <= 3200, d);
     });
 
     std::printf("\n%s (%d failure%s)\n",


### PR DESCRIPTION
Closes #4049

## What & why

The re-engage restore in the adaptive RX filter is a **live regression in `main`**. It was dormant while `emittedNs == 0`, but the #3945 review added `m_fallbackClock` (a correct fix in itself) which makes `emittedNs` always positive — and that activates `restorable`. On a QSO (two operators alternating on the **same dial frequency** with different TX widths), it reapplies operator A's fit to operator B within the 20 s window: the reported "4 kHz filter on the 3.5 kHz signal and vice versa" swap. See #4049 for the full trace.

This PR removes the restore and fixes the handoff positively, plus two adjacent accuracy bugs and an opt-in feature.

## Changes

**Remove the re-engage restore (the #4049 swap).** Deletes `lastGood*` / `restorable` / `kRefitMemoryNs`. Its "same frequency within 20 s ⇒ same station" premise is exactly what a QSO violates.

**QSO handoff, positively.** A gap counter can't detect the handoff — the per-offset peak-hold envelope (`avgEnv`, ~1.1 s release) rides the PTT gap so the measurement stays valid at A's width across it. But that same peak-hold means the measurement reads *sustainedly narrower* than the applied filter only when the signal genuinely is narrower (a different op); a brief word gap stays wide. So a **sustained-step flush**: when the measured width sits > `kStepMarginHz` inside the target for `kStepFlushFrames` straight, retire the stale peak-hold and pre-load the narrowing confirmation so B fits its own width promptly.

**Stops-adjusting.** The low-SNR narrow-freeze now scales to the active presence preset (`minPeakDb + kNarrowFreezeMarginDb`) instead of a fixed 16 dB that sat above every gate and blocked any medium signal from narrowing; and narrowing accrues on direction-consistent frames (`narrowRun`) rather than proximity to a frozen candidate, so QSB jitter no longer resets the confirmation.

**Pacing (F2).** The min-spacing-vs-last-arrival gate mapped intermediate fps to an unstable 20–40 fps sawtooth; replaced with a fixed-period phase accumulator so any 40–90 fps source decimates to a stable ~30 fps (the calibration rate). Runs on the timestamp `m_fallbackClock` now guarantees.

**F3 — bistable ESSB amputation.** The cut-vs-reanchor pivot was a razor edge, so a ~0.2 dB wiggle in a weak bass lobe flipped the high-cut by the whole treble-hump width. A separate-station CUT now needs both dead-band margins (`kRunConfidentHystDb`, `kSeparateMarginDb`); otherwise re-anchor.

**F4 — weak-signal neighbour grab.** An unconfident run bypassed the silence-stop and could grab a station 1.5–2 kHz above a weak carrier. A weak-run re-anchor now requires the inner lobe to be a real sustained lobe and bounds the bridged gap.

**Edge-het rejection (opt-in, default off).** A narrow strong interferer within `kHetSearchHz` of a finalised edge (raw ≥ `kHetExcessDb` over the local smoothed envelope) pulls that cut inboard of it — a complement to the notch/ANF for a het sitting right at a passband edge. New per-slice `adaptiveHetReject` toggle (model + "Het" Off/On control + automation snapshot).

## Tests

New **`adaptive_engine_test`** drives `AdaptiveFilterEngine::processFrame` through a real headless `SliceModel` with monotonic timestamps — the wall-clock pacing / send-throttle / QSO-handoff path no measurement test could reach, and the gap that let the dead-clock issue ship. Cases: no filt-storm at 60 fps (≤8/s, ≥125 ms spacing), engage tracking, word-gap HOLD (no false flush), QSO A(4k)→1.2 s gap→B(3.5k) corrects to B's width, manual-edit auto-disable.

`adaptive_filter_test` gains F3 (bass-at-gate resolves stably, no flip), F4 (narrow blip + far neighbour not grabbed), and edge-het (pulled below an edge het when enabled; mid-band het unmoved) regressions.

All green; app builds. Preserves every #3945 review fix underneath (`m_fallbackClock`, nth_element medians, floor-histogram NaN guard, baseline-restore-on-disable, clamp-UB guard, session force-disable, idempotent `savePrefs`).

## On-air status

Partial. The QSO swap fix and pacing were validated on the bench (engine test) and briefly on air; a separate **"stops adjusting after 30–60 s" freeze** was seen once and could not be reproduced afterwards. It appears to be a pre-existing measurement effect (the high-edge floor gate rising on a signal-dominated, zoomed-in pan), **not** introduced by these commits and **separate from #4049** — flagging as a follow-up, not a blocker. RFC #3878 DSP-feel sign-off still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
