### PR TITLE
feat(hl2): transmit — SSB modulator, mic/TONE path, PA control and C&C telemetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,6 +528,7 @@ set(CORE_SOURCES
     src/core/backends/hl2/MetisClient.cpp    # aetherd HL2 Phase 1a (UDP wire + RX ingest)
     src/core/backends/hl2/Hl2Spectrum.cpp    # aetherd HL2 Phase 1a (FFT panadapter, FFTW)
     src/core/backends/hl2/Hl2RxDsp.cpp       # aetherd HL2 Phase 1a (IQ -> WdspChannel demod + spectrum)
+    src/core/backends/hl2/Hl2TxDsp.cpp       # SSB transmit chain (TX audio -> baseband IQ)
     src/core/backends/hl2/Hl2Backend.cpp     # aetherd HL2 Phase 1b (IRadioBackend impl)
     src/core/backends/hl2/Hl2Discovery.cpp   # aetherd HL2 Phase 1c (HPSDR discovery -> picker)
     src/core/dsp/WdspChannel.cpp
@@ -3964,6 +3965,11 @@ if(Qt6WebSockets_FOUND)
 endif()
 
 # aetherd RFC 2.3 — MeterModel touchpoint: meter-status wire decode.
+add_executable(hl2_txdsp_test tests/hl2_txdsp_test.cpp)
+target_include_directories(hl2_txdsp_test PRIVATE src)
+target_link_libraries(hl2_txdsp_test PRIVATE aethercore Qt6::Core)
+add_test(NAME hl2_txdsp_test COMMAND hl2_txdsp_test)
+
 add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
 target_include_directories(hl2_tx_loopback_test PRIVATE src)
 target_link_libraries(hl2_tx_loopback_test PRIVATE aethercore Qt6::Core Qt6::Network)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3964,6 +3964,11 @@ if(Qt6WebSockets_FOUND)
 endif()
 
 # aetherd RFC 2.3 — MeterModel touchpoint: meter-status wire decode.
+add_executable(hl2_tx_gate_test tests/hl2_tx_gate_test.cpp)
+target_include_directories(hl2_tx_gate_test PRIVATE src)
+target_link_libraries(hl2_tx_gate_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME hl2_tx_gate_test COMMAND hl2_tx_gate_test)
+
 add_executable(hl2_dbref_test tests/hl2_dbref_test.cpp)
 target_include_directories(hl2_dbref_test PRIVATE src)
 add_test(NAME hl2_dbref_test COMMAND hl2_dbref_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3964,6 +3964,11 @@ if(Qt6WebSockets_FOUND)
 endif()
 
 # aetherd RFC 2.3 — MeterModel touchpoint: meter-status wire decode.
+add_executable(hl2_tx_loopback_test tests/hl2_tx_loopback_test.cpp)
+target_include_directories(hl2_tx_loopback_test PRIVATE src)
+target_link_libraries(hl2_tx_loopback_test PRIVATE aethercore Qt6::Core Qt6::Network)
+add_test(NAME hl2_tx_loopback_test COMMAND hl2_tx_loopback_test)
+
 add_executable(hl2_tx_gate_test tests/hl2_tx_gate_test.cpp)
 target_include_directories(hl2_tx_gate_test PRIVATE src)
 target_link_libraries(hl2_tx_gate_test PRIVATE aethercore Qt6::Core Qt6::Network)

--- a/HERMES.md
+++ b/HERMES.md
@@ -818,7 +818,42 @@ Practical check before claiming a control works: trace the widget's `connect()`
 to the model method it calls, and confirm that method reaches
 `IRadioBackend`. If it only emits `commandReady`, it is Flex-only.
 
-### 14.6 Process failures worth not repeating
+### 14.6 The wrong-sideband bug, and why nothing internal could find it
+
+Transmit went out on the WRONG SIDEBAND for the entire bring-up. The HPSDR wire
+order has the opposite handedness to the standard analytic convention; the
+receive path already compensated (conjugating with `-imag()` before WDSP, the
+fix filed as "USB and LSB are swapped"), and transmit never got the same
+correction.
+
+**Every internal check agreed with the bug**, because the panadapter reads the
+same wire order as the transmitter. Our display and our transmission were
+consistent with each other while both disagreed with the rest of the band:
+
+| Check | Result | Verdict |
+|---|---|---|
+| `hl2_txdsp_test` sideband assertion | 85 dB suppression, "correct" side | passed, asserting the TEXTBOOK convention |
+| `hl2_tx_loopback_test` through hpsdrsim | tone at the expected bin | passed, measuring the sim's feedback in wire order |
+| Panadapter during TX, live radio | clean single sideband, correct side of centre | looked perfect |
+| Forward power, USB vs LSB at 14.200 | 3875 vs 3876 | identical, both "working" |
+| TX FIFO depth | stable 27–31, no under/overflow | refuted the starvation theory |
+
+It was found by an operator with a second receiver: *"I heard the LSB side of
+AetherSDR on the USB side of the Yaesu."*
+
+**The generalisable lesson.** A convention error is invisible to any test that
+shares the convention. Self-consistency is not correctness, and the more
+internal instruments agree, the more confident the wrong answer looks. For
+anything that leaves the machine — RF, a wire format, a file another program
+reads — at least one check must come from **outside the system**: a second
+receiver, a different decoder, an independent implementation. Measuring harder
+inside the loop cannot substitute.
+
+Related: this is why TUNE always worked and voice never did. A tune carrier sits
+at ZERO offset, where handedness has no effect — the one signal that could not
+have exposed the bug was the one that always looked fine.
+
+### 14.7 Process failures worth not repeating
 
 - **`0x39` wedged the radio.** The filter-pipeline reset was validated with 7
   writes spaced ~2 s apart and shipped. A pan drag issues centre commands every
@@ -833,6 +868,9 @@ to the model method it calls, and confirm that method reaches
   stored 10,000,000 MHz. It invalidated several "tested on the live radio"
   claims, and only surfaced because a screenshot's axis looked wrong. *A verb
   that accepts a wrong-unit value without complaint is a silent failure.*
+- **Trusted self-consistent internal instruments.** See §14.6 — the transmitter
+  was on the wrong sideband while every test, meter and display agreed it was
+  right, because they all shared the convention that was wrong.
 - **Verified the layer that could be scripted, not the layer the operator
   presses.** Twice: once as the Hz-for-MHz harness bug, once as MOX keying
   through a model the bridge never touches. See §14.5 — this is the single most
@@ -847,7 +885,7 @@ to the model method it calls, and confirm that method reaches
   that keys a transmitter is a bad trade against fifty lines whose correctness is
   a number a test prints.
 
-### 14.7 Still open
+### 14.8 Still open
 
 - **Absolute watts.** Counts are uncalibrated; oracle §6 forbids presenting them
   as watts. Needs a per-unit calibration curve.

--- a/HERMES.md
+++ b/HERMES.md
@@ -709,3 +709,112 @@ Effort is rough: **XS** under an hour, **S** a session, **M** a few sessions,
 
 Legend: **O** = `hl2-oracle.md`, **A1** = spectrum/audio addendum,
 **A2** = AGC/filtering addendum, **A3** = WDSP channel setup addendum.
+
+---
+
+## 14. Transmit bring-up
+
+RX bring-up was mostly "the audio sounds wrong, find out why". TX was different
+in kind: **every failure was silent**. A transmitter that is misconfigured emits
+nothing, or emits something wrong, and neither announces itself. Nothing in the
+app said "you are not transmitting" — the UI keyed, the meters sat still, and
+the only evidence was the radio's own forward-power counter reading zero.
+
+### 14.1 Four defects between "correct IQ on the wire" and "RF out of the socket"
+
+Each of these, on its own, produced a perfectly correct-looking keyed
+transmission with **zero** forward power. They had to be found in series.
+
+| # | Defect | Why it was invisible |
+|---|---|---|
+| 1 | `onTxAudioReady` returns early without a Flex TX stream id | For Flex that id *is* the destination. Killed the mic **and** the TONE button, because the tone is injected *inside* that callback |
+| 2 | Mic capture never started — `startTxStream()` is called only from Flex DAX signals gated on `mic_selection=PC` | No HL2 session emits those, so `QAudioSource` never opened |
+| 3 | Onboard PA never enabled (`0x09[19]`, C2 bit 3) | Without it the only output is the AD9866's DAC level — milliwatts |
+| 4 | RF power never applied on connect | `rfPowerChanged` is edge-triggered; an untouched control left drive 0, which also leaves the PA off |
+
+**The reusable lesson:** on a transmit path, "the command was accepted" proves
+nothing. The only trustworthy signals are the radio's own telemetry (forward
+power) and physics (PA temperature rising). Both were needed here.
+
+### 14.2 The modulator bug the test caught
+
+The first SSB modulator used a textbook Hilbert transformer, `2/(pi*k)` on odd
+taps. **That filter is all-pass in magnitude.** It passed out-of-band audio at
+full amplitude with a 90-degree shift while the I path correctly rejected it, so
+energy above the passband arrived in Q *alone* — a real signal — and came out
+**double sideband**.
+
+Measured: a 5 kHz tone against a 2700 Hz filter appeared at both +5 kHz and
+−5 kHz, only 6 dB down. Splatter outside our own passband, radiated, and
+**invisible to any loopback that only checks the wanted sideband**.
+
+The fix derives both filters from one analytic prototype,
+`ha[k] = (exp(j·2π·hi·k) − exp(j·2π·lo·k)) / (j·2π·k)`, so I and Q share a
+passband by construction and their group delay matches for free. Rejection went
+from 6 dB to 100 dB; opposite-sideband suppression is 85 dB.
+
+### 14.3 Protocol facts established
+
+| Fact | Detail |
+|---|---|
+| PA enable | `0x09[19]` = C2 bit 3. **Mandatory** for useful output |
+| TX NCO | `0x01`, a **separate oscillator** from the RX DDC — it does not follow the receiver. Unset, a key transmits at DC |
+| Host→radio samples | **16-bit** I + 16-bit Q, unlike EP6's 24-bit |
+| EADDR trap | The first 32-bit word after each frame's C&C is the extended-address register, **not** headphone audio. A memcpy'd Hermes TX layout corrupts it |
+| MOX | C0 bit 0 of **every** frame, not a register. Both sub-frames must carry it or keying is cadence-dependent |
+| EP6 response C0 | `ACK` (bit 7) **changes how the rest of C0 decodes**: ACK=0 → RADDR in `[6:3]` (4 bits) + Dot/Dash/PTT; ACK=1 → RADDR in `[6:1]` (6 bits) |
+| TX inhibit | **Active low** — the bit is SET when transmit is permitted |
+| SWR | Counts are **voltage**-proportional → `(Vf+Vr)/(Vf−Vr)`, **no square root**. Validated by reading 1.0:1 into a dummy load |
+
+### 14.4 Seam gaps this phase exposed
+
+Two verbs existed and were wired to nothing at all:
+
+- **`IRadioBackend::meterUpdate`** — `meterDefined`/`meterRemoved` were connected
+  in `RadioModel`; values were not, because Flex streams them over VITA-49. Every
+  meter reading this backend computed was discarded. The S-meter had been correct
+  for days and had never once been visible.
+- **`IRadioBackend::setKeying`** — no callers anywhere. `RadioModel::setTransmit`
+  ended in `sendCmd("xmit N")`, a raw Flex text command, so **no non-Flex backend
+  could ever be keyed**.
+
+The pattern: a seam verb with no consumer looks identical to a working one from
+below. Grep for callers of every verb a new backend implements, before trusting
+that implementing it does anything.
+
+### 14.5 Process failures worth not repeating
+
+- **`0x39` wedged the radio.** The filter-pipeline reset was validated with 7
+  writes spaced ~2 s apart and shipped. A pan drag issues centre commands every
+  33 ms, so it fired ~30 resets/second and the board halted its stream and
+  stopped answering discovery until power-cycled. *Validate at the rate the UI
+  actually produces, not at the rate that is convenient to test.*
+- **Documenting a risk is not retiring it.** That same commit stated plainly
+  that the zero-fields assumption had never been checked against the gateware
+  RTL — and shipped anyway.
+- **Hz vs MHz.** The automation `tune` verb takes **MHz**. The harness passed Hz
+  for most of a session; every call returned `ok: true` and the model faithfully
+  stored 10,000,000 MHz. It invalidated several "tested on the live radio"
+  claims, and only surfaced because a screenshot's axis looked wrong. *A verb
+  that accepts a wrong-unit value without complaint is a silent failure.*
+- **Test capture artifacts produced three wrong conclusions.** Block-buffered
+  simulator stdout, `script` writing past a truncation, and reading a log delta
+  before the pty flushed each looked like "the feature does not work". Add a
+  settle delay and read by byte offset before concluding anything from a log.
+- **Prefer measurable correctness over canonical implementation.** WDSP's TXA
+  works (`wdsp_channel_test` proves it), but driven from this backend's config it
+  returned underruns and zeros. Chasing an undocumented init sequence for a path
+  that keys a transmitter is a bad trade against fifty lines whose correctness is
+  a number a test prints.
+
+### 14.6 Still open
+
+- **Absolute watts.** Counts are uncalibrated; oracle §6 forbids presenting them
+  as watts. Needs a per-unit calibration curve.
+- **FIFO-servoed TX pacing.** The decoded depth follows hpsdrsim's layout, and
+  the oracle's §6 table disagrees in a way that cannot both be right. **The
+  gateware RTL has not been consulted.** Nothing may build pacing on that field
+  until it has been.
+- **PA temperature formula** is the HL2 wiki's, unverified against a reference.
+  29.5 °C idle → 34 °C under load is plausible, not calibrated.
+- **`0x0e` T/R gain switch** and PureSignal's feedback path.

--- a/HERMES.md
+++ b/HERMES.md
@@ -782,7 +782,43 @@ The pattern: a seam verb with no consumer looks identical to a working one from
 below. Grep for callers of every verb a new backend implements, before trusting
 that implementing it does anything.
 
-### 14.5 Process failures worth not repeating
+### 14.5 Testing UX: exercise BOTH RadioModel and TransmitModel
+
+**The automation bridge is not a test of the user interface.** The two drive
+different models, and a verb that reaches the radio proves nothing about the
+button that is supposed to.
+
+| Path | Route | Reaches the seam? |
+|---|---|---|
+| Bridge `key ptt` | `RadioModel::setTransmit()` → `IRadioBackend::setKeying()` | yes |
+| **MOX button** | `TransmitModel::requestPttOn()` → `setMox()` → `commandReady("xmit 1")` | **no** — Flex TCP text |
+| **TUNE button** | `TransmitModel::startTune()` → `commandReady("transmit tune 1")` | **no** — same |
+| Bridge `tune` verb | `SliceModel::setFrequency()` | n/a |
+
+This produced a genuinely absurd state: hardware testing showed **1080 counts of
+forward power and a PA warming to 34 °C**, and the operator pressing MOX
+transmitted nothing. Every automated check passed. The operator's first attempt
+failed.
+
+**The rule:** when verifying anything user-facing — buttons, meters, keying,
+tune — exercise **both** models:
+
+- `RadioModel` is what the bridge and other clients drive.
+- `TransmitModel` is what the GUI controls drive, and it emits **Flex command
+  strings** (`xmit`, `transmit tune`, `transmit set rfpower=`) that reach a
+  backend with no command channel *not at all*.
+
+Any TransmitModel action that must work on a non-Flex backend needs a **typed
+signal** routed through the seam, gated to non-Flex families so Flex does not
+receive the command twice. `rfPowerChanged`, `moxCommandIssued` and
+`tuneCommandIssued` are the existing examples; the next one added should follow
+that shape.
+
+Practical check before claiming a control works: trace the widget's `connect()`
+to the model method it calls, and confirm that method reaches
+`IRadioBackend`. If it only emits `commandReady`, it is Flex-only.
+
+### 14.6 Process failures worth not repeating
 
 - **`0x39` wedged the radio.** The filter-pipeline reset was validated with 7
   writes spaced ~2 s apart and shipped. A pan drag issues centre commands every
@@ -797,6 +833,10 @@ that implementing it does anything.
   stored 10,000,000 MHz. It invalidated several "tested on the live radio"
   claims, and only surfaced because a screenshot's axis looked wrong. *A verb
   that accepts a wrong-unit value without complaint is a silent failure.*
+- **Verified the layer that could be scripted, not the layer the operator
+  presses.** Twice: once as the Hz-for-MHz harness bug, once as MOX keying
+  through a model the bridge never touches. See §14.5 — this is the single most
+  expensive recurring mistake of the bring-up.
 - **Test capture artifacts produced three wrong conclusions.** Block-buffered
   simulator stdout, `script` writing past a truncation, and reading a log delta
   before the pty flushed each looked like "the feature does not work". Add a
@@ -807,7 +847,7 @@ that implementing it does anything.
   that keys a transmitter is a bad trade against fifty lines whose correctness is
   a number a test prints.
 
-### 14.6 Still open
+### 14.7 Still open
 
 - **Absolute watts.** Counts are uncalibrated; oracle §6 forbids presenting them
   as watts. Needs a per-unit calibration curve.

--- a/HERMES.md
+++ b/HERMES.md
@@ -765,6 +765,8 @@ from 6 dB to 100 dB; opposite-sideband suppression is 85 dB.
 | EP6 response C0 | `ACK` (bit 7) **changes how the rest of C0 decodes**: ACK=0 → RADDR in `[6:3]` (4 bits) + Dot/Dash/PTT; ACK=1 → RADDR in `[6:1]` (6 bits) |
 | TX inhibit | **Active low** — the bit is SET when transmit is permitted |
 | SWR | Counts are **voltage**-proportional → `(Vf+Vr)/(Vf−Vr)`, **no square root**. Validated by reading 1.0:1 into a dummy load |
+| **Wire handedness** | The wire is the **conjugate** of the standard analytic convention. RX compensates with `-imag()` before WDSP; **TX must conjugate too**. Omitting it transmits every signal on the wrong sideband — see §14.6 |
+| PA enable vs handedness | A tune carrier sits at **zero offset**, where handedness has no effect. TUNE therefore works even when the sideband convention is wrong, and is useless as evidence for it |
 
 ### 14.4 Seam gaps this phase exposed
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -7725,7 +7725,9 @@ void AudioEngine::onTxAudioReady()
     if (!m_micBuffer || !m_audioSource) return;
     if (m_audioSource->state() == QAudio::StoppedState) return;
     if (!m_micBuffer->isOpen()) return;
-    if (m_txStreamId == 0 && m_remoteTxStreamId == 0) return;
+    // A host-modulating backend has no Flex stream id and never will; the
+    // audio's destination is the local modulator. See setHostModulation().
+    if (!m_hostModulation && m_txStreamId == 0 && m_remoteTxStreamId == 0) return;
     qint64 avail = m_micBuffer->pos();
     if (avail <= 0) return;
     QByteArray data = m_micBuffer->data();
@@ -7733,7 +7735,8 @@ void AudioEngine::onTxAudioReady()
     m_micBuffer->seek(0);
     if (data.isEmpty()) return;
 #else
-    if (!m_micDevice || (m_txStreamId == 0 && m_remoteTxStreamId == 0)) return;
+    if (!m_micDevice
+        || (!m_hostModulation && m_txStreamId == 0 && m_remoteTxStreamId == 0)) return;
     QByteArray data = m_micDevice->readAll();
     if (data.isEmpty()) return;
     m_txReceivedAnyBytes = true;  // disarms the WASAPI silent-open watchdog (#2929)

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -78,6 +78,7 @@ class AudioEngine : public QObject {
 
 public:
     static constexpr int DEFAULT_SAMPLE_RATE = 24000;
+    bool m_hostModulation = false;
 
     struct ReceivePresentationAudioQueues {
         int playbackQueuedMs{0};
@@ -119,6 +120,16 @@ public:
 
     // TX (microphone) – capture audio and send VITA-49 packets to radio
     Q_INVOKABLE bool startTxStream(const QHostAddress& radioAddress, quint16 radioPort);
+
+    // Host-modulating backend (HL2): run the TX audio chain even though no Flex
+    // stream id will ever be assigned.
+    //
+    // onTxAudioReady() gates on a stream id because for Flex that id IS the
+    // destination — no id means nowhere to send. A backend that modulates
+    // locally has a destination regardless, and the gate silently disabled the
+    // test tone as well, since the tone is injected inside that callback.
+    Q_INVOKABLE void setHostModulation(bool on) { m_hostModulation = on; }
+    bool hostModulation() const { return m_hostModulation; }
     Q_INVOKABLE void stopTxStream();
 
     // Set the DAX TX stream ID (from radio's response to "stream create type=dax_tx")

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -5438,6 +5438,7 @@ QJsonObject AutomationServer::doTxTest(const QString& action)
                                       "set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
         tx.startTwoToneTune();
         m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();  // arm watchdog window
+        m_txBridgeInitiated = true;   // the watchdog polices scripts, not people
         qCInfo(lcAutomation) << "txtest two-tone started (ALLOW_TX)";
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("txtest"), QStringLiteral("twotone")}};
     }
@@ -5464,6 +5465,7 @@ QJsonObject AutomationServer::doAtu(const QString& action)
                                       "set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
         tx.atuStart();
         m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();
+        m_txBridgeInitiated = true;
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("atu"), QStringLiteral("start")}};
     }
     return err(QStringLiteral("unknown atu action: ") + action + QStringLiteral(" (bypass|start)"));
@@ -5484,6 +5486,7 @@ void AutomationServer::forceUnkey(const char* reason)
     // effect until the buffer drained — defeating the all-stop guarantee. (#3646)
     m_radioModel->cwxModel().clearBuffer();
     m_txKeyedSinceMs = 0;
+    m_txBridgeInitiated = false;
     qCWarning(lcAutomation).noquote() << "TX force-unkey:" << reason;
 }
 
@@ -5499,8 +5502,28 @@ void AutomationServer::onTxWatchdog()
     const bool keyed = tx.isTransmitting() || tx.isTuning() || tx.isMox();
     if (!keyed) {
         m_txKeyedSinceMs = 0;
+        m_txBridgeInitiated = false;
         return;
     }
+
+    // ONLY police transmissions THIS BRIDGE STARTED.
+    //
+    // This watchdog exists as a backstop against a runaway script — something
+    // that keys and then crashes, loops, or loses its connection. It is not a
+    // transmit time limit for the operator, and it has no business being one:
+    // a net, a long over or a leisurely tune are all normal, and 20 seconds is
+    // nowhere near long enough for any of them.
+    //
+    // It previously armed on ANY keying, because it polls the transmit model
+    // rather than tracking who keyed. With the bridge enabled — which is a
+    // persisted setting, so it is on for ordinary sessions — the operator's own
+    // MOX and TUNE were force-unkeyed at exactly 20 seconds, mid-sentence, with
+    // nothing in the UI to explain it.
+    if (!m_txBridgeInitiated) {
+        m_txKeyedSinceMs = 0;
+        return;
+    }
+
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
     if (m_txKeyedSinceMs == 0)
         m_txKeyedSinceMs = now;
@@ -6098,6 +6121,7 @@ QJsonObject AutomationServer::doKey(const QString& name, const QString& arg)
                        + QStringLiteral("' keys the transmitter — set AETHER_AUTOMATION_ALLOW_TX=1 to allow"));
         m_radioModel->setTransmit(true);               // == space-bar PTT press (Mox)
         m_txKeyedSinceMs = QDateTime::currentMSecsSinceEpoch();  // arm watchdog window
+        m_txBridgeInitiated = true;   // the watchdog polices scripts, not people
         qCInfo(lcAutomation).noquote() << "key" << what << "ON (ALLOW_TX)";
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("key"), what},
                            {QStringLiteral("state"), QStringLiteral("on")}};

--- a/src/core/AutomationServer.h
+++ b/src/core/AutomationServer.h
@@ -720,6 +720,11 @@ private:
     QTimer* m_txWatchdog{nullptr};
     qint64  m_txKeyedSinceMs{0};   // when continuous key-down started (0 = idle)
     int     m_txMaxKeyMs{20000};   // max continuous key time before force-unkey
+    // True while the transmission in progress was started BY THIS BRIDGE. The
+    // watchdog above is a runaway-script backstop, not an operator time limit,
+    // so it enforces only when this is set — otherwise it force-unkeys a human
+    // holding MOX mid-sentence.
+    bool    m_txBridgeInitiated{false};
     int     m_txMaxPower{-1};      // power-ceiling clamp for invoke (-1 = off)
     bool    m_txAllowed{false};    // AETHER_AUTOMATION_ALLOW_TX at start()
     bool    m_readOnly{false};     // observe-only gate (#4188 area 6)

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -98,6 +98,22 @@ public:
     // capabilities().canTransmit is false implements this as a no-op.
     virtual void setKeying(bool key) = 0;
 
+    // Processed transmit audio, int16 interleaved stereo at sampleRateHz.
+    //
+    // For backends that modulate on the host (HL2). A Flex radio does its own
+    // modulation from mic or DAX, so FlexBackend ignores this — hence a default
+    // no-op rather than a pure virtual.
+    //
+    // The audio is already shaped: AudioEngine has applied the test tone,
+    // compressor and EQ before this point. That is deliberate — the TONE button,
+    // the microphone and any future source all reach the air through ONE path,
+    // so what the operator monitors is what gets transmitted.
+    virtual void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+    {
+        Q_UNUSED(int16Stereo);
+        Q_UNUSED(sampleRateHz);
+    }
+
     // ---- vendor extensions (namespaced, capability-advertised) ----
     // Vendor-specific verbs that are NOT part of the core profile. Clients
     // discover available namespaces via capabilities().extensionNamespaces.

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -108,6 +108,12 @@ public:
     // compressor and EQ before this point. That is deliberate — the TONE button,
     // the microphone and any future source all reach the air through ONE path,
     // so what the operator monitors is what gets transmitted.
+    // Tune carrier on/off.
+    //
+    // Flex takes "transmit tune N" as a text command, so FlexBackend has nothing
+    // to do here. A backend that generates its own carrier implements it.
+    virtual void setTune(bool on) { Q_UNUSED(on); }
+
     // Transmit power as a percentage, 0..100.
     //
     // Flex takes this as a text command from TransmitModel, so FlexBackend has

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -108,6 +108,13 @@ public:
     // compressor and EQ before this point. That is deliberate — the TONE button,
     // the microphone and any future source all reach the air through ONE path,
     // so what the operator monitors is what gets transmitted.
+    // Transmit power as a percentage, 0..100.
+    //
+    // Flex takes this as a text command from TransmitModel, so FlexBackend has
+    // nothing to do here. A backend that owns its own drive register (HL2)
+    // implements it.
+    virtual void setTxPower(int percent) { Q_UNUSED(percent); }
+
     virtual void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
     {
         Q_UNUSED(int16Stereo);

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -508,6 +508,26 @@ void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)
         Q_ARG(double, offsetHz), Q_ARG(double, amplitude));
 }
 
+void Hl2Backend::setTune(bool on)
+{
+    // A tune carrier is an unmodulated steady signal at the transmit frequency.
+    // The HL2 has no tune generator of its own, so it is the built-in test tone
+    // at ZERO offset — a carrier exactly on the TX NCO — with keying held for as
+    // long as tune is engaged.
+    //
+    // Ordering matters in both directions: bring the carrier up BEFORE keying so
+    // the first frames on the air already carry it rather than silence, and drop
+    // the key BEFORE the carrier on the way out so nothing is left radiating if
+    // the tone clear is delayed behind other queued control verbs.
+    if (on) {
+        setTxTestTone(0.0, kTuneCarrierAmplitude);
+        setKeying(true);
+    } else {
+        setKeying(false);
+        setTxTestTone(0.0, 0.0);
+    }
+}
+
 void Hl2Backend::setTxPower(int percent)
 {
     // The operator's 0..100 maps onto the HL2's 0..255 drive field. The gateware

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -443,13 +443,37 @@ void Hl2Backend::setKeying(bool key)
         return;
     }
     m_keyed = key;
+    // A VOICE key must never inherit a TUNE carrier.
+    //
+    // The packet builder prefers the tone over queued audio, so a tune carrier
+    // left running turns every subsequent PTT into an unmodulated carrier — the
+    // operator keys, the radio transmits, and not one word goes out. That is
+    // exactly what a latched TUNE produced.
+    //
+    // Only a tone that TUNE itself raised is cleared here. A tone an operator
+    // asked for explicitly is theirs, and keying is how they transmit it —
+    // clearing that indiscriminately broke exactly that case.
+    if (key && !m_tuning && m_toneFromTune)
+        setTxTestTone(0.0, 0.0);
+    if (!key)
+        m_tuning = false;   // an unkey ends tune too, however it was started
     if (m_metis)
         QMetaObject::invokeMethod(m_metis, "setMox", Qt::QueuedConnection,
             Q_ARG(bool, key));
-    if (!key && m_txDsp) {
-        // Drop buffered audio and filter history on unkey, so the next
-        // transmission does not open with the tail of the previous one.
-        QMetaObject::invokeMethod(m_txDsp, "reset", Qt::QueuedConnection);
+    if (!key) {
+        // Drop buffered audio on unkey so the next transmission does not open
+        // with the tail of the previous one. BOTH stages hold audio and both
+        // have to be cleared: the modulator's input buffer and filter history,
+        // AND the wire queue behind it.
+        //
+        // Resetting only the modulator was not enough, and the gap was visible
+        // on hardware — a key with no audio at all still produced ~1000 counts
+        // of forward power for a moment, which was the previous transmission's
+        // last half second going out on the air.
+        if (m_txDsp)
+            QMetaObject::invokeMethod(m_txDsp, "reset", Qt::QueuedConnection);
+        if (m_metis)
+            QMetaObject::invokeMethod(m_metis, "flushTxIq", Qt::QueuedConnection);
     }
 }
 
@@ -500,6 +524,10 @@ void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)
 {
     if (!m_metis)
         return;
+    // Whoever calls this owns the tone. setTune() re-asserts ownership straight
+    // after, which is what lets keying distinguish "a carrier TUNE left behind"
+    // from "a tone the operator asked for".
+    m_toneFromTune = false;
     if (amplitude > 0.0 && !m_txAllowed) {
         qWarning() << "Hl2Backend: test tone refused — transmit not available";
         return;
@@ -519,8 +547,10 @@ void Hl2Backend::setTune(bool on)
     // the first frames on the air already carry it rather than silence, and drop
     // the key BEFORE the carrier on the way out so nothing is left radiating if
     // the tone clear is delayed behind other queued control verbs.
+    m_tuning = on;
     if (on) {
         setTxTestTone(0.0, kTuneCarrierAmplitude);
+        m_toneFromTune = true;   // set AFTER: setTxTestTone clears the flag
         setKeying(true);
     } else {
         setKeying(false);

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -6,6 +6,8 @@
 #include "core/backends/hl2/MetisClient.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
+#include "core/AutomationBridgeSettings.h"
+
 #include <QByteArray>
 #include <QHostAddress>
 
@@ -61,12 +63,37 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     m_metis = new MetisClient(nullptr);
     m_dsp = new Hl2RxDsp(nullptr);
 
-    // Transmit is OFF unless explicitly enabled for this process. Read once here
-    // rather than per-key so the answer cannot change under a running key.
-    m_txAllowed = qEnvironmentVariableIsSet("AETHER_HL2_ALLOW_TX");
+    // Transmit availability, decided once here rather than per-key so the answer
+    // cannot change under a running key.
+    //
+    // A normal interactive run can transmit: this is a transceiver, and an
+    // operator at the keyboard keying their own radio needs no special flag.
+    //
+    // An AUTOMATION run defers to the bridge's existing TX gate
+    // (AETHER_AUTOMATION_ALLOW_TX). That gate already exists precisely because
+    // a scripted client that can key is a different risk from a human at the
+    // controls, and adding a second, HL2-specific variable alongside it would
+    // have meant two things to get right instead of one -- and a script that
+    // satisfied the automation gate but silently could not key.
+    const bool automation = qEnvironmentVariableIsSet("AETHER_AUTOMATION");
+    // The bridge's TX gate has TWO sources and both must be honoured, or this
+    // backend disagrees with the layer the operator actually configured:
+    // AutomationServer::start() reads the env var, and MainWindow applies the
+    // persisted GUI toggle through setTxAllowed(). Checking only the env var
+    // meant the bridge would accept a key, log "key ptt ON" and return ok:true
+    // while nothing keyed — a silent disagreement, which is worse than either
+    // answer on its own.
+    const bool automationAllowsTx =
+        qEnvironmentVariableIsSet("AETHER_AUTOMATION_ALLOW_TX")
+        || AutomationBridgeSettings::txAllowed();
+    m_txAllowed = !automation || automationAllowsTx;
     if (m_txAllowed) {
-        qWarning() << "Hl2Backend: TRANSMIT ENABLED (AETHER_HL2_ALLOW_TX)";
         m_metis->enableTransmit(true);
+        qInfo() << "Hl2Backend: transmit available"
+                << (automation ? "(automation, ALLOW_TX)" : "(interactive)");
+    } else {
+        qInfo() << "Hl2Backend: transmit BLOCKED — automation bridge active "
+                   "without AETHER_AUTOMATION_ALLOW_TX";
     }
 
     m_ioThread = new QThread(this);
@@ -375,8 +402,8 @@ void Hl2Backend::setKeying(bool key)
     // and the cost of a wrong key is an unintended emission.
     if (!m_txAllowed) {
         if (key)
-            qWarning() << "Hl2Backend: key refused — transmit not enabled"
-                       << "(set AETHER_HL2_ALLOW_TX=1)";
+            qWarning() << "Hl2Backend: key refused — automation bridge is active "
+                          "without AETHER_AUTOMATION_ALLOW_TX";
         return;
     }
     if (m_metis)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -723,6 +723,14 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
         qCDebug(lcHl2Tx) << "HL2 directional: fwd" << *t.forwardPowerRaw
                          << "rev" << t.reversePowerRaw.value_or(-1);
     }
+    // TX IQ FIFO depth — the oracle calls this the most important number in the
+    // protocol. A queue-fed transmission can starve the radio's buffer in a way
+    // a per-packet generated tone never can, so this is what distinguishes
+    // "the audio is wrong" from "the audio never arrived".
+    if (m_keyed && t.txFifoCount)
+        qCDebug(lcHl2Tx) << "HL2 fifo:" << *t.txFifoCount
+                         << "under" << t.txFifoUnderflow.value_or(false)
+                         << "over" << t.txFifoOverflow.value_or(false);
     if (t.temperatureRaw)
         emit meterUpdate(QStringLiteral("RAD:PATEMP"), temperatureCelsius(*t.temperatureRaw));
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "core/backends/hl2/Hl2RxDsp.h"
+#include "core/backends/hl2/Hl2TxDsp.h"
 #include "core/backends/hl2/MetisClient.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
@@ -62,6 +63,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     // destroyed explicitly in the destructor after the thread is joined.
     m_metis = new MetisClient(nullptr);
     m_dsp = new Hl2RxDsp(nullptr);
+    m_txDsp = new Hl2TxDsp(nullptr);
 
     // Transmit availability, decided once here rather than per-key so the answer
     // cannot change under a running key.
@@ -100,6 +102,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     m_ioThread->setObjectName(QStringLiteral("hl2-io"));
     m_metis->moveToThread(m_ioThread);
     m_dsp->moveToThread(m_ioThread);
+    m_txDsp->moveToThread(m_ioThread);
     m_ioThread->start();
 
     // Wire: raw IQ -> DSP. Both objects live on the I/O thread, so this stays a
@@ -144,6 +147,15 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     });
     connect(m_dsp, &Hl2RxDsp::audioReady, this,
             [this](const std::vector<float>& pcm) { emit audioFrameReady(floatBytes(pcm)); });
+    // Modulated IQ -> the wire. Both live on the I/O thread, so this is a direct
+    // call and the transmit path never touches the GUI thread.
+    connect(m_txDsp, &Hl2TxDsp::iqReady, m_metis,
+            [this](const std::vector<std::complex<float>>& iq) {
+        m_metis->queueTxIq(iq);
+    });
+    connect(m_txDsp, &Hl2TxDsp::micPeak, this,
+            [this](float dbfs) { emit meterUpdate(QStringLiteral("TX:MICPEAK"), dbfs); });
+
     connect(m_metis, &MetisClient::telemetryUpdated, this,
             [this](const Hl2Telemetry& t) { publishTelemetry(t); });
     connect(m_dsp, &Hl2RxDsp::meterUpdate, this,
@@ -169,6 +181,7 @@ Hl2Backend::~Hl2Backend()
         QMetaObject::invokeMethod(m_metis, "stop");
     }
     // Safe now: the thread is joined, so nothing can be running in either object.
+    delete m_txDsp;
     delete m_dsp;
     delete m_metis;
 }
@@ -254,6 +267,19 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     // ZERO is deliberate: this backend has no drive-level control wired to the
     // UI yet, so anything higher would be an un-commanded power level chosen by
     // a default. An operator raising it explicitly is the only way it should go up.
+    Hl2TxDsp::Config tc;
+    tc.inputSampleRateHz = 24000;    // AudioEngine's rate; submitTxAudio re-checks
+    tc.outputSampleRateHz = 48000;   // EP2 is fixed at 48 kHz
+    tc.mode = modeFromString(m_mode);
+    std::string txErr;
+    bool txOk = false;
+    QMetaObject::invokeMethod(m_txDsp, [this, &tc, &txErr, &txOk] {
+        txOk = m_txDsp->configure(tc, &txErr);
+    }, Qt::BlockingQueuedConnection);
+    if (!txOk)
+        qWarning() << "Hl2Backend: TX DSP unavailable —"
+                   << QString::fromStdString(txErr) << "(receive is unaffected)";
+
     setTxDriveLevel(0);
 
     // Initial slice/pan state is published from the linkUp handler above, once
@@ -326,6 +352,11 @@ void Hl2Backend::setSliceMode(int /*sliceId*/, const QString& mode)
     m_mode = mode;
     if (m_dsp)
         QMetaObject::invokeMethod(m_dsp, "setMode", Qt::QueuedConnection,
+            Q_ARG(WdspChannel::Mode, modeFromString(mode)));
+    // The transmit sideband follows the slice. Without this, switching to LSB
+    // would receive on the lower sideband and still transmit on the upper.
+    if (m_txDsp)
+        QMetaObject::invokeMethod(m_txDsp, "setMode", Qt::QueuedConnection,
             Q_ARG(WdspChannel::Mode, modeFromString(mode)));
     emitSliceState();
 }
@@ -408,9 +439,15 @@ void Hl2Backend::setKeying(bool key)
                           "without AETHER_AUTOMATION_ALLOW_TX";
         return;
     }
+    m_keyed = key;
     if (m_metis)
         QMetaObject::invokeMethod(m_metis, "setMox", Qt::QueuedConnection,
             Q_ARG(bool, key));
+    if (!key && m_txDsp) {
+        // Drop buffered audio and filter history on unkey, so the next
+        // transmission does not open with the tail of the previous one.
+        QMetaObject::invokeMethod(m_txDsp, "reset", Qt::QueuedConnection);
+    }
 }
 
 void Hl2Backend::setTxFrequency(double hz)
@@ -419,6 +456,41 @@ void Hl2Backend::setTxFrequency(double hz)
         return;
     QMetaObject::invokeMethod(m_metis, "setTxFrequencyHz", Qt::QueuedConnection,
         Q_ARG(std::uint32_t, static_cast<std::uint32_t>(hz)));
+}
+
+void Hl2Backend::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+{
+    // Only modulate while actually keyed. Feeding the modulator unkeyed would
+    // fill the transmit queue with audio that goes out the instant MOX asserts —
+    // the operator would hear the last second of the shack on their first
+    // syllable.
+    if (!m_txDsp || !m_keyed || int16Stereo.isEmpty())
+        return;
+    if (sampleRateHz != 24000) {
+        // Stated rather than silently resampled: the modulator's upsampler
+        // assumes this rate, and a mismatch transmits at the wrong pitch.
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            qWarning() << "Hl2Backend: TX audio arrived at" << sampleRateHz
+                       << "Hz, expected 24000 — not transmitting";
+        }
+        return;
+    }
+
+    // Interleaved stereo to mono. AudioEngine duplicates the mic across both
+    // channels, so averaging is right for that and still sane if they differ.
+    const auto* pcm = reinterpret_cast<const qint16*>(int16Stereo.constData());
+    const int frames = static_cast<int>(int16Stereo.size() / sizeof(qint16)) / 2;
+    std::vector<float> mono(static_cast<std::size_t>(frames));
+    for (int n = 0; n < frames; ++n) {
+        const float l = static_cast<float>(pcm[2 * n]) / 32768.0f;
+        const float r = static_cast<float>(pcm[2 * n + 1]) / 32768.0f;
+        mono[static_cast<std::size_t>(n)] = 0.5f * (l + r);
+    }
+    QMetaObject::invokeMethod(m_txDsp, [this, mono = std::move(mono)] {
+        m_txDsp->processAudioBlock(mono);
+    }, Qt::QueuedConnection);
 }
 
 void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -11,8 +11,11 @@
 
 #include <QByteArray>
 #include <QHostAddress>
+#include <QLoggingCategory>
 
 #include <cstdint>
+
+Q_LOGGING_CATEGORY(lcHl2Tx, "aether.hl2.tx")
 
 namespace AetherSDR::hl2 {
 
@@ -505,6 +508,16 @@ void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)
         Q_ARG(double, offsetHz), Q_ARG(double, amplitude));
 }
 
+void Hl2Backend::setTxPower(int percent)
+{
+    // The operator's 0..100 maps onto the HL2's 0..255 drive field. The gateware
+    // only decodes the top nibble, so the effective resolution is coarser than
+    // this suggests — the mapping is linear in the register, NOT calibrated to
+    // watts, and nothing here should imply otherwise.
+    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    setTxDriveLevel(clamped * kTxDriveMax / 100);
+}
+
 void Hl2Backend::setTxDriveLevel(int level)
 {
     if (!m_metis)
@@ -565,9 +578,29 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     //
     // SWR is meaningful WITHOUT calibration because it is a ratio of two
     // readings from the same converter, so the unknown scale cancels.
-    if (t.forwardPowerRaw && t.reversePowerRaw) {
+    // SWR only means something with real forward power behind it.
+    //
+    // Measured on the live radio: with no carrier the forward and reverse counts
+    // are both near zero and dominated by noise, reverse frequently exceeds
+    // forward, and the computed ratio saturated the meter at 255.99:1 — a
+    // dramatic reading of nothing at all. An operator glancing at that sees a
+    // catastrophic mismatch on an antenna that is fine.
+    //
+    // The threshold is in raw counts because that is what we have; it is a
+    // noise floor, not a calibrated power level.
+    static constexpr int kMinForwardCountsForSwr = 16;
+    if (t.forwardPowerRaw && t.reversePowerRaw
+        && *t.forwardPowerRaw >= kMinForwardCountsForSwr) {
         if (const auto swr = swrFromRaw(*t.forwardPowerRaw, *t.reversePowerRaw))
             emit meterUpdate(QStringLiteral("TX:SWR"), *swr);
+    }
+    // Raw directional counts, logged rather than published: they are what a
+    // future calibration curve will be built from, and they are the only way to
+    // tell "the radio reports no power" from "we never asked".
+    if (t.forwardPowerRaw && (*t.forwardPowerRaw != m_lastFwdRaw)) {
+        m_lastFwdRaw = *t.forwardPowerRaw;
+        qCDebug(lcHl2Tx) << "HL2 directional: fwd" << *t.forwardPowerRaw
+                         << "rev" << t.reversePowerRaw.value_or(-1);
     }
     if (t.temperatureRaw)
         emit meterUpdate(QStringLiteral("RAD:PATEMP"), temperatureCelsius(*t.temperatureRaw));

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -149,7 +149,15 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
         emit spectrumFrameReady(0, floatBytes(dbm));
     });
     connect(m_dsp, &Hl2RxDsp::audioReady, this,
-            [this](const std::vector<float>& pcm) { emit audioFrameReady(floatBytes(pcm)); });
+            [this](const std::vector<float>& pcm) {
+        // Belt and braces with the demodulator mute below. This drops any block
+        // that was already in flight when the key went down; Hl2RxDsp::
+        // setAudioMuted stops the pipeline FILLING with our own transmission,
+        // which is what stopped the tail draining out afterwards.
+        if (m_keyed)
+            return;
+        emit audioFrameReady(floatBytes(pcm));
+    });
     // Modulated IQ -> the wire. Both live on the I/O thread, so this is a direct
     // call and the transmit path never touches the GUI thread.
     connect(m_txDsp, &Hl2TxDsp::iqReady, m_metis,
@@ -443,6 +451,22 @@ void Hl2Backend::setKeying(bool key)
         return;
     }
     m_keyed = key;
+    // MUTE RECEIVE AUDIO WHILE TRANSMITTING.
+    //
+    // The HL2 keeps receiving while it transmits, and what it receives is our
+    // own signal at enormous strength. Unmuted, the operator hears the tune
+    // carrier as fuzz the instant TUNE is pressed, and their own voice played
+    // back on MOX — which, with an open microphone, closes an acoustic feedback
+    // loop and wrecks the audio actually being transmitted.
+    //
+    // Muted at the DEMODULATOR, not just at the output: the spectrum keeps
+    // running on real IQ so the panadapter still updates, while the audio
+    // channel is clocked with silence so nothing accumulates to drain out on
+    // unkey.
+    if (m_dsp)
+        QMetaObject::invokeMethod(m_dsp, "setAudioMuted", Qt::QueuedConnection,
+            Q_ARG(bool, key));
+
     // A VOICE key must never inherit a TUNE carrier.
     //
     // The packet builder prefers the tone over queued audio, so a tune carrier

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -123,6 +123,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
         emitSliceState();
         emitPanState();
         defineMeters();
+        pushInitialState();
     });
     connect(m_metis, &MetisClient::linkDown, this, [this] {
         if (m_connected) {
@@ -606,6 +607,52 @@ void Hl2Backend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
     // No HL2 extension verbs yet; honor the async contract without hanging.
     if (requestId != 0)
         emit extensionError(requestId, QStringLiteral("hl2: no extension verbs implemented"));
+}
+
+void Hl2Backend::pushInitialState()
+{
+    // THE RADIO REPORTS NO VFO, SO THE APP IS AUTHORITATIVE AND MUST PUSH.
+    //
+    // A Hermes-Lite 2 has no state to read back: it never tells us its
+    // frequency, mode or drive. Every register simply retains whatever the last
+    // session left in it. So anything not explicitly asserted here is silently
+    // inherited from a previous connection, and the UI will confidently display
+    // something the hardware is not doing.
+    //
+    // That is not hypothetical. The TX NCO was set only when the operator
+    // retuned, so on reconnect the receiver moved to the app's frequency while
+    // the TRANSMITTER stayed on the previous session's — the VFO read 10 MHz
+    // and the radio transmitted on 14 MHz. Nothing in the app could have shown
+    // that, because nothing in the app was wrong.
+    //
+    // The rule for anything added later: if the radio cannot be asked for it, it
+    // belongs here.
+    setTxFrequency(m_rxFreqHz);
+    // NOT the drive level. connectRadio() already asserts a safe 0 before the
+    // link comes up, and by the time this runs RadioModel has pushed the
+    // operator's actual RF power — emit connected() above is synchronous, so
+    // resetting here silently undid it and the radio transmitted at drive 0
+    // with the PA disabled. Caught by measurement: forward power went to 0.
+
+    if (m_dsp) {
+        QMetaObject::invokeMethod(m_dsp, "setMode", Qt::QueuedConnection,
+            Q_ARG(WdspChannel::Mode, modeFromString(m_mode)));
+        QMetaObject::invokeMethod(m_dsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(m_filterLowHz)),
+            Q_ARG(double, static_cast<double>(m_filterHighHz)));
+        QMetaObject::invokeMethod(m_dsp, "setAudioMuted", Qt::QueuedConnection,
+            Q_ARG(bool, false));
+    }
+    if (m_txDsp) {
+        QMetaObject::invokeMethod(m_txDsp, "setMode", Qt::QueuedConnection,
+            Q_ARG(WdspChannel::Mode, modeFromString(m_mode)));
+        QMetaObject::invokeMethod(m_txDsp, "reset", Qt::QueuedConnection);
+    }
+    // Keying state is ours, not the radio's: a reconnect must never come up
+    // keyed because the previous session ended mid-transmission.
+    m_keyed = false;
+    m_tuning = false;
+    setKeying(false);
 }
 
 void Hl2Backend::defineMeters()

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -419,6 +419,18 @@ void Hl2Backend::setTxFrequency(double hz)
         Q_ARG(std::uint32_t, static_cast<std::uint32_t>(hz)));
 }
 
+void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)
+{
+    if (!m_metis)
+        return;
+    if (amplitude > 0.0 && !m_txAllowed) {
+        qWarning() << "Hl2Backend: test tone refused — transmit not available";
+        return;
+    }
+    QMetaObject::invokeMethod(m_metis, "setTxTestTone", Qt::QueuedConnection,
+        Q_ARG(double, offsetHz), Q_ARG(double, amplitude));
+}
+
 void Hl2Backend::setTxDriveLevel(int level)
 {
     if (!m_metis)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -61,6 +61,14 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     m_metis = new MetisClient(nullptr);
     m_dsp = new Hl2RxDsp(nullptr);
 
+    // Transmit is OFF unless explicitly enabled for this process. Read once here
+    // rather than per-key so the answer cannot change under a running key.
+    m_txAllowed = qEnvironmentVariableIsSet("AETHER_HL2_ALLOW_TX");
+    if (m_txAllowed) {
+        qWarning() << "Hl2Backend: TRANSMIT ENABLED (AETHER_HL2_ALLOW_TX)";
+        m_metis->enableTransmit(true);
+    }
+
     m_ioThread = new QThread(this);
     m_ioThread->setObjectName(QStringLiteral("hl2-io"));
     m_metis->moveToThread(m_ioThread);
@@ -144,8 +152,10 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.maxSlices = 1;
     c.maxPanadapters = 1;
     c.sampleRatesHz = {48000, 96000, 192000, 384000};
-    c.canTransmit = false;              // RX-only: the engine TX guard denies keying
-    c.txPowerMaxWatts = 0.0;
+    // Reported from the gate, not hardcoded: the engine's TX guard keys off this,
+    // so a build with transmit disabled must look RX-only from above the seam.
+    c.canTransmit = m_txAllowed;
+    c.txPowerMaxWatts = 0.0;            // uncalibrated; see the oracle on power counts
     c.hasTuner = false;
     c.hasAmplifier = false;
     c.hasExtendedDsp = false;
@@ -166,7 +176,11 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
         m_sampleRateHz = request.params.value(QStringLiteral("sampleRateHz")).toInt();
     if (request.params.contains(QStringLiteral("lnaGainDb")))
         m_lnaGainDb = request.params.value(QStringLiteral("lnaGainDb")).toInt();
-        m_dbRef.setLnaGainDb(m_lnaGainDb);   // never let these two drift apart
+    // Outside the if ON PURPOSE, and now braced to say so: the reference must be
+    // seeded from m_lnaGainDb whether or not the caller overrode it, or a default
+    // connect leaves the dBm reference and the commanded gain disagreeing. The
+    // previous indentation implied this was inside the branch, which it never was.
+    m_dbRef.setLnaGainDb(m_lnaGainDb);
     if (request.params.contains(QStringLiteral("rxFrequencyHz")))
         m_rxFreqHz = request.params.value(QStringLiteral("rxFrequencyHz")).toDouble();
 
@@ -207,6 +221,12 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
         emit connectionError(QStringLiteral("HL2: could not open the UDP socket"));
         return;
     }
+    // Assert a known TX drive rather than inheriting whatever the board held.
+    // ZERO is deliberate: this backend has no drive-level control wired to the
+    // UI yet, so anything higher would be an un-commanded power level chosen by
+    // a default. An operator raising it explicitly is the only way it should go up.
+    setTxDriveLevel(0);
+
     // Initial slice/pan state is published from the linkUp handler above, once
     // connected() has fired and RadioModel has finished staging the old session.
 }
@@ -256,6 +276,17 @@ void Hl2Backend::setSliceFrequency(int /*sliceId*/, double hz)
     if (m_dsp)
         QMetaObject::invokeMethod(m_dsp, "setShift", Qt::QueuedConnection,
             Q_ARG(double, m_rxFreqHz - m_ncoHz));
+
+    // The TX NCO is a SEPARATE register (addr 0x01) from the RX DDC and does not
+    // follow the receiver. Without this the transmit oscillator keeps whatever
+    // it last held — zero on a fresh boot — so keying would radiate at the wrong
+    // frequency, or at DC, with nothing to indicate anything was wrong.
+    //
+    // The HL2 has one receiver and one transmitter, and its single slice is the
+    // TX slice, so the TX NCO simply tracks the slice. Sent whether or not
+    // transmit is enabled: this is oscillator setup, it keys nothing, and having
+    // it already correct is part of what makes the eventual key safe.
+    setTxFrequency(m_rxFreqHz);
 
     emitSliceState();
     emitPanState();
@@ -335,10 +366,38 @@ void Hl2Backend::setPanCenter(const QString& /*panId*/, double hz)
     emitPanState();
 }
 
-void Hl2Backend::setKeying(bool /*key*/)
+void Hl2Backend::setKeying(bool key)
 {
-    // RX-only. capabilities().canTransmit is false, so the engine guard already
-    // denies keying above the seam; this is a defensive no-op.
+    // Keying is gated twice on purpose. capabilities().canTransmit reflects the
+    // gate, so the engine guard above the seam already refuses when transmit is
+    // off; MetisClient refuses independently at the wire. Neither is trusted to
+    // be the only one -- this backend keyed nothing at all until very recently,
+    // and the cost of a wrong key is an unintended emission.
+    if (!m_txAllowed) {
+        if (key)
+            qWarning() << "Hl2Backend: key refused — transmit not enabled"
+                       << "(set AETHER_HL2_ALLOW_TX=1)";
+        return;
+    }
+    if (m_metis)
+        QMetaObject::invokeMethod(m_metis, "setMox", Qt::QueuedConnection,
+            Q_ARG(bool, key));
+}
+
+void Hl2Backend::setTxFrequency(double hz)
+{
+    if (!m_metis || hz <= 0.0)
+        return;
+    QMetaObject::invokeMethod(m_metis, "setTxFrequencyHz", Qt::QueuedConnection,
+        Q_ARG(std::uint32_t, static_cast<std::uint32_t>(hz)));
+}
+
+void Hl2Backend::setTxDriveLevel(int level)
+{
+    if (!m_metis)
+        return;
+    QMetaObject::invokeMethod(m_metis, "setTxDriveLevel", Qt::QueuedConnection,
+        Q_ARG(int, level));
 }
 
 void Hl2Backend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/, quint64 requestId,
@@ -357,6 +416,16 @@ void Hl2Backend::emitSliceState()
     d.mode = m_mode;
     d.filterLow = m_filterLowHz;
     d.filterHigh = m_filterHighHz;
+    // The HL2 has exactly one receiver and one transmitter, so its single slice
+    // IS the transmit slice. Leaving this unset meant txSlice() was null and
+    // every key attempt died in RadioModel's interlock with "No transmit slice
+    // is assigned" -- before the backend was ever asked, which is why the
+    // refusal was silent from down here.
+    //
+    // Publishing it unconditionally is correct rather than convenient: there is
+    // no second slice for the assignment to be a choice between.
+    d.txSlice = true;
+    d.active = true;
     emit sliceChanged(kSliceId, d);
 }
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -116,6 +116,7 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
         // ever sees it (slice panel stuck empty / 0.000000).
         emitSliceState();
         emitPanState();
+        defineMeters();
     });
     connect(m_metis, &MetisClient::linkDown, this, [this] {
         if (m_connected) {
@@ -143,12 +144,13 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
     });
     connect(m_dsp, &Hl2RxDsp::audioReady, this,
             [this](const std::vector<float>& pcm) { emit audioFrameReady(floatBytes(pcm)); });
+    connect(m_metis, &MetisClient::telemetryUpdated, this,
+            [this](const Hl2Telemetry& t) { publishTelemetry(t); });
     connect(m_dsp, &Hl2RxDsp::meterUpdate, this,
             [this](float dbfs) {
         // Same reference as the spectrum -- a meter that moved on a gain change
         // while the trace stayed put would be its own kind of lie.
-        emit meterUpdate(QStringLiteral("s-meter"),
-                         static_cast<float>(m_dbRef.toDbm(dbfs)));
+        emit meterUpdate(QStringLiteral("SLC:LEVEL"), m_dbRef.toDbm(dbfs));
     });
 }
 
@@ -445,6 +447,73 @@ void Hl2Backend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
     // No HL2 extension verbs yet; honor the async contract without hanging.
     if (requestId != 0)
         emit extensionError(requestId, QStringLiteral("hl2: no extension verbs implemented"));
+}
+
+void Hl2Backend::defineMeters()
+{
+    // Indices are ours to choose — nothing on the HL2 assigns meter ids, unlike
+    // Flex where they come from the radio's meter manifest. They only have to be
+    // stable and unique within this backend.
+    auto def = [this](int index, const QString& source, const QString& name,
+                      const QString& unit, double low, double high,
+                      const QString& desc) {
+        MeterDef d;
+        d.index = index;
+        d.source = source;
+        d.name = name;
+        d.unit = unit;
+        d.low = low;
+        d.high = high;
+        d.description = desc;
+        emit meterDefined(d);
+    };
+
+    def(1, QStringLiteral("SLC"), QStringLiteral("LEVEL"),   QStringLiteral("dBm"),
+        -140.0, 0.0,   QStringLiteral("Receive signal level"));
+    def(2, QStringLiteral("TX"),  QStringLiteral("FWDPWR"),  QStringLiteral("dBm"),
+        0.0, 50.0,     QStringLiteral("Forward power"));
+    def(3, QStringLiteral("TX"),  QStringLiteral("REFPWR"),  QStringLiteral("dBm"),
+        0.0, 50.0,     QStringLiteral("Reflected power"));
+    def(4, QStringLiteral("TX"),  QStringLiteral("SWR"),     QStringLiteral("SWR"),
+        1.0, 10.0,     QStringLiteral("Standing wave ratio"));
+    def(5, QStringLiteral("RAD"), QStringLiteral("PATEMP"),  QStringLiteral("degC"),
+        0.0, 100.0,    QStringLiteral("PA temperature"));
+    def(6, QStringLiteral("TX"),  QStringLiteral("MICPEAK"), QStringLiteral("dBFS"),
+        -100.0, 0.0,   QStringLiteral("Microphone peak"));
+}
+
+void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
+{
+    // Forward/reverse power are UNCALIBRATED ADC counts. MeterModel's FWDPWR
+    // path expects dBm and converts to watts, so publishing a raw count there
+    // would render as a confident, wrong wattage. Until there is a per-unit
+    // calibration curve (oracle §6 is explicit that Quisk and SparkSDR both
+    // build one, and that raw counts must not be presented as watts), only the
+    // quantities that are actually meaningful get published.
+    //
+    // SWR is meaningful WITHOUT calibration because it is a ratio of two
+    // readings from the same converter, so the unknown scale cancels.
+    if (t.forwardPowerRaw && t.reversePowerRaw) {
+        if (const auto swr = swrFromRaw(*t.forwardPowerRaw, *t.reversePowerRaw))
+            emit meterUpdate(QStringLiteral("TX:SWR"), *swr);
+    }
+    if (t.temperatureRaw)
+        emit meterUpdate(QStringLiteral("RAD:PATEMP"), temperatureCelsius(*t.temperatureRaw));
+
+    m_telemetry = t;
+    if (t.adcOverload && *t.adcOverload != m_adcOverload) {
+        m_adcOverload = *t.adcOverload;
+        if (m_adcOverload)
+            qWarning() << "Hl2Backend: ADC OVERLOAD — reduce LNA gain or attenuate";
+    }
+}
+
+double Hl2Backend::temperatureCelsius(int raw)
+{
+    // AD9866 on-die temperature via the HL2's instrumentation ADC. The scaling
+    // below is the Hermes-Lite 2 wiki's published formula. It is NOT verified
+    // against a reference thermometer here, so treat it as indicative.
+    return (3.26 * (static_cast<double>(raw) / 4096.0) - 0.5) / 0.01;
 }
 
 void Hl2Backend::emitSliceState()

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -61,6 +61,7 @@ public:
 private:
     void emitSliceState();   // sliceChanged(delta) from current freq/mode/filter
     void emitPanState();
+    void pushInitialState();
     void defineMeters();
     void publishTelemetry(const Hl2Telemetry& t);
     static double temperatureCelsius(int raw);     // panCenterBandwidthChanged from freq + sample rate

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -48,6 +48,7 @@ public:
     void setKeying(bool key) override;
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
     void setTxPower(int percent) override;
+    void setTune(bool on) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
     // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
@@ -99,6 +100,11 @@ private:
     Hl2Telemetry m_telemetry;
     bool m_adcOverload = false;
     bool m_keyed = false;
+    // Tune-carrier amplitude, full scale into the modulator. Actual radiated
+    // power is governed by the TX drive register, which is where an operator
+    // sets it; scaling here as well would make the power control non-linear for
+    // no reason.
+    static constexpr double kTuneCarrierAmplitude = 1.0;
     int m_lastFwdRaw = -1;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -80,8 +80,10 @@ private:
     // the UI. Owned by this object; joined in the destructor.
     QThread* m_ioThread = nullptr;
 
-    // Process-wide transmit gate (AETHER_HL2_ALLOW_TX), read once at
-    // construction. Mirrored into MetisClient, which refuses independently.
+    // Process-wide transmit availability, decided once at construction:
+    // interactive runs may transmit; automation runs defer to the bridge's
+    // AETHER_AUTOMATION_ALLOW_TX gate. Mirrored into MetisClient, which refuses
+    // independently at the wire.
     bool m_txAllowed = false;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -44,6 +44,8 @@ public:
     void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
     void setPanCenter(const QString& panId, double hz) override;
     void setKeying(bool key) override;
+    void setTxFrequency(double hz);
+    void setTxDriveLevel(int level);
 
     void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
                          const QVariant& arg) override;
@@ -77,6 +79,10 @@ private:
     // header for why the EP2 pacer in particular must not share a thread with
     // the UI. Owned by this object; joined in the destructor.
     QThread* m_ioThread = nullptr;
+
+    // Process-wide transmit gate (AETHER_HL2_ALLOW_TX), read once at
+    // construction. Mirrored into MetisClient, which refuses independently.
+    bool m_txAllowed = false;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.
     QString m_agcMode = QStringLiteral("med");

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -47,6 +47,7 @@ public:
     void setPanCenter(const QString& panId, double hz) override;
     void setKeying(bool key) override;
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
+    void setTxPower(int percent) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
     // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
@@ -98,6 +99,7 @@ private:
     Hl2Telemetry m_telemetry;
     bool m_adcOverload = false;
     bool m_keyed = false;
+    int m_lastFwdRaw = -1;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.
     QString m_agcMode = QStringLiteral("med");

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -8,6 +8,7 @@
 #include <QThread>
 
 #include "core/backends/hl2/Hl2DbReference.h"
+#include "core/backends/hl2/MetisProtocol.h"   // Hl2Telemetry
 
 namespace AetherSDR::hl2 {
 
@@ -55,7 +56,10 @@ public:
 
 private:
     void emitSliceState();   // sliceChanged(delta) from current freq/mode/filter
-    void emitPanState();     // panCenterBandwidthChanged from freq + sample rate
+    void emitPanState();
+    void defineMeters();
+    void publishTelemetry(const Hl2Telemetry& t);
+    static double temperatureCelsius(int raw);     // panCenterBandwidthChanged from freq + sample rate
 
     MetisClient* m_metis = nullptr;
     Hl2RxDsp* m_dsp = nullptr;
@@ -88,6 +92,8 @@ private:
     // AETHER_AUTOMATION_ALLOW_TX gate. Mirrored into MetisClient, which refuses
     // independently at the wire.
     bool m_txAllowed = false;
+    Hl2Telemetry m_telemetry;
+    bool m_adcOverload = false;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.
     QString m_agcMode = QStringLiteral("med");

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -46,6 +46,9 @@ public:
     void setKeying(bool key) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
+    // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
+    // Opt-in only — never enabled by a default.
+    void setTxTestTone(double offsetHz, double amplitude);
 
     void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
                          const QVariant& arg) override;

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -14,6 +14,7 @@ namespace AetherSDR::hl2 {
 
 class MetisClient;
 class Hl2RxDsp;
+class Hl2TxDsp;
 
 // IRadioBackend implementation for the Hermes-Lite 2 (HPSDR Protocol 1, raw IQ).
 // Owns a MetisClient (UDP wire) and an Hl2RxDsp (demod + panadapter) and maps the
@@ -45,6 +46,7 @@ public:
     void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
     void setPanCenter(const QString& panId, double hz) override;
     void setKeying(bool key) override;
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
     // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
@@ -63,6 +65,7 @@ private:
 
     MetisClient* m_metis = nullptr;
     Hl2RxDsp* m_dsp = nullptr;
+    Hl2TxDsp* m_txDsp = nullptr;
     bool m_connected = false;
 
     // Authoritative RX state (HL2 has no status wire echoing it back).
@@ -94,6 +97,7 @@ private:
     bool m_txAllowed = false;
     Hl2Telemetry m_telemetry;
     bool m_adcOverload = false;
+    bool m_keyed = false;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.
     QString m_agcMode = QStringLiteral("med");

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -21,12 +21,14 @@ class Hl2TxDsp;
 // neutral seam verbs/signals onto them. This is the first backend that owns an
 // engine-side DSP chain (RFC §5.5) rather than decoding a cooked stream.
 //
-// RX-only: capabilities().canTransmit is false, so the engine TX guard (RFC §6)
-// denies keying; setKeying() is a no-op and nothing here can key the radio.
+// THIS BACKEND CAN KEY THE RADIO. capabilities().canTransmit reports transmit
+// AVAILABILITY rather than a constant false: an interactive run may transmit,
+// and an automation run defers to the bridge's own TX gate. MetisClient refuses
+// independently at the wire, so neither gate is trusted as the only one.
 //
-// Phase 1b runs the wire + DSP on this object's thread (iqBlockReady ->
-// processIqBlock is a direct call); relocating the DSP onto its own thread is a
-// later refinement once the data plane is wired through RadioModel.
+// The wire and both DSP chains run on a dedicated I/O thread. That is not only
+// about keeping WDSP off the UI: this backend paces EP2, and the gateware
+// watchdog halts the stream if EP2 stops arriving.
 class Hl2Backend : public IRadioBackend {
     Q_OBJECT
 

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -100,6 +100,8 @@ private:
     Hl2Telemetry m_telemetry;
     bool m_adcOverload = false;
     bool m_keyed = false;
+    bool m_tuning = false;
+    bool m_toneFromTune = false;
     // Tune-carrier amplitude, full scale into the modulator. Actual radiated
     // power is governed by the TX drive register, which is where an operator
     // sets it; scaling here as well would make the power control non-linear for

--- a/src/core/backends/hl2/Hl2RxDsp.cpp
+++ b/src/core/backends/hl2/Hl2RxDsp.cpp
@@ -2,6 +2,7 @@
 
 #include <QMetaType>
 
+#include <algorithm>
 #include <cmath>
 
 namespace AetherSDR::hl2 {
@@ -94,6 +95,11 @@ void Hl2RxDsp::setAgc(int agcMode, double maximumGainDb)
         m_channel->setAgc(agcMode, maximumGainDb);
 }
 
+void Hl2RxDsp::setAudioMuted(bool muted)
+{
+    m_audioMuted = muted;
+}
+
 void Hl2RxDsp::setShift(double shiftHz)
 {
     m_shiftHz = shiftHz;
@@ -115,6 +121,14 @@ void Hl2RxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
     const std::size_t block = static_cast<std::size_t>(m_config.dspBlockSize);
     std::size_t consumed = 0;
     while (m_iqBuffer.size() - consumed >= block) {
+        if (m_audioMuted) {
+            // Clock the audio channel with silence rather than skipping it.
+            // Skipping would let the pipeline's contents go stale and emerge on
+            // unmute; feeding zeros keeps latency constant and guarantees that
+            // what comes out when transmit ends is silence.
+            std::fill(m_i.begin(), m_i.end(), 0.0f);
+            std::fill(m_q.begin(), m_q.end(), 0.0f);
+        } else
         for (std::size_t n = 0; n < block; ++n) {
             m_i[n] = m_iqBuffer[consumed + n].real();
             // Conjugate for WDSP. The HPSDR wire order (I then Q, decoded in

--- a/src/core/backends/hl2/Hl2RxDsp.h
+++ b/src/core/backends/hl2/Hl2RxDsp.h
@@ -15,7 +15,9 @@ namespace AetherSDR::hl2 {
 // into demodulated audio (WdspChannel), a panadapter spectrum (Hl2Spectrum), and
 // an S-meter. Buffers the odd 126-sample EP6 blocks into WdspChannel's fixed
 // processing block. Below the seam; the eventual Hl2Backend owns one and runs it
-// on its own thread. RX-only (WdspChannel is a receive channel; nothing keys).
+// on the backend's I/O thread. This stage is receive-only — Hl2TxDsp is its
+// transmit counterpart — and it MUTES on transmit, clocking its audio channel
+// with silence so the pipeline cannot fill with our own signal.
 class Hl2RxDsp : public QObject {
     Q_OBJECT
 

--- a/src/core/backends/hl2/Hl2RxDsp.h
+++ b/src/core/backends/hl2/Hl2RxDsp.h
@@ -69,6 +69,18 @@ public:
     // slice inside the passband without moving the DDC. Kept in m_config so a
     // later reconfigure() rebuilds the channel with the operator's offset.
     Q_INVOKABLE void setShift(double shiftHz);
+    // Mute the DEMODULATOR while transmitting.
+    //
+    // Suppressing audio further downstream is not enough: this pipeline keeps
+    // demodulating our own transmission, WDSP's filters and buffers fill with
+    // it, and the moment the mute lifts that backlog drains to the speakers —
+    // heard as the tail end of a transmission playing back after unkey.
+    //
+    // Muted, the SPECTRUM still runs on real IQ so the panadapter keeps
+    // updating, but the audio channel is clocked with SILENCE. The pipeline
+    // therefore stays running at constant latency and contains nothing but
+    // silence when transmit ends.
+    Q_INVOKABLE void setAudioMuted(bool muted);
     [[nodiscard]] bool isConfigured() const noexcept { return m_channel != nullptr; }
 
 public slots:
@@ -87,6 +99,7 @@ private:
     double m_shiftHz = 0.0;   // current slice offset from the NCO, Hz
     Config m_config;
 
+    bool m_audioMuted = false;
     std::vector<std::complex<float>> m_iqBuffer;   // IQ awaiting a full DSP block
     std::vector<float> m_i, m_q;                    // deinterleaved input scratch
     std::vector<float> m_left, m_right;             // WdspChannel output scratch

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -252,9 +252,24 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono)
             m_histPos = (m_histPos + 1) % N;
 
             // bi and bq are the in-phase and quadrature halves of the analytic
-            // signal. Negating Q mirrors the spectrum, which is the sideband
+            // signal; negating Q mirrors the spectrum, which is the sideband
             // choice.
-            m_iq.emplace_back(bi, lsb ? -bq : bq);
+            const float q = lsb ? -bq : bq;
+
+            // CONJUGATE FOR THE WIRE.
+            //
+            // The HPSDR wire order has the OPPOSITE handedness to the standard
+            // analytic convention — the receive path already compensates for
+            // exactly this, conjugating with -imag() before handing IQ to WDSP.
+            // Transmit needs the same correction in the same place and did not
+            // have it, so every transmission went out on the wrong sideband.
+            //
+            // Caught on the air, not on the bench: the operator's Yaesu heard
+            // our LSB on its USB. It is invisible from inside this application
+            // because the panadapter reads the same wire order, so our own
+            // display and our own transmission agreed with each other while
+            // both disagreed with the rest of the band.
+            m_iq.emplace_back(bi, -q);
         }
     }
 

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -140,8 +140,14 @@ void Hl2TxDsp::setMicGain(double linear)
     m_micGain = linear < 0.0 ? 0.0 : linear;
 }
 
+double Hl2TxDsp::alcGainDb() const noexcept
+{
+    return 20.0 * std::log10(std::max(1e-9, m_alcGain));
+}
+
 void Hl2TxDsp::reset()
 {
+    m_alcGain = 1.0;   // a new transmission starts from unity, not mid-ramp
     m_inBuffer.clear();
     std::fill(m_hist.begin(), m_hist.end(), 0.0f);
     m_histPos = 0;
@@ -179,9 +185,52 @@ void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono)
     m_iq.reserve(consumed * static_cast<std::size_t>(m_upsample));
     float peak = 0.0f;
 
+    // ---- ALC: bring speech up to something that actually modulates ----
+    //
+    // Peak-tracking with a fast attack and a slow release, which is the
+    // conventional shape: catch the onset of a syllable, but do not pump audibly
+    // between words. The gain is capped so a quiet room is not amplified into
+    // hiss, and the result is hard-limited below full scale afterwards, because
+    // an ALC that can overshoot is a splatter generator.
+    if (m_config.alcEnabled) {
+        float blockPeak = 0.0f;
+        for (std::size_t s = 0; s < consumed; ++s)
+            blockPeak = std::max(blockPeak, std::fabs(
+                static_cast<float>(m_inBuffer[s] * m_micGain)));
+
+        if (blockPeak > 1e-6f) {
+            const double wanted = m_config.alcTargetPeak / blockPeak;
+            const double maxGain = std::pow(10.0, m_config.alcMaxGainDb / 20.0);
+            const double target = std::min(wanted, maxGain);
+            // Per-block time constants. Attack when we need LESS gain (the
+            // signal got louder) so overshoot is corrected immediately.
+            const double blockSec = static_cast<double>(consumed)
+                                  / static_cast<double>(m_config.inputSampleRateHz);
+            const double tau = (target < m_alcGain) ? m_config.alcAttackSec
+                                                    : m_config.alcReleaseSec;
+            const double a = 1.0 - std::exp(-blockSec / std::max(1e-6, tau));
+            m_alcGain += a * (target - m_alcGain);
+        }
+        emit alcGain(static_cast<float>(alcGainDb()));
+    } else {
+        m_alcGain = 1.0;
+    }
+
     for (std::size_t s = 0; s < consumed; ++s) {
-        const float in = static_cast<float>(m_inBuffer[s] * m_micGain);
-        peak = std::max(peak, std::fabs(in));
+        // Mic peak is measured BEFORE the ALC, deliberately.
+        //
+        // A post-ALC meter sits pinned near the target by definition and tells
+        // the operator nothing — it reports the ALC's success, not their input
+        // level. What a mic-gain control acts on is this, and how hard the ALC
+        // is working is reported separately as alcGain().
+        const float preAlc = static_cast<float>(m_inBuffer[s] * m_micGain);
+        peak = std::max(peak, std::fabs(preAlc));
+
+        // Hard limit AFTER the ALC. The ALC is a smoothed estimate and will
+        // overshoot on a transient; letting that through would transmit
+        // distortion across the band rather than merely clipping our own audio.
+        const float in = std::clamp(static_cast<float>(preAlc * m_alcGain),
+                                    -1.0f, 1.0f);
 
         for (int u = 0; u < m_upsample; ++u) {
             // Zero-stuff: only the first sub-sample carries energy. The bandpass

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -1,0 +1,221 @@
+#include "core/backends/hl2/Hl2TxDsp.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR::hl2 {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+// Blackman window — ~58 dB sidelobes, which is what sets the achievable
+// opposite-sideband suppression.
+double blackman(std::size_t n, std::size_t N)
+{
+    const double x = 2.0 * kPi * static_cast<double>(n) / static_cast<double>(N - 1);
+    return 0.42 - 0.5 * std::cos(x) + 0.08 * std::cos(2.0 * x);
+}
+
+}  // namespace
+
+Hl2TxDsp::Hl2TxDsp(QObject* parent) : QObject(parent) {}
+Hl2TxDsp::~Hl2TxDsp() = default;
+
+// Phasing SSB modulator: a windowed-sinc bandpass and a matching Hilbert
+// transformer, sharing one delay line.
+//
+// WHY NOT WDSP HERE, stated carefully because the obvious reading is wrong:
+// WDSP's transmit path WORKS. wdsp_channel_test drives a TXA channel and gets
+// IQ out of it, so "WDSP TX is broken" is not the claim.
+//
+// The claim is narrower. Driven from this backend's configuration, a TXA channel
+// returned Underrun on most blocks and zeros on the rest, and closing that gap
+// means working out which of a long, largely undocumented initialisation
+// sequence it was missing — bandpass run, filter length, phase mode, panel,
+// leveler, ALC, CFIR, each with defaults that are not obviously safe. Two
+// speculative attempts at that sequence made things worse; one of them broke
+// wdsp_channel_test outright, which is how the "WDSP is at fault" reading got
+// disproved.
+//
+// The deciding factor is that the failure mode is SILENT. A transmit chain that
+// is subtly misconfigured emits nothing, or emits something wrong, on the air,
+// and neither announces itself. A phasing modulator is fifty lines, holds no
+// hidden state, and its correctness is a number this file's test measures
+// directly: opposite-sideband suppression in dB. Choosing the thing that can be
+// measured over the thing that is merely canonical is the right trade for a
+// path that keys a transmitter.
+//
+// Revisiting WDSP TXA later is entirely reasonable — with wdsp_channel_test's
+// working configuration as the starting point rather than a guess.
+void Hl2TxDsp::designFilters()
+{
+    const double fs = static_cast<double>(m_config.outputSampleRateHz);
+    const double lo = m_config.filterLowHz / fs;      // normalised
+    const double hi = m_config.filterHighHz / fs;
+    const std::size_t N = kTaps;
+    const double mid = static_cast<double>(N - 1) / 2.0;
+
+    m_bandpass.assign(N, 0.0f);
+    m_hilbert.assign(N, 0.0f);
+
+    for (std::size_t n = 0; n < N; ++n) {
+        const double k = static_cast<double>(n) - mid;
+        const double w = blackman(n, N);
+
+        // Bandpass = difference of two lowpass sincs.
+        double bp;
+        if (k == 0.0) {
+            bp = 2.0 * (hi - lo);
+        } else {
+            bp = (std::sin(2.0 * kPi * hi * k) - std::sin(2.0 * kPi * lo * k))
+                 / (kPi * k);
+        }
+        m_bandpass[n] = static_cast<float>(bp * w);
+
+        // Quadrature filter = the IMAGINARY part of the same analytic bandpass,
+        // NOT a wideband Hilbert transformer.
+        //
+        // This distinction is the whole correctness of the modulator. A textbook
+        // Hilbert (2/(pi*k) on odd taps) is all-pass in magnitude: it passes
+        // out-of-band audio at FULL amplitude with a 90-degree shift. Pairing it
+        // with a band-limited I meant energy above the passband arrived in Q
+        // only — which is a REAL signal, so it came out double-sideband on both
+        // sides of the carrier. Measured: a 5 kHz tone against a 2700 Hz filter
+        // appeared at both +5 kHz and -5 kHz, just 6 dB down, i.e. splatter
+        // outside our own passband.
+        //
+        // Deriving both filters from one analytic prototype,
+        //   ha[k] = (exp(j*2*pi*hi*k) - exp(j*2*pi*lo*k)) / (j*2*pi*k),
+        // makes I and Q share a passband by construction, and keeps their group
+        // delay identical for free.
+        double hq;
+        if (k == 0.0) {
+            hq = 0.0;
+        } else {
+            hq = (std::cos(2.0 * kPi * lo * k) - std::cos(2.0 * kPi * hi * k))
+                 / (kPi * k);
+        }
+        m_hilbert[n] = static_cast<float>(hq * w);
+    }
+
+    m_hist.assign(N, 0.0f);
+    m_histPos = 0;
+}
+
+bool Hl2TxDsp::configure(const Config& config, std::string* error)
+{
+    if (config.inputSampleRateHz <= 0 || config.outputSampleRateHz <= 0) {
+        if (error) *error = "invalid sample rate";
+        return false;
+    }
+    if (config.outputSampleRateHz % config.inputSampleRateHz != 0) {
+        // Zero-stuffing needs an integer ratio, and every rate this backend uses
+        // is one. Fail loudly rather than transmit at the wrong pitch.
+        if (error) *error = "output rate must be an integer multiple of the input rate";
+        return false;
+    }
+    m_config = config;
+    m_upsample = config.outputSampleRateHz / config.inputSampleRateHz;
+    designFilters();
+    m_inBuffer.clear();
+    return true;
+}
+
+void Hl2TxDsp::setMode(WdspChannel::Mode mode)
+{
+    m_config.mode = mode;
+}
+
+void Hl2TxDsp::setFilter(double lowHz, double highHz)
+{
+    m_config.filterLowHz = lowHz;
+    m_config.filterHighHz = highHz;
+    designFilters();
+}
+
+void Hl2TxDsp::setMicGain(double linear)
+{
+    m_micGain = linear < 0.0 ? 0.0 : linear;
+}
+
+void Hl2TxDsp::reset()
+{
+    m_inBuffer.clear();
+    std::fill(m_hist.begin(), m_hist.end(), 0.0f);
+    m_histPos = 0;
+}
+
+bool Hl2TxDsp::isLowerSideband() const
+{
+    switch (m_config.mode) {
+    case WdspChannel::Mode::Lsb:
+    case WdspChannel::Mode::Cwl:
+    case WdspChannel::Mode::Digl:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void Hl2TxDsp::processAudioBlock(const std::vector<float>& mono)
+{
+    if (m_bandpass.empty() || mono.empty())
+        return;
+
+    m_inBuffer.insert(m_inBuffer.end(), mono.begin(), mono.end());
+
+    const std::size_t block = static_cast<std::size_t>(m_config.dspBlockSize);
+    if (m_inBuffer.size() < block)
+        return;
+
+    const std::size_t blocks = m_inBuffer.size() / block;
+    const std::size_t consumed = blocks * block;
+    const std::size_t N = m_bandpass.size();
+    const bool lsb = isLowerSideband();
+
+    m_iq.clear();
+    m_iq.reserve(consumed * static_cast<std::size_t>(m_upsample));
+    float peak = 0.0f;
+
+    for (std::size_t s = 0; s < consumed; ++s) {
+        const float in = static_cast<float>(m_inBuffer[s] * m_micGain);
+        peak = std::max(peak, std::fabs(in));
+
+        for (int u = 0; u < m_upsample; ++u) {
+            // Zero-stuff: only the first sub-sample carries energy. The bandpass
+            // below doubles as the anti-imaging filter, and the m_upsample
+            // factor restores the amplitude that stuffing divides away.
+            const float x = (u == 0) ? in * static_cast<float>(m_upsample) : 0.0f;
+
+            m_hist[m_histPos] = x;
+
+            // One pass over the shared history feeding both filters.
+            float bi = 0.0f, bq = 0.0f;
+            std::size_t idx = m_histPos;
+            for (std::size_t k = 0; k < N; ++k) {
+                const float h = m_hist[idx];
+                bi += h * m_bandpass[k];
+                bq += h * m_hilbert[k];
+                idx = (idx == 0) ? N - 1 : idx - 1;
+            }
+            m_histPos = (m_histPos + 1) % N;
+
+            // bi and bq are the in-phase and quadrature halves of the analytic
+            // signal. Negating Q mirrors the spectrum, which is the sideband
+            // choice.
+            m_iq.emplace_back(bi, lsb ? -bq : bq);
+        }
+    }
+
+    m_inBuffer.erase(m_inBuffer.begin(),
+                     m_inBuffer.begin() + static_cast<std::ptrdiff_t>(consumed));
+
+    if (!m_iq.empty())
+        emit iqReady(m_iq);
+    // PRE-modulation level: this is what a mic-gain control acts on, so it is
+    // the number that tells an operator whether they are overdriving.
+    emit micPeak(peak > 0.0f ? 20.0f * std::log10(peak) : -140.0f);
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2TxDsp.cpp
+++ b/src/core/backends/hl2/Hl2TxDsp.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <QDebug>
 
 namespace AetherSDR::hl2 {
 

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -25,8 +25,13 @@ namespace AetherSDR::hl2 {
 // direction rather than a second, hand-rolled resampler.
 //
 // MODULATION is a phasing SSB modulator built here rather than WDSP's TXA
-// chain — see the long note in the .cpp for why, and for the measured evidence
-// that a correctly-configured-looking TXA channel emitted pure zeros.
+// chain. WDSP's transmit path WORKS — wdsp_channel_test proves it — but driven
+// from this backend's configuration it returned underruns and zeros, and the
+// failure mode is silent. See the long note in the .cpp.
+//
+// The output is CONJUGATED for the HPSDR wire, which has the opposite handedness
+// to the standard analytic convention. Omitting that transmitted every signal on
+// the wrong sideband.
 class Hl2TxDsp : public QObject {
     Q_OBJECT
 

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -43,6 +43,18 @@ public:
         // splatter outside this is other people's problem, not ours.
         double filterLowHz = 300.0;
         double filterHighHz = 2700.0;
+
+        // Automatic level control. Speech arrives 20-30 dB below the level
+        // needed to modulate fully, so without this a normal speaking voice
+        // produces almost no RF — measured on hardware: audio at -10 dBFS gave
+        // 1226 counts of forward power, at -30 dBFS gave 47, and speech sits
+        // around -32 dBFS. A real transceiver closes that gap with mic gain,
+        // compression and ALC; this is the ALC.
+        bool alcEnabled = true;
+        double alcTargetPeak = 0.85;   // leave headroom below clipping
+        double alcMaxGainDb = 40.0;    // do not amplify a silent room forever
+        double alcAttackSec = 0.005;   // catch a syllable's onset
+        double alcReleaseSec = 0.500;  // slow enough not to pump between words
     };
 
     Q_INVOKABLE bool configure(const Config& config, std::string* error = nullptr);
@@ -51,6 +63,8 @@ public:
     // Linear gain applied to the audio before modulation. 1.0 = unity.
     Q_INVOKABLE void setMicGain(double linear);
     [[nodiscard]] double micGain() const noexcept { return m_micGain; }
+    // Gain the ALC is currently applying, in dB. 0 means unity.
+    [[nodiscard]] double alcGainDb() const noexcept;
 
 public slots:
     // Mono TX audio at inputSampleRateHz.
@@ -62,6 +76,7 @@ public slots:
 signals:
     void iqReady(const std::vector<std::complex<float>>& iq);   // at outputSampleRateHz
     void micPeak(float dbfs);                                   // post-gain, pre-modulation
+    void alcGain(float db);                                     // ALC gain applied
 
 private:
     void designFilters();
@@ -75,6 +90,7 @@ private:
     Config m_config;
     double m_micGain = 1.0;
     int m_upsample = 2;
+    double m_alcGain = 1.0;      // current ALC gain, carried across blocks
 
     std::vector<float> m_bandpass;      // real bandpass
     std::vector<float> m_hilbert;       // quadrature half of the analytic bandpass

--- a/src/core/backends/hl2/Hl2TxDsp.h
+++ b/src/core/backends/hl2/Hl2TxDsp.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "core/dsp/WdspChannel.h"
+
+#include <QObject>
+
+#include <complex>
+#include <string>
+#include <vector>
+
+namespace AetherSDR::hl2 {
+
+// SSB transmit chain for the Hermes-Lite 2: processed TX audio in, baseband IQ
+// out, ready for EP2.
+//
+// The audio arrives already shaped — AudioEngine's TX chain has applied the test
+// tone, compressor and EQ before we see it — so this stage is only modulation.
+// That is deliberate: it means the TONE button, the microphone and any future
+// source all reach the air through ONE path, and what the operator monitors is
+// what gets transmitted.
+//
+// RATES. AudioEngine runs at 24 kHz; EP2 is clocked at a fixed 48 kHz
+// regardless of the RX sample rate. WDSP's three-rate channel model does the
+// interpolation, which is the same mechanism the RX side uses in the opposite
+// direction rather than a second, hand-rolled resampler.
+//
+// MODULATION is a phasing SSB modulator built here rather than WDSP's TXA
+// chain — see the long note in the .cpp for why, and for the measured evidence
+// that a correctly-configured-looking TXA channel emitted pure zeros.
+class Hl2TxDsp : public QObject {
+    Q_OBJECT
+
+public:
+    explicit Hl2TxDsp(QObject* parent = nullptr);
+    ~Hl2TxDsp() override;
+
+    struct Config {
+        int inputSampleRateHz = 24000;    // AudioEngine TX audio rate
+        int outputSampleRateHz = 48000;   // EP2, fixed
+        int dspBlockSize = 512;           // input samples per WDSP block
+        WdspChannel::Mode mode = WdspChannel::Mode::Usb;
+        // SSB transmit passband. Narrower than the RX default on purpose:
+        // splatter outside this is other people's problem, not ours.
+        double filterLowHz = 300.0;
+        double filterHighHz = 2700.0;
+    };
+
+    Q_INVOKABLE bool configure(const Config& config, std::string* error = nullptr);
+    Q_INVOKABLE void setMode(WdspChannel::Mode mode);
+    Q_INVOKABLE void setFilter(double lowHz, double highHz);
+    // Linear gain applied to the audio before modulation. 1.0 = unity.
+    Q_INVOKABLE void setMicGain(double linear);
+    [[nodiscard]] double micGain() const noexcept { return m_micGain; }
+
+public slots:
+    // Mono TX audio at inputSampleRateHz.
+    void processAudioBlock(const std::vector<float>& mono);
+    // Drop anything buffered — on unkey, so the next transmission does not
+    // start with the tail of the previous one.
+    void reset();
+
+signals:
+    void iqReady(const std::vector<std::complex<float>>& iq);   // at outputSampleRateHz
+    void micPeak(float dbfs);                                   // post-gain, pre-modulation
+
+private:
+    void designFilters();
+    bool isLowerSideband() const;
+
+    // Filter length. 255 taps at 48 kHz gives a transition sharp enough for a
+    // 300 Hz low edge and, with a Blackman window, opposite-sideband
+    // suppression well past what the transmitter needs.
+    static constexpr std::size_t kTaps = 255;
+
+    Config m_config;
+    double m_micGain = 1.0;
+    int m_upsample = 2;
+
+    std::vector<float> m_bandpass;      // real bandpass
+    std::vector<float> m_hilbert;       // quadrature half of the analytic bandpass
+    std::vector<float> m_hist;          // shared delay line
+    std::size_t m_histPos = 0;
+
+    std::vector<float> m_inBuffer;      // pending input audio
+    std::vector<std::complex<float>> m_iq;
+};
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -6,6 +6,8 @@
 #include <QUdpSocket>
 #include <QtGlobal>
 
+#include <QDebug>
+
 #include <algorithm>
 #include <cmath>
 #include <span>

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -7,6 +7,7 @@
 #include <QtGlobal>
 
 #include <algorithm>
+#include <cmath>
 #include <span>
 
 #ifdef Q_OS_WIN
@@ -337,6 +338,14 @@ void MetisClient::queueTxIq(std::span<const std::complex<float>> iq)
         m_txIq.pop_front();
 }
 
+void MetisClient::setTxTestTone(double offsetHz, double amplitude)
+{
+    m_toneHz = offsetHz;
+    m_toneAmp = amplitude < 0.0 ? 0.0 : (amplitude > 1.0 ? 1.0 : amplitude);
+    if (m_toneAmp == 0.0)
+        m_tonePhase = 0.0;
+}
+
 std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
 {
     static const Cc kCcAdc = ccAdcAssign();
@@ -359,7 +368,21 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     // Only put samples on the wire while actually keyed. Unkeyed frames carry
     // transmit silence, which is what ep2Packet's zero fill already gives us --
     // and which also keeps EADDR zero (see ep2WriteTxIq).
-    if (keyed && !m_txIq.empty()) {
+    if (keyed && m_toneAmp > 0.0) {
+        // EP2 is clocked at a fixed 48 kHz regardless of the RX sample rate.
+        std::vector<std::complex<float>> block(kTxSamplesPerPacket);
+        const double dphi = 2.0 * 3.14159265358979323846 * m_toneHz / kEp2AudioRateHz;
+        for (int n = 0; n < kTxSamplesPerPacket; ++n) {
+            block[static_cast<std::size_t>(n)] = {
+                static_cast<float>(m_toneAmp * std::cos(m_tonePhase)),
+                static_cast<float>(m_toneAmp * std::sin(m_tonePhase))};
+            m_tonePhase += dphi;
+        }
+        // Keep the accumulator bounded without introducing a phase step.
+        while (m_tonePhase > 2.0 * 3.14159265358979323846)
+            m_tonePhase -= 2.0 * 3.14159265358979323846;
+        ep2WriteTxIq(pkt, block);
+    } else if (keyed && !m_txIq.empty()) {
         std::vector<std::complex<float>> block;
         const std::size_t n = std::min<std::size_t>(kTxSamplesPerPacket, m_txIq.size());
         block.reserve(n);

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -356,6 +356,11 @@ void MetisClient::setTxTestTone(double offsetHz, double amplitude)
         m_tonePhase = 0.0;
 }
 
+void MetisClient::flushTxIq()
+{
+    m_txIq.clear();
+}
+
 std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
 {
     static const Cc kCcAdc = ccAdcAssign();

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -388,9 +388,15 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
         std::vector<std::complex<float>> block(kTxSamplesPerPacket);
         const double dphi = 2.0 * 3.14159265358979323846 * m_toneHz / kEp2AudioRateHz;
         for (int n = 0; n < kTxSamplesPerPacket; ++n) {
+            // Negative sine: the HPSDR wire has the opposite handedness to the
+            // standard analytic convention, so this is the conjugate — the same
+            // correction Hl2TxDsp applies. ONE convention for both transmit
+            // paths, or a tone at a non-zero offset would land on the opposite
+            // side of the carrier from voice. (At the zero offset TUNE uses,
+            // handedness has no effect either way.)
             block[static_cast<std::size_t>(n)] = {
                 static_cast<float>(m_toneAmp * std::cos(m_tonePhase)),
-                static_cast<float>(m_toneAmp * std::sin(m_tonePhase))};
+                static_cast<float>(-m_toneAmp * std::sin(m_tonePhase))};
             m_tonePhase += dphi;
         }
         // Keep the accumulator bounded without introducing a phase step.

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -305,6 +305,49 @@ void MetisClient::requestPipelineReset()
     // on hardware, not just discrete tunes.
 }
 
+void MetisClient::setMox(bool keyed)
+{
+    if (keyed && !m_txAllowed) {
+        // Fail SAFE and stay refused. Not an error return: a caller that could
+        // retry past a refusal is exactly what this gate exists to prevent.
+        m_mox = false;
+        return;
+    }
+    m_mox = keyed;
+}
+
+void MetisClient::setTxFrequencyHz(std::uint32_t hz)
+{
+    m_ccTxFreq = ccTxFreq(hz);
+    m_oneShot.push_back(m_ccTxFreq);
+}
+
+void MetisClient::setTxDriveLevel(int level)
+{
+    m_ccTxDrive = ccTxDrive(level);
+    m_oneShot.push_back(m_ccTxDrive);
+}
+
+std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
+{
+    static const Cc kCcAdc = ccAdcAssign();
+    Cc b;
+    if (!m_oneShot.empty()) {
+        b = m_oneShot.front();
+        m_oneShot.pop_front();
+    } else {
+        const Cc* alt[3] = {&m_ccFreq, &m_ccGain, &kCcAdc};
+        b = *alt[m_roundRobin % 3];
+        ++m_roundRobin;
+    }
+    // MOX rides in C0 bit 0 of EVERY frame, so BOTH sub-frames carry it -- the
+    // radio keys off whichever bank is in flight. m_mox can only be true if the
+    // gate allowed it (see setMox), so this is the single place keying reaches
+    // the wire and it cannot be set behind the gate's back.
+    const bool keyed = m_mox && m_txAllowed;
+    return ep2Packet(m_txSeq++, withMox(m_ccConfig, keyed), withMox(b, keyed));
+}
+
 void MetisClient::sendControlPacket()
 {
     if (!m_socket)
@@ -317,17 +360,7 @@ void MetisClient::sendControlPacket()
     // device leaves every receiver unassigned (and therefore emits all-zero IQ)
     // until it has seen it. Re-asserting it rather than sending it once keeps a
     // device that reconnects or resets mid-session from silently going quiet.
-    static const Cc kCcAdc = ccAdcAssign();
-    Cc b;
-    if (!m_oneShot.empty()) {
-        b = m_oneShot.front();
-        m_oneShot.pop_front();
-    } else {
-        const Cc* alt[3] = {&m_ccFreq, &m_ccGain, &kCcAdc};
-        b = *alt[m_roundRobin % 3];
-        ++m_roundRobin;
-    }
-    sendTo(*m_socket, ep2Packet(m_txSeq++, m_ccConfig, b), m_host, m_port);
+    sendTo(*m_socket, buildNextControlPacket(), m_host, m_port);
 }
 
 void MetisClient::onReadyRead()

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -58,6 +58,11 @@ void enableBroadcast(QUdpSocket& s) noexcept
 }  // namespace
 
 MetisClient::MetisClient(QObject* parent) : QObject(parent) {
+    // Telemetry crosses from the I/O thread to the GUI thread as a queued
+    // signal argument; without registration Qt drops the emission with only a
+    // warning, and the meters would simply never move.
+    qRegisterMetaType<AetherSDR::hl2::Hl2Telemetry>("AetherSDR::hl2::Hl2Telemetry");
+
     // Paces EP2 from a wall clock (see kEp2PacerTickMs) so C&C keeps flowing
     // even if the EP6 receive path stalls.
     m_ep2Timer = new QTimer(this);
@@ -438,6 +443,24 @@ void MetisClient::onReadyRead()
         }
         m_expectedRxSeq = *seq + 1;
         m_haveRxSeq = true;
+
+        // Telemetry rides in the C&C bytes of each EP6 frame. The radio
+        // free-runs through the classic response addresses, so this arrives
+        // continuously without us ever issuing a RQST -- which is the cadence
+        // the oracle asks for anyway (§5: saturating with requests starves the
+        // classic responses that carry exactly this).
+        const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+        bool telemetryChanged = false;
+        for (const std::size_t fs : frameStarts) {
+            if (bytes.size() < fs + 8)
+                break;
+            if (const auto resp = parseEp6Response(bytes.data() + fs)) {
+                m_telemetry.apply(*resp);
+                telemetryChanged = true;
+            }
+        }
+        if (telemetryChanged)
+            emit telemetryUpdated(m_telemetry);
 
         m_block.clear();
         if (ep6Samples(bytes, m_block) > 0)

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -332,7 +332,10 @@ void MetisClient::setTxFrequencyHz(std::uint32_t hz)
 
 void MetisClient::setTxDriveLevel(int level)
 {
-    m_ccTxDrive = ccTxDrive(level);
+    // The PA follows the drive level: a non-zero drive means the operator wants
+    // output, and on this board that requires the onboard amplifier. Drive 0
+    // leaves it disabled, so the safe default state stays safe.
+    m_ccTxDrive = ccTxDrive(level, level > 0);
     m_oneShot.push_back(m_ccTxDrive);
 }
 

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -328,6 +328,15 @@ void MetisClient::setTxDriveLevel(int level)
     m_oneShot.push_back(m_ccTxDrive);
 }
 
+void MetisClient::queueTxIq(std::span<const std::complex<float>> iq)
+{
+    for (const auto& s : iq)
+        m_txIq.push_back(s);
+    // Drop the OLDEST on overflow: stale transmit audio is worse than a gap.
+    while (m_txIq.size() > kTxQueueMax)
+        m_txIq.pop_front();
+}
+
 std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
 {
     static const Cc kCcAdc = ccAdcAssign();
@@ -345,7 +354,22 @@ std::array<std::uint8_t, kUsbPacketSize> MetisClient::buildNextControlPacket()
     // gate allowed it (see setMox), so this is the single place keying reaches
     // the wire and it cannot be set behind the gate's back.
     const bool keyed = m_mox && m_txAllowed;
-    return ep2Packet(m_txSeq++, withMox(m_ccConfig, keyed), withMox(b, keyed));
+    auto pkt = ep2Packet(m_txSeq++, withMox(m_ccConfig, keyed), withMox(b, keyed));
+
+    // Only put samples on the wire while actually keyed. Unkeyed frames carry
+    // transmit silence, which is what ep2Packet's zero fill already gives us --
+    // and which also keeps EADDR zero (see ep2WriteTxIq).
+    if (keyed && !m_txIq.empty()) {
+        std::vector<std::complex<float>> block;
+        const std::size_t n = std::min<std::size_t>(kTxSamplesPerPacket, m_txIq.size());
+        block.reserve(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            block.push_back(m_txIq.front());
+            m_txIq.pop_front();
+        }
+        ep2WriteTxIq(pkt, block);   // a short block leaves the rest as silence
+    }
+    return pkt;
 }
 
 void MetisClient::sendControlPacket()

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -130,6 +130,19 @@ public:
     void queueTxIq(std::span<const std::complex<float>> iq);
     [[nodiscard]] std::size_t txQueueDepth() const noexcept { return m_txIq.size(); }
 
+    // A baseband test tone, offsetHz from the TX carrier, amplitude 0..1.
+    // amplitude <= 0 disables it. Takes precedence over queued IQ.
+    //
+    // Synthesised inside the packet builder, one packet's worth at a time, so it
+    // is paced by EP2 itself rather than by a producer thread that could drift
+    // against the pacer and underrun. Phase carries across packets, so the tone
+    // is continuous rather than restarting every 2.625 ms.
+    //
+    // NEVER enabled implicitly. A radio that emits a carrier because a default
+    // said so is an unintended transmission, so this is opt-in only.
+    Q_INVOKABLE void setTxTestTone(double offsetHz, double amplitude);
+    [[nodiscard]] bool txTestToneEnabled() const noexcept { return m_toneAmp > 0.0; }
+
 signals:
     void linkUp();                                                  // first EP6 seen
     void linkDown();                                               // stopped
@@ -200,6 +213,9 @@ private:
     // Roughly a quarter second at 48 kHz. Past this the operator is hearing
     // latency, so dropping is better than growing the backlog.
     static constexpr std::size_t kTxQueueMax = 12000;
+    double m_toneHz = 0.0;
+    double m_toneAmp = 0.0;
+    double m_tonePhase = 0.0;   // radians, carried across packets
     bool m_mox = false;         // requested key state, only honoured if m_txAllowed
 
     std::uint32_t m_txSeq = 0;           // outgoing EP2 sequence

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -85,6 +85,33 @@ public:
     // numRx clamped to what the board says it has. See Params.
     int effectiveNumRx() const;
 
+    // ---- TRANSMIT ----
+    //
+    // This class could not key a radio at all until TX was added; every C0 was
+    // even, so MOX was structurally always 0. That invariant is gone, and this
+    // gate is what replaces it.
+    //
+    // enableTransmit() must be called explicitly before setMox() will do
+    // anything. Default OFF, and setMox(true) with the gate closed is a no-op
+    // that leaves every outgoing frame unkeyed -- not an error, because a
+    // refused key must fail SAFE and stay refused rather than surfacing as
+    // something a caller might retry past.
+    //
+    // hl2_tx_gate_test asserts the property directly: with the gate closed, no
+    // emitted EP2 frame ever carries C0 bit 0, even with a key request standing.
+    void enableTransmit(bool allowed) noexcept { m_txAllowed = allowed; }
+    [[nodiscard]] bool transmitEnabled() const noexcept { return m_txAllowed; }
+
+    // Key / unkey. Ignored unless enableTransmit(true) was called.
+    Q_INVOKABLE void setMox(bool keyed);
+    [[nodiscard]] bool isKeyed() const noexcept { return m_mox; }
+    Q_INVOKABLE void setTxFrequencyHz(std::uint32_t hz);
+    Q_INVOKABLE void setTxDriveLevel(int level);
+
+    // Build the EP2 packet this client would send next, without sending it.
+    // Exists so the gate can be tested on the exact bytes that would go out.
+    std::array<std::uint8_t, kUsbPacketSize> buildNextControlPacket();
+
 signals:
     void linkUp();                                                  // first EP6 seen
     void linkDown();                                               // stopped
@@ -147,6 +174,11 @@ private:
     Cc m_ccConfig{};
     Cc m_ccGain{};
     Cc m_ccFreq{};
+    Cc m_ccTxFreq{};
+    Cc m_ccTxDrive{};
+
+    bool m_txAllowed = false;   // gate; see enableTransmit()
+    bool m_mox = false;         // requested key state, only honoured if m_txAllowed
 
     std::uint32_t m_txSeq = 0;           // outgoing EP2 sequence
     unsigned m_roundRobin = 0;

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -129,6 +129,9 @@ public:
     // watchdog. Overflow drops the oldest, because on transmit the freshest
     // audio is the one that matters.
     void queueTxIq(std::span<const std::complex<float>> iq);
+    // Discard pending transmit audio. Call on unkey: whatever is still queued
+    // belongs to the transmission that just ended.
+    Q_INVOKABLE void flushTxIq();
     [[nodiscard]] std::size_t txQueueDepth() const noexcept { return m_txIq.size(); }
 
     // A baseband test tone, offsetHz from the TX carrier, amplitude 0..1.

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -98,6 +98,12 @@ public:
     // refused key must fail SAFE and stay refused rather than surfacing as
     // something a caller might retry past.
     //
+    // This class does not read the environment and has no policy of its own.
+    // Hl2Backend decides: an interactive run enables it, an automation run
+    // defers to the bridge's AETHER_AUTOMATION_ALLOW_TX gate. Keeping the
+    // mechanism here and the policy there is what lets the policy change --
+    // as it just did -- without touching the part that is actually tested.
+    //
     // hl2_tx_gate_test asserts the property directly: with the gate closed, no
     // emitted EP2 frame ever carries C0 bit 0, even with a key request standing.
     void enableTransmit(bool allowed) noexcept { m_txAllowed = allowed; }

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -7,6 +7,7 @@
 #include <QObject>
 
 #include <complex>
+#include <span>
 #include <cstdint>
 #include <deque>
 #include <vector>
@@ -112,6 +113,17 @@ public:
     // Exists so the gate can be tested on the exact bytes that would go out.
     std::array<std::uint8_t, kUsbPacketSize> buildNextControlPacket();
 
+    // Queue transmit IQ. Samples are consumed kTxSamplesPerPacket at a time, one
+    // packet per EP2 frame, so the queue drains at the 48 kHz EP2 rate.
+    //
+    // Underflow is SILENCE, not a stall: a short queue emits zeros rather than
+    // repeating stale samples or blocking the pacer. Repeating would put a
+    // periodic artefact on the air, and blocking would starve the radio's
+    // watchdog. Overflow drops the oldest, because on transmit the freshest
+    // audio is the one that matters.
+    void queueTxIq(std::span<const std::complex<float>> iq);
+    [[nodiscard]] std::size_t txQueueDepth() const noexcept { return m_txIq.size(); }
+
 signals:
     void linkUp();                                                  // first EP6 seen
     void linkDown();                                               // stopped
@@ -178,6 +190,10 @@ private:
     Cc m_ccTxDrive{};
 
     bool m_txAllowed = false;   // gate; see enableTransmit()
+    std::deque<std::complex<float>> m_txIq;   // pending transmit samples
+    // Roughly a quarter second at 48 kHz. Past this the operator is hearing
+    // latency, so dropping is better than growing the backlog.
+    static constexpr std::size_t kTxQueueMax = 12000;
     bool m_mox = false;         // requested key state, only honoured if m_txAllowed
 
     std::uint32_t m_txSeq = 0;           // outgoing EP2 sequence

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -74,6 +74,7 @@ public:
     Q_INVOKABLE void stop();                        // send stop, close socket
     [[nodiscard]] bool isRunning() const noexcept { return m_running; }
     [[nodiscard]] quint64 droppedPackets() const noexcept { return m_drops; }
+    [[nodiscard]] const Hl2Telemetry& telemetry() const noexcept { return m_telemetry; }
 
     // Live control — latched into the next C&C round sent to the radio.
     Q_INVOKABLE void setRxFrequencyHz(std::uint32_t hz);
@@ -148,6 +149,10 @@ signals:
     void linkDown();                                               // stopped
     void iqBlockReady(const std::vector<std::complex<float>>& block);  // one per EP6 packet
     void dropsUpdated(quint64 drops);                             // cumulative EP6 gaps
+    // Radio telemetry decoded from the EP6 C&C bytes: forward/reverse power,
+    // temperature, TX FIFO depth, ADC overload, PTT. Free-running, so it
+    // arrives without us issuing a request.
+    void telemetryUpdated(const AetherSDR::hl2::Hl2Telemetry& t);
     // No EP6 arrived within kConnectTimeoutMs of start() — the radio is off,
     // unreachable, or already streaming to a different client.
     void connectFailed(const QString& reason);
@@ -231,6 +236,13 @@ private:
     bool m_running = false;
     bool m_linkUp = false;
     std::vector<std::complex<float>> m_block;   // reused per-packet decode buffer
+    Hl2Telemetry m_telemetry;                   // accumulated across RADDR cycles
 };
 
 }  // namespace AetherSDR::hl2
+
+// Hl2Telemetry rides a queued signal from the I/O thread to the GUI thread.
+// Declared HERE and not in MetisProtocol.h on purpose: that header is
+// deliberately Qt-free so the wire primitives unit-test without linking Qt,
+// and hl2_metis_protocol_test does exactly that.
+Q_DECLARE_METATYPE(AetherSDR::hl2::Hl2Telemetry)

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -80,6 +80,62 @@ Cc ccPipelineReset() noexcept
     return {kC0Sync, 0x00, 0x00, 0x00, 0x80};
 }
 
+Cc ccTxFreq(std::uint32_t hz) noexcept
+{
+    return {kC0TxFreq,
+            static_cast<std::uint8_t>((hz >> 24) & 0xFF),
+            static_cast<std::uint8_t>((hz >> 16) & 0xFF),
+            static_cast<std::uint8_t>((hz >> 8) & 0xFF),
+            static_cast<std::uint8_t>(hz & 0xFF)};
+}
+
+Cc ccTxDrive(int level) noexcept
+{
+    if (level < 0) level = 0;
+    if (level > kTxDriveMax) level = kTxDriveMax;
+    // C1 = DATA[31:24]. Everything else in 0x09 (PA enable, ATU tune, Alex
+    // filters, VNA) stays zero: this is a bare drive-level write, and the PA
+    // enable in particular is not something to set as a side effect.
+    return {kC0TxDrive, static_cast<std::uint8_t>(level), 0x00, 0x00, 0x00};
+}
+
+void ep2WriteTxIq(std::array<std::uint8_t, kUsbPacketSize>& pkt,
+                  std::span<const std::complex<float>> iq) noexcept
+{
+    const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+    std::size_t consumed = 0;
+    for (const std::size_t fs : frameStarts) {
+        std::uint8_t* payload = pkt.data() + fs + 8;     // after SYNC(3) + C&C(5)
+        for (std::size_t k = 0; k + kRxSampleBytes <= kFramePayload; k += kRxSampleBytes) {
+            // payload[k+0..3] is the Hermes headphone-audio slot. On the first
+            // sample of each frame it is EADDR (extended address, base 0x3f),
+            // NOT audio. We never write it, so it stays zero from ep2Packet's
+            // zero fill -- which is exactly what "not using the extended
+            // address space" must look like on the wire.
+            std::int16_t i = 0;
+            std::int16_t q = 0;
+            if (consumed < iq.size()) {
+                const auto clamp = [](float v) -> std::int16_t {
+                    // Symmetric clamp: 32767, not 32768. Letting a full-scale
+                    // sample wrap to the negative rail is a click at best.
+                    if (v >  1.0f) v =  1.0f;
+                    if (v < -1.0f) v = -1.0f;
+                    return static_cast<std::int16_t>(v * 32767.0f);
+                };
+                i = clamp(iq[consumed].real());
+                q = clamp(iq[consumed].imag());
+                ++consumed;
+            }
+            const auto ui = static_cast<std::uint16_t>(i);
+            const auto uq = static_cast<std::uint16_t>(q);
+            payload[k + 4] = static_cast<std::uint8_t>((ui >> 8) & 0xFF);   // I high
+            payload[k + 5] = static_cast<std::uint8_t>(ui & 0xFF);          // I low
+            payload[k + 6] = static_cast<std::uint8_t>((uq >> 8) & 0xFF);   // Q high
+            payload[k + 7] = static_cast<std::uint8_t>(uq & 0xFF);          // Q low
+        }
+    }
+}
+
 std::array<std::uint8_t, 64> metisCommand(std::uint8_t cmd) noexcept
 {
     std::array<std::uint8_t, 64> out{};                  // zero-filled pad

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -1,5 +1,7 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
+#include <cmath>
+
 namespace AetherSDR::hl2 {
 
 namespace {
@@ -134,6 +136,87 @@ void ep2WriteTxIq(std::array<std::uint8_t, kUsbPacketSize>& pkt,
             payload[k + 7] = static_cast<std::uint8_t>(uq & 0xFF);          // Q low
         }
     }
+}
+
+std::optional<Ep6Response> parseEp6Response(const std::uint8_t* frame) noexcept
+{
+    if (frame[0] != kSync || frame[1] != kSync || frame[2] != kSync)
+        return std::nullopt;
+    const std::uint8_t c0 = frame[3];
+    Ep6Response r;
+    r.ack = (c0 & 0x80) != 0;
+    if (r.ack) {
+        r.raddr = (c0 >> 1) & 0x3F;      // full 6 bits when answering a RQST
+    } else {
+        r.raddr = (c0 >> 3) & 0x0F;      // classic free-running cycle
+        r.dot   = (c0 & 0x04) != 0;      // CW key tip; C0[1] Dash is always 0 here
+    }
+    r.ptt  = (c0 & 0x01) != 0;
+    r.data = readBe32(frame + 4);
+    return r;
+}
+
+void Hl2Telemetry::apply(const Ep6Response& r) noexcept
+{
+    ptt = r.ptt;
+    switch (r.raddr) {
+    case 0x00:
+        firmwareVersion = static_cast<int>(r.data & 0xFF);
+        adcOverload     = (r.data & (1u << 24)) != 0;
+        // ACTIVE LOW on the wire: the bit is SET when transmit is permitted.
+        // Decoded here so nothing above this layer has to remember the inversion.
+        txInhibited     = (r.data & (1u << 25)) == 0;
+        // TX IQ FIFO depth. hpsdrsim writes a 15-bit count as C2[6:0]:C3[7:0],
+        // i.e. DATA[22:8], and that is what this decodes because it is what we
+        // can actually verify.
+        //
+        // THE ORACLE DISAGREES: §6 lists [14:8] as "FIFO count MSBs" and [15:14]
+        // as an under/overflow code, which overlaps bit 14 and cannot both be
+        // right. The gateware RTL is the authority and this has NOT been checked
+        // against it. Do not build FIFO-servoed TX pacing on this field until it
+        // has been — a pacing loop driven by a misread depth is exactly the kind
+        // of unverified assumption that wedged a radio once already.
+        txFifoCount     = static_cast<int>((r.data >> 8) & 0x7FFF);
+        txFifoUnderflow = ((r.data >> 14) & 0x3) == 0x2;
+        txFifoOverflow  = ((r.data >> 14) & 0x3) == 0x3;
+        break;
+    case 0x01:
+        temperatureRaw  = static_cast<int>((r.data >> 16) & 0xFFFF);
+        forwardPowerRaw = static_cast<int>(r.data & 0xFFFF);
+        break;
+    case 0x02:
+        reversePowerRaw = static_cast<int>((r.data >> 16) & 0xFFFF);
+        biasCurrentRaw  = static_cast<int>(r.data & 0xFFFF);
+        break;
+    default:
+        break;                            // 0x03/0x04 carry nothing we consume
+    }
+}
+
+std::optional<double> swrFromRaw(int forwardRaw, int reverseRaw) noexcept
+{
+    // No carrier, no SWR. Returning 1.0 here would render as a perfect match
+    // when the truth is that the question is meaningless.
+    if (forwardRaw <= 0)
+        return std::nullopt;
+    // The counts are VOLTAGE-proportional, so rho is a plain ratio and there is
+    // no square root. Establishing that mattered: the power form would have
+    // reported roughly the square root of the true reflection coefficient, i.e.
+    // a flattering SWR that hides a real mismatch.
+    //
+    // Evidence: hpsdrsim derives its reading as j proportional to
+    // sqrt(txlevel), and txlevel is a sum of i^2+q^2 — a power — so the reported
+    // count is proportional to voltage. pihpsdr's own meter.c is inconsistent
+    // (one branch uses the voltage form (Vf+Vr)/(Vf-Vr), another a sqrt form
+    // whose arguments are the wrong way round and would return a NEGATIVE SWR),
+    // so it is not usable as the tie-breaker.
+    const double fwd = static_cast<double>(forwardRaw);
+    double rev = static_cast<double>(reverseRaw < 0 ? 0 : reverseRaw);
+    // Reverse above forward is physically impossible; it means noise on a tiny
+    // reading. Clamp rather than emit a negative or infinite SWR.
+    if (rev >= fwd)
+        rev = fwd * 0.999;
+    return (fwd + rev) / (fwd - rev);
 }
 
 std::array<std::uint8_t, 64> metisCommand(std::uint8_t cmd) noexcept

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -91,14 +91,15 @@ Cc ccTxFreq(std::uint32_t hz) noexcept
             static_cast<std::uint8_t>(hz & 0xFF)};
 }
 
-Cc ccTxDrive(int level) noexcept
+Cc ccTxDrive(int level, bool paEnable) noexcept
 {
     if (level < 0) level = 0;
     if (level > kTxDriveMax) level = kTxDriveMax;
-    // C1 = DATA[31:24]. Everything else in 0x09 (PA enable, ATU tune, Alex
-    // filters, VNA) stays zero: this is a bare drive-level write, and the PA
-    // enable in particular is not something to set as a side effect.
-    return {kC0TxDrive, static_cast<std::uint8_t>(level), 0x00, 0x00, 0x00};
+    // C1 = DATA[31:24] drive level. C2 = DATA[23:16]; bit 3 of it is DATA[19],
+    // the onboard PA enable. ATU tune, Alex filters and VNA stay zero — those
+    // are separate decisions and none of them belong in a drive-level write.
+    const auto c2 = static_cast<std::uint8_t>(paEnable ? 0x08 : 0x00);
+    return {kC0TxDrive, static_cast<std::uint8_t>(level), c2, 0x00, 0x00};
 }
 
 void ep2WriteTxIq(std::array<std::uint8_t, kUsbPacketSize>& pkt,

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -82,11 +82,15 @@ inline constexpr std::uint8_t kC0AdcGain = 0x14;  // addr 0x0a: AD9866 LNA gain
 // correctly framed, correctly paced, all-ZERO IQ — indistinguishable from a
 // dead antenna. Verified against hpsdrsim, whose rx_adc[] defaults to -1.
 //
-// On the HL2 itself the all-zero payload is inert: bit 15 clear leaves
-// hardware-managed TX gain disabled, which is already the default. BEFORE ANY
-// TX WORK, this must be reconciled — 0x0e is the register behind the T/R gain
-// switch (the mechanism Quisk uses) and PureSignal's unclipped feedback path,
-// and this round robin would otherwise zero it every third frame.
+// On the HL2 the all-zero payload is inert: bit 15 clear leaves hardware-managed
+// TX gain disabled, which is already the default — and transmit has since been
+// brought up and verified on air with it left that way, so this is NOT a
+// blocker for basic SSB.
+//
+// It still matters for two things neither of which is implemented: the T/R gain
+// switch (the mechanism Quisk uses for fast turnaround) and PureSignal's
+// unclipped feedback path. Both need 0x0e to carry a real value, and this round
+// robin would zero it every third frame.
 inline constexpr std::uint8_t kC0AdcAssignOrTxGain = 0x1C;
 
 // addr 0x39: sync / reset. DATA[7:4] = 0x8 resets every decimation filter
@@ -275,7 +279,9 @@ struct DiscoveryReply {
 std::optional<DiscoveryReply> parseDiscoveryReply(std::span<const std::uint8_t> pkt) noexcept;
 
 // Build a 1032-byte EP2 packet carrying two C&C registers (one per frame). The
-// 504-byte TX payload is all-zero (RX-only).
+// 504-byte payload is zero-filled, which is transmit SILENCE — ep2WriteTxIq()
+// overwrites it when there is audio to send. The zero fill is also what keeps
+// EADDR clear; see ep2WriteTxIq.
 std::array<std::uint8_t, kUsbPacketSize> ep2Packet(std::uint32_t seq, const Cc& a,
                                                    const Cc& b) noexcept;
 

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -174,6 +174,61 @@ void ep2WriteTxIq(std::array<std::uint8_t, kUsbPacketSize>& pkt,
 // Transmit samples carried per EP2 packet (63 per frame, two frames).
 inline constexpr int kTxSamplesPerPacket = 126;
 
+// ---- EP6 Command & Control responses (radio -> host) ----
+//
+// C0[7] is ACK, and it CHANGES HOW THE REST OF C0 IS READ (oracle §5):
+//   ACK == 0 (classic, free-running): C0[6:3] = RADDR[3:0], C0[2] Dot,
+//            C0[1] Dash (always 0 — the HL2 has no internal keyer), C0[0] PTT.
+//   ACK == 1 (reply to our RQST):     C0[6:1] = RADDR[5:0], C0[0] PTT.
+//
+// The radio free-runs through the classic addresses, so telemetry arrives
+// without asking. Verified against hpsdrsim's responder, whose C0 sequence is
+// 0, 8, 16, 24, 32 — i.e. RADDR 0..4 at C0[6:3].
+struct Ep6Response {
+    bool ack = false;
+    int raddr = 0;
+    bool ptt = false;
+    bool dot = false;
+    std::uint32_t data = 0;      // C1..C4, big-endian
+};
+
+// Decode the C&C bytes of one 512-byte EP6 frame. Returns nullopt if the frame
+// is not sync-framed.
+std::optional<Ep6Response> parseEp6Response(const std::uint8_t* frame) noexcept;
+
+// Everything the classic response cycle carries. Fields are std::optional
+// because each RADDR carries only part of it, so "not seen yet" stays
+// distinguishable from "seen and zero" — a forward-power reading of 0 W is a
+// real measurement, and rendering it as a dash because we conflated the two
+// would be its own bug.
+struct Hl2Telemetry {
+    std::optional<int>  firmwareVersion;
+    std::optional<bool> adcOverload;
+    std::optional<bool> txInhibited;      // register bit is ACTIVE LOW; decoded here
+    std::optional<int>  txFifoCount;
+    std::optional<bool> txFifoUnderflow;
+    std::optional<bool> txFifoOverflow;
+    std::optional<int>  temperatureRaw;
+    std::optional<int>  forwardPowerRaw;
+    std::optional<int>  reversePowerRaw;
+    std::optional<int>  biasCurrentRaw;
+    bool ptt = false;
+
+    // Merge a decoded response in, leaving untouched fields alone.
+    void apply(const Ep6Response& r) noexcept;
+};
+
+// Standing-wave ratio from raw forward/reverse counts.
+//
+// The counts are UNCALIBRATED ADC readings, but SWR is a RATIO, so the unknown
+// scale factor cancels as long as both come from the same converter — which is
+// why SWR is meaningful here while absolute watts are not (oracle §6: "don't
+// pretend uncalibrated counts are watts").
+//
+// Returns nullopt when there is no forward power to speak of: SWR is undefined
+// with no carrier, and 1.0 would read as a perfect match rather than "unknown".
+std::optional<double> swrFromRaw(int forwardRaw, int reverseRaw) noexcept;
+
 // 64-byte Metis command: EF FE 04 <cmd>. cmd 0x01 = start IQ, 0x00 = stop.
 std::array<std::uint8_t, 64> metisCommand(std::uint8_t cmd) noexcept;
 // Bit 7 of the run/stop byte is the gateware's watchdog_disable flag

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -143,8 +143,16 @@ Cc ccPipelineReset() noexcept;
 
 // TX1 NCO frequency in Hz (32-bit big-endian across C1..C4).
 Cc ccTxFreq(std::uint32_t hz) noexcept;
-// TX drive level, clamped to 0..kTxDriveMax, carried in C1.
-Cc ccTxDrive(int level) noexcept;
+// TX drive level (0..kTxDriveMax, carried in C1) plus the onboard PA enable.
+//
+// PA ENABLE IS 0x09[19], i.e. C2 bit 3, and it is NOT optional for a useful
+// transmission: with the PA off the only output is the AD9866's own DAC level,
+// which is milliwatts. Measured on hardware — a correct, modulated, keyed
+// transmission with the PA disabled produced forward-power counts of zero.
+//
+// Defaulted OFF so that enabling the power amplifier is always something a
+// caller did on purpose.
+Cc ccTxDrive(int level, bool paEnable = false) noexcept;
 // Set MOX (C0 bit 0) on a C&C bank. Keying is per-FRAME, so this is applied to
 // whichever bank is being sent rather than to one dedicated register.
 inline Cc withMox(Cc cc, bool keyed) noexcept

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -22,8 +22,15 @@
 // captured/synthetic frames without hardware; MetisClient owns the UDP socket
 // and RX thread and calls into these functions.
 //
-// RX-ONLY BY CONSTRUCTION: every C0 register-address byte here is even, so the
-// MOX bit (C0 bit 0) is always 0 — these primitives cannot key the radio.
+// TRANSMIT: this layer CAN now encode a keyed frame. The old invariant here —
+// "every C0 register-address byte is even, so MOX (C0 bit 0) is always 0, so
+// these primitives cannot key the radio" — no longer holds, and pretending
+// otherwise would be worse than losing it.
+//
+// What replaces it is a gate one level up: MetisClient will not set MOX unless
+// transmit has been explicitly enabled, and hl2_tx_gate_test asserts that with
+// the gate off NO emitted frame ever carries C0 bit 0. The encoders below are
+// pure functions; encoding a keyed frame is not the same as sending one.
 
 namespace AetherSDR::hl2 {
 
@@ -43,10 +50,24 @@ inline constexpr std::size_t kFramePayload = 504;     // 63 RX samples * 8 bytes
 inline constexpr std::size_t kRxSampleBytes = 8;      // I[3] Q[3] mic[2], 24-bit BE
 inline constexpr int kSamplesPerPacket = 126;         // 63 per frame * 2 frames
 
-// C0 register-address bytes (address << 1, MOX=0). Odd values (TX NCO C0=0x02)
-// are deliberately absent — this backend never encodes them.
+// C0 register-address bytes (address << 1). Bit 0 is MOX, not part of the
+// address, so every constant here is even and keying is applied separately with
+// withMox() — see kC0MoxBit.
 inline constexpr std::uint8_t kC0Config = 0x00;   // addr 0x00: sample rate + #RX + ADC select
 inline constexpr std::uint8_t kC0Rx1Freq = 0x04;  // addr 0x02: RX1 NCO frequency (Hz, 32-bit BE)
+inline constexpr std::uint8_t kC0TxFreq  = 0x02;  // addr 0x01: TX1 NCO frequency (Hz, 32-bit BE)
+inline constexpr std::uint8_t kC0TxDrive = 0x12;  // addr 0x09: TX drive level + PA/ATU/Alex bits
+
+// MOX lives in C0 bit 0 of EVERY C&C frame, not in a register of its own: the
+// radio reads it from whatever bank happens to be in flight. So keying is a
+// property of the frame, and every bank has to carry it while transmitting.
+inline constexpr std::uint8_t kC0MoxBit = 0x01;
+
+// TX drive level occupies DATA[31:24] (C1). The Hermes-Lite 2 gateware decodes
+// only the top nibble [31:28], but the byte-wide field is what the reference
+// clients and hpsdrsim both read, so the value is carried as 0..255 and the
+// hardware takes the coarse part of it.
+inline constexpr int kTxDriveMax = 255;
 inline constexpr std::uint8_t kC0AdcGain = 0x14;  // addr 0x0a: AD9866 LNA gain
 // addr 0x0e. THIS ADDRESS MEANS TWO DIFFERENT THINGS, which is exactly the
 // class of trap the HL2 oracle warns about:
@@ -119,6 +140,39 @@ Cc ccAdcAssign() noexcept;
 // One-shot filter-pipeline reset. UNUSED — read the warning at kC0Sync before
 // calling this from anywhere.
 Cc ccPipelineReset() noexcept;
+
+// TX1 NCO frequency in Hz (32-bit big-endian across C1..C4).
+Cc ccTxFreq(std::uint32_t hz) noexcept;
+// TX drive level, clamped to 0..kTxDriveMax, carried in C1.
+Cc ccTxDrive(int level) noexcept;
+// Set MOX (C0 bit 0) on a C&C bank. Keying is per-FRAME, so this is applied to
+// whichever bank is being sent rather than to one dedicated register.
+inline Cc withMox(Cc cc, bool keyed) noexcept
+{
+    cc[0] = static_cast<std::uint8_t>(keyed ? (cc[0] | kC0MoxBit)
+                                            : (cc[0] & ~kC0MoxBit));
+    return cc;
+}
+
+// Write 16-bit I/Q transmit samples into an EP2 packet built by ep2Packet().
+//
+// Host->radio sample layout is 8 bytes: 32 bits where Hermes put headphone
+// audio, then 16-bit I, then 16-bit Q, all big-endian. 63 samples per 512-byte
+// frame, two frames per packet.
+//
+// THE AUDIO SLOT IS NOT AUDIO. The HL2 has no codec, and the FIRST 32-bit
+// "audio" word after each frame's C&C bytes is repurposed as EADDR, the
+// extended-address register (base 0x3f). memcpy-ing a Hermes TX frame layout
+// writes garbage into it. We leave every audio slot zero, which keeps EADDR
+// zero, which is what "not using the extended space" has to look like.
+//
+// Samples beyond what the packet holds are ignored; a short span leaves the
+// remainder as transmit silence.
+void ep2WriteTxIq(std::array<std::uint8_t, kUsbPacketSize>& pkt,
+                  std::span<const std::complex<float>> iq) noexcept;
+
+// Transmit samples carried per EP2 packet (63 per frame, two frames).
+inline constexpr int kTxSamplesPerPacket = 126;
 
 // 64-byte Metis command: EF FE 04 <cmd>. cmd 0x01 = start IQ, 0x00 = stop.
 std::array<std::uint8_t, 64> metisCommand(std::uint8_t cmd) noexcept;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1369,6 +1369,15 @@ MainWindow::MainWindow(QWidget* parent)
             m_qsoRecorder, &QsoRecorder::feedRxAudio);
     connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
             m_qsoRecorder, &QsoRecorder::feedTxAudio);
+    // Host-modulated backends (HL2) take their transmit audio from the SAME tap
+    // the recorder uses: fully processed, after the test tone, compressor and
+    // EQ. One path means the TONE button, the microphone and the recording all
+    // agree with what actually goes on the air. A Flex radio modulates on the
+    // radio side and ignores this.
+    connect(m_audio, &AudioEngine::txFinalMonitorPcmReady,
+            this, [this](const QByteArray& pcm) {
+        m_radioModel.submitTxAudio(pcm, AudioEngine::DEFAULT_SAMPLE_RATE);
+    });
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             m_qsoRecorder, &QsoRecorder::onMoxChanged);
     // CW/CWX path (#2539): break-in keys the radio without a local MOX edge and

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -446,6 +446,11 @@ void MainWindow::wireRadioModel()
         const bool hostModulates =
             m_radioModel.family() != QLatin1String("flex");
         m_audio->setHostModulation(hostModulates && connected);
+        // PC audio is not optional on a host-modulating backend: all audio, both
+        // directions, lives on this computer. Turning it off would leave the
+        // operator deaf and mute with nothing to explain it.
+        if (m_titleBar)
+            m_titleBar->setPcAudioLocked(connected && hostModulates);
         if (connected && hostModulates) {
             if (!m_audio->isTxStreaming())
                 audioStartTx(m_radioModel.radioAddress(), 4991);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -427,6 +427,33 @@ void MainWindow::wireRadioModel()
             this, [this](bool connected) {
         dissolveAllSliceLinks(connected ? "radio connected" : "radio disconnected");
     });
+    // Local microphone capture for a backend that MODULATES ON THE HOST.
+    //
+    // Capture is otherwise started only from the Flex DAX signals
+    // (txAudioStreamReady / remoteTxStreamReady, gated on mic_selection=PC),
+    // none of which a Hermes-Lite 2 ever emits. The consequence was subtle: no
+    // capture meant no txFinalMonitorPcmReady, and since the TONE generator is
+    // injected INSIDE that callback, neither the microphone NOR the test tone
+    // produced anything — the radio keyed and transmitted silence, with the
+    // radio's own forward-power counts reading 0 to prove it.
+    //
+    // startTxStream also opens the Flex-side network sender, but that stays
+    // inert here: the Opus encoder and the VITA-49 send are gated on a stream id
+    // this backend never sets, so what actually runs is capture plus the client
+    // TX DSP chain, which is exactly what submitTxAudio needs.
+    connect(&m_radioModel, &RadioModel::connectionStateChanged,
+            this, [this](bool connected) {
+        const bool hostModulates =
+            m_radioModel.family() != QLatin1String("flex");
+        m_audio->setHostModulation(hostModulates && connected);
+        if (connected && hostModulates) {
+            if (!m_audio->isTxStreaming())
+                audioStartTx(m_radioModel.radioAddress(), 4991);
+        } else if (!connected && hostModulates) {
+            audioStopTx();
+        }
+    });
+
     connect(&m_radioModel, &RadioModel::connectionError,
             this, &MainWindow::onConnectionError);
     connect(&m_radioModel, &RadioModel::certFingerprintMismatch,

--- a/src/gui/PhoneCwApplet.cpp
+++ b/src/gui/PhoneCwApplet.cpp
@@ -707,6 +707,25 @@ void PhoneCwApplet::setTransmitModel(TransmitModel* model)
         m_updatingFromModel = false;
     });
 
+    // Host-modulating backend: PC is the only possible source, so show it and
+    // take the choice away rather than offering jacks that do not exist.
+    connect(m_model, &TransmitModel::hostModulationChanged, this, [this](bool on) {
+        if (!m_micSourceCombo) return;
+        m_updatingFromModel = true;
+        const QSignalBlocker blocker(m_micSourceCombo);
+        if (on) {
+            m_micSourceCombo->clear();
+            m_micSourceCombo->addItem(QStringLiteral("PC"));
+            m_micSourceCombo->setCurrentIndex(0);
+        }
+        m_micSourceCombo->setEnabled(!on);
+        m_micSourceCombo->setToolTip(
+            on ? tr("This radio is modulated by AetherSDR, so the PC microphone "
+                    "is the only input. The other sources are FlexRadio jacks.")
+               : QString());
+        m_updatingFromModel = false;
+    });
+
     connect(m_model, &TransmitModel::micInputListChanged, this, [this]() {
         m_updatingFromModel = true;
         const QSignalBlocker blocker(m_micSourceCombo);

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -803,6 +803,19 @@ void TitleBar::setMenuBar(QMenuBar* mb)
     m_hbox->insertWidget(0, mb);
 }
 
+void TitleBar::setPcAudioLocked(bool locked)
+{
+    if (!m_pcBtn)
+        return;
+    if (locked)
+        setPcAudioEnabled(true);      // locked ON, never locked off
+    m_pcBtn->setEnabled(!locked);
+    m_pcBtn->setToolTip(
+        locked ? tr("PC audio is required: this radio's audio is produced and "
+                    "captured on this computer, so it cannot be turned off.")
+               : QString());
+}
+
 void TitleBar::setPcAudioEnabled(bool on)
 {
     QSignalBlocker b(m_pcBtn);

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -30,6 +30,11 @@ public:
     void setMenuBar(QMenuBar* mb);
 
     void setPcAudioEnabled(bool on);
+    // Lock PC audio on. A host-modulating backend (HL2) plays and captures all
+    // of its audio locally, so turning PC audio off leaves the operator deaf and
+    // mute with no indication why — there is no radio-side audio path to fall
+    // back to, unlike a Flex.
+    void setPcAudioLocked(bool locked);
     void setPcAudioDevices(const QString& inputDevice, const QString& outputDevice);
     void setLineoutMuted(bool muted);
     void setMasterVolume(int pct);

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -1,4 +1,6 @@
 #include "MeterModel.h"
+
+#include <algorithm>
 #include "core/LogManager.h"
 #include <QDebug>
 #include <QDateTime>
@@ -229,6 +231,36 @@ float MeterModel::convertRaw(const MeterDef& def, qint16 raw) const
     if (def.unit == "degF" || def.unit == "degC")
         return static_cast<float>(raw) / 64.0f;
     return static_cast<float>(raw);
+}
+
+bool MeterModel::updateValueByName(const QString& source, const QString& name,
+                                   float converted, int sourceIndex)
+{
+    const int idx = findMeter(source, name, sourceIndex);
+    if (idx < 0)
+        return false;
+    const MeterDef* def = meterDef(idx);
+    if (!def)
+        return false;
+
+    // Inverse of convertRaw(). Kept adjacent to it so the two cannot drift.
+    float scale = 1.0f;
+    if (def->unit == "dBm" || def->unit == "dB" || def->unit == "dBFS" || def->unit == "SWR")
+        scale = 128.0f;
+    else if (def->unit == "Volts" || def->unit == "Amps")
+        scale = 256.0f;
+    else if (def->unit == "degF" || def->unit == "degC")
+        scale = 64.0f;
+
+    const float scaled = converted * scale;
+    // Saturate rather than wrap: a wrapped qint16 turns a large positive
+    // reading into a large NEGATIVE one, which on a power meter reads as
+    // "no output" at exactly the moment there is the most of it.
+    const qint16 raw = static_cast<qint16>(
+        std::clamp(scaled, -32768.0f, 32767.0f));
+
+    updateValues(QVector<quint16>{static_cast<quint16>(idx)}, QVector<qint16>{raw});
+    return true;
 }
 
 void MeterModel::clear()

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -51,6 +51,19 @@ public:
     // ids[i] is the meter index, vals[i] is the raw int16 value.
     void updateValues(const QVector<quint16>& ids, const QVector<qint16>& vals);
 
+    // Set one meter from an ALREADY-CONVERTED value, addressed by source+name.
+    //
+    // For backends that decode their own telemetry (HL2) rather than streaming
+    // Flex's raw meter packets. It converts back to the raw fixed-point form and
+    // goes through updateValues() on purpose: every derived quantity — forward
+    // power smoothing, SWR, TX-meter freshness timestamps, the change signals —
+    // lives in that path, and a second entry point that recomputed any of it
+    // would drift from the first.
+    //
+    // Returns false if no such meter is defined.
+    bool updateValueByName(const QString& source, const QString& name,
+                           float converted, int sourceIndex = -1);
+
     // Lookup a meter definition by index.
     const MeterDef* meterDef(int index) const;
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -585,6 +585,29 @@ void RadioModel::setupBackend(const QString& family)
         if (m_backend)
             m_backend->setTxPower(percent);
     });
+    // Keying and tune from the GUI.
+    //
+    // These paths never reached a non-Flex backend: the MOX button goes through
+    // TransmitModel::setMox, which emits the Flex text command "xmit 1" and
+    // nothing else, and TUNE emits "transmit tune 1" the same way. Only the
+    // automation bridge's key verb went through setTransmit() and therefore
+    // through the seam — which is exactly why keying worked under test and did
+    // nothing when the operator pressed MOX.
+    //
+    // Gated to non-Flex families ON PURPOSE: for Flex the text command above
+    // already keys the radio, and routing this as well would send "xmit 1"
+    // twice.
+    connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
+            [this](bool on) {
+        if (m_backend && m_family != QLatin1String("flex"))
+            m_backend->setKeying(on);
+    });
+    connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
+            [this](bool on) {
+        if (m_backend && m_family != QLatin1String("flex"))
+            m_backend->setTune(on);
+    });
+
     // Push the CURRENT power on connect, not only on change. rfPowerChanged
     // fires on edges, so a session that never touches the control left the
     // radio at whatever its own default was — on the HL2 that is drive 0, which

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5319,6 +5319,12 @@ void RadioModel::onMessageReceived(const ParsedMessage& msg)
 //   "meter 1"         → meter reading (handled by onMessageReceived)
 //   "removed=True"    → object was removed
 
+void RadioModel::submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz)
+{
+    if (m_backend)
+        m_backend->submitTxAudio(int16Stereo, sampleRateHz);
+}
+
 bool RadioModel::sendCommand(const QString& cmd)
 {
     // #3977: last-line ownership gate for pan writes. Every UI path that

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2399,7 +2399,16 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
         // stream so D-STAR is emitted only when that selected slice is DSTR.
         syncDigitalVoiceTxSelection(true);
     }
-    sendCmd(QString("xmit %1").arg(tx ? 1 : 0));
+    // Key through the SEAM, not with a raw Flex command. This used to be
+    // sendCmd("xmit N"), which meant IRadioBackend::setKeying had no callers at
+    // all and no non-Flex backend could ever be keyed -- the verb existed and
+    // was wired to nothing.
+    //
+    // Behaviour for Flex is unchanged: FlexBackend::setKeying sends the exact
+    // same "xmit N" through the same sink, and the only extra gate on that path
+    // matches "display pan set ", not "xmit".
+    if (m_backend)
+        m_backend->setKeying(tx);
 }
 
 void RadioModel::updateOperatorTransmit()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -578,6 +578,24 @@ void RadioModel::setupBackend(const QString& family)
     connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
             [this](int index) { m_meterModel.removeMeter(index); });
 
+    // Meter VALUES from a backend that decodes its own telemetry.
+    //
+    // Flex streams meter values on the VITA-49 data plane, so this signal had no
+    // consumer at all and every non-Flex meter reading was computed and then
+    // dropped on the floor — the HL2 S-meter was correct for a while before
+    // anyone noticed it never reached the UI.
+    //
+    // meterId is "SOURCE:NAME" (e.g. "TX:FWDPWR"), matching MeterDef's own
+    // source/name pair rather than inventing a second naming scheme.
+    connect(m_backend.get(), &IRadioBackend::meterUpdate, this,
+            [this](const QString& meterId, double value) {
+        const int colon = meterId.indexOf(QLatin1Char(':'));
+        if (colon <= 0)
+            return;
+        m_meterModel.updateValueByName(meterId.left(colon), meterId.mid(colon + 1),
+                                       static_cast<float>(value));
+    });
+
     // aetherd RFC 2.3: SliceModel touchpoint. The backend decodes Flex slice
     // status into a typed SliceDelta; RadioModel routes it to the addressed slice.
     // This is an AutoConnection: because FlexBackend shares RadioModel's thread it

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -578,6 +578,24 @@ void RadioModel::setupBackend(const QString& family)
     connect(m_backend.get(), &IRadioBackend::meterRemoved, this,
             [this](int index) { m_meterModel.removeMeter(index); });
 
+    // RF power to a backend that owns a drive register. Flex takes it as a text
+    // command from TransmitModel and ignores this.
+    connect(&m_transmitModel, &TransmitModel::rfPowerChanged, this,
+            [this](int percent) {
+        if (m_backend)
+            m_backend->setTxPower(percent);
+    });
+    // Push the CURRENT power on connect, not only on change. rfPowerChanged
+    // fires on edges, so a session that never touches the control left the
+    // radio at whatever its own default was — on the HL2 that is drive 0, which
+    // also leaves the PA disabled, so a perfectly correct keyed transmission
+    // produced no RF at all. Measured: forward-power counts stuck at zero.
+    connect(this, &RadioModel::connectionStateChanged, this,
+            [this](bool connected) {
+        if (connected && m_backend)
+            m_backend->setTxPower(m_transmitModel.rfPower());
+    });
+
     // Meter VALUES from a backend that decodes its own telemetry.
     //
     // Flex streams meter values on the VITA-49 data plane, so this signal had no

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -585,6 +585,15 @@ void RadioModel::setupBackend(const QString& family)
         if (m_backend)
             m_backend->setTxPower(percent);
     });
+    // Tell the transmit model whether the HOST modulates. It drives the
+    // mic-source list: a backend that modulates here has no physical input jacks
+    // to choose between, so "PC" is the only truthful answer.
+    connect(this, &RadioModel::connectionStateChanged, this,
+            [this](bool connected) {
+        m_transmitModel.setHostModulation(connected
+                                          && m_family != QLatin1String("flex"));
+    });
+
     // Keying and tune from the GUI.
     //
     // These paths never reached a non-Flex backend: the MOX button goes through

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -744,6 +744,8 @@ public:
     // advance local state to match a command MUST gate that on this return,
     // or the client will claim state the radio never took.
     bool sendCommand(const QString& cmd);
+    // Backend family currently in use ("flex", "hl2", "kiwi", ...).
+    QString family() const { return m_family; }
     // Forward processed transmit audio to a host-modulating backend. No-op when
     // the backend modulates on the radio side.
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -744,6 +744,9 @@ public:
     // advance local state to match a command MUST gate that on this return,
     // or the client will claim state the radio never took.
     bool sendCommand(const QString& cmd);
+    // Forward processed transmit audio to a host-modulating backend. No-op when
+    // the backend modulates on the radio side.
+    void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz);
 
     // Request local PTT for our station. Sends "client set local_ptt=1" and applies
     // an optimistic update in case the radio doesn't echo the state change.

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -233,6 +233,25 @@ void TransmitModel::setActiveProfile(const QString& profile)
 
 // ── Commands ────────────────────────────────────────────────────────────────
 
+void TransmitModel::setHostModulation(bool on)
+{
+    if (m_hostModulation == on)
+        return;
+    m_hostModulation = on;
+    if (on) {
+        // PC is the only source that exists on a host-modulating backend, so it
+        // is asserted rather than defaulted — a stale "MIC" carried over from a
+        // Flex session would otherwise sit there transmitting silence.
+        m_micInputList = QStringList{QStringLiteral("PC")};
+        if (m_micSelection != QLatin1String("PC")) {
+            m_micSelection = QStringLiteral("PC");
+            emit phoneStateChanged();
+        }
+        emit micInputListChanged();
+    }
+    emit hostModulationChanged(on);
+}
+
 void TransmitModel::setRfPower(int power)
 {
     power = qBound(0, power, 100);

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -274,6 +274,18 @@ void TransmitModel::startTune(PttSource source)
     // Mox tag and wrongly runs the operator-only timer. (#4131 review)
     m_activePttSource = source;
 
+    // Optimistic tune state, exactly as setMox() does for m_transmitting.
+    //
+    // m_tune was previously set ONLY from a radio status delta. Flex reports
+    // tune=1 back; a Hermes-Lite 2 reports nothing, so isTuning() stayed false
+    // forever and TxApplet's toggle — "if (isTuning()) stopTune() else
+    // startTune()" — could never take the stop branch. TUNE latched on and the
+    // only way out was keying MOX twice. Radio status still reconciles this on
+    // backends that send it.
+    if (!m_tune) {
+        m_tune = true;
+        emit tuneChanged(true);
+    }
     emit commandReady("transmit tune 1");
     emit tuneCommandIssued(true);
 }
@@ -285,6 +297,10 @@ void TransmitModel::startTwoToneTune(PttSource source)
 
     m_activePttSource = source;   // exclude local/TCI/DAX tune (see startTune, #4131)
     setTuneMode("two_tone");
+    if (!m_tune) {
+        m_tune = true;
+        emit tuneChanged(true);
+    }
     emit commandReady("transmit tune 1");
     emit tuneCommandIssued(true);
 }
@@ -306,6 +322,10 @@ void TransmitModel::toggleTwoToneTune()
 
 void TransmitModel::stopTune()
 {
+    if (m_tune) {
+        m_tune = false;
+        emit tuneChanged(false);
+    }
     emit commandReady("transmit tune 0");
     emit tuneCommandIssued(false);
 }

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -275,6 +275,7 @@ void TransmitModel::startTune(PttSource source)
     m_activePttSource = source;
 
     emit commandReady("transmit tune 1");
+    emit tuneCommandIssued(true);
 }
 
 void TransmitModel::startTwoToneTune(PttSource source)
@@ -285,6 +286,7 @@ void TransmitModel::startTwoToneTune(PttSource source)
     m_activePttSource = source;   // exclude local/TCI/DAX tune (see startTune, #4131)
     setTuneMode("two_tone");
     emit commandReady("transmit tune 1");
+    emit tuneCommandIssued(true);
 }
 
 void TransmitModel::toggleTwoToneTune()
@@ -305,6 +307,7 @@ void TransmitModel::toggleTwoToneTune()
 void TransmitModel::stopTune()
 {
     emit commandReady("transmit tune 0");
+    emit tuneCommandIssued(false);
 }
 
 void TransmitModel::setMox(bool on)
@@ -317,6 +320,7 @@ void TransmitModel::setMox(bool on)
         emit moxChanged(on);
     }
     emit commandReady(QString("xmit %1").arg(on ? 1 : 0));
+    emit moxCommandIssued(on);
 }
 
 void TransmitModel::setTransmitting(bool tx)

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -239,6 +239,7 @@ void TransmitModel::setRfPower(int power)
     if (m_rfPower != power) {
         m_rfPower = power;
         emit stateChanged();
+        emit rfPowerChanged(power);
     }
     emit commandReady(QString("transmit set rfpower=%1").arg(power));
 }

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -171,6 +171,16 @@ public:
 
     // ── Command methods (emit commandReady) ─────────────────────────────────
     void setRfPower(int power);
+
+    // The host modulates, so the microphone is a PC input and nothing else.
+    //
+    // The mic-source list (MIC / BAL / LINE / ACC / PC) enumerates a FlexRadio's
+    // physical input jacks. A Hermes-Lite 2 has none of them: audio is
+    // modulated here and handed to the radio as IQ, so "PC" is not a preference
+    // but the only thing that can possibly be true. Offering the others invites
+    // the operator to select an input that silently transmits nothing.
+    void setHostModulation(bool on);
+    [[nodiscard]] bool hostModulation() const { return m_hostModulation; }
     void setTunePower(int power);
     void setTuneMode(const QString& mode);
     void startTune(PttSource source = PttSource::Tune);
@@ -261,6 +271,7 @@ signals:
     // families, so Flex keeps its single command and does not key twice.
     void moxCommandIssued(bool on);
     void tuneCommandIssued(bool on);
+    void hostModulationChanged(bool on);
     void tuneChanged(bool tuning);
     void moxChanged(bool mox);
     // Fires whenever m_transmitting changes — from setMox() (optimistic edge)
@@ -317,6 +328,7 @@ private:
 
     // Transmit state
     int    m_rfPower{100};
+    bool   m_hostModulation{false};
     int    m_tunePower{10};
     bool   m_tune{false};
     bool   m_mox{false};

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -252,6 +252,15 @@ signals:
     // Typed RF-power change, for backends that set drive through the seam
     // rather than by parsing the Flex command string above.
     void rfPowerChanged(int percent);
+    // Keying and tune as INTENT rather than as a Flex command string.
+    //
+    // setMox() and startTune() emit "xmit N" / "transmit tune N" through
+    // commandReady, which is a Flex TCP command and reaches a backend with no
+    // command channel not at all. These carry the same intent for backends that
+    // key through IRadioBackend. RadioModel routes them only for non-Flex
+    // families, so Flex keeps its single command and does not key twice.
+    void moxCommandIssued(bool on);
+    void tuneCommandIssued(bool on);
     void tuneChanged(bool tuning);
     void moxChanged(bool mox);
     // Fires whenever m_transmitting changes — from setMox() (optimistic edge)

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -249,6 +249,9 @@ public:
 
 signals:
     void stateChanged();
+    // Typed RF-power change, for backends that set drive through the seam
+    // rather than by parsing the Flex command string above.
+    void rfPowerChanged(int percent);
     void tuneChanged(bool tuning);
     void moxChanged(bool mox);
     // Fires whenever m_transmitting changes — from setMox() (optimistic edge)

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -1,12 +1,15 @@
 // aetherd HL2 Phase 1b — Hl2Backend seam test. A capped fake HL2 on localhost
 // lets the backend connect and produce a panadapter frame; verifies the
-// IRadioBackend contract: capabilities (family=hl2, RX-only), connected on first
-// EP6, spectrumFrameReady wired to the data plane, sliceChanged on control
-// intents, setKeying as a no-op, invokeExtension's async-error stub, and
-// disconnected on stop. (Audio demod itself is covered by hl2_rxdsp_test.)
+// IRadioBackend contract: capabilities (family=hl2, transmit availability),
+// connected on first EP6, spectrumFrameReady wired to the data plane,
+// sliceChanged on control intents, keying, invokeExtension's async-error stub,
+// and disconnected on stop. (Audio demod itself is covered by hl2_rxdsp_test;
+// the transmit gate's wire-level behaviour by hl2_tx_gate_test.)
 
 #include "core/backends/IRadioBackend.h"
 #include "core/backends/hl2/Hl2Backend.h"
+
+#include "core/AutomationBridgeSettings.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QCoreApplication>
@@ -73,10 +76,42 @@ int main(int argc, char** argv)
 
     Hl2Backend backend;
 
-    // ---- capabilities: RX-only HL2 ----
+    // ---- transmit availability follows the AUTOMATION gate ----
+    //
+    // An automation run defers to the bridge's own TX gate rather than to an
+    // HL2-specific flag. Constructing a second backend under AETHER_AUTOMATION
+    // with no permission must report RX-only and refuse to key.
+    {
+        qputenv("AETHER_AUTOMATION", "1");
+        qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+        Hl2Backend gated;
+        const bool allowed = gated.capabilities().canTransmit;
+        // The persisted operator toggle also opens this gate, and it is a real
+        // user setting we must not stomp — so only assert the refusal when the
+        // environment we control is the only source in play.
+        if (!AutomationBridgeSettings::txAllowed()) {
+            check(!allowed, "automation without permission reports RX-only");
+        } else {
+            std::fprintf(stderr,
+                "note: operator TX toggle is ON, so the automation gate is open; "
+                "skipping the refusal assertion\n");
+        }
+        qputenv("AETHER_AUTOMATION_ALLOW_TX", "1");
+        Hl2Backend permitted;
+        check(permitted.capabilities().canTransmit,
+              "automation WITH permission may transmit");
+        qunsetenv("AETHER_AUTOMATION");
+        qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+    }
+
+    // ---- capabilities ----
     const RadioCapabilities caps = backend.capabilities();
     check(caps.family == QLatin1String("hl2"), "family is hl2");
-    check(!caps.canTransmit, "canTransmit is false (RX-only)");
+    // canTransmit is no longer a constant. It reports transmit AVAILABILITY, so
+    // the engine's TX guard above the seam sees an RX-only radio exactly when
+    // this backend would refuse to key. This process has no AETHER_AUTOMATION
+    // set, so it is an interactive run and may transmit.
+    check(caps.canTransmit, "canTransmit is true for an interactive run");
     check(caps.maxSlices == 1, "one slice");
     check(caps.sampleRatesHz.contains(48000) && caps.sampleRatesHz.contains(384000), "sample rates");
     check(caps.extensionNamespaces.isEmpty(), "no extension namespaces advertised");
@@ -119,9 +154,13 @@ int main(int argc, char** argv)
     backend.setSliceFilter(0, 300, 2700);
     check(sliceCount >= sliceBefore + 3, "freq/mode/filter each emit sliceChanged");
 
-    // ---- keying is a no-op (RX-only) ----
+    // ---- keying does not disturb the link ----
+    // Whether this actually keys depends on the transmit gate above; what
+    // matters here is that asking does not upset the connection either way.
     backend.setKeying(true);
-    check(backend.isConnected(), "setKeying does not disrupt / cannot key");
+    check(backend.isConnected(), "setKeying(true) does not disrupt the link");
+    backend.setKeying(false);
+    check(backend.isConnected(), "setKeying(false) does not disrupt the link");
 
     // ---- invokeExtension honors the async contract ----
     backend.invokeExtension(QStringLiteral("hl2"), QStringLiteral("noop"), 42, {});

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -207,6 +207,65 @@ int main()
               "every other command nibble left at no-action");
     }
 
+    // ---- TX encoders ----
+    {
+        const Cc f = ccTxFreq(14'200'000);
+        check(f[0] == kC0TxFreq, "TX freq targets addr 0x01 (C0 = 0x02)");
+        check(f[1] == 0x00 && f[2] == 0xD8 && f[3] == 0xAC && f[4] == 0xC0,
+              "TX freq is 32-bit big-endian Hz (14.2 MHz = 0x00D8ACC0)");
+        check((f[0] & kC0MoxBit) == 0, "TX freq bank is not keyed by itself");
+
+        const Cc d = ccTxDrive(200);
+        check(d[0] == kC0TxDrive, "TX drive targets addr 0x09 (C0 = 0x12)");
+        check(d[1] == 200, "drive level lands in C1 (DATA[31:24])");
+        check(d[2] == 0 && d[3] == 0 && d[4] == 0,
+              "a drive write does not set PA enable, ATU tune or Alex bits");
+        check(ccTxDrive(-5)[1] == 0 && ccTxDrive(9999)[1] == kTxDriveMax,
+              "drive level clamps to 0..255");
+    }
+
+    // ---- MOX is a property of the FRAME, not a register ----
+    {
+        const Cc keyed = withMox(ccRx1Freq(7'000'000), true);
+        check((keyed[0] & kC0MoxBit) != 0, "withMox sets C0 bit 0");
+        check((keyed[0] & ~kC0MoxBit) == kC0Rx1Freq,
+              "withMox leaves the register address intact");
+        check((withMox(keyed, false)[0] & kC0MoxBit) == 0, "withMox clears again");
+        // Any bank can carry MOX -- the radio reads it from whatever is in flight.
+        check((withMox(ccConfig(SampleRate::R48k, 1), true)[0] & kC0MoxBit) != 0,
+              "the config bank can carry MOX too");
+    }
+
+    // ---- TX IQ payload, and the EADDR trap ----
+    {
+        auto pkt = ep2Packet(0, ccConfig(SampleRate::R48k, 1), ccRx1Freq(7'000'000));
+        std::vector<std::complex<float>> iq;
+        iq.emplace_back(1.0f, -1.0f);            // full scale both rails
+        iq.emplace_back(0.0f, 0.5f);
+        ep2WriteTxIq(pkt, iq);
+
+        const std::uint8_t* pay = pkt.data() + 8 + 8;    // frame 0, after SYNC + C&C
+        // Sample 0: I = +32767, Q = -32767.
+        check(pay[4] == 0x7F && pay[5] == 0xFF, "full-scale I clamps to +32767, big-endian");
+        check(pay[6] == 0x80 && pay[7] == 0x01,
+              "full-scale -1.0 clamps to -32767, NOT -32768 (no wrap to the far rail)");
+
+        // THE TRAP: the first 32-bit word of each frame's payload is EADDR, the
+        // extended-address register -- not headphone audio. A memcpy'd Hermes TX
+        // layout writes garbage there. It must stay zero.
+        check(pay[0] == 0 && pay[1] == 0 && pay[2] == 0 && pay[3] == 0,
+              "EADDR (first 32-bit word after C&C) left zero");
+        const std::uint8_t* pay1 = pkt.data() + 8 + kFrameSize + 8;
+        check(pay1[0] == 0 && pay1[1] == 0 && pay1[2] == 0 && pay1[3] == 0,
+              "second frame's EADDR left zero as well");
+
+        // Sample 1 lands in the next 8-byte slot; the rest is transmit silence.
+        check(pay[12] == 0x00 && pay[13] == 0x00, "sample 1 I = 0");
+        check(pay[14] == 0x3F && pay[15] == 0xFF, "sample 1 Q = 0.5 -> 16383");
+        check(pay[20] == 0 && pay[21] == 0 && pay[22] == 0 && pay[23] == 0,
+              "unsupplied samples are transmit silence");
+    }
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_metis_protocol_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -266,6 +266,81 @@ int main()
               "unsupplied samples are transmit silence");
     }
 
+    // ---- EP6 C&C response decoding (telemetry) ----
+    {
+        auto frame = [](std::uint8_t c0, std::uint32_t data) {
+            std::array<std::uint8_t, 8> f{};
+            f[0] = f[1] = f[2] = 0x7F;
+            f[3] = c0;
+            f[4] = static_cast<std::uint8_t>((data >> 24) & 0xFF);
+            f[5] = static_cast<std::uint8_t>((data >> 16) & 0xFF);
+            f[6] = static_cast<std::uint8_t>((data >> 8) & 0xFF);
+            f[7] = static_cast<std::uint8_t>(data & 0xFF);
+            return f;
+        };
+
+        // Classic cycle: C0 = 0, 8, 16 -> RADDR 0, 1, 2 (hpsdrsim's own sequence).
+        auto r0 = parseEp6Response(frame(0x00, 0).data());
+        check(r0.has_value() && !r0->ack && r0->raddr == 0, "C0=0x00 -> RADDR 0, ACK clear");
+        auto r1 = parseEp6Response(frame(0x08, 0).data());
+        check(r1.has_value() && r1->raddr == 1, "C0=0x08 -> RADDR 1");
+        auto r2 = parseEp6Response(frame(0x10, 0).data());
+        check(r2.has_value() && r2->raddr == 2, "C0=0x10 -> RADDR 2");
+
+        // ACK changes how C0 is read: 6 address bits instead of 4.
+        auto ra = parseEp6Response(frame(0x80 | (0x2A << 1), 0).data());
+        check(ra.has_value() && ra->ack && ra->raddr == 0x2A,
+              "ACK=1 -> RADDR is C0[6:1], all six bits");
+
+        // PTT and Dot ride in C0 regardless.
+        auto rp = parseEp6Response(frame(0x08 | 0x01, 0).data());
+        check(rp.has_value() && rp->ptt, "PTT decoded from C0[0]");
+        auto rd = parseEp6Response(frame(0x08 | 0x04, 0).data());
+        check(rd.has_value() && rd->dot, "Dot decoded from C0[2]");
+
+        check(!parseEp6Response(std::array<std::uint8_t,8>{}.data()).has_value(),
+              "unsynced frame rejected");
+
+        Hl2Telemetry t;
+        check(!t.forwardPowerRaw.has_value(), "telemetry starts unknown, not zero");
+
+        // RADDR 0: firmware 0x15, ADC overload set, TX PERMITTED (bit 25 high).
+        t.apply(*parseEp6Response(frame(0x00, (1u<<25) | (1u<<24) | 0x15).data()));
+        check(t.firmwareVersion.value_or(-1) == 0x15, "firmware version from DATA[7:0]");
+        check(t.adcOverload.value_or(false), "ADC overload from bit 24");
+        check(t.txInhibited.value_or(true) == false,
+              "bit 25 SET means transmit permitted (active low, inverted here)");
+        t.apply(*parseEp6Response(frame(0x00, 0).data()));
+        check(t.txInhibited.value_or(false) == true, "bit 25 clear means INHIBITED");
+
+        // RADDR 1: temperature high half, forward power low half.
+        t.apply(*parseEp6Response(frame(0x08, (1234u << 16) | 5678u).data()));
+        check(t.temperatureRaw.value_or(-1) == 1234, "temperature from DATA[31:16]");
+        check(t.forwardPowerRaw.value_or(-1) == 5678, "forward power from DATA[15:0]");
+
+        // RADDR 2: reverse power and bias.
+        t.apply(*parseEp6Response(frame(0x10, (100u << 16) | 42u).data()));
+        check(t.reversePowerRaw.value_or(-1) == 100, "reverse power from DATA[31:16]");
+        check(t.biasCurrentRaw.value_or(-1) == 42, "bias current from DATA[15:0]");
+    }
+
+    // ---- SWR ----
+    {
+        check(!swrFromRaw(0, 0).has_value(),
+              "no forward power -> SWR is unknown, NOT 1.0");
+        const auto flat = swrFromRaw(1000, 0);
+        check(flat.has_value() && std::fabs(*flat - 1.0) < 1e-9,
+              "no reflection -> 1.0:1");
+        // Voltage form: rho = 1/3 -> SWR 2.0. The power form would have given
+        // 1.0/(1-sqrt(1/3)) ~= 2.37 here, i.e. a different and wrong number.
+        const auto two = swrFromRaw(3000, 1000);
+        check(two.has_value() && std::fabs(*two - 2.0) < 1e-9,
+              "rho = 1/3 -> 2.0:1 (voltage form, no square root)");
+        const auto bad = swrFromRaw(100, 500);
+        check(bad.has_value() && *bad > 100.0,
+              "reverse above forward clamps to a very high SWR, not negative");
+    }
+
     if (g_failures == 0)
         std::fprintf(stderr, "hl2_metis_protocol_test: all checks passed\n");
     return g_failures == 0 ? 0 : 1;

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -219,7 +219,11 @@ int main()
         check(d[0] == kC0TxDrive, "TX drive targets addr 0x09 (C0 = 0x12)");
         check(d[1] == 200, "drive level lands in C1 (DATA[31:24])");
         check(d[2] == 0 && d[3] == 0 && d[4] == 0,
-              "a drive write does not set PA enable, ATU tune or Alex bits");
+              "PA stays OFF unless explicitly asked for");
+        const Cc dpa = ccTxDrive(200, true);
+        check(dpa[2] == 0x08, "PA enable is DATA[19] = C2 bit 3");
+        check(dpa[3] == 0 && dpa[4] == 0,
+              "enabling the PA does not set ATU tune or Alex bits");
         check(ccTxDrive(-5)[1] == 0 && ccTxDrive(9999)[1] == kTxDriveMax,
               "drive level clamps to 0..255");
     }

--- a/tests/hl2_tx_gate_test.cpp
+++ b/tests/hl2_tx_gate_test.cpp
@@ -165,6 +165,17 @@ int main(int argc, char** argv)
         check(pay[0] == 0 && pay[1] == 0 && pay[2] == 0 && pay[3] == 0,
               "EADDR still zero with IQ present");
 
+        // Unkey must discard pending audio, not carry it into the next
+        // transmission. Measured on hardware before this existed: a key with no
+        // audio still produced ~1000 counts of forward power for a moment.
+        c2.queueTxIq(tone);
+        check(c2.txQueueDepth() > 0, "audio queued");
+        c2.flushTxIq();
+        check(c2.txQueueDepth() == 0, "flushTxIq discards pending transmit audio");
+        check(!payloadNonZero(c2.buildNextControlPacket()),
+              "nothing left to transmit after a flush");
+        c2.queueTxIq(tone);
+
         // Underflow is silence, not a stall and not repeated stale audio.
         while (c2.txQueueDepth() > 0)
             c2.buildNextControlPacket();

--- a/tests/hl2_tx_gate_test.cpp
+++ b/tests/hl2_tx_gate_test.cpp
@@ -1,0 +1,122 @@
+// MetisClient used to be incapable of keying a radio, structurally: every C0
+// register-address byte was even, so MOX (C0 bit 0) was always 0. Adding TX
+// destroyed that invariant. This test is what replaces it.
+//
+// The claim under test is not "setMox returns false when refused" -- it is the
+// only one that actually matters on the air: WITH THE GATE CLOSED, NO BYTE THAT
+// WOULD GO OUT ON THE WIRE EVER HAS C0 BIT 0 SET. So it inspects the real EP2
+// packet the client would send, from the same builder the socket path uses,
+// rather than trusting a status flag.
+
+#include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+
+#include <cstdio>
+
+using namespace AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+// Both sub-frames carry C0; keying either one keys the radio, so both are
+// checked. Frame C0 sits at SYNC(3) into each 512-byte frame.
+static bool anyFrameKeyed(const std::array<std::uint8_t, kUsbPacketSize>& pkt)
+{
+    const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+    for (const std::size_t fs : frameStarts) {
+        if ((pkt[fs + 3] & kC0MoxBit) != 0)
+            return true;
+    }
+    return false;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    MetisClient client;
+
+    check(!client.transmitEnabled(), "transmit is DISABLED by default");
+    check(!client.isKeyed(), "not keyed by default");
+
+    // ---- gate closed ----
+    client.setMox(true);
+    check(!client.isKeyed(), "setMox(true) refused while the gate is closed");
+
+    // Drain enough packets to cover the whole round robin (freq, gain, ADC
+    // assign) plus the config bank, several times over, with a key request
+    // standing the entire time. Any single keyed frame here is a real radio
+    // keyed by accident.
+    for (int i = 0; i < 64; ++i) {
+        client.setMox(true);                       // keep asking, every frame
+        const auto pkt = client.buildNextControlPacket();
+        if (anyFrameKeyed(pkt)) {
+            check(false, "a frame was keyed with the gate CLOSED");
+            break;
+        }
+    }
+
+    // Queuing TX frequency and drive must not key anything either -- those are
+    // setup, and setup happening before the operator keys is the normal order.
+    client.setTxFrequencyHz(14'200'000);
+    client.setTxDriveLevel(200);
+    for (int i = 0; i < 8; ++i) {
+        if (anyFrameKeyed(client.buildNextControlPacket())) {
+            check(false, "TX frequency/drive setup keyed a frame with the gate closed");
+            break;
+        }
+    }
+
+    // ---- gate open ----
+    client.enableTransmit(true);
+    check(client.transmitEnabled(), "transmit enabled after explicit opt-in");
+    check(!client.isKeyed(), "opening the gate does not key by itself");
+
+    // Still unkeyed until asked.
+    for (int i = 0; i < 4; ++i) {
+        if (anyFrameKeyed(client.buildNextControlPacket())) {
+            check(false, "an open gate keyed a frame without setMox");
+            break;
+        }
+    }
+
+    client.setMox(true);
+    check(client.isKeyed(), "setMox(true) honoured once the gate is open");
+    {
+        const auto pkt = client.buildNextControlPacket();
+        const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+        // BOTH sub-frames must carry MOX: the radio keys off whichever bank is
+        // in flight, so keying only one is an intermittent, cadence-dependent
+        // half-key -- the worst possible failure mode to debug.
+        for (const std::size_t fs : frameStarts) {
+            check((pkt[fs + 3] & kC0MoxBit) != 0, "both sub-frames carry MOX when keyed");
+            // The address must survive keying, or MOX would corrupt the bank.
+            check((pkt[fs + 3] & ~kC0MoxBit) != 0 || fs == 8,
+                  "register address intact alongside MOX");
+        }
+    }
+
+    // ---- unkey, and revoking the gate ----
+    client.setMox(false);
+    check(!anyFrameKeyed(client.buildNextControlPacket()), "unkeys cleanly");
+
+    // Revoking the gate while keyed must drop the key on the wire immediately,
+    // not merely refuse the next request.
+    client.setMox(true);
+    check(anyFrameKeyed(client.buildNextControlPacket()), "keyed again");
+    client.enableTransmit(false);
+    for (int i = 0; i < 8; ++i) {
+        if (anyFrameKeyed(client.buildNextControlPacket())) {
+            check(false, "revoking the gate did not drop the key on the wire");
+            break;
+        }
+    }
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_tx_gate_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_tx_gate_test.cpp
+++ b/tests/hl2_tx_gate_test.cpp
@@ -14,6 +14,7 @@
 #include <QCoreApplication>
 
 #include <cstdio>
+#include <vector>
 
 using namespace AetherSDR::hl2;
 
@@ -114,6 +115,61 @@ int main(int argc, char** argv)
             check(false, "revoking the gate did not drop the key on the wire");
             break;
         }
+    }
+
+    // ---- transmit IQ reaches the wire only while keyed ----
+    //
+    // The gate has to cover SAMPLES, not just MOX. A radio that is unkeyed but
+    // still being fed IQ is not transmitting, but it is one stray MOX bit away
+    // from doing so with whatever happens to be in the buffer.
+    {
+        auto payloadNonZero = [](const std::array<std::uint8_t, kUsbPacketSize>& pkt) {
+            const std::size_t frameStarts[2] = {8, 8 + kFrameSize};
+            for (const std::size_t fs : frameStarts) {
+                const std::uint8_t* pay = pkt.data() + fs + 8;
+                for (std::size_t k = 0; k < kFramePayload; ++k)
+                    if (pay[k] != 0) return true;
+            }
+            return false;
+        };
+
+        MetisClient c2;
+        std::vector<std::complex<float>> tone(512, std::complex<float>(0.5f, -0.5f));
+
+        // Gate closed, unkeyed: queued samples must not go out.
+        c2.queueTxIq(tone);
+        check(c2.txQueueDepth() == 512, "samples queue regardless of gate state");
+        for (int i = 0; i < 4; ++i) {
+            if (payloadNonZero(c2.buildNextControlPacket())) {
+                check(false, "IQ reached the wire with the gate CLOSED");
+                break;
+            }
+        }
+        check(c2.txQueueDepth() == 512, "an unkeyed frame consumes no samples");
+
+        // Gate open but still unkeyed: still silence.
+        c2.enableTransmit(true);
+        check(!payloadNonZero(c2.buildNextControlPacket()),
+              "an open gate alone does not put IQ on the wire");
+
+        // Keyed: now the samples flow.
+        c2.setMox(true);
+        const auto keyedPkt = c2.buildNextControlPacket();
+        check(payloadNonZero(keyedPkt), "keyed frames carry the queued IQ");
+        check(c2.txQueueDepth() == 512 - kTxSamplesPerPacket,
+              "one packet consumes exactly kTxSamplesPerPacket samples");
+        // 0.5 -> 16383 (0x3FFF), -0.5 -> -16383 (0xC001), big-endian.
+        const std::uint8_t* pay = keyedPkt.data() + 8 + 8;
+        check(pay[4] == 0x3F && pay[5] == 0xFF, "I sample encoded big-endian");
+        check(pay[6] == 0xC0 && pay[7] == 0x01, "Q sample encoded big-endian");
+        check(pay[0] == 0 && pay[1] == 0 && pay[2] == 0 && pay[3] == 0,
+              "EADDR still zero with IQ present");
+
+        // Underflow is silence, not a stall and not repeated stale audio.
+        while (c2.txQueueDepth() > 0)
+            c2.buildNextControlPacket();
+        check(!payloadNonZero(c2.buildNextControlPacket()),
+              "an empty queue transmits silence rather than repeating");
     }
 
     if (g_failures == 0)

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -150,6 +150,75 @@ int main(int argc, char** argv)
               "the tone is >20 dB above the unkeyed floor at that bin");
     }
 
+    // ---- the REAL audio path: submitTxAudio -> modulator -> EP2 ----
+    //
+    // The tone above is generated inside MetisClient, so it proves the wire but
+    // not the chain an operator actually uses. This drives the same entry point
+    // AudioEngine feeds: processed int16 stereo at 24 kHz, which must arrive on
+    // the air as a single sideband at the audio frequency.
+    {
+        backend.setSliceMode(0, QStringLiteral("USB"));
+        spin(300);
+        backend.setKeying(true);
+
+        std::vector<float> voice;
+        constexpr double kAudioHz = 1500.0;
+        constexpr int kRate = 24000;
+        // ~2 s of audio in 20 ms blocks, the cadence AudioEngine delivers.
+        for (int blk = 0; blk < 100; ++blk) {
+            const int frames = kRate / 50;
+            QByteArray pcm(frames * 2 * static_cast<int>(sizeof(qint16)), 0);
+            auto* out = reinterpret_cast<qint16*>(pcm.data());
+            for (int n = 0; n < frames; ++n) {
+                const double t = static_cast<double>(blk * frames + n) / kRate;
+                const auto v = static_cast<qint16>(
+                    0.5 * 32767.0 * std::sin(2.0 * M_PI * kAudioHz * t));
+                out[2 * n] = v;
+                out[2 * n + 1] = v;      // AudioEngine duplicates across channels
+            }
+            backend.submitTxAudio(pcm, kRate);
+            spin(20);
+            // Capture WHILE transmitting. Sampling after the loop would read
+            // silence: the queue drains in well under a second once audio stops,
+            // and unlike the built-in tone (synthesised per packet, so it never
+            // stops) this path only carries what has been submitted.
+            if (blk == 80)
+                voice = lastSpectrum;
+        }
+        backend.setKeying(false);
+
+        if (voice.size() == baseline.size() && !voice.empty()) {
+            const int n = static_cast<int>(voice.size());
+            const int centre = n / 2;
+            const double binHz = 48000.0 / n;
+            const int expected = centre + static_cast<int>(std::lround(kAudioHz / binHz));
+            const int mirrored = centre - static_cast<int>(std::lround(kAudioHz / binHz));
+
+            int peak = 0;
+            for (int i = 1; i < n; ++i)
+                if (voice[static_cast<std::size_t>(i)] > voice[static_cast<std::size_t>(peak)])
+                    peak = i;
+
+            std::fprintf(stderr,
+                "mic path: peak bin %d (%.0f Hz), expected %d; wanted %.1f dB, "
+                "mirror %.1f dB, floor %.1f dB\n",
+                peak, (peak - centre) * binHz, expected,
+                voice[static_cast<std::size_t>(expected)],
+                voice[static_cast<std::size_t>(mirrored)],
+                baseline[static_cast<std::size_t>(expected)]);
+
+            check(std::abs(peak - expected) <= 4,
+                  "submitTxAudio: 1.5 kHz audio transmits at +1.5 kHz (USB)");
+            check(voice[static_cast<std::size_t>(expected)]
+                      - baseline[static_cast<std::size_t>(expected)] > 20.0f,
+                  "submitTxAudio: the tone is well above the unkeyed floor");
+            // The whole point of SSB: nothing on the other side of the carrier.
+            check(voice[static_cast<std::size_t>(expected)]
+                      - voice[static_cast<std::size_t>(mirrored)] > 20.0f,
+                  "submitTxAudio: opposite sideband suppressed on the air");
+        }
+    }
+
     backend.disconnectRadio();
     spin(500);
 

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -125,7 +125,11 @@ int main(int argc, char** argv)
         const int n = static_cast<int>(keyed.size());
         const int centre = n / 2;
         const double binHz = 48000.0 / n;
-        const int expected = centre + static_cast<int>(std::lround(kToneOffsetHz / binHz));
+        // NEGATIVE offset: hpsdrsim feeds the TX IQ back in WIRE order, and the
+        // wire is the conjugate of the standard analytic convention (see
+        // Hl2TxDsp). On the air this same IQ becomes +5 kHz; here we are looking
+        // at the wire, so it reads -5 kHz.
+        const int expected = centre - static_cast<int>(std::lround(kToneOffsetHz / binHz));
 
         // Find the strongest bin while keyed.
         int peak = 0;
@@ -191,8 +195,13 @@ int main(int argc, char** argv)
             const int n = static_cast<int>(voice.size());
             const int centre = n / 2;
             const double binHz = 48000.0 / n;
-            const int expected = centre + static_cast<int>(std::lround(kAudioHz / binHz));
-            const int mirrored = centre - static_cast<int>(std::lround(kAudioHz / binHz));
+            // Same wire-order reasoning as above: USB audio leaves the
+            // modulator BELOW centre in wire order and is transmitted above the
+            // carrier. Asserting the textbook sign here is precisely what let a
+            // wrong-sideband transmitter pass its own tests — it took an
+            // operator with a second receiver to catch it.
+            const int expected = centre - static_cast<int>(std::lround(kAudioHz / binHz));
+            const int mirrored = centre + static_cast<int>(std::lround(kAudioHz / binHz));
 
             int peak = 0;
             for (int i = 1; i < n; ++i)

--- a/tests/hl2_tx_loopback_test.cpp
+++ b/tests/hl2_tx_loopback_test.cpp
@@ -1,0 +1,159 @@
+// End-to-end transmit proof against hpsdrsim.
+//
+// hpsdrsim models the PureSignal feedback path: while PTT is asserted it feeds
+// the TX IQ it received BACK into the RX stream, scaled by TX drive and with
+// simulated IM3. So if we key, set a drive level and transmit a tone, that tone
+// must reappear in our own spectrum at the offset we transmitted it on.
+//
+// That closes the loop the unit tests cannot: hl2_tx_gate_test proves the right
+// BYTES leave, but only the simulator can show the radio actually received them
+// and acted on them.
+//
+// SIM ONLY, deliberately. The address is hardcoded to the simulator and this
+// test keys the transmitter; pointing it at real hardware would radiate.
+// If nothing answers there, the test SKIPS rather than fails, so a machine
+// without the simulator running does not get a spurious red.
+
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QTimer>
+#include <QUdpSocket>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace AetherSDR;
+using AetherSDR::hl2::Hl2Backend;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static void spin(int ms)
+{
+    QEventLoop loop;
+    QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+    loop.exec();
+}
+
+// Is the simulator actually there? A plain Metis discovery probe.
+static bool simPresent(const QString& host)
+{
+    QUdpSocket s;
+    if (!s.bind(QHostAddress(QHostAddress::AnyIPv4), 0))
+        return false;
+    const auto req = AetherSDR::hl2::discoveryRequest();
+    s.writeDatagram(reinterpret_cast<const char*>(req.data()),
+                    static_cast<qint64>(req.size()), QHostAddress(host),
+                    AetherSDR::hl2::kMetisPort);
+    return s.waitForReadyRead(1500);
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    qRegisterMetaType<SliceDelta>();
+
+    const QString simHost = QStringLiteral("192.168.1.12");
+    if (!simPresent(simHost)) {
+        std::fprintf(stderr,
+            "hl2_tx_loopback_test: SKIPPED — no simulator answering at %s\n",
+            qPrintable(simHost));
+        return 0;
+    }
+
+    // Transmit must be permitted for this to mean anything. This process sets no
+    // AETHER_AUTOMATION, so it is an interactive run and the gate is open.
+    qunsetenv("AETHER_AUTOMATION");
+
+    Hl2Backend backend;
+    check(backend.capabilities().canTransmit,
+          "transmit available (interactive run)");
+
+    std::vector<float> lastSpectrum;
+    QObject::connect(&backend, &IRadioBackend::spectrumFrameReady, &backend,
+                     [&](int, const QByteArray& ba) {
+        lastSpectrum.assign(reinterpret_cast<const float*>(ba.constData()),
+                            reinterpret_cast<const float*>(ba.constData())
+                                + ba.size() / sizeof(float));
+    });
+
+    RadioConnectRequest req;
+    req.host = simHost;
+    backend.connectRadio(req);
+    spin(2500);
+    check(backend.isConnected(), "connected to the simulator");
+    if (!backend.isConnected()) {
+        std::fprintf(stderr, "hl2_tx_loopback_test: cannot continue unconnected\n");
+        return 1;
+    }
+
+    backend.setSliceFrequency(0, 14'200'000.0);
+    spin(500);
+
+    // Drive must be non-zero: the simulator scales its feedback by TX drive, so
+    // at drive 0 a perfect transmission is indistinguishable from none.
+    backend.setTxDriveLevel(200);
+
+    // Baseline: what the spectrum looks like unkeyed.
+    spin(1200);
+    const std::vector<float> baseline = lastSpectrum;
+    check(!baseline.empty(), "receiving spectrum before keying");
+
+    // ---- transmit a tone ----
+    constexpr double kToneOffsetHz = 5000.0;
+    backend.setTxTestTone(kToneOffsetHz, 0.5);
+    backend.setKeying(true);
+    spin(2500);
+    const std::vector<float> keyed = lastSpectrum;
+    backend.setKeying(false);
+    backend.setTxTestTone(0.0, 0.0);
+
+    check(keyed.size() == baseline.size() && !keyed.empty(),
+          "spectrum still flowing while keyed");
+
+    if (!keyed.empty() && keyed.size() == baseline.size()) {
+        // The spectrum is fftshifted, so DC sits at the centre bin. A +5 kHz
+        // tone lands that many bins above it.
+        const int n = static_cast<int>(keyed.size());
+        const int centre = n / 2;
+        const double binHz = 48000.0 / n;
+        const int expected = centre + static_cast<int>(std::lround(kToneOffsetHz / binHz));
+
+        // Find the strongest bin while keyed.
+        int peak = 0;
+        for (int i = 1; i < n; ++i)
+            if (keyed[static_cast<std::size_t>(i)] > keyed[static_cast<std::size_t>(peak)])
+                peak = i;
+
+        const double peakHz = (peak - centre) * binHz;
+        std::fprintf(stderr,
+            "loopback: peak bin %d (%.0f Hz), expected ~%d (%.0f Hz), level %.1f dB "
+            "(baseline at that bin %.1f dB)\n",
+            peak, peakHz, expected, kToneOffsetHz,
+            keyed[static_cast<std::size_t>(peak)],
+            baseline[static_cast<std::size_t>(expected)]);
+
+        // Within a few bins of where we transmitted it.
+        check(std::abs(peak - expected) <= 4,
+              "the transmitted tone comes back at the frequency it was sent on");
+        // And it must actually stand above where the floor was before keying.
+        check(keyed[static_cast<std::size_t>(expected)]
+                  - baseline[static_cast<std::size_t>(expected)] > 20.0f,
+              "the tone is >20 dB above the unkeyed floor at that bin");
+    }
+
+    backend.disconnectRadio();
+    spin(500);
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_tx_loopback_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -1,0 +1,179 @@
+// SSB modulator correctness for the Hermes-Lite 2 transmit chain.
+//
+// The assertion that matters on the air: a 1 kHz audio tone must appear at
+// +1 kHz of baseband for USB and at -1 kHz for LSB. Getting this inverted
+// transmits on the wrong sideband — which sounds fine in a loopback and is
+// immediately obvious to everyone else on the band.
+//
+// It also pins the rate conversion (24 kHz audio in, 48 kHz IQ out) and the
+// mic-gain path, both of which are easy to get subtly wrong in ways that only
+// show up as "my audio is quiet" or "my signal is 2 kHz wide".
+
+#include "core/backends/hl2/Hl2TxDsp.h"
+
+#include <QCoreApplication>
+#include <QObject>
+
+#include <cmath>
+#include <complex>
+#include <cstdio>
+#include <vector>
+
+using namespace AetherSDR::hl2;
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+// Goertzel-style complex bin: correlate the IQ against exp(-j*2*pi*f*n/fs).
+// Positive f probes the upper sideband, negative the lower.
+static double binPower(const std::vector<std::complex<float>>& iq, double hz, double fs)
+{
+    std::complex<double> acc{0.0, 0.0};
+    const double w = -2.0 * M_PI * hz / fs;
+    for (std::size_t n = 0; n < iq.size(); ++n) {
+        const double ph = w * static_cast<double>(n);
+        acc += std::complex<double>(iq[n].real(), iq[n].imag())
+             * std::complex<double>(std::cos(ph), std::sin(ph));
+    }
+    return std::abs(acc) / static_cast<double>(iq.size());
+}
+
+// Run `seconds` of a pure audio tone through the modulator and collect the IQ.
+static std::vector<std::complex<float>> modulate(WdspChannel::Mode mode,
+                                                 double toneHz, double amplitude,
+                                                 double micGain, double seconds,
+                                                 float* lastMicPeak = nullptr)
+{
+    Hl2TxDsp tx;
+    Hl2TxDsp::Config cfg;
+    cfg.mode = mode;
+    std::string err;
+    if (!tx.configure(cfg, &err)) {
+        std::fprintf(stderr, "FAIL: configure: %s\n", err.c_str());
+        ++g_failures;
+        return {};
+    }
+    tx.setMicGain(micGain);
+
+    std::vector<std::complex<float>> out;
+    QObject::connect(&tx, &Hl2TxDsp::iqReady, &tx,
+                     [&](const std::vector<std::complex<float>>& iq) {
+        out.insert(out.end(), iq.begin(), iq.end());
+    });
+    if (lastMicPeak) {
+        QObject::connect(&tx, &Hl2TxDsp::micPeak, &tx,
+                         [lastMicPeak](float db) { *lastMicPeak = db; });
+    }
+
+    const int fs = cfg.inputSampleRateHz;
+    const int total = static_cast<int>(seconds * fs);
+    std::vector<float> audio(static_cast<std::size_t>(total));
+    for (int n = 0; n < total; ++n)
+        audio[static_cast<std::size_t>(n)] =
+            static_cast<float>(amplitude * std::sin(2.0 * M_PI * toneHz * n / fs));
+
+    // Feed in realistic chunks rather than one giant block.
+    constexpr std::size_t kChunk = 240;
+    for (std::size_t off = 0; off < audio.size(); off += kChunk) {
+        const std::size_t n = std::min(kChunk, audio.size() - off);
+        tx.processAudioBlock(std::vector<float>(audio.begin() + static_cast<std::ptrdiff_t>(off),
+                                                audio.begin() + static_cast<std::ptrdiff_t>(off + n)));
+    }
+    return out;
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    constexpr double kFsOut = 48000.0;
+    constexpr double kTone = 1000.0;
+
+    // ---- rate conversion ----
+    {
+        const auto iq = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 1.0, 0.5);
+        check(!iq.empty(), "USB modulation produces IQ");
+        double mx = 0.0;
+        for (const auto& v : iq) mx = std::max(mx, static_cast<double>(std::abs(v)));
+        std::fprintf(stderr, "diag: %zu IQ samples, max |IQ| = %.9f\n", iq.size(), mx);
+        // 0.5 s of 24 kHz audio -> ~0.5 s of 48 kHz IQ. WDSP's filter latency
+        // eats a little, so allow a generous margin; what matters is the 2:1.
+        check(iq.size() > 18000 && iq.size() < 26000,
+              "24 kHz audio in -> ~48 kHz IQ out (2:1 rate conversion)");
+    }
+
+    // ---- USB puts the tone ABOVE the carrier ----
+    {
+        const auto iq = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 1.0, 1.0);
+        if (!iq.empty()) {
+            const double upper = binPower(iq, +kTone, kFsOut);
+            const double lower = binPower(iq, -kTone, kFsOut);
+            const double ratioDb = 20.0 * std::log10((upper + 1e-12) / (lower + 1e-12));
+            std::fprintf(stderr, "USB: +1kHz %.6f, -1kHz %.6f, suppression %.1f dB\n",
+                         upper, lower, ratioDb);
+            check(upper > lower, "USB: energy is on the UPPER side");
+            check(ratioDb > 30.0, "USB: opposite sideband suppressed by >30 dB");
+        }
+    }
+
+    // ---- LSB puts it BELOW ----
+    {
+        const auto iq = modulate(WdspChannel::Mode::Lsb, kTone, 0.5, 1.0, 1.0);
+        if (!iq.empty()) {
+            const double upper = binPower(iq, +kTone, kFsOut);
+            const double lower = binPower(iq, -kTone, kFsOut);
+            const double ratioDb = 20.0 * std::log10((lower + 1e-12) / (upper + 1e-12));
+            std::fprintf(stderr, "LSB: +1kHz %.6f, -1kHz %.6f, suppression %.1f dB\n",
+                         upper, lower, ratioDb);
+            check(lower > upper, "LSB: energy is on the LOWER side");
+            check(ratioDb > 30.0, "LSB: opposite sideband suppressed by >30 dB");
+        }
+    }
+
+    // ---- audio outside the passband does not get transmitted ----
+    {
+        // 5 kHz is well above the 2700 Hz TX filter.
+        const auto iq = modulate(WdspChannel::Mode::Usb, 5000.0, 0.5, 1.0, 1.0);
+        const auto ref = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 1.0, 1.0);
+        if (!iq.empty() && !ref.empty()) {
+            const double out = binPower(iq, 5000.0, kFsOut);
+            const double in  = binPower(ref, kTone, kFsOut);
+            const double rejDb = 20.0 * std::log10((in + 1e-12) / (out + 1e-12));
+            double mxOut = 0.0, mxRef = 0.0;
+            for (const auto& v : iq)  mxOut = std::max(mxOut, static_cast<double>(std::abs(v)));
+            for (const auto& v : ref) mxRef = std::max(mxRef, static_cast<double>(std::abs(v)));
+            // Probe where the 5 kHz energy actually went.
+            std::fprintf(stderr, "passband: 1 kHz %.6f vs 5 kHz %.6f, rejection %.1f dB "
+                                 "| max|IQ| ref %.4f out %.4f | out@-5k %.6f out@19k %.6f out@1k %.6f\n",
+                         in, out, rejDb, mxRef, mxOut,
+                         binPower(iq, -5000.0, kFsOut), binPower(iq, 19000.0, kFsOut),
+                         binPower(iq, 1000.0, kFsOut));
+            check(rejDb > 30.0, "audio above the TX passband is filtered out");
+        }
+    }
+
+    // ---- mic gain scales the drive, and the peak meter follows it ----
+    {
+        float peakUnity = -300.0f, peakHalf = -300.0f;
+        const auto loud  = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 1.0, 0.5, &peakUnity);
+        const auto quiet = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 0.5, 0.5, &peakHalf);
+        if (!loud.empty() && !quiet.empty()) {
+            const double a = binPower(loud, kTone, kFsOut);
+            const double b = binPower(quiet, kTone, kFsOut);
+            const double dropDb = 20.0 * std::log10((a + 1e-12) / (b + 1e-12));
+            std::fprintf(stderr, "mic gain: unity %.6f, half %.6f, drop %.1f dB; "
+                                 "peak %.1f -> %.1f dBFS\n",
+                         a, b, dropDb, peakUnity, peakHalf);
+            check(dropDb > 4.0 && dropDb < 8.0,
+                  "halving mic gain drops the transmitted level by ~6 dB");
+            check(peakUnity - peakHalf > 4.0 && peakUnity - peakHalf < 8.0,
+                  "the mic peak meter follows mic gain by the same ~6 dB");
+        }
+    }
+
+    if (g_failures == 0)
+        std::fprintf(stderr, "hl2_txdsp_test: all checks passed\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -45,11 +45,16 @@ static double binPower(const std::vector<std::complex<float>>& iq, double hz, do
 static std::vector<std::complex<float>> modulate(WdspChannel::Mode mode,
                                                  double toneHz, double amplitude,
                                                  double micGain, double seconds,
-                                                 float* lastMicPeak = nullptr)
+                                                 float* lastMicPeak = nullptr,
+                                                 bool alc = false)
 {
     Hl2TxDsp tx;
     Hl2TxDsp::Config cfg;
     cfg.mode = mode;
+    // ALC OFF by default in these tests. Every assertion below except the ALC's
+    // own measures a fixed relationship between input and output, and an ALC
+    // exists precisely to break fixed relationships.
+    cfg.alcEnabled = alc;
     std::string err;
     if (!tx.configure(cfg, &err)) {
         std::fprintf(stderr, "FAIL: configure: %s\n", err.c_str());
@@ -155,6 +160,8 @@ int main(int argc, char** argv)
     }
 
     // ---- mic gain scales the drive, and the peak meter follows it ----
+    // Runs with the ALC OFF: with it on, compensating for exactly this change is
+    // the ALC's purpose, and the 1:1 relationship correctly disappears.
     {
         float peakUnity = -300.0f, peakHalf = -300.0f;
         const auto loud  = modulate(WdspChannel::Mode::Usb, kTone, 0.5, 1.0, 0.5, &peakUnity);
@@ -170,6 +177,41 @@ int main(int argc, char** argv)
                   "halving mic gain drops the transmitted level by ~6 dB");
             check(peakUnity - peakHalf > 4.0 && peakUnity - peakHalf < 8.0,
                   "the mic peak meter follows mic gain by the same ~6 dB");
+        }
+    }
+
+    // ---- ALC lifts speech-level audio to something that modulates ----
+    //
+    // This is the gap that made voice inaudible on the air: measured on the
+    // radio, audio at -10 dBFS produced 1226 counts of forward power and audio
+    // at -30 dBFS produced 47, while ordinary speech sits near -32 dBFS. The
+    // ALC's job is to close that.
+    {
+        constexpr double kQuiet = 0.02;         // about -34 dBFS, speech-ish
+        const auto plain = modulate(WdspChannel::Mode::Usb, kTone, kQuiet, 1.0, 1.5,
+                                    nullptr, false);
+        const auto alced = modulate(WdspChannel::Mode::Usb, kTone, kQuiet, 1.0, 1.5,
+                                    nullptr, true);
+        if (!plain.empty() && !alced.empty()) {
+            // Compare the settled tail: the ALC ramps in, so the opening block
+            // is deliberately not representative.
+            auto tailPeak = [](const std::vector<std::complex<float>>& v) {
+                double mx = 0.0;
+                for (std::size_t i = v.size() / 2; i < v.size(); ++i)
+                    mx = std::max(mx, static_cast<double>(std::abs(v[i])));
+                return mx;
+            };
+            const double a = tailPeak(plain);
+            const double b = tailPeak(alced);
+            std::fprintf(stderr, "ALC: quiet input peak %.4f -> %.4f (+%.1f dB)\n",
+                         a, b, 20.0 * std::log10((b + 1e-12) / (a + 1e-12)));
+            check(b > a * 5.0, "ALC lifts quiet audio substantially");
+            check(b > 0.5, "ALC brings quiet audio near full modulation");
+            // And it must never overshoot into clipping — an ALC that overshoots
+            // transmits splatter rather than merely clipping our own audio.
+            double mx = 0.0;
+            for (const auto& v : alced) mx = std::max(mx, static_cast<double>(std::abs(v)));
+            check(mx <= 1.001, "ALC output never exceeds full scale");
         }
     }
 

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -1,9 +1,18 @@
 // SSB modulator correctness for the Hermes-Lite 2 transmit chain.
 //
-// The assertion that matters on the air: a 1 kHz audio tone must appear at
-// +1 kHz of baseband for USB and at -1 kHz for LSB. Getting this inverted
-// transmits on the wrong sideband — which sounds fine in a loopback and is
-// immediately obvious to everyone else on the band.
+// The assertion that matters on the air: for USB, a 1 kHz audio tone must leave
+// this modulator at -1 kHz of the IQ it hands to the wire, and for LSB at
+// +1 kHz.
+//
+// THAT SIGN LOOKS BACKWARDS AND IS NOT. The HPSDR wire order has the opposite
+// handedness to the standard analytic convention, which is why the receive path
+// conjugates with -imag() before WDSP sees anything. Transmit carries the same
+// correction, so the wire-facing sign is inverted from the textbook one.
+//
+// This was originally asserted the textbook way, and the test passed while every
+// transmission went out on the WRONG SIDEBAND — invisible from inside the
+// application, because the panadapter reads the same wire order and therefore
+// agreed with it. It took an operator with a second receiver to catch it.
 //
 // It also pins the rate conversion (24 kHz audio in, 48 kHz IQ out) and the
 // mic-gain path, both of which are easy to get subtly wrong in ways that only
@@ -118,8 +127,9 @@ int main(int argc, char** argv)
             const double ratioDb = 20.0 * std::log10((upper + 1e-12) / (lower + 1e-12));
             std::fprintf(stderr, "USB: +1kHz %.6f, -1kHz %.6f, suppression %.1f dB\n",
                          upper, lower, ratioDb);
-            check(upper > lower, "USB: energy is on the UPPER side");
-            check(ratioDb > 30.0, "USB: opposite sideband suppressed by >30 dB");
+            check(lower > upper,
+                  "USB: wire-facing IQ puts energy on the LOWER side (conjugated)");
+            check(-ratioDb > 30.0, "USB: opposite sideband suppressed by >30 dB");
         }
     }
 
@@ -132,8 +142,9 @@ int main(int argc, char** argv)
             const double ratioDb = 20.0 * std::log10((lower + 1e-12) / (upper + 1e-12));
             std::fprintf(stderr, "LSB: +1kHz %.6f, -1kHz %.6f, suppression %.1f dB\n",
                          upper, lower, ratioDb);
-            check(lower > upper, "LSB: energy is on the LOWER side");
-            check(ratioDb > 30.0, "LSB: opposite sideband suppressed by >30 dB");
+            check(upper > lower,
+                  "LSB: wire-facing IQ puts energy on the UPPER side (conjugated)");
+            check(-ratioDb > 30.0, "LSB: opposite sideband suppressed by >30 dB");
         }
     }
 


### PR DESCRIPTION
## Summary

Transmit for the Hermes-Lite 2, **verified on air** into a dummy load — keying, TUNE, an SSB modulator, the PC microphone path, an ALC, RX muting, C&C telemetry and meters.

Confirmed working on both **USB and LSB** against an independent receiver (Yaesu FTX-1), which turned out to matter more than any measurement taken inside the app.

Stacked on `feat/hl2-backend`; base is that branch, not `main`.

## The bug that mattered most

**Transmit was on the wrong sideband for the entire bring-up**, and *every internal check agreed it was right.*

The HPSDR wire has the opposite handedness to the standard analytic convention. The receive path already compensated (`-imag()` before WDSP — the fix filed earlier as "USB and LSB are swapped"); transmit never got the same correction. Because the panadapter reads the same wire order as the transmitter, our display and our transmission were consistent with each other while both disagreed with the band.

What passed anyway:

| Check | Result |
|---|---|
| Modulator sideband assertion | 85 dB suppression, "correct" side |
| Simulator loopback via PureSignal feedback | tone at the expected bin |
| Live panadapter during TX | clean single sideband, correct side of centre |
| USB vs LSB forward power @ 14.200 | 3875 vs 3876 — identical |
| TX FIFO depth | stable 27–31, no under/overflow (refuted the starvation theory) |

Found in one sentence by the operator: *"I heard the LSB side of AetherSDR on the USB side of the Yaesu."*

**A convention error is invisible to any test that shares the convention.** Both tests now pin the *wire* convention and explain why the sign looks backwards. Related: TUNE worked throughout — a carrier at zero offset has no handedness, so the one signal that always looked fine could never have exposed it.

## Measured on the live radio

```
tone      fwd 1080 counts, SWR 1.0:1, PA 29.5 → 34.1 °C
mic       fwd up to 3134, MICPEAK tracking the room
ALC       -35 dBFS tone: 30 counts → 3882 counts
RX mute   0 bytes / 0 chunks of RX audio during TX
```

Rising PA temperature is the check a wiring error can't fake. SWR reading 1.0 into a dummy load independently validates the voltage-form ratio.

## Silent defects between "correct IQ" and "RF out of the socket"

Each produced a perfectly correct-looking keyed transmission with **zero** forward power:

1. `onTxAudioReady` returned early without a Flex TX stream id — killing the mic *and* the TONE button, since the tone is injected inside that callback
2. Mic capture was never started (only Flex DAX signals start it)
3. The onboard PA was never enabled (`0x09[19]`) — output was milliwatts
4. RF power was never applied on connect (`rfPowerChanged` is edge-triggered)

Plus: **the radio reports no VFO**, so anything not explicitly pushed on connect is inherited from the previous session. The TX NCO wasn't pushed — the VFO read 10 MHz while the radio transmitted on 14 MHz.

## Other fixes

- **`meterUpdate` was wired to nothing** — every meter value this backend computed was discarded. The S-meter had been correct for days and never once visible.
- **No gain staging.** Speech at −32 dBFS produced ~1/1600 the power of a −10 dBFS tone. Added an ALC: fast attack, slow release, capped gain, hard-limited after (an ALC that overshoots is a splatter generator).
- **RX wasn't muted on TX**, so the operator heard their own carrier as fuzz and their voice as feedback through an open mic. Muted at the *demodulator*, not just the output — otherwise WDSP's buffers fill with the transmission and drain on unkey.
- **TUNE latched on** (`m_tune` was only set from a radio status delta the HL2 never sends), and a latched carrier silenced voice because the packet builder prefers the tone over queued audio.
- **Mic source** collapses to PC and PC Audio locks on for host-modulating backends — the Flex jacks don't exist here and selecting one transmits silence.
- **The TX watchdog force-unkeyed the operator at exactly 20 s.** *(Only commit here outside the HL2 backend — it touches `AutomationServer`.)* The bridge's TX watchdog is a runaway-**script** backstop, but it armed on any keying because it polls the transmit model rather than tracking who keyed. The bridge enable is a persisted setting, so it was on during ordinary operating and cut MOX and TUNE off mid-sentence. Now scoped to **automation-initiated TX only** — a human holding MOX is left alone, so it no longer cuts off live testing, while a runaway script is still stopped. Verified on the live radio: a bridge key still runs 21 s and logs `TX force-unkey: max continuous key time exceeded`.
- Retired comments the bring-up disproved (`RX-only`, "all-zero payload", "before any TX work").

## The bring-up, commit by commit

Read top to bottom, this is the order the radio actually taught us things. Several commits exist only because the one before it turned out to be wrong on the air.

| # | Commit | What it does | Why it was needed |
|---|---|---|---|
| 1 | `ad427c76` | MOX, TX NCO, drive — behind an explicit gate | First keying. Replaces the old structural invariant (*every C0 even ⇒ MOX always 0*) with a gate proven on the real outgoing bytes |
| 2 | `6a47a54d` | Carry transmit IQ in EP2, only while keyed | Host→radio samples are **16-bit** I/Q, unlike EP6's 24-bit; the first 32-bit word after C&C is **EADDR, not audio** |
| 3 | `06eed03b` | Follow the automation TX gate, not a new env var | A second flag meant two things to get right. Honouring **both** its sources mattered: checking only the env var made the bridge report `ok` while nothing keyed |
| 4 | `0396ab64` | TX test tone + simulator loopback proof | hpsdrsim's PureSignal feedback lets a transmitted tone be verified without radiating |
| 5 | `b605ed8f` | EP6 C&C telemetry, and connect the orphaned meter seam | `meterUpdate` had **no consumer anywhere** — every meter value was discarded. ACK changes how C0 decodes; TX-inhibit is active-low; SWR is the **voltage** form |
| 6 | `16727092` | SSB modulator — 85 dB opposite-sideband suppression | Caught a textbook Hilbert transformer being **all-pass in magnitude**: out-of-band audio came out double-sideband, 6 dB down. Rejection 6 dB → 100 dB |
| 7 | `b40c59d8` | The PC microphone path — TONE and mic on one chain | TONE needed no special case: it injects at the head of AudioEngine's chain, so mic, tone and the QSO recording all agree with what goes out |
| 8 | `13cb113b` | PA enable, power on connect, SWR gating | Four silent defects, each producing a correct-looking keyed transmission with **zero** forward power |
| 9 | `53a6005e` | `HERMES.md` §14 — the transmit bring-up | |
| 10 | `00358049` | Route GUI keying and TUNE through the seam | `setKeying` had **no callers**; MOX emitted the Flex text command `xmit 1`. Automation keyed fine, the button did nothing |
| 11 | `bc54d0a0` | `HERMES.md` §14.5 — exercise both models when testing UX | |
| 12 | `51f38306` | TUNE latched on; a latched carrier silenced voice | `m_tune` came only from a radio status delta the HL2 never sends, so the toggle could never stop. The packet builder prefers the tone over queued audio, so a stuck carrier replaced every subsequent PTT |
| 13 | `f99a8954` | Mute RX on transmit; add the TX ALC | Nothing muted RX, so the operator heard their own carrier through an open mic. And speech at −32 dBFS made ~1/1600 the power of a −10 dBFS tone |
| 14 | `8bf8ec74` | Push full state on connect; PC as the only mic source | **The radio reports no VFO.** The TX NCO wasn't pushed, so the VFO read 10 MHz while the radio transmitted on 14 MHz |
| 15 | `f00bd84b` | **Conjugate transmit IQ for the wire** | The one that mattered. Every transmission was on the wrong sideband, and every internal check agreed it was right |
| 16 | `7fdc5a10` | `HERMES.md` §14.6 — why internal checks missed it | |
| 17 | `8f0c8822` | Retire comments the bring-up disproved | `RX-only`, "all-zero payload", "before any TX work" — true when written, misleading now |
| 18 | `22ad1b85` | Stop the TX watchdog force-unkeying the operator | Reported as *"MOX and tune both get cut off at exactly 20 seconds"* |

**The shape of it:** commits 1–8 built transmit and proved it against a simulator and instruments. Commits 10–15 are what happened when a human pressed the buttons — five separate defects that no automated check caught, ending in the sideband inversion that only an independent receiver could find.

## Deliberately not done

- **Absolute watts.** Counts are uncalibrated; oracle §6 forbids presenting them as watts. SWR survives uncalibrated because it's a ratio from the same converter.
- **FIFO-servoed pacing.** The decoded depth follows hpsdrsim's layout and the oracle's §6 table disagrees in a way that can't both be right. **The gateware RTL has not been consulted** and the code says so.
- **WDSP TXA.** Its TX path works (`wdsp_channel_test` proves it), but driven from this backend's config it returned underruns and zeros, and the failure mode is silent.
- **PA temperature formula** is the HL2 wiki's, unverified against a reference.

## Safety

Transmit is available to an interactive run and defers to the bridge's existing TX gate under automation — **both** of its sources (env var *and* the persisted operator toggle; checking only the env var made the bridge report `ok` while nothing keyed).

`hl2_tx_gate_test` replaces the old structural invariant (every C0 even ⇒ MOX always 0) by asserting on the real outgoing bytes that with the gate closed no frame ever carries C0 bit 0 — across the full round robin, with a key request standing, including revoking the gate mid-key.

## Tests

**175/175.** New: `hl2_txdsp_test` (sideband/wire convention, rate conversion, ALC, mic gain), `hl2_tx_gate_test`, `hl2_tx_loopback_test` (end-to-end through hpsdrsim's feedback; sim-only, skips when absent), plus telemetry and SWR cases.

`HERMES.md` §14 records the bring-up: the silent defects, the all-pass Hilbert bug that would have radiated double-sideband splatter, the protocol facts, and §14.6 on why self-consistency isn't correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

