### PR TITLE
feat(aetherd): 2.3 — complete MeterModel conversion (meter-status decode behind the seam)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2553,6 +2553,13 @@ target_link_libraries(aetherd_pan_decode_test PRIVATE aethercore Qt6::Core Qt6::
 set_target_properties(aetherd_pan_decode_test PROPERTIES AUTOMOC ON)
 add_test(NAME aetherd_pan_decode_test COMMAND aetherd_pan_decode_test)
 
+# aetherd RFC 2.3 — MeterModel touchpoint: meter-status wire decode.
+add_executable(aetherd_meter_decode_test tests/aetherd_meter_decode_test.cpp)
+target_include_directories(aetherd_meter_decode_test PRIVATE src)
+target_link_libraries(aetherd_meter_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_meter_decode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_meter_decode_test COMMAND aetherd_meter_decode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -108,6 +108,15 @@ signals:
     void sliceChanged(int sliceId, const QVariantMap& changes);
     void sliceRemoved(int sliceId);
     void meterUpdate(const QString& meterId, double value);
+
+    // Meter definition catalog (aetherd RFC 2.3 — MeterModel touchpoint). The
+    // backend decodes the vendor meter-status wire format into a normalized
+    // definition; RadioModel drives the MeterModel. `fields` carries only the
+    // keys the wire reported (source, sourceIndex, name, unit, low, high,
+    // description) — the same present-only shape the old inline parse produced.
+    // The meter *values* stream on the data plane (VITA-49), separate from this.
+    void meterDefined(int index, const QVariantMap& fields);
+    void meterRemoved(int index);
     // Panadapter core display state (universal — every family has a pan center
     // and span). The backend decodes it from vendor status; RadioModel drives
     // the PanadapterModel. panId is the pan's identifier (opaque to the model).

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -349,6 +349,63 @@ void FlexBackend::decodePanExtensions(const QString& panId,
     }
 }
 
+void FlexBackend::decodeMeterStatus(const QString& rawBody)
+{
+    // Meter status body (FlexLib Radio.cs ParseMeterStatus):
+    //   Tokens separated by '#', each token is "index.key=value".
+    //   e.g. "7.src=SLC#7.num=0#7.nam=LEVEL#7.unit=dBm#7.low=-150.0#7.hi=20.0"
+    // Removal: "7 removed". Parsing verbatim from the old RadioModel path.
+    if (rawBody.contains(QStringLiteral("removed"))) {
+        const QStringList words = rawBody.split(' ', Qt::SkipEmptyParts);
+        if (!words.isEmpty()) {
+            bool ok = false;
+            const int idx = words[0].toInt(&ok);
+            if (ok) {
+                emit meterRemoved(idx);
+            }
+        }
+        return;
+    }
+
+    // Group tokens by meter index.
+    QMap<int, QMap<QString, QString>> grouped;
+    const QStringList tokens = rawBody.split('#', Qt::SkipEmptyParts);
+    for (const QString& token : tokens) {
+        const int dot = token.indexOf('.');
+        if (dot < 0) continue;
+        const int eq = token.indexOf('=', dot);
+        if (eq < 0) continue;
+        bool ok = false;
+        const int idx = token.left(dot).toInt(&ok);
+        if (!ok) continue;
+        grouped[idx][token.mid(dot + 1, eq - dot - 1)] = token.mid(eq + 1);
+    }
+
+    for (auto it = grouped.constBegin(); it != grouped.constEnd(); ++it) {
+        const QMap<QString, QString>& f = it.value();
+        // Carry only the keys the wire reported, normalized to the MeterDef
+        // field names RadioModel reconstructs (present-only — the old parse
+        // set MeterDef fields conditionally the same way).
+        QVariantMap def;
+        if (f.contains(QStringLiteral("src")))
+            def.insert(QStringLiteral("source"), f.value(QStringLiteral("src")));
+        if (f.contains(QStringLiteral("num")))
+            def.insert(QStringLiteral("sourceIndex"),
+                       f.value(QStringLiteral("num")).toInt(nullptr, 0));
+        if (f.contains(QStringLiteral("nam")))
+            def.insert(QStringLiteral("name"), f.value(QStringLiteral("nam")));
+        if (f.contains(QStringLiteral("unit")))
+            def.insert(QStringLiteral("unit"), f.value(QStringLiteral("unit")));
+        if (f.contains(QStringLiteral("low")))
+            def.insert(QStringLiteral("low"), f.value(QStringLiteral("low")).toDouble());
+        if (f.contains(QStringLiteral("hi")))
+            def.insert(QStringLiteral("high"), f.value(QStringLiteral("hi")).toDouble());
+        if (f.contains(QStringLiteral("desc")))
+            def.insert(QStringLiteral("description"), f.value(QStringLiteral("desc")));
+        emit meterDefined(it.key(), def);
+    }
+}
+
 void FlexBackend::send(const QString& cmd)
 {
     if (m_sink) {

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -99,6 +99,10 @@ public:
     // stream-id — bundled onto the namespaced extensionStatus("flex","panState")
     // channel. Present-only (each key rides only when the wire reported it).
     void decodePanState(const QString& panId, const QMap<QString, QString>& kvs);
+    // Decode the SmartSDR meter-status wire body (definitions or a "N removed"
+    // line) and emit the normalized meterDefined/meterRemoved signals. Mirrors
+    // FlexLib Radio.cs ParseMeterStatus. (aetherd RFC 2.3 — MeterModel touchpoint.)
+    void decodeMeterStatus(const QString& rawBody);
 
 private:
     void send(const QString& cmd);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -502,6 +502,33 @@ RadioModel::RadioModel(QObject* parent)
         }
     });
 
+    // aetherd RFC 2.3: MeterModel touchpoint. The backend decodes the SmartSDR
+    // meter-status wire format; RadioModel reconstructs the MeterDef (present-
+    // only, exactly as the old inline handleMeterStatus parse did) and drives the
+    // MeterModel. Meter *values* stay on the VITA-49 data plane (below).
+    connect(m_backend.get(), &IRadioBackend::meterDefined, this,
+            [this](int index, const QVariantMap& f) {
+        MeterDef def;
+        def.index = index;
+        if (f.contains(QStringLiteral("source")))
+            def.source = f.value(QStringLiteral("source")).toString();
+        if (f.contains(QStringLiteral("sourceIndex")))
+            def.sourceIndex = f.value(QStringLiteral("sourceIndex")).toInt();
+        if (f.contains(QStringLiteral("name")))
+            def.name = f.value(QStringLiteral("name")).toString();
+        if (f.contains(QStringLiteral("unit")))
+            def.unit = f.value(QStringLiteral("unit")).toString();
+        if (f.contains(QStringLiteral("low")))
+            def.low = f.value(QStringLiteral("low")).toDouble();
+        if (f.contains(QStringLiteral("high")))
+            def.high = f.value(QStringLiteral("high")).toDouble();
+        if (f.contains(QStringLiteral("description")))
+            def.description = f.value(QStringLiteral("description")).toString();
+        m_meterModel.defineMeter(def);
+    });
+    connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
+            [this](int index) { m_meterModel.removeMeter(index); });
+
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
     // WHEN a dax_rx stream must exist (refcounted acquire/release from the
     // bridge/TCI/RADE); RadioModel is the command plane that makes it so.
@@ -5849,55 +5876,14 @@ void RadioModel::handleSliceStatus(int id,
 
 void RadioModel::handleMeterStatus(const QString& rawBody)
 {
-    // Meter status body format (from FlexLib Radio.cs ParseMeterStatus):
-    //   Tokens separated by '#', each token is "index.key=value".
-    //   Example: "7.src=SLC#7.num=0#7.nam=LEVEL#7.unit=dBm#7.low=-150.0#7.hi=20.0"
-    //
-    // Removal format: "7 removed"
-
-    if (rawBody.contains("removed")) {
-        const QStringList words = rawBody.split(' ', Qt::SkipEmptyParts);
-        if (words.size() >= 1) {
-            bool ok = false;
-            const int idx = words[0].toInt(&ok);
-            if (ok) m_meterModel.removeMeter(idx);
-        }
-        return;
-    }
-
-    // Group tokens by meter index
-    QMap<int, QMap<QString, QString>> grouped;
-    const QStringList tokens = rawBody.split('#', Qt::SkipEmptyParts);
-
-    for (const QString& token : tokens) {
-        const int dot = token.indexOf('.');
-        if (dot < 0) continue;
-        const int eq = token.indexOf('=', dot);
-        if (eq < 0) continue;
-
-        bool ok = false;
-        const int idx = token.left(dot).toInt(&ok);
-        if (!ok) continue;
-
-        const QString key   = token.mid(dot + 1, eq - dot - 1);
-        const QString value = token.mid(eq + 1);
-        grouped[idx][key] = value;
-    }
-
-    for (auto it = grouped.constBegin(); it != grouped.constEnd(); ++it) {
-        const auto& fields = it.value();
-
-        MeterDef def;
-        def.index = it.key();
-        if (fields.contains("src"))  def.source      = fields["src"];
-        if (fields.contains("num"))  def.sourceIndex  = fields["num"].toInt(nullptr, 0);
-        if (fields.contains("nam"))  def.name         = fields["nam"];
-        if (fields.contains("unit")) def.unit         = fields["unit"];
-        if (fields.contains("low"))  def.low          = fields["low"].toDouble();
-        if (fields.contains("hi"))   def.high         = fields["hi"].toDouble();
-        if (fields.contains("desc")) def.description  = fields["desc"];
-
-        m_meterModel.defineMeter(def);
+    // aetherd RFC 2.3: the SmartSDR meter-status wire decode moved to
+    // FlexBackend::decodeMeterStatus, which emits meterDefined/meterRemoved →
+    // the ctor-wired handlers drive the MeterModel. Driving it from this choke
+    // point keeps both live and deferred/replayed meter status on the converted
+    // path. (MeterModel already held only core state; this removes the last Flex
+    // meter wire-decode from RadioModel.)
+    if (m_flexBackend) {
+        m_flexBackend->decodeMeterStatus(rawBody);
     }
 }
 

--- a/tests/aetherd_meter_decode_test.cpp
+++ b/tests/aetherd_meter_decode_test.cpp
@@ -1,0 +1,83 @@
+// aetherd RFC 2.3 — MeterModel touchpoint: FlexBackend::decodeMeterStatus.
+// Pins the SmartSDR meter-status wire decode (definitions + removal) that moved
+// out of RadioModel::handleMeterStatus.
+
+#include "core/backends/flex/FlexBackend.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QVariantMap>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ---- full definition ----
+    {
+        FlexBackend backend;
+        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
+        backend.decodeMeterStatus(QStringLiteral(
+            "7.src=SLC#7.num=0#7.nam=LEVEL#7.unit=dBm#7.low=-150.0#7.hi=20.0"));
+        CHECK(def.count() == 1);
+        {
+            const QList<QVariant> a = def.takeFirst();
+            CHECK(a.at(0).toInt() == 7);
+            const QVariantMap f = a.at(1).toMap();
+            CHECK(f.value(QStringLiteral("source")).toString() == QStringLiteral("SLC"));
+            CHECK(f.value(QStringLiteral("sourceIndex")).toInt() == 0);
+            CHECK(f.value(QStringLiteral("name")).toString() == QStringLiteral("LEVEL"));
+            CHECK(f.value(QStringLiteral("unit")).toString() == QStringLiteral("dBm"));
+            CHECK(qFuzzyCompare(f.value(QStringLiteral("low")).toDouble(), -150.0));
+            CHECK(qFuzzyCompare(f.value(QStringLiteral("high")).toDouble(), 20.0));
+            CHECK(!f.contains(QStringLiteral("description")));  // absent key not carried
+        }
+    }
+
+    // ---- removal ----
+    {
+        FlexBackend backend;
+        QSignalSpy rem(&backend, &IRadioBackend::meterRemoved);
+        backend.decodeMeterStatus(QStringLiteral("7 removed"));
+        CHECK(rem.count() == 1);
+        CHECK(rem.takeFirst().at(0).toInt() == 7);
+    }
+
+    // ---- multiple meters in one body, grouped by index ----
+    {
+        FlexBackend backend;
+        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
+        backend.decodeMeterStatus(QStringLiteral(
+            "1.src=TX#1.nam=FWDPWR#1.unit=Watts#2.src=TX#2.nam=SWR#2.unit=SWR"));
+        CHECK(def.count() == 2);
+        // QMap groups by ascending index → meter 1 first.
+        const QList<QVariant> a = def.takeFirst();
+        CHECK(a.at(0).toInt() == 1);
+        CHECK(a.at(1).toMap().value(QStringLiteral("name")).toString() == QStringLiteral("FWDPWR"));
+        const QList<QVariant> b = def.takeFirst();
+        CHECK(b.at(0).toInt() == 2);
+        CHECK(b.at(1).toMap().value(QStringLiteral("name")).toString() == QStringLiteral("SWR"));
+    }
+
+    // ---- malformed index token skipped, no emission ----
+    {
+        FlexBackend backend;
+        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
+        backend.decodeMeterStatus(QStringLiteral("x.src=SLC#x.nam=LEVEL"));
+        CHECK(def.count() == 0);
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherd_meter_decode_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherd_meter_decode_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Completes the **MeterModel** touchpoint of aetherd RFC 2.3 — the SmartSDR meter-status wire decode moves out of `RadioModel` into `FlexBackend`, behind the seam. Behavior-neutral.

MeterModel was already the cleanest of the five mixed models: it holds only core state (the `MeterDef` catalog + the smoothed values the UI renders via `MeterSmoother`), and the Flex-specific decode lived in `RadioModel::handleMeterStatus`. This moves that last piece behind the seam.

## What moved

- **IRadioBackend**: `meterDefined(int index, QVariantMap fields)` + `meterRemoved(int index)` — the normalized meter-definition catalog signals. (Meter *values* stream on the VITA-49 data plane, step 5 — untouched here.)
- **FlexBackend::decodeMeterStatus**: parses the `"N.key=value#…"` definition body and the `"N removed"` line — **verbatim** from the old `handleMeterStatus`, including the `num` base-0 parse, the `#`/`.`/`=` tokenizer, and present-only field extraction. `QMap` grouping preserves ascending-index emit order.
- **RadioModel**: `handleMeterStatus` is now a thin forwarder to `decodeMeterStatus` (driven from the status choke point, so live + deferred/replayed meter status both convert). The ctor-wired `meterDefined`/`meterRemoved` handlers reconstruct `MeterDef` **present-only** and call `defineMeter`/`removeMeter` exactly as before — so `defineMeter`'s SLC/LEVEL catalog caching and the `m_manifestSliceContext` side-effect run identically.

## Behavior-neutral — verified

- Field-by-field, the reconstructed `MeterDef` is byte-identical to the old inline parse (`src`→source, `num`→sourceIndex base-0, `nam`→name, `unit`, `low`/`hi`→double, `desc`→description; all present-only).
- `defineMeter` does a full replace (`m_defs[index] = def`) — the present-only reconstruction preserves exactly what the old code passed it.
- Emit order: `QMap<int,…>` iterates ascending index in both the backend group loop and (previously) the RadioModel loop, and each `meterDefined` emit is a synchronous `DirectConnection` (FlexBackend is main-thread) that runs `defineMeter` inline — so definition order and the choke-point ordering are preserved.
- Dual-parse hunt: no other meter-status parser exists in the tree.

## Tests / gates
- `aetherd_meter_decode_test`: full definition, `"N removed"`, multiple meters in one body (grouped), malformed index token skipped.
- **66/66 tests green**, engine-boundary `--strict` green, full app builds clean.

Refs #3849 (aetherd RFC tracking) — part of the step-2.3 touchpoint burndown (`docs/architecture/aetherd-touchpoints.md`).

## 2.3 progress
PanadapterModel ✅ (#4065) · **MeterModel (this PR)** · SliceModel → TransmitModel + RadioModel residual next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
