### PR TITLE
refactor(aetherd): 2.4 — move the TGXL tuner status decode behind FlexBackend (#4092)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2629,6 +2629,18 @@ target_link_libraries(aetherd_amp_decode_test PRIVATE aethercore Qt6::Core Qt6::
 set_target_properties(aetherd_amp_decode_test PROPERTIES AUTOMOC ON)
 add_test(NAME aetherd_amp_decode_test COMMAND aetherd_amp_decode_test)
 
+add_executable(tuner_model_test tests/tuner_model_test.cpp)
+target_include_directories(tuner_model_test PRIVATE src)
+target_link_libraries(tuner_model_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(tuner_model_test PROPERTIES AUTOMOC ON)
+add_test(NAME tuner_model_test COMMAND tuner_model_test)
+
+add_executable(aetherd_tuner_decode_test tests/aetherd_tuner_decode_test.cpp)
+target_include_directories(aetherd_tuner_decode_test PRIVATE src)
+target_link_libraries(aetherd_tuner_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_tuner_decode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_tuner_decode_test COMMAND aetherd_tuner_decode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -16,6 +16,7 @@
 #include "core/backends/RadioDelta.h"
 #include "core/backends/SliceDelta.h"
 #include "core/backends/TransmitDelta.h"
+#include "core/backends/TunerDelta.h"
 
 namespace AetherSDR {
 
@@ -131,6 +132,12 @@ signals:
     // "amplifier" wire and AmpModel applies the state machine. Command/encode
     // stays AmpModel::commandReady until the seam gains an encode path (step 3).
     void amplifierChanged(const AmpDelta& delta);
+
+    // Normalized antenna-tuner status delta (aetherd 2.4 — TunerModel decode
+    // split, #4092). Typed + present-only; the backend translates the SmartSDR
+    // "atu"/"amplifier"(TunerGeniusXL) wire, TunerModel applies the change-gated
+    // state. Command/encode stays TunerModel::commandReady until step 3.
+    void tunerChanged(const TunerDelta& delta);
 
     // Normalized radio-global status delta (aetherd RFC 2.3 — RadioModel
     // residual). Typed + compiler-checked; the backend populates only the fields

--- a/src/core/backends/TunerDelta.h
+++ b/src/core/backends/TunerDelta.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <optional>
+
+#include <QMetaType>
+#include <QString>
+
+namespace AetherSDR {
+
+// Normalized antenna-tuner status delta (aetherd 2.4 — TunerModel decode split,
+// #4092). FlexBackend::decodeTunerStatus translates the SmartSDR "atu"/"amplifier"
+// (model=TunerGeniusXL) wire into this typed, present-only shape; TunerModel::
+// applyChanges applies exactly the reported fields (change-gated, with the
+// tuning/antenna edge signals). Same contract as the sub-model deltas.
+//
+// Command/encode (operate/bypass/autotune/relay) is NOT here — that stays
+// TunerModel::commandReady until the seam gains an encode path (invokeExtension;
+// step 3). The direct-connection fwd-power/SWR meters are set outside this decode.
+struct TunerDelta {
+    std::optional<QString> serialNum;    // "serial_num"
+    std::optional<QString> model;
+    std::optional<QString> ip;
+    std::optional<bool>    operate;      // "1"
+    std::optional<bool>    bypass;       // "1"
+    std::optional<bool>    tuning;       // "1"
+    std::optional<int>     relayC1;
+    std::optional<int>     relayC2;
+    std::optional<int>     relayL;
+    std::optional<int>     antennaA;     // "antA", 0-indexed
+    std::optional<bool>    oneByThree;   // "one_by_three" — TGXL 3x1 model
+};
+
+}  // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::TunerDelta)

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -659,6 +659,37 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
     emit amplifierChanged(d);
 }
 
+void FlexBackend::decodeTunerStatus(const QMap<QString, QString>& kvs)
+{
+    // Present-only, strict parity with the prior TunerModel::applyStatus: bools
+    // are "1"-equality, ints are unguarded toInt() (matching val.toInt()), text
+    // is verbatim. The change-gating / edge signals live in TunerModel::applyChanges.
+    TunerDelta d;
+    if (kvs.contains(QStringLiteral("serial_num")))
+        d.serialNum = kvs.value(QStringLiteral("serial_num"));
+    if (kvs.contains(QStringLiteral("model")))
+        d.model = kvs.value(QStringLiteral("model"));
+    if (kvs.contains(QStringLiteral("ip")))
+        d.ip = kvs.value(QStringLiteral("ip"));
+    if (kvs.contains(QStringLiteral("operate")))
+        d.operate = (kvs.value(QStringLiteral("operate")) == QLatin1String("1"));
+    if (kvs.contains(QStringLiteral("bypass")))
+        d.bypass = (kvs.value(QStringLiteral("bypass")) == QLatin1String("1"));
+    if (kvs.contains(QStringLiteral("tuning")))
+        d.tuning = (kvs.value(QStringLiteral("tuning")) == QLatin1String("1"));
+    if (kvs.contains(QStringLiteral("relayC1")))
+        d.relayC1 = kvs.value(QStringLiteral("relayC1")).toInt();
+    if (kvs.contains(QStringLiteral("relayC2")))
+        d.relayC2 = kvs.value(QStringLiteral("relayC2")).toInt();
+    if (kvs.contains(QStringLiteral("relayL")))
+        d.relayL = kvs.value(QStringLiteral("relayL")).toInt();
+    if (kvs.contains(QStringLiteral("antA")))
+        d.antennaA = kvs.value(QStringLiteral("antA")).toInt();
+    if (kvs.contains(QStringLiteral("one_by_three")))
+        d.oneByThree = (kvs.value(QStringLiteral("one_by_three")) == QLatin1String("1"));
+    emit tunerChanged(d);
+}
+
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)
 {
     TransmitDelta d;

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -130,6 +130,11 @@ public:
     // presence latch / operate change-gating live in AmpModel::applyChanges.
     void decodeAmplifierStatus(const QString& handle, const QString& model,
                                const QMap<QString, QString>& kvs, bool removed);
+    // Translate a SmartSDR TGXL tuner status (the "atu <handle> …" and
+    // "amplifier <handle> model=TunerGeniusXL …" kv-sets) into a typed
+    // TunerDelta and emit tunerChanged (aetherd 2.4 — TunerModel decode split,
+    // #4092). Present-only, strict-parity with the prior TunerModel::applyStatus.
+    void decodeTunerStatus(const QMap<QString, QString>& kvs);
     void decodeApdSamplerStatus(const QMap<QString, QString>& kvs);
     // Decode the Flex GPS-status line ("gps …", '#'-separated key=value tokens)
     // into a present-only GpsDelta and emit gpsChanged (aetherd RFC 2.3 —

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -407,6 +407,7 @@ RadioModel::RadioModel(QObject* parent)
     qRegisterMetaType<MemoryDelta>();
     qRegisterMetaType<ProfileDelta>();
     qRegisterMetaType<AmpDelta>();
+    qRegisterMetaType<TunerDelta>();
 
     // aetherd RFC step 2.2b: the radio-facing seam owns the wire objects. The
     // FlexBackend creates the RadioConnection and PanadapterStream on their
@@ -553,6 +554,10 @@ RadioModel::RadioModel(QObject* parent)
     // aetherd 2.4 (#4094): power-amp status decoded in the backend drives AmpModel.
     connect(m_backend.get(), &IRadioBackend::amplifierChanged, this,
             [this](const AmpDelta& delta) { m_amplifier.applyChanges(delta); });
+
+    // aetherd 2.4 (#4092): TGXL tuner status decoded in the backend drives TunerModel.
+    connect(m_backend.get(), &IRadioBackend::tunerChanged, this,
+            [this](const TunerDelta& delta) { m_tunerModel.applyChanges(delta); });
 
     // aetherd RFC 2.3 (RadioModel residual): radio-global status decoded in the
     // backend drives RadioModel's own state via applyRadioChanges.
@@ -5222,9 +5227,9 @@ void RadioModel::onStatusReceived(const QString& object,
         const auto m = atuRe.match(object);
         if (m.hasMatch() && m_tunerModel.handle().isEmpty())
             m_tunerModel.setHandle(m.captured(1));
-        if (m_flexBackend) m_flexBackend->decodeAtuStatus(kvs);
-        if (m_tunerModel.isPresent())
-            m_tunerModel.applyStatus(kvs);
+        if (m_flexBackend) m_flexBackend->decodeAtuStatus(kvs);   // radio's own ATU → TransmitModel
+        if (m_tunerModel.isPresent() && m_flexBackend)
+            m_flexBackend->decodeTunerStatus(kvs);                // external TGXL → TunerModel (#4092)
         return;
     }
 
@@ -5302,7 +5307,7 @@ void RadioModel::onStatusReceived(const QString& object,
                     m_tunerModel.setHandle(handle);
                     m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
                 }
-                m_tunerModel.applyStatus(kvs);
+                if (m_flexBackend) m_flexBackend->decodeTunerStatus(kvs);   // #4092
             }
             // Power amplifier (PGXL / any non-TGXL amp) → AmpModel. `else` of the
             // tuner branch: a TGXL status is already routed above and would only

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -31,13 +31,20 @@ void TunerModel::applyChanges(const TunerDelta& d)
     // Apply only the present fields, change-gated — faithful to the prior
     // applyStatus (which iterated the wire kv-set). The SmartSDR key names and
     // "1"/toInt parsing now live in FlexBackend::decodeTunerStatus; informational
-    // fields (nickname/version/ant/dhcp/netmask/gateway/ptt) are dropped there.
+    // fields (nickname/version/ant/dhcp/netmask/gateway/ptta/pttb) are dropped there.
+    // Edge-signal emit order matches the old QMap key-sorted iteration:
+    // antennaAChanged (key "antA") precedes tuningChanged (key "tuning").
     bool changed = false;
 
     if (d.serialNum && m_serialNum != *d.serialNum) { m_serialNum = *d.serialNum; changed = true; }
     if (d.model && m_model != *d.model)             { m_model = *d.model;         changed = true; }
     if (d.operate && m_operate != *d.operate)       { m_operate = *d.operate;     changed = true; }
     if (d.bypass && m_bypass != *d.bypass)          { m_bypass = *d.bypass;       changed = true; }
+    if (d.antennaA && m_antennaA != *d.antennaA) {
+        m_antennaA = *d.antennaA;
+        changed = true;
+        emit antennaAChanged(m_antennaA);        // "antA" sorts before "tuning"
+    }
     if (d.tuning && m_tuning != *d.tuning) {
         m_tuning = *d.tuning;
         changed = true;
@@ -46,11 +53,6 @@ void TunerModel::applyChanges(const TunerDelta& d)
     if (d.relayC1 && m_relayC1 != *d.relayC1) { m_relayC1 = *d.relayC1; changed = true; }
     if (d.relayC2 && m_relayC2 != *d.relayC2) { m_relayC2 = *d.relayC2; changed = true; }
     if (d.relayL && m_relayL != *d.relayL)    { m_relayL = *d.relayL;   changed = true; }
-    if (d.antennaA && m_antennaA != *d.antennaA) {
-        m_antennaA = *d.antennaA;
-        changed = true;
-        emit antennaAChanged(m_antennaA);
-    }
     if (d.oneByThree && m_oneByThree != *d.oneByThree) { m_oneByThree = *d.oneByThree; changed = true; }
     if (d.ip && m_tgxlIp != *d.ip)                     { m_tgxlIp = *d.ip;              changed = true; }
 

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -26,53 +26,33 @@ void TunerModel::setHandle(const QString& handle)
     emit stateChanged();
 }
 
-void TunerModel::applyStatus(const QMap<QString, QString>& kvs)
+void TunerModel::applyChanges(const TunerDelta& d)
 {
+    // Apply only the present fields, change-gated — faithful to the prior
+    // applyStatus (which iterated the wire kv-set). The SmartSDR key names and
+    // "1"/toInt parsing now live in FlexBackend::decodeTunerStatus; informational
+    // fields (nickname/version/ant/dhcp/netmask/gateway/ptt) are dropped there.
     bool changed = false;
 
-    for (auto it = kvs.constBegin(); it != kvs.constEnd(); ++it) {
-        const QString& key = it.key();
-        const QString& val = it.value();
-
-        if (key == "serial_num") {
-            if (m_serialNum != val) { m_serialNum = val; changed = true; }
-        } else if (key == "model") {
-            if (m_model != val) { m_model = val; changed = true; }
-        } else if (key == "operate") {
-            bool on = (val == "1");
-            if (m_operate != on) { m_operate = on; changed = true; }
-        } else if (key == "bypass") {
-            bool on = (val == "1");
-            if (m_bypass != on) { m_bypass = on; changed = true; }
-        } else if (key == "tuning") {
-            bool on = (val == "1");
-            if (m_tuning != on) {
-                m_tuning = on;
-                changed = true;
-                emit tuningChanged(m_tuning);
-            }
-        } else if (key == "relayC1") {
-            int v = val.toInt();
-            if (m_relayC1 != v) { m_relayC1 = v; changed = true; }
-        } else if (key == "relayC2") {
-            int v = val.toInt();
-            if (m_relayC2 != v) { m_relayC2 = v; changed = true; }
-        } else if (key == "relayL") {
-            int v = val.toInt();
-            if (m_relayL != v) { m_relayL = v; changed = true; }
-        }
-        else if (key == "antA") {
-            int v = val.toInt();
-            if (m_antennaA != v) { m_antennaA = v; changed = true; emit antennaAChanged(v); }
-        } else if (key == "one_by_three") {
-            bool v = val == "1";
-            if (m_oneByThree != v) { m_oneByThree = v; changed = true; }
-        } else if (key == "ip") {
-            if (m_tgxlIp != val) { m_tgxlIp = val; changed = true; }
-        }
-        // nickname, version, ant, dhcp, netmask, gateway, ptta, pttb
-        // are informational — ignore for now.
+    if (d.serialNum && m_serialNum != *d.serialNum) { m_serialNum = *d.serialNum; changed = true; }
+    if (d.model && m_model != *d.model)             { m_model = *d.model;         changed = true; }
+    if (d.operate && m_operate != *d.operate)       { m_operate = *d.operate;     changed = true; }
+    if (d.bypass && m_bypass != *d.bypass)          { m_bypass = *d.bypass;       changed = true; }
+    if (d.tuning && m_tuning != *d.tuning) {
+        m_tuning = *d.tuning;
+        changed = true;
+        emit tuningChanged(m_tuning);
     }
+    if (d.relayC1 && m_relayC1 != *d.relayC1) { m_relayC1 = *d.relayC1; changed = true; }
+    if (d.relayC2 && m_relayC2 != *d.relayC2) { m_relayC2 = *d.relayC2; changed = true; }
+    if (d.relayL && m_relayL != *d.relayL)    { m_relayL = *d.relayL;   changed = true; }
+    if (d.antennaA && m_antennaA != *d.antennaA) {
+        m_antennaA = *d.antennaA;
+        changed = true;
+        emit antennaAChanged(m_antennaA);
+    }
+    if (d.oneByThree && m_oneByThree != *d.oneByThree) { m_oneByThree = *d.oneByThree; changed = true; }
+    if (d.ip && m_tgxlIp != *d.ip)                     { m_tgxlIp = *d.ip;              changed = true; }
 
     if (changed)
         emit stateChanged();

--- a/src/models/TunerModel.h
+++ b/src/models/TunerModel.h
@@ -4,6 +4,8 @@
 #include <QMap>
 #include <QString>
 
+#include "core/backends/TunerDelta.h"
+
 namespace AetherSDR {
 
 class TgxlConnection;
@@ -42,8 +44,10 @@ public:
     bool    isPresent() const { return !m_handle.isEmpty() || m_directPresence; }
     bool    hasDirectConnection() const;
 
-    // Apply key=value pairs from a TCP status message.
-    void applyStatus(const QMap<QString, QString>& kvs);
+    // Apply a normalized tuner delta decoded by the backend
+    // (IRadioBackend::tunerChanged). Change-gated; emits tuningChanged /
+    // antennaAChanged on their edges and stateChanged once if anything moved.
+    void applyChanges(const TunerDelta& delta);
 
     // Set the tuner handle (extracted from the status object name).
     void setHandle(const QString& handle);

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -1,0 +1,75 @@
+// aetherd 2.4 (#4092) — FlexBackend::decodeTunerStatus. Pins the SmartSDR TGXL
+// "atu"/"amplifier" wire → typed TunerDelta translation that moved out of
+// TunerModel::applyStatus: present-only, "1"→bool, toInt relays/antenna, verbatim
+// text, and dropping the informational keys.
+
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/TunerDelta.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
+{
+    QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
+    b.decodeTunerStatus(kvs);
+    if (spy.count() != 1) return {};
+    return spy.takeFirst().at(0).value<TunerDelta>();
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<TunerDelta>();
+    FlexBackend b;
+
+    // ---- full field set: "1"→bool, toInt relays/antenna, verbatim text ----
+    {
+        const TunerDelta d = decode(b, {
+            {"serial_num", "TG9"}, {"model", "TunerGeniusXL"},
+            {"operate", "1"}, {"bypass", "0"}, {"tuning", "1"},
+            {"relayC1", "20"}, {"relayC2", "5"}, {"relayL", "12"},
+            {"antA", "2"}, {"one_by_three", "1"}, {"ip", "10.0.0.5"}});
+        CHECK(d.serialNum.has_value() && *d.serialNum == "TG9");
+        CHECK(d.model.has_value() && *d.model == "TunerGeniusXL");
+        CHECK(d.operate.has_value() && *d.operate == true);
+        CHECK(d.bypass.has_value() && *d.bypass == false);      // "0" → false
+        CHECK(d.tuning.has_value() && *d.tuning == true);
+        CHECK(*d.relayC1 == 20 && *d.relayC2 == 5 && *d.relayL == 12);
+        CHECK(d.antennaA.has_value() && *d.antennaA == 2);
+        CHECK(d.oneByThree.has_value() && *d.oneByThree == true);
+        CHECK(d.ip.has_value() && *d.ip == "10.0.0.5");
+    }
+
+    // ---- present-only: absent keys stay disengaged ----
+    {
+        const TunerDelta d = decode(b, {{"operate", "1"}});
+        CHECK(d.operate.has_value() && *d.operate == true);
+        CHECK(!d.bypass.has_value() && !d.relayC1.has_value()
+              && !d.model.has_value() && !d.antennaA.has_value());
+    }
+
+    // ---- informational keys (nickname/version/gateway/…) are dropped ----
+    {
+        const TunerDelta d = decode(b, {
+            {"nickname", "shack"}, {"version", "1.2"}, {"gateway", "192.168.0.1"},
+            {"bypass", "1"}});
+        CHECK(d.bypass.has_value() && *d.bypass == true);
+        // nothing carries the informational keys; only the recognized field decoded.
+        CHECK(!d.operate.has_value() && !d.model.has_value() && !d.ip.has_value());
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherd_tuner_decode_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherd_tuner_decode_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/tuner_model_test.cpp
+++ b/tests/tuner_model_test.cpp
@@ -1,0 +1,73 @@
+// TunerModel unit test — the TGXL state machine (#4092). Exercises
+// TunerModel::applyChanges(TunerDelta): present-only application, change-gating,
+// the tuning/antenna edge signals, and the single stateChanged. The wire→delta
+// translation is covered separately by aetherd_tuner_decode_test.
+
+#include "models/TunerModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<TunerDelta>();
+
+    // ---- full apply + change-gated stateChanged ----
+    {
+        TunerModel t;
+        QSignalSpy st(&t, &TunerModel::stateChanged);
+        TunerDelta d;
+        d.model = "TunerGeniusXL"; d.serialNum = "TG123";
+        d.operate = true; d.bypass = false;
+        d.relayC1 = 20; d.relayC2 = 5; d.relayL = 12;
+        d.antennaA = 1; d.oneByThree = true; d.ip = "10.0.0.5";
+        t.applyChanges(d);
+        CHECK(t.modelName() == "TunerGeniusXL" && t.serialNum() == "TG123");
+        CHECK(t.isOperate() && !t.isBypass());
+        CHECK(t.relayC1() == 20 && t.relayC2() == 5 && t.relayL() == 12);
+        CHECK(t.antennaA() == 1 && t.hasAntennaSwitch() && t.tgxlIp() == "10.0.0.5");
+        CHECK(st.count() == 1);
+        t.applyChanges(d);                // identical → change-gated, no re-emit
+        CHECK(st.count() == 1);
+    }
+
+    // ---- absent fields are left untouched ----
+    {
+        TunerModel t;
+        TunerDelta a; a.operate = true; a.relayC1 = 5;
+        t.applyChanges(a);
+        QSignalSpy st(&t, &TunerModel::stateChanged);
+        TunerDelta b; b.operate = true;   // operate unchanged; relayC1 not present
+        t.applyChanges(b);
+        CHECK(t.relayC1() == 5 && st.count() == 0);
+    }
+
+    // ---- tuning + antenna edges emit their signals before stateChanged ----
+    {
+        TunerModel t;
+        QSignalSpy tun(&t, &TunerModel::tuningChanged);
+        QSignalSpy ant(&t, &TunerModel::antennaAChanged);
+        TunerDelta d; d.tuning = true; d.antennaA = 2;
+        t.applyChanges(d);
+        CHECK(t.isTuning() && tun.count() == 1 && tun.takeFirst().at(0).toBool() == true);
+        CHECK(t.antennaA() == 2 && ant.count() == 1 && ant.takeFirst().at(0).toInt() == 2);
+        TunerDelta off; off.tuning = false;
+        t.applyChanges(off);
+        CHECK(!t.isTuning() && tun.count() == 1 && tun.takeFirst().at(0).toBool() == false);
+    }
+
+    if (g_failures == 0) {
+        std::printf("tuner_model_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("tuner_model_test: %d failure(s)\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## The decode half of #4092

TunerModel was retagged `mixed(flex)` in #4093; this moves its SmartSDR **decode** behind the seam — the tuner sibling of the amp split (#4101), same typed-delta pattern as the five 2.3 models. Applies the three lessons from the #4101 review up front (strict `!isEmpty()`/per-key parity, no `carry()` ok-guard divergence, `else`-guarded shared handler).

### Changes
- **`core/backends/TunerDelta.h`** — typed, present-only tuner delta (serial/model/ip, operate/bypass/tuning, relayC1/C2/L, antennaA, oneByThree).
- **`IRadioBackend::tunerChanged(TunerDelta)`** signal.
- **`FlexBackend::decodeTunerStatus(kvs)`** — strict per-key parity with the prior `TunerModel::applyStatus`: bools are `"1"`-equality, ints unguarded `toInt()`, text verbatim, informational keys (nickname/version/ant/dhcp/…) dropped.
- **`TunerModel`** — `applyStatus` → `applyChanges(TunerDelta)`, keeping the state machine (change-gating, tuning/antenna edge signals, one `stateChanged`). **The direct port-9010 `TgxlConnection` status handler stays** — it's the peripheral's own transport, not radio-seam wire; only the *radio-proxy* decode moved.
- **`RadioModel`** — the `atu` external-TGXL branch (still gated on `isPresent`, still separate from `decodeAtuStatus → TransmitModel` for the radio's *own* ATU) and the `amplifier`/TunerGeniusXL branch both route through `decodeTunerStatus`; wires `tunerChanged → applyChanges`; registers the metatype.

### Deferred (still #4092)
The **encode** (operate/bypass/autotune → neutral intent). `FlexBackend::invokeExtension` is a stub, so there's no seam command path yet — same as every 2.3 model. Step 3.

### Verification
- Behavior-neutral decode move — **`aetherd_tuner_decode_test`** pins wire→`TunerDelta`; **`tuner_model_test`** pins the `applyChanges` state machine (change-gating + tuning/antenna edges).
- Full build clean; **77/77 ctest**; `--strict` clean; `TunerModel` radio-proxy-decode-free (grep-verified; the direct-connection parser correctly remains).

Completes the tuner/amp decode-split pair (#4101 was the amp). No Tier-1 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)