### PR TITLE
Fix wide 3D stacked-trace right-edge artifact

### DIFF
--- a/src/gui/MainWindowHelpers.cpp
+++ b/src/gui/MainWindowHelpers.cpp
@@ -315,15 +315,19 @@ constexpr int kDefaultPanXpixels = 1024;
 constexpr int kDefaultPanYpixels = 700;
 constexpr int kMinPanXpixels = 100;
 constexpr int kMinPanYpixels = 20;
-constexpr int kMaxRadioPanPixels = 8192;
+// FLEX radios cap panadapter FFT frames at a 4096-bin boundary. Requesting
+// that boundary (or more) leaves the right edge malformed on firmware
+// 4.2.18/4.2.20, so stay one bin below it.
+constexpr int kMaxRadioPanXPixels = 4095;
+constexpr int kMaxRadioPanYPixels = 8192;
 
-int radioPixelsFor(const SpectrumWidget* spectrum, int logicalPixels)
+int radioPixelsFor(const SpectrumWidget* spectrum, int logicalPixels, int maximumPixels)
 {
     const double ratio = spectrum ? spectrum->devicePixelRatioF() : 1.0;
     const double dpr = std::isfinite(ratio) && ratio > 0.0 ? ratio : 1.0;
     return std::clamp(static_cast<int>(std::lround(logicalPixels * dpr)),
                       1,
-                      kMaxRadioPanPixels);
+                      maximumPixels);
 }
 } // namespace
 
@@ -332,7 +336,7 @@ int panXpixelsFor(const SpectrumWidget* spectrum)
     if (!spectrum || spectrum->width() < kMinPanXpixels) {
         return kDefaultPanXpixels;
     }
-    return radioPixelsFor(spectrum, spectrum->width());
+    return radioPixelsFor(spectrum, spectrum->width(), kMaxRadioPanXPixels);
 }
 
 int panYpixelsFor(const SpectrumWidget* spectrum)
@@ -348,7 +352,8 @@ int panYpixelsFor(const SpectrumWidget* spectrum)
     // FFT bins arrive as radio-encoded pixel positions, not full-precision dBm
     // samples. Request render-device pixels and keep the historical 700 px
     // floor so zoomed traces have sub-screen-pixel precision.
-    return std::max(radioPixelsFor(spectrum, ypix), kDefaultPanYpixels);
+    return std::max(radioPixelsFor(spectrum, ypix, kMaxRadioPanYPixels),
+                    kDefaultPanYpixels);
 }
 
 bool panPixelDimensionsReady(const SpectrumWidget* spectrum)


### PR DESCRIPTION
## Summary

Fixes #4007.

Clamp horizontal device-pixel panadapter FFT requests to 4095 bins. The previous 8192-bin ceiling let wide/Retina 3D Stacked Trace panes request 4096 bins or more; FLEX firmware 4.2.18 and the reporter's 4.2.20 evidence show the 4096-bin boundary returning a malformed right edge. AetherSDR still renders at the full local framebuffer width and resamples the valid radio bins, so wide displays retain their native output resolution. The vertical `ypixels` ceiling remains 8192 because it is not an FFT-bin axis.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The 4095-bin ceiling is supported by a failing 4096-bin control, live-radio before/after evidence, a receive-only frequency-shift ablation, and deterministic renderer isolation.

## Test plan

- [x] Local build passes (`cmake --build build -j8`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local verification on the exact current `upstream/main` base (`aaf313ac`):

- Reproduced the green right-edge comb with v26.7.1 and current main on a 4998-device-pixel Metal/QRhi pan framebuffer at `QT_SCALE_FACTOR=2.5`.
- Confirmed the radio returned 4096 finite bins at the failing size, while requesting 4095 was clean; a temporary 4096-bin clamp still reproduced the comb and was discarded.
- Verified the final build on a FLEX-6700 running firmware 4.2.18: the same 4998-pixel framebuffer received 4095/4095 finite bins and rendered cleanly in 3D mode.
- Shifted the receive-only pan center from 14.100 to 14.300 MHz. Real RF signals moved with the tuned spectrum; the baseline comb had stayed pinned to the same right-edge screen pixels, proving it was not a station or local RF signal near an approximate frequency. The final build stayed clean at both centers.
- Ran a disconnected deterministic 3D-spectrum injection at the same 4998-pixel framebuffer; it rendered cleanly, isolating the failure from the local Metal/QRhi renderer.
- Restored the pan center to 14.100 MHz and confirmed `transmitting=false`; no TX automation was enabled or invoked.
- `cmake --build build -j8` passed after the upstream refresh.
- Full CTest set passed: 158 tests passed, 1 quarantine test intentionally skipped. Six macOS display/local-socket tests blocked by the sandbox passed 6/6 when rerun with normal macOS access.
- `python3 tools/check_engine_boundary.py --strict` passed with 0 blocking findings.
- `python3 tools/check_a11y.py` reported only the existing warning baseline (7 findings in 4 unrelated files).
- Bridge documentation and automation-probe mapping checks passed.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed (not applicable; no UI or workflow change)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
