### PR TITLE
feat(hl2): basic TCI signaling — WSJT-X over a Hermes-Lite 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4022,6 +4022,20 @@ target_include_directories(hl2_family_transition_test PRIVATE src)
 target_link_libraries(hl2_family_transition_test PRIVATE aethercore Qt6::Core Qt6::Test)
 add_test(NAME hl2_family_transition_test COMMAND hl2_family_transition_test)
 
+# TCI signaling on a backend with neither a Flex command plane nor a DAX data
+# plane (HL2) — the seam WSJT-X rides. Links WebSockets so the TciServer half of
+# the file compiles wherever HAVE_WEBSOCKETS is set for aethercore.
+add_executable(hl2_tci_signaling_test tests/hl2_tci_signaling_test.cpp)
+target_include_directories(hl2_tci_signaling_test PRIVATE src tests)
+target_link_libraries(hl2_tci_signaling_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Test
+)
+if(Qt6WebSockets_FOUND)
+    target_link_libraries(hl2_tci_signaling_test PRIVATE Qt6::WebSockets)
+endif()
+set_target_properties(hl2_tci_signaling_test PROPERTIES AUTOMOC ON)
+add_test(NAME hl2_tci_signaling_test COMMAND hl2_tci_signaling_test)
+
 add_executable(aetherd_meter_decode_test tests/aetherd_meter_decode_test.cpp)
 target_include_directories(aetherd_meter_decode_test PRIVATE src)
 target_link_libraries(aetherd_meter_decode_test PRIVATE aethercore Qt6::Core Qt6::Test)

--- a/HERMES.md
+++ b/HERMES.md
@@ -4,12 +4,17 @@ Working notes from the HL2 receive bring-up on `feat/hl2-backend` (2026-07-24,
 macOS 26.5.2 / arm64). Written to be *studied*, not just read: the last section
 turns what happened into a proposed automated bring-up sequence.
 
-Status: HL2 receives, tunes, and demodulates AM and SSB with correct pitch on
-live hardware, with the slice decoupled from the DDC so the panadapter holds
-still while tuning. Sixteen commits, `e556ad01..91b45ee0`.
+Status: HL2 receives, transmits, and runs WSJT-X over TCI on live hardware —
+confirmed by 63 PSK Reporter spots on 14.074 DIGU. The slice is decoupled from
+the DDC so the panadapter holds still while tuning.
 
-Section 11 audits all of this against the independent correctness oracles at
-`/Users/patj/oracles/hl2/` and is the best starting point for the next session.
+Section 11 audits the receive bring-up against the independent correctness
+oracles at `/Users/patj/oracles/hl2/`.
+
+**Start here for a new backend:** §15 (receive handedness and tuning) and §5's
+sideband-selection rules. Those two describe the most expensive bug of the
+project — one that survived a full session of correct-looking measurements —
+and §15.6 is the checklist that would have caught it on day one.
 
 ---
 
@@ -163,6 +168,32 @@ ruling things out quickly.
 
 `validateConfig()` checks rate divisibility and the output-block arithmetic but
 **not** the `dsp_size`/`dsp_rate` relationship, which is how a bad value passed.
+
+### Sideband selection — the mode does NOT choose it
+
+Two facts that took a full session to establish, and that no amount of reading
+WDSP's headers would have given us. Both measured against WWV on live hardware.
+
+- **RX: the passband edges select the sideband, not the mode.** `SetRXAMode`
+  rebuilds the NBP stage from its own per-mode notion of the passband, so any
+  filter applied *before* the mode call is discarded by it. **Order is
+  load-bearing: mode first, then passband, and re-push the passband on every
+  mode set** — not only when its value changed.
+- **RX: WDSP's RXA selects the OPPOSITE sign to its passband bounds.** USB
+  configured `[+150, +3000]` passes *negative* analytic frequencies. Confirmed
+  independently by `hl2_rxdsp_test` and `hl2_shift_test`. This is the single
+  least intuitive fact in the whole backend and everything in §15 follows from
+  it.
+- **TX is the mirror image: the MODE selects the sideband and the bandpass is an
+  audio-domain magnitude.** `SetTXABandpassFreqs` wants **positive** edges for
+  every mode. Handing TX the RX table's signed pairs put LSB and DIGL on the
+  upper sideband — caught by `hl2_txdsp_test` before it shipped, which is why
+  `Hl2Backend` keeps two separate tables (`defaultPassbandForMode` signed for RX,
+  `defaultTxPassbandForMode` positive for TX).
+
+The trap: RX and TX use **opposite conventions**, and both look plausible. A
+table written for one and reused for the other is silently wrong on exactly half
+the modes.
 
 ### AGC
 
@@ -824,9 +855,16 @@ to the model method it calls, and confirm that method reaches
 
 Transmit went out on the WRONG SIDEBAND for the entire bring-up. The HPSDR wire
 order has the opposite handedness to the standard analytic convention; the
-receive path already compensated (conjugating with `-imag()` before WDSP, the
+receive path appeared to compensate (conjugating with `-imag()` before WDSP, the
 fix filed as "USB and LSB are swapped"), and transmit never got the same
 correction.
+
+> **Correction (see §15).** That receive-side `-imag()` was itself wrong. It
+> inverted every demodulated sideband, and a second error — feeding the
+> panadapter the raw wire — hid it. The reasoning recorded here ("RX already
+> compensates, TX needs the same") was right about the wire's handedness and
+> wrong about which stage should carry the correction. **Do not use this
+> paragraph as the model for a new backend; use §15.**
 
 **Every internal check agreed with the bug**, because the panadapter reads the
 same wire order as the transmitter. Our display and our transmission were
@@ -898,3 +936,152 @@ have exposed the bug was the one that always looked fine.
 - **PA temperature formula** is the HL2 wiki's, unverified against a reference.
   29.5 °C idle → 34 °C under load is plausible, not calibrated.
 - **`0x0e` T/R gain switch** and PureSignal's feedback path.
+- **Reference-oscillator calibration.** Measured **~200 Hz high at 10 MHz**
+  (≈20 ppm), consistently, in both sideband directions — i.e. the radio receives
+  above where it claims. Harmless for FT8 and unrelated to handedness (§15), but
+  it is a real frequency error with no calibration knob. A per-unit ppm trim
+  belongs alongside the power-calibration curve above.
+- **`RTTY` has no HL2 mode mapping.** It is advertised in the TCI
+  `modulations_list` and falls through `modeFromString` to the USB fallback —
+  the same class of silent defect as the `CW` gap in §15.7. Left unmapped rather
+  than guessed at; WDSP has no RTTY mode, so it needs a deliberate decision.
+
+---
+
+## 15. Receive handedness and tuning — the two-error trap
+
+The most expensive bug of the project, and the one most likely to recur verbatim
+on the next radio that owns its own DSP. Read this section before wiring IQ into
+any demodulator.
+
+### 15.1 What was wrong
+
+`Hl2RxDsp` handed the **demodulator** the conjugate of the wire IQ and the
+**spectrum** the raw wire. Both backwards — each was wired to the other's
+convention. The correct split follows from two measured facts:
+
+1. **The HPSDR wire is the conjugate of the analytic convention.** A signal
+   *above* the NCO arrives at a *negative* frequency.
+2. **WDSP's RXA selects the opposite sign to its passband bounds** (§5).
+
+So the **demodulator takes the RAW wire** — (1) and (2) cancel — and the
+**spectrum takes the CONJUGATE**, having no such quirk.
+
+```cpp
+// Hl2RxDsp::processIqBlock — the whole fix
+m_conjugated[n] = std::conj(iq[n]);      // spectrum: analytic convention
+m_spectrum->process(m_conjugated, ...);
+m_iqBuffer.insert(..., iq.begin(), iq.end());   // demodulator: raw wire
+```
+
+### 15.2 The slice shift is NOT part of the bug
+
+`shift = slice - NCO` is **correct** and derivable once handedness is settled:
+the wire puts a signal at `F` at `-(F - NCO)`, so mapping the slice's own
+frequency to baseband needs `-(slice - NCO) + shift == 0`.
+
+It looked like a co-conspirator, and flipping it was tried. It measurably broke
+off-centre tuning and `hl2_shift_test` caught it within one build. **Do not
+"fix" this sign.** It only ever looked wrong because it had been validated in
+LSB — the one mode the conjugation bug made correct.
+
+### 15.3 What the operator sees, and how to read it
+
+| Symptom | What it actually means |
+|---|---|
+| **LSB/DIGL work, USB/DIGU do not** | the chain is coherently inverted — NOT a broken mode |
+| Signals render on the wrong side of a correctly-drawn cursor | spectrum handedness |
+| Slice mistunes by ~2× its offset from the NCO | shift sign disagrees with IQ handedness |
+| TX gets spotted correctly, but only in the "wrong" mode | inversion is end-to-end, not display-only |
+
+The tell for *coherent inversion* is that everything works perfectly in the
+mirrored mode — including transmit, including third-party spots. A localized
+mode/filter bug cannot produce a fully functional radio under the wrong label.
+
+### 15.4 The measurement that settles it: force the shift to ZERO
+
+Two compensating errors cancel at normal off-centre tuning, so **any measurement
+taken at a non-zero shift sees a corrected result and proves nothing.** Zero
+shift is the one geometry where nothing can compensate.
+
+Force it by exploiting the NCO re-centre rule: tune far enough away that the NCO
+must jump, then land on the target — the NCO follows and the shift is exactly 0.
+
+```
+tune 7.100 MHz   (far)      -> NCO jumps
+tune 9.9985 MHz             -> NCO == dial, shift == 0
+```
+
+Then park a known carrier (WWV) 1500 Hz off the dial and ask which side each
+mode hears. Before the fix, at zero shift:
+
+| mode | heard | wanted | margin |
+|---|---|---|---|
+| usb | below dial | above | 100–300× |
+| digu | below dial | above | 100–300× |
+| lsb | above dial | below | 100–300× |
+| digl | above dial | below | 100–300× |
+
+After: all four correct, and at normal off-centre tuning the recovered tone is
+exactly the offset (1500 Hz on a 1500 Hz offset), which is what confirms the
+shift sign independently.
+
+### 15.5 Why every instrument agreed with the bug
+
+This is §14.6's lesson recurring, and it cost a second full session because the
+compensations were *not* obviously related to each other:
+
+- **The unit tests fed IQ no HL2 ever sends.** Both `hl2_rxdsp_test` and
+  `hl2_shift_test` generated textbook `exp(+jwt)`. The wire sends `exp(-jwt)`.
+  Correct expectations, wrong stimulus — so a mirrored panadapter *and* an
+  inverted demodulator both passed. **Test stimulus must use the wire's
+  convention, not the textbook's.**
+- **`hl2_shift_test` validated in LSB**, the one mode the inversion made
+  correct. A sideband test that runs in a single mode proves nothing about
+  handedness.
+- **The live sideband sweep put the test carrier at the pan centre.** A mirror
+  is invisible on its own axis. It confirmed "all four modes correct" while the
+  panadapter was visibly mirrored to the operator. **Never validate handedness
+  with a signal at the pan centre; always off-centre.**
+- **The audio path was correct** at normal tuning, so listening proved nothing.
+  The panadapter was the only consumer with no compensating error — the one
+  instrument telling the truth, and the one easiest to dismiss as "a display
+  bug".
+
+### 15.6 Bring-up checklist for the next DSP-owning backend
+
+Do these in order, before believing any audio:
+
+1. **Establish wire handedness first**, from the decoder, with a synthetic tone
+   of known sign. Write it down. Every later decision depends on it.
+2. **Conjugate exactly once**, at one place, and be explicit about which
+   consumer gets which. Two consumers with opposite needs is a design fact, not
+   an accident — comment it at the split.
+3. **Verify at zero shift** before verifying anything else. Compensating errors
+   cancel everywhere else.
+4. **Verify off-centre**, in **all four** SSB-family modes, against a known
+   carrier. Not one mode, not at the pan centre.
+5. **Check the panadapter against the demodulator explicitly.** They are
+   independent consumers of the same buffer and can disagree; if they do, one of
+   them is compensating for something.
+6. **Confirm from outside the system** (§14.6): a second receiver, or PSK
+   Reporter spots in the mode under test. This bring-up ended with 63 spots on
+   14.074 DIGU — the first evidence that could not have come from a
+   self-consistent loop.
+
+### 15.7 Related: mode changes must re-push the passband
+
+Separate defect, same session, same root category (order-of-operations against
+WDSP). `SetRXAMode` discards a passband applied before it, so the HL2's filter
+was effectively sticky across mode changes: arriving at DIGU from CW handed the
+decoder a ~500 Hz window and it decoded nothing, with the mode indicator
+correct. A radio that owns its DSP gets no mode echo to heal this — **the
+backend must supply a per-mode default passband itself**, applied on change so
+an operator's own filter edit survives (oracle addendum 2 §B3).
+
+Also fixed here: `modeFromString` knew `"CWU"` but not `"CW"` — the spelling
+`TciProtocol::tciToSmartSDR` produces for TCI's `cw`, and the one a Flex
+reports — so plain CW fell through to the USB fallback and was demodulated as
+SSB. `NFM` was missing for the same reason. **Any mode name that appears in the
+TCI `modulations_list` needs a mapping, or it silently becomes USB.** `RTTY`
+still has this gap.

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -8301,7 +8301,12 @@ void AudioEngine::feedDaxTxAudioInternal(const QByteArray& inPcm,
                                          bool markExternalSource,
                                          bool forceRadioDaxRoute)
 {
-    if (m_txStreamId == 0 || inPcm.isEmpty()) return;
+    if (inPcm.isEmpty()) return;
+    // A host-modulating backend (HL2) has no Flex TX stream id and never will —
+    // its modulator runs here, fed from the final-monitor tap below. Gating this
+    // path on the stream id dropped every TCI/DAX frame on such a radio, so
+    // WSJT-X keyed the rig and transmitted silence. See setHostModulation().
+    if (!m_hostModulation && m_txStreamId == 0) return;
 
     // Mark TCI as the active TX-audio source. While this timer is fresh,
     // onTxAudioReady() suppresses the local mic capture path so the two
@@ -8349,6 +8354,37 @@ void AudioEngine::feedDaxTxAudioInternal(const QByteArray& inPcm,
     if (daxAudioWillTransmit) {
         emitTxPostChainScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE);
         emitScopeFromFloat32Stereo(float32pcm, DEFAULT_SAMPLE_RATE, true);
+    }
+
+    // ── Host-modulated backend (HL2): no VITA-49 plane ──────────────────
+    // Both routes below packetize for a Flex radio that modulates on its own
+    // side. A host-modulating backend has no TX stream and no radio-side
+    // modulator; its transmit audio arrives through the SAME final-monitor tap
+    // the microphone uses, which MainWindow routes to
+    // RadioModel::submitTxAudio() (and to the QSO recorder).
+    //
+    // Still a DSP bypass, for the reason stated above: this path carries
+    // pre-shaped digital tones from TCI/DAX, so no compressor, EQ, Quindar or
+    // brickwall limiter runs on it — only the TCI gain/overflow stage the
+    // caller already applied.
+    //
+    // No TX-state gate here. m_radioTransmitting is decoded from Flex interlock
+    // status, which a host-modulating backend never sends, so testing it would
+    // discard every frame. Both consumers of the signal gate themselves:
+    // Hl2Backend::submitTxAudio drops audio unless keyed, and QsoRecorder gates
+    // on MOX.
+    if (m_hostModulation) {
+        const auto* src = reinterpret_cast<const float*>(float32pcm.constData());
+        const int samples = static_cast<int>(float32pcm.size() / sizeof(float));
+        QByteArray out(samples * static_cast<int>(sizeof(qint16)), Qt::Uninitialized);
+        auto* dst = reinterpret_cast<qint16*>(out.data());
+        for (int i = 0; i < samples; ++i) {
+            const float v = std::isfinite(src[i]) ? src[i] : 0.0f;
+            dst[i] = static_cast<qint16>(
+                std::clamp(v * 32768.0f, -32768.0f, 32767.0f));
+        }
+        emit txFinalMonitorPcmReady(out);
+        return;
     }
 
     const bool useRadioDaxRoute = forceRadioDaxRoute || m_daxTxUseRadioRoute;

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1188,6 +1188,28 @@ void TciServer::tuneSliceAndConfirm(
         const double halfBandwidth = pan->bandwidthMhz() / 2.0;
         inSpan = halfBandwidth > 0.0 && qAbs(mhz - pan->centerMhz()) <= halfBandwidth;
     }
+
+    // Seam backend (HL2): there is no text-command plane, so the sendCmdPublic
+    // below would be swallowed and its completion callback would never run —
+    // WSJT-X's band-hop was dropped AND its 2 s vfo-echo timeout expired, which
+    // it reports as a rig-control failure. Drive the model instead; it routes
+    // the intent through IRadioBackend::setSliceFrequency and, having no radio
+    // status to wait for, is authoritative the moment it returns. Recentering
+    // follows the same in-span rule as the Flex command choice below.
+    if (!m_model->usesFlexCommandPlane()) {
+        if (inSpan)
+            slice->setFrequency(mhz);
+        else
+            slice->tuneAndRecenter(mhz);
+        // A locked slice refuses the tune. Confirm what the model actually
+        // holds, never the request, so a client's mirror cannot drift.
+        const long long acceptedHz = TciProtocol::mhzToHz(slice->frequency());
+        if (acceptedHz > 0) {
+            broadcast(QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(acceptedHz));
+        }
+        return;
+    }
+
     const QString command = inSpan
         ? QStringLiteral("slice tune %1 %2 autopan=0").arg(sliceId).arg(mhz, 0, 'f', 6)
         : QStringLiteral("slice tune %1 %2").arg(sliceId).arg(mhz, 0, 'f', 6);
@@ -2722,7 +2744,13 @@ void TciServer::prepareTxAudio()
     // re-derives the source rate from each frame's hdr.sampleRate and rebuilds
     // this if a client transmits at a non-48k negotiated rate (#3306).
     m_txResampler = std::make_unique<Resampler>(48000.0, 24000.0, 4096);
-    if (m_model) {
+    // The DAX TX stream is how a Flex radio is told to modulate from the
+    // network instead of its mic jack. A host-modulating backend (HL2) has no
+    // such stream and no such command set: its modulator is AudioEngine's, so
+    // arranging a radio-side route here would send Flex text at a radio that
+    // does not speak it. AudioEngine::feedDaxTxAudio routes to the local
+    // modulator on that backend and never reaches the VITA-49 packetizers.
+    if (m_model && !hostModulatingBackend()) {
         // Always dax=1 for TCI TX. The DaxTxLowLatency flag only controls
         // VITA-49 packet format (PCC 0x03E3 vs 0x0123 in feedDaxTxAudio);
         // both formats require dax=1 so the radio routes the dax_tx stream
@@ -3144,9 +3172,27 @@ void TciServer::onWaterfallRowReady(quint32 streamId, const QVector<float>& bins
 // doesn't already have one, and release it when the last TCI audio client
 // disconnects.
 
+// True when the connected backend demodulates and modulates in this process
+// (Hermes-Lite 2) rather than inside the radio. Such a backend has no DAX /
+// VITA-49 data plane at all, so every DAX arrangement in this file is not just
+// unnecessary but actively wrong — it would push Flex slice/transmit text at a
+// radio that speaks HPSDR. Capability, not a family-name test.
+bool TciServer::hostModulatingBackend() const
+{
+    return m_model && m_model->backendCapabilities().hostModulates;
+}
+
 void TciServer::ensureDaxForTci()
 {
     if (!m_model || !m_model->isConnected()) return;
+
+    // In-process backend (HL2): there is no DAX plane to arrange. RX audio
+    // reaches onDaxAudioReady() on channel 1 straight from the backend's
+    // demodulator (MainWindow wires backendAudioFrameReady), and the
+    // channel→TRX fallback there maps channel 1 to trx 0 — which is the whole
+    // mapping on a single-slice radio. Assigning slice DAX channels here would
+    // emit Flex `slice set … dax=` commands into a socket that ignores them.
+    if (!m_model->panStream()) return;
 
     QSet<int> channelsNeeded;
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1257,6 +1257,22 @@ void TciServer::promoteTxSliceAndContinue(int sliceId, std::function<void(bool)>
         return;
     }
 
+    // Seam backend (HL2): `slice set N tx=1` is Flex text with no counterpart on
+    // this plane, so the sendCmdPublic below would be swallowed AND this
+    // continuation would never run. Every caller opens a route transition
+    // around it, so a silent drop leaks m_routeTransitionInFlight forever and
+    // wedges TCI keying for the rest of the connection. Answer honestly instead
+    // of hanging: there is no seam verb to promote a slice, and the one slice
+    // such a radio has already returned true above (Hl2Backend publishes
+    // txSlice=true — its single slice IS the transmitter), so this only fires
+    // for a route that genuinely cannot be built.
+    if (!m_model->usesFlexCommandPlane()) {
+        qCWarning(lcCat) << "TCI: TX-slice selection unsupported on this radio"
+                         << "slice=" << sliceId;
+        continuation(false);
+        return;
+    }
+
     QPointer<TciServer> self(this);
     m_model->sendCmdPublic(QStringLiteral("slice set %1 tx=1").arg(sliceId),
         [self, sliceId, continuation = std::move(continuation)](
@@ -1284,6 +1300,29 @@ void TciServer::createTxSliceForVfoB(QWebSocket* client,
     if (!client || !m_model || !rxSlice) {
         return;
     }
+
+    // Seam backend (HL2): `slice create` is Flex text this radio does not speak.
+    // The command below would be swallowed and its completion callback would
+    // never run, so the route transition opened just after it could never be
+    // closed -- and handleTrxRequest() defers every subsequent trx:true into
+    // m_pendingTrxRequest while a transition is in flight, so WSJT-X could not
+    // transmit again for the rest of the connection. That is the failure this
+    // guard exists to prevent, and the capacity test below does NOT catch it:
+    // maxSlices() is the model-string-derived Flex estimate (2 by default), not
+    // the backend's own maxSlices, so a single-slice HL2 looks like it has room.
+    //
+    // Refusing is also the honest answer, not merely the safe one: WSJT-X's
+    // "Split = Rig/Fake It" reaches exactly here, and reportVfoBRouteFailure
+    // sends split_enable:...,false; plus the authoritative channel-1 VFO, which
+    // is what makes it fall back to single-VFO operation instead of waiting.
+    if (!m_model->usesFlexCommandPlane()) {
+        reportVfoBRouteFailure(client, request,
+            QStringLiteral("this radio has no second VFO: split needs a TX slice "
+                           "it cannot create"),
+            !routeConfirmation.isEmpty());
+        return;
+    }
+
     if (m_model->slices().size() >= m_model->maxSlices()) {
         reportVfoBRouteFailure(client, request,
             QStringLiteral("cannot create VFO B: radio slice capacity reached"),

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -49,6 +49,7 @@ struct TciClientInfo {
 class TciServer : public QObject {
     Q_OBJECT
     friend class TciServerReviewTest;
+    friend class Hl2TciSignalingTest;
 
 public:
     explicit TciServer(RadioModel* model, QObject* parent = nullptr);
@@ -193,6 +194,9 @@ private:
         const TciProtocol::VfoRequest& request,
         const QString& reason,
         bool rejectSplit);
+    // True when the connected backend runs the modulator/demodulator in this
+    // process (HL2) instead of inside the radio — hence has no DAX data plane.
+    bool hostModulatingBackend() const;
     void prepareTxAudio();
     void startTxChrono(QWebSocket* client, int trx);
     void stopTxChrono();

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -90,6 +90,36 @@ std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
     return {150, 3000};   // matches modeFromString's USB fallback
 }
 
+// Default TRANSMIT passband per mode, in Hz. POSITIVE for every mode, and that
+// is not an oversight — TX and RX use opposite conventions and mixing them up
+// transmits on the wrong sideband:
+//
+//   RX (RXANBPSetFreqs): the SIGN of the passband selects the sideband. The
+//                        mode does not.
+//   TX (SetTXABandpassFreqs): the MODE selects the sideband; the bandpass is an
+//                        audio-domain magnitude. Handing it a negative pair
+//                        flips LSB and DIGL onto the upper sideband.
+//
+// Measured, not assumed: hl2_txdsp_test drives a 1 kHz tone through the real
+// modulator and reads the sideband off the emitted IQ. With a negative pair,
+// LSB lands on the same wire bin as USB.
+//
+// Voice stays at the established 300..2700 rather than inheriting the wider RX
+// window — that width is deliberate (see Hl2TxDsp::Config), and widening every
+// SSB transmission is not part of making WSJT-X work. The digital modes get the
+// full window because that is the one the decoder occupies.
+std::pair<int, int> defaultTxPassbandForMode(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("DIGU") || u == QLatin1String("DIGL")) return {150, 3000};
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW")
+        || u == QLatin1String("CWL")) return {300, 900};
+    if (u == QLatin1String("AM") || u == QLatin1String("SAM")
+        || u == QLatin1String("DSB")) return {100, 3000};
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM")) return {100, 3000};
+    return {300, 2700};   // USB/LSB and anything else: the voice default
+}
+
 // Phase-1 data-plane payload: a raw little-endian float32 array. RadioModel's
 // relay decodes it; the binary step-4 frame format supersedes this later.
 QByteArray floatBytes(const std::vector<float>& v)
@@ -336,6 +366,15 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     tc.inputSampleRateHz = 24000;    // AudioEngine's rate; submitTxAudio re-checks
     tc.outputSampleRateHz = 48000;   // EP2 is fixed at 48 kHz
     tc.mode = modeFromString(m_mode);
+    // Sideband-correct from the first key, not from the first mode change. The
+    // struct default is a positive 300..2700, so connecting straight into LSB
+    // or DIGL would otherwise transmit on the upper sideband until the operator
+    // happened to change mode.
+    {
+        const auto [txLo, txHi] = defaultTxPassbandForMode(m_mode);
+        tc.filterLowHz  = txLo;
+        tc.filterHighHz = txHi;
+    }
     std::string txErr;
     bool txOk = false;
     QMetaObject::invokeMethod(m_txDsp, [this, &tc, &txErr, &txOk] {
@@ -416,6 +455,8 @@ void Hl2Backend::setSliceMode(int /*sliceId*/, const QString& mode)
 {
     const QString previous = m_mode;
     m_mode = mode;
+    const WdspChannel::Mode wdsp = modeFromString(mode);
+
     // The passband belongs to the mode. A radio that owns its own DSP echoes a
     // mode-appropriate filter back on every mode change and heals this for
     // free; we own the DSP, so nothing heals it and the previous mode's
@@ -423,22 +464,53 @@ void Hl2Backend::setSliceMode(int /*sliceId*/, const QString& mode)
     // the mode WSJT-X uses, which decodes nothing -- and the operator sees a
     // mode that changed, so the filter is the last thing they suspect.
     //
-    // Applied on CHANGE only, so an operator's own filter edit survives until
-    // they change mode again. That is what every HL2 client does (oracle
-    // addendum 2 §B3: "All clients tie default filter width to mode, with user
-    // overrides").
+    // Adopted on CHANGE only, so an operator's own filter edit survives until
+    // they change mode again (oracle addendum 2 §B3: "All clients tie default
+    // filter width to mode, with user overrides").
     if (!previous.isEmpty() && previous.compare(mode, Qt::CaseInsensitive) != 0) {
         const auto [lo, hi] = defaultPassbandForMode(mode);
-        setSliceFilter(kSliceId, lo, hi);   // pushes the DSP and emits slice state
+        m_filterLowHz  = lo;
+        m_filterHighHz = hi;
     }
-    if (m_dsp)
+
+    // ORDER IS LOAD-BEARING: mode FIRST, then passband -- and the passband is
+    // re-pushed on EVERY mode set, not only when its value changed.
+    //
+    // In WDSP the mode does not select the sideband; the NBP filter edges do
+    // (see WdspChannel::setFilter). SetRXAMode/SetTXAMode rebuild that stage
+    // from their own per-mode notion of the passband, so any filter applied
+    // BEFORE the mode call is discarded by it.
+    //
+    // What this cost: USB<->LSB happens to flip the filter's sign, so
+    // SliceModel::normalizeFilterPolarity re-pushed the passband after the mode
+    // and those two were always correct. USB->DIGU does not flip the sign,
+    // nothing re-pushed, and DIGU was left running on whatever sideband
+    // SetRXAMode had rebuilt -- FT8 sat on the wrong side of the passband and
+    // decoded nothing, while DIGL (reached via a sign flip) worked perfectly.
+    // A sideband bug that reverses itself depending on which mode you came
+    // from is exactly what an ordering bug looks like from the operator's seat.
+    if (m_dsp) {
         QMetaObject::invokeMethod(m_dsp, "setMode", Qt::QueuedConnection,
-            Q_ARG(WdspChannel::Mode, modeFromString(mode)));
+            Q_ARG(WdspChannel::Mode, wdsp));
+        QMetaObject::invokeMethod(m_dsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(m_filterLowHz)),
+            Q_ARG(double, static_cast<double>(m_filterHighHz)));
+    }
+
     // The transmit sideband follows the slice. Without this, switching to LSB
     // would receive on the lower sideband and still transmit on the upper.
-    if (m_txDsp)
+    //
+    // The passband half of that was missing entirely: Hl2TxDsp::setFilter
+    // existed and had no caller, so the TX chain ran on its construction-time
+    // 300..2700 for every mode of the session. Same ordering rule as RX.
+    if (m_txDsp) {
         QMetaObject::invokeMethod(m_txDsp, "setMode", Qt::QueuedConnection,
-            Q_ARG(WdspChannel::Mode, modeFromString(mode)));
+            Q_ARG(WdspChannel::Mode, wdsp));
+        const auto [txLo, txHi] = defaultTxPassbandForMode(mode);
+        QMetaObject::invokeMethod(m_txDsp, "setFilter", Qt::QueuedConnection,
+            Q_ARG(double, static_cast<double>(txLo)),
+            Q_ARG(double, static_cast<double>(txHi)));
+    }
     emitSliceState();
 }
 

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -14,6 +14,7 @@
 #include <QLoggingCategory>
 
 #include <cstdint>
+#include <utility>
 
 Q_LOGGING_CATEGORY(lcHl2Tx, "aether.hl2.tx")
 
@@ -38,8 +39,15 @@ WdspChannel::Mode modeFromString(const QString& mode) noexcept
     if (u == QLatin1String("USB"))  return WdspChannel::Mode::Usb;
     if (u == QLatin1String("DSB"))  return WdspChannel::Mode::Dsb;
     if (u == QLatin1String("CWL"))  return WdspChannel::Mode::Cwl;
-    if (u == QLatin1String("CWU"))  return WdspChannel::Mode::Cwu;
-    if (u == QLatin1String("FM"))   return WdspChannel::Mode::Fm;
+    // "CW" is the upper-sideband CW mode name the rest of the app uses (it is
+    // what TciProtocol::tciToSmartSDR produces for TCI's `cw`, and what a Flex
+    // reports); "CWU" is the explicit spelling. Only CWU was listed, so plain CW
+    // fell through to the USB fallback below and was demodulated as SSB -- the
+    // mode indicator read CW while the passband and detector were not.
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW"))
+        return WdspChannel::Mode::Cwu;
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM"))
+        return WdspChannel::Mode::Fm;
     if (u == QLatin1String("AM"))   return WdspChannel::Mode::Am;
     if (u == QLatin1String("DIGU")) return WdspChannel::Mode::Digu;
     if (u == QLatin1String("DIGL")) return WdspChannel::Mode::Digl;
@@ -47,6 +55,39 @@ WdspChannel::Mode modeFromString(const QString& mode) noexcept
     if (u == QLatin1String("DRM"))  return WdspChannel::Mode::Drm;
     if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return WdspChannel::Mode::Wbfm;
     return WdspChannel::Mode::Usb;
+}
+
+// Default RX passband per mode, in Hz relative to the carrier. Sign carries the
+// sideband, matching SliceModel's convention (USB-family positive, LSB-family
+// negative, carrier-straddling modes symmetric) -- a table with the wrong sign
+// here would be silently "corrected" by SliceModel::normalizeFilterPolarity and
+// the mistake would never surface.
+//
+// The digital entries are deliberately the widest of the set. DIGU is the mode
+// WSJT-X selects, and it must pass the whole 3 kHz audio window the decoder
+// expects; a snug SSB passband would clip the top of the FT8 sub-band and drop
+// exactly the signals at the edges.
+std::pair<int, int> defaultPassbandForMode(const QString& mode) noexcept
+{
+    const QString u = mode.toUpper();
+    if (u == QLatin1String("USB"))  return {100, 2900};
+    if (u == QLatin1String("LSB"))  return {-2900, -100};
+    if (u == QLatin1String("DIGU")) return {150, 3000};
+    if (u == QLatin1String("DIGL")) return {-3000, -150};
+    // CW: 500 Hz around the conventional 600 Hz pitch. The pitch itself is a
+    // client-side setting the backend is not told about, so this is the
+    // default-pitch case; an operator running another pitch retunes the filter
+    // and that edit survives until the next mode change.
+    if (u == QLatin1String("CWU") || u == QLatin1String("CW")) return {350, 850};
+    if (u == QLatin1String("CWL"))  return {-850, -350};
+    // Carrier-straddling modes: symmetric about the carrier, which the envelope
+    // and synchronous detectors both need.
+    if (u == QLatin1String("AM") || u == QLatin1String("SAM")) return {-4000, 4000};
+    if (u == QLatin1String("DSB")) return {-3000, 3000};
+    if (u == QLatin1String("FM") || u == QLatin1String("NFM")) return {-8000, 8000};
+    if (u == QLatin1String("WBFM") || u == QLatin1String("WFM")) return {-40000, 40000};
+    if (u == QLatin1String("DRM")) return {-5000, 5000};
+    return {150, 3000};   // matches modeFromString's USB fallback
 }
 
 // Phase-1 data-plane payload: a raw little-endian float32 array. RadioModel's
@@ -373,7 +414,23 @@ void Hl2Backend::setSliceFrequency(int /*sliceId*/, double hz)
 
 void Hl2Backend::setSliceMode(int /*sliceId*/, const QString& mode)
 {
+    const QString previous = m_mode;
     m_mode = mode;
+    // The passband belongs to the mode. A radio that owns its own DSP echoes a
+    // mode-appropriate filter back on every mode change and heals this for
+    // free; we own the DSP, so nothing heals it and the previous mode's
+    // passband simply stays. Selecting DIGU out of CW left a ~200 Hz filter on
+    // the mode WSJT-X uses, which decodes nothing -- and the operator sees a
+    // mode that changed, so the filter is the last thing they suspect.
+    //
+    // Applied on CHANGE only, so an operator's own filter edit survives until
+    // they change mode again. That is what every HL2 client does (oracle
+    // addendum 2 §B3: "All clients tie default filter width to mode, with user
+    // overrides").
+    if (!previous.isEmpty() && previous.compare(mode, Qt::CaseInsensitive) != 0) {
+        const auto [lo, hi] = defaultPassbandForMode(mode);
+        setSliceFilter(kSliceId, lo, hi);   // pushes the DSP and emits slice state
+    }
     if (m_dsp)
         QMetaObject::invokeMethod(m_dsp, "setMode", Qt::QueuedConnection,
             Q_ARG(WdspChannel::Mode, modeFromString(mode)));

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -426,12 +426,14 @@ void Hl2Backend::setSliceFrequency(int /*sliceId*/, double hz)
                 Q_ARG(std::uint32_t, static_cast<std::uint32_t>(hz < 0 ? 0 : hz)));
     }
 
-    // Shift by the slice's offset from the NCO, with the SAME sign. Measured,
-    // not reasoned: hl2_shift_test sweeps the stage and finds the mapping is
-    // exactly audio = tone + shift for positive values (a tone 800 Hz below the
-    // NCO lands at 2800 Hz of audio with the slice 2 kHz above it). The
-    // intuition that "bringing a signal down to baseband must be negative" is
-    // backwards here, and negative shifts push the signal out of the passband.
+    // Shift by the slice's offset from the NCO, with the SAME sign.
+    //
+    // Derivable, now that the handedness is settled: the wire puts a signal at
+    // frequency F at -(F - NCO), so mapping the slice's own frequency to
+    // baseband needs -(slice - NCO) + shift == 0, i.e. shift = slice - NCO.
+    // hl2_shift_test measures exactly that. (This sign is unchanged — it was
+    // right all along; what was wrong was the conjugation in Hl2RxDsp, which is
+    // why the stage looked correct only in LSB.)
     if (m_dsp)
         QMetaObject::invokeMethod(m_dsp, "setShift", Qt::QueuedConnection,
             Q_ARG(double, m_rxFreqHz - m_ncoHz));

--- a/src/core/backends/hl2/Hl2RxDsp.cpp
+++ b/src/core/backends/hl2/Hl2RxDsp.cpp
@@ -126,11 +126,29 @@ void Hl2RxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
     if (!m_channel)
         return;
 
-    // Panadapter: the FFT sees the full-rate IQ.
-    if (m_spectrum->process(iq, m_bins) > 0)
+    // The two consumers need OPPOSITE handedness, and each was wired to the
+    // other's. Two facts, both measured rather than reasoned:
+    //
+    //   1. The HPSDR wire is the conjugate of the analytic convention: a signal
+    //      ABOVE the NCO arrives at a NEGATIVE frequency.
+    //   2. WDSP's RXA, as configured here, selects the OPPOSITE sign to its
+    //      passband bounds — USB with [+150,+3000] passes negative frequencies.
+    //      (Confirmed independently by hl2_rxdsp_test and hl2_shift_test.)
+    //
+    // So the DEMODULATOR wants the raw wire — (1) and (2) cancel — while the
+    // SPECTRUM, which has no such quirk, wants the conjugate.
+    m_conjugated.resize(iq.size());
+    for (std::size_t n = 0; n < iq.size(); ++n)
+        m_conjugated[n] = std::conj(iq[n]);
+
+    // Panadapter: conjugated into the analytic convention Hl2Spectrum's fftshift
+    // assumes. Fed the raw wire it drew the spectrum MIRRORED about the pan
+    // centre — on 40 m that put FT8, which lives at 7.074..7.077, on screen at
+    // 7.071..7.074, left of a correctly-drawn DIGU cursor.
+    if (m_spectrum->process(m_conjugated, m_bins) > 0)
         emit spectrumReady(m_bins);
 
-    // Audio: buffer into fixed WdspChannel blocks.
+    // Audio: the RAW wire. See the note in the block loop below.
     m_iqBuffer.insert(m_iqBuffer.end(), iq.begin(), iq.end());
     const std::size_t block = static_cast<std::size_t>(m_config.dspBlockSize);
     std::size_t consumed = 0;
@@ -144,18 +162,23 @@ void Hl2RxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
             std::fill(m_q.begin(), m_q.end(), 0.0f);
         } else
         for (std::size_t n = 0; n < block; ++n) {
-            m_i[n] = m_iqBuffer[consumed + n].real();
-            // Conjugate for WDSP. The HPSDR wire order (I then Q, decoded in
-            // MetisProtocol) produces a spectrum whose handedness is the
-            // opposite of what WDSP's sideband selection assumes, so USB
-            // demodulated the LOWER sideband and LSB the upper — audibly, the
-            // two sidebands were swapped while the panadapter looked right.
+            // NOT conjugated. This carried a `-imag()` on the stated reasoning
+            // that the HPSDR wire order is the opposite handedness to WDSP's
+            // convention. Measured against WWV on live hardware, it is not: with
+            // the slice shift forced to zero — the one geometry where no second
+            // error can compensate — that conjugation made USB hear signals
+            // BELOW the dial and LSB hear them above, by 100-300x in magnitude.
+            // Removing it puts every mode on the sideband it advertises.
             //
-            // Applied HERE and not in the decoder deliberately: Hl2Spectrum
-            // takes the same buffer and its handedness is already correct, so
-            // conjugating upstream would fix the audio and mirror the display.
-            // The narrow fix is that WDSP's convention differs from the wire's.
-            m_q[n] = -m_iqBuffer[consumed + n].imag();
+            // It survived because it never acted alone: the shift sign in
+            // Hl2Backend::setSliceFrequency was calibrated THROUGH this
+            // inversion and validated in LSB (hl2_shift_test), the one mode the
+            // inversion makes correct. The two did not cancel cleanly, though —
+            // they left the slice mistuned by twice its offset from the NCO,
+            // which is the "DIGU is ~3 kHz off" an operator sees at a 1.5 kHz
+            // offset. Both halves have to come out together.
+            m_i[n] = m_iqBuffer[consumed + n].real();
+            m_q[n] = m_iqBuffer[consumed + n].imag();
         }
         consumed += block;
 

--- a/src/core/backends/hl2/Hl2RxDsp.cpp
+++ b/src/core/backends/hl2/Hl2RxDsp.cpp
@@ -174,9 +174,9 @@ void Hl2RxDsp::processIqBlock(const std::vector<std::complex<float>>& iq)
     // centre — on 40 m that put FT8, which lives at 7.074..7.077, on screen at
     // 7.071..7.074, left of a correctly-drawn DIGU cursor.
     //
-    // The FFT sees the full-rate IQ, but only when a frame is
-    // actually due. Skipping the whole computation — not just the emit — is
-    // what keeps a wide span affordable; see setSpectrumRateFps.
+    // The FFT sees the full-rate IQ, but only when a frame is actually due.
+    // Skipping the whole computation — not just the emit — is what keeps a wide
+    // span affordable; see setSpectrumRateFps.
     //
     // The accumulator is fed on BOTH paths, so a skipped interval advances the
     // window rather than emptying it: whichever fftSize samples complete a frame

--- a/src/core/backends/hl2/Hl2RxDsp.h
+++ b/src/core/backends/hl2/Hl2RxDsp.h
@@ -103,6 +103,10 @@ private:
 
     bool m_audioMuted = false;
     std::vector<std::complex<float>> m_iqBuffer;   // IQ awaiting a full DSP block
+    // Wire IQ conjugated into the analytic convention, for the SPECTRUM only —
+    // the demodulator takes the raw wire. A member rather than a local: this
+    // runs per IQ block on the I/O thread.
+    std::vector<std::complex<float>> m_conjugated;
     std::vector<float> m_i, m_q;                    // deinterleaved input scratch
     std::vector<float> m_left, m_right;             // WdspChannel output scratch
     std::vector<float> m_stereo;                    // interleaved audio out

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1609,6 +1609,25 @@ void MainWindow::wireCatPorts()
     // the shared helper the post-swap rebind also calls (#4448).
     wirePanStreamTciSinks();
 
+    // RX audio for a backend that demodulates in-process (HL2). That backend has
+    // no PanadapterStream, so wirePanStreamTciSinks() above binds nothing and TCI
+    // clients heard silence — WSJT-X connected, tracked frequency and mode, and
+    // never decoded a single signal.
+    //
+    // The payload is already what onDaxAudioReady expects: float32 interleaved
+    // stereo at 24 kHz (Hl2RxDsp::Config::audioSampleRateHz). Channel 1 is not an
+    // arbitrary pick — with no slice claiming a DAX channel, onDaxAudioReady's
+    // fallback maps channel N to trx N-1, so 1 → trx 0, the single receiver such
+    // a radio advertises in trx_count.
+    //
+    // Bound to m_radioModel, not the backend, so it survives a family swap; Flex
+    // never emits backendAudioFrameReady, so there is no double-feed.
+    connect(&m_radioModel, &RadioModel::backendAudioFrameReady,
+            this, [this](const QByteArray& pcm) {
+        if (tciServer())
+            tciServer()->onDaxAudioReady(1, pcm);
+    });
+
     // TCI client count changes no longer auto-create/remove the audio stream.
     // Control-only TCI clients (StreamDeck) don't need audio, and auto-creating
     // the stream overrode the user's explicit PC Audio toggle. Users who need

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -611,8 +611,14 @@ void RadioModel::setupBackend(const QString& family)
     // twice.
     connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
             [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex"))
+        if (m_backend && m_family != QLatin1String("flex")) {
             m_backend->setKeying(on);
+            // The MOX button and the PTT coordinator key here, NOT through
+            // setTransmit(), so the raw-TX edge has to be published on this path
+            // too — otherwise a TCI client watching an operator-initiated
+            // transmit sees nothing. See publishBackendTransmitEdge().
+            publishBackendTransmitEdge(on);
+        }
     });
     connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
             [this](bool on) {
@@ -2521,6 +2527,33 @@ void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)
     // matches "display pan set ", not "xmit".
     if (m_backend)
         m_backend->setKeying(tx);
+
+    publishBackendTransmitEdge(tx);
+}
+
+// Publish the raw TX edge for a backend that has no interlock status plane.
+//
+// m_radioTransmitting is otherwise decoded exclusively from Flex `interlock`
+// status, so on such a backend it stays false forever. That is not a cosmetic
+// gap: TciServer waits on radioTransmittingChanged to CONFIRM a TCI key and
+// gives up 1250 ms later — WSJT-X's transmission was being unkeyed a second and
+// a quarter in, every time.
+//
+// Our own command is the authoritative edge here precisely because there is no
+// status plane to be authoritative instead: no other client shares this radio,
+// and the backend's own transmit gate has already been consulted before either
+// caller reaches this point. If a backend later reports hardware PTT or an
+// interlock of its own, it should drive this through
+// IRadioBackend::transmitChanged and this fallback should yield to it.
+//
+// Flex is excluded: there the edge is decoded from interlock status, and a
+// second source would race it.
+void RadioModel::publishBackendTransmitEdge(bool tx)
+{
+    if (!m_backend || m_flexBackend || m_radioTransmitting == tx)
+        return;
+    m_radioTransmitting = tx;
+    emit radioTransmittingChanged(tx);
 }
 
 void RadioModel::updateOperatorTransmit()

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -622,8 +622,19 @@ void RadioModel::setupBackend(const QString& family)
     });
     connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
             [this](bool on) {
-        if (m_backend && m_family != QLatin1String("flex"))
+        if (m_backend && m_family != QLatin1String("flex")) {
             m_backend->setTune(on);
+            // A tune carrier is a transmission. Hl2Backend::setTune() calls
+            // setKeying(), so the radio is on the air — the raw-TX edge has to
+            // be published here for the same reason it is on the MOX path, and
+            // for one more that is specific to tune: TciServer's
+            // "already transmitting" guard reads isRadioTransmitting(), so
+            // leaving it false let a TCI client key ON TOP of a live tune
+            // carrier, and that client's unkey then dropped the key while tune
+            // still believed it owned it. A TCI-driven amplifier also never saw
+            // trx:true for the carrier operators most often tune INTO an amp.
+            publishBackendTransmitEdge(on);
+        }
     });
 
     // Push the CURRENT power on connect, not only on change. rfPowerChanged

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -612,6 +612,8 @@ void RadioModel::setupBackend(const QString& family)
     connect(&m_transmitModel, &TransmitModel::moxCommandIssued, this,
             [this](bool on) {
         if (m_backend && m_family != QLatin1String("flex")) {
+            if (on && !refuseKeyOnTransmitIncapableBackend())
+                return;
             m_backend->setKeying(on);
             // The MOX button and the PTT coordinator key here, NOT through
             // setTransmit(), so the raw-TX edge has to be published on this path
@@ -623,6 +625,15 @@ void RadioModel::setupBackend(const QString& family)
     connect(&m_transmitModel, &TransmitModel::tuneCommandIssued, this,
             [this](bool on) {
         if (m_backend && m_family != QLatin1String("flex")) {
+            if (on && !refuseKeyOnTransmitIncapableBackend()) {
+                // Un-latch TUNE as well. m_tune was already set optimistically
+                // (TransmitModel::startTune), and the button's toggle reads it,
+                // so leaving it set would strand TUNE "on" against a radio that
+                // never keyed. The re-entry through this same slot carries
+                // on=false and so skips the guard.
+                m_transmitModel.stopTune();
+                return;
+            }
             m_backend->setTune(on);
             // A tune carrier is a transmission. Hl2Backend::setTune() calls
             // setKeying(), so the radio is on the air — the raw-TX edge has to
@@ -1884,6 +1895,19 @@ void RadioModel::sendSliceCommand(SliceModel* slice, const QString& cmd)
 
 QString RadioModel::localPttInterlockMessage(TransmitModel::PttSource source) const
 {
+    // Capability first, ahead of every other test including the DAX bypass
+    // below: a backend that reports it cannot transmit refuses the key under
+    // the seam, so letting the request run its optimistic path (Quindar intro,
+    // TX state, tune latch, the raw-TX edge) only builds a TX state the radio
+    // never entered. TransmitModel consults this from runPttPreflight(), which
+    // covers requestPttOn() — MOX, TCI hardware PTT, WSPR — and startTune().
+    // Guarded on m_backend so a torn-down model behaves exactly as before;
+    // setupBackend() otherwise guarantees one exists, and FlexBackend always
+    // reports canTransmit=true, so no Flex path changes.
+    if (m_backend && !backendCapabilities().canTransmit) {
+        return tr("This radio is receive-only and cannot transmit.");
+    }
+
     auto* s = txSlice();
     if (const QString message = transmitInhibitMessageForSlice(s);
         !message.isEmpty()) {
@@ -2470,6 +2494,33 @@ void RadioModel::rebootRadio()
 RadioCapabilities RadioModel::backendCapabilities() const
 {
     return m_backend ? m_backend->capabilities() : RadioCapabilities{};
+}
+
+// Shared key-on guard for the paths that do NOT go through setTransmit().
+//
+// setTransmit() refuses a key on a backend reporting canTransmit=false before
+// touching any state; MOX and TUNE reach the seam through
+// mox/tuneCommandIssued instead and had no such test. On an HL2 with the
+// automation TX gate closed, Hl2Backend::setKeying() logged "key refused" and
+// returned while this side still flipped m_radioTransmitting — so TciServer
+// broadcast trx:...,true; for a transmission that never happened, and its
+// "already transmitting" guard then rejected the next genuine TCI key. Nothing
+// on the air, and TCI keying dead until the flag cleared.
+//
+// Returns true when keying may proceed. On refusal it rolls the optimistic
+// transmit state back and raises the same interlock notification setTransmit()
+// uses, so the operator sees one consistent reason on every path.
+bool RadioModel::refuseKeyOnTransmitIncapableBackend()
+{
+    if (backendCapabilities().canTransmit)
+        return true;
+
+    emitInterlockNotification(
+        tr("This radio is receive-only and cannot transmit."),
+        QStringLiteral("rx-only-tx"),
+        txSlice() ? txSlice()->panId() : QString());
+    m_transmitModel.setTransmitting(false);
+    return false;
 }
 
 void RadioModel::setTransmit(bool tx, TransmitModel::PttSource source)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -761,6 +761,13 @@ public:
     bool sendCommand(const QString& cmd);
     // Backend family currently in use ("flex", "hl2", "kiwi", ...).
     QString family() const { return m_family; }
+    // True when the radio speaks the SmartSDR text-command plane — the only
+    // family where sendCmd() reaches anything and a command has a response to
+    // await. Every other backend takes typed intents through the IRadioBackend
+    // seam and settles synchronously in the model, so a caller that awaits a
+    // sendCmd() callback there waits forever. Callers that must work on both
+    // planes branch on this rather than on the family name.
+    bool usesFlexCommandPlane() const { return m_family == QLatin1String("flex"); }
     // Forward processed transmit audio to a host-modulating backend. No-op when
     // the backend modulates on the radio side.
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz);
@@ -1154,6 +1161,9 @@ private:
     // Recompute the operator-transmit predicate and emit operatorTransmitChanged
     // on a rising/falling edge. Cheap; safe to call from every TX-state path.
     void updateOperatorTransmit();
+    // Raw-TX edge for backends with no interlock status plane (HL2). No-op on
+    // Flex, where the edge is decoded from `interlock` status instead.
+    void publishBackendTransmitEdge(bool tx);
     bool interlockNotificationArmed() const;
     void emitInterlockNotification(const QString& message,
                                    const QString& key,

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1164,6 +1164,11 @@ private:
     // Raw-TX edge for backends with no interlock status plane (HL2). No-op on
     // Flex, where the edge is decoded from `interlock` status instead.
     void publishBackendTransmitEdge(bool tx);
+    // Key-on guard for the MOX/TUNE seam paths, which do not run through
+    // setTransmit() and therefore missed its canTransmit test. Returns true when
+    // keying may proceed; on refusal it rolls back the optimistic transmit state
+    // and notifies, so no raw-TX edge is ever published for a refused key.
+    bool refuseKeyOnTransmitIncapableBackend();
     bool interlockNotificationArmed() const;
     void emitInterlockNotification(const QString& message,
                                    const QString& key,

--- a/tests/hl2_rxdsp_rate_test.cpp
+++ b/tests/hl2_rxdsp_rate_test.cpp
@@ -36,8 +36,8 @@ static void check(bool cond, const char* what)
 
 static constexpr double kPi = 3.14159265358979323846;
 
-// Demodulate a +1 kHz tone at `rateHz` and return the peak |sample| of the
-// audio that came out.
+// Demodulate a tone 1 kHz above centre at `rateHz` and return the peak |sample|
+// of the audio that came out.
 static float demodPeakAt(int rateHz, std::size_t* outBlockSamples,
                          int* audioBlocks, std::string* err)
 {
@@ -67,7 +67,13 @@ static float demodPeakAt(int rateHz, std::size_t* outBlockSamples,
             peak = std::max(peak, std::abs(v));
     });
 
-    // 0.5 s of a +1 kHz tone, delivered as 126-sample EP6-shaped blocks.
+    // 0.5 s of a tone 1 kHz above centre, delivered as 126-sample EP6-shaped
+    // blocks — IN WIRE ORDER, note the NEGATIVE sine. The HPSDR wire is the
+    // conjugate of the analytic convention, so a signal above centre arrives as
+    // exp(-j.2.pi.f.t), and the demodulator is fed the raw wire (HERMES §16).
+    // The textbook exp(+j...) is synthetic IQ no HL2 ever sends, and against
+    // USB [150,3000] it is out of passband: this same generator produced
+    // audible audio only while the chain inverted every sideband.
     const double f = 1000.0;
     const int total = rateHz / 2;
     std::vector<std::complex<float>> blk;
@@ -75,7 +81,7 @@ static float demodPeakAt(int rateHz, std::size_t* outBlockSamples,
     for (int n = 0; n < total; ++n) {
         const double ph = 2.0 * kPi * f * n / rateHz;
         blk.emplace_back(0.3f * static_cast<float>(std::cos(ph)),
-                         0.3f * static_cast<float>(std::sin(ph)));
+                         0.3f * static_cast<float>(-std::sin(ph)));
         if (static_cast<int>(blk.size()) == kSamplesPerPacket) {
             dsp.processIqBlock(blk);
             blk.clear();

--- a/tests/hl2_rxdsp_test.cpp
+++ b/tests/hl2_rxdsp_test.cpp
@@ -71,7 +71,13 @@ int main(int argc, char** argv)
     QObject::connect(&dsp, &Hl2RxDsp::spectrumReady, &dsp,
                      [&](const std::vector<float>& bins) { ++specCount; lastBins = bins; });
 
-    // Feed a +1 kHz complex tone (in the USB passband) as 126-sample blocks.
+    // Feed a signal 1 kHz ABOVE centre, IN WIRE ORDER — note the NEGATIVE sine.
+    //
+    // The HPSDR wire is the conjugate of the analytic convention, so a signal
+    // above centre arrives as exp(-j.2.pi.f.t). This generator emitted the
+    // textbook exp(+j...) — synthetic IQ no HL2 ever sends — and both assertions
+    // below passed against a chain that mirrored the panadapter and inverted
+    // every demodulated sideband.
     const int fs = 48000;
     const double f = 1000.0;
     const int total = fs / 2;                 // ~0.5 s
@@ -80,7 +86,7 @@ int main(int argc, char** argv)
         const double ph = 2.0 * kPi * f * n / fs;
         stream[static_cast<std::size_t>(n)] =
             0.3f * std::complex<float>(static_cast<float>(std::cos(ph)),
-                                       static_cast<float>(std::sin(ph)));
+                                       static_cast<float>(-std::sin(ph)));
     }
     std::span<const std::complex<float>> s(stream);
     for (std::size_t off = 0; off < s.size(); off += kSamplesPerPacket) {
@@ -121,9 +127,10 @@ int main(int argc, char** argv)
         const double weakAmp = 0.3 * 0.01;          // -40 dB
         for (int n = 0; n < total; ++n) {
             const double ph = 2.0 * kPi * f * n / fs;
+            // Wire order, same convention as the strong tone above.
             stream[static_cast<std::size_t>(n)] =
                 std::complex<float>(static_cast<float>(weakAmp * std::cos(ph)),
-                                    static_cast<float>(weakAmp * std::sin(ph)));
+                                    static_cast<float>(-weakAmp * std::sin(ph)));
         }
         // Feed several seconds: RXA_S_PK decays rather than jumping, so a short
         // burst measures the decay slope instead of the settled level.

--- a/tests/hl2_shift_test.cpp
+++ b/tests/hl2_shift_test.cpp
@@ -16,6 +16,21 @@
 // appears at |delta| Hz of audio in LSB. So with the tone fixed relative to the
 // NCO and the slice moved UP by `offset`, the audio frequency must RISE by the
 // same amount.
+//
+// TWO conventions matter here and both were previously wrong, in ways that
+// cancelled and left this test passing against a broken chain:
+//
+//   Tone   is generated in WIRE order. The HPSDR wire is the CONJUGATE of the
+//          analytic convention, so a tone BELOW the NCO is exp(+j.w.t), not
+//          exp(-j.w.t). Feeding the textbook form meant this test's "800 Hz
+//          below" was really 800 Hz ABOVE.
+//   Shift  is what Hl2Backend actually sends, (slice - NCO). That sign is
+//          correct and unchanged; it only ever LOOKED wrong because it was
+//          validated in LSB, the one mode the conjugation bug made correct.
+//
+// Get either backwards and the stage looks correct while the radio mistunes by
+// twice the slice offset — the "DIGU is 3 kHz off" an operator sees at a
+// 1.5 kHz offset.
 
 #include "core/backends/hl2/Hl2RxDsp.h"
 
@@ -119,24 +134,24 @@ int main(int argc, char** argv)
 
     // Tone 800 Hz BELOW the NCO. With the slice on the NCO (shift 0) LSB should
     // put it at 800 Hz of audio.
-    const double base = runTone(dsp, -800.0, 0.0);
+    const double base = runTone(dsp, 800.0, 0.0);
     std::fprintf(stderr, "offset     0 Hz -> audio %.0f Hz (expect ~800)\n", base);
     check(std::fabs(base - 800.0) < 120.0, "tone lands at 800 Hz with no shift");
 
     // Move the slice 2 kHz ABOVE the NCO. The tone is now 2800 Hz below the
     // slice, so the audio frequency must RISE to ~2800.
-    const double up2k = runTone(dsp, -800.0, 2000.0);
-    std::fprintf(stderr, "offset +2000 Hz -> audio %.0f Hz (expect ~2800)\n", up2k);
+    const double up2k = runTone(dsp, 800.0, 2000.0);
+    std::fprintf(stderr, "slice +2000 Hz -> audio %.0f Hz (expect ~2800)\n", up2k);
     check(std::fabs(up2k - 2800.0) < 200.0, "slice +2 kHz moves the tone to 2800 Hz");
 
     // And 4 kHz above.
-    const double up4k = runTone(dsp, -800.0, 4000.0);
-    std::fprintf(stderr, "offset +4000 Hz -> audio %.0f Hz (expect ~4800)\n", up4k);
+    const double up4k = runTone(dsp, 800.0, 4000.0);
+    std::fprintf(stderr, "slice +4000 Hz -> audio %.0f Hz (expect ~4800)\n", up4k);
     check(std::fabs(up4k - 4800.0) < 250.0, "slice +4 kHz moves the tone to 4800 Hz");
 
     // Returning the slice to the NCO must return the tone to where it started —
     // the stage is not accumulating.
-    const double back = runTone(dsp, -800.0, 0.0);
+    const double back = runTone(dsp, 800.0, 0.0);
     std::fprintf(stderr, "offset     0 Hz -> audio %.0f Hz (expect ~800 again)\n", back);
     check(std::fabs(back - 800.0) < 120.0, "shift back to 0 restores the tone");
 

--- a/tests/hl2_shift_test.cpp
+++ b/tests/hl2_shift_test.cpp
@@ -77,9 +77,16 @@ static double dominantHz(const std::vector<float>& mono, int rate)
     return bestF;
 }
 
-// Feed a complex tone at `toneOffsetHz` relative to the NCO and return the
-// dominant audio frequency produced.
-static double runTone(Hl2RxDsp& dsp, double toneOffsetHz, double shiftHz)
+// Feed a complex tone and return the dominant audio frequency produced.
+//
+// `wireOffsetHz` is in WIRE sign, not analytic sign — the argument is used
+// directly as the phase increment of exp(j.w.t) fed to processIqBlock(), and the
+// HPSDR wire is the conjugate of the analytic convention (see the header note).
+// So a POSITIVE value here is a tone BELOW the NCO, which is why every call site
+// passes +800.0 for "800 Hz below". Read this parameter as "what the radio puts
+// on the wire", never as "offset from the NCO"; getting that backwards is the
+// exact trap this test exists to catch.
+static double runTone(Hl2RxDsp& dsp, double wireOffsetHz, double shiftHz)
 {
     dsp.setShift(shiftHz);
 
@@ -94,7 +101,7 @@ static double runTone(Hl2RxDsp& dsp, double toneOffsetHz, double shiftHz)
     constexpr int kWarmBlocks = 24;
     constexpr int kMeasureBlocks = 24;
     double phase = 0.0;
-    const double dp = 2.0 * kPi * toneOffsetHz / kInputRate;
+    const double dp = 2.0 * kPi * wireOffsetHz / kInputRate;
     for (int b = 0; b < kWarmBlocks + kMeasureBlocks; ++b) {
         std::vector<std::complex<float>> iq(kBlock);
         for (int k = 0; k < kBlock; ++k) {

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -69,12 +69,21 @@ static RadioInfo flexInfo()
 
 // Grants access to the private predicate that gates every DAX arrangement in
 // TciServer. Declared as a friend in TciServer.h.
+//
+// Guarded because TciServer.h is `#pragma once` followed immediately by
+// `#ifdef HAVE_WEBSOCKETS`, so it expands to NOTHING in a build configured
+// without Qt6WebSockets — naming TciServer out here failed to compile such a
+// build entirely. Everything else in this file (the transmit edge, the command
+// plane, host-modulated TX audio, the per-mode passband) is WebSocket-free and
+// deliberately still runs there.
+#ifdef HAVE_WEBSOCKETS
 class Hl2TciSignalingTest {
 public:
     static bool hostModulating(TciServer& server) {
         return server.hostModulatingBackend();
     }
 };
+#endif
 
 // ── The raw-TX edge TciServer waits on ────────────────────────────────────
 static void testTransmitEdgeIsPublished()
@@ -125,6 +134,33 @@ static void testMoxPathPublishesTheSameEdge()
           "HL2 MOX-off publishes radioTransmittingChanged(false)");
 }
 
+// TUNE is the third keying path, and the one a fix applied to the other two
+// silently misses. Hl2Backend::setTune() calls setKeying(), so a tune carrier
+// IS a transmission — and TciServer's "already transmitting" guard reads
+// isRadioTransmitting(), so leaving this edge unpublished let a TCI client key
+// on top of a live tune carrier and drop the key out from under it on unkey.
+static void testTunePathPublishesTheSameEdge()
+{
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+
+    QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+
+    // PttSource::Dax for the same reason the key test uses it: it is the one
+    // source localPttInterlockMessage() lets through with no TX slice assigned,
+    // and TCI/DAX-initiated tune is a real path (see TransmitModel::startTune).
+    model.transmitModel().startTune(TransmitModel::PttSource::Dax);
+    check(edges.size() == 1 && edges.first().first().toBool(),
+          "HL2 TUNE-on publishes radioTransmittingChanged(true)");
+    check(model.isRadioTransmitting(),
+          "a tune carrier counts as the radio transmitting");
+
+    model.transmitModel().stopTune();
+    check(edges.size() == 2 && !edges.at(1).first().toBool(),
+          "HL2 TUNE-off publishes radioTransmittingChanged(false)");
+    check(!model.isRadioTransmitting(), "tune release clears the TX state");
+}
+
 // On Flex the edge is decoded from `interlock` status. A second publisher here
 // would race the authoritative one and could report TX before the radio agreed.
 static void testFlexEdgeStaysInterlockOwned()
@@ -135,6 +171,7 @@ static void testFlexEdgeStaysInterlockOwned()
     QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
     model.setTransmit(true, TransmitModel::PttSource::Dax);
     model.transmitModel().setMox(true);
+    model.transmitModel().startTune(TransmitModel::PttSource::Dax);
     check(edges.isEmpty(),
           "Flex publishes no raw-TX edge from a command; interlock owns it");
 }
@@ -298,6 +335,7 @@ int main(int argc, char** argv)
 
     AetherSDR::testTransmitEdgeIsPublished();
     AetherSDR::testMoxPathPublishesTheSameEdge();
+    AetherSDR::testTunePathPublishesTheSameEdge();
     AetherSDR::testFlexEdgeStaysInterlockOwned();
     AetherSDR::testCommandPlanePredicate();
 #ifdef HAVE_WEBSOCKETS

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -1,0 +1,312 @@
+// TCI signaling on a backend that has neither a Flex command plane nor a DAX
+// data plane (Hermes-Lite 2), which is what WSJT-X needs to work.
+//
+// Three separate silent failures made TCI useless on such a radio. Each was
+// silent in its own way -- the WebSocket stayed up, the handshake completed,
+// and WSJT-X showed a connected rig throughout:
+//
+//   TX confirmation  TciServer treats RadioModel::radioTransmittingChanged as
+//                    the authoritative "the radio really keyed" edge and gives
+//                    up 1250 ms after a TCI key request that never sees one.
+//                    That signal is decoded from Flex `interlock` status, so on
+//                    an HL2 it never arrived: every WSJT-X transmission was
+//                    unkeyed a second and a quarter in, mid-tone.
+//
+//   TX audio         AudioEngine::feedDaxTxAudio returned immediately unless a
+//                    Flex TX stream id was set. A host-modulating backend has
+//                    none and never will -- its modulator is local -- so every
+//                    TCI audio frame was dropped and the radio transmitted
+//                    silence while reporting a perfectly normal transmit.
+//
+//   Command plane    Anything routed through sendCmdPublic() (the VFO tune) is
+//                    swallowed, AND its completion callback never runs, so
+//                    WSJT-X's 2 s vfo-echo timeout expired on every band hop.
+//
+// These assertions pin the seam, not the symptom: a future backend that reports
+// hostModulates or a non-Flex family inherits the same guarantees.
+
+#include "TestSettingsProfile.h"
+#include "core/AudioEngine.h"
+#include "core/backends/hl2/Hl2Backend.h"
+#include "core/RadioDiscovery.h"
+#include "core/TciServer.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "models/TransmitModel.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include <cstdio>
+
+namespace AetherSDR {
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static RadioInfo hl2Info()
+{
+    RadioInfo i;
+    i.family  = QStringLiteral("hl2");
+    i.serial  = QStringLiteral("00:1C:C0:00:00:01");
+    i.address = QHostAddress(QStringLiteral("192.0.2.1"));   // TEST-NET-1, unroutable
+    i.port    = 1024;
+    return i;
+}
+
+static RadioInfo flexInfo()
+{
+    RadioInfo i;
+    i.family  = QStringLiteral("flex");
+    i.serial  = QStringLiteral("1234-5678-9012-3456");
+    i.address = QHostAddress(QStringLiteral("192.0.2.2"));
+    i.port    = 4992;
+    return i;
+}
+
+// Grants access to the private predicate that gates every DAX arrangement in
+// TciServer. Declared as a friend in TciServer.h.
+class Hl2TciSignalingTest {
+public:
+    static bool hostModulating(TciServer& server) {
+        return server.hostModulatingBackend();
+    }
+};
+
+// ── The raw-TX edge TciServer waits on ────────────────────────────────────
+static void testTransmitEdgeIsPublished()
+{
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+
+    QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+
+    // Exactly the call TciServer::handleTrxRequest makes for a WSJT-X key.
+    // PttSource::Dax is what lets it through the local interlock preflight with
+    // no slice assigned, so this reaches the seam on a link-less model.
+    model.setTransmit(true, TransmitModel::PttSource::Dax);
+    check(edges.size() == 1, "HL2 key publishes one radioTransmittingChanged");
+    check(!edges.isEmpty() && edges.first().first().toBool(),
+          "HL2 key publishes radioTransmittingChanged(true)");
+    check(model.isRadioTransmitting(), "HL2 key leaves isRadioTransmitting() true");
+
+    // Idempotent: a repeat request is not a new edge, or clients would see a
+    // fresh transmit session for every duplicate WSJT-X trx:true.
+    model.setTransmit(true, TransmitModel::PttSource::Dax);
+    check(edges.size() == 1, "a repeated HL2 key does not republish the edge");
+
+    model.setTransmit(false, TransmitModel::PttSource::Dax);
+    check(edges.size() == 2, "HL2 unkey publishes a second edge");
+    check(edges.size() == 2 && !edges.at(1).first().toBool(),
+          "HL2 unkey publishes radioTransmittingChanged(false)");
+    check(!model.isRadioTransmitting(), "HL2 unkey leaves isRadioTransmitting() false");
+}
+
+// The MOX button and the PTT coordinator key through moxCommandIssued, NOT
+// through setTransmit(). A fix applied to only one of the two leaves a TCI
+// client blind to operator-initiated transmits -- which is the shape of bug
+// that passes every bridge test and fails on the real button.
+static void testMoxPathPublishesTheSameEdge()
+{
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+
+    QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+
+    model.transmitModel().setMox(true);
+    check(edges.size() == 1 && edges.first().first().toBool(),
+          "HL2 MOX-on publishes radioTransmittingChanged(true)");
+
+    model.transmitModel().setMox(false);
+    check(edges.size() == 2 && !edges.at(1).first().toBool(),
+          "HL2 MOX-off publishes radioTransmittingChanged(false)");
+}
+
+// On Flex the edge is decoded from `interlock` status. A second publisher here
+// would race the authoritative one and could report TX before the radio agreed.
+static void testFlexEdgeStaysInterlockOwned()
+{
+    RadioModel model;
+    model.connectToRadio(flexInfo());
+
+    QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+    model.setTransmit(true, TransmitModel::PttSource::Dax);
+    model.transmitModel().setMox(true);
+    check(edges.isEmpty(),
+          "Flex publishes no raw-TX edge from a command; interlock owns it");
+}
+
+// ── Which command plane the radio speaks ──────────────────────────────────
+static void testCommandPlanePredicate()
+{
+    RadioModel model;
+    check(model.usesFlexCommandPlane(),
+          "a default (Flex) model speaks the Flex command plane");
+
+    model.connectToRadio(hl2Info());
+    check(!model.usesFlexCommandPlane(),
+          "HL2 does not speak the Flex command plane");
+    check(model.panStream() == nullptr,
+          "HL2 has no PanadapterStream, hence no DAX data plane");
+
+    model.connectToRadio(flexInfo());
+    check(model.usesFlexCommandPlane(),
+          "round-trip: Flex speaks the Flex command plane again");
+}
+
+#ifdef HAVE_WEBSOCKETS
+// The predicate that keeps prepareTxAudio() from arranging a radio-side DAX TX
+// route on a radio that has no such thing.
+static void testTciSeesHostModulation()
+{
+    RadioModel model;
+    TciServer server(&model);
+    check(!Hl2TciSignalingTest::hostModulating(server),
+          "Flex modulates on-radio: TCI arranges the DAX TX route");
+
+    model.connectToRadio(hl2Info());
+    check(Hl2TciSignalingTest::hostModulating(server),
+          "HL2 host-modulates: TCI skips the Flex DAX TX route entirely");
+}
+#endif
+
+// ── TCI TX audio reaching a local modulator ───────────────────────────────
+static void testHostModulatedTxAudio()
+{
+    AudioEngine audio;
+
+    // The exact frame TciServer hands over: float32 interleaved stereo at
+    // 24 kHz, already gain- and overflow-processed, L == R (WSJT-X duplicates).
+    constexpr int kFrames = 8;
+    QByteArray in(kFrames * 2 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* f = reinterpret_cast<float*>(in.data());
+    for (int n = 0; n < kFrames; ++n) {
+        const float v = 0.25f * static_cast<float>(n - 4);   // spans negative and positive
+        f[2 * n]     = v;
+        f[2 * n + 1] = v;
+    }
+
+    // ---- Flex, no TX stream: nothing goes anywhere (unchanged behavior) ----
+    {
+        QSignalSpy monitor(&audio, &AudioEngine::txFinalMonitorPcmReady);
+        QSignalSpy packets(&audio, &AudioEngine::txPacketReady);
+        audio.setHostModulation(false);
+        audio.feedDaxTxAudio(in);
+        check(monitor.isEmpty() && packets.isEmpty(),
+              "no TX stream and no host modulation: TCI audio is dropped");
+    }
+
+    // ---- Host-modulating backend: the local modulator gets it ----
+    QSignalSpy monitor(&audio, &AudioEngine::txFinalMonitorPcmReady);
+    QSignalSpy packets(&audio, &AudioEngine::txPacketReady);
+    audio.setHostModulation(true);
+    audio.feedDaxTxAudio(in);
+
+    check(monitor.size() == 1,
+          "host modulation: TCI audio reaches the final-monitor tap");
+    check(packets.isEmpty(),
+          "host modulation: no VITA-49 packet is built (there is no stream)");
+    if (monitor.isEmpty())
+        return;
+
+    // MainWindow routes that tap to RadioModel::submitTxAudio(), whose HL2
+    // implementation requires int16 interleaved stereo at 24 kHz and averages
+    // L/R. Stereo must survive, or the averaging halves every sample.
+    const QByteArray out = monitor.first().first().toByteArray();
+    check(out.size() == kFrames * 2 * static_cast<int>(sizeof(qint16)),
+          "host modulation: output is int16 STEREO, one sample per input sample");
+
+    const auto* o = reinterpret_cast<const qint16*>(out.constData());
+    bool converted = true;
+    for (int n = 0; n < kFrames; ++n) {
+        const qint16 want = static_cast<qint16>(f[2 * n] * 32768.0f);
+        if (o[2 * n] != want || o[2 * n + 1] != want)
+            converted = false;
+    }
+    check(converted, "host modulation: float32 -> int16 is a plain full-scale map");
+}
+
+// ── Per-mode default passband ─────────────────────────────────────────────
+// WSJT-X selects DIGU. Before this table the HL2's passband was simply sticky,
+// so arriving at DIGU from CW handed the decoder a ~500 Hz window and it
+// decoded nothing -- with the mode visibly correct, which is what made it hard
+// to see. A radio that owns its DSP echoes a mode-appropriate filter and heals
+// this; we own the DSP, so nothing does.
+static void testModeDefaultPassband()
+{
+    hl2::Hl2Backend backend;
+
+    int low = 0, high = 0;
+    int deltas = 0;
+    QObject::connect(&backend, &IRadioBackend::sliceChanged, &backend,
+                     [&](int, const SliceDelta& d) {
+        if (d.filterLow)  low  = *d.filterLow;
+        if (d.filterHigh) high = *d.filterHigh;
+        ++deltas;
+    });
+
+    // Arrive at DIGU from CW, the case that broke: a CW-width filter must not
+    // survive into the mode the decoder runs in.
+    backend.setSliceMode(0, QStringLiteral("CWU"));
+    const int cwWidth = high - low;
+    check(cwWidth > 0 && cwWidth <= 900,
+          "CWU gets a CW-width passband, not the SSB default");
+
+    // "CW" is the spelling TciProtocol produces for TCI's `cw` and the one a
+    // Flex reports; only "CWU" was recognised, so plain CW silently landed on
+    // the USB fallback -- right mode indicator, wrong detector and passband.
+    backend.setSliceMode(0, QStringLiteral("USB"));
+    backend.setSliceMode(0, QStringLiteral("CW"));
+    check(high - low <= 900, "plain \"CW\" is CW, not the USB fallback");
+
+    backend.setSliceMode(0, QStringLiteral("DIGU"));
+    check(low > 0 && high > 0, "DIGU passband is upper-sideband (both bounds positive)");
+    check(high - low >= 2500,
+          "DIGU passband is wide enough for WSJT-X's 3 kHz decode window");
+
+    // DIGL is the mirror. A positive passband here is the bug SliceModel's
+    // polarity normalizer would silently paper over, so assert the sign.
+    backend.setSliceMode(0, QStringLiteral("DIGL"));
+    check(low < 0 && high < 0, "DIGL passband is lower-sideband (both bounds negative)");
+    check(high - low >= 2500, "DIGL passband is as wide as DIGU");
+
+    // AM straddles the carrier -- an envelope detector fed a one-sided passband
+    // is detecting a suppressed-carrier signal and sounds distorted, not silent.
+    backend.setSliceMode(0, QStringLiteral("AM"));
+    check(low < 0 && high > 0, "AM passband straddles the carrier");
+
+    // An operator's own filter edit must survive until the NEXT mode change,
+    // or every deliberate narrowing would be undone by a repeated mode set.
+    backend.setSliceMode(0, QStringLiteral("DIGU"));
+    backend.setSliceFilter(0, 500, 2000);
+    backend.setSliceMode(0, QStringLiteral("DIGU"));
+    check(low == 500 && high == 2000,
+          "re-selecting the SAME mode leaves an operator filter edit alone");
+}
+
+}  // namespace AetherSDR
+
+int main(int argc, char** argv)
+{
+    // Before QCoreApplication: AudioEngine and RadioModel both read AppSettings,
+    // and this test must not touch the operator's real configuration.
+    TestSettingsProfile profile(QStringLiteral("hl2-tci-signaling-test"));
+    QCoreApplication app(argc, argv);
+
+    AetherSDR::testTransmitEdgeIsPublished();
+    AetherSDR::testMoxPathPublishesTheSameEdge();
+    AetherSDR::testFlexEdgeStaysInterlockOwned();
+    AetherSDR::testCommandPlanePredicate();
+#ifdef HAVE_WEBSOCKETS
+    AetherSDR::testTciSeesHostModulation();
+#endif
+    AetherSDR::testHostModulatedTxAudio();
+    AetherSDR::testModeDefaultPassband();
+
+    if (AetherSDR::g_failures == 0)
+        std::fprintf(stderr, "hl2_tci_signaling_test: all checks passed\n");
+    return AetherSDR::g_failures == 0 ? 0 : 1;
+}

--- a/tests/hl2_tci_signaling_test.cpp
+++ b/tests/hl2_tci_signaling_test.cpp
@@ -29,6 +29,7 @@
 #include "core/AudioEngine.h"
 #include "core/backends/hl2/Hl2Backend.h"
 #include "core/RadioDiscovery.h"
+#include "core/TciProtocol.h"
 #include "core/TciServer.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
@@ -36,6 +37,9 @@
 
 #include <QCoreApplication>
 #include <QSignalSpy>
+#ifdef HAVE_WEBSOCKETS
+#include <QWebSocket>
+#endif
 
 #include <cstdio>
 
@@ -81,6 +85,48 @@ class Hl2TciSignalingTest {
 public:
     static bool hostModulating(TciServer& server) {
         return server.hostModulatingBackend();
+    }
+
+    // The route-transition latch and the deferral queue it feeds. A transition
+    // that is opened and never closed is the failure mode under test, and it is
+    // invisible from outside: the socket stays up and the handshake still works.
+    static bool routeTransitionInFlight(TciServer& s) {
+        return s.m_routeTransitionInFlight;
+    }
+    static bool hasPendingTrx(TciServer& s) { return s.m_pendingTrxRequest.has_value(); }
+    static bool splitRequested(TciServer& s) { return s.m_routingState.splitRequested(); }
+
+    static void trx(TciServer& s, QWebSocket* c, const TciProtocol::TrxRequest& r) {
+        s.handleTrxRequest(c, r);
+    }
+
+    // The VFO-B route builder itself. Driven directly rather than through
+    // handleSplitRequest()/handleVfoRequest(), because those resolve their RX
+    // slice via TciProtocol::resolveSliceForTrx(), which returns null on a model
+    // that is not connected to real hardware — every assertion below it would
+    // then pass without the code under test ever running.
+    static void createVfoB(TciServer& s, QWebSocket* c,
+                           const TciProtocol::VfoRequest& r, SliceModel* rx,
+                           const QString& routeConfirmation, bool splitOnly) {
+        s.createTxSliceForVfoB(c, r, rx, routeConfirmation, splitOnly);
+    }
+    static void setSplitRequested(TciServer& s, bool on) {
+        s.m_routingState.setSplitRequested(on);
+    }
+    static bool pendingVfoBCreate(TciServer& s) {
+        return s.m_pendingVfoBCreate.has_value();
+    }
+
+    // Runs promoteTxSliceAndContinue and reports whether the continuation ran at
+    // all — the distinction that matters, since a continuation that never runs
+    // strands its caller's route transition rather than failing it.
+    static void promote(TciServer& s, int sliceId, bool* answered, bool* selected) {
+        *answered = false;
+        *selected = false;
+        s.promoteTxSliceAndContinue(sliceId, [answered, selected](bool ok) {
+            *answered = true;
+            *selected = ok;
+        });
     }
 };
 #endif
@@ -207,6 +253,158 @@ static void testTciSeesHostModulation()
     model.connectToRadio(hl2Info());
     check(Hl2TciSignalingTest::hostModulating(server),
           "HL2 host-modulates: TCI skips the Flex DAX TX route entirely");
+}
+#endif
+
+// ── Refusing to key, without faking a transmit ────────────────────────────
+//
+// setTransmit() refuses a key on a backend reporting canTransmit=false. MOX and
+// TUNE do not go through it -- they reach the seam through mox/tuneCommandIssued
+// -- and had no such test, so with the HL2 transmit gate closed the backend
+// logged "key refused" and returned while this side published the raw-TX edge
+// anyway. TciServer then broadcast trx:...,true; for a transmission that never
+// happened, and its "already transmitting" guard rejected the next genuine TCI
+// key: nothing on the air, and TCI keying dead until the flag cleared.
+static void testRefusedKeyPublishesNoTransmitEdge()
+{
+    // Reproduce the gate the way the product closes it: an automation run with
+    // no ALLOW_TX. Hl2Backend decides m_txAllowed once, in its constructor, so
+    // the environment has to be set before the backend is built.
+    qputenv("AETHER_AUTOMATION", "1");
+    qunsetenv("AETHER_AUTOMATION_ALLOW_TX");
+
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+    check(!model.backendCapabilities().canTransmit,
+          "fixture precondition: the HL2 transmit gate is closed");
+
+    QSignalSpy edges(&model, &RadioModel::radioTransmittingChanged);
+
+    model.transmitModel().setMox(true);
+    check(edges.isEmpty(), "a refused MOX publishes no raw-TX edge");
+    check(!model.isRadioTransmitting(),
+          "a refused MOX leaves isRadioTransmitting() false");
+    check(!model.transmitModel().isTransmitting(),
+          "a refused MOX rolls back the optimistic MOX state");
+
+    // TUNE is the path a fix applied only to MOX would miss, and the one that
+    // latches: TransmitModel sets m_tune before the seam ever refuses.
+    model.transmitModel().startTune(TransmitModel::PttSource::Dax);
+    check(edges.isEmpty(), "a refused TUNE publishes no raw-TX edge");
+    check(!model.transmitModel().isTuning(),
+          "a refused TUNE does not leave the TUNE button latched on");
+
+    // The TCI hardware-PTT path. It keys through requestPttOn() -> setMox(),
+    // so it is refused in the preflight before any optimistic state is built.
+    model.transmitModel().requestPttOn(TransmitModel::PttSource::TciHardware);
+    check(edges.isEmpty(), "a refused TCI hardware PTT publishes no raw-TX edge");
+    check(!model.transmitModel().isTransmitting(),
+          "a refused TCI hardware PTT does not report a transmit");
+
+    qunsetenv("AETHER_AUTOMATION");
+}
+
+#ifdef HAVE_WEBSOCKETS
+// ── VFO B / split on a radio that has neither ─────────────────────────────
+//
+// WSJT-X with Split = Rig (or Fake It) sends split_enable:0,true; before it
+// transmits. On a single-slice radio that resolves to RouteAction::Create,
+// which issued a Flex `slice create` -- swallowed by a radio that speaks HPSDR,
+// with a completion callback that therefore never ran. The route transition
+// opened around it never closed, and handleTrxRequest() defers every trx:true
+// while one is in flight, so WSJT-X could not transmit again for the rest of
+// the connection with the rig still showing connected throughout.
+//
+// The capacity check ahead of the create does NOT catch this: maxSlices() is
+// the model-string-derived Flex estimate, so a one-slice HL2 looks like it has
+// room to make a second.
+static void testSeamBackendCannotWedgeOnVfoB()
+{
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+
+    QString error;
+    if (!model.automationApplySliceFixture(0, QString(), &error)) {
+        check(false, "fixture precondition: a slice exists to route from");
+        std::fprintf(stderr, "  (%s)\n", qPrintable(error));
+        return;
+    }
+    // The HL2's single slice IS its transmitter (Hl2Backend publishes
+    // txSlice=true); the fixture seeds tx=0, so say so explicitly.
+    SliceDelta txFlag;
+    txFlag.txSlice = true;
+    model.slice(0)->applyChanges(txFlag);
+    check(model.maxSlices() > 1,
+          "fixture precondition: maxSlices() over-reports, so only the "
+          "command-plane guard can refuse the create");
+
+    TciServer server(&model);
+    QWebSocket client;
+
+    // What handleSplitRequest() does for WSJT-X's split_enable:0,true; once
+    // resolveVfoB() has returned RouteAction::Create: split already latched
+    // optimistically, the confirmation held back until the route exists.
+    Hl2TciSignalingTest::setSplitRequested(server, true);
+    Hl2TciSignalingTest::createVfoB(server, &client,
+                                    TciProtocol::VfoRequest{0, 1, 14074000},
+                                    model.slice(0),
+                                    QStringLiteral("split_enable:0,true;"), true);
+
+    check(!Hl2TciSignalingTest::routeTransitionInFlight(server),
+          "a refused VFO-B create leaves no route transition in flight");
+    check(!Hl2TciSignalingTest::pendingVfoBCreate(server),
+          "a refused VFO-B create leaves no create pending on a reply that "
+          "will never arrive");
+    check(!Hl2TciSignalingTest::splitRequested(server),
+          "a refused split is rolled back, not left half-armed");
+
+    // The whole point: the key that follows must not be deferred forever.
+    Hl2TciSignalingTest::trx(server, &client,
+                             TciProtocol::TrxRequest{0, true, QStringLiteral("tci")});
+    check(!Hl2TciSignalingTest::hasPendingTrx(server),
+          "the key after a refused split is handled, not queued behind a "
+          "transition that never ends");
+
+    // The plain channel-1 VFO route (WSJT-X's Fake It band hop) takes the same
+    // path with no split confirmation to withdraw.
+    Hl2TciSignalingTest::createVfoB(server, &client,
+                                    TciProtocol::VfoRequest{0, 1, 7074000},
+                                    model.slice(0), QString(), false);
+    check(!Hl2TciSignalingTest::routeTransitionInFlight(server),
+          "a refused VFO-B tune leaves no route transition in flight");
+}
+
+// promoteTxSliceAndContinue() has the same shape of trap: `slice set N tx=1` is
+// Flex text with no seam counterpart, and every caller opens a route transition
+// around it. A continuation that never runs strands that transition, so the
+// contract on a seam backend is to ANSWER -- false is fine, silence is not.
+static void testSeamBackendPromoteAlwaysAnswers()
+{
+    RadioModel model;
+    model.connectToRadio(hl2Info());
+
+    QString error;
+    if (!model.automationApplySliceFixture(0, QString(), &error)) {
+        check(false, "fixture precondition: a slice exists to promote");
+        return;
+    }
+    check(!model.slice(0)->isTxSlice(),
+          "fixture precondition: the slice is not already the TX slice");
+
+    TciServer server(&model);
+    bool answered = false, selected = false;
+    Hl2TciSignalingTest::promote(server, 0, &answered, &selected);
+    check(answered, "promoteTxSliceAndContinue answers on a seam backend");
+    check(!selected, "it answers 'not selected' -- there is no seam verb to promote");
+
+    // A slice that is ALREADY the TX slice still succeeds without a command:
+    // this is the path every HL2 TCI key takes, and it must not regress.
+    SliceDelta txFlag;
+    txFlag.txSlice = true;
+    model.slice(0)->applyChanges(txFlag);
+    Hl2TciSignalingTest::promote(server, 0, &answered, &selected);
+    check(answered && selected,
+          "an already-TX slice is selected with no command at all");
 }
 #endif
 
@@ -340,9 +538,14 @@ int main(int argc, char** argv)
     AetherSDR::testCommandPlanePredicate();
 #ifdef HAVE_WEBSOCKETS
     AetherSDR::testTciSeesHostModulation();
+    AetherSDR::testSeamBackendCannotWedgeOnVfoB();
+    AetherSDR::testSeamBackendPromoteAlwaysAnswers();
 #endif
     AetherSDR::testHostModulatedTxAudio();
     AetherSDR::testModeDefaultPassband();
+    // Last: it closes the HL2 transmit gate through the environment, and every
+    // test above needs it open.
+    AetherSDR::testRefusedKeyPublishesNoTransmitEdge();
 
     if (AetherSDR::g_failures == 0)
         std::fprintf(stderr, "hl2_tci_signaling_test: all checks passed\n");

--- a/tests/hl2_txdsp_test.cpp
+++ b/tests/hl2_txdsp_test.cpp
@@ -55,11 +55,19 @@ static std::vector<std::complex<float>> modulate(WdspChannel::Mode mode,
                                                  double toneHz, double amplitude,
                                                  double micGain, double seconds,
                                                  float* lastMicPeak = nullptr,
-                                                 bool alc = false)
+                                                 bool alc = false,
+                                                 const double* passband = nullptr)
 {
     Hl2TxDsp tx;
     Hl2TxDsp::Config cfg;
     cfg.mode = mode;
+    // Optional explicit passband. Hl2Backend pushes a sign-correct, mode-derived
+    // one; the struct default is a positive 300..2700 for every mode, so without
+    // this the sideband/passband interaction is never exercised at all.
+    if (passband) {
+        cfg.filterLowHz  = passband[0];
+        cfg.filterHighHz = passband[1];
+    }
     // ALC OFF by default in these tests. Every assertion below except the ALC's
     // own measures a fixed relationship between input and output, and an ALC
     // exists precisely to break fixed relationships.
@@ -145,6 +153,59 @@ int main(int argc, char** argv)
             check(upper > lower,
                   "LSB: wire-facing IQ puts energy on the UPPER side (conjugated)");
             check(-ratioDb > 30.0, "LSB: opposite sideband suppressed by >30 dB");
+        }
+    }
+
+    // ---- DIGU/DIGL transmit on the same sidebands as USB/LSB ----
+    //
+    // WSJT-X transmits in DIGU. These modes were never covered here, and the
+    // sideband is the whole question: an FT8 signal on the wrong sideband is
+    // both un-decodable and 3 kHz away from where the operator believes it is.
+    //
+    // Each is checked with the exact passband Hl2Backend now pushes for that
+    // mode, which is the combination that actually ships -- the assertions above
+    // only ever ran against the struct default, so the passband's effect on the
+    // sideband was untested until this block existed.
+    {
+        // POSITIVE for every mode. This is the TX convention, and it is the
+        // opposite of RX: here the MODE carries the sideband and the bandpass is
+        // an audio-domain magnitude. Feeding TX the RX table's signed pairs put
+        // LSB and DIGL on the upper sideband -- caught by this very block before
+        // it shipped, which is why the two tables are separate in Hl2Backend.
+        const double diguBand[2] = {150.0, 3000.0};
+        const double diglBand[2] = {150.0, 3000.0};
+        const double usbBand[2]  = {300.0, 2700.0};
+        const double lsbBand[2]  = {300.0, 2700.0};
+
+        struct Case { const char* name; WdspChannel::Mode mode; const double* band;
+                      bool wireUpper; };
+        // wireUpper mirrors the USB/LSB assertions above: the wire order is
+        // conjugated, so a USB-family mode lands on the LOWER wire bin.
+        const Case cases[] = {
+            {"USB",  WdspChannel::Mode::Usb,  usbBand,  false},
+            {"DIGU", WdspChannel::Mode::Digu, diguBand, false},
+            {"LSB",  WdspChannel::Mode::Lsb,  lsbBand,  true},
+            {"DIGL", WdspChannel::Mode::Digl, diglBand, true},
+        };
+
+        for (const Case& c : cases) {
+            const auto iq = modulate(c.mode, kTone, 0.5, 1.0, 1.0,
+                                     nullptr, false, c.band);
+            if (iq.empty()) {
+                check(false, "modulation produced IQ for this mode");
+                continue;
+            }
+            const double upper = binPower(iq, +kTone, kFsOut);
+            const double lower = binPower(iq, -kTone, kFsOut);
+            const double wanted = c.wireUpper ? upper : lower;
+            const double other  = c.wireUpper ? lower : upper;
+            const double suppDb = 20.0 * std::log10((wanted + 1e-12) / (other + 1e-12));
+            std::fprintf(stderr,
+                         "%-4s (passband %.0f..%.0f): +1kHz %.6f, -1kHz %.6f, "
+                         "suppression %.1f dB\n",
+                         c.name, c.band[0], c.band[1], upper, lower, suppDb);
+            check(wanted > other, "sideband is correct for this mode");
+            check(suppDb > 30.0, "opposite sideband suppressed by >30 dB");
         }
     }
 


### PR DESCRIPTION
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/8d17e807-48a5-40d9-adb0-e08ff4c969e5" />

Initial bring up of TCI data stack on Hermes Lite 2.

## What was broken

| | Why it was silent |
|---|---|
| **RX audio** | `wirePanStreamTciSinks()` binds TCI's audio feed to `PanadapterStream`, which an in-process backend doesn't have — so nothing was bound and TCI clients heard silence. |
| **TX confirmation** | `TciServer` waits on `RadioModel::radioTransmittingChanged` to confirm a TCI key, and gives up 1250 ms later. That edge is decoded from Flex `interlock` status and never arrived, so **every WSJT-X transmission was unkeyed a second and a quarter in, mid-tone**. |
| **TX audio** | `AudioEngine::feedDaxTxAudio` returned immediately unless a Flex TX stream id was set. A host-modulating backend has none and never will — its modulator is local. Every TCI audio frame was dropped and the radio transmitted silence while reporting a normal transmit. |
| **Tuning** | The VFO set went through `sendCmdPublic()`, which is swallowed on a seam backend *and* never runs its completion callback — so the band hop was dropped and WSJT-X's 2 s vfo-echo timeout expired on top of it. |

## What changed

- **RX audio** — route `RadioModel::backendAudioFrameReady` to `onDaxAudioReady()` on channel 1. The payload is already float32 stereo at 24 kHz, and the channel→TRX fallback maps 1 → trx 0, which is the whole mapping on a single-slice radio.
- **TX confirmation** — publish the raw-TX edge from our own keying command on a backend that has no status plane to be authoritative instead. Applied on **both** `setTransmit()` and the `moxCommandIssued` path, since the MOX button and PTT coordinator use only the latter.
- **TX audio** — hand it to the same final-monitor tap the microphone uses, which already routes to `submitTxAudio()`. Still a DSP bypass; these are pre-shaped digital tones.
- **Tuning** — drive the model instead of the wire; it routes through `IRadioBackend` and is authoritative on return.
- Skip the Flex DAX arrangements (`ensureDaxForTci`, the `dax=1` TX route) on a backend with no DAX plane, rather than emitting Flex text at a radio speaking HPSDR.

## Two mode-table bugs found while verifying

Both broke WSJT-X directly:

- **The HL2 passband was sticky across mode changes.** We own the DSP, so nothing echoes a mode-appropriate filter back the way a Flex does — arriving at DIGU from CW handed the decoder a ~500 Hz window. Added a per-mode default passband, applied on *change* only so an operator's own filter edit survives (oracle addendum 2 §B3: *"All clients tie default filter width to mode, with user overrides"*).
- **`modeFromString` knew `"CWU"` but not `"CW"`** — the spelling `TciProtocol` produces for TCI's `cw`, and the one a Flex reports. Plain CW fell through to the USB fallback and was demodulated as SSB, with the mode indicator reading CW. `NFM` was missing for the same reason.

## Verification — live Hermes-Lite 2 (`00:1C:C0:A2:13:DD`)

Driven by a stdlib-only TCI client that shares no code with AetherSDR, so a convention error on both sides can't hide.

- **Handshake** — `trx_count:1`, one slice, one pan, every field WSJT-X reads present
- **RX audio** — 187 frames / 382,976 floats in 4 s (**previously zero**)
- **VFO set** — echoed in 15–39 ms, against a 2 s client timeout
- **Keying** — held the full 4 s with no spurious unkey (previously died at 1.25 s)
- **TX audio reaches the modulator** — forward-power counts peak at **1533 with audio vs 0–1 keyed silent**; TX FIFO steady at 26–30, no under/overflow. Confirmed in **DIGU**, the mode WSJT-X actually uses.
- **Per-mode passbands** — correct for `cw` / `digu` / `digl` / `usb` / `lsb` / `am` / `cwr`

TX testing was into a dummy load on 7.200, then DIGU, at 1% and 30% drive.

New `hl2_tci_signaling_test` covers the seam (edge publication on both keying paths, Flex staying interlock-owned, the command-plane predicate, host-modulated TX audio conversion, and the per-mode passband table). Full suite: 178/178.

## Known gaps

- `vfo_limits` still advertises the Flex `1000,75000000` rather than the HL2's real range — harmless for WSJT-X, worth making honest later.
- `tx_sensors` `mic_dbm` is inert on HL2: `micMetersChanged` carries the `MIC` meter and HL2 defines `MICPEAK`. Meter plumbing, not signaling.
- `RTTY` has no HL2 mode mapping and still falls back to USB; left alone rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)