### PR TITLE
fix(profiles): reflect the radio's active global profile in the PROF applet and Profiles menu

### DIFF
--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -723,20 +723,28 @@ void MainWindow::buildMenuBar()
     });
     m_profilesMenu->addSeparator();
 
-    // Global profile list (populated on connect)
+    // Global profile list (populated on connect).  Rebuilt on every
+    // globalProfilesChanged() — the radio emits that for both the list and the
+    // active-selection ("current") status, so the checkmark tracks the radio's
+    // authoritative selection live on all platforms.
     connect(&m_radioModel, &RadioModel::globalProfilesChanged, this, [this] {
-        // Remove old profile actions (after the separator)
+        // Delete the old profile actions (after the separator).  Deleting —
+        // rather than removeAction() — frees them; removeAction() leaves each
+        // QAction parented to the menu, so a session's worth of rebuilds would
+        // otherwise accumulate detached actions.
         const auto actions = m_profilesMenu->actions();
         for (int i = 3; i < actions.size(); ++i)  // skip Manager, Import/Export, separator
-            m_profilesMenu->removeAction(actions[i]);
+            delete actions[i];
 
-        // Add current global profiles
+        // Add the current global profiles.  The radio reports an empty active
+        // ("current") until a global profile is explicitly loaded, in which
+        // case no item is checked — that is the honest state, not a bug.
         const auto profiles = m_radioModel.globalProfiles();
         const auto active = m_radioModel.activeGlobalProfile();
         for (const auto& name : profiles) {
             auto* act = m_profilesMenu->addAction(name);
             act->setCheckable(true);
-            act->setChecked(name == active);
+            act->setChecked(!active.isEmpty() && name == active);
             connect(act, &QAction::triggered, this, [this, name] {
                 m_radioModel.loadGlobalProfile(name);
             });

--- a/src/gui/ProfileSwitcherApplet.cpp
+++ b/src/gui/ProfileSwitcherApplet.cpp
@@ -25,11 +25,16 @@ void rebuildCombo(QComboBox* combo, const QStringList& profiles, const QString& 
     combo->clear();
     combo->addItems(profiles);
     const int idx = combo->findText(active);
-    // If the radio hasn't reported an active profile yet (or it isn't in the
-    // list), fall back to index 0 so the control isn't blank.  This is purely
-    // cosmetic — the set is signal-blocked, so it never issues a load, and the
-    // next *Changed/state signal corrects the highlight once active arrives.
-    combo->setCurrentIndex(idx >= 0 ? idx : (profiles.isEmpty() ? -1 : 0));
+    // Highlight the radio's authoritative active profile.  When the radio
+    // reports an EMPTY active (findText returns -1) leave the combo with no
+    // selection (index -1) so the placeholder shows — do NOT fall back to
+    // index 0.  Global profiles legitimately report an empty "current" until
+    // one is explicitly loaded (unlike TX/Mic, which always name a current), so
+    // falling back to index 0 would falsely display the first profile as the
+    // active one.  The real active is restored the moment the radio
+    // names it via the next *Changed/state signal.  The set is signal-blocked,
+    // so it never issues a load either way.
+    combo->setCurrentIndex(idx);
     combo->setEnabled(!profiles.isEmpty());
 }
 
@@ -70,6 +75,9 @@ ProfileSwitcherApplet::ProfileSwitcherApplet(QWidget* parent)
         combo->setAccessibleName(accessible);
         combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
         combo->setMinimumContentsLength(8);
+        // Shown when the radio reports no active profile (currentIndex == -1);
+        // e.g. a global profile that has never been loaded this session.
+        combo->setPlaceholderText(tr("— none —"));
         combo->setEnabled(false);  // until a model + profiles arrive
         grid->addWidget(lbl, row, 0);
         grid->addWidget(combo, row, 1);


### PR DESCRIPTION
## Problem

On startup the **PROF applet** and the **Profiles menu** never reflected the radio's selected global profile:

- The applet's **Global** row displayed the *first* profile in the list as though it were active.
- The Profiles menu showed **no checkmark** for the current profile.

## Root cause

The radio reports `profile global current=` **empty** until a global profile is explicitly loaded — unlike TX/Mic, which always name a current (verified across 164 samples in the operator's logs; every global `current` was empty and no `profile global load` was ever issued).

`ProfileSwitcherApplet::rebuildCombo` handled an empty active by **falling back to index 0**, so it *falsely* displayed the first profile (`ft8` on an 8400M) as selected. The Profiles-menu checkmark logic was correct for a real selection but had none to show because the radio never reported one as active.

## Fix

**`ProfileSwitcherApplet`**
- `rebuildCombo` now selects `findText(active)` and leaves the combo **unselected (index −1)** when the radio reports an empty active — never index 0. A new `— none —` placeholder makes the no-profile-loaded state read as intentional. The real active is still restored the instant the radio names it, and the set stays signal-blocked so it never issues a spurious load.

**Profiles menu (`MainWindow_Menus.cpp`)**
- Stale actions are now `delete`d on rebuild instead of `removeAction()` (which left them parented to the menu, accumulating across a session).
- The checkmark is guarded on a non-empty active.
- The menu already rebuilds on every `globalProfilesChanged()` — emitted for both the list *and* the active-selection status — so the checkmark tracks the radio's authoritative selection **live on macOS, Windows and Linux**.

## Verification

Built RelWithDebInfo and driven live against a **FLEX-8400M** over the agent automation bridge:

- The Global row now shows `— none —` (radio reports empty `current`) instead of a false `ft8`.
- `TX = Default` and `Mic = Pat Laptop` are unchanged — the non-empty render path (which the fix leaves intact) is proven by the Mic row correctly showing a **non-index-0** value.

Before this fix the Global row read `ft8`; after, it honestly reads `— none —`:

![PROF applet after fix](https://raw.githubusercontent.com/jensenpat/AetherSDR/pr-assets-profile-menu/prof-applet-after.png)

> Note: a live global-profile *load* was intentionally **not** exercised — slot 0 was owned by a foreign client and a global-profile load is radio-wide. The post-load checkmark/selection path is unchanged from the pre-existing (working) TX/Mic-style flow.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat
