### PR TITLE
fix(demo): #4473's unconditional seam-audio connect double-fed HL2 receive

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5750,11 +5750,26 @@ void MainWindow::wireBackendSeam(IRadioBackend* backend)
 
     // Demo/sim backend delivers RX audio directly over the seam (no VITA-49, no
     // PanadapterStream) — same 24 kHz stereo float32 format, so it feeds the
-    // identical AudioEngine path. Harmless for real backends: FlexBackend never
-    // emits audioFrameReady (its audio flows through PanadapterStream), so this
-    // connection simply stays idle unless a SimBackend is active.
-    connect(backend, &IRadioBackend::audioFrameReady,
-            m_audio, &AudioEngine::feedAudioData);
+    // identical AudioEngine path.
+    //
+    // SIM ONLY, and the cast is load-bearing. This was originally unconditional,
+    // on the reasoning that FlexBackend never emits audioFrameReady so the
+    // connection stays idle for "real backends". That holds for Flex and NOT for
+    // HL2: HL2 demodulates in-process and audioFrameReady is its ONLY audio
+    // route (Hl2Backend.cpp, emit audioFrameReady). It therefore arrived here
+    // AND via the RadioModel::backendAudioFrameReady relay in
+    // MainWindow_Session.cpp, whose gate — backendOwnsRxAudio() — excludes only
+    // the sim. Every HL2 frame was delivered twice and the engine consumed at
+    // double rate: measured 48043 Hz at the raw tap against a nominal 24000
+    // (ratio 2.002), audible as popping and crackling on every mode.
+    //
+    // Any future in-process backend needs the same treatment. The gate belongs
+    // on "does this backend own its RX audio", not on a list of families that
+    // happen not to emit the signal today.
+    if (dynamic_cast<SimBackend*>(backend) != nullptr) {
+        connect(backend, &IRadioBackend::audioFrameReady,
+                m_audio, &AudioEngine::feedAudioData);
+    }
 
     // The demo delivers native 128-sample frames, which the improved 1024/4 NR2
     // geometry (#4400) mangles (wobble + dead DSP/RADE); tell the engine to run


### PR DESCRIPTION
## Summary

**This is a regression introduced by #4473 (demo mode), not a defect in the HL2 backend.**

HL2 receive shipped correct in #4448 and its code is unchanged here. **This PR touches no HL2 file at all** — the fix is one conditional in demo-mode seam wiring in `src/gui/MainWindow.cpp`. HL2 is where the breakage was *observed*; it is not where the breakage was *introduced*.

Symptom on a live Hermes-Lite 2: popping and crackling on every mode (LSB, USB, AM). Unaffected by a radio power-cycle, with CPU at 7% — so nothing about it was radio-side or load-related.

## What HL2 had before #4473

#4448 gave HL2 exactly one audio route, and it was correct:

```
Hl2Backend::audioFrameReady
  → RadioModel::backendAudioFrameReady        (RadioModel.cpp, added by #4448)
  → MainWindow_Session.cpp relay
  → AudioEngine::feedAudioData
```

One producer, one path, one delivery. Nothing about that needed changing, and nothing in this PR changes it.

## What #4473 changed

It added a **second, ungated** path from the same signal to the same slot:

```cpp
// wireBackendSeam(), src/gui/MainWindow.cpp — added by #4473, all backends
connect(backend, &IRadioBackend::audioFrameReady,
        m_audio, &AudioEngine::feedAudioData);
```

and gated the pre-existing route for the demo only:

```cpp
// MainWindow_Session.cpp — guard added by #4473
if (backendOwnsRxAudio()) return;   // dynamic_cast<SimBackend*>
```

| route | introduced by | gate | HL2 result |
|---|---|---|---|
| 1 — relay via `RadioModel` | #4448 | `if (backendOwnsRxAudio()) return;` | passes → fires |
| 2 — direct seam connect | **#4473** | none | fires |

HL2 satisfied neither exclusion, so it got both. Every frame reached the sink twice and the engine consumed at double rate.

## The premise that made it invisible

#4473's own description states the reasoning:

> `FlexBackend` is structurally immune — it never emits `audioFrameReady` at all … which is why the existing "no double-feed" comment holds for Flex and HL2.

That is true for Flex and false for HL2. `Hl2Backend` demodulates in-process, and `audioFrameReady` is its **only** RX audio route — so the one backend the new connect was assumed not to affect was the one it broke. The same assumption is repeated in the code comment at the connect site ("Harmless for real backends").

#4473 diagnosed this exact failure mode for the demo, predicted its signature precisely ("the engine consumes at double rate: an audible ~187.5 Hz scratchy buzz"), and fixed it — but keyed the gate on backend *identity* rather than on the property that matters, *does this backend own its RX audio*. Flex was immune by accident of not emitting the signal; HL2 was not.

## Measured

Live Hermes-Lite 2, raw tap inside `feedAudioData`, 6 s window — the metric #4473 itself used, where a surviving double-feed reads ratio ≈ 2.0:

| | rate | ratio vs 24 kHz | chunks |
|---|---|---|---|
| with #4473 as merged | 48043 Hz | **2.002** | 1126 |
| with this fix | 24021 Hz | **1.001** | 563 |

Both cross-checked against two independent divisors (capture window and reported `elapsedMs`) so neither figure rests on one choice of denominator: 2.002 / 1.941 and 1.001 / 0.969.

**191/191.** Operator-confirmed on air afterwards: clean receive on AM and USB, and FT8 transmit spotted by third-party receivers.

## The fix

Scope #4473's connect to the backend it was added for. This restores HL2's pre-#4473 topology exactly.

| | stream audio | seam relay (#4448) | direct connect (#4473) | routes |
|---|---|---|---|---|
| Flex | on | never fires | never fires | 1 |
| Demo | gated off | gated off | on | 1 |
| HL2 | no stream | on | **off** | 1 |

- **Flex** — the connect existed but never fired; removing it is a no-op.
- **Demo** — the added condition is exactly when that connect previously did anything, and its relay stays gated. Unchanged. (Verified by inspection: `sim_backend_test` links `aethercore`, not the GUI, so it cannot observe this wiring.)
- **HL2** — restored to one route.

## Scope

One file, one conditional, in demo-mode wiring. Zero HL2 files.

## On the waterfall lines

The original report also mentioned horizontal lines in the waterfall. An earlier revision of this description proposed they were downstream of the same cause; **that mechanism is not supported and I withdraw it.**

`dss snapshot` exposes `dssVisibleFlatRows` — a flat row being precisely a horizontal line — measured over 13 s on both builds:

| | rows/s | visible rows | flat rows | peak |
|---|---|---|---|---|
| with #4473 as merged | 9.6 | 43 → 96 | **0** | −65.6 dBm |
| with this fix | 9.6 | 42 → 96 | **0** | −65.5 dBm |

Identical, and not vacuous — real rows and real signal in both. Isolated dashes do appear in captures ~16 s after connect, but on **both** builds, at the boundary where the waterfall is still populating, and they are gone once it fills. The operator reports the waterfall looks correct in normal use.

So this PR fixes the audio only, and makes no claim about the waterfall.

---

Found while certifying HL2 bring-up. Diagnosis independently verified against `origin/main` in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
