### PR TITLE
feat(aetherd): 2.3 — complete PanadapterModel conversion (all Flex status decode behind the seam)

### DIFF
--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -97,7 +97,7 @@ the wire semantics that produce and consume it.**
 | `RadioModel` | connection state, the slice/pan/meter/transmit sub-model set, frequency/mode plumbing | Multi-Flex handles, GUIClientID session restore, SmartSDR status routing, `m_connection`/`m_panStream` ownership |
 | `SliceModel` | freq, mode, filter low/high, RX gain, active flag, S-meter binding | DAX channel, `client_handle` ownership, Flex slice-index quirks |
 | `TransmitModel` | keying intent, TX power setpoint, mic/monitor levels, the CHAIN DSP stage state | ATU/TGXL/amp verbs, Flex profile load, `mox`-less interlock decode |
-| `PanadapterModel` | center, span, min/max dBm, per-pan display state | FlexLib stream-id (0x40xx/0x42xx) wiring, `display pan` status keys |
+| `PanadapterModel` | center, span, min/max dBm, **rfgain, antenna (rxant/ant_list)**, waterfall line-duration, per-pan display state | `wide`, loop A/B, `fps`, preamp, DAX-IQ channel, MultiFlex `client_handle`, waterfall stream-id — all on the `flex`/`panWnb`+`panState` extension channel |
 | `MeterModel` | the meter values the UI renders (via `MeterSmoother`) | Flex meter-id catalog, SLC/LEVEL source decode |
 
 Approach: keep the existing model classes as the core-profile shape; move the
@@ -152,6 +152,12 @@ backend *after* the seam is proven, retiring its side-channels (RFC §5.5).
 4. **Directory layout** → **`src/core/backends/`** confirmed: the interface at
    `src/core/backends/IRadioBackend.h`, each family under
    `src/core/backends/<family>/` (FlexBackend → `src/core/backends/flex/`).
+5. **Pan field classification (rfgain + antenna)** → **promoted to universal
+   typed signals**, extending this doc's literal pan row. Rationale: RF gain and
+   antenna selection are genuine cross-radio concepts, so a second backend (e.g.
+   HL2) emits them via the typed signals and the existing UI works with zero
+   vendor-specific handling. `wide`/loop/`fps`/preamp/DAX-IQ/`client_handle`/
+   waterfall-id remain Flex extensions on the `panState` channel.
 
 These are settled as the working defaults; any can be revised in review while
 the interface has no implementor.

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -3,6 +3,7 @@
 #include <QByteArray>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariant>
 #include <QVariantMap>
 
@@ -122,6 +123,20 @@ signals:
     // wire did not report. (aetherd RFC 2.3 — second converted universal pan
     // field, following the center/bandwidth template.)
     void panRangeChanged(const QString& panId, double minDbm, double maxDbm);
+
+    // Panadapter RF gain (universal — every family has an RX gain control; the
+    // range/step are family-specific and reported via RadioCapabilities). The
+    // backend decodes it from vendor status; RadioModel drives the pan.
+    void panRfGainChanged(const QString& panId, int gain);
+
+    // Panadapter antenna selection (universal). Two signals because the wire may
+    // report the selected RX antenna and the available list independently.
+    void panRxAntennaChanged(const QString& panId, const QString& antenna);
+    void panAntennaListChanged(const QString& panId, const QStringList& antennas);
+
+    // Waterfall line duration in ms (universal display timing). Decoded from the
+    // waterfall-status plane; RadioModel drives the pan's waterfall model state.
+    void panWaterfallLineDurationChanged(const QString& panId, int ms);
 
     // Vendor-specific status data that is NOT part of the core profile — the
     // namespaced *extension* channel (aetherd RFC §5.5). A client that doesn't

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -115,6 +115,14 @@ signals:
     void panCenterBandwidthChanged(const QString& panId,
                                    double centerMhz, double bandwidthMhz);
 
+    // Panadapter display level range (universal — the Y-axis geometry that
+    // pairs with center/bandwidth's X-axis). Unlike center/bandwidth, dBm is
+    // signed, so the "unchanged" sentinel for an omitted field is NaN, not a
+    // negative value — the backend carries NaN for whichever of min/max the
+    // wire did not report. (aetherd RFC 2.3 — second converted universal pan
+    // field, following the center/bandwidth template.)
+    void panRangeChanged(const QString& panId, double minDbm, double maxDbm);
+
     // Vendor-specific status data that is NOT part of the core profile — the
     // namespaced *extension* channel (aetherd RFC §5.5). A client that doesn't
     // understand `ns` ignores it; `kind` names the event within the namespace

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -222,10 +222,19 @@ void FlexBackend::decodePanRange(const QString& panId,
     // "absent" the way it does for center/bandwidth. Carry NaN for the field
     // the radio omitted; the model's setRange() treats NaN as "leave unchanged".
     const double nan = std::numeric_limits<double>::quiet_NaN();
+    // Guard the numeric parse: a malformed *present* field must be ignored
+    // (carry NaN = "unchanged"), not applied as 0.0 dBm — setRange() only skips
+    // NaN, so a bare 0 would collapse the vertical scale via setDbmRange. Matches
+    // decodeWaterfallLineDuration's ok-guard + FlexLib's TryParseDouble+continue.
+    const auto dbm = [nan](const QString& s) {
+        bool ok = false;
+        const double v = s.toDouble(&ok);
+        return ok ? v : nan;
+    };
     const double minDbm = kvs.contains(QStringLiteral("min_dbm"))
-        ? kvs.value(QStringLiteral("min_dbm")).toDouble() : nan;
+        ? dbm(kvs.value(QStringLiteral("min_dbm"))) : nan;
     const double maxDbm = kvs.contains(QStringLiteral("max_dbm"))
-        ? kvs.value(QStringLiteral("max_dbm")).toDouble() : nan;
+        ? dbm(kvs.value(QStringLiteral("max_dbm"))) : nan;
     emit panRangeChanged(panId, minDbm, maxDbm);
 }
 
@@ -235,7 +244,14 @@ void FlexBackend::decodePanRfGain(const QString& panId,
     if (!kvs.contains(QStringLiteral("rfgain"))) {
         return;
     }
-    emit panRfGainChanged(panId, kvs.value(QStringLiteral("rfgain")).toInt());
+    // Guard the parse — a malformed rfgain must be ignored, not emitted as 0
+    // (which setRfGain would apply as a real gain). Matches FlexLib's
+    // int.TryParse+continue and the sibling decoders' ok-guards.
+    bool ok = false;
+    const int gain = kvs.value(QStringLiteral("rfgain")).toInt(&ok);
+    if (ok) {
+        emit panRfGainChanged(panId, gain);
+    }
 }
 
 void FlexBackend::decodePanAntenna(const QString& panId,

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -229,6 +229,74 @@ void FlexBackend::decodePanRange(const QString& panId,
     emit panRangeChanged(panId, minDbm, maxDbm);
 }
 
+void FlexBackend::decodePanRfGain(const QString& panId,
+                                  const QMap<QString, QString>& kvs)
+{
+    if (!kvs.contains(QStringLiteral("rfgain"))) {
+        return;
+    }
+    emit panRfGainChanged(panId, kvs.value(QStringLiteral("rfgain")).toInt());
+}
+
+void FlexBackend::decodePanAntenna(const QString& panId,
+                                   const QMap<QString, QString>& kvs)
+{
+    // Selected RX antenna and the available list arrive independently — emit
+    // each only when its wire key is present (matches the old applyPanStatus).
+    if (kvs.contains(QStringLiteral("ant_list"))) {
+        const QStringList ants =
+            kvs.value(QStringLiteral("ant_list")).split(',', Qt::SkipEmptyParts);
+        emit panAntennaListChanged(panId, ants);
+    }
+    if (kvs.contains(QStringLiteral("rxant"))) {
+        emit panRxAntennaChanged(panId, kvs.value(QStringLiteral("rxant")));
+    }
+}
+
+void FlexBackend::decodeWaterfallLineDuration(const QString& panId,
+                                              const QMap<QString, QString>& kvs)
+{
+    if (!kvs.contains(QStringLiteral("line_duration"))) {
+        return;
+    }
+    // Guard the numeric parse — a malformed line_duration must be ignored, not
+    // applied as 0 (the old applyWaterfallStatus used toInt(&ok) + if(ok)).
+    bool ok = false;
+    const int ms = kvs.value(QStringLiteral("line_duration")).toInt(&ok);
+    if (ok) {
+        emit panWaterfallLineDurationChanged(panId, ms);
+    }
+}
+
+void FlexBackend::decodePanState(const QString& panId,
+                                 const QMap<QString, QString>& kvs)
+{
+    // Bundle the remaining Flex-specific display-pan keys onto one namespaced
+    // extension event; carry only the keys the wire actually reported so the
+    // model applies exactly what changed (present-only, like the WNB group).
+    QVariantMap st;
+    const auto carry = [&](const char* key) {
+        if (kvs.contains(QLatin1String(key))) {
+            st.insert(QLatin1String(key), kvs.value(QLatin1String(key)));
+        }
+    };
+    // Raw strings — the model parses each with its existing per-field semantics
+    // (bool flags, ok-guarded fps, hex client_handle, waterfall stream-id).
+    carry("wide");
+    carry("loopa");
+    carry("loopb");
+    carry("fps");
+    carry("pre");
+    carry("daxiq_channel");
+    carry("client_handle");
+    carry("waterfall");
+    if (!st.isEmpty()) {
+        st.insert(QStringLiteral("panId"), panId);
+        emit extensionStatus(QStringLiteral("flex"),
+                             QStringLiteral("panState"), st);
+    }
+}
+
 void FlexBackend::decodePanExtensions(const QString& panId,
                                       const QMap<QString, QString>& kvs)
 {

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -1,5 +1,7 @@
 #include "core/backends/flex/FlexBackend.h"
 
+#include <limits>
+
 #include <QThread>
 
 #include "core/RadioConnection.h"
@@ -205,6 +207,26 @@ void FlexBackend::decodePanCenterBandwidth(const QString& panId,
     const double bandwidth = kvs.contains(QStringLiteral("bandwidth"))
         ? kvs.value(QStringLiteral("bandwidth")).toDouble() : -1.0;
     emit panCenterBandwidthChanged(panId, center, bandwidth);
+}
+
+void FlexBackend::decodePanRange(const QString& panId,
+                                 const QMap<QString, QString>& kvs)
+{
+    // Only emit when the wire carried these fields — matches the old
+    // applyPanStatus behavior of touching min/max dBm only when present.
+    if (!kvs.contains(QStringLiteral("min_dbm"))
+        && !kvs.contains(QStringLiteral("max_dbm"))) {
+        return;
+    }
+    // dBm is signed (-130…-20 typical), so a negative value can't mean
+    // "absent" the way it does for center/bandwidth. Carry NaN for the field
+    // the radio omitted; the model's setRange() treats NaN as "leave unchanged".
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    const double minDbm = kvs.contains(QStringLiteral("min_dbm"))
+        ? kvs.value(QStringLiteral("min_dbm")).toDouble() : nan;
+    const double maxDbm = kvs.contains(QStringLiteral("max_dbm"))
+        ? kvs.value(QStringLiteral("max_dbm")).toDouble() : nan;
+    emit panRangeChanged(panId, minDbm, maxDbm);
 }
 
 void FlexBackend::decodePanExtensions(const QString& panId,

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -75,6 +75,11 @@ public:
     // PanadapterModel::applyPanStatus until they convert too.
     void decodePanCenterBandwidth(const QString& panId,
                                   const QMap<QString, QString>& kvs);
+    // Decode the universal panadapter display level range (min_dbm/max_dbm) and
+    // emit the normalized panRangeChanged signal. dBm is signed, so an omitted
+    // field is carried as NaN ("unchanged"), not a negative sentinel.
+    void decodePanRange(const QString& panId,
+                        const QMap<QString, QString>& kvs);
     // Decode the Flex-specific pan fields that are NOT part of the core profile
     // (currently the WNB group) and emit them on the namespaced extensionStatus
     // channel. (aetherd RFC 2.3 extension template.)

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -80,11 +80,25 @@ public:
     // field is carried as NaN ("unchanged"), not a negative sentinel.
     void decodePanRange(const QString& panId,
                         const QMap<QString, QString>& kvs);
+    // Universal pan RF gain / antenna selection — decoded from Flex status and
+    // emitted as the normalized typed signals (aetherd RFC 2.3; rfgain+antenna
+    // promoted to universal per the 2026-07-05 classification).
+    void decodePanRfGain(const QString& panId, const QMap<QString, QString>& kvs);
+    void decodePanAntenna(const QString& panId, const QMap<QString, QString>& kvs);
+    // Waterfall line duration (universal display timing), decoded from the
+    // waterfall-status plane and emitted as panWaterfallLineDurationChanged.
+    void decodeWaterfallLineDuration(const QString& panId,
+                                     const QMap<QString, QString>& kvs);
     // Decode the Flex-specific pan fields that are NOT part of the core profile
-    // (currently the WNB group) and emit them on the namespaced extensionStatus
-    // channel. (aetherd RFC 2.3 extension template.)
+    // (the WNB group) and emit them on the namespaced extensionStatus channel.
+    // (aetherd RFC 2.3 extension template.)
     void decodePanExtensions(const QString& panId,
                              const QMap<QString, QString>& kvs);
+    // The remaining Flex-specific display-pan status keys — wide, loop A/B, fps,
+    // preamp, DAX-IQ channel, MultiFlex client_handle ownership, waterfall
+    // stream-id — bundled onto the namespaced extensionStatus("flex","panState")
+    // channel. Present-only (each key rides only when the wire reported it).
+    void decodePanState(const QString& panId, const QMap<QString, QString>& kvs);
 
 private:
     void send(const QString& cmd);

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -645,8 +645,9 @@ void AtuPreTuneDialog::beginNextPoint()
         const QString centerStr = QString::number(center, 'f', 6);
         const QString widthStr  = QString::number(width,  'f', 6);
         if (auto* pan = m_radio->panadapter(m_originalPanId)) {
-            pan->applyPanStatus({{"center", centerStr},
-                                 {"bandwidth", widthStr}});
+            // Local model nudge before the radio echo (aetherd RFC 2.3: the
+            // normalized setter replaces applyPanStatus({center,bandwidth})).
+            pan->setCenterBandwidth(center, width);
         }
         m_radio->sendCommand(
             QString("display pan set %1 center=%2 bandwidth=%3")
@@ -887,8 +888,9 @@ void AtuPreTuneDialog::restoreOriginalFrequency()
         const QString centerStr = QString::number(m_originalPanCenterMhz, 'f', 6);
         const QString widthStr  = QString::number(m_originalPanBandwidthMhz, 'f', 6);
         if (auto* pan = m_radio->panadapter(m_originalPanId)) {
-            pan->applyPanStatus({{"center", centerStr},
-                                 {"bandwidth", widthStr}});
+            // Local model nudge before the radio echo (aetherd RFC 2.3: the
+            // normalized setter replaces applyPanStatus({center,bandwidth})).
+            pan->setCenterBandwidth(m_originalPanCenterMhz, m_originalPanBandwidthMhz);
         }
         m_radio->sendCommand(
             QString("display pan set %1 center=%2 bandwidth=%3")

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5938,10 +5938,8 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
         // Update both values together before the radio echo arrives. Explicit
         // zoom workflows are especially sensitive to center/bandwidth skew;
         // splitting them produced the P1/P2 waterfall-loss and zoom-drift bugs.
-        pan->applyPanStatus({
-            {"center", centerStr},
-            {"bandwidth", bandwidthStr},
-        });
+        // (aetherd RFC 2.3: setCenterBandwidth replaces applyPanStatus here.)
+        pan->setCenterBandwidth(centerMhz, bandwidthMhz);
     }
 
     m_radioModel.sendCommand(
@@ -8518,7 +8516,7 @@ void MainWindow::recenterPanFollowOnSlice0()
     auto* pan = m_radioModel.panadapter(panId);
     if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
     const QString freqStr = QString::number(freq, 'f', 6);
-    if (pan) pan->applyPanStatus({{"center", freqStr}});
+    if (pan) pan->setCenterBandwidth(freq, -1.0);  // aetherd RFC 2.3
     m_radioModel.sendCommand(
         QString("display pan set %1 center=%2").arg(panId, freqStr));
 }

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1173,7 +1173,7 @@ void MainWindow::activateWFM(int sliceId)
         auto* pan = m_radioModel.panadapter(panId);
         if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
         const QString freqStr = QString::number(freq, 'f', 6);
-        if (pan) pan->applyPanStatus({{"center", freqStr}});
+        if (pan) pan->setCenterBandwidth(freq, -1.0);  // aetherd RFC 2.3
         m_radioModel.sendCommand(
             QString("display pan set %1 center=%2").arg(panId, freqStr));
     };

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3012,7 +3012,7 @@ MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
             ? kPanFollowAnimationDurationMs
             : 0;
 
-        pan->applyPanStatus({{"center", QString::number(result.newCenterMhz, 'f', 6)}});
+        pan->setCenterBandwidth(result.newCenterMhz, -1.0);  // aetherd RFC 2.3
         m_radioModel.sendCommand(
             QString("display pan set %1 center=%2")
                 .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));
@@ -3102,7 +3102,7 @@ MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
     // Apply the center optimistically so the owning spectrum repaints
     // immediately; SpectrumWidget decides whether that becomes a short
     // retargetable animation or an immediate snap based on shift size.
-    pan->applyPanStatus({{"center", QString::number(result.newCenterMhz, 'f', 6)}});
+    pan->setCenterBandwidth(result.newCenterMhz, -1.0);  // aetherd RFC 2.3
     m_radioModel.sendCommand(
         QString("display pan set %1 center=%2")
             .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -128,77 +128,77 @@ void PanadapterModel::applyWnbExtension(const QVariantMap& fields)
     }
 }
 
-void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
+void PanadapterModel::setRfGain(int gain)
 {
-    // #3977: ownership is radio-authoritative. When another session reclaims
-    // this pan (MultiFlex reconnect), the radio broadcasts the new
-    // client_handle; tracking it here lets a superseded session stop
-    // adjusting a pan it no longer owns.
-    if (kvs.contains("client_handle")) {
-        const quint32 parsed = parseHandleHex(kvs.value("client_handle"));
-        if (parsed != 0 && parsed != m_ownerHandle) {
-            m_ownerHandle = parsed;
-            m_clientHandle = QString::number(parsed, 16);
-        }
+    if (gain != m_rfGain) {
+        m_rfGain = gain;
+        emit rfGainChanged(m_rfGain);
     }
+}
 
-    // center/bandwidth now decode in FlexBackend → panCenterBandwidthChanged →
-    // setCenterBandwidth(); min/max dBm likewise → panRangeChanged → setRange()
-    // (aetherd RFC 2.3 — the two converted universal pan display-geometry fields).
-    if (kvs.contains("rfgain")) {
-        int g = kvs["rfgain"].toInt();
-        if (g != m_rfGain) {
-            m_rfGain = g;
-            emit rfGainChanged(m_rfGain);
-        }
+void PanadapterModel::setRxAntenna(const QString& ant)
+{
+    if (ant != m_rxAntenna) {
+        m_rxAntenna = ant;
+        emit rxAntennaChanged(m_rxAntenna);
     }
-    if (kvs.contains("pre")) {
-        QString pre = kvs["pre"];
-        if (pre != m_preamp) {
-            // Preamp is internal state only — no UI listeners, no emit.
-            m_preamp = pre;
-        }
+}
+
+void PanadapterModel::setAntList(const QStringList& ants)
+{
+    if (ants != m_antList) {
+        m_antList = ants;
+        emit antListChanged(m_antList);
     }
-    // WNB decode moved to FlexBackend → extensionStatus("flex","panWnb") →
-    // applyWnbExtension() (aetherd RFC 2.3 extension template).
-    if (kvs.contains("wide")) {
-        bool wide = kvs["wide"].toInt() != 0;
+}
+
+void PanadapterModel::setWaterfallLineDuration(int ms)
+{
+    // PerfTelemetry is fed every report (even when unchanged), and
+    // waterfallLineDurationReported likewise always fires; the change-gated
+    // signal is waterfallLineDurationChanged. Semantics preserved verbatim from
+    // the old applyWaterfallStatus.
+    PerfTelemetry::instance().setWaterfallLineDurationMs(ms);
+    if (ms != m_waterfallLineDuration) {
+        m_waterfallLineDuration = ms;
+        emit waterfallLineDurationChanged(m_waterfallLineDuration);
+    }
+    emit waterfallLineDurationReported(ms);
+}
+
+void PanadapterModel::applyStateExtension(const QVariantMap& fields)
+{
+    // The Flex-specific display-pan fields, applied from the backend's
+    // namespaced extensionStatus("flex","panState",…). Each key applies only
+    // when present, with the exact per-field semantics the old applyPanStatus
+    // had (aetherd RFC 2.3 — the decode lives in FlexBackend, not here).
+    if (fields.contains(QStringLiteral("wide"))) {
+        const bool wide = fields.value(QStringLiteral("wide")).toInt() != 0;
         if (wide != m_wideActive) {
             m_wideActive = wide;
             emit wideChanged(m_wideActive);
         }
     }
-    if (kvs.contains("loopa") || kvs.contains("loopb")) {
+    if (fields.contains(QStringLiteral("loopa"))
+        || fields.contains(QStringLiteral("loopb"))) {
         bool changed = false;
-        if (kvs.contains("loopa")) {
-            const bool loopA = kvs["loopa"].toInt() != 0;
-            if (loopA != m_loopA) {
-                m_loopA = loopA;
-                changed = true;
-            }
-            if (loopA && m_loopB) {
-                m_loopB = false;
-                changed = true;
-            }
+        if (fields.contains(QStringLiteral("loopa"))) {
+            const bool loopA = fields.value(QStringLiteral("loopa")).toInt() != 0;
+            if (loopA != m_loopA) { m_loopA = loopA; changed = true; }
+            if (loopA && m_loopB) { m_loopB = false; changed = true; }
         }
-        if (kvs.contains("loopb")) {
-            const bool loopB = kvs["loopb"].toInt() != 0;
-            if (loopB != m_loopB) {
-                m_loopB = loopB;
-                changed = true;
-            }
-            if (loopB && m_loopA) {
-                m_loopA = false;
-                changed = true;
-            }
+        if (fields.contains(QStringLiteral("loopb"))) {
+            const bool loopB = fields.value(QStringLiteral("loopb")).toInt() != 0;
+            if (loopB != m_loopB) { m_loopB = loopB; changed = true; }
+            if (loopB && m_loopA) { m_loopA = false; changed = true; }
         }
         if (changed) {
             emit loopChanged(m_loopA, m_loopB);
         }
     }
-    if (kvs.contains("fps")) {
+    if (fields.contains(QStringLiteral("fps"))) {
         bool ok = false;
-        const int fps = kvs["fps"].toInt(&ok);
+        const int fps = fields.value(QStringLiteral("fps")).toInt(&ok);
         if (ok) {
             if (fps != m_fps) {
                 m_fps = fps;
@@ -207,52 +207,33 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit fpsReported(fps);
         }
     }
-    if (kvs.contains("ant_list")) {
-        QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);
-        if (ants != m_antList) {
-            m_antList = ants;
-            emit antListChanged(m_antList);
-        }
+    if (fields.contains(QStringLiteral("pre"))) {
+        const QString pre = fields.value(QStringLiteral("pre")).toString();
+        // Preamp is internal state only — no UI listeners, no emit (#1498).
+        if (pre != m_preamp) { m_preamp = pre; }
     }
-    if (kvs.contains("rxant")) {
-        const QString ant = kvs["rxant"];
-        if (ant != m_rxAntenna) {
-            m_rxAntenna = ant;
-            emit rxAntennaChanged(m_rxAntenna);
-        }
-    }
-    if (kvs.contains("waterfall")) {
-        setWaterfallId(kvs["waterfall"]);
-    }
-    if (kvs.contains("daxiq_channel")) {
-        int ch = kvs["daxiq_channel"].toInt();
+    if (fields.contains(QStringLiteral("daxiq_channel"))) {
+        const int ch = fields.value(QStringLiteral("daxiq_channel")).toInt();
         if (ch != m_daxiqChannel) {
             m_daxiqChannel = ch;
             emit daxiqChannelChanged(ch);
         }
     }
-}
-
-void PanadapterModel::applyWaterfallStatus(const QMap<QString, QString>& kvs)
-{
-    if (kvs.contains("line_duration")) {
-        bool ok = false;
-        const int ms = kvs["line_duration"].toInt(&ok);
-        if (ok) {
-            PerfTelemetry::instance().setWaterfallLineDurationMs(ms);
-            if (ms != m_waterfallLineDuration) {
-                m_waterfallLineDuration = ms;
-                emit waterfallLineDurationChanged(m_waterfallLineDuration);
-            }
-            emit waterfallLineDurationReported(ms);
+    // #3977: ownership is radio-authoritative. When another session reclaims
+    // this pan (MultiFlex reconnect), the radio broadcasts the new
+    // client_handle; tracking it lets a superseded session stop adjusting a pan
+    // it no longer owns. Semantics preserved verbatim (parsed != 0 && changed).
+    if (fields.contains(QStringLiteral("client_handle"))) {
+        const quint32 parsed =
+            parseHandleHex(fields.value(QStringLiteral("client_handle")).toString());
+        if (parsed != 0 && parsed != m_ownerHandle) {
+            m_ownerHandle = parsed;
+            m_clientHandle = QString::number(parsed, 16);
         }
     }
-
-    // Waterfall status also carries center/bandwidth; those now decode through
-    // the same FlexBackend::decodePanCenterBandwidth path as pan status (driven
-    // from RadioModel's waterfall-status choke point), so the two ingestion
-    // surfaces are single-sourced. (aetherd RFC 2.3 — waterfall dual-parse
-    // convergence; the gap disclosed on #4063.)
+    if (fields.contains(QStringLiteral("waterfall"))) {
+        setWaterfallId(fields.value(QStringLiteral("waterfall")).toString());
+    }
 }
 
 } // namespace AetherSDR

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -2,6 +2,7 @@
 #include "core/PerfTelemetry.h"
 #include <QDebug>
 #include <algorithm>
+#include <cmath>
 
 namespace AetherSDR {
 
@@ -87,6 +88,25 @@ void PanadapterModel::setCenterBandwidth(double centerMhz, double bandwidthMhz)
     }
 }
 
+bool PanadapterModel::setRange(double minDbm, double maxDbm)
+{
+    bool changed = false;
+    // NaN means "leave unchanged" — the radio may report one bound without the
+    // other, and dBm is signed so a numeric sentinel would be ambiguous.
+    if (!std::isnan(minDbm) && float(minDbm) != m_minDbm) {
+        m_minDbm = float(minDbm);
+        changed = true;
+    }
+    if (!std::isnan(maxDbm) && float(maxDbm) != m_maxDbm) {
+        m_maxDbm = float(maxDbm);
+        changed = true;
+    }
+    if (changed) {
+        emit levelChanged(m_minDbm, m_maxDbm);
+    }
+    return changed;
+}
+
 void PanadapterModel::applyWnbExtension(const QVariantMap& fields)
 {
     bool dirty = false;
@@ -110,8 +130,6 @@ void PanadapterModel::applyWnbExtension(const QVariantMap& fields)
 
 void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
 {
-    bool levelChanged = false;
-
     // #3977: ownership is radio-authoritative. When another session reclaims
     // this pan (MultiFlex reconnect), the radio broadcasts the new
     // client_handle; tracking it here lets a superseded session stop
@@ -125,15 +143,8 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
     }
 
     // center/bandwidth now decode in FlexBackend → panCenterBandwidthChanged →
-    // setCenterBandwidth() (aetherd RFC 2.3, the first converted pan touchpoint).
-    if (kvs.contains("min_dbm")) {
-        float v = kvs["min_dbm"].toFloat();
-        if (v != m_minDbm) { m_minDbm = v; levelChanged = true; }
-    }
-    if (kvs.contains("max_dbm")) {
-        float v = kvs["max_dbm"].toFloat();
-        if (v != m_maxDbm) { m_maxDbm = v; levelChanged = true; }
-    }
+    // setCenterBandwidth(); min/max dBm likewise → panRangeChanged → setRange()
+    // (aetherd RFC 2.3 — the two converted universal pan display-geometry fields).
     if (kvs.contains("rfgain")) {
         int g = kvs["rfgain"].toInt();
         if (g != m_rfGain) {
@@ -220,9 +231,6 @@ void PanadapterModel::applyPanStatus(const QMap<QString, QString>& kvs)
             emit daxiqChannelChanged(ch);
         }
     }
-
-    if (levelChanged)
-        emit this->levelChanged(m_minDbm, m_maxDbm);
 }
 
 void PanadapterModel::applyWaterfallStatus(const QMap<QString, QString>& kvs)
@@ -240,20 +248,11 @@ void PanadapterModel::applyWaterfallStatus(const QMap<QString, QString>& kvs)
         }
     }
 
-    // Waterfall status shares center/bandwidth with pan — sync if present
-    if (kvs.contains("center") || kvs.contains("bandwidth")) {
-        bool changed = false;
-        if (kvs.contains("center")) {
-            double c = kvs["center"].toDouble();
-            if (c != m_centerMhz) { m_centerMhz = c; changed = true; }
-        }
-        if (kvs.contains("bandwidth")) {
-            double b = kvs["bandwidth"].toDouble();
-            if (b != m_bandwidthMhz) { m_bandwidthMhz = b; changed = true; }
-        }
-        if (changed)
-            emit infoChanged(m_centerMhz, m_bandwidthMhz);
-    }
+    // Waterfall status also carries center/bandwidth; those now decode through
+    // the same FlexBackend::decodePanCenterBandwidth path as pan status (driven
+    // from RadioModel's waterfall-status choke point), so the two ingestion
+    // surfaces are single-sourced. (aetherd RFC 2.3 — waterfall dual-parse
+    // convergence; the gap disclosed on #4063.)
 }
 
 } // namespace AetherSDR

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -63,6 +63,13 @@ public:
     int rfGainHigh() const { return m_rfGainHigh; }
     int rfGainStep() const { return m_rfGainStep; }
     void setRfGainInfo(int low, int high, int step);
+    // Normalized setters driven by the backend (aetherd RFC 2.3 — rfgain +
+    // antenna promoted to universal typed signals). Each emits its existing
+    // change-signal only on an actual change; the wire decode lives in
+    // FlexBackend, not here.
+    void setRfGain(int gain);
+    void setRxAntenna(const QString& ant);
+    void setAntList(const QStringList& ants);
     bool wnbActive() const { return m_wnbActive; }
     int wnbLevel() const { return m_wnbLevel; }
     bool wnbUpdating() const { return m_wnbUpdating; }
@@ -71,6 +78,11 @@ public:
     bool loopB() const { return m_loopB; }
     int fps() const { return m_fps; }
     int waterfallLineDuration() const { return m_waterfallLineDuration; }
+    // Normalized waterfall-line-duration setter driven by the backend (universal
+    // display timing). Feeds PerfTelemetry and always emits
+    // waterfallLineDurationReported; the change-gated signal fires only on a real
+    // change. (aetherd RFC 2.3.)
+    void setWaterfallLineDuration(int ms);
     int fftYPixels() const { return m_fftYPixels; }
     bool setFftYPixels(int yPixels) {
         if (m_fftYPixels == yPixels) {
@@ -95,9 +107,13 @@ public:
     bool isWaterfallConfigured() const { return m_wfConfigured; }
     void setWaterfallConfigured(bool c) { m_wfConfigured = c; }
 
-    // Apply status from protocol
-    void applyPanStatus(const QMap<QString, QString>& kvs);
-    void applyWaterfallStatus(const QMap<QString, QString>& kvs);
+    // Flex-specific display-pan state applied from the backend's namespaced
+    // extensionStatus("flex","panState",…): wide, loop A/B, fps, preamp, DAX-IQ
+    // channel, MultiFlex client_handle ownership, waterfall stream-id. Applies
+    // only the keys present. (aetherd RFC 2.3 — the decode lives in FlexBackend;
+    // this is the last of PanadapterModel's Flex status decode to move, so the
+    // old applyPanStatus/applyWaterfallStatus wire-decoders are now gone.)
+    void applyStateExtension(const QVariantMap& fields);
 
 signals:
     void infoChanged(double centerMhz, double bandwidthMhz);

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -43,6 +43,12 @@ public:
     // value means "leave unchanged" (the radio may report one without the
     // other). Emits infoChanged when either actually changes.
     void setCenterBandwidth(double centerMhz, double bandwidthMhz);
+    // Normalized display-level-range setter driven by the backend (aetherd RFC
+    // 2.3, second universal pan field). NaN for either bound means "leave
+    // unchanged" (dBm is signed, so no numeric sentinel is safe). Emits
+    // levelChanged when either bound actually changes; returns whether anything
+    // changed so the caller can gate the panStream setDbmRange side-effect.
+    bool setRange(double minDbm, double maxDbm);
     // Flex-specific WNB extension applied from the backend's namespaced
     // extensionStatus("flex","panWnb",…). Applies only the keys present;
     // emits wnbChanged/wnbStateChanged when anything changes. (aetherd RFC 2.3

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -434,6 +434,22 @@ RadioModel::RadioModel(QObject* parent)
         emit panadapterInfoChanged(pan->centerMhz(), pan->bandwidthMhz());
     });
 
+    // aetherd RFC 2.3: min/max dBm — the second universal pan field. The backend
+    // decodes the display level range; RadioModel applies it to the addressed
+    // pan and preserves the two side-effects the old inline block owned: the
+    // panStream setDbmRange (only when the range actually changed, to avoid a
+    // redundant GPU-scale reset) and the legacy panadapterLevelChanged signal.
+    connect(m_backend.get(), &IRadioBackend::panRangeChanged, this,
+            [this](const QString& panId, double minDbm, double maxDbm) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (!pan) return;
+        if (pan->setRange(minDbm, maxDbm)) {
+            m_panStream->setDbmRange(pan->panStreamId(), pan->minDbm(), pan->maxDbm());
+        }
+        emit panadapterLevelChanged(pan->minDbm(), pan->maxDbm());
+    });
+
     // aetherd RFC 2.3 extension template: Flex-specific pan fields (WNB) ride
     // the namespaced extensionStatus channel; RadioModel routes them to the
     // addressed PanadapterModel. Other namespaces/kinds are ignored here.
@@ -5014,6 +5030,13 @@ void RadioModel::onStatusReceived(const QString& object,
 
             if (ownerPan)
                 ownerPan->applyWaterfallStatus(kvs);
+            // aetherd RFC 2.3 waterfall dual-parse convergence: waterfall status
+            // also carries center/bandwidth. Route it through the same backend
+            // decode as pan status so the two ingestion surfaces are single-
+            // sourced onto setCenterBandwidth (the gap disclosed on #4063),
+            // instead of applyWaterfallStatus parsing them independently.
+            if (ownerPan && m_flexBackend)
+                m_flexBackend->decodePanCenterBandwidth(ownerPan->panId(), kvs);
             if (activeWfId().isEmpty() && ownerPan == activePanadapter())
                 ownerPan->setWaterfallId(wfId);
             updateStreamFilters();
@@ -5859,32 +5882,22 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
     auto* pan = m_panadapters.value(panId, nullptr);
     const bool panMatchedById = pan != nullptr;
     if (!pan) pan = activePanadapter();  // fallback
-    const float previousMinDbm = pan ? pan->minDbm() : 0.0f;
-    const float previousMaxDbm = pan ? pan->maxDbm() : 0.0f;
     if (pan) {
         pan->applyPanStatus(kvs);
     }
 
-    // aetherd RFC 2.3: center/bandwidth decode moved to the backend. Driving it
-    // from this choke point (not a live statusReceived observer) means both live
-    // and deferred/replayed status flow through the converted path. The
-    // panCenterBandwidthChanged signal applies to the model + emits the legacy
-    // panadapterInfoChanged (in the ctor-wired handler above).
+    // aetherd RFC 2.3: the universal display-geometry fields decode in the
+    // backend and drive the model via normalized signals. Driving them from this
+    // choke point (not a live statusReceived observer) means both live and
+    // deferred/replayed status flow through the converted path.
+    //   - center/bandwidth → panCenterBandwidthChanged → setCenterBandwidth
+    //     (+ legacy panadapterInfoChanged, in the ctor-wired handler)
+    //   - min/max dBm      → panRangeChanged → setRange (+ the setDbmRange GPU
+    //     side-effect and legacy panadapterLevelChanged, likewise ctor-wired)
     if (m_flexBackend) {
         m_flexBackend->decodePanCenterBandwidth(panId, kvs);
+        m_flexBackend->decodePanRange(panId, kvs);
         m_flexBackend->decodePanExtensions(panId, kvs);
-    }
-    if (kvs.contains("min_dbm") || kvs.contains("max_dbm")) {
-        const float minDbm = pan ? pan->minDbm() : kvs.value("min_dbm", "-130").toFloat();
-        const float maxDbm = pan ? pan->maxDbm() : kvs.value("max_dbm", "-20").toFloat();
-        if (pan) {
-            const bool levelChanged = (pan->minDbm() != previousMinDbm)
-                || (pan->maxDbm() != previousMaxDbm);
-            if (levelChanged) {
-                m_panStream->setDbmRange(pan->panStreamId(), minDbm, maxDbm);
-            }
-        }
-        emit panadapterLevelChanged(minDbm, maxDbm);
     }
     // Track usable ypixels from radio status — the radio encodes FFT bins as
     // pixel Y positions (0..ypixels-1), so PanadapterStream needs this for dBm

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -426,8 +426,7 @@ RadioModel::RadioModel(QObject* parent)
     // remaining universal fields and the other mixed models.)
     connect(m_backend.get(), &IRadioBackend::panCenterBandwidthChanged, this,
             [this](const QString& panId, double centerMhz, double bandwidthMhz) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
+        auto* pan = resolvePan(panId);
         if (!pan) return;
         pan->setCenterBandwidth(centerMhz, bandwidthMhz);
         // Legacy signal MainWindow still consumes (unchanged behavior).
@@ -436,13 +435,16 @@ RadioModel::RadioModel(QObject* parent)
 
     // aetherd RFC 2.3: min/max dBm — the second universal pan field. The backend
     // decodes the display level range; RadioModel applies it to the addressed
-    // pan and preserves the two side-effects the old inline block owned: the
-    // panStream setDbmRange (only when the range actually changed, to avoid a
-    // redundant GPU-scale reset) and the legacy panadapterLevelChanged signal.
+    // pan and preserves the two side-effects the old inline block owned (for the
+    // pan-resolved case): the panStream setDbmRange (only when the range actually
+    // changed, to avoid a redundant GPU-scale reset) and the legacy
+    // panadapterLevelChanged signal. (The old code also emitted a synthesized-
+    // default panadapterLevelChanged on the pan==null path; that signal now has
+    // no live consumer — per-pan levelChanged is used instead — so the no-pan
+    // emit is intentionally dropped rather than resurrected. #4065 review.)
     connect(m_backend.get(), &IRadioBackend::panRangeChanged, this,
             [this](const QString& panId, double minDbm, double maxDbm) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
+        auto* pan = resolvePan(panId);
         if (!pan) return;
         if (pan->setRange(minDbm, maxDbm)) {
             m_panStream->setDbmRange(pan->panStreamId(), pan->minDbm(), pan->maxDbm());
@@ -457,22 +459,17 @@ RadioModel::RadioModel(QObject* parent)
     // parse of ant_list in handlePanadapterStatus onto this single source.
     connect(m_backend.get(), &IRadioBackend::panRfGainChanged, this,
             [this](const QString& panId, int gain) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
-        if (pan) pan->setRfGain(gain);
+        if (auto* pan = resolvePan(panId)) pan->setRfGain(gain);
     });
     connect(m_backend.get(), &IRadioBackend::panRxAntennaChanged, this,
             [this](const QString& panId, const QString& ant) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
-        if (pan) pan->setRxAntenna(ant);
+        if (auto* pan = resolvePan(panId)) pan->setRxAntenna(ant);
     });
     connect(m_backend.get(), &IRadioBackend::panAntennaListChanged, this,
             [this](const QString& panId, const QStringList& ants) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
-        if (pan) pan->setAntList(ants);
+        if (auto* pan = resolvePan(panId)) pan->setAntList(ants);
         // Converged RadioModel-level antenna list (the old inline dual-parse).
+        // Not gated on a resolved pan — matches the old unconditional emit.
         if (ants != m_antList) {
             m_antList = ants;
             emit antListChanged(m_antList);
@@ -480,9 +477,7 @@ RadioModel::RadioModel(QObject* parent)
     });
     connect(m_backend.get(), &IRadioBackend::panWaterfallLineDurationChanged, this,
             [this](const QString& panId, int ms) {
-        auto* pan = m_panadapters.value(panId, nullptr);
-        if (!pan) pan = activePanadapter();
-        if (pan) pan->setWaterfallLineDuration(ms);
+        if (auto* pan = resolvePan(panId)) pan->setWaterfallLineDuration(ms);
     });
 
     // aetherd RFC 2.3 extension channel: Flex-specific pan fields ride the
@@ -498,8 +493,7 @@ RadioModel::RadioModel(QObject* parent)
         if (kind != QLatin1String("panWnb") && kind != QLatin1String("panState")) {
             return;
         }
-        auto* pan = m_panadapters.value(fields.value("panId").toString(), nullptr);
-        if (!pan) pan = activePanadapter();
+        auto* pan = resolvePan(fields.value("panId").toString());
         if (!pan) return;
         if (kind == QLatin1String("panWnb")) {
             pan->applyWnbExtension(fields);
@@ -735,9 +729,21 @@ RadioModel::~RadioModel()
 {
     // Disconnect RadioModel's own connections to the wire objects BEFORE they
     // are torn down, to prevent use-after-free (ASAN). (#502) The objects are
-    // still alive here — the backend owns them and destroys them next.
+    // still alive here — the backend owns them and destroys them next. The WAN
+    // connection also delivers statusReceived → handlePanadapterStatus / the
+    // waterfall handler, both of which now deref m_flexBackend — sever it too so
+    // a late WAN status can't reach a half-destroyed backend. (#4065 review)
     QObject::disconnect(m_connection, nullptr, this, nullptr);
     QObject::disconnect(m_panStream, nullptr, this, nullptr);
+    if (m_wanConn) {
+        QObject::disconnect(m_wanConn, nullptr, this, nullptr);
+    }
+
+    // Null the transitional alias BEFORE destroying the backend, so any status
+    // slot that runs during teardown finds the `if (m_flexBackend)` guards
+    // failing closed instead of dereferencing a backend mid-destruction. (#4063
+    // introduced the alias; #4065 review moved this null ahead of the reset.)
+    m_flexBackend = nullptr;
 
     // Destroy the backend, which owns the RadioConnection + PanadapterStream and
     // their worker threads: ~FlexBackend runs the exact #502 teardown ordering
@@ -746,12 +752,6 @@ RadioModel::~RadioModel()
     m_backend.reset();
     m_connection = nullptr;
     m_panStream = nullptr;
-    // The transitional alias points into the just-destroyed backend — null it so
-    // the many `if (m_flexBackend)` guards (decode calls in handlePanadapterStatus,
-    // the slice modeChangeRequested lambda) fail closed instead of dereferencing a
-    // dangling pointer. handlePanadapterStatus is also reachable via the WAN
-    // statusReceived connection, so this isn't purely theoretical. (#4063 review)
-    m_flexBackend = nullptr;
 }
 
 bool RadioModel::isConnected() const
@@ -1982,6 +1982,15 @@ PanadapterModel* RadioModel::activePanadapter() const
 PanadapterModel* RadioModel::panadapter(const QString& panId) const
 {
     return m_panadapters.value(panId, nullptr);
+}
+
+PanadapterModel* RadioModel::resolvePan(const QString& panId) const
+{
+    // Single source of the pan-addressing policy: the addressed pan, else the
+    // active one. Used by the aetherd RFC 2.3 backend-signal handlers so a future
+    // change (e.g. don't fall back for MultiFlex-owned pans) lands in one place.
+    auto* p = m_panadapters.value(panId, nullptr);
+    return p ? p : activePanadapter();
 }
 
 DisplayInventory::Report RadioModel::displayInventoryReport() const

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -450,17 +450,62 @@ RadioModel::RadioModel(QObject* parent)
         emit panadapterLevelChanged(pan->minDbm(), pan->maxDbm());
     });
 
-    // aetherd RFC 2.3 extension template: Flex-specific pan fields (WNB) ride
-    // the namespaced extensionStatus channel; RadioModel routes them to the
-    // addressed PanadapterModel. Other namespaces/kinds are ignored here.
+    // aetherd RFC 2.3: rfgain + antenna — universal pan fields (promoted per the
+    // 2026-07-05 classification). The backend decodes them; RadioModel drives the
+    // addressed pan. The antenna-list handler ALSO drives RadioModel's own
+    // m_antList/antListChanged, converging what used to be a second independent
+    // parse of ant_list in handlePanadapterStatus onto this single source.
+    connect(m_backend.get(), &IRadioBackend::panRfGainChanged, this,
+            [this](const QString& panId, int gain) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (pan) pan->setRfGain(gain);
+    });
+    connect(m_backend.get(), &IRadioBackend::panRxAntennaChanged, this,
+            [this](const QString& panId, const QString& ant) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (pan) pan->setRxAntenna(ant);
+    });
+    connect(m_backend.get(), &IRadioBackend::panAntennaListChanged, this,
+            [this](const QString& panId, const QStringList& ants) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (pan) pan->setAntList(ants);
+        // Converged RadioModel-level antenna list (the old inline dual-parse).
+        if (ants != m_antList) {
+            m_antList = ants;
+            emit antListChanged(m_antList);
+        }
+    });
+    connect(m_backend.get(), &IRadioBackend::panWaterfallLineDurationChanged, this,
+            [this](const QString& panId, int ms) {
+        auto* pan = m_panadapters.value(panId, nullptr);
+        if (!pan) pan = activePanadapter();
+        if (pan) pan->setWaterfallLineDuration(ms);
+    });
+
+    // aetherd RFC 2.3 extension channel: Flex-specific pan fields ride the
+    // namespaced extensionStatus channel; RadioModel routes them to the addressed
+    // PanadapterModel. Two kinds: "panWnb" (noise blanker) and "panState" (wide,
+    // loop, fps, preamp, DAX-IQ, MultiFlex client_handle, waterfall id). Other
+    // namespaces/kinds are ignored here.
     connect(m_backend.get(), &IRadioBackend::extensionStatus, this,
             [this](const QString& ns, const QString& kind, const QVariantMap& fields) {
-        if (ns != QLatin1String("flex") || kind != QLatin1String("panWnb")) {
+        if (ns != QLatin1String("flex")) {
+            return;
+        }
+        if (kind != QLatin1String("panWnb") && kind != QLatin1String("panState")) {
             return;
         }
         auto* pan = m_panadapters.value(fields.value("panId").toString(), nullptr);
         if (!pan) pan = activePanadapter();
-        if (pan) pan->applyWnbExtension(fields);
+        if (!pan) return;
+        if (kind == QLatin1String("panWnb")) {
+            pan->applyWnbExtension(fields);
+        } else {
+            pan->applyStateExtension(fields);
+        }
     });
 
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
@@ -5028,15 +5073,15 @@ void RadioModel::onStatusReceived(const QString& object,
                 ours = true;
             }
 
-            if (ownerPan)
-                ownerPan->applyWaterfallStatus(kvs);
-            // aetherd RFC 2.3 waterfall dual-parse convergence: waterfall status
-            // also carries center/bandwidth. Route it through the same backend
-            // decode as pan status so the two ingestion surfaces are single-
-            // sourced onto setCenterBandwidth (the gap disclosed on #4063),
-            // instead of applyWaterfallStatus parsing them independently.
-            if (ownerPan && m_flexBackend)
+            // aetherd RFC 2.3: waterfall status decode fully behind the seam.
+            // center/bandwidth converge onto the SAME decodePanCenterBandwidth as
+            // pan status (single-sourced, the #4063 gap), and line_duration → the
+            // universal panWaterfallLineDurationChanged. applyWaterfallStatus is
+            // gone — PanadapterModel no longer decodes the wire.
+            if (ownerPan && m_flexBackend) {
                 m_flexBackend->decodePanCenterBandwidth(ownerPan->panId(), kvs);
+                m_flexBackend->decodeWaterfallLineDuration(ownerPan->panId(), kvs);
+            }
             if (activeWfId().isEmpty() && ownerPan == activePanadapter())
                 ownerPan->setWaterfallId(wfId);
             updateStreamFilters();
@@ -5878,26 +5923,32 @@ void RadioModel::handleGpsStatus(const QString& rawBody)
 
 void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString, QString>& kvs)
 {
-    // Delegate to the specific PanadapterModel, not just the active one
+    // Resolve the addressed pan (fall back to active) for the y_pixels/resize
+    // bookkeeping below. All Flex status DECODE now lives in FlexBackend and
+    // drives the model via the normalized signals wired in the ctor — so there
+    // is no longer an applyPanStatus() call here (PanadapterModel holds no wire
+    // decoder). aetherd RFC 2.3: PanadapterModel touchpoint fully converted.
     auto* pan = m_panadapters.value(panId, nullptr);
     const bool panMatchedById = pan != nullptr;
     if (!pan) pan = activePanadapter();  // fallback
-    if (pan) {
-        pan->applyPanStatus(kvs);
-    }
 
-    // aetherd RFC 2.3: the universal display-geometry fields decode in the
-    // backend and drive the model via normalized signals. Driving them from this
-    // choke point (not a live statusReceived observer) means both live and
-    // deferred/replayed status flow through the converted path.
+    // Drive every converted pan field from this status choke point (not a live
+    // statusReceived observer) so both live and deferred/replayed status flow
+    // through the backend decode:
     //   - center/bandwidth → panCenterBandwidthChanged → setCenterBandwidth
-    //     (+ legacy panadapterInfoChanged, in the ctor-wired handler)
-    //   - min/max dBm      → panRangeChanged → setRange (+ the setDbmRange GPU
-    //     side-effect and legacy panadapterLevelChanged, likewise ctor-wired)
+    //   - min/max dBm      → panRangeChanged → setRange (+ setDbmRange side-effect)
+    //   - rfgain / antenna → panRfGainChanged / panRx/AntennaList (universal)
+    //   - WNB              → extensionStatus("flex","panWnb")
+    //   - wide/loop/fps/pre/daxiq/client_handle/waterfall → …("flex","panState")
+    // Each ctor-wired handler applies to the addressed pan and preserves the
+    // legacy signals/side-effects the old inline code owned.
     if (m_flexBackend) {
         m_flexBackend->decodePanCenterBandwidth(panId, kvs);
         m_flexBackend->decodePanRange(panId, kvs);
+        m_flexBackend->decodePanRfGain(panId, kvs);
+        m_flexBackend->decodePanAntenna(panId, kvs);
         m_flexBackend->decodePanExtensions(panId, kvs);
+        m_flexBackend->decodePanState(panId, kvs);
     }
     // Track usable ypixels from radio status — the radio encodes FFT bins as
     // pixel Y positions (0..ypixels-1), so PanadapterStream needs this for dBm
@@ -5923,13 +5974,9 @@ void RadioModel::handlePanadapterStatus(const QString& panId, const QMap<QString
             emit panDimensionsNeeded(pan->panId());
         }
     }
-    if (kvs.contains("ant_list")) {
-        const QStringList ants = kvs["ant_list"].split(',', Qt::SkipEmptyParts);
-        if (ants != m_antList) {
-            m_antList = ants;
-            emit antListChanged(m_antList);
-        }
-    }
+    // (ant_list is now decoded in FlexBackend → panAntennaListChanged, whose
+    // ctor handler drives both the pan model AND this m_antList/antListChanged —
+    // the old inline dual-parse here is gone. aetherd RFC 2.3.)
 
     // Configure the panadapter once we know its ID.
     if (pan && !pan->isResized() && isConnected()) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -318,6 +318,9 @@ public:
     void setActivePanId(const QString& id) { m_activePanId = id; }
     PanadapterModel* activePanadapter() const;
     PanadapterModel* panadapter(const QString& panId) const;
+    // Addressed pan, else active — the pan-addressing policy for the aetherd RFC
+    // 2.3 backend-signal handlers, single-sourced (#4065 review).
+    PanadapterModel* resolvePan(const QString& panId) const;
     QList<PanadapterModel*> panadapters() const { return m_panadapters.values(); }
 
     // Radio-authoritative display inventory vs what we own (#3856 Layer B).

--- a/tests/aetherd_pan_decode_test.cpp
+++ b/tests/aetherd_pan_decode_test.cpp
@@ -96,6 +96,18 @@ int main(int argc, char** argv)
             CHECK(qFuzzyCompare(a.at(1).toDouble(), -125.0));
             CHECK(qFuzzyCompare(a.at(2).toDouble(), -40.0));
         }
+
+        // Malformed present min_dbm → carried as NaN (unchanged), NOT 0.0 dBm
+        // (which would collapse the scale). max still parses. (#4065 review)
+        backend.decodePanRange(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("min_dbm"), QStringLiteral("junk")},
+                                {QStringLiteral("max_dbm"), QStringLiteral("-40")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(std::isnan(a.at(1).toDouble()));
+            CHECK(qFuzzyCompare(a.at(2).toDouble(), -40.0));
+        }
     }
 
     // ---- Facet 2: EXTENSION (WNB) + the wnb_level guard ----
@@ -148,6 +160,11 @@ int main(int argc, char** argv)
                                 {{QStringLiteral("rfgain"), QStringLiteral("-8")}});
         CHECK(gain.count() == 1);
         CHECK(gain.takeFirst().at(1).toInt() == -8);   // signed gain preserved
+
+        // Malformed rfgain → dropped, not emitted as 0. (#4065 review)
+        backend.decodePanRfGain(QStringLiteral("0x40000000"),
+                                {{QStringLiteral("rfgain"), QStringLiteral("nope")}});
+        CHECK(gain.count() == 0);
 
         backend.decodePanAntenna(QStringLiteral("0x40000000"),
                                  {{QStringLiteral("rxant"), QStringLiteral("ANT2")},

--- a/tests/aetherd_pan_decode_test.cpp
+++ b/tests/aetherd_pan_decode_test.cpp
@@ -15,6 +15,7 @@
 #include <QSignalSpy>
 #include <QVariantMap>
 #include <QString>
+#include <cmath>
 #include <cstdio>
 
 using namespace AetherSDR;
@@ -62,6 +63,38 @@ int main(int argc, char** argv)
             const QList<QVariant> a = spy.takeFirst();
             CHECK(qFuzzyCompare(a.at(1).toDouble(), 14.2));
             CHECK(qFuzzyCompare(a.at(2).toDouble(), 0.2));
+        }
+    }
+
+    // ---- Facet 1b: DECODE (min/max dBm) + the NaN "unchanged" sentinel ----
+    {
+        FlexBackend backend;
+        QSignalSpy spy(&backend, &IRadioBackend::panRangeChanged);
+
+        // Neither field present → no emission.
+        backend.decodePanRange(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("center"), QStringLiteral("7.1")}});
+        CHECK(spy.count() == 0);
+
+        // min_dbm only → emitted; max carries NaN (unchanged), min is signed.
+        backend.decodePanRange(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("min_dbm"), QStringLiteral("-130")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(qFuzzyCompare(a.at(1).toDouble(), -130.0));
+            CHECK(std::isnan(a.at(2).toDouble()));
+        }
+
+        // both present → both carried (both negative — proves no numeric sentinel).
+        backend.decodePanRange(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("min_dbm"), QStringLiteral("-125")},
+                                {QStringLiteral("max_dbm"), QStringLiteral("-40")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(qFuzzyCompare(a.at(1).toDouble(), -125.0));
+            CHECK(qFuzzyCompare(a.at(2).toDouble(), -40.0));
         }
     }
 
@@ -120,6 +153,19 @@ int main(int argc, char** argv)
         // No actual change → no emission.
         pan.setCenterBandwidth(7.15, -1.0);
         CHECK(info.count() == 0);
+
+        // setRange: NaN = "leave unchanged" (max held, only min moves); returns
+        // whether anything changed (gates the setDbmRange side-effect).
+        QSignalSpy lvl(&pan, &PanadapterModel::levelChanged);
+        const float origMax = pan.maxDbm();
+        CHECK(pan.setRange(-125.0, std::nan("")) == true);
+        CHECK(qFuzzyCompare(pan.minDbm(), -125.0f));
+        CHECK(qFuzzyCompare(pan.maxDbm(), origMax));
+        CHECK(lvl.count() == 1);
+        lvl.clear();
+        // Same values → no change, no emission, returns false.
+        CHECK(pan.setRange(-125.0, std::nan("")) == false);
+        CHECK(lvl.count() == 0);
 
         // applyWnbExtension applies only present keys and clamps the level.
         QSignalSpy wnbSpy(&pan, &PanadapterModel::wnbStateChanged);

--- a/tests/aetherd_pan_decode_test.cpp
+++ b/tests/aetherd_pan_decode_test.cpp
@@ -137,6 +137,92 @@ int main(int argc, char** argv)
         }
     }
 
+    // ---- Facet 1c: DECODE (rfgain / antenna — universal) ----
+    {
+        FlexBackend backend;
+        QSignalSpy gain(&backend, &IRadioBackend::panRfGainChanged);
+        QSignalSpy rxant(&backend, &IRadioBackend::panRxAntennaChanged);
+        QSignalSpy antlist(&backend, &IRadioBackend::panAntennaListChanged);
+
+        backend.decodePanRfGain(QStringLiteral("0x40000000"),
+                                {{QStringLiteral("rfgain"), QStringLiteral("-8")}});
+        CHECK(gain.count() == 1);
+        CHECK(gain.takeFirst().at(1).toInt() == -8);   // signed gain preserved
+
+        backend.decodePanAntenna(QStringLiteral("0x40000000"),
+                                 {{QStringLiteral("rxant"), QStringLiteral("ANT2")},
+                                  {QStringLiteral("ant_list"), QStringLiteral("ANT1,ANT2,RX_A")}});
+        CHECK(rxant.count() == 1);
+        CHECK(rxant.takeFirst().at(1).toString() == QStringLiteral("ANT2"));
+        CHECK(antlist.count() == 1);
+        CHECK(antlist.takeFirst().at(1).toStringList().size() == 3);
+    }
+
+    // ---- Facet 2b: EXTENSION (panState bundle) + client_handle #3977 ----
+    {
+        FlexBackend backend;
+        QSignalSpy spy(&backend, &IRadioBackend::extensionStatus);
+
+        // No panState keys → no emission.
+        backend.decodePanState(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("center"), QStringLiteral("7.1")}});
+        CHECK(spy.count() == 0);
+
+        backend.decodePanState(QStringLiteral("0x40000000"),
+                               {{QStringLiteral("wide"), QStringLiteral("1")},
+                                {QStringLiteral("loopa"), QStringLiteral("1")},
+                                {QStringLiteral("daxiq_channel"), QStringLiteral("3")},
+                                {QStringLiteral("client_handle"), QStringLiteral("0x5C0FFEE0")},
+                                {QStringLiteral("waterfall"), QStringLiteral("0x42000000")}});
+        CHECK(spy.count() == 1);
+        {
+            const QList<QVariant> a = spy.takeFirst();
+            CHECK(a.at(0).toString() == QStringLiteral("flex"));
+            CHECK(a.at(1).toString() == QStringLiteral("panState"));
+            const QVariantMap f = a.at(2).toMap();
+            CHECK(f.value(QStringLiteral("panId")).toString() == QStringLiteral("0x40000000"));
+            CHECK(f.contains(QStringLiteral("wide")));
+            CHECK(f.contains(QStringLiteral("client_handle")));
+            CHECK(!f.contains(QStringLiteral("fps")));   // absent key not carried
+        }
+    }
+
+    // ---- Facet 1d: DECODE (waterfall line_duration guard) ----
+    {
+        FlexBackend backend;
+        QSignalSpy spy(&backend, &IRadioBackend::panWaterfallLineDurationChanged);
+        backend.decodeWaterfallLineDuration(QStringLiteral("0x40000000"),
+                                            {{QStringLiteral("line_duration"), QStringLiteral("100")}});
+        CHECK(spy.count() == 1);
+        CHECK(spy.takeFirst().at(1).toInt() == 100);
+        // Malformed → dropped, not applied as 0.
+        backend.decodeWaterfallLineDuration(QStringLiteral("0x40000000"),
+                                            {{QStringLiteral("line_duration"), QStringLiteral("nope")}});
+        CHECK(spy.count() == 0);
+    }
+
+    // ---- Facet 3b: model sink — applyStateExtension incl. #3977 ownership ----
+    {
+        PanadapterModel pan(QStringLiteral("0x40000000"));
+        QSignalSpy wide(&pan, &PanadapterModel::wideChanged);
+        QSignalSpy dax(&pan, &PanadapterModel::daxiqChannelChanged);
+        QVariantMap st;
+        st.insert(QStringLiteral("wide"), QStringLiteral("1"));
+        st.insert(QStringLiteral("daxiq_channel"), QStringLiteral("3"));
+        st.insert(QStringLiteral("client_handle"), QStringLiteral("0x5C0FFEE0"));
+        pan.applyStateExtension(st);
+        CHECK(pan.wideActive() == true);
+        CHECK(wide.count() == 1);
+        CHECK(pan.daxiqChannel() == 3);
+        CHECK(dax.count() == 1);
+        // #3977: owner handle tracked (parsed hex, non-zero).
+        CHECK(pan.ownerHandle() == 0x5C0FFEE0u);
+        // A zero client_handle must NOT overwrite a known owner (fail-closed).
+        QVariantMap z; z.insert(QStringLiteral("client_handle"), QStringLiteral("0x0"));
+        pan.applyStateExtension(z);
+        CHECK(pan.ownerHandle() == 0x5C0FFEE0u);
+    }
+
     // ---- Facet 3: model sinks ----
     {
         PanadapterModel pan(QStringLiteral("0x40000000"));

--- a/tests/panadapter_model_rx_antenna_test.cpp
+++ b/tests/panadapter_model_rx_antenna_test.cpp
@@ -29,29 +29,32 @@ int main(int argc, char** argv)
     PanadapterModel pan(QStringLiteral("0x40000000"));
     QSignalSpy spy(&pan, &PanadapterModel::rxAntennaChanged);
 
-    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("ANT1")}});
+    // aetherd RFC 2.3: rxant/rfgain decode moved to FlexBackend; the model now
+    // exposes normalized setRxAntenna/setRfGain. This test pins their change-
+    // gating semantics (the wire→setter decode is covered by aetherd_pan_decode_test).
+    pan.setRxAntenna(QStringLiteral("ANT1"));
     EXPECT_EQ(pan.rxAntenna(), QStringLiteral("ANT1"));
     EXPECT_EQ(spy.count(), 1);
     EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("ANT1"));
 
-    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("ANT1")}});
+    pan.setRxAntenna(QStringLiteral("ANT1"));
     EXPECT_EQ(spy.count(), 0);
 
-    pan.applyPanStatus({{QStringLiteral("rxant"), QStringLiteral("RX_A")}});
+    pan.setRxAntenna(QStringLiteral("RX_A"));
     EXPECT_EQ(pan.rxAntenna(), QStringLiteral("RX_A"));
     EXPECT_EQ(spy.count(), 1);
     EXPECT_EQ(spy.takeFirst().at(0).toString(), QStringLiteral("RX_A"));
 
     QSignalSpy gainSpy(&pan, &PanadapterModel::rfGainChanged);
-    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("20")}});
+    pan.setRfGain(20);
     EXPECT_EQ(pan.rfGain(), 20);
     EXPECT_EQ(gainSpy.count(), 1);
     EXPECT_EQ(gainSpy.takeFirst().at(0).toInt(), 20);
 
-    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("20")}});
+    pan.setRfGain(20);
     EXPECT_EQ(gainSpy.count(), 0);
 
-    pan.applyPanStatus({{QStringLiteral("rfgain"), QStringLiteral("-8")}});
+    pan.setRfGain(-8);
     EXPECT_EQ(pan.rfGain(), -8);
     EXPECT_EQ(gainSpy.count(), 1);
     EXPECT_EQ(gainSpy.takeFirst().at(0).toInt(), -8);


### PR DESCRIPTION
Completes the **PanadapterModel** touchpoint of aetherd RFC 2.3 in a single pass — `applyPanStatus` and `applyWaterfallStatus` are **removed**; the model holds zero wire decode. Every Flex status field now decodes in `FlexBackend` and drives the model via normalized signals wired in `RadioModel`'s ctor. This is the first *fully converted* mixed model (the template PR #4063 proved the mold on two fields; this finishes the model).

## What moved behind the seam

**Universal typed signals** (rfgain + antenna promoted to universal per the 2026-07-05 classification — cross-radio concepts, so a second backend emits them and the existing UI works with zero vendor-specific handling):
- `panCenterBandwidthChanged`, `panRangeChanged` (min/max dBm), `panRfGainChanged`, `panRxAntennaChanged`, `panAntennaListChanged`, `panWaterfallLineDurationChanged`.
- Model gains normalized setters: `setRfGain` / `setRxAntenna` / `setAntList` / `setRange` / `setWaterfallLineDuration`.

**Flex extension channel** (namespaced `extensionStatus`):
- `"panWnb"` (from #4063) + new `"panState"` bundle: `wide`, loop A/B, `fps`, preamp, DAX-IQ channel, MultiFlex `client_handle`, waterfall stream-id → `PanadapterModel::applyStateExtension`.

**Convergences** (closing dual-parse gaps):
- RadioModel's duplicate `ant_list` parse folds onto `panAntennaListChanged`.
- Waterfall `center`/`bandwidth` + `line_duration` decode through the same backend path as pan status (single-sourced; the `center`/`bandwidth` gap was disclosed on #4063).

## Behavior-neutral — verified

Adversarially reviewed field-by-field (dropped guards, emit-timing, sentinels, ordering, pan-null path). Preserved verbatim:
- `fps` ok-guard + "reported-always / changed-on-change" quirk; `line_duration` ok-guard; loopA/loopB mutual-exclusion.
- #3977 `client_handle` fail-closed re-stamp (`parsed != 0 && parsed != current`) — the re-stamp moves from first→last field within `handlePanadapterStatus`, but the only ownership readers (`noteForeignPanWriteIfAny`, pan-reclaim) run at the **top** of status dispatch before this handler, so the ordering #3977 relies on is untouched. Pinned by a test.
- `-1.0` (center/bw) and `NaN` (dBm, signed) "unchanged" sentinels; the `setDbmRange` GPU side-effect + legacy `panadapterInfoChanged`/`panadapterLevelChanged` emits.
- FlexBackend is main-thread, so every `decodePan*` → signal → setter chain is a synchronous `DirectConnection` completing before the `y_pixels`/`configurePan` bookkeeping — status ordering is preserved.
- **One deliberate exception:** the old code emitted `panadapterLevelChanged` even on the pan==null path (synthesized `-130`/`-20` defaults). That signal now has **no live `connect()`** (spectrum consumer removed; per-pan `levelChanged` used instead), so the no-pan emit is intentionally dropped rather than resurrected as dead code.

## ⚠️ Also fixes a latent regression from #4063

Six GUI call sites used `applyPanStatus({{"center",…}})` as an **optimistic pre-echo model nudge** (zoom, tune, pan-follow, ATU pre-tune). #4063 moved center/bandwidth decode out of `applyPanStatus`, silently turning those calls into **no-ops** — so since #4063 merged, those workflows have waited a full radio round-trip to recenter (visible flicker/lag on `main`). Swapped to `setCenterBandwidth`, restoring the immediate repaint. This slipped #4063's review because the GUI callers weren't in that diff's scope.

## Tests / gates
- `aetherd_pan_decode_test` extended: rfgain/antenna decode, `panState` bundle, #3977 ownership fail-closed, `line_duration` malformed-guard, NaN/`-1` sentinels.
- `panadapter_model_rx_antenna_test` uses the new setters.
- **65/65 tests green**, engine-boundary `--strict` green, full app builds clean.
- Design doc pan row + classification decision (§6.5) updated.

## Next in 2.3
One complete PR per remaining mixed model: MeterModel → SliceModel → TransmitModel + RadioModel residual.

Refs #3849 (aetherd RFC tracking) — part of the step-2.3 touchpoint burndown (`docs/architecture/aetherd-touchpoints.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
