### PR TITLE
refactor(automation): table-driven verb registry for the bridge (#4174, Phases 1–2)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -125,6 +125,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | Category | Verb | One-liner |
 |---|---|---|
 | **Introspection** | [`ping`](#ping) | Handshake; returns app + version. |
+| | [`verbs`](#verbs) | Machine-readable catalog of every verb + aliases + help. |
 | | [`dumpTree`](#dumptree) | ARIA-style snapshot of the whole widget tree. |
 | | [`grab <target> [path]`](#grab) | PNG of one widget (GPU-correct for the panadapter). |
 | | [`grab pan <index> [path]`](#grab) | Raw spectrum surface of a specific pan. |
@@ -183,6 +184,12 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 > or JSON (`{"cmd":"get","model":"slice","selector":"active","property":"mode"}`).
 > The JSON field names per verb are noted in each section; positional order is
 > shown in the bare-line examples.
+>
+> Server-side, every verb is one entry in a single registry table
+> (`AutomationServer::verbRegistry()`, #4174) that owns its name, aliases,
+> bare-line parsing, and dispatch; the startup banner, the unknown-command
+> error, and [`verbs`](#verbs) are all derived from it. When this table and
+> the running app disagree, trust `verbs` — it cannot go stale.
 
 ### `ping`
 Connectivity / handshake.
@@ -190,6 +197,22 @@ Connectivity / handshake.
 ```json
 → {"cmd":"ping"}
 ← {"ok":true,"app":"AetherSDR","version":"26.6.3"}
+```
+
+### `verbs`
+Machine-readable catalog of every verb the running build understands —
+canonical name, aliases, and a one-line help string, straight from the server's
+verb registry (#4174). Use it instead of hand-maintained verb lists in drivers;
+`tools/automation_probe.py` passes any verb not in its own mapping table
+through as a bare line, so new simple verbs work in the probe with no probe
+changes.
+
+```json
+→ {"cmd":"verbs"}
+← {"ok":true,"count":45,"verbs":[
+    {"name":"ping","help":"liveness check → app + version"},
+    {"name":"drag","aliases":["mouse"],"help":"drag <target> <dx> <dy> — synthesize press→move→release"},
+    …]}
 ```
 
 ### `dumpTree`

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1864,9 +1864,7 @@ bool AutomationServer::start(const QString& serverName)
 
     qCInfo(lcAutomation).noquote()
         << "automation bridge listening on" << fullServerName()
-        << "(verbs: ping, dumpTree, floors, grab, grab pan, grab pan-visible, invoke, get, connect, disconnect,"
-        << "txtest, atu, slice, tune, pan, layout, scale, panmessage, streams, audioCapture, txwaterfall, key, cwx, station, resize,"
-        << "menu, close, drag, hover, tooltip, showMenu, contextMenu, rightClick, hitTest, clickAt, shortcut, whoami, log, mark)";
+        << QStringLiteral("(verbs: %1)").arg(verbNamesJoined());
     return true;
 }
 
@@ -2047,11 +2045,634 @@ void AutomationServer::onDisconnected()
     qCDebug(lcAutomation) << "client disconnected;" << m_buffers.size() << "active";
 }
 
+// ── Verb registry (#4174) ────────────────────────────────────────────────────
+// One self-contained entry per bridge verb: canonical name, aliases, a
+// one-line help summary (surfaced by the `verbs` verb), a bare-line positional
+// parser, and the dispatcher. The startup banner and the "unknown command"
+// error are DERIVED from this table — never hand-list verbs anywhere else.
+// Adding a verb is adding one entry here (plus its doVerb body); nothing else
+// to keep in sync. JSON requests bypass the parsers (fields map 1:1 onto
+// VerbArgs in handleLine).
+
+struct AutomationServer::VerbArgs {
+    QString target, path, action, value, model, selector, property;
+    QString id, title, detail, tone;
+    int timeoutMs{0};
+};
+
+struct AutomationServer::VerbSpec {
+    QString name;                                   // canonical spelling
+    QStringList aliases;                            // exact-match synonyms
+    QString help;                                   // one-line positional summary
+    // Fill VerbArgs from the space-split bare line; a non-empty return rejects
+    // the request (e.g. `tooltip <t> hide <extras>`).
+    std::function<QJsonObject(const QList<QByteArray>&, VerbArgs&)> parse;
+    std::function<QJsonObject(AutomationServer&, VerbArgs&, QLocalSocket*)> dispatch;
+};
+
+namespace {
+
+QString vtok(const QList<QByteArray>& p, int i)
+{
+    return QString::fromUtf8(p.value(i));
+}
+
+QString vjoin(const QList<QByteArray>& p, int from)
+{
+    QStringList rest;
+    for (int i = from; i < p.size(); ++i)
+        rest << vtok(p, i);
+    return rest.join(QLatin1Char(' '));
+}
+
+// Model names advertised by the `get` verb's required-model error. Kept as a
+// list (not a baked string) so the error and any future introspection derive
+// from one place.
+const QStringList& getModelNames()
+{
+    static const QStringList kModels{
+        QStringLiteral("radio"),      QStringLiteral("transmit"),
+        QStringLiteral("meters"),     QStringLiteral("slice"),
+        QStringLiteral("slices"),     QStringLiteral("pan"),
+        QStringLiteral("pans"),       QStringLiteral("panstats"),
+        QStringLiteral("tracedebug"), QStringLiteral("kiwi"),
+    };
+    return kModels;
+}
+
+} // namespace
+
+const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
+{
+    static const std::vector<VerbSpec> kVerbs = [] {
+        using A = VerbArgs;
+
+        // ── Shared bare-line parse shapes ───────────────────────────────────
+        // Most verbs fit one of these; bespoke parsers live inline in their
+        // entry. Local lambdas (not free functions) because VerbArgs is a
+        // private nested type.
+        auto parseNothing = [](const QList<QByteArray>&, A&) -> QJsonObject {
+            return {};
+        };
+        // Historical default for verbs with no dedicated parse arm ("whoami
+        // and friends"): target = tok(1), path = tok(2).
+        auto parseTargetPath = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.target = vtok(p, 1);
+            a.path = vtok(p, 2);
+            return {};
+        };
+        auto parseTargetOnly = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.target = vtok(p, 1);
+            return {};
+        };
+        auto parseTargetXY = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.target = vtok(p, 1);
+            a.value = vtok(p, 2) + QLatin1Char(' ') + vtok(p, 3);
+            return {};
+        };
+        auto parseActionOnly = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.action = vtok(p, 1);
+            return {};
+        };
+        auto parseActionValue = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.action = vtok(p, 1);
+            a.value = vtok(p, 2);
+            return {};
+        };
+        auto parseActionRest = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.action = vtok(p, 1);
+            a.value = vjoin(p, 2);
+            return {};
+        };
+        auto parseValueOnly = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.value = vtok(p, 1);
+            return {};
+        };
+        auto parseValueRest = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.value = vjoin(p, 1);
+            return {};
+        };
+
+        std::vector<VerbSpec> v;
+        auto add = [&v](QString name, QStringList aliases, QString help,
+                        std::function<QJsonObject(const QList<QByteArray>&, A&)> parse,
+                        std::function<QJsonObject(AutomationServer&, A&, QLocalSocket*)>
+                            dispatch) {
+            v.push_back({std::move(name), std::move(aliases), std::move(help),
+                         std::move(parse), std::move(dispatch)});
+        };
+
+        add("ping", {}, "liveness check → app + version",
+            parseNothing,
+            [](AutomationServer&, A&, QLocalSocket*) {
+                return QJsonObject{
+                    {QStringLiteral("ok"), true},
+                    {QStringLiteral("app"), QStringLiteral("AetherSDR")},
+                    {QStringLiteral("version"), QCoreApplication::applicationVersion()},
+                };
+            });
+
+        add("verbs", {}, "list every bridge verb with aliases and help (this table)",
+            parseNothing,
+            [](AutomationServer&, A&, QLocalSocket*) {
+                QJsonArray arr;
+                for (const VerbSpec& spec : verbRegistry()) {
+                    QJsonObject o{{QStringLiteral("name"), spec.name},
+                                  {QStringLiteral("help"), spec.help}};
+                    if (!spec.aliases.isEmpty()) {
+                        o[QStringLiteral("aliases")] =
+                            QJsonArray::fromStringList(spec.aliases);
+                    }
+                    arr.append(o);
+                }
+                return QJsonObject{{QStringLiteral("ok"), true},
+                                   {QStringLiteral("count"), arr.size()},
+                                   {QStringLiteral("verbs"), arr}};
+            });
+
+        add("dumpTree", {}, "serialize the full widget tree as JSON",
+            parseTargetPath,
+            [](AutomationServer& s, A&, QLocalSocket*) { return s.doDumpTree(); });
+
+        add("floors", {}, "per-pan measured noise + display floor (dBm)",
+            parseTargetPath,
+            [](AutomationServer& s, A&, QLocalSocket*) { return s.doFloors(); });
+
+        add("grab", {}, "grab <target|pan|pan-visible [index]> [path] — PNG capture",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.target = vtok(p, 1);
+                if (a.target == QLatin1String("pan")
+                    || a.target == QLatin1String("pan-visible")
+                    || a.target == QLatin1String("pan-composite")) {
+                    a.selector = vtok(p, 2);   // pan index → "grab pan-visible 1 [path]"
+                    a.path = vtok(p, 3);
+                } else {
+                    a.path = vtok(p, 2);       // "grab SpectrumWidget [path]"
+                }
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("grab requires a target widget"));
+                if (a.target == QLatin1String("pan"))
+                    return s.doGrabPan(a.selector, a.path);
+                if (a.target == QLatin1String("pan-visible")
+                    || a.target == QLatin1String("pan-composite"))
+                    return s.doGrabPanVisible(a.selector, a.path);
+                return s.doGrab(a.target, a.path);
+            });
+
+        add("close", {}, "close <target> — close the target's top-level window",
+            parseTargetOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("close requires a target widget/window"));
+                return s.doClose(a.target);
+            });
+
+        add("hover", {}, "hover <target> [leave] — synthetic mouse hover",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.target = vtok(p, 1);
+                a.action = vtok(p, 2);  // optional "leave" → fade after exit
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("hover requires a target widget"));
+                return s.doHover(a.target, a.action);
+            });
+
+        add("tooltip", {}, "tooltip <target> [hide|text…] — force-show a native tooltip",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.target = vtok(p, 1);
+                if (vtok(p, 2) == QLatin1String("hide")) {
+                    // "hide" with trailing tokens must not silently become an
+                    // override that force-SHOWS a tip reading "hide …" (#4122
+                    // review). An override literally starting with "hide" is
+                    // available via the JSON form's explicit value field.
+                    if (p.size() != 3) {
+                        return err(QStringLiteral(
+                            "tooltip hide takes no extra arguments"));
+                    }
+                    a.action = QStringLiteral("hide");
+                } else {
+                    a.value = vjoin(p, 2);
+                }
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("tooltip requires a target widget"));
+                return s.doTooltip(a.target, a.action, a.value);
+            });
+
+        add("scrollTo", {QStringLiteral("ensureVisible")},
+            "scrollTo <target> — scroll a widget into its scroll-area viewport",
+            parseTargetPath,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("scrollTo requires a target widget"));
+                return s.doScrollTo(a.target);
+            });
+
+        add("drag", {QStringLiteral("mouse")},
+            "drag <target> <dx> <dy> — synthesize press→move→release",
+            parseTargetXY,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("drag requires a target and '<dx> <dy>'"));
+                return s.doDrag(a.target, a.value);
+            });
+
+        add("showMenu", {QStringLiteral("openMenu")},
+            "showMenu <target> — pop a button's drop-down menu",
+            parseTargetOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("showMenu requires a target button"));
+                return s.doShowMenu(a.target);
+            });
+
+        add("contextMenu", {}, "contextMenu <target> [x y] — Qt context-menu path",
+            parseTargetXY,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("contextMenu requires a target widget"));
+                return s.doContextMenu(a.target, a.value);
+            });
+
+        add("rightClick", {}, "rightClick <target> [x y] — mousePressEvent menu path",
+            parseTargetXY,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty()) {
+                    return err(QStringLiteral("rightClick requires a target widget"));
+                }
+                return s.doRightClick(a.target, a.value);
+            });
+
+        add("hitTest", {QStringLiteral("hittest")},
+            "hitTest <target> [x y] — read-only widget-owner probe",
+            parseTargetXY,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty())
+                    return err(QStringLiteral("hitTest requires a target widget"));
+                return s.doHitTest(a.target, a.value);
+            });
+
+        add("clickAt", {QStringLiteral("clickat")},
+            "clickAt <x> <y> | clickAt <target> <x> <y> — TX-guarded coordinate click",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                // Overloaded: "clickAt <x> <y>" (global) vs "clickAt <target> <x> <y>"
+                // (target-local). Disambiguate on whether the first token is numeric.
+                bool firstIsNumber = false;
+                vtok(p, 1).toInt(&firstIsNumber);
+                if (firstIsNumber) {
+                    a.value = vtok(p, 1) + QLatin1Char(' ') + vtok(p, 2);
+                } else {
+                    a.target = vtok(p, 1);
+                    a.value = vtok(p, 2) + QLatin1Char(' ') + vtok(p, 3);
+                }
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doClickAt(a.target, a.value);
+            });
+
+        add("invoke", {}, "invoke <target> <action> [value…] — drive a control (TX-guarded)",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.target = vtok(p, 1);
+                a.action = vtok(p, 2);
+                a.value = vjoin(p, 3);
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.target.isEmpty() || a.action.isEmpty())
+                    return err(QStringLiteral("invoke requires a target and an action"));
+                return s.doInvoke(a.target, a.action, a.value);
+            });
+
+        add("get", {}, "get <model> [selector] [property] — live model snapshot",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.model = vtok(p, 1);
+                a.selector = vtok(p, 2);
+                a.property = vtok(p, 3);
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.model.isEmpty())
+                    return err(QStringLiteral("get requires a model (")
+                               + getModelNames().join(QLatin1Char('|'))
+                               + QLatin1Char(')'));
+                return s.doGet(a.model, a.selector, a.property);
+            });
+
+        add("connect", {}, "connect <list|show|hide|local|ip|wait> [args]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket* sock) -> QJsonObject {
+                if (a.action.isEmpty()) {
+                    return err(QStringLiteral(
+                        "connect requires an action (list|show|hide|local|ip|wait)"));
+                }
+                return s.doConnect(a.action, a.value, sock);
+            });
+
+        add("disconnect", {}, "disconnect from the radio",
+            parseTargetPath,
+            [](AutomationServer& s, A&, QLocalSocket*) { return s.doDisconnect(); });
+
+        add("txtest", {}, "txtest <twotone|off> — TX-gated test signal",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral("txtest requires an action (twotone|off)"));
+                return s.doTxTest(a.action);
+            });
+
+        add("atu", {}, "atu <bypass|start> — antenna tuner (start is TX-gated)",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral("atu requires an action (bypass|start)"));
+                return s.doAtu(a.action);
+            });
+
+        add("slice", {}, "slice <action> [args] — slice lifecycle/config (see doSlice)",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral(
+                        "slice requires an action (add|remove|select|tx|txant|rxant|rxsource)"));
+                return s.doSlice(a.action, a.value);
+            });
+
+        add("tune", {}, "tune <mhz> — set the active slice frequency",
+            parseValueOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.value.isEmpty())
+                    return err(QStringLiteral("tune requires a frequency in MHz"));
+                return s.doTune(a.value);
+            });
+
+        add("cwx", {}, "cwx <send|speed|stop> [args] — CWX keyer (send is TX-gated)",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doCwx(a.action, a.value);
+            });
+
+        add("record", {}, "record <start|stop|status|path|dir> [args]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doRecord(a.action, a.value);
+            });
+
+        add("testtone", {}, "testtone <on|off> [freqHz levelDb]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doTestTone(a.action, a.value);
+            });
+
+        add("pan", {}, "pan <create|add|remove|close|center> [value]",
+            parseActionValue,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral(
+                        "pan requires an action (create|add|remove|close|center)"));
+                return s.doPan(a.action, a.value);
+            });
+
+        add("layout", {}, "layout <rearrange <id>|get> — splitter layout exerciser",
+            parseActionValue,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty()) {
+                    return err(QStringLiteral("layout requires an action (rearrange|get)"));
+                }
+                return s.doLayout(a.action, a.value);
+            });
+
+        add("scale", {}, "scale [pct] — report/persist the UI scale factor",
+            parseValueOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doScale(a.value);
+            });
+
+        add("panmessage", {},
+            "panmessage <add|remove|clear|list> <pan> [id timeout [tone=…] title|detail]",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.action = vtok(p, 1);            // add | remove | clear | list
+                a.target = vtok(p, 2);            // pan index | active
+                a.id = vtok(p, 3);                // message id for add/remove
+                if (a.action == QLatin1String("add")) {
+                    bool okTimeout = false;
+                    a.timeoutMs = vtok(p, 4).toInt(&okTimeout);
+                    int textStart = 5;
+                    if (!okTimeout) {
+                        // Timeout omitted — tok(4) is the first text token, not a
+                        // number; don't swallow it into the failed parse. (#3999 review)
+                        a.timeoutMs = 0;
+                        textStart = 4;
+                    }
+                    if (vtok(p, textStart).startsWith(QStringLiteral("tone="),
+                                                      Qt::CaseInsensitive)) {
+                        a.tone = vtok(p, textStart).section(QLatin1Char('='), 1).trimmed();
+                        ++textStart;
+                    }
+                    const QString text = vjoin(p, textStart);
+                    const int sep = text.indexOf(QLatin1Char('|'));
+                    if (sep >= 0) {
+                        a.title = text.left(sep).trimmed();
+                        a.detail = text.mid(sep + 1).trimmed();
+                    } else {
+                        a.title = text.trimmed();
+                        a.detail.clear();
+                    }
+                }
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty()) {
+                    return err(QStringLiteral(
+                        "panmessage requires an action (add|remove|clear|list)"));
+                }
+                return s.doPanMessage(a.action, a.target, a.id, a.title, a.detail,
+                                      a.timeoutMs, a.tone);
+            });
+
+        add("dss", {}, "dss <snapshot|reset|inject|scrollback|live> [pan] [args]",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.action = vtok(p, 1);
+                a.target = vtok(p, 2);            // pan index, optional for snapshot
+                a.value = vjoin(p, 3);
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty()) {
+                    return err(QStringLiteral(
+                        "dss requires an action (snapshot|reset|inject|scrollback|live)"));
+                }
+                return s.doDss(a.action, a.target.isEmpty() ? a.selector : a.target,
+                               a.value);
+            });
+
+        add("streams", {}, "streams [radio|reset] — stream diagnostics",
+            parseActionOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doStreams(a.action);
+            });
+
+        add("tci", {},
+            "tci start|status|stop — in-process TCI client simulator (JSON form only)",
+            // Historical quirk, preserved (#4174): tci never had a bare-line
+            // parse arm, so the default target/path fill leaves `action` empty
+            // and bare "tci start" reports the usage error below. The JSON
+            // form supplies action/value explicitly.
+            parseTargetPath,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral(
+                        "tci requires an action (start [port|sdc [port]] | status | stop [abrupt])"));
+                return s.doTci(a.action, a.value);
+            });
+
+        add("audioCapture", {}, "audioCapture <start|stop|status|read> [args]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doAudioCapture(a.action.isEmpty() ? QStringLiteral("status")
+                                                           : a.action,
+                                        a.value, a.path);
+            });
+
+        add("txwaterfall", {}, "txwaterfall <on|off> — show keyed TX in the waterfall",
+            parseValueOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                // Radio-authoritative display flag (`transmit set show_tx_in_waterfall`)
+                // that gates whether keyed-up TX renders FFT-derived rows in the
+                // waterfall. Off by default; enabling it lets a test confirm CWX/tune/ATU
+                // energy appears in the waterfall, not just the FFT trace (#3646/#3804).
+                if (!s.m_radioModel)
+                    return err(QStringLiteral("no radio model available"));
+                const QString v = a.value.trimmed().toLower();
+                const bool on = (v == QLatin1String("on") || v == QLatin1String("1")
+                                 || v == QLatin1String("true") || v == QLatin1String("enable"));
+                const bool off = (v == QLatin1String("off") || v == QLatin1String("0")
+                                  || v == QLatin1String("false") || v == QLatin1String("disable"));
+                if (!on && !off)
+                    return err(QStringLiteral("txwaterfall requires on|off"));
+                s.m_radioModel->sendCommand(
+                    QStringLiteral("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
+                return QJsonObject{
+                    {QStringLiteral("ok"), true},
+                    {QStringLiteral("txwaterfall"), on},
+                    {QStringLiteral("note"),
+                     QStringLiteral("radio echoes status; re-read with get transmit showTxInWaterfall")}};
+            });
+
+        add("key", {}, "key <ptt on|off | mox> — semantic keying (TX-gated)",
+            parseActionValue,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.action.isEmpty())
+                    return err(QStringLiteral("key requires a name (ptt on|off, mox)"));
+                return s.doKey(a.action, a.value);
+            });
+
+        add("station", {}, "station <name> — set the GUI-client station name",
+            parseValueOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.value.isEmpty())
+                    return err(QStringLiteral("station requires a name"));
+                return s.doStation(a.value);
+            });
+
+        add("resize", {}, "resize <w> <h> [target] — resize a window",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.value = vtok(p, 1) + QLatin1Char(' ') + vtok(p, 2);
+                a.target = vtok(p, 3);
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doResize(a.value, a.target);
+            });
+
+        add("window", {}, "window <maximize|restore|minimize|fullscreen> [target]",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.action = vtok(p, 1);
+                a.target = vtok(p, 2);   // optional window target
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doWindow(a.action, a.target);
+            });
+
+        add("shortcut", {}, "shortcut <id> — fire a ShortcutManager/MIDI action (TX-gated)",
+            parseTargetOnly,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doShortcut(a.target.isEmpty() ? a.id : a.target);
+            });
+
+        add("menu", {}, "menu list | open <name> — menu-bar menus",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doMenu(a.action.isEmpty() ? QStringLiteral("list") : a.action,
+                                a.value);
+            });
+
+        add("whoami", {}, "bridge instance info: pid, socket, label, station, txAllowed",
+            parseTargetPath,
+            [](AutomationServer& s, A&, QLocalSocket*) { return s.doWhoami(); });
+
+        add("log", {}, "log <categories|get|set|reset|tail|subscribe|unsubscribe> [args]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket* sock) {
+                return s.doLog(a.action.isEmpty() ? QStringLiteral("categories")
+                                                  : a.action,
+                               a.value, sock);
+            });
+
+        add("mark", {}, "mark <text> — timestamped annotation in the log ring",
+            parseValueRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
+                if (a.value.isEmpty())
+                    return err(QStringLiteral("mark requires annotation text"));
+                return s.doMark(a.value);
+            });
+
+        add("qrz", {}, "qrz <status|cached|lookup|spottext> [args]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doQrz(a.action.isEmpty() ? QStringLiteral("status") : a.action,
+                               a.value);
+            });
+
+        return v;
+    }();
+    return kVerbs;
+}
+
+const AutomationServer::VerbSpec* AutomationServer::findVerb(const QString& cmd)
+{
+    static const QHash<QString, const VerbSpec*> kIndex = [] {
+        QHash<QString, const VerbSpec*> idx;
+        for (const VerbSpec& spec : verbRegistry()) {
+            idx.insert(spec.name, &spec);
+            for (const QString& alias : spec.aliases)
+                idx.insert(alias, &spec);
+        }
+        return idx;
+    }();
+    return kIndex.value(cmd, nullptr);
+}
+
+QString AutomationServer::verbNamesJoined()
+{
+    QStringList names;
+    for (const VerbSpec& spec : verbRegistry())
+        names << spec.name;
+    return names.join(QStringLiteral(", "));
+}
+
 QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* sock)
 {
-    QString cmd, target, path, action, value, model, selector, property;
-    QString id, title, detail, tone;
-    int timeoutMs = 0;
+    QString cmd;
+    VerbArgs a;
 
     const QByteArray trimmed = line.trimmed();
     if (trimmed.startsWith('{')) {
@@ -2063,442 +2684,60 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         if (perr.error != QJsonParseError::NoError || !doc.isObject())
             return err(QStringLiteral("invalid JSON: ") + perr.errorString());
         const QJsonObject obj = doc.object();
-        cmd      = obj.value(QStringLiteral("cmd")).toString();
-        target   = obj.value(QStringLiteral("target")).toString();
-        path     = obj.value(QStringLiteral("path")).toString();
-        action   = obj.value(QStringLiteral("action")).toString();
+        cmd        = obj.value(QStringLiteral("cmd")).toString();
+        a.target   = obj.value(QStringLiteral("target")).toString();
+        a.path     = obj.value(QStringLiteral("path")).toString();
+        a.action   = obj.value(QStringLiteral("action")).toString();
         // value may be a string, number, or bool — normalize to text.
         const QJsonValue v = obj.value(QStringLiteral("value"));
-        if (v.isString())      value = v.toString();
-        else if (v.isDouble()) value = QString::number(v.toDouble());
-        else if (v.isBool())   value = v.toBool() ? QStringLiteral("true")
-                                                  : QStringLiteral("false");
-        model    = obj.value(QStringLiteral("model")).toString();
-        selector = obj.value(QStringLiteral("selector")).toString();
-        property = obj.value(QStringLiteral("property")).toString();
-        id       = obj.value(QStringLiteral("id")).toString();
-        title    = obj.value(QStringLiteral("title")).toString();
-        detail   = obj.value(QStringLiteral("detail")).toString();
-        tone     = obj.value(QStringLiteral("tone")).toString();
-        timeoutMs = obj.value(QStringLiteral("timeoutMs")).toInt(0);
+        if (v.isString())      a.value = v.toString();
+        else if (v.isDouble()) a.value = QString::number(v.toDouble());
+        else if (v.isBool())   a.value = v.toBool() ? QStringLiteral("true")
+                                                    : QStringLiteral("false");
+        a.model    = obj.value(QStringLiteral("model")).toString();
+        a.selector = obj.value(QStringLiteral("selector")).toString();
+        a.property = obj.value(QStringLiteral("property")).toString();
+        a.id       = obj.value(QStringLiteral("id")).toString();
+        a.title    = obj.value(QStringLiteral("title")).toString();
+        a.detail   = obj.value(QStringLiteral("detail")).toString();
+        a.tone     = obj.value(QStringLiteral("tone")).toString();
+        a.timeoutMs = obj.value(QStringLiteral("timeoutMs")).toInt(0);
         // clickAt accepts numeric x/y fields directly (dumpTree geometry is
         // global), folded into `value` as "x y" so both request forms share one
         // code path. Explicit `value` still wins if supplied. Fold ONLY when
         // both fields are present and JSON-numeric: toInt() coerces a missing
         // field or a string-typed number to 0, which would turn a malformed
         // request into a real click at the screen edge (or (0,0)) instead of
-        // an error — leave value empty so doClickAt rejects it. Match the verb
-        // case-insensitively like the dispatcher does.
+        // an error — leave value empty so doClickAt rejects it. Match both
+        // alias spellings, like the registry does.
         if ((cmd == QLatin1String("clickAt") || cmd == QLatin1String("clickat"))
-            && value.isEmpty()
+            && a.value.isEmpty()
             && obj.value(QStringLiteral("x")).isDouble()
             && obj.value(QStringLiteral("y")).isDouble()) {
-            value = QString::number(obj.value(QStringLiteral("x")).toInt())
-                    + QLatin1Char(' ')
-                    + QString::number(obj.value(QStringLiteral("y")).toInt());
+            a.value = QString::number(obj.value(QStringLiteral("x")).toInt())
+                      + QLatin1Char(' ')
+                      + QString::number(obj.value(QStringLiteral("y")).toInt());
         }
     } else {
-        // Bare line. Positional by verb:
-        //   grab   <target> [path]
-        //   invoke <target> <action> [value...]   (value joins the rest)
-        //   get    <model>  [selector] [property]
+        // Bare line: positional tokens, parsed by the verb's registry entry
+        // (e.g. "invoke <target> <action> [value…]"). Unknown verbs skip the
+        // parse and fall through to the shared unknown-command error below.
         const QList<QByteArray> p = trimmed.split(' ');
-        auto tok = [&p](int i) { return QString::fromUtf8(p.value(i)); };
-        cmd = tok(0);
-        if (cmd == QLatin1String("invoke")) {
-            target = tok(1);
-            action = tok(2);
-            QStringList rest;
-            for (int i = 3; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));
-        } else if (cmd == QLatin1String("get")) {
-            model = tok(1); selector = tok(2); property = tok(3);
-        } else if (cmd == QLatin1String("connect")) {
-            action = tok(1);  // list | local | ip | wait
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "serial 1234", "10.0.0.25", "30000"
-        } else if (cmd == QLatin1String("txtest") || cmd == QLatin1String("atu")) {
-            action = tok(1);  // e.g. "txtest twotone", "atu bypass"
-        } else if (cmd == QLatin1String("slice")) {
-            action = tok(1);
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) {
-                rest << tok(i);
-            }
-            value = rest.join(QLatin1Char(' '));  // "slice add 14.2", "slice fixture 4 B"
-        } else if (cmd == QLatin1String("tune")) {
-            value = tok(1);   // "tune 3.7"
-        } else if (cmd == QLatin1String("log")) {
-            action = tok(1);  // categories|get|set|reset|tail|subscribe|unsubscribe
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "aether.protocol on", "200 since=42"
-        } else if (cmd == QLatin1String("mark")) {
-            QStringList rest;
-            for (int i = 1; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // free-form annotation text
-        } else if (cmd == QLatin1String("cwx")) {
-            action = tok(1);                  // send | speed | stop
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "cwx send CQ CQ DE ...", "cwx speed 18"
-        } else if (cmd == QLatin1String("record")) {
-            action = tok(1);                  // start | stop | status | path | dir
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "record dir /tmp/recs"
-        } else if (cmd == QLatin1String("testtone")) {
-            action = tok(1);                  // on | off
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "testtone on 1000 -6" -> freqHz levelDb
-        } else if (cmd == QLatin1String("pan")) {
-            action = tok(1); value = tok(2);  // "pan create", "pan remove 0x40000001"
-        } else if (cmd == QLatin1String("layout")) {
-            action = tok(1); value = tok(2);  // "layout rearrange 2v", "layout get"
-        } else if (cmd == QLatin1String("scale")) {
-            value = tok(1);                   // "scale" (report), "scale 85" (persist)
-        } else if (cmd == QLatin1String("dss")) {
-            action = tok(1);                  // snapshot | reset | inject | scrollback | live
-            target = tok(2);                  // pan index, optional for snapshot
-            QStringList rest;
-            for (int i = 3; i < p.size(); ++i) {
-                rest << tok(i);
-            }
-            value = rest.join(QLatin1Char(' '));
-        } else if (cmd == QLatin1String("qrz")) {
-            action = tok(1);  // status | cached | lookup | spottext
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // callsign, or free-form CW text
-        } else if (cmd == QLatin1String("panmessage")) {
-            action = tok(1);                  // add | remove | clear | list
-            target = tok(2);                  // pan index | active
-            id = tok(3);                      // message id for add/remove
-            if (action == QLatin1String("add")) {
-                bool okTimeout = false;
-                timeoutMs = tok(4).toInt(&okTimeout);
-                int textStart = 5;
-                if (!okTimeout) {
-                    // Timeout omitted — tok(4) is the first text token, not a
-                    // number; don't swallow it into the failed parse. (#3999 review)
-                    timeoutMs = 0;
-                    textStart = 4;
-                }
-                if (tok(textStart).startsWith(QStringLiteral("tone="),
-                                              Qt::CaseInsensitive)) {
-                    tone = tok(textStart).section(QLatin1Char('='), 1).trimmed();
-                    ++textStart;
-                }
-                QStringList rest;
-                for (int i = textStart; i < p.size(); ++i) {
-                    rest << tok(i);
-                }
-                const QString text = rest.join(QLatin1Char(' '));
-                const int sep = text.indexOf(QLatin1Char('|'));
-                if (sep >= 0) {
-                    title = text.left(sep).trimmed();
-                    detail = text.mid(sep + 1).trimmed();
-                } else {
-                    title = text.trimmed();
-                    detail.clear();
-                }
-            }
-        } else if (cmd == QLatin1String("streams")) {
-            action = tok(1);  // "" (Layer A UDP-orphan) | "radio" (Layer B) | "reset"
-        } else if (cmd == QLatin1String("audioCapture")) {
-            action = tok(1);  // start | stop | read | status
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) {
-                rest << tok(i);
-            }
-            value = rest.join(QLatin1Char(' '));
-        } else if (cmd == QLatin1String("txwaterfall")) {
-            value = tok(1);                   // on | off
-        } else if (cmd == QLatin1String("key")) {
-            action = tok(1); value = tok(2);  // "key ptt on", "key mox"
-        } else if (cmd == QLatin1String("station")) {
-            value = tok(1);   // "station Claude"
-        } else if (cmd == QLatin1String("resize")) {
-            value = tok(1) + QLatin1Char(' ') + tok(2);  // "resize 1920 1080 [target]"
-            target = tok(3);
-        } else if (cmd == QLatin1String("window")) {
-            action = tok(1);  // maximize | restore | minimize | fullscreen
-            target = tok(2);  // optional window target
-        } else if (cmd == QLatin1String("shortcut")) {
-            target = tok(1);  // shortcut/MIDI action id → "shortcut band_zoom"
-        } else if (cmd == QLatin1String("menu")) {
-            action = tok(1);  // list | open
-            QStringList rest;
-            for (int i = 2; i < p.size(); ++i) rest << tok(i);
-            value = rest.join(QLatin1Char(' '));  // "menu open Settings"
-        } else if (cmd == QLatin1String("grab")) {
-            target = tok(1);
-            if (target == QLatin1String("pan")
-                || target == QLatin1String("pan-visible")
-                || target == QLatin1String("pan-composite")) {
-                selector = tok(2);   // pan index → "grab pan-visible 1 [path]"
-                path = tok(3);
-            } else {
-                path = tok(2);       // "grab SpectrumWidget [path]"
-            }
-        } else if (cmd == QLatin1String("close")
-                   || cmd == QLatin1String("showMenu")
-                   || cmd == QLatin1String("openMenu")) {
-            target = tok(1);  // "close ConnectionPanel", "showMenu modeButton"
-        } else if (cmd == QLatin1String("hitTest")
-                   || cmd == QLatin1String("hittest")) {
-            target = tok(1);
-            value = tok(2) + QLatin1Char(' ') + tok(3);  // "hitTest SpectrumWidget [x y]"
-        } else if (cmd == QLatin1String("clickAt")
-                   || cmd == QLatin1String("clickat")) {
-            // Overloaded: "clickAt <x> <y>" (global) vs "clickAt <target> <x> <y>"
-            // (target-local). Disambiguate on whether the first token is numeric.
-            bool firstIsNumber = false;
-            tok(1).toInt(&firstIsNumber);
-            if (firstIsNumber) {
-                value = tok(1) + QLatin1Char(' ') + tok(2);  // "clickAt 1301 200"
-            } else {
-                target = tok(1);
-                value = tok(2) + QLatin1Char(' ') + tok(3);  // "clickAt AppletPanel 10 20"
-            }
-        } else if (cmd == QLatin1String("drag") || cmd == QLatin1String("mouse")) {
-            target = tok(1);
-            value = tok(2) + QLatin1Char(' ') + tok(3);  // "drag sizeGrip 80 60"
-        } else if (cmd == QLatin1String("hover")) {
-            target = tok(1);
-            action = tok(2);  // optional "leave" → fade after exit
-        } else if (cmd == QLatin1String("tooltip")) {
-            target = tok(1);
-            if (tok(2) == QLatin1String("hide")) {
-                // "hide" with trailing tokens must not silently become an
-                // override that force-SHOWS a tip reading "hide …" (#4122
-                // review). An override literally starting with "hide" is
-                // available via the JSON form's explicit value field.
-                if (p.size() != 3) {
-                    return err(QStringLiteral(
-                        "tooltip hide takes no extra arguments"));
-                }
-                action = QStringLiteral("hide");
-            } else {
-                QStringList rest;
-                for (int i = 2; i < p.size(); ++i) {
-                    rest << tok(i);
-                }
-                value = rest.join(QLatin1Char(' '));
-            }
-        } else if (cmd == QLatin1String("contextMenu")
-                   || cmd == QLatin1String("rightClick")) {
-            target = tok(1);
-            value = tok(2) + QLatin1Char(' ') + tok(3);  // "contextMenu/rightClick SMeterWidget [x y]"
-        } else {  // whoami and friends
-            target = tok(1); path = tok(2);
+        cmd = QString::fromUtf8(p.value(0));
+        if (const VerbSpec* spec = findVerb(cmd)) {
+            const QJsonObject parseError = spec->parse(p, a);
+            if (!parseError.isEmpty())
+                return parseError;
         }
     }
 
-    qCDebug(lcAutomation) << "request:" << cmd << target << action << model << selector;
+    qCDebug(lcAutomation) << "request:" << cmd << a.target << a.action << a.model
+                          << a.selector;
 
-    if (cmd == QLatin1String("ping")) {
-        return QJsonObject{
-            {QStringLiteral("ok"), true},
-            {QStringLiteral("app"), QStringLiteral("AetherSDR")},
-            {QStringLiteral("version"), QCoreApplication::applicationVersion()},
-        };
-    }
-    if (cmd == QLatin1String("dumpTree"))
-        return doDumpTree();
-    if (cmd == QLatin1String("floors"))
-        return doFloors();
-    if (cmd == QLatin1String("grab")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("grab requires a target widget"));
-        if (target == QLatin1String("pan"))
-            return doGrabPan(selector, path);
-        if (target == QLatin1String("pan-visible")
-            || target == QLatin1String("pan-composite"))
-            return doGrabPanVisible(selector, path);
-        return doGrab(target, path);
-    }
-    if (cmd == QLatin1String("close")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("close requires a target widget/window"));
-        return doClose(target);
-    }
-    if (cmd == QLatin1String("hover")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("hover requires a target widget"));
-        return doHover(target, action);
-    }
-    if (cmd == QLatin1String("tooltip")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("tooltip requires a target widget"));
-        return doTooltip(target, action, value);
-    }
-    if (cmd == QLatin1String("scrollTo") || cmd == QLatin1String("ensureVisible")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("scrollTo requires a target widget"));
-        return doScrollTo(target);
-    }
-    if (cmd == QLatin1String("drag") || cmd == QLatin1String("mouse")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("drag requires a target and '<dx> <dy>'"));
-        return doDrag(target, value);
-    }
-    if (cmd == QLatin1String("showMenu") || cmd == QLatin1String("openMenu")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("showMenu requires a target button"));
-        return doShowMenu(target);
-    }
-    if (cmd == QLatin1String("contextMenu")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("contextMenu requires a target widget"));
-        return doContextMenu(target, value);
-    }
-    if (cmd == QLatin1String("rightClick")) {
-        if (target.isEmpty()) {
-            return err(QStringLiteral("rightClick requires a target widget"));
-        }
-        return doRightClick(target, value);
-    }
-    if (cmd == QLatin1String("hitTest") || cmd == QLatin1String("hittest")) {
-        if (target.isEmpty())
-            return err(QStringLiteral("hitTest requires a target widget"));
-        return doHitTest(target, value);
-    }
-    if (cmd == QLatin1String("clickAt") || cmd == QLatin1String("clickat")) {
-        return doClickAt(target, value);
-    }
-    if (cmd == QLatin1String("invoke")) {
-        if (target.isEmpty() || action.isEmpty())
-            return err(QStringLiteral("invoke requires a target and an action"));
-        return doInvoke(target, action, value);
-    }
-    if (cmd == QLatin1String("get")) {
-        if (model.isEmpty())
-            return err(QStringLiteral("get requires a model (radio|transmit|meters|slice|slices|pan|pans|panstats|tracedebug|kiwi)"));
-        return doGet(model, selector, property);
-    }
-    if (cmd == QLatin1String("connect")) {
-        if (action.isEmpty()) {
-            return err(QStringLiteral("connect requires an action (list|show|hide|local|ip|wait)"));
-        }
-        return doConnect(action, value, sock);
-    }
-    if (cmd == QLatin1String("disconnect")) {
-        return doDisconnect();
-    }
-    if (cmd == QLatin1String("txtest")) {
-        if (action.isEmpty())
-            return err(QStringLiteral("txtest requires an action (twotone|off)"));
-        return doTxTest(action);
-    }
-    if (cmd == QLatin1String("atu")) {
-        if (action.isEmpty())
-            return err(QStringLiteral("atu requires an action (bypass|start)"));
-        return doAtu(action);
-    }
-    if (cmd == QLatin1String("slice")) {
-        if (action.isEmpty())
-            return err(QStringLiteral("slice requires an action (add|remove|select|tx|txant|rxant|rxsource)"));
-        return doSlice(action, value);
-    }
-    if (cmd == QLatin1String("tune")) {
-        if (value.isEmpty())
-            return err(QStringLiteral("tune requires a frequency in MHz"));
-        return doTune(value);
-    }
-    if (cmd == QLatin1String("cwx"))
-        return doCwx(action, value);
-    if (cmd == QLatin1String("record"))
-        return doRecord(action, value);
-    if (cmd == QLatin1String("testtone"))
-        return doTestTone(action, value);
-    if (cmd == QLatin1String("pan")) {
-        if (action.isEmpty())
-            return err(QStringLiteral("pan requires an action (create|add|remove|close|center)"));
-        return doPan(action, value);
-    }
-    if (cmd == QLatin1String("layout")) {
-        if (action.isEmpty()) {
-            return err(QStringLiteral("layout requires an action (rearrange|get)"));
-        }
-        return doLayout(action, value);
-    }
-    if (cmd == QLatin1String("scale")) {
-        return doScale(value);
-    }
-    if (cmd == QLatin1String("panmessage")) {
-        if (action.isEmpty()) {
-            return err(QStringLiteral("panmessage requires an action (add|remove|clear|list)"));
-        }
-        return doPanMessage(action, target, id, title, detail, timeoutMs, tone);
-    }
-    if (cmd == QLatin1String("dss")) {
-        if (action.isEmpty()) {
-            return err(QStringLiteral("dss requires an action (snapshot|reset|inject|scrollback|live)"));
-        }
-        return doDss(action, target.isEmpty() ? selector : target, value);
-    }
-    if (cmd == QLatin1String("streams"))
-        return doStreams(action);
-    if (cmd == QLatin1String("tci")) {
-        if (action.isEmpty())
-            return err(QStringLiteral(
-                "tci requires an action (start [port|sdc [port]] | status | stop [abrupt])"));
-        return doTci(action, value);
-    }
-    if (cmd == QLatin1String("audioCapture"))
-        return doAudioCapture(action.isEmpty() ? QStringLiteral("status") : action,
-                              value, path);
-    if (cmd == QLatin1String("txwaterfall")) {
-        // Radio-authoritative display flag (`transmit set show_tx_in_waterfall`)
-        // that gates whether keyed-up TX renders FFT-derived rows in the
-        // waterfall. Off by default; enabling it lets a test confirm CWX/tune/ATU
-        // energy appears in the waterfall, not just the FFT trace (#3646/#3804).
-        if (!m_radioModel)
-            return err(QStringLiteral("no radio model available"));
-        const QString v = value.trimmed().toLower();
-        const bool on = (v == QLatin1String("on") || v == QLatin1String("1")
-                         || v == QLatin1String("true") || v == QLatin1String("enable"));
-        const bool off = (v == QLatin1String("off") || v == QLatin1String("0")
-                          || v == QLatin1String("false") || v == QLatin1String("disable"));
-        if (!on && !off)
-            return err(QStringLiteral("txwaterfall requires on|off"));
-        m_radioModel->sendCommand(QStringLiteral("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
-        return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("txwaterfall"), on},
-                           {QStringLiteral("note"), QStringLiteral("radio echoes status; re-read with get transmit showTxInWaterfall")}};
-    }
-    if (cmd == QLatin1String("key")) {
-        if (action.isEmpty())
-            return err(QStringLiteral("key requires a name (ptt on|off, mox)"));
-        return doKey(action, value);
-    }
-    if (cmd == QLatin1String("station")) {
-        if (value.isEmpty())
-            return err(QStringLiteral("station requires a name"));
-        return doStation(value);
-    }
-    if (cmd == QLatin1String("resize"))
-        return doResize(value, target);
-    if (cmd == QLatin1String("window"))
-        return doWindow(action, target);
-    if (cmd == QLatin1String("shortcut"))
-        return doShortcut(target.isEmpty() ? id : target);
-    if (cmd == QLatin1String("menu"))
-        return doMenu(action.isEmpty() ? QStringLiteral("list") : action, value);
-    if (cmd == QLatin1String("whoami"))
-        return doWhoami();
-    if (cmd == QLatin1String("log"))
-        return doLog(action.isEmpty() ? QStringLiteral("categories") : action, value, sock);
-    if (cmd == QLatin1String("mark")) {
-        if (value.isEmpty())
-            return err(QStringLiteral("mark requires annotation text"));
-        return doMark(value);
-    }
-    if (cmd == QLatin1String("qrz"))
-        return doQrz(action.isEmpty() ? QStringLiteral("status") : action, value);
-    return err(QStringLiteral("unknown command: ") + cmd);
+    const VerbSpec* spec = findVerb(cmd);
+    if (!spec)
+        return err(QStringLiteral("unknown command: ") + cmd);
+    return spec->dispatch(*this, a, sock);
 }
 
 QJsonObject AutomationServer::doDumpTree() const

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -290,6 +290,17 @@ private:
     // is needed for stateful per-client verbs (log subscribe/unsubscribe).
     QJsonObject handleLine(const QByteArray& line, QLocalSocket* sock);
 
+    // Verb registry (#4174): one self-describing entry per bridge verb —
+    // canonical name, aliases, one-line help, bare-line parser, dispatcher.
+    // The startup banner, the unknown-command error, and the `verbs`
+    // introspection verb all derive from this table; never hand-list verbs
+    // anywhere else. Definitions live in AutomationServer.cpp.
+    struct VerbArgs;
+    struct VerbSpec;
+    static const std::vector<VerbSpec>& verbRegistry();
+    static const VerbSpec* findVerb(const QString& cmd);
+    static QString verbNamesJoined();
+
     QJsonObject doDumpTree() const;
     QJsonObject doFloors() const;
     QJsonObject doGrab(const QString& target, const QString& path) const;

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """
-AetherSDR automation-bridge probe (issue #3646, Phase 0).
+AetherSDR automation-bridge probe (issue #3646, Phase 0; generic since #4174).
 
 Drives the in-app automation bridge that AetherSDR exposes when launched with
 AETHER_AUTOMATION=1. The bridge is a QLocalServer speaking newline-delimited
 JSON. This probe needs no Qt or third-party deps -- it talks to the AF_UNIX
 socket (macOS/Linux) or the named pipe (Windows) directly.
 
-It exercises the two Phase-0 verbs and saves the canonical deliverables:
-  * an applet semantic snapshot  -> <out>/tree.json
-  * a panadapter PNG capture     -> <out>/panadapter.png
+Any bridge verb works: verbs with a bespoke CLI->JSON mapping (multi-word
+arguments, client-side validation) are listed in MAPPERS below; every other
+verb is passed through as a bare positional line and parsed by the server's
+verb registry, so new simple verbs need no probe changes at all. Ask the
+running app what it understands:
+
+    python tools/automation_probe.py verbs
 
 Discovery: the running app writes the resolved socket path to
 <temp>/aethersdr-automation.json, so you don't have to know the platform
@@ -17,8 +21,9 @@ endpoint. Pass --socket to override.
 
 Usage:
     AETHER_AUTOMATION=1 ./AetherSDR &        # launch the app with the bridge on
-    python tools/automation_probe.py         # snapshot + panadapter grab
+    python tools/automation_probe.py         # demo: snapshot + panadapter grab
     python tools/automation_probe.py ping
+    python tools/automation_probe.py verbs
     python tools/automation_probe.py connect list
     python tools/automation_probe.py connect show
     python tools/automation_probe.py connect local first
@@ -67,7 +72,12 @@ class Bridge:
             self._pipe = None
 
     def request(self, obj):
-        line = (json.dumps(obj) + "\n").encode()
+        return self.request_line(json.dumps(obj))
+
+    def request_line(self, text):
+        """Send one raw request line (JSON or bare positional) and return the
+        decoded JSON response."""
+        line = (text + "\n").encode()
         if self._sock:
             self._sock.sendall(line)
             return self._read_line_sock()
@@ -138,17 +148,245 @@ def collect_actions(node, pattern=None):
     return matches
 
 
+# ── Verb → JSON-request mappers ──────────────────────────────────────────────
+# Only verbs whose CLI form needs a bespoke JSON mapping are listed: multi-word
+# arguments that shell quoting must survive (a bare line re-splits on spaces),
+# JSON-only fields (audioCapture's path, panmessage's id/timeoutMs), verbs
+# whose bare form the server doesn't parse (tci), or client-side validation.
+# Every mapper returns the request dict WITHOUT "cmd"; main() adds it and does
+# the one send/print. Anything not listed goes over the wire as a bare
+# positional line for the server's verb registry to parse.
+
+def _need(rest, n, usage):
+    if len(rest) < n:
+        sys.exit(f"error: {usage}")
+
+
+def _map_target_value(usage):
+    """<target> [value…] — quoting-safe target, rest joined into value."""
+    def mapper(rest):
+        _need(rest, 1, usage)
+        req = {"target": rest[0]}
+        if len(rest) > 1:
+            req["value"] = " ".join(rest[1:])
+        return req
+    return mapper
+
+
+def _map_action_value(usage=None):
+    """[action [value…]] — action + rest joined into value."""
+    def mapper(rest):
+        if usage:
+            _need(rest, 1, usage)
+        req = {}
+        if rest:
+            req["action"] = rest[0]
+            if len(rest) > 1:
+                req["value"] = " ".join(rest[1:])
+        return req
+    return mapper
+
+
+def _map_grab(rest):
+    _need(rest, 1, "grab requires a target widget name")
+    req = {"target": rest[0]}
+    if rest[0] in ("pan", "pan-visible", "pan-composite"):
+        _need(rest, 2, f"grab {rest[0]} requires a pan index")
+        req["selector"] = rest[1]
+        if len(rest) > 2:
+            req["path"] = rest[2]
+    elif len(rest) > 1:
+        req["path"] = rest[1]
+    return req
+
+
+def _map_invoke(rest):
+    _need(rest, 2, "invoke needs <target> <action> [value]")
+    req = {"target": rest[0], "action": rest[1]}
+    if len(rest) > 2:
+        req["value"] = " ".join(rest[2:])
+    return req
+
+
+def _map_get(rest):
+    _need(rest, 1, "get needs <model> [selector] [property]")
+    req = {"model": rest[0]}
+    if len(rest) > 1:
+        req["selector"] = rest[1]
+    if len(rest) > 2:
+        req["property"] = rest[2]
+    return req
+
+
+def _map_clickat(rest):
+    # clickAt <x> <y>           -> global screen coords (dumpTree geometry)
+    # clickAt <target> <x> <y>  -> coords local to <target>
+    # Disambiguate like the server: first token numeric => global form
+    # (_as_int: strict int, floats error loudly).
+    if len(rest) >= 2 and _as_int(rest[0]) is not None:
+        if _as_int(rest[1]) is None:
+            sys.exit(f"error: clickAt y must be an integer, got {rest[1]!r}")
+        return {"value": f"{rest[0]} {rest[1]}"}
+    if len(rest) >= 3 and _as_int(rest[0]) is None:
+        if _as_int(rest[1]) is None or _as_int(rest[2]) is None:
+            sys.exit("error: clickAt <target> <x> <y> — x and y must be integers")
+        return {"target": rest[0], "value": f"{rest[1]} {rest[2]}"}
+    raise SystemExit("error: clickAt needs <x> <y> or <target> <x> <y>")
+
+
+def _map_rightclick(rest):
+    if not rest:
+        sys.exit("error: rightClick needs <target> [x y]")
+    if len(rest) not in (1, 3):
+        sys.exit("error: rightClick needs <target> or <target> <x> <y>")
+    if len(rest) == 3:
+        if _as_int(rest[1]) is None or _as_int(rest[2]) is None:
+            sys.exit("error: rightClick x and y must be integers")
+    req = {"target": rest[0]}
+    if len(rest) > 1:
+        req["value"] = " ".join(rest[1:])
+    return req
+
+
+def _map_hover(rest):
+    _need(rest, 1, "hover needs <target> [leave]")
+    req = {"target": rest[0]}
+    if len(rest) > 1:
+        req["action"] = rest[1]
+    return req
+
+
+def _map_tooltip(rest):
+    _need(rest, 1, "tooltip needs <target> [hide|text...]")
+    req = {"target": rest[0]}
+    if len(rest) > 1:
+        if rest[1] == "hide":
+            if len(rest) != 2:
+                sys.exit("error: tooltip hide takes no extra arguments")
+            req["action"] = "hide"
+        else:
+            req["value"] = " ".join(rest[1:])
+    return req
+
+
+def _map_resize(rest):
+    _need(rest, 2, "resize needs <w> <h> [target]")
+    req = {"value": f"{rest[0]} {rest[1]}"}
+    if len(rest) > 2:
+        req["target"] = " ".join(rest[2:])
+    return req
+
+
+def _map_dss(rest):
+    _need(rest, 1, "dss needs <snapshot|reset|inject|scrollback|live> [pan] [args]")
+    action = rest[0]
+    req = {"action": action}
+    dss_args = rest[1:]
+    if action == "inject":
+        stream_names = {"native", "flex", "kiwi", "kiwisdr"}
+        if len(dss_args) < 3:
+            sys.exit("error: dss inject needs [pan] <count> <firstPeakBin> <stepBin> "
+                     "[native|kiwi [rowLowMhz rowHighMhz]]")
+        if (len(dss_args) == 3
+                or (len(dss_args) == 4 and dss_args[3].lower() in stream_names)
+                or (len(dss_args) == 6 and dss_args[3].lower() in stream_names)):
+            req["value"] = " ".join(dss_args)
+        else:
+            req["target"] = dss_args[0]
+            req["value"] = " ".join(dss_args[1:])
+    elif action == "scrollback":
+        if not dss_args:
+            sys.exit("error: dss scrollback needs [pan] <offsetRows>")
+        if len(dss_args) == 1:
+            req["value"] = dss_args[0]
+        else:
+            req["target"] = dss_args[0]
+            req["value"] = " ".join(dss_args[1:])
+    else:
+        if dss_args:
+            req["target"] = dss_args[0]
+        if len(dss_args) > 1:
+            req["value"] = " ".join(dss_args[1:])
+    return req
+
+
+def _map_audiocapture(rest):
+    action = rest[0] if rest else "status"
+    req = {"action": action}
+    if len(rest) > 1:
+        if action == "read" and len(rest) == 2:
+            req["path"] = rest[1]
+        else:
+            req["value"] = " ".join(rest[1:])
+    return req
+
+
+def _map_panmessage(rest):
+    if not rest:
+        sys.exit("error: panmessage needs <add|remove|clear|list> <target> ...")
+    req = {"action": rest[0]}
+    if len(rest) > 1:
+        req["target"] = rest[1]
+    if rest[0] in ("add", "upsert"):
+        if len(rest) < 5:
+            sys.exit("error: panmessage add needs <target> <id> <timeoutMs> <title|detail>")
+        req["id"] = rest[2]
+        try:
+            req["timeoutMs"] = int(rest[3])
+        except ValueError:
+            sys.exit("error: panmessage add timeoutMs must be an integer")
+        text_start = 4
+        if len(rest) > text_start and rest[text_start].lower().startswith("tone="):
+            req["tone"] = rest[text_start].split("=", 1)[1].strip()
+            text_start += 1
+        text = " ".join(rest[text_start:])
+        title, sep, detail = text.partition("|")
+        req["title"] = title.strip()
+        req["detail"] = detail.strip() if sep else ""
+    elif rest[0] in ("remove", "dismiss"):
+        if len(rest) < 3:
+            sys.exit("error: panmessage remove needs <target> <id>")
+        req["id"] = rest[2]
+    return req
+
+
+MAPPERS = {
+    "grab": _map_grab,
+    "invoke": _map_invoke,
+    "get": _map_get,
+    "hitTest": _map_target_value("hitTest needs <target> [x y]"),
+    "contextMenu": _map_target_value("contextMenu needs <target> [x y]"),
+    "rightClick": _map_rightclick,
+    "clickAt": _map_clickat,
+    "hover": _map_hover,
+    "tooltip": _map_tooltip,
+    "resize": _map_resize,
+    "connect": _map_action_value("connect needs <list|show|hide|local|ip|wait> [args]"),
+    "slice": _map_action_value("slice needs an action"),
+    "pan": _map_action_value("pan needs <create|add|center|close|remove> [value]"),
+    "layout": _map_action_value("layout needs <rearrange <id> | get>"),
+    "record": _map_action_value(),
+    "testtone": _map_action_value(),
+    # tci has no bare-line parse arm server-side (see the verb registry) —
+    # the JSON action/value form is the only supported request shape.
+    "tci": _map_action_value(),
+    "dss": _map_dss,
+    "audioCapture": _map_audiocapture,
+    "panmessage": _map_panmessage,
+}
+
+
 def main():
     ap = argparse.ArgumentParser(
         description="Drive the AetherSDR automation bridge",
-        epilog="examples:\n"
+        epilog="Any bridge verb is accepted; run `automation_probe.py verbs` to list\n"
+               "what the running app understands. examples:\n"
                "  automation_probe.py demo\n"
+               "  automation_probe.py verbs\n"
                "  automation_probe.py connect list\n"
-               "  automation_probe.py connect show\n"
                "  automation_probe.py connect local first\n"
                "  automation_probe.py connect wait 30000\n"
                "  automation_probe.py get radio\n"
-               "  automation_probe.py get sync\n"
                "  automation_probe.py get slice active frequency\n"
                "  automation_probe.py slice rxsource 7 K4JK\n"
                "  automation_probe.py slice fixture 4 B\n"
@@ -170,37 +408,11 @@ def main():
                "  automation_probe.py panmessage add 0 tx 10000 tone=warning 'Transmit disabled|TX blocked'",
         formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("command", nargs="?", default="demo",
-                    choices=["demo", "ping", "dumpTree", "grab", "invoke", "get",
-                             "connect", "disconnect", "slice", "tune", "shortcut",
-                             "actions", "contextMenu", "rightClick", "audioCapture",
-                             "record", "testtone", "tci", "panmessage",
-                             "hover", "tooltip", "hitTest", "rightClick", "clickAt", "resize", "dss",
-                             "pan", "layout", "scale"],
-                    help="verb to run (default: demo = dumpTree + panadapter grab)")
+                    help="bridge verb, or: demo (dumpTree + panadapter grab), "
+                         "actions [text-filter] (client-side QAction search)")
     ap.add_argument("rest", nargs="*",
-                    help="verb args: grab <target> [path] | grab pan-visible <index> [path] | "
-                         "invoke <target> <action> [value] | "
-                         "get <model> [selector] [property] | "
-                         "hover <target> [leave] | "
-                         "tooltip <target> [hide|text...] | "
-                         "actions [text-filter] | "
-                         "contextMenu <target> [x y] | "
-                         "rightClick <target> [x y] | "
-                         "hitTest <target> [x y] | "
-                         "rightClick <target> [x y] | "
-                         "clickAt <x> <y> | clickAt <target> <x> <y> | "
-                         "resize <w> <h> [target] | "
-                         "connect <list|show|hide|local|ip|wait> [args] | "
-                         "slice <add|remove|select|tx|diversity|centerlock|txant|rxant|rxsource|fixture|clearfixture> [args] | "
-                         "dss <snapshot|reset|live> [pan] [args] | "
-                         "dss inject [pan] <count> <firstPeakBin> <stepBin> "
-                         "[native|kiwi [rowLowMhz rowHighMhz]] | "
-                         "dss scrollback [pan] <offsetRows> | "
-                         "pan <create|add|center|close|remove> [value] | "
-                         "layout <rearrange <id>|get> | scale [pct] | "
-                         "tune <mhz> | shortcut <action-id> | "
-                         "panmessage <add|remove|clear|list> <target> [id timeout [tone=info|warning] title|detail] | "
-                         "audioCapture <start|stop|status|read> [args]")
+                    help="verb arguments (positional, same shapes as the bare "
+                         "socket protocol; see `verbs` and docs/automation-bridge.md)")
     ap.add_argument("--socket", help="override the bridge socket path")
     ap.add_argument("--out", default=".", help="output dir for demo artifacts")
     args = ap.parse_args()
@@ -216,266 +428,8 @@ def main():
         sys.exit(f"error: could not connect to {sock_path}: {e}")
 
     try:
-        if args.command == "ping":
-            print(json.dumps(bridge.request({"cmd": "ping"}), indent=2))
-
-        elif args.command == "dumpTree":
-            print(json.dumps(bridge.request({"cmd": "dumpTree"}), indent=2))
-
-        elif args.command == "grab":
-            if not args.rest:
-                sys.exit("error: grab requires a target widget name")
-            req = {"cmd": "grab", "target": args.rest[0]}
-            if args.rest[0] in ("pan", "pan-visible", "pan-composite"):
-                if len(args.rest) < 2:
-                    sys.exit(f"error: grab {args.rest[0]} requires a pan index")
-                req["selector"] = args.rest[1]
-                if len(args.rest) > 2:
-                    req["path"] = args.rest[2]
-            elif len(args.rest) > 1:
-                req["path"] = args.rest[1]
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "invoke":
-            if len(args.rest) < 2:
-                sys.exit("error: invoke needs <target> <action> [value]")
-            req = {"cmd": "invoke", "target": args.rest[0], "action": args.rest[1]}
-            if len(args.rest) > 2:
-                req["value"] = " ".join(args.rest[2:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "get":
-            if not args.rest:
-                sys.exit("error: get needs <model> [selector] [property] "
-                         "(model = radio|slice|slices|pan|pans|flags)")
-            req = {"cmd": "get", "model": args.rest[0]}
-            if len(args.rest) > 1:
-                req["selector"] = args.rest[1]
-            if len(args.rest) > 2:
-                req["property"] = args.rest[2]
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "hitTest":
-            if not args.rest:
-                sys.exit("error: hitTest needs <target> [x y]")
-            req = {"cmd": "hitTest", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "rightClick":
-            if not args.rest:
-                sys.exit("error: rightClick needs <target> [x y]")
-            req = {"cmd": "rightClick", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "clickAt":
-            # clickAt <x> <y>            -> global screen coords (dumpTree geometry)
-            # clickAt <target> <x> <y>  -> coords local to <target>
-            # Disambiguate like the server: first token numeric => global form
-            # (module-level _as_int: strict int, floats error loudly).
-            if len(args.rest) >= 2 and _as_int(args.rest[0]) is not None:
-                if _as_int(args.rest[1]) is None:
-                    sys.exit(f"error: clickAt y must be an integer, got {args.rest[1]!r}")
-                req = {"cmd": "clickAt", "value": f"{args.rest[0]} {args.rest[1]}"}
-            elif len(args.rest) >= 3 and _as_int(args.rest[0]) is None:
-                if _as_int(args.rest[1]) is None or _as_int(args.rest[2]) is None:
-                    sys.exit("error: clickAt <target> <x> <y> — x and y must be integers")
-                req = {"cmd": "clickAt", "target": args.rest[0],
-                       "value": f"{args.rest[1]} {args.rest[2]}"}
-            else:
-                sys.exit("error: clickAt needs <x> <y> or <target> <x> <y>")
-
-        elif args.command == "pan":
-            if not args.rest:
-                sys.exit("error: pan needs <create|add|center|close|remove> [value]")
-            req = {"cmd": "pan", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "tune":
-            if not args.rest:
-                sys.exit("error: tune needs a frequency in MHz")
-            print(json.dumps(bridge.request({"cmd": "tune", "value": args.rest[0]}), indent=2))
-
-        elif args.command == "shortcut":
-            if not args.rest:
-                sys.exit("error: shortcut needs an action id")
-            print(json.dumps(bridge.request({"cmd": "shortcut", "target": args.rest[0]}), indent=2))
-
-        elif args.command == "actions":
-            tree = bridge.request({"cmd": "dumpTree"})
-            pattern = " ".join(args.rest) if args.rest else None
-            actions = collect_actions(tree, pattern)
-            print(json.dumps({"ok": True, "count": len(actions), "actions": actions}, indent=2))
-
-        elif args.command == "contextMenu":
-            if not args.rest:
-                sys.exit("error: contextMenu needs <target> [x y]")
-            req = {"cmd": "contextMenu", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "rightClick":
-            if not args.rest:
-                sys.exit("error: rightClick needs <target> [x y]")
-            if len(args.rest) not in (1, 3):
-                sys.exit("error: rightClick needs <target> or <target> <x> <y>")
-            if len(args.rest) == 3:
-                if _as_int(args.rest[1]) is None or _as_int(args.rest[2]) is None:
-                    sys.exit("error: rightClick x and y must be integers")
-            req = {"cmd": "rightClick", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "layout":
-            if not args.rest:
-                sys.exit("error: layout needs <rearrange <id> | get>")
-            req = {"cmd": "layout", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "scale":
-            req = {"cmd": "scale"}
-            if args.rest:
-                req["value"] = args.rest[0]
-
-        elif args.command == "hover":
-            if not args.rest:
-                sys.exit("error: hover needs <target> [leave]")
-            req = {"cmd": "hover", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                req["action"] = args.rest[1]
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "tooltip":
-            if not args.rest:
-                sys.exit("error: tooltip needs <target> [hide|text...]")
-            req = {"cmd": "tooltip", "target": args.rest[0]}
-            if len(args.rest) > 1:
-                if args.rest[1] == "hide":
-                    if len(args.rest) != 2:
-                        sys.exit("error: tooltip hide takes no extra arguments")
-                    req["action"] = "hide"
-                else:
-                    req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "resize":
-            if len(args.rest) < 2:
-                sys.exit("error: resize needs <w> <h> [target]")
-            req = {"cmd": "resize", "value": f"{args.rest[0]} {args.rest[1]}"}
-            if len(args.rest) > 2:
-                req["target"] = " ".join(args.rest[2:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "connect":
-            if not args.rest:
-                sys.exit("error: connect needs <list|local|ip|wait> [args]")
-            req = {"cmd": "connect", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "disconnect":
-            print(json.dumps(bridge.request({"cmd": "disconnect"}), indent=2))
-
-        elif args.command == "slice":
-            if not args.rest:
-                sys.exit("error: slice needs an action")
-            req = {"cmd": "slice", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "dss":
-            if not args.rest:
-                sys.exit("error: dss needs <snapshot|reset|inject|scrollback|live> [pan] [args]")
-            action = args.rest[0]
-            req = {"cmd": "dss", "action": action}
-            dss_args = args.rest[1:]
-            if action == "inject":
-                stream_names = {"native", "flex", "kiwi", "kiwisdr"}
-                if len(dss_args) < 3:
-                    sys.exit("error: dss inject needs [pan] <count> <firstPeakBin> <stepBin> "
-                             "[native|kiwi [rowLowMhz rowHighMhz]]")
-                if (len(dss_args) == 3
-                        or (len(dss_args) == 4 and dss_args[3].lower() in stream_names)
-                        or (len(dss_args) == 6 and dss_args[3].lower() in stream_names)):
-                    req["value"] = " ".join(dss_args)
-                else:
-                    req["target"] = dss_args[0]
-                    req["value"] = " ".join(dss_args[1:])
-            elif action == "scrollback":
-                if not dss_args:
-                    sys.exit("error: dss scrollback needs [pan] <offsetRows>")
-                if len(dss_args) == 1:
-                    req["value"] = dss_args[0]
-                else:
-                    req["target"] = dss_args[0]
-                    req["value"] = " ".join(dss_args[1:])
-            else:
-                if dss_args:
-                    req["target"] = dss_args[0]
-                if len(dss_args) > 1:
-                    req["value"] = " ".join(dss_args[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "audioCapture":
-            action = args.rest[0] if args.rest else "status"
-            req = {"cmd": "audioCapture", "action": action}
-            if len(args.rest) > 1:
-                if action == "read" and len(args.rest) == 2:
-                    req["path"] = args.rest[1]
-                else:
-                    req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command in ("record", "testtone", "tci"):
-            # record <start|stop|status|path|dir [path]> | testtone <on [hz] [db]|off>
-            # tci <start [port]|status|stop [abrupt]>
-            req = {"cmd": args.command}
-            if args.rest:
-                req["action"] = args.rest[0]
-                if len(args.rest) > 1:
-                    req["value"] = " ".join(args.rest[1:])
-            print(json.dumps(bridge.request(req), indent=2))
-
-        elif args.command == "panmessage":
-            if not args.rest:
-                sys.exit("error: panmessage needs <add|remove|clear|list> <target> ...")
-            req = {"cmd": "panmessage", "action": args.rest[0]}
-            if len(args.rest) > 1:
-                req["target"] = args.rest[1]
-            if args.rest[0] in ("add", "upsert"):
-                if len(args.rest) < 5:
-                    sys.exit("error: panmessage add needs <target> <id> <timeoutMs> <title|detail>")
-                req["id"] = args.rest[2]
-                try:
-                    req["timeoutMs"] = int(args.rest[3])
-                except ValueError:
-                    sys.exit("error: panmessage add timeoutMs must be an integer")
-                text_start = 4
-                if len(args.rest) > text_start and args.rest[text_start].lower().startswith("tone="):
-                    req["tone"] = args.rest[text_start].split("=", 1)[1].strip()
-                    text_start += 1
-                text = " ".join(args.rest[text_start:])
-                title, sep, detail = text.partition("|")
-                req["title"] = title.strip()
-                req["detail"] = detail.strip() if sep else ""
-            elif args.rest[0] in ("remove", "dismiss"):
-                if len(args.rest) < 3:
-                    sys.exit("error: panmessage remove needs <target> <id>")
-                req["id"] = args.rest[2]
-            print(json.dumps(bridge.request(req), indent=2))
-
-        else:  # demo: produce the Phase-0 deliverables
+        if args.command == "demo":
+            # Produce the Phase-0 deliverables.
             os.makedirs(args.out, exist_ok=True)
 
             pong = bridge.request({"cmd": "ping"})
@@ -497,6 +451,26 @@ def main():
             else:
                 print(f"panadapter grab failed: {grab.get('error')}", file=sys.stderr)
                 sys.exit(1)
+
+        elif args.command == "actions":
+            tree = bridge.request({"cmd": "dumpTree"})
+            pattern = " ".join(args.rest) if args.rest else None
+            actions = collect_actions(tree, pattern)
+            print(json.dumps({"ok": True, "count": len(actions), "actions": actions}, indent=2))
+
+        else:
+            mapper = MAPPERS.get(args.command)
+            if mapper is not None:
+                req = mapper(args.rest)
+                req["cmd"] = args.command
+                resp = bridge.request(req)
+            else:
+                # No bespoke mapping: pass the bare positional line through and
+                # let the server's verb registry parse it. Note: the server
+                # re-splits on spaces, so multi-word arguments need a MAPPERS
+                # entry (or the JSON protocol) to survive quoting.
+                resp = bridge.request_line(" ".join([args.command] + args.rest))
+            print(json.dumps(resp, indent=2))
     finally:
         bridge.close()
 


### PR DESCRIPTION
Implements **Phases 1 and 2 of #4174** — the AutomationBridge conflict-resistance refactor.

## What we're aiming to accomplish

The automation bridge has become the most conflict-prone surface in the repo. Nearly every bridge PR adds or extends a verb, and until now doing that meant editing the **same ordered lists** in the same places:

1. the bare-line parse chain in `handleLine` (~200 lines of `else if` arms),
2. the dispatch chain below it (~45 `if (cmd == …)` blocks),
3. the hand-kept startup banner string,
4. the `get` required-model hint string,
5. `automation_probe.py`'s `choices=` list, help text, and ~30-arm elif chain,
6. the docs verb table + sections,
7. the handler declaration cluster in `AutomationServer.h`.

Two unrelated verb PRs in flight at once collide on nearly all of them — we've been paying that tax in almost every review cycle (#4116, #4124, #4137 all had verb-region conflicts this month). The root cause is that a verb's definition was smeared across seven centralized, ordered structures instead of living in one place.

**The goal: adding a verb should be one self-contained registry entry plus its handler — nothing else to keep in sync, and no shared lines for two verb PRs to fight over.** Derived data (banners, error hints, catalogs) should be computed from that single source of truth so it can never go stale.

This PR removes hotspots 1–5. Phase 3 (family-TU split of the handler bodies, generated docs with a `--check` CI gate, merge queue) stays tracked in #4174.

## What changed

### `AutomationServer`: table-driven verb registry
- New `AutomationServer::verbRegistry()`: one `VerbSpec` per verb — canonical name, aliases, one-line help, a bare-line parse lambda, and a dispatch lambda. Shared parse-shape helpers (`actionRest`, `targetXY`, `valueOnly`, …) cover most verbs; the bespoke parsers (`grab`, `clickAt`, `panmessage`, `dss`, `tooltip`, `resize`, `window`, `invoke`, `get`) migrated verbatim.
- `handleLine()` collapsed to a spine: JSON fields map 1:1 onto a `VerbArgs` struct, bare lines go through the verb's own registry parser, and dispatch is a hash lookup. Adding a verb no longer touches this function.
- **Derived enumerations**: the startup banner, the `unknown command` error, and the `get` model hint are computed from the registry / one model-name list. They can no longer drift or conflict.
- New read-only **`verbs`** verb: machine-readable catalog (`{name, aliases, help}` × 45) so drivers ask the running app what it understands instead of hand-maintaining lists.

### Behavior preserved byte-for-byte
- Every error string, TX gate, and validation was migrated exactly, including the `tooltip … hide` trailing-token rejection (#4122), the `clickAt` JSON numeric-x/y fold, and case-sensitive alias matching (`hitTest`/`hittest`, `drag`/`mouse`, `showMenu`/`openMenu`, `scrollTo`/`ensureVisible`, `clickAt`/`clickat`).
- Preserved quirk, now documented in-line instead of accidental: `tci` has no bare-line parse arm (JSON `action`/`value` form only), exactly as before.

### `tools/automation_probe.py`: generic passthrough
- Dropped the `choices=` allowlist and the elif chain. Verbs that need quoting-safe JSON fields or client-side validation keep a small `MAPPERS` entry; **every other verb passes through as a bare positional line** for the server registry to parse — so new simple verbs need zero probe changes. `whoami`, `floors`, `verbs`, `log`, `mark`, `menu`, `key`, `station`, `qrz`, … work in the probe for the first time, for free.
- Fixes two latent dead branches found during the rewrite: the old `clickAt` and `scale` arms built their request dict but never sent or printed it.

### Docs
- `docs/automation-bridge.md`: `verbs` section + a note that the registry is the single server-side source of truth ("when this table and the running app disagree, trust `verbs`").

## Verification

- Clean build (RelWithDebInfo, no new warnings) and **79/79 ctest**.
- **24-check live parity smoke** against an offscreen instance with scratch config: exact old error strings (`get` model hint, `connect`/`panmessage`/`invoke`/`grab` usage errors), all five aliases dispatch to the same handlers, `shortcut atu_start` still refused without `AETHER_AUTOMATION_ALLOW_TX`, `slice fixture` works, JSON string-typed `x`/`y` on `clickAt` still rejected (no (0,0) click), `tci` bare-line quirk intact, and the derived 45-verb banner logs correctly.
- Probe exercised live end-to-end: quoted multi-word `invoke 'Master volume' setValue 30`, new verbs via bare-line fallback, `tci status` via its JSON-only mapper, client-side validation errors, and the demo flow.

Closes nothing on its own — tracking issue #4174 stays open for Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
