### PR TITLE
fix(dax): on Windows show a note-only DAX applet (no inert controls) (#4112)

### DIFF
--- a/resources/help/understanding-data-modes.md
+++ b/resources/help/understanding-data-modes.md
@@ -250,9 +250,17 @@ Audio format: **24 kHz, stereo, 32-bit float** (shared memory ring buffer).
 
 #### Windows
 
-DAX virtual audio devices require **macOS or Linux with PipeWire**. On Windows,
-use **TCI** instead — TCI carries both control and audio over a single WebSocket
-connection, eliminating the need for virtual audio devices entirely.
+AetherSDR does **not** ship its own DAX audio driver on Windows — the built-in
+DAX bridge (the **Enable** button and meters in the DAX Audio tile) runs on
+**macOS or Linux with PipeWire** only, and those controls are disabled on
+Windows. You still have two working paths for digital-mode audio:
+
+- **TCI** (recommended) — carries both control and audio over a single WebSocket
+  connection, with no virtual audio devices to install. See the TCI setup below.
+- **FlexRadio's SmartSDR DAX** — install FlexRadio's own DAX drivers (from the
+  SmartSDR installer). AetherSDR runs alongside them, and your digital program
+  (including JTDX, which has no TCI support) uses the DAX audio devices those
+  drivers create.
 
 ### DAX gain staging
 
@@ -393,9 +401,11 @@ needed.
 2. The WSJT-X waterfall should fill with signals.
 3. Test transmit with **Tune** as above.
 
-> **Windows users:** TCI is the recommended method on Windows since DAX virtual
-> audio devices are not available. WSJT-X 3.0's TCI support gives you full
-> control and audio through a single connection.
+> **Windows users:** AetherSDR ships no DAX audio driver on Windows, so TCI is
+> the recommended method — WSJT-X 3.0's TCI support gives you full control and
+> audio through a single connection with nothing to install. If you need
+> soundcard-style DAX (for example JTDX, which has no TCI support), install
+> FlexRadio's SmartSDR DAX drivers and select those devices instead.
 
 ---
 
@@ -669,7 +679,8 @@ PulseAudio/PipeWire service is not running.
 - Click **Enable** in the DAX Audio tile.
 - On Linux: run `pactl list sources short` to check if the devices exist.
 - On macOS: check **System Settings > Sound > Input** for AetherSDR devices.
-- On Windows: use TCI instead — DAX virtual audio is not available on Windows.
+- On Windows: AetherSDR ships no DAX driver — use TCI, or FlexRadio's SmartSDR
+  DAX drivers, and check those devices instead.
 
 ### Everything works locally, but remote digital operation is choppy
 

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -51,6 +51,29 @@ void DaxApplet::buildUI()
     outer->setContentsMargins(0, 0, 0, 0);
     outer->setSpacing(0);
 
+#ifdef Q_OS_WIN
+    // On Windows AetherSDR has no built-in DAX bridge — it needs a kernel-mode
+    // audio driver we ship only on macOS/Linux (the daxToggled → startDax()
+    // wiring is compiled out here, see MainWindow_Session.cpp). DAX still works
+    // on Windows via FlexRadio's own SmartSDR DAX drivers; we just don't provide
+    // one. The Enable button, per-channel/TX meters and their labels would all
+    // be inert, so on Windows the applet shows ONLY this note and nothing else
+    // is built (#4112). The control member pointers stay null; the level/enable
+    // setters and setRadioModel() are guarded for that. The full "where to set
+    // it up" pointer lives in Help → Configuring Data Modes.
+    auto* winNote = new QLabel(
+        tr("No built-in DAX driver on Windows.\n"
+           "Use TCI, or SmartSDR DAX."));
+    winNote->setObjectName(QStringLiteral("daxWindowsNote"));
+    winNote->setAccessibleName(tr("DAX driver not shipped on Windows"));
+    winNote->setWordWrap(true);
+    winNote->setStyleSheet(
+        "QLabel { color: #d0a040; font-size: 11px; padding: 4px 6px; }");
+    outer->addWidget(winNote);
+    outer->addStretch();  // pin the note to the top; nothing below it on Windows
+    return;
+#else
+
     auto& settings = AppSettings::instance();
 
     // DAX enable row
@@ -147,12 +170,14 @@ void DaxApplet::buildUI()
 
     outer->addLayout(txRow);
     outer->addLayout(daxEnRow);
+#endif  // !Q_OS_WIN
 }
 
 void DaxApplet::setRadioModel(RadioModel* model)
 {
     m_model = model;
-    if (!model) {
+    // On Windows the applet is note-only — no status labels to update. (#4112)
+    if (!model || !m_daxTxStatus) {
         return;
     }
 
@@ -202,14 +227,17 @@ void DaxApplet::setRadioModel(RadioModel* model)
 
 void DaxApplet::setDaxEnabled(bool on)
 {
+    if (!m_daxEnable) {  // note-only on Windows (#4112)
+        return;
+    }
     QSignalBlocker b(m_daxEnable);
     m_daxEnable->setChecked(on);
 }
 
 void DaxApplet::setDaxRxLevel(int channel, float rms)
 {
-    if (channel < 1 || channel > kChannels) {
-        return;
+    if (channel < 1 || channel > kChannels || !m_daxRxMeter[channel - 1]) {
+        return;  // note-only on Windows (#4112)
     }
     // Exponential smoothing: fast attack (α=0.4), slow decay (α=0.08)
     static float smoothed[kChannels]{};
@@ -221,6 +249,9 @@ void DaxApplet::setDaxRxLevel(int channel, float rms)
 
 void DaxApplet::setDaxTxLevel(float rms)
 {
+    if (!m_daxTxMeter) {  // note-only on Windows (#4112)
+        return;
+    }
     m_daxTxMeter->setLevel(std::clamp(rms * 2.0f, 0.0f, 1.0f));
 }
 


### PR DESCRIPTION
## Issue
[#4112](https://github.com/aethersdr/AetherSDR/issues/4112) — *No DAX Sound Drivers on Windows 11.* A Flex 8600 user enabled DAX for slices A/B on Windows, CAT worked, but no DAX audio devices ever appeared in JTDX. The DAX applet let them click **Enable** and assign channels, yet nothing happened.

## Root cause
AetherSDR's **built-in** DAX bridge requires a kernel-mode audio driver, which we ship **only on macOS and Linux** (Core Audio HAL plugin / PipeWire). On Windows the `daxToggled → startDax()` wiring is compiled out (`MainWindow_Session.cpp`, `#if defined(Q_OS_MAC) || defined(HAVE_PIPEWIRE)`), but `DaxApplet` is still built unconditionally (`AppletPanel.cpp:844`). So the **Enable** toggle was a silent no-op — no bridge, no error — which is the reported confusion.

This is **not** "DAX is unavailable on Windows." DAX works on Windows via **FlexRadio's own SmartSDR DAX drivers** (the same DAX SmartSDR users install). AetherSDR simply doesn't ship a driver of its own.

## Fix (GUI + docs, all gated on `Q_OS_WIN`)
- **`DaxApplet::buildUI()`**: on Windows, build **only** the explanatory note and return — no **Enable** button, no per-channel/TX gain meters, and none of their labels (all inert on Windows). The note reads *"No built-in DAX driver on Windows. Use TCI, or SmartSDR DAX."* The control member pointers stay null, so `setDaxEnabled()/setDaxRxLevel()/setDaxTxLevel()/setRadioModel()` guard against null and no-op. The non-Windows control build is unchanged (moved into the `#else`).
- **Help → Configuring Data Modes** (`understanding-data-modes.md`): reword the three "DAX is not available on Windows" passages to the accurate framing — AetherSDR ships no DAX driver on Windows; use **TCI** (no driver), or install **FlexRadio's SmartSDR DAX** drivers (which also covers **JTDX**, since JTDX has no TCI support).

Everything is gated on `Q_OS_WIN`, so **nothing changes on macOS or Linux**, where the built-in DAX bridge works normally.

## Proof — agent automation bridge
Compile-time `#ifdef Q_OS_WIN`, so both branches were proven:

| Build | `daxWindowsNote` | `daxEnable` | `"DAX RX 1 gain"` meter |
|---|---|---|---|
| **macOS (shipping, gated)** | absent | present, enabled | present |
| **Windows preview** (`Q_OS_WIN` path, rebuilt) | present | **absent** | **absent** |

macOS readings are from the real shipping binary on hardware; the Windows readings are from a build compiling the `Q_OS_WIN` path, confirming the applet is note-only (Enable button and all meters/labels gone) and lays out cleanly.

## Proof
Left = macOS/Linux (unchanged: full DAX controls) · Right = Windows (note only — no Enable, meters, or labels).

![macOS — full DAX controls](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4112-assets/.pr-assets/4112-macos.png)
![Windows — note only](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4112-assets/.pr-assets/4112-windows.png)

Fixes #4112

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat