### PR TITLE
feat(mcp): optional path argument on grab_widget

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -126,7 +126,8 @@ contributors to self-verify UI changes before requesting review.
    - **Windows**: use `python` (or `py -3`) instead of `python3`.
 
 **Tools exposed** (22 typed tools): introspection — `bridge_status`,
-`dump_tree` (with a `filter` arg), `grab_widget` (PNG inline),
+`dump_tree` (with a `filter` arg), `grab_widget` (PNG inline; optional
+`path` for where the PNG is written, else a temp file),
 `get_state`, `get_log`, `floors`, `streams`; driving — `invoke`
 (on a target-not-found failure it appends `did_you_mean` candidates),
 `shortcut`, `tune`, `slice`, `pan`, `record`, `mark`, `window`, `menu`;

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -216,6 +216,10 @@ TOOLS = [
             "target": {"type": "string"},
             "selector": {"type": "string",
                          "description": "pan index, only for pan/pan-visible/pan-composite"},
+            "path": {"type": "string",
+                     "description": ("output PNG path; defaults to a temp file. The "
+                                     "returned JSON's `path` is authoritative — the app "
+                                     "may normalize it")},
         }, "required": ["target"]},
     },
     {
@@ -579,8 +583,9 @@ def handle_tool(name, args):
 
     if name == "grab_widget":
         target = args["target"]
-        out = os.path.join(tempfile.gettempdir(),
-                           f"aether-mcp-grab-{int(time.time())}.png")
+        out = (args.get("path")
+               or os.path.join(tempfile.gettempdir(),
+                               f"aether-mcp-grab-{int(time.time())}.png"))
         req = {"cmd": "grab", "target": target, "path": out}
         if args.get("selector"):
             req["selector"] = str(args["selector"])

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -15,6 +15,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import aether_mcp  # noqa: E402
@@ -82,6 +83,14 @@ def test_field_mapping():
     r = reqs[0]
     check("grab_widget sends cmd=grab + target",
           r.get("cmd") == "grab" and r.get("target") == "SpectrumWidget", str(r))
+    check("grab_widget default path lands in the temp dir",
+          r.get("path", "").startswith(tempfile.gettempdir()), str(r))
+
+    reqs = run_tool("grab_widget", {"target": "SpectrumWidget",
+                                    "path": "/tmp/shot.png"})
+    r = reqs[0]
+    check("grab_widget honors caller-supplied path (#4249)",
+          r.get("path") == "/tmp/shot.png", str(r))
 
     reqs = run_tool("dump_tree", {})
     check("dump_tree sends cmd=dumpTree", reqs[-1].get("cmd") == "dumpTree", str(reqs))


### PR DESCRIPTION

Adds the optional `path` property to the `grab_widget` MCP tool, wired through to the
raw `grab` verb's existing `[path]` argument, so callers can say where the PNG lands
instead of always getting `aether-mcp-grab-<epoch>.png` in the temp dir.

Implements the shape proposed in #4249's triage comment:

- **Schema** — optional `path` property on `grab_widget` (`tools/aether_mcp.py`),
  with a note that the returned JSON's `path` stays authoritative (the app may
  normalize the requested path).
- **Handler** — `out = args.get("path") or <temp default>`; the request dict, the
  `resp.get("path", out)` resolution, and the inline/too-large branches are unchanged.
- **Tests** — two new field-mapping cases in `tools/test_aether_mcp.py`: a
  caller-supplied path is emitted verbatim to the bridge, and the no-`path` default
  still lands under `tempfile.gettempdir()`.
- **Docs** — one line in `docs/automation-bridge.md`'s tool list.

**Verification (macOS, UI-only, no radio):**
- `python3 tools/test_aether_mcp.py` — all 36 checks pass (34 existing + 2 new).
- Live against AetherSDR 26.7.2 with `AETHER_AUTOMATION=1` +
  `AETHER_AUTOMATION_NO_AUTOCONNECT=1`: the same `grab_widget` call with a `path`
  wrote the PNG exactly there and returned it inline; without `path` it still landed
  as `aether-mcp-grab-<epoch>.png` in the temp dir. Returned JSON `path` matched the
  on-disk file in both cases — transcript below.

<details>
<summary>Verification transcript (paths sanitized: home → <code>~</code>, macOS per-user temp → <code>$TMPDIR</code>)</summary>

```
$ python3 tools/test_aether_mcp.py   (exit 0)
  ok   grab_widget sends cmd=grab + target
  ok   grab_widget default path lands in the temp dir
  ok   grab_widget honors caller-supplied path (#4249)
  ... all MCP field-mapping/protocol checks passed

grab_widget {"target": "MainWindow", "path": "~/Desktop/claude-code-work/screenshots/aethersdr-grab-4249-demo.png"}
  -> {"bytes": 572568, "class": "MainWindow", "height": 1527, "ok": true, "path": "~/Desktop/claude-code-work/screenshots/aethersdr-grab-4249-demo.png", "target": "MainWindow", "width": 2770}

grab_widget {"target": "MainWindow"}   (no path)
  -> {"bytes": 572272, "class": "MainWindow", "height": 1527, "ok": true, "path": "$TMPDIR/aether-mcp-grab-1784219529.png", "target": "MainWindow", "width": 2770}

$ ls -la <both>
-rw-r--r-- 1 user  staff 572568 Jul 16 09:32 ~/Desktop/claude-code-work/screenshots/aethersdr-grab-4249-demo.png
-rw-r--r-- 1 user  staff 572272 Jul 16 09:32 $TMPDIR/aether-mcp-grab-1784219529.png
```

</details>

Fixes #4249

— authored by agent (Claude Code) on behalf of @skerker

🤖 Generated with [Claude Code](https://claude.com/claude-code)
