### PR TITLE
feat(dax-tx): opt-in DAX-TX zero-power watchdog + reset primitive (POC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ set(MODEL_SOURCES
     src/models/TunerModel.cpp
     src/models/AmpModel.cpp
     src/models/TransmitModel.cpp
+    src/models/TxDaxWatchdog.cpp
     src/models/EqualizerModel.cpp
     src/models/TnfModel.cpp
     src/models/UsbCableModel.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2840,6 +2840,14 @@ target_include_directories(transmit_inhibit_policy_test PRIVATE src)
 target_link_libraries(transmit_inhibit_policy_test PRIVATE Qt6::Core)
 add_test(NAME transmit_inhibit_policy_test COMMAND transmit_inhibit_policy_test)
 
+# DAX-TX watchdog decision core (2b). Header-only policy — no extra sources.
+add_executable(dax_tx_watchdog_policy_test
+    tests/dax_tx_watchdog_policy_test.cpp
+)
+target_include_directories(dax_tx_watchdog_policy_test PRIVATE src)
+target_link_libraries(dax_tx_watchdog_policy_test PRIVATE Qt6::Core)
+add_test(NAME dax_tx_watchdog_policy_test COMMAND dax_tx_watchdog_policy_test)
+
 # Container system Phase 1 tests — needs QApplication + Widgets.
 add_executable(container_widget_test
     tests/container_widget_test.cpp

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2079,6 +2079,8 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
             }
         } else if (cmd == QLatin1String("streams")) {
             action = tok(1);  // "" (Layer A UDP-orphan) | "radio" (Layer B) | "reset"
+        } else if (cmd == QLatin1String("txstream")) {
+            action = tok(1);  // "reset" — tear down + recreate the DAX-TX stream
         } else if (cmd == QLatin1String("audioCapture")) {
             action = tok(1);  // start | stop | read | status
             QStringList rest;
@@ -2274,6 +2276,11 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     }
     if (cmd == QLatin1String("streams"))
         return doStreams(action);
+    if (cmd == QLatin1String("txstream")) {
+        if (action.isEmpty())
+            return err(QStringLiteral("txstream requires an action (reset)"));
+        return doTxStream(action);
+    }
     if (cmd == QLatin1String("tci")) {
         if (action.isEmpty())
             return err(QStringLiteral("tci requires an action (start [port] | status | stop [abrupt])"));
@@ -5610,6 +5617,33 @@ QJsonObject AutomationServer::doStreams(const QString& action)
         {QStringLiteral("registeredWfStreams"), wfReg},
         {QStringLiteral("orphanStreams"), orphans},
         {QStringLiteral("orphanCount"), orphans.size()},
+    };
+}
+
+// `txstream reset` — the software equivalent of "restart WSJT-X / toggle the
+// audio source": tear down the current DAX-TX stream on the radio and recreate
+// it, invalidating both the ownership (RadioModel::m_daxTxStreamId) and the
+// emission (AudioEngine::m_txStreamId) id caches so no VITA packet stamps a
+// stale/dead id (the H5 desync). Operator-triggered recovery for the TX
+// low-power drop; call in the RX gap. See RadioModel::resetDaxTxStream().
+QJsonObject AutomationServer::doTxStream(const QString& action)
+{
+    if (!m_radioModel)
+        return err(QStringLiteral("no radio model available"));
+
+    if (action.compare(QLatin1String("reset"), Qt::CaseInsensitive) != 0)
+        return err(QStringLiteral("unknown txstream action: ") + action
+                   + QStringLiteral(" (only 'reset' is supported)"));
+
+    if (!m_radioModel->isConnected())
+        return err(QStringLiteral("not connected — cannot reset DAX TX stream"));
+
+    m_radioModel->resetDaxTxStream();  // reason defaults to TciTxAudio
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("txstream"), QStringLiteral("reset")},
+        {QStringLiteral("hint"),
+         QStringLiteral("recreate is async on the remove-ack; trigger only in the RX gap")},
     };
 }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5638,6 +5638,13 @@ QJsonObject AutomationServer::doTxStream(const QString& action)
     if (!m_radioModel->isConnected())
         return err(QStringLiteral("not connected — cannot reset DAX TX stream"));
 
+    // RX-gap-only for the manual path: resetting mid-transmit zeroes the
+    // emission stream id during a live TX and glitches that cycle. The native
+    // watchdog (2b) enforces this itself; the bridge verb must too. (F3)
+    if (m_radioModel->isRadioTransmitting())
+        return err(QStringLiteral("currently transmitting — trigger 'txstream reset' in the "
+                                  "RX gap (between TX cycles) so it can't interrupt a live transmit"));
+
     m_radioModel->resetDaxTxStream();  // reason defaults to TciTxAudio
     return QJsonObject{
         {QStringLiteral("ok"), true},

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -363,6 +363,7 @@ private:
     //                     waterfall the client view had already purged.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
+    QJsonObject doTxStream(const QString& action);
     QJsonObject doTci(const QString& action, const QString& value);
     QJsonObject doAudioCapture(const QString& action,
                                const QString& arg,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -94,6 +94,7 @@ namespace AetherSDR {
 
 class ConnectionPanel;
 class TitleBar;
+class TxDaxWatchdog;
 class KiwiSdrManager;
 class SpectrumWidget;
 class PanadapterApplet;
@@ -681,6 +682,9 @@ private:
     DxccColorProvider m_dxccProvider;
     AudioEngine*      m_audio{nullptr};
     QThread*          m_audioThread{nullptr};
+    // 2b: opt-in native DAX-TX zero-power watchdog (off unless
+    // AETHER_TX_DAX_WATCHDOG=1). Parented to this; auto-wires to m_radioModel.
+    TxDaxWatchdog*    m_txDaxWatchdog{nullptr};
     QMediaDevices*    m_audioDeviceMonitor{nullptr};
     QTimer            m_audioDeviceChangeTimer;
     QList<QByteArray> m_knownAudioInputIds;

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -512,6 +512,13 @@ void MainWindow::wireRadioModel()
             audioStartTx(m_radioModel.radioAddress(), 4991);
         }
     });
+    // Zero the emission-side id when the DAX-TX stream is torn down (reset or
+    // radio-side removal) so no VITA packet stamps a stale/dead stream id.
+    connect(&m_radioModel, &RadioModel::txAudioStreamInvalidated,
+            this, [this] {
+        m_audio->setTxStreamId(0);
+        qDebug() << "MainWindow: DAX TX stream ID invalidated (set to 0)";
+    });
     connect(&m_radioModel, &RadioModel::remoteTxStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setRemoteTxStreamId(streamId);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -28,6 +28,7 @@
 #include "PhoneCwApplet.h"
 #include "SpectrumOverlayMenu.h"
 #include "core/CwSidetoneGenerator.h"
+#include "models/TxDaxWatchdog.h"
 #include "core/CwTrace.h"
 #include "core/CwxLocalKeyer.h"
 #include "core/IambicKeyer.h"
@@ -519,6 +520,13 @@ void MainWindow::wireRadioModel()
         m_audio->setTxStreamId(0);
         qDebug() << "MainWindow: DAX TX stream ID invalidated (set to 0)";
     });
+    // 2b: opt-in native DAX-TX zero-power watchdog. Off unless
+    // AETHER_TX_DAX_WATCHDOG=1; when armed it auto-fires resetDaxTxStream() in
+    // the RX gap after K confirmed zero-power TX cycles — the recovery proven
+    // manually on-air via the 2c `txstream reset` verb (2026-07-09). Constructed
+    // once; it wires itself to m_radioModel's TX/meter/connection signals.
+    if (!m_txDaxWatchdog)
+        m_txDaxWatchdog = new TxDaxWatchdog(m_radioModel, this);
     connect(&m_radioModel, &RadioModel::remoteTxStreamReady,
             this, [this](quint32 streamId) {
         m_audio->setRemoteTxStreamId(streamId);

--- a/src/models/DaxTxWatchdogPolicy.h
+++ b/src/models/DaxTxWatchdogPolicy.h
@@ -1,0 +1,224 @@
+#pragma once
+
+// DaxTxWatchdogPolicy — the pure decision core of the 2b DAX-TX watchdog.
+//
+// Detects the TX low-power/DAX-stall fault (radio keyed but forward power
+// collapses to ~0 W) and decides WHEN a stream reset should fire, without any
+// dependency on the radio, Qt signals, or MeterModel. The caller feeds one
+// Observation per evaluation tick (radio keyed? latest fwd-power reading + its
+// age? monotonic clock) and gets back a Decision; it is the caller's job to
+// actually invoke RadioModel::resetDaxTxStream() when the policy says
+// WouldReset — and only ever in the RX gap, which is the only place this policy
+// emits WouldReset.
+//
+// THREE power states are distinguished, because at a fixed known RF-drive
+// (slider) setting the fault presents two different ways and they are almost
+// certainly different failure modes:
+//   * Good  — forward power matches the expected drive (~50 W).
+//   * Low   — non-zero but well below expected (~5-10 W). Degraded; the stream
+//             is alive. May be real PA/drive droop, NOT a dead DAX stream.
+//   * Zero  — ~0 W on the meter: the dead-stream DAX stall this reset targets.
+// By default ONLY the Zero state escalates to a reset (Config::resetOnLowPower
+// == false): resetting the DAX stream is the proven cure for the dead-stream
+// case, but there's no evidence it fixes a genuine low-power droop — so Low is
+// classified and surfaced (Decision::LowPowerObserved) but not acted on unless
+// the operator opts in once evidence justifies it.
+//
+// Design invariants (pinned by tests/dax_tx_watchdog_policy_test.cpp):
+//  * Zero-only reset — by default only true-zero cycles escalate; a low-but-
+//                      nonzero cycle reports LowPowerObserved and breaks the
+//                      zero streak (never silently treated as either good or a
+//                      dead stream).
+//  * RX-gap-only     — WouldReset is emitted only on the TX->RX falling edge,
+//                      never mid-transmit, so a reset can never interrupt a
+//                      live TX cycle.
+//  * Confirm K cycles — a single anomalous cycle never triggers; K consecutive
+//                      faulted TX cycles must be observed (debounce).
+//  * Staleness guard — a silent/stale power lane yields SuppressedStale and is
+//                      NEVER counted as a fault (no false FAULTED on missing
+//                      telemetry).
+//  * No reset storm  — after a reset the caller calls noteResetPerformed(); a
+//                      grace window then suppresses re-escalation while the
+//                      fresh stream settles.
+//
+// Header-only + std/qint64 only, matching the sibling *Policy classes
+// (TransmitInhibitPolicy, SliceRecreatePolicy) so it links with just Qt6::Core.
+
+#include <QtGlobal>  // qint64
+
+namespace AetherSDR::DaxTxWatchdogPolicy {
+
+// Classification of a single forward-power reading against the expected drive.
+enum class PowerClass {
+    Unknown,  // stale sample — cannot judge
+    Zero,     // <= zeroPowerCeilingW — dead-stream stall
+    Low,      // (zero, lowPowerCeilingW] — degraded but alive
+    Good,     // > lowPowerCeilingW — matches expected drive
+};
+
+// Emitted after each Observation.
+enum class Decision {
+    Idle,              // healthy, or not transmitting — nothing to do
+    Arming,            // consecutive ZERO cycles seen, but < K confirmations
+    WouldReset,        // K consecutive zero cycles confirmed → reset now (RX gap)
+    LowPowerObserved,  // cycle was low-but-nonzero — distinct state, no reset (default)
+    SuppressedStale,   // power lane stale/silent → cannot judge; never a fault
+};
+
+struct Config {
+    // Thresholds are absolute watts. The caller knows the RF-drive/slider
+    // setting, so it may set these relative to expected (e.g. lowPowerCeilingW
+    // = 0.4 * expectedW) before constructing the Watchdog.
+    double zeroPowerCeilingW{0.5};   // <= this during TX == Zero (meter effectively 0)
+    double lowPowerCeilingW{10.0};   // (zero, this] == Low (degraded, non-zero; ~0-10 W
+                                     // when set for ~50 W). Caller may scale to the slider.
+    bool   resetOnLowPower{false};   // default: ONLY the Zero state triggers a reset
+    int    confirmCycles{2};         // K: consecutive faulted TX cycles before WouldReset
+    qint64 powerStaleMs{3000};       // a sample older than this is stale (unjudgeable)
+    qint64 resetGraceMs{8000};       // suppress re-escalation for this long after a reset
+};
+
+// Classify a single forward-power reading (assumes the sample is fresh; the
+// staleness check lives in the Watchdog).
+inline PowerClass classifyPower(double fwdPowerW, const Config& cfg)
+{
+    if (fwdPowerW <= cfg.zeroPowerCeilingW)
+        return PowerClass::Zero;
+    if (fwdPowerW <= cfg.lowPowerCeilingW)
+        return PowerClass::Low;
+    return PowerClass::Good;
+}
+
+// One evaluation tick.
+struct Observation {
+    bool   transmitting{false};    // radio keyed / TX window open (WSJT-X or radio state)
+    double fwdPowerW{0.0};         // latest forward-power meter reading (W)
+    qint64 powerSampleAgeMs{0};    // age of that reading (for the staleness guard)
+    qint64 nowMs{0};              // monotonic clock (grace / windowing)
+};
+
+class Watchdog {
+public:
+    Watchdog() = default;
+    explicit Watchdog(const Config& cfg) : m_cfg(cfg) {}
+
+    // Feed one tick; returns the current decision. Pure — no side effects
+    // beyond the internal state machine.
+    Decision update(const Observation& o)
+    {
+        const bool txNow = o.transmitting;
+        const bool fresh = o.powerSampleAgeMs <= m_cfg.powerStaleMs;
+
+        // Rising edge: a new TX cycle begins — clear per-cycle accumulators.
+        if (txNow && !m_wasTransmitting) {
+            m_cycleSawFresh = false;
+            m_cycleSawGood  = false;
+            m_cycleSawZero  = false;
+        }
+
+        // During TX: accumulate this cycle's evidence. Never act here
+        // (RX-gap-only) — return only a tentative in-cycle hint.
+        if (txNow) {
+            if (fresh) {
+                m_cycleSawFresh = true;
+                switch (classifyPower(o.fwdPowerW, m_cfg)) {
+                case PowerClass::Good: m_cycleSawGood = true; break;
+                case PowerClass::Zero: m_cycleSawZero = true; break;
+                case PowerClass::Low:  break;  // captured, no accumulator flag
+                case PowerClass::Unknown: break;
+                }
+            }
+            m_wasTransmitting = true;
+
+            if (m_cycleSawGood)  return Decision::Idle;
+            if (!m_cycleSawFresh) return Decision::SuppressedStale;  // only stale so far
+            if (m_cycleSawZero)  return Decision::Arming;            // zero tentative
+            return Decision::LowPowerObserved;                       // low, no zero yet
+        }
+
+        // Falling edge: the TX cycle just ended — this IS the RX gap, so judge it.
+        if (m_wasTransmitting) {
+            m_wasTransmitting = false;
+            const bool sawFresh = m_cycleSawFresh;
+            const bool sawGood  = m_cycleSawGood;
+            const bool sawZero  = m_cycleSawZero;
+            m_cycleSawFresh = false;
+            m_cycleSawGood  = false;
+            m_cycleSawZero  = false;
+
+            if (!sawFresh) {               // never a fresh sample → cannot judge
+                m_lastCycleClass = PowerClass::Unknown;
+                return Decision::SuppressedStale;
+            }
+            if (sawGood) {                 // cycle produced healthy power → clear faults
+                m_lastCycleClass = PowerClass::Good;
+                m_faultedCycles = 0;
+                return Decision::Idle;
+            }
+            // No good power this cycle. A zero sample makes it a ZERO cycle
+            // (the dead-stream stall we reset for); otherwise it's a LOW cycle.
+            const bool zeroCycle = sawZero;
+            m_lastCycleClass = zeroCycle ? PowerClass::Zero : PowerClass::Low;
+
+            // A ZERO cycle always faults; a LOW cycle faults only if the operator
+            // opted in (default: capture-only — we don't know a reset cures a real
+            // low-power droop, only the dead-stream case). A LOW cycle also breaks
+            // the consecutive-zero streak, so only *sustained* zero escalates.
+            const bool faulting = zeroCycle || m_cfg.resetOnLowPower;
+            if (!faulting) {
+                m_faultedCycles = 0;
+                return Decision::LowPowerObserved;  // distinct state, logged, no action
+            }
+
+            // Suppress escalation while the post-reset grace window is open so a
+            // just-reset stream that hasn't settled can't trigger a reset storm.
+            if (m_lastResetMs >= 0 && (o.nowMs - m_lastResetMs) < m_cfg.resetGraceMs) {
+                m_faultedCycles = 0;
+                return Decision::Idle;
+            }
+            ++m_faultedCycles;
+            if (m_faultedCycles >= m_cfg.confirmCycles)
+                return Decision::WouldReset;
+            return Decision::Arming;
+        }
+
+        // Steady RX, not transmitting — nothing to judge.
+        return Decision::Idle;
+    }
+
+    // The caller tells us a reset actually fired (opens the grace window and
+    // clears the fault count so we re-observe the fresh stream from scratch).
+    void noteResetPerformed(qint64 nowMs)
+    {
+        m_lastResetMs = nowMs;
+        m_faultedCycles = 0;
+    }
+
+    int        faultedCycles() const { return m_faultedCycles; }
+    bool       transmitting()  const { return m_wasTransmitting; }
+    PowerClass lastCycleClass() const { return m_lastCycleClass; }
+
+    // Full state clear (e.g. radio disconnect / session change).
+    void reset()
+    {
+        m_wasTransmitting = false;
+        m_cycleSawFresh = false;
+        m_cycleSawGood  = false;
+        m_cycleSawZero  = false;
+        m_faultedCycles = 0;
+        m_lastResetMs = -1;
+        m_lastCycleClass = PowerClass::Unknown;
+    }
+
+private:
+    Config m_cfg{};
+    bool   m_wasTransmitting{false};
+    bool   m_cycleSawFresh{false};  // any fresh sample this cycle?
+    bool   m_cycleSawGood{false};   // any fresh Good sample this cycle?
+    bool   m_cycleSawZero{false};   // any fresh Zero sample this cycle?
+    int    m_faultedCycles{0};      // consecutive confirmed-ZERO cycles
+    qint64 m_lastResetMs{-1};       // when noteResetPerformed() last fired
+    PowerClass m_lastCycleClass{PowerClass::Unknown};  // last judged cycle (for logs)
+};
+
+} // namespace AetherSDR::DaxTxWatchdogPolicy

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3152,6 +3152,11 @@ void RadioModel::onDisconnected()
     m_daxTxActive = false;
     m_daxTxClientHandle = 0;
     m_daxTxCreatePending = false;
+    // A reset in flight when the link dropped will never get its remove-ack
+    // (pending callbacks are not invoked on disconnect), so clear the guard
+    // here too — otherwise resetDaxTxStream() would no-op forever after
+    // reconnect. Mirrors the m_daxTxCreatePending cleanup above. (F1)
+    m_daxTxResetPending = false;
     m_deadDaxRxSeen.clear();
     m_externalDaxTxSeen.clear();
     m_externalDaxRxSeen.clear();
@@ -6426,6 +6431,14 @@ void RadioModel::resetDaxTxStream(DaxTxRequestReason reason)
     if (!isConnected())
         return;
 
+    // A reset already in flight owns the teardown/recreate sequence; a second
+    // call must not race a create ahead of the pending remove. Guard BEFORE the
+    // id==0 fast-path, because step (2) below has already zeroed m_daxTxStreamId
+    // for the in-flight reset — without this, a re-entrant call would fall into
+    // the id==0 branch and issue an out-of-order ensure. (F2)
+    if (m_daxTxResetPending)
+        return;
+
     const quint32 id = m_daxTxStreamId;
 
     // Nothing to tear down — just (re)create. Covers the case where the radio
@@ -6438,8 +6451,6 @@ void RadioModel::resetDaxTxStream(DaxTxRequestReason reason)
         ensureDaxTxStream(reason);
         return;
     }
-    if (m_daxTxResetPending)
-        return;
     m_daxTxResetPending = true;
 
     qCInfo(lcDax).noquote()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4529,6 +4529,10 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
                 m_daxTxActive = false;
                 m_daxTxClientHandle = 0;
                 m_daxTxCreatePending = false;
+                // Keep the emission-side id coherent: AudioEngine::m_txStreamId
+                // is otherwise only ever set, never cleared, so a radio-side
+                // removal would leave it stamping a dead id (the H5 desync).
+                emit txAudioStreamInvalidated();
             }
             m_deadDaxRxSeen.remove(stream.streamId);
             m_externalDaxTxSeen.remove(stream.streamId);
@@ -4657,6 +4661,8 @@ void RadioModel::traceDaxStreamStatus(const QString& object,
             m_daxTxActive = false;
             m_daxTxClientHandle = 0;
             m_daxTxCreatePending = false;
+            // Keep AudioEngine::m_txStreamId coherent on radio-side removal.
+            emit txAudioStreamInvalidated();
         }
         m_daxStreamDebug.remove(txAudioStream.streamId);
         m_externalDaxTxSeen.remove(txAudioStream.streamId);
@@ -6413,6 +6419,60 @@ bool RadioModel::ensureDaxTxStream(DaxTxRequestReason reason)
             emit txAudioStreamReady(id);
         });
     return true;
+}
+
+void RadioModel::resetDaxTxStream(DaxTxRequestReason reason)
+{
+    if (!isConnected())
+        return;
+
+    const quint32 id = m_daxTxStreamId;
+
+    // Nothing to tear down — just (re)create. Covers the case where the radio
+    // already removed the stream and zeroed our id (ensureDaxTxStream is then
+    // a real create, not a no-op).
+    if (id == 0) {
+        qCInfo(lcDax).noquote()
+            << "RadioModel: DAX TX reset — no live stream, ensuring instead"
+            << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
+        ensureDaxTxStream(reason);
+        return;
+    }
+    if (m_daxTxResetPending)
+        return;
+    m_daxTxResetPending = true;
+
+    qCInfo(lcDax).noquote()
+        << "RadioModel: DAX TX reset"
+        << QStringLiteral("stream=%1").arg(hexId(id))
+        << QStringLiteral("reason=%1").arg(daxTxRequestReasonName(reason));
+
+    // (1) Stop emission immediately: zero AudioEngine's emission id so no VITA
+    //     packet stamps the dead id. (Intended to run in the RX gap, where no
+    //     TX audio is flowing — but this also closes the general desync window.)
+    emit txAudioStreamInvalidated();
+
+    // (2) Invalidate local ownership so ensureDaxTxStream() won't early-return.
+    m_daxTxStreamId = 0;
+    m_daxTxActive = false;
+    m_daxTxClientHandle = 0;
+    m_daxTxCreatePending = false;
+
+    // (3) Drop the stream on the radio, then recreate on the ack (ack-sequenced,
+    //     so we never briefly hold two dax_tx streams). A late "removed" status
+    //     for the OLD id is harmless: the removal sites guard on
+    //     `streamId == m_daxTxStreamId`, which is the NEW id by then.
+    sendCmd(QString("stream remove 0x%1").arg(id, 0, 16),
+        [this, reason](int code, const QString& body) {
+            m_daxTxResetPending = false;
+            if (code != 0) {
+                qCWarning(lcDax).noquote()
+                    << "RadioModel: DAX TX reset — remove reported error (recreating anyway)"
+                    << QStringLiteral("code=%1").arg(hexCode(code))
+                    << QStringLiteral("body=%1").arg(body);
+            }
+            ensureDaxTxStream(reason);  // fresh create → txAudioStreamReady(newId)
+        });
 }
 
 QJsonObject RadioModel::troubleshootingSnapshot() const

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -259,6 +259,12 @@ public:
     void resetPanState();
     void createAudioStream();
     bool ensureDaxTxStream(DaxTxRequestReason reason);
+    // Tear down the current DAX-TX stream and recreate it (the software
+    // equivalent of "restart WSJT-X / toggle the audio source"): drops the
+    // stream on the radio, invalidates BOTH id caches (ownership here +
+    // AudioEngine's emission id, via txAudioStreamInvalidated), then re-runs
+    // ensureDaxTxStream() on the remove-ack. Call only in the RX gap.
+    void resetDaxTxStream(DaxTxRequestReason reason = DaxTxRequestReason::TciTxAudio);
     QJsonObject troubleshootingSnapshot() const;
 
     // Memory channel cache
@@ -515,6 +521,10 @@ signals:
     void networkQualityChanged(const QString& quality, int pingMs);
     // Emitted when the radio assigns a TX audio stream ID (DAX TX).
     void txAudioStreamReady(quint32 streamId);
+    // Emitted when the DAX-TX stream is torn down (reset, or radio-side
+    // removal) so the emission-side id (AudioEngine::m_txStreamId) is zeroed
+    // and no VITA packet stamps a stale/dead stream id.
+    void txAudioStreamInvalidated();
     // Emitted when the radio assigns a remote audio TX stream ID (voice/VOX).
     void remoteTxStreamReady(quint32 streamId);
     // Audio TX gate for sample pipeline (separate from optimistic MOX UI state).
@@ -967,6 +977,7 @@ private:
     bool        m_daxTxActive{false};
     quint32     m_daxTxClientHandle{0};  // Tracked for diagnostics only — not consulted in routing.
     bool        m_daxTxCreatePending{false};
+    bool        m_daxTxResetPending{false};   // guards resetDaxTxStream() re-entry
     QSet<quint32> m_deadDaxRxSeen;
     QSet<quint32> m_externalDaxTxSeen;
     QSet<quint32> m_externalDaxRxSeen;

--- a/src/models/TxDaxWatchdog.cpp
+++ b/src/models/TxDaxWatchdog.cpp
@@ -146,6 +146,16 @@ void TxDaxWatchdog::tick(bool transmitting)
     }
 
     if (decision == Decision::WouldReset) {
+        // The policy only ever emits WouldReset on the TX->RX falling edge, so
+        // this is already the RX gap. Re-check isRadioTransmitting() anyway as
+        // defense-in-depth — the same F3 guard the bridge verb enforces — so a
+        // reset can never zero the emission id mid-transmit even if some future
+        // signal ordering surprised us.
+        if (m_radio.isRadioTransmitting()) {
+            qCWarning(lcTxDaxWatchdog)
+                << "WouldReset while still transmitting — deferring (RX-gap-only guard)";
+            return;
+        }
         qCInfo(lcTxDaxWatchdog).noquote()
             << "confirmed zero-power DAX-TX stall over" << m_policy.faultedCycles()
             << "cycles — firing resetDaxTxStream() in the RX gap";

--- a/src/models/TxDaxWatchdog.cpp
+++ b/src/models/TxDaxWatchdog.cpp
@@ -1,0 +1,158 @@
+#include "TxDaxWatchdog.h"
+
+#include <QDateTime>
+#include <QLoggingCategory>
+
+#include "RadioModel.h"
+
+// Own category so the watchdog is silent unless explicitly enabled in logging
+// rules; default warning-level keeps it quiet in normal runs.
+Q_LOGGING_CATEGORY(lcTxDaxWatchdog, "aether.txdaxwatchdog")
+
+namespace AetherSDR {
+
+using DaxTxWatchdogPolicy::Decision;
+using DaxTxWatchdogPolicy::Observation;
+
+namespace {
+const char* decisionName(Decision d)
+{
+    switch (d) {
+    case Decision::Idle:             return "Idle";
+    case Decision::Arming:           return "Arming";
+    case Decision::WouldReset:       return "WouldReset";
+    case Decision::LowPowerObserved: return "LowPowerObserved";
+    case Decision::SuppressedStale:  return "SuppressedStale";
+    }
+    return "?";
+}
+} // namespace
+
+TxDaxWatchdog::TxDaxWatchdog(RadioModel& radio, QObject* parent)
+    : QObject(parent)
+    , m_radio(radio)
+{
+    m_enabled = enabledByEnv();
+
+    // TX/RX cycle edges (rising clears per-cycle accumulators; falling judges).
+    connect(&m_radio, &RadioModel::radioTransmittingChanged,
+            this, &TxDaxWatchdog::onTransmittingChanged);
+    // Forward-power samples arrive here repeatedly during a transmit.
+    connect(&m_radio.meterModel(), &MeterModel::txMetersChanged,
+            this, &TxDaxWatchdog::onTxMeters);
+    // Clear all state on a disconnect so a reconnect starts fresh.
+    connect(&m_radio, &RadioModel::connectionStateChanged,
+            this, &TxDaxWatchdog::onConnectionChanged);
+
+    if (m_enabled) {
+        qCInfo(lcTxDaxWatchdog).noquote()
+            << "TX-DAX watchdog ENABLED (opt-in) — zero-power auto-reset armed on the DAX path;"
+            << QStringLiteral("K=%1 zeroCeil=%2W lowCeil=%3W staleMs=%4 graceMs=%5 resetOnLow=%6")
+                   .arg(m_cfg.confirmCycles)
+                   .arg(m_cfg.zeroPowerCeilingW)
+                   .arg(m_cfg.lowPowerCeilingW)
+                   .arg(m_cfg.powerStaleMs)
+                   .arg(m_cfg.resetGraceMs)
+                   .arg(m_cfg.resetOnLowPower ? "true" : "false");
+    }
+}
+
+bool TxDaxWatchdog::enabledByEnv()
+{
+    const QByteArray v = qgetenv("AETHER_TX_DAX_WATCHDOG").trimmed().toLower();
+    return v == "1" || v == "true" || v == "on" || v == "yes";
+}
+
+void TxDaxWatchdog::setEnabled(bool on)
+{
+    if (m_enabled == on)
+        return;
+    m_enabled = on;
+    m_policy.reset();
+    m_lastLogged = Decision::Idle;
+    qCInfo(lcTxDaxWatchdog) << "TX-DAX watchdog" << (on ? "enabled" : "disabled");
+}
+
+bool TxDaxWatchdog::armed() const
+{
+    // Zero-only DAX-stall recovery: only meaningful on a connected radio, on the
+    // DAX/digital TX path (never SSB/voice). resetDaxTxStream() re-checks
+    // connection + re-entrancy itself, but gating here avoids pointless churn.
+    return m_enabled
+        && m_radio.isConnected()
+        && m_radio.transmitModel().daxOn();
+}
+
+void TxDaxWatchdog::onTransmittingChanged(bool transmitting)
+{
+    tick(transmitting);
+}
+
+void TxDaxWatchdog::onTxMeters(float /*fwdPower*/, float /*swr*/)
+{
+    // Only judge in-cycle samples while the radio is actually keyed; a stray
+    // meter update in the RX gap must not masquerade as a TX sample. The
+    // falling-edge judgment is driven by onTransmittingChanged(false).
+    if (!m_radio.isRadioTransmitting())
+        return;
+    tick(true);
+}
+
+void TxDaxWatchdog::onConnectionChanged(bool connected)
+{
+    if (!connected) {
+        m_policy.reset();
+        m_lastLogged = Decision::Idle;
+    }
+}
+
+void TxDaxWatchdog::tick(bool transmitting)
+{
+    if (!armed()) {
+        // Disarmed (off, disconnected, or off the DAX path) — keep no stale
+        // cycle state so re-arming starts clean.
+        m_policy.reset();
+        m_lastLogged = Decision::Idle;
+        return;
+    }
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    MeterModel& meters = m_radio.meterModel();
+    const qint64 updatedAt = meters.fwdPowerUpdatedAtMs();
+
+    Observation o;
+    o.transmitting     = transmitting;
+    o.fwdPowerW        = static_cast<double>(meters.fwdPower());
+    // Age from the same epoch clock MeterModel stamps with; if never updated,
+    // force "stale" so the policy's guard suppresses (never a false fault).
+    o.powerSampleAgeMs = (updatedAt > 0) ? (now - updatedAt) : (m_cfg.powerStaleMs + 1);
+    o.nowMs            = now;
+
+    const Decision decision = m_policy.update(o);
+
+    // Log only on a change of decision class, so per-tick TX meter updates
+    // don't flood the log. WouldReset/reset is always worth an INFO line.
+    if (decision != m_lastLogged) {
+        m_lastLogged = decision;
+        if (decision == Decision::Arming || decision == Decision::LowPowerObserved
+            || decision == Decision::SuppressedStale) {
+            qCInfo(lcTxDaxWatchdog).noquote()
+                << "state ->" << decisionName(decision)
+                << QStringLiteral("(fwd=%1W age=%2ms faulted=%3)")
+                       .arg(o.fwdPowerW, 0, 'f', 2)
+                       .arg(o.powerSampleAgeMs)
+                       .arg(m_policy.faultedCycles());
+        }
+    }
+
+    if (decision == Decision::WouldReset) {
+        qCInfo(lcTxDaxWatchdog).noquote()
+            << "confirmed zero-power DAX-TX stall over" << m_policy.faultedCycles()
+            << "cycles — firing resetDaxTxStream() in the RX gap";
+        m_radio.resetDaxTxStream();
+        m_policy.noteResetPerformed(now);
+        m_lastLogged = Decision::Idle;  // fresh stream — re-observe from scratch
+    }
+}
+
+} // namespace AetherSDR

--- a/src/models/TxDaxWatchdog.h
+++ b/src/models/TxDaxWatchdog.h
@@ -1,0 +1,70 @@
+#pragma once
+
+// TxDaxWatchdog — the 2b live wiring around the pure DaxTxWatchdogPolicy.
+//
+// Drives the (already-unit-tested) DaxTxWatchdogPolicy state machine from live
+// radio signals and, on a confirmed zero-power DAX-TX stall, auto-fires
+// RadioModel::resetDaxTxStream() — the exact recovery proven manually on-air
+// via the 2c `txstream reset` bridge verb (0 W -> ~33 W, 2026-07-09).
+//
+// Safety (matches AETHERSDR-TX-DAX-RESET-IMPL-PLAN.md §5, CLAUDE.md ethos):
+//   * OFF by default — arm only via env AETHER_TX_DAX_WATCHDOG=1 (or setEnabled).
+//     Auto-actions on the TX path are strictly opt-in.
+//   * DAX-digital path only — armed only while TransmitModel::daxOn() (never an
+//     SSB/voice QSO) and while the radio is connected.
+//   * RX-gap only — the policy emits WouldReset solely on the TX->RX falling
+//     edge, so a reset can never chop a live transmit.
+//   * Zero-only — by default only true-zero cycles escalate; the low-power
+//     sub-state is logged (LowPowerObserved) but not acted on. On-air 07-09
+//     confirmed the reset is a no-op on low-power, so acting on it is pointless.
+//   * Re-entrancy / not-connected are additionally guarded inside
+//     resetDaxTxStream() itself (m_daxTxResetPending, isConnected()).
+//
+// Lives in src/models/ (depends on RadioModel/MeterModel/TransmitModel — all
+// models); owned by MainWindow, parented for lifetime.
+
+#include <QObject>
+
+#include "DaxTxWatchdogPolicy.h"
+
+namespace AetherSDR {
+
+class RadioModel;
+
+class TxDaxWatchdog : public QObject {
+    Q_OBJECT
+public:
+    explicit TxDaxWatchdog(RadioModel& radio, QObject* parent = nullptr);
+
+    bool enabled() const { return m_enabled; }
+    void setEnabled(bool on);
+
+    // True if AETHER_TX_DAX_WATCHDOG is set to a truthy value (1/true/on/yes).
+    static bool enabledByEnv();
+
+    // Expose the tunables so a future settings surface / test can adjust them.
+    const DaxTxWatchdogPolicy::Config& config() const { return m_cfg; }
+    void setConfig(const DaxTxWatchdogPolicy::Config& cfg) { m_cfg = cfg; }
+
+private slots:
+    void onTransmittingChanged(bool transmitting);
+    void onTxMeters(float fwdPower, float swr);
+    void onConnectionChanged(bool connected);
+
+private:
+    // Feed one Observation reflecting `transmitting` + the latest meter sample;
+    // act on WouldReset. No-op (and clears policy state) while disarmed.
+    void tick(bool transmitting);
+
+    // All must hold to arm: enabled AND connected AND on the DAX/digital TX path.
+    bool armed() const;
+
+    RadioModel&                    m_radio;
+    DaxTxWatchdogPolicy::Config    m_cfg{};
+    DaxTxWatchdogPolicy::Watchdog  m_policy{m_cfg};
+    bool                           m_enabled{false};
+    // Last decision we logged, so per-tick meter updates during TX don't spam.
+    DaxTxWatchdogPolicy::Decision  m_lastLogged{DaxTxWatchdogPolicy::Decision::Idle};
+};
+
+} // namespace AetherSDR

--- a/tests/dax_tx_watchdog_policy_test.cpp
+++ b/tests/dax_tx_watchdog_policy_test.cpp
@@ -1,0 +1,215 @@
+// Unit tests for DaxTxWatchdogPolicy (2b DAX-TX watchdog decision core).
+//
+// Pins the state machine that decides WHEN a DAX-TX stream reset should fire on
+// the TX low-power/DAX-stall fault. Pure logic, no radio: we synthesize TX/RX
+// cycles and assert the emitted Decision.
+//
+// Three power states at a fixed ~50 W drive:
+//   Good (>10 W) — matches slider; Low (0-10 W) — degraded but alive;
+//   Zero (<=0.5 W) — dead-stream stall. ONLY Zero escalates to a reset by
+//   default; Low is captured (LowPowerObserved) but not acted on.
+//
+// Guards: zero-only reset, low captured-not-acted, RX-gap-only, confirm-K
+// debounce, staleness guard (never a false fault), no reset storm (grace).
+
+#include "models/DaxTxWatchdogPolicy.h"
+
+#include <iostream>
+
+using namespace AetherSDR;
+using namespace AetherSDR::DaxTxWatchdogPolicy;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+// Drive one complete TX cycle (rising edge -> `txTicks` transmit ticks -> the
+// falling edge) followed by a quiet RX tick, and return the decision emitted at
+// the FALLING EDGE (where a real reset would fire). `powerW` is the forward
+// power reported for the whole cycle; `ageMs` its sample age; `t` a mutable
+// clock advanced one ms per tick.
+Decision runCycle(Watchdog& wd, double powerW, qint64 ageMs, qint64& t,
+                  int txTicks = 3)
+{
+    for (int i = 0; i < txTicks; ++i)
+        wd.update({.transmitting = true, .fwdPowerW = powerW,
+                   .powerSampleAgeMs = ageMs, .nowMs = t++});
+    const Decision d = wd.update({.transmitting = false, .fwdPowerW = powerW,
+                                  .powerSampleAgeMs = ageMs, .nowMs = t++});
+    wd.update({.transmitting = false, .powerSampleAgeMs = ageMs, .nowMs = t++});
+    return d;
+}
+
+constexpr double kGood = 50.0;  // healthy forward power (W)
+constexpr double kLow  = 8.0;   // low-but-nonzero (~0-10 W) — degraded, alive
+constexpr double kZero = 0.0;   // ~0 W — dead-stream stall
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    // 0. classifyPower boundaries.
+    {
+        Config c;  // zeroCeil 0.5, lowCeil 10
+        ok &= expect(classifyPower(0.0, c)  == PowerClass::Zero
+                         && classifyPower(0.5, c) == PowerClass::Zero
+                         && classifyPower(1.0, c) == PowerClass::Low
+                         && classifyPower(10.0, c) == PowerClass::Low
+                         && classifyPower(50.0, c) == PowerClass::Good,
+                     "classifyPower splits zero / low / good at the ceilings");
+    }
+
+    // 1. Steady good power across many cycles — never escalates.
+    {
+        Watchdog wd;
+        qint64 t = 0;
+        bool anyReset = false;
+        for (int c = 0; c < 10; ++c)
+            anyReset |= (runCycle(wd, kGood, 0, t) == Decision::WouldReset);
+        ok &= expect(!anyReset && wd.faultedCycles() == 0,
+                     "steady good power never triggers a reset");
+    }
+
+    // 2. K consecutive ZERO cycles — WouldReset on exactly the Kth falling edge.
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        const Decision c1 = runCycle(wd, kZero, 0, t);
+        const Decision c2 = runCycle(wd, kZero, 0, t);
+        ok &= expect(c1 == Decision::Arming && c2 == Decision::WouldReset,
+                     "K=2 zero cycles: arm then reset on the 2nd");
+    }
+
+    // 3. LOW power is captured, never reset (default resetOnLowPower=false) —
+    //    even sustained across many cycles.
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        bool anyReset = false;
+        Decision last = Decision::Idle;
+        for (int c = 0; c < 6; ++c) {
+            last = runCycle(wd, kLow, 0, t);
+            anyReset |= (last == Decision::WouldReset);
+        }
+        ok &= expect(!anyReset && last == Decision::LowPowerObserved
+                         && wd.faultedCycles() == 0
+                         && wd.lastCycleClass() == PowerClass::Low,
+                     "low power is captured (LowPowerObserved), never reset");
+    }
+
+    // 3b. LOW cycle breaks the consecutive-ZERO streak (only sustained zero escalates).
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        const Decision z1  = runCycle(wd, kZero, 0, t);  // arm (zero 1/2)
+        const Decision low = runCycle(wd, kLow,  0, t);  // breaks streak -> low
+        const Decision z2  = runCycle(wd, kZero, 0, t);  // arm again (1/2), NOT reset
+        ok &= expect(z1 == Decision::Arming && low == Decision::LowPowerObserved
+                         && z2 == Decision::Arming && wd.faultedCycles() == 1,
+                     "a low cycle breaks the zero streak (zero must be sustained)");
+    }
+
+    // 4. Opt-in: with resetOnLowPower, K low cycles DO escalate.
+    {
+        Watchdog wd(Config{.resetOnLowPower = true, .confirmCycles = 2});
+        qint64 t = 0;
+        const Decision c1 = runCycle(wd, kLow, 0, t);
+        const Decision c2 = runCycle(wd, kLow, 0, t);
+        ok &= expect(c1 == Decision::Arming && c2 == Decision::WouldReset,
+                     "resetOnLowPower opt-in escalates sustained low power");
+    }
+
+    // 5. Staleness guard — only-stale lane is never a fault, ever.
+    {
+        Watchdog wd(Config{.confirmCycles = 2, .powerStaleMs = 3000});
+        qint64 t = 0;
+        bool anyReset = false;
+        for (int c = 0; c < 6; ++c)  // zero power BUT every sample stale (10 s old)
+            anyReset |= (runCycle(wd, kZero, /*ageMs=*/10000, t) == Decision::WouldReset);
+        ok &= expect(!anyReset && wd.faultedCycles() == 0,
+                     "stale power lane never counts as a fault");
+    }
+
+    // 5b. Stale mid-TX reports SuppressedStale.
+    {
+        Watchdog wd;
+        const Decision mid = wd.update({.transmitting = true, .fwdPowerW = kZero,
+                                        .powerSampleAgeMs = 10000, .nowMs = 0});
+        ok &= expect(mid == Decision::SuppressedStale,
+                     "stale samples mid-TX report SuppressedStale");
+    }
+
+    // 6. RX-gap-only — WouldReset never emitted while transmitting, even after
+    //    many zero-power ticks within one long TX cycle.
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        bool resetMidTx = false;
+        for (int i = 0; i < 20; ++i) {
+            const Decision d = wd.update({.transmitting = true, .fwdPowerW = kZero,
+                                          .powerSampleAgeMs = 0, .nowMs = t++});
+            resetMidTx |= (d == Decision::WouldReset);
+        }
+        ok &= expect(!resetMidTx, "never resets mid-TX (RX-gap-only)");
+    }
+
+    // 7. Debounce + recovery — a lone zero cycle only arms; a good cycle clears
+    //    the count, so the next lone zero cycle arms again (not reset).
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        const Decision f1   = runCycle(wd, kZero, 0, t);  // arm (1/2)
+        const Decision good = runCycle(wd, kGood, 0, t);  // recover -> clear
+        const Decision f2   = runCycle(wd, kZero, 0, t);  // arm again (1/2), NOT reset
+        ok &= expect(f1 == Decision::Arming && good == Decision::Idle
+                         && f2 == Decision::Arming && wd.faultedCycles() == 1,
+                     "a good cycle resets the zero-fault count (debounce)");
+    }
+
+    // 8. No reset storm — after WouldReset + noteResetPerformed, zero cycles in
+    //    the grace window are suppressed; escalation resumes after grace.
+    {
+        Watchdog wd(Config{.confirmCycles = 2, .resetGraceMs = 8000});
+        qint64 t = 0;
+        runCycle(wd, kZero, 0, t);                          // arm
+        const Decision r = runCycle(wd, kZero, 0, t);       // WouldReset
+        wd.noteResetPerformed(t);                           // caller fired the reset
+        const Decision inGrace = runCycle(wd, kZero, 0, t); // still zero, within grace
+        t += 9000;                                          // let grace expire
+        runCycle(wd, kZero, 0, t);                          // arm (1/2) again
+        const Decision afterGrace = runCycle(wd, kZero, 0, t); // reset again (2/2)
+        ok &= expect(r == Decision::WouldReset && inGrace == Decision::Idle
+                         && afterGrace == Decision::WouldReset,
+                     "post-reset grace suppresses a reset storm, then resumes");
+    }
+
+    // 9. Brief mid-cycle dip that recovers within the same TX is not a fault.
+    {
+        Watchdog wd(Config{.confirmCycles = 1});  // even the strictest K
+        qint64 t = 0;
+        wd.update({.transmitting = true, .fwdPowerW = kZero, .powerSampleAgeMs = 0, .nowMs = t++});
+        wd.update({.transmitting = true, .fwdPowerW = kGood, .powerSampleAgeMs = 0, .nowMs = t++});
+        const Decision fall = wd.update({.transmitting = false, .powerSampleAgeMs = 0, .nowMs = t++});
+        ok &= expect(fall == Decision::Idle,
+                     "a cycle that recovers to good power is healthy, not faulted");
+    }
+
+    // 10. reset() clears all accumulated state.
+    {
+        Watchdog wd(Config{.confirmCycles = 2});
+        qint64 t = 0;
+        runCycle(wd, kZero, 0, t);          // arm (faultedCycles == 1)
+        wd.reset();
+        ok &= expect(wd.faultedCycles() == 0 && !wd.transmitting()
+                         && wd.lastCycleClass() == PowerClass::Unknown,
+                     "reset() clears fault count, TX state, and last class");
+    }
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4152.

An **opt-in** recovery path for the DAX-TX **dead-stream** fault: during digital TX the measured forward
power collapses to ~0 W at fixed drive while the radio keeps keying, until the `dax_tx` stream is
re-established. This is the **"layer 2" backstop** from the #4152 discussion — the opt-in watchdog, which
complements the root-cause fix **aethersdr-agent** proposed there (re-asserting the stream's `tx=1` flag).
It triggers on the **symptom** (zero forward power) rather than any specific cause. Three pieces, layered:

- **2a — `RadioModel::resetDaxTxStream()`** + an **id-cache coherence fix.** The reset does a clean
  `stream remove 0x… → stream create type=dax_tx`. The coherence fix zeroes the emission-side id
  (`AudioEngine::m_txStreamId`) on teardown via a new `txAudioStreamInvalidated()` signal, so no VITA
  packet stamps a stale/dead stream id (a latent desync between `RadioModel::m_daxTxStreamId` and the
  AudioEngine copy).
- **2c — `txstream reset` automation-bridge verb.** Manual trigger for the primitive; RX-gap guarded.
- **2b — `TxDaxWatchdog` (opt-in native watchdog).** Wraps a pure, unit-tested `DaxTxWatchdogPolicy`;
  subscribes to `radioTransmittingChanged` + `MeterModel` forward power/staleness; after **K=2 confirmed
  zero-power TX cycles** it fires `resetDaxTxStream()` **in the RX gap**.

**Safety (all enforced):** OFF by default (env `AETHER_TX_DAX_WATCHDOG=1`); DAX-digital path only
(`transmitModel().daxOn()`), never SSB/voice; **RX-gap only** (reset on the TX→RX falling edge, never
mid-transmit); **zero-only** (low-power is logged, not acted on); post-reset grace prevents a reset
storm; a stale meter is suppressed (never a false fault); re-entrancy + not-connected guarded inside
`resetDaxTxStream()`.

**Scope — what this does NOT claim:** this is the zero-power backstop, not the root-cause fix (layer 1
in #4152). Two caveats from on-air testing: (1) after an abrupt **WSJT-X "Halt Tx"**, some cycles did
not recover from a bare stream reset — consistent with the `tx=`-arbitration mechanism aethersdr-agent
identified; (2) a separate **low-but-nonzero droop (~2–12 W)** also occurs and does not respond to a
stream reset — a different phenomenon, deliberately not acted on (zero-only).

## Constitution principle honored

- **Principle VI — AetherSDR Never Transmits Without Operator Intent.** The watchdog touches the TX path
  but never initiates a transmission: it is opt-in/off by default, acts **only in the RX gap** (never
  mid-transmit), and merely re-establishes the DAX-TX stream — it never keys/PTTs the radio. It fails
  closed (stale meter → no action; not connected / re-entrant → guarded).
- **Principle VIII — Evidence Over Assertion.** Behavior is shown, not asserted — on-air recovery
  (0 → 36 W hands-free, wire-captured stream remove/create) plus a unit-tested decision core.

## Test plan

- [x] Local build passes (clean `rm -rf build && cmake … && ninja`; About SHA `0fdbcdec` == HEAD)
- [x] Behavior verified on a real radio (FLEX-8400, 30 m FT8): manual reset + hands-free auto-recovery
- [x] Existing tests pass (`ctest`); `DaxTxWatchdogPolicy` unit test green
- [x] Reproduction / evidence documented (#4152)

## Evidence (on-air, FLEX-8400, 30 m FT8, build `0fdbcdec`)

- **Manual (2a/2c):** at a real dead-stream (0 W across 3 cycles), one `txstream reset` in the RX gap →
  power returned to ~33 W next cycle; transparent when fired in a healthy state.
- **Automatic (2b):** watchdog auto-fired after 2 confirmed zero cycles → power recovered **0 → 36 W
  hands-free**, with the full `stream remove 0x… → stream create → radio ack tx=1` captured on the wire.
  Healthy cycles never escalated (no false fires).
- **Unit:** `DaxTxWatchdogPolicy` pure decision core (zero-only, K-debounce, RX-gap-only, staleness
  guard, no reset storm). Adapter is socket-wired to `RadioModel` (not unit-testable in isolation,
  consistent with the suite) → validated by code-review + on-air.

## Checklist

- [x] Commits are signed (SSH / ED25519)
- [x] No new flat-key `AppSettings` calls — opt-in via env var only (Principle V — N/A, no config object)
- [x] Code is clean-room — not decompiled/disassembled/reverse-engineered (Principle IV)
- [x] Meter UI uses `MeterSmoother` — N/A (no meter UI; reads `MeterModel` signals)
- [x] Documentation updated if user-visible behavior changed — N/A (off by default, no default change)
- [x] Security-sensitive changes reference a GHSA — N/A

## Notes for reviewers

Opening as a **draft / proof-of-concept** to start review and discussion. The layering is deliberate:
**2a** + **2c** are a self-contained bug-fix/tooling change; **2b** is the opt-in watchdog on top. Happy
to **split 2a/2c from 2b** into separate PRs if easier to review, or to adjust defaults / thresholds /
gating however the team prefers.

## Commits
- 2a `resetDaxTxStream()` + `txAudioStreamInvalidated` coherence fix
- 2c `txstream reset` bridge verb
- 2b `DaxTxWatchdogPolicy` (pure core + unit test) and `TxDaxWatchdog` (opt-in wiring) + review hardening

Refs #4085, #3805, #752

73, Jeff (KM6LFY)
