### PR TITLE
Preserve 3D FFT history and stabilize smooth-scroll boundaries

### DIFF
--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -113,10 +113,13 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
-    // Hide only unpopulated startup slots. Do not progressively fade the rear
-    // rows: the perspective already supplies depth haze, and the extra six-row
-    // fade introduced a visibly blurry band at the back of a full history.
-    float sourceAge = sourceV * rows;
-    float historyAvailability = clamp(validRows - sourceAge, 0.0, 1.0);
+    // Hide only unpopulated startup slots. Advance the availability edge by
+    // remainingRows so the newest rear slot fades in continuously over the row
+    // interval instead of popping opaque on arrival (matching the height path's
+    // sub-row advance in sampleHistoryDbm). The rear six-row fade is
+    // deliberately gone: the perspective already supplies depth haze, and that
+    // fade left a visibly blurry band at the back of a full history.
+    float sampleAge = sourceV * rows + remainingRows;
+    float historyAvailability = clamp(validRows - sampleAge, 0.0, 1.0);
     vBoundaryFade = historyAvailability;
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -3,10 +3,10 @@
 // 3DSS GPU height-map mesh. Each vertex carries its grid position (u = column,
 // v = row/depth) and an edge tag. The height comes from a ring-buffered dBm
 // texture; geometry is a receding perspective trapezoid built entirely on the
-// GPU, so pan/zoom never rebuild any vertices. The original per-row coloured
-// curtains and their outlines stay on a fixed perspective grid and interpolate
-// between adjacent history rows, avoiding shimmer from translating dense
-// geometry across screen pixels. Outputs NDC directly (matching spectrum.vert).
+// GPU, so pan/zoom never rebuild any vertices. The per-row coloured curtains
+// and their outlines stay on a fixed perspective grid while the retained data
+// advances, avoiding shimmer from translating dense geometry across pixels.
+// Outputs NDC directly (matching spectrum.vert).
 
 layout(location = 0) in vec3 inVert;   // x = u [0,1] col, y = v [0,1) row(0=front), z = edge
 
@@ -44,22 +44,24 @@ layout(location = 3) out float vBoundaryFade;
 float sampleHistoryDbm(float texU, float historyV, float rows,
                        float remainingRows)
 {
-    float sampleAge = historyV * rows + remainingRows;
+    float sourceAge = historyV * rows;
     float cappedValidRows = clamp(validRows, 0.0, rows);
+    if (sourceAge >= cappedValidRows) {
+        return floorDbm;
+    }
+
+    // The oldest grid row has no older neighbour to interpolate toward. Clamp
+    // its sample age to the oldest retained texture row so it stays full-height
+    // until eviction instead of collapsing and reappearing at the rear edge.
+    float oldestRetainedAge = max(cappedValidRows - 1.0, 0.0);
+    float sampleAge = min(sourceAge + remainingRows, oldestRetainedAge);
     float age0 = max(floor(sampleAge), 0.0);
-    float age1 = age0 + 1.0;
+    float age1 = min(age0 + 1.0, oldestRetainedAge);
     float ageBlend = fract(sampleAge);
-    float textureAge0 = clamp(age0, 0.0, rows - 1.0);
-    float textureAge1 = clamp(age1, 0.0, rows - 1.0);
     float dbm0 = texture(
-        heightTex, vec2(texU, fract(rowOffset + textureAge0 / rows))).r;
+        heightTex, vec2(texU, fract(rowOffset + age0 / rows))).r;
     float dbm1 = texture(
-        heightTex, vec2(texU, fract(rowOffset + textureAge1 / rows))).r;
-    // A partially filled history has no row beyond its oldest valid sample.
-    // Blend that missing neighbour from the floor instead of clamping it to a
-    // duplicate of the oldest row, which made the startup boundary hop.
-    dbm0 = mix(floorDbm, dbm0, 1.0 - step(cappedValidRows, age0));
-    dbm1 = mix(floorDbm, dbm1, 1.0 - step(cappedValidRows, age1));
+        heightTex, vec2(texU, fract(rowOffset + age1 / rows))).r;
     return mix(dbm0, dbm1, ageBlend);
 }
 
@@ -70,9 +72,11 @@ void main()
     float rows = max(texRows, 1.0);
     float distanceRows = max(scrollDistanceRows, 1.0);
     float edge = inVert.z;     // -1 = outline, 0 = ridge, 1 = curtain floor
-    // Both passes use stable geometry. Motion comes from interpolating retained
-    // row samples, like the phase-stable waterfall reconstruction.
+    // Keep geometry phase-stable. Translating this dense perspective mesh makes
+    // its subpixel line spacing shimmer, especially in the compressed rear.
     float geometryV = sourceV;
+    float remainingRows = clamp(
+        distanceRows - scrollProgressRows, 0.0, distanceRows);
 
     // Sample texel CENTRES on both axes so Nearest filtering can't pick up the
     // neighbouring row/column. rowOffset already carries the row half-texel; the
@@ -83,10 +87,6 @@ void main()
     float texU = (texCols > 1.0)
         ? (sourceU * (texCols - 1.0) + 0.5) / texCols
         : 0.5;
-    float remainingRows = clamp(
-        distanceRows - scrollProgressRows, 0.0, distanceRows);
-    // The head advances immediately when a row arrives. At phase 0, sample the
-    // former row at age+1; over the interval morph toward the new row at age.
     float dbm = outsidePreview
         ? floorDbm
         : sampleHistoryDbm(texU, sourceV, rows, remainingRows);
@@ -113,14 +113,10 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
-    // During startup, the newly exposed oldest slot fades in continuously over
-    // the row interval. Keep the eviction fade anchored at the physical back
-    // of the full history so it does not move one discrete slot per arrival.
-    float sampleAge = sourceV * rows + remainingRows;
-    float historyAvailability = clamp(validRows - sampleAge, 0.0, 1.0);
-    float backFadeStart = max(0.0, (rows - 6.0) / rows);
-    float backFadeEnd = max(backFadeStart, (rows - 1.0) / rows);
-    float backBoundaryFade =
-        1.0 - smoothstep(backFadeStart, backFadeEnd, geometryV);
-    vBoundaryFade = historyAvailability * backBoundaryFade;
+    // Hide only unpopulated startup slots. Do not progressively fade the rear
+    // rows: the perspective already supplies depth haze, and the extra six-row
+    // fade introduced a visibly blurry band at the back of a full history.
+    float sourceAge = sourceV * rows;
+    float historyAvailability = clamp(validRows - sourceAge, 0.0, 1.0);
+    vBoundaryFade = historyAvailability;
 }

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -208,15 +208,20 @@ std::array<float, DssRenderer::kCols> smoothDssRow(
 
 } // namespace
 
+void DssRenderer::resetInputSmoothing()
+{
+    m_rawHistCount = 0;
+    resetHistorySmoothing();
+}
+
 void DssRenderer::clear()
 {
     m_head  = 0;
     m_count = 0;
     m_dirty = true;
-    m_rawHistCount = 0;
     m_historyWriteRow = 0;
     m_historyRowCount = 0;
-    resetHistorySmoothing();
+    resetInputSmoothing();
 }
 
 quint64 DssRenderer::fixedStorageBytes() const

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -211,6 +211,13 @@ std::array<float, DssRenderer::kCols> smoothDssRow(
 void DssRenderer::resetInputSmoothing()
 {
     m_rawHistCount = 0;
+    // Also break the temporal IIR blend for the next row of each path. Zeroing
+    // the median-of-3 counters alone does not forget the previous *smoothed*
+    // row that pushRow/appendHistoryRow blend the new row against — that row was
+    // decoded under the old scale, so without this the first post-reset row is
+    // contaminated by it.
+    m_skipLiveTemporalBlendOnce = true;
+    m_skipHistoryTemporalBlendOnce = true;
     resetHistorySmoothing();
 }
 
@@ -308,9 +315,11 @@ DssRenderer::RowStats DssRenderer::rowStats(int age, float epsilonDb) const
 void DssRenderer::pushRow(const QVector<float>& binsDbm)
 {
     const std::array<float, kCols> raw = resampledRawRow(binsDbm, -200.0f);
-    const std::array<float, kCols>* previous = m_count > 0
+    const std::array<float, kCols>* previous =
+        (m_count > 0 && !m_skipLiveTemporalBlendOnce)
         ? &m_rows[m_head]
         : nullptr;
+    m_skipLiveTemporalBlendOnce = false;
     const std::array<float, kCols> nr =
         smoothDssRow(raw, m_rawPrev1, m_rawPrev2, m_rawHistCount, previous);
 
@@ -367,13 +376,14 @@ void DssRenderer::appendHistoryRow(const QVector<float>& binsDbm,
     const std::array<float, kCols> raw = resampledRawRow(binsDbm, fallbackDbm);
     std::array<float, kCols> previousRow;
     const std::array<float, kCols>* previous = nullptr;
-    if (m_historyRowCount > 0) {
+    if (m_historyRowCount > 0 && !m_skipHistoryTemporalBlendOnce) {
         const qfloat16* src = m_historyRows.constData() + m_historyWriteRow * kCols;
         for (int c = 0; c < kCols; ++c) {
             previousRow[c] = static_cast<float>(src[c]);
         }
         previous = &previousRow;
     }
+    m_skipHistoryTemporalBlendOnce = false;
     const std::array<float, kCols> row =
         smoothDssRow(raw, m_historyRawPrev1, m_historyRawPrev2,
                      m_historyRawHistCount, previous);

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -138,6 +138,15 @@ private:
     std::array<float, kCols> m_rawPrev2{};
     int m_rawHistCount = 0;
 
+    // One-shot flags: after resetInputSmoothing() the next pushed row must not
+    // blend against the retained row that preceded the reset (it was decoded
+    // under the old raw-pixel scale). Cleared once each path consumes it. See
+    // resetInputSmoothing() — the median-of-3 raw history is not enough on its
+    // own; the temporal IIR term against the previous smoothed row also carries
+    // pre-reset data.
+    bool m_skipLiveTemporalBlendOnce = false;
+    bool m_skipHistoryTemporalBlendOnce = false;
+
     // Retained scrollback store. This is intentionally separate from the
     // 96-row visible surface above: waterfall history can be much deeper, and
     // the visible 3D mesh is rebuilt from this ring only while viewing history.

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -94,6 +94,9 @@ public:
 
     void invalidate() { m_dirty = true; }
     bool hasData() const { return m_count > 0; }
+    // Forget temporal filter inputs without discarding already-decoded dBm
+    // rows. Used when the upstream raw-pixel scale changes.
+    void resetInputSmoothing();
     void clear();
 
     // ── Data-model accessors for the GPU mesh path ──────────────────────────

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2449,6 +2449,19 @@ void MainWindow::sendPanDimensionsToRadio(const QString& panId,
         QString("display pan set %1 xpixels=%2 ypixels=%3")
             .arg(panId).arg(xpix).arg(ypix));
 
+    // Arm the DSS settle gate now, before the radio echo switches the local
+    // decoder. The stream keeps decoding with the old y_pixels until the echo,
+    // so rows arriving in the request→echo window can be decoded against a stale
+    // scale; since retained 3D history is now preserved across a resize (rather
+    // than cleared on echo), those mis-scaled rows would otherwise survive in
+    // scrollback. Dropping them here costs only a few valid rows and matches the
+    // pre-preservation intent that pre-echo rows must not persist. Only for a
+    // genuine transition off an established scale — a width-only resize or first
+    // dimension push (fftYPixels()==0) has no prior history to protect.
+    if (pan->fftYPixels() > 0 && pan->fftYPixels() != ypix) {
+        sw->beginFftPixelScaleSettle();
+    }
+
     if (profileLoadRadioStateWritesHeld()) {
         m_profileLoadPendingFftYpixels.insert(panId, ypix);
         m_profileLoadPanDimensionsSettlingUntilMs.insert(

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2471,6 +2471,13 @@ void MainWindow::sendPanDimensionsToRadio(const QString& panId,
                 || panYpixelsFor(swGuard.data()) != ypix) {
                 return;
             }
+            // A radio status echo updates both the model and stream decoder.
+            // Do not run the delayed fallback afterward: besides being
+            // redundant, it would restart the DSS scale-settle window for a
+            // width-only resize whose y_pixels never changed.
+            if (currentPan->fftYPixels() == ypix) {
+                return;
+            }
             m_radioModel.panStream()->setYPixels(streamId, ypix);
             swGuard->prepareForFftPixelScaleChange();
         };

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -184,6 +184,19 @@ inline float dssHistoryAvailability(float sampleAge, float validRows)
     return std::clamp(validRows - sampleAge, 0.0f, 1.0f);
 }
 
+inline std::optional<float> dssRetainedSampleAge(float sourceAge,
+                                                 float remainingRows,
+                                                 float validRows)
+{
+    if (!std::isfinite(sourceAge) || !std::isfinite(remainingRows)
+        || !std::isfinite(validRows) || sourceAge < 0.0f
+        || remainingRows < 0.0f || validRows <= 0.0f
+        || sourceAge >= validRows) {
+        return std::nullopt;
+    }
+    return std::min(sourceAge + remainingRows, validRows - 1.0f);
+}
+
 struct StablePresentationAnchor {
     float value{0.0f};
     float acquisitionMean{0.0f};

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -184,17 +184,29 @@ inline float dssHistoryAvailability(float sampleAge, float validRows)
     return std::clamp(validRows - sampleAge, 0.0f, 1.0f);
 }
 
+// Mirror of dss_mesh.vert sampleHistoryDbm()'s retained sample-age clamp, for
+// unit testing. It must track the shader exactly, including the two clamps the
+// shader applies: cap validRows to [0, rows] (cappedValidRows) and floor the
+// oldest retained age at 0. Omitting them makes the mirror diverge from the GPU
+// path it validates outside 1 <= validRows <= rows (e.g. a negative age at
+// validRows = 0.5, or an uncapped age when validRows > rows). std::nullopt is
+// the analogue of the shader returning floorDbm (sample past the valid range).
 inline std::optional<float> dssRetainedSampleAge(float sourceAge,
                                                  float remainingRows,
-                                                 float validRows)
+                                                 float validRows,
+                                                 float rows)
 {
     if (!std::isfinite(sourceAge) || !std::isfinite(remainingRows)
-        || !std::isfinite(validRows) || sourceAge < 0.0f
-        || remainingRows < 0.0f || validRows <= 0.0f
-        || sourceAge >= validRows) {
+        || !std::isfinite(validRows) || !std::isfinite(rows)
+        || sourceAge < 0.0f || remainingRows < 0.0f || rows < 1.0f) {
         return std::nullopt;
     }
-    return std::min(sourceAge + remainingRows, validRows - 1.0f);
+    const float cappedValidRows = std::clamp(validRows, 0.0f, rows);
+    if (sourceAge >= cappedValidRows) {
+        return std::nullopt;
+    }
+    const float oldestRetainedAge = std::max(cappedValidRows - 1.0f, 0.0f);
+    return std::min(sourceAge + remainingRows, oldestRetainedAge);
 }
 
 struct StablePresentationAnchor {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2644,11 +2644,19 @@ void SpectrumWidget::prepareForFftScaleChange()
     m_noiseFloorCandidateFrames = 0;
 }
 
+void SpectrumWidget::beginFftPixelScaleSettle()
+{
+    // Monotonic: never shorten a settle window already armed (e.g. by an
+    // earlier request in a rapid drag, or by the echo re-arm below).
+    m_flexDssFftScaleSettlingUntilMs = std::max(
+        m_flexDssFftScaleSettlingUntilMs,
+        QDateTime::currentMSecsSinceEpoch() + kDssFftPixelScaleSettleMs);
+}
+
 void SpectrumWidget::prepareForFftPixelScaleChange()
 {
     prepareForFftScaleChange();
-    m_flexDssFftScaleSettlingUntilMs =
-        QDateTime::currentMSecsSinceEpoch() + kDssFftPixelScaleSettleMs;
+    beginFftPixelScaleSettle();
 
     // A y_pixels transition changes how future raw FFT pixel values decode to
     // dBm. Already-decoded rows remain valid physical dBm samples, so preserve

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2650,18 +2650,15 @@ void SpectrumWidget::prepareForFftPixelScaleChange()
     m_flexDssFftScaleSettlingUntilMs =
         QDateTime::currentMSecsSinceEpoch() + kDssFftPixelScaleSettleMs;
 
-    // A y_pixels transition changes how raw FFT pixel values decode to dBm.
-    // Rows received before the radio echo (or queued immediately after it) are
-    // not comparable with the settled stream and must not survive in 3D
-    // history. Keep a Kiwi surface intact when only the hidden Flex decoder is
-    // changing.
+    // A y_pixels transition changes how future raw FFT pixel values decode to
+    // dBm. Already-decoded rows remain valid physical dBm samples, so preserve
+    // the visible surface and retained history across a resize. The settle gate
+    // rejects ambiguous in-flight rows; only its temporal filter inputs need
+    // resetting. Keep Kiwi state untouched when the hidden Flex decoder changes.
     DssRenderer& flexDss = m_kiwiSdrWaterfallActive
         ? m_nativeWaterfallState.dss
         : m_dss;
-    flexDss.clear();
-    if (!m_kiwiSdrWaterfallActive) {
-        resetDssUploadState();
-    }
+    flexDss.resetInputSmoothing();
 }
 
 void SpectrumWidget::setFftWeightedAvg(bool on) {

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -229,6 +229,13 @@ public:
     void setNoiseFloorEnable(bool on);
     void prepareForFftScaleChange();
     void prepareForFftPixelScaleChange();
+    // Arm the DSS FFT-pixel-scale settle gate without switching the decoder or
+    // resetting smoothing. Called when a y_pixels change is *requested* (before
+    // the radio echo switches the local decoder) so rows decoded against the
+    // stale scale during the request→echo latency window are dropped from 3D
+    // history instead of surviving as mis-scaled rows. prepareForFftPixelScaleChange()
+    // re-arms it (and resets smoothing) once the decoder actually switches.
+    void beginFftPixelScaleSettle();
     void suspendNoiseFloorAutoAdjustUntil(qint64 untilMs);
     void resumeNoiseFloorAutoAdjust();
     void reacquireNoiseFloorLock();

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -118,6 +118,46 @@ int testInputScaleResetPreservesHistory()
     return 0;
 }
 
+int testInputScaleResetBreaksTemporalBlend()
+{
+    DssRenderer renderer;
+
+    // Settle a strong peak into the live temporal filter so the retained newest
+    // row carries it.
+    const int bin = DssRenderer::kCols / 2;
+    QVector<float> peak(DssRenderer::kCols, -120.0f);
+    peak[bin] = 0.0f;
+    for (int i = 0; i < 6; ++i) {
+        renderer.pushRow(peak);
+    }
+    const float settledPeak = renderer.rowDataRing(renderer.headRing())[bin];
+    if (settledPeak < -90.0f) {
+        return fail("peak did not settle into the live row");
+    }
+
+    // A y_pixels scale change resets input smoothing but preserves history. The
+    // first row pushed afterward must NOT blend against the retained (old-scale)
+    // peak row — a flat floor row should collapse to the floor, not stay lifted
+    // by the temporal IIR term.
+    renderer.resetInputSmoothing();
+    QVector<float> flat(DssRenderer::kCols, -120.0f);
+    renderer.pushRow(flat);
+    const float afterReset = renderer.rowDataRing(renderer.headRing())[bin];
+    if (afterReset > -110.0f) {
+        return fail("input scale reset must forget the temporal blend against "
+                    "the old-scale row");
+    }
+
+    // The break is one-shot: a second flat row is identical (baseline sanity).
+    renderer.pushRow(flat);
+    const float secondRow = renderer.rowDataRing(renderer.headRing())[bin];
+    if (secondRow > -110.0f) {
+        return fail("post-reset rows should track the new-scale input");
+    }
+
+    return 0;
+}
+
 int testRetainedHistoryCapacity()
 {
     DssRenderer renderer;
@@ -287,6 +327,9 @@ int main()
         return rc;
     }
     if (int rc = testInputScaleResetPreservesHistory(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testInputScaleResetBreaksTemporalBlend(); rc != 0) {
         return rc;
     }
     if (int rc = testRetainedHistoryCapacity(); rc != 0) {

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -97,6 +97,27 @@ int testRetainedHistoryOffset()
     return 0;
 }
 
+int testInputScaleResetPreservesHistory()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(12);
+    appendStableHistoryPeak(renderer, 180);
+    renderer.rebuildVisibleFromHistory(0, 14.0, 1.0, -200.0f);
+
+    const int visibleRowsBefore = renderer.rowCount();
+    const int historyRowsBefore = renderer.historyRowCount();
+    const int peakBefore = strongestBin(renderer);
+    renderer.resetInputSmoothing();
+
+    if (renderer.rowCount() != visibleRowsBefore
+        || renderer.historyRowCount() != historyRowsBefore
+        || strongestBin(renderer) != peakBefore) {
+        return fail("input scale reset must preserve decoded DSS history");
+    }
+
+    return 0;
+}
+
 int testRetainedHistoryCapacity()
 {
     DssRenderer renderer;
@@ -263,6 +284,9 @@ int main()
         return rc;
     }
     if (int rc = testRetainedHistoryOffset(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testInputScaleResetPreservesHistory(); rc != 0) {
         return rc;
     }
     if (int rc = testRetainedHistoryCapacity(); rc != 0) {

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -221,6 +221,15 @@ int testDssStartupHistoryAvailability()
         || !nearlyEqual(dssHistoryAvailability(0.0f, 0.0f), 0.0)) {
         return fail("3D FFT startup history should fade in continuously");
     }
+    const std::optional<float> movingAge =
+        dssRetainedSampleAge(94.0f, 0.5f, 96.0f);
+    const std::optional<float> oldestAge =
+        dssRetainedSampleAge(95.0f, 1.0f, 96.0f);
+    if (!movingAge || !nearlyEqual(*movingAge, 94.5)
+        || !oldestAge || !nearlyEqual(*oldestAge, 95.0)
+        || dssRetainedSampleAge(96.0f, 0.0f, 96.0f).has_value()) {
+        return fail("3D FFT rear row should remain stable until eviction");
+    }
     return 0;
 }
 

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -222,13 +222,28 @@ int testDssStartupHistoryAvailability()
         return fail("3D FFT startup history should fade in continuously");
     }
     const std::optional<float> movingAge =
-        dssRetainedSampleAge(94.0f, 0.5f, 96.0f);
+        dssRetainedSampleAge(94.0f, 0.5f, 96.0f, 96.0f);
     const std::optional<float> oldestAge =
-        dssRetainedSampleAge(95.0f, 1.0f, 96.0f);
+        dssRetainedSampleAge(95.0f, 1.0f, 96.0f, 96.0f);
     if (!movingAge || !nearlyEqual(*movingAge, 94.5)
         || !oldestAge || !nearlyEqual(*oldestAge, 95.0)
-        || dssRetainedSampleAge(96.0f, 0.0f, 96.0f).has_value()) {
+        || dssRetainedSampleAge(96.0f, 0.0f, 96.0f, 96.0f).has_value()) {
         return fail("3D FFT rear row should remain stable until eviction");
+    }
+    // Fidelity to the shader's two clamps outside 1 <= validRows <= rows:
+    // validRows > rows caps to rows (oldest age = rows - 1, not validRows - 1);
+    // 0 < validRows < 1 floors the oldest age at 0 rather than going negative.
+    // validRows = 200 > rows caps the oldest age to rows - 1 = 95, so a
+    // sourceAge+remainingRows of 100 clamps to 95 (an uncapped mirror would
+    // return 100 against validRows - 1 = 199).
+    const std::optional<float> cappedAge =
+        dssRetainedSampleAge(90.0f, 10.0f, 200.0f, 96.0f);
+    // 0 < validRows < 1 floors the oldest age at 0 rather than going negative.
+    const std::optional<float> flooredAge =
+        dssRetainedSampleAge(0.0f, 0.0f, 0.5f, 96.0f);
+    if (!cappedAge || !nearlyEqual(*cappedAge, 95.0)
+        || !flooredAge || !nearlyEqual(*flooredAge, 0.0)) {
+        return fail("3D FFT retained sample age must match shader clamps");
     }
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes regressions in the 3D FFT display introduced by the recent smooth-scrolling changes.

Resizing the main window no longer clears the visible 3D FFT surface or its retained history. Already-decoded dBm rows remain valid across an FFT pixel-scale transition, so the renderer now resets only its temporal filter inputs while the existing settle gate rejects ambiguous in-flight rows. The delayed resize fallback also avoids restarting the transition when the radio has already acknowledged the requested dimensions.

The 3D shader keeps its phase-stable geometry and existing color mapping while removing the additional rear-boundary fade that blurred outgoing traces. Sampling at the rear is clamped to the oldest retained FFT row so the final line remains stable until eviction instead of collapsing and reappearing.

Reproduction:

1. Connect to a radio and enable the 3D FFT display.
2. Allow enough history to accumulate to fill most of the surface.
3. Resize the main application window.
4. Observe that the existing 3D FFT history remains intact.
5. Watch traces reach the rear boundary and confirm that they remain sharp and stable until rolling off.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The resize and rear-boundary failure paths have focused regression coverage, and the behavior has been exercised with a live FLEX-6700.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable — resize/history, color, blur, and shimmer fixes were exercised on a FLEX-6700; final rear-edge clamp awaits explicit confirmation
- [ ] Existing tests pass (CI) — targeted local tests pass; CI pending
- [x] Reproduction steps documented if user-reported bug

Local verification:

```bash
cmake --build build --target AetherSDR spectrum_preview_logic_test dss_renderer_test -j8
./build/spectrum_preview_logic_test
./build/dss_renderer_test
git diff --check
python3 tools/check_engine_boundary.py --strict
```

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter changes
- [x] Documentation updated if user-visible behavior changed — not applicable; this restores prior behavior
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
