### PR TITLE
Fix D-STAR slice reconciliation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2712,7 +2712,7 @@ add_executable(digital_voice_slice_lifecycle_test
     src/core/DigitalVoiceModeRegistry.cpp
 )
 target_include_directories(digital_voice_slice_lifecycle_test PRIVATE src)
-target_link_libraries(digital_voice_slice_lifecycle_test PRIVATE Qt6::Core)
+target_link_libraries(digital_voice_slice_lifecycle_test PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME digital_voice_slice_lifecycle_test COMMAND digital_voice_slice_lifecycle_test)
 
 add_executable(dstar_model_test
@@ -2726,7 +2726,7 @@ add_executable(dstar_model_test
     src/core/AppSettings.cpp
 )
 target_include_directories(dstar_model_test PRIVATE src)
-target_link_libraries(dstar_model_test PRIVATE Qt6::Core Qt6::Network)
+target_link_libraries(dstar_model_test PRIVATE Qt6::Core Qt6::Network Qt6::Test)
 if(Qt6SerialPort_FOUND)
     target_compile_definitions(dstar_model_test PRIVATE HAVE_SERIALPORT)
     target_link_libraries(dstar_model_test PRIVATE Qt6::SerialPort)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,6 +727,7 @@ set(GUI_SOURCES
     src/gui/RadioSetupDialog.cpp
     src/gui/NetworkDiagnosticsDialog.cpp
     src/gui/Ax25HfPacketDecodeDialog.cpp
+    src/gui/DStarAccessibility.cpp
     src/gui/DStarModemPage.cpp
     src/gui/AprsMessagesDialog.cpp
     src/gui/AprsSymbolIcons.cpp
@@ -2732,6 +2733,16 @@ if(Qt6SerialPort_FOUND)
     target_link_libraries(dstar_model_test PRIVATE Qt6::SerialPort)
 endif()
 add_test(NAME dstar_model_test COMMAND dstar_model_test)
+
+add_executable(dstar_accessibility_test
+    tests/dstar_accessibility_test.cpp
+    src/gui/DStarAccessibility.cpp
+)
+target_include_directories(dstar_accessibility_test PRIVATE src)
+target_link_libraries(dstar_accessibility_test PRIVATE Qt6::Widgets)
+add_test(NAME dstar_accessibility_test COMMAND dstar_accessibility_test)
+set_tests_properties(dstar_accessibility_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp

--- a/src/core/DigitalVoiceModeRegistry.cpp
+++ b/src/core/DigitalVoiceModeRegistry.cpp
@@ -68,17 +68,24 @@ bool DigitalVoiceModeRegistry::activateMode(DigitalVoiceModeId id, QString* erro
 std::optional<DigitalVoiceSliceClaim> DigitalVoiceModeRegistry::deactivateMode(
     DigitalVoiceModeId id)
 {
-    QMutexLocker locker(&m_mutex);
-    if (!m_activeMode.has_value() || m_activeMode.value() != id) {
-        return std::nullopt;
-    }
     std::optional<DigitalVoiceSliceClaim> claim;
-    if (m_activeSliceId >= 0) {
-        claim = DigitalVoiceSliceClaim{id, m_activeSliceId, m_previousMode};
+    bool releasedSlice = false;
+    {
+        QMutexLocker locker(&m_mutex);
+        if (!m_activeMode.has_value() || m_activeMode.value() != id) {
+            return std::nullopt;
+        }
+        if (m_activeSliceId >= 0) {
+            claim = DigitalVoiceSliceClaim{id, m_activeSliceId, m_previousMode};
+            releasedSlice = true;
+        }
+        m_activeMode.reset();
+        m_activeSliceId = -1;
+        m_previousMode.clear();
     }
-    m_activeMode.reset();
-    m_activeSliceId = -1;
-    m_previousMode.clear();
+    if (releasedSlice) {
+        emit activeSliceChanged(-1);
+    }
     return claim;
 }
 
@@ -104,43 +111,57 @@ bool DigitalVoiceModeRegistry::transferSlice(
     std::optional<DigitalVoiceSliceClaim>* displaced,
     QString* error)
 {
-    QMutexLocker locker(&m_mutex);
-    if (!m_activeMode.has_value() || m_activeMode.value() != id) {
-        if (error) {
-            *error = QStringLiteral("The requested digital-voice mode is not running");
-        }
-        return false;
-    }
-    if (m_activeSliceId >= 0 && m_activeSliceId != sliceId) {
-        if (displaced == nullptr) {
+    bool changedSlice = false;
+    {
+        QMutexLocker locker(&m_mutex);
+        if (!m_activeMode.has_value() || m_activeMode.value() != id) {
             if (error) {
-                *error = QStringLiteral("Digital voice is already active on slice %1")
-                    .arg(m_activeSliceId);
+                *error = QStringLiteral("The requested digital-voice mode is not running");
             }
             return false;
         }
-        *displaced = DigitalVoiceSliceClaim{id, m_activeSliceId, m_previousMode};
-    } else if (displaced != nullptr) {
-        displaced->reset();
+        if (m_activeSliceId >= 0 && m_activeSliceId != sliceId) {
+            if (displaced == nullptr) {
+                if (error) {
+                    *error = QStringLiteral("Digital voice is already active on slice %1")
+                        .arg(m_activeSliceId);
+                }
+                return false;
+            }
+            *displaced = DigitalVoiceSliceClaim{id, m_activeSliceId, m_previousMode};
+        } else if (displaced != nullptr) {
+            displaced->reset();
+        }
+        QString restoreMode = previousMode.trimmed().toUpper();
+        if (restoreMode.isEmpty() || modeForRadioMode(restoreMode).has_value()) {
+            restoreMode = descriptor(id).underlyingMode;
+        }
+        const bool moved = m_activeSliceId >= 0 && m_activeSliceId != sliceId;
+        changedSlice = m_activeSliceId != sliceId;
+        m_activeSliceId = sliceId;
+        if (m_previousMode.isEmpty() || moved) {
+            m_previousMode = restoreMode;
+        }
     }
-    QString restoreMode = previousMode.trimmed().toUpper();
-    if (restoreMode.isEmpty() || modeForRadioMode(restoreMode).has_value()) {
-        restoreMode = descriptor(id).underlyingMode;
-    }
-    const bool moved = m_activeSliceId >= 0 && m_activeSliceId != sliceId;
-    m_activeSliceId = sliceId;
-    if (m_previousMode.isEmpty() || moved) {
-        m_previousMode = restoreMode;
+    if (changedSlice) {
+        emit activeSliceChanged(sliceId);
     }
     return true;
 }
 
 void DigitalVoiceModeRegistry::releaseSlice(int sliceId)
 {
-    QMutexLocker locker(&m_mutex);
-    if (m_activeSliceId == sliceId) {
-        m_activeSliceId = -1;
-        m_previousMode.clear();
+    bool releasedSlice = false;
+    {
+        QMutexLocker locker(&m_mutex);
+        if (m_activeSliceId == sliceId) {
+            m_activeSliceId = -1;
+            m_previousMode.clear();
+            releasedSlice = true;
+        }
+    }
+    if (releasedSlice) {
+        emit activeSliceChanged(-1);
     }
 }
 

--- a/src/core/DigitalVoiceModeRegistry.h
+++ b/src/core/DigitalVoiceModeRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMutex>
+#include <QObject>
 #include <QString>
 #include <QList>
 
@@ -27,8 +28,10 @@ struct DigitalVoiceSliceClaim {
     QString previousMode;
 };
 
-class DigitalVoiceModeRegistry
+class DigitalVoiceModeRegistry : public QObject
 {
+    Q_OBJECT
+
 public:
     static DigitalVoiceModeRegistry& instance();
 
@@ -53,6 +56,9 @@ public:
     std::optional<DigitalVoiceModeId> activeMode() const;
     int activeSliceId() const;
     std::optional<DigitalVoiceSliceClaim> activeClaim() const;
+
+signals:
+    void activeSliceChanged(int sliceId);
 
 private:
     DigitalVoiceModeRegistry() = default;

--- a/src/gui/DStarAccessibility.cpp
+++ b/src/gui/DStarAccessibility.cpp
@@ -1,0 +1,28 @@
+#include "DStarAccessibility.h"
+
+#include <QAccessible>
+#include <QCoreApplication>
+#include <QLabel>
+
+namespace AetherSDR {
+
+void updateDStarSliceStateLabel(QLabel* label, const QString& sliceText)
+{
+    if (!label) {
+        return;
+    }
+
+    const QString accessibleName = QCoreApplication::translate(
+        "DStarModemPage", "D-STAR slice: %1").arg(sliceText);
+    if (label->text() == sliceText
+        && label->accessibleName() == accessibleName) {
+        return;
+    }
+
+    label->setText(sliceText);
+    label->setAccessibleName(accessibleName);
+    QAccessibleEvent event(label, QAccessible::NameChanged);
+    QAccessible::updateAccessibility(&event);
+}
+
+} // namespace AetherSDR

--- a/src/gui/DStarAccessibility.h
+++ b/src/gui/DStarAccessibility.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class QLabel;
+class QString;
+
+namespace AetherSDR {
+
+void updateDStarSliceStateLabel(QLabel* label, const QString& sliceText);
+
+} // namespace AetherSDR

--- a/src/gui/DStarModemPage.cpp
+++ b/src/gui/DStarModemPage.cpp
@@ -3,6 +3,7 @@
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
+#include <QAccessible>
 #include <QCheckBox>
 #include <QColor>
 #include <QComboBox>
@@ -58,6 +59,7 @@ QLabel#DStarPanelTitle {
 }
 QLabel#DStarModeLabel,
 QLabel#DStarMuted,
+QLabel#dstarSliceState,
 QLabel#DStarTrafficMeta {
     color: #8d99ad;
     background: transparent;
@@ -282,7 +284,8 @@ void DStarModemPage::buildHeader()
     layout->addWidget(m_serviceState);
 
     m_sliceState = new QLabel(tr("No DSTR slice"), frame);
-    m_sliceState->setObjectName(QStringLiteral("DStarMuted"));
+    m_sliceState->setObjectName(QStringLiteral("dstarSliceState"));
+    m_sliceState->setAccessibleName(tr("D-STAR slice"));
     m_sliceState->setMinimumWidth(150);
     m_sliceState->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     layout->addWidget(m_sliceState);
@@ -780,14 +783,20 @@ void DStarModemPage::refreshService()
     m_executableEdit->setReadOnly(lockServiceFields);
     m_browseButton->setEnabled(!lockServiceFields);
 
+    QString sliceText;
     const int sliceId = model.activeSliceId();
     SliceModel* slice = sliceId >= 0 ? m_radio->slice(sliceId) : nullptr;
     if (slice) {
-        m_sliceState->setText(tr("Slice %1  %2 MHz")
+        sliceText = tr("Slice %1  %2 MHz")
             .arg(slice->letter())
-            .arg(displayFrequency(slice->frequency())));
+            .arg(displayFrequency(slice->frequency()));
     } else {
-        m_sliceState->setText(tr("No DSTR slice"));
+        sliceText = tr("No DSTR slice");
+    }
+    if (m_sliceState->text() != sliceText) {
+        m_sliceState->setText(sliceText);
+        QAccessibleEvent event(m_sliceState, QAccessible::NameChanged);
+        QAccessible::updateAccessibility(&event);
     }
     m_footerState->setText(state.toUpper());
 }

--- a/src/gui/DStarModemPage.cpp
+++ b/src/gui/DStarModemPage.cpp
@@ -1,9 +1,10 @@
 #include "DStarModemPage.h"
 
+#include "DStarAccessibility.h"
+
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
-#include <QAccessible>
 #include <QCheckBox>
 #include <QColor>
 #include <QComboBox>
@@ -283,9 +284,9 @@ void DStarModemPage::buildHeader()
     m_serviceState->setMinimumWidth(78);
     layout->addWidget(m_serviceState);
 
-    m_sliceState = new QLabel(tr("No DSTR slice"), frame);
+    m_sliceState = new QLabel(frame);
     m_sliceState->setObjectName(QStringLiteral("dstarSliceState"));
-    m_sliceState->setAccessibleName(tr("D-STAR slice"));
+    updateDStarSliceStateLabel(m_sliceState, tr("No DSTR slice"));
     m_sliceState->setMinimumWidth(150);
     m_sliceState->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     layout->addWidget(m_sliceState);
@@ -793,11 +794,7 @@ void DStarModemPage::refreshService()
     } else {
         sliceText = tr("No DSTR slice");
     }
-    if (m_sliceState->text() != sliceText) {
-        m_sliceState->setText(sliceText);
-        QAccessibleEvent event(m_sliceState, QAccessible::NameChanged);
-        QAccessible::updateAccessibility(&event);
-    }
+    updateDStarSliceStateLabel(m_sliceState, sliceText);
     m_footerState->setText(state.toUpper());
 }
 

--- a/src/models/DStarModel.cpp
+++ b/src/models/DStarModel.cpp
@@ -233,6 +233,11 @@ DStarModel::DStarModel(QObject* parent, bool autoSelectSerial)
             this, &DStarModel::serviceChanged);
     connect(&process, &DigitalVoiceWaveformProcess::metricsChanged,
             this, &DStarModel::serviceChanged);
+    connect(&DigitalVoiceModeRegistry::instance(),
+            &DigitalVoiceModeRegistry::activeSliceChanged,
+            this,
+            [this](int) { emit serviceChanged(); },
+            Qt::QueuedConnection);
 
     m_serialProbe.setProcessChannelMode(QProcess::MergedChannels);
     connect(&m_serialProbe,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -457,8 +457,17 @@ RadioModel::RadioModel(QObject* parent)
         if (state == DigitalVoiceWaveformProcess::State::Running) {
             m_dstarRuntimeConfigurationPending = true;
             syncDigitalVoiceTxSelection(true);
+            applyPendingDStarRuntimeConfiguration();
         }
     });
+    connect(&DigitalVoiceModeRegistry::instance(),
+            &DigitalVoiceModeRegistry::activeSliceChanged,
+            this,
+            [this](int) {
+        m_lastDigitalVoiceTxSelectionKey.clear();
+        syncDigitalVoiceTxSelection(true);
+        applyPendingDStarRuntimeConfiguration();
+    }, Qt::QueuedConnection);
 
     const QString digitalVoiceDir =
         QFileInfo(AppSettings::instance().filePath()).absolutePath()

--- a/tests/digital_voice_slice_lifecycle_test.cpp
+++ b/tests/digital_voice_slice_lifecycle_test.cpp
@@ -2,6 +2,7 @@
 #include "models/SliceModel.h"
 
 #include <QCoreApplication>
+#include <QSignalSpy>
 
 #include <iostream>
 
@@ -27,6 +28,8 @@ int main(int argc, char** argv)
     registry.deactivateMode(DigitalVoiceModeId::DStar);
     ok &= expect(registry.activateMode(DigitalVoiceModeId::DStar),
                  "D-STAR service activates");
+    QSignalSpy activeSliceSpy(&registry,
+                              &DigitalVoiceModeRegistry::activeSliceChanged);
 
     SliceModel first(1);
     first.setMode(QStringLiteral("LSB"));
@@ -36,6 +39,9 @@ int main(int argc, char** argv)
                  && initialClaim->sliceId == 1
                  && initialClaim->previousMode == QStringLiteral("LSB"),
                  "slice claim retains the operator's previous mode");
+    ok &= expect(activeSliceSpy.size() == 1
+                 && activeSliceSpy.takeFirst().at(0).toInt() == 1,
+                 "slice claim announces the controlled slice");
 
     SliceModel second(2);
     int correctionCount = 0;
@@ -80,6 +86,9 @@ int main(int argc, char** argv)
     second.setMode(stoppedClaim->previousMode);
     ok &= expect(second.mode() == QStringLiteral("FM"),
                  "controlled slice restores without being removed");
+    ok &= expect(!activeSliceSpy.isEmpty()
+                 && activeSliceSpy.constLast().at(0).toInt() == -1,
+                 "service stop announces that no slice is controlled");
 
     ok &= expect(registry.activateMode(DigitalVoiceModeId::DStar),
                  "service reactivates");

--- a/tests/dstar_accessibility_test.cpp
+++ b/tests/dstar_accessibility_test.cpp
@@ -1,0 +1,49 @@
+#include "gui/DStarAccessibility.h"
+
+#include <QAccessible>
+#include <QApplication>
+#include <QLabel>
+
+#include <cstdio>
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+    QLabel label;
+
+    AetherSDR::updateDStarSliceStateLabel(
+        &label, QStringLiteral("No DSTR slice"));
+    QAccessibleInterface* accessible =
+        QAccessible::queryAccessibleInterface(&label);
+    report("D-STAR slice label has an accessible interface", accessible != nullptr);
+    if (!accessible) {
+        return 1;
+    }
+    report("empty slice state is exposed in the accessible name",
+           accessible->text(QAccessible::Name)
+               == QStringLiteral("D-STAR slice: No DSTR slice"));
+
+    AetherSDR::updateDStarSliceStateLabel(
+        &label, QStringLiteral("Slice A  14.100.000 MHz"));
+    report("controlled slice state updates the visible label",
+           label.text() == QStringLiteral("Slice A  14.100.000 MHz"));
+    report("controlled slice state updates the accessible name",
+           accessible->text(QAccessible::Name)
+               == QStringLiteral("D-STAR slice: Slice A  14.100.000 MHz"));
+
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/dstar_model_test.cpp
+++ b/tests/dstar_model_test.cpp
@@ -1,8 +1,10 @@
+#include "core/DigitalVoiceModeRegistry.h"
 #include "models/DStarModel.h"
 
 #include <QCoreApplication>
 #include <QFileInfo>
 #include <QMap>
+#include <QSignalSpy>
 #include <QTemporaryDir>
 
 #include <cstdio>
@@ -111,6 +113,19 @@ int main(int argc, char** argv)
 
     {
         DStarModel model;
+        QSignalSpy serviceSpy(&model, &DStarModel::serviceChanged);
+        AetherSDR::DigitalVoiceModeRegistry& registry =
+            AetherSDR::DigitalVoiceModeRegistry::instance();
+        registry.deactivateMode(AetherSDR::DigitalVoiceModeId::DStar);
+        report("D-STAR mode registry activates for service notification test",
+               registry.activateMode(AetherSDR::DigitalVoiceModeId::DStar));
+        report("D-STAR slice claim succeeds for service notification test",
+               registry.claimSlice(AetherSDR::DigitalVoiceModeId::DStar, 3));
+        QCoreApplication::processEvents();
+        report("slice claim notifies D-STAR service observers",
+               serviceSpy.count() == 1);
+        registry.deactivateMode(AetherSDR::DigitalVoiceModeId::DStar);
+        QCoreApplication::processEvents();
         model.setTrafficPersistencePath(historyPath);
 
         DStarConfiguration valid;


### PR DESCRIPTION
## Summary

Fixes #4216.

Make the digital-voice slice claim observable so AetherModem refreshes as soon as an existing slice enters or leaves DSTR. RadioModel now consumes the same claim transition after `SliceModel` finishes adopting the mode, which reliably sends the helper `tx_select` command and applies pending D-STAR runtime configuration for the reporter's start-service-then-select-DSTR sequence.

The patch does not change the ThumbDV serial handshake, D-STAR modem DSP, or transmitter teardown. If the reporter still sees the separately reported post-transmit no-RF symptom, its missing support log is still needed to root-cause that path.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The change is covered by claim-notification regression tests and was demonstrated on a real FLEX-6700 with a verified ThumbDV through the agent automation bridge.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass locally (109/109; CI pending)
- [x] Reproduction steps documented if user-reported bug

Agent automation bridge proof:

1. Launched the fresh build with `AETHER_AUTOMATION=1`; `get waveforms localDigitalVoice` reported `state=Running`, `registrationVerified=true`, and `activeSliceId=-1` while `dumpTree` reported `dstarSliceState="No DSTR slice"`.
2. Invoked `slice mode DSTR` without keying TX.
3. `get waveforms localDigitalVoice` changed to `activeSliceId=0`, and `dumpTree` changed to `dstarSliceState="Slice A  14.100.000 MHz"`.
4. The bridge log contained exactly one `slice waveform_cmd 0 tx_select 0 1 ...` and one `slice waveform_cmd 0 set destination_rptr=...` transaction for the transition.
5. Restored the slice to USB; the claim returned to `activeSliceId=-1`, the label returned to `No DSTR slice`, and `get transmit` confirmed `transmitting=false`, `mox=false`, and `tuning=false`.

Additional validation:

- `digital_voice_waveform_process_test`, `digital_voice_slice_lifecycle_test`, and `dstar_model_test`
- Full CTest suite: 109 passed, 0 failed, 1 intentional quarantine skip
- Accessibility check: 0 findings
- Strict engine-boundary check: 0 new violations
- `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter changes)
- [x] Documentation updated if user-visible behavior changed (not required; existing bridge documentation covers the exercised verbs)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
