### PR TITLE
Fix KiwiSDR CW BFO offset so a tuned carrier produces an audible tone (#4423)

### DIFF
--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1391,11 +1391,8 @@ void KiwiSdrClient::sendTrackedSliceToServer()
             << "high_cut=" << highCutHz;
         return;
     }
-    sendSoundCommand(QStringLiteral("SET mod=%1 low_cut=%2 high_cut=%3 freq=%4")
-        .arg(mode)
-        .arg(lowCutHz)
-        .arg(highCutHz)
-        .arg(freqKhz, 0, 'f', 3));
+    sendSoundCommand(KiwiSdrProtocol::formatSoundTuneCommand(
+        mode, lowCutHz, highCutHz, freqKhz));
 }
 
 void KiwiSdrClient::sendReceiverControlsToServer()

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -975,7 +975,7 @@ void KiwiSdrClient::disconnectFromEndpoint()
 void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
                                     const QString& mode, int filterLowHz,
                                     int filterHighHz, const QString& panId,
-                                    const QString& bandName)
+                                    const QString& bandName, int cwPitchHz)
 {
     const QString normalizedBandName = bandName.trimmed();
     if (m_trackedSliceId == sliceId
@@ -984,7 +984,8 @@ void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
         && m_trackedFilterLowHz == filterLowHz
         && m_trackedFilterHighHz == filterHighHz
         && m_trackedPanId == panId
-        && m_trackedBandName == normalizedBandName) {
+        && m_trackedBandName == normalizedBandName
+        && m_trackedCwPitchHz == cwPitchHz) {
         return;
     }
 
@@ -998,6 +999,7 @@ void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
     m_trackedFilterLowHz = filterLowHz;
     m_trackedFilterHighHz = filterHighHz;
     m_trackedPanId = panId;
+    m_trackedCwPitchHz = cwPitchHz;
     if (bandChanged) {
         resetWaterfallAutoScaleHistory();
     }
@@ -1392,7 +1394,7 @@ void KiwiSdrClient::sendTrackedSliceToServer()
         return;
     }
     sendSoundCommand(KiwiSdrProtocol::formatSoundTuneCommand(
-        mode, lowCutHz, highCutHz, freqKhz));
+        mode, lowCutHz, highCutHz, freqKhz, m_trackedCwPitchHz));
 }
 
 void KiwiSdrClient::sendReceiverControlsToServer()

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1393,8 +1393,10 @@ void KiwiSdrClient::sendTrackedSliceToServer()
             << "high_cut=" << highCutHz;
         return;
     }
+    const bool cwLowerSideband =
+        m_trackedMode.trimmed().compare(QStringLiteral("CWL"), Qt::CaseInsensitive) == 0;
     sendSoundCommand(KiwiSdrProtocol::formatSoundTuneCommand(
-        mode, lowCutHz, highCutHz, freqKhz, m_trackedCwPitchHz));
+        mode, lowCutHz, highCutHz, freqKhz, m_trackedCwPitchHz, cwLowerSideband));
 }
 
 void KiwiSdrClient::sendReceiverControlsToServer()

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1784,7 +1784,10 @@ int KiwiSdrClient::kiwiLowCutHz() const
         return 100;
     }
     if (mode == QStringLiteral("cw")) {
-        return 400;
+        // Symmetric about the carrier, matching how Flex reports its CW
+        // passband — formatSoundTuneCommand() shifts this by the CW pitch,
+        // so an already pitch-centered fallback would get shifted twice.
+        return -400;
     }
     if (mode == QStringLiteral("nfm")) {
         return -6000;
@@ -1806,7 +1809,7 @@ int KiwiSdrClient::kiwiHighCutHz() const
         return 2900;
     }
     if (mode == QStringLiteral("cw")) {
-        return 800;
+        return 400;
     }
     if (mode == QStringLiteral("nfm")) {
         return 6000;

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -1395,8 +1395,13 @@ void KiwiSdrClient::sendTrackedSliceToServer()
     }
     const bool cwLowerSideband =
         m_trackedMode.trimmed().compare(QStringLiteral("CWL"), Qt::CaseInsensitive) == 0;
+    // Nyquist of the negotiated sound-stream rate, not the ~12 kHz default —
+    // the Kiwi renegotiates m_soundSampleRateHz per connection (8-48 kHz).
+    const int maxAudioBandwidthHz =
+        static_cast<int>(m_soundSampleRateHz / 2.0);
     sendSoundCommand(KiwiSdrProtocol::formatSoundTuneCommand(
-        mode, lowCutHz, highCutHz, freqKhz, m_trackedCwPitchHz, cwLowerSideband));
+        mode, lowCutHz, highCutHz, freqKhz, m_trackedCwPitchHz, cwLowerSideband,
+        maxAudioBandwidthHz));
 }
 
 void KiwiSdrClient::sendReceiverControlsToServer()

--- a/src/core/KiwiSdrClient.cpp
+++ b/src/core/KiwiSdrClient.cpp
@@ -61,6 +61,17 @@ QString trKiwiSdrClient(const char* sourceText)
     return QCoreApplication::translate("KiwiSdrClient", sourceText);
 }
 
+// Shared by kiwiMode() (checks the already-tracked mode) and
+// setTrackedSlice()'s dedup guard (checks the incoming mode before it's
+// assigned to m_trackedMode) so both agree on what counts as CW.
+bool isCwModeString(const QString& mode)
+{
+    const QString normalized = mode.trimmed().toUpper();
+    return normalized == QStringLiteral("CW")
+        || normalized == QStringLiteral("CWU")
+        || normalized == QStringLiteral("CWL");
+}
+
 KiwiSdrProtocol::WaterfallDisplayRange clampedWaterfallDisplayRange(
     KiwiSdrProtocol::WaterfallDisplayRange range)
 {
@@ -978,6 +989,14 @@ void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
                                     const QString& bandName, int cwPitchHz)
 {
     const QString normalizedBandName = bandName.trimmed();
+    // cwPitchHz only affects the wire command in CW mode (formatSoundTuneCommand
+    // ignores it otherwise) — comparing it unconditionally here made every CW
+    // pitch step re-send an identical SET to every non-CW Kiwi-tracked slice too.
+    // Against a public KiwiSDR, dragging the pitch control turned into a
+    // sustained burst of redundant commands risking a kick/rate-limit policy
+    // (#4423 review). Skip the comparison outright when the incoming mode
+    // isn't CW, so a pitch-only "change" on a USB/LSB/AM slice dedups away.
+    const bool cwPitchMatters = isCwModeString(mode);
     if (m_trackedSliceId == sliceId
         && qFuzzyCompare(m_trackedFrequencyMhz, frequencyMhz)
         && m_trackedMode == mode
@@ -985,7 +1004,7 @@ void KiwiSdrClient::setTrackedSlice(int sliceId, double frequencyMhz,
         && m_trackedFilterHighHz == filterHighHz
         && m_trackedPanId == panId
         && m_trackedBandName == normalizedBandName
-        && m_trackedCwPitchHz == cwPitchHz) {
+        && (!cwPitchMatters || m_trackedCwPitchHz == cwPitchHz)) {
         return;
     }
 
@@ -1767,8 +1786,7 @@ QString KiwiSdrClient::kiwiMode() const
         || mode == QStringLiteral("RTTY")) {
         return QStringLiteral("usb");
     }
-    if (mode == QStringLiteral("CW") || mode == QStringLiteral("CWU")
-        || mode == QStringLiteral("CWL")) {
+    if (isCwModeString(mode)) {
         return QStringLiteral("cw");
     }
     if (mode == QStringLiteral("NFM") || mode == QStringLiteral("FM")) {

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -105,7 +105,7 @@ public slots:
     void setTrackedSlice(int sliceId, double frequencyMhz,
                          const QString& mode, int filterLowHz,
                          int filterHighHz, const QString& panId,
-                         const QString& bandName);
+                         const QString& bandName, int cwPitchHz);
     void setWaterfallView(const QString& panId, double centerMhz,
                           double bandwidthMhz);
     void setWaterfallLineDurationMs(int lineDurationMs);
@@ -278,6 +278,7 @@ private:
     QString m_trackedMode;
     int m_trackedFilterLowHz{0};
     int m_trackedFilterHighHz{0};
+    int m_trackedCwPitchHz{600};
     QString m_trackedPanId;
     bool m_userDisconnecting{false};
     bool m_secureWebSocket{false};

--- a/src/core/KiwiSdrClient.h
+++ b/src/core/KiwiSdrClient.h
@@ -278,7 +278,7 @@ private:
     QString m_trackedMode;
     int m_trackedFilterLowHz{0};
     int m_trackedFilterHighHz{0};
-    int m_trackedCwPitchHz{600};
+    int m_trackedCwPitchHz{0};
     QString m_trackedPanId;
     bool m_userDisconnecting{false};
     bool m_secureWebSocket{false};

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -440,7 +440,7 @@ void KiwiSdrManager::connectProfile(const QString& id)
         m_clientHasTrackedSlice.insert(id, false);
         invokeClient(id, [](KiwiSdrClient* client) {
             client->setTrackedSlice(-1, 0.0, QString(), 0, 0, QString(),
-                                    QString());
+                                    QString(), 0);
         });
         emit profileNeedsInitialTracking(id);
     }
@@ -521,7 +521,8 @@ void KiwiSdrManager::primeProfileTracking(const QString& id, int sliceId,
                                           double centerMhz,
                                           double bandwidthMhz,
                                           int lineDurationMs,
-                                          const QString& bandName)
+                                          const QString& bandName,
+                                          int cwPitchHz)
 {
     if (!hasProfile(id) || sliceId < 0 || frequencyMhz <= 0.0) {
         return;
@@ -532,10 +533,10 @@ void KiwiSdrManager::primeProfileTracking(const QString& id, int sliceId,
         m_clientHasTrackedSlice.insert(id, true);
         invokeClient(id, [sliceId, frequencyMhz, mode, filterLowHz,
                           filterHighHz, panId, lineDurationMs,
-                          centerMhz, bandwidthMhz, bandName](
+                          centerMhz, bandwidthMhz, bandName, cwPitchHz](
                              KiwiSdrClient* client) {
             client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                                    filterHighHz, panId, bandName);
+                                    filterHighHz, panId, bandName, cwPitchHz);
             client->setWaterfallLineDurationMs(lineDurationMs);
             if (!panId.isEmpty() && centerMhz > 0.0 && bandwidthMhz > 0.0) {
                 client->setWaterfallView(panId, centerMhz, bandwidthMhz);
@@ -549,7 +550,8 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
                                           const QString& mode,
                                           int filterLowHz, int filterHighHz,
                                           const QString& panId,
-                                          const QString& bandName)
+                                          const QString& bandName,
+                                          int cwPitchHz)
 {
     if (sliceId < 0 || !hasProfile(profileId)) {
         clearSliceAssignment(sliceId);
@@ -597,10 +599,11 @@ void KiwiSdrManager::assignSliceToProfile(int sliceId, const QString& profileId,
         const bool connected =
             KiwiSdrClient::stateHasReceiveAudio(state(profileId));
         invokeClient(profileId, [sliceId, frequencyMhz, mode, filterLowHz,
-                                 filterHighHz, panId, bandName, connected](
+                                 filterHighHz, panId, bandName, connected,
+                                 cwPitchHz](
                                     KiwiSdrClient* client) {
             client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                                    filterHighHz, panId, bandName);
+                                    filterHighHz, panId, bandName, cwPitchHz);
             client->setAudioActive(connected);
         });
     }
@@ -639,7 +642,8 @@ void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,
                                          const QString& mode,
                                          int filterLowHz, int filterHighHz,
                                          const QString& panId,
-                                         const QString& bandName)
+                                         const QString& bandName,
+                                         int cwPitchHz)
 {
     const QString profileId = m_sliceAssignments.value(sliceId);
     if (profileId.isEmpty()) {
@@ -650,10 +654,10 @@ void KiwiSdrManager::updateSliceTracking(int sliceId, double frequencyMhz,
         m_clientHasTrackedSlice.insert(profileId, sliceId >= 0 && frequencyMhz > 0.0);
         invokeClient(profileId, [sliceId, frequencyMhz, mode,
                                  filterLowHz, filterHighHz, panId,
-                                 bandName](
+                                 bandName, cwPitchHz](
                                     KiwiSdrClient* client) {
             client->setTrackedSlice(sliceId, frequencyMhz, mode, filterLowHz,
-                                    filterHighHz, panId, bandName);
+                                    filterHighHz, panId, bandName, cwPitchHz);
         });
     }
 }

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -101,17 +101,17 @@ public slots:
                               int filterLowHz, int filterHighHz,
                               const QString& panId, double centerMhz,
                               double bandwidthMhz, int lineDurationMs,
-                              const QString& bandName);
+                              const QString& bandName, int cwPitchHz);
     void assignSliceToProfile(int sliceId, const QString& profileId,
                               double frequencyMhz, const QString& mode,
                               int filterLowHz, int filterHighHz,
                               const QString& panId,
-                              const QString& bandName);
+                              const QString& bandName, int cwPitchHz);
     void clearSliceAssignment(int sliceId);
     void updateSliceTracking(int sliceId, double frequencyMhz,
                              const QString& mode, int filterLowHz,
                              int filterHighHz, const QString& panId,
-                             const QString& bandName);
+                             const QString& bandName, int cwPitchHz);
     void updateWaterfallView(int sliceId, const QString& panId,
                              double centerMhz, double bandwidthMhz,
                              int lineDurationMs);

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1586,25 +1586,31 @@ QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
 }
 
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
-                               double freqKhz)
+                               double freqKhz, int cwPitchHz)
 {
+    int tunedLowCutHz = lowCutHz;
+    int tunedHighCutHz = highCutHz;
     double tunedFreqKhz = freqKhz;
-    if (mode == QStringLiteral("cw")) {
-        // The Kiwi's 'freq' is the BFO/mixdown point, not a dial frequency:
-        // low_cut/high_cut are applied as an audio passband relative to it.
-        // Our CW passband is already centered on the sidetone pitch above
-        // (or, for CWL, below) the carrier, so sending freq=carrier puts the
-        // carrier at 0 Hz — outside the passband — and the tone is filtered
-        // out (#4423). Shift the BFO by the passband center so the carrier
-        // lands inside the passband and beats to the pitch tone, matching
-        // what the operator hears from the Flex sidetone.
-        const double pitchHz = (lowCutHz + highCutHz) / 2.0;
-        tunedFreqKhz -= pitchHz / 1000.0;
+    if (mode == QStringLiteral("cw") && cwPitchHz != 0) {
+        // Flex reports the CW passband symmetric about the carrier (e.g.
+        // low_cut=-400 high_cut=400) — the sidetone pitch is a DSP shift
+        // Flex applies AFTER that filter, not something baked into it. The
+        // Kiwi has no such post-filter shift: 'freq' is the BFO/mixdown
+        // point and low_cut/high_cut are an audio passband relative to it.
+        // Sending freq=carrier with the passband as reported puts the
+        // carrier at 0 Hz (audible only as a DC thump, not a tone) — #4423.
+        // Reproduce the Flex behavior by shifting the whole receive chain
+        // by the pitch: move the BFO down so the carrier demodulates to
+        // +cwPitchHz, and slide the passband up by the same amount so that
+        // frequency is still inside it.
+        tunedLowCutHz += cwPitchHz;
+        tunedHighCutHz += cwPitchHz;
+        tunedFreqKhz -= cwPitchHz / 1000.0;
     }
     return QStringLiteral("SET mod=%1 low_cut=%2 high_cut=%3 freq=%4")
         .arg(mode)
-        .arg(lowCutHz)
-        .arg(highCutHz)
+        .arg(tunedLowCutHz)
+        .arg(tunedHighCutHz)
         .arg(tunedFreqKhz, 0, 'f', 3);
 }
 

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1585,6 +1585,29 @@ QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
         .arg(clampedManualGain);
 }
 
+QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
+                               double freqKhz)
+{
+    double tunedFreqKhz = freqKhz;
+    if (mode == QStringLiteral("cw")) {
+        // The Kiwi's 'freq' is the BFO/mixdown point, not a dial frequency:
+        // low_cut/high_cut are applied as an audio passband relative to it.
+        // Our CW passband is already centered on the sidetone pitch above
+        // (or, for CWL, below) the carrier, so sending freq=carrier puts the
+        // carrier at 0 Hz — outside the passband — and the tone is filtered
+        // out (#4423). Shift the BFO by the passband center so the carrier
+        // lands inside the passband and beats to the pitch tone, matching
+        // what the operator hears from the Flex sidetone.
+        const double pitchHz = (lowCutHz + highCutHz) / 2.0;
+        tunedFreqKhz -= pitchHz / 1000.0;
+    }
+    return QStringLiteral("SET mod=%1 low_cut=%2 high_cut=%3 freq=%4")
+        .arg(mode)
+        .arg(lowCutHz)
+        .arg(highCutHz)
+        .arg(tunedFreqKhz, 0, 'f', 3);
+}
+
 MeterReading meterUnavailable(MeterSource source, const QString& notes)
 {
     MeterReading reading;

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1586,7 +1586,7 @@ QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
 }
 
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
-                               double freqKhz, int cwPitchHz)
+                               double freqKhz, int cwPitchHz, bool cwLowerSideband)
 {
     int tunedLowCutHz = lowCutHz;
     int tunedHighCutHz = highCutHz;
@@ -1600,14 +1600,21 @@ QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
         // Sending freq=carrier with the passband as reported puts the
         // carrier at 0 Hz (audible only as a DC thump, not a tone) — #4423.
         // Reproduce the Flex behavior by shifting the whole receive chain
-        // by the pitch: move the BFO down so the carrier demodulates to
-        // +cwPitchHz, and slide the passband up by the same amount so that
-        // frequency is still inside it. Clamp the shift so the passband
-        // doesn't slide past the Kiwi's audio Nyquist — an unclamped shift
-        // at the top of the CW pitch range pushes the tone to the band edge
-        // and reproduces #4423's silence with a different root cause.
-        const int shiftHz = std::min(
-            cwPitchHz, kKiwiMaxAudioBandwidthHz - tunedHighCutHz);
+        // by the pitch: move the BFO so the carrier demodulates to
+        // +cwPitchHz (CWU) or -cwPitchHz (CWL), and slide the passband by
+        // the same signed amount so that frequency is still inside it. This
+        // mirrors which side of the carrier the Flex itself listens to, so
+        // adjacent-signal rejection matches instead of always landing on
+        // the USB side regardless of sideband.
+        const int sign = cwLowerSideband ? -1 : 1;
+        // Clamp the shift so the passband doesn't slide past the Kiwi's
+        // audio Nyquist — an unclamped shift at the top of the CW pitch
+        // range pushes the tone to the band edge and reproduces #4423's
+        // silence with a different root cause.
+        const int headroomHz = cwLowerSideband
+            ? kKiwiMaxAudioBandwidthHz + tunedLowCutHz
+            : kKiwiMaxAudioBandwidthHz - tunedHighCutHz;
+        const int shiftHz = sign * std::min(cwPitchHz, headroomHz);
         tunedLowCutHz += shiftHz;
         tunedHighCutHz += shiftHz;
         tunedFreqKhz -= shiftHz / 1000.0;

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1602,10 +1602,15 @@ QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
         // Reproduce the Flex behavior by shifting the whole receive chain
         // by the pitch: move the BFO down so the carrier demodulates to
         // +cwPitchHz, and slide the passband up by the same amount so that
-        // frequency is still inside it.
-        tunedLowCutHz += cwPitchHz;
-        tunedHighCutHz += cwPitchHz;
-        tunedFreqKhz -= cwPitchHz / 1000.0;
+        // frequency is still inside it. Clamp the shift so the passband
+        // doesn't slide past the Kiwi's audio Nyquist — an unclamped shift
+        // at the top of the CW pitch range pushes the tone to the band edge
+        // and reproduces #4423's silence with a different root cause.
+        const int shiftHz = std::min(
+            cwPitchHz, kKiwiMaxAudioBandwidthHz - tunedHighCutHz);
+        tunedLowCutHz += shiftHz;
+        tunedHighCutHz += shiftHz;
+        tunedFreqKhz -= shiftHz / 1000.0;
     }
     return QStringLiteral("SET mod=%1 low_cut=%2 high_cut=%3 freq=%4")
         .arg(mode)

--- a/src/core/KiwiSdrProtocol.cpp
+++ b/src/core/KiwiSdrProtocol.cpp
@@ -1586,7 +1586,8 @@ QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
 }
 
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
-                               double freqKhz, int cwPitchHz, bool cwLowerSideband)
+                               double freqKhz, int cwPitchHz, bool cwLowerSideband,
+                               int maxAudioBandwidthHz)
 {
     int tunedLowCutHz = lowCutHz;
     int tunedHighCutHz = highCutHz;
@@ -1610,10 +1611,17 @@ QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
         // Clamp the shift so the passband doesn't slide past the Kiwi's
         // audio Nyquist — an unclamped shift at the top of the CW pitch
         // range pushes the tone to the band edge and reproduces #4423's
-        // silence with a different root cause.
-        const int headroomHz = cwLowerSideband
-            ? kKiwiMaxAudioBandwidthHz + tunedLowCutHz
-            : kKiwiMaxAudioBandwidthHz - tunedHighCutHz;
+        // silence with a different root cause. maxAudioBandwidthHz is the
+        // caller's negotiated Nyquist (sampleRateHz / 2), not a fixed
+        // constant — the Kiwi's audio sample rate is negotiated per
+        // connection, not always ~12 kHz. Floor headroom at 0: if the
+        // passband is already outside Nyquist (a filter width wider than
+        // the negotiated rate allows), a negative headroom would otherwise
+        // flip the shift's sign and push the passband further out of range
+        // instead of leaving it alone.
+        const int headroomHz = std::max(0, cwLowerSideband
+            ? maxAudioBandwidthHz + tunedLowCutHz
+            : maxAudioBandwidthHz - tunedHighCutHz);
         const int shiftHz = sign * std::min(cwPitchHz, headroomHz);
         tunedLowCutHz += shiftHz;
         tunedHighCutHz += shiftHz;

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -326,7 +326,7 @@ int agcDecayMsForMode(const QString& mode);
 QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
                          int manualGainDb, int decayMs);
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
-                               double freqKhz);
+                               double freqKhz, int cwPitchHz);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
                                                const MeterContext& context);

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -325,6 +325,8 @@ QString formatSquelchCommand(bool enabled, int thresholdDb,
 int agcDecayMsForMode(const QString& mode);
 QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
                          int manualGainDb, int decayMs);
+QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
+                               double freqKhz);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
                                                const MeterContext& context);

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -330,7 +330,8 @@ QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
                          int manualGainDb, int decayMs);
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
                                double freqKhz, int cwPitchHz,
-                               bool cwLowerSideband = false);
+                               bool cwLowerSideband = false,
+                               int maxAudioBandwidthHz = kKiwiMaxAudioBandwidthHz);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
                                                const MeterContext& context);

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -329,7 +329,8 @@ int agcDecayMsForMode(const QString& mode);
 QString formatAgcCommand(bool enabled, bool hang, int thresholdDb,
                          int manualGainDb, int decayMs);
 QString formatSoundTuneCommand(const QString& mode, int lowCutHz, int highCutHz,
-                               double freqKhz, int cwPitchHz);
+                               double freqKhz, int cwPitchHz,
+                               bool cwLowerSideband = false);
 MeterReading meterUnavailable(MeterSource source, const QString& notes = {});
 MeterReading extractMeterFromSndVerifiedLayout(const QByteArray& frame,
                                                const MeterContext& context);

--- a/src/core/KiwiSdrProtocol.h
+++ b/src/core/KiwiSdrProtocol.h
@@ -26,6 +26,9 @@ inline constexpr int kAgcFastDecayMs = 300;
 inline constexpr int kAgcMedDecayMs = 1000;
 inline constexpr int kAgcSlowDecayMs = 3000;
 inline constexpr int kAgcSlopeDb = 6;
+// Kiwi sound stream is ~12 kHz-sampled (KiwiSdrClient::m_soundSampleRateHz),
+// so its audio passband can't extend past this Nyquist limit.
+inline constexpr int kKiwiMaxAudioBandwidthHz = 6000;
 
 struct SoundFrameHeader {
     int sequence{-1};

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -602,7 +602,8 @@ void MainWindow::setKiwiSdrVirtualAntennaForSliceInternal(int sliceId,
     m_kiwiSdrManager->assignSliceToProfile(
         sliceId, profileId, slice->frequency(), slice->mode(),
         slice->filterLow(), slice->filterHigh(), slice->panId(),
-        BandSettings::bandForFrequency(slice->frequency()));
+        BandSettings::bandForFrequency(slice->frequency()),
+        m_radioModel.transmitModel().cwPitch());
     updateKiwiSdrVirtualTrackingForSlice(slice);
     updateKiwiSdrVirtualAudioControlsForSlice(slice);
     updateKiwiSdrVirtualReceiverControlsForSlice(slice);
@@ -1035,7 +1036,8 @@ void MainWindow::updateKiwiSdrVirtualTrackingForSlice(SliceModel* slice)
     m_kiwiSdrManager->updateSliceTracking(
         slice->sliceId(), slice->frequency(), slice->mode(),
         slice->filterLow(), slice->filterHigh(), slice->panId(),
-        BandSettings::bandForFrequency(slice->frequency()));
+        BandSettings::bandForFrequency(slice->frequency()),
+        m_radioModel.transmitModel().cwPitch());
     if (SpectrumWidget* spectrum = spectrumForSlice(slice)) {
         m_kiwiSdrManager->updateWaterfallView(
             slice->sliceId(), slice->panId(), spectrum->centerMhz(),
@@ -1773,7 +1775,8 @@ void MainWindow::wireKiwiSdr()
                 spectrum ? spectrum->centerMhz() : slice->frequency(),
                 spectrum ? spectrum->bandwidthMhz() : 0.2,
                 spectrum ? spectrum->wfLineDuration() : 100,
-                BandSettings::bandForFrequency(slice->frequency()));
+                BandSettings::bandForFrequency(slice->frequency()),
+                m_radioModel.transmitModel().cwPitch());
         });
         if (m_audio) {
             connect(m_kiwiSdrManager, &KiwiSdrManager::decodedAudioReady,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4917,8 +4917,10 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // Re-send the tracked-slice command when the radio's CW pitch changes so
     // an already-active KiwiSDR CW session's BFO offset stays in sync (#4423)
     // instead of going stale until the next frequency/mode/filter edit.
-    connect(&m_radioModel.transmitModel(), &TransmitModel::phoneStateChanged,
-            this, [this, s]() { updateKiwiSdrVirtualTrackingForSlice(s); });
+    // cwPitchChanged (not phoneStateChanged) so this doesn't re-run on every
+    // unrelated VOX/mic/dexp status update for every wired slice.
+    connect(&m_radioModel.transmitModel(), &TransmitModel::cwPitchChanged,
+            this, [this, s](int) { updateKiwiSdrVirtualTrackingForSlice(s); });
     connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
         updateAetherDspModePolicy();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4919,8 +4919,20 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // instead of going stale until the next frequency/mode/filter edit.
     // cwPitchChanged (not phoneStateChanged) so this doesn't re-run on every
     // unrelated VOX/mic/dexp status update for every wired slice.
+    // Context is `s` (not `this`) so Qt disconnects when the slice dies —
+    // slices come and go far more often than MainWindow does (band changes,
+    // stale-slice pruning); that was a real UAF fixed earlier on this PR.
+    // But that leaves the captured `this` untracked by Qt's own lifetime
+    // handling, so guard it separately with a QPointer (same idiom as
+    // AetherDspWidget::onDspToggled) for the rare case MainWindow is torn
+    // down while the slice and TransmitModel are still alive.
+    QPointer<MainWindow> self(this);
     connect(&m_radioModel.transmitModel(), &TransmitModel::cwPitchChanged,
-            s, [this, s](int) { updateKiwiSdrVirtualTrackingForSlice(s); });
+            s, [self, s](int) {
+        if (self) {
+            self->updateKiwiSdrVirtualTrackingForSlice(s);
+        }
+    });
     connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
         updateAetherDspModePolicy();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4920,7 +4920,7 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     // cwPitchChanged (not phoneStateChanged) so this doesn't re-run on every
     // unrelated VOX/mic/dexp status update for every wired slice.
     connect(&m_radioModel.transmitModel(), &TransmitModel::cwPitchChanged,
-            this, [this, s](int) { updateKiwiSdrVirtualTrackingForSlice(s); });
+            s, [this, s](int) { updateKiwiSdrVirtualTrackingForSlice(s); });
     connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
         updateAetherDspModePolicy();

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -4914,6 +4914,11 @@ void MainWindow::wireVfoWidget(VfoWidget* w, SliceModel* s)
     connect(s, &SliceModel::panIdChanged, this, [this, s](const QString&) {
         updateKiwiSdrVirtualTrackingForSlice(s);
     });
+    // Re-send the tracked-slice command when the radio's CW pitch changes so
+    // an already-active KiwiSDR CW session's BFO offset stays in sync (#4423)
+    // instead of going stale until the next frequency/mode/filter edit.
+    connect(&m_radioModel.transmitModel(), &TransmitModel::phoneStateChanged,
+            this, [this, s]() { updateKiwiSdrVirtualTrackingForSlice(s); });
     connect(s, &SliceModel::audioGainChanged, this, [this, s](float) {
         updateKiwiSdrVirtualAudioControlsForSlice(s);
         updateAetherDspModePolicy();

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -66,6 +66,7 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
     bool micChanged = false;
     bool phoneChanged = false;
     bool filterCutoffChanged = false;
+    bool cwPitchChanged_ = false;
 
     // ── Core transmit ──
     // rf_power / tune_power emit inline (like max_power_level below): the
@@ -114,7 +115,7 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
 
     // ── CW ──
     phoneChanged |= assign(d.cwSpeed, m_cwSpeed);
-    phoneChanged |= assign(d.cwPitch, m_cwPitch);
+    if (assign(d.cwPitch, m_cwPitch)) { phoneChanged = true; cwPitchChanged_ = true; }
     phoneChanged |= assign(d.cwBreakIn, m_cwBreakIn);
     phoneChanged |= assign(d.cwDelay, m_cwDelay);
     phoneChanged |= assign(d.cwSidetone, m_cwSidetone);
@@ -147,6 +148,7 @@ void TransmitModel::applyChanges(const TransmitDelta& d)
     if (micChanged) emit micStateChanged();
     if (phoneChanged) emit phoneStateChanged();
     if (filterCutoffChanged) emit txFilterCutoffChanged(m_txFilterLow, m_txFilterHigh);
+    if (cwPitchChanged_) emit cwPitchChanged(m_cwPitch);
 
     // ── ATU (own emit; model owns the enum parse) ──
     {
@@ -634,6 +636,7 @@ void TransmitModel::setCwPitch(int hz)
     if (m_cwPitch != hz) {
         m_cwPitch = hz;  // update local cache so rapid steppers accumulate
         emit phoneStateChanged();
+        emit cwPitchChanged(hz);
     }
     emit commandReady(QString("cw pitch %1").arg(hz));
 }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -303,6 +303,10 @@ signals:
     // instead of phoneStateChanged for slot work that should NOT run on
     // every VOX/CW/dexp/mic-boost/etc. status update.
     void txFilterCutoffChanged(int lowHz, int highHz);
+    // Fires only when cwPitch actually changes. Use this instead of
+    // phoneStateChanged for slot work that should NOT run on every
+    // VOX/CW/dexp/mic-boost/etc. status update (e.g. #4423 KiwiSDR BFO sync).
+    void cwPitchChanged(int hz);
     void apdStateChanged();
     void apdSamplerChanged(const QString& txAnt);
     void apdEqualizerResetReceived();

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -294,16 +294,20 @@ int main()
         return fail("AGC command formatting is wrong");
     }
 
-    // #4423: Kiwi 'freq' is the BFO, so CW must shift it by the passband
-    // center (the sidetone pitch) or the carrier demodulates to DC and gets
-    // filtered out, leaving no audible tone even though the pip overlays it.
-    if (formatSoundTuneCommand(QStringLiteral("cw"), 400, 800, 7000.0)
-            != QStringLiteral("SET mod=cw low_cut=400 high_cut=800 freq=6999.400")
-        || formatSoundTuneCommand(QStringLiteral("cw"), -800, -400, 7000.0)
-            != QStringLiteral("SET mod=cw low_cut=-800 high_cut=-400 freq=7000.600")
-        || formatSoundTuneCommand(QStringLiteral("usb"), 100, 2900, 7000.0)
+    // #4423: Flex reports the CW passband symmetric about the carrier (e.g.
+    // -400..400, confirmed from a real session log) and applies the sidetone
+    // pitch as a DSP shift AFTER that filter. The Kiwi has no such shift:
+    // 'freq' is the BFO and low_cut/high_cut are relative to it, so sending
+    // freq=carrier with an unshifted passband puts the carrier at 0 Hz (a DC
+    // thump, not a tone). Both the BFO and the passband must move by the
+    // pitch so the carrier lands audibly inside it.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 600)
+            != QStringLiteral("SET mod=cw low_cut=200 high_cut=1000 freq=6999.400")
+        || formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 0)
+            != QStringLiteral("SET mod=cw low_cut=-400 high_cut=400 freq=7000.000")
+        || formatSoundTuneCommand(QStringLiteral("usb"), 100, 2900, 7000.0, 600)
             != QStringLiteral("SET mod=usb low_cut=100 high_cut=2900 freq=7000.000")
-        || formatSoundTuneCommand(QStringLiteral("lsb"), -2900, -100, 7000.0)
+        || formatSoundTuneCommand(QStringLiteral("lsb"), -2900, -100, 7000.0, 600)
             != QStringLiteral("SET mod=lsb low_cut=-2900 high_cut=-100 freq=7000.000")) {
         return fail("sound tune command formatting is wrong");
     }

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -294,6 +294,20 @@ int main()
         return fail("AGC command formatting is wrong");
     }
 
+    // #4423: Kiwi 'freq' is the BFO, so CW must shift it by the passband
+    // center (the sidetone pitch) or the carrier demodulates to DC and gets
+    // filtered out, leaving no audible tone even though the pip overlays it.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), 400, 800, 7000.0)
+            != QStringLiteral("SET mod=cw low_cut=400 high_cut=800 freq=6999.400")
+        || formatSoundTuneCommand(QStringLiteral("cw"), -800, -400, 7000.0)
+            != QStringLiteral("SET mod=cw low_cut=-800 high_cut=-400 freq=7000.600")
+        || formatSoundTuneCommand(QStringLiteral("usb"), 100, 2900, 7000.0)
+            != QStringLiteral("SET mod=usb low_cut=100 high_cut=2900 freq=7000.000")
+        || formatSoundTuneCommand(QStringLiteral("lsb"), -2900, -100, 7000.0)
+            != QStringLiteral("SET mod=lsb low_cut=-2900 high_cut=-100 freq=7000.000")) {
+        return fail("sound tune command formatting is wrong");
+    }
+
     const QVector<MsgToken> msgTokens = parseMsgTokens(
         QStringLiteral("MSG wb_only password_timeout inactivity_timeout=15 "
                        "kiwi_kick=1%2coperator%20request badp=5 =ignored"));

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -312,6 +312,16 @@ int main()
         return fail("sound tune command formatting is wrong");
     }
 
+    // A pitch near the top of TransmitModel's 100-6000 Hz CW pitch range
+    // would otherwise slide high_cut past the Kiwi's ~6 kHz audio Nyquist,
+    // putting the tone at the very edge of (or past) the passband and
+    // reproducing #4423's silence with a different root cause. The shift
+    // must clamp so high_cut never exceeds kKiwiMaxAudioBandwidthHz.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 6000)
+        != QStringLiteral("SET mod=cw low_cut=5200 high_cut=6000 freq=6994.400")) {
+        return fail("sound tune command should clamp CW shift to the Kiwi audio Nyquist");
+    }
+
     const QVector<MsgToken> msgTokens = parseMsgTokens(
         QStringLiteral("MSG wb_only password_timeout inactivity_timeout=15 "
                        "kiwi_kick=1%2coperator%20request badp=5 =ignored"));

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -322,6 +322,21 @@ int main()
         return fail("sound tune command should clamp CW shift to the Kiwi audio Nyquist");
     }
 
+    // kiwiMode() collapses CWU/CWL to "cw", so the sideband must be plumbed
+    // in separately. In CWL the Flex listens below the carrier, so the Kiwi
+    // shift must mirror CWU: BFO moves up (freq increases) and the passband
+    // slides down, landing the tone at -cwPitchHz instead of +cwPitchHz, so
+    // adjacent-signal rejection matches which side of the carrier the Flex
+    // itself demodulates.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 600,
+                               /*cwLowerSideband=*/true)
+            != QStringLiteral("SET mod=cw low_cut=-1000 high_cut=-200 freq=7000.600")
+        || formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 6000,
+                                  /*cwLowerSideband=*/true)
+            != QStringLiteral("SET mod=cw low_cut=-6000 high_cut=-5200 freq=7005.600")) {
+        return fail("sound tune command should mirror the CW shift for CWL");
+    }
+
     const QVector<MsgToken> msgTokens = parseMsgTokens(
         QStringLiteral("MSG wb_only password_timeout inactivity_timeout=15 "
                        "kiwi_kick=1%2coperator%20request badp=5 =ignored"));

--- a/tests/kiwi_sdr_protocol_test.cpp
+++ b/tests/kiwi_sdr_protocol_test.cpp
@@ -337,6 +337,26 @@ int main()
         return fail("sound tune command should mirror the CW shift for CWL");
     }
 
+    // The Nyquist clamp must track the caller's actual negotiated sound-
+    // stream rate, not a fixed ~12 kHz assumption — the Kiwi renegotiates
+    // audio_rate per connection (8-48 kHz), so a receiver running at a
+    // lower rate has a lower Nyquist than kKiwiMaxAudioBandwidthHz.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), -400, 400, 7000.0, 3800,
+                               /*cwLowerSideband=*/false, /*maxAudioBandwidthHz=*/4000)
+        != QStringLiteral("SET mod=cw low_cut=3200 high_cut=4000 freq=6996.400")) {
+        return fail("sound tune command should clamp CW shift to the caller's negotiated Nyquist");
+    }
+
+    // A passband already outside the negotiated Nyquist (e.g. a filter
+    // width that predates a rate renegotiation) must leave the shift at
+    // zero rather than flip sign on a negative headroom and push the
+    // passband further out of range.
+    if (formatSoundTuneCommand(QStringLiteral("cw"), -4500, 4500, 7000.0, 600,
+                               /*cwLowerSideband=*/false, /*maxAudioBandwidthHz=*/4000)
+        != QStringLiteral("SET mod=cw low_cut=-4500 high_cut=4500 freq=7000.000")) {
+        return fail("sound tune command should floor a negative Nyquist headroom at zero shift");
+    }
+
     const QVector<MsgToken> msgTokens = parseMsgTokens(
         QStringLiteral("MSG wb_only password_timeout inactivity_timeout=15 "
                        "kiwi_kick=1%2coperator%20request badp=5 =ignored"));


### PR DESCRIPTION
## Summary
- Fixes #4423: on a KiwiSDR virtual antenna in CW mode, a carrier centered under the tuned-frequency pip produced no audible tone (or, after the first commit below, a DC-thump/heterodyne instead of a clean tone).
- KiwiSDR's `SET ... freq=` is the BFO/mixdown point, not a dial frequency — `low_cut`/`high_cut` are an audio passband applied *relative to it*. Sending `freq=carrier` puts the carrier at 0 Hz, which either falls outside the passband (no tone) or lands as an inaudible DC thump (tone, but not a tone).

## Why two commits
This shipped in two steps because the first fix's assumption was disproved by a real session log attached to the issue, and I want that story visible rather than squashed away:

1. **`Offset KiwiSDR CW sound-stream BFO by the passband center`** — an automated triage comment on the issue had already root-caused the "BFO stays at the carrier" problem and proposed shifting `freq` by the CW passband's center (assuming Flex reports the passband already offset toward the pitch, e.g. `400..800`). I implemented that. It compiled and looked reasonable, but testing on real hardware showed **no change in behavior** — still no tone, and audible "DC shifting" while tuning.
2. **`Use the radio's actual CW pitch for KiwiSDR BFO offset, not passband center`** — pulling the log files attached to the issue showed the actual commands AetherSDR was sending: `SET mod=cw low_cut=-400 high_cut=400 freq=...`. Flex's real CW passband is **symmetric about the carrier**, not offset — the sidetone pitch is a DSP shift Flex applies *after* that filter, not something baked into the reported passband. With a symmetric passband, `(low+high)/2` is always `0`, so commit 1's shift was a no-op — the carrier kept landing at 0 Hz, which is exactly the "DC thump" that was reported back.

   The fix: use the radio's actual configured CW pitch (`TransmitModel::cwPitch()`, the same value driving the Flex sidetone/monitor tone) instead of deriving anything from the passband. Move the Kiwi BFO down by the pitch (carrier demodulates to `+pitch` Hz) **and** slide `low_cut`/`high_cut` up by the same amount (so that `+pitch` Hz frequency is still inside the passband instead of getting filtered out). This reproduces, in software, the shift the Flex's own onboard DSP does natively — which is also why Flex antennas never needed this fix in the first place.

   Also plumbed `cwPitch` from `MainWindow` → `KiwiSdrManager` → `KiwiSdrClient::setTrackedSlice()`, and wired a live re-send when the operator changes CW pitch mid-session (`MainWindow_Wiring.cpp`), so an already-active KiwiSDR CW session doesn't go stale if the pitch is adjusted after switching to the Kiwi.

## Test plan
- [x] Added/updated `formatSoundTuneCommand` unit coverage in `tests/kiwi_sdr_protocol_test.cpp` (CW with real symmetric passband + pitch, CW with pitch disabled, USB/LSB unaffected).
- [x] Verified against the real `SET mod=cw low_cut=-400 high_cut=400 freq=...` commands captured in the issue's attached session log.
- [x] Manually verified on real hardware (Flex 6600 + KiwiSDR): tuned-frequency pip stays centered on the signal, CW carrier now produces an audible tone matching the configured CW Pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)