### PR TITLE
fix(gui): restore Display panel tooltip frames

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -1227,8 +1227,11 @@ void SpectrumOverlayMenu::updateLayout()
 void SpectrumOverlayMenu::buildDisplayPanel()
 {
     m_displayPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_displayPanel, "QWidget { background: rgba(15, 15, 26, 220); "
-                                   "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
+    m_displayPanel->setObjectName(QStringLiteral("displayPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(
+        m_displayPanel,
+        "QWidget#displayPanel { background: rgba(15, 15, 26, 220); "
+        "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_displayPanel->hide();
 
     // #3969: the panel's ~24 rows exceed a short window's height, so the grid
@@ -1247,10 +1250,16 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     m_displayScroll->setFrameShape(QFrame::NoFrame);
     m_displayScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_displayScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    m_displayScroll->setStyleSheet("QScrollArea { background: transparent; border: none; }");
-    m_displayScroll->viewport()->setStyleSheet("background: transparent; border: none;");
+    m_displayScroll->setStyleSheet(
+        "QScrollArea#displayPanelScroll { background: transparent; border: none; }");
+    m_displayScroll->viewport()->setObjectName(
+        QStringLiteral("displayPanelViewport"));
+    m_displayScroll->viewport()->setStyleSheet(
+        "QWidget#displayPanelViewport { background: transparent; border: none; }");
     auto* displayContent = new QWidget;
-    displayContent->setStyleSheet("background: transparent; border: none;");
+    displayContent->setObjectName(QStringLiteral("displayPanelContent"));
+    displayContent->setStyleSheet(
+        "QWidget#displayPanelContent { background: transparent; border: none; }");
     m_displayScroll->setWidget(displayContent);
     panelLayout->addWidget(m_displayScroll);
 
@@ -1366,10 +1375,9 @@ void SpectrumOverlayMenu::buildDisplayPanel()
     makeHeader("PANADAPTER");
     {
         auto* toggleRow = new QWidget;
-        // The Display panel's QWidget { border: 1px solid } cascades to this
-        // QWidget container and would otherwise draw a 1 px frame around the
-        // whole Heat Map / Grid / Wt Avg row.  Override locally.
-        toggleRow->setStyleSheet("QWidget { border: none; background: transparent; }");
+        toggleRow->setObjectName(QStringLiteral("displayPanelToggleRow"));
+        toggleRow->setStyleSheet(
+            "QWidget#displayPanelToggleRow { border: none; background: transparent; }");
         auto* toggleLayout = new QHBoxLayout(toggleRow);
         toggleLayout->setContentsMargins(0, 2, 0, 2);
         toggleLayout->setSpacing(3);


### PR DESCRIPTION
## Summary

Fix Display panel tooltips rendering as unboxed text. Broad `QWidget` and
transparent container styles were cascading into Qt's tooltip labels, removing
their background and border. Scope those styles to named Display panel widgets
so tooltips retain the normal framed appearance without changing the panel
layout or controls.

## Constitution principle honored

Principle VIII — the fix targets the identified Qt stylesheet cascade and is
supported by a successful application build and direct inspection of the
Display panel.

## Test plan

- [x] Local build passes (`cmake --build build --target AetherSDR -j6`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Reproduction:

1. Open the panadapter overlay menu.
2. Open **Display**.
3. Hover over a setting such as **FFT AVG**, **FFT FPS**, or **Waterfall Gain**.
4. Confirm the tooltip has its normal background and border instead of
   displaying bare text.

Additional validation:

- Opened the rebuilt application and confirmed the Display panel retains its
  intended layout, border, transparency, and scrolling behavior.
- `python3 tools/check_engine_boundary.py --strict` passes with no blocking
  findings.
- `git diff --check` passes.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter UI changed)
- [x] Documentation updated if user-visible behavior changed (not applicable;
      no documentation change required)
- [x] Security-sensitive changes reference a GHSA if applicable (not
      applicable)
