### PR TITLE
Fix DC-edge 3D comb and stalled waterfall

### DIFF
--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -995,11 +995,9 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
 
     if (tileWidth == 0 || tileHeight == 0) return;
 
-    // FrameLowFreq and BinBandwidth arrive as either VitaFrequency (Hz × 2^20)
-    // or plain Hz; disambiguate on the raw integer magnitude so there is no
-    // upper frequency ceiling. The previous "divide then reject results above
-    // 1000 MHz" heuristic blacked out the waterfall for every transverter above
-    // 1 GHz (#3449, #1843, #1928, #2835). See VitaTileFrequency.h.
+    // FrameLowFreq and BinBandwidth are VITA fixed-point values (Hz × 2^20).
+    // Decode them unconditionally so a tile that overhangs slightly below DC
+    // cannot be mistaken for plain Hz (#4412). See VitaTileFrequency.h.
     const auto tileFreq = AetherSDR::Vita::decodeTileFrequencyMhz(frameLowRaw, binBwRaw);
     const double lowFreqMhz = tileFreq.lowMhz;
     const double binBwMhz   = tileFreq.binBwMhz;

--- a/src/core/VitaTileFrequency.h
+++ b/src/core/VitaTileFrequency.h
@@ -5,8 +5,8 @@
 // VITA-49 waterfall-tile frequency decoding.
 //
 // A tile sub-header carries FrameLowFreq and BinBandwidth as 64-bit integers.
-// Depending on the radio/firmware these are encoded either as "VitaFrequency"
-// (Hz × 2^20) or as plain Hz.  Both fields always share the same encoding.
+// FlexLib defines both fields as "VitaFrequency" (Hz × 2^20). Decode that
+// protocol type directly rather than guessing an encoding from magnitude.
 //
 // History: the original decoder assumed VitaFrequency, divided, then rejected
 // the result as "unreasonable" if it exceeded 1000 MHz — silently re-reading it
@@ -15,14 +15,10 @@
 // divided by 1e6 instead of 2^20·1e6, inflating it by 2^20, which pushed every
 // waterfall bin outside the panadapter range and rendered the row entirely
 // black while the FFT trace stayed correct.  See issues #3449, #1843, #1928,
-// #2835 and the failed remap-layer fixes #1845 / #2709 / #2853.
-//
-// Disambiguate on the *raw integer magnitude* instead, which has a clean gap:
-//   • plain Hz for any real frequency (≤ ~100 GHz) is below 1e11
-//   • the smallest VitaFrequency we can see (~95 kHz, well under the 2200 m /
-//     135 kHz band edge) is above 1e11
-// so a single raw threshold separates the two encodings across the entire
-// usable spectrum without imposing any upper frequency limit.
+// #2835 and the failed remap-layer fixes #1845 / #2709 / #2853. A later
+// magnitude heuristic removed that upper ceiling but introduced a new one near
+// DC: a valid negative tile overhang below about 95 kHz looked like plain Hz,
+// inflating its bin bandwidth by 2^20 and mapping the row off-screen (#4412).
 
 namespace AetherSDR::Vita {
 
@@ -31,24 +27,14 @@ struct TileFrequency {
     double binBwMhz{0.0};
 };
 
-// Below this raw magnitude the value is plain Hz; at or above it, VitaFrequency
-// (Hz × 2^20).  1e11 sits in the gap between the two encodings' realistic
-// ranges (see header comment).
-inline constexpr qint64 kVitaFrequencyRawThreshold = 100000000000LL; // 1e11
-
 // Hz × 2^20 → MHz.
 inline constexpr double kVitaFrequencyToMhz = 1048576.0 * 1e6;
 
 inline TileFrequency decodeTileFrequencyMhz(qint64 frameLowRaw, qint64 binBwRaw)
 {
-    // The encoding is decided from FrameLowFreq (the large, reliable value) and
-    // applied to BinBandwidth too, since both fields share one encoding.
-    const bool isVitaFrequency = qAbs(frameLowRaw) >= kVitaFrequencyRawThreshold;
-    const double scale = isVitaFrequency ? kVitaFrequencyToMhz : 1e6;
-
     TileFrequency out;
-    out.lowMhz   = static_cast<double>(frameLowRaw) / scale;
-    out.binBwMhz = static_cast<double>(binBwRaw) / scale;
+    out.lowMhz   = static_cast<double>(frameLowRaw) / kVitaFrequencyToMhz;
+    out.binBwMhz = static_cast<double>(binBwRaw) / kVitaFrequencyToMhz;
     return out;
 }
 

--- a/src/gui/DssDcEdgeMath.h
+++ b/src/gui/DssDcEdgeMath.h
@@ -32,7 +32,12 @@ inline QVector<float> flattenLeadingSpike(const QVector<float>& binsDbm)
         return binsDbm;
     }
 
-    const int referenceStart = std::min(8, count / 4);
+    // Bins we may replace at the head. Compute this first so the noise-baseline
+    // window can start past it — the median must never be sampled from the spike
+    // itself, or a longer-than-expected spike would inflate the baseline and
+    // under-repair (#4413 review).
+    const int candidateBins = std::clamp((count + 99) / 100, 4, 32);
+    const int referenceStart = std::max(8, candidateBins);
     const int referenceEnd = std::clamp(count / 20, referenceStart + 8, 128);
     QVector<float> referenceBins;
     referenceBins.reserve(referenceEnd - referenceStart);
@@ -56,7 +61,6 @@ inline QVector<float> flattenLeadingSpike(const QVector<float>& binsDbm)
         return binsDbm;
     }
 
-    const int candidateBins = std::clamp((count + 99) / 100, 4, 32);
     int replaceCount = 0;
     while (replaceCount < candidateBins
            && std::isfinite(binsDbm[replaceCount])

--- a/src/gui/DssDcEdgeMath.h
+++ b/src/gui/DssDcEdgeMath.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::DssDcEdgeMath {
+
+inline bool viewStartsAtDc(double centerMhz, double bandwidthMhz)
+{
+    if (!std::isfinite(centerMhz)
+        || !std::isfinite(bandwidthMhz)
+        || bandwidthMhz <= 0.0) {
+        return false;
+    }
+
+    const double lowMhz = centerMhz - bandwidthMhz * 0.5;
+    const double toleranceMhz = std::max(1.0e-9, bandwidthMhz * 1.0e-9);
+    return lowMhz <= toleranceMhz;
+}
+
+// FLEX firmware 4.2.18 returns a short, steep leading spike when an FFT view
+// begins exactly at DC. In 2D it is only a few edge bins, but 3D Stacked Trace
+// repeats that edge through its perspective history and turns it into a large
+// diagonal comb. Replace only a contiguous leading outlier with the nearby
+// noise baseline; the source FFT used by the 2D trace remains untouched.
+inline QVector<float> flattenLeadingSpike(const QVector<float>& binsDbm)
+{
+    const int count = binsDbm.size();
+    if (count < 16) {
+        return binsDbm;
+    }
+
+    const int referenceStart = std::min(8, count / 4);
+    const int referenceEnd = std::clamp(count / 20, referenceStart + 8, 128);
+    QVector<float> referenceBins;
+    referenceBins.reserve(referenceEnd - referenceStart);
+    for (int i = referenceStart; i < referenceEnd; ++i) {
+        if (std::isfinite(binsDbm[i])) {
+            referenceBins.append(binsDbm[i]);
+        }
+    }
+    if (referenceBins.isEmpty()) {
+        return binsDbm;
+    }
+
+    const int middle = referenceBins.size() / 2;
+    std::nth_element(referenceBins.begin(),
+                     referenceBins.begin() + middle,
+                     referenceBins.end());
+    const float referenceDbm = referenceBins[middle];
+    constexpr float kOutlierThresholdDb = 6.0f;
+    if (!std::isfinite(binsDbm[0])
+        || binsDbm[0] <= referenceDbm + kOutlierThresholdDb) {
+        return binsDbm;
+    }
+
+    const int candidateBins = std::clamp((count + 99) / 100, 4, 32);
+    int replaceCount = 0;
+    while (replaceCount < candidateBins
+           && std::isfinite(binsDbm[replaceCount])
+           && binsDbm[replaceCount] > referenceDbm + kOutlierThresholdDb) {
+        ++replaceCount;
+    }
+    if (replaceCount == 0) {
+        return binsDbm;
+    }
+
+    QVector<float> repaired = binsDbm;
+    std::fill(repaired.begin(), repaired.begin() + replaceCount, referenceDbm);
+    return repaired;
+}
+
+} // namespace AetherSDR::DssDcEdgeMath

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -4332,31 +4332,58 @@ void SpectrumWidget::appendDssHistoryRow(const QVector<float>& binsDbm,
                         dssHistoryFallbackDbm());
 }
 
+namespace {
+
+// Returns DC-spike-repaired bins for a native FLEX DSS row whose FRAME begins at
+// DC, else the input bins unchanged; `scratch` owns any repaired copy. Gates on
+// the frame's own coverage (where the row is stamped), falling back to the view
+// only when the frame is invalid — mirroring the stampFrame/requestedFrame
+// pattern so the repair tracks the row, not a diverging view (#4413 review).
+const QVector<float>& dcRepairedDssBins(QVector<float>& scratch,
+                                        const QVector<float>& binsDbm,
+                                        bool nativeStream,
+                                        double frameCenterMhz,
+                                        double frameBandwidthMhz,
+                                        double viewCenterMhz,
+                                        double viewBandwidthMhz)
+{
+    if (!nativeStream) {
+        return binsDbm;
+    }
+    const FrequencyFrame frame{frameCenterMhz, frameBandwidthMhz};
+    const double centerMhz = frame.isValid() ? frameCenterMhz : viewCenterMhz;
+    const double bwMhz = frame.isValid() ? frameBandwidthMhz : viewBandwidthMhz;
+    if (!DssDcEdgeMath::viewStartsAtDc(centerMhz, bwMhz)) {
+        return binsDbm;
+    }
+    scratch = DssDcEdgeMath::flattenLeadingSpike(binsDbm);
+    return scratch;
+}
+
+} // namespace
+
 void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
                                            double frameCenterMhz,
                                            double frameBandwidthMhz,
                                            bool updateLiveSurface)
 {
     QVector<float> repairedBins;
-    const QVector<float>* dssBins = &binsDbm;
-    if (!m_kiwiSdrWaterfallActive
-        && DssDcEdgeMath::viewStartsAtDc(m_centerMhz, m_bandwidthMhz)) {
-        repairedBins = DssDcEdgeMath::flattenLeadingSpike(binsDbm);
-        dssBins = &repairedBins;
-    }
+    const QVector<float>& dssBins = dcRepairedDssBins(
+        repairedBins, binsDbm, !m_kiwiSdrWaterfallActive,
+        frameCenterMhz, frameBandwidthMhz, m_centerMhz, m_bandwidthMhz);
 
     // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
     if (m_wfLive && updateLiveSurface) {
         if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
             const QVector<float>& previewBins = remapPreviewDssRow(
-                *dssBins, frameCenterMhz, frameBandwidthMhz);
+                dssBins, frameCenterMhz, frameBandwidthMhz);
             pushDssLiveRow(m_dss, previewBins, false);
             ++m_frequencyPreviewRemappedDssRows;
         } else {
-            pushDssLiveRow(m_dss, *dssBins, !m_waterfallWriteVisible);
+            pushDssLiveRow(m_dss, dssBins, !m_waterfallWriteVisible);
         }
     }
-    appendDssHistoryRow(*dssBins, frameCenterMhz, frameBandwidthMhz);
+    appendDssHistoryRow(dssBins, frameCenterMhz, frameBandwidthMhz);
 }
 
 void SpectrumWidget::pushDssLiveRow(DssRenderer& dss,
@@ -10252,14 +10279,11 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
         ? activeKiwiWaterfallState().live
         : m_nativeWaterfallState.live;
     QVector<float> repairedBins;
-    const QVector<float>* dssBins = &binsDbm;
-    if (!kiwiStream
-        && DssDcEdgeMath::viewStartsAtDc(m_centerMhz, m_bandwidthMhz)) {
-        repairedBins = DssDcEdgeMath::flattenLeadingSpike(binsDbm);
-        dssBins = &repairedBins;
-    }
+    const QVector<float>& dssBins = dcRepairedDssBins(
+        repairedBins, binsDbm, !kiwiStream,
+        frameCenterMhz, frameBandwidthMhz, m_centerMhz, m_bandwidthMhz);
     if (live && updateLiveSurface) {
-        pushDssLiveRow(dss, *dssBins, true);
+        pushDssLiveRow(dss, dssBins, true);
     }
 
     const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
@@ -10269,7 +10293,7 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
     const float fallbackDbm = kiwiStream
         ? kKiwiSdrWaterfallMinDbm
         : m_refLevel - m_dynamicRange;
-    retainDssHistoryRow(dss, *dssBins,
+    retainDssHistoryRow(dss, dssBins,
                         stampFrame.centerMhz, stampFrame.bandwidthMhz,
                         fallbackDbm);
 }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,5 +1,6 @@
 #include "SpectrumWidget.h"
 #include "DbmRangeTransition.h"
+#include "DssDcEdgeMath.h"
 #include "KiwiSdrTraceMath.h"
 #include "NativeWidgetTopology.h"
 #include "PanadapterRenderScheduler.h"
@@ -4336,18 +4337,26 @@ void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
                                            double frameBandwidthMhz,
                                            bool updateLiveSurface)
 {
+    QVector<float> repairedBins;
+    const QVector<float>* dssBins = &binsDbm;
+    if (!m_kiwiSdrWaterfallActive
+        && DssDcEdgeMath::viewStartsAtDc(m_centerMhz, m_bandwidthMhz)) {
+        repairedBins = DssDcEdgeMath::flattenLeadingSpike(binsDbm);
+        dssBins = &repairedBins;
+    }
+
     // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
     if (m_wfLive && updateLiveSurface) {
         if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
             const QVector<float>& previewBins = remapPreviewDssRow(
-                binsDbm, frameCenterMhz, frameBandwidthMhz);
+                *dssBins, frameCenterMhz, frameBandwidthMhz);
             pushDssLiveRow(m_dss, previewBins, false);
             ++m_frequencyPreviewRemappedDssRows;
         } else {
-            pushDssLiveRow(m_dss, binsDbm, !m_waterfallWriteVisible);
+            pushDssLiveRow(m_dss, *dssBins, !m_waterfallWriteVisible);
         }
     }
-    appendDssHistoryRow(binsDbm, frameCenterMhz, frameBandwidthMhz);
+    appendDssHistoryRow(*dssBins, frameCenterMhz, frameBandwidthMhz);
 }
 
 void SpectrumWidget::pushDssLiveRow(DssRenderer& dss,
@@ -10242,8 +10251,15 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
     const bool live = kiwiStream
         ? activeKiwiWaterfallState().live
         : m_nativeWaterfallState.live;
+    QVector<float> repairedBins;
+    const QVector<float>* dssBins = &binsDbm;
+    if (!kiwiStream
+        && DssDcEdgeMath::viewStartsAtDc(m_centerMhz, m_bandwidthMhz)) {
+        repairedBins = DssDcEdgeMath::flattenLeadingSpike(binsDbm);
+        dssBins = &repairedBins;
+    }
     if (live && updateLiveSurface) {
-        pushDssLiveRow(dss, binsDbm, true);
+        pushDssLiveRow(dss, *dssBins, true);
     }
 
     const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
@@ -10253,7 +10269,7 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
     const float fallbackDbm = kiwiStream
         ? kKiwiSdrWaterfallMinDbm
         : m_refLevel - m_dynamicRange;
-    retainDssHistoryRow(dss, binsDbm,
+    retainDssHistoryRow(dss, *dssBins,
                         stampFrame.centerMhz, stampFrame.bandwidthMhz,
                         fallbackDbm);
 }

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -1,4 +1,5 @@
 #include "gui/DssRenderer.h"
+#include "gui/DssDcEdgeMath.h"
 
 #include <QVector>
 
@@ -218,6 +219,42 @@ int testRowPlateauStats()
     return 0;
 }
 
+int testDcEdgeSpikeFlattening()
+{
+    QVector<float> captured(2255, -68.0f);
+    captured[0] = -48.0f;
+    captured[1] = -48.0f;
+    captured[2] = -56.0f;
+    captured[3] = -66.0f;
+
+    if (!AetherSDR::DssDcEdgeMath::viewStartsAtDc(0.4315127865,
+                                                  0.8630255730)) {
+        return fail("an exact zero-Hz low edge must enable DSS DC repair");
+    }
+    if (AetherSDR::DssDcEdgeMath::viewStartsAtDc(0.4485127865,
+                                                 0.8630255730)) {
+        return fail("a 17 kHz positive low edge must not enable DSS DC repair");
+    }
+
+    const QVector<float> repaired =
+        AetherSDR::DssDcEdgeMath::flattenLeadingSpike(captured);
+    for (int i = 0; i < 3; ++i) {
+        if (std::abs(repaired[i] + 68.0f) > 0.01f) {
+            return fail("captured leading DC spike bins must use the local baseline");
+        }
+    }
+    if (std::abs(repaired[3] - captured[3]) > 0.01f) {
+        return fail("DC repair must stop at the first non-outlier bin");
+    }
+
+    QVector<float> normal(2255, -68.0f);
+    normal[0] = -63.0f;
+    if (AetherSDR::DssDcEdgeMath::flattenLeadingSpike(normal) != normal) {
+        return fail("normal leading FFT variation must remain unchanged");
+    }
+    return 0;
+}
+
 } // namespace
 
 int main()
@@ -244,6 +281,9 @@ int main()
         return rc;
     }
     if (int rc = testRowPlateauStats(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testDcEdgeSpikeFlattening(); rc != 0) {
         return rc;
     }
 

--- a/tests/vita_tile_frequency_test.cpp
+++ b/tests/vita_tile_frequency_test.cpp
@@ -1,9 +1,9 @@
 // Unit tests for VITA-49 waterfall-tile frequency decoding.
 //
 // Regression coverage for the 1 GHz ceiling that blacked out the transverter
-// waterfall above 1 GHz (#3449, #1843, #1928, #2835). The decoder must pick the
-// correct encoding (VitaFrequency vs plain Hz) from the raw integer magnitude
-// with no upper frequency limit.
+// waterfall above 1 GHz (#3449, #1843, #1928, #2835), plus the near-DC
+// magnitude ambiguity that blacked out rows whose tile overhung below zero
+// (#4412). Waterfall tile frequencies are always VITA fixed point.
 
 #include "core/VitaTileFrequency.h"
 
@@ -35,17 +35,10 @@ qint64 vitaRaw(double mhz)
     return static_cast<qint64>(std::llround(mhz * 1e6 * 1048576.0));
 }
 
-// Plain-Hz raw value for a frequency in MHz.
-qint64 hzRaw(double mhz)
-{
-    return static_cast<qint64>(std::llround(mhz * 1e6));
-}
-
 } // namespace
 
 int main()
 {
-    // ── VitaFrequency encoding ───────────────────────────────────────────────
     // HF tile (well below 1 GHz) must decode correctly.
     {
         const auto f = decodeTileFrequencyMhz(vitaRaw(14.0), vitaRaw(0.001));
@@ -79,25 +72,27 @@ int main()
                    2400.0, 1e-2);
     }
 
-    // 2200 m (135 kHz) — lowest band; VitaFrequency raw still lands above the
-    // disambiguation threshold, so it must decode as VitaFrequency.
+    // 2200 m (135 kHz) must decode without a lower-frequency heuristic.
     {
         const auto f = decodeTileFrequencyMhz(vitaRaw(0.1357), vitaRaw(0.00001));
         expectNear("vita 2200m low", f.lowMhz, 0.1357, 1e-4);
     }
 
-    // ── Plain-Hz encoding ────────────────────────────────────────────────────
-    // Radios/firmware that send plain Hz must still decode correctly across the
-    // same range (the old code claimed to support this but had latent gaps).
+    // Radio tiles extend beyond the visible pan. At a zero-Hz display edge, the
+    // first tile can therefore start slightly negative. This capture comes from
+    // the #4412 FLEX-6700 reproduction: -30,112 Hz with 375 Hz bins.
     {
-        expectNear("hz 14 MHz", decodeTileFrequencyMhz(hzRaw(14.0), hzRaw(0.001)).lowMhz,
-                   14.0, 1e-6);
-        expectNear("hz 1296 MHz", decodeTileFrequencyMhz(hzRaw(1296.0), 0).lowMhz,
-                   1296.0, 1e-6);
-        expectNear("hz 2400 MHz", decodeTileFrequencyMhz(hzRaw(2400.0), 0).lowMhz,
-                   2400.0, 1e-6);
-        const auto bw = decodeTileFrequencyMhz(hzRaw(2400.0), hzRaw(0.005));
-        expectNear("hz binBw shares encoding", bw.binBwMhz, 0.005, 1e-9);
+        const auto f = decodeTileFrequencyMhz(-31574720512LL, 393216000LL);
+        expectNear("vita negative DC overhang", f.lowMhz, -0.030112, 1e-9);
+        expectNear("vita near-DC binBw", f.binBwMhz, 0.000375, 1e-12);
+    }
+
+    // The wide-span capture reached even closer to DC: -3.2 kHz with 6 kHz
+    // bins. Both values are far below the removed magnitude threshold.
+    {
+        const auto f = decodeTileFrequencyMhz(-3355443200LL, 6291456000LL);
+        expectNear("vita -3.2 kHz overhang", f.lowMhz, -0.0032, 1e-12);
+        expectNear("vita 6 kHz binBw", f.binBwMhz, 0.006, 1e-12);
     }
 
     if (g_failures == 0) {


### PR DESCRIPTION
## Summary

Fixes #4412.

Two independent near-DC defects appeared together when a native FLEX panadapter was zoomed out and panned to an exact 0 Hz low edge:

- Waterfall tile frequency fields are VITA fixed-point values. The existing magnitude heuristic misclassified the small negative tile overhang near DC as plain Hz, inflated its bin width by 2^20, and mapped the row off-screen.
- FLEX firmware 4.2.18 supplies a short leading FFT spike at an exact DC edge. It is only a few bins in 2D, but 3D Stacked Trace repeats the spike through the perspective history and makes it look like a large comb. The fix normalizes that leading outlier only in the native FLEX 3D history copy; the source 2D FFT and KiwiSDR paths remain untouched.

This is distinct from #4007 / #4371, where a 4096-bin radio-facing FFT request malformed the far-right edge. That 4095-bin request clamp remains unchanged; the #4412 captures were structurally complete 2255-bin frames.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The decoder regression uses exact values captured from the live failure, and both narrow- and wide-span DC-edge cases were verified on the reporting FLEX-6700 through the automation bridge.

## Test plan

- [x] Local build passes (`cmake --build build -j8`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local verification:

- `ctest --test-dir build --output-on-failure`: 160 passed, 1 intentionally skipped, 0 failed
- `python3 tools/check_engine_boundary.py --strict`: 0 blocking findings
- `python3 tools/check_a11y.py`: passed with the existing unrelated warning baseline
- `git diff --check`: passed
- FLEX-6700 / firmware 4.2.18.41174, RX-only automation proof:
  - 0.863025573 MHz span, exact 0 Hz low edge, 2255/2255 finite bins: detailed waterfall and no 3D comb
  - 14.745601 MHz span, exact 0 Hz low edge: detailed/scrolled waterfall and no 3D comb
  - final readback: `transmitting=false`, TX power 0

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable

Generated with OpenAI Codex.
