### PR TITLE
fix(gui): contain panadapter overlay wheel events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4214,6 +4214,7 @@ add_test(NAME pan_layout_dialog_size_test COMMAND pan_layout_dialog_size_test)
 add_executable(spectrum_overlay_wheel_guard_test
     tests/spectrum_overlay_wheel_guard_test.cpp
     src/gui/SpectrumOverlayWheelGuard.cpp
+    src/gui/DragValuePopup.cpp   # GuardedSlider.h (ControlsLock coverage)
 )
 target_include_directories(spectrum_overlay_wheel_guard_test PRIVATE src)
 target_link_libraries(spectrum_overlay_wheel_guard_test PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,6 +770,7 @@ set(GUI_SOURCES
     src/gui/SpectrumWidget.cpp
     src/gui/WaterfallHistoryBuffer.cpp
     src/gui/SpectrumOverlayMenu.cpp
+    src/gui/SpectrumOverlayWheelGuard.cpp
     src/gui/DssRenderer.cpp
     src/gui/FrequencyEntryParser.cpp
     src/gui/SliceColorManager.cpp
@@ -4209,6 +4210,20 @@ target_link_libraries(pan_layout_dialog_size_test PRIVATE
 )
 set_target_properties(pan_layout_dialog_size_test PROPERTIES AUTOMOC ON)
 add_test(NAME pan_layout_dialog_size_test COMMAND pan_layout_dialog_size_test)
+
+add_executable(spectrum_overlay_wheel_guard_test
+    tests/spectrum_overlay_wheel_guard_test.cpp
+    src/gui/SpectrumOverlayWheelGuard.cpp
+)
+target_include_directories(spectrum_overlay_wheel_guard_test PRIVATE src)
+target_link_libraries(spectrum_overlay_wheel_guard_test PRIVATE
+    Qt6::Core Qt6::Widgets Qt6::Test
+)
+set_target_properties(spectrum_overlay_wheel_guard_test PROPERTIES AUTOMOC ON)
+add_test(NAME spectrum_overlay_wheel_guard_test
+         COMMAND spectrum_overlay_wheel_guard_test)
+set_tests_properties(spectrum_overlay_wheel_guard_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
 add_executable(device_diagnostics_test
     tests/device_diagnostics_test.cpp

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2405,8 +2405,9 @@ void SpectrumOverlayMenu::layoutDisplayPanel()
 
     m_displayPanel->resize(panelSize);
     const int menuBottom = y() + height();
-    const int panelY = menuBottom - panelSize.height();
-    m_displayPanel->move(x() + width(), std::max(0, panelY));
+    const int panelY = constrainedDisplayPanelTop(
+        menuBottom, panelSize.height(), hostHeight);
+    m_displayPanel->move(x() + width(), panelY);
 }
 
 void SpectrumOverlayMenu::setWnbState(bool on, int level)

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -352,6 +352,13 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     m_wheelGuard->guardTree(
         m_memoryPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
 
+    // The panel can be opened before the panadapter reaches its restored
+    // height. Re-clamp it whenever that host subsequently resizes so the
+    // QScrollArea retains a real scroll range instead of extending off-screen.
+    if (parentWidget()) {
+        parentWidget()->installEventFilter(this);
+    }
+
     // Mouse presses on panel backgrounds must not fall through to the
     // spectrum. Wheel ownership is handled for every descendant above.
     for (auto* panel : {m_bandPanel, m_antPanel, m_daxPanel, m_displayPanel,
@@ -2372,27 +2379,34 @@ void SpectrumOverlayMenu::toggleDisplayPanel()
     hideAllSubPanels();
     if (!wasVisible) {
         m_displayPanelVisible = true;
-        int menuBottom = y() + height();
-        // Size from the scroll content's hint — QScrollArea::sizeHint() is
-        // font-metric-capped, not content-sized — then clamp to the parent
-        // height so short windows scroll instead of clipping (#3969).
-        const QSize contentHint = m_displayScroll->widget()->sizeHint();
-        int panelW = contentHint.width() + 2;   // panelLayout 1px margins
-        int panelH = contentHint.height() + 2;
-        const QWidget* host = m_displayPanel->parentWidget();
-        const int maxH = host ? host->height() : panelH;
-        if (panelH > maxH) {
-            panelH = maxH;
-            panelW += m_displayPanel->style()->pixelMetric(
-                QStyle::PM_ScrollBarExtent, nullptr, m_displayScroll);
-        }
-        m_displayPanel->resize(panelW, panelH);
-        int panelY = menuBottom - panelH;
-        m_displayPanel->move(x() + width(), std::max(0, panelY));
+        layoutDisplayPanel();
         m_displayPanel->raise();
         m_displayPanel->show();
         m_menuBtns[kBtnDisplay]->setStyleSheet(kMenuBtnActive);
     }
+}
+
+void SpectrumOverlayMenu::layoutDisplayPanel()
+{
+    if (!m_displayPanel || !m_displayScroll || !m_displayScroll->widget()) {
+        return;
+    }
+
+    // Size from the scroll content's hint — QScrollArea::sizeHint() is
+    // font-metric-capped, not content-sized — then clamp to the current parent
+    // height so short or subsequently resized windows scroll instead of clip.
+    const QSize contentHint = m_displayScroll->widget()->sizeHint();
+    const QWidget* host = m_displayPanel->parentWidget();
+    const int hostHeight = host ? host->height() : contentHint.height() + 2;
+    const int scrollBarExtent = m_displayPanel->style()->pixelMetric(
+        QStyle::PM_ScrollBarExtent, nullptr, m_displayScroll);
+    const QSize panelSize = constrainedDisplayPanelSize(
+        contentHint, hostHeight, scrollBarExtent);
+
+    m_displayPanel->resize(panelSize);
+    const int menuBottom = y() + height();
+    const int panelY = menuBottom - panelSize.height();
+    m_displayPanel->move(x() + width(), std::max(0, panelY));
 }
 
 void SpectrumOverlayMenu::setWnbState(bool on, int level)
@@ -2772,6 +2786,11 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
 
 bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
 {
+    if (obj == parentWidget() && event->type() == QEvent::Resize
+        && m_displayPanelVisible) {
+        layoutDisplayPanel();
+    }
+
     if (event->type() == QEvent::MouseButtonDblClick) {
         if (auto* slider = qobject_cast<QSlider*>(obj)) {
             slider->setValue(50);

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -2,6 +2,7 @@
 #include "DspParamPopup.h"
 #include "MemoryBrowsePanel.h"
 #include "SpectrumWidget.h"
+#include "SpectrumOverlayWheelGuard.h"
 #include "GuardedSlider.h"
 #include "ComboStyle.h"
 #include "Theme.h"
@@ -335,7 +336,24 @@ SpectrumOverlayMenu::SpectrumOverlayMenu(QWidget* parent)
     buildDisplayPanel();
     buildMemoryPanel();
 
-    // Prevent mouse/wheel events from falling through panels to the spectrum
+    m_wheelGuard = new SpectrumOverlayWheelGuard(this);
+    m_wheelGuard->setDisplayScrollArea(m_displayScroll);
+    m_wheelGuard->guardTree(
+        this, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    m_wheelGuard->guardTree(
+        m_bandPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    m_wheelGuard->guardTree(
+        m_antPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    m_wheelGuard->guardTree(
+        m_daxPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    m_wheelGuard->guardTree(
+        m_displayPanel,
+        SpectrumOverlayWheelGuard::BoundaryMode::ScrollDisplay);
+    m_wheelGuard->guardTree(
+        m_memoryPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+
+    // Mouse presses on panel backgrounds must not fall through to the
+    // spectrum. Wheel ownership is handled for every descendant above.
     for (auto* panel : {m_bandPanel, m_antPanel, m_daxPanel, m_displayPanel,
                         static_cast<QWidget*>(m_memoryPanel)})
         if (panel) panel->installEventFilter(this);
@@ -2744,6 +2762,12 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     xvGrid->addWidget(hfBtn, slot / XVTR_COLS, slot % XVTR_COLS);
 
     m_xvtrPanel->adjustSize();
+    if (m_wheelGuard) {
+        m_wheelGuard->guardTree(
+            m_bandPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+        m_wheelGuard->guardTree(
+            m_xvtrPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    }
 }
 
 bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
@@ -2754,19 +2778,15 @@ bool SpectrumOverlayMenu::eventFilter(QObject* obj, QEvent* event)
             return true;
         }
     }
-    // Consume mouse/wheel events on sub-panels so they don't reach the spectrum
+    // Consume panel-background mouse events so they don't reach the spectrum.
+    // SpectrumOverlayWheelGuard owns wheel routing for panels and descendants.
     if (obj == m_bandPanel || obj == m_antPanel
         || obj == m_daxPanel || obj == m_displayPanel || obj == m_memoryPanel) {
-        if (event->type() == QEvent::Wheel
-            || event->type() == QEvent::MouseButtonPress
+        if (event->type() == QEvent::MouseButtonPress
             || event->type() == QEvent::MouseButtonRelease) {
             if (auto* panel = qobject_cast<QWidget*>(obj)) {
                 if (auto* mouseEvent = dynamic_cast<QMouseEvent*>(event);
                     mouseEvent && panel->childAt(mouseEvent->pos())) {
-                    return QWidget::eventFilter(obj, event);
-                }
-                if (auto* wheelEvent = dynamic_cast<QWheelEvent*>(event);
-                    wheelEvent && panel->childAt(wheelEvent->position().toPoint())) {
                     return QWidget::eventFilter(obj, event);
                 }
             }

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -24,6 +24,7 @@ namespace AetherSDR {
 class MemoryBrowsePanel;
 class KiwiSdrManager;
 class SliceModel;
+class SpectrumOverlayWheelGuard;
 
 // Floating overlay menu anchored to the top-left of the SpectrumWidget.
 // Open by default; collapses to a single arrow button when closed.
@@ -206,6 +207,7 @@ private:
     QPointer<PanadapterModel> m_panadapter;
     QMetaObject::Connection m_panRxAntennaConnection;
     QMetaObject::Connection m_panLoopConnection;
+    SpectrumOverlayWheelGuard* m_wheelGuard{nullptr};
     void setKiwiWaterfallControlMode(bool kiwiMode);
     void toggle();
     void updateLayout();

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -219,6 +219,7 @@ private:
     void buildDaxPanel();
     void syncDaxPanel();
     void toggleDisplayPanel();
+    void layoutDisplayPanel();
     void buildDisplayPanel();
     void toggleMemoryPanel();
     void buildMemoryPanel();

--- a/src/gui/SpectrumOverlayWheelGuard.cpp
+++ b/src/gui/SpectrumOverlayWheelGuard.cpp
@@ -1,0 +1,142 @@
+#include "SpectrumOverlayWheelGuard.h"
+
+#include <QAbstractItemView>
+#include <QAbstractSlider>
+#include <QAbstractSpinBox>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QEvent>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QVariant>
+#include <QWheelEvent>
+#include <QWidget>
+
+namespace AetherSDR {
+
+namespace {
+
+constexpr const char* kBoundaryModeProperty =
+    "_aetherSpectrumOverlayWheelBoundaryMode";
+
+} // namespace
+
+SpectrumOverlayWheelGuard::SpectrumOverlayWheelGuard(QObject* parent)
+    : QObject(parent)
+{
+}
+
+void SpectrumOverlayWheelGuard::setDisplayScrollArea(QScrollArea* scrollArea)
+{
+    m_displayScrollArea = scrollArea;
+}
+
+void SpectrumOverlayWheelGuard::guardTree(QWidget* root, BoundaryMode mode)
+{
+    if (!root) {
+        return;
+    }
+
+    const int modeValue = static_cast<int>(mode);
+    root->setProperty(kBoundaryModeProperty, modeValue);
+    root->installEventFilter(this);
+
+    const QList<QWidget*> descendants = root->findChildren<QWidget*>();
+    for (QWidget* descendant : descendants) {
+        descendant->setProperty(kBoundaryModeProperty, modeValue);
+        descendant->installEventFilter(this);
+    }
+}
+
+bool SpectrumOverlayWheelGuard::eventFilter(QObject* watched, QEvent* event)
+{
+    if (event->type() != QEvent::Wheel) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    QWidget* widget = qobject_cast<QWidget*>(watched);
+    QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+    if (!widget || !widget->property(kBoundaryModeProperty).isValid()) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    // A forwarded Display event may be ignored at a scroll limit. Consume its
+    // overlay-parent propagation instead of recursively forwarding it or
+    // allowing it to reach SpectrumWidget.
+    if (m_forwardingDisplayWheel) {
+        if (widget == m_displayScrollArea
+            || qobject_cast<QAbstractSlider*>(widget)
+            || isScrollAreaViewport(widget)) {
+            return QObject::eventFilter(watched, event);
+        }
+        wheelEvent->accept();
+        return true;
+    }
+
+    if (intentionallyOwnsWheel(widget)) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    const BoundaryMode mode = static_cast<BoundaryMode>(
+        widget->property(kBoundaryModeProperty).toInt());
+    if (mode == BoundaryMode::ScrollDisplay) {
+        routeToDisplayScroll(wheelEvent);
+    } else {
+        wheelEvent->accept();
+    }
+    return true;
+}
+
+bool SpectrumOverlayWheelGuard::intentionallyOwnsWheel(QWidget* widget) const
+{
+    if (qobject_cast<QAbstractSlider*>(widget)
+        || qobject_cast<QAbstractSpinBox*>(widget)
+        || qobject_cast<QAbstractItemView*>(widget)
+        || isScrollAreaViewport(widget)) {
+        return true;
+    }
+
+    if (QComboBox* combo = qobject_cast<QComboBox*>(widget)) {
+        return combo->view() && combo->view()->isVisible();
+    }
+
+    return false;
+}
+
+bool SpectrumOverlayWheelGuard::isScrollAreaViewport(QWidget* widget) const
+{
+    QWidget* parent = widget ? widget->parentWidget() : nullptr;
+    const QAbstractScrollArea* scrollArea =
+        qobject_cast<QAbstractScrollArea*>(parent);
+    return scrollArea && scrollArea->viewport() == widget;
+}
+
+void SpectrumOverlayWheelGuard::routeToDisplayScroll(QWheelEvent* wheelEvent)
+{
+    if (!m_displayScrollArea || !m_displayScrollArea->viewport()) {
+        wheelEvent->accept();
+        return;
+    }
+
+    QWidget* scrollArea = m_displayScrollArea->verticalScrollBar();
+    const QPointF scrollPosition =
+        scrollArea->mapFromGlobal(wheelEvent->globalPosition().toPoint());
+    QWheelEvent forwardedEvent(
+        scrollPosition,
+        wheelEvent->globalPosition(),
+        wheelEvent->pixelDelta(),
+        wheelEvent->angleDelta(),
+        wheelEvent->buttons(),
+        wheelEvent->modifiers(),
+        wheelEvent->phase(),
+        wheelEvent->inverted(),
+        wheelEvent->source(),
+        wheelEvent->pointingDevice());
+
+    m_forwardingDisplayWheel = true;
+    QCoreApplication::sendEvent(scrollArea, &forwardedEvent);
+    m_forwardingDisplayWheel = false;
+    wheelEvent->accept();
+}
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumOverlayWheelGuard.cpp
+++ b/src/gui/SpectrumOverlayWheelGuard.cpp
@@ -1,5 +1,9 @@
 #include "SpectrumOverlayWheelGuard.h"
 
+#include "GuardedSlider.h"   // ControlsLock
+
+#include <algorithm>
+
 #include <QAbstractItemView>
 #include <QAbstractSlider>
 #include <QAbstractSpinBox>
@@ -30,6 +34,14 @@ QSize constrainedDisplayPanelSize(const QSize& contentHint, int hostHeight,
         panelSize.rwidth() += scrollBarExtent;
     }
     return panelSize;
+}
+
+int constrainedDisplayPanelTop(int menuBottom, int panelHeight, int hostHeight)
+{
+    // Never push the bottom edge past the host: a child is clipped by its
+    // parent, so any overhang is dead space the scroll area cannot reveal.
+    const int lowestTop = std::max(0, hostHeight - panelHeight);
+    return std::clamp(menuBottom - panelHeight, 0, lowestTop);
 }
 
 SpectrumOverlayWheelGuard::SpectrumOverlayWheelGuard(QObject* parent)
@@ -100,15 +112,28 @@ bool SpectrumOverlayWheelGuard::eventFilter(QObject* watched, QEvent* event)
 
 bool SpectrumOverlayWheelGuard::intentionallyOwnsWheel(QWidget* widget) const
 {
-    if (qobject_cast<QAbstractSlider*>(widget)
-        || qobject_cast<QAbstractSpinBox*>(widget)
-        || qobject_cast<QAbstractItemView*>(widget)
-        || isScrollAreaViewport(widget)) {
+    // Navigation controls always keep the wheel — a list is scrolled by it,
+    // never valued by it, so the controls lock has nothing to protect there.
+    if (qobject_cast<QAbstractItemView*>(widget) || isScrollAreaViewport(widget)) {
         return true;
     }
 
+    // Value controls yield the wheel while the global controls lock is on
+    // (#745): sliders span most of every Display row, so without this the pane's
+    // scroll affordance is unreachable over the majority of its surface and a
+    // user wheeling to scroll silently retunes Averaging/FPS/Opacity instead.
+    // GuardedSlider/GuardedCombo already ignore the wheel when locked, but that
+    // only reaches the scroll area via Qt's parent propagation for spontaneous
+    // events; deciding it here makes the routing explicit and deterministic at
+    // the boundary this guard owns.
+    if (qobject_cast<QAbstractSlider*>(widget)
+        || qobject_cast<QAbstractSpinBox*>(widget)) {
+        return !ControlsLock::isLocked();
+    }
+
     if (QComboBox* combo = qobject_cast<QComboBox*>(widget)) {
-        return combo->view() && combo->view()->isVisible();
+        return !ControlsLock::isLocked() && combo->view()
+            && combo->view()->isVisible();
     }
 
     return false;

--- a/src/gui/SpectrumOverlayWheelGuard.cpp
+++ b/src/gui/SpectrumOverlayWheelGuard.cpp
@@ -21,6 +21,17 @@ constexpr const char* kBoundaryModeProperty =
 
 } // namespace
 
+QSize constrainedDisplayPanelSize(const QSize& contentHint, int hostHeight,
+                                  int scrollBarExtent)
+{
+    QSize panelSize(contentHint.width() + 2, contentHint.height() + 2);
+    if (panelSize.height() > hostHeight) {
+        panelSize.setHeight(hostHeight);
+        panelSize.rwidth() += scrollBarExtent;
+    }
+    return panelSize;
+}
+
 SpectrumOverlayWheelGuard::SpectrumOverlayWheelGuard(QObject* parent)
     : QObject(parent)
 {

--- a/src/gui/SpectrumOverlayWheelGuard.cpp
+++ b/src/gui/SpectrumOverlayWheelGuard.cpp
@@ -154,9 +154,11 @@ void SpectrumOverlayWheelGuard::routeToDisplayScroll(QWheelEvent* wheelEvent)
         return;
     }
 
-    QWidget* scrollArea = m_displayScrollArea->verticalScrollBar();
+    // Forward to the scroll BAR rather than the viewport: it applies the wheel
+    // directly without re-entering the viewport's own wheel handling.
+    QWidget* scrollBar = m_displayScrollArea->verticalScrollBar();
     const QPointF scrollPosition =
-        scrollArea->mapFromGlobal(wheelEvent->globalPosition().toPoint());
+        scrollBar->mapFromGlobal(wheelEvent->globalPosition().toPoint());
     QWheelEvent forwardedEvent(
         scrollPosition,
         wheelEvent->globalPosition(),
@@ -170,7 +172,7 @@ void SpectrumOverlayWheelGuard::routeToDisplayScroll(QWheelEvent* wheelEvent)
         wheelEvent->pointingDevice());
 
     m_forwardingDisplayWheel = true;
-    QCoreApplication::sendEvent(scrollArea, &forwardedEvent);
+    QCoreApplication::sendEvent(scrollBar, &forwardedEvent);
     m_forwardingDisplayWheel = false;
     wheelEvent->accept();
 }

--- a/src/gui/SpectrumOverlayWheelGuard.h
+++ b/src/gui/SpectrumOverlayWheelGuard.h
@@ -14,6 +14,14 @@ namespace AetherSDR {
 QSize constrainedDisplayPanelSize(const QSize& contentHint, int hostHeight,
                                   int scrollBarExtent);
 
+// Top edge for the Display pane: bottom-anchored to the overlay menu, then
+// clamped so the whole panel stays inside the host. Anchoring alone is not
+// enough — when the panadapter is shorter than the menu, menuBottom exceeds
+// hostHeight and the pane's tail lands below the host's bottom edge, where the
+// parent clips it and no scroll offset can reach it (the height clamp in
+// constrainedDisplayPanelSize does not move the panel back up).
+int constrainedDisplayPanelTop(int menuBottom, int panelHeight, int hostHeight);
+
 // Owns wheel routing at the boundary between SpectrumOverlayMenu's floating
 // widgets and the SpectrumWidget beneath them. Interactive controls that
 // deliberately handle wheel input keep it; everything else is either routed

--- a/src/gui/SpectrumOverlayWheelGuard.h
+++ b/src/gui/SpectrumOverlayWheelGuard.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+
+class QEvent;
+class QScrollArea;
+class QWheelEvent;
+class QWidget;
+
+namespace AetherSDR {
+
+// Owns wheel routing at the boundary between SpectrumOverlayMenu's floating
+// widgets and the SpectrumWidget beneath them. Interactive controls that
+// deliberately handle wheel input keep it; everything else is either routed
+// to the Display panel's scroll area or consumed before it can tune a slice.
+class SpectrumOverlayWheelGuard final : public QObject {
+public:
+    enum class BoundaryMode {
+        Consume,
+        ScrollDisplay
+    };
+
+    explicit SpectrumOverlayWheelGuard(QObject* parent = nullptr);
+
+    void setDisplayScrollArea(QScrollArea* scrollArea);
+    void guardTree(QWidget* root, BoundaryMode mode);
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    bool intentionallyOwnsWheel(QWidget* widget) const;
+    bool isScrollAreaViewport(QWidget* widget) const;
+    void routeToDisplayScroll(QWheelEvent* wheelEvent);
+
+    QPointer<QScrollArea> m_displayScrollArea;
+    bool m_forwardingDisplayWheel{false};
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumOverlayWheelGuard.h
+++ b/src/gui/SpectrumOverlayWheelGuard.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QPointer>
+#include <QSize>
 
 class QEvent;
 class QScrollArea;
@@ -9,6 +10,9 @@ class QWheelEvent;
 class QWidget;
 
 namespace AetherSDR {
+
+QSize constrainedDisplayPanelSize(const QSize& contentHint, int hostHeight,
+                                  int scrollBarExtent);
 
 // Owns wheel routing at the boundary between SpectrumOverlayMenu's floating
 // widgets and the SpectrumWidget beneath them. Interactive controls that

--- a/tests/spectrum_overlay_wheel_guard_test.cpp
+++ b/tests/spectrum_overlay_wheel_guard_test.cpp
@@ -1,0 +1,225 @@
+#include "gui/SpectrumOverlayWheelGuard.h"
+
+#include <QApplication>
+#include <QAbstractItemView>
+#include <QComboBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QSlider>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+class SpectrumProbe final : public QWidget {
+public:
+    using QWidget::QWidget;
+
+    int wheelCount{0};
+
+protected:
+    void wheelEvent(QWheelEvent* event) override
+    {
+        ++wheelCount;
+        event->accept();
+    }
+};
+
+void sendWheel(QWidget* target, int angleDeltaY = -120)
+{
+    const QPointF localPosition = target->rect().center();
+    const QPointF globalPosition =
+        target->mapToGlobal(localPosition.toPoint());
+    QWheelEvent event(
+        localPosition,
+        globalPosition,
+        QPoint(),
+        QPoint(0, angleDeltaY),
+        Qt::NoButton,
+        Qt::NoModifier,
+        Qt::NoScrollPhase,
+        false);
+    QApplication::sendEvent(target, &event);
+}
+
+void testDisplayRouting()
+{
+    SpectrumProbe spectrum;
+    spectrum.resize(500, 300);
+
+    QWidget displayPanel(&spectrum);
+    displayPanel.resize(180, 180);
+    auto* panelLayout = new QVBoxLayout(&displayPanel);
+    QScrollArea scroll;
+    scroll.setWidgetResizable(true);
+    scroll.setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    QWidget content;
+    content.setMinimumHeight(700);
+    auto* contentLayout = new QVBoxLayout(&content);
+    QLabel label(QStringLiteral("Display label"), &content);
+    QComboBox combo(&content);
+    for (int index = 0; index < 30; ++index) {
+        combo.addItem(QStringLiteral("Choice %1").arg(index));
+    }
+    combo.setMaxVisibleItems(5);
+    combo.setStyleSheet(QStringLiteral("QComboBox { combobox-popup: 0; }"));
+    combo.view()->setFixedHeight(70);
+    QSlider slider(Qt::Horizontal, &content);
+    slider.setRange(0, 10);
+    slider.setValue(5);
+    contentLayout->addWidget(&label);
+    contentLayout->addWidget(&combo);
+    contentLayout->addWidget(&slider);
+    contentLayout->addStretch();
+    scroll.setWidget(&content);
+    panelLayout->addWidget(&scroll);
+
+    SpectrumOverlayWheelGuard guard;
+    guard.setDisplayScrollArea(&scroll);
+    guard.guardTree(
+        &displayPanel,
+        SpectrumOverlayWheelGuard::BoundaryMode::ScrollDisplay);
+
+    spectrum.show();
+    displayPanel.show();
+    QApplication::processEvents();
+
+    scroll.verticalScrollBar()->setValue(0);
+    sendWheel(&label);
+    report("Display label wheel scrolls the vertical panel",
+           scroll.verticalScrollBar()->value() > 0);
+    report("Display label wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+
+    scroll.verticalScrollBar()->setValue(0);
+    combo.setCurrentIndex(1);
+    sendWheel(&combo);
+    report("closed Display combo does not change selection",
+           combo.currentIndex() == 1);
+    report("closed Display combo wheel scrolls the vertical panel",
+           scroll.verticalScrollBar()->value() > 0);
+    report("closed Display combo wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+
+    scroll.verticalScrollBar()->setValue(0);
+    combo.showPopup();
+    QApplication::processEvents();
+    QAbstractItemView* comboView = combo.view();
+    comboView->verticalScrollBar()->setValue(0);
+    sendWheel(comboView->viewport());
+    report("open Display combo scrolls its popup list",
+           comboView->verticalScrollBar()->value() > 0);
+    report("open Display combo does not scroll the panel behind it",
+           scroll.verticalScrollBar()->value() == 0);
+    report("open Display combo wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+    combo.hidePopup();
+
+    const int sliderBefore = slider.value();
+    sendWheel(&slider, 120);
+    report("Display slider retains deliberate wheel behavior",
+           slider.value() != sliderBefore);
+    report("Display slider wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+
+    scroll.verticalScrollBar()->setValue(
+        scroll.verticalScrollBar()->maximum());
+    sendWheel(&label);
+    report("Display wheel at scroll limit is still contained",
+           spectrum.wheelCount == 0);
+}
+
+void testNonScrollableBoundaries()
+{
+    SpectrumProbe spectrum;
+    spectrum.resize(500, 300);
+
+    QWidget panel(&spectrum);
+    auto* layout = new QVBoxLayout(&panel);
+    QLabel label(QStringLiteral("ordinary panel content"), &panel);
+    QComboBox combo(&panel);
+    combo.addItems({QStringLiteral("One"), QStringLiteral("Two")});
+    layout->addWidget(&label);
+    layout->addWidget(&combo);
+
+    QWidget mainStrip(&spectrum);
+    QPushButton stripButton(QStringLiteral("Display"), &mainStrip);
+
+    QWidget memoryPanel(&spectrum);
+    auto* memoryLayout = new QVBoxLayout(&memoryPanel);
+    QTableWidget memoryTable(30, 1, &memoryPanel);
+    memoryLayout->addWidget(&memoryTable);
+
+    SpectrumOverlayWheelGuard guard;
+    guard.guardTree(
+        &panel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    guard.guardTree(
+        &mainStrip, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    guard.guardTree(
+        &memoryPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+
+    spectrum.show();
+    panel.show();
+    mainStrip.show();
+    memoryPanel.show();
+    QApplication::processEvents();
+
+    sendWheel(&label);
+    report("non-scrollable panel content consumes wheel input",
+           spectrum.wheelCount == 0);
+
+    combo.setCurrentIndex(0);
+    sendWheel(&combo);
+    report("closed combo in non-scrollable panel stays unchanged",
+           combo.currentIndex() == 0);
+    report("closed combo in non-scrollable panel cannot tune",
+           spectrum.wheelCount == 0);
+
+    sendWheel(&stripButton);
+    report("main overlay strip child cannot leak wheel input",
+           spectrum.wheelCount == 0);
+
+    memoryTable.verticalScrollBar()->setValue(0);
+    sendWheel(memoryTable.viewport());
+    report("Memory table retains deliberate list scrolling",
+           memoryTable.verticalScrollBar()->value() > 0);
+    report("Memory table wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+    QApplication app(argc, argv);
+
+    std::printf("Spectrum overlay wheel ownership test harness\n\n");
+    testDisplayRouting();
+    testNonScrollableBoundaries();
+
+    std::printf("\n%s\n",
+                g_failed == 0
+                    ? "All tests passed."
+                    : "Failures present.");
+    return g_failed == 0 ? 0 : 1;
+}

--- a/tests/spectrum_overlay_wheel_guard_test.cpp
+++ b/tests/spectrum_overlay_wheel_guard_test.cpp
@@ -1,10 +1,12 @@
 #include "gui/SpectrumOverlayWheelGuard.h"
+#include "gui/GuardedSlider.h"
 
 #include <QApplication>
 #include <QAbstractItemView>
 #include <QComboBox>
 #include <QLabel>
 #include <QPushButton>
+#include <QRect>
 #include <QScrollArea>
 #include <QScrollBar>
 #include <QSlider>
@@ -164,6 +166,135 @@ void testDisplayPanelResizeClamp()
            contentHint.height() > resized.height() - 2);
 }
 
+// Mirrors SpectrumOverlayMenu::layoutDisplayPanel()'s composition of the two
+// pure helpers, so the geometry the widget actually receives is under test —
+// not just the size half of it.
+QRect displayPanelGeometry(const QSize& contentHint, int hostHeight,
+                           int scrollBarExtent, int menuBottom, int menuRight)
+{
+    const QSize panelSize = constrainedDisplayPanelSize(
+        contentHint, hostHeight, scrollBarExtent);
+    const int panelTop = constrainedDisplayPanelTop(
+        menuBottom, panelSize.height(), hostHeight);
+    return QRect(QPoint(menuRight, panelTop), panelSize);
+}
+
+void testDisplayPanelStaysInsideHost()
+{
+    const QSize contentHint(306, 594);
+    constexpr int scrollBarExtent = 14;
+    constexpr int menuRight = 40;
+    // The regression: a panadapter shorter than the overlay menu. Clamping the
+    // HEIGHT to the host is not enough — bottom-anchoring to the menu then
+    // pushes the pane's tail below the host, where the parent clips it and no
+    // scroll offset can reach it (#3969 follow-up).
+    constexpr int shortHost = 150;
+    constexpr int menuBottom = 194;
+
+    const QRect clipped = displayPanelGeometry(
+        contentHint, shortHost, scrollBarExtent, menuBottom, menuRight);
+    report("Display pane bottom stays inside a short host",
+           clipped.bottom() < shortHost);
+    report("Display pane top stays inside a short host",
+           clipped.top() >= 0);
+    report("short host still yields a full-height scrollable pane",
+           clipped.height() == shortHost);
+
+    // A pane short enough to sit entirely above menuBottom keeps its natural
+    // bottom-anchored placement — the clamp must not disturb the common case.
+    constexpr int tallHost = 700;
+    const QSize shortContent(306, 100);
+    const QRect anchored = displayPanelGeometry(
+        shortContent, tallHost, scrollBarExtent, menuBottom, menuRight);
+    report("Display pane stays bottom-anchored to the menu when it fits",
+           anchored.top() + anchored.height() == menuBottom);
+    report("Display pane bottom stays inside a tall host",
+           anchored.bottom() < tallHost);
+
+    // A pane taller than the menu's bottom edge is flush to the top rather
+    // than pushed off-screen (the pre-existing max(0, ...) behaviour).
+    const QRect topFlush = displayPanelGeometry(
+        contentHint, tallHost, scrollBarExtent, menuBottom, menuRight);
+    report("over-tall Display pane sits flush with the host top",
+           topFlush.top() == 0);
+
+    // Sweep: containment must hold for every host height, not just the two
+    // hand-picked cases above.
+    bool containedEverywhere = true;
+    for (int hostHeight = 20; hostHeight <= 900; ++hostHeight) {
+        const QRect geometry = displayPanelGeometry(
+            contentHint, hostHeight, scrollBarExtent, menuBottom, menuRight);
+        if (geometry.top() < 0 || geometry.bottom() >= hostHeight) {
+            containedEverywhere = false;
+            break;
+        }
+    }
+    report("Display pane is contained for every host height", containedEverywhere);
+}
+
+// Finding 3: sliders span most of each Display row, so wheeling to scroll would
+// otherwise change Averaging/FPS/Opacity. The project's existing global controls
+// lock (#745) is the opt-in that frees the wheel for scrolling; verify it
+// composes with the guard — the slider's ignored wheel must reach the guarded
+// content widget and be routed to the scroll area, never to the spectrum.
+void testControlsLockFreesDisplayScrolling()
+{
+    SpectrumProbe spectrum;
+    spectrum.resize(500, 300);
+
+    QWidget displayPanel(&spectrum);
+    displayPanel.resize(180, 180);
+    auto* panelLayout = new QVBoxLayout(&displayPanel);
+    QScrollArea scroll;
+    scroll.setWidgetResizable(true);
+    scroll.setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    QWidget content;
+    content.setMinimumHeight(700);
+    auto* contentLayout = new QVBoxLayout(&content);
+    auto* slider = new GuardedSlider(Qt::Horizontal, &content);
+    slider->setRange(0, 100);
+    slider->setValue(50);
+    contentLayout->addWidget(slider);
+    contentLayout->addStretch();
+    scroll.setWidget(&content);
+    panelLayout->addWidget(&scroll);
+
+    SpectrumOverlayWheelGuard guard;
+    guard.setDisplayScrollArea(&scroll);
+    guard.guardTree(
+        &displayPanel,
+        SpectrumOverlayWheelGuard::BoundaryMode::ScrollDisplay);
+
+    spectrum.show();
+    displayPanel.show();
+    QApplication::processEvents();
+
+    // Unlocked: the slider deliberately owns the wheel (#570/#1026).
+    ControlsLock::setLocked(false);
+    scroll.verticalScrollBar()->setValue(0);
+    const int valueBefore = slider->value();
+    sendWheel(slider, 120);
+    report("unlocked Display slider still adjusts on wheel",
+           slider->value() != valueBefore);
+    report("unlocked Display slider does not scroll the pane",
+           scroll.verticalScrollBar()->value() == 0);
+    report("unlocked Display slider wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+
+    // Locked: the wheel scrolls the pane instead, over the sliders too.
+    ControlsLock::setLocked(true);
+    scroll.verticalScrollBar()->setValue(0);
+    const int lockedValueBefore = slider->value();
+    sendWheel(slider);
+    report("locked Display slider does not change value",
+           slider->value() == lockedValueBefore);
+    report("locked Display slider wheel scrolls the pane",
+           scroll.verticalScrollBar()->value() > 0);
+    report("locked Display slider wheel does not reach SpectrumWidget",
+           spectrum.wheelCount == 0);
+    ControlsLock::setLocked(false);
+}
+
 void testNonScrollableBoundaries()
 {
     SpectrumProbe spectrum;
@@ -234,6 +365,8 @@ int main(int argc, char** argv)
     std::printf("Spectrum overlay wheel ownership test harness\n\n");
     testDisplayRouting();
     testDisplayPanelResizeClamp();
+    testDisplayPanelStaysInsideHost();
+    testControlsLockFreesDisplayScrolling();
     testNonScrollableBoundaries();
 
     std::printf("\n%s\n",

--- a/tests/spectrum_overlay_wheel_guard_test.cpp
+++ b/tests/spectrum_overlay_wheel_guard_test.cpp
@@ -146,6 +146,24 @@ void testDisplayRouting()
            spectrum.wheelCount == 0);
 }
 
+void testDisplayPanelResizeClamp()
+{
+    const QSize contentHint(306, 594);
+    constexpr int scrollBarExtent = 14;
+
+    const QSize initialSize = constrainedDisplayPanelSize(
+        contentHint, 700, scrollBarExtent);
+    report("Display panel uses its content height when the host is tall",
+           initialSize == QSize(308, 596));
+
+    const QSize resized = constrainedDisplayPanelSize(
+        contentHint, 505, scrollBarExtent);
+    report("Display panel re-clamps after its host shrinks",
+           resized == QSize(322, 505));
+    report("re-clamped Display panel leaves scrollable overflow",
+           contentHint.height() > resized.height() - 2);
+}
+
 void testNonScrollableBoundaries()
 {
     SpectrumProbe spectrum;
@@ -215,6 +233,7 @@ int main(int argc, char** argv)
 
     std::printf("Spectrum overlay wheel ownership test harness\n\n");
     testDisplayRouting();
+    testDisplayPanelResizeClamp();
     testNonScrollableBoundaries();
 
     std::printf("\n%s\n",


### PR DESCRIPTION
## Summary

Prevent wheel and two-finger scroll events inside the panadapter overlay from propagating to the spectrum and tuning the active slice. A shared `SpectrumOverlayWheelGuard` now routes ordinary Display panel content and closed dropdowns to the panel's vertical scroll area, preserves deliberate wheel handling for sliders, open dropdown lists, tables, and other scrollable controls, and consumes otherwise-unhandled wheel input across Band/XVTR, ANT, DAX, Memory, and the main overlay strip.

The Display pane also re-clamps to the panadapter whenever its host resizes. This preserves a real scrollbar range when a pane that originally fit later becomes taller than the available spectrum area, instead of leaving the pane extended off-screen with a zero-range scrollbar. When all Display controls fit, no visible scrolling is expected, but wheel input remains contained by the overlay.

The regression came from the overlay panel event filter delegating wheel events whenever `childAt()` found a child. If that child ignored the event, Qt continued propagation to `SpectrumWidget`. The later Display `QScrollArea` made the leak particularly visible, while closed `QComboBox` controls continued to own the wheel and change selection.

Reproduction:

1. Open the Display pane.
2. Scroll over ordinary panel content or a closed dropdown.
3. Before this change, the event could tune the slice or change the closed dropdown.
4. After this change, the Display pane scrolls when its content overflows; the dropdown and slice frequency remain unchanged even when all content already fits.

Focused regression coverage verifies Display routing, closed and open dropdown ownership, deliberate slider and table scrolling, scroll-limit containment, re-clamping after the host shrinks, non-scrollable panels, the Memory table, the main overlay strip, and no pass-through to a spectrum probe.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The event-routing boundary has focused regression coverage and was exercised through the automation bridge against the working-tree patch on macOS, Debian, and Windows. The resize follow-up was additionally reproduced and verified live on macOS by shrinking an open Display pane from a fully fitting layout to an overflowing one.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Additional verification:

- macOS:
  - Native application build passed.
  - Full test suite passed: 164 passed, one intentional skip, zero failures.
  - Display background and closed-dropdown wheel events moved the scrollbar from 0 to 60.
  - The closed dropdown remained `Auto`; the slice remained at 14.1 MHz.
  - With all controls visible, the Display pane correctly had no scroll range.
  - After shrinking the open window, the pane re-clamped from 596 px to the 471 px spectrum height and exposed a 0–125 scroll range; `Reset to Defaults` remained reachable below the System heading.
- Debian VMware:
  - Native application build and focused regression test passed.
  - Display background and closed-dropdown wheel events moved the scrollbar from 0 to 60.
  - The closed dropdown remained `Auto`; the slice remained at 14.096 MHz.
- Windows VMware:
  - Native MSVC/Qt application build and focused regression test passed.
  - Display background and closed-dropdown wheel events moved the scrollbar from 0 to 60.
  - The closed dropdown remained `Auto`; the slice remained at 14.1 MHz.
- On all three platforms, wheel input over the Band button did not tune the slice.
- Transmit automation remained disabled and the radio reported no active transmission throughout runtime verification.
- `git diff --check`, the accessibility scan, and the strict engine-boundary check passed with no blocking findings.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — no meter UI changed
- [x] Documentation updated if user-visible behavior changed — no documentation change was necessary for this bug fix
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
