### PR TITLE
refactor(aetherd): retag TunerModel mixed(flex) + honest TGXL/PGXL notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ you:
   decoupling can proceed without new coupling piling up behind it.
 - **The rule.** Each tracked file's baseline row is the exact **set** of
   vendor headers it may include. Adding a vendor `#include` (e.g.
-  `KiwiSdrManager.h`, `RadioConnection.h`, `TunerModel.h`) to a `gui/`,
+  `KiwiSdrManager.h`, `RadioConnection.h`, `StreamStatus.h`) to a `gui/`,
   `core/`, or `models/` file that isn't tracked — or adding a header not
   in a tracked file's set, *including a lateral swap that keeps the count
   flat* (drop `RadioConnection.h`, add `KiwiSdrManager.h`) — fails the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,9 +260,12 @@ The dependency direction is CI-enforced (`tools/check_engine_boundary.py`,
   `src/core/backends/`) may include a **vendor header** — the
   family-specific wire classes the RFC keeps behind `IRadioBackend`
   (SmartSDR/FlexLib + KiwiSDR; the headers tagged `vendor(...)` in
-  `docs/architecture/aetherd-touchpoint-tags.json` — standalone *accessory*
-  devices like the 4O3A tuner/switch/amp are tagged `peripheral(...)`, not
-  `vendor`, so they are NOT gated by EB3). Today's coupling is
+  `docs/architecture/aetherd-touchpoint-tags.json`). Only `vendor(...)` is
+  EB3-gated: a standalone *accessory* device's own transport (the 4O3A
+  antenna switch, the Tgxl/Pgxl direct sockets) is `peripheral(...)`, a
+  USB input surface is `ui-support`, and a generic device model fused with
+  vendor relay (e.g. `TunerModel`) is `mixed(flex)` — none of those are
+  `vendor`, so none are EB3-gated. Today's coupling is
   frozen as a per-file, shrink-only baseline; a **new** above-seam vendor
   include, or an **increase** in a tracked file, errors. (RFC step 2.4;
   see "Engine boundary ratchet — EB3" below.)

--- a/docs/aetherd-headless-engine-design.md
+++ b/docs/aetherd-headless-engine-design.md
@@ -142,8 +142,9 @@ half the raw touchpoint count.
 > `vendor` set to **21** (17 flex, 4 kiwi). Five headers were found to be
 > not-radio-wire and moved out: the 4O3A Tgxl/Pgxl/AntennaGenius transports →
 > `peripheral(4o3a)` (a new tag for standalone accessory devices, not behind the
-> radio seam), the FlexControl USB knob → `ui-support`, and `TunerModel` →
-> `mixed(flex)`. `aetherd-touchpoint-tags.json` is the source of truth.
+> radio seam, now **3**), the FlexControl USB knob → `ui-support`, and
+> `TunerModel` → `mixed(flex)` (so `mixed` is now **17**).
+> `aetherd-touchpoint-tags.json` is the source of truth.
 
 ---
 

--- a/docs/aetherd-headless-engine-design.md
+++ b/docs/aetherd-headless-engine-design.md
@@ -138,6 +138,13 @@ device/OS plumbing, control surfaces — need engine-vs-shell home decisions,
 not protocol messages). The protocol-message workload is therefore roughly
 half the raw touchpoint count.
 
+> **Update (2026-07):** reclassifications since the first pass narrowed the
+> `vendor` set to **21** (17 flex, 4 kiwi). Five headers were found to be
+> not-radio-wire and moved out: the 4O3A Tgxl/Pgxl/AntennaGenius transports →
+> `peripheral(4o3a)` (a new tag for standalone accessory devices, not behind the
+> radio seam), the FlexControl USB knob → `ui-support`, and `TunerModel` →
+> `mixed(flex)`. `aetherd-touchpoint-tags.json` is the source of truth.
+
 ---
 
 ## 3. Proposed architecture

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -19,12 +19,14 @@ The touchpoint audit
 ([`aetherd-touchpoints.md`](aetherd-touchpoints.md)) tags every gui→engine
 header. Two tag classes define step 2's work:
 
-- **26 `vendor` headers** — SmartSDR/FlexLib/Flex-ecosystem wire code. These
-  move *behind* the seam into `src/core/backends/flex/`; nothing above the
-  seam includes them. The load-bearing ones: `RadioConnection` (SmartSDR TCP
-  text), `PanadapterStream` (VITA-49), `SmartLinkClient`/`WanConnection`
-  (SmartLink WAN), `CommandParser`, `StreamStatus`, `RadioStatusOwnership`,
-  plus the 4O3A/amp/tuner/firmware/waveform/DAX-IQ family.
+- **21 `vendor` headers** — SmartSDR/FlexLib wire code (originally 26; 5 were
+  reclassified as not-radio-wire — the 4O3A Tgxl/Pgxl/AntennaGenius transports →
+  `peripheral(4o3a)`, the FlexControl USB knob → `ui-support`, and `TunerModel` →
+  `mixed(flex)`; see `aetherd-touchpoint-tags.json`). These move *behind* the
+  seam into `src/core/backends/flex/`; nothing above the seam includes them. The
+  load-bearing ones: `RadioConnection` (SmartSDR TCP text), `PanadapterStream`
+  (VITA-49), `SmartLinkClient`/`WanConnection` (SmartLink WAN), `CommandParser`,
+  `StreamStatus`, `RadioStatusOwnership`, plus the firmware/waveform/DAX-IQ family.
 - **16 `mixed` headers** — canonical state fused with Flex specifics. These do
   *not* move; they get **split**: the core-profile part stays as the model the
   UI/protocol sees, the Flex part becomes backend-provided. The hard five are
@@ -191,7 +193,7 @@ the interface has no implementor.
   **ratchet only** first — `check_engine_boundary.py` gains **EB3**, freezing
   today's above-seam vendor coupling as a per-file, shrink-only baseline (no new
   coupling; existing includers decoupled subsystem-by-subsystem, each routed
-  through `IRadioBackend`, driving its baseline to zero). The 26 vendor files
+  through `IRadioBackend`, driving its baseline to zero). The vendor files
   are **not** relocated in this step — EB3 enforces the boundary in place.
   Physical relocation of a header into `src/core/backends/<family>/` happens
   when its last above-seam includer is converted. Adoption guidance lives in

--- a/docs/architecture/aetherd-iradiobackend-design.md
+++ b/docs/architecture/aetherd-iradiobackend-design.md
@@ -27,7 +27,7 @@ header. Two tag classes define step 2's work:
   load-bearing ones: `RadioConnection` (SmartSDR TCP text), `PanadapterStream`
   (VITA-49), `SmartLinkClient`/`WanConnection` (SmartLink WAN), `CommandParser`,
   `StreamStatus`, `RadioStatusOwnership`, plus the firmware/waveform/DAX-IQ family.
-- **16 `mixed` headers** — canonical state fused with Flex specifics. These do
+- **17 `mixed` headers** — canonical state fused with Flex specifics. These do
   *not* move; they get **split**: the core-profile part stays as the model the
   UI/protocol sees, the Flex part becomes backend-provided. The hard five are
   `RadioModel`, `SliceModel`, `TransmitModel`, `PanadapterModel`, `MeterModel`.

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -403,7 +403,7 @@
  },
  "core/PgxlConnection.h": {
   "tag": "peripheral(4o3a)",
-  "note": "Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier peripheral \u2014 a standalone device with its own protocol (same C/R/S/V framing as TgxlConnection). Like the TGXL, the PGXL can be proxied through the radio's SmartSDR 'amplifier' API (RadioModel handles amplifier status/operate for both), but that path is fragile \u2014 the project deliberately prefers this direct connection so a firmware change can't break amp control/telemetry. Peripheral(4o3a), not radio-family wire; NOT behind the IRadioBackend radio seam.",
+  "note": "Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier \u2014 TELEMETRY-ONLY (statusUpdated: state/power/SWR/current/temp/\u2026); it has no operate/standby command. PGXL operate/standby is relayed through the radio (RadioModel::setAmpOperate \u2192 'amplifier set <handle> operate=\u2026'), which is also the only path for remote/SmartLink. So this header is a genuine local direct-transport peripheral(4o3a); the amp's radio-relay control lives in RadioModel (radio-side) and should split into a generic AmpModel + Flex relay behind FlexBackend \u2014 see the AmpModel-extraction issue.",
   "split": "",
   "confidence": "high"
  },
@@ -834,9 +834,9 @@
   "confidence": "high"
  },
  "models/TunerModel.h": {
-  "tag": "peripheral(4o3a)",
-  "note": "External 4O3A Tuner Genius XL (TGXL) peripheral — a standalone device with its own direct port-9010 protocol (core/TgxlConnection.h). Flex can proxy TGXL control through the radio's SmartSDR atu/tgxl passthrough (still used for operate/bypass today), but that path is fragile — Flex firmware 4.2.18 broke it, which is why the direct connection was added (#469). The project deliberately avoids depending on the radio proxy (a firmware change can break it), so the TGXL is peripheral(4o3a), not radio-family wire; the remaining atu/tgxl passthrough is legacy to migrate onto the direct path, NOT radio functionality behind the IRadioBackend seam. Distinct from the radio's own built-in ATU.",
-  "split": "",
+  "tag": "mixed(flex)",
+  "note": "External-tuner state model, intended to become vendor-neutral (usable by any 3rd-party tuner). Fuses universal tuner state with Flex-specific TGXL wiring, so it's mixed — NOT peripheral (that's the transport TgxlConnection) and NOT pure vendor. Distinct from the radio's own built-in ATU (TransmitModel).",
+  "split": "Core (universal, stays the model the UI/3rd-party sees): operate/bypass/tuning state, SWR/fwd-power, antenna-switch selection, presence. Flex extension (move behind FlexBackend as an IRadioBackend extension verb): the TGXL radio-relay — SmartSDR atu/tgxl/amplifier passthrough (commandReady, atu-status decode), which is the ONLY control path for remote/SmartLink operation and is TGXL-specific (the radio relays only the TGXL). A direct TgxlConnection (peripheral, port 9010) is the local fast-path. 2.3-style split; see #4092.",
   "confidence": "high"
  },
  "models/XvtrPolicy.h": {

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -403,7 +403,7 @@
  },
  "core/PgxlConnection.h": {
   "tag": "peripheral(4o3a)",
-  "note": "Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier \u2014 TELEMETRY-ONLY (statusUpdated: state/power/SWR/current/temp/\u2026); it has no operate/standby command. PGXL operate/standby is relayed through the radio (RadioModel::setAmpOperate \u2192 'amplifier set <handle> operate=\u2026'), which is also the only path for remote/SmartLink. So this header is a genuine local direct-transport peripheral(4o3a); the amp's radio-relay control lives in RadioModel (radio-side) and should split into a generic AmpModel + Flex relay behind FlexBackend \u2014 see the AmpModel-extraction issue.",
+  "note": "Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier \u2014 TELEMETRY-ONLY (statusUpdated: state/power/SWR/current/temp/\u2026); it has no operate/standby command. PGXL operate/standby is relayed through the radio (RadioModel::setAmpOperate \u2192 'amplifier set <handle> operate=\u2026'), which is also the only path for remote/SmartLink. So this header is a genuine local direct-transport peripheral(4o3a); the amp's radio-relay control lives in RadioModel (radio-side) and should split into a generic AmpModel + Flex relay behind FlexBackend \u2014 see #4094.",
   "split": "",
   "confidence": "high"
  },

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -44,7 +44,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/DxccColorProvider.h` | 2 | universal — DXCC worked-status from ADIF log, colors cluster spots by call/freq/mode; radio-agnostic spot/logging feature | unconverted |
 | `core/FirmwareStager.h` | 1 | vendor(flex) — Downloads SmartSDR installers from flexradio.com, extracts .ssdr firmware for 6x00/9600 upload — pure Flex | unconverted |
 | `core/FirmwareUploader.h` | 1 | vendor(flex) — SmartSDR firmware upload: 'file upload' cmd, .ssdr files, Flex TCP ports 4995/42607 — pure Flex protocol | unconverted |
-| `core/FlexControlManager.h` | 2 | vendor(flex) — FlexControl USB knob serial driver (VID 0x2192); Flex ecosystem hardware but client-side input, home=gui shell | unconverted |
+| `core/FlexControlManager.h` | 2 | ui-support — FlexControl USB knob serial driver (VID 0x2192); client-side input surface like RC-28/TMate, not radio-family wire | reclassified (#4089) |
 | `core/FreeDvClient.h` | 4 | universal — FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR | unconverted |
 | `core/GpuSelector.h` | 2 | ui-support — GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing | unconverted |
 | `core/HidEncoderManager.h` | 2 | ui-support — USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state | unconverted |
@@ -75,7 +75,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/PanadapterStream.h` | 4 | vendor(flex) — SmartSDR VITA-49 UDP receiver (FlexLib PCCs, DAX/IQ routing, SmartLink WAN reg); emits core-profile data | unconverted |
 | `core/PerfTelemetry.h` | 3 | ui-support — Singleton perf-instrumentation logger for client render/UDP/input timing; diagnostics, not radio state. | unconverted |
 | `core/PeripheralSettings.h` | 3 | ui-support — Client settings blob (AutoReconnect + legacy-key migration) for peripheral devices atop AppSettings; no radio state. | unconverted |
-| `core/PgxlConnection.h` | 2 | vendor(flex) — Direct TCP client (port 9008) for 4O3A Power Genius XL amp telemetry — Flex-ecosystem accessory protocol. | unconverted |
+| `core/PgxlConnection.h` | 2 | peripheral(4o3a) — direct TCP telemetry client (port 9008) for the 4O3A Power Genius XL; standalone accessory transport, not radio wire (amp operate is radio-proxied in RadioModel — see #4094) | reclassified (#4089) |
 | `core/PipeWireAudioBridge.h` | 3 | mixed(flex) — Linux virtual-audio bridge to WSJT-X etc.; audio routing is core, DAX channel model/rates are flex | unconverted |
 | `core/PotaClient.h` | 2 | universal — POTA spot poller (api.pota.app) emitting DxSpot frequency/mode spots; radio-agnostic spot feature, no vendor ties. | unconverted |
 | `core/ProfileTransfer.h` | 1 | vendor(flex) — SmartSDR .ssdr_cfg database import/export over Flex TCP transfer protocol (meta_subset, ports 4995/42607) | unconverted |
@@ -100,7 +100,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/StreamStatus.h` | 1 | vendor(flex) — SmartSDR stream-status parsing: client_handle ownership, DAX RX/TX orphan-stream firmware quirks — pure Flex wire logic | unconverted |
 | `core/SupportBundle.h` | 1 | ui-support — Diagnostics bundle: archives logs/sysinfo and opens email client; client-side support tooling, not radio state | unconverted |
 | `core/TciServer.h` | 3 | mixed(flex) — TCI WebSocket server for WSJT-X et al: protocol surface is canonical radio state, but audio/IQ rides Flex DAX | unconverted |
-| `core/TgxlConnection.h` | 2 | vendor(flex) — Direct TCP client for 4O3A Tuner Genius XL port-9010 protocol (relay/autotune); Flex-ecosystem accessory. | unconverted |
+| `core/TgxlConnection.h` | 2 | peripheral(4o3a) — direct TCP client (port 9010) for the 4O3A Tuner Genius XL; standalone accessory transport, not radio wire | reclassified (#4089) |
 | `core/ThemeManager.h` | 119 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
 | `core/TxKeyingMarker.h` | 4 | ui-support — QWidget property marker guarding TX-keying controls from the automation bridge; GUI-shell plumbing, no radio state. | unconverted |
 | `core/UlanziDialBackend.h` | 3 | ui-support — Platform alias for Ulanzi Dial HID knob backend (evdev/hidapi); physical input device for client, not radio state | unconverted |
@@ -125,7 +125,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/tnc/HeardList.h` | 1 | universal — Heard-station list for the packet monitor; radio-agnostic. | unconverted |
 | `core/tnc/KissTncServer.h` | 1 | ui-support — KISS-over-TCP server exposing the TNC to external apps; external integration, needs a home (cf CatPort/TciServer). | unconverted |
 | `core/tnc/TncTerminal.h` | 1 | universal — Packet terminal session model (command/monitor); radio-agnostic operating feature. | unconverted |
-| `models/AntennaGeniusModel.h` | 4 | vendor(flex) — 4O3A Antenna Genius switch client: UDP discovery + SmartSDR-like TCP protocol; Flex-ecosystem accessory | unconverted |
+| `models/AntennaGeniusModel.h` | 4 | peripheral(4o3a) — 4O3A Antenna Genius switch client (own UDP discovery + direct TCP); standalone accessory, not radio wire | reclassified (#4089) |
 | `models/BandDefs.h` | 4 | universal — Static ARRL band plan table (edges, default freq/mode, GEN/WWV); canonical band-plan data, no vendor ties. | unconverted |
 | `models/BandPlanManager.h` | 7 | universal — Band-plan overlay data (segments/spots/license classes, region merge) from JSON; radio-agnostic canon | unconverted |
 | `models/BandSettings.h` | 4 | universal — Per-band save/restore of canonical state (freq/mode/filter/AGC/WNB/display range) — band memories, no vendor fields | unconverted |
@@ -146,7 +146,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `models/SpotModel.h` | 1 | universal — Panadapter spot store (callsign/freq/mode/lifetime/priority) on canonical state; kv ingest is trivially generic | unconverted |
 | `models/TnfModel.h` | 1 | universal — Tracking notch filter state (freq/width/depth/permanent, global enable) — generic DSP notch surface; kv parse is transport detail | unconverted |
 | `models/TransmitModel.h` | 14 | mixed(flex) — TX state model: power/MOX/VOX/CW/filter are core-profile; ATU, DAX, APD, profiles, interlock are Flex. | unconverted |
-| `models/TunerModel.h` | 3 | vendor(flex) — 4o3a TGXL tuner state/commands via SmartSDR 'atu'/'tgxl' TCP verbs + direct port-9010 relay control | unconverted |
+| `models/TunerModel.h` | 3 | mixed(flex) — generic external-tuner model (state) fused with a Flex TGXL radio-relay; core stays, relay splits behind the seam | split pending (#4092) |
 | `models/XvtrPolicy.h` | 5 | mixed(flex) — XVTR policy: transverter list/freq translation is core; waterfall-tile offset + FLEX model power clamps are flex | unconverted |
 
-**Tag legend:** `universal` = core-profile surface every radio family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a namespaced extension; `mixed` = header carries both (split candidates noted); `ui-support` = not radio state at all (settings, theming, app plumbing) — needs a home decision, not a protocol message.
+**Tag legend:** `universal` = core-profile surface every radio family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a namespaced extension (the EB3-gated set); `mixed` = header carries both (split candidates noted); `peripheral(<vendor>)` = a standalone accessory device's own transport/protocol (e.g. 4O3A Tgxl/Pgxl/AntennaGenius) — not the radio, not behind the radio seam; `ui-support` = not radio state at all (settings, theming, app plumbing, input surfaces) — needs a home decision, not a protocol message.

--- a/tools/check_engine_boundary.py
+++ b/tools/check_engine_boundary.py
@@ -95,12 +95,13 @@ KNOWN_WIDGETS_LEGACY = {
 # grows a vendor family but this checker keeps permitting it.
 VENDOR_TAGS_JSON = REPO / "docs" / "architecture" / "aetherd-touchpoint-tags.json"
 # Sanity floor: the audit currently tags 21 radio-family vendor headers (the
-# original 26 minus reclassified peripherals not behind the radio seam — the
-# 4O3A accessory family TunerModel/AntennaGeniusModel/Tgxl/Pgxl → peripheral(4o3a),
-# and the FlexControl USB knob → ui-support). This floor only guards against the
-# audit being moved/gutted (a parse yielding near zero), NOT the exact count —
-# deliberate reclassifications lower it over time, so keep the floor well below
-# the live count.
+# original 26 minus 5 that aren't radio-family wire — the direct 4O3A transports
+# TgxlConnection/PgxlConnection + the AntennaGenius switch → peripheral(4o3a);
+# the FlexControl USB knob → ui-support; and TunerModel → mixed(flex), a
+# generic-tuner model with a Flex TGXL relay to split, not vendor). This floor
+# only guards against the audit being moved/gutted (a parse yielding near zero),
+# NOT the exact count — deliberate reclassifications lower it over time, so keep
+# the floor well below the live count.
 VENDOR_STEMS_FLOOR = 15
 
 


### PR DESCRIPTION
## Corrects the TunerModel classification (follow-up to #4089)

`TunerModel` was tagged `peripheral(4o3a)` in #4089. The subsequent design discussion (SmartLink + "TunerModel should be usable by any 3rd-party vendor") showed that's wrong on both axes — it's **`mixed(flex)`**, the same category as the five 2.3 models:

- **Universal core:** it's meant to become a **vendor-neutral external-tuner model** (any 3rd-party tuner), and already holds generic tuner state — operate/bypass/tuning, SWR/fwd-power, antenna select, presence.
- **Flex extension fused in:** the TGXL radio-relay (SmartSDR `atu`/`tgxl`/`amplifier` passthrough). The radio relays **only** the TGXL, and — critically — that relay is the **only** control path for **remote/SmartLink** operation (the direct port-9010 socket is unreachable off-LAN). So it's **not disposable legacy**; it belongs *behind* the seam as an extension verb. The direct `TgxlConnection` (peripheral) is the *local fast-path*.

`peripheral(4o3a)` describes the **transport** (`TgxlConnection`), not the model.

### Changes (metadata/docs only)
- `TunerModel.h`: `peripheral(4o3a)` → **`mixed(flex)`**, with the core/Flex split written into its `split` field.
- Keep `TgxlConnection`/`PgxlConnection` `peripheral(4o3a)` (the direct transports) and `FlexControl` `ui-support`.
- Fix two notes to match the code:
  - `PgxlConnection` is **telemetry-only**; PGXL operate/standby is radio-proxied via `RadioModel::setAmpOperate` (`amplifier set operate`) — also the remote path. There is **no `AmpModel`** — amp state is folded into `RadioModel` and should be extracted (parallel to the TunerModel split).
  - `TunerModel` note rewritten for the mixed framing.
- `check_engine_boundary.py` floor comment + `AGENTS.md` updated to reflect the tag taxonomy (`mixed(flex)` is not EB3-gated).

### EB3 impact: none
`mixed` is not a `vendor(...)` tag, so the vendor vocabulary stays **21 stems** and the baseline is **unchanged** — verified `--strict` clean. No code, no build/behavior change.

Refs: #4089, #4092 (TunerModel split), + #4094 (AmpModel extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)