### PR TITLE
refactor(aetherd): 2.4 — extract AmpModel from RadioModel (#4094)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,6 +650,7 @@ set(MODEL_SOURCES
     src/models/PanadapterModel.cpp
     src/models/MeterModel.cpp
     src/models/TunerModel.cpp
+    src/models/AmpModel.cpp
     src/models/TransmitModel.cpp
     src/models/EqualizerModel.cpp
     src/models/TnfModel.cpp
@@ -2615,6 +2616,12 @@ target_include_directories(aetherd_residual_decode_test PRIVATE src)
 target_link_libraries(aetherd_residual_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(aetherd_residual_decode_test PROPERTIES AUTOMOC ON)
 add_test(NAME aetherd_residual_decode_test COMMAND aetherd_residual_decode_test)
+
+add_executable(amp_model_test tests/amp_model_test.cpp)
+target_include_directories(amp_model_test PRIVATE src)
+target_link_libraries(amp_model_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(amp_model_test PROPERTIES AUTOMOC ON)
+add_test(NAME amp_model_test COMMAND amp_model_test)
 
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -707,6 +707,12 @@
   "split": "",
   "confidence": "medium"
  },
+ "models/AmpModel.h": {
+  "tag": "mixed(flex)",
+  "note": "Power-amplifier state model (PGXL / any non-TGXL amp the radio proxies), extracted from RadioModel (#4094). Like TunerModel: universal amp state (presence/operate/telemetry) fused with a Flex relay — the radio-proxied 'amplifier set … operate=' command (the only path that works remote/SmartLink; the direct PgxlConnection is telemetry-only).",
+  "split": "Core (stays the model the UI/3rd-party amp sees): presence, operate/standby, telemetry (power/SWR/current/temp/voltage/band). Flex extension (move behind FlexBackend as an IRadioBackend extension verb): the 'amplifier' relay — commandReady 'amplifier set operate' + amplifier-status decode. 2.3-style split; see #4094.",
+  "confidence": "high"
+ },
  "models/AntennaGeniusModel.h": {
   "tag": "peripheral(4o3a)",
   "note": "4O3A Antenna Genius switch client — standalone accessory with its own UDP-broadcast discovery (port 9007) + direct TCP; connects by device IP/port independent of the radio, works with any radio. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up).",

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -848,7 +848,7 @@ void MainWindow::updateTMate2Indicators()
     const float dbm   = m_tmate2SmeterDbm;
     const float txPowerWatts = m_tmate2TxWatts;
     const float txPowerFullScaleWatts =
-        (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) ? 2000.0f : 100.0f;
+        (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate()) ? 2000.0f : 100.0f;
     auto& settings = AppSettings::instance();
     // TMate 2 settings list the main tuning encoder first, then the two
     // auxiliary encoders. The LCD labels those auxiliaries in the opposite

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -640,7 +640,7 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
     }
     if (obj == m_pgxlContainer && event->type() == QEvent::MouseButtonPress) {
         // Simple toggle: OPERATE ↔ STANDBY (PGXL has no BYPASS)
-        m_radioModel.setAmpOperate(!m_radioModel.ampOperate());
+        m_radioModel.amplifier().setOperate(!m_radioModel.amplifier().operate());
         return true;
     }
     if (obj == m_txIndicator && event->type() == QEvent::MouseButtonPress) {

--- a/src/gui/MainWindow_SwrSweep.cpp
+++ b/src/gui/MainWindow_SwrSweep.cpp
@@ -302,7 +302,7 @@ void MainWindow::startSwrSweep(int requestedSliceId, int sweepPowerWatts,
                              tr("Stop transmit or tune before starting an SWR sweep."));
         return;
     }
-    if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) {
+    if (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate()) {
         QMessageBox::warning(this, tr("SWR Sweep"),
                              tr("Put the Power Genius XL amplifier in STANDBY before running an SWR sweep."));
         return;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3576,7 +3576,7 @@ void MainWindow::wireMeters()
     // (~100 W) and amp (~1500 W) values race into the same widget. (#2927)
     connect(&m_radioModel.meterModel(), &MeterModel::txMetersChanged,
             this, [this](float fwd, float swr) {
-        if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate())
+        if (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate())
             return;
         m_appletPanel->sMeterWidget()->setTxMeters(fwd, swr);
 #ifdef HAVE_HIDAPI
@@ -3639,9 +3639,9 @@ void MainWindow::wireMeters()
     });
 
     // Auto-connect to PGXL when detected
-    connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this](bool present) {
-        if (present && !m_radioModel.ampIp().isEmpty() && !m_pgxlConn.isConnected()) {
-            m_pgxlConn.connectToPgxl(m_radioModel.ampIp());
+    connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged, this, [this](bool present) {
+        if (present && !m_radioModel.amplifier().ip().isEmpty() && !m_pgxlConn.isConnected()) {
+            m_pgxlConn.connectToPgxl(m_radioModel.amplifier().ip());
         } else if (!present) {
             m_pgxlConn.disconnect();
         }
@@ -3681,8 +3681,8 @@ void MainWindow::wireMeters()
         // Use peakfwd (actual peak power) not fwd (floor/minimum).
         // Skip when amp is STANDBY — peakfwd reads ~0 dBm in standby and would
         // stomp on the exciter feed that should drive the barefoot scale.
-        if (kvs.contains("peakfwd") && m_radioModel.hasAmplifier()
-                && m_radioModel.ampOperate()) {
+        if (kvs.contains("peakfwd") && m_radioModel.amplifier().present()
+                && m_radioModel.amplifier().operate()) {
             float dbm = kvs["peakfwd"].toFloat();
             float watts = std::pow(10.0f, (dbm - 30.0f) / 10.0f);
             qCDebug(lcTuner) << "PGXL→SMeter: peakfwd=" << dbm << "dBm =" << watts << "W";
@@ -3721,7 +3721,7 @@ void MainWindow::wireMeters()
     // path is faster and higher-precision (the radio rebroadcast may round/lag),
     // so we skip the radio fallback to avoid display jitter from two paths
     // alternately writing slightly-different values.
-    connect(&m_radioModel, &RadioModel::ampTelemetryUpdated,
+    connect(&m_radioModel.amplifier(), &AmpModel::telemetryUpdated,
             this, [this](const QMap<QString, QString>& kvs) {
         if (m_pgxlConn.isConnected()) return;
         auto* amp = m_appletPanel->ampApplet();
@@ -3752,11 +3752,10 @@ void MainWindow::wireMeters()
     connect(m_appletPanel->ampApplet(), &AmpApplet::fanModeChanged, this, [this](const QString& mode) {
         m_pgxlConn.sendCommand(QString("setup fanmode=%1").arg(mode));
     });
-    // OPERATE button → PGXL standby/operate command via radio amplifier API
+    // OPERATE button → PGXL standby/operate command (relayed via the radio's
+    // amplifier API by AmpModel::setOperate; no-op if no amp handle). #4094.
     connect(m_appletPanel->ampApplet(), &AmpApplet::operateToggled, this, [this](bool on) {
-        if (!m_radioModel.ampHandle().isEmpty())
-            m_radioModel.sendCommand(
-                QString("amplifier set %1 operate=%2").arg(m_radioModel.ampHandle()).arg(on ? 1 : 0));
+        m_radioModel.amplifier().setOperate(on);
     });
 
     // Switch Fwd Power gauge scale based on radio max power and amplifier presence.
@@ -3773,15 +3772,15 @@ void MainWindow::wireMeters()
         if (model.startsWith("AU-") && maxW <= 100) {
             maxW = 500;
         }
-        const bool ampActive = m_radioModel.hasAmplifier()
-                            && m_radioModel.ampOperate();
+        const bool ampActive = m_radioModel.amplifier().present()
+                            && m_radioModel.amplifier().operate();
         m_appletPanel->txApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->tunerApplet()->setPowerScale(maxW, ampActive);
         m_appletPanel->sMeterWidget()->setPowerScale(maxW, ampActive);
         m_appletPanel->healthApplet()->setPowerScale(maxW, ampActive);
     };
-    connect(&m_radioModel, &RadioModel::amplifierChanged, this, updatePowerScale);
-    connect(&m_radioModel, &RadioModel::ampStateChanged, this, updatePowerScale);
+    connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged, this, updatePowerScale);
+    connect(&m_radioModel.amplifier(), &AmpModel::stateChanged, this, updatePowerScale);
 
     // TGXL indicator: two-line rich text — label on top, state smaller below.
     // Green = OPERATE, amber = BYPASS, grey = STANDBY (matches SmartSDR)
@@ -3807,21 +3806,21 @@ void MainWindow::wireMeters()
 
     // PGXL indicator: OPERATE (green) or STANDBY (grey) — no bypass for PGXL
     auto updatePgxlStyle = [this, setIndicatorHtml]() {
-        if (m_radioModel.ampOperate())
+        if (m_radioModel.amplifier().operate())
             setIndicatorHtml(m_pgxlIndicator, m_pgxlStateLabel, "OPERATE", "#00e060");
         else
             setIndicatorHtml(m_pgxlIndicator, m_pgxlStateLabel, "STANDBY", "#404858");
     };
-    connect(&m_radioModel, &RadioModel::ampStateChanged, this, [this, updatePgxlStyle]() {
+    connect(&m_radioModel.amplifier(), &AmpModel::stateChanged, this, [this, updatePgxlStyle]() {
         updatePgxlStyle();
         // Sync the AmpApplet button — the direct PGXL TCP path may not deliver
         // a state update fast enough, leaving the button stuck on the old state.
         // RadioModel is authoritative; use it to keep the button consistent.
         m_appletPanel->ampApplet()->setState(
-            m_radioModel.ampOperate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
+            m_radioModel.amplifier().operate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
     });
 
-    connect(&m_radioModel, &RadioModel::amplifierChanged, this, [this, updatePgxlStyle](bool present) {
+    connect(&m_radioModel.amplifier(), &AmpModel::presenceChanged, this, [this, updatePgxlStyle](bool present) {
         m_pgxlContainer->setVisible(present);
         m_pgxlSeparator->setVisible(present);
         m_appletPanel->setAmpVisible(present);
@@ -3829,7 +3828,7 @@ void MainWindow::wireMeters()
         if (present) {
             updatePgxlStyle();
             m_appletPanel->ampApplet()->setState(
-                m_radioModel.ampOperate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
+                m_radioModel.amplifier().operate() ? QStringLiteral("OPERATE") : QStringLiteral("STANDBY"));
         }
     });
     connect(&m_radioModel.meterModel(), &MeterModel::ampMetersChanged,
@@ -3840,7 +3839,7 @@ void MainWindow::wireMeters()
         // S-Meter TX power follows the scale: amp output when PGXL is OPERATE,
         // exciter output when it's STANDBY (txMetersChanged already handles that
         // path, so we just stop overriding it here).
-        if (m_radioModel.hasAmplifier() && m_radioModel.ampOperate()) {
+        if (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate()) {
             m_appletPanel->sMeterWidget()->setTxMeters(fwdPwr, swr);
 #ifdef HAVE_HIDAPI
             m_tmate2TxWatts = fwdPwr;

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -300,7 +300,7 @@ static QString radioOptionsText(const RadioModel* model)
     if (!model->radioOptions().isEmpty()) {
         return model->radioOptions();
     }
-    return model->hasAmplifier() ? QStringLiteral("GPS, PGXL") : QStringLiteral("GPS");
+    return model->amplifier().present() ? QStringLiteral("GPS, PGXL") : QStringLiteral("GPS");
 }
 
 static void showCopiedPopup(QWidget* anchor);

--- a/src/models/AmpModel.cpp
+++ b/src/models/AmpModel.cpp
@@ -1,0 +1,65 @@
+#include "AmpModel.h"
+
+namespace AetherSDR {
+
+void AmpModel::applyStatus(const QString& handle, const QString& model,
+                           const QMap<QString, QString>& kvs)
+{
+    // Presence: any non-empty, non-TGXL amp model marks a power amp present.
+    // (The radio reports both TGXL and PGXL via the "amplifier" API; the caller
+    // routes TunerGeniusXL to TunerModel and everything else here.)
+    if (!model.isEmpty() && model != QLatin1String("TunerGeniusXL")) {
+        m_handle = handle;
+        if (!m_present) {
+            m_present = true;
+            m_ip = kvs.value(QStringLiteral("ip"));
+            m_model = model;
+            emit presenceChanged(true);
+        }
+    }
+
+    if (!m_handle.isEmpty() && handle == m_handle) {
+        // PGXL uses "state=OPERATE|IDLE|STANDBY|TRANSMIT…" (not operate=/bypass=
+        // like TGXL). IDLE = on/ready, STANDBY = off, TRANSMIT* = keyed.
+        const QString state = kvs.value(QStringLiteral("state")).toUpper();
+        if (!state.isEmpty()) {
+            const bool op = (state == QLatin1String("IDLE")
+                             || state == QLatin1String("OPERATE")
+                             || state.startsWith(QLatin1String("TRANSMIT")));
+            if (m_operate != op) {
+                m_operate = op;
+                emit stateChanged();
+            }
+        }
+        // Forward the full KVS so the GUI can update telemetry (drain current,
+        // mains voltage, meffa, temp) without a direct PGXL TCP connection.
+        emit telemetryUpdated(kvs);
+    }
+}
+
+void AmpModel::handleRemoval(const QString& handle)
+{
+    if (handle == m_handle) {
+        m_handle.clear();
+        m_present = false;
+        m_model.clear();
+        emit presenceChanged(false);
+    }
+}
+
+void AmpModel::reset()
+{
+    m_present = false;
+    m_handle.clear();
+    m_operate = false;
+}
+
+void AmpModel::setOperate(bool on)
+{
+    if (m_handle.isEmpty()) return;
+    // FlexLib API: "amplifier set <handle> operate=0|1". The radio relays it to
+    // the PGXL (the only path that works remote/SmartLink).
+    emit commandReady(QString("amplifier set %1 operate=%2").arg(m_handle).arg(on ? 1 : 0));
+}
+
+}  // namespace AetherSDR

--- a/src/models/AmpModel.h
+++ b/src/models/AmpModel.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QObject>
+#include <QMap>
+#include <QString>
+
+namespace AetherSDR {
+
+// State model for a power amplifier the radio reports through its "amplifier"
+// API (today: 4O3A Power Genius XL / PGXL — any non-TGXL amp the radio proxies).
+// Extracted from RadioModel (#4094).
+//
+// Intended to become vendor-neutral: it holds the universal amp state
+// (presence / operate / telemetry) and, for now, encapsulates the Flex
+// "amplifier set … operate=" relay by emitting commandReady (the same pattern
+// TunerModel uses). That relay is RADIO-PROXIED and is the ONLY path that works
+// for remote/SmartLink operation — the direct PgxlConnection (port 9008) is
+// telemetry-only. A later split moves the Flex decode/encode behind FlexBackend
+// as an IRadioBackend extension verb (see #4094); until then this is mixed(flex).
+class AmpModel : public QObject {
+    Q_OBJECT
+
+public:
+    explicit AmpModel(QObject* parent = nullptr) : QObject(parent) {}
+
+    // ---- state ----
+    bool    present()   const { return m_present; }
+    bool    operate()   const { return m_operate; }
+    QString handle()    const { return m_handle; }
+    QString ip()        const { return m_ip; }      // for the direct PGXL connection
+    QString modelName() const { return m_model; }   // e.g. "PowerGeniusXL"
+
+    // Apply a decoded (non-removal) "amplifier <handle> model=… state=… …"
+    // status. `model` is the wire "model" key; a non-empty, non-TGXL model marks
+    // a power amp present. Present-only telemetry rides on telemetryUpdated.
+    void applyStatus(const QString& handle, const QString& model,
+                     const QMap<QString, QString>& kvs);
+    // Handle an "amplifier <handle> removed" — clears state if it's our amp.
+    void handleRemoval(const QString& handle);
+    // Bulk clear on radio disconnect/teardown (matches RadioModel's prior reset).
+    void reset();
+
+    // Operate/standby command. Emits commandReady with the SmartSDR verb, which
+    // the radio relays (the path that works remote). No-op without a handle.
+    void setOperate(bool on);
+
+signals:
+    void presenceChanged(bool present);                       // amp detected / lost
+    void stateChanged();                                      // operate changed
+    void telemetryUpdated(const QMap<QString, QString>& kvs); // raw amp KVS for the GUI
+    void commandReady(const QString& cmd);                    // → radio command sink
+
+private:
+    bool    m_present{false};
+    bool    m_operate{false};
+    QString m_handle;
+    QString m_ip;
+    QString m_model;
+};
+
+}  // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -652,6 +652,13 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_amplifier, &AmpModel::commandReady, this, [this](const QString& cmd){
         sendCmd(cmd);
     });
+    // Protocol-log breadcrumb on amp detection, symmetric with the "amplifier
+    // removed" log — kept here so AmpModel stays logging-category-free. #4099.
+    connect(&m_amplifier, &AmpModel::presenceChanged, this, [this](bool present){
+        if (present)
+            qCDebug(lcProtocol) << "RadioModel: power amplifier detected, model="
+                                << m_amplifier.modelName() << "ip=" << m_amplifier.ip();
+    });
 
     m_transmitModel.setPttPreflight([this](TransmitModel::PttSource source) {
         m_pendingTransmitPreflightSource = source;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -647,6 +647,12 @@ RadioModel::RadioModel(QObject* parent)
         sendCmd(cmd);
     });
 
+    // Forward amplifier (PGXL) commands to the radio — the radio relays "amplifier
+    // set … operate=" to the amp (the path that works remote/SmartLink). #4094.
+    connect(&m_amplifier, &AmpModel::commandReady, this, [this](const QString& cmd){
+        sendCmd(cmd);
+    });
+
     m_transmitModel.setPttPreflight([this](TransmitModel::PttSource source) {
         m_pendingTransmitPreflightSource = source;
         return localPttInterlockMessage(source);
@@ -3090,9 +3096,7 @@ void RadioModel::onDisconnected()
     // Must re-derive everything from the new radio's status on next connect. (#359)
     m_tunerModel.setHandle({});       // clear TGXL presence
     m_xvtrList.clear();
-    m_hasAmplifier = false;
-    m_ampHandle.clear();
-    m_ampOperate = false;
+    m_amplifier.reset();              // clear PGXL presence/operate (#4094)
     m_fullDuplex = false;
     // Reset to false so the next connect's skip-peek fast path requires the
     // radio's mf_enable status to actually arrive before treating multiFLEX
@@ -3883,12 +3887,6 @@ void RadioModel::requestLocalPtt()
     });
 }
 
-void RadioModel::setAmpOperate(bool on)
-{
-    if (m_ampHandle.isEmpty()) return;
-    // FlexLib API: "amplifier set <handle> operate=0|1"
-    sendCmd(QString("amplifier set %1 operate=%2").arg(m_ampHandle).arg(on ? 1 : 0));
-}
 
 void RadioModel::createRxAudioStream()
 {
@@ -5255,18 +5253,16 @@ void RadioModel::onStatusReceived(const QString& object,
     static const QRegularExpression ampRe(R"(^amplifier\s+(\S+)$)");
     static const QRegularExpression ampRemovedRe(R"(^amplifier\s+(\S+)\s+removed$)");
     if (object.startsWith("amplifier")) {
+        // The radio reports both TGXL and PGXL via the "amplifier" API; route
+        // TunerGeniusXL to TunerModel and every other (power) amp to AmpModel.
+        // (#4094: amp state extracted from RadioModel into AmpModel.)
         const auto rm = ampRemovedRe.match(object);
         if (rm.hasMatch()) {
             const QString handle = rm.captured(1);
             qCDebug(lcProtocol) << "RadioModel: amplifier removed (bare) handle=" << handle;
             if (handle == m_tunerModel.handle())
                 m_tunerModel.setHandle({});
-            if (handle == m_ampHandle) {
-                m_ampHandle.clear();
-                m_hasAmplifier = false;
-                m_ampModel.clear();
-                emit amplifierChanged(false);
-            }
+            m_amplifier.handleRemoval(handle);
             return;
         }
         const auto m = ampRe.match(object);
@@ -5279,12 +5275,7 @@ void RadioModel::onStatusReceived(const QString& object,
             if (kvs.contains("removed")) {
                 if (handle == m_tunerModel.handle())
                     m_tunerModel.setHandle({});
-                if (handle == m_ampHandle) {
-                    m_ampHandle.clear();
-                    m_hasAmplifier = false;
-                    m_ampModel.clear();
-                    emit amplifierChanged(false);
-                }
+                m_amplifier.handleRemoval(handle);
                 return;
             }
 
@@ -5302,35 +5293,8 @@ void RadioModel::onStatusReceived(const QString& object,
                 m_tunerModel.applyStatus(kvs);
             }
 
-            // Track power amplifier state (PGXL or any non-TGXL amp).
-            // PGXL uses "state=OPERATE|IDLE|BYPASS|..." (not operate=/bypass= like TGXL)
-            if (!model.isEmpty() && model != "TunerGeniusXL") {
-                m_ampHandle = handle;
-                if (!m_hasAmplifier) {
-                    m_hasAmplifier = true;
-                    m_ampIp = kvs.value("ip");
-                    m_ampModel = model;
-                    qCDebug(lcProtocol) << "RadioModel: power amplifier detected, model=" << model
-                                       << "ip=" << m_ampIp;
-                    emit amplifierChanged(true);
-                }
-            }
-            if (!m_ampHandle.isEmpty() && handle == m_ampHandle) {
-                const QString state = kvs.value("state").toUpper();
-                if (!state.isEmpty()) {
-                    // PGXL states: IDLE = on/ready, STANDBY = off, POWERUP = transitioning
-                    bool op = (state == "IDLE" || state == "OPERATE"
-                               || state.startsWith("TRANSMIT"));
-                    if (m_ampOperate != op) {
-                        m_ampOperate = op;
-                        emit ampStateChanged();
-                    }
-                }
-                // Forward the full KVS so the GUI can update telemetry fields
-                // (id/drain current, vac/mains voltage, meffa, temp) without
-                // requiring a direct PGXL TCP connection.
-                emit ampTelemetryUpdated(kvs);
-            }
+            // Power amplifier (PGXL / any non-TGXL amp) → AmpModel.
+            m_amplifier.applyStatus(handle, model, kvs);
         }
         return;
     }
@@ -6467,10 +6431,10 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     radio["filter_sharpness"] = filterSharpness;
 
     QJsonObject amplifier;
-    amplifier["present"] = m_hasAmplifier;
-    amplifier["handle"] = m_ampHandle;
-    amplifier["model"] = m_ampModel;
-    amplifier["operate"] = m_ampOperate;
+    amplifier["present"] = m_amplifier.present();
+    amplifier["handle"] = m_amplifier.handle();
+    amplifier["model"] = m_amplifier.modelName();
+    amplifier["operate"] = m_amplifier.operate();
     radio["amplifier"] = amplifier;
 
     QJsonObject ownership;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -15,6 +15,7 @@
 #include "MeterModel.h"
 #include "PanadapterModel.h"
 #include "TunerModel.h"
+#include "AmpModel.h"
 #include "TransmitModel.h"
 #include "EqualizerModel.h"
 #include "TnfModel.h"
@@ -81,11 +82,10 @@ public:
     UsbCableModel&    usbCableModel()    { return m_usbCableModel; }
     DaxIqModel&       daxIqModel()       { return m_daxIqModel; }
     FlexWaveformModel& flexWaveformModel() { return m_flexWaveformModel; }
-    bool              hasAmplifier() const { return m_hasAmplifier; }
-    bool              ampOperate()   const { return m_ampOperate; }
-    QString           ampHandle()    const { return m_ampHandle; }
-    QString           ampIp()        const { return m_ampIp; }
-    QString           ampModel()     const { return m_ampModel; }
+    // Power amplifier (PGXL / any non-TGXL amp the radio proxies). Extracted
+    // from RadioModel (#4094); consumers bind it like the other sub-models.
+    AmpModel&         amplifier()        { return m_amplifier; }
+    const AmpModel&   amplifier() const  { return m_amplifier; }
 
     // Getters
     QString name()    const { return m_name; }
@@ -94,7 +94,6 @@ public:
     bool isConnected() const;
     bool fullDuplexEnabled() const { return m_fullDuplex; }
     void setFullDuplex(bool on) { m_fullDuplex = on; emit infoChanged(); }
-    void setAmpOperate(bool on);
     float paTemp()    const { return m_paTemp; }
     float txPower()   const { return m_txPower; }
     bool  isRadioTransmitting() const { return m_radioTransmitting; }
@@ -476,12 +475,8 @@ signals:
     void antListChanged(QStringList ants);
     // Local AetherSDR display aliases changed. The radio still uses canonical tokens.
     void antennaAliasesChanged();
-    // Emitted when a power amplifier (e.g. PGXL) is detected or lost.
-    void amplifierChanged(bool present);
-    void ampStateChanged();   // amplifier operate/bypass changed
-    // Raw KVS from the radio's amplifier status message (id, vac, meffa, temp, state, …).
-    // Emitted on every update so the GUI can refresh telemetry without a direct PGXL connection.
-    void ampTelemetryUpdated(const QMap<QString, QString>& kvs);
+    // (Amplifier presence/state/telemetry signals moved to AmpModel — bind
+    //  m_radioModel.amplifier() directly. #4094.)
     void memoryChanged(int index);
     void memoryRemoved(int index);
     void memoriesCleared();
@@ -832,11 +827,7 @@ private:
     // emit "removed").
     QMap<QString, QPair<qint64, QMap<QString, QString>>> m_pendingPanStatuses;
 
-    bool    m_hasAmplifier{false};  // true if a power amp (PGXL) is detected
-    QString m_ampHandle;             // amplifier handle for commands
-    QString m_ampIp;                 // amplifier IP for direct connection
-    QString m_ampModel;              // "PowerGeniusXL"
-    bool    m_ampOperate{false};
+    AmpModel m_amplifier;            // power amp (PGXL) state + relay (#4094)
 
     // GPS state
     QString m_gpsStatus;           // "Locked", "Present", "Not Present"

--- a/tests/amp_model_test.cpp
+++ b/tests/amp_model_test.cpp
@@ -1,0 +1,121 @@
+// AmpModel unit test — pins the power-amplifier (PGXL) state machine extracted
+// from RadioModel (#4094): presence/operate derivation, telemetry forwarding,
+// removal, reset, and the operate-command relay. Guards the behavior-neutral
+// extraction (the 73 model tests didn't cover amp state directly).
+
+#include "models/AmpModel.h"
+
+#include <QCoreApplication>
+#include <QMap>
+#include <QSignalSpy>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+static QMap<QString, QString> kv(std::initializer_list<std::pair<QString, QString>> l)
+{
+    QMap<QString, QString> m;
+    for (const auto& p : l) m.insert(p.first, p.second);
+    return m;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ---- presence detection: ip/model captured on the first status only ----
+    {
+        AmpModel amp;
+        QSignalSpy presence(&amp, &AmpModel::presenceChanged);
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"ip", "192.168.1.50"}, {"state", "STANDBY"}}));
+        CHECK(amp.present());
+        CHECK(amp.handle() == "0x1000");
+        CHECK(amp.ip() == "192.168.1.50");
+        CHECK(amp.modelName() == "PowerGeniusXL");
+        CHECK(!amp.operate());                 // STANDBY → off
+        CHECK(presence.count() == 1);
+        CHECK(presence.takeFirst().at(0).toBool() == true);
+    }
+
+    // ---- TGXL is NOT a power amp (never marks present) ----
+    {
+        AmpModel amp;
+        amp.applyStatus("0x2000", "TunerGeniusXL", kv({{"state", "OPERATE"}}));
+        CHECK(!amp.present());
+        CHECK(amp.handle().isEmpty());
+    }
+
+    // ---- operate derivation: IDLE/OPERATE/TRANSMIT* = on, STANDBY = off; change-gated ----
+    {
+        AmpModel amp;
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "STANDBY"}}));
+        QSignalSpy st(&amp, &AmpModel::stateChanged);
+        amp.applyStatus("0x1000", "", kv({{"state", "IDLE"}}));       // later updates omit model
+        CHECK(amp.operate() && st.count() == 1);
+        amp.applyStatus("0x1000", "", kv({{"state", "OPERATE"}}));    // still on → no re-emit
+        CHECK(amp.operate() && st.count() == 1);
+        amp.applyStatus("0x1000", "", kv({{"state", "TRANSMIT_A"}})); // keyed → on
+        CHECK(amp.operate() && st.count() == 1);
+        amp.applyStatus("0x1000", "", kv({{"state", "STANDBY"}}));    // off
+        CHECK(!amp.operate() && st.count() == 2);
+    }
+
+    // ---- telemetry emitted for a matching handle, ignored otherwise ----
+    {
+        AmpModel amp;
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
+        QSignalSpy tel(&amp, &AmpModel::telemetryUpdated);
+        amp.applyStatus("0x1000", "", kv({{"temp", "42"}, {"id", "3.1"}}));
+        CHECK(tel.count() == 1);
+        amp.applyStatus("0x9999", "", kv({{"temp", "99"}}));          // foreign handle → ignored
+        CHECK(tel.count() == 1);
+    }
+
+    // ---- removal clears presence for our handle only ----
+    {
+        AmpModel amp;
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
+        CHECK(amp.present());
+        QSignalSpy presence(&amp, &AmpModel::presenceChanged);
+        amp.handleRemoval("0x9999");           // not ours → no-op
+        CHECK(amp.present() && presence.count() == 0);
+        amp.handleRemoval("0x1000");
+        CHECK(!amp.present() && amp.handle().isEmpty());
+        CHECK(presence.count() == 1 && presence.takeFirst().at(0).toBool() == false);
+    }
+
+    // ---- setOperate relays the SmartSDR verb; no-op without a handle ----
+    {
+        AmpModel amp;
+        QSignalSpy cmd(&amp, &AmpModel::commandReady);
+        amp.setOperate(true);                  // no handle yet → nothing
+        CHECK(cmd.count() == 0);
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "STANDBY"}}));
+        amp.setOperate(true);
+        CHECK(cmd.count() == 1);
+        CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=1");
+        amp.setOperate(false);
+        CHECK(cmd.count() == 1);
+        CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=0");
+    }
+
+    // ---- reset clears present/handle/operate ----
+    {
+        AmpModel amp;
+        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
+        amp.reset();
+        CHECK(!amp.present() && amp.handle().isEmpty() && !amp.operate());
+    }
+
+    if (g_failures == 0) {
+        std::printf("amp_model_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("amp_model_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Extract the power-amplifier state into a dedicated model

Moves PGXL (and any non-TGXL amp the radio proxies) state out of `RadioModel` into a new **`AmpModel`** — the amplifier parallel to `TunerModel`. This is the concrete, unblocked first step of #4094: **pure, behavior-neutral extraction**. No wire behavior changes.

### What moved
- **New `models/AmpModel.{h,cpp}`** — owns `present`/`operate`/`handle`/`ip`/`model` + telemetry; `applyStatus(handle, model, kvs)` (the PGXL decode lifted out of RadioModel), `handleRemoval`, `reset`, `setOperate(bool)` (emits `commandReady`, like TunerModel). Signals `presenceChanged`/`stateChanged`/`telemetryUpdated`/`commandReady`.
- **`RadioModel`** — dropped `m_hasAmplifier`/`m_ampHandle`/`m_ampIp`/`m_ampModel`/`m_ampOperate`, `setAmpOperate`, the amp getters, and the three amp signals. Owns an `AmpModel m_amplifier` via `amplifier()` (const + non-const). The `amplifier`-status handler keeps TGXL→`TunerModel` routing and delegates the PGXL half to the model; `commandReady → sendCmd` wired; `reset()`/`getState()` read the model.
- **~20 GUI consumers** (`MainWindow_Wiring`/`_Shortcuts`/`_Controllers`/`_SwrSweep`, `RadioSetupDialog`) repointed to `m_radioModel.amplifier()…`, matching the existing `tunerModel()` sub-model pattern; the `operateToggled` handler consolidated onto `AmpModel::setOperate`.
- **Audit**: `AmpModel.h` tagged `mixed(flex)` (universal amp state + Flex `amplifier` relay to split later). Vendor count unchanged (21); EB3-neutral.

### Verification
- Full build clean; **74/74 ctest** (added `tests/amp_model_test.cpp` pinning the state machine — presence, operate derivation `IDLE`/`OPERATE`/`TRANSMIT*`→on / `STANDBY`→off, change-gating, telemetry, removal, reset, operate relay).
- `check_engine_boundary.py --strict` clean.
- **Adversarial red-team**: verified behavior-neutral line-for-line against the pre-refactor handler — state machine, signal arity, the `sendCommand`→`sendCmd` command path (equivalent for a non-`display pan set` command), consumers, and TGXL routing all preserved. Only two immaterial `lcProtocol` debug-trace lines dropped.

### Deferred (kept minimal, per #4094)
Moving the amp decode/encode **behind `FlexBackend`** as an `IRadioBackend` extension verb (so `AmpModel` emits neutral intents) stays a follow-up — that's the step-3-adjacent half. This PR is the extraction only.

Refs #4094. No Tier-1 files touched (CMake/docs are Tier 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)