### PR TITLE
feat(asr): experimental context-carry + segment-overlap for Copy Assist

### DIFF
--- a/src/asr/AsrEngine.cpp
+++ b/src/asr/AsrEngine.cpp
@@ -151,7 +151,7 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         return;
     }
 
-    std::vector<std::vector<float>> segments =
+    std::vector<AsrSegmenter::ClosedSegment> segments =
         m_segmenter.feed(pcm16k.data(), static_cast<int>(pcm16k.size()));
     if (segments.empty()) {
         return;
@@ -165,9 +165,9 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         return;
     }
 
-    for (std::vector<float>& seg : segments) {
+    for (AsrSegmenter::ClosedSegment& seg : segments) {
         QString error;
-        const AsrTranscript result = m_backend->transcribe(seg, &error);
+        const AsrTranscript result = m_backend->transcribe(seg.samples, seg.overlapMs, &error);
         if (!error.isEmpty()) {
             emit errorOccurred(error);
             continue;
@@ -179,7 +179,7 @@ void AsrWorker::processAudio(const QVector<float>& monoSamples, int sampleRate)
         int speaker = -1;
         if (m_embedder) {
             speaker = m_clusterer.assign(
-                m_embedder->embed(seg.data(), static_cast<int>(seg.size())));
+                m_embedder->embed(seg.samples.data(), static_cast<int>(seg.samples.size())));
         }
         emit segmentText(result.text, result.confidence, speaker);
     }
@@ -206,6 +206,18 @@ void AsrWorker::setHangoverMs(int ms)
 void AsrWorker::setSpeakerThreshold(float t)
 {
     m_clusterer.setThreshold(t);
+}
+
+void AsrWorker::setOverlapMs(int ms)
+{
+    m_segmenter.setOverlapMs(ms);
+}
+
+void AsrWorker::setContextCarryEnabled(bool on)
+{
+    if (m_backend) {
+        m_backend->setContextCarryEnabled(on);
+    }
 }
 
 void AsrWorker::reset()
@@ -249,6 +261,8 @@ void AsrEngine::startThread(AsrBackendFactory factory, const AsrSegmenter::Confi
     connect(this, &AsrEngine::requestSetSpeechRms, m_worker, &AsrWorker::setSpeechRms);
     connect(this, &AsrEngine::requestSetHangoverMs, m_worker, &AsrWorker::setHangoverMs);
     connect(this, &AsrEngine::requestSetSpeakerThreshold, m_worker, &AsrWorker::setSpeakerThreshold);
+    connect(this, &AsrEngine::requestSetOverlapMs, m_worker, &AsrWorker::setOverlapMs);
+    connect(this, &AsrEngine::requestSetContextCarryEnabled, m_worker, &AsrWorker::setContextCarryEnabled);
     connect(this, &AsrEngine::requestReset, m_worker, &AsrWorker::reset);
 
     // Worker -> engine (queued back to the main thread).
@@ -358,6 +372,16 @@ void AsrEngine::setSilenceDurationMs(int ms)
 void AsrEngine::setSpeakerThreshold(float threshold)
 {
     emit requestSetSpeakerThreshold(threshold);
+}
+
+void AsrEngine::setOverlapMs(int ms)
+{
+    emit requestSetOverlapMs(ms);
+}
+
+void AsrEngine::setContextCarryEnabled(bool on)
+{
+    emit requestSetContextCarryEnabled(on);
 }
 
 void AsrEngine::reset()

--- a/src/asr/AsrEngine.h
+++ b/src/asr/AsrEngine.h
@@ -52,6 +52,11 @@ public slots:
     void setSpeechRms(float rms);
     void setHangoverMs(int ms);
     void setSpeakerThreshold(float t);
+    // Experimental (RFC #4333 follow-up), see AsrSegmenter::Config::overlapMs
+    // and IAsrBackend::setContextCarryEnabled. Not yet user-exposed — for
+    // side-by-side comparison while tuning.
+    void setOverlapMs(int ms);
+    void setContextCarryEnabled(bool on);
     void reset();
 
 signals:
@@ -121,6 +126,15 @@ public:
     //  - speaker threshold: cosine match threshold for A/B/C clustering (0..1)
     void setSpeakerThreshold(float threshold);
 
+    // Experimental (RFC #4333 follow-up), applied live, no engine rebuild:
+    //  - segment overlap: ms of trailing audio carried across a force-closed
+    //    segment boundary, to recover a word split by the cut (0 = disabled)
+    //  - context carry: condition each decode on the backend's own previous
+    //    output, for continuity across segment boundaries (off = independent
+    //    decodes, the historical default)
+    void setOverlapMs(int ms);
+    void setContextCarryEnabled(bool on);
+
     void reset();
 
 signals:
@@ -140,6 +154,8 @@ signals:
     void requestSetSpeechRms(float rms);
     void requestSetHangoverMs(int ms);
     void requestSetSpeakerThreshold(float threshold);
+    void requestSetOverlapMs(int ms);
+    void requestSetContextCarryEnabled(bool on);
     void requestReset();
 
 private:

--- a/src/asr/AsrSegmenter.cpp
+++ b/src/asr/AsrSegmenter.cpp
@@ -31,6 +31,7 @@ void AsrSegmenter::reset()
     m_inSpeech = false;
     m_trailingSilence = 0;
     m_speechSamples = 0;
+    m_pendingOverlapMs = 0;
     if (m_vad != nullptr) {
         m_vad->reset();
     }
@@ -57,22 +58,55 @@ void AsrSegmenter::setHangoverMs(int ms)
     m_hangoverSamples = framesToSamples(ms);
 }
 
-void AsrSegmenter::closeSegment(std::vector<std::vector<float>>& out)
+void AsrSegmenter::closeSegment(std::vector<ClosedSegment>& out, bool forceCap)
 {
     // Gate on speech content, not total length: the segment also carries the
     // hangover silence, which must not count toward the minimum-speech floor.
-    if (m_speechSamples >= m_minSpeechSamples) {
-        out.push_back(std::move(m_segment));
+    const bool qualifies = m_speechSamples >= m_minSpeechSamples;
+
+    // Continue the same utterance across this close only when: it's the
+    // maxSegmentMs cap firing (speech still ongoing, not real silence),
+    // overlap is configured, and the segment closing now actually qualifies
+    // (an unqualified segment's audio is about to be discarded, not emitted —
+    // nothing meaningful to carry forward from it).
+    const bool continueUtterance = forceCap && m_config.overlapMs > 0 && qualifies;
+
+    // Snapshot the trailing window BEFORE moving m_segment out below.
+    std::vector<float> carry;
+    if (continueUtterance) {
+        const int overlapSamples =
+            std::min(framesToSamples(m_config.overlapMs), static_cast<int>(m_segment.size()));
+        if (overlapSamples > 0) {
+            carry.assign(m_segment.end() - overlapSamples, m_segment.end());
+        }
     }
+
+    if (qualifies) {
+        ClosedSegment cs;
+        cs.samples = std::move(m_segment);
+        cs.overlapMs = m_pendingOverlapMs; // set if THIS segment itself started with carried audio
+        out.push_back(std::move(cs));
+    }
+
     m_segment.clear();
-    m_inSpeech = false;
     m_trailingSilence = 0;
     m_speechSamples = 0;
+    m_pendingOverlapMs = 0;
+
+    if (!carry.empty()) {
+        // Still mid-utterance: seed the next segment with the carried audio
+        // instead of starting from silence. m_inSpeech stays true.
+        m_speechSamples = static_cast<int>(carry.size());
+        m_pendingOverlapMs = m_config.overlapMs;
+        m_segment = std::move(carry);
+    } else {
+        m_inSpeech = false;
+    }
 }
 
-std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int count)
+std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::feed(const float* samples, int count)
 {
-    std::vector<std::vector<float>> out;
+    std::vector<ClosedSegment> out;
 
     for (int i = 0; i < count; ++i) {
         m_frame.push_back(samples[i]);
@@ -108,14 +142,14 @@ std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int cou
             m_segment.insert(m_segment.end(), m_frame.begin(), m_frame.end());
             m_trailingSilence += static_cast<int>(m_frame.size());
             if (m_trailingSilence >= m_hangoverSamples) {
-                closeSegment(out);
+                closeSegment(out, /*forceCap=*/false);
             }
         }
         // else: silence outside speech — ignored.
 
         // Hard cap on a single utterance.
         if (m_inSpeech && static_cast<int>(m_segment.size()) >= m_maxSegmentSamples) {
-            closeSegment(out);
+            closeSegment(out, /*forceCap=*/true);
         }
 
         m_frame.clear();
@@ -124,16 +158,18 @@ std::vector<std::vector<float>> AsrSegmenter::feed(const float* samples, int cou
     return out;
 }
 
-std::vector<std::vector<float>> AsrSegmenter::flush()
+std::vector<AsrSegmenter::ClosedSegment> AsrSegmenter::flush()
 {
-    std::vector<std::vector<float>> out;
+    std::vector<ClosedSegment> out;
     // Fold any partial frame into the segment before closing.
     if (m_inSpeech && !m_frame.empty()) {
         m_segment.insert(m_segment.end(), m_frame.begin(), m_frame.end());
     }
     m_frame.clear();
     if (m_inSpeech) {
-        closeSegment(out);
+        // End of stream: never a candidate to continue via overlap (there's no
+        // next segment to carry into).
+        closeSegment(out, /*forceCap=*/false);
     }
     return out;
 }

--- a/src/asr/AsrSegmenter.h
+++ b/src/asr/AsrSegmenter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -36,18 +37,36 @@ public:
         // labeling (A/B/C…). Empty = no labeling. Also worker-consumed.
         std::string speakerModelPath;
         float speakerThreshold = 0.50f; // cosine threshold for the same speaker
+        // Experimental segment overlap (0 = disabled). When a segment is force-
+        // closed by maxSegmentMs (speech still ongoing, not a real silence gap),
+        // carry this many ms of trailing audio forward as the start of the next
+        // segment instead of dropping it — recovers a word split at the cut. Never
+        // applied on a hangover-based close, since speech had already stopped
+        // there (nothing to recover).
+        int overlapMs = 0;
+    };
+
+    // One closed utterance. `overlapMs` is the leading portion of `samples` (in
+    // ms) that duplicates the tail of the PREVIOUS closed segment — set only
+    // when the segmenter's overlap feature carried audio across a force-close;
+    // 0 for a normal (non-overlapping) segment. The backend uses this to avoid
+    // emitting the duplicated words/phrase twice.
+    struct ClosedSegment {
+        std::vector<float> samples;
+        int overlapMs = 0;
     };
 
     AsrSegmenter() : AsrSegmenter(Config{}) {}
     explicit AsrSegmenter(const Config& config);
 
     // Feed mono float samples in [-1, 1]. Returns any utterances that closed as
-    // a result of this input (each a contiguous sample buffer). Usually empty.
-    std::vector<std::vector<float>> feed(const float* samples, int count);
+    // a result of this input. Usually empty.
+    std::vector<ClosedSegment> feed(const float* samples, int count);
 
     // Close any in-progress utterance (end of stream / mode change). Returns it
-    // if it qualifies as speech, otherwise empty.
-    std::vector<std::vector<float>> flush();
+    // if it qualifies as speech, otherwise empty. Never carries overlap forward
+    // (there's no "next segment" at end of stream).
+    std::vector<ClosedSegment> flush();
 
     // Discard all buffered state without emitting.
     void reset();
@@ -66,15 +85,21 @@ public:
     void setMaxSegmentMs(int ms);
     void setSpeechRms(float rms);
     void setHangoverMs(int ms);
+    // Experimental: see Config::overlapMs. Takes effect on the next force-close.
+    void setOverlapMs(int ms) { m_config.overlapMs = std::max(0, ms); }
     int maxSegmentMs() const { return m_config.maxSegmentMs; }
     float speechRms() const { return m_config.speechRms; }
     int hangoverMs() const { return m_config.hangoverMs; }
+    int overlapMs() const { return m_config.overlapMs; }
 
     bool inSpeech() const { return m_inSpeech; }
 
 private:
     int framesToSamples(int ms) const;
-    void closeSegment(std::vector<std::vector<float>>& out);
+    // forceCap: true when this close is the maxSegmentMs cap firing mid-speech
+    // (a candidate to continue via overlap), false for a real hangover/end-of-
+    // stream close (utterance actually ended; never carries overlap forward).
+    void closeSegment(std::vector<ClosedSegment>& out, bool forceCap);
 
     Config m_config;
     int m_frameSamples = 160;
@@ -88,6 +113,7 @@ private:
     bool m_inSpeech = false;
     int m_trailingSilence = 0;      // samples of silence since last speech frame
     int m_speechSamples = 0;        // speech-only samples (excludes hangover), gates minSpeech
+    int m_pendingOverlapMs = 0;     // overlap (ms) already carried into the front of m_segment
 };
 
 } // namespace AetherSDR

--- a/src/asr/IAsrBackend.h
+++ b/src/asr/IAsrBackend.h
@@ -35,10 +35,27 @@ public:
     // Transcribe one utterance of 16 kHz mono float samples in [-1, 1]. Returns
     // the recognized text + confidence (text empty for non-speech). Sets *error
     // on failure.
-    virtual AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) = 0;
+    //
+    // overlapMs: leading portion (in ms) of pcm16k that duplicates the tail end
+    // of the PREVIOUS call's audio — the segmenter's segment-overlap feature
+    // (experimental) carries this much trailing audio forward across a
+    // force-closed segment so a word split at the boundary isn't lost. 0 means
+    // no overlap (the common case). Backends that can identify which part of
+    // their output corresponds to that leading audio should omit it from the
+    // returned text so it isn't emitted twice; backends that can't (most
+    // non-whisper backends) may just ignore this and pass the whole segment
+    // through, at the cost of a duplicated word/phrase at re-joined boundaries.
+    virtual AsrTranscript transcribe(const std::vector<float>& pcm16k, int overlapMs,
+                                      QString* error) = 0;
 
     // Release the loaded model. Called before destruction; idempotent.
     virtual void unload() = 0;
+
+    // Experimental: when true, condition each decode on the text the backend
+    // itself produced last call (whisper.cpp's no_context=false), for
+    // continuity across segment boundaries. Default is off (independent decodes)
+    // — the historical behavior. No-op for backends that don't support it.
+    virtual void setContextCarryEnabled(bool) {}
 };
 
 } // namespace AetherSDR

--- a/src/asr/RemoteAsrBackend.cpp
+++ b/src/asr/RemoteAsrBackend.cpp
@@ -75,8 +75,10 @@ QByteArray RemoteAsrBackend::encodeWav16(const std::vector<float>& pcm16k, int s
     return wav;
 }
 
-AsrTranscript RemoteAsrBackend::transcribe(const std::vector<float>& pcm16k, QString* error)
+AsrTranscript RemoteAsrBackend::transcribe(const std::vector<float>& pcm16k, int overlapMs,
+                                            QString* error)
 {
+    (void)overlapMs; // not applied here yet — see header comment
     if (!m_loaded || m_nam == nullptr) {
         if (error != nullptr) {
             *error = QStringLiteral("Remote backend not loaded.");

--- a/src/asr/RemoteAsrBackend.h
+++ b/src/asr/RemoteAsrBackend.h
@@ -39,7 +39,11 @@ public:
     // config). Returns false only if no endpoint URL is configured.
     bool load(const QString& modelPath, QString* error) override;
     bool isLoaded() const override { return m_loaded; }
-    AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) override;
+    // overlapMs (see IAsrBackend): ignored — remote servers speak the generic
+    // OpenAI transcription API, which has no token-timestamp contract we can
+    // rely on here. An overlap-carried segment will emit its duplicated
+    // leading words again — a known limitation, not silently mishandled.
+    AsrTranscript transcribe(const std::vector<float>& pcm16k, int overlapMs, QString* error) override;
     void unload() override { m_loaded = false; }
 
     // Encode 16 kHz mono float samples as a 16-bit PCM WAV byte buffer.

--- a/src/asr/SherpaOnnxBackend.cpp
+++ b/src/asr/SherpaOnnxBackend.cpp
@@ -124,8 +124,10 @@ bool SherpaOnnxBackend::isLoaded() const
 #endif
 }
 
-AsrTranscript SherpaOnnxBackend::transcribe(const std::vector<float>& pcm16k, QString* error)
+AsrTranscript SherpaOnnxBackend::transcribe(const std::vector<float>& pcm16k, int overlapMs,
+                                             QString* error)
 {
+    (void)overlapMs; // not applied here yet — see header comment
     AsrTranscript out;
 #ifdef HAVE_SHERPA
     if (m_impl->recognizer == nullptr) {

--- a/src/asr/SherpaOnnxBackend.h
+++ b/src/asr/SherpaOnnxBackend.h
@@ -26,7 +26,12 @@ public:
     // modelPath is a directory containing a sherpa-onnx model bundle.
     bool load(const QString& modelPath, QString* error) override;
     bool isLoaded() const override;
-    AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) override;
+    // overlapMs (see IAsrBackend): ignored here. sherpa-onnx's offline
+    // recognizer has no per-token timestamp path wired up in this backend, so
+    // an overlap-carried segment will emit its duplicated leading words again
+    // — a known limitation, not silently mishandled. The experimental overlap
+    // feature is really a whisper-path thing for now.
+    AsrTranscript transcribe(const std::vector<float>& pcm16k, int overlapMs, QString* error) override;
     void unload() override;
 
 private:

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -24,6 +24,13 @@ int chooseThreadCount()
     }
     return std::clamp(hw, 1, 4);
 }
+
+// Below this confidence, don't let the segment's tokens seed the next decode's
+// context — a garbled/low-confidence result is more likely to compound into a
+// worse one downstream (a known whisper hallucination-propagation failure
+// mode) than to help continuity. Not exposed/tuned yet; revisit if the
+// context-carry toggle turns out to need it adjustable too.
+constexpr float kContextCarryMinConfidence = 0.5f;
 } // namespace
 
 WhisperAsrBackend::WhisperAsrBackend()
@@ -75,7 +82,8 @@ bool WhisperAsrBackend::load(const QString& modelPath, QString* error)
     return true;
 }
 
-AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QString* error)
+AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, int overlapMs,
+                                             QString* error)
 {
     if (m_ctx == nullptr) {
         if (error != nullptr) {
@@ -87,12 +95,24 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
         return {};
     }
 
+    // Context carry (experimental): only actually condition on the previous
+    // call's tokens when the feature is on AND that previous result was
+    // confident enough to trust as a prompt. whisper.cpp stores the prompt
+    // itself (in m_ctx's internal state) between calls; no_context just gates
+    // whether it's used for this one.
+    const bool carryContext =
+        m_contextCarryEnabled && m_hadPreviousSegment && m_lastConfidence >= kContextCarryMinConfidence;
+
     whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
     wparams.n_threads = m_threads;
     wparams.translate = false;
-    wparams.no_context = true;    // each over is independent
+    wparams.no_context = !carryContext;
     wparams.single_segment = true; // one utterance -> one segment
     wparams.no_timestamps = true;
+    // Per-token timestamps (DTW alignment) cost extra compute — only pay for
+    // them when this segment actually carries overlap audio (experimental) to
+    // trim by. The common case (overlapMs == 0) skips this entirely.
+    wparams.token_timestamps = overlapMs > 0;
     wparams.print_progress = false;
     wparams.print_realtime = false;
     wparams.print_timestamps = false;
@@ -110,24 +130,36 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
         return {};
     }
 
-    // Confidence = mean probability over the real (non-special) tokens. Special
-    // tokens (timestamps, <eot>, etc.) have ids >= the end-of-text token and are
-    // excluded so punctuation/formatting doesn't skew the score.
+    // Confidence = mean probability over the real (non-special), non-overlap
+    // tokens. Special tokens (timestamps, <eot>, etc.) have ids >= the
+    // end-of-text token and are excluded so punctuation/formatting doesn't
+    // skew the score. Text is rebuilt token-by-token (rather than via
+    // whisper_full_get_segment_text) so a segment carrying overlap audio can
+    // skip whatever tokens fall inside the duplicated leading window —
+    // whisper_token_data.t0/t1 are in centiseconds (10 ms units), relative to
+    // the start of THIS call's audio buffer, which lines up directly with
+    // AsrSegmenter's overlapMs (leading ms of pcm16k that repeats the tail of
+    // the previous segment).
     const whisper_token specialFloor = whisper_token_eot(m_ctx);
+    const int64_t overlapCentisec = overlapMs > 0 ? overlapMs / 10 : -1;
 
     QString text;
     double probSum = 0.0;
     int probCount = 0;
     const int segments = whisper_full_n_segments(m_ctx);
     for (int i = 0; i < segments; ++i) {
-        const char* seg = whisper_full_get_segment_text(m_ctx, i);
-        if (seg != nullptr) {
-            text += QString::fromUtf8(seg);
-        }
         const int nTokens = whisper_full_n_tokens(m_ctx, i);
         for (int t = 0; t < nTokens; ++t) {
             if (whisper_full_get_token_id(m_ctx, i, t) >= specialFloor) {
                 continue;
+            }
+            if (overlapCentisec >= 0
+                && whisper_full_get_token_data(m_ctx, i, t).t0 < overlapCentisec) {
+                continue; // inside the duplicated overlap window — already emitted last call
+            }
+            const char* tokText = whisper_full_get_token_text(m_ctx, i, t);
+            if (tokText != nullptr) {
+                text += QString::fromUtf8(tokText);
             }
             probSum += whisper_full_get_token_p(m_ctx, i, t);
             ++probCount;
@@ -137,7 +169,19 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     AsrTranscript result;
     result.text = text.trimmed();
     result.confidence = probCount > 0 ? static_cast<float>(probSum / probCount) : 0.0f;
+
+    m_hadPreviousSegment = !result.text.isEmpty();
+    m_lastConfidence = result.confidence;
+
     return result;
+}
+
+void WhisperAsrBackend::setContextCarryEnabled(bool on)
+{
+    m_contextCarryEnabled = on;
+    if (!on) {
+        m_hadPreviousSegment = false; // next call starts clean when re-enabled
+    }
 }
 
 void WhisperAsrBackend::unload()
@@ -146,6 +190,10 @@ void WhisperAsrBackend::unload()
         whisper_free(m_ctx);
         m_ctx = nullptr;
     }
+    // A new/different model has no relationship to whatever text the old one
+    // produced — don't carry a stale prompt into its first decode.
+    m_hadPreviousSegment = false;
+    m_lastConfidence = 0.0f;
 }
 
 std::function<std::unique_ptr<IAsrBackend>()> whisperAsrBackendFactory(const QString& language,

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -25,8 +25,12 @@ public:
 
     bool load(const QString& modelPath, QString* error) override;
     bool isLoaded() const override { return m_ctx != nullptr; }
-    AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) override;
+    AsrTranscript transcribe(const std::vector<float>& pcm16k, int overlapMs, QString* error) override;
     void unload() override;
+    // Experimental (RFC #4333 follow-up): see IAsrBackend::setContextCarryEnabled.
+    // Gated internally by the previous call's confidence (see .cpp) so a
+    // garbled decode doesn't poison the next one's prompt.
+    void setContextCarryEnabled(bool on) override;
 
     void setLanguage(const QString& language) { m_language = language; }
 
@@ -35,6 +39,9 @@ private:
     QString m_language;
     int m_threads = 0;
     int m_gpuDevice = 0;
+    bool m_contextCarryEnabled = false;
+    bool m_hadPreviousSegment = false; // false right after load()/a reset — nothing to carry yet
+    float m_lastConfidence = 0.0f;
 };
 
 // A selectable GPU: `index` is the value to pass as gpuDevice (its position among

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -308,6 +308,36 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     connect(m_settings, &CopyAssistSettingsDialog::browseSpeakerModelRequested, this,
             [this] { promptSpeakerModel(); });
 
+    // Experimental (RFC #4333 follow-up), both live — no engine rebuild needed.
+    m_settings->setContextCarryEnabled(
+        AppSettings::instance().value(QStringLiteral("AsrContextCarryEnabled"), QStringLiteral("False"))
+            .toString() == QStringLiteral("True"));
+    m_settings->setOverlapEnabled(
+        AppSettings::instance().value(QStringLiteral("AsrOverlapEnabled"), QStringLiteral("False"))
+            .toString() == QStringLiteral("True"));
+    m_settings->setOverlapMs(
+        AppSettings::instance().value(QStringLiteral("AsrOverlapMs"), QStringLiteral("500"))
+            .toString().toInt());
+    connect(m_settings, &CopyAssistSettingsDialog::contextCarryToggled, this, [this](bool on) {
+        auto& st = AppSettings::instance();
+        st.setValue(QStringLiteral("AsrContextCarryEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
+        st.save();
+        m_asr->setContextCarryEnabled(on);
+    });
+    connect(m_settings, &CopyAssistSettingsDialog::overlapToggled, this, [this](bool on) {
+        auto& st = AppSettings::instance();
+        st.setValue(QStringLiteral("AsrOverlapEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
+        st.save();
+        // "Off" means 0ms to the segmenter (disabled); "on" resumes the configured length.
+        m_asr->setOverlapMs(on ? m_settings->overlapMs() : 0);
+    });
+    connect(m_settings, &CopyAssistSettingsDialog::overlapMsChanged, this, [this](int ms) {
+        saveInt("AsrOverlapMs", ms);
+        if (m_settings->overlapEnabled()) {
+            m_asr->setOverlapMs(ms);
+        }
+    });
+
     // Model download → engine load (the handlers read m_asr at call time, so they
     // survive an engine rebuild on backend switch).
     connect(m_models, &AsrModelManager::progress, this, [this](qint64 got, qint64 total) {
@@ -469,6 +499,20 @@ void CopyAssistController::applyTuning()
     m_asr->setSpeechRms(sensitivityToRms(
         s.value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt()));
     m_asr->setSilenceDurationMs(s.value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
+
+    // Experimental (RFC #4333 follow-up) — a fresh engine (backend switch, model
+    // change) starts with these off/0 by default; re-apply the persisted state
+    // so they survive a rebuild, same as the tuning above.
+    const bool contextCarry =
+        s.value(QStringLiteral("AsrContextCarryEnabled"), QStringLiteral("False")).toString()
+        == QStringLiteral("True");
+    m_asr->setContextCarryEnabled(contextCarry);
+    const bool overlapOn =
+        s.value(QStringLiteral("AsrOverlapEnabled"), QStringLiteral("False")).toString()
+        == QStringLiteral("True");
+    m_asr->setOverlapMs(overlapOn
+        ? s.value(QStringLiteral("AsrOverlapMs"), QStringLiteral("500")).toString().toInt()
+        : 0);
 }
 
 void CopyAssistController::onEnableToggled(bool on)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -8,6 +8,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSlider>
+#include <QSpinBox>
 #include <QVBoxLayout>
 
 namespace AetherSDR {
@@ -149,6 +150,40 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     thrRow->addWidget(m_spkThresholdValue);
     form->addRow(tr("Match threshold:"), thrRow);
 
+    // Experimental (RFC #4333 follow-up): not a stable feature yet, grouped
+    // separately so it reads as "try this, not a normal setting." Both apply
+    // live (no engine rebuild) so the effect can be A/B'd on the fly.
+    auto* expLabel = new QLabel(tr("Experimental"), this);
+    expLabel->setStyleSheet(QStringLiteral("font-weight: bold; margin-top: 6px;"));
+    form->addRow(expLabel);
+
+    m_contextCarry = new QCheckBox(tr("Carry context across segments"), this);
+    m_contextCarry->setToolTip(tr("Condition each decode on the previous segment's own text, "
+                                  "for continuity across segment boundaries. Gated internally by "
+                                  "the previous segment's confidence, so a garbled decode doesn't "
+                                  "poison the next one."));
+    connect(m_contextCarry, &QCheckBox::toggled, this, &CopyAssistSettingsDialog::contextCarryToggled);
+    form->addRow(m_contextCarry);
+
+    m_overlapEnabled = new QCheckBox(tr("Overlap segments"), this);
+    m_overlapEnabled->setToolTip(tr("Carry trailing audio across a force-closed segment boundary "
+                                    "so a word split by the cut isn't lost. Only applies when a "
+                                    "segment is cut off by the length cap, not a real pause."));
+    connect(m_overlapEnabled, &QCheckBox::toggled, this, [this](bool on) {
+        m_overlapMs->setEnabled(on);
+        emit overlapToggled(on);
+    });
+    form->addRow(m_overlapEnabled);
+
+    m_overlapMs = new QSpinBox(this);
+    m_overlapMs->setRange(0, 5000);
+    m_overlapMs->setSingleStep(50);
+    m_overlapMs->setValue(500);
+    m_overlapMs->setSuffix(tr(" ms"));
+    m_overlapMs->setEnabled(false);
+    connect(m_overlapMs, &QSpinBox::valueChanged, this, &CopyAssistSettingsDialog::overlapMsChanged);
+    form->addRow(tr("Overlap length:"), m_overlapMs);
+
     root->addLayout(form);
     root->addStretch(1); // headroom for further options added here later
 }
@@ -274,6 +309,36 @@ void CopyAssistSettingsDialog::setSpeakerThreshold(int percent)
 int CopyAssistSettingsDialog::speakerThreshold() const
 {
     return m_spkThreshold->value();
+}
+
+void CopyAssistSettingsDialog::setContextCarryEnabled(bool on)
+{
+    m_contextCarry->setChecked(on);
+}
+
+bool CopyAssistSettingsDialog::contextCarryEnabled() const
+{
+    return m_contextCarry->isChecked();
+}
+
+void CopyAssistSettingsDialog::setOverlapEnabled(bool on)
+{
+    m_overlapEnabled->setChecked(on); // fires toggled → enables the spinbox + emits
+}
+
+bool CopyAssistSettingsDialog::overlapEnabled() const
+{
+    return m_overlapEnabled->isChecked();
+}
+
+void CopyAssistSettingsDialog::setOverlapMs(int ms)
+{
+    m_overlapMs->setValue(ms);
+}
+
+int CopyAssistSettingsDialog::overlapMs() const
+{
+    return m_overlapMs->value();
 }
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -9,6 +9,7 @@ class QLabel;
 class QLineEdit;
 class QPushButton;
 class QSlider;
+class QSpinBox;
 
 namespace AetherSDR {
 
@@ -61,6 +62,17 @@ public:
     void setSpeakerThreshold(int percent);
     int speakerThreshold() const;
 
+    // Experimental (RFC #4333 follow-up), not yet a stable/committed feature —
+    // deliberately grouped as "Experimental" in the UI rather than mixed in
+    // with the settings above. See AsrEngine::setContextCarryEnabled/
+    // setOverlapMs for what each one actually does.
+    void setContextCarryEnabled(bool on);
+    bool contextCarryEnabled() const;
+    void setOverlapEnabled(bool on);
+    bool overlapEnabled() const;
+    void setOverlapMs(int ms);
+    int overlapMs() const;
+
 signals:
     void tierChanged(const QString& tierId);
     void gpuChanged(int index);
@@ -71,6 +83,9 @@ signals:
     void labelSpeakersToggled(bool on);
     void browseSpeakerModelRequested();
     void speakerThresholdChanged(int percent);
+    void contextCarryToggled(bool on);
+    void overlapToggled(bool on);
+    void overlapMsChanged(int ms);
 
 private:
     QComboBox* m_tier = nullptr;
@@ -87,6 +102,9 @@ private:
     QPushButton* m_spkBrowse = nullptr;
     QSlider* m_spkThreshold = nullptr;
     QLabel* m_spkThresholdValue = nullptr;
+    QCheckBox* m_contextCarry = nullptr;
+    QCheckBox* m_overlapEnabled = nullptr;
+    QSpinBox* m_overlapMs = nullptr;
 };
 
 } // namespace AetherSDR

--- a/tests/asr_engine_test.cpp
+++ b/tests/asr_engine_test.cpp
@@ -47,7 +47,7 @@ public:
         return true;
     }
     bool isLoaded() const override { return m_loaded; }
-    AsrTranscript transcribe(const std::vector<float>& pcm, QString*) override
+    AsrTranscript transcribe(const std::vector<float>& pcm, int, QString*) override
     {
         if (pcm.empty()) {
             return {};
@@ -80,7 +80,7 @@ public:
         return true;
     }
     bool isLoaded() const override { return m_loaded; }
-    AsrTranscript transcribe(const std::vector<float>& pcm, QString*) override
+    AsrTranscript transcribe(const std::vector<float>& pcm, int, QString*) override
     {
         QThread::msleep(m_delayMs);
         if (pcm.empty()) {

--- a/tests/asr_remote_backend_test.cpp
+++ b/tests/asr_remote_backend_test.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
         expect(backend.load(QString(), &err), "load() succeeds with a configured URL");
 
         std::vector<float> pcm(1600, 0.25f); // 100 ms
-        const AsrTranscript result = backend.transcribe(pcm, &err);
+        const AsrTranscript result = backend.transcribe(pcm, /*overlapMs=*/0, &err);
         expect(err.isEmpty(), "transcribe reports no error");
         expect(result.text == QStringLiteral("hello world"), "parsed text from the endpoint");
         expect(std::abs(result.confidence - std::exp(-0.2f)) < 0.02f,

--- a/tests/asr_segmenter_test.cpp
+++ b/tests/asr_segmenter_test.cpp
@@ -45,11 +45,11 @@ void appendTone(std::vector<float>& buf, int ms, float amp = 0.3f, float freq = 
     }
 }
 
-int totalSamples(const std::vector<std::vector<float>>& segs)
+int totalSamples(const std::vector<AsrSegmenter::ClosedSegment>& segs)
 {
     int n = 0;
     for (const auto& s : segs) {
-        n += static_cast<int>(s.size());
+        n += static_cast<int>(s.samples.size());
     }
     return n;
 }
@@ -79,7 +79,7 @@ int main()
         auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
         expect(out.size() == 1, "one tone burst -> one segment");
         if (out.size() == 1) {
-            const int len = static_cast<int>(out[0].size());
+            const int len = static_cast<int>(out[0].samples.size());
             const int lo = 700 * kRate / 1000; // >= tone + most of hangover
             const int hi = 900 * kRate / 1000; // <= tone + hangover + slop
             expect(len >= lo && len <= hi, "segment length is tone + hangover");
@@ -131,6 +131,67 @@ int main()
         appendTone(audio, 1600); // continuous speech, no silence
         auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
         expect(out.size() >= 2, "setMaxSegmentMs force-closes a long over into segments");
+        if (out.size() >= 2) {
+            expect(out[0].overlapMs == 0, "first force-closed segment carries no overlap (nothing before it)");
+            expect(out[1].overlapMs == 0, "overlap defaults to 0 (disabled) — no carry without setOverlapMs");
+        }
+    }
+
+    // Experimental segment overlap: a force-close carries trailing audio into
+    // the next segment and marks how much of it is duplicate.
+    {
+        AsrSegmenter seg;
+        seg.setMaxSegmentMs(500);
+        seg.setOverlapMs(200);
+        std::vector<float> audio;
+        appendTone(audio, 1600); // continuous speech, no silence -> repeated force-closes
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        expect(out.size() >= 2, "overlap doesn't change segment count, just what's carried");
+        if (out.size() >= 2) {
+            expect(out[0].overlapMs == 0, "first segment still has no overlap (nothing precedes it)");
+            expect(out[1].overlapMs == 200, "second segment reports the configured overlap");
+            const int overlapSamples = 200 * kRate / 1000;
+            expect(static_cast<int>(out[1].samples.size()) > overlapSamples,
+                   "overlap-carrying segment holds more than just the carried tail");
+        }
+        expect(seg.inSpeech(), "still mid-utterance after a force-close continuation (no gap opened)");
+    }
+
+    // Overlap must NOT apply across a real hangover-close — that's a genuine
+    // pause, not a mid-word cut, so there's nothing to recover.
+    {
+        AsrSegmenter seg;
+        seg.setOverlapMs(300); // configured, but these utterances are well under maxSegmentMs
+        std::vector<float> audio;
+        appendSilence(audio, 100);
+        appendTone(audio, 400);
+        appendSilence(audio, 600); // real pause -> hangover closes it
+        appendTone(audio, 400);
+        appendSilence(audio, 400);
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        expect(out.size() == 2, "two separated tones still -> two segments with overlap configured");
+        if (out.size() == 2) {
+            expect(out[0].overlapMs == 0, "first utterance has no overlap");
+            expect(out[1].overlapMs == 0, "hangover-close (real silence) never carries overlap forward");
+        }
+    }
+
+    // A force-close continuation that ends via flush() (stream stops mid-word,
+    // no trailing silence) still reports the carried overlap correctly.
+    {
+        AsrSegmenter seg;
+        seg.setMaxSegmentMs(500);
+        seg.setOverlapMs(200);
+        std::vector<float> audio;
+        appendTone(audio, 600); // triggers one force-close, leaves ~100ms in progress
+        auto out = seg.feed(audio.data(), static_cast<int>(audio.size()));
+        expect(out.size() == 1, "one force-close from 600ms at a 500ms cap");
+        auto flushed = seg.flush();
+        expect(flushed.size() == 1, "flush closes the continued (post-overlap) utterance");
+        if (flushed.size() == 1) {
+            expect(flushed[0].overlapMs == 200,
+                   "flush-closed continuation still reports the carried overlap");
+        }
     }
 
     // Runtime setter: raising the RMS threshold makes a moderate tone read as

--- a/tests/asr_sherpa_backend_test.cpp
+++ b/tests/asr_sherpa_backend_test.cpp
@@ -54,7 +54,7 @@ int main()
     }
 
     const std::vector<float> pcm = readWav16(wav);
-    const AsrTranscript r = backend.transcribe(pcm, &err);
+    const AsrTranscript r = backend.transcribe(pcm, /*overlapMs=*/0, &err);
     std::printf("       text: \"%s\"\n", r.text.toUtf8().constData());
     expect(!r.text.isEmpty(), "transcription is non-empty");
     expect(r.confidence > 0.0f, "confidence is set");

--- a/tests/asr_whisper_backend_test.cpp
+++ b/tests/asr_whisper_backend_test.cpp
@@ -47,7 +47,7 @@ int main()
     std::vector<float> samples(raw.size() / sizeof(float));
     std::memcpy(samples.data(), raw.constData(), samples.size() * sizeof(float));
 
-    const AsrTranscript result = backend.transcribe(samples, &error);
+    const AsrTranscript result = backend.transcribe(samples, /*overlapMs=*/0, &error);
     if (!error.isEmpty()) {
         std::fprintf(stderr, "[FAIL] transcribe: %s\n", qPrintable(error));
         return 1;


### PR DESCRIPTION
## Summary

Two experimental, independently-toggleable Copy Assist transcription-quality options, both aimed at the same problem: whisper decodes each segment in complete isolation, so anything split across a segment boundary — or any cross-utterance continuity — is lost. Follow-up to RFC #4333 / the Copy Assist feature merged in #4338.

Both default **off**, apply **live** (no engine rebuild), and are grouped under a new **"Experimental"** heading in Copy Assist Settings so they read as "try this," not settled behavior. Not wired to any auto-enable — deliberately opt-in while their real-world value is evaluated.

> **Draft:** builds clean and unit-tested, but not yet validated on live on-air audio. Opening as a draft to park the work and gather feedback on approach.

## The two options

### 1. Carry context across segments
Conditions each whisper decode on the *text* it produced last time (`no_context = false`), for continuity across boundaries — the same mechanism whisper.cpp's own `stream.cpp` uses.

**Gated by confidence:** carry only happens when the previous segment's mean-token confidence was ≥ 0.5. On noisy SSB/QRM a garbled decode would otherwise become the "prompt" for the next segment and compound downstream (a known whisper hallucination-propagation failure mode); the gate stops that. Resets cleanly on disable and on model switch.

### 2. Overlap segments
Carries a tunable window of trailing audio (default 500 ms) across a **force-closed** segment boundary, so a word cut mid-utterance by the length cap appears complete in the next segment. Deliberately **not** applied on a hangover (real-silence) close — there's nothing to recover from an actual pause.

**Duplicate handling:** the carried audio would otherwise be transcribed twice. When a segment carries overlap, whisper's per-token timestamps are enabled and the text is rebuilt token-by-token, dropping any token whose start time falls inside the duplicated leading window. The DTW-timestamp cost is only paid when overlap is actually active (`overlapMs > 0`); the default path is unchanged.

Motivation for the tunable: a *short* `maxSegmentMs` is what makes Copy Assist near-real-time, but short segments mean more boundaries per minute and more chances to clip a word — so overlap is what makes short segments viable without shredding words. Exposing the length as a control makes that tradeoff observable.

## Interface changes

- `IAsrBackend::transcribe()` gains an `overlapMs` argument and a `setContextCarryEnabled(bool)` hook. `SherpaOnnxBackend` and `RemoteAsrBackend` accept and **ignore** `overlapMs` (documented — overlap dedup is whisper-only for now; those paths would double-emit the overlap, so overlap is a whisper-path feature until they grow token timestamps).
- `AsrSegmenter` now returns `ClosedSegment{samples, overlapMs}` instead of a bare sample buffer, and gained `Config::overlapMs` / `setOverlapMs()`.
- `AsrEngine`/`AsrWorker` gained `setOverlapMs` / `setContextCarryEnabled` passthroughs (same live, no-rebuild pattern as the existing VAD tunables); settings persist and re-apply after a backend/model switch.

## Testing

- **Unit:** 8 new `asr_segmenter_test` cases (overlap only on force-close, never on hangover-close, correct `overlapMs` reporting, flush-closed continuation) — 26/26 pass. `asr_engine_test` updated for the new signature — 14/14 pass.
- **Build:** full app + all ASR test targets build clean on macOS (Metal).
- **Not yet done:** live on-air A/B evaluation of transcription quality with each option on/off — the reason this is a draft.

Built and smoke tested on: MacBook Air M2
