### PR TITLE
feat(bands): add microwave weak-signal bands 13cm/9cm/5cm/3cm

### DIFF
--- a/src/models/BandDefs.h
+++ b/src/models/BandDefs.h
@@ -35,6 +35,11 @@ inline constexpr BandDef kBands[] = {
     {"440",  420.000,  450.000,  432.100,   "FM"},
     {"33cm", 902.000,  928.000,  903.100,   "FM"},
     {"23cm",1240.000, 1300.000, 1296.100,   "USB"},
+    // Microwave / weak-signal — transverter bands (defaults = SSB/CW calling freqs)
+    {"13cm",2300.000, 2450.000, 2304.100,   "USB"},
+    {"9cm", 3300.000, 3500.000, 3456.100,   "USB"},
+    {"5cm", 5650.000, 5925.000, 5760.100,   "USB"},
+    {"3cm",10000.000,10500.000,10368.100,   "USB"},
 };
 
 inline constexpr int kBandCount = static_cast<int>(std::size(kBands));


### PR DESCRIPTION
## What

Adds four microwave / weak-signal bands to `BandDefs.h`, so transverter and
microwave operators get band buttons, band-stack matching, and bookmark grouping
above 1.3 GHz:

| Band | Range (MHz) | Default (MHz) | Mode |
|------|-------------|---------------|------|
| 13cm | 2300–2450   | 2304.100      | USB  |
| 9cm  | 3300–3500   | 3456.100      | USB  |
| 5cm  | 5650–5925   | 5760.100      | USB  |
| 3cm  | 10000–10500 | 10368.100     | USB  |

Defaults are the US SSB/CW weak-signal calling frequencies. AE's band table
previously stopped at 23cm (1.3 GHz), so a 10 GHz transverter station had no
band entry for its operating band.

## Why it's low-risk

`kBands[]` is data-driven — nothing hardcodes the band count or an upper
frequency:

- `BandStackPanel` iterates `kBandCount` (auto-derived via `std::size`), so the
  band menu, freq→band mapping, and bookmark grouping pick these up with no
  other code change.
- Frequencies are `double` MHz, so 10368.100 is fine (no int/GHz overflow).
- The old "divide then reject results above 1000 MHz" heuristic that blacked out
  the waterfall for transverters was already removed (#3449, #1843, #1928,
  #2835 — see `PanadapterStream.cpp`), so AE already supports > 1 GHz operation.
  This just gives those bands names.

This is a natural extension of the VHF/UHF entries already added "for XVTR band
stack matching (#346, #695)".

## Testing

- Builds clean (MSVC / Ninja, Windows).
- `declared_bands_test` 9/9, `radio_discovery_test` 5/5, `band_plan_license_filter_test` 13/13.

## Scope

13cm→3cm only (the bands most weak-signal ops actually run). Higher bands
(1.2cm/24 GHz and up) deliberately left out for now — easy to add later on the
same pattern.

Pairs with the radio-declared-bands work (#4027): a gateway/transverter that
declares e.g. `bands=13cm,3cm` will now have those render in AE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)