### PR TITLE
feat(automation): add layout, scale, and get rhi bridge verbs

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -575,6 +575,32 @@ used by the stacked trace renderer.
 - `kiwiFftTraceFloorDbm` versus `kiwiDisplayFloorDbm` — distinguishes the FFT
   trace floor used by 3D placement from the waterfall color floor.
 
+### `get rhi`
+Per-panadapter `QRhiWidget` **surface geometry** — the widget size,
+devicePixelRatio, and pinned color-buffer extents — so automation can assert
+the swapchain sizing that the #4091 fix controls (the color buffer stays
+even-aligned in device pixels under a fractional `QT_SCALE_FACTOR`).
+
+```json
+→ {"cmd":"get","model":"rhi"}
+← {"ok":true,"model":"rhi","pans":[{
+   "panIndex":0,"name":"","visible":true,"widthPx":1100,"heightPx":455,"dpr":0.85,
+   "gpu":true,"renderer":"GPU QRhi (D3D11; Intel(R) HD Graphics 520)",
+   "colorBufferAutoSized":false,"colorBufferW":936,"colorBufferH":388,
+   "expectedEvenW":936,"expectedEvenH":388,"evenAligned":true}]}
+```
+
+| field | meaning |
+|---|---|
+| `dpr` | effective device-pixel ratio (fractional when `QT_SCALE_FACTOR` ≠ integer) |
+| `colorBufferAutoSized` | `true` when the widget lets QRhiWidget auto-size (`fixedColorBufferSize` unset); `false` when pinned |
+| `colorBufferW` / `colorBufferH` | the pinned device-pixel color buffer, or the unset sentinel `-1,-1` when auto-sized |
+| `expectedEvenW` / `expectedEvenH` | what an even-aligned pin should be for the current size — assert `colorBufferW/H` matches without recomputing the formula |
+| `evenAligned` | both pinned dimensions are even (the #4091 invariant); `false` when auto-sized |
+
+`selector` filters by pan index (`get rhi 0`) or objectName. On non-GPU builds
+each entry reports `gpu:false` and omits the buffer fields.
+
 ### `get clients`
 Multi-session forensics (#3977/#3951): every client connected to the radio,
 which of them have written **our** pans' dBm range, and which stale
@@ -1032,6 +1058,55 @@ Panadapter lifecycle — create or tear down a pan regardless of how it was open
 
 All are async (the radio echoes the change) — re-poll `get pans`. Every `pan`
 action is RX/config only; none keys the transmitter.
+
+### `layout`
+Drive the panadapter **splitter layout** directly, decoupled from how many
+panadapters the radio has granted.
+
+```json
+→ {"cmd":"layout","action":"rearrange","value":"2v"}
+← {"ok":true,"layout":"rearrange","requested":"2v","applied":true,
+   "panCount":2,"dockedCount":2,"floatingCount":0,"savedLayout":"1"}
+
+→ {"cmd":"layout","action":"get"}
+← {"ok":true,"layout":"get","requested":"","applied":false,
+   "panCount":1,"dockedCount":1,"floatingCount":0,"savedLayout":"1"}
+```
+
+| `action` | `value` | effect |
+|---|---|---|
+| `rearrange` | layout id (`1`/`2v`/`2h`/`2h1`/`12h`/`3v`/`2x2`/`4v`/`3h2`/`2x3`/`4h3`/`2x4`) | rebuild the splitter for that id via the production `PanadapterStack::rearrangeLayout`, exercising the full teardown/reparent/GPU-surface path on whatever pans exist. |
+| `get` | — | report the saved `PanadapterLayout` + live pan/docked/floating counts without changing anything. |
+
+Why it exists: on a shared radio, MultiFlex caps how many panadapters a client
+can open, so the add-2nd-pan resize path (the #4091 crash) can be unreachable
+from the bridge. `layout rearrange` forces the splitter machinery to run
+regardless. It is a **transient exerciser** — it does *not* persist
+`PanadapterLayout`, and a layout id needing more applets than exist falls back
+to a vertical stack (same as production). RX/config only; never keys TX.
+
+### `scale`
+Report — and optionally persist — the UI scale factor, so scale-dependent
+rendering bugs (fractional `QT_SCALE_FACTOR`, e.g. #4091) are reproducible and
+assertable.
+
+```json
+→ {"cmd":"scale"}
+← {"ok":true,"scale":true,"qtScaleFactorEnv":"0.85",
+   "uiScalePercentSaved":85,"primaryScreenDpr":2.0}
+
+→ {"cmd":"scale","value":"85"}
+← {"ok":true,"scale":true,"qtScaleFactorEnv":null,"uiScalePercentSaved":100,
+   "primaryScreenDpr":2.0,"uiScalePercentSet":85,"appliesOnNextLaunch":true}
+```
+
+Bare `scale` reports only. `scale <pct>` (one of `75|85|100|110|125|150|175|200`,
+matching the **View → UI Scale** menu) persists `UiScalePercent`. Because
+`QT_SCALE_FACTOR` must be set before `QApplication` (see `main.cpp`), a scale
+change **only applies on the next launch** — this verb never mutates the running
+process. To actually run under a fractional scale in one shot, launch with the
+env directly: `QT_SCALE_FACTOR=0.85 AETHER_AUTOMATION=1 …`. Pair with `get rhi`
+to assert the resulting swapchain dimensions. Never keys TX.
 
 ### `panmessage`
 Manual test hook for panadapter overlay popup messages. This is UI-only: it

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1066,6 +1066,7 @@ panadapters the radio has granted.
 ```json
 → {"cmd":"layout","action":"rearrange","value":"2v"}
 ← {"ok":true,"layout":"rearrange","requested":"2v","applied":true,
+   "fellBack":false,"effectiveLayout":"2v","settlesNextTurn":true,
    "panCount":2,"dockedCount":2,"floatingCount":0,"savedLayout":"1"}
 
 → {"cmd":"layout","action":"get"}
@@ -1082,8 +1083,16 @@ Why it exists: on a shared radio, MultiFlex caps how many panadapters a client
 can open, so the add-2nd-pan resize path (the #4091 crash) can be unreachable
 from the bridge. `layout rearrange` forces the splitter machinery to run
 regardless. It is a **transient exerciser** — it does *not* persist
-`PanadapterLayout`, and a layout id needing more applets than exist falls back
-to a vertical stack (same as production). RX/config only; never keys TX.
+`PanadapterLayout`. RX/config only; never keys TX.
+
+Honesty of the reply: an **unknown id is rejected** (`ok:false`) rather than
+silently building the trivial fallback; an id needing **more applets than
+exist** runs the production vertical-stack fallback and reports
+`fellBack:true` + `effectiveLayout:"vstack"` — a test that meant to exercise a
+*nested* layout (the #4091 reparent path) must assert `fellBack:false`, or the
+green result proves nothing. Geometry **settles on the next event-loop turn**
+(`settlesNextTurn:true` — ex-floating pans re-show and sizes equalize
+deferred), so don't pipeline `get rhi`/`grab` in the same write; re-poll after.
 
 ### `scale`
 Report — and optionally persist — the UI scale factor, so scale-dependent
@@ -1107,6 +1116,10 @@ change **only applies on the next launch** — this verb never mutates the runni
 process. To actually run under a fractional scale in one shot, launch with the
 env directly: `QT_SCALE_FACTOR=0.85 AETHER_AUTOMATION=1 …`. Pair with `get rhi`
 to assert the resulting swapchain dimensions. Never keys TX.
+
+Note: the running session's **View → UI Scale menu checkmark is built once at
+startup and will not reflect a bridge write** — the persisted value is applied
+(and the menu re-seeded) on the next launch.
 
 ### `panmessage`
 Manual test hook for panadapter overlay popup messages. This is UI-only: it

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -15,6 +15,7 @@
 #include <QLocalServer>
 #include <QLocalSocket>
 #include <QApplication>
+#include <QScreen>
 #include <QWidget>
 #include <QMainWindow>
 #include <QMenu>
@@ -2031,6 +2032,10 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             value = rest.join(QLatin1Char(' '));  // "testtone on 1000 -6" -> freqHz levelDb
         } else if (cmd == QLatin1String("pan")) {
             action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
+        } else if (cmd == QLatin1String("layout")) {
+            action = tok(1); value = tok(2);  // "layout rearrange 2v", "layout get"
+        } else if (cmd == QLatin1String("scale")) {
+            value = tok(1);                   // "scale" (report), "scale 85" (persist)
         } else if (cmd == QLatin1String("dss")) {
             action = tok(1);                  // snapshot | reset | inject | scrollback | live
             target = tok(2);                  // pan index, optional for snapshot
@@ -2260,6 +2265,13 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             return err(QStringLiteral("pan requires an action (create|add|remove|close|center)"));
         return doPan(action, value);
     }
+    if (cmd == QLatin1String("layout")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("layout requires an action (rearrange|get)"));
+        return doLayout(action, value);
+    }
+    if (cmd == QLatin1String("scale"))
+        return doScale(value);
     if (cmd == QLatin1String("panmessage")) {
         if (action.isEmpty()) {
             return err(QStringLiteral("panmessage requires an action (add|remove|clear|list)"));
@@ -3151,6 +3163,39 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
 
             QVariantMap snap;
             if (!QMetaObject::invokeMethod(w, "traceDebugSnapshot",
+                                           Qt::DirectConnection,
+                                           Q_RETURN_ARG(QVariantMap, snap))) {
+                continue;
+            }
+            if (!selector.isEmpty() && selectorIsIndex
+                && snap.value(QStringLiteral("panIndex")).toInt() != wantIndex) {
+                continue;
+            }
+            pans.append(QJsonObject::fromVariantMap(snap));
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("model"), model},
+                           {QStringLiteral("pans"), pans}};
+    }
+    if (model == QLatin1String("rhi")) {
+        // Per-panadapter QRhiWidget surface geometry from every SpectrumWidget,
+        // so automation can assert the swapchain/color-buffer sizing that the
+        // #4091 fix controls (fixedColorBufferSize kept even-aligned vs a
+        // fractional QT_SCALE_FACTOR). selector filters by pan index or
+        // objectName. GUI-header-free: found by class name, snapshotted via
+        // meta-call. Reports gpu:false per pan on non-GPU builds.
+        bool selectorIsIndex = false;
+        const int wantIndex = selector.toInt(&selectorIsIndex);
+        QJsonArray pans;
+        const QList<QWidget*> widgets =
+            findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+        for (QWidget* w : widgets) {
+            if (!selector.isEmpty() && !selectorIsIndex
+                && w->objectName() != selector) {
+                continue;
+            }
+            QVariantMap snap;
+            if (!QMetaObject::invokeMethod(w, "automationRhiSnapshot",
                                            Qt::DirectConnection,
                                            Q_RETURN_ARG(QVariantMap, snap))) {
                 continue;
@@ -5026,6 +5071,84 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
 
     return err(QStringLiteral("unknown pan action: ") + action
                + QStringLiteral(" (create|add|remove|close|center)"));
+}
+
+// ── Panadapter layout (bridge test hook) ────────────────────────────────────
+// `layout rearrange <id>` drives PanadapterStack::rearrangeLayout directly, so
+// the splitter reparent / GPU-surface path is exercisable regardless of how
+// many panadapters the radio has actually granted (MultiFlex capacity caps
+// live multi-pan on shared radios, which otherwise makes the add-2nd-pan
+// crash path — #4091 — unreachable from the bridge). `layout get` reports the
+// saved layout id and current pan counts without changing anything. This does
+// NOT persist PanadapterLayout — it is a transient exerciser, not the
+// production layout-change path.
+QJsonObject AutomationServer::doLayout(const QString& action, const QString& arg)
+{
+    const QList<QWidget*> stacks =
+        findWidgetsByClass(QStringLiteral("PanadapterStack"));
+    if (stacks.isEmpty())
+        return err(QStringLiteral("no PanadapterStack found (connect a radio first)"));
+
+    QString layoutId;   // empty → query-only (the "get" action)
+    if (action == QLatin1String("rearrange")) {
+        layoutId = arg.trimmed();
+        if (layoutId.isEmpty())
+            return err(QStringLiteral("layout rearrange requires a layout id "
+                                      "(1|2v|2h|2h1|12h|3v|2x2|4v|3h2|2x3|4h3|2x4)"));
+    } else if (action != QLatin1String("get")) {
+        return err(QStringLiteral("unknown layout action: ") + action
+                   + QStringLiteral(" (rearrange|get)"));
+    }
+
+    QVariantMap snap;
+    if (!QMetaObject::invokeMethod(stacks.first(), "automationRearrange",
+                                   Qt::DirectConnection,
+                                   Q_RETURN_ARG(QVariantMap, snap),
+                                   Q_ARG(QString, layoutId)))
+        return err(QStringLiteral("PanadapterStack::automationRearrange failed"));
+
+    QJsonObject out = QJsonObject::fromVariantMap(snap);
+    out[QStringLiteral("ok")] = true;
+    out[QStringLiteral("layout")] = action;
+    return out;
+}
+
+// ── UI scale (report / persist for next launch) ─────────────────────────────
+// `scale` reports the effective UI scale so automation can assert the process
+// launched at the intended fractional QT_SCALE_FACTOR (pairs with `get rhi`
+// to prove the #4091 even-alignment fix). `scale <pct>` persists UiScalePercent
+// so a subsequent relaunch reproduces that configuration — QT_SCALE_FACTOR must
+// be set before QApplication (main.cpp), so it can only apply on next launch;
+// this never mutates the running process's scale. Values match the View → UI
+// Scale menu steps.
+QJsonObject AutomationServer::doScale(const QString& arg)
+{
+    AppSettings& s = AppSettings::instance();
+    QJsonObject out{{QStringLiteral("ok"), true}, {QStringLiteral("scale"), true}};
+
+    const QByteArray env = qgetenv("QT_SCALE_FACTOR");
+    out[QStringLiteral("qtScaleFactorEnv")] =
+        env.isEmpty() ? QJsonValue() : QJsonValue(QString::fromUtf8(env));
+    out[QStringLiteral("uiScalePercentSaved")] =
+        s.value(QStringLiteral("UiScalePercent"), QStringLiteral("100")).toInt();
+    if (QScreen* scr = QApplication::primaryScreen())
+        out[QStringLiteral("primaryScreenDpr")] = scr->devicePixelRatio();
+
+    const QString a = arg.trimmed();
+    if (!a.isEmpty()) {
+        // Canonical steps mirror MainWindow's kScaleSteps / the UI Scale menu.
+        static const QList<int> kScaleSteps = {75, 85, 100, 110, 125, 150, 175, 200};
+        bool okI = false;
+        const int pct = a.toInt(&okI);
+        if (!okI || !kScaleSteps.contains(pct))
+            return err(QStringLiteral("scale pct must be one of "
+                                      "75|85|100|110|125|150|175|200"));
+        s.setValue(QStringLiteral("UiScalePercent"), QString::number(pct));
+        s.save();
+        out[QStringLiteral("uiScalePercentSet")] = pct;
+        out[QStringLiteral("appliesOnNextLaunch")] = true;
+    }
+    return out;
 }
 
 QJsonObject AutomationServer::doPanMessage(const QString& action,

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1742,7 +1742,7 @@ bool AutomationServer::start(const QString& serverName)
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
-        << "txtest, atu, slice, tune, pan, panmessage, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
+        << "txtest, atu, slice, tune, pan, layout, scale, panmessage, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
         << "menu, close, drag, hover, showMenu, contextMenu, hitTest, clickAt, shortcut, whoami, log, mark)";
     return true;
 }
@@ -2266,12 +2266,14 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         return doPan(action, value);
     }
     if (cmd == QLatin1String("layout")) {
-        if (action.isEmpty())
+        if (action.isEmpty()) {
             return err(QStringLiteral("layout requires an action (rearrange|get)"));
+        }
         return doLayout(action, value);
     }
-    if (cmd == QLatin1String("scale"))
+    if (cmd == QLatin1String("scale")) {
         return doScale(value);
+    }
     if (cmd == QLatin1String("panmessage")) {
         if (action.isEmpty()) {
             return err(QStringLiteral("panmessage requires an action (add|remove|clear|list)"));
@@ -5086,15 +5088,17 @@ QJsonObject AutomationServer::doLayout(const QString& action, const QString& arg
 {
     const QList<QWidget*> stacks =
         findWidgetsByClass(QStringLiteral("PanadapterStack"));
-    if (stacks.isEmpty())
+    if (stacks.isEmpty()) {
         return err(QStringLiteral("no PanadapterStack found (connect a radio first)"));
+    }
 
     QString layoutId;   // empty → query-only (the "get" action)
     if (action == QLatin1String("rearrange")) {
         layoutId = arg.trimmed();
-        if (layoutId.isEmpty())
+        if (layoutId.isEmpty()) {
             return err(QStringLiteral("layout rearrange requires a layout id "
                                       "(1|2v|2h|2h1|12h|3v|2x2|4v|3h2|2x3|4h3|2x4)"));
+        }
     } else if (action != QLatin1String("get")) {
         return err(QStringLiteral("unknown layout action: ") + action
                    + QStringLiteral(" (rearrange|get)"));
@@ -5104,8 +5108,14 @@ QJsonObject AutomationServer::doLayout(const QString& action, const QString& arg
     if (!QMetaObject::invokeMethod(stacks.first(), "automationRearrange",
                                    Qt::DirectConnection,
                                    Q_RETURN_ARG(QVariantMap, snap),
-                                   Q_ARG(QString, layoutId)))
+                                   Q_ARG(QString, layoutId))) {
         return err(QStringLiteral("PanadapterStack::automationRearrange failed"));
+    }
+    // An unknown layout id comes back as an error map — pass it through
+    // instead of stamping ok:true over it (#4091 test honesty).
+    if (snap.contains(QStringLiteral("error"))) {
+        return err(snap.value(QStringLiteral("error")).toString());
+    }
 
     QJsonObject out = QJsonObject::fromVariantMap(snap);
     out[QStringLiteral("ok")] = true;
@@ -5131,18 +5141,23 @@ QJsonObject AutomationServer::doScale(const QString& arg)
         env.isEmpty() ? QJsonValue() : QJsonValue(QString::fromUtf8(env));
     out[QStringLiteral("uiScalePercentSaved")] =
         s.value(QStringLiteral("UiScalePercent"), QStringLiteral("100")).toInt();
-    if (QScreen* scr = QApplication::primaryScreen())
+    if (QScreen* scr = QApplication::primaryScreen()) {
         out[QStringLiteral("primaryScreenDpr")] = scr->devicePixelRatio();
+    }
 
     const QString a = arg.trimmed();
     if (!a.isEmpty()) {
-        // Canonical steps mirror MainWindow's kScaleSteps / the UI Scale menu.
+        // Canonical steps duplicate MainWindow.cpp's TU-static kScaleSteps /
+        // the View → UI Scale menu (the bridge must not include GUI headers —
+        // Engine/UI dependency direction). If the menu grows a step, add it
+        // here too; MainWindow.cpp carries the reciprocal note.
         static const QList<int> kScaleSteps = {75, 85, 100, 110, 125, 150, 175, 200};
         bool okI = false;
         const int pct = a.toInt(&okI);
-        if (!okI || !kScaleSteps.contains(pct))
+        if (!okI || !kScaleSteps.contains(pct)) {
             return err(QStringLiteral("scale pct must be one of "
                                       "75|85|100|110|125|150|175|200"));
+        }
         s.setValue(QStringLiteral("UiScalePercent"), QString::number(pct));
         s.save();
         out[QStringLiteral("uiScalePercentSet")] = pct;

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -335,6 +335,17 @@ private:
     // production GUI close path now does the same via RadioModel::removePanadapter
     // (#3843). (#3646)
     QJsonObject doPan(const QString& action, const QString& arg);
+    // layout rearrange <id> | get: drive PanadapterStack::rearrangeLayout
+    // directly (decoupled from radio-granted pans) so the splitter
+    // reparent/GPU-reset path is exercisable on any host regardless of
+    // MultiFlex panadapter capacity; `get` reports the saved layout + counts.
+    QJsonObject doLayout(const QString& action, const QString& arg);
+    // scale [pct]: report the effective UI scale (QT_SCALE_FACTOR env,
+    // UiScalePercent setting, primary-screen devicePixelRatio); with a pct
+    // arg, persist UiScalePercent so a subsequent relaunch reproduces a
+    // fractional-DPI configuration (env must precede QApplication, so it
+    // applies on next launch — never mutates the running process).
+    QJsonObject doScale(const QString& arg);
     // panmessage add|remove|clear|list <pan-index|active>: inject/read
     // panadapter overlay messages for deterministic UI verification. UI-only;
     // never sends radio commands and never keys TX. `add` accepts optional

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6902,6 +6902,8 @@ SpectrumWidget* MainWindow::spectrum() const
 }
 
 // ── UI Scale helpers ────────────────────────────────────────────────────
+// Duplicated in AutomationServer::doScale (bridge can't include GUI
+// headers) — if a step is added here, add it there too.
 static constexpr int kScaleSteps[] = {75, 85, 100, 110, 125, 150, 175, 200};
 static constexpr int kScaleStepCount = sizeof(kScaleSteps) / sizeof(kScaleSteps[0]);
 

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -8,6 +8,7 @@
 #include <QHBoxLayout>
 #include <QLayout>
 #include <QStringList>
+#include <QVariant>
 #include <QVBoxLayout>
 #include <QPointer>
 #include <QTimer>
@@ -221,6 +222,26 @@ static void equalizeSplitter(QSplitter* splitter)
 void PanadapterStack::equalizeSizes()
 {
     equalizeSplitter(m_splitter);
+}
+
+QVariantMap PanadapterStack::automationRearrange(const QString& layoutId)
+{
+    // Non-empty id drives the real production rearrange (exercising the
+    // splitter teardown/reparent path); empty id is a query-only report.
+    if (!layoutId.isEmpty())
+        rearrangeLayout(layoutId);
+
+    const int floating = m_floatingWindows.size();
+    return QVariantMap{
+        {QStringLiteral("requested"), layoutId},
+        {QStringLiteral("applied"), !layoutId.isEmpty()},
+        {QStringLiteral("panCount"), m_pans.size()},
+        {QStringLiteral("dockedCount"), m_pans.size() - floating},
+        {QStringLiteral("floatingCount"), floating},
+        {QStringLiteral("savedLayout"),
+         AppSettings::instance().value(QStringLiteral("PanadapterLayout"),
+                                       QStringLiteral("1")).toString()},
+    };
 }
 
 void PanadapterStack::rearrangeLayout(const QString& layoutId)

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -224,20 +224,64 @@ void PanadapterStack::equalizeSizes()
     equalizeSplitter(m_splitter);
 }
 
+int PanadapterStack::layoutRequiredPanCount(const QString& layoutId)
+{
+    // Minimum applet count each layout id needs before rearrangeLayout()'s
+    // guarded branch takes it; below that (or for an unknown id) the final
+    // else falls back to a plain vertical stack. Mirrors the `>=` guards in
+    // rearrangeLayout()/rebuildDockedSplitter() — keep in sync. Returns -1
+    // for an id no branch recognizes, so callers can reject typos instead of
+    // silently exercising the trivial fallback (#4091 test honesty).
+    static const QHash<QString, int> kRequired = {
+        {QStringLiteral("1"), 1},   {QStringLiteral("2v"), 2},
+        {QStringLiteral("2h"), 2},  {QStringLiteral("2h1"), 3},
+        {QStringLiteral("12h"), 3}, {QStringLiteral("3v"), 3},
+        {QStringLiteral("2x2"), 4}, {QStringLiteral("4v"), 4},
+        {QStringLiteral("3h2"), 5}, {QStringLiteral("2x3"), 6},
+        {QStringLiteral("4h3"), 7}, {QStringLiteral("2x4"), 8},
+    };
+    return kRequired.value(layoutId, -1);
+}
+
 QVariantMap PanadapterStack::automationRearrange(const QString& layoutId)
 {
     // Non-empty id drives the real production rearrange (exercising the
     // splitter teardown/reparent path); empty id is a query-only report.
-    if (!layoutId.isEmpty())
+    // An unknown id is rejected up-front: rearrangeLayout()'s final else
+    // would silently build a trivial vertical stack — no nested splitters —
+    // and a test asserting ok:true would believe it exercised the #4091
+    // reparent path when it didn't. An id needing more applets than exist
+    // takes the same fallback; that IS reachable intent (production allows
+    // it), so it runs but is reported honestly via fellBack.
+    bool fellBack = false;
+    if (!layoutId.isEmpty()) {
+        const int required = layoutRequiredPanCount(layoutId);
+        if (required < 0) {
+            return QVariantMap{
+                {QStringLiteral("error"),
+                 QStringLiteral("unknown layout id: ") + layoutId
+                     + QStringLiteral(" (1|2v|2h|2h1|12h|3v|2x2|4v|3h2|2x3|4h3|2x4)")},
+            };
+        }
+        fellBack = m_pans.size() < required;
         rearrangeLayout(layoutId);
+    }
 
     const int floating = m_floatingWindows.size();
     return QVariantMap{
         {QStringLiteral("requested"), layoutId},
         {QStringLiteral("applied"), !layoutId.isEmpty()},
+        // True when the id needed more applets than exist, so rearrange built
+        // the vertical-stack fallback rather than the requested layout.
+        {QStringLiteral("fellBack"), fellBack},
+        {QStringLiteral("effectiveLayout"),
+         fellBack ? QStringLiteral("vstack") : layoutId},
         {QStringLiteral("panCount"), m_pans.size()},
         {QStringLiteral("dockedCount"), m_pans.size() - floating},
         {QStringLiteral("floatingCount"), floating},
+        // Ex-floating pans re-show and sizes equalize on the NEXT event-loop
+        // turn (rearrangeLayout defers them) — re-poll get rhi / grab after.
+        {QStringLiteral("settlesNextTurn"), !layoutId.isEmpty()},
         {QStringLiteral("savedLayout"),
          AppSettings::instance().value(QStringLiteral("PanadapterLayout"),
                                        QStringLiteral("1")).toString()},

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -51,8 +51,13 @@ public:
 
     // Automation bridge hook: drive rearrangeLayout directly (or, with an empty
     // id, just report) so tests can exercise the splitter reparent path without
-    // the radio granting extra panadapters. Returns saved layout id + counts.
+    // the radio granting extra panadapters. Rejects unknown ids (error map) and
+    // reports fellBack/effectiveLayout when the id needed more applets than
+    // exist. Returns saved layout id + counts; geometry settles next turn.
     Q_INVOKABLE QVariantMap automationRearrange(const QString& layoutId);
+    // Minimum applets a layout id needs before its rearrangeLayout branch
+    // takes it (-1 = unknown id). Mirrors the >= guards — keep in sync.
+    static int layoutRequiredPanCount(const QString& layoutId);
 
     // Float/dock panadapters
     void floatPanadapter(const QString& panId);

--- a/src/gui/PanadapterStack.h
+++ b/src/gui/PanadapterStack.h
@@ -49,6 +49,11 @@ public:
     void equalizeSizes();
     void rearrangeLayout(const QString& layoutId);
 
+    // Automation bridge hook: drive rearrangeLayout directly (or, with an empty
+    // id, just report) so tests can exercise the splitter reparent path without
+    // the radio granting extra panadapters. Returns saved layout id + counts.
+    Q_INVOKABLE QVariantMap automationRearrange(const QString& layoutId);
+
     // Float/dock panadapters
     void floatPanadapter(const QString& panId);
     void dockPanadapter(const QString& panId);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -835,7 +835,9 @@ QVariantMap SpectrumWidget::automationRhiSnapshot() const
     m[QStringLiteral("gpu")] = true;
     m[QStringLiteral("renderer")] = rendererDescription();
     const QSize fixed = fixedColorBufferSize();
-    const bool autoSized = fixed.isEmpty();  // (0,0) → QRhiWidget auto-sizes
+    // Unset fixedColorBufferSize() is the null QSize(-1,-1) — isEmpty()
+    // covers it (and any degenerate size) → QRhiWidget auto-sizes.
+    const bool autoSized = fixed.isEmpty();
     m[QStringLiteral("colorBufferAutoSized")] = autoSized;
     m[QStringLiteral("colorBufferW")] = fixed.width();
     m[QStringLiteral("colorBufferH")] = fixed.height();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -821,6 +821,38 @@ QString SpectrumWidget::rendererDescription() const
 #endif
 }
 
+QVariantMap SpectrumWidget::automationRhiSnapshot() const
+{
+    QVariantMap m;
+    m[QStringLiteral("panIndex")] = m_panIndex;
+    m[QStringLiteral("name")] = objectName();
+    m[QStringLiteral("visible")] = isVisible();
+    const qreal dpr = devicePixelRatioF();
+    m[QStringLiteral("widthPx")] = width();
+    m[QStringLiteral("heightPx")] = height();
+    m[QStringLiteral("dpr")] = dpr;
+#ifdef AETHER_GPU_SPECTRUM
+    m[QStringLiteral("gpu")] = true;
+    m[QStringLiteral("renderer")] = rendererDescription();
+    const QSize fixed = fixedColorBufferSize();
+    const bool autoSized = fixed.isEmpty();  // (0,0) → QRhiWidget auto-sizes
+    m[QStringLiteral("colorBufferAutoSized")] = autoSized;
+    m[QStringLiteral("colorBufferW")] = fixed.width();
+    m[QStringLiteral("colorBufferH")] = fixed.height();
+    // What an even-aligned pin *should* be for the current size — lets a test
+    // assert the #4091 alignment without recomputing the formula itself.
+    const int expW = static_cast<int>(std::ceil(width() * dpr));
+    const int expH = static_cast<int>(std::ceil(height() * dpr));
+    m[QStringLiteral("expectedEvenW")] = expW + (expW & 1);
+    m[QStringLiteral("expectedEvenH")] = expH + (expH & 1);
+    m[QStringLiteral("evenAligned")] =
+        !autoSized && (fixed.width() % 2 == 0) && (fixed.height() % 2 == 0);
+#else
+    m[QStringLiteral("gpu")] = false;
+#endif
+    return m;
+}
+
 QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
 {
     const double secs = std::max(0.001, m_panStats.sinceMs() / 1000.0);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -128,6 +128,10 @@ public:
     // plus a cause breakdown of static-overlay rebuilds. `reset` zeroes the
     // counters after the read so successive reads measure disjoint intervals.
     Q_INVOKABLE QVariantMap panstatsSnapshot(bool reset);
+    // QRhiWidget surface geometry for `get rhi`: widget size, devicePixelRatio,
+    // and (on GPU builds) the pinned fixedColorBufferSize so automation can
+    // assert it stays even-aligned under a fractional QT_SCALE_FACTOR (#4091).
+    Q_INVOKABLE QVariantMap automationRhiSnapshot() const;
     Q_INVOKABLE QVariantMap automationDssSnapshot() const;
     Q_INVOKABLE QVariantMap automationDssReset(bool kiwiStream);
     Q_INVOKABLE QVariantMap automationDssInjectRows(int count,

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -138,6 +138,8 @@ def main():
                          "dss inject [pan] <count> <firstPeakBin> <stepBin> "
                          "[native|kiwi [rowLowMhz rowHighMhz]] | "
                          "dss scrollback [pan] <offsetRows> | "
+                         "pan <create|add|center|close|remove> [value] | "
+                         "layout <rearrange <id>|get> | scale [pct] | "
                          "panmessage <add|remove|clear|list> <target> [id timeout [tone=info|warning] title|detail] | "
                          "audioCapture <start|stop|status|read> [args]")
     ap.add_argument("--socket", help="override the bridge socket path")

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -122,7 +122,8 @@ def main():
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect", "slice", "audioCapture",
                              "record", "testtone", "tci", "panmessage",
-                             "hitTest", "clickAt", "resize", "dss"],
+                             "hitTest", "clickAt", "resize", "dss",
+                             "pan", "layout", "scale"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
@@ -224,6 +225,27 @@ def main():
                        "value": f"{args.rest[1]} {args.rest[2]}"}
             else:
                 sys.exit("error: clickAt needs <x> <y> or <target> <x> <y>")
+
+        elif args.command == "pan":
+            if not args.rest:
+                sys.exit("error: pan needs <create|add|center|close|remove> [value]")
+            req = {"cmd": "pan", "action": args.rest[0]}
+            if len(args.rest) > 1:
+                req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "layout":
+            if not args.rest:
+                sys.exit("error: layout needs <rearrange <id> | get>")
+            req = {"cmd": "layout", "action": args.rest[0]}
+            if len(args.rest) > 1:
+                req["value"] = " ".join(args.rest[1:])
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "scale":
+            req = {"cmd": "scale"}
+            if args.rest:
+                req["value"] = args.rest[0]
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "resize":


### PR DESCRIPTION
## Summary

Three agent-automation-bridge verbs that came out of root-causing the #4091 add-2nd-pan swapchain crash (PR #4120). While proving that fix, the macOS bridge couldn't reach the two things that mattered:

1. the multi-pan **rearrange path** — a shared radio's MultiFlex capacity caps how many panadapters a client can open, so the crash path was unreachable; and
2. the **fractional-scale swapchain sizing** the fix controls — nothing exposed the QRhiWidget color-buffer dimensions to assert on.

These verbs close both gaps and are generally useful for GPU/layout regression testing.

## Verbs

### `layout rearrange <id>` / `layout get`
Drives `PanadapterStack::rearrangeLayout` directly (backed by a new `Q_INVOKABLE` helper), so the splitter teardown/reparent/GPU-surface path runs on whatever pans exist — decoupled from radio grants. `layout get` reports the saved layout id + pan/docked/floating counts. Transient exerciser: it does **not** persist `PanadapterLayout`.

### `scale` / `scale <pct>`
Reports the effective UI scale (`QT_SCALE_FACTOR` env, `UiScalePercent`, primary-screen DPR) so automation can assert the process launched at an intended fractional scale. `scale <pct>` (menu steps `75..200`) persists `UiScalePercent` for the **next** launch — `QT_SCALE_FACTOR` must precede `QApplication`, so it never mutates the running process. To run under a fractional scale in one shot, launch with the env directly (`QT_SCALE_FACTOR=0.85 …`).

### `get rhi`
Reports each `SpectrumWidget`'s `QRhiWidget` surface geometry — widget size, `devicePixelRatio`, pinned `fixedColorBufferSize`, an expected even-aligned target, and an `evenAligned` flag — so a test can assert the #4091 color-buffer invariant without recomputing the formula. Backed by a new `Q_INVOKABLE SpectrumWidget::automationRhiSnapshot`; reports `gpu:false` on non-GPU builds.

Together, `scale` + `get rhi` let a test launch at `QT_SCALE_FACTOR=0.85`, then assert the swapchain stays even-aligned — the exact invariant PR #4120 introduces.

## Drive-by

`tools/automation_probe.py` was missing the (pre-existing) `pan` verb in its argparse choices; added `pan` alongside the three new verbs so the CLI matches the server. All four documented in `docs/automation-bridge.md`.

## Verification

- Clean `RelWithDebInfo`/Ninja build; **76/76 ctests pass**.
- All four verbs proven live against a `QT_SCALE_FACTOR=0.85` offscreen instance:
  - `scale` → `qtScaleFactorEnv: "0.85"`, `primaryScreenDpr: 0.85` ✓
  - `scale 85` persists / `scale 999` rejected ✓
  - `layout get` / `layout rearrange 2v` → `applied:true`, process healthy after ✓
  - `get rhi` → per-pan geometry with `dpr: 0.85`, `colorBufferAutoSized: true` (pin lands with #4120) ✓

No screenshots: automation-surface change, no user-visible UI.

💻 Generated with Claude Code (claude-fable-5 7/1/26) with architecture by @jensenpat
