### PR TITLE
ci(windows): hard-gate the PDB regression class outside continue-on-error (#3946)

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -200,6 +200,25 @@ jobs:
           . .\packaging\windows\store-identity.ps1
           powershell -NoProfile -ExecutionPolicy Bypass -File packaging\windows\create-msix.ps1 -DeployDir deploy -OutputDir . -CreateUpload -SkipSign -ExcludeDfnrModel -RequirePdb
 
+      # Hard gate for the PDB-regression class (#3946). The Create MSIX
+      # package step above is continue-on-error (to tolerate MSIX SDK/tool
+      # flakes), which ALSO swallows create-msix.ps1's -RequirePdb throw — so
+      # a missing PDB can't red the build from inside that step. A missing PDB
+      # is not an MSIX hiccup though: it's a build regression (e.g.
+      # CMAKE_BUILD_TYPE flipped back to Release, which omits /Zi + /DEBUG so
+      # no build/AetherSDR.pdb is emitted) that would silently ship
+      # symbol-less .msixupload packages and skip the Windows-Symbols upload.
+      # Re-check the PDB the RelWithDebInfo Build step must emit in a step that
+      # is deliberately NOT continue-on-error, so that regression fails the job
+      # loudly instead of landing on a green build. -RequirePdb is kept above
+      # for local/dev ergonomics; this step is the CI gate that actually reds.
+      - name: Verify debug symbols (PDB) present
+        run: |
+          if (-not (Test-Path build\AetherSDR.pdb)) {
+            throw "build/AetherSDR.pdb is missing. The RelWithDebInfo Windows build must emit a PDB for Partner Center crash symbolication (.appxsym) and the standalone Windows-Symbols artifact. If CMAKE_BUILD_TYPE was changed to Release, restore RelWithDebInfo. See #3946 / #3934."
+          }
+          Write-Host "PDB present: build\AetherSDR.pdb"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:


### PR DESCRIPTION
## Problem

#3934 added `-RequirePdb` to `create-msix.ps1` so CI would **fail loudly if the PDB ever went missing again** instead of silently shipping a symbol-less `.msixupload` to Partner Center. As #3946 points out, that goal isn't actually achieved:

- `create-msix.ps1 -RequirePdb` `throw`s when no PDB is found — but it runs inside the **`Create MSIX package`** step, which is `continue-on-error: true` (intentional, to tolerate MSIX SDK/signtool flakes).
- `continue-on-error: true` converts the step outcome to *success* for job status, so the `throw` is swallowed and **the job stays green**.

If the PDB regresses (e.g. `CMAKE_BUILD_TYPE` flipped back to `Release`, which omits `/Zi` + `/DEBUG`), the build ships nothing/partial and CI is still green — the exact silent-failure class #3934 set out to eliminate, just relocated.

## Fix

A missing PDB is **not** an MSIX hiccup — it's a build regression. So gate it *outside* the `continue-on-error` step. This PR adds a dedicated **`Verify debug symbols (PDB) present`** step immediately after packaging that is deliberately **not** `continue-on-error`:

```pwsh
if (-not (Test-Path build\AetherSDR.pdb)) {
  throw "build/AetherSDR.pdb is missing. ... If CMAKE_BUILD_TYPE was changed to Release, restore RelWithDebInfo. See #3946 / #3934."
}
Write-Host "PDB present: build\AetherSDR.pdb"
```

It re-checks the `build/AetherSDR.pdb` the RelWithDebInfo build must emit; if absent it throws and reds the job. Checking the PDB itself (not the `.appxsym`) is deliberate: the PDB is a build-config invariant, whereas a missing `.appxsym` could stem from an MSIX-tool flake we intentionally tolerate. `-RequirePdb` is kept on the packaging invocation for local/dev ergonomics; this new step is the CI gate that actually reds.

## Acceptance

- Break PDB emission (flip to `Release`) → workflow goes **red** at the new verify step. ✓
- Normal builds (PDB present) stay **green** and still upload `Windows-Symbols` + `.appxsym`. ✓

## Proof

The agent automation bridge is a radio/UX test surface and doesn't apply to a GitHub Actions change, so the fix was proven by (1) parsing the workflow YAML to confirm the new step carries **no `continue-on-error`**, and (2) executing the exact step body under PowerShell 7.6.3 in both PDB states:

```
===== CASE A: PDB ABSENT (Release regression) — expect THROW + nonzero exit =====
Exception: build/AetherSDR.pdb is missing. ... See #3946 / #3934.
exit=1        <-- non-continue-on-error step exits 1 => job RED

===== CASE B: PDB PRESENT (normal RelWithDebInfo build) — expect pass + exit 0 =====
PDB present: build\AetherSDR.pdb
exit=0        <-- job GREEN
```

YAML step ordering / continue-on-error flags:

```
COE=True  | Create MSIX package
COE=None  | Verify debug symbols (PDB) present   <-- new hard gate
COE=None  | Upload artifacts
COE=None  | Upload debug symbols
```

A step with a nonzero exit and no `continue-on-error` fails the job — standard, documented Actions semantics — so CASE A reds the build and CASE B keeps it green, satisfying both acceptance criteria.

Fixes #3946

💻 Generated with Claude Code (Opus 4.8) with architecture by @jensenpat