### PR TITLE
MIDI VFO: self-heal a stale relative-CC encoding lock on controller knob-mode change

### DIFF
--- a/src/core/MidiRelativeCcDecoder.h
+++ b/src/core/MidiRelativeCcDecoder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdlib>
+
 namespace AetherSDR {
 
 enum class MidiRelativeCcEncoding {
@@ -13,6 +15,12 @@ struct MidiRelativeCcDecodeResult {
     MidiRelativeCcEncoding encoding{MidiRelativeCcEncoding::Undetermined};
 };
 
+// Largest single-message step a real spin produces is +/-50 (CTR2-MIDI manual v2.01
+// p35: WheelA at full speed sends +/-50 counts from center). A byte from the *other*
+// wheel family decoded under a stale lock lands at +/-62..63, so a delta at or beyond
+// this threshold can only mean the controller's encoding changed mid-session.
+constexpr int kMidiRelativeCcImplausibleStep = 56;
+
 // Relative MIDI CC has no encoding marker on the wire. The two encodings' unit
 // detents are disjoint — two's-complement sends 1 (CW) / 127 (CCW), center-64
 // sends 65 (CW) / 63 (CCW) — so a SINGLE-detent first value is an unambiguous
@@ -22,6 +30,9 @@ struct MidiRelativeCcDecodeResult {
 // two's-complement and then decode every later 63/65 detent as ∓63 — the #4096
 // jumps, made permanent. Defer instead (delta 0, stay Undetermined) until a
 // unit detent settles the encoding.
+// A locked encoding self-heals: a decode at or beyond the implausible-step
+// threshold means the controller's knob mode changed mid-session, so re-classify
+// from that same byte — which, like any first sample, defers if it is ambiguous.
 inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
     int value, MidiRelativeCcEncoding currentEncoding)
 {
@@ -36,13 +47,18 @@ inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
         }
     }
 
+    MidiRelativeCcDecodeResult result{0, encoding};
     if (encoding == MidiRelativeCcEncoding::Center64) {
-        return {value - 64, encoding};
+        result.delta = value - 64;
+    } else if (encoding == MidiRelativeCcEncoding::TwosComplement) {
+        result.delta = (value < 64) ? value : (value - 128);
     }
-    if (encoding == MidiRelativeCcEncoding::TwosComplement) {
-        return {(value < 64) ? value : (value - 128), encoding};
+
+    if (currentEncoding != MidiRelativeCcEncoding::Undetermined
+        && std::abs(result.delta) >= kMidiRelativeCcImplausibleStep) {
+        return decodeMidiRelativeCc(value, MidiRelativeCcEncoding::Undetermined);
     }
-    return {0, encoding};
+    return result;
 }
 
 } // namespace AetherSDR

--- a/src/core/MidiRelativeCcDecoder.h
+++ b/src/core/MidiRelativeCcDecoder.h
@@ -16,9 +16,21 @@ struct MidiRelativeCcDecodeResult {
 };
 
 // Largest single-message step a real spin produces is +/-50 (CTR2-MIDI manual v2.01
-// p35: WheelA at full speed sends +/-50 counts from center). A byte from the *other*
-// wheel family decoded under a stale lock lands at +/-62..63, so a delta at or beyond
-// this threshold can only mean the controller's encoding changed mid-session.
+// p35: WheelA at full speed sends +/-50 counts from center). A *unit detent* from
+// the other wheel family decoded under a stale lock lands at +/-62..63, so a delta
+// at or beyond this threshold can only mean the controller's encoding changed
+// mid-session.
+//
+// Coverage limit — the heal is deliberately one-message and detent-shaped. A byte
+// carrying step |d| from the other family decodes under the stale lock to
+// magnitude 64 - |d|, so it only crosses this threshold while |d| <= 8. A Speed
+// Tuning burst from the switched wheel (measured +/-12 Normal, +/-24 Fast) lands
+// below it and is bit-identical to a legitimate spin of the locked encoding
+// (two's-complement +12 == center-64 -52), so it decodes under the stale lock and
+// the lock survives; recovery is the next unit detent, which always heals.
+// Lowering the threshold to catch those bursts would false-heal legitimate
+// spec-max (+/-50) spins and flip a correct lock — strictly worse. Separating them
+// needs cross-message state in MidiControlManager, out of scope here (#4299).
 constexpr int kMidiRelativeCcImplausibleStep = 56;
 
 // Relative MIDI CC has no encoding marker on the wire. The two encodings' unit
@@ -33,6 +45,8 @@ constexpr int kMidiRelativeCcImplausibleStep = 56;
 // A locked encoding self-heals: a decode at or beyond the implausible-step
 // threshold means the controller's knob mode changed mid-session, so re-classify
 // from that same byte — which, like any first sample, defers if it is ambiguous.
+// That covers the unit detent a mode switch is first noticed by; see
+// kMidiRelativeCcImplausibleStep for the steps it deliberately does not catch.
 inline MidiRelativeCcDecodeResult decodeMidiRelativeCc(
     int value, MidiRelativeCcEncoding currentEncoding)
 {

--- a/tests/midi_relative_cc_decoder_test.cpp
+++ b/tests/midi_relative_cc_decoder_test.cpp
@@ -132,5 +132,28 @@ int main()
                      && result.encoding == MidiRelativeCcEncoding::Undetermined,
                  "stale-lock heal on a non-unit byte unlocks without guessing");
 
+    // Documented coverage limit of the one-message heal (see
+    // kMidiRelativeCcImplausibleStep). A step |d| from the switched wheel decodes
+    // under the stale lock to magnitude 64 - |d|, so only |d| <= 8 crosses the
+    // threshold. Speed Tuning bursts (+/-12 Normal, +/-24 Fast on the reference
+    // unit) land below it and are bit-identical to a legitimate spin of the
+    // locked encoding, so they decode under the stale lock and it survives.
+    // Pinned so anyone retuning the threshold sees the trade-off: catching these
+    // would false-heal legitimate spec-max (+/-50) spins.
+    encoding = MidiRelativeCcEncoding::Center64;
+    result = decodeMidiRelativeCc(12, encoding); // two's-complement +12 after a switch
+    ok &= expect(result.delta == -52
+                     && result.encoding == MidiRelativeCcEncoding::Center64,
+                 "Speed-Tuning-sized step from the switched wheel misses the heal");
+    result = decodeMidiRelativeCc(24, encoding); // two's-complement +24 after a switch
+    ok &= expect(result.delta == -40
+                     && result.encoding == MidiRelativeCcEncoding::Center64,
+                 "fast-spin step from the switched wheel also misses the heal");
+    // Recovery path: the next unit detent still heals, whatever came before it.
+    result = decodeMidiRelativeCc(1, encoding);
+    ok &= expect(result.delta == 1
+                     && result.encoding == MidiRelativeCcEncoding::TwosComplement,
+                 "a unit detent heals even after missed Speed Tuning bursts");
+
     return ok ? 0 : 1;
 }

--- a/tests/midi_relative_cc_decoder_test.cpp
+++ b/tests/midi_relative_cc_decoder_test.cpp
@@ -75,5 +75,62 @@ int main()
                  && result.encoding == MidiRelativeCcEncoding::TwosComplement,
                  "unit pulse still selects two's-complement after ambiguity");
 
+    // Stale-lock self-heal: the controller's knob mode changed mid-session, so the
+    // locked encoding decodes the other wheel family's bytes to implausible steps.
+    encoding = MidiRelativeCcEncoding::Center64;
+    result = decodeMidiRelativeCc(1, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 1,
+                 "two's-complement pulse under stale center-64 lock heals to one step");
+    ok &= expect(encoding == MidiRelativeCcEncoding::TwosComplement,
+                 "healed lock re-pins to two's-complement");
+    result = decodeMidiRelativeCc(126, encoding);
+    ok &= expect(result.delta == -2,
+                 "healed two's-complement decode preserves counter-clockwise value");
+
+    encoding = MidiRelativeCcEncoding::TwosComplement;
+    result = decodeMidiRelativeCc(65, encoding);
+    encoding = result.encoding;
+    ok &= expect(result.delta == 1,
+                 "center-64 detent under stale two's-complement lock heals to one step");
+    ok &= expect(encoding == MidiRelativeCcEncoding::Center64,
+                 "healed lock re-pins to center-64");
+    result = decodeMidiRelativeCc(63, encoding);
+    ok &= expect(result.delta == -1,
+                 "healed center-64 decode is symmetric counter-clockwise");
+
+    // No false heal on real spins: full-speed center-64 batches reach +/-50
+    // (CTR2-MIDI manual p35); the lock must survive them.
+    encoding = MidiRelativeCcEncoding::Center64;
+    result = decodeMidiRelativeCc(114, encoding);
+    ok &= expect(result.delta == 50, "spec-max clockwise spin decodes under the lock");
+    ok &= expect(result.encoding == MidiRelativeCcEncoding::Center64,
+                 "spec-max clockwise spin does not flip the lock");
+    result = decodeMidiRelativeCc(14, encoding);
+    ok &= expect(result.delta == -50,
+                 "spec-max counter-clockwise spin decodes under the lock");
+    result = decodeMidiRelativeCc(9, encoding);
+    ok &= expect(result.delta == -55, "delta below the threshold never re-classifies");
+
+    // At or beyond the threshold the heal re-classifies from the same byte; an
+    // ambiguous byte defers (like any first sample) until a unit detent settles it.
+    result = decodeMidiRelativeCc(120, encoding);
+    ok &= expect(result.delta == 0
+                     && result.encoding == MidiRelativeCcEncoding::Undetermined,
+                 "threshold heal on an ambiguous byte defers re-detection");
+    result = decodeMidiRelativeCc(127, result.encoding);
+    ok &= expect(result.delta == -1
+                     && result.encoding == MidiRelativeCcEncoding::TwosComplement,
+                 "unit detent after a deferred heal settles the encoding");
+
+    // The heal inherits the deferral for non-unit direction tokens too: a stale
+    // center-64 lock fed WheelB counter-clockwise (126 -> +62) unlocks rather
+    // than guessing an encoding from an ambiguous byte.
+    encoding = MidiRelativeCcEncoding::Center64;
+    result = decodeMidiRelativeCc(126, encoding);
+    ok &= expect(result.delta == 0
+                     && result.encoding == MidiRelativeCcEncoding::Undetermined,
+                 "stale-lock heal on a non-unit byte unlocks without guessing");
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4299. Implements the self-healing re-detect discussed there, at @jensenpat's invitation in the #4271 line-26 review thread.

> **Review note:** rebased onto `main` after #4271 merged (`e0ad48e0`); this PR is now the single commit `fec7183b` (decoder + tests, 2 files). It was originally stacked on #4271's head `edac768e`.

## What

PR #4271's auto-detect latches a learned knob's relative-CC encoding from the first unit detent. A mid-session controller mode change (CTR2-MIDI WheelA↔WheelB from its own config menu, no MIDI emitted) then decodes every click under the stale encoding — ±6.3 kHz jumps in the wrong direction until re-Learn. Full evidence in #4299.

This adds a self-heal in `decodeMidiRelativeCc` (kept in the pure, unit-tested header per the triage suggestion): after decoding under the locked encoding, a delta of ±56 or more re-classifies from that same byte exactly as a first sample is classified — a unit detent re-pins the lock on the same click; an ambiguous byte unlocks and defers until a unit detent arrives. One comparison on the already-computed delta; no `MidiControlManager` changes, no polling, no UI — the caller's existing `encoding = result.encoding` write-back does the re-pin.

## Why 56, not the ±32 sketched in #4299

The CTR2-MIDI manual (v2.01 p35) specs WheelA at **±50 counts from center at full speed** — ±32 would false-fire on a legitimate spec-max spin and flip a *correct* lock. 56 sits in the gap between the largest legitimate step (±50 spec) and the smallest stale-lock decode (±62/63). Validated on hardware [RIG]: max-effort spins at every Speed Tuning setting (Off/Normal/Fast) top out at **±24** on this unit — half the spec, 32 counts under the threshold.

## Verification

- **Unit tests:** the pre-existing decoder cases (including #4271's ambiguity guards) untouched and passing; 13 new — heal both directions incl. lock re-pin, no false heal at spec-max ±50 or below threshold, threshold heal on an ambiguous byte deferring until a unit detent settles it, and the non-unit WheelB CCW token unlocking without guessing. Full ctest **157/157** on a clean build of the rebased head.
- **Injection regression, re-run on the rebased head** (binary carries `fec7183b`; automation bridge, fixture slice, 100 Hz step, fresh launch per scenario): scenario C `65,1,126,65` decodes **+100/+100/−200/+100 Hz**; scenario D `1,65,63,1` mirrors (+100/+100/−100/+100) — identical to the pre-rebase measurements.
- **Live hardware [RIG]** (CTR2-MIDI fw v2.01.01, binding learned on WheelA two days prior, never re-learned): on-device map toggle to WheelB → first CW click **+100 Hz** (pre-fix −6,300); CCW `126` → −200 Hz (the device's WheelB CCW dialect, 126 = −2 — correct direction, dialect normalization out of scope per #4299); toggle back → first click **+100 Hz** (reverse heal). Both toggles confirmed silent on the wire. *(Measured on pre-rebase `c263fcb0`; the unit-detent decode paths it exercises are unchanged in the rebase — corroborated by the identical injection results.)*

## Out of scope (documented in #4299)

WheelB's CCW dialect (126 → −2), WheelB-r, absolute Slider modes (value-stream-undetectable), and Button mode — the supported relative encodings remain the two wheel families, now robust to mid-session switches between them. See #4402 for the related binary/Thetis (0/127) token dialect.

## Operator note

With this fix either wheel mode works, mid-session switches included. On CTR2-MIDI hardware, **WheelA remains the better daily driver**: symmetric ±1 clicks and proportional Speed Tuning at every device setting (Off/Normal/Fast — measured ±1/±12/±24 per message), while WheelB carries its firmware's CCW dialect (126 = −2, so CCW tunes 2× per click).

[aethersdr-midi-self-heal-evidence-KM6LFY-2026-07-19.zip](https://github.com/user-attachments/files/30168717/aethersdr-midi-self-heal-evidence-KM6LFY-2026-07-19.zip)

— authored by agent (Claude Code) on behalf of @skerker
