### PR TITLE
fix(kiwisdr): free cached waterfall history on receiver release (#4199)

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -2122,7 +2122,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 45 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 46 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -2148,6 +2148,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `txtest` | — | txtest <twotone\|off> — TX-gated test signal |
 | `atu` | — | atu <bypass\|start> — antenna tuner (start is TX-gated) |
 | `slice` | — | slice <action> [args] — slice lifecycle/config (see doSlice) |
+| `waveform` | — | waveform <start\|stop\|unregister\|resync> [args] — digital-voice service |
 | `tune` | — | tune <mhz> — set the active slice frequency |
 | `cwx` | — | cwx <send\|speed\|stop> [args] — CWX keyer (send is TX-gated) |
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1190,6 +1190,15 @@ void KiwiSdrClient::cleanupSockets()
     m_loggedSoundFrameShape = false;
     m_loggedWaterfallFrameShape = false;
     m_lastDecodedSoundPcm.clear();
+    // Release the sound resampler on teardown, matching the other two teardown
+    // sites (connectToEndpoint / stream-rate change). It was the one sound-decode
+    // member cleanupSockets() left alive, so it lingered per retained
+    // KiwiSdrClient until profile removal. It is rebuilt lazily on the next
+    // connection once the rate is re-negotiated. Minor on its own (~0.2 MB per
+    // receiver); the dominant #4199 growth is the cached waterfall history freed
+    // in KiwiSdrManager::disconnectProfile().
+    m_soundResamplerRateHz = 0.0;
+    m_soundResampler.reset();
     KiwiSdrProtocol::resetSoundAdpcmState(&m_soundAdpcmState);
     m_lastSoundFrameLayout = KiwiSdrProtocol::FrameLayout::Unknown;
     m_soundAudioRateText.clear();

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -385,6 +385,15 @@ void KiwiSdrManager::disconnectProfile(const QString& id)
         });
     }
     emit audioSourceEnabledChanged(id, false);
+    // Releasing a receiver ends its waterfall stream, so drop the per-profile
+    // waterfall history the GUI cached for fast switch-back. Without this the
+    // SpectrumWidget keeps a full waterfall + history QImage for every distinct
+    // Kiwi ever switched to (m_kiwiProfileWaterfallStates), which grows the
+    // working set by ~100-200 MB per receiver and is only freed on a full reset
+    // — the leak reported in #4199. Profiles that stay assigned/auto-connected
+    // are never disconnected here, so their cached history (multi-slice toggle)
+    // is preserved. The stream, and its history, rebuild on reconnection.
+    emit profileStreamReset(id);
 }
 
 void KiwiSdrManager::disconnectAll()


### PR DESCRIPTION
Fixes #4199.

## Symptom

Switching a slice's RX antenna between KiwiSDRs grows the memory readout by **~170 MB per distinct receiver** and never releases it (reporter: 438 → 612 → 785 → 957 MB, reaching ~2.9 GB after a session of switching). Switching **back** to an already-used receiver adds nothing.

## Not the neural denoisers

The initial triage suspected per-source DeepFilterNet3/NvAFX not being freed on switch-away. @wa2n-code's follow-up — *"no noise reduction was being employed"* — redirected the diagnosis, and the attached log confirms it: DFNR/NvAFX default to off, they log on enable, and there are **zero** DSP lines. Every DSP path also already frees correctly on disable. So the +170 MB is not DSP.

## Root cause

`SpectrumWidget` caches each receiver's full waterfall — the visible `QImage` **plus the entire `waterfallHistory` QImage** and the trace/timestamp vectors — in a per-profile hash:

```cpp
QHash<QString, WaterfallStreamState> m_kiwiProfileWaterfallStates;   // SpectrumWidget.h:1005
```

`saveCurrentWaterfallStreamState()` moves those images into the hash on switch-away, and `restoreCurrentWaterfallStreamState()` restores them on switch-back — which is exactly why revisiting a used receiver adds no memory.

That hash is pruned per-profile in exactly one place — `KiwiSdrManager` emits `profileStreamReset` **only when a user edits a profile's endpoint URL** (`KiwiSdrManager.cpp:251`). It never fires on switch-away, disconnect, or even profile removal. So every distinct receiver's waterfall history accumulates for the life of the session. The Windows readout is `WorkingSetSize`, so those resident QImages show up directly.

## Fix

- **`KiwiSdrManager::disconnectProfile()`** now emits the existing `profileStreamReset` signal, already wired in the GUI to prune that profile's cached waterfall state. It fires at every genuine *release* point (switch-away of a non-maintained receiver, slice-clear, manual disconnect, auto-connect-off, removal). Profiles that stay **assigned or auto-connected are never disconnected there**, so the multi-slice toggle history is preserved; the stream and its history rebuild on reconnection.
- **`KiwiSdrClient::cleanupSockets()`** now also resets `m_soundResampler` — the one sound-decode member teardown was leaving alive (the other two teardown sites already reset it). Minor on its own (~0.2 MB/receiver, measured with an RSS probe — the r8brain filter bank is cached/shared) but a real leak in the same path.
- Regenerate **`docs/automation-bridge.md`** to add the already-registered `waveform` verb, clearing pre-existing `gen_bridge_docs` drift (unrelated to the leak; folded in to keep `bridge_docs_check` green).

## Scope note

The reporter's log shows their *first* receiver stayed **connected** the whole session while a later one was disconnected on switch-away. A still-connected receiver legitimately keeps its waterfall, so fully bounding that case depends on the separate release bug filed as #4158 — this PR bounds every receiver that is actually released.

## Testing

- Builds clean (RelWithDebInfo).
- `ctest`: 107/108 pass; `bridge_docs_check` now green after the docs regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
