### PR TITLE
Fix Receive Presentation Sync source gating for Flex-only RX

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -434,7 +434,7 @@ connects).
 
 | `model` | `selector` | returns |
 |---|---|---|
-| `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, KiwiSDR TX mute gate) |
+| `audio` | — | audio-engine snapshot (RX/TX stream state, mute, buffer counters, KiwiSDR TX mute gate, Receive Presentation output-signal counters) |
 | `dsp` | — | client-side AetherDSP noise-reduction state — see [`get dsp`](#get-dsp) |
 | `radio` | — | radio snapshot (name, model, version, connected, fullDuplex, transmitting, txPower, paTemp, slice/pan counts) |
 | `transmit` | — | TX-chain snapshot: RF/tune power, mic/processor/monitor, VOX/AM/DEXP, TX filter, CW (speed/pitch/breakin/delay/sidetone/iambic/monitor), ATU, APD. Validate that a TX/Phone/CW applet control reached the radio model. |
@@ -452,6 +452,12 @@ connects).
 
 Add a trailing **property** name to any single-object form to get just that
 field: `get slice active mode` → `{"value":"LSB"}`.
+
+For `get audio`, `receivePresentationOutputSignalEmitCount` counts output
+chunks dispatched to Receive Presentation Sync analysis, while
+`receivePresentationOutputSignalSuppressedCount` counts non-empty output chunks
+that were captured for automation but skipped because no KiwiSDR audio source
+was active.
 
 ### `get cwx`
 CWX keyer state, including the **queue-drain watch** that the #3949 fix relies

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -1592,13 +1592,21 @@ AudioEngine::AudioEngine(QObject* parent)
         if (len > 0)
         {
             QByteArray chunk;
-            auto emitOutputSource = [this, sampleRate](
+            auto emitOutputSource = [this, sampleRate, anyKiwiAudio](
                                         const QString& source,
                                         const QString& sourceId,
                                         const QByteArray& pcm) {
                 if (!pcm.isEmpty()) {
                     captureAutomationAudio(QStringLiteral("output"), source,
                                            sourceId, pcm, sampleRate, 2);
+                    if (!anyKiwiAudio) {
+                        m_receivePresentationOutputSignalSuppressedCount
+                            .fetch_add(1, std::memory_order_relaxed);
+                        return;
+                    }
+
+                    m_receivePresentationOutputSignalEmitCount.fetch_add(
+                        1, std::memory_order_relaxed);
                     emit receivePresentationOutputAudioReady(
                         source, sourceId, pcm, sampleRate);
                 }

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -490,6 +490,16 @@ public:
         return m_rxPlaybackQueuedMs.load(std::memory_order_relaxed);
     }
     ReceivePresentationAudioQueues receivePresentationAudioQueues() const;
+    quint64 receivePresentationOutputSignalEmitCount() const
+    {
+        return m_receivePresentationOutputSignalEmitCount.load(
+            std::memory_order_relaxed);
+    }
+    quint64 receivePresentationOutputSignalSuppressedCount() const
+    {
+        return m_receivePresentationOutputSignalSuppressedCount.load(
+            std::memory_order_relaxed);
+    }
 
     // Local CW sidetone generator — accessor used by RadioModel signal
     // routing and PhoneCwApplet UI bindings.
@@ -1076,6 +1086,8 @@ private:
     std::atomic<int>       m_receivePresentationKiwiSdrOutputBufferMs{0};
     std::atomic<int>       m_receivePresentationExternalKiwiRawBufferMs{0};
     std::atomic<int>       m_receivePresentationExternalKiwiOutputBufferMs{0};
+    std::atomic<quint64>   m_receivePresentationOutputSignalEmitCount{0};
+    std::atomic<quint64>   m_receivePresentationOutputSignalSuppressedCount{0};
     mutable std::mutex     m_automationAudioCaptureMutex;
     std::atomic<bool>      m_automationAudioCaptureActive{false};
     bool                   m_automationCaptureRaw{false};

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1377,6 +1377,12 @@ QJsonObject audioSnapshot(const AudioEngine* audio)
             static_cast<double>(audio->rxBufferUnderrunCount())},
         {QStringLiteral("rxBufferSampleRate"),
             audio->rxBufferSampleRate()},
+        {QStringLiteral("receivePresentationOutputSignalEmitCount"),
+            static_cast<double>(
+                audio->receivePresentationOutputSignalEmitCount())},
+        {QStringLiteral("receivePresentationOutputSignalSuppressedCount"),
+            static_cast<double>(
+                audio->receivePresentationOutputSignalSuppressedCount())},
         {QStringLiteral("endpoints"),
             audio->audioEndpointDiagnostics()},
     };


### PR DESCRIPTION
## Summary

Fixes #4110. Gate `receivePresentationOutputAudioReady` at the AudioEngine source so Flex-only RX output is still available to automation capture but no longer dispatches Receive Presentation Sync analysis chunks when no KiwiSDR audio source is active. Adds `get audio` bridge counters for emitted vs suppressed Receive Presentation output chunks and documents those fields.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The change is verified with the targeted Receive Presentation Sync test plus automation-bridge evidence from a live Flex-only/no-Kiwi session showing output chunks suppressed at the source while `audioCapture output` remains functional.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR receive_presentation_sync_test --parallel`)
- [x] Behavior verified on a real radio if applicable
  - FLEX-6700 connected with no Kiwi profiles active
  - `get audio` showed `receivePresentationOutputSignalEmitCount: 0`
  - `receivePresentationOutputSignalSuppressedCount` increased while RX output stayed active
  - `audioCapture start 1000 output` captured output audio successfully
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
  - See #4110 and the bridge counter proof above

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
      (N/A — no security-sensitive change)
