### PR TITLE
[codex] Add Kiwi/Flex display toggle

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -147,6 +147,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get slice[s] \| pan[s]`](#get) | Slice & panadapter model snapshots. |
 | | [`get cwx`](#get-cwx) | CWX keyer state + queue-drain watch (#3949). |
 | | [`get panstats`](#get-panstats) | Per-panadapter render-cost counters (profiling). |
+| | [`get tracedebug`](#get-tracedebug) | Per-panadapter Flex/Kiwi FFT and 3D trace diagnostics. |
 | | [`get clients`](#get-clients) | Radio client roster + foreign-pan-write forensics (#3977). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
 | | [`get wavestats`](#get-wavestats) | WAVE/strip scope paint-cost counters. |
@@ -444,8 +445,9 @@ connects).
 | `slices` | — | array of all slice snapshots |
 | `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, **squelch/squelchLevel, agcMode/agcThreshold, apf/apfLevel**, **adaptiveFilterEnabled/adaptiveMinLowCut/adaptiveMaxHighCut/adaptiveMinSnr/adaptiveResponse/adaptiveSplatter/adaptiveActive** (SSB adaptive RX filter — `adaptiveActive` is the live AUTO-fit state), txSlice, …) |
 | `pans` | — | array of all panadapter snapshots |
-| `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps) |
+| `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps, `transmitInhibited`, `transmitInhibitReason`) |
 | `panstats` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter render-cost counters — see [`get panstats`](#get-panstats) |
+| `tracedebug` | `<panIndex>` / `<objectName>` (default: all) | per-panadapter Flex/Kiwi FFT and 3D trace diagnostics — see [`get tracedebug`](#get-tracedebug) |
 | `wavestats` | `—` / scope objectName | waveform-scope paint/append counters — see [`get wavestats`](#get-wavestats) |
 | `clients` | — | connected-client roster, per-pan ownership, foreign dBm-write counters and evictions — see [`get clients`](#get-clients) |
 | `dax` | — | DAX RX channel-ownership table — see [`get dax`](#get-dax) |
@@ -523,6 +525,43 @@ cost a few integer adds per frame.
 `selector` filters by pan index (`get panstats 0`) or objectName. `property`
 `reset` zeroes the counters after the read so successive reads measure
 disjoint intervals: `get panstats 0 reset`.
+
+### `get tracedebug`
+Per-panadapter `SpectrumWidget` trace diagnostics for proving Flex/Kiwi display
+source behavior without screenshots. This is intentionally diagnostic rather
+than user-facing state: use it to compare the currently displayed source, hidden
+background histories, separate 2D/3D trace positions, and the 3D floor anchor
+used by the stacked trace renderer.
+
+```json
+→ {"cmd":"get","model":"tracedebug","selector":"0"}
+← {"ok":true,"model":"tracedebug","pans":[{
+   "panIndex":0,"name":"SpectrumWidget","renderMode":"3D",
+   "kiwiWaterfallActive":false,
+   "noiseFloorPosition":75,
+   "flexNoiseFloorPosition":75,"kiwiNoiseFloorPosition":68,
+   "dssFloorDepth":6,
+   "flexDssFloorDepth":6,"kiwiDssFloorDepth":10,
+   "dssFloorDbm":-120.5,"dssSpanDb":90.0,
+   "flexDssRows":96,"kiwiDssRows":96,
+   "kiwiFftTraceFloorDbm":-124.0,
+   "kiwiDisplayFloorDbm":-110.0,
+   "flexBins":{"count":768,"finiteCount":768},
+   "kiwiBins":{"count":768,"finiteCount":768}}]}
+```
+
+`selector` filters by pan index (`get tracedebug 0`) or objectName. Key fields:
+
+- `kiwiWaterfallActive` — whether this pan is displaying Kiwi spectrum/waterfall
+  (`false` means Flex is displayed; audio and meters are separate concerns).
+- `flexNoiseFloorPosition` / `kiwiNoiseFloorPosition` — the source-specific 2D
+  trace position values restored when toggling displays.
+- `flexDssFloorDepth` / `kiwiDssFloorDepth` — the source-specific 3D floor-depth
+  values restored when toggling displays.
+- `flexDssRows` / `kiwiDssRows` — rolling 3D history row counts for both display
+  sources; useful for checking that hidden histories continue updating.
+- `kiwiFftTraceFloorDbm` versus `kiwiDisplayFloorDbm` — distinguishes the FFT
+  trace floor used by 3D placement from the waterfall color floor.
 
 ### `get clients`
 Multi-session forensics (#3977/#3951): every client connected to the radio,

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1212,10 +1212,12 @@ QJsonObject sliceSnapshot(const SliceModel* s)
     };
 }
 
-QJsonObject panSnapshot(const PanadapterModel* p, quint32 ourHandle)
+QJsonObject panSnapshot(const PanadapterModel* p, const RadioModel* radio)
 {
+    const quint32 ourHandle = radio ? radio->ourClientHandle() : 0;
+    const QString panId = p->panId();
     return QJsonObject{
-        {QStringLiteral("panId"),        p->panId()},
+        {QStringLiteral("panId"),        panId},
         // #3977: radio-authoritative owner of this pan; assertions on
         // multi-session tests key off these two fields. Empty string (not
         // "0x") when the radio has not yet attributed the pan.
@@ -1231,6 +1233,10 @@ QJsonObject panSnapshot(const PanadapterModel* p, quint32 ourHandle)
         {QStringLiteral("rfGain"),       p->rfGain()},
         {QStringLiteral("wide"),         p->wideActive()},
         {QStringLiteral("fps"),          p->fps()},
+        {QStringLiteral("transmitInhibited"),
+         radio && radio->panTransmitInhibited(panId)},
+        {QStringLiteral("transmitInhibitReason"),
+         radio ? radio->panTransmitInhibitReason(panId) : QString()},
     };
 }
 
@@ -2172,7 +2178,7 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("get")) {
         if (model.isEmpty())
-            return err(QStringLiteral("get requires a model (radio|transmit|meters|slice|slices|pan|pans|kiwi)"));
+            return err(QStringLiteral("get requires a model (radio|transmit|meters|slice|slices|pan|pans|panstats|tracedebug|kiwi)"));
         return doGet(model, selector, property);
     }
     if (cmd == QLatin1String("connect")) {
@@ -3082,6 +3088,42 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                            {QStringLiteral("model"), model},
                            {QStringLiteral("pans"), pans}};
     }
+    if (model == QLatin1String("tracedebug")) {
+        // Per-panadapter trace/floor state from SpectrumWidget. This keeps the
+        // bridge GUI-header-free while exposing enough state to compare Flex
+        // and Kiwi 2D/3D display sources deterministically.
+        bool selectorIsIndex = false;
+        const int wantIndex = selector.toInt(&selectorIsIndex);
+        QJsonArray pans;
+        QSet<QWidget*> seen;
+        const QList<QWidget*> widgets =
+            findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+        for (QWidget* w : widgets) {
+            if (seen.contains(w)) {
+                continue;
+            }
+            seen.insert(w);
+            if (!selector.isEmpty() && !selectorIsIndex
+                && w->objectName() != selector) {
+                continue;
+            }
+
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(w, "traceDebugSnapshot",
+                                           Qt::DirectConnection,
+                                           Q_RETURN_ARG(QVariantMap, snap))) {
+                continue;
+            }
+            if (!selector.isEmpty() && selectorIsIndex
+                && snap.value(QStringLiteral("panIndex")).toInt() != wantIndex) {
+                continue;
+            }
+            pans.append(QJsonObject::fromVariantMap(snap));
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("pans"), pans}};
+    }
     if (model == QLatin1String("wavestats")) {
         // Per-scope paint/append counters from every WaveformWidget
         // instance (sidebar WAVE applet + Aetherial strip panels), for
@@ -3171,7 +3213,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
     } else if (model == QLatin1String("pans")) {
         QJsonArray arr;
         for (const PanadapterModel* p : radio->panadapters()) {
-            arr.append(panSnapshot(p, radio->ourClientHandle()));
+            arr.append(panSnapshot(p, radio));
         }
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("pans"), arr}};
     } else if (model == QLatin1String("slice")) {
@@ -3197,10 +3239,10 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
             p = radio->panadapter(selector);   // by panId, e.g. "0x40000000"
         if (!p)
             return err(QStringLiteral("no panadapter for selector '") + selector + QStringLiteral("'"));
-        data = panSnapshot(p, radio->ourClientHandle());
+        data = panSnapshot(p, radio);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|panstats|clients|kiwi|wavestats)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|panstats|tracedebug|clients|kiwi|wavestats)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5148,6 +5148,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
         }
         m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = 0;
+        clearKiwiSdrPanDisplaySourceOverrides();
         if (m_appletPanel) {
             m_appletPanel->clearSliceButtons();
         }
@@ -5928,7 +5929,7 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
 
     centerMhz = std::max(centerMhz, bandwidthMhz / 2.0);
 
-    if (!kiwiSdrProfileForPan(panId).isEmpty()) {
+    if (kiwiSdrPanDisplaysKiwi(panId)) {
         return;
     }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -423,6 +423,10 @@ private:
     SliceModel* kiwiSdrDisplaySliceForPan(const QString& panId) const;
     QString kiwiSdrProfileForPan(const QString& panId) const;
     QString kiwiSdrOverlayProfileForPan(const QString& panId) const;
+    bool kiwiSdrPanDisplaysKiwi(const QString& panId) const;
+    void setKiwiSdrPanDisplaySource(const QString& panId, bool kiwi);
+    void clearKiwiSdrPanDisplaySourceOverride(const QString& panId);
+    void clearKiwiSdrPanDisplaySourceOverrides();
     void syncKiwiSdrPanadapterTxInhibit(const QString& panId,
                                         const QString& profileId);
     void syncKiwiSdrDiversityEscControls();
@@ -925,6 +929,7 @@ private:
     bool             m_kiwiSdrAudioTransmitMuted{false};
     QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
     QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
+    QSet<QString>    m_kiwiSdrFlexDisplayPans;
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
     ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -588,6 +588,7 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
                 m_kiwiSdrManager->waterfallAvailable(profileId));
             spectrum->setKiwiSdrWaterfallProfile(profileId);
             spectrum->setKiwiSdrWaterfallActive(
+                kiwiSdrPanDisplaysKiwi(slice->panId()) &&
                 kiwiProfileCanDriveWaterfall(m_kiwiSdrManager, profileId));
         }
         if (VfoWidget* vfo = spectrum->vfoWidget(slice->sliceId())) {
@@ -633,6 +634,9 @@ void MainWindow::clearKiwiSdrVirtualAntennaForSlice(int sliceId)
         }
     }
 
+    if (!panId.isEmpty()) {
+        m_kiwiSdrFlexDisplayPans.remove(panId);
+    }
     if (m_kiwiSdrManager) {
         m_kiwiSdrManager->clearSliceAssignment(sliceId);
     }
@@ -751,6 +755,12 @@ QJsonObject MainWindow::automationSetSliceReceiveSource(const QString& arg)
 QJsonObject MainWindow::automationKiwiSdrSnapshot() const
 {
     QJsonArray profiles;
+    QJsonArray flexDisplayPans;
+    QStringList flexDisplayPanIds = m_kiwiSdrFlexDisplayPans.values();
+    std::sort(flexDisplayPanIds.begin(), flexDisplayPanIds.end());
+    for (const QString& panId : flexDisplayPanIds) {
+        flexDisplayPans.append(panId);
+    }
     if (m_kiwiSdrManager) {
         for (const KiwiSdrAntennaProfile& profile :
              m_kiwiSdrManager->profiles()) {
@@ -795,6 +805,7 @@ QJsonObject MainWindow::automationKiwiSdrSnapshot() const
             KiwiSdrClient::diagnosticWaterfallCompressionRequested()},
         {QStringLiteral("profiles"), profiles},
         {QStringLiteral("profileCount"), profiles.size()},
+        {QStringLiteral("flexDisplayPans"), flexDisplayPans},
     };
 }
 
@@ -877,6 +888,7 @@ void MainWindow::updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice)
             slice->sliceId(), slice->panId(), spectrum->centerMhz(),
             spectrum->bandwidthMhz(), spectrum->wfLineDuration());
         if (profileId == kiwiSdrProfileForPan(slice->panId())
+            && kiwiSdrPanDisplaysKiwi(slice->panId())
             && kiwiProfileCanDriveWaterfall(m_kiwiSdrManager, profileId)) {
             spectrum->setKiwiSdrWaterfallAvailable(
                 m_kiwiSdrManager->waterfallAvailable(profileId));
@@ -956,6 +968,46 @@ QString MainWindow::kiwiSdrProfileForPan(const QString& panId) const
         return QString();
     }
     return m_kiwiSdrManager->assignedProfileForSlice(displaySlice->sliceId());
+}
+
+bool MainWindow::kiwiSdrPanDisplaysKiwi(const QString& panId) const
+{
+    const QString trimmedPanId = panId.trimmed();
+    return !trimmedPanId.isEmpty()
+        && !kiwiSdrProfileForPan(trimmedPanId).isEmpty()
+        && !m_kiwiSdrFlexDisplayPans.contains(trimmedPanId);
+}
+
+void MainWindow::setKiwiSdrPanDisplaySource(const QString& panId, bool kiwi)
+{
+    const QString trimmedPanId = panId.trimmed();
+    if (trimmedPanId.isEmpty()) {
+        return;
+    }
+
+    if (kiwiSdrProfileForPan(trimmedPanId).isEmpty() || kiwi) {
+        m_kiwiSdrFlexDisplayPans.remove(trimmedPanId);
+    } else {
+        m_kiwiSdrFlexDisplayPans.insert(trimmedPanId);
+    }
+
+    syncKiwiSdrPanadapterUiState(trimmedPanId);
+    syncKiwiSdrAppletWaterfallState();
+}
+
+void MainWindow::clearKiwiSdrPanDisplaySourceOverride(const QString& panId)
+{
+    const QString trimmedPanId = panId.trimmed();
+    if (trimmedPanId.isEmpty()) {
+        return;
+    }
+
+    m_kiwiSdrFlexDisplayPans.remove(trimmedPanId);
+}
+
+void MainWindow::clearKiwiSdrPanDisplaySourceOverrides()
+{
+    m_kiwiSdrFlexDisplayPans.clear();
 }
 
 QString MainWindow::kiwiSdrOverlayProfileForPan(const QString& panId) const
@@ -1091,7 +1143,10 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
     }
 
     const QString profileId = kiwiSdrProfileForPan(panId);
-    syncKiwiSdrPanadapterTxInhibit(panId, profileId);
+    const bool hasKiwiSource = !profileId.isEmpty();
+    const bool displayKiwi = kiwiSdrPanDisplaysKiwi(panId);
+    syncKiwiSdrPanadapterTxInhibit(
+        panId, displayKiwi ? profileId : QString());
 
     SpectrumWidget* spectrum = m_panStack->spectrum(panId);
     if (!spectrum) {
@@ -1099,7 +1154,29 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
     }
 
     SpectrumOverlayMenu* menu = spectrum->overlayMenu();
+    auto syncFlexDisplaySettings = [spectrum, menu]() {
+        if (!menu) {
+            return;
+        }
+        menu->syncDisplaySettings(
+            spectrum->fftAverage(), spectrum->fftFps(),
+            static_cast<int>(spectrum->fftFillAlpha() * 100.0f),
+            spectrum->fftWeightedAvg(), spectrum->fftFillColor(),
+            spectrum->wfColorGain(), spectrum->wfBlackLevel(),
+            spectrum->wfAutoBlack(), spectrum->wfAutoBlackOffset(),
+            spectrum->wfLineDuration(), spectrum->noiseFloorPosition(),
+            spectrum->noiseFloorEnabled(), spectrum->fftHeatMap(),
+            spectrum->wfColorScheme(), spectrum->showGrid(),
+            spectrum->fftLineWidth(), spectrum->wfAutoBlackRadioSide(),
+            spectrum->spectrumRenderMode(), spectrum->dssFloorDepth(),
+            spectrum->dssGain());
+    };
+
+    spectrum->setKiwiSdrDisplaySourceKiwi(displayKiwi);
+    spectrum->setKiwiSdrDisplaySourceControlVisible(hasKiwiSource);
+
     if (profileId.isEmpty()) {
+        m_kiwiSdrFlexDisplayPans.remove(panId);
         spectrum->setBandwidthLimits(m_radioModel.minPanBandwidthMhz(),
                                      m_radioModel.maxPanBandwidthMhz());
         const QString overlayProfileId = kiwiSdrOverlayProfileForPan(panId);
@@ -1116,20 +1193,19 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
         setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
         spectrum->setKiwiSdrWaterfallAvailable(false);
         spectrum->setKiwiSdrWaterfallProfile(QString());
-        if (menu) {
-            menu->syncDisplaySettings(
-                spectrum->fftAverage(), spectrum->fftFps(),
-                static_cast<int>(spectrum->fftFillAlpha() * 100.0f),
-                spectrum->fftWeightedAvg(), spectrum->fftFillColor(),
-                spectrum->wfColorGain(), spectrum->wfBlackLevel(),
-                spectrum->wfAutoBlack(), spectrum->wfAutoBlackOffset(),
-                spectrum->wfLineDuration(), spectrum->noiseFloorPosition(),
-                spectrum->noiseFloorEnabled(), spectrum->fftHeatMap(),
-                spectrum->wfColorScheme(), spectrum->showGrid(),
-                spectrum->fftLineWidth(), spectrum->wfAutoBlackRadioSide(),
-                spectrum->spectrumRenderMode(), spectrum->dssFloorDepth(),
-                spectrum->dssGain());
-        }
+        syncFlexDisplaySettings();
+        return;
+    }
+
+    if (!displayKiwi) {
+        spectrum->setBandwidthLimits(m_radioModel.minPanBandwidthMhz(),
+                                     m_radioModel.maxPanBandwidthMhz());
+        spectrum->setKiwiSdrConnectionOverlay(false);
+        setKiwiSdrWaterfallActive(m_radioModel, panId, spectrum, false);
+        spectrum->setKiwiSdrWaterfallAvailable(
+            m_kiwiSdrManager->waterfallAvailable(profileId));
+        spectrum->setKiwiSdrWaterfallProfile(profileId);
+        syncFlexDisplaySettings();
         return;
     }
 

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1104,13 +1104,11 @@ void MainWindow::wirePanLifecycle()
                                   "#0a0a14").toString());
             if (bgFill.isValid())
                 sw->setBackgroundFillColor(bgFill);
-            // Restore the spectrum render mode (2D / 3D stacked trace) + 3D floor
-            // depth per pan, like the other Display settings above, so a pan set
-            // to 3D survives a restart / pan re-attach.
+            // Restore the spectrum render mode per pan. Source-specific trace
+            // positions/depths are loaded by SpectrumWidget from
+            // DisplaySourceTraceSettings; do not reapply legacy flat keys here.
             sw->setSpectrumRenderMode(
                 s.value(sw->settingsKey("DisplaySpectrumRenderMode"), "0").toInt());
-            sw->setDssFloorDepth(
-                s.value(sw->settingsKey("Display3DFloorDepth"), "6").toInt());
             sw->setDssGain(
                 s.value(sw->settingsKey("Display3DGain"), "70").toInt());
             // Nudge rate to force waterfall tile re-sync
@@ -1337,6 +1335,7 @@ void MainWindow::wirePanLifecycle()
 
     connect(&m_radioModel, &RadioModel::panadapterRemoved,
             this, [this](const QString& panId) {
+        clearKiwiSdrPanDisplaySourceOverride(panId);
         if (m_shuttingDown || !m_panStack) {
             return;
         }

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -985,6 +985,7 @@ void MainWindow::onSliceRemoved(int id)
     if (m_kiwiSdrManager) {
         m_kiwiSdrManager->clearSliceAssignment(id);
     }
+    syncKiwiSdrPanadapterUiStates();
 
     // Drop the adaptive-filter engine's per-slice smoothing/baseline state.
     // processFrame() only self-clears state for slices it still sees; a deleted
@@ -1609,7 +1610,9 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                     KiwiSdrClient::stateAllowsReceiverControl(
                         m_kiwiSdrManager->state(profileId))
                     && m_kiwiSdrManager->waterfallAvailable(profileId);
-                if (profileId == displayProfileId && profileCanDriveWaterfall) {
+                if (profileId == displayProfileId
+                    && kiwiSdrPanDisplaysKiwi(applet->panId())
+                    && profileCanDriveWaterfall) {
                     sw->setKiwiSdrWaterfallAvailable(
                         m_kiwiSdrManager->waterfallAvailable(profileId));
                     sw->setKiwiSdrWaterfallProfile(profileId);
@@ -1684,6 +1687,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 updateKiwiWaterfallView(centerMhz, bandwidthMhz);
                 kiwiGestureLastViewUpdate->invalidate();
             });
+    connect(sw, &SpectrumWidget::kiwiSdrDisplaySourceRequested,
+            this, [this, applet](bool kiwi) {
+        setKiwiSdrPanDisplaySource(applet->panId(), kiwi);
+    });
 
     // Wire band plan manager to this spectrum widget
     sw->setBandPlanManager(m_bandPlanMgr);
@@ -1837,7 +1844,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(sw, &SpectrumWidget::bandwidthChangeRequested,
             this, [this, applet](double bw) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         m_radioModel.sendCommand(
@@ -1845,7 +1852,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(sw, &SpectrumWidget::centerChangeRequested,
             this, [this, applet](double center) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         if (const auto* pan = m_radioModel.panadapter(applet->panId()))
@@ -2258,7 +2265,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             sw, &SpectrumWidget::setDssGain);
     connect(menu, &SpectrumOverlayMenu::wfColorGainChanged,
             this, [this, applet, sw](int v) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         sw->setWfColorGain(v);
@@ -2269,7 +2276,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::wfBlackLevelChanged,
             this, [this, applet, sw](int v) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         sw->setWfBlackLevel(v);
@@ -2280,7 +2287,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackChanged,
             this, [this, applet, sw](bool on) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         sw->setWfAutoBlack(on);
@@ -2290,13 +2297,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackOffsetChanged,
             this, [this, applet, sw](int offset) {
-        if (!kiwiSdrProfileForPan(applet->panId()).isEmpty()) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         sw->setWfAutoBlackOffset(offset);
     });
     connect(menu, &SpectrumOverlayMenu::wfAutoBlackSourceChanged,
-            this, [this, sw](bool radioSide) {
+            this, [this, applet, sw](bool radioSide) {
+        if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
+            return;
+        }
         sw->setWfAutoBlackRadioSide(radioSide);
         // Radio-side → tell the radio to compute its per-tile auto-black level;
         // client-side → stop it (auto_black=0) and use our own estimate.
@@ -2305,7 +2315,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     const auto applyWaterfallLineDuration = [this, applet, sw](int ms) {
         const int clampedMs = std::clamp(ms, 1, 100);
         const QString profileId = kiwiSdrProfileForPan(applet->panId());
-        if (!profileId.isEmpty()) {
+        if (!profileId.isEmpty() && kiwiSdrPanDisplaysKiwi(applet->panId())) {
             const KiwiSdrAntennaProfile profile =
                 m_kiwiSdrManager ? m_kiwiSdrManager->profile(profileId)
                                  : KiwiSdrAntennaProfile{};
@@ -2340,7 +2350,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
         const QString profileId = kiwiSdrProfileForPan(applet->panId());
-        if (profileId.isEmpty()) {
+        if (profileId.isEmpty() || !kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         const KiwiSdrAntennaProfile profile =
@@ -2365,7 +2375,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
         const QString profileId = kiwiSdrProfileForPan(applet->panId());
-        if (profileId.isEmpty()) {
+        if (profileId.isEmpty() || !kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         const KiwiSdrAntennaProfile profile =
@@ -2390,7 +2400,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
         const QString profileId = kiwiSdrProfileForPan(applet->panId());
-        if (profileId.isEmpty()) {
+        if (profileId.isEmpty()
+            || !kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         const KiwiSdrAntennaProfile profile =
@@ -2407,7 +2418,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
         const QString profileId = kiwiSdrProfileForPan(applet->panId());
-        if (profileId.isEmpty()) {
+        if (profileId.isEmpty() || !kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
         const KiwiSdrAntennaProfile profile =
@@ -2546,6 +2557,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         s.setValue(sw->settingsKey("DisplayFreqGridSpacing"),     "0");
         s.setValue(sw->settingsKey("DisplayNoiseFloorEnable"),    "False");
         s.setValue(sw->settingsKey("DisplayNoiseFloorPosition"),  "75");
+        s.setValue(sw->settingsKey("DisplaySourceTraceSettings"),
+                   QStringLiteral(
+                       "{\"flex\":{\"dssFloorDepth\":6,\"noiseFloorPosition\":75},"
+                       "\"kiwi\":{\"dssFloorDepth\":6,\"noiseFloorPosition\":75},"
+                       "\"version\":1}"));
         s.setValue(sw->settingsKey("DisplaySpectrumRenderMode"),  "0");
         s.setValue(sw->settingsKey("Display3DFloorDepth"),        "6");
         s.setValue(sw->settingsKey("Display3DGain"),        "70");

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5656,11 +5656,17 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = *spectrumBins;
 
-    // Feed the Flex rolling history every frame (not only in 3D and not only
-    // while Flex is visible) so switching back from Kiwi shows current Flex
-    // 3D history instead of an old surface that refills over ~96 frames.
-    // Raw bins: the renderer does its own spatial/temporal smoothing.
-    pushDssRowForWaterfallStream(false, m_bins);
+    // While Kiwi is displayed, keep the *background* Flex surface warm every
+    // frame (not only in 3D and not only while Flex is visible) so switching
+    // back from Kiwi shows current Flex 3D history instead of an old surface
+    // that refills over ~96 frames. Raw bins: the renderer does its own
+    // spatial/temporal smoothing. When Flex is the active stream this must NOT
+    // run: updateWaterfallRow() already advances m_dss at waterfall-row cadence
+    // (paired with the 2D waterfall appendHistoryRow), and feeding here too
+    // would over-advance the retained DSS scrollback past the waterfall (#4083).
+    if (m_kiwiSdrWaterfallActive) {
+        pushDssRowForWaterfallStream(false, m_bins);
+    }
 
     if (!m_kiwiSdrWaterfallActive) {
         // ── Live noise floor measurement (two-pass trimmed mean) ─────────

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -25,6 +25,9 @@
 #include <QToolTip>
 #include <QDialog>
 #include <QFormLayout>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QCheckBox>
@@ -32,6 +35,7 @@
 #include <QFrame>
 #include <QDoubleSpinBox>
 #include <QLabel>
+#include <QSignalBlocker>
 #include <QVBoxLayout>
 #include <QWidgetAction>
 #include <QApplication>
@@ -59,6 +63,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <utility>
 #include "core/ThemeManager.h"
 
@@ -1074,6 +1079,101 @@ QVariantMap SpectrumWidget::automationDssSetScrollback(bool live,
     return snap;
 }
 
+QVariantMap SpectrumWidget::traceDebugSnapshot()
+{
+    const auto vectorStats = [this](const QVector<float>& bins) {
+        QVariantMap stats;
+        stats[QStringLiteral("count")] = bins.size();
+        if (bins.isEmpty()) {
+            stats[QStringLiteral("finiteCount")] = 0;
+            stats[QStringLiteral("minDbm")] = -1000.0;
+            stats[QStringLiteral("maxDbm")] = -1000.0;
+            stats[QStringLiteral("noiseFloorDbm")] = -1000.0;
+            return stats;
+        }
+
+        float minDbm = std::numeric_limits<float>::infinity();
+        float maxDbm = -std::numeric_limits<float>::infinity();
+        int finiteCount = 0;
+        for (float v : bins) {
+            if (!std::isfinite(v)) {
+                continue;
+            }
+            minDbm = std::min(minDbm, v);
+            maxDbm = std::max(maxDbm, v);
+            ++finiteCount;
+        }
+        stats[QStringLiteral("finiteCount")] = finiteCount;
+        stats[QStringLiteral("minDbm")] = finiteCount > 0 ? minDbm : -1000.0f;
+        stats[QStringLiteral("maxDbm")] = finiteCount > 0 ? maxDbm : -1000.0f;
+        stats[QStringLiteral("noiseFloorDbm")] =
+            finiteCount > 0 ? estimateNoiseFloorDbm(bins) : -1000.0f;
+        return stats;
+    };
+
+    const QVector<float>& flexTrace =
+        !m_smoothed.isEmpty() ? m_smoothed : m_bins;
+
+    QVariantMap m;
+    m[QStringLiteral("panIndex")] = m_panIndex;
+    m[QStringLiteral("name")] = objectName();
+    m[QStringLiteral("visible")] = isVisible();
+    m[QStringLiteral("widthPx")] = width();
+    m[QStringLiteral("heightPx")] = height();
+    m[QStringLiteral("renderMode")] =
+        m_spectrumRenderMode == SpectrumRenderMode::Mode3D
+            ? QStringLiteral("3D") : QStringLiteral("2D");
+    m[QStringLiteral("kiwiWaterfallAvailable")] = m_kiwiSdrWaterfallAvailable;
+    m[QStringLiteral("kiwiWaterfallActive")] = m_kiwiSdrWaterfallActive;
+    m[QStringLiteral("centerMhz")] = m_centerMhz;
+    m[QStringLiteral("bandwidthMhz")] = m_bandwidthMhz;
+    m[QStringLiteral("refLevelDbm")] = m_refLevel;
+    m[QStringLiteral("dynamicRangeDb")] = m_dynamicRange;
+
+    m[QStringLiteral("noiseFloorPosition")] = m_noiseFloorPosition;
+    m[QStringLiteral("flexNoiseFloorPosition")] = m_flexNoiseFloorPosition;
+    m[QStringLiteral("kiwiNoiseFloorPosition")] = m_kiwiNoiseFloorPosition;
+    m[QStringLiteral("noiseFloorEnabled")] = m_noiseFloorEnable;
+    m[QStringLiteral("measuredNoiseFloorDbm")] = m_measuredNoiseFloorDbm;
+    m[QStringLiteral("displayFloorDbm")] = displayFloorDbm();
+
+    m[QStringLiteral("dssFloorDepth")] = dssFloorDepth();
+    m[QStringLiteral("flexDssFloorDepth")] = m_flexDssFloorDepth;
+    m[QStringLiteral("kiwiDssFloorDepth")] = m_kiwiDssFloorDepth;
+    m[QStringLiteral("dssFloorOffsetDb")] = m_dssFloorOffsetDb;
+    m[QStringLiteral("dssFloorDbm")] = peekDssFloorDbm();
+    m[QStringLiteral("dssSpanDb")] = dssSpanDb();
+    m[QStringLiteral("dssFloorAnchorDbm")] = m_dssFloorAnchorDbm;
+    m[QStringLiteral("dssFloorAnchorValid")] = m_dssFloorAnchorValid;
+    m[QStringLiteral("dssRows")] = m_dss.rowCount();
+    m[QStringLiteral("dssCapacityRows")] = m_dss.rows();
+    const DssRenderer& flexDss =
+        m_kiwiSdrWaterfallActive ? m_nativeWaterfallState.dss : m_dss;
+    m[QStringLiteral("flexDssRows")] = flexDss.rowCount();
+    const WaterfallStreamState* kiwiState = activeKiwiWaterfallStateConst();
+    m[QStringLiteral("kiwiDssRows")] = m_kiwiSdrWaterfallActive
+        ? m_dss.rowCount()
+        : (kiwiState ? kiwiState->dss.rowCount() : 0);
+
+    m[QStringLiteral("kiwiDisplayRangeValid")] = m_kiwiSdrDisplayRangeValid;
+    m[QStringLiteral("kiwiDisplayRangeAutoRange")] =
+        m_kiwiSdrDisplayRangeAutoRange;
+    m[QStringLiteral("kiwiDisplayFloorDbm")] = m_kiwiSdrDisplayFloorDbm;
+    m[QStringLiteral("kiwiDisplayCeilDbm")] = m_kiwiSdrDisplayCeilDbm;
+    m[QStringLiteral("kiwiFftTraceFloorDbm")] = m_kiwiSdrFftTraceFloorDbm;
+    m[QStringLiteral("kiwiFftTraceFloorValid")] =
+        m_kiwiSdrFftTraceFloorValid;
+    m[QStringLiteral("kiwiFftTraceEstimatedFloorDbm")] =
+        m_kiwiSdrFftTrace.isEmpty()
+            ? -1000.0f
+            : estimateKiwiSdrTraceFloorDbm(m_kiwiSdrFftTrace);
+
+    m[QStringLiteral("activeBins")] = vectorStats(noiseFloorAutoLevelBins());
+    m[QStringLiteral("flexBins")] = vectorStats(flexTrace);
+    m[QStringLiteral("kiwiBins")] = vectorStats(m_kiwiSdrFftTrace);
+    return m;
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
@@ -1256,6 +1356,23 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         btn->setCursor(Qt::PointingHandCursor);
         return btn;
     };
+    m_kiwiSdrDisplaySourceBtn = new QPushButton(QStringLiteral("Flex"), this);
+    m_kiwiSdrDisplaySourceBtn->setObjectName(QStringLiteral("panDisplaySourceBtn"));
+    m_kiwiSdrDisplaySourceBtn->setAccessibleName(tr("Panadapter spectrum and waterfall source"));
+    m_kiwiSdrDisplaySourceBtn->setAccessibleDescription(
+        tr("Switches the displayed spectrum and waterfall between Flex and KiwiSDR. Audio and meters are unchanged."));
+    m_kiwiSdrDisplaySourceBtn->setCheckable(true);
+    m_kiwiSdrDisplaySourceBtn->setFixedSize(46, 22);
+    m_kiwiSdrDisplaySourceBtn->setStyleSheet(kZoomBtnStyle);
+    m_kiwiSdrDisplaySourceBtn->setCursor(Qt::PointingHandCursor);
+    m_kiwiSdrDisplaySourceBtn->setToolTip(
+        tr("Show Flex or KiwiSDR spectrum/waterfall. Audio and meters are unchanged."));
+    m_kiwiSdrDisplaySourceBtn->hide();
+    connect(m_kiwiSdrDisplaySourceBtn, &QPushButton::clicked,
+            this, [this](bool checked) {
+        emit kiwiSdrDisplaySourceRequested(checked);
+    });
+
     m_zoomSegBtn  = makeBtn("S", QStringLiteral("panZoomSegBtn"),  QStringLiteral("Zoom to segment"));
     m_zoomBandBtn = makeBtn("B", QStringLiteral("panZoomBandBtn"), QStringLiteral("Zoom to band"));
     m_zoomOutBtn  = makeBtn("\u2212", QStringLiteral("panZoomOutBtn"), QStringLiteral("Zoom out"));  // minus sign U+2212
@@ -1521,9 +1638,16 @@ void SpectrumWidget::loadSettings()
     m_freqScaleFontPt = std::clamp(
         s.value(settingsKey("DisplayFreqScaleFontPt"), "8").toInt(), 8, 14);
     m_fftLineWidth   = s.value(settingsKey("DisplayFftLineWidth"), "2.0").toFloat();
-    m_noiseFloorEnable   = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
-    m_noiseFloorPosition = std::clamp(
+    m_noiseFloorEnable = s.value(settingsKey("DisplayNoiseFloorEnable"), "False").toString() == "True";
+    const int legacyNoiseFloorPosition = std::clamp(
         s.value(settingsKey("DisplayNoiseFloorPosition"), "75").toInt(), 1, 99);
+    const int legacyDssFloorDepth = std::clamp(
+        s.value(settingsKey("Display3DFloorDepth"), "6").toInt(), 0, 24);
+    loadDisplaySourceTraceSettings(legacyNoiseFloorPosition,
+                                   legacyDssFloorDepth);
+    m_noiseFloorPosition = m_kiwiSdrWaterfallActive
+        ? m_kiwiNoiseFloorPosition
+        : m_flexNoiseFloorPosition;
     // Match the enable-time fresh-frame seed used by setNoiseFloorEnable so a
     // restored Floor=on locks onto the current floor without smoothing from a
     // stale value.
@@ -1539,7 +1663,7 @@ void SpectrumWidget::loadSettings()
         std::clamp(s.value(settingsKey("DisplaySpectrumRenderMode"), "0").toInt(),
                    0, static_cast<int>(SpectrumRenderMode::Count) - 1));
     m_dssFloorOffsetDb = -static_cast<float>(
-        std::clamp(s.value(settingsKey("Display3DFloorDepth"), "6").toInt(), 0, 24));
+        m_kiwiSdrWaterfallActive ? m_kiwiDssFloorDepth : m_flexDssFloorDepth);
     m_singleClickTune = s.value("SingleClickTune", "False").toString() == "True";
     m_showTuneGuides  = s.value("ShowTuneGuides", "False").toString() == "True";
     m_extendedFrequencyLine = s.value("ExtendedFrequencyLine", "False").toString() == "True";
@@ -1697,8 +1821,116 @@ void SpectrumWidget::setFftAverage(int frames) {
     s.setValue(settingsKey("DisplayFftAverage"), QString::number(frames));
     s.save();
 }
+
+QString SpectrumWidget::displaySourceTraceSettingsKey() const
+{
+    return settingsKey(QStringLiteral("DisplaySourceTraceSettings"));
+}
+
+void SpectrumWidget::loadDisplaySourceTraceSettings(int legacyNoiseFloorPosition,
+                                                    int legacyDssFloorDepth)
+{
+    m_flexNoiseFloorPosition = std::clamp(legacyNoiseFloorPosition, 1, 99);
+    m_kiwiNoiseFloorPosition = m_flexNoiseFloorPosition;
+    m_flexDssFloorDepth = std::clamp(legacyDssFloorDepth, 0, 24);
+    m_kiwiDssFloorDepth = m_flexDssFloorDepth;
+
+    const QString raw = AppSettings::instance()
+        .value(displaySourceTraceSettingsKey(), QString()).toString();
+    if (raw.trimmed().isEmpty()) {
+        return;
+    }
+
+    QJsonParseError error;
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcGui).noquote()
+            << "SpectrumWidget: ignoring invalid DisplaySourceTraceSettings"
+            << displaySourceTraceSettingsKey() << error.errorString();
+        return;
+    }
+
+    const auto applySource = [](const QJsonObject& source,
+                                int& noiseFloorPosition,
+                                int& dssFloorDepth) {
+        if (source.contains(QStringLiteral("noiseFloorPosition"))) {
+            noiseFloorPosition = std::clamp(
+                source.value(QStringLiteral("noiseFloorPosition")).toInt(
+                    noiseFloorPosition),
+                1, 99);
+        }
+        if (source.contains(QStringLiteral("dssFloorDepth"))) {
+            dssFloorDepth = std::clamp(
+                source.value(QStringLiteral("dssFloorDepth")).toInt(
+                    dssFloorDepth),
+                0, 24);
+        }
+    };
+
+    const QJsonObject obj = doc.object();
+    applySource(obj.value(QStringLiteral("flex")).toObject(),
+                m_flexNoiseFloorPosition, m_flexDssFloorDepth);
+    applySource(obj.value(QStringLiteral("kiwi")).toObject(),
+                m_kiwiNoiseFloorPosition, m_kiwiDssFloorDepth);
+}
+
+void SpectrumWidget::saveDisplaySourceTraceSettings()
+{
+    auto sourceObject = [](int noiseFloorPosition, int dssFloorDepth) {
+        QJsonObject source;
+        source.insert(QStringLiteral("noiseFloorPosition"),
+                      std::clamp(noiseFloorPosition, 1, 99));
+        source.insert(QStringLiteral("dssFloorDepth"),
+                      std::clamp(dssFloorDepth, 0, 24));
+        return source;
+    };
+
+    QJsonObject obj;
+    obj.insert(QStringLiteral("version"), 1);
+    obj.insert(QStringLiteral("flex"),
+               sourceObject(m_flexNoiseFloorPosition, m_flexDssFloorDepth));
+    obj.insert(QStringLiteral("kiwi"),
+               sourceObject(m_kiwiNoiseFloorPosition, m_kiwiDssFloorDepth));
+
+    auto& s = AppSettings::instance();
+    s.setValue(displaySourceTraceSettingsKey(), QString::fromUtf8(
+        QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+void SpectrumWidget::setNoiseFloorPositionForSource(bool kiwiSource,
+                                                    int pos,
+                                                    bool persist)
+{
+    const int clampedPosition = std::clamp(pos, 1, 99);
+    if (kiwiSource) {
+        m_kiwiNoiseFloorPosition = clampedPosition;
+    } else {
+        m_flexNoiseFloorPosition = clampedPosition;
+    }
+
+    if (kiwiSource == m_kiwiSdrWaterfallActive) {
+        m_noiseFloorPosition = clampedPosition;
+    }
+
+    if (persist) {
+        saveDisplaySourceTraceSettings();
+    }
+}
+
+void SpectrumWidget::restoreNoiseFloorPositionForCurrentSource(bool syncMenu)
+{
+    m_noiseFloorPosition = m_kiwiSdrWaterfallActive
+        ? m_kiwiNoiseFloorPosition
+        : m_flexNoiseFloorPosition;
+    refreshNoiseFloorTarget();
+    if (syncMenu) {
+        emit noiseFloorPositionResolved(m_noiseFloorPosition);
+    }
+}
+
 void SpectrumWidget::setNoiseFloorPosition(int pos) {
-    m_noiseFloorPosition = std::clamp(pos, 1, 99);
+    setNoiseFloorPositionForSource(m_kiwiSdrWaterfallActive, pos, true);
     m_pendingDbmRangeEcho = false;
     m_pendingDbmRangeEchoFromAutoFloor = false;
     m_pendingDbmRangeEchoStartMs = 0;
@@ -1717,9 +1949,6 @@ void SpectrumWidget::setNoiseFloorPosition(int pos) {
         }
         applyNoiseFloorAutoAdjust(QDateTime::currentMSecsSinceEpoch());
     }
-    auto& s = AppSettings::instance();
-    s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(m_noiseFloorPosition));
-    s.save();
 }
 void SpectrumWidget::setNoiseFloorEnable(bool on) {
     m_pendingDbmRangeEcho = false;
@@ -1740,6 +1969,8 @@ void SpectrumWidget::setNoiseFloorEnable(bool on) {
     s.save();
 }
 void SpectrumWidget::reacquireNoiseFloorLock() {
+    m_dssFloorAnchorDbm = -1000.0f;
+    m_dssFloorAnchorValid = false;
     if (!m_noiseFloorEnable) return;
     m_pendingDbmRangeEcho = false;
     m_pendingDbmRangeEchoFromAutoFloor = false;
@@ -1755,12 +1986,15 @@ void SpectrumWidget::reacquireNoiseFloorLock() {
 
 void SpectrumWidget::reacquireNoiseFloorLockFromVisibleSource()
 {
-    reacquireNoiseFloorLock();
-    if (!m_noiseFloorEnable) {
-        return;
+    const QVector<float>& bins = noiseFloorAutoLevelBins();
+    if (m_noiseFloorEnable) {
+        reacquireNoiseFloorLock();
+    } else {
+        m_measuredNoiseFloorDbm = -1000.0f;
+        m_dssFloorAnchorDbm = -1000.0f;
+        m_dssFloorAnchorValid = false;
     }
 
-    const QVector<float>& bins = noiseFloorAutoLevelBins();
     if (bins.isEmpty()) {
         return;
     }
@@ -1768,7 +2002,15 @@ void SpectrumWidget::reacquireNoiseFloorLockFromVisibleSource()
     const float frameFloor = estimateNoiseFloorDbm(bins);
     if (frameFloor > -500.0f) {
         m_measuredNoiseFloorDbm = frameFloor;
+        if (!m_kiwiSdrWaterfallActive) {
+            m_dssFloorAnchorDbm = frameFloor;
+            m_dssFloorAnchorValid = true;
+        }
     }
+    if (!m_noiseFloorEnable) {
+        return;
+    }
+
     updateNoiseFloorBaseline(bins, true);
     if (m_noiseFloorFreshFrameCount > 0) {
         --m_noiseFloorFreshFrameCount;
@@ -2365,12 +2607,7 @@ bool SpectrumWidget::captureNoiseFloorTargetFromCurrentScale(bool notify, bool p
         99);
 
     m_noiseFloorTargetFrac = targetFrac;
-    m_noiseFloorPosition = newPosition;
-    if (persist) {
-        auto& s = AppSettings::instance();
-        s.setValue(settingsKey("DisplayNoiseFloorPosition"), QString::number(m_noiseFloorPosition));
-        s.save();
-    }
+    setNoiseFloorPositionForSource(m_kiwiSdrWaterfallActive, newPosition, persist);
     if (notify) {
         emit noiseFloorPositionResolved(newPosition);
     }
@@ -3064,21 +3301,54 @@ void SpectrumWidget::setWfColorScheme(int scheme) {
     update();
 }
 
-void SpectrumWidget::setDssFloorDepth(int dB) {
-    dB = std::clamp(dB, 0, 24);
-    const float off = -static_cast<float>(dB);
-    if (off != m_dssFloorOffsetDb) {
-        m_dssFloorOffsetDb = off;
-        auto& s = AppSettings::instance();
-        s.setValue(settingsKey("Display3DFloorDepth"), QString::number(dB));
-        s.save();
+void SpectrumWidget::setDssFloorDepthForSource(bool kiwiSource, int dB, bool persist)
+{
+    const int clampedDepth = std::clamp(dB, 0, 24);
+    if (kiwiSource) {
+        m_kiwiDssFloorDepth = clampedDepth;
+    } else {
+        m_flexDssFloorDepth = clampedDepth;
+    }
+
+    if (persist) {
+        saveDisplaySourceTraceSettings();
+    }
+
+    if (kiwiSource != m_kiwiSdrWaterfallActive) {
+        return;
+    }
+
+    const float offsetDb = -static_cast<float>(clampedDepth);
+    if (offsetDb != m_dssFloorOffsetDb) {
+        m_dssFloorOffsetDb = offsetDb;
         m_dss.invalidate();   // CPU fallback cache; mesh re-reads each frame
         // In 3D mode the visible dBm markings are anchored to this floor, so the
         // cached overlay must redraw even when the span is stable.
         markOverlayDirty();
-        emit dssFloorDepthResolved(dB);
+        emit dssFloorDepthResolved(clampedDepth);
     }
     update();
+}
+
+void SpectrumWidget::restoreDssFloorDepthForCurrentSource(bool syncMenu)
+{
+    const int depth = m_kiwiSdrWaterfallActive
+        ? m_kiwiDssFloorDepth
+        : m_flexDssFloorDepth;
+    const float offsetDb = -static_cast<float>(depth);
+    if (offsetDb != m_dssFloorOffsetDb) {
+        m_dssFloorOffsetDb = offsetDb;
+        m_dss.invalidate();
+        markOverlayDirty();
+    }
+    if (syncMenu) {
+        emit dssFloorDepthResolved(depth);
+    }
+    update();
+}
+
+void SpectrumWidget::setDssFloorDepth(int dB) {
+    setDssFloorDepthForSource(m_kiwiSdrWaterfallActive, dB, true);
 }
 
 void SpectrumWidget::setDssGain(int pct) {
@@ -3940,6 +4210,19 @@ SpectrumWidget::WaterfallStreamState& SpectrumWidget::activeKiwiWaterfallState()
     return m_kiwiWaterfallState;
 }
 
+const SpectrumWidget::WaterfallStreamState*
+SpectrumWidget::activeKiwiWaterfallStateConst() const
+{
+    if (!m_kiwiSdrWaterfallProfileId.isEmpty()) {
+        auto it = m_kiwiProfileWaterfallStates.constFind(
+            m_kiwiSdrWaterfallProfileId);
+        return it == m_kiwiProfileWaterfallStates.constEnd()
+            ? nullptr
+            : &it.value();
+    }
+    return &m_kiwiWaterfallState;
+}
+
 void SpectrumWidget::saveCurrentWaterfallStreamState()
 {
     WaterfallStreamState& state = m_kiwiSdrWaterfallActive
@@ -3983,6 +4266,14 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.kiwiFftTraceFloorDbm = m_kiwiSdrFftTraceFloorDbm;
     updated.kiwiFftTraceFloorValid = m_kiwiSdrFftTraceFloorValid;
     updated.valid = !updated.waterfall.isNull();
+#ifdef AETHER_GPU_SPECTRUM
+    updated.wfTexFullUpload = m_wfTexFullUpload;
+    updated.wfLastUploadedRow = m_wfLastUploadedRow;
+    updated.dssTexNeedsUpload = m_dssTexNeedsUpload;
+    updated.dssLastUploadedGen = m_dssLastUploadedGen;
+    updated.dssMeshHeadUploaded = m_dssMeshHeadUploaded;
+    updated.dssMeshRowGenUploaded = m_dssMeshRowGenUploaded;
+#endif
 
     state = std::move(updated);
 }
@@ -4062,9 +4353,13 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_kiwiSdrDisplayRangeAutoRange = restored.kiwiDisplayRangeAutoRange;
     m_kiwiSdrFftTraceFloorDbm = restored.kiwiFftTraceFloorDbm;
     m_kiwiSdrFftTraceFloorValid = restored.kiwiFftTraceFloorValid;
-    resetDssUploadState();
 #ifdef AETHER_GPU_SPECTRUM
-    m_wfTexFullUpload = true;
+    m_wfTexFullUpload = restored.wfTexFullUpload;
+    m_wfLastUploadedRow = restored.wfLastUploadedRow;
+    m_dssTexNeedsUpload = restored.dssTexNeedsUpload;
+    m_dssLastUploadedGen = restored.dssLastUploadedGen;
+    m_dssMeshHeadUploaded = restored.dssMeshHeadUploaded;
+    m_dssMeshRowGenUploaded = restored.dssMeshRowGenUploaded;
 #endif
 }
 
@@ -5361,6 +5656,12 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = *spectrumBins;
 
+    // Feed the Flex rolling history every frame (not only in 3D and not only
+    // while Flex is visible) so switching back from Kiwi shows current Flex
+    // 3D history instead of an old surface that refills over ~96 frames.
+    // Raw bins: the renderer does its own spatial/temporal smoothing.
+    pushDssRowForWaterfallStream(false, m_bins);
+
     if (!m_kiwiSdrWaterfallActive) {
         // ── Live noise floor measurement (two-pass trimmed mean) ─────────
         // Same technique as the waterfall auto-black: compute the mean of ALL
@@ -5643,6 +5944,12 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
         return;
     }
 
+    setNoiseFloorPositionForSource(m_kiwiSdrWaterfallActive,
+                                   m_noiseFloorPosition,
+                                   false);
+    setDssFloorDepthForSource(m_kiwiSdrWaterfallActive,
+                              dssFloorDepth(),
+                              false);
     saveCurrentWaterfallStreamState();
     m_kiwiSdrWaterfallActive = active;
     m_lastAutoSquelchLevel = -1;
@@ -5650,6 +5957,9 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
         m_sqlNoiseFloorDbm = -999.0f;
     }
     restoreCurrentWaterfallStreamState();
+    resetDssUploadState();
+    restoreNoiseFloorPositionForCurrentSource(true);
+    restoreDssFloorDepthForCurrentSource(true);
     // The newly-active stream is no longer reprojected on every pan step
     // (handleWaterfallFrequencyFrameChange now touches only the active stream),
     // so its restored viewport can lag the current frequency frame. Remap it now
@@ -5657,14 +5967,14 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
     // frame (#3578). This is the lazy counterpart to the per-pan reproject the
     // inactive stream used to receive.
     rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
+    m_pendingDbmRangeEcho = false;
+    m_pendingDbmRangeEchoFromAutoFloor = false;
+    m_pendingDbmRangeEchoStartMs = 0;
+    clearDbmReleaseRebase();
+    resetNoiseFloorBaseline();
     if (!active) {
         clearKiwiSdrSquelchLine();
-        m_pendingDbmRangeEcho = false;
-        m_pendingDbmRangeEchoFromAutoFloor = false;
-        m_pendingDbmRangeEchoStartMs = 0;
-        clearDbmReleaseRebase();
         m_resetFftSmoothingOnNextFrame = true;
-        resetNoiseFloorBaseline();
     }
     reacquireNoiseFloorLockFromVisibleSource();
     updateFpsMeterLabels();
@@ -5672,6 +5982,34 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
     m_wfTexFullUpload = true;
 #endif
     leanCappedUpdate();
+}
+
+void SpectrumWidget::setKiwiSdrDisplaySourceControlVisible(bool visible)
+{
+    if (!m_kiwiSdrDisplaySourceBtn
+        || m_kiwiSdrDisplaySourceBtn->isHidden() != visible) {
+        return;
+    }
+
+    m_kiwiSdrDisplaySourceBtn->setVisible(visible);
+    if (visible) {
+        m_kiwiSdrDisplaySourceBtn->raise();
+    }
+}
+
+void SpectrumWidget::setKiwiSdrDisplaySourceKiwi(bool kiwi)
+{
+    m_kiwiSdrDisplaySourceKiwi = kiwi;
+    if (m_kiwiSdrDisplaySourceBtn) {
+        const QSignalBlocker blocker(m_kiwiSdrDisplaySourceBtn);
+        m_kiwiSdrDisplaySourceBtn->setChecked(kiwi);
+        m_kiwiSdrDisplaySourceBtn->setText(
+            kiwi ? QStringLiteral("Kiwi") : QStringLiteral("Flex"));
+        m_kiwiSdrDisplaySourceBtn->setToolTip(
+            kiwi
+                ? tr("Showing KiwiSDR spectrum/waterfall. Audio and meters are unchanged.")
+                : tr("Showing Flex spectrum/waterfall. Audio and meters are unchanged."));
+    }
 }
 
 void SpectrumWidget::setKiwiSdrWaterfallAvailable(bool available)
@@ -5699,6 +6037,10 @@ void SpectrumWidget::setKiwiSdrWaterfallProfile(const QString& profileId)
     m_kiwiSdrWaterfallProfileId = normalized;
     if (m_kiwiSdrWaterfallActive) {
         restoreCurrentWaterfallStreamState();
+        resetDssUploadState();
+#ifdef AETHER_GPU_SPECTRUM
+        m_wfTexFullUpload = true;
+#endif
         reacquireNoiseFloorLockFromVisibleSource();
         leanCappedUpdate();
     }
@@ -5916,8 +6258,8 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     // Keep the trace/3DSS smoothing local to those consumers; the scrolling
     // waterfall below uses decoded bins so narrow Kiwi carriers stay sharp.
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
-    bool appendedKiwiDssHistory = false;
-    if (m_kiwiSdrWaterfallActive) {
+    bool pushedKiwiDssHistory = false;
+    if (rowHasUsableTraceCoverage) {
         // 3DSS rows must be in the visible panadapter frequency frame. Raw Kiwi
         // rows often span a wider quantized server window, so feeding them
         // directly makes the stacked trace drift away from the remapped waterfall.
@@ -5925,12 +6267,11 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             smoothedBins, DssRenderer::kCols, rowCenterMhz, rowBandwidthMhz,
             m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
         if (!kiwiDssTrace.isEmpty()) {
-            appendDssWaterfallRow(kiwiDssTrace, -1.0, -1.0,
-                                  rowHasUsableTraceCoverage);
-            appendedKiwiDssHistory = true;
+            pushDssRowForWaterfallStream(true, kiwiDssTrace);
+            pushedKiwiDssHistory = true;
         }
     }
-    if (m_kiwiSdrWaterfallActive && destWidth > 0 && rowHasUsableTraceCoverage) {
+    if (destWidth > 0 && rowHasUsableTraceCoverage) {
         // The waterfall preserves narrow peaks, but the FFT line must not rise
         // just because a pan/zoom step changes the sampled row window. Average
         // the covered bins and normalize the row below.
@@ -5984,7 +6325,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
                 m_kiwiSdrFftFallbackSeedMask.clear();
             }
         }
-        if (!m_kiwiSdrFftTrace.isEmpty()) {
+        if (visibleStream && !m_kiwiSdrFftTrace.isEmpty()) {
             if (rowCanDriveAutoLevel) {
                 const float previousMeasuredNoiseFloorDbm = m_measuredNoiseFloorDbm;
                 const float frameFloor = estimateNoiseFloorDbm(m_kiwiSdrFftTrace);
@@ -6013,8 +6354,8 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             }
         }
     }
-    if (m_kiwiSdrWaterfallActive && !appendedKiwiDssHistory) {
-        appendDssWaterfallRow(QVector<float>{}, -1.0, -1.0, false);
+    if (!pushedKiwiDssHistory) {
+        pushDssRowForWaterfallStream(true, QVector<float>{}, -1.0, -1.0, false);
     }
     pushKiwiSdrWaterfallRow(binsDbm, destWidth,
                             rowCenterMhz, rowBandwidthMhz);
@@ -8057,6 +8398,11 @@ void SpectrumWidget::positionZoomButtons()
     // Row 0 (above): S | B (segment/band zoom)
     m_zoomSegBtn->move(pad, botY - sz - sz - 2);
     m_zoomBandBtn->move(pad + sz + 2, botY - sz - sz - 2);
+    if (m_kiwiSdrDisplaySourceBtn) {
+        const int sourceY = botY - (sz * 2)
+            - m_kiwiSdrDisplaySourceBtn->height() - 4;
+        m_kiwiSdrDisplaySourceBtn->move(pad, sourceY);
+    }
 }
 
 void SpectrumWidget::positionPanadapterMessageOverlay()
@@ -8122,19 +8468,122 @@ quint64 SpectrumWidget::dssPaletteToken() const
     return t;
 }
 
-float SpectrumWidget::dssFloorDbm() const
+float SpectrumWidget::dssFloorDbm()
 {
-    // Pick the measured noise floor for whichever source is live so the 3D-Floor
-    // slider behaves the same on Flex and KiwiSDR; fall back to the Ref window
-    // bottom only before a measurement exists. Quantise to 0.5 dB so per-frame
-    // floor jitter doesn't force needless rebuilds/uploads.
+    // 3D uses the FFT trace floor, not the waterfall colour aperture. Some
+    // KiwiSDRs publish a manual display range whose floor is well above the
+    // actual trace floor; using that colour floor collapses the 3D ridge to the
+    // baseline. The Kiwi trace floor is stabilized by stabilizeKiwiSdrFftTrace().
+    // Flex FFT floor estimates vary slightly frame-to-frame, so Flex follows a
+    // smoothed anchor instead of re-anchoring the surface to every raw frame.
     float floor;
-    if (m_kiwiSdrWaterfallActive && m_kiwiSdrDisplayRangeValid) {
-        floor = m_kiwiSdrDisplayFloorDbm;
-    } else if (m_measuredNoiseFloorDbm > -500.0f) {
-        floor = m_measuredNoiseFloorDbm;
+    if (m_kiwiSdrWaterfallActive) {
+        if (m_kiwiSdrFftTraceFloorValid && m_kiwiSdrFftTraceFloorDbm > -500.0f) {
+            floor = m_kiwiSdrFftTraceFloorDbm;
+        } else if (!m_kiwiSdrFftTrace.isEmpty()) {
+            const float frameFloor = estimateKiwiSdrTraceFloorDbm(m_kiwiSdrFftTrace);
+            floor = frameFloor > -500.0f
+                ? frameFloor
+                : (m_kiwiSdrDisplayRangeValid
+                    ? m_kiwiSdrDisplayFloorDbm
+                    : m_refLevel - m_dynamicRange);
+        } else {
+            floor = m_kiwiSdrDisplayRangeValid
+                ? m_kiwiSdrDisplayFloorDbm
+                : m_refLevel - m_dynamicRange;
+        }
     } else {
-        floor = m_refLevel - m_dynamicRange;
+        auto updateAnchor = [this](float targetFloor) {
+            if (!std::isfinite(targetFloor) || targetFloor <= -500.0f) {
+                return;
+            }
+            if (!m_dssFloorAnchorValid || m_dssFloorAnchorDbm <= -500.0f
+                || std::abs(targetFloor - m_dssFloorAnchorDbm) > 18.0f) {
+                m_dssFloorAnchorDbm = targetFloor;
+                m_dssFloorAnchorValid = true;
+                return;
+            }
+            constexpr float kAnchorAlpha = 0.04f;
+            m_dssFloorAnchorDbm =
+                (1.0f - kAnchorAlpha) * m_dssFloorAnchorDbm
+                + kAnchorAlpha * targetFloor;
+        };
+
+        if (m_noiseFloorEnable && m_noiseFloorBaselineValid) {
+            updateAnchor(m_noiseFloorBaselineDbm);
+        } else if (m_measuredNoiseFloorDbm > -500.0f) {
+            updateAnchor(m_measuredNoiseFloorDbm);
+        } else if (m_noiseFloorBaselineValid) {
+            updateAnchor(m_noiseFloorBaselineDbm);
+        }
+
+        if (!m_dssFloorAnchorValid) {
+            const QVector<float>& bins = noiseFloorAutoLevelBins();
+            if (!bins.isEmpty()) {
+                const float frameFloor = estimateNoiseFloorDbm(bins);
+                if (frameFloor > -500.0f) {
+                    m_dssFloorAnchorDbm = frameFloor;
+                    m_dssFloorAnchorValid = true;
+                }
+            }
+            if (!m_dssFloorAnchorValid && m_noiseFloorBaselineValid) {
+                m_dssFloorAnchorDbm = m_noiseFloorBaselineDbm;
+                m_dssFloorAnchorValid = true;
+            }
+            if (!m_dssFloorAnchorValid && m_measuredNoiseFloorDbm > -500.0f) {
+                m_dssFloorAnchorDbm = m_measuredNoiseFloorDbm;
+                m_dssFloorAnchorValid = true;
+            }
+        }
+        floor = m_dssFloorAnchorValid
+            ? m_dssFloorAnchorDbm
+            : m_refLevel - m_dynamicRange;
+    }
+    floor += m_dssFloorOffsetDb;
+    return std::round(floor * 2.0f) / 2.0f;
+}
+
+float SpectrumWidget::peekDssFloorDbm() const
+{
+    float floor;
+    if (m_kiwiSdrWaterfallActive) {
+        if (m_kiwiSdrFftTraceFloorValid
+            && m_kiwiSdrFftTraceFloorDbm > -500.0f) {
+            floor = m_kiwiSdrFftTraceFloorDbm;
+        } else if (!m_kiwiSdrFftTrace.isEmpty()) {
+            const float frameFloor =
+                estimateKiwiSdrTraceFloorDbm(m_kiwiSdrFftTrace);
+            floor = frameFloor > -500.0f
+                ? frameFloor
+                : (m_kiwiSdrDisplayRangeValid
+                    ? m_kiwiSdrDisplayFloorDbm
+                    : m_refLevel - m_dynamicRange);
+        } else {
+            floor = m_kiwiSdrDisplayRangeValid
+                ? m_kiwiSdrDisplayFloorDbm
+                : m_refLevel - m_dynamicRange;
+        }
+    } else {
+        if (m_dssFloorAnchorValid && m_dssFloorAnchorDbm > -500.0f) {
+            floor = m_dssFloorAnchorDbm;
+        } else if (m_noiseFloorEnable && m_noiseFloorBaselineValid
+                   && m_noiseFloorBaselineDbm > -500.0f) {
+            floor = m_noiseFloorBaselineDbm;
+        } else if (m_measuredNoiseFloorDbm > -500.0f) {
+            floor = m_measuredNoiseFloorDbm;
+        } else if (m_noiseFloorBaselineValid
+                   && m_noiseFloorBaselineDbm > -500.0f) {
+            floor = m_noiseFloorBaselineDbm;
+        } else {
+            floor = m_refLevel - m_dynamicRange;
+            const QVector<float>& bins = noiseFloorAutoLevelBins();
+            if (!bins.isEmpty()) {
+                const float frameFloor = estimateNoiseFloorDbm(bins);
+                if (frameFloor > -500.0f) {
+                    floor = frameFloor;
+                }
+            }
+        }
     }
     floor += m_dssFloorOffsetDb;
     return std::round(floor * 2.0f) / 2.0f;
@@ -8149,9 +8598,10 @@ float SpectrumWidget::dssSpanDb() const
     return std::clamp(span, 45.0f, 120.0f);
 }
 
-const QImage& SpectrumWidget::buildDssImage(const QSize& px, int scaleStripPx)
+const QImage& SpectrumWidget::buildDssImage(const QSize& px,
+                                            int scaleStripPx,
+                                            float floorDbm)
 {
-    const float floorDbm = dssFloorDbm();
     const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
 
     // Same mapping as the GPU mesh: full colormap over the strength axis, gamma-
@@ -8162,6 +8612,42 @@ const QImage& SpectrumWidget::buildDssImage(const QSize& px, int scaleStripPx)
     };
     return m_dss.image(px, scaleStripPx, floorDbm, rangeDb, m_dssZCurve,
                        palette, dssPaletteToken(), m_bgFillColor);
+}
+
+void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
+                                                  const QVector<float>& binsDbm,
+                                                  double frameCenterMhz,
+                                                  double frameBandwidthMhz,
+                                                  bool updateLiveSurface)
+{
+    if (m_kiwiSdrWaterfallActive == kiwiStream) {
+        appendDssWaterfallRow(binsDbm, frameCenterMhz, frameBandwidthMhz,
+                              updateLiveSurface);
+        return;
+    }
+
+    DssRenderer& dss = kiwiStream
+        ? activeKiwiWaterfallState().dss
+        : m_nativeWaterfallState.dss;
+    const bool live = kiwiStream
+        ? activeKiwiWaterfallState().live
+        : m_nativeWaterfallState.live;
+    if (live && updateLiveSurface) {
+        dss.pushRow(binsDbm);
+    }
+
+    const double stampCenterMhz =
+        (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
+            ? frameCenterMhz
+            : m_centerMhz;
+    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
+        ? frameBandwidthMhz
+        : m_bandwidthMhz;
+    const float fallbackDbm = kiwiStream
+        ? kKiwiSdrWaterfallMinDbm
+        : m_refLevel - m_dynamicRange;
+    dss.appendHistoryRow(binsDbm, stampCenterMhz, stampBandwidthMhz,
+                         fallbackDbm);
 }
 
 void SpectrumWidget::resetDssUploadState()
@@ -8919,15 +9405,18 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     // positions. Everything below is identical to 2D except the FFT trace is
     // swapped for the 3DSS surface quad inside specRect.
     const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
+    const float dssFrameFloorDbm = is3D
+        ? dssFloorDbm()
+        : m_lastDetectDssFloor;
 
     // Detect display state changes that may bypass markOverlayDirty()
     {
         // In 3D the dBm scale is anchored to the noise floor, which drifts every
         // FFT frame (dssFloorDbm() reads the measured floor, quantised to 0.5 dB).
-        // The surface UBO re-reads it per frame, so without this the surface
-        // would shift while the cached scale labels stay stale (#3937). In 2D the
+        // The surface UBO and cached scale labels consume the same per-frame
+        // floor, so a changed anchor invalidates both together (#3937). In 2D the
         // scale is Ref-anchored, so the floor is left out of the check there.
-        const float dssFloor = is3D ? dssFloorDbm() : m_lastDetectDssFloor;
+        const float dssFloor = dssFrameFloorDbm;
         if (m_centerMhz != m_lastDetectCenter || m_bandwidthMhz != m_lastDetectBw ||
             m_refLevel != m_lastDetectRef || m_dynamicRange != m_lastDetectDyn ||
             m_spectrumFrac != m_lastDetectFrac ||
@@ -9273,7 +9762,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // dBm strip: both render modes use a readable full-height amplitude
             // reference; the 3D surface itself is perspective-foreshortened.
             if (is3D) {
-                drawDbmScale3D(p, specRect);
+                drawDbmScale3D(p, specRect, dssFrameFloorDbm);
             } else {
                 drawDbmScale(p, specRect);
             }
@@ -9317,7 +9806,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // GPU mesh path: keep the palette LUT current, upload every height
             // row pushed since the last frame into the ring texture, and refresh
             // the uniforms. Geometry is static — pan/zoom rebuild nothing.
-            const float floorDbm = dssFloorDbm();
+            const float floorDbm = dssFrameFloorDbm;
             const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
             uploadDssPaletteLut(batch, floorDbm, rangeDb);
 
@@ -9422,7 +9911,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                                              double(kDssMaxH) / specPhDev));
             const int dssW = qMax(2, static_cast<int>(specPwDev * sc));
             const int dssH = qMax(2, static_cast<int>(specPhDev * sc));
-            const QImage& surf = buildDssImage(QSize(dssW, dssH), 0);
+            const QImage& surf = buildDssImage(QSize(dssW, dssH), 0,
+                                               dssFrameFloorDbm);
             // m_dssGpuTex/m_dssSrb/m_ovSampler come from initOverlayPipeline();
             // guard against a partial GPU init (OOM / device loss) so the
             // fallback never dereferences a null resource.
@@ -9843,6 +10333,9 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     const QRect wfRect   (0, wfY,     width(), wfH);
 
     const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
+    const float dssFrameFloorDbm = is3D
+        ? dssFloorDbm()
+        : m_lastDetectDssFloor;
 
     // Spectrum region: the 3DSS surface, or the classic bg + grid + FFT trace.
     // 3DSS replaces ONLY the spectrum trace — the divider, freq scale, waterfall,
@@ -9852,7 +10345,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         // window doesn't rebuild a multi-megapixel QImage every frame; the
         // surface is intrinsically low-res, so stretch it on draw.
         const QImage& surf =
-            buildDssImage(specRect.size().boundedTo(QSize(kDssMaxW, kDssMaxH)), 0);
+            buildDssImage(specRect.size().boundedTo(QSize(kDssMaxW, kDssMaxH)),
+                          0, dssFrameFloorDbm);
         if (!surf.isNull()) {
             p.drawImage(specRect, surf);
         } else {
@@ -10097,7 +10591,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     // dBm strip: 2D draws a linear dBm axis; 3D maps the ticks onto the front
     // (live) trace's ridge band. Same strip chrome and click targets either way.
     if (is3D) {
-        drawDbmScale3D(p, specRect);
+        drawDbmScale3D(p, specRect, dssFrameFloorDbm);
     } else {
         drawDbmScale(p, specRect);
     }
@@ -11789,10 +12283,10 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
 // perspective row. Keep it as a full-height amplitude reference anchored to the
 // 3D floor, so plain drag visibly shifts the dBm numbers and Ctrl/Meta-drag
 // changes the span.
-void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect)
+void SpectrumWidget::drawDbmScale3D(QPainter& p, const QRect& specRect,
+                                    float floorDbm)
 {
     drawDbmScaleChrome(p, specRect);
-    const float floorDbm = dssFloorDbm();
     // Round the span the same way the mesh/CPU surface do (buildDssImage /
     // renderGpuFrame use std::round(span*2)/2) so labels and surface agree to
     // the pixel instead of a sub-dB top/bottom skew (#3937).

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -138,6 +138,7 @@ public:
                                                     double rowHighMhz = -1.0);
     Q_INVOKABLE QVariantMap automationDssSetScrollback(bool live,
                                                        int offsetRows);
+    Q_INVOKABLE QVariantMap traceDebugSnapshot();
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void setKiwiSdrConnectionOverlay(bool visible,
                                      const QString& detail = {},
@@ -170,6 +171,9 @@ public:
     void setKiwiSdrWaterfallAvailable(bool available);
     void setKiwiSdrWaterfallActive(bool active);
     bool kiwiSdrWaterfallActive() const { return m_kiwiSdrWaterfallActive; }
+    void setKiwiSdrDisplaySourceControlVisible(bool visible);
+    void setKiwiSdrDisplaySourceKiwi(bool kiwi);
+    bool kiwiSdrDisplaySourceKiwi() const { return m_kiwiSdrDisplaySourceKiwi; }
     void setKiwiSdrWaterfallProfile(const QString& profileId);
     void clearKiwiSdrWaterfallRows();
     void clearKiwiSdrWaterfallRowsForProfile(const QString& profileId);
@@ -183,8 +187,8 @@ public:
     void setDbmRange(float minDbm, float maxDbm);
 
     // Noise floor auto-adjust: position (1=top, 99=bottom), enable on/off.
-    // Both setters persist to AppSettings (per-pan keys DisplayNoiseFloor*)
-    // so the state and value survive launch.
+    // The enable flag is shared for the pan; the position is stored separately
+    // for Flex and Kiwi display sources so switching views restores each scale.
     void setNoiseFloorPosition(int pos);
     void setNoiseFloorEnable(bool on);
     void prepareForFftScaleChange();
@@ -426,7 +430,8 @@ public:
     void setSpectrumRenderMode(int mode);
     int  spectrumRenderMode() const { return static_cast<int>(m_spectrumRenderMode); }
     // 3DSS floor depth: how far below the measured noise floor to surface (dB),
-    // lifting the floor carpet into view. Persisted per-panadapter.
+    // lifting the floor carpet into view. Stored separately for Flex and Kiwi
+    // display sources so switching views restores each 3D trace position.
     void setDssFloorDepth(int dB);
     int  dssFloorDepth() const { return static_cast<int>(std::lround(-m_dssFloorOffsetDb)); }
     // 3DSS colour floor (0-100): how far down the strength range the colormap
@@ -650,6 +655,7 @@ signals:
     void noiseFloorPositionResolved(int pos);
     void dssFloorDepthResolved(int dB);
     void waterfallLineDurationChangeRequested(int ms);
+    void kiwiSdrDisplaySourceRequested(bool kiwi);
     // TNF signals
     void tnfCreateRequested(double freqMhz);
     void tnfMoveRequested(int id, double newFreqMhz);
@@ -749,7 +755,7 @@ private:
     // Full-height dBm amplitude reference for 3D stacked-trace mode. It follows
     // the floor anchor and scale span; perspective means individual history rows
     // do not share a single pixel-exact y-axis.
-    void drawDbmScale3D(QPainter& p, const QRect& specRect);
+    void drawDbmScale3D(QPainter& p, const QRect& specRect, float floorDbm);
     void drawTimeScale(QPainter& p, const QRect& wfRect);
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
     void positionPanadapterMessageOverlay();
@@ -800,6 +806,14 @@ private:
         float kiwiFftTraceFloorDbm{-1000.0f};
         bool kiwiFftTraceFloorValid{false};
         bool valid{false};
+#ifdef AETHER_GPU_SPECTRUM
+        bool wfTexFullUpload{true};
+        int wfLastUploadedRow{-1};
+        bool dssTexNeedsUpload{true};
+        quint64 dssLastUploadedGen{~0ull};
+        int dssMeshHeadUploaded{-1};
+        quint64 dssMeshRowGenUploaded{~0ull};
+#endif
     };
     void clearCurrentWaterfallRows();
     void resetKiwiSdrWaterfallDisplayRange();
@@ -808,6 +822,7 @@ private:
     void saveCurrentWaterfallStreamState();
     void restoreCurrentWaterfallStreamState();
     WaterfallStreamState& activeKiwiWaterfallState();
+    const WaterfallStreamState* activeKiwiWaterfallStateConst() const;
     bool beginWaterfallStreamWrite(bool kiwiStream);
     void endWaterfallStreamWrite(bool kiwiStream, bool visibleStream);
     void appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
@@ -881,6 +896,14 @@ private:
     // can persist; startup/enable/layout refreshes only rebuild transient state.
     void refreshNoiseFloorTarget(bool captureCurrentScale = false, bool persistCapture = false);
     bool captureNoiseFloorTargetFromCurrentScale(bool notify, bool persist);
+    QString displaySourceTraceSettingsKey() const;
+    void loadDisplaySourceTraceSettings(int legacyNoiseFloorPosition,
+                                        int legacyDssFloorDepth);
+    void saveDisplaySourceTraceSettings();
+    void setNoiseFloorPositionForSource(bool kiwiSource, int pos, bool persist);
+    void restoreNoiseFloorPositionForCurrentSource(bool syncMenu);
+    void setDssFloorDepthForSource(bool kiwiSource, int dB, bool persist);
+    void restoreDssFloorDepthForCurrentSource(bool syncMenu);
 
     // Helper: find overlay index for a sliceId, or -1.
     int overlayIndex(int sliceId) const;
@@ -921,15 +944,20 @@ private:
 
     // 3DSS — rebuild/return the cached perspective surface for the given pixel
     // size (scaleStripPx = transparent frequency-scale strip at the bottom).
-    const QImage& buildDssImage(const QSize& px, int scaleStripPx);
+    const QImage& buildDssImage(const QSize& px, int scaleStripPx,
+                                float floorDbm);
+    void pushDssRowForWaterfallStream(bool kiwiStream,
+                                      const QVector<float>& binsDbm,
+                                      double frameCenterMhz = -1.0,
+                                      double frameBandwidthMhz = -1.0,
+                                      bool updateLiveSurface = true);
     void resetDssUploadState();
     // Token folding the dbmToRgb() palette inputs so the 3DSS cache rebuilds
     // when the colour mapping (scheme/gain/floor) changes.
     quint64 dssPaletteToken() const;
-    // Unified noise-floor anchor (dBm, quantised) for the 3D surface — uses the
-    // measured floor for the active source (Flex or KiwiSDR), offset by the
-    // user's 3D Floor depth, so the floor sits at the baseline consistently.
-    float dssFloorDbm() const;
+    // Unified noise-floor anchor (dBm, quantised) for the 3D surface.
+    float dssFloorDbm();
+    float peekDssFloorDbm() const;
     // dB span shown above the 3D floor anchor — follows the normal dBm scale,
     // clamped so the wide Flex window can't flatten signals.
     float dssSpanDb() const;
@@ -1001,6 +1029,8 @@ private:
     // Noise floor auto-adjust
     bool  m_noiseFloorEnable{false};
     int   m_noiseFloorPosition{75};  // 1=top, 99=bottom
+    int   m_flexNoiseFloorPosition{75};
+    int   m_kiwiNoiseFloorPosition{75};
     int   m_noiseFloorFrameCount{0};
     // Noise-floor auto-adjust state machine (per-frame baseline tracker
     // with asymmetric smoothing + transient rejection — keeps the floor
@@ -1102,7 +1132,11 @@ private:
     // trace baseline. A few dB negative lifts the noisy floor carpet (with its
     // own colour) up off the baseline so you see floor -> peak, not just crests.
     float m_dssFloorOffsetDb{-6.0f};
+    int   m_flexDssFloorDepth{6};
+    int   m_kiwiDssFloorDepth{6};
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
+    float m_dssFloorAnchorDbm{-1000.0f};
+    bool  m_dssFloorAnchorValid{false};
     // Consumed by BOTH the GPU mesh and the CPU fallback surface, so these stay
     // outside the AETHER_GPU_SPECTRUM block below — the CPU paint path needs them
     // even when GPU spectrum rendering is disabled (older Qt / -DAETHER_GPU_SPECTRUM=OFF).
@@ -1449,10 +1483,12 @@ private:
     VfoWidget* m_vfoWidget{nullptr};  // alias to active slice widget (compat)
 
     // Bottom-left waterfall buttons: S(egment), B(and), −/+.
+    QPushButton* m_kiwiSdrDisplaySourceBtn{nullptr};
     QPushButton* m_zoomSegBtn{nullptr};
     QPushButton* m_zoomBandBtn{nullptr};
     QPushButton* m_zoomOutBtn{nullptr};
     QPushButton* m_zoomInBtn{nullptr};
+    bool m_kiwiSdrDisplaySourceKiwi{false};
 
 #ifdef AETHER_GPU_SPECTRUM
     bool m_rhiInitialized{false};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1058,12 +1058,41 @@ void RadioModel::setPanTransmitInhibited(const QString& panId,
 
     if (!inhibited) {
         m_panTransmitInhibitReasons.remove(trimmedPanId);
+        const bool hadRestoreSlice =
+            m_panTransmitInhibitedTxSlices.contains(trimmedPanId);
+        const int restoreSliceId = hadRestoreSlice
+            ? m_panTransmitInhibitedTxSlices.take(trimmedPanId)
+            : -1;
+        if (hadRestoreSlice) {
+            SliceModel* restoreSlice = slice(restoreSliceId);
+            SliceModel* currentTxSlice = txSlice();
+            const int currentTxSliceId = currentTxSlice
+                ? currentTxSlice->sliceId()
+                : -1;
+            if (restoreSlice
+                && TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                    trimmedPanId, restoreSlice->panId(),
+                    sliceMayBelongToUs(restoreSliceId), restoreSliceId,
+                    currentTxSliceId)) {
+                sendSliceCommand(restoreSlice,
+                                 QStringLiteral("slice set %1 tx=1")
+                                     .arg(restoreSliceId));
+            }
+        }
         return;
     }
 
     const QString trimmedReason = reason.trimmed().isEmpty()
         ? QStringLiteral("Transmit is disabled because this panadapter is displaying receive-only data.")
         : reason.trimmed();
+    if (!m_panTransmitInhibitedTxSlices.contains(trimmedPanId)) {
+        if (SliceModel* currentTxSlice = txSlice();
+            currentTxSlice && currentTxSlice->panId() == trimmedPanId
+            && sliceMayBelongToUs(currentTxSlice->sliceId())) {
+            m_panTransmitInhibitedTxSlices.insert(
+                trimmedPanId, currentTxSlice->sliceId());
+        }
+    }
     if (m_panTransmitInhibitReasons.value(trimmedPanId) == trimmedReason) {
         return;
     }
@@ -1148,6 +1177,23 @@ bool RadioModel::transmitStartBlockedByInhibit(const QString& key)
     return true;
 }
 
+void RadioModel::noteLocalTxSliceEnableIntent(int sliceId)
+{
+    if (sliceId < 0) {
+        return;
+    }
+
+    for (auto it = m_panTransmitInhibitedTxSlices.begin();
+         it != m_panTransmitInhibitedTxSlices.end();) {
+        if (it.value() == sliceId) {
+            ++it;
+            continue;
+        }
+
+        it = m_panTransmitInhibitedTxSlices.erase(it);
+    }
+}
+
 void RadioModel::sendSliceCommand(SliceModel* slice, const QString& cmd)
 {
     const TransmitInhibitPolicy::SliceTxCommand txCommand =
@@ -1164,6 +1210,7 @@ void RadioModel::sendSliceCommand(SliceModel* slice, const QString& cmd)
                 target->panId());
             return;
         }
+        noteLocalTxSliceEnableIntent(txCommand.sliceId);
     }
 
     sendCmd(cmd);
@@ -2369,6 +2416,7 @@ void RadioModel::stageSessionModelsForReconnect()
     m_foreignSliceOwners.clear();
     m_pendingPanStatuses.clear();
     m_panTransmitInhibitReasons.clear();
+    m_panTransmitInhibitedTxSlices.clear();
     m_activePanId.clear();
 
     if (!m_staleSlices.isEmpty() || !m_stalePanadapters.isEmpty()) {
@@ -4986,6 +5034,7 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_radioDisplayPans.remove(normalizePanadapterId(panId));   // #3856 Layer B inventory
                 m_pendingPanStatuses.remove(panId);
                 m_panTransmitInhibitReasons.remove(panId);
+                m_panTransmitInhibitedTxSlices.remove(panId);
                 auto* pan = m_panadapters.take(panId);
                 if (!pan) {
                     pan = m_stalePanadapters.take(panId);
@@ -5077,6 +5126,7 @@ void RadioModel::onStatusReceived(const QString& object,
                 }
                 if (rejectedPan) {
                     m_panTransmitInhibitReasons.remove(panId);
+                    m_panTransmitInhibitedTxSlices.remove(panId);
                     m_panStream->unregisterPanStream(rejectedPan->panStreamId());
                     m_panStream->unregisterWfStream(rejectedPan->wfStreamId());
                     qCDebug(lcProtocol) << "RadioModel: panadapter" << panId
@@ -5106,6 +5156,8 @@ void RadioModel::onStatusReceived(const QString& object,
                             << "reassigned to client" << newOwner
                             << "— going quiet on it (#3977)";
                     }
+                    m_panTransmitInhibitReasons.remove(panId);
+                    m_panTransmitInhibitedTxSlices.remove(panId);
                     heldPan->setClientHandle(newOwner);
                 }
                 return;  // not our panadapter, ignore

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -858,6 +858,7 @@ private:
     };
     QMap<int, TxBandInfo> m_txBandSettings;
     QHash<QString, QString> m_panTransmitInhibitReasons;
+    QHash<QString, int> m_panTransmitInhibitedTxSlices;
     int  m_tuneInhibitBandId{-1};  // band ID whose TX outputs were inhibited during tune
     bool m_tuneInhibitActive{false};
 
@@ -870,6 +871,7 @@ private:
     void enforceTransmitInhibitForPan(const QString& panId);
     void enforceTransmitInhibitForSlice(SliceModel* slice);
     bool transmitStartBlockedByInhibit(const QString& key);
+    void noteLocalTxSliceEnableIntent(int sliceId);
     void sendSliceCommand(SliceModel* slice, const QString& cmd);
     QString localPttInterlockMessage(TransmitModel::PttSource source) const;
     QString txFilterFrequencyLimitMessage(int lowHz, int highHz) const;

--- a/src/models/TransmitInhibitPolicy.h
+++ b/src/models/TransmitInhibitPolicy.h
@@ -47,4 +47,18 @@ inline SliceTxCommand parseSliceTxCommand(const QString& command)
             .txEnabled = tx == QStringLiteral("1")};
 }
 
+inline bool shouldRestoreInhibitedTxSlice(const QString& inhibitedPanId,
+                                          const QString& restoreSlicePanId,
+                                          bool restoreSliceMayBelongToUs,
+                                          int restoreSliceId,
+                                          int currentTxSliceId)
+{
+    const QString trimmedPanId = inhibitedPanId.trimmed();
+    return !trimmedPanId.isEmpty()
+        && restoreSliceId >= 0
+        && restoreSliceMayBelongToUs
+        && restoreSlicePanId == trimmedPanId
+        && (currentTxSliceId < 0 || currentTxSliceId == restoreSliceId);
+}
+
 } // namespace AetherSDR::TransmitInhibitPolicy

--- a/tests/transmit_inhibit_policy_test.cpp
+++ b/tests/transmit_inhibit_policy_test.cpp
@@ -51,5 +51,40 @@ int main()
         ok &= expect(!parsed.valid, "ignores non-slice command");
     }
 
+    {
+        ok &= expect(TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                         QStringLiteral("0x40000000"),
+                         QStringLiteral("0x40000000"), true, 3, -1),
+                     "restores inhibited TX slice when radio has no current TX slice");
+    }
+
+    {
+        ok &= expect(TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                         QStringLiteral("0x40000000"),
+                         QStringLiteral("0x40000000"), true, 3, 3),
+                     "restores inhibited TX slice when it remains current TX");
+    }
+
+    {
+        ok &= expect(!TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                         QStringLiteral("0x40000000"),
+                         QStringLiteral("0x40000000"), true, 3, 4),
+                     "does not restore when TX moved to another slice");
+    }
+
+    {
+        ok &= expect(!TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                         QStringLiteral("0x40000000"),
+                         QStringLiteral("0x40000001"), true, 3, -1),
+                     "does not restore a slice on another panadapter");
+    }
+
+    {
+        ok &= expect(!TransmitInhibitPolicy::shouldRestoreInhibitedTxSlice(
+                         QStringLiteral("0x40000000"),
+                         QStringLiteral("0x40000000"), false, 3, -1),
+                     "does not restore a slice we cannot safely claim");
+    }
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Adds a bottom-left Flex/Kiwi display-source toggle for panadapters whose slice is connected to a KiwiSDR. The toggle switches only the spectrum/waterfall display source; audio and meters keep their existing behavior. Kiwi display keeps TX inhibited, Flex display clears the pan-level TX inhibit, and the restore path now avoids stealing TX back if the operator moved TX to another slice.

This also includes the bug fixes found during pre-push review: hidden Kiwi rows no longer mutate visible Flex scaling/noise-floor state, Flex/Kiwi FFT and 3D history continue filling while hidden, 2D and 3D trace positions are stored separately per display source, Kiwi 3D floor placement uses the FFT trace floor instead of the waterfall color floor, and TX restore no longer reclaims TX if the operator moved TX to another slice.

## Constitution principle honored

Principle V — the new per-source 2D/3D trace settings are persisted as one feature-owned `AppSettings` object rather than new flat keys.

Principle VI — Kiwi receive-only display state fails closed for transmit, and Flex restore only re-enables TX when that slice is still the operator's TX target.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR transmit_inhibit_policy_test transmit_model_test kiwi_sdr_trace_math_test --parallel`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Automation bridge coverage:
- [x] Added `get tracedebug` for per-pan Flex/Kiwi trace diagnostics
- [x] Added `transmitInhibited` / `transmitInhibitReason` to `get pan` and `get pans`
- [x] Documented the new bridge diagnostics in `docs/automation-bridge.md`
- [x] Verified Kiwi-selected display inhibits TX
- [x] Verified Flex-selected display clears only the pan inhibit
- [x] Verified TX is not restored to the original slice after the operator moves TX elsewhere
- [x] Verified hidden Flex/Kiwi 3D history continues updating via `get tracedebug`

Additional checks:
- [x] `./build/transmit_inhibit_policy_test`
- [x] `./build/transmit_model_test`
- [x] `./build/kiwi_sdr_trace_math_test`
- [x] `python3 tools/check_engine_boundary.py --strict`
- [x] `python3 tools/check_a11y.py`
- [x] `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
