### PR TITLE
refactor(asr): nest Copy Assist settings under one key (Principle V)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1347,6 +1347,7 @@ if (ENABLE_ASR)
     target_sources(AetherSDR PRIVATE
         src/gui/AsrAudioTap.cpp
         src/gui/CopyAssistPanel.cpp
+        src/gui/CopyAssistSettings.cpp
         src/gui/CopyAssistSettingsDialog.cpp
         src/gui/CopyAssistController.cpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3424,6 +3424,10 @@ if (ENABLE_ASR)
     add_executable(copy_assist_settings_dialog_test
         tests/copy_assist_settings_dialog_test.cpp
         src/gui/CopyAssistSettingsDialog.cpp
+        src/gui/CopyAssistSettings.cpp
+        src/core/AppSettings.cpp
+        src/core/LogManager.cpp
+        src/core/AsyncLogWriter.cpp
     )
     target_include_directories(copy_assist_settings_dialog_test PRIVATE src)
     target_link_libraries(copy_assist_settings_dialog_test PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Test)

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -1,6 +1,7 @@
 #include "CopyAssistController.h"
 
 #include "CopyAssistPanel.h"
+#include "CopyAssistSettings.h"
 #include "CopyAssistSettingsDialog.h"
 
 #include "asr/AsrEngine.h"
@@ -9,7 +10,6 @@
 #include "asr/RemoteAsrBackend.h"
 #include "asr/SherpaOnnxBackend.h"
 #include "asr/WhisperAsrBackend.h"
-#include "core/AppSettings.h"
 #include "core/ThemeManager.h"
 #include "gui/AsrAudioTap.h"
 
@@ -49,9 +49,8 @@ float sensitivityToRms(int percent)
 
 void saveInt(const char* key, int value)
 {
-    auto& s = AetherSDR::AppSettings::instance();
-    s.setValue(QString::fromLatin1(key), QString::number(value));
-    s.save();
+    // Persists into the nested Copy Assist config object (setValue saves).
+    AetherSDR::CopyAssistSettings::setValue(QString::fromLatin1(key), QString::number(value));
 }
 
 // Turn the user's base log path into a per-day file by inserting today's date
@@ -71,15 +70,17 @@ QString datedLogPath(const QString& base)
 
 AetherSDR::RemoteAsrConfig readRemoteConfig()
 {
-    auto& s = AetherSDR::AppSettings::instance();
+    // This helper lives in the file's anonymous namespace (outside
+    // AetherSDR::), so CopyAssistSettings must be fully qualified here.
+    using AetherSDR::CopyAssistSettings::value;
     AetherSDR::RemoteAsrConfig cfg;
-    cfg.url = s.value(QStringLiteral("AsrRemoteUrl"), QString()).toString();
-    cfg.apiKey = s.value(QStringLiteral("AsrRemoteApiKey"), QString()).toString();
-    cfg.model = s.value(QStringLiteral("AsrRemoteModel"), QStringLiteral("whisper-1")).toString();
+    cfg.url = value(QStringLiteral("AsrRemoteUrl"), QString()).toString();
+    cfg.apiKey = value(QStringLiteral("AsrRemoteApiKey"), QString()).toString();
+    cfg.model = value(QStringLiteral("AsrRemoteModel"), QStringLiteral("whisper-1")).toString();
     // Share the Copy Assist language selection with the remote endpoint. "auto"
     // is left empty so an OpenAI-compatible server does its own detection rather
     // than being handed a non-standard language value.
-    const QString lang = s.value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
+    const QString lang = value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
     cfg.language = (lang == QStringLiteral("auto")) ? QString() : lang;
     return cfg;
 }
@@ -115,13 +116,13 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // Remember a previously-picked custom model so its filename shows in the list
     // (and the file-picker defaults to it) across restarts.
     m_customModelPath =
-        AppSettings::instance().value(QStringLiteral("AsrCustomModelPath"), QString()).toString();
+        CopyAssistSettings::value(QStringLiteral("AsrCustomModelPath"), QString()).toString();
     if (!m_customModelPath.isEmpty()) {
         m_settings->setTierLabel(QString::fromLatin1(kCustomTierId),
                                  tr("Custom: %1").arg(QFileInfo(m_customModelPath).fileName()));
     }
     m_sherpaModelDir =
-        AppSettings::instance().value(QStringLiteral("AsrSherpaModelDir"), QString()).toString();
+        CopyAssistSettings::value(QStringLiteral("AsrSherpaModelDir"), QString()).toString();
     if (!m_sherpaModelDir.isEmpty()) {
         m_settings->setTierLabel(QString::fromLatin1(kSherpaTierId),
                                  tr("Sherpa: %1").arg(QDir(m_sherpaModelDir).dirName()));
@@ -130,8 +131,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // Initial backend: remote if previously configured+enabled, else the
     // GPU-class model when a GPU exists, else the platform default.
     const bool remoteConfigured =
-        AppSettings::instance()
-                .value(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("False"))
+        CopyAssistSettings::value(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("False"))
                 .toString() == QStringLiteral("True")
         && !readRemoteConfig().url.isEmpty();
     if (remoteConfigured) {
@@ -178,8 +178,8 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
             m_settings->addGpuDevice(g.index, g.name);
         }
         m_settings->addGpuDevice(-1, tr("CPU")); // force-CPU option
-        int saved = AppSettings::instance()
-                        .value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0")).toString().toInt();
+        int saved =
+            CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0")).toString().toInt();
         if (saved != -1 && (saved < 0 || saved >= static_cast<int>(gpus.size()))) {
             saved = 0;
         }
@@ -199,16 +199,14 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_settings->addLanguage(lang.code, lang.name);
     }
     const QString savedLang =
-        AppSettings::instance().value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
+        CopyAssistSettings::value(QStringLiteral("AsrLanguage"), QStringLiteral("en")).toString();
     // Fall back to English for any value the model can't decode — mirrors the
     // GPU-device clamp above. This also migrates the retired "auto" sentinel and
     // any empty/stale code, keeping the dropdown and the engine in sync (a
     // lingering "auto" would otherwise still trigger detection).
     const QString effectiveLang = asrLanguageOrDefault(savedLang, languages);
     if (effectiveLang != savedLang) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrLanguage"), effectiveLang);
-        st.save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrLanguage"), effectiveLang);
     }
     m_settings->setCurrentLanguage(effectiveLang);
     // The language selector only affects whisper/remote; sherpa-onnx takes its
@@ -239,9 +237,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         }
     });
     connect(m_settings, &CopyAssistSettingsDialog::languageChanged, this, [this](const QString& code) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrLanguage"), code);
-        st.save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrLanguage"), code);
         // Language is fixed at backend construction (whisper factory arg /
         // remote config), so a change needs an engine rebuild — same as GPU.
         m_tap->setEnabled(false);
@@ -254,14 +250,12 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // Transcript-to-file logging. Restore the path first, then the checkbox, so
     // the toggle handler sees a path and doesn't prompt during restore.
     m_settings->setLogFilePath(
-        AppSettings::instance().value(QStringLiteral("AsrLogFilePath"), QString()).toString());
+        CopyAssistSettings::value(QStringLiteral("AsrLogFilePath"), QString()).toString());
     m_settings->setLogToFile(
-        AppSettings::instance().value(QStringLiteral("AsrLogToFile"), QStringLiteral("False"))
+        CopyAssistSettings::value(QStringLiteral("AsrLogToFile"), QStringLiteral("False"))
             .toString() == QStringLiteral("True"));
     connect(m_settings, &CopyAssistSettingsDialog::logToFileToggled, this, [this](bool on) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrLogToFile"), on ? QStringLiteral("True") : QStringLiteral("False"));
-        st.save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrLogToFile"), on ? QStringLiteral("True") : QStringLiteral("False"));
         if (on && m_settings->logFilePath().isEmpty()) {
             promptLogFile(); // enabling with no file yet → ask for one
         }
@@ -272,9 +266,9 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // Learned Silero VAD. Restore path then checkbox (so the toggle handler sees
     // the path and doesn't prompt during restore).
     m_settings->setVadModelPath(
-        AppSettings::instance().value(QStringLiteral("AsrVadModelPath"), QString()).toString());
+        CopyAssistSettings::value(QStringLiteral("AsrVadModelPath"), QString()).toString());
     m_settings->setUseSileroVad(
-        AppSettings::instance().value(QStringLiteral("AsrVadEnabled"), QStringLiteral("False"))
+        CopyAssistSettings::value(QStringLiteral("AsrVadEnabled"), QStringLiteral("False"))
             .toString() == QStringLiteral("True"));
     // Separate download manager for the Silero VAD model (auto-fetched + SHA-
     // verified + cached like the whisper tiers, so enabling it just works).
@@ -293,9 +287,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_settings->setUseSileroVad(false);
     });
     connect(m_settings, &CopyAssistSettingsDialog::useSileroVadToggled, this, [this](bool on) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrVadEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
-        st.save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrVadEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
         if (!m_constructed) {
             return; // restore: the initial buildEngine() already applies the VAD
         }
@@ -325,21 +317,19 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_settings->setLabelSpeakers(false);
     });
     m_settings->setSpeakerModelPath(
-        AppSettings::instance().value(QStringLiteral("AsrSpeakerModelPath"), QString()).toString());
+        CopyAssistSettings::value(QStringLiteral("AsrSpeakerModelPath"), QString()).toString());
     m_settings->setSpeakerThreshold(
-        AppSettings::instance().value(QStringLiteral("AsrSpeakerThreshold"), QStringLiteral("50"))
+        CopyAssistSettings::value(QStringLiteral("AsrSpeakerThreshold"), QStringLiteral("50"))
             .toString().toInt());
     m_settings->setLabelSpeakers(
-        AppSettings::instance().value(QStringLiteral("AsrSpeakerEnabled"), QStringLiteral("False"))
+        CopyAssistSettings::value(QStringLiteral("AsrSpeakerEnabled"), QStringLiteral("False"))
             .toString() == QStringLiteral("True"));
     connect(m_settings, &CopyAssistSettingsDialog::speakerThresholdChanged, this, [this](int pct) {
         saveInt("AsrSpeakerThreshold", pct);
         m_asr->setSpeakerThreshold(pct / 100.0f); // live, no engine rebuild
     });
     connect(m_settings, &CopyAssistSettingsDialog::labelSpeakersToggled, this, [this](bool on) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrSpeakerEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
-        st.save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerEnabled"), on ? QStringLiteral("True") : QStringLiteral("False"));
         if (!m_constructed) {
             return;
         }
@@ -376,13 +366,12 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     });
 
     // Live VAD tuning (reads m_asr at call time → survives engine rebuild).
-    auto& s = AppSettings::instance();
-    m_panel->setBufferMs(s.value(QStringLiteral("AsrDecodeBufferMs"), QStringLiteral("20000")).toString().toInt());
-    m_panel->setSensitivity(s.value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt());
-    m_panel->setSilenceMs(s.value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
-    m_panel->setFontPx(s.value(QStringLiteral("AsrFontPx"), QStringLiteral("13")).toString().toInt());
+    m_panel->setBufferMs(CopyAssistSettings::value(QStringLiteral("AsrDecodeBufferMs"), QStringLiteral("20000")).toString().toInt());
+    m_panel->setSensitivity(CopyAssistSettings::value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt());
+    m_panel->setSilenceMs(CopyAssistSettings::value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
+    m_panel->setFontPx(CopyAssistSettings::value(QStringLiteral("AsrFontPx"), QStringLiteral("13")).toString().toInt());
     m_panel->setNewlineOnSilence(
-        s.value(QStringLiteral("AsrNewlineOnSilence"), QStringLiteral("False")).toString()
+        CopyAssistSettings::value(QStringLiteral("AsrNewlineOnSilence"), QStringLiteral("False")).toString()
         == QStringLiteral("True"));
     connect(m_panel, &CopyAssistPanel::bufferMsChanged, this, [this](int ms) {
         m_asr->setDecodeBufferMs(ms);
@@ -399,10 +388,8 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     connect(m_panel, &CopyAssistPanel::fontPxChanged, this,
             [](int px) { saveInt("AsrFontPx", px); });
     connect(m_panel, &CopyAssistPanel::newlineOnSilenceChanged, this, [](bool on) {
-        auto& st = AppSettings::instance();
-        st.setValue(QStringLiteral("AsrNewlineOnSilence"),
+        CopyAssistSettings::setValue(QStringLiteral("AsrNewlineOnSilence"),
                     on ? QStringLiteral("True") : QStringLiteral("False"));
-        st.save();
     });
 
     buildEngine();
@@ -440,30 +427,29 @@ void CopyAssistController::buildEngine()
     m_tap = nullptr;
     delete m_asr;
 
-    const int gpuDevice = AppSettings::instance()
-                              .value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0"))
-                              .toString().toInt();
-    const QString language = AppSettings::instance()
-                                 .value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
-                                 .toString();
+    const int gpuDevice =
+        CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0"))
+            .toString().toInt();
+    const QString language =
+        CopyAssistSettings::value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
+            .toString();
     // Optional learned (Silero) VAD — an .onnx path enables it in the worker;
     // empty (or the toggle off) keeps the built-in energy VAD.
     AsrSegmenter::Config segConfig;
-    auto& appSettings = AppSettings::instance();
-    if (appSettings.value(QStringLiteral("AsrVadEnabled"), QStringLiteral("False")).toString()
+    if (CopyAssistSettings::value(QStringLiteral("AsrVadEnabled"), QStringLiteral("False")).toString()
         == QStringLiteral("True")) {
         segConfig.vadModelPath =
-            appSettings.value(QStringLiteral("AsrVadModelPath"), QString()).toString().toStdString();
+            CopyAssistSettings::value(QStringLiteral("AsrVadModelPath"), QString()).toString().toStdString();
     }
     // Optional speaker labeling (A/B/C…): a speaker-embedding .onnx path + the
     // cosine match threshold (stored 0–100 → 0.0–1.0).
-    if (appSettings.value(QStringLiteral("AsrSpeakerEnabled"), QStringLiteral("False")).toString()
+    if (CopyAssistSettings::value(QStringLiteral("AsrSpeakerEnabled"), QStringLiteral("False")).toString()
         == QStringLiteral("True")) {
         segConfig.speakerModelPath =
-            appSettings.value(QStringLiteral("AsrSpeakerModelPath"), QString()).toString().toStdString();
+            CopyAssistSettings::value(QStringLiteral("AsrSpeakerModelPath"), QString()).toString().toStdString();
     }
     segConfig.speakerThreshold =
-        appSettings.value(QStringLiteral("AsrSpeakerThreshold"), QStringLiteral("50"))
+        CopyAssistSettings::value(QStringLiteral("AsrSpeakerThreshold"), QStringLiteral("50"))
             .toString().toInt() / 100.0f;
     switch (m_backend) {
     case AsrBackendKind::Remote:
@@ -511,11 +497,10 @@ void CopyAssistController::buildEngine()
 
 void CopyAssistController::applyTuning()
 {
-    auto& s = AppSettings::instance();
-    m_asr->setDecodeBufferMs(s.value(QStringLiteral("AsrDecodeBufferMs"), QStringLiteral("20000")).toString().toInt());
+    m_asr->setDecodeBufferMs(CopyAssistSettings::value(QStringLiteral("AsrDecodeBufferMs"), QStringLiteral("20000")).toString().toInt());
     m_asr->setSpeechRms(sensitivityToRms(
-        s.value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt()));
-    m_asr->setSilenceDurationMs(s.value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
+        CopyAssistSettings::value(QStringLiteral("AsrSensitivity"), QStringLiteral("80")).toString().toInt()));
+    m_asr->setSilenceDurationMs(CopyAssistSettings::value(QStringLiteral("AsrSilenceMs"), QStringLiteral("300")).toString().toInt());
 }
 
 void CopyAssistController::onEnableToggled(bool on)
@@ -550,8 +535,7 @@ void CopyAssistController::onTierChanged(const QString& tierId)
             return;
         }
         m_customModelPath = path;
-        AppSettings::instance().setValue(QStringLiteral("AsrCustomModelPath"), path);
-        AppSettings::instance().save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrCustomModelPath"), path);
         m_settings->setTierLabel(QString::fromLatin1(kCustomTierId),
                                  tr("Custom: %1").arg(QFileInfo(path).fileName()));
         setBackend(AsrBackendKind::Whisper, tierId);
@@ -562,8 +546,7 @@ void CopyAssistController::onTierChanged(const QString& tierId)
             return;
         }
         m_sherpaModelDir = dir;
-        AppSettings::instance().setValue(QStringLiteral("AsrSherpaModelDir"), dir);
-        AppSettings::instance().save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrSherpaModelDir"), dir);
         m_settings->setTierLabel(QString::fromLatin1(kSherpaTierId),
                                  tr("Sherpa: %1").arg(QDir(dir).dirName()));
         setBackend(AsrBackendKind::SherpaOnnx, tierId);
@@ -611,8 +594,7 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
     // Leaving the remote backend clears the persisted auto-connect flag so the
     // next launch starts on the local engine.
     if (prev == AsrBackendKind::Remote && kind != AsrBackendKind::Remote) {
-        AppSettings::instance().setValue(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("False"));
-        AppSettings::instance().save();
+        CopyAssistSettings::setValue(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("False"));
     }
 
     // Only a change of backend kind needs a fresh engine; switching models within
@@ -701,12 +683,10 @@ bool CopyAssistController::promptRemoteConfig()
         return false;
     }
 
-    auto& s = AppSettings::instance();
-    s.setValue(QStringLiteral("AsrRemoteUrl"), urlEdit->text().trimmed());
-    s.setValue(QStringLiteral("AsrRemoteApiKey"), keyEdit->text());
-    s.setValue(QStringLiteral("AsrRemoteModel"), modelEdit->text().trimmed());
-    s.setValue(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("True"));
-    s.save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrRemoteUrl"), urlEdit->text().trimmed());
+    CopyAssistSettings::setValue(QStringLiteral("AsrRemoteApiKey"), keyEdit->text());
+    CopyAssistSettings::setValue(QStringLiteral("AsrRemoteModel"), modelEdit->text().trimmed());
+    CopyAssistSettings::setValue(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("True"));
     return true;
 }
 
@@ -750,8 +730,7 @@ void CopyAssistController::promptVadModel()
         return;
     }
     m_settings->setVadModelPath(path);
-    AppSettings::instance().setValue(QStringLiteral("AsrVadModelPath"), path);
-    AppSettings::instance().save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrVadModelPath"), path);
     rebuildEngine();
 }
 
@@ -789,8 +768,7 @@ void CopyAssistController::ensureVadModel()
 void CopyAssistController::onVadModelReady(const QString& path)
 {
     m_settings->setVadModelPath(path);
-    AppSettings::instance().setValue(QStringLiteral("AsrVadModelPath"), path);
-    AppSettings::instance().save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrVadModelPath"), path);
     rebuildEngine();
 }
 
@@ -828,8 +806,7 @@ void CopyAssistController::ensureSpeakerModel()
 void CopyAssistController::onSpeakerModelReady(const QString& path)
 {
     m_settings->setSpeakerModelPath(path);
-    AppSettings::instance().setValue(QStringLiteral("AsrSpeakerModelPath"), path);
-    AppSettings::instance().save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerModelPath"), path);
     rebuildEngine();
 }
 
@@ -849,8 +826,7 @@ void CopyAssistController::promptSpeakerModel()
         return;
     }
     m_settings->setSpeakerModelPath(path);
-    AppSettings::instance().setValue(QStringLiteral("AsrSpeakerModelPath"), path);
-    AppSettings::instance().save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrSpeakerModelPath"), path);
     rebuildEngine();
 }
 
@@ -886,8 +862,7 @@ void CopyAssistController::promptLogFile()
         return;
     }
     m_settings->setLogFilePath(path);
-    AppSettings::instance().setValue(QStringLiteral("AsrLogFilePath"), path);
-    AppSettings::instance().save();
+    CopyAssistSettings::setValue(QStringLiteral("AsrLogFilePath"), path);
 }
 
 bool CopyAssistController::appendLogRaw(const QString& text)

--- a/src/gui/CopyAssistSettings.cpp
+++ b/src/gui/CopyAssistSettings.cpp
@@ -1,0 +1,71 @@
+#include "gui/CopyAssistSettings.h"
+
+#include "core/AppSettings.h"
+
+#include <QJsonDocument>
+
+namespace AetherSDR {
+namespace CopyAssistSettings {
+
+namespace {
+
+QJsonObject readObject()
+{
+    return QJsonDocument::fromJson(
+               AppSettings::instance().value(rootKey()).toString().toUtf8())
+        .object();
+}
+
+// One-time: fold any legacy flat Asr* keys into the nested object and delete
+// them, persisting the whole change atomically. Idempotent and cheap after the
+// first run (nothing left to migrate). Guarded by a process-lifetime flag so it
+// runs at most once regardless of which accessor is hit first (the panel reads
+// AsrPanelHeight independently of the controller).
+void ensureMigrated()
+{
+    static bool done = false;
+    if (done) {
+        return;
+    }
+    done = true;
+
+    auto& s = AppSettings::instance();
+    QMap<QString, QString> present;
+    for (const QString& key : legacyFlatKeys()) {
+        if (s.contains(key)) {
+            present.insert(key, s.value(key).toString());
+        }
+    }
+    if (present.isEmpty()) {
+        return; // fresh install, or already migrated
+    }
+    const QJsonObject merged = foldLegacyKeys(present, readObject());
+    s.setValue(rootKey(), QString::fromUtf8(QJsonDocument(merged).toJson(QJsonDocument::Compact)));
+    for (auto it = present.constBegin(); it != present.constEnd(); ++it) {
+        s.remove(it.key());
+    }
+    s.save();
+}
+
+} // namespace
+
+QVariant value(const QString& field, const QVariant& defaultValue)
+{
+    ensureMigrated();
+    const QJsonObject obj = readObject();
+    const QJsonValue v = obj.value(field);
+    return v.isUndefined() ? defaultValue : QVariant(v.toString());
+}
+
+void setValue(const QString& field, const QVariant& val)
+{
+    ensureMigrated();
+    QJsonObject obj = readObject();
+    obj.insert(field, val.toString());
+    auto& s = AppSettings::instance();
+    s.setValue(rootKey(), QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+    s.save();
+}
+
+} // namespace CopyAssistSettings
+} // namespace AetherSDR

--- a/src/gui/CopyAssistSettings.cpp
+++ b/src/gui/CopyAssistSettings.cpp
@@ -27,7 +27,6 @@ void ensureMigrated()
     if (done) {
         return;
     }
-    done = true;
 
     auto& s = AppSettings::instance();
     QMap<QString, QString> present;
@@ -37,8 +36,18 @@ void ensureMigrated()
         }
     }
     if (present.isEmpty()) {
-        return; // fresh install, or already migrated
+        // Nothing to fold. Latch `done` only once we can confirm this is a real
+        // loaded state — the nested root key already exists (migration ran, or a
+        // fresh install has since written a field). If BOTH the flat keys and the
+        // root object are absent we may simply be pre-load, so leave `done` unset
+        // and retry on the next access rather than permanently skipping migration
+        // and orphaning the user's settings.
+        if (s.contains(rootKey())) {
+            done = true;
+        }
+        return;
     }
+    done = true;
     const QJsonObject merged = foldLegacyKeys(present, readObject());
     s.setValue(rootKey(), QString::fromUtf8(QJsonDocument(merged).toJson(QJsonDocument::Compact)));
     for (auto it = present.constBegin(); it != present.constEnd(); ++it) {

--- a/src/gui/CopyAssistSettings.h
+++ b/src/gui/CopyAssistSettings.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <QVariant>
+
+// Copy Assist owns its configuration as one self-contained object stored under a
+// single AppSettings root key ("CopyAssist"), per Constitution Principle V —
+// never scattered as loose flat "Asr*" keys across the shared namespace. These
+// accessors read/write fields within that nested object. Values keep the same
+// string encoding the legacy flat keys used ("True"/"False", integer strings),
+// and the nested field names are the legacy key names verbatim, so migration is
+// a value-preserving move (not a rename) and callers keep their existing
+// .toString()/.toInt()/=="True" logic. A one-time migration folds any
+// pre-existing flat keys into the object and removes them.
+namespace AetherSDR {
+namespace CopyAssistSettings {
+
+// The single AppSettings key holding the whole config object.
+inline QString rootKey()
+{
+    return QStringLiteral("CopyAssist");
+}
+
+// The legacy flat AppSettings keys folded into the object. Kept verbatim as the
+// nested field names so a value never has to be re-encoded or renamed.
+inline const QStringList& legacyFlatKeys()
+{
+    static const QStringList kKeys = {
+        QStringLiteral("AsrLanguage"),        QStringLiteral("AsrGpuDevice"),
+        QStringLiteral("AsrRemoteUrl"),       QStringLiteral("AsrRemoteApiKey"),
+        QStringLiteral("AsrRemoteModel"),     QStringLiteral("AsrRemoteEnabled"),
+        QStringLiteral("AsrCustomModelPath"), QStringLiteral("AsrSherpaModelDir"),
+        QStringLiteral("AsrLogFilePath"),     QStringLiteral("AsrLogToFile"),
+        QStringLiteral("AsrVadModelPath"),    QStringLiteral("AsrVadEnabled"),
+        QStringLiteral("AsrSpeakerModelPath"),QStringLiteral("AsrSpeakerThreshold"),
+        QStringLiteral("AsrSpeakerEnabled"),  QStringLiteral("AsrDecodeBufferMs"),
+        QStringLiteral("AsrSensitivity"),     QStringLiteral("AsrSilenceMs"),
+        QStringLiteral("AsrFontPx"),          QStringLiteral("AsrNewlineOnSilence"),
+        QStringLiteral("AsrPanelHeight"),
+    };
+    return kKeys;
+}
+
+// Pure: fold present legacy flat entries into `nested`, without overwriting a
+// field already there (a value already migrated wins). `present` maps each
+// legacy flat key that EXISTS to its stored string value. Returns the merged
+// object. Header-inline and singleton-free so it is unit testable.
+inline QJsonObject foldLegacyKeys(const QMap<QString, QString>& present, QJsonObject nested)
+{
+    for (const QString& key : legacyFlatKeys()) {
+        const auto it = present.find(key);
+        if (it != present.end() && !nested.contains(key)) {
+            nested.insert(key, it.value());
+        }
+    }
+    return nested;
+}
+
+// Field accessors on the nested object (field == the legacy key name, e.g.
+// "AsrLanguage"). Reads/writes go through AppSettings; setValue() persists.
+QVariant value(const QString& field, const QVariant& defaultValue = {});
+void setValue(const QString& field, const QVariant& val);
+
+} // namespace CopyAssistSettings
+} // namespace AetherSDR

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -11,6 +11,7 @@
 #include "SpectrumWidget.h"
 #include "Theme.h"
 #include "core/AppSettings.h"
+#include "gui/CopyAssistSettings.h"
 #include "core/SettingsHelpers.h"
 
 #include <QVBoxLayout>
@@ -592,7 +593,7 @@ CopyAssistPanel* PanadapterApplet::copyAssistPanel()
     }
 
     m_copyAssistHeight = std::clamp(
-        AppSettings::instance().value("AsrPanelHeight", "160").toString().toInt(), 60, 600);
+        CopyAssistSettings::value("AsrPanelHeight", "160").toString().toInt(), 60, 600);
 
     // Dock container styled like the CW decode panel — a top border separating
     // it from the waterfall, fixed height, resizable via a top grip.
@@ -826,7 +827,7 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
             return true;
         } else if (ev->type() == QEvent::MouseButtonRelease && m_copyAssistResizing) {
             m_copyAssistResizing = false;
-            AppSettings::instance().setValue("AsrPanelHeight",
+            CopyAssistSettings::setValue("AsrPanelHeight",
                                              QString::number(m_copyAssistHeight));
             AppSettings::instance().save();
             return true;

--- a/src/gui/PanadapterApplet.cpp
+++ b/src/gui/PanadapterApplet.cpp
@@ -827,9 +827,9 @@ bool PanadapterApplet::eventFilter(QObject* obj, QEvent* ev)
             return true;
         } else if (ev->type() == QEvent::MouseButtonRelease && m_copyAssistResizing) {
             m_copyAssistResizing = false;
+            // setValue() self-persists — no extra AppSettings::save() needed.
             CopyAssistSettings::setValue("AsrPanelHeight",
-                                             QString::number(m_copyAssistHeight));
-            AppSettings::instance().save();
+                                         QString::number(m_copyAssistHeight));
             return true;
         }
     }

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -2,12 +2,16 @@
 // (QT_QPA_PLATFORM=offscreen) and verifies the model-tier + compute-device
 // selectors that moved out of CopyAssistPanel into the modeless settings dialog.
 
+#include "TestSettingsProfile.h"
+
+#include "core/AppSettings.h"
 #include "gui/CopyAssistSettingsDialog.h"
 
 #include "asr/WhisperAsrBackend.h" // asrLanguageOrDefault (header-inline, whisper-free)
-#include "gui/CopyAssistSettings.h" // foldLegacyKeys (header-inline)
+#include "gui/CopyAssistSettings.h" // foldLegacyKeys + value/setValue
 
 #include <QApplication>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QComboBox>
 #include <QLabel>
@@ -33,7 +37,45 @@ void expect(bool condition, const char* description)
 
 int main(int argc, char** argv)
 {
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-copy-assist-migration-test"));
     QApplication app(argc, argv);
+
+    // ---- CopyAssistSettings migration: flat Asr* keys -> nested "CopyAssist" ---
+    // Exercises the stateful path (ensureMigrated + value/setValue round-trip
+    // through AppSettings), complementing the pure foldLegacyKeys checks below.
+    // Runs first so it is the first accessor call (the one-time migration).
+    {
+        auto& s = AppSettings::instance();
+        s.load();
+        // Seed a couple of legacy flat keys as an un-migrated profile would have.
+        s.setValue(QStringLiteral("AsrLanguage"), QStringLiteral("es"));
+        s.setValue(QStringLiteral("AsrPanelHeight"), QStringLiteral("240"));
+
+        expect(CopyAssistSettings::value(QStringLiteral("AsrLanguage"),
+                                         QStringLiteral("en")).toString()
+                   == QStringLiteral("es"),
+               "value() returns the migrated legacy value");
+        expect(!s.contains(QStringLiteral("AsrLanguage")),
+               "migration removes the flat AsrLanguage key");
+        expect(!s.contains(QStringLiteral("AsrPanelHeight")),
+               "migration folds every present flat key, not just the one read");
+
+        const QJsonObject nested = QJsonDocument::fromJson(
+            s.value(CopyAssistSettings::rootKey()).toString().toUtf8()).object();
+        expect(nested.value(QStringLiteral("AsrLanguage")).toString()
+                   == QStringLiteral("es"),
+               "nested CopyAssist object holds the folded language");
+        expect(nested.value(QStringLiteral("AsrPanelHeight")).toString()
+                   == QStringLiteral("240"),
+               "nested CopyAssist object holds every folded field");
+
+        CopyAssistSettings::setValue(QStringLiteral("AsrLanguage"),
+                                     QStringLiteral("fr"));
+        expect(CopyAssistSettings::value(QStringLiteral("AsrLanguage")).toString()
+                   == QStringLiteral("fr"),
+               "setValue then value round-trips through the nested object");
+    }
 
     CopyAssistSettingsDialog dlg;
 

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -5,8 +5,10 @@
 #include "gui/CopyAssistSettingsDialog.h"
 
 #include "asr/WhisperAsrBackend.h" // asrLanguageOrDefault (header-inline, whisper-free)
+#include "gui/CopyAssistSettings.h" // foldLegacyKeys (header-inline)
 
 #include <QApplication>
+#include <QJsonObject>
 #include <QComboBox>
 #include <QLabel>
 #include <QSignalSpy>
@@ -118,6 +120,36 @@ int main(int argc, char** argv)
                "asrLanguageOrDefault falls back to en for an unsupported code");
         expect(asrLanguageOrDefault(QStringLiteral("en"), {}) == QStringLiteral("en"),
                "asrLanguageOrDefault falls back to en when the list is empty");
+    }
+
+    // ---- CopyAssistSettings::foldLegacyKeys: flat -> nested migration -----
+    {
+        using namespace AetherSDR;
+        QMap<QString, QString> present;
+        present.insert(QStringLiteral("AsrLanguage"), QStringLiteral("es"));
+        present.insert(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("True"));
+        present.insert(QStringLiteral("AsrPanelHeight"), QStringLiteral("240"));
+
+        // Fold into an object that already has a migrated field: existing wins.
+        QJsonObject existing;
+        existing.insert(QStringLiteral("AsrLanguage"), QStringLiteral("fr"));
+        const QJsonObject merged =
+            CopyAssistSettings::foldLegacyKeys(present, existing);
+
+        expect(merged.value(QStringLiteral("AsrLanguage")).toString() == QStringLiteral("fr"),
+               "foldLegacyKeys does not overwrite an already-nested field");
+        expect(merged.value(QStringLiteral("AsrRemoteEnabled")).toString() == QStringLiteral("True"),
+               "foldLegacyKeys folds a present flat bool verbatim");
+        expect(merged.value(QStringLiteral("AsrPanelHeight")).toString() == QStringLiteral("240"),
+               "foldLegacyKeys folds a present flat int verbatim");
+
+        // Nothing present → object unchanged (fresh install / already migrated).
+        expect(CopyAssistSettings::foldLegacyKeys({}, QJsonObject{}).isEmpty(),
+               "foldLegacyKeys leaves an empty object empty when nothing is present");
+
+        // Every migrated key is a real, unique entry in the legacy list.
+        expect(CopyAssistSettings::legacyFlatKeys().size() == 21,
+               "legacyFlatKeys enumerates all 21 migrated Asr keys");
     }
 
     // ---- Transcript file logging: state + toggle signal -------------------


### PR DESCRIPTION
## Summary

Copy Assist stored its configuration as **21 loose flat `Asr*` keys** across the shared `AppSettings` namespace, contrary to Constitution **Principle V** ("each feature owns its configuration as one self-contained object … never scattered as loose flat keys across the shared `AppSettings` namespace"). This folds all 21 into a single nested `"CopyAssist"` object.

This is the deferred **finding #2** from the review of #4399 — flagged there as out of scope for a language-selector PR, done here as a dedicated migration.

## What it does

- **New `CopyAssistSettings` accessor** (`src/gui/CopyAssistSettings.{h,cpp}`): `value()`/`setValue()` read/write fields within a nested JSON object stored under the single `AppSettings` key `"CopyAssist"`; `setValue()` persists. Same idiom as `GpuSelector` (`"Graphics"`) and the identity/`RC28Mapping` objects.
- **One-time migration**: on first access, any pre-existing flat `Asr*` keys are folded into the object **verbatim** (no value re-encoded) and then removed, persisted atomically. The migration is idempotent and cheap after the first run, and runs on whichever accessor is hit first (the panel reads `AsrPanelHeight` independently of the controller).
- **Value-preserving by design**: the nested field names are the legacy key names verbatim (`"AsrLanguage"`, …), so migration is a *move*, not a rename — every one of the 52 call sites keeps its existing `.toString()`/`.toInt()`/`=="True"` logic. This deliberately trades a little cosmetic redundancy (the `Asr` prefix inside `CopyAssist`) for zero read/write-name-mismatch risk across the migration.
- All 52 read/write sites in `CopyAssistController.cpp` and `PanadapterApplet.cpp` now go through the accessor; the redundant `AppSettings` saves (`setValue` self-persists) and the now-unused include are dropped.

## Migrated keys (21)

`AsrLanguage`, `AsrGpuDevice`, `AsrRemoteUrl`, `AsrRemoteApiKey`, `AsrRemoteModel`, `AsrRemoteEnabled`, `AsrCustomModelPath`, `AsrSherpaModelDir`, `AsrLogFilePath`, `AsrLogToFile`, `AsrVadModelPath`, `AsrVadEnabled`, `AsrSpeakerModelPath`, `AsrSpeakerThreshold`, `AsrSpeakerEnabled`, `AsrDecodeBufferMs`, `AsrSensitivity`, `AsrSilenceMs`, `AsrFontPx`, `AsrNewlineOnSilence`, `AsrPanelHeight`.

## Constitution principle honored

**Principle V — Each Feature Owns Its Configuration As A Single Object.** The whole Copy Assist config is now one defaultable, atomically-written object under one root key; the legacy flat keys are migrated and removed rather than left grandfathered.

## Testing

- `copy_assist_settings_dialog_test` extended with migration coverage on the pure, header-inline `foldLegacyKeys` / `legacyFlatKeys` (folds present flat entries; does not overwrite an already-nested field; leaves an empty object empty; enumerates all 21 keys). **All cases pass.**
- Full app builds clean (`ninja AetherSDR`) on Linux/RelWithDebInfo; the settings dialog test builds + passes.
- Existing users' saved `Asr*` values are preserved by the verbatim fold-and-remove migration; fresh installs get defaults.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls (Principle V) — this PR *removes* the flat keys and adds none
- [x] Code is clean-room (Principle IV)
- [x] Documentation updated if user-visible behavior changed — none (settings values and defaults are unchanged; only their storage layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)