### PR TITLE
fix(asr): guard THREAD_POWER_THROTTLING_STATE to MSVC in vendored ggml-cpu.c

### DIFF
--- a/third_party/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/third_party/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2525,7 +2525,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
         // Newer Windows 11 versions aggressively park (offline) CPU cores and often place
         // all our threads onto the first 4 cores which results in terrible performance with
         // n_threads > 4
-        #if _WIN32_WINNT >= 0x0602
+        #if defined(_MSC_VER) && _WIN32_WINNT >= 0x0602
         THREAD_POWER_THROTTLING_STATE t;
         ZeroMemory(&t, sizeof(t));
         t.Version     = THREAD_POWER_THROTTLING_CURRENT_VERSION;


### PR DESCRIPTION
## Summary

- Fixes a MinGW/GCC compile failure in the vendored `ggml-cpu.c` (whisper.cpp, merged via #4338) that breaks local builds using this project's MinGW toolchain (Qt 6.11.0 mingw_64 + GCC 13.1.0).
- One-line fix: gate the Windows-11 core-parking thread-priority block to `_MSC_VER`, since the struct/macros it uses are MSVC-Windows-SDK-only.

## Details

`ggml_thread_apply_priority()` in `third_party/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.c` guards a thread power-throttling mitigation with `#if _WIN32_WINNT >= 0x0602`, but `THREAD_POWER_THROTTLING_STATE` and the `THREAD_POWER_THROTTLING_EXECUTION_SPEED`/`THREAD_POWER_THROTTLING_CURRENT_VERSION` macros are only defined in the MSVC Windows SDK headers. MinGW-w64's `winbase.h` defines the `ThreadPowerThrottling` enum value (so the `SetThreadInformation(..., ThreadPowerThrottling, ...)` call resolves) but not the struct/macros this block fills in, so it fails to compile under MinGW GCC:

```
third_party/whisper.cpp/ggml/src/ggml-cpu/ggml-cpu.c:2533:10: error: request for member 'StateMask' in something not a structure or union
 2533 |         t.StateMask   = 0;
      |          ^
```

This repo's CI and the official installer build with MSVC, so the bug was invisible there — it only surfaces on a local MinGW dev build. Flagged (and this same fix proposed) as a comment on #4338 before it merged: https://github.com/aethersdr/AetherSDR/pull/4338#issuecomment-5038453728

## Fix

```diff
-        #if _WIN32_WINNT >= 0x0602
+        #if defined(_MSC_VER) && _WIN32_WINNT >= 0x0602
         THREAD_POWER_THROTTLING_STATE t;
```

Under MinGW, this only forgoes a Windows-11 core-parking performance hint — `SetThreadPriority()` immediately below is unconditional and still applies. No behavior change under MSVC (CI/installer path).

## Test plan

- [x] Reconfigured + rebuilt `AetherSDR.exe` from this branch (MinGW GCC 13.1.0, Qt 6.11.0 mingw_64, Vulkan GPU ASR backend enabled) — clean configure + `[1377/1377]` build, confirms the fix resolves the compile error with no other regressions in the vendored ggml/whisper.cpp tree.
- [ ] CI (MSVC) — expected no-op, since the guard only removes code from the MinGW path.
