### PR TITLE
Fix RX slice tooltip label mismatch

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -742,6 +742,8 @@ RX/config — none keys the transmitter. `add`/`remove`/`tx` are async
 | `tx` | `<sliceId>` | make a slice the TX slice — the external-split transition; radio enforces single-TX |
 | `txant` / `rxant` | `<port>` e.g. `ANT2` | set the TX/RX antenna of the TX (else active) slice; validated against the slice's antenna list — establish the dummy-load antenna before any TX-safety gate, then read back with `get slice tx txAntenna` |
 | `rxsource` (alias `source`) | see below | select the slice's receive source (Flex / virtual-Kiwi) |
+| `fixture` | `<sliceId> [A-H]` | disconnected-only test fixture: synthesize an owned slice through the normal slice-status path, optionally with a single radio `index_letter`, so `dumpTree` can assert UI without a radio |
+| `clearfixture` | `<sliceId>` | remove a slice created by `fixture`; when the final fixture is removed, restores the pre-fixture disconnected model/max-slice state |
 
 #### `slice rxsource`
 Selects the receive source for a slice through the same virtual-Kiwi path as
@@ -808,6 +810,24 @@ one second after the pointer leaves. Grab the badge with `grab DragValuePopup`
 — note each `HGauge` owns its own popup, so with several meters hovered the name
 resolves to the first-created one; hover a single meter per instance for an
 unambiguous grab.
+
+### `tooltip`
+Force-show a widget's native Qt tooltip, using the widget's current
+`toolTip()` text unless an override string is supplied. This is for screenshots
+and assertions where injected hover should prove the target state but the
+platform does not run Qt's built-in tooltip timer under automation.
+
+```text
+→ {"cmd":"tooltip","target":"E"}
+← {"ok":true,"target":"E","class":"QToolButton",
+   "text":"Slice E (global slot 5)","grabHint":"QTipLabel", ...}
+→ tooltip E Screenshot override text
+← {"ok":true,"target":"E","text":"Screenshot override text", ...}
+→ {"cmd":"grab","target":"QTipLabel","path":"/tmp/slice-tooltip.png"}
+← {"ok":true,"class":"QTipLabel","path":"/tmp/slice-tooltip.png", ...}
+```
+
+Use `{"cmd":"tooltip","target":"E","action":"hide"}` to dismiss it.
 
 ### `scrollTo` (alias `ensureVisible`)
 Scroll the target's nearest `QScrollArea` ancestor so the widget sits in the

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2150,7 +2150,15 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             action = tok(2);  // optional "leave" → fade after exit
         } else if (cmd == QLatin1String("tooltip")) {
             target = tok(1);
-            if (tok(2) == QLatin1String("hide") && p.size() == 3) {
+            if (tok(2) == QLatin1String("hide")) {
+                // "hide" with trailing tokens must not silently become an
+                // override that force-SHOWS a tip reading "hide …" (#4122
+                // review). An override literally starting with "hide" is
+                // available via the JSON form's explicit value field.
+                if (p.size() != 3) {
+                    return err(QStringLiteral(
+                        "tooltip hide takes no extra arguments"));
+                }
                 action = QStringLiteral("hide");
             } else {
                 QStringList rest;
@@ -4692,6 +4700,12 @@ QJsonObject AutomationServer::doTooltip(const QString& target,
                                         const QString& value) const
 {
     if (action == QLatin1String("hide")) {
+        // Validate the target like the show path — a typo'd target must not
+        // return ok:true (#4122 review). The tip itself is global, so the
+        // target is only checked, not used.
+        if (!resolveWidget(target)) {
+            return err(QStringLiteral("widget or window not found: ") + target);
+        }
         bool hidden = false;
         if (QWidget* tip = resolveWidget(QStringLiteral("QTipLabel"))) {
             tip->hide();
@@ -4703,7 +4717,7 @@ QJsonObject AutomationServer::doTooltip(const QString& target,
                            {QStringLiteral("hidden"), hidden}};
     }
 
-    QWidget* w = resolveWidget(target);
+    QPointer<QWidget> w = resolveWidget(target);
     if (!w) {
         return err(QStringLiteral("widget or window not found: ") + target);
     }
@@ -4729,6 +4743,19 @@ QJsonObject AutomationServer::doTooltip(const QString& target,
     QCoreApplication::sendEvent(w, &event);
     const bool accepted = event.isAccepted();
 
+    // QPointer guard (#4122 review): a ToolTip handler that rebuilds UI can
+    // destroy the target during sendEvent — restoring through a raw pointer
+    // would be a use-after-free.
+    if (!w) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("target"), target},
+            {QStringLiteral("text"), text},
+            {QStringLiteral("accepted"), accepted},
+            {QStringLiteral("targetDestroyed"), true},
+            {QStringLiteral("grabHint"), QStringLiteral("QTipLabel")},
+        };
+    }
     if (overrideToolTip) {
         w->setToolTip(originalToolTip);
     }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -64,6 +64,7 @@
 #include <QToolButton>   // doShowMenu: QToolButton::menu()
 #include <QWidgetAction>  // describeAction: header rows (disabled QWidgetAction + QLabel)
 #include <QContextMenuEvent>  // doContextMenu: synthesize a right-click menu trigger
+#include <QHelpEvent>    // doTooltip: synthesize the same tooltip event as a real hover
 #ifdef HAVE_WEBSOCKETS
 #include <QWebSocket>         // doTci: in-process TCI client simulator (#3305)
 #endif
@@ -1744,7 +1745,7 @@ bool AutomationServer::start(const QString& serverName)
         << "automation bridge listening on" << fullServerName()
         << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
         << "txtest, atu, slice, tune, pan, layout, scale, panmessage, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
-        << "menu, close, drag, hover, showMenu, contextMenu, hitTest, clickAt, shortcut, whoami, log, mark)";
+        << "menu, close, drag, hover, tooltip, showMenu, contextMenu, hitTest, clickAt, shortcut, whoami, log, mark)";
     return true;
 }
 
@@ -2004,7 +2005,7 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             for (int i = 2; i < p.size(); ++i) {
                 rest << tok(i);
             }
-            value = rest.join(QLatin1Char(' '));  // "slice add 14.2", "slice rxsource 7 K4JK"
+            value = rest.join(QLatin1Char(' '));  // "slice add 14.2", "slice fixture 4 B"
         } else if (cmd == QLatin1String("tune")) {
             value = tok(1);   // "tune 3.7"
         } else if (cmd == QLatin1String("log")) {
@@ -2147,6 +2148,17 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         } else if (cmd == QLatin1String("hover")) {
             target = tok(1);
             action = tok(2);  // optional "leave" → fade after exit
+        } else if (cmd == QLatin1String("tooltip")) {
+            target = tok(1);
+            if (tok(2) == QLatin1String("hide") && p.size() == 3) {
+                action = QStringLiteral("hide");
+            } else {
+                QStringList rest;
+                for (int i = 2; i < p.size(); ++i) {
+                    rest << tok(i);
+                }
+                value = rest.join(QLatin1Char(' '));
+            }
         } else if (cmd == QLatin1String("contextMenu")) {
             target = tok(1);
             value = tok(2) + QLatin1Char(' ') + tok(3);  // "contextMenu SMeterWidget [x y]"
@@ -2187,6 +2199,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         if (target.isEmpty())
             return err(QStringLiteral("hover requires a target widget"));
         return doHover(target, action);
+    }
+    if (cmd == QLatin1String("tooltip")) {
+        if (target.isEmpty())
+            return err(QStringLiteral("tooltip requires a target widget"));
+        return doTooltip(target, action, value);
     }
     if (cmd == QLatin1String("scrollTo") || cmd == QLatin1String("ensureVisible")) {
         if (target.isEmpty())
@@ -3954,7 +3971,52 @@ QJsonObject AutomationServer::doSlice(const QString& action, const QString& arg)
         }
         return m_sliceReceiveSourceHandler(arg);
     }
-    return err(QStringLiteral("unknown slice action: ") + action + QStringLiteral(" (add|remove|select|tx|txant|rxant|rxsource)"));
+    if (action == QLatin1String("fixture")) {
+        const QStringList parts = arg.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (parts.isEmpty()) {
+            return err(QStringLiteral("slice fixture requires a slice id"));
+        }
+        if (parts.size() > 2) {
+            return err(QStringLiteral("slice fixture accepts only: <slice id> [letter]"));
+        }
+        bool okId = false;
+        const int id = parts.at(0).toInt(&okId);
+        if (!okId) {
+            return err(QStringLiteral("slice fixture requires a numeric slice id"));
+        }
+        const QString letter = parts.value(1);
+        QString error;
+        if (!radio->automationApplySliceFixture(id, letter, &error)) {
+            return err(error);
+        }
+
+        QJsonObject response{{QStringLiteral("ok"), true},
+                             {QStringLiteral("slice"), QStringLiteral("fixture")},
+                             {QStringLiteral("id"), id},
+                             {QStringLiteral("sliceCount"), radio->slices().size()}};
+        SliceModel* s = radio->slice(id);
+        if (s) {
+            response[QStringLiteral("letter")] = s->letter();
+        }
+        return response;
+    }
+    if (action == QLatin1String("clearfixture")) {
+        bool okId = false;
+        const int id = arg.toInt(&okId);
+        if (!okId) {
+            return err(QStringLiteral("slice clearfixture requires a slice id"));
+        }
+        QString error;
+        if (!radio->automationRemoveSliceFixture(id, &error)) {
+            return err(error);
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("slice"), QStringLiteral("clearfixture")},
+                           {QStringLiteral("id"), id},
+                           {QStringLiteral("sliceCount"), radio->slices().size()}};
+    }
+    return err(QStringLiteral("unknown slice action: ") + action
+               + QStringLiteral(" (add|remove|select|tx|txant|rxant|rxsource|fixture|clearfixture)"));
 }
 
 // ── VFO tuning (#3646) ──────────────────────────────────────────────────────
@@ -4617,6 +4679,72 @@ QJsonObject AutomationServer::doHover(const QString& target, const QString& acti
                                          : QStringLiteral("enter")},
         {QStringLiteral("x"), global.x()},
         {QStringLiteral("y"), global.y()},
+    };
+}
+
+// tooltip <target> [hide]: explicitly ask the target widget to show its native
+// Qt tooltip. Synthetic hover is useful for hover-driven app UI, but platforms
+// do not always run the built-in tooltip timer for injected events under
+// offscreen automation. Sending QEvent::ToolTip uses the same widget event path
+// as a real hover, so a driver can `grab QTipLabel` for PR evidence.
+QJsonObject AutomationServer::doTooltip(const QString& target,
+                                        const QString& action,
+                                        const QString& value) const
+{
+    if (action == QLatin1String("hide")) {
+        bool hidden = false;
+        if (QWidget* tip = resolveWidget(QStringLiteral("QTipLabel"))) {
+            tip->hide();
+            hidden = true;
+        }
+        return QJsonObject{{QStringLiteral("ok"), true},
+                           {QStringLiteral("target"), target},
+                           {QStringLiteral("action"), QStringLiteral("hide")},
+                           {QStringLiteral("hidden"), hidden}};
+    }
+
+    QWidget* w = resolveWidget(target);
+    if (!w) {
+        return err(QStringLiteral("widget or window not found: ") + target);
+    }
+    if (!w->isVisible()) {
+        return err(QStringLiteral("refused: '") + target + QStringLiteral("' is not visible"));
+    }
+
+    const QString text = value.isEmpty() ? w->toolTip() : value;
+    if (text.isEmpty()) {
+        return err(QStringLiteral("target has no tooltip: ") + target);
+    }
+
+    const QPoint center(w->width() / 2, w->height() / 2);
+    const QPoint global = w->mapToGlobal(center);
+
+    const QString originalToolTip = w->toolTip();
+    const bool overrideToolTip = !value.isEmpty() && value != originalToolTip;
+    if (overrideToolTip) {
+        w->setToolTip(value);
+    }
+
+    QHelpEvent event(QEvent::ToolTip, center, global);
+    QCoreApplication::sendEvent(w, &event);
+    const bool accepted = event.isAccepted();
+
+    if (overrideToolTip) {
+        w->setToolTip(originalToolTip);
+    }
+
+    qCInfo(lcAutomation).noquote()
+        << "tooltip" << target << "at" << global << text;
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("target"), target},
+        {QStringLiteral("class"), shortClassName(w)},
+        {QStringLiteral("text"), text},
+        {QStringLiteral("x"), global.x()},
+        {QStringLiteral("y"), global.y()},
+        {QStringLiteral("accepted"), accepted},
+        {QStringLiteral("grabHint"), QStringLiteral("QTipLabel")},
     };
 }
 

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -300,6 +300,11 @@ private:
     // QEvent::Leave so the fade-after-exit timer can be observed. Unlike drag,
     // no button is pressed, matching a real hover.
     QJsonObject doHover(const QString& target, const QString& action) const;
+    // tooltip <target> [hide]: force-show the target widget's native Qt tooltip
+    // so a driver can grab the resulting QTipLabel under automation.
+    QJsonObject doTooltip(const QString& target,
+                          const QString& action,
+                          const QString& value) const;
     // scrollTo <target> (alias ensureVisible): scroll the nearest QScrollArea
     // ancestor so the target widget sits in its viewport. Widgets parked below
     // the fold of a scroll area (e.g. the Aetherial strip's waveform panel)
@@ -402,7 +407,8 @@ private:
 
     void forceUnkey(const char* reason);  // emergency all-stop (tune/mox/two-tone)
 
-    // Slice lifecycle (add/remove/select/tx) and VFO tuning — RX/config, no keying.
+    // Slice lifecycle/config actions, disconnected-only fixtures, and VFO tuning.
+    // RX/config only; none of these key the transmitter.
     QJsonObject doSlice(const QString& action, const QString& arg);
     QJsonObject doTune(const QString& value);
     // Semantic transmitter keying (#3646 fidelity): `key ptt on|off` / `key mox`

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1707,12 +1707,9 @@ void RxApplet::updateSliceButtons(const QList<SliceModel*>& slices, int activeSl
             btn->setEnabled(true);
             btn->setProperty("sliceId", slotId);
             btn->setProperty("slotState", "ours");
-            const QChar gLetter('A' + slotId);
-            const QString perClient = ourSlice->letter().isEmpty()
-                                           ? QString(gLetter)
-                                           : ourSlice->letter();
+            const QString displayLetter = SliceLabel::plainText(slotId, ourSlice->letter());
             btn->setToolTip(QString("Slice %1 (global slot %2)")
-                                .arg(perClient).arg(slotId + 1));
+                                .arg(displayLetter).arg(slotId + 1));
             btn->setChecked(slotId == activeSliceId);
             // Colour pairs with the displayed letter in RadioIndexed mode.
             const int colourIdx = SliceLabel::displayColorIndex(slotId, ourSlice->letter());

--- a/src/gui/SliceLabel.cpp
+++ b/src/gui/SliceLabel.cpp
@@ -47,6 +47,11 @@ int displayColorIndex(int globalSliceId, const QString& radioLetter)
     return globalSliceId;
 }
 
+QString plainText(int globalSliceId, const QString& radioLetter)
+{
+    return QString(resolveLetter(globalSliceId, radioLetter, currentMode()));
+}
+
 QString richText(int globalSliceId, const QString& radioLetter)
 {
     const Mode mode = currentMode();

--- a/src/gui/SliceLabel.h
+++ b/src/gui/SliceLabel.h
@@ -19,7 +19,7 @@ namespace AetherSDR::SliceLabel {
 //                  slice id as a subscript so slot awareness survives the
 //                  SmartSDR-style per-client lettering.  See #2606.
 //
-// All three helpers below consult this setting on every call so the
+// All helpers below consult this setting on every call so the
 // runtime view follows the user flipping it without restart.
 
 enum class Mode {
@@ -36,6 +36,11 @@ Mode currentMode();
 // user's per-client letter and badge colour stay paired regardless of
 // which physical slot the radio assigned.  See #2606.
 int displayColorIndex(int globalSliceId, const QString& radioLetter);
+
+// Render the mode-aware display letter without HTML or Unicode subscript.
+// Use this for prose/tooltips that should name the same slice letter the
+// visible badge is using.
+QString plainText(int globalSliceId, const QString& radioLetter = QString());
 
 // Render the slice label as HTML rich text.  Caller must
 // `setTextFormat(Qt::RichText)` on the target QLabel.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -978,6 +978,19 @@ bool RadioModel::automationApplySliceFixture(int sliceId,
         return fail(QStringLiteral("slice fixture letter must be A..H"));
     }
 
+    // Refuse to hijack a real slice (#4122 review). m_slices deliberately
+    // survives an unexpected disconnect so the session can be reclaimed on
+    // reconnect — a fixture applied over that id would decode fixture kvs
+    // into the user's real SliceModel (visibly retuning it) and the eventual
+    // fixture clear would DESTROY it, breaking reconnect continuity. Same for
+    // a staged stale slice, which the create path would silently reclaim.
+    if (!m_automationSliceFixtures.contains(sliceId)
+        && (slice(sliceId) || m_staleSlices.contains(sliceId))) {
+        return fail(QStringLiteral(
+            "slice %1 already exists from the previous session — "
+            "fixtures may not overwrite reclaimable slices").arg(sliceId));
+    }
+
     if (!m_automationSliceFixtureBaselineActive) {
         m_automationSliceFixtureBaselineModel = m_model;
         m_automationSliceFixtureBaselineMaxSlices = m_maxSlices;
@@ -1021,6 +1034,19 @@ bool RadioModel::automationApplySliceFixture(int sliceId,
     kvs.insert(QStringLiteral("rxant_list"), QStringLiteral("ANT1,ANT2"));
     kvs.insert(QStringLiteral("txant_list"), QStringLiteral("ANT1,ANT2"));
 
+    m_ownedSliceIds.insert(sliceId);
+    m_foreignSliceOwners.remove(sliceId);
+    handleSliceStatus(sliceId, kvs, false);
+    if (!slice(sliceId)) {
+        m_ownedSliceIds.remove(sliceId);
+        restoreAutomationSliceFixtureBaseline();  // self-guards on live fixtures
+        return fail(QStringLiteral("slice fixture did not create slice %1").arg(sliceId));
+    }
+    m_automationSliceFixtures.insert(sliceId);
+
+    // Deactivate sibling fixtures only after the new one verifiably exists —
+    // deactivating first would leave no active slice if creation failed
+    // (#4122 review). Mirrors the radio's single-active semantics.
     for (int existingId : std::as_const(m_automationSliceFixtures)) {
         if (existingId == sliceId) {
             continue;
@@ -1029,18 +1055,6 @@ bool RadioModel::automationApplySliceFixture(int sliceId,
                           {{QStringLiteral("active"), QStringLiteral("0")}},
                           false);
     }
-
-    m_ownedSliceIds.insert(sliceId);
-    m_foreignSliceOwners.remove(sliceId);
-    handleSliceStatus(sliceId, kvs, false);
-    if (!slice(sliceId)) {
-        m_ownedSliceIds.remove(sliceId);
-        if (m_automationSliceFixtures.isEmpty()) {
-            restoreAutomationSliceFixtureBaseline();
-        }
-        return fail(QStringLiteral("slice fixture did not create slice %1").arg(sliceId));
-    }
-    m_automationSliceFixtures.insert(sliceId);
     return true;
 }
 
@@ -2520,6 +2534,12 @@ void RadioModel::onConnected()
     qCDebug(lcProtocol) << "RadioModel: connected";
     m_reconnectTimer.stop();
     m_rebootInProgress = false;
+    // Belt-and-braces (#4122 review): the connect entry points clear fixtures,
+    // but isConnected() stays false for the whole Connecting phase, so a
+    // fixture applied while the handshake was in flight (seconds on WAN)
+    // would otherwise be staged below and "reclaimed" by the real status
+    // replay — with the fixture set staying poisoned for the session.
+    clearAutomationSliceFixtures();
     stageSessionModelsForReconnect();
     armClientConnectionNoticeSuppression();
     setActivePanResized(false);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <utility>
 
 namespace AetherSDR {
 
@@ -825,6 +826,7 @@ RadioModel::RadioModel(QObject* parent)
     connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
         if (!m_intentionalDisconnect && !m_lastInfo.address.isNull()) {
             qCDebug(lcProtocol) << "RadioModel: auto-reconnecting to" << m_lastInfo.address.toString();
+            clearAutomationSliceFixtures();
             QMetaObject::invokeMethod(m_connection, [this] {
                 m_connection->connectToRadio(m_lastInfo);
             });
@@ -904,6 +906,169 @@ QString RadioModel::foreignSliceOwnerStation(int sliceId) const
     auto it = m_foreignSliceOwners.constFind(sliceId);
     if (it == m_foreignSliceOwners.constEnd()) return {};
     return m_clientStations.value(it.value(), {});
+}
+
+void RadioModel::clearAutomationSliceFixtures()
+{
+    const QSet<int> fixtures = m_automationSliceFixtures;
+    for (int sliceId : fixtures) {
+        handleSliceStatus(sliceId, QMap<QString, QString>{}, true);
+        m_ownedSliceIds.remove(sliceId);
+        m_foreignSliceOwners.remove(sliceId);
+    }
+    m_automationSliceFixtures.clear();
+    restoreAutomationSliceFixtureBaseline();
+}
+
+void RadioModel::restoreAutomationSliceFixtureBaseline()
+{
+    if (!m_automationSliceFixtureBaselineActive
+        || !m_automationSliceFixtures.isEmpty()) {
+        return;
+    }
+
+    bool changed = false;
+    if (m_model != m_automationSliceFixtureBaselineModel) {
+        m_model = m_automationSliceFixtureBaselineModel;
+        changed = true;
+    }
+    if (m_maxSlices != m_automationSliceFixtureBaselineMaxSlices) {
+        m_maxSlices = m_automationSliceFixtureBaselineMaxSlices;
+        changed = true;
+    }
+
+    m_automationSliceFixtureBaselineActive = false;
+    m_automationSliceFixtureBaselineModel.clear();
+    m_automationSliceFixtureBaselineMaxSlices = 4;
+
+    if (changed) {
+        emit infoChanged();
+    }
+}
+
+bool RadioModel::automationApplySliceFixture(int sliceId,
+                                             const QString& radioLetter,
+                                             QString* error)
+{
+    auto fail = [error](const QString& message) {
+        if (error) {
+            *error = message;
+        }
+        return false;
+    };
+
+    if (isConnected()) {
+        return fail(QStringLiteral("slice fixture is only available while disconnected"));
+    }
+    if (sliceId < 0 || sliceId >= 8) {
+        return fail(QStringLiteral("slice fixture id must be 0..7"));
+    }
+
+    const QString trimmedLetter = radioLetter.trimmed();
+    if (trimmedLetter.size() > 1) {
+        return fail(QStringLiteral("slice fixture letter must be a single A..H letter"));
+    }
+
+    QString letter = trimmedLetter.toUpper();
+    if (letter.isEmpty()) {
+        letter = QString(QChar(static_cast<ushort>('A' + sliceId)));
+    }
+    const ushort letterCode = letter.at(0).unicode();
+    if (letterCode < 'A' || letterCode > 'H') {
+        return fail(QStringLiteral("slice fixture letter must be A..H"));
+    }
+
+    if (!m_automationSliceFixtureBaselineActive) {
+        m_automationSliceFixtureBaselineModel = m_model;
+        m_automationSliceFixtureBaselineMaxSlices = m_maxSlices;
+        m_automationSliceFixtureBaselineActive = true;
+    }
+
+    bool infoChangedNeeded = false;
+    if (m_model.isEmpty() || maxSlicesForModel(m_model) <= sliceId) {
+        m_model = QStringLiteral("FLEX-6700");
+        infoChangedNeeded = true;
+    }
+    const int modelMaxSlices = maxSlicesForModel(m_model);
+    if (m_maxSlices < modelMaxSlices) {
+        m_maxSlices = modelMaxSlices;
+        infoChangedNeeded = true;
+    }
+    if (m_maxSlices <= sliceId) {
+        return fail(QStringLiteral("model %1 supports only %2 slices")
+                        .arg(m_model)
+                        .arg(m_maxSlices));
+    }
+    if (infoChangedNeeded) {
+        emit infoChanged();
+    }
+
+    QMap<QString, QString> kvs;
+    kvs.insert(QStringLiteral("in_use"), QStringLiteral("1"));
+    kvs.insert(QStringLiteral("pan"), QStringLiteral("0x40000000"));
+    kvs.insert(QStringLiteral("index_letter"), letter);
+    kvs.insert(QStringLiteral("RF_frequency"), QStringLiteral("14.225000"));
+    kvs.insert(QStringLiteral("mode"), QStringLiteral("USB"));
+    kvs.insert(QStringLiteral("filter_lo"), QStringLiteral("100"));
+    kvs.insert(QStringLiteral("filter_hi"), QStringLiteral("2700"));
+    kvs.insert(QStringLiteral("active"), QStringLiteral("1"));
+    kvs.insert(QStringLiteral("tx"), QStringLiteral("0"));
+    kvs.insert(QStringLiteral("audio_level"), QStringLiteral("50"));
+    kvs.insert(QStringLiteral("audio_pan"), QStringLiteral("50"));
+    kvs.insert(QStringLiteral("audio_mute"), QStringLiteral("0"));
+    kvs.insert(QStringLiteral("rxant"), QStringLiteral("ANT1"));
+    kvs.insert(QStringLiteral("txant"), QStringLiteral("ANT1"));
+    kvs.insert(QStringLiteral("rxant_list"), QStringLiteral("ANT1,ANT2"));
+    kvs.insert(QStringLiteral("txant_list"), QStringLiteral("ANT1,ANT2"));
+
+    for (int existingId : std::as_const(m_automationSliceFixtures)) {
+        if (existingId == sliceId) {
+            continue;
+        }
+        handleSliceStatus(existingId,
+                          {{QStringLiteral("active"), QStringLiteral("0")}},
+                          false);
+    }
+
+    m_ownedSliceIds.insert(sliceId);
+    m_foreignSliceOwners.remove(sliceId);
+    handleSliceStatus(sliceId, kvs, false);
+    if (!slice(sliceId)) {
+        m_ownedSliceIds.remove(sliceId);
+        if (m_automationSliceFixtures.isEmpty()) {
+            restoreAutomationSliceFixtureBaseline();
+        }
+        return fail(QStringLiteral("slice fixture did not create slice %1").arg(sliceId));
+    }
+    m_automationSliceFixtures.insert(sliceId);
+    return true;
+}
+
+bool RadioModel::automationRemoveSliceFixture(int sliceId, QString* error)
+{
+    auto fail = [error](const QString& message) {
+        if (error) {
+            *error = message;
+        }
+        return false;
+    };
+
+    if (isConnected()) {
+        return fail(QStringLiteral("slice fixture is only available while disconnected"));
+    }
+    if (sliceId < 0 || sliceId >= 8) {
+        return fail(QStringLiteral("slice fixture id must be 0..7"));
+    }
+    if (!m_automationSliceFixtures.contains(sliceId)) {
+        return fail(QStringLiteral("no slice fixture with id %1").arg(sliceId));
+    }
+
+    handleSliceStatus(sliceId, QMap<QString, QString>{}, true);
+    m_ownedSliceIds.remove(sliceId);
+    m_foreignSliceOwners.remove(sliceId);
+    m_automationSliceFixtures.remove(sliceId);
+    restoreAutomationSliceFixtureBaseline();
+    return true;
 }
 
 int RadioModel::activeTxSliceNum() const
@@ -1391,6 +1556,8 @@ void RadioModel::emitInterlockNotification(const QString& message,
 
 void RadioModel::connectToRadio(const RadioInfo& info)
 {
+    clearAutomationSliceFixtures();
+
     m_wanConn = nullptr;  // LAN mode
     m_lastInfo = info;
     m_intentionalDisconnect = false;
@@ -1421,6 +1588,8 @@ void RadioModel::connectViaWan(WanConnection* wan, const QString& publicIp, quin
     qCDebug(lcProtocol) << "RadioModel: connectViaWan publicIp=" << publicIp
              << "udpPort=" << udpPort
              << "wanHandle=0x" << QString::number(wan->clientHandle(), 16);
+
+    clearAutomationSliceFixtures();
 
     // Disconnect any stale signal connections from a previous WAN session
     if (m_wanConn)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -359,6 +359,11 @@ public:
     // Station name of the client occupying a foreign slot, or empty string
     // if not foreign / not known yet.
     QString foreignSliceOwnerStation(int sliceId) const;
+    bool automationApplySliceFixture(int sliceId,
+                                     const QString& radioLetter,
+                                     QString* error = nullptr);
+    bool automationRemoveSliceFixture(int sliceId,
+                                      QString* error = nullptr);
 
     // High-level actions
     void connectToRadio(const RadioInfo& info);
@@ -975,6 +980,10 @@ private:
     quint16  m_wanUdpPort{4991};
     QSet<int>          m_ownedSliceIds;   // slice IDs that belong to our client
     QHash<int, quint32> m_foreignSliceOwners;  // slot id → owning client handle
+    QSet<int>          m_automationSliceFixtures; // disconnected bridge fixtures
+    bool               m_automationSliceFixtureBaselineActive{false};
+    QString            m_automationSliceFixtureBaselineModel;
+    int                m_automationSliceFixtureBaselineMaxSlices{4};
     bool               m_txOwnedByUs{true};  // true when tx_client_handle matches our handle
     bool               m_fullDuplex{false};
     int                m_rttyMarkDefault{2125};
@@ -988,6 +997,8 @@ private:
     QSet<quint32> m_startupClientConnections; // clients present before our connect status replay
     QElapsedTimer m_clientConnectionNoticeTimer;
     static constexpr qint64 CLIENT_CONNECTION_STARTUP_SUPPRESS_MS = 5000;
+    void clearAutomationSliceFixtures();
+    void restoreAutomationSliceFixtureBaseline();
 
     SleepInhibitor m_sleepInhibitor;     // prevents OS idle sleep while connected
     RadioInfo m_lastInfo;               // stored for auto-reconnect

--- a/tests/slice_label_test.cpp
+++ b/tests/slice_label_test.cpp
@@ -39,6 +39,8 @@ int main()
     EXPECT_EQ(SliceLabel::richText(2, "A"),      QString("C"));
     EXPECT_EQ(SliceLabel::richText(7, "B"),      QString("H"));
 
+    EXPECT_EQ(SliceLabel::plainText(4, "B"),     QString("E"));
+
     EXPECT_EQ(SliceLabel::unicodeForm(0),        QString("A"));
     EXPECT_EQ(SliceLabel::unicodeForm(2, "A"),   QString("C"));
 
@@ -52,6 +54,7 @@ int main()
     EXPECT_EQ(SliceLabel::richText(0, "A"),      QString("A<sub>1</sub>"));
     EXPECT_EQ(SliceLabel::richText(1, "A"),      QString("A<sub>2</sub>"));
     EXPECT_EQ(SliceLabel::richText(2, "B"),      QString("B<sub>3</sub>"));
+    EXPECT_EQ(SliceLabel::plainText(2, "B"),     QString("B"));
 
     // Missing radio letter falls back to the global letter, still with
     // subscript so slot info isn't lost.

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -267,7 +267,9 @@ def main():
                 sys.exit("error: tooltip needs <target> [hide|text...]")
             req = {"cmd": "tooltip", "target": args.rest[0]}
             if len(args.rest) > 1:
-                if args.rest[1] == "hide" and len(args.rest) == 2:
+                if args.rest[1] == "hide":
+                    if len(args.rest) != 2:
+                        sys.exit("error: tooltip hide takes no extra arguments")
                     req["action"] = "hide"
                 else:
                     req["value"] = " ".join(args.rest[1:])

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -104,7 +104,10 @@ def main():
                "  automation_probe.py get sync\n"
                "  automation_probe.py get slice active frequency\n"
                "  automation_probe.py slice rxsource 7 K4JK\n"
+               "  automation_probe.py slice fixture 4 B\n"
                "  automation_probe.py invoke 'Master volume' setValue 35\n"
+               "  automation_probe.py hover E\n"
+               "  automation_probe.py tooltip E\n"
                "  automation_probe.py hitTest SpectrumWidget 80 80\n"
                "  automation_probe.py clickAt 1420 210          # global point (dumpTree geometry)\n"
                "  automation_probe.py clickAt AppletPanel 12 34  # point local to a widget\n"
@@ -122,18 +125,20 @@ def main():
                     choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
                              "connect", "disconnect", "slice", "audioCapture",
                              "record", "testtone", "tci", "panmessage",
-                             "hitTest", "clickAt", "resize", "dss",
+                             "hover", "tooltip", "hitTest", "clickAt", "resize", "dss",
                              "pan", "layout", "scale"],
                     help="verb to run (default: demo = dumpTree + panadapter grab)")
     ap.add_argument("rest", nargs="*",
                     help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
                          "invoke <target> <action> [value] | "
                          "get <model> [selector] [property] | "
+                         "hover <target> [leave] | "
+                         "tooltip <target> [hide|text...] | "
                          "hitTest <target> [x y] | "
                          "clickAt <x> <y> | clickAt <target> <x> <y> | "
                          "resize <w> <h> [target] | "
                          "connect <list|show|hide|local|ip|wait> [args] | "
-                         "slice <add|remove|select|tx|txant|rxant|rxsource> [args] | "
+                         "slice <add|remove|select|tx|txant|rxant|rxsource|fixture|clearfixture> [args] | "
                          "dss <snapshot|reset|live> [pan] [args] | "
                          "dss inject [pan] <count> <firstPeakBin> <stepBin> "
                          "[native|kiwi [rowLowMhz rowHighMhz]] | "
@@ -248,6 +253,24 @@ def main():
             req = {"cmd": "scale"}
             if args.rest:
                 req["value"] = args.rest[0]
+
+        elif args.command == "hover":
+            if not args.rest:
+                sys.exit("error: hover needs <target> [leave]")
+            req = {"cmd": "hover", "target": args.rest[0]}
+            if len(args.rest) > 1:
+                req["action"] = args.rest[1]
+            print(json.dumps(bridge.request(req), indent=2))
+
+        elif args.command == "tooltip":
+            if not args.rest:
+                sys.exit("error: tooltip needs <target> [hide|text...]")
+            req = {"cmd": "tooltip", "target": args.rest[0]}
+            if len(args.rest) > 1:
+                if args.rest[1] == "hide" and len(args.rest) == 2:
+                    req["action"] = "hide"
+                else:
+                    req["value"] = " ".join(args.rest[1:])
             print(json.dumps(bridge.request(req), indent=2))
 
         elif args.command == "resize":


### PR DESCRIPTION
## Summary

Fix the RX Controls slice-letter tooltip so it uses the same mode-aware display letter as the visible slice badge. This covers the multi-client case where the radio-provided `index_letter` can differ from the global slice slot, and adds automation bridge support to reproduce the scenario without a live radio.

## Constitution principle honored

Principle VII — Untrusted Input Is Validated At The Boundary. The new automation fixture path rejects malformed slice fixture arguments instead of silently truncating them.

Principle XI — Fixes Are Demonstrated. The tooltip behavior is covered by a focused unit test and verified through the automation bridge.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR slice_label_test --parallel`)
- [x] Behavior verified on a real radio if applicable
  - Not applicable; the bug is reproduced with disconnected automation fixtures that exercise the normal slice-status/UI path.
- [ ] Existing tests pass (CI)
  - CI pending. Focused local test passed with `ctest --test-dir build -R '^slice_label_test$' --output-on-failure`.
- [x] Reproduction steps documented if user-reported bug
  - Automation bridge: `slice fixture 4 B` followed by `tooltip E` returns `Slice E (global slot 5)`.

Additional validation:
- `git rev-list --left-right --count HEAD...upstream/main` -> `0 0` before commit
- `git diff --check`
- `python3 tools/check_engine_boundary.py --strict`
- `python3 tools/check_a11y.py src/gui/RxApplet.cpp`
- `python3 tools/automation_probe.py --help`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
  - Not applicable.
