### PR TITLE
feat(spothub): column-visibility menu + shrinkable width (#4157)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -24,6 +24,8 @@
 #include <QSortFilterProxyModel>
 #include <QMenu>
 #include <QAction>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QSlider>
 #include <QColorDialog>
 #include <QFile>
@@ -2010,33 +2012,46 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     m_spotTable->horizontalHeader()->setSortIndicatorShown(false);
 
     // Column visibility (#4157): Time/Freq/DX Call stay always-on as the
-    // core columns; the rest can be hidden via a right-click header menu,
-    // with the hidden set persisted in AppSettings across dialog reopen.
-    static const struct { SpotTableModel::Column col; const char* key; } kToggleCols[] = {
-        { SpotTableModel::ColComment, "SpotListColVisible_Comment" },
-        { SpotTableModel::ColSpotter, "SpotListColVisible_Spotter" },
-        { SpotTableModel::ColBand,    "SpotListColVisible_Band"    },
-        { SpotTableModel::ColMode,    "SpotListColVisible_Mode"    },
-        { SpotTableModel::ColSource,  "SpotListColVisible_Source"  },
+    // core columns; the rest can be hidden via a right-click header menu.
+    // Persisted as one JSON object under a single AppSettings key, written
+    // atomically (whole object per toggle) — Constitution Principle V: a
+    // feature's config is one self-contained object, not scattered flat
+    // keys.
+    static const struct { SpotTableModel::Column col; const char* field; } kToggleCols[] = {
+        { SpotTableModel::ColComment, "comment" },
+        { SpotTableModel::ColSpotter, "spotter" },
+        { SpotTableModel::ColBand,    "band"    },
+        { SpotTableModel::ColMode,    "mode"    },
+        { SpotTableModel::ColSource,  "source"  },
     };
-    auto& colVisSettings = AppSettings::instance();
+    static const char* kColumnVisibilityKey = "SpotListColumnVisibility";
+
+    const QJsonObject savedVisibility = QJsonDocument::fromJson(
+        AppSettings::instance().value(kColumnVisibilityKey, "{}").toString().toUtf8()).object();
     for (const auto& tc : kToggleCols) {
-        bool visible = colVisSettings.value(tc.key, "True").toString() == "True";
+        bool visible = savedVisibility.value(tc.field).toBool(true);
         m_spotTable->setColumnHidden(tc.col, !visible);
     }
     m_spotTable->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_spotTable->horizontalHeader(), &QWidget::customContextMenuRequested, this,
             [this](const QPoint& pos) {
+        auto saveColumnVisibility = [this] {
+            QJsonObject obj;
+            for (const auto& tc : kToggleCols)
+                obj.insert(tc.field, !m_spotTable->isColumnHidden(tc.col));
+            auto& s = AppSettings::instance();
+            s.setValue(kColumnVisibilityKey,
+                       QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+            s.save();
+        };
         QMenu menu(this);
         for (const auto& tc : kToggleCols) {
             auto* action = menu.addAction(m_spotModel->headerData(tc.col, Qt::Horizontal, Qt::DisplayRole).toString());
             action->setCheckable(true);
             action->setChecked(!m_spotTable->isColumnHidden(tc.col));
-            connect(action, &QAction::toggled, this, [this, tc](bool on) {
+            connect(action, &QAction::toggled, this, [this, tc, saveColumnVisibility](bool on) {
                 m_spotTable->setColumnHidden(tc.col, !on);
-                auto& s = AppSettings::instance();
-                s.setValue(tc.key, on ? "True" : "False");
-                s.save();
+                saveColumnVisibility();
             });
         }
         menu.exec(m_spotTable->horizontalHeader()->mapToGlobal(pos));

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -22,6 +22,8 @@
 #include <QTableView>
 #include <QHeaderView>
 #include <QSortFilterProxyModel>
+#include <QMenu>
+#include <QAction>
 #include <QSlider>
 #include <QColorDialog>
 #include <QFile>
@@ -53,6 +55,71 @@ protected:
     }
 private:
     int m_resetValue{0};
+};
+
+// Left-to-right layout that wraps to a new row when it runs out of
+// horizontal space, rather than compressing children to illegibility
+// (#4157). Used for the Spot List band-filter checkboxes so the
+// checked state stays readable when SpotHub is narrow.
+class FlowLayout : public QLayout {
+public:
+    explicit FlowLayout(int margin, int hSpacing, int vSpacing)
+        : m_hSpace(hSpacing), m_vSpace(vSpacing) {
+        setContentsMargins(margin, margin, margin, margin);
+    }
+    ~FlowLayout() override {
+        while (QLayoutItem* item = takeAt(0))
+            delete item;
+    }
+
+    void addItem(QLayoutItem* item) override { m_items.append(item); }
+    Qt::Orientations expandingDirections() const override { return {}; }
+    bool hasHeightForWidth() const override { return true; }
+    int heightForWidth(int width) const override { return doLayout(QRect(0, 0, width, 0), true); }
+    int count() const override { return m_items.size(); }
+    QLayoutItem* itemAt(int index) const override { return m_items.value(index); }
+    QLayoutItem* takeAt(int index) override {
+        return (index >= 0 && index < m_items.size()) ? m_items.takeAt(index) : nullptr;
+    }
+    QSize sizeHint() const override { return minimumSize(); }
+    QSize minimumSize() const override {
+        QSize size;
+        for (QLayoutItem* item : m_items)
+            size = size.expandedTo(item->minimumSize());
+        const QMargins m = contentsMargins();
+        return size + QSize(m.left() + m.right(), m.top() + m.bottom());
+    }
+    void setGeometry(const QRect& rect) override {
+        QLayout::setGeometry(rect);
+        doLayout(rect, false);
+    }
+
+private:
+    int doLayout(const QRect& rect, bool testOnly) const {
+        const QMargins m = contentsMargins();
+        QRect effectiveRect = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom());
+        int x = effectiveRect.x();
+        int y = effectiveRect.y();
+        int lineHeight = 0;
+        for (QLayoutItem* item : m_items) {
+            int nextX = x + item->sizeHint().width() + m_hSpace;
+            if (nextX - m_hSpace > effectiveRect.right() && lineHeight > 0) {
+                x = effectiveRect.x();
+                y += lineHeight + m_vSpace;
+                nextX = x + item->sizeHint().width() + m_hSpace;
+                lineHeight = 0;
+            }
+            if (!testOnly)
+                item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+            x = nextX;
+            lineHeight = qMax(lineHeight, item->sizeHint().height());
+        }
+        return y + lineHeight - rect.y() + m.bottom();
+    }
+
+    QList<QLayoutItem*> m_items;
+    int m_hSpace;
+    int m_vSpace;
 };
 
 // Shared DSP-style toggle for every checkable button in SpotHub
@@ -274,7 +341,11 @@ DxClusterDialog::DxClusterDialog(DxClusterClient* clusterClient, DxClusterClient
       m_radioModel(radioModel), m_dxccProvider(dxccProvider)
 {
     theme::setContainer(this, QStringLiteral("dialog/dxCluster"));
-    setMinimumSize(680, 560);
+    // Width floor lowered from 680 (#4157) so SpotHub can be dragged down
+    // toward the Spot List tab's visible-column width once columns are
+    // hidden; the other tabs' own layouts still enforce their own wider
+    // minimums via Qt's normal layout-constraint sizing.
+    setMinimumSize(360, 560);
     resize(760, 640);
 
     // Capture source log paths up front so the per-tab Clear handlers (built
@@ -1857,9 +1928,9 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     auto* layout = new QVBoxLayout(page);
     layout->setSpacing(4);
 
-    // Band filter checkboxes
-    auto* filterRow = new QHBoxLayout;
-    filterRow->setSpacing(2);
+    // Band filter checkboxes: wraps to additional rows instead of being
+    // compressed unreadable when SpotHub is narrow (#4157).
+    auto* filterRow = new FlowLayout(0, 8, 4);
     auto* filterLabel = new QLabel("Bands:");
     AetherSDR::ThemeManager::instance().applyStyleSheet(filterLabel, "QLabel { color: {{color.text.label}}; font-size: 13px; }");
     filterRow->addWidget(filterLabel);
@@ -1891,7 +1962,7 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
             s.setValue(key, on ? "True" : "False");
             s.save();
         });
-        filterRow->addWidget(cb, 1);  // equal stretch across row
+        filterRow->addWidget(cb);
     }
     layout->addLayout(filterRow);
 
@@ -1937,6 +2008,39 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
 
     // No default sort — insertion order is newest-first
     m_spotTable->horizontalHeader()->setSortIndicatorShown(false);
+
+    // Column visibility (#4157): Time/Freq/DX Call stay always-on as the
+    // core columns; the rest can be hidden via a right-click header menu,
+    // with the hidden set persisted in AppSettings across dialog reopen.
+    static const struct { SpotTableModel::Column col; const char* key; } kToggleCols[] = {
+        { SpotTableModel::ColComment, "SpotListColVisible_Comment" },
+        { SpotTableModel::ColSpotter, "SpotListColVisible_Spotter" },
+        { SpotTableModel::ColBand,    "SpotListColVisible_Band"    },
+        { SpotTableModel::ColMode,    "SpotListColVisible_Mode"    },
+        { SpotTableModel::ColSource,  "SpotListColVisible_Source"  },
+    };
+    auto& colVisSettings = AppSettings::instance();
+    for (const auto& tc : kToggleCols) {
+        bool visible = colVisSettings.value(tc.key, "True").toString() == "True";
+        m_spotTable->setColumnHidden(tc.col, !visible);
+    }
+    m_spotTable->horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_spotTable->horizontalHeader(), &QWidget::customContextMenuRequested, this,
+            [this](const QPoint& pos) {
+        QMenu menu(this);
+        for (const auto& tc : kToggleCols) {
+            auto* action = menu.addAction(m_spotModel->headerData(tc.col, Qt::Horizontal, Qt::DisplayRole).toString());
+            action->setCheckable(true);
+            action->setChecked(!m_spotTable->isColumnHidden(tc.col));
+            connect(action, &QAction::toggled, this, [this, tc](bool on) {
+                m_spotTable->setColumnHidden(tc.col, !on);
+                auto& s = AppSettings::instance();
+                s.setValue(tc.key, on ? "True" : "False");
+                s.save();
+            });
+        }
+        menu.exec(m_spotTable->horizontalHeader()->mapToGlobal(pos));
+    });
 
     // Double-click to tune (#2298: also forward mode hints so the receiver
     // switches CW/SSB to match the spot rather than only changing frequency).

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -24,6 +24,7 @@
 #include <QSortFilterProxyModel>
 #include <QMenu>
 #include <QAction>
+#include <QMouseEvent>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QSlider>
@@ -122,6 +123,32 @@ private:
     QList<QLayoutItem*> m_items;
     int m_hSpace;
     int m_vSpace;
+};
+
+// Keeps a QMenu open while its checkable actions are toggled, so several
+// columns can be shown/hidden in one pass instead of reopening the header
+// menu per column (#4157). Installed on the menu for the duration of exec();
+// a left-release over a checkable action is toggled here and swallowed so the
+// menu doesn't dismiss. Non-checkable actions and clicks outside fall through
+// to the default close behavior.
+class KeepMenuOpenOnToggle : public QObject {
+public:
+    using QObject::QObject;
+    bool eventFilter(QObject* watched, QEvent* event) override {
+        if (event->type() == QEvent::MouseButtonRelease) {
+            auto* me = static_cast<QMouseEvent*>(event);
+            if (me->button() == Qt::LeftButton) {
+                if (auto* menu = qobject_cast<QMenu*>(watched)) {
+                    QAction* action = menu->actionAt(me->pos());
+                    if (action && action->isCheckable() && action->isEnabled()) {
+                        action->trigger();  // toggles + fires toggled()
+                        return true;        // swallow so the menu stays open
+                    }
+                }
+            }
+        }
+        return QObject::eventFilter(watched, event);
+    }
 };
 
 // Shared DSP-style toggle for every checkable button in SpotHub
@@ -2045,6 +2072,8 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
             s.save();
         };
         QMenu menu(this);
+        KeepMenuOpenOnToggle keepOpen;
+        menu.installEventFilter(&keepOpen);
         for (const auto& tc : kToggleCols) {
             auto* action = menu.addAction(m_spotModel->headerData(tc.col, Qt::Horizontal, Qt::DisplayRole).toString());
             action->setCheckable(true);


### PR DESCRIPTION
Closes #4157.

## What
- Right-click the Spot List column header for a checkable menu that
  hides/shows Comment, Spotter, Band, Mode, Source. Time, Freq, and
  DX Call stay always-on. Hidden state persists in AppSettings and
  restores on next SpotHub open.
- Dialog's `setMinimumSize` width floor lowered from 680 to 360, so
  the window can be dragged narrower once columns are hidden. The
  other tabs keep their own natural minimums via Qt's layout
  constraints — this only removes the hard-coded override.
- Band-filter checkboxes switched from an equal-stretch QHBoxLayout
  to a wrapping flow layout, so the checked/unchecked state stays
  legible at narrow widths instead of compressing illegibly.

## Test plan
- [x] Built and ran locally against a live DX cluster feed
- [x] Hid/showed each toggleable column via the header menu — table
      reflows correctly, last visible column absorbs the freed width
- [x] Closed and reopened SpotHub — hidden-column state persisted
- [x] Dialog drags narrower once columns are hidden
- [x] Band-filter checkboxes stay clearly readable at narrow widths