### PR TITLE
refactor(aetherd): #4070 — typed MeterDef payload + shared FlexKvCarry decode helpers

### DIFF
--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -7,6 +7,7 @@
 #include <QVariant>
 #include <QVariantMap>
 
+#include "core/backends/MeterDef.h"
 #include "core/backends/RadioCapabilities.h"
 #include "core/backends/SliceDelta.h"
 #include "core/backends/TransmitDelta.h"
@@ -121,12 +122,12 @@ signals:
     void transmitChanged(const TransmitDelta& delta);
 
     // Meter definition catalog (aetherd RFC 2.3 — MeterModel touchpoint). The
-    // backend decodes the vendor meter-status wire format into a normalized
-    // definition; RadioModel drives the MeterModel. `fields` carries only the
-    // keys the wire reported (source, sourceIndex, name, unit, low, high,
-    // description) — the same present-only shape the old inline parse produced.
-    // The meter *values* stream on the data plane (VITA-49), separate from this.
-    void meterDefined(int index, const QVariantMap& fields);
+    // backend decodes the vendor meter-status wire format into a typed MeterDef;
+    // RadioModel hands it straight to MeterModel::defineMeter(). Fields the wire
+    // did not report keep their MeterDef defaults (present-only on the decode
+    // side). The meter *values* stream on the data plane (VITA-49), separate.
+    // (#4070: typed payload — replaces the prior stringly-keyed QVariantMap.)
+    void meterDefined(const MeterDef& def);
     void meterRemoved(int index);
     // Panadapter core display state (universal — every family has a pan center
     // and span). The backend decodes it from vendor status; RadioModel drives

--- a/src/core/backends/MeterDef.h
+++ b/src/core/backends/MeterDef.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QMetaType>
+#include <QString>
+
+namespace AetherSDR {
+
+// A single meter definition decoded from the radio's meter-status wire message
+// (aetherd RFC 2.3 — MeterModel touchpoint). Pure data: it lives in the core
+// backend layer (not a model header) so the vendor-neutral IRadioBackend can
+// carry it on meterDefined() without depending on any model — the backend fills
+// it, RadioModel hands it straight to MeterModel::defineMeter(). Fields not
+// reported by the wire keep their defaults (present-only on the decode side).
+//
+// The meter *values* stream separately on the VITA-49 data plane; this is only
+// the catalog/definition.
+struct MeterDef {
+    int     index{-1};
+    QString source;       // "SLC", "RAD", "AMP", "TX", ...
+    int     sourceIndex{0};
+    QString name;         // "LEVEL", "FWDPWR", "SWR", "PATEMP", ...
+    QString unit;         // "dBm", "dB", "dBFS", "SWR", "Volts", "Amps", "degC", "degF", "Watts", "Percent"
+    double  low{0.0};
+    double  high{0.0};
+    QString description;
+};
+
+}  // namespace AetherSDR
+
+// Registered so MeterDef can ride IRadioBackend::meterDefined across a queued
+// connection and be captured by QSignalSpy in tests.
+Q_DECLARE_METATYPE(AetherSDR::MeterDef)

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -12,7 +12,7 @@
 namespace AetherSDR {
 
 // Shared present-only + ok-guarded Flex status carriers (#4070), used by the
-// slice/transmit/meter decoders below.
+// pan/slice/meter/transmit decoders below (one overloaded carry() family).
 using namespace flexkv;
 
 FlexBackend::FlexBackend(QObject* parent)
@@ -295,22 +295,18 @@ void FlexBackend::decodePanState(const QString& panId,
     // Bundle the remaining Flex-specific display-pan keys onto one namespaced
     // extension event; carry only the keys the wire actually reported so the
     // model applies exactly what changed (present-only, like the WNB group).
+    // Raw strings via the shared flexkv map-target carry — the model parses each
+    // with its existing per-field semantics (bool flags, ok-guarded fps, hex
+    // client_handle, waterfall stream-id).
     QVariantMap st;
-    const auto carry = [&](const char* key) {
-        if (kvs.contains(QLatin1String(key))) {
-            st.insert(QLatin1String(key), kvs.value(QLatin1String(key)));
-        }
-    };
-    // Raw strings — the model parses each with its existing per-field semantics
-    // (bool flags, ok-guarded fps, hex client_handle, waterfall stream-id).
-    carry("wide");
-    carry("loopa");
-    carry("loopb");
-    carry("fps");
-    carry("pre");
-    carry("daxiq_channel");
-    carry("client_handle");
-    carry("waterfall");
+    carry(kvs, "wide", st);
+    carry(kvs, "loopa", st);
+    carry(kvs, "loopb", st);
+    carry(kvs, "fps", st);
+    carry(kvs, "pre", st);
+    carry(kvs, "daxiq_channel", st);
+    carry(kvs, "client_handle", st);
+    carry(kvs, "waterfall", st);
     if (!st.isEmpty()) {
         st.insert(QStringLiteral("panId"), panId);
         emit extensionStatus(QStringLiteral("flex"),
@@ -389,20 +385,23 @@ void FlexBackend::decodeMeterStatus(const QString& rawBody)
     for (auto it = grouped.constBegin(); it != grouped.constEnd(); ++it) {
         const QMap<QString, QString>& f = it.value();
         // Build the typed MeterDef directly (#4070). Present-only: a field the
-        // wire didn't report keeps its MeterDef default. Numeric fields are
-        // ok-guarded — a malformed present value is dropped, not applied as
-        // 0/0.0 (a bad low/hi would otherwise collapse a meter's scale).
-        // Consistent with the slice/pan/transmit boundary decoders and FlexLib's
-        // TryParse+continue.
+        // wire didn't report keeps its MeterDef default. The carry() ok-guard is
+        // defensive/consistency only here — a plain MeterDef field's default IS
+        // 0/0.0, which is also what an unguarded parse of a malformed value would
+        // yield, and meter status is a full definition that defineMeter()
+        // full-replaces (so there's no prior value to preserve). The guard has
+        // real fail-closed effect only at the std::optional carry() sites
+        // (slice/transmit), where a dropped value leaves the field disengaged.
+        // (#4075 review.)
         MeterDef def;
         def.index = it.key();
-        flexkv::carryInto(f, "src", def.source);
-        flexkv::carryIntInto(f, "num", def.sourceIndex, /*base=*/0);
-        flexkv::carryInto(f, "nam", def.name);
-        flexkv::carryInto(f, "unit", def.unit);
-        flexkv::carryRealInto(f, "low", def.low);
-        flexkv::carryRealInto(f, "hi", def.high);
-        flexkv::carryInto(f, "desc", def.description);
+        carry(f, "src", def.source);
+        carry(f, "num", def.sourceIndex, /*base=*/0);
+        carry(f, "nam", def.name);
+        carry(f, "unit", def.unit);
+        carry(f, "low", def.low);
+        carry(f, "hi", def.high);
+        carry(f, "desc", def.description);
         emit meterDefined(def);
     }
 }
@@ -419,48 +418,43 @@ void FlexBackend::decodeSliceStatus(int sliceId, const QMap<QString, QString>& k
     // where a garbled RF_frequency would otherwise retune to 0 Hz; FlexLib itself
     // fails closed via TryParse+continue). #4068 review.
     SliceDelta d;
-    // Thin forwarders to the shared flexkv carriers — the present-only + ok-guard
-    // logic lives once in FlexKvCarry.h (#4070), not re-rolled here.
-    const auto oStr  = [&](const char* w, std::optional<QString>& f) { flexkv::carryStr(kvs, w, f); };
-    const auto oInt  = [&](const char* w, std::optional<int>& f)     { flexkv::carryInt(kvs, w, f); };
-    const auto oReal = [&](const char* w, std::optional<double>& f)  { flexkv::carryReal(kvs, w, f); };
-    const auto oBool = [&](const char* w, std::optional<bool>& f)    { flexkv::carryBool(kvs, w, f); };
-    const auto splitList = [](const QString& raw) { return flexkv::splitList(raw); };
+    // The shared flexkv carriers (overloaded carry() / carryClamp() / splitList,
+    // in scope via the file-scope `using namespace flexkv`) are called directly.
 
     // Identity / tuning
-    oStr("pan", d.panId);
-    oStr("index_letter", d.letter);
-    oReal("RF_frequency", d.frequency);
-    oStr("mode", d.mode);
-    oInt("filter_lo", d.filterLow);
-    oInt("filter_hi", d.filterHigh);
+    carry(kvs, "pan", d.panId);
+    carry(kvs, "index_letter", d.letter);
+    carry(kvs, "RF_frequency", d.frequency);
+    carry(kvs, "mode", d.mode);
+    carry(kvs, "filter_lo", d.filterLow);
+    carry(kvs, "filter_hi", d.filterHigh);
     if (kvs.contains(QStringLiteral("mode_list")))
         d.modeList = kvs.value(QStringLiteral("mode_list")).split(',', Qt::SkipEmptyParts);
 
     // Core state
-    oBool("active", d.active);
-    oBool("tx", d.txSlice);
-    oReal("rfgain", d.rfGain);
-    oReal("audio_level", d.audioGain);
-    oInt("audio_pan", d.audioPan);
-    oBool("audio_mute", d.audioMute);
-    oBool("in_use", d.inUse);
-    oBool("lock", d.locked);
-    oBool("qsk", d.qsk);
+    carry(kvs, "active", d.active);
+    carry(kvs, "tx", d.txSlice);
+    carry(kvs, "rfgain", d.rfGain);
+    carry(kvs, "audio_level", d.audioGain);
+    carry(kvs, "audio_pan", d.audioPan);
+    carry(kvs, "audio_mute", d.audioMute);
+    carry(kvs, "in_use", d.inUse);
+    carry(kvs, "lock", d.locked);
+    carry(kvs, "qsk", d.qsk);
 
     // Diversity group
-    oBool("diversity_child", d.diversityChild);
-    oBool("diversity_parent", d.diversityParent);
-    oBool("diversity", d.diversity);
-    oInt("diversity_index", d.diversityIndex);
+    carry(kvs, "diversity_child", d.diversityChild);
+    carry(kvs, "diversity_parent", d.diversityParent);
+    carry(kvs, "diversity", d.diversity);
+    carry(kvs, "diversity_index", d.diversityIndex);
 
     // ESC (diversity beamforming — "1"/"on" → true)
     if (kvs.contains(QStringLiteral("esc"))) {
         const QString v = kvs.value(QStringLiteral("esc"));
         d.esc = v == QLatin1String("1") || v == QLatin1String("on");
     }
-    oReal("esc_gain", d.escGain);
-    oReal("esc_phase_shift", d.escPhaseShift);
+    carry(kvs, "esc_gain", d.escGain);
+    carry(kvs, "esc_phase_shift", d.escPhaseShift);
 
     // Antennas (rx_ant_list takes precedence over ant_list, then split+trim)
     if (kvs.contains(QStringLiteral("rx_ant_list")) || kvs.contains(QStringLiteral("ant_list")))
@@ -468,65 +462,65 @@ void FlexBackend::decodeSliceStatus(int sliceId, const QMap<QString, QString>& k
                                               kvs.value(QStringLiteral("ant_list"))));
     if (kvs.contains(QStringLiteral("tx_ant_list")))
         d.txAntennaList = splitList(kvs.value(QStringLiteral("tx_ant_list")));
-    oStr("rxant", d.rxAntenna);
-    oStr("txant", d.txAntenna);
+    carry(kvs, "rxant", d.rxAntenna);
+    carry(kvs, "txant", d.txAntenna);
 
     // DSP toggles
-    oBool("nb", d.nb);
-    oBool("nr", d.nr);
-    oBool("anf", d.anf);
-    oBool("nrl", d.nrl);
-    oBool("nrs", d.nrs);
-    oBool("rnn", d.rnn);
-    oBool("nrf", d.nrf);
-    oBool("anfl", d.anfl);
-    oBool("anft", d.anft);
-    oBool("apf", d.apf);
+    carry(kvs, "nb", d.nb);
+    carry(kvs, "nr", d.nr);
+    carry(kvs, "anf", d.anf);
+    carry(kvs, "nrl", d.nrl);
+    carry(kvs, "nrs", d.nrs);
+    carry(kvs, "rnn", d.rnn);
+    carry(kvs, "nrf", d.nrf);
+    carry(kvs, "anfl", d.anfl);
+    carry(kvs, "anft", d.anft);
+    carry(kvs, "apf", d.apf);
     // DSP levels
-    oInt("apf_level", d.apfLevel);
-    oInt("nb_level", d.nbLevel);
-    oInt("nr_level", d.nrLevel);
-    oInt("anf_level", d.anfLevel);
-    oInt("lms_nr_level", d.nrlLevel);
-    oInt("speex_nr_level", d.nrsLevel);
-    oInt("nrf_level", d.nrfLevel);
-    oInt("lms_anf_level", d.anflLevel);
+    carry(kvs, "apf_level", d.apfLevel);
+    carry(kvs, "nb_level", d.nbLevel);
+    carry(kvs, "nr_level", d.nrLevel);
+    carry(kvs, "anf_level", d.anfLevel);
+    carry(kvs, "lms_nr_level", d.nrlLevel);
+    carry(kvs, "speex_nr_level", d.nrsLevel);
+    carry(kvs, "nrf_level", d.nrfLevel);
+    carry(kvs, "lms_anf_level", d.anflLevel);
 
     // AGC / squelch / RIT / XIT
-    oStr("agc_mode", d.agcMode);
-    oInt("agc_threshold", d.agcThreshold);
-    oInt("agc_off_level", d.agcOffLevel);
-    oBool("squelch", d.squelchOn);
-    oInt("squelch_level", d.squelchLevel);
-    oBool("rit_on", d.ritOn);
-    oInt("rit_freq", d.ritFreq);
-    oBool("xit_on", d.xitOn);
-    oInt("xit_freq", d.xitFreq);
+    carry(kvs, "agc_mode", d.agcMode);
+    carry(kvs, "agc_threshold", d.agcThreshold);
+    carry(kvs, "agc_off_level", d.agcOffLevel);
+    carry(kvs, "squelch", d.squelchOn);
+    carry(kvs, "squelch_level", d.squelchLevel);
+    carry(kvs, "rit_on", d.ritOn);
+    carry(kvs, "rit_freq", d.ritFreq);
+    carry(kvs, "xit_on", d.xitOn);
+    carry(kvs, "xit_freq", d.xitFreq);
 
     // DAX / RTTY / DIG offsets
-    oInt("dax", d.daxChannel);
-    oInt("rtty_mark", d.rttyMark);
-    oInt("rtty_shift", d.rttyShift);
-    oInt("digl_offset", d.diglOffset);
-    oInt("digu_offset", d.diguOffset);
+    carry(kvs, "dax", d.daxChannel);
+    carry(kvs, "rtty_mark", d.rttyMark);
+    carry(kvs, "rtty_shift", d.rttyShift);
+    carry(kvs, "digl_offset", d.diglOffset);
+    carry(kvs, "digu_offset", d.diguOffset);
 
     // Record / playback (play is 3-state disabled/1/0 — carry raw, model interprets)
-    oBool("record", d.recordOn);
-    oStr("play", d.play);
+    carry(kvs, "record", d.recordOn);
+    carry(kvs, "play", d.play);
 
     // FM duplex/repeater (lowercase normalization stays wire-side)
     if (kvs.contains(QStringLiteral("fm_tone_mode")))
         d.fmToneMode = kvs.value(QStringLiteral("fm_tone_mode")).toLower();
-    oReal("fm_tone_value", d.fmToneValue);  // model formats to 1 decimal
+    carry(kvs, "fm_tone_value", d.fmToneValue);  // model formats to 1 decimal
     if (kvs.contains(QStringLiteral("repeater_offset_dir")))
         d.repeaterOffsetDir = kvs.value(QStringLiteral("repeater_offset_dir")).toLower();
-    oReal("fm_repeater_offset_freq", d.fmRepeaterOffsetFreq);
-    oReal("tx_offset_freq", d.txOffsetFreq);
-    oInt("fm_deviation", d.fmDeviation);
+    carry(kvs, "fm_repeater_offset_freq", d.fmRepeaterOffsetFreq);
+    carry(kvs, "tx_offset_freq", d.txOffsetFreq);
+    carry(kvs, "fm_deviation", d.fmDeviation);
 
     // Step (step_list carried raw — model builds the QVector<int>)
-    oInt("step", d.step);
-    oStr("step_list", d.stepList);
+    carry(kvs, "step", d.step);
+    carry(kvs, "step_list", d.stepList);
 
     emit sliceChanged(sliceId, d);
 }
@@ -542,31 +536,31 @@ void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
     // Core transmit
     carryClamp(kvs, "rfpower", d.rfPower, 0, 100);
     carryClamp(kvs, "tunepower", d.tunePower, 0, 100);
-    carryBool(kvs, "tune", d.tune);
-    carryBool(kvs, "mox", d.mox);
-    carryReal(kvs, "freq", d.transmitFreq);
+    carry(kvs, "tune", d.tune);
+    carry(kvs, "mox", d.mox);
+    carry(kvs, "freq", d.transmitFreq);
 
     // Mic / monitor / processor
     if (kvs.contains(QStringLiteral("mic_selection")))
         d.micSelection = kvs.value(QStringLiteral("mic_selection")).toUpper();
     carryClamp(kvs, "mic_level", d.micLevel, 0, 100);
-    carryBool(kvs, "mic_acc", d.micAcc);
-    carryBool(kvs, "speech_processor_enable", d.speechProcEnable);
+    carry(kvs, "mic_acc", d.micAcc);
+    carry(kvs, "speech_processor_enable", d.speechProcEnable);
     carryClamp(kvs, "speech_processor_level", d.speechProcLevel, 0, 100);
-    carryBool(kvs, "compander", d.compander);
+    carry(kvs, "compander", d.compander);
     carryClamp(kvs, "compander_level", d.companderLevel, 0, 100);
-    carryBool(kvs, "dax", d.dax);
-    carryBool(kvs, "sb_monitor", d.sbMonitor);
+    carry(kvs, "dax", d.dax);
+    carry(kvs, "sb_monitor", d.sbMonitor);
     carryClamp(kvs, "mon_gain_sb", d.monGainSb, 0, 100);
 
     // VOX / phone
-    carryBool(kvs, "vox_enable", d.voxEnable);
+    carry(kvs, "vox_enable", d.voxEnable);
     carryClamp(kvs, "vox_level", d.voxLevel, 0, 100);
     carryClamp(kvs, "vox_delay", d.voxDelay, 0, 100);
-    carryBool(kvs, "mic_boost", d.micBoost);
-    carryBool(kvs, "mic_bias", d.micBias);
-    carryBool(kvs, "met_in_rx", d.metInRx);
-    carryBool(kvs, "synccwx", d.syncCwx);
+    carry(kvs, "mic_boost", d.micBoost);
+    carry(kvs, "mic_bias", d.micBias);
+    carry(kvs, "met_in_rx", d.metInRx);
+    carry(kvs, "synccwx", d.syncCwx);
     carryClamp(kvs, "am_carrier_level", d.amCarrierLevel, 0, 100);
     // dexp / noise_gate_level alias compander / compander_level, but only when
     // the compander key itself is absent (the wire sends one or the other).
@@ -584,21 +578,21 @@ void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
     // CW
     carryClamp(kvs, "speed", d.cwSpeed, 5, 100);
     carryClamp(kvs, "pitch", d.cwPitch, 100, 6000);
-    carryBool(kvs, "break_in", d.cwBreakIn);
+    carry(kvs, "break_in", d.cwBreakIn);
     carryClamp(kvs, "break_in_delay", d.cwDelay, 0, 2000);
-    carryBool(kvs, "sidetone", d.cwSidetone);
-    carryBool(kvs, "iambic", d.cwIambic);
+    carry(kvs, "sidetone", d.cwSidetone);
+    carry(kvs, "iambic", d.cwIambic);
     carryClamp(kvs, "iambic_mode", d.cwIambicMode, 0, 1);
-    carryBool(kvs, "swap_paddles", d.cwSwapPaddles);
-    carryBool(kvs, "cwl_enabled", d.cwlEnabled);
+    carry(kvs, "swap_paddles", d.cwSwapPaddles);
+    carry(kvs, "cwl_enabled", d.cwlEnabled);
     carryClamp(kvs, "mon_gain_cw", d.monGainCw, 0, 100);
     carryClamp(kvs, "mon_pan_cw", d.monPanCw, 0, 100);
 
     // Misc TX
-    carryInt(kvs, "max_power_level", d.maxPowerLevel);
+    carry(kvs, "max_power_level", d.maxPowerLevel);
     if (kvs.contains(QStringLiteral("tune_mode")))
         d.tuneMode = kvs.value(QStringLiteral("tune_mode"));
-    carryBool(kvs, "show_tx_in_waterfall", d.showTxInWaterfall);
+    carry(kvs, "show_tx_in_waterfall", d.showTxInWaterfall);
     if (kvs.contains(QStringLiteral("tx_slice_mode")))
         d.txSliceMode = kvs.value(QStringLiteral("tx_slice_mode"));
 
@@ -608,14 +602,14 @@ void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
 void FlexBackend::decodeInterlockStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;
-    carryInt(kvs, "acc_tx_delay", d.accTxDelay);
-    carryInt(kvs, "tx1_delay", d.tx1Delay);
-    carryInt(kvs, "tx2_delay", d.tx2Delay);
-    carryInt(kvs, "tx3_delay", d.tx3Delay);
-    carryInt(kvs, "tx_delay", d.txDelay);
-    carryInt(kvs, "timeout", d.interlockTimeout);
-    carryInt(kvs, "acc_txreq_polarity", d.accTxReqPolarity);
-    carryInt(kvs, "rca_txreq_polarity", d.rcaTxReqPolarity);
+    carry(kvs, "acc_tx_delay", d.accTxDelay);
+    carry(kvs, "tx1_delay", d.tx1Delay);
+    carry(kvs, "tx2_delay", d.tx2Delay);
+    carry(kvs, "tx3_delay", d.tx3Delay);
+    carry(kvs, "tx_delay", d.txDelay);
+    carry(kvs, "timeout", d.interlockTimeout);
+    carry(kvs, "acc_txreq_polarity", d.accTxReqPolarity);
+    carry(kvs, "rca_txreq_polarity", d.rcaTxReqPolarity);
     emit transmitChanged(d);
 }
 
@@ -625,18 +619,18 @@ void FlexBackend::decodeAtuStatus(const QMap<QString, QString>& kvs)
     // Raw ATU status token — the model owns the ATUStatus enum + parse.
     if (kvs.contains(QStringLiteral("status")))
         d.atuStatusRaw = kvs.value(QStringLiteral("status"));
-    carryBool(kvs, "atu_enabled", d.atuEnabled);
-    carryBool(kvs, "memories_enabled", d.memoriesEnabled);
-    carryBool(kvs, "using_mem", d.usingMemory);
+    carry(kvs, "atu_enabled", d.atuEnabled);
+    carry(kvs, "memories_enabled", d.memoriesEnabled);
+    carry(kvs, "using_mem", d.usingMemory);
     emit transmitChanged(d);
 }
 
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;
-    carryBool(kvs, "enable", d.apdEnabled);
-    carryBool(kvs, "configurable", d.apdConfigurable);
-    carryBool(kvs, "equalizer_active", d.apdEqActive);
+    carry(kvs, "enable", d.apdEnabled);
+    carry(kvs, "configurable", d.apdConfigurable);
+    carry(kvs, "equalizer_active", d.apdEqActive);
     // Bare flag (no `=`): the model clears apdEqActive + emits the reset signal.
     if (kvs.contains(QStringLiteral("equalizer_reset")))
         d.apdEqualizerReset = true;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -6,9 +6,14 @@
 
 #include "core/RadioConnection.h"
 #include "core/PanadapterStream.h"
+#include "core/backends/flex/FlexKvCarry.h"
 #include "models/ModelCapabilities.h"
 
 namespace AetherSDR {
+
+// Shared present-only + ok-guarded Flex status carriers (#4070), used by the
+// slice/transmit/meter decoders below.
+using namespace flexkv;
 
 FlexBackend::FlexBackend(QObject* parent)
     : IRadioBackend(parent)
@@ -383,38 +388,22 @@ void FlexBackend::decodeMeterStatus(const QString& rawBody)
 
     for (auto it = grouped.constBegin(); it != grouped.constEnd(); ++it) {
         const QMap<QString, QString>& f = it.value();
-        // Carry only the keys the wire reported, normalized to the MeterDef
-        // field names RadioModel reconstructs (present-only — the old parse
-        // set MeterDef fields conditionally the same way).
-        // Numeric fields are ok-guarded: a malformed present value is dropped,
-        // not applied as 0/0.0 (a bad low/hi would otherwise collapse a meter's
-        // scale). Consistent with the slice/pan/transmit boundary decoders and
-        // FlexLib's TryParse+continue. (#4066 deferred, folded into #PR D.)
-        QVariantMap def;
-        if (f.contains(QStringLiteral("src")))
-            def.insert(QStringLiteral("source"), f.value(QStringLiteral("src")));
-        if (f.contains(QStringLiteral("num"))) {
-            bool ok = false;
-            const int v = f.value(QStringLiteral("num")).toInt(&ok, 0);  // base 0
-            if (ok) def.insert(QStringLiteral("sourceIndex"), v);
-        }
-        if (f.contains(QStringLiteral("nam")))
-            def.insert(QStringLiteral("name"), f.value(QStringLiteral("nam")));
-        if (f.contains(QStringLiteral("unit")))
-            def.insert(QStringLiteral("unit"), f.value(QStringLiteral("unit")));
-        if (f.contains(QStringLiteral("low"))) {
-            bool ok = false;
-            const double v = f.value(QStringLiteral("low")).toDouble(&ok);
-            if (ok) def.insert(QStringLiteral("low"), v);
-        }
-        if (f.contains(QStringLiteral("hi"))) {
-            bool ok = false;
-            const double v = f.value(QStringLiteral("hi")).toDouble(&ok);
-            if (ok) def.insert(QStringLiteral("high"), v);
-        }
-        if (f.contains(QStringLiteral("desc")))
-            def.insert(QStringLiteral("description"), f.value(QStringLiteral("desc")));
-        emit meterDefined(it.key(), def);
+        // Build the typed MeterDef directly (#4070). Present-only: a field the
+        // wire didn't report keeps its MeterDef default. Numeric fields are
+        // ok-guarded — a malformed present value is dropped, not applied as
+        // 0/0.0 (a bad low/hi would otherwise collapse a meter's scale).
+        // Consistent with the slice/pan/transmit boundary decoders and FlexLib's
+        // TryParse+continue.
+        MeterDef def;
+        def.index = it.key();
+        flexkv::carryInto(f, "src", def.source);
+        flexkv::carryIntInto(f, "num", def.sourceIndex, /*base=*/0);
+        flexkv::carryInto(f, "nam", def.name);
+        flexkv::carryInto(f, "unit", def.unit);
+        flexkv::carryRealInto(f, "low", def.low);
+        flexkv::carryRealInto(f, "hi", def.high);
+        flexkv::carryInto(f, "desc", def.description);
+        emit meterDefined(def);
     }
 }
 
@@ -430,35 +419,13 @@ void FlexBackend::decodeSliceStatus(int sliceId, const QMap<QString, QString>& k
     // where a garbled RF_frequency would otherwise retune to 0 Hz; FlexLib itself
     // fails closed via TryParse+continue). #4068 review.
     SliceDelta d;
-    const auto oStr = [&](const char* wire, std::optional<QString>& f) {
-        if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
-    };
-    const auto oInt = [&](const char* wire, std::optional<int>& f) {
-        if (kvs.contains(QLatin1String(wire))) {
-            bool ok = false;
-            const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
-            if (ok) f = v;
-        }
-    };
-    const auto oReal = [&](const char* wire, std::optional<double>& f) {
-        if (kvs.contains(QLatin1String(wire))) {
-            bool ok = false;
-            const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
-            if (ok) f = v;
-        }
-    };
-    const auto oBool = [&](const char* wire, std::optional<bool>& f) {
-        if (kvs.contains(QLatin1String(wire)))
-            f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
-    };
-    const auto splitList = [](const QString& raw) {
-        QStringList out;
-        for (QString t : raw.split(',', Qt::SkipEmptyParts)) {
-            t = t.trimmed();
-            if (!t.isEmpty()) out.append(t);
-        }
-        return out;
-    };
+    // Thin forwarders to the shared flexkv carriers — the present-only + ok-guard
+    // logic lives once in FlexKvCarry.h (#4070), not re-rolled here.
+    const auto oStr  = [&](const char* w, std::optional<QString>& f) { flexkv::carryStr(kvs, w, f); };
+    const auto oInt  = [&](const char* w, std::optional<int>& f)     { flexkv::carryInt(kvs, w, f); };
+    const auto oReal = [&](const char* w, std::optional<double>& f)  { flexkv::carryReal(kvs, w, f); };
+    const auto oBool = [&](const char* w, std::optional<bool>& f)    { flexkv::carryBool(kvs, w, f); };
+    const auto splitList = [](const QString& raw) { return flexkv::splitList(raw); };
 
     // Identity / tuning
     oStr("pan", d.panId);
@@ -569,71 +536,38 @@ void FlexBackend::decodeSliceStatus(int sliceId, const QMap<QString, QString>& k
 // transmitChanged. Numeric parses are ok-guarded (malformed present field is
 // dropped, not applied as 0) and clamped to the model's ranges — the wire
 // normalization the old TransmitModel decoders did inline.
-namespace {
-// present-only, ok-guarded carriers over a Flex kv-set.
-inline void tBool(const QMap<QString, QString>& kvs, const char* wire,
-                  std::optional<bool>& f) {
-    if (kvs.contains(QLatin1String(wire)))
-        f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
-}
-inline void tInt(const QMap<QString, QString>& kvs, const char* wire,
-                 std::optional<int>& f) {
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
-        if (ok) f = v;
-    }
-}
-inline void tClamp(const QMap<QString, QString>& kvs, const char* wire,
-                   std::optional<int>& f, int lo, int hi) {
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
-        if (ok) f = qBound(lo, v, hi);
-    }
-}
-inline void tReal(const QMap<QString, QString>& kvs, const char* wire,
-                  std::optional<double>& f) {
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
-        if (ok) f = v;
-    }
-}
-}  // namespace
-
 void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;
     // Core transmit
-    tClamp(kvs, "rfpower", d.rfPower, 0, 100);
-    tClamp(kvs, "tunepower", d.tunePower, 0, 100);
-    tBool(kvs, "tune", d.tune);
-    tBool(kvs, "mox", d.mox);
-    tReal(kvs, "freq", d.transmitFreq);
+    carryClamp(kvs, "rfpower", d.rfPower, 0, 100);
+    carryClamp(kvs, "tunepower", d.tunePower, 0, 100);
+    carryBool(kvs, "tune", d.tune);
+    carryBool(kvs, "mox", d.mox);
+    carryReal(kvs, "freq", d.transmitFreq);
 
     // Mic / monitor / processor
     if (kvs.contains(QStringLiteral("mic_selection")))
         d.micSelection = kvs.value(QStringLiteral("mic_selection")).toUpper();
-    tClamp(kvs, "mic_level", d.micLevel, 0, 100);
-    tBool(kvs, "mic_acc", d.micAcc);
-    tBool(kvs, "speech_processor_enable", d.speechProcEnable);
-    tClamp(kvs, "speech_processor_level", d.speechProcLevel, 0, 100);
-    tBool(kvs, "compander", d.compander);
-    tClamp(kvs, "compander_level", d.companderLevel, 0, 100);
-    tBool(kvs, "dax", d.dax);
-    tBool(kvs, "sb_monitor", d.sbMonitor);
-    tClamp(kvs, "mon_gain_sb", d.monGainSb, 0, 100);
+    carryClamp(kvs, "mic_level", d.micLevel, 0, 100);
+    carryBool(kvs, "mic_acc", d.micAcc);
+    carryBool(kvs, "speech_processor_enable", d.speechProcEnable);
+    carryClamp(kvs, "speech_processor_level", d.speechProcLevel, 0, 100);
+    carryBool(kvs, "compander", d.compander);
+    carryClamp(kvs, "compander_level", d.companderLevel, 0, 100);
+    carryBool(kvs, "dax", d.dax);
+    carryBool(kvs, "sb_monitor", d.sbMonitor);
+    carryClamp(kvs, "mon_gain_sb", d.monGainSb, 0, 100);
 
     // VOX / phone
-    tBool(kvs, "vox_enable", d.voxEnable);
-    tClamp(kvs, "vox_level", d.voxLevel, 0, 100);
-    tClamp(kvs, "vox_delay", d.voxDelay, 0, 100);
-    tBool(kvs, "mic_boost", d.micBoost);
-    tBool(kvs, "mic_bias", d.micBias);
-    tBool(kvs, "met_in_rx", d.metInRx);
-    tBool(kvs, "synccwx", d.syncCwx);
-    tClamp(kvs, "am_carrier_level", d.amCarrierLevel, 0, 100);
+    carryBool(kvs, "vox_enable", d.voxEnable);
+    carryClamp(kvs, "vox_level", d.voxLevel, 0, 100);
+    carryClamp(kvs, "vox_delay", d.voxDelay, 0, 100);
+    carryBool(kvs, "mic_boost", d.micBoost);
+    carryBool(kvs, "mic_bias", d.micBias);
+    carryBool(kvs, "met_in_rx", d.metInRx);
+    carryBool(kvs, "synccwx", d.syncCwx);
+    carryClamp(kvs, "am_carrier_level", d.amCarrierLevel, 0, 100);
     // dexp / noise_gate_level alias compander / compander_level, but only when
     // the compander key itself is absent (the wire sends one or the other).
     if (kvs.contains(QStringLiteral("dexp")) && !kvs.contains(QStringLiteral("compander")))
@@ -644,27 +578,27 @@ void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
         const int v = kvs.value(QStringLiteral("noise_gate_level")).toInt(&ok);
         if (ok) d.companderLevel = qBound(0, v, 100);
     }
-    tClamp(kvs, "lo", d.txFilterLow, 0, 10000);
-    tClamp(kvs, "hi", d.txFilterHigh, 0, 10000);
+    carryClamp(kvs, "lo", d.txFilterLow, 0, 10000);
+    carryClamp(kvs, "hi", d.txFilterHigh, 0, 10000);
 
     // CW
-    tClamp(kvs, "speed", d.cwSpeed, 5, 100);
-    tClamp(kvs, "pitch", d.cwPitch, 100, 6000);
-    tBool(kvs, "break_in", d.cwBreakIn);
-    tClamp(kvs, "break_in_delay", d.cwDelay, 0, 2000);
-    tBool(kvs, "sidetone", d.cwSidetone);
-    tBool(kvs, "iambic", d.cwIambic);
-    tClamp(kvs, "iambic_mode", d.cwIambicMode, 0, 1);
-    tBool(kvs, "swap_paddles", d.cwSwapPaddles);
-    tBool(kvs, "cwl_enabled", d.cwlEnabled);
-    tClamp(kvs, "mon_gain_cw", d.monGainCw, 0, 100);
-    tClamp(kvs, "mon_pan_cw", d.monPanCw, 0, 100);
+    carryClamp(kvs, "speed", d.cwSpeed, 5, 100);
+    carryClamp(kvs, "pitch", d.cwPitch, 100, 6000);
+    carryBool(kvs, "break_in", d.cwBreakIn);
+    carryClamp(kvs, "break_in_delay", d.cwDelay, 0, 2000);
+    carryBool(kvs, "sidetone", d.cwSidetone);
+    carryBool(kvs, "iambic", d.cwIambic);
+    carryClamp(kvs, "iambic_mode", d.cwIambicMode, 0, 1);
+    carryBool(kvs, "swap_paddles", d.cwSwapPaddles);
+    carryBool(kvs, "cwl_enabled", d.cwlEnabled);
+    carryClamp(kvs, "mon_gain_cw", d.monGainCw, 0, 100);
+    carryClamp(kvs, "mon_pan_cw", d.monPanCw, 0, 100);
 
     // Misc TX
-    tInt(kvs, "max_power_level", d.maxPowerLevel);
+    carryInt(kvs, "max_power_level", d.maxPowerLevel);
     if (kvs.contains(QStringLiteral("tune_mode")))
         d.tuneMode = kvs.value(QStringLiteral("tune_mode"));
-    tBool(kvs, "show_tx_in_waterfall", d.showTxInWaterfall);
+    carryBool(kvs, "show_tx_in_waterfall", d.showTxInWaterfall);
     if (kvs.contains(QStringLiteral("tx_slice_mode")))
         d.txSliceMode = kvs.value(QStringLiteral("tx_slice_mode"));
 
@@ -674,14 +608,14 @@ void FlexBackend::decodeTransmitStatus(const QMap<QString, QString>& kvs)
 void FlexBackend::decodeInterlockStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;
-    tInt(kvs, "acc_tx_delay", d.accTxDelay);
-    tInt(kvs, "tx1_delay", d.tx1Delay);
-    tInt(kvs, "tx2_delay", d.tx2Delay);
-    tInt(kvs, "tx3_delay", d.tx3Delay);
-    tInt(kvs, "tx_delay", d.txDelay);
-    tInt(kvs, "timeout", d.interlockTimeout);
-    tInt(kvs, "acc_txreq_polarity", d.accTxReqPolarity);
-    tInt(kvs, "rca_txreq_polarity", d.rcaTxReqPolarity);
+    carryInt(kvs, "acc_tx_delay", d.accTxDelay);
+    carryInt(kvs, "tx1_delay", d.tx1Delay);
+    carryInt(kvs, "tx2_delay", d.tx2Delay);
+    carryInt(kvs, "tx3_delay", d.tx3Delay);
+    carryInt(kvs, "tx_delay", d.txDelay);
+    carryInt(kvs, "timeout", d.interlockTimeout);
+    carryInt(kvs, "acc_txreq_polarity", d.accTxReqPolarity);
+    carryInt(kvs, "rca_txreq_polarity", d.rcaTxReqPolarity);
     emit transmitChanged(d);
 }
 
@@ -691,18 +625,18 @@ void FlexBackend::decodeAtuStatus(const QMap<QString, QString>& kvs)
     // Raw ATU status token — the model owns the ATUStatus enum + parse.
     if (kvs.contains(QStringLiteral("status")))
         d.atuStatusRaw = kvs.value(QStringLiteral("status"));
-    tBool(kvs, "atu_enabled", d.atuEnabled);
-    tBool(kvs, "memories_enabled", d.memoriesEnabled);
-    tBool(kvs, "using_mem", d.usingMemory);
+    carryBool(kvs, "atu_enabled", d.atuEnabled);
+    carryBool(kvs, "memories_enabled", d.memoriesEnabled);
+    carryBool(kvs, "using_mem", d.usingMemory);
     emit transmitChanged(d);
 }
 
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;
-    tBool(kvs, "enable", d.apdEnabled);
-    tBool(kvs, "configurable", d.apdConfigurable);
-    tBool(kvs, "equalizer_active", d.apdEqActive);
+    carryBool(kvs, "enable", d.apdEnabled);
+    carryBool(kvs, "configurable", d.apdConfigurable);
+    carryBool(kvs, "equalizer_active", d.apdEqActive);
     // Bare flag (no `=`): the model clears apdEqActive + emits the reset signal.
     if (kvs.contains(QStringLiteral("equalizer_reset")))
         d.apdEqualizerReset = true;

--- a/src/core/backends/flex/FlexKvCarry.h
+++ b/src/core/backends/flex/FlexKvCarry.h
@@ -6,79 +6,88 @@
 #include <QMap>
 #include <QString>
 #include <QStringList>
+#include <QVariantMap>
 #include <QtGlobal>   // qBound
 
 // aetherd RFC 2.3 / #4070 — one home for the present-only + fail-closed decode
-// contract shared by the Flex status decoders (pan/slice/meter/transmit). Each
+// contract shared by the Flex status decoders (pan/slice/meter/transmit). Every
 // carrier reads a key out of a Flex status kv-set and applies it ONLY when the
-// wire reported it; the numeric carriers are ok-guarded (a malformed present
-// value is dropped, not applied as 0/0.0). Previously this pattern was hand-
-// re-rolled in each decoder (SliceDelta's oStr/oInt/…, TransmitDelta's tInt/…,
-// the meter inline guards) — single-sourcing it means a future tweak (base-0
-// parse, whitespace trim) can't be applied to one copy and silently skipped in
-// the others.
+// wire reported it. Numeric parses are ok-guarded (a malformed present value is
+// dropped, not applied as 0/0.0) — for an std::optional target that leaves the
+// field disengaged (the model keeps its previous value); for a plain field or a
+// map entry the value is simply not written. `carry()` is overloaded on the
+// target type so every call site reads uniformly, and the guarded parse lives in
+// exactly one place (parseInt/parseReal), so a future tweak (base-0 parse,
+// whitespace trim) can't be applied to one copy and skipped in another.
 namespace AetherSDR::flexkv {
 
 using Kv = QMap<QString, QString>;
 
-// ---- carriers into std::optional<T> delta fields (slice / transmit) ----
-inline void carryStr(const Kv& kvs, const char* wire, std::optional<QString>& f)
-{
-    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
-}
-inline void carryBool(const Kv& kvs, const char* wire, std::optional<bool>& f)
-{
-    if (kvs.contains(QLatin1String(wire)))
-        f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
-}
-inline void carryInt(const Kv& kvs, const char* wire, std::optional<int>& f)
-{
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
-        if (ok) f = v;
-    }
-}
-inline void carryClamp(const Kv& kvs, const char* wire, std::optional<int>& f,
-                       int lo, int hi)
-{
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
-        if (ok) f = qBound(lo, v, hi);
-    }
-}
-inline void carryReal(const Kv& kvs, const char* wire, std::optional<double>& f)
-{
-    if (kvs.contains(QLatin1String(wire))) {
-        bool ok = false;
-        const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
-        if (ok) f = v;
-    }
-}
-
-// ---- carriers into plain struct fields (meter's MeterDef) — same present-only
-//      + ok-guard contract, but a plain field keeps its existing/default value
-//      when the key is absent or malformed. ----
-inline void carryInto(const Kv& kvs, const char* wire, QString& f)
-{
-    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
-}
-inline void carryIntInto(const Kv& kvs, const char* wire, int& f, int base = 10)
+// The single-sourced guarded parses everything else builds on.
+inline std::optional<int> parseInt(const Kv& kvs, const char* wire, int base = 10)
 {
     if (kvs.contains(QLatin1String(wire))) {
         bool ok = false;
         const int v = kvs.value(QLatin1String(wire)).toInt(&ok, base);
-        if (ok) f = v;
+        if (ok) return v;
     }
+    return std::nullopt;
 }
-inline void carryRealInto(const Kv& kvs, const char* wire, double& f)
+inline std::optional<double> parseReal(const Kv& kvs, const char* wire)
 {
     if (kvs.contains(QLatin1String(wire))) {
         bool ok = false;
         const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
-        if (ok) f = v;
+        if (ok) return v;
     }
+    return std::nullopt;
+}
+
+// carry() — present-only apply, overloaded on the target type.
+inline void carry(const Kv& kvs, const char* wire, std::optional<QString>& f)
+{
+    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
+}
+inline void carry(const Kv& kvs, const char* wire, std::optional<bool>& f)
+{
+    if (kvs.contains(QLatin1String(wire)))
+        f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
+}
+inline void carry(const Kv& kvs, const char* wire, std::optional<int>& f)
+{
+    if (auto v = parseInt(kvs, wire)) f = v;
+}
+inline void carry(const Kv& kvs, const char* wire, std::optional<double>& f)
+{
+    if (auto v = parseReal(kvs, wire)) f = v;
+}
+// Plain-field targets (e.g. MeterDef): keep the field's existing/default value
+// when the key is absent or malformed.
+inline void carry(const Kv& kvs, const char* wire, QString& f)
+{
+    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
+}
+inline void carry(const Kv& kvs, const char* wire, int& f, int base = 10)
+{
+    if (auto v = parseInt(kvs, wire, base)) f = *v;
+}
+inline void carry(const Kv& kvs, const char* wire, double& f)
+{
+    if (auto v = parseReal(kvs, wire)) f = *v;
+}
+// Map target (namespaced extension bundles, e.g. pan "panState"): raw string,
+// keyed by the wire key, for the model to parse.
+inline void carry(const Kv& kvs, const char* wire, QVariantMap& m)
+{
+    if (kvs.contains(QLatin1String(wire)))
+        m.insert(QLatin1String(wire), kvs.value(QLatin1String(wire)));
+}
+
+// Clamped int (present-only, ok-guarded) — the transmit ranges.
+inline void carryClamp(const Kv& kvs, const char* wire, std::optional<int>& f,
+                       int lo, int hi)
+{
+    if (auto v = parseInt(kvs, wire)) f = qBound(lo, *v, hi);
 }
 
 // Comma-split with per-token trim; empty tokens dropped.

--- a/src/core/backends/flex/FlexKvCarry.h
+++ b/src/core/backends/flex/FlexKvCarry.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <optional>
+
+#include <QLatin1String>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <QtGlobal>   // qBound
+
+// aetherd RFC 2.3 / #4070 — one home for the present-only + fail-closed decode
+// contract shared by the Flex status decoders (pan/slice/meter/transmit). Each
+// carrier reads a key out of a Flex status kv-set and applies it ONLY when the
+// wire reported it; the numeric carriers are ok-guarded (a malformed present
+// value is dropped, not applied as 0/0.0). Previously this pattern was hand-
+// re-rolled in each decoder (SliceDelta's oStr/oInt/…, TransmitDelta's tInt/…,
+// the meter inline guards) — single-sourcing it means a future tweak (base-0
+// parse, whitespace trim) can't be applied to one copy and silently skipped in
+// the others.
+namespace AetherSDR::flexkv {
+
+using Kv = QMap<QString, QString>;
+
+// ---- carriers into std::optional<T> delta fields (slice / transmit) ----
+inline void carryStr(const Kv& kvs, const char* wire, std::optional<QString>& f)
+{
+    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
+}
+inline void carryBool(const Kv& kvs, const char* wire, std::optional<bool>& f)
+{
+    if (kvs.contains(QLatin1String(wire)))
+        f = kvs.value(QLatin1String(wire)) == QLatin1String("1");
+}
+inline void carryInt(const Kv& kvs, const char* wire, std::optional<int>& f)
+{
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
+        if (ok) f = v;
+    }
+}
+inline void carryClamp(const Kv& kvs, const char* wire, std::optional<int>& f,
+                       int lo, int hi)
+{
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const int v = kvs.value(QLatin1String(wire)).toInt(&ok);
+        if (ok) f = qBound(lo, v, hi);
+    }
+}
+inline void carryReal(const Kv& kvs, const char* wire, std::optional<double>& f)
+{
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
+        if (ok) f = v;
+    }
+}
+
+// ---- carriers into plain struct fields (meter's MeterDef) — same present-only
+//      + ok-guard contract, but a plain field keeps its existing/default value
+//      when the key is absent or malformed. ----
+inline void carryInto(const Kv& kvs, const char* wire, QString& f)
+{
+    if (kvs.contains(QLatin1String(wire))) f = kvs.value(QLatin1String(wire));
+}
+inline void carryIntInto(const Kv& kvs, const char* wire, int& f, int base = 10)
+{
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const int v = kvs.value(QLatin1String(wire)).toInt(&ok, base);
+        if (ok) f = v;
+    }
+}
+inline void carryRealInto(const Kv& kvs, const char* wire, double& f)
+{
+    if (kvs.contains(QLatin1String(wire))) {
+        bool ok = false;
+        const double v = kvs.value(QLatin1String(wire)).toDouble(&ok);
+        if (ok) f = v;
+    }
+}
+
+// Comma-split with per-token trim; empty tokens dropped.
+inline QStringList splitList(const QString& raw)
+{
+    QStringList out;
+    for (QString t : raw.split(',', Qt::SkipEmptyParts)) {
+        t = t.trimmed();
+        if (!t.isEmpty()) out.append(t);
+    }
+    return out;
+}
+
+}  // namespace AetherSDR::flexkv

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -5,20 +5,12 @@
 #include <QJsonArray>
 #include <QString>
 
-namespace AetherSDR {
+// MeterDef moved to the core backend layer (aetherd RFC 2.3 / #4070) so the
+// vendor-neutral IRadioBackend can carry it on meterDefined() without a
+// model dependency. Re-exported here for the model's existing users.
+#include "core/backends/MeterDef.h"
 
-// Describes a single meter definition received from the radio via TCP status.
-// Format: "meter N N.src=SLC N.num=0 N.nam=LEVEL N.unit=dBm N.low=-150 N.hi=20"
-struct MeterDef {
-    int     index{-1};
-    QString source;       // "SLC", "RAD", "AMP", "TX", ...
-    int     sourceIndex{0};
-    QString name;         // "LEVEL", "FWDPWR", "SWR", "PATEMP", ...
-    QString unit;         // "dBm", "dB", "dBFS", "SWR", "Volts", "Amps", "degC", "degF", "Watts", "Percent"
-    double  low{0.0};
-    double  high{0.0};
-    QString description;
-};
+namespace AetherSDR {
 
 // Central meter value store.
 //

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -401,6 +401,7 @@ RadioModel::RadioModel(QObject* parent)
     // silently drop the emit. Idempotent + cheap. (#4071 review.)
     qRegisterMetaType<SliceDelta>();
     qRegisterMetaType<TransmitDelta>();
+    qRegisterMetaType<MeterDef>();
 
     // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
     // FlexBackend creates the RadioConnection and PanadapterStream on their
@@ -515,26 +516,9 @@ RadioModel::RadioModel(QObject* parent)
     // meter-status wire format; RadioModel reconstructs the MeterDef (present-
     // only, exactly as the old inline handleMeterStatus parse did) and drives the
     // MeterModel. Meter *values* stay on the VITA-49 data plane (below).
+    // #4070: the backend now emits a typed MeterDef — no key-string reconstruction.
     connect(m_backend.get(), &IRadioBackend::meterDefined, this,
-            [this](int index, const QVariantMap& f) {
-        MeterDef def;
-        def.index = index;
-        if (f.contains(QStringLiteral("source")))
-            def.source = f.value(QStringLiteral("source")).toString();
-        if (f.contains(QStringLiteral("sourceIndex")))
-            def.sourceIndex = f.value(QStringLiteral("sourceIndex")).toInt();
-        if (f.contains(QStringLiteral("name")))
-            def.name = f.value(QStringLiteral("name")).toString();
-        if (f.contains(QStringLiteral("unit")))
-            def.unit = f.value(QStringLiteral("unit")).toString();
-        if (f.contains(QStringLiteral("low")))
-            def.low = f.value(QStringLiteral("low")).toDouble();
-        if (f.contains(QStringLiteral("high")))
-            def.high = f.value(QStringLiteral("high")).toDouble();
-        if (f.contains(QStringLiteral("description")))
-            def.description = f.value(QStringLiteral("description")).toString();
-        m_meterModel.defineMeter(def);
-    });
+            [this](const MeterDef& def) { m_meterModel.defineMeter(def); });
     connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
             [this](int index) { m_meterModel.removeMeter(index); });
 

--- a/tests/aetherd_meter_decode_test.cpp
+++ b/tests/aetherd_meter_decode_test.cpp
@@ -74,15 +74,20 @@ int main(int argc, char** argv)
         CHECK(def.count() == 0);
     }
 
-    // ---- malformed numeric fields dropped → keep MeterDef default (guard) ----
+    // ---- malformed numerics leave the MeterDef default; valid fields carried.
+    //      NOTE: for a plain MeterDef field the default (0/0.0) equals what an
+    //      unguarded parse of a malformed value yields, so this does NOT pin the
+    //      carry() ok-guard — that contract is pinned where nullopt ≠ 0, at the
+    //      std::optional carry() sites (aetherd_slice_decode_test /
+    //      aetherd_transmit_decode_test malformed cases). (#4075 review.)
     {
         FlexBackend backend;
         const MeterDef d = decode1(backend, QStringLiteral(
             "3.nam=LEVEL#3.low=junk#3.hi=20.0#3.num=nope"));
         CHECK(d.name == QStringLiteral("LEVEL"));
         CHECK(qFuzzyCompare(d.high, 20.0));   // valid field carried
-        CHECK(d.low == 0.0);                  // malformed low dropped → default 0.0
-        CHECK(d.sourceIndex == 0);            // malformed num dropped → default 0
+        CHECK(d.low == 0.0);                  // malformed → MeterDef default 0.0
+        CHECK(d.sourceIndex == 0);            // malformed → MeterDef default 0
     }
 
     if (g_failures == 0) {

--- a/tests/aetherd_meter_decode_test.cpp
+++ b/tests/aetherd_meter_decode_test.cpp
@@ -1,12 +1,12 @@
 // aetherd RFC 2.3 — MeterModel touchpoint: FlexBackend::decodeMeterStatus.
 // Pins the SmartSDR meter-status wire decode (definitions + removal) that moved
-// out of RadioModel::handleMeterStatus.
+// out of RadioModel::handleMeterStatus. (#4070: typed MeterDef payload.)
 
 #include "core/backends/flex/FlexBackend.h"
+#include "core/backends/MeterDef.h"
 
 #include <QCoreApplication>
 #include <QSignalSpy>
-#include <QVariantMap>
 #include <QString>
 #include <cstdio>
 
@@ -16,29 +16,32 @@ static int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
 
+static MeterDef decode1(FlexBackend& b, const QString& body)
+{
+    QSignalSpy def(&b, &IRadioBackend::meterDefined);
+    b.decodeMeterStatus(body);
+    if (def.count() != 1) return {};
+    return def.takeFirst().at(0).value<MeterDef>();
+}
+
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+    qRegisterMetaType<MeterDef>();
 
     // ---- full definition ----
     {
         FlexBackend backend;
-        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
-        backend.decodeMeterStatus(QStringLiteral(
+        const MeterDef d = decode1(backend, QStringLiteral(
             "7.src=SLC#7.num=0#7.nam=LEVEL#7.unit=dBm#7.low=-150.0#7.hi=20.0"));
-        CHECK(def.count() == 1);
-        {
-            const QList<QVariant> a = def.takeFirst();
-            CHECK(a.at(0).toInt() == 7);
-            const QVariantMap f = a.at(1).toMap();
-            CHECK(f.value(QStringLiteral("source")).toString() == QStringLiteral("SLC"));
-            CHECK(f.value(QStringLiteral("sourceIndex")).toInt() == 0);
-            CHECK(f.value(QStringLiteral("name")).toString() == QStringLiteral("LEVEL"));
-            CHECK(f.value(QStringLiteral("unit")).toString() == QStringLiteral("dBm"));
-            CHECK(qFuzzyCompare(f.value(QStringLiteral("low")).toDouble(), -150.0));
-            CHECK(qFuzzyCompare(f.value(QStringLiteral("high")).toDouble(), 20.0));
-            CHECK(!f.contains(QStringLiteral("description")));  // absent key not carried
-        }
+        CHECK(d.index == 7);
+        CHECK(d.source == QStringLiteral("SLC"));
+        CHECK(d.sourceIndex == 0);
+        CHECK(d.name == QStringLiteral("LEVEL"));
+        CHECK(d.unit == QStringLiteral("dBm"));
+        CHECK(qFuzzyCompare(d.low, -150.0));
+        CHECK(qFuzzyCompare(d.high, 20.0));
+        CHECK(d.description.isEmpty());   // absent key → MeterDef default
     }
 
     // ---- removal ----
@@ -50,20 +53,17 @@ int main(int argc, char** argv)
         CHECK(rem.takeFirst().at(0).toInt() == 7);
     }
 
-    // ---- multiple meters in one body, grouped by index ----
+    // ---- multiple meters in one body, grouped by index (ascending) ----
     {
         FlexBackend backend;
         QSignalSpy def(&backend, &IRadioBackend::meterDefined);
         backend.decodeMeterStatus(QStringLiteral(
             "1.src=TX#1.nam=FWDPWR#1.unit=Watts#2.src=TX#2.nam=SWR#2.unit=SWR"));
         CHECK(def.count() == 2);
-        // QMap groups by ascending index → meter 1 first.
-        const QList<QVariant> a = def.takeFirst();
-        CHECK(a.at(0).toInt() == 1);
-        CHECK(a.at(1).toMap().value(QStringLiteral("name")).toString() == QStringLiteral("FWDPWR"));
-        const QList<QVariant> b = def.takeFirst();
-        CHECK(b.at(0).toInt() == 2);
-        CHECK(b.at(1).toMap().value(QStringLiteral("name")).toString() == QStringLiteral("SWR"));
+        const MeterDef a = def.takeFirst().at(0).value<MeterDef>();
+        CHECK(a.index == 1 && a.name == QStringLiteral("FWDPWR"));
+        const MeterDef b = def.takeFirst().at(0).value<MeterDef>();
+        CHECK(b.index == 2 && b.name == QStringLiteral("SWR"));
     }
 
     // ---- malformed index token skipped, no emission ----
@@ -74,18 +74,15 @@ int main(int argc, char** argv)
         CHECK(def.count() == 0);
     }
 
-    // ---- malformed numeric fields dropped, not applied as 0 (#4066 guard) ----
+    // ---- malformed numeric fields dropped → keep MeterDef default (guard) ----
     {
         FlexBackend backend;
-        QSignalSpy def(&backend, &IRadioBackend::meterDefined);
-        backend.decodeMeterStatus(QStringLiteral(
+        const MeterDef d = decode1(backend, QStringLiteral(
             "3.nam=LEVEL#3.low=junk#3.hi=20.0#3.num=nope"));
-        CHECK(def.count() == 1);
-        const QVariantMap f = def.takeFirst().at(1).toMap();
-        CHECK(f.value(QStringLiteral("name")).toString() == QStringLiteral("LEVEL"));
-        CHECK(!f.contains(QStringLiteral("low")));         // malformed → dropped
-        CHECK(!f.contains(QStringLiteral("sourceIndex"))); // malformed num → dropped
-        CHECK(f.contains(QStringLiteral("high")));         // valid field still carried
+        CHECK(d.name == QStringLiteral("LEVEL"));
+        CHECK(qFuzzyCompare(d.high, 20.0));   // valid field carried
+        CHECK(d.low == 0.0);                  // malformed low dropped → default 0.0
+        CHECK(d.sourceIndex == 0);            // malformed num dropped → default 0
     }
 
     if (g_failures == 0) {


### PR DESCRIPTION
Closes #4070 — the seam-consistency follow-up from the RFC 2.3 mixed-model series. Behavior-neutral (the three decode tests pin the exact wire→output mapping).

## Typed meter payload
`MeterDef` moves from `models/MeterModel.h` to **`core/backends/MeterDef.h`** (pure data), so `IRadioBackend` carries it directly: **`meterDefined(const MeterDef&)`** instead of the stringly-keyed `QVariantMap`. `FlexBackend::decodeMeterStatus` builds the `MeterDef`; `RadioModel` hands it straight to `defineMeter()` — the ~15-line key-string reconstruction is gone, and a field-name typo is now a **compile error**. `MeterModel.h` re-includes the core header so its existing users are unaffected.

## Shared decode carriers
New **`core/backends/flex/FlexKvCarry.h`** single-sources the present-only + fail-closed parse contract (`carryStr/Bool/Int/Clamp/Real` for optional delta fields; `carryInto/IntInto/RealInto` for plain struct fields; `splitList`). The slice (`oStr/oInt/…`), transmit (`tBool/tInt/…`), and meter (inline guards) decoders now **all route through it** — resolving the "3rd/4th re-roll of the same guard" that ten9876 flagged across #4066/#4068/#4071. A future tweak (base-0 parse, whitespace trim) can no longer be applied to one copy and silently skipped in the others. `FlexBackend.cpp` net-shrinks ~90 lines.

## Deliberately NOT done (documented decisions)
- **`panState`/`panWnb` stay on the generic `extensionStatus(ns, kind, QVariantMap)` channel** — that channel exists precisely to keep Flex-specific status *off* the vendor-neutral typed interface; typing them would invert that design.
- **`TransmitDelta`/`SliceDelta` kept flat** (not per-plane sub-structs — ten9876's #4071 option): the flat structs are verified/tested, and the `assign()` helper + these shared carriers already address the maintainability concern; a sub-struct rewrite of two just-merged deltas isn't worth the churn. Revisitable if a 6th touchpoint ever copies the pattern.

## Gates
- `qRegisterMetaType<MeterDef>()` added at startup alongside `Slice`/`TransmitDelta`.
- `aetherd_meter_decode_test` asserts on the typed `MeterDef` (incl. the malformed-drop guard → default).
- **69/69 tests green**, engine-boundary `--strict` green, full app builds clean.

Refs #3849. Concludes the RFC 2.3 mixed-model split seam cleanup — the `IRadioBackend` seam now carries pan/meter/slice/transmit with compiler-checked typed payloads and one shared decode-helper set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)