### PR TITLE
fix(gui): relabel the split badge from the slice role on every update (#4051)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -4352,10 +4352,14 @@ void VfoWidget::updateTxBadgeStyle(bool isTx)
 
 void VfoWidget::updateSplitBadge(bool isTxSlice, bool isRxSplit)
 {
+    // Relabel unconditionally from the slice's current role: the click handler
+    // dispatches on this text, so a stale "SWAP" after the split pair is torn
+    // down (or after roles flip via swap) would keep emitting swapRequested()
+    // and Split could never be re-enabled (#4051).
+    m_splitBadge->setText(isTxSlice ? "SWAP" : "SPLIT");
     if (isTxSlice) {
         // TX slice in split pair — show SWAP button
         m_splitBadge->show();
-        m_splitBadge->setText("SWAP");
         AetherSDR::ThemeManager::instance().applyStyleSheet(m_splitBadge, "QPushButton { background: {{color.background.1}}; color: #80c0ff; border: none; "
             "border-radius: 2px; font-size: 11px; font-weight: bold; "
             "padding: 0px 3px; }"


### PR DESCRIPTION
## Summary
The split/swap badge in the VFO flag is one `QPushButton` whose click handler dispatches on its **text** (`VfoWidget.cpp` ~687). `updateSplitBadge()` sets `"SWAP"` in its TX-slice branch — and that is the only `setText` after construction, so the text is one-way for the widget's lifetime. After the split pair is torn down, `MainWindow::updateSplitState()` correctly re-styles the badge to the ghosted idle look, but the stale `"SWAP"` text keeps every click emitting `swapRequested()` instead of `splitToggled()` — Split can never be re-enabled from the flag without reconnecting.

This change relabels the badge unconditionally from the slice's current role at the top of `updateSplitBadge()`: `isTxSlice ? "SWAP" : "SPLIT"`.

## Why
- Fixes the reported trap: Split → close VFO B → the flag still says SWAP and Split is unreachable (#4051).
- Also fixes a second, unreported symptom of the same root cause: after a **swap**, the slice that becomes the RX-split member keeps the stale `"SWAP"` text under the red RX-split style — mislabeled *and* misdispatching.
- The label now reconciles to the model state on every update, same as the styling already does.

## Scope
- 6 lines added, 1 removed, in `src/gui/VfoWidget.cpp` (`updateSplitBadge()`)
- No protocol / persistence change; no styling change (per-branch ThemeManager stylesheets untouched)

## Constitution principle honored
**Principle II — The Radio Is Authoritative On Live State.** The badge's dispatch text is client-remembered state; before this fix it could disagree with the radio's actual split state (no split pair active) and the widget kept trusting its remembered value. The fix re-derives the label from the reconciled model state on every `updateSplitState()` pass, so the UI mirrors the radio instead of its own history.

## Test plan
- [x] Local incremental `ninja -C build` clean on Linux (Nobara 43, Qt 6.10.3, gcc 15.2.1)
- [x] **Scripted A/B on a live FLEX-6700 (RX-only) via the Automation Bridge** — the same script (`assert SPLIT → click badge → assert SPLIT(rx)+SWAP(tx) → remove the created slice → assert SPLIT`) run against pre-fix `main` (`8c973d7b`) and this branch:

| Assert | pre-fix `8c973d7b` | this branch |
|---|---|---|
| mid-split: RX badge `SPLIT`, TX badge `SWAP` | ❌ both read `SWAP` | ✅ |
| after teardown: badge returns to `SPLIT` | ❌ stuck `SWAP` (#4051) | ✅ |

<details><summary>A/B transcript (badge text read from the live widget tree via <code>dumpTree</code>; slice teardown scoped to the slice the script itself created)</summary>

```
[base-6700] PASS badge reads SPLIT before split got 'SPLIT'
[base-6700] PASS split created a second slice slices=2
[base-6700] FAIL pair shows SPLIT(rx)+SWAP(tx) [(1, 'SWAP', ...), (2, 'SWAP', ...)]
[base-6700] PASS back to one slice slices=1
[base-6700] FAIL #4051: badge reads SPLIT after teardown (stale SWAP = bug) got 'SWAP'

[fix-6700]  PASS badge reads SPLIT before split got 'SPLIT'
[fix-6700]  PASS split created a second slice slices=2
[fix-6700]  PASS pair shows SPLIT(rx)+SWAP(tx) [(1, 'SPLIT', ...), (2, 'SWAP', ...)]
[fix-6700]  PASS back to one slice slices=1
[fix-6700]  PASS #4051: badge reads SPLIT after teardown (stale SWAP = bug) got 'SPLIT'
```
</details>

- [x] `grab_widget` PNGs captured at each step (before / mid-split / after) on both builds — the after-teardown pair shows ghosted `SWAP` (base) vs ghosted `SPLIT` (fix) on the same flag

Note on unit tests: `VfoWidget` compiles only into the `AetherSDR` executable target (`GUI_SOURCES`), not `aethercore`, so a standalone badge test would need to enumerate the widget's full GUI dependency closure as a new test target — disproportionate for a one-line relabel. The existing `vfo_flag_placement_test` deliberately covers only the class's static helpers for the same reason.

## Checklist
- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls (Principle V)
- [x] All meter UI uses MeterSmoother (Principle II conventions — no meter code touched)

Closes #4051

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)
