### PR TITLE
fix(applet-panel): pin side-panel tiles to sizeHint so few-tile layouts don't gap (#3461) + clickAt bridge verb

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -137,6 +137,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`showMenu <target>`](#showmenu-alias-openmenu) | Pop a button's drop-down menu (alias `openMenu`). |
 | | [`contextMenu <target> [x y]`](#contextmenu) | Trigger a custom right-click menu. |
 | | [`hitTest <target> [x y]`](#hittest) | Read Qt's widget owner for a target-local point. |
+| | [`clickAt [<target>] <x> <y>`](#clickat) | Click at a global (or target-local) point — fallback when name matching is ambiguous (TX-guarded). |
 | | [`menu list \| open <name>`](#menu) | Enumerate / pop a menu-bar menu. |
 | | [`resize <w> <h> [target]`](#resize) | Resize a window (drives panadapter `x_pixels`). |
 | | [`window <state> [target]`](#window) | maximize / restore / minimize / fullscreen. |
@@ -856,6 +857,43 @@ owner at the same screen point.
    "childAt":{"class":"VfoWidget",...},
    "widgetAt":{"class":"VfoWidget",...}}
 ```
+
+### `clickAt`
+Synthesize a real left-click (`press`→`release`) at a **point** rather than at a
+named widget. This is the escape hatch for when `invoke`/name matching can't reach
+the control you want — most commonly because several widgets share the same
+`accessibleName` (every side-panel tile's close button is `containerClose`, its
+float toggle `containerFloatToggle`, etc.), so `invoke` can only ever hit the
+**first** match. `dumpTree` reports widget `geometry` in **global (screen)**
+coordinates, so clicking the centre of a tile's dumpTree rect clicks exactly that
+tile's control.
+
+Two forms:
+- **`clickAt <x> <y>`** — `x y` are **global** screen coordinates. The bridge
+  clicks whatever `QApplication::widgetAt(x, y)` resolves (the topmost widget at
+  that point).
+- **`clickAt <target> <x> <y>`** — `x y` are **local** to `<target>` (like
+  `hitTest`); the click is routed to the deepest `childAt` that point.
+
+The click is **TX-guarded** exactly like `invoke`: if the resolved widget is a
+transmit-keying control it is refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — a
+coordinate click is never a hole around the keying gate. Delivery is deferred one
+main-loop turn (`"deferred":true`), so any popup/dialog it raises runs on a clean
+stack; follow with `dumpTree`/`grab` to read the result.
+
+```json
+→ {"cmd":"clickAt","x":1420,"y":210}          // global point (or "value":"1420 210")
+← {"ok":true,"clicked":{"class":"QPushButton","accessibleName":"containerClose",…},
+   "globalX":1420,"globalY":210,"localX":7,"localY":6,"deferred":true}
+
+→ {"cmd":"clickAt","target":"AppletPanel","value":"12 34"}   // point local to a widget
+← {"ok":true,"clicked":{"class":"…"},"globalX":1318,"globalY":97,
+   "localX":12,"localY":34,"deferred":true}
+```
+
+Recipe — close a **specific** side-panel tile (not just the first `containerClose`):
+read the target tile's `containerClose` rect from `dumpTree`, compute its centre in
+global coordinates, and `clickAt` that point.
 
 ### `menu`
 Enumerate or pop a **menu-bar** menu. On macOS the native menu bar reparents its

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -873,13 +873,28 @@ Two forms:
   clicks whatever `QApplication::widgetAt(x, y)` resolves (the topmost widget at
   that point).
 - **`clickAt <target> <x> <y>`** — `x y` are **local** to `<target>` (like
-  `hitTest`); the click is routed to the deepest `childAt` that point.
+  `hitTest`); the point must lie inside the target's rect, and the click is
+  routed to the deepest `childAt` that point.
 
-The click is **TX-guarded** exactly like `invoke`: if the resolved widget is a
-transmit-keying control it is refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — a
-coordinate click is never a hole around the keying gate. Delivery is deferred one
-main-loop turn (`"deferred":true`), so any popup/dialog it raises runs on a clean
-stack; follow with `dumpTree`/`grab` to read the result.
+The click is **TX-guarded** like `invoke`, but stricter: the guard walks the
+**whole ancestor chain** of the widget under the point (Qt propagates an
+unaccepted press to parents, so a click on a passive child of a keying control
+must be refused too) and is refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — a
+coordinate click is never a hole around the keying gate. Clicks on the RF/Tune
+power sliders are refused while `AETHER_AUTOMATION_TX_MAX_POWER` is armed (a
+groove click can't be clamped — use `invoke … setValue`, which is). A disabled
+widget under the point is refused (`"disabled":true`), same as `invoke`.
+
+Delivery is deferred one main-loop turn (`"deferred":true`), so any popup/dialog
+it raises runs on a clean stack; follow with `dumpTree`/`grab` to read the
+result. Because the reply is sent **before** delivery, anything already queued
+(a relayout, a pan re-center) can change what that pixel means by the time the
+press lands — re-`dumpTree` right before `clickAt` and don't interleave other
+mutating verbs in between.
+
+In the reply, `localX`/`localY` are local to the widget the click was **routed
+to** (`clicked`) — the deepest child — not to the named `<target>`, so for the
+target-local form they generally differ from the `x y` you sent.
 
 ```json
 → {"cmd":"clickAt","x":1420,"y":210}          // global point (or "value":"1420 210")
@@ -888,8 +903,12 @@ stack; follow with `dumpTree`/`grab` to read the result.
 
 → {"cmd":"clickAt","target":"AppletPanel","value":"12 34"}   // point local to a widget
 ← {"ok":true,"clicked":{"class":"…"},"globalX":1318,"globalY":97,
-   "localX":12,"localY":34,"deferred":true}
+   "localX":5,"localY":3,"deferred":true}     // local to `clicked`, not to AppletPanel
 ```
+
+The JSON `x`/`y` fields must both be present and JSON-numeric; a missing or
+string-typed coordinate is rejected rather than coerced to 0 (which would click
+the screen edge).
 
 Recipe — close a **specific** side-panel tile (not just the first `containerClose`):
 read the target tile's `containerClose` rect from `dumpTree`, compute its centre in

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1959,9 +1959,16 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         timeoutMs = obj.value(QStringLiteral("timeoutMs")).toInt(0);
         // clickAt accepts numeric x/y fields directly (dumpTree geometry is
         // global), folded into `value` as "x y" so both request forms share one
-        // code path. Explicit `value` still wins if supplied.
-        if (cmd == QLatin1String("clickAt") && value.isEmpty()
-            && (obj.contains(QStringLiteral("x")) || obj.contains(QStringLiteral("y")))) {
+        // code path. Explicit `value` still wins if supplied. Fold ONLY when
+        // both fields are present and JSON-numeric: toInt() coerces a missing
+        // field or a string-typed number to 0, which would turn a malformed
+        // request into a real click at the screen edge (or (0,0)) instead of
+        // an error — leave value empty so doClickAt rejects it. Match the verb
+        // case-insensitively like the dispatcher does.
+        if ((cmd == QLatin1String("clickAt") || cmd == QLatin1String("clickat"))
+            && value.isEmpty()
+            && obj.value(QStringLiteral("x")).isDouble()
+            && obj.value(QStringLiteral("y")).isDouble()) {
             value = QString::number(obj.value(QStringLiteral("x")).toInt())
                     + QLatin1Char(' ')
                     + QString::number(obj.value(QStringLiteral("y")).toInt());
@@ -4772,11 +4779,21 @@ QJsonObject AutomationServer::doHitTest(const QString& target,
 // centre of the target's dumpTree rect and you click exactly that widget. With a
 // target, x/y are interpreted LOCAL to that widget instead (like hitTest).
 //
-// Safety: the click is routed to the deepest child under the point and passed
-// through the SAME TX-keying guard as invoke() — a coordinate click must never
-// be a hole around AETHER_AUTOMATION_ALLOW_TX. Delivery (press+release) is
-// deferred to a clean main-loop turn so any popup menu/dialog the click raises
-// runs on a normal stack, mirroring the invoke() re-entrancy fix.
+// Safety: the click is routed to the deepest child under the point, but the
+// TX-keying guard walks the WHOLE ancestor chain from that child to its window.
+// Qt re-delivers an unaccepted press to parentWidget() until some ancestor
+// accepts it, so guarding only the hit widget would let a click on a passive
+// child (a QLabel inside a composite button — see PanLayoutDialog for the live
+// pattern) propagate into an unguarded keying parent. Guarding the chain makes
+// the check match Qt's delivery semantics — safe by construction, not by the
+// accident that today's keying buttons happen to be childless. A coordinate
+// click must never be a hole around AETHER_AUTOMATION_ALLOW_TX. (#3646 safety.)
+// For the same propagation reason a disabled hit widget is refused outright:
+// Qt drops input to disabled widgets, so the click would either silently no-op
+// (while we report ok:true) or fall through to an unvetted ancestor.
+// Delivery (press+release) is deferred to a clean main-loop turn so any popup
+// menu/dialog the click raises runs on a normal stack, mirroring the invoke()
+// re-entrancy fix.
 QJsonObject AutomationServer::doClickAt(const QString& target,
                                         const QString& value) const
 {
@@ -4809,23 +4826,79 @@ QJsonObject AutomationServer::doClickAt(const QString& target,
             return err(QStringLiteral("refused: '") + target
                        + QStringLiteral("' is not visible"));
         const QPoint local(x, y);
+        // Out-of-bounds local points must not click at all: Qt would translate
+        // the press up the parent chain and land it on an ancestor the caller
+        // never named (and the TX guard below never saw the reply claim for).
+        if (!w->rect().contains(local)) {
+            return err(QStringLiteral("clickAt: (") + QString::number(x)
+                       + QStringLiteral(", ") + QString::number(y)
+                       + QStringLiteral(") is outside '") + target
+                       + QStringLiteral("' (") + QString::number(w->width())
+                       + QStringLiteral("x") + QString::number(w->height())
+                       + QStringLiteral(")"));
+        }
         global = w->mapToGlobal(local);
         if (QWidget* child = w->childAt(local))
             w = child;  // route to the deepest child for a faithful click
     }
 
+    // Refuse a disabled hit widget, exactly like invoke(): Qt drops input
+    // events to disabled widgets, so the click is a silent no-op that we would
+    // otherwise report as ok:true — the control is greyed out for a reason.
+    // isEnabled() is effective (false if any ancestor is disabled). (#3646)
+    if (!w->isEnabled()) {
+        return QJsonObject{{QStringLiteral("ok"), false},
+                           {QStringLiteral("error"),
+                            QStringLiteral("refused: '") + shortClassName(w)
+                                + QStringLiteral("' at the point is disabled — "
+                                                 "the click would be dropped")},
+                           {QStringLiteral("disabled"), true},
+                           {QStringLiteral("class"), shortClassName(w)}};
+    }
+
     // TX-safety guard — a raw coordinate click must honor the same opt-in as
-    // invoke(), or it becomes a bypass around the keying gate. (#3646 safety.)
-    if (isTransmitControl(w)
-        && !qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
-        qCWarning(lcAutomation).noquote()
-            << "BLOCKED transmit-related clickAt on" << shortClassName(w)
-            << "at global" << global;
-        return err(QStringLiteral("blocked: point resolves to '")
-                   + shortClassName(w)
-                   + QStringLiteral("', a transmit-keying control (TX-safety "
-                                    "guard). Set AETHER_AUTOMATION_ALLOW_TX=1 "
-                                    "to override."));
+    // invoke(), or it becomes a bypass around the keying gate. Walk the whole
+    // ancestor chain (see the function comment): an unaccepted press propagates
+    // to parents, so every widget Qt could deliver this click to must pass.
+    // (#3646 safety.)
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+        for (const QWidget* p = w; p; p = p->parentWidget()) {
+            if (!isTransmitControl(p)) {
+                continue;
+            }
+            qCWarning(lcAutomation).noquote()
+                << "BLOCKED transmit-related clickAt on" << shortClassName(w)
+                << "(keying control in chain:" << shortClassName(p)
+                << ") at global" << global;
+            return err(QStringLiteral("blocked: point resolves into '")
+                       + shortClassName(p)
+                       + QStringLiteral("', a transmit-keying control (TX-safety "
+                                        "guard). Set AETHER_AUTOMATION_ALLOW_TX=1 "
+                                        "to override."));
+        }
+    }
+
+    // Power-ceiling rail (#3646): invoke() clamps RF/Tune power setValue to
+    // AETHER_AUTOMATION_TX_MAX_POWER, but a groove click on the slider pages
+    // the setpoint to an arbitrary value we cannot clamp after the fact. When
+    // the rail is armed, refuse the click and point at the clamped path instead
+    // of letting a coordinate click walk power past the configured ceiling.
+    if (m_txMaxPower >= 0) {
+        for (const QWidget* p = w; p; p = p->parentWidget()) {
+            const QString an = p->accessibleName();
+            if (an == QLatin1String("RF power")
+                || an == QLatin1String("Tune power")) {
+                qCWarning(lcAutomation).noquote()
+                    << "BLOCKED clickAt on power slider" << an
+                    << "— power ceiling" << m_txMaxPower
+                    << "is armed; use invoke setValue (clamped)";
+                return err(QStringLiteral("blocked: '") + an
+                           + QStringLiteral("' click would bypass the power "
+                                            "ceiling (AETHER_AUTOMATION_TX_MAX_"
+                                            "POWER). Use `invoke '") + an
+                           + QStringLiteral("' setValue <n>`, which clamps."));
+            }
+        }
     }
 
     const QPoint local = w->mapFromGlobal(global);

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1742,7 +1742,7 @@ bool AutomationServer::start(const QString& serverName)
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
         << "txtest, atu, slice, tune, pan, panmessage, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
-        << "menu, close, drag, hover, showMenu, contextMenu, hitTest, shortcut, whoami, log, mark)";
+        << "menu, close, drag, hover, showMenu, contextMenu, hitTest, clickAt, shortcut, whoami, log, mark)";
     return true;
 }
 
@@ -1957,6 +1957,15 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         detail   = obj.value(QStringLiteral("detail")).toString();
         tone     = obj.value(QStringLiteral("tone")).toString();
         timeoutMs = obj.value(QStringLiteral("timeoutMs")).toInt(0);
+        // clickAt accepts numeric x/y fields directly (dumpTree geometry is
+        // global), folded into `value` as "x y" so both request forms share one
+        // code path. Explicit `value` still wins if supplied.
+        if (cmd == QLatin1String("clickAt") && value.isEmpty()
+            && (obj.contains(QStringLiteral("x")) || obj.contains(QStringLiteral("y")))) {
+            value = QString::number(obj.value(QStringLiteral("x")).toInt())
+                    + QLatin1Char(' ')
+                    + QString::number(obj.value(QStringLiteral("y")).toInt());
+        }
     } else {
         // Bare line. Positional by verb:
         //   grab   <target> [path]
@@ -2107,6 +2116,18 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
                    || cmd == QLatin1String("hittest")) {
             target = tok(1);
             value = tok(2) + QLatin1Char(' ') + tok(3);  // "hitTest SpectrumWidget [x y]"
+        } else if (cmd == QLatin1String("clickAt")
+                   || cmd == QLatin1String("clickat")) {
+            // Overloaded: "clickAt <x> <y>" (global) vs "clickAt <target> <x> <y>"
+            // (target-local). Disambiguate on whether the first token is numeric.
+            bool firstIsNumber = false;
+            tok(1).toInt(&firstIsNumber);
+            if (firstIsNumber) {
+                value = tok(1) + QLatin1Char(' ') + tok(2);  // "clickAt 1301 200"
+            } else {
+                target = tok(1);
+                value = tok(2) + QLatin1Char(' ') + tok(3);  // "clickAt AppletPanel 10 20"
+            }
         } else if (cmd == QLatin1String("drag") || cmd == QLatin1String("mouse")) {
             target = tok(1);
             value = tok(2) + QLatin1Char(' ') + tok(3);  // "drag sizeGrip 80 60"
@@ -2178,6 +2199,9 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         if (target.isEmpty())
             return err(QStringLiteral("hitTest requires a target widget"));
         return doHitTest(target, value);
+    }
+    if (cmd == QLatin1String("clickAt") || cmd == QLatin1String("clickat")) {
+        return doClickAt(target, value);
     }
     if (cmd == QLatin1String("invoke")) {
         if (target.isEmpty() || action.isEmpty())
@@ -4736,6 +4760,101 @@ QJsonObject AutomationServer::doHitTest(const QString& target,
         {QStringLiteral("insideTarget"), w->rect().contains(local)},
         {QStringLiteral("childAt"), describeHitWidget(child)},
         {QStringLiteral("widgetAt"), describeHitWidget(globalHit)},
+    };
+}
+
+// ── clickAt: synthesize a real mouse click at a point (#3461 follow-up) ───────
+// Generic fallback for when name/text matching can't reach the widget you want —
+// most commonly because several widgets share an accessibleName (e.g. every
+// tile's close button is "containerClose") so `invoke` can only ever hit the
+// first match. dumpTree reports widget geometry in GLOBAL (screen) coordinates,
+// so `clickAt <x> <y>` clicks whatever lives at that global point — pass the
+// centre of the target's dumpTree rect and you click exactly that widget. With a
+// target, x/y are interpreted LOCAL to that widget instead (like hitTest).
+//
+// Safety: the click is routed to the deepest child under the point and passed
+// through the SAME TX-keying guard as invoke() — a coordinate click must never
+// be a hole around AETHER_AUTOMATION_ALLOW_TX. Delivery (press+release) is
+// deferred to a clean main-loop turn so any popup menu/dialog the click raises
+// runs on a normal stack, mirroring the invoke() re-entrancy fix.
+QJsonObject AutomationServer::doClickAt(const QString& target,
+                                        const QString& value) const
+{
+    const QStringList parts = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (parts.size() < 2)
+        return err(QStringLiteral("clickAt needs both x and y"));
+    bool okx = false;
+    bool oky = false;
+    const int x = parts.at(0).toInt(&okx);
+    const int y = parts.at(1).toInt(&oky);
+    if (!okx || !oky)
+        return err(QStringLiteral("clickAt x/y must be integers"));
+
+    QPoint global;
+    QWidget* w = nullptr;
+    if (target.isEmpty()) {
+        // Global-coordinate form: resolve the widget under the screen point.
+        global = QPoint(x, y);
+        w = QApplication::widgetAt(global);
+        if (!w)
+            return err(QStringLiteral("clickAt: no widget at global (")
+                       + QString::number(x) + QStringLiteral(", ")
+                       + QString::number(y) + QStringLiteral(")"));
+    } else {
+        // Target-local form: x/y are offsets inside the resolved widget.
+        w = resolveWidget(target);
+        if (!w)
+            return err(QStringLiteral("widget not found: ") + target);
+        if (!w->isVisible())
+            return err(QStringLiteral("refused: '") + target
+                       + QStringLiteral("' is not visible"));
+        const QPoint local(x, y);
+        global = w->mapToGlobal(local);
+        if (QWidget* child = w->childAt(local))
+            w = child;  // route to the deepest child for a faithful click
+    }
+
+    // TX-safety guard — a raw coordinate click must honor the same opt-in as
+    // invoke(), or it becomes a bypass around the keying gate. (#3646 safety.)
+    if (isTransmitControl(w)
+        && !qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+        qCWarning(lcAutomation).noquote()
+            << "BLOCKED transmit-related clickAt on" << shortClassName(w)
+            << "at global" << global;
+        return err(QStringLiteral("blocked: point resolves to '")
+                   + shortClassName(w)
+                   + QStringLiteral("', a transmit-keying control (TX-safety "
+                                    "guard). Set AETHER_AUTOMATION_ALLOW_TX=1 "
+                                    "to override."));
+    }
+
+    const QPoint local = w->mapFromGlobal(global);
+    QPointer<QWidget> wp = w;
+    QPointer<QWidget> win = w->window();
+    QTimer::singleShot(0, qApp, [wp, win, local, global]() {
+        if (!wp)
+            return;
+        raiseWindowForPopup(win);  // valid active window for any popup it raises
+        const QPointF lf(local);
+        const QPointF gf(global);
+        QMouseEvent press(QEvent::MouseButtonPress, lf, lf, gf,
+                          Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+        QCoreApplication::sendEvent(wp, &press);
+        if (!wp)
+            return;
+        QMouseEvent release(QEvent::MouseButtonRelease, lf, lf, gf,
+                            Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+        QCoreApplication::sendEvent(wp, &release);
+    });
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("clicked"), describeHitWidget(w)},
+        {QStringLiteral("globalX"), global.x()},
+        {QStringLiteral("globalY"), global.y()},
+        {QStringLiteral("localX"), local.x()},
+        {QStringLiteral("localY"), local.y()},
+        {QStringLiteral("deferred"), true},   // press/release run next main-loop turn
     };
 }
 

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -325,7 +325,9 @@ private:
     // target, x/y are GLOBAL screen coordinates (matching dumpTree geometry); with
     // a target they are LOCAL to that widget. Generic fallback for when name/text
     // matching is ambiguous (e.g. several tiles share accessibleName
-    // "containerClose" and only the first is reachable by invoke). TX-gated.
+    // "containerClose" and only the first is reachable by invoke). TX-gated on the
+    // whole ancestor chain; disabled widgets and (with the power ceiling armed)
+    // the RF/Tune power sliders are refused.
     QJsonObject doClickAt(const QString& target, const QString& value) const;
     // pan close <panId|index|active|all>: tear down a panadapter regardless of
     // how it was opened. Sends `display pan remove` AND `display panafall remove`

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -321,6 +321,12 @@ private:
     // hitTest <target> [x y]: read-only Qt hit-test probe. Reports the widget
     // under a target-local point according to childAt() and QApplication::widgetAt().
     QJsonObject doHitTest(const QString& target, const QString& value) const;
+    // clickAt [<target>] <x> <y>: synthesize a real left-click at a point. With no
+    // target, x/y are GLOBAL screen coordinates (matching dumpTree geometry); with
+    // a target they are LOCAL to that widget. Generic fallback for when name/text
+    // matching is ambiguous (e.g. several tiles share accessibleName
+    // "containerClose" and only the first is reachable by invoke). TX-gated.
+    QJsonObject doClickAt(const QString& target, const QString& value) const;
     // pan close <panId|index|active|all>: tear down a panadapter regardless of
     // how it was opened. Sends `display pan remove` AND `display panafall remove`
     // (the FlexLib-correct pair) so a panafall-created pan closes too. The

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -471,7 +471,14 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     m_stack = new QVBoxLayout(container);
     m_stack->setContentsMargins(0, 0, 0, 0);
     m_stack->setSpacing(0);
-    m_stack->addStretch();
+    // Stretch factor 1 (not the default 0) so all surplus vertical space is
+    // routed to this trailing spacer.  With a factor-0 spacer, Qt distributes
+    // surplus equally among every item whose expandingDirections() includes
+    // Vertical — which is any tile whose body contains a vertically-expanding
+    // child — parking a blank band below those headers (#3461/#4098).  A
+    // non-zero factor here pins every container to its sizeHint and collects
+    // the slack at the bottom, regardless of a tile's internal size policy.
+    m_stack->addStretch(1);
     m_scrollArea->setWidget(container);
     root->addWidget(m_scrollArea, 1);
 
@@ -979,7 +986,7 @@ void AppletPanel::rebuildStackOrder()
             continue;
         m_stack->addWidget(entry.widget);
     }
-    m_stack->addStretch();
+    m_stack->addStretch(1);  // factor 1: absorb all surplus, pin tiles to sizeHint (#3461)
 }
 
 void AppletPanel::saveOrder()

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -204,14 +204,26 @@ def main():
         elif args.command == "clickAt":
             # clickAt <x> <y>            -> global screen coords (dumpTree geometry)
             # clickAt <target> <x> <y>  -> coords local to <target>
-            if len(args.rest) < 2:
-                sys.exit("error: clickAt needs <x> <y> or <target> <x> <y>")
-            req = {"cmd": "clickAt"}
-            if args.rest[0].lstrip("-").isdigit():
-                req["value"] = f"{args.rest[0]} {args.rest[1]}"
+            # Disambiguate like the server: first token numeric => global form.
+            # int() (not isdigit) so a float like 1420.5 errors loudly instead
+            # of being reclassified as a widget NAME ("widget not found: 1420.5").
+            def _as_int(tok):
+                try:
+                    return int(tok)
+                except ValueError:
+                    return None
+
+            if len(args.rest) >= 2 and _as_int(args.rest[0]) is not None:
+                if _as_int(args.rest[1]) is None:
+                    sys.exit(f"error: clickAt y must be an integer, got {args.rest[1]!r}")
+                req = {"cmd": "clickAt", "value": f"{args.rest[0]} {args.rest[1]}"}
+            elif len(args.rest) >= 3 and _as_int(args.rest[0]) is None:
+                if _as_int(args.rest[1]) is None or _as_int(args.rest[2]) is None:
+                    sys.exit("error: clickAt <target> <x> <y> — x and y must be integers")
+                req = {"cmd": "clickAt", "target": args.rest[0],
+                       "value": f"{args.rest[1]} {args.rest[2]}"}
             else:
-                req["target"] = args.rest[0]
-                req["value"] = " ".join(args.rest[1:3])
+                sys.exit("error: clickAt needs <x> <y> or <target> <x> <y>")
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "resize":

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -106,6 +106,8 @@ def main():
                "  automation_probe.py slice rxsource 7 K4JK\n"
                "  automation_probe.py invoke 'Master volume' setValue 35\n"
                "  automation_probe.py hitTest SpectrumWidget 80 80\n"
+               "  automation_probe.py clickAt 1420 210          # global point (dumpTree geometry)\n"
+               "  automation_probe.py clickAt AppletPanel 12 34  # point local to a widget\n"
                "  automation_probe.py resize 1600 900\n"
                "  automation_probe.py audioCapture start 3000 raw,post,final\n"
                "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
@@ -120,13 +122,14 @@ def main():
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect", "slice", "audioCapture",
                              "record", "testtone", "tci", "panmessage",
-                             "hitTest", "resize", "dss"],
+                             "hitTest", "clickAt", "resize", "dss"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
                          "invoke <target> <action> [value] | "
                          "get <model> [selector] [property] | "
                          "hitTest <target> [x y] | "
+                         "clickAt <x> <y> | clickAt <target> <x> <y> | "
                          "resize <w> <h> [target] | "
                          "connect <list|show|hide|local|ip|wait> [args] | "
                          "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
@@ -196,6 +199,19 @@ def main():
             req = {"cmd": "hitTest", "target": args.rest[0]}
             if len(args.rest) > 1:
                 req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "clickAt":
+            # clickAt <x> <y>            -> global screen coords (dumpTree geometry)
+            # clickAt <target> <x> <y>  -> coords local to <target>
+            if len(args.rest) < 2:
+                sys.exit("error: clickAt needs <x> <y> or <target> <x> <y>")
+            req = {"cmd": "clickAt"}
+            if args.rest[0].lstrip("-").isdigit():
+                req["value"] = f"{args.rest[0]} {args.rest[1]}"
+            else:
+                req["target"] = args.rest[0]
+                req["value"] = " ".join(args.rest[1:3])
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "resize":


### PR DESCRIPTION
## Summary

Two related changes, both stemming from #3461:

1. **The fix** — side-panel applet tiles no longer leave a blank band below their headers when only a few tiles are enabled.
2. **A new bridge verb (`clickAt`)** — added because reproducing this bug exposed a real gap in the agent automation bridge (see "Bridge capability" below).

Fixes #3461 (and #4098, closed as a duplicate).

## Root cause

The docked side-panel applets are stacked in a `QVBoxLayout` inside a `setWidgetResizable` `QScrollArea`, terminated by a trailing `m_stack->addStretch()` (`src/gui/AppletPanel.cpp`, initial build at :474 and `rebuildStackOrder()` at :982).

`addStretch()` adds a spacer with the **default stretch factor 0**. When few tiles are enabled the inner container is sized to the viewport, so there is surplus vertical space to distribute — and with **every** item at stretch factor 0, Qt falls back to sharing that surplus **equally among all items whose `expandingDirections()` include Vertical**, not just the trailing spacer.

Any tile whose body contains a vertically-expanding child propagates "expanding" up through `ContainerWidget` into the stack and therefore claims a share of the surplus, parking a blank band below its header. Several sidebar applets qualify and are **not** clamped to `Fixed` vertical policy — e.g. `MeterApplet` (internal `vbox->addStretch()`), `CatControlApplet` (`root->addStretch()`), `WaveApplet` (expanding scope). This is exactly why the gap moves around depending on which tiles are visible, and it's the same root cause behind #4098.

(The two earlier AI triage passes disagreed: the #3461 pass proposed a `MeterApplet`-only clamp; the #4098 pass identified the general mechanism. The general analysis is correct — a Meters-only fix would not explain the reporter's observation that the gap also lands on TX controls / other applets.)

## Fix

Give the trailing spacer a non-zero stretch factor — `addStretch(1)` — at both stack sites. With `sumStretch > 0`, Qt distributes surplus **by stretch factor only**: every container (factor 0) is pinned to its `sizeHint`, and the factor-1 spacer absorbs all slack at the bottom. This covers every current and future tile at once, instead of relying on each applet to remember an explicit `Fixed`-vertical clamp. When many tiles overflow the viewport the spacer collapses to 0 and scrolling is unchanged.

## Proof — agent automation bridge

Same build, same reduced tile set (**CAT + TCI** isolated, ~600px of viewport surplus), measured and screenshotted through the bridge (`dumpTree` geometry + `grab AetherSDR::AppletPanel`):

| Tile | Before (`addStretch()`) | After (`addStretch(1)`) |
|---|---|---|
| CAT Control | h = **191px** (blank band below header) | h = **66px** (natural `sizeHint`) |
| TCI Server | h = **192px** (inflated) | h = **134px** (natural `sizeHint`) |
| Slack location | shared between tiles | all collected at the bottom |

On the fixed build the two tiles are contiguous at the top (`gapAbove = 0`) with all surplus at the bottom — matching the reporter's "expected" screenshot. Notably the *after* run even had **more** surplus (908px panel vs 667px) yet tiles stayed at their natural height, confirming the change is about distribution policy, not available space.

_Before → after proof screenshots attached below._

## Bridge capability — new `clickAt` verb

Reproducing this bug required closing a **specific** side-panel tile to create viewport surplus. That turned out to be impossible with the existing bridge: `invoke` resolves its target by objectName/accessibleName/text and always takes the **first** match, and every tile's close button shares `accessibleName "containerClose"` — so `invoke containerClose click` can only ever close the *top* tile.

This PR adds a generic coordinate-click that closes that gap:

```
clickAt <x> <y>            # global screen coordinates (dumpTree geometry)
clickAt <target> <x> <y>   # coordinates local to target (like hitTest)
```

`dumpTree` reports widget geometry in global coordinates, so clicking the centre of any widget's dumpTree rect clicks exactly that widget. Key properties:

- **TX-safe** — routed through the same `isTransmitControl()` / `AETHER_AUTOMATION_ALLOW_TX` guard as `invoke`; a raw coordinate click is never a hole around the keying gate.
- **Re-entrancy-safe** — press+release delivered to the deepest `childAt` the point, deferred one main-loop turn so any popup/dialog runs on a clean stack (mirrors the `invoke` fix).
- Wired into both request forms, `tools/automation_probe.py` (new `clickAt` subcommand), the verb banner, and documented in `docs/automation-bridge.md` with a "close a specific tile" recipe.

**Proven live:** with 11 tiles enabled, `clickAt` on the centre of WAVE's `containerClose` rect (the 3rd tile, global 1539,562) closed **WAVE precisely** while the first tile and all others stayed — the exact operation `invoke` cannot do.

## Proof

CAT + TCI isolated (~600px viewport surplus), captured via the bridge (`grab AetherSDR::AppletPanel`):

| Before (`addStretch()`) | After (`addStretch(1)`) |
|---|---|
| ![before](https://raw.githubusercontent.com/jensenpat/AetherSDR/proof-3461/before-reduced.png) | ![after](https://raw.githubusercontent.com/jensenpat/AetherSDR/proof-3461/after-reduced.png) |
| CAT Control balloons — blank band below "Enable CAT" before "Pop out for configuration." (h 66→191px) | CAT + TCI compact and contiguous, all slack collected at the bottom |

Fixes #3461

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
