### PR TITLE
feat(aetherd): FlexBackend skeleton — first IRadioBackend implementor (RFC step 2.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,9 +233,14 @@ The accepted RFC at
 (tracking issue #3849) splits this codebase into an engine library
 (`libaethercore`), a headless engine daemon (`aetherd`), and thin UI
 clients, with pluggable radio backends (`IRadioBackend`). Implementation
-follows the RFC's §10 staged order; **step 1 (`libaethercore`) has
-landed** — the engine is a static library, the app is a shell that links
-it. Steps 2+ have not landed.
+follows the RFC's §10 staged order; **step 1 (`libaethercore`) and the
+step-2 seam have landed** — the engine is a static library, and
+`IRadioBackend` (`src/core/backends/`) with its first implementor
+`FlexBackend` (`src/core/backends/flex/`) exist. `FlexBackend` is a
+skeleton so far: RadioModel owns it and it observes the connection
+lifecycle, but the SmartSDR wire stack moves behind it incrementally
+(2.2b–2.4). The versioned protocol (step 3+) has not landed — UI code
+still consumes models directly, and that remains correct.
 
 **Build targets (post-RFC step 1):**
 
@@ -266,6 +271,21 @@ Boundaries above). One rule is already CI-enforced: the engine
 (`src/core/` + `src/models/`) must not gain new `gui/` includes or
 QtWidgets usage (`tools/check_engine_boundary.py`, warning for tracked
 legacy files, error for new ones).
+
+**Where radio-facing code goes now that the seam exists.** Route by kind:
+
+| Your change | Goes |
+|---|---|
+| Code speaking a vendor wire protocol (commands, discovery, stream parsing) | that family's backend under `src/core/backends/<family>/`, behind `IRadioBackend` — never in `gui/`, and increasingly not in the models (they're being decoupled from the wire over 2.2b–2.4) |
+| A new radio family | a new `IRadioBackend` implementation under `src/core/backends/<family>/` — requires an approved design doc naming its open protocol authority (Constitution Principles I & IV apply per backend) |
+| A new engine feature | `libaethercore`, exposed through models — never via a new gui→core header |
+
+Do **not** yet reroute existing model↔wire code through `FlexBackend`
+wholesale — the per-touchpoint conversion is staged work
+(`docs/architecture/aetherd-touchpoints.md`), and its claim protocol +
+before/after `tools/verify_slice0_rx.py` verification recipe land in this
+file when those conversions (2.3) begin. Until then the models' existing
+direct wire access remains correct.
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,7 @@ endif()
 
 # Sources
 set(CORE_SOURCES
+    src/core/backends/flex/FlexBackend.cpp   # aetherd RFC step 2.2 (§5.5)
     src/core/AppSettings.cpp
     src/core/GpuSelector.cpp
     src/core/AgcTCalibrator.cpp

--- a/docs/aetherd-agents-md-staging.md
+++ b/docs/aetherd-agents-md-staging.md
@@ -65,7 +65,17 @@ or add an exemption.
 
 ---
 
-## Block 2 — land with RFC step 2 (`IRadioBackend` seam)
+## Block 2 — PARTIALLY LANDED with RFC step 2.2 (FlexBackend skeleton)
+
+> The In-flight status (2a) and the "where radio-facing code goes" routing
+> table (a trimmed 2b) landed in `AGENTS.md` with the 2.2 FlexBackend
+> skeleton, reconciled to the skeleton reality (FlexBackend exists but the
+> wire stack hasn't moved behind it yet). **Still pending, to land when 2.3
+> per-touchpoint conversions begin:** the touchpoint-claim protocol, the
+> before/after `verify_slice0_rx.py` verification recipe, and the
+> Autonomous Agent Boundaries carve-out (2c) that authorizes agents to
+> convert enumerated touchpoints — premature before the first conversion
+> proves the process. The blocks below are what remains for 2.3.
 
 ### 2a. In the "In-flight" subsection, replace the status sentence
 

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -161,8 +161,20 @@ the interface has no implementor.
 - **2.1 — interface + capabilities (this PR):** `IRadioBackend.h` +
   `RadioCapabilities.h` land as a pure addition (header-only, AUTOMOC-listed,
   no implementor wired). Zero behavior change.
-- **2.2 — `FlexBackend` skeleton** delegating to the existing SmartSDR stack,
-  wired behind `RadioModel`. Next PR; AGENTS.md staging Block 2 lands with it
-  (the routing rules become actionable once a backend exists).
-- **2.3 — split the five `mixed` models** (5 PRs).
+- **2.2 — `FlexBackend` skeleton (this PR):** `FlexBackend` implements
+  `IRadioBackend`, is constructed/owned/torn-down by `RadioModel` in the real
+  connection lifecycle, and observes live wire lifecycle events (re-emitting
+  connected/disconnected/connectionError). The core verbs build the exact
+  SmartSDR strings into RadioModel's command sink (scaffold for 2.3). Purely
+  ADDITIVE: the wire objects and the command hot path are NOT rerouted, so
+  behavior is unchanged. AGENTS.md gets the "where backend code goes" routing
+  table.
+- **2.2b — move wire ownership behind the seam:** `FlexBackend` absorbs
+  `RadioConnection`/`PanadapterStream` + their worker threads and the #502
+  teardown ordering; `RadioModel::connection()`/`panStream()` delegate. The
+  single riskiest move (thread lifetime + slice-0 RX plane) — its own
+  harness-verified PR.
+- **2.3 — split the five `mixed` models** (5 PRs); AGENTS.md gains the
+  touchpoint-claim protocol + verification recipe + the autonomous-conversion
+  carve-out.
 - **2.4 — move the remaining vendor headers behind the seam.**

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -1,0 +1,130 @@
+#include "core/backends/flex/FlexBackend.h"
+
+#include "core/RadioConnection.h"
+#include "models/ModelCapabilities.h"
+
+namespace AetherSDR {
+
+FlexBackend::FlexBackend(QObject* parent)
+    : IRadioBackend(parent)
+{
+}
+
+FlexBackend::~FlexBackend() = default;
+
+void FlexBackend::attachConnection(RadioConnection* conn)
+{
+    if (m_connection == conn) {
+        return;
+    }
+    if (m_connection) {
+        disconnect(m_connection, nullptr, this, nullptr);
+    }
+    m_connection = conn;
+    if (!m_connection) {
+        return;
+    }
+    // Observe wire lifecycle and re-emit as the interface's own signals. Queued
+    // (auto) connections: the connection lives on its worker thread.
+    connect(m_connection, &RadioConnection::connected,
+            this, &IRadioBackend::connected);
+    connect(m_connection, &RadioConnection::disconnected,
+            this, &IRadioBackend::disconnected);
+    connect(m_connection, &RadioConnection::errorOccurred,
+            this, &IRadioBackend::connectionError);
+}
+
+void FlexBackend::setCommandSink(std::function<void(const QString&)> sink)
+{
+    m_sink = std::move(sink);
+}
+
+void FlexBackend::setModelProvider(std::function<QString()> provider)
+{
+    m_modelProvider = std::move(provider);
+}
+
+RadioCapabilities FlexBackend::capabilities() const
+{
+    RadioCapabilities caps;
+    caps.family = QStringLiteral("flex");
+    caps.model = m_modelProvider ? m_modelProvider() : QString();
+
+    // Seed from the FlexLib-sourced platform table (Principle I). This is the
+    // derived-from-name truth used to *seed* the reported capabilities; a fuller
+    // FlexBackend refines these from live radio status as touchpoints convert.
+    const ModelCapabilities mc = capabilitiesFor(caps.model);
+    caps.maxSlices = mc.maxSlices;
+    caps.maxPanadapters = mc.maxSlices;   // pan capacity tracks slice capacity
+    caps.hasExtendedDsp = mc.hasExtendedDsp();
+
+    // Every current FlexRadio transmits; RX-only WAN/observer nuance is layered
+    // in later. Sample rates and TX power range are refined as their touchpoints
+    // convert (they are not part of this skeleton).
+    caps.canTransmit = true;
+    caps.hasTuner = true;
+
+    caps.extensionNamespaces = { QStringLiteral("flex") };
+    return caps;
+}
+
+void FlexBackend::connectRadio(const RadioConnectRequest& /*request*/)
+{
+    // 2.2 skeleton: RadioModel still orchestrates connect (RadioInfo assembly,
+    // WAN/SmartLink duality, auto-reconnect). The backend will own this in a
+    // later increment once the RadioConnectRequest→RadioInfo adaptation and the
+    // WAN branch move behind the seam.
+}
+
+void FlexBackend::disconnectRadio()
+{
+    // 2.2 skeleton: RadioModel still orchestrates the staged gracefulDisconnect
+    // (handle/streamId/seq) and teardown ordering. Owned by the backend later.
+}
+
+bool FlexBackend::isConnected() const
+{
+    return m_connection && m_connection->isConnected();
+}
+
+void FlexBackend::setSliceFrequency(int sliceId, double hz)
+{
+    // Matches SliceModel::setFrequency's wire string exactly.
+    send(QStringLiteral("slice tune %1 %2 autopan=0")
+             .arg(sliceId)
+             .arg(hz / 1'000'000.0, 0, 'f', 6));
+}
+
+void FlexBackend::setSliceMode(int sliceId, const QString& mode)
+{
+    send(QStringLiteral("slice set %1 mode=%2").arg(sliceId).arg(mode));
+}
+
+void FlexBackend::setSliceFilter(int sliceId, int lowHz, int highHz)
+{
+    send(QStringLiteral("filt %1 %2 %3").arg(sliceId).arg(lowHz).arg(highHz));
+}
+
+void FlexBackend::setKeying(bool key)
+{
+    // Keying is only translated here; the interlock/authorization decision is
+    // made above the seam (RFC §6). Matches RadioModel::setTransmit's wire form.
+    send(QStringLiteral("xmit %1").arg(key ? 1 : 0));
+}
+
+void FlexBackend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
+                                  quint64 /*requestId*/, const QVariant& /*arg*/)
+{
+    // No flex extension verbs are routed through the seam yet; they land with
+    // the amp/tuner/DAX touchpoint conversions. A real reply would arrive via
+    // extensionResult()/extensionError() keyed by requestId.
+}
+
+void FlexBackend::send(const QString& cmd)
+{
+    if (m_sink) {
+        m_sink(cmd);
+    }
+}
+
+}  // namespace AetherSDR

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <functional>
+
+#include "core/backends/IRadioBackend.h"
+
+namespace AetherSDR {
+
+class RadioConnection;
+
+// FlexBackend — the first IRadioBackend implementor (aetherd RFC step 2.2),
+// wrapping the SmartSDR / FlexRadio wire stack.
+//
+// This is the introductory SKELETON. It is constructed, owned, and torn down by
+// RadioModel inside the real connection lifecycle, and it observes live wire
+// lifecycle events (re-emitting them as the interface's connected/disconnected/
+// connectionError). It does NOT yet:
+//   * absorb ownership of RadioConnection / PanadapterStream or their worker
+//     threads (the #502 ASAN teardown ordering is the migration's single
+//     riskiest move — its own verified increment, 2.2b), nor
+//   * reroute the command hot path (sendCmd) or the slice-0 RX data plane.
+// So this change is purely ADDITIVE and behavior-neutral: nothing above the
+// seam is rerouted through the backend yet.
+//
+// The canonical core verbs (setSliceFrequency/Mode/Filter, setKeying) build the
+// exact SmartSDR command strings and emit them through the model-provided
+// command sink. They are correct but not yet on the live path — the touchpoint
+// burndown (2.3) routes each model through them one at a time.
+class FlexBackend : public IRadioBackend {
+    Q_OBJECT
+
+public:
+    explicit FlexBackend(QObject* parent = nullptr);
+    ~FlexBackend() override;
+
+    // ---- transitional wiring (2.2: RadioModel still owns these objects) ----
+    // Observe the connection's lifecycle signals (non-owning; the connection
+    // lives on its worker thread, so these arrive via queued connections).
+    void attachConnection(RadioConnection* conn);
+    // Where the core verbs emit their SmartSDR command strings — RadioModel's
+    // existing sendCommand() funnel, so verbs reuse the one wire-write path.
+    void setCommandSink(std::function<void(const QString&)> sink);
+    // Live model-string source, for capabilities() (avoids caching a value that
+    // changes when the `model` status arrives).
+    void setModelProvider(std::function<QString()> provider);
+
+    // ---- IRadioBackend ----
+    RadioCapabilities capabilities() const override;
+    void connectRadio(const RadioConnectRequest& request) override;
+    void disconnectRadio() override;
+    bool isConnected() const override;
+    void setSliceFrequency(int sliceId, double hz) override;
+    void setSliceMode(int sliceId, const QString& mode) override;
+    void setSliceFilter(int sliceId, int lowHz, int highHz) override;
+    void setKeying(bool key) override;
+    void invokeExtension(const QString& ns, const QString& verb,
+                         quint64 requestId, const QVariant& arg = {}) override;
+
+private:
+    void send(const QString& cmd);
+
+    RadioConnection* m_connection{nullptr};   // non-owning in 2.2 (RadioModel owns it)
+    std::function<void(const QString&)> m_sink;
+    std::function<QString()> m_modelProvider;
+};
+
+}  // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2,6 +2,7 @@
 #include "AntennaAliasStore.h"
 #include "BandSettings.h"
 #include "core/CommandParser.h"
+#include "core/backends/flex/FlexBackend.h"   // aetherd RFC 2.2 radio-facing seam
 #include "core/AppSettings.h"
 #include "core/CwTrace.h"
 #include "core/LogManager.h"
@@ -475,6 +476,19 @@ RadioModel::RadioModel(QObject* parent)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
 
+    // aetherd RFC step 2.2: introduce the radio-facing seam (§5.5). The backend
+    // observes the connection lifecycle and carries the core-verb scaffold; it
+    // does not yet own the wire objects or sit on the command hot path, so this
+    // is purely additive / behavior-neutral. Constructed here so it is wired
+    // before any status arrives and torn down first in ~RadioModel.
+    {
+        auto flex = std::make_unique<FlexBackend>();
+        flex->attachConnection(m_connection);
+        flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });
+        flex->setModelProvider([this]{ return m_model; });
+        m_backend = std::move(flex);
+    }
+
     // Forward tuner commands to the radio — route through tune inhibit check
     connect(&m_tunerModel, &TunerModel::commandReady, this, [this](const QString& cmd){
         if (cmd.startsWith("tgxl autotune")) {
@@ -632,6 +646,11 @@ RadioModel::RadioModel(QObject* parent)
 
 RadioModel::~RadioModel()
 {
+    // Destroy the backend first, while m_connection is still alive, so its
+    // observation of the connection's lifecycle signals tears down cleanly
+    // (FlexBackend is a QObject; ~QObject auto-disconnects). (aetherd 2.2)
+    m_backend.reset();
+
     // Disconnect all signals BEFORE member destruction to prevent
     // use-after-free (ASAN). (#502)
     QObject::disconnect(m_connection, nullptr, this, nullptr);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -34,11 +34,14 @@
 #include <QMap>
 #include <QSet>
 #include <functional>
+#include <memory>
 
 #include <QTimer>
 #include <QElapsedTimer>
 
 namespace AetherSDR {
+
+class IRadioBackend;   // aetherd RFC §5.5 radio-facing seam (owned by value below)
 
 // RadioModel is the central data model for a connected radio.
 // It owns the RadioConnection, processes incoming status messages,
@@ -663,6 +666,10 @@ private:
 
     RadioConnection*  m_connection{nullptr};
     QThread*          m_connThread{nullptr};
+    // aetherd RFC step 2.2: the radio-facing seam (§5.5). RadioModel owns the
+    // backend; in 2.2 it observes the connection lifecycle and carries the
+    // core-verb scaffold. Ownership of the wire objects moves into it later.
+    std::unique_ptr<IRadioBackend> m_backend;
     // Sequence counter and callback map — owned by RadioModel on main thread.
     // RadioConnection no longer manages callbacks. (#502)
     std::atomic<quint32> m_seqCounter{1};


### PR DESCRIPTION
Second sub-step of aetherd RFC §10 step 2 (§5.5 pluggable backends). Introduces **`FlexBackend`**, the first `IRadioBackend` implementor, wired into the real `RadioModel` lifecycle. **Purely additive and behavior-neutral** — the wire objects and the command hot path are NOT rerouted yet.

> ⚠️ **Stacked on #4054** (the 2.1 interface) — a genuine hard dependency (2.2 implements the 2.1 interface), the one case the RFC allows stacking. **Base is `aetherd-step2-iradiobackend`; retarget to `main` once #4054 merges.**

### What it does
- **`src/core/backends/flex/FlexBackend.{h,cpp}`** — implements `IRadioBackend`. Observes the connection's `connected`/`disconnected`/`errorOccurred` and re-emits them as the interface signals, so the backend is **live in the wire lifecycle path**. `capabilities()` seeds from the FlexLib `ModelCapabilities` table (Principle I). Core verbs build the exact SmartSDR strings (`slice tune`, `slice set … mode=`, `filt …`, `xmit …`) into RadioModel's command sink — correct but not yet on the live path (2.3 routes each model through them).
- **`RadioModel`** owns it via `std::unique_ptr<IRadioBackend>`, constructed after the connection is wired and `reset()` **first** in `~RadioModel` (before the connection teardown) so its observation tears down cleanly.

### Explicitly deferred (not in this PR)
- **2.2b** — moving `RadioConnection`/`PanadapterStream` + their worker threads and the **#502 teardown ordering** behind the seam. That's the migration's single riskiest move (thread lifetime + the slice-0 RX data plane) and gets its own harness-verified PR. **This PR does not touch that teardown.**
- **2.3** — the per-touchpoint model conversions + the AGENTS.md claim protocol / verification recipe / autonomous-conversion carve-out.

### Verification
Clean build; `FlexBackend` moc'd into `libaethercore`; `engine-boundary --strict` green; **61/61 tests**; `verify_slice0_rx.py` **FULL PASS** against a live FLEX-8600 (connect → slice-0 RX at filter [−3828,−100], panadapter model, TX-guard refusal); clean connect+teardown (no ASAN/segfault — the thread teardown is unchanged).

### AGENTS.md
In-flight status advanced to the step-2 seam; added the "where radio-facing code goes" routing table (backend code → `src/core/backends/<family>/`). Conversion-process rules deferred to 2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)