### PR TITLE
[tci] Broadcast which slice has GUI focus (#4160)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -37,25 +37,22 @@ QString TciProtocol::sanitizeSliceLetter(const QString& letter)
     return clean.left(2);
 }
 
+// Reports only what TciServer has pushed. There is deliberately no scan
+// fallback: -1 is not exclusively a startup state — TciServer also pushes it
+// when the focused slice is removed, and in that window the optimistic-set
+// overlap it was assumed to avoid IS possible (SliceModel::setActive() marks
+// the incoming slice before the radio echoes active=0 on the outgoing one, so
+// a scan can see two). Scanning there would answer a GET, or seed a newly
+// connected client's init burst, with a slice that was never broadcast, so
+// GET-polling and broadcast-listening clients would disagree about focus.
+// Staying silent keeps every path consistent with the broadcast stream.
 bool TciProtocol::resolveActiveSlice(int& trx, QString& letter) const
 {
-    if (m_activeTrx >= 0) {
-        trx = m_activeTrx;
-        letter = m_activeLetter;
-        return true;
-    }
-    // Startup fallback only: no focus change has been observed yet, so no
-    // optimistic-set window can be open and a scan is unambiguous.
-    if (!m_model)
+    if (m_activeTrx < 0)
         return false;
-    for (auto* s : m_model->slices()) {
-        if (s && s->isActive()) {
-            trx = tciTrxForSlice(m_model, s);
-            letter = sanitizeSliceLetter(s->letter());
-            return true;
-        }
-    }
-    return false;
+    trx = m_activeTrx;
+    letter = m_activeLetter;
+    return true;
 }
 
 long long TciProtocol::mhzToHz(double mhz)
@@ -1818,12 +1815,17 @@ QString TciProtocol::cmdDiguOffset(const QStringList& args, bool isSet)
 // steal it would change default UX for every connected surface, which is
 // RFC territory (GOVERNANCE.md, "What requires an RFC"). Silent ignore
 // matches the TCI convention for commands the server does not honor.
-// The GET form takes no arguments, so anything present is a SET attempt.
-// Branch on args rather than the shared 2+-args isSet heuristic, which is
-// built for `trx,value` commands — the same shape cmdVolume uses.
+//
+// GET/SET follows the same split handleCommand() documents for every other
+// command: 0-1 args = GET, 2+ = SET. active_slice has no per-TRX form, so the
+// lone argument in `active_slice:0;` is redundant — but that is the shape a
+// client written against the rest of this protocol (`rx_volume:0;`,
+// `rx_mute:0;`) will send, and answering it is strictly more useful than
+// silence. Replying to a would-be setter with the unchanged focus also tells
+// them the SET did not take, which silence cannot.
 QString TciProtocol::cmdActiveSlice(const QStringList& args)
 {
-    if (!args.isEmpty()) return {};   // SET — ignored, see above
+    if (args.size() >= 2) return {};   // SET — ignored, see above
     int trx = -1;
     QString letter;
     if (!resolveActiveSlice(trx, letter)) return {};

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -27,6 +27,37 @@ int TciProtocol::tciTrxForSlice(RadioModel* model, const SliceModel* slice)
     return index >= 0 ? index : slice->sliceId();
 }
 
+QString TciProtocol::sanitizeSliceLetter(const QString& letter)
+{
+    QString clean;
+    for (const QChar c : letter) {
+        if (c.isLetterOrNumber())
+            clean.append(c);
+    }
+    return clean.left(2);
+}
+
+bool TciProtocol::resolveActiveSlice(int& trx, QString& letter) const
+{
+    if (m_activeTrx >= 0) {
+        trx = m_activeTrx;
+        letter = m_activeLetter;
+        return true;
+    }
+    // Startup fallback only: no focus change has been observed yet, so no
+    // optimistic-set window can be open and a scan is unambiguous.
+    if (!m_model)
+        return false;
+    for (auto* s : m_model->slices()) {
+        if (s && s->isActive()) {
+            trx = tciTrxForSlice(m_model, s);
+            letter = sanitizeSliceLetter(s->letter());
+            return true;
+        }
+    }
+    return false;
+}
+
 long long TciProtocol::mhzToHz(double mhz)
 {
     return static_cast<long long>(std::round(mhz * 1e6));
@@ -300,6 +331,17 @@ QString TciProtocol::generateInitBurst()
         burst += QStringLiteral("volume:%1;")
                      .arg(volumeDbFromPercent(
                          AppSettings::instance().value("MasterVolume", "100").toInt()));
+
+        // Which slice holds GUI focus (#4160) — AetherSDR extension. Without
+        // it a control surface learns focus only from the next change event,
+        // so every dial it owns targets trx 0 until the operator happens to
+        // switch slices. Emitted pre-READY with the rest of the state dump.
+        int activeTrx = -1;
+        QString activeLetter;
+        if (resolveActiveSlice(activeTrx, activeLetter)) {
+            burst += QStringLiteral("active_slice:%1,%2;")
+                         .arg(activeTrx).arg(activeLetter);
+        }
     }
 
     // ── Phase 3: Audio / IQ stream configuration ──────────────────────
@@ -436,6 +478,7 @@ QString TciProtocol::handleCommand(const QString& cmd)
     if (name == "rx_record")        return cmdRxRecord(args, isSet);
     if (name == "rx_play")          return cmdRxPlay(args, isSet);
     if (name == "tx_gain")          return cmdTxGain(args, isSet);
+    if (name == "active_slice")     return cmdActiveSlice(args);
 
     // Unknown command — ignore silently per TCI spec
     return {};
@@ -1763,6 +1806,29 @@ QString TciProtocol::cmdDiguOffset(const QStringList& args, bool isSet)
 }
 
 // ── Focus / TX frequency ───────────────────────────────────────────────────
+
+// `active_slice:<trx>;` — AetherSDR extension (#4160). Read-only: reports
+// which slice holds GUI focus so a control surface can follow the operator
+// instead of hardcoding trx 0.
+//
+// Not to be confused with `set_in_focus` below — that is the inverse
+// direction (a client asking us to raise our window).
+//
+// SET is deliberately ignored. Focus is GUI-owned; letting a remote client
+// steal it would change default UX for every connected surface, which is
+// RFC territory (GOVERNANCE.md, "What requires an RFC"). Silent ignore
+// matches the TCI convention for commands the server does not honor.
+// The GET form takes no arguments, so anything present is a SET attempt.
+// Branch on args rather than the shared 2+-args isSet heuristic, which is
+// built for `trx,value` commands — the same shape cmdVolume uses.
+QString TciProtocol::cmdActiveSlice(const QStringList& args)
+{
+    if (!args.isEmpty()) return {};   // SET — ignored, see above
+    int trx = -1;
+    QString letter;
+    if (!resolveActiveSlice(trx, letter)) return {};
+    return QStringLiteral("active_slice:%1,%2;").arg(trx).arg(letter);
+}
 
 QString TciProtocol::cmdSetInFocus()
 {

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -72,7 +72,27 @@ public:
     // TciServer directly (same pattern as pendingMasterVolume).
     int pendingTxGain() const { return m_pendingTxGain; }
 
+    // Which TCI TRX currently holds GUI focus (#4160). TciServer owns this
+    // value and pushes it in — it cannot be derived reliably by scanning
+    // slices for isActive(): SliceModel::setActive() sets the new slice's
+    // flag optimistically (SliceModel.cpp, #3854 review) while the outgoing
+    // slice keeps its flag until the radio echoes active=0, so for one round
+    // trip TWO slices report active and a scan returns whichever comes first
+    // in slice order. -1 = not yet known, in which case the scan is used as
+    // the startup fallback (before any focus change has been observed).
+    void setActiveSlice(int trx, const QString& letter)
+    {
+        m_activeTrx = trx;
+        m_activeLetter = letter;
+    }
+    int activeTrx() const { return m_activeTrx; }
+
 private:
+    // Resolves the focused slice into its trx and display letter, falling
+    // back to a slice scan while m_activeTrx is -1. Returns false when there
+    // is no model or no slice reports active.
+    bool resolveActiveSlice(int& trx, QString& letter) const;
+
     // Command handlers — return response string or empty
     QString cmdVfo(const QStringList& args, bool isSet);
     QString cmdModulation(const QStringList& args, bool isSet);
@@ -104,6 +124,7 @@ private:
     // AetherSDR extensions (DVK record/play)
     QString cmdRxRecord(const QStringList& args, bool isSet);
     QString cmdRxPlay(const QStringList& args, bool isSet);
+    QString cmdActiveSlice(const QStringList& args);
     QString cmdSpot(const QStringList& args);
     QString cmdSpotDelete(const QStringList& args);
     QString cmdSpotClear();
@@ -147,6 +168,12 @@ public:
     static QString smartsdrToTci(const QString& mode);
     static QString tciToSmartSDR(const QString& mode);
 
+    // Slice display letter for `active_slice` (#4160), public for the same
+    // reason. `index_letter` is radio-supplied, and a stray ',' or ';' in it
+    // would corrupt the TCI framing for every client, so it is reduced to the
+    // short alphanumeric label it is meant to be (Principle VII).
+    static QString sanitizeSliceLetter(const QString& letter);
+
     // Map a slice to its contiguous TCI TRX index (0..N-1) within the
     // owned-slice list.  Falls back to the raw Flex sliceId() if the
     // slice is not in the model's list.
@@ -174,6 +201,8 @@ private:
     std::optional<TrxRequest> m_trxRequest;
     int         m_pendingMasterVolume{-1};   // -1 = no change requested
     int         m_pendingTxGain{-1};         // -1 = no change requested
+    int         m_activeTrx{-1};             // -1 = focus not yet known (#4160)
+    QString     m_activeLetter;              // focused slice's display letter (#4160)
     bool        m_started{false};  // client sent START
 };
 

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -80,10 +80,16 @@ public:
     // trip TWO slices report active and a scan returns whichever comes first
     // in slice order. -1 = not yet known, in which case the scan is used as
     // the startup fallback (before any focus change has been observed).
+    // The letter is sanitized here, not just at the TciServer call site: this
+    // is the boundary the value crosses on its way to the wire, and a raw
+    // radio-supplied ',' or ';' would corrupt TCI framing for every client on
+    // the socket. Enforcing it in the setter keeps the invariant independent of
+    // any caller remembering (Principle VII). Sanitizing is idempotent, so the
+    // server sanitizing first costs nothing.
     void setActiveSlice(int trx, const QString& letter)
     {
         m_activeTrx = trx;
-        m_activeLetter = letter;
+        m_activeLetter = sanitizeSliceLetter(letter);
     }
     int activeTrx() const { return m_activeTrx; }
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -219,6 +219,8 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 abortTciPtt();
             }
             m_tciDaxSlices.remove(sliceId);
+            // Removal renumbers every later slice's trx (#4160).
+            publishActiveTrx();
             auto* ps = m_model ? m_model->panStream() : nullptr;
             if (!ps) return;
             for (int ch = 1; ch <= 4; ++ch) {
@@ -421,6 +423,50 @@ void TciServer::broadcastMasterVolume(int pct)
                   .arg(TciProtocol::volumeDbFromPercent(pct)));
 }
 
+// Recompute the focused TRX and tell clients if it moved (#4160).
+//
+// Called both when focus changes and when a slice is removed. The removal
+// case is the non-obvious one: trx is a positional index, so removing a
+// slice renumbers every later slice, but the focused slice itself emits
+// nothing — it never lost focus. Without this the tracked trx (and every
+// client seeded from it) silently points at the wrong slice.
+//
+// Unlike vfo:/modulation:, active_slice has no follow-up event that would
+// self-correct: once only one slice remains the operator cannot switch
+// focus at all, so a stale value would persist indefinitely.
+//
+// Runs even with no clients connected — focus and slice count both change
+// freely before anyone connects, and m_activeTrx seeds each new client's
+// init burst.
+void TciServer::publishActiveTrx()
+{
+    int trx = -1;
+    QString letter;
+    // Resolved from the remembered slice rather than a scan: during a focus
+    // switch SliceModel::setActive() sets the incoming slice optimistically
+    // while the outgoing one keeps its flag until the radio echoes active=0,
+    // so a scan can transiently see two active slices (#3854 review).
+    if (m_activeSlice && m_model && m_model->slices().contains(m_activeSlice)) {
+        trx = TciProtocol::tciTrxForSlice(m_model, m_activeSlice);
+        letter = TciProtocol::sanitizeSliceLetter(m_activeSlice->letter());
+    }
+
+    // Letter is part of the dedupe: the radio can relabel a slice without
+    // focus moving (MultiFlex reassignment, #2606), and a controller showing
+    // "Slice A" must not keep showing it after the radio calls it B.
+    if (trx == m_activeTrx && letter == m_activeLetter) return;
+    m_activeTrx = trx;
+    m_activeLetter = letter;
+    for (auto& c : m_clients) {
+        if (c.protocol) c.protocol->setActiveSlice(trx, letter);
+    }
+    // trx < 0 means the focused slice is gone and nothing has claimed focus
+    // yet; stay silent rather than announce a slice that does not exist. The
+    // radio's next activeChanged brings us back.
+    if (trx >= 0 && !m_clients.isEmpty())
+        broadcast(QStringLiteral("active_slice:%1,%2;").arg(trx).arg(letter));
+}
+
 void TciServer::setTxGain(float gain)
 {
     const float clamped = std::clamp(gain, 0.0f, 1.0f);
@@ -483,6 +529,11 @@ void TciServer::onNewConnection()
         ws->setMaxAllowedIncomingFrameSize(kMaxWsMessageBytes);
 
         auto* protocol = new TciProtocol(m_model, &m_routingState);
+        // Seed GUI focus so this client's init burst and any `active_slice`
+        // GET report the current slice, not a stale scan (#4160). Stays -1
+        // if no focus change has been observed yet, in which case the
+        // protocol falls back to scanning.
+        protocol->setActiveSlice(m_activeTrx, m_activeLetter);
 
         ClientState cs;
         cs.socket = ws;
@@ -2147,6 +2198,43 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
         broadcast(QStringLiteral("lock:%1,%2;")
                       .arg(trx).arg(locked ? "true" : "false"));
     });
+
+    // GUI focus → `active_slice:trx;` broadcast (#4160). Control surfaces
+    // (Elgato / StreamController / Ulanzi) otherwise hardcode trx 0 and every
+    // dial keeps addressing slice A no matter what the operator selected.
+    //
+    // Only the true edge is relayed. A slice losing focus also emits
+    // activeChanged(false), and the gaining slice's true edge is the
+    // authoritative event — relaying the false edge would emit a second,
+    // wrong active_slice for the outgoing trx.
+    //
+    // The focused slice is remembered by identity, not by trx: trx is
+    // positional, so a later slice removal renumbers it (see
+    // publishActiveTrx()).
+    connect(slice, &SliceModel::activeChanged, this, [this, slice](bool active) {
+        if (!active) return;
+        m_activeSlice = slice;
+        publishActiveTrx();
+    });
+
+    // The radio can relabel a slice without focus moving (MultiFlex
+    // reassignment, #2606). Re-announce so a controller showing "Slice A"
+    // does not keep showing it after the radio calls it something else.
+    connect(slice, &SliceModel::letterChanged, this, [this, slice](const QString&) {
+        if (slice != m_activeSlice) return;
+        publishActiveTrx();
+    });
+
+    // Seed from current state — the activeChanged edge above is not enough.
+    // RadioModel decodes the radio's slice status (applying active=1, which
+    // emits activeChanged) BEFORE it emits sliceAdded, and sliceAdded is what
+    // triggers this wiring. So for every newly added slice the focus edge has
+    // already fired by the time we connect, and nothing re-fires it: adding a
+    // slice made it active in the GUI while TCI kept reporting the old one.
+    if (slice->isActive()) {
+        m_activeSlice = slice;
+        publishActiveTrx();
+    }
 
     // Per-slice audioGain → `rx_volume:trx,N;` broadcast. Without this,
     // a GUI change to a slice's audio level was invisible to TCI clients;

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -162,6 +162,7 @@ private:
     void broadcastSpotClicked(const QString& callsign, long long frequencyHz,
                               int trx, int channel);
     void broadcastSliceFrequencies(SliceModel* slice);
+    void publishActiveTrx();
     SliceModel* sliceForPanId(const QString& panId) const;
     void broadcast(const QString& msg);
     void broadcastBinary(const QByteArray& data);
@@ -244,6 +245,12 @@ private:
     QWebSocketServer* m_server{nullptr};
     QList<ClientState> m_clients;
     QSet<int>         m_tciDaxSlices;   // slice IDs where we auto-assigned DAX (#1331)
+    int               m_activeTrx{-1};  // TRX holding GUI focus; -1 = not yet observed (#4160)
+    // The focused slice by identity. trx is positional and shifts when an
+    // earlier slice is removed, so the pointer is what survives renumbering;
+    // QPointer clears if the slice is destroyed (#4160).
+    QPointer<SliceModel> m_activeSlice;
+    QString           m_activeLetter;   // focused slice's display letter (#4160)
     QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
     QHash<QString, long long> m_lastDdsCenterHz; // panId → last broadcast dds center, gates zoom-only re-emits (#3910)
     TciRoutingState m_routingState;

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -308,6 +308,87 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    // ── active_slice (#4160) — AetherSDR extension, read-only ──────────
+    // Focus is unknown until TciServer observes an activeChanged(true), and
+    // there is no model here to scan: report nothing rather than guess trx 0,
+    // which is exactly the wrong answer the issue is about.
+    if (!protocol.handleCommand(QStringLiteral("active_slice")).isEmpty()) {
+        std::fprintf(stderr,
+                     "active_slice GET must stay silent while focus is unknown\n");
+        return 1;
+    }
+
+    // trx is positional and the operator never sees it; the display letter is
+    // what the GUI shows, so both are reported.
+    protocol.setActiveSlice(1, QStringLiteral("C"));
+    const QString activeGet =
+        protocol.handleCommand(QStringLiteral("active_slice"));
+    if (activeGet != QStringLiteral("active_slice:1,C;")) {
+        std::fprintf(stderr,
+                     "active_slice GET should report trx and letter; got %s\n",
+                     activeGet.toUtf8().constData());
+        return 1;
+    }
+
+    // A radio-supplied letter carrying TCI delimiters would corrupt framing
+    // for every client on the socket.
+    protocol.setActiveSlice(1, TciProtocol::sanitizeSliceLetter(
+                                   QStringLiteral("A;drive:0,100")));
+    const QString sanitized =
+        protocol.handleCommand(QStringLiteral("active_slice"));
+    if (sanitized.count(QLatin1Char(';')) != 1
+        || sanitized.count(QLatin1Char(',')) != 1) {
+        std::fprintf(stderr,
+                     "active_slice letter must not inject delimiters; got %s\n",
+                     sanitized.toUtf8().constData());
+        return 1;
+    }
+    protocol.setActiveSlice(1, QStringLiteral("C"));
+
+    // SET is ignored — focus is GUI-owned. A client must not be able to steal
+    // it, and must not desync every other client by appearing to.
+    if (!protocol.handleCommand(QStringLiteral("active_slice:0")).isEmpty()) {
+        std::fprintf(stderr, "active_slice SET must not reply\n");
+        return 1;
+    }
+    if (!protocol.pendingNotification().isEmpty()) {
+        std::fprintf(stderr, "active_slice SET must not notify other clients\n");
+        return 1;
+    }
+    if (protocol.handleCommand(QStringLiteral("active_slice"))
+        != QStringLiteral("active_slice:1,C;")) {
+        std::fprintf(stderr, "active_slice SET must not change reported focus\n");
+        return 1;
+    }
+
+    // Focus can become unknown again: removing the focused slice renumbers
+    // trx and leaves nothing focused until the radio picks a new slice, so
+    // TciServer pushes -1. Report nothing rather than a stale trx.
+    protocol.setActiveSlice(-1, QString());
+    if (!protocol.handleCommand(QStringLiteral("active_slice")).isEmpty()) {
+        std::fprintf(stderr,
+                     "active_slice GET must stay silent once focus is cleared\n");
+        return 1;
+    }
+    // Removing an earlier slice renumbers trx while the letter stays put —
+    // exactly why the letter is reported alongside it.
+    protocol.setActiveSlice(0, QStringLiteral("C"));
+    if (protocol.handleCommand(QStringLiteral("active_slice"))
+        != QStringLiteral("active_slice:0,C;")) {
+        std::fprintf(stderr, "active_slice GET must track renumbered focus\n");
+        return 1;
+    }
+
+    // The greeting carries focus only alongside the rest of the per-slice
+    // state dump, so a model-less protocol must not synthesize one.
+    for (const QString& command : greeting) {
+        if (command.startsWith(QStringLiteral("active_slice"))) {
+            std::fprintf(stderr,
+                         "modelless TCI greeting must not emit active_slice\n");
+            return 1;
+        }
+    }
+
     std::printf("tci_protocol_test: all checks passed\n");
     return 0;
 }

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -331,9 +331,10 @@ int main(int argc, char** argv)
     }
 
     // A radio-supplied letter carrying TCI delimiters would corrupt framing
-    // for every client on the socket.
-    protocol.setActiveSlice(1, TciProtocol::sanitizeSliceLetter(
-                                   QStringLiteral("A;drive:0,100")));
+    // for every client on the socket. The RAW string is passed in on purpose:
+    // sanitizing is the setter's job, so the invariant does not depend on each
+    // caller remembering to pre-clean.
+    protocol.setActiveSlice(1, QStringLiteral("A;drive:0,100"));
     const QString sanitized =
         protocol.handleCommand(QStringLiteral("active_slice"));
     if (sanitized.count(QLatin1Char(';')) != 1
@@ -345,9 +346,20 @@ int main(int argc, char** argv)
     }
     protocol.setActiveSlice(1, QStringLiteral("C"));
 
-    // SET is ignored — focus is GUI-owned. A client must not be able to steal
-    // it, and must not desync every other client by appearing to.
-    if (!protocol.handleCommand(QStringLiteral("active_slice:0")).isEmpty()) {
+    // 0-1 args = GET, matching the split handleCommand() documents for every
+    // other command. active_slice has no per-TRX form, but `active_slice:0;` is
+    // the shape a client written against `rx_volume:0;` will send, so it is
+    // answered rather than silently dropped.
+    if (protocol.handleCommand(QStringLiteral("active_slice:0"))
+        != QStringLiteral("active_slice:1,C;")) {
+        std::fprintf(stderr,
+                     "active_slice GET with a redundant trx arg must still report\n");
+        return 1;
+    }
+
+    // SET (2+ args) is ignored — focus is GUI-owned. A client must not be able
+    // to steal it, and must not desync every other client by appearing to.
+    if (!protocol.handleCommand(QStringLiteral("active_slice:0,1")).isEmpty()) {
         std::fprintf(stderr, "active_slice SET must not reply\n");
         return 1;
     }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -78,6 +78,70 @@ public:
             && snapshot.value(QStringLiteral("lastRouteError")).toString()
                 == QStringLiteral("capacity test");
     }
+
+    // #4160 — GUI focus must reach TCI, and a slice must seed focus from
+    // *current* state rather than waiting for a future activeChanged edge.
+    // RadioModel applies active=1 (emitting activeChanged) BEFORE it emits
+    // sliceAdded, and MainWindow wires the slice from sliceAdded — so the edge
+    // has already fired by the time TciServer::wireSlice() runs. wireSlice()
+    // therefore seeds from isActive() as well as connecting for future edges.
+    // That seed was previously exercised only on hardware (see PR #4323
+    // test-plan note); this covers it in-process by mirroring MainWindow's
+    // wireTciSlice() call over the disconnected slice-fixture seam.
+    static bool activeSliceSeedsFromCurrentState()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        // Mirror MainWindow_Session::wireTciSlice(): trx is the contiguous
+        // index within the owned slice list.
+        auto wire = [&](SliceModel* s) {
+            server.wireSlice(model.slices().indexOf(s), s);
+        };
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QStringLiteral("A"), &error)) {
+            std::fprintf(stderr, "fixture A failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        wire(model.slices().value(0));
+        // No client is connected, yet focus is tracked already: the seed runs
+        // unconditionally so the *next* client's init burst is correct.
+        if (server.m_activeTrx != 0
+            || server.m_activeLetter != QStringLiteral("A")) {
+            std::fprintf(stderr,
+                         "seed after fixture A: got trx=%d letter=%s\n",
+                         server.m_activeTrx,
+                         server.m_activeLetter.toUtf8().constData());
+            return false;
+        }
+
+        // Adding a second slice moves GUI focus (single-active semantics). TCI
+        // follows by slice identity; trx is positional, so B resolves to trx 1.
+        if (!model.automationApplySliceFixture(1, QStringLiteral("B"), &error)) {
+            std::fprintf(stderr, "fixture B failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        wire(model.slices().value(1));
+        if (server.m_activeTrx != 1
+            || server.m_activeLetter != QStringLiteral("B")) {
+            std::fprintf(stderr,
+                         "focus switch to B: got trx=%d letter=%s\n",
+                         server.m_activeTrx,
+                         server.m_activeLetter.toUtf8().constData());
+            return false;
+        }
+
+        // The seed handoff the accept path performs (TciServer connection
+        // setup) must make a newly connected client's protocol report current
+        // focus, not a stale scan — the exact bug #4160 is about.
+        TciProtocol seeded(&model, &server.m_routingState);
+        seeded.setActiveSlice(server.m_activeTrx, server.m_activeLetter);
+        return seeded.handleCommand(QStringLiteral("active_slice"))
+            == QStringLiteral("active_slice:1,B;");
+    }
 };
 
 } // namespace AetherSDR
@@ -94,6 +158,8 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::deferredAbortIsClientScoped();
     const bool observableFailure
         = AetherSDR::TciServerReviewTest::routeFailureIsObservable();
+    const bool activeSliceSeed
+        = AetherSDR::TciServerReviewTest::activeSliceSeedsFromCurrentState();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -101,6 +167,9 @@ int main(int argc, char** argv)
                 deferredAbort ? "PASS" : "FAIL");
     std::printf("%s  VFO-B route failure is observable\n",
                 observableFailure ? "PASS" : "FAIL");
+    std::printf("%s  active_slice seeds from current GUI focus (#4160)\n",
+                activeSliceSeed ? "PASS" : "FAIL");
 
-    return validProfile && deferredAbort && observableFailure ? 0 : 1;
+    return validProfile && deferredAbort && observableFailure
+        && activeSliceSeed ? 0 : 1;
 }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -142,6 +142,79 @@ public:
         return seeded.handleCommand(QStringLiteral("active_slice"))
             == QStringLiteral("active_slice:1,B;");
     }
+
+    // #4160 — trx is positional, so removing a slice renumbers every later one
+    // while the focused slice emits nothing (it never lost focus). Unlike
+    // vfo:/modulation: there is no follow-up event to self-correct, so the
+    // sliceRemoved → publishActiveTrx() path is the only thing keeping the
+    // tracked trx (and every client seeded from it) pointing at the right
+    // slice. Previously covered only on hardware.
+    static bool activeSliceFollowsSliceRemoval()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        auto wire = [&](SliceModel* s) {
+            server.wireSlice(model.slices().indexOf(s), s);
+        };
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QStringLiteral("A"), &error)
+            || !model.automationApplySliceFixture(1, QStringLiteral("B"),
+                                                  &error)) {
+            std::fprintf(stderr, "removal fixtures failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        wire(model.slices().value(0));
+        wire(model.slices().value(1));
+        if (server.m_activeTrx != 1
+            || server.m_activeLetter != QStringLiteral("B")) {
+            std::fprintf(stderr,
+                         "removal setup: expected focus B at trx 1, got trx=%d letter=%s\n",
+                         server.m_activeTrx,
+                         server.m_activeLetter.toUtf8().constData());
+            return false;
+        }
+
+        // Remove the EARLIER, unfocused slice. Focus stays with B, but B's
+        // positional trx renumbers 1 → 0. Nothing re-fires activeChanged, so
+        // only the removal hook can correct it.
+        if (!model.automationRemoveSliceFixture(0, &error)) {
+            std::fprintf(stderr, "remove slice 0 failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        if (server.m_activeTrx != 0
+            || server.m_activeLetter != QStringLiteral("B")) {
+            std::fprintf(stderr,
+                         "after removing trx 0: expected focus B renumbered to trx 0, "
+                         "got trx=%d letter=%s\n",
+                         server.m_activeTrx,
+                         server.m_activeLetter.toUtf8().constData());
+            return false;
+        }
+
+        // Remove the FOCUSED slice: nothing holds focus until the radio picks a
+        // new slice, so the tracked trx clears rather than naming a slice that
+        // no longer exists.
+        if (!model.automationRemoveSliceFixture(1, &error)) {
+            std::fprintf(stderr, "remove slice 1 failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        if (server.m_activeTrx != -1) {
+            std::fprintf(stderr,
+                         "after removing the focused slice: expected cleared focus, got trx=%d\n",
+                         server.m_activeTrx);
+            return false;
+        }
+
+        // A client connecting in that window must be told nothing rather than
+        // be handed a scanned guess that was never broadcast.
+        TciProtocol seeded(&model, &server.m_routingState);
+        seeded.setActiveSlice(server.m_activeTrx, server.m_activeLetter);
+        return seeded.handleCommand(QStringLiteral("active_slice")).isEmpty();
+    }
 };
 
 } // namespace AetherSDR
@@ -160,6 +233,8 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::routeFailureIsObservable();
     const bool activeSliceSeed
         = AetherSDR::TciServerReviewTest::activeSliceSeedsFromCurrentState();
+    const bool activeSliceRemoval
+        = AetherSDR::TciServerReviewTest::activeSliceFollowsSliceRemoval();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -169,7 +244,9 @@ int main(int argc, char** argv)
                 observableFailure ? "PASS" : "FAIL");
     std::printf("%s  active_slice seeds from current GUI focus (#4160)\n",
                 activeSliceSeed ? "PASS" : "FAIL");
+    std::printf("%s  active_slice renumbers/clears on slice removal (#4160)\n",
+                activeSliceRemoval ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure
-        && activeSliceSeed ? 0 : 1;
+        && activeSliceSeed && activeSliceRemoval ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes #4160.

> **Update — rebased onto `main` after #4407 (TCI split-routing refactor) landed.** Conflicts resolved: the client-accept path now passes `&m_routingState` into the `TciProtocol` constructor (the new #4407 signature) alongside the focus seed, and the protocol-test block sits next to #4407's routing tests. Added a TciServer-level unit test (`tests/tci_server_review_test.cpp`, via the friend harness #4407 introduced) covering the wire-time focus seed that was previously only exercised on hardware. Re-verified on live hardware against the rebased build — broadcast on add/switch/remove/re-add, init-burst seed before `ready`, renumber-down + reconnect re-seed, and GET-reports / SET-ignored (no reply, no broadcast to other clients) — all unchanged.

TCI has no way to tell a connected client which slice currently holds UI focus. `trx` is a purely positional slice index, so the three bundled control-surface plugins (Elgato Stream Deck, StreamController, Ulanzi) all hardcode `trx=0` — every dial and toggle keeps addressing whichever slice happens to sit at position 0, no matter which slice the operator has selected in the GUI.

This adds a read-only `active_slice:<trx>,<letter>;` AetherSDR extension, in the same category as the existing `rx_record` / `rx_play` / `tx_gain` extensions (not part of the TCI v2.0 spec):

- **Broadcast** — `TciServer` relays `SliceModel::activeChanged`, and re-publishes when a slice is removed or relabelled.
- **Init burst** — `generateInitBurst()` emits `active_slice` before `ready`, so a freshly connected client knows current focus rather than waiting for the next change event. Placement matters: SDC / CW Skimmer latch cached settings the moment `READY` arrives.
- **GET** — `active_slice` reports the focused slice, so a client can poll instead of relying solely on the burst plus change events.

Server-side only. The plugin-side follow-up (defaulting a control to "follow active slice") is out of scope here and can't land until the server actually emits this — see the issue.

### Why the letter is sent alongside trx

`trx` is positional and **the operator never sees it** — the GUI shows Slice A / B / C. The two are genuinely decoupled: remove a slice and re-add one, and the radio may reuse the letter "A" while the new slice appends to position 1. A controller labelling a dial from `trx` alone would say "Slice 1" while the screen says "Slice A".

`command:trx,value;` is the argument shape every per-slice TCI command already uses, so clients parse this with their existing code path. Nothing consumes `active_slice` yet, so adding the letter now costs nothing.

The letter is radio-supplied (`index_letter`) and reaches the wire, so it is sanitized to a short alphanumeric label — a stray `,` or `;` would corrupt TCI framing for every client on the socket.

### SET is deliberately a no-op

Focus is GUI-owned. Letting a remote client steal it would change what a connected device does to the GUI out of the box, which is default-UX territory and needs an RFC first (GOVERNANCE.md, "What requires an RFC"). Silently ignoring the SET form matches TCI's convention for commands the server doesn't honor, so nothing breaks for a client that tries.

### Focus is tracked by slice identity

Two simpler implementations both fail, and the reasons are the non-obvious part of this change.

**Scanning slices for `isActive()` is ambiguous.** `SliceModel::setActive()` sets the incoming slice's flag optimistically, before the radio confirms (deliberately, per the #3854 review). Meanwhile nothing calls `setActive(false)` — the outgoing slice keeps its flag until the radio echoes `active=0`. For one round trip **two slices report active**, and a scan returns whichever comes first in slice order. `MainWindow::activeSlice()` already sidesteps this by consulting its cached `m_activeSliceId` first.

**Caching the trx index goes stale.** Removing a slice renumbers every later slice, but the focused slice emits nothing — it never lost focus. Unlike `vfo:`/`modulation:`, `active_slice` has no follow-up event to self-correct: once one slice remains the operator cannot switch focus at all, so a stale value would persist indefinitely.

So the focused slice is held by identity (`QPointer<SliceModel>`) and `trx` is derived on demand. Slice removal and letter changes both re-publish through one `publishActiveTrx()`, so the two paths can't drift.

**Edges alone are also not enough.** `RadioModel` decodes the radio's slice status — applying `active=1` and emitting `activeChanged` — *before* it emits `sliceAdded`, and `sliceAdded` is what triggers the TCI wiring. For every newly added slice the focus edge has already fired by the time we connect. `wireSlice()` therefore seeds from current state as well as connecting for future edges. Without this, adding a slice made it active in the GUI while TCI kept reporting the old one.

### Not to be confused with `set_in_focus`

The existing `set_in_focus` command is the **inverse** direction — a client asking the server to raise its window — and is an unrelated no-op stub. Untouched here.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** The broadcast is driven by radio-confirmed focus edges, and focus is tracked rather than *guessed* from a scan whose result is ambiguous mid-transition.

**Principle VII — Untrusted Input Is Validated At The Boundary.** The radio-supplied slice letter is sanitized before it reaches the wire.

Purely additive: per the TCI spec unknown commands are ignored, so clients that don't understand `active_slice` (WSJT-X, RF2K-S, SDC) are unaffected.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio — transcript below
- [x] Existing tests pass locally — 129/130, see note below
- [ ] Reproduction steps documented if user-reported bug — n/a, feature request

### Live hardware

Captured from a TCI client while driving the GUI: start with Slice A, add B, add C, switch to A → B → C, remove B, remove A, add A, add B, switch to C.

```
rx: active_slice:0,A;
rx: active_slice:1,B;
rx: active_slice:2,C;
rx: active_slice:0,A;
rx: active_slice:1,B;
rx: active_slice:2,C;
rx: active_slice:1,C;
rx: active_slice:0,C;
rx: active_slice:1,A;
rx: active_slice:2,B;
rx: active_slice:0,C;
```

Three things this confirms:

- **Adding a slice announces it** (lines 2, 3) — the newly added slice takes focus in the GUI and TCI follows.
- **Removal renumbers correctly** (lines 7, 8) — focus never moved, C stayed active, yet `trx` went `2 → 1 → 0` as the slices below it were removed, each step announced.
- **Letter and trx are independent** (line 9) — after remove/re-add the radio reuses letter "A" at position 1, so `1,A`. Line 11 reports `0,C`: same letter as line 8, different trx.

No duplicate or spurious events; every line has exactly one cause.

The init burst was checked separately, by switching focus to Slice C and *then* connecting a fresh client (trailing state commands trimmed):

```
rx: volume:0;
rx: active_slice:2,C;
rx: audio_samplerate:48000;
...
rx: iq_samplerate:48000;
rx: ready;
```

`active_slice` arrives before `ready`, which matters because SDC / CW Skimmer latch cached settings the moment `READY` arrives. Removing Slice A and reconnecting then gives:

```
rx: active_slice:1,C;
```

The burst reports C's *renumbered* trx rather than the stale `2` — a cached-index implementation would have seeded a trx the client could not address (the same capture shows only `rx_smeter:0` and `rx_smeter:1`).

### Unit tests

`tests/tci_protocol_test.cpp` covers: GET reports trx and letter; GET stays silent while focus is unknown rather than guessing `trx 0`; GET stays silent once focus is cleared; GET tracks a renumbered trx; a letter containing TCI delimiters cannot inject them into the response; SET does not reply, notify, or change reported focus; a model-less greeting does not synthesize an `active_slice`.

These cover `TciProtocol` only — the `TciServer` wiring has no unit tests (there is no existing `TciServer` harness), which is why the hardware transcripts above matter: the wire-time seed bug was invisible to the suite and surfaced only on hardware. The broadcast and init-burst paths are covered by those transcripts; the read-only SET guard and the "focus cleared" silent path rest on unit tests alone.

One trap for anyone touching this: the dispatcher's shared `isSet` heuristic is `args.size() >= 2`, right for `trx,value` commands but wrong for a single-arg global like `active_slice:0;` — a SET parses as a GET and the read-only guard silently does nothing. `cmdActiveSlice` branches on `args.isEmpty()` instead, matching `cmdVolume`.

### Pre-existing unrelated test failure

`cross_needle_meter_test` (`SWR label placement cache is keyed by the rendered font`) fails identically on an untouched `origin/main`, confirmed with a from-scratch rebuild — not caused by this PR. It looks font-environment dependent.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no persistence added; focus is live state, not a saved setting
- [x] Code is clean-room — written against this codebase's own model/protocol layers, no proprietary sources involved
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI
- [ ] Documentation updated if user-visible behavior changed — **see note**
- [x] Security-sensitive changes reference a GHSA if applicable — n/a; read-only, and the one radio-supplied field that reaches the wire is sanitized
            
Doc note: I couldn't find an existing TCI protocol reference to add `active_slice` to — searching the repo for the other extensions (`rx_record` / `rx_play` / `tx_gain`) only turned up release notes. I may well have missed it; happy to document this wherever it belongs.

