### PR TITLE
Fix Copy Assist Settings frameless window support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3423,6 +3423,13 @@ if (ENABLE_ASR)
     add_executable(copy_assist_settings_dialog_test
         tests/copy_assist_settings_dialog_test.cpp
         src/gui/CopyAssistSettingsDialog.cpp
+        src/gui/PersistentDialog.cpp
+        src/gui/FramelessResizer.cpp
+        src/gui/FramelessWindowTitleBar.cpp
+        src/core/ThemeManager.cpp
+        src/core/AppSettings.cpp
+        src/core/LogManager.cpp
+        src/core/AsyncLogWriter.cpp
     )
     target_include_directories(copy_assist_settings_dialog_test PRIVATE src)
     target_link_libraries(copy_assist_settings_dialog_test PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Test)

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -367,6 +367,11 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
 
 CopyAssistController::~CopyAssistController() = default;
 
+PersistentDialog* CopyAssistController::settingsDialog() const
+{
+    return m_settings;
+}
+
 void CopyAssistController::clearDecode()
 {
     m_panel->clearText();

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -8,6 +8,7 @@ namespace AetherSDR {
 class AudioEngine;
 class CopyAssistPanel;
 class CopyAssistSettingsDialog;
+class PersistentDialog;
 class AsrEngine;
 class AsrModelManager;
 class AsrAudioTap;
@@ -34,6 +35,8 @@ class CopyAssistController : public QObject {
 public:
     CopyAssistController(AudioEngine* audio, CopyAssistPanel* panel, QObject* parent = nullptr);
     ~CopyAssistController() override;
+
+    PersistentDialog* settingsDialog() const;
 
     // Clear the transcript and drop any in-progress utterance — used on retune so
     // the decode window starts fresh for the new frequency.

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -13,16 +13,13 @@
 namespace AetherSDR {
 
 CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
-    : QDialog(parent)
+    : PersistentDialog(tr("Copy Assist Settings"),
+                       QStringLiteral("CopyAssistSettingsDialogGeometry"),
+                       parent)
 {
     setObjectName(QStringLiteral("CopyAssistSettingsDialog"));
-    setWindowTitle(tr("Copy Assist Settings"));
-    setModal(false); // modeless: never blocks the main window
-    // Float above the app as a tool window (out of the taskbar), and let the
-    // window close button just hide it — the panel's ⚙ toggles it back.
-    setWindowFlags(windowFlags() | Qt::Tool);
 
-    auto* root = new QVBoxLayout(this);
+    auto* root = new QVBoxLayout(bodyWidget());
     auto* form = new QFormLayout;
     form->setLabelAlignment(Qt::AlignRight);
 

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -13,9 +13,11 @@
 namespace AetherSDR {
 
 CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
+    // Tool window: modeless helper that floats above the app and stays out of
+    // the taskbar, matching the pre-PersistentDialog behavior (#4414).
     : PersistentDialog(tr("Copy Assist Settings"),
                        QStringLiteral("CopyAssistSettingsDialogGeometry"),
-                       parent)
+                       parent, /*toolWindow=*/true)
 {
     setObjectName(QStringLiteral("CopyAssistSettingsDialog"));
 

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <QDialog>
+#include "PersistentDialog.h"
+
 #include <QString>
 
 class QCheckBox;
@@ -20,7 +21,7 @@ namespace AetherSDR {
 // lightweight offscreen unit test); the controller populates it, wires its
 // signals, and applies any theming. It mirrors the panel's old model/GPU API so
 // the controller's call sites move over unchanged.
-class CopyAssistSettingsDialog : public QDialog {
+class CopyAssistSettingsDialog : public PersistentDialog {
     Q_OBJECT
 public:
     explicit CopyAssistSettingsDialog(QWidget* parent = nullptr);

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -1391,6 +1391,7 @@ void MainWindow::showCopyAssist()
         }
         m_copyAssistApplet = applet;
         m_copyAssistController = new CopyAssistController(m_audio, applet->copyAssistPanel(), this);
+        trackPersistentDialog(m_copyAssistController->settingsDialog());
         // Seed the current frequency so the first "on start" log marker is correct
         // even before any retune fires.
         if (auto* s = activeSlice()) {

--- a/src/gui/PersistentDialog.cpp
+++ b/src/gui/PersistentDialog.cpp
@@ -13,8 +13,10 @@ namespace AetherSDR {
 
 PersistentDialog::PersistentDialog(const QString& title,
                                    const QString& geomKey,
-                                   QWidget* parent)
-    : QDialog(parent), m_geomKey(geomKey)
+                                   QWidget* parent,
+                                   bool toolWindow)
+    : QDialog(parent), m_geomKey(geomKey),
+      m_windowType(toolWindow ? Qt::Tool : Qt::Dialog)
 {
     setWindowTitle(title);
 
@@ -45,7 +47,7 @@ void PersistentDialog::setFramelessMode(bool on)
     const QRect geom = geometry();
     const bool wasVisible = isVisible();
 
-    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Dialog;
+    Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | m_windowType;
     flags.setFlag(Qt::FramelessWindowHint, on);
     setWindowFlags(flags);
     if (wasVisible) {

--- a/src/gui/PersistentDialog.h
+++ b/src/gui/PersistentDialog.h
@@ -43,9 +43,13 @@ class PersistentDialog : public QDialog {
 public:
     // title:   Window title (and frameless chrome label).
     // geomKey: AppSettings key for geometry persistence.  Empty → no persist.
+    // toolWindow: keep the window out of the taskbar and floating above its
+    //   parent (Qt::Tool) instead of the default dialog window type (Qt::Dialog).
+    //   Preserved across the runtime frameless toggle.
     explicit PersistentDialog(const QString& title,
                               const QString& geomKey,
-                              QWidget* parent = nullptr);
+                              QWidget* parent = nullptr,
+                              bool toolWindow = false);
 
     void setFramelessMode(bool on);
 
@@ -69,6 +73,10 @@ private:
     void applyBodyLayoutMargins();
 
     QString                  m_geomKey;
+    // Base window type ORed back in after every setWindowFlags() — Qt::Dialog by
+    // default, Qt::Tool for tool windows. setFramelessMode() strips the window
+    // type bits, so this is how the choice survives a runtime chrome toggle.
+    Qt::WindowType           m_windowType{Qt::Dialog};
     FramelessWindowTitleBar* m_titleBar{nullptr};
     QWidget*                 m_body{nullptr};
     bool                     m_framelessOn{false};

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -46,6 +46,10 @@ int main(int argc, char** argv)
            "saved frameless setting applies on construction");
     expect(titleBar != nullptr && titleBar->isVisible(),
            "frameless title bar is visible");
+    // The dialog is a modeless tool window (out of the taskbar, floats above the
+    // app) — must survive the frameless toggle, not just the initial build (#4414).
+    expect(dlg.windowType() == Qt::Tool,
+           "settings dialog is a tool window on construction");
 
     dlg.setFramelessMode(false);
     app.processEvents();
@@ -53,6 +57,8 @@ int main(int argc, char** argv)
            "runtime toggle restores native window chrome");
     expect(titleBar != nullptr && !titleBar->isVisible(),
            "frameless title bar hides in native mode");
+    expect(dlg.windowType() == Qt::Tool,
+           "tool window type is preserved in native mode");
 
     dlg.setFramelessMode(true);
     app.processEvents();

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -1,8 +1,11 @@
 // Offline UI test for CopyAssistSettingsDialog (RFC #4333). Runs offscreen
-// (QT_QPA_PLATFORM=offscreen) and verifies the model-tier + compute-device
+// (QT_QPA_PLATFORM=offscreen) and verifies frameless-window behavior plus the
 // selectors that moved out of CopyAssistPanel into the modeless settings dialog.
 
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
 #include "gui/CopyAssistSettingsDialog.h"
+#include "gui/FramelessWindowTitleBar.h"
 
 #include <QApplication>
 #include <QComboBox>
@@ -28,9 +31,35 @@ void expect(bool condition, const char* description)
 
 int main(int argc, char** argv)
 {
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-copy-assist-settings-test"));
     QApplication app(argc, argv);
 
+    AppSettings::instance().load();
+    AppSettings::instance().setValue(QStringLiteral("FramelessWindow"),
+                                     QStringLiteral("True"));
     CopyAssistSettingsDialog dlg;
+    dlg.show();
+    app.processEvents();
+
+    auto* titleBar = dlg.findChild<FramelessWindowTitleBar*>();
+    expect((dlg.windowFlags() & Qt::FramelessWindowHint) != 0,
+           "saved frameless setting applies on construction");
+    expect(titleBar != nullptr && titleBar->isVisible(),
+           "frameless title bar is visible");
+
+    dlg.setFramelessMode(false);
+    app.processEvents();
+    expect((dlg.windowFlags() & Qt::FramelessWindowHint) == 0,
+           "runtime toggle restores native window chrome");
+    expect(titleBar != nullptr && !titleBar->isVisible(),
+           "frameless title bar hides in native mode");
+
+    dlg.setFramelessMode(true);
+    app.processEvents();
+    expect((dlg.windowFlags() & Qt::FramelessWindowHint) != 0,
+           "runtime toggle restores frameless window chrome");
+    expect(titleBar != nullptr && titleBar->isVisible(),
+           "frameless title bar returns in frameless mode");
 
     // ---- Tier selection emits the tier id ---------------------------------
     dlg.addTier(QStringLiteral("base"), QStringLiteral("Base"));
@@ -107,6 +136,15 @@ int main(int argc, char** argv)
         expect(!thrSpy.isEmpty() && thrSpy.last().at(0).toInt() == 65,
                "speakerThresholdChanged emits percent");
     }
+
+    dlg.resize(520, 360);
+    app.processEvents();
+    dlg.close();
+    expect(!AppSettings::instance()
+                .value(QStringLiteral("CopyAssistSettingsDialogGeometry"))
+                .toString()
+                .isEmpty(),
+           "dialog geometry is persisted on close");
 
     std::printf(g_failures == 0 ? "\nCopy Assist settings dialog: ALL PASS\n"
                                 : "\nCopy Assist settings dialog: %d FAILURE(S)\n",


### PR DESCRIPTION
## Summary

Fixes #4414.

Copy Assist Settings now uses the shared `PersistentDialog` implementation, so it honors the global View → Frameless Window preference, updates live when that preference changes, preserves geometry through `AppSettings`, and uses the standard frameless title bar and resizer. The controller exposes the dialog for `MainWindow` tracking, and the focused UI test now covers saved-state initialization, both runtime toggle directions, and geometry persistence.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The fix is covered by an offline UI regression and was exercised through the agent automation bridge against the built macOS app while connected to a real FLEX-6700.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Additional verification:

- `QT_QPA_PLATFORM=offscreen ./build/copy_assist_settings_dialog_test`
- `python3 tools/check_engine_boundary.py --strict`
- `python3 tools/check_a11y.py`
- `git diff --check upstream/main...HEAD`
- Automation bridge: opened Copy Assist Settings, confirmed the custom frameless title bar was visible, toggled View → Frameless Window off and confirmed the dialog stayed open with the custom title bar hidden, then toggled it back on and confirmed the title bar returned.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [ ] Documentation updated if user-visible behavior changed
- [ ] Security-sensitive changes reference a GHSA if applicable

Generated with OpenAI Codex.
