### PR TITLE
test(logging): read log back in Text mode so async_log_writer_test passes on Windows

### DIFF
--- a/tests/async_log_writer_test.cpp
+++ b/tests/async_log_writer_test.cpp
@@ -29,7 +29,15 @@ void report(const char* name, bool ok)
 QByteArray readAll(const QString& path)
 {
     QFile f(path);
-    if (!f.open(QIODevice::ReadOnly))
+    // Read back with QIODevice::Text to mirror how AsyncLogWriter WRITES the
+    // file (it opens with QIODevice::Text so log files get native line endings).
+    // Without the matching flag this read is asymmetric: on Windows the writer
+    // emits "\r\n" while every expectation in this file is written as "\n", so
+    // each exact-match assertion failed on the platform's line-ending
+    // translation rather than on anything the writer got wrong. Text mode here
+    // normalises "\r\n" back to "\n" on read, making the comparisons
+    // line-ending agnostic on Windows and unchanged on POSIX.
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
         return {};
     return f.readAll();
 }


### PR DESCRIPTION
`async_log_writer_test` fails every exact-match assertion on Windows. The cause is an asymmetry inside the test, not a defect in `AsyncLogWriter`.

## Root cause

- **The writer** opens the log with `QIODevice::Text` (`AsyncLogWriter.cpp:320`, `363`, `369`), so log files get native line endings — on Windows each line lands as `\r\n`. That's deliberate and correct for a log file.
- **The test's `readAll()` helper** opened the same file *without* `QIODevice::Text`, reading raw bytes, while every expectation in the file is spelled `\n`.

So the assertions were failing on the platform's line-ending translation, not on anything the writer produced. Hex-dumping a mismatch confirms it:

```
expected: ... 70 61 79 6c 6f 61 64 0a         ("payload\n")
actual:   ... 70 61 79 6c 6f 61 64 0d 0a      ("payload\r\n")
```

Payload byte-identical; only the line terminator differs.

## The fix

Add `QIODevice::Text` to the read so the round-trip is symmetric — `\r\n` is normalised back to `\n` on read. Line-ending agnostic on Windows, unchanged on POSIX. One line, plus a comment explaining why the flag has to match the writer.

## Test plan

Verified on aurora13 (Windows 11, MSVC, Qt 6.10.3), built on current `main`:

| | before | after |
|---|---|---|
| `async_log_writer_test` | exit 1, every exact-match assertion failing | **exit 0, 29/29 assertions pass** |

Full non-GUI test sweep: **135 passed, 0 failed.**

Worth noting for anyone reproducing: these test binaries need Qt's `bin` on `PATH` (`Qt6Test.dll`), otherwise they die on a loader dialog and exit-code checks can silently misreport them as passing — which is how this one stayed invisible.

Principle VII.