### PR TITLE
fix(gui): stop the add-2nd-pan swapchain crash on Intel D3D11 (#4091)

### DIFF
--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -115,6 +115,38 @@ automated draft-staging flow below) is the only "publish" step needed —
 Partner Center decodes future crash stacks against the bundled `.appxsym`
 automatically, with no further action required.
 
+### Symbolizing a crash dump (macOS / Linux)
+
+You don't need Windows or WinDbg to symbolize a reporter's crash. The
+[`rust-minidump`](https://github.com/rust-minidump/rust-minidump) toolchain
+works cross-platform against the same PDB:
+
+1. **Get the reporter's dump.** A Windows Error Reporting minidump lives in
+   `%LOCALAPPDATA%\CrashDumps\AetherSDR.exe.<pid>.dmp` (enable full dumps via
+   the `HKLM\...\Windows Error Reporting\LocalDumps` key, `DumpType=2`). Store
+   Partner Center TSVs are unsymbolized — always request the `.dmp`.
+2. **Get the matching PDB** — it must be the *exact* build that crashed or the
+   debug-id won't match. Pull the `Windows-Symbols` artifact from the
+   `windows-installer.yml` CI run for that tag/branch:
+   `gh run download <run-id> -R aethersdr/AetherSDR -n Windows-Symbols`.
+3. **Convert + walk.** [`dump_syms`](https://github.com/mozilla/dump_syms)
+   turns the PDB into a Breakpad `.sym`; `minidump-stackwalk` walks the dump
+   and matches modules by debug-id:
+   ```sh
+   dump_syms --store ./symbols AetherSDR.pdb          # → symbols/AetherSDR.pdb/<id>/AetherSDR.sym
+   minidump-stackwalk --human --symbols-path ./symbols \
+     --symbols-url https://msdl.microsoft.com/download/symbols \
+     AetherSDR.exe.<pid>.dmp
+   ```
+   Our frames symbolize from the `.sym`; the `--symbols-url` resolves Windows
+   system DLLs. Third-party GPU/driver frames (e.g. Intel `igd10iumd64.dll`)
+   stay as `module+offset` — usually enough, since the value is in *our*
+   caller frames leading into the driver. If the crashing thread won't unwind
+   past a driver frame (no CFI), fall back to a manual stack scan: parse the
+   dump's `Memory64ListStream`, find the region containing the thread's `rsp`,
+   and scan 8-byte-aligned values for pointers into `AetherSDR.exe` (resolve
+   offsets against the `.sym` `FUNC` table).
+
 ## Known WACK Follow-Ups
 
 The Windows App Certification Kit currently gives useful Store-readiness

--- a/docs/architecture/multi-pan-pitfalls.md
+++ b/docs/architecture/multi-pan-pitfalls.md
@@ -105,3 +105,26 @@ on multi-pan layout, wirePanadapter(), or slice routing.
     from the old applet and reconnect to the new one. The CW decoder is
     a singleton — its output must follow the active pan.
 
+21. **Never reparent a *live* `SpectrumWidget` through a parentless
+    (transient top-level) splitter.** Under `AETHER_GPU_SPECTRUM`,
+    `SpectrumWidget` is a `QRhiWidget`; the moment it changes top-level
+    window its backing-store QRhi changes, and on Windows/D3D11 that
+    reconfigures the composited swapchain. Doing so while the pan is
+    actively rendering can null-deref inside the GPU driver
+    (#4091 — Intel HD Graphics `igd10iumd64.dll`, AV read at `[rcx+0x310]`,
+    via `SpectrumWidget::resizeEvent` → `QRhiWidget::resizeEvent` → D3D11).
+    In `PanadapterStack::rearrangeLayout()` / `rebuildDockedSplitter()`,
+    the **nested** layouts (`2h1`/`12h`/`2x2`/`3h2`/`2x3`/`4h3`/`2x4`) build
+    a sub-`QSplitter` — if it is created parentless, filled with existing
+    live pans, *then* attached, each pan briefly lands in a transient
+    top-level. **Attach the sub-splitter to the in-window parent BEFORE
+    reparenting any pan into it** (the `addRow()` helper does `addWidget(sub)`
+    first; pans are added after). The flat layouts (`1`/`2v`/`2h`/`3v`/`4v`)
+    reparent straight into the already-in-window `m_splitter`, so they were
+    never affected. Tell-tale of this class: it crashes on a *live* add but
+    a restart that rebuilds the same layout from scratch is fine (a
+    freshly-created pan has no initialized QRhi to corrupt yet). Docked pans
+    reparented within the *same* top-level window need no GPU teardown — see
+    `prepareForTopLevelChange()`, which is only for genuine top-level changes
+    (float/dock).
+

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -291,6 +291,26 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     m_splitter->setChildrenCollapsible(false);
     layout()->addWidget(m_splitter);
 
+    // Create a horizontal sub-splitter already attached to the (in-window)
+    // m_splitter, so pans reparented into it never transit a parentless,
+    // transient top-level window. A *live* QRhiWidget that changes top-level
+    // window mid-rearrange changes its backing-store QRhi; since this path
+    // deliberately skips the teardown dance (docked pans keep their QRhi —
+    // see above), that would leave a stale cleanup callback / reconfigure the
+    // swapchain mid-render → Intel D3D11 null-deref. This only bit the nested
+    // layouts (3+ pans): the flat 2v/2h/3v/4v cases reparent straight into the
+    // already-in-window m_splitter and were fixed already; the sub-splitters
+    // were still built parentless-then-filled, so the 3rd-pan add kept
+    // crashing (#4091, follow-up). Sub-splitter must join the window BEFORE it
+    // is filled — hence addWidget(sub) here, addWidget(pan) at the call site.
+    auto addRow = [this]() {
+        auto* s = new QSplitter(Qt::Horizontal);
+        s->setHandleWidth(3);
+        s->setChildrenCollapsible(false);
+        m_splitter->addWidget(s);
+        return s;
+    };
+
     if (layoutId == "2h" && applets.size() >= 2) {
         m_splitter->setOrientation(Qt::Horizontal);
         m_splitter->addWidget(applets[0]);
@@ -298,23 +318,17 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     }
     else if (layoutId == "2h1" && applets.size() >= 3) {
         // A|B on top, C on bottom
-        auto* topSplit = new QSplitter(Qt::Horizontal);
-        topSplit->setHandleWidth(3);
-        topSplit->setChildrenCollapsible(false);
+        auto* topSplit = addRow();
         topSplit->addWidget(applets[0]);
         topSplit->addWidget(applets[1]);
-        m_splitter->addWidget(topSplit);
         m_splitter->addWidget(applets[2]);
     }
     else if (layoutId == "12h" && applets.size() >= 3) {
         // A on top, B|C on bottom
         m_splitter->addWidget(applets[0]);
-        auto* botSplit = new QSplitter(Qt::Horizontal);
-        botSplit->setHandleWidth(3);
-        botSplit->setChildrenCollapsible(false);
+        auto* botSplit = addRow();
         botSplit->addWidget(applets[1]);
         botSplit->addWidget(applets[2]);
-        m_splitter->addWidget(botSplit);
     }
     else if (layoutId == "3v" && applets.size() >= 3) {
         // A / B / C vertical stack
@@ -324,18 +338,12 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     }
     else if (layoutId == "2x2" && applets.size() >= 4) {
         // A|B on top, C|D on bottom
-        auto* topSplit = new QSplitter(Qt::Horizontal);
-        topSplit->setHandleWidth(3);
-        topSplit->setChildrenCollapsible(false);
+        auto* topSplit = addRow();
         topSplit->addWidget(applets[0]);
         topSplit->addWidget(applets[1]);
-        m_splitter->addWidget(topSplit);
-        auto* botSplit = new QSplitter(Qt::Horizontal);
-        botSplit->setHandleWidth(3);
-        botSplit->setChildrenCollapsible(false);
+        auto* botSplit = addRow();
         botSplit->addWidget(applets[2]);
         botSplit->addWidget(applets[3]);
-        m_splitter->addWidget(botSplit);
     }
     else if (layoutId == "4v" && applets.size() >= 4) {
         // A / B / C / D vertical stack
@@ -346,58 +354,40 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     }
     else if (layoutId == "3h2" && applets.size() >= 5) {
         // A|B|C on top, D|E on bottom
-        auto* topSplit = new QSplitter(Qt::Horizontal);
-        topSplit->setHandleWidth(3);
-        topSplit->setChildrenCollapsible(false);
+        auto* topSplit = addRow();
         topSplit->addWidget(applets[0]);
         topSplit->addWidget(applets[1]);
         topSplit->addWidget(applets[2]);
-        m_splitter->addWidget(topSplit);
-        auto* botSplit = new QSplitter(Qt::Horizontal);
-        botSplit->setHandleWidth(3);
-        botSplit->setChildrenCollapsible(false);
+        auto* botSplit = addRow();
         botSplit->addWidget(applets[3]);
         botSplit->addWidget(applets[4]);
-        m_splitter->addWidget(botSplit);
     }
     else if (layoutId == "2x3" && applets.size() >= 6) {
         // A|B / C|D / E|F — three rows of two
         for (int r = 0; r < 3; ++r) {
-            auto* rowSplit = new QSplitter(Qt::Horizontal);
-            rowSplit->setHandleWidth(3);
-            rowSplit->setChildrenCollapsible(false);
+            auto* rowSplit = addRow();
             rowSplit->addWidget(applets[r * 2]);
             rowSplit->addWidget(applets[r * 2 + 1]);
-            m_splitter->addWidget(rowSplit);
         }
     }
     else if (layoutId == "4h3" && applets.size() >= 7) {
         // A|B|C|D on top, E|F|G on bottom
-        auto* topSplit = new QSplitter(Qt::Horizontal);
-        topSplit->setHandleWidth(3);
-        topSplit->setChildrenCollapsible(false);
+        auto* topSplit = addRow();
         topSplit->addWidget(applets[0]);
         topSplit->addWidget(applets[1]);
         topSplit->addWidget(applets[2]);
         topSplit->addWidget(applets[3]);
-        m_splitter->addWidget(topSplit);
-        auto* botSplit = new QSplitter(Qt::Horizontal);
-        botSplit->setHandleWidth(3);
-        botSplit->setChildrenCollapsible(false);
+        auto* botSplit = addRow();
         botSplit->addWidget(applets[4]);
         botSplit->addWidget(applets[5]);
         botSplit->addWidget(applets[6]);
-        m_splitter->addWidget(botSplit);
     }
     else if (layoutId == "2x4" && applets.size() >= 8) {
         // A|B / C|D / E|F / G|H — four rows of two
         for (int r = 0; r < 4; ++r) {
-            auto* rowSplit = new QSplitter(Qt::Horizontal);
-            rowSplit->setHandleWidth(3);
-            rowSplit->setChildrenCollapsible(false);
+            auto* rowSplit = addRow();
             rowSplit->addWidget(applets[r * 2]);
             rowSplit->addWidget(applets[r * 2 + 1]);
-            m_splitter->addWidget(rowSplit);
         }
     }
     else {
@@ -486,11 +476,16 @@ void PanadapterStack::rebuildDockedSplitter()
         layoutId = defaultDockedLayoutForCount(docked.size());
     }
 
-    auto makeSplitter = [](Qt::Orientation orientation) {
-        auto* splitter = new QSplitter(orientation);
-        splitter->setHandleWidth(3);
-        splitter->setChildrenCollapsible(false);
-        return splitter;
+    // Same transient-top-level hazard as rearrangeLayout(): attach each
+    // horizontal sub-splitter to the in-window newSplitter BEFORE filling it,
+    // so a live QRhiWidget never transits a parentless top-level on dock/float
+    // (#4091). Fill happens at the call site, after addRow().
+    auto addRow = [&]() {
+        auto* s = new QSplitter(Qt::Horizontal);
+        s->setHandleWidth(3);
+        s->setChildrenCollapsible(false);
+        newSplitter->addWidget(s);
+        return s;
     };
 
     auto addVertical = [&]() {
@@ -506,61 +501,51 @@ void PanadapterStack::rebuildDockedSplitter()
         newSplitter->addWidget(docked[0]);
         newSplitter->addWidget(docked[1]);
     } else if (layoutId == "2h1" && docked.size() >= 3) {
-        auto* topSplit = makeSplitter(Qt::Horizontal);
+        auto* topSplit = addRow();
         topSplit->addWidget(docked[0]);
         topSplit->addWidget(docked[1]);
-        newSplitter->addWidget(topSplit);
         newSplitter->addWidget(docked[2]);
     } else if (layoutId == "12h" && docked.size() >= 3) {
-        auto* botSplit = makeSplitter(Qt::Horizontal);
+        newSplitter->addWidget(docked[0]);
+        auto* botSplit = addRow();
         botSplit->addWidget(docked[1]);
         botSplit->addWidget(docked[2]);
-        newSplitter->addWidget(docked[0]);
-        newSplitter->addWidget(botSplit);
     } else if (layoutId == "2x2" && docked.size() >= 4) {
-        auto* topSplit = makeSplitter(Qt::Horizontal);
+        auto* topSplit = addRow();
         topSplit->addWidget(docked[0]);
         topSplit->addWidget(docked[1]);
-        auto* botSplit = makeSplitter(Qt::Horizontal);
+        auto* botSplit = addRow();
         botSplit->addWidget(docked[2]);
         botSplit->addWidget(docked[3]);
-        newSplitter->addWidget(topSplit);
-        newSplitter->addWidget(botSplit);
     } else if (layoutId == "3h2" && docked.size() >= 5) {
-        auto* topSplit = makeSplitter(Qt::Horizontal);
+        auto* topSplit = addRow();
         topSplit->addWidget(docked[0]);
         topSplit->addWidget(docked[1]);
         topSplit->addWidget(docked[2]);
-        auto* botSplit = makeSplitter(Qt::Horizontal);
+        auto* botSplit = addRow();
         botSplit->addWidget(docked[3]);
         botSplit->addWidget(docked[4]);
-        newSplitter->addWidget(topSplit);
-        newSplitter->addWidget(botSplit);
     } else if (layoutId == "2x3" && docked.size() >= 6) {
         for (int r = 0; r < 3; ++r) {
-            auto* rowSplit = makeSplitter(Qt::Horizontal);
+            auto* rowSplit = addRow();
             rowSplit->addWidget(docked[r * 2]);
             rowSplit->addWidget(docked[r * 2 + 1]);
-            newSplitter->addWidget(rowSplit);
         }
     } else if (layoutId == "4h3" && docked.size() >= 7) {
-        auto* topSplit = makeSplitter(Qt::Horizontal);
+        auto* topSplit = addRow();
         topSplit->addWidget(docked[0]);
         topSplit->addWidget(docked[1]);
         topSplit->addWidget(docked[2]);
         topSplit->addWidget(docked[3]);
-        auto* botSplit = makeSplitter(Qt::Horizontal);
+        auto* botSplit = addRow();
         botSplit->addWidget(docked[4]);
         botSplit->addWidget(docked[5]);
         botSplit->addWidget(docked[6]);
-        newSplitter->addWidget(topSplit);
-        newSplitter->addWidget(botSplit);
     } else if (layoutId == "2x4" && docked.size() >= 8) {
         for (int r = 0; r < 4; ++r) {
-            auto* rowSplit = makeSplitter(Qt::Horizontal);
+            auto* rowSplit = addRow();
             rowSplit->addWidget(docked[r * 2]);
             rowSplit->addWidget(docked[r * 2 + 1]);
-            newSplitter->addWidget(rowSplit);
         }
     } else {
         addVertical();

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -273,23 +273,19 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
     QList<PanadapterApplet*> applets = m_pans.values();
     if (applets.isEmpty()) return;
 
-    // Remove all applets from current splitter (don't delete them).  setParent()
-    // can temporarily change the QRhiWidget's top-level window, so give Qt a
-    // chance to unregister the old backing-store callback before the move.
-    for (auto* a : applets) {
-        if (auto* sw = a ? a->spectrumWidget() : nullptr) {
-            sw->hide();
-            sw->prepareForTopLevelChange();
-            sw->resetGpuResources();
-            appendRebound(sw);
-        }
-        a->setParent(nullptr);
-    }
-
-    // Hide + remove old splitter from layout, defer deletion
-    m_splitter->hide();
-    layout()->removeWidget(m_splitter);
-    m_splitter->deleteLater();
+    // Build the new splitter first, then move applets straight into it below.
+    // addWidget() reparents splitter→splitter within the same top-level window
+    // in one step — the same pattern rebuildDockedSplitter() and
+    // dockPanadapter() already use — so the QRhiWidget's backing-store QRhi
+    // and cleanup-callback registration never change and no GPU teardown is
+    // needed for pans that stay docked. The old code detoured every applet
+    // through setParent(nullptr), which puts the QRhiWidget in a transient
+    // top-level state and forces the full hide/prepare/reset/rebuild dance;
+    // that destroy→recreate→resize storm is what the 2016-era Intel D3D11
+    // UMD (igd10iumd64.dll) null-derefed on when adding a 2nd pan (#4091).
+    // Only pans returning from floating windows (handled above) change
+    // top-level windows and need the reset.
+    QSplitter* oldSplitter = m_splitter;
     m_splitter = new QSplitter(Qt::Vertical, this);
     m_splitter->setHandleWidth(3);
     m_splitter->setChildrenCollapsible(false);
@@ -410,10 +406,35 @@ void PanadapterStack::rearrangeLayout(const QString& layoutId)
             m_splitter->addWidget(a);
     }
 
-    // Defer equalize until the new splitter has been laid out by Qt.
-    // Re-show + refresh GPU surfaces for any spectrum widgets that came
-    // out of a floating window, so they bind to the new top-level window
-    // before the first render (mirrors the dockPanadapter() refresh dance).
+    // Safety sweep: layout branches only place the applets their layout id
+    // calls for (e.g. "2h" places two). If the count ever mismatches the id,
+    // any leftover would still be a child of oldSplitter and die with its
+    // deleteLater() below, leaving dangling pointers in m_pans — fold
+    // stragglers into the new splitter instead.
+    for (auto* a : applets) {
+        if (a && !m_splitter->isAncestorOf(a))
+            m_splitter->addWidget(a);
+    }
+
+    // All applets have moved to the new splitter — retire the old one.
+    layout()->removeWidget(oldSplitter);
+    oldSplitter->hide();
+    oldSplitter->deleteLater();
+
+    // Equalize immediately so each pan's first layout pass in the new
+    // splitter already lands at final geometry. The new splitter hasn't had
+    // its layout pass yet, so the absolute values are provisional — but
+    // QSplitter redistributes proportionally on resize, so equal stays
+    // equal. This collapses the old default-sizes-then-deferred-equalize
+    // two-step into a single resize per pan; every avoided resize is one
+    // fewer swapchain rebuild for marginal GPU drivers to survive (#4091).
+    equalizeSizes();
+
+    // Deferred pass: re-show + refresh GPU surfaces for any spectrum widgets
+    // that came out of a floating window, so they bind to the new top-level
+    // window before the first render (mirrors the dockPanadapter() refresh
+    // dance). The trailing equalize is a no-op when sizes are already equal;
+    // it only settles integer-rounding drift after the real layout pass.
     QTimer::singleShot(0, this, [this, rebound]() {
         for (SpectrumWidget* sw : rebound) {
             if (!sw) continue;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -7784,6 +7784,14 @@ bool SpectrumWidget::event(QEvent* ev)
         setMouseTracking(true);
     }
 
+#ifdef AETHER_GPU_SPECTRUM
+    // Moving between monitors changes the DPR without a resize event; keep
+    // the pinned color-buffer size in device pixels current (#4091).
+    if (ev->type() == QEvent::DevicePixelRatioChange) {
+        updateFixedColorBufferSize();
+    }
+#endif
+
     if (ev->type() == QEvent::NativeGesture) {
         auto* ge = static_cast<QNativeGestureEvent*>(ev);
         if (ge->gestureType() == Qt::ZoomNativeGesture) {
@@ -8005,9 +8013,38 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
 
 // ─── Resize ───────────────────────────────────────────────────────────────────
 
+#ifdef AETHER_GPU_SPECTRUM
+void SpectrumWidget::updateFixedColorBufferSize()
+{
+    // QRhiWidget's automatic color buffer is widget-size × dpr. A fractional
+    // QT_SCALE_FACTOR (UiScalePercent ≠ 100, e.g. 0.85) turns that into
+    // odd-sized texture extents on most resizes, and the 2016-era Intel HD
+    // Graphics D3D11 UMD (igd10iumd64.dll 21.20.16.x) null-derefs recreating
+    // such textures during the add-pan resize (#4091). Pin the buffer to the
+    // ceil'd, even-aligned device-pixel size instead. The render path derives
+    // its scale from renderTarget()->pixelSize(), not width()×dpr, so the
+    // ≤1 px overshoot is invisible.
+    const qreal dpr = devicePixelRatioF();
+    QSize devicePx(static_cast<int>(std::ceil(width() * dpr)),
+                   static_cast<int>(std::ceil(height() * dpr)));
+    if (devicePx.isEmpty()) {
+        return;
+    }
+    devicePx.rwidth()  += devicePx.width()  & 1;
+    devicePx.rheight() += devicePx.height() & 1;
+    if (fixedColorBufferSize() != devicePx) {
+        setFixedColorBufferSize(devicePx);
+    }
+}
+#endif
+
 void SpectrumWidget::resizeEvent(QResizeEvent* ev)
 {
     SPECTRUM_BASE_CLASS::resizeEvent(ev);
+
+#ifdef AETHER_GPU_SPECTRUM
+    updateFixedColorBufferSize();
+#endif
 
     // Re-assert mouse tracking — on macOS with WA_NativeWindow, reparenting
     // into a QSplitter can reset native window properties.

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -677,6 +677,10 @@ protected:
     void initialize(QRhiCommandBuffer* cb) override;
     void render(QRhiCommandBuffer* cb) override;
     void releaseResources() override;
+    // Keep the RHI color buffer at an even-aligned device-pixel size so a
+    // fractional QT_SCALE_FACTOR (UiScalePercent ≠ 100) never hands the GPU
+    // driver odd texture extents on resize (#4091).
+    void updateFixedColorBufferSize();
 #else
     void paintEvent(QPaintEvent* event) override;
 #endif


### PR DESCRIPTION
## Summary

Fixes #4091 — adding a second panadapter crashes AetherSDR on Windows 10 with an access violation inside the 2016-era Intel HD Graphics D3D11 driver (`igd10iumd64.dll`, null-read at `[rcx+0x310]`). Reported by @chibondking on a Lenovo ThinkPad / Intel HD Graphics 520 / FLEX-6600.

## Root cause (from the minidump + config)

We symbolized the reporter's full minidump against the exact 26.7.1 PDB. The fault is on the GUI thread:

```
PanadapterApplet::eventFilter
SpectrumWidget::resizeEvent   (→ QRhiWidget::resizeEvent)
 … Qt6Widgets → Qt6Gui → d3d11.dll …
igd10iumd64.dll + 0x82f280    ← null deref rebuilding the D3D11 swapchain
```

Adding pan #2 re-lays-out the pan stack, which **resizes the existing pan's `QRhiWidget`**; that swapchain rebuild is what the old Intel driver null-derefs on. The crash-triggering config had `UiScalePercent=85` (→ `QT_SCALE_FACTOR=0.85`, a fractional device-pixel ratio) plus a two-pan vertical layout in a short (~455 px) window — a fresh 100%-scale / single-pan config doesn't hit the path, which matches the reporter's "old/new configs crash, fresh works."

**This is not the #3714 / #3922 reparent-callback crash.** That fix is present and working in 26.7.1 (`prepareForTopLevelChange` + `resetGpuResources` are called correctly). This is a *fresh swapchain rebuild* that the marginal driver mishandles — a separate fault.

## Fix

Three independent hardenings. The design constraint was to **preserve the low-UI-scale / many-pan contesting workflow on Intel GPUs** — Intel is the most common deployment in our userbase, so we attack the resize mechanism rather than shift Intel users onto a lower-quality Windows GL backend.

1. **No GPU teardown for pans that stay docked.** `PanadapterStack::rearrangeLayout` no longer detours every applet through `setParent(nullptr)` + `prepareForTopLevelChange`/`resetGpuResources`. It builds the new splitter and reparents splitter→splitter in one step (the pattern `rebuildDockedSplitter`/`dockPanadapter` already use), so a docked pan keeps its backing-store QRhi and never destroys/recreates its swapchain. Only pans returning from floating windows still get the reset. This removes the destroy→recreate→resize storm the driver died on — and it's a perf win on every Intel box.
2. **One resize instead of two.** `equalizeSizes()` now runs synchronously while the new splitter is built, so each pan's first layout pass lands at final geometry (one swapchain resize per pan instead of default-size-then-deferred-equalize).
3. **Even-aligned color buffer.** `SpectrumWidget` pins the `QRhiWidget` color buffer to a ceil'd, even-aligned device-pixel size (`updateFixedColorBufferSize`), so a fractional `QT_SCALE_FACTOR` never hands the driver odd texture extents. Kept current on `DevicePixelRatioChange` for monitor-to-monitor moves.

## Verification

- ✅ Clean `RelWithDebInfo`/Ninja build; **76/76 ctests pass**.
- ✅ On a live FLEX-8400M (macOS/Metal): connects, receives, and survives repeated pan add/close command cycles for 5+ minutes with no crash and no diagnostic reports.
- ⚠️ **The multi-pan rearrange path cannot be exercised on the macOS bridge** — the crash is Windows/D3D11-only (macOS uses Metal and already had the #3714 fix), and the radio's MultiFlex capacity caps live multi-pan while another station is connected. This is the documented bridge limitation for this crash class.
- 🪟 **A Windows installer build is attached for @chibondking to confirm on the actual HD 520 repro rig** — that 100%-reproducible crash is the real test.

No screenshots: this is a stability fix with no intended visual change.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat


---

### Update — 2-pan fix confirmed; 3+ pan follow-up added

The reporter tested the first CI build: the 2-pan add **no longer crashes** (both pans come alive on the exact crash config). Adding a **3rd** pan still crashed — and, tellingly, relaunching restored all 3 pans fine.

That "restore works, live-add crashes" is the signature of the live GPU-surface hop, not a pan-count limit. Follow-up commit fixes it: the nested-layout branches (`2h1`/`12h`/`2x2`/`3h2`/`2x3`/`4h3`/`2x4`) built each sub-splitter **parentless**, filled it with the live pans, then attached it — briefly placing each live `QRhiWidget` in a **transient top-level window**. The prior commit removed the GPU-teardown dance that used to cover that (correct for the flat cases, which never create a transient top-level), so the nested layouts kept crashing. Fix attaches each sub-splitter to the in-window splitter **before** filling it, in both `rearrangeLayout` and `rebuildDockedSplitter` (float/dock — same latent bug). A fresh Windows build is going out to the reporter to confirm 3+ pans.
