### PR TITLE
[audio] Fix Kiwi diversity slice volume reset on antenna change

### DIFF
--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -559,7 +559,21 @@ void MainWindow::setKiwiSdrVirtualAntennaForSlice(int sliceId,
     if (!m_kiwiSdrVirtualPreviousMute.contains(sliceId)) {
         m_kiwiSdrVirtualPreviousMute.insert(sliceId, slice->flexAudioMute());
     }
+    const bool wasExternalReceiveActive = slice->externalReceiveReplacementActive();
     slice->setExternalReceiveAudioReplacementMute(true);
+    if (!wasExternalReceiveActive && slice->isDiversityChild()
+        && slice->flexAudioGain() <= 0.0f) {
+        // A Flex diversity child always reports audio_level=0 (its audio is
+        // combined into the parent), so the snapshot just taken above is
+        // silence. Seed it from the parent's level instead, so both slices
+        // start matched rather than the child starting muted — see #4300.
+        for (SliceModel* other : m_radioModel.slices()) {
+            if (isSameDiversityReceivePair(slice, other) && other->isDiversityParent()) {
+                slice->setAudioGain(other->audioGain());
+                break;
+            }
+        }
+    }
     if (m_appletPanel) {
         m_appletPanel->updateSliceButtons(m_radioModel.slices(), m_activeSliceId);
     }

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -761,10 +761,16 @@ void SliceModel::setExternalReceiveAudioReplacementMute(bool active,
     const int previousReceiveSquelchLevel = receiveSquelchLevel();
     const bool previousExternalAutoSquelch = m_externalReceiveAutoSquelch;
     if (active) {
-        m_externalReceiveAudioGain = m_audioGain;
-        m_externalReceiveAudioPan = m_audioPan;
-        m_externalReceiveAudioMute = false;
-        m_externalReceiveAudioReplacement = true;
+        // Only snapshot the Flex gain/pan on the false→true transition. Calling
+        // this again while replacement is already active (e.g. switching from
+        // one Kiwi RX source to another) must not clobber the external volume
+        // the user has since adjusted — see #4300.
+        if (!m_externalReceiveAudioReplacement) {
+            m_externalReceiveAudioGain = m_audioGain;
+            m_externalReceiveAudioPan = m_audioPan;
+            m_externalReceiveAudioMute = false;
+            m_externalReceiveAudioReplacement = true;
+        }
         if (!m_audioMute) {
             m_audioMute = true;
             sendCommand(QString("slice set %1 audio_mute=1").arg(m_id));


### PR DESCRIPTION
## Summary
- `setExternalReceiveAudioReplacementMute()` in `SliceModel` unconditionally re-snapshotted external gain/pan from the Flex slice on every activation, so switching a Diversity child's virtual RX source between KiwiSDRs silently overwrote the volume the user had just raised. The snapshot now only happens on the false→true transition.
- A Flex diversity child always reports `audio_level=0` (its audio is combined into the parent), so the first snapshot left the child muted. The child's external gain is now seeded from its diversity parent's level when a Kiwi virtual RX source is first activated, so both slices start matched.

Fixes #4300.

## Test plan
- [x] Built on Windows 11 (Flex 6600, fw 4.2.20) against this branch
- [x] Enabled Div, created slice D, switched slice D to a KiwiSDR — volume did not drop to 0 and stayed matched with slice A
- [x] Switched slice D to a different KiwiSDR — volume remained matched, did not reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)