### PR TITLE
fix(spectrum): field-keyed deferred pan writes — never lie, never silently drop (#4142)

### DIFF
--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -642,16 +642,10 @@ void AtuPreTuneDialog::beginNextPoint()
     if (firstOfBand && !m_originalPanId.isEmpty() && p.bandHighMhz > p.bandLowMhz) {
         const double center = (p.bandLowMhz + p.bandHighMhz) / 2.0;
         const double width  = (p.bandHighMhz - p.bandLowMhz) * 1.10;
-        const QString centerStr = QString::number(center, 'f', 6);
-        const QString widthStr  = QString::number(width,  'f', 6);
-        if (auto* pan = m_radio->panadapter(m_originalPanId)) {
-            // Local model nudge before the radio echo (aetherd RFC 2.3: the
-            // normalized setter replaces applyPanStatus({center,bandwidth})).
-            pan->setCenterBandwidth(center, width);
-        }
-        m_radio->sendCommand(
-            QString("display pan set %1 center=%2 bandwidth=%3")
-                .arg(m_originalPanId, centerStr, widthStr));
+        // Center and bandwidth together, and deferred rather than dropped if a
+        // profile load is holding radio-state writes (#4142). The local model
+        // advances only when the command reaches the wire.
+        m_radio->requestPanCenter(m_originalPanId, center, width);
     }
 
     // Move slice to target. SliceModel::setFrequency uses autopan=0 — no recenter.
@@ -885,16 +879,12 @@ void AtuPreTuneDialog::restoreOriginalFrequency()
     // Restore the panadapter zoom captured at sweep start — same
     // optimistic-update pattern used for band transitions.
     if (!m_originalPanId.isEmpty() && m_originalPanBandwidthMhz > 0.0) {
-        const QString centerStr = QString::number(m_originalPanCenterMhz, 'f', 6);
-        const QString widthStr  = QString::number(m_originalPanBandwidthMhz, 'f', 6);
-        if (auto* pan = m_radio->panadapter(m_originalPanId)) {
-            // Local model nudge before the radio echo (aetherd RFC 2.3: the
-            // normalized setter replaces applyPanStatus({center,bandwidth})).
-            pan->setCenterBandwidth(m_originalPanCenterMhz, m_originalPanBandwidthMhz);
-        }
-        m_radio->sendCommand(
-            QString("display pan set %1 center=%2 bandwidth=%3")
-                .arg(m_originalPanId, centerStr, widthStr));
+        // Restoring the pre-sweep zoom is a user-visible promise: dropping it
+        // during a profile load would strand the pan on the sweep's band view.
+        // Deferred and replayed instead (#4142).
+        m_radio->requestPanCenter(m_originalPanId,
+                                  m_originalPanCenterMhz,
+                                  m_originalPanBandwidthMhz);
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6060,28 +6060,28 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
     }
 
     auto* pan = m_radioModel.panadapter(panId);
-    const QString centerStr = QString::number(centerMhz, 'f', 6);
-    const QString bandwidthStr = QString::number(bandwidthMhz, 'f', 6);
 
     if (pan) {
         if (qFuzzyCompare(pan->centerMhz(), centerMhz)
             && qFuzzyCompare(pan->bandwidthMhz(), bandwidthMhz)) {
             return;
         }
-        // Update both values together before the radio echo arrives. Explicit
-        // zoom workflows are especially sensitive to center/bandwidth skew;
-        // splitting them produced the P1/P2 waterfall-loss and zoom-drift bugs.
-        // (aetherd RFC 2.3: setCenterBandwidth replaces applyPanStatus here.)
-        pan->setCenterBandwidth(centerMhz, bandwidthMhz);
     }
 
-    m_radioModel.sendCommand(
-        QString("display pan set %1 center=%2 bandwidth=%3")
-            .arg(panId, centerStr, bandwidthStr));
+    // Center and bandwidth travel together in one command. Explicit zoom
+    // workflows are especially sensitive to center/bandwidth skew; splitting
+    // them produced the P1/P2 waterfall-loss and zoom-drift bugs.
+    //
+    // #4142: this pair is classified profile-owned, so it was silently DROPPED
+    // during a profile load — zoom and drag, not just typed frequency entry.
+    // requestPanCenter() defers and replays it, and only advances the local
+    // model when the command actually reaches the wire.
+    const bool sent = m_radioModel.requestPanCenter(panId, centerMhz, bandwidthMhz);
 
     qDebug() << "Pan range request:" << source
              << "center" << centerMhz
-             << "bandwidth" << bandwidthMhz;
+             << "bandwidth" << bandwidthMhz
+             << (sent ? "" : "(deferred: profile load)");
 }
 
 void MainWindow::setActiveSlice(int sliceId)
@@ -7450,16 +7450,24 @@ void MainWindow::centerActiveSliceInPanadapter(bool forceRadioCenter, double cen
             m_panStack->setActivePan(applet->panId());
     }
 
-    // Keep the local spectrum centered immediately so the active slice marker
-    // is visible before the radio's status echo arrives.
-    sw->setFrequencyRange(targetMhz, bandwidthMhz);
-    pushSliceFrequencyToOverlays(s, targetMhz);
-
+    // #4142 — ask the radio FIRST, so the local view can only advance if the
+    // command actually reached the wire. During a profile load this center write
+    // is suppressed; centering the spectrum on a center the radio never took is
+    // exactly what projects honest tiles into a lying frame and bakes black rows
+    // into waterfall history. requestPanCenter() defers and replays it instead.
+    bool centerDeferred = false;
     if (forceRadioCenter && m_radioModel.isConnected()) {
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2")
-                .arg(s->panId()).arg(targetMhz, 0, 'f', 6));
+        centerDeferred = !m_radioModel.requestPanCenter(s->panId(), targetMhz);
     }
+
+    // Keep the local spectrum centered immediately so the active slice marker is
+    // visible before the radio's status echo arrives — unless the center was
+    // deferred, in which case the pan must keep showing truthful spectrum for the
+    // span the radio still has.
+    if (!centerDeferred) {
+        sw->setFrequencyRange(targetMhz, bandwidthMhz);
+    }
+    pushSliceFrequencyToOverlays(s, targetMhz);
 
     TuneCenteringResult result;
     result.oldCenterMhz = pan ? pan->centerMhz() : targetMhz;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5669,8 +5669,10 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
                     << " key=" << stackKeyResult.key;
                 clearSwrSweepForBandChange(-1, slicePanId, memoryBand);
                 m_bandSettings.setCurrentBand(memoryBand);
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 band=%2").arg(slicePanId, stackKeyResult.key));
+                // #4142: during the profile-load hold a bare sendCommand()
+                // band= write is silently destroyed and the recall lands on
+                // the wrong band stack. requestPanBand defers it instead.
+                m_radioModel.requestPanBand(slicePanId, stackKeyResult.key);
                 QTimer::singleShot(300, this, [this, slicePanId]() {
                     reassertUnmutedSliceAudioForPan(slicePanId);
                 });
@@ -5908,8 +5910,11 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
         << " key=" << stackKeyResult.key;
     clearSwrSweepForBandChange(-1, slice->panId(), targetBand);
     m_bandSettings.setCurrentBand(targetBand);
-    m_radioModel.sendCommand(
-        QString("display pan set %1 band=%2").arg(slice->panId(), stackKeyResult.key));
+    // #4142: the cross-band typed tune is the reported bug's worst variant —
+    // the `slice tune` half survives the hold while a bare sendCommand()
+    // band= write is silently destroyed, so the slice lands outside the pan.
+    // requestPanBand defers the band-stack swap and replays it band-first.
+    m_radioModel.requestPanBand(slice->panId(), stackKeyResult.key);
     QTimer::singleShot(300, this, [this, panId = slice->panId()]() {
         reassertUnmutedSliceAudioForPan(panId);
     });
@@ -6062,8 +6067,13 @@ void MainWindow::applyPanRangeRequest(const QString& panId, double centerMhz,
     auto* pan = m_radioModel.panadapter(panId);
 
     if (pan) {
-        if (qFuzzyCompare(pan->centerMhz(), centerMhz)
-            && qFuzzyCompare(pan->bandwidthMhz(), bandwidthMhz)) {
+        // Effective (pending-else-model) geometry: during the profile-load
+        // hold the model deliberately lags a deferred request; comparing
+        // against it would treat the user's pending zoom as "already there"
+        // — or re-issue it forever (#4142).
+        if (qFuzzyCompare(m_radioModel.effectivePanCenterMhz(panId), centerMhz)
+            && qFuzzyCompare(m_radioModel.effectivePanBandwidthMhz(panId),
+                             bandwidthMhz)) {
             return;
         }
     }

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1199,16 +1199,20 @@ void MainWindow::activateWFM(int sliceId)
     // already correct — and during a profile load it defers the write instead of
     // letting it be dropped, which would have left the DAX IQ stream centred
     // somewhere the client no longer believed it was (#4142).
-    auto centerPanAtSlice = [this, s]() {
+    // Returns whether the pan is centred on the slice NOW — a deferred
+    // recenter (profile-load hold) is a promise, not a fact, and the NCO
+    // must not be programmed as if it already happened.
+    auto centerPanAtSlice = [this, s]() -> bool {
         const QString panId = s->panId();
-        if (panId.isEmpty()) return;
+        if (panId.isEmpty()) return false;
         const double freq = s->frequency();
         auto* pan = m_radioModel.panadapter(panId);
-        // Effective (pending-else-model) center, so a recenter already
-        // deferred in flight is not re-requested on every call (#4142).
+        // Effective (pending-else-model) compare suppresses re-requesting a
+        // recenter already deferred in flight; "centred now" is only true
+        // when the MODEL (radio truth) agrees (#4142).
         if (pan && qFuzzyCompare(m_radioModel.effectivePanCenterMhz(panId), freq))
-            return;
-        m_radioModel.requestPanCenter(panId, freq);
+            return qFuzzyCompare(pan->centerMhz(), freq);
+        return m_radioModel.requestPanCenter(panId, freq);
     };
     centerPanAtSlice();
 
@@ -1246,9 +1250,18 @@ void MainWindow::activateWFM(int sliceId)
             (sliceFreqMhz - pan->centerMhz()) * 1e6);
         if (qAbs(offsetHz) <= m_wfmDemod->maxFreqOffsetHz()) {
             m_wfmDemod->setFreqOffsetHz(offsetHz);
-        } else {
-            centerPanAtSlice();
+        } else if (centerPanAtSlice()) {
             m_wfmDemod->setFreqOffsetHz(0.0f);
+        } else {
+            // The recenter is deferred (profile-load hold) or could not be
+            // dispatched — the DAX IQ stream is still centred where the radio
+            // is. A zero offset here would tune the demod to the WRONG
+            // frequency; keep best-effort audio at the clamped edge of the IQ
+            // window instead. The deferred recenter self-heals at flush, and
+            // the next frequencyChanged converges the offset. (#4142)
+            const float maxOffsetHz = m_wfmDemod->maxFreqOffsetHz();
+            m_wfmDemod->setFreqOffsetHz(
+                std::clamp(offsetHz, -maxOffsetHz, maxOffsetHz));
         }
     });
 }

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1194,18 +1194,18 @@ void MainWindow::activateWFM(int sliceId)
     m_wfmSliceId = sliceId;
 
     // Centre the pan (and with it the DAX IQ stream) on the slice — once.
-    // applyPanStatus updates the local model immediately so offsets computed
-    // before the radio echoes the new centre are already correct.
+    // requestPanCenter() updates the local model as it puts the command on the
+    // wire, so offsets computed before the radio echoes the new centre are
+    // already correct — and during a profile load it defers the write instead of
+    // letting it be dropped, which would have left the DAX IQ stream centred
+    // somewhere the client no longer believed it was (#4142).
     auto centerPanAtSlice = [this, s]() {
         const QString panId = s->panId();
         if (panId.isEmpty()) return;
         const double freq = s->frequency();
         auto* pan = m_radioModel.panadapter(panId);
         if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
-        const QString freqStr = QString::number(freq, 'f', 6);
-        if (pan) pan->setCenterBandwidth(freq, -1.0);  // aetherd RFC 2.3
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2").arg(panId, freqStr));
+        m_radioModel.requestPanCenter(panId, freq);
     };
     centerPanAtSlice();
 

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -1204,7 +1204,10 @@ void MainWindow::activateWFM(int sliceId)
         if (panId.isEmpty()) return;
         const double freq = s->frequency();
         auto* pan = m_radioModel.panadapter(panId);
-        if (pan && qFuzzyCompare(pan->centerMhz(), freq)) return;
+        // Effective (pending-else-model) center, so a recenter already
+        // deferred in flight is not re-requested on every call (#4142).
+        if (pan && qFuzzyCompare(m_radioModel.effectivePanCenterMhz(panId), freq))
+            return;
         m_radioModel.requestPanCenter(panId, freq);
     };
     centerPanAtSlice();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -468,23 +468,31 @@ bool MainWindow::snapCenterLockForSlice(SliceModel* slice, double mhz, bool send
         bandwidthMhz > 0.0 ? std::max(mhz, bandwidthMhz / 2.0) : mhz;
     bool changed = false;
 
-    if (sw && bandwidthMhz > 0.0
+    const bool modelNeedsCenter = !qFuzzyCompare(pan->centerMhz(), targetCenterMhz);
+    bool centerDeferred = false;
+
+    if (!kiwiDisplayActive && modelNeedsCenter) {
+        if (sendCommand) {
+            // #4142 — defer, never drop. requestPanCenter() advances the local
+            // model only when the command actually reaches the wire, and queues
+            // it for replay when a profile load is holding radio-state writes.
+            centerDeferred = !m_radioModel.requestPanCenter(panId, targetCenterMhz);
+        } else {
+            // Local-only snap: the caller explicitly wants no radio write, so
+            // there is no wire command for the model to diverge from.
+            pan->setCenterBandwidth(targetCenterMhz, -1.0);  // aetherd RFC 2.3
+        }
+        changed = !centerDeferred;
+    }
+
+    // Never move the visible span while the radio stays put. A view that claims
+    // a center the radio never took is precisely what projects honest tiles into
+    // a lying frame and bakes black rows into waterfall history (#4142).
+    if (!centerDeferred && sw && bandwidthMhz > 0.0
         && (!qFuzzyCompare(sw->centerMhz(), targetCenterMhz)
             || !qFuzzyCompare(sw->bandwidthMhz(), bandwidthMhz))) {
         sw->setFrequencyRangeImmediate(targetCenterMhz, bandwidthMhz);
         changed = true;
-    }
-
-    const bool modelNeedsCenter = !qFuzzyCompare(pan->centerMhz(), targetCenterMhz);
-    if (!kiwiDisplayActive && modelNeedsCenter) {
-        pan->setCenterBandwidth(targetCenterMhz, -1.0);  // aetherd RFC 2.3
-        changed = true;
-    }
-
-    if (sendCommand && !kiwiDisplayActive && modelNeedsCenter) {
-        m_radioModel.sendCommand(
-            QStringLiteral("display pan set %1 center=%2")
-                .arg(panId, QString::number(targetCenterMhz, 'f', 6)));
     }
 
     return changed;
@@ -1990,6 +1998,15 @@ void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
     });
     QTimer::singleShot(kProfileLoadDeferredPanFlushDelayMs, this, [this]() {
         flushPendingProfileLoadPanDimensions();
+        // Ordered after dimensions on the SAME timer — no fourth scheduler.
+        // Bin size is bandwidth/xpixels, so the pan must know its pixel geometry
+        // before it is recentered. This timer is the first flush point past hold
+        // expiry; the two earlier dimension flushes (1500/3500 ms) run INSIDE the
+        // hold, where xpixels/ypixels are exempt but a center write is not.
+        // flushPendingProfileLoadPanCenters() re-checks the hold itself and
+        // early-returns while it is armed, so no center can escape early even if
+        // this call site were moved. (#4142)
+        m_radioModel.flushPendingProfileLoadPanCenters();
     });
     QTimer::singleShot(kProfileLoadPostHoldRecoveryDelayMs, this, [this]() {
         m_profileLoadPendingFftYpixels.clear();
@@ -2529,13 +2546,13 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         }
         if (auto* pan = m_radioModel.panadapter(applet->panId())) {
             center = std::max(center, pan->bandwidthMhz() / 2.0);
-            // The radio may acknowledge this command without echoing a display
-            // status to the setting client. Keep the canonical model aligned
-            // with the visible pan so TCI dds: follows the IQ center.
-            pan->setCenterBandwidth(center, -1.0);
         }
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2").arg(applet->panId()).arg(center, 0, 'f', 6));
+        // The radio may acknowledge this command without echoing a display status
+        // to the setting client, so requestPanCenter() keeps the canonical model
+        // aligned with the wire command (TCI dds: follows this center) — and
+        // during a profile load it defers rather than letting sendCmd drop it
+        // silently (#4142).
+        m_radioModel.requestPanCenter(applet->panId(), center);
     });
     // Band/Segment Zoom toggle off the pan's radio-authoritative model state
     // (togglePanZoomModeForPan) — shared with the keyboard/MIDI shortcuts
@@ -3328,9 +3345,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             // In-window drag moves pass the unchanged center purely to tune
             // without reveal — only emit the pan command when it actually moves.
             if (!qFuzzyCompare(centerMhz, pan->centerMhz())) {
-                m_radioModel.sendCommand(
-                    QString("display pan set %1 center=%2")
-                        .arg(pan->panId()).arg(centerMhz, 0, 'f', 6));
+                // Deferred rather than dropped during a profile load (#4142).
+                // The SpectrumWidget owns its own view during an edge-pan drag,
+                // so the gesture still tracks the cursor; the radio catches up
+                // when the deferred center flushes.
+                m_radioModel.requestPanCenter(pan->panId(), centerMhz);
             }
         }
         queueActiveSliceForSpectrumTarget(target->sliceId());
@@ -3804,10 +3823,12 @@ MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
             ? kPanFollowAnimationDurationMs
             : 0;
 
-        pan->setCenterBandwidth(result.newCenterMhz, -1.0);  // aetherd RFC 2.3
-        m_radioModel.sendCommand(
-            QString("display pan set %1 center=%2")
-                .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));
+        // #4142 — defer, never drop. During a profile load the pan center write
+        // is suppressed at the wire; advancing the local center anyway is what
+        // made the waterfall go black (the view claimed a center the radio never
+        // took). requestPanCenter() applies the model update only when the
+        // command actually goes out, and replays it once the hold lifts.
+        m_radioModel.requestPanCenter(pan->panId(), result.newCenterMhz);
         return result;
     }
 
@@ -3891,13 +3912,13 @@ MainWindow::TuneCenteringResult MainWindow::revealFrequencyIfNeeded(
         ? kPanFollowAnimationDurationMs
         : 0;
 
-    // Apply the center optimistically so the owning spectrum repaints
-    // immediately; SpectrumWidget decides whether that becomes a short
-    // retargetable animation or an immediate snap based on shift size.
-    pan->setCenterBandwidth(result.newCenterMhz, -1.0);  // aetherd RFC 2.3
-    m_radioModel.sendCommand(
-        QString("display pan set %1 center=%2")
-            .arg(pan->panId()).arg(result.newCenterMhz, 0, 'f', 6));
+    // Apply the center so the owning spectrum repaints immediately;
+    // SpectrumWidget decides whether that becomes a short retargetable animation
+    // or an immediate snap based on shift size. During a profile load this
+    // defers instead (#4142) — the model does not advance ahead of the radio, so
+    // the pan keeps showing truthful spectrum for its real span until the
+    // deferred center flushes.
+    m_radioModel.requestPanCenter(pan->panId(), result.newCenterMhz);
     return result;
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -459,16 +459,21 @@ bool MainWindow::snapCenterLockForSlice(SliceModel* slice, double mhz, bool send
     if (sw && sw->panDragActive()) {
         return false;
     }
+    // Effective (pending-else-model) geometry: during the profile-load hold
+    // the model deliberately lags a deferred request, and comparing against it
+    // would re-issue the same write on every echo (#4142).
+    const double effPanBandwidthMhz = m_radioModel.effectivePanBandwidthMhz(panId);
     const double bandwidthMhz = kiwiDisplayActive && sw && sw->bandwidthMhz() > 0.0
         ? sw->bandwidthMhz()
-        : (pan->bandwidthMhz() > 0.0
-            ? pan->bandwidthMhz()
+        : (effPanBandwidthMhz > 0.0
+            ? effPanBandwidthMhz
             : (sw ? sw->bandwidthMhz() : 0.0));
     const double targetCenterMhz =
         bandwidthMhz > 0.0 ? std::max(mhz, bandwidthMhz / 2.0) : mhz;
     bool changed = false;
 
-    const bool modelNeedsCenter = !qFuzzyCompare(pan->centerMhz(), targetCenterMhz);
+    const bool modelNeedsCenter =
+        !qFuzzyCompare(m_radioModel.effectivePanCenterMhz(panId), targetCenterMhz);
     bool centerDeferred = false;
 
     if (!kiwiDisplayActive && modelNeedsCenter) {
@@ -2537,16 +2542,23 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
-        m_radioModel.sendCommand(
-            QString("display pan set %1 bandwidth=%2").arg(applet->panId()).arg(bw, 0, 'f', 6));
+        // #4142: a bandwidth drag is user intent — during the profile-load
+        // hold a bare sendCommand() is silently destroyed; defer it instead.
+        m_radioModel.requestPanBandwidth(applet->panId(), bw);
     });
     connect(sw, &SpectrumWidget::centerChangeRequested,
             this, [this, applet](double center) {
         if (kiwiSdrPanDisplaysKiwi(applet->panId())) {
             return;
         }
-        if (auto* pan = m_radioModel.panadapter(applet->panId())) {
-            center = std::max(center, pan->bandwidthMhz() / 2.0);
+        // Clamp against EFFECTIVE bandwidth (a deferred zoom's pending value,
+        // else the model): during the hold the model deliberately lags the
+        // user's deferred request. Dispatch re-clamps against live geometry
+        // regardless — this caller clamp is UX-only.
+        const double effBw =
+            m_radioModel.effectivePanBandwidthMhz(applet->panId());
+        if (effBw > 0.0) {
+            center = std::max(center, effBw / 2.0);
         }
         // The radio may acknowledge this command without echoing a display status
         // to the setting client, so requestPanCenter() keeps the canonical model
@@ -3342,10 +3354,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             return;
         }
         if (auto* pan = m_radioModel.panadapter(target->panId())) {
-            centerMhz = std::max(centerMhz, pan->bandwidthMhz() / 2.0);
+            // Effective (pending-else-model) geometry, so a deferred write in
+            // flight dedupes instead of re-issuing per drag tick (#4142).
+            centerMhz = std::max(
+                centerMhz,
+                m_radioModel.effectivePanBandwidthMhz(pan->panId()) / 2.0);
             // In-window drag moves pass the unchanged center purely to tune
             // without reveal — only emit the pan command when it actually moves.
-            if (!qFuzzyCompare(centerMhz, pan->centerMhz())) {
+            if (!qFuzzyCompare(centerMhz,
+                               m_radioModel.effectivePanCenterMhz(pan->panId()))) {
                 // Deferred rather than dropped during a profile load (#4142).
                 // The SpectrumWidget owns its own view during an edge-pan drag,
                 // so the gesture still tracks the cursor; the radio catches up
@@ -3710,8 +3727,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
                                [this, panId = applet->panId()]() {
                 m_kiwiRebind.clearBandRecall(panId);
             });
-            m_radioModel.sendCommand(
-                QString("display pan set %1 band=%2").arg(applet->panId()).arg(stackKey));
+            // #4142: during the profile-load hold a bare sendCommand() band=
+            // write is silently destroyed. requestPanBand defers it instead.
+            // Outside a hold it dispatches inline, so the #4158 grace window
+            // above is unchanged on the normal user-initiated band-recall path.
+            m_radioModel.requestPanBand(applet->panId(), stackKey);
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
                 reassertUnmutedSliceAudioForPan(panId);
             });

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1998,15 +1998,16 @@ void MainWindow::scheduleProfileLoadRecovery(const QString& profileType,
     });
     QTimer::singleShot(kProfileLoadDeferredPanFlushDelayMs, this, [this]() {
         flushPendingProfileLoadPanDimensions();
-        // Ordered after dimensions on the SAME timer — no fourth scheduler.
-        // Bin size is bandwidth/xpixels, so the pan must know its pixel geometry
-        // before it is recentered. This timer is the first flush point past hold
-        // expiry; the two earlier dimension flushes (1500/3500 ms) run INSIDE the
-        // hold, where xpixels/ypixels are exempt but a center write is not.
-        // flushPendingProfileLoadPanCenters() re-checks the hold itself and
-        // early-returns while it is armed, so no center can escape early even if
-        // this call site were moved. (#4142)
-        m_radioModel.flushPendingProfileLoadPanCenters();
+        // Deferred pan WRITES (center/bandwidth/band) are NOT flushed from
+        // here. RadioModel owns that replay — hold-relative, armed by the act
+        // of deferring — because this entire recovery pass is gated on the
+        // profile-load ACK, and a large topology (8 pans / 8 slices, measured
+        // 5/5 on a 6700) can stall the radio into a force-disconnect before
+        // the ACK ever arrives; a flush scheduled here would never run. A
+        // dimensions-then-centers ordering is NOT required for correctness:
+        // every VITA-49 tile carries its own FrameLowFreq/BinBandwidth, so a
+        // recenter that lands before the pixel geometry settles is a
+        // self-correcting transient, not a scar. (#4142)
     });
     QTimer::singleShot(kProfileLoadPostHoldRecoveryDelayMs, this, [this]() {
         m_profileLoadPendingFftYpixels.clear();

--- a/src/models/ProfileLoadCommand.h
+++ b/src/models/ProfileLoadCommand.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <QLatin1Char>
 #include <QRegularExpression>
 #include <QString>
+#include <QStringList>
 #include <QtGlobal>
 
 namespace AetherSDR {
@@ -42,6 +44,44 @@ inline ProfileLoadCommand parseProfileLoadCommand(const QString& command)
         match.captured(1).toLower(),
         match.captured(2),
     };
+}
+
+// Classifies a command as a write to radio state that a profile load owns and
+// will rebuild. RadioModel::sendCmd() consults this as a low-level backstop and
+// suppresses matches while the profile-load hold is armed.
+//
+// Callers must not rely on that backstop to swallow user-initiated writes: a
+// suppressed command never reaches the wire and is lost. Route pan center /
+// bandwidth writes through RadioModel::requestPanCenter(), which defers and
+// coalesces them until the hold lifts instead of dropping them (#4142).
+inline bool isProfileOwnedRadioStateWrite(const QString& command)
+{
+    const QString trimmed = command.trimmed();
+    const QStringList tokens = trimmed.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
+    if (tokens.size() >= 5
+        && tokens[0] == QStringLiteral("display")
+        && tokens[1] == QStringLiteral("pan")
+        && tokens[2] == QStringLiteral("set")) {
+        bool hasPixelDimension = false;
+        for (int i = 4; i < tokens.size(); ++i) {
+            const QString key = tokens[i].section(QLatin1Char('='), 0, 0);
+            if (key != QStringLiteral("xpixels") && key != QStringLiteral("ypixels")) {
+                return true;
+            }
+            hasPixelDimension = true;
+        }
+        // xpixels/ypixels are allowed past this low-level guard because
+        // MainWindow queues them during a profile load and flushes them after
+        // the radio accepts the profile. Do not bypass
+        // MainWindow::requestPanDimensionsForRadio(); early dimension writes
+        // can cause the radio to save a partial GUIClient slice layout.
+        return !hasPixelDimension;
+    }
+
+    return trimmed.startsWith(QStringLiteral("slice set "))
+        || trimmed.startsWith(QStringLiteral("display pan set "))
+        || trimmed.startsWith(QStringLiteral("display panafall set "))
+        || trimmed.startsWith(QStringLiteral("display waterfall set "));
 }
 
 } // namespace AetherSDR

--- a/src/models/ProfileLoadPanWriteQueue.h
+++ b/src/models/ProfileLoadPanWriteQueue.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+#include <optional>
+#include <utility>
+
+namespace AetherSDR {
+
+// One panadapter's writes deferred during the profile-load hold (#4142).
+// Absent optional = the user never asked for that field while the hold was
+// armed; it must not be written at flush time.
+struct PanWrites {
+    std::optional<QString> bandKey;
+    std::optional<double> centerMhz;
+    std::optional<double> bandwidthMhz;
+
+    bool isEmpty() const
+    {
+        return !bandKey.has_value() && !centerMhz.has_value()
+            && !bandwidthMhz.has_value();
+    }
+};
+
+// Deferred pan-write store for the profile-load hold (#4142).
+//
+// sendCmd() suppresses profile-owned pan writes while the hold is armed (see
+// isProfileOwnedRadioStateWrite); this queue is where the user-intent portion
+// of those writes waits instead of dying. Semantics:
+//
+//  - Coalescing is FIELD-WISE per pan, last write wins per field. A later
+//    center defer must never erase a queued bandwidth: whole-struct
+//    replacement would lose a user's zoom — the exact class of silent drop
+//    #4142 exists to fix.
+//  - supersede*() erases a field group because a write for it just reached
+//    the wire through the immediate path — replaying the stale pending value
+//    afterwards would override the newer state.
+//  - cancel() voids a whole pan entry (the pan died); it returns the voided
+//    fields so the caller can log exactly what was destroyed. Entries whose
+//    last field is superseded are erased, so cancel() on such a pan
+//    truthfully reports nothing pending.
+//
+// Owned by RadioModel; kept Qt6::Core-only so profile_load_command_test can
+// link it without the GUI stack.
+class ProfileLoadPanWriteQueue {
+public:
+    void deferBand(const QString& panId, const QString& bandKey)
+    {
+        m_pending[panId].bandKey = bandKey;
+    }
+
+    void deferCenter(const QString& panId, double centerMhz)
+    {
+        m_pending[panId].centerMhz = centerMhz;
+    }
+
+    void deferCenterBandwidth(const QString& panId, double centerMhz,
+                              double bandwidthMhz)
+    {
+        PanWrites& entry = m_pending[panId];
+        entry.centerMhz = centerMhz;
+        entry.bandwidthMhz = bandwidthMhz;
+    }
+
+    void deferBandwidth(const QString& panId, double bandwidthMhz)
+    {
+        m_pending[panId].bandwidthMhz = bandwidthMhz;
+    }
+
+    void supersedeCenter(const QString& panId)
+    {
+        const auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return;
+        }
+        it->centerMhz.reset();
+        if (it->isEmpty()) {
+            m_pending.erase(it);
+        }
+    }
+
+    void supersedeBandwidth(const QString& panId)
+    {
+        const auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return;
+        }
+        it->bandwidthMhz.reset();
+        if (it->isEmpty()) {
+            m_pending.erase(it);
+        }
+    }
+
+    void supersedeCenterBandwidth(const QString& panId)
+    {
+        const auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return;
+        }
+        it->centerMhz.reset();
+        it->bandwidthMhz.reset();
+        if (it->isEmpty()) {
+            m_pending.erase(it);
+        }
+    }
+
+    void supersedeBand(const QString& panId)
+    {
+        const auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return;
+        }
+        it->bandKey.reset();
+        if (it->isEmpty()) {
+            m_pending.erase(it);
+        }
+    }
+
+    // The pan died (removed, ownership lost, disconnect). Returns the voided
+    // entry so the caller can log the destroyed fields, or nullopt when
+    // nothing was pending.
+    std::optional<PanWrites> cancel(const QString& panId)
+    {
+        const auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return std::nullopt;
+        }
+        PanWrites voided = std::move(*it);
+        m_pending.erase(it);
+        return voided;
+    }
+
+    std::optional<double> pendingCenter(const QString& panId) const
+    {
+        const auto it = m_pending.constFind(panId);
+        return it == m_pending.constEnd() ? std::nullopt : it->centerMhz;
+    }
+
+    std::optional<double> pendingBandwidth(const QString& panId) const
+    {
+        const auto it = m_pending.constFind(panId);
+        return it == m_pending.constEnd() ? std::nullopt : it->bandwidthMhz;
+    }
+
+    std::optional<QString> pendingBand(const QString& panId) const
+    {
+        const auto it = m_pending.constFind(panId);
+        return it == m_pending.constEnd() ? std::nullopt : it->bandKey;
+    }
+
+    QHash<QString, PanWrites> takeAll()
+    {
+        return std::exchange(m_pending, {});
+    }
+
+    bool isEmpty() const { return m_pending.isEmpty(); }
+    int size() const { return m_pending.size(); }
+    void clear() { m_pending.clear(); }
+
+private:
+    // Invariant: no stored entry is all-empty — supersede/cancel erase them.
+    QHash<QString, PanWrites> m_pending;
+};
+
+} // namespace AetherSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4639,7 +4639,7 @@ void RadioModel::onMessageReceived(const ParsedMessage& msg)
 //   "meter 1"         → meter reading (handled by onMessageReceived)
 //   "removed=True"    → object was removed
 
-void RadioModel::sendCommand(const QString& cmd)
+bool RadioModel::sendCommand(const QString& cmd)
 {
     // #3977: last-line ownership gate for pan writes. Every UI path that
     // adjusts a pan (auto-floor, band restore, center/bandwidth/zoom/fps)
@@ -4654,12 +4654,16 @@ void RadioModel::sendCommand(const QString& cmd)
             qCWarning(lcProtocol).noquote()
                 << "RadioModel: dropping pan-set for foreign-owned pan"
                 << panId << "(owner 0x" + pan->clientHandle() + ") —" << cmd;
-            return;
+            return false;
         }
     }
     qCDebug(lcProtocol) << "RadioModel::sendCommand:" << cmd
              << "connected:" << isConnected() << "wan:" << (m_wanConn != nullptr);
-    this->sendCmd(cmd);
+    // sendCmd() reports a drop as sequence 0, before any wire write: the
+    // profile-load hold backstop returns 0 directly, and a disconnected WAN
+    // session returns 0 from WanConnection::sendCommand(). Both live seq
+    // counters start at 1, so seq != 0 is exactly "the command was dispatched".
+    return this->sendCmd(cmd) != 0;
 }
 
 void RadioModel::sendCmdPublic(const QString& cmd, ResponseCallback cb)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2729,9 +2729,10 @@ double RadioModel::panBandwidthMhz() const
 void RadioModel::setPanBandwidth(double bandwidthMhz)
 {
     if (m_activePanId.isEmpty()) return;
-    sendCmd(
-        QString("display pan set %1 bandwidth=%2")
-            .arg(m_activePanId).arg(bandwidthMhz, 0, 'f', 6));
+    // User-intent pan write: must go through the defer queue like its sibling
+    // setPanCenter() (#4142). A raw sendCmd() here would be silently dropped
+    // during the profile-load hold and trip the routed-pan-field backstop.
+    requestPanBandwidth(m_activePanId, bandwidthMhz);
 }
 
 void RadioModel::setPanCenter(double centerMhz)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2772,6 +2772,16 @@ bool RadioModel::requestPanCenter(const QString& panId,
             << "RadioModel: deferring pan center during profile load"
             << QStringLiteral("pan=%1").arg(panId)
             << QStringLiteral("center=%1").arg(centerMhz, 0, 'f', 6);
+
+        // Whoever defers a write owns scheduling its replay. Do NOT rely on the
+        // profile-load ACK to schedule the flush: the hold is armed when the
+        // profile-load command is SENT, but MainWindow's recovery pass (and its
+        // flush timers) only runs on profileLoadCompleted, which is emitted on
+        // ACK. A large topology (8 pans / 8 slices, verified on a 6700) can stall
+        // the radio long enough that it misses pings and the client force-
+        // disconnects BEFORE the ACK ever arrives — in which case no flush would
+        // ever have been scheduled and this request would be stranded forever.
+        armProfileLoadPanCenterFlush();
         return false;
     }
 
@@ -2804,9 +2814,38 @@ void RadioModel::sendPanCenterToRadio(const QString& panId,
     sendCommand(command);
 }
 
+void RadioModel::armProfileLoadPanCenterFlush()
+{
+    // Re-arm for exactly when the hold lifts. The hold can be EXTENDED after we
+    // arm (the ACK pushes it out again, and a second profile load pushes it out
+    // further), so the flush re-checks and re-arms itself rather than trusting a
+    // single deadline computed up front.
+    const qint64 remainingMs =
+        m_profileLoadRadioStateWriteHoldUntilMs - QDateTime::currentMSecsSinceEpoch();
+    const int delayMs = static_cast<int>(std::max<qint64>(remainingMs, 0)) + 100;
+
+    QTimer::singleShot(delayMs, this, [this]() {
+        flushPendingProfileLoadPanCenters();
+    });
+}
+
 void RadioModel::flushPendingProfileLoadPanCenters()
 {
-    if (m_pendingProfileLoadPanCenters.isEmpty() || !isConnected()) {
+    if (m_pendingProfileLoadPanCenters.isEmpty()) {
+        return;
+    }
+
+    if (!isConnected()) {
+        // The session these requests belonged to is gone. Their pan ids and the
+        // user's intent both died with it, and the radio will rebuild its own
+        // topology on reconnect — replaying a pre-disconnect center could land a
+        // stale frequency on a pan that is no longer the same pan. Void them
+        // loudly rather than stranding or misapplying them. (onDisconnected()
+        // normally clears these first; this is the backstop.)
+        qCWarning(lcProtocol).noquote()
+            << "RadioModel: discarding" << m_pendingProfileLoadPanCenters.size()
+            << "deferred pan center(s) — disconnected before the profile load settled";
+        m_pendingProfileLoadPanCenters.clear();
         return;
     }
 
@@ -2815,11 +2854,12 @@ void RadioModel::flushPendingProfileLoadPanCenters()
     // the wire inside the hold window. Nothing here can reintroduce the
     // missing-slices corruption the hold exists to prevent.
     //
-    // Returning WITHOUT clearing is deliberate. The hold can only still be armed
-    // because a further topology-rebuilding profile load re-armed it — and that
-    // load scheduled its own post-hold flush, which will replay these. Dropping
-    // them here would be the exact bug this method exists to fix.
+    // Returning WITHOUT clearing is deliberate — we re-arm instead. The hold is
+    // still armed only because a further topology-rebuilding profile load pushed
+    // it out; dropping the request here would be the exact bug this method exists
+    // to fix.
     if (profileLoadRadioStateWritesHeld()) {
+        armProfileLoadPanCenterFlush();
         return;
     }
 
@@ -3817,6 +3857,19 @@ void RadioModel::restoreTuneInhibit()
 void RadioModel::onDisconnected()
 {
     qCDebug(lcProtocol) << "RadioModel: disconnected";
+
+    // #4142 — void any pan centers deferred during a profile load. The session
+    // they belonged to is gone: the radio rebuilds its topology on reconnect, so
+    // a queued center could land a stale frequency on a pan that is no longer the
+    // same pan. This is a real path, not a theoretical one — a large profile
+    // (8 pans / 8 slices on a 6700) can stall the radio past the ping timeout and
+    // force a disconnect BEFORE the profile load is ever ACKed.
+    if (!m_pendingProfileLoadPanCenters.isEmpty()) {
+        qCWarning(lcProtocol).noquote()
+            << "RadioModel: discarding" << m_pendingProfileLoadPanCenters.size()
+            << "deferred pan center(s) — disconnected before the profile load settled";
+        m_pendingProfileLoadPanCenters.clear();
+    }
 
     // Release sleep inhibition on disconnect (#1420)
     m_sleepInhibitor.release();
@@ -4937,12 +4990,31 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         && isProfileOwnedRadioStateWrite(command)) {
         // Defense-in-depth backstop only. A command that reaches here is
         // DROPPED — it never gets a sequence number and never reaches the wire.
-        // Callers that carry user intent must defer instead (see
-        // requestPanCenter()), so anything still landing here is a bug we want
-        // to see rather than silently swallow. (#4142)
-        qCWarning(lcProtocol).noquote()
-            << "RadioModel: suppressing profile-load radio-state write"
-            << command;
+        //
+        // Warn only for pan geometry, which is the class routed through
+        // requestPanCenter(): one of those arriving here means a caller bypassed
+        // the defer path and a user command is being lost — a real bug (#4142).
+        //
+        // The other suppressions on this path are model-echo/reconcile writers
+        // that #3563 drops BY DESIGN (active-slice and TX-slice reasserts,
+        // panafall/waterfall auto-black defaults). Several fire on every profile
+        // load, so warning on them would cry wolf and bury the one line that
+        // actually means something.
+        const bool panGeometryWrite =
+            command.startsWith(QStringLiteral("display pan set "))
+            && (command.contains(QStringLiteral("center="))
+                || command.contains(QStringLiteral("bandwidth=")));
+
+        if (panGeometryWrite) {
+            qCWarning(lcProtocol).noquote()
+                << "RadioModel: DROPPED a pan geometry write during profile load —"
+                << "this should have been deferred via requestPanCenter()"
+                << command;
+        } else {
+            qCDebug(lcProtocol).noquote()
+                << "RadioModel: suppressing profile-load radio-state write"
+                << command;
+        }
         if (cb) {
             cb(kProfileLoadSuppressedCommandCode,
                QStringLiteral("suppressed during profile load"));

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6156,6 +6156,15 @@ void RadioModel::onStatusReceived(const QString& object,
             // Handle pan removal — "display pan 0x40000001 removed" arrives
             // with no '=' so the parser puts the whole string in 'object'
             if (kvs.contains("removed") || object.endsWith("removed")) {
+                // #4142: this pan's deferred writes die with it. Void them
+                // loudly NOW — the radio re-uses pan ids across a profile
+                // load (observed live on a 6700), so a write left queued here
+                // would replay onto a same-id NEWCOMER and override the state
+                // the profile just restored. The user's typed-tune-during-
+                // rebuild loses both halves consistently: the slice half died
+                // in the rebuild too.
+                voidPendingPanWrites(
+                    panId, QStringLiteral("pan removed during profile load"));
                 m_radioDisplayPans.remove(normalizePanadapterId(panId));   // #3856 Layer B inventory
                 m_pendingPanStatuses.remove(panId);
                 m_panTransmitInhibitReasons.remove(panId);
@@ -6250,6 +6259,10 @@ void RadioModel::onStatusReceived(const QString& object,
                     m_stalePanadapters.erase(it);
                 }
                 if (rejectedPan) {
+                    // #4142: any deferred writes targeted the pan the user
+                    // saw, not this id's rightful owner — void, loudly.
+                    voidPendingPanWrites(panId,
+                                         QStringLiteral("pan ownership lost"));
                     m_panTransmitInhibitReasons.remove(panId);
                     m_panTransmitInhibitedTxSlices.remove(panId);
                     m_panStream->unregisterPanStream(rejectedPan->panStreamId());
@@ -6281,6 +6294,11 @@ void RadioModel::onStatusReceived(const QString& object,
                             << "reassigned to client" << newOwner
                             << "— going quiet on it (#3977)";
                     }
+                    // #4142: going quiet includes the deferred writes — the
+                    // foreign-owner gate would drop them at flush anyway;
+                    // void them at the moment ownership actually flips.
+                    voidPendingPanWrites(panId,
+                                         QStringLiteral("pan ownership lost"));
                     m_panTransmitInhibitReasons.remove(panId);
                     m_panTransmitInhibitedTxSlices.remove(panId);
                     heldPan->setClientHandle(newOwner);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -103,35 +103,9 @@ bool statusFlagSet(const QMap<QString, QString>& kvs, const QString& key)
         || value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0;
 }
 
-bool isProfileOwnedRadioStateWrite(const QString& command)
-{
-    const QString trimmed = command.trimmed();
-    const QStringList tokens = trimmed.simplified().split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    if (tokens.size() >= 5
-        && tokens[0] == QStringLiteral("display")
-        && tokens[1] == QStringLiteral("pan")
-        && tokens[2] == QStringLiteral("set")) {
-        bool hasPixelDimension = false;
-        for (int i = 4; i < tokens.size(); ++i) {
-            const QString key = tokens[i].section(QLatin1Char('='), 0, 0);
-            if (key != QStringLiteral("xpixels") && key != QStringLiteral("ypixels")) {
-                return true;
-            }
-            hasPixelDimension = true;
-        }
-        // xpixels/ypixels are allowed past this low-level guard because
-        // MainWindow queues them during a profile load and flushes them after
-        // the radio accepts the profile. Do not bypass
-        // MainWindow::requestPanDimensionsForRadio(); early dimension writes
-        // can cause the radio to save a partial GUIClient slice layout.
-        return !hasPixelDimension;
-    }
-
-    return trimmed.startsWith(QStringLiteral("slice set "))
-        || trimmed.startsWith(QStringLiteral("display pan set "))
-        || trimmed.startsWith(QStringLiteral("display panafall set "))
-        || trimmed.startsWith(QStringLiteral("display waterfall set "));
-}
+// isProfileOwnedRadioStateWrite() moved to ProfileLoadCommand.h so the
+// classification contract has a light, dependency-free test target
+// (profile_load_command_test). Behaviour unchanged. (#4142)
 
 void appendUniqueAntennaToken(QStringList& tokens, const QString& token)
 {
@@ -2761,11 +2735,115 @@ void RadioModel::setPanCenter(double centerMhz)
         // out-of-range center would be optimistically stored and advertised via
         // TCI dds: even though the radio rejects it.
         centerMhz = std::max(centerMhz, pan->bandwidthMhz() / 2.0);
-        pan->setCenterBandwidth(centerMhz, -1.0);
     }
-    sendCmd(
-        QString("display pan set %1 center=%2")
-            .arg(m_activePanId).arg(centerMhz, 0, 'f', 6));
+    requestPanCenter(m_activePanId, centerMhz);
+}
+
+bool RadioModel::requestPanCenter(const QString& panId,
+                                  double centerMhz,
+                                  double bandwidthMhz)
+{
+    if (panId.isEmpty()) {
+        return false;
+    }
+
+    // A pan center is profile-owned radio state, so sendCmd() would DROP this
+    // while a profile load is rebuilding the radio's topology. Defer it instead:
+    // queue the REQUESTED value and replay it once the hold lifts.
+    //
+    // Gate on exactly the predicate sendCmd() guards on, so "if sendCmd would
+    // drop it, we queue it" is an identity rather than an approximation — two
+    // separate clocks could skew and re-open the same silent drop.
+    if (profileLoadRadioStateWritesHeld()) {
+        PendingPanCenter& pending = m_pendingProfileLoadPanCenters[panId];
+        pending.centerMhz = centerMhz;
+        if (bandwidthMhz > 0.0) {
+            pending.bandwidthMhz = bandwidthMhz;
+        }
+
+        // Deliberately do NOT touch PanadapterModel here. The optimistic local
+        // update is the second half of #4142: with the command dropped, a client
+        // that advanced its own center claimed a center the radio never took.
+        // Honest VITA-49 tiles (each carrying its own FrameLowFreq/BinBandwidth)
+        // were then projected into a view that lied about its span, and the
+        // non-overlapping region rendered black — permanently, into history.
+        // Local state may only advance when a command actually reaches the wire.
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: deferring pan center during profile load"
+            << QStringLiteral("pan=%1").arg(panId)
+            << QStringLiteral("center=%1").arg(centerMhz, 0, 'f', 6);
+        return false;
+    }
+
+    sendPanCenterToRadio(panId, centerMhz, bandwidthMhz);
+    return true;
+}
+
+void RadioModel::sendPanCenterToRadio(const QString& panId,
+                                      double centerMhz,
+                                      double bandwidthMhz)
+{
+    if (PanadapterModel* pan = panadapter(panId)) {
+        // Keep the canonical model aligned with the command we are about to put
+        // on the wire: the radio may ACK without echoing a display status back
+        // to the setting client, and TCI dds: follows this center.
+        pan->setCenterBandwidth(centerMhz, bandwidthMhz > 0.0 ? bandwidthMhz : -1.0);
+    }
+
+    // Center and bandwidth must travel together when both are requested;
+    // splitting them produced the P1/P2 waterfall-loss and zoom-drift bugs.
+    const QString command = bandwidthMhz > 0.0
+        ? QString("display pan set %1 center=%2 bandwidth=%3")
+              .arg(panId)
+              .arg(centerMhz, 0, 'f', 6)
+              .arg(bandwidthMhz, 0, 'f', 6)
+        : QString("display pan set %1 center=%2")
+              .arg(panId)
+              .arg(centerMhz, 0, 'f', 6);
+
+    sendCommand(command);
+}
+
+void RadioModel::flushPendingProfileLoadPanCenters()
+{
+    if (m_pendingProfileLoadPanCenters.isEmpty() || !isConnected()) {
+        return;
+    }
+
+    // THE NON-REGRESSION PROOF, in one branch: while the hold is armed this
+    // returns without sending, so a deferred pan center can never put a byte on
+    // the wire inside the hold window. Nothing here can reintroduce the
+    // missing-slices corruption the hold exists to prevent.
+    //
+    // Returning WITHOUT clearing is deliberate. The hold can only still be armed
+    // because a further topology-rebuilding profile load re-armed it — and that
+    // load scheduled its own post-hold flush, which will replay these. Dropping
+    // them here would be the exact bug this method exists to fix.
+    if (profileLoadRadioStateWritesHeld()) {
+        return;
+    }
+
+    const QHash<QString, PendingPanCenter> pending =
+        std::exchange(m_pendingProfileLoadPanCenters, {});
+
+    int sent = 0;
+    for (auto it = pending.cbegin(); it != pending.cend(); ++it) {
+        // Re-resolve against the LIVE pan topology. A pan that the profile load
+        // removed — or replaced under a new id — simply never matches, so a
+        // stale center can never be applied to a pan that no longer exists.
+        if (!panadapter(it.key())) {
+            continue;
+        }
+
+        sendPanCenterToRadio(it.key(), it.value().centerMhz, it.value().bandwidthMhz);
+        ++sent;
+    }
+
+    if (sent > 0) {
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: flushed deferred profile-load pan centers"
+            << QStringLiteral("count=%1").arg(sent);
+    }
 }
 
 void RadioModel::setPanDbmRange(float minDbm, float maxDbm)
@@ -4857,7 +4935,12 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
     if (!profileLoad.valid
         && profileLoadRadioStateWritesHeld()
         && isProfileOwnedRadioStateWrite(command)) {
-        qCDebug(lcProtocol).noquote()
+        // Defense-in-depth backstop only. A command that reaches here is
+        // DROPPED — it never gets a sequence number and never reaches the wire.
+        // Callers that carry user intent must defer instead (see
+        // requestPanCenter()), so anything still landing here is a bug we want
+        // to see rather than silently swallow. (#4142)
+        qCWarning(lcProtocol).noquote()
             << "RadioModel: suppressing profile-load radio-state write"
             << command;
         if (cb) {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5269,8 +5269,9 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         // Defense-in-depth backstop only. A command that reaches here is
         // DROPPED — it never gets a sequence number and never reaches the wire.
         //
-        // Warn only for pan geometry, which is the class routed through
-        // requestPanCenter(): one of those arriving here means a caller bypassed
+        // Warn only for the routed fields (center/bandwidth/band), which is
+        // the class carried by requestPanCenter()/requestPanBandwidth()/
+        // requestPanBand(): one of those arriving here means a caller bypassed
         // the defer path and a user command is being lost — a real bug (#4142).
         //
         // The other suppressions on this path are model-echo/reconcile writers
@@ -5278,15 +5279,19 @@ quint32 RadioModel::sendCmd(const QString& command, ResponseCallback cb)
         // panafall/waterfall auto-black defaults). Several fire on every profile
         // load, so warning on them would cry wolf and bury the one line that
         // actually means something.
-        const bool panGeometryWrite =
+        //
+        // " band=" keeps its leading space so it cannot match inside
+        // "bandwidth=" — the two are distinct fields with distinct routes.
+        const bool routedPanFieldWrite =
             command.startsWith(QStringLiteral("display pan set "))
             && (command.contains(QStringLiteral("center="))
-                || command.contains(QStringLiteral("bandwidth=")));
+                || command.contains(QStringLiteral("bandwidth="))
+                || command.contains(QStringLiteral(" band=")));
 
-        if (panGeometryWrite) {
+        if (routedPanFieldWrite) {
             qCWarning(lcProtocol).noquote()
-                << "RadioModel: DROPPED a pan geometry write during profile load —"
-                << "this should have been deferred via requestPanCenter()"
+                << "RadioModel: DROPPED a routed pan field write during profile load —"
+                << "this should have been deferred via requestPan*()"
                 << command;
         } else {
             qCDebug(lcProtocol).noquote()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -31,6 +31,7 @@
 #include <QtEndian>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <utility>
 
@@ -696,6 +697,13 @@ RadioModel::RadioModel(QObject* parent)
     // Forward VITA-49 meter packets to MeterModel (cross-thread, auto-queued)
     connect(m_panStream, &PanadapterStream::meterDataReady,
             &m_meterModel, &MeterModel::updateValues);
+
+    // #4142 — single owner of the deferred pan-write replay. Armed by the
+    // defer path (armProfileLoadPanWriteFlush), hold-relative, self-re-arming;
+    // the flush re-checks the hold before sending a byte.
+    m_profileLoadPanWriteFlushTimer.setSingleShot(true);
+    connect(&m_profileLoadPanWriteFlushTimer, &QTimer::timeout,
+            this, &RadioModel::flushPendingProfileLoadPanWrites);
 
     // Route tuner relay intents to the radio through the backend seam (#4092).
     // The model emits neutral intents; FlexBackend translates them to the SmartSDR
@@ -2739,6 +2747,28 @@ void RadioModel::setPanCenter(double centerMhz)
     requestPanCenter(m_activePanId, centerMhz);
 }
 
+namespace {
+
+// Log-line rendering of a voided/flushed entry: exactly the fields that were
+// pending, in wire syntax, so the log names what was (or would have been)
+// destroyed.
+QString describePanWrites(const AetherSDR::PanWrites& writes)
+{
+    QStringList parts;
+    if (writes.bandKey) {
+        parts << QStringLiteral("band=%1").arg(*writes.bandKey);
+    }
+    if (writes.centerMhz) {
+        parts << QStringLiteral("center=%1").arg(*writes.centerMhz, 0, 'f', 6);
+    }
+    if (writes.bandwidthMhz) {
+        parts << QStringLiteral("bandwidth=%1").arg(*writes.bandwidthMhz, 0, 'f', 6);
+    }
+    return parts.join(QLatin1Char(' '));
+}
+
+} // namespace
+
 bool RadioModel::requestPanCenter(const QString& panId,
                                   double centerMhz,
                                   double bandwidthMhz)
@@ -2746,6 +2776,8 @@ bool RadioModel::requestPanCenter(const QString& panId,
     if (panId.isEmpty()) {
         return false;
     }
+
+    const bool wantsBandwidth = bandwidthMhz > 0.0;
 
     // A pan center is profile-owned radio state, so sendCmd() would DROP this
     // while a profile load is rebuilding the radio's topology. Defer it instead:
@@ -2755,10 +2787,45 @@ bool RadioModel::requestPanCenter(const QString& panId,
     // drop it, we queue it" is an identity rather than an approximation — two
     // separate clocks could skew and re-open the same silent drop.
     if (profileLoadRadioStateWritesHeld()) {
-        PendingPanCenter& pending = m_pendingProfileLoadPanCenters[panId];
-        pending.centerMhz = centerMhz;
-        if (bandwidthMhz > 0.0) {
-            pending.bandwidthMhz = bandwidthMhz;
+        const auto pendingCenter =
+            m_pendingProfileLoadPanWrites.pendingCenter(panId);
+        const auto pendingBandwidth =
+            m_pendingProfileLoadPanWrites.pendingBandwidth(panId);
+
+        // Dedupe against EFFECTIVE state. Equal to what is already pending →
+        // nothing new to record; the request stays deferred.
+        const bool equalsPending =
+            pendingCenter && qFuzzyCompare(*pendingCenter, centerMhz)
+            && (!wantsBandwidth
+                || (pendingBandwidth
+                    && qFuzzyCompare(*pendingBandwidth, bandwidthMhz)));
+        if (equalsPending) {
+            return false;
+        }
+
+        // Equal to the MODEL — which keeps tracking radio status during the
+        // hold, so this is radio truth. If a different value was pending, the
+        // user corrected back: cancel exactly the requested fields instead of
+        // replaying the superseded value later. Either way the radio is
+        // already where the caller asked — report success.
+        PanadapterModel* pan = panadapter(panId);
+        const bool equalsModel =
+            pan && qFuzzyCompare(pan->centerMhz(), centerMhz)
+            && (!wantsBandwidth
+                || qFuzzyCompare(pan->bandwidthMhz(), bandwidthMhz));
+        if (equalsModel) {
+            if (pendingCenter || (wantsBandwidth && pendingBandwidth)) {
+                m_pendingProfileLoadPanWrites.supersedeCenter(panId);
+                if (wantsBandwidth) {
+                    m_pendingProfileLoadPanWrites.supersedeBandwidth(panId);
+                }
+                qCDebug(lcProtocol).noquote()
+                    << "RadioModel: cancelled pending pan write (user corrected"
+                    << "back to the radio's state)"
+                    << QStringLiteral("pan=%1").arg(panId)
+                    << QStringLiteral("center=%1").arg(centerMhz, 0, 'f', 6);
+            }
+            return true;
         }
 
         // Deliberately do NOT touch PanadapterModel here. The optimistic local
@@ -2768,6 +2835,12 @@ bool RadioModel::requestPanCenter(const QString& panId,
         // were then projected into a view that lied about its span, and the
         // non-overlapping region rendered black — permanently, into history.
         // Local state may only advance when a command actually reaches the wire.
+        if (wantsBandwidth) {
+            m_pendingProfileLoadPanWrites.deferCenterBandwidth(panId, centerMhz,
+                                                               bandwidthMhz);
+        } else {
+            m_pendingProfileLoadPanWrites.deferCenter(panId, centerMhz);
+        }
         qCDebug(lcProtocol).noquote()
             << "RadioModel: deferring pan center during profile load"
             << QStringLiteral("pan=%1").arg(panId)
@@ -2781,76 +2854,233 @@ bool RadioModel::requestPanCenter(const QString& panId,
         // the radio long enough that it misses pings and the client force-
         // disconnects BEFORE the ACK ever arrives — in which case no flush would
         // ever have been scheduled and this request would be stranded forever.
-        armProfileLoadPanCenterFlush();
+        armProfileLoadPanWriteFlush();
         return false;
     }
 
-    sendPanCenterToRadio(panId, centerMhz, bandwidthMhz);
-    return true;
+    // Immediate path. Supersede exactly the fields this write carries FIRST,
+    // so a stale deferred value can never replay over the newer wire state
+    // (hold-expiry-to-flush is a real window: the flush runs at hold+100 ms).
+    m_pendingProfileLoadPanWrites.supersedeCenter(panId);
+    if (wantsBandwidth) {
+        m_pendingProfileLoadPanWrites.supersedeBandwidth(panId);
+    }
+    return dispatchPanCenterBandwidth(panId, centerMhz, bandwidthMhz);
 }
 
-void RadioModel::sendPanCenterToRadio(const QString& panId,
-                                      double centerMhz,
-                                      double bandwidthMhz)
+bool RadioModel::requestPanBandwidth(const QString& panId, double bandwidthMhz)
 {
-    if (PanadapterModel* pan = panadapter(panId)) {
-        // Keep the canonical model aligned with the command we are about to put
-        // on the wire: the radio may ACK without echoing a display status back
-        // to the setting client, and TCI dds: follows this center.
-        pan->setCenterBandwidth(centerMhz, bandwidthMhz > 0.0 ? bandwidthMhz : -1.0);
+    if (panId.isEmpty() || bandwidthMhz <= 0.0) {
+        return false;
+    }
+
+    if (profileLoadRadioStateWritesHeld()) {
+        const auto pendingBandwidth =
+            m_pendingProfileLoadPanWrites.pendingBandwidth(panId);
+        if (pendingBandwidth && qFuzzyCompare(*pendingBandwidth, bandwidthMhz)) {
+            return false;
+        }
+
+        PanadapterModel* pan = panadapter(panId);
+        if (pan && qFuzzyCompare(pan->bandwidthMhz(), bandwidthMhz)) {
+            if (pendingBandwidth) {
+                m_pendingProfileLoadPanWrites.supersedeBandwidth(panId);
+                qCDebug(lcProtocol).noquote()
+                    << "RadioModel: cancelled pending pan bandwidth (user"
+                    << "corrected back to the radio's state)"
+                    << QStringLiteral("pan=%1").arg(panId)
+                    << QStringLiteral("bandwidth=%1").arg(bandwidthMhz, 0, 'f', 6);
+            }
+            return true;
+        }
+
+        m_pendingProfileLoadPanWrites.deferBandwidth(panId, bandwidthMhz);
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: deferring pan bandwidth during profile load"
+            << QStringLiteral("pan=%1").arg(panId)
+            << QStringLiteral("bandwidth=%1").arg(bandwidthMhz, 0, 'f', 6);
+        armProfileLoadPanWriteFlush();
+        return false;
+    }
+
+    m_pendingProfileLoadPanWrites.supersedeBandwidth(panId);
+    return dispatchPanCenterBandwidth(
+        panId, std::numeric_limits<double>::quiet_NaN(), bandwidthMhz);
+}
+
+bool RadioModel::requestPanBand(const QString& panId, const QString& bandKey)
+{
+    if (panId.isEmpty() || bandKey.isEmpty()) {
+        return false;
+    }
+
+    if (profileLoadRadioStateWritesHeld()) {
+        const auto pendingBand = m_pendingProfileLoadPanWrites.pendingBand(panId);
+        if (pendingBand && *pendingBand == bandKey) {
+            return false;
+        }
+
+        // No model-side dedupe: the client holds no band-stack state to compare
+        // against — the radio owns it and reports the outcome via status.
+        m_pendingProfileLoadPanWrites.deferBand(panId, bandKey);
+        qCDebug(lcProtocol).noquote()
+            << "RadioModel: deferring pan band during profile load"
+            << QStringLiteral("pan=%1").arg(panId)
+            << QStringLiteral("band=%1").arg(bandKey);
+        armProfileLoadPanWriteFlush();
+        return false;
+    }
+
+    m_pendingProfileLoadPanWrites.supersedeBand(panId);
+    return dispatchPanBand(panId, bandKey);
+}
+
+double RadioModel::effectivePanCenterMhz(const QString& panId) const
+{
+    if (const auto pending = m_pendingProfileLoadPanWrites.pendingCenter(panId)) {
+        return *pending;
+    }
+    if (const PanadapterModel* pan = panadapter(panId)) {
+        return pan->centerMhz();
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+double RadioModel::effectivePanBandwidthMhz(const QString& panId) const
+{
+    if (const auto pending =
+            m_pendingProfileLoadPanWrites.pendingBandwidth(panId)) {
+        return *pending;
+    }
+    if (const PanadapterModel* pan = panadapter(panId)) {
+        return pan->bandwidthMhz();
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+bool RadioModel::dispatchPanCenterBandwidth(const QString& panId,
+                                            double centerMhz,
+                                            double bandwidthMhz)
+{
+    const bool hasCenter = !std::isnan(centerMhz);
+    const bool hasBandwidth = bandwidthMhz > 0.0;
+    if (!hasCenter && !hasBandwidth) {
+        return false;
+    }
+
+    PanadapterModel* pan = panadapter(panId);
+
+    if (hasCenter) {
+        // Re-clamp against the pan's CURRENT geometry. The request may have
+        // been clamped by its caller against geometry a profile load has since
+        // replaced — a deferred write is dispatched seconds after it was made.
+        // Same rule as every gesture path: the pan's low edge stays >= 0 Hz.
+        const double clampBandwidthMhz =
+            hasBandwidth ? bandwidthMhz : (pan ? pan->bandwidthMhz() : 0.0);
+        const double clamped = std::max(centerMhz, clampBandwidthMhz / 2.0);
+        if (clamped > centerMhz) {
+            qCDebug(lcProtocol).noquote()
+                << "RadioModel: clamping pan center against current geometry"
+                << QStringLiteral("pan=%1").arg(panId)
+                << QStringLiteral("requested=%1").arg(centerMhz, 0, 'f', 6)
+                << QStringLiteral("clamped=%1").arg(clamped, 0, 'f', 6);
+            centerMhz = clamped;
+        }
     }
 
     // Center and bandwidth must travel together when both are requested;
     // splitting them produced the P1/P2 waterfall-loss and zoom-drift bugs.
-    const QString command = bandwidthMhz > 0.0
-        ? QString("display pan set %1 center=%2 bandwidth=%3")
-              .arg(panId)
-              .arg(centerMhz, 0, 'f', 6)
-              .arg(bandwidthMhz, 0, 'f', 6)
-        : QString("display pan set %1 center=%2")
-              .arg(panId)
-              .arg(centerMhz, 0, 'f', 6);
+    QString command;
+    if (hasCenter && hasBandwidth) {
+        command = QString("display pan set %1 center=%2 bandwidth=%3")
+                      .arg(panId)
+                      .arg(centerMhz, 0, 'f', 6)
+                      .arg(bandwidthMhz, 0, 'f', 6);
+    } else if (hasCenter) {
+        command = QString("display pan set %1 center=%2")
+                      .arg(panId)
+                      .arg(centerMhz, 0, 'f', 6);
+    } else {
+        command = QString("display pan set %1 bandwidth=%2")
+                      .arg(panId)
+                      .arg(bandwidthMhz, 0, 'f', 6);
+    }
 
-    sendCommand(command);
+    // Wire BEFORE model, gated on the send actually happening. sendCommand()
+    // reports the foreign-owner drop, the hold backstop, and a dead WAN
+    // session; advancing the model on any of those would re-create the exact
+    // model-claims-state-the-radio-never-took lie this fix exists to kill.
+    if (!sendCommand(command)) {
+        qCWarning(lcProtocol).noquote()
+            << "RadioModel: pan write not dispatched — model state unchanged —"
+            << command;
+        return false;
+    }
+
+    if (pan) {
+        // Keep the canonical model aligned with the command now on the wire:
+        // the radio may ACK without echoing a display status back to the
+        // setting client, and TCI dds: follows this center.
+        pan->setCenterBandwidth(hasCenter ? centerMhz : pan->centerMhz(),
+                                hasBandwidth ? bandwidthMhz : -1.0);
+    }
+    return true;
 }
 
-void RadioModel::armProfileLoadPanCenterFlush()
+bool RadioModel::dispatchPanBand(const QString& panId, const QString& bandKey)
+{
+    const QString command =
+        QString("display pan set %1 band=%2").arg(panId, bandKey);
+
+    if (!sendCommand(command)) {
+        qCWarning(lcProtocol).noquote()
+            << "RadioModel: pan band write not dispatched —" << command;
+        return false;
+    }
+
+    // No model write: the band-stack swap retunes center/bandwidth/slices on
+    // the radio, and that state arrives via radio status like any other
+    // radio-initiated change.
+    return true;
+}
+
+void RadioModel::armProfileLoadPanWriteFlush()
 {
     // Re-arm for exactly when the hold lifts. The hold can be EXTENDED after we
     // arm (the ACK pushes it out again, and a second profile load pushes it out
     // further), so the flush re-checks and re-arms itself rather than trusting a
-    // single deadline computed up front.
+    // single deadline computed up front. stop()/start() keeps a SINGLE live
+    // deadline — every defer restarts the one timer instead of adding another.
     const qint64 remainingMs =
         m_profileLoadRadioStateWriteHoldUntilMs - QDateTime::currentMSecsSinceEpoch();
     const int delayMs = static_cast<int>(std::max<qint64>(remainingMs, 0)) + 100;
 
-    QTimer::singleShot(delayMs, this, [this]() {
-        flushPendingProfileLoadPanCenters();
-    });
+    m_profileLoadPanWriteFlushTimer.stop();
+    m_profileLoadPanWriteFlushTimer.start(delayMs);
 }
 
-void RadioModel::flushPendingProfileLoadPanCenters()
+void RadioModel::flushPendingProfileLoadPanWrites()
 {
-    if (m_pendingProfileLoadPanCenters.isEmpty()) {
+    if (m_pendingProfileLoadPanWrites.isEmpty()) {
         return;
     }
 
     if (!isConnected()) {
         // The session these requests belonged to is gone. Their pan ids and the
         // user's intent both died with it, and the radio will rebuild its own
-        // topology on reconnect — replaying a pre-disconnect center could land a
-        // stale frequency on a pan that is no longer the same pan. Void them
+        // topology on reconnect — replaying a pre-disconnect write could land
+        // stale state on a pan that is no longer the same pan. Void them
         // loudly rather than stranding or misapplying them. (onDisconnected()
         // normally clears these first; this is the backstop.)
         qCWarning(lcProtocol).noquote()
-            << "RadioModel: discarding" << m_pendingProfileLoadPanCenters.size()
-            << "deferred pan center(s) — disconnected before the profile load settled";
-        m_pendingProfileLoadPanCenters.clear();
+            << "RadioModel: discarding" << m_pendingProfileLoadPanWrites.size()
+            << "deferred pan write(s) — disconnected before the profile load settled";
+        m_pendingProfileLoadPanWrites.clear();
         return;
     }
 
     // THE NON-REGRESSION PROOF, in one branch: while the hold is armed this
-    // returns without sending, so a deferred pan center can never put a byte on
+    // returns without sending, so a deferred pan write can never put a byte on
     // the wire inside the hold window. Nothing here can reintroduce the
     // missing-slices corruption the hold exists to prevent.
     //
@@ -2859,31 +3089,74 @@ void RadioModel::flushPendingProfileLoadPanCenters()
     // it out; dropping the request here would be the exact bug this method exists
     // to fix.
     if (profileLoadRadioStateWritesHeld()) {
-        armProfileLoadPanCenterFlush();
+        armProfileLoadPanWriteFlush();
         return;
     }
 
-    const QHash<QString, PendingPanCenter> pending =
-        std::exchange(m_pendingProfileLoadPanCenters, {});
+    const QHash<QString, PanWrites> pending =
+        m_pendingProfileLoadPanWrites.takeAll();
 
     int sent = 0;
+    int voided = 0;
     for (auto it = pending.cbegin(); it != pending.cend(); ++it) {
-        // Re-resolve against the LIVE pan topology. A pan that the profile load
-        // removed — or replaced under a new id — simply never matches, so a
-        // stale center can never be applied to a pan that no longer exists.
-        if (!panadapter(it.key())) {
+        const QString& panId = it.key();
+        const PanWrites& writes = it.value();
+
+        // Backstop only: the removal hook voids a dying pan's writes at
+        // removal time, so a vanished pan here means a removal path was
+        // missed. Void loudly either way — never silently.
+        if (!panadapter(panId)) {
+            ++voided;
+            qCWarning(lcProtocol).noquote()
+                << "RadioModel: voiding deferred pan write(s) — pan vanished"
+                << "without a removal void (missed hook?)"
+                << QStringLiteral("pan=%1").arg(panId)
+                << describePanWrites(writes);
             continue;
         }
 
-        sendPanCenterToRadio(it.key(), it.value().centerMhz, it.value().bandwidthMhz);
-        ++sent;
+        // Band first, then center+bandwidth merged — the same order as the
+        // live cross-band path: the band-stack swap lands, then the explicit
+        // target overrides the stack's recalled frequency.
+        if (writes.bandKey) {
+            if (dispatchPanBand(panId, *writes.bandKey)) {
+                ++sent;
+            } else {
+                ++voided;
+            }
+        }
+        if (writes.centerMhz || writes.bandwidthMhz) {
+            const double centerMhz = writes.centerMhz
+                ? *writes.centerMhz
+                : std::numeric_limits<double>::quiet_NaN();
+            const double bandwidthMhz =
+                writes.bandwidthMhz ? *writes.bandwidthMhz : -1.0;
+            if (dispatchPanCenterBandwidth(panId, centerMhz, bandwidthMhz)) {
+                ++sent;
+            } else {
+                ++voided;
+            }
+        }
     }
 
-    if (sent > 0) {
-        qCDebug(lcProtocol).noquote()
-            << "RadioModel: flushed deferred profile-load pan centers"
-            << QStringLiteral("count=%1").arg(sent);
+    // Always account — a flush that voided everything is exactly the one that
+    // must not be invisible in the log.
+    qCInfo(lcProtocol).noquote()
+        << "RadioModel: deferred profile-load pan write flush"
+        << QStringLiteral("sent=%1").arg(sent)
+        << QStringLiteral("voided=%1").arg(voided);
+}
+
+void RadioModel::voidPendingPanWrites(const QString& panId, const QString& reason)
+{
+    const auto voided = m_pendingProfileLoadPanWrites.cancel(panId);
+    if (!voided) {
+        return;
     }
+    qCWarning(lcProtocol).noquote()
+        << "RadioModel: voiding deferred pan write(s) —" << reason
+        << QStringLiteral("pan=%1").arg(panId)
+        << describePanWrites(*voided);
 }
 
 void RadioModel::setPanDbmRange(float minDbm, float maxDbm)
@@ -3864,12 +4137,13 @@ void RadioModel::onDisconnected()
     // same pan. This is a real path, not a theoretical one — a large profile
     // (8 pans / 8 slices on a 6700) can stall the radio past the ping timeout and
     // force a disconnect BEFORE the profile load is ever ACKed.
-    if (!m_pendingProfileLoadPanCenters.isEmpty()) {
+    if (!m_pendingProfileLoadPanWrites.isEmpty()) {
         qCWarning(lcProtocol).noquote()
-            << "RadioModel: discarding" << m_pendingProfileLoadPanCenters.size()
-            << "deferred pan center(s) — disconnected before the profile load settled";
-        m_pendingProfileLoadPanCenters.clear();
+            << "RadioModel: discarding" << m_pendingProfileLoadPanWrites.size()
+            << "deferred pan write(s) — disconnected before the profile load settled";
+        m_pendingProfileLoadPanWrites.clear();
     }
+    m_profileLoadPanWriteFlushTimer.stop();
 
     // Release sleep inhibition on disconnect (#1420)
     m_sleepInhibitor.release();

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -648,8 +648,14 @@ signals:
     void radioMessageReceived(const QString& text, MessageSeverity severity);
 
 public:
-    // Send a raw command to the radio (for dialogs that need direct protocol access).
-    void sendCommand(const QString& cmd);
+    // Send a raw command to the radio (for dialogs that need direct protocol
+    // access). Returns whether the command was actually dispatched: false when
+    // the foreign-owner gate (#3977) drops a pan write, when the profile-load
+    // hold backstop suppresses a profile-owned write (#4142), or when a WAN
+    // session is not connected. Callers that advance local state to match a
+    // command MUST gate that on this return, or the client will claim state
+    // the radio never took.
+    bool sendCommand(const QString& cmd);
 
     // Request local PTT for our station. Sends "client set local_ptt=1" and applies
     // an optimistic update in case the radio doesn't echo the state change.

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -723,6 +723,10 @@ private:
     void sendPanCenterToRadio(const QString& panId,
                               double centerMhz,
                               double bandwidthMhz);
+    // Schedules the deferred-pan-center replay for when the hold lifts. Armed by
+    // the act of deferring, NOT by the profile-load ACK — a large topology can
+    // stall the radio into a disconnect before it ever ACKs. (#4142)
+    void armProfileLoadPanCenterFlush();
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -15,6 +15,7 @@
 #include "SliceModel.h"
 #include "MeterModel.h"
 #include "PanadapterModel.h"
+#include "ProfileLoadPanWriteQueue.h"
 #include "TunerModel.h"
 #include "AmpModel.h"
 #include "TransmitModel.h"
@@ -445,38 +446,61 @@ public:
     void setPanCenter(double centerMhz);
     void setPanDbmRange(float minDbm, float maxDbm);
 
-    // #4142 — the ONLY supported way to write a pan center (and, optionally, a
-    // coupled bandwidth) to the radio.
+    // #4142 — the ONLY supported way for a USER-INTENT path to write a pan's
+    // center/bandwidth/band to the radio.
     //
-    // `display pan set <id> center=…` is classified as a profile-owned radio
-    // state write, so sendCmd() DROPS it while the profile-load hold is armed:
-    // it returns before a sequence number is allocated and the command never
-    // reaches the wire. A user action that lands in that window (typed
-    // frequency, zoom, drag, ATU sweep, automation) was silently lost, and the
-    // client kept its optimistic center — leaving the pan permanently claiming
-    // a center the radio never took.
+    // `display pan set <id> center=…` (and bandwidth=/band=) is classified as
+    // a profile-owned radio state write, so sendCmd() DROPS it while the
+    // profile-load hold is armed: it returns before a sequence number is
+    // allocated and the command never reaches the wire. A user action that
+    // lands in that window (typed frequency, zoom, drag, band change, ATU
+    // sweep, automation) was silently lost, and the client kept its optimistic
+    // state — leaving the pan permanently claiming state the radio never took.
     //
-    // requestPanCenter() defers instead of dropping: while the hold is armed it
-    // coalesces the request per pan (last-write-wins) and returns false WITHOUT
-    // advancing local model state, so the client never claims a center the radio
-    // does not have. flushPendingProfileLoadPanCenters() replays it once the
-    // hold lifts.
+    // requestPan*() defers instead of dropping: while the hold is armed it
+    // coalesces the request per pan (field-wise, last write wins per field)
+    // and returns false WITHOUT advancing local model state, so the client
+    // never claims state the radio does not have. The replay is scheduled by
+    // the act of deferring and re-checks the hold before sending.
+    //
+    // Deduping is centralized here against EFFECTIVE state — the pending value
+    // if one is queued, else the model (which keeps tracking radio status
+    // during the hold). A request equal to the model that supersedes a
+    // different pending value is a user CORRECTION: the pending entry is
+    // cancelled instead of replayed.
+    //
+    // Routing discipline is the user-intent boundary: model-echo/reconcile
+    // writers (active-slice reasserts, dBm auto-floor, fps/average reconciles)
+    // must keep their explicit guards and the sendCmd() backstop — #3563
+    // suppresses them during a profile load BY DESIGN. Do not route those.
     //
     // Pass bandwidthMhz > 0 to set center and bandwidth coherently in one
     // command (zoom paths must never split the pair); pass <= 0 to leave the
     // radio's bandwidth untouched.
     //
-    // Returns true if the command reached the wire, false if it was deferred.
-    // Callers that also advance view state optimistically must gate that on the
-    // return value, or they will re-create the black-waterfall divergence.
+    // Returns true if the radio's state matches the request (dispatched, or a
+    // corrective cancel — the radio is already there); false if the request is
+    // deferred or could not be dispatched. Callers that also advance view
+    // state optimistically must gate that on the return value, or they will
+    // re-create the black-waterfall divergence.
     bool requestPanCenter(const QString& panId,
                           double centerMhz,
                           double bandwidthMhz = -1.0);
+    bool requestPanBandwidth(const QString& panId, double bandwidthMhz);
+    bool requestPanBand(const QString& panId, const QString& bandKey);
 
-    // Replays deferred pan-center writes. Hard invariant: this early-returns
-    // while the hold is armed, so no deferred center can reach the wire inside
-    // the hold window.
-    void flushPendingProfileLoadPanCenters();
+    // Effective pan geometry: the deferred pending value if one is queued,
+    // else the live model value, else NaN when the pan is unknown. Caller-side
+    // no-op guards must compare against THIS, not the raw model — during the
+    // hold the model deliberately lags the user's deferred request.
+    double effectivePanCenterMhz(const QString& panId) const;
+    double effectivePanBandwidthMhz(const QString& panId) const;
+
+    // Replays deferred pan writes. Hard invariant: this early-returns while
+    // the hold is armed, so no deferred write can reach the wire inside the
+    // hold window. Scheduling is owned by the defer path (hold-relative,
+    // self-re-arming) — never by the profile-load ACK, which may never arrive.
+    void flushPendingProfileLoadPanWrites();
     void setPanWnb(bool on);
     void setPanWnbLevel(int level);
     void setPanRfGain(int gain);
@@ -723,16 +747,27 @@ private:
     bool m_wfAutoBlackOn{true};         // mirrors the client auto-black on/off
     bool m_wfAutoBlackRadioSide{false}; // false = client-side, true = radio-side
     bool profileLoadRadioStateWritesHeld() const;
-    // Raw sender for a pan center (+ optional coupled bandwidth). Applies the
-    // local model update and puts the command on the wire together, so the two
-    // can never diverge. Everything else must go through requestPanCenter().
-    void sendPanCenterToRadio(const QString& panId,
-                              double centerMhz,
-                              double bandwidthMhz);
-    // Schedules the deferred-pan-center replay for when the hold lifts. Armed by
+    // Raw senders (#4142). Both keep ALL wire-string building for the pan
+    // touchpoint in one place (AGENTS.md seam step 2.4: command encode migrates
+    // to FlexBackend per-touchpoint — these two functions are that touchpoint).
+    //
+    // dispatchPanCenterBandwidth re-clamps the center against the pan's
+    // CURRENT geometry, puts the command on the wire FIRST, and advances the
+    // model only when the send actually happened — wire-before-model is what
+    // makes a re-entrant request converge (last wire write == last model
+    // write) instead of diverging. bandwidthMhz <= 0 means center-only;
+    // centerMhz as NaN means bandwidth-only.
+    bool dispatchPanCenterBandwidth(const QString& panId,
+                                    double centerMhz,
+                                    double bandwidthMhz);
+    // No model write: band-stack state arrives via radio status.
+    bool dispatchPanBand(const QString& panId, const QString& bandKey);
+    // Schedules the deferred-pan-write replay for when the hold lifts. Armed by
     // the act of deferring, NOT by the profile-load ACK — a large topology can
     // stall the radio into a disconnect before it ever ACKs. (#4142)
-    void armProfileLoadPanCenterFlush();
+    void armProfileLoadPanWriteFlush();
+    // Voids one pan's deferred writes, loudly naming what was destroyed.
+    void voidPendingPanWrites(const QString& panId, const QString& reason);
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for
@@ -1105,17 +1140,14 @@ private:
     quint32            m_txClientHandle{0};  // handle of the client that owns TX
     qint64             m_profileLoadRadioStateWriteHoldUntilMs{0};
 
-    // #4142 — pan-center writes deferred while the profile-load hold is armed.
-    // bandwidthMhz <= 0 means "center only; leave the radio's bandwidth alone".
-    struct PendingPanCenter {
-        double centerMhz{0.0};
-        double bandwidthMhz{-1.0};
-    };
-    // panId → last requested center. Coalesced last-write-wins, but field-wise:
-    // a later center-only request must NOT erase a bandwidth an earlier zoom
-    // asked for, or that zoom's bandwidth would be the very thing we set out to
-    // stop dropping.
-    QHash<QString, PendingPanCenter> m_pendingProfileLoadPanCenters;
+    // #4142 — user pan writes (band/center/bandwidth) deferred while the
+    // profile-load hold is armed. Field-wise coalescing lives in the queue
+    // type; see ProfileLoadPanWriteQueue.h for the semantics and
+    // profile_load_command_test for the contract.
+    ProfileLoadPanWriteQueue m_pendingProfileLoadPanWrites;
+    // Single owner of the replay schedule (stop/start re-arm — never a fan of
+    // one-shot timers, which would fire a stale flush for every extension).
+    QTimer m_profileLoadPanWriteFlushTimer;
 
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     std::function<void()> m_multiFlexContinuation; // saved continuation during conflict pause

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -676,9 +676,13 @@ public:
     // access). Returns whether the command was actually dispatched: false when
     // the foreign-owner gate (#3977) drops a pan write, when the profile-load
     // hold backstop suppresses a profile-owned write (#4142), or when a WAN
-    // session is not connected. Callers that advance local state to match a
-    // command MUST gate that on this return, or the client will claim state
-    // the radio never took.
+    // session is not connected. The WAN case is the only transport failure
+    // this contract can see: the LAN path allocates a sequence number
+    // unconditionally, so a write queued onto a dead LAN socket still reports
+    // as dispatched (pre-existing optimistic behavior; a disconnect instead
+    // voids any deferred pan writes via onDisconnected()). Callers that
+    // advance local state to match a command MUST gate that on this return,
+    // or the client will claim state the radio never took.
     bool sendCommand(const QString& cmd);
 
     // Request local PTT for our station. Sends "client set local_ptt=1" and applies

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -444,6 +444,39 @@ public:
     void setPanBandwidth(double bandwidthMhz);
     void setPanCenter(double centerMhz);
     void setPanDbmRange(float minDbm, float maxDbm);
+
+    // #4142 — the ONLY supported way to write a pan center (and, optionally, a
+    // coupled bandwidth) to the radio.
+    //
+    // `display pan set <id> center=…` is classified as a profile-owned radio
+    // state write, so sendCmd() DROPS it while the profile-load hold is armed:
+    // it returns before a sequence number is allocated and the command never
+    // reaches the wire. A user action that lands in that window (typed
+    // frequency, zoom, drag, ATU sweep, automation) was silently lost, and the
+    // client kept its optimistic center — leaving the pan permanently claiming
+    // a center the radio never took.
+    //
+    // requestPanCenter() defers instead of dropping: while the hold is armed it
+    // coalesces the request per pan (last-write-wins) and returns false WITHOUT
+    // advancing local model state, so the client never claims a center the radio
+    // does not have. flushPendingProfileLoadPanCenters() replays it once the
+    // hold lifts.
+    //
+    // Pass bandwidthMhz > 0 to set center and bandwidth coherently in one
+    // command (zoom paths must never split the pair); pass <= 0 to leave the
+    // radio's bandwidth untouched.
+    //
+    // Returns true if the command reached the wire, false if it was deferred.
+    // Callers that also advance view state optimistically must gate that on the
+    // return value, or they will re-create the black-waterfall divergence.
+    bool requestPanCenter(const QString& panId,
+                          double centerMhz,
+                          double bandwidthMhz = -1.0);
+
+    // Replays deferred pan-center writes. Hard invariant: this early-returns
+    // while the hold is armed, so no deferred center can reach the wire inside
+    // the hold window.
+    void flushPendingProfileLoadPanCenters();
     void setPanWnb(bool on);
     void setPanWnbLevel(int level);
     void setPanRfGain(int gain);
@@ -684,6 +717,12 @@ private:
     bool m_wfAutoBlackOn{true};         // mirrors the client auto-black on/off
     bool m_wfAutoBlackRadioSide{false}; // false = client-side, true = radio-side
     bool profileLoadRadioStateWritesHeld() const;
+    // Raw sender for a pan center (+ optional coupled bandwidth). Applies the
+    // local model update and puts the command on the wire together, so the two
+    // can never diverge. Everything else must go through requestPanCenter().
+    void sendPanCenterToRadio(const QString& panId,
+                              double centerMhz,
+                              double bandwidthMhz);
     void registerAsGuiClient(const QString& clientId);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for
@@ -1055,6 +1094,19 @@ private:
     int                m_rttyMarkDefault{2125};
     quint32            m_txClientHandle{0};  // handle of the client that owns TX
     qint64             m_profileLoadRadioStateWriteHoldUntilMs{0};
+
+    // #4142 — pan-center writes deferred while the profile-load hold is armed.
+    // bandwidthMhz <= 0 means "center only; leave the radio's bandwidth alone".
+    struct PendingPanCenter {
+        double centerMhz{0.0};
+        double bandwidthMhz{-1.0};
+    };
+    // panId → last requested center. Coalesced last-write-wins, but field-wise:
+    // a later center-only request must NOT erase a bandwidth an earlier zoom
+    // asked for, or that zoom's bandwidth would be the very thing we set out to
+    // stop dropping.
+    QHash<QString, PendingPanCenter> m_pendingProfileLoadPanCenters;
+
     QMap<quint32, ClientInfo> m_clientInfoMap; // handle → full client info
     std::function<void()> m_multiFlexContinuation; // saved continuation during conflict pause
     QMap<quint32, QString> m_clientStations;   // handle → station name (legacy, kept in sync)

--- a/tests/profile_load_command_test.cpp
+++ b/tests/profile_load_command_test.cpp
@@ -1,4 +1,5 @@
 #include "models/ProfileLoadCommand.h"
+#include "models/ProfileLoadPanWriteQueue.h"
 
 #include <cstdio>
 
@@ -120,6 +121,117 @@ int main()
     check(isProfileOwnedRadioStateWrite(
               QStringLiteral("display waterfall set 0x42000000 color_gain=50")),
           "waterfall write is profile-owned");
+
+    // ── ProfileLoadPanWriteQueue — deferred-write store semantics (#4142) ──
+    //
+    // The queue holds the writes sendCmd() would otherwise silently destroy
+    // during the profile-load hold. Coalescing is FIELD-WISE per pan: a later
+    // center write must never erase a queued bandwidth (whole-struct
+    // last-write-wins loses a user's zoom — the exact class of bug #4142 set
+    // out to fix).
+    {
+        const QString pan = QStringLiteral("0x40000000");
+
+        // (a) field-wise last-write-wins
+        ProfileLoadPanWriteQueue q;
+        q.deferCenter(pan, 14.1);
+        q.deferBandwidth(pan, 0.2);
+        q.deferCenter(pan, 7.086);
+        check(q.size() == 1, "coalescing keeps one entry per pan");
+        check(q.pendingCenter(pan).has_value()
+                  && qFuzzyCompare(*q.pendingCenter(pan), 7.086),
+              "later center supersedes the earlier center (last write wins)");
+        check(q.pendingBandwidth(pan).has_value()
+                  && qFuzzyCompare(*q.pendingBandwidth(pan), 0.2),
+              "a later center write does NOT erase a queued bandwidth");
+
+        // paired center+bandwidth defers both fields atomically
+        q.deferCenterBandwidth(pan, 14.250, 0.4);
+        check(qFuzzyCompare(*q.pendingCenter(pan), 14.250)
+                  && qFuzzyCompare(*q.pendingBandwidth(pan), 0.4),
+              "paired center+bandwidth defer updates both fields");
+
+        // band is an independent field with its own last-write-wins
+        q.deferBand(pan, QStringLiteral("40"));
+        q.deferBand(pan, QStringLiteral("20"));
+        check(q.pendingBand(pan).has_value()
+                  && *q.pendingBand(pan) == QStringLiteral("20"),
+              "later band supersedes the earlier band");
+
+        // (b) supersedeCenterBandwidth erases only those fields
+        q.supersedeCenterBandwidth(pan);
+        check(!q.pendingCenter(pan).has_value()
+                  && !q.pendingBandwidth(pan).has_value(),
+              "supersedeCenterBandwidth erases pending center and bandwidth");
+        check(q.pendingBand(pan).has_value(),
+              "supersedeCenterBandwidth leaves a pending band untouched");
+        check(q.size() == 1, "entry survives while any field is still pending");
+
+        // supersedeBand erases only the band
+        q.deferCenter(pan, 7.0);
+        q.supersedeBand(pan);
+        check(!q.pendingBand(pan).has_value(),
+              "supersedeBand erases the pending band");
+        check(q.pendingCenter(pan).has_value(),
+              "supersedeBand leaves a pending center untouched");
+
+        // field-precise supersede: a center-only send must not erase a queued
+        // zoom's bandwidth, and a bandwidth corrective must not swallow a
+        // queued center (the same F-trap as coalescing, on the erase side)
+        q.deferBandwidth(pan, 0.2);
+        q.supersedeCenter(pan);
+        check(!q.pendingCenter(pan).has_value(),
+              "supersedeCenter erases the pending center");
+        check(q.pendingBandwidth(pan).has_value(),
+              "supersedeCenter leaves a pending bandwidth untouched");
+        q.deferCenter(pan, 7.0);
+        q.supersedeBandwidth(pan);
+        check(!q.pendingBandwidth(pan).has_value(),
+              "supersedeBandwidth erases the pending bandwidth");
+        check(q.pendingCenter(pan).has_value(),
+              "supersedeBandwidth leaves a pending center untouched");
+
+        // (e) an entry whose last field is superseded does not linger
+        q.supersedeCenterBandwidth(pan);
+        check(q.isEmpty() && q.size() == 0,
+              "superseding the last pending field erases the entry");
+        check(!q.cancel(pan).has_value(),
+              "cancel on a pan with no pending writes reports nothing to void");
+
+        // (c) cancel returns the voided entry for logging and empties it
+        q.deferBand(pan, QStringLiteral("40"));
+        q.deferCenterBandwidth(pan, 7.086, 0.2);
+        const auto voided = q.cancel(pan);
+        check(voided.has_value(), "cancel returns the voided entry");
+        check(voided
+                  && voided->bandKey == QStringLiteral("40")
+                  && voided->centerMhz.has_value()
+                  && voided->bandwidthMhz.has_value(),
+              "the voided entry carries every pending field for the log line");
+        check(q.isEmpty(), "cancel removes the pan's whole entry");
+
+        // (d) takeAll drains the queue
+        const QString otherPan = QStringLiteral("0x40000001");
+        q.deferCenter(pan, 14.1);
+        q.deferBand(otherPan, QStringLiteral("15"));
+        check(q.size() == 2, "distinct pans queue independently");
+        const auto all = q.takeAll();
+        check(all.size() == 2, "takeAll returns every pan's entry");
+        check(all.contains(pan) && all.contains(otherPan),
+              "takeAll keys entries by pan id");
+        check(q.isEmpty(), "takeAll leaves the queue empty");
+
+        // clear() is the disconnect path
+        q.deferCenter(pan, 14.1);
+        q.clear();
+        check(q.isEmpty(), "clear empties the queue");
+
+        // PanWrites::isEmpty reflects field occupancy
+        PanWrites w;
+        check(w.isEmpty(), "a default PanWrites is empty");
+        w.centerMhz = 7.086;
+        check(!w.isEmpty(), "a PanWrites with any field set is not empty");
+    }
 
     return failures == 0 ? 0 : 1;
 }

--- a/tests/profile_load_command_test.cpp
+++ b/tests/profile_load_command_test.cpp
@@ -61,5 +61,65 @@ int main()
     check(kProfileLoadPostHoldRecoveryDelayMs > kProfileLoadDeferredPanFlushDelayMs,
           "post-hold recovery runs after deferred pan flush");
 
+    // ── isProfileOwnedRadioStateWrite() — the classification contract (#4142) ──
+    //
+    // sendCmd() DROPS every command this returns true for while the profile-load
+    // hold is armed: it returns before a sequence number is allocated, so the
+    // command never reaches the wire. These cases pin down exactly which writes
+    // are lost, and therefore which ones MUST be deferred by
+    // RadioModel::requestPanCenter() rather than handed to sendCmd() and hoped for.
+
+    // A pan center is profile-owned — this is the write that #4142 lost. Direct
+    // frequency entry emits an atomic pair; the `slice tune` half survives and the
+    // `center=` half was silently dropped, so the slice retuned and the pan did not.
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 center=7.086000")),
+          "pan center write is profile-owned (the #4142 drop)");
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 center=7.086000 bandwidth=0.200000")),
+          "coupled pan center+bandwidth write is profile-owned (zoom/drag also dropped)");
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 bandwidth=0.200000")),
+          "pan bandwidth write is profile-owned");
+
+    // xpixels/ypixels are the ONE exemption, and only because the client alone
+    // knows its pixel geometry — the display is broken until they are sent.
+    // MainWindow defers and coalesces them (requestPanDimensionsForRadio); this
+    // exemption is a necessity, NOT evidence that early pan writes are safe.
+    check(!isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 xpixels=1920 ypixels=800")),
+          "pan pixel dimensions are exempt (client-owned display geometry)");
+    check(!isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 xpixels=1920")),
+          "xpixels alone is exempt");
+
+    // A single non-pixel field anywhere in the argument list re-arms the guard:
+    // the exemption is all-or-nothing, so center can never ride in on a dimension
+    // write's coat-tails.
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display pan set 0x40000000 xpixels=1920 center=7.086000")),
+          "pixel dimensions mixed with a center write are NOT exempt");
+
+    // Reads are never suppressed — only writes.
+    check(!isProfileOwnedRadioStateWrite(QStringLiteral("display pan info 0x40000000")),
+          "pan info read is not a profile-owned write");
+    check(!isProfileOwnedRadioStateWrite(QStringLiteral("sub slice all")),
+          "subscription is not a profile-owned write");
+
+    // `slice tune` is NOT profile-owned: it is the half of the typed-frequency
+    // pair that survived the hold. That asymmetry is the bug — the slice moved
+    // and the pan could not follow.
+    check(!isProfileOwnedRadioStateWrite(QStringLiteral("slice tune 0 7.086000 autopan=0")),
+          "slice tune survives the hold (the surviving half of the #4142 pair)");
+    check(isProfileOwnedRadioStateWrite(QStringLiteral("slice set 0 rfgain=20")),
+          "slice set write is profile-owned");
+
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display panafall set 0x40000000 center=7.086000")),
+          "panafall write is profile-owned");
+    check(isProfileOwnedRadioStateWrite(
+              QStringLiteral("display waterfall set 0x42000000 color_gain=50")),
+          "waterfall write is profile-owned");
+
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes #4142.

During the 10 s profile-load hold, `sendCmd()` suppresses every profile-owned radio-state
write — silently. A typed frequency entry emits an atomic pair: the `slice tune` half
passes, the `display pan set … center=` half is destroyed before a sequence number is
allocated, and the client's optimistic model advance then projects honest VITA-49 tiles
into a view claiming a center the radio never took: the non-overlap renders black,
permanently, into waterfall history. The cross-band variant also loses its `band=` write,
so the slice lands outside the pan entirely.

This PR makes the tune/zoom/band class of user writes (`center=`, `bandwidth=`, `band=`)
**defer instead of drop**, with three properties the previous behavior lacked:

- **Never lie.** `sendCommand()` now reports whether a command was actually dispatched
  (the #3977 foreign-owner gate, the hold backstop, and a dead WAN session all return
  false), and the pan model advances only *after* a successful wire write — wire-before-
  model makes a re-entrant request converge instead of diverge. Dispatch re-clamps the
  center against the pan geometry current at flush time, not the geometry the request
  was made against.
- **Never silently drop.** User writes made during the hold coalesce field-wise per pan
  in a dedicated store (`ProfileLoadPanWriteQueue`, unit-tested) and replay when the hold
  lifts — band first, then center+bandwidth merged, mirroring the live cross-band order.
  Every write that cannot be replayed (pan removed, ownership lost, disconnect) is voided
  **loudly**, naming the pan and the destroyed fields; the flush logs a sent/voided
  account unconditionally.
- **Respect corrections.** Dedupe runs against *effective* state — the pending value if
  one is queued, else the model, which keeps tracking radio status through the hold. A
  request equal to the radio's state that supersedes a different pending value is a user
  correction: the pending entry is cancelled, never replayed over the user.

Replay scheduling is owned by the defer path (a single member `QTimer`, hold-relative,
self-re-arming) — **not** by the profile-load ACK. That matters because a large topology
can stall the radio past the ping timeout into a force-disconnect before the ACK ever
arrives (measured 5/5 on an 8-pan profile on a 6700 — full timing data in #4222), and
MainWindow's ACK-gated recovery pass — including its previous deferred-center flush call —
never runs on such a load. The
pan-removal paths void a dead pan's queued writes at removal time, because the radio
re-uses pan ids across a load (observed live): a queued write must never replay onto a
same-id newcomer and override the state the profile just restored.

**The non-regression proof, in one branch:** `flushPendingProfileLoadPanWrites()`
early-returns while the hold is armed, so a deferred write can never put a byte on the
wire inside the hold window. Nothing in this PR can reintroduce the missing-slices
corruption the #3563 hold exists to prevent. `kProfileLoadStateWriteHoldMs` is untouched.

### Honest scope

- **Routed in this PR:** `center=`, `bandwidth=`, `band=` — every path in the reported
  issue, including the cross-band typed tune. Echo/reconcile writers (active-slice/TX
  reasserts, dBm auto-floor, fps/average reconciles, auto-black) are deliberately NOT
  routed: #3563 suppresses them by design, and routing discipline at the call site is
  the user-intent boundary — no wire-protocol flag.
- **Still suppressed during the hold** (mechanism is ready; enumerated for follow-up):
  `rxant`, `wnb`/`wnb_level`, `rfgain`, `loopa`/`loopb`, `min_dbm`/`max_dbm`,
  `band_zoom`/`segment_zoom`, `fps`, `average`, `weighted_average`, `daxiq_channel`,
  plus the wholesale-suppressed `slice set` / `display panafall set` /
  `display waterfall set` families, and one genuinely mixed site
  (`dbmRangeChangeRequested`: user drag and auto-floor share a wire path). Tracked
  with the full census in #4223.
- **Gesture paths self-heal rather than never diverging:** `SpectrumWidget` applies its
  own view on zoom/drag/edge-pan before emitting the request, so on those paths the view
  can lead the radio for the duration of the hold — a temporary, self-correcting
  divergence (each VITA-49 tile carries its own geometry), not a permanent scar. Typed
  entry — the reported bug — is model-driven and fully covered.
- The WFM/Doppler escape branch no longer zeroes the demod NCO when its recenter was
  deferred; it keeps best-effort audio at the clamped IQ-window edge until the flush
  self-heals.

## Constitution principle honored

Principle II — the radio is authoritative. The client's model no longer advances for a
command that never reached the wire, deferred writes re-validate against the live pan
topology and current geometry before dispatch, and the radio's own state (tracked through
the hold) is the dedupe baseline.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] `profile_load_command_test` extended: classifier contract + full
      `ProfileLoadPanWriteQueue` semantics (field-wise coalescing, field-precise
      supersede, cancel-with-receipt, drain)
- [x] Full ctest failure set diffed against clean `upstream/main` on the same box —
      byte-identical (no new failures)
- [x] Behavior verified on a real radio (FLEX-6700, RX-only, 2026-07-13: the black-waterfall scenarios no longer reproduce on the fix build and do on the baseline; runbook: typed tune in the hold
      dead-zone, cross-band typed tune, corrective zoom/retype, worst-case multi-pan
      load with force-disconnect, pan close with a pending write, untouched-load
      missing-slices regression guard)
- [x] Reproduction steps documented in #4142

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` (n/a — no meter changes)
- [x] Documentation updated if user-visible behavior changed (n/a — behavior change is
      the fix itself; log lines document the defer/void/flush lifecycle)
- [x] Security-sensitive changes reference a GHSA (n/a)

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)

