### PR TITLE
fix(multiflex): prevent duplicate AetherSDR client identity evictions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2323,6 +2323,13 @@ if(PYTHON3_EXECUTABLE)
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_aether_mcp.py)
 endif()
 
+add_executable(gui_client_identity_policy_test
+    tests/gui_client_identity_policy_test.cpp
+)
+target_include_directories(gui_client_identity_policy_test PRIVATE src)
+target_link_libraries(gui_client_identity_policy_test PRIVATE Qt6::Core)
+add_test(NAME gui_client_identity_policy_test COMMAND gui_client_identity_policy_test)
+
 add_executable(profile_load_command_test
     tests/profile_load_command_test.cpp
 )

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -56,6 +56,25 @@ For headless / CI runs, add `QT_QPA_PLATFORM=offscreen` — no display required.
 `AETHER_AUTOMATION_NO_AUTOCONNECT=1` suppresses saved-radio autoconnect during
 bridge runs; use the `connect` verb when a test intentionally needs a radio.
 
+Parallel worktrees should give each bridge a stable automation identity and a
+human-readable agent name:
+
+```bash
+AETHER_AUTOMATION=1 \
+AETHER_AUTOMATION_IDENTITY=issue-4166-worktree \
+AETHER_AUTOMATION_AGENT_NAME=Codex-GPT-5.6 \
+AETHER_AUTOMATION_SOCKET=aethersdr-4166 \
+./build/AetherSDR.app/Contents/MacOS/AetherSDR
+```
+
+`AETHER_AUTOMATION_IDENTITY` deterministically selects a process-scoped Flex
+GUI client UUID, so concurrent worktrees do not displace one another through
+the radio's duplicate-client takeover behavior. If it is omitted, the socket,
+automation label, or PID is used in that order. `AETHER_AUTOMATION_AGENT_NAME`
+sets the station label shown to other Multi-Flex clients; it is display-only
+and is never used as the UUID because several worktrees may use the same LLM.
+Automation identities never overwrite the user's persistent `GUIClientID`.
+
 KiwiSDR compression can be forced for diagnostic runs by adding
 `AETHER_KIWI_SND_COMP=1` and/or `AETHER_KIWI_WF_COMP=1` at launch. These are
 receive-only automation knobs: SND changes the outbound sound setup request
@@ -216,7 +235,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get cwx`](#get-cwx) | CWX keyer state + queue-drain watch (#3949). |
 | | [`get panstats`](#get-panstats) | Per-panadapter render-cost counters (profiling). |
 | | [`get tracedebug`](#get-tracedebug) | Per-panadapter Flex/Kiwi FFT and 3D trace diagnostics. |
-| | [`get clients`](#get-clients) | Radio client roster + foreign-pan-write forensics (#3977). |
+| | [`get clients`](#get-clients) | Radio client roster, GUI IDs + foreign-pan-write forensics (#3977/#4166). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
 | | [`get wavestats`](#get-wavestats) | WAVE/strip scope paint-cost counters. |
 | | [`get dax`](#get-dax) | DAX RX channel-ownership table (holders/streams, #3305). |

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -401,6 +401,12 @@ void AppSettings::initializeGuiClientIdentity()
     };
     const QString encoded = QString::fromUtf8(
         QJsonDocument(identityConfig).toJson(QJsonDocument::Compact));
+    // Only persist when something actually changed, so the common case (a
+    // stored id read back unchanged) issues no save and a second concurrent
+    // instance doesn't rewrite the file. The one racy case — two fresh installs
+    // with no stored id launched simultaneously — writes divergent persistent
+    // ids last-writer-wins, but each instance's *effective* id stays distinct
+    // via the lock below, so runtime behavior is unaffected.
     if (value(QString::fromLatin1(kIdentityConfigKey)).toString() != encoded
         || value(QStringLiteral("GUIClientID")).toString() != persistent) {
         setValue(QString::fromLatin1(kIdentityConfigKey), encoded);
@@ -441,6 +447,14 @@ void AppSettings::initializeGuiClientIdentity()
     }
 
     m_guiClientLock = std::make_unique<QLockFile>(m_filePath + QStringLiteral(".gui-client.lock"));
+    // Disable time-based staleness on purpose: QLockFile stamps the lock mtime
+    // once at creation and never refreshes it while held, so a non-zero stale
+    // time would let a second instance declare a *live* long-running instance's
+    // lock stale after the interval and steal the persistent ID — reintroducing
+    // the exact collision this guards against. QLockFile's same-machine
+    // PID-alive check still reclaims a crashed instance's lock; the only
+    // residual is a crashed PID later reused by an unrelated process, which
+    // leaves this install on a transient ID until the lock file is removed.
     m_guiClientLock->setStaleLockTime(0);
     if (m_guiClientLock->tryLock(0)) {
         m_effectiveGuiClientId = persistent;
@@ -513,6 +527,11 @@ bool AppSettings::resolveLiveGuiClientIdCollision(const QString& otherStation)
 
 void AppSettings::recordPersistentGuiClientIdReply(const QString& clientId)
 {
+    // Defensive: registerAsGuiClient always sends `client gui <id>` with our
+    // non-empty effective id, so the radio normally echoes that same id and we
+    // return early below. This only adopts-and-persists if the radio ever
+    // hands back a *different* id (e.g. a future firmware that normalizes it),
+    // keeping our stored identity aligned with what the radio actually bound.
     if (m_guiClientIdentityTransient) {
         return;
     }

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -1,4 +1,5 @@
 #include "AppSettings.h"
+#include "GuiClientIdentityPolicy.h"
 
 #include <QStandardPaths>
 #include <QDir>
@@ -10,6 +11,11 @@
 #include <QDebug>
 #include <QCoreApplication>
 #include <QRegularExpression>
+#include <QCryptographicHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLockFile>
+#include <QSysInfo>
 
 namespace AetherSDR {
 
@@ -18,6 +24,32 @@ AppSettings& AppSettings::instance()
     static AppSettings s;
     return s;
 }
+
+AppSettings::~AppSettings() = default;
+
+namespace {
+
+QString validUuidOrEmpty(const QString& value)
+{
+    const QUuid uuid(value.trimmed());
+    return uuid.isNull() ? QString() : uuid.toString(QUuid::WithoutBraces).toUpper();
+}
+
+QString machineBinding()
+{
+    QByteArray unique = QSysInfo::machineUniqueId();
+    if (unique.isEmpty()) {
+        unique = QSysInfo::machineHostName().toUtf8() + '|'
+                 + QSysInfo::kernelType().toUtf8() + '|'
+                 + QSysInfo::currentCpuArchitecture().toUtf8();
+    }
+    return QString::fromLatin1(
+        QCryptographicHash::hash(unique, QCryptographicHash::Sha256).toHex());
+}
+
+constexpr char kIdentityConfigKey[] = "GuiClientIdentity";
+
+} // namespace
 
 AppSettings::AppSettings()
 {
@@ -273,10 +305,18 @@ void AppSettings::save()
 
 void AppSettings::reset()
 {
+    m_guiClientLock.reset();
     m_settings.clear();
     m_stationSettings.clear();
     m_stationName = "AetherSDR";
     m_loadedCount = 0;
+    m_persistentGuiClientId.clear();
+    m_effectiveGuiClientId.clear();
+    m_effectiveStationName.clear();
+    m_automationIdentity.clear();
+    m_automationAgentName.clear();
+    m_guiClientIdentityInitialized = false;
+    m_guiClientIdentityTransient = false;
 }
 
 // ─── Top-level accessors ──────────────────────────────────────────────────────
@@ -326,6 +366,170 @@ void AppSettings::setStationName(const QString& name)
 {
     m_stationName = name;
     m_settings.insert("StationName", name);
+}
+
+void AppSettings::initializeGuiClientIdentity()
+{
+    if (m_guiClientIdentityInitialized) {
+        return;
+    }
+    m_guiClientIdentityInitialized = true;
+
+    const QJsonObject stored = QJsonDocument::fromJson(
+        value(QString::fromLatin1(kIdentityConfigKey)).toString().toUtf8()).object();
+    QString persistent = validUuidOrEmpty(
+        stored.value(QStringLiteral("PersistentId")).toString());
+    if (persistent.isEmpty()) {
+        persistent = validUuidOrEmpty(value(QStringLiteral("GUIClientID")).toString());
+    }
+    if (persistent.isEmpty()) {
+        persistent = QUuid::createUuid().toString(QUuid::WithoutBraces).toUpper();
+    }
+
+    const QString currentBinding = machineBinding();
+    const QString storedBinding = stored.value(QStringLiteral("MachineBinding")).toString();
+    if (!storedBinding.isEmpty() && !currentBinding.isEmpty()
+        && storedBinding != currentBinding) {
+        persistent = QUuid::createUuid().toString(QUuid::WithoutBraces).toUpper();
+        qWarning() << "AppSettings: settings came from another machine; rotated GUI client ID";
+    }
+
+    m_persistentGuiClientId = persistent;
+    QJsonObject identityConfig{
+        {QStringLiteral("PersistentId"), persistent},
+        {QStringLiteral("MachineBinding"), currentBinding},
+    };
+    const QString encoded = QString::fromUtf8(
+        QJsonDocument(identityConfig).toJson(QJsonDocument::Compact));
+    if (value(QString::fromLatin1(kIdentityConfigKey)).toString() != encoded
+        || value(QStringLiteral("GUIClientID")).toString() != persistent) {
+        setValue(QString::fromLatin1(kIdentityConfigKey), encoded);
+        // Compatibility mirror for older builds and existing support tooling.
+        setValue(QStringLiteral("GUIClientID"), persistent);
+        save();
+    }
+
+    const bool automation = qEnvironmentVariableIsSet("AETHER_AUTOMATION");
+    if (automation) {
+        m_automationIdentity = qEnvironmentVariable("AETHER_AUTOMATION_IDENTITY").trimmed();
+        if (m_automationIdentity.isEmpty()) {
+            m_automationIdentity = qEnvironmentVariable("AETHER_AUTOMATION_SOCKET").trimmed();
+        }
+        if (m_automationIdentity.isEmpty()) {
+            m_automationIdentity = qEnvironmentVariable("AETHER_AUTOMATION_LABEL").trimmed();
+        }
+        if (m_automationIdentity.isEmpty()) {
+            m_automationIdentity = QStringLiteral("pid-%1")
+                                       .arg(QCoreApplication::applicationPid());
+        }
+        m_effectiveGuiClientId =
+            GuiClientIdentityPolicy::automationClientId(m_automationIdentity);
+        m_guiClientIdentityTransient = true;
+        m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_AGENT_NAME").trimmed();
+        if (m_automationAgentName.isEmpty()) {
+            m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_STATION").trimmed();
+        }
+        if (m_automationAgentName.isEmpty()) {
+            m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_LABEL").trimmed();
+        }
+        if (m_automationAgentName.isEmpty()) {
+            m_automationAgentName = QStringLiteral("Automation");
+        }
+        m_effectiveStationName =
+            GuiClientIdentityPolicy::protocolSafeStation(m_automationAgentName);
+        return;
+    }
+
+    m_guiClientLock = std::make_unique<QLockFile>(m_filePath + QStringLiteral(".gui-client.lock"));
+    m_guiClientLock->setStaleLockTime(0);
+    if (m_guiClientLock->tryLock(0)) {
+        m_effectiveGuiClientId = persistent;
+    } else {
+        m_effectiveGuiClientId =
+            QUuid::createUuid().toString(QUuid::WithoutBraces).toUpper();
+        m_guiClientIdentityTransient = true;
+        qWarning() << "AppSettings: another local process owns the persistent GUI client ID;"
+                      " using a process-scoped ID";
+    }
+
+    m_effectiveStationName = GuiClientIdentityPolicy::protocolSafeStation(
+        value(QStringLiteral("StationName")).toString());
+    if (m_effectiveStationName.isEmpty()) {
+        m_effectiveStationName =
+            GuiClientIdentityPolicy::protocolSafeStation(QSysInfo::machineHostName());
+    }
+}
+
+QString AppSettings::effectiveGuiClientId() const
+{
+    return m_effectiveGuiClientId.isEmpty()
+               ? value(QStringLiteral("GUIClientID")).toString()
+               : m_effectiveGuiClientId;
+}
+
+QString AppSettings::persistentGuiClientId() const { return m_persistentGuiClientId; }
+QString AppSettings::effectiveStationName() const { return m_effectiveStationName; }
+QString AppSettings::automationIdentity() const { return m_automationIdentity; }
+QString AppSettings::automationAgentName() const { return m_automationAgentName; }
+bool AppSettings::guiClientIdentityIsTransient() const { return m_guiClientIdentityTransient; }
+
+bool AppSettings::rotatePersistentGuiClientId(const QString& reason)
+{
+    if (!m_guiClientIdentityInitialized || m_guiClientIdentityTransient) {
+        return false;
+    }
+    m_persistentGuiClientId =
+        QUuid::createUuid().toString(QUuid::WithoutBraces).toUpper();
+    m_effectiveGuiClientId = m_persistentGuiClientId;
+    QJsonObject identityConfig{
+        {QStringLiteral("PersistentId"), m_persistentGuiClientId},
+        {QStringLiteral("MachineBinding"), machineBinding()},
+    };
+    setValue(QString::fromLatin1(kIdentityConfigKey), QString::fromUtf8(
+        QJsonDocument(identityConfig).toJson(QJsonDocument::Compact)));
+    setValue(QStringLiteral("GUIClientID"), m_persistentGuiClientId);
+    save();
+    qWarning().noquote() << "AppSettings: rotated GUI client ID —" << reason;
+    return true;
+}
+
+bool AppSettings::resolveLiveGuiClientIdCollision(const QString& otherStation)
+{
+    if (!m_guiClientIdentityInitialized) {
+        return false;
+    }
+    if (m_guiClientIdentityTransient) {
+        m_effectiveGuiClientId =
+            QUuid::createUuid().toString(QUuid::WithoutBraces).toUpper();
+        qWarning().noquote()
+            << "AppSettings: live client already owns this process-scoped GUI ID;"
+               " selected a collision fallback for station"
+            << otherStation;
+        return true;
+    }
+    return rotatePersistentGuiClientId(
+        QStringLiteral("live duplicate belongs to station %1").arg(otherStation));
+}
+
+void AppSettings::recordPersistentGuiClientIdReply(const QString& clientId)
+{
+    if (m_guiClientIdentityTransient) {
+        return;
+    }
+    const QString normalized = validUuidOrEmpty(clientId);
+    if (normalized.isEmpty() || normalized == m_persistentGuiClientId) {
+        return;
+    }
+    m_persistentGuiClientId = normalized;
+    m_effectiveGuiClientId = normalized;
+    QJsonObject identityConfig{
+        {QStringLiteral("PersistentId"), normalized},
+        {QStringLiteral("MachineBinding"), machineBinding()},
+    };
+    setValue(QString::fromLatin1(kIdentityConfigKey), QString::fromUtf8(
+        QJsonDocument(identityConfig).toJson(QJsonDocument::Compact)));
+    setValue(QStringLiteral("GUIClientID"), normalized);
+    save();
 }
 
 // ─── Migration from QSettings ─────────────────────────────────────────────────

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -3,6 +3,9 @@
 #include <QString>
 #include <QVariant>
 #include <QMap>
+#include <memory>
+
+class QLockFile;
 
 namespace AetherSDR {
 
@@ -47,6 +50,20 @@ public:
     // File path for the settings file.
     QString filePath() const { return m_filePath; }
 
+    // GUI-client identity is persistent for ordinary reconnect/session restore,
+    // but must be distinct for concurrently-running processes and automation
+    // worktrees. Call once after load(), before constructing MainWindow.
+    void initializeGuiClientIdentity();
+    QString effectiveGuiClientId() const;
+    QString persistentGuiClientId() const;
+    QString effectiveStationName() const;
+    QString automationIdentity() const;
+    QString automationAgentName() const;
+    bool guiClientIdentityIsTransient() const;
+    bool rotatePersistentGuiClientId(const QString& reason);
+    bool resolveLiveGuiClientIdCollision(const QString& otherStation);
+    void recordPersistentGuiClientIdReply(const QString& clientId);
+
     // Clear all loaded settings from memory without writing anything back out.
     void reset();
 
@@ -55,7 +72,7 @@ public:
 
 private:
     AppSettings();
-    ~AppSettings() = default;
+    ~AppSettings();
     AppSettings(const AppSettings&) = delete;
     AppSettings& operator=(const AppSettings&) = delete;
 
@@ -68,6 +85,14 @@ private:
     QMap<QString, QString> m_stationSettings;   // per-station key=value
     QString m_stationName{"AetherSDR"};
     int m_loadedCount{0};  // settings count at load time (guard against truncated saves)
+    std::unique_ptr<QLockFile> m_guiClientLock;
+    QString m_persistentGuiClientId;
+    QString m_effectiveGuiClientId;
+    QString m_effectiveStationName;
+    QString m_automationIdentity;
+    QString m_automationAgentName;
+    bool m_guiClientIdentityInitialized{false};
+    bool m_guiClientIdentityTransient{false};
 };
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1852,9 +1852,12 @@ bool AutomationServer::start(const QString& serverName)
     // MultiFlex clients. Apply now if already connected; on every (re)connect —
     // which re-runs the handshake's own `client station <user>` send — re-apply
     // shortly after so the agent name is what sticks.
-    m_agentStation = qEnvironmentVariableIsSet("AETHER_AUTOMATION_STATION")
-                         ? qEnvironmentVariable("AETHER_AUTOMATION_STATION")
-                         : QStringLiteral("Claude");
+    m_agentStation = AppSettings::instance().automationAgentName();
+    if (m_agentStation.isEmpty()) {
+        m_agentStation = qEnvironmentVariableIsSet("AETHER_AUTOMATION_STATION")
+                             ? qEnvironmentVariable("AETHER_AUTOMATION_STATION")
+                             : QStringLiteral("Automation");
+    }
     if (m_radioModel) {
         connect(m_radioModel, &RadioModel::connectionStateChanged, this,
                 [this](bool connected) {
@@ -3517,6 +3520,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
             clients.append(QJsonObject{
                 {QStringLiteral("handle"),
                  QStringLiteral("0x") + QString::number(it.key(), 16)},
+                {QStringLiteral("clientId"), it.value().clientId},
                 {QStringLiteral("station"), it.value().station},
                 {QStringLiteral("program"), it.value().program},
                 {QStringLiteral("source"), it.value().source},
@@ -3556,6 +3560,10 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
                      infoMap.value(radio->ourClientHandle()).station;
                  return reported.isEmpty() ? radio->ourStationName() : reported;
              }()},
+            {QStringLiteral("guiClientId"),
+             AppSettings::instance().effectiveGuiClientId()},
+            {QStringLiteral("guiClientIdTransient"),
+             AppSettings::instance().guiClientIdentityIsTransient()},
             {QStringLiteral("clients"), clients},
             {QStringLiteral("foreignPanWrites"), foreign},
             {QStringLiteral("evictedHandles"), evicted}};
@@ -6748,6 +6756,11 @@ QJsonObject AutomationServer::doWhoami() const
         {QStringLiteral("socket"), fullServerName()},
         {QStringLiteral("label"), m_label},
         {QStringLiteral("station"), m_agentStation},
+        {QStringLiteral("agentName"), AppSettings::instance().automationAgentName()},
+        {QStringLiteral("automationIdentity"), AppSettings::instance().automationIdentity()},
+        {QStringLiteral("guiClientId"), AppSettings::instance().effectiveGuiClientId()},
+        {QStringLiteral("guiClientIdTransient"),
+         AppSettings::instance().guiClientIdentityIsTransient()},
         {QStringLiteral("txAllowed"), m_txAllowed},
         {QStringLiteral("version"), QCoreApplication::applicationVersion()},
     };

--- a/src/core/GuiClientIdentityPolicy.h
+++ b/src/core/GuiClientIdentityPolicy.h
@@ -19,8 +19,11 @@ inline QString protocolSafeStation(QString value)
     value = value.trimmed();
     value.replace(QRegularExpression(QStringLiteral("[\\s|=\\x00-\\x1F\\x7F]+")),
                   QStringLiteral("-"));
+    // Truncate before the trailing-dash strip so a cut that lands right after a
+    // dash cannot leave the result ending in one.
+    value = value.left(48);
     value.remove(QRegularExpression(QStringLiteral("^-+|-+$")));
-    return value.left(48);
+    return value;
 }
 
 inline bool shouldSelectDistinctId(bool transientIdentity,

--- a/src/core/GuiClientIdentityPolicy.h
+++ b/src/core/GuiClientIdentityPolicy.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QString>
+#include <QUuid>
+
+namespace AetherSDR::GuiClientIdentityPolicy {
+
+inline QString automationClientId(const QString& identity)
+{
+    static const QUuid kNamespace(
+        QStringLiteral("8bc98e90-4e5a-5e62-8a95-9b975276a987"));
+    return QUuid::createUuidV5(kNamespace, identity.toUtf8())
+        .toString(QUuid::WithoutBraces).toUpper();
+}
+
+inline QString protocolSafeStation(QString value)
+{
+    value = value.trimmed();
+    value.replace(QRegularExpression(QStringLiteral("[\\s|=\\x00-\\x1F\\x7F]+")),
+                  QStringLiteral("-"));
+    value.remove(QRegularExpression(QStringLiteral("^-+|-+$")));
+    return value.left(48);
+}
+
+inline bool shouldSelectDistinctId(bool transientIdentity,
+                                   const QString& ourStation,
+                                   const QString& otherStation,
+                                   bool knownPredecessor)
+{
+    if (transientIdentity) {
+        return true;
+    }
+    return !knownPredecessor || otherStation.isEmpty()
+           || otherStation.compare(ourStation, Qt::CaseInsensitive) != 0;
+}
+
+} // namespace AetherSDR::GuiClientIdentityPolicy

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -363,6 +363,7 @@ int main(int argc, char* argv[])
     // to LogManager. SHistorySoftEdgeDb migration moved here for the same
     // reason.
     AetherSDR::AppSettings::instance().load();
+    AetherSDR::AppSettings::instance().initializeGuiClientIdentity();
     {
         auto& s = AetherSDR::AppSettings::instance();
         if (s.contains("SHistorySoftEdgeDb")) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,4 +1,5 @@
 #include "RadioModel.h"
+#include "core/GuiClientIdentityPolicy.h"
 #include "AntennaAliasStore.h"
 #include "BandSettings.h"
 #include "core/CommandParser.h"
@@ -2616,22 +2617,20 @@ void RadioModel::onConnected()
 
     // Register as GUI client FIRST — required before subscriptions,
     // especially on WAN/SmartLink where the radio is stricter.
-    const QString clientId = AppSettings::instance().value("GUIClientID").toString();
-
-    disconnectPendingClientsThen([this, clientId] {
+    disconnectPendingClientsThen([this] {
         if (m_wanConn) {
             // On WAN: wait for client ip response before sending client gui.
             // The radio needs time after wan validate to accept GUI registration.
             // multiFLEX conflict on WAN is caught pre-connection via licensedClients.
-            sendCmd("client ip", [this, clientId](int, const QString& body) {
+            sendCmd("client ip", [this](int, const QString& body) {
                 qCDebug(lcProtocol) << "RadioModel: client ip ->" << body.trimmed();
-                registerAsGuiClient(clientId);
+                registerAsGuiClient(AppSettings::instance().effectiveGuiClientId());
             });
         } else {
             // On LAN: peek at radio/client status before sending client gui so we
             // can detect a multiFLEX conflict regardless of what discovery provided.
-            peekForMultiFlexConflictThen([this, clientId] {
-                registerAsGuiClient(clientId);
+            peekForMultiFlexConflictThen([this] {
+                registerAsGuiClient(AppSettings::instance().effectiveGuiClientId());
             });
         }
     });
@@ -2804,6 +2803,7 @@ void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation
     // 400 ms is enough for the radio's status burst to arrive on a LAN path.
     sendCmd("sub radio all", [this](int, const QString&) {
         sendCmd("sub client all", [this](int, const QString&) {
+            resolveLiveGuiClientIdCollision();
             // Fast path: when multiFLEX is enabled the radio explicitly allows
             // multiple GUI clients, so the conflict check below
             // (!m_multiFlexEnabled && hasOthers) can never fire — there is
@@ -2821,6 +2821,9 @@ void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation
                 return;
             }
             QTimer::singleShot(400, this, [this] {
+                // On the non-fast path, client status may arrive during the
+                // collection window rather than before the subscription reply.
+                resolveLiveGuiClientIdCollision();
                 const quint32 ours2 = clientHandle();
                 bool hasOthers = false;
                 for (auto it = m_clientInfoMap.cbegin(); it != m_clientInfoMap.cend(); ++it) {
@@ -2854,6 +2857,44 @@ void RadioModel::peekForMultiFlexConflictThen(std::function<void()> continuation
             });
         });
     });
+}
+
+void RadioModel::resolveLiveGuiClientIdCollision()
+{
+    AppSettings& settings = AppSettings::instance();
+    const QString effectiveId = settings.effectiveGuiClientId();
+    if (effectiveId.isEmpty()) {
+        return;
+    }
+    for (auto it = m_clientInfoMap.cbegin(); it != m_clientInfoMap.cend(); ++it) {
+        if (it.key() == clientHandle()
+            || it->clientId.compare(effectiveId, Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+
+        const QString otherStation = it->station;
+        const bool selectDistinct = GuiClientIdentityPolicy::shouldSelectDistinctId(
+            settings.guiClientIdentityIsTransient(), settings.effectiveStationName(),
+            otherStation, it.key() == m_staleSessionOwnHandle);
+        // Only a handle captured from THIS process's previous connection may
+        // be reclaimed. A same-named station from a fresh process can be a
+        // cloned remote profile and must not be evicted by assumption.
+        if (!selectDistinct) {
+            qCInfo(lcProtocol).noquote()
+                << "RadioModel: reclaiming same-station GUI session"
+                << QStringLiteral("handle=%1").arg(hexId(it.key()))
+                << QStringLiteral("station=%1").arg(otherStation);
+            return;
+        }
+        if (settings.resolveLiveGuiClientIdCollision(otherStation)) {
+            qCWarning(lcProtocol).noquote()
+                << "RadioModel: avoided live duplicate GUI client ID"
+                << QStringLiteral("handle=%1").arg(hexId(it.key()))
+                << QStringLiteral("station=%1").arg(otherStation)
+                << QStringLiteral("new_id=%1").arg(settings.effectiveGuiClientId());
+        }
+        return;
+    }
 }
 
 void RadioModel::resolveMultiFlexConflict(quint32 handle)
@@ -2913,6 +2954,23 @@ void RadioModel::handleForcedClientDisconnect()
     }
 }
 
+void RadioModel::handleDuplicateClientIdDisconnect()
+{
+    if (m_forcedDisconnectInProgress) {
+        return;
+    }
+    m_forcedDisconnectInProgress = true;
+    m_intentionalDisconnect = true;
+    m_reconnectTimer.stop();
+    AppSettings::instance().resolveLiveGuiClientIdCollision(
+        QStringLiteral("radio-reported duplicate"));
+    qCWarning(lcProtocol)
+        << "RadioModel: radio disconnected this session because another GUI client used the same ID";
+    emit connectionError(tr("Connection stopped: another AetherSDR client was using this "
+                            "station identity. A distinct identity has been selected; reconnect "
+                            "to continue."));
+}
+
 void RadioModel::registerAsGuiClient(const QString& clientId)
 {
     // Match FlexLib connect-sequence ordering (Radio.cs:2230-2247):
@@ -2931,12 +2989,12 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
         armClientConnectionNoticeSuppression();
         if (code != 0) {
             qCWarning(lcProtocol) << "RadioModel: client gui failed, code" << Qt::hex << code;
-        } else if (!body.trimmed().isEmpty()) {
+        } else if (!body.trimmed().isEmpty()
+                   && !AppSettings::instance().guiClientIdentityIsTransient()) {
             // Save our UUID for session persistence across restarts.
             // The radio restores slices/frequencies for a known UUID.
             auto& s = AppSettings::instance();
-            s.setValue("GUIClientID", body.trimmed());
-            s.save();
+            s.recordPersistentGuiClientIdReply(body.trimmed());
             qCDebug(lcProtocol) << "RadioModel: saved GUIClientID:" << body.trimmed();
         }
 
@@ -4611,7 +4669,7 @@ quint32 RadioModel::ourClientHandle() const { return clientHandle(); }
 
 QString RadioModel::ourStationName() const
 {
-    QString station = AppSettings::instance().value("StationName", "").toString();
+    QString station = AppSettings::instance().effectiveStationName();
     if (station.isEmpty()) {
         station = QSysInfo::machineHostName();
     }
@@ -5031,8 +5089,13 @@ void RadioModel::onStatusReceived(const QString& object,
             QString action = cm.captured(2);  // "disconnected" or empty
 
             if (action == "disconnected") {
-                if (handle == clientHandle() && statusFlagSet(kvs, QStringLiteral("forced")))
-                    handleForcedClientDisconnect();
+                if (handle == clientHandle()) {
+                    if (statusFlagSet(kvs, QStringLiteral("duplicate_client_id"))) {
+                        handleDuplicateClientIdDisconnect();
+                    } else if (statusFlagSet(kvs, QStringLiteral("forced"))) {
+                        handleForcedClientDisconnect();
+                    }
+                }
                 m_clientStations.remove(handle);
                 m_clientInfoMap.remove(handle);
                 m_announcedClientConnections.remove(handle);
@@ -5067,6 +5130,7 @@ void RadioModel::onStatusReceived(const QString& object,
                 bool ptt = kvs.value("local_ptt", "0") == "1";
                 m_clientStations[handle] = station;
                 ClientInfo client;
+                client.clientId = kvs.value(QStringLiteral("client_id")).trimmed();
                 client.station = station;
                 client.program = program;
                 client.source = source;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2936,6 +2936,18 @@ void RadioModel::handleForcedClientDisconnect()
     qCWarning(lcProtocol) << "RadioModel: this GUI client was force-disconnected by another client";
     emit forcedDisconnectRequested();
 
+    closeConnectionForTerminalDisconnect();
+}
+
+// Tear down the transport for a radio-initiated terminal disconnect (forced or
+// duplicate-client-id). The radio evicts our GUI-client registration but does
+// not guarantee closing the raw TCP/TLS socket — FlexLib fires an event and
+// leaves the actual disconnect to the client — so we must close it ourselves,
+// or the model is stranded in a half-open "connected" state with dangling
+// streams. Callers set m_intentionalDisconnect first so this does not trip the
+// auto-reconnect loop.
+void RadioModel::closeConnectionForTerminalDisconnect()
+{
     if (m_wanConn) {
         m_wanConn->disconnectFromRadio();
         return;
@@ -2969,6 +2981,10 @@ void RadioModel::handleDuplicateClientIdDisconnect()
     emit connectionError(tr("Connection stopped: another AetherSDR client was using this "
                             "station identity. A distinct identity has been selected; reconnect "
                             "to continue."));
+    // Close the socket ourselves — the radio does not guarantee a TCP close on
+    // a duplicate-id eviction, and the error above tells the operator to
+    // reconnect, which must start from a fully torn-down connection.
+    closeConnectionForTerminalDisconnect();
 }
 
 void RadioModel::registerAsGuiClient(const QString& clientId)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -281,6 +281,7 @@ public:
     bool sliceMayBelongToUs(int sliceId) const;
 
     struct ClientInfo {
+        QString clientId;
         QString station;
         QString program;
         QString source;
@@ -652,6 +653,8 @@ private:
     // sending client gui. Calls continuation() if no conflict is found.
     void peekForMultiFlexConflictThen(std::function<void()> continuation);
     void handleForcedClientDisconnect();
+    void handleDuplicateClientIdDisconnect();
+    void resolveLiveGuiClientIdCollision();
     void applyKnownGuiClients(const QStringList& handles,
                               const QStringList& programs,
                               const QStringList& stations,

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -654,6 +654,9 @@ private:
     void peekForMultiFlexConflictThen(std::function<void()> continuation);
     void handleForcedClientDisconnect();
     void handleDuplicateClientIdDisconnect();
+    // Shared transport teardown for a radio-initiated terminal disconnect
+    // (forced or duplicate-client-id); callers set m_intentionalDisconnect first.
+    void closeConnectionForTerminalDisconnect();
     void resolveLiveGuiClientIdCollision();
     void applyKnownGuiClients(const QStringList& handles,
                               const QStringList& programs,

--- a/tests/gui_client_identity_policy_test.cpp
+++ b/tests/gui_client_identity_policy_test.cpp
@@ -1,0 +1,62 @@
+#include "core/GuiClientIdentityPolicy.h"
+
+#include <cstdio>
+#include <QLockFile>
+#include <QTemporaryDir>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    const QString a1 = GuiClientIdentityPolicy::automationClientId("worktree-a");
+    const QString a2 = GuiClientIdentityPolicy::automationClientId("worktree-a");
+    const QString b = GuiClientIdentityPolicy::automationClientId("worktree-b");
+    check(a1 == a2, "automation identity is stable across launches");
+    check(a1 != b, "different worktrees receive different GUI IDs");
+    check(!QUuid(a1).isNull(), "derived automation identity is a valid UUID");
+
+    check(GuiClientIdentityPolicy::protocolSafeStation(" Codex / GPT-5.6 ")
+              == QStringLiteral("Codex-/-GPT-5.6"),
+          "agent name is safe for the unquoted station protocol field");
+    check(GuiClientIdentityPolicy::protocolSafeStation(QString(80, 'x')).size() <= 48,
+          "station name is bounded");
+
+    check(!GuiClientIdentityPolicy::shouldSelectDistinctId(
+              false, QStringLiteral("Desk"), QStringLiteral("desk"), true),
+          "known same-station persistent predecessor is reclaimed");
+    check(GuiClientIdentityPolicy::shouldSelectDistinctId(
+              false, QStringLiteral("Desk"), QStringLiteral("Laptop"), true),
+          "different-station persistent collision rotates");
+    check(GuiClientIdentityPolicy::shouldSelectDistinctId(
+              false, QStringLiteral("Desk"), QStringLiteral("Desk"), false),
+          "same-named unproven remote session rotates");
+    check(GuiClientIdentityPolicy::shouldSelectDistinctId(
+              true, QStringLiteral("Codex"), QStringLiteral("Codex"), true),
+          "process-scoped collision always selects a distinct ID");
+
+    QTemporaryDir temp;
+    QLockFile first(temp.filePath(QStringLiteral("gui-client.lock")));
+    QLockFile second(temp.filePath(QStringLiteral("gui-client.lock")));
+    first.setStaleLockTime(0);
+    second.setStaleLockTime(0);
+    check(temp.isValid() && first.tryLock(0),
+          "first local process claims the persistent identity lock");
+    check(!second.tryLock(0),
+          "second local process cannot claim the persistent identity lock");
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4166 by giving every concurrently running AetherSDR client a collision-safe Flex GUI client identity and by treating a radio-reported duplicate GUI ID as a terminal connection event instead of feeding it into the ordinary auto-reconnect loop.

This supports all three collision cases discussed in the issue:

- two normal AetherSDR processes on the same machine;
- a copied settings profile used from another machine or a remote client whose identity cannot be proven to be our stale predecessor;
- two or more automation engines/worktrees running concurrently on one development host.

The change is intentionally limited to client identity selection and duplicate-ID disconnect handling. It does not change DAX allocation, TCP client handles, slice ownership, UDP stream routing, or the normal connection command ordering.

Credits: This PR was co-authored with @wa2n-code who did the initial discovery, analysis, captures and root cause provided in #4166.  
 
> [!NOTE]
> This work was developed against #4177 because both changes touch the automation bridge. After #4177 merged, this branch was rebased onto merge commit `680d5216`; the PR now contains only the signed fix commit `f2dfc19a` on top of current `main`.

## Investigation and root cause

The supplied connection guide and Flex protocol reference were useful for separating the identifiers involved in a Multi-Flex session. I traced AetherSDR's complete registration path, client-status parsing, reconnect policy, and existing ownership filtering, then compared that against the issue logs and earlier Multi-Flex work.

The evidence points specifically to the persistent GUI client UUID:

1. Both AetherSDR instances sent the same GUI client UUID during `client gui` registration.
2. The radio explicitly reported `duplicate_client_id=1` when the second AetherSDR registered.
3. The two TCP client handles were different, so this was not a shared connection handle.
4. DAX identifiers were also distinct and are allocated after client registration, so they could not explain the connection eviction.
5. AetherSDR only classified `forced=1` client removal as intentional. The duplicate-ID status arrived with `forced=0`, so the displaced client entered its normal three-second reconnect path.
6. That reconnect reused the same persistent GUI UUID, displaced the other AetherSDR, and allowed the two applications to alternate indefinitely.

This also explains why AetherSDR generally coexists with SmartSDR and other Multi-Flex clients: those applications use a different GUI client UUID, while two AetherSDR installations or processes commonly inherited the same persisted `GUIClientID`.

The existing slice, panadapter, and VITA-49 `client_handle` ownership filters remain correct and are not modified by this fix.

## Identity policy

### Normal desktop clients

- Preserve a stable persistent GUI UUID for normal single-instance use and radio-side session restore.
- Record a machine binding alongside the persistent UUID. If a settings file is copied to another machine, rotate the UUID instead of impersonating the original installation.
- Claim the local settings profile with `QLockFile`. A second process using the same profile receives a process-scoped transient UUID and cannot overwrite the user's persistent ID.

### Automation clients

- Derive a deterministic UUIDv5 from `AETHER_AUTOMATION_IDENTITY`.
- Fall back to the automation socket, label, and finally PID when no explicit identity is supplied.
- Keep automation identities transient so they never overwrite the desktop user's persistent GUI ID.
- Add `AETHER_AUTOMATION_AGENT_NAME` for the human-readable station label. This replaces the misleading hard-coded `Claude` default and allows values such as `Codex-GPT-5.6`.

Example for parallel worktrees:

```bash
AETHER_AUTOMATION=1 \
AETHER_AUTOMATION_IDENTITY=issue-4166-worktree \
AETHER_AUTOMATION_AGENT_NAME=Codex-GPT-5.6 \
AETHER_AUTOMATION_SOCKET=aethersdr-4166 \
./build/AetherSDR.app/Contents/MacOS/AetherSDR
```

### Live and remote collisions

Before sending `client gui`, AetherSDR examines the subscribed client roster:

- a known predecessor handle from this same connection attempt, with the expected station, may be reclaimed;
- a foreign or otherwise unproven client using the candidate UUID is never displaced;
- transient clients choose a distinct fallback UUID;
- persistent desktop clients rotate and persist a replacement UUID.

If the radio nevertheless reports `duplicate_client_id=1` after registration, AetherSDR prepares a replacement identity, marks the disconnect intentional, and stops the reconnect timer. This prevents the alternating eviction loop. The user is told to reconnect once; ordinary pre-registration collisions remain silent because they are resolved before disruption occurs.

## Implementation notes

- `AppSettings` owns persistent, transient, automation, and machine-binding identity lifecycle.
- `GuiClientIdentityPolicy` contains the deterministic UUID and collision-decision rules as a small GUI-free core policy.
- `RadioModel` records each roster entry's `client_id`, resolves collisions before registration, and handles `duplicate_client_id=1` independently of the radio's `forced` flag.
- `whoami` and `get clients` expose the effective GUI ID, transient state, automation identity, agent name, and per-client GUI IDs for future diagnosis.
- The automation bridge documentation includes the parallel-worktree environment variables.
- PR #4177's generic probe already passes arbitrary bridge verbs, including `whoami`, so the rebased version does not restore the older hard-coded probe command list.

## Validation

### Live FLEX radio tests

The radio was checked for other active automation use before testing. No transmit permission was enabled or exercised.

| Scenario | Client A | Client B | Result |
|---|---|---|---|
| Distinct automation identities | `issue-4166-a` / `Codex-A` | `issue-4166-b` / `Codex-B` | Both remained connected beyond the previous reconnect interval; distinct handles, UUIDs, and slices; no evictions |
| Deliberate duplicate identity | UUID `BBCB485E-386B-5A09-9E2D-3A5EFC0A1C98` | Same requested UUID | Client B detected the live collision before registration and selected `430084B9-011B-453E-99E8-DC2F96FC65FF`; both remained connected; no evictions |

For the distinct case, the derived UUIDs were:

- `issue-4166-a`: `1A3D37CB-9ABA-5840-BF8B-7F394B861545`
- `issue-4166-b`: `4EA02D65-879F-5630-864E-CB4DBCB7AE3C`

The bridge reported `evictedHandles: []` in both scenarios. Both applications were intentionally disconnected and stopped after testing.

### Automated checks after rebasing onto current `main` + #4177

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure -j8` — **80/80 passed**
  - includes `gui_client_identity_policy_test`
  - includes #4177's `aether_mcp_field_mapping`
  - includes `radio_status_ownership_test` and `radio_discovery_test`
- `python3 tools/check_engine_boundary.py --strict` — **0 blockers**
- `git diff --check` — passed
- signed commit verified with `git log --show-signature -1`

## Risk assessment

The highest-risk area is preserving radio-side GUI session restoration while preventing an unrelated client from being mistaken for a stale local session. The policy therefore reclaims an existing UUID only when both the predecessor handle and station evidence match the current connection attempt. Ambiguous ownership rotates the candidate identity instead of disconnecting another client.

No radio command ordering, subscription ordering, slice-0 RX setup, DAX allocation, or transmit behavior is changed.

## Automation follow-up

The expanded `whoami` and `get clients` output provides the identity observability needed for this regression. A useful future bridge addition would be a purpose-built `assert clients-distinct` verb that checks GUI IDs, handles, slice ownership, and eviction history across concurrent engines in one response.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
