### PR TITLE
fix(panadapter): preserve Center Lock across band changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2712,6 +2712,12 @@ target_include_directories(kiwi_rebind_tracker_test PRIVATE src)
 target_link_libraries(kiwi_rebind_tracker_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_rebind_tracker_test COMMAND kiwi_rebind_tracker_test)
 
+# Center Lock band-recall re-bind policy — header-only, pure logic.
+add_executable(center_lock_rebind_tracker_test tests/center_lock_rebind_tracker_test.cpp)
+target_include_directories(center_lock_rebind_tracker_test PRIVATE src)
+target_link_libraries(center_lock_rebind_tracker_test PRIVATE Qt6::Core)
+add_test(NAME center_lock_rebind_tracker_test COMMAND center_lock_rebind_tracker_test)
+
 add_executable(declared_bands_test
     tests/declared_bands_test.cpp
     src/models/DeclaredBands.cpp

--- a/src/gui/CenterLockRebindTracker.h
+++ b/src/gui/CenterLockRebindTracker.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+#include <QVector>
+#include <QtGlobal>
+
+namespace AetherSDR {
+
+// Resolves Center Lock after the intentional slice teardown/rebuild performed
+// by a FLEX band-stack recall. MainWindow owns persistence, the grace timer,
+// and UI side effects; this class owns the generation-safe identity policy.
+class CenterLockRebindTracker {
+public:
+    struct SliceIdentity {
+        QString panId;
+        int sliceId{-1};
+        QString letter;
+        bool owned{false};
+    };
+
+    struct Resolution {
+        enum class Kind {
+            NoAction,
+            Restore,
+            ReleaseMissing,
+            ReleaseAmbiguous,
+        };
+
+        Kind kind{Kind::NoAction};
+        int sliceId{-1};
+    };
+
+    quint64 noteBandRecall(const QString& panId, int sliceId,
+                           const QString& letter, int ownedSliceCount)
+    {
+        if (panId.isEmpty()) {
+            return 0;
+        }
+
+        const quint64 generation = ++m_generation;
+        if (sliceId >= 0) {
+            PendingRecall pending;
+            pending.sliceId = sliceId;
+            pending.letter = letter.trimmed().toUpper();
+            pending.ownedSliceCount = qMax(1, ownedSliceCount);
+            pending.generation = generation;
+            m_pending.insert(panId, pending);
+            return generation;
+        }
+
+        // A second band selection can arrive while the first recall has the
+        // locked slice temporarily absent. Carry the original identity into a
+        // new generation so the older timer cannot resolve the newer recall.
+        auto it = m_pending.find(panId);
+        if (it == m_pending.end()) {
+            return 0;
+        }
+        it->generation = generation;
+        return generation;
+    }
+
+    bool onSliceRemoved(const QString& panId, int sliceId)
+    {
+        auto it = m_pending.find(panId);
+        if (it == m_pending.end() || it->sliceId != sliceId) {
+            return false;
+        }
+
+        it->removed = true;
+        return true;
+    }
+
+    Resolution resolveAfterGrace(const QString& panId, quint64 generation,
+                                 const QVector<SliceIdentity>& slices)
+    {
+        auto it = m_pending.find(panId);
+        if (it == m_pending.end() || it->generation != generation) {
+            return {};
+        }
+
+        const PendingRecall pending = *it;
+        m_pending.erase(it);
+        if (!pending.removed) {
+            return {};
+        }
+
+        QVector<SliceIdentity> candidates;
+        for (const SliceIdentity& slice : slices) {
+            if (slice.owned && slice.panId == panId && slice.sliceId >= 0) {
+                candidates.append(slice);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return {Resolution::Kind::ReleaseMissing, -1};
+        }
+
+        // The common one-slice case has an unambiguous user-visible receiver
+        // even when FLEX assigns a different numeric id or per-client letter.
+        if (pending.ownedSliceCount == 1 && candidates.size() == 1) {
+            return {Resolution::Kind::Restore, candidates.first().sliceId};
+        }
+
+        // If either topology contains multiple slices, id or letter alone can
+        // be recycled during the rebuild. Require both to identify one result.
+        int matchingSliceId = -1;
+        int matchCount = 0;
+        for (const SliceIdentity& candidate : candidates) {
+            if (candidate.sliceId == pending.sliceId
+                && candidate.letter.trimmed().compare(
+                       pending.letter, Qt::CaseInsensitive) == 0) {
+                matchingSliceId = candidate.sliceId;
+                ++matchCount;
+            }
+        }
+        if (matchCount == 1) {
+            return {Resolution::Kind::Restore, matchingSliceId};
+        }
+
+        return {Resolution::Kind::ReleaseAmbiguous, -1};
+    }
+
+    bool cancel(const QString& panId)
+    {
+        return m_pending.remove(panId) > 0;
+    }
+
+    bool hasPending(const QString& panId) const
+    {
+        return m_pending.contains(panId);
+    }
+
+private:
+    struct PendingRecall {
+        int sliceId{-1};
+        QString letter;
+        int ownedSliceCount{0};
+        quint64 generation{0};
+        bool removed{false};
+    };
+
+    QHash<QString, PendingRecall> m_pending;
+    quint64 m_generation{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5723,6 +5723,7 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
                 emit bandStackRestoreStarting(slicePanId);
                 clearSwrSweepForBandChange(-1, slicePanId, memoryBand);
                 m_bandSettings.setCurrentBand(memoryBand);
+                noteBandRecallForPan(slicePanId);
                 // #4142: during the profile-load hold a bare sendCommand()
                 // band= write is silently destroyed and the recall lands on
                 // the wrong band stack. requestPanBand defers it instead.
@@ -5965,6 +5966,7 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
     emit bandStackRestoreStarting(slice->panId());
     clearSwrSweepForBandChange(-1, slice->panId(), targetBand);
     m_bandSettings.setCurrentBand(targetBand);
+    noteBandRecallForPan(slice->panId());
     // #4142: the cross-band typed tune is the reported bug's worst variant —
     // the `slice tune` half survives the hold while a bare sendCommand()
     // band= write is silently destroyed, so the slice lands outside the pan.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -16,6 +16,7 @@
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
 #include "core/ReceivePresentationSync.h"
+#include "gui/CenterLockRebindTracker.h"
 #include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
 #include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
@@ -496,6 +497,7 @@ private:
         KiwiSdrUiSyncPanadapterStates = 0x08,
     };
     void scheduleKiwiSdrUiSync(int flags);
+    void noteBandRecallForPan(const QString& panId);
     void wirePanadapter(PanadapterApplet* applet);
     void wirePanDisplayStatus(PanadapterApplet* applet, PanadapterModel* pan);
     void reassertUnmutedSliceAudioForPan(const QString& panId);
@@ -997,12 +999,12 @@ private:
     QMetaObject::Connection m_kiwiSdrAudioMuteConnection;
     QHash<int, bool> m_kiwiSdrVirtualPreviousMute;
     QSet<QString>    m_kiwiSdrFlexDisplayPans;
-    // Retains a KiwiSDR replacement across the slice remove->re-add a FLEX
-    // band-stack recall performs (band_persistence drops+re-creates the slice
-    // with the same id at the new band). The tracker is the pure policy; the
-    // grace window itself is a QTimer::singleShot in onSliceRemoved. (#4158)
+    // Retain client-side receiver state across the slice teardown/rebuild a
+    // FLEX band-stack recall performs. The trackers are pure lifecycle policy;
+    // MainWindow owns their side effects and shared grace window.
     KiwiRebindTracker    m_kiwiRebind;
-    static constexpr int kKiwiSdrRebindGraceMs = 1500;
+    CenterLockRebindTracker m_centerLockRebind;
+    static constexpr int kBandRecallRecreateGraceMs = 1500;
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
     ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;
@@ -1353,6 +1355,8 @@ private:
     void saveCenterLockSettings() const;
     void persistCenterLockForSlice(const SliceModel* slice);
     void restoreCenterLockForPan(const QString& panId);
+    void showCenterLockReleaseNotification(const QString& panId,
+                                           const QString& detail);
     void setCenterLockForSlice(SliceModel* slice, bool on);
     void setCenterLockForPan(const QString& panId, int sliceId, bool on,
                              bool persist = true);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1004,6 +1004,11 @@ private:
     // MainWindow owns their side effects and shared grace window.
     KiwiRebindTracker    m_kiwiRebind;
     CenterLockRebindTracker m_centerLockRebind;
+    // Per-pan band-recall generation: makes the shared grace timer's Kiwi
+    // marker clear generation-safe against overlapping recalls, the same way
+    // the Center Lock tracker guards its own resolution.
+    QHash<QString, quint64> m_bandRecallGenerationByPan;
+    quint64              m_bandRecallGeneration{0};
     static constexpr int kBandRecallRecreateGraceMs = 1500;
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -200,6 +200,13 @@ void MainWindow::noteBandRecallForPan(const QString& panId)
     // command. Restoration is deferred until the full grace window elapses so
     // slice status arrival order can never choose the receiver.
     m_kiwiRebind.noteBandRecall(panId);
+    // Stamp this recall so the grace timer below only clears the Kiwi marker if
+    // it is still the latest recall for this pan. Without it, an overlapping
+    // recall (band button + memory spot / tune, now all routed here) would have
+    // the first timer clear the marker mid-rebuild of the second — the Kiwi
+    // half would lose the generation-safety the Center Lock half already has.
+    const quint64 bandRecallGeneration = ++m_bandRecallGeneration;
+    m_bandRecallGenerationByPan.insert(panId, bandRecallGeneration);
     const int lockedSliceId = centerLockSliceForPan(panId);
     SliceModel* lockedSlice = m_radioModel.slice(lockedSliceId);
     if (lockedSlice
@@ -222,8 +229,14 @@ void MainWindow::noteBandRecallForPan(const QString& panId)
         lockedSlice ? lockedSlice->letter() : QString(),
         ownedSliceCount);
     QTimer::singleShot(kBandRecallRecreateGraceMs, this,
-                       [this, panId, centerLockGeneration]() {
-        m_kiwiRebind.clearBandRecall(panId);
+                       [this, panId, centerLockGeneration, bandRecallGeneration]() {
+        // Only the latest recall for this pan clears the Kiwi band-recall
+        // marker; a superseding recall now owns the window, so an older timer
+        // must not clear it out from under the in-flight rebuild.
+        if (m_bandRecallGenerationByPan.value(panId) == bandRecallGeneration) {
+            m_kiwiRebind.clearBandRecall(panId);
+            m_bandRecallGenerationByPan.remove(panId);
+        }
         if (centerLockGeneration == 0) {
             return;
         }
@@ -254,26 +267,25 @@ void MainWindow::noteBandRecallForPan(const QString& panId)
             SliceModel* replacement = m_radioModel.slice(resolution.sliceId);
             if (replacement && replacement->panId() == panId
                 && m_radioModel.sliceMayBelongToUs(replacement->sliceId())) {
-                setCenterLockForPan(panId, replacement->sliceId(), true, false);
+                // persist=true self-persists and cancels any pending recall (a
+                // no-op here — resolveAfterGrace already consumed it).
+                setCenterLockForPan(panId, replacement->sliceId(), true, true);
                 if (centerLockActiveForSlice(replacement)) {
-                    persistCenterLockForSlice(replacement);
                     return;
                 }
             }
+            // Identified a slice but couldn't re-lock it: fall through and
+            // report it as missing (not ambiguous — the tracker WAS sure).
         }
 
         clearCenterLockForPan(panId, true);
-        if (resolution.kind
-            == CenterLockRebindTracker::Resolution::Kind::ReleaseMissing) {
-            showCenterLockReleaseNotification(
-                panId,
-                tr("The band change did not restore the locked slice."));
-        } else {
-            showCenterLockReleaseNotification(
-                panId,
-                tr("The band change restored a different slice layout, so "
-                   "the locked slice could not be identified safely."));
-        }
+        showCenterLockReleaseNotification(
+            panId,
+            resolution.kind
+                    == CenterLockRebindTracker::Resolution::Kind::ReleaseAmbiguous
+                ? tr("The band change restored a different slice layout, so "
+                     "the locked slice could not be identified safely.")
+                : tr("The band change did not restore the locked slice."));
     });
 }
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -26,6 +26,7 @@
 #include "DbmRangeTransition.h"
 #include "MainWindowHelpers.h"
 #include "PanadapterApplet.h"
+#include "PanadapterMessageOverlay.h"
 #include "PanadapterStack.h"
 #include "RadioSetupDialog.h"
 #include "GpsLocationDialog.h"
@@ -188,6 +189,115 @@ void MainWindow::showGpsLocationDialog()
     showOrRaisePersistent(m_gpsLocationDialog, &m_radioModel);
 }
 
+void MainWindow::noteBandRecallForPan(const QString& panId)
+{
+    if (panId.isEmpty()) {
+        return;
+    }
+
+    // Flex band persistence destroys and rebuilds this pan's slices. Snapshot
+    // the locked receiver and our pre-recall topology before sending the band
+    // command. Restoration is deferred until the full grace window elapses so
+    // slice status arrival order can never choose the receiver.
+    m_kiwiRebind.noteBandRecall(panId);
+    const int lockedSliceId = centerLockSliceForPan(panId);
+    SliceModel* lockedSlice = m_radioModel.slice(lockedSliceId);
+    if (lockedSlice
+        && (lockedSlice->panId() != panId
+            || !m_radioModel.sliceMayBelongToUs(lockedSliceId))) {
+        lockedSlice = nullptr;
+    }
+
+    int ownedSliceCount = 0;
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (slice && slice->panId() == panId
+            && m_radioModel.sliceMayBelongToUs(slice->sliceId())) {
+            ++ownedSliceCount;
+        }
+    }
+
+    const quint64 centerLockGeneration = m_centerLockRebind.noteBandRecall(
+        panId,
+        lockedSlice ? lockedSlice->sliceId() : -1,
+        lockedSlice ? lockedSlice->letter() : QString(),
+        ownedSliceCount);
+    QTimer::singleShot(kBandRecallRecreateGraceMs, this,
+                       [this, panId, centerLockGeneration]() {
+        m_kiwiRebind.clearBandRecall(panId);
+        if (centerLockGeneration == 0) {
+            return;
+        }
+
+        QVector<CenterLockRebindTracker::SliceIdentity> sliceIdentities;
+        for (SliceModel* slice : m_radioModel.slices()) {
+            if (!slice) {
+                continue;
+            }
+            sliceIdentities.append({
+                slice->panId(),
+                slice->sliceId(),
+                slice->letter(),
+                m_radioModel.sliceMayBelongToUs(slice->sliceId()),
+            });
+        }
+
+        const CenterLockRebindTracker::Resolution resolution =
+            m_centerLockRebind.resolveAfterGrace(
+                panId, centerLockGeneration, sliceIdentities);
+        if (resolution.kind
+            == CenterLockRebindTracker::Resolution::Kind::NoAction) {
+            return;
+        }
+
+        if (resolution.kind
+            == CenterLockRebindTracker::Resolution::Kind::Restore) {
+            SliceModel* replacement = m_radioModel.slice(resolution.sliceId);
+            if (replacement && replacement->panId() == panId
+                && m_radioModel.sliceMayBelongToUs(replacement->sliceId())) {
+                setCenterLockForPan(panId, replacement->sliceId(), true, false);
+                if (centerLockActiveForSlice(replacement)) {
+                    persistCenterLockForSlice(replacement);
+                    return;
+                }
+            }
+        }
+
+        clearCenterLockForPan(panId, true);
+        if (resolution.kind
+            == CenterLockRebindTracker::Resolution::Kind::ReleaseMissing) {
+            showCenterLockReleaseNotification(
+                panId,
+                tr("The band change did not restore the locked slice."));
+        } else {
+            showCenterLockReleaseNotification(
+                panId,
+                tr("The band change restored a different slice layout, so "
+                   "the locked slice could not be identified safely."));
+        }
+    });
+}
+
+void MainWindow::showCenterLockReleaseNotification(const QString& panId,
+                                                    const QString& detail)
+{
+    if (!m_panStack) {
+        return;
+    }
+    SpectrumWidget* sw = m_panStack->spectrum(panId);
+    if (!sw) {
+        return;
+    }
+
+    PanadapterOverlayMessage message;
+    message.id = QStringLiteral("center-lock.band-recall-release");
+    message.title = tr("Center Lock released");
+    message.detail = detail;
+    message.timeoutMs = 5000;
+    message.dismissible = true;
+    message.tone = PanadapterOverlayMessageTone::Warning;
+    sw->upsertOverlayMessage(std::move(message));
+}
+
 int MainWindow::centerLockSliceForPan(const QString& panId) const
 {
     return m_centerLockSliceByPan.value(panId, -1);
@@ -325,6 +435,13 @@ void MainWindow::restoreCenterLockForPan(const QString& panId)
         return;
     }
 
+    // A band recall owns restoration until its bounded rebuild window ends.
+    // Falling through to the ordinary persisted-letter path on each add would
+    // let slice arrival order transfer Center Lock to the wrong receiver.
+    if (m_centerLockRebind.hasPending(panId)) {
+        return;
+    }
+
     const QString radioKey = centerLockRadioKey();
     SpectrumWidget* sw = m_panStack->spectrum(panId);
     if (radioKey.isEmpty() || !sw) {
@@ -367,8 +484,19 @@ void MainWindow::setCenterLockForPan(const QString& panId, int sliceId, bool on,
         return;
     }
 
+    bool canceledPendingRecall = false;
+    if (persist) {
+        // A persisted setter call is explicit operator intent. It supersedes
+        // any automatic restoration still waiting on a band recall.
+        canceledPendingRecall = m_centerLockRebind.cancel(panId);
+    }
+
     if (!on) {
-        if (sliceId < 0 || centerLockSliceForPan(panId) == sliceId) {
+        // The live binding is deliberately absent between the recalled slice's
+        // removal and its replacement. An explicit off during that window must
+        // still clear the saved intent, or a later add/restart can re-lock it.
+        if (canceledPendingRecall || sliceId < 0
+            || centerLockSliceForPan(panId) == sliceId) {
             clearCenterLockForPan(panId, persist);
         }
         return;
@@ -392,6 +520,10 @@ void MainWindow::clearCenterLockForPan(const QString& panId, bool clearPersisted
 {
     if (panId.isEmpty()) {
         return;
+    }
+
+    if (clearPersistedIntent) {
+        m_centerLockRebind.cancel(panId);
     }
 
     if (clearPersistedIntent && m_panStack) {
@@ -1554,10 +1686,13 @@ void MainWindow::onSliceRemoved(int id)
 
     qDebug() << "MainWindow: slice removed" << id;
 
-    // Center Lock (#3854 review): a LIVE removal clears the persisted letter
-    // intent too — Flex recycles letters lowest-free, so a dormant intent
-    // would silently re-lock a later, unrelated slice. Two guards ride on
-    // m_radioModel.slice(id):
+    // Center Lock (#3854 review): a LIVE removal normally clears the persisted
+    // letter intent too — Flex recycles letters lowest-free, so a dormant
+    // intent would silently re-lock a later, unrelated slice. A band-stack
+    // recall is the exception: band_persistence deliberately rebuilds the
+    // pan's slices, and the positive per-pan recall marker keeps intent alive
+    // until the bounded window can resolve the complete topology. Two guards
+    // ride on m_radioModel.slice(id):
     //  - the stale-slice prune after reconnect emits sliceRemoved(oldId)
     //    whose id collides with the NEW session's slices (slice 0 is always
     //    0). Live removals emit AFTER the slice leaves the model, so a
@@ -1566,7 +1701,15 @@ void MainWindow::onSliceRemoved(int id)
     //  - disconnect teardown never emits sliceRemoved, so reconnect/restart
     //    intent survives — that is the restore feature.
     if (!m_radioModel.slice(id)) {
-        clearCenterLockForSlice(id, /*clearPersistedIntent=*/true);
+        bool preservePersistedIntent = false;
+        for (auto it = m_centerLockSliceByPan.cbegin();
+             it != m_centerLockSliceByPan.cend(); ++it) {
+            if (it.value() == id && m_centerLockRebind.onSliceRemoved(it.key(), id)) {
+                preservePersistedIntent = true;
+                break;
+            }
+        }
+        clearCenterLockForSlice(id, /*clearPersistedIntent=*/!preservePersistedIntent);
     }
     m_centerLockTuneHoldBySlice.remove(id);
 
@@ -1595,7 +1738,7 @@ void MainWindow::onSliceRemoved(int id)
         // intact during the window so a re-bind is seamless. If no recreation
         // re-binds it, the generation-safe expiry finalizes the teardown.
         const quint64 generation = rebindAction.generation;
-        QTimer::singleShot(kKiwiSdrRebindGraceMs, this, [this, id, generation]() {
+        QTimer::singleShot(kBandRecallRecreateGraceMs, this, [this, id, generation]() {
             if (!m_kiwiRebind.onGraceExpired(id, generation)) {
                 return;
             }
@@ -3824,15 +3967,12 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             // a KiwiSDR replacement onto the recreated slice instead of reverting
             // to Flex (#4158). One-shot: consumed by the re-bind, or expired here
             // so a recall on a non-Kiwi slice can't leave the marker stale.
-            m_kiwiRebind.noteBandRecall(applet->panId());
-            QTimer::singleShot(kKiwiSdrRebindGraceMs, this,
-                               [this, panId = applet->panId()]() {
-                m_kiwiRebind.clearBandRecall(panId);
-            });
+            noteBandRecallForPan(applet->panId());
             // #4142: during the profile-load hold a bare sendCommand() band=
             // write is silently destroyed. requestPanBand defers it instead.
-            // Outside a hold it dispatches inline, so the #4158 grace window
-            // above is unchanged on the normal user-initiated band-recall path.
+            // Outside a hold it dispatches inline, so the #4158/Center Lock
+            // grace window inside noteBandRecallForPan is unchanged on the
+            // normal user-initiated band-recall path.
             m_radioModel.requestPanBand(applet->panId(), stackKey);
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
                 reassertUnmutedSliceAudioForPan(panId);

--- a/tests/center_lock_rebind_tracker_test.cpp
+++ b/tests/center_lock_rebind_tracker_test.cpp
@@ -1,0 +1,203 @@
+// Unit tests for the generation-safe policy that restores Center Lock after a
+// FLEX band recall rebuilds the slices on a panadapter.
+
+#include "gui/CenterLockRebindTracker.h"
+
+#include <QString>
+#include <QVector>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+using Kind = CenterLockRebindTracker::Resolution::Kind;
+using SliceIdentity = CenterLockRebindTracker::SliceIdentity;
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+const QString kPan = QStringLiteral("0x40000000");
+const QString kOtherPan = QStringLiteral("0x41000000");
+
+SliceIdentity owned(const QString& panId, int sliceId, const QString& letter)
+{
+    return {panId, sliceId, letter, true};
+}
+
+SliceIdentity foreign(const QString& panId, int sliceId, const QString& letter)
+{
+    return {panId, sliceId, letter, false};
+}
+
+}  // namespace
+
+int main()
+{
+    // The common one-slice workflow follows the sole recreated receiver even
+    // when FLEX changes both of its transient identifiers.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        report("single: locked removal preserves the recall",
+               generation > 0 && tracker.onSliceRemoved(kPan, 0));
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {owned(kPan, 3, "C")});
+        report("single: sole recreated slice restores despite new identity",
+               result.kind == Kind::Restore && result.sliceId == 3
+                   && !tracker.hasPending(kPan));
+    }
+
+    // Unrelated removals cannot borrow another receiver's recall claim.
+    {
+        CenterLockRebindTracker tracker;
+        tracker.noteBandRecall(kPan, 0, "A", 1);
+        report("identity: another slice does not preserve intent",
+               !tracker.onSliceRemoved(kPan, 1));
+        report("identity: another pan does not preserve intent",
+               !tracker.onSliceRemoved(kOtherPan, 0));
+    }
+
+    // Multi-slice restoration requires numeric id AND radio-provided letter.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 1, "B", 2);
+        tracker.onSliceRemoved(kPan, 1);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation,
+            {owned(kPan, 0, "A"), owned(kPan, 1, "B")});
+        report("multiple: exact id and letter restore the locked slice",
+               result.kind == Kind::Restore && result.sliceId == 1);
+    }
+
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 1, "B", 2);
+        tracker.onSliceRemoved(kPan, 1);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation,
+            {owned(kPan, 0, "B"), owned(kPan, 1, "A")});
+        report("multiple: id-only and letter-only matches are ambiguous",
+               result.kind == Kind::ReleaseAmbiguous && result.sliceId < 0);
+    }
+
+    // A changed topology is still safe when its sole candidate retains both
+    // identifiers; otherwise Center Lock must not transfer to it.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 1, "B", 2);
+        tracker.onSliceRemoved(kPan, 1);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {owned(kPan, 1, "B")});
+        report("topology: multiple-to-one exact identity restores",
+               result.kind == Kind::Restore && result.sliceId == 1);
+    }
+
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 1, "B", 2);
+        tracker.onSliceRemoved(kPan, 1);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {owned(kPan, 1, "A")});
+        report("topology: multiple-to-one mismatch releases safely",
+               result.kind == Kind::ReleaseAmbiguous);
+    }
+
+    // Foreign and cross-pan slices never participate in the result. The one
+    // owned receiver remains unambiguous even when another client has slices.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        tracker.onSliceRemoved(kPan, 0);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation,
+            {foreign(kPan, 1, "A"), owned(kOtherPan, 2, "A"),
+             owned(kPan, 4, "D")});
+        report("Multi-Flex: foreign and other-pan slices are ignored",
+               result.kind == Kind::Restore && result.sliceId == 4);
+    }
+
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        tracker.onSliceRemoved(kPan, 0);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {foreign(kPan, 0, "A")});
+        report("Multi-Flex: a foreign lookalike is not a replacement",
+               result.kind == Kind::ReleaseMissing);
+    }
+
+    // No recreated owned slice clears dormant intent instead of allowing a
+    // future unrelated receiver to inherit it.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        tracker.onSliceRemoved(kPan, 0);
+        const auto result = tracker.resolveAfterGrace(kPan, generation, {});
+        report("missing replacement: release is explicit and one-shot",
+               result.kind == Kind::ReleaseMissing
+                   && !tracker.hasPending(kPan));
+    }
+
+    // A rejected/no-op band command produces no removal, so the still-live
+    // Center Lock is left alone when the window ends.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {owned(kPan, 0, "A")});
+        report("no removal: live lock remains unchanged",
+               result.kind == Kind::NoAction && !tracker.hasPending(kPan));
+    }
+
+    // A rapid second band selection carries the absent locked identity into a
+    // new generation; the older timer cannot consume or release it.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 first = tracker.noteBandRecall(kPan, 0, "A", 1);
+        tracker.onSliceRemoved(kPan, 0);
+        const quint64 second = tracker.noteBandRecall(kPan, -1, {}, 0);
+        const auto stale = tracker.resolveAfterGrace(
+            kPan, first, {owned(kPan, 2, "C")});
+        report("rapid recall: stale generation cannot resolve the new claim",
+               first != second && stale.kind == Kind::NoAction
+                   && tracker.hasPending(kPan));
+        const auto current = tracker.resolveAfterGrace(
+            kPan, second, {owned(kPan, 2, "C")});
+        report("rapid recall: newest generation restores the sole slice",
+               current.kind == Kind::Restore && current.sliceId == 2);
+    }
+
+    // Explicit user intent always outranks an automatic rebind.
+    {
+        CenterLockRebindTracker tracker;
+        const quint64 generation = tracker.noteBandRecall(kPan, 0, "A", 1);
+        tracker.onSliceRemoved(kPan, 0);
+        const bool canceledPendingRecall = tracker.cancel(kPan);
+        const auto result = tracker.resolveAfterGrace(
+            kPan, generation, {owned(kPan, 0, "A")});
+        report("user action: cancellation reports superseded recall intent",
+               canceledPendingRecall);
+        report("user action: cancellation makes the timer inert",
+               result.kind == Kind::NoAction && !tracker.hasPending(kPan)
+                   && !tracker.cancel(kPan));
+    }
+
+    if (g_failed == 0) {
+        std::printf("\nAll %d Center Lock rebind tracker tests passed.\n", g_total);
+        return 0;
+    }
+    std::printf("\n%d of %d Center Lock rebind tracker tests failed.\n",
+                g_failed, g_total);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Preserve the per-pan **Center Lock** setting when a FLEX band change destroys and recreates the locked slice.

FLEX band persistence does not simply retune the existing slice: it can remove and recreate the panadapter's slices, potentially with different transient IDs or letters. Previously, the normal slice-removal cleanup interpreted this as a permanent removal and released Center Lock.

This adds a generation-safe band-recall tracker that snapshots the locked receiver and the owned slice topology before the band command, waits for slice recreation to settle, and then either restores the lock safely or releases it with an explanation.

The behavior applies to band changes initiated through the panadapter band menu, memory-recall band preselection, and direct-tune band preselection.

### Scenarios

| Scenario | Result |
|---|---|
| One owned slice before and one owned slice after | Transfer Center Lock to the sole recreated slice, even if its transient ID or letter changed. |
| Multiple slices exist before or after the change | Restore only when exactly one owned slice matches both the original numeric ID and reported letter. |
| No owned replacement slice appears | Release Center Lock and report that the locked slice was not restored. |
| The restored slice layout is ambiguous | Release Center Lock instead of guessing which receiver should inherit it. |
| Other clients have slices on the panadapter | Ignore foreign slices when resolving the replacement. |
| Slices exist on other panadapters | Ignore them; recall tracking and Center Lock remain scoped to the affected panadapter. |
| Band changes are selected rapidly | A newer recall generation supersedes older timers, preventing stale callbacks from restoring or releasing the wrong lock. |
| The band command is rejected or causes no slice removal | Leave the existing live Center Lock unchanged. |
| The user changes or disables Center Lock during reconstruction | Cancel automatic restoration. An explicit disable also clears saved intent so the lock cannot return on a later slice event or restart. |

When the lock must be released, the affected waterfall displays the new notification overlay for five seconds:

- **Center Lock released**
- Missing replacement: “The band change did not restore the locked slice.”
- Ambiguous replacement: “The band change restored a different slice layout, so the locked slice could not be identified safely.”

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** The radio-reported post-recall slice topology determines whether the client-side lock can be restored safely.

**Principle XIII — The Operator Outranks Every Agent.** Explicit user changes, especially turning Center Lock off during reconstruction, supersede pending automatic restoration.

## Test plan

- [x] Full local AetherSDR build passes
- [x] Center Lock and Kiwi rebind CTest targets pass
- [x] All 16 Center Lock policy assertions pass
- [x] Engine-boundary strict check passes with zero blockers
- [x] Accessibility check reports no new findings
- [x] `git diff --check` passes
- [x] Verified on a FLEX-6700 running firmware 4.2.18:
  - One-slice band change retained Center Lock
  - Ambiguous multi-slice recall released the lock safely
  - Release notification appeared on the waterfall and auto-dismissed after five seconds
  - Radio remained out of transmit
- [ ] Existing tests pass in CI

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — the existing nested Center Lock object remains the sole persistence owner (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] No meter UI changed
- [x] No additional documentation is needed for this narrowly scoped bug fix
- [x] No security-sensitive behavior changed
