### PR TITLE
HL2 raw-IQ backend: data-plane spike + design note (new radio family)

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -50,6 +50,33 @@ documented numeric ranges/behavior were used; no CuteSDR code is incorporated.
   License:        BSD-2-Clause (Simplified BSD)
   Source:         https://github.com/jks-prv/Beagle_SDR_GPS  (rx/CuteSDR/)
 
+The Hermes-Lite 2 radio backend implements HPSDR Protocol 1 ("Metis") — UDP
+discovery, the EP2/EP6 IQ frame layout, and the Command & Control register map
+(sample-rate/receiver config, the CONFIG_MERCURY ADC-source-select bit, RX NCO
+frequency, and the AD9866 extended-range LNA gain register). These wire-protocol
+facts were consulted clean-room and are expressed in original AetherSDR code
+(prototypes/hl2/ and, subsequently, the in-tree Hl2Backend). No openHPSDR,
+Hermes-Lite 2, or pihpsdr code is incorporated, vendored, translated, or linked
+into AetherSDR; the referenced sources are consulted only to verify protocol
+facts. The consulted facts are:
+  - the Metis discovery handshake and EP2/EP6 1032-byte frame framing;
+  - the C0 register-address encoding ((addr<<1)|MOX) and the config/RX-freq/
+    gain register semantics; and
+  - the minimal round-robin C&C init a receiver requires (config incl.
+    CONFIG_MERCURY, RX1 frequency, LNA gain), verified against the pihpsdr
+    reference client's C&C construction.
+
+  openHPSDR Protocol 1 (Programmer's guide) — HPSDR project, hosted by TAPR
+  License:  GPL-2.0-or-later (consulted as a protocol specification only)
+  Source:   https://github.com/TAPR/OpenHPSDR-Protocol1-Programmers
+
+  Hermes-Lite 2:  Copyright (c) Steve Haynal (KF7O) and Hermes-Lite 2 contributors
+  Reference:      https://github.com/softerhardware/Hermes-Lite2  (wiki + gateware)
+
+  pihpsdr:   Copyright (c) Christoph van Wüllen (DL1YCF) and contributors
+  License:   GPL-3.0-or-later (consulted as a behavioral reference only)
+  Source:    https://github.com/dl1ycf/pihpsdr  (src/old_protocol.c)
+
 
 1. WDSP — Spectral Noise Reduction (NR2)
 -----------------------------------------

--- a/docs/architecture/aetherd-hl2-backend-design.md
+++ b/docs/architecture/aetherd-hl2-backend-design.md
@@ -172,6 +172,9 @@ a `makeBackend(family)` that returns `unique_ptr<IRadioBackend>` — and move th
 Flex-specific sink/object wiring behind a `if (auto* flex = dynamic_cast<FlexBackend*>...)`
 adapter step, so a non-Flex backend simply skips it. This is the smallest change
 that lets a second family exist; it does **not** require the full step-3 protocol.
+The `dynamic_cast` shim is **explicitly interim** — it is the transitional stand-in
+until the step-3 engine-side registry lands and each backend injects its own
+sinks; the implementation PR should label it as such so it doesn't calcify.
 Selection input for Phase 1 can be explicit (config/UI "radio family = HL2"),
 deferring auto-discovery-driven selection.
 

--- a/docs/architecture/aetherd-hl2-backend-design.md
+++ b/docs/architecture/aetherd-hl2-backend-design.md
@@ -28,7 +28,7 @@ proof in-tree.
 
 FlexBackend is the "thin protocol decoder" half: Flex hardware ships cooked audio
 (24 kHz PCM) plus a hardware spectrum, and FlexBackend's job is almost entirely
-`decodeXStatus` translation (`FlexBackend.cpp:198-889`). **HL2 is the other
+`decodeXStatus` translation (FlexBackend's `decode*Status` translators). **HL2 is the other
 half** — it ships nothing but raw IQ, so `Hl2Backend` must own an engine-side RX
 DSP chain (tune → decimate → demodulate → FFT → S-meter) and then emit the same
 normalized `sliceChanged` / `meterUpdate` / spectrum / audio outlets. It is the
@@ -56,7 +56,7 @@ code incorporated. Recorded under Protocol References in `THIRD_PARTY_LICENSES`.
 ## 2. What `Hl2Backend` owns
 
 Mirroring FlexBackend's ownership shape (it owns its wire objects and their
-worker threads, constructed in a load-bearing order — `FlexBackend.cpp:25-94`),
+worker threads, constructed in a load-bearing order — FlexBackend's constructor),
 `Hl2Backend` owns two internal, below-seam objects, each on its own worker
 thread:
 
@@ -105,7 +105,7 @@ where the same field would be a wire command.
 | `setSliceMode(id, mode)` | **Engine DSP** — selects the `Hl2RxDsp` demodulator (AM/SSB/CW/FM/…). HL2 ships raw IQ, so mode is purely engine-side. |
 | `setSliceFilter(id, lo, hi)` | **Engine DSP** — sets the demod passband in `Hl2RxDsp`. |
 | `setKeying(bool)` | **Guarded no-op** — `capabilities().canTransmit == false`, so the engine TX guard (RFC §6) denies keying above the seam; the backend never keys. (TX is Phase 2+.) |
-| `invokeExtension(...)` | Stub, exactly like FlexBackend (`FlexBackend.cpp:185-196`): if `requestId != 0`, emit `extensionError` immediately. HL2 advertises **no** extension namespaces (see §4). |
+| `invokeExtension(...)` | Stub, exactly like FlexBackend (FlexBackend::invokeExtension): if `requestId != 0`, emit `extensionError` immediately. HL2 advertises **no** extension namespaces (see §4). |
 
 ### State UP
 
@@ -122,7 +122,7 @@ Signals HL2 simply never emits in Phase 1 (no such hardware/wire): `transmitChan
 `amplifierChanged`, `tunerChanged`, `gpsChanged`, `memoryChanged`, `profileChanged`,
 `meterDefined` catalog. RadioModel already tolerates a backend that stays silent
 on these — the wiring is per-signal `connect()` with no "all-must-fire" contract
-(`RadioModel.cpp:443-573`).
+(RadioModel's interface-typed backend signal wiring).
 
 ---
 
@@ -146,7 +146,7 @@ caps.extensionNamespaces = {};                    // advertise NONE until step 3
 ```
 
 The empty `extensionNamespaces` follows FlexBackend's deliberate precedent
-(`FlexBackend.cpp:133-137`): advertising a namespace whose `invokeExtension`
+(FlexBackend's capabilities setup): advertising a namespace whose `invokeExtension`
 can't yet reply would hang a client. HL2 keeps it empty until the step-3 encode
 path lands.
 
@@ -160,11 +160,11 @@ This is a feature: HL2 is the forcing function that closes both gaps minimally.
 
 ### Gap A — backend selection (no factory today)
 
-`FlexBackend` is **hard-wired**: `make_unique<FlexBackend>()` literal at
-`RadioModel.cpp:425`, plus a transitional concrete `FlexBackend* m_flexBackend`
-alias (`RadioModel.h:694`) and Flex-specific sink injection / object grabs
-(`setCommandSink`, `connection()`, `panStream()` — `RadioModel.cpp:426-434`).
-The *signal-wiring* half (`:443-573`) is already interface-typed and reusable;
+`FlexBackend` is **hard-wired**: a `make_unique<FlexBackend>()` literal in
+RadioModel's backend construction, plus a transitional concrete `FlexBackend* m_flexBackend`
+alias and Flex-specific sink injection / object grabs
+(`setCommandSink`, `connection()`, `panStream()`) — all in RadioModel.
+The *signal-wiring* half (the interface-typed half) is already interface-typed and reusable;
 the *construction* half is Flex-shaped.
 
 **Proposal (minimal):** introduce a tiny backend-selection seam in RadioModel —
@@ -181,7 +181,7 @@ The interface's `spectrumFrameReady/audioFrameReady` (`QByteArray`) are **declar
 but never emitted** by FlexBackend; the live path is the existing in-tree frame
 types flowing off `PanadapterStream` and reached via `RadioModel::panStream()` —
 `spectrumReady(QVector<float> binsDbm)` / `audioDataReady(QByteArray pcm)` →
-`AudioEngine::feedAudioData` (`PanadapterStream.h:208-217`; `MainWindow.cpp:1049-1053`).
+`AudioEngine::feedAudioData` (`PanadapterStream.h:208-217`; MainWindow's audio-feed wiring).
 The concrete seam frame formats are **step-4 work, not final**
 (`IRadioBackend.h:210-216`; `aetherd-headless-engine-design.md:251-266`).
 

--- a/docs/architecture/aetherd-hl2-backend-design.md
+++ b/docs/architecture/aetherd-hl2-backend-design.md
@@ -1,0 +1,277 @@
+# Hermes-Lite 2 Backend — Design Note
+
+**Status:** Draft for maintainer review. A *new radio family* under the accepted
+aetherd RFC §5.5, gated by AGENTS.md's rule that a new family "requires an
+approved design doc naming its open protocol authority" (`AGENTS.md:334`). This
+note is that prerequisite.
+
+**Scope:** An in-tree `Hl2Backend : IRadioBackend` for the Hermes-Lite 2 (HPSDR
+Protocol 1 / "Metis", raw-IQ over UDP:1024). Phase-1 target is a **working
+receive path** — discover → stream → tune → engine-side demod → panadapter/audio
+— behind the existing seam, with **zero** change to any UI or model consumer of
+`IRadioBackend`. Transmit is explicitly out of scope for Phase 1. The data plane
+and register facts are already proven against real hardware by the throwaway
+spike in `prototypes/hl2/` (see its README); this note is the plan to port that
+proof in-tree.
+
+---
+
+## 1. Why HL2 is the interesting backend
+
+`IRadioBackend.h` was written anticipating exactly this case
+(`src/core/backends/IRadioBackend.h:50-53`):
+
+> DSP location is invisible here: a backend whose hardware demodulates and
+> computes FFTs is a thin protocol decoder; one that ships raw samples owns an
+> engine-side DSP chain — either way it emits the same normalized signals, so no
+> consumer can tell the difference.
+
+FlexBackend is the "thin protocol decoder" half: Flex hardware ships cooked audio
+(24 kHz PCM) plus a hardware spectrum, and FlexBackend's job is almost entirely
+`decodeXStatus` translation (`FlexBackend.cpp:198-889`). **HL2 is the other
+half** — it ships nothing but raw IQ, so `Hl2Backend` must own an engine-side RX
+DSP chain (tune → decimate → demodulate → FFT → S-meter) and then emit the same
+normalized `sliceChanged` / `meterUpdate` / spectrum / audio outlets. It is the
+first backend that exercises the "owns a DSP chain" branch of the seam, and thus
+the first real test that the seam's abstraction holds.
+
+**What the spike already proved** (`prototypes/hl2/`, live against a real HL2 at
+gateware 7.4):
+
+- Metis discovery (board id `0x06`), EP2/EP6 1032-byte framing, 0.00% loss.
+- Sample-rate control (48/96/192/384 kHz) via the config C&C register.
+- **RX1 NCO tuning** (`C0=0x04`, 32-bit Hz BE) — WWV 10 MHz lands exactly at
+  baseband DC.
+- The non-obvious must-set: **`CONFIG_MERCURY`** (config C1 bit 6) selects the
+  ADC as the DDC source; without it the stream is flat ADC-floor noise.
+- LNA gain (`C0=0x14`, `C4 = 0x40 | (dB+12)`), −12…+48 dB.
+- End-to-end FFT panadapter resolving WWV ~50 dB over the noise floor.
+
+Protocol authority (Principle I): openHPSDR Protocol 1, the Hermes-Lite 2 wiki /
+gateware, and the pihpsdr reference client — all consulted **clean-room**, no
+code incorporated. Recorded under Protocol References in `THIRD_PARTY_LICENSES`.
+
+---
+
+## 2. What `Hl2Backend` owns
+
+Mirroring FlexBackend's ownership shape (it owns its wire objects and their
+worker threads, constructed in a load-bearing order — `FlexBackend.cpp:25-94`),
+`Hl2Backend` owns two internal, below-seam objects, each on its own worker
+thread:
+
+```
+Hl2Backend : IRadioBackend
+├── MetisClient        (UDP :1024 wire — discovery, start/stop, EP2 C&C egress,
+│                       EP6 IQ ingest; owns the socket + its RX thread)
+│      emits: iqBlockReady(complex<float> block), linkUp/linkDown, dropStats
+│      accepts: setRxFrequencyHz(), setSampleRate(), setLnaGainDb()  (C&C)
+└── Hl2RxDsp          (engine-side RX chain on its own thread)
+       in:  raw IQ blocks from MetisClient
+       out: demodulated PCM  → audio outlet
+            FFT magnitude bins → spectrum/waterfall outlet
+            S-meter level      → meterUpdate
+```
+
+`MetisClient` and `Hl2RxDsp` are a direct in-tree port of the proven
+`prototypes/hl2/hpsdr.py` primitives (register map, framing, DC-removed FFT).
+The DSP building blocks the chain needs — **liquid-dsp, FFTW, and the `WfmDsp`
+pattern — are already in the tree** (`docs/aetherd-headless-engine-design.md:309-318`),
+so `Hl2RxDsp` is assembly of existing parts, not new DSP.
+
+Everything in this box lives under `src/core/backends/hl2/`, which is **below the
+seam**: EB3 never inspects its includes and it may use any vendor/DSP header
+freely (`tools/check_engine_boundary.py:66-67, 326-327`; `AGENTS.md:316-318`).
+Only EB1/EB2 apply — no `gui/` include, no QtWidgets — which this backend never
+needs. Adding the HL2 tree touches **no** ratchet baseline row and requires **no**
+`aetherd-touchpoint-tags.json` change (nothing HL2 ends up above the seam).
+
+---
+
+## 3. Seam mapping
+
+Each `IRadioBackend` verb/signal → HL2 mechanism. "Engine DSP" means the field
+configures `Hl2RxDsp`, not the radio — the fundamental HL2 difference from Flex,
+where the same field would be a wire command.
+
+### Intents DOWN
+
+| Interface verb | HL2 realization |
+|---|---|
+| `connectRadio(req)` | **Real, unlike Flex's stub.** `MetisClient` opens the socket to `req.host:1024` (or a discovered HL2), sends the 3-register init (config incl. `CONFIG_MERCURY`, RX1 freq, LNA gain), starts EP6 ingest. Emits `connected()` on first EP6, `connectionError()` on timeout. |
+| `disconnectRadio()` | Send Metis stop (`EF FE 04 00`), stop threads in reverse order. |
+| `isConnected()` | `MetisClient` link state (EP6 flowing). |
+| `setSliceFrequency(id, hz)` | `MetisClient::setRxFrequencyHz` → RX1 NCO `C0=0x04`. (Phase 1: single slice, `id` fixed.) |
+| `setSliceMode(id, mode)` | **Engine DSP** — selects the `Hl2RxDsp` demodulator (AM/SSB/CW/FM/…). HL2 ships raw IQ, so mode is purely engine-side. |
+| `setSliceFilter(id, lo, hi)` | **Engine DSP** — sets the demod passband in `Hl2RxDsp`. |
+| `setKeying(bool)` | **Guarded no-op** — `capabilities().canTransmit == false`, so the engine TX guard (RFC §6) denies keying above the seam; the backend never keys. (TX is Phase 2+.) |
+| `invokeExtension(...)` | Stub, exactly like FlexBackend (`FlexBackend.cpp:185-196`): if `requestId != 0`, emit `extensionError` immediately. HL2 advertises **no** extension namespaces (see §4). |
+
+### State UP
+
+| Interface signal | HL2 source |
+|---|---|
+| `connected` / `disconnected` / `connectionError` | `MetisClient` link transitions. |
+| `sliceChanged(id, SliceDelta)` | Emitted from the backend's **own authoritative state**. HL2 has no status wire echoing frequency/mode back (unlike Flex's `decodeSliceStatus`); the engine is the source of truth, so the backend reflects the settings it applied. |
+| `meterUpdate("s-meter", v)` | `Hl2RxDsp` S-meter (dBFS → dBm via a calibration constant; TBD, refine like `flex-meter-learnings.md`). |
+| `panCenterBandwidthChanged(panId, ctr, span)` | Center = RX1 NCO MHz; span = sample-rate MHz. Backend-emitted from its own config. |
+| `panRfGainChanged(panId, gain)` | LNA gain (−12…+48 dB) reflected back. |
+| `spectrumFrameReady` / `waterfallRowReady` / `audioFrameReady` | The DSP outlets — **but see §5 for how these actually reach the UI in Phase 1** (the interface's `QByteArray` data-plane signals are not the live path yet). |
+
+Signals HL2 simply never emits in Phase 1 (no such hardware/wire): `transmitChanged`,
+`amplifierChanged`, `tunerChanged`, `gpsChanged`, `memoryChanged`, `profileChanged`,
+`meterDefined` catalog. RadioModel already tolerates a backend that stays silent
+on these — the wiring is per-signal `connect()` with no "all-must-fire" contract
+(`RadioModel.cpp:443-573`).
+
+---
+
+## 4. Capabilities `Hl2Backend` advertises
+
+Per `src/core/backends/RadioCapabilities.h:25-55`:
+
+```cpp
+RadioCapabilities caps;
+caps.family              = "hl2";
+caps.model               = "Hermes-Lite 2";      // + gateware ver from discovery
+caps.maxSlices           = 1;                     // Phase 1; gateware supports more DDCs
+caps.maxPanadapters      = 1;
+caps.sampleRatesHz       = {48000, 96000, 192000, 384000};
+caps.canTransmit         = false;                 // RFC §6 guard denies keying
+caps.txPowerMaxWatts     = 0.0;
+caps.hasTuner            = false;
+caps.hasAmplifier        = false;
+caps.hasExtendedDsp      = false;                 // DSP is engine-side, not firmware
+caps.extensionNamespaces = {};                    // advertise NONE until step 3
+```
+
+The empty `extensionNamespaces` follows FlexBackend's deliberate precedent
+(`FlexBackend.cpp:133-137`): advertising a namespace whose `invokeExtension`
+can't yet reply would hang a client. HL2 keeps it empty until the step-3 encode
+path lands.
+
+---
+
+## 5. The two structural gaps HL2 forces (and how)
+
+FlexBackend quietly bypasses the seam in two places. HL2 cannot, because it has
+no Flex-shaped `RadioConnection`/`PanadapterStream` for RadioModel to reach into.
+This is a feature: HL2 is the forcing function that closes both gaps minimally.
+
+### Gap A — backend selection (no factory today)
+
+`FlexBackend` is **hard-wired**: `make_unique<FlexBackend>()` literal at
+`RadioModel.cpp:425`, plus a transitional concrete `FlexBackend* m_flexBackend`
+alias (`RadioModel.h:694`) and Flex-specific sink injection / object grabs
+(`setCommandSink`, `connection()`, `panStream()` — `RadioModel.cpp:426-434`).
+The *signal-wiring* half (`:443-573`) is already interface-typed and reusable;
+the *construction* half is Flex-shaped.
+
+**Proposal (minimal):** introduce a tiny backend-selection seam in RadioModel —
+a `makeBackend(family)` that returns `unique_ptr<IRadioBackend>` — and move the
+Flex-specific sink/object wiring behind a `if (auto* flex = dynamic_cast<FlexBackend*>...)`
+adapter step, so a non-Flex backend simply skips it. This is the smallest change
+that lets a second family exist; it does **not** require the full step-3 protocol.
+Selection input for Phase 1 can be explicit (config/UI "radio family = HL2"),
+deferring auto-discovery-driven selection.
+
+### Gap B — data plane not through the seam
+
+The interface's `spectrumFrameReady/audioFrameReady` (`QByteArray`) are **declared
+but never emitted** by FlexBackend; the live path is the existing in-tree frame
+types flowing off `PanadapterStream` and reached via `RadioModel::panStream()` —
+`spectrumReady(QVector<float> binsDbm)` / `audioDataReady(QByteArray pcm)` →
+`AudioEngine::feedAudioData` (`PanadapterStream.h:208-217`; `MainWindow.cpp:1049-1053`).
+The concrete seam frame formats are **step-4 work, not final**
+(`IRadioBackend.h:210-216`; `aetherd-headless-engine-design.md:251-266`).
+
+**Proposal (Phase 1 relays existing types):** `Hl2RxDsp` produces the **same**
+in-tree frame types the UI already consumes — `QVector<float>` dBm spectrum bins,
+`QByteArray` 24 kHz PCM. Rather than invent a step-4 format now, expose them the
+way RadioModel already consumes Flex's: the cleanest minimal option is a small
+`spectrumSource()`/audio adapter on the backend that RadioModel binds the same
+way it binds `panStream()` today. When step-4 finalizes the binary frame formats,
+HL2 (and Flex) migrate to `spectrumFrameReady/audioFrameReady` together — HL2's
+DSP output is already frame-shaped, so that migration is a re-wrap, not a rewrite.
+
+**Sequencing:** both gaps are closable **without** waiting on step-3 (protocol) or
+a finalized step-4 format. HL2 Phase 1 depends only on: (A) the small selection
+seam, and (B) relaying existing frame types. TX, vendor extensions, remote/binary
+data plane, and multi-RX all wait for their respective later steps.
+
+---
+
+## 6. Explicitly out of scope for Phase 1
+
+- **Transmit.** `canTransmit=false`; `setKeying` is a guarded no-op. TX needs the
+  MOX bit + a TX-IQ data plane + the engine TX arbiter (RFC §6 / step 4-arbitration)
+  and is deliberately deferred — it is also the only path that can key a radio, so
+  keeping it out of Phase 1 is the safe default.
+- **Multiple DDC receivers.** Gateware supports them; Phase 1 is one slice / one pan.
+- **Vendor extensions.** No namespaces advertised until the step-3 encode path exists.
+- **Discovery-driven UI selection / multi-radio.** Phase 1 connects to an explicit
+  host; enumeration is a later enhancement (the spike's `discover.py` proves it works).
+
+---
+
+## 7. Clean-room provenance (allowed inputs)
+
+Consistent with the KiwiSDR precedent (`docs/kiwisdr-cleanroom-design.md`) and the
+`THIRD_PARTY_LICENSES` Protocol-References entry. `Hl2Backend` is implemented from
+clean AetherSDR interfaces plus **protocol facts** (not code) consulted from
+GPL/open sources. Allowed inputs used:
+
+- **openHPSDR Protocol 1** (TAPR, GPL-2.0) — Metis discovery handshake, EP2/EP6
+  1032-byte frame layout, the C0 `(addr<<1)|MOX` register-address encoding.
+- **Hermes-Lite 2 wiki / gateware** (KF7O + contributors) — board id `0x06`,
+  supported sample rates, register `0x0a` extended-range LNA gain, the
+  `CONFIG_MERCURY` ADC-source-select bit.
+- **pihpsdr `src/old_protocol.c`** (DL1YCF, GPL-3.0) — consulted as a *behavioral
+  reference* for the minimal round-robin C&C init sequence a receiver needs.
+- **Live black-box observation** of the AetherSDR-owned HL2 (register effects on
+  the IQ stream), recorded in `prototypes/hl2/`.
+
+No openHPSDR, Hermes-Lite 2, or pihpsdr source is incorporated, vendored,
+translated, or linked. The facts above are expressed in original AetherSDR code.
+Because AetherSDR is itself GPL-3, direct adaptation would also be permissible,
+but clean-room is chosen to match project convention.
+
+---
+
+## 8. Resolved decisions & open questions
+
+**Resolved**
+- HL2 is one `IRadioBackend` implementor, RX-only in Phase 1 (RFC §5.5 Q3: one
+  interface, `canTransmit=false`, guarded `setKeying`).
+- DSP is engine-side and encapsulated below the seam; consumers see the same
+  normalized signals (RFC §5.5, `IRadioBackend.h:50-53`).
+- Below-seam placement under `src/core/backends/hl2/` — no EB3/tags impact.
+- Protocol authority named and consulted clean-room (Principle I / AGENTS.md:334).
+
+**Open (for maintainer input)**
+- **Backend-selection seam shape (Gap A):** `makeBackend(family)` factory in
+  RadioModel now, vs. deferring until step-3 lands a fuller engine-side registry.
+  Recommendation: the minimal factory now — HL2 is the concrete second family
+  that justifies it, and it's a prerequisite for HL2 existing at all.
+- **Phase-1 data-plane wiring (Gap B):** relay existing `QVector<float>`/`QByteArray`
+  frame types via a `panStream()`-analogue, vs. emitting the interface's
+  `QByteArray` data-plane signals early with a RadioModel bridge. Recommendation:
+  relay existing types (matches how Flex reaches the UI today; least churn; both
+  families migrate to step-4 formats together later).
+- **S-meter calibration:** dBFS→dBm constant for the AD9866 front end; refine
+  empirically as in `docs/architecture/flex-meter-learnings.md`.
+
+---
+
+## 9. Phasing
+
+1. **1a — MetisClient + Hl2RxDsp in-tree** (port the spike; unit-tested against
+   captured EP6 fixtures). No RadioModel change yet.
+2. **1b — backend-selection seam** (Gap A): `makeBackend`, Flex-sink adapter step.
+3. **1c — data-plane relay** (Gap B): HL2 DSP frames reach the existing UI path;
+   first live in-app HL2 panadapter + audio.
+4. **1d — capabilities + connect UX**: family reporting, explicit-host connect,
+   error surfacing.
+
+Later (own steps): discovery-driven selection, multi-RX, transmit, vendor
+extensions, migration to finalized step-4 binary frames.

--- a/prototypes/hl2/README.md
+++ b/prototypes/hl2/README.md
@@ -1,0 +1,82 @@
+# HL2 backend spike (aetherd)
+
+Throwaway Phase‑0 prototype to de-risk a **Hermes‑Lite 2** `IRadioBackend` before
+committing to an in-tree `Hl2Backend`. Lives in `prototypes/` on purpose: an
+in-tree backend is a "new radio family" and (per `AGENTS.md`) needs an approved
+design doc first. This spike proves the **data plane** — the biggest unknown —
+cheaply in Python, so the design note + C++ port are demand-driven.
+
+## Why HL2 is different from Flex
+
+Flex does DSP in hardware and ships **cooked audio + spectrum** (DAX/VITA‑49).
+HL2 ships **raw IQ** — the client does *all* DSP (tune / decimate / demodulate /
+FFT). The spike is about proving we can ingest that IQ and turn it into a
+spectrum; the eventual `Hl2Backend` owns that RX DSP chain internally and emits
+the same normalized `IRadioBackend` signals as `FlexBackend`.
+
+## Protocol authority (Principle I)
+
+HPSDR **Protocol 1 ("Metis")** over UDP:1024. Build from the spec, don't guess.
+All protocol facts are consulted **clean-room** and re-expressed in original code
+(see `../../THIRD_PARTY_LICENSES`):
+- openHPSDR Protocol 1 Programmer's guide (discovery, EP2/EP6 frames, C&C bytes)
+- Hermes‑Lite 2 wiki + gateware repo (board id `0x06`, register map, sample rates,
+  the `0x0a` extended-range LNA gain register)
+- pihpsdr `src/old_protocol.c` (the round-robin C&C init sequence — this is where
+  the non-obvious **`CONFIG_MERCURY`** ADC-select bit came from)
+
+## Phases
+
+| Step | File | Proves |
+|---|---|---|
+| ✅ 0.1 discovery | `discover.py` | HL2 reachable + identified (Metis handshake) |
+| ✅ 0.2 stream | `stream.py` | start → EP6 IQ ingest, framing verified (see below) |
+| ✅ 0.3 tune | `tune.py` | set RX1 NCO frequency via EP2 C&C — **WWV lands exactly at DC** |
+| ✅ 0.4 spectrum | `spectrum.py` | FFT the IQ → panadapter, **data plane proven end-to-end** |
+| ⬜ 1 in-tree | design note → `src/core/backends/hl2/Hl2Backend` | port proven logic behind the seam |
+
+### The one non-obvious fact (phase 0.3/0.4)
+
+A receiver that streams IQ but shows only **flat ADC-floor noise** at every
+frequency is missing the config register's **`CONFIG_MERCURY` (C1 bit 6, 0x40)**
+— it selects the ADC as the DDC's input source. Without it the NCO tunes into
+silence. The minimal working RX is a round-robin of **three** registers:
+`config` (speed | `CONFIG_MERCURY`, plus `0x04` duplex + `#RX` in C4),
+**RX1 freq** (`C0=0x04`, 32-bit Hz BE — confirmed, *not* the `0x02` TX register),
+and **LNA gain** (`C0=0x14`, `C4 = 0x40 | (dB+12)`). Verified live: tuning WWV
+(10 MHz) puts its carrier at baseband DC ~50 dB over a clean noise floor.
+IQ sample-parse note: the ADC DC offset lives on **I only** (Q mean ≈ 0), so a
+`peak|I|` metric reads the DC spur, not signal — use a DC-removed FFT.
+
+## Running
+
+```bash
+python3 discover.py                      # smoke test — is the HL2 on the LAN?
+python3 discover.py --bcast 169.254.255.255   # if 255.255.255.255 is filtered
+```
+
+Verified device (2026‑07): HL2, MAC `00:1C:C0:A2:13:DD`, board `0x06`, gateware
+7.4, idle. **Dual-homed** — LAN address `192.168.50.99` (reached over WiFi here),
+and also answers on a link-local `169.254.x` direct-Ethernet interface. Discovery
+replies from whichever interface the broadcast arrived on. Use `192.168.50.99`
+for the protocol spike; prefer the **wired** interface for sustained IQ streaming
+(HL2 pushes a continuous UDP torrent — WiFi will drop/jitter).
+
+Phase-0.2 result (2026‑07, over WiFi to `192.168.50.99`, 3 s): 1146 EP6 packets,
+144 396 IQ samples ≈ **48.1 k/s** (matches the 48 kHz default → frame parse is
+correct), **0.00% packet loss**, 0 sync errors. (The −48 dBFS "peak" reported
+at this stage was later found to be the ADC **DC offset on I**, not signal — the
+receiver had no ADC source selected yet; see the phase-0.3/0.4 note above.)
+
+Phase-0.3/0.4 result (2026‑07, over WiFi): with the corrected 3-register init,
+`spectrum.py --freq 10000000` resolves the **WWV 10 MHz carrier at baseband DC,
+~50 dB over a clean floor**, and `tune.py` streams 0-drop after tuning. The
+raw-IQ data plane is proven end-to-end (discover → stream → tune → gain → FFT).
+
+## Notes / gaps this spike will surface for the seam
+
+- **Connect flow** isn't behind the seam yet (`FlexBackend::connectRadio` is a
+  stub); HL2's discovery/start needs a home in `IRadioBackend::connectRadio`.
+- **Data-plane frame formats** (`spectrumFrameReady`/`audioFrameReady`) are
+  step‑4 "declared but not final" — the spike shows what HL2 needs to emit.
+- **Encode path** (`invokeExtension`) is a stub — HL2 tuning/keying needs it.

--- a/prototypes/hl2/discover.py
+++ b/prototypes/hl2/discover.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""HL2 discovery smoke test — HPSDR Protocol 1 (Metis) over UDP:1024.
+
+Phase-0 spike for the aetherd Hl2Backend (see README.md). This is the very first
+step: prove a Hermes-Lite 2 is reachable on the LAN and speaks Metis, before we
+touch IQ streaming, tuning, or the IRadioBackend seam.
+
+Protocol authority (Principle I — grep the spec, don't guess):
+  - HPSDR "Metis - How it works" (discovery frame layout)
+  - Hermes-Lite 2 wiki / gateware (board id 0x06, gateware version byte)
+
+Discovery handshake:
+  request  (63 B): 0xEF 0xFE 0x02  + 60 x 0x00, broadcast to <bcast>:1024
+  reply    (60 B): 0xEF 0xFE <st>  MAC[6]  gwver  boardid  ...
+                   st = 0x02 idle / 0x03 already streaming; HL2 boardid = 0x06
+
+Run:  python3 discover.py [--bcast 255.255.255.255] [--timeout 2.0]
+Needs no third-party deps. Read-only on the wire (discovery only — does NOT start
+a stream, so it won't disturb another client already using the radio).
+"""
+
+import argparse
+import socket
+import struct
+import sys
+
+METIS_PORT = 1024
+DISCOVERY_REQUEST = bytes([0xEF, 0xFE, 0x02]) + bytes(60)  # 63 bytes
+
+BOARD_IDS = {
+    0x00: "Metis",
+    0x01: "Hermes",
+    0x02: "Griffin",
+    0x04: "Angelia",
+    0x05: "Orion",
+    0x06: "Hermes-Lite / Hermes-Lite 2",
+    0x0A: "Orion mkII",
+}
+
+
+def parse_reply(data: bytes, addr) -> dict | None:
+    """Parse a 60-byte Metis discovery reply. Returns None if it isn't one."""
+    if len(data) < 11 or data[0] != 0xEF or data[1] != 0xFE:
+        return None
+    status = data[2]              # 0x02 idle, 0x03 sending data
+    mac = ":".join(f"{b:02X}" for b in data[3:9])
+    gwver = data[9]
+    board = data[10]
+    return {
+        "ip": addr[0],
+        "mac": mac,
+        "status": "streaming" if status == 0x03 else "idle",
+        "gateware": f"{gwver // 10}.{gwver % 10}",  # e.g. 0x49 -> "7.3"; refine vs HL2 wiki
+        "gateware_raw": gwver,
+        "board_id": board,
+        "board": BOARD_IDS.get(board, f"unknown (0x{board:02X})"),
+    }
+
+
+def discover(bcast: str, timeout: float) -> list[dict]:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("", 0))
+        s.settimeout(timeout)
+        print(f"→ discovery broadcast to {bcast}:{METIS_PORT} "
+              f"({len(DISCOVERY_REQUEST)} B), waiting {timeout}s ...")
+        s.sendto(DISCOVERY_REQUEST, (bcast, METIS_PORT))
+
+        found: dict[str, dict] = {}
+        while True:
+            try:
+                data, addr = s.recvfrom(1024)
+            except socket.timeout:
+                break
+            info = parse_reply(data, addr)
+            if info:
+                found[info["mac"]] = info  # de-dup by MAC
+        return list(found.values())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="HL2 / HPSDR Metis discovery")
+    ap.add_argument("--bcast", default="255.255.255.255",
+                    help="broadcast address (use your subnet bcast if 255... is filtered)")
+    ap.add_argument("--timeout", type=float, default=2.0)
+    args = ap.parse_args()
+
+    radios = discover(args.bcast, args.timeout)
+    if not radios:
+        print("✗ no HPSDR/Hermes devices answered. Check: same L2 subnet, "
+              "firewall on :1024, try --bcast <your subnet>.255.")
+        return 1
+
+    print(f"✓ {len(radios)} device(s):")
+    for r in radios:
+        print(f"  {r['ip']:<15}  {r['mac']}  {r['board']}  "
+              f"gw={r['gateware']} (0x{r['gateware_raw']:02X})  [{r['status']}]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prototypes/hl2/discover.py
+++ b/prototypes/hl2/discover.py
@@ -21,7 +21,6 @@ a stream, so it won't disturb another client already using the radio).
 
 import argparse
 import socket
-import struct
 import sys
 
 METIS_PORT = 1024

--- a/prototypes/hl2/hpsdr.py
+++ b/prototypes/hl2/hpsdr.py
@@ -106,9 +106,18 @@ def parse_ep6(pkt: bytes):
     return seq, n, peak, sumsq, sync_ok
 
 
+def ep6_seq(pkt: bytes):
+    """Sequence number of an EP6 packet, or None if it isn't one. Cheap — reads
+    only the header, no per-sample decode (use when you want seq + iq_samples()
+    without paying for parse_ep6's discarded level stats)."""
+    if len(pkt) < 8 or pkt[0] != 0xEF or pkt[1] != 0xFE or pkt[2] != 0x01 or pkt[3] != 0x06:
+        return None
+    return struct.unpack(">I", pkt[4:8])[0]
+
+
 def iq_samples(pkt: bytes):
     """Yield (I, Q) tuples from an EP6 packet — for FFT/spectrum use."""
-    if len(pkt) < 1032:
+    if len(pkt) < 1032 or pkt[0] != 0xEF or pkt[1] != 0xFE or pkt[2] != 0x01 or pkt[3] != 0x06:
         return
     for fstart in (8, 520):
         frame = pkt[fstart:fstart + 512]

--- a/prototypes/hl2/hpsdr.py
+++ b/prototypes/hl2/hpsdr.py
@@ -1,0 +1,121 @@
+"""HPSDR Protocol 1 (Metis) primitives for the HL2 spike — grounded, not guessed.
+
+Register map sourced from the Hermes-Lite 2 wiki "Protocol" page and cross-checked
+against the pihpsdr reference client's C&C construction (src/old_protocol.c),
+consulted clean-room for wire-protocol facts only — see ../../THIRD_PARTY_LICENSES
+(Principle I). Verified live against a real HL2 (WWV 10 MHz carrier lands exactly
+at baseband DC; see README.md phase 0.3/0.4).
+
+  C0 byte:  bits [6:1] = register ADDR[5:0], bit [0] = MOX (1=TX). So the C0 byte
+            for a register = (addr << 1) | mox. Keep C0 EVEN → MOX=0 → never keys.
+  addr 0x00 → C0 0x00 : config. C1 = speed(bits[1:0]) | CONFIG_MERCURY(0x40);
+                        C4 = duplex(0x04) | ((#RX-1) & 0x7) << 3.
+                        *** C1 bit6 (CONFIG_MERCURY) selects the ADC as the RX
+                        source — WITHOUT it the DDC gets no input and the stream
+                        is dead ADC-floor noise. This is the non-obvious must-set. ***
+  addr 0x01 → C0 0x02 : TX1 NCO frequency (Hz, 32-bit)  ***DO NOT SET for RX***
+  addr 0x02 → C0 0x04 : RX1 NCO frequency (Hz, 32-bit, big-endian in C1..C4)
+  addr 0x0a → C0 0x14 : ADC gain. HL2 extended-range LNA: C4 = 0x40 | gain,
+                        gain 0..60 = -12..+48 dB (i.e. code = dB + 12).
+
+Register value is 32-bit; C1=bits[31:24], C2=[23:16], C3=[15:8], C4=[7:0].
+
+Wire framing:
+  metis command : EF FE 04 <cmd>  (pad 64)   cmd bit0 = IQ on/off
+  EP2 (→radio)  : EF FE 01 02 | seq[4] | frame512 | frame512
+  EP6 (←radio)  : EF FE 01 06 | seq[4] | frame512 | frame512
+  each 512-B frame: 7F 7F 7F | C0 C1 C2 C3 C4 | 504 B payload
+  RX sample (1 RX): I[3] Q[3] mic[2] = 8 B; I/Q are 24-bit signed big-endian.
+
+Minimal working RX = round-robin three registers: config (with CONFIG_MERCURY),
+RX1 freq, and ADC gain. Sending only freq (no Mercury bit) yields flat noise.
+"""
+
+import struct
+
+METIS_PORT = 1024
+SYNC = b"\x7f\x7f\x7f"
+FULL_SCALE = 1 << 23  # 24-bit signed full scale
+
+# C0 register-address bytes (address << 1, MOX=0).
+C0_CONFIG = 0x00
+C0_TX1_FREQ = 0x02   # avoid — transmit
+C0_RX1_FREQ = 0x04
+C0_ADC_GAIN = 0x14   # register 0x0a
+
+CONFIG_MERCURY = 0x40   # C1 bit6: select ADC as RX source (mandatory for signal)
+CONFIG_DUPLEX = 0x04    # C4 bit2: pihpsdr sets this on unconditionally
+
+
+def metis_command(cmd: int) -> bytes:
+    """EF FE 04 <cmd> padded to 64 B. cmd 0x01 = start IQ, 0x00 = stop."""
+    return bytes([0xEF, 0xFE, 0x04, cmd]) + bytes(60)
+
+
+def cc_config(speed: int = 0, n_rx: int = 1) -> bytes:
+    """5-byte C&C for register 0x00: sample rate + receiver count + ADC select.
+    C1 carries the speed AND CONFIG_MERCURY (without which there is no RX signal).
+    C4 carries the duplex bit and the receiver count. MOX stays 0."""
+    c1 = (speed & 0x3) | CONFIG_MERCURY
+    c4 = CONFIG_DUPLEX | (((n_rx - 1) & 0x7) << 3)
+    return bytes([C0_CONFIG, c1, 0x00, 0x00, c4])
+
+
+def cc_rx1_freq(hz: int) -> bytes:
+    """5-byte C&C for register 0x02: RX1 NCO frequency in Hz (32-bit BE). MOX 0."""
+    return bytes([C0_RX1_FREQ]) + struct.pack(">I", hz & 0xFFFFFFFF)
+
+
+def cc_rx_gain(db: int = 20) -> bytes:
+    """5-byte C&C for register 0x0a: HL2 extended-range LNA gain, -12..+48 dB.
+    C4 = 0x40 (enable direct AD9866 gain) | code, code = clamp(dB+12, 0, 60)."""
+    code = max(0, min(60, db + 12))
+    return bytes([C0_ADC_GAIN, 0x00, 0x00, 0x00, 0x40 | code])
+
+
+def ep2_packet(seq: int, cc_a: bytes, cc_b: bytes) -> bytes:
+    """EP2 host→radio packet: two frames, each carrying one C&C register.
+    TX payload is zero (RX-only). cc_* must be exactly 5 bytes (C0..C4)."""
+    assert len(cc_a) == 5 and len(cc_b) == 5
+    frame_a = SYNC + cc_a + bytes(504)
+    frame_b = SYNC + cc_b + bytes(504)
+    return bytes([0xEF, 0xFE, 0x01, 0x02]) + struct.pack(">I", seq) + frame_a + frame_b
+
+
+def parse_ep6(pkt: bytes):
+    """Return (seq, n_samples, peak_abs, sumsq, sync_ok) or None if not an EP6 packet.
+    Accumulates level stats rather than materializing all samples."""
+    if len(pkt) < 1032 or pkt[0] != 0xEF or pkt[1] != 0xFE or pkt[2] != 0x01 or pkt[3] != 0x06:
+        return None
+    seq = struct.unpack(">I", pkt[4:8])[0]
+    n, peak, sumsq, sync_ok = 0, 0, 0.0, True
+    for fstart in (8, 520):
+        frame = pkt[fstart:fstart + 512]
+        if frame[0:3] != SYNC:
+            sync_ok = False
+            continue
+        payload = frame[8:512]
+        for k in range(0, 504, 8):
+            i = int.from_bytes(payload[k:k + 3], "big", signed=True)
+            q = int.from_bytes(payload[k + 3:k + 6], "big", signed=True)
+            a = abs(i) if abs(i) > abs(q) else abs(q)
+            if a > peak:
+                peak = a
+            sumsq += float(i) * i + float(q) * q
+            n += 1
+    return seq, n, peak, sumsq, sync_ok
+
+
+def iq_samples(pkt: bytes):
+    """Yield (I, Q) tuples from an EP6 packet — for FFT/spectrum use."""
+    if len(pkt) < 1032:
+        return
+    for fstart in (8, 520):
+        frame = pkt[fstart:fstart + 512]
+        if frame[0:3] != SYNC:
+            continue
+        payload = frame[8:512]
+        for k in range(0, 504, 8):
+            i = int.from_bytes(payload[k:k + 3], "big", signed=True)
+            q = int.from_bytes(payload[k + 3:k + 6], "big", signed=True)
+            yield i, q

--- a/prototypes/hl2/spectrum.py
+++ b/prototypes/hl2/spectrum.py
@@ -51,12 +51,14 @@ def capture(sock, dst, freq, speed_code, gain_db, nsamp, settle):
                 data, _ = sock.recvfrom(2048)
             except socket.timeout:
                 continue
-            s = hpsdr.parse_ep6(data)
-            if s is None:
+            seq_rx = hpsdr.ep6_seq(data)     # cheap header read; iq_samples decodes
+            if seq_rx is None:
                 continue
-            if exp is not None and s[0] != exp:
-                drops += (s[0] - exp) & 0xFFFFFFFF
-            exp = (s[0] + 1) & 0xFFFFFFFF
+            if exp is not None and seq_rx != exp:
+                gap = (seq_rx - exp) & 0xFFFFFFFF
+                if gap < 0x80000000:         # forward gap = real loss; the reverse
+                    drops += gap             # half = a reordered/dup packet
+            exp = (seq_rx + 1) & 0xFFFFFFFF
             if time.monotonic() - t0 > settle:           # let AGC/NCO settle first
                 for i, q in hpsdr.iq_samples(data):
                     I.append(i); Q.append(q)
@@ -77,9 +79,10 @@ def panadapter(iq, freq, rate, bins):
     mag = np.abs(X) / (np.sum(w) / 2)                    # coherent-gain normalized
     dbfs = 20 * np.log10(mag / hpsdr.FULL_SCALE + 1e-12)
 
-    # bin the FFT down to `bins` columns across the full span, taking the peak per column
-    step = len(dbfs) // bins
-    cols = [dbfs[c * step:(c + 1) * step].max() for c in range(bins)]
+    # bin the FFT down to `bins` columns across the full span, taking the peak per
+    # column. array_split covers the whole spectrum (distributes the remainder), so
+    # no high-frequency bins are dropped when len(dbfs) isn't a multiple of bins.
+    cols = [chunk.max() for chunk in np.array_split(dbfs, bins)]
     lo, hi = min(cols), max(cols)
     span = rate / 1e6
     dc_dbfs = 20 * np.log10(abs(dc) / hpsdr.FULL_SCALE + 1e-12)

--- a/prototypes/hl2/spectrum.py
+++ b/prototypes/hl2/spectrum.py
@@ -84,7 +84,6 @@ def panadapter(iq, freq, rate, bins):
     # no high-frequency bins are dropped when len(dbfs) isn't a multiple of bins.
     cols = [chunk.max() for chunk in np.array_split(dbfs, bins)]
     lo, hi = min(cols), max(cols)
-    span = rate / 1e6
     dc_dbfs = 20 * np.log10(abs(dc) / hpsdr.FULL_SCALE + 1e-12)
     print(f"\n  RX1 {freq/1e6:.6f} MHz   span ±{rate/2000:.1f} kHz ({rate/1000:.0f} kHz)"
           f"   floor {lo:.0f} … peak {hi:.0f} dBFS   (DC offset {dc_dbfs:.0f} dBFS, removed)")

--- a/prototypes/hl2/spectrum.py
+++ b/prototypes/hl2/spectrum.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""HL2 spectrum smoke test — FFT the raw IQ into a first panadapter (phase 0.4).
+
+This is the payoff of the spike: it proves the whole raw-IQ data plane end to
+end. Unlike Flex (which ships a hardware spectrum), HL2 ships raw IQ and the
+*client* must FFT it. Here we tune RX1, capture a block of IQ, and render an
+ASCII panadapter — the exact job the eventual Hl2Backend does internally before
+emitting a normalized spectrumFrameReady.
+
+Validated live: tuning to WWV (10 MHz) puts a strong carrier at baseband DC with
+audible-band sidebands, and the noise floor sits ~50 dB down — a real, known
+station resolved by our own FFT.
+
+Protocol facts (register map, CONFIG_MERCURY ADC-select, LNA gain) are grounded
+in hpsdr.py — consulted clean-room from the HL2 wiki + pihpsdr reference client
+(see ../../THIRD_PARTY_LICENSES), never guessed. RX-only: every C0 is even so
+MOX stays 0 — this cannot key the radio.
+
+Run:  python3 spectrum.py --host 192.168.50.99 --freq 10000000 [--rate 48000]
+                          [--gain 20] [--seconds 1.5] [--bins 64]
+"""
+
+import argparse
+import socket
+import sys
+import time
+
+import numpy as np
+
+import hpsdr
+
+SPEED = {48000: 0, 96000: 1, 192000: 2, 384000: 3}
+
+
+def capture(sock, dst, freq, speed_code, gain_db, nsamp, settle):
+    """Round-robin config+gain+freq, discard `settle` seconds, return complex IQ."""
+    regs = [hpsdr.cc_config(speed=speed_code, n_rx=1),
+            hpsdr.cc_rx_gain(gain_db),
+            hpsdr.cc_rx1_freq(freq)]
+    sock.sendto(hpsdr.metis_command(0x01), dst)          # start IQ
+    seq = ri = 0
+    I, Q = [], []
+    drops = 0
+    exp = None
+    t0 = time.monotonic()
+    try:
+        while len(I) < nsamp and time.monotonic() - t0 < settle + 8:
+            sock.sendto(hpsdr.ep2_packet(seq, regs[ri % 3], regs[(ri + 1) % 3]), dst)
+            seq += 1; ri += 1
+            try:
+                data, _ = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            s = hpsdr.parse_ep6(data)
+            if s is None:
+                continue
+            if exp is not None and s[0] != exp:
+                drops += (s[0] - exp) & 0xFFFFFFFF
+            exp = (s[0] + 1) & 0xFFFFFFFF
+            if time.monotonic() - t0 > settle:           # let AGC/NCO settle first
+                for i, q in hpsdr.iq_samples(data):
+                    I.append(i); Q.append(q)
+    finally:
+        sock.sendto(hpsdr.metis_command(0x00), dst)      # stop
+    iq = np.array(I[:nsamp], dtype=float) + 1j * np.array(Q[:nsamp], dtype=float)
+    return iq, drops
+
+
+def panadapter(iq, freq, rate, bins):
+    """Render an ASCII spectrum, dBFS, DC-centered — the first HL2 panadapter."""
+    if len(iq) < bins * 4:
+        print(f"✗ too few samples ({len(iq)}) for a {bins}-bin FFT"); return
+    dc = iq.mean()
+    x = iq - dc                                          # drop the (large) DC offset
+    w = np.hanning(len(x))
+    X = np.fft.fftshift(np.fft.fft(x * w))
+    mag = np.abs(X) / (np.sum(w) / 2)                    # coherent-gain normalized
+    dbfs = 20 * np.log10(mag / hpsdr.FULL_SCALE + 1e-12)
+
+    # bin the FFT down to `bins` columns across the full span, taking the peak per column
+    step = len(dbfs) // bins
+    cols = [dbfs[c * step:(c + 1) * step].max() for c in range(bins)]
+    lo, hi = min(cols), max(cols)
+    span = rate / 1e6
+    dc_dbfs = 20 * np.log10(abs(dc) / hpsdr.FULL_SCALE + 1e-12)
+    print(f"\n  RX1 {freq/1e6:.6f} MHz   span ±{rate/2000:.1f} kHz ({rate/1000:.0f} kHz)"
+          f"   floor {lo:.0f} … peak {hi:.0f} dBFS   (DC offset {dc_dbfs:.0f} dBFS, removed)")
+    print("  " + "─" * (bins + 12))
+    for c in range(bins):
+        off = (-rate / 2 + rate * c / bins) / 1000       # kHz from center
+        v = cols[c]
+        bar = int((v - lo) / max(1e-9, hi - lo) * 40)
+        mark = "◆" if c == bins // 2 else " "            # center (tuned freq)
+        print(f"  {off:+7.1f} kHz {v:6.1f} {mark}{'█' * bar}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="HL2 IQ → panadapter (phase 0.4)")
+    ap.add_argument("--host", default="192.168.50.99")
+    ap.add_argument("--freq", type=int, default=10_000_000, help="RX1 Hz (default 10 MHz / WWV)")
+    ap.add_argument("--rate", type=int, default=48000, choices=list(SPEED))
+    ap.add_argument("--gain", type=int, default=20, help="LNA gain dB, -12..+48")
+    ap.add_argument("--seconds", type=float, default=1.5, help="capture length after settle")
+    ap.add_argument("--bins", type=int, default=64, help="panadapter columns")
+    args = ap.parse_args()
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1 << 21)
+    s.bind(("", 0)); s.settimeout(1.0)
+    dst = (args.host, hpsdr.METIS_PORT)
+
+    nsamp = int(args.rate * args.seconds)
+    print(f"→ capture {nsamp} IQ samples @ {args.rate/1000:.0f} kHz, "
+          f"RX1={args.freq/1e6:.4f} MHz, gain {args.gain:+d} dB ...")
+    iq, drops = capture(s, dst, args.freq, SPEED[args.rate], args.gain, nsamp, settle=0.6)
+    s.close()
+    if len(iq) < nsamp // 2:
+        print(f"✗ only {len(iq)} samples — check link / gateware."); return 1
+    if drops:
+        print(f"  ({drops} packets dropped — WiFi jitter; prefer wired for clean IQ)")
+    panadapter(iq, args.freq, args.rate, args.bins)
+    print("\n  ◆ = tuned frequency (baseband DC). A carrier there = exact tune; "
+          "a raised, shaped floor = live band noise. Data plane proven.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prototypes/hl2/stream.py
+++ b/prototypes/hl2/stream.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""HL2 IQ stream smoke test — HPSDR Protocol 1 (Metis) EP6 ingest.
+
+Phase-0.2 spike (see README.md): start the radio, receive the raw-IQ torrent,
+parse the HPSDR frames, and report whether the data plane is clean (sequence
+gaps = dropped UDP packets) and whether there's real signal (IQ level). This is
+the step that proves the *thing HL2 fundamentally needs and Flex never did* —
+raw-IQ ingest — is workable.
+
+Deliberately does NOT tune (set the RX NCO frequency): that needs the exact
+Protocol-1 register map, which belongs in tune.py sourced from the HL2 gateware /
+HPSDR spec (Principle I). Here the RX runs at its post-reset default; we're
+proving transport + framing, not looking at a specific band yet.
+
+Protocol authority: HPSDR "Metis - How it works"; Hermes-Lite 2 wiki/gateware.
+
+Wire summary:
+  start  → 0xEF 0xFE 0x04 0x01  (pad to 64 B) to host:1024   (0x00 = stop)
+  EP6 in ← 1032 B: EF FE 01 06 | seq[4] | frame512 | frame512   (radio → us)
+    each 512-B frame: 7F 7F 7F | C0..C4 (5 B C&C) | 504 B samples
+    504 B = 63 samples × 8 B; sample = I[3] Q[3] mic[2], I/Q are 24-bit signed BE
+  EP2 out→ 1032 B: EF FE 01 02 | seq[4] | frame512 | frame512   (us → radio)
+    we send all-zero C&C keep-alive to sustain the stream (paced 1:1 with EP6)
+
+Run:  python3 stream.py --host 192.168.50.99 [--seconds 3]
+Read-only-ish: opens an RX stream. Won't key TX (C&C MOX bit stays 0). Sends a
+stop on exit. If another client is already streaming, discovery showed [idle] so
+you're clear.
+"""
+
+import argparse
+import math
+import socket
+import struct
+import sys
+import time
+
+METIS_PORT = 1024
+SYNC = b"\x7f\x7f\x7f"
+FULL_SCALE = 1 << 23  # 24-bit signed full scale (8388608)
+
+
+def metis_command(cmd: int) -> bytes:
+    # 0xEF 0xFE 0x04 <cmd> padded to 64 bytes. cmd bit0 = IQ on.
+    return bytes([0xEF, 0xFE, 0x04, cmd]) + bytes(60)
+
+
+def ep2_keepalive(seq: int) -> bytes:
+    # EP2 (host→radio). Two 512-B frames, each: sync + 5 all-zero C&C + 504 zero
+    # TX bytes. All-zero C&C = register 0, defaults (48 kHz, 1 RX, MOX off) — safe
+    # keep-alive; real config/tuning is tune.py's job.
+    frame = SYNC + bytes(5) + bytes(504)
+    return bytes([0xEF, 0xFE, 0x01, 0x02]) + struct.pack(">I", seq) + frame + frame
+
+
+def parse_ep6(pkt: bytes):
+    """Return (seq, n_samples, peak_abs, sumsq, sync_ok) or None if not EP6."""
+    if len(pkt) < 1032 or pkt[0] != 0xEF or pkt[1] != 0xFE or pkt[2] != 0x01 or pkt[3] != 0x06:
+        return None
+    seq = struct.unpack(">I", pkt[4:8])[0]
+    n = 0
+    peak = 0
+    sumsq = 0.0
+    sync_ok = True
+    for fstart in (8, 520):
+        frame = pkt[fstart:fstart + 512]
+        if frame[0:3] != SYNC:
+            sync_ok = False
+            continue
+        payload = frame[8:512]           # 504 bytes = 63 samples
+        for k in range(0, 504, 8):
+            i = int.from_bytes(payload[k:k + 3], "big", signed=True)
+            q = int.from_bytes(payload[k + 3:k + 6], "big", signed=True)
+            # payload[k+6:k+8] = mic/line-in, ignored for RX
+            a = abs(i) if abs(i) > abs(q) else abs(q)
+            if a > peak:
+                peak = a
+            sumsq += float(i) * i + float(q) * q
+            n += 1
+    return seq, n, peak, sumsq, sync_ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="HL2 IQ stream smoke test")
+    ap.add_argument("--host", default="192.168.50.99", help="HL2 IP")
+    ap.add_argument("--seconds", type=float, default=3.0)
+    ap.add_argument("--rate", type=int, default=48000, help="assumed sample rate for the estimate")
+    args = ap.parse_args()
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1 << 20)
+    s.bind(("", 0))
+    s.settimeout(1.0)
+    dst = (args.host, METIS_PORT)
+
+    print(f"→ start IQ stream from {args.host}:{METIS_PORT} for {args.seconds}s ...")
+    ep2_seq = 0
+    s.sendto(metis_command(0x01), dst)          # start
+    for _ in range(2):                          # prime the radio's input buffer
+        s.sendto(ep2_keepalive(ep2_seq), dst); ep2_seq += 1
+
+    pkts = 0
+    total_samples = 0
+    peak = 0
+    sumsq = 0.0
+    sync_bad = 0
+    expected_seq = None
+    dropped = 0
+    non_ep6 = 0
+    t0 = time.monotonic()
+    try:
+        while time.monotonic() - t0 < args.seconds:
+            try:
+                data, _ = s.recvfrom(2048)
+            except socket.timeout:
+                print("  (timeout waiting for EP6 — no data flowing)")
+                continue
+            r = parse_ep6(data)
+            if r is None:
+                non_ep6 += 1
+                continue
+            seq, n, pk, ss, sync_ok = r
+            if expected_seq is not None and seq != expected_seq:
+                gap = (seq - expected_seq) & 0xFFFFFFFF
+                dropped += gap
+            expected_seq = (seq + 1) & 0xFFFFFFFF
+            pkts += 1
+            total_samples += n
+            if pk > peak:
+                peak = pk
+            sumsq += ss
+            if not sync_ok:
+                sync_bad += 1
+            s.sendto(ep2_keepalive(ep2_seq), dst); ep2_seq += 1   # 1:1 pace
+    finally:
+        s.sendto(metis_command(0x00), dst)      # stop
+        s.close()
+
+    elapsed = time.monotonic() - t0
+    print(f"\n── results ({elapsed:.2f}s) ─────────────────────────────")
+    if pkts == 0:
+        print("✗ no EP6 IQ packets received. Try the wired interface (--host "
+              "169.254.x), check firewall on :1024, confirm gateware streams on start.")
+        print(f"  non-EP6 packets seen: {non_ep6}")
+        return 1
+    exp = pkts + dropped
+    drop_pct = 100.0 * dropped / exp if exp else 0.0
+    rate_est = total_samples / elapsed if elapsed else 0
+    rms = math.sqrt(sumsq / (2 * total_samples)) if total_samples else 0.0
+    peak_dbfs = 20 * math.log10(peak / FULL_SCALE) if peak else float("-inf")
+    rms_dbfs = 20 * math.log10(rms / FULL_SCALE) if rms else float("-inf")
+
+    print(f"✓ EP6 packets:     {pkts}")
+    print(f"  IQ samples:      {total_samples}  (~{rate_est/1000:.1f} k/s; "
+          f"assumed rate {args.rate/1000:.0f} kHz)")
+    print(f"  dropped packets: {dropped}  ({drop_pct:.2f}%)   "
+          f"{'← WiFi jitter, expected' if drop_pct > 0.5 else 'clean'}")
+    print(f"  frame sync bad:  {sync_bad}   non-EP6: {non_ep6}")
+    print(f"  IQ level:        peak {peak_dbfs:+.1f} dBFS, rms {rms_dbfs:+.1f} dBFS "
+          f"{'(signal present)' if peak_dbfs > -80 else '(near floor)'}")
+    print("\nData plane is workable — next: tune.py (set RX NCO) + spectrum.py (FFT).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prototypes/hl2/stream.py
+++ b/prototypes/hl2/stream.py
@@ -31,53 +31,24 @@ you're clear.
 import argparse
 import math
 import socket
-import struct
 import sys
 import time
 
-METIS_PORT = 1024
-SYNC = b"\x7f\x7f\x7f"
-FULL_SCALE = 1 << 23  # 24-bit signed full scale (8388608)
+import hpsdr
 
-
-def metis_command(cmd: int) -> bytes:
-    # 0xEF 0xFE 0x04 <cmd> padded to 64 bytes. cmd bit0 = IQ on.
-    return bytes([0xEF, 0xFE, 0x04, cmd]) + bytes(60)
+# One shared wire definition for the whole spike: framing, register map, and
+# parse_ep6 all live in hpsdr.py (Principle I) — don't re-implement them here.
+METIS_PORT = hpsdr.METIS_PORT
+FULL_SCALE = hpsdr.FULL_SCALE
+metis_command = hpsdr.metis_command
+parse_ep6 = hpsdr.parse_ep6
 
 
 def ep2_keepalive(seq: int) -> bytes:
-    # EP2 (host→radio). Two 512-B frames, each: sync + 5 all-zero C&C + 504 zero
-    # TX bytes. All-zero C&C = register 0, defaults (48 kHz, 1 RX, MOX off) — safe
-    # keep-alive; real config/tuning is tune.py's job.
-    frame = SYNC + bytes(5) + bytes(504)
-    return bytes([0xEF, 0xFE, 0x01, 0x02]) + struct.pack(">I", seq) + frame + frame
-
-
-def parse_ep6(pkt: bytes):
-    """Return (seq, n_samples, peak_abs, sumsq, sync_ok) or None if not EP6."""
-    if len(pkt) < 1032 or pkt[0] != 0xEF or pkt[1] != 0xFE or pkt[2] != 0x01 or pkt[3] != 0x06:
-        return None
-    seq = struct.unpack(">I", pkt[4:8])[0]
-    n = 0
-    peak = 0
-    sumsq = 0.0
-    sync_ok = True
-    for fstart in (8, 520):
-        frame = pkt[fstart:fstart + 512]
-        if frame[0:3] != SYNC:
-            sync_ok = False
-            continue
-        payload = frame[8:512]           # 504 bytes = 63 samples
-        for k in range(0, 504, 8):
-            i = int.from_bytes(payload[k:k + 3], "big", signed=True)
-            q = int.from_bytes(payload[k + 3:k + 6], "big", signed=True)
-            # payload[k+6:k+8] = mic/line-in, ignored for RX
-            a = abs(i) if abs(i) > abs(q) else abs(q)
-            if a > peak:
-                peak = a
-            sumsq += float(i) * i + float(q) * q
-            n += 1
-    return seq, n, peak, sumsq, sync_ok
+    # EP2 (host→radio) keep-alive: two frames of all-zero C&C = register 0,
+    # defaults (48 kHz, 1 RX, MOX off) — sustains the stream without configuring
+    # anything. Real config/tuning is tune.py's job.
+    return hpsdr.ep2_packet(seq, bytes(5), bytes(5))
 
 
 def main() -> int:
@@ -122,7 +93,8 @@ def main() -> int:
             seq, n, pk, ss, sync_ok = r
             if expected_seq is not None and seq != expected_seq:
                 gap = (seq - expected_seq) & 0xFFFFFFFF
-                dropped += gap
+                if gap < 0x80000000:       # forward gap = real loss; the reverse
+                    dropped += gap         # half = a reordered/dup packet, not loss
             expected_seq = (seq + 1) & 0xFFFFFFFF
             pkts += 1
             total_samples += n

--- a/prototypes/hl2/tune.py
+++ b/prototypes/hl2/tune.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""HL2 tune smoke test — set the RX1 NCO frequency (HPSDR Protocol 1, #4092/HL2).
+
+Phase-0.3 spike (see README.md): prove we can point receiver 1 at a chosen
+frequency via the C&C register map (grounded in hpsdr.py from the HL2 wiki, NOT
+guessed), then confirm the radio keeps streaming and report the IQ level there.
+
+Safety: only writes register 0x00 (config) and 0x02 (RX1 freq). Never touches
+register 0x01 (TX NCO). Every C0 is even → MOX bit = 0 → cannot key the radio.
+
+Run:  python3 tune.py --host 192.168.50.99 --freq 10000000 [--rate 48000] [--seconds 2]
+      # --scan LOW HIGH STEP  → step RX1 across a range, print level per freq
+"""
+
+import argparse
+import math
+import socket
+import sys
+import time
+
+import hpsdr
+
+
+SPEED = {48000: 0, 96000: 1, 192000: 2, 384000: 3}
+
+
+def dbfs(v: float) -> float:
+    return 20 * math.log10(v / hpsdr.FULL_SCALE) if v > 0 else float("-inf")
+
+
+def measure(sock, dst, freq: int, speed_code: int, seconds: float, seq0: int,
+            gain_db: int = 20):
+    """Tune RX1 to freq, stream for `seconds`, return (peak_dbfs, rms_dbfs, pkts, drops, seq).
+
+    Round-robins the three registers a working RX needs: config (with the
+    CONFIG_MERCURY ADC-select bit), ADC gain, and the RX1 NCO frequency. Sending
+    only config+freq (no gain, and pre-fix no Mercury bit) yields flat noise."""
+    seq = seq0
+    regs = [hpsdr.cc_config(speed=speed_code, n_rx=1),
+            hpsdr.cc_rx_gain(gain_db),
+            hpsdr.cc_rx1_freq(freq)]
+    ri = 0
+    for _ in range(6):                       # prime: latch all three registers twice
+        sock.sendto(hpsdr.ep2_packet(seq, regs[ri % 3], regs[(ri + 1) % 3]), dst)
+        seq += 1; ri += 1
+
+    pkts, samples, peak, sumsq, drops = 0, 0, 0, 0.0, 0
+    exp = None
+    t0 = time.monotonic()
+    while time.monotonic() - t0 < seconds:
+        try:
+            data, _ = sock.recvfrom(2048)
+        except socket.timeout:
+            continue
+        r = hpsdr.parse_ep6(data)
+        if r is None:
+            continue
+        s, n, pk, ss, _ = r
+        if exp is not None and s != exp:
+            drops += (s - exp) & 0xFFFFFFFF
+        exp = (s + 1) & 0xFFFFFFFF
+        pkts += 1; samples += n; sumsq += ss
+        if pk > peak:
+            peak = pk
+        sock.sendto(hpsdr.ep2_packet(seq, regs[ri % 3], regs[(ri + 1) % 3]), dst)
+        seq += 1; ri += 1                    # keep all three registers refreshed, 1:1 pace
+    rms = math.sqrt(sumsq / (2 * samples)) if samples else 0.0
+    return dbfs(peak), dbfs(rms), pkts, drops, seq
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="HL2 RX1 tune smoke test")
+    ap.add_argument("--host", default="192.168.50.99")
+    ap.add_argument("--freq", type=int, default=10_000_000, help="RX1 Hz (default 10 MHz / WWV)")
+    ap.add_argument("--rate", type=int, default=48000, choices=list(SPEED))
+    ap.add_argument("--seconds", type=float, default=2.0)
+    ap.add_argument("--gain", type=int, default=20, help="LNA gain dB, -12..+48 (default 20)")
+    ap.add_argument("--scan", nargs=3, type=int, metavar=("LOW", "HIGH", "STEP"),
+                    help="sweep RX1 across LOW..HIGH by STEP (Hz), print level per freq")
+    args = ap.parse_args()
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 1 << 20)
+    s.bind(("", 0)); s.settimeout(1.0)
+    dst = (args.host, hpsdr.METIS_PORT)
+    speed_code = SPEED[args.rate]
+
+    s.sendto(hpsdr.metis_command(0x01), dst)   # start IQ
+    seq = 0
+    try:
+        if args.scan:
+            lo, hi, step = args.scan
+            print(f"scan {lo/1e6:.3f}–{hi/1e6:.3f} MHz step {step/1e3:.0f} kHz "
+                  f"@ {args.rate/1000:.0f} kHz, {args.seconds}s/step:")
+            for f in range(lo, hi + 1, step):
+                pk, rms, pkts, drops, seq = measure(s, dst, f, speed_code, args.seconds, seq, args.gain)
+                bar = "#" * max(0, int((pk + 100) / 2))
+                print(f"  {f/1e6:8.3f} MHz  peak {pk:+6.1f} dBFS  {bar}")
+        else:
+            print(f"→ tune RX1 = {args.freq/1e6:.6f} MHz @ {args.rate/1000:.0f} kHz "
+                  f"(C0=0x{hpsdr.C0_RX1_FREQ:02x}, C1..C4={hpsdr.cc_rx1_freq(args.freq)[1:].hex()})")
+            pk, rms, pkts, drops, seq = measure(s, dst, args.freq, speed_code, args.seconds, seq, args.gain)
+            if pkts == 0:
+                print("✗ no IQ after tune — check link / gateware."); return 1
+            print(f"✓ streaming after tune: {pkts} pkts, {drops} dropped")
+            print(f"  IQ level @ {args.freq/1e6:.3f} MHz: peak {pk:+.1f} dBFS, rms {rms:+.1f} dBFS")
+            print("  (visual confirmation of the exact tune is spectrum.py's FFT)")
+    finally:
+        s.sendto(hpsdr.metis_command(0x00), dst); s.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prototypes/hl2/tune.py
+++ b/prototypes/hl2/tune.py
@@ -57,7 +57,9 @@ def measure(sock, dst, freq: int, speed_code: int, seconds: float, seq0: int,
             continue
         s, n, pk, ss, _ = r
         if exp is not None and s != exp:
-            drops += (s - exp) & 0xFFFFFFFF
+            gap = (s - exp) & 0xFFFFFFFF
+            if gap < 0x80000000:             # forward gap = real loss; the reverse
+                drops += gap                 # half = a reordered/dup packet
         exp = (s + 1) & 0xFFFFFFFF
         pkts += 1; samples += n; sumsq += ss
         if pk > peak:


### PR DESCRIPTION
## What

Groundwork for a Hermes-Lite 2 `IRadioBackend` under the accepted aetherd RFC — a **data-plane spike** (proven against real hardware) plus the **design note** that AGENTS.md requires before any new-radio-family code lands. No engine/UI code changes; this is docs, attribution, and a throwaway Python spike.

## The spike (`prototypes/hl2/`) — data plane PROVEN

Validated live against an AetherSDR-owned HL2 (gateware 7.4), HPSDR Protocol 1 / Metis over UDP:1024:

- Discovery (board id `0x06`), EP2/EP6 1032-byte framing, **0.00% loss**
- Sample-rate control (48/96/192/384 kHz)
- **RX1 NCO tuning** (`C0=0x04`) — **WWV 10 MHz lands exactly at baseband DC, ~50 dB over the noise floor**
- The non-obvious find: config register needs **`CONFIG_MERCURY`** (C1 bit 6) to select the ADC as the DDC source — without it the stream is flat ADC-floor noise at every frequency
- LNA gain (`C0=0x14`, `C4 = 0x40 | (dB+12)`), and an end-to-end FFT panadapter

Phases discover→stream→tune→gain→FFT all pass (`prototypes/hl2/README.md`).

## The design note (`docs/architecture/aetherd-hl2-backend-design.md`)

**Draft for maintainer review — this is the AGENTS.md "new radio family" gate.** Highlights:

- HL2 is the **first raw-IQ backend** — it owns an engine-side DSP chain below the seam and emits the same normalized `IRadioBackend` signals, exactly the case `IRadioBackend.h:50-53` anticipates.
- Full **seam verb/signal → HL2 mechanism** mapping (grounded in the spike). Key HL2-vs-Flex difference: `setSliceMode`/`setSliceFilter` configure *engine DSP*, not hardware.
- **Capabilities:** `canTransmit=false` (RFC §6 guard denies keying), no extension namespaces (matching FlexBackend's deliberate precedent until the step-3 encode path exists).
- **The two structural gaps HL2 forces closed** — FlexBackend is hard-wired in RadioModel (no factory) and its data plane bypasses the seam via `PanadapterStream`. HL2 has neither, forcing (A) a minimal backend-selection seam and (B) a Phase-1 relay of the existing frame types. Both closable **without** waiting on step-3/step-4.
- TX, multi-RX, vendor extensions, discovery-driven selection — **explicitly deferred.**

**Two decisions flagged for maintainers** (design note §8): factory-now vs defer, and relay-existing-frame-types vs early step-4 bridge. Both carry a recommendation.

## Clean-room provenance

Protocol facts (not code) consulted clean-room from openHPSDR Protocol 1 (GPL-2.0), the Hermes-Lite 2 wiki/gateware, and pihpsdr (GPL-3.0). No code incorporated. Recorded under Protocol References in `THIRD_PARTY_LICENSES`, matching the existing FlexLib/KiwiSDR pattern.

## Review scope

Primarily a **design-note review** (approve the new-family plan) plus the attribution entry. The `prototypes/hl2/` spike is proof/reference and is intentionally throwaway (not built or CI-tested). No C++ changes → nothing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)