### PR TITLE
Add surface-mapped slice shadows to the 3D FFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2685,7 +2685,8 @@ foreach(APP_SETTINGS_SCENARIO
         missing-live-temp
         missing-live-backup
         missing-live-corrupt
-        failed-load)
+        failed-load
+        display-slice-depth-default)
     add_test(
         NAME app_settings_safety_${APP_SETTINGS_SCENARIO}
         COMMAND app_settings_safety_test ${APP_SETTINGS_SCENARIO})

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -8,6 +8,7 @@ layout(location = 0) in float vLut;
 layout(location = 1) in float vDepth;
 layout(location = 2) in float vEdge;
 layout(location = 3) in float vBoundaryFade;
+layout(location = 4) in float vFrequency;
 
 layout(std140, binding = 0) uniform U {
     float rowOffset;
@@ -31,19 +32,66 @@ layout(std140, binding = 0) uniform U {
     float padding18;
     float padding19;
     vec4  bgFill;
+    vec4  shadowBands[8];
+    vec4  shadowStyles[8];
+    vec4  shadowMeta;
 };
 
 layout(binding = 2) uniform sampler2D paletteLut;  // 256x1 RGBA8, floor(0)->peak(1)
 
 layout(location = 0) out vec4 fragColor;
 
+vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
+{
+    if (shadowMeta.y < 0.5) {
+        return surfaceColor;
+    }
+
+    int descriptorCount = int(clamp(shadowMeta.x, 0.0, 8.0));
+    float plotWidthPx = max(shadowMeta.z, 1.0);
+    float frequencyPixel = max(fwidth(vFrequency), 1.0 / plotWidthPx);
+    vec3 color = surfaceColor;
+    for (int i = 0; i < 8; ++i) {
+        if (i >= descriptorCount) {
+            break;
+        }
+        vec4 band = shadowBands[i];
+        vec4 style = shadowStyles[i];
+        float edgeSoftness = frequencyPixel * 0.8;
+        float insideLow = smoothstep(
+            band.x - edgeSoftness, band.x + edgeSoftness, vFrequency);
+        float insideHigh = 1.0 - smoothstep(
+            band.y - edgeSoftness, band.y + edgeSoftness, vFrequency);
+        float bandMask = insideLow * insideHigh;
+
+        // Near-black with a trace of the slice hue: this darkens the existing
+        // DSS fragment in place instead of drawing a second surface above it.
+        vec3 shadowColor = vec3(0.008) + style.rgb * 0.045;
+        color = mix(
+            color, shadowColor,
+            clamp(band.w * bandMask * depthFade, 0.0, 1.0));
+
+        float lineHalfWidth = frequencyPixel * 1.4;
+        float lineMask = 1.0 - smoothstep(
+            lineHalfWidth, lineHalfWidth * 2.1,
+            abs(vFrequency - band.z));
+        vec3 cueColor = mix(shadowColor, style.rgb, 0.42);
+        color = mix(
+            color, cueColor,
+            clamp(style.w * lineMask * depthFade, 0.0, 1.0));
+    }
+    return color;
+}
+
 void main()
 {
     float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
+    float shadowFade = pow(fade, 1.15);
 
     if (vEdge < -0.5) {
         // Original neutral ridge highlight over the amplitude-coloured curtain.
         vec3 oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
+        oc = applySliceShadow(oc, shadowFade);
         float a = (0.12 + 0.5 * fade) * vBoundaryFade;
         fragColor = vec4(oc, a);
         return;
@@ -52,5 +100,6 @@ void main()
     vec3 c = texture(paletteLut, vec2(clamp(vLut, 0.0, 1.0), 0.5)).rgb;
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
     c = mix(bgFill.rgb, c, vBoundaryFade);
+    c = applySliceShadow(c, shadowFade);
     fragColor = vec4(c, 1.0);
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -32,6 +32,9 @@ layout(std140, binding = 0) uniform U {
     float padding18;
     float padding19;
     vec4  bgFill;             // plot background colour (for haze)
+    vec4  shadowBands[8];     // low u, high u, centre u, band alpha
+    vec4  shadowStyles[8];    // cue rgb, centre-line alpha
+    vec4  shadowMeta;         // descriptor count, enabled, plot width px, pad
 };
 
 layout(binding = 1) uniform sampler2D heightTex;  // R16F, dBm, ring-buffered rows
@@ -40,6 +43,7 @@ layout(location = 0) out float vLut;    // palette lookup coord (floor->peak gra
 layout(location = 1) out float vDepth;  // row depth 0..1 for haze/fade
 layout(location = 2) out float vEdge;   // edge tag passthrough
 layout(location = 3) out float vBoundaryFade;
+layout(location = 4) out float vFrequency;
 
 float sampleHistoryDbm(float texU, float historyV, float rows,
                        float remainingRows)
@@ -113,6 +117,7 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
+    vFrequency = u;
     // During startup, the newly exposed oldest slot fades in continuously over
     // the row interval. Keep the eviction fade anchored at the physical back
     // of the full history so it does not move one discrete slot per arrival.

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -44,10 +44,11 @@ public:
     }
 
     // Perspective shadow for slice markers and passbands in the 3D
-    // stacked-trace view. Global across panadapters; dormant in 2D.
+    // stacked-trace view. Global across panadapters; dormant in 2D. New
+    // installs default on, while a persisted False keeps the user's opt-out.
     static bool threeDSliceDepth()
     {
-        return readObj().value("threeDSliceDepth").toString("False") == "True";
+        return readObj().value("threeDSliceDepth").toString("True") == "True";
     }
 
     static void setThreeDSliceDepth(bool on)

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -44,11 +44,12 @@ public:
     }
 
     // Perspective shadow for slice markers and passbands in the 3D
-    // stacked-trace view. Global across panadapters; dormant in 2D. New
-    // installs default on, while a persisted False keeps the user's opt-out.
+    // stacked-trace view. Global across panadapters; dormant in 2D. Defaults
+    // off (like every sibling Display toggle) so an upgrade never silently
+    // changes an existing user's display — the effect is opt-in.
     static bool threeDSliceDepth()
     {
-        return readObj().value("threeDSliceDepth").toString("True") == "True";
+        return readObj().value("threeDSliceDepth").toString("False") == "True";
     }
 
     static void setThreeDSliceDepth(bool on)

--- a/src/gui/DisplaySettings.h
+++ b/src/gui/DisplaySettings.h
@@ -43,6 +43,20 @@ public:
         write(o);
     }
 
+    // Perspective shadow for slice markers and passbands in the 3D
+    // stacked-trace view. Global across panadapters; dormant in 2D.
+    static bool threeDSliceDepth()
+    {
+        return readObj().value("threeDSliceDepth").toString("False") == "True";
+    }
+
+    static void setThreeDSliceDepth(bool on)
+    {
+        QJsonObject o = readObj();
+        o["threeDSliceDepth"] = on ? QStringLiteral("True") : QStringLiteral("False");
+        write(o);
+    }
+
     // VFO meter view: false = standard S-meter, true = SmartMTR component.
     // Global (not per-slice) — see MeterViewController for the live-broadcast
     // layer that fans this choice out to every open VFO flag.

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -617,3 +617,18 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
         }
     }
 }
+
+QVector<bool> dssDepthVisibleSegments(const QVector<qreal>& yFrontToBack)
+{
+    if (yFrontToBack.size() < 2) {
+        return {};
+    }
+    QVector<bool> visible(yFrontToBack.size() - 1, true);
+    qreal silhouetteY = std::numeric_limits<qreal>::max();
+    for (qsizetype i = 1; i < yFrontToBack.size(); ++i) {
+        visible[i - 1] = yFrontToBack.at(i - 1) <= silhouetteY + 0.5
+            || yFrontToBack.at(i) <= silhouetteY + 0.5;
+        silhouetteY = std::min(silhouetteY, yFrontToBack.at(i - 1));
+    }
+    return visible;
+}

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -2,11 +2,14 @@
 
 #include <QColor>
 #include <QImage>
+#include <QPointF>
 #include <QSize>
 #include <QVector>
 #include <QtCore/qfloat16.h>
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <functional>
 
 // ─── Stacked-trace spectrum stream surface ──────────────────────────────────
@@ -41,6 +44,37 @@ public:
     // Colour uses a stable signal aperture independent of the Ref-level height
     // span. Otherwise a high Ref level compresses every real signal into blue.
     static constexpr float kColorSpanDb        = 45.0f;
+
+    // Project a normalized frequency coordinate onto the same perspective
+    // plane used by both DSS renderers. depth=0 is the full-width front edge;
+    // depth=1 is the narrowed back edge. Slice overlays use this helper so
+    // their apparent angle cannot drift from the FFT surface.
+    static QPointF projectPerspective(float frequencyUnit, float depth)
+    {
+        const float d = std::clamp(depth, 0.0f, 1.0f);
+        const float width = 1.0f - d * (1.0f - kBackWidthFrac);
+        return QPointF(0.5f + (frequencyUnit - 0.5f) * width,
+                       1.0f - d * kDepthSpanFrac);
+    }
+
+    // Project a point onto the visible top of a DSS ridge. This is the CPU
+    // equivalent of dss_mesh.vert's height mapping and is used by overlays
+    // that must stay attached to the surface when the 3D floor moves.
+    static QPointF projectSurface(float frequencyUnit, float depth, float dbm,
+                                  float floorDbm, float rangeDb, float zCurve)
+    {
+        const float d = std::clamp(depth, 0.0f, 1.0f);
+        const float width = 1.0f - d * (1.0f - kBackWidthFrac);
+        const float finiteDbm = std::isfinite(dbm) ? dbm : floorDbm;
+        const float strengthLinear = std::clamp(
+            (finiteDbm - floorDbm) / std::max(rangeDb, 1.0f),
+            0.0f, 1.0f);
+        const float strengthHeight = std::pow(
+            strengthLinear, std::max(zCurve, 0.05f));
+        QPointF point = projectPerspective(frequencyUnit, d);
+        point.ry() -= strengthHeight * kFrontMaxRidgeFrac * width;
+        return point;
+    }
 
     // Maps a dBm value to an RGB colour using the host's panadapter palette.
     using PaletteFn = std::function<QRgb(float dbm)>;

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -203,3 +203,20 @@ private:
     float   m_cacheZCurve       = 0.0f;
     quint64 m_cachePaletteToken = ~0ull;
 };
+
+// Painter's-algorithm occlusion for the CPU depth-shadow overlay drawn on top
+// of this surface.
+//
+// `yFrontToBack` holds the projected screen y of one frequency column at each
+// depth step, nearest row first. rebuild() fills every row's curtain down to
+// the plot floor, so a nearer row hides everything below its ridge: a point is
+// occluded once it sits lower (larger y) than the topmost ridge in front of
+// it. The shadow is painted as a flat overlay after the surface, so segments
+// that fail this test would otherwise be stroked across the face of the nearer
+// curtain and read as floating in front of the surface.
+//
+// Returns one flag per segment (size = N-1, empty for N < 2): true when either
+// endpoint still clears that silhouette, so partial overlaps are kept rather
+// than over-culled. The half-pixel slack keeps a ridge that merely grazes the
+// silhouette from flickering in and out between frames.
+QVector<bool> dssDepthVisibleSegments(const QVector<qreal>& yFrontToBack);

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -72,7 +72,7 @@ public:
         const float strengthHeight = std::pow(
             strengthLinear, std::max(zCurve, 0.05f));
         QPointF point = projectPerspective(frequencyUnit, d);
-        point.ry() -= strengthHeight * kFrontMaxRidgeFrac * width;
+        point.ry() -= static_cast<double>(strengthHeight) * kFrontMaxRidgeFrac * width;
         return point;
     }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -14924,14 +14924,16 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
     const int cols = m_dss.cols();
     const int validRows = m_dss.rowCount();
     const int headRing = m_dss.headRing();
-    const float distanceRows =
-        std::max(m_waterfallScrollDistanceRows, 1.0f);
-    const float scrollProgressRows = m_waterfallScrollClock.isValid()
-        ? waterfallScrollProgressRows()
-        : m_waterfallScrollDistanceRows;
-    const float remainingRows = std::clamp(
-        distanceRows - scrollProgressRows, 0.0f, distanceRows);
 
+    // This geometry is only ever drawn over the CACHED surface image, which
+    // DssRenderer::rebuild() renders from each row's discrete data with no
+    // sub-row scroll offset (see its rowAt(age) loop). Sampling with the mesh
+    // shader's `remainingRows` offset instead would blend toward a row the
+    // cached surface never shows: while the scroll clock runs that offset
+    // sweeps distanceRows -> 0 every row interval, so the shadow ridge would
+    // track a row up to one row older and re-converge each FFT row, visibly
+    // bobbing off the ridge even though the surface underneath is static
+    // between rows. Snap to the same discrete row the surface drew.
     const auto sampleSurfaceDbm = [&](float displayUnit, float depth) {
         const float sourceUnit =
             0.5f + frequencyOffset
@@ -14944,21 +14946,17 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
             static_cast<int>(std::lround(
                 std::clamp(sourceUnit, 0.0f, 1.0f) * (cols - 1))),
             0, cols - 1);
-        const float sampleAge =
-            std::clamp(depth, 0.0f, 1.0f) * rows + remainingRows;
-        const int age0 = std::max(
-            0, static_cast<int>(std::floor(sampleAge)));
-        const int age1 = age0 + 1;
-        const float ageBlend = sampleAge - std::floor(sampleAge);
-        const auto dbmAtAge = [&](int age) {
-            if (age < 0 || age >= validRows) {
-                return floorDbm;
-            }
-            const int ring = (headRing + age) % rows;
-            const float value = m_dss.rowDataRing(ring)[column];
-            return std::isfinite(value) ? value : floorDbm;
-        };
-        return std::lerp(dbmAtAge(age0), dbmAtAge(age1), ageBlend);
+        // lround, not floor: depth is age/rows, so depth*rows lands a hair
+        // under the intended integer age in float and floor() would pick the
+        // row in front of it.
+        const int age = static_cast<int>(std::lround(
+            std::clamp(depth, 0.0f, 1.0f) * rows));
+        if (age < 0 || age >= validRows) {
+            return floorDbm;
+        }
+        const int ring = (headRing + age) % rows;
+        const float value = m_dss.rowDataRing(ring)[column];
+        return std::isfinite(value) ? value : floorDbm;
     };
 
     // Carry the shadow to the final DSS row and fade it fully transparent
@@ -15058,14 +15056,44 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
                 return points;
             };
 
-            QVector<QPointF> previous =
-                crossSection(depths.constFirst());
+            // Occlusion. DssRenderer::rebuild draws rows back-to-front with
+            // every curtain filled down to the plot floor, so a nearer row
+            // hides everything below its ridge. This shadow is a flat overlay
+            // painted after that surface, so without culling, far segments get
+            // stroked across the face of nearer curtains and the shadow reads
+            // as floating in front of the surface — the opposite of the decal
+            // the mesh path produces. Culling at build time fixes both
+            // consumers of this geometry (QPainter and the RHI vertex path).
+            QVector<QVector<QPointF>> crossSections;
+            crossSections.reserve(depths.size());
+            for (float depth : depths) {
+                crossSections.append(crossSection(depth));
+            }
+            // Per-column visibility down the depth axis, then a quad survives
+            // if either of the two columns it spans is still visible there —
+            // i.e. if any of its four corners clears the nearer rows.
+            QVector<QVector<bool>> columnVisible;
+            columnVisible.reserve(kBandFrequencySegments + 1);
+            for (int column = 0; column <= kBandFrequencySegments; ++column) {
+                QVector<qreal> ys;
+                ys.reserve(crossSections.size());
+                for (const QVector<QPointF>& section : crossSections) {
+                    ys.append(section.at(column).y());
+                }
+                columnVisible.append(dssDepthVisibleSegments(ys));
+            }
+
             for (int i = 1; i < depths.size(); ++i) {
                 const float frontDepth = depths.at(i - 1);
                 const float backDepth = depths.at(i);
-                QVector<QPointF> next = crossSection(backDepth);
+                const QVector<QPointF>& previous = crossSections.at(i - 1);
+                const QVector<QPointF>& next = crossSections.at(i);
                 for (int column = 0;
                      column < kBandFrequencySegments; ++column) {
+                    if (!columnVisible.at(column).at(i - 1)
+                        && !columnVisible.at(column + 1).at(i - 1)) {
+                        continue;
+                    }
                     geometry.bands.append({
                         QPolygonF{
                             previous.at(column),
@@ -15077,7 +15105,6 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
                         fadedColor(fillBase, fillAlpha, backDepth),
                     });
                 }
-                previous = std::move(next);
             }
         }
 
@@ -15099,9 +15126,23 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
                 geometry.hasFirstProjection = true;
             }
 
+            // Same occlusion rule as the band above: a marker segment behind
+            // the silhouette of the rows in front of it is hidden by their
+            // curtains and must not be stroked over them.
+            QVector<qreal> markerYs;
+            markerYs.reserve(points.size());
+            for (const QPointF& point : points) {
+                markerYs.append(point.y());
+            }
+            const QVector<bool> segmentVisible =
+                dssDepthVisibleSegments(markerYs);
+
             const QColor shadowBase = shadowColor(source, 255);
             const int shadowAlpha = so.isActive ? 185 : 72;
             for (int i = 1; i < points.size(); ++i) {
+                if (!segmentVisible.at(i - 1)) {
+                    continue;
+                }
                 geometry.lines.append({
                     QLineF(points.at(i - 1), points.at(i)),
                     fadedColor(
@@ -15114,6 +15155,9 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
             const QColor cueBase = projectionCueColor(source);
             const int cueAlpha = so.isActive ? 92 : 28;
             for (int i = 1; i < points.size(); ++i) {
+                if (!segmentVisible.at(i - 1)) {
+                    continue;
+                }
                 geometry.lines.append({
                     QLineF(points.at(i - 1), points.at(i)),
                     fadedColor(cueBase, cueAlpha, depths.at(i - 1)),
@@ -15164,7 +15208,13 @@ void SpectrumWidget::drawDssDepthGeometry(
     QPainter& painter, const DssDepthGeometry& geometry) const
 {
     painter.save();
-    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    // AA OFF for the band tiles. The band is a grid of abutting translucent
+    // polygons, and an antialiased shared edge is blended twice — once by each
+    // neighbour — leaving a visible seam lattice across the whole shadow.
+    // DssRenderer::rebuild disables AA on its tiled trapezoids for exactly this
+    // reason; the marker lines below re-enable it for a crisp stroke.
+    painter.setRenderHint(QPainter::Antialiasing, false);
 
     for (const DssDepthBand& band : geometry.bands) {
         painter.setPen(Qt::NoPen);
@@ -15178,6 +15228,7 @@ void SpectrumWidget::drawDssDepthGeometry(
         painter.setBrush(gradient);
         painter.drawPolygon(band.polygon);
     }
+    painter.setRenderHint(QPainter::Antialiasing, true);
     for (const DssDepthLine& line : geometry.lines) {
         QLinearGradient gradient(line.line.p1(), line.line.p2());
         gradient.setColorAt(0.0, line.frontColor);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -3596,15 +3596,23 @@ void SpectrumWidget::setThreeDSliceDepth(bool on)
     DisplaySettings::setThreeDSliceDepth(on);
     markOverlayDirty("threeDSliceDepth");
 
-    // This is a global display treatment: every open pan should agree.
-    if (QWidget* top = window()) {
-        const auto siblings = top->findChildren<SpectrumWidget*>();
-        for (SpectrumWidget* sw : siblings) {
-            if (sw == this || sw->m_threeDSliceDepth == on) {
-                continue;
-            }
-            sw->m_threeDSliceDepth = on;
-            sw->markOverlayDirty("threeDSliceDepthSibling");
+    // This is a global display treatment: every open pan should agree,
+    // including panadapters popped out into their own top-level window, which
+    // are NOT descendants of this widget's window(). Walk every top-level
+    // window so a floating pan updates live rather than waiting for the next
+    // loadSettings() to pick up the persisted value.
+    const auto applyToSibling = [this, on](SpectrumWidget* sw) {
+        if (!sw || sw == this || sw->m_threeDSliceDepth == on) {
+            return;
+        }
+        sw->m_threeDSliceDepth = on;
+        sw->markOverlayDirty("threeDSliceDepthSibling");
+    };
+    for (QWidget* top : QApplication::topLevelWidgets()) {
+        applyToSibling(qobject_cast<SpectrumWidget*>(top));
+        const auto pans = top->findChildren<SpectrumWidget*>();
+        for (SpectrumWidget* sw : pans) {
+            applyToSibling(sw);
         }
     }
 }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -68,7 +68,9 @@
 #include "core/PerfTelemetry.h"
 #include <QSoundEffect>
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <iterator>
 #include <cstring>
 #include <limits>
 #include <memory>
@@ -11449,6 +11451,13 @@ void SpectrumWidget::initDssMeshPipeline()
 
 void SpectrumWidget::initDssDepthPipeline()
 {
+    // Idempotent + lazy: built on first CPU-image-fallback use, not at init.
+    // m_dssDepthVbo (created first below) doubles as the "already attempted"
+    // sentinel so a create() failure doesn't retry — and rebuild — every frame.
+    // releaseResources() nulls it, so a device reset re-arms the lazy build.
+    if (m_dssDepthVbo) {
+        return;
+    }
     QRhi* r = rhi();
     m_dssDepthVertexCount = 0;
 
@@ -11522,11 +11531,16 @@ void SpectrumWidget::updateDssDepthVertices(
         return;
     }
 
+    // Each quad/line is 6 vertices (2 triangles). Reserve the whole primitive
+    // up front so the cap can never split one mid-triangle — a partial primitive
+    // would render as a dangling shard. When the cap is hit we drop the trailing
+    // primitives whole and warn once rather than silently truncating geometry.
+    bool truncated = false;
+    const auto roomFor = [&](int verts) {
+        return m_dssDepthVertexCount + verts <= kDssDepthMaxVertices;
+    };
     const auto appendVertex = [&](const QPointF& point, const QColor& color,
                                   float edge) {
-        if (m_dssDepthVertexCount >= kDssDepthMaxVertices) {
-            return;
-        }
         const float x = static_cast<float>(
             point.x() * 2.0 / logicalSize.width() - 1.0);
         const float y = static_cast<float>(
@@ -11544,26 +11558,40 @@ void SpectrumWidget::updateDssDepthVertices(
                                 const QPointF& c, const QPointF& d,
                                 const QColor& frontColor,
                                 const QColor& backColor) {
+        if (!roomFor(6)) {
+            return false;
+        }
         appendVertex(a, frontColor, 0.0f);
         appendVertex(b, frontColor, 0.0f);
         appendVertex(c, backColor, 0.0f);
         appendVertex(a, frontColor, 0.0f);
         appendVertex(c, backColor, 0.0f);
         appendVertex(d, backColor, 0.0f);
+        return true;
     };
 
     for (const DssDepthBand& band : geometry.bands) {
         if (band.polygon.size() == 4) {
-            appendQuad(band.polygon.at(0), band.polygon.at(1),
-                       band.polygon.at(2), band.polygon.at(3),
-                       band.frontColor, band.backColor);
+            if (!appendQuad(band.polygon.at(0), band.polygon.at(1),
+                            band.polygon.at(2), band.polygon.at(3),
+                            band.frontColor, band.backColor)) {
+                truncated = true;
+                break;
+            }
         }
     }
     for (const DssDepthLine& line : geometry.lines) {
+        if (truncated) {
+            break;
+        }
         const QPointF delta = line.line.p2() - line.line.p1();
         const qreal length = std::hypot(delta.x(), delta.y());
         if (length <= 0.001) {
             continue;
+        }
+        if (!roomFor(6)) {
+            truncated = true;
+            break;
         }
         const qreal halfWidth = std::max<qreal>(0.45, line.width * 0.5);
         const QPointF normal(-delta.y() / length * halfWidth,
@@ -11578,6 +11606,16 @@ void SpectrumWidget::updateDssDepthVertices(
         appendVertex(aMinus, line.frontColor, -1.0f);
         appendVertex(bPlus, line.backColor, 1.0f);
         appendVertex(bMinus, line.backColor, -1.0f);
+    }
+    if (truncated) {
+        static bool warnedOnce = false;
+        if (!warnedOnce) {
+            warnedOnce = true;
+            qCWarning(lcGui)
+                << "SpectrumWidget: 3D slice projection vertex cap"
+                << kDssDepthMaxVertices
+                << "reached; trailing slice shadows dropped this frame";
+        }
     }
 
     if (m_dssDepthVertexCount > 0) {
@@ -11606,7 +11644,9 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     initOverlayPipeline();
     initSpectrumPipeline();
     initDssMeshPipeline();
-    initDssDepthPipeline();
+    // initDssDepthPipeline() is deliberately NOT called here — its ~458 KB VBO
+    // and pipeline are only used on the CPU-image fallback, which most GPU
+    // systems never hit. Built lazily on first fallback use in renderGpuFrame.
 
     // Upload quad vertex data for both pipelines
     QRhiResourceUpdateBatch* batch = r->nextResourceUpdateBatch();
@@ -12516,7 +12556,14 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 m_waterfallScrollClock.isValid()
                 ? scrollProgressRows
                 : m_waterfallScrollDistanceRows;
-            std::array<float, kDssMeshUboFloats> ubo{
+            // Scalar UBO prefix as a deduced-size array so a dropped or added
+            // field is a COMPILE error here, not a silently zero-filled uniform.
+            // A bare std::array<float, kDssMeshUboFloats>{…} sized to the whole
+            // UBO would swallow a short initializer list (breaking e.g. preview
+            // zoom/pan) without complaint; the shadow descriptors are filled
+            // separately below.
+            constexpr int kDssMeshScalarFields = 24;  // through the bgFill vec4
+            const float uboScalars[] = {
                 rowOffset,
                 floorDbm, rangeDb, m_dssZCurve,
                 DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
@@ -12532,11 +12579,18 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<float>(m_bgFillColor.blueF()),
                 1.0f,                                         // bgFill vec4
             };
+            static_assert(std::size(uboScalars) == kDssMeshScalarFields,
+                "a missed field here is a compile error, not silent garbage");
+            std::array<float, kDssMeshUboFloats> ubo{};
+            std::copy(std::begin(uboScalars), std::end(uboScalars),
+                      ubo.begin());
 
             // Slice shadows are decals evaluated by the DSS shader itself.
             // Because the mask modifies the existing curtain/ridge fragments,
             // it cannot hover above or cut through the rendered surface.
             constexpr int kShadowBandsOffset = 24;
+            static_assert(kShadowBandsOffset == kDssMeshScalarFields,
+                "shadow descriptors must begin right after the scalar prefix");
             constexpr int kShadowStylesOffset =
                 kShadowBandsOffset + kDssMeshShadowSlices * 4;
             constexpr int kShadowMetaOffset =
@@ -12555,6 +12609,40 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             const double shadowEndMhz =
                 shadowCenterMhz + shadowBandwidthMhz * 0.5;
             int shadowCount = 0;
+            const auto unitForShadowMhz = [&](double mhz) {
+                return static_cast<float>(
+                    (mhz - shadowStartMhz) / shadowBandwidthMhz);
+            };
+            // One shadow descriptor slot carries one passband band plus one
+            // marker cue (dss_mesh.frag). A band-less slot (bandAlpha 0) is a
+            // pure cue; a cue-less slot (cueAlpha 0) is a pure passband.
+            const auto writeShadowSlot = [&](float low, float high,
+                                             bool bandVisible, float cueCenter,
+                                             const QColor& cueColor,
+                                             bool cueVisible, bool active) {
+                if (shadowCount >= kDssMeshShadowSlices) {
+                    return false;
+                }
+                const int bandBase = kShadowBandsOffset + shadowCount * 4;
+                ubo.at(bandBase) = std::clamp(low, 0.0f, 1.0f);
+                ubo.at(bandBase + 1) = std::clamp(high, 0.0f, 1.0f);
+                ubo.at(bandBase + 2) = std::clamp(cueCenter, 0.0f, 1.0f);
+                ubo.at(bandBase + 3) =
+                    bandVisible ? (active ? 0.42f : 0.17f) : 0.0f;
+                const int styleBase = kShadowStylesOffset + shadowCount * 4;
+                ubo.at(styleBase) = static_cast<float>(cueColor.redF());
+                ubo.at(styleBase + 1) = static_cast<float>(cueColor.greenF());
+                ubo.at(styleBase + 2) = static_cast<float>(cueColor.blueF());
+                ubo.at(styleBase + 3) =
+                    cueVisible ? (active ? 0.36f : 0.11f) : 0.0f;
+                ++shadowCount;
+                return true;
+            };
+            // Match drawSliceMarkers / the CPU 3D fallback: the passband band
+            // and marker cue(s) are placed independently (an off-screen passband
+            // must not drop an on-screen cue, and vice versa); RTTY/DIGL draws a
+            // mark+space pair rather than a carrier cue; markerWidth == 0 draws
+            // the passband with no cue at all.
             const auto appendShadow = [&](const SliceOverlay& so) {
                 if (shadowCount >= kDssMeshShadowSlices
                     || !std::isfinite(shadowBandwidthMhz)
@@ -12563,47 +12651,81 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     || so.freqMhz > shadowEndMhz) {
                     return;
                 }
-                float low = static_cast<float>(
-                    (so.freqMhz + so.filterLowHz / 1.0e6
-                     - shadowStartMhz) / shadowBandwidthMhz);
-                float high = static_cast<float>(
-                    (so.freqMhz + so.filterHighHz / 1.0e6
-                     - shadowStartMhz) / shadowBandwidthMhz);
+                float low = unitForShadowMhz(
+                    so.freqMhz + so.filterLowHz / 1.0e6);
+                float high = unitForShadowMhz(
+                    so.freqMhz + so.filterHighHz / 1.0e6);
                 if (low > high) {
                     std::swap(low, high);
                 }
-                if (high < 0.0f || low > 1.0f) {
+                const bool bandVisible = !(high < 0.0f || low > 1.0f);
+
+                struct ShadowCue { float center; QColor color; };
+                std::array<ShadowCue, 2> cues;
+                int cueCount = 0;
+                const bool rtty = so.mode == QStringLiteral("RTTY")
+                    || so.mode == QStringLiteral("DIGL");
+                if (rtty) {
+                    double markMhz = so.freqMhz;
+                    if (so.mode == QStringLiteral("DIGL")) {
+                        markMhz -= so.rttyMark / 1.0e6;
+                    }
+                    const double spaceMhz = markMhz - so.rttyShift / 1.0e6;
+                    cues[cueCount++] = {unitForShadowMhz(markMhz),
+                        AetherSDR::ThemeManager::instance().color(
+                            "color.accent.success")};
+                    cues[cueCount++] = {unitForShadowMhz(spaceMhz),
+                        AetherSDR::ThemeManager::instance().color(
+                            "color.accent.danger")};
+                } else if (so.markerWidth > 0) {
+                    cues[cueCount++] = {unitForShadowMhz(so.freqMhz),
+                                        sliceColorForOverlay(so)};
+                }
+
+                // Cull each cue by its own position, matching appendLine.
+                std::array<ShadowCue, 2> visible;
+                int visibleCount = 0;
+                for (int i = 0; i < cueCount; ++i) {
+                    if (cues[i].center >= 0.0f && cues[i].center <= 1.0f) {
+                        visible[visibleCount++] = cues[i];
+                    }
+                }
+
+                if (!bandVisible && visibleCount == 0) {
                     return;
                 }
-                low = std::clamp(low, 0.0f, 1.0f);
-                high = std::clamp(high, 0.0f, 1.0f);
-                const float center = std::clamp(
-                    static_cast<float>(
-                        (so.freqMhz - shadowStartMhz)
-                        / shadowBandwidthMhz),
-                    0.0f, 1.0f);
-                const QColor cue = sliceColorForOverlay(so);
-                const int bandBase = kShadowBandsOffset + shadowCount * 4;
-                ubo.at(bandBase) = low;
-                ubo.at(bandBase + 1) = high;
-                ubo.at(bandBase + 2) = center;
-                ubo.at(bandBase + 3) = so.isActive ? 0.42f : 0.17f;
-                const int styleBase =
-                    kShadowStylesOffset + shadowCount * 4;
-                ubo.at(styleBase) = static_cast<float>(cue.redF());
-                ubo.at(styleBase + 1) = static_cast<float>(cue.greenF());
-                ubo.at(styleBase + 2) = static_cast<float>(cue.blueF());
-                ubo.at(styleBase + 3) = so.isActive ? 0.36f : 0.11f;
-                ++shadowCount;
-            };
-            for (const SliceOverlay& so : m_sliceOverlays) {
-                if (!so.isActive) {
-                    appendShadow(so);
+                if (visibleCount == 0) {
+                    // Passband only (markerWidth == 0, or all cues off-screen).
+                    writeShadowSlot(low, high, bandVisible,
+                                    (low + high) * 0.5f,
+                                    sliceColorForOverlay(so), false,
+                                    so.isActive);
+                    return;
                 }
-            }
-            for (const SliceOverlay& so : m_sliceOverlays) {
-                if (so.isActive) {
-                    appendShadow(so);
+                // First cue shares the passband slot; extra cues (RTTY space)
+                // take band-less slots until the descriptor budget is spent.
+                writeShadowSlot(low, high, bandVisible, visible[0].center,
+                                visible[0].color, true, so.isActive);
+                for (int i = 1; i < visibleCount; ++i) {
+                    if (!writeShadowSlot(0.0f, 0.0f, false, visible[i].center,
+                                         visible[i].color, true, so.isActive)) {
+                        break;
+                    }
+                }
+            };
+            // Only compute shadow descriptors when the effect is on; otherwise
+            // the loops are wasted per-frame work (the shader discards them via
+            // shadowMeta.y anyway).
+            if (m_threeDSliceDepth) {
+                for (const SliceOverlay& so : m_sliceOverlays) {
+                    if (!so.isActive) {
+                        appendShadow(so);
+                    }
+                }
+                for (const SliceOverlay& so : m_sliceOverlays) {
+                    if (so.isActive) {
+                        appendShadow(so);
+                    }
                 }
             }
             ubo.at(kShadowMetaOffset) = static_cast<float>(shadowCount);
@@ -12663,6 +12785,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         // because it shows/raises widgets, which must not happen mid-render.)
         repositionVfoFlags(specRect);
         if (!m_dssMeshReady) {
+            // Lazily build the fallback pipeline/VBO on first use (runs before
+            // beginPass, so resource creation is outside the render pass). Only
+            // when the effect is on — buildDssDepthGeometry returns empty
+            // otherwise, so the pipeline would sit unused.
+            if (m_threeDSliceDepth) {
+                initDssDepthPipeline();
+            }
             updateDssDepthVertices(
                 batch, buildDssDepthGeometry(specRect, dssFrameFloorDbm),
                 logicalSize);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1240,6 +1240,22 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("dssHistoryRows")] = m_dss.historyRowCount();
     m[QStringLiteral("dssHistoryCapacityRows")] = m_dss.historyCapacityRows();
     m[QStringLiteral("dssFftScaleSettling")] = flexDssFftScaleSettling();
+    m[QStringLiteral("threeDSliceDepth")] = m_threeDSliceDepth;
+    const QRect depthSpecRect(0, 0, width(), spectrumPixelHeight());
+    const DssDepthGeometry depthGeometry =
+        buildDssDepthGeometry(depthSpecRect, peekDssFloorDbm());
+    m[QStringLiteral("dssDepthBandCount")] = depthGeometry.bands.size();
+    m[QStringLiteral("dssDepthLineCount")] = depthGeometry.lines.size();
+    if (depthGeometry.hasFirstProjection) {
+        m[QStringLiteral("dssDepthFirstFrontX")] =
+            depthGeometry.firstProjection.p1().x();
+        m[QStringLiteral("dssDepthFirstFrontY")] =
+            depthGeometry.firstProjection.p1().y();
+        m[QStringLiteral("dssDepthFirstBackX")] =
+            depthGeometry.firstProjection.p2().x();
+        m[QStringLiteral("dssDepthFirstBackY")] =
+            depthGeometry.firstProjection.p2().y();
+    }
     m[QStringLiteral("dssFixedBytes")] =
         static_cast<qulonglong>(m_dss.fixedStorageBytes());
     m[QStringLiteral("dssHistoryBytes")] =
@@ -2200,6 +2216,7 @@ void SpectrumWidget::loadSettings()
     m_showTuneGuides  = s.value("ShowTuneGuides", "False").toString() == "True";
     m_extendedFrequencyLine = s.value("ExtendedFrequencyLine", "False").toString() == "True";
     m_extendedPassband = DisplaySettings::extendedPassband();
+    m_threeDSliceDepth = DisplaySettings::threeDSliceDepth();
 
     // Background image — default to bundled logo, "none" = explicitly cleared
     QString bgPath = s.value(settingsKey("BackgroundImage"), ":/bg-default.jpg").toString();
@@ -3559,6 +3576,28 @@ void SpectrumWidget::setExtendedPassband(bool on) {
                 sw->m_extendedPassband = on;
                 sw->markOverlayDirty();
             }
+        }
+    }
+}
+
+void SpectrumWidget::setThreeDSliceDepth(bool on)
+{
+    if (m_threeDSliceDepth == on) {
+        return;
+    }
+    m_threeDSliceDepth = on;
+    DisplaySettings::setThreeDSliceDepth(on);
+    markOverlayDirty("threeDSliceDepth");
+
+    // This is a global display treatment: every open pan should agree.
+    if (QWidget* top = window()) {
+        const auto siblings = top->findChildren<SpectrumWidget*>();
+        for (SpectrumWidget* sw : siblings) {
+            if (sw == this || sw->m_threeDSliceDepth == on) {
+                continue;
+            }
+            sw->m_threeDSliceDepth = on;
+            sw->markOverlayDirty("threeDSliceDepthSibling");
         }
     }
 }
@@ -8629,6 +8668,14 @@ void SpectrumWidget::mousePressEvent(QMouseEvent* ev)
             extendedPassbandAction->setChecked(m_extendedPassband);
             connect(extendedPassbandAction, &QAction::toggled, this, &SpectrumWidget::setExtendedPassband);
 
+            if (m_spectrumRenderMode == SpectrumRenderMode::Mode3D) {
+                QAction* depthAction = menu.addAction("3D Slice Shadow");
+                depthAction->setCheckable(true);
+                depthAction->setChecked(m_threeDSliceDepth);
+                connect(depthAction, &QAction::toggled,
+                        this, &SpectrumWidget::setThreeDSliceDepth);
+            }
+
             menu.addSeparator();
             bool floating = m_isFloating;
             QAction* popOutAction = menu.addAction(floating ? "\u21a9 Dock" : "\u2197 Pop out");
@@ -11400,6 +11447,147 @@ void SpectrumWidget::initDssMeshPipeline()
     qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created" << cols << "x" << rows;
 }
 
+void SpectrumWidget::initDssDepthPipeline()
+{
+    QRhi* r = rhi();
+    m_dssDepthVertexCount = 0;
+
+    m_dssDepthVbo = r->newBuffer(
+        QRhiBuffer::Dynamic,
+        QRhiBuffer::VertexBuffer,
+        kDssDepthMaxVertices * kDssDepthVertexFloats * sizeof(float));
+    m_dssDepthSrb = r->newShaderResourceBindings();
+    if (!m_dssDepthVbo->create()) {
+        qCWarning(lcGui) << "SpectrumWidget: 3D slice projection buffer create failed";
+        return;
+    }
+    m_dssDepthSrb->setBindings({});
+    if (!m_dssDepthSrb->create()) {
+        qCWarning(lcGui) << "SpectrumWidget: 3D slice projection bindings create failed";
+        return;
+    }
+
+    const QShader vs =
+        loadShader(":/shaders/resources/shaders/spectrum.vert.qsb");
+    const QShader fs =
+        loadShader(":/shaders/resources/shaders/spectrum.frag.qsb");
+    if (!vs.isValid() || !fs.isValid()) {
+        qCWarning(lcGui) << "SpectrumWidget: 3D slice projection shader load failed";
+        return;
+    }
+
+    QRhiVertexInputLayout layout;
+    layout.setBindings({{kDssDepthVertexFloats * sizeof(float)}});
+    layout.setAttributes({
+        {0, 0, QRhiVertexInputAttribute::Float2, 0},
+        {0, 1, QRhiVertexInputAttribute::Float4, 2 * sizeof(float)},
+        {0, 2, QRhiVertexInputAttribute::Float, 6 * sizeof(float)},
+    });
+
+    QRhiGraphicsPipeline::TargetBlend blend;
+    blend.enable = true;
+    blend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
+    blend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+    blend.srcAlpha = QRhiGraphicsPipeline::One;
+    blend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+
+    m_dssDepthPipeline = r->newGraphicsPipeline();
+    m_dssDepthPipeline->setShaderStages({
+        {QRhiShaderStage::Vertex, vs},
+        {QRhiShaderStage::Fragment, fs},
+    });
+    m_dssDepthPipeline->setVertexInputLayout(layout);
+    m_dssDepthPipeline->setTopology(QRhiGraphicsPipeline::Triangles);
+    m_dssDepthPipeline->setShaderResourceBindings(m_dssDepthSrb);
+    m_dssDepthPipeline->setRenderPassDescriptor(
+        renderTarget()->renderPassDescriptor());
+    m_dssDepthPipeline->setTargetBlends({blend});
+    if (!m_dssDepthPipeline->create()) {
+        qCWarning(lcGui) << "SpectrumWidget: 3D slice projection pipeline create failed";
+        return;
+    }
+    m_dssDepthVertices.reserve(
+        kDssDepthMaxVertices * kDssDepthVertexFloats);
+}
+
+void SpectrumWidget::updateDssDepthVertices(
+    QRhiResourceUpdateBatch* batch,
+    const DssDepthGeometry& geometry,
+    const QSize& logicalSize)
+{
+    m_dssDepthVertices.clear();
+    m_dssDepthVertexCount = 0;
+    if (!batch || !m_dssDepthPipeline || !m_dssDepthVbo
+        || logicalSize.width() <= 0 || logicalSize.height() <= 0) {
+        return;
+    }
+
+    const auto appendVertex = [&](const QPointF& point, const QColor& color,
+                                  float edge) {
+        if (m_dssDepthVertexCount >= kDssDepthMaxVertices) {
+            return;
+        }
+        const float x = static_cast<float>(
+            point.x() * 2.0 / logicalSize.width() - 1.0);
+        const float y = static_cast<float>(
+            1.0 - point.y() * 2.0 / logicalSize.height());
+        m_dssDepthVertices
+            << x << y
+            << static_cast<float>(color.redF())
+            << static_cast<float>(color.greenF())
+            << static_cast<float>(color.blueF())
+            << static_cast<float>(color.alphaF())
+            << edge;
+        ++m_dssDepthVertexCount;
+    };
+    const auto appendQuad = [&](const QPointF& a, const QPointF& b,
+                                const QPointF& c, const QPointF& d,
+                                const QColor& frontColor,
+                                const QColor& backColor) {
+        appendVertex(a, frontColor, 0.0f);
+        appendVertex(b, frontColor, 0.0f);
+        appendVertex(c, backColor, 0.0f);
+        appendVertex(a, frontColor, 0.0f);
+        appendVertex(c, backColor, 0.0f);
+        appendVertex(d, backColor, 0.0f);
+    };
+
+    for (const DssDepthBand& band : geometry.bands) {
+        if (band.polygon.size() == 4) {
+            appendQuad(band.polygon.at(0), band.polygon.at(1),
+                       band.polygon.at(2), band.polygon.at(3),
+                       band.frontColor, band.backColor);
+        }
+    }
+    for (const DssDepthLine& line : geometry.lines) {
+        const QPointF delta = line.line.p2() - line.line.p1();
+        const qreal length = std::hypot(delta.x(), delta.y());
+        if (length <= 0.001) {
+            continue;
+        }
+        const qreal halfWidth = std::max<qreal>(0.45, line.width * 0.5);
+        const QPointF normal(-delta.y() / length * halfWidth,
+                             delta.x() / length * halfWidth);
+        const QPointF aMinus = line.line.p1() - normal;
+        const QPointF aPlus = line.line.p1() + normal;
+        const QPointF bMinus = line.line.p2() - normal;
+        const QPointF bPlus = line.line.p2() + normal;
+        appendVertex(aMinus, line.frontColor, -1.0f);
+        appendVertex(aPlus, line.frontColor, 1.0f);
+        appendVertex(bPlus, line.backColor, 1.0f);
+        appendVertex(aMinus, line.frontColor, -1.0f);
+        appendVertex(bPlus, line.backColor, 1.0f);
+        appendVertex(bMinus, line.backColor, -1.0f);
+    }
+
+    if (m_dssDepthVertexCount > 0) {
+        batch->updateDynamicBuffer(
+            m_dssDepthVbo, 0,
+            m_dssDepthVertices.size() * static_cast<int>(sizeof(float)),
+            m_dssDepthVertices.constData());
+    }
+}
+
 void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
 {
     if (m_rhiInitialized) return;
@@ -11418,6 +11606,7 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     initOverlayPipeline();
     initSpectrumPipeline();
     initDssMeshPipeline();
+    initDssDepthPipeline();
 
     // Upload quad vertex data for both pipelines
     QRhiResourceUpdateBatch* batch = r->nextResourceUpdateBatch();
@@ -12327,7 +12516,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 m_waterfallScrollClock.isValid()
                 ? scrollProgressRows
                 : m_waterfallScrollDistanceRows;
-            const float ubo[] = {
+            std::array<float, kDssMeshUboFloats> ubo{
                 rowOffset,
                 floorDbm, rangeDb, m_dssZCurve,
                 DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
@@ -12343,12 +12532,91 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 static_cast<float>(m_bgFillColor.blueF()),
                 1.0f,                                         // bgFill vec4
             };
-            // Deduced size + assert so a missed field here (or in the shader U
-            // block / kDssMeshUboFloats) is a compile error, not silent garbage.
-            static_assert(sizeof(ubo) == kDssMeshUboFloats * sizeof(float),
-                          "DSS mesh UBO writer element count must equal "
-                          "kDssMeshUboFloats and the dss_mesh.{vert,frag} U block");
-            batch->updateDynamicBuffer(m_dssMeshUbo, 0, sizeof(ubo), ubo);
+
+            // Slice shadows are decals evaluated by the DSS shader itself.
+            // Because the mask modifies the existing curtain/ridge fragments,
+            // it cannot hover above or cut through the rendered surface.
+            constexpr int kShadowBandsOffset = 24;
+            constexpr int kShadowStylesOffset =
+                kShadowBandsOffset + kDssMeshShadowSlices * 4;
+            constexpr int kShadowMetaOffset =
+                kShadowStylesOffset + kDssMeshShadowSlices * 4;
+            double shadowCenterMhz = m_centerMhz;
+            double shadowBandwidthMhz = m_bandwidthMhz;
+            if (m_frequencyPreviewActive
+                && std::isfinite(m_frequencyPreviewTargetCenterMhz)
+                && std::isfinite(m_frequencyPreviewTargetBandwidthMhz)
+                && m_frequencyPreviewTargetBandwidthMhz > 0.0) {
+                shadowCenterMhz = m_frequencyPreviewTargetCenterMhz;
+                shadowBandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
+            }
+            const double shadowStartMhz =
+                shadowCenterMhz - shadowBandwidthMhz * 0.5;
+            const double shadowEndMhz =
+                shadowCenterMhz + shadowBandwidthMhz * 0.5;
+            int shadowCount = 0;
+            const auto appendShadow = [&](const SliceOverlay& so) {
+                if (shadowCount >= kDssMeshShadowSlices
+                    || !std::isfinite(shadowBandwidthMhz)
+                    || shadowBandwidthMhz <= 0.0
+                    || so.freqMhz < shadowStartMhz
+                    || so.freqMhz > shadowEndMhz) {
+                    return;
+                }
+                float low = static_cast<float>(
+                    (so.freqMhz + so.filterLowHz / 1.0e6
+                     - shadowStartMhz) / shadowBandwidthMhz);
+                float high = static_cast<float>(
+                    (so.freqMhz + so.filterHighHz / 1.0e6
+                     - shadowStartMhz) / shadowBandwidthMhz);
+                if (low > high) {
+                    std::swap(low, high);
+                }
+                if (high < 0.0f || low > 1.0f) {
+                    return;
+                }
+                low = std::clamp(low, 0.0f, 1.0f);
+                high = std::clamp(high, 0.0f, 1.0f);
+                const float center = std::clamp(
+                    static_cast<float>(
+                        (so.freqMhz - shadowStartMhz)
+                        / shadowBandwidthMhz),
+                    0.0f, 1.0f);
+                const QColor cue = sliceColorForOverlay(so);
+                const int bandBase = kShadowBandsOffset + shadowCount * 4;
+                ubo.at(bandBase) = low;
+                ubo.at(bandBase + 1) = high;
+                ubo.at(bandBase + 2) = center;
+                ubo.at(bandBase + 3) = so.isActive ? 0.42f : 0.17f;
+                const int styleBase =
+                    kShadowStylesOffset + shadowCount * 4;
+                ubo.at(styleBase) = static_cast<float>(cue.redF());
+                ubo.at(styleBase + 1) = static_cast<float>(cue.greenF());
+                ubo.at(styleBase + 2) = static_cast<float>(cue.blueF());
+                ubo.at(styleBase + 3) = so.isActive ? 0.36f : 0.11f;
+                ++shadowCount;
+            };
+            for (const SliceOverlay& so : m_sliceOverlays) {
+                if (!so.isActive) {
+                    appendShadow(so);
+                }
+            }
+            for (const SliceOverlay& so : m_sliceOverlays) {
+                if (so.isActive) {
+                    appendShadow(so);
+                }
+            }
+            ubo.at(kShadowMetaOffset) = static_cast<float>(shadowCount);
+            ubo.at(kShadowMetaOffset + 1) =
+                m_threeDSliceDepth ? 1.0f : 0.0f;
+            ubo.at(kShadowMetaOffset + 2) =
+                static_cast<float>(specContentW);
+
+            static_assert(
+                kShadowMetaOffset + 4 == kDssMeshUboFloats,
+                "DSS shadow descriptors must fill the mesh UBO");
+            batch->updateDynamicBuffer(
+                m_dssMeshUbo, 0, sizeof(ubo), ubo.data());
         } else if (is3D) {
             // CPU cached-image fallback (no mesh pipeline). Rendered at a capped
             // resolution and stretched to the specRect viewport.
@@ -12394,6 +12662,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         // runs OUTSIDE the render callback — from the refresh timer / mouse move —
         // because it shows/raises widgets, which must not happen mid-render.)
         repositionVfoFlags(specRect);
+        if (!m_dssMeshReady) {
+            updateDssDepthVertices(
+                batch, buildDssDepthGeometry(specRect, dssFrameFloorDbm),
+                logicalSize);
+        } else {
+            m_dssDepthVertexCount = 0;
+        }
 
         // FFT trace columns. 2D only — in 3D the surface replaces the trace.
         // The display trace (spatially smoothed + Catmull-Rom resampled by
@@ -12541,6 +12816,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
     // Draw the 3DSS surface in the SPECTRUM viewport (FFT z-slot; waterfall + bg
     // below, static overlay on top).
+    int dssMeshOutlineRows = 0;
+    int dssMeshOutlineSkippedRows = 0;
     if (is3D && m_dssMeshReady && m_dssMeshFillPipeline) {
         // GPU height-map mesh: static grid, height from the ring texture.
         const QRhiViewport vp(static_cast<float>(specRect.x()) * dpr,
@@ -12562,16 +12839,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 cb->draw(drawnRows * dssFillVerticesPerRow(), 1,
                          skippedRows * dssFillVerticesPerRow(), 0);
             }
-            // Dim per-row trace outline on top.
-            cb->setGraphicsPipeline(m_dssMeshLinePipeline);
-            cb->setShaderResources(m_dssMeshSrb);
-            cb->setViewport(vp);
-            {
-                const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);
-                cb->setVertexInput(0, 1, &vbuf);
-                cb->draw(drawnRows * dssLineVerticesPerRow(), 1,
-                         skippedRows * dssLineVerticesPerRow(), 0);
-            }
+            dssMeshOutlineRows = drawnRows;
+            dssMeshOutlineSkippedRows = skippedRows;
         }
     } else if (is3D && m_ovPipeline && m_dssSrb && m_dssTexW > 0) {
         // Cached-image fallback quad, stretched to the specRect viewport.
@@ -12584,6 +12853,37 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         const QRhiCommandBuffer::VertexInput vbuf(m_ovVbo, 0);
         cb->setVertexInput(0, 1, &vbuf);
         cb->draw(4);
+    }
+
+    if (dssMeshOutlineRows > 0 && m_dssMeshLinePipeline && m_dssMeshSrb) {
+        const QRhiViewport vp(
+            static_cast<float>(specRect.x()) * dpr,
+            static_cast<float>(h - specRect.bottom() - 1) * dpr,
+            static_cast<float>(specContentW) * dpr,
+            static_cast<float>(specRect.height()) * dpr);
+        cb->setGraphicsPipeline(m_dssMeshLinePipeline);
+        cb->setShaderResources(m_dssMeshSrb);
+        cb->setViewport(vp);
+        const QRhiCommandBuffer::VertexInput vbuf(m_dssMeshLineVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        cb->draw(
+            dssMeshOutlineRows * dssLineVerticesPerRow(), 1,
+            dssMeshOutlineSkippedRows * dssLineVerticesPerRow(), 0);
+    }
+
+    // The mesh path applies the shadow in dss_mesh.frag. Keep this separate
+    // geometry only for the cached-image fallback, which has no surface shader.
+    if (is3D && !m_dssMeshReady && m_threeDSliceDepth && m_dssDepthPipeline
+        && m_dssDepthSrb && m_dssDepthVbo
+        && m_dssDepthVertexCount > 0) {
+        cb->setGraphicsPipeline(m_dssDepthPipeline);
+        cb->setShaderResources(m_dssDepthSrb);
+        cb->setViewport({0, 0,
+            static_cast<float>(outputSize.width()),
+            static_cast<float>(outputSize.height())});
+        const QRhiCommandBuffer::VertexInput vbuf(m_dssDepthVbo, 0);
+        cb->setVertexInput(0, 1, &vbuf);
+        cb->draw(m_dssDepthVertexCount);
     }
 
     // Draw FFT spectrum — viewport restricted to spectrum rect (2D only).
@@ -12646,59 +12946,6 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
     if (perfEnabled) {
         PerfTelemetry::instance().recordRender(
             static_cast<double>(PerfTelemetry::nowNs() - perfStartNs) / 1000000.0);
-    }
-}
-
-// Reposition VFO widgets. paintEvent() is compiled only in software mode
-// (#else !AETHER_GPU_SPECTRUM), so in GPU mode this is the sole place VFOs are
-// repositioned. Logic mirrors the paintEvent() block below exactly.  Called
-// from renderGpuFrame BEFORE the flag-layer render so a dragged flag's snapshot
-// is rasterized at this frame's position (no one-frame lag).  (#3617)
-void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
-{
-    QVector<VfoPos> vfos;
-    for (const auto& so : m_sliceOverlays) {
-        if (auto* vw = m_vfoWidgets.value(so.sliceId, nullptr)) {
-            int x = mhzToX(so.freqMhz);
-            if (so.mode == "RTTY" || so.mode == "DIGL") {
-                double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
-                x = mhzToX(hiMhz) + 4;
-            }
-            vfos.append({so.sliceId, x, vw, so.splitPartnerId, &so});
-        }
-    }
-    std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
-        return a.x < b.x;
-    });
-
-    const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
-    // Flip flags against the content edge (width minus the right strip), not the
-    // raw widget edge — a right-facing flag at the true right edge slides under
-    // the dBm tape (#3482).
-    const int specW  = contentWidth();
-
-    QMap<int, VfoWidget::FlagDir> dirMap;
-    assignDiversityPairDirections(vfos, dirMap);
-    assignSplitPairDirections(vfos, dirMap);
-    assignModeForcedDirections(m_sliceOverlays, dirMap);
-
-    if (vfos.size() == 1) {
-        VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
-        if (!dirMap.contains(vfos[0].sliceId) && vfos[0].overlay) {
-            dir = singleVfoFlagDirectionForOverlay(
-                *vfos[0].overlay, vfos[0].w, vfos[0].x, specW);
-        }
-        vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
-    } else {
-        for (int i = 0; i < vfos.size(); ++i) {
-            VfoWidget::FlagDir dir = VfoWidget::Auto;
-            if (dirMap.contains(vfos[i].sliceId)) {
-                dir = dirMap[vfos[i].sliceId];
-            } else {
-                dir = deconflictedVfoFlagDirection(vfos, i, panelW, specW);
-            }
-            vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);
-        }
     }
 }
 
@@ -12783,6 +13030,12 @@ void SpectrumWidget::releaseResources()
     m_dssMeshHeadUploaded = -1;
     m_dssMeshRowGenUploaded = ~0ull;
     m_dssLutToken = ~0ull;
+
+    delete m_dssDepthPipeline; m_dssDepthPipeline = nullptr;
+    delete m_dssDepthSrb;      m_dssDepthSrb = nullptr;
+    delete m_dssDepthVbo;      m_dssDepthVbo = nullptr;
+    m_dssDepthVertices.clear();
+    m_dssDepthVertexCount = 0;
 
     delete m_fftScopePipeline; m_fftScopePipeline = nullptr;
     delete m_fftScopeSrb;      m_fftScopeSrb = nullptr;
@@ -12900,6 +13153,11 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
     drawFreqScale(p, scaleRect);
     p.fillRect(wfRect, Qt::black);  // paint the strip gap before the time tape
     drawWaterfall(p, wfContentRect);
+    repositionVfoFlags(specRect);
+    if (is3D && m_threeDSliceDepth) {
+        drawDssDepthGeometry(
+            p, buildDssDepthGeometry(specRect, dssFrameFloorDbm));
+    }
     drawTnfMarkers(p, specRect);
     if (m_showSpots || m_showSHistory) drawSpotMarkers(p, specRect);
     drawSwrSweep(p, specRect);
@@ -12915,61 +13173,6 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 
     drawConnectionAnimation(p, specRect);
 
-    // Reposition all VFO widgets — deconflict flags so they fly away from each other
-    // Split pairs always face each other: RX←  →TX
-    {
-        // Collect visible VFOs sorted by screen X position
-        QVector<VfoPos> vfos;
-        for (const auto& so : m_sliceOverlays) {
-            if (auto* w = m_vfoWidgets.value(so.sliceId, nullptr)) {
-                int x = mhzToX(so.freqMhz);
-                // In RTTY/DIGL, anchor the flag past the filter high edge
-                // so it doesn't cover the mark/space passband.
-                if (so.mode == "RTTY" || so.mode == "DIGL") {
-                    double hiMhz = so.freqMhz + so.filterHighHz / 1.0e6;
-                    x = mhzToX(hiMhz) + 4;  // 4px padding past filter edge
-                }
-                vfos.append({so.sliceId, x, w, so.splitPartnerId, &so});
-            }
-        }
-        std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
-            return a.x < b.x;
-        });
-
-        const int panelW = vfos.isEmpty() ? 0 : vfos[0].w->width();
-        const int specW = contentWidth();  // flip against the tape edge (#3482)
-
-        // First pass: assign directions for role-locked pairs
-        QMap<int, VfoWidget::FlagDir> dirMap;  // sliceId → direction
-        assignDiversityPairDirections(vfos, dirMap);
-        assignSplitPairDirections(vfos, dirMap);
-
-        // Second pass: assign remaining mode-forced VFOs
-        // In RTTY/DIGL, force flag to fly right so it doesn't cover M/S passband
-        assignModeForcedDirections(m_sliceOverlays, dirMap);
-
-        if (vfos.size() == 1) {
-            VfoWidget::FlagDir dir = dirMap.value(vfos[0].sliceId, VfoWidget::Auto);
-            if (!dirMap.contains(vfos[0].sliceId) && vfos[0].overlay) {
-                dir = singleVfoFlagDirectionForOverlay(
-                    *vfos[0].overlay, vfos[0].w, vfos[0].x, specW);
-            }
-            vfos[0].w->updatePosition(vfos[0].x, specRect.top(), dir);
-        } else {
-            for (int i = 0; i < vfos.size(); ++i) {
-                VfoWidget::FlagDir dir = VfoWidget::Auto;
-
-                if (dirMap.contains(vfos[i].sliceId)) {
-                    // Split pair or RTTY: use pre-assigned direction
-                    dir = dirMap[vfos[i].sliceId];
-                } else {
-                    dir = deconflictedVfoFlagDirection(vfos, i, panelW, specW);
-                }
-
-                vfos[i].w->updatePosition(vfos[i].x, specRect.top(), dir);
-            }
-        }
-    }
     // Active widget on top, but overlay stays above all
     applyActiveVfoZOrder();
 
@@ -13125,6 +13328,61 @@ void SpectrumWidget::paintEvent(QPaintEvent* ev)
 }
 
 #endif // AETHER_GPU_SPECTRUM
+
+// Reposition VFO widgets in both renderers. Keeping this shared prevents the
+// interactive flag from lagging its ordinary slice marker during motion
+// or pan/zoom (#3617).
+void SpectrumWidget::repositionVfoFlags(const QRect& specRect)
+{
+    QVector<VfoPos> vfos;
+    for (const SliceOverlay& so : m_sliceOverlays) {
+        if (VfoWidget* flag = m_vfoWidgets.value(so.sliceId, nullptr)) {
+            int x = mhzToX(so.freqMhz);
+            if (so.mode == QStringLiteral("RTTY")
+                || so.mode == QStringLiteral("DIGL")) {
+                const double hiMhz =
+                    so.freqMhz + so.filterHighHz / 1.0e6;
+                x = mhzToX(hiMhz) + 4;
+            }
+            vfos.append({so.sliceId, x, flag, so.splitPartnerId, &so});
+        }
+    }
+    std::sort(vfos.begin(), vfos.end(), [](const VfoPos& a, const VfoPos& b) {
+        return a.x < b.x;
+    });
+
+    const int panelW = vfos.isEmpty() ? 0 : vfos.constFirst().w->width();
+    const int specW = contentWidth();
+    QMap<int, VfoWidget::FlagDir> directionBySlice;
+    assignDiversityPairDirections(vfos, directionBySlice);
+    assignSplitPairDirections(vfos, directionBySlice);
+    assignModeForcedDirections(m_sliceOverlays, directionBySlice);
+
+    if (vfos.size() == 1) {
+        VfoWidget::FlagDir direction =
+            directionBySlice.value(vfos[0].sliceId, VfoWidget::Auto);
+        if (!directionBySlice.contains(vfos[0].sliceId)
+            && vfos[0].overlay) {
+            direction = singleVfoFlagDirectionForOverlay(
+                *vfos[0].overlay, vfos[0].w, vfos[0].x, specW);
+        }
+        vfos[0].w->updatePosition(
+            vfos[0].x, specRect.top(), direction);
+        return;
+    }
+
+    for (int index = 0; index < vfos.size(); ++index) {
+        VfoWidget::FlagDir direction = VfoWidget::Auto;
+        if (directionBySlice.contains(vfos[index].sliceId)) {
+            direction = directionBySlice[vfos[index].sliceId];
+        } else {
+            direction =
+                deconflictedVfoFlagDirection(vfos, index, panelW, specW);
+        }
+        vfos[index].w->updatePosition(
+            vfos[index].x, specRect.top(), direction);
+    }
+}
 
 // ─── Grid ─────────────────────────────────────────────────────────────────────
 
@@ -14422,6 +14680,324 @@ void SpectrumWidget::drawSmartMtrValueLabels(QPainter& p)
 // here (edge triangles, audio low/high cut labels, AUTO status ball) are
 // data-bearing content a screen reader can't introspect. Expose via a
 // SpectrumWidget QAccessibleInterface. Tracked in aethersdr/AetherSDR#3957.
+SpectrumWidget::DssDepthGeometry
+SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
+                                      float floorDbm) const
+{
+    DssDepthGeometry geometry;
+    if (!m_threeDSliceDepth
+        || m_spectrumRenderMode != SpectrumRenderMode::Mode3D
+        || specRect.isEmpty()
+        || !std::isfinite(floorDbm)) {
+        return geometry;
+    }
+
+    double centerMhz = m_centerMhz;
+    double bandwidthMhz = m_bandwidthMhz;
+    if (m_frequencyPreviewActive
+        && std::isfinite(m_frequencyPreviewTargetCenterMhz)
+        && std::isfinite(m_frequencyPreviewTargetBandwidthMhz)
+        && m_frequencyPreviewTargetBandwidthMhz > 0.0) {
+        centerMhz = m_frequencyPreviewTargetCenterMhz;
+        bandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
+    }
+    if (!std::isfinite(centerMhz) || !std::isfinite(bandwidthMhz)
+        || bandwidthMhz <= 0.0) {
+        return geometry;
+    }
+
+    const int contentW = std::max(1, specRect.width() - DBM_STRIP_W);
+    const double startMhz = centerMhz - bandwidthMhz * 0.5;
+    const double endMhz = centerMhz + bandwidthMhz * 0.5;
+    const float rangeDb = std::round(dssSpanDb() * 2.0f) / 2.0f;
+
+    float frequencyScale = 1.0f;
+    float frequencyOffset = 0.0f;
+    bool frequencyPreview = false;
+    const FrequencyPreviewTransform previewTransform =
+        frequencyPreviewTransform(
+            FrequencyFrame{m_frequencyPreviewBaseCenterMhz,
+                           m_frequencyPreviewBaseBandwidthMhz},
+            FrequencyFrame{m_frequencyPreviewTargetCenterMhz,
+                           m_frequencyPreviewTargetBandwidthMhz});
+    if (m_frequencyPreviewActive && previewTransform.valid) {
+        frequencyScale = static_cast<float>(previewTransform.scale);
+        frequencyOffset = static_cast<float>(previewTransform.offset);
+        frequencyPreview = true;
+    }
+
+    const int rows = m_dss.rows();
+    const int cols = m_dss.cols();
+    const int validRows = m_dss.rowCount();
+    const int headRing = m_dss.headRing();
+    const float distanceRows =
+        std::max(m_waterfallScrollDistanceRows, 1.0f);
+    const float scrollProgressRows = m_waterfallScrollClock.isValid()
+        ? waterfallScrollProgressRows()
+        : m_waterfallScrollDistanceRows;
+    const float remainingRows = std::clamp(
+        distanceRows - scrollProgressRows, 0.0f, distanceRows);
+
+    const auto sampleSurfaceDbm = [&](float displayUnit, float depth) {
+        const float sourceUnit =
+            0.5f + frequencyOffset
+            + (displayUnit - 0.5f) * frequencyScale;
+        if (frequencyPreview
+            && (sourceUnit < 0.0f || sourceUnit > 1.0f)) {
+            return floorDbm;
+        }
+        const int column = std::clamp(
+            static_cast<int>(std::lround(
+                std::clamp(sourceUnit, 0.0f, 1.0f) * (cols - 1))),
+            0, cols - 1);
+        const float sampleAge =
+            std::clamp(depth, 0.0f, 1.0f) * rows + remainingRows;
+        const int age0 = std::max(
+            0, static_cast<int>(std::floor(sampleAge)));
+        const int age1 = age0 + 1;
+        const float ageBlend = sampleAge - std::floor(sampleAge);
+        const auto dbmAtAge = [&](int age) {
+            if (age < 0 || age >= validRows) {
+                return floorDbm;
+            }
+            const int ring = (headRing + age) % rows;
+            const float value = m_dss.rowDataRing(ring)[column];
+            return std::isfinite(value) ? value : floorDbm;
+        };
+        return std::lerp(dbmAtAge(age0), dbmAtAge(age1), ageBlend);
+    };
+
+    // Carry the shadow to the final DSS row and fade it fully transparent
+    // there. Short row-aligned segments let it follow the actual ridge height
+    // instead of crossing the flat perspective floor.
+    const float projectionDepth =
+        static_cast<float>(rows - 1) / rows;
+    constexpr int kDepthRowStride = 4;
+    QVector<float> depths;
+    depths.reserve(rows / kDepthRowStride + 2);
+    for (int age = 0; age < rows - 1; age += kDepthRowStride) {
+        depths.append(static_cast<float>(age) / rows);
+    }
+    if (depths.isEmpty() || depths.constLast() < projectionDepth) {
+        depths.append(projectionDepth);
+    }
+
+    const auto unitForFrequency = [&](double frequencyMhz) {
+        return static_cast<float>((frequencyMhz - startMhz) / bandwidthMhz);
+    };
+    const auto projectAtDbm = [&](float frequencyUnit, float depth,
+                                  float dbm) {
+        const QPointF unit = DssRenderer::projectSurface(
+            frequencyUnit, depth, dbm, floorDbm, rangeDb, m_dssZCurve);
+        return QPointF(specRect.left() + unit.x() * contentW,
+                       specRect.top() + unit.y() * specRect.height());
+    };
+    const auto projectionCueColor = [](const QColor& source) {
+        QColor projected = source.toHsl();
+        if (projected.hslHueF() >= 0.0f) {
+            projected.setHslF(
+                projected.hslHueF(),
+                projected.hslSaturationF() * 0.65,
+                std::min(1.0, projected.lightnessF() * 0.85 + 0.12));
+        }
+        return projected.toRgb();
+    };
+    const auto shadowColor = [](const QColor& source, int alpha) {
+        // Retain just enough slice hue to associate the shadow with its flag,
+        // while keeping luminance near black so normal alpha blending darkens
+        // the bright DSS surface underneath.
+        return QColor(
+            2 + static_cast<int>(source.red() * 0.045),
+            2 + static_cast<int>(source.green() * 0.045),
+            2 + static_cast<int>(source.blue() * 0.045),
+            alpha);
+    };
+    const auto fadedColor = [&](const QColor& source, int frontAlpha,
+                                float depth) {
+        const float normalizedDepth = projectionDepth > 0.0f
+            ? std::clamp(depth / projectionDepth, 0.0f, 1.0f)
+            : 1.0f;
+        QColor faded = source;
+        faded.setAlpha(static_cast<int>(std::lround(
+            frontAlpha * std::pow(1.0f - normalizedDepth, 1.15f))));
+        return faded;
+    };
+
+    auto appendSlice = [&](const SliceOverlay& so) {
+        if (so.freqMhz < startMhz || so.freqMhz > endMhz) {
+            return;
+        }
+
+        const QColor markerColor = sliceColorForOverlay(so);
+        const int colourIdx =
+            SliceLabel::displayColorIndex(so.sliceId, so.perClientLetter);
+        const QColor bandColor = so.isActive
+            ? SliceColorManager::instance().activeColor(colourIdx)
+            : AetherSDR::ThemeManager::instance().color("color.text.secondary");
+
+        float lowUnit =
+            unitForFrequency(so.freqMhz + so.filterLowHz / 1.0e6);
+        float highUnit =
+            unitForFrequency(so.freqMhz + so.filterHighHz / 1.0e6);
+        if (lowUnit > highUnit) {
+            std::swap(lowUnit, highUnit);
+        }
+        if (highUnit >= 0.0f && lowUnit <= 1.0f) {
+            lowUnit = std::clamp(lowUnit, 0.0f, 1.0f);
+            highUnit = std::clamp(highUnit, 0.0f, 1.0f);
+            const QColor fillBase = shadowColor(bandColor, 255);
+            const int fillAlpha = so.isActive ? 105 : 42;
+            constexpr int kBandFrequencySegments = 6;
+            const auto crossSection = [&](float depth) {
+                QVector<QPointF> points;
+                points.reserve(kBandFrequencySegments + 1);
+                for (int column = 0;
+                     column <= kBandFrequencySegments; ++column) {
+                    const float fraction =
+                        static_cast<float>(column)
+                        / kBandFrequencySegments;
+                    const float unit =
+                        std::lerp(lowUnit, highUnit, fraction);
+                    points.append(projectAtDbm(
+                        unit, depth, sampleSurfaceDbm(unit, depth)));
+                }
+                return points;
+            };
+
+            QVector<QPointF> previous =
+                crossSection(depths.constFirst());
+            for (int i = 1; i < depths.size(); ++i) {
+                const float frontDepth = depths.at(i - 1);
+                const float backDepth = depths.at(i);
+                QVector<QPointF> next = crossSection(backDepth);
+                for (int column = 0;
+                     column < kBandFrequencySegments; ++column) {
+                    geometry.bands.append({
+                        QPolygonF{
+                            previous.at(column),
+                            previous.at(column + 1),
+                            next.at(column + 1),
+                            next.at(column),
+                        },
+                        fadedColor(fillBase, fillAlpha, frontDepth),
+                        fadedColor(fillBase, fillAlpha, backDepth),
+                    });
+                }
+                previous = std::move(next);
+            }
+        }
+
+        auto appendLine = [&](double frequencyMhz, const QColor& source,
+                              qreal width) {
+            const float unit = unitForFrequency(frequencyMhz);
+            if (unit < 0.0f || unit > 1.0f) {
+                return;
+            }
+            QVector<QPointF> points;
+            points.reserve(depths.size());
+            for (float depth : depths) {
+                points.append(projectAtDbm(
+                    unit, depth, sampleSurfaceDbm(unit, depth)));
+            }
+            if (!geometry.hasFirstProjection && points.size() >= 2) {
+                geometry.firstProjection =
+                    QLineF(points.constFirst(), points.constLast());
+                geometry.hasFirstProjection = true;
+            }
+
+            const QColor shadowBase = shadowColor(source, 255);
+            const int shadowAlpha = so.isActive ? 185 : 72;
+            for (int i = 1; i < points.size(); ++i) {
+                geometry.lines.append({
+                    QLineF(points.at(i - 1), points.at(i)),
+                    fadedColor(
+                        shadowBase, shadowAlpha, depths.at(i - 1)),
+                    fadedColor(shadowBase, shadowAlpha, depths.at(i)),
+                    std::max<qreal>(2.0, width * 1.35),
+                });
+            }
+
+            const QColor cueBase = projectionCueColor(source);
+            const int cueAlpha = so.isActive ? 92 : 28;
+            for (int i = 1; i < points.size(); ++i) {
+                geometry.lines.append({
+                    QLineF(points.at(i - 1), points.at(i)),
+                    fadedColor(cueBase, cueAlpha, depths.at(i - 1)),
+                    fadedColor(cueBase, cueAlpha, depths.at(i)),
+                    std::max<qreal>(0.8, width * 0.45),
+                });
+            }
+        };
+
+        const bool rtty = so.mode == QStringLiteral("RTTY")
+            || so.mode == QStringLiteral("DIGL");
+        if (rtty) {
+            double markMhz = so.freqMhz;
+            if (so.mode == QStringLiteral("DIGL")) {
+                markMhz -= so.rttyMark / 1.0e6;
+            }
+            const double spaceMhz = markMhz - so.rttyShift / 1.0e6;
+            appendLine(
+                markMhz,
+                AetherSDR::ThemeManager::instance().color("color.accent.success"),
+                1.0);
+            appendLine(
+                spaceMhz,
+                AetherSDR::ThemeManager::instance().color("color.accent.danger"),
+                1.0);
+        } else if (so.markerWidth > 0) {
+            appendLine(so.freqMhz, markerColor,
+                       std::max<qreal>(1.0, so.markerWidth));
+        }
+
+    };
+
+    // Preserve the normal slice z-order: inactive geometry first, active last.
+    for (const SliceOverlay& so : m_sliceOverlays) {
+        if (!so.isActive) {
+            appendSlice(so);
+        }
+    }
+    for (const SliceOverlay& so : m_sliceOverlays) {
+        if (so.isActive) {
+            appendSlice(so);
+        }
+    }
+    return geometry;
+}
+
+void SpectrumWidget::drawDssDepthGeometry(
+    QPainter& painter, const DssDepthGeometry& geometry) const
+{
+    painter.save();
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    for (const DssDepthBand& band : geometry.bands) {
+        painter.setPen(Qt::NoPen);
+        const QPointF frontCenter =
+            (band.polygon.at(0) + band.polygon.at(1)) * 0.5;
+        const QPointF backCenter =
+            (band.polygon.at(2) + band.polygon.at(3)) * 0.5;
+        QLinearGradient gradient(frontCenter, backCenter);
+        gradient.setColorAt(0.0, band.frontColor);
+        gradient.setColorAt(1.0, band.backColor);
+        painter.setBrush(gradient);
+        painter.drawPolygon(band.polygon);
+    }
+    for (const DssDepthLine& line : geometry.lines) {
+        QLinearGradient gradient(line.line.p1(), line.line.p2());
+        gradient.setColorAt(0.0, line.frontColor);
+        gradient.setColorAt(1.0, line.backColor);
+        QPen pen(QBrush(gradient), line.width);
+        pen.setCosmetic(true);
+        pen.setCapStyle(Qt::RoundCap);
+        painter.setPen(pen);
+        painter.setBrush(Qt::NoBrush);
+        painter.drawLine(line.line);
+    }
+    painter.restore();
+}
+
 void SpectrumWidget::drawSliceMarkers(QPainter& p, const QRect& specRect, const QRect& wfRect)
 {
     const double startMhz = m_centerMhz - m_bandwidthMhz / 2.0;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -13,6 +13,8 @@
 #include <QColor>
 #include <QDateTime>
 #include <QElapsedTimer>
+#include <QLineF>
+#include <QPolygonF>
 #include <QVariant>
 #include <QTimer>
 #include <QLabel>
@@ -102,6 +104,7 @@ class SpectrumWidget : public SPECTRUM_BASE_CLASS {
     Q_PROPERTY(double centerMhz READ centerMhz)
     Q_PROPERTY(double bandwidthMhz READ bandwidthMhz)
     Q_PROPERTY(int centerLockSliceId READ centerLockSliceId)
+    Q_PROPERTY(bool threeDSliceDepth READ threeDSliceDepth WRITE setThreeDSliceDepth)
 
 public:
     explicit SpectrumWidget(QWidget* parent = nullptr);
@@ -401,6 +404,8 @@ public:
     bool extendedFrequencyLine() const { return m_extendedFrequencyLine; }
     void setExtendedPassband(bool on);
     bool extendedPassband() const { return m_extendedPassband; }
+    void setThreeDSliceDepth(bool on);
+    bool threeDSliceDepth() const { return m_threeDSliceDepth; }
     void setFloating(bool on) { m_isFloating = on; }
     void setBackgroundImage(const QString& path);
     QString backgroundImagePath() const { return m_bgImagePath; }
@@ -774,6 +779,27 @@ private:
     void drawGrid(QPainter& p, const QRect& r);
     void drawSpectrum(QPainter& p, const QRect& r);
     void drawSliceMarkers(QPainter& p, const QRect& specRect, const QRect& wfRect);
+    struct DssDepthBand {
+        QPolygonF polygon;
+        QColor frontColor;
+        QColor backColor;
+    };
+    struct DssDepthLine {
+        QLineF line;
+        QColor frontColor;
+        QColor backColor;
+        qreal width{1.0};
+    };
+    struct DssDepthGeometry {
+        QVector<DssDepthBand> bands;
+        QVector<DssDepthLine> lines;
+        QLineF firstProjection;
+        bool hasFirstProjection{false};
+    };
+    DssDepthGeometry buildDssDepthGeometry(const QRect& specRect,
+                                           float floorDbm) const;
+    void drawDssDepthGeometry(QPainter& painter,
+                              const DssDepthGeometry& geometry) const;
     // Draw each flag's SmartMTR extremes value labels on top of the slice markers.
     void drawSmartMtrValueLabels(QPainter& p);
     void drawOffScreenSlices(QPainter& p, const QRect& specRect);
@@ -797,9 +823,7 @@ private:
     void setVfoCursorOverride(Qt::CursorShape shape);
     void clearVfoCursorOverride();
     void applyActiveVfoZOrder();
-#ifdef AETHER_GPU_SPECTRUM
     void repositionVfoFlags(const QRect& specRect);  // #3617 — shared flag positioner
-#endif
     void setSpectrumCursor(Qt::CursorShape shape);
     void updateTrackedCursorState(const QPoint& localPos, bool insideWidget);
     void updateTnfHoverPopup();
@@ -1508,6 +1532,7 @@ private:
     bool    m_showTuneGuides{false};
     bool    m_extendedFrequencyLine{false};
     bool    m_extendedPassband{false};
+    bool    m_threeDSliceDepth{false};
     bool    m_isFloating{false};
     bool    m_tuneGuideVisible{false};
     QTimer* m_tuneGuideTimer{nullptr};
@@ -1746,8 +1771,10 @@ private:
     QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge line segments, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
-    // ubo[] writer in renderGpuFrame(). Five vec4 scalar groups plus bgFill.
-    static constexpr int kDssMeshUboFloats = 24;
+    // ubo writer in renderGpuFrame(): five scalar vec4 groups + bgFill, eight
+    // slice band descriptors, eight slice styles, and shadow metadata.
+    static constexpr int kDssMeshUboFloats = 92;
+    static constexpr int kDssMeshShadowSlices = 8;
     QRhiTexture* m_dssHeightTex{nullptr};    // R16F ring heightmap (cols x rows)
     QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT
     QRhiSampler* m_dssHeightSampler{nullptr};
@@ -1761,6 +1788,20 @@ private:
 
     void initDssMeshPipeline();
     void uploadDssPaletteLut(QRhiResourceUpdateBatch* batch, float floorDbm, float rangeDb);
+
+    // Distance-faded slice/passband shadows painted across the completed DSS
+    // surface. Tiny dynamic geometry rendered below the ordinary marker layer.
+    static constexpr int kDssDepthMaxVertices = 16384;
+    static constexpr int kDssDepthVertexFloats = 7;  // pos2 + color4 + edge
+    QRhiGraphicsPipeline* m_dssDepthPipeline{nullptr};
+    QRhiShaderResourceBindings* m_dssDepthSrb{nullptr};
+    QRhiBuffer* m_dssDepthVbo{nullptr};
+    QVector<float> m_dssDepthVertices;
+    int m_dssDepthVertexCount{0};
+    void initDssDepthPipeline();
+    void updateDssDepthVertices(QRhiResourceUpdateBatch* batch,
+                                const DssDepthGeometry& geometry,
+                                const QSize& logicalSize);
 
     bool initWaterfallPipeline();
     void releaseWaterfallFramePipelineResources();

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -1,5 +1,6 @@
 #include "TestSettingsProfile.h"
 #include "core/AppSettings.h"
+#include "gui/DisplaySettings.h"
 
 #include <QBuffer>
 #include <QCoreApplication>
@@ -320,6 +321,23 @@ void testFailedLoadCannotSave()
            "failed loads cannot create a replacement temporary file");
 }
 
+void testThreeDSliceDepthDefaultAndOptOut()
+{
+    AppSettings& settings = AppSettings::instance();
+    settings.load();
+
+    expect(DisplaySettings::threeDSliceDepth(),
+           "3D Slice Shadow defaults on when the Display field is absent");
+
+    DisplaySettings::setThreeDSliceDepth(false);
+    expect(!DisplaySettings::threeDSliceDepth(),
+           "a persisted False keeps the user's 3D Slice Shadow opt-out");
+
+    DisplaySettings::setThreeDSliceDepth(true);
+    expect(DisplaySettings::threeDSliceDepth(),
+           "3D Slice Shadow can be enabled again after opting out");
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -355,6 +373,8 @@ int main(int argc, char** argv)
         testMissingLiveCorruptRecoveryFailsClosed();
     } else if (scenario == QStringLiteral("failed-load")) {
         testFailedLoadCannotSave();
+    } else if (scenario == QStringLiteral("display-slice-depth-default")) {
+        testThreeDSliceDepthDefaultAndOptOut();
     } else {
         std::fprintf(stderr, "unknown scenario: %s\n", argv[1]);
         return 2;

--- a/tests/app_settings_safety_test.cpp
+++ b/tests/app_settings_safety_test.cpp
@@ -321,21 +321,22 @@ void testFailedLoadCannotSave()
            "failed loads cannot create a replacement temporary file");
 }
 
-void testThreeDSliceDepthDefaultAndOptOut()
+void testThreeDSliceDepthDefaultAndOptIn()
 {
     AppSettings& settings = AppSettings::instance();
     settings.load();
 
-    expect(DisplaySettings::threeDSliceDepth(),
-           "3D Slice Shadow defaults on when the Display field is absent");
-
-    DisplaySettings::setThreeDSliceDepth(false);
     expect(!DisplaySettings::threeDSliceDepth(),
-           "a persisted False keeps the user's 3D Slice Shadow opt-out");
+           "3D Slice Shadow defaults OFF when the Display field is absent, so "
+           "an upgrade never changes an existing user's display");
 
     DisplaySettings::setThreeDSliceDepth(true);
     expect(DisplaySettings::threeDSliceDepth(),
-           "3D Slice Shadow can be enabled again after opting out");
+           "a persisted True keeps the user's 3D Slice Shadow opt-in");
+
+    DisplaySettings::setThreeDSliceDepth(false);
+    expect(!DisplaySettings::threeDSliceDepth(),
+           "3D Slice Shadow can be disabled again after opting in");
 }
 
 } // namespace
@@ -374,7 +375,7 @@ int main(int argc, char** argv)
     } else if (scenario == QStringLiteral("failed-load")) {
         testFailedLoadCannotSave();
     } else if (scenario == QStringLiteral("display-slice-depth-default")) {
-        testThreeDSliceDepthDefaultAndOptOut();
+        testThreeDSliceDepthDefaultAndOptIn();
     } else {
         std::fprintf(stderr, "unknown scenario: %s\n", argv[1]);
         return 2;

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -255,6 +255,101 @@ int testDcEdgeSpikeFlattening()
     return 0;
 }
 
+int testPerspectiveProjection()
+{
+    const QPointF frontLeft =
+        DssRenderer::projectPerspective(0.0f, 0.0f);
+    const QPointF backLeft =
+        DssRenderer::projectPerspective(0.0f, 1.0f);
+    const QPointF backCenter =
+        DssRenderer::projectPerspective(0.5f, 1.0f);
+    const QPointF backRight =
+        DssRenderer::projectPerspective(1.0f, 1.0f);
+
+    if (std::abs(frontLeft.x()) > 0.0001
+        || std::abs(frontLeft.y() - 1.0) > 0.0001) {
+        return fail("DSS perspective front edge must preserve frequency");
+    }
+    if (!(backLeft.x() > frontLeft.x())
+        || !(backRight.x() < 1.0)
+        || std::abs(backCenter.x() - 0.5) > 0.0001) {
+        return fail("DSS perspective must converge toward the center");
+    }
+    if (std::abs(backLeft.x() - 0.2) > 0.0001
+        || std::abs(backRight.x() - 0.8) > 0.0001
+        || std::abs(backCenter.y()
+                    - (1.0 - DssRenderer::kDepthSpanFrac)) > 0.0001) {
+        return fail("DSS perspective projection drifted from renderer constants");
+    }
+    if (DssRenderer::projectPerspective(0.25f, -1.0f)
+            != DssRenderer::projectPerspective(0.25f, 0.0f)
+        || DssRenderer::projectPerspective(0.25f, 2.0f)
+            != DssRenderer::projectPerspective(0.25f, 1.0f)) {
+        return fail("DSS perspective depth must be clamped");
+    }
+    return 0;
+}
+
+int testSurfaceProjection()
+{
+    constexpr float floorDbm = -120.0f;
+    constexpr float rangeDb = 80.0f;
+    constexpr float zCurve = 0.7f;
+
+    const QPointF baseline =
+        DssRenderer::projectPerspective(0.25f, 0.0f);
+    const QPointF floorPoint =
+        DssRenderer::projectSurface(
+            0.25f, 0.0f, floorDbm, floorDbm, rangeDb, zCurve);
+    if (floorPoint != baseline) {
+        return fail("a floor-level DSS surface point must stay on the baseline");
+    }
+
+    const QPointF peakPoint =
+        DssRenderer::projectSurface(
+            0.25f, 0.0f, floorDbm + rangeDb,
+            floorDbm, rangeDb, zCurve);
+    if (std::abs(
+            peakPoint.y()
+            - (baseline.y() - DssRenderer::kFrontMaxRidgeFrac)) > 0.0001) {
+        return fail("a full-strength DSS surface point must reach maximum ridge height");
+    }
+
+    const QPointF raisedFloorPoint =
+        DssRenderer::projectSurface(
+            0.25f, 0.0f, -80.0f, -100.0f, rangeDb, zCurve);
+    const QPointF loweredFloorPoint =
+        DssRenderer::projectSurface(
+            0.25f, 0.0f, -80.0f, -120.0f, rangeDb, zCurve);
+    if (!(loweredFloorPoint.y() < raisedFloorPoint.y())) {
+        return fail("moving the DSS floor must move projected surface height");
+    }
+
+    const QPointF farPeak =
+        DssRenderer::projectSurface(
+            0.25f, 1.0f, floorDbm + rangeDb,
+            floorDbm, rangeDb, zCurve);
+    const QPointF farBaseline =
+        DssRenderer::projectPerspective(0.25f, 1.0f);
+    const float expectedFarRidge =
+        DssRenderer::kFrontMaxRidgeFrac * DssRenderer::kBackWidthFrac;
+    if (std::abs(
+            farPeak.y() - (farBaseline.y() - expectedFarRidge)) > 0.0001) {
+        return fail("far DSS surface height must narrow with perspective");
+    }
+
+    const QPointF bandLeft =
+        DssRenderer::projectSurface(
+            0.40f, 0.25f, -72.0f, floorDbm, rangeDb, zCurve);
+    const QPointF bandRight =
+        DssRenderer::projectSurface(
+            0.60f, 0.25f, -72.0f, floorDbm, rangeDb, zCurve);
+    if (std::abs(bandLeft.y() - bandRight.y()) > 0.0001) {
+        return fail("one DSS passband cross-section must have a level edge");
+    }
+    return 0;
+}
+
 } // namespace
 
 int main()
@@ -284,6 +379,12 @@ int main()
         return rc;
     }
     if (int rc = testDcEdgeSpikeFlattening(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testPerspectiveProjection(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testSurfaceProjection(); rc != 0) {
         return rc;
     }
 

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -158,6 +158,50 @@ int testInputScaleResetBreaksTemporalBlend()
     return 0;
 }
 
+int testDepthShadowOcclusion()
+{
+    // y grows downward; rebuild() fills each curtain to the floor, so a nearer
+    // (earlier) row hides anything below its ridge.
+
+    // A surface receding upward: every row clears the one in front of it, so
+    // nothing is occluded.
+    if (dssDepthVisibleSegments({100.0, 90.0, 80.0, 70.0})
+        != QVector<bool>{true, true, true}) {
+        return fail("a strictly rising ridge must never be culled");
+    }
+
+    // The far rows sit below the front row's ridge: their segments are behind
+    // the front curtain and must not be stroked over it.
+    const QVector<bool> behind =
+        dssDepthVisibleSegments({50.0, 120.0, 130.0, 140.0});
+    if (behind.size() != 3 || !behind.at(0) || behind.at(1) || behind.at(2)) {
+        return fail("segments behind a nearer ridge must be culled");
+    }
+
+    // A far peak that pokes back above the silhouette becomes visible again.
+    const QVector<bool> reemerges =
+        dssDepthVisibleSegments({50.0, 120.0, 40.0, 130.0});
+    if (reemerges.size() != 3 || !reemerges.at(0) || !reemerges.at(1)
+        || !reemerges.at(2)) {
+        return fail("a far ridge rising above the silhouette must reappear");
+    }
+
+    // Degenerate inputs yield no segments rather than indexing off the end.
+    if (!dssDepthVisibleSegments({}).isEmpty()
+        || !dssDepthVisibleSegments({10.0}).isEmpty()) {
+        return fail("fewer than two depths must yield no segments");
+    }
+
+    // Half-pixel slack: a ridge grazing the silhouette stays visible instead
+    // of flickering between frames.
+    if (dssDepthVisibleSegments({100.0, 100.2, 100.3})
+        != QVector<bool>{true, true}) {
+        return fail("a grazing ridge must not flicker out");
+    }
+
+    return 0;
+}
+
 int testRetainedHistoryCapacity()
 {
     DssRenderer renderer;
@@ -425,6 +469,9 @@ int main()
         return rc;
     }
     if (int rc = testInputScaleResetBreaksTemporalBlend(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testDepthShadowOcclusion(); rc != 0) {
         return rc;
     }
     if (int rc = testRetainedHistoryCapacity(); rc != 0) {


### PR DESCRIPTION
## Summary

![3D Slice Shadow rendered across the live 3D FFT](https://raw.githubusercontent.com/rfoust/AetherSDR/f42041e85c71cb9e35ea55c045b8a050d22394b5/.github/pr-assets/3d-slice-shadow-2026-07-24.png)

Adds an optional **3D Slice Shadow** item to the panadapter context menu whenever the 3D FFT is enabled. When active, each slice tuning line and passband cast a dark, depth-fading decal across the rendered FFT surface. The GPU path applies the shadow in the mesh fragment shader so its leading edge follows the FFT curvature and stays registered as slices move or the display is panned, zoomed, or repositioned vertically. The cached-image fallback uses matching projection helpers. The preference is stored inside the existing nested Display settings object and applies consistently across panadapters.

## Constitution principle honored

- **Principle V — Each Feature Owns Its Configuration As A Single Object.** The new preference is part of the existing nested Display configuration rather than a new flat `AppSettings` key.
- **Principle VIII — Evidence Over Assertion.** Projection math has focused regression coverage, the complete local target set builds, the local test suite is accounted for, and the supplied live-radio screenshot shows the resulting effect.

## Test plan

- [x] Local build passes (`cmake --build build`)
  - Complete 1,078-target build passed, including shader generation.
- [x] Behavior verified on a real radio if applicable
  - Verified interactively on the live 3D FFT; screenshot above shows two slices and their surface-mapped shadows.
- [ ] Existing tests pass (CI)
  - Local result: 163 passed and one intentionally skipped. Seven socket/display-dependent tests that were blocked by the restricted sandbox passed when rerun outside it.
- [x] Reproduction steps documented if user-reported bug
  1. Enable the 3D FFT.
  2. Right-click the panadapter and enable **3D Slice Shadow**.
  3. Move a slice, pan or zoom the display, and move the FFT vertically.
  4. Confirm the tuning-line/passband shadow remains on the FFT surface and fades continuously toward the back.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter UI changes
- [x] Documentation updated if user-visible behavior changed — usage steps and a live screenshot are included above; no standalone guide currently enumerates panadapter context-menu display toggles
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable; no security-sensitive changes
