### PR TITLE
feat(aetherd): IRadioBackend seam + RadioCapabilities (RFC step 2.1) (#3849)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1419,7 +1419,8 @@ endif()
 # mapper dialog and MainWindow dispatcher are unchanged across
 # platforms.  See #3232 for the design.
 target_sources(aethercore PRIVATE
-    src/core/UlanziDialBackend.h)   # header-only Q_OBJECT — listed so AUTOMOC mocs it in the engine
+    src/core/UlanziDialBackend.h    # header-only Q_OBJECT — listed so AUTOMOC mocs it in the engine
+    src/core/backends/IRadioBackend.h)  # aetherd RFC step 2.1: radio-facing seam (§5.5); header-only Q_OBJECT
 target_sources(AetherSDR PRIVATE
     src/gui/UlanziDialMapperDialog.cpp
     src/gui/UlanziDialMapperDialog.h)

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -1,0 +1,165 @@
+# IRadioBackend — the radio-facing seam (aetherd RFC step 2) — DESIGN DRAFT
+
+**Status:** Draft for maintainer review. Step 2 of the accepted aetherd RFC
+([`../aetherd-headless-engine-design.md`](../aetherd-headless-engine-design.md)
+§5.5, §10). Cannot land until step 1 (#4047) merges — no stacking (RFC §10).
+**Scope:** extract a radio-family-agnostic interface inside `libaethercore` so
+`RadioModel` and friends stop reaching directly into SmartSDR-specific wire
+classes, and wrap today's stack as `FlexBackend` with **zero behavior change**.
+
+Vendor-agnostic by design: this doc names no specific non-Flex radio. The
+first backend is `FlexBackend`; the interface is what any second backend
+implements.
+
+---
+
+## 1. What the seam must cover (measured, not guessed)
+
+The touchpoint audit
+([`aetherd-touchpoints.md`](aetherd-touchpoints.md)) tags every gui→engine
+header. Two tag classes define step 2's work:
+
+- **26 `vendor` headers** — SmartSDR/FlexLib/Flex-ecosystem wire code. These
+  move *behind* the seam into `src/core/backends/flex/`; nothing above the
+  seam includes them. The load-bearing ones: `RadioConnection` (SmartSDR TCP
+  text), `PanadapterStream` (VITA-49), `SmartLinkClient`/`WanConnection`
+  (SmartLink WAN), `CommandParser`, `StreamStatus`, `RadioStatusOwnership`,
+  plus the 4O3A/amp/tuner/firmware/waveform/DAX-IQ family.
+- **16 `mixed` headers** — canonical state fused with Flex specifics. These do
+  *not* move; they get **split**: the core-profile part stays as the model the
+  UI/protocol sees, the Flex part becomes backend-provided. The hard five are
+  `RadioModel`, `SliceModel`, `TransmitModel`, `PanadapterModel`, `MeterModel`.
+
+The 43 `universal` + 42 `ui-support` headers are untouched by step 2.
+
+## 2. The interface
+
+`IRadioBackend` lives in `src/core/backends/IRadioBackend.h`. It is the *only*
+thing `RadioModel` holds toward the wire. Shape (illustrative, not final):
+
+```cpp
+class IRadioBackend {
+public:
+    virtual ~IRadioBackend() = default;
+
+    // ---- identity & capability (feeds the protocol `welcome`, RFC §4.1) ----
+    virtual RadioCapabilities capabilities() const = 0;   // slices, sample
+        // rates, TX power range, tuner/amp presence, extension namespaces
+
+    // ---- lifecycle ----
+    virtual void connect(const RadioConnectInfo&) = 0;
+    virtual void disconnect() = 0;
+    // signals (Qt): connected(), disconnected(), connectionError(QString)
+
+    // ---- intents DOWN (canonical verbs; backend translates to its wire) ----
+    virtual void setSliceFrequency(int sliceId, double hz) = 0;
+    virtual void setSliceMode(int sliceId, const QString& mode) = 0;
+    virtual void setSliceFilter(int sliceId, int lowHz, int highHz) = 0;
+    virtual void setKeying(bool key) = 0;                 // gated ABOVE this
+    // ... the enumerated core-profile setters (from the `universal` tag set)
+
+    // ---- vendor extensions (namespaced, capability-advertised) ----
+    virtual QVariant invokeExtension(const QString& ns,
+                                     const QString& verb, const QVariant&) = 0;
+
+    // ---- state & streams UP (normalized) ----
+    // signals: sliceChanged(id, kvs), meterUpdate(...), spectrumFrame(...),
+    //          waterfallRow(...), audioFrame(...) — the §4.2 frame formats
+};
+```
+
+Key properties:
+
+- **DSP location is invisible here.** A backend whose hardware demodulates and
+  computes FFTs is a thin protocol decoder; a backend that ships raw samples
+  owns an engine-side DSP chain and emits the *same* `spectrumFrame`/`audioFrame`
+  signals. Above the seam, identical. (RFC §5.5.)
+- **Keying is a single canonical intent.** `setKeying(bool)` is translated by
+  the backend to its mechanism (a command verb, an in-stream bit, a hardware
+  line). The TX guard/arbitration sits **above** the seam (RFC §6) — no backend
+  self-polices; step 4 wires the guard, step 2 just routes the intent.
+- **Capabilities are declared, not assumed.** `RadioCapabilities` is the honest
+  self-description the RFC §4.1 `welcome` needs; it replaces the current
+  implicit "the radio is a Flex" assumption and kills the model-impersonation
+  anti-pattern (RFC §1, PR #4027).
+
+## 3. Splitting the five hard `mixed` models
+
+This is the genuine design work; the vendor-header moves are mechanical. Guiding
+rule: **the model holds canonical state the UI/protocol needs; the backend owns
+the wire semantics that produce and consume it.**
+
+| Model | Core-profile (stays in the model) | Flex extension (backend-owned) |
+|---|---|---|
+| `RadioModel` | connection state, the slice/pan/meter/transmit sub-model set, frequency/mode plumbing | Multi-Flex handles, GUIClientID session restore, SmartSDR status routing, `m_connection`/`m_panStream` ownership |
+| `SliceModel` | freq, mode, filter low/high, RX gain, active flag, S-meter binding | DAX channel, `client_handle` ownership, Flex slice-index quirks |
+| `TransmitModel` | keying intent, TX power setpoint, mic/monitor levels, the CHAIN DSP stage state | ATU/TGXL/amp verbs, Flex profile load, `mox`-less interlock decode |
+| `PanadapterModel` | center, span, min/max dBm, per-pan display state | FlexLib stream-id (0x40xx/0x42xx) wiring, `display pan` status keys |
+| `MeterModel` | the meter values the UI renders (via `MeterSmoother`) | Flex meter-id catalog, SLC/LEVEL source decode |
+
+Approach: keep the existing model classes as the core-profile shape; move the
+Flex-specific *decode/encode* out of them and into `FlexBackend`, which drives
+the models through the same signals the wire classes emit today. The models
+already communicate via signals (RFC §2 fact #4), so this is decoupling the
+producer, not rewriting the model.
+
+## 4. FlexBackend — zero behavior change (the acceptance bar)
+
+`FlexBackend` (`src/core/backends/flex/`) owns the existing
+`RadioConnection` + `PanadapterStream` + `RadioDiscovery` +
+`SmartLink`/`Wan`/`Tgxl`/`Pgxl` classes unchanged, and implements
+`IRadioBackend` by delegating to them. The acceptance bar is the same as step
+1: **byte-identical behavior on the slice-0 RX flow**, proven by
+`tools/verify_slice0_rx.py` (the harness added in #4047) run before and after,
+plus the 61-test suite and a live-radio bridge pass.
+
+Step 2 does **not** add the protocol, the daemon, or any client change — the
+desktop app still links `libaethercore` in-process and drives the backend
+directly. It only inserts the interface.
+
+## 5. Sequencing within step 2 (each a small, independent PR off main)
+
+1. **Land `IRadioBackend.h` + `RadioCapabilities`** (interface only, no
+   implementor wired) — pure addition.
+2. **`FlexBackend` skeleton** delegating to the existing classes, wired behind
+   `RadioModel` via a `std::unique_ptr<IRadioBackend>`, with the direct
+   member access (`m_connection`, `m_panStream`) routed through it. Behavior
+   unchanged; harness + tests gate it.
+3. **Split the five models** one at a time (5 PRs), moving Flex decode into
+   `FlexBackend`. Each PR: one model, harness-verified, manifest row flips.
+4. **Move the remaining 21 vendor headers** behind the seam (mechanical, a few
+   PRs grouped by subsystem — amp/tuner, firmware/waveform, SmartLink).
+
+Each step is behavior-neutral and independently revertable — the trunk-based
+discipline from RFC §10. The KiwiSDR path (tagged `vendor`) becomes the second
+backend *after* the seam is proven, retiring its side-channels (RFC §5.5).
+
+## 6. Resolved decisions (2026-07-05, KK7GWY — proceed-with-recommendations)
+
+1. **`RadioCapabilities` shape** → **typed struct + `QVariantMap extensions`**
+   escape hatch. Typed where universal, open where vendor. Implemented in
+   `src/core/backends/RadioCapabilities.h`.
+2. **Sub-model ownership** → **`RadioModel` keeps owning `SliceModel` et al.;
+   the backend drives them** by emitting normalized signals RadioModel connects
+   to. Minimal churn; the models already communicate via signals.
+3. **One interface vs RX/TX split** → **one interface.** A receive-only family
+   reports `capabilities().canTransmit == false` and implements `setKeying()`
+   as a guarded no-op; the engine TX guard (§6, above the seam) denies keying
+   when `canTransmit` is false. No type split.
+4. **Directory layout** → **`src/core/backends/`** confirmed: the interface at
+   `src/core/backends/IRadioBackend.h`, each family under
+   `src/core/backends/<family>/` (FlexBackend → `src/core/backends/flex/`).
+
+These are settled as the working defaults; any can be revised in review while
+the interface has no implementor.
+
+## 7. Sub-step status
+
+- **2.1 — interface + capabilities (this PR):** `IRadioBackend.h` +
+  `RadioCapabilities.h` land as a pure addition (header-only, AUTOMOC-listed,
+  no implementor wired). Zero behavior change.
+- **2.2 — `FlexBackend` skeleton** delegating to the existing SmartSDR stack,
+  wired behind `RadioModel`. Next PR; AGENTS.md staging Block 2 lands with it
+  (the routing rules become actionable once a backend exists).
+- **2.3 — split the five `mixed` models** (5 PRs).
+- **2.4 — move the remaining vendor headers behind the seam.**

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -59,12 +59,15 @@ public:
     // ... the enumerated core-profile setters (from the `universal` tag set)
 
     // ---- vendor extensions (namespaced, capability-advertised) ----
-    virtual QVariant invokeExtension(const QString& ns,
-                                     const QString& verb, const QVariant&) = 0;
+    // Fire-and-forget: the reply arrives async via extensionResult/Error,
+    // keyed by the caller's requestId (0 = no reply expected).
+    virtual void invokeExtension(const QString& ns, const QString& verb,
+                                 quint64 requestId, const QVariant&) = 0;
 
     // ---- state & streams UP (normalized) ----
-    // signals: sliceChanged(id, kvs), meterUpdate(...), spectrumFrame(...),
-    //          waterfallRow(...), audioFrame(...) — the §4.2 frame formats
+    // signals: sliceChanged(id, kvs), meterUpdate(...),
+    //          extensionResult(requestId, QVariant), extensionError(requestId, reason),
+    //          spectrumFrame(...), waterfallRow(...), audioFrame(...) — §4.2 formats
 };
 ```
 

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QVariant>
+#include <QVariantMap>
+
+#include "core/backends/RadioCapabilities.h"
+
+namespace AetherSDR {
+
+// Neutral, family-agnostic connect descriptor. Core fields cover the common
+// case; vendor-specific parameters (SmartLink token, Kiwi endpoint path, …)
+// ride in `params` so the interface never grows a per-vendor connect signature.
+struct RadioConnectRequest {
+    QString host;
+    quint16 port = 0;
+    QString serial;         // when a family identifies radios by serial
+    QVariantMap params;     // family-specific extras (namespaced by the backend)
+};
+
+// The radio-facing seam of the engine (aetherd RFC §5.5). Everything that
+// speaks a vendor wire protocol lives *behind* this interface, inside
+// libaethercore; RadioModel and the (future) protocol see only this. The
+// SmartSDR stack becomes the first implementor (FlexBackend, step 2.2) with
+// ZERO behavior change; other radio families are added as further implementors
+// without touching any client.
+//
+// Design decisions (RFC §5.5 open questions, resolved 2026-07-05):
+//   Q2 — RadioModel keeps owning its sub-models (SliceModel, MeterModel, …);
+//        the backend DRIVES them by emitting the signals below, which
+//        RadioModel connects to. The backend does not own UI-facing model
+//        objects. (Minimal churn; the models already communicate via signals.)
+//   Q3 — ONE interface, not an RX-only/TX-capable type split. A receive-only
+//        family reports capabilities().canTransmit == false and implements
+//        setKeying() as a guarded no-op; the engine TX guard (RFC §6, above
+//        this seam) denies keying when canTransmit is false.
+//
+// DSP location is invisible here (RFC §5.5): a backend whose hardware
+// demodulates and computes FFTs is a thin protocol decoder; one that ships raw
+// samples owns an engine-side DSP chain — either way it emits the same
+// normalized signals, so no consumer can tell the difference.
+//
+// This is the CORE seed. It carries the lifecycle, capability, canonical-verb,
+// and extension surface; it grows one method at a time as the touchpoint
+// burndown (docs/architecture/aetherd-touchpoints.md) converts each gui→engine
+// touchpoint into a protocol/backend verb. Do NOT dump all 140 touchpoints
+// here at once.
+class IRadioBackend : public QObject {
+    Q_OBJECT
+
+public:
+    explicit IRadioBackend(QObject* parent = nullptr) : QObject(parent) {}
+    ~IRadioBackend() override = default;
+
+    // ---- identity & capability (feeds the protocol `welcome`, §4.1) ----
+    virtual RadioCapabilities capabilities() const = 0;
+
+    // ---- connection lifecycle ----
+    virtual void connectRadio(const RadioConnectRequest& request) = 0;
+    virtual void disconnectRadio() = 0;
+    virtual bool isConnected() const = 0;
+
+    // ---- intents DOWN: canonical core-profile verbs (grow per burndown) ----
+    // The backend translates each to its vendor wire protocol.
+    virtual void setSliceFrequency(int sliceId, double hz) = 0;
+    virtual void setSliceMode(int sliceId, const QString& mode) = 0;
+    virtual void setSliceFilter(int sliceId, int lowHz, int highHz) = 0;
+
+    // TX keying intent. The decision to allow keying is made ABOVE this seam by
+    // the engine guard (RFC §6, single-holder lock + capability check); the
+    // backend only translates an already-authorized intent to its mechanism
+    // (command verb, in-stream bit, hardware line). A backend whose
+    // capabilities().canTransmit is false implements this as a no-op.
+    virtual void setKeying(bool key) = 0;
+
+    // ---- vendor extensions (namespaced, capability-advertised) ----
+    // Vendor-specific verbs that are NOT part of the core profile. Clients
+    // discover available namespaces via capabilities().extensionNamespaces.
+    virtual QVariant invokeExtension(const QString& ns, const QString& verb,
+                                     const QVariant& arg = {}) = 0;
+
+signals:
+    // ---- connection state UP ----
+    void connected();
+    void disconnected();
+    void connectionError(const QString& reason);
+    void capabilitiesChanged();
+
+    // ---- normalized model state UP (RadioModel connects these to its
+    //      sub-models; Q2) — the key/value shape mirrors the models' fields ----
+    void sliceChanged(int sliceId, const QVariantMap& changes);
+    void sliceRemoved(int sliceId);
+    void meterUpdate(const QString& meterId, double value);
+
+    // ---- data plane UP (RFC §4.2) ----
+    // Declared here so backends have a normalized outlet for spectrum/waterfall/
+    // audio; the concrete zero-copy/binary frame formats are step-4 work. Until
+    // then a backend may relay the existing in-tree frame types.
+    void spectrumFrameReady(int panId, const QByteArray& frame);
+    void waterfallRowReady(int panId, const QByteArray& row);
+    void audioFrameReady(const QByteArray& pcm);
+};
+
+}  // namespace AetherSDR

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QByteArray>
 #include <QObject>
 #include <QString>
 #include <QVariant>
@@ -77,8 +78,15 @@ public:
     // ---- vendor extensions (namespaced, capability-advertised) ----
     // Vendor-specific verbs that are NOT part of the core profile. Clients
     // discover available namespaces via capabilities().extensionNamespaces.
-    virtual QVariant invokeExtension(const QString& ns, const QString& verb,
-                                     const QVariant& arg = {}) = 0;
+    //
+    // Fire-and-forget like every other DOWN verb: the result of a real device
+    // command (ATU tune, amp state, …) arrives later on the wire, so it comes
+    // back asynchronously via extensionResult(requestId, …) / extensionError.
+    // The caller (above the seam) mints requestId and correlates the reply; a
+    // requestId of 0 means "no reply expected". A synchronous QVariant return
+    // would have to block or fabricate a local value against an async backend.
+    virtual void invokeExtension(const QString& ns, const QString& verb,
+                                 quint64 requestId, const QVariant& arg = {}) = 0;
 
 signals:
     // ---- connection state UP ----
@@ -86,6 +94,13 @@ signals:
     void disconnected();
     void connectionError(const QString& reason);
     void capabilitiesChanged();
+
+    // ---- vendor-extension replies UP (correlate to invokeExtension) ----
+    // The async result of an invokeExtension() call, keyed by the caller's
+    // requestId. A backend that completes locally may emit this synchronously;
+    // one speaking a wire protocol emits it when the device answers.
+    void extensionResult(quint64 requestId, const QVariant& result);
+    void extensionError(quint64 requestId, const QString& reason);
 
     // ---- normalized model state UP (RadioModel connects these to its
     //      sub-models; Q2) — the key/value shape mirrors the models' fields ----

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -16,6 +16,12 @@ namespace AetherSDR {
 // the surface every radio family has — plus a namespaced `extensions` bag for
 // vendor-specific capability values that don't belong in the core. Typed where
 // it's universal, open where it's vendor.
+//
+// NOT the same as models/ModelCapabilities: that is model-string-*derived*
+// truth (a static FlexLib platform table keyed by the model name, Principle I);
+// this is the radio's *reported* self-description produced by a backend and
+// surfaced to clients. A FlexBackend may seed this FROM ModelCapabilities, but
+// the two are distinct concepts (derived-from-name vs reported-by-backend).
 struct RadioCapabilities {
     // Identity
     QString family;   // backend id: "flex", "kiwi", … (stable, lowercase)

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QVariantMap>
+
+namespace AetherSDR {
+
+// The honest, self-declared feature set of a connected radio, produced by an
+// IRadioBackend and surfaced to clients (aetherd RFC §4.1 `welcome`). Clients
+// render against what the radio *reports* — a control the radio lacks is
+// disabled/absent — instead of hard-coding "the radio is a Flex". This is the
+// structural replacement for the model-impersonation anti-pattern (RFC §1).
+//
+// Design (RFC §5.5 open-question Q1): a TYPED struct for the core profile —
+// the surface every radio family has — plus a namespaced `extensions` bag for
+// vendor-specific capability values that don't belong in the core. Typed where
+// it's universal, open where it's vendor.
+struct RadioCapabilities {
+    // Identity
+    QString family;   // backend id: "flex", "kiwi", … (stable, lowercase)
+    QString model;    // radio model string as reported by the hardware
+
+    // Receive
+    int maxSlices = 1;             // independent demod slices the radio supports
+    int maxPanadapters = 1;        // simultaneous panadapters
+    QVector<int> sampleRatesHz;    // supported per-receiver sample rates (Hz)
+
+    // Transmit — the load-bearing capability for TX safety (RFC §6). A backend
+    // that cannot key sets canTransmit=false; the engine guard then denies any
+    // keying intent regardless of client requests.
+    bool canTransmit = false;
+    double txPowerMaxWatts = 0.0;  // 0 when RX-only
+
+    // Peripherals / features every family may or may not have
+    bool hasTuner = false;         // antenna tuner / ATU
+    bool hasAmplifier = false;     // integrated or controllable PA
+    bool hasExtendedDsp = false;   // extended firmware DSP filters (NRS/RNN/NRF)
+
+    // Vendor-specific capabilities, keyed by extension namespace. Clients that
+    // don't understand a namespace ignore it; a backend never puts core-profile
+    // fields here. Example: {"flex": {"multiFlex": true, "guiClientId": "…"}}.
+    QVariantMap extensions;
+
+    // The vendor-extension namespaces this backend implements (for the
+    // capability handshake). A client can pre-check before issuing
+    // invokeExtension(ns, …).
+    QVector<QString> extensionNamespaces;
+};
+
+}  // namespace AetherSDR


### PR DESCRIPTION
First sub-step of the accepted aetherd RFC (#3849, §10 step 2 / §5.5 pluggable radio backends). **Pure addition — a header-only interface with no implementor wired, zero behavior change.** Lands the radio-facing seam's contract so it can be reviewed before the FlexBackend wiring (2.2) builds on it.

### What's here
- **`src/core/backends/IRadioBackend.h`** — abstract `QObject` seam: capability query, connection lifecycle, canonical core-profile verbs (`setSliceFrequency/Mode/Filter`, `setKeying`), a namespaced `invokeExtension` escape hatch, and normalized state + data-plane signals emitted UP. AUTOMOC-listed so the `Q_OBJECT` is moc'd into `libaethercore`. Marked as the **core seed** that grows one verb at a time per the touchpoint burndown — not all 140 touchpoints at once.
- **`src/core/backends/RadioCapabilities.h`** — typed core-profile capability struct + `QVariantMap extensions` bag; the honest self-description that feeds the protocol `welcome` (§4.1) and structurally replaces the model-impersonation anti-pattern (§1, PR #4027).
- **`docs/architecture/aetherd-iradiobackend-design.md`** — the step-2 design doc.

### Resolved §5.5 open questions (proceeding as recommended; revisable in review while there's no implementor)
1. **Capabilities shape** → typed struct + `QVariantMap` extension bag.
2. **Sub-model ownership** → `RadioModel` keeps owning `SliceModel` et al.; the backend drives them via signals. Minimal churn.
3. **One interface vs RX/TX split** → one interface; `capabilities().canTransmit == false` + `setKeying()` guarded no-op for receive-only families. The TX guard lives *above* the seam (§6).
4. **Directory layout** → `src/core/backends/`, families under `src/core/backends/<family>/` (FlexBackend → `flex/`).

### Verification
Clean build; `IRadioBackend` moc'd into `libaethercore`; `engine-boundary --strict` green (the new `backends/` dir has no gui includes / no QtWidgets).

### Next
2.2 — `FlexBackend` skeleton wrapping the existing SmartSDR stack (`RadioConnection`/`PanadapterStream`/`RadioDiscovery`) behind `RadioModel`, zero behavior change, verified with `verify_slice0_rx.py`. AGENTS.md staging Block 2 lands with it (routing rules become actionable once a backend exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)