### PR TITLE
fix(tci): confirm the frequency a vfo: SET actually reached (#4500, #4493)

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1173,15 +1173,6 @@ void TciServer::tuneSliceAndConfirm(
         return;
     }
 
-    const QString confirmation
-        = QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(frequencyHz);
-    if (TciProtocol::mhzToHz(slice->frequency()) == frequencyHz) {
-        // A no-op produces no Flex status. Confirm the already-authoritative
-        // model value so WSJT-X cannot time out during startup convergence.
-        broadcast(confirmation);
-        return;
-    }
-
     const double mhz = static_cast<double>(frequencyHz) / 1.0e6;
     bool inSpan = false;
     if (PanadapterModel* pan = m_model->panadapter(slice->panId())) {
@@ -1189,56 +1180,54 @@ void TciServer::tuneSliceAndConfirm(
         inSpan = halfBandwidth > 0.0 && qAbs(mhz - pan->centerMhz()) <= halfBandwidth;
     }
 
-    // Seam backend (HL2): there is no text-command plane, so the sendCmdPublic
-    // below would be swallowed and its completion callback would never run —
-    // WSJT-X's band-hop was dropped AND its 2 s vfo-echo timeout expired, which
-    // it reports as a rig-control failure. Drive the model instead; it routes
-    // the intent through IRadioBackend::setSliceFrequency and, having no radio
-    // status to wait for, is authoritative the moment it returns. Recentering
-    // follows the same in-span rule as the Flex command choice below.
-    if (!m_model->usesFlexCommandPlane()) {
-        if (inSpan)
-            slice->setFrequency(mhz);
-        else
-            slice->tuneAndRecenter(mhz);
-        // A locked slice refuses the tune. Confirm what the model actually
-        // holds, never the request, so a client's mirror cannot drift.
-        const long long acceptedHz = TciProtocol::mhzToHz(slice->frequency());
-        if (acceptedHz > 0) {
-            broadcast(QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(acceptedHz));
-        }
-        return;
+    // TUNE THROUGH THE MODEL, ON EVERY COMMAND PLANE (#4500, #4493).
+    //
+    // This was briefly a raw `slice tune` written at the connection, with the
+    // radio's command reply used as a barrier to read the settled frequency back
+    // out of SliceModel. Both halves of that were wrong on a Flex:
+    //
+    //   - the raw command bypasses SliceModel, so nothing updates m_frequency;
+    //   - the radio does not answer `slice tune` with an RF_frequency status
+    //     either (measured: 89 tunes, 0 frequency statuses in one session).
+    //
+    // So the read-back could only ever observe the PRE-TUNE value, and every
+    // confirmation echoed the frequency the slice had already left. WSJT-X's
+    // do_frequency() waits on that echo, concluded the radio had not moved, and
+    // reported rig-control failure on every band change — while the radio was in
+    // fact sitting on the new band, which is how transmissions went out of band.
+    //
+    // The setter is the command path, not an addition to it: setFrequency()
+    // sends the byte-identical "slice tune <id> <mhz> autopan=0" this used to
+    // open-code, and additionally updates the model, honours a locked slice, and
+    // emits frequencyChanged. There is no second command and no double-tune.
+    //
+    // The model is the authority here BECAUSE the radio declines to be: with no
+    // status to wait for, an optimistic update is the only thing that can make a
+    // TCI client's mirror converge. (That the radio never confirms a tune is an
+    // older gap than the regression above and wants its own fix; until then this
+    // is what masks it, which is exactly why removing it broke so much.)
+    if (inSpan)
+        slice->setFrequency(mhz);
+    else
+        slice->tuneAndRecenter(mhz);
+
+    // Confirm what the model ACCEPTED, never what the client asked for.
+    //
+    // A locked slice refuses the tune outright and a no-op leaves the frequency
+    // where it was; in both cases the honest answer is the value the model
+    // holds, or a client's mirror drifts away from the radio.
+    //
+    // Sent unconditionally even though a successful tune also reaches clients
+    // via frequencyChanged → broadcastSliceFrequencies(). That duplicates the
+    // channel-0 vfo: frame, which is idempotent and harmless — whereas the
+    // alternative failure, a client left with NO confirmation, hangs WSJT-X for
+    // its full rig-control timeout. Channel 1 is not covered by that automatic
+    // path at all unless the routing state happens to be bound, so suppressing
+    // this would make split confirmations depend on unrelated state.
+    const long long acceptedHz = TciProtocol::mhzToHz(slice->frequency());
+    if (acceptedHz > 0) {
+        broadcast(QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(acceptedHz));
     }
-
-    const QString command = inSpan
-        ? QStringLiteral("slice tune %1 %2 autopan=0").arg(sliceId).arg(mhz, 0, 'f', 6)
-        : QStringLiteral("slice tune %1 %2").arg(sliceId).arg(mhz, 0, 'f', 6);
-
-    QPointer<TciServer> self(this);
-    QPointer<QWebSocket> socket(client);
-    m_model->sendCmdPublic(
-        command, [self, socket, trx, channel, sliceId](int code, const QString& body) {
-            if (!self || !socket) {
-                return;
-            }
-            if (code != 0) {
-                qCWarning(lcCat) << "TCI: VFO tune rejected"
-                                 << "slice=" << sliceId << "code=" << Qt::hex << code
-                                 << "body=" << body;
-                return;
-            }
-            // Flex status precedes this response. The reply is the completion
-            // barrier; publish the accepted coordinate to sender and observers.
-            SliceModel* settled = self->m_model ? self->m_model->slice(sliceId) : nullptr;
-            if (!settled) {
-                return;
-            }
-            const long long acceptedHz = TciProtocol::mhzToHz(settled->frequency());
-            if (acceptedHz > 0) {
-                self->broadcast(
-                    QStringLiteral("vfo:%1,%2,%3;").arg(trx).arg(channel).arg(acceptedHz));
-            }
-        });
 }
 
 void TciServer::promoteTxSliceAndContinue(int sliceId, std::function<void(bool)> continuation)

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -448,6 +448,144 @@ public:
         seeded.setActiveSlice(server.m_activeTrx, server.m_activeLetter);
         return seeded.handleCommand(QStringLiteral("active_slice")).isEmpty();
     }
+
+    // ── vfo: SET must confirm the frequency it actually reached (#4500/#4493) ──
+    //
+    // A raw `slice tune` written at the connection bypasses SliceModel, and the
+    // radio answers it with no RF_frequency status, so the model was never
+    // updated and the confirmation echoed the PRE-TUNE frequency forever.
+    // WSJT-X's do_frequency() waits on that echo: it concluded the radio had not
+    // moved and failed every band change, while the radio was in fact on the new
+    // band — which is how transmissions ended up out of band.
+    //
+    // Asserted on the wire (broadcast() emits tciMessage even with no clients
+    // attached) rather than only on the model, because the echo is what clients
+    // actually consume.
+    static bool vfoSetConfirmsTheAcceptedFrequency()
+    {
+        RadioModel model;
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error)) {
+            std::printf("      fixture precondition failed: %s\n", qPrintable(error));
+            return false;
+        }
+        SliceModel* slice = model.slice(0);
+        if (!slice)
+            return false;
+
+        TciServer server(&model);
+        QWebSocket client;
+
+        QStringList sent;
+        QObject::connect(&server, &TciServer::tciMessage,
+                         [&sent](const QString& dir, const QString& msg) {
+            if (dir == QLatin1String("tx"))
+                sent << msg.trimmed();
+        });
+
+        // Nine successive relative tunes — the Stream Deck encoder case from
+        // #4493. Each confirmation must carry the frequency just reached, or a
+        // client accumulating "current + delta" recomputes every step from the
+        // same stale origin and the radio oscillates instead of walking.
+        long long hz = TciProtocol::mhzToHz(slice->frequency());
+        if (hz <= 0)
+            return false;
+        for (int step = 0; step < 9; ++step) {
+            const long long want = hz - 1000;
+            sent.clear();
+            server.tuneSliceAndConfirm(&client, 0, 0, 0, want);
+
+            if (TciProtocol::mhzToHz(slice->frequency()) != want) {
+                std::printf("      step %d: model did not take the tune "
+                            "(wanted %lld, model holds %lld)\n",
+                            step, want, TciProtocol::mhzToHz(slice->frequency()));
+                return false;
+            }
+            if (!sent.contains(QStringLiteral("vfo:0,0,%1;").arg(want))) {
+                std::printf("      step %d: no confirmation for %lld; sent: %s\n",
+                            step, want, qPrintable(sent.join(QStringLiteral(" "))));
+                return false;
+            }
+            // The pre-tune value must not also go out, or a client cannot tell
+            // which of the two echoes is current.
+            if (sent.contains(QStringLiteral("vfo:0,0,%1;").arg(hz))) {
+                std::printf("      step %d: stale %lld echoed alongside %lld\n",
+                            step, hz, want);
+                return false;
+            }
+            hz = want;
+        }
+        return true;
+    }
+
+    // A tune the model refuses must be confirmed with what the model HOLDS, not
+    // with what the client asked for — otherwise the client's mirror walks away
+    // from the radio, which is the same divergence by a different route.
+    static bool vfoSetConfirmsTruthWhenRefused()
+    {
+        RadioModel model;
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error))
+            return false;
+        SliceModel* slice = model.slice(0);
+        if (!slice)
+            return false;
+
+        TciServer server(&model);
+        QWebSocket client;
+
+        const long long parked = TciProtocol::mhzToHz(slice->frequency());
+        slice->setLocked(true);
+
+        QStringList sent;
+        QObject::connect(&server, &TciServer::tciMessage,
+                         [&sent](const QString& dir, const QString& msg) {
+            if (dir == QLatin1String("tx"))
+                sent << msg.trimmed();
+        });
+
+        server.tuneSliceAndConfirm(&client, 0, 0, 0, parked - 5000);
+
+        if (TciProtocol::mhzToHz(slice->frequency()) != parked) {
+            std::printf("      a locked slice moved\n");
+            return false;
+        }
+        // Confirmed at all (never leave a client waiting out its timeout), and
+        // confirmed with the truth.
+        return sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked))
+            && !sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked - 5000));
+    }
+
+    // A repeat of the frequency the slice is already on still has to answer.
+    // This used to short-circuit ahead of the tune and confirm from the model
+    // without commanding the radio — harmless alone, but combined with the stale
+    // model above it silently dropped real tunes once the two had diverged. With
+    // the model authoritative again the short-circuit is gone; what must survive
+    // is that a no-op is still acknowledged rather than met with silence.
+    static bool vfoSetAcknowledgesANoOp()
+    {
+        RadioModel model;
+        QString error;
+        if (!model.automationApplySliceFixture(0, QString(), &error))
+            return false;
+        SliceModel* slice = model.slice(0);
+        if (!slice)
+            return false;
+
+        TciServer server(&model);
+        QWebSocket client;
+
+        QStringList sent;
+        QObject::connect(&server, &TciServer::tciMessage,
+                         [&sent](const QString& dir, const QString& msg) {
+            if (dir == QLatin1String("tx"))
+                sent << msg.trimmed();
+        });
+
+        const long long parked = TciProtocol::mhzToHz(slice->frequency());
+        server.tuneSliceAndConfirm(&client, 0, 0, 0, parked);
+        return sent.contains(QStringLiteral("vfo:0,0,%1;").arg(parked));
+    }
 };
 
 } // namespace AetherSDR
@@ -474,6 +612,12 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::flagRelaySeedsAndDeDups();
     const bool flagSeedSettled
         = AetherSDR::TciServerReviewTest::flagSeedReadsSettledNotTransient();
+    const bool vfoConfirmsAccepted
+        = AetherSDR::TciServerReviewTest::vfoSetConfirmsTheAcceptedFrequency();
+    const bool vfoConfirmsRefusal
+        = AetherSDR::TciServerReviewTest::vfoSetConfirmsTruthWhenRefused();
+    const bool vfoAcksNoOp
+        = AetherSDR::TciServerReviewTest::vfoSetAcknowledgesANoOp();
     const bool txTrxResets
         = AetherSDR::TciServerReviewTest::lastTxTrxResetsOnClose();
     const bool activeSliceSeed
@@ -503,10 +647,17 @@ int main(int argc, char** argv)
                 activeSliceSeed ? "PASS" : "FAIL");
     std::printf("%s  active_slice renumbers/clears on slice removal (#4160)\n",
                 activeSliceRemoval ? "PASS" : "FAIL");
+    std::printf("%s  vfo: SET confirms the frequency reached (#4500/#4493)\n",
+                vfoConfirmsAccepted ? "PASS" : "FAIL");
+    std::printf("%s  vfo: SET confirms the truth when the tune is refused\n",
+                vfoConfirmsRefusal ? "PASS" : "FAIL");
+    std::printf("%s  vfo: SET still acknowledges a no-op\n",
+                vfoAcksNoOp ? "PASS" : "FAIL");
 
     return validProfile && deferredAbort && observableFailure
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
         && flagSeedSettled && txTrxResets
         && activeSliceSeed && activeSliceRemoval
+        && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4500. Fixes #4493.

**Release-blocking.** WSJT-X lost all rig control in v26.7.4 — band changes fail, the dial reads the wrong frequency, and transmissions go out of band. Two users hit it independently within hours of the release, from opposite directions (WSJT-X and a Stream Deck encoder).

## Root cause

#4407 replaced the model-driven tune with a raw `slice tune` written at the connection, using the radio's command reply as a barrier to read the settled frequency back out of `SliceModel`. Both halves are wrong on a Flex:

- the raw command **bypasses `SliceModel`**, so nothing updates `m_frequency`;
- the radio answers `slice tune` with **no `RF_frequency` status** either — measured by @milenjb in #4493: 89 tunes, 0 frequency statuses in one session.

So the read-back could only ever observe the **pre-tune** value, and every confirmation echoed the frequency the slice had already left.

WSJT-X's `do_frequency()` waits on that echo. It concluded the radio had not moved and reported rig-control failure on every band change — while the radio *was* on the new band. That mismatch is why this produces out-of-band transmissions rather than just a wrong display, and why it is labelled `safety`.

### The second divergence

#4407 also added a short-circuit that confirmed from the model **without commanding the radio** when the request matched what the model held. Alone, harmless. Downstream of a model that no longer tracks the radio, not: once the two diverged, a client asking for the frequency it had just been told got a false confirmation and the radio never moved at all.

## The fix

Tune through the model on every command plane.

**The setter is the command path, not an addition to it.** `SliceModel::setFrequency()` emits the byte-identical `slice tune <id> <mhz> autopan=0` this open-coded — there is no second command and no double-tune. It additionally updates the model, honours a locked slice, emits `frequencyChanged`, and routes through the TX-inhibit-guarded slice sink that the raw `sendCmdPublic` bypassed.

Net effect on `TciServer.cpp` is **47 added, 58 removed** — this is a simplification. It also collapses the Flex/seam split #4471 introduced: the non-Flex path was already doing exactly this, so only Flex carried the broken mechanism. `tuneSliceAndConfirm` is now synchronous, so a caller's route transition closes *after* the tune has been taken rather than before.

The no-op short-circuit is removed rather than kept. Its stated purpose — acknowledging a repeat so WSJT-X cannot time out during startup convergence — survives, because a no-op falls through to the setter (which ignores it internally via `qFuzzyCompare`) and is still confirmed. There is a test pinning that specifically.

### On the duplicate broadcast

The confirmation is sent unconditionally even though a successful tune also reaches clients via `frequencyChanged` → `broadcastSliceFrequencies()`. That duplicates the channel-0 `vfo:` frame.

Deliberate: a duplicate is idempotent, whereas the opposite failure — a client left with **no** confirmation — hangs WSJT-X for its full rig-control timeout. Channel 1 is not covered by that automatic path at all unless the routing state happens to be bound, so suppressing this would make split confirmations depend on unrelated state. Documented at the call site.

## Testing

Three cases in `tci_server_review_test`, asserted **on the wire** via `tciMessage` rather than only on the model, because the echo is what clients actually consume:

- **accumulating tune** — @milenjb's nine-detent encoder scenario; each confirmation must carry the frequency just reached, and the stale value must not also go out.
- **refused tune** — a locked slice must be confirmed with what the model *holds*, never with what the client asked for.
- **no-op** — must still be acknowledged rather than met with silence (the behaviour the removed short-circuit was protecting).

Verified to fail without the fix:

```
step 0: model did not take the tune (wanted 14224000, model holds 14225000)
FAIL  vfo: SET confirms the frequency reached (#4500/#4493)
FAIL  vfo: SET confirms the truth when the tune is refused
```

Full suite **190/191**. The single failure is `cross_needle_meter_test` ("SWR label placement cache is keyed by the rendered font"), which reproduces identically on pristine `origin/main` in a separate worktree — a local font-environment issue, unrelated.

## Not fixed here

**The radio never confirming a tune at all predates #4407.** The optimistic model update is what masks it — which is precisely why removing that update broke this much. This PR restores the mask; the underlying gap wants its own issue, and #4220's TCI conformance RFC is the natural home for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
