### PR TITLE
Resynchronize the 3D FFT floor after bandwidth zoom

### DIFF
--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -159,6 +159,34 @@ private:
     bool m_waitingForFreshFrame{false};
 };
 
+// Windows in which an FFT frame's dBm encoding does not correspond to the
+// settled zoom, so it must not anchor the 3D floor. Kept out of the widget so
+// the timing policy is testable without a live radio or a QWidget.
+struct DssZoomFloorFrameGuards {
+    // std::int64_t, not qint64: this header stays Qt-free so the logic can be
+    // unit-tested without linking Qt. Callers pass qint64 epoch values.
+    std::int64_t nowMs{0};
+    std::int64_t notBeforeMs{0};    // radio still switching bandwidth
+    std::int64_t txEndMs{0};        // 0 when no recent TX→RX transition
+    std::int64_t postTxSettleMs{0}; // receiver AGC recovery window (#2117)
+    bool scaleSettling{false};      // y_pixels change still settling
+    bool rebaseActive{false};       // bins may be reprojected preview data
+    bool draggingDbmScale{false};
+};
+
+inline bool dssZoomFloorFrameTrusted(const DssZoomFloorFrameGuards& guards)
+{
+    if (guards.nowMs < guards.notBeforeMs) {
+        return false;
+    }
+    if (guards.txEndMs > 0
+        && guards.nowMs - guards.txEndMs < guards.postTxSettleMs) {
+        return false;
+    }
+    return !guards.scaleSettling && !guards.rebaseActive
+        && !guards.draggingDbmScale;
+}
+
 enum class WaterfallPipelineMode {
     Legacy,
     RowFrequencyFrames,

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -118,6 +118,47 @@ private:
     std::optional<FrequencyRangeCommand> m_pending;
 };
 
+// Coalesces bandwidth changes into one post-settle 3D floor reacquisition.
+// A new zoom cancels any previously-armed frame so rapid gestures cannot
+// resynchronize against an intermediate bandwidth.
+class DssZoomFloorSyncGate {
+public:
+    void noteBandwidthChange()
+    {
+        m_bandwidthChangeQueued = true;
+        m_waitingForFreshFrame = false;
+    }
+
+    void settle(bool flex3dActive)
+    {
+        m_waitingForFreshFrame =
+            m_bandwidthChangeQueued && flex3dActive;
+        m_bandwidthChangeQueued = false;
+    }
+
+    bool consumeFreshFrame(bool frameReady)
+    {
+        if (!m_waitingForFreshFrame || !frameReady) {
+            return false;
+        }
+        m_waitingForFreshFrame = false;
+        return true;
+    }
+
+    void clear()
+    {
+        m_bandwidthChangeQueued = false;
+        m_waitingForFreshFrame = false;
+    }
+
+    bool bandwidthChangeQueued() const { return m_bandwidthChangeQueued; }
+    bool waitingForFreshFrame() const { return m_waitingForFreshFrame; }
+
+private:
+    bool m_bandwidthChangeQueued{false};
+    bool m_waitingForFreshFrame{false};
+};
+
 enum class WaterfallPipelineMode {
     Legacy,
     RowFrequencyFrames,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1327,10 +1327,14 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
     if (m_frequencyRangeCommandTimer) {
         m_frequencyRangeCommandTimer->stop();
     }
+    if (m_dssZoomFloorSyncTimer) {
+        m_dssZoomFloorSyncTimer->stop();
+    }
     m_frequencyRangeSettlePending = false;
     m_frequencyRangePendingValid = false;
     m_frequencyRangeCommandThrottle.clear();
     m_frequencyRangeCommandClock.invalidate();
+    m_dssZoomFloorSync.clear();
     m_frequencyPreviewUpdateCount = 0;
     m_frequencyPreviewPresentCount = 0;
     m_frequencyPreviewCommitCount = 0;
@@ -1816,6 +1820,11 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
         emit frequencyRangeChangeRequested(command->centerMhz,
                                            command->bandwidthMhz);
     });
+    m_dssZoomFloorSyncTimer = new QTimer(this);
+    m_dssZoomFloorSyncTimer->setSingleShot(true);
+    m_dssZoomFloorSyncTimer->setInterval(kFrequencyRangeSettleMs);
+    connect(m_dssZoomFloorSyncTimer, &QTimer::timeout,
+            this, &SpectrumWidget::armDssZoomFloorSyncAfterSettle);
     m_resizeBufferSettleTimer = new QTimer(this);
     m_resizeBufferSettleTimer->setSingleShot(true);
     m_resizeBufferSettleTimer->setInterval(kResizeBufferSettleMs);
@@ -3180,6 +3189,73 @@ void SpectrumWidget::clearDbmReleaseRebase()
     m_dbmReleasePreviewOldMaxDbm = 0.0f;
     m_dbmReleasePreviewNewMinDbm = 0.0f;
     m_dbmReleasePreviewNewMaxDbm = 0.0f;
+}
+
+void SpectrumWidget::armDssZoomFloorSyncAfterSettle()
+{
+    const bool flex3dActive =
+        m_spectrumRenderMode == SpectrumRenderMode::Mode3D
+        && !m_kiwiSdrWaterfallActive;
+    m_dssZoomFloorSync.settle(flex3dActive);
+    if (!m_dssZoomFloorSync.waitingForFreshFrame()) {
+        return;
+    }
+
+    // Keep the old anchor visible through the gesture, then discard only the
+    // smoothed measurements. The first real post-settle FFT frame replaces
+    // them; reprojected preview bins must never become the new scale anchor.
+    m_measuredNoiseFloorDbm = -1000.0f;
+    resetNoiseFloorBaseline();
+    armNoiseFloorFastLock(5, 1);
+}
+
+void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
+{
+    const bool flex3dActive =
+        m_spectrumRenderMode == SpectrumRenderMode::Mode3D
+        && !m_kiwiSdrWaterfallActive;
+    if (!flex3dActive) {
+        m_dssZoomFloorSync.clear();
+        return;
+    }
+    if (!m_dssZoomFloorSync.waitingForFreshFrame()
+        || m_transmitting || m_pendingDbmRangeEcho || bins.isEmpty()) {
+        return;
+    }
+
+    const float frameFloorDbm = estimateNoiseFloorDbm(bins);
+    if (!m_dssZoomFloorSync.consumeFreshFrame(
+            std::isfinite(frameFloorDbm) && frameFloorDbm > -500.0f)) {
+        return;
+    }
+
+    m_measuredNoiseFloorDbm = frameFloorDbm;
+    m_dssFloorAnchorDbm = frameFloorDbm;
+    m_dssFloorAnchorValid = true;
+
+    const DbmRangeTransition::Range oldRange{
+        m_refLevel - m_dynamicRange, m_refLevel};
+    DbmRangeTransition::Range requestedRange =
+        DbmRangeTransition::manualRequestRange(
+            oldRange.minDbm, oldRange.maxDbm, true,
+            peekDssFloorDbm(), m_dynamicRange);
+    if (!clampDbmRange(requestedRange.minDbm, requestedRange.maxDbm)
+        || !DbmRangeTransition::materiallyDifferent(
+            oldRange, requestedRange,
+            kDbmReleasePreviewChangeThresholdDb)) {
+        markOverlayDirty();
+        return;
+    }
+
+    beginDbmRangeTransition(
+        oldRange.minDbm, oldRange.maxDbm,
+        requestedRange.minDbm, requestedRange.maxDbm);
+    m_refLevel = requestedRange.maxDbm;
+    m_dynamicRange = requestedRange.maxDbm - requestedRange.minDbm;
+    refreshNoiseFloorTarget();
+    markOverlayDirty();
+    emit dbmRangeChangeRequested(
+        requestedRange.minDbm, requestedRange.maxDbm);
 }
 
 void SpectrumWidget::resetNoiseFloorBaseline()
@@ -6290,6 +6366,12 @@ void SpectrumWidget::setFrequencyRangeInternal(double centerMhz, double bandwidt
     // Nudges shift center by ~10% of halfBw; 25% threshold comfortably separates the two.
     const double halfBw = bandwidthMhz / 2.0;
     const bool bwChanged = (bandwidthMhz != m_bandwidthMhz);
+    if (bwChanged) {
+        m_dssZoomFloorSync.noteBandwidthChange();
+        if (!m_frequencyRangeSettlePending && m_dssZoomFloorSyncTimer) {
+            m_dssZoomFloorSyncTimer->start();
+        }
+    }
     // Compare incoming center against the animation's *destination* (m_panCenterTarget),
     // not the mid-animation position (m_centerMhz). During a short retargetable
     // nudge, the animated center is far from its start, so a subsequent nudge
@@ -7028,6 +7110,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         m_fftFallbackSeedMask.clear();
     }
     m_bins = *spectrumBins;
+    syncDssRangeFromFreshZoomFrame(*spectrumBins);
 
     if (m_kiwiSdrWaterfallActive) {
         // The cached Flex FFT trace (m_bins, updated above) stays current for an
@@ -8959,6 +9042,13 @@ void SpectrumWidget::schedulePanDragSettleUpdate()
 void SpectrumWidget::scheduleFrequencyRangeSettleUpdate(double centerMhz,
                                                         double bandwidthMhz)
 {
+    // Every current caller is a bandwidth-zoom path (button, scale drag,
+    // native gesture, or wheel). Coalesce them so only the final settled
+    // bandwidth can arm a fresh-frame 3D floor resynchronization.
+    m_dssZoomFloorSync.noteBandwidthChange();
+    if (m_dssZoomFloorSyncTimer) {
+        m_dssZoomFloorSyncTimer->stop();
+    }
     m_frequencyRangeSettlePending = true;
     if (std::isfinite(centerMhz) && std::isfinite(bandwidthMhz)
         && centerMhz > 0.0 && bandwidthMhz > 0.0) {
@@ -8986,6 +9076,10 @@ void SpectrumWidget::finishFrequencyRangeSettleUpdate()
     requestFrequencyRangeChange(m_centerMhz, m_bandwidthMhz, true);
     m_frequencyRangeSettlePending = false;
     m_frequencyRangePendingValid = false;
+    if (m_dssZoomFloorSyncTimer) {
+        m_dssZoomFloorSyncTimer->stop();
+    }
+    armDssZoomFloorSyncAfterSettle();
     emit frequencyRangeSettled(m_centerMhz, m_bandwidthMhz);
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -322,6 +322,9 @@ static constexpr int kPanDragSettleMs = 160;
 static constexpr int kFrequencyRangeCommandMs = 33;
 static constexpr int kFrequencyRangeSettleMs = 300;
 static constexpr int kResizeBufferSettleMs = 120;
+// Receiver AGC recovery window after TX→RX (#2117). Frames inside it read
+// several dB hot, so they neither feed waterfall history nor anchor a scale.
+static constexpr qint64 kPostTxAgcSettleMs = 400;
 static constexpr float kDbmReleasePreviewChangeThresholdDb = 0.05f;
 static constexpr float kDbmReleaseRebaseMinImprovementDb = 0.75f;
 static constexpr int kFilterEdgeGrabPx = 8;
@@ -1335,6 +1338,7 @@ QVariantMap SpectrumWidget::automationDssReset(bool kiwiStream)
     m_frequencyRangeCommandThrottle.clear();
     m_frequencyRangeCommandClock.invalidate();
     m_dssZoomFloorSync.clear();
+    m_dssZoomFloorSyncNotBeforeMs = 0;
     m_frequencyPreviewUpdateCount = 0;
     m_frequencyPreviewPresentCount = 0;
     m_frequencyPreviewCommitCount = 0;
@@ -3201,6 +3205,15 @@ void SpectrumWidget::armDssZoomFloorSyncAfterSettle()
         return;
     }
 
+    // The range command has only just gone out and the radio needs ~100-300 ms
+    // to switch bandwidth. The scale-drag release path arms with no delay at
+    // all — mouseReleaseEvent() calls scheduleFrequencyRangeSettleUpdate() and
+    // finishFrequencyRangeSettleUpdate() back to back — so without this hold
+    // the next frame (~33 ms away, still encoded at the pre-zoom bandwidth)
+    // would be accepted as the first post-settle frame and disarm the gate.
+    m_dssZoomFloorSyncNotBeforeMs =
+        QDateTime::currentMSecsSinceEpoch() + kFrequencyRangeSettleMs;
+
     // Keep the old anchor visible through the gesture, then discard only the
     // smoothed measurements. The first real post-settle FFT frame replaces
     // them; reprojected preview bins must never become the new scale anchor.
@@ -3220,6 +3233,28 @@ void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
     }
     if (!m_dssZoomFloorSync.waitingForFreshFrame()
         || m_transmitting || m_pendingDbmRangeEcho || bins.isEmpty()) {
+        return;
+    }
+
+    // Reject frames whose dBm encoding cannot be trusted yet — without
+    // consuming the arm, so the gate keeps waiting for a usable one:
+    //   • the radio has not finished switching bandwidth;
+    //   • the receiver AGC is still recovering from TX (#2117 blanks the
+    //     waterfall over the same window further down updateSpectrum());
+    //   • a y_pixels change is still settling, so bins decode against the old
+    //     height (the guard appendDssWaterfallRow() and
+    //     pushDssRowForWaterfallStream() already apply);
+    //   • a dBm-range rebase may be handing us reprojected preview bins;
+    //   • the operator is dragging the scale this would fight.
+    DssZoomFloorFrameGuards guards;
+    guards.nowMs = QDateTime::currentMSecsSinceEpoch();
+    guards.notBeforeMs = m_dssZoomFloorSyncNotBeforeMs;
+    guards.txEndMs = m_txEndMs;
+    guards.postTxSettleMs = kPostTxAgcSettleMs;
+    guards.scaleSettling = flexDssFftScaleSettling();
+    guards.rebaseActive = m_dbmReleaseRebaseUntilMs > 0;
+    guards.draggingDbmScale = isDraggingDbmScale();
+    if (!dssZoomFloorFrameTrusted(guards)) {
         return;
     }
 
@@ -6366,7 +6401,12 @@ void SpectrumWidget::setFrequencyRangeInternal(double centerMhz, double bandwidt
     // Nudges shift center by ~10% of halfBw; 25% threshold comfortably separates the two.
     const double halfBw = bandwidthMhz / 2.0;
     const bool bwChanged = (bandwidthMhz != m_bandwidthMhz);
-    if (bwChanged) {
+    // Only a change away from an already-established span is a zoom. This is
+    // the radio-echo entry point, so the first geometry push of a pan (no
+    // prior bandwidth) is the radio establishing it on connect — re-anchoring
+    // there would push a client-computed aperture over the min/max dBm the
+    // radio just restored for this GUIClientID (Constitution II/III).
+    if (bwChanged && m_bandwidthMhz > 0.0) {
         m_dssZoomFloorSync.noteBandwidthChange();
         if (!m_frequencyRangeSettlePending && m_dssZoomFloorSyncTimer) {
             m_dssZoomFloorSyncTimer->start();
@@ -7198,7 +7238,7 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         bool postTxBlanking = false;
         if (m_txEndMs > 0) {
             const qint64 now = QDateTime::currentMSecsSinceEpoch();
-            if (now - m_txEndMs < 400)
+            if (now - m_txEndMs < kPostTxAgcSettleMs)
                 postTxBlanking = true;
             else
                 m_txEndMs = 0;
@@ -7266,7 +7306,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     // window.
     if (m_txEndMs > 0) {
         const qint64 now = QDateTime::currentMSecsSinceEpoch();
-        if (now - m_txEndMs < 400) return;
+        if (now - m_txEndMs < kPostTxAgcSettleMs) return;
         m_txEndMs = 0;
     }
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1302,6 +1302,10 @@ private:
     float m_dssFloorAnchorDbm{-1000.0f};
     bool  m_dssFloorAnchorValid{false};
     DssZoomFloorSyncGate m_dssZoomFloorSync;
+    // Earliest time an armed zoom sync may accept a frame. The radio needs
+    // ~100-300 ms to switch bandwidth; frames before this still carry the
+    // pre-zoom encoding.
+    qint64 m_dssZoomFloorSyncNotBeforeMs{0};
     // The radio can briefly deliver FFT packets encoded with the old y_pixels
     // after acknowledging a new height. Keep those rows out of retained 3D
     // history; the live 2D trace and waterfall continue normally.

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1020,6 +1020,8 @@ private:
     void beginDbmRangeTransition(float oldMinDbm, float oldMaxDbm,
                                  float newMinDbm, float newMaxDbm);
     void clearDbmReleaseRebase();
+    void armDssZoomFloorSyncAfterSettle();
+    void syncDssRangeFromFreshZoomFrame(const QVector<float>& bins);
     // Reset the baseline tracker — called on any input change (zoom,
     // band switch, manual dBm drag) so the next frame re-acquires
     // rather than smooths from a stale value.
@@ -1299,6 +1301,7 @@ private:
     int   m_dssGain{70};   // 3DSS colour floor 0-100 (gamma of palette lookup)
     float m_dssFloorAnchorDbm{-1000.0f};
     bool  m_dssFloorAnchorValid{false};
+    DssZoomFloorSyncGate m_dssZoomFloorSync;
     // The radio can briefly deliver FFT packets encoded with the old y_pixels
     // after acknowledging a new height. Keep those rows out of retained 3D
     // history; the live 2D trace and waterfall continue normally.
@@ -1398,6 +1401,7 @@ private:
     double m_frequencyRangePendingCenterMhz{0.0};
     QTimer* m_frequencyRangeSettleTimer{nullptr};
     QTimer* m_frequencyRangeCommandTimer{nullptr};
+    QTimer* m_dssZoomFloorSyncTimer{nullptr};
     QElapsedTimer m_frequencyRangeCommandClock;
     FrequencyRangeCommandThrottle m_frequencyRangeCommandThrottle;
     quint64 m_frequencyRangeCommandCount{0};

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -132,6 +132,53 @@ int testCommandThrottle()
     return 0;
 }
 
+int testDssZoomFloorSyncGate()
+{
+    using namespace AetherSDR;
+    DssZoomFloorSyncGate gate;
+    if (gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()
+        || gate.consumeFreshFrame(true)) {
+        return fail("3D zoom floor synchronization should start idle");
+    }
+
+    gate.noteBandwidthChange();
+    if (!gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()
+        || gate.consumeFreshFrame(true)) {
+        return fail("3D zoom floor synchronization must wait for settle");
+    }
+
+    gate.settle(false);
+    if (gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()
+        || gate.consumeFreshFrame(true)) {
+        return fail("2D or Kiwi zoom must not arm a Flex 3D floor sync");
+    }
+
+    gate.noteBandwidthChange();
+    gate.noteBandwidthChange();
+    gate.settle(true);
+    if (gate.bandwidthChangeQueued() || !gate.waitingForFreshFrame()
+        || gate.consumeFreshFrame(false)
+        || !gate.waitingForFreshFrame()) {
+        return fail("coalesced 3D zoom must wait for a usable FFT frame");
+    }
+    if (!gate.consumeFreshFrame(true) || gate.waitingForFreshFrame()
+        || gate.consumeFreshFrame(true)) {
+        return fail("only the first usable post-zoom FFT frame may resynchronize");
+    }
+
+    gate.noteBandwidthChange();
+    gate.settle(true);
+    gate.noteBandwidthChange();
+    if (!gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()) {
+        return fail("a newer zoom must cancel an intermediate armed frame");
+    }
+    gate.clear();
+    if (gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()) {
+        return fail("3D zoom floor synchronization should clear completely");
+    }
+    return 0;
+}
+
 int testWaterfallPipelineSelection()
 {
     using namespace AetherSDR;
@@ -387,6 +434,9 @@ int main()
         return result;
     }
     if (const int result = testCommandThrottle(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssZoomFloorSyncGate(); result != 0) {
         return result;
     }
     if (const int result = testWaterfallPipelineSelection(); result != 0) {

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -179,6 +179,66 @@ int testDssZoomFloorSyncGate()
     return 0;
 }
 
+int testDssZoomFloorFrameGuards()
+{
+    using namespace AetherSDR;
+
+    // A frame with every window clear is the one the gate is waiting for.
+    DssZoomFloorFrameGuards guards;
+    guards.nowMs = 10'000;
+    guards.notBeforeMs = 10'000;
+    guards.postTxSettleMs = 400;
+    if (!dssZoomFloorFrameTrusted(guards)) {
+        return fail("a settled post-zoom frame must anchor the 3D floor");
+    }
+
+    // The radio needs ~100-300 ms to switch bandwidth. Frames before the hold
+    // still carry the pre-zoom encoding; the drag-release path arms with no
+    // delay of its own, so this is the only thing keeping them out.
+    guards.nowMs = 9'999;
+    if (dssZoomFloorFrameTrusted(guards)) {
+        return fail("a frame before the bandwidth-switch hold must be rejected");
+    }
+    guards.nowMs = 10'000;
+
+    // Post-TX AGC recovery (#2117): the first RX frame after unkey reads hot.
+    guards.txEndMs = guards.nowMs - 399;
+    if (dssZoomFloorFrameTrusted(guards)) {
+        return fail("a post-TX AGC transient frame must not anchor the floor");
+    }
+    guards.txEndMs = guards.nowMs - 400;
+    if (!dssZoomFloorFrameTrusted(guards)) {
+        return fail("frames past the post-TX window are usable again");
+    }
+    guards.txEndMs = 0;
+
+    // A y_pixels change still settling decodes bins against the old height.
+    guards.scaleSettling = true;
+    if (dssZoomFloorFrameTrusted(guards)) {
+        return fail("a mis-decoded scale-settling frame must be rejected");
+    }
+    guards.scaleSettling = false;
+
+    // An open dBm-range rebase can hand the sync reprojected preview bins.
+    guards.rebaseActive = true;
+    if (dssZoomFloorFrameTrusted(guards)) {
+        return fail("reprojected preview bins must never anchor the floor");
+    }
+    guards.rebaseActive = false;
+
+    // The operator owns the scale while dragging it.
+    guards.draggingDbmScale = true;
+    if (dssZoomFloorFrameTrusted(guards)) {
+        return fail("a zoom sync must not fight an active dBm scale drag");
+    }
+    guards.draggingDbmScale = false;
+
+    if (!dssZoomFloorFrameTrusted(guards)) {
+        return fail("clearing every guard must restore a usable frame");
+    }
+    return 0;
+}
+
 int testWaterfallPipelineSelection()
 {
     using namespace AetherSDR;
@@ -437,6 +497,9 @@ int main()
         return result;
     }
     if (const int result = testDssZoomFloorSyncGate(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssZoomFloorFrameGuards(); result != 0) {
         return result;
     }
     if (const int result = testWaterfallPipelineSelection(); result != 0) {


### PR DESCRIPTION
## Summary

Resynchronizes the Flex 3D FFT floor and radio/decoder dBm aperture after a bandwidth zoom settles. Previously, zooming reset the general noise-floor baseline but left the measured 3D floor anchor and encoded dBm range stale, which could clip low FFT bins into flat segments until the user manually moved the vertical scale. This change coalesces rapid zoom events, waits for the first usable post-settle FFT frame, reacquires the floor, and uses the existing dBm-range handshake to realign the radio encoder without clearing retained 3D history.

Related: #4476 addresses the independent rear-edge motion under delayed FFT arrivals and is not a dependency of this fix.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The post-zoom synchronization is covered by a focused regression test and verified through the automation bridge on a live FLEX-6700.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
  - Verified with a FLEX-6700 running firmware 4.2.18
  - Zoomed from 200 kHz to 133.333 kHz and back in 3D mode
  - Confirmed one settled dBm aperture update after zoom
  - Confirmed 96/96 visible 3D rows remained non-flat, with 0 flat rows
  - Confirmed retained 3D history was not cleared
  - Confirmed `txAllowed=false` and `transmitting=false`
- [ ] Existing tests pass (CI)
  - Local focused tests passed: `spectrum_preview_logic_test`, `panadapter_dbm_range_test`, and `dss_renderer_test`
- [x] Reproduction steps documented if user-reported bug
  - Enable the 3D FFT display and zoom horizontally in or out
  - Before this fix, low portions of the trace could flatten until the vertical scale was dragged
  - After this fix, the floor and trace settle into the correct position automatically

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter UI changes)
- [x] Documentation updated if user-visible behavior changed (not required; restores intended behavior)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)