### PR TITLE
feat(aetherd): 2.3 — complete TransmitModel conversion (typed TransmitDelta, last mixed model)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2567,6 +2567,13 @@ target_link_libraries(aetherd_slice_decode_test PRIVATE aethercore Qt6::Core Qt6
 set_target_properties(aetherd_slice_decode_test PROPERTIES AUTOMOC ON)
 add_test(NAME aetherd_slice_decode_test COMMAND aetherd_slice_decode_test)
 
+# aetherd RFC 2.3 — TransmitModel touchpoint: transmit-family wire → typed delta.
+add_executable(aetherd_transmit_decode_test tests/aetherd_transmit_decode_test.cpp)
+target_include_directories(aetherd_transmit_decode_test PRIVATE src)
+target_link_libraries(aetherd_transmit_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_transmit_decode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_transmit_decode_test COMMAND aetherd_transmit_decode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp
@@ -2661,6 +2668,7 @@ if(UNIX)
     target_link_libraries(transmit_model_apd_test PRIVATE pthread)
 endif()
 set_target_properties(transmit_model_apd_test PROPERTIES AUTOMOC ON)
+add_test(NAME transmit_model_apd_test COMMAND transmit_model_apd_test)
 
 # Help guide search tests - needs QApplication + Widgets.
 add_executable(help_dialog_test

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -9,6 +9,7 @@
 
 #include "core/backends/RadioCapabilities.h"
 #include "core/backends/SliceDelta.h"
+#include "core/backends/TransmitDelta.h"
 
 namespace AetherSDR {
 
@@ -112,6 +113,12 @@ signals:
     void sliceChanged(int sliceId, const SliceDelta& delta);
     void sliceRemoved(int sliceId);
     void meterUpdate(const QString& meterId, double value);
+
+    // Normalized transmit-status delta (aetherd RFC 2.3 — TransmitModel
+    // touchpoint). Typed + compiler-checked; the backend populates only the
+    // fields the wire reported (across the transmit / interlock / ATU / APD /
+    // APD-sampler status planes) and RadioModel drives the TransmitModel.
+    void transmitChanged(const TransmitDelta& delta);
 
     // Meter definition catalog (aetherd RFC 2.3 — MeterModel touchpoint). The
     // backend decodes the vendor meter-status wire format into a normalized

--- a/src/core/backends/TransmitDelta.h
+++ b/src/core/backends/TransmitDelta.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <optional>
+
+#include <QMetaType>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// Normalized, vendor-neutral transmit-status delta (aetherd RFC 2.3 —
+// TransmitModel touchpoint). Same typed, compiler-checked, present-only contract
+// as SliceDelta: a backend populates only the fields the wire reported, and
+// TransmitModel::applyChanges applies exactly those. Covers the five Flex
+// transmit-family status planes (core transmit, interlock, ATU, APD, APD
+// sampler) — the FlexBackend decode owns the SmartSDR wire translation (key
+// names, "1"→bool, ok-guarded + clamped numeric parses, uppercase, list split).
+//
+// The ATU status is carried as its raw wire token (`atuStatusRaw`); the model
+// owns the ATUStatus enum + parse. The APD sampler is per-TX-antenna: a single
+// delta carries one antenna's (txAnt, available, selected) triple.
+struct TransmitDelta {
+    // ── Core transmit ──
+    std::optional<int>     rfPower;          // clamped 0..100
+    std::optional<int>     tunePower;        // clamped 0..100
+    std::optional<bool>    tune;
+    std::optional<bool>    mox;
+    std::optional<double>  transmitFreq;     // MHz
+    std::optional<int>     maxPowerLevel;    // unclamped
+    std::optional<QString> tuneMode;
+    std::optional<QString> txSliceMode;
+    std::optional<bool>    showTxInWaterfall;
+    std::optional<bool>    metInRx;
+
+    // ── Mic / monitor / processor ──
+    std::optional<QString> micSelection;     // uppercased
+    std::optional<int>     micLevel;         // 0..100
+    std::optional<bool>    micAcc;
+    std::optional<bool>    speechProcEnable;
+    std::optional<int>     speechProcLevel;  // 0..100
+    // compander / dexp are aliased on the wire: `compander` (or `dexp` when
+    // compander is absent) drives BOTH the compander (mic) and dexp (phone)
+    // member pairs; likewise compander_level / noise_gate_level.
+    std::optional<bool>    compander;
+    std::optional<int>     companderLevel;   // 0..100
+    std::optional<bool>    dax;
+    std::optional<bool>    sbMonitor;
+    std::optional<int>     monGainSb;        // 0..100
+
+    // ── VOX / phone ──
+    std::optional<bool>    voxEnable;
+    std::optional<int>     voxLevel;         // 0..100
+    std::optional<int>     voxDelay;         // 0..100
+    std::optional<bool>    micBoost;
+    std::optional<bool>    micBias;
+    std::optional<bool>    syncCwx;
+    std::optional<int>     amCarrierLevel;   // 0..100
+    std::optional<int>     txFilterLow;      // 0..10000 Hz
+    std::optional<int>     txFilterHigh;     // 0..10000 Hz
+
+    // ── CW ──
+    std::optional<int>     cwSpeed;          // 5..100
+    std::optional<int>     cwPitch;          // 100..6000
+    std::optional<bool>    cwBreakIn;
+    std::optional<int>     cwDelay;          // 0..2000
+    std::optional<bool>    cwSidetone;
+    std::optional<bool>    cwIambic;
+    std::optional<int>     cwIambicMode;     // 0..1
+    std::optional<bool>    cwSwapPaddles;
+    std::optional<bool>    cwlEnabled;
+    std::optional<int>     monGainCw;        // 0..100
+    std::optional<int>     monPanCw;         // 0..100
+
+    // ── Interlock (unclamped ints; no model emit) ──
+    std::optional<int>     accTxDelay;
+    std::optional<int>     tx1Delay;
+    std::optional<int>     tx2Delay;
+    std::optional<int>     tx3Delay;
+    std::optional<int>     txDelay;
+    std::optional<int>     interlockTimeout;
+    std::optional<int>     accTxReqPolarity;
+    std::optional<int>     rcaTxReqPolarity;
+
+    // ── ATU ──
+    std::optional<QString> atuStatusRaw;     // model parses to ATUStatus
+    std::optional<bool>    atuEnabled;
+    std::optional<bool>    memoriesEnabled;
+    std::optional<bool>    usingMemory;
+
+    // ── APD (amplifier protection) ──
+    std::optional<bool>    apdEnabled;
+    std::optional<bool>    apdConfigurable;
+    std::optional<bool>    apdEqActive;
+    // Bare `equalizer_reset` flag: model clears apdEqActive + emits the reset
+    // signal. Engaged (regardless of value) iff the wire carried the flag.
+    std::optional<bool>    apdEqualizerReset;
+
+    // ── APD sampler (per-TX-antenna; one antenna per delta) ──
+    std::optional<QString>     apdSamplerTxAnt;      // the map key (uppercased)
+    std::optional<QStringList> apdSamplerAvailable;  // INTERNAL-prepended, uppercased
+    std::optional<QString>     apdSamplerSelected;   // uppercased (model applies fallback)
+};
+
+}  // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::TransmitDelta)

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -386,20 +386,32 @@ void FlexBackend::decodeMeterStatus(const QString& rawBody)
         // Carry only the keys the wire reported, normalized to the MeterDef
         // field names RadioModel reconstructs (present-only — the old parse
         // set MeterDef fields conditionally the same way).
+        // Numeric fields are ok-guarded: a malformed present value is dropped,
+        // not applied as 0/0.0 (a bad low/hi would otherwise collapse a meter's
+        // scale). Consistent with the slice/pan/transmit boundary decoders and
+        // FlexLib's TryParse+continue. (#4066 deferred, folded into #PR D.)
         QVariantMap def;
         if (f.contains(QStringLiteral("src")))
             def.insert(QStringLiteral("source"), f.value(QStringLiteral("src")));
-        if (f.contains(QStringLiteral("num")))
-            def.insert(QStringLiteral("sourceIndex"),
-                       f.value(QStringLiteral("num")).toInt(nullptr, 0));
+        if (f.contains(QStringLiteral("num"))) {
+            bool ok = false;
+            const int v = f.value(QStringLiteral("num")).toInt(&ok, 0);  // base 0
+            if (ok) def.insert(QStringLiteral("sourceIndex"), v);
+        }
         if (f.contains(QStringLiteral("nam")))
             def.insert(QStringLiteral("name"), f.value(QStringLiteral("nam")));
         if (f.contains(QStringLiteral("unit")))
             def.insert(QStringLiteral("unit"), f.value(QStringLiteral("unit")));
-        if (f.contains(QStringLiteral("low")))
-            def.insert(QStringLiteral("low"), f.value(QStringLiteral("low")).toDouble());
-        if (f.contains(QStringLiteral("hi")))
-            def.insert(QStringLiteral("high"), f.value(QStringLiteral("hi")).toDouble());
+        if (f.contains(QStringLiteral("low"))) {
+            bool ok = false;
+            const double v = f.value(QStringLiteral("low")).toDouble(&ok);
+            if (ok) def.insert(QStringLiteral("low"), v);
+        }
+        if (f.contains(QStringLiteral("hi"))) {
+            bool ok = false;
+            const double v = f.value(QStringLiteral("hi")).toDouble(&ok);
+            if (ok) def.insert(QStringLiteral("high"), v);
+        }
         if (f.contains(QStringLiteral("desc")))
             def.insert(QStringLiteral("description"), f.value(QStringLiteral("desc")));
         emit meterDefined(it.key(), def);
@@ -550,6 +562,173 @@ void FlexBackend::decodeSliceStatus(int sliceId, const QMap<QString, QString>& k
     oStr("step_list", d.stepList);
 
     emit sliceChanged(sliceId, d);
+}
+
+// ── Transmit-family decoders (aetherd RFC 2.3 — TransmitModel touchpoint) ──
+// Each translates its Flex status plane into the typed TransmitDelta and emits
+// transmitChanged. Numeric parses are ok-guarded (malformed present field is
+// dropped, not applied as 0) and clamped to the model's ranges — the wire
+// normalization the old TransmitModel decoders did inline.
+namespace {
+// present-only, ok-guarded carriers over a Flex kv-set.
+inline void tBool(const QMap<QString, QString>& kvs, const char* wire,
+                  std::optional<bool>& f) {
+    if (kvs.contains(QLatin1String(wire)))
+        f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
+}
+inline void tInt(const QMap<QString, QString>& kvs, const char* wire,
+                 std::optional<int>& f) {
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
+        if (ok) f = v;
+    }
+}
+inline void tClamp(const QMap<QString, QString>& kvs, const char* wire,
+                   std::optional<int>& f, int lo, int hi) {
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
+        if (ok) f = qBound(lo, v, hi);
+    }
+}
+inline void tReal(const QMap<QString, QString>& kvs, const char* wire,
+                  std::optional<double>& f) {
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
+        if (ok) f = v;
+    }
+}
+}  // namespace
+
+void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
+{
+    TransmitDelta d;
+    // Core transmit
+    tClamp(kvs, "rfpower", d.rfPower, 0, 100);
+    tClamp(kvs, "tunepower", d.tunePower, 0, 100);
+    tBool(kvs, "tune", d.tune);
+    tBool(kvs, "mox", d.mox);
+    tReal(kvs, "freq", d.transmitFreq);
+
+    // Mic / monitor / processor
+    if (kvs.contains(QStringLiteral("mic_selection")))
+        d.micSelection = kvs.value(QStringLiteral("mic_selection")).toUpper();
+    tClamp(kvs, "mic_level", d.micLevel, 0, 100);
+    tBool(kvs, "mic_acc", d.micAcc);
+    tBool(kvs, "speech_processor_enable", d.speechProcEnable);
+    tClamp(kvs, "speech_processor_level", d.speechProcLevel, 0, 100);
+    tBool(kvs, "compander", d.compander);
+    tClamp(kvs, "compander_level", d.companderLevel, 0, 100);
+    tBool(kvs, "dax", d.dax);
+    tBool(kvs, "sb_monitor", d.sbMonitor);
+    tClamp(kvs, "mon_gain_sb", d.monGainSb, 0, 100);
+
+    // VOX / phone
+    tBool(kvs, "vox_enable", d.voxEnable);
+    tClamp(kvs, "vox_level", d.voxLevel, 0, 100);
+    tClamp(kvs, "vox_delay", d.voxDelay, 0, 100);
+    tBool(kvs, "mic_boost", d.micBoost);
+    tBool(kvs, "mic_bias", d.micBias);
+    tBool(kvs, "met_in_rx", d.metInRx);
+    tBool(kvs, "synccwx", d.syncCwx);
+    tClamp(kvs, "am_carrier_level", d.amCarrierLevel, 0, 100);
+    // dexp / noise_gate_level alias compander / compander_level, but only when
+    // the compander key itself is absent (the wire sends one or the other).
+    if (kvs.contains(QStringLiteral("dexp")) && !kvs.contains(QStringLiteral("compander")))
+        d.compander = kvs.value(QStringLiteral("dexp")) == QLatin1String("1");
+    if (kvs.contains(QStringLiteral("noise_gate_level"))
+        && !kvs.contains(QStringLiteral("compander_level"))) {
+        bool ok = false;
+        const int v = kvs.value(QStringLiteral("noise_gate_level")).toInt(&ok);
+        if (ok) d.companderLevel = qBound(0, v, 100);
+    }
+    tClamp(kvs, "lo", d.txFilterLow, 0, 10000);
+    tClamp(kvs, "hi", d.txFilterHigh, 0, 10000);
+
+    // CW
+    tClamp(kvs, "speed", d.cwSpeed, 5, 100);
+    tClamp(kvs, "pitch", d.cwPitch, 100, 6000);
+    tBool(kvs, "break_in", d.cwBreakIn);
+    tClamp(kvs, "break_in_delay", d.cwDelay, 0, 2000);
+    tBool(kvs, "sidetone", d.cwSidetone);
+    tBool(kvs, "iambic", d.cwIambic);
+    tClamp(kvs, "iambic_mode", d.cwIambicMode, 0, 1);
+    tBool(kvs, "swap_paddles", d.cwSwapPaddles);
+    tBool(kvs, "cwl_enabled", d.cwlEnabled);
+    tClamp(kvs, "mon_gain_cw", d.monGainCw, 0, 100);
+    tClamp(kvs, "mon_pan_cw", d.monPanCw, 0, 100);
+
+    // Misc TX
+    tInt(kvs, "max_power_level", d.maxPowerLevel);
+    if (kvs.contains(QStringLiteral("tune_mode")))
+        d.tuneMode = kvs.value(QStringLiteral("tune_mode"));
+    tBool(kvs, "show_tx_in_waterfall", d.showTxInWaterfall);
+    if (kvs.contains(QStringLiteral("tx_slice_mode")))
+        d.txSliceMode = kvs.value(QStringLiteral("tx_slice_mode"));
+
+    emit transmitChanged(d);
+}
+
+void FlexBackend::decodeInterlockStatus(const QMap<QString, QString>& kvs)
+{
+    TransmitDelta d;
+    tInt(kvs, "acc_tx_delay", d.accTxDelay);
+    tInt(kvs, "tx1_delay", d.tx1Delay);
+    tInt(kvs, "tx2_delay", d.tx2Delay);
+    tInt(kvs, "tx3_delay", d.tx3Delay);
+    tInt(kvs, "tx_delay", d.txDelay);
+    tInt(kvs, "timeout", d.interlockTimeout);
+    tInt(kvs, "acc_txreq_polarity", d.accTxReqPolarity);
+    tInt(kvs, "rca_txreq_polarity", d.rcaTxReqPolarity);
+    emit transmitChanged(d);
+}
+
+void FlexBackend::decodeAtuStatus(const QMap<QString, QString>& kvs)
+{
+    TransmitDelta d;
+    // Raw ATU status token — the model owns the ATUStatus enum + parse.
+    if (kvs.contains(QStringLiteral("status")))
+        d.atuStatusRaw = kvs.value(QStringLiteral("status"));
+    tBool(kvs, "atu_enabled", d.atuEnabled);
+    tBool(kvs, "memories_enabled", d.memoriesEnabled);
+    tBool(kvs, "using_mem", d.usingMemory);
+    emit transmitChanged(d);
+}
+
+void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
+{
+    TransmitDelta d;
+    tBool(kvs, "enable", d.apdEnabled);
+    tBool(kvs, "configurable", d.apdConfigurable);
+    tBool(kvs, "equalizer_active", d.apdEqActive);
+    // Bare flag (no `=`): the model clears apdEqActive + emits the reset signal.
+    if (kvs.contains(QStringLiteral("equalizer_reset")))
+        d.apdEqualizerReset = true;
+    emit transmitChanged(d);
+}
+
+void FlexBackend::decodeApdSamplerStatus(const QMap<QString, QString>& kvs)
+{
+    // Keyed by TX antenna; the radio sends one antenna per message. No tx_ant →
+    // nothing to route (matches the old early return, no emit).
+    const QString txAnt = kvs.value(QStringLiteral("tx_ant")).toUpper();
+    if (txAnt.isEmpty()) return;
+    TransmitDelta d;
+    d.apdSamplerTxAnt = txAnt;
+    if (kvs.contains(QStringLiteral("valid_samplers"))) {
+        QStringList avail{QStringLiteral("INTERNAL")};
+        for (const auto& p : kvs.value(QStringLiteral("valid_samplers"))
+                                 .split(',', Qt::SkipEmptyParts)) {
+            const QString u = p.trimmed().toUpper();
+            if (!u.isEmpty() && !avail.contains(u)) avail.append(u);
+        }
+        d.apdSamplerAvailable = avail;
+    }
+    if (kvs.contains(QStringLiteral("selected_sampler")))
+        d.apdSamplerSelected = kvs.value(QStringLiteral("selected_sampler")).toUpper();
+    emit transmitChanged(d);
 }
 
 void FlexBackend::send(const QString& cmd)

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -110,6 +110,17 @@ public:
     // (aetherd RFC 2.3 — SliceModel touchpoint, full canonical rename.)
     void decodeSliceStatus(int sliceId, const QMap<QString, QString>& kvs);
 
+    // Decode the five Flex transmit-family status planes into a normalized,
+    // typed TransmitDelta and emit transmitChanged (aetherd RFC 2.3 — TransmitModel
+    // touchpoint). Each owns its SmartSDR wire keys, "1"→bool, ok-guarded +
+    // clamped numeric parses, uppercase, and list split; the model applies the
+    // present fields. Called from the matching RadioModel status choke points.
+    void decodeTransmitStatus(const QMap<QString, QString>& kvs);
+    void decodeInterlockStatus(const QMap<QString, QString>& kvs);
+    void decodeAtuStatus(const QMap<QString, QString>& kvs);
+    void decodeApdStatus(const QMap<QString, QString>& kvs);
+    void decodeApdSamplerStatus(const QMap<QString, QString>& kvs);
+
 private:
     void send(const QString& cmd);
     void sendSlice(const QString& cmd);   // guarded slice path (§6)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -544,6 +544,14 @@ RadioModel::RadioModel(QObject* parent)
         }
     });
 
+    // aetherd RFC 2.3: TransmitModel touchpoint. The backend decodes the five
+    // Flex transmit-family status planes (transmit/interlock/ATU/APD/APD-sampler)
+    // into a typed TransmitDelta; RadioModel drives the TransmitModel. Driven
+    // synchronously from the matching decode*Status() calls in the status
+    // handlers (main-thread AutoConnection → DirectConnection).
+    connect(m_backend.get(), &IRadioBackend::transmitChanged, this,
+            [this](const TransmitDelta& delta) { m_transmitModel.applyChanges(delta); });
+
     // Centralized DAX RX channel ownership (#3305): PanadapterStream decides
     // WHEN a dax_rx stream must exist (refcounted acquire/release from the
     // bridge/TCI/RADE); RadioModel is the command plane that makes it so.
@@ -5154,7 +5162,7 @@ void RadioModel::onStatusReceived(const QString& object,
         const auto m = atuRe.match(object);
         if (m.hasMatch() && m_tunerModel.handle().isEmpty())
             m_tunerModel.setHandle(m.captured(1));
-        m_transmitModel.applyAtuStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeAtuStatus(kvs);
         if (m_tunerModel.isPresent())
             m_tunerModel.applyStatus(kvs);
         return;
@@ -5169,7 +5177,7 @@ void RadioModel::onStatusReceived(const QString& object,
     // Our parser splits object/kvs at the last space before the first '=',
     // so any leading bare flags get absorbed into the object name.
     if (object == "apd sampler") {
-        m_transmitModel.applyApdSamplerStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeApdSamplerStatus(kvs);
         return;
     }
     if (object == "apd" || object.startsWith("apd ")) {
@@ -5178,7 +5186,7 @@ void RadioModel::onStatusReceived(const QString& object,
             const QStringList flags = object.mid(4).split(' ', Qt::SkipEmptyParts);
             for (const auto& f : flags) merged.insert(f, QString{});
         }
-        m_transmitModel.applyApdStatus(merged);
+        if (m_flexBackend) m_flexBackend->decodeApdStatus(merged);
         return;
     }
 
@@ -5279,7 +5287,7 @@ void RadioModel::onStatusReceived(const QString& object,
 
     // Transmit status: "transmit rfpower=93 tunepower=38 tune=0 ..."
     if (object == "transmit") {
-        m_transmitModel.applyTransmitStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeTransmitStatus(kvs);
         return;
     }
 
@@ -5403,7 +5411,7 @@ void RadioModel::onStatusReceived(const QString& object,
             m_txOwnedByUs = (txOwner == clientHandle() || txOwner == 0);
         }
         // Parse interlock timing fields into TransmitModel (#498)
-        m_transmitModel.applyInterlockStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeInterlockStatus(kvs);
 
         // Track PTT source (#2373). The radio reports source=SW for software
         // MOX/CAT/xmit, and source=MIC|ACC|RCA for hardware-keyed PTT (mic
@@ -5517,7 +5525,7 @@ void RadioModel::onStatusReceived(const QString& object,
         } else {
             emit txOwnerChanged(false, {});  // we own TX (or nobody does)
         }
-        m_transmitModel.applyInterlockStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeInterlockStatus(kvs);
         return;
     }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -393,6 +393,15 @@ QJsonObject clientInfoToJson(quint32 handle,
 RadioModel::RadioModel(QObject* parent)
     : QObject(parent)
 {
+    // Register the typed seam-delta payloads so IRadioBackend's normalized
+    // signals survive a queued connection. Today decode*Status runs synchronously
+    // on this thread (AutoConnection → DirectConnection, no metatype needed), but
+    // if a backend is ever moved to a worker thread the connection becomes queued;
+    // without registration Qt would log "Cannot queue arguments of type …" and
+    // silently drop the emit. Idempotent + cheap. (#4071 review.)
+    qRegisterMetaType<SliceDelta>();
+    qRegisterMetaType<TransmitDelta>();
+
     // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
     // FlexBackend creates the RadioConnection and PanadapterStream on their
     // worker threads (in the load-bearing #502 order — panStream first) and

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -38,294 +38,145 @@ void TransmitModel::resetState()
 
 // ── Status parsing ──────────────────────────────────────────────────────────
 
-void TransmitModel::applyTransmitStatus(const QMap<QString, QString>& kvs)
+// aetherd RFC 2.3: the five Flex transmit-family status decoders
+// (applyTransmitStatus/Interlock/Atu/Apd/ApdSampler) moved to
+// FlexBackend::decode*Status, which translate the SmartSDR wire into a typed
+// TransmitDelta and emit transmitChanged. This applies the present fields —
+// no wire key names or "1"/clamp parsing remain here; only the model's business
+// logic (compander/dexp aliasing, the grouped emits, the ATU enum parse, the
+// per-antenna sampler map + selected-fallback) stays. Present-only: each field
+// is applied iff its optional is engaged.
+void TransmitModel::applyChanges(const TransmitDelta& d)
 {
     bool changed = false;
     bool tuneChanged_ = false;
-
-    if (kvs.contains("rfpower")) {
-        int v = qBound(0, kvs["rfpower"].toInt(), 100);
-        if (m_rfPower != v) { m_rfPower = v; changed = true; }
-    }
-    if (kvs.contains("tunepower")) {
-        int v = qBound(0, kvs["tunepower"].toInt(), 100);
-        if (m_tunePower != v) { m_tunePower = v; changed = true; }
-    }
-    if (kvs.contains("tune")) {
-        bool v = kvs["tune"] == "1";
-        if (m_tune != v) { m_tune = v; changed = true; tuneChanged_ = true; }
-    }
-    if (kvs.contains("mox")) {
-        bool v = kvs["mox"] == "1";
-        if (m_mox != v) { m_mox = v; changed = true; }
-    }
-    if (kvs.contains("freq")) {
-        double v = kvs["freq"].toDouble();
-        if (m_transmitFreq != v) { m_transmitFreq = v; changed = true; }
-    }
-
-    // ── Mic / monitor / processor keys ──────────────────────────────────────
     bool micChanged = false;
     bool phoneChanged = false;
-
-    if (kvs.contains("mic_selection")) {
-        QString v = kvs["mic_selection"].toUpper();
-        if (m_micSelection != v) { m_micSelection = v; micChanged = true; }
-    }
-    if (kvs.contains("mic_level")) {
-        int v = qBound(0, kvs["mic_level"].toInt(), 100);
-        if (m_micLevel != v) { m_micLevel = v; micChanged = true; }
-    }
-    if (kvs.contains("mic_acc")) {
-        bool v = kvs["mic_acc"] == "1";
-        if (m_micAcc != v) { m_micAcc = v; micChanged = true; }
-    }
-    if (kvs.contains("speech_processor_enable")) {
-        bool v = kvs["speech_processor_enable"] == "1";
-        if (m_speechProcEnable != v) { m_speechProcEnable = v; micChanged = true; }
-    }
-    if (kvs.contains("speech_processor_level")) {
-        int v = qBound(0, kvs["speech_processor_level"].toInt(), 100);
-        if (m_speechProcLevel != v) { m_speechProcLevel = v; micChanged = true; }
-    }
-    if (kvs.contains("compander")) {
-        bool v = kvs["compander"] == "1";
-        if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
-        if (m_dexpOn != v) { m_dexpOn = v; phoneChanged = true; }
-    }
-    if (kvs.contains("compander_level")) {
-        int v = qBound(0, kvs["compander_level"].toInt(), 100);
-        if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
-        if (m_dexpLevel != v) { m_dexpLevel = v; phoneChanged = true; }
-    }
-    if (kvs.contains("dax")) {
-        bool v = kvs["dax"] == "1";
-        if (m_daxOn != v) { m_daxOn = v; micChanged = true; }
-    }
-    if (kvs.contains("sb_monitor")) {
-        bool v = kvs["sb_monitor"] == "1";
-        if (m_sbMonitor != v) { m_sbMonitor = v; micChanged = true; }
-    }
-    if (kvs.contains("mon_gain_sb")) {
-        int v = qBound(0, kvs["mon_gain_sb"].toInt(), 100);
-        if (m_monGainSb != v) { m_monGainSb = v; micChanged = true; }
-    }
-
-    // ── VOX keys ───────────────────────────────────────────────────────────
-
-    if (kvs.contains("vox_enable")) {
-        bool v = kvs["vox_enable"] == "1";
-        if (m_voxEnable != v) { m_voxEnable = v; phoneChanged = true; }
-    }
-    if (kvs.contains("vox_level")) {
-        int v = qBound(0, kvs["vox_level"].toInt(), 100);
-        if (m_voxLevel != v) { m_voxLevel = v; phoneChanged = true; }
-    }
-    if (kvs.contains("vox_delay")) {
-        int v = qBound(0, kvs["vox_delay"].toInt(), 100);
-        if (m_voxDelay != v) { m_voxDelay = v; phoneChanged = true; }
-    }
-    if (kvs.contains("mic_boost")) {
-        bool v = kvs["mic_boost"] == "1";
-        if (m_micBoost != v) { m_micBoost = v; phoneChanged = true; }
-    }
-    if (kvs.contains("mic_bias")) {
-        bool v = kvs["mic_bias"] == "1";
-        if (m_micBias != v) { m_micBias = v; phoneChanged = true; }
-    }
-    if (kvs.contains("met_in_rx")) {
-        bool v = kvs["met_in_rx"] == "1";
-        if (m_metInRx != v) { m_metInRx = v; changed = true; }
-    }
-    if (kvs.contains("synccwx")) {
-        bool v = kvs["synccwx"] == "1";
-        if (m_syncCwx != v) { m_syncCwx = v; phoneChanged = true; }
-    }
-    if (kvs.contains("am_carrier_level")) {
-        int v = qBound(0, kvs["am_carrier_level"].toInt(), 100);
-        if (m_amCarrierLevel != v) { m_amCarrierLevel = v; phoneChanged = true; }
-    }
-    if (kvs.contains("dexp") && !kvs.contains("compander")) {
-        bool v = kvs["dexp"] == "1";
-        if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
-        if (m_dexpOn != v) { m_dexpOn = v; phoneChanged = true; }
-    }
-    if (kvs.contains("noise_gate_level") && !kvs.contains("compander_level")) {
-        int v = qBound(0, kvs["noise_gate_level"].toInt(), 100);
-        if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
-        if (m_dexpLevel != v) { m_dexpLevel = v; phoneChanged = true; }
-    }
     bool filterCutoffChanged = false;
-    if (kvs.contains("lo")) {
-        int v = qBound(0, kvs["lo"].toInt(), 10000);
-        if (m_txFilterLow != v) { m_txFilterLow = v; phoneChanged = true; filterCutoffChanged = true; }
-    }
-    if (kvs.contains("hi")) {
-        int v = qBound(0, kvs["hi"].toInt(), 10000);
-        if (m_txFilterHigh != v) { m_txFilterHigh = v; phoneChanged = true; filterCutoffChanged = true; }
-    }
 
-    // ── CW keys ──────────────────────────────────────────────────────────
-    if (kvs.contains("speed")) {
-        int v = qBound(5, kvs["speed"].toInt(), 100);
-        if (m_cwSpeed != v) { m_cwSpeed = v; phoneChanged = true; }
-    }
-    if (kvs.contains("pitch")) {
-        int v = qBound(100, kvs["pitch"].toInt(), 6000);
-        if (m_cwPitch != v) { m_cwPitch = v; phoneChanged = true; }
-    }
-    if (kvs.contains("break_in")) {
-        bool v = kvs["break_in"] == "1";
-        if (m_cwBreakIn != v) { m_cwBreakIn = v; phoneChanged = true; }
-    }
-    if (kvs.contains("break_in_delay")) {
-        int v = qBound(0, kvs["break_in_delay"].toInt(), 2000);
-        if (m_cwDelay != v) { m_cwDelay = v; phoneChanged = true; }
-    }
-    if (kvs.contains("sidetone")) {
-        bool v = kvs["sidetone"] == "1";
-        if (m_cwSidetone != v) { m_cwSidetone = v; phoneChanged = true; }
-    }
-    if (kvs.contains("iambic")) {
-        bool v = kvs["iambic"] == "1";
-        if (m_cwIambic != v) { m_cwIambic = v; phoneChanged = true; }
-    }
-    if (kvs.contains("iambic_mode")) {
-        int v = qBound(0, kvs["iambic_mode"].toInt(), 1);
-        if (m_cwIambicMode != v) { m_cwIambicMode = v; phoneChanged = true; }
-    }
-    if (kvs.contains("swap_paddles")) {
-        bool v = kvs["swap_paddles"] == "1";
-        if (m_cwSwapPaddles != v) { m_cwSwapPaddles = v; phoneChanged = true; }
-    }
-    if (kvs.contains("cwl_enabled")) {
-        bool v = kvs["cwl_enabled"] == "1";
-        if (m_cwlEnabled != v) { m_cwlEnabled = v; phoneChanged = true; }
-    }
-    if (kvs.contains("mon_gain_cw")) {
-        int v = qBound(0, kvs["mon_gain_cw"].toInt(), 100);
-        if (m_monGainCw != v) { m_monGainCw = v; phoneChanged = true; }
-    }
-    if (kvs.contains("mon_pan_cw")) {
-        int v = qBound(0, kvs["mon_pan_cw"].toInt(), 100);
-        if (m_monPanCw != v) { m_monPanCw = v; phoneChanged = true; }
-    }
+    // ── Core transmit ──
+    if (d.rfPower && m_rfPower != *d.rfPower)   { m_rfPower = *d.rfPower; changed = true; }
+    if (d.tunePower && m_tunePower != *d.tunePower) { m_tunePower = *d.tunePower; changed = true; }
+    if (d.tune && m_tune != *d.tune) { m_tune = *d.tune; changed = true; tuneChanged_ = true; }
+    if (d.mox && m_mox != *d.mox) { m_mox = *d.mox; changed = true; }
+    if (d.transmitFreq && m_transmitFreq != *d.transmitFreq) { m_transmitFreq = *d.transmitFreq; changed = true; }
 
-    if (kvs.contains("max_power_level")) {
-        int v = kvs["max_power_level"].toInt();
-        if (m_maxPowerLevel != v) { m_maxPowerLevel = v; changed = true; emit maxPowerLevelChanged(v); }
+    // ── Mic / monitor / processor ──
+    if (d.micSelection && m_micSelection != *d.micSelection) { m_micSelection = *d.micSelection; micChanged = true; }
+    if (d.micLevel && m_micLevel != *d.micLevel) { m_micLevel = *d.micLevel; micChanged = true; }
+    if (d.micAcc && m_micAcc != *d.micAcc) { m_micAcc = *d.micAcc; micChanged = true; }
+    if (d.speechProcEnable && m_speechProcEnable != *d.speechProcEnable) { m_speechProcEnable = *d.speechProcEnable; micChanged = true; }
+    if (d.speechProcLevel && m_speechProcLevel != *d.speechProcLevel) { m_speechProcLevel = *d.speechProcLevel; micChanged = true; }
+    // compander/dexp are aliased: one wire value drives BOTH member pairs (the
+    // compander → mic side and the dexp → phone side).
+    if (d.compander) {
+        const bool v = *d.compander;
+        if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
+        if (m_dexpOn != v)      { m_dexpOn = v;      phoneChanged = true; }
     }
-    if (kvs.contains("tune_mode")) {
-        QString v = kvs["tune_mode"];
-        if (m_tuneMode != v) { m_tuneMode = v; changed = true; }
+    if (d.companderLevel) {
+        const int v = *d.companderLevel;
+        if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
+        if (m_dexpLevel != v)      { m_dexpLevel = v;      phoneChanged = true; }
     }
-    if (kvs.contains("show_tx_in_waterfall")) {
-        bool v = kvs["show_tx_in_waterfall"] == "1";
-        if (m_showTxInWaterfall != v) { m_showTxInWaterfall = v; changed = true; }
-    }
-    if (kvs.contains("tx_slice_mode")) {
-        QString v = kvs["tx_slice_mode"];
-        if (m_txSliceMode != v) { m_txSliceMode = v; changed = true; emit txSliceModeChanged(v); }
-    }
+    if (d.dax && m_daxOn != *d.dax) { m_daxOn = *d.dax; micChanged = true; }
+    if (d.sbMonitor && m_sbMonitor != *d.sbMonitor) { m_sbMonitor = *d.sbMonitor; micChanged = true; }
+    if (d.monGainSb && m_monGainSb != *d.monGainSb) { m_monGainSb = *d.monGainSb; micChanged = true; }
 
+    // ── VOX / phone ──
+    if (d.voxEnable && m_voxEnable != *d.voxEnable) { m_voxEnable = *d.voxEnable; phoneChanged = true; }
+    if (d.voxLevel && m_voxLevel != *d.voxLevel) { m_voxLevel = *d.voxLevel; phoneChanged = true; }
+    if (d.voxDelay && m_voxDelay != *d.voxDelay) { m_voxDelay = *d.voxDelay; phoneChanged = true; }
+    if (d.micBoost && m_micBoost != *d.micBoost) { m_micBoost = *d.micBoost; phoneChanged = true; }
+    if (d.micBias && m_micBias != *d.micBias) { m_micBias = *d.micBias; phoneChanged = true; }
+    if (d.metInRx && m_metInRx != *d.metInRx) { m_metInRx = *d.metInRx; changed = true; }
+    if (d.syncCwx && m_syncCwx != *d.syncCwx) { m_syncCwx = *d.syncCwx; phoneChanged = true; }
+    if (d.amCarrierLevel && m_amCarrierLevel != *d.amCarrierLevel) { m_amCarrierLevel = *d.amCarrierLevel; phoneChanged = true; }
+    if (d.txFilterLow && m_txFilterLow != *d.txFilterLow) { m_txFilterLow = *d.txFilterLow; phoneChanged = true; filterCutoffChanged = true; }
+    if (d.txFilterHigh && m_txFilterHigh != *d.txFilterHigh) { m_txFilterHigh = *d.txFilterHigh; phoneChanged = true; filterCutoffChanged = true; }
+
+    // ── CW ──
+    if (d.cwSpeed && m_cwSpeed != *d.cwSpeed) { m_cwSpeed = *d.cwSpeed; phoneChanged = true; }
+    if (d.cwPitch && m_cwPitch != *d.cwPitch) { m_cwPitch = *d.cwPitch; phoneChanged = true; }
+    if (d.cwBreakIn && m_cwBreakIn != *d.cwBreakIn) { m_cwBreakIn = *d.cwBreakIn; phoneChanged = true; }
+    if (d.cwDelay && m_cwDelay != *d.cwDelay) { m_cwDelay = *d.cwDelay; phoneChanged = true; }
+    if (d.cwSidetone && m_cwSidetone != *d.cwSidetone) { m_cwSidetone = *d.cwSidetone; phoneChanged = true; }
+    if (d.cwIambic && m_cwIambic != *d.cwIambic) { m_cwIambic = *d.cwIambic; phoneChanged = true; }
+    if (d.cwIambicMode && m_cwIambicMode != *d.cwIambicMode) { m_cwIambicMode = *d.cwIambicMode; phoneChanged = true; }
+    if (d.cwSwapPaddles && m_cwSwapPaddles != *d.cwSwapPaddles) { m_cwSwapPaddles = *d.cwSwapPaddles; phoneChanged = true; }
+    if (d.cwlEnabled && m_cwlEnabled != *d.cwlEnabled) { m_cwlEnabled = *d.cwlEnabled; phoneChanged = true; }
+    if (d.monGainCw && m_monGainCw != *d.monGainCw) { m_monGainCw = *d.monGainCw; phoneChanged = true; }
+    if (d.monPanCw && m_monPanCw != *d.monPanCw) { m_monPanCw = *d.monPanCw; phoneChanged = true; }
+
+    // ── Misc TX (max_power_level / tx_slice_mode emit inline, like the old code) ──
+    if (d.maxPowerLevel && m_maxPowerLevel != *d.maxPowerLevel) { m_maxPowerLevel = *d.maxPowerLevel; changed = true; emit maxPowerLevelChanged(m_maxPowerLevel); }
+    if (d.tuneMode && m_tuneMode != *d.tuneMode) { m_tuneMode = *d.tuneMode; changed = true; }
+    if (d.showTxInWaterfall && m_showTxInWaterfall != *d.showTxInWaterfall) { m_showTxInWaterfall = *d.showTxInWaterfall; changed = true; }
+    if (d.txSliceMode && m_txSliceMode != *d.txSliceMode) { m_txSliceMode = *d.txSliceMode; changed = true; emit txSliceModeChanged(m_txSliceMode); }
+
+    // ── Interlock (no emit — plain state, matching applyInterlockStatus) ──
+    if (d.accTxDelay)       m_accTxDelay       = *d.accTxDelay;
+    if (d.tx1Delay)         m_tx1Delay         = *d.tx1Delay;
+    if (d.tx2Delay)         m_tx2Delay         = *d.tx2Delay;
+    if (d.tx3Delay)         m_tx3Delay         = *d.tx3Delay;
+    if (d.txDelay)          m_txDelay          = *d.txDelay;
+    if (d.interlockTimeout) m_interlockTimeout = *d.interlockTimeout;
+    if (d.accTxReqPolarity) m_accTxReqPolarity = *d.accTxReqPolarity;
+    if (d.rcaTxReqPolarity) m_rcaTxReqPolarity = *d.rcaTxReqPolarity;
+
+    // Core/mic/phone emits (same order the old applyTransmitStatus used).
     if (changed) emit stateChanged();
     if (tuneChanged_) emit tuneChanged(m_tune);
     if (micChanged) emit micStateChanged();
     if (phoneChanged) emit phoneStateChanged();
     if (filterCutoffChanged) emit txFilterCutoffChanged(m_txFilterLow, m_txFilterHigh);
-}
 
-void TransmitModel::applyInterlockStatus(const QMap<QString, QString>& kvs)
-{
-    if (kvs.contains("acc_tx_delay"))      m_accTxDelay = kvs["acc_tx_delay"].toInt();
-    if (kvs.contains("tx1_delay"))         m_tx1Delay = kvs["tx1_delay"].toInt();
-    if (kvs.contains("tx2_delay"))         m_tx2Delay = kvs["tx2_delay"].toInt();
-    if (kvs.contains("tx3_delay"))         m_tx3Delay = kvs["tx3_delay"].toInt();
-    if (kvs.contains("tx_delay"))          m_txDelay = kvs["tx_delay"].toInt();
-    if (kvs.contains("timeout"))           m_interlockTimeout = kvs["timeout"].toInt();
-    if (kvs.contains("acc_txreq_polarity"))m_accTxReqPolarity = kvs["acc_txreq_polarity"].toInt();
-    if (kvs.contains("rca_txreq_polarity"))m_rcaTxReqPolarity = kvs["rca_txreq_polarity"].toInt();
-}
-
-void TransmitModel::applyAtuStatus(const QMap<QString, QString>& kvs)
-{
-    bool changed = false;
-
-    if (kvs.contains("status")) {
-        auto s = parseAtuTuneStatus(kvs["status"]);
-        if (m_atuStatus != s) { m_atuStatus = s; changed = true; }
-    }
-    if (kvs.contains("atu_enabled")) {
-        bool v = kvs["atu_enabled"] == "1";
-        if (m_atuEnabled != v) { m_atuEnabled = v; changed = true; }
-    }
-    if (kvs.contains("memories_enabled")) {
-        bool v = kvs["memories_enabled"] == "1";
-        if (m_memoriesEnabled != v) { m_memoriesEnabled = v; changed = true; }
-    }
-    if (kvs.contains("using_mem")) {
-        bool v = kvs["using_mem"] == "1";
-        if (m_usingMemory != v) { m_usingMemory = v; changed = true; }
-    }
-
-    if (changed) emit atuStateChanged();
-}
-
-void TransmitModel::applyApdStatus(const QMap<QString, QString>& kvs)
-{
-    bool changed = false;
-
-    if (kvs.contains("enable")) {
-        bool v = kvs["enable"] == "1";
-        if (m_apdEnabled != v) { m_apdEnabled = v; changed = true; }
-    }
-    if (kvs.contains("configurable")) {
-        bool v = kvs["configurable"] == "1";
-        if (m_apdConfigurable != v) { m_apdConfigurable = v; changed = true; }
-    }
-    if (kvs.contains("equalizer_active")) {
-        bool v = kvs["equalizer_active"] == "1";
-        if (m_apdEqActive != v) { m_apdEqActive = v; changed = true; }
-    }
-    // Bare flag (no `=`) — radio signals all per-antenna equalizers cleared.
-    if (kvs.contains("equalizer_reset")) {
-        if (m_apdEqActive) { m_apdEqActive = false; changed = true; }
-        emit apdEqualizerResetReceived();
-    }
-
-    if (changed) emit apdStateChanged();
-}
-
-// "apd sampler tx_ant=ANT1 selected_sampler=RX_A valid_samplers=RX_A,XVTA"
-void TransmitModel::applyApdSamplerStatus(const QMap<QString, QString>& kvs)
-{
-    const QString txAnt = kvs.value("tx_ant").toUpper();
-    if (txAnt.isEmpty()) return;
-
-    ApdSampler s = m_apdSamplers.value(txAnt);
-    bool changed = false;
-
-    if (kvs.contains("valid_samplers")) {
-        QStringList ports = kvs["valid_samplers"].split(',', Qt::SkipEmptyParts);
-        QStringList avail{"INTERNAL"};
-        for (const auto& p : ports) {
-            const QString u = p.trimmed().toUpper();
-            if (!u.isEmpty() && !avail.contains(u)) avail.append(u);
+    // ── ATU (own emit; model owns the enum parse) ──
+    {
+        bool atuChanged = false;
+        if (d.atuStatusRaw) {
+            const ATUStatus s = parseAtuTuneStatus(*d.atuStatusRaw);
+            if (m_atuStatus != s) { m_atuStatus = s; atuChanged = true; }
         }
-        if (s.available != avail) { s.available = avail; changed = true; }
+        if (d.atuEnabled && m_atuEnabled != *d.atuEnabled) { m_atuEnabled = *d.atuEnabled; atuChanged = true; }
+        if (d.memoriesEnabled && m_memoriesEnabled != *d.memoriesEnabled) { m_memoriesEnabled = *d.memoriesEnabled; atuChanged = true; }
+        if (d.usingMemory && m_usingMemory != *d.usingMemory) { m_usingMemory = *d.usingMemory; atuChanged = true; }
+        if (atuChanged) emit atuStateChanged();
     }
 
-    if (kvs.contains("selected_sampler")) {
-        QString sel = kvs["selected_sampler"].toUpper();
-        // Match FlexLib: if selected_sampler isn't in the available list,
-        // fall back to INTERNAL.
-        if (!s.available.contains(sel)) sel = "INTERNAL";
-        if (s.selected != sel) { s.selected = sel; changed = true; }
+    // ── APD (own emit) ──
+    {
+        bool apdChanged = false;
+        if (d.apdEnabled && m_apdEnabled != *d.apdEnabled) { m_apdEnabled = *d.apdEnabled; apdChanged = true; }
+        if (d.apdConfigurable && m_apdConfigurable != *d.apdConfigurable) { m_apdConfigurable = *d.apdConfigurable; apdChanged = true; }
+        if (d.apdEqActive && m_apdEqActive != *d.apdEqActive) { m_apdEqActive = *d.apdEqActive; apdChanged = true; }
+        // Bare equalizer_reset flag: clear active + emit the reset signal.
+        if (d.apdEqualizerReset) {
+            if (m_apdEqActive) { m_apdEqActive = false; apdChanged = true; }
+            emit apdEqualizerResetReceived();
+        }
+        if (apdChanged) emit apdStateChanged();
     }
 
-    if (changed) {
-        m_apdSamplers.insert(txAnt, s);
-        emit apdSamplerChanged(txAnt);
+    // ── APD sampler (per-TX-antenna map + selected fallback) ──
+    if (d.apdSamplerTxAnt) {
+        const QString txAnt = *d.apdSamplerTxAnt;
+        ApdSampler s = m_apdSamplers.value(txAnt);
+        bool samplerChanged = false;
+        if (d.apdSamplerAvailable && s.available != *d.apdSamplerAvailable) {
+            s.available = *d.apdSamplerAvailable;
+            samplerChanged = true;
+        }
+        if (d.apdSamplerSelected) {
+            QString sel = *d.apdSamplerSelected;
+            // Fall back to INTERNAL if the selected port isn't available (FlexLib).
+            if (!s.available.contains(sel)) sel = QStringLiteral("INTERNAL");
+            if (s.selected != sel) { s.selected = sel; samplerChanged = true; }
+        }
+        if (samplerChanged) {
+            m_apdSamplers.insert(txAnt, s);
+            emit apdSamplerChanged(txAnt);
+        }
     }
 }
 

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -46,6 +46,19 @@ void TransmitModel::resetState()
 // logic (compander/dexp aliasing, the grouped emits, the ATU enum parse, the
 // per-antenna sampler map + selected-fallback) stays. Present-only: each field
 // is applied iff its optional is engaged.
+namespace {
+// Present-only change-apply: writes *src into dst iff engaged AND different,
+// returning whether it changed. Collapses the ~50 field-apply lines and names
+// the emit-flag exactly once per call site (#4071 review). The compander/dexp
+// alias, ATU parse, and sampler map stay bespoke below.
+template <class T>
+bool assign(const std::optional<T>& src, T& dst)
+{
+    if (src && dst != *src) { dst = *src; return true; }
+    return false;
+}
+}  // namespace
+
 void TransmitModel::applyChanges(const TransmitDelta& d)
 {
     bool changed = false;
@@ -55,20 +68,21 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
     bool filterCutoffChanged = false;
 
     // ── Core transmit ──
-    if (d.rfPower && m_rfPower != *d.rfPower)   { m_rfPower = *d.rfPower; changed = true; }
-    if (d.tunePower && m_tunePower != *d.tunePower) { m_tunePower = *d.tunePower; changed = true; }
-    if (d.tune && m_tune != *d.tune) { m_tune = *d.tune; changed = true; tuneChanged_ = true; }
-    if (d.mox && m_mox != *d.mox) { m_mox = *d.mox; changed = true; }
-    if (d.transmitFreq && m_transmitFreq != *d.transmitFreq) { m_transmitFreq = *d.transmitFreq; changed = true; }
+    changed |= assign(d.rfPower, m_rfPower);
+    changed |= assign(d.tunePower, m_tunePower);
+    if (assign(d.tune, m_tune)) { changed = true; tuneChanged_ = true; }
+    changed |= assign(d.mox, m_mox);
+    changed |= assign(d.transmitFreq, m_transmitFreq);
 
     // ── Mic / monitor / processor ──
-    if (d.micSelection && m_micSelection != *d.micSelection) { m_micSelection = *d.micSelection; micChanged = true; }
-    if (d.micLevel && m_micLevel != *d.micLevel) { m_micLevel = *d.micLevel; micChanged = true; }
-    if (d.micAcc && m_micAcc != *d.micAcc) { m_micAcc = *d.micAcc; micChanged = true; }
-    if (d.speechProcEnable && m_speechProcEnable != *d.speechProcEnable) { m_speechProcEnable = *d.speechProcEnable; micChanged = true; }
-    if (d.speechProcLevel && m_speechProcLevel != *d.speechProcLevel) { m_speechProcLevel = *d.speechProcLevel; micChanged = true; }
+    micChanged |= assign(d.micSelection, m_micSelection);
+    micChanged |= assign(d.micLevel, m_micLevel);
+    micChanged |= assign(d.micAcc, m_micAcc);
+    micChanged |= assign(d.speechProcEnable, m_speechProcEnable);
+    micChanged |= assign(d.speechProcLevel, m_speechProcLevel);
     // compander/dexp are aliased: one wire value drives BOTH member pairs (the
-    // compander → mic side and the dexp → phone side).
+    // compander → mic side and the dexp → phone side). Bespoke — one optional,
+    // two members, two flags.
     if (d.compander) {
         const bool v = *d.compander;
         if (m_companderOn != v) { m_companderOn = v; micChanged = true; }
@@ -79,40 +93,40 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
         if (m_companderLevel != v) { m_companderLevel = v; micChanged = true; }
         if (m_dexpLevel != v)      { m_dexpLevel = v;      phoneChanged = true; }
     }
-    if (d.dax && m_daxOn != *d.dax) { m_daxOn = *d.dax; micChanged = true; }
-    if (d.sbMonitor && m_sbMonitor != *d.sbMonitor) { m_sbMonitor = *d.sbMonitor; micChanged = true; }
-    if (d.monGainSb && m_monGainSb != *d.monGainSb) { m_monGainSb = *d.monGainSb; micChanged = true; }
+    micChanged |= assign(d.dax, m_daxOn);
+    micChanged |= assign(d.sbMonitor, m_sbMonitor);
+    micChanged |= assign(d.monGainSb, m_monGainSb);
 
     // ── VOX / phone ──
-    if (d.voxEnable && m_voxEnable != *d.voxEnable) { m_voxEnable = *d.voxEnable; phoneChanged = true; }
-    if (d.voxLevel && m_voxLevel != *d.voxLevel) { m_voxLevel = *d.voxLevel; phoneChanged = true; }
-    if (d.voxDelay && m_voxDelay != *d.voxDelay) { m_voxDelay = *d.voxDelay; phoneChanged = true; }
-    if (d.micBoost && m_micBoost != *d.micBoost) { m_micBoost = *d.micBoost; phoneChanged = true; }
-    if (d.micBias && m_micBias != *d.micBias) { m_micBias = *d.micBias; phoneChanged = true; }
-    if (d.metInRx && m_metInRx != *d.metInRx) { m_metInRx = *d.metInRx; changed = true; }
-    if (d.syncCwx && m_syncCwx != *d.syncCwx) { m_syncCwx = *d.syncCwx; phoneChanged = true; }
-    if (d.amCarrierLevel && m_amCarrierLevel != *d.amCarrierLevel) { m_amCarrierLevel = *d.amCarrierLevel; phoneChanged = true; }
-    if (d.txFilterLow && m_txFilterLow != *d.txFilterLow) { m_txFilterLow = *d.txFilterLow; phoneChanged = true; filterCutoffChanged = true; }
-    if (d.txFilterHigh && m_txFilterHigh != *d.txFilterHigh) { m_txFilterHigh = *d.txFilterHigh; phoneChanged = true; filterCutoffChanged = true; }
+    phoneChanged |= assign(d.voxEnable, m_voxEnable);
+    phoneChanged |= assign(d.voxLevel, m_voxLevel);
+    phoneChanged |= assign(d.voxDelay, m_voxDelay);
+    phoneChanged |= assign(d.micBoost, m_micBoost);
+    phoneChanged |= assign(d.micBias, m_micBias);
+    changed      |= assign(d.metInRx, m_metInRx);   // met_in_rx → stateChanged, not phone
+    phoneChanged |= assign(d.syncCwx, m_syncCwx);
+    phoneChanged |= assign(d.amCarrierLevel, m_amCarrierLevel);
+    if (assign(d.txFilterLow, m_txFilterLow))   { phoneChanged = true; filterCutoffChanged = true; }
+    if (assign(d.txFilterHigh, m_txFilterHigh)) { phoneChanged = true; filterCutoffChanged = true; }
 
     // ── CW ──
-    if (d.cwSpeed && m_cwSpeed != *d.cwSpeed) { m_cwSpeed = *d.cwSpeed; phoneChanged = true; }
-    if (d.cwPitch && m_cwPitch != *d.cwPitch) { m_cwPitch = *d.cwPitch; phoneChanged = true; }
-    if (d.cwBreakIn && m_cwBreakIn != *d.cwBreakIn) { m_cwBreakIn = *d.cwBreakIn; phoneChanged = true; }
-    if (d.cwDelay && m_cwDelay != *d.cwDelay) { m_cwDelay = *d.cwDelay; phoneChanged = true; }
-    if (d.cwSidetone && m_cwSidetone != *d.cwSidetone) { m_cwSidetone = *d.cwSidetone; phoneChanged = true; }
-    if (d.cwIambic && m_cwIambic != *d.cwIambic) { m_cwIambic = *d.cwIambic; phoneChanged = true; }
-    if (d.cwIambicMode && m_cwIambicMode != *d.cwIambicMode) { m_cwIambicMode = *d.cwIambicMode; phoneChanged = true; }
-    if (d.cwSwapPaddles && m_cwSwapPaddles != *d.cwSwapPaddles) { m_cwSwapPaddles = *d.cwSwapPaddles; phoneChanged = true; }
-    if (d.cwlEnabled && m_cwlEnabled != *d.cwlEnabled) { m_cwlEnabled = *d.cwlEnabled; phoneChanged = true; }
-    if (d.monGainCw && m_monGainCw != *d.monGainCw) { m_monGainCw = *d.monGainCw; phoneChanged = true; }
-    if (d.monPanCw && m_monPanCw != *d.monPanCw) { m_monPanCw = *d.monPanCw; phoneChanged = true; }
+    phoneChanged |= assign(d.cwSpeed, m_cwSpeed);
+    phoneChanged |= assign(d.cwPitch, m_cwPitch);
+    phoneChanged |= assign(d.cwBreakIn, m_cwBreakIn);
+    phoneChanged |= assign(d.cwDelay, m_cwDelay);
+    phoneChanged |= assign(d.cwSidetone, m_cwSidetone);
+    phoneChanged |= assign(d.cwIambic, m_cwIambic);
+    phoneChanged |= assign(d.cwIambicMode, m_cwIambicMode);
+    phoneChanged |= assign(d.cwSwapPaddles, m_cwSwapPaddles);
+    phoneChanged |= assign(d.cwlEnabled, m_cwlEnabled);
+    phoneChanged |= assign(d.monGainCw, m_monGainCw);
+    phoneChanged |= assign(d.monPanCw, m_monPanCw);
 
     // ── Misc TX (max_power_level / tx_slice_mode emit inline, like the old code) ──
-    if (d.maxPowerLevel && m_maxPowerLevel != *d.maxPowerLevel) { m_maxPowerLevel = *d.maxPowerLevel; changed = true; emit maxPowerLevelChanged(m_maxPowerLevel); }
-    if (d.tuneMode && m_tuneMode != *d.tuneMode) { m_tuneMode = *d.tuneMode; changed = true; }
-    if (d.showTxInWaterfall && m_showTxInWaterfall != *d.showTxInWaterfall) { m_showTxInWaterfall = *d.showTxInWaterfall; changed = true; }
-    if (d.txSliceMode && m_txSliceMode != *d.txSliceMode) { m_txSliceMode = *d.txSliceMode; changed = true; emit txSliceModeChanged(m_txSliceMode); }
+    if (assign(d.maxPowerLevel, m_maxPowerLevel)) { changed = true; emit maxPowerLevelChanged(m_maxPowerLevel); }
+    changed |= assign(d.tuneMode, m_tuneMode);
+    changed |= assign(d.showTxInWaterfall, m_showTxInWaterfall);
+    if (assign(d.txSliceMode, m_txSliceMode)) { changed = true; emit txSliceModeChanged(m_txSliceMode); }
 
     // ── Interlock (no emit — plain state, matching applyInterlockStatus) ──
     if (d.accTxDelay)       m_accTxDelay       = *d.accTxDelay;
@@ -138,18 +152,18 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
             const ATUStatus s = parseAtuTuneStatus(*d.atuStatusRaw);
             if (m_atuStatus != s) { m_atuStatus = s; atuChanged = true; }
         }
-        if (d.atuEnabled && m_atuEnabled != *d.atuEnabled) { m_atuEnabled = *d.atuEnabled; atuChanged = true; }
-        if (d.memoriesEnabled && m_memoriesEnabled != *d.memoriesEnabled) { m_memoriesEnabled = *d.memoriesEnabled; atuChanged = true; }
-        if (d.usingMemory && m_usingMemory != *d.usingMemory) { m_usingMemory = *d.usingMemory; atuChanged = true; }
+        atuChanged |= assign(d.atuEnabled, m_atuEnabled);
+        atuChanged |= assign(d.memoriesEnabled, m_memoriesEnabled);
+        atuChanged |= assign(d.usingMemory, m_usingMemory);
         if (atuChanged) emit atuStateChanged();
     }
 
     // ── APD (own emit) ──
     {
         bool apdChanged = false;
-        if (d.apdEnabled && m_apdEnabled != *d.apdEnabled) { m_apdEnabled = *d.apdEnabled; apdChanged = true; }
-        if (d.apdConfigurable && m_apdConfigurable != *d.apdConfigurable) { m_apdConfigurable = *d.apdConfigurable; apdChanged = true; }
-        if (d.apdEqActive && m_apdEqActive != *d.apdEqActive) { m_apdEqActive = *d.apdEqActive; apdChanged = true; }
+        apdChanged |= assign(d.apdEnabled, m_apdEnabled);
+        apdChanged |= assign(d.apdConfigurable, m_apdConfigurable);
+        apdChanged |= assign(d.apdEqActive, m_apdEqActive);
         // Bare equalizer_reset flag: clear active + emit the reset signal.
         if (d.apdEqualizerReset) {
             if (m_apdEqActive) { m_apdEqActive = false; apdChanged = true; }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -6,6 +6,8 @@
 #include <QString>
 #include <QStringList>
 
+#include "core/backends/TransmitDelta.h"
+
 #include <functional>
 
 class QTimer;
@@ -130,12 +132,11 @@ public:
     QString     activeMicProfile()  const { return m_activeMicProfile; }
     QStringList micInputList()      const { return m_micInputList; }
 
-    // ── Status parsing (called from RadioModel) ─────────────────────────────
-    void applyTransmitStatus(const QMap<QString, QString>& kvs);
-    void applyInterlockStatus(const QMap<QString, QString>& kvs);
-    void applyAtuStatus(const QMap<QString, QString>& kvs);
-    void applyApdStatus(const QMap<QString, QString>& kvs);
-    void applyApdSamplerStatus(const QMap<QString, QString>& kvs);
+    // Apply a normalized, typed transmit delta from the backend
+    // (IRadioBackend::transmitChanged). Vendor-neutral fields only — the Flex
+    // wire decode for all five transmit-family status planes lives in
+    // FlexBackend::decode*Status. Present-only. (aetherd RFC 2.3.)
+    void applyChanges(const TransmitDelta& delta);
     void setProfileList(const QStringList& profiles);
     void setActiveProfile(const QString& profile);
     void setMicProfileList(const QStringList& profiles);

--- a/tests/aetherd_meter_decode_test.cpp
+++ b/tests/aetherd_meter_decode_test.cpp
@@ -74,6 +74,20 @@ int main(int argc, char** argv)
         CHECK(def.count() == 0);
     }
 
+    // ---- malformed numeric fields dropped, not applied as 0 (#4066 guard) ----
+    {
+        FlexBackend backend;
+        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
+        backend.decodeMeterStatus(QStringLiteral(
+            "3.nam=LEVEL#3.low=junk#3.hi=20.0#3.num=nope"));
+        CHECK(def.count() == 1);
+        const QVariantMap f = def.takeFirst().at(1).toMap();
+        CHECK(f.value(QStringLiteral("name")).toString() == QStringLiteral("LEVEL"));
+        CHECK(!f.contains(QStringLiteral("low")));         // malformed → dropped
+        CHECK(!f.contains(QStringLiteral("sourceIndex"))); // malformed num → dropped
+        CHECK(f.contains(QStringLiteral("high")));         // valid field still carried
+    }
+
     if (g_failures == 0) {
         std::printf("aetherd_meter_decode_test: all checks passed\n");
         return 0;

--- a/tests/aetherd_transmit_decode_test.cpp
+++ b/tests/aetherd_transmit_decode_test.cpp
@@ -1,0 +1,152 @@
+// aetherd RFC 2.3 — TransmitModel touchpoint: FlexBackend::decode*Status.
+// Pins the Flex transmit-family wire → typed TransmitDelta translation (key
+// renames, "1"→bool, ok-guarded + clamped numerics, compander/dexp aliasing,
+// ATU raw token, APD bare-flag, sampler INTERNAL-prepend). The model apply side
+// is covered by transmit_model_test / transmit_model_apd_test.
+
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/TransmitDelta.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+template <class Fn>
+static TransmitDelta decode(FlexBackend& b, Fn call)
+{
+    QSignalSpy spy(&b, &IRadioBackend::transmitChanged);
+    call(b);
+    if (spy.count() != 1) return {};
+    return spy.takeFirst().at(0).value<TransmitDelta>();
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<TransmitDelta>();
+    FlexBackend b;
+
+    // ---- core transmit: clamp, "1"→bool, ok-guard ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeTransmitStatus({
+                {QStringLiteral("rfpower"), QStringLiteral("150")},   // clamps to 100
+                {QStringLiteral("tune"), QStringLiteral("1")},
+                {QStringLiteral("freq"), QStringLiteral("14.2")},
+                {QStringLiteral("mic_selection"), QStringLiteral("acc")},  // uppercased
+                {QStringLiteral("max_power_level"), QStringLiteral("500")}, // unclamped
+                {QStringLiteral("iambic_mode"), QStringLiteral("9")},  // clamps to 1
+            });
+        });
+        CHECK(d.rfPower.has_value() && *d.rfPower == 100);
+        CHECK(d.tune.has_value() && *d.tune == true);
+        CHECK(d.transmitFreq.has_value() && qFuzzyCompare(*d.transmitFreq, 14.2));
+        CHECK(d.micSelection.has_value() && *d.micSelection == QStringLiteral("ACC"));
+        CHECK(d.maxPowerLevel.has_value() && *d.maxPowerLevel == 500);
+        CHECK(d.cwIambicMode.has_value() && *d.cwIambicMode == 1);
+    }
+
+    // ---- ok-guard: malformed present numeric is dropped ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeTransmitStatus({
+                {QStringLiteral("rfpower"), QStringLiteral("junk")},
+                {QStringLiteral("mox"), QStringLiteral("1")},
+            });
+        });
+        CHECK(!d.rfPower.has_value());   // dropped, not clamped-0
+        CHECK(d.mox.has_value() && *d.mox == true);
+    }
+
+    // ---- compander/dexp aliasing ----
+    {
+        // compander present → carried; dexp ignored.
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeTransmitStatus({
+                {QStringLiteral("compander"), QStringLiteral("1")},
+                {QStringLiteral("dexp"), QStringLiteral("0")},
+                {QStringLiteral("compander_level"), QStringLiteral("33")},
+                {QStringLiteral("noise_gate_level"), QStringLiteral("9")},
+            });
+        });
+        CHECK(d.compander.has_value() && *d.compander == true);   // compander wins
+        CHECK(d.companderLevel.has_value() && *d.companderLevel == 33);
+    }
+    {
+        // dexp-only (no compander) → aliases into compander.
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeTransmitStatus({
+                {QStringLiteral("dexp"), QStringLiteral("1")},
+                {QStringLiteral("noise_gate_level"), QStringLiteral("8")},
+            });
+        });
+        CHECK(d.compander.has_value() && *d.compander == true);
+        CHECK(d.companderLevel.has_value() && *d.companderLevel == 8);
+    }
+
+    // ---- interlock ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeInterlockStatus({{QStringLiteral("tx1_delay"), QStringLiteral("25")},
+                                      {QStringLiteral("timeout"), QStringLiteral("120")}});
+        });
+        CHECK(d.tx1Delay.has_value() && *d.tx1Delay == 25);
+        CHECK(d.interlockTimeout.has_value() && *d.interlockTimeout == 120);
+        CHECK(!d.rfPower.has_value());   // core fields untouched
+    }
+
+    // ---- ATU: raw status token carried; model owns the enum parse ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeAtuStatus({{QStringLiteral("status"), QStringLiteral("TUNE_SUCCESSFUL")},
+                                {QStringLiteral("atu_enabled"), QStringLiteral("1")}});
+        });
+        CHECK(d.atuStatusRaw.has_value() && *d.atuStatusRaw == QStringLiteral("TUNE_SUCCESSFUL"));
+        CHECK(d.atuEnabled.has_value() && *d.atuEnabled == true);
+    }
+
+    // ---- APD: bare equalizer_reset flag engages the optional ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeApdStatus({{QStringLiteral("enable"), QStringLiteral("1")},
+                                {QStringLiteral("equalizer_reset"), QString()}});
+        });
+        CHECK(d.apdEnabled.has_value() && *d.apdEnabled == true);
+        CHECK(d.apdEqualizerReset.has_value());   // engaged by presence, value irrelevant
+    }
+
+    // ---- APD sampler: uppercase, INTERNAL-prepend, empty tx_ant → no emit ----
+    {
+        const TransmitDelta d = decode(b, [](FlexBackend& fb){
+            fb.decodeApdSamplerStatus({{QStringLiteral("tx_ant"), QStringLiteral("ant1")},
+                                       {QStringLiteral("selected_sampler"), QStringLiteral("rx_a")},
+                                       {QStringLiteral("valid_samplers"), QStringLiteral("rx_a, xvta")}});
+        });
+        CHECK(d.apdSamplerTxAnt.has_value() && *d.apdSamplerTxAnt == QStringLiteral("ANT1"));
+        CHECK(d.apdSamplerAvailable.has_value()
+              && *d.apdSamplerAvailable == QStringList({QStringLiteral("INTERNAL"),
+                                                        QStringLiteral("RX_A"),
+                                                        QStringLiteral("XVTA")}));
+        CHECK(d.apdSamplerSelected.has_value() && *d.apdSamplerSelected == QStringLiteral("RX_A"));
+    }
+    {
+        // No tx_ant → no emit at all.
+        QSignalSpy spy(&b, &IRadioBackend::transmitChanged);
+        b.decodeApdSamplerStatus({{QStringLiteral("selected_sampler"), QStringLiteral("RX_A")}});
+        CHECK(spy.count() == 0);
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherd_transmit_decode_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherd_transmit_decode_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/transmit_model_apd_test.cpp
+++ b/tests/transmit_model_apd_test.cpp
@@ -20,11 +20,17 @@ void report(const char* name, bool ok)
     if (!ok) ++g_failed;
 }
 
-QMap<QString, QString> kvs(std::initializer_list<std::pair<QString, QString>> pairs)
+// aetherd RFC 2.3: TransmitModel::applyChanges takes a typed TransmitDelta. The
+// Flex wire decode (valid_samplers split + INTERNAL prepend, "1"→bool) lives in
+// FlexBackend::decode*Status, covered by aetherd_transmit_decode_test; these
+// tests exercise the model's apply side (map insert, selected fallback,
+// idempotency, emits) via a pre-built delta.
+template <class F>
+TransmitDelta td(F&& build)
 {
-    QMap<QString, QString> m;
-    for (const auto& p : pairs) m.insert(p.first, p.second);
-    return m;
+    TransmitDelta d;
+    build(d);
+    return d;
 }
 
 void testSamplerStatusPopulatesAvailableAndSelected()
@@ -32,10 +38,10 @@ void testSamplerStatusPopulatesAvailableAndSelected()
     TransmitModel tx;
     QSignalSpy spy(&tx, &TransmitModel::apdSamplerChanged);
 
-    tx.applyApdSamplerStatus(kvs({
-        {"tx_ant", "ANT1"},
-        {"selected_sampler", "RX_A"},
-        {"valid_samplers", "RX_A,XVTA"},
+    tx.applyChanges(td([](TransmitDelta& d){
+        d.apdSamplerTxAnt = QStringLiteral("ANT1");
+        d.apdSamplerAvailable = QStringList{"INTERNAL", "RX_A", "XVTA"};
+        d.apdSamplerSelected = QStringLiteral("RX_A");
     }));
 
     const auto s = tx.apdSampler("ANT1");
@@ -53,10 +59,10 @@ void testSelectedFallbackWhenNotInValidList()
 
     // selected_sampler isn't present in valid_samplers — FlexLib falls back
     // to INTERNAL rather than displaying a value the user can't pick.
-    tx.applyApdSamplerStatus(kvs({
-        {"tx_ant", "ANT2"},
-        {"selected_sampler", "BOGUS"},
-        {"valid_samplers", "RX_B"},
+    tx.applyChanges(td([](TransmitDelta& d){
+        d.apdSamplerTxAnt = QStringLiteral("ANT2");
+        d.apdSamplerAvailable = QStringList{"INTERNAL", "RX_B"};
+        d.apdSamplerSelected = QStringLiteral("BOGUS");
     }));
 
     report("invalid selected_sampler falls back to INTERNAL",
@@ -100,7 +106,7 @@ void testEqualizerResetStatusFlagClearsActive()
 {
     TransmitModel tx;
     // Drive equalizer_active=1 first.
-    tx.applyApdStatus(kvs({{"equalizer_active", "1"}}));
+    tx.applyChanges(td([](TransmitDelta& d){ d.apdEqActive = true; }));
     report("equalizer_active goes true", tx.apdEqualizerActive());
 
     QSignalSpy resetSpy(&tx, &TransmitModel::apdEqualizerResetReceived);
@@ -108,7 +114,7 @@ void testEqualizerResetStatusFlagClearsActive()
 
     // Bare flag form: dispatcher merges "equalizer_reset" into kvs as
     // an empty-valued key.
-    tx.applyApdStatus(kvs({{"equalizer_reset", ""}}));
+    tx.applyChanges(td([](TransmitDelta& d){ d.apdEqualizerReset = true; }));
 
     report("apdEqualizerResetReceived emitted", resetSpy.count() == 1);
     report("equalizer_active clears on reset", !tx.apdEqualizerActive());
@@ -121,11 +127,11 @@ void testConfigurableEnablesUiVisibility()
     QSignalSpy spy(&tx, &TransmitModel::apdStateChanged);
 
     report("apdConfigurable starts false", !tx.apdConfigurable());
-    tx.applyApdStatus(kvs({{"configurable", "1"}}));
+    tx.applyChanges(td([](TransmitDelta& d){ d.apdConfigurable = true; }));
     report("configurable=1 flips apdConfigurable", tx.apdConfigurable());
     report("apdStateChanged emitted", spy.count() >= 1);
 
-    tx.applyApdStatus(kvs({{"configurable", "0"}}));
+    tx.applyChanges(td([](TransmitDelta& d){ d.apdConfigurable = false; }));
     report("configurable=0 turns it back off", !tx.apdConfigurable());
 }
 
@@ -133,18 +139,18 @@ void testSamplerStatusIdempotent()
 {
     TransmitModel tx;
 
-    tx.applyApdSamplerStatus(kvs({
-        {"tx_ant", "ANT1"},
-        {"selected_sampler", "RX_A"},
-        {"valid_samplers", "RX_A,XVTA"},
+    tx.applyChanges(td([](TransmitDelta& d){
+        d.apdSamplerTxAnt = QStringLiteral("ANT1");
+        d.apdSamplerAvailable = QStringList{"INTERNAL", "RX_A", "XVTA"};
+        d.apdSamplerSelected = QStringLiteral("RX_A");
     }));
 
     QSignalSpy spy(&tx, &TransmitModel::apdSamplerChanged);
     // Re-apply identical status — must not re-emit.
-    tx.applyApdSamplerStatus(kvs({
-        {"tx_ant", "ANT1"},
-        {"selected_sampler", "RX_A"},
-        {"valid_samplers", "RX_A,XVTA"},
+    tx.applyChanges(td([](TransmitDelta& d){
+        d.apdSamplerTxAnt = QStringLiteral("ANT1");
+        d.apdSamplerAvailable = QStringList{"INTERNAL", "RX_A", "XVTA"};
+        d.apdSamplerSelected = QStringLiteral("RX_A");
     }));
     report("identical sampler status is idempotent", spy.count() == 0);
 }
@@ -152,10 +158,10 @@ void testSamplerStatusIdempotent()
 void testResetStateClearsSamplers()
 {
     TransmitModel tx;
-    tx.applyApdSamplerStatus(kvs({
-        {"tx_ant", "ANT1"},
-        {"selected_sampler", "RX_A"},
-        {"valid_samplers", "RX_A"},
+    tx.applyChanges(td([](TransmitDelta& d){
+        d.apdSamplerTxAnt = QStringLiteral("ANT1");
+        d.apdSamplerAvailable = QStringList{"INTERNAL", "RX_A"};
+        d.apdSamplerSelected = QStringLiteral("RX_A");
     }));
     report("sampler set before reset", tx.apdSampler("ANT1").selected == "RX_A");
 

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -16,6 +16,17 @@ bool expect(bool condition, const char* label)
     return condition;
 }
 
+// aetherd RFC 2.3: TransmitModel::applyChanges takes a typed TransmitDelta (the
+// Flex wire decode + compander/dexp aliasing live in FlexBackend::decode*Status,
+// covered by aetherd_transmit_decode_test). This builds a delta from a setter.
+template <class F>
+TransmitDelta td(F&& build)
+{
+    TransmitDelta d;
+    build(d);
+    return d;
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -39,7 +50,7 @@ int main(int argc, char** argv)
                  }),
                  "two-tone tune sets mode before starting tune");
 
-    tx.applyTransmitStatus({{"tune", "1"}});
+    tx.applyChanges(td([](TransmitDelta& d){ d.tune = true; }));
     commands.clear();
     tx.toggleTwoToneTune();
     ok &= expect(commands == QStringList({
@@ -48,7 +59,7 @@ int main(int argc, char** argv)
                  }),
                  "two-tone tune toggle stops and restores single-tone mode");
 
-    tx.applyTransmitStatus({{"tune", "0"}});
+    tx.applyChanges(td([](TransmitDelta& d){ d.tune = false; }));
     commands.clear();
     tx.toggleTwoToneTune();
     ok &= expect(commands == QStringList({
@@ -81,21 +92,21 @@ int main(int argc, char** argv)
                  && tx.companderLevel() == 42,
                  "DEXP level sends compander_level command and updates local state");
 
-    tx.applyTransmitStatus({{"compander", "0"}, {"compander_level", "17"}});
+    tx.applyChanges(td([](TransmitDelta& d){ d.compander = false; d.companderLevel = 17; }));
     ok &= expect(!tx.dexpOn()
                  && !tx.companderOn()
                  && tx.dexpLevel() == 17
                  && tx.companderLevel() == 17,
                  "compander status updates DEXP state");
 
-    tx.applyTransmitStatus({{"compander", "1"}, {"dexp", "0"}, {"compander_level", "33"}, {"noise_gate_level", "9"}});
+    tx.applyChanges(td([](TransmitDelta& d){ d.compander = true; d.companderLevel = 33; }));
     ok &= expect(tx.dexpOn()
                  && tx.companderOn()
                  && tx.dexpLevel() == 33
                  && tx.companderLevel() == 33,
                  "canonical compander status wins over legacy DEXP aliases");
 
-    tx.applyTransmitStatus({{"dexp", "0"}, {"noise_gate_level", "8"}});
+    tx.applyChanges(td([](TransmitDelta& d){ d.compander = false; d.companderLevel = 8; }));
     ok &= expect(!tx.dexpOn()
                  && !tx.companderOn()
                  && tx.dexpLevel() == 8


### PR DESCRIPTION
Completes the **TransmitModel** touchpoint — the **last of the five mixed-model splits** in aetherd RFC 2.3. All five Flex transmit-family status decoders move out of `TransmitModel` into `FlexBackend`, behind a typed, compiler-checked `TransmitDelta` payload (the pattern established for slices in #4068). Behavior-neutral.

## What moved

- **`FlexBackend::decodeTransmitStatus` / `decodeInterlockStatus` / `decodeAtuStatus` / `decodeApdStatus` / `decodeApdSamplerStatus`** own all the SmartSDR wire knowledge: key names, `"1"`→bool, **ok-guarded + clamped** numeric parses (per-field ranges), uppercase, list split, the **compander/dexp alias precedence** (`compander` wins; `dexp`/`noise_gate_level` alias only when the compander key is absent), and the sampler `INTERNAL`-prepend. Each emits `IRadioBackend::transmitChanged(const TransmitDelta&)`.
- **`TransmitModel`**: the five `apply*Status` methods → one merged **`applyChanges(const TransmitDelta&)`**. Every emit group is preserved exactly — `stateChanged` / `tuneChanged` / `micStateChanged` / `phoneStateChanged` / `txFilterCutoffChanged` / inline `maxPowerLevelChanged`+`txSliceModeChanged` / `atuStateChanged` / `apdStateChanged` / `apdEqualizerResetReceived` / `apdSamplerChanged` — along with the model-side business logic: `compander` → both `companderOn`/`dexpOn` (+ mic/phone flags), the **ATU enum parse**, and the **stateful per-antenna APD-sampler map** + selected-not-in-available→`INTERNAL` fallback.
- **`RadioModel`**: the 6 transmit-family call sites route through the decode methods; a ctor-wired `transmitChanged` handler drives the model (synchronous, main-thread).

## Behavior-neutral — verified

- **Adversarial field-by-field review** across the 5-method merge's central risks — emit-group mapping (every field lands in its original group; `met_in_rx`→`changed` not phone; compander sets both mic+phone; interlock emits nothing), cross-contamination (single-plane deltas isolate each group's emits), clamp ranges (all match), ATU/sampler logic + idempotency, routing, and the `optional<bool>` presence-vs-value footgun — **no regressions**.
- **57 delta fields set in the decode = 57 read in the model**, empty set-diff both ways (now compiler-enforced by the typed struct).

## Fail-closed (intentional, not a regression)
Malformed *present* numerics now drop instead of applying `0`/`0.0` — `freq`, `max_power_level`, and the interlock ints were previously unguarded (a garbled `max_power_level` would have emitted `maxPowerLevelChanged(0)`). No well-formed input changes behavior. Consistent with the slice/pan standard.

## Also in this PR
- **Folds in the deferred #4066 meter parse-guards** (`num`/`low`/`hi` ok-guarded — a live fail-closed gap on `main`) + a malformed-value meter test.
- **Registered `transmit_model_apd_test`** — it was built but never run (pre-existing CMake omission).

## Tests / gates
- `transmit_model_test` + `transmit_model_apd_test` converted to typed deltas; new **`aetherd_transmit_decode_test`** pins the wire→delta mapping (clamps, ok-guard-drop, compander/dexp aliasing, ATU raw token, APD bare-flag, sampler `INTERNAL`-prepend + empty-`tx_ant` no-emit).
- **68/68 tests green**, engine-boundary `--strict` green, full app builds clean.

## Scope note — "RadioModel residual"
This finishes the five mixed models. RadioModel's own remaining *direct* Flex decoders are the radio-**global** status handlers (`handleRadioStatus`/`handleGpsStatus`/`handleMemoryStatus`/`handleProfileStatus`) — not a sub-model, and a distinct smaller concern. Kept out of this PR (already the largest) as a separate follow-up rather than bloating it.

Refs #3849 (aetherd RFC tracking). Related: #4065, #4066, #4068, #4070 (typed-payload parity for pan/meter).

## 2.3 scoreboard
Panadapter ✅ (#4065) · Meter ✅ (#4066) · Slice 🟡 (#4068) · **Transmit (this PR)** — the five mixed models complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
