### PR TITLE
[tci] Send DRIVE/TUNE_DRIVE replies with the TRX argument (SIGSEGV)

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -82,6 +82,22 @@ SliceModel* TciProtocol::sliceForTrx(int trx) const
     return slices.isEmpty() ? nullptr : slices.first();
 }
 
+// TRX index of the TX slice for the init burst and the DRIVE/TUNE_DRIVE
+// replies. Falls back to 0 when no slice is marked TX, because the wire needs
+// a concrete index and 0 is what the burst has always used.
+int TciProtocol::txTrx() const
+{
+    if (!m_model) {
+        return 0;
+    }
+    for (auto* s : m_model->slices()) {
+        if (s->isTxSlice()) {
+            return tciTrxForSlice(m_model, s);
+        }
+    }
+    return 0;
+}
+
 // DDS = the IQ-stream center frequency a skimmer (CW Skimmer / SDC) decodes
 // against. On FlexRadio the DAX IQ stream is a *panadapter* stream centered on
 // the pan, not the slice (FlexLib: DAXIQChannel is a Panadapter property), so
@@ -236,19 +252,13 @@ QString TciProtocol::generateInitBurst()
         // Global TX state
         auto& tx = m_model->transmitModel();
         bool isTx = tx.isTransmitting();
-        int txTrx = 0;
-        for (auto* s : slices) {
-            if (s->isTxSlice()) {
-                txTrx = tciTrxForSlice(m_model, s);
-                break;
-            }
-        }
+        const int txTrxIdx = txTrx();
         // ESDR3 format requires TRX index prefix for drive commands.
         // Without it, WSJT-X/JTDX crash parsing args.at(1) on a 1-element list.
-        burst += QStringLiteral("drive:%1,%2;").arg(txTrx).arg(tx.rfPower());
-        burst += QStringLiteral("tune_drive:%1,%2;").arg(txTrx).arg(tx.tunePower());
+        burst += QStringLiteral("drive:%1,%2;").arg(txTrxIdx).arg(tx.rfPower());
+        burst += QStringLiteral("tune_drive:%1,%2;").arg(txTrxIdx).arg(tx.tunePower());
         burst += QStringLiteral("mic_level:%1;").arg(tx.micLevel());
-        burst += QStringLiteral("trx:%1,%2;").arg(txTrx).arg(isTx ? "true" : "false");
+        burst += QStringLiteral("trx:%1,%2;").arg(txTrxIdx).arg(isTx ? "true" : "false");
 
         // Master AF volume — whole-radio (no trx prefix), same saved value
         // cmdVolume's GET returns, reported in dB per the TCI spec
@@ -567,18 +577,45 @@ QString TciProtocol::cmdTune(const QStringList& args, bool isSet)
 
 // ── DRIVE: get/set RF power ────────────────────────────────────────────────
 
-// DRIVE and TUNE_DRIVE are global commands per the TCI v2.0 spec — they have
-// no TRX prefix. Spec form: `drive;` for GET, `drive:N;` for SET. The
-// dispatcher's isSet heuristic (args.size() >= 2) is wrong for globals
-// (treats `drive:50;` as a GET). We override here: any args at all = SET,
-// no args = GET. We also accept the legacy TRX-prefixed form `drive:0,N;`
-// for backward compatibility — when 2+ args arrive, we take args[1] as the
-// value and ignore the trx index (drive is global anyway).
+// TCI v2.0 defines these as per-transceiver, not global:
+//
+//   Set    DRIVE:arg1,arg2;    arg1 — transceiver ordinal
+//   Read   DRIVE:arg1;         arg2 — output power, 0..100
+//   Reply  DRIVE:arg1,arg2;
+//
+// Every reply below therefore carries the trx. Do not "simplify" it back to a
+// single argument: AetherSDR advertises `protocol:ExpertSDR3,1.5`, which sets
+// the ESDR3 flag in WSJT-X/JTDX, and their handler is
+//
+//     if((!ESDR3 && !HPSDR) || args.at(0)==rx_) {
+//         if (ESDR3 || HPSDR) drive_ = args.at(1);
+//
+// so a 1-element list reaches args.at(1) and segfaults them whenever args[0]
+// equals the client's own receiver index — `drive:0;` reliably killed WSJT-X
+// 3.0.1, reproduced on a FLEX-6600 while investigating #4161. Same reason the
+// init burst has been prefixed since aa132320.
+//
+// One deviation remains, left alone because fixing it is client-visible: the
+// spec's Read is `DRIVE:arg1;` (read TRX arg1), while we treat a lone argument
+// as the power VALUE, so a spec-compliant `DRIVE:0;` read SETS power to 0.
+// Pre-existing; tracked separately.
+//
+// Current behaviour otherwise unchanged: no args = GET, any args = SET; with
+// 2+ args we take args[1] as the value and ignore the incoming trx index.
+//
+// The trx we report is the TX slice's (txTrx()), not the index the client
+// asked about: DRIVE is the power of a transmitter, and the reply names which
+// transmitter that is. One consequence worth knowing — an ESDR3 client guards
+// on `args.at(0)==rx_`, so when the TX slice is not trx 0 a client sitting on
+// receiver 0 ignores the update. That is not a regression: the old
+// one-argument `drive:75;` failed the same guard whenever 75 != rx_. It also
+// keeps these replies consistent with the init burst, which has reported
+// txTrx since aa132320.
 QString TciProtocol::cmdDrive(const QStringList& args, bool /*isSet*/)
 {
     if (args.isEmpty()) {
         int pwr = m_model ? m_model->transmitModel().rfPower() : 0;
-        return QStringLiteral("drive:%1;").arg(pwr);
+        return QStringLiteral("drive:%1,%2;").arg(txTrx()).arg(pwr);
     }
     bool ok;
     int pwr = args[args.size() == 1 ? 0 : 1].toInt(&ok);
@@ -587,7 +624,7 @@ QString TciProtocol::cmdDrive(const QStringList& args, bool /*isSet*/)
         model->transmitModel().setRfPower(pwr);
     }, Qt::QueuedConnection);
 
-    m_pendingNotification = QStringLiteral("drive:%1;").arg(pwr);
+    m_pendingNotification = QStringLiteral("drive:%1,%2;").arg(txTrx()).arg(pwr);
     return {};
 }
 
@@ -597,7 +634,7 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
 {
     if (args.isEmpty()) {
         int pwr = m_model ? m_model->transmitModel().tunePower() : 0;
-        return QStringLiteral("tune_drive:%1;").arg(pwr);
+        return QStringLiteral("tune_drive:%1,%2;").arg(txTrx()).arg(pwr);
     }
     bool ok;
     int pwr = args[args.size() == 1 ? 0 : 1].toInt(&ok);
@@ -606,7 +643,8 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
         model->transmitModel().setTunePower(pwr);
     }, Qt::QueuedConnection);
 
-    m_pendingNotification = QStringLiteral("tune_drive:%1;").arg(pwr);
+    m_pendingNotification =
+        QStringLiteral("tune_drive:%1,%2;").arg(txTrx()).arg(pwr);
     return {};
 }
 
@@ -614,10 +652,15 @@ QString TciProtocol::cmdTuneDrive(const QStringList& args, bool /*isSet*/)
 
 // mic_level bridges TransmitModel::setMicLevel() (the existing radio-side
 // setter wired into FlexLib via commandReady) to TCI clients.  Single arg
-// 0-100 (percent), global — mic is whole-radio, not per-trx — matching the
-// drive/tune_drive convention.  Accepts the legacy TRX-prefixed form
-// `mic_level:0,N;` for forward compatibility with strict-spec clients (the
-// trx index is ignored since mic is global).
+// 0-100 (percent), global — mic is whole-radio, not per-trx.  Accepts the
+// legacy TRX-prefixed form `mic_level:0,N;` for forward compatibility with
+// strict-spec clients (the trx index is ignored since mic is global).
+//
+// The single-argument reply is the same shape that crashes ESDR3 clients on
+// DRIVE (see the cmdDrive comment). It is left alone here because whether
+// WSJT-X/JTDX parse MIC_LEVEL at all is unconfirmed — do not change it by
+// symmetry with drive without reading their handler first. Follow-up to be
+// filed.
 //
 // Added 2026-05-27 to unblock the aethersdr-ulanzi-plugin Mic Gain ▲▼ keys,
 // which already send the verb but currently land on a missing dispatcher
@@ -643,8 +686,9 @@ QString TciProtocol::cmdMicLevel(const QStringList& args, bool /*isSet*/)
 
 // tx_gain is an AetherSDR extension — not in the TCI v2.0 spec. It controls
 // TciServer's outbound TX gain (m_txGain), applied to WSJT-X/JTDX audio before
-// the radio. Global command, 0-100 (percent of unity), matching the
-// drive/tune_drive convention. Like cmdVolume, TciProtocol cannot reach
+// the radio. Global command, 0-100 (percent of unity) — being an AetherSDR
+// extension, no client parses it against a spec table, so the single-argument
+// reply carries none of the DRIVE risk. Like cmdVolume, TciProtocol cannot reach
 // TciServer directly, so a SET stashes the value in m_pendingTxGain and
 // TciServer applies it via setTxGain() after handleCommand() returns.
 QString TciProtocol::cmdTxGain(const QStringList& args, bool /*isSet*/)

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -114,6 +114,9 @@ private:
 
     // Helpers
     SliceModel* sliceForTrx(int trx) const;
+    // TRX index of the current TX slice, 0 when none is marked. Used to build
+    // the spec's two-argument DRIVE/TUNE_DRIVE replies.
+    int txTrx() const;
 
 public:
     // Mode conversion (public for TciServer broadcast use)

--- a/tests/tci_protocol_test.cpp
+++ b/tests/tci_protocol_test.cpp
@@ -49,6 +49,42 @@ int main(int argc, char** argv)
         }
     }
 
+    // DRIVE/TUNE_DRIVE replies must carry the TRX argument. WSJT-X and
+    // JTDX are put in ESDR3 mode by our `protocol:ExpertSDR3,1.5;` greeting,
+    // and their handler reads args.at(1) whenever args.at(0) equals their own
+    // receiver index — so a 1-element `drive:0;` segfaults them (reproduced on
+    // WSJT-X 3.0.1). The TCI v2.0 spec agrees: `DRIVE:arg1,arg2;`, arg1 being
+    // the transceiver ordinal.
+    // This protocol instance has a null model, so both the TRX index and the
+    // power resolve to 0 and each reply is fully deterministic. Assert the
+    // exact string rather than "has two arguments": an empty reply has to fail
+    // too. A null-model early return added to the SET path would otherwise
+    // leave the notification unset and quietly retire the half of this test
+    // that guards the fan-out to other clients.
+    struct { const char* cmd; const char* expected; } powerCmds[] = {
+        {"drive",      "drive:0,0;"},
+        {"tune_drive", "tune_drive:0,0;"},
+    };
+    for (const auto& pc : powerCmds) {
+        // GET reply — goes back to the polling client.
+        const QString getReply = protocol.handleCommand(QString::fromLatin1(pc.cmd));
+        if (getReply != QString::fromLatin1(pc.expected)) {
+            std::fprintf(stderr,
+                         "%s GET reply must be `%s` (a one-argument reply crashes ESDR3 clients); got `%s`\n",
+                         pc.cmd, pc.expected, getReply.toUtf8().constData());
+            return 1;
+        }
+        // SET notification — the path that fans out to every other client.
+        protocol.handleCommand(QStringLiteral("%1:0,0").arg(QString::fromLatin1(pc.cmd)));
+        const QString note = protocol.pendingNotification();
+        if (note != QString::fromLatin1(pc.expected)) {
+            std::fprintf(stderr,
+                         "%s notification must be `%s`; got `%s`\n",
+                         pc.cmd, pc.expected, note.toUtf8().constData());
+            return 1;
+        }
+    }
+
     std::printf("tci_protocol_test: all checks passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #4343.

A TCI client sending `drive:0;` reliably segfaults WSJT-X 3.0.1 and JTDX
2.2.159, and takes down every *other* connected client with it. AetherSDR
greets clients with `protocol:ExpertSDR3,1.5;`, which sets the `ESDR3` flag in
those clients; their handler then guards on `args.at(0)==rx_` and reads
`args.at(1)` from what may be a one-element list:

```cpp
case Cmd_Drive:
  if((!ESDR3 && !HPSDR) || args.at(0)==rx_) {
    if (ESDR3 || HPSDR) drive_ = args.at(1);
```

`cmdDrive` and `cmdTuneDrive` emitted that one-argument form from two places —
the GET reply, and `m_pendingNotification`, which `TciServer` fans out to every
client except the sender. Both now carry the transceiver index, so `args.at(1)`
is always present. This is also what TCI Protocol v2.0 specifies
(`DRIVE:arg1,arg2;`, `arg1` being the transceiver ordinal, not the power); the
init burst has sent the correct form since aa132320, and only the replies were
left behind. The TX-slice lookup that the burst did inline is folded into a new
`txTrx()` helper so the burst and the replies cannot drift apart again.

The crash only fires when the value equals the client's own receiver index —
`drive:75;` against receiver 0 is harmless, `drive:0;` is fatal. That is why it
hid for so long, and why the *default* case is the broken one.

## Why this is split out of #4161

I'm working on a fix for #4161 that builds on this change, so this needs to
land first. The crash itself is unrelated to the #4161 work — it was simply
found while hardware-testing it — so it is submitted on its own rather than
buried inside a larger branch.

## Relation to the triage analysis on #4343

Triage independently confirmed the root cause against source and proposed the
same shape of fix, including factoring the init burst's TX-trx derivation into
a shared helper — implemented here as `txTrx()`. Two notes for anyone reading
the two side by side:

- **The line numbers in that comment don't match this diff.** It ran against a
  different checkout and flagged 2 of its own 4 citations unresolved. The
  emission sites it describes are correct; only the coordinates are stale.
- **This PR is deliberately a superset of the proposed fix.** Beyond the
  two-argument replies it also adds the regression test, rewords two
  neighbouring comments that cited the now-deleted "drive/tune_drive
  convention", and records the `mic_level` scope question and the `DRIVE:arg1;`
  read deviation rather than leaving them implicit.

## Constitution principle honored

**Principle VIII — Evidence Over Assertion.** The comment above `cmdDrive`
asserted that DRIVE was a global command with no TRX prefix. Rather than
replacing it with a differently-worded assertion, it is replaced with the
specification text, a hardware reproduction, and a test that pins the wire
format so the claim keeps being checked.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio — FLEX-6600, firmware 4.2.20.41343,
      over SmartLink. Before: `drive:0;` from a second TCI client killed
      WSJT-X 3.0.1. After: a third client watching from the same position
      receives `drive:0,0`, WSJT-X survives and goes on to transmit normally.
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented — see #4343
- [x] `tci_protocol_test` extended to pin both the GET reply and the
      fan-out notification to their exact two-argument form, for `drive` and
      `tune_drive`

On the test: it asserts the **exact** reply strings rather than "the reply has
two arguments." The protocol instance under test has a null model, so both the
TRX index and the power resolve to 0 and the replies are fully deterministic. A
looser check would accept an *empty* reply, which means a future null-model
early return on the SET path would leave the notification unset and silently
retire the half of the test that guards the fan-out — the exact path that
crashes bystanders. Verified by temporarily adding such a guard: the
comma-counting version still reported "all checks passed"; the exact-string
version fails with `drive notification must be `drive:0,0;`; got ``.

## Notes for reviewers

**Which transceiver the reply names.** `txTrx()` reports the TX slice's index,
not the index the client asked about — DRIVE is the power of a transmitter, and
the reply names which one. Worth knowing: since an ESDR3 client guards on
`args.at(0)==rx_`, a client on receiver 0 will *ignore* the update when the TX
slice is not trx 0. That is not a regression — the old one-argument
`drive:75;` failed the same guard whenever `75 != rx_` — and it keeps the
replies consistent with the init burst.

**Deliberately out of scope, issues to be filed shortly:**

1. The spec's Read form is `DRIVE:arg1;`, but a lone argument is still parsed
   as the power *value*, so a spec-compliant read of transceiver 0 sets power
   to 0 instead of reporting it. Not a local fix: the bundled Elgato plugin
   sends exactly that form to SET power, so the parser and the plugin have to
   move together.
2. `mic_level` still replies with a single argument — the same shape as the bug
   fixed here. I have **not** confirmed whether WSJT-X/JTDX parse `MIC_LEVEL`
   at all, so I'm not claiming it's safe and I'm not changing it on the
   strength of symmetry alone. Their handler needs reading first. (`tx_gain` is
   an AetherSDR extension that no client parses against a spec table, so it
   carries none of this risk.)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched (Principle V)
- [x] Code is clean-room — the WSJT-X handler is quoted from published GPL
      source to explain the crash; no code is derived from it (Principle IV)
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI
- [x] Documentation updated if user-visible behavior changed — n/a, no doc
      under `docs/` documents the `drive` command
- [x] Security-sensitive changes reference a GHSA if applicable — n/a