### PR TITLE
aetherd: move amp/tuner encode handle ownership into FlexBackend (closes #4198)

### DIFF
--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -214,9 +214,10 @@ void FlexBackend::invokeExtension(const QString& ns, const QString& verb,
                                   quint64 requestId, const QVariant& arg)
 {
     // Translate a neutral amp/tuner intent (#4092/#4094) into the SmartSDR relay
-    // wire. The device object handle is a Flex detail carried in the vendor arg
-    // (supplied by RadioModel, which owns handle extraction). Async contract: an
-    // awaited call (requestId != 0) gets exactly one reply, never a hang.
+    // wire. The device object handle is a Flex detail resolved from this backend's
+    // own decode-side state (m_ampHandle/m_tunerHandle, #4198) — the intent no
+    // longer carries it. Async contract: an awaited call (requestId != 0) gets
+    // exactly one reply, never a hang.
     const auto fail = [&](const QString& why) {
         if (requestId != 0)
             emit extensionError(requestId, why);
@@ -226,22 +227,20 @@ void FlexBackend::invokeExtension(const QString& ns, const QString& verb,
         return;
     }
 
-    const QVariantMap a = arg.toMap();
-    const QString handle = a.value(QStringLiteral("handle")).toString();
-    const bool on = a.value(QStringLiteral("on")).toBool();
+    const bool on = arg.toMap().value(QStringLiteral("on")).toBool();
     QString cmd;
     if (verb == QLatin1String("amp.operate")) {
-        if (handle.isEmpty()) { fail(QStringLiteral("flex amp.operate: no handle")); return; }
-        cmd = QStringLiteral("amplifier set %1 operate=%2").arg(handle).arg(on ? 1 : 0);
+        if (m_ampHandle.isEmpty()) { fail(QStringLiteral("flex amp.operate: no amp handle")); return; }
+        cmd = QStringLiteral("amplifier set %1 operate=%2").arg(m_ampHandle).arg(on ? 1 : 0);
     } else if (verb == QLatin1String("tuner.operate")) {
-        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.operate: no handle")); return; }
-        cmd = QStringLiteral("tgxl set handle=%1 mode=%2").arg(handle).arg(on ? 1 : 0);
+        if (m_tunerHandle.isEmpty()) { fail(QStringLiteral("flex tuner.operate: no tuner handle")); return; }
+        cmd = QStringLiteral("tgxl set handle=%1 mode=%2").arg(m_tunerHandle).arg(on ? 1 : 0);
     } else if (verb == QLatin1String("tuner.bypass")) {
-        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.bypass: no handle")); return; }
-        cmd = QStringLiteral("tgxl set handle=%1 bypass=%2").arg(handle).arg(on ? 1 : 0);
+        if (m_tunerHandle.isEmpty()) { fail(QStringLiteral("flex tuner.bypass: no tuner handle")); return; }
+        cmd = QStringLiteral("tgxl set handle=%1 bypass=%2").arg(m_tunerHandle).arg(on ? 1 : 0);
     } else if (verb == QLatin1String("tuner.autotune")) {
-        if (handle.isEmpty()) { fail(QStringLiteral("flex tuner.autotune: no handle")); return; }
-        cmd = QStringLiteral("tgxl autotune handle=%1").arg(handle);
+        if (m_tunerHandle.isEmpty()) { fail(QStringLiteral("flex tuner.autotune: no tuner handle")); return; }
+        cmd = QStringLiteral("tgxl autotune handle=%1").arg(m_tunerHandle);
     } else {
         fail(QStringLiteral("unknown flex verb: %1").arg(verb));
         return;
@@ -725,10 +724,20 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
     AmpDelta d;
     d.handle = handle;
     if (removed) {
+        // Drop the cached handle for the encode path (#4198) when the device it
+        // names goes away. TGXL removal also arrives on the amplifier-removed
+        // wire (routed here by RadioModel), so clear whichever handle matches.
+        if (handle == m_ampHandle) m_ampHandle.clear();
+        if (handle == m_tunerHandle) m_tunerHandle.clear();
         d.removed = true;
         emit amplifierChanged(d);
         return;
     }
+    // RadioModel routes only power amps (PGXL) into this decode, so the handle is
+    // the amp's — cache it for the encode path (#4198). Ignore the placeholder
+    // handle a first status can carry before the real one is assigned.
+    if (!handle.isEmpty() && handle != QLatin1String("0x00000000"))
+        m_ampHandle = handle;
     // A non-empty, non-TGXL model marks a power amp (PGXL); the TunerGeniusXL is
     // the tuner and routes to TunerModel, not here.
     if (!model.isEmpty() && model != QLatin1String("TunerGeniusXL")) {
@@ -749,8 +758,13 @@ void FlexBackend::decodeAmplifierStatus(const QString& handle, const QString& mo
     emit amplifierChanged(d);
 }
 
-void FlexBackend::decodeTunerStatus(const QMap<QString, QString>& kvs)
+void FlexBackend::decodeTunerStatus(const QString& handle, const QMap<QString, QString>& kvs)
 {
+    // Cache the TGXL handle for the encode path (#4198). RadioModel passes the
+    // handle it already extracted+sanitized (never the 0x00000000 placeholder),
+    // so the tuner intents no longer carry a Flex identifier through the seam.
+    if (!handle.isEmpty() && handle != QLatin1String("0x00000000"))
+        m_tunerHandle = handle;
     // Present-only, strict parity with the prior TunerModel::applyStatus: bools
     // are "1"-equality, ints are unguarded toInt() (matching val.toInt()), text
     // is verbatim. The change-gating / edge signals live in TunerModel::applyChanges.
@@ -778,6 +792,14 @@ void FlexBackend::decodeTunerStatus(const QMap<QString, QString>& kvs)
     if (kvs.contains(QStringLiteral("one_by_three")))
         d.oneByThree = (kvs.value(QStringLiteral("one_by_three")) == QLatin1String("1"));
     emit tunerChanged(d);
+}
+
+void FlexBackend::clearExtensionHandles()
+{
+    // #4198: forget the amp/tuner encode handles on disconnect/reset so a stale
+    // handle can't survive into a reconnect (possibly a different radio).
+    m_ampHandle.clear();
+    m_tunerHandle.clear();
 }
 
 void FlexBackend::decodeApdStatus(const QMap<QString, QString>& kvs)

--- a/src/core/backends/flex/FlexBackend.h
+++ b/src/core/backends/flex/FlexBackend.h
@@ -135,7 +135,14 @@ public:
     // "amplifier <handle> model=TunerGeniusXL …" kv-sets) into a typed
     // TunerDelta and emit tunerChanged (aetherd 2.4 — TunerModel decode split,
     // #4092). Present-only, strict-parity with the prior TunerModel::applyStatus.
-    void decodeTunerStatus(const QMap<QString, QString>& kvs);
+    // `handle` is the (sanitized) TGXL object handle RadioModel extracted; it is
+    // cached here to source the tuner encode path (#4198).
+    void decodeTunerStatus(const QString& handle, const QMap<QString, QString>& kvs);
+    // Drop the cached amp/tuner encode handles (#4198). Called on radio
+    // disconnect/reset, where RadioModel clears the model-side presence outside
+    // the decode path — without this the stale handle could survive a reconnect
+    // to a *different* radio and be used to build a bogus relay command.
+    void clearExtensionHandles();
     void decodeApdSamplerStatus(const QMap<QString, QString>& kvs);
     // Decode the Flex GPS-status line ("gps …", '#'-separated key=value tokens)
     // into a present-only GpsDelta and emit gpsChanged (aetherd RFC 2.3 —
@@ -166,6 +173,14 @@ private:
     std::function<void(const QString&)> m_sink;
     std::function<void(const QString&)> m_sliceSink;
     std::function<QString()> m_modelProvider;
+
+    // Decode-side handle state (#4198). Captured from the amplifier/tgxl status
+    // decode and consumed by invokeExtension() to build the amp/tuner relay wire,
+    // so RadioModel no longer threads the Flex handle through the encode arg.
+    // Touched only on the main thread — both the decode (RadioModel::handleStatus)
+    // and the encode intent lambdas run there — so a plain QString needs no sync.
+    QString m_ampHandle;
+    QString m_tunerHandle;
 };
 
 }  // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -716,20 +716,18 @@ RadioModel::RadioModel(QObject* parent)
 
     // Route tuner relay intents to the radio through the backend seam (#4092).
     // The model emits neutral intents; FlexBackend translates them to the SmartSDR
-    // "tgxl …" wire. The handle is a Flex detail carried in invokeExtension's
-    // vendor arg (RadioModel owns handle extraction). The direct port-9010
+    // "tgxl …" wire, resolving the TGXL handle from its own decode-side state
+    // (#4198) — the intent carries no Flex identifier. The direct port-9010
     // fast-path stays inside TunerModel and never reaches here.
     connect(&m_tunerModel, &TunerModel::operateRequested, this, [this](bool on){
         if (m_backend)
             m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.operate"), 0,
-                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()},
-                                                   {QStringLiteral("on"), on}});
+                                       QVariantMap{{QStringLiteral("on"), on}});
     });
     connect(&m_tunerModel, &TunerModel::bypassRequested, this, [this](bool on){
         if (m_backend)
             m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.bypass"), 0,
-                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()},
-                                                   {QStringLiteral("on"), on}});
+                                       QVariantMap{{QStringLiteral("on"), on}});
     });
     connect(&m_tunerModel, &TunerModel::autotuneRequested, this, [this](){
         // TX interlock gate (was a commandReady string-sniff on "tgxl autotune").
@@ -737,8 +735,7 @@ RadioModel::RadioModel(QObject* parent)
             return;
         applyTuneInhibit();
         if (m_backend)
-            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.autotune"), 0,
-                                       QVariantMap{{QStringLiteral("handle"), m_tunerModel.handle()}});
+            m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("tuner.autotune"), 0);
     });
 
     // Forward DAX IQ commands to the radio
@@ -748,12 +745,12 @@ RadioModel::RadioModel(QObject* parent)
 
     // Route amplifier (PGXL) operate intent to the radio through the backend seam
     // (#4094). FlexBackend relays "amplifier set … operate=" to the amp (the path
-    // that works remote/SmartLink); the handle rides in invokeExtension's vendor arg.
+    // that works remote/SmartLink), resolving the amp handle from its own
+    // decode-side state (#4198) — the intent carries no Flex identifier.
     connect(&m_amplifier, &AmpModel::operateRequested, this, [this](bool on){
         if (m_backend)
             m_backend->invokeExtension(QStringLiteral("flex"), QStringLiteral("amp.operate"), 0,
-                                       QVariantMap{{QStringLiteral("handle"), m_amplifier.handle()},
-                                                   {QStringLiteral("on"), on}});
+                                       QVariantMap{{QStringLiteral("on"), on}});
     });
     // Protocol-log breadcrumb on amp detection, symmetric with the "amplifier
     // removed" log — kept here so AmpModel stays logging-category-free. #4099.
@@ -3788,6 +3785,7 @@ void RadioModel::onDisconnected()
     m_tunerModel.setHandle({});       // clear TGXL presence
     m_xvtrList.clear();
     m_amplifier.reset();              // clear PGXL presence/operate (#4094)
+    if (m_flexBackend) m_flexBackend->clearExtensionHandles();  // drop cached encode handles (#4198)
     m_fullDuplex = false;
     // Reset to false so the next connect's skip-peek fast path requires the
     // radio's mf_enable status to actually arrive before treating multiFLEX
@@ -5966,7 +5964,7 @@ void RadioModel::onStatusReceived(const QString& object,
             m_tunerModel.setHandle(m.captured(1));
         if (m_flexBackend) m_flexBackend->decodeAtuStatus(kvs);   // radio's own ATU → TransmitModel
         if (m_tunerModel.isPresent() && m_flexBackend)
-            m_flexBackend->decodeTunerStatus(kvs);                // external TGXL → TunerModel (#4092)
+            m_flexBackend->decodeTunerStatus(m_tunerModel.handle(), kvs);  // external TGXL → TunerModel (#4092/#4198)
         return;
     }
 
@@ -6044,7 +6042,7 @@ void RadioModel::onStatusReceived(const QString& object,
                     m_tunerModel.setHandle(handle);
                     m_meterModel.setTgxlHandle(handle.toUInt(nullptr, 0));
                 }
-                if (m_flexBackend) m_flexBackend->decodeTunerStatus(kvs);   // #4092
+                if (m_flexBackend) m_flexBackend->decodeTunerStatus(m_tunerModel.handle(), kvs);   // #4092/#4198
             }
             // Power amplifier (PGXL / any non-TGXL amp) → AmpModel. `else` of the
             // tuner branch: a TGXL status is already routed above and would only

--- a/tests/aetherd_amp_tuner_encode_test.cpp
+++ b/tests/aetherd_amp_tuner_encode_test.cpp
@@ -1,13 +1,16 @@
-// aetherd #4092 / #4094 — ENCODE side. FlexBackend::invokeExtension translates
-// the neutral amp/tuner intents (operate/bypass/autotune) into the SmartSDR
-// relay wire, advertises the "flex" extension namespace, and honors the async
-// contract (an awaited call always gets exactly one extensionResult/Error).
+// aetherd #4092 / #4094 / #4198 — ENCODE side. FlexBackend::invokeExtension
+// translates the neutral amp/tuner intents (operate/bypass/autotune) into the
+// SmartSDR relay wire. Per #4198 the device object handle is sourced from the
+// backend's OWN decode-side state (captured in decodeAmplifierStatus /
+// decodeTunerStatus) — the intent no longer carries a Flex handle. Also covers
+// the "flex" namespace advertisement and the async reply contract.
 // Companion to the decode tests (aetherd_amp_decode_test / aetherd_tuner_decode_test).
 
 #include "core/backends/flex/FlexBackend.h"
 #include "core/backends/RadioCapabilities.h"
 
 #include <QCoreApplication>
+#include <QMap>
 #include <QSignalSpy>
 #include <QStringList>
 #include <QVariant>
@@ -26,13 +29,23 @@ static void check(bool cond, const char* what)
     }
 }
 
-// The vendor arg RadioModel supplies: the Flex object handle + the on/off value.
-static QVariant arg(const QString& handle, bool on)
+// The vendor arg now carries only the on/off value; the handle comes from decode.
+static QVariant argOn(bool v)
 {
     QVariantMap m;
-    m[QStringLiteral("handle")] = handle;
-    m[QStringLiteral("on")] = on;
+    m[QStringLiteral("on")] = v;
     return m;
+}
+
+// Seed the backend's decode-side handle state the way a live status would — this
+// is what invokeExtension now resolves the wire handle from.
+static void seedAmp(FlexBackend& b, const QString& handle)
+{
+    b.decodeAmplifierStatus(handle, QStringLiteral("PowerGeniusXL"), {}, /*removed=*/false);
+}
+static void seedTuner(FlexBackend& b, const QString& handle)
+{
+    b.decodeTunerStatus(handle, {});
 }
 
 int main(int argc, char** argv)
@@ -46,18 +59,20 @@ int main(int argc, char** argv)
               "capabilities() does not advertise the flex extension namespace");
     }
 
-    // ---- each verb translates to the exact SmartSDR relay string ----
+    // ---- each verb translates to the exact wire string, using the DECODED handle ----
     {
         FlexBackend b;
         QStringList sent;
         b.setCommandSink([&](const QString& c) { sent << c; });
+        seedAmp(b, "0x1000");     // handle now lives in the backend, not the arg
+        seedTuner(b, "0x2000");
 
-        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", true));
-        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", false));
-        b.invokeExtension("flex", "tuner.operate", 0, arg("0x2000", true));
-        b.invokeExtension("flex", "tuner.operate", 0, arg("0x2000", false));
-        b.invokeExtension("flex", "tuner.bypass", 0, arg("0x2000", true));
-        b.invokeExtension("flex", "tuner.autotune", 0, arg("0x2000", false));
+        b.invokeExtension("flex", "amp.operate", 0, argOn(true));
+        b.invokeExtension("flex", "amp.operate", 0, argOn(false));
+        b.invokeExtension("flex", "tuner.operate", 0, argOn(true));
+        b.invokeExtension("flex", "tuner.operate", 0, argOn(false));
+        b.invokeExtension("flex", "tuner.bypass", 0, argOn(true));
+        b.invokeExtension("flex", "tuner.autotune", 0);   // no arg needed for autotune
 
         check(sent.size() == 6, "expected 6 wire commands");
         check(sent.value(0) == "amplifier set 0x1000 operate=1", "amp.operate=1 wire");
@@ -68,16 +83,76 @@ int main(int argc, char** argv)
         check(sent.value(5) == "tgxl autotune handle=0x2000", "tuner.autotune wire");
     }
 
+    // ---- #4198: handle is resolved from decode state; re-decode updates it;
+    //      removal (incl. TGXL removal on the amplifier wire) clears it ----
+    {
+        FlexBackend b;
+        QStringList sent;
+        b.setCommandSink([&](const QString& c) { sent << c; });
+        QSignalSpy errSpy(&b, &FlexBackend::extensionError);
+
+        // no decode yet → no cached handle → error, no wire
+        b.invokeExtension("flex", "amp.operate", 1, argOn(true));
+        check(sent.isEmpty() && errSpy.count() == 1,
+              "amp.operate before any decode → error, no wire");
+
+        // after decode, the intent uses the decoded handle
+        seedAmp(b, "0x1000");
+        b.invokeExtension("flex", "amp.operate", 0, argOn(true));
+        check(sent.value(0) == "amplifier set 0x1000 operate=1",
+              "amp.operate after decode uses the decoded handle");
+
+        // a later status with a new handle re-points the encode
+        seedAmp(b, "0x1abc");
+        b.invokeExtension("flex", "amp.operate", 0, argOn(false));
+        check(sent.value(1) == "amplifier set 0x1abc operate=0",
+              "re-decode updates the cached amp handle");
+
+        // removal clears it → back to error
+        errSpy.clear();
+        sent.clear();
+        b.decodeAmplifierStatus("0x1abc", QString(), {}, /*removed=*/true);
+        b.invokeExtension("flex", "amp.operate", 2, argOn(true));
+        check(sent.isEmpty() && errSpy.count() == 1,
+              "after removal the amp handle is cleared → error");
+
+        // TGXL: its removal arrives on the amplifier-removed wire (RadioModel
+        // routes it to decodeAmplifierStatus) — must clear the tuner handle too.
+        seedTuner(b, "0x2000");
+        errSpy.clear();
+        sent.clear();
+        b.invokeExtension("flex", "tuner.bypass", 0, argOn(true));
+        check(sent.value(0) == "tgxl set handle=0x2000 bypass=1",
+              "tuner intent uses the decoded tuner handle");
+        b.decodeAmplifierStatus("0x2000", QString(), {}, /*removed=*/true);   // TGXL removed
+        sent.clear();
+        b.invokeExtension("flex", "tuner.bypass", 3, argOn(true));
+        check(sent.isEmpty() && errSpy.count() == 1,
+              "TGXL removal on the amp wire clears the tuner handle → error");
+
+        // clearExtensionHandles() (the disconnect/reset path) drops both at once
+        seedAmp(b, "0x1000");
+        seedTuner(b, "0x2000");
+        b.clearExtensionHandles();
+        errSpy.clear();
+        sent.clear();
+        b.invokeExtension("flex", "amp.operate", 4, argOn(true));
+        b.invokeExtension("flex", "tuner.operate", 5, argOn(true));
+        check(sent.isEmpty() && errSpy.count() == 2,
+              "clearExtensionHandles() drops both cached handles → errors, no wire");
+    }
+
     // ---- async contract: an awaited call gets exactly one reply ----
     {
         FlexBackend b;
         QStringList sent;
         b.setCommandSink([&](const QString& c) { sent << c; });
+        seedAmp(b, "0x1000");
         QSignalSpy okSpy(&b, &FlexBackend::extensionResult);
         QSignalSpy errSpy(&b, &FlexBackend::extensionError);
 
         // success + requestId != 0 → one extensionResult carrying the id, wire sent
-        b.invokeExtension("flex", "amp.operate", 42, arg("0x1000", true));
+        b.invokeExtension("flex", "amp.operate", 42, argOn(true));
         check(sent.size() == 1, "awaited success still sends the wire command");
         check(okSpy.count() == 1 && errSpy.count() == 0,
               "awaited success emits exactly one extensionResult");
@@ -85,7 +160,7 @@ int main(int argc, char** argv)
               "extensionResult correlates the requestId");
 
         // fire-and-forget (requestId 0) success → no reply signal at all
-        b.invokeExtension("flex", "amp.operate", 0, arg("0x1000", true));
+        b.invokeExtension("flex", "amp.operate", 0, argOn(true));
         check(okSpy.count() == 0 && errSpy.count() == 0,
               "requestId 0 success emits no reply");
     }
@@ -96,18 +171,18 @@ int main(int argc, char** argv)
         QStringList sent;
         b.setCommandSink([&](const QString& c) { sent << c; });
         QSignalSpy errSpy(&b, &FlexBackend::extensionError);
+        seedAmp(b, "0x1000");   // amp has a handle, so ns/verb errors aren't masked
 
-        b.invokeExtension("bogus", "amp.operate", 7, arg("0x1000", true));   // unknown ns
-        b.invokeExtension("flex", "amp.bogus", 8, arg("0x1000", true));       // unknown verb
-        b.invokeExtension("flex", "amp.operate", 9, arg("", true));           // no handle
-        b.invokeExtension("flex", "tuner.autotune", 10, arg("", false));      // no handle
+        b.invokeExtension("bogus", "amp.operate", 7, argOn(true));   // unknown ns
+        b.invokeExtension("flex", "amp.bogus", 8, argOn(true));       // unknown verb
+        b.invokeExtension("flex", "tuner.operate", 9, argOn(true));   // no tuner decode → no handle
         check(sent.isEmpty(), "error paths send no wire command");
-        check(errSpy.count() == 4, "each awaited error emits exactly one extensionError");
+        check(errSpy.count() == 3, "each awaited error emits exactly one extensionError");
 
         // the same failures, fire-and-forget → silent (no hang, no stray reply)
         errSpy.clear();
-        b.invokeExtension("flex", "amp.bogus", 0, arg("0x1000", true));
-        b.invokeExtension("flex", "amp.operate", 0, arg("", true));
+        b.invokeExtension("flex", "amp.bogus", 0, argOn(true));
+        b.invokeExtension("flex", "tuner.operate", 0, argOn(true));
         check(errSpy.count() == 0, "requestId 0 errors stay silent");
     }
 

--- a/tests/aetherd_tuner_decode_test.cpp
+++ b/tests/aetherd_tuner_decode_test.cpp
@@ -19,7 +19,7 @@ static int g_failures = 0;
 static TunerDelta decode(FlexBackend& b, const QMap<QString, QString>& kvs)
 {
     QSignalSpy spy(&b, &IRadioBackend::tunerChanged);
-    b.decodeTunerStatus(kvs);
+    b.decodeTunerStatus(QStringLiteral("0x2000"), kvs);   // handle unused by these delta-field checks (#4198)
     if (spy.count() != 1) return {};
     return spy.takeFirst().at(0).value<TunerDelta>();
 }


### PR DESCRIPTION
Closes #4198 — the follow-up cleanup deferred from #4192 (amp/tuner ENCODE-via-seam, merged as `4f5e33e2`).

## What & why

#4192 kept the **Flex object handle** in RadioModel, threaded into `invokeExtension` via the vendor `arg`, to stay scoped. This removes that last vendor-detail leak on the encode path: **FlexBackend now owns the handle**, caching it from its own status decode and resolving it at encode time. The amp/tuner intents carry **zero** Flex identifiers.

## Changes

- **FlexBackend caches the handle decode-side** — new `m_ampHandle`/`m_tunerHandle`. `decodeAmplifierStatus` already receives the handle (PGXL-only per RadioModel's routing); `decodeTunerStatus` gains a `handle` param (the sanitized handle RadioModel extracted). Both ignore the `0x00000000` first-status placeholder.
- **`invokeExtension("flex", …)`** builds the wire from the cached handles instead of the arg; the `isEmpty` guards now check the backend's own state.
- **Handle lifetime** — cleared on removal (a removed handle matching either cached value; TGXL removal also arrives on the amplifier-removed wire), and via a new **`clearExtensionHandles()`** called from RadioModel's disconnect/reset path (where model-side presence is cleared *outside* decode). This preserves the pre-#4198 safety that a stale handle can't survive a reconnect to a *different* radio. Main-thread only (decode + encode both run there) → plain `QString`, no sync.
- **RadioModel** intent lambdas forward just `{on}` (or nothing for autotune); the two `decodeTunerStatus` call sites pass `m_tunerModel.handle()`.

## Scope guardrails (per the issue's triage)

Left alone deliberately — the TGXL/PGXL routing decision, the `0x00000000` handling, and `MeterModel::setTgxlHandle` stay in RadioModel. This is only the encode-path ownership move, not the larger decode-routing refactor.

## Tests

- `aetherd_amp_tuner_encode_test` reworked to seed handles via **decode** (not the arg), with new #4198 coverage: handle resolved from decode state, re-decode updates it, and removal + `clearExtensionHandles()` clear it (incl. TGXL removal via the amp wire).
- `aetherd_tuner_decode_test` updated for the new signature.
- Targeted amp/tuner suite green; full build clean; `check_engine_boundary.py --strict` clean (no new vendor includes — coupling reduced).

> Note: the repo's `bridge_docs_check` is currently red on `main` (stale `docs/automation-bridge.md`) — **pre-existing and unrelated**; this PR touches no bridge/automation files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)