### PR TITLE
fix(gui): restore GPS status label layout

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4511,7 +4511,6 @@ void MainWindow::buildUI()
     // GPS satellites (top) + lock status (bottom) stacked
     auto* gpsStack = new QPushButton;
     gpsStack->setObjectName(QStringLiteral("gpsStatusButton"));
-    gpsStack->setFlat(true);
     gpsStack->setAutoDefault(false);
     gpsStack->setDefault(false);
     gpsStack->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
@@ -4521,9 +4520,24 @@ void MainWindow::buildUI()
     gpsStack->setAccessibleName(QStringLiteral("GPS and station location"));
     gpsStack->setAccessibleDescription(
         QStringLiteral("Open the live GPS, map, satellite reception, and time dashboard"));
+    // Flat, label-style resting state so the two rows sit on the same baselines
+    // as the neighbouring plain-QWidget telemetry stacks, with hover / pressed /
+    // focus feedback so the click target stays discoverable.
+    //
+    // The focus ring uses `outline` rather than `border`: Qt honours QSS
+    // `outline` only on `:focus` (it is wired to the focus-rect paint path), so
+    // hover must use `border` instead — an `outline` there silently never
+    // paints. Neither property perturbs this widget's layout: QStyleSheetStyle
+    // does not fold the button's frame into the contents rect its child layout
+    // sees, so the two rows keep the sibling stacks' y positions and full label
+    // width in every state. Do not add `padding` here — that one does consume
+    // layout space and would offset the rows against the borderless siblings.
     ThemeManager::instance().applyStyleSheet(gpsStack, QStringLiteral(
         "QPushButton { background: transparent; border: none; padding: 0; }"
-        "QPushButton:focus { border-bottom: 1px solid {{color.border.accent}}; }"));
+        "QPushButton:hover { background: {{color.background.1}}; "
+        "border: 1px solid {{color.border.strong}}; }"
+        "QPushButton:pressed { background: {{color.background.2}}; }"
+        "QPushButton:focus { outline: 1px solid {{color.border.accent}}; }"));
     connect(gpsStack, &QPushButton::clicked,
             this, &MainWindow::showGpsLocationDialog);
     reserveTelemetryStack(gpsStack, {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -4511,8 +4511,10 @@ void MainWindow::buildUI()
     // GPS satellites (top) + lock status (bottom) stacked
     auto* gpsStack = new QPushButton;
     gpsStack->setObjectName(QStringLiteral("gpsStatusButton"));
+    gpsStack->setFlat(true);
     gpsStack->setAutoDefault(false);
     gpsStack->setDefault(false);
+    gpsStack->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     gpsStack->setCursor(Qt::PointingHandCursor);
     gpsStack->setFocusPolicy(Qt::TabFocus);
     gpsStack->setToolTip(QStringLiteral("Open GPS & Station Location"));
@@ -4520,12 +4522,8 @@ void MainWindow::buildUI()
     gpsStack->setAccessibleDescription(
         QStringLiteral("Open the live GPS, map, satellite reception, and time dashboard"));
     ThemeManager::instance().applyStyleSheet(gpsStack, QStringLiteral(
-        "QPushButton { background: transparent; border: 1px solid transparent; "
-        "border-radius: 4px; padding: 1px 5px; }"
-        "QPushButton:hover { background: {{color.background.1}}; "
-        "border-color: {{color.border.strong}}; }"
-        "QPushButton:focus { border-color: {{color.border.accent}}; }"
-        "QPushButton:pressed { background: {{color.background.2}}; }"));
+        "QPushButton { background: transparent; border: none; padding: 0; }"
+        "QPushButton:focus { border-bottom: 1px solid {{color.border.accent}}; }"));
     connect(gpsStack, &QPushButton::clicked,
             this, &MainWindow::showGpsLocationDialog);
     reserveTelemetryStack(gpsStack, {


### PR DESCRIPTION
## Summary

- present the GPS status stack as a flat, label-style click target instead of a visibly framed button
- give the GPS control the same preferred vertical sizing behavior as the neighboring two-row telemetry stacks
- retain native `QPushButton` keyboard activation, focus indication, tooltip, and accessible button semantics

## Root cause

The GPS & Station Location dashboard changed the status-bar GPS stack from a plain `QWidget` container to a `QPushButton`. The button kept its fixed vertical size policy and added border, padding, hover background, and pressed background styling. That made the whole stack look like button chrome and compressed the GPS lock row relative to the CPU, PA, Network, and UTC stacks.

## User impact

The GPS station-location display once again reads visually as a normal status-bar label. Both GPS rows are evenly spaced, including `[Locked]`, while the complete label remains clickable to open the GPS & Station Location window.

## Verification

- configured and built the complete macOS app with Ninja (`RelWithDebInfo`, `-j8`)
- passed `tools/check_a11y.py src/gui/MainWindow.cpp` with zero findings
- passed `tools/check_engine_boundary.py --strict` with zero blocking findings
- passed `git diff --check`
- launched with an isolated configuration and injected the disconnected FLEX-8000 GPS fixture through the automation bridge
- verified both GPS rows are 15 px high and share the same y positions as the neighboring telemetry rows
- captured and visually reviewed the full status bar with `GPS: 8/28` and `[Locked]`
- invoked `gpsStatusButton` through the bridge and verified the 1080×720 GPS & Station Location window opened
- no radio connection or transmit action was used

👨🏼‍💻 Generated with OpenAI Codex (GPT-5.6 Sol) and tested by @jensenpat
