### PR TITLE
chore(warnings): Phase 4 — MSVC /W3 exclusive warnings (#4031). Principle VIII.

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -5660,7 +5660,7 @@ void AudioEngine::processNr2(const QByteArray& stereoPcm,
 
 QByteArray AudioEngine::applyBoost(const QByteArray& pcm, float gain) const
 {
-    const int nSamples = pcm.size() / sizeof(int16_t);
+    const int nSamples = static_cast<int>(pcm.size() / sizeof(int16_t));
     const auto* src = reinterpret_cast<const int16_t*>(pcm.constData());
     QByteArray out(pcm.size(), Qt::Uninitialized);
     auto* dst = reinterpret_cast<int16_t*>(out.data());
@@ -6783,7 +6783,7 @@ void AudioEngine::feedDaxTxAudio(const QByteArray& inPcm)
     // P/CW mic gauge shows DAX audio level regardless of mic profile (#517)
     {
         const auto* src = reinterpret_cast<const float*>(float32pcm.constData());
-        const int samples = float32pcm.size() / sizeof(float);
+        const int samples = static_cast<int>(float32pcm.size() / sizeof(float));
         float peak = 0.0f;
         double sumSq = 0.0;
         for (int i = 0; i < samples; ++i) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -4923,7 +4923,7 @@ QJsonObject AutomationServer::doLog(const QString& action, const QString& arg,
     }
 
     if (action == QLatin1String("unsubscribe")) {
-        const bool was = sock && m_logSubscribers.remove(sock) > 0;
+        const bool was = sock && m_logSubscribers.remove(sock);
         if (m_logSubscribers.isEmpty() && m_logDrain)
             m_logDrain->stop();
         return QJsonObject{{QStringLiteral("ok"), true},

--- a/src/core/OpusCodec.cpp
+++ b/src/core/OpusCodec.cpp
@@ -95,7 +95,7 @@ QByteArray OpusCodec::encode(const QByteArray& pcmStereo)
     if (!m_encoder || pcmStereo.isEmpty()) return {};
 
     // Input: stereo int16 interleaved, FRAME_SIZE sample frames (240 × 2 channels)
-    int totalSamples = pcmStereo.size() / sizeof(int16_t);
+    int totalSamples = static_cast<int>(pcmStereo.size() / sizeof(int16_t));
     int frameSamples = totalSamples / CHANNELS;  // per-channel sample count
 
     // Opus needs exactly FRAME_SIZE samples per channel per encode call

--- a/src/core/RADEEngine.cpp
+++ b/src/core/RADEEngine.cpp
@@ -269,7 +269,7 @@ void RADEEngine::feedTxAudio(const QByteArray& pcm)
 
     // Process 10ms frames (LPCNET_FRAME_SIZE = 160 samples @ 16kHz)
     while ((m_txAccum.size() / sizeof(int16_t)) >= LPCNET_FRAME_SIZE || (m_eooRequested && !m_txAccum.isEmpty())) {
-        int nToTake = std::min<int>(LPCNET_FRAME_SIZE, m_txAccum.size() / sizeof(int16_t));
+        int nToTake = std::min<int>(LPCNET_FRAME_SIZE, static_cast<int>(m_txAccum.size() / sizeof(int16_t)));
         QByteArray sampleArray = m_txAccum.left(nToTake * sizeof(int16_t));
         m_txAccum.remove(0, sampleArray.size());
 
@@ -292,7 +292,7 @@ void RADEEngine::feedTxAudio(const QByteArray& pcm)
     int n_features_in = rade_n_features_in_out(m_rade);
     int n_tx_out = rade_n_tx_out(m_rade);
     while ((m_txFeatAccum.size() / static_cast<qsizetype>(sizeof(float))) >= qsizetype(n_features_in) || (m_eooRequested && !m_txFeatAccum.isEmpty())) {
-        int nFeatures = m_txFeatAccum.size() / sizeof(float);
+        int nFeatures = static_cast<int>(m_txFeatAccum.size() / sizeof(float));
         int nToProcess = std::min(n_features_in, nFeatures);
         
         std::vector<float> feat_in(n_features_in, 0.0f);

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -29,6 +29,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "SpectralNR.h"
 #include "LogManager.h"
+#include <QByteArray>
 #include <algorithm>
 #include <cstdio>
 #include <cmath>
@@ -280,9 +281,9 @@ SpectralNR::WisdomResult SpectralNR::generateWisdom(const std::string& directory
     // This gives us a head start if Thetis is installed
 #ifdef _WIN32
     {
-        const char* appData = std::getenv("APPDATA");
-        if (appData) {
-            std::string thetisWisdom = std::string(appData)
+        const QByteArray appData = qgetenv("APPDATA");
+        if (!appData.isEmpty()) {
+            std::string thetisWisdom = std::string(appData.constData())
                 + "\\OpenHPSDR\\Thetis-x64\\wdspWisdom00";
             std::lock_guard<std::mutex> lock(s_fftwMutex);
             if (fftw_import_wisdom_from_filename(thetisWisdom.c_str())) {

--- a/src/core/SpectralNR.h
+++ b/src/core/SpectralNR.h
@@ -71,9 +71,9 @@ public:
     void setGainMax(float v)    { m_gainMax.store(v); }
     void setQspp(float v)      { m_qSpp.store(v); }
     void setGainSmooth(float v) { m_gainSmooth.store(v); }
-    float gainMax() const       { return m_gainMax.load(); }
-    float qspp() const         { return m_qSpp.load(); }
-    float gainSmooth() const    { return m_gainSmooth.load(); }
+    float gainMax() const       { return static_cast<float>(m_gainMax.load()); }
+    float qspp() const         { return static_cast<float>(m_qSpp.load()); }
+    float gainSmooth() const    { return static_cast<float>(m_gainSmooth.load()); }
 
     // Gain method: 0=Linear, 1=Log, 2=Gamma (default, MMSE-LSA), 3=Trained
     void setGainMethod(int m)   { m_gainMethod.store(m); }

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1726,7 +1726,7 @@ bool ThemeManager::eventFilter(QObject* watched, QEvent* event)
 void ThemeManager::clearWidgetTracking(QWidget* widget)
 {
     if (!widget) return;
-    if (m_trackedWidgets.remove(widget) > 0) {
+    if (m_trackedWidgets.remove(widget)) {
         QObject::disconnect(widget, &QObject::destroyed,
                             this, &ThemeManager::onTrackedWidgetDestroyed);
     }

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -523,7 +523,7 @@ void SmartMtrWidget::drawTypeLabel(QPainter& p, const SmartMtrGeometry& g) const
     p.setFont(f);
 
     QColor c(255, 255, 255);
-    c.setAlphaF(0.6); // white, 60% opacity
+    c.setAlphaF(0.6f); // white, 60% opacity
     p.setPen(c);
 
     // Bound the label to the marker span [kScaleMin, kScaleMax] so it never sits

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5631,7 +5631,7 @@ void RadioModel::handleSliceStatus(int id,
             m_ownedSliceIds.insert(id);
             // If this slot was previously foreign (e.g. another client
             // released it and we just got assigned), drop the foreign mark.
-            if (m_foreignSliceOwners.remove(id) > 0) {
+            if (m_foreignSliceOwners.remove(id)) {
                 emit slotOccupancyChanged(id);
             }
             qCDebug(lcProtocol) << "RadioModel: slice" << id << "is ours (client_handle match)";
@@ -5680,7 +5680,7 @@ void RadioModel::handleSliceStatus(int id,
             emit sliceRemoved(id);
             stale->deleteLater();
             emit slotOccupancyChanged(id);
-        } else if (m_foreignSliceOwners.remove(id) > 0) {
+        } else if (m_foreignSliceOwners.remove(id)) {
             // Foreign client released their slot — clear the dim marker.
             emit slotOccupancyChanged(id);
         }


### PR DESCRIPTION
## Summary

Refs #4031 (tracking issue stays open — the post-Phase-4 zero-warning CI
enforcement step is still outstanding). Fixes all 12 current MSVC `/W3`
warnings in `src/`, re-derived from the actual `check-windows` CI log for
the latest `main` run (run 28750499293, commit `3880b2eb`) rather than
trusting the RFC's `104ebca6` snapshot — line numbers had drifted but all
12 items were still present, unresolved by anything that landed since, and
no new `src/` items appeared.

**Two files here are Tier 1** (`src/models/RadioModel.cpp`,
`src/core/AudioEngine.cpp`) — flagging per @ten9876's own note in the issue
thread that Phase 4's "Tier 3" label was wrong, same as Phase 1's was.

- **C4267** `size_t`→`int` (`AudioEngine.cpp` ×2, `OpusCodec.cpp`,
  `RADEEngine.cpp` ×2): each is a buffer-length division
  (`byteArray.size() / sizeof(T)`) bounded by realistic audio buffer sizes,
  nowhere near `INT_MAX`. Added explicit `static_cast<int>` to document the
  intentional narrowing.
- **C4996** `getenv` (`SpectralNR.cpp:283`, inside `#ifdef _WIN32` — explains
  why GCC never saw it): replaced `std::getenv("APPDATA")` with `qgetenv()`,
  Qt's cross-platform wrapper, adjusting the null-check/`std::string`
  construction to `QByteArray`'s API.
- **C4244** `double`→`float` (`SpectralNR.h` ×3): the `gainMax`/`qspp`/
  `gainSmooth` getters return `float` but read from `std::atomic<double>`
  members — explicit `static_cast<float>` on each return.
- **C4305** double truncated to float (`SmartMtrWidget.cpp:526`): `0.6`
  literal into `QColor::setAlphaF(float)` — added the `f` suffix.
- **C4804** `bool` used as operand to `>` (`AutomationServer.cpp`,
  `ThemeManager.cpp`, `RadioModel.cpp` ×2): all four are the identical
  pattern, `QHash::remove(key) > 0`. Confirmed in the installed Qt6 headers
  that plain `QHash::remove()` returns `bool` (not a count — that's
  `QMultiHash`), so this was genuinely comparing a bool against `0`, but
  produces the exact same result as the bool alone. Per @ten9876's guidance,
  this is the "intentionally boolean, no behavior change" bucket, not the
  "stop and flag it" bucket — none of the four are latent bugs. Dropped the
  redundant `> 0`.

No behavior change in any of the 12 fixes.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The inventory driving this PR
came from reading the actual `check-windows` CI log for current `main`,
not from re-running the RFC's stale line numbers or asserting the fix was
correct without checking Qt's actual `QHash::remove()` return type.

## Test plan

- [x] Local build passes (`cmake --build build`) — full clean rebuild of
      all 9 touched files, zero new warnings (GCC continues to build these
      files warning-free, as before — these are MSVC-only diagnostics GCC
      never emitted, so a GCC build can't confirm the fix, only that
      nothing regressed)
- [ ] Behavior verified on a real radio — n/a, no behavior change; see
      note below on MSVC verification
- [x] Existing tests pass (CI) — full local `ctest` 63/63 green, including
      `spectral_nr_test` and `theme_manager_test` which directly exercise
      two of the touched files
- [x] Reproduction steps documented — see Summary

**MSVC verification note:** No MSVC/Wine toolchain available in this dev
environment, so this PR's actual pass/fail signal is a green
`check-windows` CI run once pushed — GCC can't reproduce or confirm C4xxx
diagnostics at all. Requesting that be checked before merge rather than
relying on the local build above.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI touched
- [ ] Documentation updated — n/a, no user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA — n/a