### PR TITLE
Fix macOS native Metal backing-store growth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2919,6 +2919,19 @@ add_test(NAME s_meter_geometry_test COMMAND s_meter_geometry_test)
 set_tests_properties(s_meter_geometry_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# `get rhi` native-widget topology contract (#4339): the native QRhi leaf,
+# ancestor-isolation attribute, and native-ancestor count reported to agents.
+add_executable(native_widget_topology_test
+    tests/native_widget_topology_test.cpp
+)
+target_include_directories(native_widget_topology_test PRIVATE src)
+target_link_libraries(native_widget_topology_test PRIVATE
+    Qt6::Core Qt6::Gui Qt6::Widgets
+)
+add_test(NAME native_widget_topology_test COMMAND native_widget_topology_test)
+set_tests_properties(native_widget_topology_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # MCP server field-mapping / protocol regression test (#4177). Pure Python,
 # no app or Qt needed — guards the schema ↔ bridge verb field mapping.
 find_program(PYTHON3_EXECUTABLE NAMES python3 python)

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -837,10 +837,10 @@ used by the stacked trace renderer.
   trace floor used by 3D placement from the waterfall color floor.
 
 ### `get rhi`
-Per-panadapter `QRhiWidget` **surface geometry** — the widget size,
-devicePixelRatio, and pinned color-buffer extents — so automation can assert
-the swapchain sizing that the #4091 fix controls (the color buffer stays
-even-aligned in device pixels under a fractional `QT_SCALE_FACTOR`).
+Per-panadapter `QRhiWidget` **surface geometry and native-widget topology** —
+the widget size, devicePixelRatio, pinned color-buffer extents, and (on macOS)
+native-leaf/ancestor isolation — so automation can assert the swapchain sizing
+that the #4091 fix controls and the bounded native-view hierarchy from #4339.
 
 ```json
 → {"cmd":"get","model":"rhi"}
@@ -858,9 +858,13 @@ even-aligned in device pixels under a fractional `QT_SCALE_FACTOR`).
 | `colorBufferW` / `colorBufferH` | the pinned device-pixel color buffer, or the unset sentinel `-1,-1` when auto-sized |
 | `expectedEvenW` / `expectedEvenH` | what an even-aligned pin should be for the current size — assert `colorBufferW/H` matches without recomputing the formula |
 | `evenAligned` | both pinned dimensions are even (the #4091 invariant); `false` when auto-sized |
+| `nativeWindow` | macOS only: `true` when the `SpectrumWidget` currently has an actual native child window (`windowHandle()` exists); expected for the default Metal path and `false` with `AETHER_PAN_NO_NATIVE_WINDOW=1` |
+| `nativeAncestorsBlocked` | macOS only: whether the leaf has `WA_DontCreateNativeAncestors`, preventing its native-window request from promoting the surrounding QWidget tree |
+| `nativeAncestorCount` | macOS only: number of QWidget ancestors marked `WA_NativeWindow`; the isolated default Metal path expects `0` |
 
 `selector` filters by pan index (`get rhi 0`) or objectName. On non-GPU builds
-each entry reports `gpu:false` and omits the buffer fields.
+each entry reports `gpu:false` and omits the buffer fields. The three native
+topology fields are emitted only on macOS; other platforms omit them.
 
 ### `get clients`
 Multi-session forensics (#3977/#3951): every client connected to the radio,

--- a/src/gui/NativeWidgetTopology.h
+++ b/src/gui/NativeWidgetTopology.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QVariantMap>
+#include <QWidget>
+
+namespace AetherSDR {
+
+// Append the macOS-facing native-widget topology fields used by `get rhi`.
+// Kept as a small QWidget-only helper so the bridge contract can be exercised
+// without constructing the full SpectrumWidget/radio stack.
+inline void appendNativeWidgetTopology(QVariantMap& snapshot, const QWidget& widget)
+{
+    snapshot[QStringLiteral("nativeWindow")] = widget.windowHandle() != nullptr;
+    snapshot[QStringLiteral("nativeAncestorsBlocked")] =
+        widget.testAttribute(Qt::WA_DontCreateNativeAncestors);
+
+    int nativeAncestorCount = 0;
+    for (const QWidget* ancestor = widget.parentWidget(); ancestor;
+         ancestor = ancestor->parentWidget()) {
+        if (ancestor->testAttribute(Qt::WA_NativeWindow)) {
+            ++nativeAncestorCount;
+        }
+    }
+    snapshot[QStringLiteral("nativeAncestorCount")] = nativeAncestorCount;
+}
+
+}  // namespace AetherSDR

--- a/src/gui/PanadapterStack.cpp
+++ b/src/gui/PanadapterStack.cpp
@@ -29,9 +29,10 @@ static void refreshAfterReparent(AetherSDR::SpectrumWidget* sw)
     if (QWindow* windowHandle = sw->windowHandle()) {
         windowHandle->destroy();
     }
-    if (AetherSDR::SpectrumWidget::nativeWindowPreferred()) {
-        sw->setAttribute(Qt::WA_NativeWindow);
-    }
+    // Re-realize the native leaf with its ancestor isolation intact — the helper
+    // reasserts WA_NativeWindow *and* WA_DontCreateNativeAncestors as a pair, so a
+    // reparent can't promote ancestors to native (redundant backing stores, #4339).
+    sw->applyNativeWindowIsolationPolicy();
     if (wasVisible) {
         sw->show();
     }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,5 +1,6 @@
 #include "SpectrumWidget.h"
 #include "KiwiSdrTraceMath.h"
+#include "NativeWidgetTopology.h"
 #include "PanadapterRenderScheduler.h"
 #include "PanadapterMessageOverlay.h"
 #include "SpectrumOverlayMenu.h"
@@ -847,16 +848,7 @@ QVariantMap SpectrumWidget::automationRhiSnapshot() const
     m[QStringLiteral("heightPx")] = height();
     m[QStringLiteral("dpr")] = dpr;
 #ifdef Q_OS_MAC
-    m[QStringLiteral("nativeWindow")] = windowHandle() != nullptr;
-    m[QStringLiteral("nativeAncestorsBlocked")] =
-        testAttribute(Qt::WA_DontCreateNativeAncestors);
-    int nativeAncestorCount = 0;
-    for (QWidget* ancestor = parentWidget(); ancestor; ancestor = ancestor->parentWidget()) {
-        if (ancestor->testAttribute(Qt::WA_NativeWindow)) {
-            ++nativeAncestorCount;
-        }
-    }
-    m[QStringLiteral("nativeAncestorCount")] = nativeAncestorCount;
+    appendNativeWidgetTopology(m, *this);
 #endif
 #ifdef AETHER_GPU_SPECTRUM
     m[QStringLiteral("gpu")] = true;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1323,6 +1323,22 @@ QVariantMap SpectrumWidget::traceDebugSnapshot()
     return m;
 }
 
+void SpectrumWidget::applyNativeWindowIsolationPolicy()
+{
+#if defined(AETHER_GPU_SPECTRUM) && defined(Q_OS_MAC)
+    if (nativeWindowPreferred()) {
+        // Order matters: block ancestor promotion *before* requesting the native
+        // window, so realizing the leaf's NSView can't drag its QWidget tree
+        // native (redundant window-sized Core Animation backing stores, #4339).
+        // Both attributes are set here, as one unit, so a reparent that
+        // re-realizes the native window can never reassert WA_NativeWindow
+        // without the paired ancestor isolation.
+        setAttribute(Qt::WA_DontCreateNativeAncestors);
+        setAttribute(Qt::WA_NativeWindow);
+    }
+#endif
+}
+
 SpectrumWidget::SpectrumWidget(QWidget* parent)
     : SPECTRUM_BASE_CLASS(parent)
 {
@@ -1333,14 +1349,6 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     theme::setContainer(this, QStringLiteral("spectrum"));
 
     m_panStats.clock.start();  // panstats rates are meaningless without an epoch
-
-#if defined(AETHER_GPU_SPECTRUM) && defined(Q_OS_MAC)
-    // Keep the required native Metal leaf from promoting its QWidget ancestors.
-    // QApplication's sibling policy in main.cpp is the complementary half (#4339).
-    if (nativeWindowPreferred()) {
-        setAttribute(Qt::WA_DontCreateNativeAncestors);
-    }
-#endif
 
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -1358,9 +1366,9 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // a raster flushSubWindow blend of the pan region on the GUI thread.
     // AETHER_PAN_NO_NATIVE_WINDOW=1 skips it to validate the composited path on
     // newer Qt, where the whole window flushes through one rhi swapchain.
-    if (nativeWindowPreferred()) {
-        setAttribute(Qt::WA_NativeWindow);
-    }
+    // WA_NativeWindow is set together with WA_DontCreateNativeAncestors so the
+    // native leaf never promotes its QWidget ancestors (#4339); see the helper.
+    applyNativeWindowIsolationPolicy();
 #  else
     // AETHER_NO_GPU / QT_OPENGL=software: force the OpenGL QRhi backend so the
     // software OpenGL rasterizer requested in main.cpp actually takes effect.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -846,6 +846,18 @@ QVariantMap SpectrumWidget::automationRhiSnapshot() const
     m[QStringLiteral("widthPx")] = width();
     m[QStringLiteral("heightPx")] = height();
     m[QStringLiteral("dpr")] = dpr;
+#ifdef Q_OS_MAC
+    m[QStringLiteral("nativeWindow")] = windowHandle() != nullptr;
+    m[QStringLiteral("nativeAncestorsBlocked")] =
+        testAttribute(Qt::WA_DontCreateNativeAncestors);
+    int nativeAncestorCount = 0;
+    for (QWidget* ancestor = parentWidget(); ancestor; ancestor = ancestor->parentWidget()) {
+        if (ancestor->testAttribute(Qt::WA_NativeWindow)) {
+            ++nativeAncestorCount;
+        }
+    }
+    m[QStringLiteral("nativeAncestorCount")] = nativeAncestorCount;
+#endif
 #ifdef AETHER_GPU_SPECTRUM
     m[QStringLiteral("gpu")] = true;
     m[QStringLiteral("renderer")] = rendererDescription();
@@ -1329,6 +1341,14 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     theme::setContainer(this, QStringLiteral("spectrum"));
 
     m_panStats.clock.start();  // panstats rates are meaningless without an epoch
+
+#if defined(AETHER_GPU_SPECTRUM) && defined(Q_OS_MAC)
+    // Keep the required native Metal leaf from promoting its QWidget ancestors.
+    // QApplication's sibling policy in main.cpp is the complementary half (#4339).
+    if (nativeWindowPreferred()) {
+        setAttribute(Qt::WA_DontCreateNativeAncestors);
+    }
+#endif
 
     setMinimumHeight(100);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -138,6 +138,14 @@ public:
             qEnvironmentVariableIntValue("AETHER_PAN_NO_NATIVE_WINDOW") == 1;
         return !noNative;
     }
+    // macOS: apply the native-window isolation policy as one unit — request the
+    // native Metal leaf (WA_NativeWindow) *and* block ancestor promotion
+    // (WA_DontCreateNativeAncestors), gated on nativeWindowPreferred(). Kept as a
+    // single helper so a native-window request can never lose its paired ancestor
+    // isolation (#4339): call it from the constructor and from every reparent path
+    // that re-realizes the native window (PanadapterStack::refreshAfterReparent).
+    // Idempotent; a no-op off macOS / on non-GPU builds.
+    void applyNativeWindowIsolationPolicy();
     // panstats (automation bridge): per-widget frame-cost counters — what the
     // GUI thread spends preparing this panadapter's frames, split by section,
     // plus a cause breakdown of static-overlay rebuilds. `reset` zeroes the

--- a/src/gui/WaveformWidget.cpp
+++ b/src/gui/WaveformWidget.cpp
@@ -105,7 +105,9 @@ WaveformWidget::WaveformWidget(Profile profile, QWidget* parent)
 #if defined(AETHER_GPU_SPECTRUM) && defined(Q_OS_MAC)
     // Same setup as SpectrumWidget: request Metal explicitly, and force a
     // native NSView so a QRhiWidget embedded in a raster-surface parent can
-    // obtain a Metal-capable surface of its own.
+    // obtain a Metal-capable surface of its own. Keep its QWidget ancestors
+    // non-native so they do not create redundant Core Animation backing stores.
+    setAttribute(Qt::WA_DontCreateNativeAncestors);
     setApi(QRhiWidget::Api::Metal);
     setAttribute(Qt::WA_NativeWindow);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,6 +171,13 @@ int main(int argc, char* argv[])
         }
     }
 
+#ifdef Q_OS_MAC
+    // SpectrumWidget and WaveformWidget require native Metal child views, but
+    // their surrounding raster-widget trees must not become native siblings.
+    // Together with WA_DontCreateNativeAncestors on those leaves, this avoids
+    // redundant window-sized Core Animation backing stores (#4339).
+    QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+#endif
     QApplication app(argc, argv);
     app.setApplicationName("AetherSDR");
     app.setApplicationVersion(AETHERSDR_VERSION);

--- a/tests/native_widget_topology_test.cpp
+++ b/tests/native_widget_topology_test.cpp
@@ -1,0 +1,106 @@
+#include "gui/NativeWidgetTopology.h"
+
+#include <QApplication>
+#include <QVariantMap>
+#include <QWidget>
+
+#include <cstdio>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+QVariantMap snapshotFor(const QWidget& widget)
+{
+    QVariantMap snapshot;
+    snapshot[QStringLiteral("panIndex")] = 7;
+    AetherSDR::appendNativeWidgetTopology(snapshot, widget);
+    return snapshot;
+}
+
+void testDefaultTopology()
+{
+    QWidget root;
+    QWidget leaf(&root);
+
+    const QVariantMap snapshot = snapshotFor(leaf);
+    check(!snapshot.value(QStringLiteral("nativeWindow")).toBool(),
+          "non-native leaf reports nativeWindow=false");
+    check(!snapshot.value(QStringLiteral("nativeAncestorsBlocked")).toBool(),
+          "default leaf reports nativeAncestorsBlocked=false");
+    check(snapshot.value(QStringLiteral("nativeAncestorCount")).toInt() == 0,
+          "default hierarchy reports no marked native ancestors");
+    check(snapshot.value(QStringLiteral("panIndex")).toInt() == 7,
+          "topology fields preserve existing RHI snapshot entries");
+}
+
+void testIsolatedNativeLeaf()
+{
+    QWidget root;
+    QWidget container(&root);
+    QWidget leaf(&container);
+    leaf.setAttribute(Qt::WA_DontCreateNativeAncestors);
+    leaf.setAttribute(Qt::WA_NativeWindow);
+    static_cast<void>(leaf.winId());
+
+    QVariantMap snapshot = snapshotFor(leaf);
+    check(snapshot.value(QStringLiteral("nativeWindow")).toBool(),
+          "native leaf reports nativeWindow=true");
+    check(snapshot.value(QStringLiteral("nativeAncestorsBlocked")).toBool(),
+          "isolated leaf reports nativeAncestorsBlocked=true");
+    check(snapshot.value(QStringLiteral("nativeAncestorCount")).toInt() == 0,
+          "isolated leaf does not promote QWidget ancestors");
+
+    // PanadapterStack reasserts WA_NativeWindow after a top-level reparent.
+    // The isolation attribute is independent and must survive that cycle.
+    leaf.setAttribute(Qt::WA_NativeWindow, false);
+    leaf.setAttribute(Qt::WA_NativeWindow);
+    static_cast<void>(leaf.winId());
+    snapshot = snapshotFor(leaf);
+    check(snapshot.value(QStringLiteral("nativeAncestorsBlocked")).toBool(),
+          "native-window reassertion preserves ancestor isolation");
+    check(snapshot.value(QStringLiteral("nativeAncestorCount")).toInt() == 0,
+          "native-window reassertion keeps ancestors non-native");
+}
+
+void testExplicitNativeAncestors()
+{
+    QWidget root;
+    QWidget container(&root);
+    QWidget leaf(&container);
+    root.setAttribute(Qt::WA_NativeWindow);
+    container.setAttribute(Qt::WA_NativeWindow);
+
+    const QVariantMap snapshot = snapshotFor(leaf);
+    check(snapshot.value(QStringLiteral("nativeAncestorCount")).toInt() == 2,
+          "snapshot counts every ancestor marked WA_NativeWindow");
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+    QApplication app(argc, argv);
+
+    testDefaultTopology();
+    testIsolatedNativeLeaf();
+    testExplicitNativeAncestors();
+
+    if (failures == 0) {
+        std::printf("\nAll native widget topology tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d native widget topology test(s) FAILED.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4339.

On macOS, the spectrum and waveform QRhi widgets must keep their dedicated native Metal `NSView`s; removing `WA_NativeWindow` still produces transparent panadapter holes on current Qt/macOS combinations. The native request was also allowing Qt to promote the surrounding QWidget ancestor and sibling trees into native views, multiplying window-sized Core Animation backing stores.

This change applies Qt's paired containment policies: `AA_DontCreateNativeWidgetSiblings` before `QApplication` construction, plus `WA_DontCreateNativeAncestors` on each native Metal QRhi leaf. The agent automation bridge RHI snapshot now exposes the leaf/native-ancestor topology for regression proof.

The isolating ablation on macOS 26.5.1 / Qt 6.11.1 was:

| Application sibling policy | QRhi leaf ancestor policy | Native ancestors | Metal leaf |
|---|---|---:|---|
| off | off | 6 | native and visible |
| off | on | 6 | native and visible |
| on | off | 6 | native and visible |
| on | on | 0 | native and visible |

After the fix, a 10-pair full-UI Default Light/Default Dark repaint soak left the process's `CABackingStore` object count unchanged at 11. The reporter's exact M4 Max / 5K / multi-hour workload is not available locally, so confirmation on that machine remains valuable.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The two Qt policies were ablated independently, the final native-view topology was asserted through the agent automation bridge, the Metal framebuffer was captured visibly, and live slice 0 RX plus repository tests were verified before publication.

## Test plan

- [x] Local build passes (`cmake --build build`)
  - Full RelWithDebInfo application build passes with Qt 6.11.1 / Metal on Apple M3 Max.
- [x] Behavior verified on a real radio if applicable
  - Connected to a FLEX-6700 running 4.2.18.
  - Slice 0 remained active in RX, `transmitting=false`, and no TX-keying verbs were used.
  - Owned pan/waterfall streams had zero foreign, orphan, or leaked streams.
  - Live spectrum and waterfall frames rendered through `GPU QRhi (Metal; Apple M3 Max)`.
  - Final bridge snapshot: `nativeWindow=true`, `nativeAncestorsBlocked=true`, `nativeAncestorCount=0`.
  - Agent automation bridge framebuffer capture showed a complete live 3D spectrum and waterfall with no transparent surface.
- [x] Existing tests pass (CI)
  - Local CTest: 130/130 tests passed; one expected quarantined test skipped.
  - `python3 tools/check_engine_boundary.py --strict`: 0 blocking findings.
  - `git diff --check`: passed.
- [x] Reproduction steps documented if user-reported bug
  1. Launch on macOS with the native Metal pan path enabled (the default).
  2. Inspect `get rhi` through the agent automation bridge.
  3. Before the fix, native QRhi leaves promote six QWidget ancestors; after the fix, the leaf remains native and visible while the ancestor count is zero.
  4. Trigger repeated full-UI repaints and confirm `CABackingStore` / IOSurface-backed footprint plateaus after warm-up.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
  - N/A — no settings persistence changes.
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
  - N/A — no meter UI changes.
- [x] Documentation updated if user-visible behavior changed
  - N/A — this restores bounded native-view composition without changing a user workflow or setting.
- [x] Security-sensitive changes reference a GHSA if applicable
  - N/A — no security-sensitive surface changes.

---

Generated with OpenAI Codex.
