### PR TITLE
build: disable unused liquid-dsp by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- **liquid-dsp is disabled in default builds on every platform.** The vendored
+  toolkit remains available to opt-in builds with
+  `-DENABLE_LIQUID_DSP=ON`, but no AetherSDR module currently consumes it.
 - **WAVE applet defaults to 25 fps** (was 60), matching the panadapter's
   default FFT cadence. A previously saved refresh rate is kept; the slider
   still reaches 60.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 # Libraries options — opt-in system-package replacements for vendored
-# dependencies.  Off by default so existing build hosts (CI containers,
-# release builds, contributor laptops) keep using the bundled, version-
-# pinned third_party/ snapshots.  Distro packagers turn these ON to
+# dependencies.  For dependencies enabled in a build, these stay off by
+# default so CI, releases, and contributor laptops use the bundled,
+# version-pinned third_party/ snapshots.  Distro packagers turn these ON to
 # match their dynamic-linking policy.
 
 option(USE_SYSTEM_ZLIB         "Use system zlib"         OFF)
@@ -23,6 +23,7 @@ option(USE_SYSTEM_LIQUID_DSP   "Use system liquid-dsp"   OFF)
 
 option(REQUIRE_SERIALPORT "Fail if Qt6 SerialPort is not found (use for release builds)" OFF)
 option(REQUIRE_KEYCHAIN "Fail if Qt6Keychain is not found (use for release builds)" OFF)
+option(ENABLE_LIQUID_DSP "Build with liquid-dsp toolkit support" OFF)
 option(ENABLE_RADE "Build with RADE digital voice support (uses vendored Opus snapshot)" ON)
 option(AETHER_GPU_SPECTRUM "Enable QRhi GPU spectrum rendering" ON)
 option(ENABLE_SPECBLEACH "Enable NR4 spectral bleach noise reduction" ON)
@@ -974,11 +975,16 @@ message(STATUS "AetherAFSKDemod: Direwolf profile-A (VHF 1200 baud), GPL-2.0-or-
 # bundled third_party/fftw3 can be a follow-up if a future consumer wants
 # FFTW-accelerated transforms.
 #
-# AetherSDR links against liquid-static (conditionally on non-MSVC) so the
-# build verifies clean on Linux + macOS even though no module currently
-# consumes liquid symbols. Standard linker dead-code elimination
-# (--gc-sections on ELF) drops the unused static lib from the final binary.
-if(NOT MSVC AND NOT USE_SYSTEM_LIQUID_DSP)
+# Disabled by default on every platform because no AetherSDR module currently
+# consumes liquid-dsp symbols. Opt-in non-MSVC builds link liquid-static; the
+# static linker then extracts only symbols used by a future consumer.
+if(ENABLE_LIQUID_DSP AND MSVC)
+    message(FATAL_ERROR
+        "ENABLE_LIQUID_DSP is not supported with MSVC because liquid-dsp's "
+        "public headers use C99 _Complex types")
+endif()
+
+if(ENABLE_LIQUID_DSP AND NOT USE_SYSTEM_LIQUID_DSP)
     set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(BUILD_AUTOTESTS OFF CACHE BOOL "" FORCE)
     set(BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
@@ -1006,9 +1012,9 @@ if(NOT MSVC AND NOT USE_SYSTEM_LIQUID_DSP)
     if(TARGET liquid-static)
         target_compile_options(liquid-static PRIVATE -w)
     endif()
-endif()  # NOT MSVC
+endif()
 
-if (USE_SYSTEM_LIQUID_DSP)
+if(ENABLE_LIQUID_DSP AND USE_SYSTEM_LIQUID_DSP)
     find_package(PkgConfig REQUIRED)
     if(PkgConfig_FOUND)
         pkg_check_modules(liquid-dsp REQUIRED IMPORTED_TARGET liquid-dsp)
@@ -1232,12 +1238,12 @@ target_link_libraries(AetherSDR PRIVATE
     ${CMAKE_DL_LIBS}   # dlopen/dlsym for tolerant X11 error handler (#1839)
 )
 
-if (USE_SYSTEM_LIQUID_DSP)
-    target_link_libraries(aethercore PRIVATE PkgConfig::liquid-dsp)
-else()
-    # bundled third_party/liquid-dsp (#3043) — non-MSVC only; see CMakeLists
-    # block above for the liquid-dsp/MSVC C99 _Complex incompatibility.
-    target_link_libraries(aethercore PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:liquid-static>)
+if(ENABLE_LIQUID_DSP)
+    if(USE_SYSTEM_LIQUID_DSP)
+        target_link_libraries(aethercore PRIVATE PkgConfig::liquid-dsp)
+    else()
+        target_link_libraries(aethercore PRIVATE liquid-static)
+    endif()
 endif()
 
 if(Qt6SerialPort_FOUND)

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -206,7 +206,7 @@ libraries.  See #2651.
   Source:  https://github.com/madler/zlib
 
 
-14. liquid-dsp — Comprehensive DSP Toolkit (Linux + macOS only)
+14. liquid-dsp — Comprehensive DSP Toolkit (disabled by default)
 ----------------------------------------------------------------
 Bundled at third_party/liquid-dsp/ (commit 4df6fc2ba99b3a584e9f1ad9888094013ae07b2f).
 Comprehensive DSP library covering modems (PSK/QAM/FSK/GMSK/OFDM), forward
@@ -214,10 +214,11 @@ error correction (Hamming/Golay/Reed-Solomon/convolutional), adaptive filters
 (LMS/RLS), AGC, NCO, polyphase resampling, and equalizers.  Vendored
 proactively under #3043 as foundation infrastructure for future digital-mode
 work — no AetherSDR module currently consumes liquid-dsp symbols; standard
-linker dead-code elimination drops the unused static lib from the final
-binary until a consumer arrives.  Upstream dev infrastructure (autotests,
-benchmarks, sandbox, docs, autotools wiring) trimmed before vendoring; the
-upstream CMakeLists.txt drives the build via add_subdirectory.
+builds therefore leave it disabled on every platform.  Opt-in builds use
+`-DENABLE_LIQUID_DSP=ON`; the static linker extracts only symbols used by a
+future consumer.  Upstream dev infrastructure (autotests, benchmarks, sandbox,
+docs, autotools wiring) was trimmed before vendoring; the upstream
+CMakeLists.txt drives opt-in builds via add_subdirectory.
 
 Linux + macOS only — liquid-dsp upstream targets GCC/Clang/MinGW; its
 include/liquid.h uses C99 `float _Complex` typedefs which MSVC's C compiler


### PR DESCRIPTION
## Summary

- Add an unconditional `ENABLE_LIQUID_DSP` CMake feature option that defaults to `OFF` on every platform.
- Gate bundled liquid-dsp configuration, system-package discovery, and `aethercore` linking behind that option.
- Preserve the vendored non-MSVC path for explicit `-DENABLE_LIQUID_DSP=ON` builds.
- Fail clearly when liquid-dsp is explicitly enabled with MSVC, where the public C99 `_Complex` API remains unsupported.
- Update the changelog and third-party notice to describe the new default and opt-in path.

## Why

`USE_SYSTEM_LIQUID_DSP=OFF` previously selected the vendored provider; it did not disable liquid-dsp. Consequently every ordinary Linux and macOS build configured and compiled the entire static toolkit even though no AetherSDR module includes its headers or consumes its symbols. Windows/MSVC skipped the vendored target because of the existing C99 complex-type incompatibility.

This separates two independent decisions:

1. whether AetherSDR enables liquid-dsp at all; and
2. when enabled, whether it uses the system or vendored provider.

The result is an honest default: dormant infrastructure remains vendored and available, but standard builds do not pay its clean-build cost.

## Build behavior

| Configuration | Result |
|---|---|
| Default on any platform | liquid-dsp is neither configured nor linked |
| `ENABLE_LIQUID_DSP=ON`, non-MSVC | builds and links vendored `liquid-static` |
| `ENABLE_LIQUID_DSP=ON` plus `USE_SYSTEM_LIQUID_DSP=ON`, non-MSVC | discovers and links the pkg-config provider |
| `ENABLE_LIQUID_DSP=ON`, MSVC | fails at configure time with the existing `_Complex` incompatibility explained |

## Impact

- No runtime behavior changes: there was no liquid-dsp consumer before this PR.
- Default application binaries retain no liquid-dsp dependency or symbols.
- Clean default builds avoid the 203 liquid-dsp build steps observed in the opt-in verification build.
- Future consumers can explicitly enable the toolkit without restoring unconditional build overhead.

## Relationship to Windows support

Relates to #3049.

This PR does **not** implement or close the issue's MinGW ExternalProject path. Instead, it supplies the default-off feature gate described by that issue and makes the unsupported MSVC opt-in state explicit. Issue #3049 remains the follow-up for a working Windows implementation and smoke consumer.

## Validation

- `cmake -S . -B build-default -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
  - configured with `ENABLE_LIQUID_DSP:BOOL=OFF`
  - generated no `third_party/liquid-dsp` build directory or liquid target
- `cmake --build build-default -j8 --target AetherSDR`
  - compiled and linked the macOS application successfully
  - `otool` and `nm` inspection found no liquid-dsp dependency or symbols
- `cmake -S . -B build-liquid-on -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_LIQUID_DSP=ON`
- `cmake --build build-liquid-on -j8 --target liquid-static`
  - built the opt-in 3.8 MB `libliquid.a` successfully in 203 steps
- `git diff --check`

👨🏼‍💻 Generated with OpenAI GPT-5.6 Sol 7/9/26 and tested by @jensenpat
