### PR TITLE
fix(cwx): harden inline speed modifiers (supersedes #3976)

### DIFF
--- a/src/gui/CwxPanel.cpp
+++ b/src/gui/CwxPanel.cpp
@@ -79,8 +79,9 @@ namespace AetherSDR {
 // CwxBubble's class declaration lives in CwxPanel.h so the test target
 // can dynamic_cast bubbles out of the history container and verify the
 // strikeout state set by ESC abort (#3146).
-CwxBubble::CwxBubble(const QString& text, const QString& time, QWidget* parent)
-    : QWidget(parent), m_text(text), m_time(time)
+CwxBubble::CwxBubble(const QString& displayText, const QString& time,
+                     const QString& rawText, QWidget* parent)
+    : QWidget(parent), m_text(displayText), m_rawText(rawText), m_time(time)
 {
     recalcSize();
 }
@@ -308,8 +309,7 @@ CwxPanel::CwxPanel(CwxModel* model, QWidget* parent)
             // command so the snapshot of m_model->sentIndex() lines up
             // with the chars about to be keyed for this bubble. (#3146)
             const QString raw = m_model->macro(i);
-            appendHistoryBubble(
-                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
+            appendHistoryBubble(raw);
             m_model->sendMacro(i + 1);
         });
     }
@@ -472,11 +472,16 @@ void CwxPanel::buildSetupView()
             this, [this](int v) { if (m_model) m_model->setDelay(v); });
     connect(m_qskBtn, &QPushButton::toggled,
             this, [this](bool on) { if (m_model) m_model->setQsk(on); });
+    // Live-update the model on every change (cheap, in-memory) but persist only
+    // on editingFinished (focus-out / Enter) so sweeping the arrows or wheel
+    // doesn't trigger one full atomic settings-file rewrite per tick. (#272)
     connect(m_speedStepSpin, QOverload<int>::of(&QSpinBox::valueChanged),
             this, [this](int v) {
                 if (m_model) m_model->setSpeedStep(v);
-                writeSpeedStep(v);
             });
+    connect(m_speedStepSpin, &QSpinBox::editingFinished, this, [this]() {
+        if (m_speedStepSpin) writeSpeedStep(m_speedStepSpin->value());
+    });
 
     // Style labels
     for (auto* lbl : m_setupPage->findChildren<QLabel*>())
@@ -513,8 +518,7 @@ void CwxPanel::buildSetupView()
         connect(label, &QPushButton::clicked, this, [this, i]() {
             if (!m_model) return;
             const QString raw = m_model->macro(i);
-            appendHistoryBubble(
-                bubbleTextFor(raw, m_model->speed(), m_model->speedStep()));
+            appendHistoryBubble(raw);
             m_model->sendMacro(i + 1);
         });
 
@@ -554,20 +558,26 @@ void CwxPanel::sendBuffer()
     QString text = m_textEdit->toPlainText().trimmed();
     if (text.isEmpty()) return;
 
-    // Show keyed text (modifiers stripped) so the bubble's char count
-    // matches what the radio's sent=N counter advances against. (#272)
-    appendHistoryBubble(
-        bubbleTextFor(text, m_model->speed(), m_model->speedStep()));
+    // appendHistoryBubble paints the modifier-stripped text (so the bubble's
+    // char count matches the radio's sent=N counter) while retaining the raw
+    // text for Resend. (#272)
+    appendHistoryBubble(text);
     m_textEdit->clear();
 
     m_model->send(text);
 }
 
-void CwxPanel::appendHistoryBubble(const QString& text)
+void CwxPanel::appendHistoryBubble(const QString& rawText)
 {
-    if (!m_historyLayout || text.isEmpty()) return;
+    if (!m_historyLayout || rawText.isEmpty()) return;
+    // Paint the modifier-stripped text (so its length aligns with the radio's
+    // `sent=N` counter) but keep the raw text on the bubble so a later Resend
+    // re-expands the per-word speed modifiers instead of keying at base WPM. (#272)
+    const int baseWpm = m_model ? m_model->speed() : 0;
+    const int step    = m_model ? m_model->speedStep() : 0;
+    const QString displayText = bubbleTextFor(rawText, baseWpm, step);
     const QString ts = QDateTime::currentDateTime().toString("HH:mm:ss");
-    auto* bubble = new CwxBubble(text, ts, m_historyContainer);
+    auto* bubble = new CwxBubble(displayText, ts, rawText, m_historyContainer);
     bubble->installEventFilter(this);
     m_historyLayout->addWidget(bubble);
     // Snapshot the radio's global cumulative sent index at append time —
@@ -575,7 +585,7 @@ void CwxPanel::appendHistoryBubble(const QString& text)
     // progress.  `sent=N` in CWX.cs is global, not per-block. (#3146)
     m_pendingBubble     = bubble;
     m_pendingStartIndex = m_model ? m_model->sentIndex() : -1;
-    m_pendingText       = text;
+    m_pendingText       = displayText;
     QTimer::singleShot(10, this, [this]() {
         if (m_historyScroll) {
             auto* sb = m_historyScroll->verticalScrollBar();
@@ -676,7 +686,9 @@ bool AetherSDR::CwxPanel::eventFilter(QObject* obj, QEvent* event)
             QAction* clearAction  = menu.addAction("Clear History");
             QAction* chosen = menu.exec(ce->globalPos());
             if (chosen == resendAction) {
-                resendText(bubble->text());
+                // Resend the raw text (modifiers intact) so per-word speeds
+                // are preserved rather than re-keyed at base WPM. (#272)
+                resendText(bubble->rawText());
             } else if (chosen == clearAction) {
                 clearHistory();
             }

--- a/src/gui/CwxPanel.h
+++ b/src/gui/CwxPanel.h
@@ -28,9 +28,15 @@ class CwxModel;
 // (#3146).
 class CwxBubble : public QWidget {
 public:
-    CwxBubble(const QString& text, const QString& time, QWidget* parent = nullptr);
+    // `displayText` is the modifier-stripped text that is painted and whose
+    // length the `sent=N` counter advances against; `rawText` is the original
+    // input (with `+`/`-` speed modifiers intact) so Resend can re-expand it
+    // at the correct per-word speeds rather than flattening to base WPM. (#272)
+    CwxBubble(const QString& displayText, const QString& time,
+              const QString& rawText, QWidget* parent = nullptr);
 
     QString text() const { return m_text; }
+    QString rawText() const { return m_rawText; }
     int     sentCount() const { return m_sentCount; }
     bool    isAborted() const { return m_aborted; }
 
@@ -45,6 +51,7 @@ private:
     void recalcSize();
 
     QString m_text;
+    QString m_rawText;
     QString m_time;
     int     m_sentCount{0};
     bool    m_aborted{false};
@@ -96,7 +103,7 @@ private:
     void sendBuffer();
     void resendText(const QString& text);
     void clearHistory();
-    void appendHistoryBubble(const QString& text);
+    void appendHistoryBubble(const QString& rawText);
     void onKeyPress(const QString& text);
 
     CwxModel*       m_model{nullptr};

--- a/src/models/CwxModel.cpp
+++ b/src/models/CwxModel.cpp
@@ -34,7 +34,12 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
     bool    prevWasSpace = true;  // string start acts like after-space
 
     for (int i = 0; i < text.size(); ) {
-        if (text[i] == ' ') {
+        // Whitespace (space/tab/newline) is a word boundary and keys as a word
+        // gap. Macros come from multi-line QTextEdit widgets, so a raw '\n'/'\t'
+        // must not be treated as a word char — it would bleed a modifier across
+        // the line and, un-DEL-encoded, corrupt the cwx send command. Normalize
+        // any whitespace run to a single space. (#272)
+        if (text[i].isSpace()) {
             accumText += ' ';
             prevWasSpace = true;
             ++i;
@@ -51,7 +56,7 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
             }
             // Treat as modifier only when immediately followed by a word char
             // (non-space, non-modifier).  Standalone +/- are prosigns/hyphens.
-            if (j >= text.size() || text[j] == ' ') {
+            if (j >= text.size() || text[j].isSpace()) {
                 plus = minus = 0;
                 j = i;
             }
@@ -59,7 +64,7 @@ CwxModel::expandSpeedModifiers(const QString& text, int baseWpm, int step)
 
         // Scan word body to end-of-word
         const int wordStart = j;
-        while (j < text.size() && text[j] != ' ') ++j;
+        while (j < text.size() && !text[j].isSpace()) ++j;
         const QString wordBody = text.mid(wordStart, j - wordStart);
 
         const bool hasModifier = (plus > 0 || minus > 0);
@@ -109,6 +114,7 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
         const SpeedSegment& seg = segs[i];
         if (seg.wpm != cmdWpm) {
             emit commandReady(QString("cwx wpm %1").arg(seg.wpm));
+            ++m_pendingWpmEchoes;   // swallow this transient's echo (#272)
             cmdWpm = seg.wpm;
         }
         QString encoded = seg.text;
@@ -128,8 +134,10 @@ void CwxModel::emitExpandedSend(const QVector<SpeedSegment>& segs)
             emit transmissionRequested(seg.text, seg.wpm);
     }
     // Restore authoritative WPM if transient changes were made
-    if (cmdWpm != m_speed)
+    if (cmdWpm != m_speed) {
         emit commandReady(QString("cwx wpm %1").arg(m_speed));
+        ++m_pendingWpmEchoes;   // swallow the restore's echo too (#272)
+    }
 }
 
 void CwxModel::send(const QString& text)
@@ -212,6 +220,7 @@ void CwxModel::erase(int numChars)
 void CwxModel::clearBuffer()
 {
     resetDrainWatch();    // abort pending watch + bump epoch (#3949)
+    m_pendingWpmEchoes = 0;   // abort — abandon any pending transient suppression (#272)
     // Re-anchor WPM before clearing so ESC can't leave the radio parked at
     // a transient speed that was in-flight from an expandedSend sequence.
     emit commandReady(QString("cwx wpm %1").arg(m_speed));
@@ -271,6 +280,7 @@ void CwxModel::handleSendReply(int resultCode, const QString& body, int epoch, i
 
 void CwxModel::setSpeed(int wpm)
 {
+    m_pendingWpmEchoes = 0;   // user set the base — abandon transient suppression (#272)
     wpm = clampWpm(wpm);
     if (wpm != m_speed) {
         m_speed = wpm;
@@ -338,7 +348,12 @@ void CwxModel::applyStatus(const QMap<QString, QString>& kvs)
         } else if (key == "wpm") {
             bool ok;
             int v = val.toInt(&ok);
-            if (ok && v != m_speed) {
+            if (m_pendingWpmEchoes > 0) {
+                // Echo of a transient `cwx wpm` we emitted for a per-word speed
+                // modifier — swallow it so it can't clobber the authoritative
+                // base speed or flicker the Speed spinbox. (#272)
+                --m_pendingWpmEchoes;
+            } else if (ok && v != m_speed) {
                 m_speed = v;
                 emit speedChanged(m_speed);
             }

--- a/src/models/CwxModel.h
+++ b/src/models/CwxModel.h
@@ -114,6 +114,12 @@ private:
     int     m_speed{20};
     int     m_delay{5};
     int     m_speedStep{3};
+    // Count of self-originated transient `cwx wpm` commands (per-word speed
+    // modifiers) whose radio echoes must be swallowed in applyStatus so they
+    // can't clobber the authoritative base speed or flicker the Speed spinbox.
+    // Reset on user setSpeed / clearBuffer so a dropped echo can't permanently
+    // suppress a real speed update. (#272)
+    int     m_pendingWpmEchoes{0};
     bool    m_qsk{false};
     bool    m_live{false};
     int     m_sentIndex{-1};

--- a/tests/cwx_panel_test.cpp
+++ b/tests/cwx_panel_test.cpp
@@ -12,6 +12,7 @@
 #include <QStringList>
 #include <QTextEdit>
 #include <cstdio>
+#include <algorithm>
 #include <string>
 
 using namespace AetherSDR;
@@ -178,6 +179,53 @@ void testSetupTurnsLiveOff()
 
 } // namespace
 
+// Resend must re-send the raw (modifier-bearing) text, not the flattened
+// display text, so per-word speed variation survives a Resend. (#272)
+void testResendPreservesSpeedModifiers()
+{
+    Fixture f;
+    QPushButton *send = nullptr, *live = nullptr, *setup = nullptr;
+    QTextEdit* input = nullptr;
+    if (!requireSendWidgets(f, send, live, setup, input))
+        return;
+
+    input->setPlainText("+CQ");
+    send->click();
+
+    auto* bubble = f.panel.pendingBubble();
+    const bool haveBubble = bubble != nullptr;
+    report("modifier send creates an in-flight history bubble", haveBubble);
+    if (!haveBubble)
+        return;
+
+    report("bubble retains raw modifier text for Resend",
+           bubble->rawText() == QLatin1String("+CQ"));
+    report("bubble paints modifier-stripped display text",
+           bubble->text() == QLatin1String("CQ"));
+
+    auto emitsWpmChange = [](const QStringList& cmds) {
+        return std::any_of(cmds.begin(), cmds.end(), [](const QString& c) {
+            return c.startsWith(QLatin1String("cwx wpm"));
+        });
+    };
+
+    report("modifier send emits a per-word cwx wpm speed change",
+           emitsWpmChange(f.commands));
+
+    // Re-sending the stripped display text (the pre-fix Resend bug) drops the
+    // speed change — which is exactly why the raw text is kept on the bubble.
+    f.commands.clear();
+    f.model.send(bubble->text());
+    report("resending stripped text loses the speed change",
+           !emitsWpmChange(f.commands));
+
+    // Re-sending the raw text reproduces the speed change, so Resend is faithful.
+    f.commands.clear();
+    f.model.send(bubble->rawText());
+    report("resending raw text preserves the speed change",
+           emitsWpmChange(f.commands));
+}
+
 int main(int argc, char** argv)
 {
     QApplication app(argc, argv);
@@ -188,6 +236,7 @@ int main(int argc, char** argv)
     testEnterStillSendsWhenLiveOff();
     testSendButtonTurnsLiveOffWithoutDuplicateSend();
     testSetupTurnsLiveOff();
+    testResendPreservesSpeedModifiers();
 
     std::printf("\n%s\n",
                 g_failed == 0

--- a/tests/cwx_speed_modifier_test.cpp
+++ b/tests/cwx_speed_modifier_test.cpp
@@ -126,6 +126,17 @@ int main(int argc, char** argv)
           CwxModel::expandSpeedModifiers("+CQ", 20, 1),
           Segs{{"CQ", 21}});
 
+    // ── whitespace boundaries (#272): macros come from multi-line QTextEdit,
+    // so \n / \t must act as word boundaries (normalized to a space), not word
+    // chars — otherwise a modifier bleeds across the break and a raw \n corrupts
+    // the cwx send command.
+    check("newline is a word boundary — no modifier bleed, normalized to space",
+          CwxModel::expandSpeedModifiers(QStringLiteral("+CQ CQ\nDE W1AW"), 20, 3),
+          Segs{{"CQ", 23}, {" CQ DE W1AW", 20}});
+    check("tab is a word boundary — modifier after tab is recognized",
+          CwxModel::expandSpeedModifiers(QStringLiteral("A\t+B"), 20, 3),
+          Segs{{"A ", 20}, {"B", 23}});
+
     std::printf("\n%s\n",
                 g_failed == 0
                     ? "All tests passed."


### PR DESCRIPTION
## Summary

Applies the review-hardening from **#3976** onto main's current CWX code, and **supersedes #3976**.

The inline speed-modifier feature (`+word`/`-word` per-word WPM, #272) already landed on `main` via **#3979** — but an *earlier* snapshot, before #3976's two review rounds. So `main` currently has the feature **plus** the #3949 drain-watch work, but is **missing** the later hardening that only ever lived on the #3976 branch. #3976 itself is 91 commits behind and re-adds the whole (already-merged) feature, so rather than reconcile a 300-file rebase, this is a small, focused branch off current `main` that ports only the missing fixes.

## What this fixes (all live on `main` today)

- **Multi-line macro corruption** — `expandSpeedModifiers` only treated `' '` as a word boundary. Macros come from multi-line `QTextEdit`s, so a raw `\n`/`\t` became a word-body char: a modifier bled across the line break and the un-DEL-encoded newline corrupted the `cwx send` command. Now any whitespace is a boundary, normalized to a space.
- **Transient `cwx wpm` echo clobber** — a per-word modifier emits a transient `cwx wpm`; its radio echo landed in `applyStatus` and overwrote the authoritative base speed / flickered the Speed spinbox. Now the model suppresses exactly the self-originated echoes via a counter, reset on user `setSpeed`/`clearBuffer` so a dropped echo can't wedge it.
- **Resend dropped the speed variation** — history bubbles stored only the modifier-stripped text, so right-click → Resend re-keyed at base WPM. `CwxBubble` now carries both the painted `displayText` (length still aligns with the radio's `sent=N` counter) and the original `rawText`; Resend re-sends the raw text.
- **Step-spin settings save-storm** — persist the `+`/`-` step on `editingFinished` instead of every `valueChanged`, so sweeping the arrows is one atomic settings write, not ~20.

## Not included (deliberately)

- The constant-hoisting (`kMinWpm`…) and brace cleanups from #3976 — they conflict with main's existing `clampWpm` single-source clamp and are pure style.
- The typed/pasted `send()`-stripping design question (leading `+`/`-` reinterpreted on automation/free-typed input) — left as its own follow-up decision.

## Testing

- New whitespace-boundary cases in `cwx_speed_modifier_test` (newline + tab boundaries) and a Resend round-trip in `cwx_panel_test` (a `+CQ` send emits a `cwx wpm` change; re-sending the stripped text drops it, re-sending the raw text reproduces it).
- Full build clean; **82/82 ctest**.

## Credit

The feature and all of these fixes are **@motoham88 / Tony Casciato**'s work from #272 / #3976 (co-authored on the commit); this PR just relocates the hardening onto main's post-#3979 base. Closes #3976 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
