### PR TITLE
fix(gui): use canonical automation name in status chip

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -71,7 +71,9 @@ AETHER_AUTOMATION_SOCKET=aethersdr-4166 \
 GUI client UUID, so concurrent worktrees do not displace one another through
 the radio's duplicate-client takeover behavior. If it is omitted, the socket,
 automation label, or PID is used in that order. `AETHER_AUTOMATION_AGENT_NAME`
-sets the station label shown to other Multi-Flex clients; it is display-only
+sets the station label shown to other Multi-Flex clients; the legacy
+`AETHER_AUTOMATION_STATION` and then `AETHER_AUTOMATION_LABEL` are fallbacks,
+followed by the neutral default `Automation`. The agent name is display-only
 and is never used as the UUID because several worktrees may use the same LLM.
 Automation identities never overwrite the user's persistent `GUIClientID`.
 
@@ -1776,7 +1778,8 @@ its own per-pid socket + discovery entry).
 → {"cmd":"whoami"}
 ← {"ok":true,"pid":34758,"name":"aethersdr-automation-34758",
    "socket":"/var/folders/…/aethersdr-automation-34758",
-   "label":"","station":"Claude","txAllowed":false,"version":"26.6.5"}
+   "label":"","station":"Automation","agentName":"Automation",
+   "txAllowed":false,"version":"26.6.5"}
 ```
 
 `txAllowed` reports whether `AETHER_AUTOMATION_ALLOW_TX` is set for this process —

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -431,16 +431,10 @@ void AppSettings::initializeGuiClientIdentity()
         m_effectiveGuiClientId =
             GuiClientIdentityPolicy::automationClientId(m_automationIdentity);
         m_guiClientIdentityTransient = true;
-        m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_AGENT_NAME").trimmed();
-        if (m_automationAgentName.isEmpty()) {
-            m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_STATION").trimmed();
-        }
-        if (m_automationAgentName.isEmpty()) {
-            m_automationAgentName = qEnvironmentVariable("AETHER_AUTOMATION_LABEL").trimmed();
-        }
-        if (m_automationAgentName.isEmpty()) {
-            m_automationAgentName = QStringLiteral("Automation");
-        }
+        m_automationAgentName = GuiClientIdentityPolicy::automationAgentName(
+            qEnvironmentVariable("AETHER_AUTOMATION_AGENT_NAME"),
+            qEnvironmentVariable("AETHER_AUTOMATION_STATION"),
+            qEnvironmentVariable("AETHER_AUTOMATION_LABEL"));
         m_effectiveStationName =
             GuiClientIdentityPolicy::protocolSafeStation(m_automationAgentName);
         return;

--- a/src/core/GuiClientIdentityPolicy.h
+++ b/src/core/GuiClientIdentityPolicy.h
@@ -26,6 +26,28 @@ inline QString protocolSafeStation(QString value)
     return value;
 }
 
+inline QString automationAgentName(QString configuredName,
+                                   QString legacyStation,
+                                   QString label)
+{
+    configuredName = configuredName.trimmed();
+    if (!configuredName.isEmpty()) {
+        return configuredName;
+    }
+
+    legacyStation = legacyStation.trimmed();
+    if (!legacyStation.isEmpty()) {
+        return legacyStation;
+    }
+
+    label = label.trimmed();
+    if (!label.isEmpty()) {
+        return label;
+    }
+
+    return QStringLiteral("Automation");
+}
+
 inline bool shouldSelectDistinctId(bool transientIdentity,
                                    const QString& ourStation,
                                    const QString& otherStation,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4328,16 +4328,17 @@ void MainWindow::buildUI()
     };
 
     // Automation indicator chip — visible ONLY when the agent automation bridge
-    // is active (AETHER_AUTOMATION). Mirrors the per-client station name the
-    // bridge announces to the radio (AETHER_AUTOMATION_STATION, default
-    // "Claude") so the operator can see at a glance that an agent is driving.
+    // is active (AETHER_AUTOMATION). Uses the canonical AppSettings automation
+    // agent name so the chip and tooltip match the identity announced to the
+    // radio. Legacy environment names are resolved by AppSettings. (#3646)
     // Kept deliberately separate from the station-nickname label so it never
-    // fights radio status updates. (#3646)
+    // fights radio status updates.
     if (qEnvironmentVariableIsSet("AETHER_AUTOMATION")) {
-        const QString agent = qEnvironmentVariableIsSet("AETHER_AUTOMATION_STATION")
-            ? qEnvironmentVariable("AETHER_AUTOMATION_STATION")
-            : QStringLiteral("Claude");
+        const QString agent = AppSettings::instance().automationAgentName();
         m_automationChip = new QLabel(QStringLiteral("\U0001F916 ") + agent);
+        m_automationChip->setObjectName(QStringLiteral("automationChip"));
+        m_automationChip->setAccessibleName(
+            QStringLiteral("Agent automation bridge active: %1").arg(agent));
         m_automationChip->setStyleSheet(
             "QLabel { color: #0b0e12; background: #f0a000; font-weight: bold;"
             " font-size: 18px; border-radius: 4px; padding: 2px 10px; }");

--- a/tests/gui_client_identity_policy_test.cpp
+++ b/tests/gui_client_identity_policy_test.cpp
@@ -35,6 +35,23 @@ int main()
     check(GuiClientIdentityPolicy::protocolSafeStation(QString(80, 'x')).size() <= 48,
           "station name is bounded");
 
+    check(GuiClientIdentityPolicy::automationAgentName(
+              QStringLiteral(" Codex "), QStringLiteral("Legacy"), QStringLiteral("Label"))
+              == QStringLiteral("Codex"),
+          "explicit automation agent name wins and is trimmed");
+    check(GuiClientIdentityPolicy::automationAgentName(
+              QStringLiteral(" "), QStringLiteral(" Legacy "), QStringLiteral("Label"))
+              == QStringLiteral("Legacy"),
+          "legacy automation station remains compatible");
+    check(GuiClientIdentityPolicy::automationAgentName(
+              QString(), QStringLiteral(" "), QStringLiteral(" Bridge label "))
+              == QStringLiteral("Bridge label"),
+          "automation label is the final configured fallback");
+    check(GuiClientIdentityPolicy::automationAgentName(
+              QString(), QString(), QStringLiteral(" "))
+              == QStringLiteral("Automation"),
+          "automation agent name has a neutral default");
+
     check(!GuiClientIdentityPolicy::shouldSelectDistinctId(
               false, QStringLiteral("Desk"), QStringLiteral("desk"), true),
           "known same-station persistent predecessor is reclaimed");


### PR DESCRIPTION
## Summary

The bottom-left agent automation indicator had its own legacy-only name resolver: it read `AETHER_AUTOMATION_STATION` and otherwise hardcoded `Claude`. `AppSettings` already owns the canonical `AETHER_AUTOMATION_AGENT_NAME` -> legacy station -> label -> `Automation` precedence used by the radio-facing bridge identity, so the chip and tooltip could disagree with `whoami` and the station announced to MultiFlex peers.

This routes the chip text, tooltip, object identity, and accessible name through `AppSettings::automationAgentName()`, extracts the existing precedence into the focused identity policy test, and updates the bridge documentation's stale default. No radio setting or persistent user identity changes.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The precedence matrix is covered by a focused unit test, and the built UI was exercised through the agent automation bridge for the primary, legacy, and neutral-default cases.

## Test plan

- [x] Local build passes (`cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`; `cmake --build build --target AetherSDR -j8`)
- [x] Behavior verified on a real radio if applicable (not applicable: bridge runs used `AETHER_AUTOMATION_NO_AUTOCONNECT=1`; no radio command or TX path changed)
- [x] Existing tests pass (focused `gui_client_identity_policy_test`, `aether_mcp_field_mapping`, and `bridge_docs_check`)
- [x] Reproduction steps documented if user-reported bug (launch with `AETHER_AUTOMATION=1` and inspect `whoami`, `automationChip`, and its tooltip)

Additional validation:

- Agent automation bridge, explicit precedence: with agent name, legacy station, and label all set, `whoami.agentName`, `whoami.station`, chip value, accessible name, and tooltip all reported `Codex-Indicator-Proof`.
- Agent automation bridge, legacy compatibility: without the primary name, `whoami.agentName`, `whoami.station`, and the chip all reported `Legacy-Bridge-Proof`, ahead of the configured label.
- Agent automation bridge, neutral fallback: without any name variables, `whoami.agentName` and `whoami.station` reported `Automation`; the visible chip was `🤖 Automation` and its tooltip named `Automation`.
- Every bridge proof had autoconnect disabled and `txAllowed: false`.
- `python3 tools/gen_bridge_docs.py --check`
- `python3 tools/test_aether_mcp.py`
- `python3 tools/check_a11y.py src/gui/MainWindow.cpp` (0 findings)
- `python3 tools/check_engine_boundary.py --strict` (0 blocking findings; tracked legacy warnings only)
- `git diff --check`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter code changed)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
