### PR TITLE
[codex] Sync DSS scrollback with waterfall history

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -40,8 +40,8 @@ production; it only exists when you ask for it via an env var.
 cmake --build build --parallel
 
 # 2. Launch the app with the bridge enabled.
-AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &   # macOS
-#   AETHER_AUTOMATION=1 ./build/AetherSDR &                            # Linux/Windows
+AETHER_AUTOMATION=1 AETHER_AUTOMATION_NO_AUTOCONNECT=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &   # macOS
+#   AETHER_AUTOMATION=1 AETHER_AUTOMATION_NO_AUTOCONNECT=1 ./build/AetherSDR &                            # Linux/Windows
 
 # 3. Drive it. The dependency-free probe needs no Qt:
 python3 tools/automation_probe.py ping
@@ -53,6 +53,8 @@ python3 tools/automation_probe.py demo --out /tmp/phase0   # → tree.json + pan
 to confirm a visual change; parse the JSON to assert on control state.
 
 For headless / CI runs, add `QT_QPA_PLATFORM=offscreen` — no display required.
+`AETHER_AUTOMATION_NO_AUTOCONNECT=1` suppresses saved-radio autoconnect during
+bridge runs; use the `connect` verb when a test intentionally needs a radio.
 
 KiwiSDR compression can be forced for diagnostic runs by adding
 `AETHER_KIWI_SND_COMP=1` and/or `AETHER_KIWI_WF_COMP=1` at launch. These are
@@ -77,7 +79,7 @@ HIServices are unavailable, before AetherSDR reaches the automation bridge; with
 socket the bridge needs. Launch outside the command sandbox instead:
 
 ```bash
-QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
+QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1 AETHER_AUTOMATION_NO_AUTOCONNECT=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
 ```
 
 ---
@@ -1168,43 +1170,56 @@ It is RX-only: no radio commands and no transmit keying.
 
 ```json
 → {"cmd":"dss","action":"reset","target":"0","value":"native"}
-← {"ok":true,"panIndex":0,"live":true,"dssHistoryRows":0,...}
+← {"ok":true,"panIndex":0,"live":true,"waterfallRows":96,
+   "centerMhz":14.1,"bandwidthMhz":0.192,"dssHistoryRows":0,...}
 
-→ {"cmd":"dss","action":"inject","target":"0","value":"3 100 100 native"}
-← {"ok":true,"dssHistoryRows":3,"waterfallHistoryRows":3,
-   "dssHistoryRowsAdded":3,"waterfallHistoryRowsAdded":3,
-   "dssVisiblePeakBin":300,...}
+→ {"cmd":"dss","action":"inject","target":"0","value":"99 100 1 native"}
+← {"ok":true,"dssHistoryRows":99,"waterfallHistoryRows":99,
+   "maxHistoryOffsetRows":3,
+   "dssHistoryRowsAdded":99,"waterfallHistoryRowsAdded":99,...}
 
 → {"cmd":"dss","action":"scrollback","target":"0","value":"1"}
-← {"ok":true,"live":false,"historyOffsetRows":1,"dssVisiblePeakBin":200,...}
+← {"ok":true,"live":false,"historyOffsetRows":1,
+   "maxHistoryOffsetRows":3,...}
 
-→ {"cmd":"dss","action":"inject","target":"0","value":"1 420 0 native"}
-← {"ok":true,"live":false,"dssHistoryRows":4,
-   "waterfallHistoryRows":4,"historyOffsetRows":2,
-   "dssHistoryRowsAdded":1,"waterfallHistoryRowsAdded":1,
-   "dssVisiblePeakBin":200,...}
+→ {"cmd":"dss","action":"inject","target":"0","value":"3 420 0 native"}
+← {"ok":true,"live":false,"dssHistoryRows":102,
+   "waterfallHistoryRows":102,"historyOffsetRows":4,
+   "dssHistoryRowsAdded":3,"waterfallHistoryRowsAdded":3,
+   ...}
 
 → {"cmd":"dss","action":"scrollback","target":"0","value":"0"}
 ← {"ok":true,"live":false,"historyOffsetRows":0,"dssVisiblePeakBin":420,...}
 ```
 
+This example assumes the reset response reports `waterfallRows:96`; for a
+different widget height, inject at least `waterfallRows + 3` rows before asking
+for `scrollback 1`.
+
 Actions:
 
 | action | value | effect |
 |---|---|---|
-| `snapshot` | optional pan target | Read `live`, waterfall/DSS history row counts, visible DSS row count, and the current front-row peak bin. |
+| `snapshot` | optional pan target | Read `live`, current center/bandwidth MHz, waterfall/DSS history row counts, visible DSS row count, and the current front-row peak bin. |
 | `reset` | `native` or `kiwi` | Clear the selected stream's current/history rows and make that stream active for subsequent injection. |
-| `inject` | `<count> <firstPeakBin> <stepBin> [native\|kiwi]` | Add synthetic rows with one strong peak per row. `count` is capped at the retained waterfall history capacity. Native injection adds one fallback-style waterfall/DSS row per input row; Kiwi injection drives `updateKiwiSdrWaterfallRow()`. |
+| `inject` | `<count> <firstPeakBin> <stepBin> [native\|kiwi [rowLowMhz rowHighMhz]]` | Add synthetic rows with one strong peak per row. `count` is rejected if it exceeds the retained waterfall history capacity. Native injection adds one fallback-style waterfall/DSS row per input row; Kiwi injection drives `updateKiwiSdrWaterfallRow()`. Kiwi frame arguments override the source row's frequency span, so tests can cover partial-overlap rows. |
 | `scrollback` | `<offsetRows>` | Enter waterfall history mode and rebuild the 3D surface using the same offset. |
 | `live` | none | Return to live mode. |
 
-The paused/live-history assertion is: enter `scrollback`, inject another row,
+The paused/live-history assertion is: enter `scrollback`, inject more rows,
 confirm both `waterfallHistoryRowsAdded` and `dssHistoryRowsAdded` match the
 injected count while `historyOffsetRows` advances and `dssVisiblePeakBin` stays
 on the same paused historical row, then set `scrollback 0` and confirm the newly
 injected peak becomes visible. The total row counts are still returned, but the
 `*RowsAdded` fields are the deterministic assertion surface if live data is also
 arriving between bridge requests.
+
+To reproduce a low-coverage Kiwi row, read `centerMhz` and `bandwidthMhz` from
+`dss snapshot`, then inject a Kiwi source row whose span overlaps less than 5%
+of the current view. For example, with `viewHigh = centerMhz + bandwidthMhz/2`,
+`dss inject 3 120 0 kiwi <viewHigh - 0.03*bandwidthMhz> <viewHigh + 0.97*bandwidthMhz>`
+keeps row counts aligned while proving the DSS history stores the partial row
+content instead of a flat fallback row.
 
 ### `whoami`
 Identify **this** bridge instance among concurrent bridges (each app process gets

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -154,6 +154,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`slice <action>`](#slice) | add/remove/select/tx/txant/rxant/rxsource. |
 | **Display / pans** | [`pan <action>`](#pan) | create / center / close a panadapter. |
 | | [`panmessage <action>`](#panmessage) | Add, remove, clear, or list panadapter overlay messages for UI testing. |
+| | [`dss <action>`](#dss) | Inject/read 3D stacked-trace + waterfall scrollback state. |
 | | [`streams [radio\|resync\|reset]`](#streams) | Radio-side display-stream leak detector. |
 | | [`txwaterfall on\|off`](#txwaterfall) | Toggle "show TX in waterfall". |
 | **DAX / TCI** | [`tci start\|status\|stop`](#tci) | In-process TCI client simulator (WSJT-X-shaped). |
@@ -1158,6 +1159,52 @@ recovery (#3804) or that the waterfall auto-range settled.
 
 One entry per `SpectrumWidget` that has a real measurement; the same numbers
 appear per-node in `dumpTree` (`noiseFloorDbm`/`displayFloorDbm`/`panIndex`).
+
+### `dss`
+Automation-only 3D stacked-trace / waterfall scrollback proof surface. It finds
+a `SpectrumWidget` by `panIndex`, injects synthetic RX rows through the normal
+SpectrumWidget waterfall paths, and returns compact counters/peak-bin snapshots.
+It is RX-only: no radio commands and no transmit keying.
+
+```json
+→ {"cmd":"dss","action":"reset","target":"0","value":"native"}
+← {"ok":true,"panIndex":0,"live":true,"dssHistoryRows":0,...}
+
+→ {"cmd":"dss","action":"inject","target":"0","value":"3 100 100 native"}
+← {"ok":true,"dssHistoryRows":3,"waterfallHistoryRows":3,
+   "dssHistoryRowsAdded":3,"waterfallHistoryRowsAdded":3,
+   "dssVisiblePeakBin":300,...}
+
+→ {"cmd":"dss","action":"scrollback","target":"0","value":"1"}
+← {"ok":true,"live":false,"historyOffsetRows":1,"dssVisiblePeakBin":200,...}
+
+→ {"cmd":"dss","action":"inject","target":"0","value":"1 420 0 native"}
+← {"ok":true,"live":false,"dssHistoryRows":4,
+   "waterfallHistoryRows":4,"historyOffsetRows":2,
+   "dssHistoryRowsAdded":1,"waterfallHistoryRowsAdded":1,
+   "dssVisiblePeakBin":200,...}
+
+→ {"cmd":"dss","action":"scrollback","target":"0","value":"0"}
+← {"ok":true,"live":false,"historyOffsetRows":0,"dssVisiblePeakBin":420,...}
+```
+
+Actions:
+
+| action | value | effect |
+|---|---|---|
+| `snapshot` | optional pan target | Read `live`, waterfall/DSS history row counts, visible DSS row count, and the current front-row peak bin. |
+| `reset` | `native` or `kiwi` | Clear the selected stream's current/history rows and make that stream active for subsequent injection. |
+| `inject` | `<count> <firstPeakBin> <stepBin> [native\|kiwi]` | Add synthetic rows with one strong peak per row. `count` is capped at the retained waterfall history capacity. Native injection adds one fallback-style waterfall/DSS row per input row; Kiwi injection drives `updateKiwiSdrWaterfallRow()`. |
+| `scrollback` | `<offsetRows>` | Enter waterfall history mode and rebuild the 3D surface using the same offset. |
+| `live` | none | Return to live mode. |
+
+The paused/live-history assertion is: enter `scrollback`, inject another row,
+confirm both `waterfallHistoryRowsAdded` and `dssHistoryRowsAdded` match the
+injected count while `historyOffsetRows` advances and `dssVisiblePeakBin` stays
+on the same paused historical row, then set `scrollback 0` and confirm the newly
+injected peak becomes visible. The total row counts are still returned, but the
+`*RowsAdded` fields are the deterministic assertion surface if live data is also
+arriving between bridge requests.
 
 ### `whoami`
 Identify **this** bridge instance among concurrent bridges (each app process gets

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1982,6 +1982,14 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));  // "testtone on 1000 -6" -> freqHz levelDb
         } else if (cmd == QLatin1String("pan")) {
             action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
+        } else if (cmd == QLatin1String("dss")) {
+            action = tok(1);                  // snapshot | reset | inject | scrollback | live
+            target = tok(2);                  // pan index, optional for snapshot
+            QStringList rest;
+            for (int i = 3; i < p.size(); ++i) {
+                rest << tok(i);
+            }
+            value = rest.join(QLatin1Char(' '));
         } else if (cmd == QLatin1String("qrz")) {
             action = tok(1);  // status | cached | lookup | spottext
             QStringList rest;
@@ -2191,6 +2199,12 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("panmessage requires an action (add|remove|clear|list)"));
         }
         return doPanMessage(action, target, id, title, detail, timeoutMs, tone);
+    }
+    if (cmd == QLatin1String("dss")) {
+        if (action.isEmpty()) {
+            return err(QStringLiteral("dss requires an action (snapshot|reset|inject|scrollback|live)"));
+        }
+        return doDss(action, target.isEmpty() ? selector : target, value);
     }
     if (cmd == QLatin1String("streams"))
         return doStreams(action);
@@ -4833,6 +4847,125 @@ QJsonObject AutomationServer::doPanMessage(const QString& action,
 
     return err(QStringLiteral("unknown panmessage action: ") + action
                + QStringLiteral(" (add|remove|clear|list)"));
+}
+
+QJsonObject AutomationServer::doDss(const QString& action,
+                                    const QString& target,
+                                    const QString& value) const
+{
+    QStringList args = value.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    bool okIndex = false;
+    int panIndex = target.isEmpty() ? 0 : target.toInt(&okIndex);
+    if (!target.isEmpty() && !okIndex) {
+        args.prepend(target);
+        panIndex = 0;
+    }
+
+    QJsonArray available;
+    QWidget* spectrum = panSpectrumWidgetForIndex(panIndex, &available);
+    if (!spectrum) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("no pan with index ") + QString::number(panIndex)},
+            {QStringLiteral("available"), available},
+        };
+    }
+
+    const auto parseStream = [](const QString& text, bool* ok) {
+        const QString s = text.trimmed().toLower();
+        if (s.isEmpty() || s == QLatin1String("native")
+            || s == QLatin1String("flex")) {
+            *ok = true;
+            return false;
+        }
+        if (s == QLatin1String("kiwi") || s == QLatin1String("kiwisdr")) {
+            *ok = true;
+            return true;
+        }
+        *ok = false;
+        return false;
+    };
+
+    QVariantMap out;
+    const QString lower = action.trimmed().toLower();
+    if (lower == QLatin1String("snapshot") || lower == QLatin1String("status")) {
+        if (!QMetaObject::invokeMethod(spectrum, "automationDssSnapshot",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, out))) {
+            return err(QStringLiteral("target pan does not expose automationDssSnapshot"));
+        }
+    } else if (lower == QLatin1String("reset") || lower == QLatin1String("clear")) {
+        bool okStream = false;
+        const bool kiwiStream = parseStream(args.value(0), &okStream);
+        if (!okStream) {
+            return err(QStringLiteral("dss reset stream must be native|kiwi"));
+        }
+        if (!QMetaObject::invokeMethod(spectrum, "automationDssReset",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, out),
+                                       Q_ARG(bool, kiwiStream))) {
+            return err(QStringLiteral("target pan does not expose automationDssReset"));
+        }
+    } else if (lower == QLatin1String("inject")) {
+        if (args.size() < 3) {
+            return err(QStringLiteral(
+                "dss inject requires <pan> <count> <firstPeakBin> <stepBin> [native|kiwi]"));
+        }
+        bool okCount = false;
+        bool okPeak = false;
+        bool okStep = false;
+        const int count = args.value(0).toInt(&okCount);
+        const int firstPeakBin = args.value(1).toInt(&okPeak);
+        const int stepBin = args.value(2).toInt(&okStep);
+        if (!okCount || !okPeak || !okStep) {
+            return err(QStringLiteral("dss inject count/firstPeakBin/stepBin must be integers"));
+        }
+        bool okStream = false;
+        const bool kiwiStream = parseStream(args.value(3), &okStream);
+        if (!okStream) {
+            return err(QStringLiteral("dss inject stream must be native|kiwi"));
+        }
+        if (!QMetaObject::invokeMethod(spectrum, "automationDssInjectRows",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, out),
+                                       Q_ARG(int, count),
+                                       Q_ARG(int, firstPeakBin),
+                                       Q_ARG(int, stepBin),
+                                       Q_ARG(bool, kiwiStream))) {
+            return err(QStringLiteral("target pan does not expose automationDssInjectRows"));
+        }
+    } else if (lower == QLatin1String("scrollback")
+               || lower == QLatin1String("pause")) {
+        bool okOffset = false;
+        const int offsetRows = args.value(0).toInt(&okOffset);
+        if (!okOffset) {
+            return err(QStringLiteral("dss scrollback requires an offset row count"));
+        }
+        if (!QMetaObject::invokeMethod(spectrum, "automationDssSetScrollback",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, out),
+                                       Q_ARG(bool, false),
+                                       Q_ARG(int, offsetRows))) {
+            return err(QStringLiteral("target pan does not expose automationDssSetScrollback"));
+        }
+    } else if (lower == QLatin1String("live")) {
+        if (!QMetaObject::invokeMethod(spectrum, "automationDssSetScrollback",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, out),
+                                       Q_ARG(bool, true),
+                                       Q_ARG(int, 0))) {
+            return err(QStringLiteral("target pan does not expose automationDssSetScrollback"));
+        }
+    } else {
+        return err(QStringLiteral("unknown dss action: ") + action);
+    }
+
+    QJsonObject response = QJsonObject::fromVariantMap(out);
+    response[QStringLiteral("cmd")] = QStringLiteral("dss");
+    response[QStringLiteral("action")] = action;
+    response[QStringLiteral("panIndex")] = panIndex;
+    return response;
 }
 
 // ── Radio-side display-stream inventory / leak detector (#3856) ──────────────

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -4853,11 +4853,40 @@ QJsonObject AutomationServer::doDss(const QString& action,
                                     const QString& target,
                                     const QString& value) const
 {
+    const QString lower = action.trimmed().toLower();
     QStringList args = value.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    bool okIndex = false;
-    int panIndex = target.isEmpty() ? 0 : target.toInt(&okIndex);
-    if (!target.isEmpty() && !okIndex) {
+    QString panTarget = target;
+
+    const auto isStreamToken = [](const QString& text) {
+        const QString s = text.trimmed().toLower();
+        return s == QLatin1String("native")
+            || s == QLatin1String("flex")
+            || s == QLatin1String("kiwi")
+            || s == QLatin1String("kiwisdr");
+    };
+
+    bool targetIsInt = false;
+    if (!target.isEmpty()) {
+        (void)target.toInt(&targetIsInt);
+    }
+    if (targetIsInt && lower == QLatin1String("inject")
+        && (args.size() == 2
+            || (args.size() == 3 && isStreamToken(args.value(2)))
+            || (args.size() == 5 && isStreamToken(args.value(2))))) {
         args.prepend(target);
+        panTarget.clear();
+    } else if (targetIsInt
+               && (lower == QLatin1String("scrollback")
+                   || lower == QLatin1String("pause"))
+               && args.isEmpty()) {
+        args.prepend(target);
+        panTarget.clear();
+    }
+
+    bool okIndex = false;
+    int panIndex = panTarget.isEmpty() ? 0 : panTarget.toInt(&okIndex);
+    if (!panTarget.isEmpty() && !okIndex) {
+        args.prepend(panTarget);
         panIndex = 0;
     }
 
@@ -4888,7 +4917,6 @@ QJsonObject AutomationServer::doDss(const QString& action,
     };
 
     QVariantMap out;
-    const QString lower = action.trimmed().toLower();
     if (lower == QLatin1String("snapshot") || lower == QLatin1String("status")) {
         if (!QMetaObject::invokeMethod(spectrum, "automationDssSnapshot",
                                        Qt::DirectConnection,
@@ -4910,7 +4938,12 @@ QJsonObject AutomationServer::doDss(const QString& action,
     } else if (lower == QLatin1String("inject")) {
         if (args.size() < 3) {
             return err(QStringLiteral(
-                "dss inject requires <pan> <count> <firstPeakBin> <stepBin> [native|kiwi]"));
+                "dss inject requires [pan] <count> <firstPeakBin> <stepBin> "
+                "[native|kiwi [rowLowMhz rowHighMhz]]"));
+        }
+        if (args.size() == 5 || args.size() > 6) {
+            return err(QStringLiteral(
+                "dss inject frame override requires stream plus rowLowMhz rowHighMhz"));
         }
         bool okCount = false;
         bool okPeak = false;
@@ -4926,13 +4959,30 @@ QJsonObject AutomationServer::doDss(const QString& action,
         if (!okStream) {
             return err(QStringLiteral("dss inject stream must be native|kiwi"));
         }
+        double rowLowMhz = -1.0;
+        double rowHighMhz = -1.0;
+        if (args.size() == 6) {
+            if (!kiwiStream) {
+                return err(QStringLiteral("dss inject frame override is only valid for kiwi"));
+            }
+            bool okLow = false;
+            bool okHigh = false;
+            rowLowMhz = args.value(4).toDouble(&okLow);
+            rowHighMhz = args.value(5).toDouble(&okHigh);
+            if (!okLow || !okHigh || rowHighMhz <= rowLowMhz) {
+                return err(QStringLiteral(
+                    "dss inject rowLowMhz/rowHighMhz must be ascending numbers"));
+            }
+        }
         if (!QMetaObject::invokeMethod(spectrum, "automationDssInjectRows",
                                        Qt::DirectConnection,
                                        Q_RETURN_ARG(QVariantMap, out),
                                        Q_ARG(int, count),
                                        Q_ARG(int, firstPeakBin),
                                        Q_ARG(int, stepBin),
-                                       Q_ARG(bool, kiwiStream))) {
+                                       Q_ARG(bool, kiwiStream),
+                                       Q_ARG(double, rowLowMhz),
+                                       Q_ARG(double, rowHighMhz))) {
             return err(QStringLiteral("target pan does not expose automationDssInjectRows"));
         }
     } else if (lower == QLatin1String("scrollback")

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -170,6 +170,12 @@ class QsoRecorder;
 //                                     for deterministic UI screenshots; add
 //                                     accepts tone=info|warning, timed messages
 //                                     expose countdown in snapshots.
+//   dss snapshot|reset|inject|scrollback|live
+//                                  -> automation-only 3D stacked-trace /
+//                                     waterfall scrollback proof surface.
+//                                     Injects synthetic RX rows through the
+//                                     normal SpectrumWidget row paths and reads
+//                                     compact DSS/waterfall counters.
 //   dumpTree (extended)            -> nodes now carry toolTip, and QComboBox
 //                                     nodes carry items[]/currentIndex and pans
 //                                     carry panIndex, all assertable without
@@ -332,6 +338,9 @@ private:
                              const QString& detail,
                              int timeoutMs,
                              const QString& tone) const;
+    QJsonObject doDss(const QString& action,
+                      const QString& target,
+                      const QString& value) const;
     // Radio-side display-stream inventory / leak detector (#3856).
     //   streams        — Layer A: registered pan/wf streams + UDP "orphan"
     //                     streams the radio is still transmitting that we let go.

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -136,6 +136,48 @@ std::array<float, DssRenderer::kCols> reprojectRow(
     return remapped;
 }
 
+std::array<float, DssRenderer::kCols> resampledRow(
+    const QVector<float>& binsDbm,
+    float fallback)
+{
+    std::array<float, DssRenderer::kCols> row;
+    const int n = binsDbm.size();
+    if (n <= 0) {
+        row.fill(fallback);
+        return row;
+    }
+
+    if (n == DssRenderer::kCols) {
+        for (int c = 0; c < DssRenderer::kCols; ++c) {
+            row[c] = std::isfinite(binsDbm[c]) ? binsDbm[c] : fallback;
+        }
+    } else {
+        const double step = static_cast<double>(n) / DssRenderer::kCols;
+        for (int c = 0; c < DssRenderer::kCols; ++c) {
+            int i0 = static_cast<int>(std::floor(c * step));
+            int i1 = static_cast<int>(std::ceil((c + 1) * step));
+            i0 = std::clamp(i0, 0, n - 1);
+            i1 = std::clamp(i1, i0 + 1, n);
+            float mx = std::isfinite(binsDbm[i0]) ? binsDbm[i0] : fallback;
+            for (int i = i0 + 1; i < i1; ++i) {
+                if (std::isfinite(binsDbm[i])) {
+                    mx = std::max(mx, binsDbm[i]);
+                }
+            }
+            row[c] = mx;
+        }
+    }
+
+    std::array<float, DssRenderer::kCols> smoothed = row;
+    for (int c = 0; c < DssRenderer::kCols; ++c) {
+        const float a = row[std::max(0, c - 1)];
+        const float b = row[c];
+        const float d = row[std::min(DssRenderer::kCols - 1, c + 1)];
+        smoothed[c] = 0.25f * a + 0.5f * b + 0.25f * d;
+    }
+    return smoothed;
+}
+
 } // namespace
 
 void DssRenderer::clear()
@@ -144,6 +186,8 @@ void DssRenderer::clear()
     m_count = 0;
     m_dirty = true;
     m_rawHistCount = 0;
+    m_historyWriteRow = 0;
+    m_historyRowCount = 0;
 }
 
 const std::array<float, DssRenderer::kCols>&
@@ -227,6 +271,128 @@ void DssRenderer::pushRow(const QVector<float>& binsDbm)
     m_rows[m_head] = nr;
     m_count = std::min(m_count + 1, kRows);
     m_dirty = true;
+    ++m_rowGeneration;
+}
+
+void DssRenderer::setHistoryCapacityRows(int rows)
+{
+    rows = std::max(0, rows);
+    if (rows == m_historyCapacityRows && historyStorageMatchesCapacity()) {
+        return;
+    }
+
+    m_historyCapacityRows = rows;
+    const int expectedSampleCount = rows * kCols;
+    m_historyRows = QVector<qfloat16>(expectedSampleCount);
+    m_historyRowCenterMhz = QVector<double>(rows, 0.0);
+    m_historyRowBandwidthMhz = QVector<double>(rows, 0.0);
+    m_historyWriteRow = 0;
+    m_historyRowCount = 0;
+}
+
+bool DssRenderer::historyStorageMatchesCapacity() const
+{
+    const int expectedSampleCount = m_historyCapacityRows * kCols;
+    return m_historyRows.size() == expectedSampleCount
+        && m_historyRowCenterMhz.size() == m_historyCapacityRows
+        && m_historyRowBandwidthMhz.size() == m_historyCapacityRows;
+}
+
+void DssRenderer::appendCurrentRowToHistory(double centerMhz, double bandwidthMhz)
+{
+    if (m_historyCapacityRows <= 0 || m_count <= 0) {
+        return;
+    }
+    if (!historyStorageMatchesCapacity()) {
+        setHistoryCapacityRows(m_historyCapacityRows);
+    }
+
+    m_historyWriteRow =
+        (m_historyWriteRow - 1 + m_historyCapacityRows) % m_historyCapacityRows;
+    qfloat16* dst = m_historyRows.data() + m_historyWriteRow * kCols;
+    const auto& row = m_rows[m_head];
+    for (int c = 0; c < kCols; ++c) {
+        dst[c] = qfloat16(row[c]);
+    }
+    m_historyRowCenterMhz[m_historyWriteRow] = centerMhz;
+    m_historyRowBandwidthMhz[m_historyWriteRow] = bandwidthMhz;
+    m_historyRowCount = std::min(m_historyRowCount + 1, m_historyCapacityRows);
+}
+
+void DssRenderer::appendHistoryRow(const QVector<float>& binsDbm,
+                                   double centerMhz, double bandwidthMhz,
+                                   float fallbackDbm)
+{
+    if (m_historyCapacityRows <= 0) {
+        return;
+    }
+    if (!historyStorageMatchesCapacity()) {
+        setHistoryCapacityRows(m_historyCapacityRows);
+    }
+
+    const std::array<float, kCols> row = resampledRow(binsDbm, fallbackDbm);
+    m_historyWriteRow =
+        (m_historyWriteRow - 1 + m_historyCapacityRows) % m_historyCapacityRows;
+    qfloat16* dst = m_historyRows.data() + m_historyWriteRow * kCols;
+    for (int c = 0; c < kCols; ++c) {
+        dst[c] = qfloat16(row[c]);
+    }
+    m_historyRowCenterMhz[m_historyWriteRow] = centerMhz;
+    m_historyRowBandwidthMhz[m_historyWriteRow] = bandwidthMhz;
+    m_historyRowCount = std::min(m_historyRowCount + 1, m_historyCapacityRows);
+}
+
+void DssRenderer::rebuildVisibleFromHistory(int offsetRows,
+                                            double centerMhz,
+                                            double bandwidthMhz,
+                                            float fallbackDbm)
+{
+    if (m_historyCapacityRows <= 0
+        || m_historyRowCount <= 0
+        || !historyStorageMatchesCapacity()) {
+        if (m_historyCapacityRows > 0 && !historyStorageMatchesCapacity()) {
+            setHistoryCapacityRows(m_historyCapacityRows);
+        }
+        m_head = 0;
+        m_count = 0;
+        m_dirty = true;
+        m_rawHistCount = 0;
+        ++m_rowGeneration;
+        return;
+    }
+
+    offsetRows = std::clamp(offsetRows, 0, m_historyRowCount - 1);
+    const int rowsToCopy = std::min(kRows, m_historyRowCount - offsetRows);
+    m_head = 0;
+    m_count = rowsToCopy;
+
+    for (int age = 0; age < rowsToCopy; ++age) {
+        const int historyAge = offsetRows + age;
+        const int historyRing =
+            (m_historyWriteRow + historyAge) % m_historyCapacityRows;
+        const qfloat16* src = m_historyRows.constData() + historyRing * kCols;
+        std::array<float, kCols> row;
+        for (int c = 0; c < kCols; ++c) {
+            row[c] = static_cast<float>(src[c]);
+        }
+
+        const double rowCenterMhz = m_historyRowCenterMhz.value(historyRing, 0.0);
+        const double rowBandwidthMhz =
+            m_historyRowBandwidthMhz.value(historyRing, 0.0);
+        if (rowCenterMhz > 0.0 && rowBandwidthMhz > 0.0
+            && centerMhz > 0.0 && bandwidthMhz > 0.0
+            && (rowCenterMhz != centerMhz || rowBandwidthMhz != bandwidthMhz)) {
+            row = reprojectRow(row,
+                               rowCenterMhz, rowBandwidthMhz,
+                               centerMhz, bandwidthMhz,
+                               fallbackDbm);
+        }
+
+        m_rows[age] = row;
+    }
+
+    m_dirty = true;
+    m_rawHistCount = 0;
     ++m_rowGeneration;
 }
 

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -136,7 +136,7 @@ std::array<float, DssRenderer::kCols> reprojectRow(
     return remapped;
 }
 
-std::array<float, DssRenderer::kCols> resampledRow(
+std::array<float, DssRenderer::kCols> resampledRawRow(
     const QVector<float>& binsDbm,
     float fallback)
 {
@@ -168,12 +168,39 @@ std::array<float, DssRenderer::kCols> resampledRow(
         }
     }
 
+    return row;
+}
+
+std::array<float, DssRenderer::kCols> smoothDssRow(
+    const std::array<float, DssRenderer::kCols>& raw,
+    std::array<float, DssRenderer::kCols>& rawPrev1,
+    std::array<float, DssRenderer::kCols>& rawPrev2,
+    int& rawHistCount,
+    const std::array<float, DssRenderer::kCols>* previousSmoothed)
+{
+    std::array<float, DssRenderer::kCols> row = raw;
+    if (rawHistCount >= 2) {
+        for (int c = 0; c < DssRenderer::kCols; ++c) {
+            row[c] = median3(raw[c], rawPrev1[c], rawPrev2[c]);
+        }
+    }
+
+    rawPrev2 = rawPrev1;
+    rawPrev1 = raw;
+    rawHistCount = std::min(rawHistCount + 1, 2);
+
     std::array<float, DssRenderer::kCols> smoothed = row;
     for (int c = 0; c < DssRenderer::kCols; ++c) {
         const float a = row[std::max(0, c - 1)];
         const float b = row[c];
         const float d = row[std::min(DssRenderer::kCols - 1, c + 1)];
         smoothed[c] = 0.25f * a + 0.5f * b + 0.25f * d;
+    }
+    if (previousSmoothed != nullptr) {
+        for (int c = 0; c < DssRenderer::kCols; ++c) {
+            smoothed[c] = kTemporalAlpha * smoothed[c]
+                + (1.0f - kTemporalAlpha) * (*previousSmoothed)[c];
+        }
     }
     return smoothed;
 }
@@ -188,6 +215,7 @@ void DssRenderer::clear()
     m_rawHistCount = 0;
     m_historyWriteRow = 0;
     m_historyRowCount = 0;
+    resetHistorySmoothing();
 }
 
 const std::array<float, DssRenderer::kCols>&
@@ -199,73 +227,12 @@ DssRenderer::rowAt(int age) const
 
 void DssRenderer::pushRow(const QVector<float>& binsDbm)
 {
-    const int n = binsDbm.size();
-    std::array<float, kCols> nr;
-
-    if (n <= 0) {
-        nr.fill(-200.0f);
-    } else {
-        std::array<float, kCols> raw;
-        if (n == kCols) {
-            for (int c = 0; c < kCols; ++c) {
-                raw[c] = binsDbm[c];
-            }
-        } else {
-            const double step = static_cast<double>(n) / kCols;
-            for (int c = 0; c < kCols; ++c) {
-                // Peak-preserving downsample: take the strongest bin in the source
-                // span so signals survive as ridges. Upsampling (n < kCols)
-                // collapses the span to a single source bin.
-                int i0 = static_cast<int>(std::floor(c * step));
-                int i1 = static_cast<int>(std::ceil((c + 1) * step));
-                i0 = std::clamp(i0, 0, n - 1);
-                i1 = std::clamp(i1, i0 + 1, n);
-                float mx = binsDbm[i0];
-                for (int i = i0 + 1; i < i1; ++i) {
-                    mx = std::max(mx, binsDbm[i]);
-                }
-                raw[c] = mx;
-            }
-        }
-
-        // Temporal median-of-3 impulse rejection. A strong broadband
-        // interference burst lasts only ~1 FFT frame but, once stored, becomes a
-        // full-height "wall" that recedes (and flickers) across the whole
-        // surface. As the outlier of {this, prev, prev2}, such a 1-frame spike
-        // is discarded here before it ever enters the height history. Steady
-        // signals are the median of ~equal values, so they pass through
-        // unchanged (this is an outlier rejector, not a low-pass).
-        if (m_rawHistCount >= 2) {
-            for (int c = 0; c < kCols; ++c) {
-                nr[c] = median3(raw[c], m_rawPrev1[c], m_rawPrev2[c]);
-            }
-        } else {
-            nr = raw;
-        }
-        // Shift the raw history (store the ORIGINAL raw row, not the median).
-        m_rawPrev2 = m_rawPrev1;
-        m_rawPrev1 = raw;
-        m_rawHistCount = std::min(m_rawHistCount + 1, 2);
-
-        // Spatial 3-tap low-pass — the textbook cure for the peak-detector
-        // "comb" striping (a video-bandwidth analogue).
-        std::array<float, kCols> sm = nr;
-        for (int c = 0; c < kCols; ++c) {
-            const float a = nr[std::max(0, c - 1)];
-            const float b = nr[c];
-            const float d = nr[std::min(kCols - 1, c + 1)];
-            sm[c] = 0.25f * a + 0.5f * b + 0.25f * d;
-        }
-        nr = sm;
-    }
-
-    // Temporal IIR against the current newest row → fluid scroll + denoise.
-    if (m_count > 0) {
-        const auto& prev = m_rows[m_head];
-        for (int c = 0; c < kCols; ++c) {
-            nr[c] = kTemporalAlpha * nr[c] + (1.0f - kTemporalAlpha) * prev[c];
-        }
-    }
+    const std::array<float, kCols> raw = resampledRawRow(binsDbm, -200.0f);
+    const std::array<float, kCols>* previous = m_count > 0
+        ? &m_rows[m_head]
+        : nullptr;
+    const std::array<float, kCols> nr =
+        smoothDssRow(raw, m_rawPrev1, m_rawPrev2, m_rawHistCount, previous);
 
     m_head = (m_head - 1 + kRows) % kRows;
     m_rows[m_head] = nr;
@@ -288,6 +255,7 @@ void DssRenderer::setHistoryCapacityRows(int rows)
     m_historyRowBandwidthMhz = QVector<double>(rows, 0.0);
     m_historyWriteRow = 0;
     m_historyRowCount = 0;
+    resetHistorySmoothing();
 }
 
 bool DssRenderer::historyStorageMatchesCapacity() const
@@ -298,25 +266,11 @@ bool DssRenderer::historyStorageMatchesCapacity() const
         && m_historyRowBandwidthMhz.size() == m_historyCapacityRows;
 }
 
-void DssRenderer::appendCurrentRowToHistory(double centerMhz, double bandwidthMhz)
+void DssRenderer::resetHistorySmoothing()
 {
-    if (m_historyCapacityRows <= 0 || m_count <= 0) {
-        return;
-    }
-    if (!historyStorageMatchesCapacity()) {
-        setHistoryCapacityRows(m_historyCapacityRows);
-    }
-
-    m_historyWriteRow =
-        (m_historyWriteRow - 1 + m_historyCapacityRows) % m_historyCapacityRows;
-    qfloat16* dst = m_historyRows.data() + m_historyWriteRow * kCols;
-    const auto& row = m_rows[m_head];
-    for (int c = 0; c < kCols; ++c) {
-        dst[c] = qfloat16(row[c]);
-    }
-    m_historyRowCenterMhz[m_historyWriteRow] = centerMhz;
-    m_historyRowBandwidthMhz[m_historyWriteRow] = bandwidthMhz;
-    m_historyRowCount = std::min(m_historyRowCount + 1, m_historyCapacityRows);
+    m_historyRawPrev1 = {};
+    m_historyRawPrev2 = {};
+    m_historyRawHistCount = 0;
 }
 
 void DssRenderer::appendHistoryRow(const QVector<float>& binsDbm,
@@ -330,7 +284,19 @@ void DssRenderer::appendHistoryRow(const QVector<float>& binsDbm,
         setHistoryCapacityRows(m_historyCapacityRows);
     }
 
-    const std::array<float, kCols> row = resampledRow(binsDbm, fallbackDbm);
+    const std::array<float, kCols> raw = resampledRawRow(binsDbm, fallbackDbm);
+    std::array<float, kCols> previousRow;
+    const std::array<float, kCols>* previous = nullptr;
+    if (m_historyRowCount > 0) {
+        const qfloat16* src = m_historyRows.constData() + m_historyWriteRow * kCols;
+        for (int c = 0; c < kCols; ++c) {
+            previousRow[c] = static_cast<float>(src[c]);
+        }
+        previous = &previousRow;
+    }
+    const std::array<float, kCols> row =
+        smoothDssRow(raw, m_historyRawPrev1, m_historyRawPrev2,
+                     m_historyRawHistCount, previous);
     m_historyWriteRow =
         (m_historyWriteRow - 1 + m_historyCapacityRows) % m_historyCapacityRows;
     qfloat16* dst = m_historyRows.data() + m_historyWriteRow * kCols;

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -4,6 +4,7 @@
 #include <QImage>
 #include <QSize>
 #include <QVector>
+#include <QtCore/qfloat16.h>
 
 #include <array>
 #include <functional>
@@ -44,6 +45,16 @@ public:
     // Push one freshly-decoded FFT row (any bin count, dBm). Peak-preserving
     // downsample to kCols and store it as the newest (front) trace.
     void pushRow(const QVector<float>& binsDbm);
+    void setHistoryCapacityRows(int rows);
+    int historyCapacityRows() const { return m_historyCapacityRows; }
+    int historyRowCount() const { return m_historyRowCount; }
+    void appendHistoryRow(const QVector<float>& binsDbm,
+                          double centerMhz, double bandwidthMhz,
+                          float fallbackDbm);
+    void appendCurrentRowToHistory(double centerMhz, double bandwidthMhz);
+    void rebuildVisibleFromHistory(int offsetRows,
+                                   double centerMhz, double bandwidthMhz,
+                                   float fallbackDbm);
     void reprojectFrequencyFrame(double oldCenterMhz, double oldBandwidthMhz,
                                  double newCenterMhz, double newBandwidthMhz,
                                  float fallbackDbm);
@@ -86,6 +97,7 @@ public:
     quint64 generation() const { return m_generation; }
 
 private:
+    bool historyStorageMatchesCapacity() const;
     void rebuild(const QSize& px, int scaleStripPx, float floorDbm,
                  float rangeDb, float zCurve, const PaletteFn& palette,
                  const QColor& bgFill);
@@ -106,6 +118,16 @@ private:
     std::array<float, kCols> m_rawPrev1{};
     std::array<float, kCols> m_rawPrev2{};
     int m_rawHistCount = 0;
+
+    // Retained scrollback store. This is intentionally separate from the
+    // 96-row visible surface above: waterfall history can be much deeper, and
+    // the visible 3D mesh is rebuilt from this ring only while viewing history.
+    QVector<qfloat16> m_historyRows;      // flat [history row][kCols]
+    QVector<double> m_historyRowCenterMhz;
+    QVector<double> m_historyRowBandwidthMhz;
+    int m_historyCapacityRows = 0;
+    int m_historyWriteRow = 0;            // ring index of newest retained row
+    int m_historyRowCount = 0;
 
     // Cache + the parameters it was built for (rebuild on any change).
     QImage  m_cache;

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -51,7 +51,6 @@ public:
     void appendHistoryRow(const QVector<float>& binsDbm,
                           double centerMhz, double bandwidthMhz,
                           float fallbackDbm);
-    void appendCurrentRowToHistory(double centerMhz, double bandwidthMhz);
     void rebuildVisibleFromHistory(int offsetRows,
                                    double centerMhz, double bandwidthMhz,
                                    float fallbackDbm);
@@ -98,6 +97,7 @@ public:
 
 private:
     bool historyStorageMatchesCapacity() const;
+    void resetHistorySmoothing();
     void rebuild(const QSize& px, int scaleStripPx, float floorDbm,
                  float rangeDb, float zCurve, const PaletteFn& palette,
                  const QColor& bgFill);
@@ -128,6 +128,9 @@ private:
     int m_historyCapacityRows = 0;
     int m_historyWriteRow = 0;            // ring index of newest retained row
     int m_historyRowCount = 0;
+    std::array<float, kCols> m_historyRawPrev1{};
+    std::array<float, kCols> m_historyRawPrev2{};
+    int m_historyRawHistCount = 0;
 
     // Cache + the parameters it was built for (rebuild on any change).
     QImage  m_cache;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1889,8 +1889,11 @@ MainWindow::MainWindow(QWidget* parent)
     if (m_titleBar) m_titleBar->setDiscovering(true);
     m_discovery.startListening();
 
+    const bool automationNoAutoConnect =
+        qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_AUTOCONNECT");
     const bool autoConnectToLastRadio =
-        AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() == "True";
+        !automationNoAutoConnect
+        && AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() == "True";
     const QString startupLastSerial =
         AppSettings::instance().value("LastConnectedRadioSerial").toString();
     if (!startupLastSerial.isEmpty() && autoConnectToLastRadio) {
@@ -1904,6 +1907,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(m_connPanel, &ConnectionPanel::routedRadioFound,
             this, [this](const RadioInfo& info) {
         if (m_userDisconnected || m_radioModel.isConnected()) return;
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_AUTOCONNECT")) {
+            return;
+        }
         if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
             return;
         const QString lastSerial = AppSettings::instance()

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -241,6 +241,9 @@ void MainWindow::wireDiscovery()
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
             this, [this](const RadioInfo& info) {
         if (m_userDisconnected) return;
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_AUTOCONNECT")) {
+            return;
+        }
         if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
             return;
         const QString lastSerial = AppSettings::instance()

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -874,6 +874,8 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("visible")] = isVisible();
     m[QStringLiteral("kiwiActive")] = m_kiwiSdrWaterfallActive;
     m[QStringLiteral("live")] = m_wfLive;
+    m[QStringLiteral("centerMhz")] = m_centerMhz;
+    m[QStringLiteral("bandwidthMhz")] = m_bandwidthMhz;
     m[QStringLiteral("historyOffsetRows")] = m_wfHistoryOffsetRows;
     m[QStringLiteral("maxHistoryOffsetRows")] = maxWaterfallHistoryOffsetRows();
     m[QStringLiteral("waterfallRows")] = m_waterfall.height();
@@ -952,7 +954,9 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
 QVariantMap SpectrumWidget::automationDssInjectRows(int count,
                                                     int firstPeakBin,
                                                     int stepBin,
-                                                    bool kiwiStream)
+                                                    bool kiwiStream,
+                                                    double rowLowMhz,
+                                                    double rowHighMhz)
 {
     if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
         return QVariantMap{
@@ -992,6 +996,14 @@ QVariantMap SpectrumWidget::automationDssInjectRows(int count,
 
     const int waterfallHistoryRowsBefore = m_wfHistoryRowCount;
     const int dssHistoryRowsBefore = m_dss.historyRowCount();
+    const bool hasKiwiFrameOverride =
+        kiwiStream && rowLowMhz >= 0.0 && rowHighMhz > rowLowMhz;
+    const double kiwiRowLowMhz = hasKiwiFrameOverride
+        ? rowLowMhz
+        : m_centerMhz - m_bandwidthMhz * 0.5;
+    const double kiwiRowHighMhz = hasKiwiFrameOverride
+        ? rowHighMhz
+        : m_centerMhz + m_bandwidthMhz * 0.5;
     for (int i = 0; i < count; ++i) {
         QVector<float> bins(DssRenderer::kCols, -120.0f);
         const qint64 peakValue = static_cast<qint64>(firstPeakBin)
@@ -1002,13 +1014,10 @@ QVariantMap SpectrumWidget::automationDssInjectRows(int count,
 
         if (kiwiStream) {
             updateKiwiSdrWaterfallRow(bins,
-                                      m_centerMhz - m_bandwidthMhz * 0.5,
-                                      m_centerMhz + m_bandwidthMhz * 0.5,
+                                      kiwiRowLowMhz,
+                                      kiwiRowHighMhz,
                                       static_cast<quint32>(i));
         } else {
-            if (m_wfLive) {
-                m_dss.pushRow(bins);
-            }
             pushWaterfallRow(bins, m_waterfall.width());
         }
     }
@@ -1024,6 +1033,19 @@ QVariantMap SpectrumWidget::automationDssInjectRows(int count,
     snap[QStringLiteral("stream")] = kiwiStream
         ? QStringLiteral("kiwi")
         : QStringLiteral("native");
+    if (kiwiStream) {
+        snap[QStringLiteral("rowLowMhz")] = kiwiRowLowMhz;
+        snap[QStringLiteral("rowHighMhz")] = kiwiRowHighMhz;
+        const double viewLowMhz = m_centerMhz - m_bandwidthMhz * 0.5;
+        const double viewHighMhz = m_centerMhz + m_bandwidthMhz * 0.5;
+        const double overlapMhz = std::max(
+            0.0,
+            std::min(kiwiRowHighMhz, viewHighMhz)
+                - std::max(kiwiRowLowMhz, viewLowMhz));
+        snap[QStringLiteral("viewCoverage")] = m_bandwidthMhz > 0.0
+            ? overlapMhz / m_bandwidthMhz
+            : 0.0;
+    }
     return snap;
 }
 
@@ -3440,20 +3462,22 @@ void SpectrumWidget::appendDssHistoryRow(const QVector<float>& binsDbm,
                            dssHistoryFallbackDbm());
 }
 
-void SpectrumWidget::appendLatestDssRowToHistory(double frameCenterMhz,
+void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
+                                           double frameCenterMhz,
+                                           double frameBandwidthMhz,
+                                           bool updateLiveSurface)
+{
+    // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
+    if (m_wfLive && updateLiveSurface) {
+        m_dss.pushRow(binsDbm);
+    }
+    appendDssHistoryRow(binsDbm, frameCenterMhz, frameBandwidthMhz);
+}
+
+void SpectrumWidget::appendLatestDssWaterfallRow(double frameCenterMhz,
                                                  double frameBandwidthMhz)
 {
-    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
-        ? frameCenterMhz
-        : m_centerMhz;
-    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
-        ? frameBandwidthMhz
-        : m_bandwidthMhz;
-    if (m_dss.hasData()) {
-        m_dss.appendCurrentRowToHistory(stampCenterMhz, stampBandwidthMhz);
-        return;
-    }
-    appendDssHistoryRow(displaySpectrumBins(), stampCenterMhz, stampBandwidthMhz);
+    appendDssWaterfallRow(displaySpectrumBins(), frameCenterMhz, frameBandwidthMhz);
 }
 
 void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
@@ -3744,7 +3768,7 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
         const float dssFallback = kiwiStream
             ? kKiwiSdrWaterfallMinDbm
             : m_refLevel - m_dynamicRange;
-        if (m_wfLive) {
+        if (m_wfLive || m_dss.historyRowCount() <= 0) {
             m_dss.reprojectFrequencyFrame(oldCenterMhz, oldBandwidthMhz,
                                           newCenterMhz, newBandwidthMhz,
                                           dssFallback);
@@ -5337,15 +5361,6 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     }
     m_bins = *spectrumBins;
 
-    // Feed the rolling history every frame (not only in 3D) so toggling to 3D
-    // shows a populated surface immediately instead of filling over ~96 frames.
-    // The resample is cheap; the renderer only rebuilds its cache when the 3D
-    // surface is drawn. KiwiSDR feeds via updateKiwiSdrWaterfallRow() instead.
-    // Raw bins (renderer does its own spatial/temporal smoothing + impulse reject).
-    if (!m_kiwiSdrWaterfallActive && m_wfLive && !m_bins.isEmpty()) {
-        m_dss.pushRow(m_bins);
-    }
-
     if (!m_kiwiSdrWaterfallActive) {
         // ── Live noise floor measurement (two-pass trimmed mean) ─────────
         // Same technique as the waterfall auto-black: compute the mean of ALL
@@ -5605,11 +5620,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
 
         appendHistoryRow(interpolatedRow.constData(), nowMs);
-        if (m_wfLive) {
-            appendLatestDssRowToHistory();
-        } else {
-            appendDssHistoryRow(displaySpectrumBins());
-        }
+        appendLatestDssWaterfallRow();
         if (m_wfLive) {
             appendVisibleRow(interpolatedRow.constData());
         } else {
@@ -5906,7 +5917,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     // waterfall below uses decoded bins so narrow Kiwi carriers stay sharp.
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
     bool appendedKiwiDssHistory = false;
-    if (m_kiwiSdrWaterfallActive && rowHasUsableTraceCoverage) {
+    if (m_kiwiSdrWaterfallActive) {
         // 3DSS rows must be in the visible panadapter frequency frame. Raw Kiwi
         // rows often span a wider quantized server window, so feeding them
         // directly makes the stacked trace drift away from the remapped waterfall.
@@ -5914,12 +5925,8 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             smoothedBins, DssRenderer::kCols, rowCenterMhz, rowBandwidthMhz,
             m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
         if (!kiwiDssTrace.isEmpty()) {
-            if (m_wfLive) {
-                m_dss.pushRow(kiwiDssTrace);
-                appendLatestDssRowToHistory();
-            } else {
-                appendDssHistoryRow(kiwiDssTrace);
-            }
+            appendDssWaterfallRow(kiwiDssTrace, -1.0, -1.0,
+                                  rowHasUsableTraceCoverage);
             appendedKiwiDssHistory = true;
         }
     }
@@ -6007,7 +6014,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
         }
     }
     if (m_kiwiSdrWaterfallActive && !appendedKiwiDssHistory) {
-        appendDssHistoryRow(QVector<float>{});
+        appendDssWaterfallRow(QVector<float>{}, -1.0, -1.0, false);
     }
     pushKiwiSdrWaterfallRow(binsDbm, destWidth,
                             rowCenterMhz, rowBandwidthMhz);
@@ -8310,11 +8317,7 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     }
 
     appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch());
-    if (m_wfLive) {
-        appendLatestDssRowToHistory();
-    } else {
-        appendDssHistoryRow(bins);
-    }
+    appendDssWaterfallRow(bins);
     if (m_wfLive) {
         appendVisibleRow(scanline.constData());
     } else {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -866,6 +866,192 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     return m;
 }
 
+QVariantMap SpectrumWidget::automationDssSnapshot() const
+{
+    QVariantMap m;
+    m[QStringLiteral("ok")] = true;
+    m[QStringLiteral("panIndex")] = m_panIndex;
+    m[QStringLiteral("visible")] = isVisible();
+    m[QStringLiteral("kiwiActive")] = m_kiwiSdrWaterfallActive;
+    m[QStringLiteral("live")] = m_wfLive;
+    m[QStringLiteral("historyOffsetRows")] = m_wfHistoryOffsetRows;
+    m[QStringLiteral("maxHistoryOffsetRows")] = maxWaterfallHistoryOffsetRows();
+    m[QStringLiteral("waterfallRows")] = m_waterfall.height();
+    m[QStringLiteral("waterfallHistoryRows")] = m_wfHistoryRowCount;
+    m[QStringLiteral("waterfallHistoryCapacityRows")] =
+        m_waterfallHistory.isNull() ? 0 : m_waterfallHistory.height();
+    m[QStringLiteral("dssVisibleRows")] = m_dss.rowCount();
+    m[QStringLiteral("dssHistoryRows")] = m_dss.historyRowCount();
+    m[QStringLiteral("dssHistoryCapacityRows")] = m_dss.historyCapacityRows();
+
+    int peakBin = -1;
+    float peakDbm = -1000.0f;
+    if (m_dss.rowCount() > 0) {
+        const float* row = m_dss.rowDataRing(m_dss.headRing());
+        for (int c = 0; c < m_dss.cols(); ++c) {
+            if (peakBin < 0 || row[c] > peakDbm) {
+                peakBin = c;
+                peakDbm = row[c];
+            }
+        }
+    }
+    m[QStringLiteral("dssVisiblePeakBin")] = peakBin;
+    m[QStringLiteral("dssVisiblePeakDbm")] = peakDbm;
+    return m;
+}
+
+QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
+{
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        return QVariantMap{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), QStringLiteral("AETHER_AUTOMATION is not enabled")},
+        };
+    }
+
+    const int desiredWidth = !m_waterfall.isNull()
+        ? m_waterfall.width()
+        : std::max(512, width());
+    const int chromeH = freqScaleH() + DIVIDER_H;
+    const int desiredHeight = !m_waterfall.isNull()
+        ? m_waterfall.height()
+        : std::max(96, static_cast<int>(
+              std::max(160, height() - chromeH) * (1.0f - m_spectrumFrac)));
+
+    m_nativeWaterfallState = WaterfallStreamState{};
+    m_kiwiWaterfallState = WaterfallStreamState{};
+    m_kiwiProfileWaterfallStates.clear();
+    m_kiwiSdrWaterfallAvailable = kiwiStream;
+    m_kiwiSdrWaterfallActive = kiwiStream;
+    resetCurrentWaterfallRowsForSize(
+        QSize(desiredWidth, desiredHeight),
+        QSize(desiredWidth, waterfallHistoryCapacityRows()));
+    clearCurrentWaterfallRows();
+    m_kiwiSdrWaterfallAvailable = kiwiStream;
+    m_kiwiSdrWaterfallActive = kiwiStream;
+    m_hasNativeWaterfall = !kiwiStream;
+    m_lastNativeTileMs = m_hasNativeWaterfall
+        ? QDateTime::currentMSecsSinceEpoch()
+        : 0;
+    m_waterfallFallbackActive = false;
+    m_nextFallbackWaterfallRowMs = 0;
+    m_nativeWaterfallFallbackHoldUntilMs = m_hasNativeWaterfall
+        ? m_lastNativeTileMs + 60'000
+        : 0;
+    m_wfBlankerRingCount = 0;
+    m_wfBlankerRingIdx = 0;
+    m_wfLastGoodRow.clear();
+    resetDssUploadState();
+    update();
+
+    QVariantMap snap = automationDssSnapshot();
+    snap[QStringLiteral("reset")] = true;
+    return snap;
+}
+
+QVariantMap SpectrumWidget::automationDssInjectRows(int count,
+                                                    int firstPeakBin,
+                                                    int stepBin,
+                                                    bool kiwiStream)
+{
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        return QVariantMap{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), QStringLiteral("AETHER_AUTOMATION is not enabled")},
+        };
+    }
+    if (count <= 0) {
+        return QVariantMap{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), QStringLiteral("row count must be positive")},
+        };
+    }
+    const int maxRows = waterfallHistoryCapacityRows();
+    if (count > maxRows) {
+        return QVariantMap{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("row count exceeds retained waterfall history capacity")},
+            {QStringLiteral("maxRows"), maxRows},
+        };
+    }
+
+    if (m_waterfall.isNull() || m_waterfall.width() <= 0 || m_waterfall.height() <= 1) {
+        const QVariantMap reset = automationDssReset(kiwiStream);
+        if (!reset.value(QStringLiteral("ok")).toBool()) {
+            return reset;
+        }
+    }
+
+    if (kiwiStream) {
+        setKiwiSdrWaterfallAvailable(true);
+        setKiwiSdrWaterfallActive(true);
+    } else if (m_kiwiSdrWaterfallActive) {
+        setKiwiSdrWaterfallActive(false);
+    }
+
+    const int waterfallHistoryRowsBefore = m_wfHistoryRowCount;
+    const int dssHistoryRowsBefore = m_dss.historyRowCount();
+    for (int i = 0; i < count; ++i) {
+        QVector<float> bins(DssRenderer::kCols, -120.0f);
+        const qint64 peakValue = static_cast<qint64>(firstPeakBin)
+            + static_cast<qint64>(i) * static_cast<qint64>(stepBin);
+        const int peak = static_cast<int>(
+            std::clamp<qint64>(peakValue, 0, DssRenderer::kCols - 1));
+        bins[peak] = -30.0f;
+
+        if (kiwiStream) {
+            updateKiwiSdrWaterfallRow(bins,
+                                      m_centerMhz - m_bandwidthMhz * 0.5,
+                                      m_centerMhz + m_bandwidthMhz * 0.5,
+                                      static_cast<quint32>(i));
+        } else {
+            if (m_wfLive) {
+                m_dss.pushRow(bins);
+            }
+            pushWaterfallRow(bins, m_waterfall.width());
+        }
+    }
+
+    QVariantMap snap = automationDssSnapshot();
+    snap[QStringLiteral("injectedRows")] = count;
+    snap[QStringLiteral("waterfallHistoryRowsBefore")] = waterfallHistoryRowsBefore;
+    snap[QStringLiteral("waterfallHistoryRowsAdded")] =
+        m_wfHistoryRowCount - waterfallHistoryRowsBefore;
+    snap[QStringLiteral("dssHistoryRowsBefore")] = dssHistoryRowsBefore;
+    snap[QStringLiteral("dssHistoryRowsAdded")] =
+        m_dss.historyRowCount() - dssHistoryRowsBefore;
+    snap[QStringLiteral("stream")] = kiwiStream
+        ? QStringLiteral("kiwi")
+        : QStringLiteral("native");
+    return snap;
+}
+
+QVariantMap SpectrumWidget::automationDssSetScrollback(bool live,
+                                                       int offsetRows)
+{
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        return QVariantMap{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), QStringLiteral("AETHER_AUTOMATION is not enabled")},
+        };
+    }
+
+    if (live) {
+        setWaterfallLive(true);
+    } else {
+        m_wfLive = false;
+        m_wfHistoryOffsetRows =
+            std::clamp(offsetRows, 0, maxWaterfallHistoryOffsetRows());
+        rebuildWaterfallViewport();
+        markOverlayDirty();
+    }
+
+    QVariantMap snap = automationDssSnapshot();
+    snap[QStringLiteral("scrollbackSet")] = true;
+    return snap;
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
@@ -3204,6 +3390,7 @@ void SpectrumWidget::ensureWaterfallHistory()
     }
 
     if (m_waterfallHistory.size() == desiredSize) {
+        m_dss.setHistoryCapacityRows(desiredSize.height());
         return;
     }
 
@@ -3229,6 +3416,44 @@ void SpectrumWidget::ensureWaterfallHistory()
         m_wfLive = true;
     }
     m_waterfallHistory = newHistory;
+    m_dss.setHistoryCapacityRows(desiredSize.height());
+}
+
+float SpectrumWidget::dssHistoryFallbackDbm() const
+{
+    return m_kiwiSdrWaterfallActive
+        ? kKiwiSdrWaterfallMinDbm
+        : m_refLevel - m_dynamicRange;
+}
+
+void SpectrumWidget::appendDssHistoryRow(const QVector<float>& binsDbm,
+                                         double frameCenterMhz,
+                                         double frameBandwidthMhz)
+{
+    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
+        ? frameCenterMhz
+        : m_centerMhz;
+    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
+        ? frameBandwidthMhz
+        : m_bandwidthMhz;
+    m_dss.appendHistoryRow(binsDbm, stampCenterMhz, stampBandwidthMhz,
+                           dssHistoryFallbackDbm());
+}
+
+void SpectrumWidget::appendLatestDssRowToHistory(double frameCenterMhz,
+                                                 double frameBandwidthMhz)
+{
+    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
+        ? frameCenterMhz
+        : m_centerMhz;
+    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
+        ? frameBandwidthMhz
+        : m_bandwidthMhz;
+    if (m_dss.hasData()) {
+        m_dss.appendCurrentRowToHistory(stampCenterMhz, stampBandwidthMhz);
+        return;
+    }
+    appendDssHistoryRow(displaySpectrumBins(), stampCenterMhz, stampBandwidthMhz);
 }
 
 void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
@@ -3427,6 +3652,20 @@ void SpectrumWidget::rebuildWaterfallViewport()
     rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
 }
 
+void SpectrumWidget::rebuildDssViewportFromHistory()
+{
+    rebuildDssViewportFromHistoryForFrame(m_centerMhz, m_bandwidthMhz);
+}
+
+void SpectrumWidget::rebuildDssViewportFromHistoryForFrame(double centerMhz,
+                                                           double bandwidthMhz)
+{
+    m_dss.rebuildVisibleFromHistory(m_wfHistoryOffsetRows,
+                                    centerMhz, bandwidthMhz,
+                                    dssHistoryFallbackDbm());
+    resetDssUploadState();
+}
+
 void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
                                                       double bandwidthMhz)
 {
@@ -3464,6 +3703,9 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
 #endif
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallRebuild();
+    if (!m_wfLive) {
+        rebuildDssViewportFromHistoryForFrame(centerMhz, bandwidthMhz);
+    }
     update();
 }
 
@@ -3477,6 +3719,7 @@ void SpectrumWidget::setWaterfallLive(bool live)
     }
     m_wfLive = live;
     rebuildWaterfallViewport();
+    rebuildDssViewportFromHistory();
     markOverlayDirty();
 }
 
@@ -3501,9 +3744,13 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
         const float dssFallback = kiwiStream
             ? kKiwiSdrWaterfallMinDbm
             : m_refLevel - m_dynamicRange;
-        m_dss.reprojectFrequencyFrame(oldCenterMhz, oldBandwidthMhz,
-                                      newCenterMhz, newBandwidthMhz,
-                                      dssFallback);
+        if (m_wfLive) {
+            m_dss.reprojectFrequencyFrame(oldCenterMhz, oldBandwidthMhz,
+                                          newCenterMhz, newBandwidthMhz,
+                                          dssFallback);
+        } else {
+            rebuildDssViewportFromHistoryForFrame(newCenterMhz, newBandwidthMhz);
+        }
         resetDssUploadState();
     };
 
@@ -3639,12 +3886,14 @@ void SpectrumWidget::resetCurrentWaterfallRowsForSize(
         m_wfHistoryTimestamps = QVector<qint64>(desiredHistorySize.height(), 0);
         m_wfHistoryRowCenterMhz = QVector<double>(desiredHistorySize.height(), 0.0);
         m_wfHistoryRowBwMhz = QVector<double>(desiredHistorySize.height(), 0.0);
+        m_dss.setHistoryCapacityRows(desiredHistorySize.height());
     } else {
         m_waterfallHistory = QImage();
         m_waterfallHistoryStreamSizeHint = QSize();
         m_wfHistoryTimestamps.clear();
         m_wfHistoryRowCenterMhz.clear();
         m_wfHistoryRowBwMhz.clear();
+        m_dss.setHistoryCapacityRows(0);
     }
 
     clearCurrentWaterfallRows();
@@ -5093,7 +5342,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
     // The resample is cheap; the renderer only rebuilds its cache when the 3D
     // surface is drawn. KiwiSDR feeds via updateKiwiSdrWaterfallRow() instead.
     // Raw bins (renderer does its own spatial/temporal smoothing + impulse reject).
-    if (!m_kiwiSdrWaterfallActive && !m_bins.isEmpty()) {
+    if (!m_kiwiSdrWaterfallActive && m_wfLive && !m_bins.isEmpty()) {
         m_dss.pushRow(m_bins);
     }
 
@@ -5357,6 +5606,11 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
 
         appendHistoryRow(interpolatedRow.constData(), nowMs);
         if (m_wfLive) {
+            appendLatestDssRowToHistory();
+        } else {
+            appendDssHistoryRow(displaySpectrumBins());
+        }
+        if (m_wfLive) {
             appendVisibleRow(interpolatedRow.constData());
         } else {
             rebuildWaterfallViewport();
@@ -5604,6 +5858,10 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     if (destWidth <= 0) {
         return;
     }
+    const int destHeight = m_waterfall.height();
+    if (destHeight <= 1) {
+        return;
+    }
 
     double rowLowMhz = lowFreqMhz;
     double rowHighMhz = highFreqMhz;
@@ -5614,6 +5872,9 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     const double rowBandwidthMhz = rowHighMhz - rowLowMhz;
     const double centerToleranceMhz = std::max(1.0e-9, rowBandwidthMhz * 1.0e-6);
     const double bandwidthToleranceMhz = std::max(1.0e-9, rowBandwidthMhz * 1.0e-6);
+    if (m_kiwiSdrWaterfallActive) {
+        ensureWaterfallHistory();
+    }
     const bool sameWaterfallFrame = m_kiwiSdrLastWaterfallFrameValid
         && std::abs(rowCenterMhz - m_kiwiSdrLastWaterfallCenterMhz) <= centerToleranceMhz
         && std::abs(rowBandwidthMhz - m_kiwiSdrLastWaterfallBandwidthMhz) <= bandwidthToleranceMhz;
@@ -5644,6 +5905,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     // Keep the trace/3DSS smoothing local to those consumers; the scrolling
     // waterfall below uses decoded bins so narrow Kiwi carriers stay sharp.
     const QVector<float> smoothedBins = smoothKiwiSdrWaterfallBins(binsDbm);
+    bool appendedKiwiDssHistory = false;
     if (m_kiwiSdrWaterfallActive && rowHasUsableTraceCoverage) {
         // 3DSS rows must be in the visible panadapter frequency frame. Raw Kiwi
         // rows often span a wider quantized server window, so feeding them
@@ -5652,7 +5914,13 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
             smoothedBins, DssRenderer::kCols, rowCenterMhz, rowBandwidthMhz,
             m_centerMhz, m_bandwidthMhz, kKiwiSdrWaterfallMinDbm);
         if (!kiwiDssTrace.isEmpty()) {
-            m_dss.pushRow(kiwiDssTrace);
+            if (m_wfLive) {
+                m_dss.pushRow(kiwiDssTrace);
+                appendLatestDssRowToHistory();
+            } else {
+                appendDssHistoryRow(kiwiDssTrace);
+            }
+            appendedKiwiDssHistory = true;
         }
     }
     if (m_kiwiSdrWaterfallActive && destWidth > 0 && rowHasUsableTraceCoverage) {
@@ -5737,6 +6005,9 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
                 updateAutoSquelchFromBins(m_kiwiSdrFftTrace);
             }
         }
+    }
+    if (m_kiwiSdrWaterfallActive && !appendedKiwiDssHistory) {
+        appendDssHistoryRow(QVector<float>{});
     }
     pushKiwiSdrWaterfallRow(binsDbm, destWidth,
                             rowCenterMhz, rowBandwidthMhz);
@@ -8039,6 +8310,11 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     }
 
     appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch());
+    if (m_wfLive) {
+        appendLatestDssRowToHistory();
+    } else {
+        appendDssHistoryRow(bins);
+    }
     if (m_wfLive) {
         appendVisibleRow(scanline.constData());
     } else {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -128,6 +128,14 @@ public:
     // plus a cause breakdown of static-overlay rebuilds. `reset` zeroes the
     // counters after the read so successive reads measure disjoint intervals.
     Q_INVOKABLE QVariantMap panstatsSnapshot(bool reset);
+    Q_INVOKABLE QVariantMap automationDssSnapshot() const;
+    Q_INVOKABLE QVariantMap automationDssReset(bool kiwiStream);
+    Q_INVOKABLE QVariantMap automationDssInjectRows(int count,
+                                                    int firstPeakBin,
+                                                    int stepBin,
+                                                    bool kiwiStream);
+    Q_INVOKABLE QVariantMap automationDssSetScrollback(bool live,
+                                                       int offsetRows);
     void setConnectionAnimationVisible(bool on, const QString& label = {});
     void setKiwiSdrConnectionOverlay(bool visible,
                                      const QString& detail = {},
@@ -750,6 +758,8 @@ private:
     void ensureWaterfallHistory();
     void rebuildWaterfallViewport();
     void rebuildWaterfallViewportForFrame(double centerMhz, double bandwidthMhz);
+    void rebuildDssViewportFromHistory();
+    void rebuildDssViewportFromHistoryForFrame(double centerMhz, double bandwidthMhz);
     void setWaterfallLive(bool live);
     void handleWaterfallFrequencyFrameChange(double oldCenterMhz,
                                              double oldBandwidthMhz,
@@ -801,6 +811,12 @@ private:
     void appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
                           double frameCenterMhz = -1.0,
                           double frameBandwidthMhz = -1.0);
+    void appendDssHistoryRow(const QVector<float>& binsDbm,
+                             double frameCenterMhz = -1.0,
+                             double frameBandwidthMhz = -1.0);
+    void appendLatestDssRowToHistory(double frameCenterMhz = -1.0,
+                                     double frameBandwidthMhz = -1.0);
+    float dssHistoryFallbackDbm() const;
     void appendVisibleRow(const QRgb* rowData);
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -133,7 +133,9 @@ public:
     Q_INVOKABLE QVariantMap automationDssInjectRows(int count,
                                                     int firstPeakBin,
                                                     int stepBin,
-                                                    bool kiwiStream);
+                                                    bool kiwiStream,
+                                                    double rowLowMhz = -1.0,
+                                                    double rowHighMhz = -1.0);
     Q_INVOKABLE QVariantMap automationDssSetScrollback(bool live,
                                                        int offsetRows);
     void setConnectionAnimationVisible(bool on, const QString& label = {});
@@ -814,7 +816,11 @@ private:
     void appendDssHistoryRow(const QVector<float>& binsDbm,
                              double frameCenterMhz = -1.0,
                              double frameBandwidthMhz = -1.0);
-    void appendLatestDssRowToHistory(double frameCenterMhz = -1.0,
+    void appendDssWaterfallRow(const QVector<float>& binsDbm,
+                               double frameCenterMhz = -1.0,
+                               double frameBandwidthMhz = -1.0,
+                               bool updateLiveSurface = true);
+    void appendLatestDssWaterfallRow(double frameCenterMhz = -1.0,
                                      double frameBandwidthMhz = -1.0);
     float dssHistoryFallbackDbm() const;
     void appendVisibleRow(const QRgb* rowData);

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -2,8 +2,10 @@
 
 #include <QVector>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <utility>
 
 namespace {
 
@@ -25,9 +27,14 @@ int strongestBin(const DssRenderer& renderer)
     return strongest;
 }
 
-} // namespace
+QVector<float> rowWithPeak(int bin)
+{
+    QVector<float> bins(DssRenderer::kCols, -120.0f);
+    bins[std::clamp(bin, 0, DssRenderer::kCols - 1)] = -30.0f;
+    return bins;
+}
 
-int main()
+int testFrequencyReprojection()
 {
     DssRenderer renderer;
     QVector<float> bins(DssRenderer::kCols, -100.0f);
@@ -52,6 +59,130 @@ int main()
     const int actualBin = strongestBin(renderer);
     if (std::abs(actualBin - expectedBin) > 3) {
         return fail("frequency reprojection should shift history into the new viewport");
+    }
+
+    return 0;
+}
+
+int testRetainedHistoryOffset()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(8);
+    renderer.appendHistoryRow(rowWithPeak(100), 14.0, 1.0, -200.0f);
+    renderer.appendHistoryRow(rowWithPeak(220), 14.0, 1.0, -200.0f);
+    renderer.appendHistoryRow(rowWithPeak(340), 14.0, 1.0, -200.0f);
+
+    if (renderer.historyCapacityRows() != 8 || renderer.historyRowCount() != 3) {
+        return fail("retained DSS history count/capacity is wrong");
+    }
+
+    renderer.rebuildVisibleFromHistory(0, 14.0, 1.0, -200.0f);
+    if (std::abs(strongestBin(renderer) - 340) > 2) {
+        return fail("offset 0 should rebuild the newest retained DSS row");
+    }
+
+    renderer.rebuildVisibleFromHistory(1, 14.0, 1.0, -200.0f);
+    if (std::abs(strongestBin(renderer) - 220) > 2) {
+        return fail("offset 1 should scroll DSS back with the waterfall");
+    }
+
+    return 0;
+}
+
+int testRetainedHistoryCapacity()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(2);
+    renderer.appendHistoryRow(rowWithPeak(80), 14.0, 1.0, -200.0f);
+    renderer.appendHistoryRow(rowWithPeak(180), 14.0, 1.0, -200.0f);
+    renderer.appendHistoryRow(rowWithPeak(280), 14.0, 1.0, -200.0f);
+
+    if (renderer.historyRowCount() != 2) {
+        return fail("retained DSS history must stay bounded by capacity");
+    }
+
+    renderer.rebuildVisibleFromHistory(1, 14.0, 1.0, -200.0f);
+    if (std::abs(strongestBin(renderer) - 180) > 2) {
+        return fail("retained DSS history should evict rows beyond capacity");
+    }
+
+    return 0;
+}
+
+int testEmptyHistoryRowsStayAligned()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(4);
+    renderer.appendHistoryRow(QVector<float>{}, 14.0, 1.0, -177.0f);
+
+    if (renderer.historyRowCount() != 1) {
+        return fail("empty DSS input should still retain a baseline history row");
+    }
+
+    renderer.rebuildVisibleFromHistory(0, 14.0, 1.0, -177.0f);
+    if (renderer.rowCount() != 1) {
+        return fail("baseline DSS history row should rebuild as visible data");
+    }
+
+    return 0;
+}
+
+int testRetainedHistoryReprojection()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(4);
+    renderer.appendHistoryRow(rowWithPeak(DssRenderer::kCols / 2),
+                              14.0, 1.0, -200.0f);
+    renderer.rebuildVisibleFromHistory(0, 14.25, 1.0, -200.0f);
+
+    const int expectedBin = DssRenderer::kCols / 4;
+    if (std::abs(strongestBin(renderer) - expectedBin) > 3) {
+        return fail("retained DSS history should reproject into the current viewport");
+    }
+
+    return 0;
+}
+
+int testMovedFromHistoryCapacityRebuild()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(4);
+
+    DssRenderer saved = std::move(renderer);
+    (void)saved;
+
+    renderer.setHistoryCapacityRows(4);
+    renderer.pushRow(rowWithPeak(128));
+    renderer.appendCurrentRowToHistory(14.0, 1.0);
+
+    if (renderer.historyCapacityRows() != 4 || renderer.historyRowCount() != 1) {
+        return fail("moved-from DSS history storage should rebuild at the same capacity");
+    }
+
+    return 0;
+}
+
+} // namespace
+
+int main()
+{
+    if (int rc = testFrequencyReprojection(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRetainedHistoryOffset(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRetainedHistoryCapacity(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testEmptyHistoryRowsStayAligned(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRetainedHistoryReprojection(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testMovedFromHistoryCapacityRebuild(); rc != 0) {
+        return rc;
     }
 
     return 0;

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -34,6 +34,13 @@ QVector<float> rowWithPeak(int bin)
     return bins;
 }
 
+void appendStableHistoryPeak(DssRenderer& renderer, int bin, int count = 3)
+{
+    for (int i = 0; i < count; ++i) {
+        renderer.appendHistoryRow(rowWithPeak(bin), 14.0, 1.0, -200.0f);
+    }
+}
+
 int testFrequencyReprojection()
 {
     DssRenderer renderer;
@@ -67,12 +74,12 @@ int testFrequencyReprojection()
 int testRetainedHistoryOffset()
 {
     DssRenderer renderer;
-    renderer.setHistoryCapacityRows(8);
-    renderer.appendHistoryRow(rowWithPeak(100), 14.0, 1.0, -200.0f);
-    renderer.appendHistoryRow(rowWithPeak(220), 14.0, 1.0, -200.0f);
-    renderer.appendHistoryRow(rowWithPeak(340), 14.0, 1.0, -200.0f);
+    renderer.setHistoryCapacityRows(12);
+    appendStableHistoryPeak(renderer, 100);
+    appendStableHistoryPeak(renderer, 220);
+    appendStableHistoryPeak(renderer, 340);
 
-    if (renderer.historyCapacityRows() != 8 || renderer.historyRowCount() != 3) {
+    if (renderer.historyCapacityRows() != 12 || renderer.historyRowCount() != 9) {
         return fail("retained DSS history count/capacity is wrong");
     }
 
@@ -81,9 +88,9 @@ int testRetainedHistoryOffset()
         return fail("offset 0 should rebuild the newest retained DSS row");
     }
 
-    renderer.rebuildVisibleFromHistory(1, 14.0, 1.0, -200.0f);
+    renderer.rebuildVisibleFromHistory(3, 14.0, 1.0, -200.0f);
     if (std::abs(strongestBin(renderer) - 220) > 2) {
-        return fail("offset 1 should scroll DSS back with the waterfall");
+        return fail("offset 3 should scroll DSS back with the waterfall");
     }
 
     return 0;
@@ -92,16 +99,16 @@ int testRetainedHistoryOffset()
 int testRetainedHistoryCapacity()
 {
     DssRenderer renderer;
-    renderer.setHistoryCapacityRows(2);
-    renderer.appendHistoryRow(rowWithPeak(80), 14.0, 1.0, -200.0f);
-    renderer.appendHistoryRow(rowWithPeak(180), 14.0, 1.0, -200.0f);
-    renderer.appendHistoryRow(rowWithPeak(280), 14.0, 1.0, -200.0f);
+    renderer.setHistoryCapacityRows(6);
+    appendStableHistoryPeak(renderer, 80);
+    appendStableHistoryPeak(renderer, 180);
+    appendStableHistoryPeak(renderer, 280);
 
-    if (renderer.historyRowCount() != 2) {
+    if (renderer.historyRowCount() != 6) {
         return fail("retained DSS history must stay bounded by capacity");
     }
 
-    renderer.rebuildVisibleFromHistory(1, 14.0, 1.0, -200.0f);
+    renderer.rebuildVisibleFromHistory(3, 14.0, 1.0, -200.0f);
     if (std::abs(strongestBin(renderer) - 180) > 2) {
         return fail("retained DSS history should evict rows beyond capacity");
     }
@@ -152,8 +159,7 @@ int testMovedFromHistoryCapacityRebuild()
     (void)saved;
 
     renderer.setHistoryCapacityRows(4);
-    renderer.pushRow(rowWithPeak(128));
-    renderer.appendCurrentRowToHistory(14.0, 1.0);
+    renderer.appendHistoryRow(rowWithPeak(128), 14.0, 1.0, -200.0f);
 
     if (renderer.historyCapacityRows() != 4 || renderer.historyRowCount() != 1) {
         return fail("moved-from DSS history storage should rebuild at the same capacity");

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -112,6 +112,7 @@ def main():
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png\n"
                "  automation_probe.py dss inject 0 3 100 100 native\n"
+               "  automation_probe.py dss inject 0 3 100 0 kiwi 14.000 14.010\n"
                "  automation_probe.py panmessage add 0 kiwi 0 'Waiting|Queued'\n"
                "  automation_probe.py panmessage add 0 tx 10000 tone=warning 'Transmit disabled|TX blocked'",
         formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -130,7 +131,8 @@ def main():
                          "connect <list|show|hide|local|ip|wait> [args] | "
                          "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
                          "dss <snapshot|reset|live> [pan] [args] | "
-                         "dss inject [pan] <count> <firstPeakBin> <stepBin> [native|kiwi] | "
+                         "dss inject [pan] <count> <firstPeakBin> <stepBin> "
+                         "[native|kiwi [rowLowMhz rowHighMhz]] | "
                          "dss scrollback [pan] <offsetRows> | "
                          "panmessage <add|remove|clear|list> <target> [id timeout [tone=info|warning] title|detail] | "
                          "audioCapture <start|stop|status|read> [args]")
@@ -232,8 +234,11 @@ def main():
             if action == "inject":
                 stream_names = {"native", "flex", "kiwi", "kiwisdr"}
                 if len(dss_args) < 3:
-                    sys.exit("error: dss inject needs [pan] <count> <firstPeakBin> <stepBin> [native|kiwi]")
-                if len(dss_args) == 3 or (len(dss_args) == 4 and dss_args[3].lower() in stream_names):
+                    sys.exit("error: dss inject needs [pan] <count> <firstPeakBin> <stepBin> "
+                             "[native|kiwi [rowLowMhz rowHighMhz]]")
+                if (len(dss_args) == 3
+                        or (len(dss_args) == 4 and dss_args[3].lower() in stream_names)
+                        or (len(dss_args) == 6 and dss_args[3].lower() in stream_names)):
                     req["value"] = " ".join(dss_args)
                 else:
                     req["target"] = dss_args[0]

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -129,7 +129,9 @@ def main():
                          "resize <w> <h> [target] | "
                          "connect <list|show|hide|local|ip|wait> [args] | "
                          "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
-                         "dss <snapshot|reset|inject|scrollback|live> [pan] [args] | "
+                         "dss <snapshot|reset|live> [pan] [args] | "
+                         "dss inject [pan] <count> <firstPeakBin> <stepBin> [native|kiwi] | "
+                         "dss scrollback [pan] <offsetRows> | "
                          "panmessage <add|remove|clear|list> <target> [id timeout [tone=info|warning] title|detail] | "
                          "audioCapture <start|stop|status|read> [args]")
     ap.add_argument("--socket", help="override the bridge socket path")
@@ -224,11 +226,31 @@ def main():
         elif args.command == "dss":
             if not args.rest:
                 sys.exit("error: dss needs <snapshot|reset|inject|scrollback|live> [pan] [args]")
-            req = {"cmd": "dss", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["target"] = args.rest[1]
-            if len(args.rest) > 2:
-                req["value"] = " ".join(args.rest[2:])
+            action = args.rest[0]
+            req = {"cmd": "dss", "action": action}
+            dss_args = args.rest[1:]
+            if action == "inject":
+                stream_names = {"native", "flex", "kiwi", "kiwisdr"}
+                if len(dss_args) < 3:
+                    sys.exit("error: dss inject needs [pan] <count> <firstPeakBin> <stepBin> [native|kiwi]")
+                if len(dss_args) == 3 or (len(dss_args) == 4 and dss_args[3].lower() in stream_names):
+                    req["value"] = " ".join(dss_args)
+                else:
+                    req["target"] = dss_args[0]
+                    req["value"] = " ".join(dss_args[1:])
+            elif action == "scrollback":
+                if not dss_args:
+                    sys.exit("error: dss scrollback needs [pan] <offsetRows>")
+                if len(dss_args) == 1:
+                    req["value"] = dss_args[0]
+                else:
+                    req["target"] = dss_args[0]
+                    req["value"] = " ".join(dss_args[1:])
+            else:
+                if dss_args:
+                    req["target"] = dss_args[0]
+                if len(dss_args) > 1:
+                    req["value"] = " ".join(dss_args[1:])
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "audioCapture":

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -111,6 +111,7 @@ def main():
                "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png\n"
+               "  automation_probe.py dss inject 0 3 100 100 native\n"
                "  automation_probe.py panmessage add 0 kiwi 0 'Waiting|Queued'\n"
                "  automation_probe.py panmessage add 0 tx 10000 tone=warning 'Transmit disabled|TX blocked'",
         formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -118,7 +119,7 @@ def main():
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect", "slice", "audioCapture",
                              "record", "testtone", "tci", "panmessage",
-                             "hitTest", "resize"],
+                             "hitTest", "resize", "dss"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
@@ -128,6 +129,7 @@ def main():
                          "resize <w> <h> [target] | "
                          "connect <list|show|hide|local|ip|wait> [args] | "
                          "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
+                         "dss <snapshot|reset|inject|scrollback|live> [pan] [args] | "
                          "panmessage <add|remove|clear|list> <target> [id timeout [tone=info|warning] title|detail] | "
                          "audioCapture <start|stop|status|read> [args]")
     ap.add_argument("--socket", help="override the bridge socket path")
@@ -217,6 +219,16 @@ def main():
             req = {"cmd": "slice", "action": args.rest[0]}
             if len(args.rest) > 1:
                 req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "dss":
+            if not args.rest:
+                sys.exit("error: dss needs <snapshot|reset|inject|scrollback|live> [pan] [args]")
+            req = {"cmd": "dss", "action": args.rest[0]}
+            if len(args.rest) > 1:
+                req["target"] = args.rest[1]
+            if len(args.rest) > 2:
+                req["value"] = " ".join(args.rest[2:])
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "audioCapture":


### PR DESCRIPTION
## Summary

Adds retained scrollback history for the 3D stacked trace so it follows the waterfall when the user scrolls back in history mode. The DSS renderer now keeps a bounded historical row store matched to the waterfall history capacity, rebuilds the visible 3D surface from the same history offset, and handles native and Kiwi waterfall rows through the same retained-history path. This also adds automation bridge coverage for DSS/waterfall scrollback with the new `dss` verb family: `snapshot`, `reset`, `inject`, `scrollback`, and `live`.

## Constitution principle honored

Principle XI - Fixes Are Demonstrated. The feature has focused renderer tests plus automation-bridge coverage proving native and Kiwi DSS history stay aligned with waterfall scrollback, including paused-history injection, live return, row-count caps, and overflow-safe synthetic peak generation.

## Test plan

- [x] Local build passes (`cmake --build build --target dss_renderer_test kiwi_sdr_trace_math_test AetherSDR --parallel`)
- [ ] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
- [x] `./build/dss_renderer_test`
- [x] `./build/kiwi_sdr_trace_math_test`
- [x] `ctest --test-dir build -R 'dss_renderer_test|kiwi_sdr_trace_math_test' --output-on-failure`
- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tools/automation_probe.py`
- [x] Automation bridge DSS scenarios for native and Kiwi streams: reset, inject, scrollback, paused-history injection, return-to-live, count cap, and peak-bin overflow clamping
- [x] `python3 tools/check_a11y.py`
- [x] `python3 tools/check_engine_boundary.py --strict`
- [x] `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room - not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
