### PR TITLE
chore: add FUNDING.yml — GitHub Sponsor button → Open Collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Renders the "Sponsor" button on the GitHub repo page.
+# Site funding story: https://www.aethersdr.com/#sponsor (add as `custom:`
+# once the domain cutover is live — it currently redirects back to GitHub).
+open_collective: aethersdr


### PR DESCRIPTION
## Summary

Adds `.github/FUNDING.yml` with the single typed entry `open_collective: aethersdr`, which renders GitHub's native **Sponsor** button on the repo page pointing at [opencollective.com/aethersdr](https://opencollective.com/aethersdr).

## Why

- Someone opening the Sponsor dialog has already decided to give — the typed `open_collective:` field takes them straight to the payment page with Open Collective's branding/trust, no extra hops.
- Sponsorship funds the AI development subscriptions behind the project's release pace and puts control hardware (knobs, dials, decks) on the device-testing bench.
- The collective's ledger is public — every expense visible.

## Follow-up (deliberately not in this PR)

A secondary `custom:` link to the site's funding section (https://www.aethersdr.com/#sponsor) will be added **after** the domain cutover — today `aethersdr.com` still 301s back to this repo, which would make the link circular.

## Testing

One-file YAML addition; the button renders on merge (no CI surface).

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat