### PR TITLE
[Automation] Secure fresh-build MCP auth handoff

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -97,7 +97,9 @@ On macOS, do not host the bridge from a Codex-style sandboxed command. The
 native Cocoa platform can abort during `QApplication` startup if pasteboard or
 HIServices are unavailable, before AetherSDR reaches the automation bridge; with
 `QT_QPA_PLATFORM=offscreen`, the same sandbox can still deny the `QLocalServer`
-socket the bridge needs. Launch outside the command sandbox instead:
+socket the bridge needs. When the MCP wrapper is configured, prefer its secure
+[`app_instance`](#secure-fresh-build-handoff) launch. For a manual launch, run
+outside the command sandbox instead:
 
 ```bash
 QT_QPA_PLATFORM=offscreen AETHER_AUTOMATION=1 AETHER_AUTOMATION_NO_AUTOCONNECT=1 ./build/AetherSDR.app/Contents/MacOS/AetherSDR &
@@ -115,8 +117,7 @@ contributors to self-verify UI changes before requesting review.
 
 **Setup** (zero dependencies — plain Python 3):
 
-1. Launch the app with the bridge on: `AETHER_AUTOMATION=1 ./build/AetherSDR`
-2. Register the server with your assistant:
+1. Register the server with your assistant:
    - **Claude Code**: nothing to do — the repo's `.mcp.json` registers it;
      approve the prompt on first use. (Manual: `claude mcp add aethersdr
      -- python3 tools/aether_mcp.py`)
@@ -126,8 +127,11 @@ contributors to self-verify UI changes before requesting review.
         "command": "python3", "args": ["tools/aether_mcp.py"]}}}
      ```
    - **Windows**: use `python` (or `py -3`) instead of `python3`.
+2. Launch through `app_instance` (recommended for a fresh proof build), or
+   manually with `AETHER_AUTOMATION=1 ./build/AetherSDR`.
 
-**Tools exposed** (23 typed tools): introspection — `bridge_status`,
+**Tools exposed** (25 typed tools): process handoff — `app_instance`;
+introspection — `bridge_status`,
 `dump_tree` (with a `filter` arg), `grab_widget` (PNG inline; optional
 `path` for where the PNG is written, else a temp file),
 `get_state`, `get_log`, `floors`, `streams`; driving — `invoke`, `gesture`
@@ -166,6 +170,39 @@ plaintext settings file). Copy it into your assistant's MCP config as the
 verb except `ping` without a matching token. Headless/CI can supply the
 token via `AETHER_MCP_TOKEN` directly, which overrides the keychain.
 
+### Secure fresh-build handoff
+
+Use the typed MCP `app_instance` tool when the MCP wrapper already has
+`AETHER_MCP_TOKEN` from a secure runtime source (for example macOS Keychain,
+Credential Manager, or libsecret) but a newly built app has a different secret-
+store requester identity:
+
+```json
+{"action":"launch","worktree":"/absolute/path/to/AetherSDR","label":"issue-4354-proof"}
+```
+
+`worktree` must be an absolute AetherSDR Git worktree. The wrapper runs only its
+canonical `build/AetherSDR` artifact (`build/AetherSDR.app/Contents/MacOS/AetherSDR`
+on macOS), directly without a shell. It passes the wrapper token only in the
+child process environment using the app's existing `AETHER_MCP_TOKEN` runtime
+override; the token is never a command-line argument, MCP result, discovery
+field, log message, or settings value.
+
+Each launch gets a unique explicit local socket and safe label. The wrapper
+sets `AETHER_AUTOMATION_NO_AUTOCONNECT=1`, pins TX automation off with
+`AETHER_AUTOMATION_NO_TX=1`, removes any inherited TX-enable flag, and refuses
+success unless token-free `ping` reports that auth is required and authenticated
+`whoami` matches the exact child PID, socket, and label with `txAllowed:false`.
+All other MCP tools then target that owned socket. `status` inspects only the
+owned process; `stop`, wrapper exit, or a failed launch terminates only that
+process and releases its socket.
+
+The tool fails closed if the wrapper has no token. It does not read, print, or
+copy a secret from the app settings UI, so an assistant never needs to put the
+credential in chat or a plaintext MCP configuration. Observe-only remains
+operator-authoritative: if the saved setting is enabled, the launched instance
+reports `readOnly:true` and mutating tools remain blocked.
+
 What the token *does* and *doesn't* do: it opts a **specific** client in
 and protects the secret at rest (nothing in a backed-up / synced /
 screen-shared dotfile), across other user accounts, and over any network
@@ -185,6 +222,12 @@ transmit and that you, the operator, remain responsible for all
 emissions; once confirmed the choice persists. Toggling it drives the
 same `m_txAllowed` gate live (enabling arms the force-unkey watchdog;
 disabling force-unkeys immediately).
+
+For proof-build process owners, `AETHER_AUTOMATION_NO_TX=1` pins this gate off
+even when the operator preference was previously enabled. The Radio Setup
+checkbox is disabled for that process and live attempts to enable it are
+ignored. `app_instance launch` always sets this pin and verifies it through
+authenticated `whoami` before returning success.
 
 ### Observe-only (read-only) mode
 

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1714,9 +1714,12 @@ bool MainWindow::startAutomationBridge(const QString& sockName)
         // AETHER_AUTOMATION_ALLOW_TX into m_txAllowed and would otherwise
         // clobber a pre-start value. Fold in the persisted operator opt-in so
         // a GUI enable survives restart; setTxAllowed arms the watchdog.
+        const bool txPinnedOff =
+            qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_TX");
         guard->setTxAllowed(
-            qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
-            || AutomationBridgeSettings::txAllowed());
+            !txPinnedOff
+            && (qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
+                || AutomationBridgeSettings::txAllowed()));
         // Observe-only gate (#4188) — apply the persisted operator opt-in after
         // start() so the bridge comes up read-only if the box is checked. An env
         // override lets headless/CI pin the bridge observe-only regardless.
@@ -1748,6 +1751,11 @@ void MainWindow::setAutomationBridgeToken(const QString& token)
 
 void MainWindow::setAutomationTxAllowed(bool allowed)
 {
+    if (allowed && qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_TX")) {
+        qWarning().noquote()
+            << "Ignoring TX-automation enable while AETHER_AUTOMATION_NO_TX pins it off";
+        return;
+    }
     // Persist the operator opt-in (nested config) so it survives restart.
     AutomationBridgeSettings::setTxAllowed(allowed);
     // Push live so toggling takes effect on a running bridge immediately —

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1580,7 +1580,9 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             grid->addWidget(new QLabel("Allow TX via MCP:"), 3, 0);
             auto* txCheck = new QCheckBox("Enable transmit control");
             const bool envForcesTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX");
-            txCheck->setChecked(AutomationBridgeSettings::txAllowed() || envForcesTx);
+            const bool envBlocksTx = qEnvironmentVariableIsSet("AETHER_AUTOMATION_NO_TX");
+            txCheck->setChecked(!envBlocksTx
+                                && (AutomationBridgeSettings::txAllowed() || envForcesTx));
             txCheck->setToolTip(
                 "Let an MCP client key the transmitter (MOX/PTT/TUNE/ATU/CWX).\n"
                 "OFF by default — the bridge blocks all transmit-keying otherwise.\n"
@@ -1589,7 +1591,11 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             AetherSDR::ThemeManager::instance().applyStyleSheet(txCheck,
                 "QCheckBox { color: {{color.text.primary}}; font-size: 11px; }"
                 "QCheckBox::indicator { width: 14px; height: 14px; }");
-            if (envForcesTx) {
+            if (envBlocksTx) {
+                txCheck->setEnabled(false);
+                txCheck->setToolTip(txCheck->toolTip()
+                    + "\n\nPinned off by the AETHER_AUTOMATION_NO_TX launch variable.");
+            } else if (envForcesTx) {
                 txCheck->setEnabled(false);
                 txCheck->setToolTip(txCheck->toolTip()
                     + "\n\nForced on by the AETHER_AUTOMATION_ALLOW_TX launch variable.");

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -41,10 +41,14 @@ import difflib
 import glob
 import json
 import os
+import re
+import secrets
 import socket
+import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 
 PROTOCOL_VERSION = "2024-11-05"
 SERVER_INFO = {"name": "aethersdr-automation", "version": "1.0.0"}
@@ -53,6 +57,7 @@ MAX_INLINE_IMAGE_BYTES = 800_000  # larger grabs are returned as a path only
 
 _gesture_bridge = None
 _gesture_socket_path = None
+_owned_app = None
 
 
 # --------------------------------------------------------------------------
@@ -85,6 +90,8 @@ def discover_sockets():
 
 
 def bridge_socket_path():
+    if _owned_app is not None and _owned_app["process"].poll() is None:
+        return _owned_app["socket"]
     override = os.environ.get("AETHER_MCP_SOCKET")
     if override:
         return override
@@ -154,7 +161,7 @@ def bridge_request(obj, timeout=REQUEST_TIMEOUT_S):
 
 
 def _authenticated_request(obj):
-    """Copy a request and attach the runtime token without logging it."""
+    """Copy a bridge request and attach the runtime token without logging it."""
     token = os.environ.get("AETHER_MCP_TOKEN")
     if token and "token" not in obj:
         return dict(obj, token=token)
@@ -172,6 +179,156 @@ def _close_gesture_bridge():
 
 
 atexit.register(_close_gesture_bridge)
+# --------------------------------------------------------------------------
+# Secure fresh-build process handoff
+# --------------------------------------------------------------------------
+
+def _resolve_app_artifact(worktree):
+    """Resolve only the canonical AetherSDR artifact under an absolute worktree."""
+    if not worktree or not os.path.isabs(worktree):
+        raise ValueError("`worktree` must be an absolute path")
+    try:
+        root = Path(worktree).resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"worktree could not be resolved: {exc}") from exc
+    if not root.is_dir():
+        raise ValueError("worktree is not a directory")
+    if not (root / ".git").exists() or not (root / "AGENTS.md").is_file():
+        raise ValueError("worktree is not an AetherSDR Git worktree")
+    cmake_file = root / "CMakeLists.txt"
+    try:
+        cmake_head = cmake_file.read_text(encoding="utf-8")[:4096]
+    except OSError as exc:
+        raise ValueError(f"could not read worktree CMakeLists.txt: {exc}") from exc
+    if "project(AetherSDR " not in cmake_head:
+        raise ValueError("worktree CMakeLists.txt does not declare AetherSDR")
+
+    if sys.platform == "darwin":
+        executable = root / "build" / "AetherSDR.app" / "Contents" / "MacOS" / "AetherSDR"
+    elif sys.platform == "win32":
+        executable = root / "build" / "AetherSDR.exe"
+    else:
+        executable = root / "build" / "AetherSDR"
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ValueError(f"fresh build artifact is missing or not executable: {executable}")
+    return root, executable
+
+
+def _instance_label(value):
+    if value is None or not str(value).strip():
+        return f"mcp-proof-{os.getpid()}-{secrets.token_hex(3)}"
+    label = str(value).strip()
+    if not re.fullmatch(r"[A-Za-z0-9._-]{1,48}", label):
+        raise ValueError("`label` must be 1-48 ASCII letters, digits, dot, underscore, or dash")
+    return label
+
+
+def _instance_socket():
+    suffix = f"{os.getpid()}-{secrets.token_hex(4)}"
+    if sys.platform == "win32":
+        return f"aethersdr-mcp-{suffix}"
+    # Keep the AF_UNIX path short enough for macOS even when TMPDIR is deeply
+    # nested. /tmp is present on every supported Unix platform.
+    return f"/tmp/aether-mcp-{suffix}.sock"
+
+
+def _request_at(socket_path, obj, timeout=REQUEST_TIMEOUT_S, authenticated=True):
+    bridge = Bridge(socket_path, timeout)
+    try:
+        request = _authenticated_request(obj) if authenticated else obj
+        return bridge.request(request)
+    finally:
+        bridge.close()
+
+
+def _wait_for_owned_app(instance, timeout=25):
+    """Wait for exact authenticated identity; never accept discovery fallback."""
+    deadline = time.monotonic() + timeout
+    last_error = "bridge did not become ready"
+    while time.monotonic() < deadline:
+        return_code = instance["process"].poll()
+        if return_code is not None:
+            raise RuntimeError(f"AetherSDR exited before bridge startup (code {return_code})")
+        try:
+            ping = _request_at(instance["socket"], {"cmd": "ping"}, timeout=2,
+                               authenticated=False)
+            whoami = _request_at(instance["socket"], {"cmd": "whoami"}, timeout=2)
+        except (ConnectionError, FileNotFoundError, OSError, ValueError) as exc:
+            last_error = str(exc)
+            time.sleep(0.1)
+            continue
+        if not isinstance(ping, dict) or not ping.get("authRequired"):
+            raise RuntimeError("fresh-build bridge did not require authentication")
+        if not isinstance(whoami, dict) or not whoami.get("ok"):
+            raise RuntimeError("authenticated whoami failed")
+        if int(whoami.get("pid", -1)) != instance["process"].pid:
+            raise RuntimeError("authenticated bridge PID did not match the launched app")
+        identity = whoami.get("automationIdentity") or whoami.get("socket")
+        if identity != instance["socket"]:
+            raise RuntimeError("authenticated bridge identity did not match the explicit socket")
+        if whoami.get("label") != instance["label"]:
+            raise RuntimeError("authenticated bridge label did not match the launched instance")
+        if whoami.get("txAllowed") is not False:
+            raise RuntimeError("fresh-build bridge did not keep TX automation disabled")
+        return ping, whoami
+    raise RuntimeError(last_error)
+
+
+def _remove_owned_socket(instance):
+    if sys.platform == "win32" or not instance:
+        return
+    try:
+        os.unlink(instance["socket"])
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass  # app-owned socket cleanup is best-effort after process exit
+
+
+def _stop_owned_app():
+    global _owned_app
+    instance = _owned_app
+    if instance is None:
+        return {"ok": True, "running": False}
+    process = instance["process"]
+    if process.poll() is None:
+        try:
+            process.terminate()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+    if process.poll() is None:
+        return {
+            "ok": False,
+            "running": True,
+            "pid": process.pid,
+            "socket": instance["socket"],
+            "label": instance["label"],
+            "error": "AetherSDR did not exit after terminate and kill",
+        }
+    _owned_app = None
+    _remove_owned_socket(instance)
+    return {
+        "ok": True,
+        "running": False,
+        "pid": process.pid,
+        "socket": instance["socket"],
+        "label": instance["label"],
+        "exitCode": process.poll(),
+    }
+
+
+atexit.register(_stop_owned_app)
 
 
 # --------------------------------------------------------------------------
@@ -200,6 +357,25 @@ def prune_tree(node, needle):
 # --------------------------------------------------------------------------
 
 TOOLS = [
+    {
+        "name": "app_instance",
+        "description": (
+            "Securely launch, inspect, or stop one fresh local AetherSDR "
+            "proof build owned by this MCP server. Launch accepts an absolute "
+            "AetherSDR worktree and runs only its canonical build artifact, "
+            "handing the existing AETHER_MCP_TOKEN to the child in memory. It "
+            "uses a unique explicit socket/label, disables radio autoconnect, "
+            "pins TX automation off, and succeeds only after authenticated "
+            "whoami matches the child PID and identity. No token is returned, "
+            "logged, passed on the command line, or written to settings."),
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["launch", "status", "stop"]},
+            "worktree": {"type": "string",
+                         "description": "absolute AetherSDR worktree path for launch"},
+            "label": {"type": "string",
+                      "description": "optional safe instance label for launch"},
+        }, "required": ["action"]},
+    },
     {
         "name": "bridge_status",
         "description": (
@@ -602,6 +778,136 @@ def _maybe_suggest(resp, target):
 
 
 def handle_tool(name, args):
+    if name == "app_instance":
+        global _owned_app
+        action = str(args.get("action") or "").strip().lower()
+        if action not in ("launch", "status", "stop"):
+            return error_result("app_instance action must be launch, status, or stop")
+        if action == "stop":
+            return text_result(_stop_owned_app())
+        if action == "status":
+            if _owned_app is None:
+                return text_result({"ok": True, "running": False})
+            instance = _owned_app
+            process = instance["process"]
+            return_code = process.poll()
+            if return_code is not None:
+                _owned_app = None
+                _remove_owned_socket(instance)
+                return text_result({
+                    "ok": True,
+                    "running": False,
+                    "pid": process.pid,
+                    "socket": instance["socket"],
+                    "label": instance["label"],
+                    "exitCode": return_code,
+                })
+            try:
+                whoami = _request_at(instance["socket"], {"cmd": "whoami"}, timeout=5)
+            except Exception as exc:  # noqa: BLE001 — status must remain inspectable
+                return text_result({
+                    "ok": True,
+                    "running": True,
+                    "authenticated": False,
+                    "pid": process.pid,
+                    "socket": instance["socket"],
+                    "label": instance["label"],
+                    "error": str(exc),
+                })
+            identity = whoami.get("automationIdentity") or whoami.get("socket")
+            try:
+                whoami_pid = int(whoami.get("pid", -1))
+            except (TypeError, ValueError):
+                whoami_pid = -1
+            identity_matches = (
+                bool(whoami.get("ok"))
+                and whoami_pid == process.pid
+                and identity == instance["socket"]
+                and whoami.get("label") == instance["label"]
+                and whoami.get("txAllowed") is False)
+            return text_result({
+                "ok": True,
+                "running": True,
+                "authenticated": identity_matches,
+                "identityMatches": identity_matches,
+                "pid": process.pid,
+                "socket": instance["socket"],
+                "label": instance["label"],
+                "readOnly": whoami.get("readOnly", False),
+                "txAllowed": whoami.get("txAllowed"),
+                "version": whoami.get("version"),
+            })
+
+        if _owned_app is not None:
+            if _owned_app["process"].poll() is None:
+                return error_result(
+                    "this MCP server already owns a running AetherSDR instance; stop it first")
+            _remove_owned_socket(_owned_app)
+            _owned_app = None
+        if not os.environ.get("AETHER_MCP_TOKEN"):
+            return error_result(
+                "secure launch requires AETHER_MCP_TOKEN in this MCP server environment")
+        try:
+            root, executable = _resolve_app_artifact(args.get("worktree"))
+            label = _instance_label(args.get("label"))
+        except ValueError as exc:
+            return error_result(str(exc))
+
+        socket_path = _instance_socket()
+        child_env = os.environ.copy()
+        child_env["AETHER_AUTOMATION"] = "1"
+        child_env["AETHER_AUTOMATION_NO_AUTOCONNECT"] = "1"
+        child_env["AETHER_AUTOMATION_NO_TX"] = "1"
+        child_env["AETHER_AUTOMATION_SOCKET"] = socket_path
+        child_env["AETHER_AUTOMATION_LABEL"] = label
+        child_env["AETHER_AUTOMATION_IDENTITY"] = socket_path
+        child_env["AETHER_AUTOMATION_AGENT_NAME"] = label
+        child_env.pop("AETHER_AUTOMATION_ALLOW_TX", None)
+        child_env.pop("AETHER_MCP_SOCKET", None)
+
+        popen_kwargs = {
+            "cwd": str(root),
+            "env": child_env,
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+        try:
+            process = subprocess.Popen([str(executable)], **popen_kwargs)
+        except OSError as exc:
+            return error_result(f"could not launch fresh AetherSDR build: {exc}")
+
+        _owned_app = {
+            "process": process,
+            "socket": socket_path,
+            "label": label,
+            "worktree": str(root),
+            "executable": str(executable),
+        }
+        try:
+            ping, whoami = _wait_for_owned_app(_owned_app)
+        except Exception as exc:  # noqa: BLE001 — fail closed and reap child
+            _stop_owned_app()
+            return error_result(f"fresh-build authentication failed: {exc}")
+        return text_result({
+            "ok": True,
+            "running": True,
+            "authenticated": True,
+            "authRequired": ping.get("authRequired"),
+            "pid": process.pid,
+            "socket": socket_path,
+            "label": label,
+            "worktree": str(root),
+            "executable": str(executable),
+            "readOnly": whoami.get("readOnly", False),
+            "txAllowed": whoami.get("txAllowed"),
+            "version": whoami.get("version"),
+        })
+
     if name == "bridge_status":
         entries = discover_sockets()
         status = {"instances": entries, "active": None,

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -43,6 +43,7 @@ import json
 import os
 import re
 import secrets
+import signal
 import socket
 import stat
 import subprocess
@@ -253,6 +254,10 @@ def _wait_for_owned_app(instance, timeout=25):
         try:
             ping = _request_at(instance["socket"], {"cmd": "ping"}, timeout=2,
                                authenticated=False)
+            # A tokenless privileged call must be REFUSED, not merely advertised
+            # as required — this demonstrates enforcement, not just the flag.
+            tokenless = _request_at(instance["socket"], {"cmd": "whoami"},
+                                    timeout=2, authenticated=False)
             whoami = _request_at(instance["socket"], {"cmd": "whoami"}, timeout=2)
         except (ConnectionError, FileNotFoundError, OSError, ValueError) as exc:
             last_error = str(exc)
@@ -260,6 +265,9 @@ def _wait_for_owned_app(instance, timeout=25):
             continue
         if not isinstance(ping, dict) or not ping.get("authRequired"):
             raise RuntimeError("fresh-build bridge did not require authentication")
+        if isinstance(tokenless, dict) and tokenless.get("ok"):
+            raise RuntimeError(
+                "fresh-build bridge accepted a tokenless privileged command")
         if not isinstance(whoami, dict) or not whoami.get("ok"):
             raise RuntimeError("authenticated whoami failed")
         if int(whoami.get("pid", -1)) != instance["process"].pid:
@@ -296,6 +304,25 @@ def _remove_owned_socket(instance):
         pass  # app-owned socket cleanup is best-effort after process exit
 
 
+def _signal_owned_process(process, sig):
+    """Signal the child's whole session, not just its PID.
+
+    The child is launched with start_new_session=True, so it is a session
+    leader (pgid == pid) and any helper subprocesses it spawns share that
+    group; signalling the group reaps them too. Fall back to the single
+    process if the group is already gone or on Windows (no POSIX groups)."""
+    if sys.platform != "win32":
+        try:
+            os.killpg(os.getpgid(process.pid), sig)
+            return
+        except (ProcessLookupError, PermissionError, OSError):
+            pass  # group already reaped, or racing exit — fall back below
+    try:
+        (process.kill if sig == signal.SIGKILL else process.terminate)()
+    except OSError:
+        pass
+
+
 def _stop_owned_app():
     global _owned_app
     instance = _owned_app
@@ -303,17 +330,11 @@ def _stop_owned_app():
         return {"ok": True, "running": False}
     process = instance["process"]
     if process.poll() is None:
-        try:
-            process.terminate()
-        except OSError:
-            pass
+        _signal_owned_process(process, signal.SIGTERM)
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            try:
-                process.kill()
-            except OSError:
-                pass
+            _signal_owned_process(process, signal.SIGKILL)
             try:
                 process.wait(timeout=5)
             except subprocess.TimeoutExpired:
@@ -340,6 +361,28 @@ def _stop_owned_app():
 
 
 atexit.register(_stop_owned_app)
+
+
+def _handle_shutdown_signal(signum, _frame):
+    # atexit does NOT run when the process is killed by a signal, and an MCP
+    # host shuts its server down with SIGTERM. Run the same cleanups atexit
+    # would (reap the owned child so the app, its socket, and the shared
+    # app/radio lock don't leak; release the held gesture transport), then die
+    # with the default disposition so the exit status still reflects the signal.
+    _stop_owned_app()
+    _close_gesture_bridge()
+    try:
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+    except (OSError, ValueError):
+        os._exit(128 + signum)
+
+
+for _shutdown_signal in (signal.SIGTERM, signal.SIGINT):
+    try:
+        signal.signal(_shutdown_signal, _handle_shutdown_signal)
+    except (OSError, ValueError, AttributeError):
+        pass  # not the main thread, or the platform lacks this signal
 
 
 # --------------------------------------------------------------------------
@@ -924,6 +967,16 @@ def handle_tool(name, args):
         entries = discover_sockets()
         status = {"instances": entries, "active": None,
                   "token_configured_here": bool(os.environ.get("AETHER_MCP_TOKEN"))}
+        # A running owned app uses an explicit socket that never writes a
+        # discovery file, yet bridge_request routes to it; surface it so status
+        # reflects where commands actually go, not just discovered instances.
+        if _owned_app is not None and _owned_app["process"].poll() is None:
+            status["owned_instance"] = {
+                "socket": _owned_app["socket"],
+                "label": _owned_app["label"],
+                "pid": _owned_app["process"].pid,
+                "note": "MCP-owned fresh build; bridge commands route here.",
+            }
         if entries or os.environ.get("AETHER_MCP_SOCKET"):
             # ping needs no token and reveals whether the bridge requires one.
             try:

--- a/tools/aether_mcp.py
+++ b/tools/aether_mcp.py
@@ -44,6 +44,7 @@ import os
 import re
 import secrets
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -277,10 +278,20 @@ def _wait_for_owned_app(instance, timeout=25):
 def _remove_owned_socket(instance):
     if sys.platform == "win32" or not instance:
         return
+    socket_path = instance.get("socket", "")
+    expected = rf"/tmp/aether-mcp-{os.getpid()}-[0-9a-f]{{8}}\.sock"
+    if not re.fullmatch(expected, socket_path):
+        return
     try:
-        os.unlink(instance["socket"])
+        socket_stat = os.lstat(socket_path)
     except FileNotFoundError:
-        pass
+        return
+    except OSError:
+        return
+    if not stat.S_ISSOCK(socket_stat.st_mode):
+        return
+    try:
+        os.unlink(socket_path)
     except OSError:
         pass  # app-owned socket cleanup is best-effort after process exit
 
@@ -871,6 +882,7 @@ def handle_tool(name, args):
             "stdin": subprocess.DEVNULL,
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
+            "close_fds": True,
         }
         if sys.platform == "win32":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import tempfile
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import aether_mcp  # noqa: E402
@@ -300,6 +301,176 @@ def test_gesture_session():
         aether_mcp.Bridge = original_bridge
         aether_mcp.bridge_socket_path = original_sockpath
         os.environ.pop("AETHER_MCP_TOKEN", None)
+def test_secure_app_instance():
+    """Fresh builds inherit the token only at runtime and are identity-checked."""
+    aether_mcp._stop_owned_app()
+    original_popen = aether_mcp.subprocess.Popen
+    original_bridge = aether_mcp.Bridge
+    saved_env = {key: os.environ.get(key) for key in (
+        "AETHER_MCP_TOKEN", "AETHER_MCP_SOCKET", "AETHER_AUTOMATION_ALLOW_TX")}
+    popen_calls = []
+    bridge_requests = []
+    tx_allowed = [False]
+    ignore_stop = [False]
+
+    class _Process:
+        next_pid = 4200
+
+        def __init__(self):
+            self.pid = _Process.next_pid
+            _Process.next_pid += 1
+            self.returncode = None
+            self.terminated = False
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+            if not ignore_stop[0]:
+                self.returncode = -15
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise aether_mcp.subprocess.TimeoutExpired("AetherSDR", timeout)
+            return self.returncode
+
+        def kill(self):
+            if not ignore_stop[0]:
+                self.returncode = -9
+
+    def fake_popen(argv, **kwargs):
+        process = _Process()
+        popen_calls.append((argv, kwargs, process))
+        return process
+
+    class _Bridge:
+        def __init__(self, socket_path, timeout=None):
+            self.socket_path = socket_path
+
+        def request(self, obj):
+            bridge_requests.append(obj)
+            if obj.get("cmd") == "ping":
+                return {"ok": True, "authRequired": True}
+            instance = aether_mcp._owned_app
+            return {
+                "ok": True,
+                "pid": instance["process"].pid,
+                "automationIdentity": instance["socket"],
+                "socket": instance["socket"],
+                "label": instance["label"],
+                "txAllowed": tx_allowed[0],
+                "readOnly": False,
+                "version": "test",
+            }
+
+        def close(self):
+            pass
+
+    aether_mcp.subprocess.Popen = fake_popen
+    aether_mcp.Bridge = _Bridge
+    try:
+        with tempfile.TemporaryDirectory() as temp_root:
+            worktree = Path(temp_root) / "AetherSDR"
+            (worktree / ".git").mkdir(parents=True)
+            (worktree / "AGENTS.md").write_text("test\n", encoding="utf-8")
+            (worktree / "CMakeLists.txt").write_text(
+                "project(AetherSDR VERSION 1.0 LANGUAGES CXX)\n", encoding="utf-8")
+            if sys.platform == "darwin":
+                executable = (worktree / "build" / "AetherSDR.app" /
+                              "Contents" / "MacOS" / "AetherSDR")
+            elif sys.platform == "win32":
+                executable = worktree / "build" / "AetherSDR.exe"
+            else:
+                executable = worktree / "build" / "AetherSDR"
+            executable.parent.mkdir(parents=True)
+            executable.write_text("test artifact\n", encoding="utf-8")
+            executable.chmod(0o700)
+
+            os.environ["AETHER_MCP_TOKEN"] = "runtime-only-secret"
+            os.environ["AETHER_MCP_SOCKET"] = "/tmp/unrelated.sock"
+            os.environ["AETHER_AUTOMATION_ALLOW_TX"] = "1"
+            launched = json.loads(aether_mcp.handle_tool(
+                "app_instance", {"action": "launch", "worktree": str(worktree),
+                                 "label": "secure-proof"})["content"][0]["text"])
+
+            argv, kwargs, process = popen_calls[-1]
+            child_env = kwargs["env"]
+            check("app_instance launches exact canonical artifact without shell",
+                  argv == [str(executable.resolve())] and "shell" not in kwargs, str(argv))
+            check("app_instance hands token only through child environment",
+                  child_env.get("AETHER_MCP_TOKEN") == "runtime-only-secret"
+                  and "runtime-only-secret" not in json.dumps(launched)
+                  and "runtime-only-secret" not in " ".join(argv), str(launched))
+            check("app_instance pins no-autoconnect and no-TX",
+                  child_env.get("AETHER_AUTOMATION_NO_AUTOCONNECT") == "1"
+                  and child_env.get("AETHER_AUTOMATION_NO_TX") == "1"
+                  and child_env.get("AETHER_AUTOMATION_IDENTITY") == launched.get("socket")
+                  and child_env.get("AETHER_AUTOMATION_AGENT_NAME") == "secure-proof"
+                  and "AETHER_AUTOMATION_ALLOW_TX" not in child_env, str(child_env.keys()))
+            check("app_instance verifies exact authenticated identity",
+                  launched.get("authenticated") is True
+                  and launched.get("authRequired") is True
+                  and launched.get("pid") == process.pid
+                  and launched.get("txAllowed") is False
+                  and all("token" not in req for req in bridge_requests
+                          if req.get("cmd") == "ping")
+                  and all(req.get("token") == "runtime-only-secret"
+                          for req in bridge_requests if req.get("cmd") == "whoami"),
+                  str(launched))
+            check("owned instance becomes the wrapper bridge target",
+                  aether_mcp.bridge_socket_path() == launched.get("socket"), str(launched))
+
+            status = json.loads(aether_mcp.handle_tool(
+                "app_instance", {"action": "status"})["content"][0]["text"])
+            check("app_instance status is authenticated and scoped to owned PID",
+                  status.get("running") is True and status.get("authenticated") is True
+                  and status.get("pid") == process.pid, str(status))
+            stopped = json.loads(aether_mcp.handle_tool(
+                "app_instance", {"action": "stop"})["content"][0]["text"])
+            check("app_instance stop reaps only the owned process",
+                  stopped.get("running") is False and process.terminated
+                  and aether_mcp._owned_app is None, str(stopped))
+
+            os.environ.pop("AETHER_MCP_TOKEN", None)
+            before = len(popen_calls)
+            refused = aether_mcp.handle_tool(
+                "app_instance", {"action": "launch", "worktree": str(worktree)})
+            check("app_instance refuses tokenless launch before spawning",
+                  refused.get("isError") is True and len(popen_calls) == before,
+                  str(refused))
+
+            os.environ["AETHER_MCP_TOKEN"] = "runtime-only-secret"
+            tx_allowed[0] = True
+            rejected = aether_mcp.handle_tool(
+                "app_instance", {"action": "launch", "worktree": str(worktree),
+                                 "label": "unsafe-proof"})
+            unsafe_process = popen_calls[-1][2]
+            check("app_instance kills child when authenticated TX is not pinned off",
+                  rejected.get("isError") is True and unsafe_process.terminated
+                  and aether_mcp._owned_app is None, str(rejected))
+
+            tx_allowed[0] = False
+            ignore_stop[0] = True
+            stubborn = json.loads(aether_mcp.handle_tool(
+                "app_instance", {"action": "launch", "worktree": str(worktree),
+                                 "label": "stubborn-proof"})["content"][0]["text"])
+            refused_stop = json.loads(aether_mcp.handle_tool(
+                "app_instance", {"action": "stop"})["content"][0]["text"])
+            check("app_instance does not claim an unkillable child was stopped",
+                  stubborn.get("running") is True and refused_stop.get("ok") is False
+                  and refused_stop.get("running") is True
+                  and aether_mcp._owned_app is not None, str(refused_stop))
+            ignore_stop[0] = False
+    finally:
+        aether_mcp._stop_owned_app()
+        aether_mcp.subprocess.Popen = original_popen
+        aether_mcp.Bridge = original_bridge
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 # ── JSON-RPC loop robustness (non-dict must not crash the loop) ──────────────
@@ -478,6 +649,7 @@ if __name__ == "__main__":
     test_field_mapping()
     test_token_attached()
     test_gesture_session()
+    test_secure_app_instance()
     test_jsonrpc_robustness()
     test_robustness_tools()
     test_fuzzy_suggest()

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -312,6 +312,7 @@ def test_secure_app_instance():
     bridge_requests = []
     tx_allowed = [False]
     ignore_stop = [False]
+    accept_tokenless = [False]  # simulate a bridge that advertises but doesn't enforce auth
 
     class _Process:
         next_pid = 4200
@@ -352,6 +353,13 @@ def test_secure_app_instance():
             bridge_requests.append(obj)
             if obj.get("cmd") == "ping":
                 return {"ok": True, "authRequired": True}
+            # Model the real bridge's shared-secret gate: a privileged command
+            # without the matching token is refused (never ok). This lets the
+            # launch proof assert an actual tokenless rejection, not just the
+            # advertised authRequired flag.
+            if (obj.get("token") != os.environ.get("AETHER_MCP_TOKEN")
+                    and not accept_tokenless[0]):
+                return {"error": "unauthorized: this bridge requires a token"}
             instance = aether_mcp._owned_app
             return {
                 "ok": True,
@@ -409,6 +417,8 @@ def test_secure_app_instance():
                   and child_env.get("AETHER_AUTOMATION_IDENTITY") == launched.get("socket")
                   and child_env.get("AETHER_AUTOMATION_AGENT_NAME") == "secure-proof"
                   and "AETHER_AUTOMATION_ALLOW_TX" not in child_env, str(child_env.keys()))
+            whoami_reqs = [req for req in bridge_requests
+                           if req.get("cmd") == "whoami"]
             check("app_instance verifies exact authenticated identity",
                   launched.get("authenticated") is True
                   and launched.get("authRequired") is True
@@ -416,8 +426,12 @@ def test_secure_app_instance():
                   and launched.get("txAllowed") is False
                   and all("token" not in req for req in bridge_requests
                           if req.get("cmd") == "ping")
-                  and all(req.get("token") == "runtime-only-secret"
-                          for req in bridge_requests if req.get("cmd") == "whoami"),
+                  # The authenticated identity check carries the runtime token.
+                  and any(req.get("token") == "runtime-only-secret"
+                          for req in whoami_reqs)
+                  # The launch proof also sends a TOKENLESS whoami and requires
+                  # the bridge to refuse it — enforcement, not just the flag.
+                  and any("token" not in req for req in whoami_reqs),
                   str(launched))
             check("owned instance becomes the wrapper bridge target",
                   aether_mcp.bridge_socket_path() == launched.get("socket"), str(launched))
@@ -463,6 +477,20 @@ def test_secure_app_instance():
                   and refused_stop.get("running") is True
                   and aether_mcp._owned_app is not None, str(refused_stop))
             ignore_stop[0] = False
+            # The stubborn instance is reapable again now — clear it before the
+            # next launch (which refuses while an instance is still owned).
+            aether_mcp.handle_tool("app_instance", {"action": "stop"})
+
+            # #3: a bridge that ADVERTISES authRequired but ACCEPTS a tokenless
+            # privileged command must be refused (fail closed), not launched.
+            accept_tokenless[0] = True
+            insecure = aether_mcp.handle_tool(
+                "app_instance", {"action": "launch", "worktree": str(worktree),
+                                 "label": "insecure-proof"})
+            check("app_instance refuses a bridge that accepts tokenless commands",
+                  insecure.get("isError") is True
+                  and aether_mcp._owned_app is None, str(insecure))
+            accept_tokenless[0] = False
 
             if sys.platform != "win32":
                 non_socket_path = aether_mcp._instance_socket()

--- a/tools/test_aether_mcp.py
+++ b/tools/test_aether_mcp.py
@@ -397,7 +397,8 @@ def test_secure_app_instance():
             argv, kwargs, process = popen_calls[-1]
             child_env = kwargs["env"]
             check("app_instance launches exact canonical artifact without shell",
-                  argv == [str(executable.resolve())] and "shell" not in kwargs, str(argv))
+                  argv == [str(executable.resolve())] and "shell" not in kwargs
+                  and kwargs.get("close_fds") is True, str(argv))
             check("app_instance hands token only through child environment",
                   child_env.get("AETHER_MCP_TOKEN") == "runtime-only-secret"
                   and "runtime-only-secret" not in json.dumps(launched)
@@ -462,6 +463,16 @@ def test_secure_app_instance():
                   and refused_stop.get("running") is True
                   and aether_mcp._owned_app is not None, str(refused_stop))
             ignore_stop[0] = False
+
+            if sys.platform != "win32":
+                non_socket_path = aether_mcp._instance_socket()
+                Path(non_socket_path).write_text("do not unlink\n", encoding="utf-8")
+                try:
+                    aether_mcp._remove_owned_socket({"socket": non_socket_path})
+                    check("socket cleanup refuses an owned-name non-socket",
+                          Path(non_socket_path).is_file(), non_socket_path)
+                finally:
+                    Path(non_socket_path).unlink(missing_ok=True)
     finally:
         aether_mcp._stop_owned_app()
         aether_mcp.subprocess.Popen = original_popen


### PR DESCRIPTION
## Summary

Fixes #4354. Adds a typed `app_instance` MCP tool that securely launches one canonical fresh-build artifact with the wrapper's existing runtime token, a unique explicit socket/identity, radio autoconnect disabled, and TX automation pinned off. Launch succeeds only after unauthenticated `ping` proves authentication is required and authenticated `whoami` matches the exact child PID, socket, label, and `txAllowed:false`. The wrapper owns cleanup and never places the token in arguments, results, discovery metadata, logs, or settings. The app-side no-TX pin cannot be overridden by saved settings or the live UI. Documentation and protocol regression tests cover launch, identity verification, tokenless refusal, unsafe-TX refusal, status, stop, and unkillable-child reporting.

This is intentionally separate from #4353 / #4355: that PR changes the bridge's in-process gesture protocol and connection lifecycle, while this one owns process launch, credential handoff, discovery identity, and cleanup. Keeping the security boundary isolated makes each risk independently reviewable and revertible.

## Constitution principle honored

Principle VII — every worktree, label, artifact, socket identity, authenticated PID, and TX state crossing the MCP/process boundary is validated before the wrapper claims success. Principle IX and XI are also exercised through the exact-identity live proof and fail-closed regression tests.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified without a radio; radio autoconnect stayed disabled and TX automation was `false`
- [ ] Existing tests pass (CI)
- [x] Reproduction and secure handoff steps documented
- [x] Full local CTest: 130/130 passed (one expected quarantined skip)
- [x] MCP protocol tests, bridge-doc generator/check, strict engine-boundary check, accessibility scan, Python compile, and `git diff --check`
- [x] Fresh-build MCP proof: `app_instance launch` authenticated PID 91620 at `/tmp/aether-mcp-91509-ad6c733a.sock`, label `auth-4354-live`, version 26.7.3, `txAllowed:false`; the already configured Codex MCP wrapper authenticated to the same identity and wrote a bridge log mark
- [x] Process command line contained only `build/AetherSDR.app/Contents/MacOS/AetherSDR`; `app_instance stop` returned exit code -15, removed the explicit socket, reaped the PID, and the shared app/radio lock was released

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter UI changed)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable (no vulnerability or GHSA involved)
