### PR TITLE
feat(automation): MCP server + Radio Setup bridge toggle with token auth (#3646)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ msix-root-*/
 *.msixupload
 *.pfx
 packaging/windows/certs/
+__pycache__/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "aethersdr-automation": {
+      "command": "python3",
+      "args": ["tools/aether_mcp.py"]
+    }
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,7 @@ set(CORE_SOURCES
     src/core/PskReporterClient.cpp
     src/core/MqttAntennaAlias.cpp
     src/core/MqttSettings.cpp
+    src/core/AutomationBridgeSettings.cpp
     src/core/SpotCommandPolicy.cpp
     src/core/SpotModeResolver.cpp
     src/core/TciServer.cpp
@@ -2285,6 +2286,15 @@ target_include_directories(radio_status_ownership_test PRIVATE src)
 target_link_libraries(radio_status_ownership_test PRIVATE Qt6::Core)
 enable_testing()
 add_test(NAME radio_status_ownership_test COMMAND radio_status_ownership_test)
+
+# MCP server field-mapping / protocol regression test (#4177). Pure Python,
+# no app or Qt needed — guards the schema ↔ bridge verb field mapping.
+find_program(PYTHON3_EXECUTABLE NAMES python3 python)
+if(PYTHON3_EXECUTABLE)
+    add_test(NAME aether_mcp_field_mapping
+             COMMAND ${PYTHON3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_aether_mcp.py)
+endif()
 
 add_executable(profile_load_command_test
     tests/profile_load_command_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -84,6 +84,46 @@ QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1 AETHER_AUTOMATION_NO_AUTOCONNECT=1
 
 ---
 
+## MCP server — drive the bridge from any AI assistant
+
+`tools/aether_mcp.py` wraps this bridge in the Model Context Protocol, so
+an MCP-capable coding assistant (Claude Code, Cursor, Copilot, Codex CLI,
+Gemini CLI, …) can validate your PR against the running app natively —
+no socket scripting required. This is the recommended way for
+contributors to self-verify UI changes before requesting review.
+
+**Setup** (zero dependencies — plain Python 3):
+
+1. Launch the app with the bridge on: `AETHER_AUTOMATION=1 ./build/AetherSDR`
+2. Register the server with your assistant:
+   - **Claude Code**: nothing to do — the repo's `.mcp.json` registers it;
+     approve the prompt on first use. (Manual: `claude mcp add aethersdr
+     -- python3 tools/aether_mcp.py`)
+   - **Cursor / Windsurf / others**: add to your MCP config:
+     ```json
+     {"mcpServers": {"aethersdr-automation": {
+        "command": "python3", "args": ["tools/aether_mcp.py"]}}}
+     ```
+   - **Windows**: use `python` (or `py -3`) instead of `python3`.
+
+**Tools exposed**: `bridge_status` (is the app up? which instance?),
+`dump_tree` (widget tree, with a `filter` arg to prune), `grab_widget`
+(PNG screenshot, returned inline to the model), `invoke` (click/toggle/
+setValue/…), `get_state` (`get` model snapshots), `shortcut`, and
+`bridge_command` (raw escape hatch to every other verb below).
+
+A typical assistant validation loop for a PR:
+`bridge_status` → `dump_tree filter=<your widget>` → `invoke` the
+control you changed → `get_state` to assert the model reacted →
+`grab_widget` for a visual check.
+
+The TX-safety gate is unchanged: the bridge refuses transmit-keying
+controls regardless of who's calling (see [TX safety](#tx-safety)), so
+an assistant can never key your radio unless you launched the app with
+`AETHER_AUTOMATION_ALLOW_TX=1` yourself.
+
+---
+
 ## How it works (the contract)
 
 - **Transport:** a `QLocalServer` — an `AF_UNIX` socket on macOS/Linux, a named

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -117,10 +117,16 @@ A typical assistant validation loop for a PR:
 control you changed → `get_state` to assert the model reacted →
 `grab_widget` for a visual check.
 
-The TX-safety gate is unchanged: the bridge refuses transmit-keying
-controls regardless of who's calling (see [TX safety](#tx-safety)), so
-an assistant can never key your radio unless you launched the app with
-`AETHER_AUTOMATION_ALLOW_TX=1` yourself.
+The TX-safety gate is unchanged in spirit: the bridge refuses transmit-
+keying controls regardless of who's calling (see [TX safety](#tx-safety)).
+An assistant can only key your radio if **you** opt in — either by
+launching with `AETHER_AUTOMATION_ALLOW_TX=1`, or by checking **"Allow
+TX via MCP"** in Radio Setup → Network. That checkbox raises a one-time
+confirmation spelling out that automated software will be able to
+transmit and that you, the operator, remain responsible for all
+emissions; once confirmed the choice persists. Toggling it drives the
+same `m_txAllowed` gate live (enabling arms the force-unkey watchdog;
+disabling force-unkeys immediately).
 
 ---
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -117,6 +117,23 @@ A typical assistant validation loop for a PR:
 control you changed → `get_state` to assert the model reacted →
 `grab_widget` for a visual check.
 
+**Access token.** Enabling the bridge in Radio Setup → Network mints a
+random token (stored in your OS secret store via QtKeychain — macOS
+Keychain / Windows Credential Manager / libsecret-KWallet, never in the
+plaintext settings file). Copy it into your assistant's MCP config as the
+`AETHER_MCP_TOKEN` environment variable; the bridge then rejects every
+verb except `ping` without a matching token. Headless/CI can supply the
+token via `AETHER_MCP_TOKEN` directly, which overrides the keychain.
+
+What the token *does* and *doesn't* do: it opts a **specific** client in
+and protects the secret at rest (nothing in a backed-up / synced /
+screen-shared dotfile), across other user accounts, and over any network
+reach. It is **not** a hard wall against a determined *same-user* process
+on Linux/Windows — once your login keychain is unlocked, libsecret and
+DPAPI hand the secret to any same-user caller (macOS, with its per-item
+ACL prompt, is the exception). Treat it as "this app deliberately grants
+this client access," not "same-user isolation."
+
 The TX-safety gate is unchanged in spirit: the bridge refuses transmit-
 keying controls regardless of who's calling (see [TX safety](#tx-safety)).
 An assistant can only key your radio if **you** opt in — either by

--- a/src/core/AutomationBridgeSettings.cpp
+++ b/src/core/AutomationBridgeSettings.cpp
@@ -1,0 +1,205 @@
+#include "core/AutomationBridgeSettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QObject>
+
+#ifdef HAVE_KEYCHAIN
+#include <qt6keychain/keychain.h>
+#endif
+
+namespace AetherSDR {
+
+namespace {
+// Single nested-JSON key holding the bridge's non-secret config (Principle V).
+// Shape: {"enabled":bool,"txAllowed":bool,"txAck":bool}.
+const QString kRootKey = QStringLiteral("AutomationBridge");
+
+// Legacy flat keys (pre-nesting). Migrated one-shot into kRootKey on first read.
+const QString kLegacyEnabled   = QStringLiteral("AutomationBridgeEnabled");
+const QString kLegacyTxAllowed = QStringLiteral("AutomationBridgeTxAllowed");
+const QString kLegacyTxAck     = QStringLiteral("AutomationBridgeTxAck");
+
+constexpr const char* kFieldEnabled   = "enabled";
+constexpr const char* kFieldTxAllowed = "txAllowed";
+constexpr const char* kFieldTxAck     = "txAck";
+
+// Keychain coordinates for the token (analogous to MqttSettings).
+constexpr const char* kKeychainService  = "AetherSDR";
+constexpr const char* kKeychainKey      = "automation_bridge_token";
+const QString kLegacyTokenKey = QStringLiteral("AutomationBridgeToken");
+} // namespace
+
+QJsonObject AutomationBridgeSettings::readObj()
+{
+    auto& s = AppSettings::instance();
+    const QString json = s.value(kRootKey, QString{}).toString();
+    if (!json.isEmpty())
+        return QJsonDocument::fromJson(json.toUtf8()).object();
+
+    // No nested object yet. If any legacy flat key exists, migrate them once
+    // into the nested object and drop the flat keys; otherwise return defaults.
+    const bool hasLegacy = !s.value(kLegacyEnabled).toString().isEmpty()
+                        || !s.value(kLegacyTxAllowed).toString().isEmpty()
+                        || !s.value(kLegacyTxAck).toString().isEmpty();
+    if (!hasLegacy)
+        return {};
+
+    QJsonObject o;
+    o[QLatin1String(kFieldEnabled)]   = s.value(kLegacyEnabled, false).toBool();
+    o[QLatin1String(kFieldTxAllowed)] = s.value(kLegacyTxAllowed, false).toBool();
+    o[QLatin1String(kFieldTxAck)]     = s.value(kLegacyTxAck, false).toBool();
+    s.setValue(kRootKey, QString::fromUtf8(
+                   QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.remove(kLegacyEnabled);
+    s.remove(kLegacyTxAllowed);
+    s.remove(kLegacyTxAck);
+    s.save();
+    return o;
+}
+
+void AutomationBridgeSettings::writeBool(const char* field, bool value)
+{
+    // Read-modify-write the whole object so the three bools are always
+    // persisted together (atomic — never enabled=true with a half-written peer).
+    QJsonObject o = readObj();
+    o[QLatin1String(field)] = value;
+    auto& s = AppSettings::instance();
+    s.setValue(kRootKey, QString::fromUtf8(
+                   QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+bool AutomationBridgeSettings::enabled()
+{
+    return readObj().value(QLatin1String(kFieldEnabled)).toBool(false);
+}
+void AutomationBridgeSettings::setEnabled(bool on) { writeBool(kFieldEnabled, on); }
+
+bool AutomationBridgeSettings::txAllowed()
+{
+    return readObj().value(QLatin1String(kFieldTxAllowed)).toBool(false);
+}
+void AutomationBridgeSettings::setTxAllowed(bool on) { writeBool(kFieldTxAllowed, on); }
+
+bool AutomationBridgeSettings::txAck()
+{
+    return readObj().value(QLatin1String(kFieldTxAck)).toBool(false);
+}
+void AutomationBridgeSettings::setTxAck(bool on) { writeBool(kFieldTxAck, on); }
+
+QString AutomationBridgeSettings::keychainService()
+{
+    return QString::fromLatin1(kKeychainService);
+}
+QString AutomationBridgeSettings::keychainKey()
+{
+    return QString::fromLatin1(kKeychainKey);
+}
+QString AutomationBridgeSettings::legacyTokenSettingKey() { return kLegacyTokenKey; }
+
+void AutomationBridgeSettings::loadToken(QObject* ctx,
+                                         std::function<void(const QString&)> cb)
+{
+    // Env override wins (headless / CI), regardless of keychain availability.
+    const QByteArray envTok = qgetenv("AETHER_MCP_TOKEN");
+    if (!envTok.isEmpty()) {
+        cb(QString::fromUtf8(envTok));
+        return;
+    }
+
+#ifdef HAVE_KEYCHAIN
+    auto& s = AppSettings::instance();
+    const QString legacy = s.value(kLegacyTokenKey).toString();
+    if (!legacy.isEmpty()) {
+        // One-shot migrate the old plaintext token into the OS secret store,
+        // then drop the plaintext copy. Hand the caller the value immediately.
+        auto* job = new QKeychain::WritePasswordJob(keychainService());
+        job->setAutoDelete(true);
+        job->setKey(keychainKey());
+        job->setTextData(legacy);
+        QObject::connect(job, &QKeychain::Job::finished, ctx ? ctx : job,
+                         [](QKeychain::Job* j) {
+            if (j->error() == QKeychain::NoError) {
+                AppSettings::instance().remove(kLegacyTokenKey);
+                AppSettings::instance().save();
+            } else {
+                qWarning() << "AutomationBridge: token keychain migration failed:"
+                           << j->errorString() << "- plaintext preserved for retry";
+            }
+        });
+        job->start();
+        cb(legacy);
+        return;
+    }
+    auto* job = new QKeychain::ReadPasswordJob(keychainService());
+    job->setAutoDelete(true);
+    job->setKey(keychainKey());
+    QObject::connect(job, &QKeychain::Job::finished, ctx ? ctx : job,
+                     [cb = std::move(cb)](QKeychain::Job* j) {
+        if (j->error() == QKeychain::NoError) {
+            cb(static_cast<QKeychain::ReadPasswordJob*>(j)->textData());
+        } else {
+            if (j->error() != QKeychain::EntryNotFound)
+                qWarning() << "AutomationBridge: token keychain read failed:"
+                           << j->errorString();
+            cb(QString{});
+        }
+    });
+    job->start();
+#else
+    const QString legacy = AppSettings::instance().value(kLegacyTokenKey).toString();
+    if (!legacy.isEmpty())
+        qWarning() << "AutomationBridge: HAVE_KEYCHAIN not set - token remains in "
+                      "plaintext AppSettings";
+    cb(legacy);
+#endif
+}
+
+void AutomationBridgeSettings::saveToken(const QString& token)
+{
+#ifdef HAVE_KEYCHAIN
+    // Never leave a plaintext copy once the keychain is authoritative.
+    AppSettings::instance().remove(kLegacyTokenKey);
+    AppSettings::instance().save();
+    if (token.isEmpty()) {
+        auto* job = new QKeychain::DeletePasswordJob(keychainService());
+        job->setAutoDelete(true);
+        job->setKey(keychainKey());
+        QObject::connect(job, &QKeychain::Job::finished, job, [](QKeychain::Job* j) {
+            if (j->error() != QKeychain::NoError
+                && j->error() != QKeychain::EntryNotFound) {
+                qWarning() << "AutomationBridge: token keychain delete failed:"
+                           << j->errorString();
+            }
+        });
+        job->start();
+        return;
+    }
+    auto* job = new QKeychain::WritePasswordJob(keychainService());
+    job->setAutoDelete(true);
+    job->setKey(keychainKey());
+    job->setTextData(token);
+    QObject::connect(job, &QKeychain::Job::finished, job, [](QKeychain::Job* j) {
+        if (j->error() != QKeychain::NoError)
+            qWarning() << "AutomationBridge: token keychain save failed:"
+                       << j->errorString();
+    });
+    job->start();
+#else
+    auto& s = AppSettings::instance();
+    if (token.isEmpty()) {
+        s.remove(kLegacyTokenKey);
+    } else {
+        qWarning() << "AutomationBridge: HAVE_KEYCHAIN not set - saving token to "
+                      "plaintext AppSettings";
+        s.setValue(kLegacyTokenKey, token);
+    }
+    s.save();
+#endif
+}
+
+} // namespace AetherSDR

--- a/src/core/AutomationBridgeSettings.h
+++ b/src/core/AutomationBridgeSettings.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QString>
+
+#include <functional>
+
+class QJsonObject;
+class QObject;
+
+namespace AetherSDR {
+
+// Owned configuration for the agent automation bridge (#3646), per
+// Constitution Principle V: one nested JSON object under a single root key
+// ("AutomationBridge"), read/written atomically, with a one-shot migration
+// from the earlier flat keys. The secret token is NOT stored here — it lives
+// in the OS secret store via QtKeychain (service/key below), mirroring the
+// MQTT-password pattern (GHSA-mmqp-cm4w-cvpp). The non-secret bools are:
+//
+//   enabled    — the bridge runs at launch (Radio Setup → Network toggle)
+//   txAllowed  — an MCP client may key the transmitter (the TX guard)
+//   txAck      — the operator has acknowledged the TX warning at least once
+//
+// All accessors go through AppSettings and are process-wide.
+class AutomationBridgeSettings {
+public:
+    static bool enabled();
+    static void setEnabled(bool on);
+    static bool txAllowed();
+    static void setTxAllowed(bool on);
+    static bool txAck();
+    static void setTxAck(bool on);
+
+    // Keychain coordinates for the bridge access token (see MqttSettings for
+    // the analogous MQTT-password helpers).
+    static QString keychainService();        // "AetherSDR"
+    static QString keychainKey();            // "automation_bridge_token"
+    // Legacy plaintext setting key the token used to live under, kept only for
+    // one-time migration into the keychain and for the no-keychain fallback.
+    static QString legacyTokenSettingKey();  // "AutomationBridgeToken"
+
+    // Async access-token I/O via QtKeychain, shared by the dialog and the
+    // bridge lifecycle so the secret is never duplicated in plaintext settings.
+    //
+    // Resolution order in loadToken(): the AETHER_MCP_TOKEN env var (headless /
+    // CI) wins synchronously; otherwise the OS secret store, migrating a legacy
+    // plaintext token in on first read. When HAVE_KEYCHAIN is off, falls back
+    // to the legacy plaintext setting (with a warning). `cb` always runs — with
+    // an empty string if no token is set. `ctx` scopes the async callback.
+    static void loadToken(QObject* ctx, std::function<void(const QString&)> cb);
+    // Persist the token (empty string deletes it). Keychain when available,
+    // else legacy plaintext. Also clears any legacy plaintext entry.
+    static void saveToken(const QString& token);
+
+private:
+    // Reads the nested object, migrating the legacy flat keys on first access.
+    static QJsonObject readObj();
+    static void writeBool(const char* field, bool value);
+};
+
+} // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1938,6 +1938,38 @@ void AutomationServer::stop()
     }
 }
 
+void AutomationServer::setTxAllowed(bool allowed)
+{
+    if (m_txAllowed == allowed)
+        return;  // idempotent
+    m_txAllowed = allowed;
+    if (allowed) {
+        // Arm the force-unkey watchdog (mirrors the start()-time arming). The
+        // env-driven TX_MAX_MS/POWER limits, if any, were already read at
+        // start(); keep whatever's in effect.
+        if (!m_txWatchdog) {
+            m_txWatchdog = new QTimer(this);
+            m_txWatchdog->setInterval(500);
+            connect(m_txWatchdog, &QTimer::timeout, this, &AutomationServer::onTxWatchdog);
+            m_txWatchdog->start();
+        }
+        qCInfo(lcAutomation).noquote()
+            << "TX automation ENABLED by operator — watchdog max key"
+            << m_txMaxKeyMs << "ms, power ceiling"
+            << (m_txMaxPower < 0 ? QStringLiteral("none") : QString::number(m_txMaxPower));
+    } else {
+        // Disabling: never leave the radio keyed by a script mid-transmit,
+        // then disarm the watchdog. forceUnkey is a safe no-op if not keyed.
+        forceUnkey("TX automation disabled by operator");
+        if (m_txWatchdog) {
+            m_txWatchdog->stop();
+            m_txWatchdog->deleteLater();
+            m_txWatchdog = nullptr;
+        }
+        qCInfo(lcAutomation).noquote() << "TX automation DISABLED by operator";
+    }
+}
+
 bool AutomationServer::isRunning() const
 {
     return m_server && m_server->isListening();
@@ -3051,13 +3083,13 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
             return err(QStringLiteral("action '") + target + QStringLiteral("' is disabled"));
         }
 
-        if (isTransmitAction(menuAction, menu)
-            && !qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+        if (isTransmitAction(menuAction, menu) && !m_txAllowed) {
             qCWarning(lcAutomation).noquote()
                 << "BLOCKED transmit-related QAction invoke on" << target;
             return err(QStringLiteral("blocked: '") + target
                        + QStringLiteral("' is a transmit-keying action (TX-safety guard). "
-                                        "Set AETHER_AUTOMATION_ALLOW_TX=1 to override."));
+                                        "Enable \"Allow TX via MCP\" in Radio Setup → Network "
+                                        "(or set AETHER_AUTOMATION_ALLOW_TX=1) to override."));
         }
 
         QPointer<QAction> actionGuard = menuAction;
@@ -3159,14 +3191,14 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
 
     // TX-safety guard — never key a live radio from the test bridge unless the
     // operator has explicitly opted in. (#3646 Phase 1 safety requirement.)
-    if (isTransmitControl(w)
-        && !qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+    if (isTransmitControl(w) && !m_txAllowed) {
         qCWarning(lcAutomation).noquote()
             << "BLOCKED transmit-related invoke on" << target
             << "(" << shortClassName(w) << ")";
         return err(QStringLiteral("blocked: '") + target
                    + QStringLiteral("' is a transmit-keying control (TX-safety guard). "
-                                    "Set AETHER_AUTOMATION_ALLOW_TX=1 to override."));
+                                    "Enable \"Allow TX via MCP\" in Radio Setup → Network "
+                                    "(or set AETHER_AUTOMATION_ALLOW_TX=1) to override."));
     }
 
     // Power-ceiling rail (#3646): clamp RF/Tune power setpoints to the
@@ -4914,7 +4946,7 @@ QJsonObject AutomationServer::doShortcut(const QString& id) const
         return err(QStringLiteral("no main window to dispatch shortcut"));
     }
 
-    const bool allowTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
+    const bool allowTx = m_txAllowed;
     int result = -1;
     const bool invoked = QMetaObject::invokeMethod(
         mw, "fireShortcutAction", Qt::DirectConnection,
@@ -5684,7 +5716,7 @@ QJsonObject AutomationServer::doClickAt(const QString& target,
     // ancestor chain (see the function comment): an unaccepted press propagates
     // to parents, so every widget Qt could deliver this click to must pass.
     // (#3646 safety.)
-    if (!qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")) {
+    if (!m_txAllowed) {
         for (const QWidget* p = w; p; p = p->parentWidget()) {
             if (!isTransmitControl(p)) {
                 continue;
@@ -5696,8 +5728,9 @@ QJsonObject AutomationServer::doClickAt(const QString& target,
             return err(QStringLiteral("blocked: point resolves into '")
                        + shortClassName(p)
                        + QStringLiteral("', a transmit-keying control (TX-safety "
-                                        "guard). Set AETHER_AUTOMATION_ALLOW_TX=1 "
-                                        "to override."));
+                                        "guard). Enable \"Allow TX via MCP\" in Radio "
+                                        "Setup → Network (or set "
+                                        "AETHER_AUTOMATION_ALLOW_TX=1) to override."));
         }
     }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2057,6 +2057,7 @@ void AutomationServer::onDisconnected()
 struct AutomationServer::VerbArgs {
     QString target, path, action, value, model, selector, property;
     QString id, title, detail, tone;
+    QString token;                       // shared-secret auth (#3646); JSON `token` field
     int timeoutMs{0};
 };
 
@@ -2162,13 +2163,14 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                          std::move(parse), std::move(dispatch)});
         };
 
-        add("ping", {}, "liveness check → app + version",
+        add("ping", {}, "liveness check → app + version + whether a token is required",
             parseNothing,
-            [](AutomationServer&, A&, QLocalSocket*) {
+            [](AutomationServer& self, A&, QLocalSocket*) {
                 return QJsonObject{
                     {QStringLiteral("ok"), true},
                     {QStringLiteral("app"), QStringLiteral("AetherSDR")},
                     {QStringLiteral("version"), QCoreApplication::applicationVersion()},
+                    {QStringLiteral("authRequired"), !self.m_authToken.isEmpty()},
                 };
             });
 
@@ -2701,6 +2703,7 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         a.title    = obj.value(QStringLiteral("title")).toString();
         a.detail   = obj.value(QStringLiteral("detail")).toString();
         a.tone     = obj.value(QStringLiteral("tone")).toString();
+        a.token    = obj.value(QStringLiteral("token")).toString();
         a.timeoutMs = obj.value(QStringLiteral("timeoutMs")).toInt(0);
         // clickAt accepts numeric x/y fields directly (dumpTree geometry is
         // global), folded into `value` as "x y" so both request forms share one
@@ -2737,6 +2740,37 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
     const VerbSpec* spec = findVerb(cmd);
     if (!spec)
         return err(QStringLiteral("unknown command: ") + cmd);
+
+    // Shared-secret gate (#3646). When a token is configured, every verb
+    // except `ping` must present a matching `token` field. The Unix socket /
+    // named pipe only enforces same-user access; the token is what stops a
+    // *different* local process (a stray agent) from driving the radio once
+    // the operator has opted a specific client in via Radio Setup -> Network.
+    // ping stays open (see its registry entry, which reports authRequired) so
+    // a client can detect the bridge without holding the secret. Constant-time
+    // compare so a wrong token leaks no length/prefix timing signal.
+    if (!m_authToken.isEmpty() && cmd != QLatin1String("ping")) {
+        const QByteArray want = m_authToken.toUtf8();
+        const QByteArray got = a.token.toUtf8();
+        // Never index `got` out of range — when it's shorter (or empty),
+        // substitute a zero byte rather than reading got[0], which segfaults
+        // on an empty QByteArray.
+        int diff = static_cast<int>(want.size() ^ got.size());
+        for (int i = 0; i < want.size(); ++i) {
+            const char g = (i < got.size()) ? got.at(i) : char(0);
+            diff |= want.at(i) ^ g;
+        }
+        if (diff != 0) {
+            qCWarning(lcAutomation)
+                << "rejected unauthenticated request:" << cmd
+                << "(missing or invalid token)";
+            return err(QStringLiteral(
+                "unauthorized: this bridge requires a token. Set AETHER_MCP_TOKEN "
+                "in your MCP client from Radio Setup -> Network -> Agent "
+                "Automation."));
+        }
+    }
+
     return spec->dispatch(*this, a, sock);
 }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1791,15 +1791,18 @@ bool AutomationServer::start(const QString& serverName)
         m_discoveryFile.clear();
     }
 
-    // TX safety rails (#3646): when the operator has enabled transmit
-    // automation, arm a watchdog that force-unkeys the radio if it stays keyed
-    // past a limit — a backstop independent of whatever script is driving us.
+    // TX safety rails (#3646): the watchdog force-unkeys the radio if it stays
+    // keyed past a limit — a backstop independent of whatever script drives us.
+    // Read the key-time / power-ceiling limits UNCONDITIONALLY so they also
+    // apply when TX is enabled later via the GUI toggle (setTxAllowed) — they
+    // are watchdog policy, not an env-only feature. Only the watchdog *arming*
+    // is gated on TX actually being allowed.
+    if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_MS"))
+        m_txMaxKeyMs = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_MS");
+    if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_POWER"))
+        m_txMaxPower = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_POWER");
     m_txAllowed = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
     if (m_txAllowed) {
-        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_MS"))
-            m_txMaxKeyMs = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_MS");
-        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION_TX_MAX_POWER"))
-            m_txMaxPower = qEnvironmentVariableIntValue("AETHER_AUTOMATION_TX_MAX_POWER");
         m_txWatchdog = new QTimer(this);
         m_txWatchdog->setInterval(500);
         connect(m_txWatchdog, &QTimer::timeout, this, &AutomationServer::onTxWatchdog);
@@ -1945,8 +1948,9 @@ void AutomationServer::setTxAllowed(bool allowed)
     m_txAllowed = allowed;
     if (allowed) {
         // Arm the force-unkey watchdog (mirrors the start()-time arming). The
-        // env-driven TX_MAX_MS/POWER limits, if any, were already read at
-        // start(); keep whatever's in effect.
+        // TX_MAX_MS / TX_MAX_POWER limits are read unconditionally in start(),
+        // so the same key-time and power-ceiling policy applies on this GUI
+        // path as on the env path.
         if (!m_txWatchdog) {
             m_txWatchdog = new QTimer(this);
             m_txWatchdog->setInterval(500);

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -281,6 +281,14 @@ public:
     void setAuthToken(const QString& token) { m_authToken = token; }
     QString authToken() const { return m_authToken; }
 
+    // Runtime TX-automation gate (#3646). Mirrors AETHER_AUTOMATION_ALLOW_TX
+    // but operator-driven from Radio Setup → Network. Enabling arms the
+    // force-unkey watchdog; disabling force-unkeys immediately and disarms it.
+    // The env var still force-enables at start(); this lets the GUI toggle it
+    // live on a running bridge. Idempotent.
+    void setTxAllowed(bool allowed);
+    bool txAllowed() const { return m_txAllowed; }
+
 private slots:
     void onNewConnection();
     void onReadyRead();

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -271,6 +271,16 @@ public:
         m_txTimerSnapshotHandler = std::move(handler);
     }
 
+    // Shared-secret auth (#3646). When set to a non-empty token, every verb
+    // except `ping` must carry a matching `token` field or it's rejected —
+    // so a random local process that can open the socket still can't drive
+    // the radio. Empty (the default) means no auth, preserving the original
+    // open-socket behavior for headless/CI use. Safe to call while running
+    // (the Radio Setup → Network rotate button does exactly that); it takes
+    // effect on the next request.
+    void setAuthToken(const QString& token) { m_authToken = token; }
+    QString authToken() const { return m_authToken; }
+
 private slots:
     void onNewConnection();
     void onReadyRead();
@@ -570,6 +580,7 @@ private:
     int     m_txMaxKeyMs{20000};   // max continuous key time before force-unkey
     int     m_txMaxPower{-1};      // power-ceiling clamp for invoke (-1 = off)
     bool    m_txAllowed{false};    // AETHER_AUTOMATION_ALLOW_TX at start()
+    QString m_authToken;           // shared-secret gate; empty = open (#3646)
     // Log/event channel (#3646 observability suite). The tap fills m_logRing
     // from arbitrary logging threads; the main thread reads it for tail/drain.
     struct LogEvent {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -213,6 +213,7 @@
 #include <QToolTip>
 #include <QMediaDevices>
 #include "core/AppSettings.h"
+#include "core/AutomationServer.h"
 #include "core/SpotCommandPolicy.h"
 #include "core/SpotModeResolver.h"
 #ifdef HAVE_RADE
@@ -2640,6 +2641,20 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
     if (!dlg) return;
     connect(dlg, &RadioSetupDialog::txBandSettingsRequested,
             m_txBandAction, &QAction::trigger);
+    // Agent automation bridge toggle (#3646). The dialog already persisted
+    // AutomationBridgeEnabled; here we act on it live. AETHER_AUTOMATION
+    // force-enables at launch and the dialog disables the toggle in that
+    // case, so a stop request can't arrive for an env-forced bridge.
+    connect(dlg, &RadioSetupDialog::automationBridgeToggled, this, [this](bool on) {
+        if (on) {
+            if (!startAutomationBridge())
+                qWarning() << "automation bridge failed to start (socket in use?)";
+        } else {
+            stopAutomationBridge();
+        }
+    });
+    connect(dlg, &RadioSetupDialog::automationBridgeTokenRotated, this,
+            [this](const QString& tok) { setAutomationBridgeToken(tok); });
     // serialSettingsChanged is the "external-device settings changed" signal in
     // practice — the dialog emits it for serial-port, FlexControl, Ulanzi-dial,
     // and HID-encoder edits. The Ulanzi/HID branches below run regardless of
@@ -3348,6 +3363,85 @@ QJsonObject MainWindow::automationTxTimerSnapshot() const
         return QJsonObject{{QStringLiteral("visible"), false},
                            {QStringLiteral("running"), false}};
     return QJsonObject::fromVariantMap(m_titleBar->txTimerState());
+}
+
+bool MainWindow::startAutomationBridge(const QString& sockName)
+{
+    if (m_automation && m_automation->isRunning())
+        return true;  // idempotent
+
+    // AETHER_AUTOMATION_SOCKET (or the caller's sockName) pins an explicit
+    // endpoint; otherwise the default is PID-suffixed so two instances don't
+    // steal each other's socket. Drivers find the right one via the discovery
+    // file the server drops in the temp dir.
+    QString name = sockName;
+    if (name.isEmpty())
+        name = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
+                   ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
+                   : QStringLiteral("aethersdr-automation-%1")
+                         .arg(QCoreApplication::applicationPid());
+
+    if (!m_automation)
+        m_automation = std::make_unique<AutomationServer>();
+
+    m_automation->setRadioModel(&radioModel());  // for the get() verb
+    m_automation->setAudioEngine(audioEngine());
+    m_automation->setQsoRecorder(qsoRecorder());  // for the record() verb
+    m_automation->setConnectionDialogHost(this);
+    m_automation->setConnectionAutomation(
+        findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
+    m_automation->setSliceReceiveSourceHandler(
+        [this](const QString& arg) { return automationSetSliceReceiveSource(arg); });
+    m_automation->setSliceCenterLockHandler(
+        [this](int sliceId, bool enabled) { return automationSetCenterLock(sliceId, enabled); });
+    m_automation->setTuneHandler(
+        [this](double mhz) { return automationTune(mhz); });
+    m_automation->setReceiveSyncSnapshotHandler(
+        [this]() { return automationReceiveSyncSnapshot(); });
+    m_automation->setKiwiSdrSnapshotHandler(
+        [this]() { return automationKiwiSdrSnapshot(); });
+    m_automation->setTxTimerSnapshotHandler(
+        [this]() { return automationTxTimerSnapshot(); });
+
+    // Shared-secret gate. Empty setting → open bridge (unchanged behavior);
+    // a non-empty token means only clients holding it can drive the radio.
+    m_automation->setAuthToken(
+        AppSettings::instance().value("AutomationBridgeToken").toString());
+
+    if (!m_automation->start(name)) {
+        m_automation.reset();
+        return false;
+    }
+    return true;
+}
+
+void MainWindow::stopAutomationBridge()
+{
+    if (m_automation) {
+        m_automation->stop();
+        m_automation.reset();
+    }
+}
+
+bool MainWindow::isAutomationBridgeRunning() const
+{
+    return m_automation && m_automation->isRunning();
+}
+
+QString MainWindow::automationBridgeEndpoint() const
+{
+    return m_automation ? m_automation->fullServerName() : QString();
+}
+
+void MainWindow::setAutomationBridgeToken(const QString& token)
+{
+    // Persist so it survives restart and is read by startAutomationBridge().
+    AppSettings::instance().setValue("AutomationBridgeToken", token);
+    AppSettings::instance().save();
+    // Push live so a rotate takes effect immediately on the running bridge —
+    // any client still using the old token is locked out on its next request.
+    if (m_automation)
+        m_automation->setAuthToken(token);
 }
 
 void MainWindow::showConnectionDialog()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2655,6 +2655,8 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
     });
     connect(dlg, &RadioSetupDialog::automationBridgeTokenRotated, this,
             [this](const QString& tok) { setAutomationBridgeToken(tok); });
+    connect(dlg, &RadioSetupDialog::automationBridgeTxAllowedChanged, this,
+            [this](bool allowed) { setAutomationTxAllowed(allowed); });
     // serialSettingsChanged is the "external-device settings changed" signal in
     // practice — the dialog emits it for serial-port, FlexControl, Ulanzi-dial,
     // and HID-encoder edits. The Ulanzi/HID branches below run regardless of
@@ -3412,6 +3414,14 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
         m_automation.reset();
         return false;
     }
+
+    // TX-automation gate. start() already set it from AETHER_AUTOMATION_ALLOW_TX;
+    // fold in the persisted operator opt-in (Radio Setup → Network) so a GUI
+    // enable survives restart. setTxAllowed is idempotent and arms the
+    // force-unkey watchdog if this turns TX on.
+    m_automation->setTxAllowed(
+        qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
+        || AppSettings::instance().value("AutomationBridgeTxAllowed", false).toBool());
     return true;
 }
 
@@ -3442,6 +3452,18 @@ void MainWindow::setAutomationBridgeToken(const QString& token)
     // any client still using the old token is locked out on its next request.
     if (m_automation)
         m_automation->setAuthToken(token);
+}
+
+void MainWindow::setAutomationTxAllowed(bool allowed)
+{
+    // Persist the operator opt-in so it survives restart and is read by
+    // startAutomationBridge().
+    AppSettings::instance().setValue("AutomationBridgeTxAllowed", allowed);
+    AppSettings::instance().save();
+    // Push live so toggling takes effect on a running bridge immediately —
+    // disabling force-unkeys the radio; enabling arms the TX watchdog.
+    if (m_automation)
+        m_automation->setTxAllowed(allowed);
 }
 
 void MainWindow::showConnectionDialog()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3367,104 +3367,12 @@ QJsonObject MainWindow::automationTxTimerSnapshot() const
     return QJsonObject::fromVariantMap(m_titleBar->txTimerState());
 }
 
-bool MainWindow::startAutomationBridge(const QString& sockName)
-{
-    if (m_automation && m_automation->isRunning())
-        return true;  // idempotent
-
-    // AETHER_AUTOMATION_SOCKET (or the caller's sockName) pins an explicit
-    // endpoint; otherwise the default is PID-suffixed so two instances don't
-    // steal each other's socket. Drivers find the right one via the discovery
-    // file the server drops in the temp dir.
-    QString name = sockName;
-    if (name.isEmpty())
-        name = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
-                   ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
-                   : QStringLiteral("aethersdr-automation-%1")
-                         .arg(QCoreApplication::applicationPid());
-
-    if (!m_automation)
-        m_automation = std::make_unique<AutomationServer>();
-
-    m_automation->setRadioModel(&radioModel());  // for the get() verb
-    m_automation->setAudioEngine(audioEngine());
-    m_automation->setQsoRecorder(qsoRecorder());  // for the record() verb
-    m_automation->setConnectionDialogHost(this);
-    m_automation->setConnectionAutomation(
-        findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
-    m_automation->setSliceReceiveSourceHandler(
-        [this](const QString& arg) { return automationSetSliceReceiveSource(arg); });
-    m_automation->setSliceCenterLockHandler(
-        [this](int sliceId, bool enabled) { return automationSetCenterLock(sliceId, enabled); });
-    m_automation->setTuneHandler(
-        [this](double mhz) { return automationTune(mhz); });
-    m_automation->setReceiveSyncSnapshotHandler(
-        [this]() { return automationReceiveSyncSnapshot(); });
-    m_automation->setKiwiSdrSnapshotHandler(
-        [this]() { return automationKiwiSdrSnapshot(); });
-    m_automation->setTxTimerSnapshotHandler(
-        [this]() { return automationTxTimerSnapshot(); });
-
-    // Shared-secret gate. Empty setting → open bridge (unchanged behavior);
-    // a non-empty token means only clients holding it can drive the radio.
-    m_automation->setAuthToken(
-        AppSettings::instance().value("AutomationBridgeToken").toString());
-
-    if (!m_automation->start(name)) {
-        m_automation.reset();
-        return false;
-    }
-
-    // TX-automation gate. start() already set it from AETHER_AUTOMATION_ALLOW_TX;
-    // fold in the persisted operator opt-in (Radio Setup → Network) so a GUI
-    // enable survives restart. setTxAllowed is idempotent and arms the
-    // force-unkey watchdog if this turns TX on.
-    m_automation->setTxAllowed(
-        qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
-        || AppSettings::instance().value("AutomationBridgeTxAllowed", false).toBool());
-    return true;
-}
-
-void MainWindow::stopAutomationBridge()
-{
-    if (m_automation) {
-        m_automation->stop();
-        m_automation.reset();
-    }
-}
-
-bool MainWindow::isAutomationBridgeRunning() const
-{
-    return m_automation && m_automation->isRunning();
-}
-
-QString MainWindow::automationBridgeEndpoint() const
-{
-    return m_automation ? m_automation->fullServerName() : QString();
-}
-
-void MainWindow::setAutomationBridgeToken(const QString& token)
-{
-    // Persist so it survives restart and is read by startAutomationBridge().
-    AppSettings::instance().setValue("AutomationBridgeToken", token);
-    AppSettings::instance().save();
-    // Push live so a rotate takes effect immediately on the running bridge —
-    // any client still using the old token is locked out on its next request.
-    if (m_automation)
-        m_automation->setAuthToken(token);
-}
-
-void MainWindow::setAutomationTxAllowed(bool allowed)
-{
-    // Persist the operator opt-in so it survives restart and is read by
-    // startAutomationBridge().
-    AppSettings::instance().setValue("AutomationBridgeTxAllowed", allowed);
-    AppSettings::instance().save();
-    // Push live so toggling takes effect on a running bridge immediately —
-    // disabling force-unkeys the radio; enabling arms the TX watchdog.
-    if (m_automation)
-        m_automation->setTxAllowed(allowed);
-}
+// The agent automation-bridge lifecycle (startAutomationBridge / stop /
+// isRunning / endpoint / setAutomationBridgeToken / setAutomationTxAllowed)
+// lives in MainWindow_Session.cpp with the rest of the session/subsystem
+// wiring — not in this monolith. automationTxTimerSnapshot above is the
+// per-frame status accessor and stays here with the other automation*
+// snapshot accessors.
 
 void MainWindow::showConnectionDialog()
 {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -227,6 +227,9 @@ public:
     // (the Radio Setup → Network rotate button). Old tokens stop working
     // immediately.
     void setAutomationBridgeToken(const QString& token);
+    // Persist the TX-via-MCP opt-in and push it live (Radio Setup → Network).
+    // Enabling arms the force-unkey watchdog; disabling force-unkeys the radio.
+    void setAutomationTxAllowed(bool allowed);
     // Resolved socket path / pipe name, or empty when stopped — shown in
     // the Network toggle so the operator can point their MCP client at it.
     QString automationBridgeEndpoint() const;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -222,7 +222,6 @@ public:
     // bridge is listening afterwards.
     bool startAutomationBridge(const QString& sockName = QString());
     void stopAutomationBridge();
-    bool isAutomationBridgeRunning() const;
     // Persist a new shared-secret token and push it to the running bridge
     // (the Radio Setup → Network rotate button). Old tokens stop working
     // immediately.
@@ -230,9 +229,6 @@ public:
     // Persist the TX-via-MCP opt-in and push it live (Radio Setup → Network).
     // Enabling arms the force-unkey watchdog; disabling force-unkeys the radio.
     void setAutomationTxAllowed(bool allowed);
-    // Resolved socket path / pipe name, or empty when stopped — shown in
-    // the Network toggle so the operator can point their MCP client at it.
-    QString automationBridgeEndpoint() const;
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -92,6 +92,7 @@ class QSystemTrayIcon;
 
 namespace AetherSDR {
 
+class AutomationServer;
 class ConnectionPanel;
 class TitleBar;
 class KiwiSdrManager;
@@ -211,6 +212,24 @@ public:
     QJsonObject automationKiwiSdrSnapshot() const;
     // Status-bar TX-timer state for the bridge `get txtimer` verb.
     QJsonObject automationTxTimerSnapshot() const;
+
+    // Agent automation bridge (#3646) lifecycle. Construction + full
+    // handler wiring lives in startAutomationBridge() so it can be driven
+    // both at launch (AETHER_AUTOMATION env var, from main.cpp) and at
+    // runtime from the Radio Setup → Network toggle. Idempotent: starting
+    // while running is a no-op; stopping while stopped is a no-op.
+    // sockName empty → the default PID-suffixed name. Returns true if the
+    // bridge is listening afterwards.
+    bool startAutomationBridge(const QString& sockName = QString());
+    void stopAutomationBridge();
+    bool isAutomationBridgeRunning() const;
+    // Persist a new shared-secret token and push it to the running bridge
+    // (the Radio Setup → Network rotate button). Old tokens stop working
+    // immediately.
+    void setAutomationBridgeToken(const QString& token);
+    // Resolved socket path / pipe name, or empty when stopped — shown in
+    // the Network toggle so the operator can point their MCP client at it.
+    QString automationBridgeEndpoint() const;
 
 protected:
     void showEvent(QShowEvent* event) override;
@@ -696,6 +715,7 @@ private:
     bool              m_audioDeviceDialogOpen{false};
     NetworkDiagnosticsHistory* m_networkDiagnosticsHistory{nullptr};
     QsoRecorder*      m_qsoRecorder{nullptr};
+    std::unique_ptr<AutomationServer> m_automation;  // agent bridge (#3646); nullptr when off
     ClientPuduMonitor* m_finalMonitor{nullptr};
     AudioOutputRouter* m_outputRouter{nullptr};   // registry for output-following sinks (#3306)
     BandSettings      m_bandSettings;

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -53,12 +53,16 @@
 #include "SpectrumWidget.h"
 #include "TitleBar.h"
 #include "core/AppSettings.h"
+#include "core/AutomationBridgeSettings.h"
+#include "core/AutomationServer.h"
 #include "core/LogManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
 #include <QMessageBox>
+#include <QCoreApplication>
 #include <QDateTime>
+#include <QPointer>
 #include <QThread>
 #include <QTimer>
 
@@ -1630,6 +1634,119 @@ void MainWindow::wireDaxIq()
     });
 #endif
 
+}
+
+// ── Agent automation bridge (#3646) lifecycle ────────────────────────────────
+// Kept out of the MainWindow.cpp monolith. The bridge is the endpoint MCP
+// clients connect to; MainWindow owns the server instance for its lifetime.
+
+bool MainWindow::startAutomationBridge(const QString& sockName)
+{
+    if (m_automation && m_automation->isRunning())
+        return true;  // idempotent
+
+    // AETHER_AUTOMATION_SOCKET (or the caller's sockName) pins an explicit
+    // endpoint; otherwise the default is PID-suffixed so two instances don't
+    // steal each other's socket. Drivers find the right one via the discovery
+    // file the server drops in the temp dir.
+    QString name = sockName;
+    if (name.isEmpty())
+        name = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
+                   ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
+                   : QStringLiteral("aethersdr-automation-%1")
+                         .arg(QCoreApplication::applicationPid());
+
+    if (!m_automation)
+        m_automation = std::make_unique<AutomationServer>();
+
+    m_automation->setRadioModel(&radioModel());  // for the get() verb
+    m_automation->setAudioEngine(audioEngine());
+    m_automation->setQsoRecorder(qsoRecorder());  // for the record() verb
+    m_automation->setConnectionDialogHost(this);
+    m_automation->setConnectionAutomation(
+        findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
+    m_automation->setSliceReceiveSourceHandler(
+        [this](const QString& arg) { return automationSetSliceReceiveSource(arg); });
+    m_automation->setSliceCenterLockHandler(
+        [this](int sliceId, bool enabled) { return automationSetCenterLock(sliceId, enabled); });
+    m_automation->setTuneHandler(
+        [this](double mhz) { return automationTune(mhz); });
+    m_automation->setReceiveSyncSnapshotHandler(
+        [this]() { return automationReceiveSyncSnapshot(); });
+    m_automation->setKiwiSdrSnapshotHandler(
+        [this]() { return automationKiwiSdrSnapshot(); });
+    m_automation->setTxTimerSnapshotHandler(
+        [this]() { return automationTxTimerSnapshot(); });
+
+    // The access token lives in the OS secret store (QtKeychain), which reads
+    // ASYNCHRONOUSLY. Defer start()/listen() into the token callback rather
+    // than opening a brief tokenless window on the socket. A QPointer guards
+    // against the bridge being stopped/replaced before the read lands.
+    QPointer<AutomationServer> guard(m_automation.get());
+    const QString startName = name;
+    AutomationBridgeSettings::loadToken(this, [this, guard, startName](const QString& tok) {
+        if (!guard || m_automation.get() != guard)
+            return;  // toggled off or restarted before the token arrived
+        guard->setAuthToken(tok);
+        if (tok.isEmpty()) {
+            qWarning().noquote()
+                << "Automation bridge starting UNAUTHENTICATED — any same-user "
+                   "process can drive the radio. Set an access token in Radio "
+                   "Setup → Network, or the AETHER_MCP_TOKEN environment variable.";
+        }
+        if (!guard->start(startName)) {
+            qWarning() << "Automation bridge failed to start (socket in use?)";
+            m_automation.reset();
+            return;
+        }
+        // TX-automation gate — set AFTER start(), which reads
+        // AETHER_AUTOMATION_ALLOW_TX into m_txAllowed and would otherwise
+        // clobber a pre-start value. Fold in the persisted operator opt-in so
+        // a GUI enable survives restart; setTxAllowed arms the watchdog.
+        guard->setTxAllowed(
+            qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
+            || AutomationBridgeSettings::txAllowed());
+    });
+    return true;  // start initiated; the socket begins listening once the token resolves
+}
+
+void MainWindow::stopAutomationBridge()
+{
+    if (m_automation) {
+        m_automation->stop();
+        m_automation.reset();
+    }
+}
+
+bool MainWindow::isAutomationBridgeRunning() const
+{
+    return m_automation && m_automation->isRunning();
+}
+
+QString MainWindow::automationBridgeEndpoint() const
+{
+    return m_automation ? m_automation->fullServerName() : QString();
+}
+
+void MainWindow::setAutomationBridgeToken(const QString& token)
+{
+    // Persist to the OS secret store (survives restart; read by
+    // startAutomationBridge). No plaintext copy in the settings file.
+    AutomationBridgeSettings::saveToken(token);
+    // Push live so a rotate takes effect immediately on the running bridge —
+    // any client still using the old token is locked out on its next request.
+    if (m_automation)
+        m_automation->setAuthToken(token);
+}
+
+void MainWindow::setAutomationTxAllowed(bool allowed)
+{
+    // Persist the operator opt-in (nested config) so it survives restart.
+    AutomationBridgeSettings::setTxAllowed(allowed);
+    // Push live so toggling takes effect on a running bridge immediately —
+    // disabling force-unkeys the radio; enabling arms the TX watchdog.
+    if (m_automation)
+        m_automation->setTxAllowed(allowed);
 }
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1718,16 +1718,6 @@ void MainWindow::stopAutomationBridge()
     }
 }
 
-bool MainWindow::isAutomationBridgeRunning() const
-{
-    return m_automation && m_automation->isRunning();
-}
-
-QString MainWindow::automationBridgeEndpoint() const
-{
-    return m_automation ? m_automation->fullServerName() : QString();
-}
-
 void MainWindow::setAutomationBridgeToken(const QString& token)
 {
     // Persist to the OS secret store (survives restart; read by

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -74,6 +74,7 @@
 #include <QDebug>
 #include <QGuiApplication>
 #include <QPainter>
+#include <QRandomGenerator>
 #include <QPaintEvent>
 #include <QPointer>
 #include <QScreen>
@@ -1214,7 +1215,126 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         });
         grid->addWidget(enforceBtn, 0, 1);
 
-        grid->addWidget(new QLabel("Network MTU:"), 1, 0);
+        // 128-bit hex token generator — plenty for a local same-user secret.
+        auto genToken = []() -> QString {
+            quint64 a = QRandomGenerator::global()->generate64();
+            quint64 b = QRandomGenerator::global()->generate64();
+            return QStringLiteral("%1%2")
+                .arg(a, 16, 16, QLatin1Char('0'))
+                .arg(b, 16, 16, QLatin1Char('0'));
+        };
+        // The token field is created here (before the toggle) so the toggle's
+        // enable handler can auto-fill it — enabling the bridge without a
+        // token would leave it open, which defeats the point.
+        auto* tokenEdit = new QLineEdit;
+        tokenEdit->setReadOnly(true);
+        tokenEdit->setText(
+            AppSettings::instance().value("AutomationBridgeToken").toString());
+        tokenEdit->setPlaceholderText("(none — enable the bridge or click Rotate)");
+        tokenEdit->setToolTip(
+            "Paste this into your AI assistant's MCP server config as the\n"
+            "AETHER_MCP_TOKEN environment variable. Only a client holding\n"
+            "this token can drive the radio.");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(tokenEdit,
+            "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; color: {{color.text.primary}}; font-family: monospace; "
+            "font-size: 11px; padding: 3px 6px; }");
+
+        // Agent automation bridge (#3646) — the endpoint MCP clients (AI
+        // coding assistants) connect to for validating changes against the
+        // running app. Off by default; the operator opts in here. The
+        // AETHER_AUTOMATION launch env var still force-enables it regardless
+        // of this toggle (headless/CI path), so we reflect either source.
+        {
+            grid->addWidget(new QLabel("Agent Automation (MCP):"), 1, 0);
+            const bool bridgeOn =
+                AppSettings::instance().value("AutomationBridgeEnabled", false).toBool()
+                || qEnvironmentVariableIsSet("AETHER_AUTOMATION");
+            auto* mcpBtn = new QPushButton(bridgeOn ? "Enabled" : "Disabled");
+            mcpBtn->setCheckable(true);
+            mcpBtn->setChecked(bridgeOn);
+            AetherSDR::ThemeManager::instance().applyStyleSheet(mcpBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+                "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
+                "padding: 3px 10px; }"
+                "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
+                "border: 1px solid #20a040; }");
+            mcpBtn->setToolTip(
+                "Enable the in-app automation bridge so an AI coding assistant "
+                "(via the MCP server, tools/aether_mcp.py) can introspect and\n"
+                "drive this app to validate changes. Off by default. Transmit-"
+                "keying controls stay blocked unless the app is launched with\n"
+                "AETHER_AUTOMATION_ALLOW_TX. See docs/automation-bridge.md.");
+            // Env-var force-enable wins and can't be turned off from the UI —
+            // make that visible rather than letting a toggle silently no-op.
+            if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
+                mcpBtn->setEnabled(false);
+                mcpBtn->setToolTip(mcpBtn->toolTip()
+                    + "\n\nForced on by the AETHER_AUTOMATION launch environment variable.");
+            }
+            connect(mcpBtn, &QPushButton::toggled, this,
+                    [this, mcpBtn, tokenEdit, genToken](bool on) {
+                mcpBtn->setText(on ? "Enabled" : "Disabled");
+                AppSettings::instance().setValue("AutomationBridgeEnabled", on);
+                AppSettings::instance().save();
+                // Enabling with no token yet → mint one so the bridge is never
+                // exposed without auth. Copy it out so the operator can wire it
+                // into their assistant immediately.
+                if (on && tokenEdit->text().isEmpty()) {
+                    const QString tok = genToken();
+                    tokenEdit->setText(tok);
+                    AppSettings::instance().setValue("AutomationBridgeToken", tok);
+                    AppSettings::instance().save();
+                    QGuiApplication::clipboard()->setText(tok);
+                    emit automationBridgeTokenRotated(tok);
+                }
+                emit automationBridgeToggled(on);
+            });
+            grid->addWidget(mcpBtn, 1, 1);
+        }
+
+        // Access token row — display the shared secret with Copy + Rotate.
+        // Rotate makes a new token and applies it immediately, locking out any
+        // client still using the old one.
+        {
+            grid->addWidget(new QLabel("Access Token:"), 2, 0);
+            auto* tokenRow = new QWidget;
+            auto* tokLay = new QHBoxLayout(tokenRow);
+            tokLay->setContentsMargins(0, 0, 0, 0);
+            tokLay->setSpacing(6);
+
+            auto* copyBtn = new QPushButton("Copy");
+            auto* rotateBtn = new QPushButton("Rotate");
+            for (auto* b : {copyBtn, rotateBtn})
+                AetherSDR::ThemeManager::instance().applyStyleSheet(b,
+                    "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+                    "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; "
+                    "padding: 3px 10px; }");
+            copyBtn->setToolTip("Copy the token to the clipboard.");
+            rotateBtn->setToolTip(
+                "Generate a new token and apply it immediately. Any client still\n"
+                "using the old token is locked out until you update its config.");
+
+            connect(copyBtn, &QPushButton::clicked, this, [tokenEdit]() {
+                if (!tokenEdit->text().isEmpty())
+                    QGuiApplication::clipboard()->setText(tokenEdit->text());
+            });
+            connect(rotateBtn, &QPushButton::clicked, this,
+                    [this, tokenEdit, genToken]() {
+                const QString tok = genToken();
+                tokenEdit->setText(tok);
+                AppSettings::instance().setValue("AutomationBridgeToken", tok);
+                AppSettings::instance().save();
+                QGuiApplication::clipboard()->setText(tok);
+                emit automationBridgeTokenRotated(tok);
+            });
+
+            tokLay->addWidget(tokenEdit, 1);
+            tokLay->addWidget(copyBtn);
+            tokLay->addWidget(rotateBtn);
+            grid->addWidget(tokenRow, 2, 1);
+        }
+
+        grid->addWidget(new QLabel("Network MTU:"), 3, 0);
         auto* mtuSpin = new QSpinBox;
         mtuSpin->setRange(576, 9000);
         mtuSpin->setValue(AppSettings::instance().value("NetworkMtu", "1450").toInt());
@@ -1226,7 +1346,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             AppSettings::instance().setValue("NetworkMtu", QString::number(val));
             AppSettings::instance().save();
         });
-        grid->addWidget(mtuSpin, 1, 1);
+        grid->addWidget(mtuSpin, 3, 1);
 
         // VITA-49 UDP receive buffer (SO_RCVBUF). Snap-to-preset slider; the
         // kernel clamps the grant at net.core.rmem_max, so we show the granted
@@ -1243,7 +1363,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             return QStringLiteral("%1 KB").arg(b / 1024);
         };
 
-        grid->addWidget(new QLabel("VITA-49 RX buffer:"), 2, 0);
+        grid->addWidget(new QLabel("VITA-49 RX buffer:"), 4, 0);
         auto* bufRow = new QWidget;
         auto* bufLay = new QHBoxLayout(bufRow);
         bufLay->setContentsMargins(0, 0, 0, 0);
@@ -1271,7 +1391,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         bufValLabel->setMinimumWidth(48);
         bufLay->addWidget(bufSlider, 1);
         bufLay->addWidget(bufValLabel);
-        grid->addWidget(bufRow, 2, 1);
+        grid->addWidget(bufRow, 4, 1);
 
         auto* bufGrantedLabel = new QLabel;
         if (m_model && m_model->panStream()) {
@@ -1279,7 +1399,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             bufGrantedLabel->setText(g > 0 ? QString("granted: %1").arg(fmtBytes(g))
                                            : QStringLiteral("granted: — (applies on connect)"));
         }
-        grid->addWidget(bufGrantedLabel, 3, 1);
+        grid->addWidget(bufGrantedLabel, 5, 1);
 
         connect(bufSlider, &QSlider::valueChanged, this,
                 [this, bufValLabel, fmtBytes](int idx) {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1334,7 +1334,73 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             grid->addWidget(tokenRow, 2, 1);
         }
 
-        grid->addWidget(new QLabel("Network MTU:"), 3, 0);
+        // Allow TX via MCP — the transmit-keying guard. Off by default; the
+        // bridge refuses MOX/PTT/TUNE/ATU/CWX unless this (or the
+        // AETHER_AUTOMATION_ALLOW_TX env var) is set. Checking the box the
+        // first time raises a confirmation with the operator-responsibility
+        // warning; once confirmed the choice persists and is not re-prompted.
+        {
+            grid->addWidget(new QLabel("Allow TX via MCP:"), 3, 0);
+            auto* txCheck = new QCheckBox("Enable transmit control");
+            auto& s0 = AppSettings::instance();
+            const bool envForcesTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
+            txCheck->setChecked(s0.value("AutomationBridgeTxAllowed", false).toBool()
+                                || envForcesTx);
+            txCheck->setToolTip(
+                "Let an MCP client key the transmitter (MOX/PTT/TUNE/ATU/CWX).\n"
+                "OFF by default — the bridge blocks all transmit-keying otherwise.\n"
+                "A force-unkey watchdog stays armed whenever this is on. You are\n"
+                "responsible for anything transmitted. See docs/automation-bridge.md.");
+            AetherSDR::ThemeManager::instance().applyStyleSheet(txCheck,
+                "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }"
+                "QCheckBox::indicator { width: 14px; height: 14px; }");
+            if (envForcesTx) {
+                txCheck->setEnabled(false);
+                txCheck->setToolTip(txCheck->toolTip()
+                    + "\n\nForced on by the AETHER_AUTOMATION_ALLOW_TX launch variable.");
+            }
+            connect(txCheck, &QCheckBox::toggled, this, [this, txCheck](bool on) {
+                auto& s = AppSettings::instance();
+                if (on && !s.value("AutomationBridgeTxAck", false).toBool()) {
+                    // First-time enable → confirm. Operator must acknowledge.
+                    QMessageBox box(this);
+                    box.setIcon(QMessageBox::Warning);
+                    box.setWindowTitle("Allow TX via MCP?");
+                    box.setText("Allow an AI assistant / MCP client to key the transmitter?");
+                    box.setInformativeText(
+                        "This lets any MCP client holding the access token drive "
+                        "transmit-keying controls — MOX/PTT, TUNE, the ATU, and CWX "
+                        "send — on your radio. Automated software will be able to put "
+                        "a signal on the air.\n\n"
+                        "A force-unkey watchdog stays armed while this is enabled, but "
+                        "it is a backstop, not a guarantee. You, the operator, are "
+                        "ultimately responsible for all transmissions from your station "
+                        "— including their content, timing, frequency, power, and "
+                        "compliance with your license and local regulations.\n\n"
+                        "Only enable this if you understand and accept that "
+                        "responsibility. You can turn it off again at any time.");
+                    auto* confirm = box.addButton("Confirm — allow TX", QMessageBox::AcceptRole);
+                    box.addButton("Cancel", QMessageBox::RejectRole);
+                    box.setDefaultButton(qobject_cast<QPushButton*>(box.buttons().value(1)));
+                    box.exec();
+                    if (box.clickedButton() != confirm) {
+                        // Cancelled — revert without persisting or emitting.
+                        QSignalBlocker blocker(txCheck);
+                        txCheck->setChecked(false);
+                        return;
+                    }
+                    // Confirmed — remember the acknowledgement so we never
+                    // prompt again on a future enable.
+                    s.setValue("AutomationBridgeTxAck", true);
+                }
+                s.setValue("AutomationBridgeTxAllowed", on);
+                s.save();
+                emit automationBridgeTxAllowedChanged(on);
+            });
+            grid->addWidget(txCheck, 3, 1);
+        }
+
+        grid->addWidget(new QLabel("Network MTU:"), 4, 0);
         auto* mtuSpin = new QSpinBox;
         mtuSpin->setRange(576, 9000);
         mtuSpin->setValue(AppSettings::instance().value("NetworkMtu", "1450").toInt());
@@ -1346,7 +1412,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             AppSettings::instance().setValue("NetworkMtu", QString::number(val));
             AppSettings::instance().save();
         });
-        grid->addWidget(mtuSpin, 3, 1);
+        grid->addWidget(mtuSpin, 4, 1);
 
         // VITA-49 UDP receive buffer (SO_RCVBUF). Snap-to-preset slider; the
         // kernel clamps the grant at net.core.rmem_max, so we show the granted
@@ -1363,7 +1429,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             return QStringLiteral("%1 KB").arg(b / 1024);
         };
 
-        grid->addWidget(new QLabel("VITA-49 RX buffer:"), 4, 0);
+        grid->addWidget(new QLabel("VITA-49 RX buffer:"), 5, 0);
         auto* bufRow = new QWidget;
         auto* bufLay = new QHBoxLayout(bufRow);
         bufLay->setContentsMargins(0, 0, 0, 0);
@@ -1391,7 +1457,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         bufValLabel->setMinimumWidth(48);
         bufLay->addWidget(bufSlider, 1);
         bufLay->addWidget(bufValLabel);
-        grid->addWidget(bufRow, 4, 1);
+        grid->addWidget(bufRow, 5, 1);
 
         auto* bufGrantedLabel = new QLabel;
         if (m_model && m_model->panStream()) {
@@ -1399,7 +1465,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             bufGrantedLabel->setText(g > 0 ? QString("granted: %1").arg(fmtBytes(g))
                                            : QStringLiteral("granted: — (applies on connect)"));
         }
-        grid->addWidget(bufGrantedLabel, 5, 1);
+        grid->addWidget(bufGrantedLabel, 6, 1);
 
         connect(bufSlider, &QSlider::valueChanged, this,
                 [this, bufValLabel, fmtBytes](int idx) {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6,6 +6,7 @@
 #include "models/RadioModel.h"
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
+#include "core/AutomationBridgeSettings.h"
 #include "core/NetworkSettings.h"
 #include "core/PanadapterStream.h"
 #include "core/KiwiSdrManager.h"
@@ -1225,20 +1226,29 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         };
         // The token field is created here (before the toggle) so the toggle's
         // enable handler can auto-fill it — enabling the bridge without a
-        // token would leave it open, which defeats the point.
+        // token would leave it open, which defeats the point. The token lives
+        // in the OS secret store and reads ASYNCHRONOUSLY; tokenLoaded gates
+        // the auto-mint so a toggle fired before the read lands can't clobber
+        // an existing token.
         auto* tokenEdit = new QLineEdit;
         tokenEdit->setReadOnly(true);
-        tokenEdit->setText(
-            AppSettings::instance().value("AutomationBridgeToken").toString());
-        tokenEdit->setPlaceholderText("(none — enable the bridge or click Rotate)");
+        tokenEdit->setPlaceholderText("(loading…)");
         tokenEdit->setToolTip(
             "Paste this into your AI assistant's MCP server config as the\n"
             "AETHER_MCP_TOKEN environment variable. Only a client holding\n"
-            "this token can drive the radio.");
+            "this token can drive the radio. Stored in your OS secret store.");
         AetherSDR::ThemeManager::instance().applyStyleSheet(tokenEdit,
             "QLineEdit { background: {{color.background.0}}; border: 1px solid {{color.background.2}}; "
             "border-radius: 3px; color: {{color.text.primary}}; font-family: monospace; "
             "font-size: 11px; padding: 3px 6px; }");
+        auto tokenLoaded = std::make_shared<bool>(false);
+        AutomationBridgeSettings::loadToken(this,
+            [tokenEdit, tokenLoaded](const QString& tok) {
+                tokenEdit->setText(tok);
+                tokenEdit->setPlaceholderText(
+                    "(none — enable the bridge or click Rotate)");
+                *tokenLoaded = true;
+            });
 
         // Agent automation bridge (#3646) — the endpoint MCP clients (AI
         // coding assistants) connect to for validating changes against the
@@ -1247,8 +1257,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         // of this toggle (headless/CI path), so we reflect either source.
         {
             grid->addWidget(new QLabel("Agent Automation (MCP):"), 1, 0);
-            const bool bridgeOn =
-                AppSettings::instance().value("AutomationBridgeEnabled", false).toBool()
+            const bool bridgeOn = AutomationBridgeSettings::enabled()
                 || qEnvironmentVariableIsSet("AETHER_AUTOMATION");
             auto* mcpBtn = new QPushButton(bridgeOn ? "Enabled" : "Disabled");
             mcpBtn->setCheckable(true);
@@ -1272,18 +1281,16 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     + "\n\nForced on by the AETHER_AUTOMATION launch environment variable.");
             }
             connect(mcpBtn, &QPushButton::toggled, this,
-                    [this, mcpBtn, tokenEdit, genToken](bool on) {
+                    [this, mcpBtn, tokenEdit, genToken, tokenLoaded](bool on) {
                 mcpBtn->setText(on ? "Enabled" : "Disabled");
-                AppSettings::instance().setValue("AutomationBridgeEnabled", on);
-                AppSettings::instance().save();
+                AutomationBridgeSettings::setEnabled(on);
                 // Enabling with no token yet → mint one so the bridge is never
-                // exposed without auth. Copy it out so the operator can wire it
-                // into their assistant immediately.
-                if (on && tokenEdit->text().isEmpty()) {
+                // exposed without auth. Only when the async token read has
+                // landed (tokenLoaded) so we can't clobber an existing token.
+                if (on && *tokenLoaded && tokenEdit->text().isEmpty()) {
                     const QString tok = genToken();
                     tokenEdit->setText(tok);
-                    AppSettings::instance().setValue("AutomationBridgeToken", tok);
-                    AppSettings::instance().save();
+                    AutomationBridgeSettings::saveToken(tok);
                     QGuiApplication::clipboard()->setText(tok);
                     emit automationBridgeTokenRotated(tok);
                 }
@@ -1322,8 +1329,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     [this, tokenEdit, genToken]() {
                 const QString tok = genToken();
                 tokenEdit->setText(tok);
-                AppSettings::instance().setValue("AutomationBridgeToken", tok);
-                AppSettings::instance().save();
+                AutomationBridgeSettings::saveToken(tok);
                 QGuiApplication::clipboard()->setText(tok);
                 emit automationBridgeTokenRotated(tok);
             });
@@ -1342,10 +1348,8 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         {
             grid->addWidget(new QLabel("Allow TX via MCP:"), 3, 0);
             auto* txCheck = new QCheckBox("Enable transmit control");
-            auto& s0 = AppSettings::instance();
             const bool envForcesTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
-            txCheck->setChecked(s0.value("AutomationBridgeTxAllowed", false).toBool()
-                                || envForcesTx);
+            txCheck->setChecked(AutomationBridgeSettings::txAllowed() || envForcesTx);
             txCheck->setToolTip(
                 "Let an MCP client key the transmitter (MOX/PTT/TUNE/ATU/CWX).\n"
                 "OFF by default — the bridge blocks all transmit-keying otherwise.\n"
@@ -1360,8 +1364,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     + "\n\nForced on by the AETHER_AUTOMATION_ALLOW_TX launch variable.");
             }
             connect(txCheck, &QCheckBox::toggled, this, [this, txCheck](bool on) {
-                auto& s = AppSettings::instance();
-                if (on && !s.value("AutomationBridgeTxAck", false).toBool()) {
+                if (on && !AutomationBridgeSettings::txAck()) {
                     // First-time enable → confirm. Operator must acknowledge.
                     QMessageBox box(this);
                     box.setIcon(QMessageBox::Warning);
@@ -1391,10 +1394,9 @@ QWidget* RadioSetupDialog::buildNetworkTab()
                     }
                     // Confirmed — remember the acknowledgement so we never
                     // prompt again on a future enable.
-                    s.setValue("AutomationBridgeTxAck", true);
+                    AutomationBridgeSettings::setTxAck(true);
                 }
-                s.setValue("AutomationBridgeTxAllowed", on);
-                s.save();
+                AutomationBridgeSettings::setTxAllowed(on);
                 emit automationBridgeTxAllowedChanged(on);
             });
             grid->addWidget(txCheck, 3, 1);

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -64,6 +64,10 @@ signals:
     // token. MainWindow persists it and pushes it to the running bridge so
     // the rotation takes effect immediately.
     void automationBridgeTokenRotated(const QString& token);
+    // Fired when the user changes the "Allow TX via MCP" toggle (after the
+    // one-time confirmation dialog). MainWindow persists it and pushes it to
+    // the running bridge — enabling arms the force-unkey watchdog.
+    void automationBridgeTxAllowedChanged(bool allowed);
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -54,6 +54,16 @@ signals:
     // widgets (the AppSettings value is what's actually consulted at
     // paint time — this signal is just the redraw trigger).
     void sliceLetterDisplayModeChanged();
+    // Fired when the user toggles the agent automation bridge in the
+    // Network tab. MainWindow starts/stops the in-app bridge that MCP
+    // clients (AI coding assistants) connect to. The AppSettings value
+    // AutomationBridgeEnabled is persisted by the dialog before the
+    // signal fires, so it survives restart.
+    void automationBridgeToggled(bool enabled);
+    // Fired when the user rotates (or first-generates) the bridge access
+    // token. MainWindow persists it and pushes it to the running bridge so
+    // the rotation takes effect immediately.
+    void automationBridgeTokenRotated(const QString& token);
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "gui/ConnectionPanel.h"
 #include "gui/SliceColorManager.h"
 #include "core/AppSettings.h"
+#include "core/AutomationBridgeSettings.h"
 #include "core/GpuSelector.h"
 #include "core/LogManager.h"
 #include "core/MacMicPermission.h"
@@ -449,8 +450,7 @@ int main(int argc, char* argv[])
         // Radio Setup → Network, OR when AETHER_AUTOMATION is set (the launch-
         // time override that headless drivers/CI rely on — always wins). The
         // window owns the server for its lifetime.
-        const bool bridgePersisted =
-            AetherSDR::AppSettings::instance().value("AutomationBridgeEnabled", false).toBool();
+        const bool bridgePersisted = AetherSDR::AutomationBridgeSettings::enabled();
         if (qEnvironmentVariableIsSet("AETHER_AUTOMATION") || bridgePersisted)
             window.startAutomationBridge();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,45 +443,16 @@ int main(int argc, char* argv[])
         // two concurrent automation instances don't steal each other's socket
         // (QLocalServer::removeServer() unlinks a sibling's live socket on a
         // shared name); drivers find the right one via the discovery file/dir.
-        std::unique_ptr<AetherSDR::AutomationServer> automation;
-        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
-            const QString sockName = qEnvironmentVariableIsSet("AETHER_AUTOMATION_SOCKET")
-                ? qEnvironmentVariable("AETHER_AUTOMATION_SOCKET")
-                : QStringLiteral("aethersdr-automation-%1").arg(QCoreApplication::applicationPid());
-            automation = std::make_unique<AetherSDR::AutomationServer>();
-            automation->setRadioModel(&window.radioModel());  // for the get() verb
-            automation->setAudioEngine(window.audioEngine());
-            automation->setQsoRecorder(window.qsoRecorder());  // for the record() verb
-            automation->setConnectionDialogHost(&window);
-            automation->setConnectionAutomation(
-                window.findChild<AetherSDR::ConnectionPanel*>(QStringLiteral("connectionPanel")));
-            automation->setSliceReceiveSourceHandler(
-                [&window](const QString& arg) {
-                    return window.automationSetSliceReceiveSource(arg);
-                });
-            automation->setSliceCenterLockHandler(
-                [&window](int sliceId, bool enabled) {
-                    return window.automationSetCenterLock(sliceId, enabled);
-                });
-            automation->setTuneHandler(
-                [&window](double mhz) {
-                    return window.automationTune(mhz);
-                });
-            automation->setReceiveSyncSnapshotHandler(
-                [&window]() {
-                    return window.automationReceiveSyncSnapshot();
-                });
-            automation->setKiwiSdrSnapshotHandler(
-                [&window]() {
-                    return window.automationKiwiSdrSnapshot();
-                });
-            automation->setTxTimerSnapshotHandler(
-                [&window]() {
-                    return window.automationTxTimerSnapshot();
-                });
-            if (!automation->start(sockName))
-                automation.reset();
-        }
+        // Agent automation bridge (#3646). Construction + handler wiring now
+        // lives in MainWindow::startAutomationBridge() so the same path serves
+        // both triggers. Start it when the operator persisted the toggle in
+        // Radio Setup → Network, OR when AETHER_AUTOMATION is set (the launch-
+        // time override that headless drivers/CI rely on — always wins). The
+        // window owns the server for its lifetime.
+        const bool bridgePersisted =
+            AetherSDR::AppSettings::instance().value("AutomationBridgeEnabled", false).toBool();
+        if (qEnvironmentVariableIsSet("AETHER_AUTOMATION") || bridgePersisted)
+            window.startAutomationBridge();
 
         exitCode = app.exec();
     }

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -125,7 +125,7 @@ class Bridge:
             if self._pipe:
                 self._pipe.close()
         except OSError:
-            pass
+            pass  # best-effort teardown — a close failure is not actionable
 
 
 def bridge_request(obj, timeout=REQUEST_TIMEOUT_S):
@@ -372,7 +372,9 @@ def handle_tool(name, args):
         return text_result(bridge_request(req))
 
     if name == "shortcut":
-        return text_result(bridge_request({"cmd": "shortcut", "value": args["id"]}))
+        # The registry's shortcut verb reads `id` (or `target`), not `value` —
+        # a JSON request bypasses the bare-line positional parser.
+        return text_result(bridge_request({"cmd": "shortcut", "id": args["id"]}))
 
     if name == "bridge_command":
         req = args.get("request")
@@ -396,6 +398,17 @@ def main():
         try:
             msg = json.loads(raw)
         except ValueError:
+            continue
+        # A JSON-RPC message must be an object. A batch array or a bare scalar
+        # would make msg.get(...) raise AttributeError outside every try and
+        # kill the loop — reject them per JSON-RPC (-32600) and keep serving.
+        if not isinstance(msg, dict):
+            sys.stdout.write(json.dumps({
+                "jsonrpc": "2.0", "id": None,
+                "error": {"code": -32600,
+                          "message": "Invalid Request: expected a JSON object"
+                                     " (batch requests are not supported)"}}) + "\n")
+            sys.stdout.flush()
             continue
         method, mid = msg.get("method"), msg.get("id")
         if method == "initialize":

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+AetherSDR automation-bridge MCP server (issue #3646 follow-on).
+
+Wraps the in-app automation bridge (src/core/AutomationServer.*) in the
+Model Context Protocol so ANY MCP-capable AI coding assistant — Claude
+Code, Cursor, Copilot Workspace, Codex CLI, Gemini CLI, … — can drive a
+locally-running AetherSDR to validate a change end-to-end: dump the
+widget tree, click controls, assert model state, capture screenshots.
+
+Zero third-party deps, stdio transport, newline-delimited JSON-RPC.
+Talks to the bridge over its AF_UNIX socket (macOS/Linux) or named pipe
+(Windows), discovered from <temp>/aethersdr-automation.json exactly like
+tools/automation_probe.py.
+
+Setup (contributor):
+    AETHER_AUTOMATION=1 ./AetherSDR &     # launch the app, bridge on
+    # then register this server with your assistant, e.g. Claude Code:
+    #   the repo's .mcp.json does it automatically, or:
+    #   claude mcp add aethersdr -- python3 tools/aether_mcp.py
+
+Safety: the bridge refuses transmit-keying controls (MOX/PTT/TUNE/ATU/
+CWX send) unless the operator launches the app with
+AETHER_AUTOMATION_ALLOW_TX — that gate lives in the app, not here, so
+no MCP client can key a live radio by accident.
+
+Auth: if the operator set an access token in Radio Setup → Network, the
+bridge rejects every verb (except ping) without a matching token. Put
+that token in AETHER_MCP_TOKEN and this server attaches it to every
+request. Without the right token the app cannot be driven — that's what
+stops a random local agent from touching the radio.
+
+Env:
+    AETHER_MCP_SOCKET   override the bridge socket path (else discovery)
+    AETHER_MCP_TOKEN    access token from Radio Setup → Network (if set)
+"""
+
+import base64
+import glob
+import json
+import os
+import socket
+import sys
+import tempfile
+import time
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_INFO = {"name": "aethersdr-automation", "version": "1.0.0"}
+REQUEST_TIMEOUT_S = 60
+MAX_INLINE_IMAGE_BYTES = 800_000  # larger grabs are returned as a path only
+
+
+# --------------------------------------------------------------------------
+# Bridge client (mirrors tools/automation_probe.py)
+# --------------------------------------------------------------------------
+
+def discover_sockets():
+    """All live bridge endpoints, newest first.
+
+    The app writes <temp>/aethersdr-automation.json (latest instance) and
+    <temp>/aethersdr-automation/<pid>.json (one per instance).
+    """
+    tmp = tempfile.gettempdir()
+    entries = []
+    for path in ([os.path.join(tmp, "aethersdr-automation.json")]
+                 + glob.glob(os.path.join(tmp, "aethersdr-automation", "*.json"))):
+        try:
+            with open(path) as f:
+                d = json.load(f)
+            if d.get("socket"):
+                entries.append(d)
+        except (OSError, ValueError):
+            continue
+    seen, unique = set(), []
+    for d in sorted(entries, key=lambda d: d.get("startedAt", 0), reverse=True):
+        if d["socket"] not in seen:
+            seen.add(d["socket"])
+            unique.append(d)
+    return unique
+
+
+def bridge_socket_path():
+    override = os.environ.get("AETHER_MCP_SOCKET")
+    if override:
+        return override
+    entries = discover_sockets()
+    return entries[0]["socket"] if entries else None
+
+
+class Bridge:
+    """One connection to the bridge; newline-delimited JSON both ways."""
+
+    def __init__(self, sock_path, timeout=REQUEST_TIMEOUT_S):
+        self.sock_path = sock_path
+        self._buf = b""
+        if sys.platform == "win32":
+            self._pipe = open(rf"\\.\pipe\{os.path.basename(sock_path)}",
+                              "r+b", buffering=0)
+            self._sock = None
+        else:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.settimeout(timeout)
+            self._sock.connect(sock_path)
+            self._pipe = None
+
+    def request(self, obj):
+        line = (json.dumps(obj) + "\n").encode()
+        if self._sock:
+            self._sock.sendall(line)
+            while b"\n" not in self._buf:
+                chunk = self._sock.recv(65536)
+                if not chunk:
+                    raise ConnectionError("bridge closed the connection")
+                self._buf += chunk
+            line, _, self._buf = self._buf.partition(b"\n")
+            return json.loads(line.decode())
+        self._pipe.write(line)
+        self._pipe.flush()
+        return json.loads(self._pipe.readline().decode())
+
+    def close(self):
+        try:
+            if self._sock:
+                self._sock.close()
+            if self._pipe:
+                self._pipe.close()
+        except OSError:
+            pass
+
+
+def bridge_request(obj, timeout=REQUEST_TIMEOUT_S):
+    """Connect, send one request (with the token, if set), return the response."""
+    sock_path = bridge_socket_path()
+    if not sock_path:
+        raise RuntimeError(
+            "No running AetherSDR automation bridge found. Launch the app "
+            "with the AETHER_AUTOMATION=1 environment variable set (the "
+            "bridge is off by default), then retry. Discovery file checked: "
+            + os.path.join(tempfile.gettempdir(), "aethersdr-automation.json"))
+    # Attach the access token to every request so the bridge's auth gate
+    # accepts it. Harmless when the bridge has no token configured (the
+    # field is simply ignored). `ping` doesn't need it but sending it is fine.
+    token = os.environ.get("AETHER_MCP_TOKEN")
+    if token and "token" not in obj:
+        obj = dict(obj, token=token)
+    b = Bridge(sock_path, timeout)
+    try:
+        return b.request(obj)
+    finally:
+        b.close()
+
+
+# --------------------------------------------------------------------------
+# Tree filtering (dumpTree responses are large; let callers prune)
+# --------------------------------------------------------------------------
+
+def prune_tree(node, needle):
+    """Keep subtrees whose objectName/class/accessibleName/text matches."""
+    if not isinstance(node, dict):
+        return None
+    hay = " ".join(str(node.get(k, "")) for k in
+                   ("objectName", "class", "accessibleName", "text",
+                    "title", "windowTitle", "value", "role")).lower()
+    kids = node.get("children") or []
+    kept = [c for c in (prune_tree(k, needle) for k in kids) if c]
+    if needle in hay or kept:
+        out = {k: v for k, v in node.items() if k != "children"}
+        if kept:
+            out["children"] = kept
+        return out
+    return None
+
+
+# --------------------------------------------------------------------------
+# MCP tools
+# --------------------------------------------------------------------------
+
+TOOLS = [
+    {
+        "name": "bridge_status",
+        "description": (
+            "Check the AetherSDR automation bridge: lists running "
+            "instances (pid, socket, version, label) and pings the "
+            "active one. Call this first — it tells you whether the app "
+            "is running with AETHER_AUTOMATION=1 and which instance "
+            "you're driving."),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "dump_tree",
+        "description": (
+            "ARIA-style JSON snapshot of the live widget tree: "
+            "objectName, class, accessibleName, role/value, enabled, "
+            "visible, global geometry, windowState. THE way to find a "
+            "control's target name before invoke/grab. Pass `filter` "
+            "(case-insensitive substring of objectName/class/"
+            "accessibleName/text) to prune the tree — full dumps are "
+            "large; filter whenever you know roughly what you're "
+            "looking for."),
+        "inputSchema": {"type": "object", "properties": {
+            "filter": {"type": "string",
+                       "description": "substring to prune the tree to matching subtrees"},
+        }},
+    },
+    {
+        "name": "grab_widget",
+        "description": (
+            "Screenshot a single widget as PNG, resolved by objectName, "
+            "class name, or accessibleName (use dump_tree to find it). "
+            "GPU panadapter content is captured correctly via "
+            "framebuffer readback. Special targets: 'pan', "
+            "'pan-visible', 'pan-composite' with `selector` = pan "
+            "index. Returns the image inline (and the saved file path)."),
+        "inputSchema": {"type": "object", "properties": {
+            "target": {"type": "string"},
+            "selector": {"type": "string",
+                         "description": "pan index, only for pan/pan-visible/pan-composite"},
+        }, "required": ["target"]},
+    },
+    {
+        "name": "invoke",
+        "description": (
+            "Drive a control deterministically: actions click, toggle, "
+            "setChecked, setValue, setText, setCurrentText, "
+            "setCurrentIndex, selectRow, submit (QLineEdit: setText + "
+            "returnPressed), trigger (QAction/menu item, works while "
+            "the menu is closed). Target = objectName / class / "
+            "accessibleName from dump_tree. The bridge REFUSES "
+            "transmit-keying controls (MOX/PTT/TUNE/ATU/CWX) unless the "
+            "app was launched with AETHER_AUTOMATION_ALLOW_TX."),
+        "inputSchema": {"type": "object", "properties": {
+            "target": {"type": "string"},
+            "action": {"type": "string"},
+            "value": {"type": "string", "description": "for set* / submit actions"},
+        }, "required": ["target", "action"]},
+    },
+    {
+        "name": "get_state",
+        "description": (
+            "Live JSON snapshot of app/radio state — assert on state "
+            "without screenshots. model = audio | dsp | radio | "
+            "transmit | slice <selector: id|active|tx> | slices | pan "
+            "<selector: id|active> | pans | flags | kiwi | sync. "
+            "Optional `property` returns just that field."),
+        "inputSchema": {"type": "object", "properties": {
+            "model": {"type": "string"},
+            "selector": {"type": "string"},
+            "property": {"type": "string"},
+        }, "required": ["model"]},
+    },
+    {
+        "name": "shortcut",
+        "description": ("Invoke a registered ShortcutManager action by id, "
+                        "without needing a physical key binding."),
+        "inputSchema": {"type": "object", "properties": {
+            "id": {"type": "string"},
+        }, "required": ["id"]},
+    },
+    {
+        "name": "bridge_command",
+        "description": (
+            "Raw escape hatch for every other bridge verb — send any "
+            "JSON request object ({\"cmd\": ...}) straight to the "
+            "bridge and get the raw response. Useful verbs: hover, "
+            "tooltip, hitTest, clickAt, rightClick, contextMenu, "
+            "resize {value:'W H'}, window, menu, actions, connect "
+            "(list/show/local/ip/wait), disconnect, slice, tune, pan, "
+            "layout, scale, dss (deterministic spectrum injection), "
+            "panmessage, audioCapture, record, testtone, whoami. Full "
+            "verb reference: src/core/AutomationServer.h header "
+            "comment."),
+        "inputSchema": {"type": "object", "properties": {
+            "request": {"type": "object",
+                        "description": "the raw bridge request, e.g. {\"cmd\":\"whoami\"}"},
+            "timeout_s": {"type": "number",
+                          "description": "override the 60s default (e.g. connect wait)"},
+        }, "required": ["request"]},
+    },
+]
+
+
+def text_result(obj):
+    text = obj if isinstance(obj, str) else json.dumps(obj, indent=2)
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def error_result(msg):
+    return {"content": [{"type": "text", "text": f"Error: {msg}"}], "isError": True}
+
+
+def handle_tool(name, args):
+    if name == "bridge_status":
+        entries = discover_sockets()
+        status = {"instances": entries, "active": None,
+                  "token_configured_here": bool(os.environ.get("AETHER_MCP_TOKEN"))}
+        if entries or os.environ.get("AETHER_MCP_SOCKET"):
+            # ping needs no token and reveals whether the bridge requires one.
+            try:
+                pong = bridge_request({"cmd": "ping"}, timeout=10)
+                status["bridge_auth_required"] = pong.get("authRequired")
+            except Exception as e:  # noqa: BLE001
+                status["ping_error"] = str(e)
+            # whoami is auth-gated — its success confirms our token is accepted.
+            try:
+                status["active"] = bridge_request({"cmd": "whoami"}, timeout=10)
+            except Exception as e:  # noqa: BLE001 — report, don't die
+                status["active_error"] = str(e)
+            if (status.get("bridge_auth_required")
+                    and not status["token_configured_here"]):
+                status["hint"] = ("This bridge requires a token, but "
+                                  "AETHER_MCP_TOKEN is not set for this server. "
+                                  "Copy the token from Radio Setup → Network → "
+                                  "Access Token and set it in this MCP server's "
+                                  "env config.")
+        if not entries and not os.environ.get("AETHER_MCP_SOCKET"):
+            status["hint"] = ("No bridge running. Launch AetherSDR with "
+                              "AETHER_AUTOMATION=1 or enable it in Radio Setup "
+                              "→ Network.")
+        return text_result(status)
+
+    if name == "dump_tree":
+        resp = bridge_request({"cmd": "dumpTree"})
+        needle = (args.get("filter") or "").strip().lower()
+        if needle and isinstance(resp, dict):
+            # The bridge returns top-level widgets under "roots".
+            roots = resp.get("roots")
+            if isinstance(roots, list):
+                pruned = [t for t in (prune_tree(r, needle) for r in roots) if t]
+                resp = dict(resp, roots=pruned, filtered=needle,
+                            matches=len(pruned))
+            else:
+                pruned = prune_tree(resp, needle)
+                resp = pruned if pruned else {"filtered": needle, "matches": 0}
+        return text_result(resp)
+
+    if name == "grab_widget":
+        target = args["target"]
+        out = os.path.join(tempfile.gettempdir(),
+                           f"aether-mcp-grab-{int(time.time())}.png")
+        req = {"cmd": "grab", "target": target, "path": out}
+        if args.get("selector"):
+            req["selector"] = str(args["selector"])
+        resp = bridge_request(req)
+        path = resp.get("path", out) if isinstance(resp, dict) else out
+        content = [{"type": "text", "text": json.dumps(resp)}]
+        try:
+            size = os.path.getsize(path)
+            if size <= MAX_INLINE_IMAGE_BYTES:
+                with open(path, "rb") as f:
+                    content.append({"type": "image",
+                                    "data": base64.b64encode(f.read()).decode(),
+                                    "mimeType": "image/png"})
+            else:
+                content[0]["text"] += (f"\n(image {size} bytes — too large to "
+                                       f"inline, read it from {path})")
+        except OSError as e:
+            content[0]["text"] += f"\n(could not read capture: {e})"
+        return {"content": content}
+
+    if name == "invoke":
+        req = {"cmd": "invoke", "target": args["target"], "action": args["action"]}
+        if args.get("value") is not None:
+            req["value"] = str(args["value"])
+        return text_result(bridge_request(req))
+
+    if name == "get_state":
+        req = {"cmd": "get", "model": args["model"]}
+        if args.get("selector"):
+            req["selector"] = str(args["selector"])
+        if args.get("property"):
+            req["property"] = str(args["property"])
+        return text_result(bridge_request(req))
+
+    if name == "shortcut":
+        return text_result(bridge_request({"cmd": "shortcut", "value": args["id"]}))
+
+    if name == "bridge_command":
+        req = args.get("request")
+        if not isinstance(req, dict) or "cmd" not in req:
+            return error_result("`request` must be an object with a `cmd` key")
+        timeout = float(args.get("timeout_s") or REQUEST_TIMEOUT_S)
+        return text_result(bridge_request(req, timeout=timeout))
+
+    return error_result(f"Unknown tool: {name}")
+
+
+# --------------------------------------------------------------------------
+# MCP stdio loop (newline-delimited JSON-RPC)
+# --------------------------------------------------------------------------
+
+def main():
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except ValueError:
+            continue
+        method, mid = msg.get("method"), msg.get("id")
+        if method == "initialize":
+            resp = {"jsonrpc": "2.0", "id": mid, "result": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": SERVER_INFO}}
+        elif method == "notifications/initialized":
+            continue
+        elif method == "tools/list":
+            resp = {"jsonrpc": "2.0", "id": mid,
+                    "result": {"tools": TOOLS}}
+        elif method == "tools/call":
+            params = msg.get("params") or {}
+            try:
+                result = handle_tool(params.get("name"),
+                                     params.get("arguments") or {})
+            except Exception as e:  # noqa: BLE001 — surface to the model
+                result = error_result(str(e))
+            resp = {"jsonrpc": "2.0", "id": mid, "result": result}
+        elif mid is not None:
+            resp = {"jsonrpc": "2.0", "id": mid,
+                    "error": {"code": -32601, "message": f"Unknown: {method}"}}
+        else:
+            continue
+        sys.stdout.write(json.dumps(resp) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Field-mapping / protocol regression test for the MCP server (tools/aether_mcp.py).
+
+Runs WITHOUT a live app: it stubs the bridge transport and asserts that each
+MCP tool emits the exact request the AutomationServer verb registry reads
+(e.g. shortcut → `id`, not `value`), and that the JSON-RPC loop rejects
+non-object messages. This is the guard jensenpat asked for on #4177 so the
+schema ↔ bridge field mapping cannot silently drift again.
+
+    python3 tools/test_aether_mcp.py     # exits non-zero on any failure
+"""
+
+import io
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import aether_mcp  # noqa: E402
+
+_REAL_BRIDGE_REQUEST = aether_mcp.bridge_request  # save before any monkeypatch
+_failures = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}  {detail}")
+        _failures.append(name)
+
+
+# ── Tool → bridge request field mapping ──────────────────────────────────────
+# Stub bridge_request to capture the request dicts and return a canned reply.
+
+_captured = []
+
+
+def _fake_bridge_request(obj, timeout=None):
+    _captured.append(obj)
+    cmd = obj.get("cmd")
+    if cmd == "ping":
+        return {"ok": True, "authRequired": False}
+    if cmd == "whoami":
+        return {"ok": True, "pid": 1, "socket": "/tmp/x"}
+    if cmd == "grab":
+        return {"ok": True, "path": "/nonexistent.png"}
+    return {"ok": True, "cmd": cmd, "echo": obj}
+
+
+def run_tool(name, args):
+    _captured.clear()
+    aether_mcp.handle_tool(name, args)
+    return list(_captured)
+
+
+def test_field_mapping():
+    aether_mcp.bridge_request = _fake_bridge_request  # monkeypatch
+
+    reqs = run_tool("shortcut", {"id": "band_zoom"})
+    r = reqs[-1]
+    check("shortcut sends cmd=shortcut", r.get("cmd") == "shortcut")
+    check("shortcut sends id (not value)",
+          r.get("id") == "band_zoom" and "value" not in r, detail=str(r))
+
+    reqs = run_tool("invoke", {"target": "Master volume", "action": "setValue",
+                               "value": "35"})
+    r = reqs[-1]
+    check("invoke target/action/value",
+          r.get("cmd") == "invoke" and r.get("target") == "Master volume"
+          and r.get("action") == "setValue" and r.get("value") == "35", str(r))
+
+    reqs = run_tool("get_state", {"model": "slice", "selector": "active",
+                                  "property": "frequency"})
+    r = reqs[-1]
+    check("get_state model/selector/property",
+          r.get("cmd") == "get" and r.get("model") == "slice"
+          and r.get("selector") == "active" and r.get("property") == "frequency", str(r))
+
+    reqs = run_tool("grab_widget", {"target": "SpectrumWidget"})
+    r = reqs[0]
+    check("grab_widget sends cmd=grab + target",
+          r.get("cmd") == "grab" and r.get("target") == "SpectrumWidget", str(r))
+
+    reqs = run_tool("dump_tree", {})
+    check("dump_tree sends cmd=dumpTree", reqs[-1].get("cmd") == "dumpTree", str(reqs))
+
+    reqs = run_tool("bridge_command", {"request": {"cmd": "whoami"}})
+    check("bridge_command passes raw request", reqs[-1].get("cmd") == "whoami", str(reqs))
+
+
+def test_token_attached():
+    # With AETHER_MCP_TOKEN set, real bridge_request must attach it to every req.
+    os.environ["AETHER_MCP_TOKEN"] = "secret-xyz"
+    seen = {}
+
+    class _StubBridge:
+        def __init__(self, *a, **k):
+            pass
+
+        def request(self, obj):
+            seen.update(obj)
+            return {"ok": True}
+
+        def close(self):
+            pass
+
+    orig_bridge = aether_mcp.Bridge
+    orig_sockpath = aether_mcp.bridge_socket_path
+    orig_req = aether_mcp.bridge_request
+    aether_mcp.Bridge = _StubBridge
+    aether_mcp.bridge_socket_path = lambda: "/tmp/fake.sock"
+    aether_mcp.bridge_request = _REAL_BRIDGE_REQUEST  # exercise the real token-attach path
+    try:
+        aether_mcp.bridge_request({"cmd": "get", "model": "radio"})
+        check("token attached from AETHER_MCP_TOKEN", seen.get("token") == "secret-xyz",
+              str(seen))
+    finally:
+        aether_mcp.Bridge = orig_bridge
+        aether_mcp.bridge_socket_path = orig_sockpath
+        aether_mcp.bridge_request = orig_req
+        del os.environ["AETHER_MCP_TOKEN"]
+
+
+# ── JSON-RPC loop robustness (non-dict must not crash the loop) ──────────────
+
+def drive_main(lines):
+    """Feed newline-delimited JSON-RPC into main(), capture stdout responses."""
+    stdin, stdout = sys.stdin, sys.stdout
+    sys.stdin = io.StringIO("\n".join(lines) + "\n")
+    sys.stdout = io.StringIO()
+    try:
+        aether_mcp.main()
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdin, sys.stdout = stdin, stdout
+    return [json.loads(l) for l in out.splitlines() if l.strip()]
+
+
+def test_jsonrpc_robustness():
+    resps = drive_main([
+        json.dumps([1, 2, 3]),            # batch array — must be rejected, not crash
+        json.dumps("scalar"),             # bare scalar — rejected
+        json.dumps({"jsonrpc": "2.0", "id": 7, "method": "tools/list"}),  # still served
+    ])
+    codes = [r.get("error", {}).get("code") for r in resps]
+    check("batch array rejected -32600", -32600 in codes, str(resps))
+    served = [r for r in resps if r.get("id") == 7 and "result" in r]
+    check("loop keeps serving after bad input", len(served) == 1, str(resps))
+
+
+if __name__ == "__main__":
+    test_field_mapping()
+    test_token_attached()
+    test_jsonrpc_robustness()
+    if _failures:
+        print(f"\n{len(_failures)} FAILED: {_failures}")
+        sys.exit(1)
+    print("\nall MCP field-mapping/protocol checks passed")


### PR DESCRIPTION
## Summary

Wraps the in-app automation bridge (#3646) in an **MCP server** so any MCP-capable AI coding assistant (Claude Code, Cursor, Copilot, Codex CLI, …) can validate a change against a running AetherSDR — and makes the bridge **operator-controllable, authenticated, and TX-gated from the GUI** so the operator opts a specific client in — protecting the token at rest, across other user accounts, and over any network reach (not a hard wall against a determined same-user process; see the threat-model note in docs/automation-bridge.md).

Motivated by the ~50 AI-assisted contributors: each can self-verify UI changes against the real app before requesting review.

## What's included

- **`tools/aether_mcp.py`** — zero-dependency stdio MCP server over the bridge socket. Tools: `bridge_status`, `dump_tree` (with `filter`), `grab_widget` (PNG inline), `invoke`, `get_state`, `shortcut`, `bridge_command`. **`.mcp.json`** registers it for Claude Code.
- **Radio Setup → Network → "Agent Automation (MCP)" toggle** — starts/stops the bridge at runtime (persisted `AutomationBridgeEnabled`); `AETHER_AUTOMATION` still force-enables for headless/CI and is reflected read-only.
- **Bridge lifecycle** moved from `main.cpp` into `MainWindow::startAutomationBridge()`/`stopAutomationBridge()`.
- **Shared-secret token** — Access Token field with Copy/Rotate. When set, every verb except `ping` requires a matching `token` (constant-time compare); empty = open (unchanged headless behavior). MCP server sends `AETHER_MCP_TOKEN` per request. Enabling the bridge auto-generates a token so it's never exposed unauthenticated.
- **"Allow TX via MCP" checkbox** — the transmit-keying guard, now operator-controllable. Off by default. Checking it the first time raises a confirmation making clear that automated software can transmit and that **the operator remains responsible for all emissions**; confirm persists (and is not re-prompted), cancel reverts. `m_txAllowed` is now the single source of truth across every TX guard site (previously several re-read the env var directly); toggling it drives the gate live and arms/disarms the force-unkey watchdog. `AETHER_AUTOMATION_ALLOW_TX` still force-enables at launch.

## Relationship to #4175

Built on the table-driven verb registry from **#4175**, which has now **merged to `main`** — this PR is rebased onto it and its base is `main`. The token auth gate is implemented registry-native (integrates into #4175's `VerbArgs`/`spec->dispatch`). Diff is exactly the 10 files here.

Kept as a **draft** pending the maintainer's go-ahead. Please don't arm auto-merge.

## Testing

- Full build green on current `main` (post-#4175).
- **Auth matrix** end-to-end (isolated config, offscreen): `ping` reports `authRequired`; every verb (incl. #4175's `verbs` and the `txtimer` feature) rejected with no/wrong token, accepted with the right token; MCP server blocks without `AETHER_MCP_TOKEN`, works with it.
- **TX gate**: `whoami.txAllowed` reflects the persisted setting; `key mox` blocked when off, allowed when on.
- Caught + fixed a segfault during testing: the constant-time token compare indexed an empty `QByteArray` when no token was supplied (gdb-traced); now substitutes a zero byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)