### PR TITLE
fix(waterfall): derive pane height from one helper, killing a 1px static band

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2484,6 +2484,18 @@ int SpectrumWidget::spectrumPixelHeight() const
     return std::max(1, static_cast<int>(contentH * m_spectrumFrac));
 }
 
+int SpectrumWidget::waterfallPixelHeight() const
+{
+    // Derived as the REMAINDER of the split, not as a second independent
+    // truncation of contentH * (1 - m_spectrumFrac). Those two expressions are
+    // not equivalent under integer truncation — they differ by one pixel for
+    // most window heights — and using each in a different place is what caused
+    // the waterfall image and its destination rect to disagree.
+    const int chromeH = freqScaleH() + DIVIDER_H;
+    const int contentH = std::max(0, height() - chromeH);
+    return std::max(0, contentH - spectrumPixelHeight());
+}
+
 void SpectrumWidget::positionFpsMeterLabels() {
     if (!m_panFpsMeterLabel || !m_wfFpsMeterLabel || !m_syncFpsMeterLabel) {
         return;
@@ -7895,8 +7907,12 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         // Clamp the divider position: 10%–90% of content area
         float frac = static_cast<float>(y) / contentH;
         m_spectrumFrac = std::clamp(frac, 0.10f, 0.90f);
-        // Rebuild waterfall image for new size
-        const int wfHeight = static_cast<int>(contentH * (1.0f - m_spectrumFrac));
+        // Rebuild waterfall image for new size. Uses the shared helper (which
+        // reads the m_spectrumFrac just assigned above) so the row count matches
+        // paintEvent's destination rect exactly — truncating
+        // contentH * (1 - frac) here instead would reintroduce the 1px
+        // mismatch/static band on every divider drag.
+        const int wfHeight = waterfallPixelHeight();
         // contentWidth(): rows rasterize at the displayed column count so the
         // blit into wfContentRect / the wf viewport is 1:1 — a full-width image
         // squeezed by DBM_STRIP_W nearest-drops ~36 columns per frame and a
@@ -8888,9 +8904,14 @@ void SpectrumWidget::resizeEvent(QResizeEvent* ev)
     // into a QSplitter can reset native window properties.
     setMouseTracking(true);
 
-    const int chromeH  = freqScaleH() + DIVIDER_H;
-    const int contentH = height() - chromeH;
-    const int wfHeight = static_cast<int>(contentH * (1.0f - m_spectrumFrac));
+    // waterfallPixelHeight(): the SAME expression paintEvent uses for the
+    // destination rect, so the image row count and the blit target always
+    // match (see the helper's comment). Previously this truncated
+    // contentH * (1 - frac) independently, which disagreed with paintEvent's
+    // contentH - specH by a pixel at most window heights → a 1px vertical
+    // stretch in drawWaterfall() that duplicated one source row at a fixed
+    // screen line, visible as a static band the scrolling waterfall ran through.
+    const int wfHeight = waterfallPixelHeight();
     // contentWidth(): see the divider-drag realloc — rows rasterize at the
     // displayed column count for a 1:1 blit (#3482).
     if (wfHeight > 0 && contentWidth() > 0) {
@@ -10865,8 +10886,12 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
     const int chromeH  = freqScaleH() + DIVIDER_H;
     const int contentH = height() - chromeH;
-    const int specH    = static_cast<int>(contentH * m_spectrumFrac);
-    const int wfH      = contentH - specH;
+    // Both via the shared helpers so this rect and the waterfall QImage
+    // allocated in resizeEvent are always the same height — a 1:1 vertical
+    // blit. (wfH == contentH - specH by construction; see
+    // waterfallPixelHeight().)
+    const int specH    = spectrumPixelHeight();
+    const int wfH      = waterfallPixelHeight();
 
     const int divY     = specH;
     const int scaleY   = specH + DIVIDER_H;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -112,6 +112,12 @@ public:
 
     QSize sizeHint() const override { return {800, 300}; }
     int spectrumPixelHeight() const;
+    // Waterfall pane height in pixels. MUST be the single source of truth for
+    // both the waterfall QImage row count (resizeEvent) and the destination
+    // rect drawWaterfall() blits into (paintEvent): computing it two different
+    // ways lets integer truncation make them disagree by a pixel, which shows
+    // up as a static horizontal band the scrolling waterfall passes through.
+    int waterfallPixelHeight() const;
 
     // Set the frequency range covered by this panadapter.
     void setFrequencyRange(double centerMhz, double bandwidthMhz);


### PR DESCRIPTION
Reported from the bench: a **static horizontal band** in the waterfall, only visible once the window is resized smaller (~2/3), and only noticeable *because the waterfall scrolls through it*.

## Root cause

The waterfall image and the rect it's blitted into computed their height two different ways:

```cpp
// resizeEvent  — sizes the IMAGE (rows allocated)
wfHeight = int(contentH * (1.0f - m_spectrumFrac));

// paintEvent   — sizes the DESTINATION rect
specH    = int(contentH * m_spectrumFrac);
wfH      = contentH - specH;
```

These are **not equivalent under integer truncation**. When they differ, `drawWaterfall()` is handed an N-row image to fill an (N+1)-pixel rect, and `QPainter::drawImage` duplicates one source row at a **fixed destination line**. That line is static — it falls out of the scale ratio, not the content — but every row is duplicated as it scrolls past, so it reads as a stationary band with the waterfall running through it. It's most visible at smaller pane heights, where the 1px stretch is proportionally larger.

The divider-drag realloc (`mouseMoveEvent`) had the same divergent expression, so dragging the split would have reintroduced it even after fixing resize.

## Fix

Add `waterfallPixelHeight()`, defined as the **remainder** of the split (`contentH - spectrumPixelHeight()`) rather than a second independent truncation, and use it at all three sites: image allocation, destination rect, and divider-drag realloc. The vertical blit is now 1:1 **by construction**, matching the 1:1 horizontal blit established in #3482.

## Test plan

**Arithmetic (the invariant):** across **33,167** `contentH` × split-ratio combinations (contentH 50–2000, frac 0.10–0.90):

| | mismatch |
|---|---|
| old expressions | **29,048 (87.6%)** |
| new shared helper | **0 (0.0%)** |

**Runtime** (aurora13, Windows 11, MSVC, Qt 6.10.3, built on current `main`): AE launches and drives normally against a live **FLEX-6300** via the automation bridge; window swept 1000px → 720px with the pan rendering throughout; lifecycle regression genus green (4 passed / 3 skipped / 0 failed).

**Not exercised:** I couldn't get a clean before/after *visual* capture of the band itself — on this radio the DSS history buffer reports `dssHistoryCapacityRows=0`, so `dss inject` adds no rows and the scrolling content needed to make the artifact visible in a screenshot wasn't available. I verified that's **pre-existing** and unrelated by stashing this change, rebuilding, and confirming the same `cap=0` on unmodified `main`. The fix therefore rests on the arithmetic invariant above plus the no-regression run, not on a photo of the band.

Principle VII.