### PR TITLE
feat(display): remove Lean Mode, default WAVE FPS to 25, GPU selector to top of SYSTEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Removed
+
+- **Lean Mode.** The global low-overhead render toggle (#3283) is gone; the
+  app always renders at full quality. If you had Lean Mode on: the WAVE scope
+  reappears on upgrade (Lean hid it without turning its sidebar tile off —
+  close the tile if you don't want it), VFO panels return to translucent
+  rendering, and meters repaint at their full animation rate. The structural
+  fixes tracked in #3283 (GPU-side scope/meter rendering) are the intended
+  replacement for Lean's mitigations. `get panstats` no longer reports the
+  `leanMode` field.
+
+### Changed
+
+- **WAVE applet defaults to 25 fps** (was 60), matching the panadapter's
+  default FFT cadence. A previously saved refresh rate is kept; the slider
+  still reaches 60.
+
 ## [v26.7.1] — 2026-07-02
 
 ### 3D stacked-trace spectrum + in-process NVIDIA BNR + TX meter readouts + 60 fps panadapters

--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -123,8 +123,8 @@ sighted users on the same machine because the SR overlay paints over the
 UI. Announce *settled* values — match the cadence to what a sighted user
 would read as "the value stopped changing." Patterns that work:
 
-- Use the same `MeterSmoother` settled-frame gate already in use for
-  lean-mode paint throttling (see [`MeterSmoother.h`](../src/gui/MeterSmoother.h)).
+- Use the same `MeterSmoother` settled-frame pattern the meter widgets use to
+  drive their final repaint (see [`MeterSmoother.h`](../src/gui/MeterSmoother.h)).
 - For knob/dial-driven changes, fire the announcement on
   `QAbstractSlider::sliderReleased` rather than `valueChanged`.
 - For free-form updates, debounce to ~10 Hz with a `QTimer::singleShot`.

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -532,6 +532,10 @@ cost a few integer adds per frame.
 `reset` zeroes the counters after the read so successive reads measure
 disjoint intervals: `get panstats 0 reset`.
 
+> **Removed field:** `leanMode` (boolean) was dropped when Lean Mode was
+> removed from the app — scripts that keyed on it should stop; every pan now
+> always renders the full-quality path.
+
 ### `get tracedebug`
 Per-panadapter `SpectrumWidget` trace diagnostics for proving Flex/Kiwi display
 source behavior without screenshots. This is intentionally diagnostic rather

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -508,7 +508,7 @@ cost a few integer adds per frame.
 → {"cmd":"get","model":"panstats"}
 ← {"ok":true,"model":"panstats","pans":[{
    "panIndex":0,"renderMode":"2D","renderer":"GPU QRhi (Metal; Apple M1 Ultra)",
-   "widthPx":2280,"heightPx":1302,"dpr":2.0,"leanMode":false,"sinceMs":60012,
+   "widthPx":2280,"heightPx":1302,"dpr":2.0,"sinceMs":60012,
    "fftFramesPerSec":29.6,"ingestMsPerSec":8.1,
    "gpuFramesPerSec":29.6,"gpuFrameMsPerSec":97.4,"avgGpuFrameUs":3290.0,
    "fftBuildMsPerSec":64.2,"fftVboBytesPerSec":42049536.0,

--- a/resources/shaders/panscope.frag
+++ b/resources/shaders/panscope.frag
@@ -7,7 +7,7 @@
 // every frame): the CPU now uploads ~one float per device pixel column and
 // this shader reproduces the same layers —
 //   1. fill under the trace (heat-map or solid-gradient, alpha from the
-//      fill slider; suppressed in lean mode),
+//      fill slider),
 //   2. a feather stroke (line width + featherPx, low alpha),
 //   3. the core stroke (line width, high alpha),
 // with slope-corrected stroke width via screen-space derivatives so steep
@@ -24,7 +24,7 @@ layout(binding = 1) uniform sampler2D columns;
 layout(std140, binding = 0) uniform U {
     vec4 plot;       // wPx, hPx, columnCount, hasData
     vec4 stroke;     // coreHalfWidthPx, featherPx, coreAlpha, featherAlpha
-    vec4 fillP;      // fillAlpha, heatMap (0/1), lean (0/1), pad
+    vec4 fillP;      // fillAlpha, heatMap (0/1), pad, pad
     vec4 fillColor;  // straight rgb, a unused
     vec4 darkColor;  // straight rgb (solid-mode base blend), a unused
 };
@@ -70,8 +70,7 @@ void main()
     float yTrace = (1.0 - t) * hPx;                // trace top edge in px
 
     bool heat = fillP.y > 0.5;
-    bool lean = fillP.z > 0.5;
-    float fa = lean ? 0.0 : fillP.x;
+    float fa = fillP.x;
 
     // ── Fill under the trace ────────────────────────────────────────────
     if (fa > 0.0 && py >= yTrace) {

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -37,8 +37,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || m_smooth.shouldRepaint())
-                update();
+            update();
         });
     }
 

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -43,8 +43,7 @@ ClientCompMeter::ClientCompMeter(QWidget* parent) : QWidget(parent)
         const bool settled = !m_smooth.tick(m_animElapsed.restart());
         if (settled)
             m_animTimer.stop();
-        if (settled || m_smooth.shouldRepaint())
-            update();
+        update();
     });
 
     // Phase 5 PR 3b — repaint when the theme changes so live edits to

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -35,8 +35,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || m_smooth.shouldRepaint())
-                update();
+            update();
         });
     }
 

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -36,8 +36,7 @@ public:
             const bool settled = !m_smooth.tick(m_animElapsed.restart());
             if (settled)
                 m_animTimer.stop();
-            if (settled || m_smooth.shouldRepaint())
-                update();
+            update();
         });
     }
 

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -8,26 +8,14 @@
 
 namespace AetherSDR {
 
-// Persistence helper for display-related UI toggles (#3283 Lean Mode is the
-// first; future display-feature toggles like frameless / theme variants land
-// here as additional fields).
+// Persistence helper for display-related UI toggles (the SmartMTR meter view
+// and its options; future display-feature toggles land here as additional
+// fields).
 //
 // Stored as a nested JSON blob under AppSettings["Display"], per the
-// nested-JSON-per-feature convention (constitution Principle V).  The legacy
-// flat key "LeanMode" is migrated into this blob by migrateLegacy(), called
-// once at startup (before the first read), so existing users keep their
-// behavior.
+// nested-JSON-per-feature convention (constitution Principle V).
 class DisplaySettings {
 public:
-    static bool leanMode() { return readObj().value("leanMode").toString("False") == "True"; }
-
-    static void setLeanMode(bool on)
-    {
-        QJsonObject o = readObj();
-        o["leanMode"] = on ? QStringLiteral("True") : QStringLiteral("False");
-        write(o);
-    }
-
     // VFO meter view: false = standard S-meter, true = SmartMTR component.
     // Global (not per-slice) — see MeterViewController for the live-broadcast
     // layer that fans this choice out to every open VFO flag.
@@ -158,23 +146,6 @@ public:
         case TxMeter::None: break;
         }
         return QStringLiteral("None");
-    }
-
-    // One-shot migration from the legacy "LeanMode" flat key.  Run at app
-    // startup before any caller reads the new blob.  Safe to call repeatedly:
-    // returns immediately if the new blob already exists.
-    static void migrateLegacy()
-    {
-        auto& s = AppSettings::instance();
-        if (s.contains("Display")) return;
-        const bool legacyLean =
-            s.value("LeanMode", "False").toString() == "True";
-        QJsonObject o;
-        o["leanMode"] = legacyLean ? QStringLiteral("True") : QStringLiteral("False");
-        write(o);
-        // Leave the legacy flat key in place — harmless after migration, and a
-        // future cleanup PR can drop it once we're confident no other reader
-        // still touches it.
     }
 
 private:

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -14,6 +14,14 @@ namespace AetherSDR {
 //
 // Stored as a nested JSON blob under AppSettings["Display"], per the
 // nested-JSON-per-feature convention (constitution Principle V).
+//
+// RETIRED KEYS — do not reuse. Pre-removal installs still carry these values,
+// so a new feature reusing the name would inherit stale state (e.g. a
+// leftover "True" force-enabling itself):
+//   - "leanMode" (nested, this blob) — Lean Mode, removed with #3283's
+//     mitigation retirement; ex-lean users have "True" persisted.
+//   - "LeanMode" (legacy flat AppSettings key) — pre-blob spelling, was
+//     migrated by the now-removed migrateLegacy().
 class DisplaySettings {
 public:
     // VFO meter view: false = standard S-meter, true = SmartMTR component.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -43,7 +43,6 @@
 #endif
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
-#include "MeterSmoother.h"  // global lean-mode meter repaint throttle (#3283)
 #include "AppletPanel.h"
 #include "containers/ContainerManager.h"
 #include "RxApplet.h"
@@ -991,16 +990,6 @@ MainWindow::MainWindow(QWidget* parent)
     // Audio worker thread (#502) — AudioEngine runs on its own thread so
     // audio processing never competes with paintEvent for main thread CPU.
     m_audioThread = new QThread(this);
-    // Lean render mode (#3283): read persisted state early so panadapters
-    // created during startup seed their Lean button/widget correctly, then
-    // apply once after construction to cover VFOs + the WAVE applet.
-    // Persistence is the nested "Display" blob (Principle V); the legacy
-    // flat "LeanMode" key is migrated into it on first read.
-    DisplaySettings::migrateLegacy();
-    m_leanMode = DisplaySettings::leanMode();
-    if (m_leanMode) {
-        QTimer::singleShot(0, this, [this]() { applyLeanMode(true); });
-    }
     initReceivePresentationSync();
 
     m_audioThread->setObjectName("AudioEngine");
@@ -4829,46 +4818,6 @@ void MainWindow::applyDarkTheme()
 }
 
 // ─── Radio/model event handlers ───────────────────────────────────────────────
-
-void MainWindow::applyLeanMode(bool on)
-{
-    m_leanMode = on;
-
-    // Panadapters: opaque single layer (no wallpaper / fill) + ~30 Hz cap.
-    // Also keep every pan's Lean button in sync (the toggle is global).
-    for (auto* sw : findChildren<SpectrumWidget*>()) {
-        sw->setLeanMode(on);
-        if (auto* menu = sw->overlayMenu())
-            menu->setLeanChecked(on);
-    }
-
-    // VFO panels: opaque, cacheable layer (kills the translucent re-composite).
-    for (auto* vfo : findChildren<VfoWidget*>())
-        vfo->setOpaqueMode(on);
-
-    // WAVE scope: hidden + feed dropped. Round-trip respects the user's
-    // pre-Lean choice (if they had the scope hidden before enabling Lean,
-    // disabling Lean must not silently re-show it).
-    if (m_appletPanel) {
-        if (auto* wave = m_appletPanel->waveApplet()) {
-            if (on) {
-                m_preLeanWaveActive = wave->isActive();
-                wave->setActive(false);
-            } else {
-                wave->setActive(m_preLeanWaveActive);
-            }
-        }
-    }
-
-    // Meters: throttle their animation repaint so they stop dirtying the shared
-    // backing store every frame (which forces a full-window texture re-upload to
-    // recomposite with the GPU panadapter — the dominant pooled cost on large/5K
-    // windows; see #3283). Native-layering the panel was tried and did not
-    // isolate them under Qt 6.11/macOS, so we cap the repaint rate instead.
-    MeterSmoother::setLeanThrottle(on);
-
-    DisplaySettings::setLeanMode(on);
-}
 
 void MainWindow::onConnectionStateChanged(bool connected)
 {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -210,11 +210,6 @@ protected:
 #endif
 
 private slots:
-    // Global lean render mode (#3283): opaque pan + VFO, ~30 Hz repaint cap
-    // (kLeanFrameMs = 33), WAVE scope off, meters throttled to ~12 Hz per
-    // instance. Applied across all panes/VFOs, persisted, reversible.
-    void applyLeanMode(bool on);
-
     // Radio/connection events
     void onConnectionStateChanged(bool connected);
     void adjustCatPortCounts(bool connected);  // called from onConnectionStateChanged
@@ -1053,11 +1048,6 @@ private:
     // Active slice tracking for multi-slice support
     int m_activeSliceId{-1};
     bool m_splitActive{false};
-    bool m_leanMode{false};  // global lean render mode state (#3283)
-    // Pre-lean WaveApplet active state, captured on Lean activation so the
-    // round-trip restores whatever the user had before instead of silently
-    // re-showing the scope. Only meaningful while m_leanMode is true.
-    bool m_preLeanWaveActive{true};
     int  m_splitRxSliceId{-1};
     int  m_splitTxSliceId{-1};
     int  m_pendingMemoryRevealSliceId{-1};

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2070,12 +2070,6 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     }
 
     // ── Per-pan display controls (client-side) ───────────────────────────
-    // Global lean render mode — every pan's Lean button drives the same
-    // app-wide toggle; seed this new pan's button + widget with current state.
-    connect(menu, &SpectrumOverlayMenu::leanModeToggled,
-            this, &MainWindow::applyLeanMode);
-    menu->setLeanChecked(m_leanMode);
-    sw->setLeanMode(m_leanMode);
     connect(menu, &SpectrumOverlayMenu::fftFillAlphaChanged,
             sw, &SpectrumWidget::setFftFillAlpha);
     connect(menu, &SpectrumOverlayMenu::fftFillColorChanged,

--- a/src/gui/MeterSmoother.h
+++ b/src/gui/MeterSmoother.h
@@ -100,56 +100,10 @@ public:
     void setBallistics(const Ballistics& b) { m_b = b; }
     const Ballistics& ballistics() const { return m_b; }
 
-    // ── Lean-mode per-widget repaint gate (#3283) ──────────────────────────
-    // Every meter animates its MeterSmoother at ~120 Hz; each tick repaints,
-    // and on a window that also hosts the GPU panadapter every repaint forces a
-    // full-window backing-store→texture re-upload (the dominant pooled cost on
-    // large/5K displays). Lean mode keeps the smoother integrating at the full
-    // rate (so ballistics stay smooth) but gates the *repaint* to ~kLeanRepaintHz
-    // per widget.
-    //
-    // The gate is per-instance (each MeterSmoother carries its own clock),
-    // because every active meter owns its own MeterSmoother. A previous
-    // shared-static version of this gate underdelivered on its own claim: with
-    // N meters racing into the gate, the first to tick each ~83 ms window got
-    // through and the other N−1 were starved that window, so each individual
-    // meter only saw the green light at roughly (kLeanRepaintHz / N) Hz —
-    // visibly stuttery on GR bars and S-meter needles. Per-instance gates let
-    // every meter independently hit the target rate.
-    //
-    // Usage at the meter's timer callback:
-    //     const bool settled = !m_smooth.tick(elapsed);
-    //     if (settled) m_timer.stop();
-    //     if (settled || m_smooth.shouldRepaint()) update();
-    // (Always paint the settled frame so the final value is never dropped.)
-    static void setLeanThrottle(bool on) { s_leanThrottle = on; }
-    static bool leanThrottle() { return s_leanThrottle; }
-    bool shouldRepaint()
-    {
-        if (!s_leanThrottle) {
-            return true;
-        }
-        constexpr qint64 kGateMs = 1000 / kLeanRepaintHz;
-        if (!m_gate.isValid()) {
-            m_gate.start();
-        }
-        const qint64 now = m_gate.elapsed();
-        if (m_lastMs < 0 || now - m_lastMs >= kGateMs) {
-            m_lastMs = now;
-            return true;
-        }
-        return false;
-    }
-
 private:
-    static constexpr int kLeanRepaintHz = 12;  // gated meter repaint rate in lean
-    static inline bool s_leanThrottle = false;
-
     Ballistics     m_b;
     float          m_display{0.0f};
     float          m_target{0.0f};
-    QElapsedTimer  m_gate;
-    qint64         m_lastMs{-1};
 };
 
 // Recommended driving-timer interval for a MeterSmoother.  8 ms ≈

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -1,5 +1,4 @@
 #include "SMeterWidget.h"
-#include "MeterSmoother.h"  // shared lean-mode repaint gate (#3283)
 #include "core/ThemeManager.h"
 
 #include <QAccessible>
@@ -282,11 +281,7 @@ void SMeterWidget::animateNeedle()
         m_needleAnimation.stop();
     }
 
-    // Gate the needle repaint in lean mode so it stops dirtying the shared
-    // backing store ~120×/sec (#3283); always paint the settled frame.
-    if (settled || m_smooth.shouldRepaint()) {
-        update();
-    }
+    update();
 }
 
 bool SMeterWidget::usesUnavailableRxMeter() const

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -5,7 +5,6 @@
 #include <QElapsedTimer>
 
 #include "core/KiwiSdrProtocol.h"
-#include "MeterSmoother.h"
 
 namespace AetherSDR {
 
@@ -139,13 +138,6 @@ private:
     static constexpr float ARC_START_DEG = 55.0f;   // right end (degrees from +X axis)
     static constexpr float ARC_END_DEG   = 125.0f;  // left end
 
-    // SMeterWidget runs its own needle animation (see m_needleAnimation /
-    // m_needleFraction above), but lean-mode repaint throttling is shared
-    // with every other meter through MeterSmoother::shouldRepaint().
-    // Holding an instance here only for its per-widget gate keeps every
-    // meter independently hitting kLeanRepaintHz instead of starving on a
-    // shared static (#3283).
-    MeterSmoother m_smooth;
 };
 
 } // namespace AetherSDR

--- a/src/gui/SmartMtrStyle.h
+++ b/src/gui/SmartMtrStyle.h
@@ -111,12 +111,10 @@ inline constexpr double kSlewUnitsPerSec = 60.0;
 // while still smoothing the per-packet step instead of snapping.
 inline constexpr double kPeakSlewUnitsPerSec = 4000.0;
 
-// Repaint cadence (Hz) for a returning marker, used to bypass the bar's lean
-// repaint gate (#3283). In lean mode the bar throttles its repaint to 12 Hz; a
-// marker gliding back at kSlewUnitsPerSec sampled to the screen at 12 Hz steps
-// visibly (~2 deg/frame). The original SmartMTR renders its return at a steady
-// 60 Hz, so we match that for the markers while leaving the bar and idle meters
-// lean-gated. Bounds the extra GPU recomposite cost to the return window only.
+// Repaint cadence (Hz) for a returning marker. The bar is settled while a peak
+// marker glides back, so nothing else would drive a repaint; this clock keeps
+// the marker gliding at a steady 60 Hz (matching the original SmartMTR return),
+// bounding the extra GPU recomposite cost to the return window only.
 inline constexpr int kExtremesRepaintHz = 60;
 
 // Proximity fade: markers fade out when min and max are within a few dB (the

--- a/src/gui/SmartMtrWidget.cpp
+++ b/src/gui/SmartMtrWidget.cpp
@@ -187,10 +187,9 @@ void SmartMtrWidget::advance()
     const bool barMoving = m_smooth.tick(dt);
     bool moving = barMoving;
 
-    // A returning marker must repaint at a smooth cadence even when the bar's
-    // lean gate throttles to 12 Hz (the bar is settled during the glide, so its
-    // gate would step the markers). Gate the marker repaint on its own clock at
-    // kExtremesRepaintHz, bypassing the bar's lean gate only while a marker moves.
+    // A returning marker must repaint at a smooth cadence while the bar is
+    // settled during the glide (nothing else would trigger a repaint). Gate the
+    // marker repaint on its own clock at kExtremesRepaintHz while a marker moves.
     bool extremesRepaintDue = false;
     if (m_extremesEnabled) {
         const qint64 now = m_extremesClock.elapsed();
@@ -212,9 +211,9 @@ void SmartMtrWidget::advance()
     if (settled)
         m_animTimer.stop();
     // Repaint on: the settled (final) frame; a gated marker step; or the bar
-    // moving (through its lean gate). Gate the bar repaint on barMoving so the
-    // timer staying alive through a marker hold (nothing moving) doesn't repaint.
-    if (settled || extremesRepaintDue || (barMoving && m_smooth.shouldRepaint()))
+    // moving. Gate the bar repaint on barMoving so the timer staying alive
+    // through a marker hold (nothing moving) doesn't repaint.
+    if (settled || extremesRepaintDue || barMoving)
         update();
 }
 

--- a/src/gui/SmartMtrWidget.h
+++ b/src/gui/SmartMtrWidget.h
@@ -108,8 +108,7 @@ private:
     void rebuildStaticLayers(const SmartMtrGeometry& g);
 
     // One animation tick: advance the smoother (and the extremes) by the elapsed
-    // wall-clock, stop the timer once both settle, and repaint through the
-    // lean-mode gate.
+    // wall-clock, stop the timer once both settle, and repaint.
     void advance();
 
     // Apply the bar ballistics for a meter kind: the analog d'Arsonval sag for
@@ -167,8 +166,8 @@ private:
     MeterValues m_showValues = MeterValues::None;
     bool m_showTypeLabel = false; // draw the MIC/SWR/PWR/COMP label inside the hole
 
-    // Repaint cadence for a returning marker, independent of the bar's lean
-    // repaint gate (which throttles to 12 Hz and would step the slow glide).
+    // Repaint cadence for a returning marker (the bar is settled during the
+    // glide, so this clock is what keeps the marker moving smoothly).
     // Timestamp (on m_extremesClock) of the last marker-driven repaint; -1 until
     // the first. See SmartMtrExtremes::kExtremesRepaintHz.
     qint64 m_lastExtremesRepaintMs = -1;

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -798,14 +798,6 @@ void SpectrumOverlayMenu::setPanId(const QString& id)
     refreshAntennaCombo();
 }
 
-void SpectrumOverlayMenu::setLeanChecked(bool on)
-{
-    if (!m_leanBtn || m_leanBtn->isChecked() == on)
-        return;
-    QSignalBlocker block(m_leanBtn);  // reflect state without re-emitting
-    m_leanBtn->setChecked(on);
-}
-
 void SpectrumOverlayMenu::setRadioModel(RadioModel* model)
 {
     if (m_radioModel)
@@ -1851,28 +1843,11 @@ void SpectrumOverlayMenu::buildDisplayPanel()
 
     makeHeader("SYSTEM");
 
-    // ── Lean render mode toggle (#3283) ─────────────────────────────────
-    // Global low-overhead render mode: opaque panadapter + VFO, capped
-    // repaint, WAVE scope off, throttled meters. Grouped with the spectrum
-    // render controls, below the 3D Floor slider. Drives the app-wide toggle.
-    {
-        m_leanBtn = new QPushButton("Lean Mode");
-        m_leanBtn->setObjectName("displayLeanModeBtn");
-        m_leanBtn->setCheckable(true);
-        m_leanBtn->setStyleSheet(btnStyle);
-        m_leanBtn->setToolTip("Lean mode: opaque panadapter + VFO, capped "
-                              "repaint, WAVE scope off, throttled meters. "
-                              "Reduces CPU/GPU load. Persists across restarts.");
-        connect(m_leanBtn, &QPushButton::toggled, this,
-                [this](bool on) { emit leanModeToggled(on); });
-        grid->addWidget(m_leanBtn, row, 0, 1, 4);
-        ++row;
-    }
-
     // ── Render GPU (multi-GPU systems only) ───────────────────────────────
-    // The graphics adapter can't be switched under a live context, so the
-    // choice is persisted and applied on the next launch (GpuSelector reads it
-    // before QApplication).  Hidden entirely on single-GPU systems.
+    // First control under SYSTEM: the graphics adapter can't be switched under
+    // a live context, so the choice is persisted and applied on the next launch
+    // (GpuSelector reads it before QApplication).  Hidden entirely on single-GPU
+    // systems.
     if (GpuSelector::hasMultiple()) {
         auto* lbl = new QLabel("GPU:");
         lbl->setStyleSheet(labelStyle);

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -72,10 +72,6 @@ public:
     void setPanId(const QString& id);
     QString panId() const { return m_panId; }
 
-    // Reflect the global Lean-mode state on this pan's Lean button without
-    // re-emitting (MainWindow keeps every pan's button in sync).
-    void setLeanChecked(bool on);
-
     // Connect/disconnect the ANT panel to a slice model.
     void setSlice(SliceModel* slice);
     void setWnbState(bool on, int level);
@@ -190,8 +186,6 @@ signals:
     void backgroundOpacityChanged(int pct);
     void backgroundFillColorChanged(const QColor& color);
     void displaySettingsReset();
-    // Global low-overhead render mode (opaque pan/VFO, capped repaint, WAVE off).
-    void leanModeToggled(bool on);
 
 private:
     QString m_panId;
@@ -231,7 +225,6 @@ private:
     static constexpr int kBtnDax = 6;
 
     QPushButton* m_toggleBtn{nullptr};
-    QPushButton* m_leanBtn{nullptr};  // Lean toggle (lives in the Display panel)
     QVector<QPushButton*> m_menuBtns;
     bool m_expanded{true};
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -837,7 +837,6 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
         m_spectrumRenderMode == SpectrumRenderMode::Mode3D
             ? QStringLiteral("3D") : QStringLiteral("2D");
     m[QStringLiteral("renderer")] = rendererDescription();
-    m[QStringLiteral("leanMode")] = m_leanMode;
     m[QStringLiteral("sinceMs")] = static_cast<qlonglong>(m_panStats.sinceMs());
 
     m[QStringLiteral("fftFramesPerSec")] = m_panStats.updateSpectrumCalls / secs;
@@ -5754,7 +5753,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         }
     }
 
-    leanCappedUpdate();
+    coalescedUpdate();
 }
 
 void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
@@ -5940,7 +5939,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         PerfTelemetry::instance().recordWaterfallNativeRows(rowsToPush);
 
     if (visibleStream) {
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -5987,7 +5986,7 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
-    leanCappedUpdate();
+    coalescedUpdate();
 }
 
 void SpectrumWidget::setKiwiSdrDisplaySourceControlVisible(bool visible)
@@ -6048,7 +6047,7 @@ void SpectrumWidget::setKiwiSdrWaterfallProfile(const QString& profileId)
         m_wfTexFullUpload = true;
 #endif
         reacquireNoiseFloorLockFromVisibleSource();
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -6063,7 +6062,7 @@ void SpectrumWidget::clearKiwiSdrWaterfallRows()
     m_kiwiSdrFftTraceFloorValid = false;
     if (m_kiwiSdrWaterfallActive) {
         clearCurrentWaterfallRows();
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -6079,7 +6078,7 @@ void SpectrumWidget::clearKiwiSdrWaterfallRowsForProfile(const QString& profileI
         && m_kiwiSdrWaterfallProfileId == normalized) {
         resetKiwiSdrWaterfallDisplayRange();
         clearCurrentWaterfallRows();
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -6194,7 +6193,7 @@ void SpectrumWidget::setKiwiSdrWaterfallDisplayRange(float minDbm,
     m_kiwiSdrDisplayRangeAutoRange = autoRange;
     resetDssUploadState();
     if (m_kiwiSdrWaterfallActive) {
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -6366,7 +6365,7 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
     pushKiwiSdrWaterfallRow(binsDbm, destWidth,
                             rowCenterMhz, rowBandwidthMhz);
     if (visibleStream) {
-        leanCappedUpdate();
+        coalescedUpdate();
     }
 }
 
@@ -8053,42 +8052,29 @@ void SpectrumWidget::leaveEvent(QEvent* event)
     updateTrackedCursorState(QPoint(-1, -1), false);
 }
 
-void SpectrumWidget::setLeanMode(bool on)
-{
-    if (m_leanMode == on)
-        return;
-    m_leanMode = on;
-    m_leanRepaintClock.invalidate();
-    markOverlayDirty();  // re-render with/without wallpaper + fill
-}
-
-void SpectrumWidget::leanCappedUpdate()
+void SpectrumWidget::coalescedUpdate()
 {
     // Data-driven repaints (FFT frames, waterfall rows) coalesce into one
     // present per slot; interactive paths still call update() directly so
-    // input latency is unaffected. Lean mode drops excess frames outright
-    // (~30 Hz cap); normal mode never drops — a trailing update presents
-    // whatever arrived inside the slot.
-    const int slotMs = m_leanMode ? kLeanFrameMs : kPresentCoalesceMs;
-    if (!m_leanRepaintClock.isValid()) {
-        m_leanRepaintClock.start();
+    // input latency is unaffected. No frame is dropped — a trailing update
+    // presents whatever arrived inside the slot.
+    const int slotMs = kPresentCoalesceMs;
+    if (!m_presentCoalesceClock.isValid()) {
+        m_presentCoalesceClock.start();
         update();
         return;
     }
-    const qint64 sinceMs = m_leanRepaintClock.elapsed();
+    const qint64 sinceMs = m_presentCoalesceClock.elapsed();
     if (sinceMs >= slotMs) {
-        m_leanRepaintClock.restart();
+        m_presentCoalesceClock.restart();
         update();
         return;
-    }
-    if (m_leanMode) {
-        return;  // drop frames above ~30 Hz (kLeanFrameMs = 33)
     }
     if (!m_presentPending) {
         m_presentPending = true;
         QTimer::singleShot(static_cast<int>(slotMs - sinceMs), this, [this]() {
             m_presentPending = false;
-            m_leanRepaintClock.restart();
+            m_presentCoalesceClock.restart();
             update();
         });
     }
@@ -9606,7 +9592,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             QPainter bp(&m_overlayBg);
             bp.setRenderHint(QPainter::Antialiasing, false);
             bp.fillRect(specRect, m_bgFillColor);
-            if (!m_leanMode && !m_bgImage.isNull()) {
+            if (!m_bgImage.isNull()) {
                 if (m_bgScaledSize != specRect.size()) {
                     QImage expanded = m_bgImage.scaled(specRect.size(),
                         Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
@@ -10061,7 +10047,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                     kFftLineFeatherAlpha,
                     fa,                                             // fillAlpha
                     m_fftHeatMap ? 1.0f : 0.0f,
-                    m_leanMode ? 1.0f : 0.0f,
+                    0.0f,                                           // fillP.z — unused (pad)
                     0.0f,
                     static_cast<float>(m_fftFillColor.redF()),
                     static_cast<float>(m_fftFillColor.greenF()),
@@ -10398,7 +10384,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     } else {
         // Composition z-order: bg fill → bg image → grid → FFT trace.
         p.fillRect(specRect, m_bgFillColor);
-        if (!m_leanMode && !m_bgImage.isNull()) {
+        if (!m_bgImage.isNull()) {
             if (m_bgScaledSize != specRect.size()) {
                 QImage expanded = m_bgImage.scaled(specRect.size(),
                     Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
@@ -10780,7 +10766,7 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& r)
 
             float avgT = (pts[i].t + pts[i + 1].t) * 0.5f;
             QColor top = heatColor(avgT);
-            const float swFillAlpha = m_leanMode ? 0.0f : m_fftFillAlpha;
+            const float swFillAlpha = m_fftFillAlpha;
             top.setAlphaF(swFillAlpha * 0.3f);
             QColor bot(0, 0, 77, static_cast<int>(255 * swFillAlpha));
             QLinearGradient grad(0, std::min(pts[i].y, pts[i + 1].y), 0, bottom);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -270,17 +270,6 @@ public:
     // Set the current demod mode (for zoom centering behavior).
     void setMode(const QString& mode) { m_mode = mode; }
 
-    // Lean render mode (#3283): skip the wallpaper layer (render an opaque
-    // single layer), drop the translucent FFT fill, and cap the spectrum and
-    // waterfall data-driven repaints to ~30 Hz (kLeanFrameMs = 33). The cap is
-    // applied via leanCappedUpdate() only on the two high-frequency entry
-    // points (updateSpectrum, updateWaterfallRow); interactive paths (cursor
-    // moves, marker drags, etc.) keep their immediate update() calls so input
-    // feels snappy. Reversible — no persisted state is destroyed.
-    void setLeanMode(bool on);
-    bool leanMode() const { return m_leanMode; }
-
-
     // Access the floating overlay menu (for wiring signals).
     SpectrumOverlayMenu* overlayMenu() const { return m_overlayMenu; }
 
@@ -1234,15 +1223,8 @@ private:
     FilterEdge m_draggingFilter{FilterEdge::None};
     int m_filterDragStartX{0};      // pixel X at grab time (#764)
     int m_filterDragStartHz{0};     // filter edge Hz at grab time (#764)
-    // Lean render mode state (#3283).
-    bool m_leanMode{false};
-    QElapsedTimer m_leanRepaintClock;       // data-repaint coalescing clock
-    // Each panadapter present forces a full-window backing-store→GPU texture
-    // re-upload (the dominant pooled cost on large/5K windows — #3283), so the
-    // present rate ~= the flush rate. 33 ms (~30 Hz) roughly halves that upload
-    // load vs 60 Hz while staying visually smooth for a low-overhead mode.
-    static constexpr int kLeanFrameMs = 33;
-    // Normal-mode coalescing window: FFT frames and waterfall rows arrive as
+    QElapsedTimer m_presentCoalesceClock;   // data-repaint coalescing clock
+    // Coalescing window: FFT frames and waterfall rows arrive as
     // separate UDP events, so without coalescing a narrow pan schedules up to
     // ~56 window flushes/s (30 fps FFT + 26 rows/s WF) — over the display's
     // 60 Hz budget once WAVE/meters add theirs, which starves the swapchain
@@ -1251,7 +1233,7 @@ private:
     // fires at the slot edge) while capping flushes at ~60/s.
     static constexpr int kPresentCoalesceMs = 16;
     bool m_presentPending{false};           // trailing update scheduled
-    void leanCappedUpdate();                // update(), coalesced / lean-capped
+    void coalescedUpdate();                 // update(), coalesced into one present per slot
     // VFO passband drag state (#404)
     bool m_draggingVfo{false};
     int  m_vfoDragOffsetHz{0};  // Hz offset from VFO at grab point (#1120)

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -2527,8 +2527,7 @@ void VfoWidget::setMeterMenuOpen(bool open)
     relayoutToCurrentContent();
     update();      // repaint the meter-strip underline
     // The flag composites over the GPU spectrum (QRhiWidget); our update()
-    // doesn't refresh the parent's texture, so force a recomposite, same as
-    // setOpaqueMode(). (#SmartMTR)
+    // doesn't refresh the parent's texture, so force a recomposite. (#SmartMTR)
     if (QWidget* p = parentWidget()) {
         p->update();
     }
@@ -2558,32 +2557,6 @@ void VfoWidget::showTab(int index)
         }
     }
     relayoutToCurrentContent();
-}
-
-void VfoWidget::setOpaqueMode(bool on)
-{
-    if (m_opaqueMode == on)
-        return;
-    m_opaqueMode = on;
-
-    // The panel's paintEvent already fills an opaque dark rounded rect; the
-    // translucent attribute + "background: transparent" stylesheet only existed
-    // to let the rounded corners show through. In lean mode we trade rounded
-    // corners for an opaque, independently-cacheable layer.
-    //
-    // The #VfoWidgetRoot stylesheet is what actually governs Qt's opacity
-    // decision here — with "background: transparent" the compositor re-blends
-    // the whole panel (and its buttons) over the window on every sync. Swapping
-    // to an opaque background lets it cache + Source-blit instead, which is the
-    // dominant idle/drag pool cost (#3283). Clearing WA_TranslucentBackground
-    // alone is not enough while the stylesheet stays transparent.
-    setAttribute(Qt::WA_TranslucentBackground, !on);
-    setStyleSheet(on
-        ? QStringLiteral("QWidget#VfoWidgetRoot { background: #0a0a14; border: none; }")
-        : kBgStyle);
-    update();
-    if (QWidget* p = parentWidget())
-        p->update();
 }
 
 void VfoWidget::setCollapsed(bool collapsed)

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -271,11 +271,6 @@ public:
     // to screen readers. (#3754)
     QString accessibleSummary() const;
 
-    // Lean render mode: drop WA_TranslucentBackground so the panel composites
-    // as an opaque, cacheable layer instead of being alpha-blended over the
-    // whole window every frame (the dominant idle CPU cost — see #3283).
-    void setOpaqueMode(bool on);
-
     // Which side of the slice marker the flag panel is currently rendered on.
     // Tracked by updatePosition() via m_lastOnLeft.  Used by panFollowVfo()
     // to extend the pan-follow trigger to the flag's outer edge — single-side
@@ -401,7 +396,6 @@ private:
     float          m_signalMeterFraction{0.0f};
     float          m_targetSignalMeterFraction{0.0f};
     bool           m_collapsed{false};
-    bool           m_opaqueMode{false};  // lean mode: opaque (non-translucent) panel
     bool           m_collapseToggled{false};  // guard: absorb release after toggle
     int            m_scrollAccum{0};    // trackpad pixel scroll accumulator
     int            m_angleAccum{0};     // mouse wheel angle accumulator

--- a/src/gui/WaveApplet.cpp
+++ b/src/gui/WaveApplet.cpp
@@ -27,11 +27,12 @@ constexpr int kMinZoomPercent = 100;
 constexpr int kMaxZoomPercent = 600;
 constexpr int kDefaultZoomPercent = 170;
 constexpr int kMinFps = 5;
-// Raised from 30/24 with the incremental-reduction scope (#3283 follow-up):
-// repaints no longer rescan the raw window, so 60 fps costs less than the
-// old 24 fps did. Users who previously saved an explicit FPS keep it.
 constexpr int kMaxFps = 60;
-constexpr int kDefaultFps = 60;
+// Default 25 fps — a calm, low-overhead cadence matching the 2D/3D panadapter
+// default (DisplayFftFps = 25). The slider still reaches 60 for users who want
+// a faster scope. Users who previously saved an explicit FPS keep it — the
+// default is only applied when the setting key is absent.
+constexpr int kDefaultFps = 25;
 // Discrete window steps for the WaveApplet drawer's "Window" slider.
 // First three notches give sub-second detail (240 ms, 480 ms, 1 s); the
 // rest are 1-second increments out to 10 s.  Index-based so each notch
@@ -397,18 +398,8 @@ void WaveApplet::appendScopeSamples(const QByteArray& monoFloat32Pcm,
                                     int sampleRate,
                                     bool tx)
 {
-    if (!m_active)
-        return;  // lean mode: drop the feed so the scope never repaints
     if (m_waveform)
         m_waveform->appendScopeSamples(monoFloat32Pcm, sampleRate, tx);
-}
-
-void WaveApplet::setActive(bool on)
-{
-    if (m_active == on)
-        return;
-    m_active = on;
-    setVisible(on);
 }
 
 void WaveApplet::setTransmitting(bool tx)

--- a/src/gui/WaveApplet.h
+++ b/src/gui/WaveApplet.h
@@ -25,16 +25,6 @@ public slots:
     void appendScopeSamples(const QByteArray& monoFloat32Pcm, int sampleRate, bool tx);
     void setTransmitting(bool tx);
 
-    // Lean mode: fully disable the scope — hide the applet and short-circuit
-    // the appendScopeSamples handler so the m_waveform sample buffer +
-    // 24 Hz software repaint stop entirely. The upstream
-    // AudioEngine::{tx,rx}PostChainScopeReady signal still fires per audio
-    // callback (Qt queues the event onto the GUI thread either way), so the
-    // "drop sample feed" framing means the appended-and-repainted work is
-    // skipped, not the signal emission itself. (#3283)
-    void setActive(bool on);
-    bool isActive() const { return m_active; }
-
 private:
     void buildSettingsDrawer();
     void setSettingsExpanded(bool expanded);
@@ -42,7 +32,6 @@ private:
     void updateRefreshLabel();
     void updateWindowLabel();
 
-    bool m_active{true};  // false in lean mode — applet hidden + feed dropped
     WaveformWidget* m_waveform{nullptr};
     QFrame* m_settingsDrawer{nullptr};
     GuardedComboBox* m_viewCombo{nullptr};


### PR DESCRIPTION
## Summary

Three small panadapter/display default changes:

1. **Remove Lean Mode entirely** so the WAVE applet always functions normally.
2. **Default the WAVE applet to 25 fps** to match the 2D/3D panadapter cadence.
3. **Move the GPU device selector to the top of the Display panel's SYSTEM group.**

### 1. Remove Lean Mode

Lean Mode (`#3283`) was a global low-overhead render toggle that, when on, gated
the WAVE applet off, made panadapters/VFOs opaque, dropped the FFT fill, capped
the pan to ~30 Hz, and throttled every meter to ~12 Hz. This PR removes the
feature outright:

- The **Lean Mode** button in the Display panel's SYSTEM group, its
  `leanModeToggled` signal + `setLeanChecked` plumbing.
- `DisplaySettings::leanMode/setLeanMode/migrateLegacy` persistence and the
  startup `applyLeanMode` fan-out in `MainWindow`.
- Every gate it drove: the `SpectrumWidget` lean render path (wallpaper/fill
  suppression + frame cap) **and the `panscope.frag` lean uniform**, `VfoWidget`
  opaque mode, the `WaveApplet` feed gate, and the `MeterSmoother` per-widget
  repaint throttle used by the S-meter, SmartMTR, and the Comp/DeEss/Gate bars.

Every gate defaulted to the non-lean path, so removal is **behaviour-preserving
for the default (lean-off) configuration** — it just deletes the ability to turn
the app "down." As a result the WAVE applet can no longer be silently disabled.

Housekeeping: `leanCappedUpdate()` → `coalescedUpdate()` (the present-coalescing
it also performed in non-lean mode is kept under a clearer name), and `get
panstats` no longer exposes the `leanMode` field (docs updated).

### 2. WAVE applet default FPS → 25

Only the WAVE applet's default needed changing — the 2D and 3D panadapter share a
single `DisplayFftFps` setting that already defaults to 25 (the 3DSS "3D" view is
a render mode of the same widget, not a separate frame-rate). A user's saved
value is untouched in every case — the default only applies when the settings key
is absent.

| Component | Setting key | Old default | New default | This PR |
|---|---|---|---|---|
| 2D panadapter | `DisplayFftFps` (per-pan) | 25 | 25 | unchanged (already 25) |
| 3D panadapter (3DSS) | `DisplayFftFps` (shared with 2D) | 25 | 25 | unchanged (shares the 2D cadence) |
| WAVE applet | `WaveApplet_RefreshRateHz` | **60** | **25** | `kDefaultFps` 60 → 25 |

### 3. GPU selector to top of SYSTEM

The Windows GPU device selector now sits at the top of the Display panel's SYSTEM
group (above **Reset to Defaults**), where the Lean Mode button used to be.
Multi-GPU-only, so it is hidden on single-GPU machines.

## Verification

Built clean (Ninja/RelWithDebInfo, 1398/1398) and proven live on a **FLEX-8400M**
via the agent automation bridge:

- **WAVE applet live at 25 fps** — `get wavestats` → `fps: 25`, `appendsPerSec ≈ 139`
  (audio feed reaching the scope, no gate), live cyan trace with updating RMS/PK.
- **`get panstats`** no longer contains a `leanMode` field.
- **No Lean Mode button** in the Display panel's SYSTEM group (`dumpTree` →
  `displayLeanModeBtn` absent; the panel is fully built, so this is a real removal).
- **FFT FPS reads 25** in the Display panel.

*(This Mac is single-GPU, so the GPU combo is hidden here — the SYSTEM group shows
only "Reset to Defaults." The GPU-at-top reordering is a code change; on multi-GPU
hosts the combo becomes the first SYSTEM item.)*

### WAVE applet live at 25 fps
![WAVE applet live at 25 fps](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-panadapter-defaults/.pr-assets/wave-applet-live-25fps.png)

### Display panel — SYSTEM group has no Lean button; FFT FPS = 25
![Display panel SYSTEM group](https://raw.githubusercontent.com/jensenpat/AetherSDR/assets-panadapter-defaults/.pr-assets/display-system-group-no-lean.png)

## Suggested new automation-bridge verbs

- `get displaypanel` / `display open|close` — open the Display slide-out and
  snapshot its groups, so panel-structure changes (like a removed button or a
  reordered control) are provable without hunting through `dumpTree`.
- A `gpuList` verb surfacing `GpuSelector::available()` + `hasMultiple()` so the
  GPU-selector ordering can be asserted on single-GPU CI/hosts where the combo is
  hidden.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat
