### PR TITLE
[codex] Name Kiwi waterfall controls for assistive tools

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2002,6 +2002,14 @@ void SpectrumOverlayMenu::applyAutoBlackMode(int mode, bool emitSignals)
         m_blackSlider->setToolTip(autoOn
             ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
             : "Waterfall black level. Decrease to darken the noise floor.");
+        if (!m_kiwiWaterfallControlMode) {
+            m_blackSlider->setAccessibleName(autoOn
+                ? tr("Waterfall auto-black offset")
+                : tr("Waterfall black level"));
+            m_blackSlider->setAccessibleDescription(autoOn
+                ? tr("Sets the target offset from the measured noise floor.")
+                : tr("Sets the manual waterfall black level."));
+        }
     }
     if (emitSignals) {
         emit wfAutoBlackChanged(autoOn);
@@ -2135,6 +2143,12 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
         m_gainSlider->setToolTip(kiwiMode
             ? "KiwiSDR waterfall ceiling dBm. Auto sets this from the row's 98th percentile plus 30 dB."
             : "Waterfall color gain.");
+        m_gainSlider->setAccessibleName(kiwiMode
+            ? tr("KiwiSDR waterfall ceiling")
+            : tr("Waterfall color gain"));
+        m_gainSlider->setAccessibleDescription(kiwiMode
+            ? tr("Sets the maximum KiwiSDR waterfall display level in dBm.")
+            : tr("Sets the waterfall color gain from 0 to 100."));
     }
     if (m_blackSlider) {
         m_blackSlider->setRange(kiwiMode ? -260 : 0, kiwiMode ? 29 : 100);
@@ -2143,6 +2157,11 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
             : (m_autoBlackBtn && m_autoBlackBtn->isChecked()
                    ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
                    : "Waterfall black level. Decrease to darken the noise floor."));
+        if (kiwiMode) {
+            m_blackSlider->setAccessibleName(tr("KiwiSDR waterfall floor"));
+            m_blackSlider->setAccessibleDescription(
+                tr("Sets the minimum KiwiSDR waterfall display level in dBm."));
+        }
     }
     if (m_rateSlider) {
         m_rateSlider->setRange(kiwiMode ? 0 : WF_RATE_SLIDER_MIN,
@@ -2151,6 +2170,12 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
         m_rateSlider->setToolTip(kiwiMode
             ? "KiwiSDR waterfall rate. Auto follows the Flex waterfall rate."
             : "Waterfall rate.");
+        m_rateSlider->setAccessibleName(kiwiMode
+            ? tr("KiwiSDR waterfall rate")
+            : tr("Waterfall rate"));
+        m_rateSlider->setAccessibleDescription(kiwiMode
+            ? tr("Zero follows the Flex waterfall rate; values 1 to 4 request a fixed KiwiSDR rate.")
+            : tr("Sets the waterfall row update rate."));
     }
     if (m_autoBlackBtn) {
         m_autoBlackBtn->setToolTip(kiwiMode

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2157,10 +2157,22 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
             : (m_autoBlackBtn && m_autoBlackBtn->isChecked()
                    ? "Auto-black target offset. 50 = at noise floor; lower = darker, higher = lighter."
                    : "Waterfall black level. Decrease to darken the noise floor."));
+        // Set the accessible name unconditionally in both modes (like the gain
+        // and rate sliders) so a kiwi->flex switch never leaves a stale name.
+        // The flex-mode name mirrors applyAutoBlackMode's auto-on/off wording;
+        // applyAutoBlackMode still refreshes it as the mode cycles.
         if (kiwiMode) {
             m_blackSlider->setAccessibleName(tr("KiwiSDR waterfall floor"));
             m_blackSlider->setAccessibleDescription(
                 tr("Sets the minimum KiwiSDR waterfall display level in dBm."));
+        } else {
+            const bool autoOn = (m_autoBlackMode != 0);
+            m_blackSlider->setAccessibleName(autoOn
+                ? tr("Waterfall auto-black offset")
+                : tr("Waterfall black level"));
+            m_blackSlider->setAccessibleDescription(autoOn
+                ? tr("Sets the target offset from the measured noise floor.")
+                : tr("Sets the manual waterfall black level."));
         }
     }
     if (m_rateSlider) {
@@ -2183,7 +2195,8 @@ void SpectrumOverlayMenu::setKiwiWaterfallControlMode(bool kiwiMode)
             : "Use the measured noise floor for waterfall black level.");
         m_autoBlackBtn->setAccessibleDescription(kiwiMode
             ? tr("Applies the computed KiwiSDR waterfall floor and ceiling levels.")
-            : tr("Use the measured noise floor for waterfall black level."));
+            : tr("Cycles the waterfall auto-black mode: off (manual black "
+                 "level), software noise-floor estimate, or hardware level."));
         if (kiwiMode) {
             m_autoBlackBtn->setCheckable(true);
             m_autoBlackBtn->setText("Auto");


### PR DESCRIPTION
## Summary

Fixes #4076.

The three mandatory cleanup items originally listed in #4076 were already present in #4069's merged result and remain on current `main`. This closes the remaining concrete accessibility follow-up: the shared waterfall sliders changed their visible labels, ranges, and tooltips for KiwiSDR mode, but retained no role-specific accessible identity.

This patch updates the sliders' accessible names and descriptions whenever their roles change:

- `Waterfall color gain` becomes `KiwiSDR waterfall ceiling`
- `Waterfall auto-black offset` / `Waterfall black level` becomes `KiwiSDR waterfall floor`
- `Waterfall rate` becomes `KiwiSDR waterfall rate`

Returning to Flex receive restores the generic waterfall identities. No layout, value, command, or settings behavior changes.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The defect was reproduced with an isolating source ablation, and the same live bridge sequence was repeated against the rebuilt fixed binary on current `upstream/main`.

## Test plan

- [x] Local build passes (`cmake --build build --parallel 16`; 1,540 configured steps)
- [x] Behavior verified on a real FLEX-6700 running firmware 4.2.18.41174
- [x] Existing related tests pass
- [x] Reproduction steps documented below

### Automation-bridge proof

Bridge: AetherSDR 26.7.3, fixed PID 48607.

1. Inspect the three waterfall sliders in Flex mode.
2. Assign the owned slice to a temporary KiwiSDR receive profile through the normal UI/bridge path.
3. Inspect the same sliders in Kiwi mode.
4. Restore the slice to Flex receive, remove the temporary profile, and confirm transmit remains false.

Isolating baseline (patch removed):

- `displayWfGainSlider`: Kiwi range `-259..30`, Kiwi tooltip, no `accessibleName`
- `displayBlackLevelSlider`: Kiwi range `-260..29`, Kiwi tooltip, no `accessibleName`
- `displayWfRateSlider`: Kiwi range `0..4`, Kiwi tooltip, no `accessibleName`

Fixed current-main build:

- `displayWfGainSlider`: `accessibleName="KiwiSDR waterfall ceiling"`, dBm ceiling description, range `-259..30`
- `displayBlackLevelSlider`: `accessibleName="KiwiSDR waterfall floor"`, dBm floor description, range `-260..29`
- `displayWfRateSlider`: `accessibleName="KiwiSDR waterfall rate"`, Flex-follow/fixed-rate description, range `0..4`
- Returning to Flex restored `Waterfall color gain`, `Waterfall auto-black offset`, and `Waterfall rate`
- `externalReceiveReplacement` returned to `false`; `transmitting` stayed `false`

Additional checks:

- `python3 tools/check_a11y.py src/gui/SpectrumOverlayMenu.cpp` — 0 findings
- `python3 tools/check_a11y.py` — completed with 7 pre-existing warnings in 4 unrelated files
- `python3 tools/check_engine_boundary.py --strict` — 0 blockers
- `ctest --test-dir build --output-on-failure -R 'kiwi_sdr_(protocol|trace_math)_test'` — 2/2 passed
- `ctest --test-dir build --output-on-failure -R '(spectrum_preview_logic|waterfall_history_buffer|dss_renderer)_test'` — 3/3 passed
- `git diff --check` — clean

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter code changed)
- [x] Documentation updated if user-visible behavior changed (not applicable; accessibility metadata now matches existing labels)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with OpenAI Codex.
