### PR TITLE
fix(tests): sandbox theme_manager_test's user themes dir on macOS

### DIFF
--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -35,6 +35,26 @@ static int g_failures = 0;
 
 int main(int argc, char** argv)
 {
+    // Route every QStandardPaths writable location into Qt's test-mode
+    // sandbox (~/.qttest/...).  XDG_CONFIG_HOME alone isn't enough:
+    // macOS ignores it and resolves GenericConfigLocation to
+    // ~/Library/Preferences, so importThemeFromFile() would persist the
+    // probe themes into the developer's real themes dir — the leftover
+    // files then collide on the next run and the import de-duplicates
+    // the name to "... (2)", failing the EXPECT_EQ assertions below.
+    QStandardPaths::setTestModeEnabled(true);
+
+    // The sandbox itself persists across runs, so clear any probe
+    // themes a previous (possibly crashed) run left behind before the
+    // ThemeManager singleton scans the dir.
+    {
+        const QString sandboxAppDir =
+            QStandardPaths::writableLocation(
+                QStandardPaths::GenericConfigLocation)
+            + QStringLiteral("/AetherSDR");
+        QDir(sandboxAppDir).removeRecursively();
+    }
+
     // Route AppSettings + theme dirs into an isolated temp tree so the
     // test never pollutes the developer's real ~/.config/AetherSDR.
     QTemporaryDir tmp;


### PR DESCRIPTION
theme_manager_test isolates itself with XDG_CONFIG_HOME, but Qt ignores that variable on macOS: GenericConfigLocation resolves to ~/Library/Preferences regardless, so importThemeFromFile() persisted the four "* Probe" themes into the developer's REAL themes dir. The first run passed; every later run collided with the leftovers, the import de-duplicated the name to "... (2)", and four EXPECT_EQ assertions failed.

Enable QStandardPaths::setTestModeEnabled(true) before anything touches QStandardPaths so every writable location lands in Qt's test sandbox (~/.qttest/...) on all platforms, and wipe the sandboxed AetherSDR config dir at startup so leftovers from a prior (possibly crashed) run can never collide.

Verified: three consecutive binary runs + two ctest runs all pass; probes confirmed landing in ~/.qttest/Library/Preferences/AetherSDR/ themes/ with the real dir untouched.

<!--
Thanks for contributing to AetherSDR!

Before opening the PR, please:
- Read AGENTS.md if this is your first contribution (or your AI tool's
  first contribution) — it has the conventions every contributor agent
  is expected to follow.
- Read CONTRIBUTING.md for the commit-signing and branch-protection
  rules.
- If you're an AI agent: claim the originating issue first by assigning
  yourself via `gh issue edit <N> --add-assignee <handle>`. Double-
  assigning alongside the @aethersdr-agent triage bot is fine.
-->

## Summary

<!-- One-paragraph description of what changes and why.  If this fixes
an issue, lead with "Fixes #N" or "Closes #N". -->

## Constitution principle honored

<!-- Cite the principle by Roman numeral when relevant.  E.g.
"Principle V — new feature uses nested-JSON persistence."
"Principle IV — code is clean-room, not derived from decompiled sources."
See CONSTITUTION.md for the full list. -->

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [ ] Reproduction steps documented if user-reported bug

## Checklist

- [ ] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [ ] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [ ] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [ ] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable