### PR TITLE
fix(connection): recover from rejected GUI client registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3629,6 +3629,23 @@ target_include_directories(gui_client_identity_policy_test PRIVATE src)
 target_link_libraries(gui_client_identity_policy_test PRIVATE Qt6::Core)
 add_test(NAME gui_client_identity_policy_test COMMAND gui_client_identity_policy_test)
 
+add_executable(gui_client_registration_state_test
+    tests/gui_client_registration_state_test.cpp
+)
+target_include_directories(gui_client_registration_state_test PRIVATE src)
+target_link_libraries(gui_client_registration_state_test PRIVATE Qt6::Core)
+add_test(NAME gui_client_registration_state_test COMMAND gui_client_registration_state_test)
+
+add_executable(gui_client_registration_recovery_test
+    tests/gui_client_registration_recovery_test.cpp
+)
+target_include_directories(gui_client_registration_recovery_test PRIVATE src tests)
+target_link_libraries(gui_client_registration_recovery_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Test
+)
+add_test(NAME gui_client_registration_recovery_test
+         COMMAND gui_client_registration_recovery_test)
+
 add_executable(profile_load_command_test
     tests/profile_load_command_test.cpp
 )

--- a/src/core/CommandParser.cpp
+++ b/src/core/CommandParser.cpp
@@ -57,7 +57,18 @@ ParsedMessage CommandParser::parseLine(const QString& rawLine)
         msg.type = MessageType::Response;
         const QStringList parts = body.split('|');
         if (parts.size() >= 1) msg.sequence   = parts[0].toUInt();
-        if (parts.size() >= 2) msg.resultCode = parts[1].toInt(nullptr, 16);
+        if (parts.size() >= 2) {
+            // SmartSDR result codes are unsigned 32-bit values. Fatal codes
+            // such as F3000001 have the high bit set; QString::toInt() rejects
+            // them as overflow and returns zero, which would turn a fatal
+            // rejection into an apparent success. Preserve the protocol bit
+            // pattern in the legacy int callback type.
+            bool ok = false;
+            const quint32 resultCode = parts[1].toUInt(&ok, 16);
+            if (ok) {
+                msg.resultCode = static_cast<int>(resultCode);
+            }
+        }
         if (parts.size() >= 3) {
             msg.object = parts[2];
             msg.kvs    = parseKVs(parts[2]);

--- a/src/core/GuiClientRegistrationState.h
+++ b/src/core/GuiClientRegistrationState.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "RadioMessageTypes.h"
+
+#include <QString>
+
+namespace AetherSDR {
+
+class GuiClientRegistrationState
+{
+public:
+    enum class Phase {
+        Idle,
+        AwaitingReply,
+        Registered,
+        Rejected
+    };
+
+    enum class Action {
+        ContinueHandshake,
+        DisconnectAndWaitForUser
+    };
+
+    struct Result {
+        Action action{Action::DisconnectAndWaitForUser};
+        int resultCode{0};
+        QString detail;
+
+        bool accepted() const { return action == Action::ContinueHandshake; }
+        bool automaticRetryAllowed() const { return accepted(); }
+    };
+
+    void begin()
+    {
+        m_phase = Phase::AwaitingReply;
+        m_radioErrorDetail.clear();
+    }
+
+    void noteRadioMessage(const QString& text, MessageSeverity severity)
+    {
+        if (m_phase != Phase::AwaitingReply
+            || (severity != MessageSeverity::Error
+                && severity != MessageSeverity::Fatal)) {
+            return;
+        }
+
+        const QString detail = text.trimmed();
+        if (!detail.isEmpty()) {
+            m_radioErrorDetail = detail;
+        }
+    }
+
+    Result complete(int resultCode, const QString& responseBody)
+    {
+        if (resultCode == 0) {
+            m_phase = Phase::Registered;
+            m_radioErrorDetail.clear();
+            return {Action::ContinueHandshake, resultCode, {}};
+        }
+
+        m_phase = Phase::Rejected;
+        QString detail = responseBody.trimmed();
+        if (detail.isEmpty()) {
+            detail = m_radioErrorDetail;
+        }
+        m_radioErrorDetail.clear();
+        return {Action::DisconnectAndWaitForUser, resultCode, detail};
+    }
+
+    void reset()
+    {
+        m_phase = Phase::Idle;
+        m_radioErrorDetail.clear();
+    }
+
+    Phase phase() const { return m_phase; }
+
+private:
+    Phase m_phase{Phase::Idle};
+    QString m_radioErrorDetail;
+};
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5032,6 +5032,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
     m_discovery.setConnected(connected, remoteConnection);
 
     if (connected) {
+        m_terminalConnectionError.clear();
         m_suppressStartupPanLayoutRearrange = false;
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
@@ -5322,7 +5323,8 @@ void MainWindow::onConnectionStateChanged(bool connected)
 #ifdef HAVE_WEBSOCKETS
         QMetaObject::invokeMethod(m_freedvClient, [this] { m_freedvClient->stopConnection(); });
 #endif
-        m_connStatusLabel->setText("Disconnected");
+        const bool terminalConnectionFailure = !m_terminalConnectionError.isEmpty();
+        m_connStatusLabel->setText(terminalConnectionFailure ? "Error" : "Disconnected");
         m_radioInfoLabel->setText("");
         m_radioVersionLabel->setText("");
         setStatusBarStationText(m_stationLabel, QStringLiteral("N0CALL"));
@@ -5350,7 +5352,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
         updateStatusBarMinimumWidth();
         m_txIndicator->setStyleSheet("QLabel { color: rgba(255,255,255,128); font-weight: bold; font-size: 21px; }");
         m_txIndicator->setText("TX");
-        m_connPanel->setStatusText("Not connected");
+        m_connPanel->setStatusText(
+            terminalConnectionFailure
+                ? tr("Error: %1").arg(m_terminalConnectionError)
+                : tr("Not connected"));
 #ifdef HAVE_HIDAPI
         // Safety: if latched PTT was active when the radio dropped, the radio is
         // now TX-off regardless.  Reset the latch flag so it stays in sync with
@@ -5394,7 +5399,13 @@ void MainWindow::onConnectionStateChanged(bool connected)
             }
         }
 
-        setPanadapterConnectionAnimation(!m_userDisconnected, "Reconnecting to radio…");
+        setPanadapterConnectionAnimation(
+            !m_userDisconnected && !terminalConnectionFailure,
+            "Reconnecting to radio…");
+
+        if (terminalConnectionFailure) {
+            showConnectionDialog();
+        }
 
         // Show reconnect dialog on unexpected disconnect (only one at a time)
         if (!m_userDisconnected && !m_reconnectDlg) {

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1209,6 +1209,7 @@ private:
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
+    QString m_terminalConnectionError; // preserved until the next explicit connect
     QPointer<class ThemeEditorDialog> m_themeEditorDialog; // Phase 5 — lazy, modeless
     void cancelTransmitFromIndicator();
     void beginProfileLoadRadioStateWriteHold(const QString& profileType, const QString& profileName);

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -244,6 +244,7 @@ void MainWindow::wireDiscovery()
             return;
         }
         m_radioModel.setPendingClientDisconnects(disconnectHandles);
+        m_terminalConnectionError.clear();
         m_connPanel->setStatusText("Connecting…");
         m_userDisconnected = false;
         setPanadapterConnectionAnimation(true, "Connecting to radio…");
@@ -476,6 +477,23 @@ void MainWindow::wireRadioModel()
 
     connect(&m_radioModel, &RadioModel::connectionError,
             this, &MainWindow::onConnectionError);
+    connect(&m_radioModel, &RadioModel::guiClientRegistrationFailed,
+            this, [this](const QString& message) {
+        // A rejected GUI registration is terminal for this attempt. Keep the
+        // reason visible, suppress both LAN and WAN automatic reconnect loops,
+        // and let the operator retry normally after freeing a radio slot.
+        m_userDisconnected = true;
+        m_wanReconnectTimer.stop();
+        m_wanReconnectAttemptInProgress = false;
+        m_terminalConnectionError = message;
+        setPanadapterConnectionAnimation(false);
+        if (m_reconnectDlg) {
+            QDialog* reconnectDialog = m_reconnectDlg;
+            m_reconnectDlg = nullptr;
+            reconnectDialog->close();
+            reconnectDialog->deleteLater();
+        }
+    });
     connect(&m_radioModel, &RadioModel::certFingerprintMismatch,
             this, &MainWindow::onWanCertFingerprintMismatch);
     connect(&m_radioModel, &RadioModel::forcedDisconnectRequested,

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4301,6 +4301,30 @@ void RadioModel::handleDuplicateClientIdDisconnect()
     closeConnectionForTerminalDisconnect();
 }
 
+void RadioModel::handleGuiClientRegistrationFailure(
+    const GuiClientRegistrationState::Result& result)
+{
+    m_intentionalDisconnect = true;
+    m_reconnectTimer.stop();
+
+    const QString detail = result.detail.isEmpty()
+        ? tr("The radio rejected the request without additional detail.")
+        : result.detail;
+    const QString message =
+        tr("GUI client registration failed (%1): %2 "
+           "AetherSDR disconnected without retrying. Free a GUI client slot if "
+           "needed, then choose Connect to try again.")
+            .arg(hexCode(result.resultCode), detail);
+
+    qCWarning(lcProtocol).noquote()
+        << "RadioModel: terminal GUI client registration failure"
+        << QStringLiteral("code=%1").arg(hexCode(result.resultCode))
+        << QStringLiteral("detail=%1").arg(detail);
+    emit guiClientRegistrationFailed(message);
+    emit connectionError(message);
+    closeConnectionForTerminalDisconnect();
+}
+
 void RadioModel::registerAsGuiClient(const QString& clientId)
 {
     // aetherd Gap B: SmartSDR GUI-client registration is Flex-only. Every step
@@ -4326,12 +4350,34 @@ void RadioModel::registerAsGuiClient(const QString& clientId)
     if (AppSettings::instance().value("LowBandwidthConnect", "False").toString() == "True")
         sendCmd("client low_bw_connect");
 
+    m_guiClientRegistrationState.begin();
     sendCmd(QString("client gui %1").arg(clientId), [this](int code, const QString& body) {
         armClientConnectionNoticeSuppression();
         if (code != 0) {
-            qCWarning(lcProtocol) << "RadioModel: client gui failed, code" << Qt::hex << code;
-        } else if (!body.trimmed().isEmpty()
-                   && !AppSettings::instance().guiClientIdentityIsTransient()) {
+            // A fatal M-message and the R reply are separate protocol lines. Let
+            // already-queued message delivery run once so an empty R body can
+            // still surface the radio's exact reason (for example F3000001).
+            QTimer::singleShot(0, this, [this, code, body] {
+                if (m_guiClientRegistrationState.phase()
+                    != GuiClientRegistrationState::Phase::AwaitingReply) {
+                    return;
+                }
+                const GuiClientRegistrationState::Result result =
+                    m_guiClientRegistrationState.complete(code, body);
+                handleGuiClientRegistrationFailure(result);
+            });
+            return;
+        }
+
+        const GuiClientRegistrationState::Result result =
+            m_guiClientRegistrationState.complete(code, body);
+        if (!result.accepted()) {
+            handleGuiClientRegistrationFailure(result);
+            return;
+        }
+
+        if (!body.trimmed().isEmpty()
+            && !AppSettings::instance().guiClientIdentityIsTransient()) {
             // Save our UUID for session persistence across restarts.
             // The radio restores slices/frequencies for a known UUID.
             auto& s = AppSettings::instance();
@@ -4759,6 +4805,7 @@ void RadioModel::restoreTuneInhibit()
 void RadioModel::onDisconnected()
 {
     qCDebug(lcProtocol) << "RadioModel: disconnected";
+    m_guiClientRegistrationState.reset();
 
     // #4142 — void any pan centers deferred during a profile load. The session
     // they belonged to is gone: the radio rebuilds its topology on reconnect, so
@@ -5497,6 +5544,7 @@ void RadioModel::onMessageReceived(const ParsedMessage& msg)
     }
 
     if (msg.type == MessageType::Message) {
+        m_guiClientRegistrationState.noteRadioMessage(msg.object, msg.severity);
         if (shouldSuppressRadioMessageNotice(msg.object, msg.severity)) {
             qCInfo(lcProtocol) << "Radio M-message [Info suppressed during connect]:" << msg.object;
             return;

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/CommandParser.h"   // MessageSeverity for radioMessageReceived
+#include "core/GuiClientRegistrationState.h"
 #include "core/backends/GpsDelta.h"     // applyGpsChanges payload (aetherd 2.3)
 #include "core/backends/MemoryDelta.h"  // applyMemoryChanges payload (aetherd 2.3)
 #include "core/backends/ProfileDelta.h" // applyProfileChanges payload (aetherd 2.3)
@@ -629,6 +630,9 @@ signals:
                                  const QString& presentedHex);
     // Emitted when another GUI client forces this client to disconnect.
     void forcedDisconnectRequested();
+    // Emitted before teardown when the radio rejects `client gui`. The UI uses
+    // this terminal signal to stop reconnect UX and preserve the radio's reason.
+    void guiClientRegistrationFailed(const QString& message);
     // aetherd Gap B (HL2 Phase 1c, Step 1): the backend-neutral panadapter render
     // feed. Signatures mirror PanadapterStream.h:212-218 exactly, so the UI binds
     // its panadapter/waterfall rendering to these instead of the Flex-only
@@ -909,6 +913,8 @@ private:
     // Voids one pan's deferred writes, loudly naming what was destroyed.
     void voidPendingPanWrites(const QString& panId, const QString& reason);
     void registerAsGuiClient(const QString& clientId);
+    void handleGuiClientRegistrationFailure(
+        const GuiClientRegistrationState::Result& result);
     void disconnectPendingClientsThen(std::function<void()> continuation);
     // LAN-only: subscribe to radio+client topics early, wait 400 ms for
     // the radio status burst, then check for a multiFLEX conflict before
@@ -916,8 +922,9 @@ private:
     void peekForMultiFlexConflictThen(std::function<void()> continuation);
     void handleForcedClientDisconnect();
     void handleDuplicateClientIdDisconnect();
-    // Shared transport teardown for a radio-initiated terminal disconnect
-    // (forced or duplicate-client-id); callers set m_intentionalDisconnect first.
+    // Shared transport teardown for a terminal session failure (forced,
+    // duplicate-client-id, or rejected GUI registration). Callers set
+    // m_intentionalDisconnect first.
     void closeConnectionForTerminalDisconnect();
     void resolveLiveGuiClientIdCollision();
     void applyKnownGuiClients(const QStringList& handles,
@@ -1370,6 +1377,7 @@ private:
     RadioInfo m_lastInfo;               // stored for auto-reconnect
     bool      m_intentionalDisconnect{false};
     bool      m_forcedDisconnectInProgress{false};
+    GuiClientRegistrationState m_guiClientRegistrationState;
     // Suppress connection-error toasts between rebootRadio() and the next
     // successful reconnect — multiple `Connection refused` retries fire
     // while the radio is still booting and would otherwise spam the UI.

--- a/tests/gui_client_registration_recovery_test.cpp
+++ b/tests/gui_client_registration_recovery_test.cpp
@@ -1,0 +1,207 @@
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "models/RadioModel.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QHash>
+#include <QSignalSpy>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QThread>
+
+#include <cstdio>
+#include <functional>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+bool waitFor(const std::function<bool()>& predicate, int timeoutMs)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (!predicate() && timer.elapsed() < timeoutMs) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 25);
+        QThread::msleep(5);
+    }
+    QCoreApplication::processEvents(QEventLoop::AllEvents, 25);
+    return predicate();
+}
+
+int commandCount(const QStringList& commands, const QString& prefix)
+{
+    int count = 0;
+    for (const QString& command : commands) {
+        if (command.startsWith(prefix)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(
+        QStringLiteral("aether-gui-registration-recovery-test"));
+    QCoreApplication app(argc, argv);
+    AppSettings::instance().load();
+    AppSettings::instance().initializeGuiClientIdentity();
+
+    QTcpServer server;
+    check(server.listen(QHostAddress::LocalHost, 0), "fake radio listens on loopback");
+    if (!server.isListening()) {
+        return 1;
+    }
+
+    bool rejectGuiRegistration = true;
+    bool guiRegistrationAccepted = false;
+    int connectionCount = 0;
+    QStringList commands;
+    QHash<QTcpSocket*, QByteArray> buffers;
+
+    QObject::connect(&server, &QTcpServer::newConnection, &app, [&] {
+        while (server.hasPendingConnections()) {
+            QTcpSocket* socket = server.nextPendingConnection();
+            ++connectionCount;
+            buffers.insert(socket, {});
+
+            QObject::connect(socket, &QTcpSocket::readyRead, socket, [&, socket] {
+                QByteArray& buffer = buffers[socket];
+                buffer.append(socket->readAll());
+                int newline = -1;
+                while ((newline = buffer.indexOf('\n')) >= 0) {
+                    const QString line =
+                        QString::fromUtf8(buffer.left(newline)).trimmed();
+                    buffer.remove(0, newline + 1);
+                    if (!line.startsWith(QLatin1Char('C'))) {
+                        continue;
+                    }
+
+                    const int pipe = line.indexOf(QLatin1Char('|'));
+                    if (pipe <= 1) {
+                        continue;
+                    }
+                    const quint32 sequence = line.mid(1, pipe - 1).toUInt();
+                    const QString command = line.mid(pipe + 1);
+                    commands.append(command);
+
+                    if (command.startsWith(QStringLiteral("client gui "))
+                        && rejectGuiRegistration) {
+                        socket->write(
+                            "MF3000001|The maximum number of connected clients "
+                            "has been reached\n");
+                        socket->write(
+                            QStringLiteral(
+                                "R%1|F3000001|The maximum number of connected clients "
+                                "has been reached\n")
+                                .arg(sequence)
+                                .toUtf8());
+                    } else if (command.startsWith(QStringLiteral("client gui "))) {
+                        guiRegistrationAccepted = true;
+                        socket->write(
+                            QStringLiteral("R%1|0|\n").arg(sequence).toUtf8());
+                    } else if (guiRegistrationAccepted) {
+                        // The successful client-gui callback sends the complete
+                        // post-registration batch synchronously. Withhold later
+                        // replies so the test can assert that batch and tear down
+                        // without racing unrelated info/slice callbacks.
+                    } else {
+                        socket->write(
+                            QStringLiteral("R%1|0|\n").arg(sequence).toUtf8());
+                    }
+                    socket->flush();
+                }
+            });
+            socket->write("V1.4.0.0\nH12345678\nS0|radio mf_enable=1\n");
+            socket->flush();
+        }
+    });
+
+    RadioModel model;
+    QSignalSpy connectionSpy(&model, &RadioModel::connectionStateChanged);
+    QSignalSpy registrationFailureSpy(
+        &model, &RadioModel::guiClientRegistrationFailed);
+    QSignalSpy errorSpy(&model, &RadioModel::connectionError);
+
+    RadioInfo info;
+    info.family = QStringLiteral("flex");
+    info.serial = QStringLiteral("TEST-REGISTRATION-RECOVERY");
+    info.name = QStringLiteral("Fake Flex");
+    info.model = QStringLiteral("FLEX-6700");
+    info.version = QStringLiteral("4.2.18");
+    info.address = QHostAddress::LocalHost;
+    info.port = server.serverPort();
+
+    model.connectToRadio(info);
+
+    check(waitFor([&] {
+              return registrationFailureSpy.count() == 1 && !model.isConnected();
+          }, 5000),
+          "rejected GUI registration tears down the connected TCP session");
+    check(errorSpy.count() == 1,
+          "rejected GUI registration emits a user-facing connection error");
+    check(connectionSpy.count() >= 2
+              && connectionSpy.first().at(0).toBool()
+              && !connectionSpy.last().at(0).toBool(),
+          "connection state returns from connected to disconnected");
+
+    const QString failureMessage =
+        registrationFailureSpy.isEmpty()
+            ? QString()
+            : registrationFailureSpy.first().at(0).toString();
+    check(failureMessage.contains(
+              QStringLiteral("The maximum number of connected clients has been reached")),
+          "the radio's fatal detail is preserved in the terminal error");
+    check(failureMessage.contains(QStringLiteral("0xf3000001")),
+          "the terminal error includes the rejected command result code");
+    check(failureMessage.contains(QStringLiteral("choose Connect")),
+          "the terminal error explains the explicit recovery action");
+
+    check(commandCount(commands, QStringLiteral("client gui ")) == 1,
+          "the failed attempt sends one GUI registration command");
+    check(commandCount(commands, QStringLiteral("client station ")) == 0,
+          "the failed attempt sends no post-registration station command");
+    check(commandCount(commands, QStringLiteral("sub slice all")) == 0,
+          "the failed attempt sends no post-registration subscriptions");
+    check(commandCount(commands, QStringLiteral("client udpport ")) == 0,
+          "the failed attempt performs no UDP/data-plane setup");
+
+    waitFor([&] { return false; }, 3300);
+    check(connectionCount == 1,
+          "rejected registration does not enter the automatic reconnect loop");
+    check(connectionCount == 1
+              && commandCount(commands, QStringLiteral("client gui ")) == 1,
+          "no blind TCP or GUI-registration retry occurs while the radio is full");
+
+    rejectGuiRegistration = false;
+    guiRegistrationAccepted = false;
+    model.connectToRadio(info);
+    check(waitFor([&] {
+              return connectionCount == 2
+                  && commandCount(commands, QStringLiteral("client gui ")) == 2
+                  && commandCount(commands, QStringLiteral("sub slice all")) >= 1;
+          }, 5000),
+          "a later explicit connect opens fresh TCP and resumes the successful handshake");
+    check(model.isConnected(), "successful explicit reconnect remains connected");
+    check(commandCount(commands, QStringLiteral("client station ")) >= 1,
+          "successful registration reaches post-registration client setup");
+
+    model.disconnectFromRadio();
+    check(waitFor([&] { return !model.isConnected(); }, 3000),
+          "test cleanup disconnects the successful session");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/gui_client_registration_state_test.cpp
+++ b/tests/gui_client_registration_state_test.cpp
@@ -1,0 +1,68 @@
+#include "core/GuiClientRegistrationState.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* description)
+{
+    std::printf("%s  %s\n", condition ? "PASS" : "FAIL", description);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+    GuiClientRegistrationState state;
+    check(state.phase() == GuiClientRegistrationState::Phase::Idle,
+          "registration starts idle");
+
+    state.begin();
+    const GuiClientRegistrationState::Result accepted = state.complete(0, {});
+    check(accepted.accepted(), "successful reply continues the connection handshake");
+    check(state.phase() == GuiClientRegistrationState::Phase::Registered,
+          "successful reply marks the GUI client registered");
+
+    state.begin();
+    state.noteRadioMessage(
+        QStringLiteral("The maximum number of connected clients has been reached"),
+        MessageSeverity::Fatal);
+    const GuiClientRegistrationState::Result fullRadio =
+        state.complete(static_cast<int>(0xF3000001U), {});
+    check(!fullRadio.accepted(), "nonzero reply rejects GUI registration");
+    check(!fullRadio.automaticRetryAllowed(),
+          "rejected GUI registration waits for an explicit reconnect");
+    check(state.phase() == GuiClientRegistrationState::Phase::Rejected,
+          "rejected reply enters the terminal rejected state");
+    check(fullRadio.detail
+              == QStringLiteral("The maximum number of connected clients has been reached"),
+          "fatal radio message supplies the rejection detail when the reply body is empty");
+
+    state.begin();
+    state.noteRadioMessage(QStringLiteral("older fatal detail"), MessageSeverity::Fatal);
+    const GuiClientRegistrationState::Result bodyWins =
+        state.complete(static_cast<int>(0xF3000001U),
+                       QStringLiteral("reply-specific detail"));
+    check(bodyWins.detail == QStringLiteral("reply-specific detail"),
+          "command reply detail takes precedence over a preceding fatal message");
+
+    state.begin();
+    state.noteRadioMessage(QStringLiteral("routine notice"), MessageSeverity::Info);
+    const GuiClientRegistrationState::Result noDetail =
+        state.complete(static_cast<int>(0xF3000001U), {});
+    check(noDetail.detail.isEmpty(),
+          "non-error radio messages cannot become registration failure details");
+
+    state.reset();
+    check(state.phase() == GuiClientRegistrationState::Phase::Idle,
+          "disconnect reset returns the state machine to idle");
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Treat a rejected `client gui` command as a terminal connection failure instead of continuing as an unusable non-GUI client. SmartSDR result codes are now parsed as unsigned 32-bit values so fatal responses such as `F3000001` cannot overflow to zero and appear successful.

On rejection, AetherSDR stops post-registration setup, closes the TCP connection, suppresses automatic retry loops, and returns to the Connect panel with the radio's actual error and recovery instructions. A later explicit Connect action starts a fresh TCP session and GUI registration normally.

Focused state-machine and loopback protocol tests cover successful registration, fatal rejection, teardown, suppressed automatic retry, and explicit reconnect.

## Constitution principle honored

Principle VII — Untrusted Input Is Validated At The Boundary. SmartSDR response codes are validated across their full unsigned 32-bit range, and a non-zero GUI registration result fails closed before subscriptions, UDP setup, or stream creation can proceed.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local validation on the final rebased commit:

- `gui_client_registration_state_test` passes.
- `gui_client_registration_recovery_test` passes.
- Full macOS `AetherSDR` target links successfully.
- `tools/check_engine_boundary.py --strict` reports zero blocking findings.
- `git diff --check` passes.

Native Windows/FLEX-6700 validation:

1. Occupied both GUI/MultiFlex slots with passive, receive-only fixtures.
2. Connected the Home2 worktree build with automation TX disabled.
3. Confirmed the radio returned `MF3000001` and `R...|F3000001|The maximum number of connected clients has been reached`.
4. Confirmed AetherSDR returned to `connected:false` with zero pans and slices, displayed the real error, and issued no blind TCP or GUI-registration retry.
5. Released the fixture clients and selected Connect again.
6. Confirmed a fresh TCP connection and `client gui` command succeeded, followed by an owned slice, panadapter, waterfall, and `remote_audio_rx` stream.

TX automation remained disabled throughout; the radio never transmitted. This native proof used the same fix immediately before its clean rebase onto the current `upstream/main`; the final rebased commit was then rebuilt and regression-tested on macOS.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (not applicable; no meter changes)
- [x] Documentation updated if user-visible behavior changed (recovery guidance is included directly in the connection error)
- [x] Security-sensitive changes reference a GHSA if applicable (not applicable)
