### PR TITLE
Preserve RX DSP stereo balance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2085,6 +2085,12 @@ target_include_directories(mono_dsp_stereo_adapter_test PRIVATE src)
 target_link_libraries(mono_dsp_stereo_adapter_test PRIVATE Qt6::Core)
 add_test(NAME mono_dsp_stereo_adapter_test COMMAND mono_dsp_stereo_adapter_test)
 
+add_executable(rnnoise_filter_test
+    tests/rnnoise_filter_test.cpp
+)
+target_link_libraries(rnnoise_filter_test PRIVATE aethercore Qt6::Core)
+add_test(NAME rnnoise_filter_test COMMAND rnnoise_filter_test)
+
 add_executable(adaptive_filter_test
     tests/adaptive_filter_test.cpp
     src/core/OccupiedRegion.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,7 @@ set(CORE_SOURCES
     src/core/CwxLocalKeyer.cpp
     src/core/IambicKeyer.cpp
     src/core/SpectralNR.cpp
+    src/core/MonoDspStereoAdapter.cpp
     src/core/PanadapterStream.cpp
     src/core/PacketLossConcealment.cpp
     src/core/PerfTelemetry.cpp
@@ -2074,6 +2075,14 @@ add_executable(spectral_nr_test
 target_include_directories(spectral_nr_test PRIVATE src)
 target_link_libraries(spectral_nr_test PRIVATE Qt6::Core)
 add_test(NAME spectral_nr_test COMMAND spectral_nr_test)
+
+add_executable(mono_dsp_stereo_adapter_test
+    tests/mono_dsp_stereo_adapter_test.cpp
+    src/core/MonoDspStereoAdapter.cpp
+)
+target_include_directories(mono_dsp_stereo_adapter_test PRIVATE src)
+target_link_libraries(mono_dsp_stereo_adapter_test PRIVATE Qt6::Core)
+add_test(NAME mono_dsp_stereo_adapter_test COMMAND mono_dsp_stereo_adapter_test)
 
 add_executable(adaptive_filter_test
     tests/adaptive_filter_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1960,6 +1960,7 @@ if(ENABLE_NVIDIA_AFX AND ((UNIX AND NOT APPLE) OR WIN32) AND CMAKE_SYSTEM_PROCES
     add_executable(nvidia_afx_filter_test
         tests/nvidia_afx_filter_test.cpp
         src/core/NvidiaAfxFilter.cpp
+        src/core/MonoDspStereoAdapter.cpp
         src/core/Resampler.cpp
     )
     target_compile_definitions(nvidia_afx_filter_test PRIVATE HAVE_NVIDIA_AFX)

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -64,6 +64,7 @@
 #include <QJsonObject>
 #include <QStringList>
 #include <QtGlobal>
+#include <QtConcurrent/QtConcurrentRun>
 #include <algorithm>
 #include <cstring>
 #include <functional>
@@ -75,11 +76,16 @@ static QString wisdomDir();
 static void logNr2WisdomSummary(const QString& context);
 static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result);
 static void applyNr2SettingsFromAppSettings(SpectralNR& nr2);
+static void copyNr2Settings(const SpectralNR& source, SpectralNR& target);
 #ifdef HAVE_SPECBLEACH
 static void applyNr4SettingsFromAppSettings(SpecbleachFilter& nr4);
+static void copyNr4Settings(const SpecbleachFilter& source,
+                            SpecbleachFilter& target);
 #endif
 #ifdef HAVE_DFNR
 static void applyDfnrSettingsFromAppSettings(DeepFilterFilter& dfnr);
+static void copyDfnrSettings(const DeepFilterFilter& source,
+                             DeepFilterFilter& target);
 #endif
 
 namespace {
@@ -978,7 +984,6 @@ AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
         id, m_externalKiwiReceivePresentationDelaySourceId,
         m_externalKiwiReceivePresentationDelayMs);
     source->prebuffering = true;
-    ensureExternalKiwiSourceDspState(*source);
     m_externalKiwiSources.push_back(std::move(source));
     return m_externalKiwiSources.back().get();
 }
@@ -1005,7 +1010,6 @@ AudioEngine::createNr4Filter(const QString& label) const
             << "AudioEngine: NR4 initialization failed for" << label;
         return {};
     }
-    applyNr4SettingsFromAppSettings(*filter);
     return filter;
 }
 #endif
@@ -1035,7 +1039,6 @@ AudioEngine::createDfnrFilter(const QString& label) const
             << "AudioEngine: DFNR df_create() failed for" << label;
         return {};
     }
-    applyDfnrSettingsFromAppSettings(*filter);
     return filter;
 }
 #endif
@@ -1051,125 +1054,405 @@ AudioEngine::createNvAfxFilter(const QString& label) const
             << "-" << filter->lastError();
         return {};
     }
-    filter->setIntensity(NvidiaBnrSettings::intensity());
     return filter;
 }
 #endif
 
 bool AudioEngine::ensureLegacyKiwiDspState()
 {
-    if (!kiwiSdrAudioActive()) {
-        return true;
+    quint64 configurationGeneration = 0;
+    bool needNr2 = false;
+    bool needRn2 = false;
+#ifdef HAVE_SPECBLEACH
+    bool needNr4 = false;
+#endif
+#ifdef __APPLE__
+    bool needMnr = false;
+#endif
+#ifdef HAVE_DFNR
+    bool needDfnr = false;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    bool needNvAfx = false;
+#endif
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+        if (!kiwiSdrAudioActive() || m_legacyKiwiDspInitializationPending) {
+            return true;
+        }
+        needNr2 = m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
+            && !m_kiwiSdrNr2;
+        needRn2 = m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
+            && !m_kiwiSdrRn2;
+#ifdef HAVE_SPECBLEACH
+        needNr4 = m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
+            && !m_kiwiSdrNr4;
+#endif
+#ifdef __APPLE__
+        needMnr = m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
+            && !m_kiwiSdrMnr;
+#endif
+#ifdef HAVE_DFNR
+        needDfnr = m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
+            && !m_kiwiSdrDfnr;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        needNvAfx = m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
+            && !m_kiwiSdrNvAfx;
+#endif
+        m_legacyKiwiDspInitializationPending = needNr2 || needRn2
+#ifdef HAVE_SPECBLEACH
+            || needNr4
+#endif
+#ifdef __APPLE__
+            || needMnr
+#endif
+#ifdef HAVE_DFNR
+            || needDfnr
+#endif
+#ifdef HAVE_NVIDIA_AFX
+            || needNvAfx
+#endif
+            ;
+        if (!m_legacyKiwiDspInitializationPending) {
+            return true;
+        }
+        configurationGeneration = m_dspConfigurationGeneration;
     }
 
     bool ok = true;
-    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
-        && !m_kiwiSdrNr2) {
-        m_kiwiSdrNr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (m_kiwiSdrNr2->hasPlanFailed()) {
+    std::unique_ptr<SpectralNR> nr2;
+    std::unique_ptr<RNNoiseFilter> rn2;
+#ifdef HAVE_SPECBLEACH
+    std::unique_ptr<SpecbleachFilter> nr4;
+#endif
+#ifdef __APPLE__
+    std::unique_ptr<MacNRFilter> mnr;
+#endif
+#ifdef HAVE_DFNR
+    std::unique_ptr<DeepFilterFilter> dfnr;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    std::unique_ptr<NvidiaAfxFilter> nvAfx;
+#endif
+
+    if (needNr2) {
+        nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (nr2->hasPlanFailed()) {
             qCWarning(lcAudio)
                 << "AudioEngine: legacy Kiwi NR2 plan failed";
-            m_kiwiSdrNr2.reset();
+            nr2.reset();
             ok = false;
-        } else {
-            applyNr2SettingsFromAppSettings(*m_kiwiSdrNr2);
         }
     }
-    if (m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
-        && !m_kiwiSdrRn2) {
-        m_kiwiSdrRn2 = createRn2Filter(QStringLiteral("legacy Kiwi"));
-        ok = ok && static_cast<bool>(m_kiwiSdrRn2);
+    if (needRn2) {
+        rn2 = createRn2Filter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(rn2);
     }
 #ifdef HAVE_SPECBLEACH
-    if (m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
-        && !m_kiwiSdrNr4) {
-        m_kiwiSdrNr4 = createNr4Filter(QStringLiteral("legacy Kiwi"));
-        ok = ok && static_cast<bool>(m_kiwiSdrNr4);
+    if (needNr4) {
+        nr4 = createNr4Filter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(nr4);
     }
 #endif
 #ifdef __APPLE__
-    if (m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
-        && !m_kiwiSdrMnr) {
-        m_kiwiSdrMnr = createMnrFilter(QStringLiteral("legacy Kiwi"));
-        ok = ok && static_cast<bool>(m_kiwiSdrMnr);
+    if (needMnr) {
+        mnr = createMnrFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(mnr);
     }
 #endif
 #ifdef HAVE_DFNR
-    if (m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
-        && !m_kiwiSdrDfnr) {
-        m_kiwiSdrDfnr = createDfnrFilter(QStringLiteral("legacy Kiwi"));
-        ok = ok && static_cast<bool>(m_kiwiSdrDfnr);
+    if (needDfnr) {
+        dfnr = createDfnrFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(dfnr);
     }
 #endif
 #ifdef HAVE_NVIDIA_AFX
-    if (m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
-        && !m_kiwiSdrNvAfx) {
-        m_kiwiSdrNvAfx = createNvAfxFilter(QStringLiteral("legacy Kiwi"));
-        ok = ok && static_cast<bool>(m_kiwiSdrNvAfx);
+    if (needNvAfx) {
+        nvAfx = createNvAfxFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(nvAfx);
     }
 #endif
+
+    bool retryForNewConfiguration = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+        m_legacyKiwiDspInitializationPending = false;
+        if (!kiwiSdrAudioActive()) {
+            return ok;
+        }
+        if (needNr2 && m_nr2Enabled && m_nr2 && !m_kiwiSdrNr2) {
+            if (nr2) {
+                copyNr2Settings(*m_nr2, *nr2);
+            }
+            m_kiwiSdrNr2 = std::move(nr2);
+        }
+        if (needRn2 && m_rn2Enabled && m_rn2 && !m_kiwiSdrRn2) {
+            m_kiwiSdrRn2 = std::move(rn2);
+        }
+#ifdef HAVE_SPECBLEACH
+        if (needNr4 && m_nr4Enabled && m_nr4 && !m_kiwiSdrNr4) {
+            if (nr4) {
+                copyNr4Settings(*m_nr4, *nr4);
+            }
+            m_kiwiSdrNr4 = std::move(nr4);
+        }
+#endif
+#ifdef __APPLE__
+        if (needMnr && m_mnrEnabled && m_mnr && !m_kiwiSdrMnr) {
+            if (mnr) {
+                mnr->setStrength(m_mnrStrength.load());
+            }
+            m_kiwiSdrMnr = std::move(mnr);
+        }
+#endif
+#ifdef HAVE_DFNR
+        if (needDfnr && m_dfnrEnabled && m_dfnr && !m_kiwiSdrDfnr) {
+            if (dfnr) {
+                copyDfnrSettings(*m_dfnr, *dfnr);
+            }
+            m_kiwiSdrDfnr = std::move(dfnr);
+        }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        if (needNvAfx && m_nvAfxEnabled && m_nvAfx && !m_kiwiSdrNvAfx) {
+            if (nvAfx) {
+                nvAfx->setIntensity(m_nvAfx->intensity());
+            }
+            m_kiwiSdrNvAfx = std::move(nvAfx);
+        }
+#endif
+        retryForNewConfiguration =
+            configurationGeneration != m_dspConfigurationGeneration;
+    }
+    if (retryForNewConfiguration) {
+        ok = ensureLegacyKiwiDspState() && ok;
+    }
     return ok;
 }
 
 bool AudioEngine::ensureExternalKiwiSourceDspState(
-    ExternalRxAudioSourceState& source)
+    const QString& sourceId)
 {
-    if (!externalKiwiSourceAudible(source)) {
-        return true;
+    quint64 configurationGeneration = 0;
+    const QString id = sourceId.trimmed();
+    if (id.isEmpty()) {
+        return false;
+    }
+
+    const auto findSource = [this, &id]() -> ExternalRxAudioSourceState* {
+        for (const auto& candidate : m_externalKiwiSources) {
+            if (candidate && candidate->id == id) {
+                return candidate.get();
+            }
+        }
+        return nullptr;
+    };
+
+    bool needNr2 = false;
+    bool needRn2 = false;
+#ifdef HAVE_SPECBLEACH
+    bool needNr4 = false;
+#endif
+#ifdef __APPLE__
+    bool needMnr = false;
+#endif
+#ifdef HAVE_DFNR
+    bool needDfnr = false;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    bool needNvAfx = false;
+#endif
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+        ExternalRxAudioSourceState* source = findSource();
+        if (!source || !externalKiwiSourceAudible(*source)
+            || source->dspInitializationPending) {
+            return true;
+        }
+        needNr2 = m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
+            && !source->nr2;
+        needRn2 = m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
+            && !source->rn2;
+#ifdef HAVE_SPECBLEACH
+        needNr4 = m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
+            && !source->nr4;
+#endif
+#ifdef __APPLE__
+        needMnr = m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
+            && !source->mnr;
+#endif
+#ifdef HAVE_DFNR
+        needDfnr = m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
+            && !source->dfnr;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        needNvAfx = m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
+            && !source->nvAfx;
+#endif
+        source->dspInitializationPending = needNr2 || needRn2
+#ifdef HAVE_SPECBLEACH
+            || needNr4
+#endif
+#ifdef __APPLE__
+            || needMnr
+#endif
+#ifdef HAVE_DFNR
+            || needDfnr
+#endif
+#ifdef HAVE_NVIDIA_AFX
+            || needNvAfx
+#endif
+            ;
+        if (!source->dspInitializationPending) {
+            return true;
+        }
+        configurationGeneration = m_dspConfigurationGeneration;
     }
 
     bool ok = true;
-    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
-        && !source.nr2) {
-        source.nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (source.nr2->hasPlanFailed()) {
+    std::unique_ptr<SpectralNR> nr2;
+    std::unique_ptr<RNNoiseFilter> rn2;
+#ifdef HAVE_SPECBLEACH
+    std::unique_ptr<SpecbleachFilter> nr4;
+#endif
+#ifdef __APPLE__
+    std::unique_ptr<MacNRFilter> mnr;
+#endif
+#ifdef HAVE_DFNR
+    std::unique_ptr<DeepFilterFilter> dfnr;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    std::unique_ptr<NvidiaAfxFilter> nvAfx;
+#endif
+
+    if (needNr2) {
+        nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (nr2->hasPlanFailed()) {
             qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
-                               << source.id;
-            source.nr2.reset();
+                               << id;
+            nr2.reset();
             ok = false;
-        } else {
-            applyNr2SettingsFromAppSettings(*source.nr2);
         }
     }
-    if (m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
-        && !source.rn2) {
-        source.rn2 = createRn2Filter(
-            QStringLiteral("external Kiwi %1").arg(source.id));
-        ok = ok && static_cast<bool>(source.rn2);
+    if (needRn2) {
+        rn2 = createRn2Filter(QStringLiteral("external Kiwi %1").arg(id));
+        ok = ok && static_cast<bool>(rn2);
     }
 #ifdef HAVE_SPECBLEACH
-    if (m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
-        && !source.nr4) {
-        source.nr4 = createNr4Filter(
-            QStringLiteral("external Kiwi %1").arg(source.id));
-        ok = ok && static_cast<bool>(source.nr4);
+    if (needNr4) {
+        nr4 = createNr4Filter(QStringLiteral("external Kiwi %1").arg(id));
+        ok = ok && static_cast<bool>(nr4);
     }
 #endif
 #ifdef __APPLE__
-    if (m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
-        && !source.mnr) {
-        source.mnr = createMnrFilter(
-            QStringLiteral("external Kiwi %1").arg(source.id));
-        ok = ok && static_cast<bool>(source.mnr);
+    if (needMnr) {
+        mnr = createMnrFilter(QStringLiteral("external Kiwi %1").arg(id));
+        ok = ok && static_cast<bool>(mnr);
     }
 #endif
 #ifdef HAVE_DFNR
-    if (m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
-        && !source.dfnr) {
-        source.dfnr = createDfnrFilter(
-            QStringLiteral("external Kiwi %1").arg(source.id));
-        ok = ok && static_cast<bool>(source.dfnr);
+    if (needDfnr) {
+        dfnr = createDfnrFilter(QStringLiteral("external Kiwi %1").arg(id));
+        ok = ok && static_cast<bool>(dfnr);
     }
 #endif
 #ifdef HAVE_NVIDIA_AFX
-    if (m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
-        && !source.nvAfx) {
-        source.nvAfx = createNvAfxFilter(
-            QStringLiteral("external Kiwi %1").arg(source.id));
-        ok = ok && static_cast<bool>(source.nvAfx);
+    if (needNvAfx) {
+        nvAfx = createNvAfxFilter(QStringLiteral("external Kiwi %1").arg(id));
+        ok = ok && static_cast<bool>(nvAfx);
     }
 #endif
+
+    bool retryForNewConfiguration = false;
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+        ExternalRxAudioSourceState* source = findSource();
+        if (!source) {
+            return ok;
+        }
+        source->dspInitializationPending = false;
+        if (!externalKiwiSourceAudible(*source)) {
+            return ok;
+        }
+        if (needNr2 && m_nr2Enabled && m_nr2 && !source->nr2) {
+            if (nr2) {
+                copyNr2Settings(*m_nr2, *nr2);
+            }
+            source->nr2 = std::move(nr2);
+        }
+        if (needRn2 && m_rn2Enabled && m_rn2 && !source->rn2) {
+            source->rn2 = std::move(rn2);
+        }
+#ifdef HAVE_SPECBLEACH
+        if (needNr4 && m_nr4Enabled && m_nr4 && !source->nr4) {
+            if (nr4) {
+                copyNr4Settings(*m_nr4, *nr4);
+            }
+            source->nr4 = std::move(nr4);
+        }
+#endif
+#ifdef __APPLE__
+        if (needMnr && m_mnrEnabled && m_mnr && !source->mnr) {
+            if (mnr) {
+                mnr->setStrength(m_mnrStrength.load());
+            }
+            source->mnr = std::move(mnr);
+        }
+#endif
+#ifdef HAVE_DFNR
+        if (needDfnr && m_dfnrEnabled && m_dfnr && !source->dfnr) {
+            if (dfnr) {
+                copyDfnrSettings(*m_dfnr, *dfnr);
+            }
+            source->dfnr = std::move(dfnr);
+        }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        if (needNvAfx && m_nvAfxEnabled && m_nvAfx && !source->nvAfx) {
+            if (nvAfx) {
+                nvAfx->setIntensity(m_nvAfx->intensity());
+            }
+            source->nvAfx = std::move(nvAfx);
+        }
+#endif
+        retryForNewConfiguration =
+            configurationGeneration != m_dspConfigurationGeneration;
+    }
+    if (retryForNewConfiguration) {
+        ok = ensureExternalKiwiSourceDspState(id) && ok;
+    }
     return ok;
+}
+
+bool AudioEngine::ensureAllKiwiDspState()
+{
+    bool ok = ensureLegacyKiwiDspState();
+    QStringList sourceIds;
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+        for (const auto& source : m_externalKiwiSources) {
+            if (source && externalKiwiSourceAudible(*source)) {
+                sourceIds.append(source->id);
+            }
+        }
+    }
+    for (const QString& sourceId : sourceIds) {
+        ok = ensureExternalKiwiSourceDspState(sourceId) && ok;
+    }
+    return ok;
+}
+
+void AudioEngine::scheduleAllKiwiDspStateInitialization()
+{
+    std::lock_guard<std::mutex> lock(m_dspInitializationTasksMutex);
+    if (m_dspInitializationStopping) {
+        return;
+    }
+    QFuture<void> task = QtConcurrent::run([this]() {
+        ensureAllKiwiDspState();
+    });
+    m_dspInitializationTasks.addFuture(task);
 }
 
 void AudioEngine::resetLegacyKiwiDspState()
@@ -2138,6 +2421,11 @@ AudioEngine::AudioEngine(QObject* parent)
 
 AudioEngine::~AudioEngine()
 {
+    {
+        std::lock_guard<std::mutex> lock(m_dspInitializationTasksMutex);
+        m_dspInitializationStopping = true;
+        m_dspInitializationTasks.waitForFinished();
+    }
     stopRxStream();
     stopTxStream();
 }
@@ -2508,16 +2796,26 @@ QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
     tokenText.replace(QLatin1Char(','), QLatin1Char(' '));
     const QStringList requestTokens =
         tokenText.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    QString normalizedMode = QStringLiteral("ALL");
+    QStringList modeTokens;
     bool strictCoverage = false;
     for (const QString& token : requestTokens) {
         const QString normalizedToken = token.toUpper();
         if (normalizedToken == QLatin1String("STRICT")) {
             strictCoverage = true;
-        } else if (normalizedMode == QLatin1String("ALL")) {
-            normalizedMode = normalizedToken;
+        } else {
+            modeTokens.append(normalizedToken);
         }
     }
+    if (modeTokens.size() > 1) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("probeDspStereo accepts one mode or all, plus optional strict")},
+        };
+    }
+    const QString normalizedMode = modeTokens.isEmpty()
+        ? QStringLiteral("ALL")
+        : modeTokens.constFirst();
 
     const auto probeOne = [this, &input](const QString& requestedMode) -> QJsonObject {
         if (requestedMode == QLatin1String("NR2")) {
@@ -3383,6 +3681,7 @@ void AudioEngine::feedKiwiSdrAudioData(const QByteArray& pcm24kStereoFloat)
 void AudioEngine::feedKiwiSdrAudioData(const QString& sourceId,
                                        const QByteArray& pcm24kStereoFloat)
 {
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
     ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
     if (!source || !source->enabled) {
         return;
@@ -3424,49 +3723,53 @@ void AudioEngine::setKiwiSdrAudioEnabled(bool on)
         return;
     }
 
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-    m_kiwiSdrRxBuffer.clear();
-    m_kiwiSdrRxPackets.clear();
-    m_kiwiSdrOutputBuffer.clear();
-    m_kiwiSdrNr2Output.clear();
-    m_kiwiSdrRxResampler.reset();
-    m_kiwiSdrRxResamplerR.reset();
-    if (on) {
-        ensureLegacyKiwiDspState();
-        resetLegacyKiwiDspState();
-    } else {
-        clearLegacyKiwiDspState();
+    {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        m_kiwiSdrRxBuffer.clear();
+        m_kiwiSdrRxPackets.clear();
+        m_kiwiSdrOutputBuffer.clear();
+        m_kiwiSdrNr2Output.clear();
+        m_kiwiSdrRxResampler.reset();
+        m_kiwiSdrRxResamplerR.reset();
+        if (!on) {
+            clearLegacyKiwiDspState();
+        }
+        m_kiwiSdrPrebuffering.store(on && !kiwiSdrAudioTransmitMuted(),
+                                    std::memory_order_relaxed);
+        updateRxBufferStats();
     }
-    m_kiwiSdrPrebuffering.store(on && !kiwiSdrAudioTransmitMuted(),
-                                std::memory_order_relaxed);
-    updateRxBufferStats();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
 }
 
 void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
 {
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, on);
-    if (!source || source->enabled == on) {
-        return;
-    }
+    {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, on);
+        if (!source || source->enabled == on) {
+            return;
+        }
 
-    source->enabled = on;
-    qCDebug(lcKiwiSdrAudio).noquote()
-        << "Audio source" << (on ? "enabled" : "disabled") << source->id;
-    source->rxBuffer.clear();
-    source->rxPackets.clear();
-    source->outputBuffer.clear();
-    source->nr2Output.clear();
-    source->rxResampler.reset();
-    source->rxResamplerR.reset();
-    if (on) {
-        ensureExternalKiwiSourceDspState(*source);
-        resetExternalKiwiDspState(*source);
-    } else {
-        clearExternalKiwiDspState(*source);
+        source->enabled = on;
+        qCDebug(lcKiwiSdrAudio).noquote()
+            << "Audio source" << (on ? "enabled" : "disabled") << source->id;
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Output.clear();
+        source->rxResampler.reset();
+        source->rxResamplerR.reset();
+        if (!on) {
+            clearExternalKiwiDspState(*source);
+        }
+        source->prebuffering = on;
+        updateRxBufferStats();
     }
-    source->prebuffering = on;
-    updateRxBufferStats();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
 }
 
 void AudioEngine::setKiwiSdrAudioSourceGain(const QString& sourceId,
@@ -3484,24 +3787,28 @@ void AudioEngine::setKiwiSdrAudioSourceGain(const QString& sourceId,
 void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
                                              bool muted)
 {
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
-    if (!source || source->muted == muted) {
-        return;
-    }
+    {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+        if (!source || source->muted == muted) {
+            return;
+        }
 
-    source->muted = muted;
-    source->rxBuffer.clear();
-    source->rxPackets.clear();
-    source->outputBuffer.clear();
-    source->nr2Output.clear();
-    if (!muted) {
-        ensureExternalKiwiSourceDspState(*source);
+        source->muted = muted;
+        source->rxBuffer.clear();
+        source->rxPackets.clear();
+        source->outputBuffer.clear();
+        source->nr2Output.clear();
+        if (muted) {
+            clearExternalKiwiDspState(*source);
+        }
+        source->prebuffering =
+            !muted && source->enabled && !kiwiSdrAudioTransmitMuted();
+        updateRxBufferStats();
     }
-    resetExternalKiwiDspState(*source);
-    source->prebuffering =
-        !muted && source->enabled && !kiwiSdrAudioTransmitMuted();
-    updateRxBufferStats();
+    if (!muted) {
+        scheduleAllKiwiDspStateInitialization();
+    }
 }
 
 void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
@@ -3511,34 +3818,33 @@ void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
         return;
     }
 
-    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
-    m_kiwiSdrRxBuffer.clear();
-    m_kiwiSdrRxPackets.clear();
-    m_kiwiSdrOutputBuffer.clear();
-    m_kiwiSdrNr2Output.clear();
-    if (!muted) {
-        ensureLegacyKiwiDspState();
-    }
-    resetLegacyKiwiDspState();
-    m_kiwiSdrPrebuffering.store(
-        !muted && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed),
-        std::memory_order_relaxed);
+    {
+        std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+        m_kiwiSdrRxBuffer.clear();
+        m_kiwiSdrRxPackets.clear();
+        m_kiwiSdrOutputBuffer.clear();
+        m_kiwiSdrNr2Output.clear();
+        resetLegacyKiwiDspState();
+        m_kiwiSdrPrebuffering.store(
+            !muted && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
 
-    for (const auto& source : m_externalKiwiSources) {
-        if (!source) {
-            continue;
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            source->rxBuffer.clear();
+            source->rxPackets.clear();
+            source->outputBuffer.clear();
+            source->nr2Output.clear();
+            resetExternalKiwiDspState(*source);
+            source->prebuffering = !muted && source->enabled && !source->muted;
         }
-        source->rxBuffer.clear();
-        source->rxPackets.clear();
-        source->outputBuffer.clear();
-        source->nr2Output.clear();
-        if (!muted) {
-            ensureExternalKiwiSourceDspState(*source);
-        }
-        resetExternalKiwiDspState(*source);
-        source->prebuffering = !muted && source->enabled && !source->muted;
+        updateRxBufferStats();
     }
-    updateRxBufferStats();
+    if (!muted) {
+        scheduleAllKiwiDspStateInitialization();
+    }
 }
 
 void AudioEngine::setKiwiSdrAudioSourcePan(const QString& sourceId, int pan)
@@ -3714,7 +4020,10 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     const auto sourcePan = [this, externalSource]() {
         return externalSource ? externalSource->pan : m_rxPan.load();
     };
-    const bool applyKiwiOutputPan = source == RxDspSource::KiwiSdr;
+    // Virtual Kiwi profiles have their own client-side pan. Flex and the
+    // legacy Kiwi stream keep the stereo orientation already present in their
+    // input; m_rxPan mirrors a Flex radio control and must not retarget Kiwi.
+    const bool applyKiwiOutputPan = externalSource != nullptr;
 
     // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any
     // pan, and the zero-filled frames the radio sends for muted slices
@@ -5841,6 +6150,16 @@ static void applyNr2SettingsFromAppSettings(SpectralNR& nr2)
     nr2.setAeFilter(s.value("NR2AeFilter", "True").toString() == "True");
 }
 
+static void copyNr2Settings(const SpectralNR& source, SpectralNR& target)
+{
+    target.setGainMax(source.gainMax());
+    target.setGainSmooth(source.gainSmooth());
+    target.setQspp(source.qspp());
+    target.setGainMethod(source.gainMethod());
+    target.setNpeMethod(source.npeMethod());
+    target.setAeFilter(source.aeFilter());
+}
+
 #ifdef HAVE_SPECBLEACH
 static void applyNr4SettingsFromAppSettings(SpecbleachFilter& nr4)
 {
@@ -5854,6 +6173,18 @@ static void applyNr4SettingsFromAppSettings(SpecbleachFilter& nr4)
     nr4.setSuppressionStrength(
         s.value("NR4SuppressionStrength", "0.50").toFloat());
 }
+
+static void copyNr4Settings(const SpecbleachFilter& source,
+                            SpecbleachFilter& target)
+{
+    target.setReductionAmount(source.reductionAmount());
+    target.setSmoothingFactor(source.smoothingFactor());
+    target.setWhiteningFactor(source.whiteningFactor());
+    target.setAdaptiveNoise(source.adaptiveNoise());
+    target.setNoiseEstimationMethod(source.noiseEstimationMethod());
+    target.setMaskingDepth(source.maskingDepth());
+    target.setSuppressionStrength(source.suppressionStrength());
+}
 #endif
 
 #ifdef HAVE_DFNR
@@ -5862,6 +6193,13 @@ static void applyDfnrSettingsFromAppSettings(DeepFilterFilter& dfnr)
     auto& s = AppSettings::instance();
     dfnr.setAttenLimit(s.value("DfnrAttenLimit", "100").toFloat());
     dfnr.setPostFilterBeta(s.value("DfnrPostFilterBeta", "0.0").toFloat());
+}
+
+static void copyDfnrSettings(const DeepFilterFilter& source,
+                             DeepFilterFilter& target)
+{
+    target.setAttenLimit(source.attenLimit());
+    target.setPostFilterBeta(source.postFilterBeta());
 }
 #endif
 
@@ -5899,7 +6237,8 @@ SpectralNR::WisdomResult AudioEngine::generateWisdom(
 void AudioEngine::setNr2Enabled(bool on)
 {
     if (m_nr2Enabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
     m_rxBuffer.clear();
     m_rxPackets.clear();
     m_rxOutputBuffer.clear();
@@ -5949,13 +6288,6 @@ void AudioEngine::setNr2Enabled(bool on)
         // Restore user-adjusted parameters from AppSettings
         applyNr2SettingsFromAppSettings(*m_nr2);
         m_nr2Enabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_nr2Enabled = false;
         m_nr2.reset();
@@ -5972,12 +6304,17 @@ void AudioEngine::setNr2Enabled(bool on)
             source->prebuffering = externalKiwiSourceAudible(*source);
         }
     }
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
     qCDebug(lcAudio) << "AudioEngine: NR2" << (on ? "enabled" : "disabled");
     emit nr2EnabledChanged(on);
 }
 
 void AudioEngine::setNr2GainMax(float v)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setGainMax(v);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainMax(v);
     for (const auto& source : m_externalKiwiSources) {
@@ -5989,6 +6326,7 @@ void AudioEngine::setNr2GainMax(float v)
 
 void AudioEngine::setNr2Qspp(float v)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setQspp(v);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setQspp(v);
     for (const auto& source : m_externalKiwiSources) {
@@ -6000,6 +6338,7 @@ void AudioEngine::setNr2Qspp(float v)
 
 void AudioEngine::setNr2GainSmooth(float v)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setGainSmooth(v);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainSmooth(v);
     for (const auto& source : m_externalKiwiSources) {
@@ -6011,6 +6350,7 @@ void AudioEngine::setNr2GainSmooth(float v)
 
 void AudioEngine::setNr2GainMethod(int m)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setGainMethod(m);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setGainMethod(m);
     for (const auto& source : m_externalKiwiSources) {
@@ -6022,6 +6362,7 @@ void AudioEngine::setNr2GainMethod(int m)
 
 void AudioEngine::setNr2NpeMethod(int m)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setNpeMethod(m);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setNpeMethod(m);
     for (const auto& source : m_externalKiwiSources) {
@@ -6033,6 +6374,7 @@ void AudioEngine::setNr2NpeMethod(int m)
 
 void AudioEngine::setNr2AeFilter(bool on)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr2) m_nr2->setAeFilter(on);
     if (m_kiwiSdrNr2) m_kiwiSdrNr2->setAeFilter(on);
     for (const auto& source : m_externalKiwiSources) {
@@ -6048,7 +6390,8 @@ void AudioEngine::setNr2AeFilter(bool on)
 void AudioEngine::setNr4Enabled(bool on)
 {
     if (m_nr4Enabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
     if (on) {
         if (m_nr2Enabled)  setNr2Enabled(false);
         if (m_rn2Enabled)  setRn2Enabled(false);
@@ -6061,14 +6404,8 @@ void AudioEngine::setNr4Enabled(bool on)
             emit nr4EnabledChanged(false);
             return;
         }
+        applyNr4SettingsFromAppSettings(*m_nr4);
         m_nr4Enabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_nr4Enabled = false;
         m_nr4.reset();
@@ -6079,12 +6416,17 @@ void AudioEngine::setNr4Enabled(bool on)
             }
         }
     }
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
     qCDebug(lcAudio) << "AudioEngine: NR4" << (on ? "enabled" : "disabled");
     emit nr4EnabledChanged(on);
 }
 
 void AudioEngine::setNr4ReductionAmount(float dB)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setReductionAmount(dB);
     }
@@ -6099,6 +6441,7 @@ void AudioEngine::setNr4ReductionAmount(float dB)
 }
 void AudioEngine::setNr4SmoothingFactor(float pct)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setSmoothingFactor(pct);
     }
@@ -6113,6 +6456,7 @@ void AudioEngine::setNr4SmoothingFactor(float pct)
 }
 void AudioEngine::setNr4WhiteningFactor(float pct)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setWhiteningFactor(pct);
     }
@@ -6127,6 +6471,7 @@ void AudioEngine::setNr4WhiteningFactor(float pct)
 }
 void AudioEngine::setNr4AdaptiveNoise(bool on)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setAdaptiveNoise(on);
     }
@@ -6141,6 +6486,7 @@ void AudioEngine::setNr4AdaptiveNoise(bool on)
 }
 void AudioEngine::setNr4NoiseEstimationMethod(int m)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setNoiseEstimationMethod(m);
     }
@@ -6155,6 +6501,7 @@ void AudioEngine::setNr4NoiseEstimationMethod(int m)
 }
 void AudioEngine::setNr4MaskingDepth(float v)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setMaskingDepth(v);
     }
@@ -6169,6 +6516,7 @@ void AudioEngine::setNr4MaskingDepth(float v)
 }
 void AudioEngine::setNr4SuppressionStrength(float v)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nr4) {
         m_nr4->setSuppressionStrength(v);
     }
@@ -6196,7 +6544,8 @@ void AudioEngine::setNr4SuppressionStrength(float) {}
 void AudioEngine::setMnrEnabled(bool on)
 {
     if (m_mnrEnabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
 #ifdef __APPLE__
     if (on) {
         // Disable all other noise-reduction modes — they're mutually exclusive
@@ -6215,13 +6564,6 @@ void AudioEngine::setMnrEnabled(bool on)
             return;
         }
         m_mnrEnabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_mnr.reset();
         m_kiwiSdrMnr.reset();
@@ -6233,6 +6575,10 @@ void AudioEngine::setMnrEnabled(bool on)
     }
 #endif
     m_mnrEnabled = on;
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
     emit mnrEnabledChanged(on);
 }
 
@@ -6242,6 +6588,7 @@ void AudioEngine::setMnrStrength(float normalized)
     AppSettings::instance().setValue("MnrStrength",
         QString::number(m_mnrStrength.load(), 'f', 2));
 #ifdef __APPLE__
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_mnr) {
         m_mnr->setStrength(m_mnrStrength.load());
     }
@@ -6264,7 +6611,8 @@ float AudioEngine::mnrStrength() const
 void AudioEngine::setRn2Enabled(bool on)
 {
     if (m_rn2Enabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
     if (on) {
         // Disable all other NR modes — they're mutually exclusive
         if (m_nr2Enabled)  setNr2Enabled(false);
@@ -6279,13 +6627,6 @@ void AudioEngine::setRn2Enabled(bool on)
             return;
         }
         m_rn2Enabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_rn2Enabled = false;
         m_rn2.reset();
@@ -6295,6 +6636,10 @@ void AudioEngine::setRn2Enabled(bool on)
                 source->rn2.reset();
             }
         }
+    }
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
     }
     qCDebug(lcAudio) << "AudioEngine: RN2 (RNNoise)" << (on ? "enabled" : "disabled");
     emit rn2EnabledChanged(on);
@@ -6311,7 +6656,8 @@ void AudioEngine::setRn2TxEnabled(bool on)
     if (m_rn2TxEnabled.load() == on) return;
     std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (on) {
-        m_rn2Tx = std::make_unique<RNNoiseFilter>();
+        m_rn2Tx = std::make_unique<RNNoiseFilter>(
+            RNNoiseFilter::OutputMode::ProcessedMono);
         if (!m_rn2Tx->isValid()) {
             qCWarning(lcAudio) << "AudioEngine: RN2 TX rnnoise_create() failed — disabling";
             m_rn2Tx.reset();
@@ -6335,7 +6681,8 @@ void AudioEngine::setRn2TxEnabled(bool on)
 void AudioEngine::setDfnrEnabled(bool on)
 {
     if (m_dfnrEnabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
     if (on) {
         // Mutual exclusion with all other NR modes
         if (m_nr2Enabled)  setNr2Enabled(false);
@@ -6349,14 +6696,8 @@ void AudioEngine::setDfnrEnabled(bool on)
             emit dfnrEnabledChanged(false);
             return;
         }
+        applyDfnrSettingsFromAppSettings(*m_dfnr);
         m_dfnrEnabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_dfnrEnabled = false;
         m_dfnr.reset();
@@ -6367,12 +6708,17 @@ void AudioEngine::setDfnrEnabled(bool on)
             }
         }
     }
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
     qCDebug(lcAudio) << "AudioEngine: DFNR (DeepFilterNet3)" << (on ? "enabled" : "disabled");
     emit dfnrEnabledChanged(on);
 }
 
 void AudioEngine::setDfnrAttenLimit(float db)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_dfnr) {
         m_dfnr->setAttenLimit(db);
     }
@@ -6388,11 +6734,13 @@ void AudioEngine::setDfnrAttenLimit(float db)
 
 float AudioEngine::dfnrAttenLimit() const
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     return m_dfnr ? m_dfnr->attenLimit() : 100.0f;
 }
 
 void AudioEngine::setDfnrPostFilterBeta(float beta)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_dfnr) {
         m_dfnr->setPostFilterBeta(beta);
     }
@@ -6420,7 +6768,8 @@ void AudioEngine::setDfnrPostFilterBeta(float) {}
 void AudioEngine::setNvAfxEnabled(bool on)
 {
     if (m_nvAfxEnabled == on) return;
-    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
+    std::unique_lock<std::recursive_mutex> lock(m_dspMutex);
+    ++m_dspConfigurationGeneration;
     if (on) {
         // Mutual exclusion with all other NR modes
         if (m_nr2Enabled)  setNr2Enabled(false);
@@ -6435,14 +6784,8 @@ void AudioEngine::setNvAfxEnabled(bool on)
             emit nvAfxEnabledChanged(false);
             return;
         }
+        m_nvAfx->setIntensity(NvidiaBnrSettings::intensity());
         m_nvAfxEnabled = true;
-        ensureLegacyKiwiDspState();
-        for (const auto& source : m_externalKiwiSources) {
-            if (!source) {
-                continue;
-            }
-            ensureExternalKiwiSourceDspState(*source);
-        }
     } else {
         m_nvAfxEnabled = false;
         m_nvAfx.reset();
@@ -6453,12 +6796,17 @@ void AudioEngine::setNvAfxEnabled(bool on)
             }
         }
     }
+    lock.unlock();
+    if (on) {
+        scheduleAllKiwiDspStateInitialization();
+    }
     qCDebug(lcAudio) << "AudioEngine: NVIDIA AFX denoiser" << (on ? "enabled" : "disabled");
     emit nvAfxEnabledChanged(on);
 }
 
 void AudioEngine::setNvAfxIntensity(float ratio)
 {
+    std::lock_guard<std::recursive_mutex> lock(m_dspMutex);
     if (m_nvAfx) {
         m_nvAfx->setIntensity(ratio);
     }

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -49,6 +49,7 @@
 #include <chrono>
 #include <cmath>
 #include <limits>
+#include <numbers>
 #include <QIODevice>
 #include <QFile>
 #include <QFileInfo>
@@ -65,6 +66,7 @@
 #include <QtGlobal>
 #include <algorithm>
 #include <cstring>
+#include <functional>
 #include <optional>
 
 namespace AetherSDR {
@@ -73,6 +75,12 @@ static QString wisdomDir();
 static void logNr2WisdomSummary(const QString& context);
 static void logNr2WisdomGenerationSummary(SpectralNR::WisdomResult result);
 static void applyNr2SettingsFromAppSettings(SpectralNR& nr2);
+#ifdef HAVE_SPECBLEACH
+static void applyNr4SettingsFromAppSettings(SpecbleachFilter& nr4);
+#endif
+#ifdef HAVE_DFNR
+static void applyDfnrSettingsFromAppSettings(DeepFilterFilter& dfnr);
+#endif
 
 namespace {
 constexpr qint64 kTxAutoRestartMinRuntimeMs = 60000;
@@ -970,19 +978,355 @@ AudioEngine::externalKiwiSource(const QString& sourceId, bool create)
         id, m_externalKiwiReceivePresentationDelaySourceId,
         m_externalKiwiReceivePresentationDelayMs);
     source->prebuffering = true;
-    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_kiwiSdrNr2) {
-        source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (source->nr2->hasPlanFailed()) {
-            qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
-                               << id;
-            source->nr2.reset();
-        } else {
-            applyNr2SettingsFromAppSettings(*source->nr2);
-        }
-    }
+    ensureExternalKiwiSourceDspState(*source);
     m_externalKiwiSources.push_back(std::move(source));
     return m_externalKiwiSources.back().get();
 }
+
+std::unique_ptr<RNNoiseFilter>
+AudioEngine::createRn2Filter(const QString& label) const
+{
+    auto filter = std::make_unique<RNNoiseFilter>();
+    if (!filter->isValid()) {
+        qCWarning(lcAudio).noquote()
+            << "AudioEngine: RN2 rnnoise_create() failed for" << label;
+        return {};
+    }
+    return filter;
+}
+
+#ifdef HAVE_SPECBLEACH
+std::unique_ptr<SpecbleachFilter>
+AudioEngine::createNr4Filter(const QString& label) const
+{
+    auto filter = std::make_unique<SpecbleachFilter>();
+    if (!filter->isValid()) {
+        qCWarning(lcAudio).noquote()
+            << "AudioEngine: NR4 initialization failed for" << label;
+        return {};
+    }
+    applyNr4SettingsFromAppSettings(*filter);
+    return filter;
+}
+#endif
+
+#ifdef __APPLE__
+std::unique_ptr<MacNRFilter>
+AudioEngine::createMnrFilter(const QString& label) const
+{
+    auto filter = std::make_unique<MacNRFilter>();
+    if (!filter->isValid()) {
+        qCWarning(lcAudio).noquote()
+            << "AudioEngine: MNR vDSP setup failed for" << label;
+        return {};
+    }
+    filter->setStrength(m_mnrStrength.load());
+    return filter;
+}
+#endif
+
+#ifdef HAVE_DFNR
+std::unique_ptr<DeepFilterFilter>
+AudioEngine::createDfnrFilter(const QString& label) const
+{
+    auto filter = std::make_unique<DeepFilterFilter>();
+    if (!filter->isValid()) {
+        qCWarning(lcAudio).noquote()
+            << "AudioEngine: DFNR df_create() failed for" << label;
+        return {};
+    }
+    applyDfnrSettingsFromAppSettings(*filter);
+    return filter;
+}
+#endif
+
+#ifdef HAVE_NVIDIA_AFX
+std::unique_ptr<NvidiaAfxFilter>
+AudioEngine::createNvAfxFilter(const QString& label) const
+{
+    auto filter = std::make_unique<NvidiaAfxFilter>();
+    if (!filter->isValid()) {
+        qCWarning(lcAudio).noquote()
+            << "AudioEngine: NVIDIA AFX denoiser unavailable for" << label
+            << "-" << filter->lastError();
+        return {};
+    }
+    filter->setIntensity(NvidiaBnrSettings::intensity());
+    return filter;
+}
+#endif
+
+bool AudioEngine::ensureLegacyKiwiDspState()
+{
+    if (!kiwiSdrAudioActive()) {
+        return true;
+    }
+
+    bool ok = true;
+    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
+        && !m_kiwiSdrNr2) {
+        m_kiwiSdrNr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (m_kiwiSdrNr2->hasPlanFailed()) {
+            qCWarning(lcAudio)
+                << "AudioEngine: legacy Kiwi NR2 plan failed";
+            m_kiwiSdrNr2.reset();
+            ok = false;
+        } else {
+            applyNr2SettingsFromAppSettings(*m_kiwiSdrNr2);
+        }
+    }
+    if (m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
+        && !m_kiwiSdrRn2) {
+        m_kiwiSdrRn2 = createRn2Filter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(m_kiwiSdrRn2);
+    }
+#ifdef HAVE_SPECBLEACH
+    if (m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
+        && !m_kiwiSdrNr4) {
+        m_kiwiSdrNr4 = createNr4Filter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(m_kiwiSdrNr4);
+    }
+#endif
+#ifdef __APPLE__
+    if (m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
+        && !m_kiwiSdrMnr) {
+        m_kiwiSdrMnr = createMnrFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(m_kiwiSdrMnr);
+    }
+#endif
+#ifdef HAVE_DFNR
+    if (m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
+        && !m_kiwiSdrDfnr) {
+        m_kiwiSdrDfnr = createDfnrFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(m_kiwiSdrDfnr);
+    }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    if (m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
+        && !m_kiwiSdrNvAfx) {
+        m_kiwiSdrNvAfx = createNvAfxFilter(QStringLiteral("legacy Kiwi"));
+        ok = ok && static_cast<bool>(m_kiwiSdrNvAfx);
+    }
+#endif
+    return ok;
+}
+
+bool AudioEngine::ensureExternalKiwiSourceDspState(
+    ExternalRxAudioSourceState& source)
+{
+    if (!externalKiwiSourceAudible(source)) {
+        return true;
+    }
+
+    bool ok = true;
+    if (m_nr2Enabled.load(std::memory_order_relaxed) && m_nr2
+        && !source.nr2) {
+        source.nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
+        if (source.nr2->hasPlanFailed()) {
+            qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
+                               << source.id;
+            source.nr2.reset();
+            ok = false;
+        } else {
+            applyNr2SettingsFromAppSettings(*source.nr2);
+        }
+    }
+    if (m_rn2Enabled.load(std::memory_order_relaxed) && m_rn2
+        && !source.rn2) {
+        source.rn2 = createRn2Filter(
+            QStringLiteral("external Kiwi %1").arg(source.id));
+        ok = ok && static_cast<bool>(source.rn2);
+    }
+#ifdef HAVE_SPECBLEACH
+    if (m_nr4Enabled.load(std::memory_order_relaxed) && m_nr4
+        && !source.nr4) {
+        source.nr4 = createNr4Filter(
+            QStringLiteral("external Kiwi %1").arg(source.id));
+        ok = ok && static_cast<bool>(source.nr4);
+    }
+#endif
+#ifdef __APPLE__
+    if (m_mnrEnabled.load(std::memory_order_relaxed) && m_mnr
+        && !source.mnr) {
+        source.mnr = createMnrFilter(
+            QStringLiteral("external Kiwi %1").arg(source.id));
+        ok = ok && static_cast<bool>(source.mnr);
+    }
+#endif
+#ifdef HAVE_DFNR
+    if (m_dfnrEnabled.load(std::memory_order_relaxed) && m_dfnr
+        && !source.dfnr) {
+        source.dfnr = createDfnrFilter(
+            QStringLiteral("external Kiwi %1").arg(source.id));
+        ok = ok && static_cast<bool>(source.dfnr);
+    }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    if (m_nvAfxEnabled.load(std::memory_order_relaxed) && m_nvAfx
+        && !source.nvAfx) {
+        source.nvAfx = createNvAfxFilter(
+            QStringLiteral("external Kiwi %1").arg(source.id));
+        ok = ok && static_cast<bool>(source.nvAfx);
+    }
+#endif
+    return ok;
+}
+
+void AudioEngine::resetLegacyKiwiDspState()
+{
+    if (m_nr2Enabled && m_kiwiSdrNr2) {
+        m_kiwiSdrNr2->reset();
+    }
+    if (m_rn2Enabled && m_kiwiSdrRn2) {
+        m_kiwiSdrRn2->reset();
+    }
+#ifdef HAVE_SPECBLEACH
+    if (m_nr4Enabled && m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->reset();
+    }
+#endif
+#ifdef __APPLE__
+    if (m_mnrEnabled && m_kiwiSdrMnr) {
+        m_kiwiSdrMnr->reset();
+    }
+#endif
+#ifdef HAVE_DFNR
+    if (m_dfnrEnabled && m_kiwiSdrDfnr) {
+        m_kiwiSdrDfnr->reset();
+    }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    if (m_nvAfxEnabled && m_kiwiSdrNvAfx) {
+        m_kiwiSdrNvAfx->reset();
+    }
+#endif
+}
+
+void AudioEngine::clearLegacyKiwiDspState()
+{
+    m_kiwiSdrNr2.reset();
+    m_kiwiSdrNr2Output.clear();
+    m_kiwiSdrRn2.reset();
+#ifdef HAVE_SPECBLEACH
+    m_kiwiSdrNr4.reset();
+#endif
+#ifdef __APPLE__
+    m_kiwiSdrMnr.reset();
+#endif
+#ifdef HAVE_DFNR
+    m_kiwiSdrDfnr.reset();
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    m_kiwiSdrNvAfx.reset();
+#endif
+}
+
+void AudioEngine::resetExternalKiwiDspState(ExternalRxAudioSourceState& source)
+{
+    if (m_nr2Enabled && source.nr2) {
+        source.nr2->reset();
+    }
+    if (m_rn2Enabled && source.rn2) {
+        source.rn2->reset();
+    }
+#ifdef HAVE_SPECBLEACH
+    if (m_nr4Enabled && source.nr4) {
+        source.nr4->reset();
+    }
+#endif
+#ifdef __APPLE__
+    if (m_mnrEnabled && source.mnr) {
+        source.mnr->reset();
+    }
+#endif
+#ifdef HAVE_DFNR
+    if (m_dfnrEnabled && source.dfnr) {
+        source.dfnr->reset();
+    }
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    if (m_nvAfxEnabled && source.nvAfx) {
+        source.nvAfx->reset();
+    }
+#endif
+}
+
+void AudioEngine::clearExternalKiwiDspState(ExternalRxAudioSourceState& source)
+{
+    source.nr2.reset();
+    source.nr2Output.clear();
+    source.rn2.reset();
+#ifdef HAVE_SPECBLEACH
+    source.nr4.reset();
+#endif
+#ifdef __APPLE__
+    source.mnr.reset();
+#endif
+#ifdef HAVE_DFNR
+    source.dfnr.reset();
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    source.nvAfx.reset();
+#endif
+}
+
+RNNoiseFilter* AudioEngine::rn2ForSource(
+    RxDspSource source,
+    ExternalRxAudioSourceState* externalSource) const
+{
+    if (externalSource) {
+        return externalSource->rn2.get();
+    }
+    return source == RxDspSource::KiwiSdr ? m_kiwiSdrRn2.get() : m_rn2.get();
+}
+
+#ifdef HAVE_SPECBLEACH
+SpecbleachFilter* AudioEngine::nr4ForSource(
+    RxDspSource source,
+    ExternalRxAudioSourceState* externalSource) const
+{
+    if (externalSource) {
+        return externalSource->nr4.get();
+    }
+    return source == RxDspSource::KiwiSdr ? m_kiwiSdrNr4.get() : m_nr4.get();
+}
+#endif
+
+#ifdef __APPLE__
+MacNRFilter* AudioEngine::mnrForSource(
+    RxDspSource source,
+    ExternalRxAudioSourceState* externalSource) const
+{
+    if (externalSource) {
+        return externalSource->mnr.get();
+    }
+    return source == RxDspSource::KiwiSdr ? m_kiwiSdrMnr.get() : m_mnr.get();
+}
+#endif
+
+#ifdef HAVE_DFNR
+DeepFilterFilter* AudioEngine::dfnrForSource(
+    RxDspSource source,
+    ExternalRxAudioSourceState* externalSource) const
+{
+    if (externalSource) {
+        return externalSource->dfnr.get();
+    }
+    return source == RxDspSource::KiwiSdr ? m_kiwiSdrDfnr.get() : m_dfnr.get();
+}
+#endif
+
+#ifdef HAVE_NVIDIA_AFX
+NvidiaAfxFilter* AudioEngine::nvAfxForSource(
+    RxDspSource source,
+    ExternalRxAudioSourceState* externalSource) const
+{
+    if (externalSource) {
+        return externalSource->nvAfx.get();
+    }
+    return source == RxDspSource::KiwiSdr ? m_kiwiSdrNvAfx.get() : m_nvAfx.get();
+}
+#endif
 
 bool AudioEngine::kiwiSdrAudioTransmitMuted() const
 {
@@ -2019,6 +2363,336 @@ QJsonObject AudioEngine::stopAutomationAudioCapture()
     return automationAudioCaptureSnapshot(false);
 }
 
+namespace {
+
+constexpr int kAutomationDspProbeFrames = AudioEngine::DEFAULT_SAMPLE_RATE * 3;
+constexpr int kAutomationDspProbeDiscardFrames =
+    AudioEngine::DEFAULT_SAMPLE_RATE + AudioEngine::DEFAULT_SAMPLE_RATE / 2;
+constexpr int kAutomationDspProbeBlockFrames = 960;
+
+QByteArray makeAutomationDspStereoProbeInput()
+{
+    QByteArray input(kAutomationDspProbeFrames * 2 * static_cast<int>(sizeof(float)),
+                     Qt::Uninitialized);
+    auto* src = reinterpret_cast<float*>(input.data());
+    for (int i = 0; i < kAutomationDspProbeFrames; ++i) {
+        const double t = static_cast<double>(i) / AudioEngine::DEFAULT_SAMPLE_RATE;
+        const float envelope = static_cast<float>(
+            0.62 + 0.38 * std::sin(2.0 * std::numbers::pi * 4.2 * t));
+        const float signal = static_cast<float>(
+            envelope * (0.30 * std::sin(2.0 * std::numbers::pi * 720.0 * t)
+                      + 0.16 * std::sin(2.0 * std::numbers::pi * 1180.0 * t)
+                      + 0.08 * std::sin(2.0 * std::numbers::pi * 1740.0 * t))
+          + 0.03 * std::sin(2.0 * std::numbers::pi * 43.0 * t));
+        src[2 * i] = 0.80f * signal;
+        src[2 * i + 1] = 0.20f * signal;
+    }
+    return input;
+}
+
+QJsonObject stereoRmsRatio(const QByteArray& pcm, int startFrame)
+{
+    const auto* samples = reinterpret_cast<const float*>(pcm.constData());
+    const int totalFrames = pcm.size() / (2 * static_cast<int>(sizeof(float)));
+    const int firstFrame = std::clamp(startFrame, 0, totalFrames);
+    double leftSum = 0.0;
+    double rightSum = 0.0;
+    int count = 0;
+    for (int frame = firstFrame; frame < totalFrames; ++frame) {
+        const double left = samples[2 * frame];
+        const double right = samples[2 * frame + 1];
+        leftSum += left * left;
+        rightSum += right * right;
+        ++count;
+    }
+    const double leftRms = std::sqrt(leftSum / std::max(count, 1));
+    const double rightRms = std::sqrt(rightSum / std::max(count, 1));
+    return QJsonObject{
+        {QStringLiteral("leftRms"), leftRms},
+        {QStringLiteral("rightRms"), rightRms},
+        {QStringLiteral("ratio"), leftRms / std::max(rightRms, 1e-12)},
+        {QStringLiteral("frames"), count},
+    };
+}
+
+QByteArray processAutomationDspProbeBlocks(
+    const QByteArray& input,
+    const std::function<QByteArray(const QByteArray&)>& processBlock)
+{
+    const int blockBytes =
+        kAutomationDspProbeBlockFrames * 2 * static_cast<int>(sizeof(float));
+    QByteArray output;
+    output.reserve(input.size());
+    for (int offset = 0; offset < input.size(); offset += blockBytes) {
+        output.append(processBlock(input.mid(offset, blockBytes)));
+    }
+    return output;
+}
+
+QJsonObject unavailableAutomationDspProbe(const QString& mode, const QString& reason)
+{
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("mode"), mode},
+        {QStringLiteral("available"), false},
+        {QStringLiteral("skipped"), true},
+        {QStringLiteral("tested"), false},
+        {QStringLiteral("reason"), reason},
+    };
+}
+
+QJsonObject completedAutomationDspProbe(const QString& mode,
+                                        const QByteArray& input,
+                                        const QByteArray& output)
+{
+    constexpr double kMinOutputInputRmsRatio = 0.02;
+    const QJsonObject inputRms =
+        stereoRmsRatio(input, kAutomationDspProbeDiscardFrames);
+    const QJsonObject outputRms =
+        stereoRmsRatio(output, kAutomationDspProbeDiscardFrames);
+    const double inputRatio = inputRms.value(QStringLiteral("ratio")).toDouble();
+    const double outputRatio = outputRms.value(QStringLiteral("ratio")).toDouble();
+    const double ratioError = std::fabs(outputRatio - inputRatio);
+    const double leftLevelRatio =
+        outputRms.value(QStringLiteral("leftRms")).toDouble()
+        / std::max(inputRms.value(QStringLiteral("leftRms")).toDouble(), 1.0e-12);
+    const double rightLevelRatio =
+        outputRms.value(QStringLiteral("rightRms")).toDouble()
+        / std::max(inputRms.value(QStringLiteral("rightRms")).toDouble(), 1.0e-12);
+    const bool audible =
+        leftLevelRatio >= kMinOutputInputRmsRatio
+        && rightLevelRatio >= kMinOutputInputRmsRatio;
+    const bool preserved = ratioError < 0.08 && audible;
+
+    return QJsonObject{
+        {QStringLiteral("ok"), preserved},
+        {QStringLiteral("mode"), mode},
+        {QStringLiteral("available"), true},
+        {QStringLiteral("skipped"), false},
+        {QStringLiteral("tested"), true},
+        {QStringLiteral("frames"),
+         output.size() / (2 * static_cast<int>(sizeof(float)))},
+        {QStringLiteral("discardFrames"), kAutomationDspProbeDiscardFrames},
+        {QStringLiteral("input"), inputRms},
+        {QStringLiteral("output"), outputRms},
+        {QStringLiteral("ratioError"), ratioError},
+        {QStringLiteral("leftLevelRatio"), leftLevelRatio},
+        {QStringLiteral("rightLevelRatio"), rightLevelRatio},
+        {QStringLiteral("minimumLevelRatio"), kMinOutputInputRmsRatio},
+        {QStringLiteral("audible"), audible},
+        {QStringLiteral("preserved"), preserved},
+    };
+}
+
+} // namespace
+
+QJsonObject AudioEngine::automationNr2StereoProbe() const
+{
+    QJsonObject result = automationDspStereoProbe(QStringLiteral("NR2"));
+    result[QStringLiteral("probe")] = QStringLiteral("nr2StereoBalance");
+    return result;
+}
+
+QJsonObject AudioEngine::automationDspStereoProbe(const QString& mode) const
+{
+    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("audioCapture probeDspStereo requires AETHER_AUTOMATION=1")},
+        };
+    }
+
+    const QByteArray input = makeAutomationDspStereoProbeInput();
+    QString tokenText = mode.trimmed();
+    tokenText.replace(QLatin1Char(','), QLatin1Char(' '));
+    const QStringList requestTokens =
+        tokenText.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    QString normalizedMode = QStringLiteral("ALL");
+    bool strictCoverage = false;
+    for (const QString& token : requestTokens) {
+        const QString normalizedToken = token.toUpper();
+        if (normalizedToken == QLatin1String("STRICT")) {
+            strictCoverage = true;
+        } else if (normalizedMode == QLatin1String("ALL")) {
+            normalizedMode = normalizedToken;
+        }
+    }
+
+    const auto probeOne = [this, &input](const QString& requestedMode) -> QJsonObject {
+        if (requestedMode == QLatin1String("NR2")) {
+            SpectralNR nr2(256, DEFAULT_SAMPLE_RATE);
+            if (nr2.hasPlanFailed()) {
+                return QJsonObject{
+                    {QStringLiteral("ok"), false},
+                    {QStringLiteral("mode"), requestedMode},
+                    {QStringLiteral("available"), false},
+                    {QStringLiteral("skipped"), false},
+                    {QStringLiteral("error"), QStringLiteral("NR2 plan creation failed")},
+                };
+            }
+            applyNr2SettingsFromAppSettings(nr2);
+            QByteArray output;
+            processNr2StereoSharedMask(
+                nr2,
+                reinterpret_cast<const float*>(input.constData()),
+                input.size() / (2 * static_cast<int>(sizeof(float))),
+                output);
+            return completedAutomationDspProbe(requestedMode, input, output);
+        }
+
+        if (requestedMode == QLatin1String("RN2")) {
+            RNNoiseFilter rn2;
+            if (!rn2.isValid()) {
+                return QJsonObject{
+                    {QStringLiteral("ok"), false},
+                    {QStringLiteral("mode"), requestedMode},
+                    {QStringLiteral("available"), false},
+                    {QStringLiteral("skipped"), false},
+                    {QStringLiteral("error"), QStringLiteral("RN2 initialization failed")},
+                };
+            }
+            const QByteArray output = processAutomationDspProbeBlocks(
+                input, [&rn2](const QByteArray& block) { return rn2.process(block); });
+            return completedAutomationDspProbe(requestedMode, input, output);
+        }
+
+        if (requestedMode == QLatin1String("NR4")) {
+#ifdef HAVE_SPECBLEACH
+            SpecbleachFilter nr4;
+            if (!nr4.isValid()) {
+                return unavailableAutomationDspProbe(
+                    requestedMode, QStringLiteral("NR4/specbleach unavailable"));
+            }
+            applyNr4SettingsFromAppSettings(nr4);
+            const QByteArray output = processAutomationDspProbeBlocks(
+                input, [&nr4](const QByteArray& block) { return nr4.process(block); });
+            return completedAutomationDspProbe(requestedMode, input, output);
+#else
+            return unavailableAutomationDspProbe(
+                requestedMode, QStringLiteral("NR4 not built in this configuration"));
+#endif
+        }
+
+        if (requestedMode == QLatin1String("MNR")) {
+#ifdef __APPLE__
+            MacNRFilter mnr;
+            if (!mnr.isValid()) {
+                return unavailableAutomationDspProbe(
+                    requestedMode, QStringLiteral("MNR/Accelerate initialization failed"));
+            }
+            mnr.setStrength(m_mnrStrength.load());
+            const QByteArray output = processAutomationDspProbeBlocks(
+                input, [&mnr](const QByteArray& block) { return mnr.process(block); });
+            return completedAutomationDspProbe(requestedMode, input, output);
+#else
+            return unavailableAutomationDspProbe(
+                requestedMode, QStringLiteral("MNR is macOS-only"));
+#endif
+        }
+
+        if (requestedMode == QLatin1String("DFNR")) {
+#ifdef HAVE_DFNR
+            DeepFilterFilter dfnr;
+            if (!dfnr.isValid()) {
+                return unavailableAutomationDspProbe(
+                    requestedMode, QStringLiteral("DFNR model/runtime unavailable"));
+            }
+            applyDfnrSettingsFromAppSettings(dfnr);
+            const QByteArray output = processAutomationDspProbeBlocks(
+                input, [&dfnr](const QByteArray& block) { return dfnr.process(block); });
+            return completedAutomationDspProbe(requestedMode, input, output);
+#else
+            return unavailableAutomationDspProbe(
+                requestedMode, QStringLiteral("DFNR not built in this configuration"));
+#endif
+        }
+
+        if (requestedMode == QLatin1String("BNR")) {
+#ifdef HAVE_NVIDIA_AFX
+            NvidiaAfxFilter bnr;
+            if (!bnr.isValid()) {
+                return unavailableAutomationDspProbe(
+                    requestedMode,
+                    bnr.lastError().isEmpty()
+                        ? QStringLiteral("BNR/NVIDIA AFX runtime unavailable")
+                        : bnr.lastError());
+            }
+            bnr.setIntensity(NvidiaBnrSettings::intensity());
+            const QByteArray output = processAutomationDspProbeBlocks(
+                input, [&bnr](const QByteArray& block) { return bnr.process(block); });
+            return completedAutomationDspProbe(requestedMode, input, output);
+#else
+            return unavailableAutomationDspProbe(
+                requestedMode, QStringLiteral("BNR not built in this configuration"));
+#endif
+        }
+
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("mode"), requestedMode},
+            {QStringLiteral("error"),
+             QStringLiteral("unknown DSP mode; use NR2, RN2, NR4, MNR, DFNR, BNR, or all")},
+        };
+    };
+
+    if (normalizedMode != QLatin1String("ALL")) {
+        QJsonObject result = probeOne(normalizedMode);
+        result[QStringLiteral("probe")] = QStringLiteral("dspStereoBalance");
+        const bool skipped = result.value(QStringLiteral("skipped")).toBool();
+        result[QStringLiteral("strict")] = strictCoverage;
+        result[QStringLiteral("fullCoverage")] = !skipped;
+        result[QStringLiteral("coverageStatus")] =
+            skipped ? QStringLiteral("skipped") : QStringLiteral("complete");
+        if (strictCoverage && skipped) {
+            result[QStringLiteral("ok")] = false;
+            result[QStringLiteral("coverageError")] =
+                QStringLiteral("strict DSP probe skipped requested mode");
+        }
+        return result;
+    }
+
+    const QStringList modes{
+        QStringLiteral("NR2"),
+        QStringLiteral("RN2"),
+        QStringLiteral("NR4"),
+        QStringLiteral("MNR"),
+        QStringLiteral("DFNR"),
+        QStringLiteral("BNR"),
+    };
+    QJsonArray results;
+    bool testedOk = true;
+    int skipped = 0;
+    int tested = 0;
+    for (const QString& oneMode : modes) {
+        const QJsonObject result = probeOne(oneMode);
+        results.append(result);
+        if (result.value(QStringLiteral("skipped")).toBool()) {
+            ++skipped;
+        } else {
+            ++tested;
+            testedOk = testedOk && result.value(QStringLiteral("ok")).toBool();
+        }
+    }
+    const bool fullCoverage = skipped == 0;
+    const bool ok = testedOk && (!strictCoverage || fullCoverage);
+
+    return QJsonObject{
+        {QStringLiteral("ok"), ok},
+        {QStringLiteral("probe"), QStringLiteral("dspStereoBalance")},
+        {QStringLiteral("modes"), results},
+        {QStringLiteral("strict"), strictCoverage},
+        {QStringLiteral("tested"), tested},
+        {QStringLiteral("skipped"), skipped},
+        {QStringLiteral("testedOk"), testedOk},
+        {QStringLiteral("fullCoverage"), fullCoverage},
+        {QStringLiteral("coverageStatus"),
+         fullCoverage ? QStringLiteral("complete") : QStringLiteral("partial")},
+        {QStringLiteral("frames"), kAutomationDspProbeFrames},
+        {QStringLiteral("discardFrames"), kAutomationDspProbeDiscardFrames},
+    };
+}
+
 QJsonObject AudioEngine::automationAudioCaptureSnapshot(bool includePcm) const
 {
     const qint64 nowNs = steadyNowNs();
@@ -2754,13 +3428,14 @@ void AudioEngine::setKiwiSdrAudioEnabled(bool on)
     m_kiwiSdrRxBuffer.clear();
     m_kiwiSdrRxPackets.clear();
     m_kiwiSdrOutputBuffer.clear();
-    m_kiwiSdrNr2Mono.clear();
-    m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
     m_kiwiSdrRxResampler.reset();
     m_kiwiSdrRxResamplerR.reset();
-    if (m_nr2Enabled && m_kiwiSdrNr2) {
-        m_kiwiSdrNr2->reset();
+    if (on) {
+        ensureLegacyKiwiDspState();
+        resetLegacyKiwiDspState();
+    } else {
+        clearLegacyKiwiDspState();
     }
     m_kiwiSdrPrebuffering.store(on && !kiwiSdrAudioTransmitMuted(),
                                 std::memory_order_relaxed);
@@ -2781,20 +3456,14 @@ void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
     source->rxBuffer.clear();
     source->rxPackets.clear();
     source->outputBuffer.clear();
-    source->nr2Mono.clear();
-    source->nr2Processed.clear();
     source->nr2Output.clear();
     source->rxResampler.reset();
     source->rxResamplerR.reset();
-    if (on && m_nr2Enabled.load(std::memory_order_relaxed) && !source->nr2) {
-        source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (source->nr2->hasPlanFailed()) {
-            qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
-                               << source->id;
-            source->nr2.reset();
-        } else {
-            applyNr2SettingsFromAppSettings(*source->nr2);
-        }
+    if (on) {
+        ensureExternalKiwiSourceDspState(*source);
+        resetExternalKiwiDspState(*source);
+    } else {
+        clearExternalKiwiDspState(*source);
     }
     source->prebuffering = on;
     updateRxBufferStats();
@@ -2825,9 +3494,11 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
     source->rxBuffer.clear();
     source->rxPackets.clear();
     source->outputBuffer.clear();
-    source->nr2Mono.clear();
-    source->nr2Processed.clear();
     source->nr2Output.clear();
+    if (!muted) {
+        ensureExternalKiwiSourceDspState(*source);
+    }
+    resetExternalKiwiDspState(*source);
     source->prebuffering =
         !muted && source->enabled && !kiwiSdrAudioTransmitMuted();
     updateRxBufferStats();
@@ -2844,12 +3515,11 @@ void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
     m_kiwiSdrRxBuffer.clear();
     m_kiwiSdrRxPackets.clear();
     m_kiwiSdrOutputBuffer.clear();
-    m_kiwiSdrNr2Mono.clear();
-    m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
-    if (m_nr2Enabled && m_kiwiSdrNr2) {
-        m_kiwiSdrNr2->reset();
+    if (!muted) {
+        ensureLegacyKiwiDspState();
     }
+    resetLegacyKiwiDspState();
     m_kiwiSdrPrebuffering.store(
         !muted && m_kiwiSdrAudioEnabled.load(std::memory_order_relaxed),
         std::memory_order_relaxed);
@@ -2861,12 +3531,11 @@ void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
         source->rxBuffer.clear();
         source->rxPackets.clear();
         source->outputBuffer.clear();
-        source->nr2Mono.clear();
-        source->nr2Processed.clear();
         source->nr2Output.clear();
-        if (m_nr2Enabled && source->nr2) {
-            source->nr2->reset();
+        if (!muted) {
+            ensureExternalKiwiSourceDspState(*source);
         }
+        resetExternalKiwiDspState(*source);
         source->prebuffering = !muted && source->enabled && !source->muted;
     }
     updateRxBufferStats();
@@ -2918,11 +3587,7 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
     m_clientDeEssRxScratch.clear();
     m_clientTubeRxScratch.clear();
     m_clientPuduRxScratch.clear();
-    m_nr2Mono.clear();
-    m_nr2Processed.clear();
     m_nr2Output.clear();
-    m_kiwiSdrNr2Mono.clear();
-    m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
     for (const auto& source : m_externalKiwiSources) {
         if (!source) {
@@ -2931,14 +3596,10 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
         source->rxBuffer.clear();
         source->rxPackets.clear();
         source->outputBuffer.clear();
-        source->nr2Mono.clear();
-        source->nr2Processed.clear();
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
-        if (m_nr2Enabled && source->nr2) {
-            source->nr2->reset();
-        }
+        resetExternalKiwiDspState(*source);
         source->prebuffering = externalKiwiSourceAudible(*source);
     }
 
@@ -2969,24 +3630,39 @@ void AudioEngine::resetRxChainStateForSourceSwitch()
     if (m_rn2Enabled && m_rn2) {
         m_rn2->reset();
     }
+    if (m_rn2Enabled && m_kiwiSdrRn2) {
+        m_kiwiSdrRn2->reset();
+    }
 #ifdef HAVE_SPECBLEACH
     if (m_nr4Enabled && m_nr4) {
         m_nr4->reset();
+    }
+    if (m_nr4Enabled && m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->reset();
     }
 #endif
 #ifdef HAVE_DFNR
     if (m_dfnrEnabled && m_dfnr) {
         m_dfnr->reset();
     }
+    if (m_dfnrEnabled && m_kiwiSdrDfnr) {
+        m_kiwiSdrDfnr->reset();
+    }
 #endif
 #ifdef __APPLE__
     if (m_mnrEnabled && m_mnr) {
         m_mnr->reset();
     }
+    if (m_mnrEnabled && m_kiwiSdrMnr) {
+        m_kiwiSdrMnr->reset();
+    }
 #endif
 #ifdef HAVE_NVIDIA_AFX
     if (m_nvAfxEnabled && m_nvAfx) {
         m_nvAfx->reset();
+    }
+    if (m_nvAfxEnabled && m_kiwiSdrNvAfx) {
+        m_kiwiSdrNvAfx->reset();
     }
 #endif
 }
@@ -3038,6 +3714,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     const auto sourcePan = [this, externalSource]() {
         return externalSource ? externalSource->pan : m_rxPan.load();
     };
+    const bool applyKiwiOutputPan = source == RxDspSource::KiwiSdr;
 
     // feedAudioData() handles all remote_audio_rx paths: SSB/CW/digital on any
     // pan, and the zero-filled frames the radio sends for muted slices
@@ -3181,9 +3858,9 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);
         updateRxBufferStats();
     };
-    const auto writeAudioAndLevel = [this, externalSource, &writeAudio](
+    const auto writeAudioAndLevel = [this, applyKiwiOutputPan, &writeAudio](
                                         const QByteArray& data) {
-        writeAudio(data, externalSource != nullptr);
+        writeAudio(data, applyKiwiOutputPan);
         emit levelChanged(computeRMS(data));
     };
 
@@ -3196,61 +3873,66 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
         std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
         if (m_radioTransmitting) {
             writeAudioAndLevel(pcm);
-        } else if (m_rn2Enabled && m_rn2) {
-            QByteArray processed = m_rn2->process(pcm);
-            // Re-apply pan lost during NR mono-mix (#1460)
-            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
-                              processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              sourcePan());
-            writeAudio(processed);
+        } else if (m_rn2Enabled) {
+            RNNoiseFilter* rn2 = rn2ForSource(source, externalSource);
+            if (!rn2) {
+                writeAudioAndLevel(pcm);
+                return;
+            }
+            QByteArray processed = rn2->process(pcm);
+            writeAudio(processed, applyKiwiOutputPan);
             emit levelChanged(computeRMS(processed));
         } else if (m_nr2Enabled && m_nr2) {
-            processNr2(pcm, source, externalSource);  // applyRxPanInPlace called inside processNr2
+            processNr2(pcm, source, externalSource);
             const QByteArray& nr2Output = externalSource
                 ? externalSource->nr2Output
                 : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Output
                                                    : m_nr2Output);
-            writeAudio(nr2Output);
+            writeAudio(nr2Output, applyKiwiOutputPan);
             emit levelChanged(computeRMS(nr2Output));
 
 #ifdef HAVE_SPECBLEACH
-        } else if (m_nr4Enabled && m_nr4) {
-            QByteArray processed = m_nr4->process(pcm);
-            // Re-apply pan lost during NR mono-mix (#1460)
-            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
-                              processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              sourcePan());
-            writeAudio(processed);
+        } else if (m_nr4Enabled) {
+            SpecbleachFilter* nr4 = nr4ForSource(source, externalSource);
+            if (!nr4) {
+                writeAudioAndLevel(pcm);
+                return;
+            }
+            QByteArray processed = nr4->process(pcm);
+            writeAudio(processed, applyKiwiOutputPan);
             emit levelChanged(computeRMS(processed));
 #endif
 #ifdef HAVE_DFNR
-        } else if (m_dfnrEnabled && m_dfnr) {
-            QByteArray processed = m_dfnr->process(pcm);
-            // Re-apply pan lost during NR mono-mix (#1460)
-            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
-                              processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              sourcePan());
-            writeAudio(processed);
+        } else if (m_dfnrEnabled) {
+            DeepFilterFilter* dfnr = dfnrForSource(source, externalSource);
+            if (!dfnr) {
+                writeAudioAndLevel(pcm);
+                return;
+            }
+            QByteArray processed = dfnr->process(pcm);
+            writeAudio(processed, applyKiwiOutputPan);
             emit levelChanged(computeRMS(processed));
 #endif
 #ifdef HAVE_NVIDIA_AFX
-        } else if (m_nvAfxEnabled && m_nvAfx) {
-            QByteArray processed = m_nvAfx->process(pcm);
-            // Re-apply pan lost during NR mono-mix (#1460)
-            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
-                              processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              sourcePan());
-            writeAudio(processed);
+        } else if (m_nvAfxEnabled) {
+            NvidiaAfxFilter* nvAfx = nvAfxForSource(source, externalSource);
+            if (!nvAfx) {
+                writeAudioAndLevel(pcm);
+                return;
+            }
+            QByteArray processed = nvAfx->process(pcm);
+            writeAudio(processed, applyKiwiOutputPan);
             emit levelChanged(computeRMS(processed));
 #endif
 #ifdef __APPLE__
-        } else if (m_mnrEnabled && m_mnr) {
-            QByteArray processed = m_mnr->process(pcm);
-            // Re-apply pan lost during NR mono-mix (#1460)
-            applyRxPanInPlace(reinterpret_cast<float*>(processed.data()),
-                              processed.size() / (2 * static_cast<int>(sizeof(float))),
-                              sourcePan());
-            writeAudio(processed);
+        } else if (m_mnrEnabled) {
+            MacNRFilter* mnr = mnrForSource(source, externalSource);
+            if (!mnr) {
+                writeAudioAndLevel(pcm);
+                return;
+            }
+            QByteArray processed = mnr->process(pcm);
+            writeAudio(processed, applyKiwiOutputPan);
             emit levelChanged(computeRMS(processed));
 #endif
         } else {
@@ -5159,6 +5841,30 @@ static void applyNr2SettingsFromAppSettings(SpectralNR& nr2)
     nr2.setAeFilter(s.value("NR2AeFilter", "True").toString() == "True");
 }
 
+#ifdef HAVE_SPECBLEACH
+static void applyNr4SettingsFromAppSettings(SpecbleachFilter& nr4)
+{
+    auto& s = AppSettings::instance();
+    nr4.setReductionAmount(s.value("NR4ReductionAmount", "10.0").toFloat());
+    nr4.setSmoothingFactor(s.value("NR4SmoothingFactor", "0.0").toFloat());
+    nr4.setWhiteningFactor(s.value("NR4WhiteningFactor", "0.0").toFloat());
+    nr4.setAdaptiveNoise(s.value("NR4AdaptiveNoise", "True").toString() == "True");
+    nr4.setNoiseEstimationMethod(s.value("NR4NoiseEstimationMethod", "0").toInt());
+    nr4.setMaskingDepth(s.value("NR4MaskingDepth", "0.50").toFloat());
+    nr4.setSuppressionStrength(
+        s.value("NR4SuppressionStrength", "0.50").toFloat());
+}
+#endif
+
+#ifdef HAVE_DFNR
+static void applyDfnrSettingsFromAppSettings(DeepFilterFilter& dfnr)
+{
+    auto& s = AppSettings::instance();
+    dfnr.setAttenLimit(s.value("DfnrAttenLimit", "100").toFloat());
+    dfnr.setPostFilterBeta(s.value("DfnrPostFilterBeta", "0.0").toFloat());
+}
+#endif
+
 bool AudioEngine::needsWisdomGeneration()
 {
 #ifndef HAVE_FFTW3
@@ -5202,11 +5908,7 @@ void AudioEngine::setNr2Enabled(bool on)
     m_kiwiSdrOutputBuffer.clear();
     m_kiwiSdrRxResampler.reset();
     m_kiwiSdrRxResamplerR.reset();
-    m_nr2Mono.clear();
-    m_nr2Processed.clear();
     m_nr2Output.clear();
-    m_kiwiSdrNr2Mono.clear();
-    m_kiwiSdrNr2Processed.clear();
     m_kiwiSdrNr2Output.clear();
     m_kiwiSdrPrebuffering.store(kiwiSdrAudioActive(),
                                 std::memory_order_relaxed);
@@ -5217,8 +5919,6 @@ void AudioEngine::setNr2Enabled(bool on)
         source->rxBuffer.clear();
         source->rxPackets.clear();
         source->outputBuffer.clear();
-        source->nr2Mono.clear();
-        source->nr2Processed.clear();
         source->nr2Output.clear();
         source->rxResampler.reset();
         source->rxResamplerR.reset();
@@ -5240,31 +5940,22 @@ void AudioEngine::setNr2Enabled(bool on)
                                << "using runtime FFTW_MEASURE plans";
 #endif
         m_nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        m_kiwiSdrNr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-        if (m_nr2->hasPlanFailed() || m_kiwiSdrNr2->hasPlanFailed()) {
+        if (m_nr2->hasPlanFailed()) {
             qCWarning(lcAudio) << "AudioEngine: NR2 FFTW plan creation failed — disabling";
             m_nr2.reset();
-            m_kiwiSdrNr2.reset();
             emit nr2EnabledChanged(false);
             return;
         }
         // Restore user-adjusted parameters from AppSettings
         applyNr2SettingsFromAppSettings(*m_nr2);
-        applyNr2SettingsFromAppSettings(*m_kiwiSdrNr2);
+        m_nr2Enabled = true;
+        ensureLegacyKiwiDspState();
         for (const auto& source : m_externalKiwiSources) {
             if (!source) {
                 continue;
             }
-            source->nr2 = std::make_unique<SpectralNR>(256, DEFAULT_SAMPLE_RATE);
-            if (source->nr2->hasPlanFailed()) {
-                qCWarning(lcAudio) << "AudioEngine: external Kiwi NR2 plan failed for"
-                                   << source->id;
-                source->nr2.reset();
-            } else {
-                applyNr2SettingsFromAppSettings(*source->nr2);
-            }
+            ensureExternalKiwiSourceDspState(*source);
         }
-        m_nr2Enabled = true;
     } else {
         m_nr2Enabled = false;
         m_nr2.reset();
@@ -5274,8 +5965,6 @@ void AudioEngine::setNr2Enabled(bool on)
                 continue;
             }
             source->nr2.reset();
-            source->nr2Mono.clear();
-            source->nr2Processed.clear();
             source->nr2Output.clear();
             source->outputBuffer.clear();
             source->rxResampler.reset();
@@ -5366,38 +6055,132 @@ void AudioEngine::setNr4Enabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_nr4 = std::make_unique<SpecbleachFilter>();
-        if (!m_nr4->isValid()) {
-            qCWarning(lcAudio) << "AudioEngine: NR4 initialization failed";
+        m_nr4 = createNr4Filter(QStringLiteral("Flex"));
+        if (!m_nr4) {
             m_nr4.reset();
             emit nr4EnabledChanged(false);
             return;
         }
-        // Restore all saved params
-        auto& s = AppSettings::instance();
-        m_nr4->setReductionAmount(s.value("NR4ReductionAmount", "10.0").toFloat());
-        m_nr4->setSmoothingFactor(s.value("NR4SmoothingFactor", "0.0").toFloat());
-        m_nr4->setWhiteningFactor(s.value("NR4WhiteningFactor", "0.0").toFloat());
-        m_nr4->setAdaptiveNoise(s.value("NR4AdaptiveNoise", "True").toString() == "True");
-        m_nr4->setNoiseEstimationMethod(s.value("NR4NoiseEstimationMethod", "0").toInt());
-        m_nr4->setMaskingDepth(s.value("NR4MaskingDepth", "0.50").toFloat());
-        m_nr4->setSuppressionStrength(s.value("NR4SuppressionStrength", "0.50").toFloat());
         m_nr4Enabled = true;
+        ensureLegacyKiwiDspState();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            ensureExternalKiwiSourceDspState(*source);
+        }
     } else {
         m_nr4Enabled = false;
         m_nr4.reset();
+        m_kiwiSdrNr4.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (source) {
+                source->nr4.reset();
+            }
+        }
     }
     qCDebug(lcAudio) << "AudioEngine: NR4" << (on ? "enabled" : "disabled");
     emit nr4EnabledChanged(on);
 }
 
-void AudioEngine::setNr4ReductionAmount(float dB) { if (m_nr4) m_nr4->setReductionAmount(dB); }
-void AudioEngine::setNr4SmoothingFactor(float pct) { if (m_nr4) m_nr4->setSmoothingFactor(pct); }
-void AudioEngine::setNr4WhiteningFactor(float pct) { if (m_nr4) m_nr4->setWhiteningFactor(pct); }
-void AudioEngine::setNr4AdaptiveNoise(bool on) { if (m_nr4) m_nr4->setAdaptiveNoise(on); }
-void AudioEngine::setNr4NoiseEstimationMethod(int m) { if (m_nr4) m_nr4->setNoiseEstimationMethod(m); }
-void AudioEngine::setNr4MaskingDepth(float v) { if (m_nr4) m_nr4->setMaskingDepth(v); }
-void AudioEngine::setNr4SuppressionStrength(float v) { if (m_nr4) m_nr4->setSuppressionStrength(v); }
+void AudioEngine::setNr4ReductionAmount(float dB)
+{
+    if (m_nr4) {
+        m_nr4->setReductionAmount(dB);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setReductionAmount(dB);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setReductionAmount(dB);
+        }
+    }
+}
+void AudioEngine::setNr4SmoothingFactor(float pct)
+{
+    if (m_nr4) {
+        m_nr4->setSmoothingFactor(pct);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setSmoothingFactor(pct);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setSmoothingFactor(pct);
+        }
+    }
+}
+void AudioEngine::setNr4WhiteningFactor(float pct)
+{
+    if (m_nr4) {
+        m_nr4->setWhiteningFactor(pct);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setWhiteningFactor(pct);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setWhiteningFactor(pct);
+        }
+    }
+}
+void AudioEngine::setNr4AdaptiveNoise(bool on)
+{
+    if (m_nr4) {
+        m_nr4->setAdaptiveNoise(on);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setAdaptiveNoise(on);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setAdaptiveNoise(on);
+        }
+    }
+}
+void AudioEngine::setNr4NoiseEstimationMethod(int m)
+{
+    if (m_nr4) {
+        m_nr4->setNoiseEstimationMethod(m);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setNoiseEstimationMethod(m);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setNoiseEstimationMethod(m);
+        }
+    }
+}
+void AudioEngine::setNr4MaskingDepth(float v)
+{
+    if (m_nr4) {
+        m_nr4->setMaskingDepth(v);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setMaskingDepth(v);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setMaskingDepth(v);
+        }
+    }
+}
+void AudioEngine::setNr4SuppressionStrength(float v)
+{
+    if (m_nr4) {
+        m_nr4->setSuppressionStrength(v);
+    }
+    if (m_kiwiSdrNr4) {
+        m_kiwiSdrNr4->setSuppressionStrength(v);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nr4) {
+            source->nr4->setSuppressionStrength(v);
+        }
+    }
+}
 #else // !HAVE_SPECBLEACH — stubs
 void AudioEngine::setNr4Enabled(bool on) { if (on) emit nr4EnabledChanged(false); }
 void AudioEngine::setNr4ReductionAmount(float) {}
@@ -5422,18 +6205,31 @@ void AudioEngine::setMnrEnabled(bool on)
         if (m_nr4Enabled)  setNr4Enabled(false);
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
-        m_mnr = std::make_unique<MacNRFilter>();
-        if (!m_mnr->isValid()) {
-            qCWarning(lcAudio) << "AudioEngine: MNR vDSP setup failed — disabling";
-            m_mnr.reset();
-            return;
-        }
         // Restore strength from settings (default 1.0 = full suppression)
         m_mnrStrength.store(std::clamp(
             AppSettings::instance().value("MnrStrength", "1.00").toFloat(), 0.0f, 1.0f));
-        m_mnr->setStrength(m_mnrStrength.load());
+        m_mnr = createMnrFilter(QStringLiteral("Flex"));
+        if (!m_mnr) {
+            m_mnr.reset();
+            emit mnrEnabledChanged(false);
+            return;
+        }
+        m_mnrEnabled = true;
+        ensureLegacyKiwiDspState();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            ensureExternalKiwiSourceDspState(*source);
+        }
     } else {
         m_mnr.reset();
+        m_kiwiSdrMnr.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (source) {
+                source->mnr.reset();
+            }
+        }
     }
 #endif
     m_mnrEnabled = on;
@@ -5446,7 +6242,17 @@ void AudioEngine::setMnrStrength(float normalized)
     AppSettings::instance().setValue("MnrStrength",
         QString::number(m_mnrStrength.load(), 'f', 2));
 #ifdef __APPLE__
-    if (m_mnr) m_mnr->setStrength(m_mnrStrength.load());
+    if (m_mnr) {
+        m_mnr->setStrength(m_mnrStrength.load());
+    }
+    if (m_kiwiSdrMnr) {
+        m_kiwiSdrMnr->setStrength(m_mnrStrength.load());
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->mnr) {
+            source->mnr->setStrength(m_mnrStrength.load());
+        }
+    }
 #endif
 }
 
@@ -5466,18 +6272,29 @@ void AudioEngine::setRn2Enabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_rn2 = std::make_unique<RNNoiseFilter>();
-        if (!m_rn2->isValid()) {
-            qCWarning(lcAudio) << "AudioEngine: RN2 rnnoise_create() failed — disabling";
+        m_rn2 = createRn2Filter(QStringLiteral("Flex"));
+        if (!m_rn2) {
             m_rn2.reset();
             emit rn2EnabledChanged(false);
             return;
         }
-        // Set flag AFTER object is fully constructed
         m_rn2Enabled = true;
+        ensureLegacyKiwiDspState();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            ensureExternalKiwiSourceDspState(*source);
+        }
     } else {
         m_rn2Enabled = false;
         m_rn2.reset();
+        m_kiwiSdrRn2.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (source) {
+                source->rn2.reset();
+            }
+        }
     }
     qCDebug(lcAudio) << "AudioEngine: RN2 (RNNoise)" << (on ? "enabled" : "disabled");
     emit rn2EnabledChanged(on);
@@ -5526,22 +6343,29 @@ void AudioEngine::setDfnrEnabled(bool on)
         if (m_nr4Enabled)  setNr4Enabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
-        m_dfnr = std::make_unique<DeepFilterFilter>();
-        if (!m_dfnr->isValid()) {
-            qCWarning(lcAudio) << "AudioEngine: DFNR df_create() failed — disabling";
+        m_dfnr = createDfnrFilter(QStringLiteral("Flex"));
+        if (!m_dfnr) {
             m_dfnr.reset();
             emit dfnrEnabledChanged(false);
             return;
         }
-        // Restore saved attenuation limit
-        auto& s = AppSettings::instance();
-        m_dfnr->setAttenLimit(s.value("DfnrAttenLimit", "100").toFloat());
-        m_dfnr->setPostFilterBeta(s.value("DfnrPostFilterBeta", "0.0").toFloat());
-        // Set flag AFTER object is fully constructed
         m_dfnrEnabled = true;
+        ensureLegacyKiwiDspState();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            ensureExternalKiwiSourceDspState(*source);
+        }
     } else {
         m_dfnrEnabled = false;
         m_dfnr.reset();
+        m_kiwiSdrDfnr.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (source) {
+                source->dfnr.reset();
+            }
+        }
     }
     qCDebug(lcAudio) << "AudioEngine: DFNR (DeepFilterNet3)" << (on ? "enabled" : "disabled");
     emit dfnrEnabledChanged(on);
@@ -5549,7 +6373,17 @@ void AudioEngine::setDfnrEnabled(bool on)
 
 void AudioEngine::setDfnrAttenLimit(float db)
 {
-    if (m_dfnr) m_dfnr->setAttenLimit(db);
+    if (m_dfnr) {
+        m_dfnr->setAttenLimit(db);
+    }
+    if (m_kiwiSdrDfnr) {
+        m_kiwiSdrDfnr->setAttenLimit(db);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->dfnr) {
+            source->dfnr->setAttenLimit(db);
+        }
+    }
 }
 
 float AudioEngine::dfnrAttenLimit() const
@@ -5559,7 +6393,17 @@ float AudioEngine::dfnrAttenLimit() const
 
 void AudioEngine::setDfnrPostFilterBeta(float beta)
 {
-    if (m_dfnr) m_dfnr->setPostFilterBeta(beta);
+    if (m_dfnr) {
+        m_dfnr->setPostFilterBeta(beta);
+    }
+    if (m_kiwiSdrDfnr) {
+        m_kiwiSdrDfnr->setPostFilterBeta(beta);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->dfnr) {
+            source->dfnr->setPostFilterBeta(beta);
+        }
+    }
 }
 
 #else // !HAVE_DFNR — stubs
@@ -5585,19 +6429,29 @@ void AudioEngine::setNvAfxEnabled(bool on)
         if (m_dfnrEnabled) setDfnrEnabled(false);
         if (m_nvAfxEnabled) setNvAfxEnabled(false);
         if (m_mnrEnabled)  setMnrEnabled(false);
-        m_nvAfx = std::make_unique<NvidiaAfxFilter>();
-        if (!m_nvAfx->isValid()) {
-            qCWarning(lcAudio) << "AudioEngine: NVIDIA AFX denoiser unavailable —"
-                               << m_nvAfx->lastError();
+        m_nvAfx = createNvAfxFilter(QStringLiteral("Flex"));
+        if (!m_nvAfx) {
             m_nvAfx.reset();
             emit nvAfxEnabledChanged(false);
             return;
         }
-        m_nvAfx->setIntensity(NvidiaBnrSettings::intensity());
-        m_nvAfxEnabled = true;  // set AFTER the object is fully constructed
+        m_nvAfxEnabled = true;
+        ensureLegacyKiwiDspState();
+        for (const auto& source : m_externalKiwiSources) {
+            if (!source) {
+                continue;
+            }
+            ensureExternalKiwiSourceDspState(*source);
+        }
     } else {
         m_nvAfxEnabled = false;
         m_nvAfx.reset();
+        m_kiwiSdrNvAfx.reset();
+        for (const auto& source : m_externalKiwiSources) {
+            if (source) {
+                source->nvAfx.reset();
+            }
+        }
     }
     qCDebug(lcAudio) << "AudioEngine: NVIDIA AFX denoiser" << (on ? "enabled" : "disabled");
     emit nvAfxEnabledChanged(on);
@@ -5605,7 +6459,17 @@ void AudioEngine::setNvAfxEnabled(bool on)
 
 void AudioEngine::setNvAfxIntensity(float ratio)
 {
-    if (m_nvAfx) m_nvAfx->setIntensity(ratio);
+    if (m_nvAfx) {
+        m_nvAfx->setIntensity(ratio);
+    }
+    if (m_kiwiSdrNvAfx) {
+        m_kiwiSdrNvAfx->setIntensity(ratio);
+    }
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->nvAfx) {
+            source->nvAfx->setIntensity(ratio);
+        }
+    }
 }
 
 #else // !HAVE_NVIDIA_AFX — stubs
@@ -5623,12 +6487,6 @@ void AudioEngine::processNr2(const QByteArray& stereoPcm,
     SpectralNR* nr2 = externalSource
         ? externalSource->nr2.get()
         : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2.get() : m_nr2.get());
-    std::vector<float>& mono = externalSource
-        ? externalSource->nr2Mono
-        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Mono : m_nr2Mono);
-    std::vector<float>& processed = externalSource
-        ? externalSource->nr2Processed
-        : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Processed : m_nr2Processed);
     QByteArray& output = externalSource
         ? externalSource->nr2Output
         : (source == RxDspSource::KiwiSdr ? m_kiwiSdrNr2Output : m_nr2Output);
@@ -5637,33 +6495,27 @@ void AudioEngine::processNr2(const QByteArray& stereoPcm,
         return;
     }
 
-    // Resize pre-allocated buffers if needed
-    if (static_cast<int>(mono.size()) < stereoFrames) {
-        mono.resize(stereoFrames);
-        processed.resize(stereoFrames);
-    }
+    // Compute one NR2 mask from mono analysis, then apply it to both original
+    // channels.  Flex remote_audio_rx is already a radio-mixed stereo stream;
+    // duplicating a mono NR output and panning from the active slice loses the
+    // per-slice balance inside that stream (#4035).
+    processNr2StereoSharedMask(*nr2, src, stereoFrames, output);
+}
 
-    // Stereo float32 → mono float32 (average L+R)
-    for (int i = 0; i < stereoFrames; ++i)
-        mono[i] = (src[2 * i] + src[2 * i + 1]) * 0.5f;
-
-    // Process through SpectralNR (float32 I/O)
-    nr2->process(mono.data(), processed.data(), stereoFrames);
-
-    // Mono float32 → stereo float32, then re-apply the pan the radio had set
-    // before NR mono-mixed it away (#1460).
+void AudioEngine::processNr2StereoSharedMask(SpectralNR& nr2,
+                                             const float* src,
+                                             int stereoFrames,
+                                             QByteArray& output)
+{
     // Hard-clamp to ±1.0: if gainMax was tuned above 1.0 (not recommended),
     // unclamped samples would cause digital crackling at the audio sink (#1507).
     const int outBytes = stereoFrames * 2 * static_cast<int>(sizeof(float));
     output.resize(outBytes);
     auto* dst = reinterpret_cast<float*>(output.data());
-    for (int i = 0; i < stereoFrames; ++i) {
-        const float s = std::clamp(processed[i], -1.0f, 1.0f);
-        dst[2 * i]     = s;
-        dst[2 * i + 1] = s;
+    nr2.processStereoSharedMask(src, dst, stereoFrames);
+    for (int i = 0; i < stereoFrames * 2; ++i) {
+        dst[i] = std::clamp(dst[i], -1.0f, 1.0f);
     }
-    const int pan = externalSource ? externalSource->pan : m_rxPan.load();
-    applyRxPanInPlace(dst, stereoFrames, pan);
 }
 
 QByteArray AudioEngine::applyBoost(const QByteArray& pcm, float gain) const

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -17,6 +17,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QElapsedTimer>
+#include <QFutureSynchronizer>
 #include <QPointer>
 #include <QString>
 #include <QStringList>
@@ -672,6 +673,7 @@ private:
         bool enabled{false};
         bool muted{false};
         bool prebuffering{false};
+        bool dspInitializationPending{false};
     };
 
     struct AutomationAudioCaptureChunk {
@@ -725,7 +727,9 @@ private:
     bool anyExternalKiwiBufferQueued() const;
     qsizetype externalKiwiOutputBufferBytes() const;
     bool ensureLegacyKiwiDspState();
-    bool ensureExternalKiwiSourceDspState(ExternalRxAudioSourceState& source);
+    bool ensureExternalKiwiSourceDspState(const QString& sourceId);
+    bool ensureAllKiwiDspState();
+    void scheduleAllKiwiDspStateInitialization();
     void resetLegacyKiwiDspState();
     void clearLegacyKiwiDspState();
     void resetExternalKiwiDspState(ExternalRxAudioSourceState& source);
@@ -928,7 +932,8 @@ private:
 
     // DSP lifecycle mutex: held during feedAudioData() DSP section AND
     // during enable/disable to prevent use-after-free (#502)
-    std::recursive_mutex m_dspMutex;
+    mutable std::recursive_mutex m_dspMutex;
+    quint64 m_dspConfigurationGeneration{0};
 
     // Client-side NR2 (spectral)
     std::unique_ptr<SpectralNR> m_nr2;
@@ -1114,6 +1119,10 @@ private:
     QByteArray    m_kiwiSdrOutputBuffer;  // post-DSP Kiwi speaker audio at output device rate
     QByteArray    m_radeRxBuffer;  // decoded RADE speech at output device rate
     std::atomic<bool> m_kiwiSdrAudioEnabled{false};
+    bool m_legacyKiwiDspInitializationPending{false};
+    QFutureSynchronizer<void> m_dspInitializationTasks;
+    std::mutex m_dspInitializationTasksMutex;
+    bool m_dspInitializationStopping{false};
     std::atomic<bool> m_kiwiSdrAudioTransmitMuted{false};
     std::atomic<int>  m_flexReceivePresentationDelayMs{0};
     std::atomic<int>  m_kiwiReceivePresentationDelayMs{0};

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -141,9 +141,8 @@ public:
     float rxOutputTrimDb() const { return m_rxOutputTrimDb.load(); }
 
     // Client-side RX pan (0=full-left, 50=centre, 100=full-right).
-    // Normally the radio handles panning, but client-side NR mono-mixes
-    // L+R, discarding the balance. This re-applies it to the NR output
-    // so that the pan slider still works when NR2/NR4/etc. are active (#1460).
+    // Normally the radio handles Flex panning. External single-source audio
+    // still uses this as an output pan after stereo-preserving client DSP.
     void setRxPan(int panValue);
     int  rxPan() const { return m_rxPan.load(); }
     void  setRxBufferCapMs(int ms) { m_rxBufferCapMs.store(qBound(50, ms, 1000)); }
@@ -170,6 +169,8 @@ public:
                                             const QStringList& points);
     QJsonObject stopAutomationAudioCapture();
     QJsonObject automationAudioCaptureSnapshot(bool includePcm) const;
+    QJsonObject automationNr2StereoProbe() const;
+    QJsonObject automationDspStereoProbe(const QString& mode) const;
 
     // Client-side PC mic gain (0-100 → 0.0-1.0, applied before Opus encoding)
     void setPcMicGain(int level) { m_pcMicGain.store(qBound(0, level, 100) / 100.0f); }
@@ -648,10 +649,21 @@ private:
         QByteArray rxBuffer;
         std::deque<QByteArray> rxPackets;
         QByteArray outputBuffer;
-        std::vector<float> nr2Mono;
-        std::vector<float> nr2Processed;
         QByteArray nr2Output;
         std::unique_ptr<SpectralNR> nr2;
+        std::unique_ptr<RNNoiseFilter> rn2;
+#ifdef HAVE_SPECBLEACH
+        std::unique_ptr<SpecbleachFilter> nr4;
+#endif
+#ifdef __APPLE__
+        std::unique_ptr<MacNRFilter> mnr;
+#endif
+#ifdef HAVE_DFNR
+        std::unique_ptr<DeepFilterFilter> dfnr;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+        std::unique_ptr<NvidiaAfxFilter> nvAfx;
+#endif
         std::unique_ptr<Resampler> rxResampler;
         std::unique_ptr<Resampler> rxResamplerR;
         float gain{1.0f};
@@ -700,6 +712,10 @@ private:
     void processNr2(const QByteArray& stereoPcm,
                     RxDspSource source = RxDspSource::Main,
                     ExternalRxAudioSourceState* externalSource = nullptr);
+    static void processNr2StereoSharedMask(SpectralNR& nr2,
+                                           const float* src,
+                                           int stereoFrames,
+                                           QByteArray& output);
     void updateRxBufferStats();
     ExternalRxAudioSourceState* externalKiwiSource(const QString& sourceId,
                                                    bool create);
@@ -708,6 +724,38 @@ private:
     bool anyExternalKiwiAudioEnabled() const;
     bool anyExternalKiwiBufferQueued() const;
     qsizetype externalKiwiOutputBufferBytes() const;
+    bool ensureLegacyKiwiDspState();
+    bool ensureExternalKiwiSourceDspState(ExternalRxAudioSourceState& source);
+    void resetLegacyKiwiDspState();
+    void clearLegacyKiwiDspState();
+    void resetExternalKiwiDspState(ExternalRxAudioSourceState& source);
+    void clearExternalKiwiDspState(ExternalRxAudioSourceState& source);
+    std::unique_ptr<RNNoiseFilter> createRn2Filter(const QString& label) const;
+    RNNoiseFilter* rn2ForSource(RxDspSource source,
+                                ExternalRxAudioSourceState* externalSource) const;
+#ifdef HAVE_SPECBLEACH
+    std::unique_ptr<SpecbleachFilter> createNr4Filter(const QString& label) const;
+    SpecbleachFilter* nr4ForSource(
+        RxDspSource source,
+        ExternalRxAudioSourceState* externalSource) const;
+#endif
+#ifdef __APPLE__
+    std::unique_ptr<MacNRFilter> createMnrFilter(const QString& label) const;
+    MacNRFilter* mnrForSource(RxDspSource source,
+                              ExternalRxAudioSourceState* externalSource) const;
+#endif
+#ifdef HAVE_DFNR
+    std::unique_ptr<DeepFilterFilter> createDfnrFilter(const QString& label) const;
+    DeepFilterFilter* dfnrForSource(
+        RxDspSource source,
+        ExternalRxAudioSourceState* externalSource) const;
+#endif
+#ifdef HAVE_NVIDIA_AFX
+    std::unique_ptr<NvidiaAfxFilter> createNvAfxFilter(const QString& label) const;
+    NvidiaAfxFilter* nvAfxForSource(
+        RxDspSource source,
+        ExternalRxAudioSourceState* externalSource) const;
+#endif
     // Apply client-side TX EQ in-place. No-op if disabled. Caller owns data.
     void applyClientEqTxInt16(QByteArray& int16stereo);
     void applyClientEqTxFloat32(QByteArray& float32);
@@ -889,18 +937,21 @@ private:
     // Client-side NR4 (libspecbleach)
 #ifdef HAVE_SPECBLEACH
     std::unique_ptr<SpecbleachFilter> m_nr4;
+    std::unique_ptr<SpecbleachFilter> m_kiwiSdrNr4;
 #endif
     std::atomic<bool> m_nr4Enabled{false};
 
     // Client-side MNR (macOS MMSE-Wiener)
 #ifdef __APPLE__
     std::unique_ptr<MacNRFilter> m_mnr;
+    std::unique_ptr<MacNRFilter> m_kiwiSdrMnr;
 #endif
     std::atomic<bool>  m_mnrEnabled{false};
     std::atomic<float> m_mnrStrength{1.0f};
 
     // Client-side RN2 (RNNoise)
     std::unique_ptr<RNNoiseFilter> m_rn2;
+    std::unique_ptr<RNNoiseFilter> m_kiwiSdrRn2;
     std::atomic<bool> m_rn2Enabled{false};
 
     // Client-side RN2 — TX path (mic pre-amp).  Lazy-allocated under
@@ -915,6 +966,7 @@ private:
     // Client-side DFNR (DeepFilterNet3)
 #ifdef HAVE_DFNR
     std::unique_ptr<DeepFilterFilter> m_dfnr;
+    std::unique_ptr<DeepFilterFilter> m_kiwiSdrDfnr;
 #endif
     std::atomic<bool> m_dfnrEnabled{false};
 
@@ -922,6 +974,7 @@ private:
     // mutual-exclusion in the other NR setters compiles regardless of the build).
 #ifdef HAVE_NVIDIA_AFX
     std::unique_ptr<NvidiaAfxFilter> m_nvAfx;
+    std::unique_ptr<NvidiaAfxFilter> m_kiwiSdrNvAfx;
 #endif
     std::atomic<bool> m_nvAfxEnabled{false};
 
@@ -1017,12 +1070,8 @@ private:
     void tapClientEqTxInt16(const int16_t* int16stereo, int frames);
     void tapClientEqTxFloat32(const float* f32, int samples, int channels);
 
-    // Pre-allocated NR2 work buffers (avoid per-call heap allocation)
-    std::vector<float> m_nr2Mono;
-    std::vector<float> m_nr2Processed;
+    // Pre-allocated NR2 output buffers (avoid per-call heap allocation)
     QByteArray m_nr2Output;
-    std::vector<float> m_kiwiSdrNr2Mono;
-    std::vector<float> m_kiwiSdrNr2Processed;
     QByteArray m_kiwiSdrNr2Output;
 
     // Zombie sink watchdog: tracks consecutive RX timer ticks where we have

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1260,7 +1260,11 @@ QJsonObject sliceSnapshot(const SliceModel* s)
         {QStringLiteral("txAntenna"),  s->txAntenna()},   // live TX antenna — lets a driver enforce the dummy-load gate before keying (#3646)
         {QStringLiteral("rfGain"),     s->rfGain()},
         {QStringLiteral("audioGain"),  s->audioGain()},
+        {QStringLiteral("flexAudioGain"), s->flexAudioGain()},
         {QStringLiteral("audioPan"),   s->audioPan()},
+        {QStringLiteral("flexAudioPan"), s->flexAudioPan()},
+        {QStringLiteral("audioMute"),  s->audioMute()},
+        {QStringLiteral("flexAudioMute"), s->flexAudioMute()},
         {QStringLiteral("locked"),     s->isLocked()},
         {QStringLiteral("diversity"),  s->diversity()},
         {QStringLiteral("diversityParent"), s->isDiversityParent()},
@@ -2571,7 +2575,8 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doTci(a.action, a.value);
             });
 
-        add("audioCapture", {}, "audioCapture <start|stop|status|read> [args]",
+        add("audioCapture", {},
+            "audioCapture <start|stop|status|read|probeNr2Stereo|probeDspStereo> [args]",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doAudioCapture(a.action.isEmpty() ? QStringLiteral("status")
@@ -6693,7 +6698,14 @@ QJsonObject AutomationServer::doAudioCapture(const QString& action,
         };
     }
 
-    return err(QStringLiteral("audioCapture action must be start, stop, status, or read"));
+    if (normalizedAction == QLatin1String("probenr2stereo")) {
+        return m_audioEngine->automationNr2StereoProbe();
+    }
+    if (normalizedAction == QLatin1String("probedspstereo")) {
+        return m_audioEngine->automationDspStereoProbe(arg);
+    }
+
+    return err(QStringLiteral("audioCapture action must be start, stop, status, read, probeNr2Stereo, or probeDspStereo"));
 }
 
 QJsonObject AutomationServer::doWhoami() const

--- a/src/core/DeepFilterFilter.cpp
+++ b/src/core/DeepFilterFilter.cpp
@@ -188,6 +188,10 @@ DeepFilterFilter::DeepFilterFilter()
     m_state = df_create(modelPath.constData(), m_attenLimit.load(), nullptr);
     if (m_state) {
         m_frameSize = static_cast<int>(df_get_frame_length(m_state));
+        // The bundled DFN3 model uses fft_size=960, hop_size=480 and two
+        // lookahead frames. Its documented delay is
+        // (fft_size - hop_size) + lookahead * hop_size = 3 hops at 48 kHz.
+        m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize / 2);
         qDebug() << "DeepFilterFilter: initialized, frame size =" << m_frameSize;
     } else {
         qWarning() << "DeepFilterFilter: df_create() failed!";
@@ -212,6 +216,7 @@ void DeepFilterFilter::reset()
         m_state = df_create(modelPath.constData(), m_attenLimit.load(), nullptr);
         if (m_state) {
             m_frameSize = static_cast<int>(df_get_frame_length(m_state));
+            m_stereoAdapter.setProcessingLatencyFrames(3 * m_frameSize / 2);
         }
     }
     m_up = std::make_unique<Resampler>(24000, 48000);
@@ -252,11 +257,11 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
 
     // 1. Downmix, then upsample 24kHz mono float32 → 48kHz mono float32 via r8brain.
     // The dry stereo stays queued so DeepFilterNet attenuation preserves balance.
-    std::vector<float> mono24k(stereoFrames);
+    m_mono24k.resize(stereoFrames);
     for (int i = 0; i < stereoFrames; ++i) {
-        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+        m_mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
     }
-    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
+    QByteArray mono48k = m_up->process(m_mono24k.data(), stereoFrames);
 
     // Already float32 in [-1, 1] range — DeepFilterNet's native format
     const auto* mono48kSamples = reinterpret_cast<const float*>(mono48k.constData());
@@ -278,12 +283,12 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
 
     if (completeFrames > 0) {
         auto* accumData = reinterpret_cast<float*>(m_inAccum.data());
-        std::vector<float> processed48k(completeFrames * m_frameSize);
+        m_processed48k.resize(completeFrames * m_frameSize);
 
         for (int f = 0; f < completeFrames; ++f) {
             df_process_frame(m_state,
                              &accumData[f * m_frameSize],
-                             &processed48k[f * m_frameSize]);
+                             &m_processed48k[f * m_frameSize]);
         }
 
         // Keep leftover input samples
@@ -301,7 +306,8 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
         //    then apply the shared attenuation to delayed dry stereo.
         const int outputMonoSamples = completeFrames * m_frameSize;
 
-        QByteArray downsampled = m_down->process(processed48k.data(), outputMonoSamples);
+        QByteArray downsampled = m_down->process(
+            m_processed48k.data(), outputMonoSamples);
         const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
         const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
 

--- a/src/core/DeepFilterFilter.cpp
+++ b/src/core/DeepFilterFilter.cpp
@@ -4,6 +4,7 @@
 #include "Resampler.h"
 #include "deep_filter.h"
 
+#include <cstddef>
 #include <cstring>
 #include <vector>
 #include <QCoreApplication>
@@ -283,7 +284,9 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
 
     if (completeFrames > 0) {
         auto* accumData = reinterpret_cast<float*>(m_inAccum.data());
-        m_processed48k.resize(completeFrames * m_frameSize);
+        m_processed48k.resize(
+            static_cast<std::size_t>(completeFrames)
+            * static_cast<std::size_t>(m_frameSize));
 
         for (int f = 0; f < completeFrames; ++f) {
             df_process_frame(m_state,

--- a/src/core/DeepFilterFilter.cpp
+++ b/src/core/DeepFilterFilter.cpp
@@ -218,6 +218,7 @@ void DeepFilterFilter::reset()
     m_down = std::make_unique<Resampler>(48000, 24000);
     m_inAccum.clear();
     m_outAccum.clear();
+    m_stereoAdapter.reset();
     m_paramsDirty.store(true);
 }
 
@@ -247,9 +248,15 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
 
     const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
     const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    m_stereoAdapter.pushDryStereo(pcm24kStereo);
 
-    // 1. Upsample 24kHz stereo float32 → 48kHz mono float32 via r8brain
-    QByteArray mono48k = m_up->processStereoToMono(src, stereoFrames);
+    // 1. Downmix, then upsample 24kHz mono float32 → 48kHz mono float32 via r8brain.
+    // The dry stereo stays queued so DeepFilterNet attenuation preserves balance.
+    std::vector<float> mono24k(stereoFrames);
+    for (int i = 0; i < stereoFrames; ++i) {
+        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+    }
+    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
 
     // Already float32 in [-1, 1] range — DeepFilterNet's native format
     const auto* mono48kSamples = reinterpret_cast<const float*>(mono48k.constData());
@@ -290,13 +297,15 @@ QByteArray DeepFilterFilter::process(const QByteArray& pcm24kStereo)
             m_inAccum.clear();
         }
 
-        // 3. Downsample processed 48kHz mono float32 → 24kHz stereo float32
+        // 3. Downsample processed 48kHz mono float32 → 24kHz mono float32,
+        //    then apply the shared attenuation to delayed dry stereo.
         const int outputMonoSamples = completeFrames * m_frameSize;
 
-        QByteArray downsampled = m_down->processMonoToStereo(
-            processed48k.data(), outputMonoSamples);
+        QByteArray downsampled = m_down->process(processed48k.data(), outputMonoSamples);
+        const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
+        const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
 
-        m_outAccum.append(downsampled);
+        m_outAccum.append(m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
     }
 
     // 4. Return exactly the same number of bytes as input

--- a/src/core/DeepFilterFilter.h
+++ b/src/core/DeepFilterFilter.h
@@ -7,6 +7,7 @@
 #include <QByteArray>
 #include <atomic>
 #include <memory>
+#include <vector>
 
 struct DFState;
 
@@ -55,6 +56,8 @@ private:
     std::unique_ptr<Resampler> m_down;      // 48kHz mono → 24kHz mono
     QByteArray m_inAccum;                   // accumulate 48kHz mono float input
     QByteArray m_outAccum;                  // accumulate 24kHz stereo float output
+    std::vector<float> m_mono24k;
+    std::vector<float> m_processed48k;
     MonoDspStereoAdapter m_stereoAdapter;
     std::atomic<float> m_attenLimit{100.0f};
     std::atomic<float> m_postFilterBeta{0.0f};

--- a/src/core/DeepFilterFilter.h
+++ b/src/core/DeepFilterFilter.h
@@ -2,6 +2,8 @@
 
 #ifdef HAVE_DFNR
 
+#include "MonoDspStereoAdapter.h"
+
 #include <QByteArray>
 #include <atomic>
 #include <memory>
@@ -52,7 +54,8 @@ private:
     std::unique_ptr<Resampler> m_up;        // 24kHz mono → 48kHz mono
     std::unique_ptr<Resampler> m_down;      // 48kHz mono → 24kHz mono
     QByteArray m_inAccum;                   // accumulate 48kHz mono float input
-    QByteArray m_outAccum;                  // accumulate 24kHz stereo int16 output
+    QByteArray m_outAccum;                  // accumulate 24kHz stereo float output
+    MonoDspStereoAdapter m_stereoAdapter;
     std::atomic<float> m_attenLimit{100.0f};
     std::atomic<float> m_postFilterBeta{0.0f};
     std::atomic<bool>  m_paramsDirty{false};

--- a/src/core/MacNRFilter.cpp
+++ b/src/core/MacNRFilter.cpp
@@ -29,12 +29,16 @@ MacNRFilter::MacNRFilter()
     // first call to process() sees a centred first frame immediately and
     // latency is exactly one hop (H samples ≈ 10.7 ms at 24 kHz).
     m_inAccum.assign(N, 0.0f);
+    m_inAccumL.assign(N, 0.0f);
+    m_inAccumR.assign(N, 0.0f);
 
     // OLA and scratch buffers
-    m_olaBuffer.assign(N, 0.0f);
+    m_olaBufferL.assign(N, 0.0f);
+    m_olaBufferR.assign(N, 0.0f);
     m_frameBuf .assign(N, 0.0f);
     m_synthBuf .assign(N, 0.0f);
-    m_outAccum .clear();
+    m_outAccumL.clear();
+    m_outAccumR.clear();
 
     // Noise estimator
     m_noiseEst .assign(NBINS, 1e-6f);
@@ -64,11 +68,17 @@ void MacNRFilter::reset()
 {
     // Clear time-domain accumulators
     std::fill(m_inAccum .begin(), m_inAccum .end(), 0.0f);
-    std::fill(m_olaBuffer.begin(), m_olaBuffer.end(), 0.0f);
-    m_outAccum.clear();
+    std::fill(m_inAccumL.begin(), m_inAccumL.end(), 0.0f);
+    std::fill(m_inAccumR.begin(), m_inAccumR.end(), 0.0f);
+    std::fill(m_olaBufferL.begin(), m_olaBufferL.end(), 0.0f);
+    std::fill(m_olaBufferR.begin(), m_olaBufferR.end(), 0.0f);
+    m_outAccumL.clear();
+    m_outAccumR.clear();
 
     // Re-prime input accumulator for one-hop latency (same as constructor)
     m_inAccum.assign(N, 0.0f);
+    m_inAccumL.assign(N, 0.0f);
+    m_inAccumR.assign(N, 0.0f);
 
     // Reset noise estimator
     std::fill(m_noiseEst  .begin(), m_noiseEst  .end(), 1e-6f);
@@ -85,12 +95,12 @@ void MacNRFilter::reset()
     m_frameCount = 0;
 }
 
-// ── processFrame ────────────────────────────────────────────────────────────
+// ── updateGainFromFrame ─────────────────────────────────────────────────────
 //
-// inBuf  : N windowed analysis samples
-// outBuf : N synthesis samples (added into OLA buffer by caller)
+// inBuf: N mono analysis samples. Updates m_prevGain, which is then reused for
+// independent left/right synthesis so balance survives the MNR stage.
 
-void MacNRFilter::processFrame(const float* inBuf, float* outBuf)
+void MacNRFilter::updateGainFromFrame(const float* inBuf)
 {
     // ── 1. Apply analysis window and copy into frame buffer ─────────────────
     vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, N);
@@ -148,8 +158,22 @@ void MacNRFilter::processFrame(const float* inBuf, float* outBuf)
         m_prevGain[k] = appliedGain;
         m_prevPow [k] = m_powerBuf[k];
     }
+}
 
-    // ── 5. Apply gain to spectrum ────────────────────────────────────────────
+// ── synthesizeFrameWithCurrentGain ──────────────────────────────────────────
+//
+// inBuf  : N channel samples
+// outBuf : N synthesis samples (added into OLA buffer by caller)
+
+void MacNRFilter::synthesizeFrameWithCurrentGain(const float* inBuf, float* outBuf)
+{
+    vDSP_vmul(inBuf, 1, m_window.data(), 1, m_frameBuf.data(), 1, N);
+
+    DSPSplitComplex sc{ m_splitRe.data(), m_splitIm.data() };
+    vDSP_ctoz(reinterpret_cast<const DSPComplex*>(m_frameBuf.data()), 2, &sc, 1, H);
+    vDSP_fft_zrip(m_fftSetup, &sc, 1, LOG2N, kFFTDirection_Forward);
+
+    // ── Apply shared gain to spectrum ───────────────────────────────────────
     m_splitRe[0] *= m_prevGain[0];   // DC
     m_splitIm[0] *= m_prevGain[H];   // Nyquist (stored in im[0] by vDSP)
     for (int k = 1; k < H; ++k) {
@@ -183,41 +207,55 @@ QByteArray MacNRFilter::process(const QByteArray& pcm24kStereo)
     const int nFrames  = nBytes / (2 * sizeof(float));  // 2 ch × 4 bytes each
     const auto* src    = reinterpret_cast<const float*>(pcm24kStereo.constData());
 
-    // ── Stereo float32 → mono float (average channels) ──────────────────────
+    // ── Stereo float32 → shared mono analysis plus dry L/R synthesis inputs ──
     for (int i = 0; i < nFrames; ++i) {
         const float L = src[2 * i    ];
         const float R = src[2 * i + 1];
         m_inAccum.push_back(0.5f * (L + R));
+        m_inAccumL.push_back(L);
+        m_inAccumR.push_back(R);
     }
 
     // ── OLA processing — emit one hop per iteration ──────────────────────────
     while (static_cast<int>(m_inAccum.size()) >= N) {
-        // Overlap-add: accumulate synthesis output
-        std::vector<float> outFrame(N, 0.0f);
-        processFrame(m_inAccum.data(), outFrame.data());
+        updateGainFromFrame(m_inAccum.data());
+
+        std::vector<float> outFrameL(N, 0.0f);
+        std::vector<float> outFrameR(N, 0.0f);
+        synthesizeFrameWithCurrentGain(m_inAccumL.data(), outFrameL.data());
+        synthesizeFrameWithCurrentGain(m_inAccumR.data(), outFrameR.data());
 
         // Add into OLA buffer
-        for (int i = 0; i < N; ++i)
-            m_olaBuffer[i] += outFrame[i];
+        for (int i = 0; i < N; ++i) {
+            m_olaBufferL[i] += outFrameL[i];
+            m_olaBufferR[i] += outFrameR[i];
+        }
 
         // Flush the first H samples to output
-        for (int i = 0; i < H; ++i)
-            m_outAccum.push_back(m_olaBuffer[i]);
+        for (int i = 0; i < H; ++i) {
+            m_outAccumL.push_back(m_olaBufferL[i]);
+            m_outAccumR.push_back(m_olaBufferR[i]);
+        }
 
         // Shift OLA buffer left by H
-        std::copy(m_olaBuffer.begin() + H, m_olaBuffer.end(), m_olaBuffer.begin());
-        std::fill(m_olaBuffer.begin() + H, m_olaBuffer.end(), 0.0f);
+        std::copy(m_olaBufferL.begin() + H, m_olaBufferL.end(), m_olaBufferL.begin());
+        std::copy(m_olaBufferR.begin() + H, m_olaBufferR.end(), m_olaBufferR.begin());
+        std::fill(m_olaBufferL.begin() + H, m_olaBufferL.end(), 0.0f);
+        std::fill(m_olaBufferR.begin() + H, m_olaBufferR.end(), 0.0f);
 
         // Consume H input samples
         m_inAccum.erase(m_inAccum.begin(), m_inAccum.begin() + H);
+        m_inAccumL.erase(m_inAccumL.begin(), m_inAccumL.begin() + H);
+        m_inAccumR.erase(m_inAccumR.begin(), m_inAccumR.begin() + H);
 
         ++m_frameCount;
     }
 
-    // ── Drain exactly nFrames processed mono samples → stereo float32 ───────
+    // ── Drain exactly nFrames processed L/R samples → stereo float32 ────────
     // If the accumulator has fewer samples than needed (first few calls during
     // startup), pad with zeros rather than silence the whole buffer.
-    const int available = static_cast<int>(m_outAccum.size());
+    const int available = std::min(static_cast<int>(m_outAccumL.size()),
+                                   static_cast<int>(m_outAccumR.size()));
     const int take      = std::min(available, nFrames);
 
     QByteArray out;
@@ -225,9 +263,8 @@ QByteArray MacNRFilter::process(const QByteArray& pcm24kStereo)
     auto* dst = reinterpret_cast<float*>(out.data());
 
     for (int i = 0; i < take; ++i) {
-        const float s = m_outAccum[i];
-        dst[2 * i    ] = s;
-        dst[2 * i + 1] = s;
+        dst[2 * i    ] = m_outAccumL[i];
+        dst[2 * i + 1] = m_outAccumR[i];
     }
 
     // Zero-fill any samples not yet produced (startup transient only)
@@ -237,8 +274,10 @@ QByteArray MacNRFilter::process(const QByteArray& pcm24kStereo)
     }
 
     // Remove consumed samples
-    if (take > 0)
-        m_outAccum.erase(m_outAccum.begin(), m_outAccum.begin() + take);
+    if (take > 0) {
+        m_outAccumL.erase(m_outAccumL.begin(), m_outAccumL.begin() + take);
+        m_outAccumR.erase(m_outAccumR.begin(), m_outAccumR.begin() + take);
+    }
 
     return out;
 }

--- a/src/core/MacNRFilter.h
+++ b/src/core/MacNRFilter.h
@@ -26,8 +26,8 @@ namespace AetherSDR {
 //     gaps; startup latency is one hop (≈10.7 ms) of pre-filled zeros.
 //   - User-adjustable strength: 0 = bypass, 1 = full NR.
 //
-    // Processing chain (all at 24 kHz):
-    //   stereo float32 → shared mono FFT NR mask → independent L/R OLA synthesis
+// Processing chain (all at 24 kHz):
+//   stereo float32 -> shared mono FFT NR mask -> independent L/R OLA synthesis
 
 class MacNRFilter {
 public:

--- a/src/core/MacNRFilter.h
+++ b/src/core/MacNRFilter.h
@@ -26,8 +26,8 @@ namespace AetherSDR {
 //     gaps; startup latency is one hop (≈10.7 ms) of pre-filled zeros.
 //   - User-adjustable strength: 0 = bypass, 1 = full NR.
 //
-// Processing chain (all at 24 kHz):
-//   stereo float32 → mono float → FFT NR (512-pt OLA) → stereo float32
+    // Processing chain (all at 24 kHz):
+    //   stereo float32 → shared mono FFT NR mask → independent L/R OLA synthesis
 
 class MacNRFilter {
 public:
@@ -51,8 +51,8 @@ public:
     float strength()     const { return m_strength.load(); }
 
 private:
-    // Process one N-sample analysis frame; writes H output samples to outBuf.
-    void processFrame(const float* inBuf, float* outBuf);
+    void updateGainFromFrame(const float* inBuf);
+    void synthesizeFrameWithCurrentGain(const float* inBuf, float* outBuf);
 
     // ── FFT parameters ─────────────────────────────────────────────────
     static constexpr int LOG2N = 9;           // log2(512)
@@ -76,10 +76,14 @@ private:
     // ── OLA buffers ────────────────────────────────────────────────────
     std::vector<float> m_window;    // sqrt-Hann analysis+synthesis window [N]
     std::vector<float> m_inAccum;   // 24 kHz mono float input accumulator
-    std::vector<float> m_olaBuffer; // overlap-add accumulator [N]
+    std::vector<float> m_inAccumL;  // 24 kHz left-channel input accumulator
+    std::vector<float> m_inAccumR;  // 24 kHz right-channel input accumulator
+    std::vector<float> m_olaBufferL; // left overlap-add accumulator [N]
+    std::vector<float> m_olaBufferR; // right overlap-add accumulator [N]
     std::vector<float> m_frameBuf;  // windowed analysis frame [N]
     std::vector<float> m_synthBuf;  // synthesis frame [N]
-    std::vector<float> m_outAccum;  // processed 24 kHz mono float output
+    std::vector<float> m_outAccumL; // processed 24 kHz left-channel output
+    std::vector<float> m_outAccumR; // processed 24 kHz right-channel output
 
     // ── Noise estimator state ─────────────────────────────────────────
     float              m_powerHistory[HIST][NBINS]{};

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -1,0 +1,117 @@
+#include "MonoDspStereoAdapter.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+namespace {
+
+constexpr int kChannels = 2;
+constexpr int kSampleRate = 24000;
+constexpr int kMaxBufferedFrames = kSampleRate * 5;
+constexpr float kEnvelopeCoeff = 0.006f;
+constexpr float kAttackCoeff = 0.22f;
+constexpr float kReleaseCoeff = 0.035f;
+constexpr float kPowerFloor = 1.0e-10f;
+constexpr float kMonoObservabilityRatio = 0.01f;
+constexpr float kMinObservableGain = 0.035f;
+constexpr float kMaxGain = 1.0f;
+
+float clampSample(float sample)
+{
+    return std::clamp(sample, -1.0f, 1.0f);
+}
+
+} // namespace
+
+void MonoDspStereoAdapter::reset()
+{
+    m_dryStereoFifo.clear();
+    m_dryMonoPower = 0.0f;
+    m_dryStereoPower = 0.0f;
+    m_processedPower = 0.0f;
+    m_gain = 1.0f;
+}
+
+void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
+{
+    if (stereoPcm.isEmpty()) {
+        return;
+    }
+
+    m_dryStereoFifo.append(stereoPcm);
+
+    const int maxBytes = kMaxBufferedFrames * kChannels * static_cast<int>(sizeof(float));
+    if (m_dryStereoFifo.size() > maxBytes) {
+        const int extraBytes = m_dryStereoFifo.size() - maxBytes;
+        const int alignedExtraBytes =
+            extraBytes - (extraBytes % (kChannels * static_cast<int>(sizeof(float))));
+        if (alignedExtraBytes > 0) {
+            m_dryStereoFifo.remove(0, alignedExtraBytes);
+        }
+    }
+}
+
+QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, int frames)
+{
+    if (!processedMono || frames <= 0) {
+        return {};
+    }
+
+    const int outputBytes = frames * kChannels * static_cast<int>(sizeof(float));
+    QByteArray output(outputBytes, Qt::Uninitialized);
+    auto* dst = reinterpret_cast<float*>(output.data());
+
+    const int availableFrames =
+        m_dryStereoFifo.size() / (kChannels * static_cast<int>(sizeof(float)));
+    const int dryFrames = std::min(frames, availableFrames);
+    const auto* dry = reinterpret_cast<const float*>(m_dryStereoFifo.constData());
+
+    for (int i = 0; i < dryFrames; ++i) {
+        const float left = dry[i * kChannels];
+        const float right = dry[i * kChannels + 1];
+        const float dryMono = 0.5f * (left + right);
+        const float dryStereoPower = 0.5f * (left * left + right * right);
+        const float processed = processedMono[i];
+
+        m_dryMonoPower += kEnvelopeCoeff * (dryMono * dryMono - m_dryMonoPower);
+        m_dryStereoPower += kEnvelopeCoeff * (dryStereoPower - m_dryStereoPower);
+        m_processedPower += kEnvelopeCoeff * (processed * processed - m_processedPower);
+
+        float targetGain = kMaxGain;
+        const float observableMonoFloor =
+            std::max(kPowerFloor, m_dryStereoPower * kMonoObservabilityRatio);
+        // If stereo energy is present but the mono sum cancels, the mono DSP
+        // path has no trustworthy gain estimate. Preserve the dry stereo level.
+        if (m_dryMonoPower >= observableMonoFloor) {
+            targetGain = std::clamp(
+                std::sqrt(std::max(m_processedPower, 0.0f) / m_dryMonoPower),
+                kMinObservableGain,
+                kMaxGain);
+        }
+        const float smoothCoeff = targetGain < m_gain ? kAttackCoeff : kReleaseCoeff;
+        m_gain += smoothCoeff * (targetGain - m_gain);
+
+        dst[i * kChannels] = clampSample(left * m_gain);
+        dst[i * kChannels + 1] = clampSample(right * m_gain);
+    }
+
+    for (int i = dryFrames; i < frames; ++i) {
+        dst[i * kChannels] = 0.0f;
+        dst[i * kChannels + 1] = 0.0f;
+    }
+
+    if (dryFrames > 0) {
+        m_dryStereoFifo.remove(
+            0, dryFrames * kChannels * static_cast<int>(sizeof(float)));
+    }
+
+    return output;
+}
+
+int MonoDspStereoAdapter::bufferedFrames() const
+{
+    return m_dryStereoFifo.size() / (kChannels * static_cast<int>(sizeof(float)));
+}
+
+} // namespace AetherSDR

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -19,22 +19,50 @@ constexpr float kPowerFloor = 1.0e-10f;
 constexpr float kMonoObservabilityRatio = 0.01f;
 constexpr float kMinObservableGain = 0.035f;
 constexpr float kMaxGain = 1.0f;
+constexpr float kStereoDetectionRatio = 1.0e-4f;
+constexpr float kProcessedMixAttackCoeff = 0.05f;
+constexpr float kProcessedMixReleaseCoeff = 0.01f;
 
 float clampSample(float sample)
 {
     return std::clamp(sample, -1.0f, 1.0f);
 }
 
+float updatePowerEnvelope(float current, float samplePower)
+{
+    current += kEnvelopeCoeff * (samplePower - current);
+    return current < kPowerFloor ? 0.0f : current;
+}
+
 } // namespace
+
+MonoDspStereoAdapter::MonoDspStereoAdapter(int processingLatencyFrames)
+    : m_processingLatencyFrames(std::max(0, processingLatencyFrames))
+    , m_latencyFramesRemaining(m_processingLatencyFrames)
+{}
 
 void MonoDspStereoAdapter::reset()
 {
     m_dryStereoFifo.clear();
     m_dryStereoReadOffset = 0;
+    m_latencyFramesRemaining = m_processingLatencyFrames;
+    resetEnvelopeState();
+}
+
+void MonoDspStereoAdapter::setProcessingLatencyFrames(int frames)
+{
+    m_processingLatencyFrames = std::max(0, frames);
+    reset();
+}
+
+void MonoDspStereoAdapter::resetEnvelopeState()
+{
     m_dryMonoPower = 0.0f;
     m_dryStereoPower = 0.0f;
+    m_sidePower = 0.0f;
     m_processedPower = 0.0f;
     m_gain = 1.0f;
+    m_processedMix = 1.0f;
 }
 
 int MonoDspStereoAdapter::readableDryStereoBytes() const
@@ -72,11 +100,14 @@ void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
 
     const int readableBytes = readableDryStereoBytes();
     if (readableBytes > kMaxBufferedBytes) {
-        const int extraBytes = readableBytes - kMaxBufferedBytes;
-        const int alignedExtraBytes = extraBytes - (extraBytes % kFrameBytes);
-        if (alignedExtraBytes > 0) {
-            m_dryStereoReadOffset += alignedExtraBytes;
-        }
+        // A rate mismatch this large means dry and processed timelines can no
+        // longer be paired reliably. Drop the pending dry side and re-prime on
+        // the next block instead of preserving a permanent offset.
+        m_dryStereoFifo.clear();
+        m_dryStereoReadOffset = 0;
+        m_latencyFramesRemaining = m_processingLatencyFrames;
+        resetEnvelopeState();
+        return;
     }
 
     compactDryStereoFifoIfNeeded();
@@ -93,20 +124,37 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
     auto* dst = reinterpret_cast<float*>(output.data());
 
     const int availableFrames = readableDryStereoBytes() / kFrameBytes;
-    const int dryFrames = std::min(frames, availableFrames);
     const auto* dry = reinterpret_cast<const float*>(
         m_dryStereoFifo.constData() + m_dryStereoReadOffset);
+    int dryFrames = 0;
 
-    for (int i = 0; i < dryFrames; ++i) {
-        const float left = dry[i * kChannels];
-        const float right = dry[i * kChannels + 1];
-        const float dryMono = 0.5f * (left + right);
-        const float dryStereoPower = 0.5f * (left * left + right * right);
+    for (int i = 0; i < frames; ++i) {
         const float processed = processedMono[i];
+        if (m_latencyFramesRemaining > 0) {
+            // Preserve the engine's own startup output while retaining dry
+            // samples until the processed stream reaches the same timeline.
+            dst[i * kChannels] = clampSample(processed);
+            dst[i * kChannels + 1] = clampSample(processed);
+            --m_latencyFramesRemaining;
+            continue;
+        }
 
-        m_dryMonoPower += kEnvelopeCoeff * (dryMono * dryMono - m_dryMonoPower);
-        m_dryStereoPower += kEnvelopeCoeff * (dryStereoPower - m_dryStereoPower);
-        m_processedPower += kEnvelopeCoeff * (processed * processed - m_processedPower);
+        if (dryFrames >= availableFrames) {
+            dst[i * kChannels] = clampSample(processed);
+            dst[i * kChannels + 1] = clampSample(processed);
+            continue;
+        }
+
+        const float left = dry[dryFrames * kChannels];
+        const float right = dry[dryFrames * kChannels + 1];
+        const float dryMono = 0.5f * (left + right);
+        const float side = 0.5f * (left - right);
+        const float dryStereoPower = 0.5f * (left * left + right * right);
+
+        m_dryMonoPower = updatePowerEnvelope(m_dryMonoPower, dryMono * dryMono);
+        m_dryStereoPower = updatePowerEnvelope(m_dryStereoPower, dryStereoPower);
+        m_sidePower = updatePowerEnvelope(m_sidePower, side * side);
+        m_processedPower = updatePowerEnvelope(m_processedPower, processed * processed);
 
         float targetGain = kMaxGain;
         const float observableMonoFloor =
@@ -122,13 +170,24 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         const float smoothCoeff = targetGain < m_gain ? kAttackCoeff : kReleaseCoeff;
         m_gain += smoothCoeff * (targetGain - m_gain);
 
-        dst[i * kChannels] = clampSample(left * m_gain);
-        dst[i * kChannels + 1] = clampSample(right * m_gain);
-    }
+        const float stereoRatio = m_sidePower
+            / std::max(m_dryStereoPower, kPowerFloor);
+        const float targetProcessedMix =
+            stereoRatio <= kStereoDetectionRatio ? 1.0f : 0.0f;
+        const float mixCoeff = targetProcessedMix < m_processedMix
+            ? kProcessedMixAttackCoeff
+            : kProcessedMixReleaseCoeff;
+        m_processedMix += mixCoeff * (targetProcessedMix - m_processedMix);
+        if (std::fabs(m_processedMix - targetProcessedMix) < 1.0e-6f) {
+            m_processedMix = targetProcessedMix;
+        }
 
-    for (int i = dryFrames; i < frames; ++i) {
-        dst[i * kChannels] = 0.0f;
-        dst[i * kChannels + 1] = 0.0f;
+        const float envelopeMix = 1.0f - m_processedMix;
+        dst[i * kChannels] = clampSample(
+            m_processedMix * processed + envelopeMix * left * m_gain);
+        dst[i * kChannels + 1] = clampSample(
+            m_processedMix * processed + envelopeMix * right * m_gain);
+        ++dryFrames;
     }
 
     if (dryFrames > 0) {

--- a/src/core/MonoDspStereoAdapter.cpp
+++ b/src/core/MonoDspStereoAdapter.cpp
@@ -9,6 +9,9 @@ namespace {
 constexpr int kChannels = 2;
 constexpr int kSampleRate = 24000;
 constexpr int kMaxBufferedFrames = kSampleRate * 5;
+constexpr int kFrameBytes = kChannels * static_cast<int>(sizeof(float));
+constexpr int kMaxBufferedBytes = kMaxBufferedFrames * kFrameBytes;
+constexpr int kCompactThresholdBytes = kSampleRate * kFrameBytes;
 constexpr float kEnvelopeCoeff = 0.006f;
 constexpr float kAttackCoeff = 0.22f;
 constexpr float kReleaseCoeff = 0.035f;
@@ -27,10 +30,36 @@ float clampSample(float sample)
 void MonoDspStereoAdapter::reset()
 {
     m_dryStereoFifo.clear();
+    m_dryStereoReadOffset = 0;
     m_dryMonoPower = 0.0f;
     m_dryStereoPower = 0.0f;
     m_processedPower = 0.0f;
     m_gain = 1.0f;
+}
+
+int MonoDspStereoAdapter::readableDryStereoBytes() const
+{
+    const qsizetype readableBytes =
+        m_dryStereoFifo.size() - static_cast<qsizetype>(m_dryStereoReadOffset);
+    return readableBytes > 0 ? static_cast<int>(readableBytes) : 0;
+}
+
+void MonoDspStereoAdapter::compactDryStereoFifoIfNeeded()
+{
+    if (m_dryStereoReadOffset <= 0) {
+        return;
+    }
+
+    if (m_dryStereoReadOffset >= m_dryStereoFifo.size()) {
+        m_dryStereoFifo.clear();
+        m_dryStereoReadOffset = 0;
+        return;
+    }
+
+    if (m_dryStereoReadOffset >= kCompactThresholdBytes) {
+        m_dryStereoFifo.remove(0, m_dryStereoReadOffset);
+        m_dryStereoReadOffset = 0;
+    }
 }
 
 void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
@@ -41,15 +70,16 @@ void MonoDspStereoAdapter::pushDryStereo(const QByteArray& stereoPcm)
 
     m_dryStereoFifo.append(stereoPcm);
 
-    const int maxBytes = kMaxBufferedFrames * kChannels * static_cast<int>(sizeof(float));
-    if (m_dryStereoFifo.size() > maxBytes) {
-        const int extraBytes = m_dryStereoFifo.size() - maxBytes;
-        const int alignedExtraBytes =
-            extraBytes - (extraBytes % (kChannels * static_cast<int>(sizeof(float))));
+    const int readableBytes = readableDryStereoBytes();
+    if (readableBytes > kMaxBufferedBytes) {
+        const int extraBytes = readableBytes - kMaxBufferedBytes;
+        const int alignedExtraBytes = extraBytes - (extraBytes % kFrameBytes);
         if (alignedExtraBytes > 0) {
-            m_dryStereoFifo.remove(0, alignedExtraBytes);
+            m_dryStereoReadOffset += alignedExtraBytes;
         }
     }
+
+    compactDryStereoFifoIfNeeded();
 }
 
 QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, int frames)
@@ -58,14 +88,14 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
         return {};
     }
 
-    const int outputBytes = frames * kChannels * static_cast<int>(sizeof(float));
+    const int outputBytes = frames * kFrameBytes;
     QByteArray output(outputBytes, Qt::Uninitialized);
     auto* dst = reinterpret_cast<float*>(output.data());
 
-    const int availableFrames =
-        m_dryStereoFifo.size() / (kChannels * static_cast<int>(sizeof(float)));
+    const int availableFrames = readableDryStereoBytes() / kFrameBytes;
     const int dryFrames = std::min(frames, availableFrames);
-    const auto* dry = reinterpret_cast<const float*>(m_dryStereoFifo.constData());
+    const auto* dry = reinterpret_cast<const float*>(
+        m_dryStereoFifo.constData() + m_dryStereoReadOffset);
 
     for (int i = 0; i < dryFrames; ++i) {
         const float left = dry[i * kChannels];
@@ -102,8 +132,8 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
     }
 
     if (dryFrames > 0) {
-        m_dryStereoFifo.remove(
-            0, dryFrames * kChannels * static_cast<int>(sizeof(float)));
+        m_dryStereoReadOffset += dryFrames * kFrameBytes;
+        compactDryStereoFifoIfNeeded();
     }
 
     return output;
@@ -111,7 +141,7 @@ QByteArray MonoDspStereoAdapter::takeProcessedMono(const float* processedMono, i
 
 int MonoDspStereoAdapter::bufferedFrames() const
 {
-    return m_dryStereoFifo.size() / (kChannels * static_cast<int>(sizeof(float)));
+    return readableDryStereoBytes() / kFrameBytes;
 }
 
 } // namespace AetherSDR

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -8,7 +8,10 @@ namespace AetherSDR {
 // This keeps a single mono noise analysis while preserving RX left/right balance.
 class MonoDspStereoAdapter {
 public:
+    explicit MonoDspStereoAdapter(int processingLatencyFrames = 0);
+
     void reset();
+    void setProcessingLatencyFrames(int frames);
 
     void pushDryStereo(const QByteArray& stereoPcm);
     QByteArray takeProcessedMono(const float* processedMono, int frames);
@@ -18,13 +21,18 @@ public:
 private:
     int readableDryStereoBytes() const;
     void compactDryStereoFifoIfNeeded();
+    void resetEnvelopeState();
 
     QByteArray m_dryStereoFifo;
     int m_dryStereoReadOffset{0};
+    int m_processingLatencyFrames{0};
+    int m_latencyFramesRemaining{0};
     float m_dryMonoPower{0.0f};
     float m_dryStereoPower{0.0f};
+    float m_sidePower{0.0f};
     float m_processedPower{0.0f};
     float m_gain{1.0f};
+    float m_processedMix{1.0f};
 };
 
 } // namespace AetherSDR

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -16,7 +16,11 @@ public:
     int bufferedFrames() const;
 
 private:
+    int readableDryStereoBytes() const;
+    void compactDryStereoFifoIfNeeded();
+
     QByteArray m_dryStereoFifo;
+    int m_dryStereoReadOffset{0};
     float m_dryMonoPower{0.0f};
     float m_dryStereoPower{0.0f};
     float m_processedPower{0.0f};

--- a/src/core/MonoDspStereoAdapter.h
+++ b/src/core/MonoDspStereoAdapter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QByteArray>
+
+namespace AetherSDR {
+
+// Re-applies a mono DSP path's gain envelope to the delayed dry stereo signal.
+// This keeps a single mono noise analysis while preserving RX left/right balance.
+class MonoDspStereoAdapter {
+public:
+    void reset();
+
+    void pushDryStereo(const QByteArray& stereoPcm);
+    QByteArray takeProcessedMono(const float* processedMono, int frames);
+
+    int bufferedFrames() const;
+
+private:
+    QByteArray m_dryStereoFifo;
+    float m_dryMonoPower{0.0f};
+    float m_dryStereoPower{0.0f};
+    float m_processedPower{0.0f};
+    float m_gain{1.0f};
+};
+
+} // namespace AetherSDR

--- a/src/core/NvidiaAfxFilter.cpp
+++ b/src/core/NvidiaAfxFilter.cpp
@@ -310,9 +310,15 @@ QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
 
     const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
     const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    m_stereoAdapter.pushDryStereo(pcm24kStereo);
 
-    // 1. 24 kHz stereo float32 → 48 kHz mono float32
-    QByteArray mono48k = m_up->processStereoToMono(src, stereoFrames);
+    // 1. 24 kHz stereo float32 → 48 kHz mono float32. Keep the dry stereo
+    // queued so the BNR attenuation can be applied without collapsing pan.
+    std::vector<float> mono24k(stereoFrames);
+    for (int i = 0; i < stereoFrames; ++i) {
+        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+    }
+    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
     const auto* mono = reinterpret_cast<const float*>(mono48k.constData());
     const int monoSamples = mono48k.size() / static_cast<int>(sizeof(float));
 
@@ -349,8 +355,12 @@ QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
         } else {
             m_inAccum.clear();
         }
-        // 3. 48 kHz mono float32 → 24 kHz stereo float32
-        m_outAccum.append(m_down->processMonoToStereo(out, consumed));
+        // 3. 48 kHz mono float32 → 24 kHz mono float32, then re-apply the
+        // shared BNR envelope to the delayed dry stereo.
+        const QByteArray downsampled = m_down->process(out, consumed);
+        const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
+        const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
+        m_outAccum.append(m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
     }
 
     // 4. Return exactly the input byte count. Use a read cursor instead of an
@@ -379,6 +389,7 @@ void NvidiaAfxFilter::reset()
     m_inAccum.clear();
     m_outAccum.clear();
     m_outReadPos = 0;
+    m_stereoAdapter.reset();
     m_up   = std::make_unique<Resampler>(24000, 48000);
     m_down = std::make_unique<Resampler>(48000, 24000);
 }

--- a/src/core/NvidiaAfxFilter.cpp
+++ b/src/core/NvidiaAfxFilter.cpp
@@ -314,11 +314,11 @@ QByteArray NvidiaAfxFilter::process(const QByteArray& pcm24kStereo)
 
     // 1. 24 kHz stereo float32 → 48 kHz mono float32. Keep the dry stereo
     // queued so the BNR attenuation can be applied without collapsing pan.
-    std::vector<float> mono24k(stereoFrames);
+    m_mono24k.resize(stereoFrames);
     for (int i = 0; i < stereoFrames; ++i) {
-        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+        m_mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
     }
-    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
+    QByteArray mono48k = m_up->process(m_mono24k.data(), stereoFrames);
     const auto* mono = reinterpret_cast<const float*>(mono48k.constData());
     const int monoSamples = mono48k.size() / static_cast<int>(sizeof(float));
 

--- a/src/core/NvidiaAfxFilter.h
+++ b/src/core/NvidiaAfxFilter.h
@@ -81,6 +81,7 @@ private:
     QByteArray m_outAccum;                       // 24 kHz stereo float output
     int        m_outReadPos{0};                 // read cursor into m_outAccum
     MonoDspStereoAdapter m_stereoAdapter;
+    std::vector<float> m_mono24k;
     std::vector<float> m_runScratch;            // reused NvAFX_Run output buffer
 
     std::atomic<float> m_intensity{1.0f};

--- a/src/core/NvidiaAfxFilter.h
+++ b/src/core/NvidiaAfxFilter.h
@@ -2,6 +2,8 @@
 
 #ifdef HAVE_NVIDIA_AFX
 
+#include "MonoDspStereoAdapter.h"
+
 #include <QByteArray>
 #include <QString>
 #include <atomic>
@@ -78,6 +80,7 @@ private:
     QByteArray m_inAccum;                        // 48 kHz mono float input
     QByteArray m_outAccum;                       // 24 kHz stereo float output
     int        m_outReadPos{0};                 // read cursor into m_outAccum
+    MonoDspStereoAdapter m_stereoAdapter;
     std::vector<float> m_runScratch;            // reused NvAFX_Run output buffer
 
     std::atomic<float> m_intensity{1.0f};

--- a/src/core/RNNoiseFilter.cpp
+++ b/src/core/RNNoiseFilter.cpp
@@ -31,6 +31,7 @@ void RNNoiseFilter::reset()
     m_down = std::make_unique<Resampler>(48000, 24000);
     m_inAccum.clear();
     m_outAccum.clear();
+    m_stereoAdapter.reset();
 }
 
 QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
@@ -40,9 +41,15 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
 
     const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
     const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
+    m_stereoAdapter.pushDryStereo(pcm24kStereo);
 
-    // 1. Upsample 24kHz stereo float32 → 48kHz mono float32 via r8brain
-    QByteArray mono48k = m_up->processStereoToMono(src, stereoFrames);
+    // 1. Downmix, then upsample 24kHz mono float32 → 48kHz mono float32 via r8brain.
+    // The dry stereo stays queued so the RNNoise gain can be applied to both channels.
+    std::vector<float> mono24k(stereoFrames);
+    for (int i = 0; i < stereoFrames; ++i) {
+        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+    }
+    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
 
     const auto* mono48kSamples = reinterpret_cast<const float*>(mono48k.constData());
     const int monoSamples48k = mono48k.size() / static_cast<int>(sizeof(float));
@@ -89,11 +96,13 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
         for (int i = 0; i < outputMonoSamples; ++i)
             processed48kFloat[i] = processed48k[i] / 32768.0f;
 
-        // Downsample 48kHz mono → 24kHz stereo via r8brain
-        QByteArray downsampled = m_down->processMonoToStereo(
-            processed48kFloat.data(), outputMonoSamples);
+        // Downsample 48kHz mono → 24kHz mono, then apply the shared gain envelope
+        // to the delayed dry stereo so slice/diversity balance survives RN2.
+        QByteArray downsampled = m_down->process(processed48kFloat.data(), outputMonoSamples);
+        const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
+        const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
 
-        m_outAccum.append(downsampled);
+        m_outAccum.append(m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
     }
 
     // 4. Return exactly the same number of bytes as input

--- a/src/core/RNNoiseFilter.cpp
+++ b/src/core/RNNoiseFilter.cpp
@@ -10,10 +10,11 @@ namespace AetherSDR {
 // RNNoise frame size: 480 samples at 48kHz = 10ms
 static constexpr int FRAME_SIZE = 480;
 
-RNNoiseFilter::RNNoiseFilter()
+RNNoiseFilter::RNNoiseFilter(OutputMode outputMode)
     : m_state(rnnoise_create(nullptr))
     , m_up(std::make_unique<Resampler>(24000, 48000))
     , m_down(std::make_unique<Resampler>(48000, 24000))
+    , m_outputMode(outputMode)
 {}
 
 RNNoiseFilter::~RNNoiseFilter()
@@ -41,15 +42,17 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
 
     const auto* src = reinterpret_cast<const float*>(pcm24kStereo.constData());
     const int stereoFrames = pcm24kStereo.size() / (2 * static_cast<int>(sizeof(float)));
-    m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    if (m_outputMode == OutputMode::PreserveRxStereo) {
+        m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    }
 
     // 1. Downmix, then upsample 24kHz mono float32 → 48kHz mono float32 via r8brain.
     // The dry stereo stays queued so the RNNoise gain can be applied to both channels.
-    std::vector<float> mono24k(stereoFrames);
+    m_mono24k.resize(stereoFrames);
     for (int i = 0; i < stereoFrames; ++i) {
-        mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
+        m_mono24k[i] = 0.5f * (src[i * 2] + src[i * 2 + 1]);
     }
-    QByteArray mono48k = m_up->process(mono24k.data(), stereoFrames);
+    QByteArray mono48k = m_up->process(m_mono24k.data(), stereoFrames);
 
     const auto* mono48kSamples = reinterpret_cast<const float*>(mono48k.constData());
     const int monoSamples48k = mono48k.size() / static_cast<int>(sizeof(float));
@@ -70,11 +73,11 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
 
     if (completeFrames > 0) {
         auto* accumData = reinterpret_cast<float*>(m_inAccum.data());
-        std::vector<float> processed48k(completeFrames * FRAME_SIZE);
+        m_processed48k.resize(completeFrames * FRAME_SIZE);
 
         for (int f = 0; f < completeFrames; ++f) {
             rnnoise_process_frame(m_state,
-                                  &processed48k[f * FRAME_SIZE],
+                                  &m_processed48k[f * FRAME_SIZE],
                                   &accumData[f * FRAME_SIZE]);
         }
 
@@ -92,17 +95,31 @@ QByteArray RNNoiseFilter::process(const QByteArray& pcm24kStereo)
         // 3. Scale processed 48kHz float from RNNoise range [-32768,32768] to [-1,1],
         //    then downsample to 24kHz stereo float32
         const int outputMonoSamples = completeFrames * FRAME_SIZE;
-        std::vector<float> processed48kFloat(outputMonoSamples);
+        m_processed48kFloat.resize(outputMonoSamples);
         for (int i = 0; i < outputMonoSamples; ++i)
-            processed48kFloat[i] = processed48k[i] / 32768.0f;
+            m_processed48kFloat[i] = m_processed48k[i] / 32768.0f;
 
         // Downsample 48kHz mono → 24kHz mono, then apply the shared gain envelope
         // to the delayed dry stereo so slice/diversity balance survives RN2.
-        QByteArray downsampled = m_down->process(processed48kFloat.data(), outputMonoSamples);
+        QByteArray downsampled = m_down->process(
+            m_processed48kFloat.data(), outputMonoSamples);
         const auto* downsampledMono = reinterpret_cast<const float*>(downsampled.constData());
         const int downsampledFrames = downsampled.size() / static_cast<int>(sizeof(float));
 
-        m_outAccum.append(m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
+        if (m_outputMode == OutputMode::PreserveRxStereo) {
+            m_outAccum.append(
+                m_stereoAdapter.takeProcessedMono(downsampledMono, downsampledFrames));
+        } else {
+            QByteArray processedStereo(
+                downsampledFrames * 2 * static_cast<int>(sizeof(float)),
+                Qt::Uninitialized);
+            auto* stereo = reinterpret_cast<float*>(processedStereo.data());
+            for (int i = 0; i < downsampledFrames; ++i) {
+                stereo[i * 2] = downsampledMono[i];
+                stereo[i * 2 + 1] = downsampledMono[i];
+            }
+            m_outAccum.append(processedStereo);
+        }
     }
 
     // 4. Return exactly the same number of bytes as input

--- a/src/core/RNNoiseFilter.h
+++ b/src/core/RNNoiseFilter.h
@@ -4,6 +4,7 @@
 
 #include <QByteArray>
 #include <memory>
+#include <vector>
 
 struct DenoiseState;
 
@@ -19,7 +20,12 @@ class Resampler;
 
 class RNNoiseFilter {
 public:
-    RNNoiseFilter();
+    enum class OutputMode {
+        PreserveRxStereo,
+        ProcessedMono,
+    };
+
+    explicit RNNoiseFilter(OutputMode outputMode = OutputMode::PreserveRxStereo);
     ~RNNoiseFilter();
 
     // Process a block of 24kHz duplicated-stereo FLOAT32 PCM (NOT int16
@@ -40,7 +46,11 @@ private:
     std::unique_ptr<Resampler> m_down;  // 48kHz mono → 24kHz mono
     QByteArray    m_inAccum;            // accumulate 48kHz mono float input
     QByteArray    m_outAccum;           // accumulate 24kHz stereo float output
+    std::vector<float> m_mono24k;
+    std::vector<float> m_processed48k;
+    std::vector<float> m_processed48kFloat;
     MonoDspStereoAdapter m_stereoAdapter;
+    OutputMode m_outputMode{OutputMode::PreserveRxStereo};
 };
 
 } // namespace AetherSDR

--- a/src/core/RNNoiseFilter.h
+++ b/src/core/RNNoiseFilter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "MonoDspStereoAdapter.h"
+
 #include <QByteArray>
 #include <memory>
 
@@ -37,7 +39,8 @@ private:
     std::unique_ptr<Resampler> m_up;    // 24kHz mono → 48kHz mono
     std::unique_ptr<Resampler> m_down;  // 48kHz mono → 24kHz mono
     QByteArray    m_inAccum;            // accumulate 48kHz mono float input
-    QByteArray    m_outAccum;           // accumulate 24kHz stereo int16 output
+    QByteArray    m_outAccum;           // accumulate 24kHz stereo float output
+    MonoDspStereoAdapter m_stereoAdapter;
 };
 
 } // namespace AetherSDR

--- a/src/core/SpecbleachFilter.cpp
+++ b/src/core/SpecbleachFilter.cpp
@@ -18,6 +18,8 @@ SpecbleachFilter::SpecbleachFilter()
         qWarning() << "SpecbleachFilter: failed to initialize";
         return;
     }
+    m_stereoAdapter.setProcessingLatencyFrames(
+        static_cast<int>(specbleach_get_latency(m_handle)));
     applyParams();
     qDebug() << "SpecbleachFilter: initialized, latency ="
              << specbleach_get_latency(m_handle) << "samples";

--- a/src/core/SpecbleachFilter.cpp
+++ b/src/core/SpecbleachFilter.cpp
@@ -32,6 +32,7 @@ SpecbleachFilter::~SpecbleachFilter()
 void SpecbleachFilter::reset()
 {
     m_frameCount = 0;
+    m_stereoAdapter.reset();
     if (m_handle)
         specbleach_reset_noise_profile(m_handle);
 }
@@ -90,18 +91,12 @@ QByteArray SpecbleachFilter::process(const QByteArray& pcm24kStereo)
     // builds. The library still receives the audio above for profiling. (#827)
     if (m_frameCount < kLearningFrames) {
         ++m_frameCount;
+        m_stereoAdapter.reset();
         return pcm24kStereo;
     }
 
-    // Mono float → stereo float32 (duplicate to L+R)
-    QByteArray result(totalFloats * static_cast<int>(sizeof(float)), Qt::Uninitialized);
-    auto* out = reinterpret_cast<float*>(result.data());
-    for (int i = 0; i < monoSamples; ++i) {
-        out[i * 2]     = m_monoOut[i];
-        out[i * 2 + 1] = m_monoOut[i];
-    }
-
-    return result;
+    m_stereoAdapter.pushDryStereo(pcm24kStereo);
+    return m_stereoAdapter.takeProcessedMono(m_monoOut.data(), monoSamples);
 }
 
 // Parameter setters — mark dirty so next process() applies them

--- a/src/core/SpecbleachFilter.h
+++ b/src/core/SpecbleachFilter.h
@@ -12,8 +12,8 @@ typedef void* SpectralBleachHandle;
 
 namespace AetherSDR {
 
-    // SpecbleachFilter — wrapper around libspecbleach for NR4 noise reduction.
-    // Processes 24 kHz stereo float32 audio (same interface as RNNoiseFilter).
+// SpecbleachFilter - wrapper around libspecbleach for NR4 noise reduction.
+// Processes 24 kHz stereo float32 audio (same interface as RNNoiseFilter).
 // Thread-safe parameter setters (main thread writes, audio thread reads).
 class SpecbleachFilter {
 public:
@@ -41,6 +41,10 @@ public:
     float reductionAmount() const  { return m_reduction.load(); }
     float smoothingFactor() const  { return m_smoothing.load(); }
     float whiteningFactor() const  { return m_whitening.load(); }
+    bool adaptiveNoise() const { return m_adaptive.load(); }
+    int noiseEstimationMethod() const { return m_noiseMethod.load(); }
+    float maskingDepth() const { return m_maskingDepth.load(); }
+    float suppressionStrength() const { return m_suppression.load(); }
 
 private:
     void applyParams();

--- a/src/core/SpecbleachFilter.h
+++ b/src/core/SpecbleachFilter.h
@@ -2,6 +2,8 @@
 
 #ifdef HAVE_SPECBLEACH
 
+#include "MonoDspStereoAdapter.h"
+
 #include <QByteArray>
 #include <atomic>
 #include <vector>
@@ -10,8 +12,8 @@ typedef void* SpectralBleachHandle;
 
 namespace AetherSDR {
 
-// SpecbleachFilter — wrapper around libspecbleach for NR4 noise reduction.
-// Processes 24 kHz stereo int16 audio (same interface as RNNoiseFilter).
+    // SpecbleachFilter — wrapper around libspecbleach for NR4 noise reduction.
+    // Processes 24 kHz stereo float32 audio (same interface as RNNoiseFilter).
 // Thread-safe parameter setters (main thread writes, audio thread reads).
 class SpecbleachFilter {
 public:
@@ -21,7 +23,7 @@ public:
     SpecbleachFilter(const SpecbleachFilter&) = delete;
     SpecbleachFilter& operator=(const SpecbleachFilter&) = delete;
 
-    // Process stereo int16 PCM at 24 kHz. Returns processed audio.
+    // Process stereo float32 PCM at 24 kHz. Returns processed audio.
     QByteArray process(const QByteArray& pcm24kStereo);
 
     bool isValid() const { return m_handle != nullptr; }
@@ -63,6 +65,7 @@ private:
     // Buffers
     std::vector<float> m_monoIn;
     std::vector<float> m_monoOut;
+    MonoDspStereoAdapter m_stereoAdapter;
 };
 
 } // namespace AetherSDR

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -435,6 +435,11 @@ void SpectralNR::process(const float* input, float* output, int numSamples)
         return;
     }
 
+    if (hasPlanFailed()) {
+        std::memmove(output, input, numSamples * sizeof(float));
+        return;
+    }
+
     // The overlap-add rings are sized for streaming at the native hop cadence.
     // Larger packet-sized calls can wrap the output ring before the call reads
     // its output, aliasing future synthesis data into the returned samples.
@@ -491,6 +496,11 @@ void SpectralNR::process(const float* input, float* output, int numSamples)
 void SpectralNR::processStereoSharedMask(const float* input, float* output, int numFrames)
 {
     if (numFrames <= 0) {
+        return;
+    }
+
+    if (hasPlanFailed()) {
+        std::memmove(output, input, numFrames * 2 * sizeof(float));
         return;
     }
 

--- a/src/core/SpectralNR.cpp
+++ b/src/core/SpectralNR.cpp
@@ -105,6 +105,10 @@ SpectralNR::SpectralNR(int fftSize, int sampleRate)
     // Allocate overlap-add accumulators
     m_inAccum.resize(fftSize * 4, 0.0);
     m_outAccum.resize(fftSize * 4, 0.0);
+    m_stereoInAccumL.resize(fftSize * 4, 0.0);
+    m_stereoInAccumR.resize(fftSize * 4, 0.0);
+    m_stereoOutAccumL.resize(fftSize * 4, 0.0);
+    m_stereoOutAccumR.resize(fftSize * 4, 0.0);
 
     m_window.resize(fftSize);
     m_fftIn.resize(fftSize);
@@ -190,6 +194,10 @@ void SpectralNR::reset()
 {
     std::fill(m_inAccum.begin(), m_inAccum.end(), 0.0);
     std::fill(m_outAccum.begin(), m_outAccum.end(), 0.0);
+    std::fill(m_stereoInAccumL.begin(), m_stereoInAccumL.end(), 0.0);
+    std::fill(m_stereoInAccumR.begin(), m_stereoInAccumR.end(), 0.0);
+    std::fill(m_stereoOutAccumL.begin(), m_stereoOutAccumL.end(), 0.0);
+    std::fill(m_stereoOutAccumR.begin(), m_stereoOutAccumR.end(), 0.0);
     m_inWritePos = 0;
     m_inReadPos = 0;
     m_samplesAccum = 0;
@@ -228,6 +236,7 @@ void SpectralNR::reset()
     m_subwc = 1;
     m_ambIdx = 0;
     m_frameCount = 0;
+    m_currentWet = 0.0;
 }
 
 void SpectralNR::initWindow()
@@ -479,10 +488,86 @@ void SpectralNR::process(const float* input, float* output, int numSamples)
     }
 }
 
-void SpectralNR::processFrame()
+void SpectralNR::processStereoSharedMask(const float* input, float* output, int numFrames)
+{
+    if (numFrames <= 0) {
+        return;
+    }
+
+    if (numFrames > m_hopSize) {
+        int offset = 0;
+        while (offset < numFrames) {
+            const int chunk = std::min(m_hopSize, numFrames - offset);
+            processStereoSharedMask(input + (2 * offset),
+                                    output + (2 * offset),
+                                    chunk);
+            offset += chunk;
+        }
+        return;
+    }
+
+    const int accSize = static_cast<int>(m_inAccum.size());
+    const int outSize = static_cast<int>(m_outAccum.size());
+
+    for (int i = 0; i < numFrames; ++i) {
+        const float left = input[2 * i];
+        const float right = input[2 * i + 1];
+        m_inAccum[m_inWritePos] =
+            0.5 * (static_cast<double>(left) + static_cast<double>(right));
+        m_stereoInAccumL[m_inWritePos] = static_cast<double>(left);
+        m_stereoInAccumR[m_inWritePos] = static_cast<double>(right);
+        m_inWritePos = (m_inWritePos + 1) % accSize;
+    }
+    m_samplesAccum += numFrames;
+
+    while (m_samplesAccum >= m_fftSize) {
+        const int frameReadPos = m_inReadPos;
+
+        for (int i = 0; i < m_fftSize; ++i) {
+            const int idx = (frameReadPos + i) % accSize;
+            m_fftIn[i] = m_window[i] * m_inAccum[idx];
+        }
+
+        if (updateMaskFromCurrentFrame()) {
+            for (int i = 0; i < m_fftSize; ++i) {
+                const int idx = (frameReadPos + i) % accSize;
+                m_fftIn[i] = m_window[i] * m_stereoInAccumL[idx];
+            }
+            synthesizeCurrentFrameWithMask();
+            for (int i = 0; i < m_fftSize; ++i) {
+                const int idx = (m_outWritePos + i) % outSize;
+                m_stereoOutAccumL[idx] += m_window[i] * m_ifftOut[i];
+            }
+
+            for (int i = 0; i < m_fftSize; ++i) {
+                const int idx = (frameReadPos + i) % accSize;
+                m_fftIn[i] = m_window[i] * m_stereoInAccumR[idx];
+            }
+            synthesizeCurrentFrameWithMask();
+            for (int i = 0; i < m_fftSize; ++i) {
+                const int idx = (m_outWritePos + i) % outSize;
+                m_stereoOutAccumR[idx] += m_window[i] * m_ifftOut[i];
+            }
+        }
+
+        m_inReadPos = (m_inReadPos + m_hopSize) % accSize;
+        m_samplesAccum -= m_hopSize;
+        m_outWritePos = (m_outWritePos + m_hopSize) % outSize;
+    }
+
+    for (int i = 0; i < numFrames; ++i) {
+        output[2 * i] = static_cast<float>(m_stereoOutAccumL[m_outReadPos]);
+        output[2 * i + 1] = static_cast<float>(m_stereoOutAccumR[m_outReadPos]);
+        m_stereoOutAccumL[m_outReadPos] = 0.0;
+        m_stereoOutAccumR[m_outReadPos] = 0.0;
+        m_outReadPos = (m_outReadPos + 1) % outSize;
+    }
+}
+
+bool SpectralNR::updateMaskFromCurrentFrame()
 {
 #ifdef HAVE_FFTW3
-    if (m_planFailed) return;  // FFTW plans failed — pass audio through unmodified
+    if (m_planFailed) return false;  // FFTW plans failed — pass audio through unmodified
 
     // Forward FFT via FFTW (real-to-complex, in-place from m_fftIn)
     fftw_execute(m_planFwd);
@@ -521,13 +606,35 @@ void SpectralNR::processFrame()
     // Startup ramp: crossfade from dry (gain=1) to processed over ~1 second
     // to avoid transients while the noise estimator converges.
     ++m_frameCount;
-    double wet = (m_frameCount >= RampFrames)
+    m_currentWet = (m_frameCount >= RampFrames)
         ? 1.0
         : static_cast<double>(m_frameCount) / RampFrames;
 
+    return true;
+}
+
+void SpectralNR::synthesizeCurrentFrameWithMask()
+{
+#ifdef HAVE_FFTW3
+    if (m_planFailed) return;
+
+    fftw_execute(m_planFwd);
+    for (int k = 0; k < m_msize; ++k) {
+        m_freqRe[k] = m_fftOut[k][0];
+        m_freqIm[k] = m_fftOut[k][1];
+    }
+#else
+    fftForward(m_fftIn.data(), m_freqRe.data(), m_freqIm.data());
+#endif
+
+    synthesizeCurrentFrequencyBinsWithMask();
+}
+
+void SpectralNR::synthesizeCurrentFrequencyBinsWithMask()
+{
     // Apply smoothed gain to frequency bins (with dry/wet blend during startup)
     for (int k = 0; k < m_msize; ++k) {
-        double g = wet * m_smoothMask[k] + (1.0 - wet) * 1.0;
+        double g = m_currentWet * m_smoothMask[k] + (1.0 - m_currentWet) * 1.0;
         m_gainRe[k] = g * m_freqRe[k];
         m_gainIm[k] = g * m_freqIm[k];
     }
@@ -549,6 +656,14 @@ void SpectralNR::processFrame()
 #else
     fftInverse(m_gainRe.data(), m_gainIm.data(), m_ifftOut.data());
 #endif
+}
+
+void SpectralNR::processFrame()
+{
+    if (!updateMaskFromCurrentFrame()) {
+        return;
+    }
+    synthesizeCurrentFrequencyBinsWithMask();
 }
 
 // ─── Noise Estimation (dispatches on m_npeMethod) ─────────────────────────────

--- a/src/core/SpectralNR.h
+++ b/src/core/SpectralNR.h
@@ -69,6 +69,8 @@ public:
     // float32 out.  The NR estimate/mask is computed from (L+R)/2, then the
     // same spectral gain is applied to each original channel.
     // Output buffer must be at least numFrames * 2 samples long.
+    // Use only one process entry point for an instance between resets; the mono
+    // and stereo paths share ring cursors but maintain different OLA buffers.
     void processStereoSharedMask(const float* input, float* output, int numFrames);
 
     // Reset all internal state (call when toggling on or stream restarts).

--- a/src/core/SpectralNR.h
+++ b/src/core/SpectralNR.h
@@ -49,8 +49,9 @@ namespace AetherSDR {
 // Uses FFTW3 for FFT computation (with wisdom file for optimised plans)
 // when available; falls back to a built-in radix-2 FFT otherwise.
 //
-// Processes mono int16 audio at 24 kHz.  The caller is responsible for
-// stereo<->mono conversion (average L+R on input, duplicate on output).
+// Processes mono float32 audio at 24 kHz.  For stereo Flex speaker audio,
+// processStereoSharedMask() computes one mono NR mask and applies it to both
+// original channels so radio-side balance survives client NR.
 
 class SpectralNR {
 public:
@@ -63,6 +64,12 @@ public:
     // Feed mono float32 samples in, get noise-reduced mono float32 out.
     // Output buffer must be at least numSamples long.
     void process(const float* input, float* output, int numSamples);
+
+    // Feed interleaved stereo float32 samples in, get interleaved stereo
+    // float32 out.  The NR estimate/mask is computed from (L+R)/2, then the
+    // same spectral gain is applied to each original channel.
+    // Output buffer must be at least numFrames * 2 samples long.
+    void processStereoSharedMask(const float* input, float* output, int numFrames);
 
     // Reset all internal state (call when toggling on or stream restarts).
     void reset();
@@ -130,6 +137,10 @@ private:
     std::vector<double> m_outAccum;     // overlap-add output ring
     int m_outWritePos{0};
     int m_outReadPos{0};
+    std::vector<double> m_stereoInAccumL;
+    std::vector<double> m_stereoInAccumR;
+    std::vector<double> m_stereoOutAccumL;
+    std::vector<double> m_stereoOutAccumR;
 
     // Window
     std::vector<double> m_window;
@@ -190,6 +201,7 @@ private:
     std::vector<double> m_mask;         // current gain mask
     std::vector<double> m_smoothMask;   // temporally smoothed gain (anti-musical-noise)
     std::vector<double> m_lambdaY;      // current frame signal PSD
+    double m_currentWet{0.0};            // startup dry/wet blend for current frame
 
     // Startup ramp
     int m_frameCount{0};                // frames processed since reset
@@ -220,6 +232,9 @@ private:
     // ── Internal methods ───────────────────────────────────────────────
     void initWindow();
     void processFrame();
+    bool updateMaskFromCurrentFrame();
+    void synthesizeCurrentFrequencyBinsWithMask();
+    void synthesizeCurrentFrameWithMask();
 
     // Noise estimation (dispatches on m_npeMethod)
     void estimateNoise();

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -1,0 +1,240 @@
+#include "core/MonoDspStereoAdapter.h"
+
+#include <QByteArray>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <utility>
+#include <vector>
+
+using AetherSDR::MonoDspStereoAdapter;
+
+namespace {
+
+constexpr int kSampleRate = 24000;
+constexpr float kPi = 3.14159265358979323846f;
+
+struct Rms {
+    double left{0.0};
+    double right{0.0};
+};
+
+QByteArray makeStereoBlock(int frames, float leftScale, float rightScale)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < frames; ++i) {
+        const float carrier =
+            std::sin(2.0f * kPi * 733.0f * static_cast<float>(i) / kSampleRate);
+        samples[i * 2] = leftScale * carrier;
+        samples[i * 2 + 1] = rightScale * carrier;
+    }
+    return block;
+}
+
+QByteArray makeOppositePhaseStereoBlock(int frames, float scale)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < frames; ++i) {
+        const float carrier =
+            std::sin(2.0f * kPi * 733.0f * static_cast<float>(i) / kSampleRate);
+        samples[i * 2] = scale * carrier;
+        samples[i * 2 + 1] = -scale * carrier;
+    }
+    return block;
+}
+
+std::vector<float> makeProcessedMono(const QByteArray& stereoBlock, float gain)
+{
+    const auto* samples = reinterpret_cast<const float*>(stereoBlock.constData());
+    const int frames = stereoBlock.size() / (2 * static_cast<int>(sizeof(float)));
+    std::vector<float> mono(frames);
+    for (int i = 0; i < frames; ++i) {
+        mono[i] = gain * 0.5f * (samples[i * 2] + samples[i * 2 + 1]);
+    }
+    return mono;
+}
+
+Rms measureRms(const QByteArray& stereoBlock, int discardFrames)
+{
+    const auto* samples = reinterpret_cast<const float*>(stereoBlock.constData());
+    const int frames = stereoBlock.size() / (2 * static_cast<int>(sizeof(float)));
+    double leftSq = 0.0;
+    double rightSq = 0.0;
+    int count = 0;
+    for (int i = std::min(discardFrames, frames); i < frames; ++i) {
+        leftSq += static_cast<double>(samples[i * 2]) * samples[i * 2];
+        rightSq += static_cast<double>(samples[i * 2 + 1]) * samples[i * 2 + 1];
+        ++count;
+    }
+
+    if (count == 0) {
+        return {};
+    }
+    return {std::sqrt(leftSq / count), std::sqrt(rightSq / count)};
+}
+
+bool nearlyEqual(double a, double b, double tolerance)
+{
+    return std::abs(a - b) <= tolerance;
+}
+
+bool testPreservesRatioWithSharedGain()
+{
+    MonoDspStereoAdapter adapter;
+    const QByteArray dry = makeStereoBlock(kSampleRate, 0.8f, 0.2f);
+    const std::vector<float> processedMono = makeProcessedMono(dry, 0.42f);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(
+        processedMono.data(), static_cast<int>(processedMono.size()));
+
+    const Rms rms = measureRms(out, kSampleRate / 4);
+    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
+    if (!nearlyEqual(ratio, 4.0, 0.05)) {
+        std::printf("ratio preservation failed: got %.6f expected 4.0\n", ratio);
+        return false;
+    }
+    if (rms.left <= 0.01 || rms.right <= 0.01) {
+        std::printf("adapter output unexpectedly quiet: L %.6f R %.6f\n",
+                    rms.left,
+                    rms.right);
+        return false;
+    }
+    return true;
+}
+
+bool testBuffersDryUntilProcessedArrives()
+{
+    MonoDspStereoAdapter adapter;
+    const int frames = 960;
+    const QByteArray first = makeStereoBlock(frames, 0.7f, 0.3f);
+    const QByteArray second = makeStereoBlock(frames, 0.5f, 0.5f);
+    const std::vector<float> firstProcessed = makeProcessedMono(first, 0.35f);
+
+    adapter.pushDryStereo(first);
+    adapter.pushDryStereo(second);
+    const QByteArray out = adapter.takeProcessedMono(
+        firstProcessed.data(), static_cast<int>(firstProcessed.size()));
+
+    if (adapter.bufferedFrames() != frames) {
+        std::printf("buffered frame count failed: got %d expected %d\n",
+                    adapter.bufferedFrames(),
+                    frames);
+        return false;
+    }
+
+    const Rms rms = measureRms(out, frames / 4);
+    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
+    if (!nearlyEqual(ratio, 0.7 / 0.3, 0.05)) {
+        std::printf("buffer alignment failed: got ratio %.6f\n", ratio);
+        return false;
+    }
+    return true;
+}
+
+bool testOppositePhaseStereoDoesNotFadeOut()
+{
+    MonoDspStereoAdapter adapter;
+    const QByteArray dry = makeOppositePhaseStereoBlock(kSampleRate, 0.6f);
+    const std::vector<float> processedMono = makeProcessedMono(dry, 0.42f);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(
+        processedMono.data(), static_cast<int>(processedMono.size()));
+
+    const Rms rms = measureRms(out, kSampleRate / 4);
+    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
+    if (!nearlyEqual(ratio, 1.0, 0.05)) {
+        std::printf("opposite-phase ratio failed: got %.6f expected 1.0\n", ratio);
+        return false;
+    }
+    if (rms.left < 0.35 || rms.right < 0.35) {
+        std::printf("opposite-phase stereo faded out: L %.6f R %.6f\n",
+                    rms.left,
+                    rms.right);
+        return false;
+    }
+    return true;
+}
+
+bool testProcessedSilenceKeepsMinimumStereoFloor()
+{
+    MonoDspStereoAdapter adapter;
+    const QByteArray dry = makeStereoBlock(kSampleRate * 2, 0.8f, 0.2f);
+    const int frames = dry.size() / (2 * static_cast<int>(sizeof(float)));
+    std::vector<float> processedMono(frames, 0.0f);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(
+        processedMono.data(), static_cast<int>(processedMono.size()));
+
+    const Rms rms = measureRms(out, kSampleRate);
+    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
+    if (!nearlyEqual(ratio, 4.0, 0.05)) {
+        std::printf("minimum-floor ratio failed: got %.6f expected 4.0\n", ratio);
+        return false;
+    }
+    if (rms.left < 0.012 || rms.right < 0.003) {
+        std::printf("minimum-floor output too quiet: L %.6f R %.6f\n",
+                    rms.left,
+                    rms.right);
+        return false;
+    }
+    return true;
+}
+
+bool testIndependentAdaptersDoNotDrainOtherSource()
+{
+    MonoDspStereoAdapter sourceA;
+    MonoDspStereoAdapter sourceB;
+    const int frames = 960;
+    const QByteArray dryA = makeStereoBlock(frames, 0.8f, 0.2f);
+    const QByteArray dryB = makeStereoBlock(frames, 0.25f, 0.75f);
+    const std::vector<float> processedB = makeProcessedMono(dryB, 0.45f);
+
+    sourceA.pushDryStereo(dryA);
+    sourceB.pushDryStereo(dryB);
+    const QByteArray outB = sourceB.takeProcessedMono(
+        processedB.data(), static_cast<int>(processedB.size()));
+
+    if (sourceA.bufferedFrames() != frames) {
+        std::printf("source A dry queue was drained: got %d expected %d\n",
+                    sourceA.bufferedFrames(),
+                    frames);
+        return false;
+    }
+
+    const Rms rms = measureRms(outB, frames / 4);
+    const double ratio = rms.left / std::max(rms.right, 1.0e-12);
+    if (!nearlyEqual(ratio, 0.25 / 0.75, 0.05)) {
+        std::printf("source B ratio used another source: got %.6f\n", ratio);
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if (!testPreservesRatioWithSharedGain()) {
+        return 1;
+    }
+    if (!testBuffersDryUntilProcessedArrives()) {
+        return 1;
+    }
+    if (!testOppositePhaseStereoDoesNotFadeOut()) {
+        return 1;
+    }
+    if (!testProcessedSilenceKeepsMinimumStereoFloor()) {
+        return 1;
+    }
+    if (!testIndependentAdaptersDoNotDrainOtherSource()) {
+        return 1;
+    }
+    std::printf("mono_dsp_stereo_adapter_test passed\n");
+    return 0;
+}

--- a/tests/mono_dsp_stereo_adapter_test.cpp
+++ b/tests/mono_dsp_stereo_adapter_test.cpp
@@ -46,6 +46,17 @@ QByteArray makeOppositePhaseStereoBlock(int frames, float scale)
     return block;
 }
 
+QByteArray makeConstantStereoBlock(int frames, float left, float right)
+{
+    QByteArray block(frames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < frames; ++i) {
+        samples[i * 2] = left;
+        samples[i * 2 + 1] = right;
+    }
+    return block;
+}
+
 std::vector<float> makeProcessedMono(const QByteArray& stereoBlock, float gain)
 {
     const auto* samples = reinterpret_cast<const float*>(stereoBlock.constData());
@@ -216,6 +227,67 @@ bool testIndependentAdaptersDoNotDrainOtherSource()
     return true;
 }
 
+bool testDuplicatedMonoUsesProcessedWaveform()
+{
+    MonoDspStereoAdapter adapter;
+    const int frames = 960;
+    const QByteArray dry = makeStereoBlock(frames, 0.6f, 0.6f);
+    std::vector<float> processed(frames);
+    for (int i = 0; i < frames; ++i) {
+        processed[i] = 0.2f * std::sin(
+            2.0f * kPi * 1379.0f * static_cast<float>(i) / kSampleRate);
+    }
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), frames);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = 0; i < frames; ++i) {
+        if (!nearlyEqual(samples[i * 2], processed[i], 1.0e-6)
+            || !nearlyEqual(samples[i * 2 + 1], processed[i], 1.0e-6)) {
+            std::printf("duplicated mono discarded processed waveform at frame %d\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool testProcessingLatencyRetainsDryTimeline()
+{
+    constexpr int latencyFrames = 4;
+    MonoDspStereoAdapter adapter(latencyFrames);
+    const QByteArray dry = makeConstantStereoBlock(8, 0.8f, 0.2f);
+    const std::vector<float> processed(8, 0.0f);
+
+    adapter.pushDryStereo(dry);
+    const QByteArray out = adapter.takeProcessedMono(processed.data(), 8);
+    const auto* samples = reinterpret_cast<const float*>(out.constData());
+    for (int i = 0; i < latencyFrames; ++i) {
+        if (samples[i * 2] != 0.0f || samples[i * 2 + 1] != 0.0f) {
+            std::printf("latency priming emitted dry audio at frame %d\n", i);
+            return false;
+        }
+    }
+    if (adapter.bufferedFrames() != latencyFrames) {
+        std::printf("latency pairing consumed wrong dry count: got %d expected %d\n",
+                    adapter.bufferedFrames(),
+                    latencyFrames);
+        return false;
+    }
+    return true;
+}
+
+bool testOverflowClearsInsteadOfMisaligning()
+{
+    MonoDspStereoAdapter adapter;
+    adapter.pushDryStereo(makeConstantStereoBlock(kSampleRate * 6, 0.8f, 0.2f));
+    if (adapter.bufferedFrames() != 0) {
+        std::printf("overflow retained a misaligned dry timeline: %d frames\n",
+                    adapter.bufferedFrames());
+        return false;
+    }
+    return true;
+}
+
 } // namespace
 
 int main()
@@ -233,6 +305,15 @@ int main()
         return 1;
     }
     if (!testIndependentAdaptersDoNotDrainOtherSource()) {
+        return 1;
+    }
+    if (!testDuplicatedMonoUsesProcessedWaveform()) {
+        return 1;
+    }
+    if (!testProcessingLatencyRetainsDryTimeline()) {
+        return 1;
+    }
+    if (!testOverflowClearsInsteadOfMisaligning()) {
         return 1;
     }
     std::printf("mono_dsp_stereo_adapter_test passed\n");

--- a/tests/rnnoise_filter_test.cpp
+++ b/tests/rnnoise_filter_test.cpp
@@ -1,0 +1,78 @@
+#include "core/RNNoiseFilter.h"
+
+#include <QByteArray>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::RNNoiseFilter;
+
+namespace {
+
+constexpr int kBlockFrames = 480;
+constexpr int kSampleRate = 24000;
+constexpr float kPi = 3.14159265358979323846f;
+
+QByteArray makeUnequalStereoBlock(int blockIndex)
+{
+    QByteArray block(
+        kBlockFrames * 2 * static_cast<int>(sizeof(float)),
+        Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(block.data());
+    for (int i = 0; i < kBlockFrames; ++i) {
+        const int frame = blockIndex * kBlockFrames + i;
+        const float seconds = static_cast<float>(frame) / kSampleRate;
+        const float envelope = 0.55f + 0.35f * std::sin(2.0f * kPi * 3.0f * seconds);
+        const float signal = envelope * (
+            0.45f * std::sin(2.0f * kPi * 180.0f * seconds)
+            + 0.25f * std::sin(2.0f * kPi * 440.0f * seconds)
+            + 0.15f * std::sin(2.0f * kPi * 1000.0f * seconds));
+        samples[i * 2] = signal;
+        samples[i * 2 + 1] = 0.25f * signal;
+    }
+    return block;
+}
+
+bool testProcessedMonoOutputIsDuplicated()
+{
+    RNNoiseFilter filter(RNNoiseFilter::OutputMode::ProcessedMono);
+    if (!filter.isValid()) {
+        std::printf("RNNoise initialization failed\n");
+        return false;
+    }
+
+    bool heardProcessedAudio = false;
+    for (int blockIndex = 0; blockIndex < 150; ++blockIndex) {
+        const QByteArray output = filter.process(makeUnequalStereoBlock(blockIndex));
+        const auto* samples = reinterpret_cast<const float*>(output.constData());
+        for (int i = 0; i < kBlockFrames; ++i) {
+            const float left = samples[i * 2];
+            const float right = samples[i * 2 + 1];
+            if (std::abs(left - right) > 1.0e-6f) {
+                std::printf(
+                    "processed-mono output restored dry stereo at block %d frame %d\n",
+                    blockIndex,
+                    i);
+                return false;
+            }
+            heardProcessedAudio = heardProcessedAudio || std::abs(left) > 1.0e-5f;
+        }
+    }
+
+    if (!heardProcessedAudio) {
+        std::printf("processed-mono output remained silent after startup\n");
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    if (!testProcessedMonoOutputIsDuplicated()) {
+        return 1;
+    }
+    std::printf("rnnoise_filter_test passed\n");
+    return 0;
+}

--- a/tests/spectral_nr_test.cpp
+++ b/tests/spectral_nr_test.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdio>
 #include <numbers>
+#include <utility>
 #include <vector>
 
 using AetherSDR::SpectralNR;
@@ -249,6 +250,46 @@ std::vector<float> processWithBlockSize(const std::vector<float>& input,
     return output;
 }
 
+std::vector<float> processStereoSharedMaskWithBlockSize(
+    const std::vector<float>& input,
+    int blockFrames)
+{
+    SpectralNR nr;
+    nr.setGainMethod(2);
+
+    std::vector<float> output(input.size());
+    int offsetFrames = 0;
+    const int totalFrames = static_cast<int>(input.size() / 2);
+    while (offsetFrames < totalFrames) {
+        const int count = std::min(blockFrames, totalFrames - offsetFrames);
+        nr.processStereoSharedMask(input.data() + (2 * offsetFrames),
+                                   output.data() + (2 * offsetFrames),
+                                   count);
+        offsetFrames += count;
+    }
+    return output;
+}
+
+std::pair<double, double> stereoRmsAfter(const std::vector<float>& interleaved,
+                                         int startFrame)
+{
+    double leftSum = 0.0;
+    double rightSum = 0.0;
+    int count = 0;
+    const int totalFrames = static_cast<int>(interleaved.size() / 2);
+    for (int frame = startFrame; frame < totalFrames; ++frame) {
+        const double left = interleaved[2 * frame];
+        const double right = interleaved[2 * frame + 1];
+        leftSum += left * left;
+        rightSum += right * right;
+        ++count;
+    }
+    return {
+        std::sqrt(leftSum / std::max(count, 1)),
+        std::sqrt(rightSum / std::max(count, 1)),
+    };
+}
+
 void test_block_size_invariance()
 {
     // KiwiSDR audio arrives in packet-sized bursts, while native Flex RX audio
@@ -269,6 +310,47 @@ void test_block_size_invariance()
     std::snprintf(detail, sizeof(detail), " (max abs diff: %.3e)", maxAbsDiff);
     report("block_size_invariance: 1024-sample packets match 128-sample hops",
            maxAbsDiff < 1e-7, detail);
+}
+
+void test_stereo_shared_mask_preserves_balance()
+{
+    // Flex remote_audio_rx is one radio-mixed stereo stream.  NR2 should use a
+    // shared noise estimate, but must not collapse the stream to mono and then
+    // rebuild it with one active-slice pan value (#4035).
+    constexpr int sampleRate = 24000;
+    constexpr int frames = sampleRate;
+    std::vector<float> input(frames * 2);
+    for (int i = 0; i < frames; ++i) {
+        const double t = static_cast<double>(i) / sampleRate;
+        const float signal = static_cast<float>(
+            0.34 * std::sin(2.0 * std::numbers::pi * 720.0 * t)
+          + 0.13 * std::sin(2.0 * std::numbers::pi * 1740.0 * t)
+          + 0.03 * std::sin(2.0 * std::numbers::pi * 43.0 * t));
+        input[2 * i] = 0.80f * signal;
+        input[2 * i + 1] = 0.20f * signal;
+    }
+
+    const std::vector<float> output =
+        processStereoSharedMaskWithBlockSize(input, 1024);
+
+    constexpr int discardFrames = 4096;
+    const auto [inLeft, inRight] = stereoRmsAfter(input, discardFrames);
+    const auto [outLeft, outRight] = stereoRmsAfter(output, discardFrames);
+    const double inRatio = inLeft / std::max(inRight, 1e-12);
+    const double outRatio = outLeft / std::max(outRight, 1e-12);
+    const double ratioError = std::abs(outRatio - inRatio);
+
+    char detail[128];
+    std::snprintf(detail, sizeof(detail),
+                  " (input L/R %.4f, output L/R %.4f, err %.3e)",
+                  inRatio, outRatio, ratioError);
+    report("stereo_shared_mask: preserves unbalanced L/R energy",
+           ratioError < 1e-3, detail);
+
+    std::snprintf(detail, sizeof(detail),
+                  " (output L %.6f, R %.6f)", outLeft, outRight);
+    report("stereo_shared_mask: output remains non-silent",
+           outLeft > 1e-5 && outRight > 1e-5, detail);
 }
 
 void test_gain_formula_extreme_v()
@@ -334,6 +416,9 @@ int main()
 
     std::printf("\n-- Block-size invariance (Kiwi packet cadence regression) --\n");
     test_block_size_invariance();
+
+    std::printf("\n-- Stereo shared-mask balance preservation (#4035) --\n");
+    test_stereo_shared_mask_preserves_balance();
 
     std::printf("\n-- Gain formula at extreme v (NaN-clamp regression) --\n");
     test_gain_formula_extreme_v();

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -33,7 +33,7 @@ Usage:
     python tools/automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png
     python tools/automation_probe.py panmessage add 0 kiwi 0 "Waiting|Queued"
     python tools/automation_probe.py audioCapture start 3000 raw,post,final
-    python tools/automation_probe.py audioCapture probeDspStereo all [strict]
+    python tools/automation_probe.py audioCapture probeDspStereo all [strict]  # may take up to 120s
     python tools/automation_probe.py audioCapture read /tmp/aether-audio.json
 """
 
@@ -72,16 +72,21 @@ class Bridge:
             self._sock.connect(sock_path)
             self._pipe = None
 
-    def request(self, obj):
-        return self.request_line(json.dumps(obj))
+    def request(self, obj, timeout_seconds=None):
+        return self.request_line(json.dumps(obj), timeout_seconds)
 
-    def request_line(self, text):
+    def request_line(self, text, timeout_seconds=None):
         """Send one raw request line (JSON or bare positional) and return the
         decoded JSON response."""
         line = (text + "\n").encode()
         if self._sock:
-            self._sock.sendall(line)
-            return self._read_line_sock()
+            previous_timeout = self._sock.gettimeout()
+            try:
+                self._sock.settimeout(timeout_seconds)
+                self._sock.sendall(line)
+                return self._read_line_sock()
+            finally:
+                self._sock.settimeout(previous_timeout)
         self._pipe.write(line)
         self._pipe.flush()
         return json.loads(self._pipe.readline().decode())
@@ -401,7 +406,7 @@ def main():
                "  automation_probe.py resize 1600 900\n"
                "  automation_probe.py audioCapture start 3000 raw,post,final\n"
                "  automation_probe.py audioCapture probeNr2Stereo\n"
-               "  automation_probe.py audioCapture probeDspStereo all [strict]\n"
+               "  automation_probe.py audioCapture probeDspStereo all [strict]  # up to 120s\n"
                "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png\n"
@@ -463,11 +468,18 @@ def main():
 
         else:
             mapper = MAPPERS.get(args.command)
+            action = ""
             if mapper is not None:
                 req = mapper(args.rest)
                 req["cmd"] = args.command
                 action = req.get("action", "")
-                resp = bridge.request(req)
+                probe_timeout = (120 if args.command == "audioCapture"
+                                 and action in ("probeNr2Stereo", "probeDspStereo")
+                                 else None)
+                try:
+                    resp = bridge.request(req, timeout_seconds=probe_timeout)
+                except TimeoutError:
+                    sys.exit(f"error: {action} exceeded the {probe_timeout}s bridge timeout")
             else:
                 # No bespoke mapping: pass the bare positional line through and
                 # let the server's verb registry parse it. Note: the server

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -33,6 +33,7 @@ Usage:
     python tools/automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png
     python tools/automation_probe.py panmessage add 0 kiwi 0 "Waiting|Queued"
     python tools/automation_probe.py audioCapture start 3000 raw,post,final
+    python tools/automation_probe.py audioCapture probeDspStereo all [strict]
     python tools/automation_probe.py audioCapture read /tmp/aether-audio.json
 """
 
@@ -399,6 +400,8 @@ def main():
                "  automation_probe.py clickAt AppletPanel 12 34  # point local to a widget\n"
                "  automation_probe.py resize 1600 900\n"
                "  automation_probe.py audioCapture start 3000 raw,post,final\n"
+               "  automation_probe.py audioCapture probeNr2Stereo\n"
+               "  automation_probe.py audioCapture probeDspStereo all [strict]\n"
                "  automation_probe.py audioCapture read /tmp/aether-audio.json\n"
                "  automation_probe.py grab SpectrumWidget /tmp/pan.png\n"
                "  automation_probe.py grab pan-visible 1 /tmp/pan1-visible.png\n"
@@ -463,6 +466,7 @@ def main():
             if mapper is not None:
                 req = mapper(args.rest)
                 req["cmd"] = args.command
+                action = req.get("action", "")
                 resp = bridge.request(req)
             else:
                 # No bespoke mapping: pass the bare positional line through and
@@ -471,6 +475,10 @@ def main():
                 # entry (or the JSON protocol) to survive quoting.
                 resp = bridge.request_line(" ".join([args.command] + args.rest))
             print(json.dumps(resp, indent=2))
+            if (args.command == "audioCapture"
+                    and action in ("probeNr2Stereo", "probeDspStereo")
+                    and resp.get("ok") is False):
+                sys.exit(1)
     finally:
         bridge.close()
 


### PR DESCRIPTION
## Summary

Fixes #4035. Preserve left/right receive balance through client-side RX DSP by keeping the Flex remote-audio stream stereo-aware instead of collapsing it to mono and rebuilding it from the active slice pan. NR2 now computes a shared noise mask and applies it to both original channels; RN2, NR4, MNR, DFNR, and BNR use a shared mono-DSP attenuation adapter that preserves the dry stereo balance. Kiwi/diversity receive paths now keep independent DSP state per audio source, and the automation bridge has stereo-balance probes with strict coverage reporting.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The change adds focused DSP stereo-preservation tests and automation-bridge probes that assert L/R balance preservation across built RX DSP modes.

## Test plan

- [x] Local build passes (`cmake --build build --target mono_dsp_stereo_adapter_test spectral_nr_test AetherSDR -j8`)
- [x] Behavior verified on a real radio if applicable
  - Verified through the visible automation bridge with `audioCapture probeDspStereo all`
  - `probeDspStereo all strict` correctly exits nonzero when optional DFNR/BNR support is not built
- [x] Existing tests pass (CI)
  - Local focused tests: `ctest --test-dir build -R 'mono_dsp_stereo_adapter_test|spectral_nr_test' --output-on-failure`
  - `git diff --check`
  - `python3 tools/check_engine_boundary.py --strict`
- [x] Reproduction steps documented if user-reported bug
  - Covered by the bridge `probeDspStereo`/`probeNr2Stereo` verbs and unit tests that assert unbalanced stereo survives DSP

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable