### PR TITLE
feat(aetherd): FlexBackend owns the wire objects — RadioConnection/PanadapterStream + threads (RFC step 2.2b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2515,6 +2515,15 @@ if(UNIX)
 endif()
 set_target_properties(meter_model_test PROPERTIES AUTOMOC ON)
 
+# aetherd RFC step 2.2b regression guard: FlexBackend ctor/dtor thread ownership
+# + #502 teardown ordering. FlexBackend pulls RadioConnection/PanadapterStream
+# and their deep deps, so link the engine library rather than list sources.
+add_executable(flex_backend_lifecycle_test tests/flex_backend_lifecycle_test.cpp)
+target_include_directories(flex_backend_lifecycle_test PRIVATE src)
+target_link_libraries(flex_backend_lifecycle_test PRIVATE aethercore Qt6::Core)
+set_target_properties(flex_backend_lifecycle_test PROPERTIES AUTOMOC ON)
+add_test(NAME flex_backend_lifecycle_test COMMAND flex_backend_lifecycle_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -1,6 +1,9 @@
 #include "core/backends/flex/FlexBackend.h"
 
+#include <QThread>
+
 #include "core/RadioConnection.h"
+#include "core/PanadapterStream.h"
 #include "models/ModelCapabilities.h"
 
 namespace AetherSDR {
@@ -8,22 +11,24 @@ namespace AetherSDR {
 FlexBackend::FlexBackend(QObject* parent)
     : IRadioBackend(parent)
 {
-}
+    // Own the wire objects + their worker threads. Order is load-bearing and
+    // preserved verbatim from the former RadioModel ctor (#502): PanadapterStream
+    // thread FIRST, then RadioConnection thread. Both objects are parentless and
+    // moved onto their thread; the thread is this-parented.
+    m_networkThread = new QThread(this);
+    m_networkThread->setObjectName("PanadapterStream");
+    m_panStream = new PanadapterStream;   // no parent — moved to thread
+    m_panStream->moveToThread(m_networkThread);
+    connect(m_networkThread, &QThread::started, m_panStream, &PanadapterStream::init);
+    m_networkThread->start();
 
-FlexBackend::~FlexBackend() = default;
+    m_connThread = new QThread(this);
+    m_connThread->setObjectName("RadioConnection");
+    m_connection = new RadioConnection;   // no parent — moved to thread
+    m_connection->moveToThread(m_connThread);
+    connect(m_connThread, &QThread::started, m_connection, &RadioConnection::init);
+    m_connThread->start();
 
-void FlexBackend::attachConnection(RadioConnection* conn)
-{
-    if (m_connection == conn) {
-        return;
-    }
-    if (m_connection) {
-        disconnect(m_connection, nullptr, this, nullptr);
-    }
-    m_connection = conn;
-    if (!m_connection) {
-        return;
-    }
     // Observe wire lifecycle and re-emit as the interface's own signals. Queued
     // (auto) connections: the connection lives on its worker thread.
     connect(m_connection, &RadioConnection::connected,
@@ -32,6 +37,44 @@ void FlexBackend::attachConnection(RadioConnection* conn)
             this, &IRadioBackend::disconnected);
     connect(m_connection, &RadioConnection::errorOccurred,
             this, &IRadioBackend::connectionError);
+}
+
+FlexBackend::~FlexBackend()
+{
+    // Teardown in the exact #502 order the former RadioModel dtor used:
+    // connection first (BlockingQueued disconnect → deleteLater → thread
+    // quit/wait), then panStream (BlockingQueued stop → …).
+    if (m_connection && m_connThread && m_connThread->isRunning()) {
+        RadioConnection* connection = m_connection;
+        QMetaObject::invokeMethod(connection, &RadioConnection::disconnectFromRadio,
+                                  Qt::BlockingQueuedConnection);
+        connection->deleteLater();
+        m_connThread->quit();
+        m_connThread->wait(3000);
+    } else {
+        delete m_connection;
+    }
+    if (m_connThread && m_connThread->isRunning()) {
+        m_connThread->quit();
+        m_connThread->wait(3000);
+    }
+    m_connection = nullptr;
+
+    if (m_panStream && m_networkThread && m_networkThread->isRunning()) {
+        PanadapterStream* panStream = m_panStream;
+        QMetaObject::invokeMethod(panStream, &PanadapterStream::stop,
+                                  Qt::BlockingQueuedConnection);
+        panStream->deleteLater();
+        m_networkThread->quit();
+        m_networkThread->wait(3000);
+    } else {
+        delete m_panStream;
+    }
+    if (m_networkThread && m_networkThread->isRunning()) {
+        m_networkThread->quit();
+        m_networkThread->wait(3000);
+    }
+    m_panStream = nullptr;
 }
 
 void FlexBackend::setCommandSink(std::function<void(const QString&)> sink)
@@ -55,7 +98,9 @@ RadioCapabilities FlexBackend::capabilities() const
     // FlexBackend refines these from live radio status as touchpoints convert.
     const ModelCapabilities mc = capabilitiesFor(caps.model);
     caps.maxSlices = mc.maxSlices;
-    caps.maxPanadapters = mc.maxSlices;   // pan capacity tracks slice capacity
+    // approx: pan capacity is not strictly slice count on real Flex hardware;
+    // refined from live radio status in a later touchpoint conversion.
+    caps.maxPanadapters = mc.maxSlices;
     caps.hasExtendedDsp = mc.hasExtendedDsp();
 
     // Every current FlexRadio transmits; RX-only WAN/observer nuance is layered
@@ -64,22 +109,25 @@ RadioCapabilities FlexBackend::capabilities() const
     caps.canTransmit = true;
     caps.hasTuner = true;
 
-    caps.extensionNamespaces = { QStringLiteral("flex") };
+    // Advertise NO extension namespaces yet: no flex verb is routed through the
+    // seam, and invokeExtension() can't produce a reply. Advertising "flex"
+    // would let a client pre-check the namespace and then hang awaiting an
+    // extensionResult/Error that never comes. "flex" is declared here when the
+    // first amp/tuner/DAX verb converts.
     return caps;
 }
 
 void FlexBackend::connectRadio(const RadioConnectRequest& /*request*/)
 {
-    // 2.2 skeleton: RadioModel still orchestrates connect (RadioInfo assembly,
-    // WAN/SmartLink duality, auto-reconnect). The backend will own this in a
-    // later increment once the RadioConnectRequest→RadioInfo adaptation and the
-    // WAN branch move behind the seam.
+    // RadioModel still orchestrates connect (RadioInfo assembly, WAN/SmartLink
+    // duality, auto-reconnect); the backend owns the objects but not yet the
+    // connect flow — that adaptation moves behind the seam in a later increment.
 }
 
 void FlexBackend::disconnectRadio()
 {
-    // 2.2 skeleton: RadioModel still orchestrates the staged gracefulDisconnect
-    // (handle/streamId/seq) and teardown ordering. Owned by the backend later.
+    // RadioModel still orchestrates the staged gracefulDisconnect
+    // (handle/streamId/seq). Owned by the backend later.
 }
 
 bool FlexBackend::isConnected() const
@@ -113,11 +161,16 @@ void FlexBackend::setKeying(bool key)
 }
 
 void FlexBackend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
-                                  quint64 /*requestId*/, const QVariant& /*arg*/)
+                                  quint64 requestId, const QVariant& /*arg*/)
 {
-    // No flex extension verbs are routed through the seam yet; they land with
-    // the amp/tuner/DAX touchpoint conversions. A real reply would arrive via
-    // extensionResult()/extensionError() keyed by requestId.
+    // No flex extension verbs are routed through the seam yet. Honor the async
+    // contract by construction: a caller awaiting a reply (requestId != 0) gets
+    // an error, never a hang. Real verbs land with the amp/tuner/DAX touchpoint
+    // conversions.
+    if (requestId != 0) {
+        emit extensionError(requestId,
+                            QStringLiteral("flex: no extension verbs implemented"));
+    }
 }
 
 void FlexBackend::send(const QString& cmd)

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -41,6 +41,15 @@ FlexBackend::FlexBackend(QObject* parent)
 
 FlexBackend::~FlexBackend()
 {
+    // Sever our own lifecycle observation of the connection FIRST — as the old
+    // ~RadioModel's earlier m_backend.reset() effectively did (the backend was
+    // destroyed, auto-disconnecting these links, before the wire teardown ran).
+    // Otherwise disconnectFromRadio below could re-emit connected/disconnected
+    // through this half-destroyed backend. (#4058 review)
+    if (m_connection) {
+        disconnect(m_connection, nullptr, this, nullptr);
+    }
+
     // Teardown in the exact #502 order the former RadioModel dtor used:
     // connection first (BlockingQueued disconnect → deleteLater → thread
     // quit/wait), then panStream (BlockingQueued stop → …).

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -4,28 +4,27 @@
 
 #include "core/backends/IRadioBackend.h"
 
+class QThread;
+
 namespace AetherSDR {
 
 class RadioConnection;
+class PanadapterStream;
 
-// FlexBackend — the first IRadioBackend implementor (aetherd RFC step 2.2),
+// FlexBackend — the first IRadioBackend implementor (aetherd RFC step 2),
 // wrapping the SmartSDR / FlexRadio wire stack.
 //
-// This is the introductory SKELETON. It is constructed, owned, and torn down by
-// RadioModel inside the real connection lifecycle, and it observes live wire
-// lifecycle events (re-emitting them as the interface's connected/disconnected/
-// connectionError). It does NOT yet:
-//   * absorb ownership of RadioConnection / PanadapterStream or their worker
-//     threads (the #502 ASAN teardown ordering is the migration's single
-//     riskiest move — its own verified increment, 2.2b), nor
-//   * reroute the command hot path (sendCmd) or the slice-0 RX data plane.
-// So this change is purely ADDITIVE and behavior-neutral: nothing above the
-// seam is rerouted through the backend yet.
+// As of 2.2b it OWNS the wire objects: the RadioConnection and PanadapterStream
+// plus their two worker threads, created here in the exact order RadioModel
+// used (panStream thread first, connection thread second) and torn down here in
+// the exact #502 order (BlockingQueued stop → deleteLater → thread quit/wait).
+// RadioModel holds non-owning pointers it obtains via connection()/panStream()
+// and keeps its command/WAN orchestration and its sub-models — so the move is
+// ownership-only and behavior-neutral.
 //
-// The canonical core verbs (setSliceFrequency/Mode/Filter, setKeying) build the
-// exact SmartSDR command strings and emit them through the model-provided
-// command sink. They are correct but not yet on the live path — the touchpoint
-// burndown (2.3) routes each model through them one at a time.
+// The canonical core verbs build the exact SmartSDR command strings and emit
+// them through the model-provided command sink; they grow onto the live path as
+// the touchpoint burndown converts each model (2.3).
 class FlexBackend : public IRadioBackend {
     Q_OBJECT
 
@@ -33,15 +32,18 @@ public:
     explicit FlexBackend(QObject* parent = nullptr);
     ~FlexBackend() override;
 
-    // ---- transitional wiring (2.2: RadioModel still owns these objects) ----
-    // Observe the connection's lifecycle signals (non-owning; the connection
-    // lives on its worker thread, so these arrive via queued connections).
-    void attachConnection(RadioConnection* conn);
+    // The owned wire objects, on their worker threads. Non-owning to callers;
+    // valid for the backend's lifetime. RadioModel grabs these post-construction
+    // and its connection()/panStream() getters delegate to them.
+    RadioConnection*  connection() const { return m_connection; }
+    PanadapterStream* panStream()  const { return m_panStream; }
+
     // Where the core verbs emit their SmartSDR command strings — RadioModel's
     // existing sendCommand() funnel, so verbs reuse the one wire-write path.
     void setCommandSink(std::function<void(const QString&)> sink);
-    // Live model-string source, for capabilities() (avoids caching a value that
-    // changes when the `model` status arrives).
+    // Live model-string source for capabilities(). Call on the main thread,
+    // where RadioModel lives — capabilities() is not thread-safe (no off-thread
+    // caller exists yet; this documents the assumption).
     void setModelProvider(std::function<QString()> provider);
 
     // ---- IRadioBackend ----
@@ -59,7 +61,10 @@ public:
 private:
     void send(const QString& cmd);
 
-    RadioConnection* m_connection{nullptr};   // non-owning in 2.2 (RadioModel owns it)
+    RadioConnection*  m_connection{nullptr};    // owned; lives on m_connThread
+    QThread*          m_connThread{nullptr};    // owned (this-parented)
+    PanadapterStream* m_panStream{nullptr};     // owned; lives on m_networkThread
+    QThread*          m_networkThread{nullptr}; // owned (this-parented)
     std::function<void(const QString&)> m_sink;
     std::function<QString()> m_modelProvider;
 };

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -399,6 +399,12 @@ RadioModel::RadioModel(QObject* parent)
     // tears them down. RadioModel keeps non-owning pointers, obtained here, so
     // all the signal wiring and command/WAN orchestration below is byte-for-byte
     // as before — the move is ownership-only.
+    //
+    // Note: the threads now start here (as the ctor's first statement) rather
+    // than adjacent to their signal wiring below. Safe because RadioConnection::
+    // init()/PanadapterStream::init() only allocate sockets/timers and neither
+    // auto-connects nor emits — so there is no lost-signal window before our
+    // statusReceived/etc. connections are made. Keep that true if init() grows.
     {
         auto flex = std::make_unique<FlexBackend>();
         flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -393,13 +393,20 @@ QJsonObject clientInfoToJson(quint32 handle,
 RadioModel::RadioModel(QObject* parent)
     : QObject(parent)
 {
-    // PanadapterStream runs on its own network thread (#502)
-    m_networkThread = new QThread(this);
-    m_networkThread->setObjectName("PanadapterStream");
-    m_panStream = new PanadapterStream;  // no parent — will be moved to thread
-    m_panStream->moveToThread(m_networkThread);
-    connect(m_networkThread, &QThread::started, m_panStream, &PanadapterStream::init);
-    m_networkThread->start();
+    // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
+    // FlexBackend creates the RadioConnection and PanadapterStream on their
+    // worker threads (in the load-bearing #502 order — panStream first) and
+    // tears them down. RadioModel keeps non-owning pointers, obtained here, so
+    // all the signal wiring and command/WAN orchestration below is byte-for-byte
+    // as before — the move is ownership-only.
+    {
+        auto flex = std::make_unique<FlexBackend>();
+        flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });
+        flex->setModelProvider([this]{ return m_model; });
+        m_connection = flex->connection();   // non-owning; the backend owns it
+        m_panStream  = flex->panStream();    // non-owning; the backend owns it
+        m_backend = std::move(flex);
+    }
 
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
     // WHEN a dax_rx stream must exist (refcounted acquire/release from the
@@ -438,15 +445,8 @@ RadioModel::RadioModel(QObject* parent)
         sendCommand(QString("stream remove 0x%1").arg(streamId, 0, 16));
     });
 
-    // RadioConnection runs on its own worker thread (#502) so TCP I/O
-    // (including ping RTT measurement) is never blocked by paintEvent.
-    m_connThread = new QThread(this);
-    m_connThread->setObjectName("RadioConnection");
-    m_connection = new RadioConnection;  // no parent — will be moved to thread
-    m_connection->moveToThread(m_connThread);
-    connect(m_connThread, &QThread::started, m_connection, &RadioConnection::init);
-    m_connThread->start();
-
+    // RadioConnection (created + owned by the backend above, on its own worker
+    // thread #502 so TCP I/O never blocks paintEvent) — wire its signals to us.
     // Signals from RadioConnection auto-queue to main thread (#502)
     connect(m_connection, &RadioConnection::statusReceived,
             this, &RadioModel::onStatusReceived);
@@ -475,19 +475,6 @@ RadioModel::RadioModel(QObject* parent)
     // Forward VITA-49 meter packets to MeterModel (cross-thread, auto-queued)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
-
-    // aetherd RFC step 2.2: introduce the radio-facing seam (§5.5). The backend
-    // observes the connection lifecycle and carries the core-verb scaffold; it
-    // does not yet own the wire objects or sit on the command hot path, so this
-    // is purely additive / behavior-neutral. Constructed here so it is wired
-    // before any status arrives and torn down first in ~RadioModel.
-    {
-        auto flex = std::make_unique<FlexBackend>();
-        flex->attachConnection(m_connection);
-        flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });
-        flex->setModelProvider([this]{ return m_model; });
-        m_backend = std::move(flex);
-    }
 
     // Forward tuner commands to the radio — route through tune inhibit check
     connect(&m_tunerModel, &TunerModel::commandReady, this, [this](const QString& cmd){
@@ -646,48 +633,18 @@ RadioModel::RadioModel(QObject* parent)
 
 RadioModel::~RadioModel()
 {
-    // Destroy the backend first, while m_connection is still alive, so its
-    // observation of the connection's lifecycle signals tears down cleanly
-    // (FlexBackend is a QObject; ~QObject auto-disconnects). (aetherd 2.2)
-    m_backend.reset();
-
-    // Disconnect all signals BEFORE member destruction to prevent
-    // use-after-free (ASAN). (#502)
+    // Disconnect RadioModel's own connections to the wire objects BEFORE they
+    // are torn down, to prevent use-after-free (ASAN). (#502) The objects are
+    // still alive here — the backend owns them and destroys them next.
     QObject::disconnect(m_connection, nullptr, this, nullptr);
     QObject::disconnect(m_panStream, nullptr, this, nullptr);
 
-    // Stop connection thread (#502)
-    if (m_connection && m_connThread && m_connThread->isRunning()) {
-        RadioConnection* connection = m_connection;
-        QMetaObject::invokeMethod(connection, &RadioConnection::disconnectFromRadio,
-                                  Qt::BlockingQueuedConnection);
-        connection->deleteLater();
-        m_connThread->quit();
-        m_connThread->wait(3000);
-    } else {
-        delete m_connection;
-    }
-    if (m_connThread && m_connThread->isRunning()) {
-        m_connThread->quit();
-        m_connThread->wait(3000);
-    }
+    // Destroy the backend, which owns the RadioConnection + PanadapterStream and
+    // their worker threads: ~FlexBackend runs the exact #502 teardown ordering
+    // (BlockingQueued disconnect/stop → deleteLater → thread quit/wait) that
+    // used to live here. (aetherd 2.2b)
+    m_backend.reset();
     m_connection = nullptr;
-
-    // Stop network thread (#502)
-    if (m_panStream && m_networkThread && m_networkThread->isRunning()) {
-        PanadapterStream* panStream = m_panStream;
-        QMetaObject::invokeMethod(panStream, &PanadapterStream::stop,
-                                  Qt::BlockingQueuedConnection);
-        panStream->deleteLater();
-        m_networkThread->quit();
-        m_networkThread->wait(3000);
-    } else {
-        delete m_panStream;
-    }
-    if (m_networkThread && m_networkThread->isRunning()) {
-        m_networkThread->quit();
-        m_networkThread->wait(3000);
-    }
     m_panStream = nullptr;
 }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -41,7 +41,7 @@
 
 namespace AetherSDR {
 
-class IRadioBackend;   // aetherd RFC §5.5 radio-facing seam (owned by value below)
+class IRadioBackend;   // aetherd RFC §5.5 radio-facing seam (owned via unique_ptr below)
 
 // RadioModel is the central data model for a connected radio.
 // It owns the RadioConnection, processes incoming status messages,
@@ -664,18 +664,17 @@ private:
     void stageSessionModelsForReconnect();
     void pruneStaleSessionModels(quint64 generation);
 
-    RadioConnection*  m_connection{nullptr};
-    QThread*          m_connThread{nullptr};
-    // aetherd RFC step 2.2: the radio-facing seam (§5.5). RadioModel owns the
-    // backend; in 2.2 it observes the connection lifecycle and carries the
-    // core-verb scaffold. Ownership of the wire objects moves into it later.
+    // aetherd RFC step 2 (§5.5): the radio-facing seam. Held via std::unique_ptr
+    // (owned via unique_ptr below). As of 2.2b it OWNS the RadioConnection +
+    // PanadapterStream and their worker threads; RadioModel keeps the two
+    // NON-OWNING pointers below, obtained from the backend at construction.
     std::unique_ptr<IRadioBackend> m_backend;
+    RadioConnection*  m_connection{nullptr};   // non-owning — owned by m_backend
     // Sequence counter and callback map — owned by RadioModel on main thread.
     // RadioConnection no longer manages callbacks. (#502)
     std::atomic<quint32> m_seqCounter{1};
     QMap<quint32, ResponseCallback> m_pendingCallbacks;
-    PanadapterStream* m_panStream{nullptr};
-    QThread*          m_networkThread{nullptr};
+    PanadapterStream* m_panStream{nullptr};    // non-owning — owned by m_backend
     // Sub-models — value members on main thread (#502)
     MeterModel       m_meterModel;
     TunerModel       m_tunerModel;

--- a/tests/flex_backend_lifecycle_test.cpp
+++ b/tests/flex_backend_lifecycle_test.cpp
@@ -1,0 +1,65 @@
+// Regression guard for aetherd RFC step 2.2b: FlexBackend owns the
+// RadioConnection + PanadapterStream and their two worker threads. It locks in
+// the #502 creation order (PanadapterStream thread first, RadioConnection
+// thread second) and the teardown ordering (BlockingQueued disconnect/stop →
+// deleteLater → thread quit/wait) that 2.2b relocated out of RadioModel — so a
+// future refactor of that ctor/dtor pair has an automated tripwire, not just a
+// one-time manual check. (#4058 review, @NF0T)
+
+#include "core/backends/flex/FlexBackend.h"
+#include "core/RadioConnection.h"
+#include "core/PanadapterStream.h"
+
+#include <QCoreApplication>
+#include <QThread>
+
+#include <cstdio>
+#include <memory>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // Construct/destruct repeatedly: a broken #502 teardown tends to hang
+    // (thread wait) or crash on the 2nd+ cycle rather than the 1st.
+    for (int i = 0; i < 3; ++i) {
+        auto backend = std::make_unique<FlexBackend>();
+
+        RadioConnection* conn = backend->connection();
+        PanadapterStream* pan = backend->panStream();
+        check(conn != nullptr, "connection() is null after construction");
+        check(pan != nullptr, "panStream() is null after construction");
+
+        // The wire objects must live on their own worker threads (moved off the
+        // main thread), and on two distinct threads.
+        if (conn && pan) {
+            check(conn->thread() != QThread::currentThread(),
+                  "RadioConnection is on the main thread");
+            check(pan->thread() != QThread::currentThread(),
+                  "PanadapterStream is on the main thread");
+            check(conn->thread() != pan->thread(),
+                  "connection and panStream share a worker thread");
+        }
+
+        check(!backend->isConnected(), "fresh backend reports connected");
+
+        // ~FlexBackend runs the #502 teardown; must not hang or crash.
+        backend.reset();
+    }
+
+    if (g_failures == 0) {
+        std::printf("flex_backend_lifecycle_test: OK (3 ctor/dtor cycles)\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The wire/thread **ownership move** — the migration's single riskiest step, done as one PR. `FlexBackend` now owns the `RadioConnection` + `PanadapterStream` and their two worker threads; `RadioModel` reaches them through non-owning pointers. **Ownership-only, behavior-neutral by construction.**

### What moves
- **Creation** (the load-bearing #502 order: panStream thread first, connection thread second) and **teardown** (`BlockingQueued` disconnect/stop → `deleteLater` → thread quit/wait) move **verbatim** out of `RadioModel`'s ctor/dtor into `FlexBackend`'s.
- `RadioModel` keeps **non-owning** `m_connection`/`m_panStream` pointers, grabbed from the backend at construction — so all ~100 internal usages and the public `connection()`/`panStream()` getters (including the slice-0 RX data plane: `MainWindow` spectrumReady/waterfallRowReady/audioDataReady) are **byte-for-byte unchanged**.
- `~RadioModel` disconnects its own signal links to the wire objects (ASAN guard, #502) then resets the backend, which runs the exact relocated teardown.
- WAN/command orchestration and all sub-models stay in `RadioModel`.

### Also folds in the four #4056 review nits
`invokeExtension` emits `extensionError` for `requestId != 0` (honors the async contract — no hang); `capabilities()` advertises no extension namespace until a verb converts; `maxPanadapters` "approx" comment; `RadioModel.h` "owned via unique_ptr" wording; `capabilities()` main-thread note.

### Verification (the #502 + RX-plane risks specifically)
- Clean build; boundary `--strict` green; **64/64 tests** — including the new `flex_backend_lifecycle_test`, which constructs and destructs a headless `FlexBackend` 3× (asserting the two wire objects land on distinct worker threads and the #502 teardown runs without hang/crash) — a real regression guard for exactly the ctor/dtor ordering this PR relocates. **(Correction: an earlier version of this line wrongly claimed `slice_recreate_policy_test` covered this — it does not; no prior test constructed a RadioModel. Added the real test per @NF0T.)**
- `verify_slice0_rx.py` **FULL PASS** on a live FLEX-8600 (connect → slice-0 RX → TX-guard refusal).
- **Live panadapter GPU grab renders through the backend-owned `PanadapterStream`** — the RX/waterfall/audio plane is intact (screenshot verified: live 40m spectrum + waterfall).
- **disconnect → reconnect cycle** clean with the backend-owned connection; no ASAN/segfault on exit.

Next: **2.3** — split the five `mixed` models, as one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)