### PR TITLE
ci(macos): cache the Intel from-source Qt build (~2.5h → ~20m)

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -58,8 +58,21 @@ jobs:
             echo "Pre-built Qt not available at $URL — falling back to from-source build (~27 min).  Run the Build macOS Qt (Intel deps) workflow to populate this asset."
           fi
 
-      - name: Build Qt from source (Intel only, fallback)
+      - name: Cache Qt (Intel from-source build)
+        # The pre-built Qt tarball above is the fast path; when that asset is
+        # missing we compile Qt from source (~2 h on the Intel runner). Cache the
+        # resulting qt-install prefix so it's built once per Qt version and
+        # restored on every later run. Bump the version in the key whenever the
+        # Qt version / module set below changes (same as the download URL above).
         if: matrix.label == 'intel' && steps.qt-download.outputs.downloaded != 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        id: qt-cache
+        with:
+          path: qt-install
+          key: qt-intel-src-6.8.3-deploy13.0-qtbase.mm.ws.sp.st
+
+      - name: Build Qt from source (Intel only, fallback)
+        if: matrix.label == 'intel' && steps.qt-download.outputs.downloaded != 'true' && steps.qt-cache.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 --branch v6.8.3 https://code.qt.io/qt/qt5.git qt-src
           cd qt-src


### PR DESCRIPTION
## Problem
The Intel macOS DMG job builds **Qt from source (~2 h)** on every release. The intended fast path — the pinned `deps-qt-6.8.3-macos-intel` release tarball — is currently missing, so the "Download pre-built Qt" step no-ops (11 s) and it falls through to the from-source compile every time. (This is why the v26.7.2 Intel DMG took hours while Apple-silicon finished in minutes.)

## Fix
Wrap the from-source build in `actions/cache` keyed on the Qt version, caching the resulting `qt-install/` prefix:

- **First run:** cache miss → build Qt from source → `qt-install/` saved.
- **Later runs:** cache hit → restore `qt-install/` → **skip the 2 h build** (the from-source step now also gates on `cache-hit != 'true'`).

Default-branch caches are visible to tag-triggered builds, so once a `main`/tag run populates it, every subsequent Intel release restores it — cutting Intel build time from ~2.5 h to ~20 min. Self-invalidating per Qt version; the key note reminds bumping it alongside the pinned version/URL.

Same `actions/cache` SHA already used by the DeepFilterNet cache step in this workflow. YAML validated. No effect on the Apple-silicon path.

## Note
This complements, doesn't replace, populating the pre-built Qt tarball via `build-macos-qt.yml` — but the cache is self-maintaining and needs no separate workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
