### PR TITLE
perf(meters): memoize SWR guide samples — fixes the AETHER_AUTOMATION GUI freeze

### DIFF
--- a/src/gui/CrossNeedleMeterGeometry.cpp
+++ b/src/gui/CrossNeedleMeterGeometry.cpp
@@ -103,6 +103,34 @@ double pointSegmentDistance(const QPointF &point, const QPointF &first, const QP
     return std::hypot(point.x() - closest.x(), point.y() - closest.y());
 }
 
+// Arc-length-uniform resampling of a guide path. This is the ONLY place the
+// sampling exists, so the cached and uncached paths are identical by
+// construction rather than by inspection.
+constexpr int kGuideDistanceSamples = 640;
+
+QVector<QPointF> sampleGuidePath(const QPainterPath &path) {
+    QVector<QPointF> samples;
+    if (path.isEmpty()) {
+        return samples;
+    }
+    samples.reserve(kGuideDistanceSamples + 1);
+    for (int i = 0; i <= kGuideDistanceSamples; ++i) {
+        samples.append(path.pointAtPercent(static_cast<double>(i) / kGuideDistanceSamples));
+    }
+    return samples;
+}
+
+double minimumDistanceToSamples(const QPointF &point, const QVector<QPointF> &samples) {
+    if (samples.size() < 2) {
+        return std::numeric_limits<double>::infinity();
+    }
+    double minimum = std::numeric_limits<double>::infinity();
+    for (int i = 1; i < samples.size(); ++i) {
+        minimum = std::min(minimum, pointSegmentDistance(point, samples[i - 1], samples[i]));
+    }
+    return minimum;
+}
+
 } // namespace
 
 CrossNeedleMeterGeometry CrossNeedleMeterGeometry::loadResource(QString *error) {
@@ -1299,33 +1327,38 @@ QPointF CrossNeedleMeterGeometry::powerReadingsAtIntersection(
                    inverseInterpolate(reflectedScale, reflectedAngleRadians) * safeMultiplier);
 }
 
+const QVector<QPointF> &CrossNeedleMeterGeometry::guideSamples(int index) const {
+    // The geometry is immutable after load, so the samples need no invalidation
+    // key -- same contract as swrLabelCenterCache. GUI-thread only.
+    if (swrGuideSampleCache.size() != swrGuides.size()) {
+        swrGuideSampleCache.clear();
+        swrGuideSampleCache.reserve(swrGuides.size());
+        for (const SwrGuide &guide : swrGuides) {
+            swrGuideSampleCache.append(sampleGuidePath(swrGuidePath(guide)));
+        }
+    }
+    return swrGuideSampleCache[index];
+}
+
 double CrossNeedleMeterGeometry::distanceToGuide(const QPointF &point,
                                                  const SwrGuide &guide) const {
-    const QPainterPath path = swrGuidePath(guide);
-    if (path.isEmpty()) {
-        return std::numeric_limits<double>::infinity();
+    for (int index = 0; index < swrGuides.size(); ++index) {
+        if (swrGuides[index].label == guide.label) {
+            return minimumDistanceToSamples(point, guideSamples(index));
+        }
     }
-
-    constexpr int kDistanceSamples = 640;
-    double minimum = std::numeric_limits<double>::infinity();
-    QPointF previous = path.pointAtPercent(0.0);
-    for (int i = 1; i <= kDistanceSamples; ++i) {
-        const QPointF current =
-            path.pointAtPercent(static_cast<double>(i) / kDistanceSamples);
-        minimum = std::min(minimum, pointSegmentDistance(point, previous, current));
-        previous = current;
-    }
-    return minimum;
+    // A synthetic guide that is not in the table: same sampler, just uncached.
+    return minimumDistanceToSamples(point, sampleGuidePath(swrGuidePath(guide)));
 }
 
 QString CrossNeedleMeterGeometry::nearestGuideLabel(const QPointF &point, double *distance) const {
     QString nearest;
     double minimum = std::numeric_limits<double>::infinity();
-    for (const SwrGuide &guide : swrGuides) {
-        const double candidate = distanceToGuide(point, guide);
+    for (int index = 0; index < swrGuides.size(); ++index) {
+        const double candidate = minimumDistanceToSamples(point, guideSamples(index));
         if (candidate < minimum) {
             minimum = candidate;
-            nearest = guide.label;
+            nearest = swrGuides[index].label;
         }
     }
     if (distance) {

--- a/src/gui/CrossNeedleMeterGeometry.h
+++ b/src/gui/CrossNeedleMeterGeometry.h
@@ -365,6 +365,11 @@ class CrossNeedleMeterGeometry {
     // collision layout before the static face is rebuilt.
     QVector<QPointF> swrLabelCenters(const QFont &labelFont) const;
     mutable QVector<QPointF> swrLabelCenterCache;
+    // Arc-length-uniform samples of every SWR guide, in guide order, built once
+    // on first use. The geometry is immutable after load, so unlike the label
+    // centres above there is no font or design key to invalidate against.
+    const QVector<QPointF> &guideSamples(int index) const;
+    mutable QVector<QVector<QPointF>> swrGuideSampleCache;
     mutable QString swrLabelCenterCacheFontKey;
     mutable QString swrLabelPlacementError;
     QRectF swrLabelBox(const QPointF &center, const SwrGuide &guide,


### PR DESCRIPTION
## Summary

Enabling `AETHER_AUTOMATION` freezes the GUI. Not *using* the bridge — merely
enabling it. The cost sits on the meter path, so it bites the moment power/SWR
meters start flowing, which is why it presents as "snappy for a few seconds
after connect, then a hard halt".

`CrossNeedleMeterWidget::publishAutomationProperties()` calls
`CrossNeedleMeterGeometry::nearestGuideLabel()` on every invocation, and is
reached from **five** sites — including `updateTargets()` on every meter packet
and `advanceNeedles()` off `m_animationTimer` at
`kMeterSmootherIntervalMs = 8 ms` (**125 Hz**). Per invocation, with the 12 SWR
guides in `cross-needle-v12.json`:

| Step | Cost |
|---|---|
| `swrGuidePath()` rebuilds a 257-element polyline from scratch | per guide |
| `distanceToGuide()` calls `pointAtPercent()` **641×** on that fresh path | per guide |
| `nearestGuideLabel()` repeats for all **12** guides | per publish |

≈ **6,700 curve evaluations and 7,692 `pointAtPercent` calls per publish**, and
`pointAtPercent` is itself linear in element count — on the order of **two
million segment-length evaluations**, on the GUI thread, up to 125 times a
second.

Measured on a wedged instance: main thread pegged at **88.7% CPU** with 635 s of
CPU burned, `wchan=0` (never sleeping) while the network threads kept running —
so it reads as a hang but is a busy loop. `gdb` backtrace:

```
QPainterPath::elementAt
QPainterPathPrivate::bezierAtT
QPainterPath::pointAtPercent
CrossNeedleMeterGeometry::distanceToGuide      (:1313)
CrossNeedleMeterGeometry::nearestGuideLabel    (:1325)
CrossNeedleMeterWidget::publishAutomationProperties  (:751)
CrossNeedleMeterWidget::updateTargets          (:304)
MeterModel::directionalPowerMetersChanged
MeterModel::updateValues                       (MeterModel.cpp:580)
```

The geometry is immutable after load, so those samples are constant. This
memoizes them per guide on first use, mirroring the `swrLabelCenterCache` idiom
directly above it.

**Bit-exactness is structural, not incidental.** The cache is filled by the
*same* `pointAtPercent` loop that ran before, factored into a single file-local
`sampleGuidePath()`; the fold in `minimumDistanceToSamples()` is the same
`pointSegmentDistance()` over the same 640 segments in the same order. The
tie-break in `nearestGuideLabel` (first guide wins on an exact tie) is
preserved. `publishAutomationProperties` is **untouched** — all 21 properties
still fire on every invocation with identical values.

`distanceToGuide()` keeps its public signature. A guide not present in the table
(no such caller today) falls through to the same sampler, uncached, so the two
paths cannot drift.

Cost: ~123 KB per geometry instance, built once. Under `AETHER_AUTOMATION` that
build now lands at widget construction (the publish call at :127) rather than on
the animation path — a deterministic one-time move, not a new cost. Worth
knowing so it isn't misread as a startup regression.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** The freeze is characterised with a
backtrace off a genuinely wedged process and a counted cost model, not a
plausible-looking hot spot; and the change is A/B'd on the same build tree
rather than asserted. Live before/after on hardware is in the test plan below.

Also relevant: the fix deliberately changes **no** published property, so the
automation contract other agents rely on is unaffected.

## Reproduction

1. Launch with `AETHER_AUTOMATION=1` (any socket/identity).
2. Connect to a radio that publishes forward-power/SWR meters.
3. GUI is responsive briefly, then hard-freezes; `top` shows the main thread
   pegged. Network/audio keep running, so the radio side looks healthy.

Note the trigger is the *environment variable*, not bridge traffic — no
commands need to be sent.

## Test plan

- [x] Local build passes (`ninja -C build cross_needle_meter_test`, 9/9, 0 errors)
- [x] Existing tests pass: **111 OK / 1 FAIL before AND after**, the same
      pre-existing `SWR label placement cache is keyed by the rendered font`.
      A/B'd by stashing this change on the same build tree — identical counts,
      identical failing test.
- [x] Without `AETHER_AUTOMATION`, nothing changes — `publishAutomationProperties`
      still early-returns and the cache is never built.
- [x] **Behaviour verified on a real radio.** Same host, same gateway, same
      IC-705, `AETHER_AUTOMATION=1`, offscreen, connected and left to run;
      main-thread CPU sampled over a fixed 20 s window from
      `/proc/<pid>/task/<tid>/stat`, then 8 bridge pings:

      | | unpatched `main` | this branch |
      |---|---|---|
      | main-thread CPU, 20 s | **99.6%** | **22.9%** |
      | bridge pings answered | **0 / 8** | **8 / 8** |

      The ping row is the user-visible symptom: on `main` the bridge stops
      answering entirely because the GUI thread never gets back to its event
      loop. Also confirmed interactively on a Wayland session — client stays
      responsive with the radio connected and meters flowing.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls (Principle V) — no settings touched
- [x] Code is clean-room (Principle IV) — Qt APIs only, no external provenance
- [x] All meter UI uses `MeterSmoother` — unchanged, this is below the widget
- [ ] Documentation updated — n/a, no user-visible behaviour change
- [x] Security-sensitive changes reference a GHSA if applicable — n/a

## A deliberate non-change, for the maintainer to decide

Replacing the 641 arc-length resamples with a `path.elementAt()` vertex walk
would be smaller *and* arguably more accurate — the resampled chords cut corners
the 257 real vertices do not. I did **not** adopt it: it shifts
`nearestGuideDistancePx` in the low bits, which violates "preserves the
published properties exactly". Flagging it as an option rather than taking it
unilaterally.

Memoizing `swrGuidePath()` itself is also nearly free once this cache exists,
but the static-layer path is already gated behind `m_cacheValid`, so it is not
part of this freeze. Happy to file it separately.

---

73, Ozy **K6OZY**
AI compute partnership: [cloaked.agency](https://cloaked.agency) — (model: claude-opus-4-8)
