### PR TITLE
[audio] Fix Linux PC Audio capture stall after TCI TX

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -7601,6 +7601,20 @@ void AudioEngine::onTxAudioReady()
         if (event != TxCaptureHealthTracker::Event::None) {
             logTxCaptureHealthEvent(event);
         }
+#ifdef Q_OS_LINUX
+        // Qt/PipeWire capture is edge-driven: leaving the pull device unread
+        // fills its ring, after which no new readyRead edge arrives to resume
+        // PC Audio when TCI stops (#4230). Keep consuming the Linux source but
+        // discard these samples so only TCI audio reaches the radio. Windows
+        // and macOS retain their existing behavior until equivalent evidence
+        // exists for those backends.
+        if (m_micDevice) {
+            const QByteArray discarded = m_micDevice->readAll();
+            if (!discarded.isEmpty()) {
+                m_txCaptureHealth.recordMicRead(txCaptureNowMs());
+            }
+        }
+#endif
         if (m_audioSource) {
             observeTxCaptureState(m_audioSource->state());
         }


### PR DESCRIPTION
## Summary

Fixes the Linux/PipeWire PC Audio capture stall seen after TCI transmit in #4230. While TCI audio owns the TX path, AetherSDR now continues draining the local Linux `QAudioSource` and discards those suppressed samples. This prevents the PipeWire/Qt pull-device ring from filling and losing the `readyRead()` edge needed when PC Audio resumes.

The behavior change is gated by `Q_OS_LINUX`. Windows and macOS keep their existing behavior, minimizing blast radius while the evidence is specific to PipeWire/Linux.

## Merge order

**Merge #4233 first.** This PR is intentionally stacked on the corrected diagnostic instrumentation in #4233, so its current diff contains both that instrumentation and the Linux behavior fix. Once #4233 lands, this PR reduces to the single Linux-only fix commit (`d028ead8`).

The #4233 diagnostic is part of the fix strategy: it remains default-on and bounded so support logs can show whether the source reached a full buffer and whether the drain prevents recurrence in the field.

## Root cause evidence

The new #4230 support log provides the missing direct evidence:

- TCI audio became active at 11:28:44.769.
- The local microphone source reached `12000/12000` buffered bytes.
- `lastMicReadAge` reached 14,173 ms.
- The Qt source still reported `Active/NoError`, so an Active-to-Idle-only diagnostic would miss the failure.
- `dax=0` was confirmed at 11:28:47.667, before the failed local TX at 11:28:50.486.

That isolates the failure to AetherSDR's local capture-consumption path: the TCI suppression return in `AudioEngine::onTxAudioReady()` stopped reading the pull device until its ring was full. On an edge-driven PipeWire source, freeing it only after the handoff is too late because no new readiness edge is guaranteed.

## Fix

- On Linux only, read and discard local microphone bytes while fresh TCI audio suppresses PC Audio.
- Continue recording successful microphone consumption in the TX capture-health tracker.
- Do not send the discarded samples to the radio; TCI remains the sole TX audio source during the suppression window.
- Do not change DAX routing, radio TX ownership, or Multi-Flex ownership rules. Local AetherSDR TX remains tracked in Multi-Flex mode; transmissions owned by another radio client remain excluded from local capture-failure accounting.

## Diagnostic correction in #4233

The prerequisite diagnostic now detects the actual signature shown by the field log: a buffer at capacity while the source remains Active. It retains Active-to-Idle with unread bytes as a fallback when Qt cannot report a capacity. The bounded summary and `get audio` snapshot expose:

- `full_buffer_during_tci_observations`
- `post_tci_local_tx_while_saturated`
- `buffer_bytes_available`
- `buffer_capacity_bytes`
- `source_was_active`
- `saturation_observed`
- `tci_suppressed_callbacks`
- `last_mic_read_age_ms`

## Validation

- Full RelWithDebInfo Ninja build with 8 jobs: passed.
- Full CTest suite: 114/114 passed; one existing quarantined clean-room test skipped by policy.
- TX capture-health state-machine test: 18/18 assertions passed, including Active/full-buffer detection and the Idle fallback.
- `tools/check_engine_boundary.py --strict`: zero blocking findings.
- `git diff --check`: clean.
- Automation bridge: `ping` and `get audio` passed; the corrected saturation fields were present and initialized.

The local automation host is macOS, where the Linux-only branch is deliberately excluded. Linux CI will provide compilation coverage; final PipeWire behavior validation should use the original reporter's reproduction sequence with the default Audio Summary diagnostics enabled.

## Related reports

Refs #4152, #3805, #2286, #752, #537, #1008, #75, #2864, #2895, #3363, #3669, and #4009. These reports are related for Linux/PipeWire field correlation; this PR does not claim they all share #4230's root cause.

Fixes #4230.

## Screenshots

Not applicable: this changes core audio consumption and diagnostics with no visual UI change.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
