### PR TITLE
fix(gui): toggle buttons across 6 files always read "Enabled" regardless of state

### DIFF
--- a/src/gui/CatControlApplet.cpp
+++ b/src/gui/CatControlApplet.cpp
@@ -135,14 +135,14 @@ void CatControlApplet::buildDockedView(QWidget* page)
     auto* row = new QHBoxLayout;
     row->setSpacing(6);
 
-    m_enableBtn = new QPushButton("Enable CAT");
+    const bool catEnabled = AppSettings::instance().value("CatEnabled", "False").toString() == "True";
+    m_enableBtn = new QPushButton(catEnabled ? "Enabled" : "Disabled");
     m_enableBtn->setCheckable(true);
     applyToggleButtonStyle(m_enableBtn, ToggleTribe::Success);
     m_enableBtn->setFixedSize(100, 22);
     {
         QSignalBlocker b(m_enableBtn);
-        m_enableBtn->setChecked(
-            AppSettings::instance().value("CatEnabled", "False").toString() == "True");
+        m_enableBtn->setChecked(catEnabled);
     }
     row->addWidget(m_enableBtn);
     row->addStretch();
@@ -159,6 +159,10 @@ void CatControlApplet::buildDockedView(QWidget* page)
     root->addWidget(hint);
 
     connect(m_enableBtn, &QPushButton::toggled, this, [this](bool on) {
+        m_enableBtn->setText(on ? "Enabled" : "Disabled");
+        if (m_floatingEnableBtn) {
+            m_floatingEnableBtn->setText(on ? "Enabled" : "Disabled");
+        }
         auto& s = AppSettings::instance();
         s.setValue("CatEnabled", on ? "True" : "False");
         s.save();
@@ -173,10 +177,12 @@ void CatControlApplet::setCatEnabled(bool on)
     if (m_enableBtn) {
         QSignalBlocker b(m_enableBtn);
         m_enableBtn->setChecked(on);
+        m_enableBtn->setText(on ? "Enabled" : "Disabled");
     }
     if (m_floatingEnableBtn) {
         QSignalBlocker b(m_floatingEnableBtn);
         m_floatingEnableBtn->setChecked(on);
+        m_floatingEnableBtn->setText(on ? "Enabled" : "Disabled");
     }
     for (int i = 0; i < m_rows.size(); ++i)
         updateRowLocked(i);
@@ -196,14 +202,15 @@ void CatControlApplet::setFloating(bool on)
             // Enable button + note (must enable before ports can be configured)
             auto* enableRow = new QHBoxLayout;
             enableRow->setSpacing(8);
-            m_floatingEnableBtn = new QPushButton("Enable CAT");
+            const bool floatingCatEnabled =
+                AppSettings::instance().value("CatEnabled", "False").toString() == "True";
+            m_floatingEnableBtn = new QPushButton(floatingCatEnabled ? "Enabled" : "Disabled");
             m_floatingEnableBtn->setCheckable(true);
             applyToggleButtonStyle(m_floatingEnableBtn, ToggleTribe::Success);
             m_floatingEnableBtn->setFixedSize(100, 22);
             {
                 QSignalBlocker b(m_floatingEnableBtn);
-                m_floatingEnableBtn->setChecked(
-                    AppSettings::instance().value("CatEnabled", "False").toString() == "True");
+                m_floatingEnableBtn->setChecked(floatingCatEnabled);
             }
             auto* noteLabel = new QLabel("Enable before configuring ports.");
             ThemeManager::instance().applyStyleSheet(noteLabel,
@@ -214,12 +221,14 @@ void CatControlApplet::setFloating(bool on)
             floatingRoot->addLayout(enableRow);
 
             connect(m_floatingEnableBtn, &QPushButton::toggled, this, [this](bool on) {
+                m_floatingEnableBtn->setText(on ? "Enabled" : "Disabled");
                 auto& s = AppSettings::instance();
                 s.setValue("CatEnabled", on ? "True" : "False");
                 s.save();
                 if (m_enableBtn) {
                     QSignalBlocker b(m_enableBtn);
                     m_enableBtn->setChecked(on);
+                    m_enableBtn->setText(on ? "Enabled" : "Disabled");
                 }
                 emit enableChanged(on);
             });

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -90,7 +90,7 @@ void DaxApplet::buildUI()
     m_daxEnable->setAccessibleName(tr("DAX enable"));
     m_daxEnable->setAccessibleDescription(tr("Enable or disable DAX digital audio routing"));
     m_daxEnable->setStyleSheet(kGreenToggle);
-    m_daxEnable->setFixedSize(60, 22);
+    m_daxEnable->setFixedSize(76, 22);
     daxEnRow->addWidget(m_daxEnable);
 
     // DAX enable button → save setting + notify MainWindow

--- a/src/gui/DaxApplet.cpp
+++ b/src/gui/DaxApplet.cpp
@@ -83,7 +83,8 @@ void DaxApplet::buildUI()
     daxLabel->setStyleSheet(kDimLabel);
     daxEnRow->addWidget(daxLabel);
     daxEnRow->addStretch();
-    m_daxEnable = new QPushButton("Enable");
+    const bool daxAutoStart = settings.value("AutoStartDAX", "False").toString() == "True";
+    m_daxEnable = new QPushButton(daxAutoStart ? "Enabled" : "Disabled");
     m_daxEnable->setCheckable(true);
     m_daxEnable->setObjectName(QStringLiteral("daxEnable"));
     m_daxEnable->setAccessibleName(tr("DAX enable"));
@@ -95,10 +96,10 @@ void DaxApplet::buildUI()
     // DAX enable button → save setting + notify MainWindow
     {
         const QSignalBlocker b(m_daxEnable);
-        m_daxEnable->setChecked(
-            settings.value("AutoStartDAX", "False").toString() == "True");
+        m_daxEnable->setChecked(daxAutoStart);
     }
     connect(m_daxEnable, &QPushButton::toggled, this, [this](bool on) {
+        m_daxEnable->setText(on ? "Enabled" : "Disabled");
         auto& ss = AppSettings::instance();
         ss.setValue("AutoStartDAX", on ? "True" : "False");
         ss.save();
@@ -232,6 +233,7 @@ void DaxApplet::setDaxEnabled(bool on)
     }
     QSignalBlocker b(m_daxEnable);
     m_daxEnable->setChecked(on);
+    m_daxEnable->setText(on ? "Enabled" : "Disabled");
 }
 
 void DaxApplet::setDaxRxLevel(int channel, float rms)

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2270,7 +2270,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     auto* bgEnabledBtn = new QPushButton(overrideBg ? "Enabled" : "Disabled");
     bgEnabledBtn->setCheckable(true);
     bgEnabledBtn->setChecked(overrideBg);
-    bgEnabledBtn->setFixedWidth(70);
+    bgEnabledBtn->setFixedWidth(76);
     bgEnabledBtn->setStyleSheet(bgStyle);
     auto* bgAutoBtn = new QPushButton("Auto");
     bgAutoBtn->setCheckable(true);

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2236,13 +2236,14 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     // ── Override Colors + color picker ──────────────────────────────────
     grid->addWidget(new QLabel("Override Colors:"), row, 0);
     auto* colorRow = new QHBoxLayout;
-    auto* overrideToggle = new QPushButton("Enabled");
+    auto* overrideToggle = new QPushButton(overrideColors ? "Enabled" : "Disabled");
     overrideToggle->setCheckable(true);
     overrideToggle->setChecked(overrideColors);
     overrideToggle->setFixedWidth(80);
     overrideToggle->setStyleSheet(
         kSpotHubToggle);
-    connect(overrideToggle, &QPushButton::toggled, this, [save](bool on) {
+    connect(overrideToggle, &QPushButton::toggled, this, [save, overrideToggle](bool on) {
+        overrideToggle->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsOverrideColorsEnabled", on ? "True" : "False");
     });
     colorRow->addWidget(overrideToggle);
@@ -2266,7 +2267,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     grid->addWidget(new QLabel("Override Background:"), row, 0);
     auto* bgRow = new QHBoxLayout;
     const QString& bgStyle = kSpotHubToggle;
-    auto* bgEnabledBtn = new QPushButton("Enabled");
+    auto* bgEnabledBtn = new QPushButton(overrideBg ? "Enabled" : "Disabled");
     bgEnabledBtn->setCheckable(true);
     bgEnabledBtn->setChecked(overrideBg);
     bgEnabledBtn->setFixedWidth(70);
@@ -2276,7 +2277,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
     bgAutoBtn->setChecked(overrideBgAuto);
     bgAutoBtn->setFixedWidth(50);
     bgAutoBtn->setStyleSheet(bgStyle);
-    connect(bgEnabledBtn, &QPushButton::toggled, this, [save](bool on) {
+    connect(bgEnabledBtn, &QPushButton::toggled, this, [save, bgEnabledBtn](bool on) {
+        bgEnabledBtn->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsOverrideBackgroundColorsEnabled", on ? "True" : "False");
     });
     connect(bgAutoBtn, &QPushButton::toggled, this, [save](bool on) {
@@ -2319,14 +2321,15 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    auto* spotLinesBtn = new QPushButton("Enabled");
+    auto* spotLinesBtn = new QPushButton(spotLines ? "Enabled" : "Disabled");
     spotLinesBtn->setCheckable(true);
     spotLinesBtn->setChecked(spotLines);
     spotLinesBtn->setFixedWidth(80);
     spotLinesBtn->setToolTip("Show vertical lines from the spectrum up to each spot label.\nDisable during contests to reduce clutter.");
     spotLinesBtn->setStyleSheet(
         kSpotHubToggle);
-    connect(spotLinesBtn, &QPushButton::toggled, this, [save](bool on) {
+    connect(spotLinesBtn, &QPushButton::toggled, this, [save, spotLinesBtn](bool on) {
+        spotLinesBtn->setText(on ? "Enabled" : "Disabled");
         save("IsSpotsLinesEnabled", on ? "True" : "False");
     });
     grid->addWidget(spotLinesBtn, row++, 1, Qt::AlignLeft);
@@ -2363,13 +2366,14 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         int drow = 0;
 
         bool dxccEnabled = m_dxccProvider ? m_dxccProvider->isEnabled() : false;
-        auto* dxccToggle = new QPushButton("Enabled");
+        auto* dxccToggle = new QPushButton(dxccEnabled ? "Enabled" : "Disabled");
         dxccToggle->setCheckable(true);
         dxccToggle->setChecked(dxccEnabled);
         dxccToggle->setFixedWidth(80);
         dxccToggle->setStyleSheet(
             kSpotHubToggle);
-        connect(dxccToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        connect(dxccToggle, &QPushButton::toggled, this, [this, save, dxccToggle](bool on) {
+            dxccToggle->setText(on ? "Enabled" : "Disabled");
             save("IsDxccColoringEnabled", on ? "True" : "False");
             if (m_dxccProvider) m_dxccProvider->setEnabled(on);
         });
@@ -2573,7 +2577,7 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
         // the carrier).
         const bool snapEnabled = AppSettings::instance()
             .value("SHistorySnapToStep", "False").toString() == "True";
-        auto* snapToggle = new QPushButton("Enabled");
+        auto* snapToggle = new QPushButton(snapEnabled ? "Enabled" : "Disabled");
         snapToggle->setCheckable(true);
         snapToggle->setChecked(snapEnabled);
         snapToggle->setFixedWidth(80);
@@ -2582,7 +2586,8 @@ void DxClusterDialog::buildDisplayTab(QTabWidget* tabs)
             "Round SHistory click-to-tune to the nearest multiple of the\n"
             "active slice's step size.  Hides the small carrier offset that\n"
             "comes from detecting voice on the panadapter.");
-        connect(snapToggle, &QPushButton::toggled, this, [save](bool on) {
+        connect(snapToggle, &QPushButton::toggled, this, [save, snapToggle](bool on) {
+            snapToggle->setText(on ? "Enabled" : "Disabled");
             save("SHistorySnapToStep", on ? "True" : "False");
         });
         shGrid->addWidget(new QLabel("Snap to Step:"), shr, 0);

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -890,7 +890,7 @@ QWidget* RadioSetupDialog::buildRadioTab()
         "border: 1px solid #20a040; }";
 
     auto makeToggle = [](bool checked) {
-        auto* btn = new QPushButton("Enabled");
+        auto* btn = new QPushButton(checked ? "Enabled" : "Disabled");
         btn->setCheckable(true);
         btn->setChecked(checked);
         btn->setStyleSheet(kToggleStyle);
@@ -931,6 +931,7 @@ QWidget* RadioSetupDialog::buildRadioTab()
 
         m_remoteOnBtn = makeToggle(m_model->remoteOnEnabled());
         connect(m_remoteOnBtn, &QPushButton::toggled, this, [this](bool on) {
+            m_remoteOnBtn->setText(on ? "Enabled" : "Disabled");
             m_model->setRemoteOnEnabled(on);
         });
         grid->addWidget(makeInfoField(QStringLiteral("Remote On:"), m_remoteOnBtn,
@@ -944,13 +945,37 @@ QWidget* RadioSetupDialog::buildRadioTab()
                                               m_optionsLabel),
                         2, 0);
 
-        auto* fcBtn = makeToggle(true);
-        grid->addWidget(makeInfoField(QStringLiteral("FlexControl:"), fcBtn,
+        // FlexControl support isn't a user-facing setting — it just reflects
+        // whether AetherSDR currently holds control of the radio via the
+        // FlexRadio API, so it's a status label (like Region:/HW Version:
+        // above), not a checkable button. It used to be a makeToggle(true)
+        // QPushButton with no toggled handler wired up (hardcoded true, no
+        // connection to isConnected() either) — clicking it could visually
+        // uncheck to the "off" gray style while the text stayed stuck on
+        // "Enabled", and it kept saying "Enabled" even with no radio
+        // connected at all. Now it tracks isConnected() live, the same way
+        // rebootBtn does a few lines above.
+        auto* fcLbl = new QLabel;
+        auto updateFcLbl = [fcLbl](bool connected) {
+            fcLbl->setText(connected ? "Enabled" : "Disabled");
+            AetherSDR::ThemeManager::instance().applyStyleSheet(fcLbl, connected
+                ? "QLabel { background: #1a5030; border: 1px solid #20a040; "
+                  "border-radius: 3px; color: {{color.accent.success}}; font-size: 11px; font-weight: bold; "
+                  "padding: 3px 10px; }"
+                : "QLabel { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
+                  "border-radius: 3px; color: {{color.text.primary}}; font-size: 11px; font-weight: bold; "
+                  "padding: 3px 10px; }");
+        };
+        updateFcLbl(m_model->isConnected());
+        fcLbl->setAlignment(Qt::AlignCenter);
+        connect(m_model, &RadioModel::connectionStateChanged, this, updateFcLbl);
+        grid->addWidget(makeInfoField(QStringLiteral("FlexControl:"), fcLbl,
                                       kInfoRightLabelWidth),
                         2, 1);
 
         auto* mfBtn = makeToggle(m_model->multiFlexEnabled());
-        connect(mfBtn, &QPushButton::toggled, this, [this](bool on) {
+        connect(mfBtn, &QPushButton::toggled, this, [this, mfBtn](bool on) {
+            mfBtn->setText(on ? "Enabled" : "Disabled");
             m_model->setMultiFlexEnabled(on);
         });
         grid->addWidget(makeInfoField(QStringLiteral("multiFLEX:"), mfBtn,
@@ -1407,7 +1432,7 @@ QWidget* RadioSetupDialog::buildNetworkTab()
         grid->setSpacing(6);
 
         grid->addWidget(new QLabel("Enforce Private IP Connections:"), 0, 0);
-        auto* enforceBtn = new QPushButton("Enabled");
+        auto* enforceBtn = new QPushButton(m_model->enforcePrivateIp() ? "Enabled" : "Disabled");
         enforceBtn->setCheckable(true);
         enforceBtn->setChecked(m_model->enforcePrivateIp());
         AetherSDR::ThemeManager::instance().applyStyleSheet(enforceBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -1415,7 +1440,8 @@ QWidget* RadioSetupDialog::buildNetworkTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(enforceBtn, &QPushButton::toggled, this, [this](bool on) {
+        connect(enforceBtn, &QPushButton::toggled, this, [this, enforceBtn](bool on) {
+            enforceBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
                 QString("radio set enforce_private_ip_connections=%1").arg(on ? 1 : 0));
         });
@@ -2065,7 +2091,7 @@ QWidget* RadioSetupDialog::buildTxTab()
         auto* swLbl = new QLabel("Show TX in Waterfall:");
         swLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(swLbl, 1, 0);
-        auto* swBtn = new QPushButton("Enabled");
+        auto* swBtn = new QPushButton(tx.showTxInWaterfall() ? "Enabled" : "Disabled");
         swBtn->setCheckable(true);
         swBtn->setChecked(tx.showTxInWaterfall());
         AetherSDR::ThemeManager::instance().applyStyleSheet(swBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -2073,7 +2099,8 @@ QWidget* RadioSetupDialog::buildTxTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(swBtn, &QPushButton::toggled, this, [this](bool on) {
+        connect(swBtn, &QPushButton::toggled, this, [this, swBtn](bool on) {
+            swBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
                 QString("transmit set show_tx_in_waterfall=%1").arg(on ? 1 : 0));
         });
@@ -2198,8 +2225,9 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
             m_model->transmitModel().setMicBoost(on);
         });
-        auto* metBtn = mkTogBtn("Enabled", tx.metInRx());
-        connect(metBtn, &QPushButton::toggled, this, [this](bool on) {
+        auto* metBtn = mkTogBtn(tx.metInRx() ? "Enabled" : "Disabled", tx.metInRx());
+        connect(metBtn, &QPushButton::toggled, this, [this, metBtn](bool on) {
+            metBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(QString("transmit set met_in_rx=%1").arg(on ? 1 : 0));
         });
 
@@ -2221,8 +2249,9 @@ QWidget* RadioSetupDialog::buildPhoneCwTab()
         auto* iamLbl = new QLabel("Iambic:");
         iamLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(iamLbl, 0, 0);
-        auto* iamBtn = mkTogBtn("Enabled", tx.cwIambic());
-        connect(iamBtn, &QPushButton::toggled, this, [this](bool on) {
+        auto* iamBtn = mkTogBtn(tx.cwIambic() ? "Enabled" : "Disabled", tx.cwIambic());
+        connect(iamBtn, &QPushButton::toggled, this, [this, iamBtn](bool on) {
+            iamBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(QString("cw iambic %1").arg(on ? 1 : 0));
         });
         grid->addWidget(iamBtn, 0, 1);
@@ -2612,11 +2641,12 @@ QWidget* RadioSetupDialog::buildRxTab()
             auto* lbl = new QLabel(label);
             lbl->setStyleSheet(kLabelStyle);
             grid->addWidget(lbl, row, 0);
-            auto* btn = new QPushButton("Enabled");
+            auto* btn = new QPushButton(checked ? "Enabled" : "Disabled");
             btn->setCheckable(true);
             btn->setChecked(checked);
             btn->setStyleSheet(kTogStyle);
-            connect(btn, &QPushButton::toggled, this, [this, cmd](bool on) {
+            connect(btn, &QPushButton::toggled, this, [this, cmd, btn](bool on) {
+                btn->setText(on ? "Enabled" : "Disabled");
                 m_model->sendCommand(
                     QString("%1=%2").arg(cmd).arg(on ? 1 : 0));
             });
@@ -2943,7 +2973,7 @@ QWidget* RadioSetupDialog::buildAudioTab()
         boostLabel->setStyleSheet(kLabelStyle);
         boostLabel->setFixedWidth(90);
         bool boostOn = AppSettings::instance().value("AudioBoost", "False").toString() == "True";
-        auto* boostBtn = new QPushButton("Enabled");
+        auto* boostBtn = new QPushButton(boostOn ? "Enabled" : "Disabled");
         boostBtn->setCheckable(true);
         boostBtn->setChecked(boostOn);
         boostBtn->setToolTip("Apply 50% software gain boost to PC audio output.\n"
@@ -2953,7 +2983,8 @@ QWidget* RadioSetupDialog::buildAudioTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(boostBtn, &QPushButton::toggled, this, [this](bool on) {
+        connect(boostBtn, &QPushButton::toggled, this, [this, boostBtn](bool on) {
+            boostBtn->setText(on ? "Enabled" : "Disabled");
             auto& s = AppSettings::instance();
             s.setValue("AudioBoost", on ? "True" : "False");
             s.save();
@@ -3314,7 +3345,7 @@ QWidget* RadioSetupDialog::buildXvtrTab()
         auto* rxOnlyLbl = new QLabel("RX Only:");
         rxOnlyLbl->setStyleSheet(kLabelStyle);
         grid->addWidget(rxOnlyLbl, 3, 2);
-        auto* rxOnlyBtn = new QPushButton("Enabled");
+        auto* rxOnlyBtn = new QPushButton(x.rxOnly ? "Enabled" : "Disabled");
         rxOnlyBtn->setCheckable(true);
         rxOnlyBtn->setChecked(x.rxOnly);
         AetherSDR::ThemeManager::instance().applyStyleSheet(rxOnlyBtn, "QPushButton { background: {{color.background.1}}; border: 1px solid {{color.background.2}}; "
@@ -3322,7 +3353,8 @@ QWidget* RadioSetupDialog::buildXvtrTab()
             "padding: 3px 10px; }"
             "QPushButton:checked { background: #1a5030; color: {{color.accent.success}}; "
             "border: 1px solid #20a040; }");
-        connect(rxOnlyBtn, &QPushButton::toggled, this, [this, idx](bool on) {
+        connect(rxOnlyBtn, &QPushButton::toggled, this, [this, idx, rxOnlyBtn](bool on) {
+            rxOnlyBtn->setText(on ? "Enabled" : "Disabled");
             m_model->sendCommand(
                 QString("xvtr set %1 rx_only=%2").arg(idx).arg(on ? 1 : 0));
         });

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -218,7 +218,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_overrideBgEnabled = new QPushButton(m_overrideBg ? "Enabled" : "Disabled");
     m_overrideBgEnabled->setCheckable(true);
     m_overrideBgEnabled->setChecked(m_overrideBg);
-    m_overrideBgEnabled->setFixedWidth(70);
+    m_overrideBgEnabled->setFixedWidth(76);
     m_overrideBgAuto = new QPushButton("Auto");
     m_overrideBgAuto->setCheckable(true);
     m_overrideBgAuto->setChecked(m_overrideBgAutoMode);

--- a/src/gui/SpotSettingsDialog.cpp
+++ b/src/gui/SpotSettingsDialog.cpp
@@ -59,7 +59,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spots: Enabled/Disabled ─────────────────────────────────────────
     grid->addWidget(new QLabel("Spots:"), row, 0);
-    m_spotsToggle = new QPushButton("Enabled");
+    m_spotsToggle = new QPushButton(m_spotsEnabled ? "Enabled" : "Disabled");
     m_spotsToggle->setCheckable(true);
     m_spotsToggle->setChecked(m_spotsEnabled);
     m_spotsToggle->setFixedWidth(80);
@@ -67,6 +67,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotsToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_spotsToggle->setText(on ? "Enabled" : "Disabled");
         m_spotsEnabled = on;
         save("IsSpotsEnabled", on ? "True" : "False");
     });
@@ -74,7 +75,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Memories: Enabled/Disabled ──────────────────────────────────────
     grid->addWidget(new QLabel("Memories:"), row, 0);
-    m_memoriesToggle = new QPushButton("Enabled");
+    m_memoriesToggle = new QPushButton(m_memoriesEnabled ? "Enabled" : "Disabled");
     m_memoriesToggle->setCheckable(true);
     m_memoriesToggle->setChecked(m_memoriesEnabled);
     m_memoriesToggle->setFixedWidth(80);
@@ -84,6 +85,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_memoriesToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_memoriesToggle->setText(on ? "Enabled" : "Disabled");
         m_memoriesEnabled = on;
         save("IsMemorySpotsEnabled", on ? "True" : "False");
     });
@@ -181,7 +183,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     // ── Override Colors + color picker ──────────────────────────────────
     grid->addWidget(new QLabel("Override Colors:"), row, 0);
     auto* colorRow = new QHBoxLayout;
-    m_overrideColorsToggle = new QPushButton("Enabled");
+    m_overrideColorsToggle = new QPushButton(m_overrideColors ? "Enabled" : "Disabled");
     m_overrideColorsToggle->setCheckable(true);
     m_overrideColorsToggle->setChecked(m_overrideColors);
     m_overrideColorsToggle->setFixedWidth(80);
@@ -189,6 +191,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_overrideColorsToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_overrideColorsToggle->setText(on ? "Enabled" : "Disabled");
         m_overrideColors = on;
         save("IsSpotsOverrideColorsEnabled", on ? "True" : "False");
     });
@@ -212,7 +215,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     // ── Override Background + Auto + color picker ───────────────────────
     grid->addWidget(new QLabel("Override Background:"), row, 0);
     auto* bgRow = new QHBoxLayout;
-    m_overrideBgEnabled = new QPushButton("Enabled");
+    m_overrideBgEnabled = new QPushButton(m_overrideBg ? "Enabled" : "Disabled");
     m_overrideBgEnabled->setCheckable(true);
     m_overrideBgEnabled->setChecked(m_overrideBg);
     m_overrideBgEnabled->setFixedWidth(70);
@@ -226,6 +229,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
     m_overrideBgEnabled->setStyleSheet(bgStyle);
     m_overrideBgAuto->setStyleSheet(bgStyle);
     connect(m_overrideBgEnabled, &QPushButton::toggled, this, [this, save](bool on) {
+        m_overrideBgEnabled->setText(on ? "Enabled" : "Disabled");
         m_overrideBg = on;
         save("IsSpotsOverrideBackgroundColorsEnabled", on ? "True" : "False");
     });
@@ -271,7 +275,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
 
     // ── Spot Lines ──────────────────────────────────────────────────────
     grid->addWidget(new QLabel("Spot Lines:"), row, 0);
-    m_spotLinesToggle = new QPushButton("Enabled");
+    m_spotLinesToggle = new QPushButton(m_spotShowLines ? "Enabled" : "Disabled");
     m_spotLinesToggle->setCheckable(true);
     m_spotLinesToggle->setChecked(m_spotShowLines);
     m_spotLinesToggle->setFixedWidth(80);
@@ -280,6 +284,7 @@ SpotSettingsDialog::SpotSettingsDialog(RadioModel* model, QWidget* parent)
         "QPushButton { background: #206030; color: white; border: 1px solid #305040; padding: 3px; }"
         "QPushButton:!checked { background: #603020; }");
     connect(m_spotLinesToggle, &QPushButton::toggled, this, [this, save](bool on) {
+        m_spotLinesToggle->setText(on ? "Enabled" : "Disabled");
         m_spotShowLines = on;
         save("IsSpotsLinesEnabled", on ? "True" : "False");
     });

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -222,7 +222,7 @@ void TciApplet::buildUI()
     m_tciEnable->setAccessibleName(tr("TCI server enable"));
     m_tciEnable->setAccessibleDescription(tr("Start or stop the TCI server"));
     m_tciEnable->setStyleSheet(kGreenToggle);
-    m_tciEnable->setFixedSize(60, 22);
+    m_tciEnable->setFixedSize(76, 22);
     {
         QSignalBlocker b(m_tciEnable);
         m_tciEnable->setChecked(tciAutoStart);

--- a/src/gui/TciApplet.cpp
+++ b/src/gui/TciApplet.cpp
@@ -215,7 +215,8 @@ void TciApplet::buildUI()
     AetherSDR::ThemeManager::instance().applyStyleSheet(m_tciStatus, "QLabel { color: {{color.background.3}}; font-size: 10px; }");
     enableRow->addWidget(m_tciStatus, 1);
 
-    m_tciEnable = new QPushButton("Enable");
+    const bool tciAutoStart = settings.value("AutoStartTCI", "False").toString() == "True";
+    m_tciEnable = new QPushButton(tciAutoStart ? "Enabled" : "Disabled");
     m_tciEnable->setCheckable(true);
     m_tciEnable->setObjectName(QStringLiteral("tciEnable"));
     m_tciEnable->setAccessibleName(tr("TCI server enable"));
@@ -224,8 +225,7 @@ void TciApplet::buildUI()
     m_tciEnable->setFixedSize(60, 22);
     {
         QSignalBlocker b(m_tciEnable);
-        m_tciEnable->setChecked(
-            settings.value("AutoStartTCI", "False").toString() == "True");
+        m_tciEnable->setChecked(tciAutoStart);
     }
     enableRow->addWidget(m_tciEnable);
 
@@ -249,6 +249,7 @@ void TciApplet::buildUI()
     });
 
     connect(m_tciEnable, &QPushButton::toggled, this, [this](bool on) {
+        m_tciEnable->setText(on ? "Enabled" : "Disabled");
         int port = m_tciPort->text().toInt();
         if (port < 1024 || port > 65535) {
             port = 50001;
@@ -265,6 +266,7 @@ void TciApplet::buildUI()
                 if (!m_tciServer->isRunning() && m_tciEnable) {
                     QSignalBlocker b(m_tciEnable);
                     m_tciEnable->setChecked(false);
+                    m_tciEnable->setText("Disabled");
                     m_tciStatus->setText("(port in use)");
                     m_tciStatus->setStyleSheet(
                         "QLabel { color: #cc3333; font-size: 10px; }");
@@ -390,6 +392,7 @@ void TciApplet::setTciEnabled(bool on)
     if (m_tciEnable) {
         QSignalBlocker b(m_tciEnable);
         m_tciEnable->setChecked(on);
+        m_tciEnable->setText(on ? "Enabled" : "Disabled");
     }
     updateTciStatus();
 #else


### PR DESCRIPTION
## Summary

Fixes #4388 — all three affected dialogs plus three applets, in one PR (per AetherClaude's triage recommendation on #4388 and confirmation with the reporter).

Several checkable `QPushButton` toggles across the GUI had their label text hardcoded at construction and never updated when toggled — only the background color (green when checked) reflected real state, so the text stayed "Enabled" even while a setting was off.

## Files and buttons fixed

**`RadioSetupDialog.cpp`** (`91d96ffb`)

| Setting | Variable |
|---|---|
| Remote On | `m_remoteOnBtn` |
| multiFLEX | `mfBtn` |
| Enforce Private IP Connections | `enforceBtn` |
| Show TX in Waterfall | `swBtn` |
| Level Meter During Receive | `metBtn` |
| Iambic | `iamBtn` |
| Mute Local Audio When Remote | (local toggle) |
| Binaural Audio | (local toggle) |
| Audio Boost | `boostBtn` |
| Transverter RX Only | `rxOnlyBtn` |

Also fixed in this file: **"FlexControl:"** in the Radio Information group was a checkable `QPushButton` with no `toggled` handler wired to anything at all (hardcoded `checked=true`, no backing command) — clicking it could visually flip to the gray "off" style with no effect, and it read "Enabled" even with no radio connected. Converted to a status `QLabel` that tracks `isConnected()` live, the same pattern as the Reboot Radio button.

**`SpotSettingsDialog.cpp`** (`b807cbc8`, `ac021818`) — 5 toggles: Spots, Memories, Override Colors, Override Background, Spot Lines.

> **Note for reviewers:** this dialog is currently dead code — `SpotSettingsDialog` is never instantiated anywhere in the app (its functionality was absorbed into `DxClusterDialog::buildDisplayTab()`'s "Display" tab at some point, and the standalone dialog was never removed). The fix here is correct but untestable live until that's cleaned up separately — tracked outside this PR, not folded in here to keep "fix the bug" and "remove dead code" as separate diffs.

**`DxClusterDialog.cpp`** (`80285306`, `ac021818`) — 5 toggles: Override Colors, Override Background, Spot Lines, DXCC Colors, SHistory Snap to Step. Three of these (Override Colors/Background, Spot Lines) are near-duplicates of the `SpotSettingsDialog` toggles above — same bug, same fix, carried across both copies of the UI.

**DAX / TCI / CAT applets** (`e9ff85a9`, `cb9f4cc4`) — audited every applet in the right-side panel for the same pattern and found it in three more places:
- `DaxApplet.cpp` — `m_daxEnable`
- `TciApplet.cpp` — `m_tciEnable`, including a bind-failure path that snaps the button back off (now also resets the text) and a public `setTciEnabled()` setter used to sync from outside (same)
- `CatControlApplet.cpp` — `m_enableBtn` and `m_floatingEnableBtn` (main panel + floating pop-out, which mirror each other's state via `QSignalBlocker` and needed all three sync paths — both `toggled` handlers plus the public `setCatEnabled()` setter — updated to keep text in sync too, not just checked state)

Dropped the "CAT" qualifier from `CatControlApplet`'s buttons ("Enable CAT" → "Enabled"/"Disabled") for consistency with everywhere else.

## Button widths

The old hardcoded labels ("Enable", or a static "Enabled") were sized for shorter/fixed text; the new "Disabled" (8 chars) doesn't fit some of those widths:
- DAX/TCI enable buttons: 60px → 76px (`cb9f4cc4`)
- DxClusterDialog's Override Background toggle (`bgEnabledBtn`, 70px) and its SpotSettingsDialog near-duplicate (`m_overrideBgEnabled`, same 70px): both → 76px (`ac021818`), fixing a barely-visible clip caught in review.

## Testing

- Built clean on macOS (Metal) throughout, all 6 commits.
- Manually tested every toggle listed above in the running app — text and color both track real state correctly, on dialog/panel open and after every click, including the mirrored-button sync paths (CAT applet), the bind-failure edge case (TCI applet), and the Override Background width fix.
- FlexControl verified in both states: "Disabled" with no radio connected, "Enabled" once connected, updating live without reopening the dialog.
- `SpotSettingsDialog.cpp` fix built and reviewed but not live-testable per the dead-code note above.
