### PR TITLE
Smooth waterfall and 3D FFT motion for Flex and KiwiSDR

### DIFF
--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -1,14 +1,13 @@
 #version 440
 
-// Companion to dss_mesh.vert. Fill vertices (edge >= 0) are coloured by a
-// floor->peak palette LUT with a vertical gradient (ridge = signal colour,
-// floor = floor colour) and hazed toward the background with depth. Outline
-// vertices (edge < 0) draw a dim, depth-faded hairline along each ridge — the
-// per-row trace line.
+// Companion to dss_mesh.vert. Fill vertices (edge >= 0) draw the original
+// full-height coloured curtains on phase-stable geometry. Outline vertices
+// (edge < 0) draw the retained traces.
 
 layout(location = 0) in float vLut;
 layout(location = 1) in float vDepth;
 layout(location = 2) in float vEdge;
+layout(location = 3) in float vBoundaryFade;
 
 layout(std140, binding = 0) uniform U {
     float rowOffset;
@@ -23,6 +22,14 @@ layout(std140, binding = 0) uniform U {
     float frequencyScale;
     float frequencyOffset;
     float frequencyPreview;
+    float scrollProgressRows;
+    float texRows;
+    float scrollDistanceRows;
+    float colorRangeDb;
+    float validRows;
+    float padding17;
+    float padding18;
+    float padding19;
     vec4  bgFill;
 };
 
@@ -35,14 +42,15 @@ void main()
     float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
 
     if (vEdge < -0.5) {
-        // Dim trace outline — light hairline, brighter at the front, fading back.
-        vec3  oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
-        float a  = 0.12 + 0.5 * fade;
+        // Original neutral ridge highlight over the amplitude-coloured curtain.
+        vec3 oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
+        float a = (0.12 + 0.5 * fade) * vBoundaryFade;
         fragColor = vec4(oc, a);
         return;
     }
 
     vec3 c = texture(paletteLut, vec2(clamp(vLut, 0.0, 1.0), 0.5)).rgb;
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
+    c = mix(bgFill.rgb, c, vBoundaryFade);
     fragColor = vec4(c, 1.0);
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -3,8 +3,10 @@
 // 3DSS GPU height-map mesh. Each vertex carries its grid position (u = column,
 // v = row/depth) and an edge tag. The height comes from a ring-buffered dBm
 // texture; geometry is a receding perspective trapezoid built entirely on the
-// GPU, so pan/zoom never rebuild any vertices. Outputs NDC directly (matching
-// spectrum.vert); occlusion is by back-to-front draw order, not a depth test.
+// GPU, so pan/zoom never rebuild any vertices. The original per-row coloured
+// curtains and their outlines stay on a fixed perspective grid and interpolate
+// between adjacent history rows, avoiding shimmer from translating dense
+// geometry across screen pixels. Outputs NDC directly (matching spectrum.vert).
 
 layout(location = 0) in vec3 inVert;   // x = u [0,1] col, y = v [0,1) row(0=front), z = edge
 
@@ -21,6 +23,14 @@ layout(std140, binding = 0) uniform U {
     float frequencyScale;     // target bandwidth / retained-frame bandwidth
     float frequencyOffset;    // (target centre - retained centre) / retained bandwidth
     float frequencyPreview;   // non-zero while the interaction preview is active
+    float scrollProgressRows; // continuous movement toward the back between rows
+    float texRows;
+    float scrollDistanceRows; // rows delivered by the current radio tile
+    float colorRangeDb;       // stable colour aperture; independent of height range
+    float validRows;
+    float padding17;
+    float padding18;
+    float padding19;
     vec4  bgFill;             // plot background colour (for haze)
 };
 
@@ -29,45 +39,88 @@ layout(binding = 1) uniform sampler2D heightTex;  // R16F, dBm, ring-buffered ro
 layout(location = 0) out float vLut;    // palette lookup coord (floor->peak gradient)
 layout(location = 1) out float vDepth;  // row depth 0..1 for haze/fade
 layout(location = 2) out float vEdge;   // edge tag passthrough
+layout(location = 3) out float vBoundaryFade;
+
+float sampleHistoryDbm(float texU, float historyV, float rows,
+                       float remainingRows)
+{
+    float sampleAge = historyV * rows + remainingRows;
+    float cappedValidRows = clamp(validRows, 0.0, rows);
+    float age0 = max(floor(sampleAge), 0.0);
+    float age1 = age0 + 1.0;
+    float ageBlend = fract(sampleAge);
+    float textureAge0 = clamp(age0, 0.0, rows - 1.0);
+    float textureAge1 = clamp(age1, 0.0, rows - 1.0);
+    float dbm0 = texture(
+        heightTex, vec2(texU, fract(rowOffset + textureAge0 / rows))).r;
+    float dbm1 = texture(
+        heightTex, vec2(texU, fract(rowOffset + textureAge1 / rows))).r;
+    // A partially filled history has no row beyond its oldest valid sample.
+    // Blend that missing neighbour from the floor instead of clamping it to a
+    // duplicate of the oldest row, which made the startup boundary hop.
+    dbm0 = mix(floorDbm, dbm0, 1.0 - step(cappedValidRows, age0));
+    dbm1 = mix(floorDbm, dbm1, 1.0 - step(cappedValidRows, age1));
+    return mix(dbm0, dbm1, ageBlend);
+}
 
 void main()
 {
-    float u    = inVert.x;
-    float v    = inVert.y;     // 0 = front/newest .. ~1 = back/oldest
-    float edge = inVert.z;     // 0 = ridge, 1 = floor, -1 = outline
+    float u = inVert.x;
+    float sourceV = inVert.y;  // discrete retained-row age
+    float rows = max(texRows, 1.0);
+    float distanceRows = max(scrollDistanceRows, 1.0);
+    float edge = inVert.z;     // -1 = outline, 0 = ridge, 1 = curtain floor
+    // Both passes use stable geometry. Motion comes from interpolating retained
+    // row samples, like the phase-stable waterfall reconstruction.
+    float geometryV = sourceV;
 
     // Sample texel CENTRES on both axes so Nearest filtering can't pick up the
     // neighbouring row/column. rowOffset already carries the row half-texel; the
     // column maps geometry u in [0,1] onto centre (u*(cols-1)+0.5)/cols.
-    float texY = fract(rowOffset + v);
     float sourceU = 0.5 + frequencyOffset + (u - 0.5) * frequencyScale;
     bool outsidePreview = frequencyPreview > 0.5
         && (sourceU < 0.0 || sourceU > 1.0);
     float texU = (texCols > 1.0)
         ? (sourceU * (texCols - 1.0) + 0.5) / texCols
         : 0.5;
+    float remainingRows = clamp(
+        distanceRows - scrollProgressRows, 0.0, distanceRows);
+    // The head advances immediately when a row arrives. At phase 0, sample the
+    // former row at age+1; over the interval morph toward the new row at age.
     float dbm = outsidePreview
         ? floorDbm
-        : texture(heightTex, vec2(texU, texY)).r;
+        : sampleHistoryDbm(texU, sourceV, rows, remainingRows);
     // Linear strength drives COLOUR (LUT[sLin] = dbmToRgb(floor+sLin*range),
     // matching the CPU path); the zCurve lift applies to HEIGHT only.
     float sLin = clamp((dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
     float sH   = pow(sLin, max(zCurve, 0.05));   // non-linear Z: lift floor band
+    float colorStrength = clamp(
+        (dbm - floorDbm) / max(colorRangeDb, 1.0), 0.0, 1.0);
 
     // Receding perspective trapezoid in plot space [0,1] (0,0 = top-left).
-    float w     = mix(1.0, backWidthFrac, v);          // narrows with depth
+    float w = mix(1.0, backWidthFrac, geometryV);      // narrows with depth
     float plotX = 0.5 + (u - 0.5) * w;
-    float baseY = mix(1.0, 1.0 - depthSpanFrac, v);    // baseline rises with depth
+    float baseY = mix(1.0, 1.0 - depthSpanFrac,
+                      geometryV);                       // baseline rises with depth
     float ridge = sH * frontMaxRidgeFrac * w;          // far ridges shorter
     float topY  = baseY - ridge;                       // up = smaller y
-    float plotY = (edge > 0.5) ? 1.0 : topY;           // floor edge -> plot bottom
+    float plotY = edge > 0.5 ? 1.0 : topY;
 
     gl_Position = vec4(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0, 0.0, 1.0);
 
-    // Ridge carries the full signal colour; the floor edge keeps a dimmer share
-    // of it (not pure palette[0]) so the whole curtain stays tinted by the
-    // colormap instead of fading to black between the white trace lines.
-    vLut   = (edge > 0.5) ? sLin * 0.6 : sLin;
-    vDepth = v;
+    // Restore the original curtain palette mapping: ridge = full amplitude
+    // colour, floor = a dimmer share of that same amplitude colour.
+    vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
+    vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
+    // During startup, the newly exposed oldest slot fades in continuously over
+    // the row interval. Keep the eviction fade anchored at the physical back
+    // of the full history so it does not move one discrete slot per arrival.
+    float sampleAge = sourceV * rows + remainingRows;
+    float historyAvailability = clamp(validRows - sampleAge, 0.0, 1.0);
+    float backFadeStart = max(0.0, (rows - 6.0) / rows);
+    float backFadeEnd = max(backFadeStart, (rows - 1.0) / rows);
+    float backBoundaryFade =
+        1.0 - smoothstep(backFadeStart, backFadeEnd, geometryV);
+    vBoundaryFade = historyAvailability * backBoundaryFade;
 }

--- a/resources/shaders/texturedquad.frag
+++ b/resources/shaders/texturedquad.frag
@@ -10,11 +10,47 @@ layout(std140, binding = 0) uniform Uniforms {
     float padding1;
     float padding2;
     float padding3;
+    float scrollSampleOffsetUnit;
+    float texelHeightUnit;
+    float padding6;
+    float padding7;
 };
 
 void main()
 {
-    // Apply ring buffer offset per-pixel (not per-vertex, to avoid fract() interpolation issue)
-    vec2 uv = vec2(v_uv.x, fract(v_uv.y + rowOffset));
-    fragColor = texture(tex, uv);
+    // Do not let the reconstruction kernel cross the logical bottom edge and
+    // wrap the newest ring row into a one-pixel "echo" beneath unfilled data.
+    if (v_uv.y >= 1.0 - texelHeightUnit) {
+        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
+        return;
+    }
+
+    // rowOffset advances as soon as a row arrives. The residual one-row sample
+    // offset starts at the prior ring position and closes to zero over the row
+    // interval, preserving the previous frame at the handoff.
+    float physicalY = fract(
+        v_uv.y + rowOffset + scrollSampleOffsetUnit);
+    float unit = max(texelHeightUnit, 0.000001);
+    float texel = physicalY / unit - 0.5;
+    float base = floor(texel);
+    float f = fract(texel);
+    float f2 = f * f;
+    float f3 = f2 * f;
+
+    // Cubic B-spline reconstruction keeps a stable vertical frequency response
+    // at every sub-row phase. Bilinear filtering alternates between a sharp row
+    // and a 50/50 blend, which makes noisy waterfalls appear to pulse.
+    float w0 = (1.0 - 3.0 * f + 3.0 * f2 - f3) / 6.0;
+    float w1 = (4.0 - 6.0 * f2 + 3.0 * f3) / 6.0;
+    float w2 = (1.0 + 3.0 * f + 3.0 * f2 - 3.0 * f3) / 6.0;
+    float w3 = f3 / 6.0;
+    float y0 = fract((base - 0.5) * unit);
+    float y1 = fract((base + 0.5) * unit);
+    float y2 = fract((base + 1.5) * unit);
+    float y3 = fract((base + 2.5) * unit);
+    fragColor =
+          texture(tex, vec2(v_uv.x, y0)) * w0
+        + texture(tex, vec2(v_uv.x, y1)) * w1
+        + texture(tex, vec2(v_uv.x, y2)) * w2
+        + texture(tex, vec2(v_uv.x, y3)) * w3;
 }

--- a/resources/shaders/texturedquad_rowframes.frag
+++ b/resources/shaders/texturedquad_rowframes.frag
@@ -11,29 +11,55 @@ layout(std140, binding = 0) uniform Uniforms {
     float targetCenterOffsetMhz;
     float targetBandwidthMhz;
     float rowFrequencyFrames;
+    float scrollSampleOffsetUnit;
+    float texelHeightUnit;
+    float padding6;
+    float padding7;
 };
 
-void main()
+vec4 sampleWaterfallRow(float rowIndex, float unit)
 {
-    // Every physical ring row retains the frequency frame in which it was
-    // rasterized. Map the current viewport into that row independently, so a
-    // newly arriving radio row can expose fresh frequencies during a pan while
-    // older rows remain correctly located. Center is stored relative to a CPU
-    // reference to preserve sub-kHz precision at VHF/UHF absolute frequencies.
-    float physicalY = fract(v_uv.y + rowOffset);
-    vec2 rowFrame = texture(rowFrequencyFrame, vec2(0.5, physicalY)).rg;
+    float rowY = fract((rowIndex + 0.5) * unit);
+    vec2 rowFrame = texture(rowFrequencyFrame, vec2(0.5, rowY)).rg;
     if (rowFrame.y <= 0.0) {
-        fragColor = vec4(0.0, 0.0, 0.0, 1.0);
-        return;
+        return vec4(0.0, 0.0, 0.0, 1.0);
     }
     float sourceU = 0.5 + (targetCenterOffsetMhz - rowFrame.x) / rowFrame.y
         + (v_uv.x - 0.5) * targetBandwidthMhz / rowFrame.y;
     if (sourceU < 0.0 || sourceU > 1.0) {
+        return vec4(0.0, 0.0, 0.0, 1.0);
+    }
+    return texture(tex, vec2(sourceU, rowY));
+}
+
+void main()
+{
+    // Terminate the logical bottom edge instead of allowing the four-row
+    // reconstruction kernel to wrap the newest row into a one-pixel echo.
+    if (v_uv.y >= 1.0 - texelHeightUnit) {
         fragColor = vec4(0.0, 0.0, 0.0, 1.0);
         return;
     }
 
-    // Apply ring buffer offset per-pixel (not per-vertex, to avoid fract()
-    // interpolation issues).
-    fragColor = texture(tex, vec2(sourceU, physicalY));
+    // Every physical ring row retains the frequency frame in which it was
+    // rasterized. Reconstruct four adjacent rows independently so each sample
+    // is remapped through its own frame while the vertical motion remains
+    // phase-stable instead of alternating sharp/blurred.
+    float physicalY = fract(
+        v_uv.y + rowOffset + scrollSampleOffsetUnit);
+    float unit = max(texelHeightUnit, 0.000001);
+    float texel = physicalY / unit - 0.5;
+    float base = floor(texel);
+    float f = fract(texel);
+    float f2 = f * f;
+    float f3 = f2 * f;
+    float w0 = (1.0 - 3.0 * f + 3.0 * f2 - f3) / 6.0;
+    float w1 = (4.0 - 6.0 * f2 + 3.0 * f3) / 6.0;
+    float w2 = (1.0 + 3.0 * f + 3.0 * f2 - 3.0 * f3) / 6.0;
+    float w3 = f3 / 6.0;
+    fragColor =
+          sampleWaterfallRow(base - 1.0, unit) * w0
+        + sampleWaterfallRow(base,       unit) * w1
+        + sampleWaterfallRow(base + 1.0, unit) * w2
+        + sampleWaterfallRow(base + 2.0, unit) * w3;
 }

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -38,6 +38,9 @@ public:
     static constexpr float kDepthSpanFrac     = 0.58f;  // baseline rise to the back
     static constexpr float kFrontMaxRidgeFrac = 0.46f;  // front ridge height / plot H
     static constexpr float kHaze              = 0.16f;  // fade toward bg with depth
+    // Colour uses a stable signal aperture independent of the Ref-level height
+    // span. Otherwise a high Ref level compresses every real signal into blue.
+    static constexpr float kColorSpanDb        = 45.0f;
 
     // Maps a dBm value to an RGB colour using the host's panadapter palette.
     using PaletteFn = std::function<QRgb(float dbm)>;

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -1378,6 +1378,7 @@ void MainWindow::syncKiwiSdrPanadapterUiState(const QString& panId)
         && kiwiWaterfallChannelAvailable;
     spectrum->setKiwiSdrWaterfallAvailable(kiwiWaterfallChannelAvailable);
     spectrum->setKiwiSdrWaterfallProfile(profileId);
+    spectrum->setKiwiSdrWaterfallRate(profile.waterfallRate);
     spectrum->setKiwiSdrWaterfallActive(kiwiWaterfallActive);
     const KiwiSdrWaterfallDisplayRange displayRange =
         m_kiwiSdrManager->waterfallDisplayRange(profileId);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1359,7 +1359,7 @@ void MainWindow::wirePanLifecycle()
         }
         markProfileLoadPanDimensionsReady(panId, yPixels);
         if (auto* sw = m_panStack->spectrum(panId)) {
-            sw->prepareForFftScaleChange();
+            sw->prepareForFftPixelScaleChange();
         }
     });
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2478,7 +2478,7 @@ void MainWindow::sendPanDimensionsToRadio(const QString& panId,
                 return;
             }
             m_radioModel.panStream()->setYPixels(streamId, ypix);
-            swGuard->prepareForFftScaleChange();
+            swGuard->prepareForFftPixelScaleChange();
         };
 
         if (updateLocalDecoderImmediately) {

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -142,6 +143,217 @@ inline WaterfallPipelineMode chooseWaterfallPipeline(
             && readiness.pipelineCreated
         ? WaterfallPipelineMode::RowFrequencyFrames
         : WaterfallPipelineMode::Legacy;
+}
+
+inline float waterfallScrollProgressRows(std::int64_t elapsedMs, float msPerRow,
+                                         float distanceRows = 1.0f)
+{
+    if (elapsedMs <= 0 || !std::isfinite(msPerRow) || msPerRow <= 0.0f
+        || !std::isfinite(distanceRows) || distanceRows <= 0.0f) {
+        return 0.0f;
+    }
+    return std::clamp(static_cast<float>(elapsedMs) / msPerRow,
+                      0.0f, distanceRows);
+}
+
+inline float waterfallScrollProgressUnit(float progressRows, int textureRows)
+{
+    if (!std::isfinite(progressRows) || textureRows <= 0) {
+        return 0.0f;
+    }
+    return std::clamp(progressRows, 0.0f, 1.0f)
+        / static_cast<float>(textureRows);
+}
+
+inline float waterfallScrollSampleOffsetUnit(float progressRows,
+                                              float distanceRows,
+                                              int textureRows)
+{
+    if (!std::isfinite(progressRows) || !std::isfinite(distanceRows)
+        || distanceRows <= 0.0f || textureRows <= 0) {
+        return 0.0f;
+    }
+    return (distanceRows
+            - std::clamp(progressRows, 0.0f, distanceRows))
+        / static_cast<float>(textureRows);
+}
+
+inline bool dssFftScaleSettleActive(std::int64_t nowMs,
+                                    std::int64_t settleUntilMs)
+{
+    return settleUntilMs > 0 && nowMs < settleUntilMs;
+}
+
+inline float dssHistoryAvailability(float sampleAge, float validRows)
+{
+    if (!std::isfinite(sampleAge) || !std::isfinite(validRows)
+        || validRows <= 0.0f) {
+        return 0.0f;
+    }
+    return std::clamp(validRows - sampleAge, 0.0f, 1.0f);
+}
+
+struct StablePresentationAnchor {
+    float value{0.0f};
+    float acquisitionMean{0.0f};
+    int sampleCount{0};
+    bool hasValue{false};
+    bool locked{false};
+};
+
+inline bool observeStablePresentationAnchor(
+    StablePresentationAnchor& anchor,
+    float sample,
+    int samplesToLock = 3,
+    float quantum = 1.0f)
+{
+    if (!std::isfinite(sample) || samplesToLock <= 0
+        || !std::isfinite(quantum) || quantum <= 0.0f) {
+        return false;
+    }
+    if (anchor.locked) {
+        return false;
+    }
+
+    if (!anchor.hasValue) {
+        anchor.value = sample;
+        anchor.acquisitionMean = sample;
+        anchor.sampleCount = 1;
+        anchor.hasValue = true;
+    } else {
+        anchor.sampleCount = std::min(anchor.sampleCount + 1, samplesToLock);
+        anchor.acquisitionMean +=
+            (sample - anchor.acquisitionMean)
+            / static_cast<float>(anchor.sampleCount);
+    }
+
+    if (anchor.sampleCount >= samplesToLock) {
+        anchor.value =
+            std::round(anchor.acquisitionMean / quantum) * quantum;
+        anchor.locked = true;
+    }
+    return true;
+}
+
+inline float stablePresentationValue(const StablePresentationAnchor& anchor,
+                                     float fallback)
+{
+    if (anchor.hasValue && std::isfinite(anchor.value)) {
+        return anchor.value;
+    }
+    return std::isfinite(fallback) ? fallback : 0.0f;
+}
+
+struct ObservedWaterfallCadence {
+    std::int64_t lastRowTimestampMs{0};
+    float msPerRow{100.0f};
+    int sampleCount{0};
+    bool valid{false};
+};
+
+inline bool observeWaterfallCadence(ObservedWaterfallCadence& cadence,
+                                    std::int64_t rowTimestampMs)
+{
+    constexpr std::int64_t kMinIntervalMs = 10;
+    constexpr std::int64_t kMaxIntervalMs = 15000;
+    if (rowTimestampMs <= 0) {
+        return false;
+    }
+    if (cadence.lastRowTimestampMs <= 0) {
+        cadence.lastRowTimestampMs = rowTimestampMs;
+        return false;
+    }
+
+    const std::int64_t intervalMs =
+        rowTimestampMs - cadence.lastRowTimestampMs;
+    if (intervalMs <= 0) {
+        return false;
+    }
+    cadence.lastRowTimestampMs = rowTimestampMs;
+    if (intervalMs < kMinIntervalMs || intervalMs > kMaxIntervalMs) {
+        return false;
+    }
+
+    const float measuredMs = static_cast<float>(intervalMs);
+    if (!cadence.valid) {
+        cadence.msPerRow = measuredMs;
+        cadence.sampleCount = 1;
+        cadence.valid = true;
+        return true;
+    }
+
+    // Track real arrival cadence while damping network jitter. Rate controls
+    // explicitly reset the tracker, so the first interval at a new rate locks
+    // immediately instead of being averaged against the previous setting.
+    const float boundedMeasurement = std::clamp(
+        measuredMs, cadence.msPerRow * 0.25f, cadence.msPerRow * 4.0f);
+    const float alpha = cadence.sampleCount < 3 ? 0.5f : 0.2f;
+    cadence.msPerRow += alpha * (boundedMeasurement - cadence.msPerRow);
+    cadence.sampleCount = std::min(cadence.sampleCount + 1, 1000);
+    return true;
+}
+
+inline bool observeWaterfallCadenceAndTimeScale(
+    ObservedWaterfallCadence& cadence,
+    StablePresentationAnchor& timeScaleAnchor,
+    std::int64_t rowTimestampMs)
+{
+    if (!observeWaterfallCadence(cadence, rowTimestampMs)) {
+        return false;
+    }
+    observeStablePresentationAnchor(timeScaleAnchor, cadence.msPerRow);
+    return true;
+}
+
+inline float observedWaterfallMsPerRow(
+    const ObservedWaterfallCadence& cadence,
+    float fallbackMsPerRow)
+{
+    if (cadence.valid && std::isfinite(cadence.msPerRow)
+        && cadence.msPerRow > 0.0f) {
+        return cadence.msPerRow;
+    }
+    return std::isfinite(fallbackMsPerRow) && fallbackMsPerRow > 0.0f
+        ? fallbackMsPerRow
+        : 100.0f;
+}
+
+inline float selectedWaterfallMsPerRow(
+    bool kiwiVisible,
+    float flexMsPerRow,
+    const ObservedWaterfallCadence* kiwiCadence,
+    float kiwiFallbackMsPerRow = 100.0f)
+{
+    if (!kiwiVisible) {
+        return std::isfinite(flexMsPerRow) && flexMsPerRow > 0.0f
+            ? flexMsPerRow
+            : 100.0f;
+    }
+    return kiwiCadence
+        ? observedWaterfallMsPerRow(*kiwiCadence, kiwiFallbackMsPerRow)
+        : observedWaterfallMsPerRow(
+              ObservedWaterfallCadence{}, kiwiFallbackMsPerRow);
+}
+
+inline float selectedWaterfallTimeScaleMsPerRow(
+    bool kiwiVisible,
+    float flexMsPerRow,
+    const StablePresentationAnchor* kiwiTimeScaleAnchor,
+    float kiwiFallbackMsPerRow = 100.0f)
+{
+    if (!kiwiVisible) {
+        return std::isfinite(flexMsPerRow) && flexMsPerRow > 0.0f
+            ? flexMsPerRow
+            : 100.0f;
+    }
+    if (!kiwiTimeScaleAnchor) {
+        return std::isfinite(kiwiFallbackMsPerRow)
+                && kiwiFallbackMsPerRow > 0.0f
+            ? kiwiFallbackMsPerRow
+            : 100.0f;
+    }
+    return stablePresentationValue(
+        *kiwiTimeScaleAnchor, kiwiFallbackMsPerRow);
 }
 
 } // namespace AetherSDR

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -156,15 +156,6 @@ inline float waterfallScrollProgressRows(std::int64_t elapsedMs, float msPerRow,
                       0.0f, distanceRows);
 }
 
-inline float waterfallScrollProgressUnit(float progressRows, int textureRows)
-{
-    if (!std::isfinite(progressRows) || textureRows <= 0) {
-        return 0.0f;
-    }
-    return std::clamp(progressRows, 0.0f, 1.0f)
-        / static_cast<float>(textureRows);
-}
-
 inline float waterfallScrollSampleOffsetUnit(float progressRows,
                                               float distanceRows,
                                               int textureRows)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -85,6 +85,11 @@ constexpr int kDssMaxIncrementalUploadRows = 8;
 constexpr qint64 kDssFftPixelScaleSettleMs = 750;
 
 #ifdef AETHER_GPU_SPECTRUM
+// std140 float count of the waterfall UBO — must match the Uniforms block in
+// texturedquad.frag AND texturedquad_rowframes.frag, the buffer allocs in
+// initWaterfallPipeline(), and the uniforms[] writer in renderGpuFrame().
+constexpr int kWaterfallUboFloats = 8;
+
 QSize evenAlignedRhiSize(QSize size)
 {
     if (size.isEmpty()) {
@@ -4485,7 +4490,8 @@ void SpectrumWidget::appendLatestDssWaterfallRow(double frameCenterMhz,
 
 void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
                                       double frameCenterMhz,
-                                      double frameBandwidthMhz)
+                                      double frameBandwidthMhz,
+                                      bool startScrollAnimation)
 {
     if (m_waterfall.isNull() || rowData == nullptr) {
         return;
@@ -4523,7 +4529,9 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
     ++m_panStats.waterfallVisibleRows;
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallVisibleRows();
-    startWaterfallScrollAnimation();
+    if (startScrollAnimation) {
+        startWaterfallScrollAnimation();
+    }
 }
 
 void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
@@ -7234,12 +7242,17 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         appendHistoryRow(interpolatedLevels.constData(), nowMs);
         appendLatestDssWaterfallRow();
         if (m_wfLive) {
-            appendVisibleRow(interpolatedRow.constData());
+            // The whole tile gets one start() after the loop; don't restart the
+            // scroll clock once per appended row.
+            appendVisibleRow(interpolatedRow.constData(), -1.0, -1.0,
+                             /*startScrollAnimation=*/false);
         } else {
             rebuildWaterfallViewport();
         }
     }
-    if (m_wfLive && rowsToPush > 1) {
+    if (m_wfLive) {
+        // One scroll start for the whole tile (rowsToPush >= 1), replacing the
+        // per-row starts the appendVisibleRow calls above used to issue.
         startWaterfallScrollAnimation(static_cast<float>(rowsToPush));
     }
     m_prevTileLevels = levels;
@@ -10802,7 +10815,7 @@ bool SpectrumWidget::initWaterfallPipeline()
         QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
         sizeof(kQuadData)));
     std::unique_ptr<QRhiBuffer> ubo(r->newBuffer(
-        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 8 * sizeof(float)));
+        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, kWaterfallUboFloats * sizeof(float)));
     std::unique_ptr<QRhiTexture> colorTexture(r->newTexture(
         QRhiTexture::RGBA8, QSize(textureWidth, textureHeight)));
     std::unique_ptr<QRhiSampler> colorSampler(r->newSampler(
@@ -11061,7 +11074,7 @@ void SpectrumWidget::initOverlayPipeline()
     // uniform block that remaps the frequency-overlay texture. It stays at the
     // drag-start frame while band/spot/slice geometry follows the live GPU data.
     m_ovPreviewUbo = r->newBuffer(
-        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 8 * sizeof(float));
+        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, kWaterfallUboFloats * sizeof(float));
     const bool previewUboReady = m_ovPreviewUbo->create();
     m_ovPreviewSrb = r->newShaderResourceBindings();
     m_ovPreviewSrb->setBindings({
@@ -11732,6 +11745,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         0.0f,
         0.0f,
     };
+    static_assert(sizeof(uniforms) == kWaterfallUboFloats * sizeof(float),
+                  "waterfall UBO writer must match kWaterfallUboFloats, the "
+                  "buffer allocs, and the .frag Uniforms blocks");
     batch->updateDynamicBuffer(m_wfUbo, 0, sizeof(uniforms), uniforms);
 
     // The compact 3DSS height surface still shares one preview frame across its
@@ -12271,7 +12287,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 m_waterfallScrollClock.isValid()
                 ? scrollProgressRows
                 : m_waterfallScrollDistanceRows;
-            float ubo[kDssMeshUboFloats] = {
+            const float ubo[] = {
                 rowOffset,
                 floorDbm, rangeDb, m_dssZCurve,
                 DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
@@ -12287,6 +12303,11 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<float>(m_bgFillColor.blueF()),
                 1.0f,                                         // bgFill vec4
             };
+            // Deduced size + assert so a missed field here (or in the shader U
+            // block / kDssMeshUboFloats) is a compile error, not silent garbage.
+            static_assert(sizeof(ubo) == kDssMeshUboFloats * sizeof(float),
+                          "DSS mesh UBO writer element count must equal "
+                          "kDssMeshUboFloats and the dss_mesh.{vert,frag} U block");
             batch->updateDynamicBuffer(m_dssMeshUbo, 0, sizeof(ubo), ubo);
         } else if (is3D) {
             // CPU cached-image fallback (no mesh pipeline). Rendered at a capped

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -82,6 +82,7 @@ QSoundEffect* SpectrumWidget::s_starstruckSound = nullptr;
 namespace {
 
 constexpr int kDssMaxIncrementalUploadRows = 8;
+constexpr qint64 kDssFftPixelScaleSettleMs = 750;
 
 #ifdef AETHER_GPU_SPECTRUM
 QSize evenAlignedRhiSize(QSize size)
@@ -1179,6 +1180,30 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("waterfallRows")] = m_waterfall.height();
     m[QStringLiteral("waterfallWidth")] = m_waterfall.width();
     m[QStringLiteral("waterfallWriteRow")] = m_wfWriteRow;
+    m[QStringLiteral("waterfallScrollProgressRows")] =
+        waterfallScrollProgressRows();
+    m[QStringLiteral("waterfallScrollDistanceRows")] =
+        m_waterfallScrollDistanceRows;
+    m[QStringLiteral("waterfallPresentationMsPerRow")] =
+        waterfallPresentationMsPerRow();
+    m[QStringLiteral("waterfallTimeScaleMsPerRow")] =
+        waterfallTimeScaleMsPerRow();
+    m[QStringLiteral("flexWaterfallMsPerRow")] = m_wfMsPerRow;
+    const auto kiwiCadence =
+        m_kiwiWaterfallCadenceByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    m[QStringLiteral("kiwiWaterfallCadenceValid")] =
+        kiwiCadence != m_kiwiWaterfallCadenceByProfile.constEnd()
+        && kiwiCadence.value().valid;
+    m[QStringLiteral("kiwiWaterfallCadenceSamples")] =
+        kiwiCadence != m_kiwiWaterfallCadenceByProfile.constEnd()
+        ? kiwiCadence.value().sampleCount : 0;
+    const auto kiwiTimeScaleAnchor =
+        m_kiwiTimeScaleAnchorsByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    m[QStringLiteral("kiwiWaterfallTimeScaleLocked")] =
+        kiwiTimeScaleAnchor != m_kiwiTimeScaleAnchorsByProfile.constEnd()
+        && kiwiTimeScaleAnchor.value().locked;
+    m[QStringLiteral("waterfallScrollAnimating")] =
+        m_waterfallScrollTimer && m_waterfallScrollTimer->isActive();
     m[QStringLiteral("waterfallHistoryRows")] = m_wfHistoryRowCount;
     m[QStringLiteral("waterfallHistoryCapacityRows")] =
         m_waterfallHistory.capacityRows();
@@ -1208,6 +1233,7 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         static_cast<qulonglong>(m_dss.rowGeneration());
     m[QStringLiteral("dssHistoryRows")] = m_dss.historyRowCount();
     m[QStringLiteral("dssHistoryCapacityRows")] = m_dss.historyCapacityRows();
+    m[QStringLiteral("dssFftScaleSettling")] = flexDssFftScaleSettling();
     m[QStringLiteral("dssFixedBytes")] =
         static_cast<qulonglong>(m_dss.fixedStorageBytes());
     m[QStringLiteral("dssHistoryBytes")] =
@@ -1462,6 +1488,7 @@ QVariantMap SpectrumWidget::automationDssSetScrollback(bool live,
     if (live) {
         setWaterfallLive(true);
     } else {
+        stopWaterfallScrollAnimation();
         m_wfLive = false;
         m_wfHistoryOffsetRows =
             std::clamp(offsetRows, 0, maxWaterfallHistoryOffsetRows());
@@ -1558,6 +1585,18 @@ QVariantMap SpectrumWidget::traceDebugSnapshot()
     m[QStringLiteral("kiwiFftTraceFloorDbm")] = m_kiwiSdrFftTraceFloorDbm;
     m[QStringLiteral("kiwiFftTraceFloorValid")] =
         m_kiwiSdrFftTraceFloorValid;
+    const auto kiwiDssFloorAnchor =
+        m_kiwiDssFloorAnchorsByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    m[QStringLiteral("kiwiDssFloorAnchorDbm")] =
+        kiwiDssFloorAnchor != m_kiwiDssFloorAnchorsByProfile.constEnd()
+        && kiwiDssFloorAnchor.value().hasValue
+        ? kiwiDssFloorAnchor.value().value : -1000.0f;
+    m[QStringLiteral("kiwiDssFloorAnchorLocked")] =
+        kiwiDssFloorAnchor != m_kiwiDssFloorAnchorsByProfile.constEnd()
+        && kiwiDssFloorAnchor.value().locked;
+    m[QStringLiteral("kiwiDssFloorAnchorSamples")] =
+        kiwiDssFloorAnchor != m_kiwiDssFloorAnchorsByProfile.constEnd()
+        ? kiwiDssFloorAnchor.value().sampleCount : 0;
     m[QStringLiteral("kiwiFftTraceEstimatedFloorDbm")] =
         m_kiwiSdrFftTrace.isEmpty()
             ? -1000.0f
@@ -1688,6 +1727,24 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     connect(m_connectionAnimationTimer, &QTimer::timeout, this, [this]() {
         if (m_connectionAnimationVisible)
             markOverlayDirty();
+    });
+
+    m_waterfallScrollTimer = new QTimer(this);
+    m_waterfallScrollTimer->setTimerType(Qt::PreciseTimer);
+    m_waterfallScrollTimer->setInterval(kPresentCoalesceMs);
+    connect(m_waterfallScrollTimer, &QTimer::timeout, this, [this]() {
+        if (!m_wfLive || !m_waterfallWriteVisible || !isVisible()
+            || !m_waterfallScrollClock.isValid()) {
+            stopWaterfallScrollAnimation();
+            return;
+        }
+
+        coalescedUpdate();
+        if (waterfallScrollProgressRows() >= m_waterfallScrollDistanceRows) {
+            // Keep the completed phase so the viewport remains one full row
+            // advanced until the next radio row resets the clock.
+            m_waterfallScrollTimer->stop();
+        }
     });
 
     m_fpsMeterTimer = new QTimer(this);
@@ -2126,6 +2183,8 @@ void SpectrumWidget::loadSettings()
     m_wfColorScheme  = static_cast<WfColorScheme>(
         std::clamp(s.value(settingsKey("DisplayWfColorScheme"), "0").toInt(),
                    0, static_cast<int>(WfColorScheme::Count) - 1));
+    m_dssGain = std::clamp(
+        s.value(settingsKey("Display3DGain"), "70").toInt(), 0, 100);
     m_spectrumRenderMode = static_cast<SpectrumRenderMode>(
         std::clamp(s.value(settingsKey("DisplaySpectrumRenderMode"), "0").toInt(),
                    0, static_cast<int>(SpectrumRenderMode::Count) - 1));
@@ -2579,6 +2638,26 @@ void SpectrumWidget::prepareForFftScaleChange()
     m_noiseFloorCandidateFrames = 0;
 }
 
+void SpectrumWidget::prepareForFftPixelScaleChange()
+{
+    prepareForFftScaleChange();
+    m_flexDssFftScaleSettlingUntilMs =
+        QDateTime::currentMSecsSinceEpoch() + kDssFftPixelScaleSettleMs;
+
+    // A y_pixels transition changes how raw FFT pixel values decode to dBm.
+    // Rows received before the radio echo (or queued immediately after it) are
+    // not comparable with the settled stream and must not survive in 3D
+    // history. Keep a Kiwi surface intact when only the hidden Flex decoder is
+    // changing.
+    DssRenderer& flexDss = m_kiwiSdrWaterfallActive
+        ? m_nativeWaterfallState.dss
+        : m_dss;
+    flexDss.clear();
+    if (!m_kiwiSdrWaterfallActive) {
+        resetDssUploadState();
+    }
+}
+
 void SpectrumWidget::setFftWeightedAvg(bool on) {
     m_fftWeightedAvg = on;
     if (m_overlayMenu) {
@@ -2983,6 +3062,11 @@ void SpectrumWidget::stabilizeKiwiSdrFftTrace(QVector<float>& bins,
         kKiwiSdrWaterfallMinDbm, kKiwiSdrWaterfallMaxDbm);
     m_kiwiSdrFftTraceFloorDbm = state.floorDbm;
     m_kiwiSdrFftTraceFloorValid = state.valid;
+    if (allowFloorAdapt && state.valid && state.floorDbm > -500.0f) {
+        StablePresentationAnchor& anchor =
+            m_kiwiDssFloorAnchorsByProfile[m_kiwiSdrWaterfallProfileId];
+        observeStablePresentationAnchor(anchor, state.floorDbm, 3, 0.5f);
+    }
 }
 
 void SpectrumWidget::updateKiwiSdrSquelchVisualFloor(float floorDbm)
@@ -3569,6 +3653,7 @@ void SpectrumWidget::setWfLineDuration(int ms) {
     }
 
     m_wfLineDuration = clamped;
+    stopWaterfallScrollAnimation();
     PerfTelemetry::instance().setWaterfallLineDurationMs(m_wfLineDuration);
     if (m_overlayMenu) {
         m_overlayMenu->syncWfLineDuration(m_wfLineDuration);
@@ -4117,6 +4202,11 @@ QString SpectrumWidget::pausedTimeLabelForAge(int ageRows) const
 
 void SpectrumWidget::updateWaterfallMsPerRowFromHistory()
 {
+    // Kiwi's discrete server cadence is unrelated to Flex line_duration.
+    // Keep Kiwi rows out of the radio-authoritative Flex calibration/cache.
+    if (m_kiwiSdrWaterfallActive) {
+        return;
+    }
     if (!m_waterfallHistory.isConfigured() || m_wfHistoryTimestamps.isEmpty()
         || m_wfHistoryRowCount < 2) {
         return;
@@ -4336,6 +4426,10 @@ void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
                                            double frameBandwidthMhz,
                                            bool updateLiveSurface)
 {
+    if (!m_kiwiSdrWaterfallActive && flexDssFftScaleSettling()) {
+        return;
+    }
+
     // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
     if (m_wfLive && updateLiveSurface) {
         if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
@@ -4429,6 +4523,7 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
     ++m_panStats.waterfallVisibleRows;
     if (PerfTelemetry::instance().enabled())
         PerfTelemetry::instance().recordWaterfallVisibleRows();
+    startWaterfallScrollAnimation();
 }
 
 void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
@@ -4819,10 +4914,85 @@ void SpectrumWidget::setWaterfallLive(bool live)
     if (live) {
         m_wfHistoryOffsetRows = 0;
     }
+    stopWaterfallScrollAnimation();
     m_wfLive = live;
     rebuildWaterfallViewport();
     rebuildDssViewportFromHistory();
     markOverlayDirty();
+}
+
+void SpectrumWidget::startWaterfallScrollAnimation(float distanceRows)
+{
+    if (!m_wfLive || !m_waterfallWriteVisible || m_waterfall.isNull()
+        || !std::isfinite(distanceRows) || distanceRows <= 0.0f) {
+        stopWaterfallScrollAnimation();
+        return;
+    }
+
+    m_waterfallScrollDistanceRows = distanceRows;
+    m_waterfallScrollClock.restart();
+    if (m_waterfallScrollTimer && !m_waterfallScrollTimer->isActive()) {
+        m_waterfallScrollTimer->start();
+    }
+}
+
+void SpectrumWidget::stopWaterfallScrollAnimation()
+{
+    if (m_waterfallScrollTimer) {
+        m_waterfallScrollTimer->stop();
+    }
+    m_waterfallScrollClock.invalidate();
+    m_waterfallScrollDistanceRows = 1.0f;
+}
+
+float SpectrumWidget::waterfallScrollProgressRows() const
+{
+    if (!m_wfLive || !m_waterfallWriteVisible
+        || !m_waterfallScrollClock.isValid()) {
+        return 0.0f;
+    }
+    return AetherSDR::waterfallScrollProgressRows(
+        m_waterfallScrollClock.elapsed(), waterfallPresentationMsPerRow(),
+        m_waterfallScrollDistanceRows);
+}
+
+float SpectrumWidget::waterfallPresentationMsPerRow() const
+{
+    const auto cadence =
+        m_kiwiWaterfallCadenceByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    return selectedWaterfallMsPerRow(
+        m_kiwiSdrWaterfallActive,
+        m_wfMsPerRow,
+        cadence != m_kiwiWaterfallCadenceByProfile.constEnd()
+            ? &cadence.value() : nullptr);
+}
+
+float SpectrumWidget::waterfallTimeScaleMsPerRow() const
+{
+    const auto anchor =
+        m_kiwiTimeScaleAnchorsByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    return selectedWaterfallTimeScaleMsPerRow(
+        m_kiwiSdrWaterfallActive,
+        m_wfMsPerRow,
+        anchor != m_kiwiTimeScaleAnchorsByProfile.constEnd()
+            ? &anchor.value() : nullptr);
+}
+
+void SpectrumWidget::observeKiwiSdrWaterfallCadence(qint64 rowTimestampMs)
+{
+    ObservedWaterfallCadence& cadence =
+        m_kiwiWaterfallCadenceByProfile[m_kiwiSdrWaterfallProfileId];
+    StablePresentationAnchor& timeScaleAnchor =
+        m_kiwiTimeScaleAnchorsByProfile[m_kiwiSdrWaterfallProfileId];
+    observeWaterfallCadenceAndTimeScale(
+        cadence, timeScaleAnchor, rowTimestampMs);
+}
+
+bool SpectrumWidget::flexDssFftScaleSettling() const
+{
+    return dssFftScaleSettleActive(
+        QDateTime::currentMSecsSinceEpoch(),
+        m_flexDssFftScaleSettlingUntilMs);
 }
 
 void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
@@ -5195,6 +5365,8 @@ void SpectrumWidget::clearWaterfallRows()
     m_nativeWaterfallState = WaterfallStreamState{};
     m_kiwiWaterfallState = WaterfallStreamState{};
     m_kiwiProfileWaterfallStates.clear();
+    m_kiwiTimeScaleAnchorsByProfile.clear();
+    m_kiwiDssFloorAnchorsByProfile.clear();
 }
 
 SpectrumWidget::WaterfallStreamState& SpectrumWidget::activeKiwiWaterfallState()
@@ -7067,6 +7239,9 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
             rebuildWaterfallViewport();
         }
     }
+    if (m_wfLive && rowsToPush > 1) {
+        startWaterfallScrollAnimation(static_cast<float>(rowsToPush));
+    }
     m_prevTileLevels = levels;
     recordWaterfallFrame(rowsToPush);
     if (PerfTelemetry::instance().enabled())
@@ -7084,6 +7259,7 @@ void SpectrumWidget::setKiwiSdrWaterfallActive(bool active)
     }
 
     commitFrequencyPreview();
+    stopWaterfallScrollAnimation();
     setNoiseFloorPositionForSource(m_kiwiSdrWaterfallActive,
                                    m_noiseFloorPosition,
                                    false);
@@ -7207,6 +7383,10 @@ void SpectrumWidget::clearKiwiSdrWaterfallRows()
 {
     m_kiwiWaterfallState = WaterfallStreamState{};
     m_kiwiProfileWaterfallStates.clear();
+    m_kiwiWaterfallCadenceByProfile.clear();
+    m_kiwiWaterfallRateByProfile.clear();
+    m_kiwiTimeScaleAnchorsByProfile.clear();
+    m_kiwiDssFloorAnchorsByProfile.clear();
     resetKiwiSdrWaterfallDisplayRange();
     m_kiwiSdrFftTrace.clear();
     m_kiwiSdrFftFallbackSeedMask.clear();
@@ -7226,11 +7406,40 @@ void SpectrumWidget::clearKiwiSdrWaterfallRowsForProfile(const QString& profileI
     }
 
     m_kiwiProfileWaterfallStates.remove(normalized);
+    m_kiwiWaterfallCadenceByProfile.remove(normalized);
     if (m_kiwiSdrWaterfallActive
         && m_kiwiSdrWaterfallProfileId == normalized) {
         resetKiwiSdrWaterfallDisplayRange();
         clearCurrentWaterfallRows();
         coalescedUpdate();
+    }
+}
+
+void SpectrumWidget::resetKiwiSdrWaterfallCadence()
+{
+    m_kiwiWaterfallCadenceByProfile.remove(m_kiwiSdrWaterfallProfileId);
+    m_kiwiTimeScaleAnchorsByProfile.remove(m_kiwiSdrWaterfallProfileId);
+    if (m_kiwiSdrWaterfallActive) {
+        stopWaterfallScrollAnimation();
+        coalescedUpdate();
+    }
+}
+
+void SpectrumWidget::setKiwiSdrWaterfallRate(int rate)
+{
+    const int clampedRate = std::clamp(rate, 0, 4);
+    const QString profileId = m_kiwiSdrWaterfallProfileId;
+    const auto previous = m_kiwiWaterfallRateByProfile.constFind(profileId);
+    if (previous != m_kiwiWaterfallRateByProfile.constEnd()
+        && previous.value() == clampedRate) {
+        return;
+    }
+
+    const bool changedExistingRate =
+        previous != m_kiwiWaterfallRateByProfile.constEnd();
+    m_kiwiWaterfallRateByProfile.insert(profileId, clampedRate);
+    if (changedExistingRate) {
+        resetKiwiSdrWaterfallCadence();
     }
 }
 
@@ -8939,6 +9148,7 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         if (newOffset != m_wfHistoryOffsetRows) {
             m_wfHistoryOffsetRows = newOffset;
             if (newOffset > 0) {
+                stopWaterfallScrollAnimation();
                 m_wfLive = false;
             }
             rebuildWaterfallViewport();
@@ -10150,6 +10360,9 @@ float SpectrumWidget::dssFloorDbm()
             ? m_dssFloorAnchorDbm
             : m_refLevel - m_dynamicRange;
     }
+    if (m_kiwiSdrWaterfallActive) {
+        floor = kiwiDssPresentationFloorDbm(floor);
+    }
     return std::round(floor * 2.0f) / 2.0f + m_dssFloorOffsetDb;
 }
 
@@ -10195,7 +10408,21 @@ float SpectrumWidget::peekDssFloorDbm() const
             }
         }
     }
+    if (m_kiwiSdrWaterfallActive) {
+        floor = kiwiDssPresentationFloorDbm(floor);
+    }
     return std::round(floor * 2.0f) / 2.0f + m_dssFloorOffsetDb;
+}
+
+float SpectrumWidget::kiwiDssPresentationFloorDbm(
+    float fallbackFloorDbm) const
+{
+    const auto anchor =
+        m_kiwiDssFloorAnchorsByProfile.constFind(m_kiwiSdrWaterfallProfileId);
+    if (anchor == m_kiwiDssFloorAnchorsByProfile.constEnd()) {
+        return fallbackFloorDbm;
+    }
+    return stablePresentationValue(anchor.value(), fallbackFloorDbm);
 }
 
 float SpectrumWidget::dssSpanDb() const
@@ -10214,10 +10441,12 @@ const QImage& SpectrumWidget::buildDssImage(const QSize& px,
 {
     const float rangeDb  = std::round(dssSpanDb() * 2.0f) / 2.0f;
 
-    // Same mapping as the GPU mesh: full colormap over the strength axis, gamma-
-    // shaped by "3D Gain" (NOT dbmToRgb, which clipped the low range to black).
-    auto palette = [this, floorDbm, rangeDb](float dbm) {
-        const float r = (rangeDb > 0.0f) ? rangeDb : 1.0f;
+    // Same mapping as the GPU mesh: a stable colour aperture independent of the
+    // Ref-level height span, gamma-shaped by "3D Gain".
+    const float colorRangeDb =
+        std::min(rangeDb, DssRenderer::kColorSpanDb);
+    auto palette = [this, floorDbm, colorRangeDb](float dbm) {
+        const float r = (colorRangeDb > 0.0f) ? colorRangeDb : 1.0f;
         return dssStrengthToRgb((dbm - floorDbm) / r);
     };
     return m_dss.image(px, scaleStripPx, floorDbm, rangeDb, m_dssZCurve,
@@ -10230,6 +10459,10 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
                                                   double frameBandwidthMhz,
                                                   bool updateLiveSurface)
 {
+    if (!kiwiStream && flexDssFftScaleSettling()) {
+        return;
+    }
+
     if (m_kiwiSdrWaterfallActive == kiwiStream) {
         appendDssWaterfallRow(binsDbm, frameCenterMhz, frameBandwidthMhz,
                               updateLiveSurface);
@@ -10382,9 +10615,8 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins, int destWidth,
 {
     // Callers own cadence: TX and RX stale-native fallback pace FFT-derived
     // rows from the requested waterfall interval before appending here.
-    // Time-axis labelling uses m_wfMsPerRow, seeded from the requested rate and
-    // corrected from appended-row timestamps, so the scale follows whichever
-    // path is currently producing visible rows.
+    // Time-axis labelling uses the source-specific presentation cadence: Flex
+    // keeps its line_duration calibration, while Kiwi follows observed rows.
 
     if (m_waterfall.isNull() || destWidth <= 0) return;
 
@@ -10488,7 +10720,9 @@ void SpectrumWidget::pushKiwiSdrWaterfallRow(const QVector<float>& bins,
         scanline[x] = colorLut[levels[x]];
     }
 
-    appendHistoryRow(levels.constData(), QDateTime::currentMSecsSinceEpoch(),
+    const qint64 rowTimestampMs = QDateTime::currentMSecsSinceEpoch();
+    observeKiwiSdrWaterfallCadence(rowTimestampMs);
+    appendHistoryRow(levels.constData(), rowTimestampMs,
                      rowCenterMhz, rowBandwidthMhz);
     if (m_wfLive) {
         QVector<QRgb> visibleLine(destWidth, qRgb(0, 0, 0));
@@ -10568,7 +10802,7 @@ bool SpectrumWidget::initWaterfallPipeline()
         QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
         sizeof(kQuadData)));
     std::unique_ptr<QRhiBuffer> ubo(r->newBuffer(
-        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 16));
+        QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 8 * sizeof(float)));
     std::unique_ptr<QRhiTexture> colorTexture(r->newTexture(
         QRhiTexture::RGBA8, QSize(textureWidth, textureHeight)));
     std::unique_ptr<QRhiSampler> colorSampler(r->newSampler(
@@ -10982,12 +11216,10 @@ void SpectrumWidget::uploadDssPaletteLut(QRhiResourceUpdateBatch* batch,
     if (!m_dssPaletteTex || !batch) {
         return;
     }
-    // The 3D surface maps its strength axis (noise floor -> ref level) across the
-    // FULL colormap gradient, bypassing dbmToRgb()'s waterfall black-level window
-    // (which forced everything below ~(min + (125-black)*0.4) dBm to black, so
-    // only the strongest signals showed any colour). The "3D Color" control
-    // gamma-shapes the strength before the lookup: higher = colour reaches down
-    // toward the noise floor; lower = colour only on the strongest signals.
+    // The 3D surface maps its stable colour aperture across the FULL colormap,
+    // independently of the Ref-level height span. This bypasses dbmToRgb()'s
+    // waterfall black-level window while preventing a high Ref level from
+    // compressing every real signal into blue. "3D Gain" gamma-shapes the LUT.
     // Colour depends only on the scheme + that control (NOT the per-frame floor/
     // range, which jitter every frame), so the LUT re-bakes only on a real change.
     Q_UNUSED(floorDbm);
@@ -11080,7 +11312,7 @@ void SpectrumWidget::initDssMeshPipeline()
     layout.setBindings({{3 * sizeof(float)}});
     layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});  // u, v, edge
 
-    // Fill pipeline — opaque triangle lists (occlusion via back-to-front order).
+    // Fill pipeline — one opaque front curtain, height-morphed in the shader.
     m_dssMeshFillPipeline = r->newGraphicsPipeline();
     m_dssMeshFillPipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
     m_dssMeshFillPipeline->setVertexInputLayout(layout);
@@ -11156,11 +11388,11 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
                 const float u0 = static_cast<float>(cc) / (cols - 1);
                 const float u1 = static_cast<float>(cc + 1) / (cols - 1);
                 appendDssVertex(fill, u0, v, 0.0f);   // ridge
-                appendDssVertex(fill, u0, v, 1.0f);   // floor
-                appendDssVertex(fill, u1, v, 0.0f);   // next ridge
+                appendDssVertex(fill, u0, v, 1.0f);   // plot floor
+                appendDssVertex(fill, u1, v, 0.0f);   // ridge
                 appendDssVertex(fill, u1, v, 0.0f);
                 appendDssVertex(fill, u0, v, 1.0f);
-                appendDssVertex(fill, u1, v, 1.0f);   // next floor
+                appendDssVertex(fill, u1, v, 1.0f);   // plot floor
                 appendDssVertex(line, u0, v, -1.0f);
                 appendDssVertex(line, u1, v, -1.0f);
             }
@@ -11283,11 +11515,11 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
     // Detect display state changes that may bypass markOverlayDirty()
     {
-        // In 3D the dBm scale is anchored to the noise floor, which drifts every
-        // FFT frame (dssFloorDbm() reads the measured floor, quantised to 0.5 dB).
-        // The surface UBO and cached scale labels consume the same per-frame
-        // floor, so a changed anchor invalidates both together (#3937). In 2D the
-        // scale is Ref-anchored, so the floor is left out of the check there.
+        // In 3D the surface UBO and cached scale labels consume the same
+        // source-selected floor. Flex may follow its smoothed floor; Kiwi uses
+        // a stable per-profile presentation anchor. Any intentional anchor
+        // change invalidates both together (#3937). In 2D the scale is
+        // Ref-anchored, so the floor is left out of the check there.
         const float dssFloor = dssFrameFloorDbm;
         if (m_centerMhz != m_lastDetectCenter || m_bandwidthMhz != m_lastDetectBw ||
             m_refLevel != m_lastDetectRef || m_dynamicRange != m_lastDetectDyn ||
@@ -11474,6 +11706,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
     // Update waterfall uniforms. Each row carries its own source frame, so new
     // radio rows can expose frequencies that were outside the drag-start view.
+    const float scrollProgressRows = waterfallScrollProgressRows();
+    const float scrollSampleOffsetUnit =
+        m_waterfallScrollClock.isValid()
+        ? AetherSDR::waterfallScrollSampleOffsetUnit(
+              scrollProgressRows, m_waterfallScrollDistanceRows,
+              m_wfGpuTexH)
+        : 0.0f;
     float rowOffset = (m_wfGpuTexH > 0)
         ? static_cast<float>(m_wfWriteRow) / m_wfGpuTexH
         : 0.0f;
@@ -11488,6 +11727,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         waterfallTargetCenterOffsetMhz,
         waterfallTargetBandwidthMhz,
         waterfallRowFrequencyFrames,
+        scrollSampleOffsetUnit,
+        m_wfGpuTexH > 0 ? 1.0f / static_cast<float>(m_wfGpuTexH) : 0.0f,
+        0.0f,
+        0.0f,
     };
     batch->updateDynamicBuffer(m_wfUbo, 0, sizeof(uniforms), uniforms);
 
@@ -12024,6 +12267,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             const float rowOffset = rows > 0
                 ? (static_cast<float>(head) + 0.5f) / static_cast<float>(rows)
                 : 0.0f;
+            const float dssScrollProgressRows =
+                m_waterfallScrollClock.isValid()
+                ? scrollProgressRows
+                : m_waterfallScrollDistanceRows;
             float ubo[kDssMeshUboFloats] = {
                 rowOffset,
                 floorDbm, rangeDb, m_dssZCurve,
@@ -12031,6 +12278,10 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 DssRenderer::kFrontMaxRidgeFrac, DssRenderer::kHaze,
                 static_cast<float>(cols),
                 frequencyScale, frequencyOffset, frequencyPreview,
+                dssScrollProgressRows,
+                static_cast<float>(rows), m_waterfallScrollDistanceRows,
+                std::min(rangeDb, DssRenderer::kColorSpanDb),
+                static_cast<float>(valid), 0.0f, 0.0f, 0.0f,
                 static_cast<float>(m_bgFillColor.redF()),
                 static_cast<float>(m_bgFillColor.greenF()),
                 static_cast<float>(m_bgFillColor.blueF()),
@@ -12238,9 +12489,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         const int drawnRows = m_dss.rowCount();
 
         if (drawnRows > 0) {
-            // Opaque fill curtains, back (oldest) -> front (newest) for occlusion.
-            // The static VBO is already ordered back-to-front for all rows; drawing
-            // only the valid suffix keeps startup frames short while the history fills.
+            // Original full-height curtains, now on a fixed perspective grid
+            // with interpolated row data. Draw back-to-front for occlusion.
             const int skippedRows = m_dss.rows() - drawnRows;
             cb->setGraphicsPipeline(m_dssMeshFillPipeline);
             cb->setShaderResources(m_dssMeshSrb);
@@ -13011,32 +13261,34 @@ void SpectrumWidget::drawWaterfall(QPainter& p, const QRect& r)
         return;
     }
 
-    // Ring buffer rendering: m_wfWriteRow is the newest row.
-    // Draw in two halves: [writeRow..end] then [0..writeRow)
+    // Ring buffer rendering: m_wfWriteRow is the newest row. Begin each
+    // received-row interval at the previous completed sample position, then
+    // close the residual one-row offset continuously. This makes the handoff
+    // frame-identical instead of flashing the new top row into place.
     const int h = m_waterfall.height();
-    const int topRows = h - m_wfWriteRow;  // rows from writeRow to bottom of image
-    const int botRows = m_wfWriteRow;       // rows from top of image to writeRow
+    const qreal sampleOffsetRows = m_waterfallScrollClock.isValid()
+        ? m_waterfallScrollDistanceRows - waterfallScrollProgressRows()
+        : 0.0;
+    const qreal sourceStart = std::fmod(
+        static_cast<qreal>(m_wfWriteRow) + sampleOffsetRows,
+        static_cast<qreal>(h));
+    const qreal firstRows = h - sourceStart;
+    const qreal firstHeight = r.height() * firstRows / h;
+    const qreal secondHeight = r.height() - firstHeight;
 
-    if (topRows >= h) {
-        // writeRow == 0, no split needed
-        p.drawImage(r, m_waterfall);
-    } else {
-        const double scale = static_cast<double>(r.height()) / h;
-        const int topH = static_cast<int>(topRows * scale);
-        const int botH = r.height() - topH;
-
-        // Top part: newest rows (from writeRow to end of image)
-        p.drawImage(QRect(r.x(), r.y(), r.width(), topH),
+    p.save();
+    p.setClipRect(r);
+    p.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    p.drawImage(QRectF(r.x(), r.y(), r.width(), firstHeight),
+                m_waterfall,
+                QRectF(0, sourceStart, m_waterfall.width(), firstRows));
+    if (sourceStart > 0.0 && secondHeight > 0.0) {
+        p.drawImage(QRectF(r.x(), r.y() + firstHeight,
+                           r.width(), secondHeight),
                     m_waterfall,
-                    QRect(0, m_wfWriteRow, m_waterfall.width(), topRows));
-
-        // Bottom part: older rows (from start of image to writeRow)
-        if (botRows > 0 && botH > 0) {
-            p.drawImage(QRect(r.x(), r.y() + topH, r.width(), botH),
-                        m_waterfall,
-                        QRect(0, 0, m_waterfall.width(), botRows));
-        }
+                    QRectF(0, 0, m_waterfall.width(), sourceStart));
     }
+    p.restore();
 }
 
 // ─── Band plan overlay (bottom 8px of FFT area) ─────────────────────────────
@@ -14614,7 +14866,8 @@ void SpectrumWidget::drawTimeScale(QPainter& p, const QRect& wfRect)
     p.setPen(m_wfLive ? AetherSDR::ThemeManager::instance().color("color.text.primary") : Qt::white);
     p.drawText(liveRect, Qt::AlignCenter, "LIVE");
 
-    const float msPerRow = std::max(1.0f, m_wfMsPerRow);
+    const float msPerRow =
+        std::max(1.0f, waterfallTimeScaleMsPerRow());
     const QRect labelRect = strip.adjusted(0, 4, 0, 0);
     const float totalSec = labelRect.height() * msPerRow / 1000.0f;
     if (totalSec <= 0) return;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -939,9 +939,13 @@ private:
 #ifdef AETHER_GPU_SPECTRUM
     void prepareWaterfallFrameUpload();
 #endif
+    // startScrollAnimation: begin the one-row scroll interpolation. Multi-row
+    // callers (updateWaterfallRow) pass false and issue a single start() for the
+    // whole tile instead of restarting the clock once per appended row.
     void appendVisibleRow(const QRgb* rowData,
                           double frameCenterMhz = -1.0,
-                          double frameBandwidthMhz = -1.0);
+                          double frameBandwidthMhz = -1.0,
+                          bool startScrollAnimation = true);
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;
     int historyRowIndexForAge(int ageRows) const;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -211,6 +211,7 @@ public:
     void setKiwiSdrWaterfallProfile(const QString& profileId);
     void clearKiwiSdrWaterfallRows();
     void clearKiwiSdrWaterfallRowsForProfile(const QString& profileId);
+    void setKiwiSdrWaterfallRate(int rate);
     void setKiwiSdrWaterfallDisplayRange(float minDbm, float maxDbm,
                                          bool autoRange);
     void updateKiwiSdrWaterfallRow(const QVector<float>& binsDbm,
@@ -227,6 +228,7 @@ public:
     void setNoiseFloorPosition(int pos);
     void setNoiseFloorEnable(bool on);
     void prepareForFftScaleChange();
+    void prepareForFftPixelScaleChange();
     void suspendNoiseFloorAutoAdjustUntil(qint64 untilMs);
     void resumeNoiseFloorAutoAdjust();
     void reacquireNoiseFloorLock();
@@ -836,6 +838,14 @@ private:
     void rebuildDssViewportFromHistory();
     void rebuildDssViewportFromHistoryForFrame(double centerMhz, double bandwidthMhz);
     void setWaterfallLive(bool live);
+    void startWaterfallScrollAnimation(float distanceRows = 1.0f);
+    void stopWaterfallScrollAnimation();
+    float waterfallScrollProgressRows() const;
+    float waterfallPresentationMsPerRow() const;
+    float waterfallTimeScaleMsPerRow() const;
+    void observeKiwiSdrWaterfallCadence(qint64 rowTimestampMs);
+    void resetKiwiSdrWaterfallCadence();
+    bool flexDssFftScaleSettling() const;
     void handleWaterfallFrequencyFrameChange(double oldCenterMhz,
                                              double oldBandwidthMhz,
                                              double newCenterMhz,
@@ -1040,11 +1050,11 @@ private:
     QRgb waterfallLevelToRgb(float level) const;
     static quint8 encodeWaterfallLevel(float level);
     std::array<QRgb, 256> waterfallHistoryColorLut() const;
-    // 3DSS surface colour for a normalised strength s in [0,1] (0 = noise floor,
-    // 1 = ref). The full colormap gradient, gamma-shaped by the "3D Gain"
-    // control. Shared by the GPU LUT bake and the CPU fallback so both paths
-    // colour identically (deliberately NOT dbmToRgb(), whose waterfall
-    // black-level window clipped the lower range to black).
+    // 3DSS surface colour for a normalised strength s in [0,1] across the stable
+    // colour aperture. The full colormap gradient is gamma-shaped by "3D Gain".
+    // Shared by the GPU LUT and CPU fallback so both paths colour identically
+    // (deliberately NOT dbmToRgb(), whose waterfall black-level window clipped
+    // the lower range to black).
     QRgb dssStrengthToRgb(float s) const;
 
     // 3DSS — rebuild/return the cached perspective surface for the given pixel
@@ -1060,9 +1070,10 @@ private:
     // Token folding the dbmToRgb() palette inputs so the 3DSS cache rebuilds
     // when the colour mapping (scheme/gain/floor) changes.
     quint64 dssPaletteToken() const;
-    // Unified noise-floor anchor (dBm, quantised) for the 3D surface.
+    // Source-selected floor anchor (dBm, quantised) for the 3D surface.
     float dssFloorDbm();
     float peekDssFloorDbm() const;
+    float kiwiDssPresentationFloorDbm(float fallbackFloorDbm) const;
     // dB span shown above the 3D floor anchor — follows the normal dBm scale,
     // with an upper cap so an excessively wide Flex window cannot flatten it.
     float dssSpanDb() const;
@@ -1086,6 +1097,12 @@ private:
     WaterfallStreamState m_nativeWaterfallState;
     WaterfallStreamState m_kiwiWaterfallState;
     QHash<QString, WaterfallStreamState> m_kiwiProfileWaterfallStates;
+    QHash<QString, ObservedWaterfallCadence> m_kiwiWaterfallCadenceByProfile;
+    QHash<QString, int> m_kiwiWaterfallRateByProfile;
+    // Presentation anchors outlive stream-row resets/rebinds. Motion cadence
+    // may reacquire independently; only an explicit rate change relatches time.
+    QHash<QString, StablePresentationAnchor> m_kiwiTimeScaleAnchorsByProfile;
+    QHash<QString, StablePresentationAnchor> m_kiwiDssFloorAnchorsByProfile;
     // True while the current waterfall state is the operator-visible source.
     // Hidden Flex/Kiwi updates temporarily swap their state into the current
     // fields; instrumentation and retention policy need to distinguish that
@@ -1251,6 +1268,10 @@ private:
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
     float m_dssFloorAnchorDbm{-1000.0f};
     bool  m_dssFloorAnchorValid{false};
+    // The radio can briefly deliver FFT packets encoded with the old y_pixels
+    // after acknowledging a new height. Keep those rows out of retained 3D
+    // history; the live 2D trace and waterfall continue normally.
+    qint64 m_flexDssFftScaleSettlingUntilMs{0};
     // Consumed by BOTH the GPU mesh and the CPU fallback surface, so these stay
     // outside the AETHER_GPU_SPECTRUM block below — the CPU paint path needs them
     // even when GPU spectrum rendering is disabled (older Qt / -DAETHER_GPU_SPECTRUM=OFF).
@@ -1271,6 +1292,12 @@ private:
     // Scrolling waterfall image (Format_RGB32)
     QImage m_waterfall;
     int    m_wfWriteRow{0};  // ring buffer: next row to write (newest at top)
+    // A received row appears immediately, then the viewport advances it by one
+    // row over the observed row interval. This changes display position only;
+    // the retained radio rows remain discrete and authoritative.
+    QTimer* m_waterfallScrollTimer{nullptr};
+    QElapsedTimer m_waterfallScrollClock;
+    float m_waterfallScrollDistanceRows{1.0f};
     // Per-visible-row frequency frame, indexed by the physical waterfall ring
     // row. The GPU uses this to place each row in the current viewport without
     // flattening the entire live texture into one pan/zoom frame.
@@ -1715,9 +1742,8 @@ private:
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge line segments, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
-    // ubo[] writer in renderGpuFrame(). 8 surface scalars + texCols + the three
-    // frequency-preview scalars + vec4 bgFill.
-    static constexpr int kDssMeshUboFloats = 16;
+    // ubo[] writer in renderGpuFrame(). Five vec4 scalar groups plus bgFill.
+    static constexpr int kDssMeshUboFloats = 24;
     QRhiTexture* m_dssHeightTex{nullptr};    // R16F ring heightmap (cols x rows)
     QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT
     QRhiSampler* m_dssHeightSampler{nullptr};

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -162,6 +162,202 @@ int testWaterfallPipelineSelection()
     return 0;
 }
 
+int testWaterfallScrollProgress()
+{
+    using namespace AetherSDR;
+    if (!nearlyEqual(waterfallScrollProgressRows(0, 40.0f), 0.0)
+        || !nearlyEqual(waterfallScrollProgressRows(10, 40.0f), 0.25)
+        || !nearlyEqual(waterfallScrollProgressRows(40, 40.0f), 1.0)
+        || !nearlyEqual(waterfallScrollProgressRows(80, 40.0f), 1.0)
+        || !nearlyEqual(waterfallScrollProgressRows(80, 40.0f, 3.0f), 2.0)
+        || !nearlyEqual(waterfallScrollProgressRows(160, 40.0f, 3.0f), 3.0)) {
+        return fail("waterfall scrolling should advance one row over one interval");
+    }
+    if (!nearlyEqual(waterfallScrollProgressRows(-1, 40.0f), 0.0)
+        || !nearlyEqual(waterfallScrollProgressRows(10, 0.0f), 0.0)
+        || !nearlyEqual(
+            waterfallScrollProgressRows(
+                10, std::numeric_limits<float>::quiet_NaN()),
+            0.0)) {
+        return fail("invalid waterfall timing should disable interpolation");
+    }
+    if (!nearlyEqual(waterfallScrollProgressUnit(0.5f, 100), 0.005, 1.0e-6)
+        || !nearlyEqual(waterfallScrollProgressUnit(2.0f, 100), 0.01, 1.0e-6)
+        || !nearlyEqual(
+            waterfallScrollProgressUnit(0.5f, 0), 0.0, 1.0e-6)) {
+        return fail("waterfall row progress should normalize to texture height");
+    }
+    if (!nearlyEqual(
+            waterfallScrollSampleOffsetUnit(0.0f, 1.0f, 100), 0.01, 1.0e-6)
+        || !nearlyEqual(
+            waterfallScrollSampleOffsetUnit(0.5f, 1.0f, 100), 0.005, 1.0e-6)
+        || !nearlyEqual(
+            waterfallScrollSampleOffsetUnit(1.0f, 1.0f, 100), 0.0, 1.0e-6)
+        || !nearlyEqual(
+            waterfallScrollSampleOffsetUnit(1.0f, 3.0f, 100), 0.02, 1.0e-6)
+        || !nearlyEqual(
+            waterfallScrollSampleOffsetUnit(0.5f, 1.0f, 0), 0.0, 1.0e-6)) {
+        return fail("waterfall sample offset should preserve the row handoff");
+    }
+    return 0;
+}
+
+int testDssFftScaleSettleWindow()
+{
+    using namespace AetherSDR;
+    if (!dssFftScaleSettleActive(1000, 1750)
+        || dssFftScaleSettleActive(1750, 1750)
+        || dssFftScaleSettleActive(1800, 1750)
+        || dssFftScaleSettleActive(1000, 0)) {
+        return fail("3D FFT scale settling must end exactly at its deadline");
+    }
+    return 0;
+}
+
+int testDssStartupHistoryAvailability()
+{
+    using namespace AetherSDR;
+    if (!nearlyEqual(dssHistoryAvailability(4.0f, 4.0f), 0.0)
+        || !nearlyEqual(dssHistoryAvailability(3.5f, 4.0f), 0.5)
+        || !nearlyEqual(dssHistoryAvailability(3.0f, 4.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(2.0f, 4.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(
+                            std::numeric_limits<float>::quiet_NaN(), 4.0f),
+                        0.0)
+        || !nearlyEqual(dssHistoryAvailability(0.0f, 0.0f), 0.0)) {
+        return fail("3D FFT startup history should fade in continuously");
+    }
+    return 0;
+}
+
+int testObservedWaterfallCadence()
+{
+    using namespace AetherSDR;
+    ObservedWaterfallCadence cadence;
+    StablePresentationAnchor timeScaleAnchor;
+    if (observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1000)
+        || cadence.valid
+        || !nearlyEqual(observedWaterfallMsPerRow(cadence, 75.0f), 75.0)
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor, 75.0f),
+            75.0)) {
+        return fail("first waterfall row should only seed cadence timing");
+    }
+    if (!observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1100)
+        || !cadence.valid
+        || !nearlyEqual(cadence.msPerRow, 100.0)
+        || timeScaleAnchor.locked
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor),
+            100.0)) {
+        return fail("second waterfall row should establish observed cadence");
+    }
+    if (!observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1220)
+        || !nearlyEqual(cadence.msPerRow, 110.0)
+        || timeScaleAnchor.locked
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor),
+            100.0)) {
+        return fail("waterfall cadence should smooth ordinary arrival jitter");
+    }
+    if (observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1220)
+        || !nearlyEqual(cadence.msPerRow, 110.0)) {
+        return fail("duplicate waterfall timestamps must not change cadence");
+    }
+    if (!observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1360)
+        || !nearlyEqual(cadence.msPerRow, 125.0)
+        || !timeScaleAnchor.locked
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor),
+            112.0)) {
+        return fail("Kiwi time scale should lock after startup acquisition");
+    }
+    if (!observeWaterfallCadenceAndTimeScale(
+            cadence, timeScaleAnchor, 1560)
+        || !nearlyEqual(cadence.msPerRow, 140.0)
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor),
+            112.0)) {
+        return fail("arrival jitter must not move the locked Kiwi time scale");
+    }
+    if (!nearlyEqual(
+            selectedWaterfallMsPerRow(false, 82.0f, &cadence), 82.0)
+        || !nearlyEqual(
+            selectedWaterfallMsPerRow(true, 82.0f, &cadence), 140.0)
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                false, 82.0f, &timeScaleAnchor),
+            82.0)
+        || !nearlyEqual(
+            selectedWaterfallMsPerRow(
+                true, 82.0f, nullptr, 95.0f),
+            95.0)
+        || !nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, nullptr, 95.0f),
+            95.0)) {
+        return fail("Kiwi cadence selection must not alter Flex timing");
+    }
+
+    cadence = ObservedWaterfallCadence{};
+    if (!nearlyEqual(
+            selectedWaterfallTimeScaleMsPerRow(
+                true, 82.0f, &timeScaleAnchor),
+            112.0)) {
+        return fail("Kiwi stream resets must preserve the locked time scale");
+    }
+    observeWaterfallCadence(cadence, 2000);
+    if (!observeWaterfallCadence(cadence, 7000)
+        || !nearlyEqual(cadence.msPerRow, 5000.0)) {
+        return fail("slow Kiwi waterfall rates must retain their full interval");
+    }
+    return 0;
+}
+
+int testStablePresentationAnchor()
+{
+    using namespace AetherSDR;
+    StablePresentationAnchor anchor;
+    if (observeStablePresentationAnchor(
+            anchor, std::numeric_limits<float>::quiet_NaN())
+        || anchor.hasValue) {
+        return fail("presentation anchors must reject invalid samples");
+    }
+    if (!observeStablePresentationAnchor(anchor, -101.1f, 3, 0.5f)
+        || !anchor.hasValue
+        || anchor.locked
+        || !nearlyEqual(
+            stablePresentationValue(anchor, -90.0f), -101.1, 1.0e-4)) {
+        return fail("first presentation sample should establish a fixed provisional value");
+    }
+    if (!observeStablePresentationAnchor(anchor, -99.9f, 3, 0.5f)
+        || anchor.locked
+        || !nearlyEqual(
+            stablePresentationValue(anchor, -90.0f), -101.1, 1.0e-4)) {
+        return fail("presentation acquisition should not move the provisional axis");
+    }
+    if (!observeStablePresentationAnchor(anchor, -100.2f, 3, 0.5f)
+        || !anchor.locked
+        || !nearlyEqual(stablePresentationValue(anchor, -90.0f), -100.5)) {
+        return fail("presentation anchor should lock to a quantized acquisition mean");
+    }
+    if (observeStablePresentationAnchor(anchor, -80.0f, 3, 0.5f)
+        || !nearlyEqual(stablePresentationValue(anchor, -90.0f), -100.5)) {
+        return fail("locked presentation anchors must ignore live measurement drift");
+    }
+    return 0;
+}
+
 } // namespace
 
 int main()
@@ -175,5 +371,20 @@ int main()
     if (const int result = testCommandThrottle(); result != 0) {
         return result;
     }
-    return testWaterfallPipelineSelection();
+    if (const int result = testWaterfallPipelineSelection(); result != 0) {
+        return result;
+    }
+    if (const int result = testWaterfallScrollProgress(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssFftScaleSettleWindow(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssStartupHistoryAvailability(); result != 0) {
+        return result;
+    }
+    if (const int result = testObservedWaterfallCadence(); result != 0) {
+        return result;
+    }
+    return testStablePresentationAnchor();
 }

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -181,12 +181,6 @@ int testWaterfallScrollProgress()
             0.0)) {
         return fail("invalid waterfall timing should disable interpolation");
     }
-    if (!nearlyEqual(waterfallScrollProgressUnit(0.5f, 100), 0.005, 1.0e-6)
-        || !nearlyEqual(waterfallScrollProgressUnit(2.0f, 100), 0.01, 1.0e-6)
-        || !nearlyEqual(
-            waterfallScrollProgressUnit(0.5f, 0), 0.0, 1.0e-6)) {
-        return fail("waterfall row progress should normalize to texture height");
-    }
     if (!nearlyEqual(
             waterfallScrollSampleOffsetUnit(0.0f, 1.0f, 100), 0.01, 1.0e-6)
         || !nearlyEqual(


### PR DESCRIPTION
## Summary

Smooths waterfall and 3D FFT movement between discrete radio updates for both Flex and KiwiSDR sources. The renderer now interpolates display position using the observed row cadence while preserving the underlying radio data. It also stabilizes 3D shading and color, eliminates startup spikes and incomplete-history stepping, and prevents KiwiSDR’s waterfall time scale and 3D dBm scale from shifting with ordinary cadence and noise-floor variation.

The stepping came from presenting each discrete row immediately at its final position. The Kiwi scale instability had a related cause: presentation axes consumed continuously changing cadence and trace-floor estimates. This change keeps those measurements adaptive for motion and data processing while latching stable per-profile presentation anchors. Kiwi anchors survive stream rebinds and pan/zoom activity; the time ruler is reacquired only when the configured waterfall rate changes. Flex timing and display state remain independent.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The changes were verified with focused regression tests, a complete local build on the current upstream base, strict engine-boundary validation, and live receive-side testing against a real FLEX-6700 and KiwiSDR source.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Focused tests passed:

- `spectrum_preview_logic_test`
- `dss_renderer_test`
- `waterfall_history_buffer_test`
- `kiwi_sdr_trace_math_test`

Additional validation:

- `git diff --check` passes.
- `tools/check_engine_boundary.py --strict` reports zero blocking findings.
- Verified on a FLEX-6700 running firmware 4.2.18.
- Verified with the `kiwisdr.itfais.com:8073` KiwiSDR profile.
- Confirmed smooth waterfall and 3D FFT movement at multiple update rates.
- Confirmed 3D fill shading and signal-strength colors remain present and stable.
- Confirmed startup history no longer produces spikes or stepping rows.
- Confirmed KiwiSDR motion cadence remains adaptive while the time scale stays fixed.
- Confirmed KiwiSDR trace-floor estimates can vary while the 3D dBm anchor stays fixed.
- Exercised KiwiSDR pan/zoom and stream rebind activity without moving either presentation scale.
- Live verification ran with `AETHER_AUTOMATION_NO_TX=1`; `txAllowed` remained false and the radio remained non-transmitting.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (no meter UI changed)
- [x] Documentation updated if user-visible behavior changed
      (N/A — no user-facing documentation describes renderer cadence)
- [x] Security-sensitive changes reference a GHSA if applicable
      (N/A — no security-sensitive behavior changed)
