### PR TITLE
Add optional slice id to the bridge tune verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Audio, diagnostics & automation
+
+- Add an optional slice id to the automation bridge `tune` verb
+  (`tune <mhz> [sliceId]`, JSON `id` field) so scripts can drive a non-active
+  slice directly instead of the racy `slice select` → `tune` → re-select flap.
+  No id keeps today's active-slice behavior; lock, SWR-sweep, and Multi-Flex
+  ownership refusals apply to both forms. (#4324 — @quelleck)
+
 ## [v26.7.3] — 2026-07-19
 
 ### Cross-needle metering · radio-state fidelity · operating polish

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2922,6 +2922,17 @@ if(PYTHON3_EXECUTABLE)
                      ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_bridge_docs.py --check)
 endif()
 
+# JSON boundary regression for shared bridge `id` normalization. Exercises the
+# real QLocalSocket request path and tune dispatcher without touching a radio.
+add_executable(automation_json_id_test
+    tests/automation_json_id_test.cpp
+)
+target_include_directories(automation_json_id_test PRIVATE src tests)
+target_link_libraries(automation_json_id_test PRIVATE
+    aethercore Qt6::Core Qt6::Network
+)
+add_test(NAME automation_json_id_test COMMAND automation_json_id_test)
+
 add_executable(gui_client_identity_policy_test
     tests/gui_client_identity_policy_test.cpp
 )

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -969,16 +969,28 @@ scope actually consumed, in milliseconds per wall-clock second.
   hidden-widget signature, not a bug.
 
 ### `tune`
-Set the **active slice's** frequency in MHz — the most fundamental control the
+Set a slice's frequency in MHz — the most fundamental control the
 custom-painted `VfoWidget` couldn't expose. RX/config only; despite the name it
 does **not** key (cf. `atu tune`, which does). Honors the per-slice VFO lock.
+
+Without a slice id the **active slice** is tuned (the original verb shape).
+An optional second argument (bare line) / `id` field (JSON) targets a specific
+slice by id, so scripts driving a non-active slice no longer need the racy
+`slice select` → `tune` → re-select flap:
 
 ```json
 → {"cmd":"tune","value":"7.175"}
 ← {"ok":true,"tune":7.175,"sliceId":0,"letter":"A"}
+
+→ {"cmd":"tune","value":"14.074","id":"1"}
+← {"ok":true,"tune":14.074,"sliceId":1,"letter":"B"}
 ```
 
-Refused with `refused: slice A is VFO-locked` when the slice is locked. To
+Bare-line form: `tune 14.074 1`.
+
+Refused with `refused: slice A is VFO-locked` when the slice is locked, with
+`no slice with id N` when the id names no slice, and with `refused: slice N
+belongs to another client` when another client owns it (Multi-Flex). To
 recenter the *pan* (band change) rather than move the slice within it, use
 [`pan center`](#pan).
 
@@ -2258,7 +2270,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `slice` | — | slice <action> [args] — slice lifecycle/config (see doSlice) |
 | `gps` | — | gps <fixture\|clearfixture> [6000\|8000] — disconnected GPS test data |
 | `waveform` | — | waveform <start\|stop\|unregister\|resync> [args] — digital-voice service |
-| `tune` | — | tune <mhz> — set the active slice frequency |
+| `tune` | — | tune <mhz> [sliceId] — set a slice frequency (default: the active slice) |
 | `cwx` | — | cwx <send\|speed\|stop> [args] — CWX keyer (send is TX-gated) |
 | `record` | — | record <start\|stop\|status\|path\|dir> [args] |
 | `testtone` | — | testtone <on\|off> [freqHz levelDb] |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2916,8 +2916,19 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         // like `value` above; a bare .toString() would silently coerce a
         // numeric id to "" and the request would act on the wrong target.
         const QJsonValue idv = obj.value(QStringLiteral("id"));
-        if (idv.isString())      a.id = idv.toString();
-        else if (idv.isDouble()) a.id = QString::number(idv.toDouble());
+        if (idv.isString()) {
+            a.id = idv.toString();
+        } else if (idv.isDouble()) {
+            // Keep enough precision for downstream integer validation. The
+            // default six significant digits can round 1.0000001 to "1" and
+            // silently retarget a request to a real slice.
+            a.id = QString::number(idv.toDouble(), 'g',
+                                   std::numeric_limits<double>::max_digits10);
+        } else if (obj.contains(QStringLiteral("id"))) {
+            // An omitted id intentionally selects the active/default target;
+            // an explicitly malformed id must not collapse to that sentinel.
+            return err(QStringLiteral("id must be a string or number"));
+        }
         a.title    = obj.value(QStringLiteral("title")).toString();
         a.detail   = obj.value(QStringLiteral("detail")).toString();
         a.tone     = obj.value(QStringLiteral("tone")).toString();

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -2333,6 +2333,11 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
             a.value = vtok(p, 1);
             return {};
         };
+        auto parseValueId = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+            a.value = vtok(p, 1);
+            a.id = vtok(p, 2);
+            return {};
+        };
         auto parseValueRest = [](const QList<QByteArray>& p, A& a) -> QJsonObject {
             a.value = vjoin(p, 1);
             return {};
@@ -2614,12 +2619,12 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                 return s.doWaveform(a.action, a.value);
             });
 
-        add("tune", {}, "tune <mhz> — set the active slice frequency",
-            parseValueOnly,
+        add("tune", {}, "tune <mhz> [sliceId] — set a slice frequency (default: the active slice)",
+            parseValueId,
             [](AutomationServer& s, A& a, QLocalSocket*) -> QJsonObject {
                 if (a.value.isEmpty())
                     return err(QStringLiteral("tune requires a frequency in MHz"));
-                return s.doTune(a.value);
+                return s.doTune(a.value, a.id);
             });
 
         add("cwx", {}, "cwx <send|speed|stop> [args] — CWX keyer (send is TX-gated)",
@@ -2907,7 +2912,12 @@ QJsonObject AutomationServer::handleLine(const QByteArray& line, QLocalSocket* s
         a.model    = obj.value(QStringLiteral("model")).toString();
         a.selector = obj.value(QStringLiteral("selector")).toString();
         a.property = obj.value(QStringLiteral("property")).toString();
-        a.id       = obj.value(QStringLiteral("id")).toString();
+        // id may arrive as a JSON number (e.g. tune's slice id) — normalize
+        // like `value` above; a bare .toString() would silently coerce a
+        // numeric id to "" and the request would act on the wrong target.
+        const QJsonValue idv = obj.value(QStringLiteral("id"));
+        if (idv.isString())      a.id = idv.toString();
+        else if (idv.isDouble()) a.id = QString::number(idv.toDouble());
         a.title    = obj.value(QStringLiteral("title")).toString();
         a.detail   = obj.value(QStringLiteral("detail")).toString();
         a.tone     = obj.value(QStringLiteral("tone")).toString();
@@ -5556,9 +5566,12 @@ QJsonObject AutomationServer::doGps(const QString& action, const QString& format
 }
 
 // ── VFO tuning (#3646) ──────────────────────────────────────────────────────
-// Set the active slice's frequency (MHz). The most fundamental control the
-// VfoWidget couldn't expose (it's custom-painted). Honors the slice lock guard.
-QJsonObject AutomationServer::doTune(const QString& value)
+// Set a slice's frequency (MHz). The most fundamental control the VfoWidget
+// couldn't expose (it's custom-painted). Honors the slice lock guard. An
+// optional slice id targets a specific slice directly — without it the active
+// slice is tuned (the original behavior), which forced external scripts into a
+// racy select → tune → restore flap when driving a non-active slice.
+QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
 {
     if (!m_radioModel)
         return err(QStringLiteral("no radio model available"));
@@ -5567,17 +5580,32 @@ QJsonObject AutomationServer::doTune(const QString& value)
     if (!okF || mhz <= 0)
         return err(QStringLiteral("tune requires a positive frequency in MHz"));
 
+    int sliceId = -1;  // -1 = active slice
+    if (!id.isEmpty()) {
+        bool okId = false;
+        sliceId = id.toInt(&okId);
+        if (!okId || sliceId < 0)
+            return err(QStringLiteral("tune: sliceId must be a non-negative integer"));
+    }
+
     if (m_tuneHandler) {
-        return m_tuneHandler(mhz);
+        return m_tuneHandler(mhz, sliceId);
     }
 
     SliceModel* s = nullptr;
-    for (SliceModel* c : m_radioModel->slices())
-        if (c->isActive()) { s = c; break; }
-    if (!s && !m_radioModel->slices().isEmpty())
-        s = m_radioModel->slices().first();
-    if (!s)
-        return err(QStringLiteral("no slice to tune"));
+    if (sliceId >= 0) {
+        for (SliceModel* c : m_radioModel->slices())
+            if (c->sliceId() == sliceId) { s = c; break; }
+        if (!s)
+            return err(QStringLiteral("tune: no slice with id ") + QString::number(sliceId));
+    } else {
+        for (SliceModel* c : m_radioModel->slices())
+            if (c->isActive()) { s = c; break; }
+        if (!s && !m_radioModel->slices().isEmpty())
+            s = m_radioModel->slices().first();
+        if (!s)
+            return err(QStringLiteral("no slice to tune"));
+    }
     if (s->isLocked())
         return err(QStringLiteral("refused: slice ") + s->letter() + QStringLiteral(" is VFO-locked"));
 

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5597,7 +5597,12 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
         for (SliceModel* c : m_radioModel->slices())
             if (c->sliceId() == sliceId) { s = c; break; }
         if (!s)
-            return err(QStringLiteral("tune: no slice with id ") + QString::number(sliceId));
+            return err(QStringLiteral("no slice with id ") + QString::number(sliceId));
+        // Mirror the GUI path's Multi-Flex gate (MainWindow::automationTune):
+        // a headless caller must not drive another client's slice either.
+        if (!m_radioModel->sliceMayBelongToUs(sliceId))
+            return err(QStringLiteral("refused: slice ") + QString::number(sliceId)
+                       + QStringLiteral(" belongs to another client"));
     } else {
         for (SliceModel* c : m_radioModel->slices())
             if (c->isActive()) { s = c; break; }

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -262,7 +262,8 @@ public:
     {
         m_sliceCenterLockHandler = std::move(handler);
     }
-    void setTuneHandler(std::function<QJsonObject(double)> handler)
+    // (mhz, sliceId) — sliceId -1 targets the active slice.
+    void setTuneHandler(std::function<QJsonObject(double, int)> handler)
     {
         m_tuneHandler = std::move(handler);
     }
@@ -497,7 +498,7 @@ private:
     // Disconnected-only GPS status fixtures for the 6000-series
     // hemisphere/minutes format and 8000-series decimal-degree format.
     QJsonObject doGps(const QString& action, const QString& format);
-    QJsonObject doTune(const QString& value);
+    QJsonObject doTune(const QString& value, const QString& id);
     // Semantic transmitter keying (#3646 fidelity): `key ptt on|off` / `key mox`
     // route to RadioModel::setTransmit — the exact calls the space-bar PTT filter
     // and the mox_toggle shortcut make, but reachable headlessly. Keying is gated
@@ -575,7 +576,7 @@ private:
     QPointer<QObject> m_connectionDialogHost;    // MainWindow show/hide invokables
     std::function<QJsonObject(const QString&)> m_sliceReceiveSourceHandler;
     std::function<QJsonObject(int, bool)> m_sliceCenterLockHandler;
-    std::function<QJsonObject(double)> m_tuneHandler;
+    std::function<QJsonObject(double, int)> m_tuneHandler;
     std::function<QJsonObject()> m_receiveSyncSnapshotHandler;
     std::function<QJsonObject()> m_kiwiSdrSnapshotHandler;
     std::function<QJsonObject()> m_txTimerSnapshotHandler;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6029,12 +6029,25 @@ void MainWindow::applyTuneRequest(SliceModel* slice, double mhz,
     logTunePolicyDecision(source, intent, oldFreqMhz, mhz, result);
 }
 
-QJsonObject MainWindow::automationTune(double mhz)
+QJsonObject MainWindow::automationTune(double mhz, int sliceId)
 {
-    SliceModel* slice = activeSlice();
+    // sliceId -1 = active slice (the original verb shape). A named slice is
+    // resolved directly so bridge scripts don't need the racy select → tune →
+    // restore flap to drive a non-active slice.
+    SliceModel* slice = (sliceId >= 0) ? m_radioModel.slice(sliceId)
+                                       : activeSlice();
     if (!slice) {
         return QJsonObject{{QStringLiteral("ok"), false},
-                           {QStringLiteral("error"), QStringLiteral("no slice to tune")}};
+                           {QStringLiteral("error"),
+                            sliceId >= 0
+                                ? QStringLiteral("no slice with id %1").arg(sliceId)
+                                : QStringLiteral("no slice to tune")}};
+    }
+    if (sliceId >= 0 && !m_radioModel.sliceMayBelongToUs(sliceId)) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("refused: slice %1 belongs to another client").arg(sliceId)}};
     }
     if (slice->isLocked()) {
         return QJsonObject{

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -209,7 +209,7 @@ public:
     Q_INVOKABLE int fireShortcutAction(const QString& id, bool allowTx);
     QJsonObject automationSetSliceReceiveSource(const QString& arg);
     QJsonObject automationSetCenterLock(int sliceId, bool enabled);
-    QJsonObject automationTune(double mhz);
+    QJsonObject automationTune(double mhz, int sliceId = -1);
     QJsonObject automationReceiveSyncSnapshot() const;
     QJsonObject automationKiwiSdrSnapshot() const;
     // Status-bar TX-timer state for the bridge `get txtimer` verb.

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1627,7 +1627,7 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
     m_automation->setSliceCenterLockHandler(
         [this](int sliceId, bool enabled) { return automationSetCenterLock(sliceId, enabled); });
     m_automation->setTuneHandler(
-        [this](double mhz) { return automationTune(mhz); });
+        [this](double mhz, int sliceId) { return automationTune(mhz, sliceId); });
     m_automation->setReceiveSyncSnapshotHandler(
         [this]() { return automationReceiveSyncSnapshot(); });
     m_automation->setKiwiSdrSnapshotHandler(

--- a/tests/automation_json_id_test.cpp
+++ b/tests/automation_json_id_test.cpp
@@ -1,0 +1,159 @@
+#include "TestSettingsProfile.h"
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "core/AutomationServer.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QTimer>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+class BridgeClient
+{
+public:
+    bool connectToServer(const QString& serverName)
+    {
+        m_socket.connectToServer(serverName);
+        return m_socket.waitForConnected(1000);
+    }
+
+    QJsonObject request(const QJsonObject& request)
+    {
+        QByteArray payload = QJsonDocument(request).toJson(QJsonDocument::Compact);
+        payload.append('\n');
+
+        QEventLoop loop;
+        QTimer timeout;
+        timeout.setSingleShot(true);
+        QObject::connect(&m_socket, &QLocalSocket::readyRead,
+                         &loop, &QEventLoop::quit);
+        QObject::connect(&timeout, &QTimer::timeout,
+                         &loop, &QEventLoop::quit);
+
+        m_socket.write(payload);
+        m_socket.flush();
+        timeout.start(1000);
+        if (!m_socket.canReadLine()) {
+            loop.exec();
+        }
+
+        if (!m_socket.canReadLine()) {
+            return {};
+        }
+        return QJsonDocument::fromJson(m_socket.readLine()).object();
+    }
+
+private:
+    QLocalSocket m_socket;
+};
+
+QJsonObject tuneRequest(const QJsonValue& id = QJsonValue::Undefined)
+{
+    QJsonObject request{
+        {QStringLiteral("cmd"), QStringLiteral("tune")},
+        {QStringLiteral("value"), QStringLiteral("14.225")},
+    };
+    if (!id.isUndefined()) {
+        request.insert(QStringLiteral("id"), id);
+    }
+    return request;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-automation-json-id-test"));
+    check(settingsProfile.isValid(), "isolated settings profile is available");
+
+    QCoreApplication app(argc, argv);
+    RadioModel radio;
+    AutomationServer server;
+    server.setRadioModel(&radio);
+
+    int handlerCalls = 0;
+    int capturedSliceId = -99;
+    server.setTuneHandler([&](double, int sliceId) {
+        ++handlerCalls;
+        capturedSliceId = sliceId;
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("sliceId"), sliceId},
+        };
+    });
+
+    const QString serverName = QStringLiteral("aether-json-id-test-%1")
+                                   .arg(QCoreApplication::applicationPid());
+    check(server.start(serverName), "automation server starts");
+
+    BridgeClient client;
+    check(client.connectToServer(serverName), "client connects to automation server");
+
+    auto expectAccepted = [&](const QJsonObject& request, int expectedSliceId,
+                              const char* description) {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response = client.request(request);
+        check(response.value(QStringLiteral("ok")).toBool()
+                  && handlerCalls == callsBefore + 1
+                  && capturedSliceId == expectedSliceId,
+              description);
+    };
+    auto expectRejected = [&](const QJsonObject& request, const QString& expectedError,
+                              const char* description) {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response = client.request(request);
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && response.value(QStringLiteral("error")).toString() == expectedError
+                  && handlerCalls == callsBefore,
+              description);
+    };
+
+    expectAccepted(tuneRequest(), -1, "omitted id keeps active-slice sentinel");
+    expectAccepted(tuneRequest(QStringLiteral("1")), 1,
+                   "string id reaches the requested slice");
+    expectAccepted(tuneRequest(1), 1,
+                   "integer JSON id reaches the requested slice");
+
+    const QString typeError = QStringLiteral("id must be a string or number");
+    expectRejected(tuneRequest(true), typeError,
+                   "boolean id is rejected instead of selecting the active slice");
+    expectRejected(tuneRequest(QJsonObject{{QStringLiteral("slice"), 1}}), typeError,
+                   "object id is rejected instead of selecting the active slice");
+    expectRejected(tuneRequest(QJsonArray{1}), typeError,
+                   "array id is rejected instead of selecting the active slice");
+    expectRejected(tuneRequest(QJsonValue::Null), typeError,
+                   "null id is rejected instead of selecting the active slice");
+
+    const QString integerError =
+        QStringLiteral("tune: sliceId must be a non-negative integer");
+    expectRejected(tuneRequest(1.5), integerError,
+                   "fractional numeric id is rejected");
+    expectRejected(tuneRequest(1.0000001), integerError,
+                   "near-integer numeric id is not rounded up to a slice");
+    expectRejected(tuneRequest(0.9999999), integerError,
+                   "near-integer numeric id is not rounded down to a slice");
+
+    server.stop();
+    return failures == 0 ? 0 : 1;
+}

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -321,10 +321,13 @@ TOOLS = [
     },
     {
         "name": "tune",
-        "description": ("Set the active slice frequency, in MHz "
-                        "(e.g. 14.074). Confirm with get_state model=slice."),
+        "description": ("Set a slice frequency, in MHz (e.g. 14.074). "
+                        "Tunes the active slice unless sliceId targets a "
+                        "specific slice. Confirm with get_state model=slice."),
         "inputSchema": {"type": "object", "properties": {
             "mhz": {"type": "string", "description": "frequency in MHz, e.g. '14.074'"},
+            "sliceId": {"type": "string",
+                        "description": "optional slice id; omit for the active slice"},
         }, "required": ["mhz"]},
     },
     {
@@ -674,8 +677,10 @@ def handle_tool(name, args):
         return text_result(bridge_request({"cmd": "floors"}))
 
     if name == "tune":
-        return text_result(bridge_request(
-            {"cmd": "tune", "value": str(args["mhz"])}))
+        req = {"cmd": "tune", "value": str(args["mhz"])}
+        if args.get("sliceId") not in (None, ""):
+            req["id"] = str(args["sliceId"])
+        return text_result(bridge_request(req))
 
     if name in ("slice", "record", "pan"):
         req = {"cmd": name, "action": args["action"]}

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -121,7 +121,13 @@ def test_field_mapping():
 
     r = run_tool("tune", {"mhz": "14.074"})[-1]
     check("tune → cmd=tune value(mhz)",
-          r.get("cmd") == "tune" and r.get("value") == "14.074", str(r))
+          r.get("cmd") == "tune" and r.get("value") == "14.074"
+          and "id" not in r, str(r))
+
+    r = run_tool("tune", {"mhz": "14.074", "sliceId": "1"})[-1]
+    check("tune → cmd=tune value(mhz)+id(sliceId)",
+          r.get("cmd") == "tune" and r.get("value") == "14.074"
+          and r.get("id") == "1", str(r))
 
     r = run_tool("slice", {"action": "select", "value": "3"})[-1]
     check("slice → cmd=slice action+value",


### PR DESCRIPTION
Fixes #4324.

`tune <mhz> [sliceId]` (JSON `id`, string or number) drives a specific slice through `MainWindow::automationTune` — same lock/SWR refusals, plus `refused: slice N belongs to another client` for Multi-Flex safety. No id keeps the active-slice behavior byte-for-byte, so existing scripts and `automation_probe.py` recipes are unaffected. Kills the `slice select` → `tune` → re-select race every external script had to work around (see `tools/aether_vfo_follow.py`'s `wait_sole_active` machinery in #4324).

- Registry help + regenerated verb table (`gen_bridge_docs.py --check` ok)
- Headless fallback path honors the id too
- JSON-numeric `id` normalized like `value` (a bare `.toString()` would silently coerce it to `""` and tune the wrong slice). Note: the normalization sits in the shared JSON fill, so it applies to **every** verb reading `id` (`pan message`, `shortcut`), not just `tune` — previously a JSON-numeric `id` on those silently became `""`, now it becomes the number string; string ids are unaffected.
- Review follow-up: the headless (`m_tuneHandler`-absent) fallback now mirrors the GUI path's `sliceMayBelongToUs` refusal and uses the same `no slice with id N` string, so the future aetherd-headless shape gets identical refusals
- MCP `tune` tool: optional `sliceId`; `test_aether_mcp.py` extended (2 new mapping checks)
- Observe-only mode still blocks `tune` entirely (not in `kSafe`)

**Verification run locally (macOS, Qt 6.9 brew):** full build green; `ctest -R "bridge_docs_check|aether_mcp_field_mapping"` green; `check_engine_boundary.py --strict` 0 blocking; validated live against a FLEX-8400 over the bridge — per-slice tunes, unknown/negative/foreign-id refusals, numeric-JSON id, and no-id back-compat all pass (transcript in #4291's implementation notes). Principle II.

De-risks bridge-based verification of the cross-panadapter VFO link (#4291); that PR is stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
