### PR TITLE
chore(warnings): complete Phase 1 — fix 2 struct literals missed by #4046 (#4031)

### DIFF
--- a/src/gui/MainWindow_ReceiveSync.cpp
+++ b/src/gui/MainWindow_ReceiveSync.cpp
@@ -471,7 +471,8 @@ MainWindow::ReceiveSyncTarget MainWindow::resolveReceiveSyncTarget() const
         if (receiveSyncAudioAudible(slice->flexAudioMute(),
                                     slice->flexAudioGain())) {
             flexCandidates.append({.sliceId = slice->sliceId(),
-                                   .frequencyHz = frequencyHz});
+                                   .frequencyHz = frequencyHz,
+                                   .kiwiProfileId = QString()});
         }
     }
 

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -270,8 +270,10 @@ void AntennaGeniusModel::disconnectFromDevice()
     m_deliberateDisconnect = false;
     m_antennas.clear();
     m_bands.clear();
-    m_portA = AgPortStatus{1};
-    m_portB = AgPortStatus{2};
+    m_portA = AgPortStatus{};
+    m_portA.portId = 1;
+    m_portB = AgPortStatus{};
+    m_portB.portId = 2;
     m_pending.clear();
 }
 


### PR DESCRIPTION
## Summary

Refs #4031. While re-deriving the current warning inventory for Phases 3/4
(clean rebuild against current `main`), I found 3 `-Wmissing-field-initializers`
warnings that were explicitly part of the RFC's Phase 1 scope but were never
actually fixed — `git log`/the PR #4046 diff confirm neither file below was
touched by that PR, despite the issue's Phase 1 checkbox being marked done.

- `src/models/AntennaGeniusModel.cpp:273-274` — `AgPortStatus{1}` / `AgPortStatus{2}`
  partially initialize the 8-member aggregate positionally, leaving the rest
  implicit. Changed to default-construct-then-assign
  (`AgPortStatus{}; portId = N;`).
- `src/gui/MainWindow_ReceiveSync.cpp:473` — the `flexCandidates.append({...})`
  designated-init literal omitted `.kiwiProfileId`, unlike the sibling
  `kiwiCandidates.append({...})` three lines above that lists all three
  fields. Added `.kiwiProfileId = QString()` to match.

No behavior change in either case — the omitted fields already got these
same values via in-class default member initializers; this just makes it
explicit so GCC stops flagging it.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. Verified by re-deriving the actual
warning inventory from a clean build rather than trusting the issue's
"Phase 1 done" checkbox.

## Test plan

- [x] Local build passes (`cmake --build build`) — confirmed both files
      individually recompile with zero warnings after the fix
- [ ] Behavior verified on a real radio if applicable — n/a, no behavior change
- [x] Existing tests pass (CI) — full local `ctest` 63/63 green
- [x] Reproduction steps documented — see Summary

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI touched
- [ ] Documentation updated — n/a, no user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA — n/a