### PR TITLE
refactor(aetherd): 2.4 — move the amp (PGXL) status decode behind FlexBackend (#4094)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2623,6 +2623,12 @@ target_link_libraries(amp_model_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(amp_model_test PROPERTIES AUTOMOC ON)
 add_test(NAME amp_model_test COMMAND amp_model_test)
 
+add_executable(aetherd_amp_decode_test tests/aetherd_amp_decode_test.cpp)
+target_include_directories(aetherd_amp_decode_test PRIVATE src)
+target_link_libraries(aetherd_amp_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_amp_decode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_amp_decode_test COMMAND aetherd_amp_decode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/AmpDelta.h
+++ b/src/core/backends/AmpDelta.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <optional>
+
+#include <QMap>
+#include <QMetaType>
+#include <QString>
+
+namespace AetherSDR {
+
+// Normalized power-amplifier status delta (aetherd 2.4 — AmpModel decode split,
+// #4094). FlexBackend::decodeAmplifierStatus translates the SmartSDR "amplifier"
+// wire (the "model"/"ip"/"state" keys, the TunerGeniusXL discriminator) into
+// this typed, present-only shape; AmpModel::applyChanges owns the state machine
+// (presence latch, operate change-gating, handle matching). Same contract as the
+// sub-model deltas — a backend with no amp analog simply never emits one.
+//
+// The decode is stateless: it carries what the wire reported (a detected power-amp
+// model, its ip, the derived operate flag, the raw telemetry). The model decides
+// what to do with it. Command/encode is NOT here — that stays AmpModel::setOperate
+// → commandReady until the seam gains an encode path (invokeExtension; step 3).
+struct AmpDelta {
+    QString handle;                        // amplifier handle from the status object
+    bool    removed{false};                // "amplifier <handle> removed"
+
+    // Set only when the wire reported a non-empty, non-TGXL amp model — i.e. a
+    // power amp (PGXL) as opposed to the tuner, which routes to TunerModel.
+    std::optional<QString> detectedModel;  // e.g. "PowerGeniusXL"
+    std::optional<QString> ip;             // for the direct PgxlConnection
+
+    // Operate/standby derived from the wire "state" (IDLE/OPERATE/TRANSMIT* → on,
+    // STANDBY → off). Absent when the status carried no "state".
+    std::optional<bool> operate;
+
+    // Raw amp telemetry (id/vac/vdd/meffa/temp/state/…) the GUI renders as-is.
+    QMap<QString, QString> telemetry;
+};
+
+}  // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::AmpDelta)

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -7,6 +7,7 @@
 #include <QVariant>
 #include <QVariantMap>
 
+#include "core/backends/AmpDelta.h"
 #include "core/backends/GpsDelta.h"
 #include "core/backends/MemoryDelta.h"
 #include "core/backends/MeterDef.h"
@@ -124,6 +125,12 @@ signals:
     // fields the wire reported (across the transmit / interlock / ATU / APD /
     // APD-sampler status planes) and RadioModel drives the TransmitModel.
     void transmitChanged(const TransmitDelta& delta);
+
+    // Normalized power-amplifier status delta (aetherd 2.4 — AmpModel decode
+    // split, #4094). Typed + present-only; the backend translates the SmartSDR
+    // "amplifier" wire and AmpModel applies the state machine. Command/encode
+    // stays AmpModel::commandReady until the seam gains an encode path (step 3).
+    void amplifierChanged(const AmpDelta& delta);
 
     // Normalized radio-global status delta (aetherd RFC 2.3 — RadioModel
     // residual). Typed + compiler-checked; the backend populates only the fields

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -625,6 +625,38 @@ void FlexBackend::decodeAtuStatus(const QMap<QString, QString>& kvs)
     emit transmitChanged(d);
 }
 
+void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& model,
+                                        const QMap<QString, QString>& kvs, bool removed)
+{
+    // Stateless translation of the SmartSDR "amplifier <handle> …" wire → AmpDelta
+    // (#4094). The presence latch, operate change-gating, and handle matching are
+    // the model's job (AmpModel::applyChanges) — this only reports what the wire
+    // said. Command/encode is not here (stays AmpModel::commandReady, step 3).
+    AmpDelta d;
+    d.handle = handle;
+    if (removed) {
+        d.removed = true;
+        emit amplifierChanged(d);
+        return;
+    }
+    // A non-empty, non-TGXL model marks a power amp (PGXL); the TunerGeniusXL is
+    // the tuner and routes to TunerModel, not here.
+    if (!model.isEmpty() && model != QLatin1String("TunerGeniusXL")) {
+        d.detectedModel = model;
+        if (kvs.contains(QStringLiteral("ip")))
+            d.ip = kvs.value(QStringLiteral("ip"));
+    }
+    // Operate/standby from the wire "state": IDLE/OPERATE/TRANSMIT* → on, else off.
+    if (kvs.contains(QStringLiteral("state"))) {
+        const QString state = kvs.value(QStringLiteral("state")).toUpper();
+        d.operate = (state == QLatin1String("IDLE")
+                     || state == QLatin1String("OPERATE")
+                     || state.startsWith(QLatin1String("TRANSMIT")));
+    }
+    d.telemetry = kvs;
+    emit amplifierChanged(d);
+}
+
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -647,8 +647,10 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
             d.ip = kvs.value(QStringLiteral("ip"));
     }
     // Operate/standby from the wire "state": IDLE/OPERATE/TRANSMIT* → on, else off.
-    if (kvs.contains(QStringLiteral("state"))) {
-        const QString state = kvs.value(QStringLiteral("state")).toUpper();
+    // Gate on non-empty VALUE (not just key presence) to match the prior
+    // AmpModel::applyStatus exactly — a bare "state=" must not flip operate.
+    const QString state = kvs.value(QStringLiteral("state")).toUpper();
+    if (!state.isEmpty()) {
         d.operate = (state == QLatin1String("IDLE")
                      || state == QLatin1String("OPERATE")
                      || state.startsWith(QLatin1String("TRANSMIT")));

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -123,6 +123,13 @@ public:
     void decodeInterlockStatus(const QMap<QString, QString>& kvs);
     void decodeAtuStatus(const QMap<QString, QString>& kvs);
     void decodeApdStatus(const QMap<QString, QString>& kvs);
+    // Translate a SmartSDR "amplifier <handle> …" status into a typed AmpDelta
+    // and emit amplifierChanged (aetherd 2.4 — AmpModel decode split, #4094).
+    // `model` is the wire "model" key (TunerGeniusXL routes to the tuner, not
+    // here); `removed` marks an "amplifier <handle> removed". Stateless — the
+    // presence latch / operate change-gating live in AmpModel::applyChanges.
+    void decodeAmplifierStatus(const QString& handle, const QString& model,
+                               const QMap<QString, QString>& kvs, bool removed);
     void decodeApdSamplerStatus(const QMap<QString, QString>& kvs);
     // Decode the Flex GPS-status line ("gps …", '#'-separated key=value tokens)
     // into a present-only GpsDelta and emit gpsChanged (aetherd RFC 2.3 —

--- a/src/models/AmpModel.cpp
+++ b/src/models/AmpModel.cpp
@@ -21,7 +21,9 @@ void AmpModel::applyChanges(const AmpDelta& d)
         m_handle = d.handle;
         if (!m_present) {
             m_present = true;
-            if (d.ip) m_ip = *d.ip;
+            // Strict parity with the prior applyStatus (m_ip = kvs.value("ip"),
+            // which blanked to "" when absent) — keeps this a behavior-neutral move.
+            m_ip = d.ip.value_or(QString());
             m_model = *d.detectedModel;
             emit presenceChanged(true);
         }

--- a/src/models/AmpModel.cpp
+++ b/src/models/AmpModel.cpp
@@ -2,48 +2,40 @@
 
 namespace AetherSDR {
 
-void AmpModel::applyStatus(const QString& handle, const QString& model,
-                           const QMap<QString, QString>& kvs)
+void AmpModel::applyChanges(const AmpDelta& d)
 {
-    // Presence: any non-empty, non-TGXL amp model marks a power amp present.
-    // (The radio reports both TGXL and PGXL via the "amplifier" API; the caller
-    // routes TunerGeniusXL to TunerModel and everything else here.)
-    if (!model.isEmpty() && model != QLatin1String("TunerGeniusXL")) {
-        m_handle = handle;
+    if (d.removed) {
+        // Clear only if it's our amp (matches the original removal semantics —
+        // leaves m_ip/m_operate untouched; consumers gate on present()).
+        if (d.handle == m_handle) {
+            m_handle.clear();
+            m_present = false;
+            m_model.clear();
+            emit presenceChanged(false);
+        }
+        return;
+    }
+
+    // Presence latch: a detected (non-TGXL) power-amp model marks us present.
+    if (d.detectedModel) {
+        m_handle = d.handle;
         if (!m_present) {
             m_present = true;
-            m_ip = kvs.value(QStringLiteral("ip"));
-            m_model = model;
+            if (d.ip) m_ip = *d.ip;
+            m_model = *d.detectedModel;
             emit presenceChanged(true);
         }
     }
 
-    if (!m_handle.isEmpty() && handle == m_handle) {
-        // PGXL uses "state=OPERATE|IDLE|STANDBY|TRANSMIT…" (not operate=/bypass=
-        // like TGXL). IDLE = on/ready, STANDBY = off, TRANSMIT* = keyed.
-        const QString state = kvs.value(QStringLiteral("state")).toUpper();
-        if (!state.isEmpty()) {
-            const bool op = (state == QLatin1String("IDLE")
-                             || state == QLatin1String("OPERATE")
-                             || state.startsWith(QLatin1String("TRANSMIT")));
-            if (m_operate != op) {
-                m_operate = op;
-                emit stateChanged();
-            }
+    if (!m_handle.isEmpty() && d.handle == m_handle) {
+        // Operate is change-gated; a status without a "state" leaves it as-is.
+        if (d.operate && m_operate != *d.operate) {
+            m_operate = *d.operate;
+            emit stateChanged();
         }
-        // Forward the full KVS so the GUI can update telemetry (drain current,
-        // mains voltage, meffa, temp) without a direct PGXL TCP connection.
-        emit telemetryUpdated(kvs);
-    }
-}
-
-void AmpModel::handleRemoval(const QString& handle)
-{
-    if (handle == m_handle) {
-        m_handle.clear();
-        m_present = false;
-        m_model.clear();
-        emit presenceChanged(false);
+        // Forward telemetry (drain current, mains voltage, meffa, temp, …) so
+        // the GUI updates without a direct PGXL TCP connection.
+        emit telemetryUpdated(d.telemetry);
     }
 }
 

--- a/src/models/AmpModel.h
+++ b/src/models/AmpModel.h
@@ -4,6 +4,8 @@
 #include <QMap>
 #include <QString>
 
+#include "core/backends/AmpDelta.h"
+
 namespace AetherSDR {
 
 // State model for a power amplifier the radio reports through its "amplifier"
@@ -30,13 +32,10 @@ public:
     QString ip()        const { return m_ip; }      // for the direct PGXL connection
     QString modelName() const { return m_model; }   // e.g. "PowerGeniusXL"
 
-    // Apply a decoded (non-removal) "amplifier <handle> model=… state=… …"
-    // status. `model` is the wire "model" key; a non-empty, non-TGXL model marks
-    // a power amp present. Present-only telemetry rides on telemetryUpdated.
-    void applyStatus(const QString& handle, const QString& model,
-                     const QMap<QString, QString>& kvs);
-    // Handle an "amplifier <handle> removed" — clears state if it's our amp.
-    void handleRemoval(const QString& handle);
+    // Apply a normalized amplifier delta from the backend
+    // (IRadioBackend::amplifierChanged, decoded by FlexBackend). Owns the state
+    // machine: presence latch, operate change-gating, handle matching, removal.
+    void applyChanges(const AmpDelta& delta);
     // Bulk clear on radio disconnect/teardown (matches RadioModel's prior reset).
     void reset();
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5304,9 +5304,12 @@ void RadioModel::onStatusReceived(const QString& object,
                 }
                 m_tunerModel.applyStatus(kvs);
             }
-
-            // Power amplifier (PGXL / any non-TGXL amp) → AmpModel.
-            if (m_flexBackend) m_flexBackend->decodeAmplifierStatus(handle, model, kvs, /*removed=*/false);
+            // Power amplifier (PGXL / any non-TGXL amp) → AmpModel. `else` of the
+            // tuner branch: a TGXL status is already routed above and would only
+            // no-op the amp decode — skip it to avoid the per-status AmpDelta copy.
+            else if (m_flexBackend) {
+                m_flexBackend->decodeAmplifierStatus(handle, model, kvs, /*removed=*/false);
+            }
         }
         return;
     }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -406,6 +406,7 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<GpsDelta>();
     qRegisterMetaType<MemoryDelta>();
     qRegisterMetaType<ProfileDelta>();
+    qRegisterMetaType<AmpDelta>();
 
     // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
     // FlexBackend creates the RadioConnection and PanadapterStream on their
@@ -548,6 +549,10 @@ RadioModel::RadioModel(QObject* parent)
     // handlers (main-thread AutoConnection → DirectConnection).
     connect(m_backend.get(), &IRadioBackend::transmitChanged, this,
             [this](const TransmitDelta& delta) { m_transmitModel.applyChanges(delta); });
+
+    // aetherd 2.4 (#4094): power-amp status decoded in the backend drives AmpModel.
+    connect(m_backend.get(), &IRadioBackend::amplifierChanged, this,
+            [this](const AmpDelta& delta) { m_amplifier.applyChanges(delta); });
 
     // aetherd RFC 2.3 (RadioModel residual): radio-global status decoded in the
     // backend drives RadioModel's own state via applyRadioChanges.
@@ -5269,7 +5274,7 @@ void RadioModel::onStatusReceived(const QString& object,
             qCDebug(lcProtocol) << "RadioModel: amplifier removed (bare) handle=" << handle;
             if (handle == m_tunerModel.handle())
                 m_tunerModel.setHandle({});
-            m_amplifier.handleRemoval(handle);
+            if (m_flexBackend) m_flexBackend->decodeAmplifierStatus(handle, QString(), {}, /*removed=*/true);
             return;
         }
         const auto m = ampRe.match(object);
@@ -5282,7 +5287,7 @@ void RadioModel::onStatusReceived(const QString& object,
             if (kvs.contains("removed")) {
                 if (handle == m_tunerModel.handle())
                     m_tunerModel.setHandle({});
-                m_amplifier.handleRemoval(handle);
+                if (m_flexBackend) m_flexBackend->decodeAmplifierStatus(handle, QString(), {}, /*removed=*/true);
                 return;
             }
 
@@ -5301,7 +5306,7 @@ void RadioModel::onStatusReceived(const QString& object,
             }
 
             // Power amplifier (PGXL / any non-TGXL amp) → AmpModel.
-            m_amplifier.applyStatus(handle, model, kvs);
+            if (m_flexBackend) m_flexBackend->decodeAmplifierStatus(handle, model, kvs, /*removed=*/false);
         }
         return;
     }

--- a/tests/aetherd_amp_decode_test.cpp
+++ b/tests/aetherd_amp_decode_test.cpp
@@ -57,7 +57,8 @@ int main(int argc, char** argv)
         CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "OPERATE"}}, false).operate == true);
         CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "TRANSMIT_A"}}, false).operate == true);
         CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "STANDBY"}}, false).operate == false);
-        CHECK(!decode(b, "0x1", "PowerGeniusXL", {{"ip", "x"}}, false).operate.has_value()); // no state
+        CHECK(!decode(b, "0x1", "PowerGeniusXL", {{"ip", "x"}}, false).operate.has_value());   // no state key
+        CHECK(!decode(b, "0x1", "PowerGeniusXL", {{"state", ""}}, false).operate.has_value()); // bare state= → skipped
     }
 
     // ---- ip only latched when present ----

--- a/tests/aetherd_amp_decode_test.cpp
+++ b/tests/aetherd_amp_decode_test.cpp
@@ -1,0 +1,82 @@
+// aetherd 2.4 (#4094) — FlexBackend::decodeAmplifierStatus. Pins the SmartSDR
+// "amplifier <handle> …" wire → typed AmpDelta translation that moved out of
+// RadioModel: power-amp detection (non-TGXL model), TGXL discrimination, ip
+// capture, operate derivation from "state", telemetry passthrough, removal.
+
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/AmpDelta.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+static AmpDelta decode(FlexBackend& b, const QString& handle, const QString& model,
+                       const QMap<QString, QString>& kvs, bool removed)
+{
+    QSignalSpy spy(&b, &IRadioBackend::amplifierChanged);
+    b.decodeAmplifierStatus(handle, model, kvs, removed);
+    if (spy.count() != 1) return {};
+    return spy.takeFirst().at(0).value<AmpDelta>();
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<AmpDelta>();
+    FlexBackend b;
+
+    // ---- power amp (PGXL): detected model + ip + operate-from-state ----
+    {
+        const AmpDelta d = decode(b, "0x1000", "PowerGeniusXL",
+            {{"ip", "192.168.1.50"}, {"state", "IDLE"}, {"temp", "35"}}, false);
+        CHECK(d.handle == "0x1000");
+        CHECK(!d.removed);
+        CHECK(d.detectedModel.has_value() && *d.detectedModel == "PowerGeniusXL");
+        CHECK(d.ip.has_value() && *d.ip == "192.168.1.50");
+        CHECK(d.operate.has_value() && *d.operate == true);   // IDLE → on
+        CHECK(d.telemetry.value("temp") == "35");             // full kvs forwarded
+    }
+
+    // ---- TGXL is NOT a power amp: no detectedModel (routes to TunerModel) ----
+    {
+        const AmpDelta d = decode(b, "0x2000", "TunerGeniusXL", {{"state", "OPERATE"}}, false);
+        CHECK(!d.detectedModel.has_value());
+        CHECK(d.operate.has_value() && *d.operate == true);   // still decoded, model gates it
+        CHECK(d.handle == "0x2000");
+    }
+
+    // ---- operate derivation: OPERATE/TRANSMIT* → on, STANDBY → off, absent → nullopt ----
+    {
+        CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "OPERATE"}}, false).operate == true);
+        CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "TRANSMIT_A"}}, false).operate == true);
+        CHECK(*decode(b, "0x1", "PowerGeniusXL", {{"state", "STANDBY"}}, false).operate == false);
+        CHECK(!decode(b, "0x1", "PowerGeniusXL", {{"ip", "x"}}, false).operate.has_value()); // no state
+    }
+
+    // ---- ip only latched when present ----
+    {
+        const AmpDelta d = decode(b, "0x1", "PowerGeniusXL", {{"state", "IDLE"}}, false);
+        CHECK(!d.ip.has_value());
+    }
+
+    // ---- removal: removed flag set, nothing else decoded ----
+    {
+        const AmpDelta d = decode(b, "0x1000", QString(), {}, true);
+        CHECK(d.removed && d.handle == "0x1000");
+        CHECK(!d.detectedModel.has_value() && !d.operate.has_value());
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherd_amp_decode_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherd_amp_decode_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/amp_model_test.cpp
+++ b/tests/amp_model_test.cpp
@@ -1,7 +1,7 @@
-// AmpModel unit test — pins the power-amplifier (PGXL) state machine extracted
-// from RadioModel (#4094): presence/operate derivation, telemetry forwarding,
-// removal, reset, and the operate-command relay. Guards the behavior-neutral
-// extraction (the 73 model tests didn't cover amp state directly).
+// AmpModel unit test — the power-amplifier state machine (#4094). Exercises
+// AmpModel::applyChanges(AmpDelta): presence latch, operate change-gating,
+// telemetry/handle matching, removal, reset, and the operate-command relay.
+// The wire→AmpDelta translation is covered separately by aetherd_amp_decode_test.
 
 #include "models/AmpModel.h"
 
@@ -17,74 +17,99 @@ static int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
     std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
 
-static QMap<QString, QString> kv(std::initializer_list<std::pair<QString, QString>> l)
+// A "detected power amp" status delta (as FlexBackend would decode it).
+static AmpDelta detected(const QString& handle, const QString& model,
+                         const QString& ip, std::optional<bool> operate,
+                         QMap<QString, QString> telem = {})
 {
-    QMap<QString, QString> m;
-    for (const auto& p : l) m.insert(p.first, p.second);
-    return m;
+    AmpDelta d;
+    d.handle = handle;
+    d.detectedModel = model;
+    if (!ip.isEmpty()) d.ip = ip;
+    d.operate = operate;
+    d.telemetry = std::move(telem);
+    return d;
+}
+
+// A follow-up status for an already-detected amp (no model, same handle).
+static AmpDelta update(const QString& handle, std::optional<bool> operate,
+                       QMap<QString, QString> telem = {})
+{
+    AmpDelta d;
+    d.handle = handle;
+    d.operate = operate;
+    d.telemetry = std::move(telem);
+    return d;
 }
 
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+    qRegisterMetaType<AmpDelta>();
 
-    // ---- presence detection: ip/model captured on the first status only ----
+    // ---- presence latch: model/ip captured once, on the first detect ----
     {
         AmpModel amp;
         QSignalSpy presence(&amp, &AmpModel::presenceChanged);
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"ip", "192.168.1.50"}, {"state", "STANDBY"}}));
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "192.168.1.50", false));
         CHECK(amp.present());
         CHECK(amp.handle() == "0x1000");
         CHECK(amp.ip() == "192.168.1.50");
         CHECK(amp.modelName() == "PowerGeniusXL");
-        CHECK(!amp.operate());                 // STANDBY → off
-        CHECK(presence.count() == 1);
-        CHECK(presence.takeFirst().at(0).toBool() == true);
+        CHECK(!amp.operate());
+        CHECK(presence.count() == 1 && presence.takeFirst().at(0).toBool() == true);
+        // A second detect does not re-latch ip/model or re-emit presence.
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "10.0.0.9", true));
+        CHECK(amp.ip() == "192.168.1.50");            // unchanged
+        CHECK(presence.count() == 0);
     }
 
-    // ---- TGXL is NOT a power amp (never marks present) ----
+    // ---- a delta with no detectedModel + unknown handle is a no-op (TGXL case) ----
     {
         AmpModel amp;
-        amp.applyStatus("0x2000", "TunerGeniusXL", kv({{"state", "OPERATE"}}));
+        QSignalSpy presence(&amp, &AmpModel::presenceChanged);
+        QSignalSpy tel(&amp, &AmpModel::telemetryUpdated);
+        amp.applyChanges(update("0x2000", true, {{"state", "OPERATE"}}));
         CHECK(!amp.present());
-        CHECK(amp.handle().isEmpty());
+        CHECK(presence.count() == 0 && tel.count() == 0);
     }
 
-    // ---- operate derivation: IDLE/OPERATE/TRANSMIT* = on, STANDBY = off; change-gated ----
+    // ---- operate change-gating; absent operate leaves it as-is ----
     {
         AmpModel amp;
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "STANDBY"}}));
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", false));
         QSignalSpy st(&amp, &AmpModel::stateChanged);
-        amp.applyStatus("0x1000", "", kv({{"state", "IDLE"}}));       // later updates omit model
+        amp.applyChanges(update("0x1000", true));     // off→on
         CHECK(amp.operate() && st.count() == 1);
-        amp.applyStatus("0x1000", "", kv({{"state", "OPERATE"}}));    // still on → no re-emit
+        amp.applyChanges(update("0x1000", true));     // on→on: no re-emit
         CHECK(amp.operate() && st.count() == 1);
-        amp.applyStatus("0x1000", "", kv({{"state", "TRANSMIT_A"}})); // keyed → on
-        CHECK(amp.operate() && st.count() == 1);
-        amp.applyStatus("0x1000", "", kv({{"state", "STANDBY"}}));    // off
+        amp.applyChanges(update("0x1000", std::nullopt, {{"temp", "40"}}));  // no state key
+        CHECK(amp.operate() && st.count() == 1);      // operate unchanged
+        amp.applyChanges(update("0x1000", false));    // on→off
         CHECK(!amp.operate() && st.count() == 2);
     }
 
-    // ---- telemetry emitted for a matching handle, ignored otherwise ----
+    // ---- telemetry forwarded for a matching handle, ignored otherwise ----
     {
         AmpModel amp;
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", true));
         QSignalSpy tel(&amp, &AmpModel::telemetryUpdated);
-        amp.applyStatus("0x1000", "", kv({{"temp", "42"}, {"id", "3.1"}}));
+        amp.applyChanges(update("0x1000", std::nullopt, {{"temp", "42"}, {"id", "3.1"}}));
         CHECK(tel.count() == 1);
-        amp.applyStatus("0x9999", "", kv({{"temp", "99"}}));          // foreign handle → ignored
+        amp.applyChanges(update("0x9999", std::nullopt, {{"temp", "99"}}));  // foreign handle
         CHECK(tel.count() == 1);
     }
 
     // ---- removal clears presence for our handle only ----
     {
         AmpModel amp;
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
-        CHECK(amp.present());
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", true));
         QSignalSpy presence(&amp, &AmpModel::presenceChanged);
-        amp.handleRemoval("0x9999");           // not ours → no-op
+        AmpDelta rmOther; rmOther.handle = "0x9999"; rmOther.removed = true;
+        amp.applyChanges(rmOther);                    // not ours → no-op
         CHECK(amp.present() && presence.count() == 0);
-        amp.handleRemoval("0x1000");
+        AmpDelta rm; rm.handle = "0x1000"; rm.removed = true;
+        amp.applyChanges(rm);
         CHECK(!amp.present() && amp.handle().isEmpty());
         CHECK(presence.count() == 1 && presence.takeFirst().at(0).toBool() == false);
     }
@@ -93,21 +118,20 @@ int main(int argc, char** argv)
     {
         AmpModel amp;
         QSignalSpy cmd(&amp, &AmpModel::commandReady);
-        amp.setOperate(true);                  // no handle yet → nothing
+        amp.setOperate(true);                         // no handle yet
         CHECK(cmd.count() == 0);
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "STANDBY"}}));
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", false));
         amp.setOperate(true);
         CHECK(cmd.count() == 1);
         CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=1");
         amp.setOperate(false);
-        CHECK(cmd.count() == 1);
         CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=0");
     }
 
     // ---- reset clears present/handle/operate ----
     {
         AmpModel amp;
-        amp.applyStatus("0x1000", "PowerGeniusXL", kv({{"state", "IDLE"}}));
+        amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", true));
         amp.reset();
         CHECK(!amp.present() && amp.handle().isEmpty() && !amp.operate());
     }


### PR DESCRIPTION
## The decode half of #4094

The AmpModel **extraction** landed in #4099; this moves the SmartSDR **decode** behind the seam, following the same typed-delta pattern the five 2.3 mixed models use. `AmpModel` now holds **no SmartSDR wire strings on the decode side**.

### Changes
- **`core/backends/AmpDelta.h`** — typed, present-only power-amp delta (`handle`, `removed`, `detectedModel`, `ip`, `operate`, `telemetry`).
- **`IRadioBackend::amplifierChanged(AmpDelta)`** signal.
- **`FlexBackend::decodeAmplifierStatus(handle, model, kvs, removed)`** — stateless translation of the `amplifier <handle> …` wire → `AmpDelta`. The `model`/`ip`/`state` keys, the `TunerGeniusXL` discriminator, and the `IDLE`/`OPERATE`/`TRANSMIT*` operate derivation now live here (mirrors `decodeAtuStatus`).
- **`AmpModel`** — `applyStatus`/`handleRemoval` → `applyChanges(AmpDelta)`, keeping the state machine (presence latch, operate change-gating, handle matching, removal). The only SmartSDR string left is the `setOperate` **encode** (`amplifier set … operate=`).
- **`RadioModel`** — the `amplifier` handler routes the PGXL half through `decodeAmplifierStatus` (TGXL→`TunerModel` unchanged); wires `amplifierChanged → applyChanges`; registers the metatype.

### What's deferred (still #4094)
The **encode** (`setOperate` → neutral intent translated by the backend). `FlexBackend::invokeExtension` is a bare stub, so there's no seam command path yet — same as every 2.3 model, which still emit `commandReady`. That's the step-3 piece.

### Verification
- Behavior-neutral decode move — **`aetherd_amp_decode_test`** pins the wire→`AmpDelta` translation (PGXL detect, TGXL discrimination, ip, operate derivation, telemetry, removal); **`amp_model_test`** reworked to drive `AmpModel::applyChanges` directly.
- Full build clean; **75/75 ctest**; `--strict` clean; grep-verified that `AmpModel` carries no decode literals.

Sibling: #4092 (same split for `TunerModel`, next). No Tier-1 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)