### PR TITLE
[ux] Persist applet dock state immediately

### DIFF
--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -10,6 +10,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QScopedValueRollback>
 #include <QString>
 #include <QStringList>
 
@@ -291,7 +292,7 @@ void ContainerManager::floatContainer(const QString& id)
     if (auto* tb = c->titleBar()) tb->setAlwaysOnTopState(aot);
 
     win->show();
-    saveState();
+    persistState();
 }
 
 void ContainerManager::dockContainer(const QString& id)
@@ -333,7 +334,7 @@ void ContainerManager::dockContainer(const QString& id)
         }
         released->show();
     }
-    saveState();
+    persistState();
 }
 
 void ContainerManager::setFramelessMode(bool on)
@@ -345,7 +346,7 @@ void ContainerManager::setFramelessMode(bool on)
 
 void ContainerManager::prepareShutdown()
 {
-    saveState();  // commit current floating/visibility state before closing windows
+    persistState();  // commit current floating/visibility state before closing windows
     for (auto* win : m_floatingWindows) {
         win->prepareShutdown();
     }
@@ -381,7 +382,7 @@ void ContainerManager::onCloseRequested()
     auto* c = qobject_cast<ContainerWidget*>(sender());
     if (!c) return;
     c->setContainerVisible(false);
-    saveState();
+    persistState();
 }
 
 void ContainerManager::onAlwaysOnTopToggled(bool on)
@@ -393,6 +394,7 @@ void ContainerManager::onAlwaysOnTopToggled(bool on)
     if (auto* win = m_floatingWindows.value(id, nullptr)) {
         win->setAlwaysOnTop(on);
     }
+    AppSettings::instance().save();
 }
 
 void ContainerManager::onFloatingWindowDock(ContainerWidget* c)
@@ -437,6 +439,19 @@ void ContainerManager::saveState() const
         QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact)));
 }
 
+void ContainerManager::persistState() const
+{
+    // restoreState() calls floatContainer() while reconstructing the saved
+    // tree. Persisting those intermediate states could replace a complete
+    // multi-container tree if startup is interrupted part-way through.
+    if (m_restoringState) {
+        return;
+    }
+
+    saveState();
+    AppSettings::instance().save();
+}
+
 void ContainerManager::restoreState()
 {
     const QString json = AppSettings::instance()
@@ -449,6 +464,7 @@ void ContainerManager::restoreState()
     if (root.value("version").toInt() != kSchemaVersion) return;
 
     const QJsonObject containers = root.value("containers").toObject();
+    QScopedValueRollback<bool> restoringState(m_restoringState, true);
 
     // First pass: create every container without inserting children.
     // This guarantees parent containers exist before we try to parent

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -110,6 +110,8 @@ public:
     //   }
     //
     // Phase 3 adds "parent" and "children" fields for nesting.
+    // User-driven window-state transitions flush this snapshot to disk
+    // immediately; saveState() itself only updates the AppSettings map.
     void saveState() const;
     void restoreState();
 
@@ -133,11 +135,13 @@ private:
     };
 
     void wireContainer(ContainerWidget* container);
+    void persistState() const;
 
     QMap<QString, QPointer<ContainerWidget>> m_containers;
     QMap<QString, FloatingContainerWindow*> m_floatingWindows;
     QMap<QString, ContentFactory>           m_factories;
     QMap<QString, Meta>                     m_meta;
+    bool                                    m_restoringState{false};
 };
 
 } // namespace AetherSDR

--- a/tests/container_manager_test.cpp
+++ b/tests/container_manager_test.cpp
@@ -7,6 +7,8 @@
 #include "core/AppSettings.h"
 
 #include <QApplication>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -134,6 +136,62 @@ void testSaveRestoreRoundTrip()
     report("beta hidden state restored",      beta  && !beta->isContainerVisible());
 }
 
+void testDockTransitionPersistsImmediately()
+{
+    auto& settings = AppSettings::instance();
+
+    QJsonObject rx;
+    rx["mode"] = "floating";
+    rx["visible"] = true;
+    rx["contentType"] = "";
+    rx["parent"] = "";
+
+    QJsonObject containers;
+    containers["RX"] = rx;
+
+    QJsonObject root;
+    root["version"] = 1;
+    root["containers"] = containers;
+
+    settings.setValue(
+        "ContainerTree",
+        QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact)));
+    settings.save();
+    settings.reset();
+    settings.load();
+
+    {
+        QWidget panel;
+        auto* layout = new QVBoxLayout(&panel);
+        layout->setContentsMargins(0, 0, 0, 0);
+
+        ContainerManager manager;
+        ContainerWidget* container =
+            manager.createContainer("RX", "RX Controls");
+        layout->addWidget(container);
+
+        manager.restoreState();
+        report("seed state restores RX floating", container->isFloating());
+
+        manager.dockContainer("RX");
+        report("dock transition updates live RX state",
+               container->isPanelDocked());
+    }
+
+    // Simulate a new process without any final main-window shutdown save.
+    settings.reset();
+    settings.load();
+
+    const QJsonDocument persisted = QJsonDocument::fromJson(
+        settings.value("ContainerTree", "").toString().toUtf8());
+    const QString mode = persisted.object()
+        .value("containers").toObject()
+        .value("RX").toObject()
+        .value("mode").toString();
+    report("dock transition is durable before shutdown", mode == "panel",
+           mode.toStdString());
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -151,6 +209,7 @@ int main(int argc, char** argv)
     testContentFactory();
     testFloatDockViaManager();
     testSaveRestoreRoundTrip();
+    testDockTransitionPersistsImmediately();
 
     std::printf("\n%s\n",
                 g_failed == 0


### PR DESCRIPTION
## Summary

- atomically flush applet window state when float, dock, close, or always-on-top transitions complete
- suppress persistence while `restoreState()` reconstructs saved floating windows, so startup can never write a partial container tree
- add a disk-reload regression that proves docking is durable without relying on the main-window shutdown save

## Root cause

`ContainerManager::saveState()` updated only the in-memory `AppSettings` map. Returning an applet to the panel looked correct, but the settings file still contained `"mode":"floating"` until `MainWindow::closeEvent()` eventually called `AppSettings::save()`. A restart or termination before that unrelated shutdown flush therefore restored the stale floating state.

## Proof

The same isolated macOS profile and automation action (`invoke RX/containerFloatToggle click`) were used before and after the fix.

**Before:** after RX visibly returned to the panel, `dumpTree` reported zero visible `FloatingContainerWindow` roots, but the on-disk mode remained `floating`. Terminating and relaunching restored one floating window.

![Before: stale floating RX window restored](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4427-assets/.pr-assets/4427-before.png)

**After:** the completed dock action immediately changed the on-disk mode to `panel`. After terminating without a close event and relaunching, `dumpTree` reported `floatingWindows: 0`, `rxCount: 1`; RX remained in the main panel.

![After: RX remains docked after restart](https://raw.githubusercontent.com/jensenpat/AetherSDR/fix-4427-assets/.pr-assets/4427-after.png)

No radio connection or transmit action was used.

## Testing

- `cmake --build build --parallel 8`
- `QT_QPA_PLATFORM=offscreen ./build/container_manager_test`
- `QT_QPA_PLATFORM=offscreen ./build/container_nesting_test`
- `ctest --test-dir build -R ^container_widget_test$ --output-on-failure`
- `python3 tools/check_engine_boundary.py --strict` (0 blocking findings)
- macOS automation bridge: float seed → restart → dock → terminate → relaunch

Fixes #4427

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat