### PR TITLE
feat(automation): gen_bridge_docs — verb docs drift check (#4174 Phase 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2330,6 +2330,11 @@ if(PYTHON3_EXECUTABLE)
     add_test(NAME aether_mcp_field_mapping
              COMMAND ${PYTHON3_EXECUTABLE}
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/test_aether_mcp.py)
+    # Bridge docs must stay in sync with the verb registry (#4174 Phase 3):
+    # fail CI if the generated verb table drifts or a detail heading is dup'd.
+    add_test(NAME bridge_docs_check
+             COMMAND ${PYTHON3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_bridge_docs.py --check)
 endif()
 
 add_executable(gui_client_identity_policy_test

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -538,21 +538,6 @@ re-`dumpTree` (or re-read) after any sort, filter, or insert.
 > Adding a new keying control? Call `markTxKeying(theButton)` — see
 > `src/core/TxKeyingMarker.h`.
 
-### `shortcut`
-Invoke a registered `ShortcutManager` action by id. This exercises the same
-handler a user-bound key would call, without requiring the test profile to bind
-an actual key sequence. It is useful for controller-style actions that may ship
-without a default keyboard shortcut.
-
-```json
-→ {"cmd":"shortcut","target":"center_lock_toggle"}
-← {"ok":true,"shortcut":"center_lock_toggle","fired":true}
-```
-
-Handlers may no-op when their normal app-side preconditions are not met; assert
-effects with `get`/`dumpTree` after firing, the same way a MIDI/controller
-test should.
-
 ### `get`
 Read live model state — assert on truth without a screenshot. Requires a radio
 model (present once the app is running; fields are empty until a radio
@@ -2060,3 +2045,62 @@ lands.
   scoped-targets duplicates, skips disabled + keying controls, and prints a
   findings table with timing. The reusable form of the QA sweep.
 - Log category: `lcAutomation` (`aether.automation`) — toggle in Help → Support.
+
+---
+
+## Verb registry (auto-generated)
+
+The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
+
+<!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 45 verbs. -->
+
+| Verb | Aliases | Description |
+|---|---|---|
+| `ping` | — | liveness check → app + version + whether a token is required |
+| `verbs` | — | list every bridge verb with aliases and help (this table) |
+| `dumpTree` | — | serialize the full widget tree as JSON |
+| `floors` | — | per-pan measured noise + display floor (dBm) |
+| `grab` | — | grab <target\|pan\|pan-visible [index]> [path] — PNG capture |
+| `close` | — | close <target> — close the target's top-level window |
+| `hover` | — | hover <target> [leave] — synthetic mouse hover |
+| `tooltip` | — | tooltip <target> [hide\|text…] — force-show a native tooltip |
+| `scrollTo` | `ensureVisible` | scrollTo <target> — scroll a widget into its scroll-area viewport |
+| `drag` | `mouse` | drag <target> <dx> <dy> — synthesize press→move→release |
+| `showMenu` | `openMenu` | showMenu <target> — pop a button's drop-down menu |
+| `contextMenu` | — | contextMenu <target> [x y] — Qt context-menu path |
+| `rightClick` | — | rightClick <target> [x y] — mousePressEvent menu path |
+| `hitTest` | `hittest` | hitTest <target> [x y] — read-only widget-owner probe |
+| `clickAt` | `clickat` | clickAt <x> <y> \| clickAt <target> <x> <y> — TX-guarded coordinate click |
+| `invoke` | — | invoke <target> <action> [value…] — drive a control (TX-guarded) |
+| `get` | — | get <model> [selector] [property] — live model snapshot |
+| `connect` | — | connect <list\|show\|hide\|local\|ip\|wait> [args] |
+| `disconnect` | — | disconnect from the radio |
+| `txtest` | — | txtest <twotone\|off> — TX-gated test signal |
+| `atu` | — | atu <bypass\|start> — antenna tuner (start is TX-gated) |
+| `slice` | — | slice <action> [args] — slice lifecycle/config (see doSlice) |
+| `tune` | — | tune <mhz> — set the active slice frequency |
+| `cwx` | — | cwx <send\|speed\|stop> [args] — CWX keyer (send is TX-gated) |
+| `record` | — | record <start\|stop\|status\|path\|dir> [args] |
+| `testtone` | — | testtone <on\|off> [freqHz levelDb] |
+| `pan` | — | pan <create\|add\|remove\|close\|center> [value] |
+| `layout` | — | layout <rearrange <id>\|get> — splitter layout exerciser |
+| `scale` | — | scale [pct] — report/persist the UI scale factor |
+| `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |
+| `dss` | — | dss <snapshot\|reset\|inject\|scrollback\|live> [pan] [args] |
+| `streams` | — | streams [radio\|reset] — stream diagnostics |
+| `tci` | — | tci start\|status\|stop — in-process TCI client simulator (JSON form only) |
+| `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
+| `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |
+| `key` | — | key <ptt on\|off \| mox> — semantic keying (TX-gated) |
+| `station` | — | station <name> — set the GUI-client station name |
+| `resize` | — | resize <w> <h> [target] — resize a window |
+| `window` | — | window <maximize\|restore\|minimize\|fullscreen> [target] |
+| `shortcut` | — | shortcut <id> — fire a ShortcutManager/MIDI action (TX-gated) |
+| `menu` | — | menu list \| open <name> — menu-bar menus |
+| `whoami` | — | bridge instance info: pid, socket, label, station, txAllowed |
+| `log` | — | log <categories\|get\|set\|reset\|tail\|subscribe\|unsubscribe> [args] |
+| `mark` | — | mark <text> — timestamped annotation in the log ring |
+| `qrz` | — | qrz <status\|cached\|lookup\|spottext> [args] |
+
+<!-- END GENERATED VERB TABLE -->

--- a/tools/gen_bridge_docs.py
+++ b/tools/gen_bridge_docs.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Keep docs/automation-bridge.md in sync with the AutomationServer verb registry
+(#4174 Phase 3). Two jobs, both cheap and app-free:
+
+  1. Auto-generated verb table — the canonical {verb, aliases, help} list is
+     derived from the `add(...)` registrations in AutomationServer.cpp and
+     written into docs between the GENERATED markers. This kills the recurring
+     "a verb landed but never made it into the docs table" drift (the banner
+     and error strings are already registry-derived in-code; this extends the
+     same discipline to the docs).
+
+  2. Duplicate-heading lint — flags two `###`/`####` sections with the same
+     title, the silent-bad-merge class that slipped two `### rightClick`
+     sections past review during the 2026-07 cycle.
+
+Usage:
+    tools/gen_bridge_docs.py           # rewrite the generated block in place
+    tools/gen_bridge_docs.py --check   # CI: exit 1 if the block is stale or
+                                       #     a duplicate heading exists
+
+No app, no Qt, no build required — pure static parse.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+CPP = os.path.join(REPO, "src", "core", "AutomationServer.cpp")
+DOCS = os.path.join(REPO, "docs", "automation-bridge.md")
+
+BEGIN = "<!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->"
+END = "<!-- END GENERATED VERB TABLE -->"
+
+# add("name", {aliases}, "help …",  — the three fields may wrap across lines,
+# and aliases may be bare "x" or QStringLiteral("x"); either way the alias
+# spelling is the quoted string inside the {…} block. DOTALL so the help can
+# sit on the line after the aliases (7 verbs do this).
+_ADD_RE = re.compile(
+    r'\badd\(\s*"(?P<name>[^"]+)"\s*,\s*'
+    r'\{(?P<aliases>[^}]*)\}\s*,\s*'
+    r'"(?P<help>(?:[^"\\]|\\.)*)"',
+    re.DOTALL,
+)
+_ALIAS_RE = re.compile(r'"([^"]+)"')
+# Loose "there's a registration here" probe: just `add("name"`, independent of
+# the full-shape match above. Used to cross-check that the strict parser didn't
+# silently skip a registration formatted in an unexpected way.
+_NAME_RE = re.compile(r'\badd\(\s*"([^"]+)"')
+
+
+def _unescape(s):
+    # Turn C string escapes into display text WITHOUT touching multi-byte UTF-8
+    # (unicode_escape would corrupt the → arrows in the help strings).
+    return (s.replace('\\"', '"').replace("\\n", " ")
+             .replace("\\t", " ").replace("\\\\", "\\").strip())
+
+
+def extract_registry(cpp_path):
+    """Return [(name, [aliases], help), …] in registration order.
+
+    Raises if a registration exists (an `add("name"` site) that the strict
+    parser didn't capture — otherwise a future oddly-formatted `add(...)` would
+    vanish from the docs *silently*, defeating the whole point of the drift
+    check (the generated table would just be missing a verb, and `--check`
+    would still pass against that wrong table).
+    """
+    with open(cpp_path, encoding="utf-8") as f:
+        src = f.read()
+    verbs = []
+    for m in _ADD_RE.finditer(src):
+        aliases = _ALIAS_RE.findall(m.group("aliases"))
+        verbs.append((m.group("name"), aliases, _unescape(m.group("help"))))
+
+    parsed = {name for name, _, _ in verbs}
+    sites = set(_NAME_RE.findall(src))
+    missed = sites - parsed
+    if missed:
+        raise ValueError(
+            f"gen_bridge_docs: {len(missed)} registration(s) matched "
+            f"add(\"name\" but not the full add(name, {{aliases}}, \"help\", …) "
+            f"shape — {sorted(missed)}. They'd silently drop from the docs; "
+            "fix the parser or the registration formatting.")
+    return verbs
+
+
+def render_table(verbs):
+    rows = ["| Verb | Aliases | Description |", "|---|---|---|"]
+    for name, aliases, help_text in verbs:
+        al = ", ".join(f"`{a}`" for a in aliases) if aliases else "—"
+        # Escape pipes so a help string can't break the table.
+        help_cell = help_text.replace("|", "\\|").strip()
+        rows.append(f"| `{name}` | {al} | {help_cell} |")
+    return "\n".join(rows)
+
+
+def generated_block(verbs):
+    return (f"{BEGIN}\n"
+            f"<!-- Do not edit by hand — run tools/gen_bridge_docs.py. "
+            f"{len(verbs)} verbs. -->\n\n"
+            f"{render_table(verbs)}\n\n"
+            f"{END}")
+
+
+def find_duplicate_headings(md_text):
+    # Track fenced code blocks so a ``` … ### foo … ``` example isn't mistaken
+    # for a real heading — otherwise this lint could block CI on doc content
+    # it was never meant to police.
+    seen, dups = {}, []
+    in_fence = False
+    for ln in md_text.splitlines():
+        if ln.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = re.match(r'^(#{3,4})\s+(.*\S)\s*$', ln)
+        if not m:
+            continue
+        title = m.group(2).strip()
+        if title in seen:
+            dups.append(title)
+        seen[title] = seen.get(title, 0) + 1
+    return dups
+
+
+def splice(md_text, block):
+    """Replace the marker block, or append a new section if absent."""
+    if BEGIN in md_text and END in md_text:
+        pre = md_text[:md_text.index(BEGIN)]
+        post = md_text[md_text.index(END) + len(END):]
+        return pre + block + post
+    # First run: append a new appendix section before the trailing newline.
+    section = ("\n---\n\n"
+               "## Verb registry (auto-generated)\n\n"
+               "The complete registry, generated from the `add(...)` table in "
+               "`AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails "
+               "if this drifts from the code.\n\n"
+               + block + "\n")
+    return md_text.rstrip("\n") + "\n" + section
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Sync the bridge verb docs table.")
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the docs block is stale or a heading is duplicated")
+    args = ap.parse_args()
+
+    verbs = extract_registry(CPP)
+    if not verbs:
+        print(f"error: no verbs parsed from {CPP}", file=sys.stderr)
+        return 2
+
+    with open(DOCS, encoding="utf-8") as f:
+        md = f.read()
+
+    want = splice(md, generated_block(verbs))
+    # Lint the on-disk doc (`md`), not the regenerated `want`: the generated
+    # block is a table with no ###/#### headings, so scanning either is
+    # equivalent — but linting `md` keeps "does the committed doc have dups?"
+    # honest regardless of what the generator would produce.
+    dups = find_duplicate_headings(md)
+
+    if args.check:
+        problems = []
+        if want != md:
+            problems.append(
+                f"docs verb table is STALE ({len(verbs)} verbs in the registry) "
+                "— run tools/gen_bridge_docs.py")
+        if dups:
+            problems.append("duplicate detail-section heading(s): "
+                            + ", ".join(sorted(set(dups))))
+        if problems:
+            for p in problems:
+                print("FAIL:", p, file=sys.stderr)
+            return 1
+        print(f"ok: docs verb table matches the registry ({len(verbs)} verbs), "
+              "no duplicate headings")
+        return 0
+
+    if dups:
+        print("warning: duplicate detail-section heading(s): "
+              + ", ".join(sorted(set(dups))), file=sys.stderr)
+    if want != md:
+        with open(DOCS, "w", encoding="utf-8") as f:
+            f.write(want)
+        print(f"updated {os.path.relpath(DOCS, REPO)} ({len(verbs)} verbs)")
+    else:
+        print(f"already up to date ({len(verbs)} verbs)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

#4174 Phase 3, scoped to the piece that's actually worth doing: keep the docs verb table in sync with the registry, and lint the silent-merge duplicate-heading class. **No family-TU split** (a file per verb family isn't worth the proliferation) and **no merge queue** (that re-tests every queued PR — we'd rather rebase as needed); those two Phase-3 bullets are intentionally dropped.

## What's here

- **`tools/gen_bridge_docs.py`** — static-parses the 45 `add(...)` verb registrations in `AutomationServer.cpp` (name / aliases / help; no app, Qt, or build needed) and maintains an auto-generated verb table between markers in `docs/automation-bridge.md`. The banner and unknown-command/model error strings are already registry-derived in-code (Phase 1); this extends the same discipline to the docs, which still drifted.
  - `--check` fails on drift (a verb landed but never made the table) and lints duplicate `###`/`####` detail-section headings (the silent-bad-merge class from #4137's two `### rightClick` sections).
- **Registered as the `bridge_docs_check` ctest**, so CI fails on drift — same pattern as `aether_mcp_field_mapping`.
- **Removed a real pre-existing duplicate `### shortcut` section** the new lint caught (kept the fuller MIDI-path one).

## Verification

- Parser extracts all 45 verbs (arrows/aliases intact).
- `--check` passes clean, and I confirmed it **fails** on both a tampered table and an injected duplicate heading.
- `bridge_docs_check` + `aether_mcp_field_mapping` ctests both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
