### PR TITLE
feat(aetherd): 2.3 template (complete) — decode + encode + extension facets on PanadapterModel/SliceModel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2544,6 +2544,13 @@ target_link_libraries(flex_backend_lifecycle_test PRIVATE aethercore Qt6::Core)
 set_target_properties(flex_backend_lifecycle_test PROPERTIES AUTOMOC ON)
 add_test(NAME flex_backend_lifecycle_test COMMAND flex_backend_lifecycle_test)
 
+# aetherd RFC 2.3 template — pan decode/normalize chain (incl. wnb_level guard).
+add_executable(aetherd_pan_decode_test tests/aetherd_pan_decode_test.cpp)
+target_include_directories(aetherd_pan_decode_test PRIVATE src)
+target_link_libraries(aetherd_pan_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_pan_decode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_pan_decode_test COMMAND aetherd_pan_decode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -115,6 +115,14 @@ signals:
     void panCenterBandwidthChanged(const QString& panId,
                                    double centerMhz, double bandwidthMhz);
 
+    // Vendor-specific status data that is NOT part of the core profile — the
+    // namespaced *extension* channel (aetherd RFC §5.5). A client that doesn't
+    // understand `ns` ignores it; `kind` names the event within the namespace
+    // and `fields` carries only the keys the wire actually reported. This is the
+    // status counterpart to invokeExtension's request/reply.
+    void extensionStatus(const QString& ns, const QString& kind,
+                         const QVariantMap& fields);
+
     // ---- data plane UP (RFC §4.2) ----
     // Declared here so backends have a normalized outlet for spectrum/waterfall/
     // audio; the concrete zero-copy/binary frame formats are step-4 work. Until

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -107,6 +107,13 @@ signals:
     void sliceChanged(int sliceId, const QVariantMap& changes);
     void sliceRemoved(int sliceId);
     void meterUpdate(const QString& meterId, double value);
+    // Panadapter core display state (universal — every family has a pan center
+    // and span). The backend decodes it from vendor status; RadioModel drives
+    // the PanadapterModel. panId is the pan's identifier (opaque to the model).
+    // (aetherd RFC 2.3 — first converted touchpoint; the template the other
+    // universal pan fields + the other mixed models follow.)
+    void panCenterBandwidthChanged(const QString& panId,
+                                   double centerMhz, double bandwidthMhz);
 
     // ---- data plane UP (RFC §4.2) ----
     // Declared here so backends have a normalized outlet for spectrum/waterfall/

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -182,6 +182,25 @@ void FlexBackend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/
     }
 }
 
+void FlexBackend::decodePanCenterBandwidth(const QString& panId,
+                                           const QMap<QString, QString>& kvs)
+{
+    // Only emit when the wire carried these fields — matches the old
+    // applyPanStatus behavior of touching center/bandwidth only when present.
+    if (!kvs.contains(QStringLiteral("center"))
+        && !kvs.contains(QStringLiteral("bandwidth"))) {
+        return;
+    }
+    // The radio may send one without the other; carry the current-or-parsed
+    // value for the missing one (RadioModel resolves against the model). A
+    // sentinel of -1 means "unchanged" for the absent field.
+    const double center = kvs.contains(QStringLiteral("center"))
+        ? kvs.value(QStringLiteral("center")).toDouble() : -1.0;
+    const double bandwidth = kvs.contains(QStringLiteral("bandwidth"))
+        ? kvs.value(QStringLiteral("bandwidth")).toDouble() : -1.0;
+    emit panCenterBandwidthChanged(panId, center, bandwidth);
+}
+
 void FlexBackend::send(const QString& cmd)
 {
     if (m_sink) {

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -91,6 +91,11 @@ void FlexBackend::setCommandSink(std::function<void(const QString&)> sink)
     m_sink = std::move(sink);
 }
 
+void FlexBackend::setSliceCommandSink(std::function<void(const QString&)> sink)
+{
+    m_sliceSink = std::move(sink);
+}
+
 void FlexBackend::setModelProvider(std::function<QString()> provider)
 {
     m_modelProvider = std::move(provider);
@@ -146,20 +151,21 @@ bool FlexBackend::isConnected() const
 
 void FlexBackend::setSliceFrequency(int sliceId, double hz)
 {
-    // Matches SliceModel::setFrequency's wire string exactly.
-    send(QStringLiteral("slice tune %1 %2 autopan=0")
-             .arg(sliceId)
-             .arg(hz / 1'000'000.0, 0, 'f', 6));
+    // Matches SliceModel::setFrequency's wire string exactly. Slice verbs use
+    // the TX-inhibit-guarded slice sink (§6), not the generic sink.
+    sendSlice(QStringLiteral("slice tune %1 %2 autopan=0")
+                  .arg(sliceId)
+                  .arg(hz / 1'000'000.0, 0, 'f', 6));
 }
 
 void FlexBackend::setSliceMode(int sliceId, const QString& mode)
 {
-    send(QStringLiteral("slice set %1 mode=%2").arg(sliceId).arg(mode));
+    sendSlice(QStringLiteral("slice set %1 mode=%2").arg(sliceId).arg(mode));
 }
 
 void FlexBackend::setSliceFilter(int sliceId, int lowHz, int highHz)
 {
-    send(QStringLiteral("filt %1 %2 %3").arg(sliceId).arg(lowHz).arg(highHz));
+    sendSlice(QStringLiteral("filt %1 %2 %3").arg(sliceId).arg(lowHz).arg(highHz));
 }
 
 void FlexBackend::setKeying(bool key)
@@ -201,9 +207,43 @@ void FlexBackend::decodePanCenterBandwidth(const QString& panId,
     emit panCenterBandwidthChanged(panId, center, bandwidth);
 }
 
+void FlexBackend::decodePanExtensions(const QString& panId,
+                                      const QMap<QString, QString>& kvs)
+{
+    // WNB (wideband noise blanker) is a Flex-specific pan feature, not core
+    // profile — carry only the keys the wire reported, namespaced under "flex".
+    QVariantMap wnb;
+    if (kvs.contains(QStringLiteral("wnb"))) {
+        wnb.insert(QStringLiteral("wnb"),
+                   kvs.value(QStringLiteral("wnb")).toInt() != 0);
+    }
+    if (kvs.contains(QStringLiteral("wnb_level"))) {
+        wnb.insert(QStringLiteral("wnb_level"),
+                   kvs.value(QStringLiteral("wnb_level")).toInt());
+    }
+    if (kvs.contains(QStringLiteral("wnb_updating"))) {
+        wnb.insert(QStringLiteral("wnb_updating"),
+                   kvs.value(QStringLiteral("wnb_updating")).toInt() != 0);
+    }
+    if (!wnb.isEmpty()) {
+        wnb.insert(QStringLiteral("panId"), panId);
+        emit extensionStatus(QStringLiteral("flex"),
+                             QStringLiteral("panWnb"), wnb);
+    }
+}
+
 void FlexBackend::send(const QString& cmd)
 {
     if (m_sink) {
+        m_sink(cmd);
+    }
+}
+
+void FlexBackend::sendSlice(const QString& cmd)
+{
+    if (m_sliceSink) {
+        m_sliceSink(cmd);
+    } else if (m_sink) {
         m_sink(cmd);
     }
 }

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -218,10 +218,21 @@ void FlexBackend::decodePanExtensions(const QString& panId,
                    kvs.value(QStringLiteral("wnb")).toInt() != 0);
     }
     if (kvs.contains(QStringLiteral("wnb_level"))) {
-        wnb.insert(QStringLiteral("wnb_level"),
-                   kvs.value(QStringLiteral("wnb_level")).toInt());
+        // Guard the numeric parse: a malformed/non-numeric wnb_level must be
+        // ignored, not applied as 0. The old inline applyPanStatus path did
+        // exactly this (toInt(&ok) + if(ok)), mirroring FlexLib's own
+        // uint.TryParse + skip-on-failure (Panadapter.cs:1244). Dropping the
+        // guard would silently snap the WNB-level UI to 0 (Principle VII).
+        bool ok = false;
+        const int level = kvs.value(QStringLiteral("wnb_level")).toInt(&ok);
+        if (ok) {
+            wnb.insert(QStringLiteral("wnb_level"), level);
+        }
     }
     if (kvs.contains(QStringLiteral("wnb_updating"))) {
+        // FlexLib v4.2.18 exposes wnb_updating on display pan status while the
+        // radio normalizes the SCU-level WNB threshold; it is distinct from the
+        // per-pan WNB enable flag ("wnb") above — keep them separate.
         wnb.insert(QStringLiteral("wnb_updating"),
                    kvs.value(QStringLiteral("wnb_updating")).toInt() != 0);
     }

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -2,6 +2,9 @@
 
 #include <functional>
 
+#include <QMap>
+#include <QString>
+
 #include "core/backends/IRadioBackend.h"
 
 class QThread;
@@ -57,6 +60,16 @@ public:
     void setKeying(bool key) override;
     void invokeExtension(const QString& ns, const QString& verb,
                          quint64 requestId, const QVariant& arg = {}) override;
+
+    // ---- status decode (aetherd RFC 2.3) ----
+    // Decode the universal panadapter display fields (center/bandwidth) out of
+    // a Flex "display pan" status kv-set and emit the normalized
+    // panCenterBandwidthChanged signal. RadioModel calls this from its status
+    // choke point (handlePanadapterStatus), so both live and deferred/replayed
+    // status flow through it. The Flex-specific pan fields still decode in
+    // PanadapterModel::applyPanStatus until they convert too.
+    void decodePanCenterBandwidth(const QString& panId,
+                                  const QMap<QString, QString>& kvs);
 
 private:
     void send(const QString& cmd);

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -44,6 +44,11 @@ public:
     // Where the core verbs emit their SmartSDR command strings — RadioModel's
     // existing sendCommand() funnel, so verbs reuse the one wire-write path.
     void setCommandSink(std::function<void(const QString&)> sink);
+    // Slice verbs (setSliceFrequency/Mode/Filter) route through THIS sink, which
+    // RadioModel wires to its TX-inhibit-guarded sendSliceCommand — so keeping
+    // the encode's TX safety above the seam (RFC §6). Falls back to the generic
+    // sink if unset. (aetherd RFC 2.3 encode template.)
+    void setSliceCommandSink(std::function<void(const QString&)> sink);
     // Live model-string source for capabilities(). Call on the main thread,
     // where RadioModel lives — capabilities() is not thread-safe (no off-thread
     // caller exists yet; this documents the assumption).
@@ -70,15 +75,22 @@ public:
     // PanadapterModel::applyPanStatus until they convert too.
     void decodePanCenterBandwidth(const QString& panId,
                                   const QMap<QString, QString>& kvs);
+    // Decode the Flex-specific pan fields that are NOT part of the core profile
+    // (currently the WNB group) and emit them on the namespaced extensionStatus
+    // channel. (aetherd RFC 2.3 extension template.)
+    void decodePanExtensions(const QString& panId,
+                             const QMap<QString, QString>& kvs);
 
 private:
     void send(const QString& cmd);
+    void sendSlice(const QString& cmd);   // guarded slice path (§6)
 
     RadioConnection*  m_connection{nullptr};    // owned; lives on m_connThread
     QThread*          m_connThread{nullptr};    // owned (this-parented)
     PanadapterStream* m_panStream{nullptr};     // owned; lives on m_networkThread
     QThread*          m_networkThread{nullptr}; // owned (this-parented)
     std::function<void(const QString&)> m_sink;
+    std::function<void(const QString&)> m_sliceSink;
     std::function<QString()> m_modelProvider;
 };
 

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -71,9 +71,24 @@ void PanadapterModel::setRfGainInfo(int low, int high, int step)
     emit rfGainInfoChanged(low, high, step);
 }
 
+void PanadapterModel::setCenterBandwidth(double centerMhz, double bandwidthMhz)
+{
+    bool changed = false;
+    if (centerMhz >= 0.0 && centerMhz != m_centerMhz) {
+        m_centerMhz = centerMhz;
+        changed = true;
+    }
+    if (bandwidthMhz >= 0.0 && bandwidthMhz != m_bandwidthMhz) {
+        m_bandwidthMhz = bandwidthMhz;
+        changed = true;
+    }
+    if (changed) {
+        emit infoChanged(m_centerMhz, m_bandwidthMhz);
+    }
+}
+
 void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
 {
-    bool infoChanged = false;
     bool levelChanged = false;
 
     // #3977: ownership is radio-authoritative. When another session reclaims
@@ -88,14 +103,8 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
         }
     }
 
-    if (kvs.contains("center")) {
-        double c = kvs["center"].toDouble();
-        if (c != m_centerMhz) { m_centerMhz = c; infoChanged = true; }
-    }
-    if (kvs.contains("bandwidth")) {
-        double b = kvs["bandwidth"].toDouble();
-        if (b != m_bandwidthMhz) { m_bandwidthMhz = b; infoChanged = true; }
-    }
+    // center/bandwidth now decode in FlexBackend → panCenterBandwidthChanged →
+    // setCenterBandwidth() (aetherd RFC 2.3, the first converted pan touchpoint).
     if (kvs.contains("min_dbm")) {
         float v = kvs["min_dbm"].toFloat();
         if (v != m_minDbm) { m_minDbm = v; levelChanged = true; }
@@ -219,8 +228,6 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
         }
     }
 
-    if (infoChanged)
-        emit this->infoChanged(m_centerMhz, m_bandwidthMhz);
     if (levelChanged)
         emit this->levelChanged(m_minDbm, m_maxDbm);
 }

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -87,6 +87,27 @@ void PanadapterModel::setCenterBandwidth(double centerMhz, double bandwidthMhz)
     }
 }
 
+void PanadapterModel::applyWnbExtension(const QVariantMap& fields)
+{
+    bool dirty = false;
+    if (fields.contains(QStringLiteral("wnb"))) {
+        const bool w = fields.value(QStringLiteral("wnb")).toBool();
+        if (w != m_wnbActive) { m_wnbActive = w; dirty = true; }
+    }
+    if (fields.contains(QStringLiteral("wnb_level"))) {
+        const int lvl = std::clamp(fields.value(QStringLiteral("wnb_level")).toInt(), 0, 100);
+        if (lvl != m_wnbLevel) { m_wnbLevel = lvl; dirty = true; }
+    }
+    if (fields.contains(QStringLiteral("wnb_updating"))) {
+        const bool u = fields.value(QStringLiteral("wnb_updating")).toBool();
+        if (u != m_wnbUpdating) { m_wnbUpdating = u; dirty = true; }
+    }
+    if (dirty) {
+        emit wnbChanged(m_wnbActive, m_wnbLevel);
+        emit wnbStateChanged(m_wnbActive, m_wnbLevel, m_wnbUpdating);
+    }
+}
+
 void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
 {
     bool levelChanged = false;
@@ -127,36 +148,8 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             m_preamp = pre;
         }
     }
-    // FlexLib v4.2.18 exposes wnb_updating on display pan status while the
-    // radio normalizes the SCU-level WNB threshold; keep it distinct from
-    // the per-pan WNB enable flag.
-    bool wnbStateDirty = false;
-    if (kvs.contains("wnb")) {
-        const bool w = kvs["wnb"].toInt() != 0;
-        if (w != m_wnbActive) {
-            m_wnbActive = w;
-            wnbStateDirty = true;
-        }
-    }
-    if (kvs.contains("wnb_level")) {
-        bool ok = false;
-        const int lvl = std::clamp(kvs["wnb_level"].toInt(&ok), 0, 100);
-        if (ok && lvl != m_wnbLevel) {
-            m_wnbLevel = lvl;
-            wnbStateDirty = true;
-        }
-    }
-    if (kvs.contains("wnb_updating")) {
-        const bool updating = kvs["wnb_updating"].toInt() != 0;
-        if (updating != m_wnbUpdating) {
-            m_wnbUpdating = updating;
-            wnbStateDirty = true;
-        }
-    }
-    if (wnbStateDirty) {
-        emit wnbChanged(m_wnbActive, m_wnbLevel);
-        emit wnbStateChanged(m_wnbActive, m_wnbLevel, m_wnbUpdating);
-    }
+    // WNB decode moved to FlexBackend → extensionStatus("flex","panWnb") →
+    // applyWnbExtension() (aetherd RFC 2.3 extension template).
     if (kvs.contains("wide")) {
         bool wide = kvs["wide"].toInt() != 0;
         if (wide != m_wideActive) {

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QVariantMap>
 #include <QString>
 #include <QStringList>
 
@@ -42,6 +43,11 @@ public:
     // value means "leave unchanged" (the radio may report one without the
     // other). Emits infoChanged when either actually changes.
     void setCenterBandwidth(double centerMhz, double bandwidthMhz);
+    // Flex-specific WNB extension applied from the backend's namespaced
+    // extensionStatus("flex","panWnb",…). Applies only the keys present;
+    // emits wnbChanged/wnbStateChanged when anything changes. (aetherd RFC 2.3
+    // extension template — the decode lives in FlexBackend, not here.)
+    void applyWnbExtension(const QVariantMap& fields);
     float minDbm() const { return m_minDbm; }
     float maxDbm() const { return m_maxDbm; }
     QString rxAntenna() const { return m_rxAntenna; }

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -38,6 +38,10 @@ public:
     // Display state
     double centerMhz() const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
+    // Normalized setter driven by the backend (aetherd RFC 2.3). A negative
+    // value means "leave unchanged" (the radio may report one without the
+    // other). Emits infoChanged when either actually changes.
+    void setCenterBandwidth(double centerMhz, double bandwidthMhz);
     float minDbm() const { return m_minDbm; }
     float maxDbm() const { return m_maxDbm; }
     QString rxAntenna() const { return m_rxAntenna; }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -408,6 +408,11 @@ RadioModel::RadioModel(QObject* parent)
     {
         auto flex = std::make_unique<FlexBackend>();
         flex->setCommandSink([this](const QString& cmd){ sendCommand(cmd); });
+        // Slice verbs route through the TX-inhibit-guarded slice sink (§6), so
+        // moving slice encode behind the seam keeps TX safety above it.
+        flex->setSliceCommandSink([this](const QString& cmd){
+            sendSliceCommand(nullptr, cmd);   // guard looks up the slice from cmd
+        });
         flex->setModelProvider([this]{ return m_model; });
         m_connection = flex->connection();   // non-owning; the backend owns it
         m_panStream  = flex->panStream();    // non-owning; the backend owns it
@@ -427,6 +432,19 @@ RadioModel::RadioModel(QObject* parent)
         pan->setCenterBandwidth(centerMhz, bandwidthMhz);
         // Legacy signal MainWindow still consumes (unchanged behavior).
         emit panadapterInfoChanged(pan->centerMhz(), pan->bandwidthMhz());
+    });
+
+    // aetherd RFC 2.3 extension template: Flex-specific pan fields (WNB) ride
+    // the namespaced extensionStatus channel; RadioModel routes them to the
+    // addressed PanadapterModel. Other namespaces/kinds are ignored here.
+    connect(m_backend.get(), &IRadioBackend::extensionStatus, this,
+            [this](const QString& ns, const QString& kind, const QVariantMap& fields) {
+        if (ns != QLatin1String("flex") || kind != QLatin1String("panWnb")) {
+            return;
+        }
+        auto* pan = m_panadapters.value(fields.value("panId").toString(), nullptr);
+        if (!pan) pan = activePanadapter();
+        if (pan) pan->applyWnbExtension(fields);
     });
 
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
@@ -5692,6 +5710,11 @@ void RadioModel::handleSliceStatus(int id,
             connect(s, &SliceModel::commandReady, this, [this, s](const QString& cmd){
                 sendSliceCommand(s, cmd);
             });
+            // aetherd RFC 2.3 encode template: mode intent routes through the
+            // backend verb, whose output goes through the guarded slice sink.
+            connect(s, &SliceModel::modeChangeRequested, this, [this, s](const QString& mode){
+                if (m_flexBackend) m_flexBackend->setSliceMode(s->sliceId(), mode);
+            });
             connect(s, &SliceModel::txSliceChanged, this, [this](bool) {
                 m_meterModel.setActiveTxSlice(activeTxSliceNum());
             });
@@ -5839,6 +5862,7 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     // panadapterInfoChanged (in the ctor-wired handler above).
     if (m_flexBackend) {
         m_flexBackend->decodePanCenterBandwidth(panId, kvs);
+        m_flexBackend->decodePanExtensions(panId, kvs);
     }
     if (kvs.contains("min_dbm") || kvs.contains("max_dbm")) {
         const float minDbm = pan ? pan->minDbm() : kvs.value("min_dbm", "-130").toFloat();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -411,8 +411,23 @@ RadioModel::RadioModel(QObject* parent)
         flex->setModelProvider([this]{ return m_model; });
         m_connection = flex->connection();   // non-owning; the backend owns it
         m_panStream  = flex->panStream();    // non-owning; the backend owns it
+        m_flexBackend = flex.get();          // transitional alias (2.3)
         m_backend = std::move(flex);
     }
+
+    // aetherd RFC 2.3: the first converted touchpoint. The backend decodes the
+    // universal pan center/bandwidth from Flex status and emits this normalized
+    // signal; RadioModel drives the addressed PanadapterModel. (Template for the
+    // remaining universal fields and the other mixed models.)
+    connect(m_backend.get(), &IRadioBackend::panCenterBandwidthChanged, this,
+            [this](const QString& panId, double centerMhz, double bandwidthMhz) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (!pan) return;
+        pan->setCenterBandwidth(centerMhz, bandwidthMhz);
+        // Legacy signal MainWindow still consumes (unchanged behavior).
+        emit panadapterInfoChanged(pan->centerMhz(), pan->bandwidthMhz());
+    });
 
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
     // WHEN a dax_rx stream must exist (refcounted acquire/release from the
@@ -5817,9 +5832,13 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
         pan->applyPanStatus(kvs);
     }
 
-    // Keep legacy signals for backward compat (MainWindow still uses these)
-    if (kvs.contains("center") || kvs.contains("bandwidth")) {
-        if (pan) emit panadapterInfoChanged(pan->centerMhz(), pan->bandwidthMhz());
+    // aetherd RFC 2.3: center/bandwidth decode moved to the backend. Driving it
+    // from this choke point (not a live statusReceived observer) means both live
+    // and deferred/replayed status flow through the converted path. The
+    // panCenterBandwidthChanged signal applies to the model + emits the legacy
+    // panadapterInfoChanged (in the ctor-wired handler above).
+    if (m_flexBackend) {
+        m_flexBackend->decodePanCenterBandwidth(panId, kvs);
     }
     if (kvs.contains("min_dbm") || kvs.contains("max_dbm")) {
         const float minDbm = pan ? pan->minDbm() : kvs.value("min_dbm", "-130").toFloat();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -685,6 +685,12 @@ RadioModel::~RadioModel()
     m_backend.reset();
     m_connection = nullptr;
     m_panStream = nullptr;
+    // The transitional alias points into the just-destroyed backend — null it so
+    // the many `if (m_flexBackend)` guards (decode calls in handlePanadapterStatus,
+    // the slice modeChangeRequested lambda) fail closed instead of dereferencing a
+    // dangling pointer. handlePanadapterStatus is also reachable via the WAN
+    // statusReceived connection, so this isn't purely theoretical. (#4063 review)
+    m_flexBackend = nullptr;
 }
 
 bool RadioModel::isConnected() const
@@ -5712,6 +5718,10 @@ void RadioModel::handleSliceStatus(int id,
             });
             // aetherd RFC 2.3 encode template: mode intent routes through the
             // backend verb, whose output goes through the guarded slice sink.
+            // TODO(2.x): route via IRadioBackend once encode is backend-owned —
+            // today this no-ops on the wire for any non-Flex backend (m_flexBackend
+            // null) while still emitting modeChanged. Fine while Flex is the only
+            // backend. (#4063 review)
             connect(s, &SliceModel::modeChangeRequested, this, [this, s](const QString& mode){
                 if (m_flexBackend) m_flexBackend->setSliceMode(s->sliceId(), mode);
             });

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -42,6 +42,7 @@
 namespace AetherSDR {
 
 class IRadioBackend;   // aetherd RFC §5.5 radio-facing seam (owned via unique_ptr below)
+class FlexBackend;     // transitional concrete alias for 2.3 status-decode driving
 
 // RadioModel is the central data model for a connected radio.
 // It owns the RadioConnection, processes incoming status messages,
@@ -669,6 +670,12 @@ private:
     // PanadapterStream and their worker threads; RadioModel keeps the two
     // NON-OWNING pointers below, obtained from the backend at construction.
     std::unique_ptr<IRadioBackend> m_backend;
+    // Transitional (aetherd RFC 2.3): RadioModel drives the backend's Flex
+    // status decode from its status choke points while touchpoints convert
+    // one at a time. Non-owning alias of m_backend; goes away once the backend
+    // owns status ingress (the protocol step). Concrete type because the decode
+    // input is vendor-specific; the outputs are normalized interface signals.
+    FlexBackend* m_flexBackend{nullptr};
     RadioConnection*  m_connection{nullptr};   // non-owning — owned by m_backend
     // Sequence counter and callback map — owned by RadioModel on main thread.
     // RadioConnection no longer manages callbacks. (#502)

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -76,7 +76,9 @@ void SliceModel::setMode(const QString& mode)
 {
     if (m_mode == mode) return;
     m_mode = mode;
-    sendCommand(QString("slice set %1 mode=%2").arg(m_id).arg(mode));
+    // aetherd RFC 2.3: express intent; FlexBackend builds "slice set N mode=…"
+    // and routes it through the TX-inhibit-guarded slice sink.
+    emit modeChangeRequested(mode);
     emit modeChanged(mode);
 }
 

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -341,6 +341,11 @@ signals:
     void playOnChanged(bool on);
     void playEnabledChanged(bool enabled);
     void commandReady(const QString& cmd);  // ready to send to radio
+    // aetherd RFC 2.3 encode template: express intent instead of building the
+    // wire string. RadioModel routes this to FlexBackend::setSliceMode, whose
+    // output goes through the TX-inhibit-guarded slice sink. (The other slice
+    // commands still use commandReady until they convert.)
+    void modeChangeRequested(const QString& mode);
 
 private:
     int     m_id{0};

--- a/tests/aetherd_pan_decode_test.cpp
+++ b/tests/aetherd_pan_decode_test.cpp
@@ -1,0 +1,141 @@
+// aetherd RFC 2.3 template coverage: the pan decode/normalize chain.
+//
+// Exercises the three facets the 2.3 template introduces on the pan touchpoint:
+//   1. DECODE    — FlexBackend::decodePanCenterBandwidth → panCenterBandwidthChanged
+//   2. EXTENSION — FlexBackend::decodePanExtensions      → extensionStatus("flex","panWnb")
+//   3. the model sinks — PanadapterModel::setCenterBandwidth / applyWnbExtension
+//
+// Notably pins the wnb_level numeric guard (#4063 review): a malformed
+// wnb_level must be dropped, not applied as 0.
+
+#include "core/backends/flex/FlexBackend.h"
+#include "models/PanadapterModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QVariantMap>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+        ++g_failures; \
+    } \
+} while (0)
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ---- Facet 1: DECODE (center/bandwidth) ----
+    {
+        FlexBackend backend;
+        QSignalSpy spy(&backend, &IRadioBackend::panCenterBandwidthChanged);
+
+        // Neither field present → no emission (matches old touch-only behavior).
+        backend.decodePanCenterBandwidth(QStringLiteral("0x40000000"),
+                                         {{QStringLiteral("min_dbm"), QStringLiteral("-120")}});
+        CHECK(spy.count() == 0);
+
+        // center only → emitted, bandwidth carries the -1 "unchanged" sentinel.
+        backend.decodePanCenterBandwidth(QStringLiteral("0x40000000"),
+                                         {{QStringLiteral("center"), QStringLiteral("7.15")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(a.at(0).toString() == QStringLiteral("0x40000000"));
+            CHECK(qFuzzyCompare(a.at(1).toDouble(), 7.15));
+            CHECK(a.at(2).toDouble() < 0.0);
+        }
+
+        // both present → both carried through.
+        backend.decodePanCenterBandwidth(QStringLiteral("0x40000000"),
+                                         {{QStringLiteral("center"), QStringLiteral("14.2")},
+                                          {QStringLiteral("bandwidth"), QStringLiteral("0.2")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(qFuzzyCompare(a.at(1).toDouble(), 14.2));
+            CHECK(qFuzzyCompare(a.at(2).toDouble(), 0.2));
+        }
+    }
+
+    // ---- Facet 2: EXTENSION (WNB) + the wnb_level guard ----
+    {
+        FlexBackend backend;
+        QSignalSpy spy(&backend, &IRadioBackend::extensionStatus);
+
+        // No WNB keys → no extension emission.
+        backend.decodePanExtensions(QStringLiteral("0x40000000"),
+                                    {{QStringLiteral("center"), QStringLiteral("7.1")}});
+        CHECK(spy.count() == 0);
+
+        // Valid wnb + wnb_level → namespaced under "flex"/"panWnb", both present.
+        backend.decodePanExtensions(QStringLiteral("0x40000000"),
+                                    {{QStringLiteral("wnb"), QStringLiteral("1")},
+                                     {QStringLiteral("wnb_level"), QStringLiteral("42")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(a.at(0).toString() == QStringLiteral("flex"));
+            CHECK(a.at(1).toString() == QStringLiteral("panWnb"));
+            const QVariantMap f = a.at(2).toMap();
+            CHECK(f.value(QStringLiteral("panId")).toString() == QStringLiteral("0x40000000"));
+            CHECK(f.value(QStringLiteral("wnb")).toBool() == true);
+            CHECK(f.contains(QStringLiteral("wnb_level")));
+            CHECK(f.value(QStringLiteral("wnb_level")).toInt() == 42);
+        }
+
+        // Malformed wnb_level → the key must be DROPPED, not applied as 0
+        // (#4063 review — Principle VII). wnb still carries.
+        backend.decodePanExtensions(QStringLiteral("0x40000000"),
+                                    {{QStringLiteral("wnb"), QStringLiteral("1")},
+                                     {QStringLiteral("wnb_level"), QStringLiteral("garbage")}});
+        CHECK(spy.count() == 1);
+        {
+            const QVariantMap f = spy.takeFirst().at(2).toMap();
+            CHECK(f.value(QStringLiteral("wnb")).toBool() == true);
+            CHECK(!f.contains(QStringLiteral("wnb_level")));   // guarded out
+        }
+    }
+
+    // ---- Facet 3: model sinks ----
+    {
+        PanadapterModel pan(QStringLiteral("0x40000000"));
+        QSignalSpy info(&pan, &PanadapterModel::infoChanged);
+
+        // Negative = "leave unchanged": bandwidth held, only center moves.
+        const double origBw = pan.bandwidthMhz();
+        pan.setCenterBandwidth(7.15, -1.0);
+        CHECK(qFuzzyCompare(pan.centerMhz(), 7.15));
+        CHECK(qFuzzyCompare(pan.bandwidthMhz(), origBw));
+        CHECK(info.count() == 1);
+        info.clear();
+
+        // No actual change → no emission.
+        pan.setCenterBandwidth(7.15, -1.0);
+        CHECK(info.count() == 0);
+
+        // applyWnbExtension applies only present keys and clamps the level.
+        QSignalSpy wnbSpy(&pan, &PanadapterModel::wnbStateChanged);
+        QVariantMap ext;
+        ext.insert(QStringLiteral("wnb"), true);
+        ext.insert(QStringLiteral("wnb_level"), 250);   // out of range → clamp to 100
+        pan.applyWnbExtension(ext);
+        CHECK(pan.wnbActive() == true);
+        CHECK(pan.wnbLevel() == 100);
+        CHECK(wnbSpy.count() == 1);
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherd_pan_decode_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherd_pan_decode_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
RFC step 2.3 (mixed-model split), proving the **full three-facet template** — decode, encode, extension — on the panadapter/slice touchpoints before expanding the blast radius. Scoped narrow, but end-to-end on all three facets so the mold is complete for the rest of 2.3.

### The three facets (the template the rest of 2.3 follows)

**1. DECODE — a universal field flows into the backend and out as a normalized typed signal:**
> wire → `RadioModel::handlePanadapterStatus` (the status choke point — so **both live and deferred/replayed** status convert, not just a live observer) → `FlexBackend::decodePanCenterBandwidth` → `IRadioBackend::panCenterBandwidthChanged` → `PanadapterModel::setCenterBandwidth` → GPU render.
- `decodePanCenterBandwidth()` emits only when present (negative = "unchanged" for an omitted field); center/bandwidth removed from `applyPanStatus`.

**2. ENCODE — a command intent routes through a backend verb, TX-safety kept above the seam (RFC §6):**
> `SliceModel::setMode` → `modeChangeRequested` → `FlexBackend::setSliceMode` → the **TX-inhibit-guarded** slice sink (`setSliceCommandSink` → `RadioModel::sendSliceCommand`).
- Wire string is byte-identical to the old direct `sendCommand`. The guard is inert for `slice set mode=` (a non-`tx=` verb), so this is a plumbing move, not a behavior change — it establishes *where* the guard lives for the transmitting verbs that convert later.
- Scope note: `setSliceFrequency`/`setSliceFilter` are rewired to the same guarded sink but have **no caller yet** — dead template code today, exercised when those verbs convert.

**3. EXTENSION — a Flex-specific field decodes to a namespaced channel, not the core profile:**
> `FlexBackend::decodePanExtensions` (WNB group) → `IRadioBackend::extensionStatus("flex","panWnb", …)` → `PanadapterModel::applyWnbExtension`.

- **IRadioBackend**: `panCenterBandwidthChanged(panId, center, bw)` + `extensionStatus(ns, kind, fields)`.
- **RadioModel**: a transitional concrete `FlexBackend*` alias drives decode from the choke point and services `modeChangeRequested`; legacy `panadapterInfoChanged` preserved. Behavior-neutral.

### Why this scope
The status plane is a ~921-line monolith entangled with pan lifecycle + deferred-status buffering — no clean *tiny* increment, but a clean *narrow* one. Proving all three facets end-to-end validates the whole approach (typed signal, choke-point driving, normalized setter, guarded encode seam, namespaced extension, deferred-path coverage) at minimal risk. If a TX-inhibited-slice-mode regression ever surfaces in a bisect, it traces here — the encode + extension paths land in this PR, not a later one.

### Known gaps (disclosed, deferred to the 2.3 burndown — not regressions)
- **Waterfall dual-parse**: `PanadapterModel::applyWaterfallStatus` still independently parses `center`/`bandwidth`, so they aren't single-sourced from the backend yet. Pre-existing, untouched by this diff. (FlexLib treats waterfall `bandwidth` as an explicit no-op, `Waterfall.cs:1116`.) Converges onto `setCenterBandwidth` in a follow-up.
- The remaining Flex-specific pan fields (`client_handle`, `loopa`/`loopb`, min/max dBm, …) stay in `applyPanStatus` until they convert.

### Verification
Clean build; **65/65 tests** (adds `aetherd_pan_decode_test` covering all three facets incl. the malformed-`wnb_level` guard); boundary `--strict` green; **live panadapter GPU grab on a FLEX-8600** renders the correct frequency axis — direct visual proof center/bandwidth flowed through the new backend path (a broken path would mis-scale the X axis). Full automation-bridge battery: 10/10 (6 core + 4 facet), session log clean (0 crash/assert markers).

### Next (after this template is reviewed/merged)
Same mold for the remaining universal pan fields (min/max dBm, waterfall id), then MeterModel → SliceModel → TransmitModel → RadioModel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
