### PR TITLE
[automation] Add cross-platform subsystem memory telemetry to the automation bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,7 @@ set(CORE_SOURCES
     src/core/AetherClockSettings.cpp
     src/core/PacketLossConcealment.cpp
     src/core/PerfTelemetry.cpp
+    src/core/MemoryTelemetry.cpp
     src/core/RigctlProtocol.cpp
     src/core/SmartCatProtocol.cpp
     src/core/SmartCatSession.cpp
@@ -3986,6 +3987,14 @@ if(UNIX)
 endif()
 set_target_properties(perf_telemetry_test PROPERTIES AUTOMOC ON)
 add_test(NAME perf_telemetry_test COMMAND perf_telemetry_test)
+
+add_executable(memory_telemetry_test
+    tests/memory_telemetry_test.cpp
+    src/core/MemoryTelemetry.cpp
+)
+target_include_directories(memory_telemetry_test PRIVATE src)
+target_link_libraries(memory_telemetry_test PRIVATE Qt6::Core)
+add_test(NAME memory_telemetry_test COMMAND memory_telemetry_test)
 
 add_executable(memory_recall_policy_test
     tests/memory_recall_policy_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1840,12 +1840,28 @@ counts are scoped diagnostics and are not additive.
 
 Use the companion driver for unattended runs; it writes the final report and
 raw series atomically, records the bridge identity, and warns when the process
-has the independent TX-automation rail armed (the soak itself is read-only):
+has the independent TX-automation rail armed (the soak never invokes TX):
 
 ```bash
 python3 tools/memory_soak.py --duration 300 --interval 5 \
   --output /tmp/aethersdr-memory-5m.json
 ```
+
+For a repeatable cross-band soak, the driver can also cycle the active slice
+and panadapter through RX frequencies. The first frequency is applied
+immediately, each change is marked in the bridge log, and the tune responses
+are retained in the output JSON alongside the memory series:
+
+```bash
+python3 tools/memory_soak.py --duration 3600 --interval 5 \
+  --tune-interval 600 \
+  --tune-frequencies 3.573,7.074,14.074,21.074,28.074,50.313 \
+  --output aethersdr-memory-1h.json
+```
+
+`tune` and `pan center` are RX/config-only bridge actions; this cycle never
+keys the transmitter. A refused VFO lock or pan-center request is printed as a
+failure and preserved in `tuneEvents` rather than being silently ignored.
 
 The MCP server exposes the same surface as `memory_profile`.
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1774,14 +1774,14 @@ the default Layer-A inventory and `radio`/`inventory` reads remain available;
 tally, while `resync`/`refresh` send the `sub pan all` subscription command to
 the radio.
 
-### `memory`
+### `memprofile`
 Cross-platform process and subsystem memory profiling for long-running leak
 investigations. An instant snapshot combines the operating system's native
 process counters with explicitly sized application buffers and lightweight
 QObject lifecycle inventories:
 
 ```json
-→ {"cmd":"memory","action":"snapshot"}
+→ {"cmd":"memprofile","action":"snapshot"}
 ← {"ok":true,"schemaVersion":1,
    "process":{"residentMetric":"physicalFootprint","residentBytes":412876800,
               "privateBytes":355205120,"allocatorInUseBytes":287309824,
@@ -1804,13 +1804,13 @@ they are not byte-for-byte comparable across operating systems.
 The sampler is bounded and off until explicitly started:
 
 ```text
-memory start 5000 10000   # sample every 5 s, retain at most 10,000 points
-memory status             # current snapshot + compact trend report
-memory sample             # force an extra point now
-memory report             # compact report, no raw points
-memory samples            # compact report + retained raw points
-memory stop               # final point + compact report
-memory reset              # stop and release the retained series
+memprofile start 5000 10000   # sample every 5 s, retain at most 10,000 points
+memprofile status             # current snapshot + compact trend report
+memprofile sample             # force an extra point now
+memprofile report             # compact report, no raw points
+memprofile samples            # compact report + retained raw points
+memprofile stop               # final point + compact report
+memprofile reset              # stop and release the retained series
 ```
 
 JSON requests use `action` and, for `start`, `value: "<intervalMs>
@@ -2536,7 +2536,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |
 | `dss` | — | dss <snapshot\|reset\|inject\|scrollback\|live> [pan] [args] |
 | `streams` | — | streams [radio\|inventory\|resync\|refresh\|reset] — stream diagnostics |
-| `memory` | — | memory <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |
+| `memprofile` | — | memprofile <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |
 | `tci` | — | tci start\|status\|stop — in-process TCI client simulator (JSON form only) |
 | `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1774,6 +1774,81 @@ the default Layer-A inventory and `radio`/`inventory` reads remain available;
 tally, while `resync`/`refresh` send the `sub pan all` subscription command to
 the radio.
 
+### `memory`
+Cross-platform process and subsystem memory profiling for long-running leak
+investigations. An instant snapshot combines the operating system's native
+process counters with explicitly sized application buffers and lightweight
+QObject lifecycle inventories:
+
+```json
+→ {"cmd":"memory","action":"snapshot"}
+← {"ok":true,"schemaVersion":1,
+   "process":{"residentMetric":"physicalFootprint","residentBytes":412876800,
+              "privateBytes":355205120,"allocatorInUseBytes":287309824,
+              "trackedSubsystemBytes":94781440,"unattributedResidentBytes":318095360},
+   "subsystems":{
+     "panadapter":{"trackedBytes":89128960,"estimatedGpuBytes":7549747,
+                   "objectCount":143,"classes":{"SpectrumWidget":1},"details":{"panCount":1}},
+     "audio":{"trackedBytes":65536,"objectCount":42},
+     "radioModels":{"trackedBytes":0,"objectCount":71},
+     "gui":{"trackedBytes":0,"objectCount":2610},
+     "automation":{"trackedBytes":5586944,"objectCount":12}}}
+```
+
+`residentMetric` deliberately follows the number operators see in the native
+task monitor: Working Set on Windows, physical footprint on macOS, and VmRSS on
+Linux. `privateBytes`, allocator counters, virtual size, thread count, and
+handle count appear where that OS exposes them. They are useful within one OS;
+they are not byte-for-byte comparable across operating systems.
+
+The sampler is bounded and off until explicitly started:
+
+```text
+memory start 5000 10000   # sample every 5 s, retain at most 10,000 points
+memory status             # current snapshot + compact trend report
+memory sample             # force an extra point now
+memory report             # compact report, no raw points
+memory samples            # compact report + retained raw points
+memory stop               # final point + compact report
+memory reset              # stop and release the retained series
+```
+
+JSON requests use `action` and, for `start`, `value: "<intervalMs>
+<maxSamples>"`. The interval is bounded to 250–3,600,000 ms and retention to
+2–10,000 samples so the profiler cannot become the leak. Five-second sampling
+holds about 13.8 hours; use 30–60 seconds for multi-day runs.
+
+Each byte/count trend reports `first`, `last`, `delta`, `min`, `max`, a linear
+per-hour slope, and `rSquared`. `sustainedGrowth` is a triage heuristic only: at
+least six samples over at least one minute, ≥4 MiB net byte growth, positive
+slope, and R² ≥0.5. `growthSuspects` collects metrics meeting that bar;
+`classCountGrowth` shows retained or released QObject classes by subsystem.
+Correlate the two:
+
+- rising `subsystem.panadapter.trackedBytes` identifies retained waterfall/3DSS
+  buffers;
+- a growing `SpectrumWidget`/panadapter class count identifies lifecycle leaks;
+- rising process resident/private bytes with flat tracked subsystems points to
+  an uninstrumented native, allocator, Qt, driver, or GPU allocation;
+- a positive slope with low R² is usually warm-up/cache/noise, not proof of a
+  leak. Extend the run and reproduce the same slope before fixing anything.
+
+Tracked subsystem bytes are deliberately honest lower bounds. They do not claim
+to attribute every heap allocation, and GPU surface estimates are excluded from
+resident attribution. GUI object counts include panadapter objects, so object
+counts are scoped diagnostics and are not additive.
+
+Use the companion driver for unattended runs; it writes the final report and
+raw series atomically, records the bridge identity, and warns when the process
+has the independent TX-automation rail armed (the soak itself is read-only):
+
+```bash
+python3 tools/memory_soak.py --duration 300 --interval 5 \
+  --output /tmp/aethersdr-memory-5m.json
+```
+
+The MCP server exposes the same surface as `memory_profile`.
+
 ### `txwaterfall`
 Toggle the radio's **show-TX-in-waterfall** display flag (`transmit set
 show_tx_in_waterfall`), which gates whether keyed-up TX renders FFT-derived rows
@@ -2403,7 +2478,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 52 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 53 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -2445,6 +2520,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `panmessage` | — | panmessage <add\|remove\|clear\|list> <pan> [id timeout [tone=…] title\|detail] |
 | `dss` | — | dss <snapshot\|reset\|inject\|scrollback\|live> [pan] [args] |
 | `streams` | — | streams [radio\|inventory\|resync\|refresh\|reset] — stream diagnostics |
+| `memory` | — | memory <snapshot\|start\|sample\|status\|report\|samples\|stop\|reset> [intervalMs maxSamples] |
 | `tci` | — | tci start\|status\|stop — in-process TCI client simulator (JSON form only) |
 | `audioCapture` | — | audioCapture <start\|stop\|status\|read\|probeNr2Stereo\|probeDspStereo> [args] |
 | `txwaterfall` | — | txwaterfall <on\|off> — show keyed TX in the waterfall |

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2514,6 +2514,8 @@ QJsonArray AudioEngine::audioEndpointDiagnostics() const
     rx["sample_format"] = rxRunning ? QStringLiteral("Float") : QString();
     rx["resampling_active"] = rxRunning ? QJsonValue(m_rxOutputRate.load() != DEFAULT_SAMPLE_RATE) : QJsonValue();
     rx["buffer_bytes"] = static_cast<double>(m_rxBufferBytes.load());
+    rx["buffer_capacity_bytes"] = rxRunning
+        ? static_cast<double>(m_audioSink->bufferSize()) : 0.0;
     rx["buffer_peak_bytes"] = static_cast<double>(m_rxBufferPeakBytes.load());
     rx["underrun_count"] = static_cast<double>(m_rxBufferUnderrunCount.load());
     QJsonObject presentation;

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -8456,18 +8456,25 @@ QJsonObject AutomationServer::memorySnapshot() const
             QStringLiteral("GUI includes panadapter objects, so subsystem object counts are scoped and non-additive"),
             QStringLiteral("estimatedGpuBytes is a lower-bound surface estimate and is excluded from resident attribution"),
             QStringLiteral("OS memory fields use platform-native accounting and are not byte-for-byte comparable across operating systems"),
+            QStringLiteral("each snapshot walks the live object tree on the calling (GUI) thread; prefer intervals of a few seconds for long soaks so the profiler's own work does not perturb the numbers it reports"),
+            QStringLiteral("report.classCountGrowth compares the first observed class census against the latest and spans the whole profiling session, even when older raw samples have aged out of the bounded ring (so its window can exceed report.durationMs)"),
         }},
     };
 }
 
-void AutomationServer::recordMemorySample()
+QJsonObject AutomationServer::recordMemorySample()
 {
     if (!m_memoryClock.isValid()) {
         m_memoryClock.start();
     }
     const qint64 elapsedMs = m_memoryClock.elapsed();
-    m_memorySeries.addSnapshot(elapsedMs, memorySnapshot());
+    // memorySnapshot() is heavy (full object-tree walk + cross-thread audio
+    // round-trips); build it once here and hand the same object back so callers
+    // that also want to return it don't take a second snapshot.
+    QJsonObject snapshot = memorySnapshot();
+    m_memorySeries.addSnapshot(elapsedMs, snapshot);
     m_memoryLastSampleMs = elapsedMs;
+    return snapshot;
 }
 
 QJsonObject AutomationServer::doMemory(const QString& action, const QString& value)
@@ -8533,8 +8540,7 @@ QJsonObject AutomationServer::doMemory(const QString& action, const QString& val
             m_memoryClock.start();
             m_memoryLastSampleMs = -1;
         }
-        recordMemorySample();
-        QJsonObject snapshot = memorySnapshot();
+        QJsonObject snapshot = recordMemorySample();
         snapshot[QStringLiteral("action")] = QStringLiteral("sample");
         snapshot[QStringLiteral("sampleCount")] = m_memorySeries.sampleCount();
         return snapshot;
@@ -8566,17 +8572,23 @@ QJsonObject AutomationServer::doMemory(const QString& action, const QString& val
         if (m_memoryTimer) {
             m_memoryTimer->stop();
         }
+        // Take a final sample if enough time has passed, and reuse it for the
+        // returned snapshot so `stop` never snapshots twice.
+        QJsonObject finalSnapshot;
+        bool haveSnapshot = false;
         if (m_memoryClock.isValid()
             && (m_memoryLastSampleMs < 0
                 || m_memoryClock.elapsed() - m_memoryLastSampleMs >= 100)) {
-            recordMemorySample();
+            finalSnapshot = recordMemorySample();
+            haveSnapshot = true;
         }
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("action"), QStringLiteral("stop")},
             {QStringLiteral("running"), false},
             {QStringLiteral("report"), m_memorySeries.report(false)},
-            {QStringLiteral("snapshot"), memorySnapshot()},
+            {QStringLiteral("snapshot"),
+             haveSnapshot ? finalSnapshot : memorySnapshot()},
         };
     }
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -14,6 +14,7 @@
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
 #include "models/AetherClockModel.h"  // AetherClockModel (get clock)
 #include "IConnectionAutomation.h" // gui-free connect/disconnect/dialog hook
+#include "MemoryTelemetry.h"
 
 #include <QAction>
 #include <QLocalServer>
@@ -49,10 +50,12 @@
 #include <QTimer>
 #include <QDateTime>
 #include <QTime>
+#include <QVariantMap>
 
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <utility>
 
 // Best-effort value extraction for common control types.
 #include <QAbstractButton>
@@ -731,6 +734,65 @@ QList<QWidget*> findWidgetsByClass(const QString& cls)
     for (QWidget* tlw : tops)
         collectByClass(tlw, cls, out);
     return out;
+}
+
+struct ObjectInventory {
+    int count{0};
+    QMap<QString, int> classes;
+};
+
+void collectObjectInventory(const QObject* object,
+                            QSet<const QObject*>& seen,
+                            ObjectInventory& inventory)
+{
+    if (!object || seen.contains(object)) {
+        return;
+    }
+    seen.insert(object);
+    ++inventory.count;
+    inventory.classes[QString::fromUtf8(object->metaObject()->className())]++;
+    for (const QObject* child : object->children()) {
+        collectObjectInventory(child, seen, inventory);
+    }
+}
+
+ObjectInventory inventoryFor(const QList<QObject*>& roots)
+{
+    ObjectInventory inventory;
+    QSet<const QObject*> seen;
+    for (const QObject* root : roots) {
+        collectObjectInventory(root, seen, inventory);
+    }
+    return inventory;
+}
+
+ObjectInventory inventoryForObjectThread(QObject* root)
+{
+    if (!root) {
+        return {};
+    }
+    QThread* owner = root->thread();
+    if (!owner || owner == QThread::currentThread() || !owner->isRunning()) {
+        return inventoryFor(QList<QObject*>{root});
+    }
+
+    ObjectInventory inventory;
+    const bool invoked = QMetaObject::invokeMethod(
+        root,
+        [root, &inventory]() {
+            inventory = inventoryFor(QList<QObject*>{root});
+        },
+        Qt::BlockingQueuedConnection);
+    return invoked ? inventory : ObjectInventory{};
+}
+
+QJsonObject inventoryClassesJson(const ObjectInventory& inventory)
+{
+    QJsonObject classes;
+    for (auto it = inventory.classes.constBegin(); it != inventory.classes.constEnd(); ++it) {
+        classes.insert(it.key(), it.value());
+    }
+    return classes;
 }
 
 // Map a UI pan index (SpectrumWidget::panIndex) to the radio stream panId by
@@ -2019,6 +2081,12 @@ void AutomationServer::stop()
         m_logDrain->deleteLater();
         m_logDrain = nullptr;
     }
+    if (m_memoryTimer) {
+        m_memoryTimer->stop();
+    }
+    m_memorySeries.clear();
+    m_memoryClock.invalidate();
+    m_memoryLastSampleMs = -1;
     m_logSubscribers.clear();
     for (const std::shared_ptr<ConnectWait>& wait : m_connectWaits) {
         if (!wait) {
@@ -2797,6 +2865,15 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             parseActionOnly,
             [](AutomationServer& s, A& a, QLocalSocket*) {
                 return s.doStreams(a.action);
+            });
+
+        add("memory", {},
+            "memory <snapshot|start|sample|status|report|samples|stop|reset> [intervalMs maxSamples]",
+            parseActionRest,
+            [](AutomationServer& s, A& a, QLocalSocket*) {
+                return s.doMemory(a.action.isEmpty() ? QStringLiteral("snapshot")
+                                                     : a.action,
+                                  a.value);
             });
 
         add("tci", {},
@@ -8198,6 +8275,327 @@ QJsonObject AutomationServer::doStreams(const QString& action)
         {QStringLiteral("orphanStreams"), orphans},
         {QStringLiteral("orphanCount"), orphans.size()},
     };
+}
+
+QJsonObject AutomationServer::memorySnapshot() const
+{
+    const ProcessMemorySnapshot processSnapshot = ProcessMemorySnapshot::capture();
+    QJsonObject process = processSnapshot.toJson();
+    QJsonObject subsystems;
+
+    // Panadapter display buffers are explicitly accounted by SpectrumWidget's
+    // existing render telemetry. GPU memory is a conservative lower-bound
+    // estimate for one RGBA color surface per pan; QRhi/backend staging and
+    // driver allocations remain in the deliberately-visible unattributed gap.
+    QList<QObject*> panRoots;
+    QJsonArray pans;
+    quint64 panTrackedBytes = 0;
+    quint64 panEstimatedGpuBytes = 0;
+    int visiblePanCount = 0;
+    QSet<QWidget*> seenPans;
+    const QList<QWidget*> spectrumWidgets =
+        findWidgetsByClass(QStringLiteral("SpectrumWidget"));
+    for (QWidget* widget : spectrumWidgets) {
+        if (!widget || seenPans.contains(widget)) {
+            continue;
+        }
+        seenPans.insert(widget);
+        panRoots.append(widget);
+
+        QVariantMap variant;
+        if (!QMetaObject::invokeMethod(widget, "panstatsSnapshot",
+                                       Qt::DirectConnection,
+                                       Q_RETURN_ARG(QVariantMap, variant),
+                                       Q_ARG(bool, false))) {
+            continue;
+        }
+        const QJsonObject pan = QJsonObject::fromVariantMap(variant);
+        pans.append(pan);
+        panTrackedBytes += static_cast<quint64>(
+            variant.value(QStringLiteral("waterfallAllocatedBytes")).toDouble());
+        panTrackedBytes += static_cast<quint64>(
+            variant.value(QStringLiteral("dssAllocatedBytes")).toDouble());
+        if (variant.value(QStringLiteral("visible")).toBool()) {
+            ++visiblePanCount;
+        }
+        const double dpr = variant.value(QStringLiteral("dpr")).toDouble();
+        const double width = variant.value(QStringLiteral("widthPx")).toDouble();
+        const double height = variant.value(QStringLiteral("heightPx")).toDouble();
+        if (dpr > 0.0 && width > 0.0 && height > 0.0) {
+            panEstimatedGpuBytes += static_cast<quint64>(
+                std::ceil(width * dpr) * std::ceil(height * dpr) * 4.0);
+        }
+    }
+    const ObjectInventory panObjects = inventoryFor(panRoots);
+    QJsonObject panDetails{
+        {QStringLiteral("panCount"), pans.size()},
+        {QStringLiteral("visiblePanCount"), visiblePanCount},
+        {QStringLiteral("pans"), pans},
+    };
+    if (m_radioModel && m_radioModel->panStream()) {
+        PanadapterStream* stream = m_radioModel->panStream();
+        panDetails[QStringLiteral("registeredPanStreams")] =
+            stream->registeredPanStreams().size();
+        panDetails[QStringLiteral("registeredWaterfallStreams")] =
+            stream->registeredWfStreams().size();
+        panDetails[QStringLiteral("orphanStreamCount")] =
+            stream->orphanStreams().size();
+        panDetails[QStringLiteral("kernelReceiveBufferBytes")] =
+            stream->grantedReceiveBufferBytes();
+    }
+    subsystems[QStringLiteral("panadapter")] = QJsonObject{
+        {QStringLiteral("trackedBytes"), static_cast<double>(panTrackedBytes)},
+        {QStringLiteral("estimatedGpuBytes"),
+         static_cast<double>(panEstimatedGpuBytes)},
+        {QStringLiteral("objectCount"), panObjects.count},
+        {QStringLiteral("classes"), inventoryClassesJson(panObjects)},
+        {QStringLiteral("details"), panDetails},
+    };
+
+    QList<QObject*> audioRoots;
+    QJsonArray audioEndpoints;
+    quint64 audioTrackedBytes = 0;
+    if (m_audioEngine) {
+        audioRoots.append(m_audioEngine);
+        audioEndpoints = m_audioEngine->audioEndpointDiagnostics();
+        for (const QJsonValue& value : audioEndpoints) {
+            const QJsonObject endpoint = value.toObject();
+            const double capacity = endpoint.value(
+                QStringLiteral("buffer_capacity_bytes")).toDouble(-1.0);
+            audioTrackedBytes += static_cast<quint64>(capacity >= 0.0
+                ? capacity
+                : endpoint.value(QStringLiteral("buffer_bytes")).toDouble(0.0));
+        }
+    }
+    const ObjectInventory audioObjects = audioRoots.isEmpty()
+        ? ObjectInventory{} : inventoryForObjectThread(audioRoots.constFirst());
+    subsystems[QStringLiteral("audio")] = QJsonObject{
+        {QStringLiteral("trackedBytes"), static_cast<double>(audioTrackedBytes)},
+        {QStringLiteral("objectCount"), audioObjects.count},
+        {QStringLiteral("classes"), inventoryClassesJson(audioObjects)},
+        {QStringLiteral("details"), QJsonObject{
+            {QStringLiteral("endpoints"), audioEndpoints},
+        }},
+    };
+
+    QList<QObject*> radioRoots;
+    if (m_radioModel) {
+        radioRoots.append(m_radioModel);
+    }
+    const ObjectInventory radioObjects = inventoryFor(radioRoots);
+    subsystems[QStringLiteral("radioModels")] = QJsonObject{
+        {QStringLiteral("trackedBytes"), 0.0},
+        {QStringLiteral("objectCount"), radioObjects.count},
+        {QStringLiteral("classes"), inventoryClassesJson(radioObjects)},
+    };
+
+    QList<QObject*> guiRoots;
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        guiRoots.append(widget);
+    }
+    const ObjectInventory guiObjects = inventoryFor(guiRoots);
+    subsystems[QStringLiteral("gui")] = QJsonObject{
+        {QStringLiteral("trackedBytes"), 0.0},
+        {QStringLiteral("objectCount"), guiObjects.count},
+        {QStringLiteral("classes"), inventoryClassesJson(guiObjects)},
+        {QStringLiteral("details"), QJsonObject{
+            {QStringLiteral("topLevelWidgetCount"), guiRoots.size()},
+        }},
+    };
+
+    quint64 automationTrackedBytes = m_memorySeries.estimatedStorageBytes();
+    int logRingEvents = 0;
+    {
+        QMutexLocker lock(&m_logMutex);
+        logRingEvents = static_cast<int>(m_logRing.size());
+        automationTrackedBytes += static_cast<quint64>(m_logRing.size())
+            * sizeof(LogEvent);
+        for (const LogEvent& event : m_logRing) {
+            automationTrackedBytes += static_cast<quint64>(
+                event.wall.capacity() + event.cat.capacity() + event.msg.capacity())
+                * sizeof(QChar);
+        }
+    }
+    for (auto it = m_buffers.constBegin(); it != m_buffers.constEnd(); ++it) {
+        automationTrackedBytes += static_cast<quint64>(it.value().capacity());
+    }
+    const ObjectInventory automationObjects =
+        inventoryFor(QList<QObject*>{const_cast<AutomationServer*>(this)});
+    subsystems[QStringLiteral("automation")] = QJsonObject{
+        {QStringLiteral("trackedBytes"), static_cast<double>(automationTrackedBytes)},
+        {QStringLiteral("objectCount"), automationObjects.count},
+        {QStringLiteral("classes"), inventoryClassesJson(automationObjects)},
+        {QStringLiteral("details"), QJsonObject{
+            {QStringLiteral("logRingEvents"), logRingEvents},
+            {QStringLiteral("clientBufferCount"), m_buffers.size()},
+            {QStringLiteral("profilerStorageBytesEstimate"),
+             static_cast<double>(m_memorySeries.estimatedStorageBytes())},
+        }},
+    };
+
+    quint64 trackedBytes = 0;
+    for (auto it = subsystems.constBegin(); it != subsystems.constEnd(); ++it) {
+        trackedBytes += static_cast<quint64>(
+            it.value().toObject().value(QStringLiteral("trackedBytes")).toDouble());
+    }
+    process[QStringLiteral("trackedSubsystemBytes")] = static_cast<double>(trackedBytes);
+    process[QStringLiteral("unattributedResidentBytes")] = static_cast<double>(
+        processSnapshot.residentBytes > trackedBytes
+            ? processSnapshot.residentBytes - trackedBytes : 0);
+
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("schemaVersion"), 1},
+        {QStringLiteral("timestampUtc"),
+         QDateTime::currentDateTimeUtc().toString(Qt::ISODateWithMs)},
+        {QStringLiteral("process"), process},
+        {QStringLiteral("subsystems"), subsystems},
+        {QStringLiteral("objectCountsOverlap"), true},
+        {QStringLiteral("limitations"), QJsonArray{
+            QStringLiteral("trackedBytes covers explicitly-sized buffers, not every allocation"),
+            QStringLiteral("GUI includes panadapter objects, so subsystem object counts are scoped and non-additive"),
+            QStringLiteral("estimatedGpuBytes is a lower-bound surface estimate and is excluded from resident attribution"),
+            QStringLiteral("OS memory fields use platform-native accounting and are not byte-for-byte comparable across operating systems"),
+        }},
+    };
+}
+
+void AutomationServer::recordMemorySample()
+{
+    if (!m_memoryClock.isValid()) {
+        m_memoryClock.start();
+    }
+    const qint64 elapsedMs = m_memoryClock.elapsed();
+    m_memorySeries.addSnapshot(elapsedMs, memorySnapshot());
+    m_memoryLastSampleMs = elapsedMs;
+}
+
+QJsonObject AutomationServer::doMemory(const QString& action, const QString& value)
+{
+    const QString normalized = action.trimmed().toLower();
+    if (normalized == QLatin1String("snapshot")) {
+        QJsonObject snapshot = memorySnapshot();
+        snapshot[QStringLiteral("action")] = QStringLiteral("snapshot");
+        snapshot[QStringLiteral("running")] = m_memoryTimer && m_memoryTimer->isActive();
+        return snapshot;
+    }
+
+    if (normalized == QLatin1String("start")) {
+        const QStringList parts = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        int intervalMs = 5000;
+        int maxSamples = 10000;
+        if (!parts.isEmpty()) {
+            bool ok = false;
+            intervalMs = parts.constFirst().toInt(&ok);
+            if (!ok || intervalMs < 250 || intervalMs > 3600000) {
+                return err(QStringLiteral(
+                    "memory start intervalMs must be 250..3600000"));
+            }
+        }
+        if (parts.size() >= 2) {
+            bool ok = false;
+            maxSamples = parts.at(1).toInt(&ok);
+            if (!ok || maxSamples < 2 || maxSamples > 10000) {
+                return err(QStringLiteral(
+                    "memory start maxSamples must be 2..10000"));
+            }
+        }
+        if (parts.size() > 2) {
+            return err(QStringLiteral(
+                "memory start accepts only intervalMs and maxSamples"));
+        }
+
+        if (!m_memoryTimer) {
+            m_memoryTimer = new QTimer(this);
+            connect(m_memoryTimer, &QTimer::timeout,
+                    this, &AutomationServer::recordMemorySample);
+        }
+        m_memoryTimer->stop();
+        m_memorySeries.clear();
+        m_memorySeries.setMaxSamples(maxSamples);
+        m_memoryClock.restart();
+        m_memoryLastSampleMs = -1;
+        recordMemorySample();
+        m_memoryTimer->start(intervalMs);
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("action"), QStringLiteral("start")},
+            {QStringLiteral("running"), true},
+            {QStringLiteral("intervalMs"), intervalMs},
+            {QStringLiteral("maxSamples"), maxSamples},
+            {QStringLiteral("report"), m_memorySeries.report(false)},
+        };
+    }
+
+    if (normalized == QLatin1String("sample")) {
+        if (!m_memoryClock.isValid()) {
+            m_memorySeries.clear();
+            m_memoryClock.start();
+            m_memoryLastSampleMs = -1;
+        }
+        recordMemorySample();
+        QJsonObject snapshot = memorySnapshot();
+        snapshot[QStringLiteral("action")] = QStringLiteral("sample");
+        snapshot[QStringLiteral("sampleCount")] = m_memorySeries.sampleCount();
+        return snapshot;
+    }
+
+    if (normalized == QLatin1String("status")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("action"), QStringLiteral("status")},
+            {QStringLiteral("running"), m_memoryTimer && m_memoryTimer->isActive()},
+            {QStringLiteral("intervalMs"), m_memoryTimer ? m_memoryTimer->interval() : 0},
+            {QStringLiteral("report"), m_memorySeries.report(false)},
+            {QStringLiteral("snapshot"), memorySnapshot()},
+        };
+    }
+
+    if (normalized == QLatin1String("report")
+        || normalized == QLatin1String("samples")) {
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("action"), normalized},
+            {QStringLiteral("running"), m_memoryTimer && m_memoryTimer->isActive()},
+            {QStringLiteral("report"),
+             m_memorySeries.report(normalized == QLatin1String("samples"))},
+        };
+    }
+
+    if (normalized == QLatin1String("stop")) {
+        if (m_memoryTimer) {
+            m_memoryTimer->stop();
+        }
+        if (m_memoryClock.isValid()
+            && (m_memoryLastSampleMs < 0
+                || m_memoryClock.elapsed() - m_memoryLastSampleMs >= 100)) {
+            recordMemorySample();
+        }
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("action"), QStringLiteral("stop")},
+            {QStringLiteral("running"), false},
+            {QStringLiteral("report"), m_memorySeries.report(false)},
+            {QStringLiteral("snapshot"), memorySnapshot()},
+        };
+    }
+
+    if (normalized == QLatin1String("reset")) {
+        if (m_memoryTimer) {
+            m_memoryTimer->stop();
+        }
+        m_memorySeries.clear();
+        m_memoryClock.invalidate();
+        m_memoryLastSampleMs = -1;
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("action"), QStringLiteral("reset")},
+            {QStringLiteral("running"), false},
+        };
+    }
+
+    return err(QStringLiteral(
+        "memory requires snapshot|start|sample|status|report|samples|stop|reset"));
 }
 
 QJsonObject AutomationServer::doAudioCapture(const QString& action,

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2867,13 +2867,13 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doStreams(a.action);
             });
 
-        add("memory", {},
-            "memory <snapshot|start|sample|status|report|samples|stop|reset> [intervalMs maxSamples]",
+        add("memprofile", {},
+            "memprofile <snapshot|start|sample|status|report|samples|stop|reset> [intervalMs maxSamples]",
             parseActionRest,
             [](AutomationServer& s, A& a, QLocalSocket*) {
-                return s.doMemory(a.action.isEmpty() ? QStringLiteral("snapshot")
-                                                     : a.action,
-                                  a.value);
+                return s.doMemoryProfile(a.action.isEmpty() ? QStringLiteral("snapshot")
+                                                            : a.action,
+                                         a.value);
             });
 
         add("tci", {},
@@ -8477,7 +8477,7 @@ QJsonObject AutomationServer::recordMemorySample()
     return snapshot;
 }
 
-QJsonObject AutomationServer::doMemory(const QString& action, const QString& value)
+QJsonObject AutomationServer::doMemoryProfile(const QString& action, const QString& value)
 {
     const QString normalized = action.trimmed().toLower();
     if (normalized == QLatin1String("snapshot")) {
@@ -8496,7 +8496,7 @@ QJsonObject AutomationServer::doMemory(const QString& action, const QString& val
             intervalMs = parts.constFirst().toInt(&ok);
             if (!ok || intervalMs < 250 || intervalMs > 3600000) {
                 return err(QStringLiteral(
-                    "memory start intervalMs must be 250..3600000"));
+                    "memprofile start intervalMs must be 250..3600000"));
             }
         }
         if (parts.size() >= 2) {
@@ -8504,12 +8504,12 @@ QJsonObject AutomationServer::doMemory(const QString& action, const QString& val
             maxSamples = parts.at(1).toInt(&ok);
             if (!ok || maxSamples < 2 || maxSamples > 10000) {
                 return err(QStringLiteral(
-                    "memory start maxSamples must be 2..10000"));
+                    "memprofile start maxSamples must be 2..10000"));
             }
         }
         if (parts.size() > 2) {
             return err(QStringLiteral(
-                "memory start accepts only intervalMs and maxSamples"));
+                "memprofile start accepts only intervalMs and maxSamples"));
         }
 
         if (!m_memoryTimer) {
@@ -8607,7 +8607,7 @@ QJsonObject AutomationServer::doMemory(const QString& action, const QString& val
     }
 
     return err(QStringLiteral(
-        "memory requires snapshot|start|sample|status|report|samples|stop|reset"));
+        "memprofile requires snapshot|start|sample|status|report|samples|stop|reset"));
 }
 
 QJsonObject AutomationServer::doAudioCapture(const QString& action,

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -20,6 +20,7 @@ class QWebSocket;
 #include <vector>
 
 #include "IConnectionAutomation.h"  // complete type: inline setter calls asQObject()
+#include "MemoryTelemetry.h"
 
 class QLocalServer;
 class QLocalSocket;
@@ -495,6 +496,12 @@ private:
     //                     waterfall the client view had already purged.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
+    // Cross-platform process + subsystem memory profiler. `start` samples on a
+    // bounded main-thread timer; `report`/`stop` return deltas, slopes, fit
+    // confidence, object-class growth, and raw samples on request.
+    QJsonObject doMemory(const QString& action, const QString& value);
+    QJsonObject memorySnapshot() const;
+    void recordMemorySample();
     QJsonObject doTci(const QString& action, const QString& value);
     QJsonObject doAudioCapture(const QString& action,
                                const QString& arg,
@@ -702,6 +709,11 @@ private:
         bool complete{false};
     };
     std::vector<std::shared_ptr<ConnectWait>> m_connectWaits;
+
+    QTimer* m_memoryTimer{nullptr};
+    QElapsedTimer m_memoryClock;
+    MemoryTelemetrySeries m_memorySeries;
+    qint64 m_memoryLastSampleMs{-1};
 };
 
 } // namespace AetherSDR

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -501,7 +501,9 @@ private:
     // confidence, object-class growth, and raw samples on request.
     QJsonObject doMemory(const QString& action, const QString& value);
     QJsonObject memorySnapshot() const;
-    void recordMemorySample();
+    // Takes one snapshot, appends it to the bounded series, and returns it so
+    // callers that also need to return the snapshot don't take a second one.
+    QJsonObject recordMemorySample();
     QJsonObject doTci(const QString& action, const QString& value);
     QJsonObject doAudioCapture(const QString& action,
                                const QString& arg,

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -496,10 +496,11 @@ private:
     //                     waterfall the client view had already purged.
     //   streams reset   — clear the Layer-A orphan tally to re-baseline.
     QJsonObject doStreams(const QString& action);
-    // Cross-platform process + subsystem memory profiler. `start` samples on a
-    // bounded main-thread timer; `report`/`stop` return deltas, slopes, fit
+    // Cross-platform process + subsystem memory profiler (the `memprofile`
+    // verb — distinct from the `memory` frequency-recall verb). `start` samples
+    // on a bounded main-thread timer; `report`/`stop` return deltas, slopes, fit
     // confidence, object-class growth, and raw samples on request.
-    QJsonObject doMemory(const QString& action, const QString& value);
+    QJsonObject doMemoryProfile(const QString& action, const QString& value);
     QJsonObject memorySnapshot() const;
     // Takes one snapshot, appends it to the bounded series, and returns it so
     // callers that also need to return the snapshot don't take a second one.

--- a/src/core/MemoryTelemetry.cpp
+++ b/src/core/MemoryTelemetry.cpp
@@ -113,7 +113,9 @@ ProcessMemorySnapshot ProcessMemorySnapshot::capture()
     snapshot.residentBytes = parseProcKilobytes(status.value("VmRSS"));
     snapshot.peakResidentBytes = parseProcKilobytes(status.value("VmHWM"));
     snapshot.virtualBytes = parseProcKilobytes(status.value("VmSize"));
-    snapshot.threadCount = status.value("Threads").toLongLong();
+    if (status.contains("Threads")) {
+        snapshot.threadCount = status.value("Threads").toLongLong();
+    }  // else leave the -1 "unknown" sentinel so toJson() omits it
     snapshot.valid = snapshot.residentBytes > 0;
     snapshot.residentMetric = QStringLiteral("vmRss");
 
@@ -292,7 +294,12 @@ QJsonObject MemoryTelemetrySeries::trend(const std::deque<Point>& points,
     const double first = values.constFirst().second;
     const double last = values.constLast().second;
     const double delta = last - first;
-    const double durationMs = points.back().elapsedMs - points.front().elapsedMs;
+    // Span of THIS metric's own samples (x is in hours), not the whole series —
+    // a subsystem metric that only appears partway through the run must have its
+    // sustainedGrowth duration gate measured over the range it was actually
+    // sampled, not the full point range.
+    const double durationMs =
+        (values.constLast().first - values.constFirst().first) * 3600000.0;
     const double growthThreshold = bytes ? 4.0 * 1024.0 * 1024.0 : 1.0;
     const bool sustainedGrowth = values.size() >= 6
         && durationMs >= 60000.0

--- a/src/core/MemoryTelemetry.cpp
+++ b/src/core/MemoryTelemetry.cpp
@@ -13,6 +13,9 @@
 #include <limits>
 
 #if defined(Q_OS_WIN)
+#ifndef NOMINMAX
+#define NOMINMAX  // Windows.h max macro breaks std::max/numeric_limits::max.
+#endif
 #include <windows.h>
 #include <psapi.h>
 #elif defined(Q_OS_MAC)

--- a/src/core/MemoryTelemetry.cpp
+++ b/src/core/MemoryTelemetry.cpp
@@ -1,0 +1,436 @@
+#include "MemoryTelemetry.h"
+
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonValue>
+#include <QSet>
+#include <QSysInfo>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#if defined(Q_OS_WIN)
+#include <windows.h>
+#include <psapi.h>
+#elif defined(Q_OS_MAC)
+#include <mach/mach.h>
+#include <mach/task.h>
+#include <mach/task_info.h>
+#include <malloc/malloc.h>
+#elif defined(Q_OS_LINUX)
+#if defined(__GLIBC__)
+#include <features.h>
+#include <malloc.h>
+#endif
+#endif
+
+namespace AetherSDR {
+
+namespace {
+
+double jsonNumber(const QJsonObject& object, const char* key)
+{
+    return object.value(QString::fromLatin1(key)).toDouble(0.0);
+}
+
+#if defined(Q_OS_LINUX)
+quint64 parseProcKilobytes(const QByteArray& value)
+{
+    const QList<QByteArray> fields = value.trimmed().split(' ');
+    return fields.isEmpty() ? 0 : fields.constFirst().toULongLong() * 1024ULL;
+}
+
+QMap<QByteArray, QByteArray> readProcKeyValues(const QString& path)
+{
+    QMap<QByteArray, QByteArray> values;
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return values;
+    }
+
+    QByteArray line;
+    while (!(line = file.readLine()).isEmpty()) {
+        const qsizetype colon = line.indexOf(':');
+        if (colon <= 0) {
+            continue;
+        }
+        values.insert(line.left(colon), line.mid(colon + 1).trimmed());
+    }
+    return values;
+}
+#endif
+
+} // namespace
+
+ProcessMemorySnapshot ProcessMemorySnapshot::capture()
+{
+    ProcessMemorySnapshot snapshot;
+    snapshot.platform = QSysInfo::productType();
+
+#if defined(Q_OS_WIN)
+    PROCESS_MEMORY_COUNTERS_EX counters{};
+    counters.cb = sizeof(counters);
+    if (GetProcessMemoryInfo(GetCurrentProcess(),
+                             reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&counters),
+                             sizeof(counters))) {
+        snapshot.valid = true;
+        snapshot.residentMetric = QStringLiteral("workingSet");
+        snapshot.residentBytes = static_cast<quint64>(counters.WorkingSetSize);
+        snapshot.peakResidentBytes = static_cast<quint64>(counters.PeakWorkingSetSize);
+        snapshot.privateBytes = static_cast<quint64>(counters.PrivateUsage);
+    }
+    DWORD handles = 0;
+    if (GetProcessHandleCount(GetCurrentProcess(), &handles)) {
+        snapshot.handleCount = static_cast<qint64>(handles);
+    }
+#elif defined(Q_OS_MAC)
+    task_vm_info_data_t info{};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    if (task_info(mach_task_self(), TASK_VM_INFO,
+                  reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS) {
+        snapshot.valid = true;
+        snapshot.residentMetric = QStringLiteral("physicalFootprint");
+        snapshot.residentBytes = static_cast<quint64>(info.phys_footprint);
+        snapshot.peakResidentBytes = static_cast<quint64>(info.resident_size_peak);
+        snapshot.virtualBytes = static_cast<quint64>(info.virtual_size);
+        snapshot.privateBytes = static_cast<quint64>(info.internal)
+            + static_cast<quint64>(info.compressed);
+    }
+
+    malloc_statistics_t statistics{};
+    malloc_zone_statistics(nullptr, &statistics);
+    snapshot.allocatorInUseBytes = static_cast<quint64>(statistics.size_in_use);
+    snapshot.allocatorReservedBytes = static_cast<quint64>(statistics.size_allocated);
+#elif defined(Q_OS_LINUX)
+    const QMap<QByteArray, QByteArray> status =
+        readProcKeyValues(QStringLiteral("/proc/self/status"));
+    snapshot.residentBytes = parseProcKilobytes(status.value("VmRSS"));
+    snapshot.peakResidentBytes = parseProcKilobytes(status.value("VmHWM"));
+    snapshot.virtualBytes = parseProcKilobytes(status.value("VmSize"));
+    snapshot.threadCount = status.value("Threads").toLongLong();
+    snapshot.valid = snapshot.residentBytes > 0;
+    snapshot.residentMetric = QStringLiteral("vmRss");
+
+    const QMap<QByteArray, QByteArray> rollup =
+        readProcKeyValues(QStringLiteral("/proc/self/smaps_rollup"));
+    snapshot.privateBytes = parseProcKilobytes(rollup.value("Private_Clean"))
+        + parseProcKilobytes(rollup.value("Private_Dirty"));
+
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 33)
+    const struct mallinfo2 allocator = mallinfo2();
+    snapshot.allocatorInUseBytes = static_cast<quint64>(allocator.uordblks)
+        + static_cast<quint64>(allocator.hblkhd);
+    snapshot.allocatorReservedBytes = static_cast<quint64>(allocator.arena)
+        + static_cast<quint64>(allocator.hblkhd);
+#endif
+#endif
+#else
+    snapshot.residentMetric = QStringLiteral("unsupported");
+#endif
+
+    return snapshot;
+}
+
+QJsonObject ProcessMemorySnapshot::toJson() const
+{
+    QJsonObject object{
+        {QStringLiteral("valid"), valid},
+        {QStringLiteral("platform"), platform},
+        {QStringLiteral("residentMetric"), residentMetric},
+        {QStringLiteral("residentBytes"), static_cast<double>(residentBytes)},
+        {QStringLiteral("peakResidentBytes"), static_cast<double>(peakResidentBytes)},
+        {QStringLiteral("privateBytes"), static_cast<double>(privateBytes)},
+        {QStringLiteral("virtualBytes"), static_cast<double>(virtualBytes)},
+        {QStringLiteral("allocatorInUseBytes"), static_cast<double>(allocatorInUseBytes)},
+        {QStringLiteral("allocatorReservedBytes"), static_cast<double>(allocatorReservedBytes)},
+    };
+    if (threadCount >= 0) {
+        object[QStringLiteral("threadCount")] = static_cast<double>(threadCount);
+    }
+    if (handleCount >= 0) {
+        object[QStringLiteral("handleCount")] = static_cast<double>(handleCount);
+    }
+    return object;
+}
+
+MemoryTelemetrySeries::MemoryTelemetrySeries(int maxSamples)
+{
+    setMaxSamples(maxSamples);
+}
+
+void MemoryTelemetrySeries::clear()
+{
+    m_points.clear();
+    m_firstClasses.clear();
+    m_lastClasses.clear();
+}
+
+void MemoryTelemetrySeries::setMaxSamples(int maxSamples)
+{
+    m_maxSamples = qBound(2, maxSamples, 10000);
+    while (static_cast<int>(m_points.size()) > m_maxSamples) {
+        m_points.pop_front();
+    }
+}
+
+QMap<QString, qint64> MemoryTelemetrySeries::jsonCountMap(const QJsonObject& object)
+{
+    QMap<QString, qint64> counts;
+    for (auto it = object.constBegin(); it != object.constEnd(); ++it) {
+        if (it.value().isDouble()) {
+            counts.insert(it.key(), static_cast<qint64>(it.value().toDouble()));
+        }
+    }
+    return counts;
+}
+
+void MemoryTelemetrySeries::addSnapshot(qint64 elapsedMs, const QJsonObject& snapshot)
+{
+    Point point;
+    point.elapsedMs = std::max<qint64>(0, elapsedMs);
+
+    const QJsonObject process = snapshot.value(QStringLiteral("process")).toObject();
+    for (const char* key : {"residentBytes", "peakResidentBytes", "privateBytes",
+                            "virtualBytes", "allocatorInUseBytes",
+                            "allocatorReservedBytes"}) {
+        point.byteMetrics.insert(QStringLiteral("process.") + QString::fromLatin1(key),
+                                 jsonNumber(process, key));
+    }
+    for (const char* key : {"threadCount", "handleCount"}) {
+        if (process.contains(QString::fromLatin1(key))) {
+            point.countMetrics.insert(QStringLiteral("process.") + QString::fromLatin1(key),
+                                      jsonNumber(process, key));
+        }
+    }
+
+    const QJsonObject subsystems = snapshot.value(QStringLiteral("subsystems")).toObject();
+    for (auto it = subsystems.constBegin(); it != subsystems.constEnd(); ++it) {
+        const QString prefix = QStringLiteral("subsystem.") + it.key() + QLatin1Char('.');
+        const QJsonObject subsystem = it.value().toObject();
+        for (const char* key : {"trackedBytes", "estimatedGpuBytes"}) {
+            if (subsystem.contains(QString::fromLatin1(key))) {
+                point.byteMetrics.insert(prefix + QString::fromLatin1(key),
+                                         jsonNumber(subsystem, key));
+            }
+        }
+        if (subsystem.contains(QStringLiteral("objectCount"))) {
+            point.countMetrics.insert(prefix + QStringLiteral("objectCount"),
+                                      jsonNumber(subsystem, "objectCount"));
+        }
+
+        const QMap<QString, qint64> classes =
+            jsonCountMap(subsystem.value(QStringLiteral("classes")).toObject());
+        if (!classes.isEmpty()) {
+            if (!m_firstClasses.contains(it.key())) {
+                m_firstClasses.insert(it.key(), classes);
+            }
+            m_lastClasses.insert(it.key(), classes);
+        }
+    }
+
+    if (m_points.empty()) {
+        m_points.push_back(std::move(point));
+        return;
+    }
+    if (static_cast<int>(m_points.size()) >= m_maxSamples) {
+        m_points.pop_front();
+    }
+    m_points.push_back(std::move(point));
+}
+
+QJsonObject MemoryTelemetrySeries::trend(const std::deque<Point>& points,
+                                         const QString& metric,
+                                         bool bytes)
+{
+    QVector<QPair<double, double>> values;
+    values.reserve(static_cast<qsizetype>(points.size()));
+    for (const Point& point : points) {
+        const QMap<QString, double>& metrics = bytes
+            ? point.byteMetrics : point.countMetrics;
+        const auto found = metrics.constFind(metric);
+        if (found != metrics.constEnd()) {
+            values.append({point.elapsedMs / 3600000.0, found.value()});
+        }
+    }
+    if (values.isEmpty()) {
+        return {};
+    }
+
+    double minValue = std::numeric_limits<double>::max();
+    double maxValue = std::numeric_limits<double>::lowest();
+    double sumX = 0.0;
+    double sumY = 0.0;
+    for (const auto& value : values) {
+        sumX += value.first;
+        sumY += value.second;
+        minValue = std::min(minValue, value.second);
+        maxValue = std::max(maxValue, value.second);
+    }
+    const double meanX = sumX / values.size();
+    const double meanY = sumY / values.size();
+    double covariance = 0.0;
+    double varianceX = 0.0;
+    double varianceY = 0.0;
+    for (const auto& value : values) {
+        const double dx = value.first - meanX;
+        const double dy = value.second - meanY;
+        covariance += dx * dy;
+        varianceX += dx * dx;
+        varianceY += dy * dy;
+    }
+    const double slopePerHour = varianceX > 0.0 ? covariance / varianceX : 0.0;
+    const double rSquared = varianceX > 0.0 && varianceY > 0.0
+        ? std::clamp((covariance * covariance) / (varianceX * varianceY), 0.0, 1.0)
+        : 0.0;
+    const double first = values.constFirst().second;
+    const double last = values.constLast().second;
+    const double delta = last - first;
+    const double durationMs = points.back().elapsedMs - points.front().elapsedMs;
+    const double growthThreshold = bytes ? 4.0 * 1024.0 * 1024.0 : 1.0;
+    const bool sustainedGrowth = values.size() >= 6
+        && durationMs >= 60000.0
+        && delta >= growthThreshold
+        && slopePerHour > 0.0
+        && rSquared >= 0.5;
+
+    return QJsonObject{
+        {QStringLiteral("samples"), values.size()},
+        {QStringLiteral("first"), first},
+        {QStringLiteral("last"), last},
+        {QStringLiteral("delta"), delta},
+        {QStringLiteral("min"), minValue},
+        {QStringLiteral("max"), maxValue},
+        {bytes ? QStringLiteral("slopeBytesPerHour")
+               : QStringLiteral("slopePerHour"), slopePerHour},
+        {QStringLiteral("rSquared"), rSquared},
+        {QStringLiteral("sustainedGrowth"), sustainedGrowth},
+    };
+}
+
+QJsonObject MemoryTelemetrySeries::classGrowth(
+    const QMap<QString, QMap<QString, qint64>>& first,
+    const QMap<QString, QMap<QString, qint64>>& last)
+{
+    QJsonObject result;
+    for (auto subsystem = last.constBegin(); subsystem != last.constEnd(); ++subsystem) {
+        const QMap<QString, qint64> baseline = first.value(subsystem.key());
+        QJsonObject growth;
+        for (auto klass = subsystem.value().constBegin();
+             klass != subsystem.value().constEnd(); ++klass) {
+            const qint64 delta = klass.value() - baseline.value(klass.key());
+            if (delta != 0) {
+                growth.insert(klass.key(), static_cast<double>(delta));
+            }
+        }
+        for (auto klass = baseline.constBegin(); klass != baseline.constEnd(); ++klass) {
+            if (!subsystem.value().contains(klass.key()) && klass.value() != 0) {
+                growth.insert(klass.key(), static_cast<double>(-klass.value()));
+            }
+        }
+        if (!growth.isEmpty()) {
+            result.insert(subsystem.key(), growth);
+        }
+    }
+    return result;
+}
+
+QJsonObject MemoryTelemetrySeries::pointToJson(const Point& point)
+{
+    QJsonObject bytes;
+    for (auto it = point.byteMetrics.constBegin(); it != point.byteMetrics.constEnd(); ++it) {
+        bytes.insert(it.key(), it.value());
+    }
+    QJsonObject counts;
+    for (auto it = point.countMetrics.constBegin(); it != point.countMetrics.constEnd(); ++it) {
+        counts.insert(it.key(), it.value());
+    }
+    return QJsonObject{
+        {QStringLiteral("elapsedMs"), static_cast<double>(point.elapsedMs)},
+        {QStringLiteral("bytes"), bytes},
+        {QStringLiteral("counts"), counts},
+    };
+}
+
+QJsonObject MemoryTelemetrySeries::report(bool includeSamples) const
+{
+    QJsonObject result{
+        {QStringLiteral("sampleCount"), sampleCount()},
+        {QStringLiteral("maxSamples"), m_maxSamples},
+        {QStringLiteral("storageBytesEstimate"),
+         static_cast<double>(estimatedStorageBytes())},
+    };
+    if (m_points.empty()) {
+        result[QStringLiteral("durationMs")] = 0;
+        return result;
+    }
+
+    result[QStringLiteral("durationMs")] =
+        static_cast<double>(m_points.back().elapsedMs - m_points.front().elapsedMs);
+    QSet<QString> byteNames;
+    QSet<QString> countNames;
+    for (const Point& point : m_points) {
+        for (auto it = point.byteMetrics.constBegin(); it != point.byteMetrics.constEnd(); ++it) {
+            byteNames.insert(it.key());
+        }
+        for (auto it = point.countMetrics.constBegin(); it != point.countMetrics.constEnd(); ++it) {
+            countNames.insert(it.key());
+        }
+    }
+
+    QJsonObject byteTrends;
+    for (const QString& name : byteNames) {
+        byteTrends.insert(name, trend(m_points, name, true));
+    }
+    QJsonObject countTrends;
+    for (const QString& name : countNames) {
+        countTrends.insert(name, trend(m_points, name, false));
+    }
+    result[QStringLiteral("byteTrends")] = byteTrends;
+    result[QStringLiteral("countTrends")] = countTrends;
+    result[QStringLiteral("classCountGrowth")] =
+        classGrowth(m_firstClasses, m_lastClasses);
+
+    QJsonArray suspects;
+    for (auto it = byteTrends.constBegin(); it != byteTrends.constEnd(); ++it) {
+        const QJsonObject metric = it.value().toObject();
+        if (metric.value(QStringLiteral("sustainedGrowth")).toBool()) {
+            suspects.append(QJsonObject{
+                {QStringLiteral("metric"), it.key()},
+                {QStringLiteral("deltaBytes"), metric.value(QStringLiteral("delta"))},
+                {QStringLiteral("slopeBytesPerHour"),
+                 metric.value(QStringLiteral("slopeBytesPerHour"))},
+                {QStringLiteral("rSquared"), metric.value(QStringLiteral("rSquared"))},
+            });
+        }
+    }
+    result[QStringLiteral("growthSuspects")] = suspects;
+
+    if (includeSamples) {
+        QJsonArray samples;
+        for (const Point& point : m_points) {
+            samples.append(pointToJson(point));
+        }
+        result[QStringLiteral("samples")] = samples;
+    }
+    return result;
+}
+
+quint64 MemoryTelemetrySeries::estimatedStorageBytes() const
+{
+    quint64 bytes = static_cast<quint64>(m_points.size()) * sizeof(Point);
+    for (const Point& point : m_points) {
+        bytes += static_cast<quint64>(point.byteMetrics.size()
+            + point.countMetrics.size()) * 96ULL;
+    }
+    for (auto subsystem = m_lastClasses.constBegin();
+         subsystem != m_lastClasses.constEnd(); ++subsystem) {
+        bytes += static_cast<quint64>(subsystem.value().size()) * 96ULL;
+    }
+    return bytes;
+}
+
+} // namespace AetherSDR

--- a/src/core/MemoryTelemetry.h
+++ b/src/core/MemoryTelemetry.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QMap>
+#include <QString>
+#include <QtGlobal>
+
+#include <deque>
+
+namespace AetherSDR {
+
+// Cross-platform, current-process memory counters. The resident metric follows
+// the number operators see in the native task monitor: Working Set on Windows,
+// physical footprint on macOS, and VmRSS on Linux. The other fields are
+// best-effort because the three kernels expose different accounting models.
+struct ProcessMemorySnapshot {
+    bool valid{false};
+    QString platform;
+    QString residentMetric;
+    quint64 residentBytes{0};
+    quint64 peakResidentBytes{0};
+    quint64 privateBytes{0};
+    quint64 virtualBytes{0};
+    quint64 allocatorInUseBytes{0};
+    quint64 allocatorReservedBytes{0};
+    qint64 threadCount{-1};
+    qint64 handleCount{-1};
+
+    static ProcessMemorySnapshot capture();
+    QJsonObject toJson() const;
+};
+
+// A compact, bounded time series used by the automation bridge's `memory`
+// profiler. It accepts the bridge snapshot schema instead of depending on GUI
+// classes, which keeps the trend math deterministic and independently testable.
+class MemoryTelemetrySeries final {
+public:
+    explicit MemoryTelemetrySeries(int maxSamples = 10000);
+
+    void clear();
+    void setMaxSamples(int maxSamples);
+    int maxSamples() const { return m_maxSamples; }
+    int sampleCount() const { return static_cast<int>(m_points.size()); }
+    bool isEmpty() const { return m_points.empty(); }
+
+    void addSnapshot(qint64 elapsedMs, const QJsonObject& snapshot);
+    QJsonObject report(bool includeSamples = false) const;
+    quint64 estimatedStorageBytes() const;
+
+private:
+    struct Point {
+        qint64 elapsedMs{0};
+        QMap<QString, double> byteMetrics;
+        QMap<QString, double> countMetrics;
+    };
+
+    static QJsonObject trend(const std::deque<Point>& points,
+                             const QString& metric,
+                             bool bytes);
+    static QJsonObject pointToJson(const Point& point);
+    static QMap<QString, qint64> jsonCountMap(const QJsonObject& object);
+    static QJsonObject classGrowth(
+        const QMap<QString, QMap<QString, qint64>>& first,
+        const QMap<QString, QMap<QString, qint64>>& last);
+
+    int m_maxSamples{10000};
+    std::deque<Point> m_points;
+    QMap<QString, QMap<QString, qint64>> m_firstClasses;
+    QMap<QString, QMap<QString, qint64>> m_lastClasses;
+};
+
+} // namespace AetherSDR

--- a/tests/memory_telemetry_test.cpp
+++ b/tests/memory_telemetry_test.cpp
@@ -110,6 +110,38 @@ void testBoundedRetention()
           report.value(QStringLiteral("durationMs")).toInt() == 2000);
 }
 
+void testLateMetricDurationGate()
+{
+    MemoryTelemetrySeries series;
+    constexpr double mebibyte = 1024.0 * 1024.0;
+    // Early samples with NO panadapter subsystem, spanning well over a minute.
+    for (int i = 0; i < 3; ++i) {
+        series.addSnapshot(i * 400000LL, QJsonObject{
+            {QStringLiteral("process"), QJsonObject{
+                {QStringLiteral("residentBytes"), 100.0 * mebibyte},
+            }},
+        });
+    }
+    // Six panadapter samples that appear only late and span 50s (< the 60s
+    // sustained-growth duration gate), but grow hard (steep slope, R^2 ~ 1).
+    const qint64 base = 1200000LL;
+    for (int i = 0; i < 6; ++i) {
+        series.addSnapshot(base + i * 10000LL,
+                           snapshot(100.0 * mebibyte,
+                                    (100.0 + i * 20.0) * mebibyte, 1 + i));
+    }
+    const QJsonObject trend = series.report(false)
+        .value(QStringLiteral("byteTrends")).toObject()
+        .value(QStringLiteral("subsystem.panadapter.trackedBytes")).toObject();
+    check("late-appearing metric collects its six samples",
+          trend.value(QStringLiteral("samples")).toInt() == 6);
+    // The metric's OWN span is 50s, so despite the steep growth it must not be
+    // flagged sustained — the duration gate uses the metric's span, not the
+    // full series range (which here is ~21 minutes).
+    check("late metric spanning under 60s is not flagged sustained",
+          !trend.value(QStringLiteral("sustainedGrowth")).toBool());
+}
+
 void testLiveProcessSnapshot()
 {
     const ProcessMemorySnapshot live = ProcessMemorySnapshot::capture();
@@ -128,6 +160,7 @@ int main(int argc, char** argv)
     testLinearGrowth();
     testFlatSeries();
     testBoundedRetention();
+    testLateMetricDurationGate();
     testLiveProcessSnapshot();
     return g_failures == 0 ? 0 : 1;
 }

--- a/tests/memory_telemetry_test.cpp
+++ b/tests/memory_telemetry_test.cpp
@@ -1,0 +1,133 @@
+#include "core/MemoryTelemetry.h"
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <cmath>
+#include <cstdio>
+
+using AetherSDR::MemoryTelemetrySeries;
+using AetherSDR::ProcessMemorySnapshot;
+
+namespace {
+
+int g_failures = 0;
+
+void check(const char* name, bool condition)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", name);
+    if (!condition) {
+        ++g_failures;
+    }
+}
+
+QJsonObject snapshot(double residentBytes, double panBytes, int spectrumWidgets)
+{
+    return QJsonObject{
+        {QStringLiteral("process"), QJsonObject{
+            {QStringLiteral("residentBytes"), residentBytes},
+            {QStringLiteral("peakResidentBytes"), residentBytes},
+            {QStringLiteral("privateBytes"), residentBytes * 0.8},
+            {QStringLiteral("virtualBytes"), residentBytes * 2.0},
+            {QStringLiteral("allocatorInUseBytes"), residentBytes * 0.5},
+            {QStringLiteral("allocatorReservedBytes"), residentBytes * 0.6},
+            {QStringLiteral("threadCount"), 10},
+        }},
+        {QStringLiteral("subsystems"), QJsonObject{
+            {QStringLiteral("panadapter"), QJsonObject{
+                {QStringLiteral("trackedBytes"), panBytes},
+                {QStringLiteral("estimatedGpuBytes"), panBytes * 0.25},
+                {QStringLiteral("objectCount"), spectrumWidgets * 3},
+                {QStringLiteral("classes"), QJsonObject{
+                    {QStringLiteral("SpectrumWidget"), spectrumWidgets},
+                    {QStringLiteral("QTimer"), spectrumWidgets},
+                }},
+            }},
+        }},
+    };
+}
+
+void testLinearGrowth()
+{
+    MemoryTelemetrySeries series;
+    constexpr double mebibyte = 1024.0 * 1024.0;
+    for (int i = 0; i < 6; ++i) {
+        series.addSnapshot(i * 60000LL,
+                           snapshot((100.0 + i * 5.0) * mebibyte,
+                                    (20.0 + i * 2.0) * mebibyte,
+                                    1 + i));
+    }
+
+    const QJsonObject report = series.report(false);
+    const QJsonObject trend = report.value(QStringLiteral("byteTrends"))
+        .toObject().value(QStringLiteral("process.residentBytes")).toObject();
+    check("linear series retains all samples", series.sampleCount() == 6);
+    check("linear resident growth is flagged",
+          trend.value(QStringLiteral("sustainedGrowth")).toBool());
+    check("linear fit has R squared near one",
+          trend.value(QStringLiteral("rSquared")).toDouble() > 0.999);
+    check("resident slope is 300 MiB/hour",
+          std::abs(trend.value(QStringLiteral("slopeBytesPerHour")).toDouble()
+                   - 300.0 * mebibyte) < 1.0);
+
+    const QJsonObject classGrowth = report.value(QStringLiteral("classCountGrowth"))
+        .toObject().value(QStringLiteral("panadapter")).toObject();
+    check("class growth reports five retained SpectrumWidgets",
+          classGrowth.value(QStringLiteral("SpectrumWidget")).toInt() == 5);
+    check("growth suspect includes process and subsystem metrics",
+          report.value(QStringLiteral("growthSuspects")).toArray().size() >= 2);
+}
+
+void testFlatSeries()
+{
+    MemoryTelemetrySeries series;
+    for (int i = 0; i < 8; ++i) {
+        series.addSnapshot(i * 60000LL, snapshot(100000000.0, 20000000.0, 1));
+    }
+    const QJsonObject report = series.report(false);
+    const QJsonObject resident = report.value(QStringLiteral("byteTrends"))
+        .toObject().value(QStringLiteral("process.residentBytes")).toObject();
+    check("flat resident series is not flagged",
+          !resident.value(QStringLiteral("sustainedGrowth")).toBool());
+    check("flat series has zero delta",
+          resident.value(QStringLiteral("delta")).toDouble() == 0.0);
+    check("flat class inventory has no growth entries",
+          report.value(QStringLiteral("classCountGrowth")).toObject().isEmpty());
+}
+
+void testBoundedRetention()
+{
+    MemoryTelemetrySeries series(3);
+    for (int i = 0; i < 5; ++i) {
+        series.addSnapshot(i * 1000LL, snapshot(1000.0 + i, 100.0, 1));
+    }
+    const QJsonObject report = series.report(true);
+    check("sample retention is bounded", series.sampleCount() == 3);
+    check("raw sample export matches retained count",
+          report.value(QStringLiteral("samples")).toArray().size() == 3);
+    check("retained series duration uses oldest retained point",
+          report.value(QStringLiteral("durationMs")).toInt() == 2000);
+}
+
+void testLiveProcessSnapshot()
+{
+    const ProcessMemorySnapshot live = ProcessMemorySnapshot::capture();
+    const QJsonObject json = live.toJson();
+    check("live process memory snapshot is valid", live.valid);
+    check("live resident memory is non-zero", live.residentBytes > 0);
+    check("live snapshot names its resident metric",
+          !json.value(QStringLiteral("residentMetric")).toString().isEmpty());
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    testLinearGrowth();
+    testFlatSeries();
+    testBoundedRetention();
+    testLiveProcessSnapshot();
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -429,6 +429,25 @@ TOOLS = [
         }},
     },
     {
+        "name": "memory_profile",
+        "description": (
+            "Cross-platform process and subsystem memory telemetry. snapshot "
+            "reads current OS/allocator totals and tracked panadapter, audio, "
+            "radio-model, GUI, and automation state. start samples on a bounded "
+            "timer; report/stop return deltas, bytes-per-hour slopes, fit "
+            "confidence, growth suspects, and QObject class-count growth. "
+            "samples includes the retained raw time series."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["snapshot", "start", "sample", "status",
+                                "report", "samples", "stop", "reset"]},
+            "interval_ms": {"type": "integer",
+                            "description": "start only; 250..3600000, default 5000"},
+            "max_samples": {"type": "integer",
+                            "description": "start only; 2..10000, default 10000"},
+        }, "required": ["action"]},
+    },
+    {
         "name": "wait_for",
         "description": (
             "Poll a model property until it equals `expected` or `timeout_s` "
@@ -752,6 +771,20 @@ def handle_tool(name, args):
         req = {"cmd": "streams"}
         if args.get("scope"):
             req["action"] = str(args["scope"])
+        return text_result(bridge_request(req))
+
+    if name == "memory_profile":
+        req = {"cmd": "memory", "action": args["action"]}
+        if args["action"] == "start":
+            values = []
+            if args.get("interval_ms") is not None:
+                values.append(str(int(args["interval_ms"])))
+            elif args.get("max_samples") is not None:
+                values.append("5000")
+            if args.get("max_samples") is not None:
+                values.append(str(int(args["max_samples"])))
+            if values:
+                req["value"] = " ".join(values)
         return text_result(bridge_request(req))
 
     if name == "assert_state":

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -774,7 +774,7 @@ def handle_tool(name, args):
         return text_result(bridge_request(req))
 
     if name == "memory_profile":
-        req = {"cmd": "memory", "action": args["action"]}
+        req = {"cmd": "memprofile", "action": args["action"]}
         if args["action"] == "start":
             values = []
             if args.get("interval_ms") is not None:

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -70,7 +70,6 @@ class Bridge:
     def __init__(self, sock_path):
         self.sock_path = sock_path
         self._buf = b""
-        self._token = os.environ.get("AETHER_MCP_TOKEN", "")
         if sys.platform == "win32":
             # Qt named pipe: \\.\pipe\<name>. Open like a file.
             self._pipe = open(rf"\\.\pipe\{os.path.basename(sock_path)}", "r+b", buffering=0)
@@ -81,10 +80,11 @@ class Bridge:
             self._pipe = None
 
     def request(self, obj, timeout_seconds=None):
-        request_obj = dict(obj)
-        if self._token and "token" not in request_obj:
-            request_obj["token"] = self._token
-        return self.request_line(json.dumps(request_obj), timeout_seconds)
+        request = dict(obj)
+        token = os.environ.get("AETHER_MCP_TOKEN")
+        if token and "token" not in request:
+            request["token"] = token
+        return self.request_line(json.dumps(request), timeout_seconds)
 
     def request_line(self, text, timeout_seconds=None):
         """Send one raw request line (JSON or bare positional) and return the
@@ -403,7 +403,7 @@ MAPPERS = {
         "waveform needs <start|stop|unregister|resync> [args]"),
     "pan": _map_action_value("pan needs <create|add|center|close|remove> [value]"),
     "streams": _map_action_value(),
-    "memory": _map_action_value(),
+    "memprofile": _map_action_value(),
     "layout": _map_action_value("layout needs <rearrange <id> | get>"),
     "record": _map_action_value(),
     "testtone": _map_action_value(),

--- a/tools/automation_probe.py
+++ b/tools/automation_probe.py
@@ -70,6 +70,7 @@ class Bridge:
     def __init__(self, sock_path):
         self.sock_path = sock_path
         self._buf = b""
+        self._token = os.environ.get("AETHER_MCP_TOKEN", "")
         if sys.platform == "win32":
             # Qt named pipe: \\.\pipe\<name>. Open like a file.
             self._pipe = open(rf"\\.\pipe\{os.path.basename(sock_path)}", "r+b", buffering=0)
@@ -80,11 +81,10 @@ class Bridge:
             self._pipe = None
 
     def request(self, obj, timeout_seconds=None):
-        request = dict(obj)
-        token = os.environ.get("AETHER_MCP_TOKEN")
-        if token and "token" not in request:
-            request["token"] = token
-        return self.request_line(json.dumps(request), timeout_seconds)
+        request_obj = dict(obj)
+        if self._token and "token" not in request_obj:
+            request_obj["token"] = self._token
+        return self.request_line(json.dumps(request_obj), timeout_seconds)
 
     def request_line(self, text, timeout_seconds=None):
         """Send one raw request line (JSON or bare positional) and return the
@@ -375,7 +375,16 @@ def _map_panmessage(rest):
     return req
 
 
+def _map_no_args(rest):
+    if rest:
+        sys.exit("error: this command takes no arguments")
+    return {}
+
+
 MAPPERS = {
+    "verbs": _map_no_args,
+    "whoami": _map_no_args,
+    "disconnect": _map_no_args,
     "grab": _map_grab,
     "invoke": _map_invoke,
     "get": _map_get,
@@ -393,6 +402,8 @@ MAPPERS = {
     "waveform": _map_action_value(
         "waveform needs <start|stop|unregister|resync> [args]"),
     "pan": _map_action_value("pan needs <create|add|center|close|remove> [value]"),
+    "streams": _map_action_value(),
+    "memory": _map_action_value(),
     "layout": _map_action_value("layout needs <rearrange <id> | get>"),
     "record": _map_action_value(),
     "testtone": _map_action_value(),

--- a/tools/memory_soak.py
+++ b/tools/memory_soak.py
@@ -54,6 +54,47 @@ def progress_line(status, remaining):
             f"remaining={max(0, int(remaining)):4d}s")
 
 
+def parse_frequencies(value):
+    if not value:
+        return []
+    frequencies = []
+    for token in value.split(","):
+        try:
+            frequency = float(token.strip())
+        except ValueError as error:
+            raise argparse.ArgumentTypeError(
+                f"invalid frequency '{token.strip()}'") from error
+        if not math.isfinite(frequency) or not 0.001 <= frequency <= 1300.0:
+            raise argparse.ArgumentTypeError(
+                f"frequency {token.strip()} must be 0.001 .. 1300 MHz")
+        frequencies.append(frequency)
+    if not frequencies:
+        raise argparse.ArgumentTypeError("frequency list must not be empty")
+    return frequencies
+
+
+def tune_for_soak(bridge, frequency, elapsed):
+    label = f"memory-soak tune {frequency:.6f} MHz"
+    marker = bridge.request({"cmd": "mark", "value": label})
+    tuned = bridge.request({"cmd": "tune", "value": f"{frequency:.6f}"})
+    centered = bridge.request({"cmd": "pan", "action": "center",
+                               "value": f"{frequency:.6f}"})
+    event = {
+        "elapsedSeconds": elapsed,
+        "frequencyMhz": frequency,
+        "marker": marker,
+        "tune": tuned,
+        "panCenter": centered,
+    }
+    ok = tuned.get("ok", False) and centered.get("ok", False)
+    print(f"frequency cycle: {frequency:.6f} MHz "
+          f"({'ok' if ok else 'FAILED'})", flush=True)
+    if not ok:
+        print(f"  tune={tuned} panCenter={centered}", file=sys.stderr,
+              flush=True)
+    return event
+
+
 def main():
     stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     parser = argparse.ArgumentParser(
@@ -65,6 +106,13 @@ def main():
     parser.add_argument("--progress", type=float, default=30.0,
                         help="progress print cadence in seconds (default 30)")
     parser.add_argument("--socket", help="override bridge socket / pipe")
+    parser.add_argument(
+        "--tune-frequencies", type=parse_frequencies, default=[],
+        metavar="MHZ[,MHZ...]",
+        help="cycle RX frequencies during the soak (first tune is immediate)")
+    parser.add_argument(
+        "--tune-interval", type=float, default=600.0,
+        help="seconds between frequency changes (default 600)")
     parser.add_argument(
         "--output",
         default=os.path.join(tempfile.gettempdir(),
@@ -78,6 +126,8 @@ def main():
         parser.error("--interval must be 0.25 .. 3600 seconds")
     if not 1.0 <= args.progress <= 3600.0:
         parser.error("--progress must be 1 .. 3600 seconds")
+    if not 1.0 <= args.tune_interval <= 24 * 3600.0:
+        parser.error("--tune-interval must be 1 second .. 24 hours")
 
     interval_ms = int(round(args.interval * 1000.0))
     max_samples = int(math.ceil(args.duration / args.interval)) + 2
@@ -97,7 +147,7 @@ def main():
         sys.exit(f"error: bridge identity check failed: {bridge_info}")
     if bridge_info.get("txAllowed"):
         print("warning: this bridge reports TX automation enabled; "
-              "the memory soak remains read-only", file=sys.stderr)
+              "the memory soak never invokes TX", file=sys.stderr)
     started_wall = dt.datetime.now(dt.timezone.utc)
     started = bridge.request({"cmd": "memory", "action": "start",
                               "value": f"{interval_ms} {max_samples}"})
@@ -107,14 +157,30 @@ def main():
 
     print(f"memory soak: {args.duration:.0f}s at {args.interval:.2f}s "
           f"({max_samples} samples max)")
-    deadline = time.monotonic() + args.duration
-    next_progress = time.monotonic()
+    started_monotonic = time.monotonic()
+    deadline = started_monotonic + args.duration
+    next_progress = started_monotonic
+    next_tune = started_monotonic if args.tune_frequencies else math.inf
+    tune_index = 0
+    tune_events = []
+    if args.tune_frequencies:
+        rendered = ", ".join(f"{value:.6f}" for value in args.tune_frequencies)
+        print(f"frequency cycle: every {args.tune_interval:.0f}s across "
+              f"{rendered} MHz")
     interrupted = False
     try:
         while True:
             now = time.monotonic()
             if now >= deadline:
                 break
+            if now >= next_tune:
+                frequency = args.tune_frequencies[
+                    tune_index % len(args.tune_frequencies)]
+                tune_events.append(tune_for_soak(
+                    bridge, frequency, now - started_monotonic))
+                tune_index += 1
+                next_tune = started_monotonic + (
+                    tune_index * args.tune_interval)
             if now >= next_progress:
                 status = bridge.request({"cmd": "memory", "action": "status"})
                 print(progress_line(status, deadline - now), flush=True)
@@ -133,6 +199,9 @@ def main():
         "finishedUtc": dt.datetime.now(dt.timezone.utc).isoformat(),
         "requestedDurationSeconds": args.duration,
         "sampleIntervalMs": interval_ms,
+        "tuneIntervalSeconds": args.tune_interval,
+        "tuneFrequenciesMhz": args.tune_frequencies,
+        "tuneEvents": tune_events,
         "interrupted": interrupted,
         "bridge": bridge_info,
         "start": started,

--- a/tools/memory_soak.py
+++ b/tools/memory_soak.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Run a bounded AetherSDR automation-bridge memory soak.
+
+The app samples itself, so this driver can disconnect/reconnect without losing
+the in-process series. The final JSON is written atomically and includes both
+the compact trend report and retained raw points for plotting.
+"""
+
+import argparse
+import datetime as dt
+import json
+import math
+import os
+import sys
+import tempfile
+import time
+
+from automation_probe import Bridge, discover_socket
+
+
+def mib(value):
+    return float(value or 0.0) / (1024.0 * 1024.0)
+
+
+def atomic_write_json(path, payload):
+    path = os.path.abspath(path)
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=".aethersdr-memory-",
+                                     suffix=".json.tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def progress_line(status, remaining):
+    report = status.get("report", {})
+    snapshot = status.get("snapshot", {})
+    process = snapshot.get("process", {})
+    return (f"samples={report.get('sampleCount', 0):4d} "
+            f"rss={mib(process.get('residentBytes')):8.1f} MiB "
+            f"private={mib(process.get('privateBytes')):8.1f} MiB "
+            f"remaining={max(0, int(remaining)):4d}s")
+
+
+def main():
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    parser = argparse.ArgumentParser(
+        description="Profile AetherSDR memory through the automation bridge")
+    parser.add_argument("--duration", type=float, default=300.0,
+                        help="soak duration in seconds (default 300)")
+    parser.add_argument("--interval", type=float, default=5.0,
+                        help="in-app sample interval in seconds (default 5)")
+    parser.add_argument("--progress", type=float, default=30.0,
+                        help="progress print cadence in seconds (default 30)")
+    parser.add_argument("--socket", help="override bridge socket / pipe")
+    parser.add_argument(
+        "--output",
+        default=os.path.join(tempfile.gettempdir(),
+                             f"aethersdr-memory-{stamp}.json"),
+        help="final JSON path (default: platform temp directory)")
+    args = parser.parse_args()
+
+    if not 1.0 <= args.duration <= 7 * 24 * 3600:
+        parser.error("--duration must be 1 second .. 7 days")
+    if not 0.25 <= args.interval <= 3600.0:
+        parser.error("--interval must be 0.25 .. 3600 seconds")
+    if not 1.0 <= args.progress <= 3600.0:
+        parser.error("--progress must be 1 .. 3600 seconds")
+
+    interval_ms = int(round(args.interval * 1000.0))
+    max_samples = int(math.ceil(args.duration / args.interval)) + 2
+    if max_samples > 10000:
+        parser.error("duration/interval needs more than 10000 samples; "
+                     "increase --interval")
+
+    socket_path = args.socket or discover_socket()
+    if not socket_path:
+        sys.exit("error: no automation bridge found; launch AetherSDR with "
+                 "AETHER_AUTOMATION=1 or pass --socket")
+
+    bridge = Bridge(socket_path)
+    bridge_info = bridge.request({"cmd": "whoami"})
+    if not bridge_info.get("ok"):
+        bridge.close()
+        sys.exit(f"error: bridge identity check failed: {bridge_info}")
+    if bridge_info.get("txAllowed"):
+        print("warning: this bridge reports TX automation enabled; "
+              "the memory soak remains read-only", file=sys.stderr)
+    started_wall = dt.datetime.now(dt.timezone.utc)
+    started = bridge.request({"cmd": "memory", "action": "start",
+                              "value": f"{interval_ms} {max_samples}"})
+    if not started.get("ok"):
+        bridge.close()
+        sys.exit(f"error: memory profiler refused start: {started}")
+
+    print(f"memory soak: {args.duration:.0f}s at {args.interval:.2f}s "
+          f"({max_samples} samples max)")
+    deadline = time.monotonic() + args.duration
+    next_progress = time.monotonic()
+    interrupted = False
+    try:
+        while True:
+            now = time.monotonic()
+            if now >= deadline:
+                break
+            if now >= next_progress:
+                status = bridge.request({"cmd": "memory", "action": "status"})
+                print(progress_line(status, deadline - now), flush=True)
+                next_progress = now + args.progress
+            time.sleep(min(1.0, max(0.0, deadline - now)))
+    except KeyboardInterrupt:
+        interrupted = True
+        print("interrupted; collecting the partial profile", file=sys.stderr)
+
+    stopped = bridge.request({"cmd": "memory", "action": "stop"})
+    samples = bridge.request({"cmd": "memory", "action": "samples"})
+    bridge.close()
+    payload = {
+        "format": "AetherSDR-memory-soak-v1",
+        "startedUtc": started_wall.isoformat(),
+        "finishedUtc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "requestedDurationSeconds": args.duration,
+        "sampleIntervalMs": interval_ms,
+        "interrupted": interrupted,
+        "bridge": bridge_info,
+        "start": started,
+        "stop": stopped,
+        "series": samples,
+    }
+    output = atomic_write_json(args.output, payload)
+
+    report = stopped.get("report", {})
+    resident = report.get("byteTrends", {}).get("process.residentBytes", {})
+    print(f"resident delta: {mib(resident.get('delta')):+.1f} MiB; "
+          f"slope: {mib(resident.get('slopeBytesPerHour')):+.1f} MiB/hour; "
+          f"R²={float(resident.get('rSquared') or 0.0):.3f}")
+    suspects = report.get("growthSuspects", [])
+    print(f"growth suspects: {len(suspects)}")
+    for suspect in suspects:
+        print(f"  {suspect.get('metric')}: "
+              f"delta={mib(suspect.get('deltaBytes')):+.1f} MiB "
+              f"slope={mib(suspect.get('slopeBytesPerHour')):+.1f} MiB/hour "
+              f"R²={float(suspect.get('rSquared') or 0.0):.3f}")
+    print(f"profile: {output}")
+    return 130 if interrupted else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/memory_soak.py
+++ b/tools/memory_soak.py
@@ -149,7 +149,7 @@ def main():
         print("warning: this bridge reports TX automation enabled; "
               "the memory soak never invokes TX", file=sys.stderr)
     started_wall = dt.datetime.now(dt.timezone.utc)
-    started = bridge.request({"cmd": "memory", "action": "start",
+    started = bridge.request({"cmd": "memprofile", "action": "start",
                               "value": f"{interval_ms} {max_samples}"})
     if not started.get("ok"):
         bridge.close()
@@ -182,7 +182,7 @@ def main():
                 next_tune = started_monotonic + (
                     tune_index * args.tune_interval)
             if now >= next_progress:
-                status = bridge.request({"cmd": "memory", "action": "status"})
+                status = bridge.request({"cmd": "memprofile", "action": "status"})
                 print(progress_line(status, deadline - now), flush=True)
                 next_progress = now + args.progress
             time.sleep(min(1.0, max(0.0, deadline - now)))
@@ -190,8 +190,8 @@ def main():
         interrupted = True
         print("interrupted; collecting the partial profile", file=sys.stderr)
 
-    stopped = bridge.request({"cmd": "memory", "action": "stop"})
-    samples = bridge.request({"cmd": "memory", "action": "samples"})
+    stopped = bridge.request({"cmd": "memprofile", "action": "stop"})
+    samples = bridge.request({"cmd": "memprofile", "action": "samples"})
     bridge.close()
     payload = {
         "format": "AetherSDR-memory-soak-v1",

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -161,6 +161,18 @@ def test_field_mapping():
     check("streams → cmd=streams action(scope)",
           r.get("cmd") == "streams" and r.get("action") == "radio", str(r))
 
+    r = run_tool("memory_profile",
+                 {"action": "start", "interval_ms": 2000,
+                  "max_samples": 500})[-1]
+    check("memory_profile → cmd=memory action+bounded sampler args",
+          r.get("cmd") == "memory" and r.get("action") == "start"
+          and r.get("value") == "2000 500", str(r))
+
+    r = run_tool("memory_profile", {"action": "snapshot"})[-1]
+    check("memory_profile snapshot has no synthetic value",
+          r.get("cmd") == "memory" and r.get("action") == "snapshot"
+          and "value" not in r, str(r))
+
     reqs = run_tool("bridge_command", {"request": {"cmd": "whoami"}})
     check("bridge_command passes raw request", reqs[-1].get("cmd") == "whoami", str(reqs))
 

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -165,12 +165,12 @@ def test_field_mapping():
                  {"action": "start", "interval_ms": 2000,
                   "max_samples": 500})[-1]
     check("memory_profile → cmd=memory action+bounded sampler args",
-          r.get("cmd") == "memory" and r.get("action") == "start"
+          r.get("cmd") == "memprofile" and r.get("action") == "start"
           and r.get("value") == "2000 500", str(r))
 
     r = run_tool("memory_profile", {"action": "snapshot"})[-1]
     check("memory_profile snapshot has no synthetic value",
-          r.get("cmd") == "memory" and r.get("action") == "snapshot"
+          r.get("cmd") == "memprofile" and r.get("action") == "snapshot"
           and "value" not in r, str(r))
 
     reqs = run_tool("bridge_command", {"request": {"cmd": "whoami"}})


### PR DESCRIPTION
## Summary

- add a cross-platform `memory` automation verb for native process counters, bounded sampling, raw-series export, and trend analysis
- attribute explicit buffers and QObject lifecycle inventories to panadapter, audio, radio-model, GUI, and automation scopes
- expose panadapter waterfall/3DSS allocations, a conservative GPU-surface lower bound, audio buffer capacity, stream ownership, and orphan counts
- add the unattended `tools/memory_soak.py` driver and MCP `memory_profile` tool
- make the shared automation probe attach `AETHER_MCP_TOKEN` to secured JSON requests
- document the schema, platform differences, attribution limits, heuristic thresholds, and long-duration workflow

## Motivation

We have Windows reports of memory increasing over long AetherSDR sessions, especially around panadapter workloads, while the same classes of workload appear stable on macOS. Process RSS alone cannot distinguish a retained application object from allocator behavior, an explicitly sized display buffer, or a native Qt/GPU-driver working set.

This adds a low-overhead, opt-in evidence surface to the existing automation bridge. It combines OS-native process metrics with explicit subsystem buffers and object inventories, keeps its own time series bounded, and reports linear slope plus R² so a noisy endpoint comparison is not mistaken for a leak.

## Platform counters

- Windows: Working Set, peak Working Set, PrivateUsage, and handle count
- macOS: physical footprint, resident peak, virtual size, private/internal memory, and malloc-zone use/reservation
- Linux: VmRSS, VmHWM, VmSize, thread count, `smaps_rollup` private pages, and glibc `mallinfo2` where available

The schema explicitly identifies tracked bytes as lower bounds. Backend staging resources and driver allocations remain in `unattributedResidentBytes`; the panadapter GPU number is a conservative surface estimate and is not presented as exact residency.

## Validation

- full RelWithDebInfo application build with 8 jobs
- `memory_telemetry_test`, `aether_mcp_field_mapping`, and `bridge_docs_check`
- MCP protocol/mapping checks and Python byte-compilation
- generated automation documentation check
- strict engine-boundary check: zero blocking findings
- `git diff --check`

### Five-minute macOS FLEX soak

The test used one owned slice, panadapter, and waterfall with 61 samples over 300 seconds:

- zero growth suspects
- physical footprint: 931.2 MiB to 896.4 MiB (−34.8 MiB)
- apparent RSS slope: +58.8 MiB/hour with R² 0.002, so the transient swings were not a meaningful linear trend
- allocator in-use: −0.89 MiB and tightly bounded between 268.0 and 269.3 MiB
- panadapter tracked allocation: 129.64 MiB with zero delta
- panadapter, GUI, audio, and radio-model object counts: zero delta
- zero orphan or leaked pan/waterfall streams

The process footprint had transient native/Metal working-set swings while allocator use and tracked panadapter storage stayed flat. This run therefore found no retained AetherSDR object or buffer leak on macOS.

## Windows follow-up

The intended next validation is a one-hour Windows session using the same bridge surface:

```text
python tools/memory_soak.py --duration 3600 --interval 5 --output aethersdr-memory-windows-1h.json
```

The report should make it possible to determine whether Working Set growth correlates with PrivateUsage, handles, panadapter buffers, QObject counts, or only the unattributed native/GPU gap.

## Screenshots

Not applicable: this is an automation-bridge and telemetry feature with no new visual UI. The evidence artifact is the JSON time series produced by the soak driver.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
