### PR TITLE
chore(codeowners): move THIRD_PARTY_LICENSES from Tier 1 (maintainers) to Tier 2 (infrastructure)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,16 +15,16 @@
 #         CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, ROADMAP), security
 #         controls (SECURITY*, signing keys, CODEOWNERS itself, CodeQL
 #         config, and the security-sensitive workflows — release
-#         signing/publish + the CodeQL scan invocation), legal/compliance
-#         (THIRD_PARTY_LICENSES), and bot/agent instruction (AGENTS.md,
-#         CLAUDE.md, GEMINI.md, .claude/commands/).
+#         signing/publish + the CodeQL scan invocation), and bot/agent
+#         instruction (AGENTS.md, CLAUDE.md, GEMINI.md, .claude/commands/).
 # Tier 2 — @aethersdr/infrastructure (currently: @ten9876, @jensenpat).
 #         Project infrastructure: CI/CD configuration — the ROUTINE
 #         workflow definitions (.github/workflows/ except the sensitive
 #         ones carved to Tier 1), dependabot, docker, issue templates —
 #         plus documentation (docs/, *.md catchall, including
 #         README/CHANGELOG/SUPPORT which fall through here from the *.md
-#         glob), tests, and build configuration (CMakeLists.txt).
+#         glob), tests, build configuration (CMakeLists.txt), and
+#         legal/compliance tracking (THIRD_PARTY_LICENSES).
 #         Narrower owner set than Tier 3 because infrastructure changes
 #         need deeper repo context than routine source review.
 # Tier 3 — @aethersdr/reviewers (currently: @ten9876, @jensenpat, @NF0T, @rfoust, @chibondking).
@@ -82,6 +82,7 @@ docs/                        @aethersdr/infrastructure
 
 # Build configuration
 CMakeLists.txt               @aethersdr/infrastructure
+THIRD_PARTY_LICENSES         @aethersdr/infrastructure
 
 # ── Tier 1: governance, security, bot policy — maintainer-only ────────────
 # Project governance & direction
@@ -98,7 +99,6 @@ ROADMAP.md                   @aethersdr/maintainers
 # Security & compliance
 SECURITY.md                  @aethersdr/maintainers
 SECURITY-AUDIT.md            @aethersdr/maintainers
-THIRD_PARTY_LICENSES         @aethersdr/maintainers
 .github/CODEOWNERS           @aethersdr/maintainers
 .github/codeql/              @aethersdr/maintainers
 docs/RELEASE-SIGNING-KEY.pub.asc  @aethersdr/maintainers


### PR DESCRIPTION
Reclassifies `THIRD_PARTY_LICENSES` from **Tier 1 (`@aethersdr/maintainers`)** to **Tier 2 (`@aethersdr/infrastructure`)** in CODEOWNERS.

## Why

`THIRD_PARTY_LICENSES` is a **legal/attribution tracking** file. Updating it records which upstream sources were consulted for a feature — infrastructure-review context, the same category as `CMakeLists.txt`, `tests/`, and `docs/`, which are already Tier 2. It is not a governance or security-control document like `CONSTITUTION.md`, `GOVERNANCE.md`, `SECURITY*`, the signing keys, or CODEOWNERS itself — the files Tier 1 exists to protect.

## Practical effect

Every feature PR that adds a radio backend or vendors a dependency touches `THIRD_PARTY_LICENSES`. Tier 1's roster is currently a single maintainer (`@ten9876`); when that maintainer is also a co-author — the norm for backend work — the PR can't get its required code-owner approval and **deadlocks on a one-line attribution edit**. This surfaced concretely on #4448 (the HL2 backend): CI green, an approving review, zero conflicts, blocked solely because the `THIRD_PARTY_LICENSES` change requires a non-co-author Tier 1 approval that no second maintainer exists to give.

Tier 2 has a broader roster, so attribution updates review normally while still requiring a code owner — no reduction in the "a human owner must approve" guarantee.

## Change

- Rule moved into the Tier 2 block (`@aethersdr/infrastructure`), right after `CMakeLists.txt`. Last-match-wins semantics preserved — no Tier 1 pattern below it matches `THIRD_PARTY_LICENSES`.
- Tier 1 and Tier 2 header comments updated so the documented rationale stays in sync with the rules.

Governance/security ownership of everything else in Tier 1 is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
