### PR TITLE
Fix D-STAR waveform firewall setup and missing-input diagnostics

### DIFF
--- a/docs/WINDOWS-STORE-MSIX.md
+++ b/docs/WINDOWS-STORE-MSIX.md
@@ -65,8 +65,16 @@ Values that need maintainer choice:
   - `runFullTrust`: required for a packaged classic desktop app.
   - `internetClient`: needed for SmartLink, release metadata, propagation data,
     and other internet-backed features.
+  - `internetClientServer` is intentionally not declared. It does not create a
+    Windows Firewall exception for this medium-IL packaged desktop helper.
   - `privateNetworkClientServer`: needed for LAN radio/peripheral TCP and UDP.
   - `microphone`: recommended because AetherSDR captures PC mic audio for TX.
+- Desktop extension disclosure:
+  - [`windows.firewallRules`](https://learn.microsoft.com/windows/apps/desktop/modernize/desktop-to-uwp-extensions):
+    adds an all-profile inbound UDP exception scoped to
+    `aether-dv-waveform.exe`. Windows owns the packaged rule lifecycle, so
+    package installation and updates retain it and package removal deletes it
+    without a separate elevation prompt.
 
 ## Automation Plan
 

--- a/packaging/windows/create-msix.ps1
+++ b/packaging/windows/create-msix.ps1
@@ -373,8 +373,9 @@ $manifest = @"
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap uap10 rescap">
+  IgnorableNamespaces="uap uap10 desktop2 rescap">
   <Identity
     Name="$(Escape-Xml $PackageName)"
     Publisher="$(Escape-Xml $Publisher)"
@@ -410,6 +411,13 @@ $manifest = @"
       </uap:VisualElements>
     </Application>
   </Applications>
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules">
+      <desktop2:FirewallRules Executable="aether-dv-waveform.exe">
+        <desktop2:Rule Direction="in" IPProtocol="UDP" Profile="all" />
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -55,4 +55,10 @@ Name: "{group}\Uninstall AetherSDR"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\AetherSDR"; Filename: "{app}\AetherSDR.exe"; Tasks: desktopicon
 
 [Run]
+; Keep the established per-user install scope. Elevate only this program-scoped
+; firewall update, replacing any prior rule in one UAC operation.
+Filename: "{cmd}"; Parameters: "/D /C ""netsh advfirewall firewall delete rule name=""AetherSDR D-STAR Waveform RX"" >NUL 2>&1 & netsh advfirewall firewall add rule name=""AetherSDR D-STAR Waveform RX"" dir=in action=allow program=""{app}\aether-dv-waveform.exe"" enable=yes profile=any protocol=UDP"""; WorkingDir: "{sys}"; Verb: "runas"; StatusMsg: "Configuring Windows Firewall for D-STAR reception..."; Flags: shellexec runhidden waituntilterminated; Check: FileExists(ExpandConstant('{app}\aether-dv-waveform.exe'))
 Filename: "{app}\AetherSDR.exe"; Description: "Launch AetherSDR"; Flags: nowait postinstall skipifsilent
+
+[UninstallRun]
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""AetherSDR D-STAR Waveform RX"""; Verb: "runas"; Flags: shellexec runhidden waituntilterminated; RunOnceId: "RemoveDStarWaveformFirewallRule"

--- a/src/core/DigitalVoiceWaveformProcess.cpp
+++ b/src/core/DigitalVoiceWaveformProcess.cpp
@@ -61,6 +61,25 @@ DigitalVoiceWaveformProcess::DigitalVoiceWaveformProcess(QObject* parent)
     : QObject(parent)
 {
     m_process.setProcessChannelMode(QProcess::SeparateChannels);
+    m_rxStartupWatchdog.setSingleShot(true);
+    m_rxStartupWatchdog.setInterval(8000);
+
+    connect(&m_rxStartupWatchdog, &QTimer::timeout, this, [this] {
+        if (m_state != State::Running
+                || !m_registrationVerified
+                || m_metrics.valid
+                || !DigitalVoiceModeRegistry::instance().activeClaim().has_value()) {
+            return;
+        }
+        setHealth(DigitalVoiceWaveformHealth::NoInput);
+        emit degradationStarted(healthDetail());
+        qCWarning(lcWaveform)
+            << "DigitalVoiceWaveformProcess: registered D-STAR helper received no waveform UDP";
+    });
+    connect(&DigitalVoiceModeRegistry::instance(),
+            &DigitalVoiceModeRegistry::activeSliceChanged,
+            this,
+            [this](int) { updateRxStartupWatchdog(); });
 
     connect(&m_process, &QProcess::started, this, [this] {
         setState(State::Starting, tr("Registering %1")
@@ -127,6 +146,7 @@ QString DigitalVoiceWaveformProcess::healthName(DigitalVoiceWaveformHealth healt
     case DigitalVoiceWaveformHealth::Inactive:        return QStringLiteral("Inactive");
     case DigitalVoiceWaveformHealth::Measuring:       return QStringLiteral("Measuring");
     case DigitalVoiceWaveformHealth::Healthy:         return QStringLiteral("Healthy");
+    case DigitalVoiceWaveformHealth::NoInput:         return QStringLiteral("No waveform data");
     case DigitalVoiceWaveformHealth::CadenceDegraded: return QStringLiteral("Cadence degraded");
     case DigitalVoiceWaveformHealth::TransportLoss:   return QStringLiteral("Transport loss");
     case DigitalVoiceWaveformHealth::SourceDeficits:  return QStringLiteral("Source deficits");
@@ -137,6 +157,16 @@ QString DigitalVoiceWaveformProcess::healthName(DigitalVoiceWaveformHealth healt
 QString DigitalVoiceWaveformProcess::healthDetail() const
 {
     switch (m_health) {
+    case DigitalVoiceWaveformHealth::NoInput:
+#if defined(Q_OS_WIN)
+        return tr("No D-STAR waveform data is reaching the helper. "
+                  "Check Windows Defender Firewall and the radio network path, "
+                  "then restart the D-STAR service.");
+#else
+        return tr("No D-STAR waveform data is reaching the helper. "
+                  "Check the host firewall and radio network path, then restart "
+                  "the D-STAR service.");
+#endif
     case DigitalVoiceWaveformHealth::CadenceDegraded:
         return tr("D-STAR waveform delivery is degraded (%1 of 24.00 ksps). "
                   "Other active radio clients may be consuming radio resources.")
@@ -491,6 +521,7 @@ void DigitalVoiceWaveformProcess::processLines(const QList<QByteArray>& lines)
             m_registrationVerified = true;
             setState(State::Running, tr("Running"));
             setHealth(DigitalVoiceWaveformHealth::Measuring);
+            updateRxStartupWatchdog();
             continue;
         }
 
@@ -608,6 +639,7 @@ void DigitalVoiceWaveformProcess::updateMetrics(DigitalVoiceWaveformMetrics metr
         return;
     }
 
+    m_rxStartupWatchdog.stop();
     metrics.timestampMs = nowMs;
     m_vitaSequenceGapsTotal = saturatedAdd(
         m_vitaSequenceGapsTotal, metrics.vitaSequenceGaps);
@@ -661,6 +693,7 @@ void DigitalVoiceWaveformProcess::updateMetrics(DigitalVoiceWaveformMetrics metr
 
 void DigitalVoiceWaveformProcess::resetTelemetry(bool advanceGeneration)
 {
+    m_rxStartupWatchdog.stop();
     const bool hadMetrics = m_metrics.valid || m_metrics.txValid;
     const bool hadHealth = m_health != DigitalVoiceWaveformHealth::Inactive;
     if (advanceGeneration) {
@@ -701,6 +734,24 @@ void DigitalVoiceWaveformProcess::setHealth(DigitalVoiceWaveformHealth health)
     }
     m_health = health;
     emit healthChanged();
+}
+
+void DigitalVoiceWaveformProcess::updateRxStartupWatchdog()
+{
+    const bool shouldWatch = m_state == State::Running
+        && m_registrationVerified
+        && !m_metrics.valid
+        && DigitalVoiceModeRegistry::instance().activeClaim().has_value();
+    if (shouldWatch) {
+        m_rxStartupWatchdog.start();
+    } else {
+        m_rxStartupWatchdog.stop();
+        if (m_health == DigitalVoiceWaveformHealth::NoInput
+                && m_state == State::Running
+                && !m_metrics.valid) {
+            setHealth(DigitalVoiceWaveformHealth::Measuring);
+        }
+    }
 }
 
 } // namespace AetherSDR

--- a/src/core/DigitalVoiceWaveformProcess.h
+++ b/src/core/DigitalVoiceWaveformProcess.h
@@ -7,8 +7,11 @@
 #include <QObject>
 #include <QProcess>
 #include <QString>
+#include <QTimer>
 
 namespace AetherSDR {
+
+class DigitalVoiceWaveformProcessTestAccess;
 
 class DigitalVoiceWaveformProcess : public QObject
 {
@@ -59,6 +62,8 @@ signals:
     void sliceRestoreRequested(int sliceId, const QString& previousMode);
 
 private:
+    friend class DigitalVoiceWaveformProcessTestAccess;
+
     explicit DigitalVoiceWaveformProcess(QObject* parent = nullptr);
 
     void setState(State state, const QString& statusText = {});
@@ -72,8 +77,10 @@ private:
     void updateMetrics(DigitalVoiceWaveformMetrics metrics);
     void resetTelemetry(bool advanceGeneration);
     void setHealth(DigitalVoiceWaveformHealth health);
+    void updateRxStartupWatchdog();
 
     QProcess m_process;
+    QTimer m_rxStartupWatchdog;
     State m_state{State::Stopped};
     QString m_statusText;
     QString m_lastError;

--- a/src/core/DigitalVoiceWaveformTelemetry.cpp
+++ b/src/core/DigitalVoiceWaveformTelemetry.cpp
@@ -52,7 +52,8 @@ bool parseBoundedUnsigned(const QHash<QByteArray, QByteArray>& fields,
 
 bool isDegradedDigitalVoiceWaveformHealth(DigitalVoiceWaveformHealth health)
 {
-    return health == DigitalVoiceWaveformHealth::CadenceDegraded
+    return health == DigitalVoiceWaveformHealth::NoInput
+        || health == DigitalVoiceWaveformHealth::CadenceDegraded
         || health == DigitalVoiceWaveformHealth::TransportLoss
         || health == DigitalVoiceWaveformHealth::SourceDeficits;
 }

--- a/src/core/DigitalVoiceWaveformTelemetry.h
+++ b/src/core/DigitalVoiceWaveformTelemetry.h
@@ -11,6 +11,7 @@ enum class DigitalVoiceWaveformHealth {
     Inactive,
     Measuring,
     Healthy,
+    NoInput,
     CadenceDegraded,
     TransportLoss,
     SourceDeficits

--- a/src/gui/DStarModemPage.cpp
+++ b/src/gui/DStarModemPage.cpp
@@ -756,14 +756,19 @@ void DStarModemPage::refreshService()
     const bool active = model.serviceActive();
     const bool stopping = model.serviceStopping();
     const QString state = model.serviceStateName();
+    const QString health = model.serviceHealthName();
     const QString detail = !model.serviceHealthDetail().isEmpty()
         ? model.serviceHealthDetail()
         : model.serviceStatusText();
 
-    m_serviceState->setText(state);
+    const bool noWaveformData = state == QLatin1String("Running")
+        && health == QLatin1String("No waveform data");
+    m_serviceState->setText(noWaveformData ? tr("No RX UDP") : state);
     m_serviceState->setToolTip(detail);
     m_serviceDot->setToolTip(detail.isEmpty() ? state : detail);
-    if (state == QLatin1String("Running")) {
+    if (noWaveformData) {
+        m_serviceDot->setStyleSheet(QStringLiteral("background:#d2ad74;"));
+    } else if (state == QLatin1String("Running")) {
         m_serviceDot->setStyleSheet(QStringLiteral("background:#64d36e;"));
     } else if (state == QLatin1String("Failed")) {
         m_serviceDot->setStyleSheet(QStringLiteral("background:#d2ad74;"));
@@ -795,7 +800,7 @@ void DStarModemPage::refreshService()
         sliceText = tr("No DSTR slice");
     }
     updateDStarSliceStateLabel(m_sliceState, sliceText);
-    m_footerState->setText(state.toUpper());
+    m_footerState->setText(noWaveformData ? tr("NO RX UDP") : state.toUpper());
 }
 
 void DStarModemPage::refreshConfiguration()

--- a/tests/digital_voice_waveform_process_test.cpp
+++ b/tests/digital_voice_waveform_process_test.cpp
@@ -24,6 +24,35 @@ using AetherSDR::DigitalVoiceWaveformHistoryTracker;
 using AetherSDR::DigitalVoiceModeId;
 using AetherSDR::DigitalVoiceModeRegistry;
 
+namespace AetherSDR {
+
+class DigitalVoiceWaveformProcessTestAccess
+{
+public:
+    static void resetTelemetry(DigitalVoiceWaveformProcess& process)
+    {
+        process.resetTelemetry(false);
+    }
+
+    static void armRxStartupWatchdog(DigitalVoiceWaveformProcess& process)
+    {
+        process.m_rxStartupWatchdog.start();
+    }
+
+    static bool rxStartupWatchdogActive(const DigitalVoiceWaveformProcess& process)
+    {
+        return process.m_rxStartupWatchdog.isActive();
+    }
+
+    static void updateMetrics(DigitalVoiceWaveformProcess& process,
+                              DigitalVoiceWaveformMetrics metrics)
+    {
+        process.updateMetrics(metrics);
+    }
+};
+
+} // namespace AetherSDR
+
 namespace {
 
 int g_failed = 0;
@@ -49,6 +78,12 @@ int main(int argc, char** argv)
     report("stateName: failed",
            DigitalVoiceWaveformProcess::stateName(DigitalVoiceWaveformProcess::State::Failed)
                == QStringLiteral("Failed"));
+    report("healthName: missing waveform input",
+           DigitalVoiceWaveformProcess::healthName(DigitalVoiceWaveformHealth::NoInput)
+               == QStringLiteral("No waveform data"));
+    report("health classification: missing waveform input is degraded",
+           AetherSDR::isDegradedDigitalVoiceWaveformHealth(
+               DigitalVoiceWaveformHealth::NoInput));
 
     report("resolveExecutablePath: trims configured path",
            DigitalVoiceWaveformProcess::resolveExecutablePath(QStringLiteral("  /tmp/aether-dv-waveform  "))
@@ -349,6 +384,29 @@ int main(int argc, char** argv)
 
     DigitalVoiceWaveformProcess& process = DigitalVoiceWaveformProcess::instance();
     process.stop();
+    AetherSDR::DigitalVoiceWaveformProcessTestAccess::resetTelemetry(process);
+    AetherSDR::DigitalVoiceWaveformProcessTestAccess::armRxStartupWatchdog(process);
+    DigitalVoiceWaveformMetrics txFirstMetrics;
+    txFirstMetrics.direction = DigitalVoiceWaveformMetricDirection::Tx;
+    txFirstMetrics.txSampleRateHz = 24000.0;
+    AetherSDR::DigitalVoiceWaveformProcessTestAccess::updateMetrics(
+        process, txFirstMetrics);
+    report("RX startup watchdog: TX-first telemetry keeps watchdog armed",
+           AetherSDR::DigitalVoiceWaveformProcessTestAccess::
+               rxStartupWatchdogActive(process)
+               && !process.metrics().valid
+               && process.metrics().txValid);
+    DigitalVoiceWaveformMetrics firstRxMetrics;
+    firstRxMetrics.direction = DigitalVoiceWaveformMetricDirection::Rx;
+    firstRxMetrics.rxSampleRateHz = 24000.0;
+    AetherSDR::DigitalVoiceWaveformProcessTestAccess::updateMetrics(
+        process, firstRxMetrics);
+    report("RX startup watchdog: first RX telemetry disarms watchdog",
+           !AetherSDR::DigitalVoiceWaveformProcessTestAccess::
+               rxStartupWatchdogActive(process)
+               && process.metrics().valid);
+    AetherSDR::DigitalVoiceWaveformProcessTestAccess::resetTelemetry(process);
+
     const bool started = process.startForRadio(QHostAddress());
     report("startForRadio: null radio fails", !started);
     report("startForRadio: null radio sets failed state",


### PR DESCRIPTION
## Summary

Fixes #4317.

AetherSDR could start and register the D-STAR waveform helper successfully
while Windows silently blocked the helper's inbound UDP waveform traffic. The
classic installer did not provision a helper-scoped rule, and the Store/MSIX
manifest relied on `internetClientServer`, which does not create a firewall
exception for a medium-IL packaged desktop helper. The UI therefore continued
to show the service as running even though no D-STAR data or audio could reach
the decoder.

This change:

- keeps the classic installer per-user while elevating only a program-scoped,
  all-profile inbound UDP firewall update for `aether-dv-waveform.exe`, with
  uninstall cleanup;
- declares the Store rule through
  `desktop2:Extension Category="windows.firewallRules"`, retains
  `runFullTrust`, and removes the ineffective `internetClientServer`
  capability;
- adds an RX startup watchdog that reports `No RX UDP` when the registered
  helper receives no waveform data, without allowing TX telemetry to disarm
  the RX watchdog; and
- documents the Store capability and Windows-owned firewall-rule lifecycle.

For end users, both classic and Store installations now establish explicit
coverage for the actual helper executable, and the D-STAR page reports a
specific actionable state if waveform traffic still cannot arrive.

Reproduction:

1. Install AetherSDR on Windows without an inbound helper firewall rule.
2. Select a DSTR slice, start the D-STAR service, and transmit a strong D-STAR
   signal into the selected RX antenna.
3. Observe signal energy in the waterfall but no decoded data or audio.
4. Add an inbound UDP rule scoped to `aether-dv-waveform.exe` and retry.
5. Observe D-STAR decoding begin.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The missing-input path has focused
regression coverage, the generated MSIX manifest was validated by `makeappx`,
and the firewall-rule lifecycle was exercised through native Windows
install/update/uninstall and coexistence tests.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI) — focused local tests pass; CI pending
- [x] Reproduction steps documented if user-reported bug

Current-upstream local verification:

```bash
cmake --build build --target AetherSDR digital_voice_waveform_process_test digital_voice_slice_lifecycle_test dstar_model_test -j8
./build/digital_voice_waveform_process_test
./build/digital_voice_slice_lifecycle_test
./build/dstar_model_test
git diff --check
python3 tools/check_engine_boundary.py --strict
```

Native Windows validation of the patch was performed before the final
current-upstream refresh; the two intervening upstream commits did not touch
any file in this change:

- MSVC built and linked the application and helper.
- Inno Setup 6.7.3 compiled the classic per-user installer.
- `makeappx pack /v` generated and validated signed MSIX versions
  `26.7.3.100` and `26.7.3.101`.
- A limited-token install added the packaged inbound UDP rule without UAC.
- Updating to `.101` retained coverage and moved the rule to the updated
  WindowsApps helper path.
- Uninstall removed only the package-owned rule without UAC.
- A side-by-side classic per-user installation retained separate
  program-scoped coverage throughout package install, update, and uninstall.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not
      applicable; no meter UI changes
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable — not
      applicable; this is Windows application firewall provisioning
