### PR TITLE
Honor frameless mode for radio M-message dialogs

### DIFF
--- a/src/gui/FramelessMessageBox.cpp
+++ b/src/gui/FramelessMessageBox.cpp
@@ -106,6 +106,13 @@ QMessageBox::StandardButton FramelessMessageBox::warning(
     return showMessage(Warning, parent, title, text, buttons, defaultButton);
 }
 
+QMessageBox::StandardButton FramelessMessageBox::critical(
+    QWidget* parent, const QString& title, const QString& text,
+    StandardButtons buttons, StandardButton defaultButton)
+{
+    return showMessage(Critical, parent, title, text, buttons, defaultButton);
+}
+
 QMessageBox::StandardButton FramelessMessageBox::question(
     QWidget* parent, const QString& title, const QString& text,
     StandardButtons buttons, StandardButton defaultButton)

--- a/src/gui/FramelessMessageBox.h
+++ b/src/gui/FramelessMessageBox.h
@@ -24,6 +24,10 @@ public:
                                   const QString& text,
                                   StandardButtons buttons = Ok,
                                   StandardButton defaultButton = NoButton);
+    static StandardButton critical(QWidget* parent, const QString& title,
+                                   const QString& text,
+                                   StandardButtons buttons = Ok,
+                                   StandardButton defaultButton = NoButton);
     static StandardButton question(QWidget* parent, const QString& title,
                                    const QString& text,
                                    StandardButtons buttons = StandardButtons(Yes | No),

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5528,19 +5528,19 @@ void MainWindow::onRadioMessage(const QString& text, MessageSeverity severity)
         qCWarning(lcGui) << "Radio M-message [Warning]:" << text;
         if (interlockMessage)
             break;
-        QMessageBox::warning(this, tr("Radio"), text);
+        FramelessMessageBox::warning(this, tr("Radio"), text);
         break;
     case MessageSeverity::Error:
         qCCritical(lcGui) << "Radio M-message [Error]:" << text;
         if (interlockMessage)
             break;
-        QMessageBox::critical(this, tr("Radio — Error"), text);
+        FramelessMessageBox::critical(this, tr("Radio — Error"), text);
         break;
     case MessageSeverity::Fatal:
         qCCritical(lcGui) << "Radio M-message [Fatal]:" << text;
         if (interlockMessage)
             break;
-        QMessageBox::critical(this, tr("Radio — Fatal"), text);
+        FramelessMessageBox::critical(this, tr("Radio — Fatal"), text);
         break;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4366. Radio warning, error, and fatal M-messages bypassed the shared frameless message-box wrapper by calling the static QMessageBox helpers directly. Route those three modal paths through FramelessMessageBox and add the missing critical helper, preserving the existing severity icons, titles, buttons, and modal behavior while honoring the global Frameless Window setting.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The exact maximum-connected-clients condition was recreated on a FLEX-6700 running firmware 4.2.18, and the fixed dialog was inspected and captured through the automation bridge.

## Test plan

- [x] Local build passes (cmake --build build -j16)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local verification:

- Fresh RelWithDebInfo configure and complete 1565-step build passed.
- QT_QPA_PLATFORM=offscreen ./build/help_dialog_test passed.
- tools/check_engine_boundary.py --strict passed with 0 blockers.
- tools/check_a11y.py on all three changed files passed with 0 findings.
- git diff --check passed.

Bridge proof:

1. Confirmed View → Frameless Window was checked.
2. Connected two passive GUI clients to occupy the FLEX-6700 client limit, then connected the fixed build as the third client.
3. The radio emitted MF3000001 and R129 with “The maximum number of connected clients has been reached”; the GUI logged it as a Fatal M-message.
4. The live widget tree showed the exact text inside AetherSDR::FramelessMessageBox and a visible AetherSDR::FramelessWindowTitleBar.
5. Captured the 420×133 dialog through the bridge; it used AetherSDR chrome with no native macOS traffic-light frame. The dialog was dismissed, both test clients were disconnected, and the radio lock was released.

## Checklist

- [x] Commits are signed (docs/COMMIT-SIGNING.md)
- [x] No new flat-key AppSettings calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] No meter UI changes; MeterSmoother is not applicable
- [x] No documentation change needed; this restores the existing Frameless Window policy
- [x] No security-sensitive changes

Generated with OpenAI Codex.
