### PR TITLE
[ux] Fix RX applet frequency font scope on restart

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -569,7 +569,11 @@ void RxApplet::buildUI()
         });
         m_freqRow->addWidget(m_modeCombo);
 
-        m_freqStack = new QStackedWidget;
+        // Parent the stack explicitly before registering scoped styles.  Qt
+        // does not reparent widgets in nested layouts until layout activation,
+        // so an unparented stack makes its children resolve root theme tokens
+        // at startup and miss the applet/rx scope (#4159).
+        m_freqStack = new QStackedWidget(this);
         m_freqStack->setFixedHeight(34);
 
         m_freqLabel = new QLabel("0.000.000");


### PR DESCRIPTION
## Summary

- fix the RX applet frequency font reverting to the root theme token after restart
- preserve live Theme Editor behavior and the existing shared `font.family.freq` token
- keep the change local to the RX frequency widget hierarchy

Fixes #4159.

Related context: #3653 and #3688 fixed custom-theme serialization/loading, but the persisted scoped token still resolved incorrectly while the RX applet was being constructed.

## Root cause

`RxApplet` registered the frequency label and editor styles while their `QStackedWidget` had no parent. `ThemeManager` therefore walked an incomplete ancestor chain and resolved the root frequency token at startup. Qt reparented the stack later during nested-layout activation, but that ancestor-only parent change did not reach the already-registered children. A live theme edit reapplied every style after the tree was complete, which is why the saved font appeared to work until the next launch.

## Fix

Construct the frequency stack with `RxApplet` as its explicit parent before registering either child stylesheet. Both widgets can now resolve the `applet/rx` scope immediately; later layout placement remains unchanged.

## Validation

- clean RelWithDebInfo configure and full `cmake --build build -j8`: passed
- `theme_manager_test`: 1/1 passed
- `tools/check_a11y.py`: passed (8 existing warnings outside this diff)
- `tools/check_engine_boundary.py --strict`: passed, 0 blockers
- `git diff --check`: passed
- signed commit verified with the configured SSH signing key

## Automation bridge proof

The app was launched disconnected with auto-connect disabled. A proof-only Default Dark fixture set `applet/rx` frequency text to Courier New at 12 px, making scoped resolution unmistakable; the fixture was removed before the final build and commit.

Before the fix, startup rendered the root DSEG frequency font and selecting Default Dark again changed it to the scoped Courier font. After explicitly parenting the stack, the immediate-startup capture and same-theme-reapply capture were byte-for-byte identical (`SHA-256 449a45f21b1aed4f5014b90cf23a190cb0f3fb08ff1b51dd77884323f1fb5c0f`). No radio connection or transmit action occurred.

Before: persisted scoped font missed at startup.

![Before](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4159-assets/.pr-assets/4159-before.png)

After: scoped font is already active at startup and remains unchanged after live reapply.

![After](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4159-assets/.pr-assets/4159-after.png)

💻 Generated with Codex with architecture by @jensenpat

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
