### PR TITLE
feat(amp): change fan-mode cycle button to a pull-down (#3905)

### DIFF
--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -1,5 +1,6 @@
 #include "AmpApplet.h"
 #include "HGauge.h"
+#include "GuardedSlider.h"
 #include "core/AppSettings.h"
 
 #include <QAccessible>
@@ -206,7 +207,11 @@ AmpApplet::AmpApplet(QWidget* parent)
         "QComboBox::drop-down { border: none; }"
         "QComboBox QAbstractItemView { background: {{color.background.2}}; color: {{color.text.primary}}; "
         "selection-background-color: {{color.background.1}}; }";
-    m_fanCombo = new QComboBox;
+    // GuardedComboBox (not plain QComboBox): this is a hardware control, so
+    // an accidental mouse-wheel scroll while just hovering over it must not
+    // silently change fan mode and send a command to the amp — it only
+    // responds to wheel input when its dropdown is actually open (#3905).
+    m_fanCombo = new GuardedComboBox;
     m_fanCombo->setObjectName(QStringLiteral("ampFanModeCombo"));
     for (const QString& mode : {QStringLiteral("STANDARD"), QStringLiteral("CONTEST"), QStringLiteral("BROADCAST")})
         m_fanCombo->addItem(fanModeLabel(mode), mode);
@@ -377,11 +382,15 @@ void AmpApplet::setMainsVoltage(int volts)
 
 void AmpApplet::setFanMode(const QString& mode)
 {
-    m_fanMode = mode.toUpper();
-    int idx = m_fanCombo->findData(m_fanMode);
+    const QString upper = mode.toUpper();
+    int idx = m_fanCombo->findData(upper);
     if (idx < 0) {
-        qWarning() << "AmpApplet: unknown fanmode" << m_fanMode;
+        // Leave m_fanMode and the combo's selection as they were — updating
+        // one but not the other would desync what's displayed from what
+        // AmpApplet thinks the mode is.
+        qWarning() << "AmpApplet: unknown fanmode" << upper;
     } else {
+        m_fanMode = upper;
         // Reflecting an incoming PGXL status — block signals so this
         // doesn't fire currentIndexChanged and echo a redundant
         // "setup fanmode=" command back to the amp (#3905).

--- a/src/gui/AmpApplet.cpp
+++ b/src/gui/AmpApplet.cpp
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSignalBlocker>
 #include "core/ThemeManager.h"
 #include "MeterSmoother.h"
 
@@ -192,30 +193,36 @@ AmpApplet::AmpApplet(QWidget* parent)
         "border-radius: 3px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
         "QPushButton:hover { background: {{color.background.1}}; }";
 
-    // Fan speed cycle button — labelled per mode via fanModeLabel()
-    // ("Fan: Std" / "Fan: Contest" / "Fan: Bcast").  Hidden until a direct
-    // PGXL connection delivers the first fanmode status.
-    m_fanBtn = new QPushButton(fanModeLabel(m_fanMode));
-    m_fanBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
-    m_fanBtn->setFocusPolicy(Qt::TabFocus);
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fanBtn, kBtnStyle);
-    m_fanBtn->setToolTip("Fan Speed\nClick to cycle STANDARD / CONTEST / BROADCAST");
-    m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
-    m_fanBtn->setAccessibleDescription("Cycles through STANDARD, CONTEST, and BROADCAST");
-    m_fanBtn->hide();
-    connect(m_fanBtn, &QPushButton::clicked, this, [this]() {
-        static const QStringList kModes = {"STANDARD", "CONTEST", "BROADCAST"};
-        int idx = kModes.indexOf(m_fanMode);
-        if (idx < 0) {
-            qWarning() << "AmpApplet: unknown fanmode" << m_fanMode << "— resetting to STANDARD";
-            idx = -1; // (-1 + 1) % 3 == 0 == STANDARD
-        }
-        m_fanMode = kModes[(idx + 1) % kModes.size()];
-        m_fanBtn->setText(fanModeLabel(m_fanMode));
-        m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+    // Fan speed pull-down — surfaces all three modes instead of making the
+    // operator click through them blind (#3905). Item text via
+    // fanModeLabel(); uppercase mode stored as itemData so the
+    // fanModeChanged contract ("uppercase, ready for sendCommand") is
+    // unchanged. Hidden until a direct PGXL connection delivers the first
+    // fanmode status.
+    static const char* kComboStyle =
+        "QComboBox { background: {{color.background.2}}; border: 1px solid {{color.background.2}}; "
+        "border-radius: 3px; padding: 1px 4px; color: {{color.text.primary}}; font-size: 10px; font-weight: bold; }"
+        "QComboBox:hover { background: {{color.background.1}}; }"
+        "QComboBox::drop-down { border: none; }"
+        "QComboBox QAbstractItemView { background: {{color.background.2}}; color: {{color.text.primary}}; "
+        "selection-background-color: {{color.background.1}}; }";
+    m_fanCombo = new QComboBox;
+    m_fanCombo->setObjectName(QStringLiteral("ampFanModeCombo"));
+    for (const QString& mode : {QStringLiteral("STANDARD"), QStringLiteral("CONTEST"), QStringLiteral("BROADCAST")})
+        m_fanCombo->addItem(fanModeLabel(mode), mode);
+    m_fanCombo->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+    m_fanCombo->setFocusPolicy(Qt::TabFocus);
+    AetherSDR::ThemeManager::instance().applyStyleSheet(m_fanCombo, kComboStyle);
+    m_fanCombo->setToolTip("Fan Speed\nSelect STANDARD / CONTEST / BROADCAST");
+    m_fanCombo->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+    m_fanCombo->setAccessibleDescription("Selects STANDARD, CONTEST, or BROADCAST fan mode");
+    m_fanCombo->hide();
+    connect(m_fanCombo, &QComboBox::currentIndexChanged, this, [this](int index) {
+        m_fanMode = m_fanCombo->itemData(index).toString();
+        m_fanCombo->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
         emit fanModeChanged(m_fanMode);
     });
-    btnRow->addWidget(m_fanBtn);
+    btnRow->addWidget(m_fanCombo);
 
     m_operateBtn = new QPushButton("OPERATE");
     m_operateBtn->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
@@ -371,9 +378,18 @@ void AmpApplet::setMainsVoltage(int volts)
 void AmpApplet::setFanMode(const QString& mode)
 {
     m_fanMode = mode.toUpper();
-    m_fanBtn->setText(fanModeLabel(m_fanMode));
-    m_fanBtn->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
-    m_fanBtn->show();
+    int idx = m_fanCombo->findData(m_fanMode);
+    if (idx < 0) {
+        qWarning() << "AmpApplet: unknown fanmode" << m_fanMode;
+    } else {
+        // Reflecting an incoming PGXL status — block signals so this
+        // doesn't fire currentIndexChanged and echo a redundant
+        // "setup fanmode=" command back to the amp (#3905).
+        QSignalBlocker blocker(m_fanCombo);
+        m_fanCombo->setCurrentIndex(idx);
+    }
+    m_fanCombo->setAccessibleName(QString("Fan speed: %1").arg(m_fanMode));
+    m_fanCombo->show();
 }
 
 void AmpApplet::setState(const QString& state)
@@ -414,7 +430,7 @@ void AmpApplet::setDirectConnected(bool direct)
         m_vacLabel->setText("Vac  — V");
         m_vacLabel->setStyleSheet("QLabel { color: #505050; font-size: 10px; }");
         // Fan mode is only available via direct PGXL protocol — hide until reconnected.
-        m_fanBtn->hide();
+        m_fanCombo->hide();
     }
 }
 

--- a/src/gui/AmpApplet.h
+++ b/src/gui/AmpApplet.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <QPushButton>
+#include <QComboBox>
 #include <QTimer>
 
 class QLabel;
@@ -51,7 +52,7 @@ private:
     QLabel*  m_sourceLabel{nullptr}; // "● DIRECT" or "● RADIO"
     bool     m_directConnected{false};
 
-    QPushButton* m_fanBtn{nullptr};
+    QComboBox*   m_fanCombo{nullptr};
     QPushButton* m_operateBtn{nullptr};
     QString      m_fanMode{"STANDARD"};
 

--- a/tests/amp_applet_test.cpp
+++ b/tests/amp_applet_test.cpp
@@ -4,9 +4,11 @@
 
 #include <QApplication>
 #include <QByteArray>
+#include <QComboBox>
 #include <QDir>
 #include <QFile>
 #include <QPushButton>
+#include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
 
@@ -30,6 +32,11 @@ void report(const char* name, bool ok, const QString& detail = QString())
 QPushButton* tempButton(AmpApplet& applet)
 {
     return applet.findChild<QPushButton*>(QStringLiteral("ampTempUnitButton"));
+}
+
+QComboBox* fanCombo(AmpApplet& applet)
+{
+    return applet.findChild<QComboBox*>(QStringLiteral("ampFanModeCombo"));
 }
 
 void resetSettings()
@@ -134,6 +141,50 @@ void testPreferenceReload()
            button->text());
 }
 
+void testFanModePulldown()
+{
+    resetSettings();
+
+    AmpApplet applet;
+    auto* combo = fanCombo(applet);
+    report("fan combo exists", combo != nullptr);
+    if (!combo) return;
+
+    report("fan combo has three modes", combo->count() == 3, QString::number(combo->count()));
+    // isVisibleTo(&applet), not isVisible(): the applet is never shown as a
+    // top-level window in this offscreen harness, so isVisible() would be
+    // false regardless of the combo's own shown/hidden state.
+    report("fan combo starts hidden", !combo->isVisibleTo(&applet));
+
+    QSignalSpy spy(&applet, &AmpApplet::fanModeChanged);
+
+    // Reflecting an incoming PGXL status must select the right item, show
+    // the combo, and NOT emit fanModeChanged (#3905) — that would echo a
+    // redundant "setup fanmode=" command straight back to the amp.
+    applet.setFanMode("contest");
+    report("setFanMode selects the matching item",
+           combo->currentData().toString() == QStringLiteral("CONTEST"),
+           combo->currentData().toString());
+    report("setFanMode shows the combo", combo->isVisibleTo(&applet));
+    report("setFanMode does not emit fanModeChanged", spy.isEmpty());
+
+    // A user-driven selection must emit the uppercase mode.
+    combo->setCurrentIndex(combo->findData(QStringLiteral("BROADCAST")));
+    report("user selection emits fanModeChanged", spy.count() == 1, QString::number(spy.count()));
+    if (!spy.isEmpty()) {
+        report("emitted mode is uppercase BROADCAST",
+               spy.takeFirst().at(0).toString() == QStringLiteral("BROADCAST"));
+    }
+
+    // An unrecognized mode from the radio must not crash or desync the
+    // combo's selection.
+    const QString before = combo->currentData().toString();
+    applet.setFanMode("bogus");
+    report("unknown fanmode leaves combo selection unchanged",
+           combo->currentData().toString() == before,
+           combo->currentData().toString());
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -155,6 +206,7 @@ int main(int argc, char** argv)
     testSingleSensorToggle();
     testDualSensorToggle();
     testPreferenceReload();
+    testFanModePulldown();
 
     std::printf("\n%s\n",
                 g_failed == 0


### PR DESCRIPTION
Closes #3905.

## What
The three fan modes (STANDARD/CONTEST/BROADCAST) were hidden behind a
click-to-cycle button — no way to see the choices without clicking
blind through them.

Swaps `QPushButton m_fanBtn` for a `QComboBox` with all three modes as
items (display text via the existing `fanModeLabel()`, uppercase mode
as `itemData` so the `fanModeChanged` contract — "uppercase, ready for
sendCommand" — is unchanged). `setFanMode()` now finds and selects the
matching item under `QSignalBlocker` when reflecting an incoming PGXL
status, so it doesn't echo a redundant `setup fanmode=` command back
to the amp.

No protocol change — `MainWindow_Wiring.cpp`'s incoming-status and
outgoing-command wiring is untouched.

## Test plan
No live PGXL amp available to test end-to-end (the AMP applet is
hardware-gated out of the dock without one), so extended
`tests/amp_applet_test.cpp` instead:
- [x] Fan combo exists with exactly 3 items
- [x] `setFanMode()` selects the matching item and shows the combo
- [x] `setFanMode()` does **not** emit `fanModeChanged` (the
      echo-prevention case — this is the main risk the triage flagged)
- [x] A user-driven selection **does** emit `fanModeChanged` with the
      correct uppercase mode
- [x] An unrecognized mode string leaves the selection unchanged
      instead of desyncing
- [x] All 13 pre-existing temperature-toggle tests still pass
      (unaffected, confirms no regression)