### PR TITLE
feat(automation): add phaseful pointer gestures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2689,6 +2689,21 @@ target_compile_definitions(radio_discovery_test PRIVATE AETHERSDR_TESTING)
 target_link_libraries(radio_discovery_test PRIVATE Qt6::Core Qt6::Network)
 add_test(NAME radio_discovery_test COMMAND radio_discovery_test)
 
+# Agent automation bridge phaseful-gesture lifecycle (#4353). Uses two real
+# QLocalSocket clients so the regression proves an independent request can run
+# while a QSlider remains genuinely down, plus auth/read-only/TX cleanup rails.
+add_executable(automation_server_gesture_test
+    tests/automation_server_gesture_test.cpp
+)
+target_include_directories(automation_server_gesture_test PRIVATE src tests)
+target_link_libraries(automation_server_gesture_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Widgets
+)
+set_target_properties(automation_server_gesture_test PROPERTIES AUTOMOC ON)
+add_test(NAME automation_server_gesture_test COMMAND automation_server_gesture_test)
+set_tests_properties(automation_server_gesture_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(client_quindar_test
     tests/client_quindar_test.cpp
     src/core/ClientQuindarTone.cpp

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -127,10 +127,10 @@ contributors to self-verify UI changes before requesting review.
      ```
    - **Windows**: use `python` (or `py -3`) instead of `python3`.
 
-**Tools exposed** (22 typed tools): introspection — `bridge_status`,
+**Tools exposed** (23 typed tools): introspection — `bridge_status`,
 `dump_tree` (with a `filter` arg), `grab_widget` (PNG inline; optional
 `path` for where the PNG is written, else a temp file),
-`get_state`, `get_log`, `floors`, `streams`; driving — `invoke`
+`get_state`, `get_log`, `floors`, `streams`; driving — `invoke`, `gesture`
 (on a target-not-found failure it appends `did_you_mean` candidates),
 `shortcut`, `tune`, `slice`, `pan`, `record`, `mark`, `window`, `menu`;
 assert/await — `assert_state` / `wait_for` (read a model property and
@@ -264,6 +264,7 @@ transmit-gated verbs (refused unless `AETHER_AUTOMATION_ALLOW_TX=1` — see
 | | [`close <target>`](#close) | Close the target's top-level window. |
 | | [`drag <target> "<dx> <dy>"`](#drag-alias-mouse) | Synthesize press→move→release (alias `mouse`). |
 | | [`dragAt <target> "<x> <y> <dx> <dy> [modifiers]"`](#dragat) | Drag from a target-local point with optional keyboard modifiers. |
+| | [`gesture <phase>`](#gesture) | Hold press/move/release across requests for delayed-event tests. |
 | | [`showMenu <target>`](#showmenu-alias-openmenu) | Pop a button's drop-down menu (alias `openMenu`). |
 | | [`contextMenu <target> [x y]`](#contextmenu) | Trigger a custom right-click menu. |
 | | [`rightClick <target> [x y]`](#rightclick) | Trigger a mousePressEvent-based right-click menu. |
@@ -376,6 +377,7 @@ Each `<node>`:
   "text": "NR2",                           // checkable buttons: the label (value would just be "checked")
   "checked": false,                        // checkable buttons: explicit boolean check-state
   "range": { "min": 0, "max": 100 },       // numeric controls only (slider/spinbox)
+  "sliderDown": false,                     // sliders only: real QAbstractSlider press ownership
   "items": ["LSB","USB","AM","CW"],        // QComboBox only: full option list
   "currentIndex": 1,                       // QComboBox only: selected index
   "panIndex": 0,                           // SpectrumWidget only: pass to `grab pan`/`pan close`
@@ -1145,6 +1147,48 @@ TX-keying control unless transmit automation is explicitly enabled.
 ← {"ok":true,"target":"SpectrumWidget","class":"SpectrumWidget",
    "x":1564,"y":100,"dx":0,"dy":300,"modifiers":268435456}
 ```
+
+`drag` remains the backward-compatible one-shot form. It now enforces the same
+disabled-control, TX-keying, and `AETHER_AUTOMATION_TX_MAX_POWER` pointer rails
+as `clickAt`; it cannot be used to bypass those guards.
+
+### `gesture`
+Keep a real left-button gesture open across multiple main-loop requests. This is
+the phaseful counterpart to atomic [`drag`](#drag-alias-mouse), intended for
+testing behavior such as a delayed model/radio update arriving while
+`QAbstractSlider::isSliderDown()` is genuinely true.
+
+```json
+→ {"cmd":"gesture","action":"begin","target":"RF power"}
+← {"ok":true,"active":true,"sliderDown":true,"value":50,"leaseMs":60000}
+
+→ {"cmd":"gesture","action":"move","value":"0 -30"}
+← {"ok":true,"active":true,"sliderDown":true,"dx":0,"dy":-30}
+
+→ {"cmd":"gesture","action":"end"}
+← {"ok":true,"active":false,"target":"RF power","dx":0,"dy":-30}
+```
+
+Phases:
+
+- `begin <target> [x y]` presses at the widget center, or at optional local
+  coordinates. Only one phaseful gesture may exist in the app at once.
+- `move <dx> <dy>` sends a move at fixed-base offsets from the original press.
+- `status` is read-only and reports `active`, ownership, offsets, and
+  `sliderDown`/`value` for a slider.
+- `end [dx dy]` optionally moves to a final offset, then releases.
+- `cancel` releases at the current offset.
+
+The owning bridge connection must remain open between phases. The typed MCP
+`gesture` tool does this automatically while ordinary tools keep using separate
+connections, which is what lets an independent `invoke`, `dump_tree`, or delayed
+app event interleave. Raw clients must reuse one socket themselves.
+
+Safety is fail-closed: auth and observe-only checks apply to every phase; begin
+uses the same disabled-control, TX-keying, and power-ceiling rails as pointer
+clicks. End, cancel, malformed continuation, target destruction, client
+disconnect, bridge stop, or 60 seconds without a move all synthesize the release
+and clear ownership.
 
 ### `hover`
 Synthesize a pointer **hover** over a widget (no button pressed, unlike `drag`)
@@ -2292,7 +2336,7 @@ lands.
 The complete registry, generated from the `add(...)` table in `AutomationServer.cpp` by `tools/gen_bridge_docs.py`. CI fails if this drifts from the code.
 
 <!-- BEGIN GENERATED VERB TABLE (tools/gen_bridge_docs.py) -->
-<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 50 verbs. -->
+<!-- Do not edit by hand — run tools/gen_bridge_docs.py. 51 verbs. -->
 
 | Verb | Aliases | Description |
 |---|---|---|
@@ -2307,6 +2351,7 @@ The complete registry, generated from the `add(...)` table in `AutomationServer.
 | `scrollTo` | `ensureVisible` | scrollTo <target> — scroll a widget into its scroll-area viewport |
 | `drag` | `mouse` | drag <target> <dx> <dy> — synthesize press→move→release |
 | `dragAt` | — | dragAt <target> <x> <y> <dx> <dy> [control\|meta\|shift\|alt,...] |
+| `gesture` | — | gesture <begin\|move\|end\|cancel\|status> — phaseful pointer gesture |
 | `showMenu` | `openMenu` | showMenu <target> — pop a button's drop-down menu |
 | `contextMenu` | — | contextMenu <target> [x y] — Qt context-menu path |
 | `rightClick` | — | rightClick <target> [x y] — mousePressEvent menu path |

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -361,15 +361,17 @@ QJsonObject describeWidget(const QWidget* w)
     // Range for numeric controls — lets a driver validate against the real
     // bounds (scale) and detect wrapping/circular sliders without guessing
     // extremes (#3646).
-    if (auto* s = qobject_cast<const QAbstractSlider*>(w))
+    if (auto* s = qobject_cast<const QAbstractSlider*>(w)) {
         o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), s->minimum()},
                                                  {QStringLiteral("max"), s->maximum()}};
-    else if (auto* sb = qobject_cast<const QSpinBox*>(w))
+        o[QStringLiteral("sliderDown")] = s->isSliderDown();
+    } else if (auto* sb = qobject_cast<const QSpinBox*>(w)) {
         o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), sb->minimum()},
                                                  {QStringLiteral("max"), sb->maximum()}};
-    else if (auto* ds = qobject_cast<const QDoubleSpinBox*>(w))
+    } else if (auto* ds = qobject_cast<const QDoubleSpinBox*>(w)) {
         o[QStringLiteral("range")] = QJsonObject{{QStringLiteral("min"), ds->minimum()},
                                                  {QStringLiteral("max"), ds->maximum()}};
+    }
 
     // Full option list for a combo box, so a driver can verify the available
     // choices non-destructively — `value` reports only the active text, which
@@ -1987,6 +1989,11 @@ void AutomationServer::stop()
     if (!m_server)
         return;
 
+    // A phaseful gesture owns a synthetic left-button press. Release it before
+    // clients/widgets are torn down so a slider never remains logically down
+    // after the bridge stops.
+    cancelGesture(nullptr, QStringLiteral("automation bridge stopping"));
+
     // Safety: never leave the radio keyed when the bridge shuts down.
     if (m_txAllowed)
         forceUnkey("automation bridge stopping");
@@ -2170,6 +2177,7 @@ void AutomationServer::onDisconnected()
     auto* sock = qobject_cast<QLocalSocket*>(sender());
     if (!sock)
         return;
+    cancelGesture(sock, QStringLiteral("gesture owner disconnected"));
     m_buffers.remove(sock);
     if (m_logSubscribers.remove(sock) && m_logSubscribers.isEmpty() && m_logDrain)
         m_logDrain->stop();
@@ -2251,6 +2259,9 @@ bool isReadOnlyRequest(const QString& name, const QString& action)
             QString(), QStringLiteral("radio"), QStringLiteral("inventory"),
         };
         return kSafeStreamActions.contains(normalizedAction);
+    }
+    if (name == QLatin1String("gesture")) {
+        return normalizedAction == QLatin1String("status");
     }
     return false;
 }
@@ -2490,6 +2501,22 @@ const std::vector<AutomationServer::VerbSpec>& AutomationServer::verbRegistry()
                     return err(QStringLiteral("dragAt requires a target and '<x> <y> <dx> <dy>'"));
                 }
                 return s.doDragAt(a.target, a.value);
+            });
+
+        add("gesture", {},
+            "gesture <begin|move|end|cancel|status> — phaseful pointer gesture",
+            [](const QList<QByteArray>& p, A& a) -> QJsonObject {
+                a.action = vtok(p, 1);
+                if (a.action == QLatin1String("begin")) {
+                    a.target = vtok(p, 2);
+                    a.value = vjoin(p, 3);
+                } else {
+                    a.value = vjoin(p, 2);
+                }
+                return {};
+            },
+            [](AutomationServer& s, A& a, QLocalSocket* sock) -> QJsonObject {
+                return s.doGesture(a.action, a.target, a.value, sock);
             });
 
         add("showMenu", {QStringLiteral("openMenu")},
@@ -6259,6 +6286,61 @@ QJsonObject AutomationServer::doClose(const QString& target) const
     return r;
 }
 
+QJsonObject AutomationServer::pointerSafetyError(const QWidget* widget,
+                                                 const QString& target,
+                                                 const QString& verb) const
+{
+    if (!widget->isVisible()) {
+        return err(QStringLiteral("refused: '") + target
+                   + QStringLiteral("' is not visible"));
+    }
+    if (!widget->isEnabled()) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"),
+             QStringLiteral("refused: '") + target
+                 + QStringLiteral("' is disabled — pointer input would be dropped")},
+            {QStringLiteral("disabled"), true},
+            {QStringLiteral("class"), shortClassName(widget)},
+        };
+    }
+
+    if (!m_txAllowed) {
+        for (const QWidget* parent = widget; parent; parent = parent->parentWidget()) {
+            if (!isTransmitControl(parent)) {
+                continue;
+            }
+            qCWarning(lcAutomation).noquote()
+                << "BLOCKED transmit-related" << verb << "on" << target
+                << "(keying control in chain:" << shortClassName(parent) << ')';
+            return err(QStringLiteral("blocked: '") + target
+                       + QStringLiteral("' resolves into a transmit-keying control "
+                                        "(TX-safety guard). Enable \"Allow TX via MCP\" "
+                                        "in Radio Setup → Network (or set "
+                                        "AETHER_AUTOMATION_ALLOW_TX=1) to override."));
+        }
+    }
+
+    if (m_txMaxPower >= 0) {
+        for (const QWidget* parent = widget; parent; parent = parent->parentWidget()) {
+            const QString accessibleName = parent->accessibleName();
+            if (accessibleName != QLatin1String("RF power")
+                && accessibleName != QLatin1String("Tune power")) {
+                continue;
+            }
+            qCWarning(lcAutomation).noquote()
+                << "BLOCKED" << verb << "on power slider" << accessibleName
+                << "— power ceiling" << m_txMaxPower << "is armed";
+            return err(QStringLiteral("blocked: '") + accessibleName
+                       + QStringLiteral("' pointer input would bypass the power "
+                                        "ceiling (AETHER_AUTOMATION_TX_MAX_POWER). "
+                                        "Use `invoke setValue`, which clamps."));
+        }
+    }
+
+    return {};
+}
+
 // ── Mouse-drag gesture synthesis (#3646 fidelity) ───────────────────────────
 // `drag <target> <dx> <dy>` synthesizes a press → moves → release so a resize
 // grip or slider handle is provable end-to-end, not just via seed + read-back.
@@ -6272,18 +6354,22 @@ QJsonObject AutomationServer::doDrag(const QString& target, const QString& value
     if (!w) {
         return err(QStringLiteral("widget or window not found: ") + target);
     }
-    if (!w->isVisible()) {
-        return err(QStringLiteral("refused: '") + target + QStringLiteral("' is not visible"));
+    const QJsonObject safetyError = pointerSafetyError(
+        w, target, QStringLiteral("drag"));
+    if (!safetyError.isEmpty()) {
+        return safetyError;
     }
 
     const QStringList parts = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
-    if (parts.size() < 2)
+    if (parts.size() < 2) {
         return err(QStringLiteral("drag requires '<dx> <dy>' in pixels (e.g. 'drag sizeGrip 80 60')"));
+    }
     bool okx = false, oky = false;
     const int dx = parts.at(0).toInt(&okx);
     const int dy = parts.at(1).toInt(&oky);
-    if (!okx || !oky)
+    if (!okx || !oky) {
         return err(QStringLiteral("drag dx/dy must be integers"));
+    }
 
     const QPoint start(w->width() / 2, w->height() / 2);
     const QPoint globalStart = w->mapToGlobal(start);
@@ -6326,30 +6412,10 @@ QJsonObject AutomationServer::doDragAt(const QString& target, const QString& val
     if (!w) {
         return err(QStringLiteral("widget or window not found: ") + target);
     }
-    if (!w->isVisible()) {
-        return err(QStringLiteral("refused: '") + target + QStringLiteral("' is not visible"));
-    }
-    if (!w->isEnabled()) {
-        return err(QStringLiteral("refused: '") + target
-                   + QStringLiteral("' is disabled — the drag would be dropped"));
-    }
-
-    // A target-local drag is still raw mouse input: an unaccepted event can
-    // propagate to a keying ancestor. Honor the same opt-in gate as clickAt().
-    if (!m_txAllowed) {
-        for (const QWidget* p = w; p; p = p->parentWidget()) {
-            if (!isTransmitControl(p)) {
-                continue;
-            }
-            qCWarning(lcAutomation).noquote()
-                << "BLOCKED transmit-related dragAt on" << target
-                << "(keying control in chain:" << shortClassName(p) << ")";
-            return err(QStringLiteral("blocked: '") + target
-                       + QStringLiteral("' resolves into a transmit-keying control "
-                                        "(TX-safety guard). Enable \"Allow TX via MCP\" "
-                                        "in Radio Setup → Network (or set "
-                                        "AETHER_AUTOMATION_ALLOW_TX=1) to override."));
-        }
+    const QJsonObject safetyError = pointerSafetyError(
+        w, target, QStringLiteral("dragAt"));
+    if (!safetyError.isEmpty()) {
+        return safetyError;
     }
 
     const QStringList parts = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
@@ -6432,6 +6498,223 @@ QJsonObject AutomationServer::doDragAt(const QString& target, const QString& val
         {QStringLiteral("dy"), dy},
         {QStringLiteral("modifiers"), static_cast<int>(modifiers)},
     };
+}
+
+// `gesture` keeps the left button down across requests on one QLocalSocket.
+// This is deliberately connection-owned: an MCP wrapper can hold that socket
+// while ordinary tools use independent short-lived sockets, so queued model or
+// radio updates and separate bridge requests get normal main-loop turns while
+// QAbstractSlider::isSliderDown() remains true. Losing the owner is the cleanup
+// signal; no caller-supplied session id can outlive its transport.
+QJsonObject AutomationServer::doGesture(const QString& action,
+                                        const QString& target,
+                                        const QString& value,
+                                        QLocalSocket* sock)
+{
+    const QString normalizedAction = action.trimmed().toLower();
+
+    auto active = [this]() {
+        return m_pointerGesture.owner && m_pointerGesture.widget;
+    };
+    auto response = [this, sock, &active]() {
+        QJsonObject result{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("active"), active()},
+            {QStringLiteral("leaseMs"), kPointerGestureLeaseMs},
+        };
+        if (!active()) {
+            return result;
+        }
+        result[QStringLiteral("target")] = m_pointerGesture.target;
+        result[QStringLiteral("class")] = shortClassName(m_pointerGesture.widget);
+        result[QStringLiteral("dx")] = m_pointerGesture.offset.x();
+        result[QStringLiteral("dy")] = m_pointerGesture.offset.y();
+        result[QStringLiteral("ownedByCaller")] = m_pointerGesture.owner == sock;
+        if (const auto* slider =
+                qobject_cast<const QAbstractSlider*>(m_pointerGesture.widget.data())) {
+            result[QStringLiteral("sliderDown")] = slider->isSliderDown();
+            result[QStringLiteral("value")] = slider->value();
+        }
+        return result;
+    };
+    auto parsePoint = [](const QString& text, bool optional, bool coordinates,
+                         QPoint* point) -> QString {
+        const QStringList parts = text.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        if (optional && parts.isEmpty()) {
+            return {};
+        }
+        if (parts.size() != 2) {
+            return coordinates
+                ? QStringLiteral("requires exactly '<x> <y>' integer coordinates")
+                : QStringLiteral("requires exactly '<dx> <dy>' integer offsets");
+        }
+        bool okX = false;
+        bool okY = false;
+        const int x = parts.at(0).toInt(&okX);
+        const int y = parts.at(1).toInt(&okY);
+        if (!okX || !okY) {
+            return coordinates
+                ? QStringLiteral("coordinates must be integers")
+                : QStringLiteral("offsets must be integers");
+        }
+        *point = QPoint(x, y);
+        return {};
+    };
+    auto send = [this](QEvent::Type type, Qt::MouseButton button,
+                       Qt::MouseButtons buttons) -> bool {
+        if (!m_pointerGesture.widget) {
+            return false;
+        }
+        const QPoint local = m_pointerGesture.startLocal + m_pointerGesture.offset;
+        const QPoint global = m_pointerGesture.globalStart + m_pointerGesture.offset;
+        QMouseEvent event(type, QPointF(local), QPointF(local), QPointF(global),
+                          button, buttons, Qt::NoModifier);
+        QCoreApplication::sendEvent(m_pointerGesture.widget, &event);
+        return m_pointerGesture.widget != nullptr;
+    };
+
+    if (normalizedAction == QLatin1String("status")) {
+        if (!m_pointerGesture.owner || !m_pointerGesture.widget) {
+            cancelGesture(nullptr, QStringLiteral("gesture target or owner disappeared"));
+        }
+        return response();
+    }
+
+    if (!sock) {
+        return err(QStringLiteral("gesture requires a live client connection"));
+    }
+
+    if (normalizedAction == QLatin1String("begin")) {
+        if (active()) {
+            return err(QStringLiteral("another phaseful gesture is already active"));
+        }
+        if (target.isEmpty()) {
+            return err(QStringLiteral("gesture begin requires a target"));
+        }
+        QWidget* widget = resolveWidget(target);
+        if (!widget) {
+            return err(QStringLiteral("widget or window not found: ") + target);
+        }
+        const QJsonObject safetyError = pointerSafetyError(
+            widget, target, QStringLiteral("gesture"));
+        if (!safetyError.isEmpty()) {
+            return safetyError;
+        }
+
+        QPoint start(widget->rect().center());
+        if (!value.trimmed().isEmpty()) {
+            const QString coordinateError = parsePoint(value, false, true, &start);
+            if (!coordinateError.isEmpty()) {
+                return err(QStringLiteral("gesture begin ") + coordinateError);
+            }
+            if (!widget->rect().contains(start)) {
+                return err(QStringLiteral("gesture begin point is outside '")
+                           + target + QStringLiteral("'"));
+            }
+        }
+
+        m_pointerGesture.owner = sock;
+        m_pointerGesture.widget = widget;
+        m_pointerGesture.target = target;
+        m_pointerGesture.startLocal = start;
+        m_pointerGesture.globalStart = widget->mapToGlobal(start);
+        m_pointerGesture.offset = QPoint();
+
+        if (!send(QEvent::MouseButtonPress, Qt::LeftButton, Qt::LeftButton)) {
+            cancelGesture(sock, QStringLiteral("gesture target disappeared during press"));
+            return err(QStringLiteral("gesture target disappeared during press"));
+        }
+
+        if (!m_pointerGestureTimer) {
+            m_pointerGestureTimer = new QTimer(this);
+            m_pointerGestureTimer->setSingleShot(true);
+            connect(m_pointerGestureTimer, &QTimer::timeout, this, [this]() {
+                cancelGesture(nullptr, QStringLiteral("gesture inactivity timeout"));
+            });
+        }
+        m_pointerGestureTimer->start(kPointerGestureLeaseMs);
+        qCInfo(lcAutomation).noquote() << "gesture begin" << target << "at" << start;
+        return response();
+    }
+
+    if (!active() || m_pointerGesture.owner != sock) {
+        return err(QStringLiteral("no phaseful gesture is owned by this client"));
+    }
+
+    if (normalizedAction == QLatin1String("cancel")) {
+        cancelGesture(sock, QStringLiteral("gesture cancelled by client"));
+        return response();
+    }
+
+    if (normalizedAction != QLatin1String("move")
+        && normalizedAction != QLatin1String("end")) {
+        cancelGesture(sock, QStringLiteral("invalid gesture continuation"));
+        return err(QStringLiteral("gesture action must be begin, move, end, cancel, or status"));
+    }
+
+    QPoint offset = m_pointerGesture.offset;
+    const bool hasFinalOffset = normalizedAction == QLatin1String("end")
+        && !value.trimmed().isEmpty();
+    const QString offsetError = parsePoint(
+        value, normalizedAction == QLatin1String("end"), false, &offset);
+    if (!offsetError.isEmpty()) {
+        cancelGesture(sock, QStringLiteral("invalid gesture offset"));
+        return err(QStringLiteral("gesture ") + normalizedAction + QLatin1Char(' ')
+                   + offsetError + QStringLiteral("; gesture released"));
+    }
+    m_pointerGesture.offset = offset;
+
+    if (normalizedAction == QLatin1String("move") || hasFinalOffset) {
+        if (!send(QEvent::MouseMove, Qt::NoButton, Qt::LeftButton)) {
+            cancelGesture(sock, QStringLiteral("gesture target disappeared during move"));
+            return err(QStringLiteral("gesture target disappeared during move"));
+        }
+    }
+    if (normalizedAction == QLatin1String("move")) {
+        m_pointerGestureTimer->start(kPointerGestureLeaseMs);
+        return response();
+    }
+
+    const QString endedTarget = m_pointerGesture.target;
+    const QString endedClass = shortClassName(m_pointerGesture.widget);
+    const QPoint endedOffset = m_pointerGesture.offset;
+    cancelGesture(sock, QStringLiteral("gesture ended by client"));
+    return QJsonObject{
+        {QStringLiteral("ok"), true},
+        {QStringLiteral("active"), false},
+        {QStringLiteral("target"), endedTarget},
+        {QStringLiteral("class"), endedClass},
+        {QStringLiteral("dx"), endedOffset.x()},
+        {QStringLiteral("dy"), endedOffset.y()},
+    };
+}
+
+void AutomationServer::cancelGesture(QLocalSocket* owner, const QString& reason)
+{
+    if (owner && m_pointerGesture.owner != owner) {
+        return;
+    }
+    if (!m_pointerGesture.owner && !m_pointerGesture.widget) {
+        return;
+    }
+
+    if (m_pointerGestureTimer) {
+        m_pointerGestureTimer->stop();
+    }
+
+    const QString target = m_pointerGesture.target;
+    if (m_pointerGesture.widget) {
+        const QPoint local = m_pointerGesture.startLocal + m_pointerGesture.offset;
+        const QPoint global = m_pointerGesture.globalStart + m_pointerGesture.offset;
+        QMouseEvent release(QEvent::MouseButtonRelease,
+                            QPointF(local), QPointF(local), QPointF(global),
+                            Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+        QCoreApplication::sendEvent(m_pointerGesture.widget, &release);
+    }
+
+    m_pointerGesture = PointerGesture{};
+    qCInfo(lcAutomation).noquote()
+        << "gesture release" << target << "—" << reason;
 }
 
 // hover <target> [leave]: synthesize pointer hover so hover-driven UI is

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -7,6 +7,7 @@
 #include <QElapsedTimer>
 #include <QMutex>
 #include <QJsonObject>
+#include <QPoint>
 #include <QString>
 
 #ifdef HAVE_WEBSOCKETS
@@ -165,6 +166,10 @@ class QsoRecorder;
 //                                  -> drag from a target-local point, optionally
 //                                     with control/meta/shift/alt held. This
 //                                     reaches modifier-only custom-widget paths.
+//   gesture begin <target> [x y]   -> hold a real left-button press open across
+//   gesture move <dx> <dy>            requests on the SAME client connection;
+//   gesture end [dx dy]               end/cancel/disconnect/error/timeout always
+//   gesture cancel|status             release it. Enables delayed-event proof.
 //   showMenu <target>              -> pop a QToolButton/QPushButton drop-down,
 //                                     posted onto the GUI loop with the window
 //                                     raised (crash-safe on backgrounded macOS).
@@ -376,6 +381,18 @@ private:
     // provable end-to-end, not just via seed + read-back. (#3646 fidelity)
     QJsonObject doDrag(const QString& target, const QString& value) const;
     QJsonObject doDragAt(const QString& target, const QString& value) const;
+    // Phaseful pointer gesture (#4353). The owning QLocalSocket stays connected
+    // between begin/move/end so unrelated bridge clients and queued model/radio
+    // events can interleave while a slider is genuinely down. A single global
+    // owner avoids contradictory synthetic left-button states. Every terminal
+    // and error path calls cancelGesture(), which sends the release before
+    // forgetting the state.
+    QJsonObject doGesture(const QString& action, const QString& target,
+                          const QString& value, QLocalSocket* sock);
+    void cancelGesture(QLocalSocket* owner, const QString& reason);
+    QJsonObject pointerSafetyError(const QWidget* widget,
+                                   const QString& target,
+                                   const QString& verb) const;
     // hover <target> [leave]: synthesize pointer hover over a widget so
     // hover-driven UI (e.g. the HGauge mouse-over value readout on the TX
     // SWR/power/ALC meters) is provable end-to-end. Bare form sends a
@@ -577,6 +594,20 @@ private:
     QString       m_discoveryEntry;   // this instance's <pid>.json in m_discoveryDir
     QString       m_label;            // AETHER_AUTOMATION_LABEL (human instance tag)
     QHash<QLocalSocket*, QByteArray> m_buffers;  // per-client read buffer
+    struct PointerGesture {
+        QPointer<QLocalSocket> owner;
+        QPointer<QWidget> widget;
+        QString target;
+        QPoint startLocal;
+        QPoint globalStart;
+        QPoint offset;
+    };
+    PointerGesture m_pointerGesture;
+    QTimer* m_pointerGestureTimer{nullptr};
+    // Tool-call round trips can take several seconds each in an agent host.
+    // One minute leaves room for an independent request plus observation while
+    // still bounding an abandoned synthetic press.
+    static constexpr int kPointerGestureLeaseMs = 60000;
     QPointer<RadioModel> m_radioModel;           // for get(); may be null
     QPointer<AudioEngine> m_audioEngine;          // for get audio; may be null
     QPointer<QsoRecorder> m_qsoRecorder;          // for record(); may be null

--- a/tests/automation_server_gesture_test.cpp
+++ b/tests/automation_server_gesture_test.cpp
@@ -1,0 +1,298 @@
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/QsoRecorder.h"
+#include "models/RadioModel.h"
+#include "core/AutomationServer.h"
+#include "core/TxKeyingMarker.h"
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QPushButton>
+#include <QSlider>
+#include <QVBoxLayout>
+
+#include <cstdio>
+#include <functional>
+
+using namespace AetherSDR;
+
+namespace {
+
+int gFailures = 0;
+
+void expect(const char* name, bool condition)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", name);
+    if (!condition) {
+        ++gFailures;
+    }
+}
+
+bool waitUntil(const std::function<bool()>& condition, int timeoutMs = 2000)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (!condition() && timer.elapsed() < timeoutMs) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+    }
+    return condition();
+}
+
+bool connectClient(QLocalSocket* socket, const QString& name)
+{
+    socket->connectToServer(name);
+    return waitUntil([socket]() {
+        return socket->state() == QLocalSocket::ConnectedState;
+    });
+}
+
+QJsonObject request(QLocalSocket* socket, QJsonObject object,
+                    bool authenticated = true)
+{
+    if (authenticated) {
+        object[QStringLiteral("token")] = QStringLiteral("test-token");
+    }
+    socket->write(QJsonDocument(object).toJson(QJsonDocument::Compact));
+    socket->write("\n");
+    socket->flush();
+    if (!waitUntil([socket]() { return socket->canReadLine(); })) {
+        return QJsonObject{
+            {QStringLiteral("ok"), false},
+            {QStringLiteral("error"), QStringLiteral("response timeout")},
+        };
+    }
+    return QJsonDocument::fromJson(socket->readLine()).object();
+}
+
+QJsonObject gesture(QLocalSocket* socket, const QString& action,
+                    const QString& target = {}, const QString& value = {},
+                    bool authenticated = true)
+{
+    QJsonObject object{
+        {QStringLiteral("cmd"), QStringLiteral("gesture")},
+        {QStringLiteral("action"), action},
+    };
+    if (!target.isEmpty()) {
+        object[QStringLiteral("target")] = target;
+    }
+    if (!value.isEmpty()) {
+        object[QStringLiteral("value")] = value;
+    }
+    return request(socket, object, authenticated);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-automation-gesture-test"));
+    if (!settingsProfile.isValid()) {
+        std::fprintf(stderr, "FAIL could not create isolated settings profile\n");
+        return 1;
+    }
+
+    qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+    QApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("AetherSDR-test"));
+    QCoreApplication::setApplicationName(QStringLiteral("AetherSDR-test"));
+    AppSettings::instance().load();
+
+    QWidget window;
+    window.resize(500, 180);
+    auto* layout = new QVBoxLayout(&window);
+
+    QSlider slider(Qt::Horizontal);
+    slider.setObjectName(QStringLiteral("phaseSlider"));
+    slider.setAccessibleName(QStringLiteral("Phase slider"));
+    slider.setRange(0, 100);
+    slider.setValue(50);
+    layout->addWidget(&slider);
+
+    QSlider powerSlider(Qt::Horizontal);
+    powerSlider.setObjectName(QStringLiteral("powerSlider"));
+    powerSlider.setAccessibleName(QStringLiteral("RF power"));
+    powerSlider.setRange(0, 100);
+    powerSlider.setValue(10);
+    layout->addWidget(&powerSlider);
+
+    QPushButton independentButton(QStringLiteral("Independent event"));
+    independentButton.setObjectName(QStringLiteral("independentButton"));
+    layout->addWidget(&independentButton);
+
+    QPushButton keyingButton(QStringLiteral("PTT"));
+    keyingButton.setObjectName(QStringLiteral("keyingButton"));
+    markTxKeying(&keyingButton);
+    layout->addWidget(&keyingButton);
+
+    window.show();
+    waitUntil([&window]() { return window.isVisible(); });
+
+    AutomationServer server;
+    server.setAuthToken(QStringLiteral("test-token"));
+    qputenv("AETHER_AUTOMATION_TX_MAX_POWER", "10");
+#if defined(Q_OS_UNIX)
+    // Keep the AF_UNIX path below macOS's short sockaddr_un limit even when
+    // the runner's TMPDIR is deeply nested.
+    const QString serverName = QStringLiteral("/tmp/aether-gesture-%1")
+                                   .arg(QCoreApplication::applicationPid());
+#else
+    const QString serverName = QStringLiteral("aether-gesture-%1")
+                                   .arg(QCoreApplication::applicationPid());
+#endif
+    expect("server starts", server.start(serverName));
+    qunsetenv("AETHER_AUTOMATION_TX_MAX_POWER");
+
+    QLocalSocket gestureClient;
+    QLocalSocket independentClient;
+    expect("gesture client connects",
+           connectClient(&gestureClient, server.fullServerName()));
+    expect("independent client connects",
+           connectClient(&independentClient, server.fullServerName()));
+
+    const QJsonObject badBegin = gesture(
+        &gestureClient, QStringLiteral("begin"), QStringLiteral("phaseSlider"),
+        QStringLiteral("bad"));
+    expect("malformed begin identifies local coordinates",
+           !badBegin.value(QStringLiteral("ok")).toBool()
+               && badBegin.value(QStringLiteral("error")).toString().contains(
+                   QStringLiteral("coordinates"))
+               && !badBegin.value(QStringLiteral("error")).toString().contains(
+                   QStringLiteral("offsets"))
+               && !slider.isSliderDown());
+
+    const QJsonObject begun = gesture(
+        &gestureClient, QStringLiteral("begin"), QStringLiteral("phaseSlider"));
+    expect("begin leaves the real slider down",
+           begun.value(QStringLiteral("ok")).toBool()
+               && begun.value(QStringLiteral("sliderDown")).toBool()
+               && slider.isSliderDown());
+
+    bool independentClicked = false;
+    QObject::connect(&independentButton, &QPushButton::clicked,
+                     [&independentClicked]() { independentClicked = true; });
+    const QJsonObject invoked = request(
+        &independentClient,
+        QJsonObject{
+            {QStringLiteral("cmd"), QStringLiteral("invoke")},
+            {QStringLiteral("target"), QStringLiteral("independentButton")},
+            {QStringLiteral("action"), QStringLiteral("click")},
+        });
+    expect("independent bridge request is accepted mid-gesture",
+           invoked.value(QStringLiteral("ok")).toBool());
+    expect("independent event runs while slider remains down",
+           waitUntil([&independentClicked]() { return independentClicked; })
+               && slider.isSliderDown());
+
+    const QJsonObject observed = gesture(
+        &independentClient, QStringLiteral("status"));
+    expect("second client observes active gesture without owning it",
+           observed.value(QStringLiteral("active")).toBool()
+               && observed.value(QStringLiteral("sliderDown")).toBool()
+               && !observed.value(QStringLiteral("ownedByCaller")).toBool());
+
+    const QJsonObject moved = gesture(
+        &gestureClient, QStringLiteral("move"), {}, QStringLiteral("30 0"));
+    expect("move keeps slider down",
+           moved.value(QStringLiteral("ok")).toBool()
+               && moved.value(QStringLiteral("sliderDown")).toBool()
+               && slider.isSliderDown());
+    const QJsonObject ended = gesture(
+        &gestureClient, QStringLiteral("end"));
+    expect("end releases slider",
+           ended.value(QStringLiteral("ok")).toBool()
+               && !ended.value(QStringLiteral("active")).toBool()
+               && !slider.isSliderDown());
+
+    slider.setValue(50);
+    gesture(&gestureClient, QStringLiteral("begin"),
+            QStringLiteral("phaseSlider"));
+    const QJsonObject finalMoved = gesture(
+        &gestureClient, QStringLiteral("end"), {}, QStringLiteral("60 0"));
+    expect("end with an offset sends a final move before release",
+           finalMoved.value(QStringLiteral("ok")).toBool()
+               && finalMoved.value(QStringLiteral("dx")).toInt() == 60
+               && slider.value() > 50
+               && !slider.isSliderDown());
+
+    gesture(&gestureClient, QStringLiteral("begin"),
+            QStringLiteral("phaseSlider"));
+    const QJsonObject badMove = gesture(
+        &gestureClient, QStringLiteral("move"), {}, QStringLiteral("bad"));
+    expect("malformed continuation releases slider",
+           !badMove.value(QStringLiteral("ok")).toBool()
+               && !slider.isSliderDown());
+
+    gesture(&gestureClient, QStringLiteral("begin"),
+            QStringLiteral("phaseSlider"));
+    gestureClient.abort();
+    expect("owner disconnect releases slider",
+           waitUntil([&slider]() { return !slider.isSliderDown(); }));
+
+    QLocalSocket replacementClient;
+    expect("replacement client connects",
+           connectClient(&replacementClient, server.fullServerName()));
+    const QJsonObject unauthenticated = gesture(
+        &replacementClient, QStringLiteral("begin"),
+        QStringLiteral("phaseSlider"), {}, false);
+    expect("authentication gate blocks gesture begin",
+           !unauthenticated.value(QStringLiteral("ok")).toBool()
+               && !slider.isSliderDown());
+
+    server.setReadOnly(true);
+    const QJsonObject readOnly = gesture(
+        &replacementClient, QStringLiteral("begin"),
+        QStringLiteral("phaseSlider"));
+    expect("observe-only gate blocks gesture begin",
+           !readOnly.value(QStringLiteral("ok")).toBool()
+               && !slider.isSliderDown());
+    server.setReadOnly(false);
+
+    const QJsonObject keying = gesture(
+        &replacementClient, QStringLiteral("begin"),
+        QStringLiteral("keyingButton"));
+    expect("TX-keying guard blocks phaseful gesture",
+           !keying.value(QStringLiteral("ok")).toBool());
+    const QJsonObject legacyDrag = request(
+        &replacementClient,
+        QJsonObject{
+            {QStringLiteral("cmd"), QStringLiteral("drag")},
+            {QStringLiteral("target"), QStringLiteral("keyingButton")},
+            {QStringLiteral("value"), QStringLiteral("5 0")},
+        });
+    expect("TX-keying guard also covers legacy drag",
+           !legacyDrag.value(QStringLiteral("ok")).toBool());
+
+    const QJsonObject powerGesture = gesture(
+        &replacementClient, QStringLiteral("begin"),
+        QStringLiteral("powerSlider"));
+    expect("power ceiling blocks phaseful gesture",
+           !powerGesture.value(QStringLiteral("ok")).toBool()
+               && !powerSlider.isSliderDown());
+    const QJsonObject powerDragAt = request(
+        &replacementClient,
+        QJsonObject{
+            {QStringLiteral("cmd"), QStringLiteral("dragAt")},
+            {QStringLiteral("target"), QStringLiteral("powerSlider")},
+            {QStringLiteral("value"), QStringLiteral("5 5 10 0")},
+        });
+    expect("power ceiling also covers concurrent dragAt integration",
+           !powerDragAt.value(QStringLiteral("ok")).toBool()
+               && !powerSlider.isSliderDown());
+
+    gesture(&replacementClient, QStringLiteral("begin"),
+            QStringLiteral("phaseSlider"));
+    server.stop();
+    expect("server stop releases slider", !slider.isSliderDown());
+
+    if (gFailures == 0) {
+        std::printf("\nAll phaseful-gesture checks passed.\n");
+    } else {
+        std::printf("\n%d phaseful-gesture checks failed.\n", gFailures);
+    }
+    return gFailures == 0 ? 0 : 1;
+}

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -35,6 +35,7 @@ Env:
     AETHER_MCP_TOKEN    access token from Radio Setup → Network (if set)
 """
 
+import atexit
 import base64
 import difflib
 import glob
@@ -49,6 +50,9 @@ PROTOCOL_VERSION = "2024-11-05"
 SERVER_INFO = {"name": "aethersdr-automation", "version": "1.0.0"}
 REQUEST_TIMEOUT_S = 60
 MAX_INLINE_IMAGE_BYTES = 800_000  # larger grabs are returned as a path only
+
+_gesture_bridge = None
+_gesture_socket_path = None
 
 
 # --------------------------------------------------------------------------
@@ -141,14 +145,33 @@ def bridge_request(obj, timeout=REQUEST_TIMEOUT_S):
     # Attach the access token to every request so the bridge's auth gate
     # accepts it. Harmless when the bridge has no token configured (the
     # field is simply ignored). `ping` doesn't need it but sending it is fine.
-    token = os.environ.get("AETHER_MCP_TOKEN")
-    if token and "token" not in obj:
-        obj = dict(obj, token=token)
+    obj = _authenticated_request(obj)
     b = Bridge(sock_path, timeout)
     try:
         return b.request(obj)
     finally:
         b.close()
+
+
+def _authenticated_request(obj):
+    """Copy a request and attach the runtime token without logging it."""
+    token = os.environ.get("AETHER_MCP_TOKEN")
+    if token and "token" not in obj:
+        return dict(obj, token=token)
+    return obj
+
+
+def _close_gesture_bridge():
+    """Close the held gesture transport; app-side disconnect releases input."""
+    global _gesture_bridge, _gesture_socket_path
+    bridge = _gesture_bridge
+    _gesture_bridge = None
+    _gesture_socket_path = None
+    if bridge is not None:
+        bridge.close()
+
+
+atexit.register(_close_gesture_bridge)
 
 
 # --------------------------------------------------------------------------
@@ -432,6 +455,26 @@ TOOLS = [
             "expected": {"type": "string"},
             "selector": {"type": "string"},
         }, "required": ["model", "property", "expected"]},
+    },
+    {
+        "name": "gesture",
+        "description": (
+            "Hold a real pointer gesture open across MCP calls so independent "
+            "bridge requests and delayed app/model events can interleave while "
+            "a slider is genuinely down. Use begin(target, optional start x/y), "
+            "then move(dx/dy), status, and end(dx/dy) or cancel. The wrapper "
+            "keeps one private bridge connection for the gesture; any error, "
+            "disconnect, or server lease timeout releases it. TX and read-only "
+            "guards are enforced in the app."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string",
+                       "enum": ["begin", "move", "end", "cancel", "status"]},
+            "target": {"type": "string",
+                       "description": "widget target, required for begin"},
+            "value": {"type": "string",
+                      "description": ("begin: optional local 'x y'; move/end: "
+                                      "fixed-base 'dx dy' offsets")},
+        }, "required": ["action"]},
     },
     {
         "name": "bridge_command",
@@ -745,6 +788,60 @@ def handle_tool(name, args):
                     out["last_error"] = last_err
                 return text_result(out)
             time.sleep(interval)
+
+    if name == "gesture":
+        global _gesture_bridge, _gesture_socket_path
+        action = str(args.get("action") or "").strip().lower()
+        if action not in ("begin", "move", "end", "cancel", "status"):
+            return error_result(
+                "gesture action must be begin, move, end, cancel, or status")
+
+        if action == "begin":
+            target = str(args.get("target") or "").strip()
+            if not target:
+                return error_result("gesture begin requires `target`")
+            if _gesture_bridge is not None:
+                return error_result(
+                    "a gesture is already active; end or cancel it first")
+            sock_path = bridge_socket_path()
+            if not sock_path:
+                return error_result(
+                    "no running AetherSDR automation bridge found")
+            try:
+                _gesture_bridge = Bridge(sock_path, REQUEST_TIMEOUT_S)
+                _gesture_socket_path = sock_path
+                req = {"cmd": "gesture", "action": "begin", "target": target}
+                if args.get("value") is not None:
+                    req["value"] = str(args["value"])
+                response = _gesture_bridge.request(_authenticated_request(req))
+            except Exception as exc:  # noqa: BLE001 — cleanup is the contract
+                _close_gesture_bridge()
+                return error_result(str(exc))
+            if not isinstance(response, dict) or not response.get("ok"):
+                _close_gesture_bridge()
+            return text_result(response)
+
+        if action == "status" and _gesture_bridge is None:
+            return text_result(bridge_request(
+                {"cmd": "gesture", "action": "status"}))
+        if _gesture_bridge is None:
+            return error_result("no active gesture; begin one first")
+
+        req = {"cmd": "gesture", "action": action}
+        if args.get("value") is not None:
+            req["value"] = str(args["value"])
+        try:
+            response = _gesture_bridge.request(_authenticated_request(req))
+        except Exception as exc:  # noqa: BLE001 — closing releases app input
+            _close_gesture_bridge()
+            return error_result(str(exc))
+
+        terminal = (action in ("end", "cancel")
+                    or (isinstance(response, dict)
+                        and response.get("active") is False))
+        if terminal or not isinstance(response, dict) or not response.get("ok"):
+            _close_gesture_bridge()
+        return text_result(response)
 
     if name == "bridge_command":
         req = args.get("request")

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -198,6 +198,98 @@ def test_token_attached():
         del os.environ["AETHER_MCP_TOKEN"]
 
 
+def test_gesture_session():
+    """A phaseful gesture must reuse one bridge connection until terminal."""
+    aether_mcp._close_gesture_bridge()
+    os.environ["AETHER_MCP_TOKEN"] = "gesture-secret"
+    instances = []
+
+    class _GestureBridge:
+        def __init__(self, sock_path, timeout):
+            self.sock_path = sock_path
+            self.timeout = timeout
+            self.requests = []
+            self.closed = False
+            instances.append(self)
+
+        def request(self, obj):
+            self.requests.append(obj)
+            action = obj.get("action")
+            return {"ok": True, "active": action not in ("end", "cancel"),
+                    "sliderDown": action not in ("end", "cancel")}
+
+        def close(self):
+            self.closed = True
+
+    original_bridge = aether_mcp.Bridge
+    original_sockpath = aether_mcp.bridge_socket_path
+    aether_mcp.Bridge = _GestureBridge
+    aether_mcp.bridge_socket_path = lambda: "/tmp/gesture.sock"
+    try:
+        begin = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "begin", "target": "RF power"})
+            ["content"][0]["text"])
+        move = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "move", "value": "12 0"})
+            ["content"][0]["text"])
+        status = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "status"})["content"][0]["text"])
+
+        check("gesture begin/move/status reuse one connection",
+              len(instances) == 1 and len(instances[0].requests) == 3,
+              str(instances))
+        check("gesture keeps slider down before end",
+              begin.get("sliderDown") and move.get("sliderDown")
+              and status.get("sliderDown"), str((begin, move, status)))
+        check("gesture requests carry runtime token",
+              all(r.get("token") == "gesture-secret"
+                  for r in instances[0].requests), str(instances[0].requests))
+
+        ended = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "end"})["content"][0]["text"])
+        check("gesture end closes held connection",
+              ended.get("active") is False and instances[0].closed
+              and aether_mcp._gesture_bridge is None, str(ended))
+
+        class _ExpiredGestureBridge(_GestureBridge):
+            def request(self, obj):
+                self.requests.append(obj)
+                if obj.get("action") == "status":
+                    return {"ok": True, "active": False}
+                return {"ok": True, "active": True}
+
+        aether_mcp.Bridge = _ExpiredGestureBridge
+        aether_mcp.handle_tool(
+            "gesture", {"action": "begin", "target": "RF power"})
+        expired = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "status"})["content"][0]["text"])
+        check("gesture status clears an expired held connection",
+              expired.get("active") is False and instances[-1].closed
+              and aether_mcp._gesture_bridge is None, str(expired))
+
+        class _FailingGestureBridge(_GestureBridge):
+            def request(self, obj):
+                self.requests.append(obj)
+                if obj.get("action") == "move":
+                    return {"ok": False, "error": "bad move"}
+                return {"ok": True, "active": True}
+
+        aether_mcp.Bridge = _FailingGestureBridge
+        aether_mcp.handle_tool(
+            "gesture", {"action": "begin", "target": "RF power"})
+        failed = json.loads(aether_mcp.handle_tool(
+            "gesture", {"action": "move", "value": "bad"})
+            ["content"][0]["text"])
+        check("gesture error closes transport for app-side release",
+              failed.get("ok") is False and instances[-1].closed
+              and aether_mcp._gesture_bridge is None, str(failed))
+    finally:
+        aether_mcp._close_gesture_bridge()
+        aether_mcp.Bridge = original_bridge
+        aether_mcp.bridge_socket_path = original_sockpath
+        os.environ.pop("AETHER_MCP_TOKEN", None)
+
+
 # ── JSON-RPC loop robustness (non-dict must not crash the loop) ──────────────
 
 def drive_main(lines):
@@ -373,6 +465,7 @@ def test_read_only_reflected():
 if __name__ == "__main__":
     test_field_mapping()
     test_token_attached()
+    test_gesture_session()
     test_jsonrpc_robustness()
     test_robustness_tools()
     test_fuzzy_suggest()


### PR DESCRIPTION
## Summary

Fixes #4353.

Adds a connection-owned `gesture begin/move/end/cancel/status` bridge capability so an authenticated client can keep a real synthetic pointer press open across main-loop turns. The existing atomic `drag` verb remains compatible. The implementation applies target resolution, auth, observe-only mode, TX-keying and power-ceiling guards; releases on end, cancel, malformed continuation, target loss, owner disconnect, bridge stop, and a 60-second inactivity lease; and exposes `sliderDown` for direct evidence.

The typed MCP wrapper keeps one private socket for the active gesture while other MCP tools use independent connections. No bug-specific production injection hook was added.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The regression uses two real `QLocalSocket` clients and proves an independent button event runs while `QSlider::isSliderDown()` remains true.

## Test plan

- [x] Local build passes (`cmake --build build -j8`)
- [x] Behavior verified through a fresh local app and the configured MCP transport
- [x] Existing tests pass: 131/131, with the quarantined CRDV test intentionally skipped
- [x] Reproduction and lifecycle semantics documented in `docs/automation-bridge.md`

Live proof used explicit identity `gesture-4353-live` at `/private/tmp/aether-gesture-4353.sock`, an isolated settings profile, `AETHER_AUTOMATION_NO_AUTOCONNECT=1`, and `txAllowed:false`. MCP `gesture begin` on Headphone volume returned `sliderDown:true`; a separate configured MCP client wrote an independent mark and observed `active:true`, `ownedByCaller:false`, `sliderDown:true`; move preserved the down state and end/status returned `active:false`.

Additional checks:

- `python3 tools/test_aether_mcp.py`
- `python3 tools/gen_bridge_docs.py`
- `python3 tools/check_engine_boundary.py --strict` (0 blocking findings)
- `git diff --check`

A real radio was not required or connected; no TX action was invoked.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls
- [x] Code is clean-room
- [x] No meter UI added or changed
- [x] Documentation updated
- [x] No GHSA applies; auth and TX rails are preserved and covered by tests

Generated with OpenAI Codex.