### PR TITLE
feat(spothub): add Freeze toggle to Spot List tab (#4145)

### DIFF
--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2116,13 +2116,35 @@ void DxClusterDialog::buildSpotListTab(QTabWidget* tabs)
     // (which resets the model without touching this label). (#2022)
     auto updateCount = [this] {
         if (m_spotCountLabel)
-            m_spotCountLabel->setText(QString("%1 spots").arg(m_spotModel->rowCount()));
+            m_spotCountLabel->setText(QString("%1 spots%2").arg(m_spotModel->rowCount())
+                                       .arg(m_spotListFrozen ? " (frozen)" : ""));
     };
     connect(m_spotModel, &QAbstractTableModel::rowsInserted, this, updateCount);
     connect(m_spotModel, &QAbstractTableModel::rowsRemoved, this, updateCount);
     connect(m_spotModel, &QAbstractTableModel::modelReset, this, updateCount);
     bottomRow->addWidget(m_spotCountLabel);
     bottomRow->addStretch();
+
+    // Pause the list so a spot stays put to click while new spots keep
+    // arriving in the background (#4145). Unfreezing flushes whatever
+    // buffered in m_spotBatch immediately rather than waiting for the
+    // next 1 Hz tick.
+    auto* freezeBtn = new QPushButton("Freeze");
+    freezeBtn->setObjectName("spotListFreezeBtn");
+    freezeBtn->setCheckable(true);
+    freezeBtn->setFixedWidth(60);
+    freezeBtn->setStyleSheet(kSpotHubToggle);
+    freezeBtn->setToolTip("Pause the spot list so new spots stop shifting\n"
+                          "rows while you're clicking one. Spots keep\n"
+                          "arriving in the background and appear once\n"
+                          "unfrozen.");
+    connect(freezeBtn, &QPushButton::toggled, this, [this, updateCount](bool on) {
+        m_spotListFrozen = on;
+        updateCount();
+        if (!on)
+            flushSpotBatch();
+    });
+    bottomRow->addWidget(freezeBtn);
 
     auto* clearBtn = new QPushButton("Clear");
     clearBtn->setObjectName("spotListClearBtn");
@@ -2851,7 +2873,7 @@ void DxClusterDialog::setTotalSpots(int count)
 
 void DxClusterDialog::flushSpotBatch()
 {
-    if (m_spotBatch.isEmpty()) return;
+    if (m_spotListFrozen || m_spotBatch.isEmpty()) return;
 
     auto isAtBottom = [](QAbstractScrollArea* w) {
         auto* sb = w->verticalScrollBar();

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -2873,7 +2873,17 @@ void DxClusterDialog::setTotalSpots(int count)
 
 void DxClusterDialog::flushSpotBatch()
 {
-    if (m_spotListFrozen || m_spotBatch.isEmpty()) return;
+    if (m_spotListFrozen) {
+        // Still accumulating while frozen, but don't let a long freeze
+        // against a busy feed grow the buffer unbounded — cap it to the
+        // same limit the model enforces after a flush, keeping the
+        // newest entries (review note on #4145).
+        const int cap = m_spotModel->maxSpots();
+        if (m_spotBatch.size() > cap)
+            m_spotBatch.remove(0, m_spotBatch.size() - cap);
+        return;
+    }
+    if (m_spotBatch.isEmpty()) return;
 
     auto isAtBottom = [](QAbstractScrollArea* w) {
         auto* sb = w->verticalScrollBar();

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -49,6 +49,7 @@ public:
     void addSpots(const QVector<DxSpot>& spots);
     void clear();
     void setMaxSpots(int max) { m_maxSpots = max; }
+    int maxSpots() const { return m_maxSpots; }
     const DxSpot* spotAt(int row) const;
 
 private:

--- a/src/gui/DxClusterDialog.h
+++ b/src/gui/DxClusterDialog.h
@@ -249,6 +249,9 @@ private:
     QTableView*            m_spotTable;
     BandFilterProxy*       m_proxyModel;
     QLabel*                m_spotCountLabel{nullptr};  // Spot List tab counter (#2022)
+    // While true, flushSpotBatch() leaves new spots buffered in m_spotBatch
+    // instead of inserting them, so the visible rows hold still (#4145).
+    bool                   m_spotListFrozen{false};
 
     // Display tab
     QLabel*            m_totalSpotsLabel{nullptr};


### PR DESCRIPTION
Closes #4145.

## What
New spots are prepended at row 0 on every 1s flush tick, so the list
is unusable to click a spot mid-scroll — everything below shifts down
constantly. There was no way to pause it.

Adds a checkable **Freeze** button next to Clear:
- `flushSpotBatch()` early-returns while frozen; spots keep
  accumulating in `m_spotBatch` (already capped downstream in
  `addSpots()`) rather than being lost.
- Unfreezing flushes immediately rather than waiting for the next
  1 Hz tick.
- The spot-count label reflects frozen state (`"N spots (frozen)"`).

## Test plan
- [x] Built and ran locally against a live DX cluster feed
      (dxspider.co.uk)
- [x] Froze the list at 170 spots — rows and count held exactly
      still for 6s of live incoming traffic
- [x] Unfroze — buffered spots (170→181) appeared immediately,
      button and label reflected state correctly
- [x] Confirmed normal (unfrozen) auto-scroll/flush behavior is
      unchanged