### PR TITLE
fix(gui): scope overlay panel styles

### DIFF
--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -204,7 +204,7 @@ static constexpr int BAND_BTN_W = 48;
 static constexpr int BAND_BTN_H = 26;
 
 static const QString kPanelStyle =
-    "QWidget { background: rgba(15, 15, 26, 220); "
+    "QWidget#antPanel, QWidget#daxPanel { background: rgba(15, 15, 26, 220); "
     "border: 1px solid #304050; border-radius: 3px; }";
 
 static const QString kLabelStyle =
@@ -378,7 +378,8 @@ void SpectrumOverlayMenu::setMemories(const QMap<int, MemoryEntry>& memories)
 void SpectrumOverlayMenu::buildBandPanel()
 {
     m_bandPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
                                 "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
 
@@ -441,6 +442,7 @@ void SpectrumOverlayMenu::buildBandPanel()
 void SpectrumOverlayMenu::buildAntPanel()
 {
     m_antPanel = new QWidget(parentWidget());
+    m_antPanel->setObjectName(QStringLiteral("antPanel"));
     m_antPanel->setStyleSheet(kPanelStyle);
     m_antPanel->hide();
 
@@ -505,7 +507,9 @@ void SpectrumOverlayMenu::buildAntPanel()
         "border: 1px solid #0090e0; }"
         "QPushButton:hover { border: 1px solid #0090e0; }";
     m_loopRow = new QWidget(m_antPanel);
-    m_loopRow->setStyleSheet("QWidget { background: transparent; border: none; }");
+    m_loopRow->setObjectName(QStringLiteral("antLoopRow"));
+    m_loopRow->setStyleSheet(
+        "QWidget#antLoopRow { background: transparent; border: none; }");
     auto* loopRow = new QHBoxLayout(m_loopRow);
     loopRow->setContentsMargins(0, 0, 0, 0);
     loopRow->setSpacing(4);
@@ -1006,6 +1010,7 @@ void SpectrumOverlayMenu::syncAntPanel()
 void SpectrumOverlayMenu::buildDaxPanel()
 {
     m_daxPanel = new QWidget(parentWidget());
+    m_daxPanel->setObjectName(QStringLiteral("daxPanel"));
     m_daxPanel->setStyleSheet(kPanelStyle);
     m_daxPanel->hide();
 
@@ -2508,7 +2513,8 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_bandPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+    m_bandPanel->setObjectName(QStringLiteral("bandPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_bandPanel, "QWidget#bandPanel { background: rgba(15, 15, 26, 220); "
                                 "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_bandPanel->hide();
     m_bandPanel->installEventFilter(this);
@@ -2674,7 +2680,8 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     }
 
     m_xvtrPanel = new QWidget(parentWidget());
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_xvtrPanel, "QWidget { background: rgba(15, 15, 26, 220); "
+    m_xvtrPanel->setObjectName(QStringLiteral("xvtrPanel"));
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_xvtrPanel, "QWidget#xvtrPanel { background: rgba(15, 15, 26, 220); "
                                 "border: 1px solid {{color.background.2}}; border-radius: 3px; }");
     m_xvtrPanel->hide();
     m_xvtrPanel->installEventFilter(this);


### PR DESCRIPTION
## Summary

Fixes #4444.

I scoped the remaining Spectrum overlay panel styles to their object names so they no longer cascade into descendant tooltip labels. This covers the shared Ant/DAX style, both Band panel construction paths, the Ant loop row, and the XVTR panel without changing colors, layout, or control behavior.

## Constitution principle honored

Principle VIII — I verified the selector contract and relevant static checks rather than relying on the mechanical nature of the change.

## Test plan

- [ ] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

I ran:

- a focused selector regression check covering all five affected construction sites and rejecting the old unscoped selectors
- `python3 tools/check_a11y.py src/gui/SpectrumOverlayMenu.cpp`
- `python3 tools/check_engine_boundary.py --strict`
- `git diff --check origin/main...HEAD`

I also attempted the documented CMake configure, but this environment does not have the Qt 6 development package, so I am deferring the full build and runtime tooltip hover check to CI and maintainer verification.

To verify manually: open the panadapter overlay, visit the Band, Ant, DAX, and XVTR panels, then hover their controls and confirm each tooltip retains its framed background.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable
