### PR TITLE
Android companion: discovery data-plane spike (thin mobile client)

### DIFF
--- a/prototypes/android-companion/.gitignore
+++ b/prototypes/android-companion/.gitignore
@@ -1,0 +1,2 @@
+build/
+build-*/

--- a/prototypes/android-companion/CMakeLists.txt
+++ b/prototypes/android-companion/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.25)
+
+# Android companion spike — throwaway Phase-0/1 prototype (see README.md).
+# Self-contained on purpose: does NOT link aethercore and is not added to
+# the root build. Configure with the Qt-for-Android kit's qt-cmake.
+project(AetherCompanionSpike VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Gui Qml Quick Network)
+
+qt_standard_project_setup(REQUIRES 6.5)
+
+qt_add_executable(aethercompanion
+    src/main.cpp
+    src/DiscoveryModel.cpp
+    src/DiscoveryModel.h
+)
+
+qt_add_qml_module(aethercompanion
+    URI AetherCompanion
+    VERSION 1.0
+    QML_FILES
+        qml/Main.qml
+)
+
+set_target_properties(aethercompanion PROPERTIES
+    QT_ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android"
+    QT_ANDROID_MIN_SDK_VERSION 28
+    QT_ANDROID_TARGET_SDK_VERSION 35
+)
+
+target_link_libraries(aethercompanion PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::Network
+)

--- a/prototypes/android-companion/README.md
+++ b/prototypes/android-companion/README.md
@@ -1,0 +1,65 @@
+# Android companion spike (mobile thin client)
+
+Throwaway prototype de-risking an **Android companion app** (remote head:
+discovery, connect, tune, RX audio, spectrum) before the aetherd RFC's
+thin-client step lands. Lives in `prototypes/` on purpose — same pattern
+as `prototypes/hl2`: an in-tree mobile client is architecture ahead of
+the RFC (per `AGENTS.md`, maintainer-only), so the unknowns get proven
+cheaply and disposably first. Self-contained: own CMake project, **does
+not link `aethercore`**, root build untouched.
+
+## Unknowns this spike proves
+
+| Phase | Proves |
+|---|---|
+| 1 | Qt 6.11 for Android builds + deploys a C++20 Qt Quick APK |
+| 2 | SmartSDR UDP :4992 discovery broadcast reception on Android WiFi (MulticastLock) |
+| 3 | TCP :4992 command channel + slice tune from touch UI |
+| 4 | RX audio via Qt Multimedia (AAudio) at usable latency |
+| 5 | FFT packet ingest → drag-to-tune spectrum strip in Quick |
+| 6 | Foreground service; RX survives screen lock |
+
+Phases 1–2 are in this tree. Protocol facts mirror
+`src/core/RadioDiscovery.{h,cpp}` (same project — no clean-room needed);
+the spike code itself is original and minimal.
+
+## Build (macOS host)
+
+Prereqs: JDK 21, Android SDK (platform 35, build-tools 35, NDK 27.2),
+Qt 6.11.1 `android_arm64_v8a` + macOS host kit installed via `aqt` under
+`~/Qt`.
+
+```bash
+export ANDROID_SDK_ROOT=/usr/local/share/android-commandlinetools
+~/Qt/6.11.1/android_arm64_v8a/bin/qt-cmake -S . -B build -G Ninja \
+  -DQT_HOST_PATH=$HOME/Qt/6.11.1/macos \
+  -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
+  -DANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/27.2.12479018
+cmake --build build --target apk
+adb install build/android-build/build/outputs/apk/debug/android-build-debug.apk
+```
+
+Phone and radio must share a WiFi/LAN segment; the discovery list
+populates from live broadcasts within ~1 s of a radio being present.
+
+## Emulator validation (no phone / no radio)
+
+Validated 2026-07-24 on the x86_64 emulator: build the
+`android_x86_64` kit variant into `build-x86` (same configure line,
+swap the kit path), then:
+
+```bash
+avdmanager create avd -n spike -k "system-images;android-35;google_apis;x86_64" -d pixel_7
+emulator -avd spike -no-window -no-audio &
+adb install -r build-x86/android-build/build/outputs/apk/debug/android-build-debug.apk
+adb emu 'redir add udp:14992:4992'   # host 14992 → guest 4992
+adb shell am start -n org.aethersdr.companion/org.qtproject.qt.android.bindings.QtActivity
+```
+
+Send synthetic discovery datagrams to `127.0.0.1:14992` (key=value
+payload per `RadioDiscovery.cpp`) and the radio card appears. Host port
+is 14992 because a running desktop AetherSDR already owns UDP 4992.
+
+Emulator proves parse + model + UI only. Still phone-only: real WiFi
+broadcast delivery / MulticastLock behavior (spike phase 2 sign-off)
+— untested until Android hardware is available.

--- a/prototypes/android-companion/android/AndroidManifest.xml
+++ b/prototypes/android-companion/android/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="org.aethersdr.companion"
+          android:installLocation="auto"
+          android:versionCode="1"
+          android:versionName="0.1">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+
+    <application android:name="org.qtproject.qt.android.bindings.QtApplication"
+                 android:label="Aether Companion"
+                 android:hardwareAccelerated="true"
+                 android:requestLegacyExternalStorage="false"
+                 android:allowBackup="true"
+                 android:fullBackupOnly="false">
+        <activity android:name="org.qtproject.qt.android.bindings.QtActivity"
+                  android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+                  android:launchMode="singleTop"
+                  android:screenOrientation="unspecified"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <meta-data android:name="android.app.lib_name"
+                       android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
+            <meta-data android:name="android.app.arguments"
+                       android:value="-- %%INSERT_APP_ARGUMENTS%% --"/>
+            <meta-data android:name="android.app.extract_android_style"
+                       android:value="minimal"/>
+        </activity>
+    </application>
+</manifest>

--- a/prototypes/android-companion/qml/Main.qml
+++ b/prototypes/android-companion/qml/Main.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+    visible: true
+    title: "Aether Companion (spike)"
+
+    header: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 16
+            Label {
+                text: discoveryModel.listening
+                      ? "Listening for radios on UDP 4992…"
+                      : "Discovery socket failed to bind"
+                font.pixelSize: 16
+                Layout.fillWidth: true
+            }
+        }
+    }
+
+    ListView {
+        anchors.fill: parent
+        anchors.margins: 12
+        spacing: 8
+        model: discoveryModel
+
+        delegate: Frame {
+            id: card
+            width: ListView.view.width
+
+            required property string radioModel
+            required property string nickname
+            required property string callsign
+            required property string version
+            required property string status
+            required property string address
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 2
+                Label {
+                    text: card.radioModel
+                          + (card.nickname ? "  ·  " + card.nickname : "")
+                    font.pixelSize: 20
+                    font.bold: true
+                }
+                Label {
+                    text: (card.callsign ? card.callsign + "  ·  " : "")
+                          + card.address + "  ·  v" + card.version
+                    font.pixelSize: 14
+                    opacity: 0.7
+                }
+                Label {
+                    text: card.status
+                    font.pixelSize: 14
+                    color: card.status === "Available" ? "#2e7d32" : "#c62828"
+                }
+            }
+        }
+
+        Label {
+            anchors.centerIn: parent
+            visible: parent.count === 0
+            text: "No radios found yet.\nPhone must be on the same WiFi as the radio."
+            horizontalAlignment: Text.AlignHCenter
+            opacity: 0.6
+            font.pixelSize: 16
+        }
+    }
+}

--- a/prototypes/android-companion/src/DiscoveryModel.cpp
+++ b/prototypes/android-companion/src/DiscoveryModel.cpp
@@ -1,0 +1,157 @@
+#include "DiscoveryModel.h"
+
+#include <QDateTime>
+#include <QNetworkDatagram>
+
+#ifdef Q_OS_ANDROID
+#include <QJniObject>
+#include <QCoreApplication>
+#endif
+
+namespace {
+
+constexpr quint16 kDiscoveryPort = 4992;
+constexpr int kStaleMs = 15000;
+
+#ifdef Q_OS_ANDROID
+// Android drops UDP broadcast unless the app holds a WifiManager
+// MulticastLock. Acquire one for the process lifetime (spike-grade).
+void acquireMulticastLock()
+{
+    static QJniObject lock;
+    if (lock.isValid())
+        return;
+    QJniObject context = QNativeInterface::QAndroidApplication::context();
+    QJniObject wifi = context.callObjectMethod(
+        "getSystemService",
+        "(Ljava/lang/String;)Ljava/lang/Object;",
+        QJniObject::fromString("wifi").object<jstring>());
+    if (!wifi.isValid())
+        return;
+    lock = wifi.callObjectMethod(
+        "createMulticastLock",
+        "(Ljava/lang/String;)Landroid/net/wifi/WifiManager$MulticastLock;",
+        QJniObject::fromString("aethercompanion-discovery").object<jstring>());
+    if (lock.isValid())
+        lock.callMethod<void>("acquire");
+}
+#endif
+
+} // namespace
+
+DiscoveryModel::DiscoveryModel(QObject* parent)
+    : QAbstractListModel(parent)
+{
+    connect(&m_socket, &QUdpSocket::readyRead, this, &DiscoveryModel::onReadyRead);
+    m_staleTimer.setInterval(5000);
+    connect(&m_staleTimer, &QTimer::timeout, this, &DiscoveryModel::onStaleSweep);
+}
+
+int DiscoveryModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : static_cast<int>(m_radios.size());
+}
+
+QVariant DiscoveryModel::data(const QModelIndex& index, int role) const
+{
+    if (!index.isValid() || index.row() >= static_cast<int>(m_radios.size()))
+        return {};
+    const SpikeRadio& r = m_radios[static_cast<size_t>(index.row())];
+    switch (role) {
+    case SerialRole:   return r.serial;
+    case RadioModelRole: return r.model;
+    case NicknameRole: return r.nickname;
+    case CallsignRole: return r.callsign;
+    case VersionRole:  return r.version;
+    case StatusRole:   return r.status;
+    case AddressRole:  return r.address.toString();
+    }
+    return {};
+}
+
+QHash<int, QByteArray> DiscoveryModel::roleNames() const
+{
+    return {
+        {SerialRole, "serial"},
+        {RadioModelRole, "radioModel"},
+        {NicknameRole, "nickname"},
+        {CallsignRole, "callsign"},
+        {VersionRole, "version"},
+        {StatusRole, "status"},
+        {AddressRole, "address"},
+    };
+}
+
+void DiscoveryModel::start()
+{
+    if (m_listening)
+        return;
+#ifdef Q_OS_ANDROID
+    acquireMulticastLock();
+#endif
+    m_listening = m_socket.bind(QHostAddress::AnyIPv4, kDiscoveryPort,
+                                QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint);
+    if (m_listening)
+        m_staleTimer.start();
+    emit listeningChanged();
+}
+
+void DiscoveryModel::onReadyRead()
+{
+    while (m_socket.hasPendingDatagrams()) {
+        const QNetworkDatagram datagram = m_socket.receiveDatagram();
+        SpikeRadio radio;
+        // Datagram is (possibly VITA-framed) text; tokens without '=' are
+        // skipped, so parsing the raw bytes as UTF-8 key=value pairs works.
+        const QString text = QString::fromUtf8(datagram.data()).trimmed();
+        for (const QString& token : text.split(' ', Qt::SkipEmptyParts)) {
+            const int eq = token.indexOf('=');
+            if (eq <= 0)
+                continue;
+            const QString key = token.left(eq).toLower();
+            QString value = token.mid(eq + 1);
+            value.remove(QChar('\0'));
+            if (key == "serial")        radio.serial = value;
+            else if (key == "model")    radio.model = value;
+            else if (key == "nickname") radio.nickname = value;
+            else if (key == "callsign") radio.callsign = value;
+            else if (key == "version")  radio.version = value;
+            else if (key == "status")   radio.status = value;
+            else if (key == "ip")       radio.address = QHostAddress(value);
+        }
+        if (radio.serial.isEmpty())
+            continue;
+        if (radio.address.isNull())
+            radio.address = datagram.senderAddress();
+        radio.lastSeenMs = QDateTime::currentMSecsSinceEpoch();
+        upsert(std::move(radio));
+    }
+}
+
+void DiscoveryModel::upsert(SpikeRadio radio)
+{
+    for (size_t i = 0; i < m_radios.size(); ++i) {
+        if (m_radios[i].serial == radio.serial) {
+            m_radios[i] = std::move(radio);
+            const QModelIndex idx = index(static_cast<int>(i));
+            emit dataChanged(idx, idx);
+            return;
+        }
+    }
+    beginInsertRows({}, static_cast<int>(m_radios.size()),
+                    static_cast<int>(m_radios.size()));
+    m_radios.push_back(std::move(radio));
+    endInsertRows();
+}
+
+void DiscoveryModel::onStaleSweep()
+{
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    for (int i = static_cast<int>(m_radios.size()) - 1; i >= 0; --i) {
+        if (now - m_radios[static_cast<size_t>(i)].lastSeenMs > kStaleMs) {
+            beginRemoveRows({}, i, i);
+            m_radios.erase(m_radios.begin() + i);
+            endRemoveRows();
+        }
+    }
+}

--- a/prototypes/android-companion/src/DiscoveryModel.h
+++ b/prototypes/android-companion/src/DiscoveryModel.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// Minimal SmartSDR discovery listener for the Android companion spike.
+// Original throwaway code; protocol facts (UDP :4992, space-separated
+// key=value datagram) match src/core/RadioDiscovery.{h,cpp}.
+
+#include <QAbstractListModel>
+#include <QHostAddress>
+#include <QTimer>
+#include <QUdpSocket>
+
+#include <vector>
+
+struct SpikeRadio {
+    QString serial;
+    QString model;
+    QString nickname;
+    QString callsign;
+    QString version;
+    QString status;
+    QHostAddress address;
+    qint64 lastSeenMs{0};
+};
+
+class DiscoveryModel : public QAbstractListModel {
+    Q_OBJECT
+    Q_PROPERTY(bool listening READ listening NOTIFY listeningChanged)
+
+public:
+    enum Role {
+        SerialRole = Qt::UserRole + 1,
+        RadioModelRole,
+        NicknameRole,
+        CallsignRole,
+        VersionRole,
+        StatusRole,
+        AddressRole,
+    };
+
+    explicit DiscoveryModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = {}) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    bool listening() const { return m_listening; }
+
+    Q_INVOKABLE void start();
+
+signals:
+    void listeningChanged();
+
+private:
+    void onReadyRead();
+    void onStaleSweep();
+    void upsert(SpikeRadio radio);
+
+    QUdpSocket m_socket;
+    QTimer m_staleTimer;
+    std::vector<SpikeRadio> m_radios;
+    bool m_listening{false};
+};

--- a/prototypes/android-companion/src/main.cpp
+++ b/prototypes/android-companion/src/main.cpp
@@ -1,0 +1,21 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+
+#include "DiscoveryModel.h"
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+
+    DiscoveryModel discovery;
+    discovery.start();
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty("discoveryModel", &discovery);
+    engine.loadFromModule("AetherCompanion", "Main");
+    if (engine.rootObjects().isEmpty())
+        return 1;
+
+    return app.exec();
+}


### PR DESCRIPTION
## Summary

Throwaway `prototypes/` spike de-risking an **Android companion app** (remote head: discovery → connect → tune → RX audio → spectrum) ahead of the aetherd RFC's thin-client step — same pattern as `prototypes/hl2` (#4171). Self-contained Qt Quick project: does **not** link `aethercore`, root build untouched, no EB ratchet or RFC ordering affected (per the AGENTS.md "no architecture ahead of RFC steps" rule, this stays a disposable spike; graduation to an in-tree `mobile/` client is maintainer-gated on RFC step 3).

## Proven (phases 1–2 of the README's table)

- **Qt 6.11 for Android** builds + deploys a C++20 Qt Quick APK (arm64-v8a for hardware, x86_64 for emulator), JDK 21 / SDK 35 / NDK 27.
- **SmartSDR UDP :4992 discovery** datagrams parse into a live radio list — validated end-to-end in the Android 35 emulator (UDP redir + synthetic FLEX-6600 broadcasts; screenshot below). MulticastLock acquired via JNI for real WiFi; hardware sign-off pending an actual phone.

Protocol facts mirror `src/core/RadioDiscovery.{h,cpp}`; spike code is original and minimal. Build + emulator recipes in the README.

## Still open (later phases)

TCP command channel + slice tune (3), RX audio via Qt Multimedia/AAudio (4), drag-to-tune spectrum strip (5), foreground service (6) — each lands as a runnable APK increment in this prototype tree.

## Test plan

- [x] arm64-v8a APK builds (`qt-cmake` + `--target apk`)
- [x] x86_64 APK builds, installs, runs on Android 35 emulator
- [x] Synthetic discovery datagram → radio card renders (model/nickname/callsign/IP/version/status)
- [x] Stale sweep removes radios after broadcasts stop
- [ ] Real-phone WiFi broadcast reception (no Android hardware on hand — 2-minute test when available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)