### PR TITLE
Add per-receiver KiwiSDR password support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,9 @@ else()
     find_package(Qt6Keychain QUIET)
 endif()
 if(Qt6Keychain_FOUND)
-    message(STATUS "Qt6Keychain found — SmartLink credential persistence enabled")
+    message(STATUS "Qt6Keychain found — credential persistence enabled")
 else()
-    message(STATUS "Qt6Keychain not found — SmartLink credential persistence disabled")
+    message(STATUS "Qt6Keychain not found — credential persistence disabled")
 endif()
 
 # PortAudio (optional fallback for audio)
@@ -540,6 +540,7 @@ set(CORE_SOURCES
     src/core/SmartLinkClient.cpp
     src/core/KiwiSdrProtocol.cpp
     src/core/KiwiSdrRedirectPolicy.cpp
+    src/core/KiwiSdrCredentialStore.cpp
     src/core/KiwiSdrClient.cpp
     src/core/KiwiSdrManager.cpp
     src/core/ReceivePresentationSync.cpp
@@ -2549,6 +2550,16 @@ add_executable(kiwi_sdr_protocol_test
 target_include_directories(kiwi_sdr_protocol_test PRIVATE src)
 target_link_libraries(kiwi_sdr_protocol_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_protocol_test COMMAND kiwi_sdr_protocol_test)
+
+add_executable(kiwi_sdr_manager_password_test
+    tests/kiwi_sdr_manager_password_test.cpp
+)
+target_include_directories(kiwi_sdr_manager_password_test PRIVATE src)
+target_link_libraries(kiwi_sdr_manager_password_test PRIVATE
+    aethercore Qt6::Core Qt6::Test)
+set_target_properties(kiwi_sdr_manager_password_test PROPERTIES AUTOMOC ON)
+add_test(NAME kiwi_sdr_manager_password_test
+         COMMAND kiwi_sdr_manager_password_test)
 
 add_executable(kiwi_sdr_trace_math_test
     tests/kiwi_sdr_trace_math_test.cpp

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -171,6 +171,17 @@ black-box observations made in this thread.
   `SET client_type=MicroKiwi`, `SET name=...`, `SET password=...`,
   `SET audio_on=1`, or `SET wf_on=1`; use `SET auth t=kiwi p=...`,
   `SET ident_user=...`, and the stream client marker commands instead.
+- User-provided password-support requirement from 2026-07-12: each configured
+  KiwiSDR receiver may have its own password, stored through AetherSDR's
+  existing per-OS credential-store integration rather than in AppSettings.
+- License-compatible Kiwi server verification from revision
+  `417e2c8add196e879b8cc4eb4a488b35b4bf0df7` (2026-07-10), using only files
+  carrying the GNU Library GPL v2-or-later header: `rx/rx_cmd.cpp` parses
+  `SET auth t=<type> p=<token>`, caps the encoded `p=` token at 256
+  characters, maps a literal `#` to no password, and calls
+  `kiwi_str_decode_inplace()` before comparing the password;
+  `support/str.cpp` implements that decode with `mg_url_decode()`. No Kiwi
+  browser/client source was inspected for this behavior.
 - User-provided protocol correction from 2026-06-18: string values in `SET`
   commands must not contain spaces. The current runtime sends only sanitized
   callsign identity strings and fixed client labels without spaces.
@@ -804,7 +815,15 @@ row delivery on endpoints that return `wf_fps=0` for larger values.
 
 Remaining uncertainties are deliberately conservative:
 
-- Only password-free public receive access is supported.
+- Password-free and user-password-protected receive access are supported.
+  Passwords are UTF-8 percent-encoded into the server's whitespace-delimited
+  `p=` token, and connection setup fails closed if the encoded token exceeds
+  the server's 256-character limit. Per-receiver secrets use the platform
+  credential store when available; save/read/delete failures are surfaced in
+  Radio Setup, while a failed save leaves the entered password usable for the
+  current session. A failed startup read blocks deferred auto-connect rather
+  than silently attempting an empty password. Admin-password access is not
+  requested.
 - Audio still requests uncompressed `SND` via `SET compression=0` by default,
   but diagnostic runs can request compressed `SND` via `SET compression=1`.
   The runtime can safely accept the source-attributed compressed mono SND

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -433,8 +433,18 @@ void KiwiSdrClient::setReceiverControls(
     sendReceiverControlsToServer();
 }
 
-void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
+void KiwiSdrClient::connectToEndpoint(const QString& endpoint,
+                                      const QString& password)
 {
+    if (!KiwiSdrProtocol::authPasswordFitsServerLimit(password)) {
+        setState(
+            State::Error,
+            tr("The KiwiSDR password is too long after URL encoding "
+               "(maximum %1 characters).")
+                .arg(KiwiSdrProtocol::kAuthPasswordEncodedMaxLength));
+        return;
+    }
+
     QString host;
     quint16 port = 0;
     if (!parseEndpoint(endpoint, &host, &port)) {
@@ -443,6 +453,7 @@ void KiwiSdrClient::connectToEndpoint(const QString& endpoint)
     }
 
     m_endpoint = QStringLiteral("%1:%2").arg(host).arg(port);
+    m_password = password;
     m_host = host;
     m_port = port;
     m_webSocketPort = 0;
@@ -1275,7 +1286,7 @@ void KiwiSdrClient::cleanupSockets()
 
 void KiwiSdrClient::sendSoundSetupCommands()
 {
-    sendSoundCommand(QStringLiteral("SET auth t=kiwi p=#"));
+    sendSoundCommand(KiwiSdrProtocol::formatAuthCommand(m_password));
     sendSoundIdentityToServer();
     sendSoundCommand(KiwiSdrProtocol::formatSoundCompressionCommand(
         diagnosticSoundCompressionRequested()));
@@ -1327,7 +1338,7 @@ void KiwiSdrClient::sendSoundSampleRateCommands()
 
 void KiwiSdrClient::sendWaterfallSetupCommands()
 {
-    sendWaterfallCommand(QStringLiteral("SET auth t=kiwi p=#"));
+    sendWaterfallCommand(KiwiSdrProtocol::formatAuthCommand(m_password));
     sendWaterfallIdentityToServer();
     sendWaterfallCommand(QStringLiteral("SERVER DE CLIENT AetherSDR W/F"));
     sendWaterfallCommand(KiwiSdrProtocol::formatWaterfallCompressionCommand(

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -99,7 +99,8 @@ public:
 public slots:
     void setOperatorCallsign(const QString& callsign);
     void setReceiverControls(const KiwiSdrReceiverControls& controls);
-    void connectToEndpoint(const QString& endpoint);
+    void connectToEndpoint(const QString& endpoint,
+                           const QString& password = {});
     void disconnectFromEndpoint();
     void setTrackedSlice(int sliceId, double frequencyMhz,
                          const QString& mode, int filterLowHz,
@@ -260,6 +261,7 @@ private:
     State m_state{State::Disconnected};
     QString m_stateDetail;
     QString m_endpoint;
+    QString m_password;
     QString m_host;
     QString m_operatorCallsign;
     QString m_lastSoundIdentityCallsign;

--- a/src/core/KiwiSdrCredentialStore.cpp
+++ b/src/core/KiwiSdrCredentialStore.cpp
@@ -1,0 +1,178 @@
+#include "KiwiSdrCredentialStore.h"
+
+#include <QObject>
+#include <QHash>
+#include <QPointer>
+#include <QQueue>
+#include <QSet>
+#include <QTimer>
+
+#ifdef HAVE_KEYCHAIN
+#include <qt6keychain/keychain.h>
+#endif
+
+#include <utility>
+
+namespace AetherSDR {
+namespace {
+
+#ifdef HAVE_KEYCHAIN
+constexpr const char* kKeychainService = "AetherSDR";
+
+KiwiSdrCredentialResult resultForJob(QKeychain::Job* job)
+{
+    if (job->error() == QKeychain::NoError) {
+        return {};
+    }
+    if (job->error() == QKeychain::EntryNotFound) {
+        return {KiwiSdrCredentialResultCode::NotFound, {}, {}};
+    }
+    return {KiwiSdrCredentialResultCode::Error, {}, job->errorString()};
+}
+
+class KeychainKiwiSdrCredentialStore final
+    : public IKiwiSdrCredentialStore,
+      public std::enable_shared_from_this<KeychainKiwiSdrCredentialStore> {
+public:
+    bool isPersistent() const override { return true; }
+
+    void read(const QString& key, QObject* context,
+              Callback callback) override
+    {
+        enqueue({Operation::Read, key, {}, context, std::move(callback)});
+    }
+
+    void write(const QString& key, const QString& value, QObject* context,
+               Callback callback) override
+    {
+        enqueue({Operation::Write, key, value, context, std::move(callback)});
+    }
+
+    void remove(const QString& key, QObject* context,
+                Callback callback) override
+    {
+        enqueue({Operation::Remove, key, {}, context, std::move(callback)});
+    }
+
+private:
+    enum class Operation { Read, Write, Remove };
+    struct Request {
+        Operation operation;
+        QString key;
+        QString value;
+        QPointer<QObject> context;
+        Callback callback;
+    };
+
+    void enqueue(Request request)
+    {
+        const QString key = request.key;
+        m_queues[key].enqueue(std::move(request));
+        startNext(key);
+    }
+
+    void startNext(const QString& key)
+    {
+        if (m_activeKeys.contains(key) || m_queues.value(key).isEmpty()) {
+            return;
+        }
+
+        Request request = m_queues[key].dequeue();
+        if (m_queues[key].isEmpty()) {
+            m_queues.remove(key);
+        }
+        m_activeKeys.insert(key);
+
+        QKeychain::Job* job = nullptr;
+        if (request.operation == Operation::Read) {
+            auto* readJob = new QKeychain::ReadPasswordJob(
+                QString::fromLatin1(kKeychainService));
+            job = readJob;
+        } else if (request.operation == Operation::Write) {
+            auto* writeJob = new QKeychain::WritePasswordJob(
+                QString::fromLatin1(kKeychainService));
+            writeJob->setTextData(request.value);
+            job = writeJob;
+        } else {
+            job = new QKeychain::DeletePasswordJob(
+                QString::fromLatin1(kKeychainService));
+        }
+        job->setKey(key);
+
+        const std::shared_ptr<KeychainKiwiSdrCredentialStore> self =
+            shared_from_this();
+        QObject::connect(
+            job, &QKeychain::Job::finished, job,
+            [self, key, request = std::move(request)](
+                QKeychain::Job* finished) mutable {
+                KiwiSdrCredentialResult result = resultForJob(finished);
+                if (request.operation == Operation::Read
+                    && result.code == KiwiSdrCredentialResultCode::Success) {
+                    result.value = static_cast<QKeychain::ReadPasswordJob*>(
+                                       finished)->textData();
+                }
+                if (request.context) {
+                    request.callback(result);
+                }
+                self->m_activeKeys.remove(key);
+                self->startNext(key);
+            });
+        job->start();
+    }
+
+    QHash<QString, QQueue<Request>> m_queues;
+    QSet<QString> m_activeKeys;
+};
+
+#else
+
+class SessionKiwiSdrCredentialStore final
+    : public IKiwiSdrCredentialStore {
+public:
+    bool isPersistent() const override { return false; }
+
+    void read(const QString&, QObject* context, Callback callback) override
+    {
+        QTimer::singleShot(0, context,
+                           [callback = std::move(callback)] {
+            callback({KiwiSdrCredentialResultCode::NotFound, {}, {}});
+        });
+    }
+
+    void write(const QString&, const QString&, QObject* context,
+               Callback callback) override
+    {
+        complete(context, std::move(callback));
+    }
+
+    void remove(const QString&, QObject* context,
+                Callback callback) override
+    {
+        complete(context, std::move(callback));
+    }
+
+private:
+    static void complete(QObject* context, Callback callback)
+    {
+        QTimer::singleShot(0, context,
+                           [callback = std::move(callback)] {
+            callback({});
+        });
+    }
+};
+
+#endif
+
+} // namespace
+
+std::shared_ptr<IKiwiSdrCredentialStore>
+createDefaultKiwiSdrCredentialStore()
+{
+#ifdef HAVE_KEYCHAIN
+    return std::make_shared<KeychainKiwiSdrCredentialStore>();
+#else
+    return std::make_shared<SessionKiwiSdrCredentialStore>();
+#endif
+}
+
+} // namespace AetherSDR

--- a/src/core/KiwiSdrCredentialStore.cpp
+++ b/src/core/KiwiSdrCredentialStore.cpp
@@ -98,6 +98,12 @@ private:
                 QString::fromLatin1(kKeychainService));
         }
         job->setKey(key);
+        // Auto-delete the job after it finishes, matching every other QKeychain
+        // user in the tree (SmartLinkClient, CallsignLookupService,
+        // AutomationBridgeSettings). Otherwise the job leaks — and because the
+        // finished handler captures a shared_ptr to this store, a leaked job
+        // would pin the whole credential store alive for the process lifetime.
+        job->setAutoDelete(true);
 
         const std::shared_ptr<KeychainKiwiSdrCredentialStore> self =
             shared_from_this();

--- a/src/core/KiwiSdrCredentialStore.h
+++ b/src/core/KiwiSdrCredentialStore.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QString>
+
+#include <functional>
+#include <memory>
+
+class QObject;
+
+namespace AetherSDR {
+
+enum class KiwiSdrCredentialResultCode {
+    Success,
+    NotFound,
+    Error,
+};
+
+struct KiwiSdrCredentialResult {
+    KiwiSdrCredentialResultCode code{KiwiSdrCredentialResultCode::Success};
+    QString value;
+    QString error;
+};
+
+class IKiwiSdrCredentialStore {
+public:
+    using Callback = std::function<void(const KiwiSdrCredentialResult&)>;
+
+    virtual ~IKiwiSdrCredentialStore() = default;
+    // Implementations preserve submission order for operations sharing a key.
+    // Persistent implementations also own queued work independently of the
+    // callback context so a manager teardown cannot discard a later write or
+    // delete that has already been handed off.
+    virtual bool isPersistent() const = 0;
+    virtual void read(const QString& key, QObject* context,
+                      Callback callback) = 0;
+    virtual void write(const QString& key, const QString& value,
+                       QObject* context, Callback callback) = 0;
+    virtual void remove(const QString& key, QObject* context,
+                        Callback callback) = 0;
+};
+
+std::shared_ptr<IKiwiSdrCredentialStore>
+createDefaultKiwiSdrCredentialStore();
+
+} // namespace AetherSDR

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -329,6 +329,14 @@ void KiwiSdrManager::setProfilePassword(const QString& id,
     }
 
     const bool changed = m_profilePasswords.value(id) != password;
+    const bool retryAfterError =
+        profilePasswordPersistenceState(id)
+        == KiwiSdrPasswordPersistenceState::Error;
+    if (!changed && m_loadedProfilePasswords.contains(id)
+        && !retryAfterError) {
+        return;
+    }
+
     m_profilePasswordRevisions.insert(
         id, m_profilePasswordRevisions.value(id) + 1);
     m_profilePasswords.insert(id, password);

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -35,8 +35,13 @@ QString normalizedProfileEndpoint(const QString& endpoint)
 
 } // namespace
 
-KiwiSdrManager::KiwiSdrManager(QObject* parent)
+KiwiSdrManager::KiwiSdrManager(
+    QObject* parent,
+    std::shared_ptr<IKiwiSdrCredentialStore> credentialStore)
     : QObject(parent)
+    , m_credentialStore(credentialStore
+                            ? std::move(credentialStore)
+                            : createDefaultKiwiSdrCredentialStore())
 {
     qRegisterMetaType<AetherSDR::KiwiSdrClient::State>(
         "AetherSDR::KiwiSdrClient::State");
@@ -49,7 +54,12 @@ KiwiSdrManager::KiwiSdrManager(QObject* parent)
     qRegisterMetaType<AetherSDR::KiwiSdrProtocol::MeterReading>(
         "AetherSDR::KiwiSdrProtocol::MeterReading");
     qRegisterMetaType<QVector<float>>("QVector<float>");
+    qRegisterMetaType<AetherSDR::KiwiSdrPasswordPersistenceState>(
+        "AetherSDR::KiwiSdrPasswordPersistenceState");
     loadSettings();
+    for (const KiwiSdrAntennaProfile& profile : std::as_const(m_profiles)) {
+        loadProfilePassword(profile.id);
+    }
 }
 
 KiwiSdrManager::~KiwiSdrManager()
@@ -201,6 +211,29 @@ int KiwiSdrManager::assignedSliceForProfile(const QString& id) const
     return -1;
 }
 
+QString KiwiSdrManager::profilePassword(const QString& id) const
+{
+    return m_profilePasswords.value(id);
+}
+
+bool KiwiSdrManager::isProfilePasswordLoaded(const QString& id) const
+{
+    return m_loadedProfilePasswords.contains(id);
+}
+
+KiwiSdrPasswordPersistenceState
+KiwiSdrManager::profilePasswordPersistenceState(const QString& id) const
+{
+    return m_profilePasswordPersistenceStates.value(
+        id, KiwiSdrPasswordPersistenceState::Loading);
+}
+
+QString KiwiSdrManager::profilePasswordPersistenceDetail(
+    const QString& id) const
+{
+    return m_profilePasswordPersistenceDetails.value(id);
+}
+
 QString KiwiSdrManager::addProfile(const QString& name, const QString& endpoint)
 {
     const QString normalizedEndpoint = normalizedProfileEndpoint(endpoint);
@@ -259,6 +292,7 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
                                   rate = updated.waterfallRate,
                                   endpointChanged,
                                   endpoint = updated.endpoint,
+                                  password = profilePassword(updated.id),
                                   reconnect = state(updated.id)
                                       != KiwiSdrClient::State::Disconnected](
                                      KiwiSdrClient* client) {
@@ -267,7 +301,7 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
             if (endpointChanged && reconnect) {
                 client->disconnectFromEndpoint();
                 if (!endpoint.isEmpty()) {
-                    client->connectToEndpoint(endpoint);
+                    client->connectToEndpoint(endpoint, password);
                 }
             }
         });
@@ -285,6 +319,39 @@ void KiwiSdrManager::updateProfile(const KiwiSdrAntennaProfile& profile)
     }
 
     emit profilesChanged();
+}
+
+void KiwiSdrManager::setProfilePassword(const QString& id,
+                                        const QString& password)
+{
+    if (!hasProfile(id)) {
+        return;
+    }
+
+    const bool changed = m_profilePasswords.value(id) != password;
+    m_profilePasswordRevisions.insert(
+        id, m_profilePasswordRevisions.value(id) + 1);
+    m_profilePasswords.insert(id, password);
+    m_loadedProfilePasswords.insert(id);
+    m_loadingProfilePasswords.remove(id);
+    queueProfilePasswordStore(id, password, false);
+
+    emit profilePasswordChanged(id);
+    if (m_pendingPasswordConnects.remove(id)) {
+        QTimer::singleShot(0, this, [this, id]() { connectProfile(id); });
+    }
+    if (!changed || state(id) == KiwiSdrClient::State::Disconnected) {
+        return;
+    }
+
+    cancelReconnect(id);
+    const QString endpoint = profile(id).endpoint;
+    invokeClient(id, [endpoint, password](KiwiSdrClient* client) {
+        client->disconnectFromEndpoint();
+        if (!endpoint.isEmpty()) {
+            client->connectToEndpoint(endpoint, password);
+        }
+    });
 }
 
 void KiwiSdrManager::removeProfile(const QString& id)
@@ -316,6 +383,7 @@ void KiwiSdrManager::removeProfile(const QString& id)
     m_waterfallAvailable.remove(id);
     m_waterfallDetails.remove(id);
     m_waterfallDisplayRanges.remove(id);
+    deleteProfilePassword(id);
     m_profiles.removeAt(idx);
     saveSettings();
     // The client deletion is already scheduled above, so no further audio will
@@ -329,6 +397,12 @@ void KiwiSdrManager::connectProfile(const QString& id)
 {
     const int idx = profileIndex(id);
     if (idx < 0) {
+        return;
+    }
+
+    if (!isProfilePasswordLoaded(id)) {
+        m_pendingPasswordConnects.insert(id);
+        loadProfilePassword(id);
         return;
     }
 
@@ -369,8 +443,9 @@ void KiwiSdrManager::connectProfile(const QString& id)
         << "Connecting" << m_profiles[idx].name
         << "->" << m_profiles[idx].endpoint;
     m_states.insert(id, KiwiSdrClient::State::Connecting);
-    invokeClient(id, [endpoint = m_profiles[idx].endpoint](KiwiSdrClient* client) {
-        client->connectToEndpoint(endpoint);
+    invokeClient(id, [endpoint = m_profiles[idx].endpoint,
+                      password = profilePassword(id)](KiwiSdrClient* client) {
+        client->connectToEndpoint(endpoint, password);
     });
 }
 
@@ -940,6 +1015,150 @@ void KiwiSdrManager::saveSettings() const
     settings.setValue(kKiwiSdrRxAntennasSettingsKey, QString::fromUtf8(
         QJsonDocument(root).toJson(QJsonDocument::Compact)));
     settings.save();
+}
+
+QString KiwiSdrManager::profilePasswordKey(const QString& id)
+{
+    return QStringLiteral("kiwisdr_password_%1").arg(id);
+}
+
+void KiwiSdrManager::loadProfilePassword(const QString& id)
+{
+    if (!hasProfile(id) || m_loadedProfilePasswords.contains(id)
+        || m_loadingProfilePasswords.contains(id)) {
+        return;
+    }
+    m_loadingProfilePasswords.insert(id);
+    setProfilePasswordPersistence(
+        id, KiwiSdrPasswordPersistenceState::Loading);
+    const quint64 revision = m_profilePasswordRevisions.value(id);
+
+    m_credentialStore->read(
+        profilePasswordKey(id), this,
+        [this, id, revision](const KiwiSdrCredentialResult& result) {
+        m_loadingProfilePasswords.remove(id);
+        if (!hasProfile(id)) {
+            return;
+        }
+        if (m_profilePasswordRevisions.value(id) != revision) {
+            return;
+        }
+        if (result.code == KiwiSdrCredentialResultCode::Success) {
+            m_profilePasswords.insert(id, result.value);
+            setProfilePasswordPersistence(
+                id, result.value.isEmpty()
+                        ? KiwiSdrPasswordPersistenceState::NoPassword
+                        : (m_credentialStore->isPersistent()
+                               ? KiwiSdrPasswordPersistenceState::Stored
+                               : KiwiSdrPasswordPersistenceState::SessionOnly));
+        } else if (result.code == KiwiSdrCredentialResultCode::NotFound) {
+            m_profilePasswords.remove(id);
+            setProfilePasswordPersistence(
+                id, KiwiSdrPasswordPersistenceState::NoPassword);
+        } else {
+            qCWarning(lcKiwiSdr).noquote()
+                << "KiwiSDR password keychain read failed"
+                << "id=" << id << result.error;
+            setProfilePasswordPersistence(
+                id, KiwiSdrPasswordPersistenceState::Error,
+                tr("Could not read the saved password: %1")
+                    .arg(result.error));
+        }
+        m_loadedProfilePasswords.insert(id);
+        emit profilePasswordChanged(id);
+        if (result.code != KiwiSdrCredentialResultCode::Error
+            && m_pendingPasswordConnects.remove(id)) {
+            connectProfile(id);
+        } else if (result.code == KiwiSdrCredentialResultCode::Error) {
+            m_pendingPasswordConnects.remove(id);
+        }
+    });
+}
+
+void KiwiSdrManager::deleteProfilePassword(const QString& id)
+{
+    m_profilePasswordRevisions.insert(
+        id, m_profilePasswordRevisions.value(id) + 1);
+    m_profilePasswords.remove(id);
+    m_loadedProfilePasswords.remove(id);
+    m_loadingProfilePasswords.remove(id);
+    m_pendingPasswordConnects.remove(id);
+    queueProfilePasswordStore(id, {}, true);
+}
+
+void KiwiSdrManager::queueProfilePasswordStore(
+    const QString& id, const QString& password, bool profileRemoval)
+{
+    const PendingPasswordStore pending{
+        m_profilePasswordRevisions.value(id), password, profileRemoval};
+    if (!profileRemoval) {
+        setProfilePasswordPersistence(
+            id, m_credentialStore->isPersistent()
+                    ? KiwiSdrPasswordPersistenceState::Saving
+                    : (password.isEmpty()
+                           ? KiwiSdrPasswordPersistenceState::NoPassword
+                           : KiwiSdrPasswordPersistenceState::SessionOnly));
+    }
+    const auto finished =
+        [this, id, pending](const KiwiSdrCredentialResult& result) {
+        const bool latest = m_profilePasswordRevisions.value(id)
+            == pending.revision;
+        if (latest) {
+            if (result.code == KiwiSdrCredentialResultCode::Success
+                || (pending.password.isEmpty()
+                    && result.code == KiwiSdrCredentialResultCode::NotFound)) {
+                if (!pending.profileRemoval) {
+                    setProfilePasswordPersistence(
+                        id, pending.password.isEmpty()
+                                ? KiwiSdrPasswordPersistenceState::NoPassword
+                                : (m_credentialStore->isPersistent()
+                                       ? KiwiSdrPasswordPersistenceState::Stored
+                                       : KiwiSdrPasswordPersistenceState::SessionOnly));
+                }
+            } else {
+                const QString action = pending.password.isEmpty()
+                    ? tr("delete") : tr("save");
+                const QString detail =
+                    tr("Could not %1 the KiwiSDR password: %2")
+                        .arg(action, result.error);
+                qCWarning(lcKiwiSdr).noquote()
+                    << "KiwiSDR password credential-store update failed"
+                    << "id=" << id << detail;
+                setProfilePasswordPersistence(
+                    id, KiwiSdrPasswordPersistenceState::Error, detail);
+            }
+        }
+
+        if (pending.profileRemoval && latest) {
+            m_profilePasswordRevisions.remove(id);
+            m_profilePasswordPersistenceStates.remove(id);
+            m_profilePasswordPersistenceDetails.remove(id);
+        }
+    };
+
+    if (pending.password.isEmpty()) {
+        m_credentialStore->remove(profilePasswordKey(id), this, finished);
+    } else {
+        m_credentialStore->write(profilePasswordKey(id), pending.password,
+                                 this, finished);
+    }
+}
+
+void KiwiSdrManager::setProfilePasswordPersistence(
+    const QString& id, KiwiSdrPasswordPersistenceState state,
+    const QString& detail)
+{
+    if (m_profilePasswordPersistenceStates.value(id) == state
+        && m_profilePasswordPersistenceDetails.value(id) == detail) {
+        return;
+    }
+    m_profilePasswordPersistenceStates.insert(id, state);
+    if (detail.isEmpty()) {
+        m_profilePasswordPersistenceDetails.remove(id);
+    } else {
+        m_profilePasswordPersistenceDetails.insert(id, detail);
+    }
+    emit profilePasswordPersistenceChanged(id, state, detail);
 }
 
 bool KiwiSdrManager::shouldMaintainProfileConnection(const QString& id) const

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -1,13 +1,16 @@
 #pragma once
 
 #include "KiwiSdrClient.h"
+#include "KiwiSdrCredentialStore.h"
 
 #include <QHash>
 #include <QObject>
+#include <QSet>
 #include <QString>
 #include <QVector>
 
 #include <functional>
+#include <memory>
 
 class QTimer;
 class QThread;
@@ -32,11 +35,22 @@ struct KiwiSdrWaterfallDisplayRange {
     bool valid{false};
 };
 
+enum class KiwiSdrPasswordPersistenceState {
+    Loading,
+    NoPassword,
+    Saving,
+    Stored,
+    SessionOnly,
+    Error,
+};
+
 class KiwiSdrManager : public QObject {
     Q_OBJECT
 
 public:
-    explicit KiwiSdrManager(QObject* parent = nullptr);
+    explicit KiwiSdrManager(
+        QObject* parent = nullptr,
+        std::shared_ptr<IKiwiSdrCredentialStore> credentialStore = {});
     ~KiwiSdrManager() override;
 
     QVector<KiwiSdrAntennaProfile> profiles() const { return m_profiles; }
@@ -62,10 +76,16 @@ public:
 
     QString assignedProfileForSlice(int sliceId) const;
     int assignedSliceForProfile(const QString& id) const;
+    QString profilePassword(const QString& id) const;
+    bool isProfilePasswordLoaded(const QString& id) const;
+    KiwiSdrPasswordPersistenceState profilePasswordPersistenceState(
+        const QString& id) const;
+    QString profilePasswordPersistenceDetail(const QString& id) const;
 
 public slots:
     QString addProfile(const QString& name, const QString& endpoint);
     void updateProfile(const KiwiSdrAntennaProfile& profile);
+    void setProfilePassword(const QString& id, const QString& password);
     void removeProfile(const QString& id);
     void connectProfile(const QString& id);
     void disconnectProfile(const QString& id);
@@ -100,6 +120,11 @@ public slots:
 
 signals:
     void profilesChanged();
+    void profilePasswordChanged(const QString& id);
+    void profilePasswordPersistenceChanged(
+        const QString& id,
+        AetherSDR::KiwiSdrPasswordPersistenceState state,
+        const QString& detail);
     void profileStateChanged(const QString& id, AetherSDR::KiwiSdrClient::State state,
                              const QString& detail);
     void profileTelemetryChanged(
@@ -132,6 +157,14 @@ private:
     int profileIndex(const QString& id) const;
     void loadSettings();
     void saveSettings() const;
+    void loadProfilePassword(const QString& id);
+    void deleteProfilePassword(const QString& id);
+    void queueProfilePasswordStore(const QString& id, const QString& password,
+                                   bool profileRemoval);
+    void setProfilePasswordPersistence(
+        const QString& id, KiwiSdrPasswordPersistenceState state,
+        const QString& detail = {});
+    static QString profilePasswordKey(const QString& id);
     bool shouldMaintainProfileConnection(const QString& id) const;
     void ensureClientThread();
     void invokeClient(const QString& id, std::function<void(KiwiSdrClient*)> fn);
@@ -152,8 +185,24 @@ private:
     QHash<QString, QString> m_waterfallDetails;
     QHash<QString, KiwiSdrWaterfallDisplayRange> m_waterfallDisplayRanges;
     QHash<int, QString> m_sliceAssignments;
+    QHash<QString, QString> m_profilePasswords;
+    QHash<QString, quint64> m_profilePasswordRevisions;
+    struct PendingPasswordStore {
+        quint64 revision{0};
+        QString password;
+        bool profileRemoval{false};
+    };
+    QHash<QString, KiwiSdrPasswordPersistenceState>
+        m_profilePasswordPersistenceStates;
+    QHash<QString, QString> m_profilePasswordPersistenceDetails;
+    QSet<QString> m_loadedProfilePasswords;
+    QSet<QString> m_loadingProfilePasswords;
+    QSet<QString> m_pendingPasswordConnects;
+    std::shared_ptr<IKiwiSdrCredentialStore> m_credentialStore;
     QString m_operatorCallsign;
     QThread* m_clientThread{nullptr};
 };
 
 } // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::KiwiSdrPasswordPersistenceState)

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -815,6 +815,31 @@ bool diagnosticWaterfallCompressionFlagEnabled(const QByteArray& value)
     return diagnosticCompressionFlagEnabled(value);
 }
 
+QString formatAuthCommand(const QString& password)
+{
+    // The LGPL Kiwi server parses p= as a whitespace-delimited token capped at
+    // 256 encoded characters, maps a bare '#' to no password, then URL-decodes
+    // the token before comparison (rx/rx_cmd.cpp and support/str.cpp, server
+    // revision 417e2c8). A real '#' must therefore become %23.
+    const QByteArray encodedBytes = password.isEmpty()
+        ? QByteArrayLiteral("#")
+        : QUrl::toPercentEncoding(password);
+    if (encodedBytes.size() > kAuthPasswordEncodedMaxLength) {
+        return QString();
+    }
+    const QString encoded = QString::fromLatin1(encodedBytes);
+    return QStringLiteral("SET auth t=kiwi p=%1").arg(encoded);
+}
+
+bool authPasswordFitsServerLimit(const QString& password)
+{
+    if (password.isEmpty()) {
+        return true;
+    }
+    return QUrl::toPercentEncoding(password).size()
+        <= kAuthPasswordEncodedMaxLength;
+}
+
 QString formatSoundCompressionCommand(bool compressed)
 {
     return QStringLiteral("SET compression=%1").arg(compressed ? 1 : 0);

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -301,6 +301,9 @@ bool diagnosticCompressionFlagEnabled(const QByteArray& value);
 bool diagnosticWaterfallCompressionFlagEnabled(const QByteArray& value);
 QString formatSoundCompressionCommand(bool compressed);
 QString formatWaterfallCompressionCommand(bool compressed);
+constexpr int kAuthPasswordEncodedMaxLength = 256;
+bool authPasswordFitsServerLimit(const QString& password);
+QString formatAuthCommand(const QString& password);
 FrameObservation classifySoundFrame(const QByteArray& frame);
 FrameObservation classifyWaterfallFrame(const QByteArray& frame,
                                         int zoomCap = 14);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4046,16 +4046,22 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 + kCheckBoxIndicator);
             rowLayout->addWidget(autoCheck, 3, 0, Qt::AlignLeft);
 
+            auto committed = std::make_shared<bool>(false);
             auto commitNewRow = [this, nameEdit, endpointEdit, passwordEdit,
-                                 autoCheck] {
+                                 autoCheck, committed] {
+                if (*committed) {
+                    return;
+                }
                 const QString name = nameEdit->text().trimmed();
                 const QString endpoint =
                     KiwiSdrClient::normalizeEndpoint(endpointEdit->text());
                 if (name.isEmpty() || endpoint.isEmpty()) {
                     return;
                 }
+                *committed = true;
                 const QString id = m_kiwiSdrManager->addProfile(name, endpoint);
                 if (id.isEmpty()) {
+                    *committed = false;
                     return;
                 }
                 m_kiwiSdrManager->setProfilePassword(id, passwordEdit->text());

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -3435,11 +3435,72 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
 
     QVBoxLayout* kiwiRowsLayout = nullptr;
 
+#ifdef HAVE_KEYCHAIN
+    const QString kiwiPasswordHelpText =
+        QStringLiteral("Configure receive-only KiwiSDR servers. Passwords "
+                       "are saved separately for each receiver in the "
+                       "operating system credential store when available. "
+                       "The status below each password confirms the result.");
+    const QString kiwiPasswordDescription =
+        QStringLiteral("Optional password for this KiwiSDR receiver. Type "
+                       "over the current value to replace it; the storage "
+                       "status below confirms whether the operating system "
+                       "credential store accepted it.");
+#else
+    const QString kiwiPasswordHelpText =
+        QStringLiteral("Configure receive-only KiwiSDR servers. This build "
+                       "keeps passwords only for the current session.");
+    const QString kiwiPasswordDescription =
+        QStringLiteral("Optional password for this KiwiSDR receiver. This "
+                       "build keeps it only for the current session.");
+#endif
+
     if (m_kiwiSdrManager) {
         auto* kiwiGroup = new QGroupBox("KiwiSDR RX Antennas");
         kiwiGroup->setStyleSheet(kGroupStyle);
         auto* kiwiLayout = new QVBoxLayout(kiwiGroup);
         kiwiLayout->setSpacing(6);
+
+        auto* kiwiHelp = new QLabel(
+            kiwiPasswordHelpText);
+        kiwiHelp->setWordWrap(true);
+        kiwiHelp->setAccessibleName("KiwiSDR receiver configuration help");
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            kiwiHelp,
+            "QLabel { color: {{color.text.secondary}}; font-size: 11px; "
+            "padding: 0 4px 4px 4px; }");
+        kiwiLayout->addWidget(kiwiHelp);
+
+        auto* kiwiCredentialNotice = new QLabel;
+        kiwiCredentialNotice->setWordWrap(true);
+        kiwiCredentialNotice->setAccessibleName(
+            "KiwiSDR credential storage notice");
+        kiwiCredentialNotice->setVisible(false);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            kiwiCredentialNotice,
+            "QLabel { color: {{color.accent.danger}}; font-size: 11px; "
+            "padding: 4px; }");
+        kiwiLayout->addWidget(kiwiCredentialNotice);
+        connect(
+            m_kiwiSdrManager,
+            &KiwiSdrManager::profilePasswordPersistenceChanged,
+            kiwiCredentialNotice,
+            [kiwiCredentialNotice](
+                const QString& id, KiwiSdrPasswordPersistenceState state,
+                const QString& detail) {
+                if (state != KiwiSdrPasswordPersistenceState::Error) {
+                    if (kiwiCredentialNotice->property("profileId").toString()
+                        == id) {
+                        kiwiCredentialNotice->clear();
+                        kiwiCredentialNotice->setVisible(false);
+                    }
+                    return;
+                }
+                kiwiCredentialNotice->setProperty("profileId", id);
+                kiwiCredentialNotice->setText(detail);
+                kiwiCredentialNotice->setAccessibleDescription(detail);
+                kiwiCredentialNotice->setVisible(true);
+            });
 
         auto* kiwiScroll = new QScrollArea;
         kiwiScroll->setWidgetResizable(true);
@@ -3646,7 +3707,8 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
         };
 
         *refreshKiwi = [this, kiwiRowsLayout, stateText, styleKiwiEdit,
-                        styleKiwiButton, styleKiwiIconButton] {
+                        styleKiwiButton, styleKiwiIconButton,
+                        kiwiPasswordDescription] {
             while (QLayoutItem* item = kiwiRowsLayout->takeAt(0)) {
                 if (QWidget* widget = item->widget()) {
                     widget->deleteLater();
@@ -3656,55 +3718,209 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
 
             const QVector<KiwiSdrAntennaProfile> profiles =
                 m_kiwiSdrManager->profiles();
-            for (int row = 0; row < profiles.size(); ++row) {
-                const KiwiSdrAntennaProfile profile = profiles[row];
+            auto addSectionHeader = [kiwiRowsLayout](const QString& text) {
+                auto* header = new QLabel(text);
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    header,
+                    "QLabel { color: {{color.accent.bright}}; font-size: 11px; "
+                    "font-weight: bold; padding: 4px 2px 1px 2px; }");
+                kiwiRowsLayout->addWidget(header);
+            };
+            auto addFieldLabel = [](QGridLayout* layout, const QString& text,
+                                    int column) {
+                auto* label = new QLabel(text);
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    label,
+                    "QLabel { color: {{color.text.secondary}}; font-size: 10px; "
+                    "font-weight: bold; }");
+                layout->addWidget(label, 1, column);
+            };
+            auto passwordPersistenceText = [](KiwiSdrPasswordPersistenceState state,
+                                              const QString& detail) {
+                switch (state) {
+                case KiwiSdrPasswordPersistenceState::Loading:
+                    return QStringLiteral("Loading secure password…");
+                case KiwiSdrPasswordPersistenceState::NoPassword:
+                    return QStringLiteral("No password stored");
+                case KiwiSdrPasswordPersistenceState::Saving:
+                    return QStringLiteral("Saving securely…");
+                case KiwiSdrPasswordPersistenceState::Stored:
+                    return QStringLiteral("Stored securely");
+                case KiwiSdrPasswordPersistenceState::SessionOnly:
+                    return QStringLiteral("Current session only");
+                case KiwiSdrPasswordPersistenceState::Error:
+                    return detail.isEmpty()
+                        ? QStringLiteral("Password was not stored")
+                        : detail;
+                }
+                return QString();
+            };
+
+            addSectionHeader("CONFIGURED RECEIVERS");
+            if (profiles.isEmpty()) {
+                auto* empty = new QLabel("No KiwiSDR receivers configured.");
+                empty->setAccessibleName("No configured KiwiSDR receivers");
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    empty,
+                    "QLabel { color: {{color.text.label}}; font-size: 12px; "
+                    "padding: 8px; }");
+                kiwiRowsLayout->addWidget(empty);
+            }
+
+            for (const KiwiSdrAntennaProfile& profile : profiles) {
 
                 auto* rowFrame = new QFrame;
                 rowFrame->setObjectName("kiwiAntennaRow");
+                rowFrame->setAccessibleName(
+                    QStringLiteral("KiwiSDR receiver %1").arg(profile.name));
                 rowFrame->setStyleSheet(kKiwiRowStyle);
                 auto* rowLayout = new QGridLayout(rowFrame);
-                rowLayout->setContentsMargins(6, 5, 6, 5);
-                rowLayout->setHorizontalSpacing(6);
-                rowLayout->setVerticalSpacing(3);
+                rowLayout->setContentsMargins(10, 8, 10, 8);
+                rowLayout->setHorizontalSpacing(8);
+                rowLayout->setVerticalSpacing(4);
                 rowLayout->setColumnStretch(0, 1);
+                rowLayout->setColumnStretch(1, 1);
+                rowLayout->setColumnStretch(2, 1);
+
+                auto* title = new QLabel(profile.name);
+                title->setAccessibleName("KiwiSDR receiver name");
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    title,
+                    "QLabel { color: {{color.text.primary}}; font-size: 14px; "
+                    "font-weight: bold; }");
+                rowLayout->addWidget(title, 0, 0, 1, 2);
+
+                const KiwiSdrClient::State kiwiState =
+                    m_kiwiSdrManager->state(profile.id);
+                auto* status = new QLabel(stateText(profile.id));
+                status->setAccessibleName("KiwiSDR antenna status");
+                status->setAccessibleDescription(status->text());
+                QString statusColor = QStringLiteral("{{color.text.secondary}}");
+                if (kiwiState == KiwiSdrClient::State::Connected
+                    || kiwiState == KiwiSdrClient::State::Camping) {
+                    statusColor = QStringLiteral("{{color.accent.success}}");
+                } else if (kiwiState == KiwiSdrClient::State::Error) {
+                    statusColor = QStringLiteral("{{color.accent.danger}}");
+                } else if (kiwiState == KiwiSdrClient::State::Connecting
+                           || kiwiState == KiwiSdrClient::State::Waiting) {
+                    statusColor = QStringLiteral("{{color.accent.bright}}");
+                }
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    status,
+                    QStringLiteral("QLabel { color: %1; font-size: 12px; "
+                                   "padding-left: 6px; }")
+                        .arg(statusColor));
+                status->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+                status->setWordWrap(true);
+                status->setToolTip(status->text());
+                rowLayout->addWidget(status, 0, 2, 1, 2);
+
+                addFieldLabel(rowLayout, "NAME", 0);
+                addFieldLabel(rowLayout, "SERVER", 1);
+                addFieldLabel(rowLayout, "PASSWORD", 2);
 
                 auto* nameEdit = new QLineEdit(profile.name);
                 nameEdit->setMaxLength(16);
-                nameEdit->setPlaceholderText("Custom Name");
                 nameEdit->setAccessibleName("KiwiSDR antenna name");
                 nameEdit->setAccessibleDescription(
                     "Required display name for this KiwiSDR receive antenna.");
                 styleKiwiEdit(nameEdit);
-                rowLayout->addWidget(nameEdit, 0, 0);
-
-                auto* status = new QLabel(stateText(profile.id));
-                status->setAccessibleName("KiwiSDR antenna status");
-                status->setAccessibleDescription(status->text());
-                status->setStyleSheet(
-                    "QLabel { color: #c8d8e8; font-size: 12px; padding-left: 6px; }");
-                status->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-                status->setWordWrap(true);
-                status->setToolTip(status->text());
-                rowLayout->addWidget(status, 0, 1, 1, 3);
+                rowLayout->addWidget(nameEdit, 2, 0);
 
                 auto* endpointEdit = new QLineEdit(profile.endpoint);
                 endpointEdit->setAccessibleName("KiwiSDR server");
                 endpointEdit->setAccessibleDescription(
                     "Hostname or hostname:port for this KiwiSDR endpoint.");
                 styleKiwiEdit(endpointEdit);
-                rowLayout->addWidget(endpointEdit, 1, 0);
+                rowLayout->addWidget(endpointEdit, 2, 1);
+
+                auto* passwordEdit = new QLineEdit(
+                    m_kiwiSdrManager->profilePassword(profile.id));
+                passwordEdit->setEchoMode(QLineEdit::Password);
+                passwordEdit->setMaxLength(256);
+                passwordEdit->setObjectName(
+                    QStringLiteral("kiwiPassword_%1").arg(profile.id));
+                passwordEdit->setAccessibleName("KiwiSDR password");
+                passwordEdit->setAccessibleDescription(
+                    kiwiPasswordDescription);
+                if (!m_kiwiSdrManager->isProfilePasswordLoaded(profile.id)) {
+                    passwordEdit->setPlaceholderText("Loading secure password…");
+                    passwordEdit->setEnabled(false);
+                }
+                styleKiwiEdit(passwordEdit);
+                rowLayout->addWidget(passwordEdit, 2, 2, 1, 2);
+
+                const KiwiSdrPasswordPersistenceState persistenceState =
+                    m_kiwiSdrManager->profilePasswordPersistenceState(
+                        profile.id);
+                auto* passwordStatus = new QLabel(passwordPersistenceText(
+                    persistenceState,
+                    m_kiwiSdrManager->profilePasswordPersistenceDetail(
+                        profile.id)));
+                passwordStatus->setObjectName(
+                    QStringLiteral("kiwiPasswordStatus_%1").arg(profile.id));
+                passwordStatus->setAccessibleName(
+                    "KiwiSDR password storage status");
+                passwordStatus->setAccessibleDescription(
+                    passwordStatus->text());
+                passwordStatus->setWordWrap(true);
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    passwordStatus,
+                    persistenceState == KiwiSdrPasswordPersistenceState::Error
+                        ? "QLabel { color: {{color.accent.danger}}; "
+                          "font-size: 10px; padding: 0 2px; }"
+                        : "QLabel { color: {{color.text.secondary}}; "
+                          "font-size: 10px; padding: 0 2px; }");
+                rowLayout->addWidget(passwordStatus, 3, 2, 1, 2);
+                connect(
+                    m_kiwiSdrManager,
+                    &KiwiSdrManager::profilePasswordChanged,
+                    passwordEdit,
+                    [manager = m_kiwiSdrManager, profileId = profile.id,
+                     passwordEdit](const QString& changedId) {
+                        if (changedId != profileId) {
+                            return;
+                        }
+                        const QSignalBlocker blocker(passwordEdit);
+                        passwordEdit->setText(
+                            manager->profilePassword(profileId));
+                        passwordEdit->setPlaceholderText(QString());
+                        passwordEdit->setEnabled(true);
+                    });
+                connect(
+                    m_kiwiSdrManager,
+                    &KiwiSdrManager::profilePasswordPersistenceChanged,
+                    passwordStatus,
+                    [profileId = profile.id, passwordStatus,
+                     passwordPersistenceText](
+                        const QString& changedId,
+                        KiwiSdrPasswordPersistenceState state,
+                        const QString& detail) {
+                        if (changedId != profileId) {
+                            return;
+                        }
+                        const QString text =
+                            passwordPersistenceText(state, detail);
+                        passwordStatus->setText(text);
+                        passwordStatus->setAccessibleDescription(text);
+                        AetherSDR::ThemeManager::instance().applyStyleSheet(
+                            passwordStatus,
+                            state == KiwiSdrPasswordPersistenceState::Error
+                                ? "QLabel { color: {{color.accent.danger}}; "
+                                  "font-size: 10px; padding: 0 2px; }"
+                                : "QLabel { color: {{color.text.secondary}}; "
+                                  "font-size: 10px; padding: 0 2px; }");
+                    });
 
                 auto* autoCheck = new QCheckBox;
-                autoCheck->setText("Auto");
+                autoCheck->setText("Auto-connect");
                 autoCheck->setChecked(profile.autoConnect);
                 autoCheck->setAccessibleName("Auto connect KiwiSDR antenna");
                 AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck,
                     "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
                     + kCheckBoxIndicator);
-                rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
+                rowLayout->addWidget(autoCheck, 4, 0, 1, 2, Qt::AlignLeft);
 
-                const KiwiSdrClient::State kiwiState =
-                    m_kiwiSdrManager->state(profile.id);
                 const bool activeSession =
                     kiwiState == KiwiSdrClient::State::Connecting
                     || kiwiState == KiwiSdrClient::State::Waiting
@@ -3715,14 +3931,14 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                     activeSession ? "Disconnect KiwiSDR antenna"
                                   : "Connect KiwiSDR antenna");
                 styleKiwiButton(connectButton);
-                rowLayout->addWidget(connectButton, 1, 2);
+                rowLayout->addWidget(connectButton, 4, 2);
 
                 auto* removeButton = new QPushButton;
                 removeButton->setIcon(style()->standardIcon(QStyle::SP_TrashIcon));
                 removeButton->setToolTip("Remove");
                 removeButton->setAccessibleName("Remove KiwiSDR antenna");
                 styleKiwiIconButton(removeButton);
-                rowLayout->addWidget(removeButton, 1, 3);
+                rowLayout->addWidget(removeButton, 4, 3);
                 kiwiRowsLayout->addWidget(rowFrame);
 
                 auto updateProfile = [this, profile, nameEdit, endpointEdit,
@@ -3758,6 +3974,11 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                         this, updateProfile);
                 connect(endpointEdit, &QLineEdit::returnPressed,
                         this, updateProfile);
+                connect(passwordEdit, &QLineEdit::editingFinished,
+                        this, [this, profile, passwordEdit] {
+                    m_kiwiSdrManager->setProfilePassword(
+                        profile.id, passwordEdit->text());
+                });
                 connect(autoCheck, &QCheckBox::toggled,
                         this, [updateProfile](bool) { updateProfile(); });
                 connect(connectButton, &QPushButton::clicked,
@@ -3774,14 +3995,21 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 });
             }
 
+            addSectionHeader("ADD RECEIVER");
             auto* rowFrame = new QFrame;
             rowFrame->setObjectName("kiwiAntennaRow");
             rowFrame->setStyleSheet(kKiwiRowStyle);
             auto* rowLayout = new QGridLayout(rowFrame);
-            rowLayout->setContentsMargins(6, 5, 6, 5);
-            rowLayout->setHorizontalSpacing(6);
-            rowLayout->setVerticalSpacing(3);
+            rowLayout->setContentsMargins(10, 8, 10, 8);
+            rowLayout->setHorizontalSpacing(8);
+            rowLayout->setVerticalSpacing(4);
             rowLayout->setColumnStretch(0, 1);
+            rowLayout->setColumnStretch(1, 1);
+            rowLayout->setColumnStretch(2, 1);
+
+            addFieldLabel(rowLayout, "NAME", 0);
+            addFieldLabel(rowLayout, "SERVER", 1);
+            addFieldLabel(rowLayout, "PASSWORD", 2);
 
             auto* nameEdit = new QLineEdit;
             nameEdit->setMaxLength(16);
@@ -3790,7 +4018,7 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             nameEdit->setAccessibleDescription(
                 "Required display name for the new KiwiSDR receive antenna.");
             styleKiwiEdit(nameEdit);
-            rowLayout->addWidget(nameEdit, 0, 0);
+            rowLayout->addWidget(nameEdit, 2, 0);
 
             auto* endpointEdit = new QLineEdit;
             endpointEdit->setPlaceholderText("host:8073");
@@ -3798,69 +4026,79 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
             endpointEdit->setAccessibleDescription(
                 "Hostname or hostname:port for the new KiwiSDR receive antenna.");
             styleKiwiEdit(endpointEdit);
-            rowLayout->addWidget(endpointEdit, 1, 0);
+            rowLayout->addWidget(endpointEdit, 2, 1);
+
+            auto* passwordEdit = new QLineEdit;
+            passwordEdit->setEchoMode(QLineEdit::Password);
+            passwordEdit->setMaxLength(256);
+            passwordEdit->setObjectName("newKiwiPassword");
+            passwordEdit->setAccessibleName("New KiwiSDR password");
+            passwordEdit->setAccessibleDescription(
+                kiwiPasswordDescription);
+            styleKiwiEdit(passwordEdit);
+            rowLayout->addWidget(passwordEdit, 2, 2);
 
             auto* autoCheck = new QCheckBox;
-            autoCheck->setText("Auto");
+            autoCheck->setText("Auto-connect");
             autoCheck->setAccessibleName("Auto connect new KiwiSDR antenna");
             AetherSDR::ThemeManager::instance().applyStyleSheet(autoCheck,
                 "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
                 + kCheckBoxIndicator);
-            rowLayout->addWidget(autoCheck, 1, 1, Qt::AlignCenter);
+            rowLayout->addWidget(autoCheck, 3, 0, Qt::AlignLeft);
 
-            auto committed = std::make_shared<bool>(false);
-            auto commitNewRow = [this, nameEdit, endpointEdit, autoCheck,
-                                 committed] {
-                if (*committed) {
-                    return;
-                }
+            auto commitNewRow = [this, nameEdit, endpointEdit, passwordEdit,
+                                 autoCheck] {
                 const QString name = nameEdit->text().trimmed();
                 const QString endpoint =
                     KiwiSdrClient::normalizeEndpoint(endpointEdit->text());
                 if (name.isEmpty() || endpoint.isEmpty()) {
                     return;
                 }
-                *committed = true;
                 const QString id = m_kiwiSdrManager->addProfile(name, endpoint);
-                if (autoCheck->isChecked()) {
-                    KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(id);
-                    profile.autoConnect = true;
-                    m_kiwiSdrManager->updateProfile(profile);
+                if (id.isEmpty()) {
+                    return;
                 }
+                m_kiwiSdrManager->setProfilePassword(id, passwordEdit->text());
+                KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(id);
+                profile.autoConnect = autoCheck->isChecked();
+                m_kiwiSdrManager->updateProfile(profile);
             };
 
             // Browse the public KiwiSDR directory to fill in a receiver. Only
             // API-permitting receivers are listed (web-only operators honored).
-            // Picking one adds the profile immediately — no extra Tab/confirm.
+            // Picking one fills the fields; Add receiver commits the profile.
             auto* browseButton = new QPushButton("Browse public…");
             browseButton->setAccessibleName("Browse public KiwiSDR receivers");
             browseButton->setAccessibleDescription(
                 "Choose from the public KiwiSDR directory; receivers whose "
                 "operator disabled the external API are not shown.");
-            rowLayout->addWidget(browseButton, 0, 1);
+            styleKiwiButton(browseButton);
+            rowLayout->addWidget(browseButton, 3, 1);
             connect(browseButton, &QPushButton::clicked, this,
-                    [this, nameEdit, endpointEdit, commitNewRow] {
+                    [this, nameEdit, endpointEdit] {
                 KiwiPublicReceiverPicker picker(this);
                 if (picker.exec() == QDialog::Accepted
                     && !picker.selectedEndpoint().isEmpty()) {
                     endpointEdit->setText(picker.selectedEndpoint());
-                    if (nameEdit->text().trimmed().isEmpty())
+                    if (nameEdit->text().trimmed().isEmpty()) {
                         nameEdit->setText(picker.selectedName());
-                    commitNewRow();  // add directly; no Tab-out needed
+                    }
                 }
             });
+
+            auto* addButton = new QPushButton("Add receiver");
+            addButton->setAccessibleName("Add KiwiSDR receiver");
+            styleKiwiButton(addButton);
+            rowLayout->addWidget(addButton, 3, 2);
+            connect(addButton, &QPushButton::clicked, this, commitNewRow);
             kiwiRowsLayout->addWidget(rowFrame);
 
-            connect(nameEdit, &QLineEdit::editingFinished,
-                    this, commitNewRow);
             connect(nameEdit, &QLineEdit::returnPressed,
-                    this, commitNewRow);
-            connect(endpointEdit, &QLineEdit::editingFinished,
                     this, commitNewRow);
             connect(endpointEdit, &QLineEdit::returnPressed,
                     this, commitNewRow);
-            connect(autoCheck, &QCheckBox::toggled,
-                    this, [commitNewRow](bool) { commitNewRow(); });
+            connect(passwordEdit, &QLineEdit::returnPressed,
+                    this, commitNewRow);
 
             kiwiRowsLayout->addStretch(1);
         };

--- a/tests/kiwi_sdr_manager_password_test.cpp
+++ b/tests/kiwi_sdr_manager_password_test.cpp
@@ -146,6 +146,13 @@ int main(int argc, char** argv)
             return fail("latest password revision did not win");
         }
 
+        manager.setProfilePassword(first, "replacement");
+        if (store->pendingCount() != 0
+            || manager.profilePasswordPersistenceState(first)
+                != KiwiSdrPasswordPersistenceState::Stored) {
+            return fail("unchanged stored password queued another write");
+        }
+
         manager.setProfilePassword(first, "cannot-save");
         store->completeNext(
             {KiwiSdrCredentialResultCode::Error, {}, "keychain locked"});
@@ -155,6 +162,19 @@ int main(int argc, char** argv)
             || !manager.profilePasswordPersistenceDetail(first)
                     .contains("keychain locked")) {
             return fail("write failure did not preserve the session password and surface an error");
+        }
+
+        manager.setProfilePassword(first, "cannot-save");
+        if (store->pendingCount() != 1
+            || store->next().type != FakeCredentialStore::OperationType::Write
+            || manager.profilePasswordPersistenceState(first)
+                != KiwiSdrPasswordPersistenceState::Saving) {
+            return fail("unchanged password could not retry after a storage error");
+        }
+        store->completeNext({});
+        if (manager.profilePasswordPersistenceState(first)
+            != KiwiSdrPasswordPersistenceState::Stored) {
+            return fail("password retry did not restore stored state");
         }
 
         manager.setProfilePassword(second, "remove-me");

--- a/tests/kiwi_sdr_manager_password_test.cpp
+++ b/tests/kiwi_sdr_manager_password_test.cpp
@@ -1,0 +1,308 @@
+#include "core/AppSettings.h"
+#include "core/KiwiSdrManager.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include <memory>
+
+using namespace AetherSDR;
+
+namespace {
+
+constexpr const char* kProfilesKey = "KiwiSdrRxAntennas";
+
+class FakeCredentialStore final : public IKiwiSdrCredentialStore {
+public:
+    enum class OperationType { Read, Write, Remove };
+    struct Operation {
+        OperationType type;
+        QString key;
+        QString value;
+        QPointer<QObject> context;
+        Callback callback;
+    };
+
+    explicit FakeCredentialStore(bool persistent)
+        : m_persistent(persistent)
+    {
+    }
+
+    bool isPersistent() const override { return m_persistent; }
+
+    void read(const QString& key, QObject* context, Callback callback) override
+    {
+        m_operations.append(
+            {OperationType::Read, key, {}, context, std::move(callback)});
+    }
+
+    void write(const QString& key, const QString& value, QObject* context,
+               Callback callback) override
+    {
+        m_operations.append(
+            {OperationType::Write, key, value, context, std::move(callback)});
+    }
+
+    void remove(const QString& key, QObject* context,
+                Callback callback) override
+    {
+        m_operations.append(
+            {OperationType::Remove, key, {}, context, std::move(callback)});
+    }
+
+    int pendingCount() const { return m_operations.size(); }
+    const Operation& next() const { return m_operations.first(); }
+
+    void completeNext(const KiwiSdrCredentialResult& result)
+    {
+        Operation operation = m_operations.takeFirst();
+        if (operation.context) {
+            operation.callback(result);
+        }
+    }
+
+private:
+    bool m_persistent{false};
+    QList<Operation> m_operations;
+};
+
+int fail(const QString& message)
+{
+    qCritical().noquote() << message;
+    return 1;
+}
+
+void clearProfiles()
+{
+    AppSettings::instance().remove(QString::fromLatin1(kProfilesKey));
+    AppSettings::instance().save();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QTemporaryDir settingsHome;
+    if (!settingsHome.isValid()) {
+        return fail("could not create isolated settings home");
+    }
+    qputenv("CFFIXED_USER_HOME", settingsHome.path().toUtf8());
+    qputenv("XDG_CONFIG_HOME", settingsHome.path().toUtf8());
+    QCoreApplication app(argc, argv);
+    const QString configDir =
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+        + "/AetherSDR";
+    QDir().mkpath(configDir);
+    QFile settingsFile(configDir + "/AetherSDR.settings");
+    if (!settingsFile.open(QIODevice::WriteOnly | QIODevice::Text)
+        || settingsFile.write("<Settings></Settings>\n") < 0) {
+        return fail("could not initialize isolated AppSettings file");
+    }
+    settingsFile.close();
+    AppSettings::instance().load();
+    clearProfiles();
+
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        KiwiSdrManager manager(nullptr, store);
+        const QString first = manager.addProfile("First", "first.test:8073");
+        const QString second = manager.addProfile("Second", "second.test:8073");
+        manager.setProfilePassword(first, "alpha");
+        manager.setProfilePassword(second, "bravo");
+        if (manager.profilePassword(first) != "alpha"
+            || manager.profilePassword(second) != "bravo"
+            || store->pendingCount() != 2) {
+            return fail("per-profile passwords were not isolated");
+        }
+        store->completeNext({});
+        store->completeNext({});
+        if (manager.profilePasswordPersistenceState(first)
+                != KiwiSdrPasswordPersistenceState::Stored
+            || manager.profilePasswordPersistenceState(second)
+                != KiwiSdrPasswordPersistenceState::Stored) {
+            return fail("successful writes were not reported as stored");
+        }
+
+        manager.setProfilePassword(first, "first-edit");
+        manager.setProfilePassword(first, "replacement");
+        if (store->pendingCount() != 2
+            || store->next().value != "first-edit") {
+            return fail("password revisions were not handed to the ordered store");
+        }
+        store->completeNext({});
+        if (store->pendingCount() != 1
+            || store->next().value != "replacement") {
+            return fail("latest password revision did not remain ordered after the active write");
+        }
+        store->completeNext({});
+        if (manager.profilePassword(first) != "replacement"
+            || manager.profilePasswordPersistenceState(first)
+                != KiwiSdrPasswordPersistenceState::Stored) {
+            return fail("latest password revision did not win");
+        }
+
+        manager.setProfilePassword(first, "cannot-save");
+        store->completeNext(
+            {KiwiSdrCredentialResultCode::Error, {}, "keychain locked"});
+        if (manager.profilePassword(first) != "cannot-save"
+            || manager.profilePasswordPersistenceState(first)
+                != KiwiSdrPasswordPersistenceState::Error
+            || !manager.profilePasswordPersistenceDetail(first)
+                    .contains("keychain locked")) {
+            return fail("write failure did not preserve the session password and surface an error");
+        }
+
+        manager.setProfilePassword(second, "remove-me");
+        store->completeNext({});
+        QSignalSpy persistenceSpy(
+            &manager, &KiwiSdrManager::profilePasswordPersistenceChanged);
+        manager.removeProfile(second);
+        if (store->pendingCount() != 1
+            || store->next().type != FakeCredentialStore::OperationType::Remove) {
+            return fail("profile removal did not queue credential deletion");
+        }
+        store->completeNext(
+            {KiwiSdrCredentialResultCode::Error, {}, "delete denied"});
+        if (persistenceSpy.isEmpty()
+            || persistenceSpy.last().at(1).value<KiwiSdrPasswordPersistenceState>()
+                != KiwiSdrPasswordPersistenceState::Error
+            || !persistenceSpy.last().at(2).toString().contains("delete denied")) {
+            return fail("credential deletion failure was silent");
+        }
+
+        manager.removeProfile(first);
+        store->completeNext({});
+    }
+
+    clearProfiles();
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        {
+            KiwiSdrManager manager(nullptr, store);
+            const QString id =
+                manager.addProfile("Shutdown", "shutdown.test:8073");
+            manager.setProfilePassword(id, "first-edit");
+            manager.setProfilePassword(id, "replacement");
+        }
+        if (store->pendingCount() != 2
+            || store->next().type != FakeCredentialStore::OperationType::Write
+            || store->next().value != "first-edit") {
+            return fail("manager teardown discarded a handed-off password revision");
+        }
+        store->completeNext({});
+        if (store->pendingCount() != 1
+            || store->next().value != "replacement") {
+            return fail("latest password revision did not survive manager teardown");
+        }
+        store->completeNext({});
+    }
+
+    clearProfiles();
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        {
+            KiwiSdrManager manager(nullptr, store);
+            const QString id =
+                manager.addProfile("Delete", "delete.test:8073");
+            manager.setProfilePassword(id, "pending-write");
+            manager.removeProfile(id);
+        }
+        if (store->pendingCount() != 2
+            || store->next().type != FakeCredentialStore::OperationType::Write) {
+            return fail("profile removal did not preserve the ordered write/delete handoff");
+        }
+        store->completeNext({});
+        if (store->pendingCount() != 1
+            || store->next().type != FakeCredentialStore::OperationType::Remove) {
+            return fail("credential deletion did not survive manager teardown");
+        }
+        store->completeNext({});
+    }
+
+    clearProfiles();
+    QString persistedProfileId;
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        KiwiSdrManager manager(nullptr, store);
+        persistedProfileId = manager.addProfile("Deferred", "deferred.test:8073");
+    }
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        KiwiSdrManager manager(nullptr, store);
+        if (store->pendingCount() != 1
+            || store->next().type != FakeCredentialStore::OperationType::Read) {
+            return fail("startup did not request the saved profile password");
+        }
+        manager.connectProfile(persistedProfileId);
+        if (manager.isProfilePasswordLoaded(persistedProfileId)
+            || manager.state(persistedProfileId)
+                != KiwiSdrClient::State::Disconnected) {
+            return fail("connection was not deferred while the password was loading");
+        }
+        store->completeNext(
+            {KiwiSdrCredentialResultCode::Success, "loaded-secret", {}});
+        if (!manager.isProfilePasswordLoaded(persistedProfileId)
+            || manager.profilePassword(persistedProfileId) != "loaded-secret") {
+            return fail("deferred password read did not complete");
+        }
+    }
+    {
+        auto store = std::make_shared<FakeCredentialStore>(true);
+        KiwiSdrManager manager(nullptr, store);
+        manager.connectProfile(persistedProfileId);
+        store->completeNext(
+            {KiwiSdrCredentialResultCode::Error, {}, "read denied"});
+        if (!manager.isProfilePasswordLoaded(persistedProfileId)
+            || manager.profilePasswordPersistenceState(persistedProfileId)
+                != KiwiSdrPasswordPersistenceState::Error
+            || manager.state(persistedProfileId)
+                != KiwiSdrClient::State::Disconnected
+            || !manager.profilePasswordPersistenceDetail(persistedProfileId)
+                    .contains("read denied")) {
+            return fail("credential read failure did not stop deferred connection and surface an error");
+        }
+        manager.removeProfile(persistedProfileId);
+        store->completeNext({});
+    }
+
+    clearProfiles();
+    QString sessionProfileId;
+    {
+        auto store = std::make_shared<FakeCredentialStore>(false);
+        KiwiSdrManager manager(nullptr, store);
+        sessionProfileId = manager.addProfile("Session", "session.test:8073");
+        manager.setProfilePassword(sessionProfileId, "session-secret");
+        if (manager.profilePasswordPersistenceState(sessionProfileId)
+                != KiwiSdrPasswordPersistenceState::SessionOnly
+            || AppSettings::instance()
+                   .value(QString::fromLatin1(kProfilesKey)).toString()
+                   .contains("session-secret")) {
+            return fail("no-keychain fallback was not session-only");
+        }
+        store->completeNext({});
+    }
+    {
+        auto store = std::make_shared<FakeCredentialStore>(false);
+        KiwiSdrManager manager(nullptr, store);
+        if (store->pendingCount() != 1) {
+            return fail("session-only restart did not perform a fresh credential read");
+        }
+        store->completeNext(
+            {KiwiSdrCredentialResultCode::NotFound, {}, {}});
+        if (manager.profilePassword(sessionProfileId).size() != 0
+            || manager.profilePasswordPersistenceState(sessionProfileId)
+                != KiwiSdrPasswordPersistenceState::NoPassword) {
+            return fail("session-only password survived a simulated restart");
+        }
+        manager.removeProfile(sessionProfileId);
+        store->completeNext({});
+    }
+
+    clearProfiles();
+    return 0;
+}

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -56,6 +56,27 @@ int main()
 {
     using namespace AetherSDR::KiwiSdrProtocol;
 
+    if (formatAuthCommand(QString())
+        != QStringLiteral("SET auth t=kiwi p=#")) {
+        return fail("empty Kiwi password should use the public sentinel");
+    }
+    if (formatAuthCommand(QStringLiteral("space #100% ü"))
+        != QStringLiteral("SET auth t=kiwi p=space%20%23100%25%20%C3%BC")) {
+        return fail("Kiwi password should use UTF-8 percent encoding");
+    }
+    if (!authPasswordFitsServerLimit(QString(256, QLatin1Char('a')))
+        || formatAuthCommand(QString(256, QLatin1Char('a'))).isEmpty()) {
+        return fail("256 unreserved password characters should fit");
+    }
+    if (authPasswordFitsServerLimit(QString(257, QLatin1Char('a')))
+        || !formatAuthCommand(QString(257, QLatin1Char('a'))).isEmpty()) {
+        return fail("passwords beyond the server token limit should fail closed");
+    }
+    if (!authPasswordFitsServerLimit(QString(85, QLatin1Char(' ')))
+        || authPasswordFitsServerLimit(QString(86, QLatin1Char(' ')))) {
+        return fail("password limit should apply after percent encoding");
+    }
+
     const QByteArray soundFrame =
         QByteArray("SND", 3)
         + QByteArray::fromHex("051234");


### PR DESCRIPTION
## Summary

Adds a separate optional password for each configured KiwiSDR receiver and sends it using the authentication format verified against the license-compatible KiwiSDR server source. Passwords are stored in the operating system credential store when available, with session-only fallback behavior and clear persistence status/error reporting. Radio Setup’s KiwiSDR section is reorganized into configured-receiver and add-receiver sections; users change a password by typing over the current masked value without entering the old password. Credential operations are serialized independently of `KiwiSdrManager`, ensuring queued replacements and deletions complete during application teardown.

## Constitution principle honored

Principle IV — the authentication implementation is clean-room and documents its provenance from license-compatible KiwiSDR server code, without consulting the AGPL client.

Principle VII — passwords are UTF-8 percent-encoded and validated against the server’s encoded 256-character limit before reaching the protocol boundary.

Principle XI — password formatting, per-profile isolation, replacement ordering, failure reporting, session-only fallback, teardown behavior, and the real GUI workflow are covered by focused tests and automation-bridge validation.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local validation completed:

- Built `AetherSDR`, `kiwi_sdr_protocol_test`, and `kiwi_sdr_manager_password_test`.
- Ran all five KiwiSDR tests successfully with `ctest --test-dir build --output-on-failure -R '^kiwi_'`.
- Built and ran the password manager test without QtKeychain to verify session-only fallback behavior.
- Built `RadioSetupDialog.cpp` in the no-keychain configuration.
- Used the authenticated automation bridge with an isolated application profile to verify:
  - the reorganized KiwiSDR settings layout;
  - password values remain masked in the semantic widget tree;
  - each receiver has its own password and persistence status;
  - users can type over the current password without an old-password field;
  - removing a receiver and immediately quitting still deletes its macOS Keychain credential.
- Confirmed no second AetherSDR instance was running during bridge testing.
- `python3 tools/check_engine_boundary.py --strict` reports zero blockers.
- `python3 tools/check_a11y.py` reports only eight unrelated existing warnings.
- `git diff --check` passes.

A live password-protected KiwiSDR receiver was not available for end-to-end radio verification. Authentication formatting was instead validated against the compatible server implementation and focused protocol tests.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable

No GHSA applies to this feature.
