### PR TITLE
Install udev rules only if building DVStar module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3586,7 +3586,7 @@ else()
         )
         if(LINUX)
             install(FILES packaging/linux/70-aethersdr-thumbdv.rules
-                DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d
+                DESTINATION lib/udev/rules.d
             )
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3584,6 +3584,11 @@ else()
         install(FILES third_party/smartsdr-dsp/config/AetherDV.cfg
             DESTINATION ${CMAKE_INSTALL_BINDIR}
         )
+        if(LINUX)
+            install(FILES packaging/linux/70-aethersdr-thumbdv.rules
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d
+            )
+        endif()
     endif()
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/packaging/linux/AetherSDR.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
@@ -3600,9 +3605,4 @@ else()
     install(FILES packaging/linux/aethersdr.1
         DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
     )
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        install(FILES packaging/linux/70-aethersdr-thumbdv.rules
-            DESTINATION lib/udev/rules.d
-        )
-    endif()
 endif()


### PR DESCRIPTION
Hello,

I have noticed while packaging the newest version for Debian, that even when you don't build the DVStar subsystem the udev rules are placed there, so I made a PR to fix this.

Also, the metainfo file should contain section about compatible hardware IDs, so it can recommend users who have the particular hardware device the AetherSDR software :smile: 

Thanks,
Dawid Kulas
SP9SKA