### PR TITLE
[memory] Keep Add Memory visible in short memory drawers

### DIFF
--- a/src/gui/MemoryBrowsePanel.cpp
+++ b/src/gui/MemoryBrowsePanel.cpp
@@ -72,10 +72,14 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
     root->addWidget(m_table, 1);
     m_table->hide();
 
-    // "MEM+" button anchored at the bottom of the panel — outside the
-    // scrolling table so it stays visible regardless of scroll position.
-    // Style matches the spectrum overlay menu buttons it replaces.
+    // Keep the list action at the top of the panel, immediately above the
+    // scrolling rows. The bottom of this fixed-height drawer can be clipped
+    // by short panadapters, but its top remains visible.
     m_addBtn = new QPushButton(QStringLiteral("Add Memory"), this);
+    m_addBtn->setObjectName(QStringLiteral("memoryAddButton"));
+    m_addBtn->setAccessibleName(QStringLiteral("Add Memory"));
+    m_addBtn->setAccessibleDescription(
+        QStringLiteral("Save the current slice on this panadapter as a memory."));
     m_addBtn->setFixedHeight(22);
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_addBtn, "QPushButton { background: rgba(20, 30, 45, 240); "
         "border: 1px solid rgba(255, 255, 255, 40); border-radius: 2px; "
@@ -83,7 +87,7 @@ MemoryBrowsePanel::MemoryBrowsePanel(QWidget* parent)
         "QPushButton:hover { background: rgba(0, 112, 192, 180); "
         "border: 1px solid {{color.accent.dim}}; }");
     m_addBtn->setToolTip("Save the current slice on this panadapter as a memory.");
-    root->addWidget(m_addBtn, 0);
+    root->insertWidget(0, m_addBtn, 0);
     connect(m_addBtn, &QPushButton::clicked, this,
             &MemoryBrowsePanel::quickAddRequested);
 

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -295,7 +295,7 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
         {"ANT",       1, nullptr},   // 3 — toggleAntPanel
         {"Display",   4, nullptr},   // 4 — toggleDisplayPanel
         {"Memory",    5, nullptr},   // 6 — toggleMemoryPanel
-        // MEM+ moved into MemoryBrowsePanel (bottom button — doesn't scroll).
+        // Add Memory lives at the top of MemoryBrowsePanel, outside the scrolling rows.
         {"DAX",       3, nullptr},   // 6 — toggleDaxPanel
     };
 


### PR DESCRIPTION
## Summary

- move Add Memory to the top of the Memory drawer so it remains reachable when a short panadapter clips the drawer
- keep the action immediately above the same scrollable memory list so it reads as the list's primary action
- give the action a stable automation object name and explicit accessibility description

## Root cause

MemoryBrowsePanel is a fixed 252 x 460 drawer. Add Memory was the final child below the stretchable table, so a short application window or constrained multi-slice view clipped the bottom of the drawer and hid the action. The bottom placement also left the action visually detached beneath the list.

The fix preserves the existing drawer size, memory ordering, scrollbar, recall behavior, and per-pan slice routing. It changes only the layout order: Add Memory is now layout index 0, directly followed by the scrollable list.

## Proof

The agent automation bridge reproduced the issue and verified the fix against the live radio at the reporter-style 679 x 494 window size. This was RX-only; no transmitter action was performed.

Before: the list is visible, but Add Memory is below the clipped window.

![Before: Add Memory clipped below the list](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-3871-assets/.pr-assets/3871-before.png)

After: Add Memory remains visible at the top and is grouped directly with the list.

![After: Add Memory visible above the list](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-3871-assets/.pr-assets/3871-after.png)

Two-slice proof: a temporary Slice B was added alongside Slice A; Add Memory remained visible at the same short height. Slice B was removed afterward and the bridge confirmed the radio returned to its original single-slice state.

![After with Slice A and Slice B](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-3871-assets/.pr-assets/3871-after-multislice.png)

Bridge assertions:

- resize requested and applied: 679 x 494
- Memory drawer opened through the production Memory button
- memoryAddButton resolved as a QPushButton with the expected Save the current slice tooltip
- before, after, and two-slice screenshots captured successfully
- all proof image URLs verified HTTP 200

## Testing

- cmake --build build -j8
- memory_recall_policy_test
- memory_field_values_test
- memory_csv_compat_test
- accessibility checker on both changed GUI files: 0 findings
- git diff --check

This placement follows the requested UX direction in #3871; the maintainer-review label remains appropriate for final visual approval.

Fixes #3871

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
