### PR TITLE
ci(macos): sign extra Contents/MacOS/ helpers (aether-dv-waveform) before notarization

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -202,6 +202,20 @@ jobs:
             codesign --force --options runtime --timestamp --sign "$SIGN_ID" "$fw"
           done
 
+          # 2b. Sign any extra helper executables in Contents/MacOS/ (e.g.
+          # aether-dv-waveform, the D-STAR ThumbDV helper). The bundle sign in
+          # step 3 runs without --deep, and these aren't .dylib or frameworks,
+          # so without this they reach notarization unsigned — no Developer ID,
+          # no secure timestamp, no hardened runtime — and Apple rejects the
+          # whole archive. Skip the bundle's main executable (step 3 signs it).
+          find "$APP/Contents/MacOS" -maxdepth 1 -type f ! -name AetherSDR -print0 |
+            while IFS= read -r -d '' bin; do
+              if file "$bin" | grep -q "Mach-O"; then
+                echo "Signing helper executable: $bin"
+                codesign --force --options runtime --timestamp --sign "$SIGN_ID" "$bin"
+              fi
+            done
+
           # 3. Sign the main app bundle last (no --deep)
           codesign --force --options runtime --timestamp \
             --entitlements packaging/macos/AetherSDR.entitlements \


### PR DESCRIPTION
## Problem
The **v26.7.2 macOS DMG build failed** at notarization. Apple rejected the archive with three errors, all pointing at one file:

```
path: AetherSDR.app/Contents/MacOS/aether-dv-waveform
- The binary is not signed with a valid Developer ID certificate.
- The signature does not include a secure timestamp.
- The executable does not have the hardened runtime enabled.
```

`aether-dv-waveform` (the D-STAR ThumbDV helper, new in #4186) is a **plain executable in `Contents/MacOS/`** — not a `.dylib` and not a framework — so the existing dylib/framework signing passes skip it, and the step-3 bundle sign runs **without `--deep`**, so it never reaches the helper. It hit notarization unsigned and Apple rejected the whole DMG.

## Fix
Add a signing pass (step 2b) that signs every non-main Mach-O in `Contents/MacOS/` with `--options runtime --timestamp --sign "Developer ID Application"` **before** the bundle is sealed. The `find … ! -name AetherSDR` scope means it also covers any future helper without another workflow edit.

## Validation
Kicked off a `workflow_dispatch` run of this workflow on the branch — it builds + notarizes the DMG (release/Store upload steps are gated on a tag ref, so they no-op on a branch). The corrected DMGs will be uploaded to the **v26.7.2** release manually once that run passes; this PR fixes the workflow for all future tagged releases.

YAML + bash syntax validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
