### PR TITLE
fix(ui): reset stale per-connection state (radio-name label + DAX-TX stream) on reconnect

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1432,6 +1432,11 @@ MainWindow::MainWindow(QWidget* parent)
             m_radioInfoLabel->setText(m_radioModel.model());
         if (m_radioVersionLabel && !m_radioModel.version().isEmpty())
             m_radioVersionLabel->setText(m_radioModel.version());
+        // Also refresh the station/nickname label: the nickname can be corrected
+        // by the async "info" reply after connect, and this handler previously
+        // updated only model + version, leaving a stale station name on screen.
+        if (m_stationLabel && !m_radioModel.nickname().isEmpty())
+            setStatusBarStationText(m_stationLabel, m_radioModel.nickname());
     });
 
     // Propagate late-arriving SmartSDR+ subscription + dual-SCU diversity
@@ -5277,6 +5282,15 @@ void MainWindow::onConnectionStateChanged(bool connected)
 #endif
         audioStopRx();
         audioStopTx();
+        // Clear the cached DAX-TX stream id on connection loss. RadioModel already
+        // resets its own dax_tx state on disconnect, but AudioEngine::m_txStreamId
+        // was left holding the OLD id — so after a reconnect the AX.25 modem's
+        // "create the stream only if txStreamId()==0" guard saw a stale non-zero
+        // id, skipped ensureDaxTxStream(), and pumped modem audio to a dead stream
+        // (bare carrier, no modulation). Resetting it here makes the next transmit
+        // re-create the DAX-TX stream on the new connection.
+        if (m_audio)
+            m_audio->setTxStreamId(0);
 
         for (auto it = m_panFpsReconcileConnections.begin();
              it != m_panFpsReconcileConnections.end(); ++it) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1435,7 +1435,7 @@ MainWindow::MainWindow(QWidget* parent)
         // Also refresh the station/nickname label: the nickname can be corrected
         // by the async "info" reply after connect, and this handler previously
         // updated only model + version, leaving a stale station name on screen.
-        if (m_stationLabel && !m_radioModel.nickname().isEmpty())
+        if (!m_radioModel.nickname().isEmpty())
             setStatusBarStationText(m_stationLabel, m_radioModel.nickname());
     });
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3811,6 +3811,13 @@ void RadioModel::onDisconnected()
         m_staleSessionSerial = m_chassisSerial;
     m_chassisSerial.clear();
     m_callsign.clear();
+    // Clear the nickname here too, not just on the connectToRadio() seeding
+    // path: connectViaWan() takes no RadioInfo and the LAN auto-reconnect timer
+    // calls m_connection->connectToRadio(m_lastInfo) directly, both bypassing
+    // RadioModel::connectToRadio(). Clearing on the disconnect side closes all
+    // three paths at once, so a reconnect can never show the previous radio's
+    // station label while the async info reply is in flight. (#4260 review)
+    m_nickname.clear();
     m_region.clear();
     m_rxAudio = {};
     m_netCwStreamId = 0;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1767,6 +1767,14 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_name    = info.name;
     m_model   = info.model;
     m_version = info.version;
+    // Seed nickname/callsign from the discovery packet so the status-bar station
+    // label is correct the instant onConnectionStateChanged(true) reads it. These
+    // were previously only set later from the async "info" reply, so on connect
+    // the label showed a STALE m_nickname — blank on the first connect, or the
+    // PREVIOUSLY connected radio's name (it is never cleared on disconnect). The
+    // async reply still refreshes them if they differ.
+    m_nickname = info.nickname;
+    m_callsign = info.callsign;
     m_declaredBands = parseDeclaredBands(info.bands);   // empty for real Flex
     m_maxSlices = maxSlicesForModel(m_model);
     if (reloadAntennaAliases())


### PR DESCRIPTION
## Summary

Two client-side values were cached across a radio disconnect and reused on the next connection, producing wrong state on reconnect. They're the same shape — a field the connection/`RadioModel` resets, but a mirror doesn't — and both are ~a handful of lines.

### 1. Stale radio-name in the status-bar station label

**Symptom:** on the **first** connect after launch, the bottom-center station label is blank; if a radio was connected earlier in the session, it shows the **previously** connected radio's name. A disconnect+reconnect then shows the correct name.

**Cause:** `RadioModel::connectToRadio()` seeds `m_name`/`m_model`/`m_version` from the discovery `RadioInfo` but not `m_nickname`/`m_callsign` (the `RadioInfo` already carries both). `m_nickname` is also never cleared on disconnect. So `onConnectionStateChanged(true)`, which sets the label synchronously from `m_radioModel.nickname()`, reads a stale value; the correct nickname only arrives later via the async `info` reply — and the late-arriving `infoChanged` handler refreshed only the model + version labels, not the station label.

**Fix:** seed `m_nickname`/`m_callsign` from the discovery packet in `connectToRadio()`, and refresh the station label in the `infoChanged` handler alongside model/version.

### 2. DAX-TX stream not re-created on reconnect (digital/AX.25 TX goes out unmodulated)

**Symptom:** after a disconnect+reconnect, transmitting from the AetherModem AX.25 terminal produces a **bare carrier** — the radio keys but no modem audio modulates it. Re-opening the modem terminal restores it.

**Cause:** on disconnect `RadioModel` resets its own dax_tx state, but `AudioEngine::m_txStreamId` keeps the **old** stream id (it's never reset). The AX.25 TX path (`Ax25HfPacketDecodeDialog::beginTransmission`) only calls `ensureDaxTxStream()` when `txStreamId() == 0`, so on the new connection it sees the stale non-zero id, **skips the re-create**, and pumps VITA-49 modem audio to a dead stream id.

**Fix:** clear `m_txStreamId` on connection loss (right where `audioStopTx()` is already called in the disconnect path), so the next transmit re-creates the DAX-TX stream on the new connection. Scoped to the disconnect handler so it can't drop a still-valid stream mid-session.

## Verification (live, on real hardware)

Tested against a real IC-9700 bridged to AetherSDR as a Flex-6700 (via a gateway that presents the Flex protocol), reproducing both bugs before the fix and confirming both after:

- **Name label:** now correct on the **first** connect (was blank/previous-radio's-name).
- **DAX-TX / AX.25:** after a disconnect+reconnect, the client now re-sends `stream create type=dax_tx` on the next transmit and real modem audio flows — a clean AX.25 transmission on reconnect **without** re-opening the modem terminal (previously a bare carrier).

Built on `main` (Windows, Qt 6.10.3). Small, self-contained; no lifecycle refactor.