### PR TITLE
fix(tx): keep power sliders stable during drag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3665,6 +3665,24 @@ target_link_libraries(amp_applet_test PRIVATE
 set_target_properties(amp_applet_test PROPERTIES AUTOMOC ON)
 add_test(NAME amp_applet_test COMMAND amp_applet_test)
 
+add_executable(tx_applet_power_reconciliation_test
+    tests/tx_applet_power_reconciliation_test.cpp
+    src/gui/TxApplet.cpp
+    src/gui/AtuPreTuneDialog.cpp
+    src/gui/DragValuePopup.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+)
+target_include_directories(tx_applet_power_reconciliation_test PRIVATE src)
+target_link_libraries(tx_applet_power_reconciliation_test PRIVATE
+    aethercore Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(tx_applet_power_reconciliation_test PROPERTIES AUTOMOC ON)
+add_test(NAME tx_applet_power_reconciliation_test
+         COMMAND tx_applet_power_reconciliation_test)
+set_tests_properties(tx_applet_power_reconciliation_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(container_manager_test
     tests/container_manager_test.cpp
     src/gui/FramelessResizer.cpp

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -350,11 +350,15 @@ void TxApplet::buildUI()
         if (!m_updatingFromModel && m_model)
             m_model->setRfPower(v);
     });
+    connect(m_rfPowerSlider, &QSlider::sliderReleased,
+            this, &TxApplet::syncFromModel);
     connect(m_tunePowerSlider, &QSlider::valueChanged, this, [this](int v) {
         m_tunePowerLabel->setText(QString::number(v));
         if (!m_updatingFromModel && m_model)
             m_model->setTunePower(v);
     });
+    connect(m_tunePowerSlider, &QSlider::sliderReleased,
+            this, &TxApplet::syncFromModel);
 
     // Profile dropdown → load command
     connect(m_profileCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -518,12 +518,16 @@ void TxApplet::syncFromModel()
 
     m_updatingFromModel = true;
 
-    if (m_rfPowerSlider->value() != m_model->rfPower())
+    if (!m_rfPowerSlider->isSliderDown()
+        && m_rfPowerSlider->value() != m_model->rfPower()) {
         m_rfPowerSlider->setValue(m_model->rfPower());
+    }
     m_rfPowerLabel->setText(QString::number(m_model->rfPower()));
 
-    if (m_tunePowerSlider->value() != m_model->tunePower())
+    if (!m_tunePowerSlider->isSliderDown()
+        && m_tunePowerSlider->value() != m_model->tunePower()) {
         m_tunePowerSlider->setValue(m_model->tunePower());
+    }
     m_tunePowerLabel->setText(QString::number(m_model->tunePower()));
 
     // Active profile — update combo selection

--- a/tests/tx_applet_power_reconciliation_test.cpp
+++ b/tests/tx_applet_power_reconciliation_test.cpp
@@ -1,0 +1,110 @@
+#include "TestSettingsProfile.h"
+#include "core/backends/TransmitDelta.h"
+#include "gui/TxApplet.h"
+#include "models/TransmitModel.h"
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QSlider>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const QString& detail = QString())
+{
+    std::printf("%s %-52s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                qPrintable(detail));
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+QSlider* powerSlider(TxApplet& applet, const QString& accessibleName)
+{
+    const QList<QSlider*> sliders = applet.findChildren<QSlider*>();
+    for (QSlider* slider : sliders) {
+        if (slider->accessibleName() == accessibleName) {
+            return slider;
+        }
+    }
+    return nullptr;
+}
+
+void testReleaseReconcilesAuthoritativePower(const QString& accessibleName,
+                                             bool rfPower)
+{
+    TransmitModel model;
+    TxApplet applet;
+    applet.setTransmitModel(&model);
+
+    QSlider* slider = powerSlider(applet, accessibleName);
+    const QByteArray sliderName = accessibleName.toUtf8();
+    report(qPrintable(sliderName + " slider exists"), slider != nullptr);
+    if (!slider) {
+        return;
+    }
+
+    QSignalSpy commandSpy(&model, &TransmitModel::commandReady);
+
+    slider->setSliderDown(true);
+    slider->setValue(66);
+    report(qPrintable(sliderName + " drag updates model"),
+           rfPower ? model.rfPower() == 66 : model.tunePower() == 66);
+
+    TransmitDelta clamp;
+    if (rfPower) {
+        clamp.rfPower = 40;
+    } else {
+        clamp.tunePower = 40;
+    }
+    model.applyChanges(clamp);
+
+    report(qPrintable(sliderName + " defers clamp during drag"),
+           slider->value() == 66,
+           QString::number(slider->value()));
+    commandSpy.clear();
+
+    slider->setSliderDown(false);
+
+    report(qPrintable(sliderName + " reconciles on release"),
+           slider->value() == 40,
+           QString::number(slider->value()));
+    report(qPrintable(sliderName + " release sends no command"),
+           commandSpy.isEmpty(),
+           QString::number(commandSpy.count()));
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-tx-applet-power-reconciliation-test"));
+    if (!settingsProfile.isValid()) {
+        std::printf("[FAIL] create temporary home\n");
+        return 1;
+    }
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+
+    QApplication app(argc, argv);
+
+    std::printf("TxApplet power reconciliation test harness\n\n");
+
+    testReleaseReconcilesAuthoritativePower(QStringLiteral("RF power"), true);
+    testReleaseReconcilesAuthoritativePower(QStringLiteral("Tune power"), false);
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : qPrintable(QStringLiteral("%1 test(s) failed.").arg(g_failed)));
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4350.

`TxApplet::syncFromModel()` now leaves the RF Power and Tune Power slider handles under pointer control for the duration of an active drag while the model and numeric labels continue accepting every radio-authoritative update. Each slider also calls `syncFromModel()` on `sliderReleased`, so a radio, amplifier, SWR-protection, or max-power clamp that arrives during the drag is reflected on the handle immediately at release even if no later status event arrives.

No `TransmitModel`, CAT, amplifier, or command-routing behavior changes.

## Constitution principle honored

Principle II — radio-authoritative live state. The local handle defers to active pointer ownership only while the drag is in progress, then deterministically reconciles to the model on release.

Principle XI — fixes are demonstrated. The new regression test reproduces the mid-drag authoritative clamp for both sliders and proves the release-time reconciliation without sending a duplicate command.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI — running on the updated head)
- [x] Reproduction steps documented if user-reported bug

Final local verification on current `upstream/main` (`f35316f9`):

- Full RelWithDebInfo configure/build passed.
- `ctest --test-dir build --output-on-failure -j8`: 136/136 passed; one quarantined test skipped as configured.
- `python3 tools/check_engine_boundary.py --strict`: 0 blocking findings (tracked legacy warnings only).
- Focused red/green ablation for both RF Power and Tune Power:
  - Without the two `sliderReleased` connections, an authoritative clamp from 66 to 40 left both handles stuck at 66 after release.
  - With the connections restored, both handles reconciled to 40 at release and emitted zero additional `commandReady` signals.
- Agent automation bridge on the exact rebased bundle, disconnected and without any TX action:
  - Both visible sliders drove the corresponding transmit-model values.
  - Final state was restored to RF Power 100, Tune Power 10, MOX off, and Tune off.
- Real contention validation: @milenjb applied the same `sliderReleased` fix and confirmed it resolves the desync against the SPE 1.3kFA overdrive-protection clamp ([result](https://github.com/aethersdr/AetherSDR/pull/4351#issuecomment-5038268606)).

The bridge on this branch cannot yet interleave an independent authoritative model update inside a held pointer gesture. The exact race is therefore covered by the focused applet test; the phaseful gesture and secure fresh-process handoff improvements remain isolated in #4355 and #4356 rather than expanding this bug-fix PR.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter code changed)
- [x] Documentation updated if user-visible behavior changed (no documentation change needed for this bug fix)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
