### PR TITLE
feat(asr): Copy Assist transcription-language selector

### DIFF
--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -99,9 +99,14 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     wparams.print_special = false;
     wparams.suppress_blank = true;
 
+    // "auto" (or empty) → let whisper detect the language from the audio; any
+    // other value pins decoding to that language. whisper_full() treats a
+    // language of "auto" as detection on its own (see whisper.cpp), but set the
+    // flag explicitly too so the intent is unambiguous.
     const QByteArray langUtf8 = m_language.toUtf8();
-    wparams.language = langUtf8.isEmpty() ? "en" : langUtf8.constData();
-    wparams.detect_language = false;
+    const bool autoDetect = langUtf8.isEmpty() || langUtf8 == "auto";
+    wparams.language = autoDetect ? "auto" : langUtf8.constData();
+    wparams.detect_language = autoDetect;
 
     if (whisper_full(m_ctx, wparams, pcm16k.data(), static_cast<int>(pcm16k.size())) != 0) {
         if (error != nullptr) {
@@ -179,6 +184,40 @@ bool asrGpuAvailable()
 {
     // True when ggml has at least one GPU (discrete or integrated) device.
     return !asrGpuDevices().empty();
+}
+
+std::vector<AsrLanguage> asrWhisperLanguages()
+{
+    // Enumerate every language the vendored whisper build supports, straight
+    // from its own table (whisper_lang_str = ISO code, whisper_lang_str_full =
+    // English name), so this never drifts out of sync with the model. The
+    // multilingual checkpoints cover them all; the .en-only models ignore the
+    // setting and always decode English. Sorted by display name; the caller
+    // prepends "Auto-detect" (there's no such entry in whisper's table — a
+    // language of "auto" triggers detection in transcribe()).
+    std::vector<AsrLanguage> langs;
+    const int maxId = whisper_lang_max_id();
+    langs.reserve(static_cast<size_t>(maxId) + 1);
+    for (int id = 0; id <= maxId; ++id) {
+        const char* code = whisper_lang_str(id);
+        const char* full = whisper_lang_str_full(id);
+        if (code == nullptr || full == nullptr) {
+            continue;
+        }
+        AsrLanguage lang;
+        lang.code = QString::fromUtf8(code);
+        // whisper's full names are lowercase ("english"); title-case the first
+        // letter for display ("English") without pulling in a locale.
+        QString name = QString::fromUtf8(full);
+        if (!name.isEmpty()) {
+            name[0] = name[0].toUpper();
+        }
+        lang.name = name;
+        langs.push_back(std::move(lang));
+    }
+    std::sort(langs.begin(), langs.end(),
+              [](const AsrLanguage& a, const AsrLanguage& b) { return a.name < b.name; });
+    return langs;
 }
 
 } // namespace AetherSDR

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -206,11 +206,18 @@ std::vector<AsrLanguage> asrWhisperLanguages()
         }
         AsrLanguage lang;
         lang.code = QString::fromUtf8(code);
-        // whisper's full names are lowercase ("english"); title-case the first
-        // letter for display ("English") without pulling in a locale.
+        // whisper's full names are lowercase ("english", "haitian creole");
+        // title-case each word for display ("Haitian Creole") without pulling in
+        // a locale.
         QString name = QString::fromUtf8(full);
-        if (!name.isEmpty()) {
-            name[0] = name[0].toUpper();
+        bool startOfWord = true;
+        for (QChar& ch : name) {
+            if (ch.isSpace()) {
+                startOfWord = true;
+            } else if (startOfWord && ch.isLetter()) {
+                ch = ch.toUpper();
+                startOfWord = false;
+            }
         }
         lang.name = name;
         langs.push_back(std::move(lang));

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -99,14 +99,16 @@ AsrTranscript WhisperAsrBackend::transcribe(const std::vector<float>& pcm16k, QS
     wparams.print_special = false;
     wparams.suppress_blank = true;
 
-    // "auto" (or empty) → let whisper detect the language from the audio; any
-    // other value pins decoding to that language. whisper_full() treats a
-    // language of "auto" as detection on its own (see whisper.cpp), but set the
-    // flag explicitly too so the intent is unambiguous.
+    // "auto" (or empty) → let whisper detect the language from the audio and
+    // then transcribe it; any other value pins decoding to that language.
+    // whisper_full() treats a language of "auto" as detect-then-transcribe on
+    // its own. detect_language MUST stay false: when it is true whisper detects
+    // the language and returns early WITHOUT transcribing (whisper.cpp:
+    // `if (params.detect_language) return 0;`), which would yield empty output.
     const QByteArray langUtf8 = m_language.toUtf8();
     const bool autoDetect = langUtf8.isEmpty() || langUtf8 == "auto";
     wparams.language = autoDetect ? "auto" : langUtf8.constData();
-    wparams.detect_language = autoDetect;
+    wparams.detect_language = false;
 
     if (whisper_full(m_ctx, wparams, pcm16k.data(), static_cast<int>(pcm16k.size())) != 0) {
         if (error != nullptr) {

--- a/src/asr/WhisperAsrBackend.cpp
+++ b/src/asr/WhisperAsrBackend.cpp
@@ -192,9 +192,9 @@ std::vector<AsrLanguage> asrWhisperLanguages()
     // from its own table (whisper_lang_str = ISO code, whisper_lang_str_full =
     // English name), so this never drifts out of sync with the model. The
     // multilingual checkpoints cover them all; the .en-only models ignore the
-    // setting and always decode English. Sorted by display name; the caller
-    // prepends "Auto-detect" (there's no such entry in whisper's table — a
-    // language of "auto" triggers detection in transcribe()).
+    // setting and always decode English. Sorted by display name. There is no
+    // "auto-detect" entry — whisper's table has no such code, and the UI does
+    // not add one (detection was unreliable on short VAD segments).
     std::vector<AsrLanguage> langs;
     const int maxId = whisper_lang_max_id();
     langs.reserve(static_cast<size_t>(maxId) + 1);

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -58,4 +58,17 @@ bool asrGpuAvailable();
 // gpu_device indexes them. Empty on CPU-only builds / GPU-less hosts.
 std::vector<AsrGpuDevice> asrGpuDevices();
 
+// A selectable transcription language: `code` is the ISO code passed to the
+// backend (e.g. "en", "es"); `name` is the English display name ("English").
+struct AsrLanguage {
+    QString code;
+    QString name;
+};
+
+// Every language the vendored whisper build supports, sorted by display name.
+// Multilingual models honor the choice; English-only (.en) models ignore it.
+// Does NOT include an "auto-detect" entry — pass a language of "auto" (or empty)
+// to whisperAsrBackendFactory to auto-detect; the UI adds that option itself.
+std::vector<AsrLanguage> asrWhisperLanguages();
+
 } // namespace AetherSDR

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -67,8 +67,10 @@ struct AsrLanguage {
 
 // Every language the vendored whisper build supports, sorted by display name.
 // Multilingual models honor the choice; English-only (.en) models ignore it.
-// Does NOT include an "auto-detect" entry — pass a language of "auto" (or empty)
-// to whisperAsrBackendFactory to auto-detect; the UI adds that option itself.
+// There is no "auto-detect" entry: passing a language of "auto" (or empty) to
+// whisperAsrBackendFactory still triggers detection in transcribe(), but the UI
+// does not offer that option — detection was unreliable on Copy Assist's short
+// VAD segments (whisper keys off ~30 s of audio), so the path is left dormant.
 std::vector<AsrLanguage> asrWhisperLanguages();
 
 } // namespace AetherSDR

--- a/src/asr/WhisperAsrBackend.h
+++ b/src/asr/WhisperAsrBackend.h
@@ -28,8 +28,6 @@ public:
     AsrTranscript transcribe(const std::vector<float>& pcm16k, QString* error) override;
     void unload() override;
 
-    void setLanguage(const QString& language) { m_language = language; }
-
 private:
     whisper_context* m_ctx = nullptr;
     QString m_language;
@@ -72,5 +70,22 @@ struct AsrLanguage {
 // does not offer that option — detection was unreliable on Copy Assist's short
 // VAD segments (whisper keys off ~30 s of audio), so the path is left dormant.
 std::vector<AsrLanguage> asrWhisperLanguages();
+
+// Coerce a persisted language code to one the model can actually decode:
+// returns `saved` when it appears in `supported`, otherwise falls back to
+// English ("en"). Used to validate/migrate the stored AsrLanguage (including
+// the retired "auto" sentinel and any empty/stale code) so the selector and the
+// engine can never disagree. Header-inline and whisper-free so it is unit
+// testable without linking the vendored library.
+inline QString asrLanguageOrDefault(const QString& saved,
+                                    const std::vector<AsrLanguage>& supported)
+{
+    for (const AsrLanguage& lang : supported) {
+        if (lang.code == saved) {
+            return saved;
+        }
+    }
+    return QStringLiteral("en");
+}
 
 } // namespace AetherSDR

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -190,19 +190,24 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // Language selector — every language the whisper build supports.
     // Multilingual models honor it; English-only models ignore it. (The
     // remote/sherpa backends read the same stored value where relevant.)
-    // NOTE: the "Auto-detect" option was removed — whisper language detection
-    // wasn't working reliably in testing. The backend still handles "auto"
-    // (see WhisperAsrBackend::transcribe), so re-adding is a one-line change
-    // once the detection issue is understood.
-    for (const AsrLanguage& lang : asrWhisperLanguages()) {
-        m_settings->addLanguage(lang.code, lang.name);
-    }
+    // NOTE: the "Auto-detect" option was removed — whisper's detection wasn't
+    // reliable on Copy Assist's short VAD segments (it keys off ~30 s of audio).
+    // The backend still handles "auto" (see WhisperAsrBackend::transcribe), left
+    // dormant so re-adding it is a one-line change once detection is understood.
     QString savedLang =
         AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
-    if (savedLang == QStringLiteral("auto")) {
-        // Auto-detect option removed: migrate any previously-saved value to
-        // English so the dropdown and the engine agree (a lingering "auto"
-        // would otherwise still trigger detection in the backend).
+    bool savedLangSupported = false;
+    for (const AsrLanguage& lang : asrWhisperLanguages()) {
+        m_settings->addLanguage(lang.code, lang.name);
+        if (lang.code == savedLang) {
+            savedLangSupported = true;
+        }
+    }
+    if (!savedLangSupported) {
+        // Fall back to English for any value the model can't decode — mirrors the
+        // GPU-device clamp above. This also migrates the retired "auto" sentinel
+        // and any empty/stale code, keeping the dropdown and the engine in sync
+        // (a lingering "auto" would otherwise still trigger detection).
         savedLang = QStringLiteral("en");
         auto& st = AppSettings::instance();
         st.setValue(QStringLiteral("AsrLanguage"), savedLang);

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -194,26 +194,23 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // reliable on Copy Assist's short VAD segments (it keys off ~30 s of audio).
     // The backend still handles "auto" (see WhisperAsrBackend::transcribe), left
     // dormant so re-adding it is a one-line change once detection is understood.
-    QString savedLang =
-        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
-    bool savedLangSupported = false;
-    for (const AsrLanguage& lang : asrWhisperLanguages()) {
+    const std::vector<AsrLanguage> languages = asrWhisperLanguages();
+    for (const AsrLanguage& lang : languages) {
         m_settings->addLanguage(lang.code, lang.name);
-        if (lang.code == savedLang) {
-            savedLangSupported = true;
-        }
     }
-    if (!savedLangSupported) {
-        // Fall back to English for any value the model can't decode — mirrors the
-        // GPU-device clamp above. This also migrates the retired "auto" sentinel
-        // and any empty/stale code, keeping the dropdown and the engine in sync
-        // (a lingering "auto" would otherwise still trigger detection).
-        savedLang = QStringLiteral("en");
+    const QString savedLang =
+        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
+    // Fall back to English for any value the model can't decode — mirrors the
+    // GPU-device clamp above. This also migrates the retired "auto" sentinel and
+    // any empty/stale code, keeping the dropdown and the engine in sync (a
+    // lingering "auto" would otherwise still trigger detection).
+    const QString effectiveLang = asrLanguageOrDefault(savedLang, languages);
+    if (effectiveLang != savedLang) {
         auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrLanguage"), savedLang);
+        st.setValue(QStringLiteral("AsrLanguage"), effectiveLang);
         st.save();
     }
-    m_settings->setCurrentLanguage(savedLang);
+    m_settings->setCurrentLanguage(effectiveLang);
     // The language selector only affects whisper/remote; sherpa-onnx takes its
     // language from the model, so hide it when sherpa is the active backend.
     m_settings->setLanguageSelectorVisible(m_backend != AsrBackendKind::SherpaOnnx);

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -187,16 +187,28 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_settings->setGpuSelectorVisible(true);
     }
 
-    // Language selector — "Auto-detect" first, then every language the whisper
-    // build supports. Multilingual models honor it; English-only models ignore
-    // it. (The remote/sherpa backends read the same stored value where relevant.)
-    m_settings->addLanguage(QStringLiteral("auto"), tr("Auto-detect"));
+    // Language selector — every language the whisper build supports.
+    // Multilingual models honor it; English-only models ignore it. (The
+    // remote/sherpa backends read the same stored value where relevant.)
+    // NOTE: the "Auto-detect" option was removed — whisper language detection
+    // wasn't working reliably in testing. The backend still handles "auto"
+    // (see WhisperAsrBackend::transcribe), so re-adding is a one-line change
+    // once the detection issue is understood.
     for (const AsrLanguage& lang : asrWhisperLanguages()) {
         m_settings->addLanguage(lang.code, lang.name);
     }
-    m_settings->setCurrentLanguage(
-        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
-            .toString());
+    QString savedLang =
+        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
+    if (savedLang == QStringLiteral("auto")) {
+        // Auto-detect option removed: migrate any previously-saved value to
+        // English so the dropdown and the engine agree (a lingering "auto"
+        // would otherwise still trigger detection in the backend).
+        savedLang = QStringLiteral("en");
+        auto& st = AppSettings::instance();
+        st.setValue(QStringLiteral("AsrLanguage"), savedLang);
+        st.save();
+    }
+    m_settings->setCurrentLanguage(savedLang);
 
     // Panel intent. The ⚙ button toggles the modeless settings dialog; model/GPU
     // changes come from the dialog itself.

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -76,7 +76,11 @@ AetherSDR::RemoteAsrConfig readRemoteConfig()
     cfg.url = s.value(QStringLiteral("AsrRemoteUrl"), QString()).toString();
     cfg.apiKey = s.value(QStringLiteral("AsrRemoteApiKey"), QString()).toString();
     cfg.model = s.value(QStringLiteral("AsrRemoteModel"), QStringLiteral("whisper-1")).toString();
-    cfg.language = QStringLiteral("en");
+    // Share the Copy Assist language selection with the remote endpoint. "auto"
+    // is left empty so an OpenAI-compatible server does its own detection rather
+    // than being handed a non-standard language value.
+    const QString lang = s.value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
+    cfg.language = (lang == QStringLiteral("auto")) ? QString() : lang;
     return cfg;
 }
 
@@ -183,6 +187,17 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_settings->setGpuSelectorVisible(true);
     }
 
+    // Language selector — "Auto-detect" first, then every language the whisper
+    // build supports. Multilingual models honor it; English-only models ignore
+    // it. (The remote/sherpa backends read the same stored value where relevant.)
+    m_settings->addLanguage(QStringLiteral("auto"), tr("Auto-detect"));
+    for (const AsrLanguage& lang : asrWhisperLanguages()) {
+        m_settings->addLanguage(lang.code, lang.name);
+    }
+    m_settings->setCurrentLanguage(
+        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
+            .toString());
+
     // Panel intent. The ⚙ button toggles the modeless settings dialog; model/GPU
     // changes come from the dialog itself.
     connect(m_panel, &CopyAssistPanel::enableToggled, this, &CopyAssistController::onEnableToggled);
@@ -204,6 +219,18 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             if (m_enabled) {
                 beginEnable();
             }
+        }
+    });
+    connect(m_settings, &CopyAssistSettingsDialog::languageChanged, this, [this](const QString& code) {
+        auto& st = AppSettings::instance();
+        st.setValue(QStringLiteral("AsrLanguage"), code);
+        st.save();
+        // Language is fixed at backend construction (whisper factory arg /
+        // remote config), so a change needs an engine rebuild — same as GPU.
+        m_tap->setEnabled(false);
+        buildEngine();
+        if (m_enabled) {
+            beginEnable();
         }
     });
 
@@ -399,6 +426,9 @@ void CopyAssistController::buildEngine()
     const int gpuDevice = AppSettings::instance()
                               .value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0"))
                               .toString().toInt();
+    const QString language = AppSettings::instance()
+                                 .value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
+                                 .toString();
     // Optional learned (Silero) VAD — an .onnx path enables it in the worker;
     // empty (or the toggle off) keeps the built-in energy VAD.
     AsrSegmenter::Config segConfig;
@@ -423,7 +453,7 @@ void CopyAssistController::buildEngine()
         m_asr = new AsrEngine(remoteAsrBackendFactory(readRemoteConfig()), segConfig, this);
         break;
     case AsrBackendKind::Whisper:
-        m_asr = new AsrEngine(whisperAsrBackendFactory(QStringLiteral("en"), gpuDevice),
+        m_asr = new AsrEngine(whisperAsrBackendFactory(language, gpuDevice),
                               segConfig, this);
         break;
     case AsrBackendKind::SherpaOnnx:

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -209,6 +209,9 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         st.save();
     }
     m_settings->setCurrentLanguage(savedLang);
+    // The language selector only affects whisper/remote; sherpa-onnx takes its
+    // language from the model, so hide it when sherpa is the active backend.
+    m_settings->setLanguageSelectorVisible(m_backend != AsrBackendKind::SherpaOnnx);
 
     // Panel intent. The ⚙ button toggles the modeless settings dialog; model/GPU
     // changes come from the dialog itself.
@@ -598,6 +601,10 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
     const AsrBackendKind prev = m_backend;
     m_backend = kind;
     m_tierId = tierId;
+
+    // Language applies to whisper/remote only; sherpa-onnx picks it from the
+    // model. Keep the selector's visibility in sync with the active backend.
+    m_settings->setLanguageSelectorVisible(kind != AsrBackendKind::SherpaOnnx);
 
     // Leaving the remote backend clears the persisted auto-connect flag so the
     // next launch starts on the local engine.

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -48,6 +48,15 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     m_gpuLabel->hide();
     m_gpu->hide();
 
+    m_language = new QComboBox(this);
+    m_language->setObjectName(QStringLiteral("CopyAssistLanguageCombo"));
+    m_language->setAccessibleName(tr("Copy Assist language"));
+    m_language->setToolTip(tr("Spoken language to transcribe (multilingual models only; "
+                              "Auto-detect picks it from the audio)"));
+    connect(m_language, &QComboBox::currentIndexChanged, this,
+            [this](int) { emit languageChanged(currentLanguage()); });
+    form->addRow(tr("Language:"), m_language);
+
     // Transcript-to-file logging. The checkbox is the master switch; the path row
     // (populated by the controller's file picker) enables with it.
     m_logToFile = new QCheckBox(tr("Save transcript to a file"), this);
@@ -201,6 +210,24 @@ void CopyAssistSettingsDialog::setGpuSelectorVisible(bool on)
 {
     m_gpuLabel->setVisible(on);
     m_gpu->setVisible(on);
+}
+
+void CopyAssistSettingsDialog::addLanguage(const QString& code, const QString& name)
+{
+    m_language->addItem(name, code);
+}
+
+void CopyAssistSettingsDialog::setCurrentLanguage(const QString& code)
+{
+    const int idx = m_language->findData(code);
+    if (idx >= 0) {
+        m_language->setCurrentIndex(idx);
+    }
+}
+
+QString CopyAssistSettingsDialog::currentLanguage() const
+{
+    return m_language->currentData().toString();
 }
 
 void CopyAssistSettingsDialog::setLogToFile(bool on)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -51,11 +51,14 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     m_language = new QComboBox(this);
     m_language->setObjectName(QStringLiteral("CopyAssistLanguageCombo"));
     m_language->setAccessibleName(tr("Copy Assist language"));
-    m_language->setToolTip(tr("Spoken language to transcribe (multilingual models only; "
-                              "Auto-detect picks it from the audio)"));
+    m_language->setToolTip(tr("Spoken language to transcribe (multilingual models only)"));
     connect(m_language, &QComboBox::currentIndexChanged, this,
             [this](int) { emit languageChanged(currentLanguage()); });
-    form->addRow(tr("Language:"), m_language);
+    // Explicit label (kept so the whole row can hide together) — the language
+    // selector only applies to the whisper/remote backends; sherpa-onnx picks
+    // its language from the loaded model, so the controller hides this row then.
+    m_languageLabel = new QLabel(tr("Language:"), this);
+    form->addRow(m_languageLabel, m_language);
 
     // Transcript-to-file logging. The checkbox is the master switch; the path row
     // (populated by the controller's file picker) enables with it.
@@ -228,6 +231,12 @@ void CopyAssistSettingsDialog::setCurrentLanguage(const QString& code)
 QString CopyAssistSettingsDialog::currentLanguage() const
 {
     return m_language->currentData().toString();
+}
+
+void CopyAssistSettingsDialog::setLanguageSelectorVisible(bool on)
+{
+    m_languageLabel->setVisible(on);
+    m_language->setVisible(on);
 }
 
 void CopyAssistSettingsDialog::setLogToFile(bool on)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -58,6 +58,7 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     // selector only applies to the whisper/remote backends; sherpa-onnx picks
     // its language from the loaded model, so the controller hides this row then.
     m_languageLabel = new QLabel(tr("Language:"), this);
+    m_languageLabel->setObjectName(QStringLiteral("CopyAssistLanguageLabel"));
     form->addRow(m_languageLabel, m_language);
 
     // Transcript-to-file logging. The checkbox is the master switch; the path row

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -37,6 +37,13 @@ public:
     int currentGpu() const;
     void setGpuSelectorVisible(bool on);
 
+    // Transcription-language selector (code + human label, e.g. "en"/"English").
+    // The controller populates it from the whisper backend's supported list
+    // plus an "Auto-detect" entry; whisper-free here, same as the tier/GPU combos.
+    void addLanguage(const QString& code, const QString& name);
+    void setCurrentLanguage(const QString& code);
+    QString currentLanguage() const;
+
     // Transcript-to-file logging: a checkbox + a (controller-populated) path. The
     // controller owns the file picker and the actual writing.
     void setLogToFile(bool on);
@@ -64,6 +71,7 @@ public:
 signals:
     void tierChanged(const QString& tierId);
     void gpuChanged(int index);
+    void languageChanged(const QString& code);
     void logToFileToggled(bool on);
     void browseLogFileRequested();
     void useSileroVadToggled(bool on);
@@ -76,6 +84,7 @@ private:
     QComboBox* m_tier = nullptr;
     QComboBox* m_gpu = nullptr;
     QLabel* m_gpuLabel = nullptr;   // paired with m_gpu so both hide together
+    QComboBox* m_language = nullptr;
     QCheckBox* m_logToFile = nullptr;
     QLineEdit* m_logPath = nullptr; // read-only display of the chosen path
     QPushButton* m_logBrowse = nullptr;

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -38,11 +38,14 @@ public:
     void setGpuSelectorVisible(bool on);
 
     // Transcription-language selector (code + human label, e.g. "en"/"English").
-    // The controller populates it from the whisper backend's supported list
-    // plus an "Auto-detect" entry; whisper-free here, same as the tier/GPU combos.
+    // The controller populates it from the whisper backend's supported list;
+    // whisper-free here, same as the tier/GPU combos. Only applies to the
+    // whisper/remote backends — the controller hides it for sherpa-onnx (which
+    // takes its language from the loaded model).
     void addLanguage(const QString& code, const QString& name);
     void setCurrentLanguage(const QString& code);
     QString currentLanguage() const;
+    void setLanguageSelectorVisible(bool on);
 
     // Transcript-to-file logging: a checkbox + a (controller-populated) path. The
     // controller owns the file picker and the actual writing.
@@ -85,6 +88,7 @@ private:
     QComboBox* m_gpu = nullptr;
     QLabel* m_gpuLabel = nullptr;   // paired with m_gpu so both hide together
     QComboBox* m_language = nullptr;
+    QLabel* m_languageLabel = nullptr; // paired with m_language so both hide together
     QCheckBox* m_logToFile = nullptr;
     QLineEdit* m_logPath = nullptr; // read-only display of the chosen path
     QPushButton* m_logBrowse = nullptr;

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -4,6 +4,8 @@
 
 #include "gui/CopyAssistSettingsDialog.h"
 
+#include "asr/WhisperAsrBackend.h" // asrLanguageOrDefault (header-inline, whisper-free)
+
 #include <QApplication>
 #include <QComboBox>
 #include <QLabel>
@@ -97,6 +99,25 @@ int main(int argc, char** argv)
         expect(langCombo != nullptr && langCombo->isVisibleTo(&dlg)
                    && langLabel != nullptr && langLabel->isVisibleTo(&dlg),
                "setLanguageSelectorVisible(true) shows label + combo together");
+    }
+
+    // ---- asrLanguageOrDefault: validate/migrate a saved language code -----
+    {
+        const std::vector<AsrLanguage> supported = {
+            {QStringLiteral("en"), QStringLiteral("English")},
+            {QStringLiteral("es"), QStringLiteral("Spanish")},
+            {QStringLiteral("fr"), QStringLiteral("French")},
+        };
+        expect(asrLanguageOrDefault(QStringLiteral("fr"), supported) == QStringLiteral("fr"),
+               "asrLanguageOrDefault keeps a supported code");
+        expect(asrLanguageOrDefault(QStringLiteral("auto"), supported) == QStringLiteral("en"),
+               "asrLanguageOrDefault migrates the retired \"auto\" sentinel to en");
+        expect(asrLanguageOrDefault(QString(), supported) == QStringLiteral("en"),
+               "asrLanguageOrDefault migrates an empty code to en");
+        expect(asrLanguageOrDefault(QStringLiteral("zz-nonesuch"), supported) == QStringLiteral("en"),
+               "asrLanguageOrDefault falls back to en for an unsupported code");
+        expect(asrLanguageOrDefault(QStringLiteral("en"), {}) == QStringLiteral("en"),
+               "asrLanguageOrDefault falls back to en when the list is empty");
     }
 
     // ---- Transcript file logging: state + toggle signal -------------------

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -6,6 +6,7 @@
 
 #include <QApplication>
 #include <QComboBox>
+#include <QLabel>
 #include <QSignalSpy>
 
 #include <cstdio>
@@ -65,6 +66,37 @@ int main(int argc, char** argv)
         expect(dlg.currentGpu() == -1, "setCurrentGpu selects the CPU sentinel");
         expect(!gpuSpy.isEmpty() && gpuSpy.last().at(0).toInt() == -1,
                "gpuChanged carries the device index");
+    }
+
+    // ---- Language selector: round-trip, signal, paired visibility ---------
+    {
+        dlg.addLanguage(QStringLiteral("en"), QStringLiteral("English"));
+        dlg.addLanguage(QStringLiteral("es"), QStringLiteral("Spanish"));
+
+        QSignalSpy langSpy(&dlg, &CopyAssistSettingsDialog::languageChanged);
+        dlg.setCurrentLanguage(QStringLiteral("es"));
+        expect(dlg.currentLanguage() == QStringLiteral("es"),
+               "setCurrentLanguage selects by code, currentLanguage round-trips");
+        expect(!langSpy.isEmpty() && langSpy.last().at(0).toString() == QStringLiteral("es"),
+               "languageChanged carries the language code");
+
+        // Unknown code is a no-op (the controller coerces to a supported code
+        // before calling this), so the selection stays put.
+        dlg.setCurrentLanguage(QStringLiteral("zz-nonesuch"));
+        expect(dlg.currentLanguage() == QStringLiteral("es"),
+               "setCurrentLanguage ignores an unsupported code");
+
+        // The label + combo hide/show together (sherpa-onnx path hides the row).
+        auto* langCombo = dlg.findChild<QComboBox*>(QStringLiteral("CopyAssistLanguageCombo"));
+        auto* langLabel = dlg.findChild<QLabel*>(QStringLiteral("CopyAssistLanguageLabel"));
+        dlg.setLanguageSelectorVisible(false);
+        expect(langCombo != nullptr && !langCombo->isVisibleTo(&dlg)
+                   && langLabel != nullptr && !langLabel->isVisibleTo(&dlg),
+               "setLanguageSelectorVisible(false) hides label + combo together");
+        dlg.setLanguageSelectorVisible(true);
+        expect(langCombo != nullptr && langCombo->isVisibleTo(&dlg)
+                   && langLabel != nullptr && langLabel->isVisibleTo(&dlg),
+               "setLanguageSelectorVisible(true) shows label + combo together");
     }
 
     // ---- Transcript file logging: state + toggle signal -------------------


### PR DESCRIPTION
Resolves #4408

## Summary

Copy Assist decoded every over as **English**, even though the multilingual whisper models AetherSDR already ships can transcribe ~99 languages. The plumbing was all stubbed for English: `WhisperAsrBackend` hardcoded `wparams.language = "en"` with `detect_language = false`, the controller passed a literal `"en"` into the whisper factory, and `setLanguage()` was dead API. This surfaces the capability with a language dropdown.

## 📣 Call for testers — non-English languages

English is verified end-to-end (macOS + RPi5). **The other ~98 languages are wired up but unverified** — I don't have a source of clean non-English SSB/CW audio to test against. If you speak another language, please select it in Copy Assist Settings (⚙ → Language), run it against live or recorded audio, and report back how it does. That real-world feedback is exactly why this is going out now rather than waiting.

## ⚠️ Deviation from the #4408 analysis: "Auto-detect" was removed

The #4408 triage's proposed fix (and this PR's first commit) included an **"Auto-detect"** option that toggles whisper's `detect_language`. **It was removed in `7de6207d` after testing** — it didn't work reliably in practice. Whisper's language detection keys off roughly the first **~30 s** of audio, but Copy Assist feeds the backend **short VAD segments** (often just a few seconds of a single over), so detection on a brief, noisy SSB snippet was unreliable and frequently wrong. Rather than ship a misleading option, it's dropped from the dropdown.

- The backend still handles the `"auto"` sentinel (`WhisperAsrBackend::transcribe` → `detect_language`), left **intact but dormant**, so re-adding the option is a one-line change once the detection path is understood.
- Any previously-saved `AsrLanguage="auto"` (or an empty/stale value) is **migrated to `"en"`** so the dropdown and the engine can't disagree.
- **English is the default selection.**

## What it does

- New **Language** dropdown in Copy Assist Settings (⚙): every language the vendored whisper build supports, enumerated at runtime from whisper's own table (`whisper_lang_max_id` / `whisper_lang_str` / `whisper_lang_str_full`), so the list can never drift out of sync with the model. **English is selected by default.**
- Selection persists (`AsrLanguage`, default `"en"`) and pins that language for decoding.
- Kept the settings dialog **whisper-free** — the controller feeds it the list, same pattern as the GPU-device combo, so the lightweight Qt-only dialog test still links.
- Changing language rebuilds the engine (language is fixed at backend construction), mirroring the existing GPU-change behavior. The remote whisper-server path (`readRemoteConfig()`) shares the same setting.
- **The Language row is hidden for the sherpa-onnx backend** (`9cc1b496`): sherpa takes its language from the loaded model, not this setting, so showing the dropdown there would be misleading. Visible for whisper + remote; hidden for sherpa, kept in sync on every backend/model switch.

## Caveats (worth documenting for users)

- Only the **multilingual** models (`tiny`/`base`/`small`/`large-v3-turbo`) honor this; the English-only `.en` variants ignore it.
- Multilingual accuracy drops faster at small sizes — `small` or `large-v3-turbo` suit non-English better than `tiny`/`base`.

## Testing

- **English transcription verified working** on macOS (Metal) and RPi5 (RelWithDebInfo).
- **English is the default selection** (fresh install, and via migration for anyone who'd previously selected auto-detect).
- Language row confirmed to **hide when sherpa-onnx is the active backend** and reappear for whisper.
- Full app builds clean on macOS + RPi5; `copy_assist_settings_dialog_test` passes on both, now with language-selector coverage (round-trip, `languageChanged` signal, unsupported-code no-op, paired label+combo visibility).
- **Non-English:** wired up but not yet verified — see the *Call for testers* section above.

## Changes since this PR opened

Red-team review (no blocking findings) → three follow-up commits:
- Corrected stale comments referencing the removed "Auto-detect" option.
- Validate the saved language against the model's supported list, falling back to English for any unsupported/stale value (previously it was silently possible to drift the dropdown vs. the engine, or land on the first alphabetical entry rather than English).
- Added dialog test coverage for the language selector.

Built and smoke tested on: MacBook Air M2 / Raspberry Pi 5 (Debian, RelWithDebInfo)
