### PR TITLE
[tci] Broadcast DSP, squelch, RIT/XIT and TX power on model change

### DIFF
--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -122,17 +122,23 @@ SliceModel* TciProtocol::sliceForVfo(int trx, int channel) const
 // (#4161). This path is driven by a client command arriving at an arbitrary
 // moment, so it only ever meets that window by coincidence, and a transiently
 // 0-labelled reply is the same fallback the burst has always emitted.
-int TciProtocol::txTrx() const
+int TciProtocol::txSliceTrxOrNone(RadioModel* model)
 {
-    if (!m_model) {
-        return 0;
+    if (!model) {
+        return -1;
     }
-    for (SliceModel* slice : m_model->slices()) {
+    for (SliceModel* slice : model->slices()) {
         if (slice && slice->isTxSlice()) {
-            return tciTrxForSlice(m_model, slice);
+            return tciTrxForSlice(model, slice);
         }
     }
-    return 0;
+    return -1;
+}
+
+int TciProtocol::txTrx() const
+{
+    const int trx = txSliceTrxOrNone(m_model);
+    return trx < 0 ? 0 : trx;  // request/response wire needs a concrete index
 }
 
 // DDS = the IQ-stream center frequency a skimmer (CW Skimmer / SDC) decodes

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -108,6 +108,20 @@ SliceModel* TciProtocol::sliceForVfo(int trx, int channel) const
     return rxSlice;
 }
 
+// TRX index of the TX slice for the request/response path — the init burst and
+// the DRIVE/TUNE_DRIVE replies. Falls back to 0 when no slice is marked TX,
+// because the wire needs a concrete index and 0 is what the burst has always
+// used.
+//
+// TciServer has a near-twin, txTrxIndex(), which returns -1 for "none" and
+// resolves that against a cached last-known TX trx. The difference is
+// deliberate and worth understanding before merging them: that one serves the
+// async broadcast, which is driven by the radio's own power restore during a
+// band change — i.e. it fires *inside* the window where the recreated slice has
+// not yet regained its TX flag, so without the cache it would reliably mislabel
+// (#4161). This path is driven by a client command arriving at an arbitrary
+// moment, so it only ever meets that window by coincidence, and a transiently
+// 0-labelled reply is the same fallback the burst has always emitted.
 int TciProtocol::txTrx() const
 {
     if (!m_model) {
@@ -273,6 +287,15 @@ QString TciProtocol::generateInitBurst()
                          .arg(trx).arg(s->anfOn() ? "true" : "false");
             burst += QStringLiteral("rx_apf_enable:%1,%2;")
                          .arg(trx).arg(s->apfOn() ? "true" : "false");
+
+            // Mute. Seeded here for the same reason sql/DSP are: without it a
+            // connecting client's mute mirror starts at a default guess, and
+            // mute was the one flag in this family the burst never carried
+            // (#4161). audioMute() is the effective value -- it follows the
+            // external-receive source when one is replacing Flex RX audio,
+            // which is also what audioMuteChanged carries.
+            burst += QStringLiteral("mute:%1,%2;")
+                         .arg(trx).arg(s->audioMute() ? "true" : "false");
 
             // TX
             burst += QStringLiteral("tx_enable:%1,%2;")

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -152,6 +152,14 @@ public:
     // slice is not in the model's list.
     static int tciTrxForSlice(RadioModel* model, const SliceModel* slice);
 
+    // The single scan for "which trx is the TX slice", returning -1 when none
+    // is marked. Both TX-trx resolvers build on this so the scan lives in one
+    // place; they differ ONLY in how they map the -1 sentinel (txTrx() below
+    // returns 0 for the request/response wire; TciServer's async broadcast
+    // resolves -1 against a cached last-known trx, #4161). Keeping the scan
+    // shared means a future change to slice iteration can't drift one path.
+    static int txSliceTrxOrNone(RadioModel* model);
+
     // Resolve a contiguous TCI receiver index, then the legacy raw Flex slice
     // id, then the first slice for compatibility. Shared by parser and server
     // command paths so GET and SET never target different receivers.

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -76,8 +76,36 @@ constexpr qint64 kTxChronoPeriodNs =
 constexpr int kTxChronoPollMs = 5;
 constexpr qint64 kTxSummaryEveryBlocks = 48;
 
+// Minimum gap between drive:/tune_drive: sends (#4161). Measured on a
+// FLEX-6600 over SmartLink: one RF-power slider drag emitted 40 `drive:`
+// broadcasts in ~900 ms — without this, every one of those reaches every
+// client. With it, the same drag settles to ~20 over 2.8 s.
+constexpr int kPowerRateLimitMs = 100;
+
 // parseStatusHandle / streamStatusBelongsToUs  → StreamStatus.h
 // tciTrxForSlice                               → TciProtocol::tciTrxForSlice
+
+// TRX index of the current TX slice, or -1 when none is currently marked.
+// Note TciProtocol::txTrx() is the request/response twin of this and returns 0
+// rather than -1; see the comment there for why the two differ.
+// drive/tune_drive are radio-global but ship TRX-prefixed on the wire, so the
+// caller resolves -1 against a cached last-known TX trx: a band change on a
+// multi-slice setup recreates the TX slice and restores its TX flag *after*
+// the power change is processed, so a plain scan would momentarily find no TX
+// slice and mislabel drive with trx 0 (#4161). -1 (not 0) is returned for
+// "none" because trx 0 is a legitimate TX slice and must be distinguishable.
+int txTrxIndex(RadioModel* model)
+{
+    if (!model) {
+        return -1;
+    }
+    for (auto* s : model->slices()) {
+        if (s->isTxSlice()) {
+            return TciProtocol::tciTrxForSlice(model, s);
+        }
+    }
+    return -1;
+}
 
 } // namespace
 
@@ -129,6 +157,17 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 this, [this](float dbfs) {
             m_cachedAlc = dbfs;
         });
+
+        // RF/tune power → `drive:` / `tune_drive:` broadcast (#4161). Without
+        // this, power was announced only in the init burst and as an echo to
+        // the client that set it: a GUI change or the radio's own per-band
+        // power restore on QSY stayed invisible to every TCI client until
+        // reconnect, leaving control-surface dials showing a stale figure
+        // while the operator keyed an amplifier against it (#4310).
+        connect(&m_model->transmitModel(), &TransmitModel::rfPowerChanged,
+                this, [this](int) { m_drivePending = true; queuePowerBroadcast(); });
+        connect(&m_model->transmitModel(), &TransmitModel::tunePowerChanged,
+                this, [this](int) { m_tuneDrivePending = true; queuePowerBroadcast(); });
     }
 
     // Capture DAX RX stream creation responses so we can register them
@@ -292,6 +331,19 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
     m_meterTimer->setInterval(200);
     connect(m_meterTimer, &QTimer::timeout, this, &TciServer::broadcastStatus);
 
+    // Rate limiter for drive:/tune_drive: — see queuePowerBroadcast().
+    m_powerRateTimer = new QTimer(this);
+    m_powerRateTimer->setSingleShot(true);
+    m_powerRateTimer->setInterval(kPowerRateLimitMs);
+    connect(m_powerRateTimer, &QTimer::timeout, this, [this]() {
+        if (!m_drivePending && !m_tuneDrivePending) {
+            return;  // no trailing change; let the timer lapse so the next
+                     // change gets a fresh leading edge
+        }
+        broadcastPower();
+        m_powerRateTimer->start();
+    });
+
     // Debounced DAX RX teardown — see scheduleDaxRelease(). Single-shot; a
     // reconnecting audio client cancels it before it fires.
     m_daxReleaseTimer = new QTimer(this);
@@ -419,6 +471,72 @@ void TciServer::broadcastMasterVolume(int pct)
     // 0-100 amplitude from the title bar slider / applyMasterVolume.
     broadcast(QStringLiteral("volume:%1;")
                   .arg(TciProtocol::volumeDbFromPercent(pct)));
+}
+
+// Rate-limited entry point for TransmitModel's power signals (#4161).
+//
+// Leading edge sends immediately, so a client's own SET still echoes in a few
+// ms and a band change announces the new per-band power without added latency.
+// Anything arriving inside the window is collapsed: one trailing send carries
+// whatever the latest value turned out to be. A power-slider drag steps ~40
+// times a second (each step is its own `transmit set rfpower=` to the radio),
+// and relaying every one floods clients that are often on the far side of a
+// SmartLink hop.
+void TciServer::queuePowerBroadcast()
+{
+    // The pending flag for the field that changed is set by the caller. Inside
+    // the rate window we do nothing more — the trailing flush picks it up.
+    if (m_powerRateTimer->isActive()) {
+        return;
+    }
+    broadcastPower();
+    m_powerRateTimer->start();
+}
+
+void TciServer::broadcastPower()
+{
+    if (m_clients.isEmpty() || !m_model) {
+        m_drivePending = false;
+        m_tuneDrivePending = false;
+        // Forget what was last sent. The de-dup below means "the clients
+        // already have this value", which is worthless with none attached:
+        // power moves while disconnected, a reconnecting client is seeded
+        // from the init burst, and a surviving cache would then suppress the
+        // next genuine change back to the remembered value — dial stuck on
+        // the old figure while the radio keys at the new one (#4161).
+        m_lastDriveSent = -1;
+        m_lastTuneDriveSent = -1;
+        return;
+    }
+    auto& tx = m_model->transmitModel();
+    // Resolve the TX trx, falling back to the last known one when a slice
+    // recreation has momentarily cleared every TX flag (#4161). Refresh the
+    // cache whenever a real TX slice is found.
+    int trx = txTrxIndex(m_model);
+    if (trx < 0) {
+        trx = m_lastTxTrx;
+    } else {
+        m_lastTxTrx = trx;
+    }
+
+    // Only the field that actually changed is sent — sending drive must not
+    // drag tune_drive onto the wire (and vice versa). Value de-dup still
+    // guards a change that lands back on the last-sent value inside a window.
+    if (m_drivePending) {
+        m_drivePending = false;
+        if (tx.rfPower() != m_lastDriveSent) {
+            m_lastDriveSent = tx.rfPower();
+            broadcast(QStringLiteral("drive:%1,%2;").arg(trx).arg(m_lastDriveSent));
+        }
+    }
+    if (m_tuneDrivePending) {
+        m_tuneDrivePending = false;
+        if (tx.tunePower() != m_lastTuneDriveSent) {
+            m_lastTuneDriveSent = tx.tunePower();
+            broadcast(QStringLiteral("tune_drive:%1,%2;")
+                          .arg(trx).arg(m_lastTuneDriveSent));
+        }
+    }
 }
 
 void TciServer::setTxGain(float gain)
@@ -2135,11 +2253,23 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
     });
 
     connect(slice, &SliceModel::txSliceChanged, this, [this, slice](bool tx) {
-        if (m_clients.isEmpty()) return;
         const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
+        // Keep the drive:/tune_drive: label cache truthful even with no
+        // clients attached, so a later power change resolves the right trx
+        // (#4161). Only a slice *gaining* TX updates it; the losing edge
+        // leaves the cache pointing at the outgoing slice for the brief
+        // band-change gap, which is the value drive should still use.
+        if (tx) m_lastTxTrx = trx;
+        if (m_clients.isEmpty()) return;
         broadcast(QStringLiteral("tx_enable:%1,%2;")
                       .arg(trx).arg(tx ? "true" : "false"));
     });
+
+    // Seed the TX-trx cache from current state — txSliceChanged only fires on
+    // a change, so a slice that is already TX at wire time would never set it.
+    if (slice->isTxSlice()) {
+        m_lastTxTrx = TciProtocol::tciTrxForSlice(m_model, slice);
+    }
 
     connect(slice, &SliceModel::lockedChanged, this, [this, slice](bool locked) {
         if (m_clients.isEmpty()) return;
@@ -2157,6 +2287,93 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
         broadcast(QStringLiteral("rx_volume:%1,%2;")
                       .arg(trx).arg(static_cast<int>(gain)));
     });
+
+    // DSP / squelch / RIT / XIT flags → per-slice broadcasts (#4161). These
+    // had no signal wiring at all, so a flag toggled in AetherSDR's own GUI
+    // was invisible to every TCI client, and the client that sent the SET was
+    // never told the radio accepted it (the command-echo path excludes the
+    // sender).
+    //
+    // Each relay is seeded from the slice's current state at wire time and
+    // then de-dups against that seed, dropping repeats. The de-dup is needed
+    // because SliceModel's emit discipline is uneven — nb/nr/anf/squelch/rit/
+    // xit re-emit on every status refresh whether or not the value moved,
+    // while apf/audioMute guard — and squelchChanged/ritChanged/xitChanged
+    // carry both the flag and its value, so spinning a RIT offset would
+    // otherwise re-announce an unchanged rit_enable on every step. De-duping
+    // here keeps this layer independent of that discipline.
+    //
+    // The seed is required for the same
+    // reason #4160 needed one: RadioModel decodes the radio's slice status
+    // BEFORE it emits sliceAdded, and sliceAdded is what triggers this wiring
+    // -- so for a newly added slice every flag edge has already fired by the
+    // time we connect, and nothing re-fires it. A Flex band change recreates
+    // the slice, so without the seed a band change left every connected
+    // client's DSP mirror stale until the operator next touched that control.
+    //
+    // The seed is a no-op before any client connects (slices are wired at
+    // startup); a client connecting later gets this state from the init burst.
+    auto emitFlag = [this](SliceModel* s, const char* cmd, bool on) {
+        if (m_clients.isEmpty()) {
+            return;
+        }
+        const int trx = TciProtocol::tciTrxForSlice(m_model, s);
+        broadcast(QStringLiteral("%1:%2,%3;")
+                      .arg(QLatin1String(cmd)).arg(trx)
+                      .arg(on ? "true" : "false"));
+    };
+
+    auto wireFlag = [this, slice, emitFlag](auto signal, const char* cmd, bool current) {
+        connect(slice, signal, this,
+                [slice, cmd, emitFlag, last = static_cast<int>(current)](bool on) mutable {
+            if (last == static_cast<int>(on)) {
+                return;
+            }
+            last = on;
+            emitFlag(slice, cmd, on);
+        });
+        emitFlag(slice, cmd, current);
+    };
+
+    wireFlag(&SliceModel::nbChanged,        "rx_nb_enable",  slice->nbOn());
+    wireFlag(&SliceModel::nrChanged,        "rx_nr_enable",  slice->nrOn());
+    wireFlag(&SliceModel::anfChanged,       "rx_anf_enable", slice->anfOn());
+    wireFlag(&SliceModel::apfChanged,       "rx_apf_enable", slice->apfOn());
+    wireFlag(&SliceModel::audioMuteChanged, "mute",          slice->audioMute());
+
+    // squelch/rit/xit carry (flag, value); only the flag is broadcast here.
+    // sql_level / rit_offset / xit_offset have the same gap but are out of
+    // scope for #4161, which is scoped to the *_enable family.
+    auto wireFlagWithValue = [this, slice, emitFlag](auto signal, const char* cmd, bool current) {
+        connect(slice, signal, this,
+                [slice, cmd, emitFlag, last = static_cast<int>(current)](bool on, int) mutable {
+            if (last == static_cast<int>(on)) {
+                return;
+            }
+            last = on;
+            emitFlag(slice, cmd, on);
+        });
+        emitFlag(slice, cmd, current);
+    };
+
+    // Known limitation, sql_enable only. Three squelch sources are in play and
+    // they diverge ONLY when m_externalReceiveAudioReplacement is set (a KiwiSDR
+    // RX source replacing Flex RX audio):
+    //   - init burst reports receiveSquelchOn()  — the effective value
+    //   - this seed matches the burst (receiveSquelchOn())
+    //   - squelchChanged carries squelchOn()      — the Flex-side m_squelchOn
+    // In that mode the de-dup baseline (effective) and the first edge (Flex-side)
+    // can disagree, producing one spurious sql_enable edge on connect. In normal
+    // mode all three are equal and there is no divergence. This is NOT the
+    // false→true transient seen on a band change — that is the pre-settle timing
+    // race (the seed reads the recreated slice before the radio restores its
+    // squelch), and it converges regardless of source. Left as-is deliberately:
+    // a real fix aligns all three sources and can only be verified with a
+    // KiwiSDR RX source, which is out of this change's *_enable scope. The seed
+    // matches the burst so a freshly-connected client is at least self-consistent.
+    wireFlagWithValue(&SliceModel::squelchChanged, "sql_enable", slice->receiveSquelchOn());
+    wireFlagWithValue(&SliceModel::ritChanged,     "rit_enable", slice->ritOn());
+    wireFlagWithValue(&SliceModel::xitChanged,     "xit_enable", slice->xitOn());
 
     // State sync on (re)wire, deferred. A Flex band change (display pan set
     // band=) tears down and recreates the slice, so wireSlice() runs again for

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -25,6 +25,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <functional>
+#include <memory>
 #include <utility>
 
 namespace AetherSDR {
@@ -86,25 +88,34 @@ constexpr int kPowerRateLimitMs = 100;
 // tciTrxForSlice                               → TciProtocol::tciTrxForSlice
 
 // TRX index of the current TX slice, or -1 when none is currently marked.
-// Note TciProtocol::txTrx() is the request/response twin of this and returns 0
-// rather than -1; see the comment there for why the two differ.
-// drive/tune_drive are radio-global but ship TRX-prefixed on the wire, so the
-// caller resolves -1 against a cached last-known TX trx: a band change on a
-// multi-slice setup recreates the TX slice and restores its TX flag *after*
-// the power change is processed, so a plain scan would momentarily find no TX
-// slice and mislabel drive with trx 0 (#4161). -1 (not 0) is returned for
-// "none" because trx 0 is a legitimate TX slice and must be distinguishable.
-int txTrxIndex(RadioModel* model)
+// Thin alias over TciProtocol::txSliceTrxOrNone() so the scan lives in one
+// place (see the header comment there). The async broadcast keeps the -1
+// sentinel and resolves it against a cached last-known TX trx: a band change
+// on a multi-slice setup recreates the TX slice and restores its TX flag
+// *after* the power change is processed, so a plain scan would momentarily
+// find no TX slice and mislabel drive with trx 0 (#4161). -1 (not 0) is
+// returned for "none" because trx 0 is a legitimate TX slice and must be
+// distinguishable.
+inline int txTrxIndex(RadioModel* model)
+{
+    return TciProtocol::txSliceTrxOrNone(model);
+}
+
+// True when some live slice currently maps to `trx`. Used to tell a genuine TX
+// slice *close* (nothing carries the cached trx anymore) apart from the
+// band-change recreation gap (the recreated slice carries the trx, it just has
+// not regained its TX flag yet). (#4161)
+bool trxHasLiveSlice(RadioModel* model, int trx)
 {
     if (!model) {
-        return -1;
+        return false;
     }
     for (auto* s : model->slices()) {
-        if (s->isTxSlice()) {
-            return TciProtocol::tciTrxForSlice(model, s);
+        if (s && TciProtocol::tciTrxForSlice(model, s) == trx) {
+            return true;
         }
     }
-    return -1;
+    return false;
 }
 
 } // namespace
@@ -258,6 +269,26 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 abortTciPtt();
             }
             m_tciDaxSlices.remove(sliceId);
+
+            // m_lastTxTrx caches the last TX slice's trx so a power change
+            // during the band-change slice-recreation gap still labels
+            // drive:/tune_drive: correctly (the recreated slice exists but has
+            // not regained its TX flag yet). A TX slice that is *closed* —
+            // removed with no recreation — would instead leave the cache
+            // pointing at a trx no live slice carries, mislabelling a later
+            // power change with a dead index. Tell the two apart by deferring
+            // past the ~340 ms settle window: a band change re-adds the slice
+            // (same id) well within it, so the cache still resolves to a live
+            // slice and this is a no-op; a genuine close leaves nothing carrying
+            // that trx and resets the cache to the burst's historical default.
+            if (!trxHasLiveSlice(m_model, m_lastTxTrx)) {
+                QTimer::singleShot(500, this, [this]() {
+                    if (m_model && !trxHasLiveSlice(m_model, m_lastTxTrx)) {
+                        m_lastTxTrx = 0;
+                    }
+                });
+            }
+
             auto* ps = m_model ? m_model->panStream() : nullptr;
             if (!ps) return;
             for (int ch = 1; ch <= 4; ++ch) {
@@ -2294,25 +2325,34 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
     // never told the radio accepted it (the command-echo path excludes the
     // sender).
     //
-    // Each relay is seeded from the slice's current state at wire time and
-    // then de-dups against that seed, dropping repeats. The de-dup is needed
-    // because SliceModel's emit discipline is uneven — nb/nr/anf/squelch/rit/
-    // xit re-emit on every status refresh whether or not the value moved,
-    // while apf/audioMute guard — and squelchChanged/ritChanged/xitChanged
-    // carry both the flag and its value, so spinning a RIT offset would
-    // otherwise re-announce an unchanged rit_enable on every step. De-duping
-    // here keeps this layer independent of that discipline.
+    // Each relay is a change handler that de-dups repeats, plus a seed that
+    // announces the current state after a (re)wire. Both share one baseline
+    // (`last`, starting "unsent") so a value is never announced twice. The
+    // de-dup is needed because SliceModel's emit discipline is uneven —
+    // nb/nr/anf/squelch/rit/xit re-emit on every status refresh whether or not
+    // the value moved, while apf/audioMute guard — and squelchChanged/
+    // ritChanged/xitChanged carry (flag, value), so spinning a RIT offset would
+    // otherwise re-announce an unchanged rit_enable on every step. The trailing
+    // int on those three signals is simply dropped: Qt binds a 1-arg slot to a
+    // 2-arg signal, so one helper serves both shapes (#4161 is scoped to the
+    // *_enable family; sql_level/rit_offset/xit_offset are out of scope).
     //
-    // The seed is required for the same
-    // reason #4160 needed one: RadioModel decodes the radio's slice status
-    // BEFORE it emits sliceAdded, and sliceAdded is what triggers this wiring
-    // -- so for a newly added slice every flag edge has already fired by the
-    // time we connect, and nothing re-fires it. A Flex band change recreates
-    // the slice, so without the seed a band change left every connected
-    // client's DSP mirror stale until the operator next touched that control.
+    // The seed is DEFERRED ~400 ms and reads the *settled* value, exactly like
+    // the frequency push below and for the same reason: a Flex band change
+    // recreates the slice, and RadioModel decodes the radio's slice status
+    // BEFORE it emits sliceAdded (the signal that triggers this wiring), so at
+    // wire time the recreated slice still holds pre-settle DSP state. An
+    // immediate seed would broadcast that stale value, then the radio's restore
+    // (~250-340 ms later) would broadcast the corrected one — flapping every
+    // flag on every band change. Deferring past the settle window announces
+    // exactly the settled value: if a restore edge lands inside the window the
+    // handler announces it and the seed de-dups; if the new band's value equals
+    // the recreated default no edge fires and the seed is what announces it (the
+    // per-flag analog of the #2824 vfo: case handled by the frequency push).
     //
-    // The seed is a no-op before any client connects (slices are wired at
-    // startup); a client connecting later gets this state from the init burst.
+    // The seed no-ops before any client connects (slices are wired at startup);
+    // a client connecting later gets this state from the init burst. QPointer
+    // guards a rapid band change that destroys the slice before the timer fires.
     auto emitFlag = [this](SliceModel* s, const char* cmd, bool on) {
         if (m_clients.isEmpty()) {
             return;
@@ -2323,57 +2363,53 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
                       .arg(on ? "true" : "false"));
     };
 
-    auto wireFlag = [this, slice, emitFlag](auto signal, const char* cmd, bool current) {
-        connect(slice, signal, this,
-                [slice, cmd, emitFlag, last = static_cast<int>(current)](bool on) mutable {
-            if (last == static_cast<int>(on)) {
+    auto wireFlag = [this, slice, emitFlag](auto signal, const char* cmd,
+                                            std::function<bool()> read) {
+        auto last = std::make_shared<int>(-1);  // -1 = nothing announced yet
+        // Change handler. A 1-arg slot binds both bool and (bool,int) signals.
+        connect(slice, signal, this, [slice, cmd, emitFlag, last](bool on) {
+            const int v = on ? 1 : 0;
+            if (*last == v) {
                 return;
             }
-            last = on;
+            *last = v;
             emitFlag(slice, cmd, on);
         });
-        emitFlag(slice, cmd, current);
-    };
-
-    wireFlag(&SliceModel::nbChanged,        "rx_nb_enable",  slice->nbOn());
-    wireFlag(&SliceModel::nrChanged,        "rx_nr_enable",  slice->nrOn());
-    wireFlag(&SliceModel::anfChanged,       "rx_anf_enable", slice->anfOn());
-    wireFlag(&SliceModel::apfChanged,       "rx_apf_enable", slice->apfOn());
-    wireFlag(&SliceModel::audioMuteChanged, "mute",          slice->audioMute());
-
-    // squelch/rit/xit carry (flag, value); only the flag is broadcast here.
-    // sql_level / rit_offset / xit_offset have the same gap but are out of
-    // scope for #4161, which is scoped to the *_enable family.
-    auto wireFlagWithValue = [this, slice, emitFlag](auto signal, const char* cmd, bool current) {
-        connect(slice, signal, this,
-                [slice, cmd, emitFlag, last = static_cast<int>(current)](bool on, int) mutable {
-            if (last == static_cast<int>(on)) {
+        // Deferred settled seed, sharing `last` so it can't double-announce.
+        QPointer<SliceModel> guard(slice);
+        QTimer::singleShot(400, this, [this, guard, cmd, emitFlag, last, read]() {
+            if (!guard || m_clients.isEmpty()) {
                 return;
             }
-            last = on;
-            emitFlag(slice, cmd, on);
+            const bool on = read();
+            const int v = on ? 1 : 0;
+            if (*last == v) {
+                return;
+            }
+            *last = v;
+            emitFlag(guard, cmd, on);
         });
-        emitFlag(slice, cmd, current);
     };
 
-    // Known limitation, sql_enable only. Three squelch sources are in play and
-    // they diverge ONLY when m_externalReceiveAudioReplacement is set (a KiwiSDR
-    // RX source replacing Flex RX audio):
-    //   - init burst reports receiveSquelchOn()  — the effective value
-    //   - this seed matches the burst (receiveSquelchOn())
-    //   - squelchChanged carries squelchOn()      — the Flex-side m_squelchOn
-    // In that mode the de-dup baseline (effective) and the first edge (Flex-side)
-    // can disagree, producing one spurious sql_enable edge on connect. In normal
-    // mode all three are equal and there is no divergence. This is NOT the
-    // false→true transient seen on a band change — that is the pre-settle timing
-    // race (the seed reads the recreated slice before the radio restores its
-    // squelch), and it converges regardless of source. Left as-is deliberately:
-    // a real fix aligns all three sources and can only be verified with a
-    // KiwiSDR RX source, which is out of this change's *_enable scope. The seed
-    // matches the burst so a freshly-connected client is at least self-consistent.
-    wireFlagWithValue(&SliceModel::squelchChanged, "sql_enable", slice->receiveSquelchOn());
-    wireFlagWithValue(&SliceModel::ritChanged,     "rit_enable", slice->ritOn());
-    wireFlagWithValue(&SliceModel::xitChanged,     "xit_enable", slice->xitOn());
+    wireFlag(&SliceModel::nbChanged,        "rx_nb_enable",  [slice]{ return slice->nbOn(); });
+    wireFlag(&SliceModel::nrChanged,        "rx_nr_enable",  [slice]{ return slice->nrOn(); });
+    wireFlag(&SliceModel::anfChanged,       "rx_anf_enable", [slice]{ return slice->anfOn(); });
+    wireFlag(&SliceModel::apfChanged,       "rx_apf_enable", [slice]{ return slice->apfOn(); });
+    wireFlag(&SliceModel::audioMuteChanged, "mute",          [slice]{ return slice->audioMute(); });
+
+    // squelch/rit/xit emit (flag, value); the value is dropped (see above).
+    // sql_enable keeps a known KiwiSDR-only quirk: three squelch sources are in
+    // play and diverge ONLY when m_externalReceiveAudioReplacement is set — the
+    // init burst and this seed report receiveSquelchOn() (effective), while
+    // squelchChanged carries squelchOn() (Flex-side). In that mode the seed and
+    // the first edge can disagree, producing one spurious sql_enable edge on
+    // connect; in normal mode all three are equal. Left as-is deliberately: a
+    // real fix aligns all three sources and can only be verified with a KiwiSDR
+    // RX source, out of this change's *_enable scope. (The band-change transient
+    // that used to compound this is gone now the seed is deferred and settled.)
+    wireFlag(&SliceModel::squelchChanged, "sql_enable", [slice]{ return slice->receiveSquelchOn(); });
+    wireFlag(&SliceModel::ritChanged,     "rit_enable", [slice]{ return slice->ritOn(); });
+    wireFlag(&SliceModel::xitChanged,     "xit_enable", [slice]{ return slice->xitOn(); });
 
     // State sync on (re)wire, deferred. A Flex band change (display pan set
     // band=) tears down and recreates the slice, so wireSlice() runs again for

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -155,6 +155,11 @@ private slots:
     void broadcastStatus();
 
 private:
+    // Rate-limited drive:/tune_drive: relay (#4161). queue* is the signal
+    // entry point; broadcast* does the de-duped send.
+    void queuePowerBroadcast();
+    void broadcastPower();
+
     void sendInitBurst(QWebSocket* client);
     // Diagnostic: log + send a text reply to one client (per-command echoes
     // bypass the central dispatch log, so route them here for visibility).
@@ -280,6 +285,19 @@ private:
     QString m_lastRouteError;
     QTimer*           m_meterTimer{nullptr};  // 200ms status broadcast
     QTimer*           m_daxReleaseTimer{nullptr}; // debounced DAX RX teardown
+    // Rate limiter for drive:/tune_drive: (#4161). A power-slider drag steps
+    // the value ~40 times a second and each step is a separate radio command,
+    // so relaying every one floods remote clients. Leading edge is sent
+    // immediately (a client's own SET still echoes promptly); further changes
+    // inside the window collapse to one trailing send of the latest value.
+    QTimer*           m_powerRateTimer{nullptr};
+    bool              m_drivePending{false};      // rfPowerChanged since last flush
+    bool              m_tuneDrivePending{false};  // tunePowerChanged since last flush
+    int               m_lastDriveSent{-1};
+    int               m_lastTuneDriveSent{-1};
+    // Last resolved TX-slice trx, used to label drive:/tune_drive: when a
+    // band-change slice recreation momentarily leaves no slice marked TX.
+    int               m_lastTxTrx{0};
     QTimer*           m_txChronoTimer{nullptr}; // TX_CHRONO frame cadence
     QWebSocket*       m_txChronoClient{nullptr};
     QPointer<QWebSocket> m_tciPttClient;

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -68,8 +68,11 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
     bool filterCutoffChanged = false;
 
     // ── Core transmit ──
-    changed |= assign(d.rfPower, m_rfPower);
-    changed |= assign(d.tunePower, m_tunePower);
+    // rf_power / tune_power emit inline (like max_power_level below): the
+    // radio restores per-band power on QSY, and TCI clients need that edge
+    // distinctly, not folded into the catch-all stateChanged() (#4161).
+    if (assign(d.rfPower, m_rfPower))   { changed = true; emit rfPowerChanged(m_rfPower); }
+    if (assign(d.tunePower, m_tunePower)) { changed = true; emit tunePowerChanged(m_tunePower); }
     if (assign(d.tune, m_tune)) { changed = true; tuneChanged_ = true; }
     changed |= assign(d.mox, m_mox);
     changed |= assign(d.transmitFreq, m_transmitFreq);
@@ -238,6 +241,7 @@ void TransmitModel::setRfPower(int power)
     power = qBound(0, power, 100);
     if (m_rfPower != power) {
         m_rfPower = power;
+        emit rfPowerChanged(power);
         emit stateChanged();
     }
     emit commandReady(QString("transmit set rfpower=%1").arg(power));
@@ -248,6 +252,7 @@ void TransmitModel::setTunePower(int power)
     power = qBound(0, power, 100);
     if (m_tunePower != power) {
         m_tunePower = power;
+        emit tunePowerChanged(power);
         emit stateChanged();
     }
     emit commandReady(QString("transmit set tunepower=%1").arg(power));

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -268,6 +268,13 @@ signals:
     void apdSamplerChanged(const QString& txAnt);
     void apdEqualizerResetReceived();
     void maxPowerLevelChanged(int maxWatts);
+    // Fire only when RF/tune power actually changes, from either the local
+    // setter or a radio status update. Use these instead of stateChanged()
+    // for anything that mirrors power to an external surface (#4161) — the
+    // radio restores per-band power on QSY, and a coarse stateChanged()
+    // listener cannot tell that apart from any other TX field moving.
+    void rfPowerChanged(int watts);
+    void tunePowerChanged(int watts);
     // Emitted when the radio reports the TX slice mode (e.g. "FDVU", "FDVL", "USB").
     // Value is empty string until the first transmit status is received.
     void txSliceModeChanged(const QString& mode);

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -199,8 +199,10 @@ public:
         return server.m_lastDriveSent == -1 && server.m_lastTuneDriveSent == -1;
     }
 
-    // wireSlice seeds each flag relay from current state, then de-dups — a
-    // repeat of the same value does not re-announce.
+    // wireSlice schedules a de-duping change handler plus a *deferred* settled
+    // seed, both sharing one baseline. Nothing goes on the wire synchronously;
+    // after the settle window the seed announces the current value once, and a
+    // repeat edge does not re-announce.
     static bool flagRelaySeedsAndDeDups()
     {
         RadioModel model;
@@ -222,9 +224,11 @@ public:
         model.automationApplySliceFixture(0, QString(), &err);
         SliceModel* s0 = model.slice(0);
         if (!s0) return false;
-        server.wireSlice(s0->sliceId(), s0);     // as MainWindow_Session does; seeds
-        const bool seeded = !nb.isEmpty()
-            && nb.last() == QStringLiteral("rx_nb_enable:0,false;");
+        server.wireSlice(s0->sliceId(), s0);     // as MainWindow_Session does
+        if (!nb.isEmpty()) return false;         // seed is deferred, not sync
+        spin(450);                               // let the settled seed fire
+        const bool seeded
+            = nb == QStringList{QStringLiteral("rx_nb_enable:0,false;")};
 
         nb.clear();
         s0->setNb(true);                         // real edge → one broadcast
@@ -233,6 +237,79 @@ public:
 
         s0->setNb(true);                         // same value again → de-duped
         return seeded && oneOnChange && nb.size() == 1;
+    }
+
+    // The #4161 transient fix: on a band-change re-wire the seed reads the
+    // *settled* flag, not the recreated slice's pre-settle state, so a client
+    // sees exactly one correct edge — never a stale blip then a correction.
+    // Model it: wire a slice holding a pre-settle value, flip it inside the
+    // settle window (as the radio's restore does), and require the client to
+    // see only the final value, once. An immediate seed would emit the blip.
+    static bool flagSeedReadsSettledNotTransient()
+    {
+        RadioModel model;
+        QWebSocket sock;
+        TciServer server(&model);
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QStringList nb;
+        QObject::connect(&server, &TciServer::tciMessage,
+            [&nb](const QString& dir, const QString& msg) {
+                if (dir == QLatin1String("tx")
+                    && msg.startsWith(QLatin1String("rx_nb_enable:")))
+                    nb << msg.trimmed();
+            });
+
+        QString err;
+        model.automationApplySliceFixture(0, QString(), &err);
+        SliceModel* s0 = model.slice(0);
+        if (!s0) return false;
+        s0->setNb(true);                         // recreated slice's pre-settle
+        nb.clear();
+        server.wireSlice(s0->sliceId(), s0);     // re-wire; seed deferred
+        spin(120);                               // still inside the window
+        s0->setNb(false);                        // radio restores settled value
+        // Handler announces the settled edge exactly once...
+        if (nb != QStringList{QStringLiteral("rx_nb_enable:0,false;")})
+            return false;
+        spin(400);                               // ...and the deferred seed de-dups.
+        return nb.size() == 1;
+    }
+
+    // A TX slice *closed* (removed with no recreation) must not leave
+    // m_lastTxTrx pointing at a dead index. The deferred cleanup resets it once
+    // the settle window passes with no live slice carrying that trx; a
+    // same-id recreation (band change) inside the window must not reset it.
+    static bool lastTxTrxResetsOnClose()
+    {
+        RadioModel model;
+        QWebSocket sock;
+        TciServer server(&model);
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QString err;
+        model.automationApplySliceFixture(0, QString(), &err);
+        model.automationApplySliceFixture(1, QString(), &err);
+        SliceModel* s0 = model.slice(0);
+        SliceModel* s1 = model.slice(1);
+        if (!s0 || !s1) return false;
+        server.wireSlice(s0->sliceId(), s0);
+        server.wireSlice(s1->sliceId(), s1);
+        SliceDelta txOn;
+        txOn.txSlice = true;
+        s1->applyChanges(txOn);                  // caches m_lastTxTrx = trx(s1)
+        const int cachedTrx = server.m_lastTxTrx;
+        if (cachedTrx == 0) return false;        // need non-zero to detect a reset
+
+        model.automationRemoveSliceFixture(1, &err);   // close it for good
+        // Immediately after removal the cache is untouched (band-change grace).
+        if (server.m_lastTxTrx != cachedTrx) return false;
+        spin(600);                               // past the 500 ms cleanup
+        return server.m_lastTxTrx == 0;
     }
 };
 
@@ -258,6 +335,10 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::powerCacheResetsWhenClientsLeave();
     const bool flagSeedsDeDups
         = AetherSDR::TciServerReviewTest::flagRelaySeedsAndDeDups();
+    const bool flagSeedSettled
+        = AetherSDR::TciServerReviewTest::flagSeedReadsSettledNotTransient();
+    const bool txTrxResets
+        = AetherSDR::TciServerReviewTest::lastTxTrxResetsOnClose();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -273,8 +354,13 @@ int main(int argc, char** argv)
                 cacheResets ? "PASS" : "FAIL");
     std::printf("%s  flag relay seeds and de-dups\n",
                 flagSeedsDeDups ? "PASS" : "FAIL");
+    std::printf("%s  flag seed reads settled, no band-change transient\n",
+                flagSeedSettled ? "PASS" : "FAIL");
+    std::printf("%s  m_lastTxTrx resets when TX slice is closed\n",
+                txTrxResets ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
+        && flagSeedSettled && txTrxResets
         ? 0 : 1;
 }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -4,9 +4,13 @@
 #include "core/QsoRecorder.h"
 #include "core/TciServer.h"
 #include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/TransmitModel.h"
 
 #include <QCoreApplication>
+#include <QEventLoop>
 #include <QJsonObject>
+#include <QTimer>
 #include <QWebSocket>
 
 #include <cstdio>
@@ -78,6 +82,158 @@ public:
             && snapshot.value(QStringLiteral("lastRouteError")).toString()
                 == QStringLiteral("capacity test");
     }
+
+    // ── #4161 power / flag broadcast internals ──────────────────────────────
+
+    // Run the event loop for `ms` so a QTimer (the power rate limiter) can fire,
+    // without pulling in QtTest.
+    static void spin(int ms)
+    {
+        QEventLoop loop;
+        QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+        loop.exec();
+    }
+
+    // Rapid rfPowerChanged collapses to a prompt leading edge plus one trailing
+    // send of the settled value; an unchanged value produces nothing.
+    static bool powerBroadcastRateLimits()
+    {
+        RadioModel model;
+        QWebSocket sock;
+        TciServer server(&model);
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QStringList drives;
+        QObject::connect(&server, &TciServer::tciMessage,
+            [&drives](const QString& dir, const QString& msg) {
+                if (dir == QLatin1String("tx")
+                    && msg.startsWith(QLatin1String("drive:")))
+                    drives << msg.trimmed();
+            });
+
+        auto& tx = model.transmitModel();
+        tx.setRfPower(55);                       // leading edge — sent at once
+        if (drives != QStringList{QStringLiteral("drive:0,55;")}) return false;
+
+        tx.setRfPower(56);                       // inside the 100 ms window:
+        tx.setRfPower(57);                       // collapsed, nothing on the wire
+        tx.setRfPower(58);
+        if (drives.size() != 1) return false;
+
+        spin(160);                               // trailing flush of the latest
+        if (drives != QStringList{QStringLiteral("drive:0,55;"),
+                                  QStringLiteral("drive:0,58;")}) return false;
+
+        tx.setRfPower(58);                       // unchanged → no broadcast
+        spin(160);
+        return drives.size() == 2;
+    }
+
+    // The #4161 mislabel fix: when the TX flag momentarily clears (the
+    // band-change slice-recreation gap), drive: keeps the last resolved TX trx
+    // from m_lastTxTrx rather than falling back to trx 0.
+    static bool driveTrxSurvivesTxFlagClear()
+    {
+        RadioModel model;
+        QWebSocket sock;
+        TciServer server(&model);
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QString err;
+        model.automationApplySliceFixture(0, QString(), &err);
+        model.automationApplySliceFixture(1, QString(), &err);
+        SliceModel* s0 = model.slice(0);
+        SliceModel* s1 = model.slice(1);
+        if (!s0 || !s1) return false;
+        // wireSlice() is driven by MainWindow_Session in the app; call it here.
+        server.wireSlice(s0->sliceId(), s0);
+        server.wireSlice(s1->sliceId(), s1);
+        // TX flag is radio-authoritative — setTxSlice() only sends a command, so
+        // drive the status path (as the radio would) to mark slice 1 TX.
+        SliceDelta txOn;
+        txOn.txSlice = true;
+        s1->applyChanges(txOn);                  // → txSliceChanged → caches trx
+
+        QStringList drives;
+        QObject::connect(&server, &TciServer::tciMessage,
+            [&drives](const QString& dir, const QString& msg) {
+                if (dir == QLatin1String("tx")
+                    && msg.startsWith(QLatin1String("drive:")))
+                    drives << msg.trimmed();
+            });
+
+        server.m_drivePending = true;
+        server.m_lastDriveSent = -1;
+        server.broadcastPower();
+        if (drives.size() != 1) return false;
+        const QString withTx = drives.first();   // e.g. "drive:1,100;"
+        // The TX slice must map to a non-zero trx, or the test can't tell the
+        // cache apart from the old trx-0 fallback.
+        if (withTx == QStringLiteral("drive:0,100;")) return false;
+
+        drives.clear();
+        SliceDelta txOff;
+        txOff.txSlice = false;
+        s1->applyChanges(txOff);                 // TX flag cleared → txTrxIndex -1
+        server.m_drivePending = true;
+        server.m_lastDriveSent = -1;
+        server.broadcastPower();
+        return drives.size() == 1 && drives.first() == withTx;
+    }
+
+    // The last-sent cache is forgotten when the last client leaves, so a genuine
+    // change back to the remembered value after a reconnect is not suppressed.
+    static bool powerCacheResetsWhenClientsLeave()
+    {
+        RadioModel model;
+        TciServer server(&model);
+        server.m_lastDriveSent = 55;
+        server.m_lastTuneDriveSent = 19;
+        server.m_drivePending = true;
+        server.m_tuneDrivePending = true;
+        server.broadcastPower();                 // no clients → reset + bail
+        return server.m_lastDriveSent == -1 && server.m_lastTuneDriveSent == -1;
+    }
+
+    // wireSlice seeds each flag relay from current state, then de-dups — a
+    // repeat of the same value does not re-announce.
+    static bool flagRelaySeedsAndDeDups()
+    {
+        RadioModel model;
+        QWebSocket sock;
+        TciServer server(&model);
+        TciServer::ClientState cs;
+        cs.socket = &sock;
+        server.m_clients.append(cs);
+
+        QStringList nb;
+        QObject::connect(&server, &TciServer::tciMessage,
+            [&nb](const QString& dir, const QString& msg) {
+                if (dir == QLatin1String("tx")
+                    && msg.startsWith(QLatin1String("rx_nb_enable:")))
+                    nb << msg.trimmed();
+            });
+
+        QString err;
+        model.automationApplySliceFixture(0, QString(), &err);
+        SliceModel* s0 = model.slice(0);
+        if (!s0) return false;
+        server.wireSlice(s0->sliceId(), s0);     // as MainWindow_Session does; seeds
+        const bool seeded = !nb.isEmpty()
+            && nb.last() == QStringLiteral("rx_nb_enable:0,false;");
+
+        nb.clear();
+        s0->setNb(true);                         // real edge → one broadcast
+        const bool oneOnChange
+            = nb == QStringList{QStringLiteral("rx_nb_enable:0,true;")};
+
+        s0->setNb(true);                         // same value again → de-duped
+        return seeded && oneOnChange && nb.size() == 1;
+    }
 };
 
 } // namespace AetherSDR
@@ -94,6 +250,14 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::deferredAbortIsClientScoped();
     const bool observableFailure
         = AetherSDR::TciServerReviewTest::routeFailureIsObservable();
+    const bool powerRateLimits
+        = AetherSDR::TciServerReviewTest::powerBroadcastRateLimits();
+    const bool trxCacheHolds
+        = AetherSDR::TciServerReviewTest::driveTrxSurvivesTxFlagClear();
+    const bool cacheResets
+        = AetherSDR::TciServerReviewTest::powerCacheResetsWhenClientsLeave();
+    const bool flagSeedsDeDups
+        = AetherSDR::TciServerReviewTest::flagRelaySeedsAndDeDups();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -101,6 +265,16 @@ int main(int argc, char** argv)
                 deferredAbort ? "PASS" : "FAIL");
     std::printf("%s  VFO-B route failure is observable\n",
                 observableFailure ? "PASS" : "FAIL");
+    std::printf("%s  drive: rate-limits and de-dups\n",
+                powerRateLimits ? "PASS" : "FAIL");
+    std::printf("%s  drive: trx survives a TX-flag clear\n",
+                trxCacheHolds ? "PASS" : "FAIL");
+    std::printf("%s  power cache resets when clients leave\n",
+                cacheResets ? "PASS" : "FAIL");
+    std::printf("%s  flag relay seeds and de-dups\n",
+                flagSeedsDeDups ? "PASS" : "FAIL");
 
-    return validProfile && deferredAbort && observableFailure ? 0 : 1;
+    return validProfile && deferredAbort && observableFailure
+        && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
+        ? 0 : 1;
 }

--- a/tests/transmit_model_test.cpp
+++ b/tests/transmit_model_test.cpp
@@ -143,5 +143,47 @@ int main(int argc, char** argv)
     ok &= expect(commands == QStringList({"profile mic load \"Studio Mic\""}),
                  "Mic profile load uses profile mic load");
 
+    // #4161 / #4310: rf_power and tune_power need a dedicated signal so TCI
+    // can announce them. A coarse stateChanged() listener cannot tell a power
+    // move apart from any other TX field, and the radio restores per-band
+    // power on QSY — the case that left control-surface dials stale.
+    QList<int> rfPowers;
+    QList<int> tunePowers;
+    QObject::connect(&tx, &TransmitModel::rfPowerChanged,
+                     [&rfPowers](int w) { rfPowers.append(w); });
+    QObject::connect(&tx, &TransmitModel::tunePowerChanged,
+                     [&tunePowers](int w) { tunePowers.append(w); });
+
+    // Radio-originated: the band-switch path. This is the #4310 regression.
+    tx.applyChanges(td([](TransmitDelta& d) { d.rfPower = 30; }));
+    ok &= expect(rfPowers == QList<int>({30}),
+                 "radio-reported rf_power emits rfPowerChanged");
+
+    tx.applyChanges(td([](TransmitDelta& d) { d.tunePower = 15; }));
+    ok &= expect(tunePowers == QList<int>({15}),
+                 "radio-reported tune_power emits tunePowerChanged");
+
+    // An unchanged value must not re-announce, or every status refresh would
+    // re-broadcast to every connected TCI client.
+    tx.applyChanges(td([](TransmitDelta& d) { d.rfPower = 30; }));
+    ok &= expect(rfPowers == QList<int>({30}),
+                 "unchanged rf_power does not re-emit");
+
+    // Locally-originated: GUI slider or a TCI client's SET.
+    rfPowers.clear();
+    tunePowers.clear();
+    tx.setRfPower(75);
+    ok &= expect(rfPowers == QList<int>({75}),
+                 "setRfPower emits rfPowerChanged");
+
+    tx.setTunePower(20);
+    ok &= expect(tunePowers == QList<int>({20}),
+                 "setTunePower emits tunePowerChanged");
+
+    rfPowers.clear();
+    tx.setRfPower(75);
+    ok &= expect(rfPowers.isEmpty(),
+                 "setRfPower to the same value does not re-emit");
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

Fixes #4161.

TCI has two delivery paths for state, and ten fields sit on the wrong one. A SET
arrives, `cmdDrive` and the `rx_*_enable` family stash `m_pendingNotification`
and return `{}` — so the sender gets nothing back from `replyText`, and is then
excluded from the notification fan-out. The client that changed a value is never
told the radio accepted it. The second path — a model signal wired to
`broadcast()` — reaches every client including the sender, but only `frequency`,
`modulation`, `rx_filter_band`, `tx_enable`, `lock` and `rx_volume` were ever
connected to it. Everything else had no signal wiring at all, so a change made in
**AetherSDR's own GUI**, or by the radio itself, was invisible to *every* TCI
client until reconnect.

This PR moves the remaining ten fields onto the second path: `drive`,
`tune_drive`, `rx_nb_enable`, `rx_nr_enable`, `rx_anf_enable`, `rx_apf_enable`,
`mute`, `sql_enable`, `rit_enable`, `xit_enable` — each relayed from a
radio-confirmed model edge, TRX-labelled from the transmitting slice, de-duped,
and (for power) rate-limited. The init burst also gains `mute:`, the one flag in
this family it never carried.

The power signals fire from `applyChanges` as well as the local setters, so a
change with no TCI-client or GUI origin — the radio restoring its own per-band RF
power on QSY — is relayed too; a stale power readout otherwise risks driving an
amplifier past its limit. `tests/transmit_model_test.cpp` pins that radio-origin
case.

## Relation to #4407

#4407 rewrote the TCI stack and closed #4161 by converging the sender with
observers on the routing verbs — `vfo`, `split_enable`, `trx`. The
`modulation`/`rx_filter_band`/`tx_enable`/`lock`/`rx_volume` slice broadcasts
already existed on the model-signal path and predate #4407. What neither #4407
nor its predecessors moved is the ten DSP/power fields this issue was filed
against; they stayed on the command-echo path. This PR completes that remainder
on top of #4407, hooking into `wireSlice()` and the `TransmitModel` model-signal
pattern, which the rewrite left in place. The port re-applied cleanly; `drive:`/
`tune_drive:` are labelled with the same TX-slice trx the `txTrx()` helper on
`main` uses for the burst and GET replies, so the async broadcast and the
synchronous replies never disagree.

## Deliberately out of scope

- **`trx` and `split_enable`** are already owned by #4407 — it defers them into
  its routing state machine and emits `trx:true` only after the radio confirms
  TRANSMITTING (a naive echo to a transmitting WSJT-X/JTDX would make it read the
  echo as an external state change and cycle PTT, which is why this stays on
  #4407's careful path rather than the model-signal broadcast).
- **`tune`** remains RFC #4220 territory.
- **The residual notification/broadcast duplication.** A client-originated SET
  still fires both `m_pendingNotification` (to other clients) and the model
  broadcast (to all), so a non-sender receives two copies. Since #4407 made the
  notification two-argument (incorporating the reply shape from the now-closed
  #4344 and closing #4345), the copies are now identical in format. Collapsing this — dropping `m_pendingNotification` for fields that
  have a model broadcast — changes what an ack means (the notification fires
  optimistically on every SET, the model signal only on actual change), so it is
  a **maintainer decision left out of this PR**; if I rolled it in, I would exceed 
  the scope of #4161.
- **`sql_enable` in external-receive mode.** Burst and seed use `receiveSquelchOn()`
  (effective) while `squelchChanged` carries `squelchOn()` (Flex-side); these
  diverge **only** with a KiwiSDR RX source (`m_externalReceiveAudioReplacement`),
  where the de-dup baseline can produce one spurious edge on connect. This is
  distinct from the band-change false→true settle transient observed on hardware,
  which is the pre-settle timing race and converges regardless. A real fix aligns
  all three squelch sources and can only be verified with a KiwiSDR, so it is
  documented as a known limitation in-code rather than fixed blind here.

## Findings from hardware testing

- **Controller-driven power changes double `drive:` with a TRX divergence.** With
  two slices and TX on slice 1, an OpenDeck dial change reaches observers as
  `drive:0,<w>` (the notification, echoing the plugin's hardcoded trx 0 via
  `cmdDrive`'s `args[0]`) **plus** `drive:1,<w>` (this PR's model broadcast, the
  correct TX slice). The value is always right and clients read the last field,
  so it converges; the model broadcast is the correct one. The bundled plugins
  hardcode `drive:0,${w}` rather than sending the active TX trx. **I plan a
  follow-up PR with further plugin changes and new features built on this work,
  and will address the plugin's TRX handling there.** Dropping the notification
  (the maintainer decision above) would also remove this divergence at the
  server.

## Constitution principle honored

**Principle II — The Radio Is Authoritative On Live State.** Power and DSP state
are relayed from radio-confirmed model edges rather than echoed optimistically
from the requesting command, so clients converge on what the radio accepted
rather than what they asked for.

**Principle XI — Fixes Are Demonstrated.** Every change beyond the initial wiring
answers a defect observed on live hardware — the TRX mislabel, the stale de-dup
cache, the unrequested `tune_drive`, and the power-drag flood were all found on a
FLEX-6600 and re-verified on the radio after the fix. `transmit_model_test` pins
the dedicated power-signal contract (radio-origin included), and
`tci_server_review_test` now pins the novel `TciServer` logic directly — the
rate-limit + trailing flush, the `m_lastTxTrx` cache holding a non-zero TRX
across a TX-flag clear, the empty-client cache reset, and the `wireSlice` flag
seed + de-dup — so CI catches the parts most likely to regress, not just the
model contract.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio — FLEX-6600, fw 4.2.20.41343, SmartLink
- [x] Existing tests pass (CI) — `transmit_model_test` (20, incl. 6 new),
      `tci_protocol_test`, `tci_automation_test`, `tci_server_review_test`
      (4 new cases: power rate-limit/de-dup, TRX-cache across a TX-flag clear,
      empty-client cache reset, flag seed + de-dup)
- [x] Reproduction steps documented — see #4161

Real-radio results (2026-07-24, FLEX-6600 via SmartLink):

- **Safety** — three TX cycles, one clean `trx:` edge each way, no oscillation,
  and **no `drive:`/`tune_drive:` during any TX** (a power broadcast off a PTT
  edge would be the bug).
- **WSJT-X coexistence (#4407)** — five clean FT8 cycles in Fake It; a GUI NB
  toggle mid-session broadcast without perturbing WSJT-X's split/VFO/TRX
  sequence; `trx:true` only after radio-confirmed TRANSMITTING.
- **DSP/squelch/RIT/XIT relays** — 7 of 8 toggled from the GUI, one broadcast
  each; `rx_apf_enable` untested (no APF enabled in firmware); client-SET sender echo
  confirmed (2–7 ms).
- **Per-band power on QSY** — each band change on the TX slice emitted a single
  `drive:<txtrx>,<watts>` with the new band's value, correct trx, no fallback;
  the `m_lastTxTrx` cache held through repeated slice recreations. The
  slice-recreation seed re-announced all eight flags per QSY, and the documented
  `sql_enable` false→true settle transient was observed.
- **Duplication** — sender receives one copy, every other client two identical
  copies at the same millisecond; uniform wire format since #4407 made the
  notification two-argument.

Full transcripts in the branch test-plan notes.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings touched (Principle V)
- [x] Code is clean-room — implemented from the published TCI protocol and
      client behavior; not decompiled or reverse-engineered (Principle IV)
- [x] All meter UI uses `MeterSmoother` — n/a, no meter UI
- [x] Documentation updated if user-visible behavior changed — n/a, no `docs/`
      page documents the affected TCI commands
- [x] Security-sensitive changes reference a GHSA if applicable — n/a
