### PR TITLE
feat(help): revamp Help menu — promote Reset Settings & File an Issue, add Website, reorder

### DIFF
--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1120,10 +1120,13 @@ void MainWindow::buildMenuBar()
     helpMenu->addSeparator();
 
     // ── Community & feedback ──────────────────────────────────────────────
-    // Outward-facing links: the website, feature ideas, bug reports, and how
-    // to contribute back.
+    // Outward-facing links: the website, donations, feature ideas, bug
+    // reports, and how to contribute back.
     helpMenu->addAction("AetherSDR Website", this, []() {
         QDesktopServices::openUrl(QUrl("https://www.aethersdr.com"));
+    });
+    helpMenu->addAction("Donate to AetherSDR", this, []() {
+        QDesktopServices::openUrl(QUrl("https://opencollective.com/aethersdr"));
     });
     helpMenu->addAction(QString::fromUtf8("Submit your Idea... \xF0\x9F\x92\xA1"),
                         this, [this]() {

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -45,6 +45,7 @@
 #include <QActionGroup>
 #include <QCoreApplication>
 #include <QCheckBox>
+#include <QDesktopServices>
 #include <QFrame>
 #include <QJsonDocument>
 #include <QLabel>
@@ -56,6 +57,7 @@
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTimer>
+#include <QUrl>
 #include <QVBoxLayout>
 #include <QWidgetAction>
 
@@ -1054,19 +1056,9 @@ void MainWindow::buildMenuBar()
     }
 
     auto* helpMenu = menuBar()->addMenu("&Help");
-    helpMenu->addAction("What's New...", this, [this]() {
-        if (m_whatsNewDialog) {
-            m_whatsNewDialog->show();
-            m_whatsNewDialog->raise();
-            m_whatsNewDialog->activateWindow();
-            return;
-        }
-        m_whatsNewDialog = WhatsNewDialog::showAll(this);
-        m_whatsNewDialog->setFramelessMode(
-            AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-        m_persistentDialogs.append(QPointer<PersistentDialog>(m_whatsNewDialog));
-    });
-    helpMenu->addSeparator();
+
+    // ── Learn & news ──────────────────────────────────────────────────────
+    // Orientation first: how to get going, the full manual, and what changed.
     helpMenu->addAction("Getting Started...", this, [this]() {
         auto* dlg = new HelpDialog("Getting Started", ":/help/getting-started.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
@@ -1083,6 +1075,22 @@ void MainWindow::buildMenuBar()
         dlg->raise();
         dlg->activateWindow();
     });
+    helpMenu->addAction("What's New...", this, [this]() {
+        if (m_whatsNewDialog) {
+            m_whatsNewDialog->show();
+            m_whatsNewDialog->raise();
+            m_whatsNewDialog->activateWindow();
+            return;
+        }
+        m_whatsNewDialog = WhatsNewDialog::showAll(this);
+        m_whatsNewDialog->setFramelessMode(
+            AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+        m_persistentDialogs.append(QPointer<PersistentDialog>(m_whatsNewDialog));
+    });
+    helpMenu->addSeparator();
+
+    // ── Feature guides ────────────────────────────────────────────────────
+    // Deeper topic walkthroughs for specific parts of the app.
     helpMenu->addAction("Understanding Noise Cancellation...", this, [this]() {
         auto* dlg = new HelpDialog("Understanding Noise Cancellation", ":/help/understanding-noise-cancellation.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
@@ -1109,6 +1117,23 @@ void MainWindow::buildMenuBar()
         dlg->activateWindow();
     });
     dataModesAction->setMenuRole(QAction::NoRole); // prevent macOS auto-reparenting (#883)
+    helpMenu->addSeparator();
+
+    // ── Community & feedback ──────────────────────────────────────────────
+    // Outward-facing links: the website, feature ideas, bug reports, and how
+    // to contribute back.
+    helpMenu->addAction("AetherSDR Website", this, []() {
+        QDesktopServices::openUrl(QUrl("https://www.aethersdr.com"));
+    });
+    helpMenu->addAction(QString::fromUtf8("Submit your Idea... \xF0\x9F\x92\xA1"),
+                        this, [this]() {
+        if (m_titleBar) m_titleBar->showFeatureRequestDialog();
+    });
+    // "File an Issue" was previously buried inside the Support dialog; surface
+    // it directly so reporting a bug is one click from the Help menu.
+    helpMenu->addAction("File an Issue...", this, [this]() {
+        SupportDialog::fileIssue(this, &m_radioModel);
+    });
     helpMenu->addAction("Contributing to AetherSDR...", this, [this]() {
         auto* dlg = new HelpDialog("Contributing to AetherSDR", ":/help/contributing-to-aethersdr.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
@@ -1118,11 +1143,11 @@ void MainWindow::buildMenuBar()
         dlg->activateWindow();
     });
     helpMenu->addSeparator();
-    helpMenu->addAction(QString::fromUtf8("Submit your idea... \xF0\x9F\x92\xA1"),
-                        this, [this]() {
-        if (m_titleBar) m_titleBar->showFeatureRequestDialog();
-    });
-    helpMenu->addAction("Support...", this, [this]() {
+
+    // ── Diagnostics & maintenance ─────────────────────────────────────────
+    // Tools for capturing logs, chasing slice problems, resetting local
+    // settings, and staying up to date.
+    helpMenu->addAction("Support && Diagnostics...", this, [this]() {
         auto* dlg = new SupportDialog(this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         dlg->setRadioModel(&m_radioModel);
@@ -1142,6 +1167,13 @@ void MainWindow::buildMenuBar()
                                        });
         dlg.exec();
     });
+    // "Reset Settings" was previously buried inside the Support dialog too.
+    // NoRole is required: macOS would otherwise treat the word "Settings" as a
+    // Preferences action and reparent it into the application menu.
+    auto* resetSettingsAction = helpMenu->addAction("Reset Settings...", this, [this]() {
+        SupportDialog::resetSettings(this);
+    });
+    resetSettingsAction->setMenuRole(QAction::NoRole);
     helpMenu->addAction("Check for Updates...", this, [this]() {
         m_updateChecker->checkNow();
     });

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -120,178 +120,28 @@ void SupportDialog::buildUI()
     auto* refreshBtn = new QPushButton("Refresh");
     auto* clearBtn = new QPushButton("Clear Log");
     auto* openBtn = new QPushButton("Open Log Folder");
-    auto* resetBtn = new QPushButton("Reset Settings");
     refreshBtn->setFixedHeight(26);
     clearBtn->setFixedHeight(26);
     openBtn->setFixedHeight(26);
-    resetBtn->setFixedHeight(26);
-    resetBtn->setToolTip("Delete AetherSDR's local settings and NR2 wisdom cache. Radio settings stay on the radio.");
     connect(refreshBtn, &QPushButton::clicked, this, &SupportDialog::refreshLog);
     connect(clearBtn, &QPushButton::clicked, this, &SupportDialog::clearLog);
     connect(openBtn, &QPushButton::clicked, this, &SupportDialog::openLogFolder);
-    connect(resetBtn, &QPushButton::clicked, this, &SupportDialog::resetSettings);
-    auto* sendBtn = new QPushButton("File an Issue");
-    sendBtn->setFixedHeight(26);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(sendBtn, "QPushButton { background: #00607a; color: {{color.text.primary}}; font-weight: bold; }");
-    connect(sendBtn, &QPushButton::clicked, this, [this]() {
-        // Create support bundle
-        SupportBundle::RadioInfo radio;
-        if (m_radioModel && m_radioModel->isConnected()) {
-            radio.model = m_radioModel->model();
-            radio.serial = m_radioModel->serial();
-            radio.firmware = m_radioModel->version();
-            radio.callsign = m_radioModel->callsign();
-            radio.ip = m_radioModel->radioAddress().toString();
-            radio.connected = true;
-        }
-        QString bundlePath = SupportBundle::createBundle(radio);
-        if (bundlePath.isEmpty()) {
-            QMessageBox::warning(this, "Error",
-                "Failed to create support bundle.");
-            return;
-        }
-
-        // Collect system info
-        QString version = QCoreApplication::applicationVersion();
-        QString qt = qVersion();
-        QString os;
-#if defined(Q_OS_MAC)
-        os = "macOS";
-#elif defined(Q_OS_WIN)
-        os = "Windows";
-#else
-        os = "Linux";
-#endif
-        QString radioInfo = (m_radioModel && m_radioModel->isConnected())
-            ? QString("%1 fw %2").arg(m_radioModel->model(), m_radioModel->version())
-            : "not connected";
-
-        // Diagnostic prompt for AI
-        static const QString kPromptTemplate =
-            "I'm experiencing an issue with AetherSDR, a Linux/macOS/Windows SDR client\n"
-            "for FlexRadio transceivers (https://github.com/aethersdr/AetherSDR).\n\n"
-            "My system:\n"
-            "- AetherSDR version: %1\n"
-            "- Qt version: %2\n"
-            "- OS: %3\n"
-            "- Radio: %4\n\n"
-            "Before writing the bug report, please read the AetherSDR project context at\n"
-            "https://raw.githubusercontent.com/aethersdr/AetherSDR/main/CLAUDE.md\n"
-            "for architecture overview, data flow, protocol details, and known issues.\n\n"
-            "Based on my description below, write a complete GitHub bug report.\n"
-            "Do NOT ask me follow-up questions — just write the best report you can\n"
-            "from what I've provided. Output it in one response, ready to paste.\n"
-            "Use GitHub-flavored Markdown formatting (headers, code blocks, bullet points).\n\n"
-            "Format it as:\n"
-            "### Title: (short, descriptive)\n"
-            "### What happened?\n"
-            "(expand on my description with clear, specific language)\n"
-            "### What did you expect?\n"
-            "(infer the expected behavior from context)\n"
-            "### Steps to reproduce\n"
-            "(numbered steps based on my description)\n"
-            "### Radio model & firmware\n"
-            "(pre-filled above)\n"
-            "### OS & version\n"
-            "(pre-filled above)\n"
-            "### Developer Notes\n"
-            "(After reviewing the codebase, suggest which source files and functions\n"
-            "are most likely involved, what logging categories to enable in\n"
-            "Help → Support to capture diagnostic data, and any potential root causes\n"
-            "based on the code architecture. Reference specific file paths and line\n"
-            "numbers where possible.)\n\n"
-            "Here is my issue:\n\n"
-            "[Describe what went wrong — for example: \"The waterfall freezes after\n"
-            "about 10 minutes\" or \"Audio cuts out when I switch bands\"]";
-
-        QString prompt = kPromptTemplate.arg(version, qt, os, radioInfo);
-        QApplication::clipboard()->setText(prompt);
-
-        QMessageBox dlg(this);
-        dlg.setWindowTitle("AI-Assisted Bug Report");
-        dlg.setIcon(QMessageBox::Information);
-        dlg.setText(
-            "<h3>Get Help Describing Your Issue</h3>"
-            "<p>Use any AI assistant to help you write a clear bug report. "
-            "A diagnostic prompt with your system info has been copied to your clipboard.</p>"
-            "<ol>"
-            "<li><b>Choose your AI</b> — click one of the buttons below</li>"
-            "<li><b>Paste the prompt</b> — your system info is pre-filled</li>"
-            "<li><b>Describe what happened</b> — the AI will help you structure it</li>"
-            "<li><b>Copy the AI's output</b> and click <b>Submit Bug Report</b></li>"
-            "<li><b>Drag your support bundle</b> into the GitHub issue form</li>"
-            "</ol>"
-            "<p style='color:#8aa8c0; font-size:11px;'>"
-            "Your support bundle (logs + settings) is ready to attach.</p>");
-
-        auto* claudeBtn   = dlg.addButton("Claude", QMessageBox::ActionRole);
-        auto* chatgptBtn  = dlg.addButton("ChatGPT", QMessageBox::ActionRole);
-        auto* geminiBtn   = dlg.addButton("Gemini", QMessageBox::ActionRole);
-        auto* grokBtn     = dlg.addButton("Grok", QMessageBox::ActionRole);
-        auto* perplexBtn  = dlg.addButton("Perplexity", QMessageBox::ActionRole);
-        auto* issueBtn    = dlg.addButton("Submit Bug Report", QMessageBox::ActionRole);
-        dlg.addButton(QMessageBox::Close);
-
-        dlg.exec();
-
-        auto* clicked = dlg.clickedButton();
-        bool openedLLM = false;
-        if (clicked == claudeBtn) {
-            QDesktopServices::openUrl(QUrl("https://claude.ai/new"));
-            openedLLM = true;
-        } else if (clicked == chatgptBtn) {
-            QDesktopServices::openUrl(QUrl("https://chat.openai.com/"));
-            openedLLM = true;
-        } else if (clicked == geminiBtn) {
-            QDesktopServices::openUrl(QUrl("https://gemini.google.com/"));
-            openedLLM = true;
-        } else if (clicked == grokBtn) {
-            QDesktopServices::openUrl(QUrl("https://grok.x.ai/"));
-            openedLLM = true;
-        } else if (clicked == perplexBtn) {
-            QDesktopServices::openUrl(QUrl("https://www.perplexity.ai/"));
-            openedLLM = true;
-        } else if (clicked == issueBtn) {
-            QUrl url("https://github.com/aethersdr/AetherSDR/issues/new");
-            QUrlQuery query;
-            query.addQueryItem("labels", "bug");
-            url.setQuery(query);
-            QDesktopServices::openUrl(url);
-
-            // Open support bundle folder for drag-and-drop
-            QFileInfo fi(bundlePath);
-            QDesktopServices::openUrl(QUrl::fromLocalFile(fi.absolutePath()));
-
-            QMessageBox::information(this, "Submit Bug Report",
-                QString("Your browser and support folder have been opened.\n\n"
-                        "1. Paste the AI's bug report into the GitHub form\n"
-                        "2. Drag and drop the support bundle: %1")
-                    .arg(fi.fileName()));
-        }
-
-        if (openedLLM) {
-            QMessageBox::information(this, "Prompt Copied",
-                "The diagnostic prompt has been copied to your clipboard.\n\n"
-                "Paste it into the AI, describe your issue, then come back\n"
-                "and click \"Submit Bug Report\" to file it on GitHub.");
-        }
-    });
     actionRow->addWidget(refreshBtn);
     actionRow->addWidget(clearBtn);
     actionRow->addWidget(openBtn);
-    actionRow->addWidget(resetBtn);
     actionRow->addStretch();
-    actionRow->addWidget(sendBtn);
     layout->addLayout(actionRow);
 
     // ── Instructions ──────────────────────────────────────────────────────
+    // "File an Issue" and "Reset Settings" now live directly on the Help menu;
+    // point the user there rather than duplicating the buttons here.
     auto* instructions = new QLabel(
         "<p style='color:#c8d8e8; font-size: 13px;'>"
         "To report an issue:<br>"
         "1. Enable logging for the relevant module(s) above<br>"
         "2. <b>Restart AetherSDR</b> (logging changes take effect on next launch)<br>"
         "3. Reproduce the problem<br>"
-        "4. Click <b>File an Issue</b> and drag your log file into the GitHub form</p>");
+        "4. Choose <b>Help \xE2\x86\x92 File an Issue\xE2\x80\xA6</b> and drag your log file into the GitHub form</p>");
     instructions->setTextFormat(Qt::RichText);
     layout->addWidget(instructions);
 
@@ -350,7 +200,7 @@ void SupportDialog::openLogFolder()
     QDesktopServices::openUrl(QUrl::fromLocalFile(fi.absolutePath()));
 }
 
-void SupportDialog::resetSettings()
+void SupportDialog::resetSettings(QWidget* parent)
 {
     QStringList resetPaths = {
         AppSettings::instance().filePath(),
@@ -369,7 +219,7 @@ void SupportDialog::resetSettings()
         "Continue?")
         .arg(QString("- %1").arg(resetPaths.join("\n- ")));
 
-    if (QMessageBox::question(this, "Reset Settings", prompt,
+    if (QMessageBox::question(parent, "Reset Settings", prompt,
             QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) != QMessageBox::Yes) {
         return;
     }
@@ -399,7 +249,7 @@ void SupportDialog::resetSettings()
     }
 
     QMessageBox::warning(
-        this, "Reset Settings",
+        parent, "Reset Settings",
         QString(
             "Some files could not be removed.\n\n"
             "Removed: %1\n"
@@ -408,6 +258,151 @@ void SupportDialog::resetSettings()
             .arg(removed.isEmpty() ? "none" : removed.join("\n"),
                  failed.join("\n")));
     QApplication::quit();
+}
+
+void SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)
+{
+    // Create support bundle
+    SupportBundle::RadioInfo radio;
+    if (radioModel && radioModel->isConnected()) {
+        radio.model = radioModel->model();
+        radio.serial = radioModel->serial();
+        radio.firmware = radioModel->version();
+        radio.callsign = radioModel->callsign();
+        radio.ip = radioModel->radioAddress().toString();
+        radio.connected = true;
+    }
+    QString bundlePath = SupportBundle::createBundle(radio);
+    if (bundlePath.isEmpty()) {
+        QMessageBox::warning(parent, "Error",
+            "Failed to create support bundle.");
+        return;
+    }
+
+    // Collect system info
+    QString version = QCoreApplication::applicationVersion();
+    QString qt = qVersion();
+    QString os;
+#if defined(Q_OS_MAC)
+    os = "macOS";
+#elif defined(Q_OS_WIN)
+    os = "Windows";
+#else
+    os = "Linux";
+#endif
+    QString radioInfo = (radioModel && radioModel->isConnected())
+        ? QString("%1 fw %2").arg(radioModel->model(), radioModel->version())
+        : "not connected";
+
+    // Diagnostic prompt for AI
+    static const QString kPromptTemplate =
+        "I'm experiencing an issue with AetherSDR, a Linux/macOS/Windows SDR client\n"
+        "for FlexRadio transceivers (https://github.com/aethersdr/AetherSDR).\n\n"
+        "My system:\n"
+        "- AetherSDR version: %1\n"
+        "- Qt version: %2\n"
+        "- OS: %3\n"
+        "- Radio: %4\n\n"
+        "Before writing the bug report, please read the AetherSDR project context at\n"
+        "https://raw.githubusercontent.com/aethersdr/AetherSDR/main/CLAUDE.md\n"
+        "for architecture overview, data flow, protocol details, and known issues.\n\n"
+        "Based on my description below, write a complete GitHub bug report.\n"
+        "Do NOT ask me follow-up questions — just write the best report you can\n"
+        "from what I've provided. Output it in one response, ready to paste.\n"
+        "Use GitHub-flavored Markdown formatting (headers, code blocks, bullet points).\n\n"
+        "Format it as:\n"
+        "### Title: (short, descriptive)\n"
+        "### What happened?\n"
+        "(expand on my description with clear, specific language)\n"
+        "### What did you expect?\n"
+        "(infer the expected behavior from context)\n"
+        "### Steps to reproduce\n"
+        "(numbered steps based on my description)\n"
+        "### Radio model & firmware\n"
+        "(pre-filled above)\n"
+        "### OS & version\n"
+        "(pre-filled above)\n"
+        "### Developer Notes\n"
+        "(After reviewing the codebase, suggest which source files and functions\n"
+        "are most likely involved, what logging categories to enable in\n"
+        "Help → Support to capture diagnostic data, and any potential root causes\n"
+        "based on the code architecture. Reference specific file paths and line\n"
+        "numbers where possible.)\n\n"
+        "Here is my issue:\n\n"
+        "[Describe what went wrong — for example: \"The waterfall freezes after\n"
+        "about 10 minutes\" or \"Audio cuts out when I switch bands\"]";
+
+    QString prompt = kPromptTemplate.arg(version, qt, os, radioInfo);
+    QApplication::clipboard()->setText(prompt);
+
+    QMessageBox dlg(parent);
+    dlg.setWindowTitle("AI-Assisted Bug Report");
+    dlg.setIcon(QMessageBox::Information);
+    dlg.setText(
+        "<h3>Get Help Describing Your Issue</h3>"
+        "<p>Use any AI assistant to help you write a clear bug report. "
+        "A diagnostic prompt with your system info has been copied to your clipboard.</p>"
+        "<ol>"
+        "<li><b>Choose your AI</b> — click one of the buttons below</li>"
+        "<li><b>Paste the prompt</b> — your system info is pre-filled</li>"
+        "<li><b>Describe what happened</b> — the AI will help you structure it</li>"
+        "<li><b>Copy the AI's output</b> and click <b>Submit Bug Report</b></li>"
+        "<li><b>Drag your support bundle</b> into the GitHub issue form</li>"
+        "</ol>"
+        "<p style='color:#8aa8c0; font-size:11px;'>"
+        "Your support bundle (logs + settings) is ready to attach.</p>");
+
+    auto* claudeBtn   = dlg.addButton("Claude", QMessageBox::ActionRole);
+    auto* chatgptBtn  = dlg.addButton("ChatGPT", QMessageBox::ActionRole);
+    auto* geminiBtn   = dlg.addButton("Gemini", QMessageBox::ActionRole);
+    auto* grokBtn     = dlg.addButton("Grok", QMessageBox::ActionRole);
+    auto* perplexBtn  = dlg.addButton("Perplexity", QMessageBox::ActionRole);
+    auto* issueBtn    = dlg.addButton("Submit Bug Report", QMessageBox::ActionRole);
+    dlg.addButton(QMessageBox::Close);
+
+    dlg.exec();
+
+    auto* clicked = dlg.clickedButton();
+    bool openedLLM = false;
+    if (clicked == claudeBtn) {
+        QDesktopServices::openUrl(QUrl("https://claude.ai/new"));
+        openedLLM = true;
+    } else if (clicked == chatgptBtn) {
+        QDesktopServices::openUrl(QUrl("https://chat.openai.com/"));
+        openedLLM = true;
+    } else if (clicked == geminiBtn) {
+        QDesktopServices::openUrl(QUrl("https://gemini.google.com/"));
+        openedLLM = true;
+    } else if (clicked == grokBtn) {
+        QDesktopServices::openUrl(QUrl("https://grok.x.ai/"));
+        openedLLM = true;
+    } else if (clicked == perplexBtn) {
+        QDesktopServices::openUrl(QUrl("https://www.perplexity.ai/"));
+        openedLLM = true;
+    } else if (clicked == issueBtn) {
+        QUrl url("https://github.com/aethersdr/AetherSDR/issues/new");
+        QUrlQuery query;
+        query.addQueryItem("labels", "bug");
+        url.setQuery(query);
+        QDesktopServices::openUrl(url);
+
+        // Open support bundle folder for drag-and-drop
+        QFileInfo fi(bundlePath);
+        QDesktopServices::openUrl(QUrl::fromLocalFile(fi.absolutePath()));
+
+        QMessageBox::information(parent, "Submit Bug Report",
+            QString("Your browser and support folder have been opened.\n\n"
+                    "1. Paste the AI's bug report into the GitHub form\n"
+                    "2. Drag and drop the support bundle: %1")
+                .arg(fi.fileName()));
+    }
+
+    if (openedLLM) {
+        QMessageBox::information(parent, "Prompt Copied",
+            "The diagnostic prompt has been copied to your clipboard.\n\n"
+            "Paste it into the AI, describe your issue, then come back\n"
+            "and click \"Submit Bug Report\" to file it on GitHub.");
+    }
 }
 
 void SupportDialog::enableAll()

--- a/src/gui/SupportDialog.h
+++ b/src/gui/SupportDialog.h
@@ -19,11 +19,15 @@ public:
 
     void setRadioModel(RadioModel* model) { m_radioModel = model; }
 
+    // Standalone entry points so the Help menu can offer these actions
+    // directly, without routing the user through the Support dialog.
+    static void fileIssue(QWidget* parent, RadioModel* radioModel);
+    static void resetSettings(QWidget* parent);
+
 private slots:
     void refreshLog();
     void clearLog();
     void openLogFolder();
-    void resetSettings();
     void enableAll();
     void disableAll();
     void sendToSupport();


### PR DESCRIPTION
## Summary

Revamps the **Help** menu so the most-used actions are easy to find, matching how other desktop apps organize their Help menus. Also promotes two actions that were previously buried inside the *Support & Diagnostics* dialog up to the top level, and adds website + donation links.

### 1. Reset Settings & File an Issue promoted out of the Support dialog
Both were `QPushButton`s inside `SupportDialog`. They're now first-class Help-menu items. Their logic moved into two shared statics so the menu and (any future caller) use one implementation — no duplication:

- `SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)`
- `SupportDialog::resetSettings(QWidget* parent)`

The Support dialog drops both buttons and its instructions now read *"Choose **Help → File an Issue…** and drag your log file into the GitHub form."*

### 2. Added web links: Website + Donate
- **AetherSDR Website** → https://www.aethersdr.com
- **Donate to AetherSDR** → https://opencollective.com/aethersdr

Named "Donate…" rather than "Support…"/"Contribute…" — both of those words are already used in this menu (`Support & Diagnostics…`, `Contributing to AetherSDR…`) and would be ambiguous.

### 3. Reordered into five intuitive, divider-separated blocks

```
Help
├── Getting Started…                     ┐
├── AetherSDR Help…                       │  Learn & news
├── What's New…                          ┘
├──────────────────────────────
├── Understanding Noise Cancellation…    ┐
├── Configuring AetherSDR Controls…       │  Feature guides
├── Configuring Data Modes…              ┘
├──────────────────────────────
├── AetherSDR Website                    ┐
├── Donate to AetherSDR                   │
├── Submit your Idea… 💡                  │  Community & feedback
├── File an Issue…            ← moved out │
├── Contributing to AetherSDR…           ┘
├──────────────────────────────
├── Support & Diagnostics…               ┐
├── Slice Troubleshooting…                │  Diagnostics & maintenance
├── Reset Settings…           ← moved out │
├── Check for Updates…                   ┘
├──────────────────────────────
└── About AetherSDR
```

Other tweaks:
- `What's New…` moves below the docs — it's news, not a starting point.
- `Support…` renamed to `Support & Diagnostics…` to match the dialog title.
- `Reset Settings…` is given `QAction::NoRole`: on macOS the word "Settings" would otherwise be auto-classified as a Preferences action and reparented into the application menu, disappearing from Help.

## Verification (agent automation bridge)

`menu list` against a live build confirms the new Help order, and that **Donate to AetherSDR**, **Reset Settings**, **File an Issue**, and **AetherSDR Website** are all present as top-level items:

```
Getting Started… · AetherSDR Help… · What's New…
Understanding Noise Cancellation… · Configuring AetherSDR Controls… · Configuring Data Modes…
AetherSDR Website · Donate to AetherSDR · Submit your Idea… 💡 · File an Issue… · Contributing to AetherSDR…
Support & Diagnostics… · Slice Troubleshooting… · Reset Settings… · Check for Updates…
About AetherSDR
```

A bridge `grab` of the *Support & Diagnostics* dialog confirms the two buttons are gone (only Refresh / Clear Log / Open Log Folder remain) and the instructions now point to **Help → File an Issue…**.

## Files
- `src/gui/MainWindow_Menus.cpp` — rebuilt Help menu, added Website + Donate links + top-level Reset Settings/File an Issue, NoRole guard.
- `src/gui/SupportDialog.{h,cpp}` — extracted `fileIssue`/`resetSettings` statics, removed the two buttons, updated instructions.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat
