### PR TITLE
Fix signed integer overflow in AdifParser::extractField (#4411)

### DIFF
--- a/src/core/AdifParser.cpp
+++ b/src/core/AdifParser.cpp
@@ -25,7 +25,10 @@ static QString extractField(const QString& block, const QString& fieldName)
     if (!m.hasMatch()) return {};
     int len = m.captured(1).toInt();
     int start = m.capturedEnd(0);
-    if (start + len > block.length()) return {};
+    // Compare against remaining space rather than computing start + len:
+    // len comes straight from the ADIF length token, so a crafted value near
+    // INT_MAX overflows the signed addition (UB) and slips past the guard.
+    if (len < 0 || len > block.length() - start) return {};
     return block.mid(start, len);
 }
 


### PR DESCRIPTION
Looked into #4411. In `extractField` (`src/core/AdifParser.cpp`), `len` is pulled straight from the ADIF field-length token via `m.captured(1).toInt()`, then the guard does `start + len > block.length()`. Both `start` and `len` are `int`, so a crafted length near `INT_MAX` (e.g. `<CALL:2147483647>...`) overflows the signed addition — UB — and wraps to a negative value, which sails right past the `> block.length()` check. `QString::mid` clamps so there's no actual OOB read, but it's still UB and the length guard is silently defeated on malformed/untrusted `.adi` input.

Fix compares `len` against the remaining space (`block.length() - start`) instead of computing `start + len`. In Qt6 `block.length()` is `qsizetype` (64-bit) and `start` never exceeds it, so the subtraction can't underflow, and the addition that was overflowing is gone. Also added a `len < 0` guard so a negative length is rejected rather than handed to `mid`.

didn't have a Qt6 build env here so i couldn't compile the full app — flagging for CI/review. i did model the arithmetic standalone with the Qt6 types (`length()` as 64-bit, `start`/`len` as int): the old `start + len` wraps to `-2147483631` and the old guard lets it through, while the new guard rejects it and a normal-length field still passes. matches the sanitizer trace in the issue.

Fixes #4411
