### PR TITLE
fix(gui): a diversity slice is not a split partner (#3980)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6468,14 +6468,18 @@ void MainWindow::updateSplitState()
 
     for (auto* s : m_radioModel.slices()) {
         if (!s || s->isTxSlice()) continue;       // RX candidates only
-        // A diversity slice is not a split partner (#3980). The child is an
+        // A diversity CHILD is not a split partner (#3980). The child is an
         // RX-only beamforming slave that deliberately SHARES its parent's
         // panadapter, so it matches the "distinct RX slice on the TX slice's
         // pan" shape below and would otherwise be badged SPLIT while the real
         // TX slice is badged SWAP — and acting on that badge transmits on the
-        // wrong slice. Skip the parent too, so the pair can never be read as a
-        // split in either direction.
-        if (s->diversity() && (s->isDiversityChild() || s->isDiversityParent())) continue;
+        // wrong slice.
+        // Skip ONLY the child, not the parent: the child is strictly RX-only so
+        // it can never be the TX slice, and a diversity PARENT can be a genuine
+        // RX split partner to a *separate* TX slice on the same pan (split-TX +
+        // diversity-RX on one pan, reachable on 2-SCU radios) — suppressing the
+        // parent's badge there would be a regression.
+        if (s->diversity() && s->isDiversityChild()) continue;
         if (!txByPan.contains(s->panId())) continue;  // need a distinct TX slice here
         auto*& chosen = rxByPan[s->panId()];      // default-inserts nullptr
         // Prefer the GUI-tracked RX (exact pairing for the SPLIT button), then the

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6468,6 +6468,14 @@ void MainWindow::updateSplitState()
 
     for (auto* s : m_radioModel.slices()) {
         if (!s || s->isTxSlice()) continue;       // RX candidates only
+        // A diversity slice is not a split partner (#3980). The child is an
+        // RX-only beamforming slave that deliberately SHARES its parent's
+        // panadapter, so it matches the "distinct RX slice on the TX slice's
+        // pan" shape below and would otherwise be badged SPLIT while the real
+        // TX slice is badged SWAP — and acting on that badge transmits on the
+        // wrong slice. Skip the parent too, so the pair can never be read as a
+        // split in either direction.
+        if (s->diversity() && (s->isDiversityChild() || s->isDiversityParent())) continue;
         if (!txByPan.contains(s->panId())) continue;  // need a distinct TX slice here
         auto*& chosen = rxByPan[s->panId()];      // default-inserts nullptr
         // Prefer the GUI-tracked RX (exact pairing for the SPLIT button), then the


### PR DESCRIPTION
Fixes #3980.

### Problem

`MainWindow::updateSplitState()` derives the SPLIT/SWAP flag badges purely from topology: a slice is the "RX-in-split" partner when it is **not** the TX slice and it **shares the TX slice's panadapter**.

A diversity child is precisely that shape — it is RX-only, and it deliberately shares its parent's pan. So clicking DIV badges the child `SPLIT` and the real TX slice `SWAP`, as reported.

That is not cosmetic. Acting on the false badge drives the split/swap action against a slice that was never a transmit partner, so TX lands on the wrong slice.

### Fix

```cpp
if (s->diversity() && (s->isDiversityChild() || s->isDiversityParent())) continue;
```

AetherSDR already models this relationship — `SliceModel::isDiversityChild()` / `isDiversityParent()` are parsed and available; they simply were not consulted in the badge derivation. Skipping both halves means the pair can never be read as a split in either direction.

**On the `diversity()` gate:** my first attempt was `isDiversityChild() || isDiversityParent()` alone. That is wrong. The sub-flags can be stale — I hit a slice reporting `diversity=0` while still carrying `diversityParent=1` — and excluding such a slice suppresses the badge on a **legitimate** split pair. Gating on `diversity()` as well keeps the guard robust to stale sub-flags from any source. The regression test below is what caught this; without it I would have shipped the broken version.

The triage suggested reusing `MainWindow::isSameDiversityReceivePair()`. I looked at it and did not: that helper compares **two** slices (and has a same-pan fallback), whereas this loop filters a single candidate before any partner is chosen. Using it here would mean inventing a second argument.

### Verification

AetherSDR 26.7.3 against a synthetic FLEX-6700, **fresh instance for each run**:

| case | result |
|---|---|
| **Baseline** — one slice, DIV never clicked | `SPLIT` badge idle/ghosted |
| **DIV on** — diversity pair | both slices idle; **no SWAP, no active SPLIT** |
| **DIV on, +30 s** | unchanged |
| **Genuine split** — TX slice + an ordinary RX slice on the same pan | `SWAP` + active `SPLIT`, **unaffected** |
| *(before this change, same DIV scenario)* | `SWAP` + active `SPLIT` — the bug |

Two notes on method, since both changed the result:

- **The baseline case is load-bearing.** A ghosted `SPLIT` is AE's *idle* badge, not an absence — without capturing a slice that had never been in diversity or split, "both ghosted" could equally have been a stale badge stuck in the idle look.
- **The +30 s check** exists because `updateSplitState()` re-runs on every slice update and overlay push. A guard that only held on the first pass would have surfaced there.

The last row is the one that matters for review: excluding diversity slices does not disturb a real split pair sharing a panadapter.

### Reproducing without hardware

The diversity path is now emulatable in [flex-sim](https://github.com/nigelfenton/flex-sim) (`a148c06`) — it emits `tx=` on the transmit slice and answers `slice set N diversity=1|0` by creating an RX-only child on the parent's panadapter. Point AE at a flex-sim started with `--models FLEX-6700` and toggle DIV; no radio needed.

### Not addressed here

- The greyed-out `TX` chip on the diversity child is *observed* behaviour; I have not traced whether it follows from the diversity flags or simply from `txSlice=false`. Worth noting only because it means the UI already had the information needed to avoid the false pairing.
- PR #4262 (merged) relabels the badge **text** from the slice role (#4051). That is a different bug in adjacent code — it governs which handler a click dispatches to, not whether a diversity child is paired in the first place.
