### PR TITLE
chore(warnings): close a Linux-native-GCC coverage gap in the #4031 inventory (#4031)

### DIFF
--- a/src/core/HidEncoderManager.cpp
+++ b/src/core/HidEncoderManager.cpp
@@ -850,7 +850,7 @@ void HidEncoderManager::setTMate2Indicators(bool tx, const QString& mode,
 
 void HidEncoderManager::setTMate2OverlayIndicators(const QString& overlayType,
                                                     int overlayValue,
-                                                    const QString& mode)
+                                                    const QString& /* mode */)
 {
     if (!m_device || !isTMate2()) return;
 

--- a/src/core/PipeWireAudioBridge.cpp
+++ b/src/core/PipeWireAudioBridge.cpp
@@ -491,7 +491,9 @@ void PipeWireAudioBridge::feedSilenceToAllPipes()
 
     // Write silence (zero float32 samples) to each active RX path.
     QByteArray silence(monoSamples * static_cast<int>(sizeof(float)), '\0');
+#ifdef HAVE_PIPEWIRE_NATIVE
     const auto* silenceFloat = reinterpret_cast<const float*>(silence.constData());
+#endif
     for (int i = 0; i < NUM_CHANNELS; ++i) {
 #ifdef HAVE_PIPEWIRE_NATIVE
         if (m_nativeRx[i]) {


### PR DESCRIPTION
## Summary

Refs #4031. While verifying Phases 1/3/4 together on a unified test branch,
a clean Linux GCC build surfaced 2 warnings not in the RFC's original
inventory:

- `src/core/HidEncoderManager.cpp:853` (`-Wunused-parameter`): `mode`
  unused in `setTMate2OverlayIndicators()`.
- `src/core/PipeWireAudioBridge.cpp:494` (`-Wunused-variable`):
  `silenceFloat` unused when `HAVE_PIPEWIRE_NATIVE` isn't defined.

Neither is a new regression — both commits that introduced this code
(`fdfab036`, 2026-06-13; `b245b1d0`, 2026-06-06) predate the RFC's own
`104ebca6` snapshot (2026-07-04) by weeks. The gap is structural, not
temporal: `PipeWireAudioBridge.cpp` is only compiled `elseif(UNIX)`
(`CMakeLists.txt`) — it never builds on Windows, MinGW or otherwise — and
`HidEncoderManager.cpp`'s HID sources are gated behind `HIDAPI_FOUND`. A
Windows/MinGW-based "GCC" inventory structurally cannot compile either
file, regardless of how thorough that pass was.

**Fixes:**
- `HidEncoderManager.cpp`: comment out the unused parameter name, matching
  the RFC's own established Phase 1 pattern for this exact warning class.
- `PipeWireAudioBridge.cpp`: **not** a delete — `silenceFloat` *is* used,
  three lines down, inside `#ifdef HAVE_PIPEWIRE_NATIVE`. Deleting it
  outright would have broken that build configuration — exactly the trap
  #4031's own Phase 2 guidance warned about for `-Wunused-function` ("grep
  entire `src/` for every function name including `#ifdef`-guarded call
  sites before deleting"); same principle applies to unused-variable.
  Wrapped the declaration in the same `#ifdef` instead, so it only exists
  where it's used.

No behavior change in either fix.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. Checked the commit dates against
the RFC's snapshot rather than assuming "new" vs. "missed," and grepped for
the variable's other use sites before touching anything (see verification
note below on what couldn't be locally confirmed).

## Test plan

- [x] Local build passes (`cmake --build build`) — both touched files
      recompile with zero warnings
- [ ] Behavior verified on a real radio — n/a, no behavior change
- [x] Existing tests pass (CI) — full local `ctest` 64/64 green
- [x] Reproduction steps documented — see Summary

**Verification note:** `libpipewire-0.3` isn't installed in this dev
environment, so `HAVE_PIPEWIRE_NATIVE` is never defined here — only the
warned (non-native) path was locally exercised. The `#ifdef`-guarded fix
is a pure textual move (declaration site only), safe by inspection, but
the `HAVE_PIPEWIRE_NATIVE`-defined path itself couldn't be locally
recompiled to confirm.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI touched
- [ ] Documentation updated — n/a, no user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA — n/a