### PR TITLE
fix(gui): allow compact floating PWR meter

### DIFF
--- a/src/gui/CrossNeedleMeterApplet.cpp
+++ b/src/gui/CrossNeedleMeterApplet.cpp
@@ -18,13 +18,14 @@ namespace AetherSDR {
 
 namespace {
 
-// The docked meter is intentionally compact, but the dense physical scale is
-// most useful at a larger size when popped out. Keep these at the face's 3:2
-// aspect ratio; the floating window adds its title bar above this content.
+// Open the popped-out meter large enough to keep the dense physical scale
+// readable, but let users shrink it to the widget's natural minimum. Keep
+// these at the face's 3:2 aspect ratio; the floating window adds its title bar
+// above this content.
 constexpr int kFloatingWidth = 640;
 constexpr int kFloatingHeight = 427;
-constexpr int kFloatingMinimumWidth = 420;
-constexpr int kFloatingMinimumHeight = 280;
+constexpr int kFloatingMinimumWidth = 210;
+constexpr int kFloatingMinimumHeight = 140;
 
 } // namespace
 


### PR DESCRIPTION
## Summary

Fixes #4308. The floating Power & SWR meter imposed a 420x280 content minimum even though its resolution-independent renderer already supports the widget's natural 210x140 minimum. Keep the existing 640x427 first-popout size, but lower the floating minimum to 210x140 so operators can reclaim screen space when desired.

## Constitution principle honored

Principle XI - Fixes Are Demonstrated. The same bridge-driven resize was captured before and after the change: the baseline clamped a requested 210x158 floating window to 210x298, while the fixed build accepted 210x158 and retained a correctly fitted meter face.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable (not applicable: GUI layout only; proof used an isolated profile with radio auto-connect disabled and `txAllowed=false`)
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local verification:

- Clean RelWithDebInfo build completed (1517/1517)
- `ctest --test-dir build -R 'cross_needle_meter_test|container_widget_test' --output-on-failure`
- `./build/container_manager_test`
- `python3 tools/check_engine_boundary.py --strict`
- Agent automation bridge before/after:
  - Baseline: requested 210x158, actual 210x298, capture 210x298
  - Fixed: requested 210x158, actual 210x158, capture 210x158
  - Post-marker log windows contained only the successful capture events

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls - use nested-JSON-under-one-key (no settings calls changed)
- [x] Code is clean-room - not decompiled, disassembled, or reverse-engineered from a proprietary binary
- [x] All meter UI uses `MeterSmoother` (no meter data path changed)
- [x] Documentation updated if user-visible behavior changed (no standalone documentation needed for the resize floor; issue and bridge evidence document the behavior)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
