### PR TITLE
refactor(aetherd): 2.4 — reclassify peripheral/accessory devices out of the radio-vendor set (EB3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,8 +259,10 @@ The dependency direction is CI-enforced (`tools/check_engine_boundary.py`,
   `src/core/`, `src/models/` **except** the backend tree
   `src/core/backends/`) may include a **vendor header** — the
   family-specific wire classes the RFC keeps behind `IRadioBackend`
-  (SmartSDR/FlexLib + KiwiSDR; the 26 headers tagged `vendor` in
-  `docs/architecture/aetherd-touchpoint-tags.json`). Today's coupling is
+  (SmartSDR/FlexLib + KiwiSDR; the headers tagged `vendor(...)` in
+  `docs/architecture/aetherd-touchpoint-tags.json` — standalone *accessory*
+  devices like the 4O3A tuner/switch/amp are tagged `peripheral(...)`, not
+  `vendor`, so they are NOT gated by EB3). Today's coupling is
   frozen as a per-file, shrink-only baseline; a **new** above-seam vendor
   include, or an **increase** in a tracked file, errors. (RFC step 2.4;
   see "Engine boundary ratchet — EB3" below.)
@@ -287,7 +289,7 @@ for new violations).
 reaches around `IRadioBackend` to a vendor wire class. What this means for
 you:
 
-- **Nothing was relocated.** Step 2.4 is *ratchet-only*: the 26 vendor
+- **Nothing was relocated.** Step 2.4 is *ratchet-only*: the vendor
   headers stay where they are (`src/core/…`, `src/models/…`) for now. EB3
   just makes the existing boundary enforceable *in place*, so the
   decoupling can proceed without new coupling piling up behind it.

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -403,7 +403,7 @@
  },
  "core/PgxlConnection.h": {
   "tag": "peripheral(4o3a)",
-  "note": "Direct TCP client (port 9008) for the 4O3A Power Genius XL amplifier \u2014 a standalone accessory device with its own protocol, works with any radio. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
+  "note": "Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier peripheral \u2014 a standalone device with its own protocol (same C/R/S/V framing as TgxlConnection). Like the TGXL, the PGXL can be proxied through the radio's SmartSDR 'amplifier' API (RadioModel handles amplifier status/operate for both), but that path is fragile \u2014 the project deliberately prefers this direct connection so a firmware change can't break amp control/telemetry. Peripheral(4o3a), not radio-family wire; NOT behind the IRadioBackend radio seam.",
   "split": "",
   "confidence": "high"
  },
@@ -835,7 +835,7 @@
  },
  "models/TunerModel.h": {
   "tag": "peripheral(4o3a)",
-  "note": "4O3A Tuner Genius XL client — a standalone accessory with its own UDP-broadcast discovery + direct port-9010 TCP (reverse-engineered from the 4O3A app), works with any radio. The SmartSDR 'atu'/'tgxl' verbs are one OPTIONAL radio-relayed control path, not the device's identity. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
+  "note": "External 4O3A Tuner Genius XL (TGXL) peripheral — a standalone device with its own direct port-9010 protocol (core/TgxlConnection.h). Flex can proxy TGXL control through the radio's SmartSDR atu/tgxl passthrough (still used for operate/bypass today), but that path is fragile — Flex firmware 4.2.18 broke it, which is why the direct connection was added (#469). The project deliberately avoids depending on the radio proxy (a firmware change can break it), so the TGXL is peripheral(4o3a), not radio-family wire; the remaining atu/tgxl passthrough is legacy to migrate onto the direct path, NOT radio functionality behind the IRadioBackend seam. Distinct from the radio's own built-in ATU.",
   "split": "",
   "confidence": "high"
  },

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -402,8 +402,8 @@
   "confidence": "high"
  },
  "core/PgxlConnection.h": {
-  "tag": "vendor(flex)",
-  "note": "Direct TCP client (port 9008) for 4O3A Power Genius XL amp telemetry \u2014 Flex-ecosystem accessory protocol.",
+  "tag": "peripheral(4o3a)",
+  "note": "Direct TCP client (port 9008) for the 4O3A Power Genius XL amplifier \u2014 a standalone accessory device with its own protocol, works with any radio. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
   "split": "",
   "confidence": "high"
  },
@@ -558,8 +558,8 @@
   "confidence": "high"
  },
  "core/TgxlConnection.h": {
-  "tag": "vendor(flex)",
-  "note": "Direct TCP client for 4O3A Tuner Genius XL port-9010 protocol (relay/autotune); Flex-ecosystem accessory.",
+  "tag": "peripheral(4o3a)",
+  "note": "Direct TCP client for the 4O3A Tuner Genius XL (port 9010, relay/autotune), reverse-engineered from the 4O3A management app — a standalone accessory transport, not SmartSDR. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
   "split": "",
   "confidence": "high"
  },
@@ -708,8 +708,8 @@
   "confidence": "medium"
  },
  "models/AntennaGeniusModel.h": {
-  "tag": "vendor(flex)",
-  "note": "4O3A Antenna Genius switch client: UDP discovery + SmartSDR-like TCP protocol; Flex-ecosystem accessory",
+  "tag": "peripheral(4o3a)",
+  "note": "4O3A Antenna Genius switch client — standalone accessory with its own UDP-broadcast discovery (port 9007) + direct TCP; connects by device IP/port independent of the radio, works with any radio. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
   "split": "",
   "confidence": "high"
  },
@@ -834,8 +834,8 @@
   "confidence": "high"
  },
  "models/TunerModel.h": {
-  "tag": "vendor(flex)",
-  "note": "4o3a TGXL tuner state/commands via SmartSDR 'atu'/'tgxl' TCP verbs + direct port-9010 relay control",
+  "tag": "peripheral(4o3a)",
+  "note": "4O3A Tuner Genius XL client — a standalone accessory with its own UDP-broadcast discovery + direct port-9010 TCP (reverse-engineered from the 4O3A app), works with any radio. The SmartSDR 'atu'/'tgxl' verbs are one OPTIONAL radio-relayed control path, not the device's identity. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",
   "split": "",
   "confidence": "high"
  },

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -216,8 +216,8 @@
   "confidence": "high"
  },
  "core/FlexControlManager.h": {
-  "tag": "vendor(flex)",
-  "note": "FlexControl USB knob serial driver (VID 0x2192); Flex ecosystem hardware but client-side input, home=gui shell",
+  "tag": "ui-support",
+  "note": "FlexControl USB knob serial driver (VID 0x2192) — a desktop input-surface driver, the same class as HidEncoderManager (RC-28/TMate)/UlanziDialBackend/SerialPortController, all ui-support. Flex-branded hardware but client-side input, not radio-family wire; NOT behind the radio seam (reclassified from vendor(flex), #4089).",
   "split": "",
   "confidence": "high"
  },

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -94,12 +94,13 @@ KNOWN_WIDGETS_LEGACY = {
 # `vendor(*)` there is enforced automatically — no silent drift where the audit
 # grows a vendor family but this checker keeps permitting it.
 VENDOR_TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
-# Sanity floor: the audit currently tags 22 radio-family vendor headers (the
-# original 26 minus the 4O3A accessory family — TunerModel/AntennaGeniusModel/
-# Tgxl/Pgxl — which were reclassified peripheral(4o3a), not radio wire). This
-# floor only guards against the audit being moved/gutted (a parse yielding near
-# zero), NOT the exact count — deliberate reclassifications lower it over time,
-# so keep the floor well below the live count.
+# Sanity floor: the audit currently tags 21 radio-family vendor headers (the
+# original 26 minus reclassified peripherals not behind the radio seam — the
+# 4O3A accessory family TunerModel/AntennaGeniusModel/Tgxl/Pgxl → peripheral(4o3a),
+# and the FlexControl USB knob → ui-support). This floor only guards against the
+# audit being moved/gutted (a parse yielding near zero), NOT the exact count —
+# deliberate reclassifications lower it over time, so keep the floor well below
+# the live count.
 VENDOR_STEMS_FLOOR = 15
 
 
@@ -162,7 +163,7 @@ KNOWN_VENDOR_INCLUDE_BASELINE = {
     "src/gui/KiwiPublicReceiverPicker.h": ["KiwiPublicDirectory"],
     "src/gui/KiwiSdrApplet.h": ["KiwiSdrClient"],
     "src/gui/MainWindow.cpp": ["DvkWavTransfer", "KiwiSdrManager", "PanadapterStream", "RadioStatusOwnership", "StreamStatus"],
-    "src/gui/MainWindow.h": ["FlexControlManager", "SmartLinkClient", "WanConnection"],
+    "src/gui/MainWindow.h": ["SmartLinkClient", "WanConnection"],
     "src/gui/MainWindowHelpers.cpp": ["PanadapterStream", "SmartLinkClient"],
     "src/gui/MainWindow_Controllers.cpp": ["KiwiSdrProtocol"],
     "src/gui/MainWindow_KiwiSdr.cpp": ["KiwiSdrClient", "KiwiSdrManager", "KiwiSdrProtocol"],
@@ -172,7 +173,7 @@ KNOWN_VENDOR_INCLUDE_BASELINE = {
     "src/gui/MemoryDialog.cpp": ["MemoryCsvCompat", "RadioConnection"],
     "src/gui/NetworkDiagnosticsDialog.h": ["PanadapterStream"],
     "src/gui/ProfileImportExportDialog.h": ["ProfileTransfer"],
-    "src/gui/RadioSetupDialog.cpp": ["FirmwareStager", "FirmwareUploader", "FlexControlManager", "KiwiSdrManager", "PanadapterStream", "WanConnection"],
+    "src/gui/RadioSetupDialog.cpp": ["FirmwareStager", "FirmwareUploader", "KiwiSdrManager", "PanadapterStream", "WanConnection"],
     "src/gui/RxApplet.cpp": ["KiwiSdrManager", "KiwiSdrProtocol"],
     "src/gui/SMeterWidget.h": ["KiwiSdrProtocol"],
     "src/gui/SpectrumOverlayMenu.cpp": ["KiwiSdrManager"],

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -94,10 +94,13 @@ KNOWN_WIDGETS_LEGACY = {
 # `vendor(*)` there is enforced automatically — no silent drift where the audit
 # grows a vendor family but this checker keeps permitting it.
 VENDOR_TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
-# Sanity floor: the audit currently tags 26 vendor headers. If a parse yields
-# far fewer, the audit moved or its schema changed and EB3 is silently
-# under-armed — fail loudly (handled at load).
-VENDOR_STEMS_FLOOR = 20
+# Sanity floor: the audit currently tags 22 radio-family vendor headers (the
+# original 26 minus the 4O3A accessory family — TunerModel/AntennaGeniusModel/
+# Tgxl/Pgxl — which were reclassified peripheral(4o3a), not radio wire). This
+# floor only guards against the audit being moved/gutted (a parse yielding near
+# zero), NOT the exact count — deliberate reclassifications lower it over time,
+# so keep the floor well below the live count.
+VENDOR_STEMS_FLOOR = 15
 
 
 def load_vendor_vocabulary():
@@ -152,15 +155,14 @@ KNOWN_VENDOR_INCLUDE_BASELINE = {
     "src/core/TciProtocol.cpp": ["DaxIqModel"],
     "src/core/TciServer.cpp": ["DaxIqModel", "StreamStatus"],
     "src/core/WfmDemodulator.cpp": ["DaxIqModel"],
-    "src/gui/AntennaGeniusApplet.cpp": ["AntennaGeniusModel"],
     "src/gui/Ax25HfPacketDecodeDialog.cpp": ["DaxTxPolicy"],
     "src/gui/ConnectionPanel.h": ["SmartLinkClient"],
     "src/gui/DaxIqApplet.cpp": ["DaxIqModel"],
     "src/gui/DvkPanel.cpp": ["DvkWavTransfer"],
     "src/gui/KiwiPublicReceiverPicker.h": ["KiwiPublicDirectory"],
     "src/gui/KiwiSdrApplet.h": ["KiwiSdrClient"],
-    "src/gui/MainWindow.cpp": ["DvkWavTransfer", "KiwiSdrManager", "PanadapterStream", "RadioStatusOwnership", "StreamStatus", "TunerModel"],
-    "src/gui/MainWindow.h": ["AntennaGeniusModel", "FlexControlManager", "PgxlConnection", "SmartLinkClient", "TgxlConnection", "WanConnection"],
+    "src/gui/MainWindow.cpp": ["DvkWavTransfer", "KiwiSdrManager", "PanadapterStream", "RadioStatusOwnership", "StreamStatus"],
+    "src/gui/MainWindow.h": ["FlexControlManager", "SmartLinkClient", "WanConnection"],
     "src/gui/MainWindowHelpers.cpp": ["PanadapterStream", "SmartLinkClient"],
     "src/gui/MainWindow_Controllers.cpp": ["KiwiSdrProtocol"],
     "src/gui/MainWindow_KiwiSdr.cpp": ["KiwiSdrClient", "KiwiSdrManager", "KiwiSdrProtocol"],
@@ -170,20 +172,17 @@ KNOWN_VENDOR_INCLUDE_BASELINE = {
     "src/gui/MemoryDialog.cpp": ["MemoryCsvCompat", "RadioConnection"],
     "src/gui/NetworkDiagnosticsDialog.h": ["PanadapterStream"],
     "src/gui/ProfileImportExportDialog.h": ["ProfileTransfer"],
-    "src/gui/RadioSetupDialog.cpp": ["AntennaGeniusModel", "FirmwareStager", "FirmwareUploader", "FlexControlManager", "KiwiSdrManager", "PanadapterStream", "PgxlConnection", "TgxlConnection", "WanConnection"],
+    "src/gui/RadioSetupDialog.cpp": ["FirmwareStager", "FirmwareUploader", "FlexControlManager", "KiwiSdrManager", "PanadapterStream", "WanConnection"],
     "src/gui/RxApplet.cpp": ["KiwiSdrManager", "KiwiSdrProtocol"],
     "src/gui/SMeterWidget.h": ["KiwiSdrProtocol"],
-    "src/gui/ShackSwitchApplet.cpp": ["AntennaGeniusModel"],
     "src/gui/SpectrumOverlayMenu.cpp": ["KiwiSdrManager"],
     "src/gui/SpectrumWidget.cpp": ["KiwiSdrProtocol"],
     "src/gui/SupportDialog.cpp": ["RadioConnection"],
-    "src/gui/TunerApplet.cpp": ["TunerModel"],
-    "src/gui/TxApplet.cpp": ["TunerModel"],
     "src/gui/VfoWidget.cpp": ["KiwiSdrManager", "KiwiSdrProtocol"],
     "src/gui/VfoWidget.h": ["KiwiSdrProtocol"],
     "src/gui/WaveformsDialog.cpp": ["FlexWaveformModel", "WaveformInstaller"],
     "src/models/RadioModel.cpp": ["CommandParser", "ProfileLoadCommand", "RadioStatusOwnership", "StreamStatus"],
-    "src/models/RadioModel.h": ["CommandParser", "DaxIqModel", "DaxTxPolicy", "FlexWaveformModel", "PanadapterStream", "RadioConnection", "RadioStatusOwnership", "TunerModel", "WanConnection"],
+    "src/models/RadioModel.h": ["CommandParser", "DaxIqModel", "DaxTxPolicy", "FlexWaveformModel", "PanadapterStream", "RadioConnection", "RadioStatusOwnership", "WanConnection"],
     "src/models/SliceModel.cpp": ["KiwiSdrProtocol"],
     "src/models/TransmitInhibitPolicy.h": ["CommandParser"],
 }


### PR DESCRIPTION
## Correcting mis-classifications, not a code refactor

EB3 exists to keep **radio-family** vendor wire behind `IRadioBackend`. Several **peripheral/accessory devices** — separate hardware the app talks to, not the radio — were mis-swept into `vendor(flex)`. This corrects the audit (the SoT the EB3 vocabulary derives from at runtime). **Zero code change.**

### 1. The 4O3A accessory family → `peripheral(4o3a)`
Standalone devices, each with its own protocol/port/discovery, that work with any radio:

| 4O3A device | Header(s) |
|---|---|
| Antenna Genius (switch) | `AntennaGeniusModel.h` — own UDP discovery (9007) + direct TCP |
| Tuner Genius XL | `TunerModel.h` + `TgxlConnection.h` — own UDP discovery + direct port-9010 (SmartSDR `atu`/`tgxl` is one *optional* relay path) |
| Power Genius XL (amp) | `PgxlConnection.h` — direct TCP (9008) |

A full sweep confirmed these four are the *complete* 4O3A device family in the codebase (no Station Genius, no separate amp model; `AmpApplet` pulls no 4O3A header). Credit @ten9876 for catching that TGXL is standalone like AG — my initial read wrongly called it radio-bound.

### 2. FlexControl USB knob → `ui-support`
`FlexControlManager` is a USB tuning-knob serial driver (VID `0x2192`) — a desktop input-surface driver, the same class as its siblings `HidEncoderManager` (RC-28/TMate), `UlanziDialBackend`, `MidiControlManager`, `SerialPortController`, **all already `ui-support`**. Its own note read "client-side input, home=gui shell" — recognized as input, just mistagged. Flex-branded ≠ radio wire.

### EB3 impact
- Vendor vocabulary **26 → 21** stems (5 headers reclassified).
- **Baseline 76 → 62** across 31 files. Emptied rows removed (`TunerApplet`, `TxApplet`, `AntennaGeniusApplet`, `ShackSwitchApplet`); `MainWindow.h` 6→2, `RadioSetupDialog.cpp` 9→5, `MainWindow.cpp` 6→5, `RadioModel.h` 8→7.
- **No new findings**: every now-above-seam `.cpp` (the reclassified TUs) includes no remaining radio-vendor header — verified.
- `VENDOR_STEMS_FLOOR` 20 → 15 for headroom; `AGENTS.md` notes `peripheral(...)`/`ui-support` are not EB3-gated.

### Why this is honest, not gaming the ratchet
EB3 guards *radio wire behind the radio seam*. A 4O3A antenna switch/tuner/amp, and a USB tuning knob, are not radio wire — they're separate devices the app drives over their own transports. Removing EB3 enforcement for them makes the audit *more* correct (Evidence Over Assertion — standalone protocols/ports/discovery, and sibling-consistent tagging, both verified in code). A future peripheral abstraction, if ever wanted, is out of the radio-seam RFC's scope.

Behavior-neutral: audit JSON + checker baseline + docs only; no build impact; `--strict` clean.

_Touches `AGENTS.md` (Tier 1) → needs an admin merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)