### PR TITLE
feat(hl2): user-assignable per-radio nickname, keyed by MAC

### DIFF
--- a/src/core/backends/hl2/Hl2Discovery.cpp
+++ b/src/core/backends/hl2/Hl2Discovery.cpp
@@ -1,5 +1,6 @@
 #include "core/backends/hl2/Hl2Discovery.h"
 
+#include "core/AppSettings.h"
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include <QNetworkDatagram>
@@ -47,6 +48,19 @@ QString macToSerial(const std::array<std::uint8_t, 6>& mac)
 }
 
 }  // namespace
+
+QString Hl2Discovery::nicknameSettingsKey(const QString& serial)
+{
+    // Serial IS the MAC string (macToSerial). Namespaced under Hl2Nickname/.
+    return QStringLiteral("Hl2Nickname/") + serial;
+}
+
+QString Hl2Discovery::effectiveNickname(const QString& serial, const QString& fallback)
+{
+    const QString custom =
+        AppSettings::instance().value(nicknameSettingsKey(serial)).toString().trimmed();
+    return custom.isEmpty() ? fallback : custom;
+}
 
 Hl2Discovery::Hl2Discovery(QObject* parent) : QObject(parent)
 {
@@ -131,8 +145,10 @@ void Hl2Discovery::onReadyRead()
         info.port     = kMetisPort;
         info.model    = QStringLiteral("Hermes-Lite 2");
         info.name     = info.model;
-        info.nickname = info.model;
         info.serial   = macToSerial(reply->mac);
+        // An HL2 has no on-radio name store; show the operator's custom nickname
+        // (keyed by MAC/serial in AppSettings) if one is set, else the model name.
+        info.nickname = effectiveNickname(info.serial, info.model);
         info.version  = QString::number(reply->gatewareVersion);
         // A radio already streaming to another client answers with 0x03. Show it
         // as present-but-taken rather than hiding it.
@@ -150,7 +166,8 @@ void Hl2Discovery::onReadyRead()
             const RadioInfo& prev = it.value().info;
             const bool changed = prev.address != info.address
                               || prev.status  != info.status
-                              || prev.version != info.version;
+                              || prev.version != info.version
+                              || prev.nickname != info.nickname;
             it.value().info = info;
             if (changed)
                 emit radioUpdated(info);

--- a/src/core/backends/hl2/Hl2Discovery.h
+++ b/src/core/backends/hl2/Hl2Discovery.h
@@ -40,6 +40,17 @@ public:
 
     [[nodiscard]] bool isRunning() const noexcept;
 
+    // AppSettings key for a user-assigned nickname for the HL2 with this serial
+    // (the MAC string). An HL2 has no on-radio name store (unlike Flex's
+    // "radio name" command), so the operator's custom name is persisted
+    // client-side, keyed by the radio's stable MAC, and read back here at
+    // discovery time. Shared with RadioSetupDialog so both sides agree on the key.
+    static QString nicknameSettingsKey(const QString& serial);
+    // The nickname to show for this serial: the saved custom name, or a default
+    // when none is set. Centralises the "custom or fall back" rule.
+    static QString effectiveNickname(const QString& serial,
+                                     const QString& fallback);
+
 signals:
     void radioDiscovered(const RadioInfo& info);
     void radioUpdated(const RadioInfo& info);

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -1,5 +1,6 @@
 #include "ConnectionPanel.h"
 #include "core/AppSettings.h"
+#include "core/backends/hl2/Hl2Discovery.h"   // shared nickname settings helper
 #include "core/NetworkPathResolver.h"
 #include "FramelessResizer.h"
 #include "FramelessWindowTitleBar.h"
@@ -8,6 +9,8 @@
 
 #include <QAbstractItemView>
 #include <QFormLayout>
+#include <QInputDialog>
+#include <QMenu>
 #include <QFrame>
 #include <QGroupBox>
 #include <QHBoxLayout>
@@ -354,6 +357,16 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_radioList->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_radioList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     localGroupLayout->addWidget(m_radioList);
+
+    // Right-click a discovered radio to set a custom nickname without connecting
+    // first. Only radios without an on-radio name store (non-Flex: HL2, sim, …)
+    // are stored client-side; Flex's own "radio name" is set from Radio Setup
+    // while connected, so we don't offer it here for Flex to avoid two sources of
+    // truth. The nickname is persisted keyed by serial and picked up on the next
+    // discovery sweep.
+    m_radioList->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_radioList, &QListWidget::customContextMenuRequested, this,
+            [this](const QPoint& pos) { showRadioContextMenu(pos); });
     localListLayout->addWidget(localGroup, 1);
 
     auto* localActionRow = new QHBoxLayout;
@@ -1058,6 +1071,60 @@ void ConnectionPanel::setCurrentMode(ConnectionMode mode)
 void ConnectionPanel::onConnectionModeClicked(int id)
 {
     setCurrentMode(static_cast<ConnectionMode>(id));
+}
+
+void ConnectionPanel::showRadioContextMenu(const QPoint& pos)
+{
+    QListWidgetItem* item = m_radioList->itemAt(pos);
+    if (!item)
+        return;
+    const int row = m_radioList->row(item);
+    if (row < 0 || row >= m_radios.size())
+        return;
+    const RadioInfo radio = m_radios[row];
+
+    // Flex stores its name on the radio itself (set from Radio Setup while
+    // connected); offering a client-side override here would create two sources
+    // of truth. So the client-side nickname is only for families without an
+    // on-radio store (HL2, sim, any future non-Flex backend).
+    const bool isFlex =
+        radio.family.isEmpty()
+        || radio.family.compare(QLatin1String("flex"), Qt::CaseInsensitive) == 0;
+    if (isFlex)
+        return;
+
+    QMenu menu(this);
+    QAction* setNick = menu.addAction(tr("Set Nickname…"));
+    const QString savedKey = hl2::Hl2Discovery::nicknameSettingsKey(radio.serial);
+    const bool hasCustom =
+        !AppSettings::instance().value(savedKey).toString().trimmed().isEmpty();
+    QAction* clearNick = hasCustom ? menu.addAction(tr("Clear Nickname")) : nullptr;
+
+    QAction* chosen = menu.exec(m_radioList->mapToGlobal(pos));
+    if (!chosen)
+        return;
+
+    if (chosen == setNick) {
+        bool ok = false;
+        const QString current =
+            AppSettings::instance().value(savedKey).toString();
+        const QString name = QInputDialog::getText(
+            this, tr("Set Nickname"),
+            tr("Nickname for %1:").arg(radio.model),
+            QLineEdit::Normal, current, &ok);
+        if (ok)
+            AppSettings::instance().setValue(savedKey, name.trimmed());
+    } else if (clearNick && chosen == clearNick) {
+        AppSettings::instance().remove(savedKey);
+    }
+
+    // Reflect the change immediately: re-label this row from the saved setting
+    // rather than waiting for the next discovery sweep.
+    RadioInfo updated = radio;
+    updated.nickname =
+        hl2::Hl2Discovery::effectiveNickname(radio.serial, radio.model);
+    m_radios[row] = updated;
+    item->setText(formatLocalRadioLabel(updated));
 }
 
 void ConnectionPanel::onRadioDiscovered(const RadioInfo& radio)

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -93,6 +93,9 @@ private:
     void setCurrentMode(ConnectionMode mode);
     void updateLocalPageState();
     void updateSmartLinkUi();
+    // Right-click menu on a discovered radio row: set/clear a client-side
+    // nickname (non-Flex families only). pos is in m_radioList viewport coords.
+    void showRadioContextMenu(const QPoint& pos);
     void updateActionState();
     void updateLowBandwidthVisibility();
     void updateManualAdvancedVisibility();

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -7,6 +7,7 @@
 #include "models/XvtrPolicy.h"
 #include "core/AppSettings.h"
 #include "core/AutomationBridgeSettings.h"
+#include "core/backends/hl2/Hl2Discovery.h"   // HL2 custom-nickname settings key
 #include "core/NetworkSettings.h"
 #include "core/PanadapterStream.h"
 #include "core/KiwiSdrManager.h"
@@ -1069,7 +1070,18 @@ QWidget* RadioSetupDialog::buildRadioTab()
                         1, 0);
 
         connect(m_nicknameEdit, &QLineEdit::editingFinished, this, [this] {
-            m_model->sendCommand("radio name " + m_nicknameEdit->text());
+            const RadioInfo info = m_model->lastRadioInfo();
+            if (info.family.compare(QLatin1String("hl2"), Qt::CaseInsensitive) == 0) {
+                // An HL2 has no on-radio name store, so "radio name" is a no-op on
+                // the wire. Persist the operator's nickname client-side, keyed by
+                // the radio's MAC (== serial), so Hl2Discovery shows it in the
+                // picker on the next sweep. (aetherd HL2: custom nickname.)
+                AppSettings::instance().setValue(
+                    hl2::Hl2Discovery::nicknameSettingsKey(info.serial),
+                    m_nicknameEdit->text().trimmed());
+            } else {
+                m_model->sendCommand("radio name " + m_nicknameEdit->text());
+            }
         });
         connect(m_callsignEdit, &QLineEdit::editingFinished, this, [this] {
             m_model->sendCommand("radio callsign " + m_callsignEdit->text());

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -1057,8 +1057,19 @@ QWidget* RadioSetupDialog::buildRadioTab()
                                               m_modelLabel),
                         0, 0);
 
-        m_nicknameEdit = new QLineEdit(m_model->nickname().isEmpty()
-            ? m_model->name() : m_model->nickname());
+        // Initial nickname text. For an HL2 the name lives in AppSettings (keyed
+        // by MAC), not on the radio, so read it back from there — otherwise the
+        // field would show the model default even after the operator set a custom
+        // name. Flex keeps its existing model-sourced behaviour.
+        QString initialNickname = m_model->nickname().isEmpty()
+            ? m_model->name() : m_model->nickname();
+        {
+            const RadioInfo info = m_model->lastRadioInfo();
+            if (info.family.compare(QLatin1String("hl2"), Qt::CaseInsensitive) == 0)
+                initialNickname = hl2::Hl2Discovery::effectiveNickname(
+                    info.serial, info.model.isEmpty() ? m_model->name() : info.model);
+        }
+        m_nicknameEdit = new QLineEdit(initialNickname);
         m_nicknameEdit->setStyleSheet(kEditStyle);
         grid->addWidget(makeInfoField(QStringLiteral("Nickname:"), m_nicknameEdit,
                                       kInfoRightLabelWidth),
@@ -1071,16 +1082,21 @@ QWidget* RadioSetupDialog::buildRadioTab()
 
         connect(m_nicknameEdit, &QLineEdit::editingFinished, this, [this] {
             const RadioInfo info = m_model->lastRadioInfo();
-            if (info.family.compare(QLatin1String("hl2"), Qt::CaseInsensitive) == 0) {
-                // An HL2 has no on-radio name store, so "radio name" is a no-op on
-                // the wire. Persist the operator's nickname client-side, keyed by
-                // the radio's MAC (== serial), so Hl2Discovery shows it in the
-                // picker on the next sweep. (aetherd HL2: custom nickname.)
+            // Only FlexRadio has an on-radio name store ("radio name" command).
+            // Every other family (HL2, the sim demo, any future non-Flex backend)
+            // has no wire to store a name, so the "radio name" command is a silent
+            // no-op there. For those, persist the operator's nickname client-side,
+            // keyed by the radio's stable serial, so discovery shows it in the
+            // picker on the next sweep and RadioSetup reads it back on reopen.
+            const bool isFlex =
+                info.family.isEmpty()   // legacy/default entries are Flex
+                || info.family.compare(QLatin1String("flex"), Qt::CaseInsensitive) == 0;
+            if (isFlex) {
+                m_model->sendCommand("radio name " + m_nicknameEdit->text());
+            } else {
                 AppSettings::instance().setValue(
                     hl2::Hl2Discovery::nicknameSettingsKey(info.serial),
                     m_nicknameEdit->text().trimmed());
-            } else {
-                m_model->sendCommand("radio name " + m_nicknameEdit->text());
             }
         });
         connect(m_callsignEdit, &QLineEdit::editingFinished, this, [this] {


### PR DESCRIPTION
## Summary

User-assignable per-radio **nickname** for radios that have no on-radio name store — first and foremost the Hermes-Lite 2, which otherwise shows identically as "Hermes-Lite 2" in the connection picker no matter how many you own.

FlexRadio keeps its nickname *on the radio* (the `radio name` command, set from Radio Setup). An HL2 has no such store, so this persists the operator's name **client-side, keyed by the radio's stable MAC** (which `Hl2Discovery` already uses as the serial), and reads it back at discovery time so it appears in the device chooser as e.g. "Pat's Hermes".

Requested by @jensenpat in the dev channel.

## What it does

- **Name any non-Flex radio.** Two entry points:
  - **Right-click** a radio in the connection list → **Set Nickname… / Clear Nickname** — no need to connect first.
  - The **Radio Setup → Nickname** field, when connected.
- The name shows in the **connection picker**, the **connected-radio label**, and reads back into **Radio Setup** on reopen.
- **Flex is unchanged** — Flex rows get no right-click menu, and the Radio Setup field still issues `radio name` for a Flex. Only families without an on-radio store (HL2 today; any future non-Flex backend) persist client-side, so there's never two sources of truth.

## How it works

- `Hl2Discovery::nicknameSettingsKey(serial)` + `effectiveNickname(serial, fallback)` — one shared helper pair so discovery, Radio Setup, and the connect-list menu all agree on the key (`Hl2Nickname/<MAC>`) and the "custom-or-fallback" rule.
- `Hl2Discovery` emits `info.nickname = effectiveNickname(serial, "Hermes-Lite 2")`; the nickname is added to the change-detection so a live rename re-emits `radioUpdated` and the label refreshes on the next sweep.
- `RadioSetupDialog` reads the saved name back into the field for non-Flex radios, and on edit persists to `AppSettings` (non-Flex) or sends `radio name` (Flex).
- `ConnectionPanel` gains a context menu on the local-radio list (non-Flex rows only).

## Scope / notes

- Persistence is **per-MAC, global** — the name follows the radio across sessions and reconnects.
- No wire/protocol change; no effect on the Flex path.
- Stacked on `feat/hl2-backend` (this is where the HL2 backend + `RadioInfo.family` live), so it targets that branch rather than `main`.

## Testing

- Built clean on Windows (MSVC, Qt 6.10.3).
- Round-trip verified live: set a nickname → it appears in the picker, the connected-radio label, and reads back into Radio Setup; cleared → reverts to the model name. Both the right-click and Radio Setup entry points exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
