### PR TITLE
feat(radio): accept conventional band-name aliases (70cm -> 440) in declared bands

### DIFF
--- a/src/models/DeclaredBands.cpp
+++ b/src/models/DeclaredBands.cpp
@@ -2,6 +2,7 @@
 
 #include "BandDefs.h"
 
+#include <cstddef>
 #include <string_view>
 
 namespace AetherSDR {
@@ -43,24 +44,61 @@ constexpr BandAlias kBandAliases[] = {
     {"70cm", "440"},   // UHF: every ham + gateway spells it 70cm; AE names it 440
 };
 
-// Enforce the security invariant at COMPILE TIME: every alias's canonical must
-// name an existing kBands entry. This makes Principle VII hold by construction
-// (an alias can only ever be a second spelling of a real band) rather than by
-// review — a future typo'd or renamed canonical fails the build instead of
-// silently dropping the band.
-constexpr bool aliasCanonicalsExist()
+// Constexpr ASCII case-insensitive compare. Band tokens are ASCII, so this
+// matches resolveAlias()'s Qt::CaseInsensitive comparison for the shadow check
+// below while staying evaluable at compile time.
+constexpr char asciiLower(char c)
+{
+    return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+}
+constexpr bool ciEqualAscii(std::string_view a, std::string_view b)
+{
+    if (a.size() != b.size())
+        return false;
+    for (std::size_t i = 0; i < a.size(); ++i)
+        if (asciiLower(a[i]) != asciiLower(b[i]))
+            return false;
+    return true;
+}
+
+// Enforce the alias invariants at COMPILE TIME so Principle VII holds by
+// construction (an alias can only ever be a second spelling of a real,
+// renderable band) rather than by review. A future bad alias fails the build
+// instead of silently misbehaving. Three invariants, each with a concrete
+// failure mode if it were violated:
+//   (1) canonical exists in kBands — else the alias resolves to a name the
+//       allow-list drops (dead alias).
+//   (2) canonical is declarable — resolveAlias() runs before the isDeclarable
+//       gate, so an alias to a non-declarable band (2200m/630m) would also be
+//       a dead alias; require declarability up front so the failure is a build
+//       error, not a silent empty result.
+//   (3) the alias key does NOT collide with a real kBands name — resolveAlias()
+//       runs BEFORE the allow-list match, so a key equal to a real band would
+//       silently redirect (shadow) that legitimate band's token.
+constexpr bool aliasesAreValid()
 {
     for (const auto& a : kBandAliases) {
-        bool found = false;
+        // (3) alias key must not shadow a real band (case-insensitive, matching
+        //     resolveAlias's own comparison).
         for (const auto& def : kBands)
-            if (std::string_view(def.name) == a.canonical) { found = true; break; }
-        if (!found)
+            if (ciEqualAscii(def.name, a.alias))
+                return false;
+        // (1) + (2) canonical must name an existing, declarable kBands entry.
+        bool ok = false;
+        for (const auto& def : kBands)
+            if (std::string_view(def.name) == a.canonical && isDeclarable(def)) {
+                ok = true;
+                break;
+            }
+        if (!ok)
             return false;
     }
     return true;
 }
-static_assert(aliasCanonicalsExist(),
-              "every kBandAliases canonical must name an existing kBands entry");
+static_assert(aliasesAreValid(),
+              "every kBandAliases entry must (1) name an existing kBands "
+              "canonical, (2) that is declarable, and (3) use an alias key that "
+              "does not collide with any real kBands name");
 
 // If `name` is a known alias, return its canonical kBands spelling; otherwise
 // return `name` unchanged. Case-insensitive on the alias key.

--- a/src/models/DeclaredBands.cpp
+++ b/src/models/DeclaredBands.cpp
@@ -2,6 +2,8 @@
 
 #include "BandDefs.h"
 
+#include <string_view>
+
 namespace AetherSDR {
 
 namespace {
@@ -31,7 +33,8 @@ constexpr bool isDeclarable(const BandDef& def)
 // new band — so it cannot introduce anything the band UI doesn't already have,
 // and the resolved name still runs the isDeclarable + kBands allow-list below.
 // Kept deliberately minimal: only real-world mismatches that have actually been
-// observed from a gateway (currently just 70cm; see Aether-gate PRs #14/#15).
+// observed from a gateway (currently just 70cm; the same class of mismatch was
+// patched per-adapter in Aether-gate PRs #14/#15/#16 — this fixes it once here).
 struct BandAlias {
     const char* alias;
     const char* canonical;
@@ -39,6 +42,25 @@ struct BandAlias {
 constexpr BandAlias kBandAliases[] = {
     {"70cm", "440"},   // UHF: every ham + gateway spells it 70cm; AE names it 440
 };
+
+// Enforce the security invariant at COMPILE TIME: every alias's canonical must
+// name an existing kBands entry. This makes Principle VII hold by construction
+// (an alias can only ever be a second spelling of a real band) rather than by
+// review — a future typo'd or renamed canonical fails the build instead of
+// silently dropping the band.
+constexpr bool aliasCanonicalsExist()
+{
+    for (const auto& a : kBandAliases) {
+        bool found = false;
+        for (const auto& def : kBands)
+            if (std::string_view(def.name) == a.canonical) { found = true; break; }
+        if (!found)
+            return false;
+    }
+    return true;
+}
+static_assert(aliasCanonicalsExist(),
+              "every kBandAliases canonical must name an existing kBands entry");
 
 // If `name` is a known alias, return its canonical kBands spelling; otherwise
 // return `name` unchanged. Case-insensitive on the alias key.

--- a/src/models/DeclaredBands.cpp
+++ b/src/models/DeclaredBands.cpp
@@ -20,6 +20,37 @@ constexpr bool isDeclarable(const BandDef& def)
     return def.highMhz >= 1.0;
 }
 
+// Accepted alternate spellings for a band, mapping to the canonical kBands
+// name. AE's band vocabulary is internally inconsistent — the 70cm band is
+// named "440" — but a gateway (or a ham typing a profile) naturally spells it
+// "70cm". Rather than force every radio adapter to know AE's quirk, accept the
+// conventional name here and resolve it to the canonical one.
+//
+// SECURITY INVARIANT (Principle VII): an alias may ONLY map to a name that
+// already exists in kBands. It is a second *spelling* of a known band, never a
+// new band — so it cannot introduce anything the band UI doesn't already have,
+// and the resolved name still runs the isDeclarable + kBands allow-list below.
+// Kept deliberately minimal: only real-world mismatches that have actually been
+// observed from a gateway (currently just 70cm; see Aether-gate PRs #14/#15).
+struct BandAlias {
+    const char* alias;
+    const char* canonical;
+};
+constexpr BandAlias kBandAliases[] = {
+    {"70cm", "440"},   // UHF: every ham + gateway spells it 70cm; AE names it 440
+};
+
+// If `name` is a known alias, return its canonical kBands spelling; otherwise
+// return `name` unchanged. Case-insensitive on the alias key.
+QString resolveAlias(const QString& name)
+{
+    for (const auto& a : kBandAliases) {
+        if (name.compare(QLatin1String(a.alias), Qt::CaseInsensitive) == 0)
+            return QString::fromLatin1(a.canonical);
+    }
+    return name;
+}
+
 } // namespace
 
 QStringList parseDeclaredBands(const QString& csv)
@@ -27,7 +58,10 @@ QStringList parseDeclaredBands(const QString& csv)
     QStringList out;
     const QStringList parts = csv.split(',', Qt::SkipEmptyParts);
     for (const QString& part : parts) {
-        const QString name = part.trimmed();
+        // Resolve a conventional spelling (e.g. "70cm") to its canonical kBands
+        // name before matching. A non-alias token passes through unchanged, so
+        // the allow-list below is still the sole gate on what gets rendered.
+        const QString name = resolveAlias(part.trimmed());
         for (const auto& def : kBands) {
             if (!isDeclarable(def))
                 continue;

--- a/src/models/DeclaredBands.h
+++ b/src/models/DeclaredBands.h
@@ -14,6 +14,11 @@ namespace AetherSDR {
 // non-declarable per #4027's non-goals, even though they are kBands entries
 // (see the isDeclarable() firewall in DeclaredBands.cpp). An empty/absent
 // value yields an empty list, which is the real-Flex path (band UI unchanged).
+//
+// A short alias table also accepts conventional spellings (e.g. "70cm") and
+// resolves them to the canonical kBands name ("440"), so gateways need not
+// know AE's naming quirks. Aliases only ever map to names already in kBands,
+// so the allow-list guarantee above is unchanged (see kBandAliases in the .cpp).
 QStringList parseDeclaredBands(const QString& csv);
 
 } // namespace AetherSDR

--- a/tests/declared_bands_test.cpp
+++ b/tests/declared_bands_test.cpp
@@ -86,6 +86,31 @@ int main(int argc, char** argv)
            eq(parseDeclaredBands(QStringLiteral("2m,440,2m")),
               {QStringLiteral("2m"), QStringLiteral("440")}));
 
+    // Band-name aliases: a conventional spelling resolves to the canonical
+    // kBands name. "70cm" is what every ham + gateway spells UHF; AE names it
+    // "440" (see Aether-gate PRs #14/#15). The alias maps only to a name that
+    // already exists in kBands, so Principle VII is unchanged (junk still drops).
+    report("alias (70cm -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("70cm")),
+              {QStringLiteral("440")}));
+    report("alias case-fold (70CM -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("70CM")),
+              {QStringLiteral("440")}));
+    report("alias among reals (2m,70cm,23cm -> [2m,440,23cm])",
+           eq(parseDeclaredBands(QStringLiteral("2m,70cm,23cm")),
+              {QStringLiteral("2m"), QStringLiteral("440"), QStringLiteral("23cm")}));
+    // Both spellings sent -> dedup collapses to one canonical entry (either order).
+    report("alias dedup (440,70cm -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("440,70cm")),
+              {QStringLiteral("440")}));
+    report("alias dedup (70cm,440 -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("70cm,440")),
+              {QStringLiteral("440")}));
+    // Principle VII holds with aliasing on: the alias is kept, junk still dropped.
+    report("alias kept, junk dropped (70cm,junk -> [440])",
+           eq(parseDeclaredBands(QStringLiteral("70cm,junk")),
+              {QStringLiteral("440")}));
+
     if (g_failed == 0) {
         std::printf("\nAll %d declared-bands tests passed.\n", g_total);
         return 0;

--- a/tests/declared_bands_test.cpp
+++ b/tests/declared_bands_test.cpp
@@ -110,6 +110,14 @@ int main(int argc, char** argv)
     report("alias kept, junk dropped (70cm,junk -> [440])",
            eq(parseDeclaredBands(QStringLiteral("70cm,junk")),
               {QStringLiteral("440")}));
+    // An alias must be a *faithful* second spelling: it produces exactly what
+    // the canonical produces — same output, and (since the canonical renders)
+    // never a name the allow-list drops. This pins the observable half of the
+    // compile-time invariants (canonical exists AND is declarable); the shadow
+    // and declarability guarantees themselves are enforced by static_assert.
+    report("alias parse equals canonical parse (70cm == 440)",
+           eq(parseDeclaredBands(QStringLiteral("70cm")),
+              parseDeclaredBands(QStringLiteral("440"))));
 
     if (g_failed == 0) {
         std::printf("\nAll %d declared-bands tests passed.\n", g_total);


### PR DESCRIPTION
## Summary

AE's band vocabulary is internally inconsistent — the 70 cm band is named **`440`**, not `70cm`. But a gateway (or a ham typing a radio profile) naturally spells it `70cm`, and `parseDeclaredBands()` matches names exactly against `kBands`, so the conventional spelling is **silently dropped** and the band never appears.

That mismatch has so far been patched *adapter-by-adapter* on the [Aether-gate](https://github.com/nigelfenton/Aether-gate) side — one rename per radio (its PRs #14 `_70CM`→`440`, #15, #16 `6cm`→`5cm`). This fixes it **once, in AE**, so no adapter has to know AE's naming quirks: teach `parseDeclaredBands` a small alias table that resolves a conventional spelling to the canonical `kBands` name before matching.

Follows #4027 (radio-declared `bands=`) and its review follow-ups in #4194. Standalone off `main` (not stacked).

## Change

- A `constexpr` alias table + `resolveAlias()` helper in `DeclaredBands.cpp`. Each incoming token is alias-resolved (case-insensitive) before the existing `kBands` allow-list loop.
- Kept **deliberately minimal** — one entry, `70cm → 440`, the only mismatch actually observed from a gateway. Easy to extend later with concrete evidence (e.g. `6cm → 5cm`), but no speculative aliases.

## Principle VII is unchanged (the bit worth checking)

An alias may **only** map to a name that already exists in `kBands`. The resolved name still runs through `isDeclarable()` + the `kBands` allow-list, so:
- an alias is a second *spelling* of a known band, never a new band — it cannot inject anything the band UI doesn't already have;
- unknown tokens still drop; the LF/MF exclusion from #4191/#4194 still applies.

This is enforced by construction: `resolveAlias()` returns a plain string that is then validated exactly as before. A non-alias token passes through unchanged.

## Tests

`declared_bands_test` gains 6 cases (all green — **17/17**):
- `70cm → [440]`, case-fold `70CM → [440]`
- alias among reals `2m,70cm,23cm → [2m,440,23cm]`
- dedup when both spellings arrive: `440,70cm → [440]` and `70cm,440 → [440]`
- **Principle VII:** `70cm,junk → [440]` — alias kept, junk dropped

Built + ran locally on Windows (Qt 6.10.3, current `main` = `b9735c79`).