### PR TITLE
fix(spectrum): parse pan average/weighted_average + reconcile after profile load (#4001)

### DIFF
--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -303,6 +303,8 @@ void FlexBackend::decodePanState(const QString& panId,
     carry(kvs, "loopa", st);
     carry(kvs, "loopb", st);
     carry(kvs, "fps", st);
+    carry(kvs, "average", st);
+    carry(kvs, "weighted_average", st);
     carry(kvs, "pre", st);
     carry(kvs, "daxiq_channel", st);
     carry(kvs, "client_handle", st);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5244,6 +5244,32 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
         m_wfLineDurationReconcile.clear();
+        for (auto it = m_panAverageReconcileConnections.begin();
+             it != m_panAverageReconcileConnections.end(); ++it) {
+            QObject::disconnect(it.value());
+        }
+        m_panAverageReconcileConnections.clear();
+        for (auto it = m_panWeightedAvgReconcileConnections.begin();
+             it != m_panWeightedAvgReconcileConnections.end(); ++it) {
+            QObject::disconnect(it.value());
+        }
+        m_panWeightedAvgReconcileConnections.clear();
+        for (auto it = m_panAverageReconcile.begin();
+             it != m_panAverageReconcile.end(); ++it) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+        }
+        m_panAverageReconcile.clear();
+        for (auto it = m_panWeightedAvgReconcile.begin();
+             it != m_panWeightedAvgReconcile.end(); ++it) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+        }
+        m_panWeightedAvgReconcile.clear();
         m_adaptiveThrottleActive = false;
         m_adaptiveFpsCap = 0;  // clear cap alongside throttle flag — see #2829 review
 
@@ -6625,6 +6651,193 @@ void MainWindow::schedulePanFpsReconcile(const QString& panId, int reportedFps)
     state.timer->start();
 }
 
+void MainWindow::schedulePanAverageReconcile(const QString& panId, int reportedAverage)
+{
+    // FFT averaging is radio-authoritative (#4001): the firmware runs the
+    // averaging and echoes the level in pan status. After a global-profile /
+    // band switch the firmware adopts the profile's stored average, but the
+    // client never re-asserts the user's displayed level. Mirror the fps
+    // reconcile — reuse the profile-load write-hold + cooldown guards. Unlike
+    // fps, averaging is NOT adaptively throttled, so there is deliberately NO
+    // adaptive-throttle guard here. average=0 (off) is a VALID desired value, so
+    // guard on < 0 (the unknown sentinel), never <= 0.
+    if (panId.isEmpty() || reportedAverage < 0)
+        return;
+    if (profileLoadRadioStateWritesHeld()) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: average reconcile suppressed for profile load pan=" << panId
+            << " reported=" << reportedAverage;
+        return;
+    }
+
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan)
+        return;
+
+    auto& state = m_panAverageReconcile[panId];
+    if (!state.spectrum) {
+        if (auto* applet = m_panStack->panadapter(panId))
+            state.spectrum = applet->spectrumWidget();
+    }
+
+    auto* sw = state.spectrum.data();
+    if (!sw)
+        return;
+
+    const int desiredAverage = sw->fftAverage();
+    if (desiredAverage < 0)
+        return;
+    if (desiredAverage == reportedAverage) {
+        if (state.timer)
+            state.timer->stop();
+        state.lastSentMs = 0;
+        state.lastSentDesired = -1;
+        return;
+    }
+
+    if (!state.timer) {
+        state.timer = new QTimer(this);
+        state.timer->setSingleShot(true);
+        state.timer->setInterval(300);
+        connect(state.timer, &QTimer::timeout, this, [this, panId]() {
+            auto it = m_panAverageReconcile.find(panId);
+            if (it == m_panAverageReconcile.end())
+                return;
+
+            auto* pan = m_radioModel.panadapter(panId);
+            auto* sw = it->spectrum.data();
+            if (!sw) {
+                if (auto* applet = m_panStack->panadapter(panId)) {
+                    sw = applet->spectrumWidget();
+                    it->spectrum = sw;
+                }
+            }
+            if (!pan || !sw)
+                return;
+            if (profileLoadRadioStateWritesHeld()) {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: average timer suppressed for profile load pan=" << panId;
+                return;
+            }
+
+            const int reported = pan->average();
+            const int desired = sw->fftAverage();
+            if (reported < 0 || desired < 0 || reported == desired)
+                return;
+
+            constexpr qint64 kCooldownMs = 5000;
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            if (it->lastSentDesired == desired
+                && it->lastSentMs > 0
+                && now - it->lastSentMs < kCooldownMs) {
+                return;
+            }
+
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: reasserting panadapter average pan=" << panId
+                << " reported=" << reported
+                << " desired=" << desired;
+            m_radioModel.sendCommand(
+                QString("display pan set %1 average=%2").arg(panId).arg(desired));
+            it->lastSentMs = now;
+            it->lastSentDesired = desired;
+        });
+    }
+
+    state.timer->start();
+}
+
+void MainWindow::schedulePanWeightedAvgReconcile(const QString& panId, bool reportedWeighted)
+{
+    // weighted_average has the identical latent gap (#4001): a band switch via
+    // global profile adopts the profile's stored flag and the client never
+    // re-asserts the user's checkbox. Mirror the average reconcile; the wire
+    // field is a bool flag (weighted_average=0/1). No adaptive-throttle guard.
+    if (panId.isEmpty())
+        return;
+    if (profileLoadRadioStateWritesHeld()) {
+        qCDebug(lcProtocol).noquote().nospace()
+            << "MainWindow: weighted_average reconcile suppressed for profile load pan=" << panId
+            << " reported=" << reportedWeighted;
+        return;
+    }
+
+    auto* pan = m_radioModel.panadapter(panId);
+    if (!pan)
+        return;
+
+    auto& state = m_panWeightedAvgReconcile[panId];
+    if (!state.spectrum) {
+        if (auto* applet = m_panStack->panadapter(panId))
+            state.spectrum = applet->spectrumWidget();
+    }
+
+    auto* sw = state.spectrum.data();
+    if (!sw)
+        return;
+
+    const bool desiredWeighted = sw->fftWeightedAvg();
+    if (desiredWeighted == reportedWeighted) {
+        if (state.timer)
+            state.timer->stop();
+        state.lastSentMs = 0;
+        state.lastSentDesired = -1;
+        return;
+    }
+
+    if (!state.timer) {
+        state.timer = new QTimer(this);
+        state.timer->setSingleShot(true);
+        state.timer->setInterval(300);
+        connect(state.timer, &QTimer::timeout, this, [this, panId]() {
+            auto it = m_panWeightedAvgReconcile.find(panId);
+            if (it == m_panWeightedAvgReconcile.end())
+                return;
+
+            auto* pan = m_radioModel.panadapter(panId);
+            auto* sw = it->spectrum.data();
+            if (!sw) {
+                if (auto* applet = m_panStack->panadapter(panId)) {
+                    sw = applet->spectrumWidget();
+                    it->spectrum = sw;
+                }
+            }
+            if (!pan || !sw)
+                return;
+            if (profileLoadRadioStateWritesHeld()) {
+                qCDebug(lcProtocol).noquote().nospace()
+                    << "MainWindow: weighted_average timer suppressed for profile load pan=" << panId;
+                return;
+            }
+
+            const bool reported = pan->weightedAverage();
+            const bool desired = sw->fftWeightedAvg();
+            if (reported == desired)
+                return;
+
+            constexpr qint64 kCooldownMs = 5000;
+            const qint64 now = QDateTime::currentMSecsSinceEpoch();
+            const int desiredInt = desired ? 1 : 0;
+            if (it->lastSentDesired == desiredInt
+                && it->lastSentMs > 0
+                && now - it->lastSentMs < kCooldownMs) {
+                return;
+            }
+
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: reasserting panadapter weighted_average pan=" << panId
+                << " reported=" << reported
+                << " desired=" << desired;
+            m_radioModel.sendCommand(
+                QString("display pan set %1 weighted_average=%2").arg(panId).arg(desiredInt));
+            it->lastSentMs = now;
+            it->lastSentDesired = desiredInt;
+        });
+    }
+
+    state.timer->start();
+}
+
 void MainWindow::scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs)
 {
     if (panId.isEmpty() || reportedMs <= 0)
@@ -6761,6 +6974,36 @@ void MainWindow::wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* p
         }));
     scheduleWaterfallLineDurationReconcile(applet->panId(),
                                            pan->waterfallLineDuration());
+
+    auto oldAverageConnection =
+        m_panAverageReconcileConnections.take(applet->panId());
+    if (oldAverageConnection)
+        QObject::disconnect(oldAverageConnection);
+
+    auto& averageState = m_panAverageReconcile[applet->panId()];
+    averageState.spectrum = sw;
+    m_panAverageReconcileConnections.insert(
+        applet->panId(),
+        connect(pan, &PanadapterModel::averageReported,
+                this, [this, panId = applet->panId()](int average) {
+            schedulePanAverageReconcile(panId, average);
+        }));
+    schedulePanAverageReconcile(applet->panId(), pan->average());
+
+    auto oldWeightedAvgConnection =
+        m_panWeightedAvgReconcileConnections.take(applet->panId());
+    if (oldWeightedAvgConnection)
+        QObject::disconnect(oldWeightedAvgConnection);
+
+    auto& weightedAvgState = m_panWeightedAvgReconcile[applet->panId()];
+    weightedAvgState.spectrum = sw;
+    m_panWeightedAvgReconcileConnections.insert(
+        applet->panId(),
+        connect(pan, &PanadapterModel::weightedAverageReported,
+                this, [this, panId = applet->panId()](bool weighted) {
+            schedulePanWeightedAvgReconcile(panId, weighted);
+        }));
+    schedulePanWeightedAvgReconcile(applet->panId(), pan->weightedAverage());
 }
 
 // wirePanadapter() / revealFrequencyIfNeeded() / panFollowVfo() / wireVfoWidget() lives in MainWindow_Wiring.cpp (#3351 Phase 1d).

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -438,6 +438,8 @@ private:
     void wirePanadapter(PanadapterApplet* applet);
     void wirePanReconcilers(PanadapterApplet* applet, PanadapterModel* pan);
     void schedulePanFpsReconcile(const QString& panId, int reportedFps);
+    void schedulePanAverageReconcile(const QString& panId, int reportedAverage);
+    void schedulePanWeightedAvgReconcile(const QString& panId, bool reportedWeighted);
     void scheduleWaterfallLineDurationReconcile(const QString& panId, int reportedMs);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
     void onMuteAllSlicesToggle();
@@ -1132,6 +1134,26 @@ private:
     };
     QHash<QString, PanFpsReconcileState> m_panFpsReconcile;
     QHash<QString, QMetaObject::Connection> m_panFpsReconcileConnections;
+    // FFT averaging reconcile (#4001) — mirrors the fps reconcile so a global
+    // profile / band switch that adopts the profile's stored average/weighted
+    // value gets the user's desired value re-asserted once the write-hold
+    // releases. Averaging is NOT adaptively throttled, so no throttle guard.
+    struct PanAverageReconcileState {
+        QTimer* timer{nullptr};
+        QPointer<SpectrumWidget> spectrum;
+        qint64 lastSentMs{0};
+        int lastSentDesired{-1};
+    };
+    QHash<QString, PanAverageReconcileState> m_panAverageReconcile;
+    QHash<QString, QMetaObject::Connection> m_panAverageReconcileConnections;
+    struct PanWeightedAvgReconcileState {
+        QTimer* timer{nullptr};
+        QPointer<SpectrumWidget> spectrum;
+        qint64 lastSentMs{0};
+        int lastSentDesired{-1};   // 0/1 last-sent weighted_average flag
+    };
+    QHash<QString, PanWeightedAvgReconcileState> m_panWeightedAvgReconcile;
+    QHash<QString, QMetaObject::Connection> m_panWeightedAvgReconcileConnections;
     bool m_adaptiveThrottleActive{false}; // fps/wf reconcile suppressed while true
     int  m_adaptiveFpsCap{0};             // current cap (> 0 when throttle active); shown in network label
     struct WaterfallLineDurationReconcileState {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1366,6 +1366,32 @@ void MainWindow::wirePanLifecycle()
             }
             m_wfLineDurationReconcile.erase(it);
         }
+        if (auto it = m_panAverageReconcileConnections.find(panId);
+            it != m_panAverageReconcileConnections.end()) {
+            QObject::disconnect(it.value());
+            m_panAverageReconcileConnections.erase(it);
+        }
+        if (auto it = m_panWeightedAvgReconcileConnections.find(panId);
+            it != m_panWeightedAvgReconcileConnections.end()) {
+            QObject::disconnect(it.value());
+            m_panWeightedAvgReconcileConnections.erase(it);
+        }
+        if (auto it = m_panAverageReconcile.find(panId);
+            it != m_panAverageReconcile.end()) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+            m_panAverageReconcile.erase(it);
+        }
+        if (auto it = m_panWeightedAvgReconcile.find(panId);
+            it != m_panWeightedAvgReconcile.end()) {
+            if (it->timer) {
+                it->timer->stop();
+                it->timer->deleteLater();
+            }
+            m_panWeightedAvgReconcile.erase(it);
+        }
 
         // Disconnect all signals from the dying applet's widgets to prevent
         // dangling pointer crashes in wirePanadapter lambdas (#242)

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -207,6 +207,32 @@ void PanadapterModel::applyStateExtension(const QVariantMap& fields)
             emit fpsReported(fps);
         }
     }
+    // Averaging is radio-authoritative: parse the level the firmware echoes back
+    // and re-emit it so MainWindow can reconcile the user's desired value after a
+    // global-profile / band switch (#4001). average=0 (off) is a valid value —
+    // the ok-guard rejects only a malformed field, exactly like fps.
+    if (fields.contains(QStringLiteral("average"))) {
+        bool ok = false;
+        const int average = fields.value(QStringLiteral("average")).toInt(&ok);
+        if (ok) {
+            if (average != m_average) {
+                m_average = average;
+                emit averageChanged(m_average);
+            }
+            emit averageReported(average);
+        }
+    }
+    // weighted_average is a bool flag on the wire (weighted_average=0/1) — same
+    // latent desync gap; parse it like the loopa/loopb flags (present-only).
+    if (fields.contains(QStringLiteral("weighted_average"))) {
+        const bool weighted =
+            fields.value(QStringLiteral("weighted_average")).toInt() != 0;
+        if (weighted != m_weightedAverage) {
+            m_weightedAverage = weighted;
+            emit weightedAverageChanged(m_weightedAverage);
+        }
+        emit weightedAverageReported(weighted);
+    }
     if (fields.contains(QStringLiteral("pre"))) {
         const QString pre = fields.value(QStringLiteral("pre")).toString();
         // Preamp is internal state only — no UI listeners, no emit (#1498).

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -77,6 +77,8 @@ public:
     bool loopA() const { return m_loopA; }
     bool loopB() const { return m_loopB; }
     int fps() const { return m_fps; }
+    int average() const { return m_average; }
+    bool weightedAverage() const { return m_weightedAverage; }
     int waterfallLineDuration() const { return m_waterfallLineDuration; }
     // Normalized waterfall-line-duration setter driven by the backend (universal
     // display timing). Feeds PerfTelemetry and always emits
@@ -128,6 +130,14 @@ signals:
     void loopChanged(bool loopA, bool loopB);
     void fpsChanged(int fps);
     void fpsReported(int fps);
+    // Averaging is radio-authoritative (firmware runs it, echoes the level in
+    // pan status). Reported fires every status cycle; Changed only on an actual
+    // change — mirrors the fps pair so MainWindow can reconcile after a
+    // global-profile / band switch adopts the profile's stored value (#4001).
+    void averageChanged(int average);
+    void averageReported(int average);
+    void weightedAverageChanged(bool weighted);
+    void weightedAverageReported(bool weighted);
     void waterfallLineDurationChanged(int ms);
     void waterfallLineDurationReported(int ms);
     void waterfallIdChanged(const QString& wfId);
@@ -155,6 +165,8 @@ private:
     bool        m_loopB{false};
     int         m_wnbLevel{50};
     int         m_fps{-1};
+    int         m_average{-1};        // -1 = unknown; 0 = off, 1-N = level (#4001)
+    bool        m_weightedAverage{false};
     int         m_waterfallLineDuration{-1};
     int         m_fftYPixels{-1};
     QString     m_preamp;


### PR DESCRIPTION
## Summary
FFT frame averaging is radio-authoritative: the client sends `display pan set <pan> average=<N>` and the firmware
does the averaging. The pan-status decode path parsed `fps` (and gave it a reconcile loop) but silently dropped the
`average` / `weighted_average` fields that upstream FlexLib parses. After a global-profile / band switch the firmware
adopts the profile’s stored averaging while the overlay slider keeps showing the user’s preference — the two desync
until the slider is nudged. This restores the dropped fields end-to-end and mirrors the existing `fps` reconcile so
the client re-asserts the user’s value once the profile-load write-hold releases.

## Why
- `average` / `weighted_average` were never carried through `FlexBackend::decodePanState` nor parsed in
  `PanadapterModel::applyStateExtension()` — no `m_average` member, no reported signal.
- Only `fps` had a reconcile loop, so global-profile loads left the averaging slider out of sync with the firmware.
- User-visible: switch bands via a global preference and the FFT AVG display no longer matches what the radio runs.

## Scope
- `FlexBackend.cpp`: carry `average` / `weighted_average` from pan status into the namespaced state bundle (they were
  dropped before the model ever saw them).
- `PanadapterModel.{h,cpp}`: parse both fields in `applyStateExtension()`; add members/accessors +
  `…Changed`/`…Reported` signals, following the `fps` pattern exactly.
- `MainWindow.{h,cpp}` + `MainWindow_Session.cpp`: add `average` / `weighted-average` reconcilers in
  `wirePanReconcilers()` mirroring the fps reconcile (same 300 ms debounce, 5 s cooldown, and
  `profileLoadRadioStateWritesHeld()` write-hold guard; **no** adaptive-throttle guard — averaging isn’t throttled;
  `< 0` unknown-sentinel guard so `average=0` / off is a valid desired value), with matching teardown at every fps
  management site.
- No protocol/firmware change; restores fields FlexLib already handles.

## Constitution principle honored
Principle I (FlexLib is protocol authority): restores pan-status fields that upstream FlexLib parses, bringing the
clean-room client back into fidelity with the wire protocol.

## Test plan
- [x] Local incremental `ninja -C build` clean on Linux (Nobara, Qt 6.10.x).
- [x] Live on a FLEX-6700: set FFT AVG on 40m, switched bands via a global profile and back — the slider now
      re-asserts and stays in sync (no desync; the nudge-to-fix workaround is no longer needed). Weighted-average
      checkbox likewise stays in sync.
- Known behavior: on a profile switch the FFT briefly renders at the profile’s averaging rate for the
  reconcile-latency window (profile-load write-hold + debounce) before snapping back to the user’s value. This is
  intentional and identical to the existing `fps` reconcile — the write-hold deliberately avoids fighting the profile
  load mid-flight.

## Checklist
- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II) — N/A; this change touches no meter UI.

Closes #4001

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-opus-4-8)