### PR TITLE
Add cached elevation shadows to slice flags

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -58,6 +58,7 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <QtMath>            // qCeil in FlagShadow::paintEvent
 #include <algorithm>
 #include <cmath>
 #include <utility>
@@ -337,8 +338,13 @@ private:
         }
 
         const int pixelCount = pixelSize.width() * pixelSize.height();
-        std::vector<quint8> alpha(static_cast<size_t>(pixelCount));
-        std::vector<quint8> scratch(static_cast<size_t>(pixelCount));
+        // Reused across rebuilds: resize() keeps prior capacity, so a resize
+        // (tab open/close, collapse toggle) doesn't malloc/free tens of KB each
+        // time. Every element is overwritten below before it is read.
+        m_alpha.resize(static_cast<size_t>(pixelCount));
+        m_scratch.resize(static_cast<size_t>(pixelCount));
+        std::vector<quint8>& alpha = m_alpha;
+        std::vector<quint8>& scratch = m_scratch;
         for (int y = 0; y < pixelSize.height(); ++y) {
             const QRgb* row = reinterpret_cast<const QRgb*>(mask.constScanLine(y));
             for (int x = 0; x < pixelSize.width(); ++x) {
@@ -375,6 +381,8 @@ private:
     static constexpr int kShadowAlpha = 150;
 
     QImage m_shadowImage;
+    std::vector<quint8> m_alpha;    // reused blur scratch (see rebuildShadow)
+    std::vector<quint8> m_scratch;
 };
 
 namespace AetherSDR {
@@ -713,11 +721,11 @@ void VfoWidget::mouseReleaseEvent(QMouseEvent* ev)
 
 VfoWidget::~VfoWidget()
 {
+    // The shadow and the close/lock buttons are children of our parent
+    // (SpectrumWidget), not us. During widget tree teardown, Qt may destroy
+    // them before us (they're siblings, not children). QPointer auto-nulls when
+    // the target is deleted, preventing double-free.
     delete m_shadowWidget.data();
-    // Close/lock buttons are children of our parent (SpectrumWidget),
-    // not us. During widget tree teardown, Qt may destroy them before us
-    // (they're siblings, not children). QPointer auto-nulls when the
-    // target is deleted, preventing double-free.
     delete m_closeSliceBtn.data();
     delete m_lockVfoBtn.data();
     delete m_recordBtn.data();

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -61,6 +61,7 @@
 #include <algorithm>
 #include <cmath>
 #include <utility>
+#include <vector>
 #include "core/ThemeManager.h"
 #include "FreqLineEdit.h"
 
@@ -224,6 +225,156 @@ public:
         return (w && w->hasHeightForWidth()) ? w->heightForWidth(width)
                                              : QStackedWidget::heightForWidth(width);
     }
+};
+
+// Lightweight sibling surface for the VFO flag's elevation shadow. Keeping the
+// shadow separate from VfoWidget means live meter repaints do not re-blur the
+// entire flag at animation rate.
+class FlagShadow : public QWidget {
+public:
+    explicit FlagShadow(QWidget* parent)
+        : QWidget(parent)
+    {
+        setObjectName(QStringLiteral("VfoFlagShadow"));
+        setAttribute(Qt::WA_TransparentForMouseEvents);
+        setAttribute(Qt::WA_TranslucentBackground);
+        setAutoFillBackground(false);
+    }
+
+    void setFlagGeometry(const QRect& flagGeometry)
+    {
+        setGeometry(flagGeometry.adjusted(
+            -kHorizontalMargin, -kTopMargin,
+            kHorizontalMargin, kBottomMargin));
+    }
+
+protected:
+    void paintEvent(QPaintEvent*) override
+    {
+        const qreal dpr = devicePixelRatioF();
+        const QSize pixelSize(
+            qMax(1, qCeil(width() * dpr)),
+            qMax(1, qCeil(height() * dpr)));
+        if (m_shadowImage.size() != pixelSize
+            || !qFuzzyCompare(m_shadowImage.devicePixelRatio(), dpr)) {
+            rebuildShadow(pixelSize, dpr);
+        }
+
+        QPainter p(this);
+        p.drawImage(QPoint(0, 0), m_shadowImage);
+    }
+
+private:
+    static void boxBlurPass(const std::vector<quint8>& source,
+                            std::vector<quint8>& target,
+                            int width,
+                            int height,
+                            int radius,
+                            bool horizontal)
+    {
+        const int window = 2 * radius + 1;
+        if (horizontal) {
+            for (int y = 0; y < height; ++y) {
+                int sum = 0;
+                for (int x = 0; x <= radius && x < width; ++x) {
+                    sum += source[static_cast<size_t>(y * width + x)];
+                }
+                for (int x = 0; x < width; ++x) {
+                    target[static_cast<size_t>(y * width + x)] =
+                        static_cast<quint8>(sum / window);
+                    const int removeX = x - radius;
+                    const int addX = x + radius + 1;
+                    if (removeX >= 0) {
+                        sum -= source[static_cast<size_t>(y * width + removeX)];
+                    }
+                    if (addX < width) {
+                        sum += source[static_cast<size_t>(y * width + addX)];
+                    }
+                }
+            }
+            return;
+        }
+
+        for (int x = 0; x < width; ++x) {
+            int sum = 0;
+            for (int y = 0; y <= radius && y < height; ++y) {
+                sum += source[static_cast<size_t>(y * width + x)];
+            }
+            for (int y = 0; y < height; ++y) {
+                target[static_cast<size_t>(y * width + x)] =
+                    static_cast<quint8>(sum / window);
+                const int removeY = y - radius;
+                const int addY = y + radius + 1;
+                if (removeY >= 0) {
+                    sum -= source[static_cast<size_t>(removeY * width + x)];
+                }
+                if (addY < height) {
+                    sum += source[static_cast<size_t>(addY * width + x)];
+                }
+            }
+        }
+    }
+
+    void rebuildShadow(const QSize& pixelSize, qreal dpr)
+    {
+        QImage mask(pixelSize, QImage::Format_ARGB32_Premultiplied);
+        mask.fill(Qt::transparent);
+        {
+            QPainter p(&mask);
+            p.scale(dpr, dpr);
+            p.setRenderHint(QPainter::Antialiasing, true);
+            p.setPen(Qt::NoPen);
+            p.setBrush(QColor(0, 0, 0, kShadowAlpha));
+            const QRectF flagRect(
+                kHorizontalMargin,
+                kTopMargin,
+                width() - 2 * kHorizontalMargin,
+                height() - kTopMargin - kBottomMargin);
+            p.drawRoundedRect(
+                flagRect.translated(0.0, kOffsetY).adjusted(1.0, 1.0, -1.0, -1.0),
+                4.0,
+                4.0);
+        }
+
+        const int pixelCount = pixelSize.width() * pixelSize.height();
+        std::vector<quint8> alpha(static_cast<size_t>(pixelCount));
+        std::vector<quint8> scratch(static_cast<size_t>(pixelCount));
+        for (int y = 0; y < pixelSize.height(); ++y) {
+            const QRgb* row = reinterpret_cast<const QRgb*>(mask.constScanLine(y));
+            for (int x = 0; x < pixelSize.width(); ++x) {
+                alpha[static_cast<size_t>(y * pixelSize.width() + x)] =
+                    static_cast<quint8>(qAlpha(row[x]));
+            }
+        }
+
+        const int radius = qMax(1, qRound(kBoxBlurRadius * dpr));
+        for (int pass = 0; pass < 3; ++pass) {
+            boxBlurPass(
+                alpha, scratch, pixelSize.width(), pixelSize.height(), radius, true);
+            boxBlurPass(
+                scratch, alpha, pixelSize.width(), pixelSize.height(), radius, false);
+        }
+
+        m_shadowImage = QImage(pixelSize, QImage::Format_ARGB32_Premultiplied);
+        for (int y = 0; y < pixelSize.height(); ++y) {
+            QRgb* row = reinterpret_cast<QRgb*>(m_shadowImage.scanLine(y));
+            for (int x = 0; x < pixelSize.width(); ++x) {
+                const quint8 a =
+                    alpha[static_cast<size_t>(y * pixelSize.width() + x)];
+                row[x] = qRgba(0, 0, 0, a);
+            }
+        }
+        m_shadowImage.setDevicePixelRatio(dpr);
+    }
+
+    static constexpr int kHorizontalMargin = 28;
+    static constexpr int kTopMargin = 24;
+    static constexpr int kBottomMargin = 38;
+    static constexpr qreal kBoxBlurRadius = 8.0;
+    static constexpr qreal kOffsetY = 10.0;
+    static constexpr int kShadowAlpha = 150;
+
+    QImage m_shadowImage;
 };
 
 namespace AetherSDR {
@@ -562,6 +713,7 @@ void VfoWidget::mouseReleaseEvent(QMouseEvent* ev)
 
 VfoWidget::~VfoWidget()
 {
+    delete m_shadowWidget.data();
     // Close/lock buttons are children of our parent (SpectrumWidget),
     // not us. During widget tree teardown, Qt may destroy them before us
     // (they're siblings, not children). QPointer auto-nulls when the
@@ -3104,6 +3256,7 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
     m_lastOnLeft = onLeft;
 
     move(newPos);
+    syncShadowGeometry();
 
     // The value labels (drawn by the spectrum's above-flags layer) are anchored to
     // this flag — repaint them as it pans. Only when labels are actually shown.
@@ -3154,6 +3307,46 @@ void VfoWidget::updatePosition(int vfoX, int specTop, FlagDir dir)
         }
         m_collapsedFreqLabel->move(freqX, freqY);
     }
+}
+
+void VfoWidget::syncShadowGeometry()
+{
+    QWidget* flagParent = parentWidget();
+    if (!flagParent) {
+        return;
+    }
+
+    auto* shadow = static_cast<FlagShadow*>(m_shadowWidget.data());
+    if (!shadow) {
+        shadow = new FlagShadow(flagParent);
+        m_shadowWidget = shadow;
+    } else if (shadow->parentWidget() != flagParent) {
+        shadow->setParent(flagParent);
+    }
+
+    shadow->setFlagGeometry(geometry());
+    shadow->stackUnder(this);
+    shadow->setVisible(isVisible());
+}
+
+void VfoWidget::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    syncShadowGeometry();
+}
+
+void VfoWidget::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    syncShadowGeometry();
+}
+
+void VfoWidget::hideEvent(QHideEvent* event)
+{
+    if (m_shadowWidget) {
+        m_shadowWidget->hide();
+    }
+    QWidget::hideEvent(event);
 }
 
 // ── S-Meter bar (custom paint) ────────────────────────────────────────────────
@@ -5961,7 +6154,7 @@ void VfoWidget::reparentFlagSatellites(QWidget* newParent)
     const std::initializer_list<QWidget*> satellites = {
         m_closeSliceBtn.data(), m_lockVfoBtn.data(),
         m_recordBtn.data(), m_playBtn.data(),
-        m_collapsedFreqLabel.data(),
+        m_collapsedFreqLabel.data(), m_shadowWidget.data(),
     };
     for (QWidget* sat : satellites) {
         if (!sat || sat->parentWidget() == newParent) {
@@ -5975,6 +6168,7 @@ void VfoWidget::reparentFlagSatellites(QWidget* newParent)
         sat->setVisible(wasVisible);
         sat->raise();
     }
+    syncShadowGeometry();
 }
 
 } // namespace AetherSDR

--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -58,6 +58,7 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QMouseEvent>
+#include <QImage>            // FlagShadow::m_shadowImage (was transitive only)
 #include <QtMath>            // qCeil in FlagShadow::paintEvent
 #include <algorithm>
 #include <cmath>

--- a/src/gui/VfoWidget.h
+++ b/src/gui/VfoWidget.h
@@ -28,6 +28,9 @@ class QGraphicsOpacityEffect;
 class QDoubleSpinBox;
 class QGridLayout;
 class QPainter;
+class QHideEvent;
+class QResizeEvent;
+class QShowEvent;
 
 namespace AetherSDR {
 
@@ -347,8 +350,12 @@ protected:
     void wheelEvent(QWheelEvent* ev) override;
     void mousePressEvent(QMouseEvent* ev) override;
     void mouseReleaseEvent(QMouseEvent* ev) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
 
 private:
+    void syncShadowGeometry();
     void updateSignalMeterTarget();
     void animateSignalMeter();
     // Build and push the current MeterInput (RX signal vs the selected TX meter)
@@ -518,6 +525,7 @@ private:
     QStackedWidget* m_tabStack{nullptr};
     QWidget*        m_tabBar{nullptr};
     int m_activeTab{-1};
+    QPointer<QWidget> m_shadowWidget;
 
     // Tab content widgets
     // Audio tab


### PR DESCRIPTION
## Summary

Adds a soft elevation shadow behind slice flags to give them a clearer floating appearance over the panadapter. The shadow uses a separate sibling widget with a cached blurred mask, preventing live meter and VFO updates from recalculating the blur every frame. Shadow geometry, visibility, stacking, and multi-pan reparenting remain synchronized with the corresponding slice flag.

## Constitution principle honored

Principle VIII — Evidence Over Assertion. The visual change was validated with placement tests, a real-radio automation run, and an A/B GPU performance comparison against the pristine base commit.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug — not applicable; this is a visual enhancement

Additional validation:

- 163/163 runnable local CTests pass; one intentional quarantine test skipped
- `vfo_flag_placement_test` passes
- Strict engine-boundary validation passes with no blocking findings
- `git diff --check` passes
- Automation bridge confirmed the shadow remained attached to the expected pan with no missing slices
- Compared three timed 3D-rendering samples for the original and shadow implementations on a FLEX-6700:
  - Median GPU work: 279.15 ms/s original, 277.82 ms/s with shadow
  - Median GPU frame time: 6.276 ms original, 6.222 ms with shadow
  - Median main-thread render work: 286.35 ms/s original, 284.83 ms/s with shadow
  - FFT delivery remained approximately 24.65 FPS
- Final radio state confirmed `transmitting=false`, `mox=false`, and `tuning=false`

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — no meter behavior changed
- [x] Documentation updated if user-visible behavior changed — no documentation or interaction changes required
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
