### PR TITLE
Preserve global AetherDSP selection across modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ set(CORE_SOURCES
     src/core/AudioFormatNegotiator.cpp
     src/core/AudioDeviceNegotiator.cpp
     src/core/AudioOutputRouter.cpp
+    src/core/AetherDspModePolicy.cpp
     src/core/AudioEngine.cpp
     src/core/TxMicChannelNormalizer.cpp
     src/core/ChannelStripPresets.cpp
@@ -2864,6 +2865,15 @@ add_executable(audio_output_router_test
 target_include_directories(audio_output_router_test PRIVATE src)
 target_link_libraries(audio_output_router_test PRIVATE Qt6::Core Qt6::Multimedia)
 add_test(NAME audio_output_router_test COMMAND audio_output_router_test)
+
+# Pure mode-policy regression for global AetherDSP selection (#4415).
+add_executable(aether_dsp_mode_policy_test
+    tests/aether_dsp_mode_policy_test.cpp
+    src/core/AetherDspModePolicy.cpp
+)
+target_include_directories(aether_dsp_mode_policy_test PRIVATE src)
+target_link_libraries(aether_dsp_mode_policy_test PRIVATE Qt6::Core)
+add_test(NAME aether_dsp_mode_policy_test COMMAND aether_dsp_mode_policy_test)
 
 # Hardware-free state-machine coverage for the opt-in TX capture health
 # summary. Reproduces the Qt pull-mode Active -> Idle/full-buffer signature and

--- a/src/core/AetherDspModePolicy.cpp
+++ b/src/core/AetherDspModePolicy.cpp
@@ -42,8 +42,14 @@ AetherDspModePolicy::Action AetherDspModePolicy::update(
         m_autoDisabledMethod.clear();
     }
 
-    if (restricted && !m_userOverride && m_autoDisabledMethod.isEmpty()
-        && !enabled.isEmpty()) {
+    // Disable an audible method under restriction. Re-disable also fires when
+    // the still-remembered method is the one enabled — a restriction that recurs
+    // after a restore but before the queued enable is observed (rapid mode
+    // churn) would otherwise be skipped and leave the method processing a
+    // CW/digital stream. `!enabled.isEmpty()` already means a method is on, so
+    // there is nothing to re-emit once it is off.
+    if (restricted && !m_userOverride && !enabled.isEmpty()
+        && (m_autoDisabledMethod.isEmpty() || m_autoDisabledMethod == enabled)) {
         m_autoDisabledMethod = enabled;
         return {ActionKind::Disable, enabled};
     }

--- a/src/core/AetherDspModePolicy.cpp
+++ b/src/core/AetherDspModePolicy.cpp
@@ -1,0 +1,70 @@
+#include "AetherDspModePolicy.h"
+
+namespace AetherSDR {
+
+bool aetherDspModeRequiresDisable(QStringView mode)
+{
+    return mode == u"DIGU" || mode == u"DIGL" || mode == u"RTTY"
+        || mode == u"CW" || mode == u"CWL" || mode == u"NT";
+}
+
+bool aetherDspMixRequiresDisable(const QList<AetherDspSliceAudioState>& slices)
+{
+    for (const AetherDspSliceAudioState& slice : slices) {
+        if (!slice.muted && slice.gain > 0.0f
+            && aetherDspModeRequiresDisable(slice.mode)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+AetherDspModePolicy::Action AetherDspModePolicy::update(
+    bool restricted, QStringView enabledMethod)
+{
+    const QString enabled = enabledMethod.toString();
+    if (restricted != m_restricted) {
+        m_restricted = restricted;
+        if (!restricted) {
+            m_userOverride = false;
+            if (!m_autoDisabledMethod.isEmpty()) {
+                return {ActionKind::Enable, m_autoDisabledMethod};
+            }
+            return {};
+        }
+    }
+
+    // Keep the remembered method until the queued engine enable is observed.
+    // This also preserves the intended restart state if the app closes in the
+    // short interval between a mode change and the audio-thread callback.
+    if (!restricted && !m_autoDisabledMethod.isEmpty()
+        && enabled == m_autoDisabledMethod) {
+        m_autoDisabledMethod.clear();
+    }
+
+    if (restricted && !m_userOverride && m_autoDisabledMethod.isEmpty()
+        && !enabled.isEmpty()) {
+        m_autoDisabledMethod = enabled;
+        return {ActionKind::Disable, enabled};
+    }
+
+    return {};
+}
+
+void AetherDspModePolicy::noteUserOverride()
+{
+    if (!m_restricted) {
+        return;
+    }
+    m_userOverride = true;
+    m_autoDisabledMethod.clear();
+}
+
+QString AetherDspModePolicy::methodForPersistence(QStringView enabledMethod) const
+{
+    return m_autoDisabledMethod.isEmpty()
+        ? enabledMethod.toString()
+        : m_autoDisabledMethod;
+}
+
+} // namespace AetherSDR

--- a/src/core/AetherDspModePolicy.h
+++ b/src/core/AetherDspModePolicy.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <QStringView>
+
+namespace AetherSDR {
+
+bool aetherDspModeRequiresDisable(QStringView mode);
+
+struct AetherDspSliceAudioState {
+    QString mode;
+    bool muted{false};
+    float gain{0.0f};
+};
+
+bool aetherDspMixRequiresDisable(const QList<AetherDspSliceAudioState>& slices);
+
+class AetherDspModePolicy {
+public:
+    enum class ActionKind {
+        None,
+        Disable,
+        Enable,
+    };
+
+    struct Action {
+        ActionKind kind{ActionKind::None};
+        QString method;
+    };
+
+    Action update(bool restricted, QStringView enabledMethod);
+    void noteUserOverride();
+
+    bool restricted() const { return m_restricted; }
+    QString methodForPersistence(QStringView enabledMethod) const;
+
+private:
+    bool m_restricted{false};
+    bool m_userOverride{false};
+    QString m_autoDisabledMethod;
+};
+
+} // namespace AetherSDR

--- a/src/gui/AetherDspWidget.cpp
+++ b/src/gui/AetherDspWidget.cpp
@@ -351,6 +351,9 @@ void AetherDspWidget::onDspButtonClicked(int index, bool nowChecked)
         return;
     }
 #endif
+    static const char* kNames[NumDsps] = {"NR2", "NR4", "MNR", "DFNR", "RN2", "BNR"};
+    emit dspMethodUserToggled(QString::fromLatin1(kNames[index]), nowChecked);
+
     // Always bring this DSP's panel forward, regardless of new check
     // state — toggling off keeps the panel visible so the user can
     // re-enable from the same place.

--- a/src/gui/AetherDspWidget.h
+++ b/src/gui/AetherDspWidget.h
@@ -61,6 +61,10 @@ public:
     void setNr2Available(bool available, const QString& tooltip);
 
 signals:
+    // Explicit operator action, emitted before the engine request. Mode-based
+    // auto-disable policy uses this to let the button click win.
+    void dspMethodUserToggled(const QString& method, bool enabled);
+
     // NR2 parameter changes
     void nr2GainMaxChanged(float value);
     void nr2GainFloorChanged(float value);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1039,6 +1039,21 @@ MainWindow::MainWindow(QWidget* parent)
         AppSettings::instance().value("AudioBufferMs", "100").toInt());
     m_audio->moveToThread(m_audioThread);
     m_audioThread->start();
+    const auto updateAetherDspPolicy = [this](bool) {
+        updateAetherDspModePolicy();
+    };
+    connect(m_audio, &AudioEngine::nr2EnabledChanged,
+            this, updateAetherDspPolicy);
+    connect(m_audio, &AudioEngine::nr4EnabledChanged,
+            this, updateAetherDspPolicy);
+    connect(m_audio, &AudioEngine::mnrEnabledChanged,
+            this, updateAetherDspPolicy);
+    connect(m_audio, &AudioEngine::dfnrEnabledChanged,
+            this, updateAetherDspPolicy);
+    connect(m_audio, &AudioEngine::rn2EnabledChanged,
+            this, updateAetherDspPolicy);
+    connect(m_audio, &AudioEngine::nvAfxEnabledChanged,
+            this, updateAetherDspPolicy);
     // Start the CW-sidetone record pump on the audio thread (#2539): queued so
     // its QTimer is created + started on m_audio's thread after the move.
     QMetaObject::invokeMethod(m_audio, [ae = m_audio]() { ae->startCwRecordPump(); },
@@ -3147,12 +3162,22 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // DAX IQ channel is radio-authoritative — no client-side persistence needed.
     // The radio echoes daxiq_channel in pan status on reconnect.
 
-    // Save client-side DSP state before destructor disables them
-    Nr2SettingsModel::instance().setEnabled(m_audio->nr2Enabled());
-    s.setValue("ClientRn2Enabled", m_audio->rn2Enabled() ? "True" : "False");
-    s.setValue("ClientNr4Enabled", m_audio->nr4Enabled() ? "True" : "False");
-    s.setValue("ClientDfnrEnabled", m_audio->dfnrEnabled() ? "True" : "False");
-    s.setValue("ClientMnrEnabled", m_audio->mnrEnabled() ? "True" : "False");
+    // Persist an automatically-disabled method as enabled so quitting while an
+    // audible CW/digital slice is present does not erase the user's selection.
+    // A manual button override clears the remembered method, so actual visible
+    // state remains authoritative in that case.
+    const QString persistedAetherDspMethod =
+        m_aetherDspModePolicy.methodForPersistence(activeAetherDspMethod());
+    Nr2SettingsModel::instance().setEnabled(
+        persistedAetherDspMethod == QStringLiteral("NR2"));
+    s.setValue("ClientRn2Enabled",
+               persistedAetherDspMethod == QStringLiteral("RN2") ? "True" : "False");
+    s.setValue("ClientNr4Enabled",
+               persistedAetherDspMethod == QStringLiteral("NR4") ? "True" : "False");
+    s.setValue("ClientDfnrEnabled",
+               persistedAetherDspMethod == QStringLiteral("DFNR") ? "True" : "False");
+    s.setValue("ClientMnrEnabled",
+               persistedAetherDspMethod == QStringLiteral("MNR") ? "True" : "False");
     // BNR not persisted — requires manual enable each session
 
     s.save();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -13,6 +13,7 @@
 #include "models/AntennaGeniusModel.h"
 #include "models/SliceLinkPolicy.h"
 #include "core/AppSettings.h"
+#include "core/AetherDspModePolicy.h"
 #include "core/RadioMessageTypes.h"   // MessageSeverity for onRadioMessage slot
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
@@ -745,6 +746,7 @@ private:
     RadioModel&       m_radioModel;
     DxccColorProvider m_dxccProvider;
     AudioEngine*      m_audio{nullptr};
+    AetherDspModePolicy m_aetherDspModePolicy;
     QThread*          m_audioThread{nullptr};
     QMediaDevices*    m_audioDeviceMonitor{nullptr};
     QTimer            m_audioDeviceChangeTimer;
@@ -1216,6 +1218,9 @@ private:
     // by both the modeless AetherDspDialog and the docked ClientRxDspApplet
     // so they push every change into the engine identically.
     void wireAetherDspWidget(class AetherDspWidget* widget);
+    void updateAetherDspModePolicy();
+    QString activeAetherDspMethod() const;
+    void setAetherDspMethodEnabled(const QString& method, bool enabled);
     class ClientCompEditor* m_clientCompEditor{nullptr}; // lazy — created on first Edit… click
     class ClientGateEditor* m_clientGateEditor{nullptr}; // lazy — created on first Edit… click
     class ClientTubeEditor* m_clientTubeEditor{nullptr}; // lazy — created on first Edit… click

--- a/src/gui/MainWindow_DspApplets.cpp
+++ b/src/gui/MainWindow_DspApplets.cpp
@@ -39,6 +39,7 @@
 #include "TitleBar.h"
 #include "ClientChainApplet.h"
 #include "MainWindowHelpers.h"
+#include "core/AetherDspModePolicy.h"
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/LogManager.h"
@@ -52,6 +53,93 @@
 #include <algorithm>
 
 namespace AetherSDR {
+
+QString MainWindow::activeAetherDspMethod() const
+{
+    if (!m_audio) {
+        return {};
+    }
+    if (m_audio->nr2Enabled()) {
+        return QStringLiteral("NR2");
+    }
+    if (m_audio->nr4Enabled()) {
+        return QStringLiteral("NR4");
+    }
+    if (m_audio->mnrEnabled()) {
+        return QStringLiteral("MNR");
+    }
+    if (m_audio->dfnrEnabled()) {
+        return QStringLiteral("DFNR");
+    }
+    if (m_audio->rn2Enabled()) {
+        return QStringLiteral("RN2");
+    }
+    if (m_audio->nvAfxEnabled()) {
+        return QStringLiteral("BNR");
+    }
+    return {};
+}
+
+void MainWindow::setAetherDspMethodEnabled(const QString& method, bool enabled)
+{
+    if (!m_audio || method.isEmpty()) {
+        return;
+    }
+    if (method == QStringLiteral("NR2") && enabled) {
+        enableNr2WithWisdom();
+        return;
+    }
+
+    QMetaObject::invokeMethod(m_audio, [audio = m_audio, method, enabled]() {
+        if (method == QStringLiteral("NR2")) {
+            audio->setNr2Enabled(enabled);
+        } else if (method == QStringLiteral("NR4")) {
+            audio->setNr4Enabled(enabled);
+        } else if (method == QStringLiteral("MNR")) {
+            audio->setMnrEnabled(enabled);
+        } else if (method == QStringLiteral("DFNR")) {
+            audio->setDfnrEnabled(enabled);
+        } else if (method == QStringLiteral("RN2")) {
+            audio->setRn2Enabled(enabled);
+        } else if (method == QStringLiteral("BNR")) {
+            audio->setNvAfxEnabled(enabled);
+        }
+    });
+}
+
+void MainWindow::updateAetherDspModePolicy()
+{
+    if (!m_audio) {
+        return;
+    }
+
+    QList<AetherDspSliceAudioState> sliceStates;
+    for (SliceModel* slice : m_radioModel.slices()) {
+        if (!slice) {
+            continue;
+        }
+        sliceStates.append({
+            slice->mode(),
+            slice->audioMute(),
+            slice->audioGain(),
+        });
+    }
+
+    const bool restricted = aetherDspMixRequiresDisable(sliceStates);
+    const AetherDspModePolicy::Action action =
+        m_aetherDspModePolicy.update(restricted, activeAetherDspMethod());
+    if (action.kind == AetherDspModePolicy::ActionKind::Disable) {
+        qCInfo(lcAudio).noquote()
+            << "AetherDSP: disabling" << action.method
+            << "because an audible slice uses CW or a digital mode";
+        setAetherDspMethodEnabled(action.method, false);
+    } else if (action.kind == AetherDspModePolicy::ActionKind::Enable) {
+        qCInfo(lcAudio).noquote()
+            << "AetherDSP: restoring" << action.method
+            << "after all audible slices returned to compatible modes";
+        setAetherDspMethodEnabled(action.method, true);
+    }
+}
 
 void MainWindow::wirePooDooTiles()
 {

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1290,6 +1290,11 @@ void MainWindow::wireAetherDspWidget(AetherDspWidget* w)
 {
     if (!w || !m_audio) return;
 
+    connect(w, &AetherDspWidget::dspMethodUserToggled,
+            this, [this](const QString&, bool) {
+        m_aetherDspModePolicy.noteUserOverride();
+    });
+
     // NR2
     connect(w, &AetherDspWidget::nr2GainMaxChanged, this, [this](float v) {
         QMetaObject::invokeMethod(m_audio, [this, v]() { m_audio->setNr2GainMax(v); });
@@ -1912,23 +1917,10 @@ void MainWindow::onSliceAdded(SliceModel* s)
             refreshCwDecodeState();
             refreshRttyDecodeState();
 
-            // Disable client-side DSP in digital and CW modes — NR2/RN2/BNR
-            // corrupt digital data (#534) and suppress CW tones (#784)
-            bool disableDsp = (mode == "DIGU" || mode == "DIGL" || mode == "RTTY"
-                            || mode == "CW"   || mode == "CWL"  || mode == "NT");
-            if (disableDsp) {
-                if (m_audio->nr2Enabled())
-                    QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr2Enabled(false); });
-                if (m_audio->rn2Enabled())
-                    QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setRn2Enabled(false); });
-                if (m_audio->nr4Enabled())
-                    QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNr4Enabled(false); });
-                if (m_audio->dfnrEnabled())
-                    QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setDfnrEnabled(false); });
-                if (m_audio->nvAfxEnabled())  // AFX is a speech denoiser too
-                    QMetaObject::invokeMethod(m_audio, [this]() { m_audio->setNvAfxEnabled(false); });
-            }
         }
+        // The radio supplies one already-mixed RX stream, so the most
+        // restrictive audible slice controls the global client DSP state.
+        updateAetherDspModePolicy();
 
         // CWX/DVK availability and their F1-F12 shortcuts follow the TX slice,
         // so re-evaluate only when the TX slice changes mode (#4173).
@@ -2076,6 +2068,7 @@ void MainWindow::onSliceAdded(SliceModel* s)
     updateSplitState();
 
     refreshSliceLinkUi();
+    updateAetherDspModePolicy();
 }
 
 void MainWindow::onSliceRemoved(int id)
@@ -2270,6 +2263,7 @@ void MainWindow::onSliceRemoved(int id)
     // Removing one half of a split pair (e.g. external controller deletes the TX
     // slice) must re-derive the panadapter split-pair from the model. (#3726)
     updateSplitState();
+    updateAetherDspModePolicy();
 }
 
 void MainWindow::beginProfileLoadRadioStateWriteHold(const QString& profileType,
@@ -4696,10 +4690,12 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     });
     connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
+        updateAetherDspModePolicy();
     });
     connect(s, &SliceModel::audioMuteChanged, this, [this, s](bool) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
         syncFlexRxPanToAudioEngine();
+        updateAetherDspModePolicy();
     });
     connect(s, &SliceModel::audioPanChanged, this, [this, s](int) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);

--- a/tests/aether_dsp_mode_policy_test.cpp
+++ b/tests/aether_dsp_mode_policy_test.cpp
@@ -1,0 +1,102 @@
+#include "core/AetherDspModePolicy.h"
+
+#include <QString>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void expect(const char* name, bool condition)
+{
+    std::printf("%s %s\n", condition ? "[ OK ]" : "[FAIL]", name);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    for (const QString& mode :
+         {QStringLiteral("DIGU"), QStringLiteral("DIGL"),
+          QStringLiteral("RTTY"), QStringLiteral("CW"),
+          QStringLiteral("CWL"), QStringLiteral("NT")}) {
+        expect(qPrintable(mode + QStringLiteral(" disables AetherDSP")),
+               aetherDspModeRequiresDisable(mode));
+    }
+
+    for (const QString& mode :
+         {QStringLiteral("LSB"), QStringLiteral("USB"),
+          QStringLiteral("AM"), QStringLiteral("SAM"),
+          QStringLiteral("FM"), QStringLiteral("NFM")}) {
+        expect(qPrintable(mode + QStringLiteral(" allows AetherDSP")),
+               !aetherDspModeRequiresDisable(mode));
+    }
+
+    expect("audible CW slice restricts mixed stream",
+           aetherDspMixRequiresDisable({
+               {QStringLiteral("LSB"), false, 50.0f},
+               {QStringLiteral("CW"), false, 50.0f},
+           }));
+    expect("muted CW slice does not restrict mixed stream",
+           !aetherDspMixRequiresDisable({
+               {QStringLiteral("LSB"), false, 50.0f},
+               {QStringLiteral("CW"), true, 50.0f},
+           }));
+    expect("zero-gain digital slice does not restrict mixed stream",
+           !aetherDspMixRequiresDisable({
+               {QStringLiteral("USB"), false, 50.0f},
+               {QStringLiteral("DIGU"), false, 0.0f},
+           }));
+
+    AetherDspModePolicy policy;
+    AetherDspModePolicy::Action action =
+        policy.update(false, QStringLiteral("NR2"));
+    expect("compatible mode does not change NR2",
+           action.kind == AetherDspModePolicy::ActionKind::None);
+
+    action = policy.update(true, QStringLiteral("NR2"));
+    expect("restriction visibly disables selected method",
+           action.kind == AetherDspModePolicy::ActionKind::Disable
+               && action.method == QStringLiteral("NR2"));
+    expect("automatic disable persists original selection",
+           policy.methodForPersistence({}) == QStringLiteral("NR2"));
+
+    action = policy.update(true, {});
+    expect("continued restriction does not repeat disable",
+           action.kind == AetherDspModePolicy::ActionKind::None);
+
+    action = policy.update(false, {});
+    expect("clearing restriction restores selected method",
+           action.kind == AetherDspModePolicy::ActionKind::Enable
+               && action.method == QStringLiteral("NR2"));
+    expect("pending restore remains persistent until engine confirms it",
+           policy.methodForPersistence({}) == QStringLiteral("NR2"));
+    action = policy.update(false, QStringLiteral("NR2"));
+    expect("engine confirmation completes automatic restore",
+           action.kind == AetherDspModePolicy::ActionKind::None
+               && policy.methodForPersistence(QStringLiteral("NR2"))
+                      == QStringLiteral("NR2"));
+
+    action = policy.update(true, QStringLiteral("RN2"));
+    expect("new restriction remembers current method",
+           action.kind == AetherDspModePolicy::ActionKind::Disable
+               && action.method == QStringLiteral("RN2"));
+    policy.noteUserOverride();
+    action = policy.update(true, QStringLiteral("NR4"));
+    expect("user override wins while restriction remains",
+           action.kind == AetherDspModePolicy::ActionKind::None);
+    expect("user override replaces automatic persistence memory",
+           policy.methodForPersistence(QStringLiteral("NR4"))
+               == QStringLiteral("NR4"));
+    action = policy.update(false, QStringLiteral("NR4"));
+    expect("user override is not replaced when restriction clears",
+           action.kind == AetherDspModePolicy::ActionKind::None);
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/aether_dsp_mode_policy_test.cpp
+++ b/tests/aether_dsp_mode_policy_test.cpp
@@ -98,5 +98,20 @@ int main()
     expect("user override is not replaced when restriction clears",
            action.kind == AetherDspModePolicy::ActionKind::None);
 
+    // Restore, then a restriction that recurs BEFORE the engine confirms the
+    // enable (rapid mode churn). The restored method is still remembered, but a
+    // fresh restriction must re-disable it rather than silently skip and leave
+    // it processing a CW/digital stream.
+    AetherDspModePolicy racePolicy;
+    racePolicy.update(true, QStringLiteral("NR2"));   // disable, remembers NR2
+    action = racePolicy.update(false, {});            // restore -> Enable, keeps NR2
+    expect("race: clearing restriction emits restore",
+           action.kind == AetherDspModePolicy::ActionKind::Enable
+               && action.method == QStringLiteral("NR2"));
+    action = racePolicy.update(true, QStringLiteral("NR2")); // re-restrict before clear
+    expect("race: re-restriction before engine confirm re-disables",
+           action.kind == AetherDspModePolicy::ActionKind::Disable
+               && action.method == QStringLiteral("NR2"));
+
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes #4415.

AetherDSP processes the radio's single mixed RX audio stream, so its selected method and UI state are global rather than slice-owned.

The existing CW/digital protection was intentional (#534, #784), but it destructively disabled the active method without restoring it and could persist the forced-off state at shutdown. This change keeps that protection as visible, real engine state:

- Any audible slice in CW, CWL, DIGU, DIGL, RTTY, or NT disables the active AetherDSP method; its button visibly turns off.
- Muted and zero-gain slices do not participate, so the most restrictive audible slice wins.
- When all audible slices return to compatible modes, the method that was automatically disabled is restored and its button visibly turns on.
- A button click while a restricted slice is audible is an explicit operator override and cancels the pending automatic restore.
- If the app exits while a method is automatically disabled, the remembered selection is persisted for the next launch. A manual override persists the actual visible state.

There is no hidden background bypass: button state, engine state, and processing state remain the same.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The policy has focused coverage for mode compatibility, mixed-slice audibility, automatic disable/restore, operator override, and shutdown persistence. The rebased change also passes a clean full build and the strict engine-boundary check.

## Test plan

- [x] Rebased onto current `upstream/main`
- [x] Full local build passes (`cmake --build build -j8`)
- [x] Focused tests pass:
  - `aether_dsp_mode_policy_test`
  - `nr2_settings_model_test`
  - `spectral_nr_test`
  - `rnnoise_filter_test`
  - `mono_dsp_stereo_adapter_test`
- [x] Mixed-slice policy covers audible CW precedence plus muted and zero-gain exclusions
- [x] Local revision handed to the maintainer for acceptance testing before publication
- [x] Reproduction steps documented in #4415
- [x] `python3 tools/check_engine_boundary.py --strict`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — existing client-DSP persistence keys are reused
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter changes)
- [x] Documentation updated if user-visible behavior changed (behavior and rationale are documented in #4415 and this PR)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)

Generated with Codex.
