### PR TITLE
build(deps): bump ws 8.20.1 → 8.21.0 in elgato plugin (CVE-2026-48779)

### DIFF
--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/.package-lock.json
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/.package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "packages": {
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/receiver.js
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/receiver.js
@@ -40,6 +40,10 @@ class Receiver extends Writable {
    *     extensions
    * @param {Boolean} [options.isServer=false] Specifies whether to operate in
    *     client or server mode
+   * @param {Number} [options.maxBufferedChunks=0] The maximum number of
+   *     buffered data chunks
+   * @param {Number} [options.maxFragments=0] The maximum number of message
+   *     fragments
    * @param {Number} [options.maxPayload=0] The maximum allowed message length
    * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
    *     not to skip UTF-8 validation for text and close messages
@@ -54,6 +58,8 @@ class Receiver extends Writable {
     this._binaryType = options.binaryType || BINARY_TYPES[0];
     this._extensions = options.extensions || {};
     this._isServer = !!options.isServer;
+    this._maxBufferedChunks = options.maxBufferedChunks | 0;
+    this._maxFragments = options.maxFragments | 0;
     this._maxPayload = options.maxPayload | 0;
     this._skipUTF8Validation = !!options.skipUTF8Validation;
     this[kWebSocket] = undefined;
@@ -88,6 +94,22 @@ class Receiver extends Writable {
    */
   _write(chunk, encoding, cb) {
     if (this._opcode === 0x08 && this._state == GET_INFO) return cb();
+
+    if (
+      this._maxBufferedChunks > 0 &&
+      this._buffers.length >= this._maxBufferedChunks
+    ) {
+      cb(
+        this.createError(
+          RangeError,
+          'Too many buffered chunks',
+          false,
+          1008,
+          'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+        )
+      );
+      return;
+    }
 
     this._bufferedBytes += chunk.length;
     this._buffers.push(chunk);
@@ -485,6 +507,22 @@ class Receiver extends Writable {
     }
 
     if (data.length) {
+      if (
+        this._maxFragments > 0 &&
+        this._fragments.length >= this._maxFragments
+      ) {
+        const error = this.createError(
+          RangeError,
+          'Too many message fragments',
+          false,
+          1008,
+          'WS_ERR_TOO_MANY_BUFFERED_PARTS'
+        );
+
+        cb(error);
+        return;
+      }
+
       //
       // This message is not compressed so its length is the sum of the payload
       // length of all fragments.
@@ -518,6 +556,22 @@ class Receiver extends Writable {
             false,
             1009,
             'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH'
+          );
+
+          cb(error);
+          return;
+        }
+
+        if (
+          this._maxFragments > 0 &&
+          this._fragments.length >= this._maxFragments
+        ) {
+          const error = this.createError(
+            RangeError,
+            'Too many message fragments',
+            false,
+            1008,
+            'WS_ERR_TOO_MANY_BUFFERED_PARTS'
           );
 
           cb(error);

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/sender.js
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/sender.js
@@ -4,6 +4,9 @@
 
 const { Duplex } = require('stream');
 const { randomFillSync } = require('crypto');
+const {
+  types: { isUint8Array }
+} = require('util');
 
 const PerMessageDeflate = require('./permessage-deflate');
 const { EMPTY_BUFFER, kWebSocket, NOOP } = require('./constants');
@@ -200,8 +203,10 @@ class Sender {
 
       if (typeof data === 'string') {
         buf.write(data, 2);
-      } else {
+      } else if (isUint8Array(data)) {
         buf.set(data, 2);
+      } else {
+        throw new TypeError('Second argument must be a string or a Uint8Array');
       }
     }
 

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/websocket-server.js
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/websocket-server.js
@@ -43,6 +43,10 @@ class WebSocketServer extends EventEmitter {
    *     called
    * @param {Function} [options.handleProtocols] A hook to handle protocols
    * @param {String} [options.host] The hostname where to bind the server
+   * @param {Number} [options.maxBufferedChunks=1048576] The maximum number of
+   *     buffered data chunks
+   * @param {Number} [options.maxFragments=131072] The maximum number of message
+   *     fragments
    * @param {Number} [options.maxPayload=104857600] The maximum allowed message
    *     size
    * @param {Boolean} [options.noServer=false] Enable no server mode
@@ -65,6 +69,8 @@ class WebSocketServer extends EventEmitter {
     options = {
       allowSynchronousEvents: true,
       autoPong: true,
+      maxBufferedChunks: 1024 * 1024,
+      maxFragments: 128 * 1024,
       maxPayload: 100 * 1024 * 1024,
       skipUTF8Validation: false,
       perMessageDeflate: false,
@@ -424,6 +430,8 @@ class WebSocketServer extends EventEmitter {
 
     ws.setSocket(socket, head, {
       allowSynchronousEvents: this.options.allowSynchronousEvents,
+      maxBufferedChunks: this.options.maxBufferedChunks,
+      maxFragments: this.options.maxFragments,
       maxPayload: this.options.maxPayload,
       skipUTF8Validation: this.options.skipUTF8Validation
     });

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/websocket.js
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/lib/websocket.js
@@ -201,6 +201,10 @@ class WebSocket extends EventEmitter {
    *     multiple times in the same tick
    * @param {Function} [options.generateMask] The function used to generate the
    *     masking key
+   * @param {Number} [options.maxBufferedChunks=0] The maximum number of
+   *     buffered data chunks
+   * @param {Number} [options.maxFragments=0] The maximum number of message
+   *     fragments
    * @param {Number} [options.maxPayload=0] The maximum allowed message size
    * @param {Boolean} [options.skipUTF8Validation=false] Specifies whether or
    *     not to skip UTF-8 validation for text and close messages
@@ -212,6 +216,8 @@ class WebSocket extends EventEmitter {
       binaryType: this.binaryType,
       extensions: this._extensions,
       isServer: this._isServer,
+      maxBufferedChunks: options.maxBufferedChunks,
+      maxFragments: options.maxFragments,
       maxPayload: options.maxPayload,
       skipUTF8Validation: options.skipUTF8Validation
     });
@@ -640,6 +646,10 @@ module.exports = WebSocket;
  *     masking key
  * @param {Number} [options.handshakeTimeout] Timeout in milliseconds for the
  *     handshake request
+ * @param {Number} [options.maxBufferedChunks=1048576] The maximum number of
+ *     buffered data chunks
+ * @param {Number} [options.maxFragments=131072] The maximum number of message
+ *     fragments
  * @param {Number} [options.maxPayload=104857600] The maximum allowed message
  *     size
  * @param {Number} [options.maxRedirects=10] The maximum number of redirects
@@ -660,6 +670,8 @@ function initAsClient(websocket, address, protocols, options) {
     autoPong: true,
     closeTimeout: CLOSE_TIMEOUT,
     protocolVersion: protocolVersions[1],
+    maxBufferedChunks: 1024 * 1024,
+    maxFragments: 128 * 1024,
     maxPayload: 100 * 1024 * 1024,
     skipUTF8Validation: false,
     perMessageDeflate: true,
@@ -1017,6 +1029,8 @@ function initAsClient(websocket, address, protocols, options) {
     websocket.setSocket(socket, head, {
       allowSynchronousEvents: opts.allowSynchronousEvents,
       generateMask: opts.generateMask,
+      maxBufferedChunks: opts.maxBufferedChunks,
+      maxFragments: opts.maxFragments,
       maxPayload: opts.maxPayload,
       skipUTF8Validation: opts.skipUTF8Validation
     });

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/package.json
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/node_modules/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ws",
-  "version": "8.20.0",
+  "version": "8.21.0",
   "description": "Simple to use, blazing fast and thoroughly tested websocket client and server for Node.js",
   "keywords": [
     "HyBi",

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/package-lock.json
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "ws": "^8.20.1"
+        "ws": "^8.21.0"
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/package.json
+++ b/plugins/elgato-aethersdr/com.aethersdr.radio.sdPlugin/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "ws": "^8.20.1"
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
Bumps `ws` **8.20.1 → 8.21.0** in the Elgato Stream Deck plugin, resolving Dependabot alert #2 — **CVE-2026-48779** / GHSA-96hv-2xvq-fx4p (High, CVSS 7.5): `ws < 8.21.0` can be driven to OOM by a flood of tiny WebSocket fragments.

## Real-world impact: negligible
The dependency is **not in the C++ app** — only in the Stream Deck plugin, which uses `ws` as a **client only** (no `WebSocketServer`, no `listen()`):
- `tciWs` → `ws://localhost:40001` (AetherSDR's own TCI server, loopback)
- `sdWs` → `ws://127.0.0.1:<sdPort>` (Stream Deck software, loopback)

Both peers are loopback + trusted, so there's no network-exposed server for the DoS vector, and the worst case is the peripheral plugin's Node process OOMing — no path to the radio, the C++ app, or user data. The CVSS 7.5 assumes an exposed server. Patching regardless, since it's a trivial, zero-risk bump.

## Changes
- `package.json`: `^8.20.1` → `^8.21.0`
- `package-lock.json`: ws 8.20.1 → 8.21.0 (new integrity hash)
- Vendored `node_modules/ws/**`: regenerated to 8.21.0 — this also realigns the vendored copy, which had drifted to **8.20.0** vs the lockfile's 8.20.1 (left behind by #2922).

## Verification
- `npm audit`: **0 vulnerabilities**
- `ws@8.21.0` loads; `node --check plugin.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
