### PR TITLE
feat(peripherals): add ACOM S-series amplifier support (serial/ser2net)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,8 @@ set(CORE_SOURCES
     src/core/AutomationServer.cpp
     src/core/MqttClient.cpp
     src/core/PgxlConnection.cpp
+    src/core/AcomProtocol.cpp
+    src/core/AcomConnection.cpp
     src/core/FirmwareUploader.cpp
     src/core/WaveformInstaller.cpp
     src/core/WaveformUploadState.cpp
@@ -758,6 +760,7 @@ set(GUI_SOURCES
     src/gui/PanFloatingWindow.cpp
     src/gui/DvkPanel.cpp
     src/gui/AmpApplet.cpp
+    src/gui/AcomApplet.cpp
     src/gui/MeterApplet.cpp
     src/gui/ProfileSwitcherApplet.cpp
     src/gui/RadeApplet.cpp
@@ -2815,6 +2818,14 @@ target_link_libraries(dstar_accessibility_test PRIVATE Qt6::Widgets)
 add_test(NAME dstar_accessibility_test COMMAND dstar_accessibility_test)
 set_tests_properties(dstar_accessibility_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+add_executable(acom_protocol_test
+    tests/acom_protocol_test.cpp
+    src/core/AcomProtocol.cpp
+)
+target_include_directories(acom_protocol_test PRIVATE src)
+target_link_libraries(acom_protocol_test PRIVATE Qt6::Core)
+add_test(NAME acom_protocol_test COMMAND acom_protocol_test)
 
 add_executable(ole_compound_file_test
     tests/ole_compound_file_test.cpp

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -77,6 +77,39 @@ facts. The consulted facts are:
   License:   GPL-3.0-or-later (consulted as a behavioral reference only)
   Source:    https://github.com/dl1ycf/pihpsdr  (src/old_protocol.c)
 
+The ACOM S-series amplifier peripheral (shipped; see
+docs/architecture/acom-600s-amplifier-design.md) implements ACOM's RS-232
+serial protocol — the binary frame layout (start byte, address, length,
+checksum), the unified telemetry message (address 0x2F), the error-code
+bitfields (address 0x21), the system-config query (address 0x11), and the
+mode-change/clear-faults command envelope (address 0x81). These wire-protocol
+facts were consulted clean-room from the manufacturer's own published
+specification and are expressed in original AetherSDR code; no code from
+either source below is incorporated, vendored, translated, or linked into
+AetherSDR.
+
+  ACOM 600S Serial Port Communication Protocol, v1.1 (2014-12-04) — eng.
+  Nikolay Nenov, the primary protocol authority (Principle I).
+  Publisher: ACOM (manufacturer public documentation)
+  Reference: no stable public URL — distributed directly by ACOM (Bulgaria)
+             as a maintainer-supplied PDF, not a web download, so no
+             URL/access-date/hash triple is recorded here; contrast
+             third_party/crdv/CLEANROOM_PROVENANCE.md's stricter format,
+             used where a public, hashable download exists
+
+  ACOM-Controller (Björn Ekelund, SM7IUN) — consulted only as a secondary,
+  practical cross-check (e.g. that the checksum sign convention and 72-byte
+  framing match a working real-world implementation; that the mandatory-per-spec
+  0x86 acknowledgement is safely omittable on a direct RS-232 link in practice).
+  License:  MIT
+  Source:   https://github.com/bjornekelund/ACOM-Controller
+
+  ACOM product pages (acom-bg.com) — consulted for the per-model nominal/max
+  rated-power figures used to derive the auto-ranging table in
+  AcomProtocol.cpp's modelTable() (500S/600S/700S/1200S/1400S/2020S); no code
+  or text incorporated, figures only.
+  Publisher: ACOM (manufacturer public documentation)
+
 
 1. WDSP — Spectral Noise Reduction (NR2)
 -----------------------------------------

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -28,6 +28,11 @@ context that would otherwise live in tribal knowledge.
 - [`mainwindow-decomposition.md`](mainwindow-decomposition.md) — the
   `MainWindow_*.cpp` TU map and a decision guide for where new
   `MainWindow` code belongs (read before touching anything `MainWindow*`).
+- [`acom-600s-amplifier-design.md`](acom-600s-amplifier-design.md) — design
+  note for ACOM S-series amplifier support (serial or ser2net), a peripheral
+  accessory alongside the existing PGXL/TGXL integrations. Implemented as a
+  dedicated `AcomConnection`/`AcomApplet` pair, deliberately independent of
+  `AmpModel`/`AmpApplet` — see the doc's design-reversal section for why.
 
 Code-level reviewers should also skim the corresponding header files
 in `src/core/` and `src/models/`.

--- a/docs/architecture/acom-600s-amplifier-design.md
+++ b/docs/architecture/acom-600s-amplifier-design.md
@@ -1,0 +1,383 @@
+# ACOM S-Series Amplifier Support — Design Note
+
+**Status:** Draft for maintainer review. Not a new `IRadioBackend` family under
+the aetherd RFC — the ACOM has no FlexRadio awareness at all, so this adds a
+**peripheral accessory** in the same sense as the existing 4O3A PGXL/TGXL/
+Antenna Genius integrations (`peripheral(4o3a)` in
+`docs/architecture/aetherd-touchpoint-tags.json`), which AGENTS.md's touchpoint
+taxonomy explicitly exempts from the `IRadioBackend`-design-doc requirement
+that gates a *new radio family*.
+
+**Scope:** A dedicated `AcomApplet` (sibling of `AmpApplet`, not a variant of
+it — see §2) driven by `AcomConnection`, a peripheral transport (serial or
+ser2net-style TCP, same binary protocol either way), plus a Peripherals
+settings row. Telemetry/status decode, Operate/Standby/Off, clear-faults, and
+model auto-detection/auto-ranging across the whole current S-series line
+(500S/600S/700S/1200S/1400S/2020S). No manual band/antenna override, no
+CAT-passthrough config, no factory reset/service-mode/bootloader access, and
+deliberately **no model-selector dropdown** (see §6) — see §4 for the full
+scope rationale.
+
+---
+
+## 1. Why this is a peripheral, not a backend
+
+`IRadioBackend`'s canonical amplifier path (`amplifierChanged(AmpDelta)`,
+`invokeExtension("flex", "amp.operate", ...)`) exists because PGXL is *relayed
+through the radio* — SmartSDR's own `amplifier` status object reports PGXL's
+presence and proxies its operate command, which is also the only path that
+works remote/SmartLink. The ACOM has no such relationship: it is a standalone
+RS-232 device the radio has never heard of. So, same as
+`PgxlConnection`/`TgxlConnection`/`AntennaGeniusModel`, `AcomConnection` lives
+directly under `src/core/`, outside the radio seam, and never touches
+`IRadioBackend`/`invokeExtension`. `AmpModel` (PGXL's model) is untouched by
+this feature — see §2 for why an earlier draft that extended it got reverted.
+
+**Protocol authority (Principle I):** the manufacturer's own published *"RF
+Amplifier ACOM 600S Serial Port Communication Protocol"* (v1.1, 2014-12-04,
+eng. Nikolay Nenov) is the primary source for wire framing, telemetry fields,
+error-code bitfields, and the command/request envelope. A secondary,
+MIT-licensed open-source reference client (`bjornekelund/ACOM-Controller`) was
+consulted only as a practical cross-check — confirming the checksum sign
+convention and that the spec's mandatory `0x86` acknowledgement is, in
+practice, safely omittable on a direct RS-232 link. No code from either
+source is incorporated — see `THIRD_PARTY_LICENSES` for the full provenance
+record. ACOM's own public product pages (acom-bg.com) are a *third* source,
+consulted for §6's rated-power figures — see that section for why the
+reference client's embedded power constants turned out not to be trustworthy
+for anything but the 600S.
+
+---
+
+## 2. What gets added — and a design reversal worth recording
+
+```
+AcomConnection (src/core/AcomConnection.h/.cpp)
+  holds a QIODevice* — either a QSerialPort (local COM port) or a
+  QTcpSocket (ser2net-style proxy, raw TCP mode) — chosen at connect time.
+  One binary framing state machine reads/writes both identically.
+    parses:  0x2F  unified telemetry (72 B: mode, power, SWR, temp, DC
+                    voltages/currents, active LPF band, carrier freq, fault
+                    code — see §3)
+             0x21  error-code bitfields (10 words, WARNING/SOFT/HARD tiers)
+             0x11  SystemConfig (amplifier type/firmware/serial — one-shot,
+                    on request only; drives model auto-detection, §6)
+    sends:   0x81  mode-change (Standby/Operate/Off) + clear-soft-faults
+             0x91/0x92  telemetry disable/enable (re-armed via keepalive)
+             0x02  request-specific-message (used to ask for 0x11)
+  tracks:  currentModel() — the effective model tier, resolved by
+           auto-detection + auto-ranging, never by user selection (§6)
+  signals: connected/disconnected/connectionFailed, telemetryUpdated,
+           rawErrorCodesUpdated, modelChanged(name, reason),
+           systemConfigReceived(SystemConfig)
+
+AcomApplet (src/gui/AcomApplet.h/.cpp)
+  a dedicated widget, NOT built by extending AmpApplet. Three permanent
+  HGauge rows — Power / Reflected / SWR — since ACOM's 0x2F frame reports
+  all three as independently real fields (unlike PGXL, which only ever
+  gave AmpApplet a reason to show Power/SWR/Id). PAM drain current (Id)
+  is a text readout, not a gauge — no protocol-defined scale to size an
+  axis against. 3-cell-per-row info grid (temp/HV/Id, band/uptime/clear),
+  a status pill carrying the auto-detection/ranging diagnostic tooltip,
+  and three separate STANDBY/OPERATE/OFF buttons (not one toggling button).
+
+AppletPanel (extended)
+  registers AcomApplet as its own dockable panel (acomApplet(),
+  setAcomVisible()) — independent of setAmpVisible(), since a station can
+  have both a radio-relayed PGXL and a direct-connected ACOM at once.
+
+RadioSetupDialog::buildPeripheralsTab()  (extended)
+  ACOM row: Serial ⇄ Network mode toggle, reusing the QSerialPortInfo/
+  "Custom…" port-combo pattern from the CW/keying page and the existing
+  IP:port fields for Network mode.
+```
+
+**Design reversal worth recording:** the first working version of this
+feature extended `AmpModel` (PGXL's model) with a direct-connection path,
+mirroring `TunerModel::setDirectConnection`, and rendered ACOM telemetry
+through `AmpApplet` with additive fields and a click-to-toggle SWR/reflected
+row. That shipped, ran against real 600S hardware, and worked — but two
+problems surfaced under actual use: it couldn't be made to match the intended
+layout without fighting `AmpApplet`'s PGXL-shaped assumptions (fixed 3-gauge
+row count, fixed info-stack shape), and — more importantly — routing ACOM's
+presence through `AmpModel`'s shared `present()` flag caused the **PGXL
+applet to appear whenever an ACOM connected**, even with no PGXL anywhere in
+the station, because `AmpModel::present()` couldn't distinguish "PGXL
+relayed" from "ACOM direct." Both `AmpModel` and `AmpApplet` were reverted to
+byte-identical with `main` and this dedicated-applet design took their place.
+The lesson generalized: a peripheral with no relationship to an existing
+device's model/view should get its own model and view from the start, not
+share one for code-reuse's sake, even when the sharing looks cheap initially.
+
+---
+
+## 3. Protocol summary
+
+Binary framing, symmetric both directions, 9600 8N1, no handshake, ~10 ms
+inter-message pacing, 72-byte max message:
+
+```
+| 0x55 | Address | Length | ...Data... | Checksum |
+```
+
+`Checksum = 256 − (sum of all prior bytes & 0xFF)`; a valid frame sums to 0
+mod 256.
+
+| Address | Direction | Contents |
+|---|---|---|
+| `0x2F` | amp → host | Unified telemetry (72 B): mode (Reset/Init/Debug/Service/STB/OPR-RX/OPR-TX/ATAC/Off), PAM temp, DC power, input/forward/reflected power, SWR, dissipation power, VCC5/VCC26/HV1, PAM current, bias voltages, carrier frequency, active LPF band + fan speed, error code + parameter. |
+| `0x21` | amp → host | 10 error-code words, each bit independently named, each tagged WARNING / SOFT FAULT / HARD FAULT. |
+| `0x11` | amp → host | SystemConfig — amplifier type, firmware/hardware/bootloader versions, 12-byte serial number, hard-fault record count. **One-shot, on request only** — not pushed automatically like `0x2F`/`0x21`. Drives model auto-detection (§6). |
+| `0x02` | host → amp | Request a specific one-shot message by address (used to ask for `0x11`). Sent up to 5 times total (the spec's own retry ceiling — 5 attempts, not 5 retries after an initial send) with an 800 ms timeout between attempts; gives up silently if the amp never replies — auto-ranging (§6) covers that case without blocking on it. |
+| `0x81` | host → amp | Command envelope. Sub-command `0x02` = mode change (`0x05`=Standby, `0x06`=Operate, `0x0A`=Off); `0x08` = clear soft faults. (Sub-commands for CAT passthrough config, manual band/antenna override, buzzer, LOG dump, service-mode tests, factory reset exist in the spec and are **not implemented**; see §4.) |
+| `0x91` / `0x92` | host → amp | Disable / enable automatic telemetry push. |
+| `0x86` | either | Per-message acknowledgement. Sent only for the one-shot `0x11` SystemConfig reply, which has its own request/retry-with-timeout exchange (`0x02`) the ack model naturally fits. **Not** sent for `0x2F`/`0x21`, which are auto-pushed continuously (~10/s) rather than requested — the reference client never acks anything, on any message type, and is a documented-working real-hardware implementation over direct RS-232, so acking isn't required to keep the push streams flowing, and blanket-acking a ~10/s broadcast stopped making sense once the push-vs-request distinction was reconsidered. |
+
+One transport gotcha for the ser2net path specifically: the data stream can
+legitimately contain byte `0xFF` (e.g. "no error" is encoded as `0xFF` in the
+error-code field). If ser2net is configured with `connection type: telnet`
+rather than `raw`, telnet's IAC-escaping corrupts that byte. `AcomConnection`'s
+network mode assumes/requires a **raw** TCP proxy.
+
+**Protocol-parity assumption**, stated explicitly since §6 leans on it: the
+wire framing, checksum, and the specific messages this project implements
+(`0x2F`, `0x21`, `0x11`, `0x81` mode-change/clear-faults, `0x91`/`0x92`,
+`0x02`) are assumed identical across the whole S-series — only power-scaling
+constants and PAM2-field presence differ per model. This is the manufacturer's
+own documented framing, not something invented per-model; nothing in the
+public record suggests the bigger amps use a different wire format for the
+same message addresses. What's explicitly **not** assumed shared: any
+model-specific extras a bigger amp might expose beyond what's implemented
+here (e.g. dual-PAM telemetry fields) — those are out of scope for v1
+regardless of model, not silently assumed absent.
+
+---
+
+## 4. Command scope for v1
+
+| Tier | Included in v1? | Rationale |
+|---|---|---|
+| Telemetry + fault decode (`0x2F`, `0x21`) | Yes | Read-only, no risk. |
+| SystemConfig query (`0x11` via `0x02`) | Yes | One-shot, read-only, drives model auto-detection (§6). |
+| Operate / Standby / Off, clear-soft-faults | Yes | The functional slice needed for normal operation; matches what the widely-used open-source reference client itself implements. |
+| Manual band/antenna override, buzzer control | No | Convenience only — the amp senses its own band from the drive signal via its own frequency counter, so AetherSDR never *needs* to tell it the band. Deferred, not rejected. |
+| CAT-passthrough config, user-flags settings mirror | No | The amp's own front panel already owns this; duplicating it in AetherSDR adds surface for the two to drift out of sync. |
+| Factory reset, service-mode hardware tests, bootloader activation | **Never** (not just deferred) | Destructive/technician-only operations with no legitimate use from a radio-control app. |
+
+---
+
+## 5. Power/Reflected/SWR — three permanent gauges, no toggle
+
+An earlier draft gave the SWR row a click-to-toggle between SWR and reflected
+power, on the theory that PGXL's `AmpApplet` only had 3 gauge slots (Power/
+SWR/Id) to work with. Once ACOM got its own dedicated applet (§2), that
+constraint no longer existed — forward power, reflected power, and SWR are
+**all three independently real fields from the same `0x2F` frame**, so
+`AcomApplet` just shows all three permanently: no toggle, no interaction
+needed to see reflected power, strictly more information at a glance. PAM
+drain current (Id) moved to a plain text readout instead of competing for a
+4th gauge slot.
+
+- **Power / Reflected** — scaled per the model tier (§6), two-zone
+  (green/red, no amber) at that tier's nominal/max.
+- **SWR** — fixed 1.0–3.0, three-zone (green/amber/red), same scale
+  regardless of model — SWR is a ratio, not a wattage, so it doesn't need
+  per-model scaling.
+
+---
+
+## 6. Multi-model support: auto-detection + auto-ranging, not a dropdown
+
+The protocol is assumed shared across the whole line (§3). Getting the right
+**power scale** per model is the harder problem, and the design here is
+worth spelling out in full since it went through several iterations.
+
+### 6.1 The rated-power table is not what it looks like
+
+Nominal (rated) output power, sourced from **ACOM's own current published
+product pages** (acom-bg.com) — not the model name, and not the public
+reference client's embedded constants, both of which turned out to be wrong:
+
+| Model | Rated output (ACOM's own spec) | Model name | Reference client's constant |
+|---|---|---|---|
+| 500S | 500 W | 500 | 500 W — agrees |
+| 600S | 600 W | 600 | 600 W — agrees, **and hardware-confirmed** |
+| 700S | 700 W | 700 | 700 W — agrees |
+| 1200S | **1000 W** | 1200 | 1200 W — **wrong** |
+| 1400S | **1200 W** | 1400 | *(not in the reference client at all)* |
+| 2020S | **1500 W** | 2020 | 1800 W — **wrong** |
+
+The model name equals the rated wattage for the three smaller amps, but not
+for the three bigger ones — 1200S is actually rated 1000W, 2020S is actually
+rated 1500W. Neither "infer from the model name" nor "trust the reference
+client" holds up as a methodology; ACOM's own current spec pages are the only
+reliable source found, and they were checked individually for every model
+in scope.
+
+### 6.2 Deriving the gauge ceiling ("max")
+
+ACOM's marketing publishes a single rated figure, not a separate red-zone
+ceiling. The 600S is real hardware, so its ratio is real: 700W max is exactly
+600W rated + 100W. Applying **that same +100W** to the other two "name equals
+rated" models keeps the ceiling a round number and consistent with the one
+confirmed data point:
+
+- 500S: 500 + 100 = **600 W**
+- 700S: 700 + 100 = **800 W**
+
+For 1200S and 1400S, the model name itself turns out to be `rated + 200W` —
+1200 = 1000 + 200, 1400 = 1200 + 200 — a clean enough pattern that the name
+is used directly as the ceiling (1200W and 1400W respectively) rather than
+computing a separate derived number. 2020S does **not** fit this pattern
+(2020 ≠ 1500 + 200 = 1700), so its name isn't power-derived at all and isn't
+trusted as a ceiling; it falls back to the 600S-derived ratio instead
+(1500 × 1.167 ≈ 1750W).
+
+Final table (`AcomProtocol.h`'s `modelTable()`):
+
+| Model | Nominal (W) | Max (W) | Basis for max |
+|---|---|---|---|
+| 500S | 500 | 600 | 600S's +100W ratio |
+| 600S | 600 | 700 | **confirmed (hardware)** |
+| 700S | 700 | 800 | 600S's +100W ratio |
+| 1200S | 1000 | 1200 | model name (fits `rated+200`) |
+| 1400S | 1200 | 1400 | model name (fits `rated+200`) |
+| 2020S | 1500 | 1750 | 600S's ratio (name doesn't fit) |
+
+Reflected power (nominal/max) has no public source at all for any model —
+derived proportionally from the 600S's own confirmed ratios (114/600 ≈ 19%
+nominal, 150/700 ≈ 21.4% max) applied to each model's forward-power figures.
+Temperature offset and PAM2-field presence are carried from the reference
+client where no better source exists, defaulted to the majority/inferred
+value for 1400S (which the reference client doesn't cover at all). None of
+this is independently verified beyond 600S — it's a documented best effort,
+not a claim of accuracy.
+
+### 6.3 Why there's no model-selector dropdown
+
+`0x11`'s `Amplifier Type` byte is the wire-level way to ask the amp what it
+is — but the spec documents **only one value**: `1 = A600S`. Nothing public
+(ACOM's own site, the reference client, forum posts, other technical
+articles) confirms what the other five models report. Guessing a mapping —
+even a plausible-looking one like "sequential by launch order" — was
+considered and rejected: there's no evidence for any particular ordering, and
+a wrong guess presented as confident would be worse than no guess at all.
+
+Given the explicit product decision to support the whole line **without**
+asking the user to pick their model from a dropdown, the design instead
+leans on **auto-ranging from observed telemetry**, which needs no type-code
+knowledge at all:
+
+1. On every connect, `AcomConnection` resets to **"600S"** — the one
+   confirmed model — as the starting tier, and requests `0x11` (sent up to 5
+   times total — not 5 retries *after* an initial send, i.e. `0x11` is never
+   sent a 6th time — 800 ms apart, per the spec's own retry ceiling; silently
+   gives up if the amp never replies — some firmware may not support the
+   query at all, and that's fine, auto-ranging still covers it).
+2. If the reply's `amplifierType == 1`, the tier is confirmed as "600S"
+   (already the default, but the GUI's diagnostic tooltip changes from
+   "default" to "confirmed").
+3. On every telemetry frame, observed forward power is compared against the
+   *current* tier's max. A `tierForForwardPower()` pure function (unit
+   tested against literal wattage values, no hardware needed) finds the
+   smallest tier whose ceiling comfortably fits the reading (a 2% margin
+   avoids boundary-flapping right at a tier edge). If that required tier is
+   **higher** than the current one, the connection jumps directly to it —
+   not incrementally through every intervening tier — and re-emits
+   `modelChanged` so the GUI re-applies gauge ranges, reflected-power
+   scaling, and the temperature offset together as one consistent tier.
+4. The tier only ever moves **up**, never back down, for the life of a
+   connection — a momentary dip in power is normal operation, not evidence
+   of a smaller amp. It resets to "600S" fresh on every reconnect.
+
+This directly satisfies "query the model and adjust scale to match
+capability on connect" without needing a trustworthy type-code table at
+all: a 500S *cannot* report 900W forward power, so observing 900W is itself
+proof the amp is at least 1200S-class, regardless of what its `0x11` reply
+says or doesn't say.
+
+### 6.4 Gathering data to fill out the table properly
+
+Nothing here is a substitute for real confirmed type codes. To make it
+possible to replace derived numbers with real ones over time:
+
+- **Logging** (`lcTuner` category, same as the rest of `AcomConnection`):
+  every `0x11` reply logs the raw `amplifierType` byte, firmware/hardware
+  version, and serial number at `qCInfo` level; every auto-ranging tier
+  bump logs the forward-power reading that triggered it and which tiers
+  were involved. This rides on the existing `SupportBundle` log-collection
+  path — no new infrastructure needed to get this data out of a user's
+  machine and into a bug report.
+- **User-visible surface**: a tooltip on `AcomApplet`'s status pill (not a
+  new field in the Peripherals settings row — no other device row there
+  surfaces detected-hardware info, only connection status/errors, so a
+  tooltip on the applet itself is the more consistent choice) shows the
+  detected/current tier and reason (`default`/`confirmed`/`auto-scaled`),
+  and after a `0x11` reply, the raw type byte, firmware version, and serial
+  number — explicitly inviting a report if the type is unrecognized.
+- **The ask**: if you own a 500S/700S/1200S/1400S/2020S, please file a
+  GitHub issue with the tooltip's reported type byte and your actual model.
+  Once even one more model has a confirmed type code,
+  `modelNameForAmplifierType()` gets a second confident `==` case instead of
+  relying on auto-ranging for it.
+
+---
+
+## 7. Touchpoint tagging
+
+`core/AcomConnection.h` is tagged `peripheral(acom)` in
+`docs/architecture/aetherd-touchpoint-tags.json`, matching the existing
+`peripheral(4o3a)` precedent for PGXL/TGXL/Antenna Genius. `src/gui/AcomApplet.h`
+needs no entry — the touchpoint manifest tracks `core/`/`models/` headers the
+UI *includes*, not `gui/` files themselves. `AmpModel.h` and `AmpApplet.h/.cpp`
+are untouched by this feature (§2's reversal put them back to byte-identical
+with `main`), so their existing tags are unaffected.
+
+---
+
+## 8. Resolved decisions & open questions
+
+**Resolved**
+- Peripheral, not backend — no `IRadioBackend` involvement (§1).
+- **Dedicated `AcomApplet`/`AcomConnection`, not a shared `AmpModel`/`AmpApplet`
+  extension** — reversed from the original design after it caused PGXL's
+  applet to appear with no PGXL present (§2).
+- v1 command scope: telemetry + SystemConfig query + Operate/Standby/Off +
+  clear-faults only (§4).
+- Power/Reflected/SWR are three permanent gauges, no toggle (§5).
+- Whole current S-series line supported (500S/600S/700S/1200S/1400S/2020S),
+  via auto-detection + auto-ranging, deliberately **without** a model-selector
+  dropdown (§6).
+- Rated-power table sourced from ACOM's own product pages, not the model name
+  or the reference client's constants, both shown to be unreliable (§6.1).
+- **`0x86` acknowledgement:** sent only for the one-shot `0x11` SystemConfig
+  reply, not for the auto-pushed `0x2F`/`0x21` streams — see §3's protocol
+  table for the reasoning (the reference client's own no-ack-anywhere
+  behavior, cross-checked as a working real-hardware precedent).
+- **`systemClockSec` word order:** cross-checked against a real 600S —
+  its front-panel `127:43:17` (H:MM:SS) reading matches the applet's
+  decoded `5d 7h` display exactly (459,797s either way), confirming the
+  current high-word/low-word order is correct, not swapped.
+
+**Open (for maintainer input)**
+- **Id gauge scale removed as a concern** — Id is a text readout now, not a
+  gauge, so there's no axis to calibrate.
+- **500S/700S/1200S/1400S/2020S power table** — derived, not measured; every
+  entry except 600S needs a real owner to confirm it (§6.4).
+
+---
+
+## 9. Phasing
+
+1. `AcomConnection` + binary framing/checksum + `AcomApplet` — shipped,
+   iterated against real 600S hardware across several rounds (layout,
+   button/info-grid grouping, uptime semantics).
+2. Model auto-detection (`0x11`/`0x02`) + auto-ranging + corrected multi-model
+   table — this round.
+3. Hardware validation pass against real 600S: confirm `SystemConfig` request
+   actually elicits a reply (settles the `0x02`-standalone vs.
+   `0x81`-sub-command-`0x01` ambiguity the spec's translation left open),
+   confirm auto-ranging behaves sanely if ever exercised, `0x86` ack behavior,
+   ser2net raw-mode round trip.
+4. Community data-gathering for the rest of the model table (§6.4) — ongoing,
+   not gated on a release.

--- a/docs/architecture/aetherd-touchpoint-tags.json
+++ b/docs/architecture/aetherd-touchpoint-tags.json
@@ -1,4 +1,10 @@
 {
+ "core/AcomConnection.h": {
+  "tag": "peripheral(acom)",
+  "note": "Direct serial/ser2net client for the ACOM S-series amplifier line (600S primary target, protocol shared across 500S/700S/1200S/2020S) — a standalone RS-232 accessory with no FlexRadio awareness at all, same precedent as core/PgxlConnection.h and core/TgxlConnection.h. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam. See docs/architecture/acom-600s-amplifier-design.md.",
+  "split": "",
+  "confidence": "high"
+ },
  "core/AdaptiveFilterEngine.h": {
   "tag": "universal",
   "note": "GUI-thread adaptive RX passband coordinator over SliceModel/spectrum frames; canonical radio state, no vendor ties.",

--- a/docs/architecture/aetherd-touchpoints.md
+++ b/docs/architecture/aetherd-touchpoints.md
@@ -4,16 +4,18 @@
 
 Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine-design.md) §2, §10). One row per engine header the UI includes; converting a touchpoint means the UI reaches that surface through the versioned protocol instead of the header.
 
-**Totals:** 140 touchpoint headers (117 core, 23 models) — 140/140 tagged, 0/140 converted.
+**Totals:** 149 touchpoint headers (123 core, 26 models) — 141/149 tagged, 0/149 converted.
 
 | Header | Includers | Tag | Status |
 |---|---:|---|---|
+| `core/AcomConnection.h` | 2 | peripheral(acom) — Direct serial/ser2net client for the ACOM S-series amplifier line (600S primary target, protocol shared across 500S/700S/1200S/2020S) — a standalone RS-232 accessory with no FlexRadio awareness at all, same precedent as core/PgxlConnection.h and core/TgxlConnection.h. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam. See docs/architecture/acom-600s-amplifier-design.md. | unconverted |
 | `core/AdaptiveFilterEngine.h` | 1 | universal — GUI-thread adaptive RX passband coordinator over SliceModel/spectrum frames; canonical radio state, no vendor ties. | unconverted |
 | `core/AgcTCalibrator.h` | 1 | universal — Engine algo sweeping slice AGC threshold vs audio RMS/S-meter to recommend a value; only canonical state. | unconverted |
-| `core/AppSettings.h` | 90 | ui-support — Client-side XML settings store (SSDR.settings-style key/value persistence); app plumbing, not radio state. | unconverted |
+| `core/AppSettings.h` | 91 | ui-support — Client-side XML settings store (SSDR.settings-style key/value persistence); app plumbing, not radio state. | unconverted |
 | `core/AudioEngine.h` | 44 | mixed(flex) — Client audio I/O + full RX/TX DSP chain (universal) fused with Flex VITA-49/DAX/Opus TX and Kiwi buffering | unconverted |
 | `core/AudioOutputRouter.h` | 1 | ui-support — Registry fanning the user-selected QAudioDevice to local playback sinks; OS device plumbing, no radio state | unconverted |
-| `core/AutomationServer.h` | 1 | ui-support — QLocalServer GUI-automation/test bridge (dumpTree/grab/invoke on QWidgets); dev tooling, stays in gui shell | unconverted |
+| `core/AutomationBridgeSettings.h` | 3 | — | unconverted |
+| `core/AutomationServer.h` | 3 | ui-support — QLocalServer GUI-automation/test bridge (dumpTree/grab/invoke on QWidgets); dev tooling, stays in gui shell | unconverted |
 | `core/BandStackSettings.h` | 4 | universal — Per-radio band-stack memories (freq/mode/filter/AGC/NB-NR) — canonical radio state; only the XML store is client-side | unconverted |
 | `core/CallsignInfo.h` | 1 | universal — Callsign lookup result struct (name/QTH/grid, JSON cache form); radio-agnostic spot/logging data. | unconverted |
 | `core/CallsignLookupService.h` | 3 | universal — Orchestrates QRZ/cty.dat callsign lookups + cache; radio-agnostic spot/logging integration. | unconverted |
@@ -31,7 +33,6 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/ClientReverb.h` | 7 | universal — Client TX-chain Freeverb DSP (size/decay/damping/predelay/mix + meters); radio-agnostic engine DSP feature. | unconverted |
 | `core/ClientTube.h` | 11 | universal — Client TX-chain tube saturator DSP (drive/tone/env follower); radio-agnostic engine DSP, no vendor ties. | unconverted |
 | `core/ClientTxTestTone.h` | 1 | universal — 1 kHz TX test-tone generator injected at head of client TX DSP chain; radio-agnostic engine DSP feature | unconverted |
-| `core/CommandParser.h` | 2 | vendor(flex) — Stateless parser/builder for SmartSDR TCP wire lines (V/H/C/R/S/M, FlexLib semantics) — pure Flex protocol. | unconverted |
 | `core/CwCallsignSpotter.h` | 1 | universal — Spots callsigns from the client-side CW decoder stream; radio-agnostic engine feature. | unconverted |
 | `core/CwDecoder.h` | 1 | universal — Client-side CW/Morse decoder (ggmorse) over generic 24kHz PCM; radio-agnostic engine DSP feature. | unconverted |
 | `core/CwSidetoneGenerator.h` | 2 | universal — Engine-side low-latency CW sidetone DSP driven by keying intent; radio-agnostic (DAX only in comment). | unconverted |
@@ -39,12 +40,16 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/CwxLocalKeyer.h` | 2 | universal — Local CW sidetone keyer: text+WPM in, key-down edges out; radio-agnostic despite Flex 'CWX' naming. | unconverted |
 | `core/DaxTxPolicy.h` | 1 | vendor(flex) — Policy deciding when to claim a Flex dax_tx stream vs deferring to SmartSDR DAX2; whole surface is DAX/VITA-49. | unconverted |
 | `core/DeviceDiagnostics.h` | 1 | ui-support — Host audio-device diagnostics (Qt device BT/USB heuristics, JSON snapshots for troubleshooting), not radio state | unconverted |
+| `core/DigitalVoiceFeature.h` | 7 | — | unconverted |
+| `core/DigitalVoiceModeRegistry.h` | 1 | — | unconverted |
+| `core/DigitalVoiceWaveformProcess.h` | 2 | — | unconverted |
+| `core/DigitalVoiceWaveformSettings.h` | 2 | — | unconverted |
 | `core/DvkWavTransfer.h` | 2 | vendor(flex) — DVK WAV upload/download via SmartSDR 'dvk' verbs + ad-hoc TCP port streaming; FlexLib 5MB limit baked in | unconverted |
 | `core/DxClusterClient.h` | 3 | universal — Telnet DX cluster spot client (Spider/AR/CC); emits radio-agnostic DxSpot on canonical freq state. | unconverted |
 | `core/DxccColorProvider.h` | 2 | universal — DXCC worked-status from ADIF log, colors cluster spots by call/freq/mode; radio-agnostic spot/logging feature | unconverted |
 | `core/FirmwareStager.h` | 1 | vendor(flex) — Downloads SmartSDR installers from flexradio.com, extracts .ssdr firmware for 6x00/9600 upload — pure Flex | unconverted |
 | `core/FirmwareUploader.h` | 1 | vendor(flex) — SmartSDR firmware upload: 'file upload' cmd, .ssdr files, Flex TCP ports 4995/42607 — pure Flex protocol | unconverted |
-| `core/FlexControlManager.h` | 2 | ui-support — FlexControl USB knob serial driver (VID 0x2192); client-side input surface like RC-28/TMate, not radio-family wire | reclassified (#4089) |
+| `core/FlexControlManager.h` | 2 | ui-support — FlexControl USB knob serial driver (VID 0x2192) — a desktop input-surface driver, the same class as HidEncoderManager (RC-28/TMate)/UlanziDialBackend/SerialPortController, all ui-support. Flex-branded hardware but client-side input, not radio-family wire; NOT behind the radio seam (reclassified from vendor(flex), #4089). | unconverted |
 | `core/FreeDvClient.h` | 4 | universal — FreeDV Reporter spot client (qso.freedv.org); radio-agnostic spotting fed by canonical freq/TX + RADE SNR | unconverted |
 | `core/GpuSelector.h` | 2 | ui-support — GPU enumeration + persisted QRhi render-adapter choice applied at app startup; pure client rendering plumbing | unconverted |
 | `core/HidEncoderManager.h` | 2 | ui-support — USB HID control-surface driver (RC-28, StreamDeck+, TMate 2): desktop input device plumbing, not radio state | unconverted |
@@ -75,7 +80,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/PanadapterStream.h` | 4 | vendor(flex) — SmartSDR VITA-49 UDP receiver (FlexLib PCCs, DAX/IQ routing, SmartLink WAN reg); emits core-profile data | unconverted |
 | `core/PerfTelemetry.h` | 3 | ui-support — Singleton perf-instrumentation logger for client render/UDP/input timing; diagnostics, not radio state. | unconverted |
 | `core/PeripheralSettings.h` | 3 | ui-support — Client settings blob (AutoReconnect + legacy-key migration) for peripheral devices atop AppSettings; no radio state. | unconverted |
-| `core/PgxlConnection.h` | 2 | peripheral(4o3a) — direct TCP telemetry client (port 9008) for the 4O3A Power Genius XL; standalone accessory transport, not radio wire (amp operate is radio-proxied in RadioModel — see #4094) | reclassified (#4089) |
+| `core/PgxlConnection.h` | 2 | peripheral(4o3a) — Direct TCP client (port 9008) for the external 4O3A Power Genius XL (PGXL) amplifier — TELEMETRY-ONLY (statusUpdated: state/power/SWR/current/temp/…); it has no operate/standby command. PGXL operate/standby is relayed through the radio (RadioModel::setAmpOperate → 'amplifier set <handle> operate=…'), which is also the only path for remote/SmartLink. So this header is a genuine local direct-transport peripheral(4o3a); the amp's radio-relay control lives in RadioModel (radio-side) and should split into a generic AmpModel + Flex relay behind FlexBackend — see #4094. | unconverted |
 | `core/PipeWireAudioBridge.h` | 3 | mixed(flex) — Linux virtual-audio bridge to WSJT-X etc.; audio routing is core, DAX channel model/rates are flex | unconverted |
 | `core/PotaClient.h` | 2 | universal — POTA spot poller (api.pota.app) emitting DxSpot frequency/mode spots; radio-agnostic spot feature, no vendor ties. | unconverted |
 | `core/ProfileTransfer.h` | 1 | vendor(flex) — SmartSDR .ssdr_cfg database import/export over Flex TCP transfer protocol (meta_subset, ports 4995/42607) | unconverted |
@@ -86,6 +91,7 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/RADEEngine.h` | 4 | universal — Engine-side RADE/FreeDV digital-voice codec (PCM in/out, EOO, sync/SNR); DAX mentions are just audio plumbing | unconverted |
 | `core/RadioConnection.h` | 2 | vendor(flex) — SmartSDR TCP text-protocol connection (commands/replies/status) — Flex wire protocol, per calibration anchor | unconverted |
 | `core/RadioDiscovery.h` | 3 | mixed(flex) — Device-discovery list/events are core-profile; SmartSDR UDP:4992 parsing + Multi-Flex/license fields are flex | unconverted |
+| `core/RadioMessageTypes.h` | 2 | universal — Generic radio-message classification enums (MessageType/MessageSeverity) — no vendor ties. Extracted from vendor(flex) core/CommandParser.h so above-seam consumers of just the enums decouple from the SmartSDR wire parser (EB3 decouple, #4087). MessageSeverity values are load-bearing wire values (see the header). | unconverted |
 | `core/ReceivePresentationSync.h` | 1 | mixed(flex) — Cross-source RX latency sync (queues + GCC-PHAT); mechanism is core, but API hardcodes Flex/KiwiSdr pair | unconverted |
 | `core/RttyDecoder.h` | 1 | universal — Radio-agnostic RTTY (Baudot) DSP decoder over generic 24 kHz PCM; engine-side digital-mode decode feature. | unconverted |
 | `core/SerialPortController.h` | 2 | ui-support — USB-serial DTR/RTS PTT + CTS/DSR/DCD key/paddle input; local hardware I/O device, emits intent only | unconverted |
@@ -100,8 +106,8 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/StreamStatus.h` | 1 | vendor(flex) — SmartSDR stream-status parsing: client_handle ownership, DAX RX/TX orphan-stream firmware quirks — pure Flex wire logic | unconverted |
 | `core/SupportBundle.h` | 1 | ui-support — Diagnostics bundle: archives logs/sysinfo and opens email client; client-side support tooling, not radio state | unconverted |
 | `core/TciServer.h` | 3 | mixed(flex) — TCI WebSocket server for WSJT-X et al: protocol surface is canonical radio state, but audio/IQ rides Flex DAX | unconverted |
-| `core/TgxlConnection.h` | 2 | peripheral(4o3a) — direct TCP client (port 9010) for the 4O3A Tuner Genius XL; standalone accessory transport, not radio wire | reclassified (#4089) |
-| `core/ThemeManager.h` | 119 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
+| `core/TgxlConnection.h` | 2 | peripheral(4o3a) — Direct TCP client for the 4O3A Tuner Genius XL (port 9010, relay/autotune), reverse-engineered from the 4O3A management app — a standalone accessory transport, not SmartSDR. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up). | unconverted |
+| `core/ThemeManager.h` | 120 | ui-support — Qt token-based theming singleton (colors/fonts/QSS, theme files, editor hooks) — pure client GUI plumbing, no radio state. | unconverted |
 | `core/TxKeyingMarker.h` | 4 | ui-support — QWidget property marker guarding TX-keying controls from the automation bridge; GUI-shell plumbing, no radio state. | unconverted |
 | `core/UlanziDialBackend.h` | 3 | ui-support — Platform alias for Ulanzi Dial HID knob backend (evdev/hidapi); physical input device for client, not radio state | unconverted |
 | `core/UpdateChecker.h` | 3 | ui-support — App self-update checker polling GitHub releases API; pure client plumbing, no radio state — belongs in gui shell. | unconverted |
@@ -125,28 +131,31 @@ Burndown manifest for the engine/UI decoupling ([RFC](../aetherd-headless-engine
 | `core/tnc/HeardList.h` | 1 | universal — Heard-station list for the packet monitor; radio-agnostic. | unconverted |
 | `core/tnc/KissTncServer.h` | 1 | ui-support — KISS-over-TCP server exposing the TNC to external apps; external integration, needs a home (cf CatPort/TciServer). | unconverted |
 | `core/tnc/TncTerminal.h` | 1 | universal — Packet terminal session model (command/monitor); radio-agnostic operating feature. | unconverted |
-| `models/AntennaGeniusModel.h` | 4 | peripheral(4o3a) — 4O3A Antenna Genius switch client (own UDP discovery + direct TCP); standalone accessory, not radio wire | reclassified (#4089) |
+| `models/AntennaGeniusModel.h` | 4 | peripheral(4o3a) — 4O3A Antenna Genius switch client — standalone accessory with its own UDP-broadcast discovery (port 9007) + direct TCP; connects by device IP/port independent of the radio, works with any radio. Not radio-family wire; a peripheral accessory, NOT behind the IRadioBackend radio seam (reclassified from vendor(flex), #4087 follow-up). | unconverted |
 | `models/BandDefs.h` | 4 | universal — Static ARRL band plan table (edges, default freq/mode, GEN/WWV); canonical band-plan data, no vendor ties. | unconverted |
 | `models/BandPlanManager.h` | 7 | universal — Band-plan overlay data (segments/spots/license classes, region merge) from JSON; radio-agnostic canon | unconverted |
-| `models/BandSettings.h` | 4 | universal — Per-band save/restore of canonical state (freq/mode/filter/AGC/WNB/display range) — band memories, no vendor fields | unconverted |
+| `models/BandSettings.h` | 5 | universal — Per-band save/restore of canonical state (freq/mode/filter/AGC/WNB/display range) — band memories, no vendor fields | unconverted |
 | `models/CwxModel.h` | 1 | universal — CW keyer intent: WPM/delay/QSK, 12 macros, send/erase, sent-index progress. Generic despite Flex 'CWX' name. | unconverted |
+| `models/DStarModel.h` | 1 | — | unconverted |
 | `models/DaxIqModel.h` | 1 | vendor(flex) — Flex DAX IQ streams: dax_iq stream create/rate cmds, 4-ch DAX model, pipes to SDR apps — DAX is Flex-only | unconverted |
+| `models/DigitalVoiceWaveformHistory.h` | 1 | — | unconverted |
 | `models/DvkModel.h` | 1 | mixed(flex) — Voice keyer slots/commands are core-profile; status parsing + FlexLib SsdrErrors mapping are flex. | unconverted |
 | `models/EqualizerModel.h` | 2 | universal — 8-band TX/RX audio EQ state (enable + band gains) — core capability; SmartSDR wire parsing/cmds move to flex adapter | unconverted |
 | `models/FlexWaveformModel.h` | 1 | vendor(flex) — FlexLib waveform/WFP container management: parses SmartSDR waveform status, emits Flex protocol commands | unconverted |
 | `models/MemoryEntry.h` | 1 | universal — POD memory-channel record (freq/mode/offset/tone/squelch/filter/digital offsets) — canonical memories surface | unconverted |
 | `models/MeterModel.h` | 6 | mixed(flex) — Meter registry+values are core-profile; VITA-49 raw scaling, TGXL/PGXL amp routing, COMPPEAK quirks are Flex | unconverted |
+| `models/ModelCapabilities.h` | 1 | — | unconverted |
 | `models/NetEntry.h` | 2 | ui-support — Net scheduler entry: RRULE/timezone/reminder metadata, operator-scoped local JSON; radio state only via embedded MemoryEntry | unconverted |
 | `models/PanadapterModel.h` | 2 | mixed(flex) — Per-pan display state is core-profile; DAX IQ ch, client_handle, VITA stream IDs, SmartSDR kv parsing are flex. | unconverted |
 | `models/ProfileLoadCommand.h` | 1 | vendor(flex) — Parses SmartSDR 'profile global/tx/mic load' wire command + recall-hold timing/suppression sentinels; Flex-only | unconverted |
-| `models/RadioModel.h` | 39 | mixed(flex) — Central radio aggregate: core slice/pan/TX/meter/memory state fused with Flex protocol, DAX, SmartLink, Multi-Flex | unconverted |
+| `models/RadioModel.h` | 40 | mixed(flex) — Central radio aggregate: core slice/pan/TX/meter/memory state fused with Flex protocol, DAX, SmartLink, Multi-Flex | unconverted |
 | `models/RadioSession.h` | 1 | universal — Per-radio session aggregate: owns RadioModel + id/label; session concept is core-profile, no vendor surface | unconverted |
 | `models/RadioStatusOwnership.h` | 1 | vendor(flex) — SmartSDR status parsing helpers: Flex hex handles, client_handle ownership, remote_audio_rx, interlock gate | unconverted |
-| `models/SliceModel.h` | 28 | mixed(flex) — Slice state (freq/mode/filter/DSP) is core-profile; DAX, index_letter, SmartSDR status KVs are flex ext | unconverted |
+| `models/SliceModel.h` | 29 | mixed(flex) — Slice state (freq/mode/filter/DSP) is core-profile; DAX, index_letter, SmartSDR status KVs are flex ext | unconverted |
 | `models/SpotModel.h` | 1 | universal — Panadapter spot store (callsign/freq/mode/lifetime/priority) on canonical state; kv ingest is trivially generic | unconverted |
 | `models/TnfModel.h` | 1 | universal — Tracking notch filter state (freq/width/depth/permanent, global enable) — generic DSP notch surface; kv parse is transport detail | unconverted |
 | `models/TransmitModel.h` | 14 | mixed(flex) — TX state model: power/MOX/VOX/CW/filter are core-profile; ATU, DAX, APD, profiles, interlock are Flex. | unconverted |
-| `models/TunerModel.h` | 3 | mixed(flex) — generic external-tuner model (state) fused with a Flex TGXL radio-relay; core stays, relay splits behind the seam | split pending (#4092) |
+| `models/TunerModel.h` | 3 | mixed(flex) — External-tuner state model, intended to become vendor-neutral (usable by any 3rd-party tuner). Fuses universal tuner state with Flex-specific TGXL wiring, so it's mixed — NOT peripheral (that's the transport TgxlConnection) and NOT pure vendor. Distinct from the radio's own built-in ATU (TransmitModel). | unconverted |
 | `models/XvtrPolicy.h` | 5 | mixed(flex) — XVTR policy: transverter list/freq translation is core; waterfall-tile offset + FLEX model power clamps are flex | unconverted |
 
-**Tag legend:** `universal` = core-profile surface every radio family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a namespaced extension (the EB3-gated set); `mixed` = header carries both (split candidates noted); `peripheral(<vendor>)` = a standalone accessory device's own transport/protocol (e.g. 4O3A Tgxl/Pgxl/AntennaGenius) — not the radio, not behind the radio seam; `ui-support` = not radio state at all (settings, theming, app plumbing, input surfaces) — needs a home decision, not a protocol message.
+**Tag legend:** `universal` = core-profile surface every radio family has; `vendor` = FlexRadio/SmartSDR-specific, becomes a namespaced extension; `mixed` = header carries both (split candidates noted); `ui-support` = not radio state at all (settings, theming, app plumbing) — needs a home decision, not a protocol message.

--- a/src/core/AcomConnection.cpp
+++ b/src/core/AcomConnection.cpp
@@ -1,0 +1,422 @@
+#include "AcomConnection.h"
+#include "LogManager.h"
+
+namespace AetherSDR {
+
+AcomConnection::AcomConnection(QObject* parent)
+    : QObject(parent)
+{
+    connect(&m_socket, &QTcpSocket::connected, this, &AcomConnection::onTransportUp);
+    connect(&m_socket, &QTcpSocket::disconnected, this, &AcomConnection::onTransportDown);
+    connect(&m_socket, &QTcpSocket::readyRead, this, &AcomConnection::onReadyRead);
+    connect(&m_socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError) {
+        onTransportError(m_socket.errorString());
+    });
+
+    m_parser.setFrameCallback([this](const Acom::Frame& f) { onFrameReceived(f); });
+
+    // Retries every 5s indefinitely until the amp returns or the user
+    // disconnects — matches PgxlConnection/TgxlConnection's precedent for a
+    // peripheral that may be power-cycling or, on the serial side, unplugged.
+    m_reconnectTimer.setSingleShot(true);
+    m_reconnectTimer.setInterval(5000);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, [this]() {
+        if (m_connected) { return; }
+        if (m_mode == Mode::Network && !m_lastHost.isEmpty()) {
+            connectNetwork(m_lastHost, m_lastPort);
+#ifdef HAVE_SERIALPORT
+        } else if (m_mode == Mode::Serial && !m_lastSerialPort.isEmpty()) {
+            connectSerial(m_lastSerialPort);
+#endif
+        }
+    });
+
+    m_keepaliveTimer.setInterval(200);
+    connect(&m_keepaliveTimer, &QTimer::timeout, this, [this]() {
+        if (!m_frameSeenSinceTick) {
+            sendRaw(Acom::buildTelemetryEnable());
+        }
+        m_frameSeenSinceTick = false;
+    });
+
+    // Model auto-detection request/retry (design doc §6). 800ms is generous
+    // relative to the protocol's own 10ms inter-message pacing — this is a
+    // one-shot query at connect time, not a latency-sensitive path, so
+    // there's no reason to race it.
+    m_systemConfigRetryTimer.setSingleShot(true);
+    m_systemConfigRetryTimer.setInterval(800);
+    connect(&m_systemConfigRetryTimer, &QTimer::timeout, this, &AcomConnection::sendSystemConfigRequest);
+}
+
+QString AcomConnection::description() const
+{
+    if (m_mode == Mode::Network) {
+        return QStringLiteral("%1:%2").arg(m_lastHost).arg(m_lastPort);
+    }
+#ifdef HAVE_SERIALPORT
+    if (m_mode == Mode::Serial) {
+        return m_lastSerialPort;
+    }
+#endif
+    return QString();
+}
+
+QString AcomConnection::sourceLabel() const
+{
+    switch (m_mode) {
+        case Mode::Network: return QStringLiteral("NETWORK");
+        case Mode::Serial:  return QStringLiteral("SERIAL");
+        default:            return QStringLiteral("—");
+    }
+}
+
+#ifdef HAVE_SERIALPORT
+void AcomConnection::connectSerial(const QString& portName)
+{
+    m_mode = Mode::Serial;
+    m_lastSerialPort = portName;
+    m_deliberateDisconnect = false;
+    m_reconnectTimer.stop();
+    teardownDevice();
+    m_parser.reset();
+
+    if (!m_serialPort) {
+        m_serialPort = new QSerialPort(this);
+        connect(m_serialPort, &QSerialPort::readyRead, this, &AcomConnection::onReadyRead);
+        connect(m_serialPort, &QSerialPort::errorOccurred, this,
+                [this](QSerialPort::SerialPortError err) {
+            if (err == QSerialPort::NoError) { return; }
+            const QString msg = m_serialPort->errorString();
+            qCWarning(lcTuner) << "AcomConnection: serial error" << err << msg;
+            onTransportError(msg);
+            if (m_connected) { onTransportDown(); }
+        });
+    }
+
+    m_serialPort->setPortName(portName);
+    // Fixed by the amplifier's own protocol spec — not user-configurable.
+    m_serialPort->setBaudRate(QSerialPort::Baud9600);
+    m_serialPort->setDataBits(QSerialPort::Data8);
+    m_serialPort->setParity(QSerialPort::NoParity);
+    m_serialPort->setStopBits(QSerialPort::OneStop);
+    m_serialPort->setFlowControl(QSerialPort::NoFlowControl);
+
+    if (!m_serialPort->open(QIODevice::ReadWrite)) {
+        const QString err = m_serialPort->errorString();
+        qCWarning(lcTuner) << "AcomConnection: failed to open" << portName << err;
+        emit connectionFailed(err);
+        if (m_autoReconnect) { armReconnect(); }
+        return;
+    }
+    // Hold DTR/RTS low — avoids interfering with the amplifier's own
+    // front-panel power-button logic (same precaution the open-source
+    // reference client takes; see THIRD_PARTY_LICENSES).
+    m_serialPort->setDataTerminalReady(false);
+    m_serialPort->setRequestToSend(false);
+
+    m_device = m_serialPort;
+    onTransportUp();
+}
+#endif
+
+void AcomConnection::connectNetwork(const QString& host, quint16 port)
+{
+    m_mode = Mode::Network;
+    m_lastHost = host;
+    m_lastPort = port;
+    m_deliberateDisconnect = false;
+    m_reconnectTimer.stop();
+    teardownDevice();
+    m_parser.reset();
+
+    m_device = &m_socket;
+    qCDebug(lcTuner) << "AcomConnection: connecting to" << host << ":" << port;
+    m_socket.connectToHost(host, port);
+    // onTransportUp() fires from the connected() signal (async).
+}
+
+void AcomConnection::disconnect()
+{
+    // Self-contained: don't depend on teardownDevice() indirectly triggering
+    // onTransportDown() to do this cleanup. It sometimes does (QTcpSocket::
+    // abort() synchronously emits disconnected()) and sometimes doesn't
+    // (QSerialPort::close() emits nothing at all) — relying on that meant a
+    // user-initiated disconnect silently never fired AcomConnection's own
+    // disconnected() signal on either transport, leaving the applet stuck
+    // showing "Connected" (its only disconnected() handler drives
+    // setAcomVisible(false)).
+    const bool wasConnected = m_connected;
+    m_deliberateDisconnect = true;
+    m_reconnectTimer.stop();
+    m_keepaliveTimer.stop();
+    m_systemConfigRetryTimer.stop();
+    m_connected = false;
+    teardownDevice();
+    m_parser.reset();
+    if (wasConnected) {
+        qCDebug(lcTuner) << "AcomConnection: disconnected";
+        emit disconnected();
+    }
+    m_deliberateDisconnect = false;
+}
+
+void AcomConnection::teardownDevice()
+{
+    if (m_device == &m_socket && m_socket.state() != QAbstractSocket::UnconnectedState) {
+        m_socket.abort();
+    }
+#ifdef HAVE_SERIALPORT
+    if (m_serialPort && m_device == m_serialPort && m_serialPort->isOpen()) {
+        m_serialPort->close();
+    }
+#endif
+    m_device = nullptr;
+}
+
+void AcomConnection::onTransportUp()
+{
+    m_connected = true;
+    m_frameSeenSinceTick = false;
+    m_telemetryDecodeFailed = false;
+    m_errorCodesDecodeFailed = false;
+    m_pendingAutoRangeTier.clear();
+    m_autoRangeStreak = 0;
+    qCInfo(lcTuner) << "AcomConnection: connected via" << description();
+    sendRaw(Acom::buildTelemetryEnable());
+    m_keepaliveTimer.start();
+
+    // Reset to the known-good starting tier on every fresh connect — never
+    // carries a prior session's auto-scaled tier forward (design doc §6).
+    m_currentModel = QStringLiteral("600S");
+    emit modelChanged(m_currentModel, QStringLiteral("default"));
+    requestSystemConfig();
+
+    emit connected();
+}
+
+void AcomConnection::onTransportDown()
+{
+    const bool wasConnected = m_connected;
+    m_connected = false;
+    m_keepaliveTimer.stop();
+    m_systemConfigRetryTimer.stop();
+    m_parser.reset();
+    if (wasConnected) {
+        qCDebug(lcTuner) << "AcomConnection: disconnected";
+        emit disconnected();
+    }
+    if (!m_deliberateDisconnect && m_autoReconnect) {
+        armReconnect();
+    }
+    m_deliberateDisconnect = false;
+}
+
+void AcomConnection::onTransportError(const QString& errorString)
+{
+    qCWarning(lcTuner) << "AcomConnection: transport error" << errorString;
+    emit connectionFailed(errorString);
+    if (!m_deliberateDisconnect && m_autoReconnect && !m_connected) {
+        armReconnect();
+    }
+}
+
+void AcomConnection::armReconnect()
+{
+    if (!m_reconnectTimer.isActive()) {
+        m_reconnectTimer.start();
+    }
+}
+
+void AcomConnection::onReadyRead()
+{
+    if (!m_device) { return; }
+    m_parser.feed(m_device->readAll());
+}
+
+void AcomConnection::onFrameReceived(const Acom::Frame& f)
+{
+    m_frameSeenSinceTick = true;
+
+    switch (static_cast<Acom::Address>(f.address)) {
+        case Acom::Address::Telemetry: {
+            // No 0x86 ack here — Telemetry is auto-pushed continuously (every
+            // ~100ms in practice), not requested. The spec's per-message
+            // resend-until-acked mandate (§1/§5.5) reads as written for a
+            // request/reply exchange; the MIT-licensed reference client (see
+            // THIRD_PARTY_LICENSES) never sends 0x86 for anything, on any
+            // message type, and is a documented-working real-hardware
+            // implementation over direct RS-232 — so acking isn't required to
+            // keep the push stream flowing, and continuously acking a
+            // ~10/s broadcast is the one place blanket-acking every frame
+            // type stopped making sense.
+            auto t = Acom::decodeTelemetry(f.data);
+            if (t) {
+                if (m_telemetryDecodeFailed) {
+                    qCInfo(lcTuner) << "AcomConnection: telemetry decode recovered"
+                                       " (" << f.data.size() << "B).";
+                    m_telemetryDecodeFailed = false;
+                }
+                m_lastTelemetry = *t;
+                emit telemetryUpdated(*t);
+                maybeAutoRangeUp(*t);
+            } else if (!m_telemetryDecodeFailed) {
+                // Checksum-valid frame the decoder rejected as too short. Without
+                // this the ACOM panel just stays blank — connected, frames
+                // arriving, gauges dead, nothing logged. Likely a firmware
+                // variant with a shorter telemetry frame, or link corruption.
+                // Latched (see m_telemetryDecodeFailed) so a permanently-short
+                // stream logs once, not at the ~10 Hz frame rate.
+                m_telemetryDecodeFailed = true;
+                qCWarning(lcTuner) << "AcomConnection: telemetry frame too short to"
+                                      " decode (" << f.data.size() << "B) — gauges will"
+                                      " stay blank. Firmware variant, or a corrupt link?";
+            }
+            break;
+        }
+        case Acom::Address::ErrorCodes:
+            // Also auto-pushed, not requested — same reasoning as Telemetry.
+            if (f.data.size() >= 20) {
+                if (m_errorCodesDecodeFailed) {
+                    m_errorCodesDecodeFailed = false;
+                }
+                emit rawErrorCodesUpdated(f.data);
+            } else if (!m_errorCodesDecodeFailed) {
+                m_errorCodesDecodeFailed = true;
+                qCWarning(lcTuner) << "AcomConnection: error-codes frame too short"
+                                      " (" << f.data.size() << "B, need >= 20) — fault"
+                                      " state won't update. Firmware variant?";
+            }
+            break;
+        case Acom::Address::SystemConfig: {
+            // SystemConfig, unlike Telemetry/ErrorCodes, is a genuine one-shot
+            // request/reply (see buildRequestMessage/sendSystemConfigRequest's
+            // own retry-with-timeout) — acking it matches the spec's
+            // resend-until-acked model for that exchange shape.
+            sendRaw(Acom::buildAck(f.address));
+            m_systemConfigRetryTimer.stop();
+            auto cfg = Acom::decodeSystemConfig(f.data);
+            if (cfg) {
+                qCInfo(lcTuner) << "AcomConnection: SystemConfig — amplifierType="
+                                 << cfg->amplifierType << "fw=" << cfg->fwVersion << "."
+                                 << cfg->fwSubVersion << "serial=" << cfg->serialNumberHex
+                                 << "hardFaults=" << cfg->hardFaultCount;
+                emit systemConfigReceived(*cfg);
+
+                const QString confirmed = Acom::modelNameForAmplifierType(cfg->amplifierType);
+                if (confirmed.isEmpty()) {
+                    qCInfo(lcTuner) << "AcomConnection: unrecognized amplifierType"
+                                     << cfg->amplifierType
+                                     << "— no confirmed mapping yet; relying on auto-ranging."
+                                        " Please report this value if you know your model"
+                                        " (see docs/architecture/acom-600s-amplifier-design.md).";
+                    break;
+                }
+                // Same up-only guard as maybeAutoRangeUp(): a genuine but
+                // delayed SystemConfig reply (the request/retry sequence can
+                // take up to ~4s) must never snap the tier back down below
+                // whatever auto-ranging has already confirmed from observed
+                // power in the meantime — see design doc §6.3 point 4 and
+                // this class's own currentModel() doc comment.
+                const auto& order = Acom::orderedModelTiers();
+                if (order.indexOf(confirmed) < order.indexOf(m_currentModel)) {
+                    qCInfo(lcTuner) << "AcomConnection: SystemConfig confirms" << confirmed
+                                     << "but auto-ranging already established" << m_currentModel
+                                     << "from observed power — keeping the higher tier.";
+                    break;
+                }
+                // Either a genuine change (including the common case:
+                // default "600S" -> confirmed "600S", same name but the GUI
+                // still wants the reason to change for its diagnostic
+                // tooltip) or confirming the tier auto-ranging already
+                // reached — either way it's now "confirmed", not "default"
+                // or "auto-scaled".
+                m_currentModel = confirmed;
+                emit modelChanged(m_currentModel, QStringLiteral("confirmed"));
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+void AcomConnection::requestSystemConfig()
+{
+    m_systemConfigAttempts = 0;
+    sendSystemConfigRequest();
+}
+
+void AcomConnection::sendSystemConfigRequest()
+{
+    if (m_systemConfigAttempts >= kSystemConfigMaxAttempts) {
+        qCInfo(lcTuner) << "AcomConnection: gave up requesting SystemConfig after"
+                         << kSystemConfigMaxAttempts << "attempts — amp may not support"
+                            " this query on its firmware; auto-ranging still applies.";
+        return;
+    }
+    ++m_systemConfigAttempts;
+    qCDebug(lcTuner) << "AcomConnection: requesting SystemConfig, attempt"
+                      << m_systemConfigAttempts << "of" << kSystemConfigMaxAttempts;
+    sendRaw(Acom::buildRequestMessage(static_cast<quint8>(Acom::Address::SystemConfig)));
+    m_systemConfigRetryTimer.start();
+}
+
+void AcomConnection::maybeAutoRangeUp(const Acom::Telemetry& t)
+{
+    const QString required = Acom::tierForForwardPower(static_cast<float>(t.forwardPowerW));
+    const auto& order = Acom::orderedModelTiers();
+    if (order.indexOf(required) <= order.indexOf(m_currentModel)) {
+        // At/above the required tier already — reset any in-progress streak so a
+        // lone spike followed by normal readings doesn't accumulate across gaps.
+        m_autoRangeStreak = 0;
+        m_pendingAutoRangeTier.clear();
+        return;  // never downgrades
+    }
+
+    // Debounce before ratcheting: the tier only ever moves UP and never back
+    // down within a session, so acting on a single frame means one corrupt-
+    // but-checksum-valid reading (the 8-bit checksum passes ~1/256 of corrupted
+    // frames) over-ranges every gauge irreversibly until reconnect. Require the
+    // SAME higher tier on kAutoRangeConsecutiveFrames consecutive frames — a
+    // spurious spike won't repeat; a genuinely bigger amp will.
+    if (required != m_pendingAutoRangeTier) {
+        m_pendingAutoRangeTier = required;
+        m_autoRangeStreak = 1;
+        return;
+    }
+    if (++m_autoRangeStreak < kAutoRangeConsecutiveFrames) {
+        return;
+    }
+
+    qCInfo(lcTuner) << "AcomConnection: observed" << t.forwardPowerW
+                     << "W forward power exceeds" << m_currentModel << "tier ceiling on"
+                     << m_autoRangeStreak << "consecutive frames — auto-scaling up to"
+                     << required;
+    m_currentModel = required;
+    m_autoRangeStreak = 0;
+    m_pendingAutoRangeTier.clear();
+    emit modelChanged(m_currentModel, QStringLiteral("auto-scaled"));
+}
+
+void AcomConnection::sendRaw(const QByteArray& frame)
+{
+    if (!m_device || !m_connected) { return; }
+    m_device->write(frame);
+}
+
+void AcomConnection::setOperate(bool on)
+{
+    sendRaw(Acom::buildModeCommand(on ? Acom::ModeCommand::Operate : Acom::ModeCommand::Standby));
+}
+
+void AcomConnection::powerOff()
+{
+    sendRaw(Acom::buildModeCommand(Acom::ModeCommand::PowerOff));
+}
+
+void AcomConnection::clearFaults()
+{
+    sendRaw(Acom::buildClearFaultsCommand());
+}
+
+}  // namespace AetherSDR

--- a/src/core/AcomConnection.h
+++ b/src/core/AcomConnection.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <QByteArray>
+#include <QObject>
+#include <QString>
+#include <QTcpSocket>
+#include <QTimer>
+
+#ifdef HAVE_SERIALPORT
+#include <QSerialPort>
+#endif
+
+#include "AcomProtocol.h"
+
+namespace AetherSDR {
+
+// Peripheral transport for an ACOM S-series amplifier (500S/600S/700S/1200S/
+// 2020S) — a standalone RS-232 device with no FlexRadio awareness at all, so
+// this is a peripheral(acom) accessory alongside PgxlConnection/TgxlConnection,
+// not an IRadioBackend implementor. See
+// docs/architecture/acom-600s-amplifier-design.md for the full design note.
+//
+// The wire protocol is binary and transport-agnostic — the exact same bytes
+// flow whether the peer is a local COM port or a raw-mode ser2net TCP proxy —
+// so a single Acom::FrameParser instance decodes either transport. Only one
+// transport is active at a time, selected by which connect method is called.
+class AcomConnection : public QObject {
+    Q_OBJECT
+
+public:
+    explicit AcomConnection(QObject* parent = nullptr);
+
+    bool isConnected() const { return m_connected; }
+    QString description() const;  // "COM4" or "192.168.1.52:7000", for status display
+    // "SERIAL" / "NETWORK" for the applet's compact source label — derived from
+    // the LIVE transport (m_mode), never the persisted ConnectionMode setting.
+    // The two can diverge: switching the Radio Setup mode combo persists the
+    // setting without disconnecting, so a serial link that later auto-reconnects
+    // would be mislabelled "NETWORK" if the label came from the setting.
+    QString sourceLabel() const;
+
+#ifdef HAVE_SERIALPORT
+    // Fixed 9600 8N1, no handshake — mandated by the amplifier's own spec,
+    // not user-configurable.
+    void connectSerial(const QString& portName);
+#endif
+    // Network mode assumes a RAW TCP proxy (e.g. ser2net `connection type: raw`).
+    // A telnet-mode proxy will IAC-escape byte 0xFF, which appears legitimately
+    // in this protocol (e.g. errorCode 0xFF = "no fault") and will corrupt the
+    // stream.
+    void connectNetwork(const QString& host, quint16 port);
+    void disconnect();
+
+    void setAutoReconnect(bool on) { m_autoReconnect = on; }
+
+    // Commands (host -> amp). No-ops when not connected.
+    void setOperate(bool on);
+    void powerOff();
+    void clearFaults();
+
+    const Acom::Telemetry& lastTelemetry() const { return m_lastTelemetry; }
+
+    // Effective model tier right now — starts at "600S" (our one confirmed
+    // model) on every fresh connect, and only ever moves UP (auto-ranging;
+    // see modelChanged) or gets confirmed by a SystemConfig reply. Never
+    // reset mid-session, only on reconnect. See design doc §6.
+    QString currentModel() const { return m_currentModel; }
+
+signals:
+    void connected();
+    void disconnected();
+    void connectionFailed(const QString& errorString);
+    void telemetryUpdated(const AetherSDR::Acom::Telemetry& telemetry);
+    // Raw 10-word (20-byte) error-code bitmask from address 0x21. Per-bit
+    // decode into named faults is a documented follow-up (see AcomProtocol.h);
+    // the single "currently displayed" fault is already available via
+    // telemetryUpdated()'s Telemetry::errorCode.
+    void rawErrorCodesUpdated(const QByteArray& tenWords);
+    // Fires once on every connect ("default"), again if a SystemConfig reply
+    // confidently identifies the model ("confirmed"), and again any time
+    // observed forward power outgrows the current tier ("auto-scaled"). The
+    // GUI re-applies gauge ranges each time rather than just once at connect.
+    void modelChanged(const QString& modelName, const QString& reason);
+    // One-shot PCB versions/type/serial from a 0x11 reply, surfaced mainly
+    // for the diagnostic tooltip and for users to report an unrecognized
+    // amplifierType back to the project (see design doc §6).
+    void systemConfigReceived(const AetherSDR::Acom::SystemConfig& config);
+
+private slots:
+    void onReadyRead();
+
+private:
+    enum class Mode { None, Serial, Network };
+
+    void onTransportUp();
+    void onTransportDown();
+    void onTransportError(const QString& errorString);
+    void onFrameReceived(const Acom::Frame& frame);
+    void teardownDevice();
+    void sendRaw(const QByteArray& frame);
+    void armReconnect();
+    void requestSystemConfig();       // resets attempt counter, sends first request
+    void sendSystemConfigRequest();   // one attempt; re-armed by the retry timer
+    void maybeAutoRangeUp(const Acom::Telemetry& t);
+
+    QIODevice*    m_device{nullptr};
+    QTcpSocket    m_socket;
+#ifdef HAVE_SERIALPORT
+    QSerialPort*  m_serialPort{nullptr};
+#endif
+
+    Acom::FrameParser m_parser;
+    Acom::Telemetry   m_lastTelemetry;
+
+    Mode      m_mode{Mode::None};
+    QString   m_lastSerialPort;
+    QString   m_lastHost;
+    quint16   m_lastPort{0};
+
+    bool m_connected{false};
+    bool m_autoReconnect{false};
+    bool m_deliberateDisconnect{false};
+    bool m_frameSeenSinceTick{false};
+
+    QTimer m_reconnectTimer;
+    // Re-arms telemetry push if the amp goes quiet (it doesn't confirm the
+    // enable command stuck) — same keepalive cadence as the open-source
+    // reference client this protocol was cross-checked against (see
+    // THIRD_PARTY_LICENSES).
+    QTimer m_keepaliveTimer;
+
+    QString m_currentModel{QStringLiteral("600S")};  // see currentModel()/modelChanged
+    QTimer  m_systemConfigRetryTimer;
+    int     m_systemConfigAttempts{0};
+    static constexpr int kSystemConfigMaxAttempts = 5;  // spec's own retry ceiling (§1)
+
+    // Latched so an undersized-frame diagnostic is logged once on the
+    // transition into failure, not on every ~10 Hz frame — a firmware variant
+    // whose frames are permanently too short would otherwise flood the log
+    // indefinitely. Reset on a successful decode (recovery) and on reconnect.
+    bool m_telemetryDecodeFailed{false};
+    bool m_errorCodesDecodeFailed{false};
+
+    // Auto-range debounce: a single checksum-valid-but-corrupt frame with a
+    // spurious forwardPowerW would otherwise ratchet the gauge scaling up
+    // irreversibly for the whole session. Require the reading to clear the
+    // current tier's ceiling on this many consecutive frames before bumping.
+    static constexpr int kAutoRangeConsecutiveFrames = 2;
+    QString m_pendingAutoRangeTier;
+    int     m_autoRangeStreak{0};
+};
+
+}  // namespace AetherSDR

--- a/src/core/AcomProtocol.cpp
+++ b/src/core/AcomProtocol.cpp
@@ -1,0 +1,343 @@
+#include "AcomProtocol.h"
+
+#include <QMap>
+
+namespace AetherSDR {
+namespace Acom {
+
+namespace {
+
+quint16 le16(const QByteArray& d, int offset)
+{
+    return static_cast<quint16>(static_cast<quint8>(d.at(offset)))
+         | (static_cast<quint16>(static_cast<quint8>(d.at(offset + 1))) << 8);
+}
+
+// LPF band names indexed by the telemetry frame's 4-bit "active FLP channel"
+// field (Byte 69 low nibble). 16 entries — indices beyond the spec's
+// documented 0..10 are reserved/unused on hardware seen so far.
+const QStringList& bandTable()
+{
+    static const QStringList table = {
+        "?m", "160m", "80m", "40/60m", "30m", "20m",
+        "17m", "15m", "12m", "10m", "6m", "4m",
+        "?m", "?m", "?m", "?m",
+    };
+    return table;
+}
+
+// 600S is the only row verified against real hardware. The others are
+// derived, not measured — methodology (design doc §6):
+//   - Nominal (rated output): ACOM's own current published spec sheets
+//     (acom-bg.com product pages), NOT the model name and NOT the public
+//     reference client's constants. Both of those turned out to be wrong
+//     for the higher-power models: the model name is not the rated wattage
+//     (1200S is rated 1000W, 2020S is rated 1500W), and the reference
+//     client's embedded constants (1200S=1200W, 2020S=1800W) don't match
+//     ACOM's current official specs either.
+//   - Max (gauge red-zone ceiling): where the model name is exactly
+//     "rated + 200W" (1200S, 1400S), the name itself is used as a round-
+//     number ceiling. Where it isn't (500S/600S/700S have name == rated;
+//     2020S's name doesn't fit the +200W pattern at all), the ceiling is
+//     the 600S's own confirmed max/nominal ratio (700/600, rounded) applied
+//     to that model's rated wattage instead.
+//   - Reflected power (nominal/max): no public source exists at all: derived
+//     proportionally from the 600S's confirmed reflected/forward ratios
+//     (114/600 nominal, 150/700 max) applied to each model's forward figures.
+//   - Temperature offset / hasPam2: carried from the reference client where
+//     no better source exists; defaulted to the majority value (282 / no
+//     PAM2 assumption based on power class) for 1400S, which the reference
+//     client doesn't cover at all.
+// None of this is a substitute for real confirmation. See AcomConnection's
+// auto-ranging (tierForForwardPower) for how the UI stays correct even when
+// these constants are wrong, and modelNameForAmplifierType for how little of
+// the identification problem the wire protocol itself actually solves.
+const QMap<QString, ModelSpec>& modelTable()
+{
+    static const QMap<QString, ModelSpec> table = {
+        {"500S",  ModelSpec{"500S",   500.0f,  600.0f,  95.0f, 129.0f, 282, false}},
+        {"600S",  ModelSpec{"600S",   600.0f,  700.0f, 114.0f, 150.0f, 273, false}},
+        {"700S",  ModelSpec{"700S",   700.0f,  800.0f, 133.0f, 171.0f, 282, false}},
+        {"1200S", ModelSpec{"1200S", 1000.0f, 1200.0f, 190.0f, 257.0f, 281, true}},
+        {"1400S", ModelSpec{"1400S", 1200.0f, 1400.0f, 228.0f, 300.0f, 282, true}},
+        {"2020S", ModelSpec{"2020S", 1500.0f, 1750.0f, 285.0f, 375.0f, 282, true}},
+    };
+    return table;
+}
+
+// Ascending power order — both by nominal and by max (the two orderings
+// agree), so one list drives auto-ranging.
+const QStringList& tierOrder()
+{
+    static const QStringList order = {"500S", "600S", "700S", "1200S", "1400S", "2020S"};
+    return order;
+}
+
+}  // namespace
+
+QString modeName(Mode mode)
+{
+    switch (mode) {
+        case Mode::Reset:     return QStringLiteral("RESET");
+        case Mode::Init:      return QStringLiteral("INIT");
+        case Mode::Debug:     return QStringLiteral("DEBUG");
+        case Mode::Service:   return QStringLiteral("SERVICE");
+        case Mode::Standby:   return QStringLiteral("STANDBY");
+        case Mode::OperateRx: return QStringLiteral("OPR/RX");
+        case Mode::OperateTx: return QStringLiteral("OPR/TX");
+        case Mode::Atac:      return QStringLiteral("ATAC");
+        case Mode::SetParams: return QStringLiteral("SET PARAMS");
+        case Mode::PowerOff:  return QStringLiteral("OFF");
+        default:              return QStringLiteral("UNKNOWN");
+    }
+}
+
+quint8 checksum(const QByteArray& frameWithoutChecksum)
+{
+    quint8 sum = 0;
+    for (char c : frameWithoutChecksum)
+        sum = static_cast<quint8>(sum - static_cast<quint8>(c));
+    return sum;
+}
+
+QByteArray buildFrame(quint8 address, const QByteArray& data)
+{
+    QByteArray frame;
+    frame.append(static_cast<char>(kStartByte));
+    frame.append(static_cast<char>(address));
+    frame.append(static_cast<char>(4 + data.size()));  // start+address+length+checksum + data
+    frame.append(data);
+    frame.append(static_cast<char>(checksum(frame)));
+    return frame;
+}
+
+void FrameParser::feed(const QByteArray& bytes)
+{
+    m_buf.append(bytes);
+
+    while (true) {
+        int start = m_buf.indexOf(static_cast<char>(kStartByte));
+        if (start < 0) {
+            m_buf.clear();
+            return;
+        }
+        if (start > 0)
+            m_buf.remove(0, start);
+
+        if (m_buf.size() < 3)
+            return;  // need start+address+length to know how big this frame is
+
+        const quint8 length = static_cast<quint8>(m_buf.at(2));
+        if (length < 4 || length > kMaxFrameLength) {
+            // Not a real frame length — this 0x55 was noise (or a bit-flip
+            // produced an implausible size). Resync to the next 0x55 rather than
+            // buffering toward a length that will never resolve.
+            if (!resyncToNextStart())
+                return;
+            continue;
+        }
+        if (m_buf.size() < length)
+            return;  // wait for the rest of the frame to arrive
+
+        const QByteArray candidate = m_buf.left(length);
+        const quint8 expected = checksum(candidate.left(length - 1));
+        if (expected == static_cast<quint8>(candidate.at(length - 1))) {
+            Frame f;
+            f.address = static_cast<quint8>(candidate.at(1));
+            f.data = candidate.mid(3, length - 4);
+            if (m_onFrame)
+                m_onFrame(f);
+            m_buf.remove(0, length);
+        } else {
+            // Checksum mismatch: either this 0x55 was payload data, not a real
+            // start byte, or the frame was corrupted in transit. Resync to the
+            // next 0x55 — a genuine frame's start byte may still be later.
+            if (!resyncToNextStart())
+                return;
+        }
+    }
+}
+
+bool FrameParser::resyncToNextStart()
+{
+    const int next = m_buf.indexOf(static_cast<char>(kStartByte), 1);
+    if (next < 0) {
+        m_buf.clear();
+        return false;
+    }
+    m_buf.remove(0, next);
+    return true;
+}
+
+std::optional<Telemetry> decodeTelemetry(const QByteArray& payload)
+{
+    if (payload.size() < 68)
+        return std::nullopt;
+
+    Telemetry t;
+    t.mode                   = static_cast<Mode>((static_cast<quint8>(payload.at(0)) & 0xF0) >> 4);
+    t.dcPowerPam1_x10W       = le16(payload, 5);
+    {
+        const quint16 hw = le16(payload, 9);
+        const quint16 lw = le16(payload, 11);
+        t.systemClockSec = (static_cast<quint32>(hw) << 16) | lw;
+    }
+    t.paTempRaw              = le16(payload, 13);
+    t.inputPower_x10W        = le16(payload, 17);
+    t.forwardPowerW          = le16(payload, 19);
+    t.reflectedPowerW        = le16(payload, 21);
+    t.swr_x100                = le16(payload, 23);
+    t.dissipationPam1_x10W   = le16(payload, 25);
+    t.vcc5_mV                 = le16(payload, 33);
+    t.vcc26_x10V              = le16(payload, 35);
+    t.hv1_x10V                = le16(payload, 37);
+    t.id1_mA                  = le16(payload, 41);
+    t.carrierFreqKHz          = le16(payload, 45);
+    t.errorCode               = static_cast<quint8>(payload.at(63));
+    t.errorParam               = le16(payload, 64);
+    {
+        const quint8 fanBand = static_cast<quint8>(payload.at(66));
+        t.fanSpeed   = (fanBand & 0xF0) >> 4;
+        t.activeBand = fanBand & 0x0F;
+    }
+    return t;
+}
+
+QString bandName(int index)
+{
+    const auto& table = bandTable();
+    if (index < 0 || index >= table.size())
+        return QStringLiteral("?m");
+    return table.at(index);
+}
+
+QString errorCodeName(quint8 code)
+{
+    switch (code) {
+        case 0xFF: return QStringLiteral("No fault");
+        case 0x00:
+        case 0x08: return QStringLiteral("Hot switching");
+        case 0x03: return QStringLiteral("Drive power at wrong time");
+        case 0x04:
+        case 0x05: return QStringLiteral("Reflected power warning");
+        case 0x06:
+        case 0x07: return QStringLiteral("Drive power too high");
+        case 0x0C: return QStringLiteral("RF power at wrong time");
+        case 0x0E: return QStringLiteral("Stop transmission first");
+        case 0x0F: return QStringLiteral("Remove drive power");
+        case 0x24:
+        case 0x25:
+        case 0x39:
+        case 0x44:
+        case 0x45:
+        case 0x59: return QStringLiteral("Excessive PAM current");
+        case 0x70: return QStringLiteral("CAT error");
+        default:   return QStringLiteral("Fault — see amplifier display");
+    }
+}
+
+QByteArray buildModeCommand(ModeCommand cmd)
+{
+    QByteArray data;
+    data.append(static_cast<char>(0x02));  // sub-command: request amplifier mode change
+    data.append(static_cast<char>(0x00));  // param (HW) — not used for mode change
+    data.append(static_cast<char>(static_cast<quint8>(cmd)));  // param (LW) — desired mode
+    data.append(static_cast<char>(0x00));  // keyboard state — not applicable from software
+    return buildFrame(static_cast<quint8>(Address::Command), data);
+}
+
+QByteArray buildClearFaultsCommand()
+{
+    QByteArray data;
+    data.append(static_cast<char>(0x08));  // sub-command: clear soft faults
+    data.append(static_cast<char>(0x00));
+    data.append(static_cast<char>(0x00));
+    data.append(static_cast<char>(0x00));
+    return buildFrame(static_cast<quint8>(Address::Command), data);
+}
+
+QByteArray buildTelemetryEnable()
+{
+    return buildFrame(static_cast<quint8>(Address::TelemetryEnable));
+}
+
+QByteArray buildTelemetryDisable()
+{
+    return buildFrame(static_cast<quint8>(Address::TelemetryDisable));
+}
+
+QByteArray buildAck(quint8 receivedMessageNumber)
+{
+    QByteArray data;
+    data.append(static_cast<char>(receivedMessageNumber));
+    return buildFrame(static_cast<quint8>(Address::Ack), data);
+}
+
+QByteArray buildRequestMessage(quint8 desiredAddress)
+{
+    QByteArray data;
+    data.append(static_cast<char>(desiredAddress));
+    return buildFrame(static_cast<quint8>(Address::RequestMessage), data);
+}
+
+const ModelSpec& modelSpec(const QString& modelName)
+{
+    const auto& table = modelTable();
+    auto it = table.constFind(modelName);
+    if (it != table.constEnd())
+        return it.value();
+    return table.constFind(QStringLiteral("600S")).value();  // safe fallback
+}
+
+QStringList modelNames()
+{
+    return modelTable().keys();
+}
+
+QStringList orderedModelTiers()
+{
+    return tierOrder();
+}
+
+QString tierForForwardPower(float watts)
+{
+    const auto& order = tierOrder();
+    // Small margin so a reading right at a tier's ceiling doesn't immediately
+    // demand the next tier up — avoids boundary flapping on ordinary peaks.
+    constexpr float kMargin = 1.02f;
+    for (const QString& name : order) {
+        if (watts <= modelSpec(name).maxForwardW * kMargin)
+            return name;
+    }
+    return order.last();  // exceeds even the top tier — clamp, don't guess higher
+}
+
+std::optional<SystemConfig> decodeSystemConfig(const QByteArray& payload)
+{
+    if (payload.size() < 26)
+        return std::nullopt;
+
+    SystemConfig cfg;
+    cfg.amplifierType = static_cast<quint8>(payload.at(0));
+    cfg.fwVersion     = static_cast<quint8>(payload.at(1));
+    cfg.fwSubVersion  = static_cast<quint8>(payload.at(2));
+
+    QByteArray serial = payload.mid(13, 12);
+    cfg.serialNumberHex = QString::fromLatin1(serial.toHex());
+    cfg.hardFaultCount = static_cast<quint8>(payload.at(25));
+    return cfg;
+}
+
+QString modelNameForAmplifierType(quint8 amplifierType)
+{
+    // Only type 1 is documented by the spec ("1 - A600S"). Every other
+    // value is a genuine unknown, not a guess dressed up as one — see the
+    // modelTable() comment and design doc §6 for why the rest of the line
+    // is covered by auto-ranging instead of a type-code table.
+    if (amplifierType == 1)
+        return QStringLiteral("600S");
+    return QString();
+}
+
+}  // namespace Acom
+}  // namespace AetherSDR

--- a/src/core/AcomProtocol.h
+++ b/src/core/AcomProtocol.h
@@ -1,0 +1,251 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+#include <QByteArray>
+#include <QMetaType>
+#include <QString>
+#include <QStringList>
+
+namespace AetherSDR {
+
+// ACOM S-series (500S/600S/700S/1200S/1400S/2020S) RS-232 amplifier protocol.
+//
+// Protocol authority: "RF Amplifier ACOM 600S Serial Port Communication
+// Protocol", v1.1 (2014-12-04), eng. Nikolay Nenov — the manufacturer's own
+// published spec (see docs/architecture/acom-600s-amplifier-design.md and
+// THIRD_PARTY_LICENSES for the full provenance record). Framing is identical
+// across the whole S-series; only power-scaling constants and PAM2-field
+// presence differ per model (see AcomModelSpec below).
+//
+// Wire framing (both directions):
+//   | 0x55 | Address | Length | ...Data... | Checksum |
+// Length counts every byte in the frame including the start byte and the
+// checksum itself. Checksum = 256 - (sum of all prior bytes & 0xFF); a
+// valid frame's full byte sum is 0 mod 256.
+namespace Acom {
+
+constexpr quint8 kStartByte = 0x55;
+
+// The spec caps every message at 72 bytes; anything claiming to be larger
+// is noise (or a bit-flip) rather than a real frame length.
+constexpr quint8 kMaxFrameLength = 72;
+
+// Message addresses this implementation understands. The spec defines many
+// more (CAT passthrough config, manual band/antenna override, buzzer, LOG
+// dump, service-mode tests, factory reset) — deliberately not implemented;
+// see docs/architecture/acom-600s-amplifier-design.md §4 for why.
+enum class Address : quint8 {
+    SystemConfig     = 0x11,  // amp -> host, PCB versions/amplifier type/serial — one-shot, on request only
+    Telemetry        = 0x2F,  // amp -> host, 72 B unified status
+    ErrorCodes       = 0x21,  // amp -> host, 10-word fault bitmask
+    RequestMessage   = 0x02,  // host -> amp, "send me message N" (used to request SystemConfig)
+    Command          = 0x81,  // host -> amp, mode-change / clear-faults envelope
+    TelemetryDisable = 0x91,  // host -> amp
+    TelemetryEnable  = 0x92,  // host -> amp
+    Ack              = 0x86,  // either direction, per-message acknowledgement
+};
+
+// Amplifier operating mode, decoded from the telemetry frame's mode byte
+// high nibble (Byte 3, upper nibble). Values below 0x1..0xA per spec §3.4.8.
+enum class Mode : quint8 {
+    Reset      = 0x1,
+    Init       = 0x2,
+    Debug      = 0x3,
+    Service    = 0x4,
+    Standby    = 0x5,
+    OperateRx  = 0x6,
+    OperateTx  = 0x7,
+    Atac       = 0x8,  // antenna-tune/change procedure in progress
+    SetParams  = 0x9,
+    PowerOff   = 0xA,
+    Unknown    = 0x0,
+};
+
+// Mode-change targets accepted by Command sub-command 0x02 (spec §5.1).
+enum class ModeCommand : quint8 {
+    Standby  = 0x05,
+    Operate  = 0x06,
+    PowerOff = 0x0A,
+};
+
+QString modeName(Mode mode);
+
+// ── Framing ──────────────────────────────────────────────────────────────
+
+// Checksum over every byte of the frame EXCLUDING the checksum byte itself.
+// A complete, valid frame (checksum byte included) sums to 0 mod 256.
+quint8 checksum(const QByteArray& frameWithoutChecksum);
+
+// Builds a complete, checksummed frame: 0x55, address, length, data..., checksum.
+QByteArray buildFrame(quint8 address, const QByteArray& data = {});
+
+// A single decoded, checksum-valid frame.
+struct Frame {
+    quint8     address{0};
+    QByteArray data;  // payload only — excludes start/address/length/checksum
+};
+
+// Streaming byte-oriented parser. Feed it raw bytes from any transport
+// (QSerialPort or QTcpSocket — the wire format is identical either way);
+// it resyncs on the 0x55 start byte whenever a candidate frame's checksum
+// fails, so garbage/partial data from a flaky link self-heals rather than
+// desyncing permanently. Deliberately has zero Qt-networking dependency so
+// it's unit-testable against captured byte sequences without a live device.
+class FrameParser {
+public:
+    void setFrameCallback(std::function<void(const Frame&)> cb) { m_onFrame = std::move(cb); }
+    void feed(const QByteArray& bytes);
+    void reset() { m_buf.clear(); }
+
+private:
+    // Called with a rejected start byte (bad length or bad checksum) at buffer
+    // position 0: drops from it to the next 0x55 in a single shift, so a run of
+    // 0x55 noise resyncs in one O(n) pass rather than O(n^2) (a byte-at-a-time
+    // drop shifts the whole buffer per byte). Returns false and empties the
+    // buffer when no further start byte remains.
+    bool resyncToNextStart();
+
+    QByteArray m_buf;
+    std::function<void(const Frame&)> m_onFrame;
+};
+
+// ── Telemetry decode (address 0x2F, 72 bytes) ───────────────────────────
+
+// Raw wire values, exactly as the spec defines each field — no per-model
+// scaling or unit conversion applied here (that needs AcomModelSpec, which
+// this layer has no knowledge of). See AmpModel/GUI layer for the
+// model-aware interpretation (temperature offset, gauge nominal/max).
+struct Telemetry {
+    Mode    mode{Mode::Unknown};
+
+    quint16 dcPowerPam1_x10W{0};      // Byte 8-9,   [10 x W]
+    quint32 systemClockSec{0};        // Byte 12-15, [s] — a cumulative total-
+                                       //   operating-time counter, NOT time
+                                       //   since the last power-on; confirmed
+                                       //   against a real 600S (front-panel
+                                       //   127:43:17 H:MM:SS matched the
+                                       //   decoded 459,797s exactly, ruling
+                                       //   out a high/low word swap too)
+    quint16 paTempRaw{0};             // Byte 16-17, raw sensor units (subtract the
+                                       //   model's TemperatureOffset for real degC)
+    quint16 inputPower_x10W{0};       // Byte 20-21, [10 x W]
+    quint16 forwardPowerW{0};         // Byte 22-23, [W]
+    quint16 reflectedPowerW{0};       // Byte 24-25, [W]
+    quint16 swr_x100{0};              // Byte 26-27, [100x] — divide by 100 for ratio
+    quint16 dissipationPam1_x10W{0};  // Byte 28-29, [10 x W]
+    quint16 vcc5_mV{0};               // Byte 36-37, [mV]
+    quint16 vcc26_x10V{0};            // Byte 38-39, [10 x V]
+    quint16 hv1_x10V{0};              // Byte 40-41, [10 x V]
+    quint16 id1_mA{0};                // Byte 44-45, [mA] — PA drain current
+    quint16 carrierFreqKHz{0};        // Byte 48-49, [kHz] — amp's own frequency counter
+
+    quint8  fanSpeed{0};              // Byte 69 high nibble, 0..4
+    quint8  activeBand{0};            // Byte 69 low nibble — index into bandName()
+
+    quint8  errorCode{0xFF};          // Byte 66 — 0xFF means no active alarm
+    quint16 errorParam{0};            // Byte 67-68
+};
+
+// Decodes a 0x2F Telemetry frame's payload (Frame::data, i.e. bytes 3..70 of
+// the full 72-byte message — start/address/length/checksum already stripped
+// by FrameParser). Returns nullopt if the payload is short.
+std::optional<Telemetry> decodeTelemetry(const QByteArray& payload);
+
+// LPF band name for Telemetry::activeBand (spec §3.3.7 / the 4-bit "Active
+// FLP channel" field in the telemetry frame). Index 0 and 11-15 are reserved
+// ("?m" in the amp's own display convention).
+QString bandName(int index);
+
+// Human-readable name for Telemetry::errorCode (Byte 66 of 0x2F — the
+// single currently-displayed alarm condition). This is a small, verified
+// subset (cross-checked against both the spec's bit-name table in message
+// 0x21 and a working open-source reference client — see
+// docs/architecture/acom-600s-amplifier-design.md and THIRD_PARTY_LICENSES)
+// covering the faults an operator is actually likely to see. The full 0x21
+// message carries ~80 independently-named bits across 10 words for a
+// complete fault dashboard; that full table is a documented follow-up, not
+// transcribed here yet — see the design doc's provenance notes on why a
+// partial, verified table beats a large, unverified one.
+QString errorCodeName(quint8 code);
+
+// ── System config decode (address 0x11, one-shot on request) ────────────
+
+// PCB versions / amplifier type / serial number. Not pushed automatically
+// like Telemetry — the host must ask for it (see buildRequestMessage).
+// Amplifier type is the only field this project uses programmatically
+// (model auto-detection, §6 of the design doc); firmware/hardware versions
+// and serial number are decoded because they're free once the frame is
+// being parsed anyway, useful for diagnostics and for reporting a new type
+// code back to the project.
+struct SystemConfig {
+    quint8  amplifierType{0};      // Byte 3 — spec confirms only "1 = A600S"
+    quint8  fwVersion{0};          // Byte 4
+    quint8  fwSubVersion{0};       // Byte 5
+    QString serialNumberHex;       // Byte 16-27 (12 bytes) — exact ASCII vs binary
+                                    // encoding is unconfirmed, so this is a hex
+                                    // dump (safe regardless of true encoding),
+                                    // not a claimed human-readable serial string.
+    quint8  hardFaultCount{0};     // Byte 28 — count of stored Hard Fault records
+};
+
+// Decodes a 0x11 SystemConfig frame's payload. Returns nullopt if short.
+std::optional<SystemConfig> decodeSystemConfig(const QByteArray& payload);
+
+// Confident model name for a SystemConfig::amplifierType value, or an empty
+// string if unrecognized. Only type 1 is confirmed by the spec — see the
+// design doc §6 for why the rest of the S-series isn't (and can't yet be)
+// enumerated here, and how auto-ranging covers the gap.
+QString modelNameForAmplifierType(quint8 amplifierType);
+
+// ── Commands (host -> amp) ───────────────────────────────────────────────
+
+QByteArray buildModeCommand(ModeCommand cmd);
+QByteArray buildClearFaultsCommand();
+QByteArray buildTelemetryEnable();
+QByteArray buildTelemetryDisable();
+QByteArray buildAck(quint8 receivedMessageNumber);
+// Requests the amp send a specific one-shot message (e.g. SystemConfig).
+// Spec §3.2. Not needed for Telemetry/ErrorCodes, which push automatically
+// once telemetry is enabled.
+QByteArray buildRequestMessage(quint8 desiredAddress);
+
+// ── Per-model scaling (spec is shared; these constants are per amplifier) ──
+
+struct ModelSpec {
+    QString name;
+    float   nominalForwardW{0};
+    float   maxForwardW{0};
+    float   nominalReflectedW{0};
+    float   maxReflectedW{0};
+    int     temperatureOffset{0};  // subtract from Telemetry::paTempRaw for degC
+    bool    hasPam2{false};
+};
+
+// 600S is the only entry verified against real hardware by this project.
+// The rest are derived from ACOM's own published rated-output specs (not
+// the reference client's constants, which turned out to be wrong for the
+// higher-power models — see design doc §6) using a documented, but still
+// unverified-beyond-600S, methodology. Treat as best-effort until confirmed.
+const ModelSpec& modelSpec(const QString& modelName);
+QStringList modelNames();
+
+// Model tiers in ascending power order — the order auto-ranging steps
+// through. Same ordering by nominal and by max power, so one list serves
+// both.
+QStringList orderedModelTiers();
+
+// Smallest tier whose maxForwardW comfortably fits an observed forward-power
+// reading (small margin to avoid boundary flapping at the exact ceiling),
+// clamped to the top tier if the reading exceeds even that. Pure/stateless —
+// AcomConnection owns deciding *when* to act on this (only moving up, never
+// back down mid-session; see design doc §6).
+QString tierForForwardPower(float watts);
+
+}  // namespace Acom
+}  // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::Acom::Telemetry)
+Q_DECLARE_METATYPE(AetherSDR::Acom::SystemConfig)

--- a/src/core/PeripheralSettings.h
+++ b/src/core/PeripheralSettings.h
@@ -13,6 +13,15 @@ namespace AetherSDR {
 // Peripherals feature settings live in one nested AppSettings JSON blob per
 // constitution Principle V. The temporary flat key from PR #3321 is migrated
 // so testers of the PR branch keep their selected behavior.
+//
+// ACOM's own manual connection settings (ManualIp/ManualPort/SerialPort/
+// ConnectionMode) use the generic per-device accessors below, nested under
+// obj["Acom"] — ACOM has never shipped with flat keys in a released build,
+// so there's no legacy data to migrate; new installs write directly into the
+// nested shape. TGXL/PGXL/Antenna Genius/ShackSwitch still use their
+// original flat AppSettings keys directly (not through this class) —
+// migrating those is legitimate follow-up work, scoped to its own PR rather
+// than bundled with the ACOM feature that motivated adding these accessors.
 class PeripheralSettings {
 public:
     static bool autoReconnect()
@@ -32,6 +41,61 @@ public:
         obj[QStringLiteral("AutoReconnect")] =
             on ? QStringLiteral("True") : QStringLiteral("False");
         write(obj);
+    }
+
+    // Generic per-device connection settings — e.g. device "Acom", field
+    // "ManualIp" reads/writes obj["Acom"]["ManualIp"] within the shared
+    // "Peripherals" root object. Currently only ACOM uses these (see the
+    // class comment above); kept generic by device/field name rather than
+    // ACOM-specific so a future migration of the other peripheral rows can
+    // reuse the same accessors instead of re-inventing them.
+    static QString deviceString(const QString& device, const QString& field,
+                                const QString& def = QString())
+    {
+        const QJsonValue v = deviceObj(device).value(field);
+        return v.isUndefined() || v.isNull() ? def : v.toString();
+    }
+
+    static void setDeviceString(const QString& device, const QString& field,
+                                const QString& value)
+    {
+        setDeviceField(device, field, QJsonValue(value));
+    }
+
+    static int deviceInt(const QString& device, const QString& field, int def = 0)
+    {
+        const QJsonValue v = deviceObj(device).value(field);
+        if (v.isDouble()) {
+            return v.toInt();
+        }
+        if (v.isString()) {
+            bool ok = false;
+            const int n = v.toString().toInt(&ok);
+            if (ok) {
+                return n;
+            }
+        }
+        return def;
+    }
+
+    static void setDeviceInt(const QString& device, const QString& field, int value)
+    {
+        setDeviceField(device, field, QJsonValue(value));
+    }
+
+    static void clearDeviceField(const QString& device, const QString& field)
+    {
+        QJsonObject root = readObj();
+        if (!root.contains(device)) {
+            return;
+        }
+        QJsonObject devObj = root.value(device).toObject();
+        if (!devObj.contains(field)) {
+            return;
+        }
+        devObj.remove(field);
+        root[device] = devObj;
+        write(root);
     }
 
     static void migrateLegacy()
@@ -60,10 +124,8 @@ public:
 private:
     static constexpr const char* kRootKey = "Peripherals";
 
-    static QJsonObject readObj()
+    static QJsonObject readRawObj()
     {
-        migrateLegacy();
-
         const QString json =
             AppSettings::instance().value(kRootKey, QString{}).toString();
         if (json.isEmpty()) {
@@ -76,6 +138,27 @@ private:
             return {};
         }
         return doc.object();
+    }
+
+    static QJsonObject readObj()
+    {
+        migrateLegacy();
+        return readRawObj();
+    }
+
+    static QJsonObject deviceObj(const QString& device)
+    {
+        return readObj().value(device).toObject();
+    }
+
+    static void setDeviceField(const QString& device, const QString& field,
+                               const QJsonValue& value)
+    {
+        QJsonObject root = readObj();
+        QJsonObject devObj = root.value(device).toObject();
+        devObj[field] = value;
+        root[device] = devObj;
+        write(root);
     }
 
     static void write(const QJsonObject& obj)

--- a/src/gui/AcomApplet.cpp
+++ b/src/gui/AcomApplet.cpp
@@ -1,0 +1,532 @@
+#include "AcomApplet.h"
+#include "HGauge.h"
+#include "core/AppSettings.h"
+#include "core/ThemeManager.h"
+#include "MeterSmoother.h"
+
+#include <QAccessible>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QLabel>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kAcomAppletSettingsKey = "AcomApplet";
+constexpr const char* kTempFahrenheitField = "tempFahrenheit";
+
+QJsonObject readAcomAppletSettings()
+{
+    const QString json = AppSettings::instance()
+        .value(kAcomAppletSettingsKey, QString{}).toString();
+    if (json.isEmpty()) return {};
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
+void writeAcomAppletSettings(const QJsonObject& obj)
+{
+    auto& settings = AppSettings::instance();
+    settings.setValue(kAcomAppletSettingsKey,
+        QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    settings.save();
+}
+
+bool readTempFahrenheit()
+{
+    return readAcomAppletSettings()
+        .value(kTempFahrenheitField)
+        .toString(QStringLiteral("False")) == QStringLiteral("True");
+}
+
+void writeTempFahrenheit(bool enabled)
+{
+    QJsonObject obj = readAcomAppletSettings();
+    obj[kTempFahrenheitField] = enabled ? QStringLiteral("True") : QStringLiteral("False");
+    writeAcomAppletSettings(obj);
+}
+
+float displayTemp(float degC, bool fahrenheit)
+{
+    return fahrenheit ? degC * 9.0f / 5.0f + 32.0f : degC;
+}
+
+QString formatTemp(float degC, bool fahrenheit)
+{
+    return QStringLiteral("%1").arg(displayTemp(degC, fahrenheit), 0, 'f', 1);
+}
+
+// 5 evenly spaced ticks across [0, max] — used for the PWR/REF gauges,
+// which get their scale from the amplifier's own nominal/max constants
+// (design doc §6) rather than a fixed range like the SWR gauge.
+QVector<HGauge::Tick> evenTicks(float max)
+{
+    QVector<HGauge::Tick> ticks;
+    for (float frac : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
+        const int v = static_cast<int>(max * frac);
+        ticks.append({static_cast<float>(v), QString::number(v)});
+    }
+    return ticks;
+}
+
+// Left-side label+value, fixed width so all gauge rows line up — matches
+// AmpApplet's makeValueLabel convention.
+QLabel* makeValueLabel(QWidget* parent)
+{
+    auto* lbl = new QLabel(parent);
+    lbl->setFixedWidth(46);
+    lbl->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    lbl->setStyleSheet("QLabel { color: #c8d8e8; font-size: 11px; font-weight: bold; }");
+    return lbl;
+}
+
+QString modePillStyle(Acom::Mode mode)
+{
+    using Acom::Mode;
+    switch (mode) {
+        case Mode::OperateTx:
+            return "QLabel { background: #3a1418; color: #ff8080; border: 1px solid #ff4d4d; "
+                   "border-radius: 3px; font-size: 9px; font-weight: bold; padding: 2px 6px; }";
+        case Mode::OperateRx:
+            return "QLabel { background: #0f2a1c; color: #6be899; border: 1px solid #4dd87a; "
+                   "border-radius: 3px; font-size: 9px; font-weight: bold; padding: 2px 6px; }";
+        case Mode::Standby:
+            return "QLabel { background: #12222e; color: #7fc4dc; border: 1px solid #2a5a70; "
+                   "border-radius: 3px; font-size: 9px; font-weight: bold; padding: 2px 6px; }";
+        default:
+            return "QLabel { background: #1c222a; color: #6b7684; border: 1px solid #303a44; "
+                   "border-radius: 3px; font-size: 9px; font-weight: bold; padding: 2px 6px; }";
+    }
+}
+
+QString modePillText(Acom::Mode mode)
+{
+    using Acom::Mode;
+    switch (mode) {
+        case Mode::OperateTx: return QStringLiteral("OPR · TX");
+        case Mode::OperateRx: return QStringLiteral("OPR · RX");
+        case Mode::Standby:   return QStringLiteral("STANDBY");
+        case Mode::PowerOff:  return QStringLiteral("OFF");
+        default:              return QStringLiteral("—");
+    }
+}
+
+}  // namespace
+
+AcomApplet::AcomApplet(QWidget* parent)
+    : QWidget(parent)
+{
+    theme::setContainer(this, QStringLiteral("applet/acom"));
+    auto* vbox = new QVBoxLayout(this);
+    vbox->setContentsMargins(4, 2, 4, 2);
+    vbox->setSpacing(2);
+
+    // ── Header: source (connection status) + status pill (mode) ────────────
+    // Source lives here rather than in the info grid — it's connection
+    // status, not a telemetry reading, and keeping it out of the grid lets
+    // the grid stay a clean 3-cells-per-row layout (temp/HV/Id, band/carrier/
+    // uptime) instead of splitting a field across a shared cell.
+    m_sourceLabel = new QLabel("● —", this);
+    m_sourceLabel->setStyleSheet("QLabel { color: #00b4d8; font-size: 9px; }");
+    m_statusPill = new QLabel(modePillText(m_mode), this);
+    m_statusPill->setStyleSheet(modePillStyle(m_mode));
+    m_statusPill->setAlignment(Qt::AlignCenter);
+    auto* headerRow = new QHBoxLayout;
+    headerRow->addWidget(m_sourceLabel);
+    headerRow->addStretch();
+    headerRow->addWidget(m_statusPill);
+    vbox->addLayout(headerRow);
+
+    // ── PWR row ───────────────────────────────────────────────────────────
+    m_pwrLabel = makeValueLabel(this);
+    m_pwrLabel->setText("PWR");
+    m_pwrGauge = new HGauge(0.0f, 700.0f, 600.0f, "", "",
+        evenTicks(700.0f), this);
+    m_pwrGauge->setBallistics({0.030f, 0.800f});
+    m_pwrGauge->setAccessibleName(tr("Forward power"));
+    auto* pwrRow = new QHBoxLayout;
+    pwrRow->setSpacing(4);
+    pwrRow->addWidget(m_pwrLabel);
+    pwrRow->addWidget(m_pwrGauge, 1);
+    vbox->addLayout(pwrRow);
+
+    // ── REF row (reflected power) ────────────────────────────────────────
+    m_refLabel = makeValueLabel(this);
+    m_refLabel->setText("REF");
+    m_refGauge = new HGauge(0.0f, 150.0f, 114.0f, "", "",
+        evenTicks(150.0f), this);
+    m_refGauge->setAccessibleName(tr("Reflected power"));
+    auto* refRow = new QHBoxLayout;
+    refRow->setSpacing(4);
+    refRow->addWidget(m_refLabel);
+    refRow->addWidget(m_refGauge, 1);
+    vbox->addLayout(refRow);
+
+    // ── SWR row ───────────────────────────────────────────────────────────
+    m_swrLabel = makeValueLabel(this);
+    m_swrLabel->setText("SWR");
+    m_swrGauge = new HGauge(1.0f, 3.0f, 2.5f, "", "",
+        {{1.0f, "1"}, {1.5f, "1.5"}, {2.0f, "2"}, {2.5f, "2.5"}, {3.0f, "3"}},
+        this, 2.0f);
+    m_swrGauge->setAccessibleName(tr("SWR"));
+    auto* swrRow = new QHBoxLayout;
+    swrRow->setSpacing(4);
+    swrRow->addWidget(m_swrLabel);
+    swrRow->addWidget(m_swrGauge, 1);
+    vbox->addLayout(swrRow);
+
+    vbox->addSpacing(4);
+
+    // ── Info grid: temp / HV / Id / band / carrier / uptime / source ───────
+    static const char* kTelStyle = "QLabel { color: #c8d8e8; font-size: 10px; }";
+
+    m_tempFahrenheit = readTempFahrenheit();
+    m_tempBtn = new QPushButton(this);
+    m_tempBtn->setObjectName(QStringLiteral("acomTempUnitButton"));
+    m_tempBtn->setFlat(true);
+    m_tempBtn->setFocusPolicy(Qt::TabFocus);
+    m_tempBtn->setCursor(Qt::PointingHandCursor);
+    m_tempBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    m_tempBtn->setAccessibleDescription("Toggles amplifier temperature between Celsius and Fahrenheit");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_tempBtn,
+        "QPushButton { background: transparent; border: 1px solid transparent; "
+        "color: #c8d8e8; font-size: 10px; text-align: left; padding: 0 2px; }"
+        "QPushButton:hover { border-color: #203040; color: #ffffff; }"
+        "QPushButton:focus { border-color: #00b4d8; }");
+    connect(m_tempBtn, &QPushButton::clicked, this, [this]() {
+        m_tempFahrenheit = !m_tempFahrenheit;
+        writeTempFahrenheit(m_tempFahrenheit);
+        updateTempLabel();
+    });
+    updateTempLabel();
+
+    m_hvLabel = new QLabel("HV  — V", this);
+    m_hvLabel->setStyleSheet(kTelStyle);
+    m_idLabel = new QLabel("Id  — A", this);
+    m_idLabel->setStyleSheet(kTelStyle);
+    m_bandLabel = new QLabel(this);
+    m_bandLabel->setStyleSheet(kTelStyle);
+    m_bandLabel->hide();
+    m_uptimeLabel = new QLabel(this);
+    m_uptimeLabel->setStyleSheet(kTelStyle);
+    m_uptimeLabel->hide();
+
+    // Compact — sized to sit inline in the info grid rather than the full
+    // button row (see the grid comment below for why it moved here).
+    m_clearFaultBtn = new QPushButton("CLEAR", this);
+    m_clearFaultBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_clearFaultBtn,
+        "QPushButton { background: #2a2210; border: 1px solid #5a4a1a; "
+        "border-radius: 3px; color: #ffb84d; font-size: 9px; font-weight: bold; padding: 1px 4px; }"
+        "QPushButton:hover { background: #3a2e14; }"
+        "QPushButton:disabled { background: #181c22; border: 1px solid #232a33; color: #3a4552; }");
+    m_clearFaultBtn->setEnabled(false);
+    connect(m_clearFaultBtn, &QPushButton::clicked, this, &AcomApplet::clearFaultClicked);
+
+    // 3 cells per row: temp/HV/Id, then band/uptime/clear. Carrier frequency
+    // only reads nonzero while the amp senses actual RF drive — idle/standby
+    // leaves it blank most of the time in practice — so instead of a mostly-
+    // empty cell, CLEAR lives there. That also frees the button row below to
+    // 3 buttons (STANDBY/OPERATE/OFF) instead of 4, which were clipping at
+    // default width.
+    auto* infoGrid = new QGridLayout;
+    infoGrid->setHorizontalSpacing(12);
+    infoGrid->setVerticalSpacing(2);
+    infoGrid->addWidget(m_tempBtn,      0, 0);
+    infoGrid->addWidget(m_hvLabel,      0, 1);
+    infoGrid->addWidget(m_idLabel,      0, 2);
+    infoGrid->addWidget(m_bandLabel,    1, 0);
+    infoGrid->addWidget(m_uptimeLabel,  1, 1);
+    infoGrid->addWidget(m_clearFaultBtn, 1, 2);
+    vbox->addLayout(infoGrid);
+
+    vbox->addSpacing(4);
+
+    // ── Fault banner (own row, full width, only shown when active) ─────────
+    m_faultLabel = new QLabel(this);
+    m_faultLabel->setWordWrap(true);
+    m_faultLabel->setStyleSheet(
+        "QLabel { color: #ff8080; font-size: 10px; font-weight: bold; }");
+    m_faultLabel->hide();
+    vbox->addWidget(m_faultLabel);
+
+    // ── Button row: STANDBY / OPERATE / OFF ─────────────────────────────────
+    static const char* kBtnStyle =
+        "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
+        "QPushButton:hover { background: {{color.background.1}}; }";
+
+    auto* btnRow = new QHBoxLayout;
+    btnRow->setSpacing(6);
+    btnRow->addStretch();
+
+    m_standbyBtn = new QPushButton("STANDBY", this);
+    m_standbyBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_standbyBtn, kBtnStyle);
+    connect(m_standbyBtn, &QPushButton::clicked, this, [this]() { emit operateToggled(false); });
+    btnRow->addWidget(m_standbyBtn);
+
+    m_operateBtn = new QPushButton("OPERATE", this);
+    m_operateBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_operateBtn, kBtnStyle);
+    connect(m_operateBtn, &QPushButton::clicked, this, [this]() { emit operateToggled(true); });
+    btnRow->addWidget(m_operateBtn);
+
+    m_offBtn = new QPushButton("OFF", this);
+    m_offBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_offBtn, kBtnStyle);
+    connect(m_offBtn, &QPushButton::clicked, this, &AcomApplet::offClicked);
+    btnRow->addWidget(m_offBtn);
+    vbox->addLayout(btnRow);
+
+    // Label text throttle — matches AmpApplet's 10 Hz readout convention.
+    m_labelTimer.setInterval(kMeterReadoutUpdateMs);
+    connect(&m_labelTimer, &QTimer::timeout, this, &AcomApplet::updateValueLabels);
+    m_labelTimer.start();
+
+    m_peakTimer = new QTimer(this);
+    m_peakTimer->setSingleShot(true);
+    m_peakTimer->setInterval(2500);
+    connect(m_peakTimer, &QTimer::timeout, this, [this]() {
+        m_peakFwd = 0.0f;
+        m_pwrGauge->clearPeak();
+    });
+
+    setConnected(false);
+}
+
+void AcomApplet::setPowerRange(float nominalW, float maxW)
+{
+    m_pwrGauge->setRange(0.0f, maxW, nominalW, evenTicks(maxW));
+}
+
+void AcomApplet::setReflectedRange(float nominalW, float maxW)
+{
+    m_refGauge->setRange(0.0f, maxW, nominalW, evenTicks(maxW));
+}
+
+void AcomApplet::setForwardPower(float watts)
+{
+    m_fwdWatts = watts;
+    m_pwrGauge->setValue(watts);
+    if (watts > m_peakFwd) {
+        m_peakFwd = watts;
+        m_pwrGauge->setPeakValue(watts);
+        m_peakTimer->start();
+    }
+}
+
+void AcomApplet::setReflectedPower(float watts)
+{
+    m_reflectedWatts = watts;
+    m_refGauge->setValue(watts);
+}
+
+void AcomApplet::setSwr(float swr)
+{
+    m_swrVal = swr;
+    m_swrGauge->setValue(swr);
+}
+
+void AcomApplet::setDrainCurrent(float amps)
+{
+    m_drainAmps = amps;
+    m_diagDirty = true;
+}
+
+void AcomApplet::setDrainVoltage(float volts)
+{
+    m_drainVolts = volts;
+    m_diagDirty = true;
+}
+
+void AcomApplet::setTemp(float degC)
+{
+    m_tempC = degC;
+    m_hasTemp = true;
+    m_tempDirty = true;
+}
+
+void AcomApplet::updateTempLabel()
+{
+    const QString unit = m_tempFahrenheit ? QStringLiteral("F") : QStringLiteral("C");
+    const QString val = m_hasTemp ? formatTemp(m_tempC, m_tempFahrenheit) : QStringLiteral("—");
+    m_tempBtn->setText(QStringLiteral("%1 %2").arg(val, unit));
+    const QString nextUnit = m_tempFahrenheit ? tr("Celsius") : tr("Fahrenheit");
+    m_tempBtn->setToolTip(tr("Amplifier temperature\nClick to show degrees %1").arg(nextUnit));
+    m_tempBtn->setAccessibleName(tr("Amplifier temperature %1").arg(m_tempBtn->text()));
+    if (QAccessible::isActive()) {
+        QAccessibleEvent event(m_tempBtn, QAccessible::NameChanged);
+        QAccessible::updateAccessibility(&event);
+    }
+}
+
+void AcomApplet::setBand(const QString& band)
+{
+    m_pendingBand = band;
+    m_bandDirty = true;
+}
+
+void AcomApplet::setUptime(quint32 totalSeconds)
+{
+    m_pendingUptimeSeconds = totalSeconds;
+    m_uptimeDirty = true;
+}
+
+void AcomApplet::setSource(const QString& text)
+{
+    m_sourceLabel->setText(QStringLiteral("● %1").arg(text));
+}
+
+namespace {
+QString activeBtnStyle(const QString& bg, const QString& border)
+{
+    return QStringLiteral(
+        "QPushButton { background: %1; border: 1px solid %2; border-radius: 3px; "
+        "color: {{color.text.primary}}; font-size: 10px; font-weight: bold; } "
+        "QPushButton:hover { background: %1; }").arg(bg, border);
+}
+
+QString neutralBtnStyle()
+{
+    return QStringLiteral(
+        "QPushButton { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
+        "QPushButton:hover { background: {{color.background.1}}; }");
+}
+}  // namespace
+
+void AcomApplet::setMode(Acom::Mode mode)
+{
+    m_mode = mode;
+    m_statusPill->setText(modePillText(mode));
+    m_statusPill->setStyleSheet(modePillStyle(mode));
+
+    const bool isStandby = (mode == Acom::Mode::Standby);
+    const bool isOperate = (mode == Acom::Mode::OperateTx || mode == Acom::Mode::OperateRx);
+    const bool isOff     = (mode == Acom::Mode::PowerOff || mode == Acom::Mode::Unknown);
+
+    auto& theme = AetherSDR::ThemeManager::instance();
+    theme.applyStyleSheet(m_standbyBtn,
+        isStandby ? activeBtnStyle("#12222e", "#2a5a70") : neutralBtnStyle());
+    theme.applyStyleSheet(m_operateBtn,
+        isOperate ? activeBtnStyle("#006030", "#008040") : neutralBtnStyle());
+    theme.applyStyleSheet(m_offBtn,
+        isOff ? activeBtnStyle("#3a2a2a", "#5a3a3a") : neutralBtnStyle());
+}
+
+void AcomApplet::setFaultText(const QString& text)
+{
+    if (text.isEmpty()) {
+        m_faultLabel->hide();
+        m_faultLabel->clear();
+        return;
+    }
+    m_faultLabel->setText(text);
+    m_faultLabel->show();
+}
+
+void AcomApplet::setClearFaultEnabled(bool enabled)
+{
+    // Stays visible always — only enabled state changes — so it reads as
+    // "here, nothing to clear right now" rather than disappearing entirely.
+    m_clearFaultBtn->setEnabled(enabled);
+}
+
+void AcomApplet::setDiagnosticTooltip(const QString& text)
+{
+    m_statusPill->setToolTip(text);
+}
+
+void AcomApplet::setConnected(bool connected)
+{
+    m_standbyBtn->setEnabled(connected);
+    m_operateBtn->setEnabled(connected);
+    m_offBtn->setEnabled(connected);
+    if (!connected) {
+        setMode(Acom::Mode::Unknown);
+        setFaultText(QString());
+        setClearFaultEnabled(false);
+        m_sourceLabel->setText(QStringLiteral("● —"));
+        m_bandLabel->hide();
+        m_uptimeLabel->hide();
+        m_bandDirty = false;
+        m_uptimeDirty = false;
+        m_drainAmps = 0.0f;
+        m_drainVolts = 0.0f;
+        m_diagDirty = false;
+        m_hvLabel->setText("HV  — V");
+        m_idLabel->setText("Id  — A");
+        m_hasTemp = false;
+        m_tempDirty = false;
+        updateTempLabel();
+        m_fwdWatts = 0.0f;
+        m_reflectedWatts = 0.0f;
+        m_swrVal = 1.0f;
+        m_pwrGauge->setValueImmediate(0.0f);
+        m_refGauge->setValueImmediate(0.0f);
+        m_swrGauge->setValueImmediate(1.0f);
+        updateValueLabels();
+    }
+}
+
+void AcomApplet::updateValueLabels()
+{
+    m_pwrLabel->setText(m_fwdWatts >= 1.0f
+        ? QStringLiteral("PWR  %1").arg(static_cast<int>(m_fwdWatts))
+        : QStringLiteral("PWR"));
+    m_refLabel->setText(m_fwdWatts >= 1.0f
+        ? QStringLiteral("REF  %1").arg(static_cast<int>(m_reflectedWatts))
+        : QStringLiteral("REF"));
+    m_swrLabel->setText(m_fwdWatts >= 1.0f
+        ? QStringLiteral("SWR  %1:1").arg(m_swrVal, 0, 'f', 1)
+        : QStringLiteral("SWR"));
+
+    if (m_tempDirty) {
+        m_tempDirty = false;
+        updateTempLabel();
+    }
+    if (m_diagDirty) {
+        m_diagDirty = false;
+        // Text readouts, not gauges — the protocol has no nominal/max
+        // current constant to size an axis against (design doc, "Id gauge
+        // scale" note).
+        m_idLabel->setText(QStringLiteral("Id  %1A").arg(m_drainAmps, 0, 'f', 1));
+        m_hvLabel->setText(QStringLiteral("HV  %1V").arg(m_drainVolts, 0, 'f', 1));
+    }
+    if (m_bandDirty) {
+        m_bandDirty = false;
+        m_bandLabel->setText(QStringLiteral("BAND  %1").arg(m_pendingBand));
+        m_bandLabel->show();
+    }
+    if (m_uptimeDirty) {
+        m_uptimeDirty = false;
+        // The amp's "system clock" telemetry field is a cumulative total-
+        // operating-time counter, not time since the last power-on —
+        // confirmed against real 600S telemetry showing a value far larger
+        // than any single session (it does not reset per power cycle). "ON"
+        // + day/hour format reads naturally for that and stays bounded in
+        // length, unlike an unbounded H:MM:SS string that eventually
+        // overflows its grid cell.
+        const quint32 totalMinutes = m_pendingUptimeSeconds / 60;
+        const quint32 totalHours = totalMinutes / 60;
+        const quint32 minutes = totalMinutes % 60;
+
+        QString text;
+        if (totalHours >= 24) {
+            const quint32 days = totalHours / 24;
+            const quint32 hours = totalHours % 24;
+            text = QStringLiteral("ON  %1d %2h").arg(days).arg(hours);
+        } else {
+            text = QStringLiteral("ON  %1h %2m").arg(totalHours).arg(minutes);
+        }
+        m_uptimeLabel->setText(text);
+        m_uptimeLabel->show();
+    }
+}
+
+}  // namespace AetherSDR

--- a/src/gui/AcomApplet.cpp
+++ b/src/gui/AcomApplet.cpp
@@ -323,13 +323,19 @@ void AcomApplet::setForwardPower(float watts)
 void AcomApplet::setReflectedPower(float watts)
 {
     m_reflectedWatts = watts;
-    m_refGauge->setValue(watts);
+    // Reflected power is only meaningful while there's forward drive — hold the
+    // needle at baseline below 1 W so the gauge agrees with its readout label,
+    // which already blanks under the same condition (updateValueLabels). Wiring
+    // sets forward power first each frame, so m_fwdWatts is current here.
+    m_refGauge->setValue(m_fwdWatts >= 1.0f ? watts : 0.0f);
 }
 
 void AcomApplet::setSwr(float swr)
 {
     m_swrVal = swr;
-    m_swrGauge->setValue(swr);
+    // Same forward-power gate as the SWR label: without forward drive SWR is
+    // undefined, so hold the gauge at 1.0 rather than tracking a garbage ratio.
+    m_swrGauge->setValue(m_fwdWatts >= 1.0f ? swr : 1.0f);
 }
 
 void AcomApplet::setDrainCurrent(float amps)
@@ -467,7 +473,14 @@ void AcomApplet::setConnected(bool connected)
         m_fwdWatts = 0.0f;
         m_reflectedWatts = 0.0f;
         m_swrVal = 1.0f;
+        // Clear the forward-power peak hold too — otherwise a stale peak from
+        // the prior session survives (m_peakFwd is not otherwise reset), and a
+        // reconnect within the 2.5 s peak-hold window suppresses the new
+        // session's peak marker until a reading exceeds the old peak.
+        m_peakFwd = 0.0f;
+        if (m_peakTimer) m_peakTimer->stop();
         m_pwrGauge->setValueImmediate(0.0f);
+        m_pwrGauge->clearPeak();
         m_refGauge->setValueImmediate(0.0f);
         m_swrGauge->setValueImmediate(1.0f);
         updateValueLabels();

--- a/src/gui/AcomApplet.h
+++ b/src/gui/AcomApplet.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include "core/AcomProtocol.h"
+
+#include <QWidget>
+#include <QPushButton>
+#include <QTimer>
+
+class QLabel;
+
+namespace AetherSDR {
+
+class HGauge;
+
+// Dedicated applet for an ACOM S-series amplifier (600S primary target) —
+// a sibling of AmpApplet (PGXL), not a variant of it. Split out after
+// discovering that bolting ACOM's richer telemetry onto AmpApplet's
+// PGXL-shaped 3-gauge layout (a) couldn't actually match the proposed
+// design, and (b) leaked a dead SWR/reflected-power toggle into PGXL's
+// panel. See docs/architecture/acom-600s-amplifier-design.md.
+//
+// Unlike AmpApplet's PWR/SWR/Id gauges (PGXL's own data shape), ACOM's
+// 0x2F telemetry frame reports forward power, reflected power, AND SWR as
+// independently real fields — no toggle needed, all three get a permanent
+// gauge row. PAM drain current (Id) has no protocol-defined scale to gauge
+// against, so it's a plain text readout instead, same treatment as
+// PA temperature already gets.
+class AcomApplet : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit AcomApplet(QWidget* parent = nullptr);
+
+    // Gauge scale configuration — call once the model is known (600S
+    // default is set by the caller today; see design doc §6 for the full
+    // 500S/600S/700S/1200S/2020S table).
+    void setPowerRange(float nominalW, float maxW);
+    void setReflectedRange(float nominalW, float maxW);
+
+    // Telemetry
+    void setForwardPower(float watts);
+    void setReflectedPower(float watts);
+    void setSwr(float swr);
+    void setDrainCurrent(float amps);   // text readout, not a gauge
+    void setDrainVoltage(float volts);  // HV1 rail
+    void setTemp(float degC);
+    void setBand(const QString& band);
+    // Cumulative total operating time (not session uptime — the amp's
+    // "system clock" telemetry field does not reset per power cycle).
+    void setUptime(quint32 totalSeconds);
+    void setSource(const QString& text);  // "SERIAL" or "NETWORK"
+    void setMode(Acom::Mode mode);        // drives the status pill + STANDBY/OPERATE/OFF buttons
+    void setFaultText(const QString& text);  // empty clears/hides the banner
+    // Clear stays visible always (matches the proposed design) and is only
+    // enabled — not hidden — while a fault is actually active.
+    void setClearFaultEnabled(bool enabled);
+    void setConnected(bool connected);    // shows/hides live controls, resets on disconnect
+
+    // Model auto-detection/auto-ranging diagnostic info, shown as a tooltip
+    // on the status pill rather than a permanent on-screen field — this is
+    // "why is the scale what it is" context, not operational telemetry.
+    // Chosen over the Peripherals settings row because no other device row
+    // there surfaces detected-hardware info; connection status only.
+    void setDiagnosticTooltip(const QString& text);
+
+signals:
+    void operateToggled(bool on);  // true = OPERATE clicked, false = STANDBY clicked
+    void offClicked();
+    void clearFaultClicked();
+
+private:
+    void updateTempLabel();
+    void updateValueLabels();  // 10 Hz throttled label text refresh
+
+    HGauge* m_pwrGauge{nullptr};
+    HGauge* m_refGauge{nullptr};
+    HGauge* m_swrGauge{nullptr};
+
+    QLabel* m_pwrLabel{nullptr};
+    QLabel* m_refLabel{nullptr};
+    QLabel* m_swrLabel{nullptr};
+
+    QLabel* m_statusPill{nullptr};
+    QLabel* m_sourceLabel{nullptr};  // sits next to the status pill, not in the info grid
+
+    // Info grid — 3 cells per row: temp/HV/Id, then band/uptime/clear.
+    // Carrier frequency (byte 48-49) turned out to only read nonzero while
+    // the amp senses actual RF drive — idle/standby leaves it blank most of
+    // the time in practice, so it doesn't get a permanent slot; the clear-
+    // fault button lives there instead (see setConnected/setClearFaultEnabled),
+    // which also gives STANDBY/OPERATE/OFF a 3-button row with room to
+    // breathe instead of 4 buttons clipping at default width.
+    QPushButton* m_tempBtn{nullptr};
+    QLabel* m_hvLabel{nullptr};
+    QLabel* m_idLabel{nullptr};
+    QLabel* m_bandLabel{nullptr};
+    QLabel* m_uptimeLabel{nullptr};
+
+    QLabel* m_faultLabel{nullptr};
+    QPushButton* m_clearFaultBtn{nullptr};  // lives in the info grid, not the button row
+
+    QPushButton* m_standbyBtn{nullptr};
+    QPushButton* m_operateBtn{nullptr};
+    QPushButton* m_offBtn{nullptr};
+
+    QTimer m_labelTimer;
+    QTimer* m_peakTimer{nullptr};
+    float m_peakFwd{0.0f};
+
+    float m_fwdWatts{0.0f};
+    float m_reflectedWatts{0.0f};
+    float m_swrVal{1.0f};
+    float m_drainAmps{0.0f};
+    float m_drainVolts{0.0f};
+    float m_tempC{0.0f};
+    bool m_hasTemp{false};
+    bool m_tempFahrenheit{false};
+    Acom::Mode m_mode{Acom::Mode::Unknown};
+
+    // setTemp/setBand/setUptime/setDrainCurrent/setDrainVoltage arrive at
+    // telemetry rate (well above 10 Hz in practice), same as the PWR/REF/SWR
+    // gauge values above. Those already funnel display updates through the
+    // 10 Hz m_labelTimer tick (updateValueLabels) instead of repainting and
+    // re-announcing accessibility text on every frame; these dirty flags let
+    // the info-grid/temp fields join that same throttle rather than flooding
+    // screen-reader NameChanged events and label repaints at full telemetry
+    // rate.
+    bool m_tempDirty{false};
+    bool m_diagDirty{false};  // Id + HV labels
+    bool m_bandDirty{false};
+    QString m_pendingBand;
+    bool m_uptimeDirty{false};
+    quint32 m_pendingUptimeSeconds{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -11,6 +11,7 @@
 #include "VuMeterSettings.h"
 #include "TunerApplet.h"
 #include "AmpApplet.h"
+#include "AcomApplet.h"
 #include "TxApplet.h"
 #include "PhoneCwApplet.h"
 #include "PhoneApplet.h"
@@ -733,6 +734,18 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         m_appletOrder.append(entry);
     }
 
+    // ACOM S-series amplifier — independent of AMP (PGXL): a station can
+    // have both a radio-relayed PGXL and a direct-connected ACOM amplifier
+    // at once. See docs/architecture/acom-600s-amplifier-design.md.
+    m_acomApplet = new AcomApplet;
+    {
+        auto entry = makeEntry("ACOM", "ACOM Amplifier", m_acomApplet, false,
+                               m_drawer, m_drawerLayout);
+        m_acomBtn = entry.btn;
+        markHardwareConditional("ACOM");
+        m_appletOrder.append(entry);
+    }
+
     m_txApplet = new TxApplet;
     m_appletOrder.append(makeEntry("TX", "TX Controls", m_txApplet, true, m_drawer, m_drawerLayout));
 
@@ -1369,6 +1382,12 @@ void AppletPanel::setTunerVisible(bool visible)
 void AppletPanel::setAmpVisible(bool visible)
 {
     updateHardwareAvailability("AMP", "Applet_AMP", visible);
+    applyBarLayout();
+}
+
+void AppletPanel::setAcomVisible(bool visible)
+{
+    updateHardwareAvailability("ACOM", "Applet_ACOM", visible);
     applyBarLayout();
 }
 

--- a/src/gui/AppletPanel.h
+++ b/src/gui/AppletPanel.h
@@ -31,6 +31,7 @@ class CrossNeedleMeterApplet;
 class CrossNeedleMeterWidget;
 class TunerApplet;
 class AmpApplet;
+class AcomApplet;
 class TxApplet;
 class PhoneCwApplet;
 class PhoneApplet;
@@ -93,6 +94,7 @@ public:
     void setMeterPowerScale(int maxWatts, bool amplifierActive);
     TunerApplet*  tunerApplet()   { return m_tunerApplet; }
     AmpApplet*    ampApplet()     { return m_ampApplet; }
+    AcomApplet*   acomApplet()    { return m_acomApplet; }
     TxApplet*       txApplet()       { return m_txApplet; }
     PhoneCwApplet*  phoneCwApplet()  { return m_phoneCwApplet; }
     PhoneApplet*    phoneApplet()    { return m_phoneApplet; }
@@ -152,6 +154,11 @@ public:
 
     // Show/hide the AMP button and applet based on amplifier presence.
     void setAmpVisible(bool visible);
+
+    // Show/hide the ACOM button and applet based on a direct ACOM amplifier
+    // connection. Independent of setAmpVisible — a station can have both a
+    // radio-relayed PGXL and a direct-connected ACOM amplifier at once.
+    void setAcomVisible(bool visible);
 
     // Show/hide the AG button and applet based on Antenna Genius presence.
     void setAgVisible(bool visible);
@@ -281,6 +288,8 @@ private:
     TunerApplet* m_tunerApplet{nullptr};
     AmpApplet*   m_ampApplet{nullptr};
     QPushButton* m_ampBtn{nullptr};
+    AcomApplet*  m_acomApplet{nullptr};
+    QPushButton* m_acomBtn{nullptr};
     TxApplet*      m_txApplet{nullptr};
     PhoneCwApplet* m_phoneCwApplet{nullptr};
     PhoneApplet*   m_phoneApplet{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -62,6 +62,7 @@
 #include "core/SignalClassifier.h"
 #include "core/TgxlConnection.h"
 #include "core/PgxlConnection.h"
+#include "core/AcomConnection.h"
 #include "core/DxccColorProvider.h"
 
 #include <QMainWindow>
@@ -745,6 +746,7 @@ private:
     AntennaGeniusModel m_antennaGenius;
     TgxlConnection    m_tgxlConn;        // direct TCP 9010 to TGXL for manual relay control
     PgxlConnection    m_pgxlConn;        // direct TCP 9008 to PGXL for telemetry
+    AcomConnection    m_acomConn;        // ACOM S-series amplifier, serial or ser2net
     BandPlanManager*  m_bandPlanMgr{nullptr};
     CwDecoder         m_cwDecoder;
     float             m_cwLastPitchHz{0.0f};

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -99,7 +99,7 @@ void MainWindow::buildMenuBar()
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
                               &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager);
+                              m_kiwiSdrManager, &m_acomConn);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
     });
@@ -297,7 +297,7 @@ void MainWindow::buildMenuBar()
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
                               &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager);
+                              m_kiwiSdrManager, &m_acomConn);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
         if (m_radioSetupDialog)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -30,6 +30,7 @@
 #include "GpsLocationDialog.h"
 #include "RxApplet.h"
 #include "AmpApplet.h"
+#include "AcomApplet.h"
 #include "HealthApplet.h"
 #include "MeterApplet.h"
 #include "ProfileSwitcherApplet.h"
@@ -3717,7 +3718,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         showOrRaisePersistent(m_radioSetupDialog,
                               &m_radioModel, m_audio,
                               &m_tgxlConn, &m_pgxlConn, &m_antennaGenius,
-                              m_kiwiSdrManager);
+                              m_kiwiSdrManager, &m_acomConn);
         if (wasFresh && m_radioSetupDialog)
             wireRadioSetupDialogSignals(m_radioSetupDialog, prevComp);
         if (m_radioSetupDialog)
@@ -4418,10 +4419,18 @@ void MainWindow::wireMeters()
         m_tgxlConn.setAutoReconnect(ar);
         m_pgxlConn.setAutoReconnect(ar);
         m_antennaGenius.setAutoReconnect(ar);
+        m_acomConn.setAutoReconnect(ar);
     }
 
     // Wire TgxlConnection to TunerModel
     m_radioModel.tunerModel().setDirectConnection(&m_tgxlConn);
+    // ACOM deliberately does NOT route through AmpModel — it has its own
+    // dedicated AcomApplet talking straight to AcomConnection (commands and
+    // telemetry alike), so AmpModel stays 100% PGXL/Flex-relay-only. Wiring
+    // ACOM into AmpModel's shared presence signal previously caused the AMP
+    // (PGXL) panel to appear whenever ACOM connected, since AmpModel::present()
+    // couldn't distinguish "PGXL relayed" from "ACOM direct". See
+    // docs/architecture/acom-600s-amplifier-design.md.
     // Also attempt connection when TGXL IP arrives (may come after presence)
     connect(&m_radioModel.tunerModel(), &TunerModel::stateChanged, this, [this]() {
         auto* tuner = &m_radioModel.tunerModel();
@@ -4549,6 +4558,119 @@ void MainWindow::wireMeters()
     connect(m_appletPanel->ampApplet(), &AmpApplet::operateToggled, this, [this](bool on) {
         m_radioModel.amplifier().setOperate(on);
     });
+
+    // ── ACOM S-series amplifier — serial or ser2net, no FlexRadio relay ─────
+    // See docs/architecture/acom-600s-amplifier-design.md. All signal wiring
+    // happens before the startup auto-connect trigger at the bottom of this
+    // block — connectSerial() can call onTransportUp() synchronously (unlike
+    // connectNetwork(), which waits on the TCP handshake), so wiring after
+    // triggering auto-connect would silently miss the first connected()/
+    // modelChanged() emission on every app start with a saved serial config.
+    connect(&m_acomConn, &AcomConnection::connected, this, [this]() {
+        auto* acom = m_appletPanel->acomApplet();
+        // Source label from the live transport, not the persisted
+        // ConnectionMode setting — the two can diverge (mode combo switched in
+        // Radio Setup without a reconnect), which would mislabel an active
+        // serial link as "NETWORK". See AcomConnection::sourceLabel().
+        acom->setSource(m_acomConn.sourceLabel());
+        acom->setConnected(true);
+        m_appletPanel->setAcomVisible(true);
+    });
+    connect(&m_acomConn, &AcomConnection::disconnected, this, [this]() {
+        m_appletPanel->acomApplet()->setConnected(false);
+        m_appletPanel->setAcomVisible(false);
+    });
+    connect(m_appletPanel->acomApplet(), &AcomApplet::clearFaultClicked, this, [this]() {
+        m_acomConn.clearFaults();
+    });
+    connect(m_appletPanel->acomApplet(), &AcomApplet::operateToggled, this, [this](bool on) {
+        m_acomConn.setOperate(on);
+    });
+    connect(m_appletPanel->acomApplet(), &AcomApplet::offClicked, this, [this]() {
+        m_acomConn.powerOff();
+    });
+
+    // Gauge ranges (and the temperature-offset used per telemetry frame below)
+    // re-apply every time the effective model changes — at connect ("default"
+    // = 600S, our one confirmed model), when a SystemConfig reply confirms a
+    // model ("confirmed"), and whenever observed forward power outgrows the
+    // current tier ("auto-scaled"). See design doc §6 for why there's no
+    // model-selector dropdown driving this instead.
+    connect(&m_acomConn, &AcomConnection::modelChanged, this,
+            [this](const QString& model, const QString& reason) {
+        const auto& spec = AetherSDR::Acom::modelSpec(model);
+        auto* acom = m_appletPanel->acomApplet();
+        acom->setPowerRange(spec.nominalForwardW, spec.maxForwardW);
+        acom->setReflectedRange(spec.nominalReflectedW, spec.maxReflectedW);
+        acom->setDiagnosticTooltip(QStringLiteral("Scaled for %1 (%2)").arg(model, reason));
+    });
+    // SystemConfig (0x11) is one-shot diagnostic info — firmware/serial/the
+    // raw amplifierType byte — surfaced so a user with an unrecognized model
+    // can report it back to the project (design doc §6's "help us confirm").
+    connect(&m_acomConn, &AcomConnection::systemConfigReceived, this,
+            [this](const AetherSDR::Acom::SystemConfig& cfg) {
+        auto* acom = m_appletPanel->acomApplet();
+        const QString modelGuess = AetherSDR::Acom::modelNameForAmplifierType(cfg.amplifierType);
+        const QString identity = modelGuess.isEmpty()
+            ? QStringLiteral("type %1 (unrecognized)").arg(cfg.amplifierType)
+            : modelGuess;
+        acom->setDiagnosticTooltip(QStringLiteral(
+            "Detected: %1 · FW %2.%3 · S/N %4\nUnrecognized type? Please report it — "
+            "see docs/architecture/acom-600s-amplifier-design.md")
+            .arg(identity)
+            .arg(cfg.fwVersion)
+            .arg(cfg.fwSubVersion)
+            .arg(cfg.serialNumberHex));
+    });
+
+    connect(&m_acomConn, &AcomConnection::telemetryUpdated, this,
+            [this](const AetherSDR::Acom::Telemetry& t) {
+        auto* acom = m_appletPanel->acomApplet();
+        const QString effectiveModel = m_acomConn.currentModel();
+        const auto& spec = AetherSDR::Acom::modelSpec(effectiveModel);
+
+        acom->setForwardPower(static_cast<float>(t.forwardPowerW));
+        acom->setReflectedPower(static_cast<float>(t.reflectedPowerW));
+        acom->setSwr(t.swr_x100 / 100.0f);
+        acom->setDrainCurrent(t.id1_mA / 1000.0f);
+        acom->setDrainVoltage(t.hv1_x10V / 10.0f);
+        acom->setTemp(static_cast<float>(t.paTempRaw) - static_cast<float>(spec.temperatureOffset));
+        acom->setBand(AetherSDR::Acom::bandName(t.activeBand));
+        acom->setUptime(t.systemClockSec);
+        acom->setMode(t.mode);
+        acom->setFaultText(t.errorCode == 0xFF
+            ? QString()
+            : AetherSDR::Acom::errorCodeName(t.errorCode));
+        acom->setClearFaultEnabled(t.errorCode != 0xFF);
+    });
+
+    // Startup auto-connect from saved Peripherals settings — deliberately
+    // last in this block (see the comment above). Unlike PGXL/TGXL (which
+    // auto-connect when the *radio* reports their IP), the ACOM has no
+    // radio-side presence signal at all — the saved setting is the only
+    // trigger there will ever be.
+    {
+        const QString mode = PeripheralSettings::deviceString("Acom", "ConnectionMode",
+#ifdef HAVE_SERIALPORT
+            "Serial"
+#else
+            "Network"
+#endif
+        );
+        if (mode == "Network") {
+            const QString ip = PeripheralSettings::deviceString("Acom", "ManualIp");
+            const int port = PeripheralSettings::deviceInt("Acom", "ManualPort", 7000);
+            if (!ip.isEmpty())
+                m_acomConn.connectNetwork(ip, static_cast<quint16>(port));
+        }
+#ifdef HAVE_SERIALPORT
+        else {
+            const QString port = PeripheralSettings::deviceString("Acom", "SerialPort");
+            if (!port.isEmpty())
+                m_acomConn.connectSerial(port);
+        }
+#endif
+    }
 
     // Switch Fwd Power gauge scale based on radio max power and amplifier presence.
     // All three power gauges (TxApplet, TunerApplet, SMeterWidget) update together.

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -26,6 +26,7 @@
 #include "core/FirmwareStager.h"
 #include "core/TgxlConnection.h"
 #include "core/PgxlConnection.h"
+#include "core/AcomConnection.h"
 #include "core/WanConnection.h"   // PinnedCertInfo + WanCertCache (#2951)
 #include "core/CallsignLookupService.h"
 #include "core/QrzLookupSettings.h"
@@ -588,16 +589,52 @@ static void refreshOscillatorSourceCombo(QComboBox* combo, const RadioModel* mod
     if (idx >= 0) combo->setCurrentIndex(idx);
 }
 
+#ifdef HAVE_SERIALPORT
+// Populates a serial-port combo (real ports discovered via QSerialPortInfo,
+// plus a trailing "Custom..." sentinel) and selects the entry matching
+// savedPort. If none of the discovered ports match — the saved port isn't
+// currently plugged in, or it's a non-standard path (e.g. /dev/ttyUSB0 on
+// Linux, a symlinked TTY) — falls back to "Custom..." with customEdit
+// pre-filled, so the saved value is never silently dropped. Returns true if
+// the fallback (Custom) was selected. Shared by the CW/keying Port
+// Configuration group and the ACOM Peripherals row, which independently
+// re-implemented this match/fallback logic with a subtly different
+// isCustom computation before this was factored out.
+static bool populateSerialPortCombo(QComboBox* combo, QLineEdit* customEdit,
+                                    const QString& savedPort)
+{
+    for (const auto& info : QSerialPortInfo::availablePorts())
+        combo->addItem(QString("%1 — %2").arg(info.portName(), info.description()),
+                        info.portName());
+    combo->addItem("Custom...", QStringLiteral("__custom__"));
+
+    bool isCustom = !savedPort.isEmpty();
+    for (int i = 0; i < combo->count() - 1; ++i) {
+        if (combo->itemData(i).toString() == savedPort) {
+            combo->setCurrentIndex(i);
+            isCustom = false;
+            break;
+        }
+    }
+    if (isCustom) {
+        combo->setCurrentIndex(combo->count() - 1);
+        if (customEdit) customEdit->setText(savedPort);
+    }
+    return isCustom;
+}
+#endif
+
 RadioSetupDialog::RadioSetupDialog(RadioModel* model, AudioEngine* audio,
                                    TgxlConnection* tgxl, PgxlConnection* pgxl,
                                    AntennaGeniusModel* ag,
                                    KiwiSdrManager* kiwiSdrManager,
+                                   AcomConnection* acom,
                                    QWidget* parent)
     : PersistentDialog(QStringLiteral("Radio Setup"),
                        QStringLiteral("RadioSetupDialogGeometry"), parent),
       m_model(model), m_audio(audio),
       m_tgxl(tgxl), m_pgxl(pgxl), m_ag(ag),
-      m_kiwiSdrManager(kiwiSdrManager)
+      m_kiwiSdrManager(kiwiSdrManager), m_acom(acom)
 {
     theme::setContainer(this, QStringLiteral("dialog/radioSetup"));
     setMinimumSize(960, 680);
@@ -5436,22 +5473,10 @@ QWidget* RadioSetupDialog::buildSerialTab()
         grid->addWidget(new QLabel("Port:"), 0, 0);
         auto* portCombo = new QComboBox;
         portCombo->setMinimumWidth(200);
-        for (const auto& info : QSerialPortInfo::availablePorts())
-            portCombo->addItem(QString("%1 — %2").arg(info.portName(), info.description()),
-                               info.portName());
-        // "Custom..." sentinel triggers manual entry field
-        portCombo->addItem("Custom...", QStringLiteral("__custom__"));
         QString savedPort = settings.value("SerialPortName", "").toString();
-        bool isCustom = false;
-        for (int i = 0; i < portCombo->count() - 1; ++i) {
-            if (portCombo->itemData(i).toString() == savedPort) {
-                portCombo->setCurrentIndex(i);
-                break;
-            }
-            if (i == portCombo->count() - 2) {
-                isCustom = !savedPort.isEmpty();
-            }
-        }
+        auto* customEdit = new QLineEdit;
+        customEdit->setPlaceholderText("/dev/ttyr0");
+        bool isCustom = populateSerialPortCombo(portCombo, customEdit, savedPort);
         grid->addWidget(portCombo, 0, 1);
 
         auto* refreshBtn = new QPushButton("Refresh");
@@ -5462,14 +5487,8 @@ QWidget* RadioSetupDialog::buildSerialTab()
 
         // Custom port row — hidden unless "Custom..." selected or saved port is custom
         auto* customLabel = new QLabel("Path:");
-        auto* customEdit = new QLineEdit;
-        customEdit->setPlaceholderText("/dev/ttyr0");
         customLabel->setVisible(isCustom);
         customEdit->setVisible(isCustom);
-        if (isCustom) {
-            customEdit->setText(savedPort);
-            portCombo->setCurrentIndex(portCombo->count() - 1);  // select "Custom..."
-        }
         grid->addWidget(customLabel, 1, 0);
         grid->addWidget(customEdit, 1, 1, 1, 3);
 
@@ -6627,6 +6646,201 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         });
     }
 
+    // Row 5: ACOM S-series amplifier — serial OR ser2net network, unlike the
+    // rows above (which are network-only). See
+    // docs/architecture/acom-600s-amplifier-design.md for the design note.
+    if (m_acom) {
+        const int row = 5;
+        static const QString kComboStyle =
+            "QComboBox { background: #1a2a3a; border: 1px solid #304050; "
+            "border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }"
+            "QComboBox::drop-down { border: none; }";
+
+        auto* devWidget = new QWidget;
+        auto* devLay = new QVBoxLayout(devWidget);
+        devLay->setContentsMargins(0, 0, 0, 0);
+        devLay->setSpacing(2);
+        auto* devLbl = new QLabel("ACOM Amplifier");
+        devLbl->setStyleSheet(kLabelStyle);
+        devLay->addWidget(devLbl);
+        auto* modeCombo = new QComboBox;
+        modeCombo->setStyleSheet(kComboStyle);
+#ifdef HAVE_SERIALPORT
+        modeCombo->addItem("Serial", "Serial");
+#endif
+        modeCombo->addItem("Network", "Network");
+        devLay->addWidget(modeCombo);
+        grid->addWidget(devWidget, row, 0);
+
+        // Address column: serial-port combo (with "Custom..." fallback, same
+        // pattern as the CW/keying Port Configuration group) OR a plain IP
+        // field, swapped via a QStackedWidget.
+        auto* addrStack = new QStackedWidget;
+        int serialPageIdx = -1;
+        QComboBox* serialCombo = nullptr;
+        QLineEdit* serialCustomEdit = nullptr;
+#ifdef HAVE_SERIALPORT
+        {
+            auto* serialPage = new QWidget;
+            auto* lay = new QHBoxLayout(serialPage);
+            lay->setContentsMargins(0, 0, 0, 0);
+            serialCombo = new QComboBox;
+            serialCombo->setStyleSheet(kComboStyle);
+            serialCustomEdit = new QLineEdit;
+            serialCustomEdit->setPlaceholderText("/dev/ttyUSB0");
+            serialCustomEdit->setStyleSheet(kEditStyle);
+            const QString savedSerialPort = PeripheralSettings::deviceString("Acom", "SerialPort");
+            populateSerialPortCombo(serialCombo, serialCustomEdit, savedSerialPort);
+            serialCustomEdit->setVisible(serialCombo->currentData().toString() == "__custom__");
+            connect(serialCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                    [serialCombo, serialCustomEdit](int idx) {
+                serialCustomEdit->setVisible(serialCombo->itemData(idx).toString() == "__custom__");
+            });
+            lay->addWidget(serialCombo, 1);
+            lay->addWidget(serialCustomEdit, 1);
+            serialPageIdx = addrStack->addWidget(serialPage);
+        }
+#endif
+        auto* netPage = new QWidget;
+        auto* netLay = new QHBoxLayout(netPage);
+        netLay->setContentsMargins(0, 0, 0, 0);
+        auto* netIpEdit = new QLineEdit;
+        netIpEdit->setPlaceholderText("ser2net host, raw mode — e.g. 192.168.1.52");
+        netIpEdit->setStyleSheet(kEditStyle);
+        netIpEdit->setText(PeripheralSettings::deviceString("Acom", "ManualIp"));
+        netLay->addWidget(netIpEdit);
+        const int netPageIdx = addrStack->addWidget(netPage);
+        grid->addWidget(addrStack, row, 1);
+
+        // Port/baud column: fixed "9600 8N1" text for serial (not
+        // user-configurable — mandated by the amplifier's own protocol
+        // spec) OR a port spin box for network mode.
+        auto* portStack = new QStackedWidget;
+        int serialBaudIdx = -1;
+#ifdef HAVE_SERIALPORT
+        {
+            auto* fixedLbl = new QLabel("9600 8N1");
+            fixedLbl->setStyleSheet("QLabel { color: #8aa8c0; font-size: 11px; }");
+            serialBaudIdx = portStack->addWidget(fixedLbl);
+        }
+#endif
+        auto* netPortSpin = new QSpinBox;
+        netPortSpin->setRange(1, 65535);
+        netPortSpin->setValue(PeripheralSettings::deviceInt("Acom", "ManualPort", 7000));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(netPortSpin,
+            "QSpinBox { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+            "border-radius: 3px; color: {{color.text.primary}}; font-size: 12px; padding: 2px; }");
+        const int netPortIdx = portStack->addWidget(netPortSpin);
+        grid->addWidget(portStack, row, 2);
+
+        auto applyMode = [=](const QString& mode) {
+#ifdef HAVE_SERIALPORT
+            if (mode == "Serial" && serialPageIdx >= 0) {
+                addrStack->setCurrentIndex(serialPageIdx);
+                portStack->setCurrentIndex(serialBaudIdx);
+                return;
+            }
+#endif
+            addrStack->setCurrentIndex(netPageIdx);
+            portStack->setCurrentIndex(netPortIdx);
+        };
+        const QString savedMode = PeripheralSettings::deviceString("Acom", "ConnectionMode",
+#ifdef HAVE_SERIALPORT
+            "Serial"
+#else
+            "Network"
+#endif
+        );
+        {
+            const int idx = modeCombo->findData(savedMode);
+            modeCombo->setCurrentIndex(idx >= 0 ? idx : 0);
+        }
+        applyMode(modeCombo->currentData().toString());
+        connect(modeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                [=](int idx) {
+            const QString mode = modeCombo->itemData(idx).toString();
+            PeripheralSettings::setDeviceString("Acom", "ConnectionMode", mode);
+            applyMode(mode);
+        });
+
+        auto* statusLbl = new QLabel(m_acom->isConnected() ? "Connected" : "Not connected");
+        statusLbl->setStyleSheet(m_acom->isConnected()
+            ? "QLabel { color: #00e060; font-size: 11px; }"
+            : "QLabel { color: #8aa8c0; font-size: 11px; }");
+        grid->addWidget(statusLbl, row, 4);
+
+        auto* acomBtn = new QPushButton(m_acom->isConnected() ? "Disconnect" : "Connect");
+        acomBtn->setStyleSheet(kBtnStyle);
+        grid->addWidget(acomBtn, row, 3);
+
+        auto updateAcomState = [this, acomBtn, statusLbl]() {
+            const bool conn = m_acom->isConnected();
+            acomBtn->setText(conn ? "Disconnect" : "Connect");
+            statusLbl->setText(conn ? "Connected" : "Not connected");
+            statusLbl->setStyleSheet(conn
+                ? "QLabel { color: #00e060; font-size: 11px; }"
+                : "QLabel { color: #8aa8c0; font-size: 11px; }");
+        };
+        connect(m_acom, &AcomConnection::connected, this, updateAcomState);
+        connect(m_acom, &AcomConnection::disconnected, this, updateAcomState);
+        connect(m_acom, &AcomConnection::connectionFailed, this,
+                [statusLbl](const QString& err) {
+            statusLbl->setText("Error: " + err);
+            statusLbl->setStyleSheet("QLabel { color: #e06060; font-size: 11px; }");
+        });
+
+        connect(acomBtn, &QPushButton::clicked, this, [=, this]() {
+            if (m_acom->isConnected()) {
+                m_acom->disconnect();
+                return;
+            }
+            const QString mode = modeCombo->currentData().toString();
+            if (mode == "Network") {
+                const QString ip = netIpEdit->text().trimmed();
+                if (ip.isEmpty()) return;
+                const int port = netPortSpin->value();
+                PeripheralSettings::setDeviceString("Acom", "ManualIp", ip);
+                PeripheralSettings::setDeviceInt("Acom", "ManualPort", port);
+                m_acom->connectNetwork(ip, static_cast<quint16>(port));
+            }
+#ifdef HAVE_SERIALPORT
+            else {
+                QString port = serialCombo->currentData().toString();
+                if (port == "__custom__")
+                    port = serialCustomEdit->text().trimmed();
+                if (port.isEmpty()) return;
+                PeripheralSettings::setDeviceString("Acom", "SerialPort", port);
+                m_acom->connectSerial(port);
+            }
+#endif
+        });
+
+        // Save-on-close: same "user cleared the field and closed the dialog
+        // without clicking Connect/Disconnect" handling the network-only
+        // rows get via buildRow() above — wipe the saved manual network IP
+        // (and its port) so a cleared field does not leave a stale
+        // auto-connect target behind. Serial mode has no equivalent free-text
+        // field to leak (the combo always resolves to either a discovered
+        // port or the explicit "Custom..." edit, which is only committed on
+        // a Connect click), so this only covers Acom's ManualIp/ManualPort.
+        m_peripheralRowSavers.append([netIpEdit, this]() {
+            if (!netIpEdit) return;
+            const QString ip = netIpEdit->text().trimmed();
+            if (!ip.isEmpty()) return;
+            const QString savedIp = PeripheralSettings::deviceString("Acom", "ManualIp");
+            if (savedIp.isEmpty()) return;
+            PeripheralSettings::clearDeviceField("Acom", "ManualIp");
+            PeripheralSettings::clearDeviceField("Acom", "ManualPort");
+            // Only disconnect if the live connection is actually the network
+            // target being cleared — ACOM, unlike the network-only rows
+            // above, may currently be connected over Serial instead, which
+            // this saved IP has nothing to do with.
+            if (m_acom->isConnected() && m_acom->description().startsWith(savedIp + ":")) {
+                m_acom->disconnect();
+            }
+        });
+    }
+
     for (auto* lbl : group->findChildren<QLabel*>())
         if (lbl->styleSheet().isEmpty()) lbl->setStyleSheet(kLabelStyle);
 
@@ -6650,6 +6864,9 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
         }
         if (m_ag) {
             m_ag->setAutoReconnect(on);
+        }
+        if (m_acom) {
+            m_acom->setAutoReconnect(on);
         }
     });
     vbox->addWidget(reconnectCheck);

--- a/src/gui/RadioSetupDialog.h
+++ b/src/gui/RadioSetupDialog.h
@@ -31,6 +31,7 @@ class TgxlConnection;
 class PgxlConnection;
 class AntennaGeniusModel;
 class KiwiSdrManager;
+class AcomConnection;
 
 // Radio Setup dialog — searchable, category-based configuration window.
 class RadioSetupDialog : public PersistentDialog {
@@ -42,6 +43,7 @@ public:
                               PgxlConnection* pgxl = nullptr,
                               AntennaGeniusModel* ag = nullptr,
                               KiwiSdrManager* kiwiSdrManager = nullptr,
+                              AcomConnection* acom = nullptr,
                               QWidget* parent = nullptr);
     void selectTab(const QString& tabName);
     void refreshFlexControlButtonActions();
@@ -125,6 +127,7 @@ private:
     PgxlConnection*    m_pgxl{nullptr};
     AntennaGeniusModel* m_ag{nullptr};
     KiwiSdrManager* m_kiwiSdrManager{nullptr};
+    AcomConnection* m_acom{nullptr};
     QTreeWidget* m_navigation{nullptr};
     QStackedWidget* m_pages{nullptr};
     QLabel* m_pageTitle{nullptr};

--- a/tests/acom_protocol_test.cpp
+++ b/tests/acom_protocol_test.cpp
@@ -1,0 +1,293 @@
+#include "core/AcomProtocol.h"
+
+#include <QByteArray>
+#include <QList>
+
+#include <cstdio>
+
+using namespace AetherSDR::Acom;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+void setLe16(QByteArray& buf, int offset, quint16 value)
+{
+    buf[offset] = static_cast<char>(value & 0xFF);
+    buf[offset + 1] = static_cast<char>((value >> 8) & 0xFF);
+}
+
+}  // namespace
+
+int main()
+{
+    // ── Checksum / framing, verified against literal examples from the
+    //    manufacturer's own spec (§3.1, §5.6, §5.7, §5.8, §5.9) — not derived
+    //    from our own formula, so these catch a wrong-sign or off-by-one bug.
+    report("TelemetryEnable (0x92) matches spec's literal checksum 0x15",
+           buildTelemetryEnable() == QByteArray::fromHex("55920415"));
+    report("TelemetryDisable (0x91) matches spec's literal checksum 0x16",
+           buildTelemetryDisable() == QByteArray::fromHex("55910416"));
+    report("obsolete ASCII-switch frame (0x90) matches spec's literal checksum 0x17",
+           buildFrame(0x90) == QByteArray::fromHex("55900417"));
+    report("bootloader-activation frame (0x93) matches spec's literal checksum 0x14",
+           buildFrame(0x93) == QByteArray::fromHex("55930414"));
+    report("'reply to wrong message' frame (0x01) matches spec's literal checksum 0xA6",
+           buildFrame(0x01) == QByteArray::fromHex("550104a6"));
+
+    // ── FrameParser: round-trips a built command frame back to itself.
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+
+        parser.feed(buildModeCommand(ModeCommand::Operate));
+        report("mode-change command round-trips through the parser",
+               received.size() == 1
+                   && received.at(0).address == static_cast<quint8>(Address::Command)
+                   && received.at(0).data.size() == 4
+                   && static_cast<quint8>(received.at(0).data.at(0)) == 0x02
+                   && static_cast<quint8>(received.at(0).data.at(2))
+                          == static_cast<quint8>(ModeCommand::Operate));
+    }
+
+    // ── FrameParser: self-heals past noise and a corrupted candidate frame.
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+
+        QByteArray stream;
+        stream.append(QByteArray::fromHex("0000FF"));       // leading noise, no start byte
+        stream.append(QByteArray::fromHex("550104FF"));     // 0x55 start, but wrong checksum
+        stream.append(buildClearFaultsCommand());           // a genuine valid frame
+        parser.feed(stream);
+
+        report("parser ignores noise and a bad-checksum candidate, still finds the real frame",
+               received.size() == 1
+                   && received.at(0).address == static_cast<quint8>(Address::Command)
+                   && static_cast<quint8>(received.at(0).data.at(0)) == 0x08);
+    }
+
+    // ── FrameParser: an implausible length byte (e.g. a bit-flip) is
+    //    discarded as noise immediately, rather than buffered forever
+    //    waiting for a frame that large to arrive — which would silently
+    //    absorb every subsequent real frame into the dead buffer.
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+
+        QByteArray stream;
+        QByteArray bogus = QByteArray::fromHex("55FF00");  // 0x55, addr, length=255
+        bogus.append(QByteArray(250, '\0'));               // plausible-looking trailing bytes
+        stream.append(bogus);
+        stream.append(buildClearFaultsCommand());          // a genuine valid frame
+
+        parser.feed(stream);
+        report("length byte over the 72-byte spec max is rejected as noise, not buffered",
+               received.size() == 1
+                   && received.at(0).address == static_cast<quint8>(Address::Command)
+                   && static_cast<quint8>(received.at(0).data.at(0)) == 0x08);
+    }
+
+    // ── FrameParser: a false 0x55 followed by a long non-0x55 garbage span
+    //    resyncs to the trailing valid frame in one shift (the linear-resync
+    //    path — the whole span is dropped at once rather than a byte at a time).
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+
+        QByteArray stream;
+        stream.append(QByteArray::fromHex("5500FF"));      // 0x55, then length 0xFF = invalid
+        stream.append(QByteArray(300, '\0'));              // long non-0x55 garbage span
+        stream.append(buildClearFaultsCommand());          // a genuine valid frame
+        parser.feed(stream);
+
+        report("a false start byte + long garbage span resyncs to the trailing frame",
+               received.size() == 1
+                   && received.at(0).address == static_cast<quint8>(Address::Command)
+                   && static_cast<quint8>(received.at(0).data.at(0)) == 0x08);
+    }
+
+    // ── FrameParser: split across two feed() calls (mid-frame boundary).
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+
+        const QByteArray frame = buildModeCommand(ModeCommand::Standby);
+        parser.feed(frame.left(3));   // start+address+length only
+        report("no frame emitted until the full length has arrived", received.isEmpty());
+        parser.feed(frame.mid(3));    // rest of the frame
+        report("frame split across feed() calls still decodes",
+               received.size() == 1
+                   && static_cast<quint8>(received.at(0).data.at(2))
+                          == static_cast<quint8>(ModeCommand::Standby));
+    }
+
+    // ── Telemetry decode (0x2F payload) — synthetic frame with known values
+    //    at every offset the decoder reads, built independently of the
+    //    decoder's own offset math (hand-placed, not looped).
+    {
+        QByteArray payload(68, '\0');
+        payload[0] = static_cast<char>(0x70);  // mode nibble = OperateTx (0x7)
+        setLe16(payload, 5, 1234);             // dcPowerPam1_x10W
+        setLe16(payload, 9, 1);                // system clock high word
+        setLe16(payload, 11, 5000);            // system clock low word -> 70536 total
+        setLe16(payload, 13, 305);             // paTempRaw
+        setLe16(payload, 17, 50);              // inputPower_x10W
+        setLe16(payload, 19, 450);             // forwardPowerW
+        setLe16(payload, 21, 8);               // reflectedPowerW
+        setLe16(payload, 23, 130);             // swr_x100 (1.30)
+        setLe16(payload, 25, 200);             // dissipationPam1_x10W
+        setLe16(payload, 33, 5000);            // vcc5_mV
+        setLe16(payload, 35, 261);             // vcc26_x10V (26.1 V)
+        setLe16(payload, 37, 502);             // hv1_x10V (50.2 V)
+        setLe16(payload, 41, 9400);            // id1_mA (9.4 A)
+        setLe16(payload, 45, 14245);           // carrierFreqKHz
+        payload[63] = static_cast<char>(0xFF); // errorCode: no fault
+        setLe16(payload, 64, 0);               // errorParam
+        payload[66] = static_cast<char>((2 << 4) | 5);  // fanSpeed=2, activeBand=5 (20m)
+
+        const QByteArray fullFrame = buildFrame(static_cast<quint8>(Address::Telemetry), payload);
+        report("hand-built telemetry frame is exactly 72 bytes", fullFrame.size() == 72);
+
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+        parser.feed(fullFrame);
+        report("telemetry frame parses with a valid checksum", received.size() == 1);
+
+        const auto decoded = decodeTelemetry(received.at(0).data);
+        report("decodeTelemetry succeeds on a full-length payload", decoded.has_value());
+        if (decoded) {
+            report("mode decodes to OperateTx", decoded->mode == Mode::OperateTx);
+            report("dcPowerPam1_x10W round-trips", decoded->dcPowerPam1_x10W == 1234);
+            report("systemClockSec combines high+low words correctly",
+                   decoded->systemClockSec == 70536);
+            report("paTempRaw round-trips", decoded->paTempRaw == 305);
+            report("forwardPowerW round-trips", decoded->forwardPowerW == 450);
+            report("reflectedPowerW round-trips", decoded->reflectedPowerW == 8);
+            report("swr_x100 round-trips", decoded->swr_x100 == 130);
+            report("vcc26_x10V round-trips", decoded->vcc26_x10V == 261);
+            report("hv1_x10V round-trips", decoded->hv1_x10V == 502);
+            report("id1_mA round-trips", decoded->id1_mA == 9400);
+            report("carrierFreqKHz round-trips", decoded->carrierFreqKHz == 14245);
+            report("errorCode round-trips (0xFF = no fault)", decoded->errorCode == 0xFF);
+            report("fanSpeed extracted from high nibble", decoded->fanSpeed == 2);
+            report("activeBand extracted from low nibble", decoded->activeBand == 5);
+        }
+        report("short payload is rejected rather than reading out of bounds",
+               !decodeTelemetry(payload.left(67)).has_value());
+    }
+
+    // ── Lookup tables.
+    report("bandName(5) is 20m per the spec's LPF channel table", bandName(5) == "20m");
+    report("bandName(0) is the reserved placeholder", bandName(0) == "?m");
+    report("bandName rejects an out-of-range index safely", bandName(99) == "?m");
+    report("errorCodeName(0xFF) reads as no fault", errorCodeName(0xFF) == "No fault");
+    report("errorCodeName(0x39) matches the PAM-overcurrent group",
+           errorCodeName(0x39) == "Excessive PAM current");
+
+    // ── Per-model scaling table (design doc §6). 600S is hardware-confirmed;
+    //    the rest are derived from ACOM's own published rated-output specs,
+    //    not the model name and not the (wrong, for the big models) public
+    //    reference client constants — see the modelTable() comment.
+    const auto& s600 = modelSpec("600S");
+    report("600S nominal/max forward power matches the design doc table",
+           s600.nominalForwardW == 600.0f && s600.maxForwardW == 700.0f);
+    report("600S has no PAM2", !s600.hasPam2);
+    report("500S max is a round number derived from the 600S ratio, not the model name",
+           modelSpec("500S").nominalForwardW == 500.0f && modelSpec("500S").maxForwardW == 600.0f);
+    report("700S max is a round number derived from the 600S ratio, not the model name",
+           modelSpec("700S").nominalForwardW == 700.0f && modelSpec("700S").maxForwardW == 800.0f);
+    report("1200S is rated 1000W (NOT 1200W — the model name is not the rated wattage), "
+           "max uses the name itself (1200W) since that fits the +200W pattern",
+           modelSpec("1200S").nominalForwardW == 1000.0f && modelSpec("1200S").maxForwardW == 1200.0f);
+    report("1400S is rated 1200W, max 1400W (name fits the +200W pattern)",
+           modelSpec("1400S").nominalForwardW == 1200.0f && modelSpec("1400S").maxForwardW == 1400.0f);
+    report("2020S is rated 1500W (name doesn't fit any wattage pattern), "
+           "max falls back to the ratio-derived value, not '2020'",
+           modelSpec("2020S").nominalForwardW == 1500.0f && modelSpec("2020S").maxForwardW == 1750.0f);
+    const auto& s1200 = modelSpec("1200S");
+    report("1200S has PAM2", s1200.hasPam2);
+    report("1400S has PAM2 (inferred from power class, like 1200S/2020S)",
+           modelSpec("1400S").hasPam2);
+    report("unknown model name falls back to 600S rather than crashing",
+           modelSpec("NoSuchModel").name == "600S");
+    report("modelNames() lists all six S-series entries (500/600/700/1200/1400/2020)",
+           modelNames().size() == 6);
+
+    // ── Model tier ordering + auto-ranging (design doc §6).
+    const QStringList tiers = orderedModelTiers();
+    report("tier order is ascending by power: 500S,600S,700S,1200S,1400S,2020S",
+           tiers == QStringList({"500S", "600S", "700S", "1200S", "1400S", "2020S"}));
+    report("a reading that exceeds 500S's ceiling but fits 600S's resolves to 600S",
+           tierForForwardPower(650.0f) == "600S");
+    report("a reading that fits 500S still returns 500S, not something smaller nonexistent",
+           tierForForwardPower(400.0f) == "500S");
+    report("a reading between 600S and 700S ceilings picks 700S",
+           tierForForwardPower(750.0f) == "700S");
+    report("a reading that only a 1200S-tier amp could produce picks 1200S, "
+           "skipping 700S directly rather than requiring incremental steps",
+           tierForForwardPower(1100.0f) == "1200S");
+    report("a reading beyond every tier's max clamps to the top tier (2020S) rather than erroring",
+           tierForForwardPower(5000.0f) == "2020S");
+
+    // ── SystemConfig (address 0x11) — request framing + decode.
+    report("SystemConfig request (0x02, asking for 0x11) has the spec's 5-byte shape",
+           buildRequestMessage(0x11).size() == 5);
+    {
+        QList<Frame> received;
+        FrameParser parser;
+        parser.setFrameCallback([&](const Frame& f) { received.append(f); });
+        parser.feed(buildRequestMessage(0x11));
+        report("SystemConfig request round-trips through the parser",
+               received.size() == 1
+                   && received.at(0).address == 0x02
+                   && static_cast<quint8>(received.at(0).data.at(0)) == 0x11);
+    }
+    {
+        // Hand-built SystemConfig payload (26 bytes) — amplifierType=1 (the
+        // spec's only documented value), a fabricated fw/serial/fault-count
+        // for round-trip verification, not real hardware data.
+        QByteArray payload(26, '\0');
+        payload[0] = static_cast<char>(0x01);  // amplifierType = 1 (A600S)
+        payload[1] = static_cast<char>(0x02);  // fwVersion
+        payload[2] = static_cast<char>(0x09);  // fwSubVersion
+        for (int i = 0; i < 12; ++i)
+            payload[13 + i] = static_cast<char>(0xA0 + i);  // serial number bytes
+        payload[25] = static_cast<char>(0x03);  // hardFaultCount
+
+        const auto cfg = decodeSystemConfig(payload);
+        report("decodeSystemConfig succeeds on a full-length payload", cfg.has_value());
+        if (cfg) {
+            report("amplifierType round-trips", cfg->amplifierType == 1);
+            report("fwVersion/fwSubVersion round-trip", cfg->fwVersion == 2 && cfg->fwSubVersion == 9);
+            report("serial number decodes as a 24-char hex dump of the 12 raw bytes",
+                   cfg->serialNumberHex == QStringLiteral("a0a1a2a3a4a5a6a7a8a9aaab"));
+            report("hardFaultCount round-trips", cfg->hardFaultCount == 3);
+        }
+        report("short SystemConfig payload is rejected rather than reading out of bounds",
+               !decodeSystemConfig(payload.left(25)).has_value());
+    }
+    report("modelNameForAmplifierType(1) confidently resolves to 600S — the only "
+           "value the spec actually documents",
+           modelNameForAmplifierType(1) == "600S");
+    report("modelNameForAmplifierType(anything else) returns empty — a genuine "
+           "unknown, not a guess (design doc §6)",
+           modelNameForAmplifierType(2).isEmpty() && modelNameForAmplifierType(0).isEmpty());
+
+    std::printf("\n%d ACOM protocol test(s) failed.\n", g_failed);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4295. Adds native ACOM S-series amplifier support (500S/600S/700S/
1200S/1400S/2020S) as a standalone RS-232 peripheral — serial or
ser2net-style raw TCP, same binary protocol either way. A dedicated
`AcomConnection`/`AcomApplet` pair (sibling of the existing PGXL/TGXL
peripherals, not a variant of `AmpModel`/`AmpApplet` — see the design
doc's §2 for why an earlier version that shared `AmpModel` was reverted)
decodes live telemetry and error state, drives STANDBY/OPERATE/OFF and
clear-faults, and resolves the amp's model tier automatically — via a
one-shot system-config query where the amp reports it, and otherwise by
auto-ranging from observed forward power — with no manual model-selector
dropdown. Includes a Radio Setup → Peripherals row (Serial/Network toggle)
and protocol-layer unit tests independent of live hardware.

Also resolves a 10-item adversarial code review of the initial two
commits: a SystemConfig-downgrade guard, wiring the spec-mandated 0x86
ack into the receive path, a length-ceiling check in the frame parser,
throttling info-grid label updates through the existing 10 Hz timer,
peripheral-row settings cleanup parity with PGXL/TGXL/Antenna Genius, a
shared serial-port-combo helper (previously duplicated with a subtly
different edge case between this row and the CW/keying tab), ACOM's own
settings moved onto the nested-JSON `PeripheralSettings` class (Principle
V) instead of flat `AppSettings` keys, and several documentation/licensing
accuracy fixes.

Two findings were deliberately left untouched rather than resolved, since
fixing them meant editing files outside this PR's actual scope: a
reconnect-backoff timer duplicated across PgxlConnection/TgxlConnection/
AcomConnection, and TGXL/PGXL/Antenna Genius/ShackSwitch's own settings
still using the same flat-key pattern ACOM's used to. Both are real,
legitimate follow-up work — scoped to their own PR against `main`, not
bundled with this ACOM-only branch. See the Checklist section for detail
on the second one.

Tested against real ACOM 600S hardware over multiple iterations.

## Constitution principle honored

Principle IV — the protocol implementation is clean-room, consulted from
ACOM's own published RS-232 spec (plus a secondary MIT-licensed reference
client used only as a practical cross-check); no code from either is
incorporated (see `THIRD_PARTY_LICENSES`). Principle XI also applies to
the review-fix commit — each finding was verified by an added/passing
test or a local build, not just asserted fixed.

## Test plan

- [x] Local build passes (`cmake --build` — `acom_protocol_test` and the
      full `AetherSDR.exe` target, zero warnings from any touched file)
- [x] Behavior verified on a real radio/amplifier (ACOM 600S, iterated
      over multiple rounds of live hardware testing)
- [x] Existing tests pass (CI) — `acom_protocol_test`: 62/62
- [x] Rebased onto current `main` (squashed to a single commit first,
      one `CMakeLists.txt` conflict against an unrelated new upstream
      test target, resolved by keeping both) and rebuilt clean
- [ ] Reproduction steps documented if user-reported bug — n/a, new
      feature, not a bug fix

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V). ACOM's own row now stores its settings
      (`ManualIp`/`ManualPort`/`SerialPort`/`ConnectionMode`) via the
      existing `PeripheralSettings` class (already the Principle-V home
      for `AutoReconnect`), extended with generic per-device field
      accessors — `obj["Acom"]["ManualIp"]` etc. — instead of introducing
      a fifth set of flat `Acom_*` keys. No migration step was needed:
      ACOM hasn't shipped in a release yet, so no user has an existing
      flat `Acom_ManualIp` to preserve; new installs write directly into
      the nested shape.
      TGXL/PGXL/Antenna Genius/ShackSwitch still use their own original
      flat keys, unchanged — an earlier pass in this PR also migrated
      those onto the same nested class, but that reached outside ACOM's
      actual scope to touch four working, unrelated peripherals just to
      "finish the job" cleanly. Reverted that part back to flat keys per
      established branch convention (scope discipline over eliminating
      inconsistency); the sibling migration is real, useful work but
      belongs in its own PR against `main`.
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — the
      PWR/REF/SWR gauges are `HGauge` instances, which own their own
      `MeterSmoother` internally
- [x] Documentation updated if user-visible behavior changed —
      `docs/architecture/acom-600s-amplifier-design.md` (new),
      `docs/architecture/README.md` index entry, `THIRD_PARTY_LICENSES`
- [ ] Security-sensitive changes reference a GHSA if applicable — n/a
