### PR TITLE
Organize and stabilize the network diagnostics tooltip

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1751,13 +1751,9 @@ MainWindow::MainWindow(QWidget* parent)
         m_networkLabel->setText(QString("[<span style='color:%1'>%2</span>]")
             .arg(color, quality + capSuffix));
         Q_UNUSED(pingMs);
-        QString tooltip = buildNetworkTooltip(m_radioModel);
-        if (m_adaptiveFpsCap > 0) {
-            const QString throttleMsg = dwellPending
-                ? QStringLiteral("Adaptive throttle holding for link stability — restoring shortly\n\n")
-                : QString("Adaptive throttle active: %1 fps cap\n\n").arg(m_adaptiveFpsCap);
-            tooltip.prepend(throttleMsg);
-        }
+        const QString tooltip = buildNetworkTooltip(m_radioModel,
+                                                     m_adaptiveFpsCap,
+                                                     dwellPending);
         m_networkLabel->setToolTip(tooltip);
     });
 
@@ -4707,10 +4703,15 @@ void MainWindow::buildUI()
     netTitle->setAlignment(Qt::AlignCenter);
     netVbox->addWidget(netTitle);
     m_networkLabel = new QLabel("");
+    m_networkLabel->setAccessibleName(QStringLiteral("Network status"));
+    m_networkLabel->setAccessibleDescription(
+        QStringLiteral("Network quality; double-click to open full diagnostics"));
     applyStatusBarCompactLabelStyle(m_networkLabel, QStringLiteral("{{color.text.label}}"));
     m_networkLabel->setTextFormat(Qt::RichText);
     m_networkLabel->setAlignment(Qt::AlignCenter);
-    m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel));
+    m_networkLabel->setToolTip(buildNetworkTooltip(m_radioModel,
+                                                   m_adaptiveFpsCap,
+                                                   m_radioModel.pendingThrottleLift()));
     m_networkLabel->installEventFilter(this);
     m_networkTooltipRefreshTimer.setInterval(1000);
     connect(&m_networkTooltipRefreshTimer, &QTimer::timeout, this, [this] {
@@ -4718,7 +4719,9 @@ void MainWindow::buildUI()
             m_networkTooltipRefreshTimer.stop();
             return;
         }
-        const QString tooltip = buildNetworkTooltip(m_radioModel);
+        const QString tooltip = buildNetworkTooltip(m_radioModel,
+                                                     m_adaptiveFpsCap,
+                                                     m_radioModel.pendingThrottleLift());
         m_networkLabel->setToolTip(tooltip);
         const QPoint pos = m_networkLabel->mapToGlobal(QPoint(m_networkLabel->width() / 2, 0));
         QToolTip::showText(pos, tooltip, m_networkLabel);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1721,14 +1721,9 @@ MainWindow::MainWindow(QWidget* parent)
     wireDaxIq();
 
     // ── Status bar telemetry ──────────────────────────────────────────────────
-    // Single source of truth for quality-level colors used by the footer label
-    // and the heartbeat throttle indicator.  Both must stay in sync.
-    auto qualityColor = [](const QString& quality) -> QString {
-        if (quality == "Fair") return QStringLiteral("#cc9900");
-        if (quality == "Poor") return QStringLiteral("#cc3333");
-        if (quality == "Good") return QStringLiteral("#00b4d8");
-        return QStringLiteral("#00cc66"); // Excellent / Very Good
-    };
+    // Quality-level colors come from networkQualityColor() (MainWindowHelpers)
+    // so the footer label and the diagnostics tooltip share one mapping and
+    // never diverge (e.g. "Off" is neutral grey in both, not green here).
     // Map an fps cap to the matching quality-level color for the throttle indicator.
     auto fpsCapColor = [](int fpsCap) -> QString {
         if (fpsCap <= 4) return QStringLiteral("#cc3333"); // Poor
@@ -1737,8 +1732,8 @@ MainWindow::MainWindow(QWidget* parent)
     };
 
     connect(&m_radioModel, &RadioModel::networkQualityChanged,
-            this, [this, qualityColor](const QString& quality, int pingMs) {
-        const QString color = qualityColor(quality);
+            this, [this](const QString& quality, int pingMs) {
+        const QString color = networkQualityColor(quality);
         // Append fps cap so users understand why moving the fps slider has no effect.
         // Show "(restoring)" during the min-dwell hold so testers can distinguish
         // stuck throttle from a deliberate stability wait.
@@ -4703,9 +4698,9 @@ void MainWindow::buildUI()
     netTitle->setAlignment(Qt::AlignCenter);
     netVbox->addWidget(netTitle);
     m_networkLabel = new QLabel("");
-    m_networkLabel->setAccessibleName(QStringLiteral("Network status"));
+    m_networkLabel->setAccessibleName(tr("Network status"));
     m_networkLabel->setAccessibleDescription(
-        QStringLiteral("Network quality; double-click to open full diagnostics"));
+        tr("Network quality; double-click to open full diagnostics"));
     applyStatusBarCompactLabelStyle(m_networkLabel, QStringLiteral("{{color.text.label}}"));
     m_networkLabel->setTextFormat(Qt::RichText);
     m_networkLabel->setAlignment(Qt::AlignCenter);

--- a/src/gui/MainWindowHelpers.cpp
+++ b/src/gui/MainWindowHelpers.cpp
@@ -70,24 +70,6 @@ QString formatCategorySeqErrors(const PanadapterStream::CategoryStats& stats)
     return formatNetworkSeqErrors(stats.errors, stats.packets);
 }
 
-QString networkQualityColor(const QString& quality)
-{
-    if (quality == QStringLiteral("Excellent")
-            || quality == QStringLiteral("Very Good")) {
-        return QStringLiteral("#00cc66");
-    }
-    if (quality == QStringLiteral("Fair")) {
-        return QStringLiteral("#cc9900");
-    }
-    if (quality == QStringLiteral("Poor")) {
-        return QStringLiteral("#cc3333");
-    }
-    if (quality == QStringLiteral("Good")) {
-        return QStringLiteral("#00b4d8");
-    }
-    return QStringLiteral("#8aa8c0"); // Off / unknown
-}
-
 QString networkTooltipSection(const QString& title)
 {
     return QStringLiteral(
@@ -108,6 +90,24 @@ QString networkTooltipRow(const QString& label, const QString& value)
 }
 } // namespace
 
+QString networkQualityColor(const QString& quality)
+{
+    if (quality == QStringLiteral("Excellent")
+            || quality == QStringLiteral("Very Good")) {
+        return QStringLiteral("#00cc66");
+    }
+    if (quality == QStringLiteral("Fair")) {
+        return QStringLiteral("#cc9900");
+    }
+    if (quality == QStringLiteral("Poor")) {
+        return QStringLiteral("#cc3333");
+    }
+    if (quality == QStringLiteral("Good")) {
+        return QStringLiteral("#00b4d8");
+    }
+    return QStringLiteral("#8aa8c0"); // Off / unknown
+}
+
 QString buildNetworkTooltip(const RadioModel& model,
                             int adaptiveFpsCap,
                             bool throttleRestorePending)
@@ -126,7 +126,11 @@ QString buildNetworkTooltip(const RadioModel& model,
     const QString quality = model.networkQuality();
     QString html = QStringLiteral(
         "<html><body>"
-        "<table width='%1' cellspacing='0' cellpadding='3'>"
+        // Dark background so the fixed light foreground colors below stay
+        // legible regardless of the platform/theme tooltip base color (the
+        // status-bar tooltip has no global QToolTip palette). Matches the
+        // pairing used in PropDashboardDialog.
+        "<table width='%1' bgcolor='#102131' cellspacing='0' cellpadding='3'>"
         "<tr>"
         "<td colspan='2'>"
         "<span style='font-size:10pt; font-weight:600; color:#c8d8e8;'>"

--- a/src/gui/MainWindowHelpers.cpp
+++ b/src/gui/MainWindowHelpers.cpp
@@ -60,6 +60,8 @@ QString formatNetworkSeqErrors(int errors, int packets)
 }
 
 namespace {
+constexpr int kNetworkTooltipWidthPx = 300;
+
 // Distinct name (not an overload of formatNetworkSeqErrors): an
 // anonymous-namespace overload would hide the namespace-scope two-int
 // overload from unqualified lookup inside this TU.
@@ -67,9 +69,48 @@ QString formatCategorySeqErrors(const PanadapterStream::CategoryStats& stats)
 {
     return formatNetworkSeqErrors(stats.errors, stats.packets);
 }
+
+QString networkQualityColor(const QString& quality)
+{
+    if (quality == QStringLiteral("Excellent")
+            || quality == QStringLiteral("Very Good")) {
+        return QStringLiteral("#00cc66");
+    }
+    if (quality == QStringLiteral("Fair")) {
+        return QStringLiteral("#cc9900");
+    }
+    if (quality == QStringLiteral("Poor")) {
+        return QStringLiteral("#cc3333");
+    }
+    if (quality == QStringLiteral("Good")) {
+        return QStringLiteral("#00b4d8");
+    }
+    return QStringLiteral("#8aa8c0"); // Off / unknown
+}
+
+QString networkTooltipSection(const QString& title)
+{
+    return QStringLiteral(
+        "<tr><td colspan='2' style='color:#8aa8c0; font-size:8pt; padding-top:5px;'>"
+        "%1"
+        "</td></tr>")
+        .arg(title.toHtmlEscaped());
+}
+
+QString networkTooltipRow(const QString& label, const QString& value)
+{
+    return QStringLiteral(
+        "<tr>"
+        "<td width='52%' style='color:#8aa8c0; padding-right:18px;'>%1</td>"
+        "<td width='48%' align='right' style='color:#c8d8e8;'>%2</td>"
+        "</tr>")
+        .arg(label.toHtmlEscaped(), value.toHtmlEscaped());
+}
 } // namespace
 
-QString buildNetworkTooltip(const RadioModel& model)
+QString buildNetworkTooltip(const RadioModel& model,
+                            int adaptiveFpsCap,
+                            bool throttleRestorePending)
 {
     const PanadapterStream::CategoryStats audioStats =
         model.categoryStats(PanadapterStream::CatAudio);
@@ -82,30 +123,74 @@ QString buildNetworkTooltip(const RadioModel& model)
     const PanadapterStream::CategoryStats daxStats =
         model.categoryStats(PanadapterStream::CatDAX);
 
-    QStringList lines;
-    lines
-        << QString("Network: %1").arg(model.networkQuality())
-        << QString("Latency (RTT): %1").arg(formatNetworkMs(model.lastPingRtt()))
-        << QString("Max RTT (session): %1").arg(formatNetworkMs(model.maxPingRtt()))
-        << QString("Packet loss (%1s): %2")
-               .arg(model.packetLossWindowSeconds())
-               .arg(formatNetworkSeqErrors(model.packetLossWindowDrops(),
-                                           model.packetLossWindowPackets()))
-        << QString("Network jitter: %1").arg(formatNetworkMs(model.audioPacketJitterMs()))
-        << QString("Audio gap: %1 (max %2)")
-               .arg(formatNetworkMs(model.audioPacketGapMs()),
-                    formatNetworkMs(model.audioPacketGapMaxMs()))
-        << QString("Total sequence gaps: %1")
-               .arg(formatNetworkSeqErrors(model.packetDropCount(), model.packetTotalCount()))
-        << QString("Audio: %1").arg(formatCategorySeqErrors(audioStats))
-        << QString("FFT: %1").arg(formatCategorySeqErrors(fftStats))
-        << QString("Waterfall: %1").arg(formatCategorySeqErrors(waterfallStats))
-        << QString("Meters: %1").arg(formatCategorySeqErrors(meterStats))
-        << QString("DAX: %1").arg(formatCategorySeqErrors(daxStats))
-        << QString("UDP RX bytes: %1").arg(QLocale().formattedDataSize(model.rxBytes()))
-        << QString("UDP TX bytes: %1").arg(QLocale().formattedDataSize(model.txBytes()))
-        << "Double-click for full diagnostics";
-    return lines.join('\n');
+    const QString quality = model.networkQuality();
+    QString html = QStringLiteral(
+        "<html><body>"
+        "<table width='%1' cellspacing='0' cellpadding='3'>"
+        "<tr>"
+        "<td colspan='2'>"
+        "<span style='font-size:10pt; font-weight:600; color:#c8d8e8;'>"
+        "Network diagnostics"
+        "</span>&nbsp;&nbsp;"
+        "<span style='color:%2;'>&#9679; %3</span>"
+        "</td>"
+        "</tr>")
+        .arg(kNetworkTooltipWidthPx)
+        .arg(networkQualityColor(quality), quality.toHtmlEscaped());
+
+    if (adaptiveFpsCap > 0) {
+        const QString throttleStatus = throttleRestorePending
+            ? QStringLiteral("Adaptive throttle: %1 fps cap · restoring shortly")
+                  .arg(adaptiveFpsCap)
+            : QStringLiteral("Adaptive throttle: %1 fps cap").arg(adaptiveFpsCap);
+        html += QStringLiteral(
+            "<tr><td colspan='2' style='color:#ffc000;'>%1</td></tr>")
+                    .arg(throttleStatus.toHtmlEscaped());
+    }
+
+    html += networkTooltipSection(QStringLiteral("LINK TIMING"));
+    html += networkTooltipRow(QStringLiteral("Current RTT"),
+                              formatNetworkMs(model.lastPingRtt()));
+    html += networkTooltipRow(QStringLiteral("Session maximum"),
+                              formatNetworkMs(model.maxPingRtt()));
+    html += networkTooltipRow(QStringLiteral("Network jitter"),
+                              formatNetworkMs(model.audioPacketJitterMs()));
+    html += networkTooltipRow(
+        QStringLiteral("Audio gap"),
+        QStringLiteral("%1 · max %2")
+            .arg(formatNetworkMs(model.audioPacketGapMs()),
+                 formatNetworkMs(model.audioPacketGapMaxMs())));
+
+    html += networkTooltipSection(QStringLiteral("PACKET INTEGRITY"));
+    html += networkTooltipRow(
+        QStringLiteral("Recent loss (%1 s)").arg(model.packetLossWindowSeconds()),
+        formatNetworkSeqErrors(model.packetLossWindowDrops(),
+                               model.packetLossWindowPackets()));
+    html += networkTooltipRow(
+        QStringLiteral("Session sequence gaps"),
+        formatNetworkSeqErrors(model.packetDropCount(), model.packetTotalCount()));
+
+    html += networkTooltipSection(QStringLiteral("STREAM SEQUENCE GAPS"));
+    html += networkTooltipRow(QStringLiteral("Audio"), formatCategorySeqErrors(audioStats));
+    html += networkTooltipRow(QStringLiteral("FFT"), formatCategorySeqErrors(fftStats));
+    html += networkTooltipRow(QStringLiteral("Waterfall"),
+                              formatCategorySeqErrors(waterfallStats));
+    html += networkTooltipRow(QStringLiteral("Meters"), formatCategorySeqErrors(meterStats));
+    html += networkTooltipRow(QStringLiteral("DAX"), formatCategorySeqErrors(daxStats));
+
+    html += networkTooltipSection(QStringLiteral("UDP TRAFFIC"));
+    html += networkTooltipRow(QStringLiteral("Received"),
+                              QLocale().formattedDataSize(model.rxBytes()));
+    html += networkTooltipRow(QStringLiteral("Sent"),
+                              QLocale().formattedDataSize(model.txBytes()));
+    html += QStringLiteral(
+        "<tr>"
+        "<td colspan='2' style='color:#8aa8c0; padding-top:7px;'>"
+        "Double-click to open full diagnostics"
+        "</td>"
+        "</tr>"
+        "</table></body></html>");
+    return html;
 }
 
 // ─── TNF tooltip ─────────────────────────────────────────────────────────────

--- a/src/gui/MainWindowHelpers.h
+++ b/src/gui/MainWindowHelpers.h
@@ -48,7 +48,9 @@ bool macDaxDriverInstalled();
 
 QString formatNetworkMs(int ms);
 QString formatNetworkSeqErrors(int errors, int packets);
-QString buildNetworkTooltip(const RadioModel& model);
+QString buildNetworkTooltip(const RadioModel& model,
+                            int adaptiveFpsCap,
+                            bool throttleRestorePending);
 
 // ─── TNF tooltip ─────────────────────────────────────────────────────────────
 

--- a/src/gui/MainWindowHelpers.h
+++ b/src/gui/MainWindowHelpers.h
@@ -48,6 +48,10 @@ bool macDaxDriverInstalled();
 
 QString formatNetworkMs(int ms);
 QString formatNetworkSeqErrors(int errors, int packets);
+// Single source of truth for network quality-level colors, shared by the
+// footer status label and the diagnostics tooltip so they never diverge.
+// "Off"/unknown maps to a neutral grey (disconnected is not a "good" state).
+QString networkQualityColor(const QString& quality);
 QString buildNetworkTooltip(const RadioModel& model,
                             int adaptiveFpsCap,
                             bool throttleRestorePending);

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -531,7 +531,9 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event)
         QToolTip::hideText();
     }
     if (obj == m_networkLabel && event->type() == QEvent::ToolTip) {
-        const QString tooltip = buildNetworkTooltip(m_radioModel);
+        const QString tooltip = buildNetworkTooltip(m_radioModel,
+                                                     m_adaptiveFpsCap,
+                                                     m_radioModel.pendingThrottleLift());
         m_networkLabel->setToolTip(tooltip);
         auto* helpEvent = static_cast<QHelpEvent*>(event);
         QToolTip::showText(helpEvent->globalPos(), tooltip, m_networkLabel);


### PR DESCRIPTION
## Summary

Reorganizes the status-bar Network diagnostics tooltip into clearly labeled sections with aligned metric/value columns, integrates adaptive-throttle status into the live refresh path, and adds an accessible identity for the Network status control. The tooltip uses a fixed 300 px content width so changing telemetry values no longer make it resize horizontally; unusually long values wrap within their column instead.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The updated tooltip was rendered through the native automation bridge, captured at its normal size, and stress-tested with nine-digit packet counters. Both cases remained exactly 308 px wide including the Qt tooltip frame.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable — not applicable; this changes presentation only and does not alter radio or protocol behavior
- [ ] Existing tests pass (CI) — pending CI
- [x] Reproduction steps documented if user-reported bug
  - Hover over the Network status while its telemetry values update and observe that the previous tooltip changes width.
  - With this change, render the normal tooltip and a stress case containing nine-digit packet counters.
  - Confirm both render at 308 px wide; oversized values wrap instead of expanding the tooltip.
  - `python3 tools/check_a11y.py src/gui/MainWindow.cpp src/gui/MainWindowHelpers.cpp src/gui/MainWindowHelpers.h src/gui/MainWindow_Shortcuts.cpp` reports 0 findings.
  - `python3 tools/check_engine_boundary.py --strict` reports 0 blocking findings.
  - `git diff --check` passes.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter UI changed
- [x] Documentation updated if user-visible behavior changed — no documentation update required; no documented setting or workflow changed
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
