### PR TITLE
aetherd: amp/tuner ENCODE via the seam — neutral intents → FlexBackend invokeExtension (#4092, #4094)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2692,6 +2692,12 @@ target_link_libraries(aetherd_tuner_decode_test PRIVATE aethercore Qt6::Core Qt6
 set_target_properties(aetherd_tuner_decode_test PROPERTIES AUTOMOC ON)
 add_test(NAME aetherd_tuner_decode_test COMMAND aetherd_tuner_decode_test)
 
+add_executable(aetherd_amp_tuner_encode_test tests/aetherd_amp_tuner_encode_test.cpp)
+target_include_directories(aetherd_amp_tuner_encode_test PRIVATE src)
+target_link_libraries(aetherd_amp_tuner_encode_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherd_amp_tuner_encode_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherd_amp_tuner_encode_test COMMAND aetherd_amp_tuner_encode_test)
+
 add_executable(usb_cable_model_test
     tests/usb_cable_model_test.cpp
     src/models/UsbCableModel.cpp

--- a/src/core/backends/AmpDelta.h
+++ b/src/core/backends/AmpDelta.h
@@ -17,8 +17,9 @@ namespace AetherSDR {
 //
 // The decode is stateless: it carries what the wire reported (a detected power-amp
 // model, its ip, the derived operate flag, the raw telemetry). The model decides
-// what to do with it. Command/encode is NOT here — that stays AmpModel::setOperate
-// → commandReady until the seam gains an encode path (invokeExtension; step 3).
+// what to do with it. Command/encode is NOT here — AmpModel::setOperate emits the
+// neutral operateRequested intent, translated back to the wire by
+// FlexBackend::invokeExtension("flex", "amp.operate", …) (#4094).
 struct AmpDelta {
     QString handle;                        // amplifier handle from the status object
     bool    removed{false};                // "amplifier <handle> removed"

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -129,14 +129,16 @@ signals:
 
     // Normalized power-amplifier status delta (aetherd 2.4 — AmpModel decode
     // split, #4094). Typed + present-only; the backend translates the SmartSDR
-    // "amplifier" wire and AmpModel applies the state machine. Command/encode
-    // stays AmpModel::commandReady until the seam gains an encode path (step 3).
+    // "amplifier" wire and AmpModel applies the state machine. Command/encode is
+    // the neutral AmpModel::operateRequested intent, translated back to the wire
+    // by invokeExtension("flex", "amp.operate", …) (#4094).
     void amplifierChanged(const AmpDelta& delta);
 
     // Normalized antenna-tuner status delta (aetherd 2.4 — TunerModel decode
     // split, #4092). Typed + present-only; the backend translates the SmartSDR
     // "atu"/"amplifier"(TunerGeniusXL) wire, TunerModel applies the change-gated
-    // state. Command/encode stays TunerModel::commandReady until step 3.
+    // state. Command/encode is TunerModel's neutral operate/bypass/autotune
+    // intents, translated by invokeExtension("flex", "tuner.*", …) (#4092).
     void tunerChanged(const TunerDelta& delta);
 
     // Normalized radio-global status delta (aetherd RFC 2.3 — RadioModel

--- a/src/core/backends/TunerDelta.h
+++ b/src/core/backends/TunerDelta.h
@@ -13,9 +13,10 @@ namespace AetherSDR {
 // applyChanges applies exactly the reported fields (change-gated, with the
 // tuning/antenna edge signals). Same contract as the sub-model deltas.
 //
-// Command/encode (operate/bypass/autotune/relay) is NOT here — that stays
-// TunerModel::commandReady until the seam gains an encode path (invokeExtension;
-// step 3). The direct-connection fwd-power/SWR meters are set outside this decode.
+// Command/encode (operate/bypass/autotune) is NOT here — TunerModel emits neutral
+// intents, translated back to the wire by FlexBackend::invokeExtension("flex",
+// "tuner.*", …) (#4092). The direct port-9010 relay/antenna fast-path and the
+// direct-connection fwd-power/SWR meters are set outside this decode.
 struct TunerDelta {
     std::optional<QString> serialNum;    // "serial_num"
     std::optional<QString> model;

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -131,11 +131,11 @@ RadioCapabilities FlexBackend::capabilities() const
     caps.canTransmit = true;
     caps.hasTuner = true;
 
-    // Advertise NO extension namespaces yet: no flex verb is routed through the
-    // seam, and invokeExtension() can't produce a reply. Advertising "flex"
-    // would let a client pre-check the namespace and then hang awaiting an
-    // extensionResult/Error that never comes. "flex" is declared here when the
-    // first amp/tuner/DAX verb converts.
+    // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
+    // autotune verbs are now routed through invokeExtension() (#4092/#4094), and
+    // it honors the async contract — an awaited call (requestId != 0) always
+    // gets exactly one extensionResult/Error, never a hang.
+    caps.extensionNamespaces << QStringLiteral("flex");
     return caps;
 }
 
@@ -183,17 +183,49 @@ void FlexBackend::setKeying(bool key)
     send(QStringLiteral("xmit %1").arg(key ? 1 : 0));
 }
 
-void FlexBackend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
-                                  quint64 requestId, const QVariant& /*arg*/)
+void FlexBackend::invokeExtension(const QString& ns, const QString& verb,
+                                  quint64 requestId, const QVariant& arg)
 {
-    // No flex extension verbs are routed through the seam yet. Honor the async
-    // contract by construction: a caller awaiting a reply (requestId != 0) gets
-    // an error, never a hang. Real verbs land with the amp/tuner/DAX touchpoint
-    // conversions.
-    if (requestId != 0) {
-        emit extensionError(requestId,
-                            QStringLiteral("flex: no extension verbs implemented"));
+    // Translate a neutral amp/tuner intent (#4092/#4094) into the SmartSDR relay
+    // wire. The device object handle is a Flex detail carried in the vendor arg
+    // (supplied by RadioModel, which owns handle extraction). Async contract: an
+    // awaited call (requestId != 0) gets exactly one reply, never a hang.
+    const auto fail = [&](const QString& why) {
+        if (requestId != 0)
+            emit extensionError(requestId, why);
+    };
+    if (ns != QLatin1String("flex")) {
+        fail(QStringLiteral("unknown extension namespace: %1").arg(ns));
+        return;
     }
+
+    const QVariantMap a = arg.toMap();
+    const QString handle = a.value(QStringLiteral("handle")).toString();
+    const bool on = a.value(QStringLiteral("on")).toBool();
+    QString cmd;
+    if (verb == QLatin1String("amp.operate")) {
+        if (handle.isEmpty()) { fail(QStringLiteral("flex amp.operate: no handle")); return; }
+        cmd = QStringLiteral("amplifier set %1 operate=%2").arg(handle).arg(on ? 1 : 0);
+    } else if (verb == QLatin1String("tuner.operate")) {
+        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.operate: no handle")); return; }
+        cmd = QStringLiteral("tgxl set handle=%1 mode=%2").arg(handle).arg(on ? 1 : 0);
+    } else if (verb == QLatin1String("tuner.bypass")) {
+        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.bypass: no handle")); return; }
+        cmd = QStringLiteral("tgxl set handle=%1 bypass=%2").arg(handle).arg(on ? 1 : 0);
+    } else if (verb == QLatin1String("tuner.autotune")) {
+        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.autotune: no handle")); return; }
+        cmd = QStringLiteral("tgxl autotune handle=%1").arg(handle);
+    } else {
+        fail(QStringLiteral("unknown flex verb: %1").arg(verb));
+        return;
+    }
+
+    send(cmd);
+    // Fire-and-forget on the wire: the real device state returns asynchronously
+    // via the amplifier/tgxl status decode. Acknowledge dispatch so an awaiting
+    // caller (requestId != 0) completes; our own RadioModel routes pass 0.
+    if (requestId != 0)
+        emit extensionResult(requestId, QVariant(true));
 }
 
 void FlexBackend::decodePanCenterBandwidth(const QString& panId,
@@ -660,7 +692,8 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
     // Stateless translation of the SmartSDR "amplifier <handle> …" wire → AmpDelta
     // (#4094). The presence latch, operate change-gating, and handle matching are
     // the model's job (AmpModel::applyChanges) — this only reports what the wire
-    // said. Command/encode is not here (stays AmpModel::commandReady, step 3).
+    // said. Command/encode is the reverse path — invokeExtension("flex",
+    // "amp.operate", …) below translates AmpModel's neutral intent (#4094).
     AmpDelta d;
     d.handle = handle;
     if (removed) {

--- a/src/models/AmpModel.cpp
+++ b/src/models/AmpModel.cpp
@@ -50,10 +50,11 @@ void AmpModel::reset()
 
 void AmpModel::setOperate(bool on)
 {
-    if (m_handle.isEmpty()) return;
-    // FlexLib API: "amplifier set <handle> operate=0|1". The radio relays it to
-    // the PGXL (the only path that works remote/SmartLink).
-    emit commandReady(QString("amplifier set %1 operate=%2").arg(m_handle).arg(on ? 1 : 0));
+    if (m_handle.isEmpty()) return;   // no amp present → nothing to command
+    // Neutral intent. FlexBackend translates it to "amplifier set <handle>
+    // operate=0|1" (radio-relayed — the only path that works remote/SmartLink);
+    // the handle is supplied by RadioModel via invokeExtension's vendor arg.
+    emit operateRequested(on);
 }
 
 }  // namespace AetherSDR

--- a/src/models/AmpModel.h
+++ b/src/models/AmpModel.h
@@ -12,13 +12,13 @@ namespace AetherSDR {
 // API (today: 4O3A Power Genius XL / PGXL — any non-TGXL amp the radio proxies).
 // Extracted from RadioModel (#4094).
 //
-// Intended to become vendor-neutral: it holds the universal amp state
-// (presence / operate / telemetry) and, for now, encapsulates the Flex
-// "amplifier set … operate=" relay by emitting commandReady (the same pattern
-// TunerModel uses). That relay is RADIO-PROXIED and is the ONLY path that works
-// for remote/SmartLink operation — the direct PgxlConnection (port 9008) is
-// telemetry-only. A later split moves the Flex decode/encode behind FlexBackend
-// as an IRadioBackend extension verb (see #4094); until then this is mixed(flex).
+// Vendor-neutral: it holds the universal amp state (presence / operate /
+// telemetry) and emits a neutral operate *intent* — it builds no SmartSDR
+// strings. FlexBackend translates the intent into the radio-proxied
+// "amplifier set … operate=" relay via its invokeExtension("flex", …) path
+// (#4094); that relay is the ONLY path that works for remote/SmartLink (the
+// direct PgxlConnection on port 9008 is telemetry-only). The Flex handle is a
+// backend detail supplied by RadioModel through invokeExtension's vendor arg.
 class AmpModel : public QObject {
     Q_OBJECT
 
@@ -39,15 +39,18 @@ public:
     // Bulk clear on radio disconnect/teardown (matches RadioModel's prior reset).
     void reset();
 
-    // Operate/standby command. Emits commandReady with the SmartSDR verb, which
-    // the radio relays (the path that works remote). No-op without a handle.
+    // Operate/standby command. Emits the neutral operateRequested intent, which
+    // RadioModel routes to FlexBackend for wire translation. No-op without a
+    // handle (i.e. no amp present).
     void setOperate(bool on);
 
 signals:
     void presenceChanged(bool present);                       // amp detected / lost
     void stateChanged();                                      // operate changed
     void telemetryUpdated(const QMap<QString, QString>& kvs); // raw amp KVS for the GUI
-    void commandReady(const QString& cmd);                    // → radio command sink
+    // Neutral operate intent (on/off). RadioModel translates it to the Flex
+    // "amplifier set <handle> operate=" wire via IRadioBackend::invokeExtension.
+    void operateRequested(bool on);
 
 private:
     bool    m_present{false};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -642,15 +642,31 @@ RadioModel::RadioModel(QObject* parent)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
 
-    // Forward tuner commands to the radio — route through tune inhibit check
-    connect(&m_tunerModel, &TunerModel::commandReady, this, [this](const QString& cmd){
-        if (cmd.startsWith("tgxl autotune")) {
-            if (transmitStartBlockedByInhibit(QStringLiteral("tgxl-autotune"))) {
-                return;
-            }
-            applyTuneInhibit();
-        }
-        sendCmd(cmd);
+    // Route tuner relay intents to the radio through the backend seam (#4092).
+    // The model emits neutral intents; FlexBackend translates them to the SmartSDR
+    // "tgxl …" wire. The handle is a Flex detail carried in invokeExtension's
+    // vendor arg (RadioModel owns handle extraction). The direct port-9010
+    // fast-path stays inside TunerModel and never reaches here.
+    connect(&m_tunerModel, &TunerModel::operateRequested, this, [this](bool on){
+        if (m_backend)
+            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.operate"), 0,
+                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()},
+                                                   {QStringLiteral("on"), on}});
+    });
+    connect(&m_tunerModel, &TunerModel::bypassRequested, this, [this](bool on){
+        if (m_backend)
+            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.bypass"), 0,
+                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()},
+                                                   {QStringLiteral("on"), on}});
+    });
+    connect(&m_tunerModel, &TunerModel::autotuneRequested, this, [this](){
+        // TX interlock gate (was a commandReady string-sniff on "tgxl autotune").
+        if (transmitStartBlockedByInhibit(QStringLiteral("tgxl-autotune")))
+            return;
+        applyTuneInhibit();
+        if (m_backend)
+            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.autotune"), 0,
+                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()}});
     });
 
     // Forward DAX IQ commands to the radio
@@ -658,10 +674,14 @@ RadioModel::RadioModel(QObject* parent)
         sendCmd(cmd);
     });
 
-    // Forward amplifier (PGXL) commands to the radio — the radio relays "amplifier
-    // set … operate=" to the amp (the path that works remote/SmartLink). #4094.
-    connect(&m_amplifier, &AmpModel::commandReady, this, [this](const QString& cmd){
-        sendCmd(cmd);
+    // Route amplifier (PGXL) operate intent to the radio through the backend seam
+    // (#4094). FlexBackend relays "amplifier set … operate=" to the amp (the path
+    // that works remote/SmartLink); the handle rides in invokeExtension's vendor arg.
+    connect(&m_amplifier, &AmpModel::operateRequested, this, [this](bool on){
+        if (m_backend)
+            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("amp.operate"), 0,
+                                       QVariantMap{{QStringLiteral("handle"), m_amplifier.handle()},
+                                                   {QStringLiteral("on"), on}});
     });
     // Protocol-log breadcrumb on amp detection, symmetric with the "amplifier
     // removed" log — kept here so AmpModel stays logging-category-free. #4099.

--- a/src/models/TunerModel.cpp
+++ b/src/models/TunerModel.cpp
@@ -68,9 +68,8 @@ void TunerModel::setOperate(bool on)
         qCDebug(lcTuner) << "TunerModel::setOperate: no handle yet, ignoring";
         return;
     }
-    const QString cmd = "tgxl set handle=" + m_handle + " mode=" + (on ? "1" : "0");
-    qCDebug(lcTuner) << "TunerModel:" << cmd;
-    emit commandReady(cmd);
+    // Neutral intent → Flex "tgxl set handle=<h> mode=" wire (via RadioModel).
+    emit operateRequested(on);
     // Optimistic update: reflect the commanded state immediately so the
     // button label stays in sync even before the radio echoes back.
     if (m_operate != on) { m_operate = on; emit stateChanged(); }
@@ -82,9 +81,8 @@ void TunerModel::setBypass(bool on)
         qCDebug(lcTuner) << "TunerModel::setBypass: no handle yet, ignoring";
         return;
     }
-    const QString cmd = "tgxl set handle=" + m_handle + " bypass=" + (on ? "1" : "0");
-    qCDebug(lcTuner) << "TunerModel:" << cmd;
-    emit commandReady(cmd);
+    // Neutral intent → Flex "tgxl set handle=<h> bypass=" wire (via RadioModel).
+    emit bypassRequested(on);
     // Optimistic update: reflect the commanded state immediately so the
     // button label stays in sync even before the radio echoes back.
     if (m_bypass != on) { m_bypass = on; emit stateChanged(); }
@@ -105,9 +103,9 @@ void TunerModel::autoTune()
         qCDebug(lcTuner) << "TunerModel::autoTune: no direct conn and no handle, ignoring";
         return;
     }
-    const QString cmd = "tgxl autotune handle=" + m_handle;
-    qCDebug(lcTuner) << "TunerModel:" << cmd;
-    emit commandReady(cmd);
+    // Neutral intent → Flex "tgxl autotune handle=<h>" wire. RadioModel applies
+    // the TX interlock gate before dispatching (was a commandReady string-sniff).
+    emit autotuneRequested();
 }
 
 void TunerModel::setAntennaA(int ant)

--- a/src/models/TunerModel.h
+++ b/src/models/TunerModel.h
@@ -58,7 +58,10 @@ public:
     // Manual relay adjustment: relay 0=C1, 1=L, 2=C2; direction +1 or -1
     void adjustRelay(int relay, int direction);
 
-    // Command methods — emit commandReady()
+    // Command methods — emit neutral intents (operate/bypass/autotune) that
+    // RadioModel translates to the Flex TGXL relay via invokeExtension. The
+    // direct port-9010 fast-path (autoTune when a direct conn is up, and the
+    // antenna/relay methods below) stays local and does not go through the seam.
     void setOperate(bool on);
     void setBypass(bool on);
     void autoTune();
@@ -73,7 +76,13 @@ signals:
     void metersChanged(float fwdPower, float swr);  // fwd power/SWR from direct TGXL
     void presenceChanged(bool present); // tuner detected / lost
     void directConnectionChanged(bool connected);
-    void commandReady(const QString& cmd);
+    // Neutral relay intents. RadioModel translates each to the Flex TGXL wire
+    // ("tgxl set handle=<h> mode=/bypass=", "tgxl autotune handle=<h>") via
+    // IRadioBackend::invokeExtension. autotuneRequested also carries the TX
+    // interlock gate in RadioModel (was a commandReady string-sniff).
+    void operateRequested(bool on);
+    void bypassRequested(bool on);
+    void autotuneRequested();
 
 private:
     QString m_handle;

--- a/tests/aetherd_amp_tuner_encode_test.cpp
+++ b/tests/aetherd_amp_tuner_encode_test.cpp
@@ -1,0 +1,117 @@
+// aetherd #4092 / #4094 — ENCODE side. FlexBackend::invokeExtension translates
+// the neutral amp/tuner intents (operate/bypass/autotune) into the SmartSDR
+// relay wire, advertises the "flex" extension namespace, and honors the async
+// contract (an awaited call always gets exactly one extensionResult/Error).
+// Companion to the decode tests (aetherd_amp_decode_test / aetherd_tuner_decode_test).
+
+#include "core/backends/flex/FlexBackend.h"
+#include "core/backends/RadioCapabilities.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QStringList>
+#include <QVariant>
+#include <QVariantMap>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+static void check(bool cond, const char* what)
+{
+    if (!cond) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+// The vendor arg RadioModel supplies: the Flex object handle + the on/off value.
+static QVariant arg(const QString& handle, bool on)
+{
+    QVariantMap m;
+    m[QStringLiteral("handle")] = handle;
+    m[QStringLiteral("on")] = on;
+    return m;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // ---- capabilities advertises the flex namespace now that verbs route ----
+    {
+        FlexBackend b;
+        check(b.capabilities().extensionNamespaces.contains(QStringLiteral("flex")),
+              "capabilities() does not advertise the flex extension namespace");
+    }
+
+    // ---- each verb translates to the exact SmartSDR relay string ----
+    {
+        FlexBackend b;
+        QStringList sent;
+        b.setCommandSink([&](const QString& c) { sent << c; });
+
+        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", true));
+        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", false));
+        b.invokeExtension("flex", "tuner.operate", 0, arg("0x2000", true));
+        b.invokeExtension("flex", "tuner.operate", 0, arg("0x2000", false));
+        b.invokeExtension("flex", "tuner.bypass", 0, arg("0x2000", true));
+        b.invokeExtension("flex", "tuner.autotune", 0, arg("0x2000", false));
+
+        check(sent.size() == 6, "expected 6 wire commands");
+        check(sent.value(0) == "amplifier set 0x1000 operate=1", "amp.operate=1 wire");
+        check(sent.value(1) == "amplifier set 0x1000 operate=0", "amp.operate=0 wire");
+        check(sent.value(2) == "tgxl set handle=0x2000 mode=1", "tuner.operate=1 wire (mode=)");
+        check(sent.value(3) == "tgxl set handle=0x2000 mode=0", "tuner.operate=0 wire");
+        check(sent.value(4) == "tgxl set handle=0x2000 bypass=1", "tuner.bypass wire");
+        check(sent.value(5) == "tgxl autotune handle=0x2000", "tuner.autotune wire");
+    }
+
+    // ---- async contract: an awaited call gets exactly one reply ----
+    {
+        FlexBackend b;
+        QStringList sent;
+        b.setCommandSink([&](const QString& c) { sent << c; });
+        QSignalSpy okSpy(&b, &FlexBackend::extensionResult);
+        QSignalSpy errSpy(&b, &FlexBackend::extensionError);
+
+        // success + requestId != 0 → one extensionResult carrying the id, wire sent
+        b.invokeExtension("flex", "amp.operate", 42, arg("0x1000", true));
+        check(sent.size() == 1, "awaited success still sends the wire command");
+        check(okSpy.count() == 1 && errSpy.count() == 0,
+              "awaited success emits exactly one extensionResult");
+        check(okSpy.takeFirst().at(0).toULongLong() == 42u,
+              "extensionResult correlates the requestId");
+
+        // fire-and-forget (requestId 0) success → no reply signal at all
+        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", true));
+        check(okSpy.count() == 0 && errSpy.count() == 0,
+              "requestId 0 success emits no reply");
+    }
+
+    // ---- error paths: unknown ns / verb / missing handle → error, no wire ----
+    {
+        FlexBackend b;
+        QStringList sent;
+        b.setCommandSink([&](const QString& c) { sent << c; });
+        QSignalSpy errSpy(&b, &FlexBackend::extensionError);
+
+        b.invokeExtension("bogus", "amp.operate", 7, arg("0x1000", true));   // unknown ns
+        b.invokeExtension("flex", "amp.bogus", 8, arg("0x1000", true));       // unknown verb
+        b.invokeExtension("flex", "amp.operate", 9, arg("", true));           // no handle
+        b.invokeExtension("flex", "tuner.autotune", 10, arg("", false));      // no handle
+        check(sent.isEmpty(), "error paths send no wire command");
+        check(errSpy.count() == 4, "each awaited error emits exactly one extensionError");
+
+        // the same failures, fire-and-forget → silent (no hang, no stray reply)
+        errSpy.clear();
+        b.invokeExtension("flex", "amp.bogus", 0, arg("0x1000", true));
+        b.invokeExtension("flex", "amp.operate", 0, arg("", true));
+        check(errSpy.count() == 0, "requestId 0 errors stay silent");
+    }
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "aetherd_amp_tuner_encode_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/amp_model_test.cpp
+++ b/tests/amp_model_test.cpp
@@ -114,18 +114,20 @@ int main(int argc, char** argv)
         CHECK(presence.count() == 1 && presence.takeFirst().at(0).toBool() == false);
     }
 
-    // ---- setOperate relays the SmartSDR verb; no-op without a handle ----
+    // ---- setOperate emits the neutral operate intent; no-op without a handle ----
+    // The SmartSDR string is FlexBackend's job now (#4094); the model only signals
+    // operate on/off. (See aetherd_amp_encode_test for the wire translation.)
     {
         AmpModel amp;
-        QSignalSpy cmd(&amp, &AmpModel::commandReady);
-        amp.setOperate(true);                         // no handle yet
-        CHECK(cmd.count() == 0);
+        QSignalSpy req(&amp, &AmpModel::operateRequested);
+        amp.setOperate(true);                         // no handle yet → no intent
+        CHECK(req.count() == 0);
         amp.applyChanges(detected("0x1000", "PowerGeniusXL", "", false));
         amp.setOperate(true);
-        CHECK(cmd.count() == 1);
-        CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=1");
+        CHECK(req.count() == 1);
+        CHECK(req.takeFirst().at(0).toBool() == true);
         amp.setOperate(false);
-        CHECK(cmd.takeFirst().at(0).toString() == "amplifier set 0x1000 operate=0");
+        CHECK(req.takeFirst().at(0).toBool() == false);
     }
 
     // ---- reset clears present/handle/operate ----

--- a/tests/tuner_model_test.cpp
+++ b/tests/tuner_model_test.cpp
@@ -64,6 +64,32 @@ int main(int argc, char** argv)
         CHECK(!t.isTuning() && tun.count() == 1 && tun.takeFirst().at(0).toBool() == false);
     }
 
+    // ---- encode: neutral relay intents; no-op without a handle (#4092) ----
+    // The model emits vendor-neutral intents (no SmartSDR strings); FlexBackend
+    // translates them — see aetherd_amp_tuner_encode_test for the wire form.
+    {
+        TunerModel t;
+        QSignalSpy op(&t, &TunerModel::operateRequested);
+        QSignalSpy by(&t, &TunerModel::bypassRequested);
+        QSignalSpy at(&t, &TunerModel::autotuneRequested);
+
+        // No handle yet (no direct conn) → every relay verb is a no-op.
+        t.setOperate(true); t.setBypass(true); t.autoTune();
+        CHECK(op.count() == 0 && by.count() == 0 && at.count() == 0);
+
+        t.setHandle("0x2000");
+        QSignalSpy st(&t, &TunerModel::stateChanged);
+
+        t.setOperate(true);
+        CHECK(op.count() == 1 && op.takeFirst().at(0).toBool() == true);
+        CHECK(t.isOperate() && st.count() == 1);          // optimistic state update
+        t.setBypass(true);
+        CHECK(by.count() == 1 && by.takeFirst().at(0).toBool() == true);
+        CHECK(t.isBypass() && st.count() == 2);
+        t.autoTune();                                      // no direct conn → relay intent
+        CHECK(at.count() == 1);
+    }
+
     if (g_failures == 0) {
         std::printf("tuner_model_test: all checks passed\n");
         return 0;


### PR DESCRIPTION
Closes the **ENCODE half** of #4092 (TunerModel) and #4094 (AmpModel). The decode half already landed (#4101/#4113); this makes both models genuinely vendor-neutral by moving the SmartSDR command-string building behind the `IRadioBackend` extension-verb seam.

## What changes

The models emit **neutral intents** instead of SmartSDR strings; `FlexBackend::invokeExtension("flex", …)` translates them back to the wire.

| Layer | Before | After |
|---|---|---|
| `AmpModel` / `TunerModel` | built `"amplifier set…"` / `"tgxl set…"` via `commandReady` | emit `operateRequested` / `bypassRequested` / `autotuneRequested` |
| `FlexBackend::invokeExtension` | stub (errored on await) | real body → exact wire strings; `capabilities()` advertises the `"flex"` namespace |
| `RadioModel` | `commandReady → sendCmd` | `intent → m_backend->invokeExtension("flex", …)` |

## Design decisions

- **The Flex handle stays a vendor detail** — it rides in `invokeExtension`'s vendor `arg` (the channel `IRadioBackend.h` designates for exactly this), supplied by RadioModel which already owns handle extraction. The models carry **zero** Flex identifiers — the core acceptance criterion. (Moving handle *ownership/extraction* into FlexBackend is a follow-up; it's a decode-side routing concern, deliberately out of scope here.)
- **Async contract honored** — an awaited call (`requestId != 0`) gets exactly one `extensionResult`/`extensionError`, never a hang. Our RadioModel routes pass `0` (fire-and-forget, matching the prior `commandReady→sendCmd` semantics — the real device state returns via the status decode).
- **TX-inhibit interlock** migrated from a `cmd.startsWith("tgxl autotune")` string-sniff to a clean verb check on the `autotuneRequested` connection.
- **Direct port-9010 tuner fast-path untouched** — autotune-when-direct, `setAntennaA`, and `adjustRelay` stay local and never go through the seam.
- Stale "stays commandReady until step 3" comments updated across `IRadioBackend`/`AmpDelta`/`TunerDelta`/`FlexBackend`.

## Acceptance criteria (both issues)

- ✅ `AmpModel`/`TunerModel` emit no SmartSDR strings and read no raw amp kvs — only neutral state/intents.
- ✅ The Flex amplifier/tuner encode lives in `FlexBackend`.
- ✅ Operate/bypass/autotune work local (direct fast-path preserved) **and** remote (radio relay via the seam).
- ✅ Existing tests pass; `check_engine_boundary.py --strict` clean.

## Tests

- **New `aetherd_amp_tuner_encode_test`** — exact wire strings for all four verbs, async-contract replies (awaited → one reply; `requestId 0` → silent), unknown-ns/verb/no-handle → `extensionError` + no wire, and the `"flex"` capability.
- `amp_model_test` re-pointed from the `commandReady` string to `operateRequested`.
- `tuner_model_test` gains encode coverage (it had none): neutral intents fire, no-handle guard, optimistic `stateChanged`.
- **83/83 ctest pass**; full build clean; `--strict` clean (no new vendor includes — coupling *reduced*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)