### PR TITLE
fix(slice): mirror FDVL passband to the lower side of the carrier (#3434)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2421,9 +2421,12 @@ void MainWindow::onEqCutoffsDragRequested(ClientEqApplet::Path path,
     const QString mode = s->mode();
     int lo = audioLo;
     int hi = audioHi;
-    if (mode == "LSB" || mode == "DIGL") {
+    if (mode == "LSB" || mode == "DIGL" || mode == "FDVL") {
         // Lower-sideband: filter offsets are negative; the audio low edge
-        // maps to the high (closest-to-zero) offset and vice versa.
+        // maps to the high (closest-to-zero) offset and vice versa. FDVL
+        // included since #3434 stores it canonically negative — the old
+        // pass-through sent positives that flip-flopped the overlay per
+        // drag step against the mirrored radio echo.
         lo = -audioHi;
         hi = -audioLo;
     } else if (mode == "AM" || mode == "SAM" || mode == "FM"

--- a/src/gui/MemoryCommands.cpp
+++ b/src/gui/MemoryCommands.cpp
@@ -32,8 +32,25 @@ MemoryEntry captureMemoryFromSlice(const RadioModel& model,
     memory.toneValue = slice.fmToneValue().toDouble();
     memory.squelch = slice.squelchOn();
     memory.squelchLevel = slice.squelchLevel();
-    memory.rxFilterLow = slice.filterLow();
-    memory.rxFilterHigh = slice.filterHigh();
+    // Memory filter fields are USB-form on the wire for FDV modes (FlexLib
+    // Memory.cs clamps FDV rx_filter_low to >= 0), while the client stores
+    // FDVL canonically negative since #3434. Mirror back to the ecosystem
+    // form at capture so radio-side memory slots (and the CSV export built
+    // from this struct) stay compatible with SmartSDR/FlexLib clients —
+    // a stored negative low would be clamped to 0 there, degrading the slot.
+    {
+        int memLow = slice.filterLow();
+        int memHigh = slice.filterHigh();
+        if (SliceModel::filterPolarityLsbFamily(memory.mode)
+            && memory.mode.startsWith(QStringLiteral("FDV"))
+            && memLow < 0) {
+            const int lo = memLow, hi = memHigh;
+            memLow  = -hi;
+            memHigh = -lo;
+        }
+        memory.rxFilterLow = memLow;
+        memory.rxFilterHigh = memHigh;
+    }
     memory.rttyMark = slice.rttyMark();
     memory.rttyShift = slice.rttyShift();
     memory.diglOffset = slice.diglOffset();

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -841,25 +841,33 @@ void SliceModel::applyChanges(const SliceDelta& d)
         // Radio sometimes sends wrong-polarity filter offsets after session
         // restore (e.g. negative offsets for USB/DIGU). Normalize based on mode.
         //
-        // FDV/FDVU/FDVL are excluded: FreeDV passbands are asymmetric
-        // (e.g. 95..widthHz for FDVU; -widthHz..-95 for FDVL — see
-        // VfoWidget.cpp:3773-3777) and FlexLib only knows "FDV" as a
-        // USB-family mode (Slice.cs:545-550). When the radio echoes an
-        // asymmetric FDVL filter as USB-form (positive lo/hi), the
-        // anchored flip discards one edge and offsets the overlay (#3092).
+        // FlexLib only knows "FDV" as a USB-family mode (Slice.cs:545-550), so
+        // the radio echoes BOTH FDVU and FDVL passbands as USB-form (positive
+        // lo/hi). FDVL is lower-sideband: its overlay, hit-testing and the
+        // client's own preset math all expect NEGATIVE offsets (see
+        // VfoWidget::applyFilterPreset / RxApplet::applyFilterPreset:
+        // lo=-widthHz, hi=-95). Left positive, an FDVL passband is shaded on
+        // the wrong (upper) side of the carrier (#3434). PR #3092 excluded FDV
+        // from the flip because the old anchored flip discarded one edge of the
+        // asymmetric FreeDV passband; the mirror below preserves both edges, so
+        // FDV is normalized safely here again.
         const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU"
+                                  || m_mode == "FDVU"
                                   || m_mode == "NT");  // NAVTEX: USB-family digital (v4.2.18)
-        const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL");
+        const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL"
+                                  || m_mode == "FDVL");
+        // Mirror across the carrier, preserving BOTH edges (asymmetric-safe):
+        // (lo,hi) → (-hi,-lo). For symmetric SSB this matches the historical
+        // flip (0,2700 → -2700,0); for asymmetric FDVL it keeps the low cut
+        // (95,2000 → -2000,-95) instead of collapsing it to (-2000,0).
         if (isUsbFamily && m_filterLow < 0 && m_filterHigh <= 0) {
-            // Flip: -2700,0 → 0,2700
-            int w = std::abs(m_filterLow);
-            m_filterLow = 0;
-            m_filterHigh = w;
+            const int lo = m_filterLow, hi = m_filterHigh;
+            m_filterLow  = -hi;
+            m_filterHigh = -lo;
         } else if (isLsbFamily && m_filterLow >= 0 && m_filterHigh > 0) {
-            // Flip: 0,2700 → -2700,0
-            int w = m_filterHigh;
-            m_filterLow = -w;
-            m_filterHigh = 0;
+            const int lo = m_filterLow, hi = m_filterHigh;
+            m_filterLow  = -hi;
+            m_filterHigh = -lo;
         }
         filterChanged_ = true;
     }

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -32,6 +32,45 @@ void SliceModel::sendCommand(const QString& cmd)
     emit commandReady(cmd);
 }
 
+// ── Filter polarity (#3434) ─────────────────────────────────────────────
+// FlexLib knows FDV only as a USB-family mode (Slice.cs:543-546), so the
+// radio reports BOTH FDVU and FDVL passbands in USB form (positive lo/hi).
+// Client-side, lower-sideband modes store negative offsets from the carrier
+// (the overlay, hit-testing and preset math all assume it). These helpers
+// hold the single mode→family mapping every polarity decision uses.
+bool SliceModel::filterPolarityUsbFamily(const QString& mode)
+{
+    return mode == "USB" || mode == "DIGU"
+        || mode == "FDV" || mode == "FDVU"   // FlexLib USB-family (FDV incl.)
+        || mode == "NT";                     // NAVTEX: USB-family digital (v4.2.18)
+}
+
+bool SliceModel::filterPolarityLsbFamily(const QString& mode)
+{
+    return mode == "LSB" || mode == "DIGL" || mode == "FDVL";
+}
+
+bool SliceModel::normalizeFilterPolarity()
+{
+    // Mirror across the carrier, preserving BOTH edges (asymmetric-safe):
+    // (lo,hi) → (-hi,-lo). For symmetric SSB this matches the historical
+    // flip (0,2700 → -2700,0); for asymmetric FDVL it keeps the low cut
+    // (95,2000 → -2000,-95) instead of collapsing it to (-2000,0), which is
+    // the discarded-edge regression #3092 worked around by excluding FDV.
+    // Sign-guarded and idempotent: values already in canonical form (and
+    // carrier-straddling passbands) are left untouched.
+    const bool usbFam = filterPolarityUsbFamily(m_mode);
+    const bool lsbFam = filterPolarityLsbFamily(m_mode);
+    if ((usbFam && m_filterLow < 0 && m_filterHigh <= 0)
+        || (lsbFam && m_filterLow >= 0 && m_filterHigh > 0)) {
+        const int lo = m_filterLow, hi = m_filterHigh;
+        m_filterLow  = -hi;
+        m_filterHigh = -lo;
+        return true;
+    }
+    return false;
+}
+
 void SliceModel::setFrequency(double mhz)
 {
     if (m_locked) {
@@ -74,6 +113,16 @@ void SliceModel::setFilterWidth(int low, int high)
 {
     m_filterLow  = low;
     m_filterHigh = high;
+    // Boundary defense (#3434): client-side callers can replay values captured
+    // under the pre-mirror convention (band-stack bookmarks, band snapshots,
+    // FilterPresets_* in AppSettings, net presets stored positive for FDVL) or
+    // pass audio-domain positives (EQ cutoff drag). Normalizing here keeps the
+    // model canonical even when the radio's filter already matches and no
+    // status echo will arrive to heal it. Sign-guarded: canonical input is
+    // untouched.
+    normalizeFilterPolarity();
+    low = m_filterLow;
+    high = m_filterHigh;
     // Operator-driven filter change (preset/drag): bump the user epoch so the
     // adaptive engine adopts this as its new baseline. applyAdaptiveFilter()
     // deliberately does NOT bump it. RFC #3878.
@@ -830,46 +879,57 @@ void SliceModel::applyChanges(const SliceDelta& d)
             modeChanged_ = true;
         }
     }
-    if (d.filterLow.has_value() || d.filterHigh.has_value()) {
-        // The radio may report one edge without the other; keep the current
-        // value for the absent one (the old parse defaulted to the member).
-        m_filterLow  = d.filterLow.has_value()
-            ? *d.filterLow : m_filterLow;
-        m_filterHigh = d.filterHigh.has_value()
-            ? *d.filterHigh : m_filterHigh;
-
-        // Radio sometimes sends wrong-polarity filter offsets after session
-        // restore (e.g. negative offsets for USB/DIGU). Normalize based on mode.
-        //
-        // FlexLib only knows "FDV" as a USB-family mode (Slice.cs:545-550), so
-        // the radio echoes BOTH FDVU and FDVL passbands as USB-form (positive
-        // lo/hi). FDVL is lower-sideband: its overlay, hit-testing and the
-        // client's own preset math all expect NEGATIVE offsets (see
-        // VfoWidget::applyFilterPreset / RxApplet::applyFilterPreset:
-        // lo=-widthHz, hi=-95). Left positive, an FDVL passband is shaded on
-        // the wrong (upper) side of the carrier (#3434). PR #3092 excluded FDV
-        // from the flip because the old anchored flip discarded one edge of the
-        // asymmetric FreeDV passband; the mirror below preserves both edges, so
-        // FDV is normalized safely here again.
-        const bool isUsbFamily = (m_mode == "USB" || m_mode == "DIGU"
-                                  || m_mode == "FDVU"
-                                  || m_mode == "NT");  // NAVTEX: USB-family digital (v4.2.18)
-        const bool isLsbFamily = (m_mode == "LSB" || m_mode == "DIGL"
-                                  || m_mode == "FDVL");
-        // Mirror across the carrier, preserving BOTH edges (asymmetric-safe):
-        // (lo,hi) → (-hi,-lo). For symmetric SSB this matches the historical
-        // flip (0,2700 → -2700,0); for asymmetric FDVL it keeps the low cut
-        // (95,2000 → -2000,-95) instead of collapsing it to (-2000,0).
-        if (isUsbFamily && m_filterLow < 0 && m_filterHigh <= 0) {
-            const int lo = m_filterLow, hi = m_filterHigh;
-            m_filterLow  = -hi;
-            m_filterHigh = -lo;
-        } else if (isLsbFamily && m_filterLow >= 0 && m_filterHigh > 0) {
-            const int lo = m_filterLow, hi = m_filterHigh;
-            m_filterLow  = -hi;
-            m_filterHigh = -lo;
+    if (d.filterLow.has_value() && d.filterHigh.has_value()) {
+        // Full pair: adopt the wire values, then normalize polarity. The radio
+        // sometimes reports wrong-polarity offsets after session restore
+        // (negative for USB/DIGU), and it ALWAYS reports FDVL in USB form
+        // (positive — FlexLib Slice.cs:543-546 knows FDV only as USB-family)
+        // while the client stores lower-sideband modes negative (overlay,
+        // hit-testing and preset math: lo=-widthHz, hi=-95). #3092 excluded
+        // FDV because the old anchored flip discarded one asymmetric edge;
+        // normalizeFilterPolarity()'s mirror preserves both edges (#3434).
+        m_filterLow  = *d.filterLow;
+        m_filterHigh = *d.filterHigh;
+        normalizeFilterPolarity();
+        filterChanged_ = true;
+    } else if (d.filterLow.has_value() || d.filterHigh.has_value()) {
+        // One edge without the other. The stored form can legitimately differ
+        // from the wire form (FDVL: stored negative, wire positive), and under
+        // the mirror a single wire edge maps to the OPPOSITE stored edge
+        // (wire filter_hi=3000 for FDVL means stored filterLow=-3000). Merging
+        // a wrong-form edge directly would build a carrier-straddling passband
+        // that neither pair guard can fix (#3434 review). Sign-gate per edge:
+        // wrong-form → crosswise with negation; canonical-form → direct.
+        // Applying this rule to both edges of a pair reproduces the pair
+        // mirror exactly, so it is a strict generalization.
+        const bool haveLo = d.filterLow.has_value();
+        const int v = haveLo ? *d.filterLow : *d.filterHigh;
+        const bool wrongForm =
+            (filterPolarityLsbFamily(m_mode) && v > 0)
+            || (filterPolarityUsbFamily(m_mode) && v < 0);
+        if (wrongForm) {
+            if (haveLo) {
+                m_filterHigh = -v;
+            } else {
+                m_filterLow = -v;
+            }
+        } else {
+            if (haveLo) {
+                m_filterLow = v;
+            } else {
+                m_filterHigh = v;
+            }
         }
         filterChanged_ = true;
+    } else if (modeChanged_) {
+        // Mode changed with NO filter keys in the same delta (a second client
+        // flipping FDVU→FDVL mid-session — the reporter's MultiFlex setup).
+        // The stored polarity may now be wrong for the new mode; the mirror is
+        // sign-guarded and idempotent, so re-running it is safe and fixes the
+        // stale-side overlay without waiting for the next filter echo (#3434).
+        if (normalizeFilterPolarity()) {
+            filterChanged_ = true;
+        }
     }
     if (d.modeList.has_value()) {
         const QStringList modes = *d.modeList;

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -352,7 +352,18 @@ signals:
     // commands still use commandReady until they convert.)
     void modeChangeRequested(const QString& mode);
 
+public:
+    // Filter polarity families (#3434): the single mode→family mapping every
+    // polarity decision uses. Public/static so capture paths (memories) can
+    // mirror back to the wire form without duplicating the mode list.
+    static bool filterPolarityUsbFamily(const QString& mode);
+    static bool filterPolarityLsbFamily(const QString& mode);
+
 private:
+    // Sign-guarded, idempotent (lo,hi)→(-hi,-lo) mirror of the stored filter
+    // when its polarity is wrong for m_mode; true if it changed anything.
+    bool normalizeFilterPolarity();
+
     int     m_id{0};
     QString m_letter;          // per-client display letter from `index_letter`
     QString m_panId;           // panadapter assignment (e.g. "0x40000000")

--- a/tests/slice_model_letter_test.cpp
+++ b/tests/slice_model_letter_test.cpp
@@ -386,6 +386,114 @@ int main(int argc, char** argv)
         EXPECT_EQ(s.filterLow(),  -2000);
         EXPECT_EQ(s.filterHigh(), -95);
     }
+    {
+        // FDVU wrong-polarity restore echo → mirrored positive. This is the
+        // behavior FDVU actually GAINS from joining the USB family — the
+        // stays-positive case above also passed pre-mirror (#3434 review).
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVU");
+            d.filterLow = -2000; d.filterHigh = -95;
+        }));
+        EXPECT_EQ(s.filterLow(),  95);
+        EXPECT_EQ(s.filterHigh(), 2000);
+    }
+    {
+        // Plain FDV is USB-family too (FlexLib Slice.cs:543-546) — a
+        // wrong-polarity echo is corrected, not skipped (#3434 review).
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDV");
+            d.filterLow = -2000; d.filterHigh = -95;
+        }));
+        EXPECT_EQ(s.filterLow(),  95);
+        EXPECT_EQ(s.filterHigh(), 2000);
+    }
+    {
+        // Repeated positive echo is idempotent: the radio keeps reporting
+        // USB-form for FDVL on every status; each apply must land on the same
+        // canonical values, never oscillate.
+        SliceModel s(0);
+        auto d1 = delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+            d.filterLow = 95; d.filterHigh = 2000;
+        });
+        s.applyChanges(d1);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.filterLow = 95; d.filterHigh = 2000;
+        }));
+        EXPECT_EQ(s.filterLow(),  -2000);
+        EXPECT_EQ(s.filterHigh(), -95);
+    }
+    {
+        // Single-edge echoes (#3434 review): under the mirror a wire edge in
+        // the wrong-polarity form maps to the OPPOSITE stored edge — merging
+        // it directly would build a carrier-straddling passband.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+            d.filterLow = 95; d.filterHigh = 2000;   // → stored (-2000,-95)
+        }));
+        // Wire reports only filter_hi=3000 (USB-form width change):
+        // canonical stored low becomes -3000. NOT (lo=-2000, hi=3000).
+        s.applyChanges(delta([](SliceDelta& d){ d.filterHigh = 3000; }));
+        EXPECT_EQ(s.filterLow(),  -3000);
+        EXPECT_EQ(s.filterHigh(), -95);
+        // Wire reports only filter_lo=200 (USB-form low cut): canonical
+        // stored high becomes -200.
+        s.applyChanges(delta([](SliceDelta& d){ d.filterLow = 200; }));
+        EXPECT_EQ(s.filterLow(),  -3000);
+        EXPECT_EQ(s.filterHigh(), -200);
+        // A canonical-form (negative) single edge merges directly.
+        s.applyChanges(delta([](SliceDelta& d){ d.filterLow = -2500; }));
+        EXPECT_EQ(s.filterLow(),  -2500);
+        EXPECT_EQ(s.filterHigh(), -200);
+    }
+    {
+        // USB-family single wrong-form edge: crosswise with negation.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("USB");
+            d.filterLow = 100; d.filterHigh = 2800;
+        }));
+        s.applyChanges(delta([](SliceDelta& d){ d.filterLow = -2700; }));
+        EXPECT_EQ(s.filterLow(),  100);
+        EXPECT_EQ(s.filterHigh(), 2700);
+    }
+    {
+        // Mode-only change (no filter keys in the delta): a second client
+        // flips FDVU→FDVL mid-session — the reporter's MultiFlex scenario.
+        // The stored positive passband must re-normalize immediately, not
+        // wait for the next filter echo (#3434 review).
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVU");
+            d.filterLow = 95; d.filterHigh = 2000;
+        }));
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+        }));
+        EXPECT_EQ(s.filterLow(),  -2000);
+        EXPECT_EQ(s.filterHigh(), -95);
+    }
+    {
+        // setFilterWidth boundary defense (#3434 review): client-side callers
+        // can replay values captured under the pre-mirror convention (band
+        // stack, snapshots, FilterPresets_FDVL, net presets) or pass
+        // audio-domain positives (EQ drag) — and when the radio's filter
+        // already matches, no echo arrives to heal the model.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+            d.filterLow = -2000; d.filterHigh = -95;
+        }));
+        s.setFilterWidth(95, 2000);                  // stale positive replay
+        EXPECT_EQ(s.filterLow(),  -2000);
+        EXPECT_EQ(s.filterHigh(), -95);
+        s.setFilterWidth(-2500, -95);                // canonical → untouched
+        EXPECT_EQ(s.filterLow(),  -2500);
+        EXPECT_EQ(s.filterHigh(), -95);
+    }
 
     if (g_failures == 0) {
         std::printf("slice_model_letter_test: all checks passed\n");

--- a/tests/slice_model_letter_test.cpp
+++ b/tests/slice_model_letter_test.cpp
@@ -331,6 +331,62 @@ int main(int argc, char** argv)
         }
     }
 
+    // ── Filter polarity mirror (#3434). FlexLib reports FDV passbands as
+    // USB-form (positive lo/hi) for BOTH sidebands; FDVL is lower-sideband and
+    // must be mirrored to negative offsets so the overlay draws below the
+    // carrier. The mirror is asymmetric-safe (lo,hi)→(-hi,-lo), so the FreeDV
+    // low cut is preserved rather than collapsed (the regression #3092 hit).
+    {
+        // FDVL: asymmetric positive echo → mirrored, both edges kept.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+            d.filterLow = 95; d.filterHigh = 2000;
+        }));
+        EXPECT_EQ(s.filterLow(),  -2000);   // was 95 → -hi
+        EXPECT_EQ(s.filterHigh(),  -95);    // was 2000 → -lo (low cut preserved)
+    }
+    {
+        // FDVU: upper-sideband FreeDV stays positive (mode-aware).
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVU");
+            d.filterLow = 95; d.filterHigh = 2000;
+        }));
+        EXPECT_EQ(s.filterLow(),  95);
+        EXPECT_EQ(s.filterHigh(), 2000);
+    }
+    {
+        // LSB: symmetric positive echo → historical (-2700,0) result unchanged.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("LSB");
+            d.filterLow = 0; d.filterHigh = 2700;
+        }));
+        EXPECT_EQ(s.filterLow(),  -2700);
+        EXPECT_EQ(s.filterHigh(), 0);
+    }
+    {
+        // USB: wrong-polarity negative echo after restore → mirrored positive.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("USB");
+            d.filterLow = -2700; d.filterHigh = 0;
+        }));
+        EXPECT_EQ(s.filterLow(),  0);
+        EXPECT_EQ(s.filterHigh(), 2700);
+    }
+    {
+        // FDVL already correct (negative) → left untouched, no double-flip.
+        SliceModel s(0);
+        s.applyChanges(delta([](SliceDelta& d){
+            d.mode = QStringLiteral("FDVL");
+            d.filterLow = -2000; d.filterHigh = -95;
+        }));
+        EXPECT_EQ(s.filterLow(),  -2000);
+        EXPECT_EQ(s.filterHigh(), -95);
+    }
+
     if (g_failures == 0) {
         std::printf("slice_model_letter_test: all checks passed\n");
         return 0;


### PR DESCRIPTION
## Summary

Fixes #3434 (the FreeDV half of it — see "Scope" below).

FreeDV lower-sideband (`FDVL`) slices had their filter passband shaded on the
**wrong (upper) side of the carrier**. A user on a FLEX-8600 driving a Pi5
RADE/FreeDV gateway reported that after a profile recall the passband "looks
like USB" and sounds wrong until nudged — the width and side never recover to
the profile's settings.

### Root cause

FlexLib only knows `FDV` as a **USB-family** mode (`Slice.cs:545-550`), so the
radio echoes **both** `FDVU` and `FDVL` passbands as USB-form **positive**
`filter_lo`/`filter_hi`. From the reporter's own support-bundle capture:

```
RX: slice 0 mode=FDVL filter_lo=300 filter_hi=3000     ← positive, USB-form
RX: slice 0 mode=FDVU filter_lo=95  filter_hi=2000
```

`FDVL` is lower-sideband, so its overlay, hit-testing, flag anchoring and the
client's own preset math (`VfoWidget`/`RxApplet::applyFilterPreset`:
`lo=-widthHz, hi=-95`) all expect **negative** offsets from the carrier. The
panadapter overlay (`SpectrumWidget.cpp:11139`) adds `filterLow/High` to the
carrier as **signed Hz**, so a stored `+300…+3000` draws the FDVL shade entirely
**above** the carrier.

PR #3092 side-stepped this by **excluding** FDV from the polarity-flip in
`SliceModel`, because the old anchored flip (`w=hi; lo=-w; hi=0`) collapsed the
*asymmetric* FreeDV passband to symmetric and **discarded the low cut** (e.g.
`95..2000 → -2000..0`). Excluding FDV avoided the discarded-edge bug but left
FDVL positive → drawn on the wrong side.

### The fix

Generalize the flip to an **asymmetric-safe mirror** `(lo,hi) → (-hi,-lo)` that
preserves **both** edges, then re-include `FDVU`/`FDVL` in the polarity
families:

| mode | radio echo | stored (after fix) | side |
|---|---|---|---|
| `FDVL` | `95 … 2000` | `-2000 … -95` | lower ✅ (low cut kept) |
| `FDVU` | `95 … 2000` | `95 … 2000` | upper ✅ (unchanged — mode-aware) |
| `LSB`  | `0 … 2700`  | `-2700 … 0`  | lower ✅ (historical result unchanged) |
| `LSB`  | `100 … 2800`| `-2800 … -100`| lower ✅ (low cut now preserved) |
| `USB`  | `-2700 … 0` | `0 … 2700`   | upper ✅ |

The mirror is a strict superset of the old behavior: for symmetric SSB it
produces the identical `(-w,0)` / `(0,w)` result, and for asymmetric passbands
it keeps the edge the old flip threw away — so it also supersedes #3092's
exclusion without reintroducing the discarded-edge regression.

## Proof

**Unit test (new, `slice_model_letter_test`)** — five polarity cases pinning the
exact wire input the reporter's radio sends and asserting the corrected stored
output, including the asymmetric FDVL mirror and the no-double-flip guard:

```
1/1 Test #3: slice_model_letter_test .......... Passed
```

**Agent automation bridge (live, FLEX-8400M @ 14.100 MHz, RX-only):** the
rewritten polarity branch was exercised on the SSB paths this radio supports and
renders correct geometry with no regression —

```
LSB: filterLow=-2800 filterHigh=-100 → overlay LOWER  [OK]
USB: filterLow=100    filterHigh=2800 → overlay UPPER  [OK]
```

_proof screenshot attached below (LSB passband shaded on the correct lower side
of the carrier)._

**Honest proof boundary:** the FDVL correction itself could **not** be
reproduced on live hardware here — the test FLEX-8400M has **no classic FreeDV
(FDVU/FDVL) waveform** in its `mode_list` (the direct analogue of the reporter's
Pi5 RADE gateway), so the slice can't be driven into `FDVL` via the bridge, and
this radio applies the mode-change filter client-side (bypassing the echo path
the fix corrects). The FDVL behavior is therefore proven by the unit test + the
reporter's raw radio capture, and the live bridge proves the shared code branch
does not regress SSB. See the bridge-gaps note in the issue.

## Scope

This addresses the **FDVL passband geometry** — the "width/side looks like USB
and sounds wrong" core of #3434. The reporter also describes an audible
desync *during* profile transitions in a MultiFlex (Maestro + SmartSDR +
AetherSDR) session; that timing-dependent path is not reproduced here and may be
a separate follow-up. Leaving #3434 open / maintainer-review as appropriate.

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat
