### PR TITLE
Gate status-bar TX timer during tune carriers

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1977,11 +1977,11 @@ proves the co-hold path.
 Read the status-bar transmit timer's state. The timer sits just left of the
 **PC Audio** button and runs **only** for operator-driven phone/data transmits
 — MOX, local/hardware PTT, footswitch, VOX — and deliberately **not** for
-TCI-hardware or DAX transmits (external-app keying paths) **nor CW** (break-in/
-QSK toggles the interlock per element, which would thrash a wall-clock timer).
-All three exclusions are gated in `RadioModel::operatorTransmitChanged`. It is
-hidden when idle; on unkey it holds the final elapsed reading for 15 s, then
-fades out.
+TUNE/two-tone carriers, internal ATU tuning, TCI-hardware or DAX transmits
+(external-app keying paths), **nor CW** (break-in/QSK toggles the interlock per
+element, which would thrash a wall-clock timer). These exclusions are gated in
+`RadioModel::operatorTransmitChanged`. It is hidden when idle; on unkey it
+holds the final elapsed reading for 15 s, then fades out.
 
 ```json
 → {"cmd":"get","model":"txtimer"}
@@ -1996,8 +1996,8 @@ flight), `elapsedMs` / `text` (live while running, frozen at unkey), `opacity`
 it: `get txtimer running` → `{"value":true}`. Assertion shapes: after a 1 W
 dummy-load MOX key, `running=true` + `elapsedMs` climbing; after unkey,
 `running=false`, `holding=true`, `text` frozen; ~15 s later `fading=true` then
-`visible=false`. A DAX, TCI, or CW transmit must leave `visible=false`
-throughout.
+`visible=false`. A TUNE, two-tone, ATU, DAX, TCI, or CW transmit must leave
+`visible=false` throughout.
 
 ### `tci`
 In-process TCI **client** simulator. Connects to this app's own TCI server

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -810,6 +810,15 @@ RadioModel::RadioModel(QObject* parent)
             if (transmitStartBlockedByInhibit(QStringLiteral("tune-start"))) {
                 return;
             }
+            if (cmd == "atu start") {
+                // Attribute the whole interlock cycle before dispatch. ATU and
+                // interlock statuses are independent asynchronous planes, so
+                // gating only on TUNE_IN_PROGRESS can briefly start (or
+                // prematurely resume) the operator-over timer when those
+                // statuses arrive out of order.
+                m_transmitModel.noteActivePttSource(
+                    TransmitModel::PttSource::Atu);
+            }
             armInterlockNotification(m_pendingTransmitPreflightSource);
             m_pendingTransmitPreflightSource = TransmitModel::PttSource::Mox;
             applyTuneInhibit();
@@ -904,7 +913,7 @@ RadioModel::RadioModel(QObject* parent)
 
     // Drive the status-bar operator TX timer from actual transmit-state edges
     // (optimistic MOX/PTT plus interlock-driven VOX/footswitch/CW). The source
-    // gate inside updateOperatorTransmit() keeps TCI/DAX transmits out.
+    // gate inside updateOperatorTransmit() keeps TUNE/ATU/TCI/DAX transmits out.
     connect(&m_transmitModel, &TransmitModel::transmittingChanged, this,
             [this](bool) { updateOperatorTransmit(); });
     // Also recompute when the TX-slice mode changes (phone↔CW) or first resolves
@@ -2148,8 +2157,8 @@ void RadioModel::updateOperatorTransmit()
     // On a full unkey, forget the remembered PTT source. A subsequent
     // hardware-mic PTT, footswitch, or VOX key never flows through a
     // source-bearing entry point (the radio just starts transmitting), so
-    // without this reset it would inherit a stale TCI/DAX tag and be wrongly
-    // excluded from the operator TX timer.
+    // without this reset it would inherit a stale ATU/TCI/DAX tag and be
+    // wrongly excluded from the operator TX timer.
     if (!m_transmitModel.isTransmitting()
         && m_transmitModel.activePttSource() != TransmitModel::PttSource::Mox) {
         m_transmitModel.noteActivePttSource(TransmitModel::PttSource::Mox);
@@ -2169,11 +2178,15 @@ void RadioModel::updateOperatorTransmit()
     const QString txMode = (ts ? ts->mode() : m_transmitModel.txSliceMode())
                                .trimmed().toUpper();
     const bool modeIsCw = txMode.startsWith(QStringLiteral("CW"));
+    const bool sourceIsTuneCarrier =
+        src == TransmitModel::PttSource::Tune
+        || src == TransmitModel::PttSource::Atu;
     const bool op = RadioStatusOwnership::operatorTransmitActive(
         m_transmitModel.isTransmitting(),
         m_daxTxActive,
         src == TransmitModel::PttSource::TciHardware,
         src == TransmitModel::PttSource::Dax,
+        sourceIsTuneCarrier,
         modeIsCw);
 
     if (op == m_operatorTransmitting)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -816,6 +816,13 @@ RadioModel::RadioModel(QObject* parent)
                 // gating only on TUNE_IN_PROGRESS can briefly start (or
                 // prematurely resume) the operator-over timer when those
                 // statuses arrive out of order.
+                //
+                // Tag here, AFTER the inhibit gate above, and NOT in
+                // TransmitModel::atuStart() (which — unlike startTune — has no
+                // runPttPreflight of its own). Tagging before the gate would
+                // leave a stale Atu source on a blocked ATU, which a following
+                // bare hardware/VOX key (no source-bearing entry point) would
+                // inherit and be wrongly excluded from the operator TX timer.
                 m_transmitModel.noteActivePttSource(
                     TransmitModel::PttSource::Atu);
             }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -637,11 +637,11 @@ signals:
     // Raw interlock TX state (regardless of ownership — for DAX passthrough).
     void radioTransmittingChanged(bool transmitting);
     // Operator-driven RF transmit: true while THIS seat is keyed by the local
-    // operator in a phone/data mode (MOX, local/hardware PTT, footswitch, VOX,
-    // tune) and false otherwise. Deliberately excludes TCI-hardware and DAX
-    // transmits (external-app keying paths, not the operator on the mic) and CW
-    // (break-in/QSK per-element keying would thrash a wall-clock timer). Drives
-    // the status-bar TX timer.
+    // operator in a phone/data mode (MOX, local/hardware PTT, footswitch, VOX)
+    // and false otherwise. Deliberately excludes TUNE/two-tone/ATU carriers,
+    // TCI-hardware/DAX transmits (external-app keying paths, not the operator
+    // on the mic), and CW (break-in/QSK per-element keying would thrash a
+    // wall-clock timer). Drives the status-bar TX timer.
     void operatorTransmitChanged(bool active);
     // Short operator-facing interlock warnings for the panadapter overlay.
     // `key` is the stable, translation-invariant dedup key (e.g. "radio:...",
@@ -947,7 +947,7 @@ private:
     bool        m_cwxDrainArmed{false}; // CWX drain-release latch, immune to interlock flicker (#3949)
     bool        m_txAudioGate{false}; // actual TX audio gate state
     bool        m_radioTransmitting{false}; // raw interlock TX state, any owner
-    bool        m_operatorTransmitting{false}; // owned MOX/PTT/VOX (not TCI/DAX)
+    bool        m_operatorTransmitting{false}; // owned MOX/PTT/VOX (not tune/ATU/TCI/DAX)
     QString     m_lastInterlockNotificationKey;
     qint64      m_lastInterlockNotificationMs{0};
     qint64      m_interlockNotificationArmedUntilMs{0};

--- a/src/models/RadioStatusOwnership.h
+++ b/src/models/RadioStatusOwnership.h
@@ -112,8 +112,8 @@ inline bool interlockKeepsLocalTxOn(bool txOwnedByUs, bool txRequested,
 }
 
 // Whether the *local operator* is the one keying the transmitter — mic/PTT,
-// MOX, VOX, footswitch, tune — as opposed to a TCI-hardware or DAX
-// (external-app) transmit. Drives the status-bar TX timer.
+// MOX, VOX, or footswitch — as opposed to a TUNE/two-tone/ATU carrier or a
+// TCI-hardware/DAX (external-app) transmit. Drives the status-bar TX timer.
 //
 // `transmitting` is TransmitModel::isTransmitting(), which the interlock handler
 // already forces false for DAX and other-client TX, so it captures every owned
@@ -122,16 +122,20 @@ inline bool interlockKeepsLocalTxOn(bool txOwnedByUs, bool txRequested,
 // disambiguates them from the remembered PTT source and passes the flags here.
 // `daxTxActive` is a belt-and-suspenders guard for the optimistic DAX key edge.
 //
-// `modeIsCw` excludes CW entirely: break-in/QSK keying toggles the interlock
-// (and thus transmittingChanged) per element, which would restart the timer
-// from 0:00 on every dit/dah and never show a meaningful over. A wall-clock
-// over-timer isn't the right readout for CW, so we simply never show it there.
+// `sourceIsTuneCarrier` excludes both `transmit tune 1` variants and `atu
+// start`. Their source is captured before dispatch, so it covers the whole
+// interlock cycle without depending on the ordering of transmit/ATU and
+// interlock status. `modeIsCw` excludes CW entirely: break-in/QSK keying
+// toggles the interlock (and thus transmittingChanged) per element, which
+// would restart the timer from 0:00 on every dit/dah and never show a
+// meaningful over. A wall-clock over-timer isn't the right readout for CW, so
+// we simply never show it there.
 inline bool operatorTransmitActive(bool transmitting, bool daxTxActive,
                                    bool sourceIsTciHardware, bool sourceIsDax,
-                                   bool modeIsCw)
+                                   bool sourceIsTuneCarrier, bool modeIsCw)
 {
     return transmitting && !daxTxActive && !sourceIsTciHardware && !sourceIsDax
-           && !modeIsCw;
+           && !sourceIsTuneCarrier && !modeIsCw;
 }
 
 enum class OwnedStatusAction {

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -268,10 +268,9 @@ void TransmitModel::startTune(PttSource source)
         return;
 
     // Tag the initiating source so the status-bar operator TX timer can exclude
-    // a TCI/DAX-initiated tune (the radio reports both as source=SW). An
-    // operator tune (source=Tune) is neither TCI nor DAX, so it still shows the
-    // timer. Without this, an external-app tune inherits the stale Mox tag and
-    // wrongly runs the "operator-only" timer. (#4131 review)
+    // local TUNE carriers as well as TCI/DAX-initiated tune (the radio reports
+    // every software path as source=SW). Without this, tune inherits the stale
+    // Mox tag and wrongly runs the operator-only timer. (#4131 review)
     m_activePttSource = source;
 
     emit commandReady("transmit tune 1");
@@ -282,7 +281,7 @@ void TransmitModel::startTwoToneTune(PttSource source)
     if (!runPttPreflight(source, false))
         return;
 
-    m_activePttSource = source;   // exclude TCI/DAX-initiated tune (see startTune, #4131)
+    m_activePttSource = source;   // exclude local/TCI/DAX tune (see startTune, #4131)
     setTuneMode("two_tone");
     emit commandReady("transmit tune 1");
 }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -155,13 +155,15 @@ public:
         Footswitch   = 2,   // future: serial-PTT or other hardware path
         Tune         = 3,   // local TUNE/two-tone carrier
         Dax          = 4,   // external digital-audio PTT path
+        Atu          = 5,   // internal automatic-tuner carrier
     };
 
     // Source of the most recently *initiated* key-up. Set by the keying entry
-    // points (requestPttOn / RadioModel::setTransmit) so downstream consumers
-    // can tell an operator-driven MOX/PTT/VOX transmit from a TCI-hardware or
-    // DAX-triggered one — the radio interlock reports both local software paths
-    // as source=SW, so the distinction has to be captured here at the funnel.
+    // points (requestPttOn / RadioModel::setTransmit / RadioModel's ATU command
+    // gate) so downstream consumers can tell an operator-driven MOX/PTT/VOX
+    // transmit from an ATU/TCI-hardware/DAX-triggered one — the radio interlock
+    // reports these software paths as source=SW, so the distinction has to be
+    // captured here at the funnel.
     // Resets to Mox on full unkey so a subsequent hardware/VOX key (which never
     // flows through a source-bearing entry point) is treated as operator TX.
     PttSource activePttSource() const { return m_activePttSource; }

--- a/tests/radio_status_ownership_test.cpp
+++ b/tests/radio_status_ownership_test.cpp
@@ -88,35 +88,41 @@ void testInterlockTxGate()
 
 void testOperatorTransmitGate()
 {
-    // args: (transmitting, daxTxActive, sourceIsTciHardware, sourceIsDax, modeIsCw)
+    // args: (transmitting, daxTxActive, sourceIsTciHardware, sourceIsDax,
+    //        sourceIsTuneCarrier, modeIsCw)
 
-    // Operator MOX/PTT/VOX/tune in a phone mode: transmitting, no DAX,
-    // source not TCI/DAX, not CW.
-    check(operatorTransmitActive(true, false, false, false, false),
+    // Operator MOX/PTT/VOX in a phone mode: transmitting, no DAX,
+    // source not TCI/DAX/tune, not CW.
+    check(operatorTransmitActive(true, false, false, false, false, false),
           "operator MOX/PTT keying runs the TX timer");
 
     // Idle: never active.
-    check(!operatorTransmitActive(false, false, false, false, false),
+    check(!operatorTransmitActive(false, false, false, false, false, false),
           "no transmit -> timer off");
 
     // TCI-hardware PTT is excluded even though it is an owned SW transmit.
-    check(!operatorTransmitActive(true, false, true, false, false),
+    check(!operatorTransmitActive(true, false, true, false, false, false),
           "TCI-hardware PTT does NOT run the timer");
 
     // DAX is excluded — both by the source flag and the daxTxActive guard.
-    check(!operatorTransmitActive(true, false, false, true, false),
+    check(!operatorTransmitActive(true, false, false, true, false, false),
           "DAX transmit (source) does NOT run the timer");
-    check(!operatorTransmitActive(true, true, false, false, false),
+    check(!operatorTransmitActive(true, true, false, false, false, false),
           "DAX transmit (active guard) does NOT run the timer");
 
     // Belt-and-suspenders: an in-flight DAX key that momentarily shows
     // transmitting must still be excluded.
-    check(!operatorTransmitActive(true, true, false, true, false),
+    check(!operatorTransmitActive(true, true, false, true, false, false),
           "optimistic DAX key edge stays excluded");
+
+    // TUNE, two-tone, and the internal ATU all use a tune-carrier source. They
+    // are equipment setup/test carriers rather than operator overs.
+    check(!operatorTransmitActive(true, false, false, false, true, false),
+          "TUNE/two-tone/ATU carriers do NOT run the timer");
 
     // CW is excluded entirely — break-in/QSK per-element keying would thrash the
     // wall-clock timer, so it never displays for CW even on an owned MOX key.
-    check(!operatorTransmitActive(true, false, false, false, true),
+    check(!operatorTransmitActive(true, false, false, false, false, true),
           "CW mode does NOT run the timer");
 }
 

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -47,8 +47,9 @@ int main(int argc, char** argv)
     ok &= expect(commands == QStringList({
                      "transmit set tune_mode=two_tone",
                      "transmit tune 1",
-                 }),
-                 "two-tone tune sets mode before starting tune");
+                 })
+                     && tx.activePttSource() == TransmitModel::PttSource::Tune,
+                 "two-tone tune sets mode and tags the tune source before starting");
 
     tx.applyChanges(td([](TransmitDelta& d){ d.tune = true; }));
     commands.clear();
@@ -67,6 +68,12 @@ int main(int argc, char** argv)
                      "transmit tune 1",
                  }),
                  "two-tone tune toggle starts two-tone when not tuning");
+
+    commands.clear();
+    tx.startTune();
+    ok &= expect(commands == QStringList({"transmit tune 1"})
+                     && tx.activePttSource() == TransmitModel::PttSource::Tune,
+                 "single-tone tune tags the tune source before starting");
 
     commands.clear();
     tx.setTuneMode("single_tone");


### PR DESCRIPTION
## Summary

- keep the status-bar transmission timer hidden during internal ATU tuning
- apply the same gate to single-tone TUNE and two-tone TUNE carriers
- preserve timer behavior for operator-driven MOX, PTT, footswitch, and VOX transmissions

## Root cause

The radio reports internal ATU, TUNE, and other local software transmit paths through the same interlock `source=SW` state. The timer ownership gate excluded TCI, DAX, and CW transmissions, but it did not distinguish setup/test carriers from operator-driven transmissions.

This change records an explicit ATU source before dispatching `atu start`, avoiding races between the independent ATU and interlock status streams. Both TUNE entry points already record `PttSource::Tune`; the ownership gate now excludes that source alongside the new ATU source.

## User impact

Running the internal tuner, pressing TUNE, or starting two-tone TUNE no longer creates a misleading 3–5 second transmission reading in the status bar. Normal operator transmission timing is unchanged.

## Validation

- user confirmed the internal ATU timer behavior against the radio
- built `AetherSDR` successfully with 8 cores
- passed `radio_status_ownership_test`
- passed `transmit_model_test`
- passed `transmit_inhibit_policy_test`
- passed `atu_pretune_centers_test`
- passed `aetherd_transmit_decode_test`
- passed `tools/check_engine_boundary.py --strict` with zero blocking findings

Screenshots are not applicable because this is a transient-state correctness fix with no new visual surface.

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
