### PR TITLE
fix(rx): make manual squelch level per-slice, not globally shared (#3326)

### DIFF
--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1402,9 +1402,9 @@ void RxApplet::setManualSqlLevelForCurrentSurface(int level)
 
     // Per-slice (#3326): the attached slice keeps its own threshold. The
     // shared m_sqlManualLevel / AppSettings key still get updated too, but
-    // only as the seed a NEWLY created slice starts from — see
-    // RadioModel.cpp's SliceModel construction — not a live cross-slice
-    // value read back here.
+    // only as the seed a NEWLY created slice starts from when the radio's
+    // status carries no squelch_level of its own — see RadioModel.cpp's
+    // SliceModel construction — not a live cross-slice value read back here.
     if (m_slice) {
         m_slice->setManualSquelchLevel(clamped);
     } else {

--- a/src/gui/RxApplet.cpp
+++ b/src/gui/RxApplet.cpp
@@ -1373,7 +1373,12 @@ int RxApplet::sqlManualLevel() const
         return clampManualSqlLevelForCurrentSurface(
             m_slice->receiveSquelchLevel());
     }
-    return clampManualSqlLevelForCurrentSurface(m_sqlManualLevel);
+    // Per-slice (#3326): m_sqlManualLevel is only the fallback for the rare
+    // moment no slice is attached — once attached, each slice keeps its own
+    // remembered manual threshold so switching the active slice doesn't
+    // pull in whichever slice last touched the control.
+    return clampManualSqlLevelForCurrentSurface(
+        m_slice ? m_slice->manualSquelchLevel() : m_sqlManualLevel);
 }
 
 int RxApplet::sqlManualMaximum() const
@@ -1395,7 +1400,16 @@ void RxApplet::setManualSqlLevelForCurrentSurface(int level)
         return;
     }
 
-    m_sqlManualLevel = clamped;
+    // Per-slice (#3326): the attached slice keeps its own threshold. The
+    // shared m_sqlManualLevel / AppSettings key still get updated too, but
+    // only as the seed a NEWLY created slice starts from — see
+    // RadioModel.cpp's SliceModel construction — not a live cross-slice
+    // value read back here.
+    if (m_slice) {
+        m_slice->setManualSquelchLevel(clamped);
+    } else {
+        m_sqlManualLevel = clamped;
+    }
     auto& s = AppSettings::instance();
     s.setValue("LastManualSquelchLevel", QString::number(clamped));
     s.save();

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -66,9 +66,11 @@ public:
     void    cycleSqlModeExternal();
     // Programmatic slider drag from another UI surface.  Branches by mode
     // exactly like the in-applet slider does: Manual writes the current
-    // receive surface; Flex also persists m_sqlManualLevel, while Kiwi keeps
-    // its replacement-source level independent. Auto writes AppSettings
-    // AutoSqlMarginDb and emits autoSqlMarginDbChanged. Off is a no-op.
+    // receive surface; Flex persists the level on the attached SliceModel
+    // (per-slice, #3326) plus AppSettings as the seed for future new
+    // slices, while Kiwi keeps its replacement-source level independent.
+    // Auto writes AppSettings AutoSqlMarginDb and emits
+    // autoSqlMarginDbChanged. Off is a no-op.
     void    setSqlSliderValueExternal(int v);
     void syncStepFromSlice(int stepHz, const QVector<int>& stepList);
     void cycleStepUp();
@@ -272,10 +274,13 @@ private:
     SqlMode      m_sqlMode{SqlMode::Off};
     SqlMode      m_flexSqlMode{SqlMode::Off};
     bool         m_savedSquelchOn{false};
-    // Last user-chosen Manual squelch level (0–100).  Auto mode overwrites
-    // the slice's squelchLevel with algorithm-suggested values every FFT
-    // tick, so we cache the manual value separately and restore it when
-    // the user comes back to Manual.  Seeded from the slice on first attach.
+    // Fallback only, for the rare case no slice is attached (#3326): Auto
+    // mode overwrites the slice's squelchLevel with algorithm-suggested
+    // values every FFT tick, so the manual value needs to be cached
+    // separately to restore when the user comes back to Manual — but that
+    // cache now lives per-slice on SliceModel::manualSquelchLevel(), seeded
+    // from AppSettings when a slice is first created (RadioModel.cpp), so
+    // switching the active slice doesn't pull in another slice's threshold.
     int          m_sqlManualLevel{20};
 
     void applySqlModeVisuals();

--- a/src/gui/RxApplet.h
+++ b/src/gui/RxApplet.h
@@ -279,8 +279,9 @@ private:
     // values every FFT tick, so the manual value needs to be cached
     // separately to restore when the user comes back to Manual — but that
     // cache now lives per-slice on SliceModel::manualSquelchLevel(), seeded
-    // from AppSettings when a slice is first created (RadioModel.cpp), so
-    // switching the active slice doesn't pull in another slice's threshold.
+    // when a slice is first created (RadioModel.cpp) from the radio's own
+    // squelch_level when the status frame carries one, else from AppSettings,
+    // so switching the active slice doesn't pull in another slice's threshold.
     int          m_sqlManualLevel{20};
 
     void applySqlModeVisuals();

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7171,13 +7171,25 @@ void RadioModel::handleSliceStatus(int id,
                                 << "from previous session";
         } else {
             s = new SliceModel(id, this);
-            // Seed the manual-squelch-threshold default from the operator's
-            // last-used value, so a freshly created slice starts where they
-            // left off rather than at the hardcoded default (#3326) — this
-            // is only a starting point, not a live shared value; each
-            // slice's own threshold is independent from here on.
+            // Seed this slice's manual-squelch memory (#3326).  The radio
+            // wins whenever its status frame carries a level: a slice that
+            // already existed when we connected — ours from a prior run, or
+            // one another Multi-Flex client created — arrives with its own
+            // squelch_level, and adopting this client's last-used value
+            // instead would clobber it on the first flip to Manual
+            // (Principle II).  Only when the status is silent do we fall
+            // back to the operator's last-used value so a genuinely new
+            // slice starts where they left off.  Either way this is only a
+            // starting point, not a live shared value; each slice's own
+            // threshold is independent from here on.
+            bool haveRadioLevel = false;
+            const int radioLevel =
+                kvs.value(QStringLiteral("squelch_level")).toInt(&haveRadioLevel);
             s->setManualSquelchLevel(
-                AppSettings::instance().value("LastManualSquelchLevel", "20").toInt());
+                haveRadioLevel
+                    ? radioLevel
+                    : AppSettings::instance()
+                          .value("LastManualSquelchLevel", "20").toInt());
             // Forward slice commands to the radio
             connect(s, &SliceModel::commandReady, this, [this, s](const QString& cmd){
                 sendSliceCommand(s, cmd);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7171,6 +7171,13 @@ void RadioModel::handleSliceStatus(int id,
                                 << "from previous session";
         } else {
             s = new SliceModel(id, this);
+            // Seed the manual-squelch-threshold default from the operator's
+            // last-used value, so a freshly created slice starts where they
+            // left off rather than at the hardcoded default (#3326) — this
+            // is only a starting point, not a live shared value; each
+            // slice's own threshold is independent from here on.
+            s->setManualSquelchLevel(
+                AppSettings::instance().value("LastManualSquelchLevel", "20").toInt());
             // Forward slice commands to the radio
             connect(s, &SliceModel::commandReady, this, [this, s](const QString& cmd){
                 sendSliceCommand(s, cmd);

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -126,6 +126,13 @@ public:
     int     receiveSquelchLevel() const { return m_externalReceiveAudioReplacement
                                               ? m_externalReceiveSquelchLevel
                                               : m_squelchLevel; }
+    // Last manual-mode threshold the operator chose for THIS slice,
+    // independent of squelchLevel() (which Auto mode also overwrites with
+    // its own computed threshold each update). RxApplet restores Manual
+    // mode's slider from this when it reattaches to a slice, so switching
+    // the active slice doesn't pull in another slice's threshold (#3326).
+    int     manualSquelchLevel() const { return m_manualSquelchLevel; }
+    void    setManualSquelchLevel(int level) { m_manualSquelchLevel = qBound(0, level, 100); }
     bool    ritOn()       const { return m_ritOn; }
     int     ritFreq()     const { return m_ritFreq; }
     bool    xitOn()       const { return m_xitOn; }
@@ -452,6 +459,7 @@ private:
     int     m_agcOffLevel{10};
     bool    m_squelchOn{false};
     int     m_squelchLevel{20};
+    int     m_manualSquelchLevel{20};
     int     m_stepHz{100};
     QVector<int> m_stepList;
     bool    m_ritOn{false};


### PR DESCRIPTION
Closes #3326.

## What
`RxApplet::m_sqlManualLevel` was a single shared cache for "the
operator's last manual squelch threshold," used by
`applySqlModeVisuals()` to restore the slider whenever RxApplet
reattaches to a slice in Manual mode. Since it's one value shared by
every slice, switching the active slice pulled in whichever slice
last touched the control — exactly the reported symptom (adjusting
squelch on one slice appears to change the other's).

The live `squelch_level` itself was already correctly per-slice
(`SliceModel::m_squelchLevel`, sent via a slice-scoped command) — the
bug was specifically the *manual-mode memory*, which needs to be
separate from the live level because Auto mode overwrites that same
live level with its own computed threshold every update.

Fix: add `SliceModel::manualSquelchLevel()`/`setManualSquelchLevel()`,
mirroring how Kiwi/external-receive slices already store their own
threshold independently. `RxApplet` reads/writes through the attached
slice instead of its own shared member; `m_sqlManualLevel` is now
only a fallback for the rare case no slice is attached. A newly
created slice still seeds from the last-used `AppSettings` value
(`RadioModel.cpp`), so new slices start where the operator left off
— but that's only a starting point, not a live cross-slice value.

## Test plan
- [x] Built and ran locally against a live FLEX-6600
- [x] Opened two slices on different bands
- [x] Enabled Manual squelch on Slice B, set it to 100 — Slice A
      remained at its own independent default (~20)
- [x] Switched back and forth between the two slices repeatedly —
      each held its own value, no cross-talk in either direction