### PR TITLE
fix(macos): put AetherDV.cfg in Contents/Resources, not Contents/MacOS (codesign)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1267,8 +1267,14 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
     if(APPLE)
         target_link_libraries(aether-dv-waveform PRIVATE "-framework IOKit")
         set(DIGITAL_VOICE_WAVEFORM_RUNTIME_DIR "${CMAKE_BINARY_DIR}/AetherSDR.app/Contents/MacOS")
+        # AetherDV.cfg is a metadata manifest, not a Mach-O, so it must live in
+        # Contents/Resources/ — codesign rejects a non-executable in MacOS/
+        # ("code object is not signed at all"). The helper is env-var driven and
+        # never reads the .cfg, so this is purely its packaging location.
+        set(DIGITAL_VOICE_WAVEFORM_CONFIG_DIR "${CMAKE_BINARY_DIR}/AetherSDR.app/Contents/Resources")
     else()
         set(DIGITAL_VOICE_WAVEFORM_RUNTIME_DIR "${CMAKE_BINARY_DIR}")
+        set(DIGITAL_VOICE_WAVEFORM_CONFIG_DIR "${CMAKE_BINARY_DIR}")
     endif()
     set_target_properties(aether-dv-waveform PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${DIGITAL_VOICE_WAVEFORM_RUNTIME_DIR}"
@@ -1277,13 +1283,15 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
         target_compile_options(aether-dv-waveform PRIVATE -w)
     endif()
     add_custom_command(TARGET aether-dv-waveform POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${DIGITAL_VOICE_WAVEFORM_CONFIG_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "${DIGITAL_VOICE_WAVEFORM_DIR}/config/AetherDV.cfg"
-            "$<TARGET_FILE_DIR:aether-dv-waveform>/AetherDV.cfg"
+            "${DIGITAL_VOICE_WAVEFORM_CONFIG_DIR}/AetherDV.cfg"
         COMMAND ${CMAKE_COMMAND} -E rm -f
             "$<TARGET_FILE_DIR:aether-dv-waveform>/aether-dstar-waveform"
             "$<TARGET_FILE_DIR:aether-dv-waveform>/aether-dstar-waveform.exe"
             "$<TARGET_FILE_DIR:aether-dv-waveform>/ThumbDV.cfg"
+            "$<TARGET_FILE_DIR:aether-dv-waveform>/AetherDV.cfg"
         COMMENT "Copying AetherDV waveform manifest"
     )
     add_test(NAME aether_dv_waveform_no_args
@@ -3507,14 +3515,17 @@ if(APPLE)
         file(REMOVE
             "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/AetherSDR.app/Contents/MacOS/aether-dstar-waveform"
             "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/AetherSDR.app/Contents/MacOS/aether-dstar-waveform.exe"
-            "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/AetherSDR.app/Contents/MacOS/ThumbDV.cfg")
+            "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/AetherSDR.app/Contents/MacOS/ThumbDV.cfg"
+            "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/AetherSDR.app/Contents/MacOS/AetherDV.cfg")
     ]])
     if(TARGET aether-dv-waveform)
         install(PROGRAMS "$<TARGET_FILE:aether-dv-waveform>"
             DESTINATION AetherSDR.app/Contents/MacOS
         )
+        # The manifest is not a Mach-O; keep it out of MacOS/ (codesign) — see
+        # the POST_BUILD note above.
         install(FILES third_party/smartsdr-dsp/config/AetherDV.cfg
-            DESTINATION AetherSDR.app/Contents/MacOS
+            DESTINATION AetherSDR.app/Contents/Resources
         )
     endif()
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1291,9 +1291,18 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
             "$<TARGET_FILE_DIR:aether-dv-waveform>/aether-dstar-waveform"
             "$<TARGET_FILE_DIR:aether-dv-waveform>/aether-dstar-waveform.exe"
             "$<TARGET_FILE_DIR:aether-dv-waveform>/ThumbDV.cfg"
-            "$<TARGET_FILE_DIR:aether-dv-waveform>/AetherDV.cfg"
         COMMENT "Copying AetherDV waveform manifest"
     )
+    if(APPLE)
+        # Clear a stale AetherDV.cfg left in the OLD Contents/MacOS/ location by
+        # an incremental build tree from before the move to Contents/Resources/.
+        # Apple-only: elsewhere RUNTIME_DIR == CONFIG_DIR == ${CMAKE_BINARY_DIR},
+        # so removing it there would delete the manifest just staged above.
+        add_custom_command(TARGET aether-dv-waveform POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E rm -f
+                "${DIGITAL_VOICE_WAVEFORM_RUNTIME_DIR}/AetherDV.cfg"
+        )
+    endif()
     add_test(NAME aether_dv_waveform_no_args
         COMMAND ${CMAKE_COMMAND}
             -DHELPER=$<TARGET_FILE:aether-dv-waveform>


### PR DESCRIPTION
## Problem
`AetherDV.cfg` — the D-STAR waveform **manifest** (metadata: Name/Version/Executable/mode) — is installed into `AetherSDR.app/Contents/MacOS/`. That directory is **executables-only** per Apple, and `codesign` rejects a non–Mach-O there:

```
build/AetherSDR.app: code object is not signed at all
In subcomponent: …/Contents/MacOS/AetherDV.cfg
```

This **hard-failed the Intel v26.7.2 DMG** at code-sign. The **Apple-silicon** runner's codesign *tolerated* the same misplaced file and sealed it, so that DMG built + notarized — but it's still malformed/fragile (a future codesign or macOS update could reject it too). So this is latent on **both** arches, not Intel-only.

## Fix
Move the manifest to `Contents/Resources/` (build-tree copy + install), matching how the DFNR model is already handled, and clear any stale copy from `MacOS/`. The **binary** `aether-dv-waveform` stays in `Contents/MacOS/` (signed by #4213).

**No runtime impact:** `aether-dv-waveform` is entirely env-var driven (`AETHER_DV_*` / `AETHER_DSTAR_*`, set by `DigitalVoiceWaveformProcess`) and never reads `AetherDV.cfg` — grep confirms nothing in the repo reads it. It's pure metadata, so relocating it can't affect D-STAR.

## Rollout
After merge, rebuild **both** macOS arches and replace **both** DMGs on the v26.7.2 release (the current Apple-silicon DMG has the malformed layout).

## Testing note
The code-sign/notarization outcome is verified by the build itself. Since the manifest isn't read at runtime, there's no D-STAR runtime behavior to re-verify from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
