### PR TITLE
fix(gui): collapsed-VFO right-click Add Spot captures wrong frequency (#4455)

### DIFF
--- a/src/gui/VfoWidget.cpp
+++ b/src/gui/VfoWidget.cpp
@@ -801,6 +801,10 @@ void VfoWidget::buildUI()
         " padding: 1px 4px; }");
     m_collapsedFreqLabel->setAlignment(Qt::AlignCenter);
     m_collapsedFreqLabel->hide();
+    // Right-click → Add Spot must work in collapsed mode too (#4455); without
+    // this, clicks fall through to the SpectrumWidget underneath, which
+    // reports the cursor's step-snapped frequency instead of the VFO's.
+    m_collapsedFreqLabel->installEventFilter(this);
 
     // ── Frequency row (right-aligned, double-click to edit) ────────────────
     m_freqStack = new QStackedWidget;
@@ -5859,8 +5863,12 @@ bool VfoWidget::eventFilter(QObject* obj, QEvent* event)
         beginDirectEntry();
         return true;
     }
-    // Right-click on frequency label → context menu
-    if (obj == m_freqLabel && event->type() == QEvent::MouseButtonPress) {
+    // Right-click on frequency label → context menu (also handles the
+    // collapsed-mode label, #4455). Double-click direct-entry is
+    // deliberately not mirrored here: m_freqStack (which holds the edit
+    // box) is hidden/mouse-transparent while collapsed and would need
+    // real repositioning work to become usable — left as a follow-up.
+    if ((obj == m_freqLabel || obj == m_collapsedFreqLabel) && event->type() == QEvent::MouseButtonPress) {
         auto* me = static_cast<QMouseEvent*>(event);
         if (me->button() == Qt::RightButton && m_slice) {
             QMenu menu(this);


### PR DESCRIPTION
Closes #4455.

## What
`m_collapsedFreqLabel` (the frequency shown when a VFO flag is
collapsed) never got `installEventFilter(this)`, so right-clicking it
never reached `VfoWidget::eventFilter()`'s Add Spot handler. The click
fell through to `SpectrumWidget`'s own context menu instead, which
reports the cursor's step-snapped frequency rather than the VFO's
actual frequency — the reported bug.

Fix: install the event filter on `m_collapsedFreqLabel` too, and
extend the right-click branch to match it alongside `m_freqLabel`.

Double-click direct-entry is deliberately **not** mirrored here: the
edit box (`m_freqStack`) is hidden and mouse-transparent while
collapsed, and would need real repositioning work to become usable —
left as a follow-up rather than folded into this fix.

## Test plan
- [x] Reproduced the bug first on the *installed release build*
      (right-click on collapsed VFO label → SpectrumWidget's "Add Spot
      at 21.277000 MHz…" menu, mismatched against the VFO's actual
      21.281900) to confirm it's real before fixing
- [x] Built and ran the patched build locally
- [x] Collapsed a VFO, right-clicked the frequency label → now shows
      "Add Spot", pre-fills the dialog with the VFO's true frequency
- [x] Confirmed normal (expanded-mode) Add Spot behavior is unchanged