### PR TITLE
fix(tci): keep CW skimmer DDS aligned with the pan center

### DIFF
--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2408,8 +2408,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
-        if (const auto* pan = m_radioModel.panadapter(applet->panId()))
+        if (auto* pan = m_radioModel.panadapter(applet->panId())) {
             center = std::max(center, pan->bandwidthMhz() / 2.0);
+            // The radio may acknowledge this command without echoing a display
+            // status to the setting client. Keep the canonical model aligned
+            // with the visible pan so TCI dds: follows the IQ center.
+            pan->setCenterBandwidth(center, -1.0);
+        }
         m_radioModel.sendCommand(
             QString("display pan set %1 center=%2").arg(applet->panId()).arg(center, 0, 'f', 6));
     });

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -45,6 +45,10 @@ public:
     // other). Emits infoChanged when either value changes or when the center
     // is populated for the first time (even if it equals the placeholder).
     void setCenterBandwidth(double centerMhz, double bandwidthMhz);
+    // A reclaimed model retains its numeric display state while reconnecting,
+    // but that previous-session center is not authoritative until the radio
+    // reports the new session's pan state.
+    void resetCenterKnownForReconnect() { m_centerKnown = false; }
     // Normalized display-level-range setter driven by the backend (aetherd RFC
     // 2.3, second universal pan field). NaN for either bound means "leave
     // unchanged" (dBm is signed, so no numeric sentinel is safe). Emits

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2454,6 +2454,11 @@ void RadioModel::setPanCenter(double centerMhz)
 {
     if (m_activePanId.isEmpty()) return;
     if (PanadapterModel* pan = panadapter(m_activePanId)) {
+        // Clamp so the pan's low edge stays >= 0 Hz, matching the spectrum
+        // pan-drag path (MainWindow_Wiring wirePanadapter). Without it an
+        // out-of-range center would be optimistically stored and advertised via
+        // TCI dds: even though the radio rejects it.
+        centerMhz = std::max(centerMhz, pan->bandwidthMhz() / 2.0);
         pan->setCenterBandwidth(centerMhz, -1.0);
     }
     sendCmd(

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2453,6 +2453,9 @@ void RadioModel::setPanBandwidth(double bandwidthMhz)
 void RadioModel::setPanCenter(double centerMhz)
 {
     if (m_activePanId.isEmpty()) return;
+    if (PanadapterModel* pan = panadapter(m_activePanId)) {
+        pan->setCenterBandwidth(centerMhz, -1.0);
+    }
     sendCmd(
         QString("display pan set %1 center=%2")
             .arg(m_activePanId).arg(centerMhz, 0, 'f', 6));
@@ -2650,6 +2653,7 @@ void RadioModel::stageSessionModelsForReconnect()
         if (it.value()) {
             it.value()->setResized(false);
             it.value()->setWaterfallConfigured(false);
+            it.value()->resetCenterKnownForReconnect();
             m_stalePanadapters.insert(it.key(), it.value());
         }
     }

--- a/tests/aetherd_pan_decode_test.cpp
+++ b/tests/aetherd_pan_decode_test.cpp
@@ -365,6 +365,17 @@ int main(int argc, char** argv)
         pan.setCenterBandwidth(7.15, -1.0);
         CHECK(info.count() == 0);
 
+        // Reconnect staging may retain the model object, but its old numeric
+        // center must not remain authoritative for TCI dds: in the new session.
+        pan.resetCenterKnownForReconnect();
+        CHECK(pan.centerKnown() == false);
+        CHECK(qFuzzyCompare(pan.centerMhz(), 7.15));
+        CHECK(info.count() == 0);
+        pan.setCenterBandwidth(7.15, -1.0);
+        CHECK(pan.centerKnown() == true);
+        CHECK(info.count() == 1);
+        info.clear();
+
         // setRange: NaN = "leave unchanged" (max held, only min moves); returns
         // whether anything changed (gates the setDbmRange side-effect).
         QSignalSpy lvl(&pan, &PanadapterModel::levelChanged);


### PR DESCRIPTION

<img width="1691" height="1613" alt="image" src="https://github.com/user-attachments/assets/2dfcac64-a8ef-46be-86a9-cceada337c12" />

## What

Keeps the TCI `dds:` IQ-center notification synchronized with the panadapter center that the operator actually sees, and prevents a reclaimed panadapter model from advertising the previous radio session's center as current state.

This hardens the SDC/CW-skimmer support added in #3913.

## Why

TCI skimmers map each decoded IQ offset to an RF frequency using `dds:`. For Flex DAX IQ, that value must be the panadapter center rather than the slice/VFO frequency.

The original synchronization work listened for `PanadapterModel::infoChanged`, but one common pan-drag path only sent:

```text
display pan set <panId> center=<MHz>
```

The FLEX-8400M used for testing acknowledges that command without reliably echoing a `display pan` center status to the setting client. The spectrum could therefore move visibly while the canonical pan model—and consequently TCI `dds:`—remained at the old center. SDC then displayed or spotted signals at an offset from the AetherSDR pan.

Separately, reconnect staging deliberately retains panadapter model objects. The new `centerKnown` flag from #3913 was not reset during staging, so a reclaimed model could briefly present the preceding session's center as authoritative before fresh radio status arrived.

## Changes

- Optimistically apply a user pan-center drag to `PanadapterModel` before sending the radio command, matching the existing explicit pan-range and tune-centering paths.
- Apply the same canonical-model update in `RadioModel::setPanCenter`, which is used by automation and other model-level callers.
- Reset only the center-authority flag when staging pan models for reconnect. The numeric center remains available for display continuity, but TCI falls back until the new session supplies authoritative pan state.
- Extend `aetherd_pan_decode_test` to pin the unknown → known → reconnect-unknown → repopulated lifecycle, including signal emission behavior.

The radio remains authoritative: a later radio status update still reconciles the optimistic center if the requested value differs from the value the radio accepts.

## User impact

- SDC/CW Skimmer frequency labels and emitted spots follow AetherSDR pan recentering immediately.
- A reconnect cannot leak the previous session's pan center into the new TCI initialization window.
- Slice AGC, filter, and audio-DSP behavior is unchanged; the change is limited to the pan/DAX-IQ frequency reference.

## Verification

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo` — PASS
- `cmake --build build -j8` — PASS (macOS arm64, RelWithDebInfo)
- `ctest --test-dir build -R 'tci_protocol_test|aetherd_pan_decode_test|panadapter_model_rx_antenna_test' --output-on-failure` — 3/3 PASS
- `python3 tools/check_engine_boundary.py --strict` — PASS, 0 blocking findings
- `python3 tools/check_a11y.py` — PASS, existing warnings only
- `git diff --check` — PASS
- Signed commit verified with `git log --show-signature -1`

### Live RX-only result

Tested with a FLEX-8400M running firmware `4.2.18.41174` in an available MultiFlex slot. Transmit state remained false.

The operator confirmed that AetherSDR and SDC pan frequencies aligned at startup. SDC then decoded both sides of a real 40 m CW QSO at a high decode percentage, repeatedly recognized `KN6BAZ`, placed its marker on the visible signal near 7.0375 MHz, and emitted a spot that appeared at the correct frequency in AetherSDR. This exercises the full IQ → DDS mapping → decode → spot round trip.

## Automation follow-up

A useful follow-up verb would expose the last TCI `vfo:` and `dds:` values per receiver, plus the achieved IQ sample rate and VITA IQ sequence-gap count. That would let automation assert `pan.center == tci.dds` and distinguish frequency-reference regressions from IQ-continuity problems without an external skimmer.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
