### PR TITLE
Carry explicit ASR audio channel count

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -4234,7 +4234,7 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
             source == RxDspSource::KiwiSdr ? QStringLiteral("kiwi")
                                            : QStringLiteral("flex"),
             externalSource ? externalSource->id : QString(),
-            *output, scopeSampleRate);
+            *output, 2, scopeSampleRate);
         outputBuffer.append(*output);
         emitScopeFromFloat32Stereo(*output, scopeSampleRate, false);
         emitRxPostChainScopeFromFloat32Stereo(*output, scopeSampleRate);

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -627,6 +627,7 @@ signals:
     void receivePresentationPostDspAudioReady(const QString& source,
                                               const QString& sourceId,
                                               const QByteArray& pcmStereoFloat,
+                                              int channels,
                                               int sampleRate);
     void receivePresentationOutputAudioReady(const QString& source,
                                              const QString& sourceId,

--- a/src/gui/AsrAudioTap.cpp
+++ b/src/gui/AsrAudioTap.cpp
@@ -51,6 +51,7 @@ void AsrAudioTap::setEnabled(bool on)
 void AsrAudioTap::onRxAudio(const QString& source,
                             const QString& sourceId,
                             const QByteArray& stereoFloat32Pcm,
+                            int channels,
                             int sampleRate)
 {
     if (!m_enabled || m_asr == nullptr) {
@@ -60,7 +61,7 @@ void AsrAudioTap::onRxAudio(const QString& source,
                           m_clock.isValid() ? m_clock.elapsed() : 0)) {
         return;
     }
-    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm);
+    const QVector<float> mono = AsrTapPolicy::toMono(stereoFloat32Pcm, channels);
     if (mono.isEmpty()) {
         return;
     }

--- a/src/gui/AsrAudioTap.h
+++ b/src/gui/AsrAudioTap.h
@@ -59,6 +59,7 @@ private:
     void onRxAudio(const QString& source,
                    const QString& sourceId,
                    const QByteArray& stereoFloat32Pcm,
+                   int channels,
                    int sampleRate);
 
     AudioEngine* m_audio = nullptr;

--- a/src/gui/AsrTapPolicy.h
+++ b/src/gui/AsrTapPolicy.h
@@ -86,20 +86,26 @@ public:
     // a single NaN reaching the resampler poisons every sample after it, so
     // dropping that clamp when moving off the engine-side tap would trade a
     // known bug for a worse one.
-    static QVector<float> toMono(const QByteArray& stereoFloat32)
+    static QVector<float> toMono(const QByteArray& float32, int channels)
     {
-        const int floatSamples =
-            static_cast<int>(stereoFloat32.size() / static_cast<int>(sizeof(float)));
-        if (floatSamples <= 0) {
+        if (channels <= 0) {
             return {};
         }
-        const bool stereo = (floatSamples % 2) == 0;
-        const int monoSamples = stereo ? floatSamples / 2 : floatSamples;
+        const qsizetype floatSamples =
+            float32.size() / static_cast<qsizetype>(sizeof(float));
+        if (floatSamples <= 0 || floatSamples % channels != 0) {
+            return {};
+        }
+        const qsizetype monoSamples = floatSamples / channels;
 
-        QVector<float> mono(monoSamples);
-        const auto* src = reinterpret_cast<const float*>(stereoFloat32.constData());
-        for (int i = 0; i < monoSamples; ++i) {
-            const float v = stereo ? (src[2 * i] + src[2 * i + 1]) * 0.5f : src[i];
+        QVector<float> mono(static_cast<qsizetype>(monoSamples));
+        const auto* src = reinterpret_cast<const float*>(float32.constData());
+        for (qsizetype i = 0; i < monoSamples; ++i) {
+            float v = 0.0f;
+            for (int channel = 0; channel < channels; ++channel) {
+                v += src[i * channels + channel];
+            }
+            v /= static_cast<float>(channels);
             mono[i] = std::clamp(std::isfinite(v) ? v : 0.0f, -1.0f, 1.0f);
         }
         return mono;

--- a/tests/asr_tap_policy_test.cpp
+++ b/tests/asr_tap_policy_test.cpp
@@ -129,7 +129,7 @@ static void testMonoCollapse()
     // over before the tap moved. Asymmetric channels prove it is an average and
     // not a channel pick.
     const QByteArray in = stereoBlock({{1.0f, 0.0f}, {-0.5f, -0.5f}, {0.25f, 0.75f}});
-    const QVector<float> mono = AsrTapPolicy::toMono(in);
+    const QVector<float> mono = AsrTapPolicy::toMono(in, 2);
 
     check(mono.size() == 3, "one mono sample per stereo frame");
     if (mono.size() != 3) return;
@@ -146,7 +146,7 @@ static void testMonoCollapseGuardsAgainstNonFiniteAndClipping()
     const float nan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
     const QByteArray in = stereoBlock({{nan, 0.0f}, {inf, inf}, {5.0f, 5.0f}, {-9.0f, -9.0f}});
-    const QVector<float> mono = AsrTapPolicy::toMono(in);
+    const QVector<float> mono = AsrTapPolicy::toMono(in, 2);
 
     check(mono.size() == 4, "non-finite input still yields one sample per frame");
     if (mono.size() != 4) return;
@@ -158,11 +158,22 @@ static void testMonoCollapseGuardsAgainstNonFiniteAndClipping()
 
 static void testMonoCollapseEdgeCases()
 {
-    check(AsrTapPolicy::toMono(QByteArray()).isEmpty(),
+    check(AsrTapPolicy::toMono(QByteArray(), 2).isEmpty(),
           "an empty block produces no samples");
     // Shorter than one float: must not read past the end.
-    check(AsrTapPolicy::toMono(QByteArray(3, '\0')).isEmpty(),
+    check(AsrTapPolicy::toMono(QByteArray(3, '\0'), 2).isEmpty(),
           "a sub-sample block produces no samples");
+
+    QByteArray mono(4 * static_cast<int>(sizeof(float)), Qt::Uninitialized);
+    auto* samples = reinterpret_cast<float*>(mono.data());
+    samples[0] = 0.1f;
+    samples[1] = 0.2f;
+    samples[2] = 0.3f;
+    samples[3] = 0.4f;
+    check(AsrTapPolicy::toMono(mono, 1).size() == 4,
+          "an even-length mono block remains mono when channels are explicit");
+    check(AsrTapPolicy::toMono(mono, 0).isEmpty(),
+          "an invalid channel count is rejected");
 }
 
 // The property the whole change exists to protect: EVERY sample handed to the
@@ -185,7 +196,7 @@ static void testNoSamplesAreDropped()
     int delivered = 0;
     for (int n = 0; n < 10; ++n) {
         if (p.accepts(QStringLiteral("flex"), QString(), 0)) {
-            delivered += AsrTapPolicy::toMono(packet).size();
+            delivered += AsrTapPolicy::toMono(packet, 2).size();
         }
     }
     check(delivered == 10 * kFramesPerPacket,


### PR DESCRIPTION
## What changed

`AsrTapPolicy::toMono()` inferred channel count from sample-count parity. That misclassified even-length mono buffers as stereo and could halve their duration.

This change carries the explicit channel count through the audio signal and tap, rejects buffers that are not whole frames, and adds coverage for even-length mono input.

## Verification

- `git diff --check` passed.
- Updated all signal, slot, helper, and test call sites.
- Full CMake build was not run because `cmake` is unavailable in this environment.

Fixes #4489