### PR TITLE
fix(kiwisdr): retain Kiwi RX across band change, restore mute on exit (#4158). Principle II.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2297,6 +2297,12 @@ target_include_directories(model_capabilities_test PRIVATE src)
 target_link_libraries(model_capabilities_test PRIVATE Qt6::Core)
 add_test(NAME model_capabilities_test COMMAND model_capabilities_test)
 
+# KiwiSDR band-recall re-bind policy (#4158) — header-only, pure logic.
+add_executable(kiwi_rebind_tracker_test tests/kiwi_rebind_tracker_test.cpp)
+target_include_directories(kiwi_rebind_tracker_test PRIVATE src)
+target_link_libraries(kiwi_rebind_tracker_test PRIVATE Qt6::Core)
+add_test(NAME kiwi_rebind_tracker_test COMMAND kiwi_rebind_tracker_test)
+
 add_executable(declared_bands_test
     tests/declared_bands_test.cpp
     src/models/DeclaredBands.cpp

--- a/src/gui/KiwiRebindTracker.h
+++ b/src/gui/KiwiRebindTracker.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <QHash>
+#include <QSet>
+#include <QString>
+
+namespace AetherSDR {
+
+// Policy for retaining a KiwiSDR RX replacement across the slice remove->re-add
+// that a FLEX band-stack recall performs. With band_persistence a band recall
+// does NOT retune the slice: the radio DROPS it (in_use=0) and RE-CREATES it
+// (same id, new band) a moment later, so a naive "tear the Kiwi down on
+// sliceRemoved" reverts audio to the Flex antenna on every band change (#4158).
+//
+// This is a pure state machine — no widgets, no timers, no side effects — so
+// MainWindow owns the side effects (disconnect / re-establish / mute) and this
+// decides WHEN. Kept testable on its own because slice-id identity is subtle:
+//   * Flex recycles slice ids, so id + elapsed time is NOT identity — a re-bind
+//     must be gated on positive band-recall intent (noteBandRecall) or an
+//     unrelated close+create would steal the Kiwi onto the wrong slice;
+//   * the reconnect stale-slice prune emits sliceRemoved(oldId) while that id
+//     already belongs to a live new-session slice, so a non-live removal must
+//     never defer/tear down;
+//   * repeated remove->re-add->remove within the grace window must be
+//     generation-safe so an older expiry can't consume newer pending state.
+// Unit-tested in kiwi_rebind_tracker_test.
+class KiwiRebindTracker {
+public:
+    // A band recall was initiated by us on this pan; the slice the radio
+    // re-creates on it should re-bind rather than tear down. One-shot per pan
+    // (consumed by onSliceAdded on a match); MainWindow also expires it on a
+    // timer so a recall that yields no re-bindable slice can't leave it stale.
+    void noteBandRecall(const QString& panId) { m_bandRecallPans.insert(panId); }
+    void clearBandRecall(const QString& panId) { m_bandRecallPans.remove(panId); }
+
+    struct RemoveAction {
+        enum Kind {
+            Ignore,        // nothing Kiwi-related to do
+            TeardownNow,   // finalize immediately (non-Kiwi live close, or the
+                           // reconnect stale-prune — pre-existing behavior)
+            Defer,         // a Kiwi live-removal: hold across the grace window
+        };
+        Kind     kind{Ignore};
+        quint64  generation{0};   // valid when kind == Defer
+    };
+
+    // A slice was removed. `live` is false for the reconnect stale-prune (the id
+    // still resolves to a live slice) — never defer then. `kiwiProfile` is empty
+    // unless the removed slice carried a Kiwi replacement.
+    RemoveAction onSliceRemoved(int sliceId, bool live, const QString& kiwiProfile)
+    {
+        if (live && !kiwiProfile.isEmpty()) {
+            const quint64 generation = ++m_generation;
+            m_pending.insert(sliceId, {kiwiProfile, generation});
+            return {RemoveAction::Defer, generation};
+        }
+        return {RemoveAction::TeardownNow, 0};
+    }
+
+    // A slice was (re-)added. Returns the profile to re-bind, or an empty string
+    // for "do nothing". Re-binds only when a rebind is pending for this id AND
+    // this pan actually just did a band recall — so a plain id reuse leaves the
+    // pending entry to time out (finalizing the original teardown) instead of
+    // hijacking the Kiwi onto an unrelated slice.
+    QString onSliceAdded(int sliceId, const QString& panId)
+    {
+        const auto it = m_pending.constFind(sliceId);
+        if (it == m_pending.constEnd()) {
+            return QString();
+        }
+        if (!m_bandRecallPans.contains(panId)) {
+            return QString();
+        }
+        const QString profileId = it->profileId;
+        m_pending.remove(sliceId);
+        m_bandRecallPans.remove(panId);
+        return profileId;
+    }
+
+    // The grace window elapsed for a deferred removal. Returns true only if this
+    // exact (sliceId, generation) is still the pending entry — an older timer
+    // whose entry was superseded by a newer removal returns false, so it can't
+    // finalize a teardown that no longer applies. On true, the entry is dropped
+    // and MainWindow performs the real teardown.
+    bool onGraceExpired(int sliceId, quint64 generation)
+    {
+        const auto it = m_pending.constFind(sliceId);
+        if (it == m_pending.constEnd() || it->generation != generation) {
+            return false;
+        }
+        m_pending.remove(sliceId);
+        return true;
+    }
+
+    // Test/inspection helpers.
+    bool hasPending(int sliceId) const { return m_pending.contains(sliceId); }
+    bool bandRecallPending(const QString& panId) const
+    {
+        return m_bandRecallPans.contains(panId);
+    }
+
+private:
+    struct Pending {
+        QString profileId;
+        quint64 generation{0};
+    };
+    QHash<int, Pending> m_pending;        // removed Kiwi slice id -> pending rebind
+    QSet<QString>       m_bandRecallPans;  // pans with an in-flight band recall
+    quint64             m_generation{0};   // monotonic; disambiguates re-removals
+};
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3054,6 +3054,28 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // next AetherSDR launch from reacquiring it.
     stopDigitalVoiceService(true);
 
+    // Restore the Flex slice mute for any active KiwiSDR audio replacement
+    // before we exit. The replacement mutes the radio slice (audio_mute=1) so
+    // only the Kiwi stream is heard; with the radio's auto_save enabled that
+    // muted state is persisted, so a slice left replaced comes up silent on the
+    // next launch — KiwiSDR is client-side only and is not reselected, leaving a
+    // plain, muted Flex slice the user must manually unmute (#4158). Restoring
+    // the pre-Kiwi mute here clears that. Done before the UI teardown below so
+    // the radio connection is still open to receive the command.
+    if (m_kiwiSdrManager) {
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (!slice || !slice->externalReceiveReplacementActive()) {
+                continue;
+            }
+            const int sliceId = slice->sliceId();
+            const bool restoreMute =
+                m_kiwiSdrVirtualPreviousMute.contains(sliceId)
+                    ? m_kiwiSdrVirtualPreviousMute.take(sliceId)
+                    : slice->flexAudioMute();
+            slice->setExternalReceiveAudioReplacementMute(false, restoreMute);
+        }
+    }
+
     preparePanadapterUiForShutdown();
     auto& s = AppSettings::instance();
     s.setValue("MainWindowGeometry", saveGeometry().toBase64());
@@ -6474,6 +6496,17 @@ void MainWindow::reassertUnmutedSliceAudioForPan(const QString& panId)
     for (auto* slice : slices) {
         if (!slice || slice->panId() != panId || slice->audioMute())
             continue;
+
+        // A KiwiSDR-replaced slice shows unmuted (the Kiwi stream is the audio)
+        // but the Flex slice must stay muted on the radio. Its visible
+        // audioMute() is false, so without this guard a band-change reassert
+        // would blast audio_mute=0 and fight the replacement (the status parser
+        // re-mutes it, but that is a needless round-trip and a brief unmute
+        // glitch). Retaining the Kiwi across a band change (#4158) requires
+        // leaving these muted. flexAudioMute() carries the true radio mute.
+        if (slice->externalReceiveReplacementActive()) {
+            continue;
+        }
 
         // The model already shows unmuted, so SliceModel::setAudioMute(false)
         // would no-op. Send the command directly to rebuild radio audio routing.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -16,6 +16,7 @@
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
 #include "core/ReceivePresentationSync.h"
+#include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
 #include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
 #include "core/TciServer.h"
@@ -970,6 +971,12 @@ private:
     QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
     QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
     QSet<QString>    m_kiwiSdrFlexDisplayPans;
+    // Retains a KiwiSDR replacement across the slice remove->re-add a FLEX
+    // band-stack recall performs (band_persistence drops+re-creates the slice
+    // with the same id at the new band). The tracker is the pure policy; the
+    // grace window itself is a QTimer::singleShot in onSliceRemoved. (#4158)
+    KiwiRebindTracker    m_kiwiRebind;
+    static constexpr int kKiwiSdrRebindGraceMs = 1500;
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
     ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -454,6 +454,22 @@ void MainWindow::wireRadioModel()
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
             this, &MainWindow::onSliceRemoved);
+    // Re-bind a KiwiSDR replacement across a band-stack slice recreation (#4158).
+    // A band recall DROPS then RE-CREATES the slice (same id, new band). The
+    // tracker re-binds only when a rebind is pending for this id AND this pan
+    // actually just did a band recall (noteBandRecall), so a plain slice-id
+    // reuse can't hijack the Kiwi onto an unrelated slice. Connected AFTER
+    // onSliceAdded so the recreated slice's VFO widget/overlay already exist.
+    connect(&m_radioModel, &RadioModel::sliceAdded, this, [this](SliceModel* s) {
+        if (!s) {
+            return;
+        }
+        const QString profileId = m_kiwiRebind.onSliceAdded(s->sliceId(), s->panId());
+        if (profileId.isEmpty()) {
+            return;
+        }
+        setKiwiSdrVirtualAntennaForSlice(s->sliceId(), profileId);
+    });
     connect(&m_radioModel, &RadioModel::memoryChanged,
             this, &MainWindow::syncMemorySpot);
     connect(&m_radioModel, &RadioModel::memoryRemoved,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1533,9 +1533,46 @@ void MainWindow::onSliceRemoved(int id)
     }
     m_centerLockTuneHoldBySlice.remove(id);
 
-    m_kiwiSdrVirtualPreviousMute.remove(id);
-    if (m_kiwiSdrManager) {
-        m_kiwiSdrManager->clearSliceAssignment(id);
+    // A band-stack recall (band_persistence) DROPS and RE-CREATES the slice
+    // (same id, new band) instead of retuning it, which would tear down a
+    // KiwiSDR replacement on the removal. Defer that teardown across the
+    // remove->re-add so onSliceAdded can re-bind the Kiwi (retuned to the new
+    // band) instead of reverting to a plain Flex slice (#4158). m_kiwiRebind is
+    // the pure policy — see KiwiRebindTracker; identity is gated on band-recall
+    // intent and generation, not slice id + time.
+    //
+    // `live` distinguishes a genuine removal (the slice has already left the
+    // model, so slice(id) is null) from the reconnect stale-slice prune (a
+    // sliceRemoved(oldId) whose id already belongs to a live new-session slice)
+    // — same guard the center-lock logic above uses. Only a live Kiwi removal
+    // defers; the prune keeps the pre-existing immediate cleanup and never
+    // enters the grace path, so a stale prune can't later clear a live
+    // assignment.
+    const bool liveRemoval = !m_radioModel.slice(id);
+    const QString kiwiRebindProfile = (liveRemoval && m_kiwiSdrManager)
+        ? m_kiwiSdrManager->assignedProfileForSlice(id) : QString();
+    const auto rebindAction =
+        m_kiwiRebind.onSliceRemoved(id, liveRemoval, kiwiRebindProfile);
+    if (rebindAction.kind == KiwiRebindTracker::RemoveAction::Defer) {
+        // Leave the assignment (and Kiwi connection) and the pre-Kiwi mute
+        // intact during the window so a re-bind is seamless. If no recreation
+        // re-binds it, the generation-safe expiry finalizes the teardown.
+        const quint64 generation = rebindAction.generation;
+        QTimer::singleShot(kKiwiSdrRebindGraceMs, this, [this, id, generation]() {
+            if (!m_kiwiRebind.onGraceExpired(id, generation)) {
+                return;
+            }
+            m_kiwiSdrVirtualPreviousMute.remove(id);
+            if (m_kiwiSdrManager) {
+                m_kiwiSdrManager->clearSliceAssignment(id);
+            }
+            syncKiwiSdrPanadapterUiStates();
+        });
+    } else {
+        m_kiwiSdrVirtualPreviousMute.remove(id);
+        if (m_kiwiSdrManager) {
+            m_kiwiSdrManager->clearSliceAssignment(id);
+        }
     }
     syncKiwiSdrPanadapterUiStates();
 
@@ -3566,6 +3603,16 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                 << " xvtr=" << xvtrForBandSummary(bandName, xvtrs);
             clearSwrSweepForBandChange(-1, applet->panId(), bandName);
             m_bandSettings.setCurrentBand(bandName);
+            // A band recall makes the radio drop+re-create this pan's slice;
+            // mark the pan (positive band-recall intent) so onSliceAdded re-binds
+            // a KiwiSDR replacement onto the recreated slice instead of reverting
+            // to Flex (#4158). One-shot: consumed by the re-bind, or expired here
+            // so a recall on a non-Kiwi slice can't leave the marker stale.
+            m_kiwiRebind.noteBandRecall(applet->panId());
+            QTimer::singleShot(kKiwiSdrRebindGraceMs, this,
+                               [this, panId = applet->panId()]() {
+                m_kiwiRebind.clearBandRecall(panId);
+            });
             m_radioModel.sendCommand(
                 QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {

--- a/tests/kiwi_rebind_tracker_test.cpp
+++ b/tests/kiwi_rebind_tracker_test.cpp
@@ -1,0 +1,130 @@
+// Unit tests for KiwiRebindTracker — the policy that retains a KiwiSDR RX
+// replacement across the slice remove->re-add a FLEX band-stack recall performs
+// (#4158). Covers the four identity hazards raised in review:
+//   1. expected band-recall remove/re-add -> re-bind;
+//   2. ordinary close followed by same-id creation -> NO transfer;
+//   3. reconnect stale-prune collision (non-live removal) -> never defers;
+//   4. repeated removals before an earlier timer expires -> generation-safe.
+
+#include "gui/KiwiRebindTracker.h"
+
+#include <QString>
+#include <cstdio>
+
+using namespace AetherSDR;
+using RA = KiwiRebindTracker::RemoveAction;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+const QString kPan  = QStringLiteral("0x40000000");
+const QString kPanB = QStringLiteral("0x41000000");
+const QString kKiwi = QStringLiteral("kb5ag.ddns.net");
+
+}  // namespace
+
+int main()
+{
+    // 1. Expected band-recall: mark the pan, remove the Kiwi slice (defers),
+    //    same id re-appears on the same pan -> re-bind to the same profile.
+    {
+        KiwiRebindTracker t;
+        t.noteBandRecall(kPan);
+        const RA a = t.onSliceRemoved(0, /*live=*/true, kKiwi);
+        report("band-recall: Kiwi live removal defers",
+               a.kind == RA::Defer && t.hasPending(0));
+        const QString rebind = t.onSliceAdded(0, kPan);
+        report("band-recall: same id+pan re-binds the same profile",
+               rebind == kKiwi);
+        report("band-recall: pending + marker consumed on re-bind",
+               !t.hasPending(0) && !t.bandRecallPending(kPan));
+        report("band-recall: expiry after re-bind is a no-op",
+               !t.onGraceExpired(0, a.generation));
+    }
+
+    // 2. Ordinary close + same-id create (no band recall): must NOT transfer the
+    //    Kiwi to the unrelated new slice; the pending survives to be finalized.
+    {
+        KiwiRebindTracker t;
+        const RA a = t.onSliceRemoved(0, /*live=*/true, kKiwi);
+        report("plain close: Kiwi live removal defers", a.kind == RA::Defer);
+        const QString rebind = t.onSliceAdded(0, kPan);   // no noteBandRecall()
+        report("plain close: same-id create does NOT re-bind (no band recall)",
+               rebind.isEmpty() && t.hasPending(0));
+        report("plain close: grace expiry then finalizes the real teardown",
+               t.onGraceExpired(0, a.generation) && !t.hasPending(0));
+    }
+
+    // 2b. A band recall on a DIFFERENT pan must not re-bind this slice.
+    {
+        KiwiRebindTracker t;
+        t.noteBandRecall(kPanB);
+        t.onSliceRemoved(0, /*live=*/true, kKiwi);
+        report("cross-pan: band recall on another pan does not re-bind",
+               t.onSliceAdded(0, kPan).isEmpty() && t.hasPending(0));
+    }
+
+    // 3. Reconnect stale-prune: sliceRemoved(oldId) whose id still resolves to a
+    //    live slice (live=false). Must NOT defer and must NOT create pending, so
+    //    it can never later clear the live slice's assignment.
+    {
+        KiwiRebindTracker t;
+        const RA a = t.onSliceRemoved(0, /*live=*/false, kKiwi);
+        report("stale prune: non-live removal tears down now, no defer",
+               a.kind == RA::TeardownNow && !t.hasPending(0));
+    }
+
+    // 3b. A non-Kiwi live removal also tears down now (no pending).
+    {
+        KiwiRebindTracker t;
+        const RA a = t.onSliceRemoved(0, /*live=*/true, QString());
+        report("non-Kiwi live removal tears down now, no defer",
+               a.kind == RA::TeardownNow && !t.hasPending(0));
+    }
+
+    // 4. Repeated removals before the first timer fires: the first (older)
+    //    generation's expiry must be a no-op; only the newest finalizes.
+    {
+        KiwiRebindTracker t;
+        const RA a1 = t.onSliceRemoved(0, /*live=*/true, kKiwi);   // gen 1
+        const RA a2 = t.onSliceRemoved(0, /*live=*/true, kKiwi);   // gen 2 (supersedes)
+        report("re-removal supersedes the pending generation",
+               a2.generation != a1.generation && t.hasPending(0));
+        report("older-generation expiry is a no-op",
+               !t.onGraceExpired(0, a1.generation) && t.hasPending(0));
+        report("newest-generation expiry finalizes",
+               t.onGraceExpired(0, a2.generation) && !t.hasPending(0));
+    }
+
+    // 4b. Re-bind then re-remove within the window: the FIRST timer (its entry
+    //     already consumed by the re-bind) must not finalize the new pending.
+    {
+        KiwiRebindTracker t;
+        t.noteBandRecall(kPan);
+        const RA a1 = t.onSliceRemoved(0, /*live=*/true, kKiwi);   // gen 1
+        (void)t.onSliceAdded(0, kPan);                             // re-bind, clears pending
+        const RA a2 = t.onSliceRemoved(0, /*live=*/true, kKiwi);   // gen 2 (new pending)
+        report("rebind-then-reremove: stale gen-1 expiry does not finalize gen 2",
+               !t.onGraceExpired(0, a1.generation) && t.hasPending(0));
+        report("rebind-then-reremove: gen-2 expiry finalizes",
+               t.onGraceExpired(0, a2.generation) && !t.hasPending(0));
+    }
+
+    if (g_failed == 0) {
+        std::printf("\nAll %d kiwi-rebind-tracker tests passed.\n", g_total);
+        return 0;
+    }
+    std::printf("\n%d of %d kiwi-rebind-tracker tests failed.\n", g_failed, g_total);
+    return 1;
+}


### PR DESCRIPTION
Fixes #4158 (retain-Kiwi, option 2A). **Updated after live FLEX-8600 validation — the original band-change diagnosis was wrong; see the correction below.**

## Symptom 1 — band change (retain the Kiwi) — CORRECTED ROOT CAUSE

The original theory (Kiwi tracking already follows the band; nothing tears the assignment down) was **disproven on the live radio**. With `band_persistence` a band-stack recall does **not** retune the slice — the radio **drops the slice** (`in_use=0`) and **re-creates it** (same id, new band) ~50 ms later:

```
slice 0 in_use=0                → MainWindow: slice removed 0
kiwisdr: Slice 0 cleared … / Disconnecting …     (Kiwi torn down on removal)
slice 0 in_use=1 … RF=14.1 pan=… → MainWindow: slice added 0   (plain Flex)
```

`onSliceRemoved` tore the Kiwi replacement down on the removal, so audio reverted to the Flex antenna on every band change. (The reassert-guard hunk never applied — by reassert time the Kiwi was already gone.)

**Fix:** defer the Kiwi teardown across the remove→re-add. `onSliceRemoved` stashes a removed Kiwi slice's `id → profile` and starts a short grace timer instead of disconnecting (the Kiwi connection and pre-Kiwi mute are left intact so the re-bind is seamless). `onSliceAdded` re-establishes the replacement on the recreated slice via `setKiwiSdrVirtualAntennaForSlice` — re-muting the new Flex slice and **retuning the Kiwi to the new band**. A genuine close (no recreation within the window) lets the timer finalize the teardown exactly as before. The reassert-guard now correctly protects the *re-bound* slice.

## Symptom 2 — silent slice on restart (unchanged)

`closeEvent()` never restored the pre-Kiwi mute; with `auto_save` on, the `audio_mute=1` persisted and the slice came up silent next launch. Fix restores the pre-Kiwi mute for every replaced slice on shutdown, before the UI teardown, while the radio connection is still open.

## Live validation (done, FLEX-8600)

- ✅ Band change keeps the KiwiSDR as the source, audio uninterrupted, retuned to the new band (log shows a `Virtual RX antenna selected` re-bind right after `slice added`, no `Disconnecting`).
- ✅ Restart-with-Kiwi comes up **unmuted on the local Flex antenna** (was silent before). Kiwi is client-side only, so it is not auto-reselected — coming up as a normal unmuted Flex slice is the intended symptom-2 fix.

## Note / follow-up

The re-bind matches on slice-id + a 1.5 s grace window (the band-change signature), not pan — robust for normal use; a pan-strict match is an easy follow-up if ever needed.

## Commits

- `closeEvent` mute-restore + reassert-guard (original hunks).
- `f3761e67` — the band-recall slice-recreation re-bind (the real symptom-1 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)