### PR TITLE
feat(mcp): promote 13 bridge verbs to typed MCP tools (#4188 area 1)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -125,14 +125,21 @@ contributors to self-verify UI changes before requesting review.
      ```
    - **Windows**: use `python` (or `py -3`) instead of `python3`.
 
-**Tools exposed**: `bridge_status` (is the app up? which instance?),
-`dump_tree` (widget tree, with a `filter` arg to prune), `grab_widget`
-(PNG screenshot, returned inline to the model), `invoke` (click/toggle/
-setValue/…), `get_state` (`get` model snapshots), `shortcut`, `get_log`
-(tail app log events — why an action didn't take), `connect` /
-`disconnect` (radio-connection lifecycle), `capture_audio` (RX audio
-tap capture), `floors` (per-pan noise/display floor in dBm), and
-`bridge_command` (raw escape hatch to every other verb below).
+**Tools exposed** (20 typed tools): introspection — `bridge_status`,
+`dump_tree` (with a `filter` arg), `grab_widget` (PNG inline),
+`get_state`, `get_log`, `floors`, `streams`; driving — `invoke`,
+`shortcut`, `tune`, `slice`, `pan`, `record`, `mark`, `window`, `menu`;
+connection — `connect` / `disconnect`; audio — `capture_audio`; and
+`bridge_command` (raw escape hatch for everything else).
+
+The verbs kept behind `bridge_command` on purpose: the low-level widget
+primitives (`close`, `hover`, `tooltip`, `scrollTo`, `drag`, `showMenu`,
+`contextMenu`, `rightClick`, `hitTest`, `clickAt` — `invoke`/`grab`
+cover the common cases), the transmit-keying verbs (`key`, `txtest`,
+`atu`, `cwx`, `testtone`, `txwaterfall` — gated by
+`AETHER_AUTOMATION_ALLOW_TX`, deliberately less convenient), and the
+niche/complex ones (`dss`, `layout`, `scale`, `panmessage`, `tci`,
+`station`, `resize`, `qrz`).
 
 A typical assistant validation loop for a PR:
 `bridge_status` → `dump_tree filter=<your widget>` → `invoke` the

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -128,7 +128,10 @@ contributors to self-verify UI changes before requesting review.
 **Tools exposed**: `bridge_status` (is the app up? which instance?),
 `dump_tree` (widget tree, with a `filter` arg to prune), `grab_widget`
 (PNG screenshot, returned inline to the model), `invoke` (click/toggle/
-setValue/…), `get_state` (`get` model snapshots), `shortcut`, and
+setValue/…), `get_state` (`get` model snapshots), `shortcut`, `get_log`
+(tail app log events — why an action didn't take), `connect` /
+`disconnect` (radio-connection lifecycle), `capture_audio` (RX audio
+tap capture), `floors` (per-pan noise/display floor in dBm), and
 `bridge_command` (raw escape hatch to every other verb below).
 
 A typical assistant validation loop for a PR:

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -536,7 +536,7 @@ def handle_tool(name, args):
             try:
                 timeout = max(timeout, int(args["value"]) / 1000 + 10)
             except (ValueError, TypeError):
-                pass
+                pass  # non-numeric wait value → keep the default timeout
         return text_result(bridge_request(req, timeout=timeout))
 
     if name == "disconnect":
@@ -557,14 +557,8 @@ def handle_tool(name, args):
         return text_result(bridge_request(
             {"cmd": "tune", "value": str(args["mhz"])}))
 
-    if name in ("slice", "record"):
+    if name in ("slice", "record", "pan"):
         req = {"cmd": name, "action": args["action"]}
-        if args.get("value"):
-            req["value"] = str(args["value"])
-        return text_result(bridge_request(req))
-
-    if name == "pan":
-        req = {"cmd": "pan", "action": args["action"]}
         if args.get("value"):
             req["value"] = str(args["value"])
         return text_result(bridge_request(req))

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -315,18 +315,101 @@ TOOLS = [
         "inputSchema": {"type": "object", "properties": {}},
     },
     {
+        "name": "tune",
+        "description": ("Set the active slice frequency, in MHz "
+                        "(e.g. 14.074). Confirm with get_state model=slice."),
+        "inputSchema": {"type": "object", "properties": {
+            "mhz": {"type": "string", "description": "frequency in MHz, e.g. '14.074'"},
+        }, "required": ["mhz"]},
+    },
+    {
+        "name": "slice",
+        "description": (
+            "Slice lifecycle / config. action = add | remove | select | tx | "
+            "diversity | centerlock | txant | rxant | rxsource | fixture | "
+            "clearfixture. `value` carries the action's args (e.g. add '14.2', "
+            "select a slice id). See get_state model=slices to inspect."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string"},
+            "value": {"type": "string", "description": "action arguments"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "pan",
+        "description": (
+            "Panadapter lifecycle. action = create | add | remove | close | "
+            "center; `value` is the action arg (pan id, or a frequency for "
+            "center). See get_state model=pans."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["create", "add", "remove", "close", "center"]},
+            "value": {"type": "string", "description": "pan id / frequency"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "record",
+        "description": (
+            "QSO audio recording. action = start | stop | status | path (get "
+            "the current file) | dir (value = a directory to record into)."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["start", "stop", "status", "path", "dir"]},
+            "value": {"type": "string", "description": "e.g. a directory for 'dir'"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "mark",
+        "description": (
+            "Write a timestamped annotation into the app log ring — bracket "
+            "your actions so a later get_log shows exactly what you did and "
+            "when."),
+        "inputSchema": {"type": "object", "properties": {
+            "text": {"type": "string"},
+        }, "required": ["text"]},
+    },
+    {
+        "name": "window",
+        "description": ("Drive a top-level window's state. Useful for headless "
+                        "render tests (a real size gives the panadapter real "
+                        "x_pixels)."),
+        "inputSchema": {"type": "object", "properties": {
+            "state": {"type": "string",
+                      "enum": ["maximize", "restore", "minimize", "fullscreen"]},
+            "target": {"type": "string", "description": "optional window target"},
+        }, "required": ["state"]},
+    },
+    {
+        "name": "menu",
+        "description": ("Menu-bar menus. action = list (enumerate) | open "
+                        "(pop `name`), so a follow-up dump_tree/grab_widget can "
+                        "see the opened menu."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["list", "open"]},
+            "name": {"type": "string", "description": "menu name, for open"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "streams",
+        "description": ("Stream diagnostics. scope empty = UDP-orphan layer; "
+                        "'radio' = radio-authoritative display objects; "
+                        "'reset' clears counters."),
+        "inputSchema": {"type": "object", "properties": {
+            "scope": {"type": "string", "enum": ["radio", "reset"]},
+        }},
+    },
+    {
         "name": "bridge_command",
         "description": (
-            "Raw escape hatch for every other bridge verb — send any "
-            "JSON request object ({\"cmd\": ...}) straight to the "
-            "bridge and get the raw response. Useful verbs: hover, "
-            "tooltip, hitTest, clickAt, rightClick, contextMenu, "
-            "resize {value:'W H'}, window, menu, actions, connect "
-            "(list/show/local/ip/wait), disconnect, slice, tune, pan, "
-            "layout, scale, dss (deterministic spectrum injection), "
-            "panmessage, audioCapture, record, testtone, whoami. Full "
-            "verb reference: src/core/AutomationServer.h header "
-            "comment."),
+            "Raw escape hatch for the verbs without a dedicated tool — "
+            "send any JSON request object ({\"cmd\": ...}) straight to "
+            "the bridge and get the raw response. Reaches: the low-level "
+            "widget verbs (hover, tooltip, hitTest, clickAt, rightClick, "
+            "contextMenu, close, scrollTo, drag, showMenu), the "
+            "transmit-keying verbs (key, txtest, atu, cwx, testtone, "
+            "txwaterfall — gated by AETHER_AUTOMATION_ALLOW_TX), and the "
+            "niche ones (dss deterministic spectrum injection, resize, "
+            "scale, layout, panmessage, tci, station, qrz). Full verb "
+            "reference: src/core/AutomationServer.h header comment."),
         "inputSchema": {"type": "object", "properties": {
             "request": {"type": "object",
                         "description": "the raw bridge request, e.g. {\"cmd\":\"whoami\"}"},
@@ -469,6 +552,45 @@ def handle_tool(name, args):
 
     if name == "floors":
         return text_result(bridge_request({"cmd": "floors"}))
+
+    if name == "tune":
+        return text_result(bridge_request(
+            {"cmd": "tune", "value": str(args["mhz"])}))
+
+    if name in ("slice", "record"):
+        req = {"cmd": name, "action": args["action"]}
+        if args.get("value"):
+            req["value"] = str(args["value"])
+        return text_result(bridge_request(req))
+
+    if name == "pan":
+        req = {"cmd": "pan", "action": args["action"]}
+        if args.get("value"):
+            req["value"] = str(args["value"])
+        return text_result(bridge_request(req))
+
+    if name == "mark":
+        return text_result(bridge_request(
+            {"cmd": "mark", "value": str(args["text"])}))
+
+    if name == "window":
+        # window reads `target`, not `value`.
+        req = {"cmd": "window", "action": args["state"]}
+        if args.get("target"):
+            req["target"] = str(args["target"])
+        return text_result(bridge_request(req))
+
+    if name == "menu":
+        req = {"cmd": "menu", "action": args["action"]}
+        if args.get("name"):
+            req["value"] = str(args["name"])
+        return text_result(bridge_request(req))
+
+    if name == "streams":
+        req = {"cmd": "streams"}
+        if args.get("scope"):
+            req["action"] = str(args["scope"])
+        return text_result(bridge_request(req))
 
     if name == "bridge_command":
         req = args.get("request")

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -257,6 +257,64 @@ TOOLS = [
         }, "required": ["id"]},
     },
     {
+        "name": "get_log",
+        "description": (
+            "Tail recent app log events from the bridge's in-memory ring — "
+            "the fastest way to see WHY an action didn't take (Qt warnings, "
+            "category messages, your own `mark` annotations). Returns the "
+            "newest `count` events; pass `since` (an event seq from a prior "
+            "call) to fetch only newer ones for incremental polling."),
+        "inputSchema": {"type": "object", "properties": {
+            "count": {"type": "integer",
+                      "description": "newest N events (default 100)"},
+            "since": {"type": "integer",
+                      "description": "only events with seq greater than this"},
+        }},
+    },
+    {
+        "name": "connect",
+        "description": (
+            "Drive the radio-connection lifecycle. action = list (discovered "
+            "radios) | show / hide (the Connect dialog) | local (connect to a "
+            "local radio — value 'first' or 'serial <serial>') | ip (connect "
+            "by host/IP — value = host) | wait (block until connected — value "
+            "= timeout in ms). Confirm with get_state model=radio."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["list", "show", "hide", "local", "ip", "wait"]},
+            "value": {"type": "string",
+                      "description": "'first' / 'serial N', a host/IP, or a timeout in ms"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "disconnect",
+        "description": "Disconnect from the radio (the normal user disconnect path).",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "capture_audio",
+        "description": (
+            "Capture RX audio from the engine's tap points for analysis. "
+            "action = start (value = '<durationMs> <taps>', e.g. "
+            "'3000 raw,post,final') | status | stop | read (write the captured "
+            "buffer to `path` as JSON). Pair with get_state model=dsp to "
+            "correlate with the noise-reduction chain."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["start", "stop", "status", "read"]},
+            "value": {"type": "string",
+                      "description": "for start: '<durationMs> <comma,taps>' (default 5000ms)"},
+            "path": {"type": "string", "description": "for read: output file path"},
+        }, "required": ["action"]},
+    },
+    {
+        "name": "floors",
+        "description": (
+            "Per-pan measured noise floor and display floor in dBm — the "
+            "numeric RX-noise readout, no screenshot needed."),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
         "name": "bridge_command",
         "description": (
             "Raw escape hatch for every other bridge verb — send any "
@@ -375,6 +433,42 @@ def handle_tool(name, args):
         # The registry's shortcut verb reads `id` (or `target`), not `value` —
         # a JSON request bypasses the bare-line positional parser.
         return text_result(bridge_request({"cmd": "shortcut", "id": args["id"]}))
+
+    if name == "get_log":
+        # log verb: action="tail", value="<n> [since=<seq>]".
+        parts = [str(int(args.get("count", 100)))]
+        if args.get("since") is not None:
+            parts.append(f"since={int(args['since'])}")
+        return text_result(bridge_request(
+            {"cmd": "log", "action": "tail", "value": " ".join(parts)}))
+
+    if name == "connect":
+        req = {"cmd": "connect", "action": args["action"]}
+        if args.get("value"):
+            req["value"] = str(args["value"])
+        # `connect wait <ms>` can legitimately run past the default request
+        # timeout — stretch it to cover the requested wait plus slack.
+        timeout = REQUEST_TIMEOUT_S
+        if args["action"] == "wait" and args.get("value"):
+            try:
+                timeout = max(timeout, int(args["value"]) / 1000 + 10)
+            except (ValueError, TypeError):
+                pass
+        return text_result(bridge_request(req, timeout=timeout))
+
+    if name == "disconnect":
+        return text_result(bridge_request({"cmd": "disconnect"}))
+
+    if name == "capture_audio":
+        req = {"cmd": "audioCapture", "action": args["action"]}
+        if args.get("value"):
+            req["value"] = str(args["value"])
+        if args.get("path"):
+            req["path"] = str(args["path"])
+        return text_result(bridge_request(req))
+
+    if name == "floors":
+        return text_result(bridge_request({"cmd": "floors"}))
 
     if name == "bridge_command":
         req = args.get("request")

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -86,6 +86,30 @@ def test_field_mapping():
     reqs = run_tool("dump_tree", {})
     check("dump_tree sends cmd=dumpTree", reqs[-1].get("cmd") == "dumpTree", str(reqs))
 
+    # Promoted first-class verbs (#4188 area 1) — the registry reads
+    # action/value/path; these must map exactly or the tool is dead.
+    r = run_tool("get_log", {"count": 50, "since": 7})[-1]
+    check("get_log → log tail with count+since",
+          r.get("cmd") == "log" and r.get("action") == "tail"
+          and r.get("value") == "50 since=7", str(r))
+
+    r = run_tool("connect", {"action": "ip", "value": "192.168.50.100"})[-1]
+    check("connect → cmd=connect action+value",
+          r.get("cmd") == "connect" and r.get("action") == "ip"
+          and r.get("value") == "192.168.50.100", str(r))
+
+    r = run_tool("disconnect", {})[-1]
+    check("disconnect → cmd=disconnect", r.get("cmd") == "disconnect", str(r))
+
+    r = run_tool("capture_audio",
+                 {"action": "start", "value": "3000 raw,post"})[-1]
+    check("capture_audio → cmd=audioCapture action+value",
+          r.get("cmd") == "audioCapture" and r.get("action") == "start"
+          and r.get("value") == "3000 raw,post", str(r))
+
+    r = run_tool("floors", {})[-1]
+    check("floors → cmd=floors", r.get("cmd") == "floors", str(r))
+
     reqs = run_tool("bridge_command", {"request": {"cmd": "whoami"}})
     check("bridge_command passes raw request", reqs[-1].get("cmd") == "whoami", str(reqs))
 

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -110,6 +110,42 @@ def test_field_mapping():
     r = run_tool("floors", {})[-1]
     check("floors → cmd=floors", r.get("cmd") == "floors", str(r))
 
+    r = run_tool("tune", {"mhz": "14.074"})[-1]
+    check("tune → cmd=tune value(mhz)",
+          r.get("cmd") == "tune" and r.get("value") == "14.074", str(r))
+
+    r = run_tool("slice", {"action": "select", "value": "3"})[-1]
+    check("slice → cmd=slice action+value",
+          r.get("cmd") == "slice" and r.get("action") == "select"
+          and r.get("value") == "3", str(r))
+
+    r = run_tool("pan", {"action": "center", "value": "7.1"})[-1]
+    check("pan → cmd=pan action+value",
+          r.get("cmd") == "pan" and r.get("action") == "center"
+          and r.get("value") == "7.1", str(r))
+
+    r = run_tool("record", {"action": "start"})[-1]
+    check("record → cmd=record action", r.get("cmd") == "record"
+          and r.get("action") == "start", str(r))
+
+    r = run_tool("mark", {"text": "agent bracket"})[-1]
+    check("mark → cmd=mark value(text)",
+          r.get("cmd") == "mark" and r.get("value") == "agent bracket", str(r))
+
+    r = run_tool("window", {"state": "maximize", "target": "MainWindow"})[-1]
+    check("window → action=state, target (NOT value)",
+          r.get("cmd") == "window" and r.get("action") == "maximize"
+          and r.get("target") == "MainWindow" and "value" not in r, str(r))
+
+    r = run_tool("menu", {"action": "open", "name": "File"})[-1]
+    check("menu → action + value(name)",
+          r.get("cmd") == "menu" and r.get("action") == "open"
+          and r.get("value") == "File", str(r))
+
+    r = run_tool("streams", {"scope": "radio"})[-1]
+    check("streams → cmd=streams action(scope)",
+          r.get("cmd") == "streams" and r.get("action") == "radio", str(r))
+
     reqs = run_tool("bridge_command", {"request": {"cmd": "whoami"}})
     check("bridge_command passes raw request", reqs[-1].get("cmd") == "whoami", str(reqs))
 


### PR DESCRIPTION
## Summary

Implements **area 1 of #4188** — promote high-value bridge verbs from the `bridge_command` escape hatch to first-class, schema-validated MCP tools. The server went from **7 typed tools over a 45-verb bridge** to **20 typed tools**, so an assistant discovers and gets argument-validated on the common actions instead of hand-writing wire JSON.

## Promoted to typed tools (13 new)

**Introspection / data:** `get_log` (tail app log events — *why* an action didn't take), `floors` (per-pan noise/display floor in dBm), `streams` (stream diagnostics).
**Radio driving:** `tune`, `slice`, `pan`, `record`, `mark`, `window`, `menu`.
**Connection / audio:** `connect`, `disconnect`, `capture_audio`.

## Kept behind `bridge_command` on purpose (documented)

- The 10 low-level widget primitives (`hover`, `tooltip`, `clickAt`, `drag`, `close`, `scrollTo`, `showMenu`, `contextMenu`, `rightClick`, `hitTest`) — `invoke`/`grab` cover the common cases.
- The 6 transmit-keying verbs (`key`, `txtest`, `atu`, `cwx`, `testtone`, `txwaterfall`) — gated by `AETHER_AUTOMATION_ALLOW_TX`, deliberately less convenient on a UI-validation surface.
- Niche/complex: `dss` (belongs to #4188 area 2's RF-data work), `layout`, `scale`, `panmessage`, `tci`, `station`, `resize`, `qrz`.

## Correctness

Each tool maps to the **exact** registry field shape — the class of bug that made the `shortcut` tool dead in #4177. Two easy-to-miss ones: `window` reads `target` (not `value`), and `menu`'s name rides `value`. All mappings are covered by new cases in `tools/test_aether_mcp.py` (the `aether_mcp_field_mapping` ctest), so they can't silently drift.

## Testing

- Field-mapping test: all 20 tools' request shapes asserted; passes.
- **Live end-to-end** (offscreen app): `tools/list` advertises 20; `floors` / `get_log` / `connect list` / `capture_audio status` / `mark` / `menu list` / `streams` / `record status` / `window` all drive the running bridge and return real data; `disconnect` and `tune` return the correct "not connected" / "no slice" responses with no radio.

Checks off area 1 of #4188. TX safety is unchanged: keying stays behind the existing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
