### PR TITLE
Honor frameless mode in the UI Scale restart prompt

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6932,7 +6932,7 @@ void MainWindow::applyUiScale(int pct)
     AppSettings::instance().setValue("UiScalePercent", QString::number(pct));
     AppSettings::instance().save();
 
-    auto answer = QMessageBox::question(this, "UI Scale",
+    auto answer = FramelessMessageBox::question(this, "UI Scale",
         QString("UI scale changed to %1%. Restart AetherSDR now to apply?").arg(pct),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (answer == QMessageBox::Yes) {


### PR DESCRIPTION
## Summary

Makes the View → UI Scale restart confirmation honor the global Use Frameless Windows setting by routing it through the shared `FramelessMessageBox`. The prompt retains its existing text, buttons, default selection, modal behavior, and restart path.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The built macOS artifact was exercised through the automation bridge, confirming that the UI Scale prompt uses `FramelessMessageBox` and displays a visible `FramelessWindowTitleBar`.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable — not applicable; this is an isolated UI-only change
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug
- [x] `python3 tools/check_a11y.py` completes with no blocking findings
- [x] `python3 tools/check_engine_boundary.py --strict` reports 0 blocking findings
- [x] `git diff --check` passes

Reproduction:

1. Enable View → Use Frameless Windows.
2. Select a different value under View → UI Scale.
3. Confirm that the restart prompt uses AetherSDR's custom frameless title bar instead of native window chrome.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable
- [x] Documentation updated if user-visible behavior changed — no documentation change needed; the prompt now conforms to the existing setting
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
