### PR TITLE
fix(hl2): parenthesize std::max to build on Windows/MSVC

### DIFF
--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -113,7 +113,7 @@ QList<MetisClient::Discovered> MetisClient::discover(int timeoutMs, const QHostA
     QElapsedTimer timer;
     timer.start();
     while (timer.elapsed() < timeoutMs) {
-        const int remaining = std::max(1, timeoutMs - static_cast<int>(timer.elapsed()));
+        const int remaining = (std::max)(1, timeoutMs - static_cast<int>(timer.elapsed()));
         if (!sock.waitForReadyRead(remaining))
             continue;
         while (sock.hasPendingDatagrams()) {


### PR DESCRIPTION
`MetisClient::discover()` uses `std::max(1, ...)`, which fails to compile under MSVC when `<windows.h>` is in the include graph (`winsock2.h` is included in this file on Windows). `windows.h` defines a `max` function-like macro, so `std::max(` expands to `std::(1, ...)` — MSVC reports `C2589` (`'(' illegal token on the right side of '::'`) and `C2059`.

Wrapping the call as `(std::max)(...)` suppresses the macro expansion — the standard portable idiom — without changing behaviour or requiring a global `NOMINMAX` define. No other call sites in the HL2 backend are affected (this was the only `std::min`/`std::max` in the `backends/hl2/` sources).

### Context
Found while doing what appears to be the first **Windows/MSVC** build of this branch (Qt 6.10.3, MSVC 14.50), driving the native HL2 backend against a real Hermes-Lite 2 / Radioberry. Without this, `AetherSDR` fails to compile on Windows at `MetisClient.cpp:116`.

### Test
- Builds clean on Windows/MSVC with the change; the branch does not build without it.
- Behaviour is identical (parenthesization only defeats the macro; the `std::max` call is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)