### PR TITLE
chore(warnings): Phase 3 — C++20 [=] implicit-this captures (#4031). Principle VIII.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5039,7 +5039,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 quint16 cPort = static_cast<quint16>(cs.value("DxClusterPort", 7300).toInt());
                 QString call = cs.value("DxClusterCallsign").toString();
                 if (!call.isEmpty() && !m_dxCluster->isConnected())
-                    QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->connectToCluster(host, cPort, call); });
+                    QMetaObject::invokeMethod(m_dxCluster, [=, this] { m_dxCluster->connectToCluster(host, cPort, call); });
             }
             // Auto-connect RBN if enabled
             if (cs.value("RbnAutoConnect", "False").toString() == "True") {
@@ -5049,26 +5049,26 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 if (call.isEmpty())
                     call = cs.value("DxClusterCallsign").toString();
                 if (!call.isEmpty() && !m_rbnClient->isConnected())
-                    QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->connectToCluster(host, rPort, call); });
+                    QMetaObject::invokeMethod(m_rbnClient, [=, this] { m_rbnClient->connectToCluster(host, rPort, call); });
             }
             // Auto-start WSJT-X listener if enabled
             if (cs.value("WsjtxAutoStart", "False").toString() == "True") {
                 QString wAddr = cs.value("WsjtxAddress", "224.0.0.1").toString();
                 quint16 wPort = static_cast<quint16>(cs.value("WsjtxPort", 2237).toInt());
                 if (!m_wsjtxClient->isListening())
-                    QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->startListening(wAddr, wPort); });
+                    QMetaObject::invokeMethod(m_wsjtxClient, [=, this] { m_wsjtxClient->startListening(wAddr, wPort); });
             }
             // Auto-start SpotCollector listener if enabled
             if (cs.value("SpotCollectorAutoStart", "False").toString() == "True") {
                 quint16 scPort = static_cast<quint16>(cs.value("SpotCollectorPort", 9999).toInt());
                 if (!m_spotCollectorClient->isListening())
-                    QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->startListening(scPort); });
+                    QMetaObject::invokeMethod(m_spotCollectorClient, [=, this] { m_spotCollectorClient->startListening(scPort); });
             }
             // Auto-start POTA polling if enabled
             if (cs.value("PotaAutoStart", "False").toString() == "True") {
                 int pInterval = cs.value("PotaPollInterval", 60).toInt();
                 if (!m_potaClient->isPolling())
-                    QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->startPolling(pInterval); });
+                    QMetaObject::invokeMethod(m_potaClient, [=, this] { m_potaClient->startPolling(pInterval); });
             }
 #ifdef HAVE_WEBSOCKETS
             // Auto-start FreeDV Reporter if enabled
@@ -5160,11 +5160,11 @@ void MainWindow::onConnectionStateChanged(bool connected)
         }
         if (m_swrSweep.running)
             finishSwrSweep(true, QStringLiteral("SWR sweep stopped on disconnect"));
-        QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); });
-        QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->disconnect(); });
-        QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->stopListening(); });
-        QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->stopListening(); });
-        QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->stopPolling(); });
+        QMetaObject::invokeMethod(m_dxCluster, [=, this] { m_dxCluster->disconnect(); });
+        QMetaObject::invokeMethod(m_rbnClient, [=, this] { m_rbnClient->disconnect(); });
+        QMetaObject::invokeMethod(m_wsjtxClient, [=, this] { m_wsjtxClient->stopListening(); });
+        QMetaObject::invokeMethod(m_spotCollectorClient, [=, this] { m_spotCollectorClient->stopListening(); });
+        QMetaObject::invokeMethod(m_potaClient, [=, this] { m_potaClient->stopPolling(); });
 #ifdef HAVE_WEBSOCKETS
         QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); });
 #endif

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -408,34 +408,34 @@ void MainWindow::buildMenuBar()
         });
         connect(dlg, &DxClusterDialog::connectRequested,
                 this, [this](const QString& host, quint16 port, const QString& call) {
-            QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->connectToCluster(host, port, call); });
+            QMetaObject::invokeMethod(m_dxCluster, [=, this] { m_dxCluster->connectToCluster(host, port, call); });
         });
         connect(dlg, &DxClusterDialog::disconnectRequested,
-                this, [this] { QMetaObject::invokeMethod(m_dxCluster, [=] { m_dxCluster->disconnect(); }); });
+                this, [this] { QMetaObject::invokeMethod(m_dxCluster, [=, this] { m_dxCluster->disconnect(); }); });
         connect(dlg, &DxClusterDialog::rbnConnectRequested,
                 this, [this](const QString& host, quint16 port, const QString& call) {
-            QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->connectToCluster(host, port, call); });
+            QMetaObject::invokeMethod(m_rbnClient, [=, this] { m_rbnClient->connectToCluster(host, port, call); });
         });
         connect(dlg, &DxClusterDialog::rbnDisconnectRequested,
-                this, [this] { QMetaObject::invokeMethod(m_rbnClient, [=] { m_rbnClient->disconnect(); }); });
+                this, [this] { QMetaObject::invokeMethod(m_rbnClient, [=, this] { m_rbnClient->disconnect(); }); });
         connect(dlg, &DxClusterDialog::wsjtxStartRequested,
                 this, [this](const QString& addr, quint16 port) {
-            QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->startListening(addr, port); });
+            QMetaObject::invokeMethod(m_wsjtxClient, [=, this] { m_wsjtxClient->startListening(addr, port); });
         });
         connect(dlg, &DxClusterDialog::wsjtxStopRequested,
-                this, [this] { QMetaObject::invokeMethod(m_wsjtxClient, [=] { m_wsjtxClient->stopListening(); }); });
+                this, [this] { QMetaObject::invokeMethod(m_wsjtxClient, [=, this] { m_wsjtxClient->stopListening(); }); });
         connect(dlg, &DxClusterDialog::spotCollectorStartRequested,
                 this, [this](quint16 port) {
-            QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->startListening(port); });
+            QMetaObject::invokeMethod(m_spotCollectorClient, [=, this] { m_spotCollectorClient->startListening(port); });
         });
         connect(dlg, &DxClusterDialog::spotCollectorStopRequested,
-                this, [this] { QMetaObject::invokeMethod(m_spotCollectorClient, [=] { m_spotCollectorClient->stopListening(); }); });
+                this, [this] { QMetaObject::invokeMethod(m_spotCollectorClient, [=, this] { m_spotCollectorClient->stopListening(); }); });
         connect(dlg, &DxClusterDialog::potaStartRequested,
                 this, [this](int interval) {
-            QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->startPolling(interval); });
+            QMetaObject::invokeMethod(m_potaClient, [=, this] { m_potaClient->startPolling(interval); });
         });
         connect(dlg, &DxClusterDialog::potaStopRequested,
-                this, [this] { QMetaObject::invokeMethod(m_potaClient, [=] { m_potaClient->stopPolling(); }); });
+                this, [this] { QMetaObject::invokeMethod(m_potaClient, [=, this] { m_potaClient->stopPolling(); }); });
 #ifdef HAVE_WEBSOCKETS
         connect(dlg, &DxClusterDialog::freedvStartRequested,
                 this, [this] { QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->startConnection(); }); });

--- a/src/gui/StripFinalOutputPanel.cpp
+++ b/src/gui/StripFinalOutputPanel.cpp
@@ -1060,7 +1060,7 @@ void StripFinalOutputPanel::showQuindarEditor()
     };
     refreshFieldsForStyle();
 
-    auto setStyle = [=](bool morse) {
+    auto setStyle = [=, this](bool morse) {
         toneStyleBtn->setChecked(!morse);
         morseStyleBtn->setChecked(morse);
         if (auto* qt = m_audio->clientQuindarTone()) {


### PR DESCRIPTION
## Summary

Refs #4031 (do not close — Phase 4 and the zero-warning-enforcement step
remain open). Fixes all 21 current `-Wdeprecated` ("implicit capture of
'this' via '[=]' is deprecated in C++20") warnings across the three files
the RFC scoped for Phase 3:

- `src/gui/MainWindow.cpp` — 10 sites
- `src/gui/MainWindow_Menus.cpp` — 10 sites
- `src/gui/StripFinalOutputPanel.cpp` — 1 site

**Correction versus the RFC's proposed fix.** The RFC described this as a
mechanical `[=]` → `[this]` substitution, claiming all 21 sites use `this`
as their sole capture. That holds for about half of them, but the other
half — the `QMetaObject::invokeMethod` lambdas taking `host`/`port`/`call`/
`addr`/`interval`-style parameters — also capture local by-value variables
alongside the implicit `this`, e.g. `MainWindow.cpp`'s
`[=] { m_dxCluster->connectToCluster(host, cPort, call); }`. A bare `[this]`
there would fail to compile (`host`/`cPort`/`call` wouldn't be captured).

Used `[=]` → `[=, this]` uniformly at all 21 sites instead — this is GCC's
own suggested fix ("add explicit 'this' or '*this' capture") and is
provably a no-op change in capture semantics everywhere: every existing
by-value capture stays exactly as it was, and only the previously-implicit
`this` capture becomes explicit, whether or not a site also captures other
locals. No per-site judgment call needed, no behavior change anywhere.

Also verified: the RFC implied 3 more occurrences in
`StripFinalOutputPanel.cpp` (`refreshFieldsForStyle` and two
`toneStyleBtn`/`morseStyleBtn` `connect()` lambdas). Those don't actually
warn — their bodies only reference locally-captured widget pointers and
never need `this`, so the compiler never implicitly captures it there.
Left unchanged; confirmed via a full clean-build inventory that only line
1063 triggers `-Wdeprecated` in this file.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. Every one of the 21 sites was
individually read and verified (not batch-assumed) before deciding
`[=, this]` was safe there; the RFC's own claim about capture composition
was checked against actual source rather than taken on trust.

## Test plan

- [x] Local build passes (`cmake --build build`) — clean rebuild of all
      three touched files shows zero `-Wdeprecated` warnings, no new
      warnings introduced
- [ ] Behavior verified on a real radio if applicable — n/a, capture-list
      syntax change only, no runtime behavior difference
- [x] Existing tests pass (CI) — full local `ctest` 63/63 green
- [x] Reproduction steps documented — see Summary

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI touched
- [ ] Documentation updated — n/a, no user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA — n/a