### PR TITLE
fix(ci): build the x86_64 AppImage against LunarG's Vulkan headers, not jammy's

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -28,6 +28,28 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      # Ubuntu 22.04 ships Vulkan 1.3.204 headers, which predate the extensions
+      # the vendored ggml-vulkan uses — VK_KHR_cooperative_matrix,
+      # VK_EXT_pipeline_robustness, VK_EXT_layer_settings, DriverId::eMesaDozen.
+      # Building against them fails with a wall of "is not a member of 'vk'".
+      #
+      # Add LunarG's Vulkan SDK repo BEFORE the shared install so apt resolves
+      # libvulkan-dev and spirv-headers to the SDK's 1.4.313 versions rather
+      # than jammy's, and the loader, headers, SPIR-V headers and glslc all come
+      # from one matched set. Mixing SDK glslc with distro headers is what
+      # produced the second failure on the v26.7.4 tag.
+      #
+      # x86_64 stays on jammy deliberately: it keeps the AppImage's glibc floor
+      # low enough for older distros, so bumping the runner would trade this
+      # breakage for a wider, quieter one.
+      - name: Add LunarG Vulkan SDK repository (Ubuntu 22.04)
+        if: matrix.runner == 'ubuntu-22.04'
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
+            | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc > /dev/null
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+            https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -43,39 +65,36 @@ jobs:
             python3-pip autoconf automake libtool libasound2-dev \
             libfftw3-dev libhidapi-dev portaudio19-dev
 
-      # glslc — the SPIR-V shader compiler that whisper's Vulkan backend needs
-      # at BUILD time (CMake resolves it via find_package(Vulkan COMPONENTS
-      # glslc), and REQUIRE_ASR_GPU=ON makes a miss fatal on x86_64).
+      # glslc — the SPIR-V shader compiler whisper's Vulkan backend needs at
+      # BUILD time (CMake resolves it via find_package(Vulkan COMPONENTS glslc),
+      # and REQUIRE_ASR_GPU=ON makes a miss fatal on x86_64).
       #
-      # It is packaged as `glslc` on Ubuntu 24.04+ but NOT on 22.04, where it
-      # simply does not exist — installing it unconditionally is what broke the
-      # x86_64 leg of the v26.7.4 tag with "E: Unable to locate package glslc".
-      # The x86_64 AppImage stays on jammy deliberately (it keeps the AppImage's
-      # glibc floor low enough for older distros), so bumping the runner is not
-      # the fix. Pull glslc from LunarG's Vulkan SDK repo instead — the same
-      # vendor scripts/setup/setup-vulkan-sdk.ps1 already uses on Windows.
-      # `shaderc` is the ~6 MB package that ships /usr/bin/glslc; `vulkan-sdk`
-      # would drag in the entire SDK for one binary.
+      # Packaged as `glslc` on Ubuntu 24.04+ but absent on 22.04 entirely —
+      # installing it unconditionally is what broke the x86_64 leg of the
+      # v26.7.4 tag with "E: Unable to locate package glslc". On jammy it comes
+      # from LunarG's `shaderc` (~6 MB, ships /usr/bin/glslc) instead.
       #
       # This workflow only runs on tag pushes, so a break here is invisible
-      # until release day — hence the explicit `glslc --version` assertion on
-      # both legs.
+      # until release day — hence the explicit assertions on both legs.
       - name: Install glslc (Ubuntu 24.04+)
         if: matrix.runner != 'ubuntu-22.04'
         run: |
           sudo apt-get install -y glslc
           glslc --version
 
-      - name: Install glslc from LunarG (Ubuntu 22.04)
+      - name: Install glslc + SDK headers from LunarG (Ubuntu 22.04)
         if: matrix.runner == 'ubuntu-22.04'
         run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
-            | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc > /dev/null
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
-            https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
-          sudo apt-get update
-          sudo apt-get install -y shaderc
+          sudo apt-get install -y shaderc vulkan-headers
           glslc --version
+          # Fail loudly here rather than 200 lines into ggml-vulkan.cpp if the
+          # loader/header set silently resolved back to jammy's 1.3.204.
+          echo "vulkan_core.h version macros:"
+          grep -E '#define VK_HEADER_VERSION\b' /usr/include/vulkan/vulkan_core.h
+          grep -q 'VK_KHR_cooperative_matrix' /usr/include/vulkan/vulkan_core.h \
+            || { echo "ERROR: Vulkan headers predate VK_KHR_cooperative_matrix — ggml-vulkan will not build"; exit 1; }
+          grep -q 'VK_EXT_pipeline_robustness' /usr/include/vulkan/vulkan_core.h \
+            || { echo "ERROR: Vulkan headers predate VK_EXT_pipeline_robustness — ggml-vulkan will not build"; exit 1; }
 
       - name: Install system Qt (ARM only)
         if: matrix.use_aqt == false


### PR DESCRIPTION
**Second half of the v26.7.4 x86_64 AppImage fix.** #4492 got the dependency step
green; the build then died compiling `ggml-vulkan.cpp`:

```
'PipelineRobustnessCreateInfoEXT' is not a member of 'vk'
'VkPhysicalDeviceCooperativeMatrixFeaturesKHR' was not declared in this scope
'LayerSettingEXT' is not a member of 'vk'
'eMesaDozen' is not a member of 'vk::DriverId'
```

## Cause

Ubuntu 22.04's `libvulkan-dev` ships Vulkan **1.3.204** headers, which predate every
extension the vendored `ggml-vulkan` uses. #4492 installed LunarG's `glslc` against
jammy's headers — a mismatched toolchain. Necessary, but not sufficient.

## Fix

Move the LunarG repo setup **ahead of** the shared apt install, so `libvulkan-dev`
and `spirv-headers` resolve to the SDK's 1.4.313 versions rather than jammy's, and
pull `vulkan-headers` alongside `shaderc`. Loader, headers, SPIR-V headers and
`glslc` now all come from one matched set.

x86_64 stays on jammy — it is there to keep the AppImage's glibc floor low for older
distros, so bumping the runner would trade this breakage for a wider, quieter one.

Also added assertions that the resolved headers actually declare
`VK_KHR_cooperative_matrix` and `VK_EXT_pipeline_robustness`. If the set ever
silently falls back to the distro's, the step fails with one clear line instead of
200 lines of template errors deep inside `third_party`.

## Verified by an actual build, not by reasoning

`appimage.yml` does not run on `pull_request` — which is exactly why two consecutive
breaks reached a tag. So this was validated by `workflow_dispatch` on the branch
before merging:

**[Run 30220362371](https://github.com/aethersdr/AetherSDR/actions/runs/30220362371) — both legs green:**

```
build-appimage (ubuntu-22.04, x86_64, true, ON):     success
build-appimage (ubuntu-24.04-arm, aarch64, false, OFF): success
```

From the x86_64 job log:

```
Get:1 https://packages.lunarg.com/vulkan jammy/main amd64 shaderc amd64 2025.2~rc1-1lunarg22.04-1
#define VK_HEADER_VERSION 313
-- ASR: Vulkan GPU backend enabled (glslc: /bin/glslc)
```

Header version 313 (not 204) confirms the SDK set won, and the CMake line confirms
`REQUIRE_ASR_GPU` was satisfied with the Vulkan backend genuinely enabled — this is
**not** a CPU-only fallback.

This is the first successful x86_64 AppImage build since `4d7f00a6` (#4338).

## Follow-up worth its own issue

`appimage.yml` runs only on `push: tags: ['v*']` and `workflow_dispatch`. Both of
this evening's breaks were introduced in a PR and discovered on release day. A
`pull_request` trigger scoped to `.github/workflows/**` and the build files would
have caught them at authoring time. Out of scope here — this PR is the release
unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
