### PR TITLE
Add frameless support to Help menu windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3266,6 +3266,9 @@ add_test(NAME transmit_model_apd_test COMMAND transmit_model_apd_test)
 add_executable(help_dialog_test
     tests/help_dialog_test.cpp
     src/gui/HelpDialog.cpp
+    src/gui/PersistentDialog.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
     # HelpDialog.cpp calls ThemeManager::resolve() post-Phase-2 migration;
     # pull in the manager + its logging deps so the test links.
     src/core/ThemeManager.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,6 +759,7 @@ set(GUI_SOURCES
     src/gui/RadeApplet.cpp
     src/gui/HealthApplet.cpp
     src/gui/PersistentDialog.cpp
+    src/gui/FramelessMessageBox.cpp
     src/gui/ProfileManagerDialog.cpp
     src/gui/ProfileImportExportDialog.cpp
     src/gui/TxBandDialog.cpp

--- a/src/gui/FramelessMessageBox.cpp
+++ b/src/gui/FramelessMessageBox.cpp
@@ -1,0 +1,105 @@
+#include "FramelessMessageBox.h"
+
+#include "FramelessResizer.h"
+#include "FramelessWindowTitleBar.h"
+#include "core/AppSettings.h"
+
+#include <QLayout>
+#include <QResizeEvent>
+#include <QShowEvent>
+
+namespace AetherSDR {
+
+FramelessMessageBox::FramelessMessageBox(QWidget* parent)
+    : QMessageBox(parent)
+{
+    m_originalMargins = layout()->contentsMargins();
+    m_titleBar = new FramelessWindowTitleBar(windowTitle(), this);
+    m_titleBar->raise();
+    FramelessResizer::install(this);
+    setFramelessMode(
+        AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
+}
+
+void FramelessMessageBox::setFramelessMode(bool on)
+{
+    m_framelessOn = on;
+    const QRect geom = geometry();
+    const bool wasVisible = isVisible();
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    flags.setFlag(Qt::FramelessWindowHint, on);
+    setWindowFlags(flags);
+    if (wasVisible) {
+        setGeometry(geom);
+    }
+
+    m_titleBar->setVisible(on);
+    const int titleHeight = on ? m_titleBar->sizeHint().height() : 0;
+    layout()->setContentsMargins(m_originalMargins.left(),
+                                 m_originalMargins.top() + titleHeight,
+                                 m_originalMargins.right(),
+                                 m_originalMargins.bottom());
+    positionTitleBar();
+    if (wasVisible) {
+        show();
+    }
+}
+
+void FramelessMessageBox::resizeEvent(QResizeEvent* event)
+{
+    QMessageBox::resizeEvent(event);
+    positionTitleBar();
+}
+
+void FramelessMessageBox::showEvent(QShowEvent* event)
+{
+    m_titleBar->setTitleText(windowTitle());
+    QMessageBox::showEvent(event);
+    positionTitleBar();
+}
+
+void FramelessMessageBox::positionTitleBar()
+{
+    if (m_titleBar) {
+        m_titleBar->setGeometry(0, 0, width(), m_titleBar->sizeHint().height());
+        m_titleBar->raise();
+    }
+}
+
+QMessageBox::StandardButton FramelessMessageBox::showMessage(
+    Icon icon, QWidget* parent, const QString& title, const QString& text,
+    StandardButtons buttons, StandardButton defaultButton)
+{
+    FramelessMessageBox box(parent);
+    box.setIcon(icon);
+    box.setWindowTitle(title);
+    box.setText(text);
+    box.setStandardButtons(buttons);
+    if (defaultButton != NoButton) {
+        box.setDefaultButton(defaultButton);
+    }
+    return static_cast<StandardButton>(box.exec());
+}
+
+QMessageBox::StandardButton FramelessMessageBox::information(
+    QWidget* parent, const QString& title, const QString& text,
+    StandardButtons buttons, StandardButton defaultButton)
+{
+    return showMessage(Information, parent, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton FramelessMessageBox::warning(
+    QWidget* parent, const QString& title, const QString& text,
+    StandardButtons buttons, StandardButton defaultButton)
+{
+    return showMessage(Warning, parent, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton FramelessMessageBox::question(
+    QWidget* parent, const QString& title, const QString& text,
+    StandardButtons buttons, StandardButton defaultButton)
+{
+    return showMessage(Question, parent, title, text, buttons, defaultButton);
+}
+
+} // namespace AetherSDR

--- a/src/gui/FramelessMessageBox.cpp
+++ b/src/gui/FramelessMessageBox.cpp
@@ -23,7 +23,6 @@ FramelessMessageBox::FramelessMessageBox(QWidget* parent)
 
 void FramelessMessageBox::setFramelessMode(bool on)
 {
-    m_framelessOn = on;
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
     Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;

--- a/src/gui/FramelessMessageBox.h
+++ b/src/gui/FramelessMessageBox.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QMessageBox>
+
+namespace AetherSDR {
+
+class FramelessWindowTitleBar;
+
+// QMessageBox with the same optional custom chrome as PersistentDialog.
+// These prompts are transient, so they intentionally do not persist geometry.
+class FramelessMessageBox : public QMessageBox {
+    Q_OBJECT
+
+public:
+    explicit FramelessMessageBox(QWidget* parent = nullptr);
+
+    void setFramelessMode(bool on);
+
+    static StandardButton information(QWidget* parent, const QString& title,
+                                      const QString& text,
+                                      StandardButtons buttons = Ok,
+                                      StandardButton defaultButton = NoButton);
+    static StandardButton warning(QWidget* parent, const QString& title,
+                                  const QString& text,
+                                  StandardButtons buttons = Ok,
+                                  StandardButton defaultButton = NoButton);
+    static StandardButton question(QWidget* parent, const QString& title,
+                                   const QString& text,
+                                   StandardButtons buttons = StandardButtons(Yes | No),
+                                   StandardButton defaultButton = NoButton);
+
+protected:
+    void resizeEvent(QResizeEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+
+private:
+    static StandardButton showMessage(Icon icon, QWidget* parent,
+                                      const QString& title, const QString& text,
+                                      StandardButtons buttons,
+                                      StandardButton defaultButton);
+    void positionTitleBar();
+
+    FramelessWindowTitleBar* m_titleBar{nullptr};
+    QMargins m_originalMargins;
+    bool m_framelessOn{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/FramelessMessageBox.h
+++ b/src/gui/FramelessMessageBox.h
@@ -42,7 +42,6 @@ private:
 
     FramelessWindowTitleBar* m_titleBar{nullptr};
     QMargins m_originalMargins;
-    bool m_framelessOn{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -2,6 +2,7 @@
 
 #include <QDialogButtonBox>
 #include <QFile>
+#include <QFileInfo>
 #include <QHBoxLayout>
 #include <QKeySequence>
 #include <QLabel>
@@ -16,6 +17,16 @@
 namespace AetherSDR {
 
 namespace {
+
+// Per-guide geometry key derived from the (stable) help resource path, so two
+// guides open at once persist and restore independent positions instead of
+// sharing one "HelpDialogGeometry" slot and stacking on top of each other.
+QString helpGeometryKey(const QString& resourcePath)
+{
+    const QString stem = QFileInfo(resourcePath).baseName();
+    return stem.isEmpty() ? QStringLiteral("HelpDialogGeometry")
+                          : QStringLiteral("HelpDialogGeometry_") + stem;
+}
 
 const char* kFindEditStyle =
     "QLineEdit {"
@@ -44,7 +55,7 @@ const char* kFindEditNoMatchStyle =
 HelpDialog::HelpDialog(const QString& windowTitle,
                        const QString& resourcePath,
                        QWidget* parent)
-    : PersistentDialog(windowTitle, QStringLiteral("HelpDialogGeometry"), parent)
+    : PersistentDialog(windowTitle, helpGeometryKey(resourcePath), parent)
 {
     theme::setContainer(this, QStringLiteral("dialog/help"));
     buildUI(resourcePath);

--- a/src/gui/HelpDialog.cpp
+++ b/src/gui/HelpDialog.cpp
@@ -44,11 +44,9 @@ const char* kFindEditNoMatchStyle =
 HelpDialog::HelpDialog(const QString& windowTitle,
                        const QString& resourcePath,
                        QWidget* parent)
-    : QDialog(parent)
+    : PersistentDialog(windowTitle, QStringLiteral("HelpDialogGeometry"), parent)
 {
     theme::setContainer(this, QStringLiteral("dialog/help"));
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    setWindowTitle(windowTitle);
     buildUI(resourcePath);
 }
 
@@ -57,9 +55,10 @@ void HelpDialog::buildUI(const QString& resourcePath)
     resize(760, 680);
     setMinimumSize(520, 420);
 
-    auto* layout = new QVBoxLayout(this);
+    auto* layout = new QVBoxLayout(bodyWidget());
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
+    setBodyLayoutMargins(QMargins(), QMargins());
 
     auto* header = new QWidget(this);
     AetherSDR::ThemeManager::instance().applyStyleSheet(header, "background: {{color.background.0}};");

--- a/src/gui/HelpDialog.h
+++ b/src/gui/HelpDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
 #include <QString>
 
 class QLabel;
@@ -10,7 +10,7 @@ class QTextBrowser;
 
 namespace AetherSDR {
 
-class HelpDialog : public QDialog {
+class HelpDialog : public PersistentDialog {
     Q_OBJECT
 
 public:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -145,6 +145,7 @@
 #include "MeterSlider.h"
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
+#include "FramelessMessageBox.h"
 
 #include <algorithm>
 #include <atomic>
@@ -1159,7 +1160,7 @@ MainWindow::MainWindow(QWidget* parent)
     m_updateChecker = new UpdateChecker(this);
     connect(m_updateChecker, &UpdateChecker::updateAvailable, this, [this](const QString& ver) {
         const QString current = QCoreApplication::applicationVersion();
-        QMessageBox box(this);
+        FramelessMessageBox box(this);
         box.setWindowTitle("AetherSDR Update Available");
         box.setIcon(QMessageBox::Information);
         box.setText(QString("AetherSDR v%1 is available.").arg(ver));
@@ -1177,11 +1178,11 @@ MainWindow::MainWindow(QWidget* parent)
             QDesktopServices::openUrl(QUrl(UpdateChecker::kReleasesPageUrl));
     });
     connect(m_updateChecker, &UpdateChecker::upToDate, this, [this](const QString& ver) {
-        QMessageBox::information(this, "Check for Updates",
+        FramelessMessageBox::information(this, "Check for Updates",
             QString("AetherSDR is up to date (v%1).").arg(ver));
     });
     connect(m_updateChecker, &UpdateChecker::checkFailed, this, [this]() {
-        QMessageBox::warning(this, "Check for Updates",
+        FramelessMessageBox::warning(this, "Check for Updates",
             "Could not reach GitHub. Check your connection and try again.");
     });
 
@@ -7518,6 +7519,8 @@ void MainWindow::setFramelessWindow(bool on)
         m_appletPanel->containerManager()->setFramelessMode(on);
     if (m_connPanel)
         m_connPanel->setFramelessMode(on);
+    if (m_titleBar)
+        m_titleBar->setChildDialogsFramelessMode(on);
     // RadioSetupDialog frameless propagation flows through the
     // m_persistentDialogs loop below (#2781) — all four entry points use
     // showOrRaisePersistent so the dialog is always tracked there.

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -7478,6 +7478,17 @@ void MainWindow::toggleAppletPanelFloating(bool floating)
     }
 }
 
+void MainWindow::trackPersistentDialog(PersistentDialog* dialog)
+{
+    if (!dialog) {
+        return;
+    }
+    m_persistentDialogs.removeIf([dialog](const QPointer<PersistentDialog>& tracked) {
+        return tracked.isNull() || tracked.data() == dialog;
+    });
+    m_persistentDialogs.append(QPointer<PersistentDialog>(dialog));
+}
+
 void MainWindow::setFramelessWindow(bool on)
 {
     auto& s = AppSettings::instance();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -523,6 +523,7 @@ private:
     // Toggle OS window-chrome on/off. Persists to AppSettings("FramelessWindow").
     // When on, TitleBar provides the drag surface and window-control buttons.
     void setFramelessWindow(bool on);
+    void trackPersistentDialog(PersistentDialog* dialog);
 
     // Lazy-construct + show + raise + activate for a PersistentDialog
     // subclass.  Collapses the ~10-line "if slot raise else new+setAttribute+
@@ -1028,11 +1029,10 @@ private:
 #endif
     QPointer<UlanziDialMapperDialog> m_ulanziMapperDialog;
 
-    // Tracks every PersistentDialog created via showOrRaisePersistent() so
-    // setFramelessWindow() can propagate the frameless toggle without an
-    // explicit per-dialog qobject_cast branch.  QPointer entries auto-null on
-    // dialog destruction (QSet::insert handles deduplication on null QPointer
-    // re-creation by removing them on iteration via removeIf below).
+    // Tracks PersistentDialogs so setFramelessWindow() can propagate the
+    // frameless toggle without explicit per-dialog branches. Registration
+    // prunes null and duplicate QPointers so repeated close/reopen cycles do
+    // not grow the list when the frameless setting is never toggled.
     QList<QPointer<PersistentDialog>> m_persistentDialogs;
 
     // Menus
@@ -1390,7 +1390,7 @@ void MainWindow::showOrRaisePersistent(QPointer<T>& slot, Args&&... ctorArgs)
         dlg->setFramelessMode(
             AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
         slot = dlg;
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
     }
     slot->show();
     slot->raise();

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -104,7 +104,7 @@ void MainWindow::showAx25HfPacketDecodeDialog()
         dlg->setFramelessMode(
             AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
         m_ax25HfPacketDecodeDialog = dlg;
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
     }
     m_ax25HfPacketDecodeDialog->setAttachedSlice(slice);
 #ifdef HAVE_MQTT
@@ -137,7 +137,7 @@ void MainWindow::startKissTncOnStartupIfConfigured()
     dlg->setFramelessMode(
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
     m_ax25HfPacketDecodeDialog = dlg;
-    m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+    trackPersistentDialog(dlg);
 #ifdef HAVE_MQTT
     m_ax25HfPacketDecodeDialog->setMqttClient(m_mqttClient);
 #endif
@@ -1297,7 +1297,7 @@ void MainWindow::showPskReporterMapDialog()
         dlg->setFramelessMode(
             AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
         m_pskReporterMapDialog = dlg;
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
     }
     m_pskReporterMapDialog->show();
     m_pskReporterMapDialog->raise();

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1070,7 +1070,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Getting Started...", this, [this]() {
         auto* dlg = new HelpDialog("Getting Started", ":/help/getting-started.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1078,7 +1078,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("AetherSDR Help...", this, [this]() {
         auto* dlg = new HelpDialog("AetherSDR Help", ":/help/aethersdr-help.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1093,7 +1093,7 @@ void MainWindow::buildMenuBar()
         m_whatsNewDialog = WhatsNewDialog::showAll(this);
         m_whatsNewDialog->setFramelessMode(
             AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-        m_persistentDialogs.append(QPointer<PersistentDialog>(m_whatsNewDialog));
+        trackPersistentDialog(m_whatsNewDialog);
     });
     helpMenu->addSeparator();
 
@@ -1102,7 +1102,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Understanding Noise Cancellation...", this, [this]() {
         auto* dlg = new HelpDialog("Understanding Noise Cancellation", ":/help/understanding-noise-cancellation.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1110,7 +1110,7 @@ void MainWindow::buildMenuBar()
     auto* controlsHelpAction = helpMenu->addAction("Configuring AetherSDR Controls...", this, [this]() {
         auto* dlg = new HelpDialog("Configuring AetherSDR Controls", ":/help/configuring-aethersdr-controls.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1119,7 +1119,7 @@ void MainWindow::buildMenuBar()
     auto* dataModesAction = helpMenu->addAction("Configuring Data Modes...", this, [this]() {
         auto* dlg = new HelpDialog("Configuring Data Modes", ":/help/understanding-data-modes.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1148,7 +1148,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Contributing to AetherSDR...", this, [this]() {
         auto* dlg = new HelpDialog("Contributing to AetherSDR", ":/help/contributing-to-aethersdr.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1162,7 +1162,7 @@ void MainWindow::buildMenuBar()
         auto* dlg = new SupportDialog(this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         dlg->setRadioModel(&m_radioModel);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
     });
@@ -1180,7 +1180,7 @@ void MainWindow::buildMenuBar()
             });
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         dlg->setWindowModality(Qt::ApplicationModal);
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1208,7 +1208,7 @@ void MainWindow::buildMenuBar()
         vbox->setContentsMargins(16, 16, 16, 16);
         dlg->setBodyLayoutMargins(QMargins(16, 16, 16, 16),
                                   QMargins(16, 14, 16, 16));
-        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        trackPersistentDialog(dlg);
 
         // Icon
         auto* iconLbl = new QLabel;

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1070,7 +1070,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Getting Started...", this, [this]() {
         auto* dlg = new HelpDialog("Getting Started", ":/help/getting-started.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1078,7 +1078,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("AetherSDR Help...", this, [this]() {
         auto* dlg = new HelpDialog("AetherSDR Help", ":/help/aethersdr-help.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1102,7 +1102,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Understanding Noise Cancellation...", this, [this]() {
         auto* dlg = new HelpDialog("Understanding Noise Cancellation", ":/help/understanding-noise-cancellation.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1110,7 +1110,7 @@ void MainWindow::buildMenuBar()
     auto* controlsHelpAction = helpMenu->addAction("Configuring AetherSDR Controls...", this, [this]() {
         auto* dlg = new HelpDialog("Configuring AetherSDR Controls", ":/help/configuring-aethersdr-controls.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1119,7 +1119,7 @@ void MainWindow::buildMenuBar()
     auto* dataModesAction = helpMenu->addAction("Configuring Data Modes...", this, [this]() {
         auto* dlg = new HelpDialog("Configuring Data Modes", ":/help/understanding-data-modes.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1148,7 +1148,7 @@ void MainWindow::buildMenuBar()
     helpMenu->addAction("Contributing to AetherSDR...", this, [this]() {
         auto* dlg = new HelpDialog("Contributing to AetherSDR", ":/help/contributing-to-aethersdr.md", this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setModal(false);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
         dlg->activateWindow();
@@ -1162,21 +1162,28 @@ void MainWindow::buildMenuBar()
         auto* dlg = new SupportDialog(this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
         dlg->setRadioModel(&m_radioModel);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
         dlg->show();
         dlg->raise();
     });
     helpMenu->addAction("Slice Troubleshooting...", this, [this]() {
-        SliceTroubleshootingDialog dlg(&m_radioModel, m_audio, this,
-                                       [this]() { return buildControlDevicesSnapshot(); },
-                                       [this]() {
-                                           QJsonObject renderer;
-                                           renderer["available"] = true;
-                                           renderer["description"] = spectrum()
-                                               ? spectrum()->rendererDescription()
-                                               : QStringLiteral("No active pan");
-                                           return renderer;
-                                       });
-        dlg.exec();
+        auto* dlg = new SliceTroubleshootingDialog(
+            &m_radioModel, m_audio, this,
+            [this]() { return buildControlDevicesSnapshot(); },
+            [this]() {
+                QJsonObject renderer;
+                renderer["available"] = true;
+                renderer["description"] = spectrum()
+                    ? spectrum()->rendererDescription()
+                    : QStringLiteral("No active pan");
+                return renderer;
+            });
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->setWindowModality(Qt::ApplicationModal);
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
     });
     // "Reset Settings" was previously buried inside the Support dialog too.
     // NoRole is required: macOS would otherwise treat the word "Settings" as a
@@ -1190,15 +1197,18 @@ void MainWindow::buildMenuBar()
     });
     helpMenu->addSeparator();
     helpMenu->addAction("About AetherSDR", this, [this]{
-        auto* dlg = new QDialog(this);
+        auto* dlg = new PersistentDialog(QStringLiteral("About AetherSDR"),
+                                         QStringLiteral("AboutDialogGeometry"), this);
         dlg->setAttribute(Qt::WA_DeleteOnClose);
-        dlg->setWindowTitle("About AetherSDR");
         dlg->setFixedWidth(380);
         AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }");
 
-        auto* vbox = new QVBoxLayout(dlg);
+        auto* vbox = new QVBoxLayout(dlg->bodyWidget());
         vbox->setSpacing(8);
         vbox->setContentsMargins(16, 16, 16, 16);
+        dlg->setBodyLayoutMargins(QMargins(16, 16, 16, 16),
+                                  QMargins(16, 14, 16, 16));
+        m_persistentDialogs.append(QPointer<PersistentDialog>(dlg));
 
         // Icon
         auto* iconLbl = new QLabel;

--- a/src/gui/PersistentDialog.cpp
+++ b/src/gui/PersistentDialog.cpp
@@ -68,8 +68,17 @@ void PersistentDialog::setFramelessMode(bool on)
 void PersistentDialog::applyBodyLayoutMargins()
 {
     if (m_body && m_body->layout()) {
-        m_body->layout()->setContentsMargins(9, m_framelessOn ? 7 : 9, 9, 9);
+        m_body->layout()->setContentsMargins(
+            m_framelessOn ? m_framelessBodyMargins : m_framedBodyMargins);
     }
+}
+
+void PersistentDialog::setBodyLayoutMargins(const QMargins& framed,
+                                            const QMargins& frameless)
+{
+    m_framedBodyMargins = framed;
+    m_framelessBodyMargins = frameless;
+    applyBodyLayoutMargins();
 }
 
 void PersistentDialog::showEvent(QShowEvent* event)

--- a/src/gui/PersistentDialog.h
+++ b/src/gui/PersistentDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QMargins>
 
 class QCloseEvent;
 class QMoveEvent;
@@ -50,6 +51,10 @@ public:
 
     // Content goes here.  Subclasses install their own QLayout on this widget.
     QWidget* bodyWidget() const { return m_body; }
+    // Override the standard 9 px body inset for dialogs whose content owns a
+    // deliberate edge-to-edge or wider layout.  Call after installing the
+    // body layout; the values are also reapplied after runtime chrome toggles.
+    void setBodyLayoutMargins(const QMargins& framed, const QMargins& frameless);
 
 protected:
     void closeEvent(QCloseEvent* event) override;
@@ -69,6 +74,8 @@ private:
     bool                     m_framelessOn{false};
     bool                     m_restoringGeometry{false};
     bool                     m_geometryRestored{false};
+    QMargins                 m_framedBodyMargins{9, 9, 9, 9};
+    QMargins                 m_framelessBodyMargins{9, 7, 9, 9};
 };
 
 } // namespace AetherSDR

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -383,19 +383,17 @@ SliceTroubleshootingDialog::SliceTroubleshootingDialog(RadioModel* model,
                                                        QWidget* parent,
                                                        SnapshotProvider controlDevicesProvider,
                                                        SnapshotProvider rendererProvider)
-    : QDialog(parent)
+    : PersistentDialog(QStringLiteral("Slice Troubleshooting"),
+                       QStringLiteral("SliceTroubleshootingDialogGeometry"), parent)
     , m_model(model)
     , m_audio(audio)
     , m_controlDevicesProvider(std::move(controlDevicesProvider))
     , m_rendererProvider(std::move(rendererProvider))
 {
     theme::setContainer(this, QStringLiteral("dialog/sliceTroubleshoot"));
-    setWindowTitle("Slice Troubleshooting");
     setMinimumSize(920, 720);
     resize(980, 760);
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
-    auto* root = new QVBoxLayout(this);
+    auto* root = new QVBoxLayout(bodyWidget());
     root->setSpacing(8);
 
     auto* intro = new QLabel(

--- a/src/gui/SliceTroubleshootingDialog.h
+++ b/src/gui/SliceTroubleshootingDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
 #include <QJsonObject>
 #include <functional>
 
@@ -14,7 +14,7 @@ namespace AetherSDR {
 class RadioModel;
 class AudioEngine;
 
-class SliceTroubleshootingDialog : public QDialog {
+class SliceTroubleshootingDialog : public PersistentDialog {
     Q_OBJECT
 
 public:

--- a/src/gui/SupportDialog.cpp
+++ b/src/gui/SupportDialog.cpp
@@ -1,4 +1,5 @@
 #include "SupportDialog.h"
+#include "FramelessMessageBox.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
@@ -11,7 +12,6 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
-#include <QMessageBox>
 #include <QFileInfo>
 #include <QGridLayout>
 #include <QGroupBox>
@@ -31,10 +31,10 @@
 namespace AetherSDR {
 
 SupportDialog::SupportDialog(QWidget* parent)
-    : QDialog(parent)
+    : PersistentDialog(QStringLiteral("Support & Diagnostics"),
+                       QStringLiteral("SupportDialogGeometry"), parent)
 {
     theme::setContainer(this, QStringLiteral("dialog/support"));
-    setWindowTitle("Support & Diagnostics");
     setMinimumSize(600, 520);
     resize(680, 600);
     buildUI();
@@ -44,7 +44,7 @@ SupportDialog::SupportDialog(QWidget* parent)
 
 void SupportDialog::buildUI()
 {
-    auto* layout = new QVBoxLayout(this);
+    auto* layout = new QVBoxLayout(bodyWidget());
     layout->setSpacing(8);
 
     // ── Diagnostic Logging group ──────────────────────────────────────────
@@ -219,7 +219,7 @@ void SupportDialog::resetSettings(QWidget* parent)
         "Continue?")
         .arg(QString("- %1").arg(resetPaths.join("\n- ")));
 
-    if (QMessageBox::question(parent, "Reset Settings", prompt,
+    if (FramelessMessageBox::question(parent, "Reset Settings", prompt,
             QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) != QMessageBox::Yes) {
         return;
     }
@@ -248,7 +248,7 @@ void SupportDialog::resetSettings(QWidget* parent)
         return;
     }
 
-    QMessageBox::warning(
+    FramelessMessageBox::warning(
         parent, "Reset Settings",
         QString(
             "Some files could not be removed.\n\n"
@@ -274,7 +274,7 @@ void SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)
     }
     QString bundlePath = SupportBundle::createBundle(radio);
     if (bundlePath.isEmpty()) {
-        QMessageBox::warning(parent, "Error",
+        FramelessMessageBox::warning(parent, "Error",
             "Failed to create support bundle.");
         return;
     }
@@ -335,7 +335,7 @@ void SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)
     QString prompt = kPromptTemplate.arg(version, qt, os, radioInfo);
     QApplication::clipboard()->setText(prompt);
 
-    QMessageBox dlg(parent);
+    FramelessMessageBox dlg(parent);
     dlg.setWindowTitle("AI-Assisted Bug Report");
     dlg.setIcon(QMessageBox::Information);
     dlg.setText(
@@ -390,7 +390,7 @@ void SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)
         QFileInfo fi(bundlePath);
         QDesktopServices::openUrl(QUrl::fromLocalFile(fi.absolutePath()));
 
-        QMessageBox::information(parent, "Submit Bug Report",
+        FramelessMessageBox::information(parent, "Submit Bug Report",
             QString("Your browser and support folder have been opened.\n\n"
                     "1. Paste the AI's bug report into the GitHub form\n"
                     "2. Drag and drop the support bundle: %1")
@@ -398,7 +398,7 @@ void SupportDialog::fileIssue(QWidget* parent, RadioModel* radioModel)
     }
 
     if (openedLLM) {
-        QMessageBox::information(parent, "Prompt Copied",
+        FramelessMessageBox::information(parent, "Prompt Copied",
             "The diagnostic prompt has been copied to your clipboard.\n\n"
             "Paste it into the AI, describe your issue, then come back\n"
             "and click \"Submit Bug Report\" to file it on GitHub.");
@@ -428,13 +428,13 @@ void SupportDialog::sendToSupport()
     setCursor(Qt::ArrowCursor);
 
     if (bundlePath.isEmpty()) {
-        QMessageBox::warning(this, "Support Bundle",
+        FramelessMessageBox::warning(this, "Support Bundle",
             "Failed to create support bundle.\n"
             "Check that the log directory is writable.");
         return;
     }
 
-    QMessageBox::information(this, "Support Bundle Created",
+    FramelessMessageBox::information(this, "Support Bundle Created",
         QString("Support bundle saved to:\n%1\n\n"
                 "Your email client will now open.\n"
                 "Please attach the bundle file and describe the issue.")

--- a/src/gui/SupportDialog.h
+++ b/src/gui/SupportDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
 #include <QMap>
 
 class QCheckBox;
@@ -11,7 +11,7 @@ namespace AetherSDR {
 
 class RadioModel;
 
-class SupportDialog : public QDialog {
+class SupportDialog : public PersistentDialog {
     Q_OBJECT
 
 public:

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1,5 +1,7 @@
 #include "TitleBar.h"
+#include "FramelessMessageBox.h"
 #include "GuardedSlider.h"
+#include "PersistentDialog.h"
 #include "core/AppSettings.h"
 
 #include <QFrame>
@@ -977,7 +979,7 @@ void TitleBar::showFeatureRequestDialog()
             auto latestVer = VersionNumber::parse(latest);
             auto currentVer = VersionNumber::parse(QCoreApplication::applicationVersion());
             if (!latestVer.isNull() && currentVer < latestVer) {
-                auto answer = QMessageBox::warning(this, "Outdated Version",
+                auto answer = FramelessMessageBox::warning(this, "Outdated Version",
                     QString("<p>You are running <b>v%1</b> but <b>v%2</b> is available.</p>"
                             "<p>Your issue may already be fixed in the latest release. "
                             "Please update before filing a bug report.</p>"
@@ -1036,23 +1038,24 @@ void TitleBar::showFeatureRequestDialogImpl()
         "[Describe your feature or bug here in plain English]";
 
     // Reuse existing dialog if still open
-    static QPointer<QDialog> sDlg;
-    if (sDlg) {
-        sDlg->raise();
-        sDlg->activateWindow();
+    if (m_issueReporterDialog) {
+        m_issueReporterDialog->raise();
+        m_issueReporterDialog->activateWindow();
         return;
     }
 
-    auto* dlg = new QDialog(this);
-    sDlg = dlg;
-    dlg->setWindowTitle("AI-Assisted Issue Reporter");
+    auto* dlg = new PersistentDialog(QStringLiteral("AI-Assisted Issue Reporter"),
+                                     QStringLiteral("IssueReporterDialogGeometry"), this);
+    m_issueReporterDialog = dlg;
     dlg->setAttribute(Qt::WA_DeleteOnClose);
     AetherSDR::ThemeManager::instance().applyStyleSheet(dlg, "QDialog { background: {{color.background.0}}; }");
     dlg->setMinimumWidth(620);
 
-    auto* vbox = new QVBoxLayout(dlg);
+    auto* vbox = new QVBoxLayout(dlg->bodyWidget());
     vbox->setSpacing(8);
     vbox->setContentsMargins(16, 16, 16, 16);
+    dlg->setBodyLayoutMargins(QMargins(16, 16, 16, 16),
+                              QMargins(16, 14, 16, 16));
 
     auto* header = new QLabel(
         "<h3 style='color:#c8d8e8;'>AI-Assisted Issue Reporter</h3>"
@@ -1141,6 +1144,13 @@ void TitleBar::showFeatureRequestDialogImpl()
     QApplication::clipboard()->setText(kPrompt);
 
     dlg->show();
+}
+
+void TitleBar::setChildDialogsFramelessMode(bool on)
+{
+    if (m_issueReporterDialog) {
+        m_issueReporterDialog->setFramelessMode(on);
+    }
 }
 
 void TitleBar::setDiscovering(bool active)

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QElapsedTimer>
+#include <QPointer>
 #include <QString>
 #include <QVariantMap>
 #include <QWidget>
@@ -16,6 +17,8 @@ class QGraphicsOpacityEffect;
 class QPropertyAnimation;
 
 namespace AetherSDR {
+
+class PersistentDialog;
 
 class TitleBar : public QWidget {
     Q_OBJECT
@@ -85,6 +88,7 @@ signals:
 public:
     // Open the feature-request dialog.  Wired from Help → Submit your idea…
     void showFeatureRequestDialog();
+    void setChildDialogsFramelessMode(bool on);
 
 private:
     void markDragHandle(QWidget* widget);
@@ -116,6 +120,7 @@ private:
     QLabel*      m_dockLeftLbl{nullptr};
     QLabel*      m_dockRightLbl{nullptr};
     QLabel*      m_popOutLbl{nullptr};
+    QPointer<PersistentDialog> m_issueReporterDialog;
     QFrame*      m_dockSep{nullptr};
     bool         m_minimalMode{false};
     bool         m_windowMoveActive{false};


### PR DESCRIPTION
## Summary

Adds frameless-window support to every in-app window and prompt launched from the Help menu. Help guides, Support & Diagnostics, Slice Troubleshooting, About AetherSDR, and the AI-assisted issue reporter now use the shared `PersistentDialog` pattern, while transient confirmations and result prompts use a new `FramelessMessageBox`. Existing content, modality, menu organization, and workflows are preserved; open windows respond to runtime Frameless Window toggles, and substantial dialogs persist their geometry through `AppSettings`.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. Every Help-menu window was exercised through the automation bridge in framed and frameless modes, including runtime chrome toggling, modal-dialog lifetime, and safe inspection of Reset Settings and File an Issue prompts.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug — N/A; verified each Help-menu action directly

Additional validation:

- `python3 tools/check_a11y.py` — 0 findings across the eight affected GUI files
- `python3 tools/check_engine_boundary.py --strict` — 0 blocking findings
- `git diff --check`
- Automation bridge verified all six offline Help guides, What's New, Support & Diagnostics, Slice Troubleshooting, About AetherSDR, Submit your Idea, File an Issue, Reset Settings, and Check for Updates
- Automation bridge verified framed and frameless first-open behavior, runtime chrome toggling, modal-dialog lifetime, and geometry persistence
- Local red-team review completed with no blocking or non-blocking findings

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — geometry persistence is encapsulated by the established `PersistentDialog` pattern
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — no meter UI changed
- [x] Documentation updated if user-visible behavior changed — existing dialog-pattern documentation already defines the implemented behavior
- [x] Security-sensitive changes reference a GHSA if applicable — N/A
