### PR TITLE
feat(gui): add Slice Audio Switcher dialog for one-click slice mute toggling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -742,6 +742,7 @@ set(GUI_SOURCES
     src/gui/MemoryCommands.cpp
     src/gui/MemoryBrowsePanel.cpp
     src/gui/MemoryDialog.cpp
+    src/gui/SliceAudioSwitcherDialog.cpp
     src/gui/NetSchedulerDialog.cpp
     src/gui/NetReminderBanner.cpp
     src/gui/SpotSettingsDialog.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -93,6 +93,7 @@
 #include "PropDashboardDialog.h"
 #include "MemoryCommands.h"
 #include "MemoryDialog.h"
+#include "SliceAudioSwitcherDialog.h"
 #include "SwrSweepLicenseDialog.h"
 #include "DxClusterDialog.h"
 #ifdef HAVE_WEBSOCKETS
@@ -3475,6 +3476,11 @@ void MainWindow::showMemoryDialog()
             s.save();
         });
     }
+}
+
+void MainWindow::showSliceAudioSwitcherDialog()
+{
+    showOrRaisePersistent(m_sliceAudioSwitcherDialog, &m_radioModel);
 }
 
 SliceModel* MainWindow::preferredMemorySlice(const QString& preferredPanId) const

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -93,7 +93,6 @@
 #include "PropDashboardDialog.h"
 #include "MemoryCommands.h"
 #include "MemoryDialog.h"
-#include "SliceAudioSwitcherDialog.h"
 #include "SwrSweepLicenseDialog.h"
 #include "DxClusterDialog.h"
 #ifdef HAVE_WEBSOCKETS
@@ -3476,11 +3475,6 @@ void MainWindow::showMemoryDialog()
             s.save();
         });
     }
-}
-
-void MainWindow::showSliceAudioSwitcherDialog()
-{
-    showOrRaisePersistent(m_sliceAudioSwitcherDialog, &m_radioModel);
 }
 
 SliceModel* MainWindow::preferredMemorySlice(const QString& preferredPanId) const

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -112,6 +112,7 @@ class RadioSetupDialog;
 class NetworkDiagnosticsDialog;
 class AgcCalibrationDialog;
 class MemoryDialog;
+class SliceAudioSwitcherDialog;
 class NetSchedulerDialog;
 class NetReminderBanner;
 class NetScheduler;
@@ -589,6 +590,7 @@ private:
 
     void showMemoryDialog();
     void showQuickAddMemoryDialog(const QString& preferredPanId = {});
+    void showSliceAudioSwitcherDialog();
 
     // Net Reminder Scheduler (MainWindow_Nets.cpp).
     void initNetScheduler();
@@ -1025,6 +1027,7 @@ private:
     QPointer<PropDashboardDialog> m_propDashboardDialog;
     QPointer<TxBandDialog> m_txBandDialog;
     QPointer<MemoryDialog> m_memoryDialog;
+    QPointer<SliceAudioSwitcherDialog> m_sliceAudioSwitcherDialog;
     QPointer<NetSchedulerDialog> m_netSchedulerDialog;
     NetScheduler* m_netScheduler{nullptr};
     NetReminderBanner* m_netReminderBanner{nullptr};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -590,7 +590,6 @@ private:
 
     void showMemoryDialog();
     void showQuickAddMemoryDialog(const QString& preferredPanId = {});
-    void showSliceAudioSwitcherDialog();
 
     // Net Reminder Scheduler (MainWindow_Nets.cpp).
     void initNetScheduler();

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -22,6 +22,7 @@
 #include "PersistentDialog.h"
 #include "RC28MappingDialog.h"
 #include "ShortcutDialog.h"
+#include "SliceAudioSwitcherDialog.h"
 #include "SliceTroubleshootingDialog.h"
 #include "SpectrumWidget.h"
 #include "SupportDialog.h"
@@ -288,7 +289,7 @@ void MainWindow::buildMenuBar()
     });
     auto* sliceAudioAction = settingsMenu->addAction("Slice Audio Switcher...");
     connect(sliceAudioAction, &QAction::triggered, this, [this] {
-        showSliceAudioSwitcherDialog();
+        showOrRaisePersistent(m_sliceAudioSwitcherDialog, &m_radioModel);
     });
     auto* netSchedulerAction = settingsMenu->addAction("Net Scheduler...");
     connect(netSchedulerAction, &QAction::triggered, this, [this] {

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -286,6 +286,10 @@ void MainWindow::buildMenuBar()
     connect(memoryAction, &QAction::triggered, this, [this] {
         showMemoryDialog();
     });
+    auto* sliceAudioAction = settingsMenu->addAction("Slice Audio Switcher...");
+    connect(sliceAudioAction, &QAction::triggered, this, [this] {
+        showSliceAudioSwitcherDialog();
+    });
     auto* netSchedulerAction = settingsMenu->addAction("Net Scheduler...");
     connect(netSchedulerAction, &QAction::triggered, this, [this] {
         showNetSchedulerDialog();

--- a/src/gui/SliceAudioSwitcherDialog.cpp
+++ b/src/gui/SliceAudioSwitcherDialog.cpp
@@ -31,6 +31,7 @@ SliceAudioSwitcherDialog::SliceAudioSwitcherDialog(RadioModel* model, QWidget* p
         auto* btn = new QPushButton(bodyWidget());
         btn->setFixedSize(56, 40);
         btn->setCursor(Qt::PointingHandCursor);
+        btn->setAccessibleName(QString("Slice %1 audio mute toggle").arg(QChar('A' + id)));
         layout->addWidget(btn);
         m_slots[id].button = btn;
 
@@ -104,6 +105,8 @@ void SliceAudioSwitcherDialog::updateButton(QPushButton* button, SliceModel* sli
                          .arg(muteGlyph(muted)));
     button->setToolTip(muted ? QString("Slice %1 muted — click to unmute").arg(slice->letter())
                               : QString("Slice %1 audio on — click to mute").arg(slice->letter()));
+    button->setAccessibleDescription(muted ? QStringLiteral("Currently muted")
+                                            : QStringLiteral("Currently on"));
     button->setStyleSheet(
         QString("QPushButton { background: %1; color: #000000; border: none; "
                 "border-radius: 4px; font-weight: bold; }")

--- a/src/gui/SliceAudioSwitcherDialog.cpp
+++ b/src/gui/SliceAudioSwitcherDialog.cpp
@@ -1,16 +1,21 @@
 #include "SliceAudioSwitcherDialog.h"
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
+#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 
+#include <QCheckBox>
 #include <QHBoxLayout>
 #include <QPushButton>
+#include <QVBoxLayout>
 
 namespace AetherSDR {
 
 namespace {
+
+const QString kSoloModeSettingsKey = QStringLiteral("SliceAudioSwitcherSoloMode");
 
 QString muteGlyph(bool muted)
 {
@@ -18,36 +23,40 @@ QString muteGlyph(bool muted)
                  : QString::fromUtf8("\xF0\x9F\x94\x8A");  // U+1F50A
 }
 
+// Simple luminance-based pick so the mute glyph/label stays readable against
+// both light and dark per-slice colors (SliceColorManager custom colors can
+// land anywhere in the wheel).
+QColor contrastingTextColor(const QColor& background)
+{
+    const double luminance = (0.299 * background.red() + 0.587 * background.green()
+                               + 0.114 * background.blue()) / 255.0;
+    return luminance > 0.55 ? QColor(0, 0, 0) : QColor(255, 255, 255);
+}
+
 } // namespace
 
 SliceAudioSwitcherDialog::SliceAudioSwitcherDialog(RadioModel* model, QWidget* parent)
-    : PersistentDialog("Slice Audio", "SliceAudioSwitcherDialogGeometry", parent)
+    : PersistentDialog("Slice Audio Switcher", "SliceAudioSwitcherDialogGeometry", parent)
     , m_model(model)
 {
-    auto* layout = new QHBoxLayout(bodyWidget());
-    layout->setSpacing(6);
+    auto* outer = new QVBoxLayout(bodyWidget());
+    outer->setSpacing(4);
 
-    for (int id = 0; id < static_cast<int>(m_slots.size()); ++id) {
-        auto* btn = new QPushButton(bodyWidget());
-        btn->setFixedSize(56, 40);
-        btn->setCursor(Qt::PointingHandCursor);
-        btn->setAccessibleName(QString("Slice %1 audio mute toggle").arg(QChar('A' + id)));
-        layout->addWidget(btn);
-        m_slots[id].button = btn;
+    m_soloCheck = new QCheckBox(QStringLiteral("Solo (only one slice audible)"), bodyWidget());
+    m_soloCheck->setChecked(AppSettings::instance().value(kSoloModeSettingsKey, false).toBool());
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_soloCheck,
+        "QCheckBox { color: {{color.text.secondary}}; font-size: 11px; spacing: 6px; }"
+        + ThemeManager::checkBoxIndicatorStyle());
+    connect(m_soloCheck, &QCheckBox::toggled, this, [](bool on) {
+        AppSettings::instance().setValue(kSoloModeSettingsKey, on);
+    });
+    outer->addWidget(m_soloCheck);
 
-        connect(btn, &QPushButton::clicked, this, [this, id] {
-            for (auto* slice : m_model->slices()) {
-                if (slice && slice->sliceId() == id) {
-                    slice->setAudioMute(!slice->audioMute());
-                    break;
-                }
-            }
-        });
+    m_buttonRow = new QHBoxLayout();
+    m_buttonRow->setSpacing(6);
+    outer->addLayout(m_buttonRow);
 
-        rebuildSlot(id);
-    }
-
-    setMinimumSize(4 * 62, 56);
+    setSlotCount(m_model->maxSlices() > 0 ? m_model->maxSlices() : 1);
 
     connect(m_model, &RadioModel::sliceAdded, this, [this](SliceModel* slice) {
         if (slice && slice->sliceId() >= 0
@@ -59,12 +68,82 @@ SliceAudioSwitcherDialog::SliceAudioSwitcherDialog(RadioModel* model, QWidget* p
         if (sliceId >= 0 && sliceId < static_cast<int>(m_slots.size()))
             rebuildSlot(sliceId);
     });
+    // Radio capacity (4 vs 8 slices on dual-SCU models) is only known once
+    // info arrives, and can change across a reconnect to a different model.
+    connect(m_model, &RadioModel::infoChanged, this, [this]() {
+        setSlotCount(m_model->maxSlices() > 0 ? m_model->maxSlices() : 1);
+    });
+    // Custom slice colors (Settings) apply globally, not per-slice, so
+    // refresh every populated slot rather than waiting on a per-slice signal.
+    connect(&SliceColorManager::instance(), &SliceColorManager::colorsChanged, this, [this]() {
+        for (auto& slot : m_slots) {
+            if (slot.slice)
+                updateButton(slot.button, slot.slice);
+        }
+    });
+}
+
+void SliceAudioSwitcherDialog::setSlotCount(int count)
+{
+    if (count < 1)
+        count = 1;
+    if (count == static_cast<int>(m_slots.size()))
+        return;
+
+    if (count < static_cast<int>(m_slots.size())) {
+        for (int id = count; id < static_cast<int>(m_slots.size()); ++id) {
+            QObject::disconnect(m_slots[id].muteConn);
+            QObject::disconnect(m_slots[id].letterConn);
+            delete m_slots[id].button;
+        }
+        m_slots.resize(count);
+    } else {
+        const int oldSize = static_cast<int>(m_slots.size());
+        m_slots.resize(count);
+        for (int id = oldSize; id < count; ++id) {
+            auto* btn = new QPushButton(bodyWidget());
+            btn->setFixedSize(56, 40);
+            btn->setCursor(Qt::PointingHandCursor);
+            m_buttonRow->addWidget(btn);
+            m_slots[id].button = btn;
+
+            connect(btn, &QPushButton::clicked, this, [this, id] {
+                SliceModel* clicked = nullptr;
+                for (auto* slice : m_model->slices()) {
+                    if (slice && slice->sliceId() == id) {
+                        clicked = slice;
+                        break;
+                    }
+                }
+                if (!clicked)
+                    return;
+
+                clicked->setAudioMute(!clicked->audioMute());
+
+                // Solo mode: turning a slice's audio ON mutes every other
+                // slice so only one is ever audible at a time. Muting the
+                // soloed slice itself doesn't touch the others.
+                if (m_soloCheck->isChecked() && !clicked->audioMute()) {
+                    for (auto* slice : m_model->slices()) {
+                        if (slice && slice->sliceId() != id && !slice->audioMute())
+                            slice->setAudioMute(true);
+                    }
+                }
+            });
+
+            rebuildSlot(id);
+        }
+    }
+
+    setMinimumSize(count * 62, 86);
 }
 
 void SliceAudioSwitcherDialog::rebuildSlot(int sliceId)
 {
     Slot& slot = m_slots[sliceId];
     QObject::disconnect(slot.muteConn);
+    QObject::disconnect(slot.letterConn);
+    slot.slice = nullptr;
 
     SliceModel* slice = nullptr;
     for (auto* s : m_model->slices()) {
@@ -79,15 +158,19 @@ void SliceAudioSwitcherDialog::rebuildSlot(int sliceId)
 
     if (!slice) {
         btn->setText(QString("%1\n\xE2\x80\x94").arg(QChar('A' + sliceId)));
+        btn->setAccessibleName(QString("Slice %1 audio mute toggle").arg(QChar('A' + sliceId)));
         AetherSDR::ThemeManager::instance().applyStyleSheet(btn,
             "QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; "
             "border: none; border-radius: 4px; font-weight: bold; }");
         return;
     }
 
+    slot.slice = slice;
     updateButton(btn, slice);
     slot.muteConn = connect(slice, &SliceModel::audioMuteChanged, this,
                              [this, btn, slice](bool) { updateButton(btn, slice); });
+    slot.letterConn = connect(slice, &SliceModel::letterChanged, this,
+                               [this, btn, slice](const QString&) { updateButton(btn, slice); });
 }
 
 void SliceAudioSwitcherDialog::updateButton(QPushButton* button, SliceModel* slice) const
@@ -99,18 +182,20 @@ void SliceAudioSwitcherDialog::updateButton(QPushButton* button, SliceModel* sli
     const bool muted = slice->audioMute();
     const QColor bg = muted ? SliceColorManager::instance().dimColor(colourIdx)
                              : SliceColorManager::instance().activeColor(colourIdx);
+    const QColor fg = contrastingTextColor(bg);
 
     button->setText(QString("%1\n%2")
                          .arg(SliceLabel::unicodeForm(slice->sliceId(), slice->letter()))
                          .arg(muteGlyph(muted)));
+    button->setAccessibleName(QString("Slice %1 audio mute toggle").arg(slice->letter()));
     button->setToolTip(muted ? QString("Slice %1 muted — click to unmute").arg(slice->letter())
                               : QString("Slice %1 audio on — click to mute").arg(slice->letter()));
     button->setAccessibleDescription(muted ? QStringLiteral("Currently muted")
                                             : QStringLiteral("Currently on"));
-    button->setStyleSheet(
-        QString("QPushButton { background: %1; color: #000000; border: none; "
+    AetherSDR::ThemeManager::instance().applyStyleSheet(button,
+        QString("QPushButton { background: %1; color: %2; border: none; "
                 "border-radius: 4px; font-weight: bold; }")
-            .arg(bg.name()));
+            .arg(bg.name(), fg.name()));
 }
 
 } // namespace AetherSDR

--- a/src/gui/SliceAudioSwitcherDialog.cpp
+++ b/src/gui/SliceAudioSwitcherDialog.cpp
@@ -1,0 +1,113 @@
+#include "SliceAudioSwitcherDialog.h"
+#include "SliceColorManager.h"
+#include "SliceLabel.h"
+#include "core/ThemeManager.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <QHBoxLayout>
+#include <QPushButton>
+
+namespace AetherSDR {
+
+namespace {
+
+QString muteGlyph(bool muted)
+{
+    return muted ? QString::fromUtf8("\xF0\x9F\x94\x87")   // U+1F507
+                 : QString::fromUtf8("\xF0\x9F\x94\x8A");  // U+1F50A
+}
+
+} // namespace
+
+SliceAudioSwitcherDialog::SliceAudioSwitcherDialog(RadioModel* model, QWidget* parent)
+    : PersistentDialog("Slice Audio", "SliceAudioSwitcherDialogGeometry", parent)
+    , m_model(model)
+{
+    auto* layout = new QHBoxLayout(bodyWidget());
+    layout->setSpacing(6);
+
+    for (int id = 0; id < static_cast<int>(m_slots.size()); ++id) {
+        auto* btn = new QPushButton(bodyWidget());
+        btn->setFixedSize(56, 40);
+        btn->setCursor(Qt::PointingHandCursor);
+        layout->addWidget(btn);
+        m_slots[id].button = btn;
+
+        connect(btn, &QPushButton::clicked, this, [this, id] {
+            for (auto* slice : m_model->slices()) {
+                if (slice && slice->sliceId() == id) {
+                    slice->setAudioMute(!slice->audioMute());
+                    break;
+                }
+            }
+        });
+
+        rebuildSlot(id);
+    }
+
+    setMinimumSize(4 * 62, 56);
+
+    connect(m_model, &RadioModel::sliceAdded, this, [this](SliceModel* slice) {
+        if (slice && slice->sliceId() >= 0
+            && slice->sliceId() < static_cast<int>(m_slots.size())) {
+            rebuildSlot(slice->sliceId());
+        }
+    });
+    connect(m_model, &RadioModel::sliceRemoved, this, [this](int sliceId) {
+        if (sliceId >= 0 && sliceId < static_cast<int>(m_slots.size()))
+            rebuildSlot(sliceId);
+    });
+}
+
+void SliceAudioSwitcherDialog::rebuildSlot(int sliceId)
+{
+    Slot& slot = m_slots[sliceId];
+    QObject::disconnect(slot.muteConn);
+
+    SliceModel* slice = nullptr;
+    for (auto* s : m_model->slices()) {
+        if (s && s->sliceId() == sliceId) {
+            slice = s;
+            break;
+        }
+    }
+
+    QPushButton* btn = slot.button;
+    btn->setEnabled(slice != nullptr);
+
+    if (!slice) {
+        btn->setText(QString("%1\n\xE2\x80\x94").arg(QChar('A' + sliceId)));
+        AetherSDR::ThemeManager::instance().applyStyleSheet(btn,
+            "QPushButton { background: {{color.background.1}}; color: {{color.text.secondary}}; "
+            "border: none; border-radius: 4px; font-weight: bold; }");
+        return;
+    }
+
+    updateButton(btn, slice);
+    slot.muteConn = connect(slice, &SliceModel::audioMuteChanged, this,
+                             [this, btn, slice](bool) { updateButton(btn, slice); });
+}
+
+void SliceAudioSwitcherDialog::updateButton(QPushButton* button, SliceModel* slice) const
+{
+    if (!slice)
+        return;
+
+    const int colourIdx = SliceLabel::displayColorIndex(slice->sliceId(), slice->letter());
+    const bool muted = slice->audioMute();
+    const QColor bg = muted ? SliceColorManager::instance().dimColor(colourIdx)
+                             : SliceColorManager::instance().activeColor(colourIdx);
+
+    button->setText(QString("%1\n%2")
+                         .arg(SliceLabel::unicodeForm(slice->sliceId(), slice->letter()))
+                         .arg(muteGlyph(muted)));
+    button->setToolTip(muted ? QString("Slice %1 muted — click to unmute").arg(slice->letter())
+                              : QString("Slice %1 audio on — click to mute").arg(slice->letter()));
+    button->setStyleSheet(
+        QString("QPushButton { background: %1; color: #000000; border: none; "
+                "border-radius: 4px; font-weight: bold; }")
+            .arg(bg.name()));
+}
+
+} // namespace AetherSDR

--- a/src/gui/SliceAudioSwitcherDialog.h
+++ b/src/gui/SliceAudioSwitcherDialog.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+#include <array>
+
+class QPushButton;
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+
+// Small always-on-top-capable panel listing all four possible slice slots
+// (A-D) with a single click to mute/unmute each slice's audio, so the user
+// doesn't have to open every RxApplet to pick which slice to listen to.
+class SliceAudioSwitcherDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit SliceAudioSwitcherDialog(RadioModel* model, QWidget* parent = nullptr);
+
+private:
+    struct Slot {
+        QPushButton* button{nullptr};
+        QMetaObject::Connection muteConn;
+    };
+
+    void rebuildSlot(int sliceId);
+    void updateButton(QPushButton* button, SliceModel* slice) const;
+
+    RadioModel* m_model;
+    std::array<Slot, 4> m_slots;
+};
+
+} // namespace AetherSDR

--- a/src/gui/SliceAudioSwitcherDialog.h
+++ b/src/gui/SliceAudioSwitcherDialog.h
@@ -2,18 +2,23 @@
 
 #include "PersistentDialog.h"
 
-#include <array>
+#include <vector>
 
 class QPushButton;
+class QHBoxLayout;
+class QCheckBox;
 
 namespace AetherSDR {
 
 class RadioModel;
 class SliceModel;
 
-// Small always-on-top-capable panel listing all four possible slice slots
-// (A-D) with a single click to mute/unmute each slice's audio, so the user
-// doesn't have to open every RxApplet to pick which slice to listen to.
+// Small always-on-top-capable panel listing every slice slot the connected
+// radio can host (sized to RadioModel::maxSlices(), so it grows to 8 on
+// dual-SCU radios like the 6700/8600) with a single click to mute/unmute
+// each slice's audio, so the user doesn't have to open every RxApplet to
+// pick which slice to listen to. An optional "Solo" mode keeps at most one
+// slice's audio on at a time — unmuting a slice mutes every other one.
 class SliceAudioSwitcherDialog : public PersistentDialog {
     Q_OBJECT
 
@@ -23,14 +28,19 @@ public:
 private:
     struct Slot {
         QPushButton* button{nullptr};
+        SliceModel* slice{nullptr};
         QMetaObject::Connection muteConn;
+        QMetaObject::Connection letterConn;
     };
 
+    void setSlotCount(int count);
     void rebuildSlot(int sliceId);
     void updateButton(QPushButton* button, SliceModel* slice) const;
 
     RadioModel* m_model;
-    std::array<Slot, 4> m_slots;
+    std::vector<Slot> m_slots;
+    QHBoxLayout* m_buttonRow{nullptr};
+    QCheckBox* m_soloCheck{nullptr};
 };
 
 } // namespace AetherSDR


### PR DESCRIPTION
Closes #4390

## Summary

Adds `SliceAudioSwitcherApplet`, a sidebar applet (id `SLAU`, label "Slice
Audio") listing every slice slot the connected radio can host as
single-click mute/unmute buttons, so the user doesn't have to open every
RxApplet to pick which slice to listen to.

**Rewritten from a `Settings`-menu dialog to an applet** per @jensenpat's
review on the previous version of this PR: a Settings-menu dialog
controlling live radio state (mute) didn't fit the app's UX convention, and
an `AppletPanel`-hosted applet gets pop-out controls, saved-per-instance
dimensions, and multi-monitor placement for free from the existing
container system — no bespoke geometry code needed.

- `SliceAudioSwitcherApplet` (`QWidget`, registered via `AppletPanel`'s
  `makeEntry`, off by default): one button per slice slot, sized to
  `RadioModel::maxSlices()` (so it grows to 8 on dual-SCU radios like the
  6700/8600 instead of a hardcoded 4), colored with the slice's assigned
  color, showing 🔊/🔇 and the slice letter. Click toggles
  `SliceModel::setAudioMute()`.
- Live-synced on `sliceAdded`/`sliceRemoved`, each slice's
  `audioMuteChanged`/`letterChanged`, `SliceColorManager::colorsChanged()`,
  and `RadioModel::slotOccupancyChanged` (dims slots another Multi-Flex
  client owns, via `isSlotForeign`/`foreignSliceOwnerStation`).
- Reacts to `RadioModel::connectionStateChanged`: on disconnect, every slot
  is forced into the disabled placeholder state without trusting
  `RadioModel::slice(id)` (which can still return a stale, dead-session
  object post-disconnect) — avoids the client showing a mute state the
  radio no longer has.
- Model wiring from `MainWindow_Session.cpp`, alongside the other
  multi-slice applets (DAX, DAX IQ, TCI).

**No "Solo" mode in this PR.** An earlier revision of this branch added a
persisted Solo toggle; @ten9876's review correctly flagged that issue #4390
explicitly deferred it ("Follow-up ideas ... will be filed separately") and
that it wasn't disclosed in this PR's description. It's been dropped
entirely and will ship later as its own PR against a dedicated issue.

## Constitution principle honored

Principle II — The Radio Is Authoritative On Live State. The applet holds
no local mute state; every button reflects `SliceModel::audioMute()` live
and a click only sends a request (`setAudioMute`). The
`connectionStateChanged` handling exists specifically to prevent the
opposite (showing a mute state the radio doesn't have after a disconnect).

## Test plan

- [x] Local build passes (`cmake --build build-win --target AetherSDR`) —
      clean compile, no leftover references to the old
      `SliceAudioSwitcherDialog` anywhere in the tree.
- [x] New test `tests/slice_audio_switcher_applet_test.cpp`
      (`slice_audio_switcher_applet_test`) — covers default construction
      (4 disabled slots, no model), `setRadioModel()` against a fresh
      `RadioModel` (still disabled, no live slices), and
      `setRadioModel(nullptr)` not crashing. All assertions pass.
- [x] Behavior verified on a real radio — built and run against a live
      Flex6600; the applet appears in the sidebar drawer, floats/pops out
      with saved geometry, and muting/unmuting each slice works and stays
      synced with the RxApplet's own mute button.
- [ ] Existing tests pass (CI)

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V) — N/A, no new `AppSettings` keys added at all; applet
      visibility/geometry persistence is handled entirely by
      `AppletPanel`'s existing container system.
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — N/A, no
      meter UI in this change
- [x] Documentation updated if user-visible behavior changed — N/A, no
      user-facing docs reference the old Settings-menu entry
- [x] Security-sensitive changes reference a GHSA if applicable — N/A
