### PR TITLE
Smooth window resize and panadapter navigation with GPU previews

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1780,6 +1780,7 @@ if(AETHER_GPU_SPECTRUM)
             resources/shaders/texturedquad_rowframes.frag
             resources/shaders/overlay.vert
             resources/shaders/overlay.frag
+            resources/shaders/overlay_frequency_preview.frag
             resources/shaders/spectrum.vert
             resources/shaders/spectrum.frag
             resources/shaders/panscope.frag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1777,6 +1777,7 @@ if(AETHER_GPU_SPECTRUM)
         FILES
             resources/shaders/texturedquad.vert
             resources/shaders/texturedquad.frag
+            resources/shaders/texturedquad_rowframes.frag
             resources/shaders/overlay.vert
             resources/shaders/overlay.frag
             resources/shaders/spectrum.vert
@@ -2651,6 +2652,13 @@ add_executable(dss_renderer_test
 target_include_directories(dss_renderer_test PRIVATE src)
 target_link_libraries(dss_renderer_test PRIVATE Qt6::Core Qt6::Gui)
 add_test(NAME dss_renderer_test COMMAND dss_renderer_test)
+
+add_executable(spectrum_preview_logic_test
+    tests/spectrum_preview_logic_test.cpp
+)
+target_include_directories(spectrum_preview_logic_test PRIVATE src)
+target_link_libraries(spectrum_preview_logic_test PRIVATE Qt6::Core)
+add_test(NAME spectrum_preview_logic_test COMMAND spectrum_preview_logic_test)
 
 add_executable(kiwi_sdr_redirect_policy_test
     tests/kiwi_sdr_redirect_policy_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,6 +719,7 @@ set(GUI_SOURCES
     src/gui/PanadapterMessageOverlay.h
     src/gui/PanadapterRenderScheduler.cpp
     src/gui/SpectrumWidget.cpp
+    src/gui/WaterfallHistoryBuffer.cpp
     src/gui/SpectrumOverlayMenu.cpp
     src/gui/DssRenderer.cpp
     src/gui/FrequencyEntryParser.cpp
@@ -2660,6 +2661,14 @@ add_executable(spectrum_preview_logic_test
 target_include_directories(spectrum_preview_logic_test PRIVATE src)
 target_link_libraries(spectrum_preview_logic_test PRIVATE Qt6::Core)
 add_test(NAME spectrum_preview_logic_test COMMAND spectrum_preview_logic_test)
+
+add_executable(waterfall_history_buffer_test
+    tests/waterfall_history_buffer_test.cpp
+    src/gui/WaterfallHistoryBuffer.cpp
+)
+target_include_directories(waterfall_history_buffer_test PRIVATE src)
+target_link_libraries(waterfall_history_buffer_test PRIVATE Qt6::Core)
+add_test(NAME waterfall_history_buffer_test COMMAND waterfall_history_buffer_test)
 
 add_executable(kiwi_sdr_redirect_policy_test
     tests/kiwi_sdr_redirect_policy_test.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -742,7 +742,7 @@ separately because they are a subset of FFT/waterfall ingest.
      "measuredMainThreadMsPerSec":10.7,
      "hiddenWaterfallUpdatesPerSec":0.0,
      "hiddenDssHistoryRowsPerSec":0.0,
-     "waterfallAllocatedBytes":102760448,
+     "waterfallAllocatedBytes":583680,
      "dssAllocatedBytes":37847040},
    "pans":[...],"scopes":[...],"renderScheduler":{...}}
 ```
@@ -787,9 +787,9 @@ cost a few integer adds per frame.
 | `previewScaleRefreshesPerSec`, `previewScalePaintMsPerSec`, `previewScaleUploadBytesPerSec` | narrow frequency-scale strip refreshes during preview; separates the small correctness update from full-pan overlay work |
 | `wfUploadBytesPerSec` | waterfall texture upload volume |
 | `nativeWaterfall*` / `kiwiWaterfall*` | source-specific ingest rate and GUI-thread cost; `HiddenUpdates` identifies background Flex/Kiwi work |
-| `waterfallVisibleRows*` / `waterfallHistoryRows*` | viewport and retained RGB-history write rates/cost (RGB history is written only for the visible source) |
+| `waterfallVisibleRows*` / `waterfallHistoryRows*` | viewport and retained compact-intensity-history write rates/cost (history is written only for the visible source) |
 | `dssLiveRows*` / `dssHistoryRows*` | 96-row live 3D surface work versus deep retained scrollback work; `dssHiddenLiveRowsPerSec` exposes the hidden-Flex live-ring warming (#4081) — hidden sources retain no deep history |
-| `waterfallAllocatedBytes` / `dssAllocatedBytes` | current plus cached Flex/Kiwi/profile storage, including hidden-source retained history |
+| `waterfallAllocatedBytes` / `dssAllocatedBytes` | current plus cached Flex/Kiwi/profile storage; waterfall history is counted by actually allocated lazy chunks, not logical capacity |
 | `paintsPerSec` / `paintMsPerSec` | software-QPainter path (non-zero only before QRhi init or in non-GPU builds) |
 | `renderScheduler` | shared panadapter repaint scheduler counters; `coalescedRequests` and `avgWidgetsPerFlush` show cross-pan request coalescing |
 

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -782,6 +782,9 @@ cost a few integer adds per frame.
 | `fftBuildMsPerSec` / `fftVboBytesPerSec` | FFT trace resample + vertex bake cost and VBO upload volume |
 | `overlayRebuilds*`, `overlayUploadBytesPerSec` | static-overlay QPainter repaints (should be ~0/s when idle) |
 | `overlayDirtyCauses` | first-cause attribution for each overlay rebuild (`smartMtr`, `detect`, `other`) |
+| `previewOverlayTransformsPerSec` | GPU-only remaps of the retained frequency-overlay texture during pan/zoom; these should not produce matching full-image rebuilds/uploads |
+| `previewOverlayCommitRefreshes` | exact CPU overlay refreshes performed when pan/zoom previews commit |
+| `previewScaleRefreshesPerSec`, `previewScalePaintMsPerSec`, `previewScaleUploadBytesPerSec` | narrow frequency-scale strip refreshes during preview; separates the small correctness update from full-pan overlay work |
 | `wfUploadBytesPerSec` | waterfall texture upload volume |
 | `nativeWaterfall*` / `kiwiWaterfall*` | source-specific ingest rate and GUI-thread cost; `HiddenUpdates` identifies background Flex/Kiwi work |
 | `waterfallVisibleRows*` / `waterfallHistoryRows*` | viewport and retained RGB-history write rates/cost (RGB history is written only for the visible source) |

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -20,9 +20,9 @@ layout(std140, binding = 0) uniform U {
     float frontMaxRidgeFrac;
     float haze;
     float texCols;
-    float pad0;
-    float pad1;
-    float pad2;
+    float frequencyScale;
+    float frequencyOffset;
+    float frequencyPreview;
     vec4  bgFill;
 };
 

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -18,9 +18,9 @@ layout(std140, binding = 0) uniform U {
     float frontMaxRidgeFrac;  // max ridge height (front) as a fraction of plot H
     float haze;               // atmospheric fade toward bgFill with depth
     float texCols;            // height-texture width, for column texel-centre sampling
-    float pad0;
-    float pad1;
-    float pad2;
+    float frequencyScale;     // target bandwidth / retained-frame bandwidth
+    float frequencyOffset;    // (target centre - retained centre) / retained bandwidth
+    float frequencyPreview;   // non-zero while the interaction preview is active
     vec4  bgFill;             // plot background colour (for haze)
 };
 
@@ -40,8 +40,15 @@ void main()
     // neighbouring row/column. rowOffset already carries the row half-texel; the
     // column maps geometry u in [0,1] onto centre (u*(cols-1)+0.5)/cols.
     float texY = fract(rowOffset + v);
-    float texU = (texCols > 1.0) ? (u * (texCols - 1.0) + 0.5) / texCols : 0.5;
-    float dbm  = texture(heightTex, vec2(texU, texY)).r;
+    float sourceU = 0.5 + frequencyOffset + (u - 0.5) * frequencyScale;
+    bool outsidePreview = frequencyPreview > 0.5
+        && (sourceU < 0.0 || sourceU > 1.0);
+    float texU = (texCols > 1.0)
+        ? (sourceU * (texCols - 1.0) + 0.5) / texCols
+        : 0.5;
+    float dbm = outsidePreview
+        ? floorDbm
+        : texture(heightTex, vec2(texU, texY)).r;
     // Linear strength drives COLOUR (LUT[sLin] = dbmToRgb(floor+sLin*range),
     // matching the CPU path); the zCurve lift applies to HEIGHT only.
     float sLin = clamp((dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);

--- a/resources/shaders/overlay_frequency_preview.frag
+++ b/resources/shaders/overlay_frequency_preview.frag
@@ -1,0 +1,38 @@
+#version 440
+
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 fragColor;
+
+layout(std140, binding = 0) uniform PreviewUniforms {
+    float frequencyScale;
+    float frequencyOffset;
+    float frequencyPreview;
+    float spectrumRight;
+    float spectrumBottom;
+    float waterfallTop;
+    float waterfallRight;
+    float reserved;
+};
+
+layout(binding = 1) uniform sampler2D tex;
+
+void main()
+{
+    vec2 sourceUv = v_uv;
+    bool inSpectrum = v_uv.y < spectrumBottom && v_uv.x < spectrumRight;
+    bool inWaterfall = v_uv.y >= waterfallTop && v_uv.x < waterfallRight;
+
+    if (frequencyPreview > 0.5 && (inSpectrum || inWaterfall)) {
+        float contentRight = inSpectrum ? spectrumRight : waterfallRight;
+        float targetU = v_uv.x / max(contentRight, 0.0001);
+        float sourceU = 0.5 + frequencyOffset
+            + (targetU - 0.5) * frequencyScale;
+        if (sourceU < 0.0 || sourceU > 1.0) {
+            fragColor = vec4(0.0);
+            return;
+        }
+        sourceUv.x = sourceU * contentRight;
+    }
+
+    fragColor = texture(tex, sourceUv);
+}

--- a/resources/shaders/texturedquad_rowframes.frag
+++ b/resources/shaders/texturedquad_rowframes.frag
@@ -1,0 +1,39 @@
+#version 440
+
+layout(location = 0) in vec2 v_uv;
+layout(location = 0) out vec4 fragColor;
+
+layout(binding = 1) uniform sampler2D tex;
+layout(binding = 2) uniform sampler2D rowFrequencyFrame;
+
+layout(std140, binding = 0) uniform Uniforms {
+    float rowOffset;
+    float targetCenterOffsetMhz;
+    float targetBandwidthMhz;
+    float rowFrequencyFrames;
+};
+
+void main()
+{
+    // Every physical ring row retains the frequency frame in which it was
+    // rasterized. Map the current viewport into that row independently, so a
+    // newly arriving radio row can expose fresh frequencies during a pan while
+    // older rows remain correctly located. Center is stored relative to a CPU
+    // reference to preserve sub-kHz precision at VHF/UHF absolute frequencies.
+    float physicalY = fract(v_uv.y + rowOffset);
+    vec2 rowFrame = texture(rowFrequencyFrame, vec2(0.5, physicalY)).rg;
+    if (rowFrame.y <= 0.0) {
+        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+        return;
+    }
+    float sourceU = 0.5 + (targetCenterOffsetMhz - rowFrame.x) / rowFrame.y
+        + (v_uv.x - 0.5) * targetBandwidthMhz / rowFrame.y;
+    if (sourceU < 0.0 || sourceU > 1.0) {
+        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+        return;
+    }
+
+    // Apply ring buffer offset per-pixel (not per-vertex, to avoid fract()
+    // interpolation issues).
+    fragColor = texture(tex, vec2(sourceU, physicalY));
+}

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
+
+namespace AetherSDR {
+
+struct FrequencyFrame {
+    double centerMhz{0.0};
+    double bandwidthMhz{0.0};
+
+    bool isValid() const
+    {
+        return std::isfinite(centerMhz)
+            && std::isfinite(bandwidthMhz)
+            && centerMhz > 0.0
+            && bandwidthMhz > 0.0;
+    }
+};
+
+struct FrequencyPreviewTransform {
+    double scale{1.0};
+    double offset{0.0};
+    bool valid{false};
+};
+
+inline double frequencyCanvasFraction(double localX, int contentWidth)
+{
+    const int safeWidth = std::max(1, contentWidth);
+    return std::clamp(localX / static_cast<double>(safeWidth) - 0.5,
+                      -0.5, 0.5);
+}
+
+inline double frequencyAtFraction(const FrequencyFrame& frame, double fraction)
+{
+    return frame.centerMhz + fraction * frame.bandwidthMhz;
+}
+
+inline double centerForAnchoredBandwidth(double anchorMhz,
+                                         double anchorFraction,
+                                         double bandwidthMhz)
+{
+    return anchorMhz - anchorFraction * bandwidthMhz;
+}
+
+inline FrequencyPreviewTransform frequencyPreviewTransform(
+    const FrequencyFrame& base,
+    const FrequencyFrame& target)
+{
+    if (!base.isValid() || !target.isValid()) {
+        return {};
+    }
+    return FrequencyPreviewTransform{
+        target.bandwidthMhz / base.bandwidthMhz,
+        (target.centerMhz - base.centerMhz) / base.bandwidthMhz,
+        true,
+    };
+}
+
+inline double sourceUnitPosition(double targetUnitPosition,
+                                 const FrequencyFrame& source,
+                                 const FrequencyFrame& target)
+{
+    if (!source.isValid() || !target.isValid()
+        || !std::isfinite(targetUnitPosition)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const double targetFrequencyMhz = target.centerMhz
+        + (targetUnitPosition - 0.5) * target.bandwidthMhz;
+    return 0.5 + (targetFrequencyMhz - source.centerMhz)
+        / source.bandwidthMhz;
+}
+
+struct FrequencyRangeCommand {
+    double centerMhz{0.0};
+    double bandwidthMhz{0.0};
+
+    bool isValid() const
+    {
+        return FrequencyFrame{centerMhz, bandwidthMhz}.isValid();
+    }
+};
+
+class FrequencyRangeCommandThrottle {
+public:
+    std::optional<FrequencyRangeCommand> request(
+        const FrequencyRangeCommand& command,
+        bool due,
+        bool force)
+    {
+        if (!command.isValid()) {
+            return std::nullopt;
+        }
+        m_pending = command;
+        if (!due && !force) {
+            return std::nullopt;
+        }
+        return takePending();
+    }
+
+    std::optional<FrequencyRangeCommand> takePending()
+    {
+        if (!m_pending.has_value()) {
+            return std::nullopt;
+        }
+        const FrequencyRangeCommand command = *m_pending;
+        m_pending.reset();
+        return command;
+    }
+
+    void clear() { m_pending.reset(); }
+    bool hasPending() const { return m_pending.has_value(); }
+
+private:
+    std::optional<FrequencyRangeCommand> m_pending;
+};
+
+enum class WaterfallPipelineMode {
+    Legacy,
+    RowFrequencyFrames,
+};
+
+struct WaterfallRowFrameReadiness {
+    bool requested{false};
+    bool formatSupported{false};
+    bool textureCreated{false};
+    bool samplerCreated{false};
+    bool bindingsCreated{false};
+    bool pipelineCreated{false};
+};
+
+inline WaterfallPipelineMode chooseWaterfallPipeline(
+    const WaterfallRowFrameReadiness& readiness)
+{
+    return readiness.requested
+            && readiness.formatSupported
+            && readiness.textureCreated
+            && readiness.samplerCreated
+            && readiness.bindingsCreated
+            && readiness.pipelineCreated
+        ? WaterfallPipelineMode::RowFrequencyFrames
+        : WaterfallPipelineMode::Legacy;
+}
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -69,6 +69,7 @@
 #include <cmath>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <utility>
 #include "core/ThemeManager.h"
 
@@ -80,6 +81,30 @@ QSoundEffect* SpectrumWidget::s_starstruckSound = nullptr;
 namespace {
 
 constexpr int kDssMaxIncrementalUploadRows = 8;
+
+#ifdef AETHER_GPU_SPECTRUM
+bool waterfallGpuFrequencyPreviewRequested()
+{
+    if (!qEnvironmentVariableIsSet("AETHER_WF_GPU_PREVIEW")) {
+        return true;
+    }
+    return qEnvironmentVariableIntValue("AETHER_WF_GPU_PREVIEW") != 0;
+}
+
+bool waterfallFrameTextureFailureForced()
+{
+    return qEnvironmentVariableIsSet("AETHER_AUTOMATION")
+        && qEnvironmentVariableIntValue(
+               "AETHER_AUTOMATION_FORCE_WF_FRAME_TEXTURE_FAILURE") != 0;
+}
+
+bool waterfallFrameResizeFailureForced()
+{
+    return qEnvironmentVariableIsSet("AETHER_AUTOMATION")
+        && qEnvironmentVariableIntValue(
+               "AETHER_AUTOMATION_FORCE_WF_FRAME_RESIZE_FAILURE") != 0;
+}
+#endif
 
 constexpr int dssFillVerticesPerRow()
 {
@@ -276,7 +301,9 @@ static constexpr int kNativeWaterfallRateChangeGraceMaxMs = 14000;
 static constexpr int kPanDragFrameMs = 33;
 static constexpr int kPanDragCommandMs = 33;
 static constexpr int kPanDragSettleMs = 160;
+static constexpr int kFrequencyRangeCommandMs = 33;
 static constexpr int kFrequencyRangeSettleMs = 300;
+static constexpr int kResizeBufferSettleMs = 120;
 static constexpr int kDbmReleaseHoldFrames = 10;
 static constexpr int kDbmReleaseErrorSampleCount = 256;
 static constexpr float kDbmReleasePreviewChangeThresholdDb = 0.05f;
@@ -1020,13 +1047,108 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("live")] = m_wfLive;
     m[QStringLiteral("centerMhz")] = m_centerMhz;
     m[QStringLiteral("bandwidthMhz")] = m_bandwidthMhz;
+    m[QStringLiteral("frequencyPreviewAvailable")] = frequencyPreviewAvailable();
+    m[QStringLiteral("frequencyPreviewActive")] = m_frequencyPreviewActive;
+    m[QStringLiteral("frequencyPreviewBaseCenterMhz")] =
+        m_frequencyPreviewBaseCenterMhz;
+    m[QStringLiteral("frequencyPreviewBaseBandwidthMhz")] =
+        m_frequencyPreviewBaseBandwidthMhz;
+    m[QStringLiteral("frequencyPreviewTargetCenterMhz")] =
+        m_frequencyPreviewTargetCenterMhz;
+    m[QStringLiteral("frequencyPreviewTargetBandwidthMhz")] =
+        m_frequencyPreviewTargetBandwidthMhz;
+    const FrequencyPreviewTransform previewTransform =
+        frequencyPreviewTransform(
+            FrequencyFrame{m_frequencyPreviewBaseCenterMhz,
+                           m_frequencyPreviewBaseBandwidthMhz},
+            FrequencyFrame{m_frequencyPreviewTargetCenterMhz,
+                           m_frequencyPreviewTargetBandwidthMhz});
+    m[QStringLiteral("frequencyPreviewScale")] = previewTransform.valid
+        ? previewTransform.scale : 1.0;
+    m[QStringLiteral("frequencyPreviewOffset")] = previewTransform.valid
+        ? previewTransform.offset : 0.0;
+    m[QStringLiteral("frequencyPreviewUpdateCount")] =
+        static_cast<qulonglong>(m_frequencyPreviewUpdateCount);
+    m[QStringLiteral("frequencyPreviewPresentCount")] =
+        static_cast<qulonglong>(m_frequencyPreviewPresentCount);
+    m[QStringLiteral("frequencyPreviewCommitCount")] =
+        static_cast<qulonglong>(m_frequencyPreviewCommitCount);
+    m[QStringLiteral("frequencyPreviewNativeVisibleRows")] =
+        static_cast<qulonglong>(m_frequencyPreviewNativeVisibleRows);
+    m[QStringLiteral("frequencyPreviewRemappedDssRows")] =
+        static_cast<qulonglong>(m_frequencyPreviewRemappedDssRows);
+    m[QStringLiteral("frequencyPreviewSuppressedViewportRebuilds")] =
+        static_cast<qulonglong>(m_frequencyPreviewSuppressedViewportRebuilds);
+    m[QStringLiteral("frequencyPreviewCommitLastMs")] =
+        static_cast<double>(m_frequencyPreviewCommitLastNs) / 1000000.0;
+    m[QStringLiteral("frequencyPreviewCommitMaxMs")] =
+        static_cast<double>(m_frequencyPreviewCommitMaxNs) / 1000000.0;
+#ifdef AETHER_GPU_SPECTRUM
+    m[QStringLiteral("waterfallRowFrequencyFrames")] =
+        m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+        && m_wfFrameTexReady;
+    m[QStringLiteral("waterfallPipelineReady")] =
+        m_wfPipeline != nullptr && m_wfSrb != nullptr;
+    m[QStringLiteral("waterfallPipelineMode")] =
+        m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+        ? QStringLiteral("rowFrequencyFrames")
+        : QStringLiteral("legacy");
+    m[QStringLiteral("waterfallPipelineFallbackReason")] =
+        m_wfPipelineFallbackReason;
+#endif
+    if (m_wfVisibleRowCenterMhz.size() == m_waterfall.height()
+        && !m_wfVisibleRowCenterMhz.isEmpty()) {
+        double minCenterMhz = std::numeric_limits<double>::infinity();
+        double maxCenterMhz = -std::numeric_limits<double>::infinity();
+        int currentFrameRows = 0;
+        for (int row = 0; row < m_wfVisibleRowCenterMhz.size(); ++row) {
+            const double rowCenterMhz = m_wfVisibleRowCenterMhz[row];
+            const double rowBandwidthMhz = m_wfVisibleRowBwMhz[row];
+            minCenterMhz = std::min(minCenterMhz, rowCenterMhz);
+            maxCenterMhz = std::max(maxCenterMhz, rowCenterMhz);
+            if (mhzNearlyEqual(rowCenterMhz, m_centerMhz)
+                && mhzNearlyEqual(rowBandwidthMhz, m_bandwidthMhz)) {
+                ++currentFrameRows;
+            }
+        }
+        m[QStringLiteral("waterfallVisibleFrameMinCenterMhz")] = minCenterMhz;
+        m[QStringLiteral("waterfallVisibleFrameMaxCenterMhz")] = maxCenterMhz;
+        m[QStringLiteral("waterfallVisibleCurrentFrameRows")] = currentFrameRows;
+    }
+    m[QStringLiteral("frequencyRangeCommandPending")] =
+        m_frequencyRangeCommandThrottle.hasPending();
+    m[QStringLiteral("frequencyRangeCommandCount")] =
+        static_cast<qulonglong>(m_frequencyRangeCommandCount);
     m[QStringLiteral("historyOffsetRows")] = m_wfHistoryOffsetRows;
     m[QStringLiteral("maxHistoryOffsetRows")] = maxWaterfallHistoryOffsetRows();
     m[QStringLiteral("waterfallRows")] = m_waterfall.height();
+    m[QStringLiteral("waterfallWidth")] = m_waterfall.width();
+    m[QStringLiteral("waterfallWriteRow")] = m_wfWriteRow;
     m[QStringLiteral("waterfallHistoryRows")] = m_wfHistoryRowCount;
     m[QStringLiteral("waterfallHistoryCapacityRows")] =
         m_waterfallHistory.isNull() ? 0 : m_waterfallHistory.height();
+    m[QStringLiteral("waterfallHistoryWidth")] = m_waterfallHistory.width();
+    m[QStringLiteral("resizeEventCount")] =
+        static_cast<qulonglong>(m_resizeEventCount);
+    m[QStringLiteral("resizeBufferCommitCount")] =
+        static_cast<qulonglong>(m_resizeBufferCommitCount);
+    m[QStringLiteral("resizeFrameHoldCount")] =
+        static_cast<qulonglong>(m_resizeFrameHoldCount);
+    m[QStringLiteral("resizePreviewFrameCount")] =
+        static_cast<qulonglong>(m_resizePreviewFrameCount);
+    m[QStringLiteral("resizeBufferPending")] =
+        m_resizeBufferSettleTimer && m_resizeBufferSettleTimer->isActive();
+    m[QStringLiteral("resizeBufferCommitLastMs")] =
+        static_cast<double>(m_resizeBufferCommitLastNs) / 1000000.0;
+    m[QStringLiteral("resizeBufferCommitMaxMs")] =
+        static_cast<double>(m_resizeBufferCommitMaxNs) / 1000000.0;
+#ifdef AETHER_GPU_SPECTRUM
+    m[QStringLiteral("resizeRenderBufferWidth")] = fixedColorBufferSize().width();
+    m[QStringLiteral("resizeRenderBufferHeight")] = fixedColorBufferSize().height();
+#endif
     m[QStringLiteral("dssVisibleRows")] = m_dss.rowCount();
+    m[QStringLiteral("dssRowGeneration")] =
+        static_cast<qulonglong>(m_dss.rowGeneration());
     m[QStringLiteral("dssHistoryRows")] = m_dss.historyRowCount();
     m[QStringLiteral("dssHistoryCapacityRows")] = m_dss.historyCapacityRows();
     m[QStringLiteral("dssFixedBytes")] =
@@ -1064,6 +1186,27 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
             {QStringLiteral("error"), QStringLiteral("AETHER_AUTOMATION is not enabled")},
         };
     }
+
+    clearFrequencyPreview();
+    if (m_frequencyRangeSettleTimer) {
+        m_frequencyRangeSettleTimer->stop();
+    }
+    if (m_frequencyRangeCommandTimer) {
+        m_frequencyRangeCommandTimer->stop();
+    }
+    m_frequencyRangeSettlePending = false;
+    m_frequencyRangePendingValid = false;
+    m_frequencyRangeCommandThrottle.clear();
+    m_frequencyRangeCommandClock.invalidate();
+    m_frequencyPreviewUpdateCount = 0;
+    m_frequencyPreviewPresentCount = 0;
+    m_frequencyPreviewCommitCount = 0;
+    m_frequencyPreviewNativeVisibleRows = 0;
+    m_frequencyPreviewRemappedDssRows = 0;
+    m_frequencyPreviewSuppressedViewportRebuilds = 0;
+    m_frequencyPreviewCommitLastNs = 0;
+    m_frequencyPreviewCommitMaxNs = 0;
+    m_frequencyRangeCommandCount = 0;
 
     const int desiredWidth = !m_waterfall.isNull()
         ? m_waterfall.width()
@@ -1478,20 +1621,37 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     m_panDragSettleTimer->setInterval(kPanDragSettleMs);
     connect(m_panDragSettleTimer, &QTimer::timeout, this, [this]() {
         if (m_draggingPan) {
+            // A pause with the mouse button still down is a radio-command
+            // settle point, not the end of the visual gesture. Keep the GPU
+            // preview alive; committing here used to rebuild the full visible
+            // waterfall synchronously and caused a hitch before dragging
+            // resumed.
             emit panDragSettled(m_centerMhz, m_bandwidthMhz);
         }
     });
     m_frequencyRangeSettleTimer = new QTimer(this);
     m_frequencyRangeSettleTimer->setSingleShot(true);
     m_frequencyRangeSettleTimer->setInterval(kFrequencyRangeSettleMs);
-    connect(m_frequencyRangeSettleTimer, &QTimer::timeout, this, [this]() {
-        if (!m_frequencyRangeSettlePending) {
+    connect(m_frequencyRangeSettleTimer, &QTimer::timeout,
+            this, &SpectrumWidget::finishFrequencyRangeSettleUpdate);
+    m_frequencyRangeCommandTimer = new QTimer(this);
+    m_frequencyRangeCommandTimer->setSingleShot(true);
+    connect(m_frequencyRangeCommandTimer, &QTimer::timeout, this, [this]() {
+        const std::optional<FrequencyRangeCommand> command =
+            m_frequencyRangeCommandThrottle.takePending();
+        if (!command.has_value()) {
             return;
         }
-        m_frequencyRangeSettlePending = false;
-        m_frequencyRangePendingValid = false;
-        emit frequencyRangeSettled(m_centerMhz, m_bandwidthMhz);
+        m_frequencyRangeCommandClock.restart();
+        ++m_frequencyRangeCommandCount;
+        emit frequencyRangeChangeRequested(command->centerMhz,
+                                           command->bandwidthMhz);
     });
+    m_resizeBufferSettleTimer = new QTimer(this);
+    m_resizeBufferSettleTimer->setSingleShot(true);
+    m_resizeBufferSettleTimer->setInterval(kResizeBufferSettleMs);
+    connect(m_resizeBufferSettleTimer, &QTimer::timeout,
+            this, &SpectrumWidget::applySettledResizeBuffers);
 
     // Load display settings (panIndex 0 by default — loadSettings() can be
     // called again after setPanIndex() for multi-pan)
@@ -1570,8 +1730,12 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         }
         newCenter = std::max(newCenter, newBw / 2.0);
 
-        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
-                                            newCenter, newBw);
+        const bool previewed = updateFrequencyPreview(
+            m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+        if (!previewed) {
+            handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                                newCenter, newBw);
+        }
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -1580,9 +1744,13 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         m_centerMhz = newCenter;
         m_bandwidthMhz = newBw;
         resetNoiseFloorBaseline();
-        markOverlayDirty();
+        if (previewed) {
+            scheduleFrequencyPreviewFrame();
+        } else {
+            markOverlayDirty();
+        }
         scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
-        emit frequencyRangeChangeRequested(newCenter, newBw);
+        requestFrequencyRangeChange(newCenter, newBw);
     };
     connect(m_zoomOutBtn, &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.5); });
     connect(m_zoomInBtn,  &QPushButton::clicked, this, [emitZoom]() { emitZoom(1.0 / 1.5); });
@@ -3650,6 +3818,7 @@ void SpectrumWidget::setSpectrumRenderMode(int mode) {
     auto clamped = static_cast<SpectrumRenderMode>(
         std::clamp(mode, 0, static_cast<int>(SpectrumRenderMode::Count) - 1));
     if (clamped != m_spectrumRenderMode) {
+        commitFrequencyPreview();
         m_spectrumRenderMode = clamped;
         auto& s = AppSettings::instance();
         s.setValue(settingsKey("DisplaySpectrumRenderMode"),
@@ -4021,13 +4190,12 @@ void SpectrumWidget::appendDssHistoryRow(const QVector<float>& binsDbm,
         || m_spectrumRenderMode != SpectrumRenderMode::Mode3D) {
         return;
     }
-    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
-        ? frameCenterMhz
-        : m_centerMhz;
-    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
-        ? frameBandwidthMhz
-        : m_bandwidthMhz;
-    retainDssHistoryRow(m_dss, binsDbm, stampCenterMhz, stampBandwidthMhz,
+    const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
+    const FrequencyFrame stampFrame = requestedFrame.isValid()
+        ? requestedFrame
+        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
+    retainDssHistoryRow(m_dss, binsDbm,
+                        stampFrame.centerMhz, stampFrame.bandwidthMhz,
                         dssHistoryFallbackDbm());
 }
 
@@ -4038,7 +4206,14 @@ void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
 {
     // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
     if (m_wfLive && updateLiveSurface) {
-        pushDssLiveRow(m_dss, binsDbm, !m_waterfallWriteVisible);
+        if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
+            const QVector<float>& previewBins = remapPreviewDssRow(
+                binsDbm, frameCenterMhz, frameBandwidthMhz);
+            pushDssLiveRow(m_dss, previewBins, false);
+            ++m_frequencyPreviewRemappedDssRows;
+        } else {
+            pushDssLiveRow(m_dss, binsDbm, !m_waterfallWriteVisible);
+        }
     }
     appendDssHistoryRow(binsDbm, frameCenterMhz, frameBandwidthMhz);
 }
@@ -4082,7 +4257,9 @@ void SpectrumWidget::appendLatestDssWaterfallRow(double frameCenterMhz,
     appendDssWaterfallRow(displaySpectrumBins(), frameCenterMhz, frameBandwidthMhz);
 }
 
-void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
+void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
+                                      double frameCenterMhz,
+                                      double frameBandwidthMhz)
 {
     if (m_waterfall.isNull() || rowData == nullptr) {
         return;
@@ -4093,11 +4270,28 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData)
         return;
     }
 
+    const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
+    const FrequencyFrame rowFrame = requestedFrame.isValid()
+        ? requestedFrame
+        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
+
     QElapsedTimer timer;
     timer.start();
     m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
     auto* row = reinterpret_cast<QRgb*>(m_waterfall.bits() + m_wfWriteRow * m_waterfall.bytesPerLine());
     std::memcpy(row, rowData, m_waterfall.width() * sizeof(QRgb));
+    if (m_wfVisibleRowCenterMhz.size() != h
+        || m_wfVisibleRowBwMhz.size() != h) {
+        resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
+    }
+    m_wfVisibleRowCenterMhz[m_wfWriteRow] = rowFrame.centerMhz;
+    m_wfVisibleRowBwMhz[m_wfWriteRow] = rowFrame.bandwidthMhz;
+#ifdef AETHER_GPU_SPECTRUM
+    m_wfFrameTexDirty = true;
+#endif
+    if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
+        ++m_frequencyPreviewNativeVisibleRows;
+    }
     m_panStats.waterfallVisibleRowUs +=
         static_cast<quint64>(timer.nsecsElapsed() / 1000);
     ++m_panStats.waterfallVisibleRows;
@@ -4133,15 +4327,13 @@ void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
     }
     // Stamp the frequency frame this row was captured in, so the viewport can
     // remap it later regardless of how the center/bandwidth has since panned.
-    const double stampCenterMhz = (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
-        ? frameCenterMhz
-        : m_centerMhz;
-    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
-        ? frameBandwidthMhz
-        : m_bandwidthMhz;
+    const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
+    const FrequencyFrame stampFrame = requestedFrame.isValid()
+        ? requestedFrame
+        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
     if (m_wfHistoryWriteRow >= 0 && m_wfHistoryWriteRow < m_wfHistoryRowCenterMhz.size()) {
-        m_wfHistoryRowCenterMhz[m_wfHistoryWriteRow] = stampCenterMhz;
-        m_wfHistoryRowBwMhz[m_wfHistoryWriteRow] = stampBandwidthMhz;
+        m_wfHistoryRowCenterMhz[m_wfHistoryWriteRow] = stampFrame.centerMhz;
+        m_wfHistoryRowBwMhz[m_wfHistoryWriteRow] = stampFrame.bandwidthMhz;
     }
     if (m_wfHistoryRowCount < h) {
         ++m_wfHistoryRowCount;
@@ -4256,6 +4448,65 @@ static float peakPreservedBinSample(const QVector<float>& bins,
     return haveBest ? best : fallback;
 }
 
+const QVector<float>& SpectrumWidget::remapPreviewDssRow(
+    const QVector<float>& binsDbm,
+    double frameCenterMhz,
+    double frameBandwidthMhz)
+{
+    if (!m_frequencyPreviewActive || binsDbm.isEmpty()) {
+        return binsDbm;
+    }
+
+    const bool hasFrame = frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0;
+    const double sourceCenterMhz = hasFrame ? frameCenterMhz : m_centerMhz;
+    const double sourceBandwidthMhz = hasFrame
+        ? frameBandwidthMhz
+        : m_bandwidthMhz;
+    const double destinationCenterMhz = m_frequencyPreviewBaseCenterMhz;
+    const double destinationBandwidthMhz =
+        m_frequencyPreviewBaseBandwidthMhz;
+    if (sourceBandwidthMhz <= 0.0 || destinationBandwidthMhz <= 0.0
+        || !std::isfinite(sourceCenterMhz)
+        || !std::isfinite(sourceBandwidthMhz)
+        || !std::isfinite(destinationCenterMhz)
+        || !std::isfinite(destinationBandwidthMhz)) {
+        return binsDbm;
+    }
+    if (mhzNearlyEqual(sourceCenterMhz, destinationCenterMhz)
+        && mhzNearlyEqual(sourceBandwidthMhz,
+                          destinationBandwidthMhz)) {
+        return binsDbm;
+    }
+
+    const int count = binsDbm.size();
+    const double sourceStartMhz = sourceCenterMhz
+        - sourceBandwidthMhz * 0.5;
+    const double destinationStartMhz = destinationCenterMhz
+        - destinationBandwidthMhz * 0.5;
+    const float fallback = dssHistoryFallbackDbm();
+    m_frequencyPreviewDssScratch.fill(fallback, count);
+    for (int destination = 0; destination < count; ++destination) {
+        const double destinationLeftMhz = destinationStartMhz
+            + static_cast<double>(destination) / count
+                * destinationBandwidthMhz;
+        const double destinationRightMhz = destinationStartMhz
+            + static_cast<double>(destination + 1) / count
+                * destinationBandwidthMhz;
+        const double destinationCenterBinMhz =
+            (destinationLeftMhz + destinationRightMhz) * 0.5;
+        const double sourceLeft = (destinationLeftMhz - sourceStartMhz)
+            / sourceBandwidthMhz * count;
+        const double sourceRight = (destinationRightMhz - sourceStartMhz)
+            / sourceBandwidthMhz * count;
+        const double sourceCenter =
+            (destinationCenterBinMhz - sourceStartMhz)
+                / sourceBandwidthMhz * count - 0.5;
+        m_frequencyPreviewDssScratch[destination] = peakPreservedBinSample(
+            binsDbm, sourceLeft, sourceRight, sourceCenter, fallback);
+    }
+    return m_frequencyPreviewDssScratch;
+}
+
 static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
                                 double rowCenterMhz, double rowBwMhz,
                                 double curCenterMhz, double curBwMhz,
@@ -4292,6 +4543,70 @@ static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
     }
 }
 
+void SpectrumWidget::resetVisibleWaterfallFrequencyFrames(
+    double centerMhz,
+    double bandwidthMhz)
+{
+    const int height = m_waterfall.height();
+    if (height <= 0) {
+        m_wfVisibleRowCenterMhz.clear();
+        m_wfVisibleRowBwMhz.clear();
+#ifdef AETHER_GPU_SPECTRUM
+        m_wfFrameTexDirty = true;
+#endif
+        return;
+    }
+
+    const double validCenterMhz = std::isfinite(centerMhz) && centerMhz > 0.0
+        ? centerMhz
+        : m_centerMhz;
+    const double validBandwidthMhz = std::isfinite(bandwidthMhz)
+            && bandwidthMhz > 0.0
+        ? bandwidthMhz
+        : m_bandwidthMhz;
+    m_wfVisibleRowCenterMhz.fill(validCenterMhz, height);
+    m_wfVisibleRowBwMhz.fill(validBandwidthMhz, height);
+#ifdef AETHER_GPU_SPECTRUM
+    m_wfFrameTexDirty = true;
+#endif
+}
+
+#ifdef AETHER_GPU_SPECTRUM
+void SpectrumWidget::prepareWaterfallFrameUpload()
+{
+    const int visibleHeight = m_waterfall.height();
+    const int uploadHeight = std::max(visibleHeight, m_wfGpuTexH);
+    if (uploadHeight <= 0) {
+        m_wfFrameUpload.clear();
+        return;
+    }
+    if (m_wfVisibleRowCenterMhz.size() != visibleHeight
+        || m_wfVisibleRowBwMhz.size() != visibleHeight) {
+        resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
+    }
+
+    // Store center as an offset from a nearby double-precision reference.
+    // Sending absolute MHz as float would lose fine tuning precision at
+    // VHF/UHF frequencies even though the per-row metadata texture is float32.
+    m_wfFrameReferenceCenterMhz = m_centerMhz;
+    m_wfFrameUpload.resize(uploadHeight * 4);
+    for (int row = 0; row < uploadHeight; ++row) {
+        const bool visibleRow = row < visibleHeight;
+        const double centerMhz = visibleRow
+            ? m_wfVisibleRowCenterMhz[row]
+            : m_centerMhz;
+        const double bandwidthMhz = visibleRow
+            ? m_wfVisibleRowBwMhz[row]
+            : m_bandwidthMhz;
+        m_wfFrameUpload[row * 4] = static_cast<float>(
+            centerMhz - m_wfFrameReferenceCenterMhz);
+        m_wfFrameUpload[row * 4 + 1] = static_cast<float>(bandwidthMhz);
+        m_wfFrameUpload[row * 4 + 2] = 0.0f;
+        m_wfFrameUpload[row * 4 + 3] = 0.0f;
+    }
+}
+#endif
+
 void SpectrumWidget::rebuildWaterfallViewport()
 {
     rebuildWaterfallViewportForFrame(m_centerMhz, m_bandwidthMhz);
@@ -4314,6 +4629,10 @@ void SpectrumWidget::rebuildDssViewportFromHistoryForFrame(double centerMhz,
 void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
                                                       double bandwidthMhz)
 {
+    if (m_frequencyPreviewActive) {
+        ++m_frequencyPreviewSuppressedViewportRebuilds;
+        return;
+    }
     if (m_waterfall.isNull()) {
         return;
     }
@@ -4321,6 +4640,7 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
     m_wfHistoryOffsetRows = std::clamp(m_wfHistoryOffsetRows, 0, maxWaterfallHistoryOffsetRows());
     m_waterfall.fill(Qt::black);
     m_wfWriteRow = 0;
+    resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
 
     if (m_waterfallHistory.isNull()) {
         update();
@@ -4427,6 +4747,151 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
     }
 }
 
+bool SpectrumWidget::frequencyPreviewAvailable() const
+{
+#ifdef AETHER_GPU_SPECTRUM
+    // The 3D cached-image fallback cannot transform its horizontal sampling;
+    // keep its existing exact CPU path. The preferred height-map mesh and the
+    // normal 2D waterfall both have the preview uniforms.
+    return waterfallGpuFrequencyPreviewRequested()
+        && m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+        && m_wfFrameTexReady
+        && (m_spectrumRenderMode != SpectrumRenderMode::Mode3D || m_dssMeshReady);
+#else
+    return false;
+#endif
+}
+
+bool SpectrumWidget::updateFrequencyPreview(double oldCenterMhz,
+                                            double oldBandwidthMhz,
+                                            double newCenterMhz,
+                                            double newBandwidthMhz)
+{
+    if (!frequencyPreviewAvailable()
+        || !std::isfinite(oldCenterMhz) || !std::isfinite(oldBandwidthMhz)
+        || !std::isfinite(newCenterMhz) || !std::isfinite(newBandwidthMhz)
+        || oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
+        return false;
+    }
+
+    if (!m_frequencyPreviewActive) {
+        if (mhzNearlyEqual(oldCenterMhz, newCenterMhz)
+            && mhzNearlyEqual(oldBandwidthMhz, newBandwidthMhz)) {
+            return false;
+        }
+        m_frequencyPreviewBaseCenterMhz = oldCenterMhz;
+        m_frequencyPreviewBaseBandwidthMhz = oldBandwidthMhz;
+        m_frequencyPreviewActive = true;
+    }
+
+    m_frequencyPreviewTargetCenterMhz = newCenterMhz;
+    m_frequencyPreviewTargetBandwidthMhz = newBandwidthMhz;
+    ++m_frequencyPreviewUpdateCount;
+    return true;
+}
+
+void SpectrumWidget::scheduleFrequencyPreviewFrame()
+{
+    // Rebuild frequency-dependent overlays at the same coalesced cadence as
+    // GPU/data presentation instead of issuing an immediate paint per mouse or
+    // trackpad event.
+    markOverlayDirty("frequencyPreview", false);
+    coalescedUpdate();
+}
+
+void SpectrumWidget::commitFrequencyPreview()
+{
+    if (!m_frequencyPreviewActive) {
+        return;
+    }
+
+    const double baseCenterMhz = m_frequencyPreviewBaseCenterMhz;
+    const double baseBandwidthMhz = m_frequencyPreviewBaseBandwidthMhz;
+    const double targetCenterMhz = m_frequencyPreviewTargetCenterMhz;
+    const double targetBandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
+
+    // Each RGB row now retains its own frequency frame, so the waterfall shader
+    // is already exact at the target center/bandwidth and needs no release-time
+    // CPU rebuild. Only the compact 3D stacked-trace surface still uses the
+    // uniform preview base and must be landed into the target frame.
+    m_frequencyPreviewActive = false;
+    QElapsedTimer timer;
+    timer.start();
+#ifdef AETHER_GPU_SPECTRUM
+    const bool rowFrequencyFrames =
+        m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+        && m_wfFrameTexReady;
+#else
+    constexpr bool rowFrequencyFrames = false;
+#endif
+    if (!rowFrequencyFrames) {
+        handleWaterfallFrequencyFrameChange(baseCenterMhz, baseBandwidthMhz,
+                                            targetCenterMhz, targetBandwidthMhz);
+    } else if (m_spectrumRenderMode == SpectrumRenderMode::Mode3D) {
+        if (!m_wfLive && m_dss.historyRowCount() > 0) {
+            rebuildDssViewportFromHistoryForFrame(targetCenterMhz,
+                                                  targetBandwidthMhz);
+        } else {
+            m_dss.reprojectFrequencyFrame(baseCenterMhz, baseBandwidthMhz,
+                                          targetCenterMhz, targetBandwidthMhz,
+                                          dssHistoryFallbackDbm());
+            resetDssUploadState();
+        }
+    }
+    m_frequencyPreviewCommitLastNs = timer.nsecsElapsed();
+    m_frequencyPreviewCommitMaxNs = std::max(
+        m_frequencyPreviewCommitMaxNs, m_frequencyPreviewCommitLastNs);
+    ++m_frequencyPreviewCommitCount;
+
+    m_frequencyPreviewBaseCenterMhz = targetCenterMhz;
+    m_frequencyPreviewBaseBandwidthMhz = targetBandwidthMhz;
+    m_frequencyPreviewTargetCenterMhz = targetCenterMhz;
+    m_frequencyPreviewTargetBandwidthMhz = targetBandwidthMhz;
+}
+
+void SpectrumWidget::clearFrequencyPreview()
+{
+    m_frequencyPreviewActive = false;
+    m_frequencyPreviewBaseCenterMhz = m_centerMhz;
+    m_frequencyPreviewBaseBandwidthMhz = m_bandwidthMhz;
+    m_frequencyPreviewTargetCenterMhz = m_centerMhz;
+    m_frequencyPreviewTargetBandwidthMhz = m_bandwidthMhz;
+}
+
+void SpectrumWidget::requestFrequencyRangeChange(double centerMhz,
+                                                 double bandwidthMhz,
+                                                 bool force)
+{
+    if (!std::isfinite(centerMhz) || !std::isfinite(bandwidthMhz)
+        || centerMhz <= 0.0 || bandwidthMhz <= 0.0) {
+        return;
+    }
+
+    const bool due = !m_frequencyRangeCommandClock.isValid()
+        || m_frequencyRangeCommandClock.elapsed() >= kFrequencyRangeCommandMs;
+    const std::optional<FrequencyRangeCommand> command =
+        m_frequencyRangeCommandThrottle.request(
+            FrequencyRangeCommand{centerMhz, bandwidthMhz}, due, force);
+    if (command.has_value()) {
+        if (m_frequencyRangeCommandTimer) {
+            m_frequencyRangeCommandTimer->stop();
+        }
+        m_frequencyRangeCommandClock.restart();
+        ++m_frequencyRangeCommandCount;
+        emit frequencyRangeChangeRequested(command->centerMhz,
+                                           command->bandwidthMhz);
+        return;
+    }
+
+    if (m_frequencyRangeCommandTimer
+        && !m_frequencyRangeCommandTimer->isActive()) {
+        const int remainingMs = std::max(
+            1, kFrequencyRangeCommandMs
+                - static_cast<int>(m_frequencyRangeCommandClock.elapsed()));
+        m_frequencyRangeCommandTimer->start(remainingMs);
+    }
+}
+
 int SpectrumWidget::waterfallStripWidth() const
 {
     return m_wfLive ? DBM_STRIP_W : 72;
@@ -4453,6 +4918,7 @@ QRect SpectrumWidget::waterfallLiveButtonRect(const QRect& wfRect) const
 
 void SpectrumWidget::clearDisplay()
 {
+    clearFrequencyPreview();
     m_bins.clear();
     m_smoothed.clear();
     clearWaterfallRows();
@@ -4477,6 +4943,7 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     std::fill(m_wfHistoryRowCenterMhz.begin(), m_wfHistoryRowCenterMhz.end(), 0.0);
     std::fill(m_wfHistoryRowBwMhz.begin(), m_wfHistoryRowBwMhz.end(), 0.0);
     m_wfWriteRow = 0;
+    resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     m_wfHistoryWriteRow = 0;
     m_wfHistoryRowCount = 0;
     m_wfHistoryOffsetRows = 0;
@@ -4597,6 +5064,8 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     WaterfallStreamState updated;
     updated.waterfall = std::move(m_waterfall);
     updated.wfWriteRow = m_wfWriteRow;
+    updated.visibleRowCenterMhz = std::move(m_wfVisibleRowCenterMhz);
+    updated.visibleRowBwMhz = std::move(m_wfVisibleRowBwMhz);
     updated.waterfallHistory = std::move(m_waterfallHistory);
     updated.historyTimestamps = std::move(m_wfHistoryTimestamps);
     updated.historyWriteRow = m_wfHistoryWriteRow;
@@ -4696,6 +5165,12 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
         m_waterfallStreamSizeHint = m_waterfall.size();
     }
     m_wfWriteRow = restored.wfWriteRow;
+    m_wfVisibleRowCenterMhz = std::move(restored.visibleRowCenterMhz);
+    m_wfVisibleRowBwMhz = std::move(restored.visibleRowBwMhz);
+    if (m_wfVisibleRowCenterMhz.size() != m_waterfall.height()
+        || m_wfVisibleRowBwMhz.size() != m_waterfall.height()) {
+        resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
+    }
     m_waterfallHistory = std::move(restored.waterfallHistory);
     if (!m_waterfallHistory.isNull()) {
         m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
@@ -4725,6 +5200,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = restored.wfTexFullUpload;
     m_wfLastUploadedRow = restored.wfLastUploadedRow;
+    m_wfFrameTexDirty = true;
     m_dssTexNeedsUpload = restored.dssTexNeedsUpload;
     m_dssLastUploadedGen = restored.dssLastUploadedGen;
     m_dssMeshHeadUploaded = restored.dssMeshHeadUploaded;
@@ -5101,6 +5577,11 @@ void SpectrumWidget::drawConnectionAnimation(QPainter& p, const QRect& contentRe
 
 void SpectrumWidget::resetGpuResources()
 {
+    if (m_shutdownPrepared) {
+        clearFrequencyPreview();
+    } else {
+        commitFrequencyPreview();
+    }
 #ifdef AETHER_GPU_SPECTRUM
     // On macOS/Windows, the GPU surface doesn't survive reparenting — tear
     // down old pipelines so initialize() rebuilds them for the new window.
@@ -5174,6 +5655,7 @@ void SpectrumWidget::reprojectWaterfall(double oldCenterMhz, double oldBandwidth
     } else {
         reprojectWaterfallImage(m_waterfall, oldCenterMhz, oldBandwidthMhz,
                                 newCenterMhz, newBandwidthMhz);
+        resetVisibleWaterfallFrequencyFrames(newCenterMhz, newBandwidthMhz);
     }
     m_prevTileScanline.clear();
 #ifdef AETHER_GPU_SPECTRUM
@@ -6379,6 +6861,7 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
         return;
     }
 
+    commitFrequencyPreview();
     setNoiseFloorPositionForSource(m_kiwiSdrWaterfallActive,
                                    m_noiseFloorPosition,
                                    false);
@@ -6476,6 +6959,7 @@ void SpectrumWidget::setKiwiSdrWaterfallProfile(const QString& profileId)
     }
 
     if (m_kiwiSdrWaterfallActive) {
+        commitFrequencyPreview();
         saveCurrentWaterfallStreamState();
         discardRetainedHistory(m_nativeWaterfallState);
         discardRetainedHistory(m_kiwiWaterfallState);
@@ -6845,6 +7329,17 @@ int SpectrumWidget::contentWidth() const
     return std::max(1, width() - DBM_STRIP_W);
 }
 
+double SpectrumWidget::frequencyCanvasFractionAtGlobal(
+    const QPointF& globalPosition) const
+{
+    // Native gestures are delivered through QWidget::event() rather than the
+    // mouse handlers. Normalize every zoom path from the stable global point
+    // so its anchor does not depend on how event propagation translated the
+    // local position for a composited QRhiWidget.
+    const QPointF localPosition = mapFromGlobal(globalPosition);
+    return frequencyCanvasFraction(localPosition.x(), contentWidth());
+}
+
 int SpectrumWidget::mhzToX(double mhz) const
 {
     if (m_bandwidthMhz <= 0.0) return -1;
@@ -7123,14 +7618,17 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
         }
 
         m_draggingBandwidth = true;
-        m_bwDragStartX = static_cast<int>(ev->position().x());
+        const QPointF localPosition = mapFromGlobal(ev->globalPosition());
+        m_bwDragStartX = static_cast<int>(std::lround(localPosition.x()));
         m_bwDragStartBw = m_bandwidthMhz;
         // Clamp to the canvas: the cursor can sit over the strip, and at
         // degenerate widths contentWidth()=1 would extrapolate the anchor
         // wildly off-canvas (#3482 review).
-        const double mouseXFrac = std::clamp(
-            ev->position().x() / contentWidth() - 0.5, -0.5, 0.5);
-        m_bwDragAnchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
+        m_bwDragAnchorFraction = frequencyCanvasFractionAtGlobal(
+            ev->globalPosition());
+        m_bwDragAnchorMhz = frequencyAtFraction(
+            FrequencyFrame{m_centerMhz, m_bandwidthMhz},
+            m_bwDragAnchorFraction);
         setSpectrumCursor(Qt::SizeHorCursor);
         ev->accept();
         return;
@@ -7794,6 +8292,15 @@ void SpectrumWidget::finishFrequencyRangeSettleUpdate()
     if (m_frequencyRangeSettleTimer) {
         m_frequencyRangeSettleTimer->stop();
     }
+    if (!m_frequencyRangeSettlePending && !m_frequencyPreviewActive
+        && !m_frequencyRangeCommandThrottle.hasPending()) {
+        return;
+    }
+
+    commitFrequencyPreview();
+    // Land the radio on the exact final center/bandwidth pair even when the
+    // last high-rate gesture event fell inside the command throttle window.
+    requestFrequencyRangeChange(m_centerMhz, m_bandwidthMhz, true);
     m_frequencyRangeSettlePending = false;
     m_frequencyRangePendingValid = false;
     emit frequencyRangeSettled(m_centerMhz, m_bandwidthMhz);
@@ -7825,17 +8332,22 @@ void SpectrumWidget::applyPanDragCenter(double newCenterMhz, bool force)
     bool needsDeferredFlush = false;
     const bool waterfallChanged =
         !mhzNearlyEqual(newCenterMhz, m_panDragWaterfallFrameCenterMhz);
-    const bool waterfallDue = force || !m_panDragWaterfallClock.isValid()
-        || m_panDragWaterfallClock.elapsed() >= kPanDragFrameMs;
-    if (waterfallChanged && waterfallDue) {
-        handleWaterfallFrequencyFrameChange(m_panDragWaterfallFrameCenterMhz,
-                                            m_bandwidthMhz,
-                                            newCenterMhz,
-                                            m_bandwidthMhz);
-        m_panDragWaterfallFrameCenterMhz = newCenterMhz;
-        m_panDragWaterfallClock.restart();
-    } else if (waterfallChanged) {
-        needsDeferredFlush = true;
+    const bool previewed = waterfallChanged && updateFrequencyPreview(
+        m_panDragWaterfallFrameCenterMhz, m_bandwidthMhz,
+        newCenterMhz, m_bandwidthMhz);
+    if (!previewed) {
+        const bool waterfallDue = force || !m_panDragWaterfallClock.isValid()
+            || m_panDragWaterfallClock.elapsed() >= kPanDragFrameMs;
+        if (waterfallChanged && waterfallDue) {
+            handleWaterfallFrequencyFrameChange(m_panDragWaterfallFrameCenterMhz,
+                                                m_bandwidthMhz,
+                                                newCenterMhz,
+                                                m_bandwidthMhz);
+            m_panDragWaterfallFrameCenterMhz = newCenterMhz;
+            m_panDragWaterfallClock.restart();
+        } else if (waterfallChanged) {
+            needsDeferredFlush = true;
+        }
     }
     if (waterfallChanged) {
         reprojectSpectrum(m_centerMhz, m_bandwidthMhz,
@@ -7843,7 +8355,11 @@ void SpectrumWidget::applyPanDragCenter(double newCenterMhz, bool force)
     }
 
     m_centerMhz = newCenterMhz;
-    markOverlayDirty();
+    if (previewed) {
+        scheduleFrequencyPreviewFrame();
+    } else {
+        markOverlayDirty();
+    }
 
     const bool commandChanged =
         !mhzNearlyEqual(newCenterMhz, m_panDragLastCommandCenterMhz);
@@ -7965,6 +8481,9 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
             ensureWaterfallHistory();
             if (m_wfHistoryRowCount > 0) {
                 rebuildWaterfallViewport();
+            } else {
+                resetVisibleWaterfallFrequencyFrames(m_centerMhz,
+                                                     m_bandwidthMhz);
             }
         }
         positionFpsMeterLabels();
@@ -8062,16 +8581,22 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
     }
 
     if (m_draggingBandwidth) {
-        const int dx = static_cast<int>(ev->position().x()) - m_bwDragStartX;
+        const QPointF localPosition = mapFromGlobal(ev->globalPosition());
+        const int dx = static_cast<int>(std::lround(localPosition.x()))
+            - m_bwDragStartX;
         // 4x multiplier: dragging 1/4 of widget width doubles/halves bandwidth
         const double scale = std::pow(2.0, static_cast<double>(-dx) / (width() / 4.0));
         const double newBw = std::clamp(m_bwDragStartBw * scale, m_minBwMhz, m_maxBwMhz);
-        const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
-            static_cast<double>(m_bwDragStartX) / contentWidth() - 0.5, -0.5, 0.5);
-        const double zoomCenter = std::max(m_bwDragAnchorMhz - mouseXFrac * newBw,
-                                           newBw / 2.0);
-        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
-                                            zoomCenter, newBw);
+        const double zoomCenter = std::max(
+            centerForAnchoredBandwidth(
+                m_bwDragAnchorMhz, m_bwDragAnchorFraction, newBw),
+            newBw / 2.0);
+        const bool previewed = updateFrequencyPreview(
+            m_centerMhz, m_bandwidthMhz, zoomCenter, newBw);
+        if (!previewed) {
+            handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                                zoomCenter, newBw);
+        }
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, zoomCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -8080,12 +8605,16 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         m_bandwidthMhz = newBw;
         m_centerMhz = zoomCenter;
         resetNoiseFloorBaseline();
-        markOverlayDirty();
+        if (previewed) {
+            scheduleFrequencyPreviewFrame();
+        } else {
+            markOverlayDirty();
+        }
         // Keep center and bandwidth coupled while dragging. Sending only the
         // bandwidth and waiting to send center on release caused the radio and
         // client waterfall to diverge under trackpad-heavy zoom workflows.
         scheduleFrequencyRangeSettleUpdate(zoomCenter, newBw);
-        emit frequencyRangeChangeRequested(zoomCenter, newBw);
+        requestFrequencyRangeChange(zoomCenter, newBw);
         ev->accept();
         return;
     }
@@ -8383,10 +8912,7 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
     if (m_draggingBandwidth) {
         m_draggingBandwidth = false;
         setSpectrumCursor(Qt::CrossCursor);
-        // Re-send the final combined range so the release lands on the same
-        // coherent center/bandwidth pair as the in-flight drag updates.
         scheduleFrequencyRangeSettleUpdate(m_centerMhz, m_bandwidthMhz);
-        emit frequencyRangeChangeRequested(m_centerMhz, m_bandwidthMhz);
         finishFrequencyRangeSettleUpdate();
         ev->accept();
         return;
@@ -8414,6 +8940,8 @@ void SpectrumWidget::mouseReleaseEvent(QMouseEvent* ev)
             m_panDragSettleTimer->stop();
         }
         applyPanDragCenter(m_centerMhz, true);
+        commitFrequencyPreview();
+        m_panDragWaterfallFrameCenterMhz = m_centerMhz;
         emit panDragSettled(m_centerMhz, m_bandwidthMhz);
         m_panDragPendingCenterValid = false;
         m_panDragDeferredUpdateScheduled = false;
@@ -8691,13 +9219,19 @@ bool SpectrumWidget::event(QEvent* ev)
             const double newBw = m_bandwidthMhz * factor;
             if (newBw < m_minBwMhz || newBw > m_maxBwMhz) { return true; }  // at limit
             // Anchor: keep the frequency under the cursor at the same pixel.
-            const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
-                ge->position().x() / contentWidth() - 0.5, -0.5, 0.5);
-            const double anchorMhz = m_centerMhz + mouseXFrac * m_bandwidthMhz;
-            const double newCenter = std::max(anchorMhz - mouseXFrac * newBw,
-                                              newBw / 2.0);
-            handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
-                                                newCenter, newBw);
+            const double mouseXFrac = frequencyCanvasFractionAtGlobal(
+                ge->globalPosition());
+            const double anchorMhz = frequencyAtFraction(
+                FrequencyFrame{m_centerMhz, m_bandwidthMhz}, mouseXFrac);
+            const double newCenter = std::max(
+                centerForAnchoredBandwidth(anchorMhz, mouseXFrac, newBw),
+                newBw / 2.0);
+            const bool previewed = updateFrequencyPreview(
+                m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+            if (!previewed) {
+                handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                                    newCenter, newBw);
+            }
             if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
                 m_bins.clear();
                 m_smoothed.clear();
@@ -8706,9 +9240,13 @@ bool SpectrumWidget::event(QEvent* ev)
             m_bandwidthMhz = newBw;
             m_centerMhz = newCenter;
             resetNoiseFloorBaseline();
-            markOverlayDirty();
+            if (previewed) {
+                scheduleFrequencyPreviewFrame();
+            } else {
+                markOverlayDirty();
+            }
             scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
-            emit frequencyRangeChangeRequested(newCenter, newBw);
+            requestFrequencyRangeChange(newCenter, newBw);
             return true;
         }
     }
@@ -8862,12 +9400,19 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         const double factor  = (steps > 0) ? (1.0 / 1.5) : 1.5;
         const double newBw   = std::clamp(m_bandwidthMhz * factor, m_minBwMhz, m_maxBwMhz);
         if (qFuzzyCompare(newBw, m_bandwidthMhz)) { ev->accept(); return; }
-        const double mouseXFrac = std::clamp(  // bounded anchor (#3482 review)
-            ev->position().x() / contentWidth() - 0.5, -0.5, 0.5);
-        const double anchorMhz  = m_centerMhz + mouseXFrac * m_bandwidthMhz;
-        const double newCenter  = std::max(anchorMhz - mouseXFrac * newBw, newBw / 2.0);
-        handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
-                                            newCenter, newBw);
+        const double mouseXFrac = frequencyCanvasFractionAtGlobal(
+            ev->globalPosition());
+        const double anchorMhz = frequencyAtFraction(
+            FrequencyFrame{m_centerMhz, m_bandwidthMhz}, mouseXFrac);
+        const double newCenter = std::max(
+            centerForAnchoredBandwidth(anchorMhz, mouseXFrac, newBw),
+            newBw / 2.0);
+        const bool previewed = updateFrequencyPreview(
+            m_centerMhz, m_bandwidthMhz, newCenter, newBw);
+        if (!previewed) {
+            handleWaterfallFrequencyFrameChange(m_centerMhz, m_bandwidthMhz,
+                                                newCenter, newBw);
+        }
         if (!reprojectSpectrum(m_centerMhz, m_bandwidthMhz, newCenter, newBw)) {
             m_bins.clear();
             m_smoothed.clear();
@@ -8876,9 +9421,13 @@ void SpectrumWidget::wheelEvent(QWheelEvent* ev)
         m_centerMhz    = newCenter;
         m_bandwidthMhz = newBw;
         resetNoiseFloorBaseline();
-        markOverlayDirty();
+        if (previewed) {
+            scheduleFrequencyPreviewFrame();
+        } else {
+            markOverlayDirty();
+        }
         scheduleFrequencyRangeSettleUpdate(newCenter, newBw);
-        emit frequencyRangeChangeRequested(newCenter, newBw);
+        requestFrequencyRangeChange(newCenter, newBw);
         ev->accept();
         return;
     }
@@ -8926,43 +9475,97 @@ void SpectrumWidget::updateFixedColorBufferSize()
 }
 #endif
 
-void SpectrumWidget::resizeEvent(QResizeEvent* ev)
+void SpectrumWidget::applySettledResizeBuffers()
 {
-    SPECTRUM_BASE_CLASS::resizeEvent(ev);
+    QElapsedTimer commitTimer;
+    commitTimer.start();
+    bool buffersChanged = false;
+
+    // This logical size owns the fixed render target, overlay images, FFT
+    // columns, and waterfall until the next settled commit. During a live
+    // window resize, render into this complete old-size frame and let
+    // QRhiWidget scale it to the widget's intermediate geometry.
+    if (width() > 0 && height() > 0) {
+        m_resizePresentationSize = size();
+    }
 
 #ifdef AETHER_GPU_SPECTRUM
+    const QSize previousRenderBufferSize = fixedColorBufferSize();
     updateFixedColorBufferSize();
+    buffersChanged = fixedColorBufferSize() != previousRenderBufferSize;
 #endif
 
-    // Re-assert mouse tracking — on macOS with WA_NativeWindow, reparenting
-    // into a QSplitter can reset native window properties.
-    setMouseTracking(true);
-
-    // waterfallPixelHeight(): the SAME expression paintEvent uses for the
-    // destination rect, so the image row count and the blit target always
-    // match (see the helper's comment). Previously this truncated
-    // contentH * (1 - frac) independently, which disagreed with paintEvent's
-    // contentH - specH by a pixel at most window heights → a 1px vertical
-    // stretch in drawWaterfall() that duplicated one source row at a fixed
-    // screen line, visible as a static band the scrolling waterfall ran through.
+    // Match the remainder-based split used by painting and GPU presentation,
+    // so the stored row count cannot differ from its destination by one pixel.
     const int wfHeight = waterfallPixelHeight();
-    // contentWidth(): see the divider-drag realloc — rows rasterize at the
-    // displayed column count for a 1:1 blit (#3482).
-    if (wfHeight > 0 && contentWidth() > 0) {
-        QImage newWf(contentWidth(), wfHeight, QImage::Format_RGB32);
+    const QSize waterfallSize(contentWidth(), wfHeight);
+    if (waterfallSize.isEmpty()) {
+        if (buffersChanged) {
+            m_resizeBufferCommitLastNs = commitTimer.nsecsElapsed();
+            m_resizeBufferCommitMaxNs = std::max(
+                m_resizeBufferCommitMaxNs, m_resizeBufferCommitLastNs);
+            ++m_resizeBufferCommitCount;
+            update();
+        }
+        return;
+    }
+
+    const bool waterfallChanged = m_waterfall.size() != waterfallSize;
+    if (!waterfallChanged && !buffersChanged) {
+        return;
+    }
+
+    if (waterfallChanged) {
+        QImage newWf(waterfallSize, QImage::Format_RGB32);
         newWf.fill(Qt::black);
         if (!m_waterfall.isNull()) {
-            QImage scaled = m_waterfall.scaled(contentWidth(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
-            if (!scaled.isNull())
+            QImage scaled = m_waterfall.scaled(
+                waterfallSize, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+            if (!scaled.isNull()) {
                 newWf = std::move(scaled);
+            }
         }
         m_waterfall = std::move(newWf);
         m_wfWriteRow = 0;
         ensureWaterfallHistory();
         if (m_wfHistoryRowCount > 0) {
             rebuildWaterfallViewport();
+        } else {
+            resetVisibleWaterfallFrequencyFrames(m_centerMhz,
+                                                 m_bandwidthMhz);
+#ifdef AETHER_GPU_SPECTRUM
+            m_wfTexFullUpload = true;
+#endif
         }
     }
+
+    m_resizeBufferCommitLastNs = commitTimer.nsecsElapsed();
+    m_resizeBufferCommitMaxNs = std::max(
+        m_resizeBufferCommitMaxNs, m_resizeBufferCommitLastNs);
+    ++m_resizeBufferCommitCount;
+    update();
+}
+
+void SpectrumWidget::resizeEvent(QResizeEvent* ev)
+{
+    SPECTRUM_BASE_CLASS::resizeEvent(ev);
+    ++m_resizeEventCount;
+    commitFrequencyPreview();
+
+    // Keep every size-dependent buffer at the last completed size while the
+    // window is moving. QRhiWidget scales that fixed color buffer to the
+    // widget's current geometry while render() continues presenting new FFT
+    // and waterfall data into it. The render target, overlays, FFT columns,
+    // waterfall, and its 24,000-row history still coalesce to one commit.
+    if (m_waterfall.isNull()) {
+        applySettledResizeBuffers();
+    } else if (m_resizeBufferSettleTimer) {
+        m_resizeBufferSettleTimer->start();
+    }
+
+    // Re-assert mouse tracking — on macOS with WA_NativeWindow, reparenting
+    // into a QSplitter can reset native window properties.
+    setMouseTracking(true);
 
     // Position GPU renderer to cover FFT + waterfall area
 
@@ -9227,17 +9830,15 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
         pushDssLiveRow(dss, binsDbm, true);
     }
 
-    const double stampCenterMhz =
-        (frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0)
-            ? frameCenterMhz
-            : m_centerMhz;
-    const double stampBandwidthMhz = frameBandwidthMhz > 0.0
-        ? frameBandwidthMhz
-        : m_bandwidthMhz;
+    const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
+    const FrequencyFrame stampFrame = requestedFrame.isValid()
+        ? requestedFrame
+        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
     const float fallbackDbm = kiwiStream
         ? kKiwiSdrWaterfallMinDbm
         : m_refLevel - m_dynamicRange;
-    retainDssHistoryRow(dss, binsDbm, stampCenterMhz, stampBandwidthMhz,
+    retainDssHistoryRow(dss, binsDbm,
+                        stampFrame.centerMhz, stampFrame.bandwidthMhz,
                         fallbackDbm);
 }
 
@@ -9479,45 +10080,71 @@ static QShader loadShader(const QString& path)
     return s;
 }
 
-void SpectrumWidget::initWaterfallPipeline()
+void SpectrumWidget::releaseWaterfallFramePipelineResources()
+{
+    delete m_wfFramePipeline;
+    m_wfFramePipeline = nullptr;
+    delete m_wfFrameSrb;
+    m_wfFrameSrb = nullptr;
+    delete m_wfFrameTex;
+    m_wfFrameTex = nullptr;
+    delete m_wfFrameSampler;
+    m_wfFrameSampler = nullptr;
+    m_wfFrameTexReady = false;
+    m_wfFrameTexDirty = true;
+    m_wfPipelineMode = WaterfallPipelineMode::Legacy;
+    m_wfFrameUpload.clear();
+}
+
+bool SpectrumWidget::initWaterfallPipeline()
 {
     QRhi* r = rhi();
-
-    m_wfVbo = r->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, sizeof(kQuadData));
-    m_wfVbo->create();
-
-    m_wfUbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 16);
-    m_wfUbo->create();
-
-    m_wfGpuTexW = qMax(contentWidth(), 64);  // rows rasterize at content width (#3482)
-    m_wfGpuTexH = qMax(m_waterfall.height(), 64);
-    m_wfGpuTex = r->newTexture(QRhiTexture::RGBA8, QSize(m_wfGpuTexW, m_wfGpuTexH));
-    m_wfGpuTex->create();
-
-    m_wfSampler = r->newSampler(QRhiSampler::Linear, QRhiSampler::Linear,
-                                 QRhiSampler::None,
-                                 QRhiSampler::ClampToEdge, QRhiSampler::Repeat);
-    m_wfSampler->create();
-
-    m_wfSrb = r->newShaderResourceBindings();
-    m_wfSrb->setBindings({
-        QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::FragmentStage, m_wfUbo),
-        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_wfGpuTex, m_wfSampler),
-    });
-    m_wfSrb->create();
-
-    QShader vs = loadShader(":/shaders/resources/shaders/texturedquad.vert.qsb");
-    QShader fs = loadShader(":/shaders/resources/shaders/texturedquad.frag.qsb");
-    if (!vs.isValid() || !fs.isValid()) {
-        qWarning() << "SpectrumWidget: waterfall shader load failed";
-        return;
+    if (!r) {
+        return false;
     }
 
-    m_wfPipeline = r->newGraphicsPipeline();
-    m_wfPipeline->setShaderStages({
-        {QRhiShaderStage::Vertex, vs},
-        {QRhiShaderStage::Fragment, fs},
+    const int textureWidth = qMax(contentWidth(), 64);
+    const int textureHeight = qMax(m_waterfall.height(), 64);
+    std::unique_ptr<QRhiBuffer> vbo(r->newBuffer(
+        QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
+        sizeof(kQuadData)));
+    std::unique_ptr<QRhiBuffer> ubo(r->newBuffer(
+        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 16));
+    std::unique_ptr<QRhiTexture> colorTexture(r->newTexture(
+        QRhiTexture::RGBA8, QSize(textureWidth, textureHeight)));
+    std::unique_ptr<QRhiSampler> colorSampler(r->newSampler(
+        QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
+        QRhiSampler::ClampToEdge, QRhiSampler::Repeat));
+    if (!vbo->create() || !ubo->create() || !colorTexture->create()
+        || !colorSampler->create()) {
+        qCWarning(lcGui)
+            << "SpectrumWidget: legacy waterfall resource creation failed";
+        return false;
+    }
+
+    std::unique_ptr<QRhiShaderResourceBindings> legacySrb(
+        r->newShaderResourceBindings());
+    legacySrb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(
+            0, QRhiShaderResourceBinding::FragmentStage, ubo.get()),
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage,
+            colorTexture.get(), colorSampler.get()),
     });
+    if (!legacySrb->create()) {
+        qCWarning(lcGui)
+            << "SpectrumWidget: legacy waterfall bindings creation failed";
+        return false;
+    }
+
+    const QShader vertexShader = loadShader(
+        ":/shaders/resources/shaders/texturedquad.vert.qsb");
+    const QShader legacyFragmentShader = loadShader(
+        ":/shaders/resources/shaders/texturedquad.frag.qsb");
+    if (!vertexShader.isValid() || !legacyFragmentShader.isValid()) {
+        qCWarning(lcGui) << "SpectrumWidget: legacy waterfall shader load failed";
+        return false;
+    }
 
     QRhiVertexInputLayout layout;
     layout.setBindings({{4 * sizeof(float)}});
@@ -9525,14 +10152,136 @@ void SpectrumWidget::initWaterfallPipeline()
         {0, 0, QRhiVertexInputAttribute::Float2, 0},
         {0, 1, QRhiVertexInputAttribute::Float2, 2 * sizeof(float)},
     });
-    m_wfPipeline->setVertexInputLayout(layout);
-    m_wfPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
-    m_wfPipeline->setShaderResourceBindings(m_wfSrb);
-    m_wfPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
-    m_wfPipeline->create();
 
-    qDebug() << "SpectrumWidget: waterfall pipeline created"
+    std::unique_ptr<QRhiGraphicsPipeline> legacyPipeline(
+        r->newGraphicsPipeline());
+    legacyPipeline->setShaderStages({
+        {QRhiShaderStage::Vertex, vertexShader},
+        {QRhiShaderStage::Fragment, legacyFragmentShader},
+    });
+    legacyPipeline->setVertexInputLayout(layout);
+    legacyPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    legacyPipeline->setShaderResourceBindings(legacySrb.get());
+    legacyPipeline->setRenderPassDescriptor(
+        renderTarget()->renderPassDescriptor());
+    if (!legacyPipeline->create()) {
+        qCWarning(lcGui) << "SpectrumWidget: legacy waterfall pipeline failed";
+        return false;
+    }
+
+    m_wfVbo = vbo.release();
+    m_wfUbo = ubo.release();
+    m_wfGpuTex = colorTexture.release();
+    m_wfSampler = colorSampler.release();
+    m_wfSrb = legacySrb.release();
+    m_wfPipeline = legacyPipeline.release();
+    m_wfGpuTexW = textureWidth;
+    m_wfGpuTexH = textureHeight;
+    m_wfPipelineMode = WaterfallPipelineMode::Legacy;
+    m_wfPipelineFallbackReason.clear();
+
+    // The legacy texture/pipeline above is committed first and never depends
+    // on binding 2. The row-frequency path below is an optional transaction:
+    // every resource must succeed before the renderer switches to it.
+    WaterfallRowFrameReadiness readiness;
+    readiness.requested = waterfallGpuFrequencyPreviewRequested();
+    const auto useLegacyPipeline = [this, &readiness](
+        const QString& reason, bool warning) {
+        m_wfPipelineMode = chooseWaterfallPipeline(readiness);
+        m_wfPipelineFallbackReason = reason;
+        if (warning) {
+            qCWarning(lcGui)
+                << "SpectrumWidget: using legacy waterfall pipeline:" << reason;
+        } else {
+            qDebug() << "SpectrumWidget: using legacy waterfall pipeline:"
+                     << reason;
+        }
+        return true;
+    };
+    if (!readiness.requested) {
+        return useLegacyPipeline(
+            QStringLiteral("disabled by AETHER_WF_GPU_PREVIEW"), false);
+    }
+
+    readiness.formatSupported = r->isTextureFormatSupported(
+        QRhiTexture::RGBA32F, {});
+    if (!readiness.formatSupported) {
+        return useLegacyPipeline(
+            QStringLiteral("RGBA32F row texture unsupported"), true);
+    }
+
+    std::unique_ptr<QRhiTexture> frameTexture(r->newTexture(
+        QRhiTexture::RGBA32F, QSize(1, textureHeight)));
+    readiness.textureCreated = !waterfallFrameTextureFailureForced()
+        && frameTexture->create();
+    if (!readiness.textureCreated) {
+        const QString reason = waterfallFrameTextureFailureForced()
+            ? QStringLiteral("row texture failure forced by automation")
+            : QStringLiteral("RGBA32F row texture creation failed");
+        return useLegacyPipeline(reason, true);
+    }
+
+    std::unique_ptr<QRhiSampler> frameSampler(r->newSampler(
+        QRhiSampler::Nearest, QRhiSampler::Nearest, QRhiSampler::None,
+        QRhiSampler::ClampToEdge, QRhiSampler::Repeat));
+    readiness.samplerCreated = frameSampler->create();
+    if (!readiness.samplerCreated) {
+        return useLegacyPipeline(
+            QStringLiteral("row texture sampler creation failed"), true);
+    }
+
+    std::unique_ptr<QRhiShaderResourceBindings> frameSrb(
+        r->newShaderResourceBindings());
+    frameSrb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(
+            0, QRhiShaderResourceBinding::FragmentStage, m_wfUbo),
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage,
+            m_wfGpuTex, m_wfSampler),
+        QRhiShaderResourceBinding::sampledTexture(
+            2, QRhiShaderResourceBinding::FragmentStage,
+            frameTexture.get(), frameSampler.get()),
+    });
+    readiness.bindingsCreated = frameSrb->create();
+    if (!readiness.bindingsCreated) {
+        return useLegacyPipeline(
+            QStringLiteral("row texture bindings creation failed"), true);
+    }
+
+    const QShader frameFragmentShader = loadShader(
+        ":/shaders/resources/shaders/texturedquad_rowframes.frag.qsb");
+    if (!frameFragmentShader.isValid()) {
+        return useLegacyPipeline(
+            QStringLiteral("row-frequency shader load failed"), true);
+    }
+
+    std::unique_ptr<QRhiGraphicsPipeline> framePipeline(
+        r->newGraphicsPipeline());
+    framePipeline->setShaderStages({
+        {QRhiShaderStage::Vertex, vertexShader},
+        {QRhiShaderStage::Fragment, frameFragmentShader},
+    });
+    framePipeline->setVertexInputLayout(layout);
+    framePipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    framePipeline->setShaderResourceBindings(frameSrb.get());
+    framePipeline->setRenderPassDescriptor(
+        renderTarget()->renderPassDescriptor());
+    readiness.pipelineCreated = framePipeline->create();
+    m_wfPipelineMode = chooseWaterfallPipeline(readiness);
+    if (m_wfPipelineMode != WaterfallPipelineMode::RowFrequencyFrames) {
+        return useLegacyPipeline(
+            QStringLiteral("row-frequency pipeline creation failed"), true);
+    }
+
+    m_wfFrameTex = frameTexture.release();
+    m_wfFrameSampler = frameSampler.release();
+    m_wfFrameSrb = frameSrb.release();
+    m_wfFramePipeline = framePipeline.release();
+    m_wfFrameTexReady = true;
+    m_wfFrameTexDirty = true;
+    qDebug() << "SpectrumWidget: waterfall row-frequency pipeline created"
              << m_wfGpuTexW << "x" << m_wfGpuTexH;
+    return true;
 }
 
 void SpectrumWidget::initOverlayPipeline()
@@ -9867,13 +10616,15 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
 
     qDebug() << "SpectrumWidget: QRhi initialized, backend:" << r->backendName();
 
-    // Upload quad vertex data for both pipelines
-    auto* batch = r->nextResourceUpdateBatch();
-
-    initWaterfallPipeline();
+    if (!initWaterfallPipeline()) {
+        return;
+    }
     initOverlayPipeline();
     initSpectrumPipeline();
     initDssMeshPipeline();
+
+    // Upload quad vertex data for both pipelines
+    QRhiResourceUpdateBatch* batch = r->nextResourceUpdateBatch();
 
     // Upload VBO data
     batch->uploadStaticBuffer(m_wfVbo, kQuadData);
@@ -9914,6 +10665,17 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
         QRhiTextureSubresourceUploadDescription desc(rgba);
         batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
+        if (m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+            && m_wfFrameTexReady) {
+            prepareWaterfallFrameUpload();
+            QRhiTextureSubresourceUploadDescription frameDesc(
+                m_wfFrameUpload.constData(),
+                m_wfFrameUpload.size() * static_cast<int>(sizeof(float)));
+            frameDesc.setSourceSize(QSize(1, m_wfGpuTexH));
+            batch->uploadTexture(m_wfFrameTex,
+                                 QRhiTextureUploadEntry(0, 0, frameDesc));
+            m_wfFrameTexDirty = false;
+        }
         if (PerfTelemetry::instance().enabled())
             PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
     }
@@ -9934,7 +10696,9 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     setMouseTracking(true);
 }
 
-void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
+void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
+                                    const QSize& logicalSize,
+                                    bool resizePreview)
 {
     // Guard: QRhiWidget surface recreation (add/remove panadapter, reparent)
     // can silently clear mouse tracking on macOS. Re-assert cheaply per frame.
@@ -9967,8 +10731,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     }
 
     QRhi* r = rhi();
-    const int w = width();
-    const int h = height();
+    const int w = logicalSize.width();
+    const int h = logicalSize.height();
     if (w <= 0 || h <= freqScaleH() + DIVIDER_H + 2) return;
     const bool perfEnabled = PerfTelemetry::instance().enabled();
     const qint64 perfStartNs = perfEnabled ? PerfTelemetry::nowNs() : 0;
@@ -10039,19 +10803,90 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     if (!m_waterfall.isNull()) {
         // Resize texture if needed — full re-upload
         if (m_waterfall.width() != m_wfGpuTexW || m_waterfall.height() != m_wfGpuTexH) {
-            m_wfGpuTexW = m_waterfall.width();
-            m_wfGpuTexH = m_waterfall.height();
-            m_wfGpuTex->setPixelSize(QSize(m_wfGpuTexW, m_wfGpuTexH));
-            m_wfGpuTex->create();
-            m_wfSrb->setBindings({
-                QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::FragmentStage, m_wfUbo),
-                QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_wfGpuTex, m_wfSampler),
-            });
-            m_wfSrb->create();
-            m_wfTexFullUpload = true;
+            const int desiredWidth = m_waterfall.width();
+            const int desiredHeight = m_waterfall.height();
+            std::unique_ptr<QRhiTexture> colorTexture(r->newTexture(
+                QRhiTexture::RGBA8, QSize(desiredWidth, desiredHeight)));
+            std::unique_ptr<QRhiShaderResourceBindings> legacySrb(
+                r->newShaderResourceBindings());
+            bool legacyResizeReady = colorTexture->create();
+            if (legacyResizeReady) {
+                legacySrb->setBindings({
+                    QRhiShaderResourceBinding::uniformBuffer(
+                        0, QRhiShaderResourceBinding::FragmentStage, m_wfUbo),
+                    QRhiShaderResourceBinding::sampledTexture(
+                        1, QRhiShaderResourceBinding::FragmentStage,
+                        colorTexture.get(), m_wfSampler),
+                });
+                legacyResizeReady = legacySrb->create();
+            }
+
+            const bool rowPipelineWasActive =
+                m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+                && m_wfFrameTexReady;
+            std::unique_ptr<QRhiTexture> frameTexture;
+            std::unique_ptr<QRhiShaderResourceBindings> frameSrb;
+            bool frameResizeReady = !rowPipelineWasActive;
+            if (legacyResizeReady && rowPipelineWasActive) {
+                frameTexture.reset(r->newTexture(
+                    QRhiTexture::RGBA32F, QSize(1, desiredHeight)));
+                frameResizeReady = !waterfallFrameResizeFailureForced()
+                    && frameTexture->create();
+                if (frameResizeReady) {
+                    frameSrb.reset(r->newShaderResourceBindings());
+                    frameSrb->setBindings({
+                        QRhiShaderResourceBinding::uniformBuffer(
+                            0, QRhiShaderResourceBinding::FragmentStage,
+                            m_wfUbo),
+                        QRhiShaderResourceBinding::sampledTexture(
+                            1, QRhiShaderResourceBinding::FragmentStage,
+                            colorTexture.get(), m_wfSampler),
+                        QRhiShaderResourceBinding::sampledTexture(
+                            2, QRhiShaderResourceBinding::FragmentStage,
+                            frameTexture.get(), m_wfFrameSampler),
+                    });
+                    frameResizeReady = frameSrb->create();
+                }
+            }
+
+            if (!legacyResizeReady) {
+                qCWarning(lcGui)
+                    << "SpectrumWidget: waterfall resize transaction failed;"
+                       " retaining the previous legacy texture";
+            } else {
+                QRhiTexture* oldColorTexture = m_wfGpuTex;
+                QRhiShaderResourceBindings* oldLegacySrb = m_wfSrb;
+                QRhiTexture* oldFrameTexture = m_wfFrameTex;
+                QRhiShaderResourceBindings* oldFrameSrb = m_wfFrameSrb;
+                m_wfGpuTex = colorTexture.release();
+                m_wfSrb = legacySrb.release();
+                m_wfGpuTexW = desiredWidth;
+                m_wfGpuTexH = desiredHeight;
+                m_wfTexFullUpload = true;
+
+                if (rowPipelineWasActive && frameResizeReady) {
+                    m_wfFrameTex = frameTexture.release();
+                    m_wfFrameSrb = frameSrb.release();
+                    delete oldFrameSrb;
+                    delete oldFrameTexture;
+                    m_wfFrameTexDirty = true;
+                } else if (rowPipelineWasActive) {
+                    releaseWaterfallFramePipelineResources();
+                    m_wfPipelineFallbackReason =
+                        QStringLiteral("row texture resize transaction failed");
+                    qCWarning(lcGui)
+                        << "SpectrumWidget: using legacy waterfall pipeline:"
+                        << m_wfPipelineFallbackReason;
+                }
+                delete oldLegacySrb;
+                delete oldColorTexture;
+            }
         }
 
-        if (m_wfTexFullUpload) {
+        const bool waterfallTextureMatchesSource =
+            m_waterfall.width() == m_wfGpuTexW
+            && m_waterfall.height() == m_wfGpuTexH;
+        if (m_wfTexFullUpload && waterfallTextureMatchesSource) {
             // Full upload (init or resize)
             QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
             QRhiTextureSubresourceUploadDescription desc(rgba);
@@ -10061,7 +10896,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
             m_wfLastUploadedRow = m_wfWriteRow;
             m_wfTexFullUpload = false;
-        } else if (m_wfWriteRow != m_wfLastUploadedRow) {
+        } else if (waterfallTextureMatchesSource
+                   && m_wfWriteRow != m_wfLastUploadedRow) {
             // Incremental upload — only the rows that changed since last frame
             const int texH = m_wfGpuTexH;
             int from = m_wfLastUploadedRow;
@@ -10100,14 +10936,66 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             }
             m_wfLastUploadedRow = m_wfWriteRow;
         }
+
+        const double maxReferenceDriftMhz = std::max(
+            1.0, std::abs(m_bandwidthMhz) * 8.0);
+        if (!std::isfinite(m_wfFrameReferenceCenterMhz)
+            || std::abs(m_centerMhz - m_wfFrameReferenceCenterMhz)
+                > maxReferenceDriftMhz) {
+            m_wfFrameTexDirty = true;
+        }
+        if (waterfallTextureMatchesSource
+            && m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+            && m_wfFrameTexReady && m_wfFrameTexDirty) {
+            prepareWaterfallFrameUpload();
+            QRhiTextureSubresourceUploadDescription frameDesc(
+                m_wfFrameUpload.constData(),
+                m_wfFrameUpload.size() * static_cast<int>(sizeof(float)));
+            frameDesc.setSourceSize(QSize(1, m_wfGpuTexH));
+            batch->uploadTexture(m_wfFrameTex,
+                                 QRhiTextureUploadEntry(0, 0, frameDesc));
+            m_panStats.wfUploadBytes += static_cast<quint64>(
+                m_wfFrameUpload.size() * static_cast<int>(sizeof(float)));
+            m_wfFrameTexDirty = false;
+        }
     }
 
-    // Update waterfall uniforms — just the ring buffer row offset
+    // Update waterfall uniforms. Each row carries its own source frame, so new
+    // radio rows can expose frequencies that were outside the drag-start view.
     float rowOffset = (m_wfGpuTexH > 0)
         ? static_cast<float>(m_wfWriteRow) / m_wfGpuTexH
         : 0.0f;
-    float uniforms[] = {rowOffset, 0.0f, 0.0f, 0.0f};
+    const float waterfallTargetCenterOffsetMhz = static_cast<float>(
+        m_centerMhz - m_wfFrameReferenceCenterMhz);
+    const float waterfallTargetBandwidthMhz = static_cast<float>(m_bandwidthMhz);
+    const float waterfallRowFrequencyFrames =
+        m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+            && m_wfFrameTexReady ? 1.0f : 0.0f;
+    float uniforms[] = {
+        rowOffset,
+        waterfallTargetCenterOffsetMhz,
+        waterfallTargetBandwidthMhz,
+        waterfallRowFrequencyFrames,
+    };
     batch->updateDynamicBuffer(m_wfUbo, 0, sizeof(uniforms), uniforms);
+
+    // The compact 3DSS height surface still shares one preview frame across its
+    // rows, so it retains the original affine preview uniforms.
+    float frequencyScale = 1.0f;
+    float frequencyOffset = 0.0f;
+    float frequencyPreview = 0.0f;
+    const FrequencyPreviewTransform previewTransform =
+        frequencyPreviewTransform(
+            FrequencyFrame{m_frequencyPreviewBaseCenterMhz,
+                           m_frequencyPreviewBaseBandwidthMhz},
+            FrequencyFrame{m_frequencyPreviewTargetCenterMhz,
+                           m_frequencyPreviewTargetBandwidthMhz});
+    if (m_frequencyPreviewActive && previewTransform.valid) {
+        frequencyScale = static_cast<float>(previewTransform.scale);
+        frequencyOffset = static_cast<float>(previewTransform.offset);
+        frequencyPreview = 1.0f;
+        ++m_frequencyPreviewPresentCount;
+    }
 
     // Render overlays — split into static (on state change) and dynamic (every frame)
     {
@@ -10115,7 +11003,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         const qreal dpr = devicePixelRatioF();
         const int pw = static_cast<int>(w * dpr);
         const int ph = static_cast<int>(h * dpr);
-        if (m_overlayStatic.size() != QSize(pw, ph)) {
+        if (!resizePreview && m_overlayStatic.size() != QSize(pw, ph)) {
             m_overlayStatic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
             m_overlayStatic.setDevicePixelRatio(dpr);
             m_ovGpuTex->setPixelSize(QSize(pw, ph));
@@ -10141,7 +11029,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         }
 
         // panstats: time the bg + static QPainter repaints as one rebuild.
-        const bool panStatsOvRebuild = m_overlayStaticDirty;
+        const bool rebuildStaticOverlay = m_overlayStaticDirty && !resizePreview;
+        const bool panStatsOvRebuild = rebuildStaticOverlay;
         QElapsedTimer panStatsOvTimer;
         if (panStatsOvRebuild)
             panStatsOvTimer.start();
@@ -10154,7 +11043,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         // Composition (bottom → top):
         //     m_bgFillColor (full opacity)
         //     m_bgImage     (opacity = 1 - m_bgOpacity/100, lets fill bleed through)
-        if (m_overlayStaticDirty) {
+        if (rebuildStaticOverlay) {
             m_overlayBg.fill(Qt::transparent);
             QPainter bp(&m_overlayBg);
             bp.setRenderHint(QPainter::Antialiasing, false);
@@ -10183,7 +11072,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         }
 
         // Static overlay: only repaint when state changes (markOverlayDirty).
-        if (m_overlayStaticDirty) {
+        if (rebuildStaticOverlay) {
             m_overlayStatic.fill(Qt::transparent);
             QPainter p(&m_overlayStatic);
             p.setRenderHint(QPainter::Antialiasing, false);
@@ -10376,7 +11265,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         }
 
         // Upload overlay texture only when content changed
-        if (m_overlayNeedsUpload) {
+        if (m_overlayNeedsUpload && !resizePreview) {
             QRhiTextureSubresourceUploadDescription ovDesc(m_overlayStatic);
             batch->uploadTexture(m_ovGpuTex, QRhiTextureUploadEntry(0, 0, ovDesc));
             m_panStats.overlayUploadBytes += static_cast<quint64>(m_overlayStatic.sizeInBytes());
@@ -10384,7 +11273,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
             m_overlayNeedsUpload = false;
         }
-        if (m_overlayBgNeedsUpload) {
+        if (m_overlayBgNeedsUpload && !resizePreview) {
             QRhiTextureSubresourceUploadDescription bgDesc(m_overlayBg);
             batch->uploadTexture(m_bgGpuTex, QRhiTextureUploadEntry(0, 0, bgDesc));
             m_panStats.overlayUploadBytes += static_cast<quint64>(m_overlayBg.sizeInBytes());
@@ -10490,7 +11379,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
                 floorDbm, rangeDb, m_dssZCurve,
                 DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
                 DssRenderer::kFrontMaxRidgeFrac, DssRenderer::kHaze,
-                static_cast<float>(cols), 0.0f, 0.0f, 0.0f,   // texCols + std140 pad
+                static_cast<float>(cols),
+                frequencyScale, frequencyOffset, frequencyPreview,
                 static_cast<float>(m_bgFillColor.redF()),
                 static_cast<float>(m_bgFillColor.greenF()),
                 static_cast<float>(m_bgFillColor.blueF()),
@@ -10650,9 +11540,16 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
 
     // Draw waterfall quad — viewport restricted to waterfall rect. Always drawn:
     // 3DSS replaces only the spectrum trace, the waterfall stays below it.
-    if (m_wfPipeline) {
-        cb->setGraphicsPipeline(m_wfPipeline);
-        cb->setShaderResources(m_wfSrb);
+    const bool useRowFrequencyPipeline =
+        m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+        && m_wfFramePipeline && m_wfFrameSrb && m_wfFrameTexReady;
+    QRhiGraphicsPipeline* waterfallPipeline = useRowFrequencyPipeline
+        ? m_wfFramePipeline : m_wfPipeline;
+    QRhiShaderResourceBindings* waterfallSrb = useRowFrequencyPipeline
+        ? m_wfFrameSrb : m_wfSrb;
+    if (waterfallPipeline && waterfallSrb) {
+        cb->setGraphicsPipeline(waterfallPipeline);
+        cb->setShaderResources(waterfallSrb);
         // QRhiViewport: (x, y, width, height) — y is bottom-up in GL convention
         float vpX = static_cast<float>(wfRect.x()) * dpr;
         float vpY = static_cast<float>(h - wfRect.bottom() - 1) * dpr;
@@ -10832,17 +11729,38 @@ void SpectrumWidget::render(QRhiCommandBuffer* cb)
         initialize(cb);
         if (!m_rhiInitialized) return;
     }
-    renderGpuFrame(cb);
+    if (m_resizeBufferSettleTimer && m_resizeBufferSettleTimer->isActive()) {
+        // Keep presenting fresh FFT/waterfall data into the last settled render
+        // target while QRhiWidget stretches it to the live geometry. This
+        // preserves motion without recreating full-size resources at every
+        // intermediate mouse position (once per visible panadapter).
+        static const bool liveResizePreviewEnabled = [] {
+            if (!qEnvironmentVariableIsSet("AETHER_RESIZE_LIVE_PREVIEW")) {
+                return true;
+            }
+            return qEnvironmentVariableIntValue("AETHER_RESIZE_LIVE_PREVIEW") != 0;
+        }();
+        if (liveResizePreviewEnabled && m_resizePresentationSize.isValid()) {
+            ++m_resizePreviewFrameCount;
+            renderGpuFrame(cb, m_resizePresentationSize, true);
+            return;
+        }
+        ++m_resizeFrameHoldCount;
+        return;
+    }
+    renderGpuFrame(cb, size(), false);
 }
 
 void SpectrumWidget::releaseResources()
 {
+    releaseWaterfallFramePipelineResources();
     delete m_wfPipeline;     m_wfPipeline = nullptr;
     delete m_wfSrb;          m_wfSrb = nullptr;
     delete m_wfVbo;          m_wfVbo = nullptr;
     delete m_wfUbo;          m_wfUbo = nullptr;
     delete m_wfGpuTex;       m_wfGpuTex = nullptr;
     delete m_wfSampler;      m_wfSampler = nullptr;
+    m_wfPipelineFallbackReason.clear();
 
     delete m_ovPipeline;     m_ovPipeline = nullptr;
     delete m_ovSrb;          m_ovSrb = nullptr;
@@ -10926,8 +11844,8 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
     // Both via the shared helpers so this rect and the waterfall QImage
-    // allocated in resizeEvent are always the same height — a 1:1 vertical
-    // blit. (wfH == contentH - specH by construction; see
+    // allocated by applySettledResizeBuffers() are always the same height — a
+    // 1:1 vertical blit. (wfH == contentH - specH by construction; see
     // waterfallPixelHeight().)
     const int specH    = spectrumPixelHeight();
     const int wfH      = waterfallPixelHeight();

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -9615,7 +9615,9 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
 {
     SPECTRUM_BASE_CLASS::resizeEvent(ev);
     ++m_resizeEventCount;
-    commitFrequencyPreview();
+    if (m_frequencyPreviewActive) {
+        commitFrequencyPreview();
+    }
 
     // Keep every size-dependent buffer at the last completed size while the
     // window is moving. QRhiWidget scales that fixed color buffer to the

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -940,6 +940,16 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     m[QStringLiteral("overlayRebuildMsPerSec")] = msPerSec(m_panStats.overlayRebuildUs);
     m[QStringLiteral("overlayUploadBytesPerSec")] =
         static_cast<double>(m_panStats.overlayUploadBytes) / secs;
+    m[QStringLiteral("previewOverlayTransformsPerSec")] =
+        m_panStats.previewOverlayTransforms / secs;
+    m[QStringLiteral("previewOverlayCommitRefreshes")] =
+        static_cast<qulonglong>(m_panStats.previewOverlayCommitRefreshes);
+    m[QStringLiteral("previewScaleRefreshesPerSec")] =
+        m_panStats.previewScaleRefreshes / secs;
+    m[QStringLiteral("previewScalePaintMsPerSec")] =
+        msPerSec(m_panStats.previewScalePaintUs);
+    m[QStringLiteral("previewScaleUploadBytesPerSec")] =
+        static_cast<double>(m_panStats.previewScaleUploadBytes) / secs;
     m[QStringLiteral("wfUploadBytesPerSec")] =
         static_cast<double>(m_panStats.wfUploadBytes) / secs;
     m[QStringLiteral("nativeWaterfallUpdatesPerSec")] =
@@ -1079,6 +1089,10 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         static_cast<qulonglong>(m_frequencyPreviewRemappedDssRows);
     m[QStringLiteral("frequencyPreviewSuppressedViewportRebuilds")] =
         static_cast<qulonglong>(m_frequencyPreviewSuppressedViewportRebuilds);
+    m[QStringLiteral("frequencyPreviewOverlayTransformCount")] =
+        static_cast<qulonglong>(m_frequencyPreviewOverlayTransformCount);
+    m[QStringLiteral("frequencyPreviewOverlayCommitRefreshCount")] =
+        static_cast<qulonglong>(m_frequencyPreviewOverlayCommitRefreshCount);
     m[QStringLiteral("frequencyPreviewCommitLastMs")] =
         static_cast<double>(m_frequencyPreviewCommitLastNs) / 1000000.0;
     m[QStringLiteral("frequencyPreviewCommitMaxMs")] =
@@ -1204,6 +1218,8 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
     m_frequencyPreviewNativeVisibleRows = 0;
     m_frequencyPreviewRemappedDssRows = 0;
     m_frequencyPreviewSuppressedViewportRebuilds = 0;
+    m_frequencyPreviewOverlayTransformCount = 0;
+    m_frequencyPreviewOverlayCommitRefreshCount = 0;
     m_frequencyPreviewCommitLastNs = 0;
     m_frequencyPreviewCommitMaxNs = 0;
     m_frequencyRangeCommandCount = 0;
@@ -1496,6 +1512,11 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoFillBackground(false);
+    // SpectrumWidget paints every output pixel, including the background under
+    // its internally-composited transparent overlay textures.  Tell QWidget's
+    // repaint manager it does not need to paint ancestors or siblings behind
+    // this QRhiWidget whenever a 60 Hz data/preview frame is presented.
+    setAttribute(Qt::WA_OpaquePaintEvent);
     setAccessibleName(tr("Panadapter spectrum display"));
 #ifdef AETHER_GPU_SPECTRUM
     // Explicitly request Metal on macOS.
@@ -1534,8 +1555,6 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
                       "or AETHER_NO_GPU=1 to work around (#1233)";
     }
 #  endif
-#else
-    setAttribute(Qt::WA_OpaquePaintEvent);
 #endif
     setSpectrumCursor(Qt::CrossCursor);
     setMouseTracking(true);
@@ -4781,6 +4800,17 @@ bool SpectrumWidget::updateFrequencyPreview(double oldCenterMhz,
         }
         m_frequencyPreviewBaseCenterMhz = oldCenterMhz;
         m_frequencyPreviewBaseBandwidthMhz = oldBandwidthMhz;
+        // A clean texture represents the old frame. If it was already dirty,
+        // the first preview render will rasterize at the new frame before the
+        // dirty flag is frozen, so use that as the overlay transform base.
+        bool overlayDirty = false;
+#ifdef AETHER_GPU_SPECTRUM
+        overlayDirty = m_overlayStaticDirty;
+#endif
+        m_frequencyPreviewOverlayBaseCenterMhz = overlayDirty
+            ? newCenterMhz : oldCenterMhz;
+        m_frequencyPreviewOverlayBaseBandwidthMhz = overlayDirty
+            ? newBandwidthMhz : oldBandwidthMhz;
         m_frequencyPreviewActive = true;
     }
 
@@ -4792,10 +4822,20 @@ bool SpectrumWidget::updateFrequencyPreview(double oldCenterMhz,
 
 void SpectrumWidget::scheduleFrequencyPreviewFrame()
 {
-    // Rebuild frequency-dependent overlays at the same coalesced cadence as
-    // GPU/data presentation instead of issuing an immediate paint per mouse or
-    // trackpad event.
-    markOverlayDirty("frequencyPreview", false);
+    // The drag-start QPainter overlay remains resident on the GPU. The preview
+    // shader remaps its frequency-canvas pixels alongside the waterfall/3D
+    // data, avoiding two full-widget rasterizations and texture uploads for
+    // every input frame. commitFrequencyPreview() lands one exact CPU overlay.
+#ifdef AETHER_GPU_SPECTRUM
+    if (!m_ovPreviewPipeline || !m_ovPreviewSrb || !m_ovPreviewUbo) {
+        markOverlayDirty("frequencyPreviewFallback", false);
+    } else {
+        // Unlike the full marker/chrome textures, this is only a narrow strip.
+        // Repaint it at presentation cadence so its labels remain exact while
+        // the frequency marker layer moves entirely on the GPU.
+        m_frequencyScalePreviewNeedsUpload = true;
+    }
+#endif
     coalescedUpdate();
 }
 
@@ -4847,6 +4887,15 @@ void SpectrumWidget::commitFrequencyPreview()
     m_frequencyPreviewBaseBandwidthMhz = targetBandwidthMhz;
     m_frequencyPreviewTargetCenterMhz = targetCenterMhz;
     m_frequencyPreviewTargetBandwidthMhz = targetBandwidthMhz;
+    m_frequencyPreviewOverlayBaseCenterMhz = targetCenterMhz;
+    m_frequencyPreviewOverlayBaseBandwidthMhz = targetBandwidthMhz;
+#ifdef AETHER_GPU_SPECTRUM
+    m_frequencyScalePreviewNeedsUpload = false;
+#endif
+    ++m_frequencyPreviewOverlayCommitRefreshCount;
+    ++m_panStats.previewOverlayCommitRefreshes;
+    markOverlayDirty("frequencyPreviewCommit", false);
+    coalescedUpdate();
 }
 
 void SpectrumWidget::clearFrequencyPreview()
@@ -4856,6 +4905,11 @@ void SpectrumWidget::clearFrequencyPreview()
     m_frequencyPreviewBaseBandwidthMhz = m_bandwidthMhz;
     m_frequencyPreviewTargetCenterMhz = m_centerMhz;
     m_frequencyPreviewTargetBandwidthMhz = m_bandwidthMhz;
+    m_frequencyPreviewOverlayBaseCenterMhz = m_centerMhz;
+    m_frequencyPreviewOverlayBaseBandwidthMhz = m_bandwidthMhz;
+#ifdef AETHER_GPU_SPECTRUM
+    m_frequencyScalePreviewNeedsUpload = false;
+#endif
 }
 
 void SpectrumWidget::requestFrequencyRangeChange(double centerMhz,
@@ -10310,6 +10364,16 @@ void SpectrumWidget::initOverlayPipeline()
     });
     m_ovSrb->create();
 
+    m_ovFrequencyGpuTex = r->newTexture(QRhiTexture::RGBA8, QSize(pw, ph));
+    m_ovFrequencyGpuTex->create();
+    m_ovFrequencySrb = r->newShaderResourceBindings();
+    m_ovFrequencySrb->setBindings({
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage,
+            m_ovFrequencyGpuTex, m_ovSampler),
+    });
+    m_ovFrequencySrb->create();
+
     QShader vs = loadShader(":/shaders/resources/shaders/overlay.vert.qsb");
     QShader fs = loadShader(":/shaders/resources/shaders/overlay.frag.qsb");
     if (!vs.isValid() || !fs.isValid()) {
@@ -10354,8 +10418,51 @@ void SpectrumWidget::initOverlayPipeline()
 
     m_ovPipeline->create();
 
+    // Frequency-preview overlay path. Unlike m_ovPipeline (also reused by the
+    // screen-space, background, and cached 3D layers), this pipeline has a small
+    // uniform block that remaps the frequency-overlay texture. It stays at the
+    // drag-start frame while band/spot/slice geometry follows the live GPU data.
+    m_ovPreviewUbo = r->newBuffer(
+        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 8 * sizeof(float));
+    const bool previewUboReady = m_ovPreviewUbo->create();
+    m_ovPreviewSrb = r->newShaderResourceBindings();
+    m_ovPreviewSrb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(
+            0, QRhiShaderResourceBinding::FragmentStage, m_ovPreviewUbo),
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage,
+            m_ovFrequencyGpuTex, m_ovSampler),
+    });
+    const bool previewSrbReady = m_ovPreviewSrb->create();
+    const QShader previewFs = loadShader(
+        ":/shaders/resources/shaders/overlay_frequency_preview.frag.qsb");
+    if (previewUboReady && previewSrbReady && previewFs.isValid()) {
+        m_ovPreviewPipeline = r->newGraphicsPipeline();
+        m_ovPreviewPipeline->setShaderStages({
+            {QRhiShaderStage::Vertex, vs},
+            {QRhiShaderStage::Fragment, previewFs},
+        });
+        m_ovPreviewPipeline->setVertexInputLayout(layout);
+        m_ovPreviewPipeline->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+        m_ovPreviewPipeline->setShaderResourceBindings(m_ovPreviewSrb);
+        m_ovPreviewPipeline->setRenderPassDescriptor(
+            renderTarget()->renderPassDescriptor());
+        m_ovPreviewPipeline->setTargetBlends({blend});
+        if (!m_ovPreviewPipeline->create()) {
+            delete m_ovPreviewPipeline;
+            m_ovPreviewPipeline = nullptr;
+        }
+    }
+    if (!m_ovPreviewPipeline) {
+        qWarning() << "SpectrumWidget: frequency-preview overlay pipeline unavailable;"
+                      " falling back to CPU overlay refreshes";
+    }
+
     m_overlayStatic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
     m_overlayStatic.setDevicePixelRatio(dpr);
+    m_overlayFrequency = QImage(
+        pw, ph, QImage::Format_RGBA8888_Premultiplied);
+    m_overlayFrequency.setDevicePixelRatio(dpr);
 
     // Background-image layer — parallel texture + SRB so the same overlay
     // pipeline can paint a separate quad BEFORE the FFT pass.  The image
@@ -10690,6 +10797,7 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     // false from the previous render cycle, leaving the overlay invisible.
     m_overlayStaticDirty = true;
     m_overlayNeedsUpload = true;
+    m_overlayFrequencyNeedsUpload = true;
 
     // Re-apply cursor and mouse tracking now that the native surface exists.
     setCursor(cursor());
@@ -10997,6 +11105,40 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         ++m_frequencyPreviewPresentCount;
     }
 
+    if (m_ovPreviewPipeline && m_ovPreviewSrb && m_ovPreviewUbo) {
+        float overlayScale = 1.0f;
+        float overlayOffset = 0.0f;
+        float overlayPreview = 0.0f;
+        const FrequencyPreviewTransform overlayTransform =
+            frequencyPreviewTransform(
+                FrequencyFrame{m_frequencyPreviewOverlayBaseCenterMhz,
+                               m_frequencyPreviewOverlayBaseBandwidthMhz},
+                FrequencyFrame{m_frequencyPreviewTargetCenterMhz,
+                               m_frequencyPreviewTargetBandwidthMhz});
+        if (m_frequencyPreviewActive && overlayTransform.valid) {
+            overlayScale = static_cast<float>(overlayTransform.scale);
+            overlayOffset = static_cast<float>(overlayTransform.offset);
+            overlayPreview = 1.0f;
+            ++m_frequencyPreviewOverlayTransformCount;
+            ++m_panStats.previewOverlayTransforms;
+        }
+
+        const float logicalW = static_cast<float>(std::max(1, w));
+        const float logicalH = static_cast<float>(std::max(1, h));
+        const float previewUniforms[8] = {
+            overlayScale,
+            overlayOffset,
+            overlayPreview,
+            static_cast<float>(specContentW) / logicalW,
+            static_cast<float>(specH) / logicalH,
+            static_cast<float>(wfY) / logicalH,
+            static_cast<float>(wfContentW) / logicalW,
+            0.0f,
+        };
+        batch->updateDynamicBuffer(
+            m_ovPreviewUbo, 0, sizeof(previewUniforms), previewUniforms);
+    }
+
     // Render overlays — split into static (on state change) and dynamic (every frame)
     {
         // Resize overlay images if needed
@@ -11006,12 +11148,34 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         if (!resizePreview && m_overlayStatic.size() != QSize(pw, ph)) {
             m_overlayStatic = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
             m_overlayStatic.setDevicePixelRatio(dpr);
+            m_overlayFrequency = QImage(
+                pw, ph, QImage::Format_RGBA8888_Premultiplied);
+            m_overlayFrequency.setDevicePixelRatio(dpr);
             m_ovGpuTex->setPixelSize(QSize(pw, ph));
             m_ovGpuTex->create();
             m_ovSrb->setBindings({
                 QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_ovGpuTex, m_ovSampler),
             });
             m_ovSrb->create();
+            m_ovFrequencyGpuTex->setPixelSize(QSize(pw, ph));
+            m_ovFrequencyGpuTex->create();
+            m_ovFrequencySrb->setBindings({
+                QRhiShaderResourceBinding::sampledTexture(
+                    1, QRhiShaderResourceBinding::FragmentStage,
+                    m_ovFrequencyGpuTex, m_ovSampler),
+            });
+            m_ovFrequencySrb->create();
+            if (m_ovPreviewSrb && m_ovPreviewUbo) {
+                m_ovPreviewSrb->setBindings({
+                    QRhiShaderResourceBinding::uniformBuffer(
+                        0, QRhiShaderResourceBinding::FragmentStage,
+                        m_ovPreviewUbo),
+                    QRhiShaderResourceBinding::sampledTexture(
+                        1, QRhiShaderResourceBinding::FragmentStage,
+                        m_ovFrequencyGpuTex, m_ovSampler),
+                });
+                m_ovPreviewSrb->create();
+            }
             // Background layer mirrors the resize so its texture stays the
             // same pixel size as the framebuffer.
             m_overlayBg = QImage(pw, ph, QImage::Format_RGBA8888_Premultiplied);
@@ -11034,6 +11198,62 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         QElapsedTimer panStatsOvTimer;
         if (panStatsOvRebuild)
             panStatsOvTimer.start();
+
+        // Keep the center frequency scale exact during the GPU preview without
+        // repainting either full-pan overlay. This strip is typically only a
+        // few dozen pixels tall; upload it directly into the screen-space
+        // texture at the divider's destination row.
+        const bool refreshFrequencyScalePreview =
+            m_frequencyPreviewActive
+            && m_frequencyScalePreviewNeedsUpload
+            && !rebuildStaticOverlay
+            && !resizePreview;
+        if (refreshFrequencyScalePreview) {
+            QElapsedTimer previewScaleTimer;
+            previewScaleTimer.start();
+            const int scaleBandH = DIVIDER_H + freqScaleH();
+            const QSize scalePixelSize(
+                pw, static_cast<int>(scaleBandH * dpr));
+            if (m_frequencyScalePreviewImage.size() != scalePixelSize) {
+                m_frequencyScalePreviewImage = QImage(
+                    scalePixelSize,
+                    QImage::Format_RGBA8888_Premultiplied);
+                m_frequencyScalePreviewImage.setDevicePixelRatio(dpr);
+            }
+            m_frequencyScalePreviewImage.fill(Qt::transparent);
+            {
+                QPainter scalePainter(&m_frequencyScalePreviewImage);
+                scalePainter.setRenderHint(QPainter::Antialiasing, false);
+                scalePainter.fillRect(
+                    0, 0, w, DIVIDER_H,
+                    AetherSDR::ThemeManager::instance().color(
+                        "color.background.2"));
+                drawFreqScale(
+                    scalePainter,
+                    QRect(0, DIVIDER_H, w, freqScaleH()));
+            }
+
+            m_panStats.previewScalePaintUs += static_cast<quint64>(
+                previewScaleTimer.nsecsElapsed() / 1000);
+            ++m_panStats.previewScaleRefreshes;
+            const quint64 previewBytes = static_cast<quint64>(
+                m_frequencyScalePreviewImage.sizeInBytes());
+            m_panStats.previewScaleUploadBytes += previewBytes;
+            m_panStats.overlayUploadBytes += previewBytes;
+
+            QRhiTextureSubresourceUploadDescription scaleDesc(
+                m_frequencyScalePreviewImage);
+            scaleDesc.setDestinationTopLeft(
+                QPoint(0, static_cast<int>(specH * dpr)));
+            batch->uploadTexture(
+                m_ovGpuTex,
+                QRhiTextureUploadEntry(0, 0, scaleDesc));
+            if (perfEnabled) {
+                PerfTelemetry::instance().recordGpuUpload(
+                    PerfTelemetry::GpuUploadKind::Overlay);
+            }
+            m_frequencyScalePreviewNeedsUpload = false;
+        }
 
         // Background-image layer — kept separate from the static overlay so
         // it can render BELOW the FFT trace (parity with software paint).
@@ -11071,28 +11291,33 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             m_overlayBgNeedsUpload = true;
         }
 
-        // Static overlay: only repaint when state changes (markOverlayDirty).
+        // Static overlays: only repaint when state changes (markOverlayDirty).
+        // Frequency-anchored elements live in their own texture so the preview
+        // shader can move them without also distorting screen-space controls.
         if (rebuildStaticOverlay) {
+            m_overlayFrequency.fill(Qt::transparent);
+            QPainter frequencyPainter(&m_overlayFrequency);
+            frequencyPainter.setRenderHint(QPainter::Antialiasing, false);
+
+            if (m_bandPlanFontSize > 0) {
+                drawBandPlan(frequencyPainter, specRect);
+            }
+            drawTnfMarkers(frequencyPainter, specRect);
+            if (m_showSpots || m_showSHistory) {
+                drawSpotMarkers(frequencyPainter, specRect);
+            }
+            drawSwrSweep(frequencyPainter, specRect);
+            drawSliceMarkers(frequencyPainter, specRect, wfRect);
+            drawOffScreenSlices(frequencyPainter, specRect);
+
             m_overlayStatic.fill(Qt::transparent);
             QPainter p(&m_overlayStatic);
             p.setRenderHint(QPainter::Antialiasing, false);
 
-            // #3606: grid moved to the background layer (composites below the
-            // FFT trace). The static overlay composites ABOVE the trace, so only
-            // markers/scales/band-plan that belong on top of the peaks stay here.
-            if (m_bandPlanFontSize > 0)
-                drawBandPlan(p, specRect);
-
             // Divider bar
             p.fillRect(0, specH, w, DIVIDER_H, AetherSDR::ThemeManager::instance().color("color.background.2"));
             drawFreqScale(p, QRect(0, specH + DIVIDER_H, w, freqScaleH()));
-            drawTnfMarkers(p, specRect);
-            if (m_showSpots || m_showSHistory)
-                drawSpotMarkers(p, specRect);
-            drawSwrSweep(p, specRect);
-            drawSliceMarkers(p, specRect, wfRect);
             drawSmartMtrValueLabels(p);
-            drawOffScreenSlices(p, specRect);
 
             // The auto-SQL floor and squelch line are anchored to the 2D
             // dynamic-range y-axis, which doesn't map onto the 3D surface — only
@@ -11256,6 +11481,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
             m_overlayStaticDirty = false;
             m_overlayNeedsUpload = true;
+            m_overlayFrequencyNeedsUpload = true;
+            m_frequencyScalePreviewNeedsUpload = false;
         }
 
         if (panStatsOvRebuild) {
@@ -11272,6 +11499,20 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             if (perfEnabled)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::Overlay);
             m_overlayNeedsUpload = false;
+        }
+        if (m_overlayFrequencyNeedsUpload && !resizePreview) {
+            QRhiTextureSubresourceUploadDescription frequencyDesc(
+                m_overlayFrequency);
+            batch->uploadTexture(
+                m_ovFrequencyGpuTex,
+                QRhiTextureUploadEntry(0, 0, frequencyDesc));
+            m_panStats.overlayUploadBytes += static_cast<quint64>(
+                m_overlayFrequency.sizeInBytes());
+            if (perfEnabled) {
+                PerfTelemetry::instance().recordGpuUpload(
+                    PerfTelemetry::GpuUploadKind::Overlay);
+            }
+            m_overlayFrequencyNeedsUpload = false;
         }
         if (m_overlayBgNeedsUpload && !resizePreview) {
             QRhiTextureSubresourceUploadDescription bgDesc(m_overlayBg);
@@ -11641,8 +11882,29 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         cb->draw(4);
     }
 
-    // Draw overlay quad — on top of FFT fill/line
-    if (m_ovPipeline) {
+    // Frequency-anchored overlay geometry follows the preview transform. When
+    // the preview shader is unavailable, the CPU fallback refreshes this
+    // texture at the target frame and the ordinary overlay pipeline draws it.
+    QRhiGraphicsPipeline* frequencyOverlayPipeline =
+        m_frequencyPreviewActive && m_ovPreviewPipeline
+            ? m_ovPreviewPipeline : m_ovPipeline;
+    QRhiShaderResourceBindings* frequencyOverlaySrb =
+        m_frequencyPreviewActive && m_ovPreviewPipeline
+            ? m_ovPreviewSrb : m_ovFrequencySrb;
+    if (frequencyOverlayPipeline && frequencyOverlaySrb) {
+        cb->setGraphicsPipeline(frequencyOverlayPipeline);
+        cb->setShaderResources(frequencyOverlaySrb);
+        cb->setViewport({0, 0,
+            static_cast<float>(outputSize.width()),
+            static_cast<float>(outputSize.height())});
+        const QRhiCommandBuffer::VertexInput vbuf(m_ovVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        cb->draw(4);
+    }
+
+    // Screen-space chrome stays fixed above the transformed markers: frequency
+    // and amplitude scales, SQL lines, cursor/status text, and time controls.
+    if (m_ovPipeline && m_ovSrb) {
         cb->setGraphicsPipeline(m_ovPipeline);
         cb->setShaderResources(m_ovSrb);
         cb->setViewport({0, 0,
@@ -11764,6 +12026,11 @@ void SpectrumWidget::releaseResources()
 
     delete m_ovPipeline;     m_ovPipeline = nullptr;
     delete m_ovSrb;          m_ovSrb = nullptr;
+    delete m_ovFrequencySrb; m_ovFrequencySrb = nullptr;
+    delete m_ovFrequencyGpuTex; m_ovFrequencyGpuTex = nullptr;
+    delete m_ovPreviewPipeline; m_ovPreviewPipeline = nullptr;
+    delete m_ovPreviewSrb;      m_ovPreviewSrb = nullptr;
+    delete m_ovPreviewUbo;      m_ovPreviewUbo = nullptr;
     delete m_ovVbo;          m_ovVbo = nullptr;
     delete m_ovGpuTex;       m_ovGpuTex = nullptr;
     delete m_ovSampler;      m_ovSampler = nullptr;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -990,8 +990,8 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     auto accountState = [&](const WaterfallStreamState& state) {
         cachedWaterfallVisibleBytes += state.waterfall.isNull()
             ? 0 : static_cast<quint64>(state.waterfall.sizeInBytes());
-        cachedWaterfallHistoryBytes += state.waterfallHistory.isNull()
-            ? 0 : static_cast<quint64>(state.waterfallHistory.sizeInBytes());
+        cachedWaterfallHistoryBytes += static_cast<quint64>(
+            state.waterfallHistory.allocatedBytes());
         dssFixedBytes += state.dss.fixedStorageBytes();
         dssHistoryBytes += state.dss.historyStorageBytes();
         dssCacheBytes += state.dss.cacheStorageBytes();
@@ -1005,8 +1005,8 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     }
     const quint64 currentWaterfallVisibleBytes = m_waterfall.isNull()
         ? 0 : static_cast<quint64>(m_waterfall.sizeInBytes());
-    const quint64 currentWaterfallHistoryBytes = m_waterfallHistory.isNull()
-        ? 0 : static_cast<quint64>(m_waterfallHistory.sizeInBytes());
+    const quint64 currentWaterfallHistoryBytes = static_cast<quint64>(
+        m_waterfallHistory.allocatedBytes());
     m[QStringLiteral("currentWaterfallVisibleBytes")] =
         static_cast<qulonglong>(currentWaterfallVisibleBytes);
     m[QStringLiteral("currentWaterfallHistoryBytes")] =
@@ -1140,8 +1140,10 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("waterfallWriteRow")] = m_wfWriteRow;
     m[QStringLiteral("waterfallHistoryRows")] = m_wfHistoryRowCount;
     m[QStringLiteral("waterfallHistoryCapacityRows")] =
-        m_waterfallHistory.isNull() ? 0 : m_waterfallHistory.height();
+        m_waterfallHistory.capacityRows();
     m[QStringLiteral("waterfallHistoryWidth")] = m_waterfallHistory.width();
+    m[QStringLiteral("waterfallHistoryAllocatedChunks")] =
+        m_waterfallHistory.allocatedChunkCount();
     m[QStringLiteral("resizeEventCount")] =
         static_cast<qulonglong>(m_resizeEventCount);
     m[QStringLiteral("resizeBufferCommitCount")] =
@@ -1173,8 +1175,8 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         static_cast<qulonglong>(m_dss.cacheStorageBytes());
     m[QStringLiteral("dssAllocatedBytes")] =
         static_cast<qulonglong>(m_dss.allocatedBytes());
-    m[QStringLiteral("waterfallHistoryBytes")] = m_waterfallHistory.isNull()
-        ? 0 : static_cast<qulonglong>(m_waterfallHistory.sizeInBytes());
+    m[QStringLiteral("waterfallHistoryBytes")] =
+        static_cast<qulonglong>(m_waterfallHistory.allocatedBytes());
 
     int peakBin = -1;
     float peakDbm = -1000.0f;
@@ -1255,7 +1257,7 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
         : 0;
     m_wfBlankerRingCount = 0;
     m_wfBlankerRingIdx = 0;
-    m_wfLastGoodRow.clear();
+    m_wfLastGoodLevels.clear();
     resetDssUploadState();
     update();
 
@@ -3974,10 +3976,12 @@ int SpectrumWidget::maxWaterfallHistoryOffsetRows() const
 
 int SpectrumWidget::historyRowIndexForAge(int ageRows) const
 {
-    if (m_waterfallHistory.isNull() || ageRows < 0 || ageRows >= m_wfHistoryRowCount) {
+    if (!m_waterfallHistory.isConfigured()
+        || ageRows < 0 || ageRows >= m_wfHistoryRowCount) {
         return -1;
     }
-    return (m_wfHistoryWriteRow + ageRows) % m_waterfallHistory.height();
+    return (m_wfHistoryWriteRow + ageRows)
+        % m_waterfallHistory.capacityRows();
 }
 
 QString SpectrumWidget::pausedTimeLabelForAge(int ageRows) const
@@ -3998,7 +4002,7 @@ QString SpectrumWidget::pausedTimeLabelForAge(int ageRows) const
 
 void SpectrumWidget::updateWaterfallMsPerRowFromHistory()
 {
-    if (m_waterfallHistory.isNull() || m_wfHistoryTimestamps.isEmpty()
+    if (!m_waterfallHistory.isConfigured() || m_wfHistoryTimestamps.isEmpty()
         || m_wfHistoryRowCount < 2) {
         return;
     }
@@ -4169,19 +4173,14 @@ void SpectrumWidget::ensureWaterfallHistory()
         return;
     }
 
-    // Preserve rows across width changes (e.g. band stack toggle, manual
-    // window resize) by horizontally scaling the existing history image.
-    // Height capacity is fixed via waterfallHistoryCapacityRows() so row
-    // indices and timestamps remain valid.
-    QImage newHistory;
-    if (!m_waterfallHistory.isNull() && m_wfHistoryRowCount > 0
-        && m_waterfallHistory.height() == desiredSize.height()) {
-        newHistory = m_waterfallHistory.scaled(
-            desiredSize, Qt::IgnoreAspectRatio, Qt::FastTransformation);
-    }
-    if (newHistory.isNull() || newHistory.size() != desiredSize) {
-        newHistory = QImage(desiredSize, QImage::Format_RGB32);
-        newHistory.fill(Qt::black);
+    // Preserve allocated chunks across width changes (e.g. band stack toggle,
+    // settled window resize). Unreached history remains unallocated.
+    const bool resizedExisting = m_waterfallHistory.isConfigured()
+        && m_waterfallHistory.capacityRows() == desiredSize.height()
+        && m_waterfallHistory.resizeWidth(desiredSize.width());
+    if (!resizedExisting) {
+        m_waterfallHistory.configure(
+            desiredSize.width(), desiredSize.height());
         m_wfHistoryTimestamps = QVector<qint64>(desiredSize.height(), 0);
         m_wfHistoryRowCenterMhz = QVector<double>(desiredSize.height(), 0.0);
         m_wfHistoryRowBwMhz = QVector<double>(desiredSize.height(), 0.0);
@@ -4190,7 +4189,6 @@ void SpectrumWidget::ensureWaterfallHistory()
         m_wfHistoryOffsetRows = 0;
         m_wfLive = true;
     }
-    m_waterfallHistory = newHistory;
     m_dss.setHistoryCapacityRows(retainDssHistory ? desiredSize.height() : 0);
 }
 
@@ -4318,7 +4316,8 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
         PerfTelemetry::instance().recordWaterfallVisibleRows();
 }
 
-void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
+void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
+                                      qint64 timestampMs,
                                       double frameCenterMhz,
                                       double frameBandwidthMhz)
 {
@@ -4332,15 +4331,17 @@ void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
     QElapsedTimer timer;
     timer.start();
     ensureWaterfallHistory();
-    if (m_waterfallHistory.isNull() || rowData == nullptr) {
+    if (!m_waterfallHistory.isConfigured() || intensityData == nullptr) {
         return;
     }
 
-    const int h = m_waterfallHistory.height();
+    const int h = m_waterfallHistory.capacityRows();
     m_wfHistoryWriteRow = (m_wfHistoryWriteRow - 1 + h) % h;
-    auto* row = reinterpret_cast<QRgb*>(m_waterfallHistory.bits()
-                                        + m_wfHistoryWriteRow * m_waterfallHistory.bytesPerLine());
-    std::memcpy(row, rowData, m_waterfallHistory.width() * sizeof(QRgb));
+    quint8* row = m_waterfallHistory.writableRow(m_wfHistoryWriteRow);
+    if (!row) {
+        return;
+    }
+    std::memcpy(row, intensityData, m_waterfallHistory.width());
     if (m_wfHistoryWriteRow >= 0 && m_wfHistoryWriteRow < m_wfHistoryTimestamps.size()) {
         m_wfHistoryTimestamps[m_wfHistoryWriteRow] = timestampMs;
     }
@@ -4368,47 +4369,40 @@ void SpectrumWidget::appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
         static_cast<quint64>(timer.nsecsElapsed() / 1000);
     ++m_panStats.waterfallHistoryRows;
     // No hidden-history counter: appendHistoryRow early-returns for a hidden
-    // source above, so RGB history is only ever written for the visible one.
+    // source above, so compact intensity history is only written for the
+    // visible one.
 }
 
 // Copy one history scanline into the viewport, remapping its columns from the
 // frame it was captured in (rowCenter/rowBw) to the current frame (curCenter/
 // curBw). When the frames match (no pan/zoom since capture) this is a plain
-// copy; otherwise it is a horizontal resample and newly-exposed columns are
-// black. Kiwi rows can be narrower than the current viewport after a zoom-out,
-// so its path preserves the brightest source pixel covered by each destination
-// column instead of point-sampling carriers out of existence.
-static int waterfallPixelScore(QRgb pixel)
-{
-    const int maxChannel = std::max(qRed(pixel), std::max(qGreen(pixel), qBlue(pixel)));
-    return maxChannel * 1024 + qRed(pixel) + qGreen(pixel) + qBlue(pixel);
-}
-
-static QRgb peakPreservedWaterfallSample(const QRgb* src, int w,
-                                         double srcLeft, double srcRight,
-                                         double srcCenter)
+// colorized copy; otherwise it is a horizontal resample and newly-exposed
+// columns are black. Kiwi rows can be narrower than the current viewport after
+// a zoom-out, so its path preserves the strongest normalized source sample
+// covered by each destination column instead of point-sampling carriers out of
+// existence.
+static quint8 peakPreservedWaterfallSample(const quint8* src, int w,
+                                           double srcLeft, double srcRight,
+                                           double srcCenter)
 {
     if (srcRight <= 0.0 || srcLeft >= static_cast<double>(w)) {
-        return qRgb(0, 0, 0);
+        return 0;
     }
 
     const double clampedLeft = std::clamp(srcLeft, 0.0, static_cast<double>(w));
     const double clampedRight = std::clamp(srcRight, 0.0, static_cast<double>(w));
     if (clampedRight - clampedLeft <= 1.0) {
         return (srcCenter < 0.0 || srcCenter >= static_cast<double>(w))
-            ? qRgb(0, 0, 0)
+            ? 0
             : src[static_cast<int>(srcCenter)];
     }
 
     const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)), 0, w - 1);
     const int last = std::clamp(static_cast<int>(std::ceil(clampedRight)) - 1, 0, w - 1);
-    QRgb best = src[first];
-    int bestScore = waterfallPixelScore(best);
+    quint8 best = src[first];
     for (int i = first + 1; i <= last; ++i) {
-        const int score = waterfallPixelScore(src[i]);
-        if (score > bestScore) {
+        if (src[i] > best) {
             best = src[i];
-            bestScore = score;
         }
     }
     return best;
@@ -4526,14 +4520,17 @@ const QVector<float>& SpectrumWidget::remapPreviewDssRow(
     return m_frequencyPreviewDssScratch;
 }
 
-static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
+static void remapHistoryRowInto(QRgb* dst, const quint8* src, int w,
+                                const std::array<QRgb, 256>& colorLut,
                                 double rowCenterMhz, double rowBwMhz,
                                 double curCenterMhz, double curBwMhz,
                                 bool preservePeaks)
 {
     if (rowBwMhz <= 0.0 || curBwMhz <= 0.0
         || (rowCenterMhz == curCenterMhz && rowBwMhz == curBwMhz)) {
-        std::memcpy(dst, src, w * static_cast<int>(sizeof(QRgb)));
+        for (int x = 0; x < w; ++x) {
+            dst[x] = colorLut[src[x]];
+        }
         return;
     }
     const double rowStartMhz = rowCenterMhz - rowBwMhz / 2.0;
@@ -4544,7 +4541,7 @@ static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
         const double srcX = (freqMhz - rowStartMhz) / rowBwMhz * w;
         if (!preservePeaks) {
             dst[x] = (srcX < 0.0 || srcX >= w) ? qRgb(0, 0, 0)
-                                               : src[static_cast<int>(srcX)];
+                : colorLut[src[static_cast<int>(srcX)]];
             continue;
         }
 
@@ -4558,7 +4555,8 @@ static void remapHistoryRowInto(QRgb* dst, const QRgb* src, int w,
         }
         const double srcLeft = (freqLeftMhz - rowStartMhz) / rowBwMhz * w;
         const double srcRight = (freqRightMhz - rowStartMhz) / rowBwMhz * w;
-        dst[x] = peakPreservedWaterfallSample(src, w, srcLeft, srcRight, srcX);
+        dst[x] = colorLut[peakPreservedWaterfallSample(
+            src, w, srcLeft, srcRight, srcX)];
     }
 }
 
@@ -4661,24 +4659,29 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
     m_wfWriteRow = 0;
     resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
 
-    if (m_waterfallHistory.isNull()) {
+    if (!m_waterfallHistory.isConfigured()) {
         update();
         return;
     }
 
     const int w = m_waterfall.width();
-    const bool haveFrames = m_wfHistoryRowCenterMhz.size() == m_waterfallHistory.height();
+    const bool haveFrames = m_wfHistoryRowCenterMhz.size()
+        == m_waterfallHistory.capacityRows();
+    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
     for (int y = 0; y < m_waterfall.height(); ++y) {
         const int rowIndex = historyRowIndexForAge(m_wfHistoryOffsetRows + y);
         if (rowIndex < 0) {
             break;
         }
-        const QRgb* src = reinterpret_cast<const QRgb*>(
-            m_waterfallHistory.constScanLine(rowIndex));
+        const quint8* src = m_waterfallHistory.row(rowIndex);
+        if (!src) {
+            continue;
+        }
         auto* dst = reinterpret_cast<QRgb*>(m_waterfall.scanLine(y));
         const double rowCenter = haveFrames ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
         const double rowBw = haveFrames ? m_wfHistoryRowBwMhz[rowIndex] : m_bandwidthMhz;
-        remapHistoryRowInto(dst, src, w, rowCenter, rowBw, centerMhz, bandwidthMhz,
+        remapHistoryRowInto(dst, src, w, colorLut,
+                            rowCenter, rowBw, centerMhz, bandwidthMhz,
                             m_kiwiSdrWaterfallActive);
     }
 
@@ -4990,8 +4993,8 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     if (!m_waterfall.isNull()) {
         m_waterfall.fill(Qt::black);
     }
-    if (!m_waterfallHistory.isNull()) {
-        m_waterfallHistory.fill(Qt::black);
+    if (m_waterfallHistory.isConfigured()) {
+        m_waterfallHistory.discardRows();
     }
     std::fill(m_wfHistoryTimestamps.begin(), m_wfHistoryTimestamps.end(), 0);
     std::fill(m_wfHistoryRowCenterMhz.begin(), m_wfHistoryRowCenterMhz.end(), 0.0);
@@ -5003,7 +5006,7 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     m_wfHistoryOffsetRows = 0;
     m_wfLive = true;
     m_wfRowsSinceRateChange = 0;
-    m_prevTileScanline.clear();
+    m_prevTileLevels.clear();
     m_kiwiSdrFftTrace.clear();
     m_kiwiSdrFftFallbackSeedMask.clear();
     m_kiwiSdrLastWaterfallBins.clear();
@@ -5048,7 +5051,8 @@ void SpectrumWidget::resetCurrentWaterfallRowsForSize(
             QSize(waterfallSize.width(), waterfallHistoryCapacityRows());
     }
     if (!desiredHistorySize.isEmpty()) {
-        m_waterfallHistory = QImage(desiredHistorySize, QImage::Format_RGB32);
+        m_waterfallHistory.configure(desiredHistorySize.width(),
+                                     desiredHistorySize.height());
         m_waterfallHistoryStreamSizeHint = desiredHistorySize;
         m_wfHistoryTimestamps = QVector<qint64>(desiredHistorySize.height(), 0);
         m_wfHistoryRowCenterMhz = QVector<double>(desiredHistorySize.height(), 0.0);
@@ -5058,7 +5062,7 @@ void SpectrumWidget::resetCurrentWaterfallRowsForSize(
         m_dss.setHistoryCapacityRows(
             retainDssHistory ? desiredHistorySize.height() : 0);
     } else {
-        m_waterfallHistory = QImage();
+        m_waterfallHistory.reset();
         m_waterfallHistoryStreamSizeHint = QSize();
         m_wfHistoryTimestamps.clear();
         m_wfHistoryRowCenterMhz.clear();
@@ -5108,13 +5112,13 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     if (!m_waterfall.isNull()) {
         m_waterfallStreamSizeHint = m_waterfall.size();
     }
-    if (!m_waterfallHistory.isNull()) {
+    if (m_waterfallHistory.isConfigured()) {
         m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
     }
 
     // Transfer ownership between the visible stream and saved stream state.
-    // QImage assignment would COW-share the large waterfall history, making the
-    // next scanline write detach and copy the whole image on the GUI thread.
+    // Moving the compact history avoids sharing its allocated chunks with the
+    // inactive source while keeping source switches allocation-free.
     WaterfallStreamState updated;
     updated.waterfall = std::move(m_waterfall);
     updated.wfWriteRow = m_wfWriteRow;
@@ -5129,7 +5133,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     updated.historyRowBwMhz = std::move(m_wfHistoryRowBwMhz);
     updated.live = m_wfLive;
     updated.rowsSinceRateChange = m_wfRowsSinceRateChange;
-    updated.prevTileScanline = std::move(m_prevTileScanline);
+    updated.prevTileLevels = std::move(m_prevTileLevels);
     updated.kiwiFftTrace = std::move(m_kiwiSdrFftTrace);
     updated.kiwiFftFallbackSeedMask = std::move(m_kiwiSdrFftFallbackSeedMask);
     updated.kiwiLastWaterfallBins = std::move(m_kiwiSdrLastWaterfallBins);
@@ -5158,7 +5162,7 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
 
 void SpectrumWidget::discardRetainedHistory(WaterfallStreamState& state)
 {
-    state.waterfallHistory = QImage{};
+    state.waterfallHistory.reset();
     state.historyTimestamps.clear();
     state.historyWriteRow = 0;
     state.historyRowCount = 0;
@@ -5178,7 +5182,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     const QSize currentSize = !m_waterfall.isNull()
         ? m_waterfall.size()
         : m_waterfallStreamSizeHint;
-    const QSize currentHistorySize = !m_waterfallHistory.isNull()
+    const QSize currentHistorySize = m_waterfallHistory.isConfigured()
         ? m_waterfallHistory.size()
         : m_waterfallHistoryStreamSizeHint;
 
@@ -5187,7 +5191,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
         && (state.waterfall.isNull() || state.waterfall.size() != currentSize);
     const bool stateHasWrongHistory =
         !currentHistorySize.isEmpty()
-        && !state.waterfallHistory.isNull()
+        && state.waterfallHistory.isConfigured()
         && state.waterfallHistory.size() != currentHistorySize;
     if (!state.valid || stateHasWrongWaterfall || stateHasWrongHistory) {
         const bool restoreKiwiDisplayRange =
@@ -5226,7 +5230,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
         resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     }
     m_waterfallHistory = std::move(restored.waterfallHistory);
-    if (!m_waterfallHistory.isNull()) {
+    if (m_waterfallHistory.isConfigured()) {
         m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
     }
     m_wfHistoryTimestamps = std::move(restored.historyTimestamps);
@@ -5237,7 +5241,7 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_wfHistoryRowBwMhz = std::move(restored.historyRowBwMhz);
     m_wfLive = restored.live;
     m_wfRowsSinceRateChange = restored.rowsSinceRateChange;
-    m_prevTileScanline = std::move(restored.prevTileScanline);
+    m_prevTileLevels = std::move(restored.prevTileLevels);
     m_kiwiSdrFftTrace = std::move(restored.kiwiFftTrace);
     m_kiwiSdrFftFallbackSeedMask = std::move(restored.kiwiFftFallbackSeedMask);
     m_kiwiSdrLastWaterfallBins = std::move(restored.kiwiLastWaterfallBins);
@@ -5704,14 +5708,14 @@ void SpectrumWidget::reprojectWaterfall(double oldCenterMhz, double oldBandwidth
     // Prefer the per-row history. Rows can be captured across several pan/zoom
     // frames, especially when switching between native and Kiwi waterfall data;
     // rebuilding from stamped history preserves each row's own frequency frame.
-    if (!m_waterfallHistory.isNull() && m_wfHistoryRowCount > 0) {
+    if (m_waterfallHistory.isConfigured() && m_wfHistoryRowCount > 0) {
         rebuildWaterfallViewportForFrame(newCenterMhz, newBandwidthMhz);
     } else {
         reprojectWaterfallImage(m_waterfall, oldCenterMhz, oldBandwidthMhz,
                                 newCenterMhz, newBandwidthMhz);
         resetVisibleWaterfallFrequencyFrames(newCenterMhz, newBandwidthMhz);
     }
-    m_prevTileScanline.clear();
+    m_prevTileLevels.clear();
 #ifdef AETHER_GPU_SPECTRUM
     m_wfTexFullUpload = true;
 #endif
@@ -6222,7 +6226,7 @@ void SpectrumWidget::setTransmitting(bool tx)
         m_wfPrevTimecodeMs = 0;
         m_txEndMs = QDateTime::currentMSecsSinceEpoch(); // post-TX blanking (#2117)
         m_wfBlankerRingCount = 0;                        // reset stale blanker baseline
-        m_wfLastGoodRow.clear();                          // forget any TX-era last-good scanline
+        m_wfLastGoodLevels.clear();                       // forget any TX-era last-good row
         // Drop the FFT trace's client-side EMA so the first clean RX frame is
         // taken raw instead of weighted against TX-contaminated history. During
         // the UNKEY_REQUESTED window the radio keeps streaming TX-contaminated
@@ -6813,7 +6817,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     const double tileBw = (srcSize > 0) ? (highFreqMhz - lowFreqMhz) / srcSize : 0.0;
     const double panStartMhz = m_centerMhz - m_bandwidthMhz / 2.0;
 
-    QVector<QRgb> scanline(destWidth, qRgb(0, 0, 0));
+    QVector<quint8> levels(destWidth, 0);
     if (tileBw > 0) {
         for (int x = 0; x < destWidth; ++x) {
             const double freq = panStartMhz + (static_cast<double>(x) / destWidth) * m_bandwidthMhz;
@@ -6824,7 +6828,8 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
                 const float frac = static_cast<float>(binF - binIdx);
                 const float i0 = binsIntensity[binIdx];
                 const float i1 = (binIdx + 1 < srcSize) ? binsIntensity[binIdx + 1] : i0;
-                scanline[x] = intensityToRgb(i0 + frac * (i1 - i0));
+                levels[x] = encodeWaterfallLevel(
+                    intensityToWaterfallLevel(i0 + frac * (i1 - i0)));
             }
         }
     }
@@ -6833,8 +6838,8 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     // Skip entirely during TX: with show-tx-in-waterfall enabled, TX-era tiles
     // flow through and would otherwise poison the rolling baseline.  Post-TX,
     // real RX rows would then read as huge "impulses" against the suppressed
-    // TX-era baseline, causing the blanker to substitute m_wfLastGoodRow (a
-    // TX-era scanline) for ~10–18 s while baseline slowly re-converges —
+    // TX-era baseline, causing the blanker to substitute m_wfLastGoodLevels (a
+    // TX-era row) for ~10–18 s while baseline slowly re-converges —
     // visible as a frozen, striped waterfall.  Freezing the ring across TX
     // means post-TX rows are compared against the pre-TX baseline instead.
     if (m_wfBlankerEnabled && !m_transmitting) {
@@ -6855,16 +6860,17 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         if (m_wfBlankerRingCount >= 8 && baseline > 0.0f
                 && rowMean > baseline * m_wfBlankerThreshold) {
             // Impulse detected — replace with last good row (interpolate)
-            if (m_wfLastGoodRow.size() == destWidth) {
-                scanline = m_wfLastGoodRow;
+            if (m_wfLastGoodLevels.size() == destWidth) {
+                levels = m_wfLastGoodLevels;
             } else {
                 // No previous good row yet — fill with noise floor color
-                const QRgb floorColor = intensityToRgb(baseline);
-                std::fill(scanline.begin(), scanline.end(), floorColor);
+                const quint8 floorLevel = encodeWaterfallLevel(
+                    intensityToWaterfallLevel(baseline));
+                std::fill(levels.begin(), levels.end(), floorLevel);
             }
             m_wfBlankerRing[m_wfBlankerRingIdx] = std::min(rowMean, baseline * 1.05f);
         } else {
-            m_wfLastGoodRow = scanline;
+            m_wfLastGoodLevels = levels;
             m_wfBlankerRing[m_wfBlankerRingIdx] = rowMean;
         }
         m_wfBlankerRingIdx = (m_wfBlankerRingIdx + 1) % WF_BLANKER_N;
@@ -6873,25 +6879,30 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     }
 
     // Write rows into history + visible viewport.
-    const bool canInterp = (m_prevTileScanline.size() == destWidth && rowsToPush > 1);
+    const bool canInterp = (m_prevTileLevels.size() == destWidth && rowsToPush > 1);
+    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
     for (int r = 0; r < rowsToPush; ++r) {
+        QVector<quint8> interpolatedLevels(destWidth, 0);
         QVector<QRgb> interpolatedRow(destWidth, qRgb(0, 0, 0));
         if (canInterp) {
             // t=0 at row 0 (current), t=1 at last row (previous)
             const float t = static_cast<float>(r) / rowsToPush;
             for (int x = 0; x < destWidth; ++x) {
-                const QRgb c = scanline[x];
-                const QRgb p = m_prevTileScanline[x];
-                const int cr = qRed(c)   + static_cast<int>(t * (qRed(p)   - qRed(c)));
-                const int cg = qGreen(c) + static_cast<int>(t * (qGreen(p) - qGreen(c)));
-                const int cb = qBlue(c)  + static_cast<int>(t * (qBlue(p)  - qBlue(c)));
-                interpolatedRow[x] = qRgb(cr, cg, cb);
+                const int current = levels[x];
+                const int previous = m_prevTileLevels[x];
+                interpolatedLevels[x] = static_cast<quint8>(std::clamp(
+                    current + static_cast<int>(
+                        std::lround(t * (previous - current))),
+                    0, 255));
             }
         } else {
-            interpolatedRow = scanline;
+            interpolatedLevels = levels;
+        }
+        for (int x = 0; x < destWidth; ++x) {
+            interpolatedRow[x] = colorLut[interpolatedLevels[x]];
         }
 
-        appendHistoryRow(interpolatedRow.constData(), nowMs);
+        appendHistoryRow(interpolatedLevels.constData(), nowMs);
         appendLatestDssWaterfallRow();
         if (m_wfLive) {
             appendVisibleRow(interpolatedRow.constData());
@@ -6899,7 +6910,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
             rebuildWaterfallViewport();
         }
     }
-    m_prevTileScanline = scanline;
+    m_prevTileLevels = levels;
     recordWaterfallFrame(rowsToPush);
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallNativeRows(rowsToPush);
@@ -6923,9 +6934,9 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
                               dssFloorDepth(),
                               false);
     saveCurrentWaterfallStreamState();
-    // Retained RGB/DSS scrollback follows the visible source. Keep the small
-    // live viewport/DSS rings in every cached state for an immediate toggle,
-    // but release all deep histories before choosing the new owner.
+    // Retained intensity/DSS scrollback follows the visible source. Keep the
+    // small live viewport/DSS rings in every cached state for an immediate
+    // toggle, but release all deep histories before choosing the new owner.
     discardRetainedHistory(m_nativeWaterfallState);
     discardRetainedHistory(m_kiwiWaterfallState);
     for (auto it = m_kiwiProfileWaterfallStates.begin();
@@ -9610,7 +9621,8 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
     // window is moving. QRhiWidget scales that fixed color buffer to the
     // widget's current geometry while render() continues presenting new FFT
     // and waterfall data into it. The render target, overlays, FFT columns,
-    // waterfall, and its 24,000-row history still coalesce to one commit.
+    // waterfall, and its 24,000-row compact history still coalesce to one
+    // commit.
     if (m_waterfall.isNull()) {
         applySettledResizeBuffers();
     } else if (m_resizeBufferSettleTimer) {
@@ -9675,6 +9687,11 @@ void SpectrumWidget::raisePanadapterMessageOverlay()
 
 QRgb SpectrumWidget::dbmToRgb(float dbm) const
 {
+    return waterfallLevelToRgb(dbmToWaterfallLevel(dbm));
+}
+
+float SpectrumWidget::dbmToWaterfallLevel(float dbm) const
+{
     // Black level shifts the floor: higher black_level = more of the noise is black.
     // Color gain controls the visible range: higher gain = narrower range = more contrast.
     // black_level 0-125: higher = floor moves closer to signals (more black)
@@ -9684,11 +9701,9 @@ QRgb SpectrumWidget::dbmToRgb(float dbm) const
     const float effectiveMin = m_wfMinDbm + floorShift;
     const float effectiveMax = effectiveMin + visRange;
 
-    const float t = qBound(0.0f, (dbm - effectiveMin) / (effectiveMax - effectiveMin), 1.0f);
-
-    int n = 0;
-    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
-    return interpolateGradient(t, stops, n);
+    return qBound(0.0f,
+                  (dbm - effectiveMin) / (effectiveMax - effectiveMin),
+                  1.0f);
 }
 
 QRgb SpectrumWidget::dssStrengthToRgb(float s) const
@@ -9909,6 +9924,11 @@ void SpectrumWidget::resetDssUploadState()
 
 QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
 {
+    return waterfallLevelToRgb(kiwiSdrWaterfallLevel(level));
+}
+
+float SpectrumWidget::kiwiSdrWaterfallLevel(float level) const
+{
     // Kiwi direct W/F bytes are decoded to the server's wrapped negative dB
     // scale; color aperture is still Kiwi-only and independent of Flex.
     const KiwiSdrProtocol::WaterfallDisplayRange defaultRange =
@@ -9923,12 +9943,8 @@ QRgb SpectrumWidget::kiwiSdrLevelToRgb(float level) const
         ? m_kiwiSdrDisplayCeilDbm
         : defaultRange.maxDbm;
     const float adjustedCeilDbm = qMax(floorDbm + 1.0f, ceilDbm);
-    const float t = KiwiSdrProtocol::waterfallColorIndex(
+    return KiwiSdrProtocol::waterfallColorIndex(
         level, floorDbm, adjustedCeilDbm);
-
-    int n = 0;
-    const auto* stops = wfSchemeStops(m_wfColorScheme, n);
-    return interpolateGradient(t, stops, n);
 }
 
 // Cubic colour-gain curve mapping the radio's black point (low) to a white
@@ -9951,6 +9967,11 @@ static float wfHighThresholdRaw(float lowRaw, int colorGain)
 // Intensity is int16(raw)/128.0f — observed range ~96-120 on HF.
 // m_wfBlackLevel and m_wfColorGain control the mapping independently from FFT.
 QRgb SpectrumWidget::intensityToRgb(float intensity) const
+{
+    return waterfallLevelToRgb(intensityToWaterfallLevel(intensity));
+}
+
+float SpectrumWidget::intensityToWaterfallLevel(float intensity) const
 {
     // Two auto-black paths (intensity arrives as raw_uint16 / 128):
     //  • Radio-authoritative: the radio's per-tile black level is the low/black
@@ -9981,11 +10002,30 @@ QRgb SpectrumWidget::intensityToRgb(float intensity) const
         rangeWidth  = std::max(1.0f, 120.0f - m_wfColorGain * 0.91f);
     }
 
-    const float t = qBound(0.0f, (intensity - blackThresh) / rangeWidth, 1.0f);
+    return qBound(0.0f, (intensity - blackThresh) / rangeWidth, 1.0f);
+}
 
+QRgb SpectrumWidget::waterfallLevelToRgb(float level) const
+{
     int n = 0;
     const auto* stops = wfSchemeStops(m_wfColorScheme, n);
-    return interpolateGradient(t, stops, n);
+    return interpolateGradient(std::clamp(level, 0.0f, 1.0f), stops, n);
+}
+
+quint8 SpectrumWidget::encodeWaterfallLevel(float level)
+{
+    return static_cast<quint8>(std::lround(
+        std::clamp(level, 0.0f, 1.0f) * 255.0f));
+}
+
+std::array<QRgb, 256> SpectrumWidget::waterfallHistoryColorLut() const
+{
+    std::array<QRgb, 256> lut{};
+    for (int level = 0; level < static_cast<int>(lut.size()); ++level) {
+        lut[static_cast<size_t>(level)] = waterfallLevelToRgb(
+            static_cast<float>(level) / 255.0f);
+    }
+    return lut;
 }
 
 // ─── Waterfall update ─────────────────────────────────────────────────────────
@@ -10018,6 +10058,8 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
     const int srcSize = bins.size();
     const double panStartMhz = m_centerMhz - m_bandwidthMhz / 2.0;
 
+    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
+    QVector<quint8> levels(destWidth, 0);
     QVector<QRgb> scanline(destWidth, qRgb(0, 0, 0));
     for (int x = 0; x < destWidth; ++x) {
         if (useTxFilterMask) {
@@ -10045,10 +10087,12 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
             const float b1 = std::max(bins[nextIdx], kMinDisplayDbm);
             dbm = b0 + frac * (b1 - b0);
         }
-        scanline[x] = dbmToRgb(dbm);
+        const float level = dbmToWaterfallLevel(dbm);
+        levels[x] = encodeWaterfallLevel(level);
+        scanline[x] = colorLut[levels[x]];
     }
 
-    appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch());
+    appendHistoryRow(levels.constData(), QDateTime::currentMSecsSinceEpoch());
     appendDssWaterfallRow(bins);
     if (m_wfLive) {
         appendVisibleRow(scanline.constData());
@@ -10080,6 +10124,8 @@ void SpectrumWidget::pushKiwiSdrWaterfallRow(const QVector<float>& bins,
         rowBandwidthMhz = m_bandwidthMhz;
     }
 
+    const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
+    QVector<quint8> levels(destWidth, 0);
     QVector<QRgb> scanline(destWidth, qRgb(0, 0, 0));
     for (int x = 0; x < destWidth; ++x) {
         const double srcLeft = static_cast<double>(x)
@@ -10090,14 +10136,17 @@ void SpectrumWidget::pushKiwiSdrWaterfallRow(const QVector<float>& bins,
             * static_cast<double>(srcSize) / static_cast<double>(destWidth) - 0.5;
         const float level = peakPreservedBinSample(
             bins, srcLeft, srcRight, srcCenter, kKiwiSdrWaterfallMinDbm);
-        scanline[x] = kiwiSdrLevelToRgb(level);
+        const float normalized = kiwiSdrWaterfallLevel(level);
+        levels[x] = encodeWaterfallLevel(normalized);
+        scanline[x] = colorLut[levels[x]];
     }
 
-    appendHistoryRow(scanline.constData(), QDateTime::currentMSecsSinceEpoch(),
+    appendHistoryRow(levels.constData(), QDateTime::currentMSecsSinceEpoch(),
                      rowCenterMhz, rowBandwidthMhz);
     if (m_wfLive) {
         QVector<QRgb> visibleLine(destWidth, qRgb(0, 0, 0));
-        remapHistoryRowInto(visibleLine.data(), scanline.constData(), destWidth,
+        remapHistoryRowInto(visibleLine.data(), levels.constData(), destWidth,
+                            colorLut,
                             rowCenterMhz, rowBandwidthMhz,
                             m_centerMhz, m_bandwidthMhz,
                             true);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <functional>
 #include <QHash>
 #include <QWidget>
@@ -18,6 +19,7 @@
 
 #include "DssRenderer.h"
 #include "SpectrumPreviewLogic.h"
+#include "WaterfallHistoryBuffer.h"
 
 class QVariantAnimation;
 class QSoundEffect;
@@ -839,7 +841,7 @@ private:
         int wfWriteRow{0};
         QVector<double> visibleRowCenterMhz;
         QVector<double> visibleRowBwMhz;
-        QImage waterfallHistory;
+        WaterfallHistoryBuffer waterfallHistory;
         QVector<qint64> historyTimestamps;
         int historyWriteRow{0};
         int historyRowCount{0};
@@ -848,7 +850,7 @@ private:
         QVector<double> historyRowBwMhz;
         bool live{true};
         int rowsSinceRateChange{0};
-        QVector<QRgb> prevTileScanline;
+        QVector<quint8> prevTileLevels;
         QVector<float> kiwiFftTrace;
         QVector<quint8> kiwiFftFallbackSeedMask;
         QVector<float> kiwiLastWaterfallBins;
@@ -883,7 +885,7 @@ private:
     const WaterfallStreamState* activeKiwiWaterfallStateConst() const;
     bool beginWaterfallStreamWrite(bool kiwiStream);
     void endWaterfallStreamWrite(bool kiwiStream, bool visibleStream);
-    void appendHistoryRow(const QRgb* rowData, qint64 timestampMs,
+    void appendHistoryRow(const quint8* intensityData, qint64 timestampMs,
                           double frameCenterMhz = -1.0,
                           double frameBandwidthMhz = -1.0);
     void appendDssHistoryRow(const QVector<float>& binsDbm,
@@ -1008,6 +1010,12 @@ private:
     QRgb dbmToRgb(float dbm) const;
     QRgb kiwiSdrLevelToRgb(float level) const;
     QRgb intensityToRgb(float intensity) const;  // for native waterfall tiles
+    float dbmToWaterfallLevel(float dbm) const;
+    float kiwiSdrWaterfallLevel(float level) const;
+    float intensityToWaterfallLevel(float intensity) const;
+    QRgb waterfallLevelToRgb(float level) const;
+    static quint8 encodeWaterfallLevel(float level);
+    std::array<QRgb, 256> waterfallHistoryColorLut() const;
     // 3DSS surface colour for a normalised strength s in [0,1] (0 = noise floor,
     // 1 = ref). The full colormap gradient, gamma-shaped by the "3D Gain"
     // control. Shared by the GPU LUT bake and the CPU fallback so both paths
@@ -1242,7 +1250,7 @@ private:
     // flattening the entire live texture into one pan/zoom frame.
     QVector<double> m_wfVisibleRowCenterMhz;
     QVector<double> m_wfVisibleRowBwMhz;
-    QImage m_waterfallHistory;
+    WaterfallHistoryBuffer m_waterfallHistory;
     QTimer* m_resizeBufferSettleTimer{nullptr};
     quint64 m_resizeEventCount{0};
     quint64 m_resizeBufferCommitCount{0};
@@ -1258,11 +1266,9 @@ private:
     int    m_wfHistoryRowCount{0};
     int    m_wfHistoryOffsetRows{0};
     // Per-row frequency frame: each history row records the center/bandwidth it
-    // was captured at (parallel to m_wfHistoryTimestamps). The full history image
-    // (up to ~24k rows, ~0.5 GB at ultrawide widths) is therefore never globally
-    // reprojected on a pan — instead rebuildWaterfallViewport remaps only the
-    // ~700 visible rows from their own frame to the requested viewport on live
-    // pan/zoom changes and time-scrollback.
+    // was captured at (parallel to m_wfHistoryTimestamps). Pixel history is a
+    // lazy, chunked 8-bit normalized-intensity ring rather than an eager RGB32
+    // image. rebuildWaterfallViewport remaps and colorizes only visible rows.
     QVector<double> m_wfHistoryRowCenterMhz;
     QVector<double> m_wfHistoryRowBwMhz;
     bool   m_wfLive{true};
@@ -1283,7 +1289,7 @@ private:
     // Before the first native tile, or after a rate change, hold fallback
     // briefly so fast previews do not flash FFT rows while native data catches up.
     qint64 m_nativeWaterfallFallbackHoldUntilMs{0};
-    QVector<QRgb> m_prevTileScanline;  // previous tile row for interpolation
+    QVector<quint8> m_prevTileLevels;  // previous normalized row for interpolation
 
     static constexpr float SMOOTH_ALPHA    = 0.35f;
     // Fraction of the panadapter area (above freq scale) used for spectrum
@@ -1477,7 +1483,7 @@ private:
     float m_wfBlankerRing[WF_BLANKER_N]{};
     int   m_wfBlankerRingIdx{0};
     int   m_wfBlankerRingCount{0};
-    QVector<QRgb> m_wfLastGoodRow;
+    QVector<quint8> m_wfLastGoodLevels;
     int  m_bandPlanFontSize{6};  // 0 = off
     bool m_bandPlanShowSpots{true};
     BandPlanManager* m_bandPlanMgr{nullptr};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -131,15 +131,16 @@ public:
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     QString rendererDescription() const;
     void setRenderScheduler(PanadapterRenderScheduler* scheduler);
-    // macOS: whether the pan gets its own native NSView. QRhiWidget is only
-    // enabled with Qt 6.7+, where the composited child-widget path is available,
-    // so keep the cheaper single-window path as the default. The native path is
-    // retained as an escape hatch for platform-specific QRhi regressions.
+    // macOS: whether the pan gets its own native NSView (historical default —
+    // #714). AETHER_PAN_NO_NATIVE_WINDOW=1 opts out to validate the cheaper
+    // composited path (no per-present raster flushSubWindow blend). Keep the
+    // native path as the production default because current Qt/macOS versions
+    // can otherwise leave a QRhiWidget inside a raster top-level window with no
+    // Metal surface, producing a transparent panadapter.
     static bool nativeWindowPreferred() {
-        static const bool native =
-            qEnvironmentVariableIntValue("AETHER_PAN_NATIVE_WINDOW") == 1
-            && qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") != 1;
-        return native;
+        static const bool noNative =
+            qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") == 1;
+        return !noNative;
     }
     // macOS: apply the native-window isolation policy as one unit — request the
     // native Metal leaf (WA_NativeWindow) *and* block ancestor promotion

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1315,12 +1315,16 @@ private:
     double m_frequencyPreviewBaseBandwidthMhz{0.0};
     double m_frequencyPreviewTargetCenterMhz{0.0};
     double m_frequencyPreviewTargetBandwidthMhz{0.0};
+    double m_frequencyPreviewOverlayBaseCenterMhz{0.0};
+    double m_frequencyPreviewOverlayBaseBandwidthMhz{0.0};
     quint64 m_frequencyPreviewUpdateCount{0};
     quint64 m_frequencyPreviewPresentCount{0};
     quint64 m_frequencyPreviewCommitCount{0};
     quint64 m_frequencyPreviewNativeVisibleRows{0};
     quint64 m_frequencyPreviewRemappedDssRows{0};
     quint64 m_frequencyPreviewSuppressedViewportRebuilds{0};
+    quint64 m_frequencyPreviewOverlayTransformCount{0};
+    quint64 m_frequencyPreviewOverlayCommitRefreshCount{0};
     QVector<float> m_frequencyPreviewDssScratch;
     qint64 m_frequencyPreviewCommitLastNs{0};
     qint64 m_frequencyPreviewCommitMaxNs{0};
@@ -1623,17 +1627,29 @@ private:
     double m_wfFrameReferenceCenterMhz{0.0};
     QVector<float> m_wfFrameUpload;  // RGBA32F staging, four floats per row
 
-    // Overlay GPU resources (QPainter → QImage → texture)
-    // Static: grid, band plan, scales, slice markers, TNF, spots (repainted on state change)
-    // Dynamic: FFT spectrum line (repainted every frame)
+    // Overlay GPU resources (QPainter → QImage → texture). Screen-space
+    // chrome and frequency-anchored markers use separate textures so only the
+    // latter is remapped during a pan/zoom preview.
     QRhiGraphicsPipeline* m_ovPipeline{nullptr};
     QRhiShaderResourceBindings* m_ovSrb{nullptr};
+    QRhiShaderResourceBindings* m_ovFrequencySrb{nullptr};
+    QRhiTexture* m_ovFrequencyGpuTex{nullptr};
+    // The frequency-overlay preview pipeline reuses the drag-start texture and
+    // remaps its frequency-canvas pixels in the fragment shader. Fixed chrome
+    // remains in the unmodified screen-space texture above it.
+    QRhiGraphicsPipeline* m_ovPreviewPipeline{nullptr};
+    QRhiShaderResourceBindings* m_ovPreviewSrb{nullptr};
+    QRhiBuffer* m_ovPreviewUbo{nullptr};
     QRhiBuffer* m_ovVbo{nullptr};
     QRhiTexture* m_ovGpuTex{nullptr};
     QRhiSampler* m_ovSampler{nullptr};
-    QImage m_overlayStatic;     // grid, band plan, scales, markers — drawn ABOVE FFT
+    QImage m_overlayStatic;     // screen-space chrome — drawn ABOVE FFT
+    QImage m_overlayFrequency;  // frequency-anchored markers — drawn ABOVE FFT
+    QImage m_frequencyScalePreviewImage;  // narrow partial-upload staging strip
     bool m_overlayStaticDirty{true};
     bool m_overlayNeedsUpload{true};
+    bool m_overlayFrequencyNeedsUpload{true};
+    bool m_frequencyScalePreviewNeedsUpload{false};
 
     // Background-image layer — kept separate from m_overlayStatic so it can
     // render BELOW the FFT trace (parity with the software paint path).  Same
@@ -1720,6 +1736,11 @@ private:
         quint64 overlayRebuilds{0};       // static+bg QPainter repaints
         quint64 overlayRebuildUs{0};
         quint64 overlayUploadBytes{0};    // static+bg texture bytes uploaded
+        quint64 previewOverlayTransforms{0};
+        quint64 previewOverlayCommitRefreshes{0};
+        quint64 previewScaleRefreshes{0};
+        quint64 previewScalePaintUs{0};
+        quint64 previewScaleUploadBytes{0};
         quint64 wfUploadBytes{0};         // waterfall texture bytes uploaded
         quint64 nativeWaterfallCalls{0};  // native VITA waterfall updates
         quint64 nativeWaterfallUs{0};
@@ -1758,6 +1779,18 @@ private:
     // dirty-cause breakdown — annotate call sites that can fire at frame rate.
     void markOverlayDirty(const char* cause = nullptr, bool scheduleUpdate = true) {
 #ifdef AETHER_GPU_SPECTRUM
+        // While a frequency preview is active, the drag-start overlay texture
+        // is the immutable source for the GPU remap. Defer unrelated overlay
+        // changes until commitFrequencyPreview() performs the exact final
+        // rebuild; repainting here would change the source frame underneath
+        // the transform and reintroduce the full-image interaction cost.
+        if (m_frequencyPreviewActive && m_ovPreviewPipeline
+            && m_ovPreviewSrb && m_ovPreviewUbo) {
+            if (scheduleUpdate) {
+                update();
+            }
+            return;
+        }
         if (!m_overlayStaticDirty)
             m_panStats.noteDirty(cause);
         m_overlayStaticDirty = true;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -17,6 +17,7 @@
 #include <QLabel>
 
 #include "DssRenderer.h"
+#include "SpectrumPreviewLogic.h"
 
 class QVariantAnimation;
 class QSoundEffect;
@@ -113,10 +114,10 @@ public:
     QSize sizeHint() const override { return {800, 300}; }
     int spectrumPixelHeight() const;
     // Waterfall pane height in pixels. MUST be the single source of truth for
-    // both the waterfall QImage row count (resizeEvent) and the destination
-    // rect drawWaterfall() blits into (paintEvent): computing it two different
-    // ways lets integer truncation make them disagree by a pixel, which shows
-    // up as a static horizontal band the scrolling waterfall passes through.
+    // both the waterfall QImage row count (applySettledResizeBuffers) and the
+    // destination rect drawWaterfall() blits into (paintEvent): computing it
+    // two different ways lets integer truncation make them disagree by a pixel,
+    // which shows up as a static horizontal band the waterfall passes through.
     int waterfallPixelHeight() const;
 
     // Set the frequency range covered by this panadapter.
@@ -130,13 +131,15 @@ public:
     void prepareForShutdown(); // tear down QRhi/native resources before QWidget backing store destruction
     QString rendererDescription() const;
     void setRenderScheduler(PanadapterRenderScheduler* scheduler);
-    // macOS: whether the pan gets its own native NSView (historical default —
-    // #714). AETHER_PAN_NO_NATIVE_WINDOW=1 opts out to validate the cheaper
-    // composited path (no per-present raster flushSubWindow blend).
+    // macOS: whether the pan gets its own native NSView. QRhiWidget is only
+    // enabled with Qt 6.7+, where the composited child-widget path is available,
+    // so keep the cheaper single-window path as the default. The native path is
+    // retained as an escape hatch for platform-specific QRhi regressions.
     static bool nativeWindowPreferred() {
-        static const bool noNative =
-            qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") == 1;
-        return !noNative;
+        static const bool native =
+            qEnvironmentVariableIntValue("AETHER_PAN_NATIVE_WINDOW") == 1
+            && qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") != 1;
+        return native;
     }
     // macOS: apply the native-window isolation policy as one unit — request the
     // native Metal leaf (WA_NativeWindow) *and* block ancestor promotion
@@ -784,6 +787,7 @@ private:
     void positionFpsMeterLabels();
     void positionZoomButtons();
     void drawFreqScale(QPainter& p, const QRect& r);
+    double frequencyCanvasFractionAtGlobal(const QPointF& globalPosition) const;
     void drawDbmScale(QPainter& p, const QRect& specRect);
     // Shared strip chrome (background, border, ref-adjust arrows) for both the
     // 2D linear dBm scale and the 3D stacked-trace amplitude scale, so the
@@ -801,6 +805,7 @@ private:
     void drawConnectionAnimation(QPainter& p, const QRect& contentRect);
     void positionPanadapterMessageOverlay();
     void raisePanadapterMessageOverlay();
+    void applySettledResizeBuffers();
     int waterfallStripWidth() const;
     QRect waterfallLiveButtonRect(const QRect& wfRect) const;
     QRect waterfallTimeScaleRect(const QRect& wfRect) const;
@@ -814,6 +819,14 @@ private:
                                              double oldBandwidthMhz,
                                              double newCenterMhz,
                                              double newBandwidthMhz);
+    bool updateFrequencyPreview(double oldCenterMhz, double oldBandwidthMhz,
+                                double newCenterMhz, double newBandwidthMhz);
+    void scheduleFrequencyPreviewFrame();
+    void commitFrequencyPreview();
+    void clearFrequencyPreview();
+    bool frequencyPreviewAvailable() const;
+    void requestFrequencyRangeChange(double centerMhz, double bandwidthMhz,
+                                     bool force = false);
     void applyPanDragCenter(double newCenterMhz, bool force);
     void beginPanDrag(int startX);
     void schedulePanDragDeferredUpdate();
@@ -823,6 +836,8 @@ private:
     struct WaterfallStreamState {
         QImage waterfall;
         int wfWriteRow{0};
+        QVector<double> visibleRowCenterMhz;
+        QVector<double> visibleRowBwMhz;
         QImage waterfallHistory;
         QVector<qint64> historyTimestamps;
         int historyWriteRow{0};
@@ -885,7 +900,17 @@ private:
                              double centerMhz, double bandwidthMhz,
                              float fallbackDbm);
     float dssHistoryFallbackDbm() const;
-    void appendVisibleRow(const QRgb* rowData);
+    const QVector<float>& remapPreviewDssRow(const QVector<float>& binsDbm,
+                                             double frameCenterMhz,
+                                             double frameBandwidthMhz);
+    void resetVisibleWaterfallFrequencyFrames(double centerMhz,
+                                              double bandwidthMhz);
+#ifdef AETHER_GPU_SPECTRUM
+    void prepareWaterfallFrameUpload();
+#endif
+    void appendVisibleRow(const QRgb* rowData,
+                          double frameCenterMhz = -1.0,
+                          double frameBandwidthMhz = -1.0);
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;
     int historyRowIndexForAge(int ageRows) const;
@@ -1211,7 +1236,20 @@ private:
     // Scrolling waterfall image (Format_RGB32)
     QImage m_waterfall;
     int    m_wfWriteRow{0};  // ring buffer: next row to write (newest at top)
+    // Per-visible-row frequency frame, indexed by the physical waterfall ring
+    // row. The GPU uses this to place each row in the current viewport without
+    // flattening the entire live texture into one pan/zoom frame.
+    QVector<double> m_wfVisibleRowCenterMhz;
+    QVector<double> m_wfVisibleRowBwMhz;
     QImage m_waterfallHistory;
+    QTimer* m_resizeBufferSettleTimer{nullptr};
+    quint64 m_resizeEventCount{0};
+    quint64 m_resizeBufferCommitCount{0};
+    quint64 m_resizeFrameHoldCount{0};
+    quint64 m_resizePreviewFrameCount{0};
+    qint64 m_resizeBufferCommitLastNs{0};
+    qint64 m_resizeBufferCommitMaxNs{0};
+    QSize  m_resizePresentationSize;
     QSize  m_waterfallStreamSizeHint;
     QSize  m_waterfallHistoryStreamSizeHint;
     QVector<qint64> m_wfHistoryTimestamps;
@@ -1263,10 +1301,29 @@ private:
     int  m_bwDragStartX{0};
     double m_bwDragStartBw{0.0};
     double m_bwDragAnchorMhz{0.0};
+    double m_bwDragAnchorFraction{0.0};
     bool m_frequencyRangeSettlePending{false};
     bool m_frequencyRangePendingValid{false};
     double m_frequencyRangePendingCenterMhz{0.0};
     QTimer* m_frequencyRangeSettleTimer{nullptr};
+    QTimer* m_frequencyRangeCommandTimer{nullptr};
+    QElapsedTimer m_frequencyRangeCommandClock;
+    FrequencyRangeCommandThrottle m_frequencyRangeCommandThrottle;
+    quint64 m_frequencyRangeCommandCount{0};
+    bool m_frequencyPreviewActive{false};
+    double m_frequencyPreviewBaseCenterMhz{0.0};
+    double m_frequencyPreviewBaseBandwidthMhz{0.0};
+    double m_frequencyPreviewTargetCenterMhz{0.0};
+    double m_frequencyPreviewTargetBandwidthMhz{0.0};
+    quint64 m_frequencyPreviewUpdateCount{0};
+    quint64 m_frequencyPreviewPresentCount{0};
+    quint64 m_frequencyPreviewCommitCount{0};
+    quint64 m_frequencyPreviewNativeVisibleRows{0};
+    quint64 m_frequencyPreviewRemappedDssRows{0};
+    quint64 m_frequencyPreviewSuppressedViewportRebuilds{0};
+    QVector<float> m_frequencyPreviewDssScratch;
+    qint64 m_frequencyPreviewCommitLastNs{0};
+    qint64 m_frequencyPreviewCommitMaxNs{0};
     // Waterfall pan drag state
     bool m_draggingPan{false};
     int  m_panDragStartX{0};
@@ -1547,14 +1604,24 @@ private:
     // Waterfall GPU resources
     QRhiGraphicsPipeline* m_wfPipeline{nullptr};
     QRhiShaderResourceBindings* m_wfSrb{nullptr};
+    QRhiGraphicsPipeline* m_wfFramePipeline{nullptr};
+    QRhiShaderResourceBindings* m_wfFrameSrb{nullptr};
     QRhiBuffer* m_wfVbo{nullptr};
     QRhiBuffer* m_wfUbo{nullptr};
     QRhiTexture* m_wfGpuTex{nullptr};
+    QRhiTexture* m_wfFrameTex{nullptr};     // 1 x rows RGBA32F: center offset + bandwidth
     QRhiSampler* m_wfSampler{nullptr};
+    QRhiSampler* m_wfFrameSampler{nullptr};
     int m_wfGpuTexW{0};
     int m_wfGpuTexH{0};
     bool m_wfTexFullUpload{true};  // full re-upload needed (resize/init)
     int m_wfLastUploadedRow{-1};   // last row uploaded to GPU (-1 = none)
+    bool m_wfFrameTexReady{false};
+    bool m_wfFrameTexDirty{true};
+    WaterfallPipelineMode m_wfPipelineMode{WaterfallPipelineMode::Legacy};
+    QString m_wfPipelineFallbackReason;
+    double m_wfFrameReferenceCenterMhz{0.0};
+    QVector<float> m_wfFrameUpload;  // RGBA32F staging, four floats per row
 
     // Overlay GPU resources (QPainter → QImage → texture)
     // Static: grid, band plan, scales, slice markers, TNF, spots (repainted on state change)
@@ -1599,7 +1666,8 @@ private:
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge line segments, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
-    // ubo[] writer in renderGpuFrame(). 8 scalars + texCols + 3 pad + vec4 bgFill.
+    // ubo[] writer in renderGpuFrame(). 8 surface scalars + texCols + the three
+    // frequency-preview scalars + vec4 bgFill.
     static constexpr int kDssMeshUboFloats = 16;
     QRhiTexture* m_dssHeightTex{nullptr};    // R16F ring heightmap (cols x rows)
     QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT
@@ -1615,10 +1683,12 @@ private:
     void initDssMeshPipeline();
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);
 
-    void initWaterfallPipeline();
+    bool initWaterfallPipeline();
+    void releaseWaterfallFramePipelineResources();
     void initOverlayPipeline();
     void initSpectrumPipeline();
-    void renderGpuFrame(QRhiCommandBuffer* cb);
+    void renderGpuFrame(QRhiCommandBuffer* cb, const QSize& logicalSize,
+                        bool resizePreview);
 
     // FFT spectrum GPU resources — the trace is evaluated per-pixel by
     // panscope.frag from a width×1 R32F column texture (normalized amplitude
@@ -1686,7 +1756,7 @@ private:
     // Mark the static overlay for repaint and schedule a frame update.
     // In non-GPU mode this is just update(). `cause` feeds the panstats
     // dirty-cause breakdown — annotate call sites that can fire at frame rate.
-    void markOverlayDirty(const char* cause = nullptr) {
+    void markOverlayDirty(const char* cause = nullptr, bool scheduleUpdate = true) {
 #ifdef AETHER_GPU_SPECTRUM
         if (!m_overlayStaticDirty)
             m_panStats.noteDirty(cause);
@@ -1694,7 +1764,8 @@ private:
 #else
         m_panStats.noteDirty(cause);
 #endif
-        update();
+        if (scheduleUpdate)
+            update();
     }
 
     void reprojectWaterfall(double oldCenterMhz, double oldBandwidthMhz,

--- a/src/gui/WaterfallHistoryBuffer.cpp
+++ b/src/gui/WaterfallHistoryBuffer.cpp
@@ -1,0 +1,159 @@
+#include "WaterfallHistoryBuffer.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace AetherSDR {
+
+WaterfallHistoryBuffer::WaterfallHistoryBuffer(
+    WaterfallHistoryBuffer&& other) noexcept
+    : m_width(std::exchange(other.m_width, 0))
+    , m_capacityRows(std::exchange(other.m_capacityRows, 0))
+    , m_chunks(std::move(other.m_chunks))
+{
+    other.m_chunks.clear();
+}
+
+WaterfallHistoryBuffer& WaterfallHistoryBuffer::operator=(
+    WaterfallHistoryBuffer&& other) noexcept
+{
+    if (this == &other) {
+        return *this;
+    }
+    m_width = std::exchange(other.m_width, 0);
+    m_capacityRows = std::exchange(other.m_capacityRows, 0);
+    m_chunks = std::move(other.m_chunks);
+    other.m_chunks.clear();
+    return *this;
+}
+
+void WaterfallHistoryBuffer::configure(int width, int capacityRows)
+{
+    if (width <= 0 || capacityRows <= 0) {
+        reset();
+        return;
+    }
+    const int chunkCount =
+        (capacityRows + kRowsPerChunk - 1) / kRowsPerChunk;
+    if (width == m_width && capacityRows == m_capacityRows
+        && m_chunks.size() == chunkCount) {
+        return;
+    }
+
+    m_width = width;
+    m_capacityRows = capacityRows;
+    m_chunks = QVector<QByteArray>(chunkCount);
+}
+
+void WaterfallHistoryBuffer::discardRows()
+{
+    for (QByteArray& chunk : m_chunks) {
+        chunk.clear();
+        chunk.squeeze();
+    }
+}
+
+void WaterfallHistoryBuffer::reset()
+{
+    m_width = 0;
+    m_capacityRows = 0;
+    m_chunks.clear();
+}
+
+bool WaterfallHistoryBuffer::resizeWidth(int width)
+{
+    if (!isConfigured() || width <= 0) {
+        return false;
+    }
+    if (width == m_width) {
+        return true;
+    }
+
+    QVector<QByteArray> resized(m_chunks.size());
+    for (int chunkIndex = 0; chunkIndex < m_chunks.size(); ++chunkIndex) {
+        const QByteArray& sourceChunk = m_chunks[chunkIndex];
+        if (sourceChunk.isEmpty()) {
+            continue;
+        }
+
+        const int rowCount = rowsInChunk(chunkIndex);
+        QByteArray& destinationChunk = resized[chunkIndex];
+        destinationChunk.resize(static_cast<qsizetype>(rowCount) * width);
+        for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+            const quint8* source = reinterpret_cast<const quint8*>(
+                sourceChunk.constData()
+                + static_cast<qsizetype>(rowIndex) * m_width);
+            quint8* destination = reinterpret_cast<quint8*>(
+                destinationChunk.data()
+                + static_cast<qsizetype>(rowIndex) * width);
+            for (int x = 0; x < width; ++x) {
+                const int sourceX = std::min(
+                    m_width - 1,
+                    static_cast<int>(
+                        static_cast<qint64>(x) * m_width / width));
+                destination[x] = source[sourceX];
+            }
+        }
+    }
+
+    m_width = width;
+    m_chunks = std::move(resized);
+    return true;
+}
+
+quint8* WaterfallHistoryBuffer::writableRow(int row)
+{
+    if (!isConfigured() || row < 0 || row >= m_capacityRows) {
+        return nullptr;
+    }
+
+    const int chunkIndex = row / kRowsPerChunk;
+    const int rowInChunk = row % kRowsPerChunk;
+    QByteArray& chunk = m_chunks[chunkIndex];
+    if (chunk.isEmpty()) {
+        chunk.fill('\0',
+                   static_cast<qsizetype>(rowsInChunk(chunkIndex)) * m_width);
+    }
+    return reinterpret_cast<quint8*>(
+        chunk.data() + static_cast<qsizetype>(rowInChunk) * m_width);
+}
+
+const quint8* WaterfallHistoryBuffer::row(int row) const
+{
+    if (!isConfigured() || row < 0 || row >= m_capacityRows) {
+        return nullptr;
+    }
+
+    const int chunkIndex = row / kRowsPerChunk;
+    const int rowInChunk = row % kRowsPerChunk;
+    const QByteArray& chunk = m_chunks[chunkIndex];
+    if (chunk.isEmpty()) {
+        return nullptr;
+    }
+    return reinterpret_cast<const quint8*>(
+        chunk.constData() + static_cast<qsizetype>(rowInChunk) * m_width);
+}
+
+qsizetype WaterfallHistoryBuffer::allocatedBytes() const
+{
+    qsizetype bytes = 0;
+    for (const QByteArray& chunk : m_chunks) {
+        bytes += chunk.size();
+    }
+    return bytes;
+}
+
+int WaterfallHistoryBuffer::allocatedChunkCount() const
+{
+    return static_cast<int>(std::count_if(
+        m_chunks.cbegin(), m_chunks.cend(),
+        [](const QByteArray& chunk) { return !chunk.isEmpty(); }));
+}
+
+int WaterfallHistoryBuffer::rowsInChunk(int chunkIndex) const
+{
+    const int firstRow = chunkIndex * kRowsPerChunk;
+    return std::clamp(m_capacityRows - firstRow, 0, kRowsPerChunk);
+}
+
+} // namespace AetherSDR

--- a/src/gui/WaterfallHistoryBuffer.h
+++ b/src/gui/WaterfallHistoryBuffer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QByteArray>
+#include <QSize>
+#include <QVector>
+
+namespace AetherSDR {
+
+// Lazily allocated ring-row backing for retained waterfall intensity. The
+// logical slot count is fixed, but storage appears in small row chunks only as
+// history reaches them. Each sample is a normalized palette index (0..255),
+// not a four-byte color pixel; the visible viewport applies the active palette.
+class WaterfallHistoryBuffer final {
+public:
+    static constexpr int kRowsPerChunk = 256;
+
+    WaterfallHistoryBuffer() = default;
+    WaterfallHistoryBuffer(const WaterfallHistoryBuffer&) = default;
+    WaterfallHistoryBuffer& operator=(const WaterfallHistoryBuffer&) = default;
+    WaterfallHistoryBuffer(WaterfallHistoryBuffer&& other) noexcept;
+    WaterfallHistoryBuffer& operator=(WaterfallHistoryBuffer&& other) noexcept;
+
+    void configure(int width, int capacityRows);
+    void discardRows();
+    void reset();
+    bool resizeWidth(int width);
+
+    bool isConfigured() const { return m_width > 0 && m_capacityRows > 0; }
+    int width() const { return m_width; }
+    int capacityRows() const { return m_capacityRows; }
+    QSize size() const { return QSize(m_width, m_capacityRows); }
+
+    quint8* writableRow(int row);
+    const quint8* row(int row) const;
+
+    qsizetype allocatedBytes() const;
+    int allocatedChunkCount() const;
+
+private:
+    int rowsInChunk(int chunkIndex) const;
+
+    int m_width{0};
+    int m_capacityRows{0};
+    QVector<QByteArray> m_chunks;
+};
+
+} // namespace AetherSDR

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -1,0 +1,179 @@
+#include "gui/SpectrumPreviewLogic.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+namespace {
+
+int fail(const char* message)
+{
+    std::fprintf(stderr, "spectrum_preview_logic_test: %s\n", message);
+    return 1;
+}
+
+bool nearlyEqual(double a, double b, double epsilon = 1.0e-12)
+{
+    return std::abs(a - b) <= epsilon;
+}
+
+int testCursorAnchoredZoom()
+{
+    using namespace AetherSDR;
+    const FrequencyFrame base{14.1, 0.2};
+    constexpr std::array<double, 5> kFractions{
+        -0.5, -0.25, 0.0, 0.31, 0.5,
+    };
+    constexpr std::array<double, 2> kBandwidths{0.08, 0.45};
+    for (double fraction : kFractions) {
+        const double anchorMhz = frequencyAtFraction(base, fraction);
+        for (double bandwidthMhz : kBandwidths) {
+            const double centerMhz = centerForAnchoredBandwidth(
+                anchorMhz, fraction, bandwidthMhz);
+            const FrequencyFrame zoomed{centerMhz, bandwidthMhz};
+            if (!nearlyEqual(frequencyAtFraction(zoomed, fraction),
+                             anchorMhz)) {
+                return fail("cursor anchor moved during zoom");
+            }
+        }
+    }
+    if (!nearlyEqual(frequencyCanvasFraction(250.0, 1000), -0.25)
+        || !nearlyEqual(frequencyCanvasFraction(-100.0, 1000), -0.5)
+        || !nearlyEqual(frequencyCanvasFraction(1200.0, 1000), 0.5)) {
+        return fail("frequency canvas fraction should clamp to the canvas");
+    }
+    return 0;
+}
+
+int testFrequencyFrameMapping()
+{
+    using namespace AetherSDR;
+    const FrequencyFrame source{14.0, 0.2};
+    const FrequencyFrame pannedTarget{14.05, 0.2};
+    const FrequencyFrame zoomedTarget{14.0, 0.1};
+    if (!nearlyEqual(sourceUnitPosition(0.5, source, pannedTarget), 0.75)
+        || !nearlyEqual(sourceUnitPosition(0.5, source, zoomedTarget), 0.5)
+        || !nearlyEqual(sourceUnitPosition(0.0, source, zoomedTarget), 0.25)
+        || !nearlyEqual(sourceUnitPosition(1.0, source, zoomedTarget), 0.75)) {
+        return fail("frequency frame mapping is incorrect");
+    }
+    if (sourceUnitPosition(1.0, source, FrequencyFrame{14.2, 0.2}) <= 1.0) {
+        return fail("newly exposed frequency should map outside the retained frame");
+    }
+
+    const FrequencyFrame vhfBase{146.520000, 0.005};
+    const FrequencyFrame vhfTarget{146.520375, 0.0025};
+    const FrequencyPreviewTransform transform = frequencyPreviewTransform(
+        vhfBase, vhfTarget);
+    if (!transform.valid || !nearlyEqual(transform.scale, 0.5)
+        || !nearlyEqual(transform.offset, 0.075, 1.0e-10)) {
+        return fail("preview transform lost narrow-band VHF precision");
+    }
+    const double sourceU = sourceUnitPosition(0.37, vhfBase, vhfTarget);
+    const double shaderEquivalent = 0.5 + transform.offset
+        + (0.37 - 0.5) * transform.scale;
+    if (!nearlyEqual(sourceU, shaderEquivalent, 1.0e-10)) {
+        return fail("CPU and shader preview transforms diverged");
+    }
+    if (!std::isnan(sourceUnitPosition(
+            0.5, FrequencyFrame{14.0, 0.0}, vhfTarget))) {
+        return fail("invalid source frame should fail closed");
+    }
+    if (FrequencyFrame{std::numeric_limits<double>::infinity(), 0.2}.isValid()
+        || FrequencyFrame{14.0, std::numeric_limits<double>::infinity()}
+               .isValid()) {
+        return fail("non-finite frequency frames should be rejected");
+    }
+    return 0;
+}
+
+int testCommandThrottle()
+{
+    using namespace AetherSDR;
+    FrequencyRangeCommandThrottle throttle;
+    const FrequencyRangeCommand first{14.0, 0.2};
+    const FrequencyRangeCommand intermediate{14.01, 0.18};
+    const FrequencyRangeCommand latest{14.02, 0.16};
+    const FrequencyRangeCommand final{14.03, 0.14};
+
+    const std::optional<FrequencyRangeCommand> emittedFirst =
+        throttle.request(first, true, false);
+    if (!emittedFirst.has_value() || throttle.hasPending()) {
+        return fail("first due command should emit immediately");
+    }
+    if (throttle.request(intermediate, false, false).has_value()
+        || throttle.request(latest, false, false).has_value()
+        || !throttle.hasPending()) {
+        return fail("intermediate commands should coalesce");
+    }
+    const std::optional<FrequencyRangeCommand> emittedFinal =
+        throttle.request(final, false, true);
+    if (!emittedFinal.has_value()
+        || !nearlyEqual(emittedFinal->centerMhz, final.centerMhz)
+        || throttle.hasPending()
+        || throttle.takePending().has_value()) {
+        return fail("forced release should emit once and cancel delayed output");
+    }
+    throttle.request(intermediate, false, false);
+    throttle.request(latest, false, false);
+    const std::optional<FrequencyRangeCommand> timeoutCommand =
+        throttle.takePending();
+    if (!timeoutCommand.has_value()
+        || !nearlyEqual(timeoutCommand->centerMhz, latest.centerMhz)
+        || throttle.hasPending()) {
+        return fail("timeout should emit only the latest coalesced command");
+    }
+    if (throttle.request(FrequencyRangeCommand{
+            std::numeric_limits<double>::quiet_NaN(), 0.2}, true, false)
+            .has_value()) {
+        return fail("invalid command should be rejected");
+    }
+    return 0;
+}
+
+int testWaterfallPipelineSelection()
+{
+    using namespace AetherSDR;
+    WaterfallRowFrameReadiness readiness{
+        true, true, true, true, true, true,
+    };
+    if (chooseWaterfallPipeline(readiness)
+        != WaterfallPipelineMode::RowFrequencyFrames) {
+        return fail("complete row-frame resources should select the GPU preview");
+    }
+
+    bool* stages[] = {
+        &readiness.requested,
+        &readiness.formatSupported,
+        &readiness.textureCreated,
+        &readiness.samplerCreated,
+        &readiness.bindingsCreated,
+        &readiness.pipelineCreated,
+    };
+    for (bool* stage : stages) {
+        *stage = false;
+        if (chooseWaterfallPipeline(readiness)
+            != WaterfallPipelineMode::Legacy) {
+            return fail("any row-frame failure must select the legacy pipeline");
+        }
+        *stage = true;
+    }
+    return 0;
+}
+
+} // namespace
+
+int main()
+{
+    if (const int result = testCursorAnchoredZoom(); result != 0) {
+        return result;
+    }
+    if (const int result = testFrequencyFrameMapping(); result != 0) {
+        return result;
+    }
+    if (const int result = testCommandThrottle(); result != 0) {
+        return result;
+    }
+    return testWaterfallPipelineSelection();
+}

--- a/tests/waterfall_history_buffer_test.cpp
+++ b/tests/waterfall_history_buffer_test.cpp
@@ -1,0 +1,103 @@
+#include "gui/WaterfallHistoryBuffer.h"
+
+#include <QDebug>
+
+#include <algorithm>
+#include <utility>
+
+using AetherSDR::WaterfallHistoryBuffer;
+
+namespace {
+
+int fail(const char* message)
+{
+    qCritical().noquote() << message;
+    return 1;
+}
+
+} // namespace
+
+int main()
+{
+    WaterfallHistoryBuffer history;
+    history.configure(8, 600);
+    if (!history.isConfigured() || history.size() != QSize(8, 600)) {
+        return fail("history configuration was not retained");
+    }
+    if (history.allocatedBytes() != 0 || history.allocatedChunkCount() != 0) {
+        return fail("history allocated pixel rows eagerly");
+    }
+
+    quint8* newest = history.writableRow(599);
+    if (!newest) {
+        return fail("last logical ring slot was not writable");
+    }
+    for (int x = 0; x < 8; ++x) {
+        newest[x] = static_cast<quint8>(x * 10);
+    }
+    if (history.allocatedChunkCount() != 1
+        || history.allocatedBytes() >
+            WaterfallHistoryBuffer::kRowsPerChunk * history.width()) {
+        return fail("first row allocated more than one bounded chunk");
+    }
+    if (!history.row(599) || history.row(599)[7] != 70) {
+        return fail("written intensity row was not readable");
+    }
+
+    quint8* older = history.writableRow(0);
+    if (!older || history.allocatedChunkCount() != 2) {
+        return fail("a distant ring slot did not allocate its own chunk");
+    }
+    std::fill(older, older + history.width(), quint8(200));
+
+    if (!history.resizeWidth(4) || history.width() != 4) {
+        return fail("width resize failed");
+    }
+    const quint8* resizedNewest = history.row(599);
+    if (!resizedNewest || resizedNewest[0] != 0
+        || resizedNewest[1] != 20 || resizedNewest[3] != 60) {
+        return fail("width resize did not preserve nearest-neighbor intensity");
+    }
+    if (!history.row(0) || history.row(0)[3] != 200) {
+        return fail("width resize lost a second allocated chunk");
+    }
+
+    WaterfallHistoryBuffer copied = history;
+    quint8* copiedOldest = copied.writableRow(0);
+    if (!copiedOldest) {
+        return fail("copied history row was not writable");
+    }
+    copiedOldest[3] = 17;
+    if (!history.row(0) || history.row(0)[3] != 200
+        || copied.row(0)[3] != 17) {
+        return fail("copy-on-write did not isolate history chunks");
+    }
+
+    WaterfallHistoryBuffer moved = std::move(history);
+    if (history.isConfigured() || !moved.isConfigured()
+        || !moved.row(599) || moved.row(599)[3] != 60) {
+        return fail("move did not transfer ownership and clear the source");
+    }
+    history.configure(4, 600);
+    if (!history.isConfigured() || history.allocatedBytes() != 0
+        || history.writableRow(0) == nullptr) {
+        return fail("moved-from history could not be configured safely");
+    }
+    history = std::move(moved);
+    if (moved.isConfigured() || !history.row(0)
+        || history.row(0)[3] != 200) {
+        return fail("move assignment did not preserve allocated rows");
+    }
+
+    history.discardRows();
+    if (!history.isConfigured() || history.allocatedBytes() != 0
+        || history.row(599) != nullptr) {
+        return fail("discardRows did not release chunks while retaining shape");
+    }
+
+    history.reset();
+    if (history.isConfigured() || history.writableRow(0) != nullptr) {
+        return fail("reset did not clear the logical history shape");
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

This PR fixes choppy main-window resizing and uneven panadapter navigation. Dragging a window edge could make the application jump, freeze the spectrum and waterfall, or leave stale and misaligned content until resize ended. Panning and zooming had similar symptoms: movement lagged behind the pointer, frequencies entering the viewport were absent until release, the final release could pause while history was rebuilt, and zoom was not consistently anchored under the pointer.

The implementation separates immediate GPU presentation from expensive resource rebuilds, history remapping, and radio-state commits. Spectrum and waterfall content now follow resize, pan, and zoom at the QRhi presentation cadence, while exact state and size-dependent resources are committed at controlled boundaries.

### Main-window live resize

`SpectrumWidget` retains the last complete render target, overlays, FFT geometry, waterfall viewport, and history width while the window is actively changing size. QRhi continues presenting new spectrum and waterfall data into those valid resources and scales the completed frame to the intermediate widget geometry. A single settled resize then transactionally rebuilds the size-dependent resources instead of rebuilding every panadapter on every native resize event.

macOS continues to use a native `NSView`/`WA_NativeWindow` surface by default. Current Qt/macOS combinations can render a composited QRhi child under a raster top-level window as a transparent hole, so `AETHER_PAN_NO_NATIVE_WINDOW=1` is retained only as an explicit diagnostic opt-out. The smooth-resize improvement does not depend on shipping the unsafe composited path.

### GPU pan and zoom previews

Pan, wheel/gesture zoom, and visible-bandwidth dragging now establish a frequency preview frame and update only its target center and bandwidth while the gesture is active. The GPU remaps the 2D spectrum, waterfall, 3D mesh, and retained frequency-marker overlay from the stable base frame into the target frame. The exact frequency-scale strip is narrow and refreshed independently; the full static overlay is not repainted and uploaded at mouse-event rate.

Frequency-range commands are independent from visual presentation:

- The first update is sent immediately.
- Intermediate updates are coalesced to approximately 33 ms.
- The exact final center frequency and bandwidth are always delivered when the gesture settles.

Cursor anchoring is calculated from the real frequency canvas and shared by Ctrl+wheel, native zoom gestures, and bandwidth dragging, so the frequency under the pointer stays fixed instead of drifting toward an edge.

### Per-row waterfall frequency mapping

Rows arriving during a gesture retain the center frequency and bandwidth at which they were captured. A compact metadata texture supplies those frames to the waterfall shader, allowing every physical row in the ring to map independently into the current viewport. A nearby double-precision reference center avoids losing tuning precision when the metadata offsets are uploaded as floats.

This allows newly exposed frequencies to appear while dragging and removes the release-time full-history reprojection. Invalid metadata is rejected, and renderers that cannot create the row-frequency resources retain the original functional waterfall pipeline.

### Compact retained waterfall history

The previous 20-minute history was an eager `QImage::Format_RGB32` allocation of as many as 24,000 rows per visible panadapter. It is replaced by a `WaterfallHistoryBuffer` containing normalized 8-bit intensity samples in lazily allocated 256-row chunks. Only reached history consumes pixel storage, and only visible rows are remapped and colorized.

The compact path covers native Flex tiles, FFT fallback rows, and Kiwi rows while retaining source switching, blanking, interpolation, per-row frequency frames, paused scrollback, width changes, and Kiwi peak-preserving resampling. At 1,077 pixels wide, 1,918 retained rows used 2,136,768 bytes; the previous eager RGB allocation reserved 103,392,000 bytes for the same configured capacity.

### Scope and compatibility

- Pan/zoom previews, per-row mapping, resize presentation, command coalescing, and compact history are cross-platform.
- The native-surface requirement is macOS-specific.
- GPU and software rendering builds remain supported.
- No transmit behavior, radio ownership, protocol parsing, DSP processing, or persisted settings change.
- Controlled 1/4/8-pan samples measured 24.37/96.31/189.38 FFT frames per second, 30.64/100.19/126.30 GPU frames per second, and only 7.12/14.50/18.83 ms of instrumented main-thread rendering work per wall-second. The proposed worker pool was therefore not added; its synchronization and ordering cost was not justified by the remaining CPU preparation.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. Preview math and compact-history ownership/allocation behavior have deterministic tests; GPU and software builds pass; the final implementation was exercised with eight live panadapters, 2D and 3D views, Flex and Kiwi waterfall paths, slice 0 RX/audio, resize, pan, zoom, and scrollback; and the supported-platform CI matrix passes on the final head.

## Test plan

- [x] Local build passes (`cmake --build build`)
  - Metal/QRhi application build passes.
  - Software-renderer application build passes.
  - `spectrum_preview_logic_test` and `waterfall_history_buffer_test` build in both configurations.
- [x] Behavior verified on a real radio if applicable
  - Eight owned panadapters remained visible and live on Metal, with six in 2D and two in 3D mode.
  - Resized the main window while spectrum and waterfall data continued arriving.
  - Panned and zoomed at the left, center, and right of the frequency canvas and verified pointer anchoring and exact final state.
  - Verified new waterfall data appears during a gesture and release does not perform a full-history rebuild.
  - Exercised live Flex history plus automation-only Kiwi history, 3D rows, scrollback, return-to-live, and source restoration.
  - Confirmed slice 0 remained active and the RX audio sink remained operational and streaming.
- [x] Existing tests pass (CI)
  - Linux, Windows, macOS, accessibility, engine-boundary, and CodeQL all pass on the latest-upstream merge head `497a7e6e`.
  - Local CTest: 129 passed, 1 expected quarantined test skipped, 0 failed.
- [x] Reproduction steps documented if user-reported bug
  1. Connect to a radio and open several active panadapters.
  2. Drag a main-window edge continuously while watching live spectrum and waterfall data.
  3. Pan left/right while new waterfall rows arrive, then release and verify there is no delayed repositioning or history-rebuild pause.
  4. Zoom at several horizontal positions and verify the frequency beneath the pointer remains anchored.
  5. On macOS, verify every QRhi pan remains visible without setting a native-window environment override.

Additional validation:

- `python3 tools/check_engine_boundary.py --strict` passes.
- `git diff --check` passes.
- `spectrum_preview_logic_test` covers cursor anchoring, affine transforms, per-row mapping, narrow-band precision, invalid-frame rejection, command coalescing, final delivery, and pipeline selection.
- `waterfall_history_buffer_test` covers lazy bounded allocation, row access, width resampling, copy-on-write isolation, move safety, discard, reset, and moved-from reuse.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
  - N/A — no meter UI changes.
- [x] Documentation updated if user-visible behavior changed
  - Automation/performance telemetry documentation is updated; no new user setting or workflow was added.
- [x] Security-sensitive changes reference a GHSA if applicable
  - N/A — no security-sensitive surface changes.
