### PR TITLE
chore: surface Aether-gate + auto-mirror it under the org

### DIFF
--- a/.github/workflows/mirror-aether-gate.yml
+++ b/.github/workflows/mirror-aether-gate.yml
@@ -1,0 +1,47 @@
+name: Mirror Aether-gate
+
+# Keeps the org's copy (aethersdr/Aether-gate) fast-forwarded from its upstream,
+# nigelfenton/Aether-gate, so it stays a current, byte-identical mirror. The
+# mirror content is never modified here — this workflow only pulls upstream into
+# the fork's default branch.
+#
+# Cadence: scheduled runs are best-effort (GitHub can delay or skip them under
+# load), so this is "near-real-time," not instantaneous. Dial the cron below if
+# you want it more/less frequent. True real-time would require an upstream push
+# webhook, which needs the upstream owner's cooperation.
+#
+# Auth: syncing another repo needs write access to it, which the default
+# GITHUB_TOKEN does not have. Add a fine-grained PAT with **Contents: read/write
+# on aethersdr/Aether-gate** as the repo secret MIRROR_SYNC_TOKEN. Until that
+# secret exists the job no-ops (it does not fail), so it won't spam failures.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 min (best-effort; not exact)
+  workflow_dispatch: {}       # manual "sync now" button
+
+# We authenticate with MIRROR_SYNC_TOKEN, not GITHUB_TOKEN — drop all default perms.
+permissions: {}
+
+concurrency:
+  group: mirror-aether-gate
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fast-forward aethersdr/Aether-gate from upstream
+        env:
+          GH_TOKEN: ${{ secrets.MIRROR_SYNC_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "MIRROR_SYNC_TOKEN is not set."
+            echo "Add a fine-grained PAT (Contents: read/write on aethersdr/Aether-gate)"
+            echo "as the MIRROR_SYNC_TOKEN secret to enable auto-sync. Skipping."
+            exit 0
+          fi
+          gh repo sync aethersdr/Aether-gate \
+            --source nigelfenton/Aether-gate \
+            --branch main \
+            --force

--- a/README.md
+++ b/README.md
@@ -249,6 +249,21 @@ PRs, bug reports, and feature requests welcome! See [CONTRIBUTING.md](CONTRIBUTI
 
 ---
 
+## Related projects
+
+- **[Aether-gate](https://github.com/aethersdr/Aether-gate)** — put *any* radio into
+  AetherSDR. A bridge that presents an Icom/Kenwood/Yaesu/Elecraft CAT rig (via
+  [Hamlib](https://hamlib.github.io/)), an Icom LAN rig, or a SoapySDR dongle to
+  AetherSDR as if it were a FlexRadio — live panadapter, waterfall, and
+  frequency/mode control. Receive + control today (no transmit yet). By Nigel
+  Fenton (G0JKN); GPL-3.0-or-later. *(`aethersdr/Aether-gate` tracks upstream
+  [nigelfenton/Aether-gate](https://github.com/nigelfenton/Aether-gate).)*
+
+AetherSDR integrates radios that earn deep native support directly in-engine; the
+gate covers the long tail of legacy/CAT radios and dongles.
+
+---
+
 ## Verifying Downloads
 
 Linux and Windows binaries are GPG-signed. macOS artifacts are Apple notarized. Each release includes `.asc` signatures and `SHA256SUMS.txt`.


### PR DESCRIPTION
Extends the visibility of **[Aether-gate](https://github.com/nigelfenton/Aether-gate)** (Nigel Fenton / G0JKN, GPL-3.0) — the "put any radio into AetherSDR" bridge — and keeps an org copy auto-updated from upstream. **Nothing on the upstream repo is changed.**

## What's here

1. **README "Related projects" section** linking `aethersdr/Aether-gate` (a fork/mirror of upstream), with the routing rule per the [aetherd-vs-gate split](https://github.com/aethersdr/AetherSDR): native in-engine support for first-class radios, the gate for the long tail of legacy/CAT rigs and dongles.
2. **`.github/workflows/mirror-aether-gate.yml`** — a scheduled (~15 min, best-effort) + manual-dispatch job that **fast-forwards `aethersdr/Aether-gate` from `nigelfenton/Aether-gate`**. The mirror stays byte-identical (force fast-forward only; nothing is committed to it).

## Fork vs. mirror (why the workflow)

A GitHub fork is a one-time copy — it does **not** auto-update. `aethersdr/Aether-gate` was forked so it's a discoverable first-party copy; this workflow is what keeps it *current*. Note "real-time" is best-effort periodic (scheduled runs can be delayed); true real-time would need an upstream push webhook, which requires the upstream owner's cooperation.

## ⚠️ One manual step to activate the auto-sync

The default `GITHUB_TOKEN` can't write to another repo, so the workflow needs a **fine-grained PAT** with **Contents: read/write on `aethersdr/Aether-gate`**, added as the repo secret **`MIRROR_SYNC_TOKEN`**. Until that secret exists the job **no-ops** (it prints how to set it and exits 0 — no failure spam). After adding it, use *Actions → Mirror Aether-gate → Run workflow* to test.

Scope: docs + one workflow. No engine/build/source change; nothing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)