### PR TITLE
Clean compiler and linker warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
+
+# CMake 3.29+ can safely de-duplicate libraries for linkers that support it.
+# This avoids duplicate-library warnings from Apple's linker while preserving
+# compatibility with the project's CMake 3.25 minimum.
+if(POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
 project(AetherSDR VERSION 26.7.3 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -1249,6 +1257,18 @@ if((UNIX OR WIN32) AND ENABLE_DSTAR)
         ${DIGITAL_VOICE_WAVEFORM_DIR}/resampler.c
     )
 
+    # ThumbDV is vendored C code and is also compiled directly by its queue
+    # test, so suppress platform deprecation warnings at the source boundary.
+    if(MSVC)
+        set_source_files_properties(
+            ${DIGITAL_VOICE_WAVEFORM_DIR}/ThumbDV/thumbDV.c
+            PROPERTIES COMPILE_FLAGS "/w")
+    else()
+        set_source_files_properties(
+            ${DIGITAL_VOICE_WAVEFORM_DIR}/ThumbDV/thumbDV.c
+            PROPERTIES COMPILE_FLAGS "-w")
+    endif()
+
     add_executable(aether-dv-waveform ${DIGITAL_VOICE_WAVEFORM_SOURCES})
     set_target_properties(aether-dv-waveform PROPERTIES
         C_STANDARD 11
@@ -1819,6 +1839,11 @@ if (USE_SYSTEM_RTMIDI)
     target_link_libraries(aethercore PUBLIC PkgConfig::rtmidi)
 else()
     target_sources(aethercore PRIVATE third_party/rtmidi/RtMidi.cpp)
+    if(MSVC)
+        set_source_files_properties(third_party/rtmidi/RtMidi.cpp PROPERTIES COMPILE_FLAGS "/w")
+    else()
+        set_source_files_properties(third_party/rtmidi/RtMidi.cpp PROPERTIES COMPILE_FLAGS "-w")
+    endif()
     # PUBLIC: MidiControlManager.h includes RtMidi.h
     target_include_directories(aethercore PUBLIC third_party/rtmidi)
 endif()
@@ -2173,7 +2198,7 @@ if(ENABLE_MQTT)
             target_compile_definitions(aethercore PUBLIC HAVE_MQTT_TLS)
         endif()
     else()
-        target_include_directories(aethercore PRIVATE
+        target_include_directories(aethercore SYSTEM PRIVATE
             ${MOSQUITTO_DIR}/include
             ${MOSQUITTO_DIR}/src)
         target_sources(aethercore PRIVATE ${MOSQUITTO_SOURCES})

--- a/src/core/AsyncLogWriter.cpp
+++ b/src/core/AsyncLogWriter.cpp
@@ -348,6 +348,17 @@ void AsyncLogWriter::run(std::promise<bool> opened)
         bufferedLineCount = 0;
     };
 
+    auto reopenForAppendOrMirrorToStderr = [&](const QString& reopenPath) {
+        QDir().mkpath(QFileInfo(reopenPath).absolutePath());
+        file.setFileName(reopenPath);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+            mirrorToStderr = true;
+            return false;
+        }
+        file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+        return true;
+    };
+
     auto maybeRotate = [&]() {
         if (maxFileBytes <= 0 || !rotationCb)
             return;
@@ -359,8 +370,7 @@ void AsyncLogWriter::run(std::promise<bool> opened)
 
         const QString newPath = rotationCb(oldPath);
         if (newPath.isEmpty() || newPath == oldPath) {
-            file.setFileName(oldPath);
-            if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+            if (!reopenForAppendOrMirrorToStderr(oldPath)) {
                 maxFileBytes = 0;
                 return;
             }
@@ -368,10 +378,10 @@ void AsyncLogWriter::run(std::promise<bool> opened)
             return;
         }
 
+        QDir().mkpath(QFileInfo(newPath).absolutePath());
         file.setFileName(newPath);
         if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-            file.setFileName(oldPath);
-            if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+            if (!reopenForAppendOrMirrorToStderr(oldPath)) {
                 maxFileBytes = 0;
                 return;
             }
@@ -440,10 +450,15 @@ void AsyncLogWriter::run(std::promise<bool> opened)
                                                    item.log.timestamp,
                                                    item.log.category,
                                                    item.log.message);
-                buffer.append(line);
-                ++bufferedLineCount;
+                if (file.isOpen()) {
+                    buffer.append(line);
+                    ++bufferedLineCount;
+                }
                 if (mirrorToStderr) {
                     fwrite(line.constData(), 1, static_cast<size_t>(line.size()), stderr);
+                    if (!file.isOpen()) {
+                        fflush(stderr);
+                    }
                 }
                 if (!isDebugOrInfo(item.log.type))
                     flushAfterBatch = true;

--- a/src/core/AsyncLogWriter.cpp
+++ b/src/core/AsyncLogWriter.cpp
@@ -360,7 +360,10 @@ void AsyncLogWriter::run(std::promise<bool> opened)
         const QString newPath = rotationCb(oldPath);
         if (newPath.isEmpty() || newPath == oldPath) {
             file.setFileName(oldPath);
-            file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
+            if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+                maxFileBytes = 0;
+                return;
+            }
             maxFileBytes = 0;
             return;
         }
@@ -368,7 +371,10 @@ void AsyncLogWriter::run(std::promise<bool> opened)
         file.setFileName(newPath);
         if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
             file.setFileName(oldPath);
-            file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text);
+            if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+                maxFileBytes = 0;
+                return;
+            }
             maxFileBytes = 0;
             return;
         }

--- a/src/core/ClientEq.cpp
+++ b/src/core/ClientEq.cpp
@@ -23,9 +23,6 @@ constexpr float kSmoothTimeConstantSec = 0.015f;
 
 // Chebyshev I passband ripple (dB) — classic 1 dB Chebyshev default.
 constexpr float kChebyshevRippleDb = 1.0f;
-// Elliptic passband ripple and stopband attenuation.
-constexpr float kEllipticRippleDb  = 1.0f;
-constexpr float kEllipticStopDb    = 60.0f;
 
 float dbToAmp(float db) noexcept
 {

--- a/src/core/CwxLocalKeyer.h
+++ b/src/core/CwxLocalKeyer.h
@@ -41,7 +41,7 @@ public:
     using KeyDownCallback = std::function<void(bool down)>;
 
     CwxLocalKeyer();
-    ~CwxLocalKeyer();
+    virtual ~CwxLocalKeyer();
 
     CwxLocalKeyer(const CwxLocalKeyer&) = delete;
     CwxLocalKeyer& operator=(const CwxLocalKeyer&) = delete;

--- a/src/gui/AppletPanel.cpp
+++ b/src/gui/AppletPanel.cpp
@@ -586,7 +586,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
 
         if (btn) {
             connect(btn, &QPushButton::toggled, this,
-                    [this, id, c, key](bool checked) {
+                    [c, key](bool checked) {
                 // Floating containers: raising = show the window,
                 // lowering = hide it.  The manager owns the window
                 // so we just toggle the container's visibility.
@@ -604,7 +604,7 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
         // button on the ContainerTitleBar) back to the tray toggle
         // and settings so everything stays in sync.
         connect(c, &ContainerWidget::visibilityChanged, this,
-                [this, btn, key](bool visible) {
+                [btn, key](bool visible) {
             if (btn) {
                 QSignalBlocker b(btn);
                 btn->setChecked(visible);
@@ -796,10 +796,10 @@ AppletPanel::AppletPanel(QWidget* parent) : QWidget(parent)
     // already narrower so this is a no-op there.
     if (txDsp) txDsp->setMaximumWidth(280);
 
-    auto makeChildContainer = [this, txDsp](const QString& id,
-                                            const QString& title,
-                                            QWidget* applet,
-                                            int index) {
+    auto makeChildContainer = [this](const QString& id,
+                                     const QString& title,
+                                     QWidget* applet,
+                                     int index) {
         auto* child = m_containerMgr->createContainer(
             id, title, /*contentType=*/{}, /*parentId=*/"tx_dsp", index);
         if (child) child->setContent(applet);

--- a/src/gui/ClientCompApplet.cpp
+++ b/src/gui/ClientCompApplet.cpp
@@ -95,13 +95,6 @@ const QString kEnableStyle =
     "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
     "}";
 
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
 } // namespace
 
 ClientCompApplet::ClientCompApplet(Side side, QWidget* parent)

--- a/src/gui/ClientCompLimiterButton.cpp
+++ b/src/gui/ClientCompLimiterButton.cpp
@@ -53,7 +53,11 @@ void ClientCompLimiterButton::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
     p.setRenderHint(QPainter::TextAntialiasing, true);
 
-    const QRectF r = rect();
+    // Half-pixel inset so the 1px antialiased border lands on pixel centres
+    // (crisp). QRectF::adjusted takes qreal, so 0.5 is honoured — unlike
+    // QRect::adjusted, which truncated it to 0 and left the stroke straddling
+    // the edge (soft).
+    const QRectF r = QRectF(rect()).adjusted(0.5, 0.5, -0.5, -0.5);
     const qreal radius = 3.0;
 
     // Colour the body by state precedence: active > checked > idle.

--- a/src/gui/ClientCompLimiterButton.cpp
+++ b/src/gui/ClientCompLimiterButton.cpp
@@ -53,7 +53,7 @@ void ClientCompLimiterButton::paintEvent(QPaintEvent*)
     p.setRenderHint(QPainter::Antialiasing, true);
     p.setRenderHint(QPainter::TextAntialiasing, true);
 
-    const QRectF r = rect().adjusted(0.5, 0.5, -0.5, -0.5);
+    const QRectF r = rect();
     const qreal radius = 3.0;
 
     // Colour the body by state precedence: active > checked > idle.

--- a/src/gui/ClientCompMeter.cpp
+++ b/src/gui/ClientCompMeter.cpp
@@ -18,11 +18,7 @@ constexpr int   kPeakHoldMs =  700;
 constexpr float kPeakDecayDbPer100Ms = 1.0f;
 
 inline QColor kBarBg() { return AetherSDR::ThemeManager::instance().color("color.background.0"); }
-inline QColor kLevelLo() { return AetherSDR::ThemeManager::instance().color("color.accent.success"); }
-inline QColor kLevelMid() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
-inline QColor kLevelHi() { return AetherSDR::ThemeManager::instance().color("color.accent.danger"); }
 inline QColor kGrColor() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }
-inline QColor kLabelColor() { return AetherSDR::ThemeManager::instance().color("color.text.secondary"); }
 inline QColor kPeakLine() { return AetherSDR::ThemeManager::instance().color("color.text.primary"); }
 inline QColor kCeilingLine() { return AetherSDR::ThemeManager::instance().color("color.accent.warning"); }  // bright amber — matches LIMIT button
 const QColor kCeilingZone("#3a1810");     // dim red tint for the "no-go" zone

--- a/src/gui/ClientDeEssApplet.cpp
+++ b/src/gui/ClientDeEssApplet.cpp
@@ -92,13 +92,6 @@ const QString kEnableStyle =
     "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
     "}";
 
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
 } // namespace
 
 ClientDeEssApplet::ClientDeEssApplet(QWidget* parent) : QWidget(parent)

--- a/src/gui/ClientGateApplet.cpp
+++ b/src/gui/ClientGateApplet.cpp
@@ -95,13 +95,6 @@ const QString kEnableStyle =
     "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
     "}";
 
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
 } // namespace
 
 ClientGateApplet::ClientGateApplet(Side side, QWidget* parent)

--- a/src/gui/ClientPuduApplet.cpp
+++ b/src/gui/ClientPuduApplet.cpp
@@ -30,13 +30,6 @@ const QString kEnableStyle =
     "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
     "}";
 
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
 const QString kModeStyle = QStringLiteral(
     "QPushButton {"
     "  background: #1a2a3a; border: 1px solid #2a4458; border-radius: 3px;"

--- a/src/gui/ClientTubeApplet.cpp
+++ b/src/gui/ClientTubeApplet.cpp
@@ -26,13 +26,6 @@ const QString kEnableStyle =
     "  background: #006040; color: #00ff88; border: 1px solid #00a060;"
     "}";
 
-constexpr const char* kEditStyle =
-    "QPushButton {"
-    "  background: #1a2a3a; border: 1px solid #205070; border-radius: 3px;"
-    "  color: #c8d8e8; font-size: 11px; padding: 2px 10px;"
-    "}"
-    "QPushButton:hover { background: #204060; }";
-
 } // namespace
 
 ClientTubeApplet::ClientTubeApplet(Side side, QWidget* parent)

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -235,11 +235,18 @@ QString SpotTableModel::bandForFreq(double mhz)
 
 void BandFilterProxy::setBandVisible(const QString& band, bool visible)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    beginFilterChange();
+#endif
     if (visible)
         m_hiddenBands.remove(band);
     else
         m_hiddenBands.insert(band);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+    endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
     invalidateFilter();
+#endif
 }
 
 bool BandFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const

--- a/src/gui/FreeDvReporterDialog.cpp
+++ b/src/gui/FreeDvReporterDialog.cpp
@@ -39,16 +39,30 @@ public:
     // bands: empty vector = "All"; non-empty = OR of all ranges
     void setBandFilters(const QVector<QPair<double,double>>& bands)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        beginFilterChange();
+#endif
         m_mode  = Band;
         m_bands = bands;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
         invalidateFilter();
+#endif
     }
 
     void setFreqFilter(double hz)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        beginFilterChange();
+#endif
         m_mode   = Freq;
         m_freqHz = hz;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
         invalidateFilter();
+#endif
     }
 
 protected:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -273,7 +273,6 @@ constexpr int kPanadapterSliceCapacityStatusMs = 4000;
 // shared between the constructor timer setup here and MainWindow_SwrSweep.cpp.
 constexpr const char* kSuppressAudioDeviceNotificationsKey =
     "SuppressAudioDeviceNotifications";
-constexpr int kTMate2DefaultUserInteractionTimeoutMs = 2000;
 constexpr const char* kStatusBarCompactLabelObjectName = "statusBarCompactLabel";
 
 QString statusBarCompactLabelStyle(const QString& color)

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -86,10 +86,6 @@ static constexpr const char* kLabelStyle =
 static constexpr const char* kDimLabelStyle =
     "QLabel { color: #8090a0; font-size: 10px; }";
 
-static constexpr const char* kInsetValueStyle =
-    "QLabel { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e; "
-    "border-radius: 3px; padding: 1px 2px; color: #c8d8e8; }";
-
 static constexpr const char* kInsetEditStyle =
     "QLineEdit { font-size: 10px; background: #0a0a18; border: 1px solid #1e2e3e; "
     "border-radius: 3px; padding: 1px 2px; color: #c8d8e8; }"

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -6614,7 +6614,7 @@ QWidget* RadioSetupDialog::buildPeripheralsTab()
             [this]() { m_ag->disconnectFromDevice(); },
             isSsConnected,
             [this]() { return m_ag->peerAddress(); },
-            [this]() { return (quint16)9007; });
+            []() { return (quint16)9007; });
         connect(m_ag, &AntennaGeniusModel::connected,    this, updateSs);
         connect(m_ag, &AntennaGeniusModel::disconnected, this, updateSs);
 

--- a/src/gui/StripRxOutputPanel.cpp
+++ b/src/gui/StripRxOutputPanel.cpp
@@ -41,7 +41,7 @@ float dbToRatio(float db)
 // RX-side gradient meter — visual mirror of the TX HorizMeter (gradient
 // fill, dB tick scale, peak-hold hairline) minus the limiter-specific
 // bits (no ceiling drag handle, no GR overlay, no input-peak backdrop,
-// no LIMIT band).  Single child widget; reads m_peak / m_rms on the
+// no LIMIT band).  Single child widget; reads m_rms on the
 // parent through references so it has no internal state of its own.
 //
 // Bar gradient renders RMS (the slow, average-loudness reading), with
@@ -51,8 +51,8 @@ float dbToRatio(float db)
 // visual indicator of instantaneous peaks.
 class RxGradientMeter : public QWidget {
 public:
-    RxGradientMeter(const float& peak, const float& rms, QWidget* parent)
-        : QWidget(parent), m_peak(peak), m_rms(rms)
+    RxGradientMeter(const float& rms, QWidget* parent)
+        : QWidget(parent), m_rms(rms)
     {
         // Match the TX meter's geometry: 22 px header (unused on RX —
         // no ceiling handle / value text) + 28 px bar + 22 px tick
@@ -148,7 +148,6 @@ protected:
     }
 
 private:
-    const float& m_peak;
     const float& m_rms;
     float  m_holdDb{-120.0f};
     qint64 m_holdUntilMs{0};
@@ -206,7 +205,7 @@ StripRxOutputPanel::StripRxOutputPanel(AudioEngine* engine, QWidget* parent)
     });
     row->addWidget(m_trim);
 
-    auto* meter = new RxGradientMeter(m_peakDb, m_rmsDb, this);
+    auto* meter = new RxGradientMeter(m_rmsDb, this);
     m_meter = meter;
     row->addWidget(meter, 1);
 

--- a/src/models/AntennaGeniusModel.cpp
+++ b/src/models/AntennaGeniusModel.cpp
@@ -94,7 +94,7 @@ void AntennaGeniusModel::startDiscovery()
     // Timeout timer: prune devices that stop broadcasting.
     m_discoveryTimeout = new QTimer(this);
     m_discoveryTimeout->setInterval(kDiscoveryTimeoutMs);
-    connect(m_discoveryTimeout, &QTimer::timeout, this, [this]() {
+    connect(m_discoveryTimeout, &QTimer::timeout, this, []() {
         // In a full implementation we'd track last-seen timestamps.
         // For now we rely on the device broadcasting every 1 s.
     });

--- a/tests/async_log_writer_test.cpp
+++ b/tests/async_log_writer_test.cpp
@@ -325,6 +325,66 @@ void testHighPriorityReservePreservesCritical(const QString& dir)
            c.droppedHighPriorityLines == 0);
 }
 
+void testRotationReopenFailureMirrorsToStderr(const QString& dir)
+{
+    auto runCase = [&](const QString& caseName, bool returnInvalidNewPath) {
+        const QString stderrPath = dir + "/rotation_" + caseName + "_stderr.txt";
+        const QString activeDir = dir + "/rotation_" + caseName + "_active";
+        const QString logPath = activeDir + "/active.log";
+        const QString marker = "rotation-fallback-" + caseName;
+
+        QDir().mkpath(activeDir);
+        std::fflush(stderr);
+        FILE* redirected = std::freopen(stderrPath.toUtf8().constData(), "w", stderr);
+        if (!redirected) {
+            const QByteArray label = ("rotation fallback " + caseName
+                                      + ": freopen succeeds").toUtf8();
+            report(label.constData(), false);
+            return;
+        }
+
+        bool blockerCreated = false;
+        AsyncLogWriter w;
+        w.setRotationConfig(1,
+            [activeDir, returnInvalidNewPath, &blockerCreated](const QString& currentPath) {
+                QFile::remove(currentPath);
+                QDir(activeDir).removeRecursively();
+
+                QFile blocker(activeDir);
+                blockerCreated = blocker.open(QIODevice::WriteOnly | QIODevice::Truncate);
+                blocker.close();
+
+                if (returnInvalidNewPath) {
+                    return activeDir + "/rotated.log";
+                }
+                return QString{};
+            });
+
+        const bool started = w.start(logPath, false);
+        if (started) {
+            w.enqueue(QtWarningMsg, QTime(9, 0, 0, 0),
+                      QStringLiteral("aether.x"), QStringLiteral("trigger-rotation"));
+            w.flush();
+            w.enqueue(QtWarningMsg, QTime(9, 0, 0, 1),
+                      QStringLiteral("aether.x"), marker);
+            w.flush();
+            w.shutdown();
+        }
+
+        std::fflush(stderr);
+        const QByteArray captured = readAll(stderrPath);
+        const QByteArray label = ("rotation fallback " + caseName
+                                  + ": future logs mirror to stderr").toUtf8();
+        report(label.constData(), started && blockerCreated
+               && captured.contains(marker.toUtf8()));
+
+        QFile::remove(activeDir);
+    };
+
+    runCase(QStringLiteral("same-path"), false);
+    runCase(QStringLiteral("new-path"), true);
+}
+
 void testStderrMirroring(const QString& dir)
 {
     const QString stderrPath = dir + "/captured_stderr.txt";
@@ -391,6 +451,7 @@ int main(int argc, char** argv)
     testShutdownDrainsAllEnqueuedLines(dir);
     testDropAccountingEmitsSummaryAndCounters(dir);
     testHighPriorityReservePreservesCritical(dir);
+    testRotationReopenFailureMirrorsToStderr(dir);
     testStderrMirroring(dir);
 
     return g_failed == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Cleans up compiler and linker warnings discovered during a fresh macOS AppleClang build with the project's `-Wall -Wextra -Wpedantic` flags.

The changes remove stale first-party code, correct warning-producing constructs, adopt the current Qt filtering API where available, isolate unavoidable warnings from bundled dependencies, and enable CMake's capability-aware library de-duplication. Project-owned engine and GUI code now compile without warnings, and the final application link no longer reports duplicate `hidapi` or `portaudio` libraries.

There are no intended user-visible, radio-protocol, DSP, settings, or UI behavior changes.

### First-party source cleanup

- Check both fallback `QFile::open()` results in `AsyncLogWriter`.
  - A failed fallback is now handled explicitly instead of discarding a `[[nodiscard]]` result.
  - Further rotation attempts are disabled when the log cannot be reopened, matching the existing failure path.
- Make `CwxLocalKeyer`'s destructor virtual because the class exposes virtual methods and is subclassed by the drift-correction test harness.
- Remove unused Client EQ elliptic-filter constants that are not part of the implemented filter paths.
- Remove unused lambda captures from:
  - applet container visibility synchronization;
  - TX DSP child-container creation;
  - Radio Setup peripheral port lookup; and
  - Antenna Genius discovery timeout handling.
- Remove unused GUI constants and style definitions from:
  - `MainWindow`;
  - Phone/CW;
  - Client Compressor;
  - Client Gate;
  - Client De-Esser;
  - Client Tube;
  - Client PUDU; and
  - Client Compressor meter rendering.
- Remove the unused peak-value reference from the RX output gradient meter. The meter continues to use its RMS input and existing peak-hold calculation.
- Replace the warning-producing floating-point call to `QRect::adjusted()` in the compressor limiter button with a direct `QRectF` construction. The old values were truncated by the integer overload, so this preserves the effective geometry.
- Replace deprecated `QSortFilterProxyModel::invalidateFilter()` calls with `beginFilterChange()` and `endFilterChange(Rows)` on Qt 6.10 and newer.
  - The existing `invalidateFilter()` path remains for the project's Qt 6.4.2 compatibility floor.

### Bundled dependency warning boundaries

- Treat bundled Mosquitto headers as system headers so GNU anonymous-structure extensions in the upstream public header do not appear as AetherSDR warnings.
- Suppress warnings for the bundled RtMidi translation unit. Its current upstream implementation uses a variable-length array and a signed/unsigned comparison.
- Suppress platform deprecation warnings for the bundled ThumbDV translation unit, including when it is compiled directly by the queue test.
- These warning controls apply only to the named bundled translation units and do not weaken warning flags for AetherSDR source.

### Linker cleanup

- Enable CMake policy `CMP0156` when supported.
  - CMake 3.29 and newer can de-duplicate libraries according to linker capabilities.
  - This removes the macOS linker warning for duplicate `hidapi` and `portaudio` libraries.
  - The policy is guarded with `if(POLICY CMP0156)`, preserving compatibility with the project's CMake 3.25 minimum.

### Intentionally remaining external diagnostics

A newly extracted RADE Opus external build still reports four unused-variable/parameter warnings from the vendored Opus source. Those sources are generated from the prepared third-party archive and were not patched or globally silenced in this change.

Qt's `GuiPrivate` ABI warning also remains intentional because AetherSDR currently uses QRhi private APIs.

## Constitution principle honored

Principle VIII — Evidence Over Assertion: the warning inventory was captured from a fresh build and each cleanup was recompiled against the exact generated compile commands.

Principle XI — Fixes Are Demonstrated: all 195 GUI translation units, the engine targets, focused tests, and the final application link were rerun after the changes and after refreshing to the current `upstream/main`.

## Test plan

- [ ] Local build passes (`cmake --build build`)
  - All engine and GUI compilation succeeds, and the application links successfully.
  - The normal macOS Ninja target remains blocked by the pre-existing `iconutil: Invalid Iconset` packaging failure. This occurs after the warning cleanup and is outside this PR's scope.
- [x] Behavior verified on a real radio if applicable
  - Not applicable; this change does not alter radio commands, status handling, DSP behavior, or slice 0 RX flow.
- [ ] Existing tests pass (CI)
  - Pending CI.
- [x] Reproduction steps documented if user-reported bug
  - Warning output was audited from a fresh `RelWithDebInfo` Ninja configuration.

### Local verification

- Refreshed the branch onto `upstream/main` at `6af248bd` immediately before publication.
- Rebuilt `aethercore` with zero project-owned compiler warnings.
- Replayed all 195 generated AetherSDR GUI compile commands:
  - zero warnings;
  - zero errors.
- Linked `AetherSDR.app/Contents/MacOS/AetherSDR` successfully:
  - zero duplicate-library warnings;
  - zero linker output.
- Passed `client_eq_test`.
- Passed `async_log_writer_test`.
- Passed `cwx_local_keyer_drift_test`.
- Passed `thumbdv_queue_test`.
- Passed `python3 tools/check_engine_boundary.py --strict`:
  - 809 files scanned;
  - 86 tracked legacy findings;
  - 0 strict blockers.
- Passed `git diff --check`.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings persistence changes
- [x] Code is clean-room — no proprietary implementation was referenced
- [x] All meter UI uses `MeterSmoother`
  - No meter smoothing or value-update behavior was added or changed.
- [x] Documentation updated if user-visible behavior changed
  - Not applicable; there are no intended user-visible changes.
- [x] Security-sensitive changes reference a GHSA if applicable
  - Not applicable; this PR contains no security-sensitive changes.
