### PR TITLE
Stabilize 3D FFT rear edge during delayed row arrivals

### DIFF
--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -113,12 +113,25 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
-    // Visibility follows the fixed grid age, not the interpolated sample age.
-    // Including remainingRows here makes the last row's opacity jump 1 -> 0
-    // whenever a delayed radio row restarts the scroll clock, so the apparent
-    // rear boundary moves forward and then back. Keep only unpopulated startup
-    // slots hidden; sampleHistoryDbm() still performs the smooth data advance.
+    // Rear visibility follows the fixed grid age, not the interpolated sample
+    // age — but only once the history is FULL.
+    //
+    // At steady state validRows is pinned at rows, so validRows - sourceAge is
+    // permanently 1 for the oldest slot: indistinguishable from a slot that has
+    // only just been populated. Subtracting the scroll advance there ramps that
+    // permanent row 0 -> 1 across every row interval and snaps it back on each
+    // arrival, which is the rear pulse (worst at slow presentation cadences,
+    // and it also disagreed with sampleHistoryDbm()'s un-advanced early-out).
+    //
+    // While history is still filling, a slot genuinely IS newly populated on
+    // each arrival, and for that one interval sampleHistoryDbm() clamps it to
+    // oldestRetainedAge — the same texture row its neighbour is already
+    // drawing. Subtracting the advance is what fades that duplicate curtain in
+    // instead of popping it opaque. So keep the term until validRows stops
+    // growing, after which nothing is ever newly populated again.
     float sourceAge = sourceV * rows;
-    float historyAvailability = clamp(validRows - sourceAge, 0.0, 1.0);
+    float fillFade = validRows < rows ? remainingRows : 0.0;
+    float historyAvailability = clamp(
+        validRows - sourceAge - fillFade, 0.0, 1.0);
     vBoundaryFade = historyAvailability;
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -113,13 +113,12 @@ void main()
     vLut = edge > 0.5 ? colorStrength * 0.6 : colorStrength;
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
-    // Hide only unpopulated startup slots. Advance the availability edge by
-    // remainingRows so the newest rear slot fades in continuously over the row
-    // interval instead of popping opaque on arrival (matching the height path's
-    // sub-row advance in sampleHistoryDbm). The rear six-row fade is
-    // deliberately gone: the perspective already supplies depth haze, and that
-    // fade left a visibly blurry band at the back of a full history.
-    float sampleAge = sourceV * rows + remainingRows;
-    float historyAvailability = clamp(validRows - sampleAge, 0.0, 1.0);
+    // Visibility follows the fixed grid age, not the interpolated sample age.
+    // Including remainingRows here makes the last row's opacity jump 1 -> 0
+    // whenever a delayed radio row restarts the scroll clock, so the apparent
+    // rear boundary moves forward and then back. Keep only unpopulated startup
+    // slots hidden; sampleHistoryDbm() still performs the smooth data advance.
+    float sourceAge = sourceV * rows;
+    float historyAvailability = clamp(validRows - sourceAge, 0.0, 1.0);
     vBoundaryFade = historyAvailability;
 }

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -175,15 +175,26 @@ inline bool dssFftScaleSettleActive(std::int64_t nowMs,
     return settleUntilMs > 0 && nowMs < settleUntilMs;
 }
 
-// The DSS boundary is phase-stable: availability is based on a fixed grid-row
-// age and must not include the scroll animation's remaining-row offset.
-inline float dssHistoryAvailability(float sourceAge, float validRows)
+// Mirror of dss_mesh.vert's rear-visibility edge; it must track the shader
+// exactly, including which regime the scroll advance participates in.
+//
+// Full history (validRows >= rows): phase-stable. validRows - sourceAge is
+// permanently 1 for the oldest slot, so subtracting the advance would pulse
+// that permanent row 0 -> 1 on every arrival rather than fading anything in.
+//
+// Still filling (validRows < rows): the newest slot really is newly populated
+// each arrival, and dssRetainedSampleAge() clamps it onto its neighbour's row
+// for that one interval, so the advance is what fades the duplicate in.
+inline float dssHistoryAvailability(float sourceAge, float validRows,
+                                    float rows, float remainingRows)
 {
     if (!std::isfinite(sourceAge) || !std::isfinite(validRows)
-        || validRows <= 0.0f) {
+        || !std::isfinite(rows) || !std::isfinite(remainingRows)
+        || validRows <= 0.0f || rows < 1.0f || remainingRows < 0.0f) {
         return 0.0f;
     }
-    return std::clamp(validRows - sourceAge, 0.0f, 1.0f);
+    const float fillFade = validRows < rows ? remainingRows : 0.0f;
+    return std::clamp(validRows - sourceAge - fillFade, 0.0f, 1.0f);
 }
 
 // Mirror of dss_mesh.vert sampleHistoryDbm()'s retained sample-age clamp, for

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -175,13 +175,15 @@ inline bool dssFftScaleSettleActive(std::int64_t nowMs,
     return settleUntilMs > 0 && nowMs < settleUntilMs;
 }
 
-inline float dssHistoryAvailability(float sampleAge, float validRows)
+// The DSS boundary is phase-stable: availability is based on a fixed grid-row
+// age and must not include the scroll animation's remaining-row offset.
+inline float dssHistoryAvailability(float sourceAge, float validRows)
 {
-    if (!std::isfinite(sampleAge) || !std::isfinite(validRows)
+    if (!std::isfinite(sourceAge) || !std::isfinite(validRows)
         || validRows <= 0.0f) {
         return 0.0f;
     }
-    return std::clamp(validRows - sampleAge, 0.0f, 1.0f);
+    return std::clamp(validRows - sourceAge, 0.0f, 1.0f);
 }
 
 // Mirror of dss_mesh.vert sampleHistoryDbm()'s retained sample-age clamp, for

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -211,15 +211,71 @@ int testDssFftScaleSettleWindow()
 int testDssStartupHistoryAvailability()
 {
     using namespace AetherSDR;
-    if (!nearlyEqual(dssHistoryAvailability(4.0f, 4.0f), 0.0)
-        || !nearlyEqual(dssHistoryAvailability(3.5f, 4.0f), 0.5)
-        || !nearlyEqual(dssHistoryAvailability(3.0f, 4.0f), 1.0)
-        || !nearlyEqual(dssHistoryAvailability(2.0f, 4.0f), 1.0)
-        || !nearlyEqual(dssHistoryAvailability(
-                            std::numeric_limits<float>::quiet_NaN(), 4.0f),
-                        0.0)
-        || !nearlyEqual(dssHistoryAvailability(0.0f, 0.0f), 0.0)) {
-        return fail("3D FFT startup history should fade in continuously");
+    // Grid ages are integral (sourceV * rows over a fixed grid) and validRows is
+    // an int row count, so at a FULL history availability is strictly binary:
+    // populated slots opaque, the rest hidden. No partial values are reachable.
+    constexpr float kRows = 96.0f;
+    if (!nearlyEqual(dssHistoryAvailability(96.0f, 96.0f, kRows, 0.0f), 0.0)
+        || !nearlyEqual(dssHistoryAvailability(95.0f, 96.0f, kRows, 0.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(94.0f, 96.0f, kRows, 0.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(0.0f, 96.0f, kRows, 0.0f), 1.0)) {
+        return fail("3D FFT rear visibility must be binary on a full history");
+    }
+    // Non-finite input and an empty history both fail closed to hidden.
+    if (!nearlyEqual(dssHistoryAvailability(
+                         std::numeric_limits<float>::quiet_NaN(), 96.0f,
+                         kRows, 0.0f),
+                     0.0)
+        || !nearlyEqual(dssHistoryAvailability(0.0f, 0.0f, kRows, 0.0f), 0.0)
+        || !nearlyEqual(dssHistoryAvailability(0.0f, 96.0f, kRows,
+                                              std::numeric_limits<float>::
+                                                  quiet_NaN()),
+                        0.0)) {
+        return fail("3D FFT rear visibility must fail closed on bad input");
+    }
+    // THE regression this guards (#4476): on a full history the oldest slot is
+    // permanently populated, so its opacity must not depend on where the scroll
+    // clock happens to be. Reinstating the advance term unconditionally makes
+    // this ramp 0 -> 1 and snap back on every delayed arrival — the rear pulse.
+    for (const float remainingRows : {0.0f, 0.25f, 0.5f, 1.0f, 3.0f}) {
+        if (!nearlyEqual(
+                dssHistoryAvailability(95.0f, 96.0f, kRows, remainingRows),
+                1.0)) {
+            return fail("3D FFT rear visibility must not pulse with scroll "
+                        "latency on a full history");
+        }
+    }
+    // While the history is still FILLING, the newest slot is genuinely new and
+    // dssRetainedSampleAge() clamps it onto its neighbour's row for one
+    // interval, so it must fade in over that interval rather than popping a
+    // duplicate curtain opaque. Dropping the advance term in this regime makes
+    // all three of these 1.0.
+    constexpr float kFilling = 10.0f;   // 10 of 96 rows populated
+    if (!nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 1.0f), 0.0)
+        || !nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 0.5f), 0.5)
+        || !nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 0.0f),
+                        1.0)) {
+        return fail("3D FFT newest rear slot must fade in while history fills");
+    }
+    // ...and only the newest slot fades: settled slots behind it stay opaque
+    // regardless of the scroll clock, and unpopulated ones stay hidden.
+    if (!nearlyEqual(dssHistoryAvailability(8.0f, kFilling, kRows, 1.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(0.0f, kFilling, kRows, 1.0f), 1.0)
+        || !nearlyEqual(dssHistoryAvailability(10.0f, kFilling, kRows, 0.0f),
+                        0.0)) {
+        return fail("3D FFT fill fade must apply only to the newest slot");
+    }
+    // The visibility edge and the height path must agree about what exists: on
+    // a full history a slot is visible exactly when it has a retained sample.
+    for (const float sourceAge : {0.0f, 1.0f, 94.0f, 95.0f, 96.0f, 97.0f}) {
+        const bool visible =
+            dssHistoryAvailability(sourceAge, 96.0f, kRows, 0.0f) > 0.0f;
+        const bool hasSample =
+            dssRetainedSampleAge(sourceAge, 0.0f, 96.0f, kRows).has_value();
+        if (visible != hasSample) {
+            return fail("3D FFT rear visibility must agree with the height "
+                        "path's valid-range early-out");
+        }
     }
     const std::optional<float> movingAge =
         dssRetainedSampleAge(94.0f, 0.5f, 96.0f, 96.0f);
@@ -230,13 +286,16 @@ int testDssStartupHistoryAvailability()
         || dssRetainedSampleAge(96.0f, 0.0f, 96.0f, 96.0f).has_value()) {
         return fail("3D FFT rear row should remain stable until eviction");
     }
-    for (const float remainingRows : {0.0f, 0.5f, 1.0f}) {
-        const std::optional<float> interpolatedAge =
+    // The oldest slot's SAMPLE age is clamped to oldestRetainedAge, so it holds
+    // still under any scroll phase — this is the clamp that also makes it
+    // duplicate its neighbour for one interval while the history fills, which
+    // is why the fill fade above exists.
+    for (const float remainingRows : {0.0f, 0.5f, 1.0f, 4.0f}) {
+        const std::optional<float> clampedAge =
             dssRetainedSampleAge(95.0f, remainingRows, 96.0f, 96.0f);
-        if (!interpolatedAge || !nearlyEqual(*interpolatedAge, 95.0)
-            || !nearlyEqual(dssHistoryAvailability(95.0f, 96.0f), 1.0)) {
-            return fail(
-                "3D FFT rear visibility must not reset with scroll latency");
+        if (!clampedAge || !nearlyEqual(*clampedAge, 95.0)) {
+            return fail("3D FFT oldest retained sample age must not move with "
+                        "scroll latency");
         }
     }
     // Fidelity to the shader's two clamps outside 1 <= validRows <= rows:

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -230,6 +230,15 @@ int testDssStartupHistoryAvailability()
         || dssRetainedSampleAge(96.0f, 0.0f, 96.0f, 96.0f).has_value()) {
         return fail("3D FFT rear row should remain stable until eviction");
     }
+    for (const float remainingRows : {0.0f, 0.5f, 1.0f}) {
+        const std::optional<float> interpolatedAge =
+            dssRetainedSampleAge(95.0f, remainingRows, 96.0f, 96.0f);
+        if (!interpolatedAge || !nearlyEqual(*interpolatedAge, 95.0)
+            || !nearlyEqual(dssHistoryAvailability(95.0f, 96.0f), 1.0)) {
+            return fail(
+                "3D FFT rear visibility must not reset with scroll latency");
+        }
+    }
     // Fidelity to the shader's two clamps outside 1 <= validRows <= rows:
     // validRows > rows caps to rows (oldest age = rows - 1, not validRows - 1);
     // 0 < validRows < 1 floors the oldest age at 0 rather than going negative.


### PR DESCRIPTION
## Summary

Follow-up to #4432 correcting a smooth-scroll visibility regression reintroduced during review. Stabilizes the outgoing edge of the 3D FFT when incoming FFT data is delayed.

The smooth-scroll shader used the interpolated sample age for both retained-data sampling and history visibility. When a delayed row arrived, restarting the scroll clock reset the oldest row's opacity from fully visible to hidden, making the rear boundary appear to jump forward and then back.

This change makes history visibility depend only on the fixed grid-row age while retaining phase-aware data interpolation. Palette, colors, geometry, and depth mapping are unchanged. A focused regression test covers the rear row at the beginning, middle, and end of the scroll phase.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The latency condition is covered by a focused phase-stability test and deterministic macOS automation-bridge verification.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [ ] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Additional verification:

- `spectrum_preview_logic_test` passes
- `dss_renderer_test` passes
- `tools/check_engine_boundary.py --strict` passes with no blocking findings
- macOS automation bridge filled all 96 visible 3D history rows, configured a six-second presentation interval, and injected a delayed row
- Settled and mid-scroll captures confirmed the rear edge remained fully present
- The bridge reported 96 visible rows throughout
- Transmit automation was disabled and the radio remained out of transmit

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter changes
- [x] Documentation updated if user-visible behavior changed — not applicable; this restores intended behavior
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
