### PR TITLE
fix(asr): move Copy Assist off the lossy visualization tap (#4486)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3510,6 +3510,14 @@ if (ENABLE_ASR)
     target_link_libraries(asr_remote_backend_test PRIVATE Qt6::Core Qt6::Network)
     add_test(NAME asr_remote_backend_test COMMAND asr_remote_backend_test)
 
+    # Copy Assist audio tap: which RX source it follows, and the stereo→mono
+    # collapse including the non-finite guard. The policy is header-only, so
+    # this needs no AudioEngine — which cannot be built headless anyway (#4486).
+    add_executable(asr_tap_policy_test tests/asr_tap_policy_test.cpp)
+    target_include_directories(asr_tap_policy_test PRIVATE src)
+    target_link_libraries(asr_tap_policy_test PRIVATE Qt6::Core)
+    add_test(NAME asr_tap_policy_test COMMAND asr_tap_policy_test)
+
     # Copy Assist panel: offscreen UI test of confidence color-coding + controls.
     add_executable(copy_assist_panel_test
         tests/copy_assist_panel_test.cpp

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -641,10 +641,26 @@ signals:
     // because those paths intentionally skip the voice chain.
     void txPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     // Mirror of txPostChainScopeReady for the RX side: high-rate emit
-    // (~125 Hz, no sample loss across audio callbacks) so the channel
-    // strip's "Aetherial Waveform — RX" panel sees a wall-clock-accurate
-    // scope.  The shared scopeSamplesReady throttles at 25 ms which made
-    // the strip's RX scroll lag wall clock at short time-window settings.
+    // (~125 Hz) so the channel strip's "Aetherial Waveform — RX" panel sees a
+    // wall-clock-accurate scope.  The shared scopeSamplesReady throttles at
+    // 25 ms which made the strip's RX scroll lag wall clock at short
+    // time-window settings.
+    //
+    // LOSSY — FOR DISPLAY ONLY.  This is throttled at 8 ms and the throttle
+    // DISCARDS the whole block, it does not merely skip a repaint.  Blocks
+    // shorter than 8 ms are therefore dropped outright: with NR2 enabled the
+    // RX drain hands over whole radio packets (5.33 ms on a Flex LAN stream)
+    // microseconds apart, and only the first of each drain tick survives —
+    // about half the audio.  An earlier version of this comment claimed "no
+    // sample loss across audio callbacks", which holds only while blocks are
+    // at least 8 ms long; Copy Assist was wired here on the strength of it and
+    // was fed a stream with a gap at every phoneme (#4486).
+    //
+    // Anything that must see EVERY sample — recognisers, decoders, recorders —
+    // belongs on receivePresentationPostDspAudioReady, which is unthrottled and
+    // additionally tags its source.  Also note this signal is emitted for every
+    // RX source with no tag, so a station running a Kiwi alongside the Flex
+    // sees the two interleaved here.
     void rxPostChainScopeReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     void tncRxAudioReady(const QByteArray& monoFloat32Pcm, int sampleRate);
     void radioTransmittingChanged(bool tx);

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -6,8 +6,6 @@
 #include <QByteArray>
 #include <QVector>
 
-#include <algorithm>
-
 namespace AetherSDR {
 
 AsrAudioTap::AsrAudioTap(AudioEngine* audio, AsrEngine* asr, QObject* parent)
@@ -28,31 +26,44 @@ void AsrAudioTap::setEnabled(bool on)
     }
 
     if (on) {
+        // A fresh session picks its receiver again — the one that was live last
+        // time may be gone, and the operator would otherwise have to wait out
+        // the release window before anything was transcribed.
+        m_policy.reset();
+        m_clock.start();
         if (m_audio != nullptr) {
             // Queued so the audio-thread emit lands on this (main) thread; the
             // heavy resample+inference then happens on the ASR worker thread.
-            m_conn = connect(m_audio, &AudioEngine::rxPostChainScopeReady,
+            //
+            // Unthrottled by design — see the note in the header. Every block
+            // this signal carries must reach the engine.
+            m_conn = connect(m_audio, &AudioEngine::receivePresentationPostDspAudioReady,
                              this, &AsrAudioTap::onRxAudio, Qt::QueuedConnection);
         }
     } else {
         disconnect(m_conn);
+        m_policy.reset();
         // m_asr->setEnabled(false) above already resets and drops any queued
         // backlog — no separate reset() needed here.
     }
 }
 
-void AsrAudioTap::onRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate)
+void AsrAudioTap::onRxAudio(const QString& source,
+                            const QString& sourceId,
+                            const QByteArray& stereoFloat32Pcm,
+                            int sampleRate)
 {
     if (!m_enabled || m_asr == nullptr) {
         return;
     }
-    const int n = monoFloat32Pcm.size() / static_cast<int>(sizeof(float));
-    if (n <= 0) {
+    if (!m_policy.accepts(source, sourceId,
+                          m_clock.isValid() ? m_clock.elapsed() : 0)) {
         return;
     }
-    const auto* f = reinterpret_cast<const float*>(monoFloat32Pcm.constData());
-    QVector<float> mono(n);
-    std::copy(f, f + n, mono.begin());
+    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm);
+    if (mono.isEmpty()) {
+        return;
+    }
     m_asr->pushAudio(mono, sampleRate);
 }
 

--- a/src/gui/AsrAudioTap.h
+++ b/src/gui/AsrAudioTap.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <QObject>
+#include "gui/AsrTapPolicy.h"
+
+#include <QElapsedTimer>
 #include <QMetaObject>
+#include <QObject>
 
 class QByteArray;
 
@@ -15,10 +18,31 @@ class AsrEngine;
 // AudioEngine with aetherasr's AsrEngine without either knowing about the other,
 // keeping both libraries decoupled (the whole point of the aetherasr split).
 //
-// When enabled it forwards the post-client-NR mono RX audio (AudioEngine's
-// rxPostChainScopeReady, 24 kHz) to AsrEngine, which resamples to 16 kHz on its
-// own worker thread — so nothing here runs on the audio callback. When disabled
-// it disconnects entirely, so an idle ASR feature costs nothing.
+// When enabled it forwards post-client-DSP mono RX audio to AsrEngine, which
+// resamples to 16 kHz on its own worker thread — so nothing here runs on the
+// audio callback. When disabled it disconnects entirely, so an idle ASR feature
+// costs nothing.
+//
+// ── Which engine signal, and why it matters (#4486) ───────────────────────
+//
+// This subscribes to receivePresentationPostDspAudioReady, NOT to
+// rxPostChainScopeReady. The latter is a VISUALISATION signal: it drops any
+// block arriving within 8 ms of the previous one. That is correct for a scope
+// and ruinous for a recogniser, and it was not hypothetical — with NR2 enabled
+// the engine queues whole radio packets and drains them in a tight loop, so
+// blocks arrive microseconds apart at 5.33 ms each (128 frames at 24 kHz on a
+// Flex LAN stream). Only the first survived each drain tick, which discarded
+// roughly HALF the speech samples and spliced what remained into a stream with
+// a discontinuity at every phoneme. ASR "barely worked" with NR2 on while the
+// speaker sounded better than ever, because the speaker path was never lossy.
+//
+// The presentation signal is unthrottled, carries the same post-DSP audio from
+// the same place in writeAudio(), and is additionally tagged with its source —
+// which is what lets the tap follow ONE receiver instead of an interleaved mix
+// of every Kiwi on the system. See AsrTapPolicy.
+//
+// Do NOT "fix" this by relaxing the 8 ms throttle: StripWaveformPanel and
+// MainWindow are its intended consumers and frame-dropping is right for them.
 //
 // In the aetherd future this glue moves to the engine/daemon side; the thin UI
 // then subscribes to AsrEngine::finalText streamed over the wire and never sees
@@ -32,12 +56,17 @@ public:
     bool isEnabled() const { return m_enabled; }
 
 private:
-    void onRxAudio(const QByteArray& monoFloat32Pcm, int sampleRate);
+    void onRxAudio(const QString& source,
+                   const QString& sourceId,
+                   const QByteArray& stereoFloat32Pcm,
+                   int sampleRate);
 
     AudioEngine* m_audio = nullptr;
     AsrEngine* m_asr = nullptr;
     QMetaObject::Connection m_conn;
     bool m_enabled = false;
+    AsrTapPolicy m_policy;
+    QElapsedTimer m_clock;   // monotonic source for the policy's release window
 };
 
 } // namespace AetherSDR

--- a/src/gui/AsrTapPolicy.h
+++ b/src/gui/AsrTapPolicy.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+
+namespace AetherSDR {
+
+// The two decisions AsrAudioTap has to make about the RX audio it forwards to
+// the ASR engine: WHICH receiver's blocks to follow, and how to turn a post-DSP
+// stereo block into the mono float32 the engine expects.
+//
+// Split out of AsrAudioTap because that class is a QObject wired to a concrete
+// AudioEngine, and AudioEngine cannot be constructed in a headless test (it
+// needs a live QAudioSink). This is Qt-object-free and header-only so the logic
+// that can actually be wrong is unit-testable on its own; what is left in the
+// tap is a connect() and a call into here.
+//
+// ── Why a source lock exists at all ───────────────────────────────────────
+//
+// receivePresentationPostDspAudioReady is emitted from writeAudio(), which runs
+// once per RX source: the Flex, the applet Kiwi, and every external Kiwi
+// antenna. A consumer that takes all of them receives two or more receivers'
+// audio interleaved into one stream. For a waveform that is cosmetic; for a
+// speech recogniser it is noise. Copy Assist has no receiver selector of its
+// own (it follows "the RX audio"), so the tap picks one and stays with it.
+class AsrTapPolicy {
+public:
+    // A source that has stopped producing blocks for this long has released its
+    // claim. Post-DSP audio flows continuously while a receiver is up — a quiet
+    // band still produces blocks of near-silence — so a gap this long means the
+    // source went away, not that nobody is talking.
+    static constexpr qint64 kSourceReleaseMs = 2000;
+
+    // True when this block belongs to the receiver Copy Assist is following.
+    //
+    // The first block after a reset claims the lock, so a Flex-only station
+    // locks Flex and a Kiwi-only station locks Kiwi with no configuration. With
+    // both running the choice between them is arbitrary, but it is CONSISTENT,
+    // which is the property that matters — an arbitrary single receiver is
+    // transcribable and two interleaved ones are not.
+    //
+    // `nowMs` is passed in rather than read from a clock so the release window
+    // is testable without sleeping.
+    bool accepts(const QString& source, const QString& sourceId, qint64 nowMs)
+    {
+        if (m_locked && (source != m_source || sourceId != m_sourceId)) {
+            if (nowMs - m_lastAcceptMs < kSourceReleaseMs) {
+                return false;
+            }
+            // The locked source went silent and another is still running:
+            // hand the lock over rather than transcribing nothing. This is how
+            // an operator switching from the Flex to a Kiwi mid-session is
+            // picked up without touching Copy Assist.
+            m_locked = false;
+        }
+        if (!m_locked) {
+            m_locked = true;
+            m_source = source;
+            m_sourceId = sourceId;
+        }
+        m_lastAcceptMs = nowMs;
+        return true;
+    }
+
+    // Drop the claim. Called when the tap is disabled, so the next session is
+    // free to lock whichever receiver is live then.
+    void reset()
+    {
+        m_locked = false;
+        m_source.clear();
+        m_sourceId.clear();
+        m_lastAcceptMs = 0;
+    }
+
+    bool hasLock() const { return m_locked; }
+    QString lockedSource() const { return m_source; }
+    QString lockedSourceId() const { return m_sourceId; }
+
+    // Collapse interleaved float32 stereo to mono, matching what
+    // AudioEngine::emitRxPostChainScopeFromFloat32Stereo used to hand us —
+    // INCLUDING the non-finite guard. AsrEngine does not sanitise its input, and
+    // a single NaN reaching the resampler poisons every sample after it, so
+    // dropping that clamp when moving off the engine-side tap would trade a
+    // known bug for a worse one.
+    static QVector<float> toMono(const QByteArray& stereoFloat32)
+    {
+        const int floatSamples =
+            static_cast<int>(stereoFloat32.size() / static_cast<int>(sizeof(float)));
+        if (floatSamples <= 0) {
+            return {};
+        }
+        const bool stereo = (floatSamples % 2) == 0;
+        const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+
+        QVector<float> mono(monoSamples);
+        const auto* src = reinterpret_cast<const float*>(stereoFloat32.constData());
+        for (int i = 0; i < monoSamples; ++i) {
+            const float v = stereo ? (src[2 * i] + src[2 * i + 1]) * 0.5f : src[i];
+            mono[i] = std::clamp(std::isfinite(v) ? v : 0.0f, -1.0f, 1.0f);
+        }
+        return mono;
+    }
+
+private:
+    bool    m_locked = false;
+    QString m_source;
+    QString m_sourceId;
+    qint64  m_lastAcceptMs = 0;
+};
+
+} // namespace AetherSDR

--- a/tests/asr_tap_policy_test.cpp
+++ b/tests/asr_tap_policy_test.cpp
@@ -1,0 +1,213 @@
+// The two decisions the Copy Assist audio tap makes about incoming RX blocks:
+// which receiver to follow, and how to collapse a post-DSP stereo block to the
+// mono float the ASR engine consumes. (#4486)
+//
+// These are unit-tested rather than driven end-to-end through AudioEngine
+// because AudioEngine cannot be constructed headless — it needs a live
+// QAudioSink, and no test in this suite instantiates one. What that leaves
+// unverified here is the connect() itself, which is a single line visible in
+// review; what it DOES verify is every rule that has state and can therefore
+// drift.
+
+#include "gui/AsrTapPolicy.h"
+
+#include <QCoreApplication>
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+namespace AetherSDR {
+
+static int g_failures = 0;
+static void check(bool ok, const char* what)
+{
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++g_failures; }
+}
+
+static QByteArray stereoBlock(std::initializer_list<std::pair<float, float>> frames)
+{
+    QByteArray out(static_cast<int>(frames.size()) * 2
+                       * static_cast<int>(sizeof(float)),
+                   Qt::Uninitialized);
+    auto* f = reinterpret_cast<float*>(out.data());
+    int i = 0;
+    for (const auto& [l, r] : frames) {
+        f[i++] = l;
+        f[i++] = r;
+    }
+    return out;
+}
+
+// ── Source lock ───────────────────────────────────────────────────────────
+
+// receivePresentationPostDspAudioReady fires once per RX source. Taking all of
+// them hands a recogniser two receivers interleaved into one stream, which is
+// the state Copy Assist shipped in. One source, consistently, is the fix.
+static void testLocksOntoOneSource()
+{
+    AsrTapPolicy p;
+    check(!p.hasLock(), "a fresh policy follows nothing yet");
+
+    check(p.accepts(QStringLiteral("flex"), QString(), 0),
+          "the first block claims the lock");
+    check(p.hasLock() && p.lockedSource() == QLatin1String("flex"),
+          "the lock records which source claimed it");
+
+    // A Kiwi running alongside the Flex must not be mixed in.
+    check(!p.accepts(QStringLiteral("kiwi"), QString(), 5),
+          "a second, different source is refused while the first is live");
+    check(!p.accepts(QStringLiteral("kiwi"), QStringLiteral("ant-2"), 10),
+          "an external Kiwi antenna is refused for the same reason");
+
+    check(p.accepts(QStringLiteral("flex"), QString(), 15),
+          "the locked source keeps being accepted");
+}
+
+// A Kiwi-only station has no Flex blocks at all. Hard-coding "flex" would have
+// silently disabled Copy Assist for them, which is why the first block claims
+// the lock rather than the policy naming a preferred source.
+static void testAnySourceMayClaimTheLock()
+{
+    AsrTapPolicy p;
+    check(p.accepts(QStringLiteral("kiwi"), QStringLiteral("ant-1"), 0),
+          "a Kiwi-only station locks its Kiwi");
+    check(p.lockedSource() == QLatin1String("kiwi")
+              && p.lockedSourceId() == QLatin1String("ant-1"),
+          "the sourceId is part of the identity, not just the family");
+
+    // Same family, different antenna, is a DIFFERENT receiver.
+    check(!p.accepts(QStringLiteral("kiwi"), QStringLiteral("ant-2"), 5),
+          "a sibling Kiwi antenna does not share the lock");
+}
+
+// An operator who switches receivers mid-session must not be left transcribing
+// silence forever. Post-DSP audio flows continuously while a receiver is up —
+// a quiet band still produces blocks — so a long gap means the source went
+// away, and only then does the lock move.
+static void testSilentSourceReleasesTheLock()
+{
+    AsrTapPolicy p;
+    check(p.accepts(QStringLiteral("flex"), QString(), 1000), "flex claims the lock");
+
+    // Just under the window: still the Flex's lock, even though it has been
+    // quiet for nearly two seconds.
+    check(!p.accepts(QStringLiteral("kiwi"), QString(),
+                     1000 + AsrTapPolicy::kSourceReleaseMs - 1),
+          "the lock is not stolen before the release window elapses");
+
+    check(p.accepts(QStringLiteral("kiwi"), QString(),
+                    1000 + AsrTapPolicy::kSourceReleaseMs),
+          "a source silent for the whole window releases its lock");
+    check(p.lockedSource() == QLatin1String("kiwi"),
+          "the new source takes the lock over");
+
+    // And the window is measured from the last ACCEPTED block, so a stream of
+    // refused blocks from the other source cannot keep resetting it.
+    check(!p.accepts(QStringLiteral("flex"), QString(),
+                     1000 + AsrTapPolicy::kSourceReleaseMs + 1),
+          "the previous owner is now the one being refused");
+}
+
+// Disabling Copy Assist and re-enabling it must not make the operator wait out
+// a release window against a receiver that is no longer there.
+static void testResetDropsTheLock()
+{
+    AsrTapPolicy p;
+    p.accepts(QStringLiteral("flex"), QString(), 0);
+    p.reset();
+    check(!p.hasLock(), "reset drops the claim");
+    check(p.accepts(QStringLiteral("kiwi"), QString(), 1),
+          "the next session locks whichever receiver is live then, immediately");
+}
+
+// ── Stereo → mono ─────────────────────────────────────────────────────────
+
+static void testMonoCollapse()
+{
+    // L/R averaged, matching what emitRxPostChainScopeFromFloat32Stereo handed
+    // over before the tap moved. Asymmetric channels prove it is an average and
+    // not a channel pick.
+    const QByteArray in = stereoBlock({{1.0f, 0.0f}, {-0.5f, -0.5f}, {0.25f, 0.75f}});
+    const QVector<float> mono = AsrTapPolicy::toMono(in);
+
+    check(mono.size() == 3, "one mono sample per stereo frame");
+    if (mono.size() != 3) return;
+    check(std::fabs(mono[0] - 0.5f) < 1e-6f, "L/R are averaged, not taken from one channel");
+    check(std::fabs(mono[1] + 0.5f) < 1e-6f, "a matched pair passes through unchanged");
+    check(std::fabs(mono[2] - 0.5f) < 1e-6f, "averaging is correct for unequal channels");
+}
+
+// AsrEngine does not sanitise its input, and one NaN reaching the resampler
+// poisons every sample after it. The engine-side tap clamped; dropping that on
+// the way out would have traded a known bug for a worse one.
+static void testMonoCollapseGuardsAgainstNonFiniteAndClipping()
+{
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+    const float inf = std::numeric_limits<float>::infinity();
+    const QByteArray in = stereoBlock({{nan, 0.0f}, {inf, inf}, {5.0f, 5.0f}, {-9.0f, -9.0f}});
+    const QVector<float> mono = AsrTapPolicy::toMono(in);
+
+    check(mono.size() == 4, "non-finite input still yields one sample per frame");
+    if (mono.size() != 4) return;
+    check(mono[0] == 0.0f, "a NaN channel becomes silence, not a poisoned sample");
+    check(mono[1] == 0.0f, "an infinite channel becomes silence");
+    check(std::fabs(mono[2] - 1.0f) < 1e-6f, "over-range audio clamps to +1.0");
+    check(std::fabs(mono[3] + 1.0f) < 1e-6f, "under-range audio clamps to -1.0");
+}
+
+static void testMonoCollapseEdgeCases()
+{
+    check(AsrTapPolicy::toMono(QByteArray()).isEmpty(),
+          "an empty block produces no samples");
+    // Shorter than one float: must not read past the end.
+    check(AsrTapPolicy::toMono(QByteArray(3, '\0')).isEmpty(),
+          "a sub-sample block produces no samples");
+}
+
+// The property the whole change exists to protect: EVERY sample handed to the
+// policy comes back out. The old tap dropped whole blocks; nothing here may.
+static void testNoSamplesAreDropped()
+{
+    AsrTapPolicy p;
+    // 128 stereo frames is a Flex LAN audio packet — the 5.33 ms block that the
+    // 8 ms scope throttle used to discard when NR2 drained several per tick.
+    constexpr int kFramesPerPacket = 128;
+    QByteArray packet(kFramesPerPacket * 2 * static_cast<int>(sizeof(float)),
+                      Qt::Uninitialized);
+    auto* f = reinterpret_cast<float*>(packet.data());
+    for (int i = 0; i < kFramesPerPacket * 2; ++i) {
+        f[i] = 0.1f;
+    }
+
+    // Ten packets delivered in the same millisecond, exactly as the NR2 drain
+    // loop delivers them.
+    int delivered = 0;
+    for (int n = 0; n < 10; ++n) {
+        if (p.accepts(QStringLiteral("flex"), QString(), 0)) {
+            delivered += AsrTapPolicy::toMono(packet).size();
+        }
+    }
+    check(delivered == 10 * kFramesPerPacket,
+          "ten packets arriving in the same millisecond all reach the engine");
+}
+
+}  // namespace AetherSDR
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    AetherSDR::testLocksOntoOneSource();
+    AetherSDR::testAnySourceMayClaimTheLock();
+    AetherSDR::testSilentSourceReleasesTheLock();
+    AetherSDR::testResetDropsTheLock();
+    AetherSDR::testMonoCollapse();
+    AetherSDR::testMonoCollapseGuardsAgainstNonFiniteAndClipping();
+    AetherSDR::testMonoCollapseEdgeCases();
+    AetherSDR::testNoSamplesAreDropped();
+
+    if (AetherSDR::g_failures == 0)
+        std::fprintf(stderr, "asr_tap_policy_test: all checks passed\n");
+    return AetherSDR::g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #4486.

## The problem

Copy Assist subscribed to `rxPostChainScopeReady`, which is a **visualization** signal: it drops any block arriving within 8 ms of the previous one, and the throttle `return`s before any processing — it discards the whole block, it does not merely skip a repaint.

NR2 is the only DSP mode that exposes this. With NR2 off the RX drain appends to `m_rxBuffer` and the timer takes one contiguous ~10 ms chunk per tick, which clears the threshold. With NR2 on the drain queues whole radio packets and empties them in a tight loop, so blocks arrive microseconds apart at **5.33 ms** each (128 frames at 24 kHz on a Flex LAN stream). Only the first of each tick survived.

That discarded roughly **half the speech samples**, and spliced what remained into a stream with a 5.33 ms discontinuity at every join — the resampler and VAD assume contiguous PCM and have no way to detect or bridge the gaps. The speaker path was never lossy, so NR2 sounded *better* while Copy Assist got worse, which is exactly why this read as an NR2 speech-quality problem.

`AsrEngine`'s backlog meter is structurally blind to it: `m_pushedMs` counts only samples that arrive, so it reported a healthy engine that was being starved.

## The fix touches no audio processing

`receivePresentationPostDspAudioReady` is **already emitted unconditionally** seven lines above the throttled scope emit, from the same `writeAudio` lambda, carrying the same `*output` buffer at the same rate. It was simply never used for this.

So the change is one `connect()` plus the stereo→mono collapse the engine used to do on our behalf. **The only edit to `AudioEngine.h` is a comment** — the diff filtered of comment lines is empty, and `AudioEngine.cpp` is untouched entirely.

The 8 ms throttle is deliberately left alone: `StripWaveformPanel` and `MainWindow` are its intended consumers and dropping frames is correct for them.

(I evaluated `receivePresentationOutputAudioReady` first — it is suppressed unless Kiwi audio is active, so it is a Kiwi-sync diagnostic rather than a general tap.)

## A second defect fixed on the way past

The scope signal is emitted for **every** RX source with no tag, so a station running a Kiwi alongside the Flex was already feeding Copy Assist two receivers interleaved into a single stream — NR2 or not.

The presentation signal is source-tagged, so `AsrTapPolicy` follows exactly one receiver: the first to produce a block claims the lock, and only a source silent for 2 s hands it over.

Two judgement calls worth a reviewer's eye:

- **First-claim rather than hard-coding `"flex"`.** A Kiwi-only station would otherwise get no transcription at all, which would be a regression from today's behaviour.
- **The 2 s release window** relies on post-DSP audio flowing continuously while a receiver is up — a quiet band still produces blocks of near-silence — so a gap that long means the source went away rather than that nobody is talking.

## Also

Corrects the `rxPostChainScopeReady` contract, which claimed "no sample loss across audio callbacks". That holds only while blocks are at least 8 ms long, and Copy Assist was almost certainly wired there on the strength of it. The replacement comment states the precondition and points anything needing every sample at the unthrottled signal.

## Testing

`asr_tap_policy_test` — 8 cases, all passing — covers the source lock (claim, refuse siblings, release on silence, reset on disable) and the mono collapse (averaging, clamping, and the NaN/Inf guard `AsrEngine` does not do for itself — one NaN poisons every sample after it in the resampler). The load-bearing case asserts that ten packets arriving in the same millisecond all reach the engine.

Full suite: **190/191**. The single failure is `cross_needle_meter_test` ("SWR label placement cache is keyed by the rendered font"), which reproduces identically on pristine `origin/main` in a separate worktree — a local font-environment issue, unrelated to this change.

### What the tests do NOT cover

**The `connect()` itself.** No test in this suite instantiates `AudioEngine` — it needs a live `QAudioSink` — so an end-to-end "feed NR2 packets, count samples out" test is not available without a fixture that does not exist today. That is why the policy is split out header-only: it makes the stateful logic testable, but the wiring line is verified by inspection only.

Given that gap, a live confirmation is still worth doing. The issue notes a cheap one: Opus/reduced-bandwidth streams use 240-frame packets — exactly 10 ms, comfortably over the threshold — so **Copy Assist + NR2 should already work noticeably better over SmartLink than on the LAN before this change, and equally well on both after it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
