### PR TITLE
Fix stale CW and RTTY panels after pan routing

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4246,15 +4246,13 @@ void MainWindow::buildUI()
             this, [this](const QString& panId) {
         m_radioModel.setActivePanId(panId);
 
-        // Update m_panApplet for the new active pan
+        // Update m_panApplet for the new active pan. setActivePanApplet()
+        // re-targets the decoders and refreshes the panels, so visibility
+        // follows the active slice (not whichever slice appears first on the
+        // newly active pan) and stale docks are cleared on every other pan
+        // (#4409).
         if (auto* applet = m_panStack->panadapter(panId))
             setActivePanApplet(applet);
-
-        // Decoder panel visibility follows the active slice, not whichever
-        // slice happens to appear first on the newly active pan (#4409).
-        // The refresh functions also clear stale panels on every other pan.
-        refreshCwDecodeState();
-        refreshRttyDecodeState();
     });
     splitter->setStretchFactor(0, 0);  // CWX panel: fixed width
     splitter->setStretchFactor(1, 0);  // DVK panel: fixed width
@@ -6594,8 +6592,15 @@ void MainWindow::setActivePanApplet(PanadapterApplet* applet)
     if (applet == m_panApplet) return;
     m_panApplet = applet;
 
+    // Re-target the decoders to the new active pan, then refresh so the moved
+    // panel becomes visible on the new target and is cleared on every other pan.
+    // route*() only hides the old target; refresh*() decides visibility from the
+    // active slice — pairing them here means every caller stays consistent
+    // without having to remember the follow-up refresh (#4409).
     routeCwDecoderOutput();
     routeRttyDecoderOutput();
+    refreshCwDecodeState();
+    refreshRttyDecodeState();
 }
 
 // Route CW decoder text/stats output to the pan that owns the active slice,
@@ -6694,6 +6699,23 @@ void MainWindow::routeCwDecoderOutput()
 // independent RX/TX toggles, MOX edges, and slice-mode changes all
 // converge on the same decision tree.
 // RTTY decoder routing lives in MainWindow_DigitalModes.cpp (#3351 Phase 1e).
+void MainWindow::setDecoderPanelVisibleOnly(
+    PanadapterApplet* target, bool shouldShow,
+    void (PanadapterApplet::*setter)(bool))
+{
+    // Exactly one panel — the current decoder target — may be visible; every
+    // other applet is hidden so a target moved during startup status ordering
+    // can't leave an orphaned decoder dock behind (#4409).
+    if (m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (applet)
+                (applet->*setter)(applet == target && shouldShow);
+        }
+    } else if (target) {
+        (target->*setter)(shouldShow);
+    }
+}
+
 void MainWindow::refreshCwDecodeState()
 {
     const bool rxOn = CwDecodeSettings::rxEnabled();
@@ -6707,16 +6729,8 @@ void MainWindow::refreshCwDecodeState()
     // text view is anchored to a CW slice's panadapter.  TX-side
     // decode is shown in the same panel, so if there's no CW slice in
     // view, there's no panel either.
-    if (m_panStack) {
-        for (PanadapterApplet* applet : m_panStack->allApplets()) {
-            if (applet) {
-                applet->setCwPanelVisible(
-                    applet == m_cwDecoderApplet && isCw && anyOn);
-            }
-        }
-    } else if (m_cwDecoderApplet) {
-        m_cwDecoderApplet->setCwPanelVisible(isCw && anyOn);
-    }
+    setDecoderPanelVisibleOnly(m_cwDecoderApplet, isCw && anyOn,
+                               &PanadapterApplet::setCwPanelVisible);
 
     // RX decoder runs only when RX-decode is on and the operator is
     // listening to a CW slice.  Non-CW slices feed unrelated audio,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4250,21 +4250,11 @@ void MainWindow::buildUI()
         if (auto* applet = m_panStack->panadapter(panId))
             setActivePanApplet(applet);
 
-        // Show/hide CW decode panel based on the new active pan's slice mode
-        // — driven through refreshCwDecodeState() so the panel on the
-        // landed pan picks up the same RX/TX toggle gating the active
-        // slice does (#2417).
-        for (auto* sl : m_radioModel.slices()) {
-            if (sl->panId() == panId) {
-                const bool isCw = (sl->mode() == "CW" || sl->mode() == "CWL");
-                const bool anyOn = CwDecodeSettings::anyEnabled();
-                if (auto* applet = m_panStack->panadapter(panId))
-                    applet->setCwPanelVisible(isCw && anyOn);
-                refreshCwDecodeState();
-                refreshRttyDecodeState();
-                break;
-            }
-        }
+        // Decoder panel visibility follows the active slice, not whichever
+        // slice happens to appear first on the newly active pan (#4409).
+        // The refresh functions also clear stale panels on every other pan.
+        refreshCwDecodeState();
+        refreshRttyDecodeState();
     });
     splitter->setStretchFactor(0, 0);  // CWX panel: fixed width
     splitter->setStretchFactor(1, 0);  // DVK panel: fixed width
@@ -6627,6 +6617,10 @@ void MainWindow::routeCwDecoderOutput()
     disconnect(m_cwStatsConn);
 #endif
     if (m_cwDecoderApplet) {
+        // A panel can still be visible when startup status ordering moves the
+        // decoder target. Hide it before dropping ownership so a later refresh
+        // cannot leave an orphaned CW dock on the old pan (#4409).
+        m_cwDecoderApplet->setCwPanelVisible(false);
         disconnect(&m_cwDecoder, &CwDecoder::textDecoded,
                    m_cwDecoderApplet, &PanadapterApplet::appendCwText);
         disconnect(&m_cwDecoderTx, &CwDecoder::textDecoded,
@@ -6713,8 +6707,16 @@ void MainWindow::refreshCwDecodeState()
     // text view is anchored to a CW slice's panadapter.  TX-side
     // decode is shown in the same panel, so if there's no CW slice in
     // view, there's no panel either.
-    if (m_cwDecoderApplet)
+    if (m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (applet) {
+                applet->setCwPanelVisible(
+                    applet == m_cwDecoderApplet && isCw && anyOn);
+            }
+        }
+    } else if (m_cwDecoderApplet) {
         m_cwDecoderApplet->setCwPanelVisible(isCw && anyOn);
+    }
 
     // RX decoder runs only when RX-decode is on and the operator is
     // listening to a CW slice.  Non-CW slices feed unrelated audio,

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -517,6 +517,11 @@ private:
                                              const QString& panId = QString());
     void setActivePanApplet(PanadapterApplet* applet);
     void routeCwDecoderOutput();
+    // Show a decoder panel on exactly one applet — the current decoder target —
+    // and hide it on every other pan, so a moved target can't leave a stale
+    // dock (#4409). `setter` is setCwPanelVisible or setRttyPanelVisible.
+    void setDecoderPanelVisibleOnly(PanadapterApplet* target, bool shouldShow,
+                                    void (PanadapterApplet::*setter)(bool));
     void refreshCwDecodeState();
     // QRZ callsign lookup (MainWindow_Callsign.cpp): CW-spotter → lookup
     // service → contact card on the CW decode panel + lookup dialog.

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -206,16 +206,8 @@ void MainWindow::refreshRttyDecodeState()
     // the panel manually via the slice context menu (future work).
     const bool isRtty = s && s->mode() == "RTTY";
 
-    if (m_panStack) {
-        for (PanadapterApplet* applet : m_panStack->allApplets()) {
-            if (applet) {
-                applet->setRttyPanelVisible(
-                    applet == m_rttyDecoderApplet && isRtty);
-            }
-        }
-    } else if (m_rttyDecoderApplet) {
-        m_rttyDecoderApplet->setRttyPanelVisible(isRtty);
-    }
+    setDecoderPanelVisibleOnly(m_rttyDecoderApplet, isRtty,
+                               &PanadapterApplet::setRttyPanelVisible);
 
     if (!isRtty) {
         if (m_rttyDecoder.isRunning()) m_rttyDecoder.stop();

--- a/src/gui/MainWindow_DigitalModes.cpp
+++ b/src/gui/MainWindow_DigitalModes.cpp
@@ -158,6 +158,9 @@ void MainWindow::routeRttyDecoderOutput()
     if (target == m_rttyDecoderApplet) return;
 
     if (m_rttyDecoderApplet) {
+        // Keep the old pan from retaining a visible RTTY dock when startup
+        // status ordering or a slice switch moves decoder ownership (#4409).
+        m_rttyDecoderApplet->setRttyPanelVisible(false);
         disconnect(&m_rttyDecoder, &RttyDecoder::textDecoded,
                    m_rttyDecoderApplet, &PanadapterApplet::appendRttyText);
         disconnect(&m_rttyDecoder, &RttyDecoder::statsUpdated,
@@ -203,8 +206,16 @@ void MainWindow::refreshRttyDecodeState()
     // the panel manually via the slice context menu (future work).
     const bool isRtty = s && s->mode() == "RTTY";
 
-    if (m_rttyDecoderApplet)
+    if (m_panStack) {
+        for (PanadapterApplet* applet : m_panStack->allApplets()) {
+            if (applet) {
+                applet->setRttyPanelVisible(
+                    applet == m_rttyDecoderApplet && isRtty);
+            }
+        }
+    } else if (m_rttyDecoderApplet) {
         m_rttyDecoderApplet->setRttyPanelVisible(isRtty);
+    }
 
     if (!isRtty) {
         if (m_rttyDecoder.isRunning()) m_rttyDecoder.stop();


### PR DESCRIPTION
## Summary

Fixes #4409.

Decoder panel ownership can move between panadapter applets while startup statuses are still arriving. The previous target was disconnected without hiding its panel, and later refreshes only updated the new target. This could leave the CW panel visible under a non-CW slice until another pan interaction refreshed the UI.

This change:

- hides the old CW or RTTY panel before rerouting decoder output;
- refreshes every panadapter applet so only the current decoder target can remain visible;
- refreshes both decoder panels unconditionally when the active pan changes, using the active slice rather than the first slice found on that pan.

The sibling audit found RTTY had the same stale-owner lifecycle, so it is fixed in the same patch. Copy Assist retains explicit pan ownership too, but it is lazy-created only by an ASR action and cannot randomly appear during startup; that behavior is intentionally left unchanged.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The patch was built from current `upstream/main` and exercised through the isolated automation bridge with a disconnected synthetic slice.

## Test plan

- [x] Local build passes (`cmake --build build -j12`)
- [x] Behavior verified through the agent automation bridge with no radio connected
- [x] Focused native widget topology test passes
- [x] Reproduction steps documented in #4409

Bridge proof on the freshly built app:

1. Launch with `AETHER_AUTOMATION=1`, `AETHER_AUTOMATION_NO_AUTOCONNECT=1`, and `AETHER_AUTOMATION_NO_TX=1`.
2. Create disconnected slice fixture `0 A`.
3. Set mode to `CW`: `cwDecodePanel.visible == true`.
4. Set mode to `USB`: `cwDecodePanel.visible == false`.
5. Set mode to `RTTY`: the RTTY panel and label are visible.
6. Set mode back to `USB`: the RTTY panel and label are hidden.

The live radio was not used because another AetherSDR instance already owned it; the disconnected fixture exercises the normal slice-status/model/UI path without disturbing that session.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed (issue/PR documents the correction; no user docs needed)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

---
*This fix was authored and verified using the `fb` end-to-end bug-fix workflow.*
