### PR TITLE
fix(ci): source glslc from LunarG on jammy so the x86_64 AppImage builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build pkg-config \
-            glslc libvulkan-dev spirv-headers \
+            libvulkan-dev spirv-headers \
             libgl1-mesa-dev libxkbcommon-dev libxkbcommon-x11-0 \
             libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxcb-shape0 \
             libxcb-render-util0 libxcb-xinerama0 libxcb-randr0 libxcb-xfixes0 \
@@ -42,6 +42,40 @@ jobs:
             libfuse2 file desktop-file-utils imagemagick \
             python3-pip autoconf automake libtool libasound2-dev \
             libfftw3-dev libhidapi-dev portaudio19-dev
+
+      # glslc — the SPIR-V shader compiler that whisper's Vulkan backend needs
+      # at BUILD time (CMake resolves it via find_package(Vulkan COMPONENTS
+      # glslc), and REQUIRE_ASR_GPU=ON makes a miss fatal on x86_64).
+      #
+      # It is packaged as `glslc` on Ubuntu 24.04+ but NOT on 22.04, where it
+      # simply does not exist — installing it unconditionally is what broke the
+      # x86_64 leg of the v26.7.4 tag with "E: Unable to locate package glslc".
+      # The x86_64 AppImage stays on jammy deliberately (it keeps the AppImage's
+      # glibc floor low enough for older distros), so bumping the runner is not
+      # the fix. Pull glslc from LunarG's Vulkan SDK repo instead — the same
+      # vendor scripts/setup/setup-vulkan-sdk.ps1 already uses on Windows.
+      # `shaderc` is the ~6 MB package that ships /usr/bin/glslc; `vulkan-sdk`
+      # would drag in the entire SDK for one binary.
+      #
+      # This workflow only runs on tag pushes, so a break here is invisible
+      # until release day — hence the explicit `glslc --version` assertion on
+      # both legs.
+      - name: Install glslc (Ubuntu 24.04+)
+        if: matrix.runner != 'ubuntu-22.04'
+        run: |
+          sudo apt-get install -y glslc
+          glslc --version
+
+      - name: Install glslc from LunarG (Ubuntu 22.04)
+        if: matrix.runner == 'ubuntu-22.04'
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+            | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc > /dev/null
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+            https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update
+          sudo apt-get install -y shaderc
+          glslc --version
 
       - name: Install system Qt (ARM only)
         if: matrix.use_aqt == false


### PR DESCRIPTION
**Release blocker for v26.7.4** — the tag produced no x86_64 AppImage.

## What broke

```
E: Unable to locate package glslc
##[error]Process completed with exit code 100
```

`glslc` is packaged as `glslc` on Ubuntu 24.04+ but **does not exist on 22.04**.
The shared apt line installed it unconditionally, so:

| leg | runner | `require_gpu` | result |
|---|---|---|---|
| aarch64 | `ubuntu-24.04-arm` | `OFF` | ✅ passed — has the package, doesn't need it |
| x86_64 | `ubuntu-22.04` | `ON` | ❌ **failed** — needs it, package doesn't exist |

The irony is exact: x86_64 is the leg that actually needs `glslc` — CMake resolves
it through `find_package(Vulkan COMPONENTS glslc)` and `REQUIRE_ASR_GPU=ON` makes a
miss fatal — and it's the one on the distro without it. It died in
*Install system dependencies*, before compiling a single file.

## Why it wasn't caught

Introduced by `4d7f00a6` (#4338, Copy Assist via whisper.cpp), which added the
Vulkan GPU backend and its `glslc` dependency together.

`appimage.yml` triggers on **`push: tags: ['v*']` and `workflow_dispatch` only** —
never on PRs or `main`. So nothing exercised it between that merge and the v26.7.4
tag, and the break surfaced on release day. v26.7.3 shipped both AppImages fine.

## The fix

**Keep x86_64 on jammy.** It is on 22.04 deliberately — that keeps the AppImage's
glibc floor low enough for the older distros AppImage exists to serve. Bumping the
runner would trade one breakage for a wider, quieter one.

Instead, install `glslc` from **LunarG's Vulkan SDK repo** — the same vendor
[`scripts/setup/setup-vulkan-sdk.ps1`](scripts/setup/setup-vulkan-sdk.ps1) already
uses on Windows, so this is an established dependency rather than a new one.
`shaderc` is the ~6 MB package that ships the binary; `vulkan-sdk` would pull the
entire SDK for one executable.

Verified against LunarG's jammy index before relying on it:

```
$ ar p shaderc_2025.2~rc1-1lunarg22.04-1_amd64.deb data.tar.zst | zstd -d | tar t | grep bin/
./usr/bin/
./usr/bin/glslc
```

The 24.04-arm leg keeps its plain `apt-get install glslc`, so **its behavior is
unchanged** — worth stating explicitly, since that leg currently gets glslc from
the distro and I did not want to silently alter whether ARM builds with Vulkan.

Both legs now assert `glslc --version` after install. A tag-only workflow hides
this class of break until release day; the assertion makes it fail loudly at the
step that owns it.

## Verification

- Workflow YAML parses; step gating confirmed (`matrix.runner != 'ubuntu-22.04'`
  vs `== 'ubuntu-22.04'`, mutually exclusive across both matrix legs).
- LunarG package contents verified to ship `/usr/bin/glslc` (above).
- Cannot be verified further pre-merge: this workflow does not run on PRs, so the
  real proof is the re-run against the tag.

## Honest caveat

The x86_64 leg has **never completed since #4338** — it has died at dependency
install every time. Fixing `glslc` unblocks that step, but if the Vulkan build path
has further problems on jammy (e.g. `SPIRV-Headers` config resolution), they will
surface next. This fix is necessary; whether it is sufficient is proven only by the
re-run.

## Follow-up worth considering separately

`appimage.yml` running only on tags is the root cause of the *late detection*, not
of the break itself. A `pull_request` trigger scoped to changes under
`.github/workflows/` and the build files would have caught this in #4338. Out of
scope here — this PR is the release unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
