### PR TITLE
feat(core): AetherClock — NIST time-signal decode engine + model (WWV/WWVH/WWVB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,8 @@ set(CORE_SOURCES
     src/core/TimeFrameVoter.cpp
     src/core/WwvDecoder.cpp
     src/core/WwvbDecoder.cpp
+    src/core/AetherClockEngine.cpp
+    src/core/AetherClockSettings.cpp
     src/core/PacketLossConcealment.cpp
     src/core/PerfTelemetry.cpp
     src/core/RigctlProtocol.cpp
@@ -704,6 +706,7 @@ set(MODEL_SOURCES
     src/models/BandPlanManager.cpp
     src/models/XvtrPolicy.cpp
     src/models/AntennaGeniusModel.cpp
+    src/models/AetherClockModel.cpp
 )
 
 # Vendored QGeoView (LGPL-3.0) — slippy-map widget for the common
@@ -3863,6 +3866,18 @@ target_include_directories(wwvb_decoder_test PRIVATE src)
 target_link_libraries(wwvb_decoder_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(wwvb_decoder_test PROPERTIES AUTOMOC ON)
 add_test(NAME wwvb_decoder_test COMMAND wwvb_decoder_test)
+
+add_executable(aetherclock_engine_test tests/aetherclock_engine_test.cpp)
+target_include_directories(aetherclock_engine_test PRIVATE src)
+target_link_libraries(aetherclock_engine_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherclock_engine_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherclock_engine_test COMMAND aetherclock_engine_test)
+
+add_executable(aetherclock_model_test tests/aetherclock_model_test.cpp)
+target_include_directories(aetherclock_model_test PRIVATE src)
+target_link_libraries(aetherclock_model_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(aetherclock_model_test PROPERTIES AUTOMOC ON)
+add_test(NAME aetherclock_model_test COMMAND aetherclock_model_test)
 
 add_executable(aetherd_amp_decode_test tests/aetherd_amp_decode_test.cpp)
 target_include_directories(aetherd_amp_decode_test PRIVATE src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,9 @@ set(CORE_SOURCES
     src/core/SpectralNR.cpp
     src/core/MonoDspStereoAdapter.cpp
     src/core/PanadapterStream.cpp
+    src/core/TimeFrameVoter.cpp
+    src/core/WwvDecoder.cpp
+    src/core/WwvbDecoder.cpp
     src/core/PacketLossConcealment.cpp
     src/core/PerfTelemetry.cpp
     src/core/RigctlProtocol.cpp
@@ -3848,6 +3851,18 @@ target_include_directories(amp_model_test PRIVATE src)
 target_link_libraries(amp_model_test PRIVATE aethercore Qt6::Core Qt6::Test)
 set_target_properties(amp_model_test PROPERTIES AUTOMOC ON)
 add_test(NAME amp_model_test COMMAND amp_model_test)
+
+add_executable(wwv_decoder_test tests/wwv_decoder_test.cpp)
+target_include_directories(wwv_decoder_test PRIVATE src)
+target_link_libraries(wwv_decoder_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(wwv_decoder_test PROPERTIES AUTOMOC ON)
+add_test(NAME wwv_decoder_test COMMAND wwv_decoder_test)
+
+add_executable(wwvb_decoder_test tests/wwvb_decoder_test.cpp)
+target_include_directories(wwvb_decoder_test PRIVATE src)
+target_link_libraries(wwvb_decoder_test PRIVATE aethercore Qt6::Core Qt6::Test)
+set_target_properties(wwvb_decoder_test PROPERTIES AUTOMOC ON)
+add_test(NAME wwvb_decoder_test COMMAND wwvb_decoder_test)
 
 add_executable(aetherd_amp_decode_test tests/aetherd_amp_decode_test.cpp)
 target_include_directories(aetherd_amp_decode_test PRIVATE src)

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1859,6 +1859,24 @@ Useful fields:
 | `sliceId` | Bound slice while running, −1 when stopped |
 | `gpsTimeAvailable` | Whether the connected radio reports GPS time (context for the offset) |
 
+Acquisition telemetry (additive; mirrors the engine's ~1 Hz `ClockDiagnostics`
+snapshot — every value is a real measurement or a real gate verdict, updated
+while the engine runs):
+
+| field | meaning |
+|---|---|
+| `toneSnrDb` | Stage 1 carrier readout: WWVB tone-search peak/median in dB; WWV/WWVH folded tick-band peak-to-mean in dB |
+| `pwmContrast` | WWVB envelope p90/p10 contrast (0 when n/a); ≥ ~1.4 means a real AM drop exists |
+| `toneDetected` | Carrier gate result (WWVB tone gate / WWV tick-fold lock) |
+| `phaseLocked` | Second-edge timing sync (WWV tick lock / WWVB envelope phase) |
+| `delayEstMs` | WWV tracked matched-filter delay estimate; `null` when the decoder has none |
+| `anchored` | Minute frame anchored (marker sync) |
+| `badFrameStreak` | Consecutive broken-marker-skeleton frames (WWV; 3 triggers resync) |
+| `classifiedPct` | % of the last 60 s that classified into a symbol |
+| `framesInWindow` / `windowSize` | Voter sliding-window occupancy |
+| `voteQuality` | Raw voter lock confidence 0–1 (pre-scale; `lockQuality` is the 0–100 post-lock mirror) |
+| `refusalReason` / `refusalName` | Which lock gate is currently refusing: `None`, `QualityFloor`, `Plausibility`, `Staleness`, `Contested` (`None` = locked or still collecting frames) |
+
 ### `audioCapture`
 Bounded, automation-only PCM capture for receive-sync diagnostics. It is active
 only inside an `AETHER_AUTOMATION=1` process, is read-only, and does not change

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -286,6 +286,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get tracedebug`](#get-tracedebug) | Per-panadapter Flex/Kiwi FFT and 3D trace diagnostics. |
 | | [`get clients`](#get-clients) | Radio client roster, GUI IDs + foreign-pan-write forensics (#3977/#4166). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
+| | [`get clock`](#get) | AetherClock time-signal decode state (lock, station, decoded UTC, offset, quality). |
 | | [`get wavestats`](#get-wavestats) | WAVE/strip scope paint-cost counters. |
 | | `get waveforms` | Installed waveform list, WFP state, local D-STAR service/configuration, delivery health/metrics, and recent waveform status reports. |
 | | [`get dax`](#get-dax) | DAX RX channel-ownership table (holders/streams, #3305). |
@@ -617,6 +618,7 @@ connects).
 | `meters` | — | `{all:[…]}` — every radio meter with `name`, `value`, `unit`, `low`/`high`, `description`, and **`age_ms`** (staleness): a meter that updates has small `age_ms` and a tracking `value`. |
 | `slices` | — | array of all slice snapshots |
 | `slice` | `active` (default) / `tx` / `<sliceId>` | one slice (sliceId, letter, frequency, mode, filterLow/High, rxAntenna, nb/nr/anf + levels, **squelch/squelchLevel, agcMode/agcThreshold, apf/apfLevel**, **adaptiveFilterEnabled/adaptiveMinLowCut/adaptiveMaxHighCut/adaptiveMinSnr/adaptiveResponse/adaptiveSplatter/adaptiveActive** (SSB adaptive RX filter — `adaptiveActive` is the live AUTO-fit state), txSlice, …) |
+| `clock` | — | AetherClock snapshot: `state`/`stateName` (NoSignal/Acquiring/Locked), `station`/`stationName` (WWV/WWVH/WWVB), `decodedUtc` (ISO-8601, empty until a decode), `offsetMs` (decoded − host at the second edge; positive = host behind broadcast), `lockQuality` (0–100), `sliceId` (bound slice, −1 when stopped), `gpsTimeAvailable`. Validate applet Start/Tune/station-switch actions and lock progress without pixels. |
 | `pans` | — | array of all panadapter snapshots |
 | `pan` | `active` (default) / `<panId>` e.g. `0x40000000` | one pan (centerMhz, bandwidthMhz, min/maxDbm, rxAntenna, rfGain, fps, `transmitInhibited`, `transmitInhibitReason`) |
 | `flags` (or `vfoFlags`) | `all` (default) / `<sliceId>` | VFO flag attachment snapshot: each flag’s slice id, expected radio pan id, attached UI pan id/index, geometry, visibility, and `attachedToExpectedPan`; also reports `missingSlices`. |

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -286,7 +286,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`get tracedebug`](#get-tracedebug) | Per-panadapter Flex/Kiwi FFT and 3D trace diagnostics. |
 | | [`get clients`](#get-clients) | Radio client roster, GUI IDs + foreign-pan-write forensics (#3977/#4166). |
 | | [`get sync`](#get-sync) | Receive-Sync (Auto Assist) state. |
-| | [`get clock`](#get) | AetherClock time-signal decode state (lock, station, decoded UTC, offset, quality). |
+| | [`get clock`](#get-clock) | AetherClock time-signal decode state (lock, station, decoded UTC, offset, quality). |
 | | [`get wavestats`](#get-wavestats) | WAVE/strip scope paint-cost counters. |
 | | `get waveforms` | Installed waveform list, WFP state, local D-STAR service/configuration, delivery health/metrics, and recent waveform status reports. |
 | | [`get dax`](#get-dax) | DAX RX channel-ownership table (holders/streams, #3305). |
@@ -1833,6 +1833,31 @@ Useful fields:
 | `stableEstimateCount` | Count of consecutive near-equal candidate offsets |
 | `lastAcceptedLock` | Whether the latest estimator pass changed/confirmed the applied lock |
 | `flex*BufferMs`, `kiwi*BufferMs`, `playbackQueuedMs` | Current live-to-ear staging counters |
+
+### `get clock`
+Read the AetherClock time-signal decode snapshot (engine + voter state for the
+WWV/WWVH/WWVB decoders). Served before the radio guard, so it answers even
+while disconnected; until the GUI wires a model it replies
+`"no clock model available"`.
+
+```json
+→ {"cmd":"get","model":"clock"}
+← {"ok":true,"model":"clock","state":2,"stateName":"Locked",
+   "station":1,"stationName":"WWV","decodedUtc":"2026-07-20T22:52:59.000Z",
+   "offsetMs":-129.7,"lockQuality":75,"sliceId":0,"gpsTimeAvailable":false}
+```
+
+Useful fields:
+
+| field | meaning |
+|---|---|
+| `state` / `stateName` | `NoSignal`, `Acquiring`, `Locked` — the authoritative currency signal |
+| `station` / `stationName` | Auto-tagged station: WWV / WWVH / WWVB |
+| `decodedUtc` | Last voted broadcast time (ISO-8601; empty until a first decode). Retained after demotion so age-since-decode stays computable — always read it beside `stateName` |
+| `offsetMs` | decoded − host at the second edge; positive = host behind broadcast |
+| `lockQuality` | Voter lock confidence 0–100 (weakest-voted-bit semantics) |
+| `sliceId` | Bound slice while running, −1 when stopped |
+| `gpsTimeAvailable` | Whether the connected radio reports GPS time (context for the offset) |
 
 ### `audioCapture`
 Bounded, automation-only PCM capture for receive-sync diagnostics. It is active

--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -11,6 +11,7 @@
 #include <QPointer>
 #include <QString>
 #include <QTimeZone>
+#include <QTimer>
 #include <QVector>
 
 #include <algorithm>
@@ -35,6 +36,9 @@ struct IDecoder {
     virtual void reset() = 0;
     virtual ClockStation station() const = 0;
     virtual std::int64_t samplesConsumed() const = 0;
+    // Live decoder lock state — the decoder suppresses no-change state edges, so
+    // after an engine-side lock decay handleSecond resyncs from this accessor.
+    virtual ClockLockState lockState() const = 0;
 
     // Engine-side callbacks, forwarded from the concrete decoder's callbacks.
     std::function<void(const ClockSecondInfo&)> onSecond;
@@ -56,12 +60,21 @@ struct DecoderHolder final : IDecoder {
     void reset() override { d.reset(); }
     ClockStation station() const override { return d.station(); }
     std::int64_t samplesConsumed() const override { return d.samplesConsumed(); }
+    ClockLockState lockState() const override { return d.state(); }
 };
 
 } // namespace
 
 struct AetherClockEngine::Impl {
-    explicit Impl(AetherClockEngine* owner) : q(owner) {}
+    explicit Impl(AetherClockEngine* owner) : q(owner) {
+        // Parented to q so it dies with the engine. Single-shot; the engine is a
+        // thread-agnostic QObject whose slots and queued feedRxAudio all run on
+        // its own thread, so every start/stop/re-arm of this timer happens there
+        // — no cross-thread QTimer use.
+        decayTimer = new QTimer(q);
+        decayTimer->setSingleShot(true);
+        QObject::connect(decayTimer, &QTimer::timeout, q, [this] { onDecayTimeout(); });
+    }
 
     AetherClockEngine* q = nullptr;
 
@@ -79,6 +92,12 @@ struct AetherClockEngine::Impl {
     ClockStation lastStation = ClockStation::Unknown; // for stationDetected edges
     ClockLockState lastState = ClockLockState::NoSignal;
     bool running = false;
+
+    // Lock-decay watchdog (see setLockDecayTimeoutMs). Armed on start() and
+    // re-armed on every classified second; on timeout it demotes the state one
+    // step so a stalled feed cannot pin a stale Locked/Acquiring.
+    QTimer* decayTimer = nullptr;
+    int decayTimeoutMs = 10000;
 
     std::function<qint64()> nowUtcMs =
         [] { return QDateTime::currentMSecsSinceEpoch(); };
@@ -126,6 +145,20 @@ struct AetherClockEngine::Impl {
         heldChannel = 0;
     }
 
+    void armDecayTimer() { decayTimer->start(decayTimeoutMs); }
+
+    void onDecayTimeout() {
+        if (!running) return;
+        // Demote ONE step and re-arm; at the NoSignal floor stop re-arming until
+        // the next classified second re-arms the watchdog (handleSecond).
+        if (lastState == ClockLockState::Locked) {
+            setState(ClockLockState::Acquiring);
+            armDecayTimer();
+        } else if (lastState == ClockLockState::Acquiring) {
+            setState(ClockLockState::NoSignal);
+        }
+    }
+
     // ---- Decoder callbacks: fire inline on the feed thread during process() ----
 
     void handleState(ClockLockState st) { setState(st); }
@@ -153,6 +186,15 @@ struct AetherClockEngine::Impl {
             lastStation = st;
             emit q->stationDetected(st);
         }
+
+        // A classified second means audio is live: re-arm the lock-decay
+        // watchdog, then resync engine state from the decoder's live accessor.
+        // The decoder suppresses no-change state edges, so after an engine-side
+        // decay it may still believe Locked and never re-emit it; the resync
+        // recovers the engine to the decoder's truth.
+        armDecayTimer();
+        const ClockLockState ds = decoder->lockState();
+        if (ds != lastState) setState(ds);
     }
 
     void handleFrame(const ClockFrameInfo& frame) {
@@ -219,6 +261,10 @@ void AetherClockEngine::setHostClock(std::function<qint64()> nowUtcMs) {
         m_impl->nowUtcMs = std::move(nowUtcMs);
     else
         m_impl->nowUtcMs = [] { return QDateTime::currentMSecsSinceEpoch(); };
+}
+
+void AetherClockEngine::setLockDecayTimeoutMs(int ms) {
+    m_impl->decayTimeoutMs = ms < 50 ? 50 : ms;
 }
 
 bool AetherClockEngine::isRunning() const { return m_impl->running; }
@@ -295,6 +341,7 @@ void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
     // Graceful loss if the bound slice is destroyed under us.
     d.connDestroyed = connect(slice, &QObject::destroyed, this, [this] {
         auto& e = *m_impl;
+        e.decayTimer->stop();
         e.releaseHold();
         e.disconnectAll();
         if (e.decoder) e.decoder->reset();
@@ -305,12 +352,14 @@ void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
 
     d.running = true;
     d.lastState = ClockLockState::NoSignal;  // state starts NoSignal
+    d.armDecayTimer();                       // watchdog runs while running
     emit runningChanged(true);
 }
 
 void AetherClockEngine::stop() {
     auto& d = *m_impl;
     const bool was = d.running;
+    d.decayTimer->stop();
     d.releaseHold();
     d.disconnectAll();
     if (d.decoder) d.decoder->reset();
@@ -324,22 +373,32 @@ void AetherClockEngine::stop() {
 }
 
 void AetherClockEngine::applyStationPreset(ClockStation station, double carrierMHz) {
-    auto& d = *m_impl;
-    if (!d.slice) return;  // no-op unless bound
+    // The bound slice is null when unbound, so this keeps the no-op-unless-bound
+    // semantics (the overload warns + returns on a null slice).
+    applyStationPreset(m_impl->slice.data(), station, carrierMHz);
+}
+
+void AetherClockEngine::applyStationPreset(SliceModel* slice, ClockStation station,
+                                           double carrierMHz) {
+    if (!slice) {
+        qWarning() << "AetherClockEngine: no slice - station preset not applied";
+        return;
+    }
     // All-or-nothing: on a locked slice only setFrequency honors the lock
     // (SliceModel.cpp), so applying the preset would strand the slice on its
     // old frequency while still forcing USB (and AGC off for WWVB). Refuse the
     // whole preset instead of leaving an inconsistent state.
-    if (d.slice->isLocked()) {
-        qWarning() << "AetherClockEngine: bound slice is locked -"
+    if (slice->isLocked()) {
+        qWarning() << "AetherClockEngine: slice is locked -"
                    << "station preset not applied";
         return;
     }
-    // Radio-authoritative live-slice state only; nothing persisted.
-    d.slice->setFrequency(listeningDialMHz(carrierMHz));
-    d.slice->setMode(QStringLiteral("USB"));
+    // Radio-authoritative live-slice state only; nothing persisted. Neither
+    // binds the slice nor starts the engine.
+    slice->setFrequency(listeningDialMHz(carrierMHz));
+    slice->setMode(QStringLiteral("USB"));
     if (station == ClockStation::Wwvb)
-        d.slice->setAgcMode(QStringLiteral("off"));
+        slice->setAgcMode(QStringLiteral("off"));
 }
 
 void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {

--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -1,0 +1,379 @@
+#include "core/AetherClockEngine.h"
+
+#include "core/WwvDecoder.h"
+#include "core/WwvbDecoder.h"
+#include "models/SliceModel.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QDebug>
+#include <QMetaObject>
+#include <QPointer>
+#include <QString>
+#include <QTimeZone>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace AetherSDR {
+
+namespace {
+
+// Type-erasing holder so the engine can own EITHER time-signal decoder behind
+// one pointer: WwvDecoder and WwvbDecoder expose an identical surface
+// (WwvDecoder.h / WwvbDecoder.h) but share no base class. This is purely an
+// implementation detail of Task A's "owned WwvDecoder/WwvbDecoder (create the
+// one selected at start())".
+struct IDecoder {
+    virtual ~IDecoder() = default;
+    virtual void process(const float* mono, std::size_t n) = 0;
+    virtual void reset() = 0;
+    virtual ClockStation station() const = 0;
+    virtual std::int64_t samplesConsumed() const = 0;
+
+    // Engine-side callbacks, forwarded from the concrete decoder's callbacks.
+    std::function<void(const ClockSecondInfo&)> onSecond;
+    std::function<void(const ClockFrameInfo&)> onFrame;
+    std::function<void(const ClockTimeInfo&)> onTime;
+    std::function<void(ClockLockState)> onStateChanged;
+};
+
+template <class D>
+struct DecoderHolder final : IDecoder {
+    D d;
+    explicit DecoderHolder(int sampleRateHz) : d(sampleRateHz) {
+        d.onSecond = [this](const ClockSecondInfo& i) { if (onSecond) onSecond(i); };
+        d.onFrame = [this](const ClockFrameInfo& fr) { if (onFrame) onFrame(fr); };
+        d.onTime = [this](const ClockTimeInfo& t) { if (onTime) onTime(t); };
+        d.onStateChanged = [this](ClockLockState s) { if (onStateChanged) onStateChanged(s); };
+    }
+    void process(const float* mono, std::size_t n) override { d.process(mono, n); }
+    void reset() override { d.reset(); }
+    ClockStation station() const override { return d.station(); }
+    std::int64_t samplesConsumed() const override { return d.samplesConsumed(); }
+};
+
+} // namespace
+
+struct AetherClockEngine::Impl {
+    explicit Impl(AetherClockEngine* owner) : q(owner) {}
+
+    AetherClockEngine* q = nullptr;
+
+    // DAX-hold provider (EB3: the engine never touches the vendor stream). The
+    // wiring layer wraps the central PanadapterStream::acquire/releaseDaxChannel
+    // with DaxConsumer::Clock; the engine drives these with the bound channel.
+    std::function<void(int)> acquireCh;
+    std::function<void(int)> releaseCh;
+
+    QPointer<SliceModel> slice;
+    std::unique_ptr<IDecoder> decoder;
+
+    int heldChannel = 0;                              // 0 = none
+    ClockStation configured = ClockStation::Unknown;  // station chosen at start()
+    ClockStation lastStation = ClockStation::Unknown; // for stationDetected edges
+    ClockLockState lastState = ClockLockState::NoSignal;
+    bool running = false;
+
+    std::function<qint64()> nowUtcMs =
+        [] { return QDateTime::currentMSecsSinceEpoch(); };
+
+    // Sample <-> host anchor: host time `anchorHostMs` corresponds to total
+    // consumed sample `anchorSamples` (the END of the last fed buffer).
+    std::int64_t anchorSamples = 0;
+    qint64 anchorHostMs = 0;
+
+    // Second-0 sample index of the most recent completed frame (from onFrame,
+    // which always fires immediately before the vote refresh). votedField
+    // (FieldMinutes) is normalized to this newest frame, so hh:mm from the vote
+    // is the time AT this frame's second 0 — the anchor for onTime composition.
+    std::int64_t lastFrameStartSample = 0;
+    bool haveFrame = false;
+
+    std::vector<float> monoScratch;
+
+    QMetaObject::Connection connDax;
+    QMetaObject::Connection connDestroyed;
+
+    double hostMsAtSample(std::int64_t s) const {
+        return static_cast<double>(anchorHostMs)
+             - static_cast<double>(anchorSamples - s) * 1000.0
+                   / static_cast<double>(AetherClockEngine::kSampleRateHz);
+    }
+
+    void setState(ClockLockState s) {
+        if (s == lastState) return;
+        lastState = s;
+        emit q->lockStateChanged(s);
+        emit q->lockedChanged(s == ClockLockState::Locked);
+    }
+
+    void disconnectAll() {
+        QObject::disconnect(connDax);
+        QObject::disconnect(connDestroyed);
+        connDax = {};
+        connDestroyed = {};
+    }
+
+    void releaseHold() {
+        if (releaseCh && heldChannel >= 1 && heldChannel <= 4)
+            releaseCh(heldChannel);
+        heldChannel = 0;
+    }
+
+    // ---- Decoder callbacks: fire inline on the feed thread during process() ----
+
+    void handleState(ClockLockState st) { setState(st); }
+
+    void handleSecond(const ClockSecondInfo& info) {
+        ClockAlignmentFrame f;
+        f.hostUtcMs = static_cast<qint64>(std::llround(hostMsAtSample(info.edgeSample)));
+        f.secondOfFrame = info.secondOfFrame;
+        f.envelope = QVector<float>(info.envelope.begin(), info.envelope.end());
+        f.expected = QVector<float>(info.expected.begin(), info.expected.end());
+        // The decoders' 1 s alignment window is edge-anchored: the window start
+        // IS the detected AM-drop second edge (WwvDecoder.cpp: the window is cut
+        // at the tick-phase boundary and edgeSample = startJ * decim), so there
+        // is no window->edge lead to report.
+        f.edgeOffsetMs = 0;
+        f.symbol = static_cast<int>(info.symbol);
+        f.confidence = info.confidence;
+        f.station = static_cast<quint8>(static_cast<int>(decoder->station()));
+        emit q->alignmentFrame(f);
+
+        // Surface the station once the decoder classifies it (WWV/WWVH by tick
+        // band per NIST SP 432; WWVB by construction).
+        const ClockStation st = decoder->station();
+        if (st != lastStation) {
+            lastStation = st;
+            emit q->stationDetected(st);
+        }
+    }
+
+    void handleFrame(const ClockFrameInfo& frame) {
+        // Fires immediately BEFORE any vote refresh; frameStartSample is the
+        // decoder input-sample index of this frame's second 0 (same clock as
+        // lastEdgeSample and the host anchor).
+        lastFrameStartSample = frame.frameStartSample;
+        haveFrame = true;
+    }
+
+    void handleTime(const ClockTimeInfo& t) {
+        // Compose from the voted frame's second 0 plus the elapsed-sample count
+        // to the last edge. This is exact across WWVB per-second re-emission
+        // (cached vote), WWV chunk-straddle, and multi-frame backlog, because
+        // lastEdgeSecondOfFrame can point into a frame LATER than the vote —
+        // using it directly would be up to minutes off. No host-clock snapping.
+        if (!haveFrame) return;  // onFrame always precedes the vote; guard anyway
+
+        const int year = 2000 + t.year2;
+        // doy is 1-based day-of-year (NIST SP 432 BCD day field).
+        const QDate date = QDate::fromJulianDay(
+            QDate(year, 1, 1).toJulianDay() + static_cast<qint64>(t.doy) - 1);
+        // hh:mm AT the voted frame's second 0 (votedField(Minutes) is normalized
+        // to the newest frame = the most recent onFrame).
+        const QDateTime baseUtc(date, QTime(t.hour, t.minute, 0), QTimeZone::utc());
+        const int elapsedSec = static_cast<int>(std::lround(
+            static_cast<double>(t.lastEdgeSample - lastFrameStartSample)
+            / static_cast<double>(AetherClockEngine::kSampleRateHz)));
+        const QDateTime decodedUtc = baseUtc.addSecs(elapsedSec);
+
+        const double offsetMs =
+            static_cast<double>(decodedUtc.toMSecsSinceEpoch())
+            - hostMsAtSample(t.lastEdgeSample);
+        int quality = static_cast<int>(std::lround(t.quality * 100.0));
+        quality = std::clamp(quality, 0, 100);
+        emit q->timeDecoded(decodedUtc, offsetMs, quality);
+    }
+};
+
+AetherClockEngine::AetherClockEngine(QObject* parent)
+    : QObject(parent), m_impl(std::make_unique<Impl>(this)) {
+    // Register everything that crosses queued connections (GpsDelta precedent).
+    qRegisterMetaType<AetherSDR::ClockAlignmentFrame>();
+    qRegisterMetaType<AetherSDR::ClockLockState>("AetherSDR::ClockLockState");
+    qRegisterMetaType<AetherSDR::ClockStation>("AetherSDR::ClockStation");
+}
+
+AetherClockEngine::~AetherClockEngine() {
+    // Silent teardown: never leak a DAX hold (INV-3). No signals from a dying
+    // object.
+    m_impl->disconnectAll();
+    m_impl->releaseHold();
+    m_impl->decoder.reset();
+}
+
+void AetherClockEngine::setDaxChannelProvider(std::function<void(int)> acquire,
+                                              std::function<void(int)> release) {
+    m_impl->acquireCh = std::move(acquire);
+    m_impl->releaseCh = std::move(release);
+}
+
+void AetherClockEngine::setHostClock(std::function<qint64()> nowUtcMs) {
+    if (nowUtcMs)
+        m_impl->nowUtcMs = std::move(nowUtcMs);
+    else
+        m_impl->nowUtcMs = [] { return QDateTime::currentMSecsSinceEpoch(); };
+}
+
+bool AetherClockEngine::isRunning() const { return m_impl->running; }
+
+int AetherClockEngine::boundSliceId() const {
+    return m_impl->slice ? m_impl->slice->sliceId() : -1;
+}
+
+ClockStation AetherClockEngine::configuredStation() const {
+    return m_impl->configured;
+}
+
+ClockLockState AetherClockEngine::lockState() const { return m_impl->lastState; }
+
+void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
+    auto& d = *m_impl;
+    if (d.running) stop();
+
+    // Require a slice to bind; stay stopped otherwise.
+    if (!slice) {
+        qWarning() << "AetherClockEngine::start: no slice - staying stopped";
+        return;
+    }
+
+    d.slice = slice;
+    d.configured = station;
+    d.lastStation = ClockStation::Unknown;
+
+    // Create the selected decoder and wire its inline callbacks.
+    if (station == ClockStation::Wwvb)
+        d.decoder = std::make_unique<DecoderHolder<WwvbDecoder>>(kSampleRateHz);
+    else
+        d.decoder = std::make_unique<DecoderHolder<WwvDecoder>>(kSampleRateHz);
+    d.decoder->onSecond = [this](const ClockSecondInfo& i) { m_impl->handleSecond(i); };
+    d.decoder->onFrame = [this](const ClockFrameInfo& fr) { m_impl->handleFrame(fr); };
+    d.decoder->onTime = [this](const ClockTimeInfo& t) { m_impl->handleTime(t); };
+    d.decoder->onStateChanged = [this](ClockLockState s) { m_impl->handleState(s); };
+
+    // Fresh sample<->host and frame anchors for the fresh decoder.
+    d.anchorSamples = 0;
+    d.anchorHostMs = d.nowUtcMs();
+    d.lastFrameStartSample = 0;
+    d.haveFrame = false;
+
+    // Hold the slice's LIVE DAX channel through the injected provider (the
+    // wiring layer routes this to the central #3305 ownership registry).
+    const int ch = slice->daxChannel();
+    d.heldChannel = 0;
+    if (!d.acquireCh || !d.releaseCh) {
+        qWarning() << "AetherClockEngine::start: no DAX channel provider set -"
+                   << "hold not acquired; audio will not flow";
+    } else if (ch >= 1 && ch <= 4) {
+        d.heldChannel = ch;
+        d.acquireCh(ch);
+    } else {
+        qWarning() << "AetherClockEngine::start: slice" << slice->sliceId()
+                   << "has no DAX channel assigned - audio will not flow";
+    }
+
+    // Follow mid-session DAX reassignment THROUGH THE PROVIDER: acquire NEW
+    // before releasing OLD so the channel's holder set never transiently hits
+    // zero (RADE precedent).
+    d.connDax = connect(slice, &SliceModel::daxChannelChanged, this,
+                        [this](int newCh) {
+        auto& e = *m_impl;
+        if (!e.acquireCh || !e.releaseCh) return;
+        const int oldCh = e.heldChannel;
+        const int nc = (newCh >= 1 && newCh <= 4) ? newCh : 0;
+        if (nc) e.acquireCh(nc);
+        if (oldCh >= 1 && oldCh <= 4 && oldCh != nc) e.releaseCh(oldCh);
+        e.heldChannel = nc;
+    });
+
+    // Graceful loss if the bound slice is destroyed under us.
+    d.connDestroyed = connect(slice, &QObject::destroyed, this, [this] {
+        auto& e = *m_impl;
+        e.releaseHold();
+        e.disconnectAll();
+        if (e.decoder) e.decoder->reset();
+        e.running = false;
+        e.setState(ClockLockState::NoSignal);
+        emit runningChanged(false);
+    });
+
+    d.running = true;
+    d.lastState = ClockLockState::NoSignal;  // state starts NoSignal
+    emit runningChanged(true);
+}
+
+void AetherClockEngine::stop() {
+    auto& d = *m_impl;
+    const bool was = d.running;
+    d.releaseHold();
+    d.disconnectAll();
+    if (d.decoder) d.decoder->reset();
+    d.decoder.reset();
+    d.slice = nullptr;
+    d.lastStation = ClockStation::Unknown;
+    d.haveFrame = false;
+    d.running = false;
+    d.setState(ClockLockState::NoSignal);  // emits only on actual change
+    if (was) emit runningChanged(false);
+}
+
+void AetherClockEngine::applyStationPreset(ClockStation station, double carrierMHz) {
+    auto& d = *m_impl;
+    if (!d.slice) return;  // no-op unless bound
+    // All-or-nothing: on a locked slice only setFrequency honors the lock
+    // (SliceModel.cpp), so applying the preset would strand the slice on its
+    // old frequency while still forcing USB (and AGC off for WWVB). Refuse the
+    // whole preset instead of leaving an inconsistent state.
+    if (d.slice->isLocked()) {
+        qWarning() << "AetherClockEngine: bound slice is locked -"
+                   << "station preset not applied";
+        return;
+    }
+    // Radio-authoritative live-slice state only; nothing persisted.
+    d.slice->setFrequency(listeningDialMHz(carrierMHz));
+    d.slice->setMode(QStringLiteral("USB"));
+    if (station == ClockStation::Wwvb)
+        d.slice->setAgcMode(QStringLiteral("off"));
+}
+
+void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {
+    auto& d = *m_impl;
+    if (!d.running || !d.decoder || !d.slice) return;
+    if (channel != d.slice->daxChannel()) return;  // live channel filter
+
+    // Payload: float32 interleaved stereo, native-endian, 24 kHz (8 bytes/frame).
+    const std::size_t n = static_cast<std::size_t>(pcm.size()) / 8;
+    if (n == 0) return;
+    const float* in = reinterpret_cast<const float*>(pcm.constData());
+
+    d.monoScratch.resize(n);
+    for (std::size_t i = 0; i < n; ++i)
+        d.monoScratch[i] = 0.5f * (in[2 * i] + in[2 * i + 1]);  // downmix L+R
+
+    // Anchor BEFORE process(): host time corresponds to the END of this buffer
+    // (samplesConsumedBefore + n), so callbacks fired inline during process()
+    // already read a current sample<->host mapping.
+    d.anchorSamples = d.decoder->samplesConsumed() + static_cast<std::int64_t>(n);
+    d.anchorHostMs = d.nowUtcMs();
+    d.decoder->process(d.monoScratch.data(), n);
+}
+
+// ---- Station preset statics ----
+
+QVector<double> AetherClockEngine::wwvCarrierFrequenciesMHz() {
+    return QVector<double>{2.5, 5.0, 10.0, 15.0, 20.0};
+}
+
+double AetherClockEngine::wwvbCarrierFrequencyMHz() { return 0.060; }
+
+double AetherClockEngine::listeningDialMHz(double carrierMHz) {
+    return carrierMHz - 0.001;
+}
+
+} // namespace AetherSDR

--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -25,6 +25,14 @@ namespace AetherSDR {
 
 namespace {
 
+// Absolute-plausibility bound handed to the shared voter (WS-4.5): a voted
+// timestamp farther than this from the host clock refuses to lock. Generous by
+// design — a host clock minutes or even hours wrong is exactly what the applet
+// measures; a decode DECADES away (the 2026-07-20 q100 lock on 2006-01-01)
+// can only be systematic misreads. Lock gating only; decodedUtc composition
+// remains host-free (no host snapping).
+constexpr int kPlausibilityBoundMinutes = 24 * 60;
+
 // Type-erasing holder so the engine can own EITHER time-signal decoder behind
 // one pointer: WwvDecoder and WwvbDecoder expose an identical surface
 // (WwvDecoder.h / WwvbDecoder.h) but share no base class. This is purely an
@@ -39,6 +47,9 @@ struct IDecoder {
     // Live decoder lock state — the decoder suppresses no-change state edges, so
     // after an engine-side lock decay handleSecond resyncs from this accessor.
     virtual ClockLockState lockState() const = 0;
+    // WS-4.5: arm the shared voter's absolute-plausibility gate.
+    virtual void setPlausibility(std::function<TimeFields()> referenceNow,
+                                 int boundMinutes) = 0;
 
     // Engine-side callbacks, forwarded from the concrete decoder's callbacks.
     std::function<void(const ClockSecondInfo&)> onSecond;
@@ -61,6 +72,10 @@ struct DecoderHolder final : IDecoder {
     ClockStation station() const override { return d.station(); }
     std::int64_t samplesConsumed() const override { return d.samplesConsumed(); }
     ClockLockState lockState() const override { return d.state(); }
+    void setPlausibility(std::function<TimeFields()> referenceNow,
+                         int boundMinutes) override {
+        d.setPlausibility(std::move(referenceNow), boundMinutes);
+    }
 };
 
 } // namespace
@@ -169,11 +184,13 @@ struct AetherClockEngine::Impl {
         f.secondOfFrame = info.secondOfFrame;
         f.envelope = QVector<float>(info.envelope.begin(), info.envelope.end());
         f.expected = QVector<float>(info.expected.begin(), info.expected.end());
-        // The decoders' 1 s alignment window is edge-anchored: the window start
-        // IS the detected AM-drop second edge (WwvDecoder.cpp: the window is cut
-        // at the tick-phase boundary and edgeSample = startJ * decim), so there
-        // is no window->edge lead to report.
-        f.edgeOffsetMs = 0;
+        // Where the received pulse sits relative to the template's nominal
+        // position (WS-4.5): ~0 on a drift-free stream, nonzero while the
+        // decoder is absorbing sample-clock drift. The display shifts the
+        // expected overlay by this so envelope and template stay honest.
+        f.edgeOffsetMs = (info.seriesRateHz > 0)
+            ? qRound(info.windowShift * 1000.0 / info.seriesRateHz)
+            : 0;
         f.symbol = static_cast<int>(info.symbol);
         f.confidence = info.confidence;
         f.station = static_cast<quint8>(static_cast<int>(decoder->station()));
@@ -302,6 +319,22 @@ void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
     d.decoder->onFrame = [this](const ClockFrameInfo& fr) { m_impl->handleFrame(fr); };
     d.decoder->onTime = [this](const ClockTimeInfo& t) { m_impl->handleTime(t); };
     d.decoder->onStateChanged = [this](ClockLockState s) { m_impl->handleState(s); };
+
+    // Arm the absolute-plausibility gate with the host clock (WS-4.5). The
+    // callback fires on the feed thread inside process(); nowUtcMs is the same
+    // injectable clock the sample<->host anchor uses, so tests stay in control.
+    d.decoder->setPlausibility(
+        [this] {
+            const QDateTime now = QDateTime::fromMSecsSinceEpoch(
+                m_impl->nowUtcMs(), QTimeZone::utc());
+            TimeFields tf;
+            tf.minute = now.time().minute();
+            tf.hour = now.time().hour();
+            tf.doy = now.date().dayOfYear();
+            tf.year2 = now.date().year() % 100;
+            return tf;
+        },
+        kPlausibilityBoundMinutes);
 
     // Fresh sample<->host and frame anchors for the fresh decoder.
     d.anchorSamples = 0;

--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -439,7 +439,11 @@ void AetherClockEngine::feedRxAudio(int channel, const QByteArray& pcm) {
     if (!d.running || !d.decoder || !d.slice) return;
     if (channel != d.slice->daxChannel()) return;  // live channel filter
 
-    // Payload: float32 interleaved stereo, native-endian, 24 kHz (8 bytes/frame).
+    // Payload contract (shared with the Bridge/Tci/Rade DAX consumers):
+    // float32 interleaved stereo, native-endian, 24 kHz, 8 bytes per frame,
+    // 4-byte-aligned buffer. A trailing partial frame is deliberately floored
+    // away by the /8 — the stream is frame-oriented and a fragment carries no
+    // usable sample pair.
     const std::size_t n = static_cast<std::size_t>(pcm.size()) / 8;
     if (n == 0) return;
     const float* in = reinterpret_cast<const float*>(pcm.constData());

--- a/src/core/AetherClockEngine.cpp
+++ b/src/core/AetherClockEngine.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -50,6 +51,8 @@ struct IDecoder {
     // WS-4.5: arm the shared voter's absolute-plausibility gate.
     virtual void setPlausibility(std::function<TimeFields()> referenceNow,
                                  int boundMinutes) = 0;
+    // WS-7: read-only acquisition snapshot (funnel stages 1-3 + 5).
+    virtual ClockDecoderDiagnostics diagnostics() const = 0;
 
     // Engine-side callbacks, forwarded from the concrete decoder's callbacks.
     std::function<void(const ClockSecondInfo&)> onSecond;
@@ -76,6 +79,7 @@ struct DecoderHolder final : IDecoder {
                          int boundMinutes) override {
         d.setPlausibility(std::move(referenceNow), boundMinutes);
     }
+    ClockDecoderDiagnostics diagnostics() const override { return d.diagnostics(); }
 };
 
 } // namespace
@@ -89,6 +93,14 @@ struct AetherClockEngine::Impl {
         decayTimer = new QTimer(q);
         decayTimer->setSingleShot(true);
         QObject::connect(decayTimer, &QTimer::timeout, q, [this] { onDecayTimeout(); });
+
+        // WS-7: ~1 Hz diagnostics emission while running. Same threading story
+        // as decayTimer — every start/stop happens on the engine's thread.
+        diagTimer = new QTimer(q);
+        diagTimer->setInterval(1000);
+        QObject::connect(diagTimer, &QTimer::timeout, q, [this] {
+            if (running) emit q->diagnosticsUpdated(q->currentDiagnostics());
+        });
     }
 
     AetherClockEngine* q = nullptr;
@@ -113,6 +125,17 @@ struct AetherClockEngine::Impl {
     // step so a stalled feed cannot pin a stale Locked/Acquiring.
     QTimer* decayTimer = nullptr;
     int decayTimeoutMs = 10000;
+
+    // WS-7 diagnostics cadence + the stage-4 classified-seconds ring: host-ms
+    // stamps of the last minute's classified seconds (each handleSecond call IS
+    // a classified second — the decoders emit nothing for an unclassified one).
+    QTimer* diagTimer = nullptr;
+    std::deque<qint64> classifiedMs;
+
+    void pruneClassified(qint64 nowMs) {
+        while (!classifiedMs.empty() && nowMs - classifiedMs.front() > 60000)
+            classifiedMs.pop_front();
+    }
 
     std::function<qint64()> nowUtcMs =
         [] { return QDateTime::currentMSecsSinceEpoch(); };
@@ -212,6 +235,11 @@ struct AetherClockEngine::Impl {
         armDecayTimer();
         const ClockLockState ds = decoder->lockState();
         if (ds != lastState) setState(ds);
+
+        // WS-7 stage-4 ring: this callback fires once per CLASSIFIED second.
+        const qint64 nowMs = nowUtcMs();
+        classifiedMs.push_back(nowMs);
+        pruneClassified(nowMs);
     }
 
     void handleFrame(const ClockFrameInfo& frame) {
@@ -220,6 +248,10 @@ struct AetherClockEngine::Impl {
         // lastEdgeSample and the host anchor).
         lastFrameStartSample = frame.frameStartSample;
         haveFrame = true;
+
+        // WS-7: re-emit the raw per-frame decode (previously discarded here —
+        // frameConfidence, DUT1/DST/leap now reach the debug pane).
+        emit q->frameDecoded(frame);
     }
 
     void handleTime(const ClockTimeInfo& t) {
@@ -257,6 +289,8 @@ AetherClockEngine::AetherClockEngine(QObject* parent)
     qRegisterMetaType<AetherSDR::ClockAlignmentFrame>();
     qRegisterMetaType<AetherSDR::ClockLockState>("AetherSDR::ClockLockState");
     qRegisterMetaType<AetherSDR::ClockStation>("AetherSDR::ClockStation");
+    qRegisterMetaType<AetherSDR::ClockDiagnostics>();
+    qRegisterMetaType<AetherSDR::ClockFrameInfo>();
 }
 
 AetherClockEngine::~AetherClockEngine() {
@@ -295,6 +329,33 @@ ClockStation AetherClockEngine::configuredStation() const {
 }
 
 ClockLockState AetherClockEngine::lockState() const { return m_impl->lastState; }
+
+ClockDiagnostics AetherClockEngine::currentDiagnostics() const {
+    auto& d = *m_impl;
+    ClockDiagnostics g;
+    if (d.decoder) {
+        const ClockDecoderDiagnostics dd = d.decoder->diagnostics();
+        g.toneSnrDb = dd.toneSnrDb;
+        g.pwmContrast = dd.pwmContrast;
+        g.toneDetected = dd.toneDetected;
+        g.phaseLocked = dd.phaseLocked;
+        g.delayEstMs = dd.delayEstMs;
+        g.anchored = dd.anchored;
+        g.badFrameStreak = dd.badFrameStreak;
+        g.framesInWindow = dd.framesInWindow;
+        g.windowSize = dd.windowSize;
+        g.voteQuality = dd.voteQuality;
+        g.refusalReason = dd.refusalReason;
+    }
+    // Count, don't prune — this accessor is const; handleSecond's prune keeps
+    // the ring bounded.
+    const qint64 nowMs = d.nowUtcMs();
+    std::size_t live = 0;
+    for (qint64 t : d.classifiedMs)
+        if (nowMs - t <= 60000) ++live;
+    g.classifiedPct = static_cast<int>(std::min<std::size_t>(100, live * 100 / 60));
+    return g;
+}
 
 void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
     auto& d = *m_impl;
@@ -386,6 +447,8 @@ void AetherClockEngine::start(SliceModel* slice, ClockStation station) {
     d.running = true;
     d.lastState = ClockLockState::NoSignal;  // state starts NoSignal
     d.armDecayTimer();                       // watchdog runs while running
+    d.classifiedMs.clear();
+    d.diagTimer->start();                    // ~1 Hz diagnostics while running
     emit runningChanged(true);
 }
 
@@ -393,6 +456,8 @@ void AetherClockEngine::stop() {
     auto& d = *m_impl;
     const bool was = d.running;
     d.decayTimer->stop();
+    d.diagTimer->stop();
+    d.classifiedMs.clear();
     d.releaseHold();
     d.disconnectAll();
     if (d.decoder) d.decoder->reset();

--- a/src/core/AetherClockEngine.h
+++ b/src/core/AetherClockEngine.h
@@ -1,0 +1,112 @@
+#pragma once
+
+// AetherClock engine: binds a user-chosen RX slice, owns the DAX-hold
+// LIFECYCLE for that slice's channel (acquire on start, follow live
+// reassignment, release on stop/slice loss), feeds the WWV/WWVB decoders,
+// and emits decode + alignment signals.
+//
+// Radio-seam discipline (EB3): this file never touches the vendor stream
+// classes. The wiring layer (GUI applet, tests, any future host) injects a
+// DAX-hold provider wrapping the CENTRAL
+// PanadapterStream::acquireDaxChannel/releaseDaxChannel(ch,
+// DaxConsumer::Clock) registry, and connects the stream's daxAudioReady to
+// feedRxAudio(). That keeps the engine above the radio seam and
+// source-agnostic: any 24 kHz float32-stereo feed (Flex DAX today, other
+// backends tomorrow) drives it through the same two seams.
+//
+// RX-only by design: no TX path, nothing radio-authoritative persisted, and
+// the OS clock is never modified — the engine only READS the host clock
+// (through an injectable hook so tests control time).
+//
+// Threading: thread-agnostic QObject. The creator may move it to a worker
+// thread; all cross-object wiring is queued. Decode work runs inside
+// feedRxAudio() — the signals carry 1 bit/s, so this is trivially cheap.
+
+#include "ClockAlignmentFrame.h"
+#include "TimeFrameVoter.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QObject>
+#include <QVector>
+
+#include <functional>
+#include <memory>
+
+namespace AetherSDR {
+
+class SliceModel;
+
+class AetherClockEngine : public QObject {
+    Q_OBJECT
+public:
+    explicit AetherClockEngine(QObject* parent = nullptr);
+    ~AetherClockEngine() override;
+
+    // DAX RX audio sample rate (Hz) — the daxAudioReady contract.
+    static constexpr int kSampleRateHz = 24000;
+
+    // Station presets. Listening dial = carrier − 1 kHz, USB.
+    static QVector<double> wwvCarrierFrequenciesMHz();  // 2.5, 5, 10, 15, 20
+    static double wwvbCarrierFrequencyMHz();            // 0.060
+    static double listeningDialMHz(double carrierMHz);  // carrier − 0.001
+
+    // DAX-hold provider — set before start() whenever the audio source is
+    // DAX (a missing provider warns and skips hold acquisition, so non-DAX
+    // sources can drive feedRxAudio directly). The callbacks wrap the
+    // central DAX ownership registry
+    // (PanadapterStream::acquireDaxChannel/releaseDaxChannel with
+    // DaxConsumer::Clock); the engine drives them with the bound slice's
+    // channel and never registers a stream privately.
+    void setDaxChannelProvider(std::function<void(int)> acquire,
+                               std::function<void(int)> release);
+
+    // Host-clock READ hook (UTC ms since epoch). Defaults to
+    // QDateTime::currentMSecsSinceEpoch. Tests inject a fake clock. The
+    // engine never writes the OS clock.
+    void setHostClock(std::function<qint64()> nowUtcMs);
+
+    bool isRunning() const;
+    int boundSliceId() const;               // -1 when not bound
+    ClockStation configuredStation() const; // station selected at start()
+    ClockLockState lockState() const;
+
+public slots:
+    // Bind `slice` and start decoding. `station` selects the decoder:
+    // Wwv (auto-tags Wwvh by tick band) or Wwvb. Acquires the DAX hold on
+    // the slice's live daxChannel() through the injected provider, follows
+    // daxChannelChanged (acquire-new-before-release-old), and stops
+    // gracefully (state → NoSignal, hold released) if the slice is
+    // destroyed. Calling start() while running stops first.
+    void start(SliceModel* slice, ClockStation station);
+    void stop();
+
+    // Convenience tune: tunes the BOUND slice to listeningDialMHz(carrierMHz)
+    // USB; for Wwvb also sets AGC off on that slice. Radio-authoritative
+    // state — applied to the live slice only, never persisted. No-op when
+    // not bound.
+    void applyStationPreset(ClockStation station, double carrierMHz);
+
+    // PCM ingest — the daxAudioReady payload (float32 interleaved stereo,
+    // native-endian, 24 kHz). The wiring layer connects the audio source
+    // here; it is also the test-harness seam and the future non-Flex source
+    // seam. Samples whose channel differs from the bound slice's live
+    // daxChannel() are ignored.
+    void feedRxAudio(int channel, const QByteArray& pcm);
+
+signals:
+    void runningChanged(bool running);
+    void lockStateChanged(AetherSDR::ClockLockState state);
+    void lockedChanged(bool locked);
+    void stationDetected(AetherSDR::ClockStation station);
+    // quality 0-100. offsetMs = decodedUtc − hostUtc at the decoded second
+    // edge — POSITIVE means the host clock is BEHIND the broadcast.
+    void timeDecoded(const QDateTime& utc, double offsetMs, int quality);
+    void alignmentFrame(const AetherSDR::ClockAlignmentFrame& frame);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace AetherSDR

--- a/src/core/AetherClockEngine.h
+++ b/src/core/AetherClockEngine.h
@@ -66,6 +66,14 @@ public:
     // engine never writes the OS clock.
     void setHostClock(std::function<qint64()> nowUtcMs);
 
+    // Lock-decay watchdog timeout (ms). Decoder state only advances inside
+    // process(); if audio stops arriving (or no second classifies) a
+    // Locked/Acquiring state would stick forever. When this window elapses with
+    // no classified second while running, the engine demotes the state one step
+    // (Locked -> Acquiring -> NoSignal). Test seam; default 10000 ms, values
+    // < 50 clamped to 50.
+    void setLockDecayTimeoutMs(int ms);
+
     bool isRunning() const;
     int boundSliceId() const;               // -1 when not bound
     ClockStation configuredStation() const; // station selected at start()
@@ -81,11 +89,16 @@ public slots:
     void start(SliceModel* slice, ClockStation station);
     void stop();
 
-    // Convenience tune: tunes the BOUND slice to listeningDialMHz(carrierMHz)
-    // USB; for Wwvb also sets AGC off on that slice. Radio-authoritative
-    // state — applied to the live slice only, never persisted. No-op when
-    // not bound.
+    // Convenience tune to listeningDialMHz(carrierMHz) USB; for Wwvb also sets
+    // AGC off on that slice. Radio-authoritative state — applied to the live
+    // slice only, never persisted; neither binds the slice nor starts the
+    // engine. A locked slice refuses the whole preset (all-or-nothing).
+    // The two-arg form acts on the BOUND slice (no-op when not bound); the
+    // three-arg form acts on any given slice — the applet's Tune-while-stopped
+    // path, acting on the strip's selected slice.
     void applyStationPreset(ClockStation station, double carrierMHz);
+    void applyStationPreset(SliceModel* slice, ClockStation station,
+                            double carrierMHz);
 
     // PCM ingest — the daxAudioReady payload (float32 interleaved stereo,
     // native-endian, 24 kHz). The wiring layer connects the audio source

--- a/src/core/AetherClockEngine.h
+++ b/src/core/AetherClockEngine.h
@@ -23,6 +23,7 @@
 // feedRxAudio() — the signals carry 1 bit/s, so this is trivially cheap.
 
 #include "ClockAlignmentFrame.h"
+#include "ClockDiagnostics.h"
 #include "TimeFrameVoter.h"
 
 #include <QByteArray>
@@ -79,6 +80,13 @@ public:
     ClockStation configuredStation() const; // station selected at start()
     ClockLockState lockState() const;
 
+    // WS-7 acquisition telemetry: the current diagnostics snapshot, assembled
+    // on call from the decoder's read-only accessors plus the engine's
+    // classified-seconds ring. The same snapshot is emitted at ~1 Hz via
+    // diagnosticsUpdated() while running; this accessor is the test/bridge
+    // seam (no event loop required). Default-constructed when not running.
+    ClockDiagnostics currentDiagnostics() const;
+
 public slots:
     // Bind `slice` and start decoding. `station` selects the decoder:
     // Wwv (auto-tags Wwvh by tick band) or Wwvb. Acquires the DAX hold on
@@ -116,6 +124,12 @@ signals:
     // edge — POSITIVE means the host clock is BEHIND the broadcast.
     void timeDecoded(const QDateTime& utc, double offsetMs, int quality);
     void alignmentFrame(const AetherSDR::ClockAlignmentFrame& frame);
+    // WS-7 telemetry (both additive, read-only w.r.t. decode behavior):
+    // ~1 Hz diagnostics while running, and the raw per-frame decode re-emitted
+    // instead of dying at the engine boundary (frameConfidence, DUT1/DST/leap
+    // feed the debug pane).
+    void diagnosticsUpdated(const AetherSDR::ClockDiagnostics& diag);
+    void frameDecoded(const AetherSDR::ClockFrameInfo& frame);
 
 private:
     struct Impl;

--- a/src/core/AetherClockSettings.cpp
+++ b/src/core/AetherClockSettings.cpp
@@ -84,4 +84,16 @@ void AetherClockSettings::setWwvCarrierMHz(double mhz)
     write(o);
 }
 
+bool AetherClockSettings::debugLogVisible()
+{
+    return readObj().value(QStringLiteral("debugLogVisible")).toBool(false);
+}
+
+void AetherClockSettings::setDebugLogVisible(bool visible)
+{
+    QJsonObject o = readObj();
+    o[QStringLiteral("debugLogVisible")] = visible;
+    write(o);
+}
+
 } // namespace AetherSDR

--- a/src/core/AetherClockSettings.cpp
+++ b/src/core/AetherClockSettings.cpp
@@ -1,0 +1,87 @@
+#include "core/AetherClockSettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+#include <QLatin1String>
+#include <QString>
+
+#include <cmath>
+#include <limits>
+
+namespace AetherSDR {
+
+namespace {
+const QString kAetherClockKey = QStringLiteral("AetherClock");
+
+// WWV carrier presets mirrored from AetherClockEngine::wwvCarrierFrequenciesMHz
+// (2.5/5/10/15/20 MHz). Hardcoded here to keep the settings unit
+// dependency-light — no engine include. per WS-2 authoring spec, Task C.
+constexpr double kWwvCarrierPresetsMHz[] = {2.5, 5.0, 10.0, 15.0, 20.0};
+constexpr double kDefaultWwvCarrierMHz = 10.0;
+} // namespace
+
+// One nested JSON blob under the single AppSettings key "AetherClock"
+// (the AprsSettings pattern). Values in the store are strings; the blob
+// itself is compact JSON.
+QJsonObject AetherClockSettings::readObj()
+{
+    const QString json =
+        AppSettings::instance().value(kAetherClockKey, QString{}).toString();
+    if (json.isEmpty())
+        return {};
+    return QJsonDocument::fromJson(json.toUtf8()).object();
+}
+
+void AetherClockSettings::write(const QJsonObject& o)
+{
+    auto& s = AppSettings::instance();
+    s.setValue(kAetherClockKey,
+               QString::fromUtf8(
+                   QJsonDocument(o).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+QString AetherClockSettings::stationPreset()
+{
+    return readObj().value(QStringLiteral("stationPreset"))
+        .toString(QStringLiteral("WWV"));
+}
+
+void AetherClockSettings::setStationPreset(const QString& preset)
+{
+    // Validate to {"WWV","WWVB"}; anything else falls back to "WWV".
+    const QString valid = (preset == QLatin1String("WWVB"))
+                              ? QStringLiteral("WWVB")
+                              : QStringLiteral("WWV");
+    QJsonObject o = readObj();
+    o[QStringLiteral("stationPreset")] = valid;
+    write(o);
+}
+
+double AetherClockSettings::wwvCarrierMHz()
+{
+    return readObj().value(QStringLiteral("wwvCarrierMHz"))
+        .toDouble(kDefaultWwvCarrierMHz);
+}
+
+void AetherClockSettings::setWwvCarrierMHz(double mhz)
+{
+    // Clamp to the nearest legal preset; nonsense (NaN/inf) → default 10.0.
+    double chosen = kDefaultWwvCarrierMHz;
+    if (std::isfinite(mhz)) {
+        double best = std::numeric_limits<double>::infinity();
+        for (const double preset : kWwvCarrierPresetsMHz) {
+            const double d = std::abs(preset - mhz);
+            if (d < best) {
+                best = d;
+                chosen = preset;
+            }
+        }
+    }
+    QJsonObject o = readObj();
+    o[QStringLiteral("wwvCarrierMHz")] = chosen; // stored as a JSON number
+    write(o);
+}
+
+} // namespace AetherSDR

--- a/src/core/AetherClockSettings.h
+++ b/src/core/AetherClockSettings.h
@@ -21,6 +21,11 @@ public:
     static double wwvCarrierMHz(); // default 10.0
     static void setWwvCarrierMHz(double mhz);
 
+    // Debug-log pane visibility in the applet's settings drawer (WS-7).
+    // Collapsed by default; a field in the same nested blob, never a flat key.
+    static bool debugLogVisible(); // default false
+    static void setDebugLogVisible(bool visible);
+
 private:
     static QJsonObject readObj();
     static void write(const QJsonObject& o);

--- a/src/core/AetherClockSettings.h
+++ b/src/core/AetherClockSettings.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// AetherClock persistence. Per Constitution Principle V the configuration
+// lives as ONE nested JSON blob under the single AppSettings key
+// "AetherClock" (the AprsSettings / AutomationBridgeSettings pattern) —
+// never flat keys. Radio-authoritative state (slice frequency, mode, AGC)
+// is NEVER persisted.
+
+#include <QJsonObject>
+#include <QString>
+
+namespace AetherSDR {
+
+class AetherClockSettings {
+public:
+    // Chosen station preset: "WWV" (default) or "WWVB".
+    static QString stationPreset();
+    static void setStationPreset(const QString& preset);
+
+    // Chosen WWV carrier (MHz), one of AetherClockEngine's preset list.
+    static double wwvCarrierMHz(); // default 10.0
+    static void setWwvCarrierMHz(double mhz);
+
+private:
+    static QJsonObject readObj();
+    static void write(const QJsonObject& o);
+};
+
+} // namespace AetherSDR

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -11,6 +11,7 @@
 #include "CallsignLookupService.h" // qrz() verb — QRZ lookup cache/service
 #include "CallsignUtils.h"
 #include "models/RadioModel.h"   // RadioModel, SliceModel, PanadapterModel (get())
+#include "models/AetherClockModel.h"  // AetherClockModel (get clock)
 #include "IConnectionAutomation.h" // gui-free connect/disconnect/dialog hook
 
 #include <QAction>
@@ -2278,7 +2279,7 @@ const QStringList& getModelNames()
         QStringLiteral("meters"),     QStringLiteral("slice"),
         QStringLiteral("slices"),     QStringLiteral("pan"),
         QStringLiteral("pans"),       QStringLiteral("panstats"),
-        QStringLiteral("gps"),
+        QStringLiteral("gps"),        QStringLiteral("clock"),
         QStringLiteral("renderstats"),
         QStringLiteral("tracedebug"), QStringLiteral("waveforms"),
         QStringLiteral("kiwi"),
@@ -3685,6 +3686,32 @@ QJsonObject AutomationServer::doInvoke(const QString& target, const QString& act
     return r;
 }
 
+void AutomationServer::setClockModel(AetherClockModel* model)
+{
+    m_clockModel = model;
+}
+
+namespace {
+// AetherClock model snapshot for "get clock" (PRD-A: bridge exposure).
+QJsonObject clockSnapshot(const AetherClockModel* m)
+{
+    return QJsonObject{
+        {QStringLiteral("state"), m->state()},
+        {QStringLiteral("stateName"), m->stateName()},
+        {QStringLiteral("station"), m->station()},
+        {QStringLiteral("stationName"), m->stationName()},
+        {QStringLiteral("decodedUtc"),
+         m->decodedUtc().isValid()
+             ? m->decodedUtc().toUTC().toString(Qt::ISODateWithMs)
+             : QString{}},
+        {QStringLiteral("offsetMs"), m->offsetMs()},
+        {QStringLiteral("lockQuality"), m->lockQuality()},
+        {QStringLiteral("sliceId"), m->sliceId()},
+        {QStringLiteral("gpsTimeAvailable"), m->gpsTimeAvailable()},
+    };
+}
+} // namespace
+
 QJsonObject AutomationServer::doGet(const QString& model, const QString& selector,
                                     const QString& property) const
 {
@@ -4566,6 +4593,27 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         return data;
     }
 
+    if (model == QLatin1String("clock")) {
+        // AetherClock time-signal decode state — model exists independently
+        // of a radio connection, so it is served before the radio guard.
+        AetherClockModel* clock = m_clockModel;
+        if (!clock)
+            return err(QStringLiteral("no clock model available"));
+        QJsonObject data = clockSnapshot(clock);
+        if (!property.isEmpty()) {
+            if (!data.contains(property))
+                return err(QStringLiteral("unknown property '") + property
+                           + QStringLiteral("' for clock"));
+            return QJsonObject{{QStringLiteral("ok"), true},
+                               {QStringLiteral("model"), model},
+                               {QStringLiteral("property"), property},
+                               {QStringLiteral("value"), data.value(property)}};
+        }
+        data[QStringLiteral("ok")] = true;
+        data[QStringLiteral("model")] = model;
+        return data;
+    }
+
     RadioModel* radio = m_radioModel;
     if (!radio)
         return err(QStringLiteral("no radio model available"));
@@ -4679,7 +4727,7 @@ QJsonObject AutomationServer::doGet(const QString& model, const QString& selecto
         data = panSnapshot(p, radio);
     } else {
         return err(QStringLiteral("unknown model: ") + model
-                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|tracedebug|clients|kiwi|wavestats)"));
+                   + QStringLiteral(" (use audio|dsp|sync|radio|transmit|cwx|equalizer|meters|slice|slices|pan|pans|flags|panstats|renderstats|tracedebug|clients|kiwi|wavestats|clock)"));
     }
 
     if (!property.isEmpty()) {

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -3708,6 +3708,22 @@ QJsonObject clockSnapshot(const AetherClockModel* m)
         {QStringLiteral("lockQuality"), m->lockQuality()},
         {QStringLiteral("sliceId"), m->sliceId()},
         {QStringLiteral("gpsTimeAvailable"), m->gpsTimeAvailable()},
+        // WS-7 acquisition telemetry (additive — existing consumers see the
+        // original keys unchanged). delayEstMs is NaN when the decoder has no
+        // estimate; QJsonValue maps NaN to null.
+        {QStringLiteral("toneSnrDb"), m->toneSnrDb()},
+        {QStringLiteral("pwmContrast"), m->pwmContrast()},
+        {QStringLiteral("toneDetected"), m->toneDetected()},
+        {QStringLiteral("phaseLocked"), m->phaseLocked()},
+        {QStringLiteral("delayEstMs"), m->delayEstMs()},
+        {QStringLiteral("anchored"), m->anchored()},
+        {QStringLiteral("badFrameStreak"), m->badFrameStreak()},
+        {QStringLiteral("classifiedPct"), m->classifiedPct()},
+        {QStringLiteral("framesInWindow"), m->framesInWindow()},
+        {QStringLiteral("windowSize"), m->windowSize()},
+        {QStringLiteral("voteQuality"), m->voteQuality()},
+        {QStringLiteral("refusalReason"), m->refusalReason()},
+        {QStringLiteral("refusalName"), m->refusalName()},
     };
 }
 } // namespace

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -30,6 +30,7 @@ namespace AetherSDR {
 class RadioModel;
 class AudioEngine;
 class QsoRecorder;
+class AetherClockModel;
 
 // In-app, agent-first automation bridge (issue #3646, Phases 0-1).
 //
@@ -240,6 +241,9 @@ public:
     // "no radio model" rather than crashing).
     void setRadioModel(RadioModel* model) { m_radioModel = model; }
     void setAudioEngine(AudioEngine* audio) { m_audioEngine = audio; }
+    // AetherClock model handle for "get clock"; may be null (reports
+    // "no clock model available" until the applet wires it).
+    void setClockModel(AetherClockModel* model);  // out-of-line: QPointer needs the complete type
     // QSO recorder handle for the record() verb (start/stop/status/path).
     void setQsoRecorder(QsoRecorder* rec) { m_qsoRecorder = rec; }
     // Real connection hook for the connect/disconnect/dialog verbs. The bridge
@@ -580,6 +584,7 @@ private:
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<QsoRecorder> m_qsoRecorder;          // for record(); may be null
+    QPointer<AetherClockModel> m_clockModel;      // for get clock; may be null
     IConnectionAutomation* m_connection = nullptr;  // connect/disconnect verbs
     QPointer<QObject> m_connectionGuard;            // auto-nulls when the impl is destroyed
     // Returns the connection hook only while its implementor is alive, so every

--- a/src/core/ClockAlignmentFrame.h
+++ b/src/core/ClockAlignmentFrame.h
@@ -15,7 +15,7 @@ struct ClockAlignmentFrame {
     QVector<float> envelope;     // received envelope over the 1 s window
                                  // (series rate = envelope.size() per second)
     QVector<float> expected;     // matched template of the decoded symbol, same rate
-    int     edgeOffsetMs = 0;    // detected AM-drop edge vs window start
+    int     edgeOffsetMs = 0;    // signed drift of the detected edge vs the nominal window start, ms (~0 drift-free)
     int     symbol = -1;         // 0, 1, 2 = marker, -1 = unknown
     float   confidence = 0.0f;   // classification margin, 0..1
     quint8  station = 0;         // ClockStation enum value

--- a/src/core/ClockAlignmentFrame.h
+++ b/src/core/ClockAlignmentFrame.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// AetherClock alignment contract — one emission per classified second while
+// the engine runs; drives the PR-B alignment display. The field set is
+// FROZEN as a cross-PR contract (PRD-A §5): PR-B consumes exactly this.
+
+#include <QMetaType>
+#include <QVector>
+
+namespace AetherSDR {
+
+struct ClockAlignmentFrame {
+    qint64  hostUtcMs = 0;       // host clock (UTC ms) at the detected second edge
+    int     secondOfFrame = -1;  // 0-59 once frame-synced, else -1
+    QVector<float> envelope;     // received envelope over the 1 s window
+                                 // (series rate = envelope.size() per second)
+    QVector<float> expected;     // matched template of the decoded symbol, same rate
+    int     edgeOffsetMs = 0;    // detected AM-drop edge vs window start
+    int     symbol = -1;         // 0, 1, 2 = marker, -1 = unknown
+    float   confidence = 0.0f;   // classification margin, 0..1
+    quint8  station = 0;         // ClockStation enum value
+};
+
+} // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::ClockAlignmentFrame)

--- a/src/core/ClockDiagnostics.h
+++ b/src/core/ClockDiagnostics.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// AetherClock acquisition telemetry (WS-7 / PRD-C): the engine's ~1 Hz
+// read-only diagnostics snapshot that drives the pre-lock funnel, the verdict
+// line and the debug pane. PARALLEL to — never extending — the frozen
+// ClockAlignmentFrame contract (that field set is cross-PR frozen and stays
+// untouched; diagnostics ride this separate struct). Every field is a real
+// measured quantity or a real gate verdict mirrored from the decode chain:
+// nothing is display-derived, and nothing here feeds back into decode
+// behavior.
+
+#include "TimeFrameVoter.h"
+
+#include <QMetaType>
+
+namespace AetherSDR {
+
+struct ClockDiagnostics {
+    // stage 1 — carrier
+    float toneSnrDb = 0.0f;    // WWVB: tone-search peak/median dB; WWV: tick fold dB
+    float pwmContrast = 0.0f;  // WWVB: p90/p10 envelope contrast (0 when n/a)
+    bool  toneDetected = false;
+    // stage 2 — timing
+    bool  phaseLocked = false;
+    float delayEstMs = 0.0f;   // NaN when the decoder has no delay estimate
+    // stage 3 — frame
+    bool  anchored = false;
+    int   badFrameStreak = 0;
+    // stage 4 — decode (engine-side ring: % of the last 60 s that classified)
+    int   classifiedPct = 0;
+    // stage 5 — vote
+    int   framesInWindow = 0;
+    int   windowSize = 0;
+    float voteQuality = 0.0f;  // voter lockConfidence() raw 0..1
+    quint8 refusalReason = 0;  // ClockLockRefusal
+};
+
+} // namespace AetherSDR
+
+Q_DECLARE_METATYPE(AetherSDR::ClockDiagnostics)
+// Queued-signal registration for the raw per-frame decode the engine re-emits
+// beside the diagnostics (frameDecoded): decoded fields that previously died
+// at the engine boundary.
+Q_DECLARE_METATYPE(AetherSDR::ClockFrameInfo)

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -43,6 +43,7 @@ Q_LOGGING_CATEGORY(lcKiwiSdr,    "aether.kiwisdr",     QtDebugMsg)
 Q_LOGGING_CATEGORY(lcKiwiSdrAudio, "aether.kiwisdr.audio", QtWarningMsg)
 Q_LOGGING_CATEGORY(lcAutomation, "aether.automation",  QtInfoMsg)
 Q_LOGGING_CATEGORY(lcQrz,        "aether.qrz",         QtWarningMsg)
+Q_LOGGING_CATEGORY(lcClock,      "aether.clock",       QtWarningMsg)
 
 LogManager::LogManager()
 {
@@ -78,6 +79,7 @@ LogManager::LogManager()
         {"aether.kiwisdr.audio", "KiwiSDR Audio/DSP", "Verbose KiwiSDR receive audio: frame decode, resampler, jitter/FIFO under/overrun, mixing (high-rate; off by default)"},
         {"aether.automation", "Automation Bridge", "Agent-drivable test bridge (#3646): QLocalServer verbs, widget snapshots, captures (AETHER_AUTOMATION only)"},
         {"aether.qrz",        "QRZ Lookup",   "QRZ.com callsign lookups: session, cache, CW callsign spotting, photos"},
+        {"aether.clock",      "AetherClock",  "WWV/WWVB time-signal decoder: state transitions, per-second alignment, frame decodes, voter verdicts"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -46,6 +46,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdr)
 Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdrAudio)
 Q_DECLARE_LOGGING_CATEGORY(lcAutomation)
 Q_DECLARE_LOGGING_CATEGORY(lcQrz)
+Q_DECLARE_LOGGING_CATEGORY(lcClock)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -1504,6 +1504,7 @@ const char* PanadapterStream::daxConsumerName(DaxConsumer who)
     case DaxConsumer::Bridge: return "bridge";
     case DaxConsumer::Tci:    return "tci";
     case DaxConsumer::Rade:   return "rade";
+    case DaxConsumer::Clock:  return "clock";
     }
     return "?";
 }
@@ -1637,7 +1638,8 @@ QVector<PanadapterStream::DaxChannelSnapshot> PanadapterStream::daxChannelSnapsh
         s.channel = it.key();
         s.streamId = it->streamId;
         s.createPending = it->createPending;
-        for (DaxConsumer who : {DaxConsumer::Bridge, DaxConsumer::Tci, DaxConsumer::Rade}) {
+        for (DaxConsumer who : {DaxConsumer::Bridge, DaxConsumer::Tci, DaxConsumer::Rade,
+                                DaxConsumer::Clock}) {
             if (it->holders & daxHolderBit(who))
                 s.holders << QString::fromLatin1(daxConsumerName(who));
         }

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -139,6 +139,7 @@ public:
         Bridge = 0,   // DAX virtual-audio bridge (macOS CoreAudio / PipeWire)
         Tci    = 1,   // TCI server audio clients (WSJT-X etc.)
         Rade   = 2,   // RADE digital-voice engine
+        Clock  = 3,   // AetherClock time-signal decode engine
     };
     static const char* daxConsumerName(DaxConsumer who);
 

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -155,6 +155,12 @@ TimeFrameVoter::buildNormalizedFrames() const {
         if (raw.hour   < 0 || raw.hour   > 23) continue;
         if (raw.doy    < 1 || raw.doy    > 366) continue;
         if (raw.year2  < 0 || raw.year2  > 99) continue;
+        // doy 366 is only ever broadcast in a leap year. Accepting it in a
+        // non-leap year would let advanceMinutes wrap a corrupt frame into
+        // January of the next year (doy 366 > 365 = year length) — even at age 0,
+        // where the wrap loop still runs — polluting the vote with an off-air
+        // date. Gate it out with the rest of the range-invalid frames.
+        if (raw.doy == 366 && !isLeapYear2(raw.year2)) continue;
 
         NormalizedFrame nf;
         nf.age = age;
@@ -350,13 +356,18 @@ bool TimeFrameVoter::locked() const {
 }
 
 float TimeFrameVoter::lockConfidence() const {
-    // Mean normalized winning margin over the voted timestamp bits, in the SAME
-    // normalized (age-extrapolated) space as votedField. Measuring the margin
-    // after normalization is what couples quality to the reported value: a clean
-    // rollover reads as unambiguous (every frame agrees once expressed at the
-    // newest epoch, so no dip), while a window whose frames genuinely disagree
-    // at comparable confidence carries that disagreement into the quality. The
-    // mean-margin x frame-count-saturation shape is unchanged.
+    // MINIMUM normalized winning margin over the voted timestamp bits, in the
+    // SAME normalized (age-extrapolated) space as votedField, x frame-count
+    // saturation. The min — not the mean — is the honest aggregate: a timestamp
+    // is exactly as trustworthy as its least-certain bit (one flipped bit changes
+    // the value), so quality must collapse to the single most-contested bit's
+    // margin. A mean let ~30 clean bits mask the one bit that actually decided a
+    // field, reporting near-1.0 while the value was wrong — confident garbage.
+    // Same principle as the re-encode weighting. Clean/clean-rollover windows:
+    // every bit unanimous once normalized -> every margin ~1.0 -> min ~1.0, so
+    // quality still tracks saturation and does not dip. A bit with ZERO
+    // participating votes (its second decoded Marker/Unknown in every window
+    // frame) has no consensus at all and is scored margin 0 -> quality 0.
     const int n = static_cast<int>(m_frames.size());
     if (n < m_cfg.minFramesForLock) {
         return 0.0f;
@@ -368,8 +379,8 @@ float TimeFrameVoter::lockConfidence() const {
     }
 
     constexpr float kEpsilon = 1e-6f;
-    double marginSum = 0.0;
-    int bitCount = 0;
+    double minMargin = 1.0;
+    bool sawBit = false;
 
     for (std::size_t fld = 0; fld < FieldCount; ++fld) {
         const ClockFieldMap& map = m_cfg.fields[fld];
@@ -382,18 +393,21 @@ float TimeFrameVoter::lockConfidence() const {
                     (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
                 }
             }
-            const float winning = std::max(t.w0, t.w1);
-            const float losing = std::min(t.w0, t.w1);
-            marginSum += (winning - losing) / (t.w0 + t.w1 + kEpsilon);
-            ++bitCount;
+            const float total = t.w0 + t.w1;
+            // No participating vote for this bit -> no consensus -> margin 0.
+            const double margin =
+                (total > 0.0f)
+                    ? (std::max(t.w0, t.w1) - std::min(t.w0, t.w1)) / (total + kEpsilon)
+                    : 0.0;
+            minMargin = std::min(minMargin, margin);
+            sawBit = true;
         }
     }
 
-    const double meanMargin = bitCount ? marginSum / bitCount : 0.0;
     const double saturation =
         std::min(1.0, static_cast<double>(n) /
                           (2.0 * static_cast<double>(m_cfg.minFramesForLock)));
-    const double quality = meanMargin * saturation;
+    const double quality = (sawBit ? minMargin : 0.0) * saturation;
     return static_cast<float>(std::clamp(quality, 0.0, 1.0));
 }
 

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -2,20 +2,23 @@
 
 #include <algorithm>
 #include <cmath>
-#include <unordered_map>
 #include <utility>
+#include <vector>
 
-// Cross-frame confidence-weighted bit voting per the AetherClock reference
-// decoder: a bit's vote is the sum of its per-frame matched-filter margins
-// (floored at 0.01), with older frames discounted by agingFactor^age. Markers
-// and Unknown symbols never vote. Lock gates on consecutive +1 minute
-// increments plus self-consistent static fields.
+// Cross-frame confidence-weighted voting per the AetherClock reference decoder:
+// a bit's vote is the sum of its per-frame matched-filter margins (floored at
+// 0.01), with older frames discounted by agingFactor^age. Markers and Unknown
+// symbols never vote. The timestamp vote is NORMALIZE-then-per-bit: every frame
+// is first extrapolated to the newest epoch (removing the epoch skew that makes
+// a stale hour dangerous), then bits are voted in that normalized space, where
+// frames are supposed to agree. Lock gates on consecutive +1 minute increments
+// plus self-consistent static fields.
 
 namespace AetherSDR {
 
 namespace {
 
-// Per-frame vote weight for one static bit: max(confidence, 0.01) aged by
+// Per-frame vote weight for one bit: max(confidence, 0.01) aged by
 // agingFactor^age (age 0 = newest frame).
 inline float agedWeight(float confidence, float agingFactor, int age) {
     const float base = std::max(confidence, 0.01f);
@@ -92,71 +95,71 @@ int TimeFrameVoter::decodeMinutes(const Frame& f) const {
     return decodeField(f, FieldMinutes);
 }
 
-bool TimeFrameVoter::locked() const {
+std::vector<TimeFrameVoter::NormalizedFrame>
+TimeFrameVoter::buildNormalizedFrames() const {
     const int n = static_cast<int>(m_frames.size());
-    if (n < m_cfg.minFramesForLock) {
-        return false;
-    }
+    std::vector<NormalizedFrame> out;
+    out.reserve(static_cast<std::size_t>(n));
 
-    // Count adjacent frame pairs whose decoded minutes increment by exactly +1
-    // (mod 60; 59 -> 0 valid). Live per-frame decodes are routinely imperfect,
-    // so increment support is COUNTED across the window rather than required of
-    // every pair (cf. the reference's marker_score + 4 * increment_count) — one
-    // corrupted frame must not permanently prevent or drop the lock.
-    int increments = 0;
-    for (int i = 1; i < n; ++i) {
-        const int prev = decodeMinutes(m_frames[i - 1]);
-        const int cur = decodeMinutes(m_frames[i]);
-        if (((prev + 1) % 60) == cur) {
-            ++increments;
-        }
-    }
-    if (increments < m_cfg.minFramesForLock - 1) {
-        return false;
-    }
-
-    // Confidence-weighted vote weights for one mapped second across the window.
-    auto bitWeights = [&](int second) -> std::pair<float, float> {
-        float w0 = 0.0f, w1 = 0.0f;
-        if (second < 0 || second >= 60) {
-            return {w0, w1};
-        }
-        for (int i = 0; i < n; ++i) {
-            const int age = (n - 1) - i; // newest -> age 0
-            const Frame& f = m_frames[i];
-            const ClockSymbol s = f.symbols[second];
-            if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
-                const float w =
-                    agedWeight(f.confidence[second], m_cfg.agingFactor, age);
-                (s == ClockSymbol::One ? w1 : w0) += w;
+    // Greedy descending-weight BCD encode of `value` over a field map: the maps
+    // carry canonical BCD weights, so subtracting weights largest-first
+    // reconstructs the exact bit pattern (One/Zero, parallel to the map).
+    auto encodeField = [](const ClockFieldMap& map, int value) {
+        std::vector<ClockSymbol> bits(map.size(), ClockSymbol::Zero);
+        std::vector<std::size_t> order(map.size());
+        for (std::size_t k = 0; k < map.size(); ++k) order[k] = k;
+        std::sort(order.begin(), order.end(),
+                  [&](std::size_t a, std::size_t b) {
+                      return map[a].weight > map[b].weight;
+                  });
+        int rem = value;
+        for (std::size_t k : order) {
+            if (map[k].weight > 0 && map[k].weight <= rem) {
+                bits[k] = ClockSymbol::One;
+                rem -= map[k].weight;
             }
         }
-        return {w0, w1};
+        return bits;
     };
 
-    // Static-field self-consistency: each static field must carry at least one
-    // confident bit vote (a strictly positive winning margin). An all-Unknown
-    // window yields zero margin everywhere and must not lock.
-    for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
-        double margin = 0.0;
-        for (const auto& bw : m_cfg.fields[fi]) {
-            const auto [w0, w1] = bitWeights(bw.second);
-            margin += std::max(w0, w1) - std::min(w0, w1);
+    // Weakest of the original per-second confidences over one field map, floored
+    // at 0.01 (a re-encoded field weights every bit by this). A BCD field VALUE is
+    // exactly as reliable as its least-reliable bit — one flipped bit changes the
+    // whole value — so a re-encoded value's vote must carry the weakest bit's
+    // margin, never the average, which would dilute a single faded bit ~1/N.
+    auto fieldMinConf = [&](const Frame& f, FieldIndex fld) -> float {
+        float lo = -1.0f;
+        for (const auto& bw : m_cfg.fields[fld]) {
+            if (bw.second >= 0 && bw.second < 60) {
+                lo = (lo < 0.0f) ? f.confidence[bw.second]
+                                 : std::min(lo, f.confidence[bw.second]);
+            }
         }
-        if (!(margin > 0.0)) {
-            return false;
-        }
-    }
+        return std::max(lo < 0.0f ? 0.0f : lo, 0.01f);
+    };
 
-    return true;
-}
+    for (int i = 0; i < n; ++i) {
+        const int age = (n - 1) - i;  // newest -> age 0
+        const Frame& f = m_frames[i];
 
-TimeFields TimeFrameVoter::votedTimestamp() const {
-    const int n = static_cast<int>(m_frames.size());
+        TimeFields raw;
+        raw.minute = decodeField(f, FieldMinutes);
+        raw.hour   = decodeField(f, FieldHours);
+        raw.doy    = decodeField(f, FieldDoy);
+        raw.year2  = decodeField(f, FieldYear);
 
-    // Field-map bit indices whose per-frame confidences represent a frame's
-    // timestamp-decode quality (union of the four voted field maps).
-    auto meanTimestampConfidence = [&](const Frame& f) -> double {
+        // Whole-frame range gate — a frame decoding outside valid broadcast
+        // ranges is excluded, the same spirit as excluding Marker/Unknown from a
+        // bit vote. (Guards the calendar arithmetic below, too.)
+        if (raw.minute < 0 || raw.minute > 59) continue;
+        if (raw.hour   < 0 || raw.hour   > 23) continue;
+        if (raw.doy    < 1 || raw.doy    > 366) continue;
+        if (raw.year2  < 0 || raw.year2  > 99) continue;
+
+        NormalizedFrame nf;
+        nf.age = age;
+        nf.ext = advanceMinutes(raw, age);
+
         double sum = 0.0;
         int count = 0;
         for (const FieldIndex fld : {FieldMinutes, FieldHours, FieldDoy, FieldYear}) {
@@ -167,60 +170,108 @@ TimeFields TimeFrameVoter::votedTimestamp() const {
                 }
             }
         }
-        return count ? sum / count : 0.0;
-    };
+        nf.meanConfidence = count ? sum / count : 0.0;
 
-    // Encode a range-valid timestamp tuple to a collision-free key so equal
-    // extrapolated timestamps accumulate their weight together.
-    auto encode = [](const TimeFields& t) -> int64_t {
-        return (static_cast<int64_t>(t.year2) * 100000000) +
-               (static_cast<int64_t>(t.doy) * 100000) +
-               (static_cast<int64_t>(t.hour) * 1000) +
-               static_cast<int64_t>(t.minute);
-    };
+        const int rawByField[FieldCount] = {raw.minute, raw.hour, raw.doy, raw.year2};
+        const int extByField[FieldCount] = {nf.ext.minute, nf.ext.hour,
+                                            nf.ext.doy, nf.ext.year2};
 
-    std::unordered_map<int64_t, double> weightByTuple;
-    std::unordered_map<int64_t, TimeFields> tupleByKey;
+        for (std::size_t fld = 0; fld < FieldCount; ++fld) {
+            const ClockFieldMap& map = m_cfg.fields[fld];
+            std::vector<NormalizedFrame::Bit>& dst = nf.bits[fld];
+            dst.resize(map.size());
 
-    for (int i = 0; i < n; ++i) {
-        const int age = (n - 1) - i;  // newest -> age 0
-        const Frame& f = m_frames[i];
+            if (extByField[fld] == rawByField[fld]) {
+                // Extrapolation left this field unchanged (the common case away
+                // from a boundary): vote its ORIGINAL symbols with their ORIGINAL
+                // per-second confidences — a faded bit carries a low matched-
+                // filter margin and loses the cross-frame vote. This is the
+                // reference model that rescues single-bit fades in noisy corpora.
+                for (std::size_t k = 0; k < map.size(); ++k) {
+                    const int sec = map[k].second;
+                    const bool inRange = sec >= 0 && sec < 60;
+                    dst[k].symbol = inRange ? f.symbols[sec] : ClockSymbol::Unknown;
+                    dst[k].confidence = inRange ? f.confidence[sec] : 0.0f;
+                }
+            } else {
+                // Extrapolation moved this field across a carry: re-encode the
+                // NORMALIZED value and weight every bit by the field-MIN original
+                // confidence, so a value whose weakest bit faded votes at that
+                // faded margin. Blending is thus confined to normalized space,
+                // where the frames are supposed to agree.
+                const std::vector<ClockSymbol> bits = encodeField(map, extByField[fld]);
+                const float w = fieldMinConf(f, static_cast<FieldIndex>(fld));
+                for (std::size_t k = 0; k < map.size(); ++k) {
+                    dst[k].symbol = bits[k];
+                    dst[k].confidence = w;
+                }
+            }
+        }
+        out.push_back(std::move(nf));
+    }
+    return out;
+}
 
-        TimeFields tf;
-        tf.minute = decodeField(f, FieldMinutes);
-        tf.hour   = decodeField(f, FieldHours);
-        tf.doy    = decodeField(f, FieldDoy);
-        tf.year2  = decodeField(f, FieldYear);
+// Per-field, per-bit tally across the normalized window: heavier of One/Zero
+// wins. `frames` is the shared normalized view.
+namespace {
+struct BitTally { float w0 = 0.0f, w1 = 0.0f; };
+} // namespace
 
-        // Exclude frames whose fields decode outside valid broadcast ranges —
-        // the same spirit as excluding Marker/Unknown symbols from a bit vote.
-        if (tf.minute < 0 || tf.minute > 59) continue;
-        if (tf.hour   < 0 || tf.hour   > 23) continue;
-        if (tf.doy    < 1 || tf.doy    > 366) continue;
-        if (tf.year2  < 0 || tf.year2  > 99) continue;
-
-        // Extrapolate this frame's timestamp forward to the newest frame, so all
-        // in-window frames vote on the SAME (newest) timestamp.
-        const TimeFields ext = advanceMinutes(tf, age);
-        const double w =
-            agedWeight(static_cast<float>(meanTimestampConfidence(f)),
-                       m_cfg.agingFactor, age);
-        const int64_t key = encode(ext);
-        weightByTuple[key] += w;
-        tupleByKey[key] = ext;
+TimeFields TimeFrameVoter::votedTimestamp() const {
+    const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
+    if (frames.empty()) {
+        return TimeFields{};
     }
 
-    int64_t bestKey = 0;
-    double bestWeight = -1.0;
-    bool have = false;
-    for (const auto& [key, weight] : weightByTuple) {
-        if (weight > bestWeight) {
-            bestWeight = weight;
-            bestKey = key;
-            have = true;
+    int valueByField[FieldCount] = {0, 0, 0, 0};
+    for (std::size_t fld = 0; fld < FieldCount; ++fld) {
+        const ClockFieldMap& map = m_cfg.fields[fld];
+        for (std::size_t k = 0; k < map.size(); ++k) {
+            BitTally t;
+            for (const NormalizedFrame& nf : frames) {
+                const NormalizedFrame::Bit b = nf.bits[fld][k];
+                if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
+                    const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
+                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
+                }
+            }
+            if (t.w1 > t.w0) {
+                valueByField[fld] += map[k].weight;
+            }
         }
     }
-    return have ? tupleByKey[bestKey] : TimeFields{};
+
+    TimeFields voted;
+    voted.minute = valueByField[FieldMinutes];
+    voted.hour   = valueByField[FieldHours];
+    voted.doy    = valueByField[FieldDoy];
+    voted.year2  = valueByField[FieldYear];
+
+    // Final-range guard: per-bit blending can in principle synthesize an
+    // out-of-range BCD value (e.g. a minute summing 5+10+20+40). If it did, fall
+    // back to the single highest-aged-weight frame's extrapolated tuple rather
+    // than emit an impossible broadcast time.
+    const bool inRange =
+        voted.minute >= 0 && voted.minute <= 59 &&
+        voted.hour   >= 0 && voted.hour   <= 23 &&
+        voted.doy    >= 1 && voted.doy    <= 366 &&
+        voted.year2  >= 0 && voted.year2  <= 99;
+    if (inRange) {
+        return voted;
+    }
+
+    const NormalizedFrame* best = nullptr;
+    double bestWeight = -1.0;
+    for (const NormalizedFrame& nf : frames) {
+        const double w = agedWeight(static_cast<float>(nf.meanConfidence),
+                                    m_cfg.agingFactor, nf.age);
+        if (w > bestWeight) {
+            bestWeight = w;
+            best = &nf;
+        }
+    }
+    return best ? best->ext : TimeFields{};
 }
 
 int TimeFrameVoter::votedField(FieldIndex field) const {
@@ -244,16 +295,75 @@ int TimeFrameVoter::lastFrameMinute() const {
     return decodeMinutes(m_frames.back());
 }
 
-float TimeFrameVoter::lockConfidence() const {
-    // Deliberately retained as the per-bit winning-margin over the static-field
-    // bits of the window, NOT switched to the winning-tuple weight margin. It
-    // measures raw bit stability, which is the honest quantity here: during an
-    // hour/day rollover the window straddles two timestamps, the per-bit margins
-    // dip, and reporting that dip is correct — quality SHOULD soften through a
-    // transition even though the tuple vote (votedTimestamp) now resolves the
-    // reported time unambiguously.
+bool TimeFrameVoter::locked() const {
     const int n = static_cast<int>(m_frames.size());
     if (n < m_cfg.minFramesForLock) {
+        return false;
+    }
+
+    // Count adjacent frame pairs whose decoded minutes increment by exactly +1
+    // (mod 60; 59 -> 0 valid). Live per-frame decodes are routinely imperfect,
+    // so increment support is COUNTED across the window rather than required of
+    // every pair (cf. the reference's marker_score + 4 * increment_count) — one
+    // corrupted frame must not permanently prevent or drop the lock.
+    int increments = 0;
+    for (int i = 1; i < n; ++i) {
+        const int prev = decodeMinutes(m_frames[i - 1]);
+        const int cur = decodeMinutes(m_frames[i]);
+        if (((prev + 1) % 60) == cur) {
+            ++increments;
+        }
+    }
+    if (increments < m_cfg.minFramesForLock - 1) {
+        return false;
+    }
+
+    // Static-field self-consistency in the SAME normalized space the vote uses:
+    // each static field must carry at least one confident bit vote (a strictly
+    // positive winning margin). No qualifying frame (e.g. an all-Unknown window
+    // whose doy decodes out of range) yields zero margin everywhere — must not
+    // lock.
+    const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
+    if (frames.empty()) {
+        return false;
+    }
+    for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
+        const ClockFieldMap& map = m_cfg.fields[fi];
+        double margin = 0.0;
+        for (std::size_t k = 0; k < map.size(); ++k) {
+            BitTally t;
+            for (const NormalizedFrame& nf : frames) {
+                const NormalizedFrame::Bit b = nf.bits[fi][k];
+                if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
+                    const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
+                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
+                }
+            }
+            margin += std::max(t.w0, t.w1) - std::min(t.w0, t.w1);
+        }
+        if (!(margin > 0.0)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+float TimeFrameVoter::lockConfidence() const {
+    // Mean normalized winning margin over the voted timestamp bits, in the SAME
+    // normalized (age-extrapolated) space as votedField. Measuring the margin
+    // after normalization is what couples quality to the reported value: a clean
+    // rollover reads as unambiguous (every frame agrees once expressed at the
+    // newest epoch, so no dip), while a window whose frames genuinely disagree
+    // at comparable confidence carries that disagreement into the quality. The
+    // mean-margin x frame-count-saturation shape is unchanged.
+    const int n = static_cast<int>(m_frames.size());
+    if (n < m_cfg.minFramesForLock) {
+        return 0.0f;
+    }
+
+    const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
+    if (frames.empty()) {
         return 0.0f;
     }
 
@@ -261,26 +371,20 @@ float TimeFrameVoter::lockConfidence() const {
     double marginSum = 0.0;
     int bitCount = 0;
 
-    // Mean normalized winning margin over every static-field mapped bit.
-    for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
-        for (const auto& bw : m_cfg.fields[fi]) {
-            if (bw.second < 0 || bw.second >= 60) {
-                continue;
-            }
-            float w0 = 0.0f, w1 = 0.0f;
-            for (int i = 0; i < n; ++i) {
-                const int age = (n - 1) - i;
-                const Frame& f = m_frames[i];
-                const ClockSymbol s = f.symbols[bw.second];
-                if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
-                    const float w = agedWeight(f.confidence[bw.second],
-                                               m_cfg.agingFactor, age);
-                    (s == ClockSymbol::One ? w1 : w0) += w;
+    for (std::size_t fld = 0; fld < FieldCount; ++fld) {
+        const ClockFieldMap& map = m_cfg.fields[fld];
+        for (std::size_t k = 0; k < map.size(); ++k) {
+            BitTally t;
+            for (const NormalizedFrame& nf : frames) {
+                const NormalizedFrame::Bit b = nf.bits[fld][k];
+                if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
+                    const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
+                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
                 }
             }
-            const float winning = std::max(w0, w1);
-            const float losing = std::min(w0, w1);
-            marginSum += (winning - losing) / (w0 + w1 + kEpsilon);
+            const float winning = std::max(t.w0, t.w1);
+            const float losing = std::min(t.w0, t.w1);
+            marginSum += (winning - losing) / (t.w0 + t.w1 + kEpsilon);
             ++bitCount;
         }
     }

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -41,6 +41,16 @@ inline bool isLeapYear2(int year2) {
     return (y % 4 == 0) && (y % 100 != 0 || y % 400 == 0);
 }
 
+// Absolute minute count of a range-valid timestamp since 2000-001T00:00, under
+// the same 20xx century assumption. Used only for plausibility DIFFERENCES, so
+// the epoch choice is arbitrary as long as both sides share it.
+inline long long minutesSince2000(const TimeFields& t) {
+    long long days = 0;
+    for (int y = 0; y < t.year2; ++y) days += isLeapYear2(y) ? 366 : 365;
+    days += t.doy - 1;
+    return ((days * 24 + t.hour) * 60) + t.minute;
+}
+
 } // namespace
 
 // Forward calendar arithmetic with minute/hour/doy/year carries. `minutes` is
@@ -63,6 +73,12 @@ TimeFields advanceMinutes(TimeFields t, int minutes) {
 }
 
 TimeFrameVoter::TimeFrameVoter(Config cfg) : m_cfg(std::move(cfg)) {}
+
+void TimeFrameVoter::setPlausibility(std::function<TimeFields()> referenceNow,
+                                     int boundMinutes) {
+    m_cfg.referenceNow = std::move(referenceNow);
+    m_cfg.plausibilityBoundMinutes = boundMinutes;
+}
 
 void TimeFrameVoter::addFrame(const std::array<ClockSymbol, 60>& symbols,
                               const std::array<float, 60>& confidence) {
@@ -155,18 +171,41 @@ TimeFrameVoter::buildNormalizedFrames() const {
         raw.year2  = decodeField(f, FieldYear);
 
         // Whole-frame range gate — a frame decoding outside valid broadcast
-        // ranges is excluded, the same spirit as excluding Marker/Unknown from a
-        // bit vote. (Guards the calendar arithmetic below, too.)
-        if (raw.minute < 0 || raw.minute > 59) continue;
-        if (raw.hour   < 0 || raw.hour   > 23) continue;
-        if (raw.doy    < 1 || raw.doy    > 366) continue;
-        if (raw.year2  < 0 || raw.year2  > 99) continue;
-        // doy 366 is only ever broadcast in a leap year. Accepting it in a
+        // ranges votes nothing and holds nothing (same spirit as excluding
+        // Marker/Unknown from a bit vote; also guards the calendar arithmetic
+        // below). It is NOT dropped from the window (WS-4.5): it keeps its slot
+        // and its real per-second confidences count against participation, so a
+        // run of garbage frames drags quality down instead of letting the
+        // surviving stale frames dead-reckon at undiminished quality.
+        // doy 366 is only ever broadcast in a leap year — accepting it in a
         // non-leap year would let advanceMinutes wrap a corrupt frame into
-        // January of the next year (doy 366 > 365 = year length) — even at age 0,
-        // where the wrap loop still runs — polluting the vote with an off-air
-        // date. Gate it out with the rest of the range-invalid frames.
-        if (raw.doy == 366 && !isLeapYear2(raw.year2)) continue;
+        // January of the next year, polluting the vote with an off-air date.
+        const bool rangeValid =
+            raw.minute >= 0 && raw.minute <= 59 &&
+            raw.hour   >= 0 && raw.hour   <= 23 &&
+            raw.doy    >= 1 && raw.doy    <= 366 &&
+            raw.year2  >= 0 && raw.year2  <= 99 &&
+            !(raw.doy == 366 && !isLeapYear2(raw.year2));
+
+        if (!rangeValid) {
+            NormalizedFrame nf;
+            nf.age = age;
+            nf.valid = false;
+            nf.meanConfidence = 0.0;
+            for (std::size_t fld = 0; fld < FieldCount; ++fld) {
+                const ClockFieldMap& map = m_cfg.fields[fld];
+                std::vector<NormalizedFrame::Bit>& dst = nf.bits[fld];
+                dst.resize(map.size());
+                for (std::size_t k = 0; k < map.size(); ++k) {
+                    const int sec = map[k].second;
+                    dst[k].symbol = ClockSymbol::Unknown;   // votes nothing
+                    dst[k].confidence =
+                        (sec >= 0 && sec < 60) ? f.confidence[sec] : 0.0f;
+                }
+            }
+            out.push_back(std::move(nf));
+            continue;
+        }
 
         NormalizedFrame nf;
         nf.age = age;
@@ -199,6 +238,12 @@ TimeFrameVoter::buildNormalizedFrames() const {
                 // per-second confidences — a faded bit carries a low matched-
                 // filter margin and loses the cross-frame vote. This is the
                 // reference model that rescues single-bit fades in noisy corpora.
+                // Note (WS-4.5): noise-grade margins still VOTE here — silencing
+                // them flips coherence verdicts and vote topology on real
+                // corpora (measured 2026-07-20 on the live WWV corpus). Their
+                // honesty cost is charged in TRUST instead: a bit whose winning
+                // side has no confident support scores zero trust
+                // (computeResolution), which is what refuses the lock.
                 for (std::size_t k = 0; k < map.size(); ++k) {
                     const int sec = map[k].second;
                     const bool inRange = sec >= 0 && sec < 60;
@@ -210,7 +255,13 @@ TimeFrameVoter::buildNormalizedFrames() const {
                 // NORMALIZED value and weight every bit by the field-MIN original
                 // confidence, so a value whose weakest bit faded votes at that
                 // faded margin. Blending is thus confined to normalized space,
-                // where the frames are supposed to agree.
+                // where the frames are supposed to agree. The eligibility floor
+                // deliberately does NOT apply here: the field-MIN weighting
+                // already discounts a faded frame to near-zero, and silencing it
+                // outright guts the fade rescue on minutes (every frame takes
+                // this path for minutes) — measured on the 2026-07-19 live WWV
+                // corpus, where the floor flipped the voted minute to the
+                // newest frame's corrupt raw value.
                 const std::vector<ClockSymbol> bits = encodeField(map, extByField[fld]);
                 const float w = fieldMinConf(f, static_cast<FieldIndex>(fld));
                 for (std::size_t k = 0; k < map.size(); ++k) {
@@ -285,6 +336,7 @@ TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
         int composeValue = 0;
 
         for (const NormalizedFrame& nf : frames) {
+            if (!nf.valid) continue;   // holds no value
             float fmin = -1.0f;
             for (const auto& b : nf.bits[fld]) {
                 fmin = (fmin < 0.0f) ? b.confidence : std::min(fmin, b.confidence);
@@ -298,6 +350,7 @@ TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
         for (std::size_t k = 0; k < map.size(); ++k) {
             BitStat s;
             double pAct = 0.0, pPot = 0.0;
+            float bestConf0 = 0.0f, bestConf1 = 0.0f;
             for (const NormalizedFrame& nf : frames) {
                 const NormalizedFrame::Bit b = nf.bits[fld][k];
                 const double aged =
@@ -308,11 +361,24 @@ TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
                     (b.symbol == ClockSymbol::One ? s.w1 : s.w0) += confW;
                     (b.symbol == ClockSymbol::One ? s.c1 : s.c0) += aged;
                     pAct += confW;
+                    float& best = (b.symbol == ClockSymbol::One) ? bestConf1
+                                                                 : bestConf0;
+                    best = std::max(best, b.confidence);
                 }
             }
             s.participation = pPot > 0.0 ? pAct / pPot : 0.0;
 
-            const double trust = bitMargin(s) * s.participation;
+            // Trust floor (WS-4.5): a bit whose WINNING side has not one vote
+            // at a confident margin is certified by nothing but noise — a deep
+            // fade misreads the SAME bits in every frame, and unanimity of
+            // noise-grade reads must not score margin-1.0 trust (the
+            // 2026-07-20 q100-on-2006-01-01 mechanism). The vote itself is
+            // untouched; only its certification collapses.
+            const float winnerBest = (s.w1 > s.w0) ? bestConf1 : bestConf0;
+            const bool certified = m_cfg.minBitConfidence <= 0.0f ||
+                                   winnerBest >= m_cfg.minBitConfidence;
+            const double trust =
+                certified ? bitMargin(s) * s.participation : 0.0;
             if (bitCoherent(s)) {
                 minCoherentTrust = std::min(minCoherentTrust, trust);
             } else {
@@ -367,6 +433,7 @@ TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
         const NormalizedFrame* best = nullptr;
         double bestWeight = -1.0;
         for (const NormalizedFrame& nf : frames) {
+            if (!nf.valid) continue;   // never fall back onto a garbage tuple
             const double w = agedWeight(static_cast<float>(nf.meanConfidence),
                                         m_cfg.agingFactor, nf.age);
             if (w > bestWeight) { bestWeight = w; best = &nf; }
@@ -439,6 +506,23 @@ bool TimeFrameVoter::locked() const {
     if (frames.empty()) {
         return false;
     }
+
+    // Staleness bound (WS-4.5): a lock needs a range-VALID frame among the
+    // newest maxNewestValidAge slots. Without this the window dead-reckons on
+    // aged frames while garbage streams in — the vote keeps extrapolating
+    // forward with no live support.
+    if (m_cfg.maxNewestValidAge >= 0) {
+        bool fresh = false;
+        for (const NormalizedFrame& nf : frames) {
+            if (nf.valid && nf.age <= m_cfg.maxNewestValidAge) {
+                fresh = true;
+                break;
+            }
+        }
+        if (!fresh) {
+            return false;
+        }
+    }
     for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
         const ClockFieldMap& map = m_cfg.fields[fi];
         double margin = 0.0;
@@ -455,6 +539,43 @@ bool TimeFrameVoter::locked() const {
         }
         if (!(margin > 0.0)) {
             return false;
+        }
+    }
+
+    // WS-4.5 honesty gates. Both consume the SAME resolution votedField and
+    // lockConfidence report, so a refused lock is always explicable from the
+    // published value/quality pair.
+    if (m_cfg.minLockQuality > 0.0f || (m_cfg.plausibilityBoundMinutes > 0 &&
+                                        m_cfg.referenceNow)) {
+        const Resolution res = computeResolution();
+
+        // Quality floor: unanimity of ineligible (noise-grade) bits shows up
+        // here as collapsed participation -> collapsed trust.
+        if (m_cfg.minLockQuality > 0.0f &&
+            res.quality < static_cast<double>(m_cfg.minLockQuality)) {
+            return false;
+        }
+
+        // Absolute plausibility: a self-consistent decode implausibly far from
+        // the reference clock is vetoed by the only independent evidence there
+        // is. Fields of `res.value` are range-valid by construction (both the
+        // compose and its fallback pass the range gates), so the calendar
+        // arithmetic is safe.
+        if (m_cfg.plausibilityBoundMinutes > 0 && m_cfg.referenceNow) {
+            const TimeFields ref = m_cfg.referenceNow();
+            const bool refValid =
+                ref.minute >= 0 && ref.minute <= 59 &&
+                ref.hour   >= 0 && ref.hour   <= 23 &&
+                ref.doy    >= 1 && ref.doy    <= 366 &&
+                ref.year2  >= 0 && ref.year2  <= 99;
+            if (refValid) {
+                const long long diff =
+                    minutesSince2000(res.value) - minutesSince2000(ref);
+                const long long bound = m_cfg.plausibilityBoundMinutes;
+                if (diff > bound || diff < -bound) {
+                    return false;
+                }
+            }
         }
     }
 

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -487,10 +487,19 @@ int TimeFrameVoter::lastFrameMinute() const {
     return decodeMinutes(m_frames.back());
 }
 
-bool TimeFrameVoter::locked() const {
+bool TimeFrameVoter::locked() const { return lockVerdict().locked; }
+
+ClockLockRefusal TimeFrameVoter::lockRefusal() const {
+    return lockVerdict().reason;
+}
+
+// The original locked() body, verbatim, with each refusal tagged (WS-7): same
+// gates, same order, same short-circuits — the tag names the branch that was
+// already taken, so tagging cannot change lock behavior (corpus-gated A/B).
+TimeFrameVoter::LockVerdict TimeFrameVoter::lockVerdict() const {
     const int n = static_cast<int>(m_frames.size());
     if (n < m_cfg.minFramesForLock) {
-        return false;
+        return {false, ClockLockRefusal::None};  // still collecting
     }
 
     // Count adjacent frame pairs whose decoded minutes increment by exactly +1
@@ -507,7 +516,7 @@ bool TimeFrameVoter::locked() const {
         }
     }
     if (increments < m_cfg.minFramesForLock - 1) {
-        return false;
+        return {false, ClockLockRefusal::Contested};
     }
 
     // Static-field self-consistency in the SAME normalized space the vote uses:
@@ -517,7 +526,7 @@ bool TimeFrameVoter::locked() const {
     // lock.
     const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
     if (frames.empty()) {
-        return false;
+        return {false, ClockLockRefusal::Staleness};
     }
 
     // Staleness bound (WS-4.5): a lock needs a range-VALID frame among the
@@ -533,7 +542,7 @@ bool TimeFrameVoter::locked() const {
             }
         }
         if (!fresh) {
-            return false;
+            return {false, ClockLockRefusal::Staleness};
         }
     }
     for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
@@ -551,7 +560,7 @@ bool TimeFrameVoter::locked() const {
             margin += std::max(w0, w1) - std::min(w0, w1);
         }
         if (!(margin > 0.0)) {
-            return false;
+            return {false, ClockLockRefusal::Contested};
         }
     }
 
@@ -566,7 +575,7 @@ bool TimeFrameVoter::locked() const {
         // here as collapsed participation -> collapsed trust.
         if (m_cfg.minLockQuality > 0.0f &&
             res.quality < static_cast<double>(m_cfg.minLockQuality)) {
-            return false;
+            return {false, ClockLockRefusal::QualityFloor};
         }
 
         // Absolute plausibility: a self-consistent decode implausibly far from
@@ -586,13 +595,13 @@ bool TimeFrameVoter::locked() const {
                     minutesSince2000(res.value) - minutesSince2000(ref);
                 const long long bound = m_cfg.plausibilityBoundMinutes;
                 if (diff > bound || diff < -bound) {
-                    return false;
+                    return {false, ClockLockRefusal::Plausibility};
                 }
             }
         }
     }
 
-    return true;
+    return {true, ClockLockRefusal::None};
 }
 
 float TimeFrameVoter::lockConfidence() const {

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -22,7 +22,36 @@ inline float agedWeight(float confidence, float agingFactor, int age) {
     return base * std::pow(agingFactor, static_cast<float>(age));
 }
 
+// True when the two-digit year names a Gregorian leap year, under the 20xx
+// century assumption (full year = 2000 + year2). Within 2000..2099 this reduces
+// to year2 % 4 == 0 — 2000 is a 400-divisible leap year and no year in that
+// span is century-divisible — but the full rule is written out so the helper
+// stays correct if the century assumption is ever revisited.
+inline bool isLeapYear2(int year2) {
+    const int y = 2000 + year2;
+    return (y % 4 == 0) && (y % 100 != 0 || y % 400 == 0);
+}
+
 } // namespace
+
+// Forward calendar arithmetic with minute/hour/doy/year carries. `minutes` is
+// small in practice (bounded by the voter window), but the loops are written to
+// carry across any number of day/year boundaries.
+TimeFields advanceMinutes(TimeFields t, int minutes) {
+    t.minute += minutes;
+    t.hour   += t.minute / 60;
+    t.minute %= 60;
+    int carryDays = t.hour / 24;
+    t.hour %= 24;
+    t.doy += carryDays;
+    // doy is 1-based; wrap at the current year's length, carrying year2 (mod 100).
+    for (int len = isLeapYear2(t.year2) ? 366 : 365; t.doy > len;
+         len = isLeapYear2(t.year2) ? 366 : 365) {
+        t.doy -= len;
+        t.year2 = (t.year2 + 1) % 100;
+    }
+    return t;
+}
 
 TimeFrameVoter::TimeFrameVoter(Config cfg) : m_cfg(std::move(cfg)) {}
 
@@ -46,17 +75,21 @@ int TimeFrameVoter::frameCount() const {
     return static_cast<int>(m_frames.size());
 }
 
-// Per-frame BCD minutes decode: sum the minutes-map weights whose second
-// classified as One. Marker/Unknown contribute nothing.
-int TimeFrameVoter::decodeMinutes(const Frame& f) const {
+// Per-frame BCD field decode: sum the field-map weights whose second classified
+// as One. Marker/Unknown contribute nothing.
+int TimeFrameVoter::decodeField(const Frame& f, FieldIndex field) const {
     int value = 0;
-    for (const auto& bw : m_cfg.fields[FieldMinutes]) {
+    for (const auto& bw : m_cfg.fields[field]) {
         if (bw.second >= 0 && bw.second < 60 &&
             f.symbols[bw.second] == ClockSymbol::One) {
             value += bw.weight;
         }
     }
     return value;
+}
+
+int TimeFrameVoter::decodeMinutes(const Frame& f) const {
+    return decodeField(f, FieldMinutes);
 }
 
 bool TimeFrameVoter::locked() const {
@@ -118,71 +151,90 @@ bool TimeFrameVoter::locked() const {
     return true;
 }
 
-int TimeFrameVoter::votedField(FieldIndex field) const {
+TimeFields TimeFrameVoter::votedTimestamp() const {
     const int n = static_cast<int>(m_frames.size());
-    if (n == 0) {
-        return -1;
-    }
 
-    // FieldMinutes is special: bits change frame-to-frame, so vote on the
-    // decoded VALUE normalized to the newest frame (older frames + their age,
-    // mod 60), weighted by each frame's mean minutes-map confidence, aged.
-    if (field == FieldMinutes) {
-        const auto& mmap = m_cfg.fields[FieldMinutes];
-        std::unordered_map<int, double> weightByValue;
-        for (int i = 0; i < n; ++i) {
-            const int age = (n - 1) - i;
-            const Frame& f = m_frames[i];
-            const int normalized = ((decodeMinutes(f) + age) % 60 + 60) % 60;
-
-            double confSum = 0.0;
-            int confCount = 0;
-            for (const auto& bw : mmap) {
+    // Field-map bit indices whose per-frame confidences represent a frame's
+    // timestamp-decode quality (union of the four voted field maps).
+    auto meanTimestampConfidence = [&](const Frame& f) -> double {
+        double sum = 0.0;
+        int count = 0;
+        for (const FieldIndex fld : {FieldMinutes, FieldHours, FieldDoy, FieldYear}) {
+            for (const auto& bw : m_cfg.fields[fld]) {
                 if (bw.second >= 0 && bw.second < 60) {
-                    confSum += f.confidence[bw.second];
-                    ++confCount;
+                    sum += f.confidence[bw.second];
+                    ++count;
                 }
             }
-            const double meanConf = confCount ? confSum / confCount : 0.0;
-            weightByValue[normalized] +=
-                meanConf * std::pow(static_cast<double>(m_cfg.agingFactor),
-                                    static_cast<double>(age));
         }
+        return count ? sum / count : 0.0;
+    };
 
-        int best = -1;
-        double bestWeight = -1.0;
-        for (const auto& [value, weight] : weightByValue) {
-            if (weight > bestWeight) {
-                bestWeight = weight;
-                best = value;
-            }
-        }
-        return best;
+    // Encode a range-valid timestamp tuple to a collision-free key so equal
+    // extrapolated timestamps accumulate their weight together.
+    auto encode = [](const TimeFields& t) -> int64_t {
+        return (static_cast<int64_t>(t.year2) * 100000000) +
+               (static_cast<int64_t>(t.doy) * 100000) +
+               (static_cast<int64_t>(t.hour) * 1000) +
+               static_cast<int64_t>(t.minute);
+    };
+
+    std::unordered_map<int64_t, double> weightByTuple;
+    std::unordered_map<int64_t, TimeFields> tupleByKey;
+
+    for (int i = 0; i < n; ++i) {
+        const int age = (n - 1) - i;  // newest -> age 0
+        const Frame& f = m_frames[i];
+
+        TimeFields tf;
+        tf.minute = decodeField(f, FieldMinutes);
+        tf.hour   = decodeField(f, FieldHours);
+        tf.doy    = decodeField(f, FieldDoy);
+        tf.year2  = decodeField(f, FieldYear);
+
+        // Exclude frames whose fields decode outside valid broadcast ranges —
+        // the same spirit as excluding Marker/Unknown symbols from a bit vote.
+        if (tf.minute < 0 || tf.minute > 59) continue;
+        if (tf.hour   < 0 || tf.hour   > 23) continue;
+        if (tf.doy    < 1 || tf.doy    > 366) continue;
+        if (tf.year2  < 0 || tf.year2  > 99) continue;
+
+        // Extrapolate this frame's timestamp forward to the newest frame, so all
+        // in-window frames vote on the SAME (newest) timestamp.
+        const TimeFields ext = advanceMinutes(tf, age);
+        const double w =
+            agedWeight(static_cast<float>(meanTimestampConfidence(f)),
+                       m_cfg.agingFactor, age);
+        const int64_t key = encode(ext);
+        weightByTuple[key] += w;
+        tupleByKey[key] = ext;
     }
 
-    // Static fields: per-bit confidence-weighted majority; sum the weights of
-    // the bits that voted One.
-    int value = 0;
-    for (const auto& bw : m_cfg.fields[field]) {
-        if (bw.second < 0 || bw.second >= 60) {
-            continue;
-        }
-        float w0 = 0.0f, w1 = 0.0f;
-        for (int i = 0; i < n; ++i) {
-            const int age = (n - 1) - i;
-            const Frame& f = m_frames[i];
-            const ClockSymbol s = f.symbols[bw.second];
-            if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
-                const float w =
-                    agedWeight(f.confidence[bw.second], m_cfg.agingFactor, age);
-                (s == ClockSymbol::One ? w1 : w0) += w;
-            }
-        }
-        if (w1 > w0) {
-            value += bw.weight;
+    int64_t bestKey = 0;
+    double bestWeight = -1.0;
+    bool have = false;
+    for (const auto& [key, weight] : weightByTuple) {
+        if (weight > bestWeight) {
+            bestWeight = weight;
+            bestKey = key;
+            have = true;
         }
     }
-    return value;
+    return have ? tupleByKey[bestKey] : TimeFields{};
+}
+
+int TimeFrameVoter::votedField(FieldIndex field) const {
+    if (m_frames.empty()) {
+        return -1;
+    }
+    const TimeFields t = votedTimestamp();
+    switch (field) {
+        case FieldMinutes: return t.minute;
+        case FieldHours:   return t.hour;
+        case FieldDoy:     return t.doy;
+        case FieldYear:    return t.year2;
+        default:           return -1;
+    }
 }
 
 int TimeFrameVoter::lastFrameMinute() const {
@@ -193,6 +245,13 @@ int TimeFrameVoter::lastFrameMinute() const {
 }
 
 float TimeFrameVoter::lockConfidence() const {
+    // Deliberately retained as the per-bit winning-margin over the static-field
+    // bits of the window, NOT switched to the winning-tuple weight margin. It
+    // measures raw bit stability, which is the honest quantity here: during an
+    // hour/day rollover the window straddles two timestamps, the per-bit margins
+    // dip, and reporting that dip is correct — quality SHOULD soften through a
+    // transition even though the tuple vote (votedTimestamp) now resolves the
+    // reported time unambiguously.
     const int n = static_cast<int>(m_frames.size());
     if (n < m_cfg.minFramesForLock) {
         return 0.0f;

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -8,11 +8,17 @@
 // Cross-frame confidence-weighted voting per the AetherClock reference decoder:
 // a bit's vote is the sum of its per-frame matched-filter margins (floored at
 // 0.01), with older frames discounted by agingFactor^age. Markers and Unknown
-// symbols never vote. The timestamp vote is NORMALIZE-then-per-bit: every frame
-// is first extrapolated to the newest epoch (removing the epoch skew that makes
-// a stale hour dangerous), then bits are voted in that normalized space, where
-// frames are supposed to agree. Lock gates on consecutive +1 minute increments
-// plus self-consistent static fields.
+// symbols never vote. The timestamp vote is NORMALIZE-then-COHERENCE-GATED-
+// per-bit: every frame is first extrapolated to the newest epoch (removing the
+// epoch skew that makes a stale hour dangerous), then each field is composed from
+// its bits ONLY when every bit is coherent (its confidence-winner agrees with its
+// aging-only count majority); an incoherent field — where sibling bits are carried
+// by different frame camps — falls back to the top value some frame actually held,
+// so per-bit voting can never assemble a phantom value. Quality is computed in the
+// same pass (computeResolution) as the min across fields of per-bit trust
+// (margin x participation) or the held-value margin, so value and quality can
+// never disagree. Lock gates on consecutive +1 minute increments plus
+// self-consistent static fields.
 
 namespace AetherSDR {
 
@@ -218,33 +224,128 @@ TimeFrameVoter::buildNormalizedFrames() const {
     return out;
 }
 
-// Per-field, per-bit tally across the normalized window: heavier of One/Zero
-// wins. `frames` is the shared normalized view.
 namespace {
-struct BitTally { float w0 = 0.0f, w1 = 0.0f; };
+
+// One field's per-bit tallies across the normalized window: confidence-weighted
+// (w) decides the value; aging-only count (c) decides the count majority; the
+// two together decide COHERENCE. `part` is participation (participating weight /
+// potential weight) — the lone-floor-voter guard.
+struct BitStat {
+    double w0 = 0.0, w1 = 0.0;   // confidence-weighted (aged x max(conf,0.01))
+    double c0 = 0.0, c1 = 0.0;   // aging-only count (aged, no confidence)
+    double participation = 0.0;  // Pact / Ppot
+};
+
+// This bit is coherent iff its confidence-winner agrees with its count-winner,
+// or the count is tied (no majority to contradict). Ties in w resolve to Zero,
+// matching the compose rule (value bit set only when w1 > w0).
+inline bool bitCoherent(const BitStat& b) {
+    const bool wOne = b.w1 > b.w0;
+    const bool cOne = b.c1 > b.c0;
+    const bool cTied = b.c0 == b.c1;
+    return cTied || (wOne == cOne);
+}
+
+// Normalized winning margin of a bit, 0 when nothing participated.
+inline double bitMargin(const BitStat& b) {
+    const double total = b.w0 + b.w1;
+    constexpr double kEpsilon = 1e-6;
+    return total > 0.0 ? (std::max(b.w0, b.w1) - std::min(b.w0, b.w1)) / (total + kEpsilon)
+                       : 0.0;
+}
+
 } // namespace
 
-TimeFields TimeFrameVoter::votedTimestamp() const {
+TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
+    Resolution r;  // value all -1, quality 0
     const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
     if (frames.empty()) {
-        return TimeFields{};
+        return r;
     }
 
     int valueByField[FieldCount] = {0, 0, 0, 0};
+    double qualityByField[FieldCount] = {1.0, 1.0, 1.0, 1.0};
+
     for (std::size_t fld = 0; fld < FieldCount; ++fld) {
         const ClockFieldMap& map = m_cfg.fields[fld];
+
+        // Held-value vote: each frame votes its whole ext field VALUE, weighted by
+        // aged x the frame's field-min original confidence (consistent with the
+        // re-encode weighting) — a value a frame actually carried, never composed.
+        std::vector<std::pair<int, double>> held;  // (value, weight)
+        auto addHeld = [&](int value, double weight) {
+            for (auto& hv : held) {
+                if (hv.first == value) { hv.second += weight; return; }
+            }
+            held.push_back({value, weight});
+        };
+
+        bool allCoherent = true;
+        double minCoherentTrust = 1.0;
+        int composeValue = 0;
+
+        for (const NormalizedFrame& nf : frames) {
+            float fmin = -1.0f;
+            for (const auto& b : nf.bits[fld]) {
+                fmin = (fmin < 0.0f) ? b.confidence : std::min(fmin, b.confidence);
+            }
+            const int extByField[FieldCount] = {nf.ext.minute, nf.ext.hour,
+                                                nf.ext.doy, nf.ext.year2};
+            addHeld(extByField[fld],
+                    agedWeight(fmin < 0.0f ? 0.0f : fmin, m_cfg.agingFactor, nf.age));
+        }
+
         for (std::size_t k = 0; k < map.size(); ++k) {
-            BitTally t;
+            BitStat s;
+            double pAct = 0.0, pPot = 0.0;
             for (const NormalizedFrame& nf : frames) {
                 const NormalizedFrame::Bit b = nf.bits[fld][k];
+                const double aged =
+                    std::pow(static_cast<double>(m_cfg.agingFactor), nf.age);
+                const double confW = std::max(b.confidence, 0.01f) * aged;
+                pPot += confW;  // potential: every frame's aged floored confidence
                 if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
-                    const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
-                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
+                    (b.symbol == ClockSymbol::One ? s.w1 : s.w0) += confW;
+                    (b.symbol == ClockSymbol::One ? s.c1 : s.c0) += aged;
+                    pAct += confW;
                 }
             }
-            if (t.w1 > t.w0) {
-                valueByField[fld] += map[k].weight;
+            s.participation = pPot > 0.0 ? pAct / pPot : 0.0;
+
+            const double trust = bitMargin(s) * s.participation;
+            if (bitCoherent(s)) {
+                minCoherentTrust = std::min(minCoherentTrust, trust);
+            } else {
+                allCoherent = false;
             }
+            if (s.w1 > s.w0) {
+                composeValue += map[k].weight;
+            }
+        }
+
+        // Top two held values -> held-value margin.
+        double topW = 0.0, runnerW = 0.0, totalHeld = 0.0;
+        int topValue = 0;
+        for (const auto& hv : held) {
+            totalHeld += hv.second;
+            if (hv.second > topW) { runnerW = topW; topW = hv.second; topValue = hv.first; }
+            else if (hv.second > runnerW) { runnerW = hv.second; }
+        }
+        constexpr double kEpsilon = 1e-6;
+        const double valueMargin = (topW - runnerW) / (totalHeld + kEpsilon);
+
+        if (allCoherent) {
+            // Fade-rescue / clean path: every bit's confidence-winner is also its
+            // count majority, so composing them cannot synthesize a phantom value.
+            valueByField[fld] = composeValue;
+            qualityByField[fld] = minCoherentTrust;
+        } else {
+            // A sibling bit was carried by a DIFFERENT frame camp than its count
+            // majority — per-bit composition would Frankenstein a value no frame
+            // held. Fall back to the top held value; quality is the weaker of the
+            // held-value consensus and the coherent bits' trust.
+            valueByField[fld] = topValue;
+            qualityByField[fld] = std::min(valueMargin, minCoherentTrust);
         }
     }
 
@@ -254,30 +355,35 @@ TimeFields TimeFrameVoter::votedTimestamp() const {
     voted.doy    = valueByField[FieldDoy];
     voted.year2  = valueByField[FieldYear];
 
-    // Final-range guard: per-bit blending can in principle synthesize an
-    // out-of-range BCD value (e.g. a minute summing 5+10+20+40). If it did, fall
-    // back to the single highest-aged-weight frame's extrapolated tuple rather
-    // than emit an impossible broadcast time.
+    // Final-range guard: an all-coherent compose can still sum to an out-of-range
+    // BCD value. If it did, the window has no usable consensus — fall back to the
+    // highest-aged-weight frame's tuple and report quality 0 for the emission.
     const bool inRange =
         voted.minute >= 0 && voted.minute <= 59 &&
         voted.hour   >= 0 && voted.hour   <= 23 &&
         voted.doy    >= 1 && voted.doy    <= 366 &&
         voted.year2  >= 0 && voted.year2  <= 99;
-    if (inRange) {
-        return voted;
+    if (!inRange) {
+        const NormalizedFrame* best = nullptr;
+        double bestWeight = -1.0;
+        for (const NormalizedFrame& nf : frames) {
+            const double w = agedWeight(static_cast<float>(nf.meanConfidence),
+                                        m_cfg.agingFactor, nf.age);
+            if (w > bestWeight) { bestWeight = w; best = &nf; }
+        }
+        r.value = best ? best->ext : TimeFields{};
+        r.quality = 0.0;
+        return r;
     }
 
-    const NormalizedFrame* best = nullptr;
-    double bestWeight = -1.0;
-    for (const NormalizedFrame& nf : frames) {
-        const double w = agedWeight(static_cast<float>(nf.meanConfidence),
-                                    m_cfg.agingFactor, nf.age);
-        if (w > bestWeight) {
-            bestWeight = w;
-            best = &nf;
-        }
-    }
-    return best ? best->ext : TimeFields{};
+    r.value = voted;
+    r.quality = std::min({qualityByField[FieldMinutes], qualityByField[FieldHours],
+                          qualityByField[FieldDoy], qualityByField[FieldYear]});
+    return r;
+}
+
+TimeFields TimeFrameVoter::votedTimestamp() const {
+    return computeResolution().value;
 }
 
 int TimeFrameVoter::votedField(FieldIndex field) const {
@@ -337,15 +443,15 @@ bool TimeFrameVoter::locked() const {
         const ClockFieldMap& map = m_cfg.fields[fi];
         double margin = 0.0;
         for (std::size_t k = 0; k < map.size(); ++k) {
-            BitTally t;
+            float w0 = 0.0f, w1 = 0.0f;
             for (const NormalizedFrame& nf : frames) {
                 const NormalizedFrame::Bit b = nf.bits[fi][k];
                 if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
                     const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
-                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
+                    (b.symbol == ClockSymbol::One ? w1 : w0) += w;
                 }
             }
-            margin += std::max(t.w0, t.w1) - std::min(t.w0, t.w1);
+            margin += std::max(w0, w1) - std::min(w0, w1);
         }
         if (!(margin > 0.0)) {
             return false;
@@ -356,58 +462,29 @@ bool TimeFrameVoter::locked() const {
 }
 
 float TimeFrameVoter::lockConfidence() const {
-    // MINIMUM normalized winning margin over the voted timestamp bits, in the
-    // SAME normalized (age-extrapolated) space as votedField, x frame-count
-    // saturation. The min — not the mean — is the honest aggregate: a timestamp
-    // is exactly as trustworthy as its least-certain bit (one flipped bit changes
-    // the value), so quality must collapse to the single most-contested bit's
-    // margin. A mean let ~30 clean bits mask the one bit that actually decided a
-    // field, reporting near-1.0 while the value was wrong — confident garbage.
-    // Same principle as the re-encode weighting. Clean/clean-rollover windows:
-    // every bit unanimous once normalized -> every margin ~1.0 -> min ~1.0, so
-    // quality still tracks saturation and does not dip. A bit with ZERO
-    // participating votes (its second decoded Marker/Unknown in every window
-    // frame) has no consensus at all and is scored margin 0 -> quality 0.
+    // Quality is the resolution's own quality (computed WITH the value in
+    // computeResolution, so the two can never disagree) x frame-count saturation.
+    // That quality is the MIN across fields of each field's contribution: for a
+    // coherent field the minimum per-bit TRUST (normalized margin x participation
+    // — participation demotes a bit only one frame actually voted); for an
+    // incoherent field the held-value margin capped by the coherent bits' trust;
+    // and 0 outright when the compose fell out of range. Per-bit statistics alone
+    // (mean OR min) cannot certify a multi-bit BCD value — sibling bits can be
+    // carried by different frame camps — so quality reflects the weakest CERTIFIED
+    // link, not the weakest bit. Clean/clean-rollover windows: every bit coherent
+    // at full participation and margin ~1.0 -> quality ~1.0, tracking saturation.
     const int n = static_cast<int>(m_frames.size());
     if (n < m_cfg.minFramesForLock) {
         return 0.0f;
     }
-
-    const std::vector<NormalizedFrame> frames = buildNormalizedFrames();
-    if (frames.empty()) {
+    if (buildNormalizedFrames().empty()) {
         return 0.0f;
-    }
-
-    constexpr float kEpsilon = 1e-6f;
-    double minMargin = 1.0;
-    bool sawBit = false;
-
-    for (std::size_t fld = 0; fld < FieldCount; ++fld) {
-        const ClockFieldMap& map = m_cfg.fields[fld];
-        for (std::size_t k = 0; k < map.size(); ++k) {
-            BitTally t;
-            for (const NormalizedFrame& nf : frames) {
-                const NormalizedFrame::Bit b = nf.bits[fld][k];
-                if (b.symbol == ClockSymbol::One || b.symbol == ClockSymbol::Zero) {
-                    const float w = agedWeight(b.confidence, m_cfg.agingFactor, nf.age);
-                    (b.symbol == ClockSymbol::One ? t.w1 : t.w0) += w;
-                }
-            }
-            const float total = t.w0 + t.w1;
-            // No participating vote for this bit -> no consensus -> margin 0.
-            const double margin =
-                (total > 0.0f)
-                    ? (std::max(t.w0, t.w1) - std::min(t.w0, t.w1)) / (total + kEpsilon)
-                    : 0.0;
-            minMargin = std::min(minMargin, margin);
-            sawBit = true;
-        }
     }
 
     const double saturation =
         std::min(1.0, static_cast<double>(n) /
                           (2.0 * static_cast<double>(m_cfg.minFramesForLock)));
-    const double quality = (sawBit ? minMargin : 0.0) * saturation;
+    const double quality = computeResolution().quality * saturation;
     return static_cast<float>(std::clamp(quality, 0.0, 1.0));
 }
 

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -400,9 +400,22 @@ TimeFrameVoter::Resolution TimeFrameVoter::computeResolution() const {
         constexpr double kEpsilon = 1e-6;
         const double valueMargin = (topW - runnerW) / (totalHeld + kEpsilon);
 
-        if (allCoherent) {
-            // Fade-rescue / clean path: every bit's confidence-winner is also its
-            // count majority, so composing them cannot synthesize a phantom value.
+        // Per-bit coherence is necessary but NOT sufficient to rule out a
+        // synthesized value: rotating multi-bit misreads at comparable
+        // confidence can win every bit from a DIFFERENT frame camp -- each bit
+        // coherent, yet the composed value held by no frame (refuter round 5,
+        // 2026-07-20: frames holding {9, 10, 3} compose hour 11). The composed
+        // value must itself be a held value; otherwise the field demotes to
+        // the held-value fallback below.
+        bool composeHeld = false;
+        for (const auto& hv : held) {
+            if (hv.first == composeValue) { composeHeld = true; break; }
+        }
+
+        if (allCoherent && composeHeld) {
+            // Fade-rescue / clean path: every bit's confidence-winner is also
+            // its count majority AND the composed value is one some frame
+            // actually carried -- composing cannot synthesize a phantom.
             valueByField[fld] = composeValue;
             qualityByField[fld] = minCoherentTrust;
         } else {

--- a/src/core/TimeFrameVoter.cpp
+++ b/src/core/TimeFrameVoter.cpp
@@ -1,0 +1,237 @@
+#include "TimeFrameVoter.h"
+
+#include <algorithm>
+#include <cmath>
+#include <unordered_map>
+#include <utility>
+
+// Cross-frame confidence-weighted bit voting per the AetherClock reference
+// decoder: a bit's vote is the sum of its per-frame matched-filter margins
+// (floored at 0.01), with older frames discounted by agingFactor^age. Markers
+// and Unknown symbols never vote. Lock gates on consecutive +1 minute
+// increments plus self-consistent static fields.
+
+namespace AetherSDR {
+
+namespace {
+
+// Per-frame vote weight for one static bit: max(confidence, 0.01) aged by
+// agingFactor^age (age 0 = newest frame).
+inline float agedWeight(float confidence, float agingFactor, int age) {
+    const float base = std::max(confidence, 0.01f);
+    return base * std::pow(agingFactor, static_cast<float>(age));
+}
+
+} // namespace
+
+TimeFrameVoter::TimeFrameVoter(Config cfg) : m_cfg(std::move(cfg)) {}
+
+void TimeFrameVoter::addFrame(const std::array<ClockSymbol, 60>& symbols,
+                              const std::array<float, 60>& confidence) {
+    Frame f;
+    f.symbols = symbols;
+    f.confidence = confidence;
+    m_frames.push_back(f);
+    // Drop oldest beyond the sliding window (newest kept at the back).
+    while (m_frames.size() > m_cfg.window) {
+        m_frames.erase(m_frames.begin());
+    }
+}
+
+void TimeFrameVoter::reset() {
+    m_frames.clear();
+}
+
+int TimeFrameVoter::frameCount() const {
+    return static_cast<int>(m_frames.size());
+}
+
+// Per-frame BCD minutes decode: sum the minutes-map weights whose second
+// classified as One. Marker/Unknown contribute nothing.
+int TimeFrameVoter::decodeMinutes(const Frame& f) const {
+    int value = 0;
+    for (const auto& bw : m_cfg.fields[FieldMinutes]) {
+        if (bw.second >= 0 && bw.second < 60 &&
+            f.symbols[bw.second] == ClockSymbol::One) {
+            value += bw.weight;
+        }
+    }
+    return value;
+}
+
+bool TimeFrameVoter::locked() const {
+    const int n = static_cast<int>(m_frames.size());
+    if (n < m_cfg.minFramesForLock) {
+        return false;
+    }
+
+    // Count adjacent frame pairs whose decoded minutes increment by exactly +1
+    // (mod 60; 59 -> 0 valid). Live per-frame decodes are routinely imperfect,
+    // so increment support is COUNTED across the window rather than required of
+    // every pair (cf. the reference's marker_score + 4 * increment_count) — one
+    // corrupted frame must not permanently prevent or drop the lock.
+    int increments = 0;
+    for (int i = 1; i < n; ++i) {
+        const int prev = decodeMinutes(m_frames[i - 1]);
+        const int cur = decodeMinutes(m_frames[i]);
+        if (((prev + 1) % 60) == cur) {
+            ++increments;
+        }
+    }
+    if (increments < m_cfg.minFramesForLock - 1) {
+        return false;
+    }
+
+    // Confidence-weighted vote weights for one mapped second across the window.
+    auto bitWeights = [&](int second) -> std::pair<float, float> {
+        float w0 = 0.0f, w1 = 0.0f;
+        if (second < 0 || second >= 60) {
+            return {w0, w1};
+        }
+        for (int i = 0; i < n; ++i) {
+            const int age = (n - 1) - i; // newest -> age 0
+            const Frame& f = m_frames[i];
+            const ClockSymbol s = f.symbols[second];
+            if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
+                const float w =
+                    agedWeight(f.confidence[second], m_cfg.agingFactor, age);
+                (s == ClockSymbol::One ? w1 : w0) += w;
+            }
+        }
+        return {w0, w1};
+    };
+
+    // Static-field self-consistency: each static field must carry at least one
+    // confident bit vote (a strictly positive winning margin). An all-Unknown
+    // window yields zero margin everywhere and must not lock.
+    for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
+        double margin = 0.0;
+        for (const auto& bw : m_cfg.fields[fi]) {
+            const auto [w0, w1] = bitWeights(bw.second);
+            margin += std::max(w0, w1) - std::min(w0, w1);
+        }
+        if (!(margin > 0.0)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int TimeFrameVoter::votedField(FieldIndex field) const {
+    const int n = static_cast<int>(m_frames.size());
+    if (n == 0) {
+        return -1;
+    }
+
+    // FieldMinutes is special: bits change frame-to-frame, so vote on the
+    // decoded VALUE normalized to the newest frame (older frames + their age,
+    // mod 60), weighted by each frame's mean minutes-map confidence, aged.
+    if (field == FieldMinutes) {
+        const auto& mmap = m_cfg.fields[FieldMinutes];
+        std::unordered_map<int, double> weightByValue;
+        for (int i = 0; i < n; ++i) {
+            const int age = (n - 1) - i;
+            const Frame& f = m_frames[i];
+            const int normalized = ((decodeMinutes(f) + age) % 60 + 60) % 60;
+
+            double confSum = 0.0;
+            int confCount = 0;
+            for (const auto& bw : mmap) {
+                if (bw.second >= 0 && bw.second < 60) {
+                    confSum += f.confidence[bw.second];
+                    ++confCount;
+                }
+            }
+            const double meanConf = confCount ? confSum / confCount : 0.0;
+            weightByValue[normalized] +=
+                meanConf * std::pow(static_cast<double>(m_cfg.agingFactor),
+                                    static_cast<double>(age));
+        }
+
+        int best = -1;
+        double bestWeight = -1.0;
+        for (const auto& [value, weight] : weightByValue) {
+            if (weight > bestWeight) {
+                bestWeight = weight;
+                best = value;
+            }
+        }
+        return best;
+    }
+
+    // Static fields: per-bit confidence-weighted majority; sum the weights of
+    // the bits that voted One.
+    int value = 0;
+    for (const auto& bw : m_cfg.fields[field]) {
+        if (bw.second < 0 || bw.second >= 60) {
+            continue;
+        }
+        float w0 = 0.0f, w1 = 0.0f;
+        for (int i = 0; i < n; ++i) {
+            const int age = (n - 1) - i;
+            const Frame& f = m_frames[i];
+            const ClockSymbol s = f.symbols[bw.second];
+            if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
+                const float w =
+                    agedWeight(f.confidence[bw.second], m_cfg.agingFactor, age);
+                (s == ClockSymbol::One ? w1 : w0) += w;
+            }
+        }
+        if (w1 > w0) {
+            value += bw.weight;
+        }
+    }
+    return value;
+}
+
+int TimeFrameVoter::lastFrameMinute() const {
+    if (m_frames.empty()) {
+        return -1;
+    }
+    return decodeMinutes(m_frames.back());
+}
+
+float TimeFrameVoter::lockConfidence() const {
+    const int n = static_cast<int>(m_frames.size());
+    if (n < m_cfg.minFramesForLock) {
+        return 0.0f;
+    }
+
+    constexpr float kEpsilon = 1e-6f;
+    double marginSum = 0.0;
+    int bitCount = 0;
+
+    // Mean normalized winning margin over every static-field mapped bit.
+    for (std::size_t fi = FieldHours; fi <= FieldYear; ++fi) {
+        for (const auto& bw : m_cfg.fields[fi]) {
+            if (bw.second < 0 || bw.second >= 60) {
+                continue;
+            }
+            float w0 = 0.0f, w1 = 0.0f;
+            for (int i = 0; i < n; ++i) {
+                const int age = (n - 1) - i;
+                const Frame& f = m_frames[i];
+                const ClockSymbol s = f.symbols[bw.second];
+                if (s == ClockSymbol::One || s == ClockSymbol::Zero) {
+                    const float w = agedWeight(f.confidence[bw.second],
+                                               m_cfg.agingFactor, age);
+                    (s == ClockSymbol::One ? w1 : w0) += w;
+                }
+            }
+            const float winning = std::max(w0, w1);
+            const float losing = std::min(w0, w1);
+            marginSum += (winning - losing) / (w0 + w1 + kEpsilon);
+            ++bitCount;
+        }
+    }
+
+    const double meanMargin = bitCount ? marginSum / bitCount : 0.0;
+    const double saturation =
+        std::min(1.0, static_cast<double>(n) /
+                          (2.0 * static_cast<double>(m_cfg.minFramesForLock)));
+    const double quality = meanMargin * saturation;
+    return static_cast<float>(std::clamp(quality, 0.0, 1.0));
+}
+
+} // namespace AetherSDR

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <vector>
 
 namespace AetherSDR {
@@ -57,6 +58,12 @@ struct ClockSecondInfo {
     std::vector<float> envelope; // received amplitude series (normalized 0..1-ish)
     std::vector<float> expected; // zero-mean matched template of `symbol`
     int seriesRateHz = 0;        // 200 for WWV/WWVH, 100 for WWVB
+    // Where the received pulse actually sits relative to the template's nominal
+    // position, in series samples (matched-filter shift minus the nominal chain
+    // delay). ~0 on a drift-free stream; nonzero while the decoder is absorbing
+    // sample-clock drift — the display should shift the expected overlay by
+    // this so envelope and template stay honest to each other (WS-4.5).
+    int windowShift = 0;
 };
 
 // Emitted once per completed frame decode (raw, pre-voting).
@@ -118,9 +125,49 @@ public:
         size_t window = 8;               // sliding window of most recent frames
         int minFramesForLock = 2;        // consistent frames required for lock
         float agingFactor = 0.9f;        // per-frame-age weight multiplier
+
+        // WS-4.5 honesty gates (all default-off = pre-WS-4.5 behavior).
+        //
+        // Trust floor: a bit whose WINNING side has no single vote at/above
+        // this margin contributes zero trust (its value still composes — only
+        // the certification collapses). Rationale (2026-07-20 live false lock,
+        // decoded 2006-01-01 at q100): a deep fade zero-biases the SAME bits in
+        // EVERY window frame, so the misread is unanimous — margin 1.0, full
+        // participation — and a disagreement-based quality metric certifies it.
+        // Unanimity of noise-grade reads is not evidence; a lock-quality floor
+        // then refuses the lock. (Deliberately NOT an eligibility gate on the
+        // votes themselves: silencing noise-grade votes flips coherence
+        // verdicts and vote topology on real corpora — measured 2026-07-20.)
+        float minBitConfidence = 0.0f;
+        // locked() additionally requires the resolution quality to reach this.
+        float minLockQuality = 0.0f;
+        // Absolute-plausibility leg: when armed (bound > 0 and referenceNow
+        // set), locked() refuses any voted timestamp farther than this many
+        // minutes from the reference clock. Systematic misreads (misaligned
+        // windows, coherent zero-bias) are self-consistent by construction, so
+        // an independent reference is the only evidence that can veto them. The
+        // bound is deliberately generous — a host clock that is minutes or even
+        // hours wrong is exactly what the feature measures; a decode DECADES
+        // away can only be garbage.
+        int plausibilityBoundMinutes = 0;
+        std::function<TimeFields()> referenceNow;
+        // Staleness bound: locked() requires a range-VALID frame within the
+        // newest maxNewestValidAge window slots. Without it the voter
+        // dead-reckons: range-invalid garbage frames used to vanish from the
+        // normalized window entirely, so the surviving stale frames kept
+        // extrapolating forward (+1 min per garbage frame) at undiminished
+        // quality — the 2026-07-20 receiver emitted advancing timestamps at
+        // q1.00 for minutes after the air turned to garbage.
+        int maxNewestValidAge = 3;
     };
 
     explicit TimeFrameVoter(Config cfg);
+
+    // Arm (or replace) the absolute-plausibility reference at runtime — the
+    // engine plumbs the host clock through the owning decoder after
+    // construction. boundMinutes <= 0 or a null function disarms the gate.
+    void setPlausibility(std::function<TimeFields()> referenceNow,
+                         int boundMinutes);
 
     // Add one complete 60 s frame of classified symbols + confidences. Frames
     // MUST be consecutive broadcast minutes — the caller resets on gaps or
@@ -213,6 +260,12 @@ private:
     // locked all consume, so their view of the window is guaranteed identical.
     struct NormalizedFrame {
         int age = 0;                 // 0 = newest frame
+        // False for a frame whose raw decode fell outside valid broadcast
+        // ranges: it VOTES nothing and HOLDS nothing, but it still occupies its
+        // window slot and its real per-second confidences still count against
+        // participation — confident air that fails to form a valid timestamp
+        // is evidence AGAINST the surviving stale frames, not silence.
+        bool valid = true;
         double meanConfidence = 0.0; // frame mean over the four field maps
         TimeFields ext;              // this frame's timestamp at the newest epoch
         // Per bit of a field map: the normalized symbol and the confidence that

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -1,0 +1,152 @@
+#pragma once
+
+// AetherClock shared time-frame machinery: the per-second/per-frame result
+// types both time-signal decoders emit, plus cross-frame confidence-weighted
+// bit voting over a sliding window of decoded frames.
+//
+// Field maps are supplied by each decoder from the NIST time-code tables
+// (WWV/WWVH per NIST SP 432; WWVB legacy AM per NIST SP 250-67). This unit is
+// map-agnostic: it votes bits, scores minute increments across consecutive
+// frames, and reports lock + aggregate confidence.
+//
+// Pure DSP/logic — no Qt, no GUI (engine-boundary EB1/EB2).
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace AetherSDR {
+
+// Classified per-second symbol of an AM time-code frame.
+enum class ClockSymbol : int8_t {
+    Unknown = -1,
+    Zero    = 0,
+    One     = 1,
+    Marker  = 2,
+};
+
+enum class ClockLockState : int {
+    NoSignal  = 0,
+    Acquiring = 1,
+    Locked    = 2,
+};
+
+enum class ClockStation : int {
+    Unknown = 0,
+    Wwv     = 1,
+    Wwvh    = 2,
+    Wwvb    = 3,
+};
+
+// One BCD map entry: which second-of-frame carries which weight. A field's
+// value is the sum of weights whose seconds decoded as One.
+struct ClockBitWeight {
+    int second;   // 0..59
+    int weight;
+};
+using ClockFieldMap = std::vector<ClockBitWeight>;
+
+// Emitted once per classified second (drives the alignment display).
+struct ClockSecondInfo {
+    int64_t edgeSample = 0;      // sample index (total consumed) of the second edge
+    ClockSymbol symbol = ClockSymbol::Unknown;
+    float confidence = 0.0f;     // matched-filter margin (best - runner-up), >= 0
+    int secondOfFrame = -1;      // 0..59 once frame-synced, else -1
+    // 1 s alignment window at the decoder's series rate:
+    std::vector<float> envelope; // received amplitude series (normalized 0..1-ish)
+    std::vector<float> expected; // zero-mean matched template of `symbol`
+    int seriesRateHz = 0;        // 200 for WWV/WWVH, 100 for WWVB
+};
+
+// Emitted once per completed frame decode (raw, pre-voting).
+struct ClockFrameInfo {
+    int minute = -1, hour = -1, doy = -1, year2 = -1; // per-frame BCD decode
+    int dut1Tenths = 0;          // signed tenths of a second (e.g. -3 = -0.3 s)
+    bool dst1 = false;           // WWV s2  (WWVB: DST-code bit s57)
+    bool dst2 = false;           // WWV s55 (WWVB: DST-code bit s58)
+    bool leapPending = false;    // leap-second warning bit
+    bool leapYear = false;       // WWVB LYI s55 (always false for WWV)
+    float frameConfidence = 0.0f;    // 0..1
+    int64_t frameStartSample = 0;    // sample index of second 0 of this frame
+    ClockStation station = ClockStation::Unknown;
+};
+
+// The voted broadcast time once locked.
+struct ClockTimeInfo {
+    int minute = -1, hour = -1, doy = -1, year2 = -1;
+    float quality = 0.0f;            // voter lockConfidence, 0..1
+    int64_t lastEdgeSample = 0;      // sample index of the most recent second edge
+    int lastEdgeSecondOfFrame = -1;  // second-of-frame of that edge
+    ClockStation station = ClockStation::Unknown;
+};
+
+// Cross-frame confidence-weighted bit voter (reference: wwv_decode_proto.py —
+// weight = max(confidence, 0.01); production adds frame aging).
+class TimeFrameVoter {
+public:
+    // Well-known indices into Config::fields.
+    enum FieldIndex : size_t {
+        FieldMinutes = 0,   // special: expected to increment +1 per frame
+        FieldHours   = 1,
+        FieldDoy     = 2,
+        FieldYear    = 3,
+        FieldCount   = 4,
+    };
+
+    struct Config {
+        std::array<ClockFieldMap, FieldCount> fields;
+        std::vector<int> markerSeconds;  // marker positions within the frame
+        size_t window = 8;               // sliding window of most recent frames
+        int minFramesForLock = 2;        // consistent frames required for lock
+        float agingFactor = 0.9f;        // per-frame-age weight multiplier
+    };
+
+    explicit TimeFrameVoter(Config cfg);
+
+    // Add one complete 60 s frame of classified symbols + confidences. Frames
+    // MUST be consecutive broadcast minutes — the caller resets on gaps or
+    // re-anchoring. Markers are excluded from bit votes automatically.
+    void addFrame(const std::array<ClockSymbol, 60>& symbols,
+                  const std::array<float, 60>& confidence);
+
+    void reset();
+
+    int frameCount() const;   // frames currently in the window
+
+    // Lock = at least minFramesForLock frames in the window, AND at least
+    // (minFramesForLock - 1) adjacent frame pairs whose per-frame minutes
+    // decode increments by exactly +1 (mod 60), AND voted static fields
+    // self-consistent. Increment support is COUNTED across the window, not
+    // required of every pair — live per-frame decodes are routinely imperfect
+    // and one corrupted frame must not permanently prevent or drop the lock
+    // (the reference scores increments: marker_score + 4 * increment_count).
+    bool locked() const;
+
+    // Confidence-weighted bit vote across the window. For each mapped second,
+    // per-frame vote weight = max(confidence, 0.01) * agingFactor^age (age 0 =
+    // newest frame). For FieldMinutes the per-frame decoded value is first
+    // normalized to the NEWEST frame (+age), so the returned minutes value is
+    // "minutes as of the newest frame".
+    int votedField(FieldIndex field) const;
+
+    // Raw per-frame minutes decode of the newest frame (no voting).
+    int lastFrameMinute() const;
+
+    // Aggregate lock quality 0..1: mean winning-vote margin across the voted
+    // bits of the static fields, saturating with frame count. Monotonically
+    // non-decreasing for repeated clean frames; ~0 with < minFramesForLock
+    // frames.
+    float lockConfidence() const;
+
+private:
+    struct Frame {
+        std::array<ClockSymbol, 60> symbols;
+        std::array<float, 60> confidence;
+    };
+    Config m_cfg;
+    std::vector<Frame> m_frames;   // newest last
+    int decodeMinutes(const Frame& f) const;
+};
+
+} // namespace AetherSDR

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -174,16 +174,16 @@ public:
     // Raw per-frame minutes decode of the newest frame (no voting).
     int lastFrameMinute() const;
 
-    // Aggregate lock quality 0..1: mean winning-vote margin across the voted
-    // bits of the timestamp, measured in the SAME normalized (age-extrapolated)
-    // space as votedField, saturating with frame count. Because the margin is
-    // taken after normalization, quality now reflects the consensus of the voted
-    // space itself: a clean rollover no longer dips (the decode is genuinely
-    // unambiguous once every frame is expressed at the newest epoch), while a
-    // genuinely corrupt window — frames disagreeing at comparable confidence —
-    // does. Value and quality can no longer decouple: a field that had to be
-    // rescued against real cross-frame disagreement carries that dip into the
-    // reported quality. ~0 with < minFramesForLock frames.
+    // Aggregate lock quality 0..1: the MINIMUM winning-vote margin across the
+    // voted bits of the timestamp, measured in the SAME normalized
+    // (age-extrapolated) space as votedField, saturating with frame count. The
+    // min — not the mean — is the honest aggregate: a timestamp is only as
+    // trustworthy as its least-certain bit, so quality collapses to the single
+    // most-contested bit's margin. Averaging let dozens of clean bits mask the
+    // one bit that decided a field, reporting near-1.0 while the value was wrong.
+    // A clean rollover still reads ~1.0 (every bit unanimous once normalized), so
+    // value and quality can no longer decouple. A bit with zero participating
+    // votes across the window scores margin 0. ~0 with < minFramesForLock frames.
     float lockConfidence() const;
 
 private:

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -81,6 +81,24 @@ struct ClockTimeInfo {
     ClockStation station = ClockStation::Unknown;
 };
 
+// A complete broadcast timestamp decoded from a single frame. minute/hour are
+// 0-based; doy is 1-based day-of-year; year2 is the two-digit year (century
+// assumption: full year = 2000 + year2, i.e. the 20xx century).
+struct TimeFields {
+    int minute = -1;
+    int hour   = -1;
+    int doy    = -1;
+    int year2  = -1;
+    bool operator==(const TimeFields&) const = default;
+};
+
+// Advance a timestamp forward by `minutes` (>= 0) using calendar arithmetic:
+// minute 59 -> 0 carries the hour, hour 23 -> 0 carries the day-of-year, and
+// doy wraps at the year length (365, or 366 when 2000 + year2 is a Gregorian
+// leap year) carrying year2 (mod 100). Pure/stateless so it is unit-testable in
+// isolation. Inputs are assumed already range-valid.
+TimeFields advanceMinutes(TimeFields t, int minutes);
+
 // Cross-frame confidence-weighted bit voter (reference: wwv_decode_proto.py —
 // weight = max(confidence, 0.01); production adds frame aging).
 class TimeFrameVoter {
@@ -123,11 +141,18 @@ public:
     // (the reference scores increments: marker_score + 4 * increment_count).
     bool locked() const;
 
-    // Confidence-weighted bit vote across the window. For each mapped second,
-    // per-frame vote weight = max(confidence, 0.01) * agingFactor^age (age 0 =
-    // newest frame). For FieldMinutes the per-frame decoded value is first
-    // normalized to the NEWEST frame (+age), so the returned minutes value is
-    // "minutes as of the newest frame".
+    // Voted value of a timestamp field (minute/hour/doy/year), reported "as of
+    // the newest frame". All four fields come from a single VALUE-level vote:
+    // each frame's complete timestamp is decoded from that frame's own bits,
+    // extrapolated forward by its age in minutes (calendar arithmetic), and the
+    // whole tuple is majority-voted with per-frame weight
+    // max(meanConfidence, 0.01) * agingFactor^age (age 0 = newest frame). Voting
+    // the tuple — not each field's bits independently across frames — is what
+    // makes an hour/day rollover safe: a stale hour cannot outvote the current
+    // one for a window length, and per-bit mixing can never synthesize a field
+    // value that no frame in the window actually carried. Per-bit voting remains
+    // only WITHIN a single frame's decode (never across frames for these
+    // fields). Returns -1 if no frame decodes to a range-valid timestamp.
     int votedField(FieldIndex field) const;
 
     // Raw per-frame minutes decode of the newest frame (no voting).
@@ -146,7 +171,17 @@ private:
     };
     Config m_cfg;
     std::vector<Frame> m_frames;   // newest last
-    int decodeMinutes(const Frame& f) const;
+
+    // Per-frame BCD decode of one field: sum the field-map weights whose second
+    // classified as One (Marker/Unknown contribute nothing).
+    int decodeField(const Frame& f, FieldIndex field) const;
+    int decodeMinutes(const Frame& f) const;  // == decodeField(f, FieldMinutes)
+
+    // Value-level, age-extrapolated majority vote of the whole timestamp across
+    // the window (the source of truth for votedField's four fields). Frames
+    // whose decoded fields fall outside valid broadcast ranges are excluded.
+    // Returns all-(-1) TimeFields when no candidate qualifies.
+    TimeFields votedTimestamp() const;
 };
 
 } // namespace AetherSDR

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -40,6 +40,21 @@ enum class ClockStation : int {
     Wwvb    = 3,
 };
 
+// Why locked() currently says no (WS-7 acquisition telemetry). A tag on the
+// EXISTING lock gates — the verdict logic is unchanged, the tag just names
+// which gate refused (PRD-C: refusal reasons are set exactly where the voter
+// already branches, never new logic). None means locked, or simply not enough
+// frames yet (still collecting — the funnel reports frameCount separately).
+// uint8_t so it crosses the engine boundary as a plain byte.
+enum class ClockLockRefusal : std::uint8_t {
+    None         = 0,
+    QualityFloor = 1,  // resolution quality below Config::minLockQuality
+    Plausibility = 2,  // voted timestamp implausibly far from the reference
+    Staleness    = 3,  // no range-valid frame recent enough (or none at all)
+    Contested    = 4,  // window disagrees with itself: minute-increment chain
+                       // short, or a static field carries zero winning margin
+};
+
 // One BCD map entry: which second-of-frame carries which weight. A field's
 // value is the sum of weights whose seconds decoded as One.
 struct ClockBitWeight {
@@ -86,6 +101,32 @@ struct ClockTimeInfo {
     int64_t lastEdgeSample = 0;      // sample index of the most recent second edge
     int lastEdgeSecondOfFrame = -1;  // second-of-frame of that edge
     ClockStation station = ClockStation::Unknown;
+};
+
+// Read-only decoder acquisition snapshot (WS-7 / PRD-C): the pre-lock funnel's
+// stages 1-3 and 5, assembled ON CALL from state the decoder already keeps —
+// nothing here feeds back into decode behavior, and no field is display-derived
+// (every value is a real measurement or a real gate verdict). Stage 4 (the
+// classified-seconds ring) is engine-side. Pure std types — the decoders are
+// Qt-free (EB1/EB2); the engine mirrors this into the Qt-facing
+// ClockDiagnostics struct it emits at ~1 Hz.
+struct ClockDecoderDiagnostics {
+    // stage 1 — carrier
+    float toneSnrDb = 0.0f;    // WWVB: last tone-search peak/median in dB;
+                               // WWV/WWVH: folded tick-band peak-to-mean in dB
+    float pwmContrast = 0.0f;  // WWVB: p90/p10 envelope contrast (0 when n/a)
+    bool toneDetected = false; // WWVB tone-gate passed / WWV tick fold locked
+    // stage 2 — timing
+    bool phaseLocked = false;  // WWV tickLocked / WWVB phaseKnown
+    float delayEstMs = 0.0f;   // WWV tracked matched-filter delay; NaN when n/a
+    // stage 3 — frame
+    bool anchored = false;
+    int badFrameStreak = 0;    // WWV marker-skeleton health (WWVB: 0)
+    // stage 5 — vote
+    int framesInWindow = 0;    // TimeFrameVoter::frameCount()
+    int windowSize = 0;        // Config::window
+    float voteQuality = 0.0f;  // lockConfidence() raw 0..1
+    std::uint8_t refusalReason = 0;  // ClockLockRefusal
 };
 
 // A complete broadcast timestamp decoded from a single frame. minute/hour are
@@ -178,6 +219,7 @@ public:
     void reset();
 
     int frameCount() const;   // frames currently in the window
+    int windowSize() const { return static_cast<int>(m_cfg.window); }
 
     // Lock = at least minFramesForLock frames in the window, AND at least
     // (minFramesForLock - 1) adjacent frame pairs whose per-frame minutes
@@ -190,6 +232,12 @@ public:
     // must not permanently prevent or drop the lock (the reference scores
     // increments: marker_score + 4 * increment_count).
     bool locked() const;
+
+    // WS-7: which gate locked() is currently refusing on (None when locked, or
+    // when merely short of minFramesForLock — the funnel reports frameCount()
+    // separately). locked() and lockRefusal() both read one lockVerdict() pass,
+    // so the two can never disagree.
+    ClockLockRefusal lockRefusal() const;
 
     // Voted value of a timestamp field (minute/hour/doy/year), reported "as of
     // the newest frame". The contract is NORMALIZE, THEN PER-BIT:
@@ -304,6 +352,14 @@ private:
     // Thin wrapper: the resolved timestamp value (the source of truth for
     // votedField's four fields). Returns all-(-1) TimeFields when none qualifies.
     TimeFields votedTimestamp() const;
+
+    // The lock gates, evaluated in their original order, with each refusal
+    // tagged (WS-7). locked() == lockVerdict().locked by construction.
+    struct LockVerdict {
+        bool locked = false;
+        ClockLockRefusal reason = ClockLockRefusal::None;
+    };
+    LockVerdict lockVerdict() const;
 };
 
 } // namespace AetherSDR

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -135,33 +135,55 @@ public:
     // Lock = at least minFramesForLock frames in the window, AND at least
     // (minFramesForLock - 1) adjacent frame pairs whose per-frame minutes
     // decode increments by exactly +1 (mod 60), AND voted static fields
-    // self-consistent. Increment support is COUNTED across the window, not
-    // required of every pair — live per-frame decodes are routinely imperfect
-    // and one corrupted frame must not permanently prevent or drop the lock
-    // (the reference scores increments: marker_score + 4 * increment_count).
+    // self-consistent (each static field carries a strictly positive winning
+    // margin in the same normalized space votedField/lockConfidence use — an
+    // all-Unknown window yields zero margin everywhere and must not lock).
+    // Increment support is COUNTED across the window, not required of every pair
+    // — live per-frame decodes are routinely imperfect and one corrupted frame
+    // must not permanently prevent or drop the lock (the reference scores
+    // increments: marker_score + 4 * increment_count).
     bool locked() const;
 
     // Voted value of a timestamp field (minute/hour/doy/year), reported "as of
-    // the newest frame". All four fields come from a single VALUE-level vote:
-    // each frame's complete timestamp is decoded from that frame's own bits,
-    // extrapolated forward by its age in minutes (calendar arithmetic), and the
-    // whole tuple is majority-voted with per-frame weight
-    // max(meanConfidence, 0.01) * agingFactor^age (age 0 = newest frame). Voting
-    // the tuple — not each field's bits independently across frames — is what
-    // makes an hour/day rollover safe: a stale hour cannot outvote the current
-    // one for a window length, and per-bit mixing can never synthesize a field
-    // value that no frame in the window actually carried. Per-bit voting remains
-    // only WITHIN a single frame's decode (never across frames for these
-    // fields). Returns -1 if no frame decodes to a range-valid timestamp.
+    // the newest frame". The contract is NORMALIZE, THEN PER-BIT:
+    //   1. Each frame's whole timestamp is decoded from its own bits and
+    //      extrapolated forward by its age in minutes (calendar arithmetic), so
+    //      every in-window frame is expressed at the SAME (newest) epoch.
+    //   2. Bits are then voted per-field across that normalized space. For a
+    //      field the extrapolation left unchanged (the common case away from a
+    //      boundary) each frame votes its ORIGINAL symbols with their ORIGINAL
+    //      per-second confidences — a faded bit carries a low matched-filter
+    //      margin and loses, which is what corrects the single-bit fades that
+    //      corrupt noisy corpora frame-by-frame. For a field the extrapolation
+    //      moved across a carry (minutes almost always; hour/doy/year only when
+    //      the window straddles a boundary) the frame re-encodes the normalized
+    //      value and weights every bit by its field-MIN original confidence — a
+    //      BCD value is only as reliable as its weakest bit.
+    //   3. Per-bit weights are max(confidence, 0.01) * agingFactor^age.
+    // This is rollover-safe BECAUSE the extrapolation removes the epoch skew: a
+    // stale hour can never outvote the current one, since after normalization
+    // every frame is voting on the current hour. Cross-frame bit blending is
+    // confined to normalized space, where the frames are SUPPOSED to agree, so
+    // blending there is correction, not synthesis across epochs. Should the
+    // per-bit blend ever produce an out-of-range BCD value, the vote falls back
+    // to the single highest-aged-weight frame's extrapolated tuple (a guarded
+    // fallback, never the primary path). Returns -1 if no frame decodes to a
+    // range-valid timestamp.
     int votedField(FieldIndex field) const;
 
     // Raw per-frame minutes decode of the newest frame (no voting).
     int lastFrameMinute() const;
 
     // Aggregate lock quality 0..1: mean winning-vote margin across the voted
-    // bits of the static fields, saturating with frame count. Monotonically
-    // non-decreasing for repeated clean frames; ~0 with < minFramesForLock
-    // frames.
+    // bits of the timestamp, measured in the SAME normalized (age-extrapolated)
+    // space as votedField, saturating with frame count. Because the margin is
+    // taken after normalization, quality now reflects the consensus of the voted
+    // space itself: a clean rollover no longer dips (the decode is genuinely
+    // unambiguous once every frame is expressed at the newest epoch), while a
+    // genuinely corrupt window — frames disagreeing at comparable confidence —
+    // does. Value and quality can no longer decouple: a field that had to be
+    // rescued against real cross-frame disagreement carries that dip into the
+    // reported quality. ~0 with < minFramesForLock frames.
     float lockConfidence() const;
 
 private:
@@ -177,10 +199,33 @@ private:
     int decodeField(const Frame& f, FieldIndex field) const;
     int decodeMinutes(const Frame& f) const;  // == decodeField(f, FieldMinutes)
 
-    // Value-level, age-extrapolated majority vote of the whole timestamp across
-    // the window (the source of truth for votedField's four fields). Frames
-    // whose decoded fields fall outside valid broadcast ranges are excluded.
-    // Returns all-(-1) TimeFields when no candidate qualifies.
+    // One in-window frame reduced to its NORMALIZED (age-extrapolated) per-field
+    // bit set — the single representation votedTimestamp / lockConfidence /
+    // locked all consume, so their view of the window is guaranteed identical.
+    struct NormalizedFrame {
+        int age = 0;                 // 0 = newest frame
+        double meanConfidence = 0.0; // frame mean over the four field maps
+        TimeFields ext;              // this frame's timestamp at the newest epoch
+        // Per bit of a field map: the normalized symbol and the confidence that
+        // weights it. symbol == Unknown means "no vote" (an original Marker /
+        // Unknown second that survived into the unchanged-field path).
+        struct Bit {
+            ClockSymbol symbol = ClockSymbol::Unknown;
+            float confidence = 0.0f;
+        };
+        std::array<std::vector<Bit>, FieldCount> bits; // parallel to Config::fields
+    };
+
+    // Reduce every range-valid in-window frame to its NormalizedFrame (newest ->
+    // age 0). Frames whose raw decode falls outside valid broadcast ranges are
+    // dropped, in the same spirit as excluding Marker/Unknown symbols from a bit
+    // vote. Empty when no frame qualifies.
+    std::vector<NormalizedFrame> buildNormalizedFrames() const;
+
+    // Normalize-then-per-bit vote of the whole timestamp across the window (the
+    // source of truth for votedField's four fields). A per-bit blend that lands
+    // out of range falls back to the highest-aged-weight frame's extrapolated
+    // tuple. Returns all-(-1) TimeFields when no candidate qualifies.
     TimeFields votedTimestamp() const;
 };
 

--- a/src/core/TimeFrameVoter.h
+++ b/src/core/TimeFrameVoter.h
@@ -160,15 +160,24 @@ public:
     //      value and weights every bit by its field-MIN original confidence — a
     //      BCD value is only as reliable as its weakest bit.
     //   3. Per-bit weights are max(confidence, 0.01) * agingFactor^age.
+    //   4. Composition is COHERENCE-GATED. Per-bit statistics alone cannot certify
+    //      a multi-bit BCD value: sibling bits can be won by DIFFERENT frame camps
+    //      (a faded bit plus a confident sibling misread), assembling a value no
+    //      frame held. A bit is coherent only when its confidence-weighted winner
+    //      agrees with its aging-only count majority. If every bit of a field is
+    //      coherent the field is that per-bit compose (the fade-rescue / clean
+    //      path); if any bit is incoherent the field falls back to the top HELD
+    //      value — one a frame actually carried, voted per-value with the same
+    //      aged x field-min weighting.
     // This is rollover-safe BECAUSE the extrapolation removes the epoch skew: a
     // stale hour can never outvote the current one, since after normalization
     // every frame is voting on the current hour. Cross-frame bit blending is
-    // confined to normalized space, where the frames are SUPPOSED to agree, so
-    // blending there is correction, not synthesis across epochs. Should the
-    // per-bit blend ever produce an out-of-range BCD value, the vote falls back
-    // to the single highest-aged-weight frame's extrapolated tuple (a guarded
-    // fallback, never the primary path). Returns -1 if no frame decodes to a
-    // range-valid timestamp.
+    // confined to normalized space AND to coherent bits, so blending there is
+    // correction, not synthesis across epochs or across frame camps. Should the
+    // compose ever produce an out-of-range BCD value, the vote falls back to the
+    // single highest-aged-weight frame's extrapolated tuple (a guarded fallback,
+    // never the primary path). Returns -1 if no frame decodes to a range-valid
+    // timestamp.
     int votedField(FieldIndex field) const;
 
     // Raw per-frame minutes decode of the newest frame (no voting).
@@ -222,10 +231,25 @@ private:
     // vote. Empty when no frame qualifies.
     std::vector<NormalizedFrame> buildNormalizedFrames() const;
 
-    // Normalize-then-per-bit vote of the whole timestamp across the window (the
-    // source of truth for votedField's four fields). A per-bit blend that lands
-    // out of range falls back to the highest-aged-weight frame's extrapolated
-    // tuple. Returns all-(-1) TimeFields when no candidate qualifies.
+    // The whole timestamp resolved from the normalized window, PLUS the quality
+    // of that resolution — computed together so value and quality can never
+    // disagree. Per field: if every bit is COHERENT (its confidence-weighted
+    // winner agrees with its aging-only count majority) the field is the per-bit
+    // compose, as before; if any bit is incoherent (a confident sibling misread
+    // would let per-bit voting assemble a value no frame held) the field falls
+    // back to the top HELD value (one a frame actually carried). Quality is the
+    // MIN across fields of the field's contribution: for a coherent field the min
+    // per-bit trust (margin x participation), for an incoherent field the min of
+    // the held-value margin and the coherent bits' trust. An out-of-range compose
+    // falls back to the highest-aged-weight frame's tuple at quality 0.
+    struct Resolution {
+        TimeFields value;    // all -1 when no frame qualifies
+        double quality = 0.0;  // pre-saturation; 0 on the range fallback
+    };
+    Resolution computeResolution() const;
+
+    // Thin wrapper: the resolved timestamp value (the source of truth for
+    // votedField's four fields). Returns all-(-1) TimeFields when none qualifies.
     TimeFields votedTimestamp() const;
 };
 

--- a/src/core/WwvDecoder.cpp
+++ b/src/core/WwvDecoder.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <vector>
 
 namespace AetherSDR {
@@ -770,5 +771,41 @@ void WwvDecoder::setPlausibility(std::function<TimeFields()> referenceNow,
 ClockLockState WwvDecoder::state() const { return m_impl->state; }
 ClockStation WwvDecoder::station() const { return m_impl->station; }
 std::int64_t WwvDecoder::samplesConsumed() const { return m_impl->samplesConsumed; }
+
+ClockDecoderDiagnostics WwvDecoder::diagnostics() const {
+    const Impl& d = *m_impl;
+    ClockDecoderDiagnostics g;
+
+    // Stage 1: folded tick-band impulsiveness — the same peak-to-mean statistic
+    // the tick lock gates on, recomputed here from the leaky folds (read-only).
+    const auto foldRatio = [](const std::array<double, kSecLen>& fold) {
+        double peak = 0.0, sum = 0.0;
+        for (int p = 0; p < kSecLen; ++p) {
+            sum += fold[p];
+            if (fold[p] > peak) peak = fold[p];
+        }
+        const double mean = sum / kSecLen;
+        return (mean > 0.0) ? peak / mean : 0.0;
+    };
+    const double ratio = std::max(foldRatio(d.foldV), foldRatio(d.foldH));
+    g.toneSnrDb = (ratio > 0.0)
+        ? static_cast<float>(10.0 * std::log10(ratio)) : 0.0f;
+    g.pwmContrast = 0.0f;  // WWVB-only metric
+    g.toneDetected = d.tickLocked;
+
+    g.phaseLocked = d.tickLocked;
+    g.delayEstMs = d.delayLocked
+        ? static_cast<float>(d.delayEst * 1000.0 / kSeriesRate)
+        : std::numeric_limits<float>::quiet_NaN();
+
+    g.anchored = d.anchored;
+    g.badFrameStreak = d.badFrameStreak;
+
+    g.framesInWindow = d.voter.frameCount();
+    g.windowSize = d.voter.windowSize();
+    g.voteQuality = d.voter.lockConfidence();
+    g.refusalReason = static_cast<std::uint8_t>(d.voter.lockRefusal());
+    return g;
+}
 
 } // namespace AetherSDR

--- a/src/core/WwvDecoder.cpp
+++ b/src/core/WwvDecoder.cpp
@@ -46,6 +46,23 @@ constexpr int kSeriesRate = 200;                 // decimated series rate (Hz)
 constexpr int kSecLen     = kSeriesRate;          // samples per broadcast second
 constexpr int kFrameSecs  = 60;
 
+// Nominal biquad-chain group delay at 200 Hz (~35 ms) — the matched-filter
+// shift a clean, drift-free stream settles at. The tracked delay estimate
+// starts here, and the reported second edge subtracts it back out so the edge
+// label follows REAL stream drift, not the fixed chain delay.
+constexpr int kNominalDelaySamples = 7;
+
+// Matched-filter shift search ceiling (series samples, 200 ms). Wide (WS-4.5)
+// so slow sample-clock drift is ABSORBED by the tracked delay estimate instead
+// of accumulating into systematic misreads; drift beyond the rails triggers a
+// soft resynchronization.
+constexpr int kMaxShift = 40;
+
+// Leaky tick-fold decay per hit (each phase bin is hit once per second, so
+// this is τ ≈ 100 s). The fold must FORGET a stale phase: after a sample
+// discontinuity the re-seed has to find the CURRENT tick phase, not history.
+constexpr double kFoldDecay = 0.99;
+
 // Markers (P1..P5, P0) land at seconds 9/19/29/39/49/59 — i.e. (s % 10 == 9).
 inline bool isMarkerSec(int s) { return (s % 10) == 9; }
 
@@ -136,12 +153,17 @@ struct WwvDecoder::Impl {
     bool tickLocked = false;
     int tickPhase = 0;               // series-sample index of the second edge
 
-    // Slowly-adapted matched-filter group-delay estimate (the biquad chain
-    // delay is FIXED; estimate it once confidently and track it slowly instead
-    // of re-searching freely every second, which flaps under fading/noise).
-    double delayEst = 7.0;           // samples at 200 Hz (~35 ms chain delay)
+    // Slowly-adapted matched-filter delay estimate: nominal chain group delay
+    // plus any accumulated stream drift. Tracked slowly instead of re-searched
+    // freely every second (which flaps under fading/noise); reaching the
+    // search rails means drift exceeded what the window can absorb -> soft
+    // resynchronization.
+    double delayEst = kNominalDelaySamples;   // series samples at 200 Hz
     bool delayLocked = false;
     int delayCount = 0;
+
+    // Consecutive structurally-invalid frames (marker skeleton broken).
+    int badFrameStreak = 0;
 
     // Per-second windowing at 200 Hz.
     std::array<float, kSecLen> curSec{};
@@ -188,6 +210,7 @@ struct WwvDecoder::Impl {
                   int& winShift) const;
     void tryAnchor();
     void feedPendingFrames();
+    void softReacquire();
     ClockFrameInfo decodeFrame(const std::array<int8_t, kFrameSecs>& sym,
                                const std::array<float, kFrameSecs>& conf,
                                std::int64_t frameStartSample) const;
@@ -206,6 +229,15 @@ TimeFrameVoter::Config WwvDecoder::Impl::makeVoterConfig() {
     c.window = 8;
     c.minFramesForLock = 2;
     c.agingFactor = 0.9f;
+    // WS-4.5 honesty floors: noise-grade margins (clean-signal bits run
+    // >= ~0.12 even at the pinned 20 dB SNR floor) must not vote — a deep fade
+    // zero-biases the SAME bits in every frame, and unanimity of noise-grade
+    // reads is how the 2026-07-20 receiver certified 2006-01-01 at q100. The
+    // lock-quality floor sits BELOW the dirty-but-correct band measured on the
+    // 2026-07-19 live corpus (q ~0.11-0.16) and far above unanimous-fade
+    // garbage (~0.00).
+    c.minBitConfidence = 0.05f;
+    c.minLockQuality   = 0.05f;
     return c;
 }
 
@@ -310,9 +342,11 @@ void WwvDecoder::Impl::processSample(float x) {
 void WwvDecoder::Impl::onSeriesSample(double a, double tickV, double tickH) {
     const std::int64_t j = n200++;
 
-    // Fold each tick band's envelope mod 1 s.
+    // Fold each tick band's envelope mod 1 s — leaky, so a stale phase decays
+    // and a post-discontinuity re-seed finds the CURRENT phase (WS-4.5).
     int phase = static_cast<int>(j % kSecLen);
-    foldV[phase] += tickV; foldH[phase] += tickH;
+    foldV[phase] = foldV[phase] * kFoldDecay + tickV;
+    foldH[phase] = foldH[phase] * kFoldDecay + tickH;
 
     // Folded impulsiveness of a band: peak-to-mean ratio + argmax phase.
     auto stats = [](const std::array<double, kSecLen>& fold, double& ratio, int& arg) {
@@ -388,13 +422,14 @@ void WwvDecoder::Impl::classify(const std::array<float, kSecLen>& w,
     double invn = 1.0 / (vnorm + 1e-12);
 
     // Streaming biquads add a FIXED group delay the prototype's zero-phase FFT
-    // filters did not, so the received pulse sits a few samples late. All three
-    // 170/470/770 ms templates are correlated at a COMMON start-shift each
-    // second (a fair duration comparison — a longer template never wins on a
-    // short pulse), and the shift is picked to best explain the second. Once the
-    // delay estimate has settled, the search is constrained to a narrow band
-    // around it so the alignment can't flap second-to-second under fading.
-    constexpr int kMaxShift = 16;    // <= 80 ms of group-delay slack
+    // filters did not, so the received pulse sits a few samples late — and any
+    // sample-clock drift between the DAX stream and true UTC seconds shifts it
+    // further. All three 170/470/770 ms templates are correlated at a COMMON
+    // start-shift each second (a fair duration comparison — a longer template
+    // never wins on a short pulse), and the shift is picked to best explain the
+    // second. Once the delay estimate has settled, the search is constrained to
+    // a narrow band around it so the alignment can't flap second-to-second
+    // under fading, while the estimate itself keeps tracking slow drift.
     int lo = 0, hi = kMaxShift;
     if (delayLocked) {
         int c = static_cast<int>(std::lround(delayEst));
@@ -431,18 +466,33 @@ void WwvDecoder::Impl::processSecond(std::int64_t startJ,
     int8_t sym; float conf; int winShift = 0;
     classify(w, sym, conf, winShift);
 
-    // Slowly adapt the fixed group-delay estimate toward the alignment that
-    // confident seconds actually used; freeze the search band once it settles.
+    // Slowly adapt the delay estimate toward the alignment that confident
+    // seconds actually used; constrain the search band once it settles. The
+    // estimate keeps moving after settling — that is what absorbs slow
+    // sample-clock drift (WS-4.5).
     if (conf > 0.12f) {
         delayEst = 0.85 * delayEst + 0.15 * winShift;
         if (++delayCount >= 4) delayLocked = true;
+    }
+
+    // Drift beyond the search rails cannot be absorbed — the window itself is
+    // wrong. Resynchronize instead of degrading into systematic misreads (the
+    // 2026-07-20 misalignment failure mode).
+    if (delayLocked && (delayEst < 1.5 || delayEst > kMaxShift - 1.5)) {
+        softReacquire();
+        return;
     }
 
     double emean = 0.0;
     for (float v : w) emean += v;
     emean /= kSecLen;
 
-    const std::int64_t edgeSample = startJ * decim;
+    // The second-edge label subtracts the nominal chain delay back out of the
+    // matched shift, so it tracks REAL stream drift: on a clean drift-free
+    // stream winShift ~= kNominalDelaySamples and this reduces to the window
+    // start, unchanged from pre-WS-4.5 behavior.
+    const std::int64_t edgeSample =
+        (startJ + (winShift - kNominalDelaySamples)) * decim;
     const std::int64_t k = secIndex;
     int secOfFrame = anchored
         ? static_cast<int>(((k - anchorSec0) % kFrameSecs + kFrameSecs) % kFrameSecs)
@@ -459,6 +509,7 @@ void WwvDecoder::Impl::processSecond(std::int64_t startJ,
         info.confidence = conf;
         info.secondOfFrame = secOfFrame;
         info.seriesRateHz = kSeriesRate;
+        info.windowShift = winShift - kNominalDelaySamples;
         info.envelope.resize(kSecLen);
         double s = (aScale > 1e-9) ? (1.0 / aScale) : 0.0;
         for (int n = 0; n < kSecLen; ++n)
@@ -558,6 +609,28 @@ void WwvDecoder::Impl::feedPendingFrames() {
         ClockFrameInfo frame = decodeFrame(sym, conf, frameStartSample);
         if (owner && owner->onFrame) owner->onFrame(frame);
 
+        // Structural re-validation (WS-4.5): the marker skeleton is the frame's
+        // ground truth — a healthy frame has its 6 P markers on the 9s and
+        // nowhere else. A STREAK of broken-skeleton frames means the current
+        // window/anchor is systematically wrong (sample discontinuity,
+        // accumulated drift) — resynchronize rather than decode garbage
+        // forever. Individual noisy frames still VOTE below: their bits carry
+        // usable signal and pruning them thins the window the fade rescue
+        // needs (measured on the 2026-07-19 live corpus — the voter's own
+        // range/staleness/trust gates absorb per-frame noise).
+        int mkOk = 0, mkFalse = 0;
+        for (int s = 0; s < kFrameSecs; ++s) {
+            if (sym[s] == 2) (isMarkerSec(s) ? mkOk : mkFalse) += 1;
+        }
+        if (mkOk < 4 || mkFalse > 5) {
+            if (++badFrameStreak >= 3) {
+                softReacquire();
+                return;
+            }
+        } else {
+            badFrameStreak = 0;
+        }
+
         // Feed the cross-frame voter (markers excluded internally).
         voter.addFrame(vsym, conf);
         if (voter.locked()) {
@@ -574,10 +647,37 @@ void WwvDecoder::Impl::feedPendingFrames() {
                 t.station = station;
                 owner->onTime(t);
             }
+        } else if (state == ClockLockState::Locked) {
+            // The voter no longer certifies a timestamp: demote instead of
+            // pinning a stale Locked (the decoder is the lock authority the
+            // engine's state resync trusts — WS-4.5).
+            setState(ClockLockState::Acquiring);
         }
 
         nextFrameStartK += kFrameSecs;
     }
+}
+
+void WwvDecoder::Impl::softReacquire() {
+    // Forget every timing estimate; keep the warm filters, the leaky tick fold
+    // (already integrating the CURRENT phase, which is what makes re-lock
+    // fast), the station tag, and the sample counter. Called when structure
+    // proves the current window/anchor wrong.
+    tickLocked = false;
+    curFill = 0;
+    secStarted = false;
+    secStartJ = 0;
+    delayEst = kNominalDelaySamples;
+    delayLocked = false;
+    delayCount = 0;
+    recs.clear();
+    recBase = secIndex;
+    anchored = false;
+    anchorSec0 = 0;
+    nextFrameStartK = 0;
+    badFrameStreak = 0;
+    voter.reset();
+    if (state != ClockLockState::NoSignal) setState(ClockLockState::Acquiring);
 }
 
 ClockFrameInfo WwvDecoder::Impl::decodeFrame(
@@ -628,7 +728,8 @@ void WwvDecoder::Impl::reset() {
     accA = accTickV = accTickH = 0.0; decCount = 0; n200 = 0;
     foldV.fill(0.0); foldH.fill(0.0);
     tickLocked = false; tickPhase = 0;
-    delayEst = 7.0; delayLocked = false; delayCount = 0;
+    delayEst = kNominalDelaySamples; delayLocked = false; delayCount = 0;
+    badFrameStreak = 0;
     curFill = 0; secStarted = false; secStartJ = 0; aScale = 1e-6;
     recs.clear(); recBase = 0; secIndex = 0;
     anchored = false; anchorSec0 = 0; nextFrameStartK = 0;
@@ -656,6 +757,11 @@ void WwvDecoder::process(const float* mono, std::size_t n) {
 }
 
 void WwvDecoder::reset() { m_impl->reset(); }
+
+void WwvDecoder::setPlausibility(std::function<TimeFields()> referenceNow,
+                                 int boundMinutes) {
+    m_impl->voter.setPlausibility(std::move(referenceNow), boundMinutes);
+}
 
 ClockLockState WwvDecoder::state() const { return m_impl->state; }
 ClockStation WwvDecoder::station() const { return m_impl->station; }

--- a/src/core/WwvDecoder.cpp
+++ b/src/core/WwvDecoder.cpp
@@ -1,0 +1,664 @@
+#include "WwvDecoder.h"
+
+// WWV/WWVH 100 Hz-subcarrier BCD time-code decoder — streaming implementation.
+//
+// Ports the MATH of the gate-passed AetherClock reference chain
+// (research/wwv_decode_proto.py) to a sample-streaming front-end: the
+// prototype's whole-file FFT stages become biquad cascades + running mixers +
+// decimated per-second work, per the NIST WWV/WWVH time-code table (NIST
+// SP 432) and the AetherClock reference chain documented in WwvDecoder.h.
+//
+// Chain (identical intent to the prototype, streaming realization):
+//   analytic bandpass 700-1300 Hz (biquad cascade) -> rectify+LPF envelope
+//   -> coherent 100 Hz demod (running quadrature mixer, 25 Hz LPF both rails,
+//      magnitude) -> decimate to a 200 Hz amplitude series a[]
+//   -> tick rail: bandpass 2000 Hz (WWV) / 2200 Hz (WWVH), envelope, decimate,
+//      fold mod 1 s for tick phase + station tag
+//   -> per-second matched-filter classify (zero-mean 170/470/770 ms templates
+//      at +30 ms; confidence = best correlation minus runner-up)
+//   -> marker frame sync (P markers at 9/19/29/39/49/59), mod-10 degeneracy
+//      resolved by the s0 minute-mark subcarrier hole + minute-increment
+//      scoring -> NIST BCD field map -> TimeFrameVoter.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <deque>
+#include <vector>
+
+namespace AetherSDR {
+
+namespace {
+
+// ---- NIST WWV/WWVH BCD field map (second, weight) — per NIST SP 432. -------
+// LSB-first within each field; a field's value is the sum of the weights of
+// the seconds decoded as binary One.
+const ClockFieldMap kMin = {{10, 1}, {11, 2}, {12, 4}, {13, 8},
+                            {15, 10}, {16, 20}, {17, 40}};
+const ClockFieldMap kHr  = {{20, 1}, {21, 2}, {22, 4}, {23, 8}, {25, 10}, {26, 20}};
+const ClockFieldMap kDoy = {{30, 1},  {31, 2},  {32, 4},  {33, 8},  {35, 10},
+                            {36, 20}, {37, 40}, {38, 80}, {40, 100}, {41, 200}};
+const ClockFieldMap kYr  = {{4, 1},  {5, 2},  {6, 4},  {7, 8},
+                            {51, 10}, {52, 20}, {53, 40}, {54, 80}};
+
+constexpr int kSeriesRate = 200;                 // decimated series rate (Hz)
+constexpr int kSecLen     = kSeriesRate;          // samples per broadcast second
+constexpr int kFrameSecs  = 60;
+
+// Markers (P1..P5, P0) land at seconds 9/19/29/39/49/59 — i.e. (s % 10 == 9).
+inline bool isMarkerSec(int s) { return (s % 10) == 9; }
+
+// ---- Transposed Direct-Form-II biquad (RBJ cookbook coefficients). ---------
+struct Biquad {
+    double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0;
+    double z1 = 0.0, z2 = 0.0;
+    inline double process(double x) {
+        double y = b0 * x + z1;
+        z1 = b1 * x - a1 * y + z2;
+        z2 = b2 * x - a2 * y;
+        return y;
+    }
+    void reset() { z1 = z2 = 0.0; }
+};
+
+Biquad designBandpass(double f0, double q, double fs) {
+    // RBJ constant-0dB-peak bandpass.
+    double w0 = 2.0 * M_PI * f0 / fs;
+    double c = std::cos(w0), s = std::sin(w0);
+    double alpha = s / (2.0 * q);
+    double a0 = 1.0 + alpha;
+    Biquad bq;
+    bq.b0 = alpha / a0;
+    bq.b1 = 0.0;
+    bq.b2 = -alpha / a0;
+    bq.a1 = (-2.0 * c) / a0;
+    bq.a2 = (1.0 - alpha) / a0;
+    return bq;
+}
+
+Biquad designLowpass(double fc, double q, double fs) {
+    double w0 = 2.0 * M_PI * fc / fs;
+    double c = std::cos(w0), s = std::sin(w0);
+    double alpha = s / (2.0 * q);
+    double a0 = 1.0 + alpha;
+    Biquad bq;
+    bq.b0 = ((1.0 - c) / 2.0) / a0;
+    bq.b1 = (1.0 - c) / a0;
+    bq.b2 = ((1.0 - c) / 2.0) / a0;
+    bq.a1 = (-2.0 * c) / a0;
+    bq.a2 = (1.0 - alpha) / a0;
+    return bq;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+struct WwvDecoder::Impl {
+    explicit Impl(int sampleRateHz);
+
+    // Public-surface state.
+    int fs;
+    int decim;                       // input samples per 200 Hz series sample
+    ClockLockState state = ClockLockState::NoSignal;
+    ClockStation station = ClockStation::Unknown;
+    std::int64_t samplesConsumed = 0;
+
+    // Callbacks (owned by the outer WwvDecoder; copied pointers here).
+    WwvDecoder* owner = nullptr;
+
+    // --- Streaming front-end filters (preallocated, no per-sample alloc). ---
+    std::array<Biquad, 2> bpMain;    // analytic bandpass 700-1300 Hz
+    std::array<Biquad, 2> lpEnv;     // envelope smoothing
+    std::array<Biquad, 2> lpI;       // 25 Hz LPF, in-phase rail
+    std::array<Biquad, 2> lpQ;       // 25 Hz LPF, quadrature rail
+    std::array<Biquad, 2> bpTickV;   // WWV  tick band (2000 Hz)
+    std::array<Biquad, 2> bpTickH;   // WWVH tick band (2200 Hz)
+
+    // 100 Hz quadrature oscillator (running rotation — no per-sample trig).
+    double oscC = 1.0, oscS = 0.0, rotC = 1.0, rotS = 0.0;
+    int oscRenorm = 0;
+
+    // Decimation accumulators.
+    double accA = 0.0, accTickV = 0.0, accTickH = 0.0;
+    int decCount = 0;
+    std::int64_t n200 = 0;           // count of 200 Hz series samples emitted
+
+    // Tick-phase fold (mod 1 s). Station is tagged by folded IMPULSIVENESS
+    // (peak-to-mean of each tick band), not total energy: WWV voice
+    // announcements dump broadband energy that lands in the 2200 Hz WWVH band
+    // and would out-power a plain energy comparison, but voice is phase-
+    // incoherent and folds flat, whereas the real 5 ms tick folds to a sharp
+    // peak at a fixed phase.
+    std::array<double, kSecLen> foldV{};
+    std::array<double, kSecLen> foldH{};
+    bool tickLocked = false;
+    int tickPhase = 0;               // series-sample index of the second edge
+
+    // Slowly-adapted matched-filter group-delay estimate (the biquad chain
+    // delay is FIXED; estimate it once confidently and track it slowly instead
+    // of re-searching freely every second, which flaps under fading/noise).
+    double delayEst = 7.0;           // samples at 200 Hz (~35 ms chain delay)
+    bool delayLocked = false;
+    int delayCount = 0;
+
+    // Per-second windowing at 200 Hz.
+    std::array<float, kSecLen> curSec{};
+    int curFill = 0;
+    bool secStarted = false;
+    std::int64_t secStartJ = 0;      // 200 Hz index of current window start
+    double aScale = 1e-6;            // running peak of a[] for display normalize
+
+    // Matched-filter templates (zero-mean) + norms.
+    std::array<std::array<float, kSecLen>, 3> tpl{};
+    std::array<float, 3> tplNorm{};
+
+    // --- Per-second record ring for frame anchoring. -----------------------
+    struct Rec {
+        std::int64_t secIndex;
+        std::int64_t edgeSample;
+        int8_t sym;                  // 0 Zero / 1 One / 2 Marker
+        float conf;
+        float energy;                // mean a[] over the second (s0 hole => ~0)
+    };
+    static constexpr std::size_t kRecCap = 12 * kFrameSecs;
+    std::deque<Rec> recs;
+    std::int64_t recBase = 0;        // secIndex of recs.front()
+    std::int64_t secIndex = 0;       // next second index to assign
+
+    // Frame anchor / assembly.
+    bool anchored = false;
+    std::int64_t anchorSec0 = 0;     // secIndex whose second-of-frame == 0
+    std::int64_t nextFrameStartK = 0;
+    std::int64_t lastEdgeSample = 0;
+    int lastEdgeSecondOfFrame = -1;
+
+    // Cross-frame voter.
+    TimeFrameVoter voter;
+
+    // --- Methods. ----------------------------------------------------------
+    void designFilters();
+    void buildTemplates();
+    void setState(ClockLockState s);
+    void processSample(float x);
+    void onSeriesSample(double a, double tickV, double tickH);
+    void processSecond(std::int64_t startJ, const std::array<float, kSecLen>& w);
+    void classify(const std::array<float, kSecLen>& w, int8_t& sym, float& conf,
+                  int& winShift) const;
+    void tryAnchor();
+    void feedPendingFrames();
+    ClockFrameInfo decodeFrame(const std::array<int8_t, kFrameSecs>& sym,
+                               const std::array<float, kFrameSecs>& conf,
+                               std::int64_t frameStartSample) const;
+    void reset();
+
+    static TimeFrameVoter::Config makeVoterConfig();
+};
+
+TimeFrameVoter::Config WwvDecoder::Impl::makeVoterConfig() {
+    TimeFrameVoter::Config c;
+    c.fields[TimeFrameVoter::FieldMinutes] = kMin;
+    c.fields[TimeFrameVoter::FieldHours]   = kHr;
+    c.fields[TimeFrameVoter::FieldDoy]     = kDoy;
+    c.fields[TimeFrameVoter::FieldYear]    = kYr;
+    c.markerSeconds = {9, 19, 29, 39, 49, 59};
+    c.window = 8;
+    c.minFramesForLock = 2;
+    c.agingFactor = 0.9f;
+    return c;
+}
+
+WwvDecoder::Impl::Impl(int sampleRateHz)
+    : fs(sampleRateHz > 0 ? sampleRateHz : 24000),
+      decim(std::max(1, (sampleRateHz > 0 ? sampleRateHz : 24000) / kSeriesRate)),
+      voter(makeVoterConfig()) {
+    designFilters();
+    buildTemplates();
+}
+
+void WwvDecoder::Impl::designFilters() {
+    double f = static_cast<double>(fs);
+    // Analytic bandpass 700-1300 Hz: pass the 1000 Hz carrier + 900/1100 Hz
+    // subcarrier sidebands, reject the 2000/2200 Hz tick image and out-of-band
+    // noise. Two wide sections keep the sidebands while limiting noise.
+    for (auto& b : bpMain) b = designBandpass(1000.0, 1.0, f);
+    // Envelope smoothing: pass the 100 Hz subcarrier modulation, kill the
+    // rectified-carrier ripple (2000 Hz and up).
+    for (auto& b : lpEnv) b = designLowpass(180.0, 0.70710678, f);
+    // Coherent-demod baseband LPF (25 Hz) — matches the prototype's 25 Hz mask.
+    for (auto& b : lpI) b = designLowpass(25.0, 0.70710678, f);
+    for (auto& b : lpQ) b = designLowpass(25.0, 0.70710678, f);
+    // Tick bands: narrow so 2000 Hz (WWV) and 2200 Hz (WWVH) separate cleanly.
+    for (auto& b : bpTickV) b = designBandpass(2000.0, 12.0, f);
+    for (auto& b : bpTickH) b = designBandpass(2200.0, 12.0, f);
+
+    double dth = 2.0 * M_PI * 100.0 / f;   // 100 Hz demod rotation per sample
+    rotC = std::cos(dth);
+    rotS = std::sin(dth);
+}
+
+void WwvDecoder::Impl::buildTemplates() {
+    // Zero-mean matched templates: pulse rises +30 ms into the second and lasts
+    // 170 ms (binary 0), 470 ms (binary 1) or 770 ms (marker) — NIST SP 432.
+    const int s0 = static_cast<int>(std::lround(0.030 * kSeriesRate));
+    const int durMs[3] = {170, 470, 770};
+    for (int k = 0; k < 3; ++k) {
+        auto& t = tpl[k];
+        t.fill(0.0f);
+        int len = static_cast<int>(std::lround(durMs[k] / 1000.0 * kSeriesRate));
+        for (int i = s0; i < s0 + len && i < kSecLen; ++i) t[i] = 1.0f;
+        double mean = 0.0;
+        for (float v : t) mean += v;
+        mean /= kSecLen;
+        double nrm = 0.0;
+        for (float& v : t) { v -= static_cast<float>(mean); nrm += double(v) * v; }
+        tplNorm[k] = static_cast<float>(std::sqrt(nrm));
+    }
+}
+
+void WwvDecoder::Impl::setState(ClockLockState s) {
+    if (s == state) return;
+    state = s;
+    if (owner && owner->onStateChanged) owner->onStateChanged(s);
+}
+
+void WwvDecoder::Impl::processSample(float x) {
+    ++samplesConsumed;
+
+    // 1) Analytic bandpass 700-1300 Hz, then rectify + LPF -> AM envelope. The
+    //    envelope carries the 100 Hz subcarrier as a DC + 100 Hz component.
+    double bp = x;
+    for (auto& b : bpMain) bp = b.process(bp);
+    double env = std::fabs(bp);
+    for (auto& b : lpEnv) env = b.process(env);
+
+    // 2) Coherent 100 Hz demod: mix envelope down by the running quadrature
+    //    oscillator, LPF both rails at 25 Hz, take the magnitude.
+    double i = env * oscC;
+    double q = env * oscS;
+    for (auto& b : lpI) i = b.process(i);
+    for (auto& b : lpQ) q = b.process(q);
+    double a = std::sqrt(i * i + q * q);
+
+    // advance + periodically renormalize the oscillator
+    double nc = oscC * rotC - oscS * rotS;
+    double ns = oscS * rotC + oscC * rotS;
+    oscC = nc; oscS = ns;
+    if (++oscRenorm >= 1024) {
+        oscRenorm = 0;
+        double m = std::sqrt(oscC * oscC + oscS * oscS);
+        if (m > 0.0) { oscC /= m; oscS /= m; }
+    }
+
+    // 3) Tick rails: bandpass around each tick image, rectify.
+    double tv = x, th = x;
+    for (auto& b : bpTickV) tv = b.process(tv);
+    for (auto& b : bpTickH) th = b.process(th);
+    double etv = std::fabs(tv), eth = std::fabs(th);
+
+    // 4) Decimate by block-average to the 200 Hz series (matches prototype).
+    accA += a; accTickV += etv; accTickH += eth;
+    if (++decCount >= decim) {
+        double invd = 1.0 / decim;
+        onSeriesSample(accA * invd, accTickV * invd, accTickH * invd);
+        accA = accTickV = accTickH = 0.0;
+        decCount = 0;
+    }
+}
+
+void WwvDecoder::Impl::onSeriesSample(double a, double tickV, double tickH) {
+    const std::int64_t j = n200++;
+
+    // Fold each tick band's envelope mod 1 s.
+    int phase = static_cast<int>(j % kSecLen);
+    foldV[phase] += tickV; foldH[phase] += tickH;
+
+    // Folded impulsiveness of a band: peak-to-mean ratio + argmax phase.
+    auto stats = [](const std::array<double, kSecLen>& fold, double& ratio, int& arg) {
+        double peak = 0.0, sum = 0.0; arg = 0;
+        for (int p = 0; p < kSecLen; ++p) {
+            sum += fold[p];
+            if (fold[p] > peak) { peak = fold[p]; arg = p; }
+        }
+        double mean = sum / kSecLen;
+        ratio = (mean > 0.0) ? peak / mean : 0.0;
+    };
+
+    if (!tickLocked && j >= 5 * kSecLen) {
+        double rV, rH; int argV, argH;
+        stats(foldV, rV, argV);
+        stats(foldH, rH, argH);
+        // Lock onto whichever band folds to a genuine impulse (a flat fold from
+        // noise or voice never clears the ratio gate). Tag the station only when
+        // that band's peakiness clearly beats the other's; hold Unknown (per the
+        // header) until confident.
+        bool vWins = rV >= rH;
+        double win = vWins ? rV : rH;
+        double lose = vWins ? rH : rV;
+        if (win > 2.5) {
+            tickLocked = true;
+            tickPhase = vWins ? argV : argH;
+            if (win > 1.3 * lose)
+                station = vWins ? ClockStation::Wwv : ClockStation::Wwvh;
+            setState(ClockLockState::Acquiring);
+        }
+    }
+
+    // Keep refining the station tag once per second: the fixed-phase tick keeps
+    // sharpening its band's fold while phase-incoherent voice averages flat, so
+    // impulsiveness separates the bands more cleanly the longer we integrate.
+    if (tickLocked && station == ClockStation::Unknown && phase == 0) {
+        double rV, rH; int argV, argH;
+        stats(foldV, rV, argV);
+        stats(foldH, rH, argH);
+        bool vWins = rV >= rH;
+        double win = vWins ? rV : rH, lose = vWins ? rH : rV;
+        if (win > 2.5 && win > 1.3 * lose)
+            station = vWins ? ClockStation::Wwv : ClockStation::Wwvh;
+    }
+
+    if (a > aScale) aScale = a;
+    aScale *= 0.99999;               // slow decay so display normalization adapts
+
+    if (!tickLocked) return;
+
+    // Cut a[] into 1 s windows aligned to the tick phase.
+    bool boundary = (((j - tickPhase) % kSecLen) == 0) && (j >= tickPhase);
+    if (boundary) {
+        if (secStarted && curFill == kSecLen) processSecond(secStartJ, curSec);
+        curFill = 0;
+        secStarted = true;
+        secStartJ = j;
+    }
+    if (secStarted && curFill < kSecLen) curSec[curFill++] = static_cast<float>(a);
+}
+
+void WwvDecoder::Impl::classify(const std::array<float, kSecLen>& w,
+                                int8_t& sym, float& conf, int& winShift) const {
+    // Normalized correlation against each zero-mean template; symbol = best,
+    // confidence = best minus runner-up (the prototype's classify() margin).
+    double mean = 0.0;
+    for (float v : w) mean += v;
+    mean /= kSecLen;
+    double vnorm = 0.0;
+    std::array<double, kSecLen> v{};
+    for (int n = 0; n < kSecLen; ++n) { v[n] = w[n] - mean; vnorm += v[n] * v[n]; }
+    vnorm = std::sqrt(vnorm);
+    double invn = 1.0 / (vnorm + 1e-12);
+
+    // Streaming biquads add a FIXED group delay the prototype's zero-phase FFT
+    // filters did not, so the received pulse sits a few samples late. All three
+    // 170/470/770 ms templates are correlated at a COMMON start-shift each
+    // second (a fair duration comparison — a longer template never wins on a
+    // short pulse), and the shift is picked to best explain the second. Once the
+    // delay estimate has settled, the search is constrained to a narrow band
+    // around it so the alignment can't flap second-to-second under fading.
+    constexpr int kMaxShift = 16;    // <= 80 ms of group-delay slack
+    int lo = 0, hi = kMaxShift;
+    if (delayLocked) {
+        int c = static_cast<int>(std::lround(delayEst));
+        lo = std::max(0, c - 3);
+        hi = std::min(kMaxShift, c + 3);
+    }
+
+    double bestScore = -1e30, scStar[3] = {0, 0, 0};
+    winShift = lo;
+    for (int d = lo; d <= hi; ++d) {
+        double sc[3];
+        for (int k = 0; k < 3; ++k) {
+            double dot = 0.0;
+            for (int n = d; n < kSecLen; ++n) dot += v[n] * tpl[k][n - d];
+            sc[k] = dot * invn / (tplNorm[k] + 1e-12);
+        }
+        double m = std::max({sc[0], sc[1], sc[2]});
+        if (m > bestScore) {
+            bestScore = m; winShift = d;
+            scStar[0] = sc[0]; scStar[1] = sc[1]; scStar[2] = sc[2];
+        }
+    }
+
+    int best = 0;
+    for (int k = 1; k < 3; ++k) if (scStar[k] > scStar[best]) best = k;
+    double runner = -1e30;
+    for (int k = 0; k < 3; ++k) if (k != best && scStar[k] > runner) runner = scStar[k];
+    sym = static_cast<int8_t>(best);
+    conf = static_cast<float>(std::max(0.0, scStar[best] - runner));
+}
+
+void WwvDecoder::Impl::processSecond(std::int64_t startJ,
+                                     const std::array<float, kSecLen>& w) {
+    int8_t sym; float conf; int winShift = 0;
+    classify(w, sym, conf, winShift);
+
+    // Slowly adapt the fixed group-delay estimate toward the alignment that
+    // confident seconds actually used; freeze the search band once it settles.
+    if (conf > 0.12f) {
+        delayEst = 0.85 * delayEst + 0.15 * winShift;
+        if (++delayCount >= 4) delayLocked = true;
+    }
+
+    double emean = 0.0;
+    for (float v : w) emean += v;
+    emean /= kSecLen;
+
+    const std::int64_t edgeSample = startJ * decim;
+    const std::int64_t k = secIndex;
+    int secOfFrame = anchored
+        ? static_cast<int>(((k - anchorSec0) % kFrameSecs + kFrameSecs) % kFrameSecs)
+        : -1;
+
+    lastEdgeSample = edgeSample;
+    lastEdgeSecondOfFrame = secOfFrame;
+
+    // Emit the classified second (drives the alignment display).
+    if (owner && owner->onSecond) {
+        ClockSecondInfo info;
+        info.edgeSample = edgeSample;
+        info.symbol = static_cast<ClockSymbol>(sym);
+        info.confidence = conf;
+        info.secondOfFrame = secOfFrame;
+        info.seriesRateHz = kSeriesRate;
+        info.envelope.resize(kSecLen);
+        double s = (aScale > 1e-9) ? (1.0 / aScale) : 0.0;
+        for (int n = 0; n < kSecLen; ++n)
+            info.envelope[n] = static_cast<float>(std::min(1.5, w[n] * s));
+        info.expected.assign(tpl[sym].begin(), tpl[sym].end());
+        owner->onSecond(info);
+    }
+
+    // Record for frame anchoring.
+    recs.push_back(Rec{k, edgeSample, sym, conf, static_cast<float>(emean)});
+    if (recs.size() > kRecCap) { recs.pop_front(); ++recBase; }
+    ++secIndex;
+
+    if (!anchored) tryAnchor();
+    feedPendingFrames();
+}
+
+void WwvDecoder::Impl::tryAnchor() {
+    // Marker-only anchoring is degenerate mod 10 s; disambiguate with the s0
+    // subcarrier hole (second 0 has NO subcarrier -> ~0 energy) and minute-
+    // increment scoring across frames. Gate on structure so noise never anchors.
+    const int M = static_cast<int>(recs.size());
+    if (M < 2 * kFrameSecs) return;
+
+    int bestScore = -1 << 30, bestOff = -1, bestMarker = 0, bestInc = 0, bestHole = 0;
+
+    for (int off = 0; off < kFrameSecs; ++off) {
+        int nf = (M - off) / kFrameSecs;
+        if (nf < 2) continue;
+
+        int markerScore = 0, holeScore = 0;
+        std::vector<int> minutes;
+        minutes.reserve(nf);
+
+        for (int t = 0; t < nf; ++t) {
+            int base = off + kFrameSecs * t;
+            // marker agreement
+            for (int s = 0; s < kFrameSecs; ++s) {
+                if (recs[base + s].sym == 2) markerScore += isMarkerSec(s) ? 2 : -1;
+            }
+            // s0 hole: energy[0] a clear low outlier vs the frame's pulse energy
+            double e0 = recs[base + 0].energy;
+            double meanE = 0.0, minE = 1e30;
+            for (int s = 1; s < kFrameSecs; ++s) {
+                double e = recs[base + s].energy;
+                meanE += e;
+                if (e < minE) minE = e;
+            }
+            meanE /= (kFrameSecs - 1);
+            if (e0 < 0.5 * meanE && e0 <= minE + 1e-9) ++holeScore;
+            // per-frame minute decode
+            int mv = 0;
+            for (const auto& bw : kMin)
+                if (recs[base + bw.second].sym == 1) mv += bw.weight;
+            minutes.push_back(mv);
+        }
+        int inc = 0;
+        for (int t = 0; t + 1 < nf; ++t)
+            if (minutes[t + 1] - minutes[t] == 1) ++inc;
+
+        int score = markerScore + 4 * inc + 3 * holeScore;
+        if (score > bestScore) {
+            bestScore = score; bestOff = off;
+            bestMarker = markerScore; bestInc = inc; bestHole = holeScore;
+        }
+    }
+
+    // Structural gate: real marker agreement, at least one minute increment, and
+    // a detected s0 hole. A 10 s-shifted anchor lands a pulse on second 0 (no
+    // hole) and misdecodes minutes (no increment), so it loses this gate.
+    if (bestOff >= 0 && bestMarker > 0 && bestInc >= 1 && bestHole >= 1) {
+        anchored = true;
+        anchorSec0 = recBase + bestOff;
+        nextFrameStartK = anchorSec0;
+    }
+}
+
+void WwvDecoder::Impl::feedPendingFrames() {
+    if (!anchored) return;
+    const std::int64_t maxComplete = secIndex - 1;   // last processed secIndex
+
+    while (nextFrameStartK + (kFrameSecs - 1) <= maxComplete) {
+        if (nextFrameStartK < recBase) { nextFrameStartK += kFrameSecs; continue; }
+
+        std::array<int8_t, kFrameSecs> sym{};
+        std::array<float, kFrameSecs> conf{};
+        std::array<ClockSymbol, kFrameSecs> vsym{};
+        std::int64_t base = nextFrameStartK - recBase;
+        for (int s = 0; s < kFrameSecs; ++s) {
+            const Rec& r = recs[static_cast<std::size_t>(base + s)];
+            sym[s] = r.sym;
+            conf[s] = r.conf;
+            vsym[s] = static_cast<ClockSymbol>(r.sym);
+        }
+
+        std::int64_t frameStartSample = recs[static_cast<std::size_t>(base)].edgeSample;
+        ClockFrameInfo frame = decodeFrame(sym, conf, frameStartSample);
+        if (owner && owner->onFrame) owner->onFrame(frame);
+
+        // Feed the cross-frame voter (markers excluded internally).
+        voter.addFrame(vsym, conf);
+        if (voter.locked()) {
+            setState(ClockLockState::Locked);
+            if (owner && owner->onTime) {
+                ClockTimeInfo t;
+                t.minute = voter.votedField(TimeFrameVoter::FieldMinutes);
+                t.hour   = voter.votedField(TimeFrameVoter::FieldHours);
+                t.doy    = voter.votedField(TimeFrameVoter::FieldDoy);
+                t.year2  = voter.votedField(TimeFrameVoter::FieldYear);
+                t.quality = voter.lockConfidence();
+                t.lastEdgeSample = lastEdgeSample;
+                t.lastEdgeSecondOfFrame = lastEdgeSecondOfFrame;
+                t.station = station;
+                owner->onTime(t);
+            }
+        }
+
+        nextFrameStartK += kFrameSecs;
+    }
+}
+
+ClockFrameInfo WwvDecoder::Impl::decodeFrame(
+    const std::array<int8_t, kFrameSecs>& sym,
+    const std::array<float, kFrameSecs>& conf,
+    std::int64_t frameStartSample) const {
+    auto bit = [&](int s) { return sym[s] == 1; };
+    auto sumField = [&](const ClockFieldMap& m) {
+        int v = 0;
+        for (const auto& bw : m) if (bit(bw.second)) v += bw.weight;
+        return v;
+    };
+
+    ClockFrameInfo f;
+    f.minute = sumField(kMin);
+    f.hour   = sumField(kHr);
+    f.doy    = sumField(kDoy);
+    f.year2  = sumField(kYr);
+
+    // DUT1: sign at s50 (1 = positive); magnitude in tenths at s56/57/58.
+    int magTenths = (bit(56) ? 1 : 0) + (bit(57) ? 2 : 0) + (bit(58) ? 4 : 0);
+    f.dut1Tenths = (bit(50) ? magTenths : -magTenths);
+
+    f.dst1 = bit(2);          // DST at 00:00Z today
+    f.dst2 = bit(55);         // DST at 24:00Z today
+    f.leapPending = bit(3);   // leap-second warning
+    f.leapYear = false;       // WWV/WWVH carry no leap-year bit
+
+    // Frame confidence: mean per-second margin over the non-marker seconds.
+    double sumc = 0.0; int cnt = 0;
+    for (int s = 0; s < kFrameSecs; ++s)
+        if (!isMarkerSec(s)) { sumc += conf[s]; ++cnt; }
+    f.frameConfidence = cnt ? static_cast<float>(std::min(1.0, sumc / cnt)) : 0.0f;
+
+    f.frameStartSample = frameStartSample;
+    f.station = station;
+    return f;
+}
+
+void WwvDecoder::Impl::reset() {
+    for (auto& b : bpMain) b.reset();
+    for (auto& b : lpEnv) b.reset();
+    for (auto& b : lpI) b.reset();
+    for (auto& b : lpQ) b.reset();
+    for (auto& b : bpTickV) b.reset();
+    for (auto& b : bpTickH) b.reset();
+    oscC = 1.0; oscS = 0.0; oscRenorm = 0;
+    accA = accTickV = accTickH = 0.0; decCount = 0; n200 = 0;
+    foldV.fill(0.0); foldH.fill(0.0);
+    tickLocked = false; tickPhase = 0;
+    delayEst = 7.0; delayLocked = false; delayCount = 0;
+    curFill = 0; secStarted = false; secStartJ = 0; aScale = 1e-6;
+    recs.clear(); recBase = 0; secIndex = 0;
+    anchored = false; anchorSec0 = 0; nextFrameStartK = 0;
+    lastEdgeSample = 0; lastEdgeSecondOfFrame = -1;
+    station = ClockStation::Unknown;
+    samplesConsumed = 0;
+    voter.reset();
+    setState(ClockLockState::NoSignal);
+}
+
+// ---------------------------------------------------------------------------
+// Public surface.
+
+WwvDecoder::WwvDecoder(int sampleRateHz)
+    : m_impl(std::make_unique<Impl>(sampleRateHz)) {
+    m_impl->owner = this;
+}
+
+WwvDecoder::~WwvDecoder() = default;
+
+void WwvDecoder::process(const float* mono, std::size_t n) {
+    if (!mono) return;
+    Impl* d = m_impl.get();
+    for (std::size_t k = 0; k < n; ++k) d->processSample(mono[k]);
+}
+
+void WwvDecoder::reset() { m_impl->reset(); }
+
+ClockLockState WwvDecoder::state() const { return m_impl->state; }
+ClockStation WwvDecoder::station() const { return m_impl->station; }
+std::int64_t WwvDecoder::samplesConsumed() const { return m_impl->samplesConsumed; }
+
+} // namespace AetherSDR

--- a/src/core/WwvDecoder.cpp
+++ b/src/core/WwvDecoder.cpp
@@ -67,6 +67,10 @@ constexpr double kFoldDecay = 0.99;
 inline bool isMarkerSec(int s) { return (s % 10) == 9; }
 
 // ---- Transposed Direct-Form-II biquad (RBJ cookbook coefficients). ---------
+// MSVC <cmath> does not define M_PI without _USE_MATH_DEFINES; repo core
+// convention is a local constant (Biquad/ClientEq/ClientPhaseRotator).
+constexpr double kPi = 3.14159265358979323846;
+
 struct Biquad {
     double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0;
     double z1 = 0.0, z2 = 0.0;
@@ -81,7 +85,7 @@ struct Biquad {
 
 Biquad designBandpass(double f0, double q, double fs) {
     // RBJ constant-0dB-peak bandpass.
-    double w0 = 2.0 * M_PI * f0 / fs;
+    double w0 = 2.0 * kPi * f0 / fs;
     double c = std::cos(w0), s = std::sin(w0);
     double alpha = s / (2.0 * q);
     double a0 = 1.0 + alpha;
@@ -95,7 +99,7 @@ Biquad designBandpass(double f0, double q, double fs) {
 }
 
 Biquad designLowpass(double fc, double q, double fs) {
-    double w0 = 2.0 * M_PI * fc / fs;
+    double w0 = 2.0 * kPi * fc / fs;
     double c = std::cos(w0), s = std::sin(w0);
     double alpha = s / (2.0 * q);
     double a0 = 1.0 + alpha;
@@ -265,7 +269,7 @@ void WwvDecoder::Impl::designFilters() {
     for (auto& b : bpTickV) b = designBandpass(2000.0, 12.0, f);
     for (auto& b : bpTickH) b = designBandpass(2200.0, 12.0, f);
 
-    double dth = 2.0 * M_PI * 100.0 / f;   // 100 Hz demod rotation per sample
+    double dth = 2.0 * kPi * 100.0 / f;   // 100 Hz demod rotation per sample
     rotC = std::cos(dth);
     rotS = std::sin(dth);
 }

--- a/src/core/WwvDecoder.h
+++ b/src/core/WwvDecoder.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// WWV/WWVH 100 Hz-subcarrier BCD time-code decoder — streaming port of the
+// gate-passed AetherClock reference chain (research/wwv_decode_proto.py).
+// Format facts per the NIST WWV/WWVH time-code table (NIST SP 432).
+//
+// Input contract: 24 kHz mono float32 from a slice tuned USB at
+// (carrier - 1 kHz). In that spectrum the RF carrier is a 1000 Hz audio tone,
+// the 100 Hz BCD subcarrier appears as 900/1100 Hz sidebands, and the WWV
+// 1000 Hz seconds tick images at 2000 Hz (WWVH's 1200 Hz tick at 2200 Hz —
+// which tick band carries energy tags the station).
+//
+// Chain: analytic bandpass 700-1300 Hz -> envelope -> coherent 100 Hz demod
+// (25 Hz LPF) -> 200 Hz amplitude series -> tick-phase sync (2000/2200 Hz
+// band) -> per-second matched-filter classify (170/470/770 ms templates at
+// +30 ms; margin = confidence) -> marker frame sync (P markers at seconds
+// 9/19/29/39/49/59; marker-only anchoring is DEGENERATE mod 10 s —
+// disambiguated via the s0 minute-mark subcarrier hole and minute-increment
+// scoring) -> NIST BCD field map -> TimeFrameVoter.
+//
+// Pure DSP — no Qt (EB1/EB2). Streaming: process() accumulates internally,
+// no whole-file transforms.
+
+#include "TimeFrameVoter.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace AetherSDR {
+
+class WwvDecoder {
+public:
+    explicit WwvDecoder(int sampleRateHz = 24000);
+    ~WwvDecoder();
+
+    WwvDecoder(const WwvDecoder&) = delete;
+    WwvDecoder& operator=(const WwvDecoder&) = delete;
+
+    // Feed mono float32 samples; fires callbacks inline (same thread) as
+    // seconds/frames/time updates become available.
+    void process(const float* mono, std::size_t n);
+
+    void reset();
+
+    ClockLockState state() const;
+    ClockStation station() const;      // Wwv or Wwvh once tick-tagged
+    std::int64_t samplesConsumed() const;
+
+    // Callbacks (any may be left unset).
+    std::function<void(const ClockSecondInfo&)> onSecond;
+    std::function<void(const ClockFrameInfo&)> onFrame;
+    std::function<void(const ClockTimeInfo&)> onTime;  // voted updates while locked
+    std::function<void(ClockLockState)> onStateChanged;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace AetherSDR

--- a/src/core/WwvDecoder.h
+++ b/src/core/WwvDecoder.h
@@ -54,6 +54,11 @@ public:
     ClockStation station() const;      // Wwv or Wwvh once tick-tagged
     std::int64_t samplesConsumed() const;
 
+    // WS-7 acquisition telemetry: read-only snapshot assembled ON CALL from
+    // state the decoder already keeps (tick fold, delay estimate, anchor,
+    // voter) — zero cost on the sample path, no feedback into decoding.
+    ClockDecoderDiagnostics diagnostics() const;
+
     // Callbacks (any may be left unset).
     std::function<void(const ClockSecondInfo&)> onSecond;
     std::function<void(const ClockFrameInfo&)> onFrame;

--- a/src/core/WwvDecoder.h
+++ b/src/core/WwvDecoder.h
@@ -43,6 +43,13 @@ public:
 
     void reset();
 
+    // Arm the shared voter's absolute-plausibility gate (WS-4.5): a voted
+    // timestamp farther than boundMinutes from the reference clock refuses to
+    // lock. The engine plumbs the host clock here; default is disarmed so pure
+    // decoder use (tests, corpus runners) is reference-free.
+    void setPlausibility(std::function<TimeFields()> referenceNow,
+                         int boundMinutes);
+
     ClockLockState state() const;
     ClockStation station() const;      // Wwv or Wwvh once tick-tagged
     std::int64_t samplesConsumed() const;

--- a/src/core/WwvbDecoder.cpp
+++ b/src/core/WwvbDecoder.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdint>
 #include <initializer_list>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -167,6 +168,7 @@ struct WwvbDecoder::Impl {
     void reset() {
         phase = Phase::Searching;
         acqCount = 0;
+        lastToneSnrDb = 0.0f;
         std::fill(gS1.begin(), gS1.end(), 0.0);
         std::fill(gS2.begin(), gS2.end(), 0.0);
         oscRe = 1.0; oscIm = 0.0; oscRenorm = 0;
@@ -209,6 +211,13 @@ struct WwvbDecoder::Impl {
         std::vector<double> med = pw;
         std::nth_element(med.begin(), med.begin() + med.size() / 2, med.end());
         double median = med[med.size() / 2];
+
+        // WS-7 telemetry: remember what the tone search measured (read-only
+        // store — the gate decision below is untouched). Updated every 2 s
+        // search window until the tone gate passes, so the funnel's stage-1
+        // readout is live even when nothing is there.
+        if (median > 0.0)
+            lastToneSnrDb = static_cast<float>(10.0 * std::log10(peakP / median));
 
         if (peakP > kToneGate * median && median > 0.0) {
             f0 = gFreq[peak];
@@ -567,6 +576,7 @@ struct WwvbDecoder::Impl {
     // acquisition
     std::vector<double> gFreq, gCoeff, gS1, gS2;
     int64_t acqCount = 0, acqTarget = 0;
+    float lastToneSnrDb = 0.0f;   // WS-7 telemetry: last tone-search peak/median (dB)
 
     // mixer / envelope generation
     double f0 = 1000.0;
@@ -634,5 +644,22 @@ ClockStation WwvbDecoder::station() const {
 }
 
 std::int64_t WwvbDecoder::samplesConsumed() const { return m_impl->samplesConsumed; }
+
+ClockDecoderDiagnostics WwvbDecoder::diagnostics() const {
+    const Impl& d = *m_impl;
+    ClockDecoderDiagnostics g;
+    g.toneSnrDb = d.lastToneSnrDb;
+    g.pwmContrast = (d.pP10 > 1e-6f) ? d.pP90 / d.pP10 : 0.0f;
+    g.toneDetected = (d.phase == Impl::Phase::Running);
+    g.phaseLocked = d.phaseKnown;
+    g.delayEstMs = std::numeric_limits<float>::quiet_NaN();  // WWV-only metric
+    g.anchored = d.anchored;
+    g.badFrameStreak = 0;  // WWV-only metric (marker-skeleton streak)
+    g.framesInWindow = d.voter.frameCount();
+    g.windowSize = d.voter.windowSize();
+    g.voteQuality = d.voter.lockConfidence();
+    g.refusalReason = static_cast<std::uint8_t>(d.voter.lockRefusal());
+    return g;
+}
 
 } // namespace AetherSDR

--- a/src/core/WwvbDecoder.cpp
+++ b/src/core/WwvbDecoder.cpp
@@ -1,0 +1,616 @@
+// WwvbDecoder.cpp — implementation translation unit (no include guard needed).
+
+#include "WwvbDecoder.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <initializer_list>
+#include <utility>
+#include <vector>
+
+// WWVB 60 kHz legacy-AM/PWM decoder. All format facts per the NIST WWVB
+// time-code description (NIST SP 250-67): one bit per second; carrier power
+// reduced 17 dB at each second start for 0.2 s (binary 0), 0.5 s (binary 1)
+// or 0.8 s (marker); markers at seconds 0, 9, 19, 29, 39, 49, 59; two
+// consecutive markers (s59 -> s0) mark the minute boundary. BCD field weights
+// are MSB-first (opposite of WWV). Amplitude-only by design: the post-2012
+// BPSK phase layer (a 180 deg flip +100 ms after each second) leaves the AM
+// envelope unchanged, and a magnitude detector is invariant to a phase flip
+// (|-z| == |z|), so this decoder ignores it entirely.
+//
+// Chain: one-shot tone search 800-1200 Hz -> complex mix to baseband ->
+// biquad LPF on I/Q -> magnitude -> boxcar-decimate to a 100 Hz envelope ->
+// AM-drop second-edge tracking -> per-second zero-mean matched-filter
+// classify (0.2/0.5/0.8 s low durations; confidence = correlation margin) ->
+// double-marker minute sync -> NIST WWVB BCD map -> TimeFrameVoter.
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr double kPi          = 3.14159265358979323846;
+constexpr int    kEnvRateHz   = 100;    // decoded envelope series rate
+constexpr int    kEnvCap      = 1024;   // envelope ring capacity (>10 s)
+constexpr int    kPctWin      = 300;    // adaptive-threshold window (3 s)
+constexpr int    kEdgeTol     = 12;     // +/- env samples searched per second
+constexpr int    kWarmEnv     = 200;    // env samples before seeding phase
+constexpr double kMinContrast = 1.4;    // p90 >= 1.4*p10 => a real AM drop exists
+constexpr double kLpfCutHz    = 150.0;  // I/Q low-pass corner
+
+// Acquisition tone search.
+constexpr double kAcqSeconds  = 2.0;
+constexpr double kToneLoHz    = 800.0;
+constexpr double kToneHiHz    = 1200.0;
+constexpr double kToneStepHz  = 2.0;
+constexpr double kToneGate    = 12.0;   // peak/median power ratio for "tone present"
+
+constexpr std::array<int, 7> kMarkerSeconds = {0, 9, 19, 29, 39, 49, 59};
+
+// Low-duration (in 100 Hz env samples) of each symbol: 0.2/0.5/0.8 s.
+constexpr std::array<int, 3> kSymbolLowLen = {20, 50, 80};
+
+// Transposed-direct-form-II biquad, runtime-designed Butterworth low-pass.
+struct Biquad {
+    double b0 = 1.0, b1 = 0.0, b2 = 0.0, a1 = 0.0, a2 = 0.0;
+    double z1 = 0.0, z2 = 0.0;
+
+    double process(double x) {
+        double y = b0 * x + z1;
+        z1 = b1 * x - a1 * y + z2;
+        z2 = b2 * x - a2 * y;
+        return y;
+    }
+    void reset() { z1 = z2 = 0.0; }
+
+    static Biquad lowpass(double fs, double fc) {
+        const double w0 = 2.0 * kPi * fc / fs;
+        const double c = std::cos(w0);
+        const double s = std::sin(w0);
+        const double q = 0.70710678118654752440;   // Butterworth Q
+        const double alpha = s / (2.0 * q);
+        const double a0 = 1.0 + alpha;
+        Biquad bq;
+        bq.b0 = ((1.0 - c) / 2.0) / a0;
+        bq.b1 = (1.0 - c) / a0;
+        bq.b2 = ((1.0 - c) / 2.0) / a0;
+        bq.a1 = (-2.0 * c) / a0;
+        bq.a2 = (1.0 - alpha) / a0;
+        return bq;
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+struct WwvbDecoder::Impl {
+    explicit Impl(WwvbDecoder* o, int sampleRateHz)
+        : owner(o),
+          sr(sampleRateHz > 0 ? sampleRateHz : 24000),
+          decim(std::max(1, static_cast<int>(std::lround(sr / 100.0)))),
+          voter(buildVoterConfig()) {
+        acqTarget = static_cast<int64_t>(std::llround(kAcqSeconds * sr));
+        for (double f = kToneLoHz; f <= kToneHiHz + 1e-9; f += kToneStepHz) {
+            gFreq.push_back(f);
+            gCoeff.push_back(2.0 * std::cos(2.0 * kPi * f / sr));
+        }
+        gS1.assign(gFreq.size(), 0.0);
+        gS2.assign(gFreq.size(), 0.0);
+        pctScratch.reserve(kPctWin);
+        buildTemplates();
+    }
+
+    // ---- fixed configuration -------------------------------------------
+
+    // NIST WWVB BCD field maps (MSB-first weights) for the shared voter.
+    static TimeFrameVoter::Config buildVoterConfig() {
+        TimeFrameVoter::Config c;
+        c.fields[TimeFrameVoter::FieldMinutes] =
+            {{1, 40}, {2, 20}, {3, 10}, {5, 8}, {6, 4}, {7, 2}, {8, 1}};
+        c.fields[TimeFrameVoter::FieldHours] =
+            {{12, 20}, {13, 10}, {15, 8}, {16, 4}, {17, 2}, {18, 1}};
+        c.fields[TimeFrameVoter::FieldDoy] =
+            {{22, 200}, {23, 100}, {25, 80}, {26, 40}, {27, 20},
+             {28, 10}, {30, 8}, {31, 4}, {32, 2}, {33, 1}};
+        c.fields[TimeFrameVoter::FieldYear] =
+            {{45, 80}, {46, 40}, {47, 20}, {48, 10}, {50, 8}, {51, 4}, {52, 2}, {53, 1}};
+        c.markerSeconds = {0, 9, 19, 29, 39, 49, 59};
+        return c;
+    }
+
+    void buildTemplates() {
+        // Zero-mean expected envelope per symbol: 0 during the reduced-carrier
+        // (low) portion, 1 during the full-carrier (high) portion. The winning
+        // template's low->high transition point identifies the pulse duration.
+        for (int s = 0; s < 3; ++s) {
+            const int low = kSymbolLowLen[s];
+            double mean = 0.0;
+            for (int k = 0; k < kEnvRateHz; ++k) {
+                float e = (k < low) ? 0.0f : 1.0f;
+                tpl[s][k] = e;
+                mean += e;
+            }
+            mean /= kEnvRateHz;
+            double nrm = 0.0;
+            for (int k = 0; k < kEnvRateHz; ++k) {
+                tpl[s][k] -= static_cast<float>(mean);
+                nrm += static_cast<double>(tpl[s][k]) * tpl[s][k];
+            }
+            tplNorm[s] = std::sqrt(nrm) + 1e-12;
+        }
+    }
+
+    // ---- driving ---------------------------------------------------------
+
+    void process(const float* mono, std::size_t n) {
+        for (std::size_t i = 0; i < n; ++i) {
+            const double x = static_cast<double>(mono[i]);
+            ++samplesConsumed;
+            if (phase == Phase::Searching)
+                feedAcquisition(x);
+            else
+                feedSteady(x);
+        }
+    }
+
+    void reset() {
+        phase = Phase::Searching;
+        acqCount = 0;
+        std::fill(gS1.begin(), gS1.end(), 0.0);
+        std::fill(gS2.begin(), gS2.end(), 0.0);
+        oscRe = 1.0; oscIm = 0.0; oscRenorm = 0;
+        lpI.reset(); lpQ.reset();
+        magAccum = 0.0; magCount = 0;
+        env.fill(0.0f); envCount = 0; envBaseSample = 0;
+        pP10 = 0.0f; pP90 = 0.0f;
+        phaseKnown = false; curStart = 0; scanPos = 0;
+        anchored = false; sofNext = 0; prevSym = ClockSymbol::Unknown; havePrev = false;
+        frFilledCount = 0; frStartSample = 0;
+        haveLastFrame = false; lastFrameS0Env = 0;
+        haveVoted = false;
+        votedMinute = votedHour = votedDoy = votedYear = -1; votedQuality = 0.0f;
+        voter.reset();
+        samplesConsumed = 0;
+        setLockState(ClockLockState::NoSignal);
+    }
+
+    // ---- acquisition (one-shot tone search) ------------------------------
+
+    void feedAcquisition(double x) {
+        for (std::size_t i = 0; i < gFreq.size(); ++i) {
+            double s = x + gCoeff[i] * gS1[i] - gS2[i];
+            gS2[i] = gS1[i];
+            gS1[i] = s;
+        }
+        if (++acqCount >= acqTarget)
+            finalizeAcquisition();
+    }
+
+    void finalizeAcquisition() {
+        int peak = 0;
+        double peakP = -1.0;
+        std::vector<double> pw(gFreq.size());
+        for (std::size_t i = 0; i < gFreq.size(); ++i) {
+            double p = gS1[i] * gS1[i] + gS2[i] * gS2[i] - gCoeff[i] * gS1[i] * gS2[i];
+            pw[i] = p;
+            if (p > peakP) { peakP = p; peak = static_cast<int>(i); }
+        }
+        std::vector<double> med = pw;
+        std::nth_element(med.begin(), med.begin() + med.size() / 2, med.end());
+        double median = med[med.size() / 2];
+
+        if (peakP > kToneGate * median && median > 0.0) {
+            f0 = gFreq[peak];
+            startSteady();
+        } else {
+            // No tone: keep searching over the next acquisition window.
+            std::fill(gS1.begin(), gS1.end(), 0.0);
+            std::fill(gS2.begin(), gS2.end(), 0.0);
+            acqCount = 0;
+        }
+    }
+
+    void startSteady() {
+        phase = Phase::Running;
+        envBaseSample = samplesConsumed;    // env index 0 begins here
+        const double w0 = 2.0 * kPi * f0 / sr;
+        stepRe = std::cos(w0);
+        stepIm = -std::sin(w0);             // e^{-j w0}
+        oscRe = 1.0; oscIm = 0.0; oscRenorm = 0;
+        lpI = Biquad::lowpass(sr, kLpfCutHz);
+        lpQ = Biquad::lowpass(sr, kLpfCutHz);
+        magAccum = 0.0; magCount = 0;
+        setLockState(ClockLockState::Acquiring);
+    }
+
+    // ---- steady state (mix -> LPF -> magnitude -> decimate) --------------
+
+    void feedSteady(double x) {
+        double I = lpI.process(x * oscRe);
+        double Q = lpQ.process(x * oscIm);
+        magAccum += std::sqrt(I * I + Q * Q);
+        if (++magCount >= decim) {
+            pushEnvelope(static_cast<float>(magAccum / magCount));
+            magAccum = 0.0;
+            magCount = 0;
+        }
+        // Advance the baseband phasor (rotation recurrence + periodic renorm).
+        double nr = oscRe * stepRe - oscIm * stepIm;
+        double ni = oscRe * stepIm + oscIm * stepRe;
+        oscRe = nr; oscIm = ni;
+        if (++oscRenorm >= 1024) {
+            double m = std::sqrt(oscRe * oscRe + oscIm * oscIm);
+            if (m > 1e-9) { oscRe /= m; oscIm /= m; }
+            oscRenorm = 0;
+        }
+    }
+
+    void pushEnvelope(float v) {
+        env[static_cast<std::size_t>(envCount % kEnvCap)] = v;
+        ++envCount;
+        updatePercentiles();
+        processSeconds();
+    }
+
+    float envAt(int64_t idx) const { return env[static_cast<std::size_t>(idx % kEnvCap)]; }
+
+    void updatePercentiles() {
+        int64_t n = std::min<int64_t>(kPctWin, envCount);
+        if (n < 8) { pP10 = pP90 = 0.0f; return; }
+        pctScratch.clear();
+        for (int64_t i = envCount - n; i < envCount; ++i)
+            pctScratch.push_back(envAt(i));
+        std::size_t k10 = static_cast<std::size_t>(0.10 * n);
+        std::size_t k90 = static_cast<std::size_t>(0.90 * n);
+        std::nth_element(pctScratch.begin(), pctScratch.begin() + k10, pctScratch.end());
+        pP10 = pctScratch[k10];
+        std::nth_element(pctScratch.begin(), pctScratch.begin() + k90, pctScratch.end());
+        pP90 = pctScratch[k90];
+    }
+
+    bool haveContrast() const {
+        return pP90 >= kMinContrast * std::max(pP10, 1e-6f);
+    }
+
+    // A genuine second edge stays low for several env samples; the BPSK
+    // +100 ms phase-flip transient is only ~1 sample wide and is rejected.
+    bool sustainedLow(int64_t i, float thrLo) const {
+        int checked = 0, low = 0;
+        for (int d = 1; d <= 7; ++d) {
+            if (i + d >= envCount) break;
+            ++checked;
+            if (envAt(i + d) < thrLo) ++low;
+        }
+        return checked >= 5 && low >= checked - 1;
+    }
+
+    // ---- second segmentation & classification ----------------------------
+
+    void processSeconds() {
+        if (!phaseKnown) {
+            trySeed();
+            if (!phaseKnown) return;
+        }
+        while (phaseKnown && envCount >= curStart + kEnvRateHz + kEdgeTol)
+            classifyAndAdvance();
+    }
+
+    void trySeed() {
+        if (envCount < kWarmEnv || !haveContrast()) return;
+        const float thrHi = pP10 + 0.6f * (pP90 - pP10);
+        const float thrLo = pP10 + 0.4f * (pP90 - pP10);
+        int64_t lo = std::max<int64_t>(std::max<int64_t>(scanPos, 1), envCount - kEnvCap + 2);
+        for (int64_t i = lo; i + 7 < envCount; ++i) {
+            scanPos = i;
+            if (envAt(i - 1) >= thrHi && envAt(i) < thrLo && sustainedLow(i, thrLo)) {
+                curStart = i;
+                phaseKnown = true;
+                return;
+            }
+        }
+    }
+
+    int64_t findFallingEdgeNear(int64_t pred, int tol) {
+        if (!haveContrast()) return pred;   // coast on predicted cadence
+        const float thrHi = pP10 + 0.6f * (pP90 - pP10);
+        const float thrLo = pP10 + 0.4f * (pP90 - pP10);
+        int64_t lo = std::max<int64_t>(pred - tol, envCount - kEnvCap + 2);
+        int64_t hi = std::min<int64_t>(pred + tol, envCount - 1);
+        int64_t bestEdge = pred, bestDist = tol + 1;
+        for (int64_t i = lo; i <= hi; ++i) {
+            if (i < 1) continue;
+            if (envAt(i - 1) >= thrHi && envAt(i) < thrLo && sustainedLow(i, thrLo)) {
+                int64_t d = std::llabs(i - pred);
+                if (d < bestDist) { bestDist = d; bestEdge = i; }
+            }
+        }
+        return bestEdge;
+    }
+
+    void classifyAndAdvance() {
+        // Window = one full second from the drop edge (100 env samples).
+        std::array<float, kEnvRateHz> w;
+        double mean = 0.0;
+        for (int k = 0; k < kEnvRateHz; ++k) { w[k] = envAt(curStart + k); mean += w[k]; }
+        mean /= kEnvRateHz;
+
+        std::array<float, kEnvRateHz> v;
+        double vnorm = 0.0;
+        for (int k = 0; k < kEnvRateHz; ++k) {
+            v[k] = w[k] - static_cast<float>(mean);
+            vnorm += static_cast<double>(v[k]) * v[k];
+        }
+        vnorm = std::sqrt(vnorm) + 1e-12;
+
+        double corr[3];
+        for (int s = 0; s < 3; ++s) {
+            double dot = 0.0;
+            for (int k = 0; k < kEnvRateHz; ++k)
+                dot += static_cast<double>(v[k]) * tpl[s][k];
+            corr[s] = dot / (vnorm * tplNorm[s]);
+        }
+        int best = 0;
+        for (int s = 1; s < 3; ++s) if (corr[s] > corr[best]) best = s;
+        double runner = -1e18;
+        for (int s = 0; s < 3; ++s) if (s != best && corr[s] > runner) runner = corr[s];
+        float conf = static_cast<float>(std::max(0.0, corr[best] - runner));
+
+        ClockSymbol sym = (best == 0) ? ClockSymbol::Zero
+                        : (best == 1) ? ClockSymbol::One
+                                      : ClockSymbol::Marker;
+        int64_t edgeSample = envBaseSample + curStart * decim;
+
+        int sof = -1;
+        updateSync(sym, edgeSample, sof);
+        emitSecond(edgeSample, sym, conf, sof, w, best);
+
+        if (anchored && sof >= 0)
+            recordFrameSecond(sof, sym, conf);
+
+        if (lockState == ClockLockState::Locked && haveVoted && owner->onTime) {
+            ClockTimeInfo ti;
+            ti.minute = votedMinute; ti.hour = votedHour;
+            ti.doy = votedDoy; ti.year2 = votedYear;
+            ti.quality = votedQuality;
+            ti.lastEdgeSample = edgeSample;
+            ti.lastEdgeSecondOfFrame = sof;
+            ti.station = ClockStation::Wwvb;
+            owner->onTime(ti);
+        }
+
+        int64_t pred = curStart + kEnvRateHz;
+        curStart = findFallingEdgeNear(pred, kEdgeTol);
+    }
+
+    // ---- frame sync (double marker) --------------------------------------
+
+    void updateSync(ClockSymbol sym, int64_t edgeSample, int& sofOut) {
+        if (!anchored) {
+            // Two consecutive markers = s59 -> s0; this second is s0.
+            if (havePrev && prevSym == ClockSymbol::Marker && sym == ClockSymbol::Marker) {
+                anchored = true;
+                sofOut = 0;
+                sofNext = 1;
+                beginFrame(edgeSample);
+            } else {
+                sofOut = -1;
+            }
+        } else {
+            sofOut = sofNext;
+            if (sofOut == 0) beginFrame(edgeSample);
+            sofNext = (sofNext + 1) % 60;
+        }
+        prevSym = sym;
+        havePrev = true;
+    }
+
+    void beginFrame(int64_t s0edge) {
+        frStartSample = s0edge;
+        frFilledCount = 0;
+        frSym.fill(ClockSymbol::Unknown);
+        frConf.fill(0.0f);
+    }
+
+    void recordFrameSecond(int sof, ClockSymbol sym, float conf) {
+        frSym[static_cast<std::size_t>(sof)] = sym;
+        frConf[static_cast<std::size_t>(sof)] = conf;
+        ++frFilledCount;
+        if (sof == 59) finalizeFrame();
+    }
+
+    // ---- frame decode + voting -------------------------------------------
+
+    void finalizeFrame() {
+        bool ok = (frFilledCount >= 60);
+        for (int m : kMarkerSeconds)
+            if (frSym[static_cast<std::size_t>(m)] != ClockSymbol::Marker) { ok = false; break; }
+        if (!ok) {
+            // Corrupted markers: drop the anchor, re-search, never emit a frame.
+            anchored = false;
+            havePrev = false;
+            haveLastFrame = false;
+            haveVoted = false;
+            voter.reset();
+            setLockState(ClockLockState::Acquiring);
+            return;
+        }
+
+        ClockFrameInfo fi = decodeFrame();
+        if (owner->onFrame) owner->onFrame(fi);
+
+        int64_t s0env = (frStartSample - envBaseSample) / decim;
+        bool consecutive =
+            haveLastFrame &&
+            std::llabs((s0env - lastFrameS0Env) - 60LL * kEnvRateHz) <= 2LL * kEdgeTol;
+        if (!consecutive) voter.reset();
+        haveLastFrame = true;
+        lastFrameS0Env = s0env;
+
+        std::array<ClockSymbol, 60> syms = frSym;
+        std::array<float, 60> confs = frConf;
+        voter.addFrame(syms, confs);
+
+        if (voter.locked()) {
+            votedMinute = voter.votedField(TimeFrameVoter::FieldMinutes);
+            votedHour = voter.votedField(TimeFrameVoter::FieldHours);
+            votedDoy = voter.votedField(TimeFrameVoter::FieldDoy);
+            votedYear = voter.votedField(TimeFrameVoter::FieldYear);
+            votedQuality = voter.lockConfidence();
+            haveVoted = true;
+            setLockState(ClockLockState::Locked);
+        }
+    }
+
+    ClockFrameInfo decodeFrame() const {
+        auto bit = [&](int s) {
+            return frSym[static_cast<std::size_t>(s)] == ClockSymbol::One ? 1 : 0;
+        };
+        auto field = [&](std::initializer_list<std::pair<int, int>> map) {
+            int v = 0;
+            for (const auto& p : map) if (bit(p.first)) v += p.second;
+            return v;
+        };
+
+        ClockFrameInfo fi;
+        fi.minute = field({{1, 40}, {2, 20}, {3, 10}, {5, 8}, {6, 4}, {7, 2}, {8, 1}});
+        fi.hour   = field({{12, 20}, {13, 10}, {15, 8}, {16, 4}, {17, 2}, {18, 1}});
+        fi.doy    = field({{22, 200}, {23, 100}, {25, 80}, {26, 40}, {27, 20},
+                           {28, 10}, {30, 8}, {31, 4}, {32, 2}, {33, 1}});
+        fi.year2  = field({{45, 80}, {46, 40}, {47, 20}, {48, 10},
+                           {50, 8}, {51, 4}, {52, 2}, {53, 1}});
+
+        // DUT1: sign s36=+, s37=-, s38=+ (positive => s36 & s38 set; negative
+        // => s37 set). Magnitude weights in tenths of a second: 0.8/0.4/0.2/0.1.
+        int sign = bit(37) ? -1 : +1;
+        int mag10 = 0;
+        if (bit(40)) mag10 += 8;
+        if (bit(41)) mag10 += 4;
+        if (bit(42)) mag10 += 2;
+        if (bit(43)) mag10 += 1;
+        fi.dut1Tenths = sign * mag10;
+
+        fi.leapYear    = bit(55) != 0;   // LYI
+        fi.leapPending = bit(56) != 0;   // LSW
+        fi.dst1        = bit(57) != 0;   // DST code bit "2"
+        fi.dst2        = bit(58) != 0;   // DST code bit "1"
+
+        double sum = 0.0;
+        int cnt = 0;
+        for (int s = 0; s < 60; ++s) {
+            bool isMarker = false;
+            for (int m : kMarkerSeconds) if (m == s) { isMarker = true; break; }
+            if (!isMarker) { sum += frConf[static_cast<std::size_t>(s)]; ++cnt; }
+        }
+        fi.frameConfidence =
+            cnt ? static_cast<float>(std::min(1.0, std::max(0.0, sum / cnt))) : 0.0f;
+        fi.frameStartSample = frStartSample;
+        fi.station = ClockStation::Wwvb;
+        return fi;
+    }
+
+    // ---- callbacks & state -----------------------------------------------
+
+    void emitSecond(int64_t edgeSample, ClockSymbol sym, float conf, int sof,
+                    const std::array<float, kEnvRateHz>& w, int best) {
+        if (!owner->onSecond) return;
+        ClockSecondInfo si;
+        si.edgeSample = edgeSample;
+        si.symbol = sym;
+        si.confidence = conf;
+        si.secondOfFrame = sof;
+        si.seriesRateHz = kEnvRateHz;
+        si.envelope.resize(kEnvRateHz);
+        float norm = (pP90 > 1e-6f) ? pP90 : 1.0f;
+        for (int k = 0; k < kEnvRateHz; ++k)
+            si.envelope[k] = std::min(1.5f, std::max(0.0f, w[k] / norm));
+        si.expected.assign(tpl[best].begin(), tpl[best].end());
+        owner->onSecond(si);
+    }
+
+    void setLockState(ClockLockState s) {
+        if (s != lockState) {
+            lockState = s;
+            if (owner->onStateChanged) owner->onStateChanged(s);
+        }
+    }
+
+    // ---- members ---------------------------------------------------------
+
+    WwvbDecoder* owner;
+    int sr;
+    int decim;
+    TimeFrameVoter voter;
+
+    ClockLockState lockState = ClockLockState::NoSignal;
+    enum class Phase { Searching, Running } phase = Phase::Searching;
+    int64_t samplesConsumed = 0;
+
+    // acquisition
+    std::vector<double> gFreq, gCoeff, gS1, gS2;
+    int64_t acqCount = 0, acqTarget = 0;
+
+    // mixer / envelope generation
+    double f0 = 1000.0;
+    double oscRe = 1.0, oscIm = 0.0, stepRe = 1.0, stepIm = 0.0;
+    int oscRenorm = 0;
+    Biquad lpI, lpQ;
+    double magAccum = 0.0;
+    int magCount = 0;
+    int64_t envBaseSample = 0;
+
+    // envelope ring + adaptive threshold
+    std::array<float, kEnvCap> env{};
+    int64_t envCount = 0;
+    std::vector<float> pctScratch;
+    float pP10 = 0.0f, pP90 = 0.0f;
+
+    // second segmentation
+    bool phaseKnown = false;
+    int64_t curStart = 0, scanPos = 0;
+
+    // matched-filter templates
+    std::array<std::array<float, kEnvRateHz>, 3> tpl{};
+    std::array<double, 3> tplNorm{};
+
+    // frame sync
+    bool anchored = false;
+    int sofNext = 0;
+    ClockSymbol prevSym = ClockSymbol::Unknown;
+    bool havePrev = false;
+
+    // frame assembly
+    std::array<ClockSymbol, 60> frSym{};
+    std::array<float, 60> frConf{};
+    int frFilledCount = 0;
+    int64_t frStartSample = 0;
+    bool haveLastFrame = false;
+    int64_t lastFrameS0Env = 0;
+
+    // cached voted result (for onTime while locked)
+    bool haveVoted = false;
+    int votedMinute = -1, votedHour = -1, votedDoy = -1, votedYear = -1;
+    float votedQuality = 0.0f;
+};
+
+// ---------------------------------------------------------------------------
+
+WwvbDecoder::WwvbDecoder(int sampleRateHz)
+    : m_impl(std::make_unique<Impl>(this, sampleRateHz)) {}
+
+WwvbDecoder::~WwvbDecoder() = default;
+
+void WwvbDecoder::process(const float* mono, std::size_t n) { m_impl->process(mono, n); }
+void WwvbDecoder::reset() { m_impl->reset(); }
+
+ClockLockState WwvbDecoder::state() const { return m_impl->lockState; }
+
+ClockStation WwvbDecoder::station() const {
+    return (m_impl->lockState == ClockLockState::NoSignal) ? ClockStation::Unknown
+                                                           : ClockStation::Wwvb;
+}
+
+std::int64_t WwvbDecoder::samplesConsumed() const { return m_impl->samplesConsumed; }
+
+} // namespace AetherSDR

--- a/src/core/WwvbDecoder.cpp
+++ b/src/core/WwvbDecoder.cpp
@@ -120,6 +120,12 @@ struct WwvbDecoder::Impl {
         c.fields[TimeFrameVoter::FieldYear] =
             {{45, 80}, {46, 40}, {47, 20}, {48, 10}, {50, 8}, {51, 4}, {52, 2}, {53, 1}};
         c.markerSeconds = {0, 9, 19, 29, 39, 49, 59};
+        // WS-4.5 honesty floors (shared rationale with WwvDecoder): noise-grade
+        // margins must not vote, and a window whose trust collapsed must not
+        // lock — unanimity of systematic misreads is not evidence. Floors match
+        // WwvDecoder's (calibrated on the 2026-07-19 live WWV corpus).
+        c.minBitConfidence = 0.05f;
+        c.minLockQuality   = 0.05f;
         return c;
     }
 
@@ -463,6 +469,14 @@ struct WwvbDecoder::Impl {
             votedQuality = voter.lockConfidence();
             haveVoted = true;
             setLockState(ClockLockState::Locked);
+        } else {
+            // WS-4.5: the voter no longer certifies a timestamp — stop the
+            // per-second cached re-emission and demote a stale Locked instead
+            // of pinning it (the decoder is the lock authority the engine's
+            // state resync trusts).
+            haveVoted = false;
+            if (lockState == ClockLockState::Locked)
+                setLockState(ClockLockState::Acquiring);
         }
     }
 
@@ -606,6 +620,11 @@ WwvbDecoder::~WwvbDecoder() = default;
 
 void WwvbDecoder::process(const float* mono, std::size_t n) { m_impl->process(mono, n); }
 void WwvbDecoder::reset() { m_impl->reset(); }
+
+void WwvbDecoder::setPlausibility(std::function<TimeFields()> referenceNow,
+                                  int boundMinutes) {
+    m_impl->voter.setPlausibility(std::move(referenceNow), boundMinutes);
+}
 
 ClockLockState WwvbDecoder::state() const { return m_impl->lockState; }
 

--- a/src/core/WwvbDecoder.cpp
+++ b/src/core/WwvbDecoder.cpp
@@ -17,8 +17,11 @@
 // consecutive markers (s59 -> s0) mark the minute boundary. BCD field weights
 // are MSB-first (opposite of WWV). Amplitude-only by design: the post-2012
 // BPSK phase layer (a 180 deg flip +100 ms after each second) leaves the AM
-// envelope unchanged, and a magnitude detector is invariant to a phase flip
-// (|-z| == |z|), so this decoder ignores it entirely.
+// envelope unchanged in steady state (|-z| == |z|), and the flip TRANSIENT --
+// the discontinuity briefly rings the I/Q low-pass into a ~1-sample magnitude
+// notch -- is rejected by the ~10 ms boxcar decimation averaging it flat plus
+// the sustained-low edge gate (several consecutive low samples required), so
+// this decoder ignores the BPSK layer entirely; no edge is phase-derived.
 //
 // Chain: one-shot tone search 800-1200 Hz -> complex mix to baseband ->
 // biquad LPF on I/Q -> magnitude -> boxcar-decimate to a 100 Hz envelope ->

--- a/src/core/WwvbDecoder.h
+++ b/src/core/WwvbDecoder.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// WWVB 60 kHz legacy AM/PWM time-code decoder. Format facts per the NIST
+// WWVB time-code description (NIST SP 250-67): one bit per second, carrier
+// power reduced 17 dB at each second start for 0.2 s (binary 0), 0.5 s
+// (binary 1), or 0.8 s (marker); markers at seconds 0, 9, 19, 29, 39, 49,
+// 59 — two consecutive markers (s59 -> s0) mark the minute boundary.
+//
+// Input contract: 24 kHz mono float32 from a slice tuned USB at 0.059 MHz —
+// the 60 kHz carrier appears as a ~1000 Hz audio tone whose amplitude
+// carries the PWM.
+//
+// Chain: FFT-refined tone search 800-1200 Hz once at acquisition -> complex
+// mix at f0 -> LPF -> 100 Hz envelope series -> seconds edge = the AM drop
+// (NEVER a phase edge: WWVB's 2012 BPSK layer flips phase +100 ms after the
+// second and amplitude receivers are immune by design — INV-8) -> per-second
+// PWM matched-filter classify (0.2/0.5/0.8 s low-power durations; margin =
+// confidence; threshold adapts between the 10th/90th envelope percentiles)
+// -> double-marker minute sync -> NIST WWVB BCD field map (MSB-first
+// weights) -> TimeFrameVoter (shared with WwvDecoder).
+//
+// Pure DSP — no Qt (EB1/EB2). Streaming: process() accumulates internally,
+// no whole-file transforms.
+
+#include "TimeFrameVoter.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace AetherSDR {
+
+class WwvbDecoder {
+public:
+    explicit WwvbDecoder(int sampleRateHz = 24000);
+    ~WwvbDecoder();
+
+    WwvbDecoder(const WwvbDecoder&) = delete;
+    WwvbDecoder& operator=(const WwvbDecoder&) = delete;
+
+    // Feed mono float32 samples; fires callbacks inline (same thread).
+    void process(const float* mono, std::size_t n);
+
+    void reset();
+
+    ClockLockState state() const;
+    ClockStation station() const;      // always Wwvb once acquiring
+    std::int64_t samplesConsumed() const;
+
+    // Callbacks (any may be left unset).
+    std::function<void(const ClockSecondInfo&)> onSecond;
+    std::function<void(const ClockFrameInfo&)> onFrame;
+    std::function<void(const ClockTimeInfo&)> onTime;  // voted updates while locked
+    std::function<void(ClockLockState)> onStateChanged;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace AetherSDR

--- a/src/core/WwvbDecoder.h
+++ b/src/core/WwvbDecoder.h
@@ -54,6 +54,11 @@ public:
     ClockStation station() const;      // always Wwvb once acquiring
     std::int64_t samplesConsumed() const;
 
+    // WS-7 acquisition telemetry: read-only snapshot assembled ON CALL from
+    // state the decoder already keeps (tone search, envelope percentiles,
+    // anchor, voter) — zero cost on the sample path, no feedback into decoding.
+    ClockDecoderDiagnostics diagnostics() const;
+
     // Callbacks (any may be left unset).
     std::function<void(const ClockSecondInfo&)> onSecond;
     std::function<void(const ClockFrameInfo&)> onFrame;

--- a/src/core/WwvbDecoder.h
+++ b/src/core/WwvbDecoder.h
@@ -43,6 +43,13 @@ public:
 
     void reset();
 
+    // Arm the shared voter's absolute-plausibility gate (WS-4.5): a voted
+    // timestamp farther than boundMinutes from the reference clock refuses to
+    // lock. The engine plumbs the host clock here; default is disarmed so pure
+    // decoder use (tests, corpus runners) is reference-free.
+    void setPlausibility(std::function<TimeFields()> referenceNow,
+                         int boundMinutes);
+
     ClockLockState state() const;
     ClockStation station() const;      // always Wwvb once acquiring
     std::int64_t samplesConsumed() const;

--- a/src/models/AetherClockModel.cpp
+++ b/src/models/AetherClockModel.cpp
@@ -29,6 +29,12 @@ void AetherClockModel::attachEngine(AetherClockEngine* engine)
             this, &AetherClockModel::onStationDetected, Qt::QueuedConnection);
     connect(engine, &AetherClockEngine::timeDecoded,
             this, &AetherClockModel::onTimeDecoded, Qt::QueuedConnection);
+    connect(engine, &AetherClockEngine::diagnosticsUpdated,
+            this, &AetherClockModel::onDiagnostics, Qt::QueuedConnection);
+    // Signal-to-signal forward: the model adds no state for per-frame decodes,
+    // it just carries them across the thread boundary for the debug pane.
+    connect(engine, &AetherClockEngine::frameDecoded,
+            this, &AetherClockModel::frameDecoded, Qt::QueuedConnection);
 }
 
 QString AetherClockModel::stateName() const
@@ -39,6 +45,18 @@ QString AetherClockModel::stateName() const
     case ClockLockState::Locked:    return QStringLiteral("Locked");
     }
     return QStringLiteral("NoSignal");
+}
+
+QString AetherClockModel::refusalName() const
+{
+    switch (ClockLockRefusal(m_diag.refusalReason)) {
+    case ClockLockRefusal::None:         return QStringLiteral("None");
+    case ClockLockRefusal::QualityFloor: return QStringLiteral("QualityFloor");
+    case ClockLockRefusal::Plausibility: return QStringLiteral("Plausibility");
+    case ClockLockRefusal::Staleness:    return QStringLiteral("Staleness");
+    case ClockLockRefusal::Contested:    return QStringLiteral("Contested");
+    }
+    return QStringLiteral("None");
 }
 
 QString AetherClockModel::stationName() const
@@ -78,6 +96,12 @@ void AetherClockModel::onStationDetected(AetherSDR::ClockStation station)
     if (m_station == station) return;
     m_station = station;
     emit stationChanged(int(station));
+}
+
+void AetherClockModel::onDiagnostics(const AetherSDR::ClockDiagnostics& diag)
+{
+    m_diag = diag;
+    emit diagnosticsChanged();  // one snapshot, one notify (arrives at ~1 Hz)
 }
 
 void AetherClockModel::onTimeDecoded(const QDateTime& utc, double offsetMs, int quality)

--- a/src/models/AetherClockModel.cpp
+++ b/src/models/AetherClockModel.cpp
@@ -1,0 +1,99 @@
+#include "AetherClockModel.h"
+
+#include "core/AetherClockEngine.h"
+
+namespace AetherSDR {
+
+AetherClockModel::AetherClockModel(QObject* parent)
+    : QObject(parent)
+{}
+
+// All engine->model wiring uses Qt::QueuedConnection ONLY: per the model
+// header's threading contract the engine may be moved to a worker thread.
+void AetherClockModel::attachEngine(AetherClockEngine* engine)
+{
+    // Detach any previously attached engine first: drop every connection it
+    // made to this model so a re-attach can never double-deliver.
+    if (m_engine) {
+        disconnect(m_engine, nullptr, this, nullptr);
+    }
+
+    m_engine = engine;
+    if (!engine) {
+        return;
+    }
+
+    connect(engine, &AetherClockEngine::lockStateChanged,
+            this, &AetherClockModel::onLockStateChanged, Qt::QueuedConnection);
+    connect(engine, &AetherClockEngine::stationDetected,
+            this, &AetherClockModel::onStationDetected, Qt::QueuedConnection);
+    connect(engine, &AetherClockEngine::timeDecoded,
+            this, &AetherClockModel::onTimeDecoded, Qt::QueuedConnection);
+}
+
+QString AetherClockModel::stateName() const
+{
+    switch (m_state) {
+    case ClockLockState::NoSignal:  return QStringLiteral("NoSignal");
+    case ClockLockState::Acquiring: return QStringLiteral("Acquiring");
+    case ClockLockState::Locked:    return QStringLiteral("Locked");
+    }
+    return QStringLiteral("NoSignal");
+}
+
+QString AetherClockModel::stationName() const
+{
+    switch (m_station) {
+    case ClockStation::Unknown: return QStringLiteral("Unknown");
+    case ClockStation::Wwv:     return QStringLiteral("WWV");
+    case ClockStation::Wwvh:    return QStringLiteral("WWVH");
+    case ClockStation::Wwvb:    return QStringLiteral("WWVB");
+    }
+    return QStringLiteral("Unknown");
+}
+
+void AetherClockModel::setSliceId(int id)
+{
+    if (m_sliceId == id) return;
+    m_sliceId = id;
+    emit sliceIdChanged(id);
+}
+
+void AetherClockModel::setGpsTimeAvailable(bool available)
+{
+    if (m_gpsTimeAvailable == available) return;
+    m_gpsTimeAvailable = available;
+    emit gpsTimeAvailableChanged(available);
+}
+
+void AetherClockModel::onLockStateChanged(AetherSDR::ClockLockState state)
+{
+    if (m_state == state) return;
+    m_state = state;
+    emit stateChanged(int(state));
+}
+
+void AetherClockModel::onStationDetected(AetherSDR::ClockStation station)
+{
+    if (m_station == station) return;
+    m_station = station;
+    emit stationChanged(int(station));
+}
+
+void AetherClockModel::onTimeDecoded(const QDateTime& utc, double offsetMs, int quality)
+{
+    if (m_decodedUtc != utc) {
+        m_decodedUtc = utc;
+        emit decodedUtcChanged(utc);
+    }
+    if (m_offsetMs != offsetMs) {
+        m_offsetMs = offsetMs;
+        emit offsetMsChanged(offsetMs);
+    }
+    if (m_lockQuality != quality) {
+        m_lockQuality = quality;
+        emit lockQualityChanged(quality);
+    }
+}
+
+} // namespace AetherSDR

--- a/src/models/AetherClockModel.h
+++ b/src/models/AetherClockModel.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// First-class AetherClock model: full Q_PROPERTY coverage so the state is
+// protocol-serializable (bridge `get clock`) and QML-ready. Thin — mirrors
+// engine state, owns no DSP. All engine→model wiring is QUEUED
+// (attachEngine) so the engine may live on a worker thread.
+
+#include "core/TimeFrameVoter.h" // ClockLockState / ClockStation
+
+#include <QDateTime>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+namespace AetherSDR {
+
+class AetherClockEngine;
+
+class AetherClockModel : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(int state READ state NOTIFY stateChanged)
+    Q_PROPERTY(QString stateName READ stateName NOTIFY stateChanged)
+    Q_PROPERTY(int station READ station NOTIFY stationChanged)
+    Q_PROPERTY(QString stationName READ stationName NOTIFY stationChanged)
+    Q_PROPERTY(QDateTime decodedUtc READ decodedUtc NOTIFY decodedUtcChanged)
+    Q_PROPERTY(double offsetMs READ offsetMs NOTIFY offsetMsChanged)
+    Q_PROPERTY(int lockQuality READ lockQuality NOTIFY lockQualityChanged)
+    Q_PROPERTY(int sliceId READ sliceId WRITE setSliceId NOTIFY sliceIdChanged)
+    Q_PROPERTY(bool gpsTimeAvailable READ gpsTimeAvailable
+               WRITE setGpsTimeAvailable NOTIFY gpsTimeAvailableChanged)
+public:
+    explicit AetherClockModel(QObject* parent = nullptr);
+
+    // Connects the engine's signals to this model with Qt::QueuedConnection
+    // ONLY (cross-thread-safe). Detaches any previously attached engine.
+    void attachEngine(AetherClockEngine* engine);
+
+    int state() const { return int(m_state); }
+    ClockLockState lockState() const { return m_state; }
+    QString stateName() const;   // "NoSignal" | "Acquiring" | "Locked"
+    int station() const { return int(m_station); }
+    QString stationName() const; // "Unknown" | "WWV" | "WWVH" | "WWVB"
+    QDateTime decodedUtc() const { return m_decodedUtc; }
+    double offsetMs() const { return m_offsetMs; }
+    int lockQuality() const { return m_lockQuality; }
+    int sliceId() const { return m_sliceId; }
+    bool gpsTimeAvailable() const { return m_gpsTimeAvailable; }
+
+public slots:
+    void setSliceId(int id);
+    void setGpsTimeAvailable(bool available);
+
+signals:
+    void stateChanged(int state);
+    void stationChanged(int station);
+    void decodedUtcChanged(const QDateTime& utc);
+    void offsetMsChanged(double offsetMs);
+    void lockQualityChanged(int quality);
+    void sliceIdChanged(int id);
+    void gpsTimeAvailableChanged(bool available);
+
+private slots:
+    void onLockStateChanged(AetherSDR::ClockLockState state);
+    void onStationDetected(AetherSDR::ClockStation station);
+    void onTimeDecoded(const QDateTime& utc, double offsetMs, int quality);
+
+private:
+    QPointer<AetherClockEngine> m_engine;
+    ClockLockState m_state{ClockLockState::NoSignal};
+    ClockStation m_station{ClockStation::Unknown};
+    QDateTime m_decodedUtc;
+    double m_offsetMs{0.0};
+    int m_lockQuality{0};
+    int m_sliceId{-1};
+    bool m_gpsTimeAvailable{false};
+};
+
+} // namespace AetherSDR

--- a/src/models/AetherClockModel.h
+++ b/src/models/AetherClockModel.h
@@ -5,7 +5,8 @@
 // engine state, owns no DSP. All engine→model wiring is QUEUED
 // (attachEngine) so the engine may live on a worker thread.
 
-#include "core/TimeFrameVoter.h" // ClockLockState / ClockStation
+#include "core/ClockDiagnostics.h" // WS-7 acquisition telemetry
+#include "core/TimeFrameVoter.h"   // ClockLockState / ClockStation
 
 #include <QDateTime>
 #include <QObject>
@@ -28,6 +29,22 @@ class AetherClockModel : public QObject {
     Q_PROPERTY(int sliceId READ sliceId WRITE setSliceId NOTIFY sliceIdChanged)
     Q_PROPERTY(bool gpsTimeAvailable READ gpsTimeAvailable
                WRITE setGpsTimeAvailable NOTIFY gpsTimeAvailableChanged)
+    // WS-7 acquisition telemetry (PRD-C): the funnel-relevant diagnostics
+    // subset, all riding ONE notify — the snapshot arrives atomically at
+    // ~1 Hz, so per-field signals would only fragment a single update.
+    Q_PROPERTY(double toneSnrDb READ toneSnrDb NOTIFY diagnosticsChanged)
+    Q_PROPERTY(double pwmContrast READ pwmContrast NOTIFY diagnosticsChanged)
+    Q_PROPERTY(bool toneDetected READ toneDetected NOTIFY diagnosticsChanged)
+    Q_PROPERTY(bool phaseLocked READ phaseLocked NOTIFY diagnosticsChanged)
+    Q_PROPERTY(double delayEstMs READ delayEstMs NOTIFY diagnosticsChanged)
+    Q_PROPERTY(bool anchored READ anchored NOTIFY diagnosticsChanged)
+    Q_PROPERTY(int badFrameStreak READ badFrameStreak NOTIFY diagnosticsChanged)
+    Q_PROPERTY(int classifiedPct READ classifiedPct NOTIFY diagnosticsChanged)
+    Q_PROPERTY(int framesInWindow READ framesInWindow NOTIFY diagnosticsChanged)
+    Q_PROPERTY(int windowSize READ windowSize NOTIFY diagnosticsChanged)
+    Q_PROPERTY(double voteQuality READ voteQuality NOTIFY diagnosticsChanged)
+    Q_PROPERTY(int refusalReason READ refusalReason NOTIFY diagnosticsChanged)
+    Q_PROPERTY(QString refusalName READ refusalName NOTIFY diagnosticsChanged)
 public:
     explicit AetherClockModel(QObject* parent = nullptr);
 
@@ -46,6 +63,22 @@ public:
     int sliceId() const { return m_sliceId; }
     bool gpsTimeAvailable() const { return m_gpsTimeAvailable; }
 
+    // WS-7 diagnostics mirror (last snapshot received from the engine).
+    double toneSnrDb() const { return m_diag.toneSnrDb; }
+    double pwmContrast() const { return m_diag.pwmContrast; }
+    bool toneDetected() const { return m_diag.toneDetected; }
+    bool phaseLocked() const { return m_diag.phaseLocked; }
+    double delayEstMs() const { return m_diag.delayEstMs; }
+    bool anchored() const { return m_diag.anchored; }
+    int badFrameStreak() const { return m_diag.badFrameStreak; }
+    int classifiedPct() const { return m_diag.classifiedPct; }
+    int framesInWindow() const { return m_diag.framesInWindow; }
+    int windowSize() const { return m_diag.windowSize; }
+    double voteQuality() const { return m_diag.voteQuality; }
+    int refusalReason() const { return int(m_diag.refusalReason); }
+    QString refusalName() const;  // "None" | "QualityFloor" | ...
+    const ClockDiagnostics& diagnostics() const { return m_diag; }
+
 public slots:
     void setSliceId(int id);
     void setGpsTimeAvailable(bool available);
@@ -58,11 +91,16 @@ signals:
     void lockQualityChanged(int quality);
     void sliceIdChanged(int id);
     void gpsTimeAvailableChanged(bool available);
+    // WS-7: one notify per diagnostics snapshot; frameDecoded forwards the
+    // engine's raw per-frame decode to the debug pane.
+    void diagnosticsChanged();
+    void frameDecoded(const AetherSDR::ClockFrameInfo& frame);
 
 private slots:
     void onLockStateChanged(AetherSDR::ClockLockState state);
     void onStationDetected(AetherSDR::ClockStation station);
     void onTimeDecoded(const QDateTime& utc, double offsetMs, int quality);
+    void onDiagnostics(const AetherSDR::ClockDiagnostics& diag);
 
 private:
     QPointer<AetherClockEngine> m_engine;
@@ -73,6 +111,7 @@ private:
     int m_lockQuality{0};
     int m_sliceId{-1};
     bool m_gpsTimeAvailable{false};
+    ClockDiagnostics m_diag;
 };
 
 } // namespace AetherSDR

--- a/tests/aetherclock_engine_test.cpp
+++ b/tests/aetherclock_engine_test.cpp
@@ -1,0 +1,510 @@
+// AetherClock WS-2 — AetherClockEngine integration test (plain main() + CHECK,
+// NOT QtTest; harness idiom per tests/amp_model_test.cpp + SPEC "Repo
+// conventions"). Drives the ENGINE through its public header contract only:
+// setPanadapterStream / setHostClock / start / stop / applyStationPreset /
+// feedRxAudio, observing the six engine signals via QSignalSpy. The decoder
+// .cpp is authored in parallel; this file asserts engine contracts, never
+// decoder internals.
+//
+// The WWV signal synthesizer helpers below are COPIED (not included) from
+// tests/wwv_decoder_test.cpp — the gate-passed WS-1 vector generator. Only the
+// clean-signal path is reused (no AWGN / WAV writer / decoder driver): the
+// engine ingests float32 INTERLEAVED STEREO (the daxAudioReady payload), so
+// each mono sample is duplicated L=R into the QByteArray and fed in ~200 ms
+// blocks. A fake host clock is injected and advanced per block so the decoded
+// second edge can be compared against a known skew.
+
+#include "core/AetherClockEngine.h"
+#include "core/PanadapterStream.h"
+#include "core/TimeFrameVoter.h"
+#include "models/SliceModel.h"
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDate>
+#include <QDateTime>
+#include <QList>
+#include <QSignalSpy>
+#include <QTime>
+#include <QTimeZone>
+#include <QVariant>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+using namespace AetherSDR;
+
+// ---- test harness (per SPEC "Repo conventions") ---------------------------
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr int    kFs = 24000;              // pinned DAX RX sample rate
+
+// ===========================================================================
+// WWV time-code synthesizer — COPIED verbatim from tests/wwv_decoder_test.cpp
+// (WS-1). Levels pinned by SPEC §"Signal synthesizer spec": 24 kHz; carrier
+// 1000 Hz @ 0.5; 100 Hz subcarrier depth 0.30 pulse-on / 0.06 pulse-off / 0 in
+// the s0 minute hole; pulse per the NIST 170/470/770 ms @ +30 ms encoding; 5 ms
+// tick @ 0.25 at the 2000 Hz image (WWVH: 2200 Hz). Field map per NIST SP 432.
+// ===========================================================================
+
+// Per-second pulse class of the 100 Hz subcarrier.
+enum class Sym { Hole, Zero, One, Marker };
+
+// Broadcast truth for one minute; the synthesizer encodes ALL of these.
+struct Truth {
+    int  minute = 0, hour = 0, doy = 0, year2 = 0;
+    int  dut1Tenths = 0;   // signed tenths (e.g. -3 => -0.3 s)
+    bool dst1 = false;     // WWV s2
+    bool dst2 = false;     // WWV s55
+    bool lsw  = false;     // WWV s3 (leap-second warning)
+};
+
+struct SynthOpts {
+    int          numFrames     = 3;                 // >= 3 consecutive minutes
+    int          leadInSeconds = 10;                // tail of the prior minute
+    int          leadOutSeconds = 10;               // head of the next minute
+    ClockStation station       = ClockStation::Wwv; // tick image 2000/2200 Hz
+    bool         removeHole     = false; // s0 gets a normal pulse (kills the cue)
+    bool         corruptMarkers = false; // markers flattened to 170 ms zeros
+    int          truncateSeconds = -1;   // stop the final frame after N seconds
+};
+
+using BcdMap = std::vector<std::pair<int,int>>; // (secondOfFrame, weight)
+
+// Field maps, LSB-first within field, per the NIST WWV time-code table.
+const BcdMap kMapMin{{10,1},{11,2},{12,4},{13,8},{15,10},{16,20},{17,40}};
+const BcdMap kMapHr {{20,1},{21,2},{22,4},{23,8},{25,10},{26,20}};
+const BcdMap kMapDoy{{30,1},{31,2},{32,4},{33,8},{35,10},{36,20},{37,40},
+                     {38,80},{40,100},{41,200}};
+const BcdMap kMapYr {{4,1},{5,2},{6,4},{7,8},{51,10},{52,20},{53,40},{54,80}};
+
+void setBcd(std::array<Sym,60>& s, const BcdMap& m, int value) {
+    for (const auto& pr : m) {
+        int sec = pr.first, w = pr.second;
+        int place = 1;
+        while (w / place >= 10) place *= 10;   // decade of this weight
+        int bw    = w / place;                  // 1|2|4|8 within the decade
+        int digit = (value / place) % 10;
+        if (digit & bw) s[sec] = Sym::One;
+    }
+}
+
+// One minute of classified per-second symbols from broadcast truth.
+std::array<Sym,60> encodeMinute(const Truth& t) {
+    std::array<Sym,60> s;
+    s.fill(Sym::Zero);
+    s[0] = Sym::Hole;                                   // minute-mark subcarrier hole
+    for (int m : {9,19,29,39,49,59}) s[m] = Sym::Marker; // P1..P5, P0
+    setBcd(s, kMapMin, t.minute);
+    setBcd(s, kMapHr,  t.hour);
+    setBcd(s, kMapDoy, t.doy);
+    setBcd(s, kMapYr,  t.year2);
+    if (t.dut1Tenths > 0) s[50] = Sym::One;             // DUT1 sign (1 = +)
+    int mag = std::abs(t.dut1Tenths);
+    if (mag & 1) s[56] = Sym::One;                      // DUT1 magnitude 0.1
+    if (mag & 2) s[57] = Sym::One;                      // DUT1 magnitude 0.2
+    if (mag & 4) s[58] = Sym::One;                      // DUT1 magnitude 0.4
+    if (t.dst1) s[2]  = Sym::One;
+    if (t.dst2) s[55] = Sym::One;
+    if (t.lsw)  s[3]  = Sym::One;
+    return s;
+}
+
+// Append one second (kFs samples) of the pinned WWV waveform.
+//   sample(t) = 0.5*sin(2pi*1000*t)*(1 + d(t)*sin(2pi*100*t)) + tick(t)
+void appendSecond(std::vector<float>& sig, Sym sym, int tickFreq) {
+    for (int k = 0; k < kFs; ++k) {
+        const double t   = static_cast<double>(sig.size()) / kFs; // absolute -> phase-continuous
+        const double tau = static_cast<double>(k) / kFs;          // within-second
+        const double car = 0.5 * std::sin(2.0 * kPi * 1000.0 * t);
+        double d;
+        if (sym == Sym::Hole) {
+            d = 0.0;                                    // no subcarrier at all
+        } else {
+            const double dur = (sym == Sym::Zero) ? 0.170
+                             : (sym == Sym::One)  ? 0.470
+                                                  : 0.770;         // marker
+            d = (tau >= 0.030 && tau < 0.030 + dur) ? 0.30 : 0.06; // +30 ms start
+        }
+        const double sub  = 1.0 + d * std::sin(2.0 * kPi * 100.0 * t);
+        const double tick = (tau < 0.005)                          // 5 ms burst
+                          ? 0.25 * std::sin(2.0 * kPi * tickFreq * t)
+                          : 0.0;
+        sig.push_back(static_cast<float>(car * sub + tick));
+    }
+}
+
+std::vector<float> synthWwv(const Truth& start, const SynthOpts& o) {
+    const int tickFreq = (o.station == ClockStation::Wwvh) ? 2200 : 2000;
+    std::vector<float> sig;
+    sig.reserve(static_cast<size_t>((o.leadInSeconds + 60 * o.numFrames)) * kFs);
+
+    // NB: named emitRange, not `emit` — this file includes QtCore, which
+    // #defines `emit` to nothing (WS-1 could use `emit` as it pulls no Qt).
+    auto emitRange = [&](std::array<Sym,60> sym, int secStart, int secEnd) {
+        for (int sec = secStart; sec < secEnd; ++sec) {
+            Sym s = sym[sec];
+            if (o.corruptMarkers && s == Sym::Marker) s = Sym::Zero; // flatten markers
+            if (o.removeHole && sec == 0)             s = Sym::Zero; // fill the hole
+            appendSecond(sig, s, tickFreq);
+        }
+    };
+
+    // Lead-in: the tail seconds of the prior minute, correctly encoded.
+    Truth lead = start;
+    lead.minute -= 1;
+    if (lead.minute < 0) { lead.minute += 60; lead.hour = (lead.hour + 23) % 24; }
+    emitRange(encodeMinute(lead), 60 - o.leadInSeconds, 60);
+
+    // Consecutive full frames, minutes monotonically incrementing.
+    for (int i = 0; i < o.numFrames; ++i) {
+        Truth cur = start;
+        const int total = start.minute + i;
+        cur.minute = total % 60;
+        cur.hour   = (start.hour + total / 60) % 24;
+        int lastSec = 60;
+        if (o.truncateSeconds >= 0 && i == o.numFrames - 1) lastSec = o.truncateSeconds;
+        emitRange(encodeMinute(cur), 0, lastSec);
+    }
+
+    // Lead-out: the head seconds of the NEXT minute so the final frame closes.
+    if (o.truncateSeconds < 0 && o.leadOutSeconds > 0) {
+        Truth next = start;
+        const int total = start.minute + o.numFrames;
+        next.minute = total % 60;
+        next.hour   = (start.hour + total / 60) % 24;
+        emitRange(encodeMinute(next), 0, o.leadOutSeconds);
+    }
+    return sig;
+}
+
+// ===========================================================================
+// WS-2 test scaffolding
+// ===========================================================================
+
+// The golden broadcast truth: 06:20 -> 06:21 -> 06:22 on doy 200, yr 26.
+// Matches WS-1's kGold so the voter's "newest frame" minute is 22.
+const Truth   kGold{20, 6, 200, 26, /*dut1*/ -3, /*dst1*/ true, /*dst2*/ false, /*lsw*/ true};
+constexpr int kExpectNewestMin = 22;        // start.minute + numFrames - 1
+constexpr qint64 kSkewMs = 400;             // host clock skewed AHEAD -> offset ~ -400
+
+// UTC (ms since epoch) of synth sample 0 = the first lead-in sample, i.e. the
+// frame-0 broadcast minute minus the lead-in seconds. With the fake host clock
+// defined as (epoch + samplesFed/24 kHz + skew), the host reads exactly
+// true-broadcast-time + skew at every sample, so a correctly disciplined engine
+// reports offsetMs = decodedUtc - hostUtc ~ -skew at the decoded edge.
+qint64 synthEpochMs(const Truth& g, const SynthOpts& o) {
+    const int year = 2000 + g.year2;
+    const QDate d  = QDate(year, 1, 1).addDays(g.doy - 1);            // doy is 1-based
+    const QDateTime frame0(d, QTime(g.hour, g.minute, 0), QTimeZone::utc());
+    return frame0.addSecs(-o.leadInSeconds).toMSecsSinceEpoch();
+}
+
+// Feed `mono` to the engine as ~200 ms float32 interleaved-STEREO blocks on
+// `channel`, duplicating each mono sample into L and R (the engine downmixes
+// mono = 0.5*(L+R), recovering the original). When `advanceClock`, *fakeNow is
+// updated per block to model host = epoch + samplesFed/24 kHz + skew at the END
+// of the block (the anchor point). processEvents() drains any queued paths.
+void feedStereo(AetherClockEngine& eng, int channel, const std::vector<float>& mono,
+                qint64 epochMs, qint64 skewMs,
+                qint64& samplesFed, qint64& fakeNow, bool advanceClock) {
+    constexpr size_t kBlockFrames = 4800;   // 200 ms @ 24 kHz
+    for (size_t i = 0; i < mono.size(); i += kBlockFrames) {
+        const size_t n = std::min(kBlockFrames, mono.size() - i);
+        QByteArray block;
+        block.resize(static_cast<int>(n * 2 * sizeof(float)));
+        auto* out = reinterpret_cast<float*>(block.data());
+        for (size_t k = 0; k < n; ++k) {
+            out[2 * k]     = mono[i + k];   // L
+            out[2 * k + 1] = mono[i + k];   // R == L
+        }
+        samplesFed += static_cast<qint64>(n);
+        if (advanceClock)
+            fakeNow = epochMs + samplesFed * 1000 / kFs + skewMs;
+        eng.feedRxAudio(channel, block);
+        QCoreApplication::processEvents();
+    }
+}
+
+using Clock = PanadapterStream::DaxConsumer;   // ::Clock == time-signal consumer
+
+// Wire the engine's injected DAX-hold provider to a REAL central registry
+// (PanadapterStream), per the amended header: the engine drives these lambdas
+// with the bound slice's channel; they acquire/release under DaxConsumer::Clock
+// so stream.daxChannelHeldBy(ch, Clock) observes the exact same holds the
+// production wiring layer would create.
+void wireProvider(AetherClockEngine& eng, PanadapterStream& stream) {
+    eng.setDaxChannelProvider(
+        [&stream](int ch) { stream.acquireDaxChannel(ch, Clock::Clock); },
+        [&stream](int ch) { stream.releaseDaxChannel(ch, Clock::Clock); });
+}
+
+// Did any recorded lockStateChanged carry the Locked state? (Value read via the
+// direct getter to avoid enum-from-QVariant fragility; count proves transitions.)
+bool sawLocked(const QSignalSpy& lockSpy, const AetherClockEngine& eng) {
+    return eng.lockState() == ClockLockState::Locked && lockSpy.count() >= 1;
+}
+
+// ==== test sections ========================================================
+
+// [1] Happy path: start(slice @ dax 2, Wwv), feed >=3 clean synth frames on
+// ch 2 -> timeDecoded fires; utc == truth; offset ~ -skew; quality high; Locked.
+void sectionHappyPath() {
+    SynthOpts opts;                                   // 3 frames, lead-in/out 10 s
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    qint64 fakeNow = epochMs + kSkewMs;               // host at sample 0
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyTime(&engine, &AetherClockEngine::timeDecoded);
+    QSignalSpy spyLock(&engine, &AetherClockEngine::lockStateChanged);
+    QSignalSpy spyLocked(&engine, &AetherClockEngine::lockedChanged);
+    QSignalSpy spyRunning(&engine, &AetherClockEngine::runningChanged);
+
+    engine.start(&slice, ClockStation::Wwv);
+    CHECK(engine.isRunning());
+    CHECK(spyRunning.count() >= 1);
+    CHECK(engine.lockState() == ClockLockState::NoSignal);   // starts NoSignal
+
+    qint64 samplesFed = 0;
+    feedStereo(engine, 2, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+
+    // timeDecoded fired, reached Locked.
+    CHECK(!spyTime.isEmpty());
+    CHECK(sawLocked(spyLock, engine));
+    bool lockedTrue = false;
+    for (int i = 0; i < spyLocked.count(); ++i)
+        if (spyLocked.at(i).at(0).toBool()) lockedTrue = true;
+    CHECK(lockedTrue);
+
+    if (!spyTime.isEmpty()) {
+        const QList<QVariant> last = spyTime.back();
+        const QDateTime utc   = last.at(0).toDateTime().toUTC();
+        const double    offMs = last.at(1).toDouble();
+        const int       qual  = last.at(2).toInt();
+
+        // utc == synth truth: correct date/hour and the newest voted minute.
+        // At the frame boundary where onTime fires, the most recent edge may
+        // already sit in the next broadcast minute, so a disciplined engine may
+        // report minute 22 (newest voted frame) or 23 (edge minute) — both are
+        // real synth-truth instants. The offset assertion below is what pins
+        // the decodedUtc<->host alignment. See test report: cross-task risk R1.
+        CHECK(utc.isValid());
+        CHECK(utc.date() == QDate(2026, 1, 1).addDays(kGold.doy - 1));
+        CHECK(utc.time().hour() == 6);
+        CHECK(utc.time().minute() == kExpectNewestMin ||
+              utc.time().minute() == kExpectNewestMin + 1);
+
+        // Host clock skewed +skew ahead of broadcast -> host is BEHIND -> the
+        // engine's offset (decodedUtc - hostUtc) is NEGATIVE and ~ -skew.
+        CHECK(std::abs(offMs - (-static_cast<double>(kSkewMs))) <= 60.0);
+
+        // Quality high: WS-1's documented clean-lock floor is 0.40 -> >= 40/100.
+        CHECK(qual >= 40 && qual <= 100);
+    }
+
+    engine.stop();
+    CHECK(!stream.daxChannelHeldBy(2, Clock::Clock));
+}
+
+// [2] DAX filter: feed the same signal tagged channel 3 while the slice is
+// still dax 2 -> zero signals, state stays NoSignal.
+void sectionDaxFilter() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyTime(&engine, &AetherClockEngine::timeDecoded);
+    QSignalSpy spyLock(&engine, &AetherClockEngine::lockStateChanged);
+    QSignalSpy spyAlign(&engine, &AetherClockEngine::alignmentFrame);
+
+    engine.start(&slice, ClockStation::Wwv);
+    qint64 samplesFed = 0;
+    feedStereo(engine, 3, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+
+    CHECK(spyTime.isEmpty());                 // wrong channel -> nothing decoded
+    CHECK(spyAlign.isEmpty());
+    CHECK(spyLock.isEmpty());                 // no state change away from NoSignal
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    engine.stop();
+}
+
+// [3] Hold lifecycle (INV-3): after start the slice's dax channel is held by
+// the clock consumer; after stop() the hold is gone; start/stop never leak.
+void sectionHoldLifecycle() {
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        engine.start(&slice, ClockStation::Wwv);
+        CHECK(engine.isRunning());
+        CHECK(stream.daxChannelHeldBy(2, Clock::Clock));      // held while running
+        engine.stop();
+        CHECK(!engine.isRunning());
+        CHECK(!stream.daxChannelHeldBy(2, Clock::Clock));     // released on stop
+    }
+    // No leak on any channel after the cycles.
+    for (int ch = 1; ch <= 4; ++ch)
+        CHECK(!stream.daxChannelHeldBy(ch, Clock::Clock));
+}
+
+// [4] DAX reassign: while running, setDaxChannel(3) -> hold moves 2 -> 3; audio
+// fed on 3 is accepted, on 2 ignored.
+void sectionDaxReassign() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    engine.start(&slice, ClockStation::Wwv);
+    CHECK(stream.daxChannelHeldBy(2, Clock::Clock));
+
+    slice.setDaxChannel(3);                    // engine reacquires new-before-old
+    QCoreApplication::processEvents();
+    CHECK(stream.daxChannelHeldBy(3, Clock::Clock));   // hold moved to 3
+    CHECK(!stream.daxChannelHeldBy(2, Clock::Clock));  // released 2
+
+    // Audio on the NEW channel is accepted (alignment frames flow).
+    QSignalSpy spyAlign(&engine, &AetherClockEngine::alignmentFrame);
+    qint64 samplesFed = 0;
+    feedStereo(engine, 3, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+    CHECK(!spyAlign.isEmpty());                        // ch 3 accepted post-reassign
+
+    // Audio on the OLD channel is now ignored.
+    const int alignAfterCh3 = spyAlign.count();
+    QByteArray oneBlock;
+    oneBlock.resize(static_cast<int>(4800 * 2 * sizeof(float)));
+    auto* out = reinterpret_cast<float*>(oneBlock.data());
+    for (size_t k = 0; k < 4800; ++k) { out[2 * k] = mono[k]; out[2 * k + 1] = mono[k]; }
+    engine.feedRxAudio(2, oneBlock);
+    QCoreApplication::processEvents();
+    CHECK(spyAlign.count() == alignAfterCh3);          // ch 2 ignored
+
+    engine.stop();
+}
+
+// [5] Slice removal: heap-allocate a slice, start, delete it, processEvents ->
+// isRunning() false, lockState NoSignal, no hold remains, no crash.
+void sectionSliceRemoval() {
+    PanadapterStream stream;
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+
+    auto* slice = new SliceModel(0);
+    slice->setDaxChannel(2);
+
+    QSignalSpy spyRunning(&engine, &AetherClockEngine::runningChanged);
+    engine.start(slice, ClockStation::Wwv);
+    CHECK(engine.isRunning());
+    CHECK(stream.daxChannelHeldBy(2, Clock::Clock));
+
+    delete slice;                              // graceful-loss handler fires
+    QCoreApplication::processEvents();
+
+    CHECK(!engine.isRunning());
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+    CHECK(!stream.daxChannelHeldBy(2, Clock::Clock));  // no orphaned hold
+}
+
+// [6] applyStationPreset tunes the BOUND slice: Wwv/10.0 -> 9.999 MHz USB;
+// Wwvb/0.060 -> 0.059 MHz, AGC off.
+void sectionStationPreset() {
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    engine.start(&slice, ClockStation::Wwv);   // bind the slice
+
+    engine.applyStationPreset(ClockStation::Wwv, 10.0);
+    CHECK(std::abs(slice.frequency() - 9.999) < 1e-9);
+    CHECK(slice.mode() == QStringLiteral("USB"));
+
+    engine.applyStationPreset(ClockStation::Wwvb, 0.060);
+    CHECK(std::abs(slice.frequency() - 0.059) < 1e-9);
+    CHECK(slice.agcMode() == QStringLiteral("off"));
+
+    engine.stop();
+}
+
+// [7] Statics: preset lists exactly as frozen.
+void sectionStatics() {
+    const QVector<double> wwv = AetherClockEngine::wwvCarrierFrequenciesMHz();
+    const QVector<double> expect{2.5, 5.0, 10.0, 15.0, 20.0};
+    CHECK(wwv.size() == expect.size());
+    if (wwv.size() == expect.size())
+        for (int i = 0; i < wwv.size(); ++i)
+            CHECK(std::abs(wwv[i] - expect[i]) < 1e-9);
+
+    CHECK(std::abs(AetherClockEngine::wwvbCarrierFrequencyMHz() - 0.060) < 1e-9);
+    CHECK(std::abs(AetherClockEngine::listeningDialMHz(10.0) - 9.999) < 1e-9);
+    CHECK(std::abs(AetherClockEngine::listeningDialMHz(0.060) - 0.059) < 1e-9);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+
+    // Register the queued-connection metatypes (the engine ctor also does this;
+    // registration is idempotent and makes the QSignalSpy captures robust).
+    qRegisterMetaType<AetherSDR::ClockAlignmentFrame>();
+    qRegisterMetaType<AetherSDR::ClockLockState>("AetherSDR::ClockLockState");
+    qRegisterMetaType<AetherSDR::ClockStation>("AetherSDR::ClockStation");
+
+    sectionHappyPath();
+    sectionDaxFilter();
+    sectionHoldLifecycle();
+    sectionDaxReassign();
+    sectionSliceRemoval();
+    sectionStationPreset();
+    sectionStatics();
+
+    if (g_failures == 0) {
+        std::printf("aetherclock_engine_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherclock_engine_test: %d checks FAILED\n", g_failures);
+    return 1;
+}

--- a/tests/aetherclock_engine_test.cpp
+++ b/tests/aetherclock_engine_test.cpp
@@ -586,6 +586,78 @@ void sectionLockDecayDemotes() {
     engine.stop();
 }
 
+// [WS-7] Acquisition telemetry: currentDiagnostics() stages flip on the happy
+// path, frameDecoded re-emits every completed frame (previously discarded at
+// the engine boundary), the classified-seconds ring reports a full last
+// minute, the refusal tag is None once locked, and the ~1 Hz timer emission
+// fires while running.
+void sectionDiagnosticsTelemetry() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyFrame(&engine, &AetherClockEngine::frameDecoded);
+    QSignalSpy spyDiag(&engine, &AetherClockEngine::diagnosticsUpdated);
+
+    // Not running: default-constructed snapshot.
+    {
+        const ClockDiagnostics d0 = engine.currentDiagnostics();
+        CHECK(!d0.toneDetected);
+        CHECK(d0.framesInWindow == 0);
+        CHECK(d0.classifiedPct == 0);
+    }
+
+    engine.start(&slice, ClockStation::Wwv);
+    qint64 samplesFed = 0;
+    feedStereo(engine, 2, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+    CHECK(engine.lockState() == ClockLockState::Locked);
+
+    const ClockDiagnostics d = engine.currentDiagnostics();
+    // stages 1-2: tick fold locked on the synth signal; delay settled.
+    CHECK(d.toneDetected);
+    CHECK(d.phaseLocked);
+    CHECK(d.toneSnrDb > 0.0f);
+    CHECK(std::isfinite(d.delayEstMs));
+    // stage 3
+    CHECK(d.anchored);
+    CHECK(d.badFrameStreak == 0);
+    // stage 4: the fake clock advanced with the feed, so the last 60 s of host
+    // time carry a full minute of classified seconds.
+    CHECK(d.classifiedPct >= 90);
+    // stage 5
+    CHECK(d.framesInWindow >= 2);
+    CHECK(d.windowSize == 8);
+    CHECK(d.voteQuality > 0.0f);
+    CHECK(d.refusalReason == quint8(ClockLockRefusal::None));
+
+    // frameDecoded re-emission: one per completed synth frame (3 frames), with
+    // the raw fields intact.
+    CHECK(spyFrame.count() >= 3);
+    if (spyFrame.count() >= 1) {
+        const auto fi = spyFrame.back().at(0).value<ClockFrameInfo>();
+        CHECK(fi.station == ClockStation::Wwv);
+        CHECK(fi.frameConfidence > 0.0f);
+        CHECK(fi.minute >= 0 && fi.minute <= 59);
+    }
+
+    // ~1 Hz emission while running (wall-clock timer; one wait is enough).
+    CHECK(spyDiag.count() >= 1 || spyDiag.wait(1500));
+
+    engine.stop();
+    const ClockDiagnostics dStop = engine.currentDiagnostics();
+    CHECK(dStop.framesInWindow == 0);   // decoder torn down -> defaults
+    CHECK(dStop.classifiedPct == 0);    // ring cleared
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -607,6 +679,7 @@ int main(int argc, char** argv) {
     sectionStationPresetOverload();
     sectionLockDecayNoSignalStable();
     sectionLockDecayDemotes();
+    sectionDiagnosticsTelemetry();
 
     if (g_failures == 0) {
         std::printf("aetherclock_engine_test: all checks passed\n");

--- a/tests/aetherclock_engine_test.cpp
+++ b/tests/aetherclock_engine_test.cpp
@@ -1,8 +1,9 @@
 // AetherClock WS-2 — AetherClockEngine integration test (plain main() + CHECK,
 // NOT QtTest; harness idiom per tests/amp_model_test.cpp + SPEC "Repo
 // conventions"). Drives the ENGINE through its public header contract only:
-// setPanadapterStream / setHostClock / start / stop / applyStationPreset /
-// feedRxAudio, observing the six engine signals via QSignalSpy. The decoder
+// setPanadapterStream / setHostClock / setLockDecayTimeoutMs / start / stop /
+// applyStationPreset / feedRxAudio, observing the six engine signals via
+// QSignalSpy. The decoder
 // .cpp is authored in parallel; this file asserts engine contracts, never
 // decoder internals.
 //
@@ -482,6 +483,109 @@ void sectionStatics() {
     CHECK(std::abs(AetherClockEngine::listeningDialMHz(0.060) - 0.059) < 1e-9);
 }
 
+// [8] applyStationPreset(SliceModel*, ...) overload: tunes ANY given slice
+// without binding it or starting the engine; a locked slice refuses the whole
+// preset (all-or-nothing). This is the applet's Tune-while-stopped path.
+void sectionStationPresetOverload() {
+    AetherClockEngine engine;   // never started; nothing bound, no provider
+
+    // Unlocked WWV: dial = carrier - 1 kHz, USB. The engine stays stopped and
+    // unbound (the overload touches only the slice it is handed).
+    SliceModel wwv(0);
+    engine.applyStationPreset(&wwv, ClockStation::Wwv, 10.0);
+    CHECK(std::abs(wwv.frequency() - 9.999) < 1e-9);
+    CHECK(wwv.mode() == QStringLiteral("USB"));
+    CHECK(!engine.isRunning());
+    CHECK(engine.boundSliceId() == -1);
+
+    // Unlocked WWVB additionally forces AGC off on that slice.
+    SliceModel wwvb(1);
+    engine.applyStationPreset(&wwvb, ClockStation::Wwvb, 0.060);
+    CHECK(std::abs(wwvb.frequency() - 0.059) < 1e-9);
+    CHECK(wwvb.mode() == QStringLiteral("USB"));
+    CHECK(wwvb.agcMode() == QStringLiteral("off"));
+
+    // Locked slice: the lock check refuses the preset, so nothing changes.
+    SliceModel locked(2);
+    locked.setFrequency(14.0);
+    locked.setMode(QStringLiteral("LSB"));
+    locked.setLocked(true);
+    engine.applyStationPreset(&locked, ClockStation::Wwv, 10.0);
+    CHECK(std::abs(locked.frequency() - 14.0) < 1e-9);
+    CHECK(locked.mode() == QStringLiteral("LSB"));
+}
+
+// [9] Lock-decay watchdog at the NoSignal floor: after start() the state is
+// NoSignal and the watchdog fires repeatedly (60 ms) but must NEVER emit —
+// there is nothing below NoSignal to demote to.
+void sectionLockDecayNoSignalStable() {
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    engine.setLockDecayTimeoutMs(60);   // well under the 200 ms spin below
+
+    QSignalSpy spyLock(&engine, &AetherClockEngine::lockStateChanged);
+    engine.start(&slice, ClockStation::Wwv);
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    // wait() spins an event loop so the QTimer can fire; it returns false when
+    // no lockStateChanged arrives within the window — exactly what we want at
+    // the floor. No audio is fed, so no second re-arms toward a real state.
+    CHECK(!spyLock.wait(200));
+    CHECK(spyLock.isEmpty());
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    engine.stop();
+}
+
+// [10] Lock-decay watchdog demotes a stalled lock one step at a time. Reach
+// Locked on clean synth audio, then stop feeding: with a 60 ms timeout the
+// engine-side watchdog walks Locked -> Acquiring -> NoSignal and then stops
+// re-arming at the floor. (The handleSecond resync — which re-pulls the
+// decoder's live state after a decay — is exercised implicitly by the happy
+// path, where fast feeding re-arms every classified second and any transient
+// decay self-heals back to the decoder's Locked; live QA covers the on-air
+// re-emit-after-decay recovery directly.)
+void sectionLockDecayDemotes() {
+    SynthOpts opts;
+    const std::vector<float> mono = synthWwv(kGold, opts);
+    const qint64 epochMs = synthEpochMs(kGold, opts);
+
+    PanadapterStream stream;
+    SliceModel slice(0);
+    slice.setDaxChannel(2);
+
+    AetherClockEngine engine;
+    wireProvider(engine, stream);
+    engine.setLockDecayTimeoutMs(60);
+    qint64 fakeNow = epochMs + kSkewMs;
+    engine.setHostClock([&fakeNow] { return fakeNow; });
+
+    QSignalSpy spyLock(&engine, &AetherClockEngine::lockStateChanged);
+    engine.start(&slice, ClockStation::Wwv);
+
+    qint64 samplesFed = 0;
+    feedStereo(engine, 2, mono, epochMs, kSkewMs, samplesFed, fakeNow, /*advance*/ true);
+    CHECK(sawLocked(spyLock, engine));
+    CHECK(engine.lockState() == ClockLockState::Locked);   // no more audio flows
+
+    // With feeding stopped the 60 ms watchdog decays the stale lock stepwise.
+    // Each wait() spins the loop until the next demotion edge.
+    CHECK(spyLock.wait(2000));                              // Locked -> Acquiring
+    CHECK(engine.lockState() == ClockLockState::Acquiring);
+    CHECK(spyLock.wait(2000));                              // Acquiring -> NoSignal
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    // At the floor the watchdog stops re-arming: no further edges.
+    CHECK(!spyLock.wait(300));
+    CHECK(engine.lockState() == ClockLockState::NoSignal);
+
+    engine.stop();
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -500,6 +604,9 @@ int main(int argc, char** argv) {
     sectionSliceRemoval();
     sectionStationPreset();
     sectionStatics();
+    sectionStationPresetOverload();
+    sectionLockDecayNoSignalStable();
+    sectionLockDecayDemotes();
 
     if (g_failures == 0) {
         std::printf("aetherclock_engine_test: all checks passed\n");

--- a/tests/aetherclock_model_test.cpp
+++ b/tests/aetherclock_model_test.cpp
@@ -42,6 +42,8 @@ int main(int argc, char** argv)
     // private slots via Q_ARG — they must be known to the metatype system.
     qRegisterMetaType<AetherSDR::ClockLockState>("AetherSDR::ClockLockState");
     qRegisterMetaType<AetherSDR::ClockStation>("AetherSDR::ClockStation");
+    qRegisterMetaType<AetherSDR::ClockDiagnostics>("AetherSDR::ClockDiagnostics");
+    qRegisterMetaType<AetherSDR::ClockFrameInfo>("AetherSDR::ClockFrameInfo");
 
     // ---- 1. Defaults ----
     {
@@ -211,6 +213,84 @@ int main(int argc, char** argv)
         pump();
         CHECK(stateSpy.count() == 2);            // single delivery, not doubled
         CHECK(m.state() == int(ClockLockState::Locked));
+    }
+
+    // ---- 7. WS-7 diagnostics mirror: one snapshot, one notify; Q_PROPERTY +
+    // refusalName map; frameDecoded forwards through the model unchanged ----
+    {
+        AetherClockModel m;
+        // Defaults before any snapshot arrives.
+        CHECK(m.toneSnrDb() == 0.0);
+        CHECK(!m.toneDetected());
+        CHECK(m.framesInWindow() == 0);
+        CHECK(m.refusalName() == QStringLiteral("None"));
+
+        QSignalSpy diagSpy(&m, &AetherClockModel::diagnosticsChanged);
+        ClockDiagnostics d;
+        d.toneSnrDb = 18.5f;
+        d.pwmContrast = 3.2f;
+        d.toneDetected = true;
+        d.phaseLocked = true;
+        d.delayEstMs = 105.0f;
+        d.anchored = true;
+        d.badFrameStreak = 1;
+        d.classifiedPct = 87;
+        d.framesInWindow = 3;
+        d.windowSize = 8;
+        d.voteQuality = 0.034f;
+        d.refusalReason = quint8(ClockLockRefusal::QualityFloor);
+        QMetaObject::invokeMethod(&m, "onDiagnostics", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockDiagnostics, d));
+        pump();
+
+        CHECK(diagSpy.count() == 1);   // one snapshot, one notify
+        CHECK(m.property("toneSnrDb").toDouble() > 18.4 &&
+              m.property("toneSnrDb").toDouble() < 18.6);
+        CHECK(m.property("toneDetected").toBool());
+        CHECK(m.property("phaseLocked").toBool());
+        CHECK(m.property("anchored").toBool());
+        CHECK(m.property("badFrameStreak").toInt() == 1);
+        CHECK(m.property("classifiedPct").toInt() == 87);
+        CHECK(m.property("framesInWindow").toInt() == 3);
+        CHECK(m.property("windowSize").toInt() == 8);
+        CHECK(m.property("voteQuality").toDouble() > 0.03 &&
+              m.property("voteQuality").toDouble() < 0.04);
+        CHECK(m.property("refusalReason").toInt() ==
+              int(ClockLockRefusal::QualityFloor));
+        CHECK(m.property("refusalName").toString() == QStringLiteral("QualityFloor"));
+
+        // The full name map (bridge asserts read these strings).
+        auto nameFor = [&m](ClockLockRefusal r) {
+            ClockDiagnostics x;
+            x.refusalReason = quint8(r);
+            QMetaObject::invokeMethod(&m, "onDiagnostics", Qt::QueuedConnection,
+                                      Q_ARG(AetherSDR::ClockDiagnostics, x));
+            pump();
+            return m.refusalName();
+        };
+        CHECK(nameFor(ClockLockRefusal::Plausibility) == QStringLiteral("Plausibility"));
+        CHECK(nameFor(ClockLockRefusal::Staleness) == QStringLiteral("Staleness"));
+        CHECK(nameFor(ClockLockRefusal::Contested) == QStringLiteral("Contested"));
+        CHECK(nameFor(ClockLockRefusal::None) == QStringLiteral("None"));
+
+        // frameDecoded: engine signal → model signal, payload intact.
+        AetherClockEngine engine;
+        m.attachEngine(&engine);
+        QSignalSpy frameSpy(&m, &AetherClockModel::frameDecoded);
+        ClockFrameInfo fi;
+        fi.minute = 22; fi.hour = 6; fi.doy = 200; fi.year2 = 26;
+        fi.frameConfidence = 0.5f;
+        fi.station = ClockStation::Wwv;
+        QMetaObject::invokeMethod(&engine, "frameDecoded", Qt::DirectConnection,
+                                  Q_ARG(AetherSDR::ClockFrameInfo, fi));
+        pump();
+        CHECK(frameSpy.count() == 1);
+        if (frameSpy.count() == 1) {
+            const auto got = frameSpy.at(0).at(0).value<ClockFrameInfo>();
+            CHECK(got.minute == 22);
+            CHECK(got.station == ClockStation::Wwv);
+            CHECK(got.frameConfidence > 0.49f && got.frameConfidence < 0.51f);
+        }
     }
 
     if (g_failures == 0) {

--- a/tests/aetherclock_model_test.cpp
+++ b/tests/aetherclock_model_test.cpp
@@ -1,0 +1,222 @@
+// AetherClockModel unit test — the thin, Q_PROPERTY-covered mirror of the
+// AetherClock engine (PRD-A §8 row 4). Exercises defaults, the guard-compare
+// "emit once" setter/slot idiom, the state machine + name maps, and the
+// QUEUED engine→model wiring (attachEngine must not double-connect).
+//
+// The model's engine-facing handlers are PRIVATE slots by design; per the WS-2
+// spec we drive them through the meta-object with Qt::QueuedConnection +
+// processEvents (invokable regardless of access) and read the resulting state
+// back through the Q_PROPERTY system to prove the property wiring.
+
+#include "models/AetherClockModel.h"
+#include "core/AetherClockEngine.h"
+
+#include <QCoreApplication>
+#include <QDate>
+#include <QDateTime>
+#include <QSignalSpy>
+#include <QString>
+#include <QTime>
+#include <QTimeZone>
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+// Deliver everything queued so far (the engine→model and meta-invoked slots
+// are all Qt::QueuedConnection).
+static void pump()
+{
+    QCoreApplication::processEvents();
+    QCoreApplication::sendPostedEvents();
+    QCoreApplication::processEvents();
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    // Enum args cross a queued connection (engine→model) and are passed to the
+    // private slots via Q_ARG — they must be known to the metatype system.
+    qRegisterMetaType<AetherSDR::ClockLockState>("AetherSDR::ClockLockState");
+    qRegisterMetaType<AetherSDR::ClockStation>("AetherSDR::ClockStation");
+
+    // ---- 1. Defaults ----
+    {
+        AetherClockModel m;
+        CHECK(m.state() == int(ClockLockState::NoSignal));       // 0
+        CHECK(m.lockState() == ClockLockState::NoSignal);
+        CHECK(m.stateName() == QStringLiteral("NoSignal"));
+        CHECK(m.station() == int(ClockStation::Unknown));        // 0
+        CHECK(m.stationName() == QStringLiteral("Unknown"));
+        CHECK(m.lockQuality() == 0);
+        CHECK(m.sliceId() == -1);
+        CHECK(m.gpsTimeAvailable() == false);
+        CHECK(!m.decodedUtc().isValid());
+        CHECK(m.offsetMs() == 0.0);
+        // Same facts, but through the Q_PROPERTY seam (protocol/QML surface).
+        CHECK(m.property("state").toInt() == 0);
+        CHECK(m.property("stateName").toString() == QStringLiteral("NoSignal"));
+        CHECK(m.property("station").toInt() == 0);
+        CHECK(m.property("sliceId").toInt() == -1);
+        CHECK(m.property("gpsTimeAvailable").toBool() == false);
+        CHECK(!m.property("decodedUtc").toDateTime().isValid());
+    }
+
+    // ---- 2. Change-signal-once (guard-compare, emit exactly once) ----
+    {
+        AetherClockModel m;
+
+        // Public writable properties — direct calls, invoked twice / same value.
+        QSignalSpy sliceSpy(&m, &AetherClockModel::sliceIdChanged);
+        m.setSliceId(5);
+        m.setSliceId(5);
+        CHECK(sliceSpy.count() == 1);
+        CHECK(m.sliceId() == 5);
+
+        QSignalSpy gpsSpy(&m, &AetherClockModel::gpsTimeAvailableChanged);
+        m.setGpsTimeAvailable(true);
+        m.setGpsTimeAvailable(true);
+        CHECK(gpsSpy.count() == 1);
+        CHECK(m.gpsTimeAvailable() == true);
+
+        // Private engine-facing slots — driven queued, same value twice.
+        QSignalSpy stateSpy(&m, &AetherClockModel::stateChanged);
+        QMetaObject::invokeMethod(&m, "onLockStateChanged", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Locked));
+        QMetaObject::invokeMethod(&m, "onLockStateChanged", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Locked));
+        pump();
+        CHECK(stateSpy.count() == 1);
+        CHECK(m.state() == int(ClockLockState::Locked));
+
+        QSignalSpy stationSpy(&m, &AetherClockModel::stationChanged);
+        QMetaObject::invokeMethod(&m, "onStationDetected", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockStation, ClockStation::Wwv));
+        QMetaObject::invokeMethod(&m, "onStationDetected", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockStation, ClockStation::Wwv));
+        pump();
+        CHECK(stationSpy.count() == 1);
+        CHECK(m.station() == int(ClockStation::Wwv));
+
+        const QDateTime utc(QDate(2026, 7, 19), QTime(12, 34, 56), QTimeZone::utc());
+        QSignalSpy utcSpy(&m, &AetherClockModel::decodedUtcChanged);
+        QSignalSpy offSpy(&m, &AetherClockModel::offsetMsChanged);
+        QSignalSpy qualSpy(&m, &AetherClockModel::lockQualityChanged);
+        QMetaObject::invokeMethod(&m, "onTimeDecoded", Qt::QueuedConnection,
+                                  Q_ARG(QDateTime, utc), Q_ARG(double, 100.0), Q_ARG(int, 50));
+        QMetaObject::invokeMethod(&m, "onTimeDecoded", Qt::QueuedConnection,
+                                  Q_ARG(QDateTime, utc), Q_ARG(double, 100.0), Q_ARG(int, 50));
+        pump();
+        CHECK(utcSpy.count() == 1);
+        CHECK(offSpy.count() == 1);
+        CHECK(qualSpy.count() == 1);
+    }
+
+    // ---- 3. onTimeDecoded updates the three fields; readable via Q_PROPERTY ----
+    {
+        AetherClockModel m;
+        QSignalSpy utcSpy(&m, &AetherClockModel::decodedUtcChanged);
+        QSignalSpy offSpy(&m, &AetherClockModel::offsetMsChanged);
+        QSignalSpy qualSpy(&m, &AetherClockModel::lockQualityChanged);
+
+        const QDateTime utc(QDate(2026, 7, 19), QTime(0, 0, 30), QTimeZone::utc());
+        QMetaObject::invokeMethod(&m, "onTimeDecoded", Qt::QueuedConnection,
+                                  Q_ARG(QDateTime, utc), Q_ARG(double, 123.0), Q_ARG(int, 87));
+        pump();
+
+        CHECK(utcSpy.count() == 1 && offSpy.count() == 1 && qualSpy.count() == 1);
+        // Prove the Q_PROPERTY wiring (bridge `get clock` / QML surface).
+        CHECK(m.property("offsetMs").toDouble() == 123.0);
+        CHECK(m.property("lockQuality").toInt() == 87);
+        CHECK(m.property("decodedUtc").toDateTime() == utc);
+        // And the plain accessors agree.
+        CHECK(m.offsetMs() == 123.0);
+        CHECK(m.lockQuality() == 87);
+        CHECK(m.decodedUtc() == utc);
+    }
+
+    // ---- 4. State machine: NoSignal → Acquiring → Locked → NoSignal ----
+    {
+        AetherClockModel m;
+        QSignalSpy stateSpy(&m, &AetherClockModel::stateChanged);
+
+        QMetaObject::invokeMethod(&m, "onLockStateChanged", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Acquiring));
+        pump();
+        CHECK(stateSpy.count() == 1);
+        CHECK(m.state() == int(ClockLockState::Acquiring));
+        CHECK(m.stateName() == QStringLiteral("Acquiring"));
+
+        QMetaObject::invokeMethod(&m, "onLockStateChanged", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Locked));
+        pump();
+        CHECK(stateSpy.count() == 2);
+        CHECK(m.state() == int(ClockLockState::Locked));
+        CHECK(m.stateName() == QStringLiteral("Locked"));
+
+        QMetaObject::invokeMethod(&m, "onLockStateChanged", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::NoSignal));
+        pump();
+        CHECK(stateSpy.count() == 3);
+        CHECK(m.state() == int(ClockLockState::NoSignal));
+        CHECK(m.stateName() == QStringLiteral("NoSignal"));
+    }
+
+    // ---- 5. stationDetected(Wwvh) → station()==2, stationName "WWVH" ----
+    {
+        AetherClockModel m;
+        QSignalSpy stationSpy(&m, &AetherClockModel::stationChanged);
+        QMetaObject::invokeMethod(&m, "onStationDetected", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockStation, ClockStation::Wwvh));
+        pump();
+        CHECK(stationSpy.count() == 1);
+        CHECK(m.station() == 2);
+        CHECK(m.stationName() == QStringLiteral("WWVH"));
+        // Round out the name map through the same seam.
+        QMetaObject::invokeMethod(&m, "onStationDetected", Qt::QueuedConnection,
+                                  Q_ARG(AetherSDR::ClockStation, ClockStation::Wwvb));
+        pump();
+        CHECK(m.station() == 3);
+        CHECK(m.stationName() == QStringLiteral("WWVB"));
+    }
+
+    // ---- 6. attachEngine + queued semantics: no double-connect on re-attach ----
+    // A real engine is enough (no PanadapterStream needed): we drive the
+    // engine's lockStateChanged signal through the meta-object and count how
+    // many times the model reacts. attachEngine wires QUEUED, so we pump.
+    // Attaching the SAME engine twice must detach the prior connection first —
+    // a double-connect would deliver the second transition twice.
+    {
+        AetherClockEngine engine;
+        AetherClockModel m;
+        m.attachEngine(&engine);
+
+        QSignalSpy stateSpy(&m, &AetherClockModel::stateChanged);
+
+        // First engine transition → exactly one model reaction.
+        QMetaObject::invokeMethod(&engine, "lockStateChanged", Qt::DirectConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Acquiring));
+        pump();
+        CHECK(stateSpy.count() == 1);
+        CHECK(m.state() == int(ClockLockState::Acquiring));
+
+        // Re-attach the same engine, then a new transition. If attachEngine
+        // failed to detach, this would bump the count by 2 (→ 3), not 1.
+        m.attachEngine(&engine);
+        QMetaObject::invokeMethod(&engine, "lockStateChanged", Qt::DirectConnection,
+                                  Q_ARG(AetherSDR::ClockLockState, ClockLockState::Locked));
+        pump();
+        CHECK(stateSpy.count() == 2);            // single delivery, not doubled
+        CHECK(m.state() == int(ClockLockState::Locked));
+    }
+
+    if (g_failures == 0) {
+        std::printf("aetherclock_model_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("aetherclock_model_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -718,17 +718,14 @@ void sectionVoterNoisyCorpus() {
     // frame — this is what the WS-3 exact-tuple voter got wrong.
     CHECK(v.lastFrameMinute() == 25);
 
-    // Quality is coupled to the voted space now: with the year/hour/doy votes
-    // rescued against confident wrong bits, lockConfidence must NOT sit up in the
-    // clean-lock band. It is a genuine lock (well above zero) but visibly dipped
-    // below a clean window's quality — and below the ~0.926 the old voter emitted
-    // on this same window while reporting the WRONG time. Measured ~0.898 (the
-    // faded minute frames vote their field-MIN margin ~0.05, so the residual dip
-    // is carried by the confident static misreads); the absolute bound is loose,
-    // the strict dip vs the clean window below is the load-bearing check.
+    // Quality is coupled to the voted space now: lockConfidence is the MINIMUM
+    // per-bit margin, so this window's several contested bits collapse it far out
+    // of the clean-lock band — measured ~0.292 (the single most-contested voted
+    // bit's normalized margin), vs the ~0.926 the mean-aggregating voter reported
+    // on this same window while emitting the WRONG time. No confident garbage.
     const float q = v.lockConfidence();
     CHECK(q > 0.0f && q <= 1.0f);
-    CHECK(q < 0.93f);
+    CHECK(q < 0.35f);
 
     // A clean 8-frame window over the same minutes votes the same timestamp at
     // strictly higher quality — proving the dip tracks the contention, not luck.
@@ -781,6 +778,61 @@ void sectionVoterMinuteFadeWeighting() {
     CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
 }
 
+// [wwv.voter.contested-bit-quality] Quality must be HONEST about a single
+// decisive contested bit. The year-40 bit is flipped in the four NEWEST frames
+// (raw year 26 -> 66, in-range so the frame gate keeps them); their aged weight
+// (0.40 x (0.9^0..0.9^3) = 1.3756) beats the four clean oldest frames' (0.40 x
+// (0.9^4..0.9^7) = 0.9025), so votedField votes year 66 — recency wins and that
+// is accepted. The invariant here is quality: exactly ONE bit decided a whole
+// field against real cross-frame disagreement, so lockConfidence must collapse
+// to that bit's normalized margin ((1.3756-0.9025)/(1.3756+0.9025) = 0.2077),
+// not average it away. A mean over the 31 timestamp bits reads (30*1.0 + 0.208)/
+// 31 = 0.974 — confident garbage; the MIN aggregation reports ~0.208.
+void sectionVoterContestedBitQuality() {
+    std::array<float, 60> conf;
+    conf.fill(0.40f);
+
+    TimeFrameVoter v(wwvVoterConfig());
+    // Minutes increment (18..25) so the window locks; oldest four carry the true
+    // year 26, newest four carry 66 (only the year-40 bit differs).
+    for (int mn = 18; mn <= 21; ++mn) v.addFrame(wwvVoterFrame(mn, 6, 200, 26), conf);
+    for (int mn = 22; mn <= 25; ++mn) v.addFrame(wwvVoterFrame(mn, 6, 200, 66), conf);
+
+    CHECK(v.locked());                                          // it IS a lock...
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 66);       // ...voting year 66...
+    // ...but quality is honest about the lone decisive bit (mean-agg reads ~0.974).
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.35f);
+    // The other three fields are unanimous, so they don't prop the quality up.
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+}
+
+// [wwv.voter.doy366gate] A doy-366 frame in a NON-leap year is off-air and must
+// be gated out: advanceMinutes wraps doy 366 > 365 into Jan 1 of the next year
+// (even at age 0, where the wrap loop still runs), so an un-gated corrupt frame
+// would drag the vote onto an off-air date. Here a confident (high-margin) newest
+// frame decodes doy 366 in yr 27 (2027 is not a leap year); the gate excludes it
+// so the two clean frames hold the vote at doy 200 / yr 27. Without the gate this
+// frame outweighs them and the vote becomes doy 1 / yr 28.
+void sectionVoterDoy366Gate() {
+    constexpr float C  = 0.35f;
+    constexpr float HI = 0.90f;
+    std::array<float, 60> cc;  cc.fill(C);
+    std::array<float, 60> chi; chi.fill(HI);
+
+    TimeFrameVoter v(wwvVoterConfig());
+    v.addFrame(wwvVoterFrame(23, 6, 200, 27), cc);   // clean
+    v.addFrame(wwvVoterFrame(24, 6, 200, 27), cc);   // clean
+    v.addFrame(wwvVoterFrame(25, 6, 366, 27), chi);  // corrupt newest: doy 366 in a non-leap year
+
+    // The corrupt frame is gated out; the clean frames hold the true date.
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)  == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 27);
+}
+
 } // namespace
 
 int main() {
@@ -801,6 +853,8 @@ int main() {
     sectionVoterRollover();
     sectionVoterNoisyCorpus();
     sectionVoterMinuteFadeWeighting();
+    sectionVoterContestedBitQuality();
+    sectionVoterDoy366Gate();
 
     // Print encoded truth for the python cross-check gate.
     std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -348,6 +348,23 @@ void sectionCleanBitExact(const std::vector<float>& clean) {
     CHECK(dec.state()   == ClockLockState::Locked);
     CHECK(dec.station() == ClockStation::Wwv);
 
+    // WS-7 diagnostics snapshot: on the clean locked vector every funnel stage
+    // reads "passed" and the refusal tag is None. (Stage 4 lives engine-side.)
+    {
+        const ClockDecoderDiagnostics g = dec.diagnostics();
+        CHECK(g.toneDetected);
+        CHECK(g.phaseLocked);
+        CHECK(g.toneSnrDb > 0.0f);            // folded tick impulse, honest dB
+        CHECK(g.pwmContrast == 0.0f);         // WWVB-only metric
+        CHECK(!std::isnan(g.delayEstMs));     // delay settled on the clean vector
+        CHECK(g.anchored);
+        CHECK(g.badFrameStreak == 0);
+        CHECK(g.framesInWindow >= 2);
+        CHECK(g.windowSize == 8);
+        CHECK(g.voteQuality >= kConfidenceFloor);
+        CHECK(g.refusalReason == static_cast<std::uint8_t>(ClockLockRefusal::None));
+    }
+
     // Voted time "as of the newest frame".
     CHECK(!cap.times.empty());
     if (!cap.times.empty()) {
@@ -920,6 +937,9 @@ void sectionVoterPhantomRotating() {
     CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 20);
     // If it claims a lock at all, the hour must be a value some frame held.
     CHECK(!v.locked() || h == 3 || h == 9 || h == 10);
+    // WS-7: any refusal must carry a tag (never an unexplained "no").
+    if (!v.locked())
+        CHECK(v.lockRefusal() != ClockLockRefusal::None);
 }
 
 // [wwv.voter.lone-voter-participation] A bit only ONE frame actually voted must
@@ -982,6 +1002,8 @@ void sectionVoterUnanimousFadeNoConfidentGarbage() {
     }
     CHECK(!v.locked());                 // the 2006-01-01 event must not lock
     CHECK(v.lockConfidence() < 0.10f);
+    // WS-7: the refusal is attributable — the quality floor said no.
+    CHECK(v.lockRefusal() == ClockLockRefusal::QualityFloor);
 
     // (b) The same window through a floors-off voter locks at high quality —
     //     pinning that the gate is what kills the live failure mode.
@@ -992,6 +1014,7 @@ void sectionVoterUnanimousFadeNoConfidentGarbage() {
     }
     CHECK(legacy.locked());
     CHECK(legacy.lockConfidence() > 0.9f);
+    CHECK(legacy.lockRefusal() == ClockLockRefusal::None);   // locked -> None
 
     // (c) The floors must not break a CLEAN window: same minutes, no fade.
     TimeFrameVoter cleanV(hardened);
@@ -1027,6 +1050,8 @@ void sectionVoterPlausibilityGate() {
     for (int mn = 45; mn <= 52; ++mn)
         garbage.addFrame(wwvVoterFrame(mn, 3, 1, 6), conf);   // 2006-01-01
     CHECK(!garbage.locked());
+    // WS-7: the refusal is attributable — the plausibility gate said no.
+    CHECK(garbage.lockRefusal() == ClockLockRefusal::Plausibility);
 
     // (b) A host ~40 minutes wrong is WITHIN the bound — measuring that error
     //     is the applet's purpose, so this must still lock.
@@ -1035,6 +1060,7 @@ void sectionVoterPlausibilityGate() {
         hostSlow.addFrame(wwvVoterFrame(mn, 3, 201, 26), conf);
     CHECK(hostSlow.locked());
     CHECK(hostSlow.votedField(TimeFrameVoter::FieldMinutes) == 17);
+    CHECK(hostSlow.lockRefusal() == ClockLockRefusal::None);
 
     // (c) Gate disarmed (bound 0, the default): back-compat is explicit.
     TimeFrameVoter ungated(wwvVoterConfig());
@@ -1089,6 +1115,40 @@ void sectionVoterNoDeadReckoning() {
     }
     CHECK(!v.locked());                  // stale window must not stay locked
     CHECK(locksAfterGarbage <= 3);       // free-run bounded by the staleness age
+    // WS-7: the refusal is attributable — the staleness bound said no.
+    CHECK(v.lockRefusal() == ClockLockRefusal::Staleness);
+}
+
+// [wwv.voter.refusal-tags] WS-7: lockRefusal() distinguishes "still
+// collecting" (None) from an actual gate refusal, and tags the disagreement
+// gates as Contested. locked()/lockRefusal() read one verdict pass, so a
+// locked voter is always None and a refused one is never unexplained.
+void sectionVoterRefusalTags() {
+    constexpr float C = 0.35f;
+    std::array<float, 60> conf;
+    conf.fill(C);
+
+    // (a) Collecting: one frame is below minFramesForLock — not a refusal.
+    TimeFrameVoter collecting(wwvVoterConfig());
+    collecting.addFrame(wwvVoterFrame(10, 6, 200, 26), conf);
+    CHECK(!collecting.locked());
+    CHECK(collecting.frameCount() == 1);
+    CHECK(collecting.lockRefusal() == ClockLockRefusal::None);
+
+    // (b) Contested: two frames whose minutes do not chain (+1) — the window
+    //     disagrees with itself.
+    TimeFrameVoter contested(wwvVoterConfig());
+    contested.addFrame(wwvVoterFrame(10, 6, 200, 26), conf);
+    contested.addFrame(wwvVoterFrame(25, 6, 200, 26), conf);
+    CHECK(!contested.locked());
+    CHECK(contested.lockRefusal() == ClockLockRefusal::Contested);
+
+    // (c) Locked: a clean incrementing window refuses nothing.
+    TimeFrameVoter clean(wwvVoterConfig());
+    for (int mn = 10; mn <= 13; ++mn)
+        clean.addFrame(wwvVoterFrame(mn, 6, 200, 26), conf);
+    CHECK(clean.locked());
+    CHECK(clean.lockRefusal() == ClockLockRefusal::None);
 }
 
 // ---- WS-4.5 decoder-level hardening ---------------------------------------
@@ -1282,6 +1342,7 @@ int main() {
     sectionVoterUnanimousFadeNoConfidentGarbage();
     sectionVoterPlausibilityGate();
     sectionVoterNoDeadReckoning();
+    sectionVoterRefusalTags();
     sectionLockDemotesOnSignalLoss();
     sectionGapRealignsAndRelocks();
     sectionSlowDriftHoldsLock();

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <functional>
+#include <initializer_list>
 #include <random>
 #include <string>
 #include <utility>
@@ -640,6 +641,146 @@ void sectionVoterRollover() {
     }
 }
 
+// One voter frame from a timestamp, then per-second corruptions injected at
+// chosen confidences: each Corrupt overrides one second's symbol and its
+// matched-filter margin. This is how the noisy-corpus vector shapes single-bit
+// fades (low margin) and confident misreads (high margin) the way the live
+// receiver saw them.
+struct Corrupt { int second; ClockSymbol symbol; float confidence; };
+std::pair<std::array<ClockSymbol, 60>, std::array<float, 60>>
+wwvNoisyFrame(int mn, int hr, int doy, int yr, float baseConf,
+              const std::vector<Corrupt>& corruptions) {
+    std::array<ClockSymbol, 60> syms = wwvVoterFrame(mn, hr, doy, yr);
+    std::array<float, 60> conf;
+    conf.fill(baseConf);
+    for (const Corrupt& c : corruptions) {
+        syms[c.second] = c.symbol;
+        conf[c.second] = c.confidence;
+    }
+    return {syms, conf};
+}
+
+// [wwv.voter.noisycorpus] Regression for the WS-3 exact-tuple degeneracy: an
+// 8-frame window inside one hour (06:18..06:25, doy 200, yr 26) where EVERY
+// frame is corrupt in a different field, so no whole-tuple key ever repeats.
+// The old whole-tuple vote then degenerates to the newest frame's corrupt tuple
+// (it carries yr=66, so the voter reports the year 25 off) at a high, honest-
+// looking per-bit static quality — the exact "confident garbage" the live
+// receiver locked onto. Normalize-then-per-bit recovers the true timestamp from
+// the per-field majorities: single-bit fades lose on their low margin, confident
+// misreads lose to the aged weight of the many correct frames, and the reported
+// quality now dips because the voted space itself is contested.
+void sectionVoterNoisyCorpus() {
+    constexpr float C  = 0.35f;   // clean-bit margin (the live corpus ran ~0.35..0.41)
+    constexpr float LO = 0.05f;   // faded minute bit — a low-margin miss
+    constexpr float HI = 0.90f;   // a confident misread — high margin, wrong bit
+
+    TimeFrameVoter v(wwvVoterConfig());
+
+    // Frames added oldest -> newest (newest kept at the back of the window).
+    // The three oldest carry a faded minutes tens bit at LOW margin; the five
+    // newest are minutes-clean but each carries one confident wrong static bit,
+    // so NO frame decodes a fully-correct tuple.
+    struct NF { int mn, hr, doy, yr; std::vector<Corrupt> corr; };
+    const NF frames[] = {
+        // min18: drop the minutes 10-bit (sec 15) -> raw minute 08.
+        {18, 6, 200, 26, {{15, ClockSymbol::Zero, LO}}},
+        // min19: drop the minutes 10-bit -> raw minute 09.
+        {19, 6, 200, 26, {{15, ClockSymbol::Zero, LO}}},
+        // min20: drop the minutes 20-bit (sec 16) -> raw minute 00.
+        {20, 6, 200, 26, {{16, ClockSymbol::Zero, LO}}},
+        // min21: set the doy 2-bit (sec 31) -> raw doy 202.
+        {21, 6, 200, 26, {{31, ClockSymbol::One, HI}}},
+        // min22: set the doy 1-bit (sec 30) -> raw doy 201.
+        {22, 6, 200, 26, {{30, ClockSymbol::One, HI}}},
+        // min23: drop the year 20-bit (sec 52) -> raw year 06.
+        {23, 6, 200, 26, {{52, ClockSymbol::Zero, HI}}},
+        // min24: drop the hour 4-bit (sec 22) -> raw hour 02.
+        {24, 6, 200, 26, {{22, ClockSymbol::Zero, HI}}},
+        // min25 (newest): set the year 40-bit (sec 53) -> raw year 66. An
+        // as-newest / exact-tuple voter reports THIS frame's year (66).
+        {25, 6, 200, 26, {{53, ClockSymbol::One, HI}}},
+    };
+    for (const NF& f : frames) {
+        const auto [syms, conf] = wwvNoisyFrame(f.mn, f.hr, f.doy, f.yr, C, f.corr);
+        v.addFrame(syms, conf);
+    }
+
+    // Normalize-then-per-bit recovers the TRUE timestamp as of the newest frame,
+    // even though the newest frame's own decode carries yr=66 and no tuple repeats.
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+
+    // The newest raw frame really does decode yr=66, so the reported year (26)
+    // could ONLY come from the cross-frame normalized vote, not from any single
+    // frame — this is what the WS-3 exact-tuple voter got wrong.
+    CHECK(v.lastFrameMinute() == 25);
+
+    // Quality is coupled to the voted space now: with the year/hour/doy votes
+    // rescued against confident wrong bits, lockConfidence must NOT sit up in the
+    // clean-lock band. It is a genuine lock (well above zero) but visibly dipped
+    // below a clean window's quality — and below the ~0.926 the old voter emitted
+    // on this same window while reporting the WRONG time. Measured ~0.898 (the
+    // faded minute frames vote their field-MIN margin ~0.05, so the residual dip
+    // is carried by the confident static misreads); the absolute bound is loose,
+    // the strict dip vs the clean window below is the load-bearing check.
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f && q <= 1.0f);
+    CHECK(q < 0.93f);
+
+    // A clean 8-frame window over the same minutes votes the same timestamp at
+    // strictly higher quality — proving the dip tracks the contention, not luck.
+    TimeFrameVoter clean(wwvVoterConfig());
+    std::array<float, 60> cleanConf;
+    cleanConf.fill(C);
+    for (int mn = 18; mn <= 25; ++mn)
+        clean.addFrame(wwvVoterFrame(mn, 6, 200, 26), cleanConf);
+    CHECK(clean.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(clean.votedField(TimeFrameVoter::FieldYear)    == 26);
+    CHECK(clean.lockConfidence() > q);
+}
+
+// [wwv.voter.minutefade] Guards the re-encoded-field weighting: minutes ALWAYS
+// take the re-encode path (extrapolation always moves them), so the per-bit fade
+// rescue reaches minutes only through that path's weight. A window of 5 newest
+// frames whose minutes-20 bit faded (LOW margin) over 3 older clean frames votes
+// the WRONG minute (05, the live "min=03/06" symptom) if the re-encoded value is
+// weighted by its field-MEAN confidence — the one faded bit is diluted ~1/7 and
+// the five heavy-but-wrong frames tip the tally. Weighting by the field-MIN
+// confidence makes each faded frame vote its minutes at ~0.05, so the three
+// clean frames carry the 20 bit and the true minute (25) survives.
+void sectionVoterMinuteFadeWeighting() {
+    constexpr float C  = 0.40f;   // clean-bit margin
+    constexpr float LO = 0.05f;   // faded minutes-20 bit — a low-margin miss
+
+    TimeFrameVoter v(wwvVoterConfig());
+    // Oldest three frames clean (min 18/19/20); newest five fade the minutes 20
+    // bit (sec 16) at LOW margin — each still decodes the other minute bits, so
+    // only the tens is wrong, and all statics stay clean.
+    struct NF { int mn; std::vector<Corrupt> corr; };
+    const NF frames[] = {
+        {18, {}}, {19, {}}, {20, {}},
+        {21, {{16, ClockSymbol::Zero, LO}}}, // 21 has the 20 bit -> raw 01
+        {22, {{16, ClockSymbol::Zero, LO}}}, // -> raw 02
+        {23, {{16, ClockSymbol::Zero, LO}}}, // -> raw 03
+        {24, {{16, ClockSymbol::Zero, LO}}}, // -> raw 04
+        {25, {{16, ClockSymbol::Zero, LO}}}, // newest -> raw 05
+    };
+    for (const NF& f : frames) {
+        const auto [syms, conf] = wwvNoisyFrame(f.mn, 6, 200, 26, C, f.corr);
+        v.addFrame(syms, conf);
+    }
+
+    // Field-MIN weighting: the true minute survives the five heavier faded frames.
+    // (Field-MEAN weighting would vote 05 here — the regression this pins.)
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+}
+
 } // namespace
 
 int main() {
@@ -658,6 +799,8 @@ int main() {
     sectionDecadeDegeneracy(clean);
     sectionConfidenceFloor(clean);
     sectionVoterRollover();
+    sectionVoterNoisyCorpus();
+    sectionVoterMinuteFadeWeighting();
 
     // Print encoded truth for the python cross-check gate.
     std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -833,6 +833,76 @@ void sectionVoterDoy366Gate() {
     CHECK(v.votedField(TimeFrameVoter::FieldYear) == 27);
 }
 
+// [wwv.voter.frankenstein] Per-bit voting alone can assemble a value NO frame
+// held when sibling bits are won by DIFFERENT frame camps. Three clean frames
+// read hour 2 with the 4-bit (sec 22, truly Zero) FADED (sec21 One@0.90, sec22
+// Zero@0.05); one confident newest frame reads hour 4 (sec21 Zero@0.05, sec22
+// One@0.90). Per-bit: sec21 -> One (the three), sec22 -> One (the one) -> compose
+// = 2+4 = 6, against a 3:1 frame majority for 2. Coherence catches it: sec22's
+// confidence-winner (One) contradicts its aging-count majority (Zero, 3 frames),
+// so the hour field falls back to the top HELD value (2). Quality collapses to
+// the weak held-value margin (both camps vote at field-min conf 0.05: value 2 =
+// 0.05x(0.9^1+0.9^2+0.9^3)=0.122, value 4 = 0.05, margin 0.072/0.172 = 0.418).
+// The round-3 min-margin voter read hour 6 at q0.76 — confident garbage.
+void sectionVoterFrankenstein() {
+    constexpr float LO = 0.05f;   // faded / wrong-camp bit
+    constexpr float HI = 0.90f;   // confident bit
+    constexpr float C  = 0.40f;
+
+    TimeFrameVoter v(wwvVoterConfig());
+    // Minutes 18..21 increment so it locks; three clean hour-2 frames then one
+    // confident hour-4 newest. (sec 21 = hour 2-bit, sec 22 = hour 4-bit.)
+    for (int mn = 18; mn <= 20; ++mn) {
+        const auto [syms, conf] = wwvNoisyFrame(
+            mn, 2, 200, 26, C,
+            {{21, ClockSymbol::One, HI}, {22, ClockSymbol::Zero, LO}});
+        v.addFrame(syms, conf);
+    }
+    {
+        const auto [syms, conf] = wwvNoisyFrame(
+            21, 4, 200, 26, C,
+            {{21, ClockSymbol::Zero, LO}, {22, ClockSymbol::One, HI}});
+        v.addFrame(syms, conf);  // corrupt newest reads hour 4
+    }
+
+    CHECK(v.locked());
+    CHECK(v.votedField(TimeFrameVoter::FieldHours) == 2);   // held majority, NOT 6
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 21);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)   == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)  == 26);
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.45f);   // held-value margin ~0.418; round-3 read ~0.76 at hour 6
+}
+
+// [wwv.voter.lone-voter-participation] A bit only ONE frame actually voted must
+// not read as certain. sec 54 (year-80 bit, truly Zero) is Unknown in three of
+// four otherwise-clean frames; only the newest classifies it (Zero). Its winning
+// margin is ~1.0 (no opposition), but participation = aged_newest / Σ aged =
+// 1.0/(1+0.9+0.81+0.729) = 0.291, so its TRUST = 0.291 pulls quality down. The
+// value is unaffected (year 26); the round-3 min-margin voter read this window
+// at q~1.0 — certain about a bit almost no frame saw.
+void sectionVoterLoneVoterParticipation() {
+    constexpr float C = 0.40f;
+
+    TimeFrameVoter v(wwvVoterConfig());
+    for (int mn = 18; mn <= 20; ++mn) {
+        const auto [syms, conf] =
+            wwvNoisyFrame(mn, 6, 200, 26, C, {{54, ClockSymbol::Unknown, C}});
+        v.addFrame(syms, conf);
+    }
+    std::array<float, 60> newestConf;
+    newestConf.fill(C);
+    v.addFrame(wwvVoterFrame(21, 6, 200, 26), newestConf);  // newest votes sec 54
+
+    CHECK(v.locked());
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 26);   // value unaffected
+    CHECK(v.votedField(TimeFrameVoter::FieldHours) == 6);
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.35f);   // participation ~0.291 caps it; round-3 read ~1.0
+}
+
 } // namespace
 
 int main() {
@@ -855,6 +925,8 @@ int main() {
     sectionVoterMinuteFadeWeighting();
     sectionVoterContestedBitQuality();
     sectionVoterDoy366Gate();
+    sectionVoterFrankenstein();
+    sectionVoterLoneVoterParticipation();
 
     // Print encoded truth for the python cross-check gate.
     std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -1,0 +1,581 @@
+// AetherClock WS-1 — WWV/WWVH decoder test (plain main() + CHECK, NOT QtTest).
+//
+// Self-contained: the WWV signal synthesizer, the AWGN helper, and a tiny WAV
+// writer all live in this file (std only). It exercises WwvDecoder through
+// process() with realistic streaming chunk sizes and asserts every BCD field
+// bit-exact against the synthesized truth.
+//
+// Signal model + levels are PINNED by SPEC.md §"Signal synthesizer spec"
+// (PRD-A §8): 24 kHz; carrier 1000 Hz @ 0.5; 100 Hz subcarrier depth 0.30
+// pulse-on / 0.06 pulse-off / 0 during the s0 minute hole; pulse per the NIST
+// 170/470/770 ms @ +30 ms encoding; 5 ms tick @ 0.25 at the 2000 Hz image
+// (WWVH: 2200 Hz). Field map per the NIST WWV time-code table (SP 432).
+//
+// The decoder .cpp implementations are authored in parallel; this file is
+// syntax-checked against the frozen headers only. Value asserts therefore fix
+// exact FIELD values and assert confidence RANGES/FLOORS, never exact
+// confidence numbers.
+
+#include "core/TimeFrameVoter.h"
+#include "core/WwvDecoder.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace AetherSDR;
+
+// ---- test harness (per SPEC.md §"Repo conventions") -----------------------
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr int    kFs = 24000;              // pinned sample rate
+
+// Pinned NIST WWV noise floor: bit-exact decode at >= 20 dB SNR in 700-1300 Hz.
+constexpr double kWwvSnrFloorDb = 20.0;
+
+// QA-documented confidence floor for a clean / near-clean lock (ranges only —
+// exact matched-filter margins are impl-defined). Loosen here if a correct
+// implementation legitimately reports lower; never tighten silently.
+// Calibrated against the streaming decoder on the clean golden vector
+// (observed minima: frameConfidence 0.475, quality 0.500 — the streaming
+// biquad chain's matched-filter margins sit slightly below the batch
+// prototype's). Noise-only input never locks at all, so these floors bound
+// the clean/degraded cases with real headroom.
+constexpr float  kConfidenceFloor      = 0.40f;  // clean golden vector
+constexpr float  kConfidenceFloor20dB  = 0.25f;  // at the pinned 20 dB floor
+
+// ---- WWV time-code synthesizer --------------------------------------------
+// Per-second pulse class of the 100 Hz subcarrier.
+enum class Sym { Hole, Zero, One, Marker };
+
+// Broadcast truth for one minute; the synthesizer encodes ALL of these so
+// bit-exactness of every field is assertable.
+struct Truth {
+    int  minute = 0, hour = 0, doy = 0, year2 = 0;
+    int  dut1Tenths = 0;   // signed tenths (e.g. -3 => -0.3 s)
+    bool dst1 = false;     // WWV s2
+    bool dst2 = false;     // WWV s55
+    bool lsw  = false;     // WWV s3 (leap-second warning)
+};
+
+struct SynthOpts {
+    int          numFrames     = 3;                 // >= 3 consecutive minutes
+    int          leadInSeconds = 10;                // tail of the prior minute
+    int          leadOutSeconds = 10;               // head of the next minute
+    ClockStation station       = ClockStation::Wwv; // tick image 2000/2200 Hz
+    bool         removeHole     = false; // s0 gets a normal pulse (kills the cue)
+    bool         corruptMarkers = false; // markers flattened to 170 ms zeros
+    int          truncateSeconds = -1;   // stop the final frame after N seconds
+};
+
+using BcdMap = std::vector<std::pair<int,int>>; // (secondOfFrame, weight)
+
+// Field maps, LSB-first within field, per the NIST WWV time-code table.
+const BcdMap kMapMin{{10,1},{11,2},{12,4},{13,8},{15,10},{16,20},{17,40}};
+const BcdMap kMapHr {{20,1},{21,2},{22,4},{23,8},{25,10},{26,20}};
+const BcdMap kMapDoy{{30,1},{31,2},{32,4},{33,8},{35,10},{36,20},{37,40},
+                     {38,80},{40,100},{41,200}};
+const BcdMap kMapYr {{4,1},{5,2},{6,4},{7,8},{51,10},{52,20},{53,40},{54,80}};
+
+void setBcd(std::array<Sym,60>& s, const BcdMap& m, int value) {
+    for (const auto& pr : m) {
+        int sec = pr.first, w = pr.second;
+        int place = 1;
+        while (w / place >= 10) place *= 10;   // decade of this weight
+        int bw    = w / place;                  // 1|2|4|8 within the decade
+        int digit = (value / place) % 10;
+        if (digit & bw) s[sec] = Sym::One;
+    }
+}
+
+// One minute of classified per-second symbols from broadcast truth.
+std::array<Sym,60> encodeMinute(const Truth& t) {
+    std::array<Sym,60> s;
+    s.fill(Sym::Zero);
+    s[0] = Sym::Hole;                                   // minute-mark subcarrier hole
+    for (int m : {9,19,29,39,49,59}) s[m] = Sym::Marker; // P1..P5, P0
+    setBcd(s, kMapMin, t.minute);
+    setBcd(s, kMapHr,  t.hour);
+    setBcd(s, kMapDoy, t.doy);
+    setBcd(s, kMapYr,  t.year2);
+    if (t.dut1Tenths > 0) s[50] = Sym::One;             // DUT1 sign (1 = +)
+    int mag = std::abs(t.dut1Tenths);
+    if (mag & 1) s[56] = Sym::One;                      // DUT1 magnitude 0.1
+    if (mag & 2) s[57] = Sym::One;                      // DUT1 magnitude 0.2
+    if (mag & 4) s[58] = Sym::One;                      // DUT1 magnitude 0.4
+    if (t.dst1) s[2]  = Sym::One;
+    if (t.dst2) s[55] = Sym::One;
+    if (t.lsw)  s[3]  = Sym::One;
+    return s;
+}
+
+// Append one second (kFs samples) of the pinned WWV waveform.
+//   sample(t) = 0.5*sin(2pi*1000*t)*(1 + d(t)*sin(2pi*100*t)) + tick(t)
+void appendSecond(std::vector<float>& sig, Sym sym, int tickFreq) {
+    for (int k = 0; k < kFs; ++k) {
+        const double t   = static_cast<double>(sig.size()) / kFs; // absolute -> phase-continuous
+        const double tau = static_cast<double>(k) / kFs;          // within-second
+        const double car = 0.5 * std::sin(2.0 * kPi * 1000.0 * t);
+        double d;
+        if (sym == Sym::Hole) {
+            d = 0.0;                                    // no subcarrier at all
+        } else {
+            const double dur = (sym == Sym::Zero) ? 0.170
+                             : (sym == Sym::One)  ? 0.470
+                                                  : 0.770;         // marker
+            d = (tau >= 0.030 && tau < 0.030 + dur) ? 0.30 : 0.06; // +30 ms start
+        }
+        const double sub  = 1.0 + d * std::sin(2.0 * kPi * 100.0 * t);
+        const double tick = (tau < 0.005)                          // 5 ms burst
+                          ? 0.25 * std::sin(2.0 * kPi * tickFreq * t)
+                          : 0.0;
+        sig.push_back(static_cast<float>(car * sub + tick));
+    }
+}
+
+std::vector<float> synthWwv(const Truth& start, const SynthOpts& o) {
+    const int tickFreq = (o.station == ClockStation::Wwvh) ? 2200 : 2000;
+    std::vector<float> sig;
+    sig.reserve(static_cast<size_t>((o.leadInSeconds + 60 * o.numFrames)) * kFs);
+
+    auto emit = [&](std::array<Sym,60> sym, int secStart, int secEnd) {
+        for (int sec = secStart; sec < secEnd; ++sec) {
+            Sym s = sym[sec];
+            if (o.corruptMarkers && s == Sym::Marker) s = Sym::Zero; // flatten markers
+            if (o.removeHole && sec == 0)             s = Sym::Zero; // fill the hole
+            appendSecond(sig, s, tickFreq);
+        }
+    };
+
+    // Lead-in: the tail seconds of the prior minute, correctly encoded.
+    Truth lead = start;
+    lead.minute -= 1;
+    if (lead.minute < 0) { lead.minute += 60; lead.hour = (lead.hour + 23) % 24; }
+    emit(encodeMinute(lead), 60 - o.leadInSeconds, 60);
+
+    // Consecutive full frames, minutes monotonically incrementing.
+    for (int i = 0; i < o.numFrames; ++i) {
+        Truth cur = start;
+        const int total = start.minute + i;
+        cur.minute = total % 60;
+        cur.hour   = (start.hour + total / 60) % 24;
+        int lastSec = 60;
+        if (o.truncateSeconds >= 0 && i == o.numFrames - 1) lastSec = o.truncateSeconds;
+        emit(encodeMinute(cur), 0, lastSec);
+    }
+
+    // Lead-out: the head seconds of the NEXT minute, correctly encoded, so the
+    // final frame can complete (streaming decoders need trailing signal to
+    // close the last second/frame). Skipped when truncating — the truncation
+    // section depends on the signal ending mid-frame.
+    if (o.truncateSeconds < 0 && o.leadOutSeconds > 0) {
+        Truth next = start;
+        const int total = start.minute + o.numFrames;
+        next.minute = total % 60;
+        next.hour   = (start.hour + total / 60) % 24;
+        emit(encodeMinute(next), 0, o.leadOutSeconds);
+    }
+    return sig;
+}
+
+// ---- AWGN with SNR measured/scaled in the 700-1300 Hz band ----------------
+// RBJ constant-0-dB-peak bandpass, f0=1000, Q=f0/BW with BW=600 Hz -> -3 dB
+// edges near 700/1300 Hz. The SAME filter measures signal and noise power, so
+// the resulting ratio IS the band-limited SNR of SPEC's floor definition.
+std::vector<float> bandpass700_1300(const std::vector<float>& x) {
+    const double f0 = 1000.0, Q = 1000.0 / 600.0;
+    const double w0 = 2.0 * kPi * f0 / kFs;
+    const double cs = std::cos(w0), sn = std::sin(w0), alpha = sn / (2.0 * Q);
+    double b0 = alpha, b1 = 0.0, b2 = -alpha;
+    const double a0 = 1.0 + alpha, a1 = -2.0 * cs, a2 = 1.0 - alpha;
+    b0 /= a0; b1 /= a0; b2 /= a0;
+    const double na1 = a1 / a0, na2 = a2 / a0;
+    std::vector<float> y(x.size());
+    double x1 = 0, x2 = 0, y1 = 0, y2 = 0;
+    for (size_t i = 0; i < x.size(); ++i) {
+        const double xi = x[i];
+        const double yi = b0 * xi + b1 * x1 + b2 * x2 - na1 * y1 - na2 * y2;
+        y[i] = static_cast<float>(yi);
+        x2 = x1; x1 = xi; y2 = y1; y1 = yi;
+    }
+    return y;
+}
+
+double meanSquare(const std::vector<float>& x) {
+    double s = 0.0;
+    for (float v : x) s += static_cast<double>(v) * v;
+    return x.empty() ? 0.0 : s / x.size();
+}
+double bandPower(const std::vector<float>& x) { return meanSquare(bandpass700_1300(x)); }
+
+// Add AWGN scaled so band-SNR == snrDb. Deterministic (caller owns the PRNG).
+std::vector<float> addAwgnAtBandSnr(const std::vector<float>& sig, double snrDb,
+                                    std::mt19937& rng) {
+    const double psig = bandPower(sig);
+    std::normal_distribution<double> nd(0.0, 1.0);
+    std::vector<float> noise(sig.size());
+    for (auto& v : noise) v = static_cast<float>(nd(rng));
+    const double pn     = bandPower(noise);
+    const double snrLin = std::pow(10.0, snrDb / 10.0);
+    const double g      = (pn > 0.0) ? std::sqrt(psig / (snrLin * pn)) : 0.0;
+    std::vector<float> out(sig.size());
+    for (size_t i = 0; i < sig.size(); ++i)
+        out[i] = static_cast<float>(sig[i] + g * noise[i]);
+    return out;
+}
+
+std::vector<float> pureAwgn(size_t n, double amp, std::mt19937& rng) {
+    std::normal_distribution<double> nd(0.0, amp);
+    std::vector<float> v(n);
+    for (auto& x : v) x = static_cast<float>(nd(rng));
+    return v;
+}
+
+// Measured band-SNR of a noisy vector vs its clean reference.
+double measuredBandSnrDb(const std::vector<float>& clean, const std::vector<float>& noisy) {
+    std::vector<float> resid(clean.size());
+    for (size_t i = 0; i < clean.size(); ++i) resid[i] = noisy[i] - clean[i];
+    const double ps = bandPower(clean), pn = bandPower(resid);
+    return (pn > 0.0) ? 10.0 * std::log10(ps / pn) : 999.0;
+}
+
+// ---- tiny WAV writer (16-bit PCM, stereo dup, 24 kHz) ---------------------
+void writeWavStereo(const std::string& path, const std::vector<float>& mono) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return;
+    const uint16_t nch = 2, bits = 16;
+    const uint16_t blockAlign = static_cast<uint16_t>(nch * bits / 8);
+    const uint32_t byteRate   = static_cast<uint32_t>(kFs) * blockAlign;
+    const uint32_t dataBytes  = static_cast<uint32_t>(mono.size()) * blockAlign;
+    const uint32_t riffSize   = 36u + dataBytes;
+    auto w32 = [&](uint32_t v) { f.write(reinterpret_cast<const char*>(&v), 4); };
+    auto w16 = [&](uint16_t v) { f.write(reinterpret_cast<const char*>(&v), 2); };
+    f.write("RIFF", 4); w32(riffSize); f.write("WAVE", 4);
+    f.write("fmt ", 4); w32(16); w16(1); w16(nch);
+    w32(static_cast<uint32_t>(kFs)); w32(byteRate); w16(blockAlign); w16(bits);
+    f.write("data", 4); w32(dataBytes);
+    for (float s : mono) {
+        float c = std::max(-1.0f, std::min(1.0f, s));
+        int16_t v = static_cast<int16_t>(std::lround(c * 32767.0f));
+        w16(static_cast<uint16_t>(v)); // L
+        w16(static_cast<uint16_t>(v)); // R (duplicated mono)
+    }
+}
+
+// ---- decoder driving + callback capture -----------------------------------
+struct Capture {
+    std::vector<ClockFrameInfo> frames;
+    std::vector<ClockTimeInfo>  times;
+    std::vector<ClockLockState> states;
+    int lockedTransitions = 0;
+};
+
+void wire(WwvDecoder& d, Capture& c) {
+    d.onFrame        = [&c](const ClockFrameInfo& f) { c.frames.push_back(f); };
+    d.onTime         = [&c](const ClockTimeInfo&  t) { c.times.push_back(t); };
+    d.onStateChanged = [&c](ClockLockState s) {
+        c.states.push_back(s);
+        if (s == ClockLockState::Locked) ++c.lockedTransitions;
+    };
+}
+
+void feedChunks(WwvDecoder& d, const std::vector<float>& sig, size_t chunk) {
+    for (size_t i = 0; i < sig.size(); ) {
+        const size_t n = std::min(chunk, sig.size() - i);
+        d.process(sig.data() + i, n);
+        i += n;
+    }
+}
+
+// Irregular chunking to shake out chunk-boundary bugs (edges split mid-tick,
+// mid-pulse, single-sample dribbles).
+void feedIrregular(WwvDecoder& d, const std::vector<float>& sig) {
+    static const size_t sizes[] = {1, 7, 63, 512, 4096, 333, 2048, 9};
+    size_t i = 0, k = 0;
+    while (i < sig.size()) {
+        const size_t n = std::min(sizes[k % 8], sig.size() - i);
+        d.process(sig.data() + i, n);
+        i += n; ++k;
+    }
+}
+
+bool minutesIncrement(const std::vector<ClockFrameInfo>& f) {
+    if (f.size() < 2) return false;
+    for (size_t i = 1; i < f.size(); ++i)
+        if (f[i].minute != (f[i - 1].minute + 1) % 60) return false;
+    return true;
+}
+
+bool acquiringBeforeLock(const std::vector<ClockLockState>& s) {
+    size_t li = s.size();
+    for (size_t i = 0; i < s.size(); ++i)
+        if (s[i] == ClockLockState::Locked) { li = i; break; }
+    if (li == s.size()) return false;
+    for (size_t i = 0; i < li; ++i)
+        if (s[i] == ClockLockState::Acquiring) return true;
+    return false;
+}
+
+// The golden broadcast truth: 06:20 -> 06:21 -> 06:22 on doy 200, yr 26,
+// DUT1 = -0.3 s, DST1 set, DST2 clear, leap-second warning set.
+const Truth   kGold{20, 6, 200, 26, /*dut1*/ -3, /*dst1*/ true, /*dst2*/ false, /*lsw*/ true};
+constexpr int kExpectNewestMin = 22; // start.minute + numFrames - 1
+
+// ==== test sections ========================================================
+
+// [wwv.clean] Clean 3-frame synth -> every BCD field bit-exact, station tag,
+// lock, minutes increment, callback sequencing, confidence floor.
+void sectionCleanBitExact(const std::vector<float>& clean) {
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, clean, 512);
+
+    CHECK(dec.state()   == ClockLockState::Locked);
+    CHECK(dec.station() == ClockStation::Wwv);
+
+    // Voted time "as of the newest frame".
+    CHECK(!cap.times.empty());
+    if (!cap.times.empty()) {
+        const ClockTimeInfo& t = cap.times.back();
+        CHECK(t.minute == kExpectNewestMin);
+        CHECK(t.hour   == 6);
+        CHECK(t.doy    == 200);
+        CHECK(t.year2  == 26);
+        CHECK(t.station == ClockStation::Wwv);
+        CHECK(t.quality >= kConfidenceFloor && t.quality <= 1.0f);
+    }
+
+    // Per-frame raw decode: fields including DUT1 sign+magnitude, DST, LSW.
+    CHECK(!cap.frames.empty());
+    if (!cap.frames.empty()) {
+        const ClockFrameInfo& f = cap.frames.back();
+        CHECK(f.minute      == kExpectNewestMin);
+        CHECK(f.hour        == 6);
+        CHECK(f.doy         == 200);
+        CHECK(f.year2       == 26);
+        CHECK(f.dut1Tenths  == -3);          // sign + magnitude bit-exact
+        CHECK(f.dst1        == true);
+        CHECK(f.dst2        == false);
+        CHECK(f.leapPending == true);        // WWV LSW s3
+        CHECK(f.leapYear    == false);       // always false for WWV
+        CHECK(f.station     == ClockStation::Wwv);
+        CHECK(f.frameConfidence >= kConfidenceFloor && f.frameConfidence <= 1.0f);
+    }
+
+    CHECK(minutesIncrement(cap.frames));
+
+    // Sequencing: Acquiring precedes Locked; exactly ONE transition to Locked.
+    CHECK(acquiringBeforeLock(cap.states));
+    CHECK(cap.lockedTransitions == 1);
+}
+
+// [wwv.wwvh] WWVH variant (2200 Hz tick image) -> station() == Wwvh, fields
+// decode identically (same code, only the tick tone tags the station).
+void sectionWwvhStation() {
+    SynthOpts o; o.station = ClockStation::Wwvh;
+    const std::vector<float> sig = synthWwv(kGold, o);
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, sig, 512);
+
+    CHECK(dec.station() == ClockStation::Wwvh);
+    CHECK(dec.state()   == ClockLockState::Locked);
+    if (!cap.frames.empty()) {
+        CHECK(cap.frames.back().station == ClockStation::Wwvh);
+        CHECK(cap.frames.back().minute  == kExpectNewestMin);
+    }
+    if (!cap.times.empty())
+        CHECK(cap.times.back().station == ClockStation::Wwvh);
+}
+
+// [wwv.snr20] Pinned noise floor: bit-exact at exactly 20 dB SNR in-band.
+void sectionSnr20(const std::vector<float>& clean, std::mt19937& rng) {
+    CHECK(kWwvSnrFloorDb == 20.0);           // pinned floor is documented in-test
+
+    const std::vector<float> noisy = addAwgnAtBandSnr(clean, kWwvSnrFloorDb, rng);
+
+    // Independent of the decoder: prove the synth/AWGN path really hit 20 dB.
+    const double snrMeas = measuredBandSnrDb(clean, noisy);
+    CHECK(std::fabs(snrMeas - kWwvSnrFloorDb) < 0.5);
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedIrregular(dec, noisy);               // irregular chunks under noise
+
+    CHECK(dec.state() == ClockLockState::Locked);
+    if (!cap.frames.empty()) {
+        const ClockFrameInfo& f = cap.frames.back();
+        CHECK(f.minute     == kExpectNewestMin);
+        CHECK(f.hour       == 6);
+        CHECK(f.doy        == 200);
+        CHECK(f.year2      == 26);
+        CHECK(f.dut1Tenths == -3);
+        CHECK(f.dst1 == true && f.dst2 == false && f.leapPending == true);
+        CHECK(f.frameConfidence >= kConfidenceFloor20dB && f.frameConfidence <= 1.0f);
+    }
+    if (!cap.times.empty())
+        CHECK(cap.times.back().minute == kExpectNewestMin);
+}
+
+// [wwv.noiseonly] >= 5 minutes of pure AWGN -> NEVER locks.
+void sectionNoiseOnlyNeverLocks(std::mt19937& rng) {
+    const size_t n = static_cast<size_t>(5 * 60) * kFs;   // 5 minutes
+    const std::vector<float> noise = pureAwgn(n, 0.3, rng);
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, noise, 512);
+
+    CHECK(dec.state() != ClockLockState::Locked);
+    CHECK(cap.lockedTransitions == 0);
+    CHECK(cap.times.empty());                // no voted time ever emitted
+}
+
+// [wwv.badmarkers] Corrupted markers (P-pulses flattened to 170 ms zeros) ->
+// no frame sync, no false lock.
+void sectionCorruptMarkersNoFalseLock() {
+    SynthOpts o; o.corruptMarkers = true;
+    const std::vector<float> sig = synthWwv(kGold, o);
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, sig, 512);
+
+    CHECK(dec.state() != ClockLockState::Locked);
+    CHECK(cap.lockedTransitions == 0);
+}
+
+// [wwv.truncated] Truncated final frame (30 s) -> no partial-field emission
+// for the incomplete minute.
+void sectionTruncatedNoPartial() {
+    SynthOpts o; o.truncateSeconds = 30;     // frame min=22 cut off at s30
+    const std::vector<float> sig = synthWwv(kGold, o);
+    const int truncatedMin = kExpectNewestMin;   // 22 — must never be emitted
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, sig, 512);
+
+    for (const ClockFrameInfo& f : cap.frames)
+        CHECK(f.minute != truncatedMin);     // no partial frame surfaced
+    if (!cap.frames.empty())
+        CHECK(cap.frames.back().minute == truncatedMin - 1);  // last COMPLETE = 21
+    if (!cap.times.empty())
+        CHECK(cap.times.back().minute != truncatedMin);
+}
+
+// [wwv.decade] Decade degeneracy: marker-only anchoring is degenerate mod 10 s.
+// (a) On the clean vector a correct decode landing exactly on truth IS the
+//     rejection proof — a 10 s-shifted anchor would decode shifted fields.
+// (b) On a hole-omitted-but-marker-consistent vector, the decoder must either
+//     refuse to lock or still land on truth.
+void sectionDecadeDegeneracy(const std::vector<float>& clean) {
+    // (a) clean — decoded minutes match truth exactly, not truth+/-shift.
+    {
+        WwvDecoder dec(kFs);
+        Capture cap; wire(dec, cap);
+        feedChunks(dec, clean, 512);
+        CHECK(dec.state() == ClockLockState::Locked);
+        if (!cap.times.empty())
+            CHECK(cap.times.back().minute == kExpectNewestMin);
+        // Every per-frame minute is exactly one of the encoded truths.
+        for (const ClockFrameInfo& f : cap.frames)
+            CHECK(f.minute == 20 || f.minute == 21 || f.minute == 22);
+        CHECK(minutesIncrement(cap.frames));
+    }
+    // (b) hole omitted (s0 carries a normal pulse), markers still consistent.
+    {
+        SynthOpts o; o.removeHole = true;
+        const std::vector<float> sig = synthWwv(kGold, o);
+        WwvDecoder dec(kFs);
+        Capture cap; wire(dec, cap);
+        feedChunks(dec, sig, 512);
+        const bool refused = (dec.state() != ClockLockState::Locked);
+        const bool onTruth = (!cap.times.empty() &&
+                              cap.times.back().minute == kExpectNewestMin);
+        CHECK(refused || onTruth);           // refuse, or still land on truth
+    }
+}
+
+// [wwv.confidence] Documented confidence floor: reported per-frame and voted
+// confidences sit in [0,1] and clear the QA floor on the clean vector.
+void sectionConfidenceFloor(const std::vector<float>& clean) {
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, clean, 512);
+
+    for (const ClockFrameInfo& f : cap.frames) {
+        CHECK(f.frameConfidence >= 0.0f && f.frameConfidence <= 1.0f);
+        CHECK(f.frameConfidence >= kConfidenceFloor);   // documented floor
+    }
+    for (const ClockTimeInfo& t : cap.times) {
+        CHECK(t.quality >= 0.0f && t.quality <= 1.0f);
+        CHECK(t.quality >= kConfidenceFloor);
+    }
+    float minFrameConf = 1.0f, minQuality = 1.0f;
+    for (const ClockFrameInfo& f : cap.frames)
+        minFrameConf = std::min(minFrameConf, f.frameConfidence);
+    for (const ClockTimeInfo& t : cap.times)
+        minQuality = std::min(minQuality, t.quality);
+    std::fprintf(stderr, "[wwv.confidence] documented floor = %.2f "
+                 "(observed clean minima: frameConfidence %.3f, quality %.3f)\n",
+                 static_cast<double>(kConfidenceFloor),
+                 static_cast<double>(minFrameConf),
+                 static_cast<double>(minQuality));
+}
+
+} // namespace
+
+int main() {
+    std::mt19937 rng(0xC0FFEEu);             // fixed seed -> reproducible AWGN
+
+    // Build the clean golden vector once; reuse across sections + WAV dump.
+    SynthOpts opts;
+    const std::vector<float> clean = synthWwv(kGold, opts);
+
+    sectionCleanBitExact(clean);
+    sectionWwvhStation();
+    sectionSnr20(clean, rng);
+    sectionNoiseOnlyNeverLocks(rng);
+    sectionCorruptMarkersNoFalseLock();
+    sectionTruncatedNoPartial();
+    sectionDecadeDegeneracy(clean);
+    sectionConfidenceFloor(clean);
+
+    // Print encoded truth for the python cross-check gate.
+    std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",
+                kGold.minute, kGold.hour, kGold.doy, kGold.year2, opts.numFrames);
+    std::printf("golden extra: dut1_tenths=%d dst1=%d dst2=%d lsw=%d station=WWV\n",
+                kGold.dut1Tenths, kGold.dst1 ? 1 : 0, kGold.dst2 ? 1 : 0,
+                kGold.lsw ? 1 : 0);
+
+    // WAV dump for the cross-check gate: 16-bit PCM stereo (dup mono), 24 kHz.
+    if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {
+        const std::string path = std::string(dir) + "/wwv_golden.wav";
+        writeWavStereo(path, clean);
+        std::fprintf(stderr, "wrote golden vector: %s (%zu samples)\n",
+                     path.c_str(), clean.size());
+    }
+
+    if (g_failures == 0) {
+        std::printf("wwv_decoder_test: all checks passed\n");
+        return 0;
+    }
+    std::printf("wwv_decoder_test: %d checks FAILED\n", g_failures);
+    return 1;
+}

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -903,6 +903,310 @@ void sectionVoterLoneVoterParticipation() {
     CHECK(q <= 0.35f);   // participation ~0.291 caps it; round-3 read ~1.0
 }
 
+// [wwv.voter.unanimous-fade] WS-4.5 regression for the 2026-07-20 live false
+// lock (decoded 2006-01-01 at q100): a deep fade zero-biased the SAME date bits
+// in EVERY window frame — doy 201 -> 001 (s36/s38/s40 lost), year 26 -> 06
+// (s52 lost) — so the wrongness was unanimous: margin 1.0, full participation,
+// and the disagreement-based quality metric certified confident garbage at
+// ~1.0. With the eligibility floor (minBitConfidence) noise-grade bits stop
+// voting entirely: participation collapses, the affected fields' trust goes to
+// ~0, and the minLockQuality gate refuses the lock.
+void sectionVoterUnanimousFadeNoConfidentGarbage() {
+    constexpr float C  = 0.35f;   // healthy bits
+    constexpr float LO = 0.02f;   // deep-fade margin — noise-grade
+
+    auto fadedFrame = [](int mn) {
+        return wwvNoisyFrame(mn, 3, 201, 26, C,
+                             {{36, ClockSymbol::Zero, LO},
+                              {38, ClockSymbol::Zero, LO},
+                              {40, ClockSymbol::Zero, LO},
+                              {52, ClockSymbol::Zero, LO}});
+    };
+
+    // (a) With the production floors armed the unanimously-faded window must
+    //     not lock, and quality must say why.
+    TimeFrameVoter::Config hardened = wwvVoterConfig();
+    hardened.minBitConfidence = 0.05f;
+    hardened.minLockQuality   = 0.10f;
+    TimeFrameVoter v(hardened);
+    for (int mn = 45; mn <= 52; ++mn) {
+        const auto [syms, conf] = fadedFrame(mn);
+        v.addFrame(syms, conf);
+    }
+    CHECK(!v.locked());                 // the 2006-01-01 event must not lock
+    CHECK(v.lockConfidence() < 0.10f);
+
+    // (b) The same window through a floors-off voter locks at high quality —
+    //     pinning that the gate is what kills the live failure mode.
+    TimeFrameVoter legacy(wwvVoterConfig());
+    for (int mn = 45; mn <= 52; ++mn) {
+        const auto [syms, conf] = fadedFrame(mn);
+        legacy.addFrame(syms, conf);
+    }
+    CHECK(legacy.locked());
+    CHECK(legacy.lockConfidence() > 0.9f);
+
+    // (c) The floors must not break a CLEAN window: same minutes, no fade.
+    TimeFrameVoter cleanV(hardened);
+    std::array<float, 60> conf;
+    conf.fill(C);
+    for (int mn = 45; mn <= 52; ++mn)
+        cleanV.addFrame(wwvVoterFrame(mn, 3, 201, 26), conf);
+    CHECK(cleanV.locked());
+    CHECK(cleanV.votedField(TimeFrameVoter::FieldDoy)  == 201);
+    CHECK(cleanV.votedField(TimeFrameVoter::FieldYear) == 26);
+    CHECK(cleanV.lockConfidence() > 0.5f);
+}
+
+// [wwv.voter.plausibility] Absolute-plausibility leg (WS-4.5): even a
+// confident, unanimous, self-consistent decode must not lock when the voted
+// timestamp is implausibly far from the reference clock. Systematic misreads
+// are self-consistent by construction — the reference is the only independent
+// evidence. The bound is generous: a host minutes or hours wrong still
+// measures; decades cannot lock.
+void sectionVoterPlausibilityGate() {
+    constexpr float C = 0.35f;
+    std::array<float, 60> conf;
+    conf.fill(C);
+
+    const TimeFields ref{50, 3, 201, 26};   // "host now": 03:50 doy 201 yr 26
+
+    TimeFrameVoter::Config gated = wwvVoterConfig();
+    gated.plausibilityBoundMinutes = 24 * 60;
+    gated.referenceNow = [ref] { return ref; };
+
+    // (a) Confident garbage 20 years out (the live event): must not lock.
+    TimeFrameVoter garbage(gated);
+    for (int mn = 45; mn <= 52; ++mn)
+        garbage.addFrame(wwvVoterFrame(mn, 3, 1, 6), conf);   // 2006-01-01
+    CHECK(!garbage.locked());
+
+    // (b) A host ~40 minutes wrong is WITHIN the bound — measuring that error
+    //     is the applet's purpose, so this must still lock.
+    TimeFrameVoter hostSlow(gated);
+    for (int mn = 10; mn <= 17; ++mn)
+        hostSlow.addFrame(wwvVoterFrame(mn, 3, 201, 26), conf);
+    CHECK(hostSlow.locked());
+    CHECK(hostSlow.votedField(TimeFrameVoter::FieldMinutes) == 17);
+
+    // (c) Gate disarmed (bound 0, the default): back-compat is explicit.
+    TimeFrameVoter ungated(wwvVoterConfig());
+    for (int mn = 45; mn <= 52; ++mn)
+        ungated.addFrame(wwvVoterFrame(mn, 3, 1, 6), conf);
+    CHECK(ungated.locked());
+
+    // (d) Bound edge: one day out (1438 min at the newest frame) locks at a
+    //     24 h bound; two days out does not.
+    TimeFrameVoter atEdge(gated);
+    for (int mn = 45; mn <= 52; ++mn)
+        atEdge.addFrame(wwvVoterFrame(mn, 3, 200, 26), conf);
+    CHECK(atEdge.locked());
+    TimeFrameVoter pastEdge(gated);
+    for (int mn = 45; mn <= 52; ++mn)
+        pastEdge.addFrame(wwvVoterFrame(mn, 3, 199, 26), conf);
+    CHECK(!pastEdge.locked());
+
+    // (e) setPlausibility arms the gate on a default-constructed config too.
+    TimeFrameVoter armed(wwvVoterConfig());
+    armed.setPlausibility([ref] { return ref; }, 24 * 60);
+    for (int mn = 45; mn <= 52; ++mn)
+        armed.addFrame(wwvVoterFrame(mn, 3, 1, 6), conf);
+    CHECK(!armed.locked());
+}
+
+// [wwv.voter.dead-reckoning] Garbage frames must not let the voter free-run on
+// the stale survivors: pre-WS-4.5, a range-invalid frame (the all-zeros decode
+// a misaligned window produces; doy 0 is invalid) vanished from the normalized
+// window entirely, so the aged good frames kept extrapolating +1 min per
+// garbage frame at q1.00 — advancing timestamps with zero live support (the
+// live receiver did exactly this after its window drifted). The staleness
+// bound caps the free-run; participation accounting drags the quality down.
+void sectionVoterNoDeadReckoning() {
+    constexpr float C = 0.35f;
+    std::array<float, 60> conf;
+    conf.fill(C);
+
+    TimeFrameVoter v(wwvVoterConfig());
+    for (int mn = 10; mn <= 14; ++mn)
+        v.addFrame(wwvVoterFrame(mn, 6, 200, 26), conf);
+    CHECK(v.locked());
+
+    // Confident garbage: every second Zero at margin C -> minute 0, hour 0,
+    // doy 0 (range-invalid) — the all-zeros shape a misaligned window decodes.
+    std::array<ClockSymbol, 60> zeros{};
+    zeros.fill(ClockSymbol::Zero);
+    int locksAfterGarbage = 0;
+    for (int g = 0; g < 6; ++g) {
+        v.addFrame(zeros, conf);
+        if (v.locked()) ++locksAfterGarbage;
+    }
+    CHECK(!v.locked());                  // stale window must not stay locked
+    CHECK(locksAfterGarbage <= 3);       // free-run bounded by the staleness age
+}
+
+// ---- WS-4.5 decoder-level hardening ---------------------------------------
+
+// [wwv.demote] Lock must not survive the signal: after a clean lock, dead air
+// must demote the decoder out of Locked. (Live 2026-07-20: the applet pinned
+// Locked q100 for 45 minutes of stale decode — nothing in the decoder could
+// ever lower the state once set.)
+void sectionLockDemotesOnSignalLoss() {
+    SynthOpts opts;
+    opts.numFrames = 5;
+    const std::vector<float> clean = synthWwv(kGold, opts);
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, clean, 512);
+    CHECK(dec.state() == ClockLockState::Locked);       // precondition
+
+    const std::vector<float> silence(static_cast<size_t>(kFs) * 300, 0.0f);
+    feedChunks(dec, silence, 512);
+    CHECK(dec.state() != ClockLockState::Locked);       // demoted, not pinned
+}
+
+// [wwv.gap] A sample-stream discontinuity (dropped DAX buffers) must not
+// permanently derail the decoder: pre-WS-4.5 the tick phase and frame anchor
+// were estimated once and frozen, so a 300 ms gap misaligned every subsequent
+// window — confident systematic misreads forever (the live white-vs-blue
+// drift). Structural re-validation detects it, soft reacquire + the leaky
+// fold re-lock on the CURRENT phase, and the decoder is locked on truth again
+// by the end.
+void sectionGapRealignsAndRelocks() {
+    SynthOpts opts;
+    opts.numFrames = 18;
+    opts.leadOutSeconds = 30;
+    const Truth t{10, 6, 200, 26, -3, true, false, true};
+    const std::vector<float> full = synthWwv(t, opts);
+
+    // 10 s lead-in + 5.5 frames -> cut 300 ms mid-minute.
+    const size_t cutAt = static_cast<size_t>(kFs) * (10 + 5 * 60 + 30);
+    const size_t gap = static_cast<size_t>(kFs) * 3 / 10;
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    dec.process(full.data(), cutAt);
+    CHECK(dec.state() == ClockLockState::Locked);        // locked pre-gap
+
+    const std::vector<float> tail(full.begin() + static_cast<long>(cutAt + gap),
+                                  full.end());
+    feedChunks(dec, tail, 512);
+
+    CHECK(dec.state() == ClockLockState::Locked);        // re-locked post-heal
+    CHECK(!cap.times.empty());
+    const ClockTimeInfo& last = cap.times.back();
+    CHECK(last.hour == 6);
+    CHECK(last.doy == 200);
+    CHECK(last.year2 == 26);
+    CHECK(last.minute >= t.minute + 11 && last.minute <= t.minute + 17);
+    CHECK(last.quality > 0.1f);
+
+    // The re-lock must be LIVE decode, not dead reckoning: post-heal FRAMES
+    // (raw, pre-voting) must decode the on-air truth again. (The old decoder
+    // decoded all-zeros forever here while the voter free-ran — a voted time
+    // in range proved nothing by itself.)
+    bool liveDecodePostGap = false;
+    for (const ClockFrameInfo& f : cap.frames) {
+        if (f.minute >= t.minute + 11 && f.minute <= t.minute + 17 &&
+            f.hour == 6 && f.doy == 200 && f.year2 == 26) {
+            liveDecodePostGap = true;
+        }
+    }
+    CHECK(liveDecodePostGap);
+}
+
+// [wwv.drift] Slow sample-clock drift must be ABSORBED, not accumulated into
+// misreads: +5 ms of stream slip every 20 s (~250 ppm, far beyond any real
+// DAX rate offset) from minute 3 on. The old 80 ms matched-filter cap froze
+// the alignment and turned accumulated drift into the live receiver's
+// systematic misreads; the tracked delay estimate must follow the drift,
+// keep the decode exact and hold the lock the whole way.
+void sectionSlowDriftHoldsLock() {
+    SynthOpts opts;
+    opts.numFrames = 10;
+    opts.leadOutSeconds = 20;
+    const Truth t{30, 6, 200, 26, -3, true, false, true};
+    const std::vector<float> base = synthWwv(t, opts);
+
+    std::vector<float> drifty;
+    drifty.reserve(base.size() + base.size() / 100);
+    const size_t insEvery = static_cast<size_t>(kFs) * 20;
+    size_t nextIns = static_cast<size_t>(kFs) * (10 + 3 * 60);
+    for (size_t i = 0; i < base.size(); ++i) {
+        if (i == nextIns) {
+            drifty.insert(drifty.end(), 120, 0.0f);   // +5 ms of stream slip
+            nextIns += insEvery;
+        }
+        drifty.push_back(base[i]);
+    }
+
+    WwvDecoder dec(kFs);
+    Capture cap; wire(dec, cap);
+    feedChunks(dec, drifty, 512);
+
+    CHECK(dec.state() == ClockLockState::Locked);
+    CHECK(!cap.times.empty());
+    const ClockTimeInfo& last = cap.times.back();
+    CHECK(last.minute == t.minute + opts.numFrames - 1);   // exact to the end
+    CHECK(last.hour == 6);
+    CHECK(last.doy == 200);
+    CHECK(last.year2 == 26);
+
+    // The absorbed drift must not have cost the lock even transiently.
+    bool sawLock = false, demotedAfterLock = false;
+    for (ClockLockState s : cap.states) {
+        if (s == ClockLockState::Locked) sawLock = true;
+        else if (sawLock) demotedAfterLock = true;
+    }
+    CHECK(sawLock);
+    CHECK(!demotedAfterLock);
+
+    // Edge labels must TRACK the drift, not the frozen window grid: the span
+    // between frame s0 edges of minute 30 and minute 39 covers 9 broadcast
+    // minutes PLUS the 18-19 slips inserted between them (the insertion at the
+    // exact minute-39 boundary is ±1). The old fixed-grid labels missed by the
+    // full accumulated drift (~90-110 ms); the compensated labels stay within
+    // a few series samples. (Constant chain-delay bias cancels in the span.)
+    const ClockFrameInfo* f30 = nullptr;
+    const ClockFrameInfo* f39 = nullptr;
+    for (const ClockFrameInfo& f : cap.frames) {
+        if (f.minute == 30 && !f30) f30 = &f;
+        if (f.minute == 39) f39 = &f;
+    }
+    CHECK(f30 != nullptr && f39 != nullptr);
+    if (f30 && f39) {
+        const long long trueSpan = 9LL * 60 * kFs + 18LL * 120;
+        const long long measured = f39->frameStartSample - f30->frameStartSample;
+        const long long tolerance = 6LL * (kFs / 200) + 120;   // 30 ms + slip ambiguity
+        CHECK(std::llabs(measured - trueSpan) <= tolerance);
+    }
+}
+
+// [wwv.plumb-plausibility] setPlausibility reaches the shared voter: a signal
+// broadcasting a date 20 years from the reference must never lock, while the
+// same signal locks against a matching reference. (Gate semantics are
+// unit-tested at the voter level; this pins the decoder plumbing.)
+void sectionDecoderPlausibilityPlumbing() {
+    SynthOpts opts;
+    opts.numFrames = 4;
+    const Truth wrongEra{20, 6, 1, 6, 0, false, false, false};   // 2006-001
+    const std::vector<float> sig = synthWwv(wrongEra, opts);
+
+    WwvDecoder rej(kFs);
+    rej.setPlausibility([] { return TimeFields{50, 3, 201, 26}; }, 24 * 60);
+    Capture capR; wire(rej, capR);
+    feedChunks(rej, sig, 512);
+    CHECK(rej.state() != ClockLockState::Locked);
+    CHECK(capR.times.empty());
+
+    WwvDecoder acc(kFs);
+    acc.setPlausibility([] { return TimeFields{21, 6, 1, 6}; }, 24 * 60);
+    Capture capA; wire(acc, capA);
+    feedChunks(acc, sig, 512);
+    CHECK(acc.state() == ClockLockState::Locked);
+    CHECK(!capA.times.empty());
+}
+
 } // namespace
 
 int main() {
@@ -927,6 +1231,13 @@ int main() {
     sectionVoterDoy366Gate();
     sectionVoterFrankenstein();
     sectionVoterLoneVoterParticipation();
+    sectionVoterUnanimousFadeNoConfidentGarbage();
+    sectionVoterPlausibilityGate();
+    sectionVoterNoDeadReckoning();
+    sectionLockDemotesOnSignalLoss();
+    sectionGapRealignsAndRelocks();
+    sectionSlowDriftHoldsLock();
+    sectionDecoderPlausibilityPlumbing();
 
     // Print encoded truth for the python cross-check gate.
     std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -539,6 +539,107 @@ void sectionConfidenceFloor(const std::vector<float>& clean) {
                  static_cast<double>(minQuality));
 }
 
+// ---- direct TimeFrameVoter rollover tests (WWV field maps) ----------------
+// These drive TimeFrameVoter directly (no audio path) so the whole-timestamp
+// value vote is exercised across hour/day/year rollovers — the case no golden
+// audio vector reached because every vector stayed inside one hour.
+
+TimeFrameVoter::Config wwvVoterConfig() {
+    auto toFieldMap = [](const BcdMap& m) {
+        ClockFieldMap fm;
+        for (const auto& pr : m) fm.push_back(ClockBitWeight{pr.first, pr.second});
+        return fm;
+    };
+    TimeFrameVoter::Config cfg;
+    cfg.fields[TimeFrameVoter::FieldMinutes] = toFieldMap(kMapMin);
+    cfg.fields[TimeFrameVoter::FieldHours]   = toFieldMap(kMapHr);
+    cfg.fields[TimeFrameVoter::FieldDoy]     = toFieldMap(kMapDoy);
+    cfg.fields[TimeFrameVoter::FieldYear]    = toFieldMap(kMapYr);
+    cfg.markerSeconds = {9, 19, 29, 39, 49, 59};
+    cfg.window = 8;
+    cfg.minFramesForLock = 2;
+    cfg.agingFactor = 0.9f;
+    return cfg;
+}
+
+// One voter frame (per-second ClockSymbol) from a timestamp; the s0 minute hole
+// is a non-data second, mapped to Marker (never in a field map).
+std::array<ClockSymbol, 60> wwvVoterFrame(int mn, int hr, int doy, int yr) {
+    Truth t; t.minute = mn; t.hour = hr; t.doy = doy; t.year2 = yr;
+    const std::array<Sym, 60> s = encodeMinute(t);
+    std::array<ClockSymbol, 60> out{};
+    for (int i = 0; i < 60; ++i) {
+        out[i] = (s[i] == Sym::One)    ? ClockSymbol::One
+               : (s[i] == Sym::Zero)   ? ClockSymbol::Zero
+                                       : ClockSymbol::Marker;  // Marker or Hole
+    }
+    return out;
+}
+
+// [wwv.voter.rollover] After every appended frame the voted timestamp equals the
+// newest frame's truth across hour/day/year boundaries, and a mixed-hour window
+// never votes an off-air hour.
+void sectionVoterRollover() {
+    std::array<float, 60> conf; conf.fill(1.0f);
+
+    // (a) advanceMinutes helper is calendar-correct in isolation.
+    CHECK(advanceMinutes(TimeFields{59, 21, 200, 26}, 1) == (TimeFields{0, 22, 200, 26}));
+    CHECK(advanceMinutes(TimeFields{59, 23, 200, 26}, 1) == (TimeFields{0, 0, 201, 26}));
+    CHECK(advanceMinutes(TimeFields{59, 23, 365, 26}, 1) == (TimeFields{0, 0, 1, 27})); // 2026 not leap
+    CHECK(advanceMinutes(TimeFields{59, 23, 366, 28}, 1) == (TimeFields{0, 0, 1, 29})); // 2028 leap
+
+    // (b) hour rollover 21:57 -> 22:02.
+    {
+        TimeFrameVoter v(wwvVoterConfig());
+        struct MH { int mn, hr; };
+        for (const MH e : {MH{57,21}, {58,21}, {59,21}, {0,22}, {1,22}, {2,22}}) {
+            v.addFrame(wwvVoterFrame(e.mn, e.hr, 200, 26), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == e.mn);
+            CHECK(v.votedField(TimeFrameVoter::FieldHours)   == e.hr);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+            CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+        }
+    }
+
+    // (c) day rollover 23:58 -> 00:01, doy 200 -> 201.
+    {
+        TimeFrameVoter v(wwvVoterConfig());
+        struct MHD { int mn, hr, doy; };
+        for (const MHD e : {MHD{58,23,200}, {59,23,200}, {0,0,201}, {1,0,201}}) {
+            v.addFrame(wwvVoterFrame(e.mn, e.hr, e.doy, 26), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == e.mn);
+            CHECK(v.votedField(TimeFrameVoter::FieldHours)   == e.hr);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == e.doy);
+        }
+    }
+
+    // (d) year rollover on doy 365 -> 1, yr 26 -> 27 (non-leap year length).
+    {
+        TimeFrameVoter v(wwvVoterConfig());
+        struct T { int mn, hr, doy, yr; };
+        for (const T e : {T{58,23,365,26}, {59,23,365,26}, {0,0,1,27}, {1,0,1,27}}) {
+            v.addFrame(wwvVoterFrame(e.mn, e.hr, e.doy, e.yr), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)  == e.doy);
+            CHECK(v.votedField(TimeFrameVoter::FieldYear) == e.yr);
+        }
+    }
+
+    // (e) bizarre-blend regression: a window holding hour-21 AND hour-22 frames
+    //     must vote an hour of ONLY 21 or 22 — never a per-bit-mixed third value
+    //     (the live 20:xx symptom). 7 consecutive hour-21 frames, then hour-22.
+    {
+        TimeFrameVoter v(wwvVoterConfig());
+        struct MH { int mn, hr; };
+        for (const MH e : {MH{53,21}, {54,21}, {55,21}, {56,21}, {57,21}, {58,21},
+                           {59,21}, {0,22}, {1,22}, {2,22}}) {
+            v.addFrame(wwvVoterFrame(e.mn, e.hr, 200, 26), conf);
+            const int h = v.votedField(TimeFrameVoter::FieldHours);
+            CHECK(h == 21 || h == 22);                 // never an off-air hour
+            CHECK(h == e.hr);                          // and the newest hour wins
+        }
+    }
+}
+
 } // namespace
 
 int main() {
@@ -556,6 +657,7 @@ int main() {
     sectionTruncatedNoPartial();
     sectionDecadeDegeneracy(clean);
     sectionConfidenceFloor(clean);
+    sectionVoterRollover();
 
     // Print encoded truth for the python cross-check gate.
     std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",

--- a/tests/wwv_decoder_test.cpp
+++ b/tests/wwv_decoder_test.cpp
@@ -875,6 +875,53 @@ void sectionVoterFrankenstein() {
     CHECK(q <= 0.45f);   // held-value margin ~0.418; round-3 read ~0.76 at hour 6
 }
 
+// [wwv.voter.phantom-rotating] Refuter-round-5 regression (2026-07-20): even
+// with EVERY bit coherent (confidence-winner == count majority), rotating
+// 2-of-3 misreads at uniform noise-band confidence can win each hour bit from
+// a different frame camp and compose an hour NO frame held: frames holding
+// {9, 10, 3} per-bit-compose to 8+2+1 = 11, in range, every winning side
+// carrying a floor-clearing vote (the pre-fix voter emitted it at q~0.20,
+// above the lock floor). Per-bit coherence is necessary but not sufficient --
+// the composed value must itself be a HELD value, else the field demotes to
+// the held-value fallback (here: the clean newest frame's hour 3, whose
+// contested margin then honestly refuses the lock).
+void sectionVoterPhantomRotating() {
+    constexpr float N = 0.10f;   // uniform noise-band margin -- clears the
+                                 // trust floor, below the clean corpus band
+
+    TimeFrameVoter::Config cfg = wwvVoterConfig();
+    cfg.minBitConfidence = 0.05f;   // production floors (WS-4.5)
+    cfg.minLockQuality   = 0.05f;
+    TimeFrameVoter v(cfg);
+
+    // Minutes increment 18..20 (lockable); hour truth 3 (s20 + s21). The two
+    // older frames each misread TWO hour bits; the newest is fully correct.
+    {   // holds hour 9 (8+1): s23 set, s21 dropped
+        const auto [syms, conf] = wwvNoisyFrame(
+            18, 3, 200, 26, N,
+            {{23, ClockSymbol::One, N}, {21, ClockSymbol::Zero, N}});
+        v.addFrame(syms, conf);
+    }
+    {   // holds hour 10 (8+2): s23 set, s20 dropped
+        const auto [syms, conf] = wwvNoisyFrame(
+            19, 3, 200, 26, N,
+            {{23, ClockSymbol::One, N}, {20, ClockSymbol::Zero, N}});
+        v.addFrame(syms, conf);
+    }
+    {   // newest: clean, holds the true hour 3
+        std::array<float, 60> conf;
+        conf.fill(N);
+        v.addFrame(wwvVoterFrame(20, 3, 200, 26), conf);
+    }
+
+    const int h = v.votedField(TimeFrameVoter::FieldHours);
+    CHECK(h != 11);   // the phantom -- held by no frame
+    CHECK(h == 3);    // held-value fallback: the newest (true) hour
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 20);
+    // If it claims a lock at all, the hour must be a value some frame held.
+    CHECK(!v.locked() || h == 3 || h == 9 || h == 10);
+}
+
 // [wwv.voter.lone-voter-participation] A bit only ONE frame actually voted must
 // not read as certain. sec 54 (year-80 bit, truly Zero) is Unknown in three of
 // four otherwise-clean frames; only the newest classifies it (Zero). Its winning
@@ -1230,6 +1277,7 @@ int main() {
     sectionVoterContestedBitQuality();
     sectionVoterDoy366Gate();
     sectionVoterFrankenstein();
+    sectionVoterPhantomRotating();
     sectionVoterLoneVoterParticipation();
     sectionVoterUnanimousFadeNoConfidentGarbage();
     sectionVoterPlausibilityGate();

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -640,6 +640,45 @@ int main() {
         CHECK(lockTransitions == 1);
     }
 
+    // --- Section: WS-7 diagnostics — stage flips on the clean vector; stage-1
+    // readouts stay honest on noise-only air (tone measured, gate not passed).
+    {
+        const auto x = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0x1D1A6u);
+        WwvbDecoder d(24000);
+        Capture c; wire(d, c);
+        feedFixed(d, x, 512);
+        CHECK(d.state() == ClockLockState::Locked);      // precondition
+        const ClockDecoderDiagnostics g = d.diagnostics();
+        CHECK(g.toneDetected);
+        CHECK(g.toneSnrDb > 10.0f);      // gate is peak > 12x median (~10.8 dB)
+        CHECK(g.pwmContrast >= 1.4f);    // kMinContrast — a real AM drop exists
+        CHECK(g.phaseLocked);
+        CHECK(std::isnan(g.delayEstMs)); // WWV-only metric
+        CHECK(g.anchored);
+        CHECK(g.badFrameStreak == 0);    // WWV-only metric
+        CHECK(g.framesInWindow >= 2);
+        CHECK(g.windowSize == 8);
+        CHECK(g.voteQuality > 0.0f);
+        CHECK(g.refusalReason == static_cast<std::uint8_t>(ClockLockRefusal::None));
+
+        // Noise-only: MEASURED decoder behavior (fail-first run 2026-07-22) is
+        // that the early stages can transiently pass on pure AWGN — the 12x
+        // Goertzel tone gate false-fires within ~60 s of windows, and random
+        // symbol chatter can even double-marker-anchor briefly. What refuses
+        // noise is the frame/voter machinery: no structurally-valid frame ever
+        // completes. The diagnostics must report exactly that shape — late
+        // stages empty, no lock, no unexplained verdict.
+        WwvbDecoder n(24000);
+        Capture cn; wire(n, cn);
+        const auto nx = noiseVector(static_cast<std::size_t>(60) * kSR, 0.2, 0xF00Du);
+        feedFixed(n, nx, 512);
+        CHECK(n.state() != ClockLockState::Locked);
+        const ClockDecoderDiagnostics gn = n.diagnostics();
+        CHECK(gn.framesInWindow == 0);   // no valid frame ever survives noise
+        CHECK(gn.voteQuality == 0.0f);
+        CHECK(gn.refusalReason <= 4);    // always a valid ClockLockRefusal
+    }
+
     // --- Section: WS-4.5 — lock demotes on signal loss, cached vote stops
     // (Live 2026-07-20 class: a stale Locked must never be pinned; dead air
     // demotes and the per-second cached re-emission stops with it.)

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -536,6 +536,65 @@ static void sectionVoterDoy366Gate() {
     CHECK(v.votedField(TimeFrameVoter::FieldYear) == 27);
 }
 
+// [wwvb.voter.frankenstein] Mirror: three clean hour-2 frames with the 4-bit
+// (sec 16) faded (sec17 One@0.90, sec16 Zero@0.05) and one confident hour-4
+// newest (sec17 Zero@0.05, sec16 One@0.90). Per-bit would compose 2+4 = 6;
+// coherence gates sec16 (confidence-winner One vs count-majority Zero) so the
+// hour falls back to the held majority 2, at the weak held-value margin (~0.42).
+static void sectionVoterFrankenstein() {
+    constexpr float LO = 0.05f;
+    constexpr float HI = 0.90f;
+    constexpr float C  = 0.40f;
+
+    TimeFrameVoter v(wwvbVoterConfig());
+    for (int mn = 18; mn <= 20; ++mn) {
+        const auto [syms, conf] = wwvbNoisyFrame(
+            mn, 2, 200, 26, C,
+            {{17, ClockSymbol::One, HI}, {16, ClockSymbol::Zero, LO}});
+        v.addFrame(syms, conf);
+    }
+    {
+        const auto [syms, conf] = wwvbNoisyFrame(
+            21, 4, 200, 26, C,
+            {{17, ClockSymbol::Zero, LO}, {16, ClockSymbol::One, HI}});
+        v.addFrame(syms, conf);
+    }
+
+    CHECK(v.locked());
+    CHECK(v.votedField(TimeFrameVoter::FieldHours) == 2);   // held majority, NOT 6
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 21);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)   == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)  == 26);
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.45f);
+}
+
+// [wwvb.voter.lone-voter-participation] Mirror: sec 45 (year-80 bit) is Unknown
+// in three of four otherwise-clean frames; only the newest classifies it. Its
+// margin is ~1.0 but participation ~0.291 caps its trust, pulling quality down
+// while the value stays year 26.
+static void sectionVoterLoneVoterParticipation() {
+    constexpr float C = 0.40f;
+
+    TimeFrameVoter v(wwvbVoterConfig());
+    for (int mn = 18; mn <= 20; ++mn) {
+        const auto [syms, conf] =
+            wwvbNoisyFrame(mn, 6, 200, 26, C, {{45, ClockSymbol::Unknown, C}});
+        v.addFrame(syms, conf);
+    }
+    std::array<float, 60> newestConf;
+    newestConf.fill(C);
+    v.addFrame(wwvbVoterFrame(21, 6, 200, 26), newestConf);
+
+    CHECK(v.locked());
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 26);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours) == 6);
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.35f);
+}
+
 // ------------------------------------------------------------------------ main
 int main() {
     // Golden truth for the clean 3-frame vector: 06:20/06:21/06:22, doy 200,
@@ -689,6 +748,12 @@ int main() {
 
     // --- Section: doy-366-in-non-leap-year gate
     sectionVoterDoy366Gate();
+
+    // --- Section: cross-bit Frankenstein composition (coherence gating)
+    sectionVoterFrankenstein();
+
+    // --- Section: lone-voter participation scaling
+    sectionVoterLoneVoterParticipation();
 
     // --- WAV dump of the clean golden vector (opt-in via env var) + truth print
     if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -20,8 +20,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <initializer_list>
 #include <random>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace AetherSDR;
@@ -385,6 +387,116 @@ static void sectionVoterRollover() {
     }
 }
 
+// One voter frame, then per-second corruptions injected at chosen confidences:
+// each Corrupt overrides a second's symbol and its matched-filter margin, so the
+// vector can shape single-bit fades (low margin) and confident misreads (high
+// margin) the way the live receiver saw them.
+struct Corrupt { int second; ClockSymbol symbol; float confidence; };
+static std::pair<std::array<ClockSymbol, 60>, std::array<float, 60>>
+wwvbNoisyFrame(int mn, int hr, int doy, int yr, float baseConf,
+               const std::vector<Corrupt>& corruptions) {
+    std::array<ClockSymbol, 60> syms = wwvbVoterFrame(mn, hr, doy, yr);
+    std::array<float, 60> conf;
+    conf.fill(baseConf);
+    for (const Corrupt& c : corruptions) {
+        syms[c.second] = c.symbol;
+        conf[c.second] = c.confidence;
+    }
+    return {syms, conf};
+}
+
+// [wwvb.voter.noisycorpus] Mirror of the WWV WS-3 exact-tuple degeneracy on the
+// WWVB legacy-AM map: an 8-frame window inside one hour (06:18..06:25, doy 200,
+// yr 26) where every frame is corrupt in a different field, so no whole-tuple
+// key repeats. The old whole-tuple vote degenerates to the newest frame's
+// corrupt tuple (yr=66, the year 25 off) at a high, honest-looking static
+// quality. Normalize-then-per-bit recovers the true timestamp from the per-field
+// majorities and reports a quality that finally reflects the contested vote.
+static void sectionVoterNoisyCorpus() {
+    constexpr float C  = 0.35f;   // clean-bit margin (the live corpus ran ~0.35..0.41)
+    constexpr float LO = 0.05f;   // faded minute bit — a low-margin miss
+    constexpr float HI = 0.90f;   // a confident misread — high margin, wrong bit
+
+    TimeFrameVoter v(wwvbVoterConfig());
+
+    // Frames oldest -> newest. The three oldest fade a minutes tens bit at LOW
+    // margin; the five newest are minutes-clean but each carries one confident
+    // wrong static bit — so NO frame decodes a fully-correct tuple.
+    struct NF { int mn, hr, doy, yr; std::vector<Corrupt> corr; };
+    const NF frames[] = {
+        {18, 6, 200, 26, {{3,  ClockSymbol::Zero, LO}}}, // drop min 10-bit -> 08
+        {19, 6, 200, 26, {{3,  ClockSymbol::Zero, LO}}}, // -> 09
+        {20, 6, 200, 26, {{2,  ClockSymbol::Zero, LO}}}, // drop min 20-bit -> 00
+        {21, 6, 200, 26, {{32, ClockSymbol::One,  HI}}}, // set doy 2-bit -> 202
+        {22, 6, 200, 26, {{33, ClockSymbol::One,  HI}}}, // set doy 1-bit -> 201
+        {23, 6, 200, 26, {{47, ClockSymbol::Zero, HI}}}, // drop yr 20-bit -> 06
+        {24, 6, 200, 26, {{16, ClockSymbol::Zero, HI}}}, // drop hr 4-bit -> 02
+        {25, 6, 200, 26, {{46, ClockSymbol::One,  HI}}}, // set yr 40-bit -> 66 (newest)
+    };
+    for (const NF& f : frames) {
+        const auto [syms, conf] = wwvbNoisyFrame(f.mn, f.hr, f.doy, f.yr, C, f.corr);
+        v.addFrame(syms, conf);
+    }
+
+    // Normalize-then-per-bit recovers the TRUE timestamp as of the newest frame,
+    // even though the newest frame's own decode carries yr=66 and no tuple repeats.
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+    CHECK(v.lastFrameMinute() == 25);   // newest raw frame really is minute 25/yr 66
+
+    // Quality is coupled to the voted space: with the static votes rescued
+    // against confident wrong bits, lockConfidence dips out of the clean-lock
+    // band (measured ~0.898 — the faded minute frames vote their field-MIN margin
+    // ~0.05, so the residual dip is carried by the confident static misreads) yet
+    // stays a genuine lock. The absolute bound is loose; the strict dip vs the
+    // clean window below is the load-bearing check.
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f && q <= 1.0f);
+    CHECK(q < 0.93f);
+
+    // A clean 8-frame window over the same minutes votes the same timestamp at
+    // strictly higher quality — the dip tracks the contention, not luck.
+    TimeFrameVoter clean(wwvbVoterConfig());
+    std::array<float, 60> cleanConf;
+    cleanConf.fill(C);
+    for (int mn = 18; mn <= 25; ++mn)
+        clean.addFrame(wwvbVoterFrame(mn, 6, 200, 26), cleanConf);
+    CHECK(clean.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(clean.votedField(TimeFrameVoter::FieldYear)    == 26);
+    CHECK(clean.lockConfidence() > q);
+}
+
+// [wwvb.voter.minutefade] Mirror guard for the re-encoded-field weighting: five
+// newest frames fade the minutes 20 bit (sec 2 here) over three older clean
+// frames. Field-MEAN weighting of the re-encoded minute votes the wrong minute
+// (05); field-MIN weighting lets the three clean frames carry the 20 bit so the
+// true minute (25) survives.
+static void sectionVoterMinuteFadeWeighting() {
+    constexpr float C  = 0.40f;   // clean-bit margin
+    constexpr float LO = 0.05f;   // faded minutes-20 bit — a low-margin miss
+
+    TimeFrameVoter v(wwvbVoterConfig());
+    struct NF { int mn; std::vector<Corrupt> corr; };
+    const NF frames[] = {
+        {18, {}}, {19, {}}, {20, {}},
+        {21, {{2, ClockSymbol::Zero, LO}}}, // 21 has the 20 bit -> raw 01
+        {22, {{2, ClockSymbol::Zero, LO}}}, // -> raw 02
+        {23, {{2, ClockSymbol::Zero, LO}}}, // -> raw 03
+        {24, {{2, ClockSymbol::Zero, LO}}}, // -> raw 04
+        {25, {{2, ClockSymbol::Zero, LO}}}, // newest -> raw 05
+    };
+    for (const NF& f : frames) {
+        const auto [syms, conf] = wwvbNoisyFrame(f.mn, 6, 200, 26, C, f.corr);
+        v.addFrame(syms, conf);
+    }
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+}
+
 // ------------------------------------------------------------------------ main
 int main() {
     // Golden truth for the clean 3-frame vector: 06:20/06:21/06:22, doy 200,
@@ -526,6 +638,12 @@ int main() {
 
     // --- Section: direct TimeFrameVoter hour/day/year rollover
     sectionVoterRollover();
+
+    // --- Section: noisy-corpus regression (WS-3 exact-tuple degeneracy)
+    sectionVoterNoisyCorpus();
+
+    // --- Section: re-encoded-field weighting (field-min vs field-mean)
+    sectionVoterMinuteFadeWeighting();
 
     // --- WAV dump of the clean golden vector (opt-in via env var) + truth print
     if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -446,15 +446,12 @@ static void sectionVoterNoisyCorpus() {
     CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
     CHECK(v.lastFrameMinute() == 25);   // newest raw frame really is minute 25/yr 66
 
-    // Quality is coupled to the voted space: with the static votes rescued
-    // against confident wrong bits, lockConfidence dips out of the clean-lock
-    // band (measured ~0.898 — the faded minute frames vote their field-MIN margin
-    // ~0.05, so the residual dip is carried by the confident static misreads) yet
-    // stays a genuine lock. The absolute bound is loose; the strict dip vs the
-    // clean window below is the load-bearing check.
+    // Quality is coupled to the voted space: lockConfidence is the MINIMUM
+    // per-bit margin, so this window's several contested bits collapse it far out
+    // of the clean-lock band — measured ~0.292 — while the value is recovered.
     const float q = v.lockConfidence();
     CHECK(q > 0.0f && q <= 1.0f);
-    CHECK(q < 0.93f);
+    CHECK(q < 0.35f);
 
     // A clean 8-frame window over the same minutes votes the same timestamp at
     // strictly higher quality — the dip tracks the contention, not luck.
@@ -495,6 +492,48 @@ static void sectionVoterMinuteFadeWeighting() {
     CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
     CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
     CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+}
+
+// [wwvb.voter.contested-bit-quality] Mirror: the year-40 bit is flipped in the
+// four newest frames (raw year 26 -> 66); votedField votes 66 on recency, but a
+// single bit decided the field, so lockConfidence must collapse to that bit's
+// normalized margin (~0.208) rather than average it into the clean-lock band
+// (~0.974 under a mean over 31 bits).
+static void sectionVoterContestedBitQuality() {
+    std::array<float, 60> conf;
+    conf.fill(0.40f);
+
+    TimeFrameVoter v(wwvbVoterConfig());
+    for (int mn = 18; mn <= 21; ++mn) v.addFrame(wwvbVoterFrame(mn, 6, 200, 26), conf);
+    for (int mn = 22; mn <= 25; ++mn) v.addFrame(wwvbVoterFrame(mn, 6, 200, 66), conf);
+
+    CHECK(v.locked());
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 66);
+    const float q = v.lockConfidence();
+    CHECK(q > 0.0f);
+    CHECK(q <= 0.35f);
+    CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == 25);
+    CHECK(v.votedField(TimeFrameVoter::FieldHours)   == 6);
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+}
+
+// [wwvb.voter.doy366gate] Mirror: a confident newest frame decodes doy 366 in yr
+// 27 (2027 is not a leap year). advanceMinutes would wrap doy 366 into Jan 1 of
+// yr 28 (even at age 0), so the gate excludes it and the two clean frames hold
+// the vote at doy 200 / yr 27; without the gate the vote becomes doy 1 / yr 28.
+static void sectionVoterDoy366Gate() {
+    constexpr float C  = 0.35f;
+    constexpr float HI = 0.90f;
+    std::array<float, 60> cc;  cc.fill(C);
+    std::array<float, 60> chi; chi.fill(HI);
+
+    TimeFrameVoter v(wwvbVoterConfig());
+    v.addFrame(wwvbVoterFrame(23, 6, 200, 27), cc);
+    v.addFrame(wwvbVoterFrame(24, 6, 200, 27), cc);
+    v.addFrame(wwvbVoterFrame(25, 6, 366, 27), chi);  // doy 366 in a non-leap year
+
+    CHECK(v.votedField(TimeFrameVoter::FieldDoy)  == 200);
+    CHECK(v.votedField(TimeFrameVoter::FieldYear) == 27);
 }
 
 // ------------------------------------------------------------------------ main
@@ -644,6 +683,12 @@ int main() {
 
     // --- Section: re-encoded-field weighting (field-min vs field-mean)
     sectionVoterMinuteFadeWeighting();
+
+    // --- Section: quality honesty on a single decisive contested bit
+    sectionVoterContestedBitQuality();
+
+    // --- Section: doy-366-in-non-leap-year gate
+    sectionVoterDoy366Gate();
 
     // --- WAV dump of the clean golden vector (opt-in via env var) + truth print
     if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -280,6 +280,111 @@ static void checkAuxFields(const Capture& c, const FrameTruth& truth, int nFrame
     CHECK(matched >= nFrames);
 }
 
+// ---------------------------------------------- direct TimeFrameVoter rollover
+// Drive TimeFrameVoter directly with the NIST WWVB legacy-AM field map so the
+// whole-timestamp value vote is exercised across hour/day/year boundaries — the
+// case the golden audio vectors never reached (all stayed within one hour).
+
+using VMap = std::vector<std::pair<int, int>>;  // (second, weight)
+// WWVB field maps derived from encodeFrame's setBits placement (NIST SP 250-67).
+static const VMap kVbMin{{1,40},{2,20},{3,10},{5,8},{6,4},{7,2},{8,1}};
+static const VMap kVbHr {{12,20},{13,10},{15,8},{16,4},{17,2},{18,1}};
+static const VMap kVbDoy{{22,200},{23,100},{25,80},{26,40},{27,20},{28,10},
+                         {30,8},{31,4},{32,2},{33,1}};
+static const VMap kVbYr {{45,80},{46,40},{47,20},{48,10},{50,8},{51,4},{52,2},{53,1}};
+
+static TimeFrameVoter::Config wwvbVoterConfig() {
+    auto toFieldMap = [](const VMap& m) {
+        ClockFieldMap fm;
+        for (const auto& pr : m) fm.push_back(ClockBitWeight{pr.first, pr.second});
+        return fm;
+    };
+    TimeFrameVoter::Config cfg;
+    cfg.fields[TimeFrameVoter::FieldMinutes] = toFieldMap(kVbMin);
+    cfg.fields[TimeFrameVoter::FieldHours]   = toFieldMap(kVbHr);
+    cfg.fields[TimeFrameVoter::FieldDoy]     = toFieldMap(kVbDoy);
+    cfg.fields[TimeFrameVoter::FieldYear]    = toFieldMap(kVbYr);
+    cfg.markerSeconds = {0, 9, 19, 29, 39, 49, 59};
+    cfg.window = 8;
+    cfg.minFramesForLock = 2;
+    cfg.agingFactor = 0.9f;
+    return cfg;
+}
+
+static std::array<ClockSymbol, 60> wwvbVoterFrame(int mn, int hr, int doy, int yr) {
+    const FrameTruth t{mn, hr, doy, yr, /*dut1*/0, /*lyi*/false, /*lsw*/false, /*dst*/0};
+    const std::array<int, 60> s = encodeFrame(t);
+    std::array<ClockSymbol, 60> out{};
+    for (int i = 0; i < 60; ++i) {
+        out[i] = (s[i] == kSymOne)    ? ClockSymbol::One
+               : (s[i] == kSymMarker) ? ClockSymbol::Marker
+                                      : ClockSymbol::Zero;
+    }
+    return out;
+}
+
+// [wwvb.voter.rollover] Whole-timestamp value vote survives hour/day/year
+// rollovers; a mixed-hour window never votes an off-air hour.
+static void sectionVoterRollover() {
+    std::array<float, 60> conf; conf.fill(1.0f);
+
+    // (a) advanceMinutes helper is calendar-correct in isolation.
+    CHECK(advanceMinutes(TimeFields{59, 21, 200, 26}, 1) == (TimeFields{0, 22, 200, 26}));
+    CHECK(advanceMinutes(TimeFields{59, 23, 200, 26}, 1) == (TimeFields{0, 0, 201, 26}));
+    CHECK(advanceMinutes(TimeFields{59, 23, 365, 26}, 1) == (TimeFields{0, 0, 1, 27}));
+    CHECK(advanceMinutes(TimeFields{59, 23, 366, 28}, 1) == (TimeFields{0, 0, 1, 29}));
+
+    // (b) hour rollover 21:57 -> 22:02.
+    {
+        TimeFrameVoter v(wwvbVoterConfig());
+        struct MH { int mn, hr; };
+        for (const MH e : {MH{57,21}, {58,21}, {59,21}, {0,22}, {1,22}, {2,22}}) {
+            v.addFrame(wwvbVoterFrame(e.mn, e.hr, 200, 26), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == e.mn);
+            CHECK(v.votedField(TimeFrameVoter::FieldHours)   == e.hr);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == 200);
+            CHECK(v.votedField(TimeFrameVoter::FieldYear)    == 26);
+        }
+    }
+
+    // (c) day rollover 23:58 -> 00:01, doy 200 -> 201.
+    {
+        TimeFrameVoter v(wwvbVoterConfig());
+        struct MHD { int mn, hr, doy; };
+        for (const MHD e : {MHD{58,23,200}, {59,23,200}, {0,0,201}, {1,0,201}}) {
+            v.addFrame(wwvbVoterFrame(e.mn, e.hr, e.doy, 26), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldMinutes) == e.mn);
+            CHECK(v.votedField(TimeFrameVoter::FieldHours)   == e.hr);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)     == e.doy);
+        }
+    }
+
+    // (d) year rollover on doy 365 -> 1, yr 26 -> 27 (non-leap year length).
+    {
+        TimeFrameVoter v(wwvbVoterConfig());
+        struct T { int mn, hr, doy, yr; };
+        for (const T e : {T{58,23,365,26}, {59,23,365,26}, {0,0,1,27}, {1,0,1,27}}) {
+            v.addFrame(wwvbVoterFrame(e.mn, e.hr, e.doy, e.yr), conf);
+            CHECK(v.votedField(TimeFrameVoter::FieldDoy)  == e.doy);
+            CHECK(v.votedField(TimeFrameVoter::FieldYear) == e.yr);
+        }
+    }
+
+    // (e) bizarre-blend regression: 7 consecutive hour-21 frames then hour-22 —
+    //     voted hour must only ever be 21 or 22, never a per-bit-mixed value.
+    {
+        TimeFrameVoter v(wwvbVoterConfig());
+        struct MH { int mn, hr; };
+        for (const MH e : {MH{53,21}, {54,21}, {55,21}, {56,21}, {57,21}, {58,21},
+                           {59,21}, {0,22}, {1,22}, {2,22}}) {
+            v.addFrame(wwvbVoterFrame(e.mn, e.hr, 200, 26), conf);
+            const int h = v.votedField(TimeFrameVoter::FieldHours);
+            CHECK(h == 21 || h == 22);
+            CHECK(h == e.hr);
+        }
+    }
+}
+
 // ------------------------------------------------------------------------ main
 int main() {
     // Golden truth for the clean 3-frame vector: 06:20/06:21/06:22, doy 200,
@@ -418,6 +523,9 @@ int main() {
         for (const auto& f : c.frames) CHECK(f.minute != 22);
         for (const auto& t : c.times) CHECK(t.minute != 22);
     }
+
+    // --- Section: direct TimeFrameVoter hour/day/year rollover
+    sectionVoterRollover();
 
     // --- WAV dump of the clean golden vector (opt-in via env var) + truth print
     if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -640,6 +640,27 @@ int main() {
         CHECK(lockTransitions == 1);
     }
 
+    // --- Section: WS-4.5 — lock demotes on signal loss, cached vote stops
+    // (Live 2026-07-20 class: a stale Locked must never be pinned; dead air
+    // demotes and the per-second cached re-emission stops with it.)
+    {
+        const auto x = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0xD37Au);
+        WwvbDecoder d(24000);
+        Capture c; wire(d, c);
+        feedFixed(d, x, 512);
+        CHECK(d.state() == ClockLockState::Locked);      // precondition
+
+        const std::vector<float> silence(24000 * 240, 0.0f);
+        feedFixed(d, silence, 512);
+        CHECK(d.state() != ClockLockState::Locked);      // demoted, not pinned
+
+        // After the demotion no further voted times may be emitted.
+        const std::size_t nAtDemote = c.times.size();
+        const std::vector<float> moreSilence(24000 * 60, 0.0f);
+        feedFixed(d, moreSilence, 512);
+        CHECK(c.times.size() == nAtDemote);
+    }
+
     // --- Section: 16 dB envelope SNR bit-exact (assert the pinned floor)
     {
         const double sigma16 = (kCarrierAmp / std::sqrt(2.0)) / std::pow(10.0, kEnvSnrFloor / 20.0);

--- a/tests/wwvb_decoder_test.cpp
+++ b/tests/wwvb_decoder_test.cpp
@@ -1,0 +1,438 @@
+// WWVB legacy-AM decoder test (AetherClock WS-1).
+//
+// Self-contained: an in-file WWVB PWM synthesizer (per the pinned PRD-A §8
+// signal levels), a deterministic AWGN helper, a BPSK-phase-flip variant, and
+// a tiny std-only WAV writer. Exercises the frozen WwvbDecoder + TimeFrameVoter
+// contract against the NIST WWVB legacy-AM field map (NIST SP 250-67, MSB-first
+// weights, verified vs the frozen WS-1 spec table).
+//
+// Plain int main() + CHECK macro (NOT QtTest). No Qt. Only the two engine
+// headers + std.
+
+#include "core/WwvbDecoder.h"
+#include "core/TimeFrameVoter.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <random>
+#include <string>
+#include <vector>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_failures; } } while (0)
+
+// ------------------------------------------------------------------ constants
+constexpr int    kSR          = 24000;   // 24 kHz per the input contract
+constexpr double kCarrierHz   = 1000.0;  // 60 kHz -> ~1000 Hz audio tone
+constexpr double kCarrierAmp  = 0.5;     // full carrier amplitude (~ -6 dBFS)
+constexpr double kPi          = 3.14159265358979323846;
+constexpr double kWwvbDropDb  = 17.0;    // pinned power drop for a low-power bit
+constexpr double kWwvbAgcDb   = 12.0;    // AGC-compression robustness variant
+constexpr double kEnvSnrFloor = 16.0;    // pinned WWVB envelope-SNR floor (dB)
+
+// Symbol codes used by the synth timeline (mirror ClockSymbol Zero/One/Marker).
+constexpr int kSymZero = 0, kSymOne = 1, kSymMarker = 2;
+
+// ------------------------------------------------------------- frame encoding
+struct FrameTruth {
+    int  min, hr, doy, yr;
+    int  dut1Tenths;   // signed tenths of a second
+    bool lyi;          // leap-year indicator (s55)
+    bool lsw;          // leap-second warning (s56)
+    int  dstCode;      // 2-bit DST code: bit "2" = s57 (dst1), bit "1" = s58 (dst2)
+};
+
+// Encode one 60 s WWVB frame to per-second symbols (0/1/marker). MSB-first BCD
+// per the NIST WWVB time-code table; unused seconds stay binary 0.
+static std::array<int, 60> encodeFrame(const FrameTruth& t) {
+    std::array<int, 60> s;
+    s.fill(kSymZero);
+    for (int m : {0, 9, 19, 29, 39, 49, 59}) s[m] = kSymMarker;
+
+    // Set a decimal digit (0..9) into the seconds carrying binary weights 8,4,2,1
+    // (a second index of -1 means that weight is absent from the field).
+    auto setBits = [&](int value, const std::array<int, 4>& secs) {
+        const int w[4] = {8, 4, 2, 1};
+        for (int i = 0; i < 4; ++i)
+            if (secs[i] >= 0) s[secs[i]] = (value & w[i]) ? kSymOne : kSymZero;
+    };
+
+    // MIN: (1,40)(2,20)(3,10) tens; (5,8)(6,4)(7,2)(8,1) units
+    setBits(t.min / 10, {-1, 1, 2, 3});
+    setBits(t.min % 10, {5, 6, 7, 8});
+    // HR: (12,20)(13,10) tens; (15,8)(16,4)(17,2)(18,1) units
+    setBits(t.hr / 10, {-1, -1, 12, 13});
+    setBits(t.hr % 10, {15, 16, 17, 18});
+    // DOY: (22,200)(23,100) hundreds; (25,80)(26,40)(27,20)(28,10) tens; (30..33) units
+    setBits(t.doy / 100, {-1, -1, 22, 23});
+    setBits((t.doy / 10) % 10, {25, 26, 27, 28});
+    setBits(t.doy % 10, {30, 31, 32, 33});
+    // DUT1 sign: s36=+ s37=- s38=+  (positive -> 36 AND 38; negative -> 37)
+    if (t.dut1Tenths >= 0) { s[36] = kSymOne; s[37] = kSymZero; s[38] = kSymOne; }
+    else                   { s[36] = kSymZero; s[37] = kSymOne; s[38] = kSymZero; }
+    // DUT1 magnitude: (40,0.8)(41,0.4)(42,0.2)(43,0.1)
+    setBits(std::abs(t.dut1Tenths), {40, 41, 42, 43});
+    // YR: (45,80)(46,40)(47,20)(48,10) tens; (50,8)(51,4)(52,2)(53,1) units
+    setBits(t.yr / 10, {45, 46, 47, 48});
+    setBits(t.yr % 10, {50, 51, 52, 53});
+    // LYI s55, LSW s56, DST code s57/s58
+    s[55] = t.lyi ? kSymOne : kSymZero;
+    s[56] = t.lsw ? kSymOne : kSymZero;
+    s[57] = (t.dstCode >> 1) & 1 ? kSymOne : kSymZero;
+    s[58] = (t.dstCode & 1) ? kSymOne : kSymZero;
+    return s;
+}
+
+// Build a run of `nFrames` consecutive minutes, with `leadTail` seconds of the
+// previous minute in front (acquisition runway + the s59->s0 double marker at
+// the first frame boundary) and `leadOut` seconds of the following minute after
+// (so the last full frame's closing double marker exists and it can emit).
+static std::vector<int> buildTimeline(const FrameTruth& base, int nFrames,
+                                      int leadTail, int leadOut) {
+    std::vector<int> secs;
+    FrameTruth prev = base; prev.min = base.min - 1;
+    auto psym = encodeFrame(prev);
+    for (int s = 60 - leadTail; s < 60; ++s) secs.push_back(psym[s]);
+    for (int fi = 0; fi < nFrames; ++fi) {
+        FrameTruth ft = base; ft.min = base.min + fi;
+        auto sm = encodeFrame(ft);
+        for (int s = 0; s < 60; ++s) secs.push_back(sm[s]);
+    }
+    if (leadOut > 0) {
+        FrameTruth nxt = base; nxt.min = base.min + nFrames;
+        auto nsym = encodeFrame(nxt);
+        for (int s = 0; s < leadOut; ++s) secs.push_back(nsym[s]);
+    }
+    return secs;
+}
+
+// ------------------------------------------------------------------ synthesis
+// Low-power window duration (seconds) for a symbol: 0.2 s = 0, 0.5 s = 1, 0.8 s = marker.
+static double symbolLowSeconds(int sym) {
+    return sym == kSymZero ? 0.2 : sym == kSymOne ? 0.5 : 0.8;
+}
+
+// Render the symbol timeline to 24 kHz float mono. The carrier is a continuous
+// 1000 Hz tone at kCarrierAmp; amplitude drops `dropDb` at each second start for
+// the encoded duration, then returns to full (dropDb == 0 => pure carrier tone,
+// no PWM). `bpsk` adds a 180-degree carrier phase flip starting +100 ms after
+// each 1-bit second edge, WITHOUT touching the amplitude envelope (INV-8).
+// `sigma` > 0 adds deterministic AWGN.
+static std::vector<float> synth(const std::vector<int>& secs, double dropDb,
+                                bool bpsk, double sigma, std::uint64_t seed) {
+    const double drop = std::pow(10.0, -dropDb / 20.0);
+    const int flipStart = static_cast<int>(std::lround(0.100 * kSR));  // +100 ms
+    std::mt19937_64 rng(seed);
+    std::normal_distribution<double> noise(0.0, sigma > 0.0 ? sigma : 1.0);
+
+    std::vector<float> out;
+    out.reserve(secs.size() * static_cast<std::size_t>(kSR));
+    long long n = 0;
+    for (int sym : secs) {
+        const int lowSamples = static_cast<int>(std::lround(symbolLowSeconds(sym) * kSR));
+        for (int j = 0; j < kSR; ++j) {
+            const double amp = (j < lowSamples) ? drop : 1.0;
+            const double t = static_cast<double>(n) / kSR;
+            double carrier = std::sin(2.0 * kPi * kCarrierHz * t);
+            if (bpsk && sym == kSymOne && j >= flipStart) carrier = -carrier;
+            double v = amp * kCarrierAmp * carrier;
+            if (sigma > 0.0) v += noise(rng);
+            out.push_back(static_cast<float>(v));
+            ++n;
+        }
+    }
+    return out;
+}
+
+// Pure AWGN, no carrier.
+static std::vector<float> noiseVector(std::size_t nSamples, double sigma, std::uint64_t seed) {
+    std::vector<float> out(nSamples);
+    std::mt19937_64 rng(seed);
+    std::normal_distribution<double> nd(0.0, sigma);
+    for (auto& v : out) v = static_cast<float>(nd(rng));
+    return out;
+}
+
+// Envelope-SNR (dB) definition consistent with the pinned 16 dB floor: full
+// carrier RMS over the time-domain noise RMS.
+static double envelopeSnrDb(double carrierAmp, double sigma) {
+    const double carrierRms = carrierAmp / std::sqrt(2.0);
+    return 20.0 * std::log10(carrierRms / sigma);
+}
+
+// ------------------------------------------------------------------ WAV writer
+// Minimal std-only WAV: 16-bit PCM, stereo (duplicated mono), 24 kHz.
+static void writeWavStereo16(const std::string& path, const std::vector<float>& mono, int sr) {
+    std::ofstream f(path, std::ios::binary);
+    if (!f) return;
+    const std::uint16_t channels = 2, bits = 16;
+    const std::uint16_t blockAlign = channels * (bits / 8);
+    const std::uint32_t byteRate = static_cast<std::uint32_t>(sr) * blockAlign;
+    const std::uint32_t nFrames = static_cast<std::uint32_t>(mono.size());
+    const std::uint32_t dataBytes = nFrames * blockAlign;
+    const std::uint32_t riff = 36 + dataBytes;
+    auto w32 = [&](std::uint32_t v) {
+        char b[4] = {char(v & 0xff), char((v >> 8) & 0xff), char((v >> 16) & 0xff), char((v >> 24) & 0xff)};
+        f.write(b, 4);
+    };
+    auto w16 = [&](std::uint16_t v) {
+        char b[2] = {char(v & 0xff), char((v >> 8) & 0xff)};
+        f.write(b, 2);
+    };
+    f.write("RIFF", 4); w32(riff); f.write("WAVE", 4);
+    f.write("fmt ", 4); w32(16); w16(1); w16(channels);
+    w32(static_cast<std::uint32_t>(sr)); w32(byteRate); w16(blockAlign); w16(bits);
+    f.write("data", 4); w32(dataBytes);
+    for (float s : mono) {
+        double c = std::max(-1.0, std::min(1.0, static_cast<double>(s)));
+        const std::int16_t v = static_cast<std::int16_t>(std::lround(c * 32767.0));
+        w16(static_cast<std::uint16_t>(v));  // L
+        w16(static_cast<std::uint16_t>(v));  // R (duplicated mono)
+    }
+}
+
+// ---------------------------------------------------------------- capture/feed
+struct Capture {
+    std::vector<ClockFrameInfo> frames;
+    std::vector<ClockTimeInfo>  times;
+    std::vector<ClockLockState> states;
+    long secondCount = 0;
+    ClockLockState finalState = ClockLockState::NoSignal;
+    ClockStation   finalStation = ClockStation::Unknown;
+};
+
+static void wire(WwvbDecoder& d, Capture& c) {
+    d.onSecond       = [&](const ClockSecondInfo&) { ++c.secondCount; };
+    d.onFrame        = [&](const ClockFrameInfo& f) { c.frames.push_back(f); };
+    d.onTime         = [&](const ClockTimeInfo& t) { c.times.push_back(t); };
+    d.onStateChanged = [&](ClockLockState s) { c.states.push_back(s); };
+}
+
+static void feedFixed(WwvbDecoder& d, const std::vector<float>& x, std::size_t chunk) {
+    for (std::size_t i = 0; i < x.size(); i += chunk) {
+        const std::size_t c = std::min(chunk, x.size() - i);
+        d.process(x.data() + i, c);
+    }
+}
+
+// Deliberately irregular chunk sizes to exercise the streaming accumulator.
+static void feedIrregular(WwvbDecoder& d, const std::vector<float>& x) {
+    static const std::size_t sizes[] = {1, 7, 64, 999, 4096, 24000, 333, 2, 17000};
+    const std::size_t nSizes = sizeof(sizes) / sizeof(sizes[0]);
+    std::size_t i = 0, k = 0;
+    while (i < x.size()) {
+        std::size_t c = sizes[k % nSizes];
+        if (i + c > x.size()) c = x.size() - i;
+        d.process(x.data() + i, c);
+        i += c; ++k;
+    }
+}
+
+static Capture runFixed(const std::vector<float>& x) {
+    WwvbDecoder d; Capture c; wire(d, c);
+    feedFixed(d, x, 8192);
+    c.finalState = d.state(); c.finalStation = d.station();
+    return c;
+}
+
+static Capture runIrregular(const std::vector<float>& x) {
+    WwvbDecoder d; Capture c; wire(d, c);
+    feedIrregular(d, x);
+    c.finalState = d.state(); c.finalStation = d.station();
+    return c;
+}
+
+// --------------------------------------------------------------- shared checks
+static void checkVoted(const Capture& c, int min, int hr, int doy, int yr, const char* tag) {
+    CHECK(!c.times.empty());
+    if (c.times.empty()) { (void)tag; return; }
+    const ClockTimeInfo& tv = c.times.back();
+    CHECK(tv.minute == min);
+    CHECK(tv.hour   == hr);
+    CHECK(tv.doy    == doy);
+    CHECK(tv.year2  == yr);
+    CHECK(tv.station == ClockStation::Wwvb);
+    (void)tag;
+}
+
+// Per-frame auxiliary fields (not voted): DUT1 sign+magnitude, DST code, LYI, LSW.
+static void checkAuxFields(const Capture& c, const FrameTruth& truth, int nFrames) {
+    int matched = 0;
+    for (const auto& f : c.frames) {
+        if (f.minute < truth.min || f.minute > truth.min + nFrames - 1) continue;
+        ++matched;
+        CHECK(f.station == ClockStation::Wwvb);
+        CHECK(f.dut1Tenths == truth.dut1Tenths);
+        CHECK(f.dst1 == (((truth.dstCode >> 1) & 1) != 0));
+        CHECK(f.dst2 == ((truth.dstCode & 1) != 0));
+        CHECK(f.leapYear == truth.lyi);
+        CHECK(f.leapPending == truth.lsw);
+    }
+    CHECK(matched >= nFrames);
+}
+
+// ------------------------------------------------------------------------ main
+int main() {
+    // Golden truth for the clean 3-frame vector: 06:20/06:21/06:22, doy 200,
+    // yr 26; DUT1 = -0.3 s (negative sign path + magnitude 3), LYI set, LSW
+    // clear, DST code = 10 (begins today -> dst1 set, dst2 clear).
+    const FrameTruth kBase = {/*min*/20, /*hr*/6, /*doy*/200, /*yr*/26,
+                              /*dut1Tenths*/-3, /*lyi*/true, /*lsw*/false, /*dstCode*/2};
+    const int kFrames = 3;
+    const std::vector<int> cleanSecs = buildTimeline(kBase, kFrames, /*leadTail*/10, /*leadOut*/11);
+
+    // --- Section: clean bit-exact ALL fields + double-marker minute sync + lock
+    {
+        const auto x = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0xC10Cu);
+        const Capture c = runIrregular(x);  // irregular chunk sizes here
+
+        CHECK(c.finalState == ClockLockState::Locked);
+        CHECK(c.finalStation == ClockStation::Wwvb);
+        CHECK(c.secondCount > 0);
+        // Voted time is "as of the newest frame" -> minute 22.
+        checkVoted(c, /*min*/22, /*hr*/6, /*doy*/200, /*yr*/26, "clean");
+        checkAuxFields(c, kBase, kFrames);
+        // Minutes increment across the emitted frames (double-marker sync worked).
+        bool saw20 = false, saw21 = false, saw22 = false;
+        for (const auto& f : c.frames) {
+            if (f.minute == 20) saw20 = true;
+            if (f.minute == 21) saw21 = true;
+            if (f.minute == 22) saw22 = true;
+        }
+        CHECK(saw20 && saw21 && saw22);
+
+        // Callback sequencing: Acquiring before Locked; exactly one Locked transition.
+        bool sawAcquiring = false, acqBeforeLock = true;
+        int lockTransitions = 0;
+        for (ClockLockState s : c.states) {
+            if (s == ClockLockState::Acquiring) sawAcquiring = true;
+            if (s == ClockLockState::Locked) {
+                ++lockTransitions;
+                if (!sawAcquiring) acqBeforeLock = false;
+            }
+        }
+        CHECK(sawAcquiring);
+        CHECK(acqBeforeLock);
+        CHECK(lockTransitions == 1);
+    }
+
+    // --- Section: 16 dB envelope SNR bit-exact (assert the pinned floor)
+    {
+        const double sigma16 = (kCarrierAmp / std::sqrt(2.0)) / std::pow(10.0, kEnvSnrFloor / 20.0);
+        const double snr = envelopeSnrDb(kCarrierAmp, sigma16);
+        CHECK(snr >= kEnvSnrFloor - 1e-6);  // at/above the pinned floor
+
+        const auto x = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, sigma16, 0x5A1Fu);
+        const Capture c = runFixed(x);
+        CHECK(c.finalState == ClockLockState::Locked);
+        checkVoted(c, 22, 6, 200, 26, "snr16");
+        checkAuxFields(c, kBase, kFrames);
+    }
+
+    // --- Section: 12 dB depth (AGC compression) bit-exact
+    {
+        const auto x = synth(cleanSecs, kWwvbAgcDb, /*bpsk*/false, /*sigma*/0.0, 0xA6Cu);
+        const Capture c = runFixed(x);
+        CHECK(c.finalState == ClockLockState::Locked);
+        checkVoted(c, 22, 6, 200, 26, "agc12");
+        checkAuxFields(c, kBase, kFrames);
+    }
+
+    // --- Section: BPSK-flip vector -> envelope IDENTICAL, decode unchanged (INV-8)
+    {
+        const auto clean = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0xB0B0u);
+        const auto flip  = synth(cleanSecs, kWwvbDropDb, /*bpsk*/true,  /*sigma*/0.0, 0xB0B0u);
+        CHECK(clean.size() == flip.size());
+        // Amplitude envelope must be byte-for-byte identical: the phase flip only
+        // changes carrier sign, so |sample| is unchanged.
+        double maxEnvDiff = 0.0;
+        for (std::size_t i = 0; i < clean.size(); ++i)
+            maxEnvDiff = std::max(maxEnvDiff,
+                                  std::fabs(static_cast<double>(std::fabs(clean[i])) -
+                                            static_cast<double>(std::fabs(flip[i]))));
+        CHECK(maxEnvDiff < 1e-6);
+
+        const Capture cc = runFixed(clean);
+        const Capture cf = runFixed(flip);
+        CHECK(cc.finalState == ClockLockState::Locked);
+        CHECK(cf.finalState == ClockLockState::Locked);
+        CHECK(!cc.times.empty());
+        CHECK(!cf.times.empty());
+        if (!cc.times.empty() && !cf.times.empty()) {
+            CHECK(cc.times.back().minute == cf.times.back().minute);
+            CHECK(cc.times.back().hour   == cf.times.back().hour);
+            CHECK(cc.times.back().doy    == cf.times.back().doy);
+            CHECK(cc.times.back().year2  == cf.times.back().year2);
+        }
+        CHECK(cc.frames.size() == cf.frames.size());
+    }
+
+    // --- Section: noise-only (>= 5 minutes of pure AWGN) -> NEVER locks
+    {
+        const std::size_t fiveMin = static_cast<std::size_t>(5 * 60) * kSR;
+        const auto x = noiseVector(fiveMin, 0.2, 0xDEADu);
+        const Capture c = runFixed(x);
+        CHECK(c.finalState != ClockLockState::Locked);
+        CHECK(c.times.empty());
+        for (ClockLockState s : c.states) CHECK(s != ClockLockState::Locked);
+    }
+
+    // --- Section: carrier-tone-only (no PWM) -> stays Acquiring, NEVER Locked
+    {
+        const auto x = synth(cleanSecs, /*dropDb*/0.0, /*bpsk*/false, /*sigma*/0.0, 0x7C0Eu);
+        const Capture c = runFixed(x);
+        CHECK(c.finalState == ClockLockState::Acquiring);
+        CHECK(c.times.empty());
+        for (ClockLockState s : c.states) CHECK(s != ClockLockState::Locked);
+    }
+
+    // --- Section: corrupted markers -> no false lock
+    {
+        std::vector<int> corrupt = cleanSecs;
+        for (int& s : corrupt) if (s == kSymMarker) s = kSymZero;  // destroy every marker
+        const auto x = synth(corrupt, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0xC0FFu);
+        const Capture c = runFixed(x);
+        CHECK(c.finalState != ClockLockState::Locked);
+        CHECK(c.times.empty());
+        for (ClockLockState s : c.states) CHECK(s != ClockLockState::Locked);
+    }
+
+    // --- Section: truncated final frame -> no partial-field emission
+    {
+        // lead-in(10) + frame20(60) + frame21(60) + 30 s of frame22 (cut off).
+        std::vector<int> secs = buildTimeline(kBase, kFrames, /*leadTail*/10, /*leadOut*/0);
+        const std::size_t keep = 10 + 60 + 60 + 30;
+        if (secs.size() > keep) secs.resize(keep);
+        const auto x = synth(secs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0x7A11u);
+        const Capture c = runFixed(x);
+        // The truncated minute (22) must never surface as a completed frame or vote.
+        for (const auto& f : c.frames) CHECK(f.minute != 22);
+        for (const auto& t : c.times) CHECK(t.minute != 22);
+    }
+
+    // --- WAV dump of the clean golden vector (opt-in via env var) + truth print
+    if (const char* dir = std::getenv("AETHERCLOCK_DUMP_WAV_DIR")) {
+        const auto golden = synth(cleanSecs, kWwvbDropDb, /*bpsk*/false, /*sigma*/0.0, 0xC10Cu);
+        std::string path = std::string(dir) + "/wwvb_golden.wav";
+        writeWavStereo16(path, golden, kSR);
+        std::printf("golden truth: min=%d hr=%d doy=%d yr=%d frames=%d\n",
+                    kBase.min, kBase.hr, kBase.doy, kBase.yr, kFrames);
+        std::printf("wrote %s\n", path.c_str());
+    }
+
+    if (g_failures) {
+        std::fprintf(stderr, "wwvb_decoder_test: %d check(s) failed\n", g_failures);
+        return 1;
+    }
+    std::printf("wwvb_decoder_test: all checks passed\n");
+    return 0;
+}

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -245,7 +245,7 @@ TOOLS = [
             "Live JSON snapshot of app/radio state — assert on state "
             "without screenshots. model = audio | dsp | radio | "
             "transmit | slice <selector: id|active|tx> | slices | pan "
-            "<selector: id|active> | pans | flags | kiwi | sync. "
+            "<selector: id|active> | pans | flags | kiwi | sync | clock. "
             "Optional `property` returns just that field."),
         "inputSchema": {"type": "object", "properties": {
             "model": {"type": "string"},


### PR DESCRIPTION

## Summary

Core (no-GUI) engine for **AetherClock**: decode NIST time signals — WWV/WWVH (HF, 100 Hz-subcarrier BCD) and WWVB (60 kHz legacy AM/PWM) — from a user-chosen RX slice's DAX audio, and expose the decoded broadcast time, host-clock offset, and per-second alignment data through a first-class model and the automation bridge (`get clock`). The GUI applet (channel strip, alignment display) follows in a stacked PR.

The goal of this first sprint is deliberately narrow: a **super-stable, accurate, trustable WWV-class decode engine** that the project can expand on. Most of the engineering below is about *earning* the word "trustable" — the decode path is straightforward DSP; the hard part is making sure the engine can never confidently report a wrong time, and every defense in it was forced by a real failure we caught in our own adversarial QA before opening this PR.

## Why

- FT8/JS8-class modes need the host clock within ~±1 s; off-grid stations have no NTP/GPS. Decoding broadcast time signals from the radio already on the desk closes that gap (resolves to tens of ms), with no privileges and no OS-clock writes — display/verification only.
- Radio GPS (where fitted) disciplines the radio, never the host clock; as AetherSDR grows beyond Flex, most backends will have no GPS at all. The engine is deliberately source-agnostic: any 24 kHz float32-stereo feed drives it through the same two seams (a DAX-hold provider callback pair + the PCM ingest slot).

## How the decoder works

<details open>
<summary><b>Signal chain — from DAX audio to classified seconds (diagram)</b></summary>

```mermaid
flowchart TD
    A["DAX RX audio 24 kHz float32 stereo"] --> B["Downmix + decimate to symbol series rate"]
    B --> C["Biquad bandpass at the station subcarrier"]
    C --> D["Coherent demod to amplitude envelope"]
    D --> E["Leaky 1 Hz tick fold, tau approx 100 s"]
    E --> F{"Tick phase locked?"}
    F -- "no" --> E
    F -- "yes" --> G["Cut 1 s windows on the tick boundary"]
    G --> H["Matched-filter classify: 170 / 470 / 770 ms pulse templates"]
    H --> I["Per-second symbol + confidence margin"]
    I --> J["Alignment display feed (ClockSecondInfo)"]
    I --> K["Marker-skeleton frame anchor"]
    K --> L["Per-frame BCD field decode (NIST tables)"]
    L --> M["TimeFrameVoter (8-frame window)"]
    M --> N{"Lock gates pass?"}
    N -- "yes" --> O["Voted UTC + quality + host offset"]
    N -- "no" --> P["Acquiring / demotion"]
```

</details>

**Per-second classification.** WWV/WWVH carries its time code on a 100 Hz subcarrier: each second is one pulse of 170 ms (Zero), 470 ms (One), or 770 ms (Marker). The decoder bandpasses and coherently demodulates the subcarrier, folds the envelope at 1 Hz into a leaky accumulator (τ≈100 s) to find the tick phase, then cuts exact 1 s windows and correlates each against zero-mean templates of the three pulse shapes. The winning template is the symbol; **confidence = best-minus-runner-up correlation margin**. WWVB's legacy AM code is the same idea with PWM classes (0.2/0.5/0.8 s) on the 60 kHz carrier envelope. Streaming biquads add fixed group delay and DAX adds unknown latency, so all templates correlate at a **common start-shift per second** with a slowly-tracked delay estimate — the estimate keeps moving after settling, which is what absorbs slow sample-clock drift.

**Honest-display contract.** Classified seconds are only emitted while the tick-phase lock holds. When structure proves the alignment wrong — the drift estimate hits its search rails, or three consecutive frames contradict the marker skeleton — the decoder performs a *soft reacquire*: it forgets all timing state and demotes to Acquiring rather than continuing to classify misaligned windows. A frozen display that says "acquiring" is the designed alternative to a moving display full of confidently misread bits.

**Frame anchoring and field decode.** Markers arrive at fixed seconds-of-frame; the anchor is found by matching the observed marker skeleton, and (for WWV, whose skeleton is degenerate mod 10 s) disambiguated by field content. Each completed frame then decodes minute/hour/day-of-year/year straight from the public NIST BCD tables, plus DUT1, DST, and leap bits. Frame decodes are raw and unfiltered at this stage — cleaning them up is the voter's job, and keeping the two stages separate is what makes each auditable.

<details open>
<summary><b>The voter — how eight noisy frames become one trustable timestamp (diagram)</b></summary>

```mermaid
flowchart TD
    A["Sliding window: last 8 frame decodes with per-bit confidences"] --> B["Normalize: advance every frame's full timestamp to the newest epoch with calendar arithmetic"]
    B --> C["Per field: held-value vote — each frame votes the value it actually carries"]
    B --> D["Per field: per-bit confidence-weighted vote"]
    D --> E{"Every bit coherent? (confidence winner == count majority)"}
    E -- "no" --> F["Fall back to top held value; quality capped by held-value margin"]
    E -- "yes" --> G{"Composed value held by some frame?"}
    G -- "no" --> F
    G -- "yes" --> H["Emit composed value; quality = weakest voted bit's trust"]
    H --> I["Field values + field qualities from ONE pass"]
    F --> I
    I --> J["Lock gates"]
```

</details>

**Why the voting works this way.** The design is the survivor of every simpler design failing against real signal, in order:

- *Per-bit voting over "static" fields* fails at rollovers: after an hour boundary the stale majority outvotes the new hour for window-length minutes, and cross-frame bit-blending can emit an hour **no frame carried**. We watched this live: a correct 21:59:59 lock decayed to 21:00:59 and then 20:02:59 — a value never on air.
- *Exact whole-tuple voting* (the obvious fix) fails on noisy signal: when every frame is corrupt *differently*, no tuple repeats, and the vote degenerates to the newest corrupt frame — confident garbage. Our banked live corpus caught this before it shipped.
- The synthesis is **normalize-then-per-bit**: age-extrapolate every frame's full timestamp to the newest epoch (calendar-correct, so rollovers vanish as a special case), then vote per-bit with original margins so single-bit fades lose to the healthy majority — with two guards that make composition honest:
  - **Coherence gate:** a bit only composes if its confidence-weighted winner agrees with its aging-only count majority — the signature that separates fade-rescue from phantom assembly.
  - **Held-value membership:** even an all-coherent compose must produce a value some frame actually held; rotating misreads that win each bit from a *different* frame camp otherwise assemble a value nobody sent. Anything not held falls back to the top held value, whose contested margin honestly refuses the lock.
- **Quality is computed in the same pass as the value** — `computeResolution()` returns both — so quality structurally cannot certify a different value than the one emitted. Three separate historical defects were all value/quality decoupling through different doors; this closes the class.
- **Quality = the weakest voted bit** (margin × participation), never a mean: a mean over 31 bits dilutes one decisive contested bit 30:1.

<details open>
<summary><b>Lock gates — what must all be true before the engine claims a time (diagram)</b></summary>

```mermaid
flowchart TD
    A["Candidate voted timestamp + quality"] --> B{"Minute increment chain across the window?"}
    B -- "no" --> X["No lock / demote"]
    B -- "yes" --> C{"Quality >= lock floor?"}
    C -- "no" --> X
    C -- "yes" --> D{"Range-valid frame within the newest 3 window slots?"}
    D -- "no" --> X
    D -- "yes" --> E{"Winning side of every field carries at least one genuinely confident vote?"}
    E -- "no" --> X
    E -- "yes" --> F{"Within 24 h of the engine-injected host reference?"}
    F -- "no" --> X
    F -- "yes" --> L["Locked: emit voted UTC + offset"]
```

</details>

**Why each gate exists** (each one is a scar, not a precaution):

| Gate | The failure it prevents (all observed live or in refuter review) |
|---|---|
| Increment chain | Random garbage never counts up correctly minute over minute |
| Trust floor (one confident vote per field) | A deep fade zero-biases the *same* bits in every frame — the misread is unanimous, so disagreement-based quality scores it 1.0. Unanimity of noise-grade reads is not evidence. This produced a q100 lock on a date 20 years in the past during an overnight soak. |
| Quality floor | Calibrated below the dirty-but-correct band of the real corpus, above garbage |
| Staleness bound + no dead reckoning | Range-invalid frames used to vanish from the window, letting stale survivors extrapolate forward +1 min/frame at q1.00 — a confidently advancing timestamp decoded from nothing. Invalid frames now keep their slot and count against participation. |
| Plausibility (±24 h vs host reference) | Systematic zero-bias produces *self-consistent* wrong decades (2006-01-01, incrementing). Self-consistency proves consistency, not truth; an independent reference is the only evidence that can veto it. Lock-gating only — the decoded value is never snapped toward the host, since "the host clock is wrong" is the product premise. |
| Two-way demotion | Lock is revocable: voter unlock demotes both decoders, cached re-emission stops, and the (stacked-PR) display stops ticking the moment the engine stops knowing. |

## How the decode earned trust — six rounds of adversarial QA

We gated this branch with a banked real-signal corpus regression, independent adversarial refuter reviews of the voter, and multi-hour live soaks. Six distinct defect classes were caught and fixed *before this PR opened*, every one with a fail-first regression vector (red on the pre-fix code, green on the fix):

1. **Rollover safety** (live QA) — per-bit "static field" voting blended hours across the boundary → value-level normalize-then-vote with calendar carry; synthetic vectors cross hour, day+DOY, and year boundaries.
2. **Noisy-window degeneracy** (corpus regression) — exact-tuple voting collapsed to the newest corrupt frame → normalize-then-per-bit with field-MIN re-encode weighting.
3. **Quality dilution** (refuter review) — mean-of-31-bits hides one decisive bit → quality = weakest voted bit.
4. **Phantom composition** (fresh refuter on the fixed code) — per-bit blend of two camps emits a third value → coherence gating; value+quality from one pass.
5. **Lock honesty** (overnight live soak) — unanimous systematic misread held a q100 lock on 2006-01-01, 45 min stale, display drifted off the pulses → trust floor, plausibility gate, staleness bound, drift absorption with soft reacquire, two-way demotion.
6. **Rotating phantom assembly** (fourth refuter round) — all-coherent rotating misreads compose a value no frame held → held-value membership on the compose path. A stash A/B on both live corpora proved the guard corpus-neutral: on real signal, fade-rescue always composed held values; the check fires only on phantoms.

A final independent refuter review of the shipping code returned **NOT REFUTED** across eight attack angles (composition integrity, quality/value coupling, floor edge-cases, plausibility bypass, staleness, participation, boundary conditions, unlock re-emission) — including an empirical trace that the armed plausibility gate refuses the wrong-year emissions an *ungated* test harness accepts.

## Scope

- **All-new:** `src/core/{WwvDecoder,WwvbDecoder,TimeFrameVoter,AetherClockEngine,AetherClockSettings}.{h,cpp}`, `src/core/ClockAlignmentFrame.h`, `src/models/AetherClockModel.{h,cpp}`, 4 test suites.
- **Registration-only edits (4 surfaces):** `PanadapterStream` (`DaxConsumer::Clock = 3` + name + snapshot holder), `AutomationServer` (`get clock` read-only snapshot; admitted under the observe-only policy's existing `get` allowlist, served before the radio guard so it works disconnected), `CMakeLists.txt`, `aether_mcp.py` (help string). Plus `docs/automation-bridge.md` rows for the new model.
- Engine conveniences the applet builds on: **slice-scoped station presets** (all-or-nothing, refused on a locked slice) and a **lock-decay watchdog** (a lock that stops earning evidence demotes instead of lingering).
- No protocol change, no persistence-format change beyond one new nested-JSON settings key, no UX change (no GUI in this PR).
- Engine-boundary ratchet stays clean (`check_engine_boundary.py --strict` exit 0): the engine holds DAX through an injected provider wrapping the central `acquireDaxChannel/releaseDaxChannel(ch, DaxConsumer::Clock)` registry — no vendor include above the seam, no private stream registration.

## Constitution principle honored

**Principle IV — Every Contribution Is Clean-Room.** Decode logic derives solely from the public NIST time-code specifications (WWV/WWVH per NIST SP 432; WWVB legacy AM per NIST SP 250-67) and our own live-verified prototypes; code comments cite spec only. Independently-authored Python references cross-check the C++ decoders bit-for-bit on golden vectors, and both were validated against real off-air captures from a FLEX-6700 (WWV 10 MHz; WWVB 60 kHz on an RF-loop test antenna) decoding to the exact wall-clock minute.

Also load-bearing: **V** (one nested-JSON `"AetherClock"` settings object, no flat keys), **II/III** (radio stays authoritative — nothing radio-side is persisted or overridden; the convenience preset only commands the live bound slice and is all-or-nothing lock-guarded), **VI** (RX-only; no transmit path).

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] 4 new test binaries green (Linux, Nobara 43, Qt 6.10.3, gcc 16): decoder golden vectors (≥3 consecutive incrementing frames, both stations, pinned SNR floors asserted in-test), negative fail-safes (noise-only never locks, marker corruption, WWV decade-degeneracy, WWVB BPSK-flip immunity), engine end-to-end synth decode (offset vs injected host clock ±60 ms, DAX-hold lifecycle/reassign/slice-loss via the real central registry), model property/signal semantics.
- [x] Every hardening round proven **fail-first**: each fix's vectors are red on the pre-fix code and green on the fix — rollover boundaries (hour / day+DOY / year / stale-blend), noisy-window degeneracy, weakest-bit quality, phantom composition, rotating-phantom membership, unanimous-fade trust floor, plausibility plumb, dead reckoning, demote-on-silence, gap-heal + re-lock, slow-drift hold.
- [x] Full suite ≥ baseline: zero regressions (the sole pre-existing red, `cross_needle_meter_test`, is upstream-known and unrelated).
- [x] Live-corpus regression (local captures, not in repo): WWV 9-min capture → exact wall-clock decode; WWVB 401 s RF-loop capture → quality 1.000 exact decode; C++ and independent Python references agree on both; re-gated after every voter round.
- [x] Live on-air (FLEX-6700, DAX chain end-to-end): **two hour-rollovers tracked** — midnight UTC (hour + DOY + date advance simultaneously) and 02:00 UTC on a 40-minute continuous hold, offsets stable within a ±35 ms band; **12-hour continuous soak** on the final build still locked and honest at wrap (quality ~78, offset −162 ms, decoded UTC == wall clock).
- [x] Multi-hour run on macOS against a real FLEX-6700 by the licensed operator (K6OZY), including observed fade → soft-reacquire → re-lock cycles behaving per the honest-display contract.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — NIST public specs + our own prototypes only (Principle IV)
- [x] All meter UI uses `MeterSmoother` — N/A: no meter/GUI code in this PR
- [x] Documentation updated — `docs/automation-bridge.md` documents the `get clock` model
- [x] Security-sensitive changes reference a GHSA — N/A

## Added since draft — acquisition telemetry (2026-07-22)

A new-user field report ("listening for hours, no locks, no feedback — sit or give up?") exposed that everything answering that question was computed and then discarded below the engine boundary. This adds read-only exposure — **zero decode-behavior change**, proven by a stash A/B on both banked live corpora (bit-identical decode outputs pre/post):

- **`ClockDiagnostics`** — a NEW parallel struct (the frozen `ClockAlignmentFrame` contract is untouched): carrier SNR / PWM contrast, timing sync + tracked delay, frame anchor + bad-frame streak, an engine-side %-classified ring, and voter window occupancy + raw quality. Emitted at ~1 Hz while running; the decoders assemble their half ON CALL from state they already keep, so the per-sample path gains nothing.
- **Tagged lock refusals** — `TimeFrameVoter::locked()` refactored into a single `lockVerdict()` pass with each *existing* refusal branch tagged (`None / QualityFloor / Plausibility / Staleness / Contested`). Same gates, same order; `locked()` and `lockRefusal()` read one verdict so they structurally cannot disagree. The new refusal-tag asserts ran red against a deliberately unmapped verdict first (fail-first), and the WS-4.5 refusal regressions (unanimous-fade, plausibility, dead-reckoning) now assert their exact tag.
- **`frameDecoded` re-emission** — per-frame `ClockFrameInfo` (frameConfidence, DUT1, DST, leap) previously died at the engine boundary; it now reaches the model and GUI.
- **`get clock` extended** (additive JSON; existing keys unchanged) with the full telemetry set — documented in `docs/automation-bridge.md`.
- **`lcClock`** logging category (`aether.clock`) and a `debugLogVisible` field in the existing AetherClock settings blob (Principle V — no flat keys).

Live on the FLEX-6700 during this session: enable → carrier + tick sync within seconds → 100 % of seconds classified through marker search → anchored → 2/8 frames → **Locked in ~2.4 min** (decoded == wall clock, offset −139 ms), every stage asserted through `get clock`.

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-fable-5)

