### PR TITLE
fix(spectrum): map frequency across the content canvas — band clears the tape, Pan-Follows-VFO is symmetric, tighter margin + opaque scale strips (#3482)

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -68,8 +68,17 @@ namespace AetherSDR {
 
 namespace {
 
-constexpr double kIncrementalTriggerEdgeMarginFrac = 0.05;
-constexpr double kIncrementalSettleEdgeMarginFrac = 0.06;
+// Pan-Follows-VFO edge margins, as a fraction of the visible span. Because
+// frequency now maps linearly across contentWidth() (#3482), these are a
+// constant fraction of the panadapter *width* in pixels at every zoom — trigger
+// is the gap between the VFO flag's outer edge and the pan edge at which the pan
+// starts to scroll; settle is where the flag lands after it does. settle >
+// trigger by ~1.5% supplies the hysteresis that stops a held arrow-key tune from
+// re-firing every step. Tightened from 0.05/0.06 so the signal can tune much
+// closer to the edge before the pan shifts (#3482 follow-up); the flag flips
+// inward at the content edge so it never clips the tape at this margin.
+constexpr double kIncrementalTriggerEdgeMarginFrac = 0.02;
+constexpr double kIncrementalSettleEdgeMarginFrac = 0.035;
 constexpr double kRevealComfortEdgeMarginFrac = 0.18;
 constexpr double kSpectrumClickEdgeMarginFrac = 0.05;
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3169,7 +3169,11 @@ MainWindow::TuneCenteringResult MainWindow::panFollowVfo(
     if (auto* sw = spectrumForSlice(s)) {
         if (auto* vfo = sw->vfoWidget(s->sliceId())) {
             const double bw = sw->bandwidthMhz();
-            const int specW = sw->width();
+            // Frequency maps across the content canvas (width minus the right
+            // dBm / time strip), so convert the flag's pixel width to MHz with
+            // the same denominator mhzToX uses — otherwise the flag-edge trigger
+            // drifts from the rendered flag position by the strip ratio (#3482).
+            const int specW = sw->contentWidth();
             if (bw > 0.0 && specW > 0 && !vfo->isCollapsed()) {
                 const double mhzPerPixel = bw / static_cast<double>(specW);
                 const double flagWidthMhz =

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -917,7 +917,7 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
 
     const int desiredWidth = !m_waterfall.isNull()
         ? m_waterfall.width()
-        : std::max(512, width());
+        : std::max(512, contentWidth());
     const int chromeH = freqScaleH() + DIVIDER_H;
     const int desiredHeight = !m_waterfall.isNull()
         ? m_waterfall.height()
@@ -1577,14 +1577,20 @@ bool SpectrumWidget::vfoFlagOnLeftForSlice(
     }
 
     VfoWidget::FlagDir dir = VfoWidget::Auto;
+    // contentWidth(), not width(): the renderer flips flags at the content
+    // edge (repositionVfoFlags / the paintEvent copy), so the predictor must
+    // use the same edge — a width() prediction disagrees with the rendered
+    // side for markers in the right DBM_STRIP_W band, and panFollowVfo then
+    // extends the flag-width trigger on the wrong side (#3482).
     if (vfos.size() == 1) {
         const bool defaultOnLeft = VfoWidget::defaultFlagOnLeftForMode(overlay.mode);
         dir = VfoWidget::autoDirectionForSingleFlag(
-            vfos[targetIndex].x, panelWidth, width(), defaultOnLeft, previousOnLeft);
+            vfos[targetIndex].x, panelWidth, contentWidth(), defaultOnLeft,
+            previousOnLeft);
     } else {
         const int deconflictPanelWidth = vfos.first().w ? vfos.first().w->width() : panelWidth;
         dir = deconflictedVfoFlagDirection(
-            vfos, targetIndex, deconflictPanelWidth, width());
+            vfos, targetIndex, deconflictPanelWidth, contentWidth());
     }
     return flagDirectionOnLeft(dir);
 }
@@ -6661,7 +6667,11 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         m_draggingBandwidth = true;
         m_bwDragStartX = static_cast<int>(ev->position().x());
         m_bwDragStartBw = m_bandwidthMhz;
-        const double mouseXFrac = ev->position().x() / contentWidth() - 0.5;
+        // Clamp to the canvas: the cursor can sit over the strip, and at
+        // degenerate widths contentWidth()=1 would extrapolate the anchor
+        // wildly off-canvas (#3482 review).
+        const double mouseXFrac = std::clamp(
+            ev->position().x() / contentWidth() - 0.5, -0.5, 0.5);
         m_bwDragAnchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
         setSpectrumCursor(Qt::SizeHorCursor);
         ev->accept();
@@ -7149,9 +7159,12 @@ void SpectrumWidget::driveVfoDragTune(int mx, const char* phase)
 // each time the zone is (re-)entered.  (user-reported)
 bool SpectrumWidget::updateVfoDragEdgePan(int mx)
 {
-    const int zonePx = std::max(1, static_cast<int>(width() * kVfoDragEdgeZoneFrac));
+    // contentWidth(): the right zone must end at the tape, not the widget edge
+    // — otherwise its first DBM_STRIP_W px sit under the opaque strip and the
+    // drag-to-edge feel is asymmetric vs the left (#3482).
+    const int zonePx = std::max(1, static_cast<int>(contentWidth() * kVfoDragEdgeZoneFrac));
     const bool inEdgeZone = !m_vfoDragEdgePanDisabled
-        && ((mx <= zonePx) || (mx >= width() - zonePx));
+        && ((mx <= zonePx) || (mx >= contentWidth() - zonePx));
     if (!m_vfoDragEdgePanTimer) {
         return inEdgeZone;
     }
@@ -7177,7 +7190,7 @@ bool SpectrumWidget::updateVfoDragEdgePan(int mx)
 // pan+tune to MainWindow via edgePanTuneRequested (no reveal).  (user-reported)
 void SpectrumWidget::edgePanVelocityStep()
 {
-    const int w = width();
+    const int w = contentWidth();  // zones frame the frequency canvas (#3482)
     const int zonePx = std::max(1, static_cast<int>(w * kVfoDragEdgeZoneFrac));
     int borderDist;
     double dir;
@@ -7421,11 +7434,16 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         m_spectrumFrac = std::clamp(frac, 0.10f, 0.90f);
         // Rebuild waterfall image for new size
         const int wfHeight = static_cast<int>(contentH * (1.0f - m_spectrumFrac));
-        if (wfHeight > 0 && width() > 0) {
-            QImage newWf(width(), wfHeight, QImage::Format_RGB32);
+        // contentWidth(): rows rasterize at the displayed column count so the
+        // blit into wfContentRect / the wf viewport is 1:1 — a full-width image
+        // squeezed by DBM_STRIP_W nearest-drops ~36 columns per frame and a
+        // narrow carrier on a dropped column vanishes from the waterfall while
+        // still visible in the FFT (#3482).
+        if (wfHeight > 0 && contentWidth() > 0) {
+            QImage newWf(contentWidth(), wfHeight, QImage::Format_RGB32);
             newWf.fill(Qt::black);
             if (!m_waterfall.isNull()) {
-                QImage scaled = m_waterfall.scaled(width(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+                QImage scaled = m_waterfall.scaled(contentWidth(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
                 if (!scaled.isNull())
                     newWf = std::move(scaled);
             }
@@ -7535,7 +7553,8 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         // 4x multiplier: dragging 1/4 of widget width doubles/halves bandwidth
         const double scale = std::pow(2.0, static_cast<double>(-dx) / (width() / 4.0));
         const double newBw = std::clamp(m_bwDragStartBw * scale, m_minBwMhz, m_maxBwMhz);
-        const double mouseXFrac = static_cast<double>(m_bwDragStartX) / contentWidth() - 0.5;
+        const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
+            static_cast<double>(m_bwDragStartX) / contentWidth() - 0.5, -0.5, 0.5);
         const double zoomCenter = std::max(m_bwDragAnchorMhz - mouseXFrac * newBw,
                                            newBw / 2.0);
         handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
@@ -8043,7 +8062,9 @@ void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     // Double-click in FFT or waterfall → tune to clicked frequency
     if (y < specH || y >= wfY) {
         const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
-        double rawMhz = startMhz + (ev->position().x() / contentWidth()) * m_bandwidthMhz;
+        const double clickX = std::clamp(ev->position().x(), 0.0,
+                                         static_cast<double>(contentWidth()));
+        double rawMhz = startMhz + (clickX / contentWidth()) * m_bandwidthMhz;
 
         emit frequencyClicked(snapToStep(rawMhz, m_stepHz));
         ev->accept();
@@ -8148,7 +8169,8 @@ bool SpectrumWidget::event(QEvent* ev)
             const double newBw = m_bandwidthMhz * factor;
             if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return true; }  // at limit
             // Anchor: keep the frequency under the cursor at the same pixel.
-            const double mouseXFrac = ge->position().x() / contentWidth() - 0.5;
+            const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
+                ge->position().x() / contentWidth() - 0.5, -0.5, 0.5);
             const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
             const double newCenter = std::max(anchorMhz - mouseXFrac * newBw,
                                               newBw / 2.0);
@@ -8318,7 +8340,8 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         const double factor  = (steps > 0) ? (1.0 / 1.5) : 1.5;
         const double newBw   = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
         if (qFuzzyCompare(newBw, m_bandwidthMhz)) { ev->accept(); return; }
-        const double mouseXFrac = ev->position().x() / contentWidth() - 0.5;
+        const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
+            ev->position().x() / contentWidth() - 0.5, -0.5, 0.5);
         const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
         const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
         handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
@@ -8396,11 +8419,13 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
     const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     const int wfHeight = static_cast<int>(contentH * (1.0f - m_spectrumFrac));
-    if (wfHeight > 0 && width() > 0) {
-        QImage newWf(width(), wfHeight, QImage::Format_RGB32);
+    // contentWidth(): see the divider-drag realloc — rows rasterize at the
+    // displayed column count for a 1:1 blit (#3482).
+    if (wfHeight > 0 && contentWidth() > 0) {
+        QImage newWf(contentWidth(), wfHeight, QImage::Format_RGB32);
         newWf.fill(Qt::black);
         if (!m_waterfall.isNull()) {
-            QImage scaled = m_waterfall.scaled(width(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+            QImage scaled = m_waterfall.scaled(contentWidth(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
             if (!scaled.isNull())
                 newWf = std::move(scaled);
         }
@@ -8937,7 +8962,7 @@ void SpectrumWidget::initWaterfallPipeline()
     m_wfUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 16);
     m_wfUbo->create();
 
-    m_wfGpuTexW = qMax(width(), 64);
+    m_wfGpuTexW = qMax(contentWidth(), 64);  // rows rasterize at content width (#3482)
     m_wfGpuTexH = qMax(m_waterfall.height(), 64);
     m_wfGpuTex = r->newTexture(QRhiTexture::RGBA8, QSize(m_wfGpuTexW, m_wfGpuTexH));
     m_wfGpuTex->create();
@@ -9441,7 +9466,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     // canvas only (width minus the right dBm / time strip) so they end at the
     // tape, matching the contentWidth() mapping used by every marker (#3482).
     const int specContentW = std::max(1, specRect.width() - DBM_STRIP_W);
-    const int wfContentW    = std::max(1, wfRect.width() - DBM_STRIP_W);
+    const int wfContentW   = std::max(1, wfRect.width() - DBM_STRIP_W);
     int fftTracePointCount = 0;
 
     // 3DSS replaces only the spectrum trace: the surface fills specRect and the
@@ -9763,7 +9788,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 const int tw = fm.horizontalAdvance(label) + 8;
                 const int th = fm.height() + 4;
                 int lx = m_cursorPos.x() + 12;
-                if (lx + tw > w) lx = m_cursorPos.x() - tw - 4;
+                // Flip at the content edge — the strip is opaque now (#3482).
+                if (lx + tw > w - DBM_STRIP_W) lx = m_cursorPos.x() - tw - 4;
                 int ly = m_cursorPos.y() - th - 4;
                 if (ly < 0) ly = m_cursorPos.y() + 16;
                 p.fillRect(lx, ly, tw, th, AetherSDR::theme::withAlpha("color.background.0", 200));
@@ -9794,7 +9820,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 const int tw = fm.horizontalAdvance(label) + 8;
                 const int th = fm.height() + 4;
                 int lx = cx + 12;
-                if (lx + tw > w) { lx = cx - tw - 4; }
+                if (lx + tw > w - DBM_STRIP_W) { lx = cx - tw - 4; }  // content edge (#3482)
                 int ly = m_cursorPos.y() - th - 4;
                 if (ly < 0) { ly = m_cursorPos.y() + 16; }
                 p.fillRect(lx, ly, tw, th, AetherSDR::theme::withAlpha("color.background.0", 200));
@@ -10383,7 +10409,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     // the right dBm / time strip) so they end at the tape rather than painting
     // under it, matching the contentWidth() mapping used by mhzToX (#3482).
     const QRect specContentRect = specRect.adjusted(0, 0, -DBM_STRIP_W, 0);
-    const QRect wfContentRect    = wfRect.adjusted(0, 0, -DBM_STRIP_W, 0);
+    const QRect wfContentRect   = wfRect.adjusted(0, 0, -DBM_STRIP_W, 0);
 
     const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
     const float dssFrameFloorDbm = is3D
@@ -10602,7 +10628,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         const int th = fm.height() + 4;
         // Position label to the right of cursor, flip left if near right edge
         int lx = m_cursorPos.x() + 12;
-        if (lx + tw > width()) lx = m_cursorPos.x() - tw - 4;
+        // Flip at the content edge — the strip is opaque now (#3482).
+        if (lx + tw > contentWidth()) lx = m_cursorPos.x() - tw - 4;
         int ly = m_cursorPos.y() - th - 4;
         if (ly < 0) ly = m_cursorPos.y() + 16;
         p.fillRect(lx, ly, tw, th, AetherSDR::theme::withAlpha("color.background.0", 200));
@@ -10633,7 +10660,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         const int tw = fm.horizontalAdvance(label) + 8;
         const int th = fm.height() + 4;
         int lx = cx + 12;
-        if (lx + tw > width()) { lx = cx - tw - 4; }
+        if (lx + tw > contentWidth()) { lx = cx - tw - 4; }  // content edge (#3482)
         int ly = m_cursorPos.y() - th - 4;
         if (ly < 0) { ly = m_cursorPos.y() + 16; }
         p.fillRect(lx, ly, tw, th, AetherSDR::theme::withAlpha("color.background.0", 200));
@@ -11300,7 +11327,10 @@ void SpectrumWidget::drawSpotMarkers(QPainter& p, const QRect& specRect)
     int mIdx = 0;
     for (const auto& spot : allMarkers) {
         const int x = mhzToX(spot.freqMhz);
-        if (x < 0 || x > width()) { ++mIdx; continue; }
+        // Cull at the content edge: a spot past the tape would be laid out
+        // invisibly under the opaque strip while still consuming a cluster
+        // bin — demoting a real visible spot into the "+N" overflow (#3482).
+        if (x < 0 || x > contentWidth()) { ++mIdx; continue; }
 
         // Color priority: override → DXCC → spot-provided → default cyan
         QColor col(0x00, 0xb4, 0xd8);  // default cyan
@@ -12204,7 +12234,7 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
     // every Nth line so labels don't overlap (~60px minimum between labels).
     int labelEvery = 1;
     if (m_freqGridSpacingKhz > 0 && width() > 0) {
-        double pxPerStep = (stepMhz / m_bandwidthMhz) * width();
+        double pxPerStep = (stepMhz / m_bandwidthMhz) * contentWidth();  // label spacing in mapped px (#3482)
         if (pxPerStep < 60.0)
             labelEvery = static_cast<int>(std::ceil(60.0 / pxPerStep));
     }
@@ -12357,10 +12387,24 @@ void SpectrumWidget::drawTimeScale(QPainter& p, const QRect& wfRect)
     const QRect strip = waterfallTimeScaleRect(wfRect);
     const int stripX = strip.x();
 
-    // Opaque background — matches the dBm strip (#3482); the waterfall ends at
-    // the strip edge so a solid fill keeps the right edge crisp and symmetric
-    // with the left window border.
-    p.fillRect(strip, AetherSDR::ThemeManager::instance().color("color.background.0"));
+    // Background. The frequency mapping reserves exactly DBM_STRIP_W (#3482),
+    // so only the rightmost DBM_STRIP_W of the strip sits over dead canvas —
+    // that part is opaque, matching the dBm strip, for a crisp right edge. In
+    // history mode (LIVE off) the strip widens to 72 px and its LEFT half lies
+    // on top of *mapped* waterfall content: keep that overlap translucent so
+    // scrubbed history stays readable beneath the extra timestamps rather than
+    // being blacked out by an opaque fill.
+    const QColor bg0 = AetherSDR::ThemeManager::instance().color("color.background.0");
+    if (strip.width() > DBM_STRIP_W) {
+        const QRect overlap(stripX, strip.top(),
+                            strip.width() - DBM_STRIP_W, strip.height());
+        const QRect reserved(stripX + overlap.width(), strip.top(),
+                             DBM_STRIP_W, strip.height());
+        p.fillRect(overlap, AetherSDR::theme::withAlpha("color.background.0", 220));
+        p.fillRect(reserved, bg0);
+    } else {
+        p.fillRect(strip, bg0);
+    }
 
     // Left border line
     p.setPen(AetherSDR::ThemeManager::instance().color("color.background.2"));

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -12241,8 +12241,11 @@ void SpectrumWidget::drawDbmScaleChrome(QPainter& p, const QRect& specRect)
     const int stripX = specRect.right() - DBM_STRIP_W + 1;
     const QRect strip(stripX, specRect.top(), DBM_STRIP_W, specRect.height());
 
-    // Semi-opaque background
-    p.fillRect(strip, AetherSDR::theme::withAlpha("color.background.0", 220));
+    // Opaque background: since #3482 the FFT trace/waterfall end at the strip's
+    // left edge, so nothing meaningful renders beneath it — a solid fill gives a
+    // crisp right edge instead of letting the bg/grid bleed through and read as
+    // right-side asymmetry against the hard left window border.
+    p.fillRect(strip, AetherSDR::ThemeManager::instance().color("color.background.0"));
 
     // Left border line
     p.setPen(AetherSDR::ThemeManager::instance().color("color.background.2"));
@@ -12354,8 +12357,10 @@ void SpectrumWidget::drawTimeScale(QPainter& p, const QRect& wfRect)
     const QRect strip = waterfallTimeScaleRect(wfRect);
     const int stripX = strip.x();
 
-    // Semi-opaque background
-    p.fillRect(strip, AetherSDR::theme::withAlpha("color.background.0", 220));
+    // Opaque background — matches the dBm strip (#3482); the waterfall ends at
+    // the strip edge so a solid fill keeps the right edge crisp and symmetric
+    // with the left window border.
+    p.fillRect(strip, AetherSDR::ThemeManager::instance().color("color.background.0"));
 
     // Left border line
     p.setPen(AetherSDR::ThemeManager::instance().color("color.background.2"));

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -6371,11 +6371,21 @@ void SpectrumWidget::updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
 
 // ─── Layout helpers ────────────────────────────────────────────────────────────
 
+int SpectrumWidget::contentWidth() const
+{
+    // The right DBM_STRIP_W pixels are covered by the dBm scale (spectrum) and
+    // the waterfall time-scale (both DBM_STRIP_W wide while live), so the usable
+    // frequency canvas ends there.  Mapping frequency across this width — and
+    // painting the trace/waterfall into it — keeps the band from hiding under
+    // the tape and makes the pan-follow trigger symmetric in pixels (#3482).
+    return std::max(1, width() - DBM_STRIP_W);
+}
+
 int SpectrumWidget::mhzToX(double mhz) const
 {
     if (m_bandwidthMhz <= 0.0) return -1;
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
-    const double px = (mhz - startMhz) / m_bandwidthMhz * width();
+    const double px = (mhz - startMhz) / m_bandwidthMhz * contentWidth();
     if (std::isnan(px) || std::isinf(px)) return -1;
     // Round to nearest pixel so all vertical markers (VFO, TNF, filter edges) are
     // centred on the true frequency.  Truncation caused ±1 px jitter during
@@ -6387,7 +6397,7 @@ int SpectrumWidget::mhzToX(double mhz) const
 double SpectrumWidget::xToMhz(int x) const
 {
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
-    return startMhz + (static_cast<double>(x) / width()) * m_bandwidthMhz;
+    return startMhz + (static_cast<double>(x) / contentWidth()) * m_bandwidthMhz;
 }
 
 void SpectrumWidget::updateTrackedCursorState(const QPoint& localPos, bool insideWidget)
@@ -6651,7 +6661,7 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         m_draggingBandwidth = true;
         m_bwDragStartX = static_cast<int>(ev->position().x());
         m_bwDragStartBw = m_bandwidthMhz;
-        const double mouseXFrac = ev->position().x() / width() - 0.5;
+        const double mouseXFrac = ev->position().x() / contentWidth() - 0.5;
         m_bwDragAnchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
         setSpectrumCursor(Qt::SizeHorCursor);
         ev->accept();
@@ -7525,7 +7535,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         // 4x multiplier: dragging 1/4 of widget width doubles/halves bandwidth
         const double scale = std::pow(2.0, static_cast<double>(-dx) / (width() / 4.0));
         const double newBw = std::clamp(m_bwDragStartBw * scale, m_minBwMhz, m_maxBwMhz);
-        const double mouseXFrac = static_cast<double>(m_bwDragStartX) / width() - 0.5;
+        const double mouseXFrac = static_cast<double>(m_bwDragStartX) / contentWidth() - 0.5;
         const double zoomCenter = std::max(m_bwDragAnchorMhz - mouseXFrac * newBw,
                                            newBw / 2.0);
         handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
@@ -7553,7 +7563,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         if (!ao) { m_draggingFilter = FilterEdge::None; return; }
         const int mx = static_cast<int>(ev->position().x());
         // Compute Hz delta from pixel delta — immune to freq/overlay changes (#764)
-        const double hzPerPx = (m_bandwidthMhz * 1.0e6) / width();
+        const double hzPerPx = (m_bandwidthMhz * 1.0e6) / contentWidth();
         int hz = m_filterDragStartHz + static_cast<int>(std::round((mx - m_filterDragStartX) * hzPerPx));
 
         if (m_draggingFilter == FilterEdge::Low) {
@@ -7583,7 +7593,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     if (m_draggingPan) {
         const int dx = static_cast<int>(ev->position().x()) - m_panDragStartX;
         // Dragging right moves the view right → center shifts left
-        const double deltaMhz = -(static_cast<double>(dx) / width()) * m_bandwidthMhz;
+        const double deltaMhz = -(static_cast<double>(dx) / contentWidth()) * m_bandwidthMhz;
         const double newCenter = std::max(m_panDragStartCenter + deltaMhz,
                                           m_bandwidthMhz / 2.0);
         m_panDragPendingCenterMhz = newCenter;
@@ -8033,7 +8043,7 @@ void SpectrumWidget::mouseDoubleClickEvent(QMouseEvent* ev)
     // Double-click in FFT or waterfall → tune to clicked frequency
     if (y < specH || y >= wfY) {
         const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;
-        double rawMhz = startMhz + (ev->position().x() / width()) * m_bandwidthMhz;
+        double rawMhz = startMhz + (ev->position().x() / contentWidth()) * m_bandwidthMhz;
 
         emit frequencyClicked(snapToStep(rawMhz, m_stepHz));
         ev->accept();
@@ -8138,7 +8148,7 @@ bool SpectrumWidget::event(QEvent* ev)
             const double newBw = m_bandwidthMhz * factor;
             if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return true; }  // at limit
             // Anchor: keep the frequency under the cursor at the same pixel.
-            const double mouseXFrac = ge->position().x() / width() - 0.5;
+            const double mouseXFrac = ge->position().x() / contentWidth() - 0.5;
             const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
             const double newCenter = std::max(anchorMhz - mouseXFrac * newBw,
                                               newBw / 2.0);
@@ -8308,7 +8318,7 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         const double factor  = (steps > 0) ? (1.0 / 1.5) : 1.5;
         const double newBw   = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
         if (qFuzzyCompare(newBw, m_bandwidthMhz)) { ev->accept(); return; }
-        const double mouseXFrac = ev->position().x() / width() - 0.5;
+        const double mouseXFrac = ev->position().x() / contentWidth() - 0.5;
         const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
         const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
         handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
@@ -9427,6 +9437,11 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     const int wfH = h - wfY;
     const QRect specRect(0, 0, w, specH);
     const QRect wfRect(0, wfY, w, wfH);
+    // The FFT trace, 3DSS surface, and waterfall render into the frequency
+    // canvas only (width minus the right dBm / time strip) so they end at the
+    // tape, matching the contentWidth() mapping used by every marker (#3482).
+    const int specContentW = std::max(1, specRect.width() - DBM_STRIP_W);
+    const int wfContentW    = std::max(1, wfRect.width() - DBM_STRIP_W);
     int fftTracePointCount = 0;
 
     // 3DSS replaces only the spectrum trace: the surface fills specRect and the
@@ -9934,7 +9949,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             // resolution and stretched to the specRect viewport.
             const float fbDpr = static_cast<float>(renderTarget()->pixelSize().width())
                               / static_cast<float>(qMax(1, w));
-            const int specPwDev = qMax(1, qRound(specRect.width() * fbDpr));
+            const int specPwDev = qMax(1, qRound(specContentW * fbDpr));
             const int specPhDev = qMax(1, qRound(specH * fbDpr));
             const double sc = qMin(1.0, qMin(double(kDssMaxW) / specPwDev,
                                              double(kDssMaxH) / specPhDev));
@@ -9988,7 +10003,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             const float fbDpr = static_cast<float>(renderTarget()->pixelSize().width())
                               / static_cast<float>(qMax(1, w));
             const int cols = std::clamp(
-                static_cast<int>(std::lround(specRect.width() * fbDpr)),
+                static_cast<int>(std::lround(specContentW * fbDpr)),
                 2, kMaxFftDisplayTracePoints);
             const QVector<float>& trace =
                 buildFftDisplayTrace(displaySpectrumBins(), cols);
@@ -10035,7 +10050,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 const QColor dk = m_fftFillColor.darker(300);
                 const float fa = m_fftFillAlpha;
                 const float ubo[20] = {
-                    static_cast<float>(specRect.width()) * fbDpr,   // plot: wPx
+                    static_cast<float>(specContentW) * fbDpr,       // plot: wPx
                     static_cast<float>(specH) * fbDpr,              // hPx
                     static_cast<float>(n),                          // columnCount
                     1.0f,                                           // hasData
@@ -10083,7 +10098,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         // QRhiViewport: (x, y, width, height) — y is bottom-up in GL convention
         float vpX = static_cast<float>(wfRect.x()) * dpr;
         float vpY = static_cast<float>(h - wfRect.bottom() - 1) * dpr;
-        float vpW = static_cast<float>(wfRect.width()) * dpr;
+        float vpW = static_cast<float>(wfContentW) * dpr;
         float vpH = static_cast<float>(wfRect.height()) * dpr;
 
         cb->setViewport({vpX, vpY, vpW, vpH});
@@ -10113,7 +10128,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         // GPU height-map mesh: static grid, height from the ring texture.
         const QRhiViewport vp(static_cast<float>(specRect.x()) * dpr,
                               static_cast<float>(h - specRect.bottom() - 1) * dpr,
-                              static_cast<float>(specRect.width()) * dpr,
+                              static_cast<float>(specContentW) * dpr,
                               static_cast<float>(specRect.height()) * dpr);
         const int drawnRows = m_dss.rowCount();
 
@@ -10148,7 +10163,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         cb->setShaderResources(m_dssSrb);
         cb->setViewport({static_cast<float>(specRect.x()) * dpr,
                          static_cast<float>(h - specRect.bottom() - 1) * dpr,
-                         static_cast<float>(specRect.width()) * dpr,
+                         static_cast<float>(specContentW) * dpr,
                          static_cast<float>(specRect.height()) * dpr});
         const QRhiCommandBuffer::VertexInput vbuf(m_ovVbo, 0);
         cb->setVertexInput(0, 1, &vbuf);
@@ -10161,7 +10176,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     if (!is3D && m_fftScopePipeline && m_ovVbo && fftTracePointCount > 0) {
         float specVpX = static_cast<float>(specRect.x()) * dpr;
         float specVpY = static_cast<float>(h - specRect.bottom() - 1) * dpr;
-        float specVpW = static_cast<float>(specRect.width()) * dpr;
+        float specVpW = static_cast<float>(specContentW) * dpr;
         float specVpH = static_cast<float>(specRect.height()) * dpr;
         cb->setGraphicsPipeline(m_fftScopePipeline);
         cb->setShaderResources(m_fftScopeSrb);
@@ -10220,7 +10235,10 @@ void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
     });
 
     const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
-    const int specW  = specRect.width();
+    // Flip flags against the content edge (width minus the right strip), not the
+    // raw widget edge — a right-facing flag at the true right edge slides under
+    // the dBm tape (#3482).
+    const int specW  = contentWidth();
 
     QMap<int, VfoWidget::FlagDir> dirMap;
     assignDiversityPairDirections(vfos, dirMap);
@@ -10361,6 +10379,12 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     const QRect scaleRect(0, scaleY,  width(), freqScaleH());
     const QRect wfRect   (0, wfY,     width(), wfH);
 
+    // The FFT trace and waterfall span only the frequency canvas (width minus
+    // the right dBm / time strip) so they end at the tape rather than painting
+    // under it, matching the contentWidth() mapping used by mhzToX (#3482).
+    const QRect specContentRect = specRect.adjusted(0, 0, -DBM_STRIP_W, 0);
+    const QRect wfContentRect    = wfRect.adjusted(0, 0, -DBM_STRIP_W, 0);
+
     const bool is3D = (m_spectrumRenderMode == SpectrumRenderMode::Mode3D);
     const float dssFrameFloorDbm = is3D
         ? dssFloorDbm()
@@ -10376,10 +10400,9 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         const QImage& surf =
             buildDssImage(specRect.size().boundedTo(QSize(kDssMaxW, kDssMaxH)),
                           0, dssFrameFloorDbm);
+        p.fillRect(specRect, m_bgFillColor);
         if (!surf.isNull()) {
-            p.drawImage(specRect, surf);
-        } else {
-            p.fillRect(specRect, m_bgFillColor);
+            p.drawImage(specContentRect, surf);
         }
     } else {
         // Composition z-order: bg fill → bg image → grid → FFT trace.
@@ -10398,7 +10421,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
             p.setOpacity(1.0);
         }
         drawGrid(p, specRect);
-        drawSpectrum(p, specRect);
+        drawSpectrum(p, specContentRect);
     }
 
     if (m_bandPlanFontSize > 0) drawBandPlan(p, specRect);
@@ -10408,7 +10431,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     p.drawLine(divRect.left(), divRect.center().y(), divRect.right(), divRect.center().y());
 
     drawFreqScale(p, scaleRect);
-    drawWaterfall(p, wfRect);
+    p.fillRect(wfRect, Qt::black);  // paint the strip gap before the time tape
+    drawWaterfall(p, wfContentRect);
     drawTnfMarkers(p, specRect);
     if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
     drawSwrSweep(p, specRect);
@@ -10446,7 +10470,7 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
         });
 
         const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
-        const int specW = specRect.width();
+        const int specW = contentWidth();  // flip against the tape edge (#3482)
 
         // First pass: assign directions for role-locked pairs
         QMap<int, VfoWidget::FlagDir> dirMap;  // sliceId → direction

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -253,6 +253,12 @@ public:
     bool noiseFloorAutoAdjustEnabled() const { return m_noiseFloorEnable; }
     double centerMhz()    const { return m_centerMhz; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
+    // Width of the frequency canvas, in logical pixels: the widget width minus
+    // the right-edge dBm / waterfall-time strip that is painted on top of it.
+    // The spectrum, waterfall, and every mhzToX/xToMhz mapping span this width
+    // so the trace ends at the tape (not under it) and Pan-Follows-VFO margins
+    // are symmetric in pixels, not just in frequency (#3482).
+    int contentWidth() const;
 
     // Set the FFT/waterfall split ratio programmatically.
     void setSpectrumFrac(float f);

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -115,7 +115,11 @@ public:
         }
 
         constexpr int kEdgeHysteresis = 20;
-        constexpr double kPanFollowTriggerMarginFrac = 0.05; // matches incremental pan-follow
+        // Must track kIncrementalTriggerEdgeMarginFrac (MainWindow_Wiring.cpp)
+        // so the flag flips sides at the same margin the pan starts to
+        // scroll — a looser value here makes the flag jump sides long
+        // before anything else reacts (#3482: 0.05 -> 0.02).
+        constexpr double kPanFollowTriggerMarginFrac = 0.02; // matches incremental pan-follow
         const int guardPx = std::max(
             kEdgeHysteresis,
             static_cast<int>(std::round(spectrumWidth * kPanFollowTriggerMarginFrac)));
@@ -149,7 +153,11 @@ public:
         }
 
         constexpr int kEdgeHysteresis = 20;
-        constexpr double kPanFollowTriggerMarginFrac = 0.05; // matches incremental pan-follow
+        // Must track kIncrementalTriggerEdgeMarginFrac (MainWindow_Wiring.cpp)
+        // so the flag flips sides at the same margin the pan starts to
+        // scroll — a looser value here makes the flag jump sides long
+        // before anything else reacts (#3482: 0.05 -> 0.02).
+        constexpr double kPanFollowTriggerMarginFrac = 0.02; // matches incremental pan-follow
         const int guardPx = std::max(
             kEdgeHysteresis,
             static_cast<int>(std::round(spectrumWidth * kPanFollowTriggerMarginFrac)));

--- a/tests/vfo_flag_placement_test.cpp
+++ b/tests/vfo_flag_placement_test.cpp
@@ -25,6 +25,11 @@ void expectDir(const char* name, VfoWidget::FlagDir actual, VfoWidget::FlagDir e
 
 int main()
 {
+    // Guard math at these dimensions (see VfoWidget.h): guardPx =
+    // max(20, round(1000 * kPanFollowTriggerMarginFrac=0.02)) = 20, so
+    // default-left flipEnter = 200+20 = 220 (exit 240) and default-right
+    // flipEnter = 1000-200-20 = 780 (exit 760). The margin tracks
+    // kIncrementalTriggerEdgeMarginFrac (#3482: 0.05 -> 0.02).
     constexpr int kSpectrumWidth = 1000;
     constexpr int kPanelWidth = 200;
 
@@ -43,19 +48,19 @@ int main()
               VfoWidget::ForceLeft);
     expectDir("default-left flips right before left pan-follow guard",
               VfoWidget::autoDirectionForSingleFlag(
-                  240, kPanelWidth, kSpectrumWidth, true, true),
+                  210, kPanelWidth, kSpectrumWidth, true, true),
               VfoWidget::ForceRight);
     expectDir("default-left flips right at left pan-follow guard",
               VfoWidget::autoDirectionForSingleFlag(
-                  250, kPanelWidth, kSpectrumWidth, true, true),
+                  220, kPanelWidth, kSpectrumWidth, true, true),
               VfoWidget::ForceRight);
     expectDir("default-left holds right through hysteresis",
               VfoWidget::autoDirectionForSingleFlag(
-                  260, kPanelWidth, kSpectrumWidth, true, false),
+                  230, kPanelWidth, kSpectrumWidth, true, false),
               VfoWidget::ForceRight);
     expectDir("default-left returns left after hysteresis",
               VfoWidget::autoDirectionForSingleFlag(
-                  280, kPanelWidth, kSpectrumWidth, true, false),
+                  250, kPanelWidth, kSpectrumWidth, true, false),
               VfoWidget::ForceLeft);
 
     expectDir("default-right stays right in middle",
@@ -64,61 +69,61 @@ int main()
               VfoWidget::ForceRight);
     expectDir("default-right flips left before right pan-follow guard",
               VfoWidget::autoDirectionForSingleFlag(
-                  760, kPanelWidth, kSpectrumWidth, false, false),
+                  790, kPanelWidth, kSpectrumWidth, false, false),
               VfoWidget::ForceLeft);
     expectDir("default-right flips left at right pan-follow guard",
               VfoWidget::autoDirectionForSingleFlag(
-                  750, kPanelWidth, kSpectrumWidth, false, false),
+                  780, kPanelWidth, kSpectrumWidth, false, false),
               VfoWidget::ForceLeft);
     expectDir("default-right holds left through hysteresis",
               VfoWidget::autoDirectionForSingleFlag(
-                  740, kPanelWidth, kSpectrumWidth, false, true),
+                  770, kPanelWidth, kSpectrumWidth, false, true),
               VfoWidget::ForceLeft);
     expectDir("default-right returns right after hysteresis",
               VfoWidget::autoDirectionForSingleFlag(
-                  720, kPanelWidth, kSpectrumWidth, false, true),
+                  750, kPanelWidth, kSpectrumWidth, false, true),
               VfoWidget::ForceRight);
 
     expectDir("two-vfo leftmost flips right at left edge",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  0, 2, 240, 0, 760, kPanelWidth, kSpectrumWidth, true),
+                  0, 2, 210, 0, 760, kPanelWidth, kSpectrumWidth, true),
               VfoWidget::ForceRight);
     expectDir("two-vfo leftmost flips right at pan-follow guard",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  0, 2, 250, 0, 760, kPanelWidth, kSpectrumWidth, true),
+                  0, 2, 220, 0, 760, kPanelWidth, kSpectrumWidth, true),
               VfoWidget::ForceRight);
     expectDir("two-vfo leftmost holds right through hysteresis",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  0, 2, 260, 0, 760, kPanelWidth, kSpectrumWidth, false),
+                  0, 2, 230, 0, 760, kPanelWidth, kSpectrumWidth, false),
               VfoWidget::ForceRight);
     expectDir("two-vfo leftmost returns left after hysteresis",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  0, 2, 280, 0, 760, kPanelWidth, kSpectrumWidth, false),
+                  0, 2, 250, 0, 760, kPanelWidth, kSpectrumWidth, false),
               VfoWidget::ForceLeft);
     expectDir("two-vfo rightmost flips left at right edge",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  1, 2, 760, 240, 0, kPanelWidth, kSpectrumWidth, false),
+                  1, 2, 790, 240, 0, kPanelWidth, kSpectrumWidth, false),
               VfoWidget::ForceLeft);
     expectDir("two-vfo rightmost flips left at pan-follow guard",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  1, 2, 750, 240, 0, kPanelWidth, kSpectrumWidth, false),
+                  1, 2, 780, 240, 0, kPanelWidth, kSpectrumWidth, false),
               VfoWidget::ForceLeft);
     expectDir("two-vfo rightmost holds left through hysteresis",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  1, 2, 740, 240, 0, kPanelWidth, kSpectrumWidth, true),
+                  1, 2, 770, 240, 0, kPanelWidth, kSpectrumWidth, true),
               VfoWidget::ForceLeft);
     expectDir("two-vfo rightmost returns right after hysteresis",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  1, 2, 720, 240, 0, kPanelWidth, kSpectrumWidth, true),
+                  1, 2, 750, 240, 0, kPanelWidth, kSpectrumWidth, true),
               VfoWidget::ForceRight);
 
     expectDir("three-vfo first flips right at left edge",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  0, 3, 240, 0, 500, kPanelWidth, kSpectrumWidth, true),
+                  0, 3, 210, 0, 500, kPanelWidth, kSpectrumWidth, true),
               VfoWidget::ForceRight);
     expectDir("three-vfo last flips left at right edge",
               VfoWidget::autoDirectionForDeconflictedFlag(
-                  2, 3, 760, 500, 0, kPanelWidth, kSpectrumWidth, false),
+                  2, 3, 790, 500, 0, kPanelWidth, kSpectrumWidth, false),
               VfoWidget::ForceLeft);
     expectDir("three-vfo interior uses larger left gap",
               VfoWidget::autoDirectionForDeconflictedFlag(


### PR DESCRIPTION
## Summary

The panadapter's frequency↔pixel mapping (`SpectrumWidget::mhzToX` / `xToMhz`) spanned the **full widget `width()`**, but the right `DBM_STRIP_W` (36 px) of that canvas is occluded by the dBm scale (spectrum) and the waterfall time-scale **tape** painted on top of it. That one mismatch produced the reported symptoms, and fixing it cleanly surfaced two natural follow-ups (both about the right edge) that are included here.

## Root cause

`mhzToX`/`xToMhz` used `width()` as the denominator while the painted band, the tape overlay, and the pan-follow trigger all disagreed about where the usable canvas ends:

- **Band painted under the tape** — the FFT trace and waterfall were drawn across the full width, so the rightmost ~36 px of the band rendered *beneath* the tape and was unusable.
- **Pan-Follows-VFO felt asymmetric** — the trigger margins are symmetric in *frequency* (`halfBw ± margin·BW`), but because the right strip is hidden, that frequency margin mapped to a **much smaller pixel margin on the right than the left**. Tuning right, the pan shifted far closer to the apparent edge than tuning left, leaving a large untuneable dead band on the left (reporter: *"stops scrolling too early"* on the left).

## Fix

### 1. Content-width mapping (the core fix)

Introduce `SpectrumWidget::contentWidth() = width() − DBM_STRIP_W` — the frequency canvas that ends at the tape — and map everything across it:

- `mhzToX` / `xToMhz`, plus the click-to-tune, pan-drag, filter-edge-drag, and pinch / Ctrl-wheel **zoom-anchor** paths that reimplement the scale inline (so the frequency under the cursor stays put on zoom).
- Shrink the **FFT-trace, 3DSS, and waterfall** render viewports (GPU `renderGpuFrame`) and rects (software `paintEvent`) by the strip so the band ends *at* the tape, not under it.
- Flip VFO flags against the content edge, and use `contentWidth()` for `panFollowVfo`'s flag-width-in-MHz so the flag-edge trigger stays aligned with the rendered flag.

No `MainWindow` policy change was needed for symmetry: once the painted band matches the mapped frequency range, the existing margins are symmetric in pixels automatically.

### 2. Tighter pan-follow edge margin

`kIncrementalTriggerEdgeMarginFrac` / `kIncrementalSettleEdgeMarginFrac` **0.05 / 0.06 → 0.02 / 0.035**, so the signal can tune much closer to the edge before the pan scrolls (the reporter's *"spectrum jump point should be closer to each edge"*). These margins are already **symmetric by construction** — a single distance-from-center scalar applied mirror-imaged left/right — and, since the mapping now puts `center` at the pixel midpoint of `contentWidth()`, they land at **identical pixel offsets on both sides**:

| | fraction | px from its canvas edge (content width 2140 px) |
|---|---|---|
| Trigger (both sides) | 2.0 % | **43 px** |
| Settle (both sides) | 3.5 % | **75 px** |

`settle > trigger` by 1.5 % supplies the hysteresis that stops a held key-repeat tune from re-firing every step.

### 3. Opaque right-edge scale strips

The dBm strip (`drawDbmScaleChrome`) and waterfall time strip (`drawTimeScale`) filled their background at **alpha 220 (~86 %)** — translucent — so the background fill and horizontal grid lines bled through the right 36 px and read as right-side asymmetry against the hard left window border. Before this PR the translucency let the far-right FFT/waterfall show faintly through the scale; now that the trace and waterfall **end at the strip edge**, nothing meaningful is beneath it, so a solid `color.background.0` fill is strictly better — crisp right edge and more legible tick labels. This is cosmetic only: it doesn't touch the trigger/settle math, it makes the already-exact symmetry *visible* instead of blurred.

## A note on "which edge"

The right-hand reference is `x = contentWidth` (the tape's left edge = the edge of the *usable spectrum*), not the widget's physical right edge 36 px further. A signal can't render in the tape gutter (that's exactly what this PR stops), so measured from the usable-canvas edges (`0` and `contentWidth`) the trigger/settle margins are exact mirror images. The right-side scale gutter is chrome the left doesn't have — inherent to a right-side-only scale, and now that it's opaque the boundary reads as crisp as the left.

## Proof

Verified live with the **agent automation bridge** on a Flex 6600 (pan `0x40000000`, 14.164 MHz / 200 kHz, **ANT1, RX-only** — TX never keyed). Grabs are device pixels (dpr = 2, widget 2212 px → tape starts at 2212 − 72 = **2140**).

**Pan-Follows-VFO symmetry**

![Pan-Follows-VFO margin symmetry](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-3482-assets/.pr-assets/pan-follow-symmetry.png)

_Slice tuned to symmetric offsets (±0.35·BW, center held at 14.164): the VFO marker (green) lands **322 px** from the left edge and **320 px** from the tape edge (red, x=2140) — a 2 px / 0.09 % error. The pre-fix full-width map on the same geometry gave **260 px** vs **331 px** (a 71 px asymmetry — the reported "closer to the right edge than the left")._

**Band clears the opaque tape**

![Band and waterfall end at the opaque tape](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-3482-assets/.pr-assets/panadapter-opaque-tape.png)

_Live grab on the fixed build: the FFT trace and waterfall end crisply at the now-opaque dBm / time strip instead of painting under it._

**Canvas is symmetric** — waterfall data spans `x = 0 … 2140`, tape at `2140 … 2212`; the band no longer renders under the tape.

**Mapping is pixel-symmetric** — a slice tuned to symmetric offsets from center (`±0.35·BW`, center held at 14.164):

| Side | Slice freq | Marker col | Gap to visible edge |
|---|---|---|---|
| Left | 14.094 MHz | 322 px | **322 px** from left edge (x=0) |
| Right | 14.234 MHz | 1820 px | **320 px** from tape edge (x=2140) |

Symmetry error **2 px (0.09 %)**. For contrast, the old full-width map (÷ 2212) on the same geometry gives **260 px** (right) vs **331 px** (left) — a **71 px asymmetry**, i.e. the reported "closer to the right edge than the left." Manual keyboard + mouse testing on the deployed build confirms the corrected feel.

## Test plan

- [x] Builds clean (RelWithDebInfo/Ninja, macOS arm64).
- [x] Bridge: waterfall/trace end at the tape edge; symmetric marker positions; center stable; TX never keyed.
- [x] Manual keyboard + mouse tuning on the deployed test build — symmetric feel, signal reaches close to each edge, crisp opaque strip.
- [ ] Reporter to confirm on Windows / Flex 6600 (rendering is cross-platform QRhi; not Windows-specific).

Fixes #3482

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat
