### PR TITLE
feat(hl2): Band switching, hardware filters, hardware preamp, and a Radio Health dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,7 @@ set(CORE_SOURCES
     src/core/backends/sim/NoiseMixer.cpp                 # demo mode — audio engine (RFC #4288 Phase 2b)
     src/core/backends/hl2/MetisProtocol.cpp  # aetherd HL2 Phase 1a (HPSDR Protocol 1)
     src/core/backends/hl2/MetisClient.cpp    # aetherd HL2 Phase 1a (UDP wire + RX ingest)
+    src/core/backends/hl2/Hl2EmergencyStop.cpp # release the radio from a signal handler
     src/core/backends/hl2/Hl2Spectrum.cpp    # aetherd HL2 Phase 1a (FFT panadapter, FFTW)
     src/core/backends/hl2/Hl2RxDsp.cpp       # aetherd HL2 Phase 1a (IQ -> WdspChannel demod + spectrum)
     src/core/backends/hl2/Hl2TxDsp.cpp       # SSB transmit chain (TX audio -> baseband IQ)
@@ -2632,6 +2633,20 @@ add_executable(hl2_live_band_filter_probe EXCLUDE_FROM_ALL
     tests/hl2_live_band_filter_probe.cpp)
 target_include_directories(hl2_live_band_filter_probe PRIVATE src)
 target_link_libraries(hl2_live_band_filter_probe PRIVATE aethercore Qt6::Core Qt6::Network)
+
+# A killed AetherSDR must still release the radio. A child process runs a real
+# MetisClient against a fake radio; the Python driver kills it and requires a
+# metis-stop datagram to arrive. End-to-end on purpose — see the .py header.
+add_executable(hl2_signal_stop_child tests/hl2_signal_stop_child.cpp)
+target_include_directories(hl2_signal_stop_child PRIVATE src)
+target_link_libraries(hl2_signal_stop_child PRIVATE aethercore Qt6::Core Qt6::Network)
+find_package(Python3 COMPONENTS Interpreter)
+if(NOT WIN32 AND Python3_Interpreter_FOUND)
+    add_test(NAME hl2_signal_stop_test
+             COMMAND ${Python3_EXECUTABLE}
+                     ${CMAKE_CURRENT_SOURCE_DIR}/tests/hl2_signal_stop_test.py
+                     $<TARGET_FILE:hl2_signal_stop_child>)
+endif()
 
 # HL2 MetisClient loopback test — drives the UDP wire against a fake HL2.
 add_executable(hl2_metis_client_test tests/hl2_metis_client_test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,6 +930,7 @@ set(GUI_SOURCES
     src/gui/TitleBar.cpp
     src/gui/SupportDialog.cpp
     src/gui/SliceTroubleshootingDialog.cpp
+    src/gui/RadioHealthDialog.cpp
     src/gui/KeyboardMapWidget.cpp
     src/gui/ShortcutDialog.cpp
     src/gui/MultiFlexDialog.cpp
@@ -2622,6 +2623,15 @@ add_executable(hl2_metis_protocol_test
     src/core/backends/hl2/MetisProtocol.cpp)
 target_include_directories(hl2_metis_protocol_test PRIVATE src)
 add_test(NAME hl2_metis_protocol_test COMMAND hl2_metis_protocol_test)
+
+# HL2 live band-filter probe — REQUIRES REAL HARDWARE, so deliberately NOT
+# registered with add_test(). Build it and run it by hand against a radio:
+#   cmake --build build --target hl2_live_band_filter_probe
+#   ./build/hl2_live_band_filter_probe 192.168.1.21
+add_executable(hl2_live_band_filter_probe EXCLUDE_FROM_ALL
+    tests/hl2_live_band_filter_probe.cpp)
+target_include_directories(hl2_live_band_filter_probe PRIVATE src)
+target_link_libraries(hl2_live_band_filter_probe PRIVATE aethercore Qt6::Core Qt6::Network)
 
 # HL2 MetisClient loopback test — drives the UDP wire against a fake HL2.
 add_executable(hl2_metis_client_test tests/hl2_metis_client_test.cpp)

--- a/HERMES.md
+++ b/HERMES.md
@@ -704,7 +704,7 @@ Effort is rough: **XS** under an hour, **S** a session, **M** a few sessions,
 | 10 | RADE null-deref at `MainWindow_DigitalModes.cpp:461` | ours, gap 9 | Same shape as the DAX crash; will kill HL2 the moment RADE starts | XS |
 | 11 | `AETHER_AUTOMATION_NO_AUTOCONNECT` not honoured on the HL2 path | ours, gap 10 | Test instances grab a live radio | S |
 | 12 | One dB-reference object per slice (LNA + calibration + AGC threshold) | A2 §A3 | Every LNA change shifts the absolute reference; the trace jumps and users read it as a real event | S |
-| 12a | Seam verb for RF/LNA gain | §15.7 | `lnaGainDb` is connect-time only. An operator on a strong band cannot back it off without reconnecting, and audio clips hard (peak 5.5 against full scale 1.0) with no recovery | S |
+| ~~12a~~ | ~~Seam verb for RF/LNA gain~~ **DONE** | §15.7 | `IRadioBackend::setPanRfGain` carries the ANT panel's RF Gain slider to the AD9866. Measured on hardware: a commanded 20 dB step moved the wire noise floor 19.8 dB | — |
 | 12b | Automation verbs `pan span`, `pan rate`, `perf` | §15.7 | Proving §15 needed span driven by repeated `pan_zoom_in`, the FPS slider reached through a menu, and frame rates scraped from a log file the chatter in 6a nearly buried | S |
 
 ### Tier 3 — absent subsystems, in dependency order
@@ -717,7 +717,7 @@ Effort is rough: **XS** under an hour, **S** a session, **M** a few sessions,
 | 16 | Pair WDSP `RXA_ADC_PK` with the hardware clip indicator | A3 §7 | Post-DDC slice vs pre-DDC full spectrum. They disagree by design; A3 calls this the most useful diagnostic pairing on the HL2 | S |
 | 17 | TX IQ FIFO depth + servo | O §6, A1 §B3 | "The most important number in the protocol." TX pacing must servo against it, not a host timer — clock domains drift | M |
 | 18 | Wideband bandscope (endpoint `0x04`) | O §7, A1 §A1 | Unimplemented by piHPSDR (dead code) and declined by SDR Console — a differentiation opportunity. **4 packets/block on HL2, not 32** | M |
-| 19 | Filter board (I2C `0x20`), PA bias, config EEPROM | O §8 | Band filtering, and the AM-broadcast HPF matters more here than on radios with better dynamic range | M |
+| ~~19~~ | ~~Filter board band switching (J16 / I2C `0x20`)~~ **DONE** — PA bias + config EEPROM still open | O §8 | Band filters auto-select from the slice frequency (`Hl2Backend::applyBandFilter`). PA bias and the config EEPROM are untouched and still want the RQST/ACK path | — |
 | 20 | Multi-slice: index-space mapping object | A3 §3 | `{ddcIndex, dspChannel, analyzerId, uiNumber}` — never derive arithmetically. Trivial now at one slice, which is when to build it | S |
 | 21 | Diversity as a **pre-channel combiner** | A3 §6 | `divEXT` takes two DDC streams and yields one. Modelling it as a two-input slice fights the DSP layer | M |
 | 22 | Hardware-managed T/R LNA gain (`0x0e[15]`) | A2 §A2 | Quisk uses it; lower latency than any host round trip; PureSignal needs an unclipped feedback path | S |
@@ -1392,3 +1392,131 @@ reports — so plain CW fell through to the USB fallback and was demodulated as
 SSB. `NFM` was missing for the same reason. **Any mode name that appears in the
 TCI `modulations_list` needs a mapping, or it silently becomes USB.** `RTTY`
 still has this gap.
+
+---
+
+## 17. Band switching, the companion filter board, and RF gain
+
+Three controls that all looked wired and were not. Each failed in the same
+shape: the GUI drove a **Flex command plane** that this radio does not have, so
+the widget moved, the setting persisted, and nothing reached the hardware.
+
+### 17.1 Band buttons — the app is the band stack
+
+The Band sub-panel resolved a Flex band-stack key and sent
+`display pan set <pan> band=<key>`. On a Flex the RADIO owns the stack and
+restores frequency, mode, filters and antenna from it. **The HL2 owns none of
+that** — it has no VFO to read back — so the command reached nothing.
+
+`MainWindow_Wiring.cpp` now branches on `usesFlexCommandPlane()`: for a
+non-Flex backend the app is authoritative and tunes the slice to the band's
+default frequency and mode directly. Note this is the *exact opposite* of the
+rule stated for Flex three lines above it, where using the button's `freqMhz`
+is explicitly called out as wrong (#1876). Both are right — the argument is a
+"static UI default" only when something better exists.
+
+`RadioCapabilities::tuningMinHz/tuningMaxHz` was added so the grid can be
+honest: the HL2 reports 0.1–38.4 MHz (the AD9866's first Nyquist zone), and
+band buttons outside it are disabled with a tooltip rather than tuning the
+receiver somewhere it cannot hear.
+
+### 17.2 The J16 filter byte rides the CONFIG register
+
+**The HL2 has no switchable filters of its own.** It has seven open-collector
+outputs at `0x00[23:17]`, which the *gateware* forwards as one byte to I2C
+address `0x20`. Nothing in this codebase writes I2C — setting the config bits
+IS the whole mechanism (oracle §8).
+
+Two things make this the riskiest change in the area:
+
+1. **It shares a register with the sample rate and the receiver count.** A bit
+   in the wrong place lands in `[25:24]` or `[6:3]`, and the failure is a radio
+   that still streams, still looks correctly framed, and delivers samples at the
+   wrong rate or from an unassigned receiver.
+2. **The field is shifted.** `DATA[16]` is not part of it, so the byte goes in
+   as `C2 = (oc & 0x7F) << 1`. Unshifted, every selection is one relay too low —
+   80 m would engage the 160 m low-pass.
+
+Anything that rebuilds `m_ccConfig` must carry the filter byte through.
+`setSampleRate()` already had this bug once for the receiver count; the comment
+there now covers both.
+
+The one-hot mapping is **Quisk's `Hermes_BandDict` verbatim**, not re-derived:
+the grouping (60+40 share a filter, 17+15 share one) is a property of the N2ADR
+board. Our contribution is the frequency *ranges*, and the unit test checks
+those by asserting every amateur band lands on Quisk's answer.
+
+Two deliberate departures from "always engage the HPF":
+- Below 1.6 MHz nothing is engaged — the AM-blocking HPF would remove exactly
+  what is being listened to.
+- On 160 m the HPF stays out. The HL2's own switching supply couples spurs into
+  the filter board's 160 m and HPF inductors (wiki, `Options.md`).
+
+**Selection is logged at INFO on `aether.hl2`, not debug.** There is no
+readback anywhere in the protocol — the gateware writes to I2C and nothing
+answers — so that log line is the only evidence of what the relays were told to
+do, and a support log captured after the fact has to already contain it.
+
+### 17.3 Verifying something with no readback
+
+`tests/hl2_live_band_filter_probe.cpp` (hardware-only, `EXCLUDE_FROM_ALL`) is
+the answer to "the unit test shares our reading of the register map, so what
+would catch a convention error?"
+
+- **Sample rate as the independent check.** EP6 carries 126 samples per packet,
+  so 48 kHz is 381 packets/second. Measured across all nine filter selections
+  it stayed within 1.002× — a bit leaking into `DATA[25:24]` would have halved
+  or doubled it. Non-zero IQ rules out an unassigned receiver.
+- **Physics as the proof the relay moved.** Park on 0.6 MHz, A/B the AM-blocking
+  HPF, and measure. On this radio the AM band dropped **22–24 dB** when the HPF
+  was engaged. That is not the radio agreeing with our register map; that is the
+  antenna path changing. It also confirms an N2ADR board is fitted — the writes
+  are inert and harmless on a bare HL2.
+- Same method for RF gain: a commanded 10 → 30 dB step moved the raw wire noise
+  floor **19.8 dB**, measured before any of our DSP or dB referencing runs.
+
+### 17.4 RF gain was connect-time only
+
+`lnaGainDb` was applied once in `connectRadio()`. `IRadioBackend::setPanRfGain`
+(default no-op, so Flex is unaffected) now carries the ANT panel's slider to
+`MetisClient::setLnaGainDb` at any time, and `panRfGainInfoChanged` reports the
+AD9866's real geometry — **−12…+48 dB in 1 dB steps**, against the model's
+Flex-shaped default of −8…+32 in 8s, which had made two thirds of the available
+gain unreachable.
+
+`Hl2DbReference` is moved in the same call, so the trace and the S-meter do not
+slide when gain changes — an operator backing off 10 dB on a strong band would
+otherwise watch the noise floor drop 10 dB and read it as the band going quiet.
+
+**The persisted key is now family-scoped** (`DisplayRfGain_hl2`). It was shared,
+which was harmless while the HL2 ignored the value and stopped being harmless
+the moment the slider reached the register: a gain last set on a Flex was
+restored onto the HL2 as an LNA gain the operator never chose for that radio.
+Observed live — a Flex-era `16` was pushed at connect.
+
+### 17.5 Directional power is UNCALIBRATED and says so
+
+Forward/reverse counts go through Quisk's `power_meter_std_calibrations
+['HL2FilterE3']` curve. That is a *reference* curve for an N2ADR rev E3 board,
+**not a calibration of this radio** — the coupler, toroid and detector diode all
+vary between boards (oracle §6). The meters are labelled "(uncalibrated)" in
+their own `MeterDef` descriptions, because the number itself looks exactly like
+a calibrated one. Raw counts continue to be logged; a per-unit calibration
+replaces the table and nothing else.
+
+SWR remains the one directional quantity that is meaningful without
+calibration — it is a ratio from the same converter, so the unknown scale
+cancels.
+
+### 17.6 Meter pacing
+
+WDSP hands us a signal-strength reading per demodulated block — ~47/s at 24 kHz
+output, scaling with the span — and every one crossed to the GUI thread. Two
+separate mechanisms fix that and they are not interchangeable: an EMA smooths
+*every* sample so the published value represents the whole interval, and a
+100 ms gate decides how often one is published. Dropping samples without
+smoothing would alias.
+
+100 ms is the cadence `MetisClient` already paces telemetry at, and the
+attack/decay constants (0.5/0.15) are the ones `MeterModel` uses for Flex
+forward power — reused so meters behave the same across families.

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -44,6 +44,10 @@ Q_LOGGING_CATEGORY(lcKiwiSdrAudio, "aether.kiwisdr.audio", QtWarningMsg)
 Q_LOGGING_CATEGORY(lcAutomation, "aether.automation",  QtInfoMsg)
 Q_LOGGING_CATEGORY(lcQrz,        "aether.qrz",         QtWarningMsg)
 Q_LOGGING_CATEGORY(lcClock,      "aether.clock",       QtWarningMsg)
+// Info by default: the band-filter transitions this carries are low-rate and
+// are the only record of what the companion filter board was told to do, so
+// they have to be in a support log that was captured without foreknowledge.
+Q_LOGGING_CATEGORY(lcHl2,        "aether.hl2",         QtInfoMsg)
 
 LogManager::LogManager()
 {
@@ -80,6 +84,7 @@ LogManager::LogManager()
         {"aether.automation", "Automation Bridge", "Agent-drivable test bridge (#3646): QLocalServer verbs, widget snapshots, captures (AETHER_AUTOMATION only)"},
         {"aether.qrz",        "QRZ Lookup",   "QRZ.com callsign lookups: session, cache, CW callsign spotting, photos"},
         {"aether.clock",      "AetherClock",  "WWV/WWVB time-signal decoder: state transitions, per-second alignment, frame decodes, voter verdicts"},
+        {"aether.hl2",        "Hermes-Lite 2", "HL2 backend: band changes, J16 companion-filter selection, LNA gain, and radio health telemetry"},
     };
 
     // QLoggingCategory objects are defined above via Q_LOGGING_CATEGORY macros.

--- a/src/core/LogManager.h
+++ b/src/core/LogManager.h
@@ -47,6 +47,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcKiwiSdrAudio)
 Q_DECLARE_LOGGING_CATEGORY(lcAutomation)
 Q_DECLARE_LOGGING_CATEGORY(lcQrz)
 Q_DECLARE_LOGGING_CATEGORY(lcClock)
+Q_DECLARE_LOGGING_CATEGORY(lcHl2)
 
 // Central registry for toggling per-module diagnostic logging at runtime.
 // The Support dialog (Help → Support) uses this to let users enable/disable

--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QByteArray>
+#include <QMap>
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -118,6 +119,29 @@ public:
         Q_UNUSED(hz);
     }
 
+    // Receive RF gain for a panadapter, in dB.
+    //
+    // The sibling of setPanCenter/setPanBandwidth, and it exists for the same
+    // reason: a backend whose gain lives in a hardware register (the HL2's
+    // AD9866 LNA, 0x0a) cannot be driven by "display pan set … rfgain=" wire
+    // text, so the ANT panel's RF Gain slider reached nothing and the operator
+    // had to RECONNECT to change gain — on a direct-sampling receiver, where a
+    // strong band clips the converter and there is no AGC in front of it.
+    //
+    // gainDb is the operator's value in the range the backend itself advertised
+    // via panRfGainInfoChanged. A backend clamps rather than refuses: the
+    // control is continuous, and a silently ignored end-of-travel is worse than
+    // a value that stops moving. What the hardware took comes back on
+    // panRfGainChanged.
+    //
+    // Default no-op: a Flex radio takes rfgain as wire text, so FlexBackend has
+    // nothing to do here.
+    virtual void setPanRfGain(const QString& panId, int gainDb)
+    {
+        Q_UNUSED(panId);
+        Q_UNUSED(gainDb);
+    }
+
     // How often the operator wants panadapter frames, in frames per second.
     //
     // For a backend that streams cooked spectra there is no radio-side display
@@ -170,6 +194,38 @@ public:
         Q_UNUSED(int16Stereo);
         Q_UNUSED(sampleRateHz);
     }
+
+    // ---- diagnostics ----
+    //
+    // A snapshot of whatever health/status registers this backend can report:
+    // converter overload, transmit FIFO depth, thermal, firmware revision, link
+    // counters. Purely for display — nothing in the app makes a decision from
+    // it, which is why it is a plain map rather than a typed delta.
+    //
+    // SYNCHRONOUS, and that is not a shortcut. Every value here is already
+    // cached in the backend from telemetry the radio sends unprompted, so there
+    // is no wire round-trip to await. Making it async would mean a dialog that
+    // renders empty and fills in later, for data that is sitting in memory.
+    // A backend whose values live on a worker thread must cache them on this
+    // one (see Hl2Backend) rather than reaching across.
+    //
+    // Two parallel outputs so the dialog does not have to know the vocabulary:
+    // `values` is the data, and `order` lists the keys in the sequence they
+    // should be displayed, so a backend controls its own grouping. Keys absent
+    // from `values` are rendered as "not reported" rather than as zero — on a
+    // health readout the difference between "0" and "we never heard" is the
+    // whole point.
+    struct HealthSnapshot {
+        QVariantMap values;
+        QStringList order;
+        // Section headings, keyed by the value-key they precede.
+        QMap<QString, QString> sections;
+        // Human-readable labels, keyed by value-key. A key with no label is
+        // displayed under its own name.
+        QMap<QString, QString> labels;
+        [[nodiscard]] bool isEmpty() const { return order.isEmpty(); }
+    };
+    virtual HealthSnapshot healthSnapshot() const { return {}; }
 
     // ---- vendor extensions (namespaced, capability-advertised) ----
     // Vendor-specific verbs that are NOT part of the core profile. Clients
@@ -295,6 +351,19 @@ signals:
     // range/step are family-specific and reported via RadioCapabilities). The
     // backend decodes it from vendor status; RadioModel drives the pan.
     void panRfGainChanged(const QString& panId, int gain);
+
+    // The RF-gain range and step this pan actually offers, in dB.
+    //
+    // Reported by the backend for the same reason the span limits are: only the
+    // backend knows. Flex learns it by asking the radio ("display pan
+    // rfgain_info"), which is a Flex command and answers nothing on any other
+    // family — so without this an HL2 kept the model's Flex-shaped -8..+32 in
+    // 8 dB steps while its AD9866 LNA actually spans -12..+48 in 1 dB steps,
+    // and two thirds of the available gain was unreachable from the slider.
+    //
+    // A backend that doesn't know simply never emits this and the model keeps
+    // its existing defaults, so this is additive for Flex.
+    void panRfGainInfoChanged(const QString& panId, int low, int high, int step);
 
     // Panadapter antenna selection (universal). Two signals because the wire may
     // report the selected RX antenna and the available list independently.

--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -32,6 +32,19 @@ struct RadioCapabilities {
     int maxPanadapters = 1;        // simultaneous panadapters
     QVector<int> sampleRatesHz;    // supported per-receiver sample rates (Hz)
 
+    // The frequency range the receiver can actually be tuned to, in Hz.
+    //
+    // Both zero means "not reported" — clients then keep whatever range they
+    // previously assumed, so this is additive for a backend that never sets it.
+    //
+    // This exists because the band buttons had no way to be honest. They are a
+    // fixed grid from 2200 m to 2 m, and every one of them was live on every
+    // radio: pressing 6 m on a direct-sampling HF receiver tuned it somewhere
+    // it cannot hear, and the operator got a dead band rather than a control
+    // that told them it was not available.
+    double tuningMinHz = 0.0;
+    double tuningMaxHz = 0.0;
+
     // Transmit — the load-bearing capability for TX safety (RFC §6). A backend
     // that cannot key sets canTransmit=false; the engine guard then denies any
     // keying intent regardless of client requests.

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -9,6 +9,7 @@
 #include "core/backends/hl2/MetisProtocol.h"
 
 #include "core/AutomationBridgeSettings.h"
+#include "core/LogManager.h"
 #include "core/backends/hl2/Hl2Settings.h"
 
 #include <QByteArray>
@@ -332,11 +333,34 @@ Hl2Backend::Hl2Backend(QObject* parent) : IRadioBackend(parent)
 
     connect(m_metis, &MetisClient::telemetryUpdated, this,
             [this](const Hl2Telemetry& t) { publishTelemetry(t); });
+    // Mirror the drop counter onto this thread so healthSnapshot() can read it
+    // without touching an object that lives on the I/O thread.
+    connect(m_metis, &MetisClient::dropsUpdated, this,
+            [this](quint64 drops) { m_drops = drops; });
     connect(m_dsp, &Hl2RxDsp::meterUpdate, this,
             [this](float dbfs) {
         // Same reference as the spectrum -- a meter that moved on a gain change
         // while the trace stayed put would be its own kind of lie.
-        emit meterUpdate(QStringLiteral("SLC:LEVEL"), m_dbRef.toDbm(dbfs));
+        const double dbm = m_dbRef.toDbm(dbfs);
+
+        // Smooth EVERY sample, publish only on the tick. Both halves matter:
+        // smoothing all of them is what makes the published value represent the
+        // whole interval rather than one arbitrary instant inside it, and the
+        // tick is what stops ~47 cross-thread emits a second repainting a
+        // widget nobody can read that fast. See kMeterPublishIntervalMs.
+        if (!m_haveSMeter) {
+            m_sMeterDbm = dbm;
+            m_haveSMeter = true;
+        } else {
+            const double alpha = (dbm > m_sMeterDbm) ? kMeterAttackAlpha
+                                                     : kMeterDecayAlpha;
+            m_sMeterDbm = alpha * dbm + (1.0 - alpha) * m_sMeterDbm;
+        }
+        if (m_sMeterClock.isValid()
+            && m_sMeterClock.elapsed() < kMeterPublishIntervalMs)
+            return;
+        m_sMeterClock.restart();
+        emit meterUpdate(QStringLiteral("SLC:LEVEL"), m_sMeterDbm);
     });
 }
 
@@ -369,6 +393,13 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.maxPanadapters = 1;
     for (const int rate : kIqSampleRatesHz)
         c.sampleRatesHz.append(rate);
+    // The AD9866 samples at 76.8 MHz, so the first Nyquist zone — everything
+    // this receiver can hear without relying on an alias — is DC to 38.4 MHz
+    // (oracle §7, which is also why the wideband bandscope spans exactly that).
+    // The low end is 100 kHz rather than 0: below that the input transformer
+    // rolls off and there is nothing to hear.
+    c.tuningMinHz = 100'000.0;
+    c.tuningMaxHz = 38'400'000.0;
     // Reported from the gate, not hardcoded: the engine's TX guard keys off this,
     // so a build with transmit disabled must look RX-only from above the seam.
     c.canTransmit = m_txAllowed;
@@ -434,6 +465,18 @@ void Hl2Backend::connectRadio(const RadioConnectRequest& request)
     mp.sampleRate = sampleRateEnum(m_sampleRateHz);
     mp.rxFrequencyHz = static_cast<std::uint32_t>(m_rxFreqHz < 0 ? 0 : m_rxFreqHz);
     mp.lnaGainDb = m_lnaGainDb;
+    // The filter board has to be right from the FIRST config frame, not from
+    // the operator's first band change. m_rxFreqHz here is the persisted
+    // frequency this session is coming up on, so a launch straight onto 40 m
+    // starts with the 40 m low-pass engaged rather than with whatever the last
+    // session left in the relays — the radio never reports its own state, so
+    // "unchanged since last time" is indistinguishable from "correct".
+    mp.ocFilterByte = ocFilterByteForHz(m_rxFreqHz);
+    m_ocFilterByte = static_cast<int>(mp.ocFilterByte);
+    qCInfo(lcHl2).nospace()
+        << "HL2 band filter: " << QString::asprintf("0x%02X", m_ocFilterByte)
+        << " (" << ocFilterName(mp.ocFilterByte) << ") for "
+        << QString::number(m_rxFreqHz / 1.0e6, 'f', 6) << " MHz, trigger=connect";
     // Seed the reference from the gain we are about to command, so the very
     // first spectrum frame is already on the same footing as every later one.
     m_dbRef.setLnaGainDb(m_lnaGainDb);
@@ -537,6 +580,12 @@ void Hl2Backend::setSliceFrequency(int /*sliceId*/, double hz)
     // transmit is enabled: this is oscillator setup, it keys nothing, and having
     // it already correct is part of what makes the eventual key safe.
     setTxFrequency(m_rxFreqHz);
+
+    // The companion filter board follows the SLICE, not the NCO: it is band
+    // hardware in the antenna path, and on transmit it is what keeps the
+    // harmonics legal. Change-gated inside, so tuning within a band sends
+    // nothing and only a band crossing moves the relays.
+    applyBandFilter("tune");
 
     emitSliceState();
     emitPanState();
@@ -694,6 +743,33 @@ void Hl2Backend::setPanBandwidth(const QString& /*panId*/, double hz)
 
     applyPanBandwidth(hz);
     m_bandwidthThrottle->start();
+}
+
+void Hl2Backend::setPanRfGain(const QString& /*panId*/, int gainDb)
+{
+    const int clamped = qBound(kLnaGainMinDb, gainDb, kLnaGainMaxDb);
+    if (clamped == m_lnaGainDb)
+        return;
+    m_lnaGainDb = clamped;
+
+    // Move the dB reference IN LOCKSTEP with the gain, and do it here rather
+    // than letting the two drift. The spectrum and the S-meter are both
+    // rendered through m_dbRef, so without this every gain change would slide
+    // the whole trace up or down the display — an operator backing off 10 dB on
+    // a strong band would watch the noise floor drop 10 dB and read it as the
+    // band going quiet, which is the opposite of what they just did.
+    m_dbRef.setLnaGainDb(m_lnaGainDb);
+
+    if (m_metis)
+        QMetaObject::invokeMethod(m_metis, "setLnaGainDb", Qt::QueuedConnection,
+            Q_ARG(int, m_lnaGainDb));
+
+    qCInfo(lcHl2) << "HL2 LNA gain:" << m_lnaGainDb << "dB (requested" << gainDb << ")";
+
+    // Echo what the hardware actually took. The slider is free to have asked
+    // for something outside the register's range, and this is where it finds
+    // out it did not get it.
+    emit panRfGainChanged(QString::fromLatin1(kPanId), m_lnaGainDb);
 }
 
 void Hl2Backend::applyPanBandwidth(double hz)
@@ -979,6 +1055,111 @@ void Hl2Backend::invokeExtension(const QString& /*ns*/, const QString& /*verb*/,
         emit extensionError(requestId, QStringLiteral("hl2: no extension verbs implemented"));
 }
 
+IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
+{
+    HealthSnapshot h;
+    auto put = [&h](const char* key, const QString& label, const QVariant& v) {
+        const QString k = QString::fromLatin1(key);
+        h.order.append(k);
+        h.labels.insert(k, label);
+        // An INVALID variant is left out of `values` on purpose: that is what
+        // renders as "not reported". Writing a zero here instead would turn
+        // "this radio never told us its FIFO depth" into "the FIFO is empty",
+        // which is the single most misleading thing a health readout can do.
+        if (v.isValid())
+            h.values.insert(k, v);
+    };
+    auto section = [&h](const char* key, const QString& title) {
+        h.sections.insert(QString::fromLatin1(key), title);
+    };
+    // std::optional -> QVariant, preserving "not seen yet" as an invalid variant.
+    auto opt = [](const auto& o) -> QVariant {
+        return o ? QVariant(*o) : QVariant();
+    };
+
+    section("connected", QStringLiteral("Radio"));
+    put("connected", QStringLiteral("Connected"), m_connected);
+    put("model", QStringLiteral("Model"), QStringLiteral("Hermes-Lite 2"));
+    // From EP6 RADDR 0, C4[7:0]. This is the GATEWARE's firmware revision as
+    // the running radio reports it — not the version string the discovery reply
+    // carried, which is only ever seen by the radio picker before connecting.
+    put("firmwareVersion", QStringLiteral("Firmware version"),
+        opt(m_telemetry.firmwareVersion));
+
+    section("adcOverload", QStringLiteral("Converter"));
+    put("adcOverload", QStringLiteral("ADC overload"), opt(m_telemetry.adcOverload));
+    put("lnaGainDb", QStringLiteral("LNA gain (dB)"), m_lnaGainDb);
+
+    section("txInhibited", QStringLiteral("Transmit"));
+    // The register bit is ACTIVE LOW and MetisProtocol already decodes it, so
+    // what is shown here is the plain-language sense: true means transmit is
+    // being held off. Displaying the raw bit would read exactly backwards.
+    put("txInhibited", QStringLiteral("TX inhibited"), opt(m_telemetry.txInhibited));
+    put("ptt", QStringLiteral("PTT (radio)"), m_telemetry.ptt);
+    put("keyed", QStringLiteral("Keyed (app)"), m_keyed);
+    put("tuning", QStringLiteral("Tune carrier"), m_tuning);
+    // "The most important number in the protocol" (oracle §6): the depth of the
+    // FPGA's transmit sample buffer. Drifting up means we are sending faster
+    // than the radio consumes; drifting down is an impending underrun.
+    put("txFifoCount", QStringLiteral("TX FIFO depth"), opt(m_telemetry.txFifoCount));
+    put("txFifoUnderflow", QStringLiteral("TX FIFO underflow"),
+        opt(m_telemetry.txFifoUnderflow));
+    put("txFifoOverflow", QStringLiteral("TX FIFO overflow"),
+        opt(m_telemetry.txFifoOverflow));
+
+    section("temperatureC", QStringLiteral("Analog / thermal"));
+    put("temperatureC", QStringLiteral("PA temperature (°C)"),
+        m_havePaTemp ? QVariant(m_paTempC) : QVariant());
+    put("temperatureRaw", QStringLiteral("Temperature (raw counts)"),
+        opt(m_telemetry.temperatureRaw));
+    put("biasCurrentRaw", QStringLiteral("PA bias current (raw counts)"),
+        opt(m_telemetry.biasCurrentRaw));
+
+    section("forwardPowerRaw", QStringLiteral("Directional coupler (uncalibrated)"));
+    put("forwardPowerRaw", QStringLiteral("Forward (raw counts)"),
+        opt(m_telemetry.forwardPowerRaw));
+    put("forwardPowerW", QStringLiteral("Forward (W, approx)"),
+        m_telemetry.forwardPowerRaw
+            ? QVariant(directionalWatts(*m_telemetry.forwardPowerRaw)) : QVariant());
+    put("reversePowerRaw", QStringLiteral("Reverse (raw counts)"),
+        opt(m_telemetry.reversePowerRaw));
+    put("reversePowerW", QStringLiteral("Reverse (W, approx)"),
+        m_telemetry.reversePowerRaw
+            ? QVariant(directionalWatts(*m_telemetry.reversePowerRaw)) : QVariant());
+    // Meaningful without calibration — it is a ratio of two readings from the
+    // same converter, so the unknown scale cancels. Absent below the noise
+    // floor, where a ratio of two noise samples is not a mismatch reading.
+    {
+        QVariant swr;
+        if (m_telemetry.forwardPowerRaw && m_telemetry.reversePowerRaw) {
+            if (const auto v = swrFromRaw(*m_telemetry.forwardPowerRaw,
+                                          *m_telemetry.reversePowerRaw))
+                swr = *v;
+        }
+        put("swr", QStringLiteral("SWR"), swr);
+    }
+
+    section("bandFilter", QStringLiteral("Front end"));
+    put("bandFilter", QStringLiteral("J16 filter byte"),
+        (m_ocFilterByte >= 0 && m_ocFilterByte <= 0x7F)
+            ? QVariant(QString::asprintf("0x%02X — %s", m_ocFilterByte,
+                       ocFilterName(static_cast<std::uint8_t>(m_ocFilterByte))))
+            : QVariant());
+    put("rxFrequencyHz", QStringLiteral("Slice frequency (Hz)"),
+        static_cast<qulonglong>(m_rxFreqHz < 0 ? 0 : m_rxFreqHz));
+    put("ncoHz", QStringLiteral("DDC / pan centre (Hz)"),
+        static_cast<qulonglong>(m_ncoHz < 0 ? 0 : m_ncoHz));
+
+    section("sampleRateHz", QStringLiteral("Link"));
+    put("sampleRateHz", QStringLiteral("IQ sample rate (Hz)"), m_sampleRateHz);
+    // Cumulative EP6 sequence gaps. The oracle is blunt that UDP loss on a
+    // marginal link is the most common cause of "the audio sounds wrong", so
+    // this is the first number to look at when it does.
+    put("droppedPackets", QStringLiteral("Dropped EP6 packets"),
+        static_cast<qulonglong>(m_drops));
+    return h;
+}
+
 void Hl2Backend::pushInitialState()
 {
     // THE RADIO REPORTS NO VFO, SO THE APP IS AUTHORITATIVE AND MUST PUSH.
@@ -1030,6 +1211,16 @@ void Hl2Backend::pushInitialState()
         static_cast<double>(kIqSampleRatesHz[0]) / 1.0e6,
         static_cast<double>(maxIqSampleRateHz()) / 1.0e6);
 
+    // What the RF Gain slider is allowed to ask for, and where it currently
+    // sits. Pushed here for the same reason as everything else in this
+    // function: the model's default is Flex's -8..+32 in 8 dB steps, learned
+    // from a "display pan rfgain_info" command that answers nothing on this
+    // radio, so without this the slider would misrepresent both the range and
+    // the resolution of the AD9866's LNA.
+    emit panRfGainInfoChanged(QString::fromLatin1(kPanId),
+                              kLnaGainMinDb, kLnaGainMaxDb, kLnaGainStepDb);
+    emit panRfGainChanged(QString::fromLatin1(kPanId), m_lnaGainDb);
+
     // Keying state is ours, not the radio's: a reconnect must never come up
     // keyed because the previous session ended mid-transmission.
     m_keyed = false;
@@ -1058,10 +1249,18 @@ void Hl2Backend::defineMeters()
 
     def(1, QStringLiteral("SLC"), QStringLiteral("LEVEL"),   QStringLiteral("dBm"),
         -140.0, 0.0,   QStringLiteral("Receive signal level"));
+    // The two directional meters are labelled uncalibrated in their own
+    // descriptions, which is where the honesty has to live: the VALUE looks
+    // exactly like a calibrated one, so nothing about the number itself warns
+    // the operator. See directionalWatts().
+    //
+    // The upper bound is 41 dBm rather than Flex's 50: that is ~12.6 W, a
+    // little above the top of the reference curve. A 50 dBm (100 W) scale would
+    // leave every real HL2 reading in the bottom tenth of the meter.
     def(2, QStringLiteral("TX"),  QStringLiteral("FWDPWR"),  QStringLiteral("dBm"),
-        0.0, 50.0,     QStringLiteral("Forward power"));
+        0.0, 41.0,     QStringLiteral("Forward power (uncalibrated)"));
     def(3, QStringLiteral("TX"),  QStringLiteral("REFPWR"),  QStringLiteral("dBm"),
-        0.0, 50.0,     QStringLiteral("Reflected power"));
+        0.0, 41.0,     QStringLiteral("Reflected power (uncalibrated)"));
     def(4, QStringLiteral("TX"),  QStringLiteral("SWR"),     QStringLiteral("SWR"),
         1.0, 10.0,     QStringLiteral("Standing wave ratio"));
     def(5, QStringLiteral("RAD"), QStringLiteral("PATEMP"),  QStringLiteral("degC"),
@@ -1097,13 +1296,28 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
         if (const auto swr = swrFromRaw(*t.forwardPowerRaw, *t.reversePowerRaw))
             emit meterUpdate(QStringLiteral("TX:SWR"), *swr);
     }
-    // Raw directional counts, logged rather than published: they are what a
-    // future calibration curve will be built from, and they are the only way to
-    // tell "the radio reports no power" from "we never asked".
+    // Forward and reverse power, through the reference curve in
+    // directionalWatts(). UNCALIBRATED — see that function for exactly what
+    // that means and why publishing an approximate value still beats publishing
+    // none. The raw counts continue to be logged alongside, because they are
+    // what a per-unit calibration will be built from and they are the only way
+    // to tell "the radio reports no power" from "we never asked".
+    //
+    // Arrives at the 10 Hz MetisClient already paces telemetry at
+    // (kTelemetryMinIntervalMs), so no further rate gate is needed here;
+    // MeterModel applies its own forward-power ballistics on top.
+    if (t.forwardPowerRaw)
+        emit meterUpdate(QStringLiteral("TX:FWDPWR"),
+                         wattsToDbm(directionalWatts(*t.forwardPowerRaw)));
+    if (t.reversePowerRaw)
+        emit meterUpdate(QStringLiteral("TX:REFPWR"),
+                         wattsToDbm(directionalWatts(*t.reversePowerRaw)));
     if (t.forwardPowerRaw && (*t.forwardPowerRaw != m_lastFwdRaw)) {
         m_lastFwdRaw = *t.forwardPowerRaw;
         qCDebug(lcHl2Tx) << "HL2 directional: fwd" << *t.forwardPowerRaw
-                         << "rev" << t.reversePowerRaw.value_or(-1);
+                         << "rev" << t.reversePowerRaw.value_or(-1)
+                         << "-> fwd" << directionalWatts(*t.forwardPowerRaw) << "W"
+                         << "(uncalibrated reference curve)";
     }
     // TX IQ FIFO depth — the oracle calls this the most important number in the
     // protocol. A queue-fed transmission can starve the radio's buffer in a way
@@ -1113,8 +1327,17 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
         qCDebug(lcHl2Tx) << "HL2 fifo:" << *t.txFifoCount
                          << "under" << t.txFifoUnderflow.value_or(false)
                          << "over" << t.txFifoOverflow.value_or(false);
-    if (t.temperatureRaw)
-        emit meterUpdate(QStringLiteral("RAD:PATEMP"), temperatureCelsius(*t.temperatureRaw));
+    if (t.temperatureRaw) {
+        const double c = temperatureCelsius(*t.temperatureRaw);
+        // The instrumentation ADC's low bits are noisy enough that the displayed
+        // temperature flickered by a degree with the radio sitting idle. A
+        // single pole settles it; heating and cooling are both slow, so unlike
+        // the S-meter this one has no reason to attack faster than it decays.
+        m_paTempC = m_havePaTemp ? (kPaTempAlpha * c + (1.0 - kPaTempAlpha) * m_paTempC)
+                                 : c;
+        m_havePaTemp = true;
+        emit meterUpdate(QStringLiteral("RAD:PATEMP"), m_paTempC);
+    }
 
     m_telemetry = t;
     if (t.adcOverload && *t.adcOverload != m_adcOverload) {
@@ -1124,12 +1347,113 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     }
 }
 
+double Hl2Backend::directionalWatts(int raw)
+{
+    // Quisk's `power_meter_std_calibrations['HL2FilterE3']` verbatim
+    // (quisk_conf_defaults.py): measured [ADC count, watts] pairs for a
+    // Hermes-Lite 2 with an N2ADR companion filter board, rev E3. Quisk is the
+    // reference client and tier 3 on the source-precedence ladder, and this is
+    // the only published curve for this coupler.
+    //
+    // WHAT THIS IS NOT: a calibration of THIS radio. The oracle (§6) is explicit
+    // that these counts need a per-unit calibration against a dummy load to mean
+    // watts, because the coupler, the toroid winding and the detector diode all
+    // vary between boards. A reading from this curve is the right ORDER OF
+    // MAGNITUDE and roughly the right shape; it is not a measurement.
+    //
+    // It is still much better than the alternative, which was publishing
+    // nothing: an operator had no way to tell 100 mW from 5 W, and on a radio
+    // where a mis-set drive level is silent that is the difference between
+    // "working" and "not transmitting". The meters are labelled uncalibrated
+    // (defineMeters) so nobody reads them as a power measurement.
+    //
+    // A future per-unit calibration replaces this table and nothing else.
+    struct Point { double counts; double watts; };
+    static constexpr Point kCurve[] = {
+        {    0.000000, 0.000000 }, {   25.865385, 0.002550 },
+        {  101.024540, 0.012752 }, {  265.290123, 0.050601 },
+        {  647.915584, 0.216458 }, { 1196.593548, 0.665480 },
+        { 1603.703226, 1.155723 }, { 2012.327160, 1.811892 },
+        { 2616.772727, 3.008585 }, { 3173.818182, 4.392743 },
+        { 3382.792208, 4.979133 }, { 3721.071429, 6.024751 },
+        { 4093.178571, 7.289948 }, { 4502.496429, 8.820838 },
+        { 4952.746071, 10.673214 },
+    };
+    constexpr std::size_t kN = std::size(kCurve);
+
+    const double counts = static_cast<double>(raw);
+    if (counts <= kCurve[0].counts)
+        return 0.0;
+    // Above the top of the table, extrapolate along the last segment rather
+    // than clamping. Clamping would pin the meter at 10.7 W and hide the one
+    // reading an operator most needs to see — that they are past where the
+    // curve was ever measured.
+    if (counts >= kCurve[kN - 1].counts) {
+        const Point& a = kCurve[kN - 2];
+        const Point& b = kCurve[kN - 1];
+        const double slope = (b.watts - a.watts) / (b.counts - a.counts);
+        return b.watts + (counts - b.counts) * slope;
+    }
+    for (std::size_t i = 1; i < kN; ++i) {
+        if (counts <= kCurve[i].counts) {
+            const Point& a = kCurve[i - 1];
+            const Point& b = kCurve[i];
+            const double span = b.counts - a.counts;
+            if (span <= 0.0)
+                return b.watts;
+            return a.watts + (counts - a.counts) * (b.watts - a.watts) / span;
+        }
+    }
+    return kCurve[kN - 1].watts;
+}
+
+double Hl2Backend::wattsToDbm(double watts)
+{
+    // The meter seam carries dBm (MeterDef unit), and MeterModel converts back
+    // to watts for display. Floored at the meter's own low bound so 0 W becomes
+    // "nothing" rather than -inf, which would propagate as NaN through the
+    // widget's scaling.
+    constexpr double kFloorDbm = 0.0;   // 1 mW; matches MeterDef low
+    if (!(watts > 0.0))
+        return kFloorDbm;
+    const double dbm = 10.0 * std::log10(watts * 1000.0);
+    return dbm < kFloorDbm ? kFloorDbm : dbm;
+}
+
 double Hl2Backend::temperatureCelsius(int raw)
 {
     // AD9866 on-die temperature via the HL2's instrumentation ADC. The scaling
     // below is the Hermes-Lite 2 wiki's published formula. It is NOT verified
     // against a reference thermometer here, so treat it as indicative.
     return (3.26 * (static_cast<double>(raw) / 4096.0) - 0.5) / 0.01;
+}
+
+void Hl2Backend::applyBandFilter(const char* reason)
+{
+    if (!m_metis)
+        return;
+    const int oc = static_cast<int>(ocFilterByteForHz(m_rxFreqHz));
+    if (oc == m_ocFilterByte)
+        return;
+    const int previous = m_ocFilterByte;
+    m_ocFilterByte = oc;
+
+    // INFO, not debug. There is no readback: the gateware forwards this byte to
+    // the filter board over I2C and nothing comes back, so this log line is the
+    // ONLY evidence of what the relays were told to do. A support log captured
+    // after the fact has to already contain it. (aether.hl2)
+    qCInfo(lcHl2).nospace()
+        << "HL2 band filter: " << QString::asprintf("0x%02X", oc)
+        << " (" << ocFilterName(static_cast<std::uint8_t>(oc)) << ") for "
+        << QString::number(m_rxFreqHz / 1.0e6, 'f', 6) << " MHz"
+        << " — was "
+        << (previous < 0 || previous > 0x7F
+                ? QStringLiteral("unset")
+                : QString::asprintf("0x%02X", previous))
+        << ", trigger=" << reason;
+
+    QMetaObject::invokeMethod(m_metis, "setBandFilter", Qt::QueuedConnection,
+        Q_ARG(int, oc));
 }
 
 void Hl2Backend::emitSliceState()

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -49,6 +49,7 @@ public:
     void setSliceAgc(int sliceId, const QString& mode, int thresholdDb) override;
     void setPanCenter(const QString& panId, double hz) override;
     void setPanBandwidth(const QString& panId, double hz) override;
+    void setPanRfGain(const QString& panId, int gainDb) override;
 
 private:
     // The actual span change, after the throttle above has settled.
@@ -69,13 +70,25 @@ public:
     void invokeExtension(const QString& ns, const QString& verb, quint64 requestId,
                          const QVariant& arg) override;
 
+    HealthSnapshot healthSnapshot() const override;
+
 private:
+    // Re-select the companion filter board's band filter for the current slice
+    // frequency. Idempotent and change-gated, so it is safe to call from every
+    // path that can move the dial.
+    void applyBandFilter(const char* reason);
+
     void emitSliceState();   // sliceChanged(delta) from current freq/mode/filter
     void emitPanState();     // panCenterBandwidthChanged from freq + sample rate
     void pushInitialState();
     void defineMeters();
     void publishTelemetry(const Hl2Telemetry& t);
     static double temperatureCelsius(int raw);
+    // Uncalibrated directional-coupler counts -> watts. See the table in the
+    // .cpp for what this curve is and, more importantly, what it is not.
+    static double directionalWatts(int raw);
+    // Watts -> dBm for the meter seam, floored so 0 W does not become -inf.
+    static double wattsToDbm(double watts);
 
     MetisClient* m_metis = nullptr;
     Hl2RxDsp* m_dsp = nullptr;
@@ -120,6 +133,10 @@ private:
     int m_filterLowHz = 150;
     int m_filterHighHz = 3000;
     int m_lnaGainDb = 20;
+    // Last J16 open-collector filter byte commanded. 0xFF is "nothing sent yet"
+    // rather than a real selection — kOcNone (0x00) is a legitimate value
+    // meaning "every relay released", so it cannot double as the sentinel.
+    int m_ocFilterByte = 0xFF;
     // Owns the LNA gain <-> dBm coupling so a gain change cannot move the trace.
     Hl2DbReference m_dbRef;
 
@@ -134,6 +151,11 @@ private:
     // independently at the wire.
     bool m_txAllowed = false;
     Hl2Telemetry m_telemetry;
+    // Cumulative EP6 sequence gaps, mirrored onto THIS thread from
+    // MetisClient::dropsUpdated. Deliberately a copy rather than a call into
+    // MetisClient::droppedPackets(): that object lives on the I/O thread, and
+    // healthSnapshot() is read from the GUI thread.
+    quint64 m_drops = 0;
     bool m_adcOverload = false;
     bool m_keyed = false;
     bool m_tuning = false;
@@ -144,6 +166,40 @@ private:
     // no reason.
     static constexpr double kTuneCarrierAmplitude = 1.0;
     int m_lastFwdRaw = -1;
+
+    // ---- Meter pacing / ballistics ----
+    //
+    // WDSP hands us a signal-strength reading once per demodulated block, which
+    // at 24 kHz output is ~47 a second and scales with the span. Every one of
+    // them crossed the thread boundary into MeterModel and repainted the
+    // S-meter, so the needle was being driven far faster than it can be read
+    // and far faster than a Flex drives the same widget.
+    //
+    // Two separate things fix that and they are NOT interchangeable:
+    //   - the RATE gate below decides how often a value is published;
+    //   - the EMA decides what value gets published when it is.
+    // Dropping samples without smoothing would alias — the meter would show
+    // whichever instant happened to land on the tick.
+    //
+    // 100 ms is the cadence MetisClient already publishes radio telemetry at
+    // (kTelemetryMinIntervalMs), so every HL2 meter now updates on one clock.
+    static constexpr qint64 kMeterPublishIntervalMs = 100;
+    // Flex's own meter ballistics, from MeterModel's forward-power smoothing:
+    // fast attack so a peak is not missed, slow decay so the needle settles.
+    // Reused rather than re-invented so an operator moving between a Flex and
+    // an HL2 sees meters that behave the same way.
+    static constexpr double kMeterAttackAlpha = 0.5;
+    static constexpr double kMeterDecayAlpha  = 0.15;
+    QElapsedTimer m_sMeterClock;
+    double m_sMeterDbm = 0.0;
+    bool   m_haveSMeter = false;
+    // PA temperature rides the 10 Hz telemetry, so it needs no rate gate of its
+    // own — but the instrumentation ADC's low bits are noisy enough that the
+    // displayed value flickered by a degree at rest. Same EMA, symmetric:
+    // heating and cooling are both slow and neither deserves a fast attack.
+    static constexpr double kPaTempAlpha = 0.2;
+    double m_paTempC = 0.0;
+    bool   m_havePaTemp = false;
     // Authoritative AGC state, mirroring the DSP defaults in Hl2RxDsp::Config so
     // the first sliceChanged reports what WDSP was actually opened with.
     QString m_agcMode = QStringLiteral("med");
@@ -157,6 +213,15 @@ private:
     static constexpr double kUsablePassbandFraction = 0.8;
     static constexpr int kSliceId = 0;
     static constexpr const char* kPanId = "hl2";
+
+    // AD9866 LNA gain limits, in dB. These are the range ccRxGain() encodes
+    // (C4 = 0x40 | (dB + 12), a 6-bit field), so they are the register's own
+    // limits rather than a policy choice — clamping anywhere else would let a
+    // value be silently truncated on the wire instead of stopping at the end of
+    // the slider's travel.
+    static constexpr int kLnaGainMinDb  = -12;
+    static constexpr int kLnaGainMaxDb  = 48;
+    static constexpr int kLnaGainStepDb = 1;
 };
 
 }  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2EmergencyStop.cpp
+++ b/src/core/backends/hl2/Hl2EmergencyStop.cpp
@@ -1,0 +1,140 @@
+#include "core/backends/hl2/Hl2EmergencyStop.h"
+
+#include <QHostAddress>
+
+#include <atomic>
+#include <csignal>
+#include <cstring>
+
+#ifdef Q_OS_WIN
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#else
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#endif
+
+namespace AetherSDR::hl2 {
+
+namespace {
+
+// Plain globals, not a class: a signal handler must not touch anything whose
+// lifetime it cannot reason about, and these have static storage duration for
+// the whole process.
+//
+// The armed flag is the ONLY synchronisation. arm() fills the payload first and
+// publishes the descriptor last with a release store; fire() acquires the
+// descriptor before reading anything else. That ordering is what makes a
+// handler firing halfway through arm() see either the complete previous state
+// or nothing at all — never a descriptor paired with someone else's address.
+std::atomic<int>  g_fd{-1};
+sockaddr_in       g_addr{};
+std::uint8_t      g_packet[64]{};
+
+// Repeats of the stop datagram. UDP, 64 bytes, and the cost of losing the only
+// copy is a physical power cycle — so send it more than once.
+constexpr int kStopRepeats = 3;
+
+#ifndef Q_OS_WIN
+using socket_t = int;
+#else
+using socket_t = SOCKET;
+#endif
+
+extern "C" void terminatingSignalHandler(int sig)
+{
+    fireEmergencyStop();
+
+    // Restore the default disposition and re-raise, so the process dies exactly
+    // as it would have without us: same exit status, same core dump, same
+    // crash reporter. Swallowing the signal here would turn a kill into a hang.
+    std::signal(sig, SIG_DFL);
+    std::raise(sig);
+}
+
+}  // namespace
+
+void armEmergencyStop(qintptr fd, const QHostAddress& host, quint16 port,
+                      const std::array<std::uint8_t, 64>& stopPacket) noexcept
+{
+    bool ipv4 = false;
+    const quint32 v4 = host.toIPv4Address(&ipv4);
+    if (fd < 0 || !ipv4) {
+        // Metis is IPv4-only, so a non-IPv4 address means we have nothing we
+        // could send to. Disarm rather than leave a stale descriptor armed.
+        disarmEmergencyStop();
+        return;
+    }
+
+    g_fd.store(-1, std::memory_order_relaxed);   // stop any concurrent fire()
+
+    std::memset(&g_addr, 0, sizeof(g_addr));
+    g_addr.sin_family = AF_INET;
+    g_addr.sin_port = htons(port);
+    g_addr.sin_addr.s_addr = htonl(v4);
+    std::memcpy(g_packet, stopPacket.data(), sizeof(g_packet));
+
+    // Publish LAST. Everything above must be visible to a handler that sees
+    // this store.
+    g_fd.store(static_cast<int>(fd), std::memory_order_release);
+}
+
+void disarmEmergencyStop() noexcept
+{
+    g_fd.store(-1, std::memory_order_release);
+}
+
+void fireEmergencyStop() noexcept
+{
+    const int fd = g_fd.load(std::memory_order_acquire);
+    if (fd < 0)
+        return;
+
+    for (int i = 0; i < kStopRepeats; ++i) {
+        // sendto() is on POSIX's async-signal-safe list. Nothing else in this
+        // function allocates, locks, or calls into Qt — that is the whole
+        // reason the payload was built in advance.
+        (void)::sendto(static_cast<socket_t>(fd),
+                       reinterpret_cast<const char*>(g_packet), sizeof(g_packet),
+                       0, reinterpret_cast<const sockaddr*>(&g_addr),
+                       sizeof(g_addr));
+    }
+}
+
+void installEmergencyStopSignalHandlers() noexcept
+{
+    // SIGTERM  — plain `kill`, and what a service manager or the OS sends.
+    // SIGINT   — Ctrl-C from a terminal-launched run.
+    // SIGHUP   — the controlling terminal went away.
+    // SIGQUIT  — Ctrl-backslash.
+    //
+    // NOT SIGKILL: it cannot be caught, so `kill -9` still wedges the radio.
+    //
+    // TERMINATION SIGNALS ONLY — deliberately not SIGSEGV/SIGABRT/SIGBUS. A
+    // crash leaves the radio in the same state and it is tempting to cover it
+    // here, but those signals belong to whatever crash reporting the platform
+    // and the app already have (on macOS the reporter uses Mach exception
+    // ports, and MacStartupAbortGuard owns SIGABRT during startup). Quietly
+    // taking them over to save a power cycle is not a trade worth making.
+    static const int kSignals[] = {
+        SIGTERM, SIGINT,
+#ifndef Q_OS_WIN
+        SIGHUP, SIGQUIT,
+#endif
+    };
+    for (const int sig : kSignals) {
+        // NEVER override an inherited SIG_IGN.
+        //
+        // POSIX is explicit that a process which inherits a signal as ignored
+        // should leave it that way, and this is not a theoretical rule: nohup
+        // works by ignoring SIGHUP, so installing a handler over it converts a
+        // signal the parent deliberately neutralised back into a fatal one.
+        // Caught in testing — a nohup'd run died the moment its launching shell
+        // exited, which is the exact opposite of what nohup is for.
+        const auto previous = std::signal(sig, terminatingSignalHandler);
+        if (previous == SIG_IGN)
+            std::signal(sig, SIG_IGN);
+    }
+}
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/Hl2EmergencyStop.h
+++ b/src/core/backends/hl2/Hl2EmergencyStop.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <QtGlobal>   // qintptr / quint16
+
+#include <array>
+#include <cstdint>
+
+class QHostAddress;
+
+namespace AetherSDR::hl2 {
+
+// Release the radio from inside a signal handler.
+//
+// WHY THIS EXISTS. The Hermes-Lite 2 must be told to stop streaming. When it is
+// not, it keeps sending EP6 at a host that is gone and then stops answering
+// discovery — alive at the network layer, invisible to every client, and
+// requiring a physical power cycle. Reproduced three times: `kill <pid>` on a
+// connected AetherSDR wedges the radio every time.
+//
+// Hl2Backend's destructor already sends the stop, and that covers a normal
+// quit. It does not run on a signal: Qt tears nothing down for SIGTERM, so the
+// process simply vanishes mid-stream. The gateware watchdog is documented as
+// the anti-wedge mechanism for exactly this case (MetisProtocol.h,
+// kRunWatchdogDisable) and did NOT recover it in practice — which is why this
+// belt exists alongside that brace rather than instead of it.
+//
+// WHY IT IS NOT A SELF-PIPE. The textbook Qt answer is to write to a pipe from
+// the handler and do the real work back on the event loop. That would be
+// useless here: an unresponsive event loop is one of the main reasons anyone
+// reaches for kill in the first place, so the fix must not depend on the thing
+// that may already be stuck. fire() therefore does the whole job in the
+// handler, using nothing but sendto() on an address resolved in advance.
+//
+// EVERYTHING IS PRE-COMPUTED so that fire() is async-signal-safe: the socket
+// descriptor, the destination sockaddr and the 64-byte stop datagram are all
+// built by arm(), on a normal thread, while the link is coming up.
+//
+// SIGKILL cannot be caught, so `kill -9` still wedges the radio. Nothing in a
+// process can change that.
+
+// Publish the parameters needed to stop the radio. Called by MetisClient once
+// its socket is bound and the destination is known. Passing an invalid fd
+// disarms.
+void armEmergencyStop(qintptr fd, const QHostAddress& host, quint16 port,
+                      const std::array<std::uint8_t, 64>& stopPacket) noexcept;
+
+// Forget the armed radio. Called from MetisClient::stop(), which has already
+// sent the stop through the normal path.
+void disarmEmergencyStop() noexcept;
+
+// Send the stop datagram. ASYNC-SIGNAL-SAFE — calls only sendto(). A no-op
+// when nothing is armed, so it is always safe to call from a handler.
+//
+// Sends the datagram a few times: this is UDP, the packet is 64 bytes, and the
+// cost of a lost one is a radio the operator has to walk over to and unplug.
+void fireEmergencyStop() noexcept;
+
+// Install handlers for the TERMINATING signals (SIGTERM/SIGINT/SIGHUP/SIGQUIT)
+// so fireEmergencyStop() runs before the process dies. Each handler restores
+// the default disposition and re-raises, so the exit status is unchanged.
+//
+// A signal already inherited as SIG_IGN is left ignored — see the
+// implementation for why that matters more than it looks.
+//
+// Crash signals are deliberately NOT taken over; they belong to the platform's
+// crash reporting.
+//
+// Call once, early in main(). Safe to call when no radio is connected.
+void installEmergencyStopSignalHandlers() noexcept;
+
+}  // namespace AetherSDR::hl2

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -1,4 +1,5 @@
 #include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/Hl2EmergencyStop.h"
 
 #include <QElapsedTimer>
 #include <QThread>
@@ -184,6 +185,16 @@ bool MetisClient::start(const Params& params)
     // again so nothing is lost to the start transition. Starting before any C&C
     // has landed makes the firmware stream ADC-idle samples (Q pinned to zero).
     m_running = true;
+
+    // Arm the signal-handler stop BEFORE the first start datagram goes out.
+    //
+    // Ordering matters and it is one-sided: armed-but-not-streaming costs a
+    // stray 64-byte datagram to a radio that is not listening for it, while
+    // streaming-but-not-armed is a radio that has to be power-cycled. Arm
+    // early, on the pessimistic side.
+    armEmergencyStop(m_socket->socketDescriptor(), m_host, m_port,
+                     metisStop(m_watchdogEnabled));
+
     sendPrimingBurst(3);
     sendTo(*m_socket, metisStart(m_watchdogEnabled), m_host, m_port);
     sendPrimingBurst(3);
@@ -248,6 +259,11 @@ void MetisClient::stop()
     if (m_connectWatchdog) m_connectWatchdog->stop();
     if (m_socket) {
         sendTo(*m_socket, metisStop(m_watchdogEnabled), m_host, m_port);
+        // Disarm only AFTER the normal stop has gone out, and before the
+        // descriptor is closed. Disarming earlier would leave a window where a
+        // signal arriving mid-teardown released nothing; later would leave a
+        // closed — or worse, recycled — descriptor armed.
+        disarmEmergencyStop();
         m_socket->close();
         m_socket->deleteLater();
         m_socket = nullptr;

--- a/src/core/backends/hl2/MetisClient.cpp
+++ b/src/core/backends/hl2/MetisClient.cpp
@@ -161,7 +161,7 @@ bool MetisClient::start(const Params& params)
     m_params = params;
     m_host = params.host;
     m_port = params.port;
-    m_ccConfig = ccConfig(m_params.sampleRate, effectiveNumRx());
+    m_ccConfig = ccConfig(m_params.sampleRate, effectiveNumRx(), m_params.ocFilterByte);
     m_ccGain = ccRxGain(m_params.lnaGainDb);
     m_ccFreq = ccRx1Freq(m_params.rxFrequencyHz);
     m_txSeq = 0;
@@ -276,13 +276,31 @@ void MetisClient::setSampleRate(SampleRate rate)
     // Was hardcoded to 1: changing sample rate silently reset the receiver
     // count, so any multi-receiver configuration would have collapsed to a
     // single receiver the first time the operator changed bandwidth.
-    m_ccConfig = ccConfig(rate, effectiveNumRx());
+    //
+    // The filter byte is here for the SAME reason. Everything that shares this
+    // register has to be carried through every rebuild of it; anything a
+    // rebuild re-defaults gets silently dropped the next time an unrelated
+    // control changes — a zoom would have released the band relays.
+    m_ccConfig = ccConfig(rate, effectiveNumRx(), m_params.ocFilterByte);
 }
 
 void MetisClient::setLnaGainDb(int db)
 {
     m_params.lnaGainDb = db;
     m_ccGain = ccRxGain(db);
+}
+
+void MetisClient::setBandFilter(int ocFilterByte)
+{
+    const std::uint8_t oc = static_cast<std::uint8_t>(ocFilterByte & 0x7F);
+    if (oc == m_params.ocFilterByte)
+        return;                       // relays already where they belong
+    m_params.ocFilterByte = oc;
+    m_ccConfig = ccConfig(m_params.sampleRate, effectiveNumRx(), oc);
+    // Ahead of the rotation: a band change moves the NCO and the filter in the
+    // same gesture, and waiting for the round robin would leave the relays on
+    // the old band for up to three EP2 frames.
+    m_oneShot.push_back(m_ccConfig);
 }
 
 void MetisClient::requestPipelineReset()

--- a/src/core/backends/hl2/MetisClient.h
+++ b/src/core/backends/hl2/MetisClient.h
@@ -52,6 +52,11 @@ public:
         // a board for more receivers than it has is a configuration the
         // gateware cannot honour, and it does not report the refusal.
         int boardMaxRx = 0;
+        // J16 open-collector filter selection (MetisProtocol kOc* bits). Rides
+        // the config register, so it is part of the same Params the config
+        // register is rebuilt from — see setSampleRate() for why a field that
+        // shares a register with another has to be carried, not re-defaulted.
+        std::uint8_t ocFilterByte = kOcNone;
     };
 
     // A discovered radio: its Metis reply plus the address to connect to.
@@ -80,6 +85,18 @@ public:
     Q_INVOKABLE void setRxFrequencyHz(std::uint32_t hz);
     Q_INVOKABLE void setSampleRate(SampleRate rate);
     Q_INVOKABLE void setLnaGainDb(int db);
+    // Select the companion filter board's band filter (MetisProtocol kOc* bits).
+    //
+    // Latched into the config register and sent on the next round, and ALSO
+    // pushed as a one-shot so the relays move with the band change rather than
+    // up to three EP2 frames later. Filter switching that lags the retune is
+    // the failure mode that matters on transmit.
+    // Takes int, not uint8_t: this crosses threads via
+    // QMetaObject::invokeMethod, which matches Q_ARG against the type name moc
+    // recorded from this declaration, and `std::uint8_t` does not normalize to
+    // the same string as `unsigned char`.
+    Q_INVOKABLE void setBandFilter(int ocFilterByte);
+    [[nodiscard]] std::uint8_t bandFilter() const noexcept { return m_params.ocFilterByte; }
     // Queue a one-shot filter-pipeline reset (MetisProtocol kC0Sync) to be sent
     // on the next EP2 frame, ahead of the round robin.
     Q_INVOKABLE void requestPipelineReset();

--- a/src/core/backends/hl2/MetisProtocol.cpp
+++ b/src/core/backends/hl2/MetisProtocol.cpp
@@ -42,13 +42,49 @@ int sampleRateHz(SampleRate rate) noexcept
     return 48000;
 }
 
-Cc ccConfig(SampleRate rate, int numRx) noexcept
+std::uint8_t ocFilterByteForHz(double hz) noexcept
+{
+    const double mhz = hz / 1.0e6;
+    // Ordered low to high; the first range that contains the frequency wins.
+    // Boundaries sit in the gaps BETWEEN amateur bands, so every band lands
+    // wholly inside one range — hl2_band_filter_test asserts that against
+    // Quisk's table rather than trusting the arithmetic here.
+    if (mhz < 1.6)   return kOcNone;                        // LW/MW: HPF would gut it
+    if (mhz < 2.5)   return kOcLpf160;                      // 160 m — HPF out (spurs)
+    if (mhz < 4.5)   return kOcHpfAmBc | kOcLpf80;          // 80 m
+    if (mhz < 8.5)   return kOcHpfAmBc | kOcLpf60_40;       // 60 m, 40 m
+    if (mhz < 16.5)  return kOcHpfAmBc | kOcLpf30_20;       // 30 m, 20 m
+    if (mhz < 22.5)  return kOcHpfAmBc | kOcLpf17_15;       // 17 m, 15 m
+    if (mhz <= 30.0) return kOcHpfAmBc | kOcLpf12_10;       // 12 m, 10 m
+    return kOcNone;                                          // 6 m and up: no filter fitted
+}
+
+const char* ocFilterName(std::uint8_t oc) noexcept
+{
+    switch (static_cast<std::uint8_t>(oc & 0x7F)) {
+    case kOcNone:                       return "none (bypass)";
+    case kOcLpf160:                     return "160m LPF";
+    case kOcHpfAmBc | kOcLpf80:         return "HPF + 80m LPF";
+    case kOcHpfAmBc | kOcLpf60_40:      return "HPF + 60/40m LPF";
+    case kOcHpfAmBc | kOcLpf30_20:      return "HPF + 30/20m LPF";
+    case kOcHpfAmBc | kOcLpf17_15:      return "HPF + 17/15m LPF";
+    case kOcHpfAmBc | kOcLpf12_10:      return "HPF + 12/10m LPF";
+    default:                            return "custom";
+    }
+}
+
+Cc ccConfig(SampleRate rate, int numRx, std::uint8_t ocFilterByte) noexcept
 {
     const auto c1 = static_cast<std::uint8_t>((static_cast<std::uint8_t>(rate) & 0x03) | kConfigMercury);
     if (numRx < 1) numRx = 1;
     if (numRx > 8) numRx = 8;
+    // Open collector outputs are DATA[23:17] == C2[7:1]. The one-bit shift is
+    // the whole reason this cannot be a straight assignment: DATA[16] is not
+    // part of the field, and writing the byte unshifted would put the 160 m
+    // relay's bit there and every real selection one filter too low.
+    const auto c2 = static_cast<std::uint8_t>((ocFilterByte & 0x7F) << 1);
     const auto c4 = static_cast<std::uint8_t>(kConfigDuplex | (((numRx - 1) & 0x07) << 3));
-    return {kC0Config, c1, 0x00, 0x00, c4};
+    return {kC0Config, c1, c2, 0x00, c4};
 }
 
 Cc ccRx1Freq(std::uint32_t hz) noexcept

--- a/src/core/backends/hl2/MetisProtocol.h
+++ b/src/core/backends/hl2/MetisProtocol.h
@@ -127,12 +127,70 @@ inline constexpr std::uint8_t kConfigDuplex = 0x04;   // C4 bit2: pihpsdr sets t
 enum class SampleRate : std::uint8_t { R48k = 0, R96k = 1, R192k = 2, R384k = 3 };
 int sampleRateHz(SampleRate rate) noexcept;
 
+// ---- Companion filter board (J16 open-collector outputs) ----
+//
+// The HL2 has NO switchable filters of its own. What it has is seven
+// open-collector outputs in the config register at 0x00[23:17], which the
+// GATEWARE forwards as one byte to I2C address 0x20 — bits [6:0] from those
+// outputs, bit [7] from the RX-antenna bit at 0x00[13]. Nothing here writes
+// I2C: setting the config bits IS the whole mechanism (HL2 wiki, Protocol.md
+// "Filter Board"; oracle §8).
+//
+// The N2ADR companion board decodes bits 6:0 ONE-HOT into six low-pass filters
+// and one AM-broadcast-blocking high-pass. Values below are Quisk's
+// Hermes_BandDict verbatim (quisk_conf_defaults.py) — the reference client, and
+// tier 3 on the source-precedence ladder. They are reproduced rather than
+// re-derived because the grouping (60 and 40 share a filter; 17 and 15 share
+// one) is a property of that board, not something inferable from the band plan.
+//
+// A board that is absent simply has nothing listening on the I2C bus, so
+// writing these is inert on a bare HL2 — which is why this is safe to drive
+// unconditionally rather than behind a "do you have the filter board" setting.
+inline constexpr std::uint8_t kOcLpf160   = 0x01;   // 160 m low-pass
+inline constexpr std::uint8_t kOcLpf80    = 0x02;   // 80 m
+inline constexpr std::uint8_t kOcLpf60_40 = 0x04;   // 60 m + 40 m share one
+inline constexpr std::uint8_t kOcLpf30_20 = 0x08;   // 30 m + 20 m
+inline constexpr std::uint8_t kOcLpf17_15 = 0x10;   // 17 m + 15 m
+inline constexpr std::uint8_t kOcLpf12_10 = 0x20;   // 12 m + 10 m
+inline constexpr std::uint8_t kOcHpfAmBc  = 0x40;   // AM broadcast blocking HPF
+inline constexpr std::uint8_t kOcNone     = 0x00;   // every relay released
+
+// The open-collector byte for a receive/transmit frequency in Hz.
+//
+// Chosen by FREQUENCY rather than by a band name, because this has to answer
+// for the whole tuning range, not only the ten HF amateur bands: the operator
+// can park on 9 MHz shortwave or 500 kHz, and "no band matched" must still give
+// a defined filter state rather than leaving whatever the last band selected.
+//
+// Every amateur band lands on the same value Quisk's table gives it — that is
+// the check that the range boundaries are right, not an accident of rounding.
+//
+// Two deliberate departures from "always engage the HPF":
+//   - Below 1.6 MHz the AM-blocking HPF would remove exactly what is being
+//     listened to, so nothing is engaged.
+//   - On 160 m the HPF stays OUT. The HL2's own switching supply couples spurs
+//     into the filter board's 160 m and HPF inductors (HL2 wiki, Options.md),
+//     and Quisk's default omits it there for that reason.
+//   - Above 30 MHz the board has no filter at all (6 m and up), so
+//     everything is released rather than engaging a low-pass that would
+//     attenuate the very signal being received.
+std::uint8_t ocFilterByteForHz(double hz) noexcept;
+
+// Human-readable name of an open-collector filter selection, for logging.
+const char* ocFilterName(std::uint8_t oc) noexcept;
+
 // A 5-byte Command & Control payload: C0 (register address) + C1..C4 (data).
 using Cc = std::array<std::uint8_t, 5>;
 
-// Config register: sample rate + receiver count. Also carries the Mercury and
-// duplex bits for openHPSDR compatibility; both are ignored by the HL2 gateware.
-Cc ccConfig(SampleRate rate, int numRx = 1) noexcept;
+// Config register: sample rate + receiver count + the J16 open-collector filter
+// byte. Also carries the Mercury and duplex bits for openHPSDR compatibility;
+// both are ignored by the HL2 gateware.
+//
+// ocFilterByte is the value from ocFilterByteForHz(); only bits [6:0] are used
+// (they land in DATA[23:17]). Bit 7 is the RX-antenna bit and lives elsewhere in
+// the register, so it is masked off here rather than silently switching antennas
+// on a caller who passed a full I2C byte.
+Cc ccConfig(SampleRate rate, int numRx = 1, std::uint8_t ocFilterByte = kOcNone) noexcept;
 // RX1 NCO frequency in Hz (32-bit big-endian across C1..C4).
 Cc ccRx1Freq(std::uint32_t hz) noexcept;
 // AD9866 LNA gain in dB, clamped to [-12, +48]; C4 = 0x40 | (dB + 12).

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5292,6 +5292,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 menu->setRadioCapabilities(caps);
                 menu->setDeclaredBands(declaredBands);
                 menu->setXvtrBands(xvtrBands);
+                applyTuningRangeToOverlayMenu(menu);
             }
         };
         QTimer::singleShot(2000, this, refreshXvtr);
@@ -6049,6 +6050,28 @@ void MainWindow::applyMasterVolume(int pct)
 }
 
 // onSliceAdded() / onSliceRemoved() lives in MainWindow_Wiring.cpp (#3351 Phase 1d).
+QString MainWindow::rfGainSettingsKey(SpectrumWidget* sw) const
+{
+    if (!sw)
+        return QStringLiteral("DisplayRfGain");
+    const QString base = sw->settingsKey(QStringLiteral("DisplayRfGain"));
+    const QString family = m_radioModel.backendCapabilities().family;
+    if (family.isEmpty() || family == QLatin1String("flex"))
+        return base;                       // unchanged for Flex and when unknown
+    return base + QLatin1Char('_') + family;
+}
+
+void MainWindow::applyTuningRangeToOverlayMenu(SpectrumOverlayMenu* menu) const
+{
+    if (!menu)
+        return;
+    const RadioCapabilities caps = m_radioModel.backendCapabilities();
+    // Zero/zero when the backend reports no range, which the menu reads as
+    // "unconstrained" — so a Flex, and a disconnected session, both keep every
+    // band button live exactly as before.
+    menu->setTuningRangeMhz(caps.tuningMinHz / 1.0e6, caps.tuningMaxHz / 1.0e6);
+}
+
 SliceModel* MainWindow::activeSlice() const
 {
     SliceModel* cached = nullptr;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -107,6 +107,7 @@ class ContributeDialog;
 class TitleBar;
 class KiwiSdrManager;
 class SpectrumWidget;
+class SpectrumOverlayMenu;
 class IRadioBackend;
 class PanadapterApplet;
 class PanadapterStack;
@@ -343,6 +344,24 @@ private:
                                            bool resetOutput,
                                            bool reinitializePcInput);
     SliceModel* activeSlice() const;
+
+    // Push the connected backend's reported tuning range into one overlay
+    // menu's band panel, so bands the radio cannot reach are disabled rather
+    // than tuning it somewhere it hears nothing. A backend that reports no
+    // range leaves every band enabled (the Flex behaviour).
+    void applyTuningRangeToOverlayMenu(SpectrumOverlayMenu* menu) const;
+
+    // AppSettings key for a pan's persisted RF gain, scoped by radio FAMILY.
+    //
+    // RF gain is the one "display" setting that is really a hardware register,
+    // and its range is family-specific: a Flex's is -8..+32 in 8 dB steps, the
+    // HL2's AD9866 LNA is -12..+48 in 1 dB steps. Sharing one key meant a value
+    // last set on a Flex was restored onto an HL2 as an LNA gain the operator
+    // never chose for that radio — harmless while the HL2 ignored it, real now
+    // that the slider reaches the register.
+    //
+    // Flex keeps the unsuffixed key so existing settings survive untouched.
+    QString rfGainSettingsKey(SpectrumWidget* sw) const;
     static const char* tuneIntentName(TuneIntent intent);
     bool panFollowEnabled() const;
     BandStackPreselectResult preselectBandStackForTune(SliceModel* slice, double mhz,

--- a/src/gui/MainWindow_Menus.cpp
+++ b/src/gui/MainWindow_Menus.cpp
@@ -28,6 +28,7 @@
 #include "PersistentDialog.h"
 #include "RC28MappingDialog.h"
 #include "ShortcutDialog.h"
+#include "RadioHealthDialog.h"
 #include "SliceTroubleshootingDialog.h"
 #include "SpectrumWidget.h"
 #include "SupportDialog.h"
@@ -1177,6 +1178,17 @@ void MainWindow::buildMenuBar()
         trackPersistentDialog(dlg);
         dlg->show();
         dlg->raise();
+    });
+    // Before Slice Troubleshooting: this one is about the RADIO's own health
+    // registers, which is the first thing to check when the slice-level
+    // symptoms in that dialog turn out to have a hardware cause.
+    helpMenu->addAction("Radio Health...", this, [this]() {
+        auto* dlg = new RadioHealthDialog(&m_radioModel, this);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        trackPersistentDialog(dlg);
+        dlg->show();
+        dlg->raise();
+        dlg->activateWindow();
     });
     helpMenu->addAction("Slice Troubleshooting...", this, [this]() {
         auto* dlg = new SliceTroubleshootingDialog(

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -1207,10 +1207,35 @@ void MainWindow::wirePanLifecycle()
             auto& s = AppSettings::instance();
             bool wnbOn = s.value(sw->settingsKey("DisplayWnbEnabled"), "False").toString() == "True";
             int wnbLevel = s.value(sw->settingsKey("DisplayWnbLevel"), "50").toInt();
-            int rfGain = s.value(sw->settingsKey("DisplayRfGain"), "0").toInt();
+            // RF gain: push ONLY a value the operator actually saved.
+            //
+            // With no saved value there is nothing to restore, and the radio's
+            // own gain is the right answer — so leave it alone and mirror it
+            // into the widgets instead.
+            //
+            // Writing a default here is what made this subtle. On a Flex,
+            // rfgain 0 is the neutral middle of a -8..+32 range, so pushing a
+            // hardcoded 0 was invisible. On a backend that owns its gain in a
+            // register it is not: the HL2 comes up at 20 dB of AD9866 LNA gain,
+            // and a never-saved "0" pushed it 20 dB down — a receiver that is
+            // simply deaf, with nothing in the UI saying anything was applied.
+            //
+            // Seeding the default from the pan model instead does NOT fix it.
+            // This restore runs off panadapterInfoChanged, which can land
+            // before the backend has published its gain, so the model still
+            // reads its own 0 and the same 0 goes back to the hardware.
+            // Measured: Radio Health showed "LNA gain 0 dB" on a fresh HL2
+            // profile. The only correct rule is not to write at all.
+            const QString rfGainKey = rfGainSettingsKey(sw);
+            const bool haveSavedRfGain = s.contains(rfGainKey);
+            PanadapterModel* activePan = m_radioModel.activePanadapter();
+            const int rfGain = haveSavedRfGain
+                ? s.value(rfGainKey).toInt()
+                : (activePan ? activePan->rfGain() : 0);
             m_radioModel.setPanWnb(wnbOn);
             m_radioModel.setPanWnbLevel(wnbLevel);
-            m_radioModel.setPanRfGain(rfGain);
+            if (haveSavedRfGain)
+                m_radioModel.setPanRfGain(rfGain);
             sw->setWnbActive(wnbOn);
             sw->setRfGain(rfGain);
             sw->overlayMenu()->setWnbState(wnbOn, wnbLevel);
@@ -1255,6 +1280,7 @@ void MainWindow::wirePanLifecycle()
                 menu->setRadioModel(&m_radioModel);
                 menu->setRadioCapabilities(m_radioModel.capabilities());
                 menu->setDeclaredBands(m_radioModel.declaredBands());
+                applyTuningRangeToOverlayMenu(menu);
                 connect(pan, &PanadapterModel::infoChanged,
                         sw, &SpectrumWidget::setFrequencyRange);
                 // Re-push authoritative geometry when a gesture that was

--- a/src/gui/MainWindow_Shortcuts.cpp
+++ b/src/gui/MainWindow_Shortcuts.cpp
@@ -746,7 +746,7 @@ void MainWindow::registerShortcutActions()
             menu->setRfGain(next);
 
         auto& settings = AppSettings::instance();
-        settings.setValue(sw->settingsKey("DisplayRfGain"), QString::number(next));
+        settings.setValue(rfGainSettingsKey(sw), QString::number(next));
         settings.save();
     };
 

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -3134,6 +3134,7 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     menu->setKiwiSdrManager(m_kiwiSdrManager);
     menu->setRadioCapabilities(m_radioModel.capabilities());
     menu->setDeclaredBands(m_radioModel.declaredBands());
+    applyTuningRangeToOverlayMenu(menu);
 
     // Antenna list → this overlay menu (per-pan, mirrors VfoWidget pattern) (#1260)
     connect(&m_radioModel, &RadioModel::antListChanged,
@@ -4423,6 +4424,67 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         // current slice/pan state untouched. Guessing is worse than failing
         // visibly because a wrong tune destroys the very band-stack state this
         // path exists to preserve.
+        // ── Radios with no band stack of their own ────────────────────────
+        //
+        // Everything below this branch is Flex band-stack machinery: it resolves
+        // a protocol band key and sends "display pan set … band=", and the radio
+        // restores frequency, mode, filters and antenna from state IT owns. A
+        // Hermes-Lite 2 owns none of that — it has no VFO to read back and no
+        // stack to restore — so that command reached nothing and the band
+        // buttons did precisely nothing on this family.
+        //
+        // Here the APP is authoritative, so the freqMhz/mode the button carries
+        // are used directly. That is the exact opposite of the rule stated above
+        // for Flex, and deliberately so: those arguments are "static UI
+        // defaults" only when something better exists, and on this family
+        // nothing does. Tuning to band centre in the band's usual mode is what
+        // every radio without a stack does.
+        if (!m_radioModel.usesFlexCommandPlane()) {
+            const RadioCapabilities caps = m_radioModel.backendCapabilities();
+            const double hz = freqMhz * 1.0e6;
+            // Refuse rather than tune somewhere the receiver cannot hear. Only
+            // when the backend actually reported a range — a backend that
+            // reports none keeps the previous unconditional behaviour.
+            if (caps.tuningMaxHz > caps.tuningMinHz
+                && (hz < caps.tuningMinHz || hz > caps.tuningMaxHz)) {
+                const QString reason =
+                    tr("%1 is outside this radio's tuning range (%2–%3 MHz)")
+                        .arg(bandName)
+                        .arg(caps.tuningMinHz / 1.0e6, 0, 'f', 3)
+                        .arg(caps.tuningMaxHz / 1.0e6, 0, 'f', 3);
+                qCWarning(lcProtocol).noquote() << "MainWindow: " << reason;
+                statusBar()->showMessage(reason, 5000);
+                return;
+            }
+
+            SliceModel* s = activeSlice();
+            if (!s) {
+                statusBar()->showMessage(tr("No active slice to tune"), 4000);
+                return;
+            }
+            clearSwrSweepForBandChange(s->sliceId(), applet->panId(), bandName);
+            m_bandSettings.setCurrentBand(bandName);
+            // MODE FIRST, then frequency. The backend adopts a mode-appropriate
+            // passband on a mode CHANGE (Hl2Backend::setSliceMode), and the
+            // frequency move is what re-selects the companion filter board — so
+            // this order leaves both the passband and the band filter settled
+            // for the band being arrived at, not the one being left.
+            if (!mode.isEmpty())
+                s->setMode(mode);
+            s->setFrequency(freqMhz);
+            // Centre the window on the new band. Without this the panadapter
+            // keeps the old band's NCO until the tune happens to fall outside
+            // the usable passband, so a band change could leave the trace
+            // centred a whole band away from the slice that just moved.
+            m_radioModel.requestPanCenter(applet->panId(), freqMhz);
+            qCDebug(lcProtocol).noquote().nospace()
+                << "MainWindow: band switch (no radio band stack) band=" << bandName
+                << " pan=" << applet->panId()
+                << " freq_mhz=" << QString::number(freqMhz, 'f', 6)
+                << " mode=" << mode;
+            return;
+        }
+
         const auto xvtrs = xvtrPolicyBandsFrom(m_radioModel.xvtrList());
         QString stackKey = stackKeyHint;
         QString unsupportedBandReason;
@@ -4546,11 +4608,15 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     });
     connect(menu, &SpectrumOverlayMenu::rfGainChanged,
             this, [this, sw, applet](int gain) {
-        m_radioModel.sendCommand(
-            QString("display pan set %1 rfgain=%2").arg(applet->panId()).arg(gain));
+        // Through the model, not raw wire text. RadioModel::setPanRfGain routes
+        // a non-Flex backend's gain through the seam (the HL2 keeps it in an
+        // AD9866 register, not in a "display pan set" command), and emitting the
+        // Flex string here bypassed that entirely — the slider moved, the value
+        // persisted, and nothing reached the radio.
+        m_radioModel.setPanRfGainFor(applet->panId(), gain);
         sw->setRfGain(gain);
         auto& s = AppSettings::instance();
-        s.setValue(sw->settingsKey("DisplayRfGain"), QString::number(gain));
+        s.setValue(rfGainSettingsKey(sw), QString::number(gain));
         s.save();
     });
     connect(menu, &SpectrumOverlayMenu::loopAToggled,

--- a/src/gui/RadioHealthDialog.cpp
+++ b/src/gui/RadioHealthDialog.cpp
@@ -1,0 +1,187 @@
+#include "RadioHealthDialog.h"
+
+#include "core/ThemeManager.h"
+#include "models/RadioModel.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QFont>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QTimer>
+#include <QVBoxLayout>
+
+namespace AetherSDR {
+
+namespace {
+
+// Fast enough to watch a FIFO move or an ADC overload blink, slow enough that
+// the table is readable. The underlying telemetry only arrives at 10 Hz
+// anyway (MetisClient::kTelemetryMinIntervalMs), so polling faster than this
+// would re-render identical values.
+constexpr int kRefreshIntervalMs = 500;
+
+}  // namespace
+
+RadioHealthDialog::RadioHealthDialog(RadioModel* model, QWidget* parent)
+    : PersistentDialog(QStringLiteral("Radio Health"),
+                       QStringLiteral("RadioHealthDialogGeometry"), parent)
+    , m_model(model)
+{
+    theme::setContainer(this, QStringLiteral("dialog/radioHealth"));
+    setMinimumSize(460, 460);
+    resize(520, 620);
+
+    auto* root = new QVBoxLayout(bodyWidget());
+    root->setSpacing(8);
+
+    auto* intro = new QLabel(
+        tr("Health and status registers reported by the connected radio. "
+           "A dash means the radio has not reported that value — which is not "
+           "the same as a value of zero."));
+    intro->setWordWrap(true);
+    ThemeManager::instance().applyStyleSheet(intro,
+        "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
+    root->addWidget(intro);
+
+    m_table = new QTableWidget(0, 2);
+    m_table->setHorizontalHeaderLabels({tr("Register"), tr("Value")});
+    m_table->verticalHeader()->setVisible(false);
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setAlternatingRowColors(true);
+    m_table->setShowGrid(false);
+    ThemeManager::instance().applyStyleSheet(m_table, "QTableWidget {"
+        "  background: {{color.background.0}};"
+        "  color: {{color.text.primary}};"
+        "  border: 1px solid {{color.background.2}};"
+        "  font-size: 11px;"
+        "}"
+        "QHeaderView::section {"
+        "  background: {{color.background.1}};"
+        "  color: {{color.text.secondary}};"
+        "  border: 0px;"
+        "  padding: 4px;"
+        "}");
+    root->addWidget(m_table, 1);
+
+    auto* buttonRow = new QHBoxLayout;
+    m_statusLabel = new QLabel;
+    ThemeManager::instance().applyStyleSheet(m_statusLabel,
+        "QLabel { color: {{color.text.secondary}}; font-size: 11px; }");
+    buttonRow->addWidget(m_statusLabel, 1);
+    auto* copyBtn = new QPushButton(tr("Copy"));
+    copyBtn->setAutoDefault(false);
+    connect(copyBtn, &QPushButton::clicked, this, &RadioHealthDialog::copyToClipboard);
+    buttonRow->addWidget(copyBtn);
+    auto* closeBtn = new QPushButton(tr("Close"));
+    closeBtn->setAutoDefault(false);
+    connect(closeBtn, &QPushButton::clicked, this, &QDialog::accept);
+    buttonRow->addWidget(closeBtn);
+    root->addLayout(buttonRow);
+
+    m_refreshTimer = new QTimer(this);
+    m_refreshTimer->setInterval(kRefreshIntervalMs);
+    connect(m_refreshTimer, &QTimer::timeout, this, &RadioHealthDialog::refresh);
+    m_refreshTimer->start();
+    refresh();
+}
+
+QString RadioHealthDialog::formatValue(const QVariant& v)
+{
+    if (!v.isValid())
+        return QStringLiteral("—");
+    // Booleans FIRST: QVariant::Bool would otherwise fall through to the
+    // numeric branch and render an ADC overload as "1", which reads like a
+    // count rather than a flag.
+    if (v.typeId() == QMetaType::Bool)
+        return v.toBool() ? QObject::tr("Yes") : QObject::tr("No");
+    if (v.typeId() == QMetaType::Double || v.typeId() == QMetaType::Float)
+        return QString::number(v.toDouble(), 'f', 2);
+    return v.toString();
+}
+
+void RadioHealthDialog::refresh()
+{
+    if (!m_model)
+        return;
+    const IRadioBackend::HealthSnapshot snap = m_model->backendHealthSnapshot();
+
+    if (snap.isEmpty()) {
+        m_table->setRowCount(0);
+        m_currentKeys.clear();
+        m_statusLabel->setText(
+            m_model->isConnected()
+                ? tr("This radio reports no health registers.")
+                : tr("Not connected."));
+        return;
+    }
+    m_statusLabel->setText(tr("Updating every %1 ms").arg(kRefreshIntervalMs));
+
+    // Rebuild the rows only when the set of keys changes. On a steady snapshot
+    // this runs once and every later refresh just rewrites the value column,
+    // which is what keeps the operator's scroll position and selection intact
+    // while they are reading.
+    if (snap.order != m_currentKeys) {
+        m_currentKeys = snap.order;
+        m_table->setRowCount(0);
+        int row = 0;
+        for (const QString& key : snap.order) {
+            if (const auto sectionIt = snap.sections.constFind(key);
+                sectionIt != snap.sections.constEnd()) {
+                m_table->insertRow(row);
+                auto* header = new QTableWidgetItem(sectionIt.value());
+                QFont f = header->font();
+                f.setBold(true);
+                header->setFont(f);
+                // Section headers carry no key, so the value-column writer
+                // below can tell them apart from real rows and skip them.
+                m_table->setItem(row, 0, header);
+                m_table->setItem(row, 1, new QTableWidgetItem(QString()));
+                ++row;
+            }
+            m_table->insertRow(row);
+            auto* label = new QTableWidgetItem(snap.labels.value(key, key));
+            label->setData(Qt::UserRole, key);
+            m_table->setItem(row, 0, label);
+            m_table->setItem(row, 1, new QTableWidgetItem(QString()));
+            ++row;
+        }
+    }
+
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        QTableWidgetItem* label = m_table->item(row, 0);
+        if (!label)
+            continue;
+        const QString key = label->data(Qt::UserRole).toString();
+        if (key.isEmpty())
+            continue;                    // section header
+        m_table->item(row, 1)->setText(formatValue(snap.values.value(key)));
+    }
+}
+
+void RadioHealthDialog::copyToClipboard()
+{
+    QStringList lines;
+    lines << QStringLiteral("AetherSDR — Radio Health");
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        QTableWidgetItem* label = m_table->item(row, 0);
+        QTableWidgetItem* value = m_table->item(row, 1);
+        if (!label)
+            continue;
+        if (label->data(Qt::UserRole).toString().isEmpty())
+            lines << QString() << label->text();          // section heading
+        else
+            lines << QStringLiteral("  %1: %2")
+                         .arg(label->text(), value ? value->text() : QString());
+    }
+    QApplication::clipboard()->setText(lines.join(QLatin1Char('\n')));
+    m_statusLabel->setText(tr("Copied to clipboard"));
+}
+
+} // namespace AetherSDR

--- a/src/gui/RadioHealthDialog.h
+++ b/src/gui/RadioHealthDialog.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "PersistentDialog.h"
+
+class QLabel;
+class QTableWidget;
+class QTimer;
+
+namespace AetherSDR {
+
+class RadioModel;
+
+// Live view of the connected radio's health/status registers.
+//
+// The values come from IRadioBackend::healthSnapshot(), so the dialog knows
+// nothing about any particular radio family: the backend decides which
+// registers exist, what they are called and how they group. A family that
+// reports none gets an explanatory message instead of an empty table, because
+// "this radio does not report health registers" and "every register reads zero"
+// are completely different situations and the operator has to be able to tell
+// them apart.
+//
+// This is a DIAGNOSTIC read-out, not a control surface — nothing here writes to
+// the radio. The one thing it must never do is invent a value: a register the
+// radio has not reported shows a dash.
+class RadioHealthDialog : public PersistentDialog {
+    Q_OBJECT
+
+public:
+    explicit RadioHealthDialog(RadioModel* model, QWidget* parent = nullptr);
+
+private:
+    void refresh();
+    void copyToClipboard();
+    // Format one snapshot value for display. Booleans become Yes/No rather
+    // than true/false, and an invalid variant becomes an em dash.
+    static QString formatValue(const QVariant& v);
+
+    RadioModel* m_model{nullptr};
+    QTableWidget* m_table{nullptr};
+    QLabel* m_statusLabel{nullptr};
+    QTimer* m_refreshTimer{nullptr};
+    // The row layout is rebuilt only when the KEY SET changes, not on every
+    // tick: rebuilding a QTableWidget every refresh would drop the operator's
+    // selection and scroll position twice a second while they were reading it.
+    QStringList m_currentKeys;
+};
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -452,12 +452,14 @@ void SpectrumOverlayMenu::buildBandPanel()
                     hideAllSubPanels();
                     emit bandSelected(bandName, freq, mode);
                 });
+                m_bandBtnFreqs.append({btn, freq});
             }
 
             grid->addWidget(btn, row, col);
         }
     }
 
+    applyTuningRangeToBandButtons();
     m_bandPanel->adjustSize();
 }
 
@@ -2530,6 +2532,10 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
     for (auto* btn : m_xvtrBandBtns)
         btn->deleteLater();
     m_xvtrBandBtns.clear();
+    // The whole band panel is destroyed and rebuilt below, so every pointer in
+    // here is about to dangle. Cleared HERE rather than after the rebuild,
+    // because deleteLater() on the panel takes its children with it.
+    m_bandBtnFreqs.clear();
 
     // Rebuild the main band panel to insert XVTR bands between
     // HF bands and utility buttons (WWV/GEN/2200/630/XVTR). (#571)
@@ -2583,6 +2589,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             hideAllSubPanels();
             emit bandSelected(bandName, freq, mode);
         });
+        m_bandBtnFreqs.append({btn, freq});
         return btn;
     };
 
@@ -2611,6 +2618,7 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
                 hideAllSubPanels();
                 emit bandSelected(bandName, freq, mode);
             });
+            m_bandBtnFreqs.append({btn, freq});
             grid->addWidget(btn, row, col % 3);
             if (++col % 3 == 0)
                 ++row;
@@ -2782,6 +2790,43 @@ void SpectrumOverlayMenu::setXvtrBands(const QVector<XvtrBand>& bands)
             m_bandPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
         m_wheelGuard->guardTree(
             m_xvtrPanel, SpectrumOverlayWheelGuard::BoundaryMode::Consume);
+    }
+    // The panel was rebuilt from scratch, so the range gate has to be
+    // re-applied — it is a property of the radio, not of the buttons.
+    applyTuningRangeToBandButtons();
+}
+
+void SpectrumOverlayMenu::setTuningRangeMhz(double minMhz, double maxMhz)
+{
+    if (qFuzzyCompare(m_tuningMinMhz, minMhz) && qFuzzyCompare(m_tuningMaxMhz, maxMhz))
+        return;
+    m_tuningMinMhz = minMhz;
+    m_tuningMaxMhz = maxMhz;
+    applyTuningRangeToBandButtons();
+}
+
+void SpectrumOverlayMenu::applyTuningRangeToBandButtons()
+{
+    // "Not reported" is max <= min, which covers both the (0,0) disconnected
+    // case and any backend that never sets a range. Everything stays enabled,
+    // so this is a no-op for Flex.
+    const bool constrained = m_tuningMaxMhz > m_tuningMinMhz;
+    for (auto it = m_bandBtnFreqs.begin(); it != m_bandBtnFreqs.end(); ) {
+        QPushButton* btn = it->first;
+        if (!btn) {                       // destroyed out from under us
+            it = m_bandBtnFreqs.erase(it);
+            continue;
+        }
+        const double freq = it->second;
+        const bool reachable = !constrained
+                            || (freq >= m_tuningMinMhz && freq <= m_tuningMaxMhz);
+        btn->setEnabled(reachable);
+        btn->setToolTip(reachable
+            ? QString()
+            : tr("Outside this radio's tuning range (%1–%2 MHz)")
+                  .arg(m_tuningMinMhz, 0, 'f', 3)
+                  .arg(m_tuningMaxMhz, 0, 'f', 3));
+        ++it;
     }
 }
 

--- a/src/gui/SpectrumOverlayMenu.h
+++ b/src/gui/SpectrumOverlayMenu.h
@@ -98,6 +98,13 @@ public:
     // VHF row will disappear.  Triggers a band-panel rebuild. (#695)
     void setRadioCapabilities(ModelCapabilities caps);
 
+    // The tuning range the connected backend reports (MHz). Band buttons whose
+    // target frequency falls outside it are disabled and say why, so a
+    // direct-sampling HF receiver stops offering 6 m as though it were a band
+    // it could reach. Pass (0, 0) for "not reported" — every button is enabled,
+    // which is the pre-existing behaviour and what a Flex gets.
+    void setTuningRangeMhz(double minMhz, double maxMhz);
+
     // Bands the radio itself declared (optional "bands=" discovery/status
     // key, names from BandDefs).  Non-empty: the band grid is built from
     // this list instead of the HF layout + model capability flags, so a
@@ -251,6 +258,18 @@ private:
     QWidget* m_xvtrPanel{nullptr};
     bool m_xvtrPanelVisible{false};
     QVector<QPushButton*> m_xvtrBandBtns;
+
+    // Every band button in the main band panel paired with the frequency it
+    // tunes to, so the tuning-range gate can be re-applied after any rebuild
+    // without the two builders each having to know about it.
+    //
+    // QPointer, not a raw pointer: the band panel is destroyed with
+    // deleteLater() on every rebuild, so entries can outlive their buttons by a
+    // full event-loop turn if a range update lands in that window.
+    QVector<QPair<QPointer<QPushButton>, double>> m_bandBtnFreqs;
+    double m_tuningMinMhz{0.0};
+    double m_tuningMaxMhz{0.0};
+    void applyTuningRangeToBandButtons();
 
     // Cached state for band-panel rebuilds — setXvtrBands() and
     // setRadioCapabilities() each store their argument and trigger

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -491,8 +491,40 @@ void TxApplet::setTransmitModel(TransmitModel* model)
         m_updatingFromModel = false;
     });
 
+    // Whether this radio has an ATU at all. A Hermes-Lite 2 does not, and a
+    // live-looking ATU button on a radio with no tuner is worse than a missing
+    // one: pressing it KEYS THE TRANSMITTER (markTxKeying above) to run a tune
+    // cycle that nothing will answer.
+    connect(m_model, &TransmitModel::hasTunerChanged, this, [this](bool present) {
+        m_radioHasTuner = present;
+        updateAtuAvailability();
+    });
+    m_radioHasTuner = m_model->hasTuner();
+
     syncFromModel();
     syncAtuIndicators();
+    updateAtuAvailability();
+}
+
+void TxApplet::updateAtuAvailability()
+{
+    if (!m_atuBtn || !m_memBtn)
+        return;
+    const bool enabled = m_radioHasTuner && !m_tgxlOperate;
+    m_atuBtn->setEnabled(enabled);
+    m_memBtn->setEnabled(enabled);
+
+    // The radio-has-no-tuner reason is checked FIRST because it is the more
+    // fundamental one: with no ATU fitted, what the TGXL is doing is beside the
+    // point, and "Disabled — TGXL is in OPERATE mode" would send the operator
+    // looking at the wrong box.
+    QString tip;
+    if (!m_radioHasTuner)
+        tip = tr("This radio has no antenna tuner");
+    else if (m_tgxlOperate)
+        tip = tr("Disabled — TGXL is in OPERATE mode");
+    m_atuBtn->setToolTip(tip);
+    m_memBtn->setToolTip(tip);
 }
 
 void TxApplet::setTunerModel(TunerModel* tuner)
@@ -503,12 +535,8 @@ void TxApplet::setTunerModel(TunerModel* tuner)
         // When TGXL is in Operate, disable only the internal ATU controls.
         // TUNE stays enabled — it sends a carrier through the TGXL for
         // power/SWR checks, matching SmartSDR behavior (#443).
-        bool tgxlOperate = tuner->isPresent() && tuner->isOperate() && !tuner->isBypass();
-        m_atuBtn->setEnabled(!tgxlOperate);
-        m_memBtn->setEnabled(!tgxlOperate);
-        QString tip = tgxlOperate ? "Disabled — TGXL is in OPERATE mode" : "";
-        m_atuBtn->setToolTip(tip);
-        m_memBtn->setToolTip(tip);
+        m_tgxlOperate = tuner->isPresent() && tuner->isOperate() && !tuner->isBypass();
+        updateAtuAvailability();
     };
 
     connect(tuner, &TunerModel::stateChanged, this, updateButtons);

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -58,6 +58,14 @@ private:
     void buildUI();
     void syncFromModel();
     void syncAtuIndicators();
+    // Single owner of the ATU/MEM enabled state.
+    //
+    // Two independent reasons exist to grey these out — the radio has no tuner
+    // at all, and a TunerGenius XL is in Operate — and they arrive from
+    // different models at different times. Before this they each called
+    // setEnabled() directly, so whichever fired last won and a TGXL state change
+    // could re-enable an ATU button on a radio that has no ATU.
+    void updateAtuAvailability();
     // Right-click menu on the ATU button — exposes Pre-tune Bands and
     // Clear ATU Memories. Pre-tune is grayed when MEM is off. (#2624)
     void showAtuContextMenu(const QPoint& pos);
@@ -80,6 +88,12 @@ private:
     // current TX frequency still matches the freq we tuned at.  Any freq
     // change between clicks falls back to "atu start". (#1993)
     double m_atuTunedFreqMhz{-1.0};
+
+    // Inputs to updateAtuAvailability(). Both default to the permissive value
+    // so an applet built before either model has reported looks exactly as it
+    // did before this gate existed.
+    bool m_radioHasTuner{true};
+    bool m_tgxlOperate{false};
 
     // Gauges (HGauge*)
     QWidget* m_fwdGauge{nullptr};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,8 @@
 #include "MacStartupAbortGuard.h"
 #endif
 
+#include "core/backends/hl2/Hl2EmergencyStop.h"
+
 #include <QApplication>
 #include <QSurfaceFormat>
 #include <memory>
@@ -207,6 +209,20 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 #endif
+
+    // Release the Hermes-Lite 2 if this process is killed or crashes.
+    //
+    // A signal tears down nothing — Hl2Backend's destructor never runs — and an
+    // HL2 that is never told to stop keeps streaming at a host that is gone,
+    // then stops answering discovery until it is physically power-cycled.
+    // Reproduced three times with a plain `kill` on a connected session.
+    //
+    // Installed HERE, after the macOS startup guard has restored SIGABRT: doing
+    // it earlier would have the guard overwrite the handler for that signal.
+    // No-op until a radio is actually connected, so it costs a disconnected run
+    // nothing. See Hl2EmergencyStop.h for why it acts inside the handler rather
+    // than deferring to the event loop.
+    AetherSDR::hl2::installEmergencyStopSignalHandlers();
 
     app.setApplicationName("AetherSDR");
     app.setApplicationVersion(AETHERSDR_VERSION);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -584,6 +584,12 @@ void RadioModel::setupBackend(const QString& family)
             [this](const QString& panId, int gain) {
         if (auto* pan = resolvePan(panId)) pan->setRfGain(gain);
     });
+    connect(m_backend.get(), &IRadioBackend::panRfGainInfoChanged, this,
+            [this](const QString& panId, int low, int high, int step) {
+        if (step <= 0)
+            return;                       // a zero step would freeze the slider
+        if (auto* pan = resolvePan(panId)) pan->setRfGainInfo(low, high, step);
+    });
     connect(m_backend.get(), &IRadioBackend::panRxAntennaChanged, this,
             [this](const QString& panId, const QString& ant) {
         if (auto* pan = resolvePan(panId)) pan->setRxAntenna(ant);
@@ -652,6 +658,14 @@ void RadioModel::setupBackend(const QString& family)
         const RadioCapabilities caps = backendCapabilities();
         m_transmitModel.setHostModulation(connected
                                           && caps.hostModulates && caps.canTransmit);
+        // Whether an antenna tuner exists at all. Same shape and the same
+        // reason: the capability is the backend's to report, and the widgets
+        // that need it only see the model.
+        //
+        // Restored to TRUE on disconnect rather than left false — with no radio
+        // connected there is nothing to be honest ABOUT, and leaving the ATU
+        // greyed out after unplugging an HL2 would look like a fault.
+        m_transmitModel.setHasTuner(!connected || caps.hasTuner);
     });
 
     // Keying and tune from the GUI.
@@ -2599,6 +2613,12 @@ RadioCapabilities RadioModel::backendCapabilities() const
     return m_backend ? m_backend->capabilities() : RadioCapabilities{};
 }
 
+IRadioBackend::HealthSnapshot RadioModel::backendHealthSnapshot() const
+{
+    return m_backend ? m_backend->healthSnapshot()
+                     : IRadioBackend::HealthSnapshot{};
+}
+
 // Shared key-on guard for the paths that do NOT go through setTransmit().
 //
 // setTransmit() refuses a key on a backend reporting canTransmit=false before
@@ -3875,9 +3895,21 @@ void RadioModel::setPanWnbLevel(int level)
 
 void RadioModel::setPanRfGain(int gain)
 {
-    if (m_activePanId.isEmpty()) return;
-    sendCmd(
-        QString("display pan set %1 rfgain=%2").arg(m_activePanId).arg(gain));
+    setPanRfGainFor(m_activePanId, gain);
+}
+
+void RadioModel::setPanRfGainFor(const QString& panId, int gain)
+{
+    if (panId.isEmpty()) return;
+    // A backend that owns its gain in a hardware register cannot be driven with
+    // Flex wire text — the same reason center/bandwidth route through the seam.
+    // Without this the HL2's RF Gain slider moved, persisted, and changed
+    // nothing: lnaGainDb was applied once at connect and never again.
+    if (!m_flexBackend && m_backend) {
+        m_backend->setPanRfGain(panId, gain);
+        return;
+    }
+    sendCmd(QString("display pan set %1 rfgain=%2").arg(panId).arg(gain));
 }
 
 // ── Display controls — FFT ─────────────────────────────────────────────────

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -6,6 +6,7 @@
 #include "core/backends/ProfileDelta.h" // applyProfileChanges payload (aetherd 2.3)
 #include "core/backends/RadioDelta.h"   // applyRadioChanges payload (aetherd 2.3)
 #include "core/backends/RadioCapabilities.h" // backendCapabilities() return type
+#include "core/backends/IRadioBackend.h"     // backendHealthSnapshot() return type
 #include "core/RadioConnection.h"
 #include "core/WanConnection.h"
 #include "core/PanadapterStream.h"
@@ -209,6 +210,12 @@ public:
     // e.g. TX capability and reboot support, which differ by radio family (#4448).
     // Non-inline: IRadioBackend is only forward-declared here.
     RadioCapabilities backendCapabilities() const;
+
+    // The connected backend's health/status registers, for the Radio Health
+    // dialog. Empty when no backend is connected or the family reports none —
+    // which the dialog renders as "this radio reports no health registers"
+    // rather than as an empty table.
+    IRadioBackend::HealthSnapshot backendHealthSnapshot() const;
 
     // Bands the radio itself declared via the optional discovery/status
     // key "bands=2m,440,23cm" (names validated against BandDefs).  Empty
@@ -593,6 +600,10 @@ public:
     void setPanWnb(bool on);
     void setPanWnbLevel(int level);
     void setPanRfGain(int gain);
+    // Same, addressed at a specific pan rather than the active one. The overlay
+    // menu belongs to one panadapter and must drive that one, not whichever
+    // happens to be active when the slider moves.
+    void setPanRfGainFor(const QString& panId, int gain);
 
     // Display controls — FFT (display pan set)
     void setPanAverage(int frames);

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -255,6 +255,14 @@ void TransmitModel::setHostModulation(bool on)
     emit hostModulationChanged(on);
 }
 
+void TransmitModel::setHasTuner(bool present)
+{
+    if (m_hasTuner == present)
+        return;
+    m_hasTuner = present;
+    emit hasTunerChanged(present);
+}
+
 void TransmitModel::setRfPower(int power)
 {
     power = qBound(0, power, 100);

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -182,6 +182,17 @@ public:
     // the operator to select an input that silently transmits nothing.
     void setHostModulation(bool on);
     [[nodiscard]] bool hostModulation() const { return m_hostModulation; }
+
+    // Whether the connected radio has an antenna tuner at all
+    // (RadioCapabilities::hasTuner), pushed down by RadioModel on connect for
+    // the same reason hostModulation is: the capability lives on the backend and
+    // the widgets that need it only see this model.
+    //
+    // Defaults TRUE so nothing changes for a Flex, and so a widget that reads it
+    // before any backend has reported stays in the pre-existing state rather
+    // than briefly greying out a control that does exist.
+    void setHasTuner(bool present);
+    [[nodiscard]] bool hasTuner() const { return m_hasTuner; }
     void setTunePower(int power);
     void setTuneMode(const QString& mode);
     void startTune(PttSource source = PttSource::Tune);
@@ -274,6 +285,7 @@ signals:
     void moxCommandIssued(bool on);
     void tuneCommandIssued(bool on);
     void hostModulationChanged(bool on);
+    void hasTunerChanged(bool present);
     void tuneChanged(bool tuning);
     void moxChanged(bool mox);
     // Fires whenever m_transmitting changes — from setMox() (optimistic edge)
@@ -338,6 +350,7 @@ private:
     // Transmit state
     int    m_rfPower{100};
     bool   m_hostModulation{false};
+    bool   m_hasTuner{true};
     int    m_tunePower{10};
     bool   m_tune{false};
     bool   m_mox{false};

--- a/tests/hl2_live_band_filter_probe.cpp
+++ b/tests/hl2_live_band_filter_probe.cpp
@@ -1,0 +1,260 @@
+// LIVE hardware probe — NOT part of ctest. Requires a real Hermes-Lite 2.
+//
+//   ./hl2_live_band_filter_probe <ip>
+//
+// Why this exists: the J16 filter byte rides the CONFIG register (0x00), the
+// same register that carries the DDC sample rate and the receiver count. That
+// makes it the one change in this work that can break receive outright — a
+// misplaced bit lands in [25:24] (sample rate) or [6:3] (receiver count), and
+// the failure mode is a radio that still streams, still looks framed, and
+// delivers samples at the wrong rate or from an unassigned receiver.
+//
+// The unit test proves the ENCODER puts the bits where the register map says.
+// It cannot prove the radio agrees, because it shares our reading of the map.
+// This asks the hardware: with each band filter selected in turn, does EP6
+// still arrive, at the expected packet rate, carrying non-trivial IQ?
+//
+// Sample rate is the independent check. It is not derived from anything we
+// send back to ourselves: EP6 packets carry 126 samples each, so 48 kHz means
+// 381 packets/second and 96 kHz means 762. If a filter bit leaked into
+// DATA[25:24] the measured packet rate would move, and no amount of agreeing
+// with ourselves about the register map would hide it.
+
+#include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QHostAddress>
+#include <QTimer>
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using namespace AetherSDR::hl2;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool ok, const QString& what)
+{
+    std::printf("%s  %s\n", ok ? "PASS" : "FAIL", qPrintable(what));
+    if (!ok)
+        ++g_failures;
+}
+
+struct Observation {
+    int    packets = 0;
+    double rms = 0.0;
+    Hl2Telemetry telemetry;
+};
+
+// Watch the stream for windowMs and report what arrived.
+Observation observe(MetisClient& c, int windowMs)
+{
+    Observation o;
+    double sumSq = 0.0;
+    std::size_t n = 0;
+    auto blockConn = QObject::connect(&c, &MetisClient::iqBlockReady,
+        [&](const std::vector<std::complex<float>>& block) {
+            ++o.packets;
+            for (const auto& s : block) {
+                sumSq += static_cast<double>(std::norm(s));
+                ++n;
+            }
+        });
+    auto telConn = QObject::connect(&c, &MetisClient::telemetryUpdated,
+        [&](const Hl2Telemetry& t) { o.telemetry = t; });
+
+    QEventLoop loop;
+    QTimer::singleShot(windowMs, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    QObject::disconnect(blockConn);
+    QObject::disconnect(telConn);
+    o.rms = n ? std::sqrt(sumSq / static_cast<double>(n)) : 0.0;
+    return o;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    const QString host = argc > 1 ? QString::fromLatin1(argv[1])
+                                  : QStringLiteral("192.168.1.21");
+
+    MetisClient client;
+    MetisClient::Params p;
+    p.host = QHostAddress(host);
+    p.sampleRate = SampleRate::R48k;
+    p.rxFrequencyHz = 10'000'000;      // WWV — a signal that is reliably there
+    p.lnaGainDb = 20;
+    p.ocFilterByte = ocFilterByteForHz(10'000'000);
+
+    std::printf("connecting to %s ...\n", qPrintable(host));
+    if (!client.start(p)) {
+        std::fprintf(stderr, "FATAL: could not open the UDP socket\n");
+        return 2;
+    }
+
+    // Let the link come up before measuring anything.
+    {
+        QEventLoop loop;
+        QTimer::singleShot(1500, &loop, &QEventLoop::quit);
+        loop.exec();
+    }
+    if (!client.isRunning()) {
+        std::fprintf(stderr, "FATAL: client stopped — radio unreachable or in use\n");
+        return 2;
+    }
+
+    // Sweep every filter selection the band map can produce, at the frequency
+    // that selects it. Each one rewrites the config register.
+    struct Step { double mhz; const char* label; };
+    const Step steps[] = {
+        {  1.900, "160m" }, {  3.800, "80m"  }, {  7.200, "40m"  },
+        { 10.000, "30m"  }, { 14.225, "20m"  }, { 18.130, "17m"  },
+        { 24.950, "12m"  }, { 28.400, "10m"  }, {  0.600, "AM BC (no filter)" },
+    };
+
+    // 126 samples per EP6 packet at 48 kHz => 381/s. Allow generous slack: this
+    // is a check that the rate did not CHANGE, not a jitter measurement.
+    constexpr double kExpectedPacketsPerSec = 48000.0 / 126.0;
+    constexpr int kWindowMs = 1200;
+
+    for (const Step& s : steps) {
+        const auto oc = ocFilterByteForHz(s.mhz * 1.0e6);
+        client.setRxFrequencyHz(static_cast<std::uint32_t>(s.mhz * 1.0e6));
+        client.setBandFilter(static_cast<int>(oc));
+
+        const Observation o = observe(client, kWindowMs);
+        const double rate = o.packets * 1000.0 / kWindowMs;
+        const double ratio = rate / kExpectedPacketsPerSec;
+
+        std::printf("  %-18s %.3f MHz  oc=0x%02X (%-20s) "
+                    "%4d pkt  %6.1f pkt/s  rms=%.2e\n",
+                    s.label, s.mhz, oc, ocFilterName(oc), o.packets, rate, o.rms);
+
+        check(o.packets > 0,
+              QStringLiteral("%1: stream still running after filter write").arg(s.label));
+        // The load-bearing assertion. A filter bit that leaked into the sample
+        // rate field would halve or double this.
+        check(ratio > 0.85 && ratio < 1.15,
+              QStringLiteral("%1: EP6 packet rate unchanged (%2x expected)")
+                  .arg(s.label).arg(ratio, 0, 'f', 3));
+        // A receiver-count bit landing in [6:3] leaves the DDC unassigned and
+        // the payload becomes exactly zero — framed, paced, and silent.
+        check(o.rms > 0.0,
+              QStringLiteral("%1: IQ is not all-zero (receiver still assigned)")
+                  .arg(s.label));
+    }
+
+    // ---- Does the filter board actually exist? ----
+    //
+    // Everything above proves we did not BREAK the config register. It cannot
+    // prove a relay moved, because the gateware forwards this byte to I2C and
+    // nothing answers — there is no readback anywhere in the protocol.
+    //
+    // So ask physics instead. Park on the AM broadcast band, where there is a
+    // large signal by definition, and A/B the AM-blocking high-pass. With an
+    // N2ADR board fitted, engaging it has to crush that signal by tens of dB.
+    // With no board, the write is inert and the two readings are identical.
+    //
+    // This is the only measurement here that is outside our own convention: it
+    // does not ask whether the radio agreed with our register map, it asks
+    // whether the antenna path changed.
+    {
+        client.setRxFrequencyHz(600'000);
+        client.setBandFilter(static_cast<int>(kOcNone));
+        const double bypassed = observe(client, 1500).rms;
+        client.setBandFilter(static_cast<int>(kOcHpfAmBc));
+        const double filtered = observe(client, 1500).rms;
+        client.setBandFilter(static_cast<int>(kOcNone));
+
+        const double ratioDb = (bypassed > 0.0 && filtered > 0.0)
+            ? 20.0 * std::log10(filtered / bypassed) : 0.0;
+        std::printf("\n  AM BC 0.600 MHz: bypassed rms=%.3e  HPF-in rms=%.3e  "
+                    "delta=%.1f dB\n", bypassed, filtered, ratioDb);
+        if (ratioDb < -6.0) {
+            std::printf("  -> companion filter board IS present and switching "
+                        "(HPF attenuated the AM band)\n");
+        } else {
+            std::printf("  -> NO measurable change. Either no companion filter "
+                        "board is fitted (the writes are inert, which is safe "
+                        "and expected on a bare HL2) or the band is quiet. This "
+                        "is NOT a failure — it is the limit of what can be "
+                        "observed without one.\n");
+        }
+    }
+
+    // ---- Does a LIVE LNA gain change reach the hardware? ----
+    //
+    // Same question as the filter, same kind of answer. lnaGainDb used to be
+    // applied once at connect and never again, so the RF Gain slider had
+    // nothing behind it. The fix routes it through MetisClient::setLnaGainDb at
+    // any time — and the way to know that took is that the noise floor moves by
+    // the amount we asked for.
+    //
+    // 20 dB apart, measured on the raw wire before any of our DSP or dB
+    // referencing runs, so nothing in our own gain accounting can flatter the
+    // result. Tolerance is wide: the AD9866's step is not exactly 1.000 dB and
+    // an off-air noise floor is not stationary. What is being tested is that
+    // the register moved AT ALL and in the right DIRECTION, not its linearity.
+    {
+        client.setRxFrequencyHz(10'000'000);
+        client.setBandFilter(static_cast<int>(ocFilterByteForHz(10'000'000)));
+        client.setLnaGainDb(10);
+        const double lowGain = observe(client, 1500).rms;
+        client.setLnaGainDb(30);
+        const double highGain = observe(client, 1500).rms;
+        client.setLnaGainDb(20);       // back to the default we came up on
+
+        const double deltaDb = (lowGain > 0.0 && highGain > 0.0)
+            ? 20.0 * std::log10(highGain / lowGain) : 0.0;
+        std::printf("\n  LNA gain 10 dB -> 30 dB: rms %.3e -> %.3e  "
+                    "measured delta=%.1f dB (commanded 20 dB)\n",
+                    lowGain, highGain, deltaDb);
+        check(deltaDb > 10.0,
+              QStringLiteral("live LNA gain change reaches the AD9866 "
+                             "(measured %1 dB for a commanded 20 dB)")
+                  .arg(deltaDb, 0, 'f', 1));
+    }
+
+    // Telemetry the Radio Health dialog renders, read back from the real radio.
+    {
+        const Observation o = observe(client, 1000);
+        const Hl2Telemetry& t = o.telemetry;
+        std::printf("\n  telemetry: fw=%s adcOvl=%s txInh=%s fifo=%s tempRaw=%s "
+                    "fwd=%s rev=%s bias=%s\n",
+                    t.firmwareVersion ? qPrintable(QString::number(*t.firmwareVersion)) : "-",
+                    t.adcOverload ? (*t.adcOverload ? "yes" : "no") : "-",
+                    t.txInhibited ? (*t.txInhibited ? "yes" : "no") : "-",
+                    t.txFifoCount ? qPrintable(QString::number(*t.txFifoCount)) : "-",
+                    t.temperatureRaw ? qPrintable(QString::number(*t.temperatureRaw)) : "-",
+                    t.forwardPowerRaw ? qPrintable(QString::number(*t.forwardPowerRaw)) : "-",
+                    t.reversePowerRaw ? qPrintable(QString::number(*t.reversePowerRaw)) : "-",
+                    t.biasCurrentRaw ? qPrintable(QString::number(*t.biasCurrentRaw)) : "-");
+        check(t.firmwareVersion.has_value(),
+              QStringLiteral("firmware version reported (Radio Health)"));
+        check(t.temperatureRaw.has_value(),
+              QStringLiteral("temperature reported (Radio Health)"));
+        // Sanity, not calibration: the AD9866 die sits somewhere between a cold
+        // room and its thermal limit. A raw count that scales outside this is a
+        // decode error, not a hot radio.
+        if (t.temperatureRaw) {
+            const double c = (3.26 * (*t.temperatureRaw / 4096.0) - 0.5) / 0.01;
+            std::printf("  decoded temperature: %.1f C\n", c);
+            check(c > 0.0 && c < 100.0,
+                  QStringLiteral("decoded temperature is physically plausible"));
+        }
+    }
+
+    client.stop();
+    std::printf("\n%s (%d failures)\n", g_failures ? "PROBE FAILED" : "PROBE PASSED",
+                g_failures);
+    return g_failures ? 1 : 0;
+}

--- a/tests/hl2_metis_protocol_test.cpp
+++ b/tests/hl2_metis_protocol_test.cpp
@@ -69,6 +69,74 @@ int main()
         check((c[0] & 0x01) == 0, "config C0 is even (MOX=0, cannot key)");
     }
 
+    // ---- J16 open-collector filter byte: DATA[23:17] == C2[7:1] ----
+    //
+    // The SHIFT is the whole point. DATA[16] is not part of the field, so an
+    // unshifted byte would put every selection one relay too low — 80 m would
+    // engage the 160 m filter. Asserted on the encoder, not inferred.
+    {
+        const Cc c = ccConfig(SampleRate::R48k, 1, kOcLpf160);
+        check(c[2] == 0x02, "oc 0x01 (160m) lands in C2 bit 1, not bit 0");
+        check(ccConfig(SampleRate::R48k, 1, kOcHpfAmBc | kOcLpf12_10)[2] == 0xC0,
+              "oc 0x60 (HPF|12/10m) -> C2 0xC0");
+        // Bit 7 is the RX-antenna bit and lives at DATA[13], not in this field.
+        // Passing a full I2C byte must not shift it into DATA[24] (the sample
+        // rate's low bit lives at [24] — this would change the DDC rate).
+        check(ccConfig(SampleRate::R48k, 1, 0xFF)[2] == 0xFE,
+              "oc bit 7 masked off (it is the RX antenna bit, not a filter)");
+        check(ccConfig(SampleRate::R48k, 1, kOcNone)[2] == 0x00,
+              "oc none releases every relay");
+        // The filter byte must not disturb what shares this register.
+        check(c[1] == (0x40 | 0x00) && c[4] == 0x04,
+              "oc byte leaves sample rate and #RX untouched");
+    }
+
+    // ---- band -> filter selection ----
+    //
+    // Every value below is Quisk's Hermes_BandDict for that band
+    // (quisk_conf_defaults.py), which is the reference client's own table for
+    // the N2ADR companion board. Checking against it is what makes the
+    // frequency RANGES in ocFilterByteForHz() verifiable rather than plausible:
+    // the ranges are ours, the answers are not.
+    {
+        struct { double mhz; std::uint8_t oc; const char* what; } cases[] = {
+            {  1.900, 0b0000001, "160m -> 160 LPF, HPF out" },
+            {  3.800, 0b1000010, "80m  -> HPF + 80 LPF" },
+            {  5.357, 0b1000100, "60m  -> HPF + 60/40 LPF" },
+            {  7.200, 0b1000100, "40m  -> HPF + 60/40 LPF" },
+            { 10.125, 0b1001000, "30m  -> HPF + 30/20 LPF" },
+            { 14.225, 0b1001000, "20m  -> HPF + 30/20 LPF" },
+            { 18.130, 0b1010000, "17m  -> HPF + 17/15 LPF" },
+            { 21.300, 0b1010000, "15m  -> HPF + 17/15 LPF" },
+            { 24.950, 0b1100000, "12m  -> HPF + 12/10 LPF" },
+            { 28.400, 0b1100000, "10m  -> HPF + 12/10 LPF" },
+        };
+        for (const auto& c : cases)
+            check(ocFilterByteForHz(c.mhz * 1.0e6) == c.oc, c.what);
+
+        // Band EDGES, not just the button's default frequency: a range boundary
+        // that fell inside a band would filter one end of it correctly and the
+        // other end through the neighbouring low-pass.
+        check(ocFilterByteForHz(1.800e6) == ocFilterByteForHz(2.000e6),
+              "160m band edges share one filter");
+        check(ocFilterByteForHz(3.500e6) == ocFilterByteForHz(4.000e6),
+              "80m band edges share one filter");
+        check(ocFilterByteForHz(7.000e6) == ocFilterByteForHz(7.300e6),
+              "40m band edges share one filter");
+        check(ocFilterByteForHz(14.000e6) == ocFilterByteForHz(14.350e6),
+              "20m band edges share one filter");
+        check(ocFilterByteForHz(28.000e6) == ocFilterByteForHz(29.700e6),
+              "10m band edges share one filter");
+
+        // Outside the board's coverage nothing is engaged — a low-pass chosen
+        // for a band that is not there would only attenuate.
+        check(ocFilterByteForHz(0.600e6) == kOcNone,
+              "AM broadcast: no filter, and specifically not the AM-blocking HPF");
+        check(ocFilterByteForHz(50.150e6) == kOcNone, "6m: no filter fitted");
+        // Never the RX-antenna bit, whatever the frequency.
+        check((ocFilterByteForHz(14.2e6) & 0x80) == 0, "filter byte never sets bit 7");
+    }
+
     // ---- RX1 NCO frequency: 32-bit big-endian ----
     {
         const Cc f = ccRx1Freq(10'000'000);               // 0x00989680

--- a/tests/hl2_signal_stop_child.cpp
+++ b/tests/hl2_signal_stop_child.cpp
@@ -1,0 +1,62 @@
+// Child process for hl2_signal_stop_test.py — not useful on its own.
+//
+//   ./hl2_signal_stop_child <port>
+//
+// Starts a real MetisClient against a fake radio on 127.0.0.1:<port>, prints
+// "READY", then blocks. The parent kills it and checks that a metis-stop
+// datagram arrived.
+//
+// The point is that this exercises the SHIPPING path: the same
+// installEmergencyStopSignalHandlers() main() calls, the same arm() inside
+// MetisClient::start(), and a real signal delivered by a real kill(2). A unit
+// test that called fireEmergencyStop() directly would prove only that sendto()
+// works — it would not prove the handler is installed, that arming happened, or
+// that the descriptor is still valid at the moment the process dies.
+
+#include "core/backends/hl2/Hl2EmergencyStop.h"
+#include "core/backends/hl2/MetisClient.h"
+#include "core/backends/hl2/MetisProtocol.h"
+
+#include <QCoreApplication>
+#include <QHostAddress>
+
+#include <cstdio>
+#include <string>
+#include <cstdlib>
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: hl2_signal_stop_child <port>\n");
+        return 2;
+    }
+    const quint16 port = static_cast<quint16>(std::atoi(argv[1]));
+
+    // --no-handlers reproduces the ORIGINAL bug on purpose, so the driver can
+    // assert that no stop arrives without it. Without this negative control the
+    // test would still pass if the handler were never installed and something
+    // else happened to emit a stop on the way out — and a test that cannot fail
+    // for the right reason is not evidence.
+    bool installHandlers = true;
+    for (int i = 2; i < argc; ++i) {
+        if (std::string(argv[i]) == "--no-handlers")
+            installHandlers = false;
+    }
+    if (installHandlers)
+        AetherSDR::hl2::installEmergencyStopSignalHandlers();
+
+    AetherSDR::hl2::MetisClient client;
+    AetherSDR::hl2::MetisClient::Params p;
+    p.host = QHostAddress(QStringLiteral("127.0.0.1"));
+    p.port = port;
+    p.rxFrequencyHz = 14'200'000;
+    if (!client.start(p)) {
+        std::fprintf(stderr, "child: could not start MetisClient\n");
+        return 2;
+    }
+
+    std::printf("READY\n");
+    std::fflush(stdout);
+    return app.exec();   // the parent kills us out of here
+}

--- a/tests/hl2_signal_stop_test.py
+++ b/tests/hl2_signal_stop_test.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""A killed AetherSDR must still release the Hermes-Lite 2.
+
+An HL2 that is never told to stop keeps streaming at a host that is gone and
+then stops answering discovery until it is physically power-cycled. Qt tears
+nothing down on a signal, so Hl2Backend's destructor -- which does send the stop
+-- never runs.
+
+This stands in as the fake radio: bind a UDP socket, run a real MetisClient
+against it, kill that process, and require a metis-stop datagram to arrive.
+
+Deliberately an end-to-end process test rather than a unit test. Calling
+fireEmergencyStop() directly would prove sendto() works; it would not prove the
+handler is installed, that MetisClient armed it, or that the descriptor is still
+usable at the moment the process dies -- which are the three things that can
+actually be wrong.
+
+Usage: hl2_signal_stop_test.py <path-to-hl2_signal_stop_child>
+"""
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+# EF FE 04 <cmd>, 64 bytes. cmd bit 0 clear == stop; bit 7 is watchdog_disable,
+# which MetisClient leaves clear (watchdog ENABLED) by default.
+STOP_PREFIX = bytes([0xEF, 0xFE, 0x04])
+START_CMD_BIT = 0x01
+
+failures = 0
+
+
+def check(ok, what):
+    global failures
+    print(("PASS  " if ok else "FAIL  ") + what)
+    if not ok:
+        failures += 1
+
+
+def drain(sock, seconds):
+    """Collect every datagram that arrives within `seconds`."""
+    out = []
+    deadline = time.monotonic() + seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return out
+        sock.settimeout(remaining)
+        try:
+            out.append(sock.recv(4096))
+        except socket.timeout:
+            return out
+
+
+def run_case(child, sig, extra_args=()):
+    """Kill the child with `sig`; return the datagrams seen afterwards."""
+    radio = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    radio.bind(("127.0.0.1", 0))
+    port = radio.getsockname()[1]
+
+    proc = subprocess.Popen([child, str(port), *extra_args],
+                            stdout=subprocess.PIPE)
+    try:
+        # Wait for the client to be streaming before killing it -- killing it
+        # mid-startup would test nothing.
+        line = proc.stdout.readline().decode().strip()
+        if line != "READY":
+            check(False, f"{sig}: child failed to start (got {line!r})")
+            return []
+        pre = drain(radio, 1.0)
+        check(any(d[:3] == STOP_PREFIX and (d[3] & START_CMD_BIT) for d in pre),
+              f"{signal.Signals(sig).name}: radio saw metis-START before the kill")
+
+        os.kill(proc.pid, sig)
+        proc.wait(timeout=10)
+        return drain(radio, 1.5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        radio.close()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: hl2_signal_stop_test.py <path-to-hl2_signal_stop_child>")
+        return 2
+    child = sys.argv[1]
+
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        name = signal.Signals(sig).name
+        after = run_case(child, sig)
+        stops = [d for d in after
+                 if d[:3] == STOP_PREFIX and not (d[3] & START_CMD_BIT)]
+        check(bool(stops),
+              f"{name}: radio received metis-STOP after the process was killed")
+        if stops:
+            check(len(stops[0]) == 64, f"{name}: stop datagram is 64 bytes")
+            # Watchdog must stay ENABLED (bit 7 clear). Disabling it here would
+            # tell the gateware to keep streaming forever at a host that is
+            # about to vanish -- the exact wedge this whole mechanism exists to
+            # prevent.
+            check(not (stops[0][3] & 0x80),
+                  f"{name}: stop leaves the gateware watchdog enabled")
+
+    # Negative control: the same kill with the handlers NOT installed must
+    # leave the radio un-stopped. This is what makes the passes above mean
+    # something -- it reproduces the original bug in the same harness.
+    after = run_case(child, signal.SIGTERM, ("--no-handlers",))
+    stops = [d for d in after
+             if d[:3] == STOP_PREFIX and not (d[3] & START_CMD_BIT)]
+    check(not stops,
+          "control: WITHOUT the handlers a killed process sends no stop "
+          "(i.e. this test can fail)")
+
+    print()
+    print("hl2_signal_stop_test: "
+          + ("all checks passed" if not failures else f"{failures} FAILURES"))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Seven quality-of-life items for the Hermes-Lite 2, plus a shutdown-safety fix found while testing them (second commit). Three of them share one root cause: **the GUI drove a Flex command plane this radio does not have**, so the widget moved, the setting persisted, and nothing reached the hardware.

## What changed

### 1. Band switching (Band sidebar)
The band buttons resolved a Flex band-stack key and sent `display pan set <pan> band=`. The HL2 has no band stack and no VFO to read back, so that reached nothing. `MainWindow` now branches on `usesFlexCommandPlane()`; for a non-Flex backend the app is authoritative and tunes the slice directly — mode first, then frequency, then pan centre.

`RadioCapabilities` gains `tuningMinHz`/`tuningMaxHz` so the grid can be honest. The HL2 reports 0.1–38.4 MHz (the AD9866's first Nyquist zone) and the 6 m button is **disabled with a tooltip** rather than tuning somewhere it cannot hear. Zero/zero means "not reported", so Flex is unaffected.

### 2. Companion filter board (J16 open collectors)
The HL2 has **no switchable filters of its own** — it has seven open-collector outputs at `0x00[23:17]` that the *gateware* forwards to I2C `0x20`. Setting the config bits IS the whole mechanism. Selection is derived from the slice frequency and auto-applies on connect (from the persisted frequency) and on every band crossing.

The one-hot mapping is **Quisk's `Hermes_BandDict` verbatim** — the grouping (60+40 share a filter, 17+15 share one) is a property of the N2ADR board, not something inferable from the band plan. Ours is the frequency *ranges*, and the unit test checks them by asserting every amateur band lands on Quisk's answer.

Two departures from "always engage the HPF": nothing below 1.6 MHz (it would remove exactly what is being listened to), and no HPF on 160 m (the HL2's switching supply couples spurs into those inductors — wiki `Options.md`).

Logged at **INFO** on a new `aether.hl2` category, not debug. There is no readback anywhere in the protocol, so that line is the only evidence of what the relays were told to do, and a support log has to already contain it.

### 3. RF gain → AD9866 LNA
`lnaGainDb` was connect-time only. `IRadioBackend::setPanRfGain` (default no-op, so Flex is untouched) carries the ANT panel's slider to the register at any time, and `panRfGainInfoChanged` reports the real geometry: **−12…+48 dB in 1 dB steps**, against the model's Flex-shaped −8…+32 in 8s, which had made two thirds of the available gain unreachable.

`Hl2DbReference` moves in the same call so the trace and S-meter do not slide when gain changes.

Two restore bugs fixed along the way:
- The persisted key is now **family-scoped**. A value last set on a Flex was restored onto the HL2 as an LNA gain the operator never chose for that radio (observed live — a Flex-era `16` was pushed at connect).
- The restore no longer writes a **default** at all. With nothing saved, the radio's own gain is the right answer. Seeding from the pan model does *not* fix it: the restore can run before the backend has published, so the model still reads 0 and the same 0 goes to the hardware. Caught by Radio Health showing "LNA gain 0 dB" on a fresh profile.

### 4. Forward / reverse power (uncalibrated)
Counts go through Quisk's `power_meter_std_calibrations['HL2FilterE3']` curve. That is a *reference* curve for an N2ADR rev E3 board, **not a calibration of this radio** — coupler, toroid and detector diode all vary. The meters are labelled `(uncalibrated)` in their own `MeterDef` descriptions, because the number itself looks exactly like a calibrated one. Raw counts are still logged; a per-unit calibration replaces the table and nothing else.

### 5. Radio Health dialog (Help menu, immediately before Slice Troubleshooting)
New `IRadioBackend::healthSnapshot()` — synchronous, because every value is already cached from unprompted telemetry, so there is no round-trip to await. Shows firmware, ADC overload, LNA gain, TX inhibit (decoded from the active-low bit), PTT/keyed/tune, TX FIFO depth and under/overflow, PA temperature and bias, directional counts and watts, SWR, the J16 filter byte **and its meaning**, tuning/DDC frequency, IQ rate and dropped EP6 packets.

A register the radio has not reported renders as a **dash, never as zero** — on a health readout that distinction is the whole point.

### 6. Meter pacing
WDSP handed us ~47 S-meter readings a second and every one crossed to the GUI thread. An EMA smooths *every* sample (so the published value represents the whole interval rather than one arbitrary instant) and a 100 ms gate decides how often one is published — dropping without smoothing would alias. 100 ms is the cadence `MetisClient` already paces telemetry at, and the attack/decay constants are `MeterModel`'s own Flex forward-power ballistics, reused so meters behave the same across families.

### 7. ATU button
`TxApplet` greys ATU and MEM when the backend reports `hasTuner=false`. A live ATU button on a radio with no tuner is worse than a missing one: **pressing it keys the transmitter**. `updateAtuAvailability()` is now the single owner of that enabled state — the radio-has-no-tuner and TGXL-in-Operate reasons arrive from different models, and whichever fired last used to win.

### 8. Killing the app no longer wedges the radio *(second commit)*
Found while testing the above: SIGTERM-ing AetherSDR mid-stream left the HL2 answering ping but **not** Metis discovery — needing a physical power cycle. Reproduced three times. `Hl2Backend`'s destructor does send `metis-stop`, but Qt tears nothing down on a signal, so the process just vanishes mid-stream. The gateware watchdog is documented as the anti-wedge mechanism for exactly this and did not recover it.

**Deliberately not a self-pipe.** The textbook Qt answer defers the work to the event loop — useless here, since an unresponsive event loop is a main reason anyone reaches for `kill`. The handler does the whole job itself, calling nothing but `sendto()` on an address resolved in advance: descriptor, sockaddr and the 64-byte datagram are all built by `MetisClient::start()` on a normal thread.

Termination signals only (`SIGTERM`/`SIGINT`/`SIGHUP`/`SIGQUIT`) — **not** the crash signals, which belong to the platform's crash reporting. `SIGKILL` still wedges it; nothing can change that.

An inherited `SIG_IGN` is left ignored. `nohup` works by ignoring `SIGHUP`, so installing a handler over it turns a neutralised signal fatal — caught in testing when a `nohup`'d run died as its launching shell exited.

`tests/hl2_signal_stop_test.py` drives a real `MetisClient` against a fake radio, kills it with a real signal, and requires a stop datagram — with a **negative control** (handlers not installed → no stop) so the passes mean something. **Confirmed on the real radio by the maintainer: `pkill` on a connected session, recovered and reconnected with no power cycle.**

## Verification

**192/192 tests pass**, including 20 new assertions pinning the filter encoding and the band map against Quisk's table.

`tests/hl2_live_band_filter_probe.cpp` (hardware-only, `EXCLUDE_FROM_ALL`) answers *"the unit test shares our reading of the register map, so what would catch a convention error?"*. The filter byte rides the **CONFIG register**, so a misplaced bit lands in the sample rate or receiver count and the failure is a radio that still streams and still looks correctly framed. Measured on a real HL2 (gateware 7.4):

- **EP6 packet rate held at 381/s (within 1.002×)** across all nine filter selections, with non-zero IQ. A bit leaking into `DATA[25:24]` would have halved or doubled it; one in `[6:3]` would have left the receiver unassigned and the payload exactly zero.
- **Engaging the AM-blocking HPF at 0.6 MHz dropped the band 22–24 dB.** That is not the radio agreeing with our register map — that is the antenna path changing. It also confirms an N2ADR board is fitted; on a bare HL2 the writes are inert and harmless.
- **A commanded 10 → 30 dB LNA step moved the raw wire noise floor 19.8 dB**, measured before any of our DSP or dB referencing runs.

Driven on hardware through the automation bridge:

| Check | Result |
|---|---|
| 40 m button | slice 9.98 USB → **7.200 LSB**, pan centre followed |
| Filter on band change | `0x48 (HPF + 30/20m)` → `0x44 (HPF + 60/40m)`, logged at INFO |
| Radio Health | populated with live telemetry (fw 74, 34.6 °C, FIFO 128, `0x48 — HPF + 30/20m LPF`) |
| RF Gain slider | −12…+48, 1 dB steps, reading 20 dB |
| ATU / MEM | disabled, *"This radio has no antenna tuner"* |
| 6 m button | disabled, *"Outside this radio's tuning range (0.100–38.400 MHz)"* |

## Notes for review

- `HERMES.md` §17 documents all of the above, and tier-3 items 12a and 19 are marked done.
- **No FFTW / NR2 behaviour is changed by this PR.** An earlier revision gated the post-connect NR2 auto-restore on cached wisdom; that has been reverted at the maintainer's request and `SpectralNR`, `AudioEngine` and `WdspChannel` are untouched.
- The shutdown fix is the **second commit** and is reviewable on its own.
- FWD/REV power is deliberately rudimentary and labelled as such; per-unit calibration is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
