### PR TITLE
[midi] Fix center-64 MIDI VFO tuning jumps (CTR2-Midi)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4128,6 +4128,12 @@ target_include_directories(midi_settings_test PRIVATE src)
 target_link_libraries(midi_settings_test PRIVATE Qt6::Core)
 add_test(NAME midi_settings_test COMMAND midi_settings_test)
 
+add_executable(midi_relative_cc_decoder_test
+    tests/midi_relative_cc_decoder_test.cpp
+)
+target_include_directories(midi_relative_cc_decoder_test PRIVATE src)
+add_test(NAME midi_relative_cc_decoder_test COMMAND midi_relative_cc_decoder_test)
+
 add_executable(transmit_model_test
     tests/transmit_model_test.cpp
     src/models/TransmitModel.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -274,6 +274,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`resize <w> <h> [target]`](#resize) | Resize a window (drives panadapter `x_pixels`). |
 | | [`window <state> [target]`](#window) | maximize / restore / minimize / fullscreen. |
 | | [`shortcut <id>`](#shortcut) | Fire a ShortcutManager/MIDI action by id (TX-guarded). |
+| | [`midi cc <0-127>`](#midi) | Inject a learned VFO Tune Knob CC event (RX-only). |
 | | [`scrollTo <target>`](#scrollto-alias-ensurevisible) | Scroll a widget into its scroll-area viewport. |
 | **State (`get`)** | [`get audio`](#get) | Audio-engine stream/buffer snapshot. |
 | | [`get dsp`](#get-dsp) | Client-side AetherDSP NR state (NR2…BNR). |
@@ -1487,6 +1488,21 @@ needs key **release** edges. The bridge replies with a distinct
 truth, no bridge-side id list to drift. RX-only actions (the zoom shortcuts
 included) need no flag.
 
+### `midi`
+Inject one MIDI Control Change value through the same learned VFO Tune Knob
+relative decoder used by physical controllers. This focused automation surface
+does not create or persist a binding and is RX-only.
+
+```json
+→ {"cmd":"midi","action":"cc","value":"65"}
+← {"ok":true,"midi":"cc","value":65,"paramId":"rx.tuneKnob","accepted":true}
+```
+
+Bare form: `midi cc 65`. Use `get slice active` before and after the injection
+to assert that center-64 values 65 and 63 move exactly one configured tuning
+step in opposite directions. The controller manager coalesces events for 20 ms,
+so callers should wait briefly before reading the resulting slice frequency.
+
 ### `pan`
 Panadapter lifecycle — create or tear down a pan regardless of how it was opened.
 
@@ -2387,7 +2403,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 51 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 52 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -2437,6 +2453,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `resize` | — | resize <w> <h> [target] — resize a window |
 | `window` | — | window <maximize\|restore\|minimize\|fullscreen> [target] |
 | `shortcut` | — | shortcut <id> — fire a ShortcutManager/MIDI action (TX-gated) |
+| `midi` | — | midi cc <0-127> — inject a learned VFO Tune Knob CC event |
 | `menu` | — | menu list \| open <name> — menu-bar menus |
 | `whoami` | — | bridge instance info: pid, socket, label, station, txAllowed |
 | `log` | — | log <categories\|get\|set\|reset\|tail\|subscribe\|unsubscribe> [args] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2887,6 +2887,12 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doShortcut(a.target.isEmpty() ? a.id : a.target);
             });
 
+        add("midi", {}, "midi cc <0-127> — inject a learned VFO Tune Knob CC event",
+            parseActionValue,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doMidi(a.action, a.value);
+            });
+
         add("menu", {}, "menu list | open <name> — menu-bar menus",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
@@ -6160,6 +6166,47 @@ QJsonObject AutomationServer::doShortcut(const QString& id) const
         {QStringLiteral("ok"), true},
         {QStringLiteral("shortcut"), id},
         {QStringLiteral("fired"), true},
+    };
+}
+
+QJsonObject AutomationServer::doMidi(const QString& action, const QString& value) const
+{
+    if (action.compare(QStringLiteral("cc"), Qt::CaseInsensitive) != 0) {
+        return err(QStringLiteral("midi requires 'cc <0-127>'"));
+    }
+
+    bool okValue = false;
+    const int ccValue = value.toInt(&okValue);
+    if (!okValue || ccValue < 0 || ccValue > 127) {
+        return err(QStringLiteral("midi cc value must be an integer from 0 to 127"));
+    }
+
+    QWidget* mw = primaryTopLevelWindow();
+    if (!mw) {
+        return err(QStringLiteral("no main window to dispatch MIDI CC"));
+    }
+
+    int result = -1;
+    const bool invoked = QMetaObject::invokeMethod(
+        mw, "injectMidiVfoCcForAutomation", Qt::DirectConnection,
+        Q_RETURN_ARG(int, result), Q_ARG(int, ccValue));
+    if (!invoked) {
+        return err(QStringLiteral("MIDI automation injection is unavailable"));
+    }
+    if (result == 1) {
+        return err(QStringLiteral("MIDI support is unavailable in this build"));
+    }
+    if (result != 0) {
+        return err(QStringLiteral("MIDI CC value was rejected"));
+    }
+
+    qCInfo(lcAutomation).noquote() << "MIDI VFO CC injected:" << ccValue;
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("midi"), QStringLiteral("cc")},
+        {QStringLiteral("value"), ccValue},
+        {QStringLiteral("paramId"), QStringLiteral("rx.tuneKnob")},
+        {QStringLiteral("accepted"), true},
     };
 }
 

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -568,6 +568,9 @@ private:
     // for actions with no key sequence and no menu entry (Band Zoom, Segment
     // Zoom, …). TX-keying ids stay behind AETHER_AUTOMATION_ALLOW_TX. (#4057)
     QJsonObject doShortcut(const QString& id) const;
+    // Inject a learned VFO Tune Knob MIDI CC value through the controller
+    // decoder. Automation-only, RX-only, and never persists a binding.
+    QJsonObject doMidi(const QString& action, const QString& value) const;
     // Resolve the top-level window a window-scoped verb (resize/window) acts on:
     // the target's window() if given, else the QMainWindow (or first visible real
     // top-level). Shared by doResize and doWindow.

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -204,13 +204,31 @@ void MidiControlManager::clearBindings()
 {
     m_bindings.clear();
     m_bindingIndex.clear();
+    m_relativeCcEncodings.clear();
 }
 
 void MidiControlManager::rebuildIndex()
 {
     m_bindingIndex.clear();
+    m_relativeCcEncodings.clear();
     for (int i = 0; i < m_bindings.size(); ++i)
         m_bindingIndex[m_bindings[i].key()] = i;
+}
+
+bool MidiControlManager::injectVfoCcForAutomation(int value)
+{
+    if (value < 0 || value > 127) {
+        return false;
+    }
+
+    MidiBinding binding;
+    binding.channel = 0;
+    binding.msgType = MidiBinding::CC;
+    binding.number = 0;
+    binding.paramId = QStringLiteral("rx.tuneKnob");
+    binding.relative = true;
+    dispatchRelativeCc(binding, value);
+    return true;
 }
 
 // ── MIDI Learn ──────────────────────────────────────────────────────────────
@@ -371,21 +389,13 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     //
-    // Explicit-relative bindings (user picked Relative in MIDI Learn) are
-    // assumed to use two's-complement encoding — that's what the relative
-    // flag has always meant, and overloading it with a binary-mode override
-    // for the VFO would silently flip CCW pulses (data2=127, two's-complement
-    // -1) to CW for users with existing two's-complement encoders bound to
-    // the VFO knob.  Binary-mode encoders (data2 ∈ {0, 127}) instead fall
-    // through to the backward-compat Tier 1 below, which handles them
-    // without requiring the relative flag.
+    // Learned VFO bindings auto-detect the two common encodings from the first
+    // directional value: 1/127 remains two's-complement, while the distinctive
+    // 63/65 pair selects center-64. Other relative parameters retain the
+    // established two's-complement behavior. Binary-mode encoders fall through
+    // to the backward-compat Tier 1 below when not explicitly marked relative.
     if (binding.relative && msgType == MidiBinding::CC) {
-        int delta = relativeCcDelta(data2);
-        if (binding.inverted) delta = -delta;
-
-        accumulateRelativeStep(binding.paramId, delta);
-
-        emit paramValueChanged(binding.paramId, delta > 0 ? 1.0f : 0.0f);
+        dispatchRelativeCc(binding, data2);
         return;
     }
 
@@ -466,6 +476,29 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
     }
 
     emit paramValueChanged(binding.paramId, value);
+}
+
+void MidiControlManager::dispatchRelativeCc(const MidiBinding& binding, int value)
+{
+    int delta = 0;
+    if (isVfoTuneKnobParamId(binding.paramId)) {
+        MidiRelativeCcEncoding& encoding = m_relativeCcEncodings[binding.key()];
+        const MidiRelativeCcDecodeResult result = decodeMidiRelativeCc(value, encoding);
+        encoding = result.encoding;
+        delta = result.delta;
+    } else {
+        delta = relativeCcDelta(value);
+    }
+
+    if (binding.inverted) {
+        delta = -delta;
+    }
+    if (delta == 0) {
+        return;
+    }
+
+    accumulateRelativeStep(binding.paramId, delta);
+    emit paramValueChanged(binding.paramId, delta > 0 ? 1.0f : 0.0f);
 }
 
 // ── Relative knob coalescing ───────────────────────────────────────────────

--- a/src/core/MidiControlManager.cpp
+++ b/src/core/MidiControlManager.cpp
@@ -210,9 +210,21 @@ void MidiControlManager::clearBindings()
 void MidiControlManager::rebuildIndex()
 {
     m_bindingIndex.clear();
-    m_relativeCcEncodings.clear();
     for (int i = 0; i < m_bindings.size(); ++i)
         m_bindingIndex[m_bindings[i].key()] = i;
+
+    // Preserve detected relative-CC encodings for bindings that still exist;
+    // only drop entries whose binding was removed. Clearing the whole map here
+    // would silently reset a working VFO lock on any unrelated Mapping-dialog
+    // edit (toggling Invert/Relative or deleting some other binding all call
+    // rebuildIndex()), re-opening the ambiguous-first-sample window far more
+    // often than the intended once-per-connect.
+    for (auto it = m_relativeCcEncodings.begin(); it != m_relativeCcEncodings.end();) {
+        if (!m_bindingIndex.contains(it.key()))
+            it = m_relativeCcEncodings.erase(it);
+        else
+            ++it;
+    }
 }
 
 bool MidiControlManager::injectVfoCcForAutomation(int value)
@@ -221,13 +233,20 @@ bool MidiControlManager::injectVfoCcForAutomation(int value)
         return false;
     }
 
-    MidiBinding binding;
-    binding.channel = 0;
-    binding.msgType = MidiBinding::CC;
-    binding.number = 0;
-    binding.paramId = QStringLiteral("rx.tuneKnob");
-    binding.relative = true;
-    dispatchRelativeCc(binding, value);
+    // Decode against a DEDICATED automation encoding, never the real binding
+    // map. Building a synthetic binding (channel 0 / CC 0) would share
+    // m_relativeCcEncodings[key()==0] with a real VFO knob learned on MIDI
+    // channel 1 / CC 0 and could permanently mis-lock that operator's
+    // controller. This path also mirrors dispatchRelativeCc's VFO branch
+    // (accumulate + direction pulse) without touching per-binding state.
+    const MidiRelativeCcDecodeResult result =
+        decodeMidiRelativeCc(value, m_automationCcEncoding);
+    m_automationCcEncoding = result.encoding;
+    if (result.delta != 0) {
+        accumulateRelativeStep(QStringLiteral("rx.tuneKnob"), result.delta);
+        emit paramValueChanged(QStringLiteral("rx.tuneKnob"),
+                               result.delta > 0 ? 1.0f : 0.0f);
+    }
     return true;
 }
 
@@ -389,11 +408,18 @@ void MidiControlManager::onMidiMessage(int status, int data1, int data2,
 
     // ── Relative knob mode: decode delta and accumulate ────────────────
     //
-    // Learned VFO bindings auto-detect the two common encodings from the first
-    // directional value: 1/127 remains two's-complement, while the distinctive
-    // 63/65 pair selects center-64. Other relative parameters retain the
-    // established two's-complement behavior. Binary-mode encoders fall through
-    // to the backward-compat Tier 1 below when not explicitly marked relative.
+    // Learned VFO bindings auto-detect the two common signed encodings from the
+    // first unit detent: 1/127 selects two's-complement, the distinctive 63/65
+    // pair selects center-64 (see decodeMidiRelativeCc). Other relative
+    // parameters retain the established two's-complement behavior.
+    //
+    // NOTE: MIDI Learn always marks a VFO CC binding relative (see startLearn),
+    // so the Tier-1/Tier-2 backward-compat paths below (guarded by
+    // !binding.relative) are reached only by legacy non-relative bindings, never
+    // by a freshly-learned one. A binary/Thetis (0/127) encoder learned on the
+    // VFO is therefore decoded here as two's-complement (127 → −1), NOT via
+    // Tier 1 — genuine binary support needs its own encoding, since 0/127 is
+    // ambiguous with two's-complement's own ±1 unit values (tracked in #4402).
     if (binding.relative && msgType == MidiBinding::CC) {
         dispatchRelativeCc(binding, data2);
         return;

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -11,6 +11,8 @@
 #include <memory>
 #include <RtMidi.h>
 
+#include "MidiRelativeCcDecoder.h"
+
 namespace AetherSDR {
 
 // ── Data types ──────────────────────────────────────────────────────────────
@@ -83,6 +85,10 @@ public:
     const QVector<MidiBinding>& bindings() const { return m_bindings; }
     void rebuildIndex();
 
+    // Automation-only injection point used by the agent bridge to exercise the
+    // same learned VFO-relative decoder without requiring physical MIDI input.
+    Q_INVOKABLE bool injectVfoCcForAutomation(int value);
+
     // MIDI Learn
     void startLearn(const QString& paramId);
     void cancelLearn();
@@ -123,6 +129,7 @@ private:
 
     QVector<MidiBinding> m_bindings;
     QHash<quint32, int>  m_bindingIndex; // binding key → index into m_bindings
+    QHash<quint32, MidiRelativeCcEncoding> m_relativeCcEncodings;
 
     bool    m_learning{false};
     QString m_learnParamId;
@@ -139,6 +146,7 @@ private:
     QTimer* m_relativeTimer{nullptr};
     void accumulateRelativeStep(const QString& paramId, int delta);
     void flushRelativeAccum();
+    void dispatchRelativeCc(const MidiBinding& binding, int value);
 };
 
 } // namespace AetherSDR

--- a/src/core/MidiControlManager.h
+++ b/src/core/MidiControlManager.h
@@ -130,6 +130,10 @@ private:
     QVector<MidiBinding> m_bindings;
     QHash<quint32, int>  m_bindingIndex; // binding key → index into m_bindings
     QHash<quint32, MidiRelativeCcEncoding> m_relativeCcEncodings;
+    // Encoding state for the automation-only injectVfoCcForAutomation() path,
+    // kept separate from m_relativeCcEncodings so a test injection can never
+    // collide with (and mis-lock) a real controller's binding key.
+    MidiRelativeCcEncoding m_automationCcEncoding{MidiRelativeCcEncoding::Undetermined};
 
     bool    m_learning{false};
     QString m_learnParamId;

--- a/src/core/MidiRelativeCcDecoder.h
+++ b/src/core/MidiRelativeCcDecoder.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace AetherSDR {
+
+enum class MidiRelativeCcEncoding {
+    Undetermined,
+    TwosComplement,
+    Center64,
+};
+
+struct MidiRelativeCcDecodeResult {
+    int delta{0};
+    MidiRelativeCcEncoding encoding{MidiRelativeCcEncoding::Undetermined};
+};
+
+// Relative MIDI CC has no encoding marker on the wire. Preserve the established
+// two's-complement 1/127 convention unless the first directional value is the
+// distinctive 63/65 pair used by center-64 controllers such as CTR2-MIDI.
+inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
+    int value, MidiRelativeCcEncoding currentEncoding)
+{
+    MidiRelativeCcEncoding encoding = currentEncoding;
+    if (encoding == MidiRelativeCcEncoding::Undetermined) {
+        if (value == 63 || value == 65) {
+            encoding = MidiRelativeCcEncoding::Center64;
+        } else if (value != 64) {
+            encoding = MidiRelativeCcEncoding::TwosComplement;
+        }
+    }
+
+    if (encoding == MidiRelativeCcEncoding::Center64) {
+        return {value - 64, encoding};
+    }
+    if (encoding == MidiRelativeCcEncoding::TwosComplement) {
+        return {(value < 64) ? value : (value - 128), encoding};
+    }
+    return {0, encoding};
+}
+
+} // namespace AetherSDR

--- a/src/core/MidiRelativeCcDecoder.h
+++ b/src/core/MidiRelativeCcDecoder.h
@@ -13,9 +13,15 @@ struct MidiRelativeCcDecodeResult {
     MidiRelativeCcEncoding encoding{MidiRelativeCcEncoding::Undetermined};
 };
 
-// Relative MIDI CC has no encoding marker on the wire. Preserve the established
-// two's-complement 1/127 convention unless the first directional value is the
-// distinctive 63/65 pair used by center-64 controllers such as CTR2-MIDI.
+// Relative MIDI CC has no encoding marker on the wire. The two encodings' unit
+// detents are disjoint — two's-complement sends 1 (CW) / 127 (CCW), center-64
+// sends 65 (CW) / 63 (CCW) — so a SINGLE-detent first value is an unambiguous
+// discriminator. Any other first value (e.g. a fast first turn landing on 70)
+// is ambiguous and must NOT commit an encoding: locking on it would, for a
+// center-64 controller whose first move isn't a unit detent, wrongly select
+// two's-complement and then decode every later 63/65 detent as ∓63 — the #4096
+// jumps, made permanent. Defer instead (delta 0, stay Undetermined) until a
+// unit detent settles the encoding.
 inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
     int value, MidiRelativeCcEncoding currentEncoding)
 {
@@ -23,8 +29,10 @@ inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
     if (encoding == MidiRelativeCcEncoding::Undetermined) {
         if (value == 63 || value == 65) {
             encoding = MidiRelativeCcEncoding::Center64;
-        } else if (value != 64) {
+        } else if (value == 1 || value == 127) {
             encoding = MidiRelativeCcEncoding::TwosComplement;
+        } else {
+            return {0, encoding};  // ambiguous first sample — stay Undetermined
         }
     }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -215,6 +215,10 @@ public:
     // actions registered keysTx (the caller decides policy; the registration
     // site declares the data). Returns a ShortcutFire* code.
     Q_INVOKABLE int fireShortcutAction(const QString& id, bool allowTx);
+    // Inject one learned VFO-knob CC value through MidiControlManager for
+    // automation proof. Returns 0 on acceptance, 1 if MIDI is unavailable,
+    // and 2 for an out-of-range MIDI value.
+    Q_INVOKABLE int injectMidiVfoCcForAutomation(int value);
     QJsonObject automationSetSliceReceiveSource(const QString& arg);
     QJsonObject automationSetCenterLock(int sliceId, bool enabled);
     QJsonObject automationTune(double mhz, int sliceId = -1);

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -1292,6 +1292,27 @@ void MainWindow::refreshStreamDeckLabels()
 }
 #endif
 
+int MainWindow::injectMidiVfoCcForAutomation(int value)
+{
+    if (value < 0 || value > 127) {
+        return 2;
+    }
+#ifdef HAVE_MIDI
+    if (!m_midiControl) {
+        return 1;
+    }
+
+    bool accepted = false;
+    const bool invoked = QMetaObject::invokeMethod(
+        m_midiControl, "injectVfoCcForAutomation", Qt::BlockingQueuedConnection,
+        Q_RETURN_ARG(bool, accepted), Q_ARG(int, value));
+    return invoked && accepted ? 0 : 1;
+#else
+    Q_UNUSED(value)
+    return 1;
+#endif
+}
+
 void MainWindow::applyFlexControlWheelAction(const QString& actionId, int steps)
 {
     if (steps == 0)

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -40,6 +40,7 @@
 
 #include <QColor>
 #include <QPainter>
+#include <QThread>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -1302,9 +1303,19 @@ int MainWindow::injectMidiVfoCcForAutomation(int value)
         return 1;
     }
 
+    // Only block-queue when m_midiControl is genuinely on another thread — a
+    // same-thread BlockingQueuedConnection deadlocks, and a dead/quitting
+    // ext-ctrl event loop would hang the GUI (same guard idiom as the audio
+    // snapshot verbs in AutomationServer). m_midiControl normally lives on
+    // m_extCtrlThread, but don't assume it.
+    QThread* mgrThread = m_midiControl->thread();
+    const Qt::ConnectionType conn =
+        (!mgrThread || mgrThread == QThread::currentThread())
+            ? Qt::DirectConnection
+            : Qt::BlockingQueuedConnection;
     bool accepted = false;
     const bool invoked = QMetaObject::invokeMethod(
-        m_midiControl, "injectVfoCcForAutomation", Qt::BlockingQueuedConnection,
+        m_midiControl, "injectVfoCcForAutomation", conn,
         Q_RETURN_ARG(bool, accepted), Q_ARG(int, value));
     return invoked && accepted ? 0 : 1;
 #else

--- a/tests/midi_relative_cc_decoder_test.cpp
+++ b/tests/midi_relative_cc_decoder_test.cpp
@@ -1,0 +1,49 @@
+#include "core/MidiRelativeCcDecoder.h"
+
+#include <iostream>
+
+using namespace AetherSDR;
+
+namespace {
+
+bool expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    return condition;
+}
+
+} // namespace
+
+int main()
+{
+    bool ok = true;
+
+    MidiRelativeCcEncoding encoding = MidiRelativeCcEncoding::Undetermined;
+    MidiRelativeCcDecodeResult result = decodeMidiRelativeCc(65, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 1, "CTR2 clockwise detent is one step");
+    ok &= expect(encoding == MidiRelativeCcEncoding::Center64,
+                 "CTR2 detent selects center-64 encoding");
+
+    result = decodeMidiRelativeCc(63, encoding);
+    ok &= expect(result.delta == -1, "CTR2 counter-clockwise detent is one step");
+
+    encoding = MidiRelativeCcEncoding::Undetermined;
+    result = decodeMidiRelativeCc(1, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 1, "two's-complement clockwise pulse is preserved");
+    ok &= expect(encoding == MidiRelativeCcEncoding::TwosComplement,
+                 "unit pulse selects two's-complement encoding");
+
+    result = decodeMidiRelativeCc(127, encoding);
+    ok &= expect(result.delta == -1,
+                 "two's-complement counter-clockwise pulse is preserved");
+
+    encoding = MidiRelativeCcEncoding::Undetermined;
+    result = decodeMidiRelativeCc(64, encoding);
+    ok &= expect(result.delta == 0, "center value is neutral before detection");
+    ok &= expect(result.encoding == MidiRelativeCcEncoding::Undetermined,
+                 "neutral value does not lock an encoding");
+
+    return ok ? 0 : 1;
+}

--- a/tests/midi_relative_cc_decoder_test.cpp
+++ b/tests/midi_relative_cc_decoder_test.cpp
@@ -45,5 +45,35 @@ int main()
     ok &= expect(result.encoding == MidiRelativeCcEncoding::Undetermined,
                  "neutral value does not lock an encoding");
 
+    // #4096 regression guard: an ambiguous FIRST value (a fast first turn that
+    // isn't a unit detent, e.g. 70) must NOT lock an encoding. Locking it as
+    // two's-complement would decode every later center-64 detent as ∓63.
+    encoding = MidiRelativeCcEncoding::Undetermined;
+    result = decodeMidiRelativeCc(70, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 0, "ambiguous first value yields no step");
+    ok &= expect(encoding == MidiRelativeCcEncoding::Undetermined,
+                 "ambiguous first value does not lock an encoding");
+    // The first real unit detent then settles it correctly (center-64), and
+    // subsequent detents decode as ±1 rather than the mis-locked ∓63.
+    result = decodeMidiRelativeCc(65, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 1 && encoding == MidiRelativeCcEncoding::Center64,
+                 "first real detent after ambiguity selects center-64 (+1)");
+    result = decodeMidiRelativeCc(63, encoding);
+    ok &= expect(result.delta == -1, "and the opposite detent is one step, not -63");
+
+    // A two's-complement controller is likewise unaffected: its unit pulse
+    // still locks two's-complement even after an ambiguous first sample.
+    encoding = MidiRelativeCcEncoding::Undetermined;
+    result = decodeMidiRelativeCc(10, encoding);   // ambiguous (fast first turn)
+    encoding = result.encoding;
+    ok &= expect(result.delta == 0 && encoding == MidiRelativeCcEncoding::Undetermined,
+                 "ambiguous first value defers for two's-complement too");
+    result = decodeMidiRelativeCc(1, encoding);
+    ok &= expect(result.delta == 1
+                 && result.encoding == MidiRelativeCcEncoding::TwosComplement,
+                 "unit pulse still selects two's-complement after ambiguity");
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- Detect center-64 relative MIDI CC encoding for learned VFO Tune Knob bindings, so CTR2-MIDI values `65` and `63` produce one clockwise/counter-clockwise step.
- Preserve the established two's-complement `1`/`127` behavior for existing relative encoders by locking the detected encoding per binding.
- Add a focused decoder regression test and an RX-only `midi cc` automation verb for repeatable controller-path proof.

## Root cause

MIDI Learn marks every VFO Control Change binding as relative. The explicit-relative path then unconditionally decoded values as two's complement, so CTR2-MIDI's center-64 detents (`65`/`63`) became `-63`/`+63`. The center-64 fallback added in #2994 was guarded by `!binding.relative`, making it unreachable for learned VFO bindings.

The reporter's follow-up log shows the exact signature: 14.300 MHz moved to 14.363 MHz and then 14.237 MHz in 63-step increments.

## Proof

Built the macOS app and drove the same learned VFO relative decoder through the agent automation bridge on a connected FLEX-8400M (firmware 4.2.18.41174), with the configured 100 Hz tuning step:

| Action | Active-slice frequency |
|---|---:|
| Before | 14.100000 MHz |
| `midi cc 65` | 14.100100 MHz |
| `midi cc 63` | 14.100000 MHz |

Both detents moved exactly one 100 Hz step in opposite directions, the starting frequency was restored, and the final radio snapshot reported `transmitting:false`.

![VFO at 14.100100 MHz after one CTR2 clockwise detent](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4096-assets/.pr-assets/4096-after.png)

## Tests

- `cmake --build build --target AetherSDR -j8`
- `midi_relative_cc_decoder_test`
- `midi_settings_test`
- `bridge_docs_check`
- `tools/check_engine_boundary.py --strict` (zero blocking findings)
- `tools/check_a11y.py` (existing warning-only findings)

Fixes #4096

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
