### PR TITLE
feat(aetherd): 2.4 — EB3 vendor-include ratchet (freeze above-seam vendor coupling in place)

### DIFF
--- a/.github/workflows/engine-boundary.yml
+++ b/.github/workflows/engine-boundary.yml
@@ -1,15 +1,20 @@
 name: Engine Boundary Check
 
 # aetherd-migration ratchet (docs/aetherd-headless-engine-design.md §10):
-# the engine (src/core/ + src/models/) must never depend on the UI —
-# no gui/ header includes, no QtWidgets. Known legacy offenders are
-# tracked in tools/check_engine_boundary.py and warn without blocking;
-# NEW violations fail the job (--strict). The legacy lists only shrink.
+#   EB1/EB2 — the engine (src/core/ + src/models/) must never depend on the
+#             UI: no gui/ header includes, no QtWidgets.
+#   EB3     — no file ABOVE the radio seam (src/gui/ + src/core/ + src/models/,
+#             excluding the backend tree) may include a VENDOR header; the
+#             wire is reached only through IRadioBackend (RFC step 2.4).
+# Known legacy offenders are tracked in tools/check_engine_boundary.py and warn
+# without blocking; NEW violations fail the job (--strict). The baselines only
+# shrink. src/gui/** is in the trigger set because EB3 guards it too.
 
 on:
   pull_request:
     branches: ["**"]
     paths:
+      - "src/gui/**"
       - "src/core/**"
       - "src/models/**"
       - "tools/check_engine_boundary.py"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,13 +291,18 @@ you:
   headers stay where they are (`src/core/…`, `src/models/…`) for now. EB3
   just makes the existing boundary enforceable *in place*, so the
   decoupling can proceed without new coupling piling up behind it.
-- **The rule.** Adding a vendor `#include` (e.g. `KiwiSdrManager.h`,
-  `RadioConnection.h`, `TunerModel.h`) to a `gui/`, `core/`, or `models/`
-  file that isn't already tracked — or adding one to a tracked file beyond
-  its baseline count — fails the check. The full vendor list and the
-  frozen per-file baseline live at the top of
-  `tools/check_engine_boundary.py`
-  (`VENDOR_HEADERS` / `KNOWN_VENDOR_INCLUDE_BASELINE`).
+- **The rule.** Each tracked file's baseline row is the exact **set** of
+  vendor headers it may include. Adding a vendor `#include` (e.g.
+  `KiwiSdrManager.h`, `RadioConnection.h`, `TunerModel.h`) to a `gui/`,
+  `core/`, or `models/` file that isn't tracked — or adding a header not
+  in a tracked file's set, *including a lateral swap that keeps the count
+  flat* (drop `RadioConnection.h`, add `KiwiSdrManager.h`) — fails the
+  check. The per-file baseline (`KNOWN_VENDOR_INCLUDE_BASELINE`) lives at
+  the top of `tools/check_engine_boundary.py`; the vendor vocabulary is
+  **derived at runtime from the touchpoint audit**
+  (`docs/architecture/aetherd-touchpoint-tags.json`, the single source of
+  truth), so a header newly tagged `vendor` there is enforced without
+  editing the checker.
 - **Adding a radio feature?** Don't include the vendor class above the
   seam. Put the wire code in the family backend
   (`src/core/backends/<family>/`) and surface it through `IRadioBackend`
@@ -307,12 +312,11 @@ you:
   `src/core/backends/`) and the vendor translation units themselves may
   include vendor headers freely — they're below the seam.
 - **Removing coupling (the goal).** When you convert a file's radio access
-  to the seam and drop a vendor include, **lower that file's baseline**
-  in `KNOWN_VENDOR_INCLUDE_BASELINE` to match (delete the row when it hits
-  0). The baseline only shrinks — never raise a count or add a row to make
-  a build pass. If EB3 blocks you and the include is genuinely
-  unavoidable, that's a design conversation for a maintainer, not a
-  baseline bump.
+  to the seam and drop a vendor include, **remove that stem from the
+  file's row** in `KNOWN_VENDOR_INCLUDE_BASELINE` (delete the row when it
+  empties). The set only shrinks — never add a stem or a row to make a
+  build pass. If EB3 blocks you and the include is genuinely unavoidable,
+  that's a design conversation for a maintainer, not a baseline edit.
 - **`src/gui/**` is in the CI trigger** for `engine-boundary.yml` now
   (EB3 guards gui files), so a gui-only PR that adds vendor coupling is
   still caught.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,15 +249,26 @@ still consumes models directly, and that remains correct.
 | `libaethercore` (`aethercore`) | `src/core/` + `src/models/` — the engine | Qt Core/Network/Multimedia/WebSockets/SerialPort/DBus, the DSP + third-party libs. **Never `gui/`; QtWidgets only via the tracked-legacy files below, shrinking to zero** |
 | `AetherSDR` | `src/gui/` + `main.cpp` — the desktop app | `aethercore` + Qt Widgets + qgeoview + QRhi private |
 
-The engine→gui dependency direction is CI-enforced
-(`tools/check_engine_boundary.py`, `engine-boundary.yml`, `--strict`): no
-`core/`/`models/` file may include a `gui/` header (**EB1 — now zero,
-any finding is an error**), nor use QtWidgets (**EB2** — a shrinking
-tracked-legacy set warns, new usage errors). If your change trips the
-check, restructure the change — do not move the file, weaken the check,
-or add an exemption. Engine code that needs a UI callback defines a
-gui-free interface in `core/` (e.g. `IConnectionAutomation`) that the gui
-implements — never a `gui/` include.
+The dependency direction is CI-enforced (`tools/check_engine_boundary.py`,
+`engine-boundary.yml`, `--strict`) by three ratchets:
+- **EB1** — no `core/`/`models/` file may include a `gui/` header (now
+  zero; any finding is an error).
+- **EB2** — no `core/`/`models/` file may use QtWidgets (a shrinking
+  tracked-legacy set warns, new usage errors).
+- **EB3** — no file **above the radio seam** (all of `src/gui/`,
+  `src/core/`, `src/models/` **except** the backend tree
+  `src/core/backends/`) may include a **vendor header** — the
+  family-specific wire classes the RFC keeps behind `IRadioBackend`
+  (SmartSDR/FlexLib + KiwiSDR; the 26 headers tagged `vendor` in
+  `docs/architecture/aetherd-touchpoint-tags.json`). Today's coupling is
+  frozen as a per-file, shrink-only baseline; a **new** above-seam vendor
+  include, or an **increase** in a tracked file, errors. (RFC step 2.4;
+  see "Engine boundary ratchet — EB3" below.)
+
+If your change trips any of these, restructure the change — do not move
+the file, weaken the check, or add an exemption. Engine code that needs a
+UI callback defines a gui-free interface in `core/` (e.g.
+`IConnectionAutomation`) that the gui implements — never a `gui/` include.
 
 **Until migration rules appear in this file, nothing changes for you.**
 Do not pre-emptively restructure code toward the RFC — no new engine/UI
@@ -267,10 +278,44 @@ rules (pre-drafted in
 [`docs/aetherd-agents-md-staging.md`](docs/aetherd-agents-md-staging.md));
 if a rule isn't in this file, its step hasn't landed. Architecture changes
 ahead of the RFC steps remain maintainer-only (see Autonomous Agent
-Boundaries above). One rule is already CI-enforced: the engine
-(`src/core/` + `src/models/`) must not gain new `gui/` includes or
-QtWidgets usage (`tools/check_engine_boundary.py`, warning for tracked
-legacy files, error for new ones).
+Boundaries above). The CI-enforced rules so far are EB1/EB2/EB3 above
+(`tools/check_engine_boundary.py`, warning for tracked baselines, error
+for new violations).
+
+**Engine boundary ratchet — EB3 (vendor includes).** As of RFC step 2.4,
+`check_engine_boundary.py` also enforces that nothing above the radio seam
+reaches around `IRadioBackend` to a vendor wire class. What this means for
+you:
+
+- **Nothing was relocated.** Step 2.4 is *ratchet-only*: the 26 vendor
+  headers stay where they are (`src/core/…`, `src/models/…`) for now. EB3
+  just makes the existing boundary enforceable *in place*, so the
+  decoupling can proceed without new coupling piling up behind it.
+- **The rule.** Adding a vendor `#include` (e.g. `KiwiSdrManager.h`,
+  `RadioConnection.h`, `TunerModel.h`) to a `gui/`, `core/`, or `models/`
+  file that isn't already tracked — or adding one to a tracked file beyond
+  its baseline count — fails the check. The full vendor list and the
+  frozen per-file baseline live at the top of
+  `tools/check_engine_boundary.py`
+  (`VENDOR_HEADERS` / `KNOWN_VENDOR_INCLUDE_BASELINE`).
+- **Adding a radio feature?** Don't include the vendor class above the
+  seam. Put the wire code in the family backend
+  (`src/core/backends/<family>/`) and surface it through `IRadioBackend`
+  (a canonical verb/signal, or the namespaced
+  `invokeExtension`/`extensionStatus` channel for vendor-specifics), then
+  consume *that* from the model/UI. Backend code (under
+  `src/core/backends/`) and the vendor translation units themselves may
+  include vendor headers freely — they're below the seam.
+- **Removing coupling (the goal).** When you convert a file's radio access
+  to the seam and drop a vendor include, **lower that file's baseline**
+  in `KNOWN_VENDOR_INCLUDE_BASELINE` to match (delete the row when it hits
+  0). The baseline only shrinks — never raise a count or add a row to make
+  a build pass. If EB3 blocks you and the include is genuinely
+  unavoidable, that's a design conversation for a maintainer, not a
+  baseline bump.
+- **`src/gui/**` is in the CI trigger** for `engine-boundary.yml` now
+  (EB3 guards gui files), so a gui-only PR that adds vendor coupling is
+  still caught.
 
 **Where radio-facing code goes now that the seam exists.** Route by kind:
 
@@ -280,12 +325,17 @@ legacy files, error for new ones).
 | A new radio family | a new `IRadioBackend` implementation under `src/core/backends/<family>/` — requires an approved design doc naming its open protocol authority (Constitution Principles I & IV apply per backend) |
 | A new engine feature | `libaethercore`, exposed through models — never via a new gui→core header |
 
-Do **not** yet reroute existing model↔wire code through `FlexBackend`
+Do **not** reroute existing model↔wire code through `FlexBackend`
 wholesale — the per-touchpoint conversion is staged work
-(`docs/architecture/aetherd-touchpoints.md`), and its claim protocol +
-before/after `tools/verify_slice0_rx.py` verification recipe land in this
-file when those conversions (2.3) begin. Until then the models' existing
-direct wire access remains correct.
+(`docs/architecture/aetherd-touchpoints.md`). The five `mixed` models
+(Radio/Slice/Transmit/Panadapter/Meter) have been split (2.3): their
+SmartSDR status decode now lives in `FlexBackend` behind typed deltas, and
+the models apply normalized signals. The remaining vendor headers are
+**not** relocated yet — step 2.4 landed the EB3 ratchet (above) that
+freezes today's above-seam vendor coupling and lets it be decoupled
+subsystem-by-subsystem. Converting a touchpoint still follows the claim
+protocol + before/after `tools/verify_slice0_rx.py` recipe; a converted
+file drops its vendor include and lowers its EB3 baseline.
 
 ---
 

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -183,4 +183,16 @@ the interface has no implementor.
 - **2.3 — split the five `mixed` models** (5 PRs); AGENTS.md gains the
   touchpoint-claim protocol + verification recipe + the autonomous-conversion
   carve-out.
-- **2.4 — move the remaining vendor headers behind the seam.**
+- **2.4 — vendor-header boundary (ratchet-first).** The literal end state
+  ("nothing above the seam includes a vendor header") cannot land in one move:
+  the GUI still drives Flex/Kiwi features directly because the verb/protocol
+  layer (step 3) doesn't exist yet, so the ~78 above-seam vendor includes can't
+  drop to zero without step-3 work. Decision (2026-07-06, KK7GWY): land the
+  **ratchet only** first — `check_engine_boundary.py` gains **EB3**, freezing
+  today's above-seam vendor coupling as a per-file, shrink-only baseline (no new
+  coupling; existing includers decoupled subsystem-by-subsystem, each routed
+  through `IRadioBackend`, driving its baseline to zero). The 26 vendor files
+  are **not** relocated in this step — EB3 enforces the boundary in place.
+  Physical relocation of a header into `src/core/backends/<family>/` happens
+  when its last above-seam includer is converted. Adoption guidance lives in
+  `AGENTS.md` ("Engine boundary ratchet — EB3").

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -20,16 +20,23 @@ Guards the dependency direction the aetherd RFC
        aetherd RFC keeps *behind* IRadioBackend. "Above the seam" is
        everything in src/gui/, src/core/, and src/models/ EXCEPT the
        backend tree (src/core/backends/) and the vendor translation
-       units themselves. Today's coupling is frozen as a per-file,
-       shrink-only baseline (KNOWN_VENDOR_INCLUDE_BASELINE); any NEW
-       above-seam vendor include, or any INCREASE in a tracked file,
-       fails --strict. This is RFC step 2.4's ratchet: the interface
-       already exists, so no new code should reach around it — the
-       existing includers are decoupled subsystem-by-subsystem (each
-       routed through the seam) and their counts driven to zero.
-       Ratchet-only: the vendor files are NOT relocated in this step;
-       EB3 makes the boundary enforceable in place. See AGENTS.md
-       ("Engine boundary ratchet — EB3 vendor includes").
+       units themselves. Today's coupling is frozen as a per-file
+       baseline of the EXACT vendor headers each file may include
+       (KNOWN_VENDOR_INCLUDE_BASELINE). A file may only SHRINK its set;
+       any header not in its baseline row — a brand-new include, OR a
+       lateral swap that keeps the count flat (drop RadioConnection, add
+       KiwiSdrManager) — fails --strict. A set, not a count, so churn
+       that trades one vendor dependency for another can't slip through.
+       This is RFC step 2.4's ratchet: the interface already exists, so
+       no new code should reach around it — existing includers are
+       decoupled subsystem-by-subsystem (each routed through the seam)
+       and their rows driven to empty. Ratchet-only: the vendor files
+       are NOT relocated in this step; EB3 makes the boundary
+       enforceable in place. The vendor vocabulary is derived at runtime
+       from the touchpoint audit (docs/architecture/
+       aetherd-touchpoint-tags.json) so the audit is the single source
+       of truth — a header newly tagged vendor there is enforced without
+       editing this file. See AGENTS.md ("Engine boundary ratchet — EB3").
 
 Exit 0 always in default mode (annotation/warning stage, like
 check_a11y.py). --strict exits 1 on any non-legacy EB1/EB2/EB3 finding
@@ -45,6 +52,7 @@ stdlib only; no third-party dependencies.
 """
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -81,75 +89,110 @@ KNOWN_WIDGETS_LEGACY = {
 }
 
 # ---- EB3: vendor headers (family-specific wire code, kept behind the seam) ----
-# The 26 headers the aetherd touchpoint audit tags `vendor(flex)` / `vendor(kiwi)`
-# (docs/architecture/aetherd-touchpoint-tags.json). Keyed by basename STEM — an
-# include is a vendor include when its file's stem is in this map, regardless of
-# how the path is written ("core/RadioConnection.h", "RadioConnection.h",
-# "../core/RadioConnection.h", or <...>). Keep this in sync with the audit's
-# vendor tag set; there are no basename collisions with non-vendor headers.
-VENDOR_HEADERS = {
-    # SmartSDR / FlexLib / Flex-ecosystem wire code
-    "CommandParser": "flex", "DaxTxPolicy": "flex", "DvkWavTransfer": "flex",
-    "FirmwareStager": "flex", "FirmwareUploader": "flex", "FlexControlManager": "flex",
-    "MemoryCsvCompat": "flex", "PanadapterStream": "flex", "PgxlConnection": "flex",
-    "ProfileTransfer": "flex", "RadioConnection": "flex", "SmartLinkClient": "flex",
-    "StreamStatus": "flex", "TgxlConnection": "flex", "WanConnection": "flex",
-    "WaveformInstaller": "flex", "AntennaGeniusModel": "flex", "DaxIqModel": "flex",
-    "FlexWaveformModel": "flex", "ProfileLoadCommand": "flex",
-    "RadioStatusOwnership": "flex", "TunerModel": "flex",
-    # KiwiSDR wire code (the eventual second-backend template)
-    "KiwiPublicDirectory": "kiwi", "KiwiSdrClient": "kiwi",
-    "KiwiSdrManager": "kiwi", "KiwiSdrProtocol": "kiwi",
-}
+# The vendor vocabulary is DERIVED at runtime from the touchpoint audit
+# (single source of truth) rather than hand-copied, so a header newly tagged
+# `vendor(*)` there is enforced automatically — no silent drift where the audit
+# grows a vendor family but this checker keeps permitting it.
+VENDOR_TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
+# Sanity floor: the audit currently tags 26 vendor headers. If a parse yields
+# far fewer, the audit moved or its schema changed and EB3 is silently
+# under-armed — fail loudly (handled at load).
+VENDOR_STEMS_FLOOR = 20
+
+
+def load_vendor_vocabulary():
+    """Derive (stem -> family, {vendor TU rel-paths}) from the touchpoint audit.
+
+    - stems: an include is a vendor include when the included header's basename
+      stem is a key here (so "core/RadioConnection.h", "RadioConnection.h",
+      "../core/RadioConnection.h", and <...> all resolve the same).
+    - tu_paths: the EXACT rel-paths of the vendor translation units (each tagged
+      header plus its sibling impl files). The below-seam exemption keys on these
+      full paths, NOT a bare stem — so a *different* file that merely shares a
+      vendor stem (a future src/gui/CommandParser.cpp) is NOT exempted.
+
+    Returns (stems, tu_paths, error-or-None). On any load/parse failure the
+    error string is returned so main() can emit a blocking EB3-load finding
+    rather than silently scanning with an empty vocabulary.
+    """
+    try:
+        data = json.loads(VENDOR_TAGS_JSON.read_text())
+    except (OSError, ValueError) as e:
+        return {}, set(), f"cannot read {VENDOR_TAGS_JSON.name}: {e}"
+    stems, tu_paths = {}, set()
+    for hdr, meta in data.items():
+        tag = (meta or {}).get("tag", "")
+        if not tag.startswith("vendor"):
+            continue
+        family = tag[tag.find("(") + 1:tag.find(")")] if "(" in tag else "vendor"
+        stems[Path(hdr).stem] = family
+        base = Path("src") / hdr           # e.g. "src/core/CommandParser.h"
+        for suf in ENGINE_SUFFIXES:         # header + sibling impl TUs
+            tu_paths.add(base.with_suffix(suf).as_posix())
+    if len(stems) < VENDOR_STEMS_FLOOR:
+        return stems, tu_paths, (
+            f"parsed only {len(stems)} vendor stems from {VENDOR_TAGS_JSON.name} "
+            f"(expected >= {VENDOR_STEMS_FLOOR}) — the audit moved or its schema "
+            "changed; EB3 is under-armed")
+    return stems, tu_paths, None
+
 
 VENDOR_INCLUDE_RE = re.compile(
     r'^\s*#\s*include\s*[<"](?P<path>[A-Za-z0-9_./]+)\.h[>"]'
 )
 
-# EB3 per-file, shrink-only baseline: today's above-seam files and HOW MANY
-# vendor headers each includes (frozen 2026-07-06, RFC step 2.4). Like EB2 this
-# is a COUNT, not a whole-file exemption — any increase fails --strict. Drive
-# each to zero by routing that file's radio access through IRadioBackend; when a
-# file reaches 0, delete its row. NEVER add a row or raise a count.
+# EB3 per-file baseline: today's above-seam files and the EXACT set of vendor
+# headers each may include (frozen 2026-07-06, RFC step 2.4). A SET, not a count
+# — a file may only drop headers from its row; any header not listed (a new
+# include OR a lateral swap that keeps the count flat) fails --strict. Decouple
+# a file by routing its radio access through IRadioBackend, then delete the
+# dropped stem(s) from its row; delete the row when it empties. NEVER add a stem
+# or a row to make a build pass.
 KNOWN_VENDOR_INCLUDE_BASELINE = {
-    "src/core/TciProtocol.cpp": 1,
-    "src/core/TciServer.cpp": 2,
-    "src/core/WfmDemodulator.cpp": 1,
-    "src/gui/AntennaGeniusApplet.cpp": 1,
-    "src/gui/Ax25HfPacketDecodeDialog.cpp": 1,
-    "src/gui/ConnectionPanel.h": 1,
-    "src/gui/DaxIqApplet.cpp": 1,
-    "src/gui/DvkPanel.cpp": 1,
-    "src/gui/KiwiPublicReceiverPicker.h": 1,
-    "src/gui/KiwiSdrApplet.h": 1,
-    "src/gui/MainWindow.cpp": 7,
-    "src/gui/MainWindow.h": 7,
-    "src/gui/MainWindowHelpers.cpp": 2,
-    "src/gui/MainWindow_Controllers.cpp": 1,
-    "src/gui/MainWindow_KiwiSdr.cpp": 3,
-    "src/gui/MainWindow_ReceiveSync.cpp": 1,
-    "src/gui/MainWindow_Shortcuts.cpp": 1,
-    "src/gui/MainWindow_Wiring.cpp": 3,
-    "src/gui/MemoryDialog.cpp": 2,
-    "src/gui/NetworkDiagnosticsDialog.h": 1,
-    "src/gui/ProfileImportExportDialog.h": 1,
-    "src/gui/RadioSetupDialog.cpp": 9,
-    "src/gui/RxApplet.cpp": 2,
-    "src/gui/SMeterWidget.h": 1,
-    "src/gui/ShackSwitchApplet.cpp": 1,
-    "src/gui/SpectrumOverlayMenu.cpp": 1,
-    "src/gui/SpectrumWidget.cpp": 1,
-    "src/gui/SupportDialog.cpp": 1,
-    "src/gui/TunerApplet.cpp": 1,
-    "src/gui/TxApplet.cpp": 1,
-    "src/gui/VfoWidget.cpp": 2,
-    "src/gui/VfoWidget.h": 1,
-    "src/gui/WaveformsDialog.cpp": 2,
-    "src/models/RadioModel.cpp": 4,
-    "src/models/RadioModel.h": 9,
-    "src/models/SliceModel.cpp": 1,
-    "src/models/TransmitInhibitPolicy.h": 1,
+    "src/core/TciProtocol.cpp": ["DaxIqModel"],
+    "src/core/TciServer.cpp": ["DaxIqModel", "StreamStatus"],
+    "src/core/WfmDemodulator.cpp": ["DaxIqModel"],
+    "src/gui/AntennaGeniusApplet.cpp": ["AntennaGeniusModel"],
+    "src/gui/Ax25HfPacketDecodeDialog.cpp": ["DaxTxPolicy"],
+    "src/gui/ConnectionPanel.h": ["SmartLinkClient"],
+    "src/gui/DaxIqApplet.cpp": ["DaxIqModel"],
+    "src/gui/DvkPanel.cpp": ["DvkWavTransfer"],
+    "src/gui/KiwiPublicReceiverPicker.h": ["KiwiPublicDirectory"],
+    "src/gui/KiwiSdrApplet.h": ["KiwiSdrClient"],
+    "src/gui/MainWindow.cpp": ["CommandParser", "DvkWavTransfer", "KiwiSdrManager", "PanadapterStream", "RadioStatusOwnership", "StreamStatus", "TunerModel"],
+    "src/gui/MainWindow.h": ["AntennaGeniusModel", "CommandParser", "FlexControlManager", "PgxlConnection", "SmartLinkClient", "TgxlConnection", "WanConnection"],
+    "src/gui/MainWindowHelpers.cpp": ["PanadapterStream", "SmartLinkClient"],
+    "src/gui/MainWindow_Controllers.cpp": ["KiwiSdrProtocol"],
+    "src/gui/MainWindow_KiwiSdr.cpp": ["KiwiSdrClient", "KiwiSdrManager", "KiwiSdrProtocol"],
+    "src/gui/MainWindow_ReceiveSync.cpp": ["KiwiSdrManager"],
+    "src/gui/MainWindow_Shortcuts.cpp": ["KiwiSdrProtocol"],
+    "src/gui/MainWindow_Wiring.cpp": ["KiwiSdrManager", "KiwiSdrProtocol", "ProfileLoadCommand"],
+    "src/gui/MemoryDialog.cpp": ["MemoryCsvCompat", "RadioConnection"],
+    "src/gui/NetworkDiagnosticsDialog.h": ["PanadapterStream"],
+    "src/gui/ProfileImportExportDialog.h": ["ProfileTransfer"],
+    "src/gui/RadioSetupDialog.cpp": ["AntennaGeniusModel", "FirmwareStager", "FirmwareUploader", "FlexControlManager", "KiwiSdrManager", "PanadapterStream", "PgxlConnection", "TgxlConnection", "WanConnection"],
+    "src/gui/RxApplet.cpp": ["KiwiSdrManager", "KiwiSdrProtocol"],
+    "src/gui/SMeterWidget.h": ["KiwiSdrProtocol"],
+    "src/gui/ShackSwitchApplet.cpp": ["AntennaGeniusModel"],
+    "src/gui/SpectrumOverlayMenu.cpp": ["KiwiSdrManager"],
+    "src/gui/SpectrumWidget.cpp": ["KiwiSdrProtocol"],
+    "src/gui/SupportDialog.cpp": ["RadioConnection"],
+    "src/gui/TunerApplet.cpp": ["TunerModel"],
+    "src/gui/TxApplet.cpp": ["TunerModel"],
+    "src/gui/VfoWidget.cpp": ["KiwiSdrManager", "KiwiSdrProtocol"],
+    "src/gui/VfoWidget.h": ["KiwiSdrProtocol"],
+    "src/gui/WaveformsDialog.cpp": ["FlexWaveformModel", "WaveformInstaller"],
+    "src/models/RadioModel.cpp": ["CommandParser", "ProfileLoadCommand", "RadioStatusOwnership", "StreamStatus"],
+    "src/models/RadioModel.h": ["CommandParser", "DaxIqModel", "DaxTxPolicy", "FlexWaveformModel", "PanadapterStream", "RadioConnection", "RadioStatusOwnership", "TunerModel", "WanConnection"],
+    "src/models/SliceModel.cpp": ["KiwiSdrProtocol"],
+    "src/models/TransmitInhibitPolicy.h": ["CommandParser"],
 }
+# Per-directory vacuity floor for the above-seam scan (EB3's analog of EB0):
+# if src/gui/ — the bulk of the baseline — is ever renamed/relocated, its files
+# vanish from the scan, every gui row degrades to a non-blocking EB3-stale
+# warning, and the gui ratchet silently disarms while CI stays green. Require
+# each above-seam dir to still yield at least this many files on a full scan.
+ABOVE_SEAM_DIR_FLOOR = 20
 
 # Matches gui includes in "..." OR <...>, optional space, optional gui/ prefix,
 # and SUBDIR paths (name group carries '/'), so angle-bracket, no-space, and
@@ -198,8 +241,8 @@ def collect_files(args):
         for a in args:
             p = (REPO / a) if not Path(a).is_absolute() else Path(a)
             if p.suffix in ENGINE_SUFFIXES and p.is_file():
-                rel = p.resolve().relative_to(REPO)
-                if any(str(rel).startswith(f"src/{d}/") for d in ("core", "models")):
+                rel = p.resolve().relative_to(REPO).as_posix()
+                if any(rel.startswith(f"src/{d}/") for d in ("core", "models")):
                     files.append(p.resolve())
         return files
     files = []
@@ -262,20 +305,24 @@ def check_file(path):
     return findings
 
 
-def is_below_seam(rel):
+def is_below_seam(rel, vendor_tu_paths):
     """A file is BELOW the radio seam — free to include vendor code — if it is
-    in the backend tree, or is a vendor translation unit itself (its stem names
-    a vendor header, so RadioConnection.cpp including StreamStatus.h is fine)."""
-    return rel.startswith(BACKENDS_PREFIX) or Path(rel).stem in VENDOR_HEADERS
+    in the backend tree, or IS one of the vendor translation units itself
+    (RadioConnection.cpp including StreamStatus.h is fine). The exemption keys on
+    the vendor TU's EXACT rel-path, not a bare stem: a different file that merely
+    shares a vendor basename (a future src/gui/CommandParser.cpp) is NOT exempt
+    and its vendor includes are still checked."""
+    return rel.startswith(BACKENDS_PREFIX) or rel in vendor_tu_paths
 
 
-def check_vendor_file(path):
-    """EB3 — vendor-include findings for one ABOVE-SEAM file. Per-file count vs
-    the frozen baseline (mirrors EB2): a tracked file's known vendor includes
-    warn 'EB3-known'; a NEW above-seam includer, or a tracked file whose count
-    grew, is a blocking EB3."""
+def check_vendor_file(path, vendor_stems, vendor_tu_paths):
+    """EB3 — vendor-include findings for one ABOVE-SEAM file. The baseline row is
+    the SET of vendor headers the file may include: a listed stem warns
+    'EB3-known'; any stem NOT in the row — a new include, or a lateral swap that
+    keeps the count flat — is a blocking EB3. A file with no row may include no
+    vendor header at all."""
     rel = path.relative_to(REPO).as_posix()
-    if is_below_seam(rel):
+    if is_below_seam(rel, vendor_tu_paths):
         return []
     lines = path.read_text(errors="replace").splitlines()
     hits = []  # (line_no, stem, family)
@@ -284,32 +331,33 @@ def check_vendor_file(path):
         if not m:
             continue
         stem = Path(m.group("path")).name
-        fam = VENDOR_HEADERS.get(stem)
+        fam = vendor_stems.get(stem)
         if fam:
             hits.append((i, stem, fam))
 
+    allowed = set(KNOWN_VENDOR_INCLUDE_BASELINE.get(rel, ()))
+    tracked = rel in KNOWN_VENDOR_INCLUDE_BASELINE
     findings = []
-    baseline = KNOWN_VENDOR_INCLUDE_BASELINE.get(rel)
-    if baseline is None:
-        # Untracked above-seam file: every vendor include is NEW coupling.
-        for i, stem, fam in hits:
+    for i, stem, fam in hits:
+        if stem in allowed:
+            findings.append(("warning", i, "EB3-known",
+                f"{rel} includes vendor({fam}) header {stem}.h — tracked legacy; "
+                "the baseline may only shrink. Decouple via IRadioBackend, then "
+                "drop this stem from the file's KNOWN_VENDOR_INCLUDE_BASELINE row."))
+        elif tracked:
+            # A stem not in this tracked file's allowed set — new or swapped-in.
+            findings.append(("error", i, "EB3",
+                f"{rel} includes vendor({fam}) header {stem}.h, which is not in "
+                "its EB3 baseline set — new (or laterally swapped-in) vendor "
+                "coupling above the radio seam. Route it through IRadioBackend "
+                "(aetherd RFC §5.5 / step 2.4); the baseline set only shrinks."))
+        else:
+            # Untracked above-seam file: any vendor include is new coupling.
             findings.append(("error", i, "EB3",
                 f"{rel} includes vendor({fam}) header {stem}.h — code above the "
                 "radio seam must reach the wire only through IRadioBackend "
                 "(aetherd RFC §5.5 / step 2.4); no new vendor coupling. Route "
                 "this through the backend, or add a seam verb/signal."))
-    else:
-        for i, stem, fam in hits:
-            findings.append(("warning", i, "EB3-known",
-                f"{rel} includes vendor({fam}) header {stem}.h — tracked legacy "
-                f"(baseline {baseline}); the count may only shrink. Decouple via "
-                "IRadioBackend and lower the baseline."))
-        if len(hits) > baseline:
-            findings.append(("error", hits[-1][0], "EB3",
-                f"{rel} vendor includes grew to {len(hits)} (baseline "
-                f"{baseline}) — the tracked count may only shrink; route new "
-                "radio access through IRadioBackend (or lower the baseline if "
-                "you removed some)."))
     return findings
 
 
@@ -321,8 +369,8 @@ def collect_above_seam_files(args):
         for a in args:
             p = (REPO / a) if not Path(a).is_absolute() else Path(a)
             if p.suffix in ENGINE_SUFFIXES and p.is_file():
-                rel = p.resolve().relative_to(REPO)
-                if any(str(rel).startswith(f"src/{d}/") for d in ("gui", "core", "models")):
+                rel = p.resolve().relative_to(REPO).as_posix()
+                if any(rel.startswith(f"src/{d}/") for d in ("gui", "core", "models")):
                     out.append(p.resolve())
         return out
     out = []
@@ -335,10 +383,11 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("files", nargs="*")
     ap.add_argument("--strict", action="store_true",
-                    help="exit 1 on EB1 or non-legacy EB2 findings")
+                    help="exit 1 on any non-legacy EB0/EB1/EB2/EB3 finding")
     args = ap.parse_args()
 
     files = collect_files(args.files)
+    vendor_stems, vendor_tu_paths, vocab_err = load_vendor_vocabulary()
 
     # Floor check: a full-tree scan that finds no engine files means the
     # directory layout moved and the ratchet silently disarmed. Fail loudly
@@ -354,6 +403,16 @@ def main():
 
     blocking = 0
     total = 0
+
+    # EB3 vocabulary must load, or the whole vendor ratchet is disarmed — the
+    # scan would run with an empty vendor set and pass every file vacuously.
+    if vocab_err:
+        annotate("error", "tools/check_engine_boundary.py", 1, "EB3-load",
+                 f"EB3 vendor vocabulary failed to load: {vocab_err}. The vendor "
+                 "ratchet is disarmed until this is fixed.")
+        total += 1
+        blocking += 1
+
     for f in files:
         for sev, line, rule, msg in check_file(f):
             annotate(sev, f.relative_to(REPO).as_posix(), line, rule, msg)
@@ -363,16 +422,33 @@ def main():
 
     # EB3 — vendor-include ratchet over the wider above-seam tree.
     seam_files = collect_above_seam_files(args.files)
+
+    # Per-directory vacuity floor (EB3's analog of EB0): on a full scan, if any
+    # above-seam dir collapses below the floor it was renamed/relocated and its
+    # half of the ratchet silently disarmed — fail loudly. gui/ holds the bulk
+    # of the baseline, so an EB0 that only counts core+models wouldn't catch it.
+    if not args.files:
+        for d in ABOVE_SEAM_DIRS:
+            n = sum(1 for p in d.rglob("*") if p.suffix in ENGINE_SUFFIXES)
+            if n < ABOVE_SEAM_DIR_FLOOR:
+                annotate("error", "tools/check_engine_boundary.py", 1, "EB3-floor",
+                         f"only {n} files under {d.relative_to(REPO)} "
+                         f"(floor {ABOVE_SEAM_DIR_FLOOR}) — the above-seam tree "
+                         "moved; the EB3 ratchet is disarmed for it. Fix "
+                         "ABOVE_SEAM_DIRS.")
+                total += 1
+                blocking += 1
+
     for f in seam_files:
-        for sev, line, rule, msg in check_vendor_file(f):
+        for sev, line, rule, msg in check_vendor_file(f, vendor_stems, vendor_tu_paths):
             annotate(sev, f.relative_to(REPO).as_posix(), line, rule, msg)
             total += 1
-            if rule == "EB3":
+            if rule in ("EB3", "EB3-floor", "EB3-load"):
                 blocking += 1
 
     # Stale-baseline hygiene (full-tree scans only): a baseline row for a file
     # that no longer exists is dead weight — flag it non-blocking so it gets
-    # pruned. (A row whose COUNT dropped is fine; that's the ratchet working.)
+    # pruned. (A row whose set merely shrank is fine; that's the ratchet working.)
     if not args.files:
         for rel in sorted(KNOWN_VENDOR_INCLUDE_BASELINE):
             if not (REPO / rel).is_file():
@@ -381,9 +457,10 @@ def main():
                          "exists — remove the stale row.")
                 total += 1
 
-    print(f"engine-boundary: {len(files)} engine + {len(seam_files)} above-seam "
-          f"file(s) scanned, {total} finding(s), {blocking} would block under "
-          "--strict")
+    scanned = sorted({f.as_posix() for f in files} | {f.as_posix() for f in seam_files})
+    print(f"engine-boundary: {len(scanned)} file(s) scanned "
+          f"({len(files)} engine, {len(seam_files)} above-seam), "
+          f"{total} finding(s), {blocking} would block under --strict")
     if args.strict and blocking:
         return 1
     return 0

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -15,10 +15,26 @@ Guards the dependency direction the aetherd RFC
        relocation during RFC step 1 (KNOWN_WIDGETS_LEGACY below); they
        warn as "known". Any OTHER file warns as NEW leakage.
 
+  EB3  No file ABOVE the radio seam may include a VENDOR header —
+       family-specific wire code (SmartSDR/FlexLib + KiwiSDR) that the
+       aetherd RFC keeps *behind* IRadioBackend. "Above the seam" is
+       everything in src/gui/, src/core/, and src/models/ EXCEPT the
+       backend tree (src/core/backends/) and the vendor translation
+       units themselves. Today's coupling is frozen as a per-file,
+       shrink-only baseline (KNOWN_VENDOR_INCLUDE_BASELINE); any NEW
+       above-seam vendor include, or any INCREASE in a tracked file,
+       fails --strict. This is RFC step 2.4's ratchet: the interface
+       already exists, so no new code should reach around it — the
+       existing includers are decoupled subsystem-by-subsystem (each
+       routed through the seam) and their counts driven to zero.
+       Ratchet-only: the vendor files are NOT relocated in this step;
+       EB3 makes the boundary enforceable in place. See AGENTS.md
+       ("Engine boundary ratchet — EB3 vendor includes").
+
 Exit 0 always in default mode (annotation/warning stage, like
-check_a11y.py). --strict exits 1 on any non-legacy EB1/EB2 finding —
-new leakage blocks immediately while the tracked legacy set shrinks
-to zero during step 1. Shrink the legacy lists; never grow them.
+check_a11y.py). --strict exits 1 on any non-legacy EB1/EB2/EB3 finding
+— new leakage blocks immediately while the tracked baselines shrink to
+zero during the migration. Shrink the legacy lists; never grow them.
 
 Usage:
     python tools/check_engine_boundary.py [file1 file2 ...]
@@ -36,6 +52,11 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 ENGINE_DIRS = [REPO / "src" / "core", REPO / "src" / "models"]
 GUI_DIR = REPO / "src" / "gui"
+# EB3 scans a WIDER set than EB1/EB2: the radio seam lives below all three of
+# these, so gui/ is in scope for vendor-include leakage too.
+ABOVE_SEAM_DIRS = [REPO / "src" / "gui", REPO / "src" / "core", REPO / "src" / "models"]
+# Below the seam = the backend tree. Anything here may include vendor code freely.
+BACKENDS_PREFIX = "src/core/backends/"
 
 # Scanned source suffixes. Includes .mm (Objective-C++, e.g. MacMicPermission.mm)
 # and .hpp/.cc so no engine TU is a blind spot for gui/QtWidgets leakage.
@@ -57,6 +78,77 @@ KNOWN_WIDGETS_LEGACY = {
     "src/core/AutomationServer.cpp": 20,
     "src/core/ShortcutManager.cpp": 1,
     "src/core/SettingsHelpers.cpp": 1,
+}
+
+# ---- EB3: vendor headers (family-specific wire code, kept behind the seam) ----
+# The 26 headers the aetherd touchpoint audit tags `vendor(flex)` / `vendor(kiwi)`
+# (docs/architecture/aetherd-touchpoint-tags.json). Keyed by basename STEM — an
+# include is a vendor include when its file's stem is in this map, regardless of
+# how the path is written ("core/RadioConnection.h", "RadioConnection.h",
+# "../core/RadioConnection.h", or <...>). Keep this in sync with the audit's
+# vendor tag set; there are no basename collisions with non-vendor headers.
+VENDOR_HEADERS = {
+    # SmartSDR / FlexLib / Flex-ecosystem wire code
+    "CommandParser": "flex", "DaxTxPolicy": "flex", "DvkWavTransfer": "flex",
+    "FirmwareStager": "flex", "FirmwareUploader": "flex", "FlexControlManager": "flex",
+    "MemoryCsvCompat": "flex", "PanadapterStream": "flex", "PgxlConnection": "flex",
+    "ProfileTransfer": "flex", "RadioConnection": "flex", "SmartLinkClient": "flex",
+    "StreamStatus": "flex", "TgxlConnection": "flex", "WanConnection": "flex",
+    "WaveformInstaller": "flex", "AntennaGeniusModel": "flex", "DaxIqModel": "flex",
+    "FlexWaveformModel": "flex", "ProfileLoadCommand": "flex",
+    "RadioStatusOwnership": "flex", "TunerModel": "flex",
+    # KiwiSDR wire code (the eventual second-backend template)
+    "KiwiPublicDirectory": "kiwi", "KiwiSdrClient": "kiwi",
+    "KiwiSdrManager": "kiwi", "KiwiSdrProtocol": "kiwi",
+}
+
+VENDOR_INCLUDE_RE = re.compile(
+    r'^\s*#\s*include\s*[<"](?P<path>[A-Za-z0-9_./]+)\.h[>"]'
+)
+
+# EB3 per-file, shrink-only baseline: today's above-seam files and HOW MANY
+# vendor headers each includes (frozen 2026-07-06, RFC step 2.4). Like EB2 this
+# is a COUNT, not a whole-file exemption — any increase fails --strict. Drive
+# each to zero by routing that file's radio access through IRadioBackend; when a
+# file reaches 0, delete its row. NEVER add a row or raise a count.
+KNOWN_VENDOR_INCLUDE_BASELINE = {
+    "src/core/TciProtocol.cpp": 1,
+    "src/core/TciServer.cpp": 2,
+    "src/core/WfmDemodulator.cpp": 1,
+    "src/gui/AntennaGeniusApplet.cpp": 1,
+    "src/gui/Ax25HfPacketDecodeDialog.cpp": 1,
+    "src/gui/ConnectionPanel.h": 1,
+    "src/gui/DaxIqApplet.cpp": 1,
+    "src/gui/DvkPanel.cpp": 1,
+    "src/gui/KiwiPublicReceiverPicker.h": 1,
+    "src/gui/KiwiSdrApplet.h": 1,
+    "src/gui/MainWindow.cpp": 7,
+    "src/gui/MainWindow.h": 7,
+    "src/gui/MainWindowHelpers.cpp": 2,
+    "src/gui/MainWindow_Controllers.cpp": 1,
+    "src/gui/MainWindow_KiwiSdr.cpp": 3,
+    "src/gui/MainWindow_ReceiveSync.cpp": 1,
+    "src/gui/MainWindow_Shortcuts.cpp": 1,
+    "src/gui/MainWindow_Wiring.cpp": 3,
+    "src/gui/MemoryDialog.cpp": 2,
+    "src/gui/NetworkDiagnosticsDialog.h": 1,
+    "src/gui/ProfileImportExportDialog.h": 1,
+    "src/gui/RadioSetupDialog.cpp": 9,
+    "src/gui/RxApplet.cpp": 2,
+    "src/gui/SMeterWidget.h": 1,
+    "src/gui/ShackSwitchApplet.cpp": 1,
+    "src/gui/SpectrumOverlayMenu.cpp": 1,
+    "src/gui/SpectrumWidget.cpp": 1,
+    "src/gui/SupportDialog.cpp": 1,
+    "src/gui/TunerApplet.cpp": 1,
+    "src/gui/TxApplet.cpp": 1,
+    "src/gui/VfoWidget.cpp": 2,
+    "src/gui/VfoWidget.h": 1,
+    "src/gui/WaveformsDialog.cpp": 2,
+    "src/models/RadioModel.cpp": 4,
+    "src/models/RadioModel.h": 9,
+    "src/models/SliceModel.cpp": 1,
+    "src/models/TransmitInhibitPolicy.h": 1,
 }
 
 # Matches gui includes in "..." OR <...>, optional space, optional gui/ prefix,
@@ -170,6 +262,75 @@ def check_file(path):
     return findings
 
 
+def is_below_seam(rel):
+    """A file is BELOW the radio seam — free to include vendor code — if it is
+    in the backend tree, or is a vendor translation unit itself (its stem names
+    a vendor header, so RadioConnection.cpp including StreamStatus.h is fine)."""
+    return rel.startswith(BACKENDS_PREFIX) or Path(rel).stem in VENDOR_HEADERS
+
+
+def check_vendor_file(path):
+    """EB3 — vendor-include findings for one ABOVE-SEAM file. Per-file count vs
+    the frozen baseline (mirrors EB2): a tracked file's known vendor includes
+    warn 'EB3-known'; a NEW above-seam includer, or a tracked file whose count
+    grew, is a blocking EB3."""
+    rel = path.relative_to(REPO).as_posix()
+    if is_below_seam(rel):
+        return []
+    lines = path.read_text(errors="replace").splitlines()
+    hits = []  # (line_no, stem, family)
+    for i, line in enumerate(lines, 1):
+        m = VENDOR_INCLUDE_RE.match(line)
+        if not m:
+            continue
+        stem = Path(m.group("path")).name
+        fam = VENDOR_HEADERS.get(stem)
+        if fam:
+            hits.append((i, stem, fam))
+
+    findings = []
+    baseline = KNOWN_VENDOR_INCLUDE_BASELINE.get(rel)
+    if baseline is None:
+        # Untracked above-seam file: every vendor include is NEW coupling.
+        for i, stem, fam in hits:
+            findings.append(("error", i, "EB3",
+                f"{rel} includes vendor({fam}) header {stem}.h — code above the "
+                "radio seam must reach the wire only through IRadioBackend "
+                "(aetherd RFC §5.5 / step 2.4); no new vendor coupling. Route "
+                "this through the backend, or add a seam verb/signal."))
+    else:
+        for i, stem, fam in hits:
+            findings.append(("warning", i, "EB3-known",
+                f"{rel} includes vendor({fam}) header {stem}.h — tracked legacy "
+                f"(baseline {baseline}); the count may only shrink. Decouple via "
+                "IRadioBackend and lower the baseline."))
+        if len(hits) > baseline:
+            findings.append(("error", hits[-1][0], "EB3",
+                f"{rel} vendor includes grew to {len(hits)} (baseline "
+                f"{baseline}) — the tracked count may only shrink; route new "
+                "radio access through IRadioBackend (or lower the baseline if "
+                "you removed some)."))
+    return findings
+
+
+def collect_above_seam_files(args):
+    """Files to scan for EB3. In file-args mode, honor the passed set (filtered
+    to the above-seam dirs); otherwise the full gui+core+models tree."""
+    if args:
+        out = []
+        for a in args:
+            p = (REPO / a) if not Path(a).is_absolute() else Path(a)
+            if p.suffix in ENGINE_SUFFIXES and p.is_file():
+                rel = p.resolve().relative_to(REPO)
+                if any(str(rel).startswith(f"src/{d}/") for d in ("gui", "core", "models")):
+                    out.append(p.resolve())
+        return out
+    out = []
+    for d in ABOVE_SEAM_DIRS:
+        out.extend(p for p in sorted(d.rglob("*")) if p.suffix in ENGINE_SUFFIXES)
+    return out
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("files", nargs="*")
@@ -200,8 +361,29 @@ def main():
             if rule in ("EB1", "EB2", "EB0"):
                 blocking += 1
 
-    print(f"engine-boundary: {len(files)} file(s) scanned, "
-          f"{total} finding(s), {blocking} would block under --strict")
+    # EB3 — vendor-include ratchet over the wider above-seam tree.
+    seam_files = collect_above_seam_files(args.files)
+    for f in seam_files:
+        for sev, line, rule, msg in check_vendor_file(f):
+            annotate(sev, f.relative_to(REPO).as_posix(), line, rule, msg)
+            total += 1
+            if rule == "EB3":
+                blocking += 1
+
+    # Stale-baseline hygiene (full-tree scans only): a baseline row for a file
+    # that no longer exists is dead weight — flag it non-blocking so it gets
+    # pruned. (A row whose COUNT dropped is fine; that's the ratchet working.)
+    if not args.files:
+        for rel in sorted(KNOWN_VENDOR_INCLUDE_BASELINE):
+            if not (REPO / rel).is_file():
+                annotate("warning", "tools/check_engine_boundary.py", 1,
+                         "EB3-stale", f"baseline names {rel}, which no longer "
+                         "exists — remove the stale row.")
+                total += 1
+
+    print(f"engine-boundary: {len(files)} engine + {len(seam_files)} above-seam "
+          f"file(s) scanned, {total} finding(s), {blocking} would block under "
+          "--strict")
     if args.strict and blocking:
         return 1
     return 0


### PR DESCRIPTION
## aetherd RFC step 2.4 — ratchet-first

The literal end state ("nothing above the radio seam includes a vendor header") can't land in one move: the GUI still drives Flex/Kiwi features directly until the step-3 verb/protocol layer exists, so the ~78 above-seam vendor includes can't drop to zero yet. Rather than a mass file relocation (cosmetic re: the second-backend goal, noisy, risky), this lands the **enforcement first** so coupling can be decoupled subsystem-by-subsystem without new coupling piling up behind it.

### What this adds
`check_engine_boundary.py` gains **EB3**: no file **above the seam** (all of `src/gui/` + `src/core/` + `src/models/`, **except** the backend tree `src/core/backends/` and the vendor translation units themselves) may include a **vendor header** — the 26 headers tagged `vendor(flex)`/`vendor(kiwi)` in the touchpoint audit. Today's coupling is frozen as a per-file, shrink-only baseline (`KNOWN_VENDOR_INCLUDE_BASELINE`, **37 files / 78 includes**, mirroring EB2's shape): a **new** above-seam vendor include, or an **increase** in a tracked file, fails `--strict`. Below-seam code may include vendor headers freely.

**No files are relocated** — EB3 enforces the boundary in place. A converted touchpoint drops its vendor include and lowers its baseline; the baseline only shrinks (delete a row at 0), never grows.

### Changes
- **`tools/check_engine_boundary.py`** — `VENDOR_HEADERS` + baseline + `check_vendor_file` + `collect_above_seam_files`; EB3 pass, stale-baseline hygiene, wider scan set.
- **`.github/workflows/engine-boundary.yml`** — add `src/gui/**` to the trigger (EB3 guards gui files, so a gui-only PR adding vendor coupling is still caught); header comment documents EB1/EB2/EB3.
- **`AGENTS.md`** — EB3 in the CI-enforced-rules list + a dedicated "Engine boundary ratchet — EB3" adoption section (what/why/how-to-lower); radio-facing-code guidance refreshed now that 2.3 has landed.
- **design doc** — records the ratchet-first decision under sub-step 2.4.

### Verification
- **78 `EB3-known` / 0 blocking** on a clean tree; `--strict` exit 0.
- Ratchet **fires** on both a new untracked includer and a tracked-file increase; below-seam TUs exempt; file-args (CI diff) mode honored; restores clean.

Behavior-neutral: no engine/app code changes — docs + a stdlib CI check only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)