### PR TITLE
test(asr): use std::numbers::pi so asr_segmenter_test builds on MSVC

### DIFF
--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <numbers>   // std::numbers::pi — M_PI needs _USE_MATH_DEFINES on MSVC
 #include <vector>
 
 using AetherSDR::AsrSegmenter;
@@ -36,7 +37,7 @@ void appendTone(std::vector<float>& buf, int ms, float amp = 0.3f, float freq = 
     const int n = ms * kRate / 1000;
     for (int i = 0; i < n; ++i) {
         const double t = static_cast<double>(i) / kRate;
-        buf.push_back(amp * static_cast<float>(std::sin(2.0 * M_PI * freq * t)));
+        buf.push_back(amp * static_cast<float>(std::sin(2.0 * std::numbers::pi * freq * t)));
     }
 }
 


### PR DESCRIPTION
### Problem

`asr_segmenter_test` does not compile with MSVC:

```
tests\asr_segmenter_test.cpp(39): error C2065: 'M_PI': undeclared identifier
FAILED: CMakeFiles/asr_segmenter_test.dir/tests/asr_segmenter_test.cpp.obj
ninja: build stopped: subcommand failed.
```

`M_PI` is a POSIX extension rather than part of standard C or C++. libstdc++ and libc++ expose it from `<cmath>` by default, so GCC and Clang builds are unaffected; MSVC only defines it when `_USE_MATH_DEFINES` is set before `<cmath>` is included.

### Why only this one file

The other ASR and GUI tests use `M_PI` too, but they compile under MSVC by accident: their Qt includes (`<QVector>`, `<QPainterPath>`, …) pull in `qmath.h`, which defines `M_PI` as a side effect. `asr_segmenter_test.cpp` includes no Qt headers, so it has nothing to fall back on and is the only one that actually breaks.

I verified this rather than assuming it — forcing a recompile of each translation unit individually with the fix reverted, `asr_segmenter_test` is the only failure. I'd initially patched all three call sites and reverted the two that turned out to be unnecessary, to keep this change minimal.

### Fix

Use the C++20 `std::numbers::pi`, matching the convention already established in this repo:

- `src/core/WfmDsp.cpp:7` — `#include <numbers>   // std::numbers::pi — M_PI needs _USE_MATH_DEFINES on MSVC`
- `tests/wfm_dsp_test.cpp:16` — same include and comment
- `src/core/PacketLossConcealment.cpp:11` documents the same trap

Two lines: the include, and the constant. No behaviour change — `std::numbers::pi` is the same value as a `double`, and the surrounding `static_cast<float>` is untouched.

### Why CI did not catch it

`check-windows` in `.github/workflows/ci.yml` configures without `-DENABLE_ASR`, so the ASR test targets are never built on Windows. Worth considering whether a Windows job should exercise `-DENABLE_ASR=ON`, since the branch's Windows path is currently unexercised — see also @NF0T's MinGW report on #4338 (`ggml-cpu.c` `StateMask`), which is a separate issue in vendored ggml but points the same way.

### Test plan

Built on Windows 11, MSVC (VS BuildTools 18), Qt 6.10.3, Ninja, off `feat/asr-phase1-build` @ `765099cb` with `-DENABLE_ASR=ON` and the Vulkan GPU backend enabled:

- Before: `asr_segmenter_test` fails to compile (error above).
- After: compiles clean, and the test passes — `ASR segmenter: ALL PASS`, exit 0.
- `asr_engine_test` also `ALL PASS`, exit 0 (untouched by this PR).

Full-app build is green with this change, and I ran the resulting binary against a live FLEX-6300 with Copy Assist transcribing 20 m SSB on the GPU, so the branch is otherwise working well on Windows.

Base branch is `feat/asr-phase1-build` rather than `main`, since that is where the affected test lives.
