### PR TITLE
fix(cat): make CAT band changes follow the panadapter (RFC #4333)

### DIFF
--- a/src/core/RigctlProtocol.cpp
+++ b/src/core/RigctlProtocol.cpp
@@ -751,20 +751,12 @@ QString RigctlProtocol::cmdSetFreq(const QString& arg)
 
     double mhz = hz / 1e6;
     RadioModel* model = m_model;
+    // Cross-band-aware retune on the GUI thread (#536): tuneSliceForCat() applies
+    // the recenter policy — in-span keeps autopan=0 (no yank — SatPC32 Doppler),
+    // out-of-span/cross-band uses tuneAndRecenter so the radio recenters the pan
+    // and the panadapter follows instead of being left behind.
     QMetaObject::invokeMethod(slice, [slice, model, mhz]() {
-        // Recenter only when the target falls outside the pan's current
-        // span — the cross-band case (e.g. WSJT-X band changes, #536).
-        // In-span retunes use autopan=0: external Doppler software
-        // (SatPC32) issues set_freq every few seconds, and recentering
-        // each one keeps yanking the pan regardless of the GUI's
-        // Pan-Follows-VFO setting (the recenter happens radio-side).
-        bool inSpan = false;
-        if (auto* pan = model ? model->panadapter(slice->panId()) : nullptr) {
-            const double halfBw = pan->bandwidthMhz() / 2.0;
-            inSpan = halfBw > 0.0 && qAbs(mhz - pan->centerMhz()) <= halfBw;
-        }
-        if (inSpan) slice->setFrequency(mhz);
-        else        slice->tuneAndRecenter(mhz);
+        if (model) model->tuneSliceForCat(slice, mhz);
     }, Qt::QueuedConnection);
     return rprt(0);
 }
@@ -992,6 +984,11 @@ void RigctlProtocol::tryPromoteTxSlice()
             // setTxSlice above and every other model mutation in this class.
             if (m_pendingSplitFreqMHz > 0.0) {
                 const double mhz = m_pendingSplitFreqMHz;
+                // Bare setFrequency (autopan=0) — the split TX slice must NOT
+                // recenter the pan: that would yank the operator's view off the
+                // RX slice they're watching. Unlike a VFO-A tune (which recenters
+                // to follow the operator via tuneSliceForCat), set_split_freq is a
+                // background TX-slice set with no TCI analog. Per #4497 triage.
                 QMetaObject::invokeMethod(s, [s, mhz]{ s->setFrequency(mhz); },
                                           Qt::QueuedConnection);
                 m_pendingSplitFreqMHz = 0.0;
@@ -1213,6 +1210,9 @@ QString RigctlProtocol::cmdSetSplitFreq(const QString& args)
     return applySplitParam(
         [this, mhz]{ m_pendingSplitFreqMHz = mhz; },
         [mhz](SliceModel* tx) {
+            // Bare setFrequency (autopan=0) — do NOT recenter on the split TX
+            // slice; that would yank the operator's pan off the RX slice. See
+            // tryPromoteTxSlice above and the #4497 triage.
             QMetaObject::invokeMethod(tx, [tx, mhz]{ tx->setFrequency(mhz); },
                                       Qt::QueuedConnection);
         });
@@ -2040,15 +2040,17 @@ QString RigctlProtocol::cmdVfoOp(const QString& arg)
 
     if (op == "UP") {
         const double mhz = slice->frequency() + slice->stepHz() / 1e6;
-        QMetaObject::invokeMethod(slice, [slice, mhz]() {
-            slice->setFrequency(mhz);
+        RadioModel* model = m_model;
+        QMetaObject::invokeMethod(slice, [slice, model, mhz]() {
+            if (model) model->tuneSliceForCat(slice, mhz);
         }, Qt::QueuedConnection);
         return rprt(0);
     }
     if (op == "DOWN") {
         const double mhz = slice->frequency() - slice->stepHz() / 1e6;
-        QMetaObject::invokeMethod(slice, [slice, mhz]() {
-            slice->setFrequency(mhz);
+        RadioModel* model = m_model;
+        QMetaObject::invokeMethod(slice, [slice, model, mhz]() {
+            if (model) model->tuneSliceForCat(slice, mhz);
         }, Qt::QueuedConnection);
         return rprt(0);
     }

--- a/src/core/SmartCatProtocol.cpp
+++ b/src/core/SmartCatProtocol.cpp
@@ -306,7 +306,11 @@ QString SmartCatProtocol::cmdFA(const QString& arg)
     bool ok;
     double hz = arg.toDouble(&ok);
     if (!ok) return "?;";
-    a->setFrequency(hz / 1e6);
+    // Cross-band-aware: tuneSliceForCat() applies the recenter policy so a band
+    // change makes the panadapter follow (in-span keeps autopan=0; out-of-span
+    // recenters) instead of leaving it behind until a manual GUI action. CatPort
+    // runs on the GUI thread, so this is a direct, synchronous call.
+    if (m_model) m_model->tuneSliceForCat(a, hz / 1e6);
     return {};
 }
 
@@ -324,7 +328,12 @@ QString SmartCatProtocol::cmdFB(const QString& arg)
     bool ok;
     double hz = arg.toDouble(&ok);
     if (!ok) return "?;";
-    b->setFrequency(hz / 1e6);
+    // Cross-band-aware (see cmdFA): the recenter policy makes the panadapter
+    // follow a band change; in-span keeps autopan=0. An out-of-span split TX
+    // (VFO B on a different band than RX) therefore recenters the pan onto the
+    // TX freq — a deliberate change from the old autopan=0 split behavior, made
+    // to match TCI, which recenters on any VFO tune regardless of channel.
+    if (m_model) m_model->tuneSliceForCat(b, hz / 1e6);
     return {};
 }
 
@@ -1405,7 +1414,11 @@ QString SmartCatProtocol::cmdUP(const QString& arg)
         if (ok && n > 0) steps = n;
     }
     double stepMhz = static_cast<double>(a->stepHz()) / 1e6;
-    a->setFrequency(a->frequency() + stepMhz * steps);
+    // Cross-band-aware (see cmdFA): a multi-step move can leave the pan span, so
+    // route through the recenter policy rather than a bare autopan=0 setFrequency.
+    // Stepping up only ever increases the target, so it stays positive by
+    // construction — the radio rejects an implausibly high freq on its own.
+    if (m_model) m_model->tuneSliceForCat(a, a->frequency() + stepMhz * steps);
     return {};
 }
 
@@ -1424,7 +1437,10 @@ QString SmartCatProtocol::cmdDN(const QString& arg)
         if (ok && n > 0) steps = n;
     }
     double stepMhz = static_cast<double>(a->stepHz()) / 1e6;
-    a->setFrequency(a->frequency() - stepMhz * steps);
+    // Cross-band-aware (see cmdFA). A large multi-step DN can underflow the
+    // target past 0; tuneSliceForCat rejects a non-positive frequency at the
+    // boundary, so no clamp is needed here.
+    if (m_model) m_model->tuneSliceForCat(a, a->frequency() - stepMhz * steps);
     return {};
 }
 

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1175,9 +1175,8 @@ void TciServer::tuneSliceAndConfirm(
 
     const double mhz = static_cast<double>(frequencyHz) / 1.0e6;
     bool inSpan = false;
-    if (PanadapterModel* pan = m_model->panadapter(slice->panId())) {
-        const double halfBandwidth = pan->bandwidthMhz() / 2.0;
-        inSpan = halfBandwidth > 0.0 && qAbs(mhz - pan->centerMhz()) <= halfBandwidth;
+    if (const PanadapterModel* pan = m_model->panadapter(slice->panId())) {
+        inSpan = pan->spanContainsMhz(mhz);
     }
 
     // TUNE THROUGH THE MODEL, ON EVERY COMMAND PLANE (#4500, #4493).

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -40,6 +40,21 @@ public:
     double centerMhz() const { return m_centerMhz; }
     bool centerKnown() const { return m_centerKnown; }
     double bandwidthMhz() const { return m_bandwidthMhz; }
+    // True when a target frequency (MHz) lies within this pan's current span
+    // [center - bw/2, center + bw/2]. The single source of truth for the
+    // CAT/TCI VFO-tune recenter policy: in-span retunes keep autopan=0 (no
+    // yank), out-of-span targets recenter/re-band the display. Until the radio
+    // has reported a real center (centerKnown), m_centerMhz is a placeholder,
+    // so treat the target as out of span — that recenters, which is the safe
+    // direction and establishes the center. A non-positive bandwidth (span not
+    // yet known) is likewise never in span.
+    bool spanContainsMhz(double mhz) const {
+        if (!m_centerKnown) {
+            return false;
+        }
+        const double halfBw = m_bandwidthMhz / 2.0;
+        return halfBw > 0.0 && qAbs(mhz - m_centerMhz) <= halfBw;
+    }
     // Normalized setter driven by the backend (aetherd RFC 2.3). A negative
     // value means "leave unchanged" (the radio may report one without the
     // other). Emits infoChanged when either value changes or when the center

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3590,6 +3590,42 @@ bool RadioModel::requestPanBand(const QString& panId, const QString& bandKey)
     return dispatchPanBand(panId, bandKey);
 }
 
+void RadioModel::tuneSliceForCat(SliceModel* slice, double mhz)
+{
+    if (!slice) {
+        return;
+    }
+    // Boundary validation (Principle VII): this is the single seam every CAT /
+    // rigctld retune funnels through, so reject an implausible frequency here
+    // once rather than in each caller. A non-positive or non-finite target
+    // (a client sending FA-5000;, a multi-step DN/UP that underflows, a parse
+    // that yielded NaN/inf) would otherwise be pushed optimistically into the
+    // model and broadcast via frequencyChanged before the radio rejects it.
+    if (!(mhz > 0.0 && std::isfinite(mhz))) {
+        return;
+    }
+    // Recenter policy: an in-span retune keeps autopan=0 (no yank — external
+    // Doppler software like SatPC32 steps every few seconds); an out-of-span or
+    // cross-band target uses tuneAndRecenter so the radio recenters/re-bands the
+    // panadapter. Both go through SliceModel, which updates the model frequency
+    // and emits frequencyChanged — that drives the client-side follow (Center
+    // Lock / Pan-Follows-VFO) the radio needs to actually move a centered slice.
+    // (A bare command via sendCmdPublic does NOT emit frequencyChanged, so the
+    // follow never runs and the tune doesn't stick on real hardware.) SliceModel
+    // itself guards the slice lock and no-op (freq unchanged), so no extra checks
+    // here. We issue no pan command directly — the client lock logic does, exactly
+    // as the GUI tune path does.
+    bool inSpan = false;
+    if (const PanadapterModel* pan = panadapter(slice->panId())) {
+        inSpan = pan->spanContainsMhz(mhz);
+    }
+    if (inSpan) {
+        slice->setFrequency(mhz);
+    } else {
+        slice->tuneAndRecenter(mhz);
+    }
+}
+
 double RadioModel::effectivePanCenterMhz(const QString& panId) const
 {
     if (const auto pending = m_pendingProfileLoadPanWrites.pendingCenter(panId)) {

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -578,6 +578,18 @@ public:
                                 int wfLineDurationMs);
     bool requestPanBand(const QString& panId, const QString& bandKey);
 
+    // Retune a slice on behalf of the CAT servers (rigctld / SmartCAT) so a band
+    // change made over CAT (WSJT-X/FLDigi "change band") is recentered instead of
+    // leaving the panadapter behind. Applies the recenter policy: in-span keeps
+    // autopan=0 (no yank — external Doppler software like SatPC32 steps every few
+    // seconds); an out-of-span or cross-band target uses tuneAndRecenter. Both go
+    // through SliceModel, which updates the model and emits frequencyChanged —
+    // required to drive the client-side follow (Center Lock / Pan-Follows-VFO)
+    // that lets the radio actually move a centered slice. We issue no pan command
+    // directly; the client lock logic does, exactly as the GUI path does. Call on
+    // the GUI thread (owns SliceModel).
+    void tuneSliceForCat(SliceModel* slice, double mhz);
+
     // Effective pan geometry: the deferred pending value if one is queued,
     // else the live model value, else NaN when the pan is unknown. Caller-side
     // no-op guards must compare against THIS, not the raw model — during the

--- a/tests/CAT_Flex_test.cpp
+++ b/tests/CAT_Flex_test.cpp
@@ -204,6 +204,21 @@ static QString hz11(qint64 hz)
     return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
 }
 
+// Poll a frequency readback until it matches (or a generous cap elapses). A tune
+// updates the model optimistically, so the readback is normally immediate; polling
+// is belt-and-suspenders so the check never depends on exact settle timing (fast
+// simulator or a slower real radio). `got` receives the last response (for detail).
+static bool pollFreqEquals(CatClient& c, const QString& query, const QString& expect,
+                           QString& got, int capMs = 1000)
+{
+    for (int elapsed = 0; elapsed < capMs; elapsed += 50) {
+        QThread::msleep(50);
+        got = c.query(query);
+        if (got == expect) return true;
+    }
+    return false;
+}
+
 // Does this port have a usable VFO B? ZZFB returns its frequency when present, or
 // "?" (NOT_ENABLED) on a single-VFO port / when the VFO B slice isn't open. Single
 // definition so the split-section gates can't drift apart.
@@ -342,11 +357,12 @@ void section2(CatClient& c, Runner& r, qint64 origHz)
             resp.mid(4) == faResp.mid(2),
             QStringLiteral("ZZFA=%1 FA=%2").arg(repr(resp.mid(4)), repr(faResp.mid(2))));
 
+    // Poll rather than assume a fixed wait (see pollFreqEquals) so the check stays
+    // timing-independent regardless of where the radio started.
     const qint64 testHz = 14'074'000;
     c.send(QStringLiteral("ZZFA") + hz11(testHz));
-    QThread::msleep(150);
-
-    QString respZz = c.query(QStringLiteral("ZZFA"));
+    QString respZz;
+    pollFreqEquals(c, QStringLiteral("ZZFA"), QStringLiteral("ZZFA") + hz11(testHz), respZz);
     QString respFa = c.query(QStringLiteral("FA"));
     r.check(QStringLiteral("2.3  set ZZFA 14.074 MHz → ZZFA; confirms"),
             respZz == QStringLiteral("ZZFA") + hz11(testHz),
@@ -355,16 +371,56 @@ void section2(CatClient& c, Runner& r, qint64 origHz)
             respFa == QStringLiteral("FA") + hz11(testHz),
             QStringLiteral("got %1").arg(repr(respFa)));
 
-    const qint64 test2Hz = 21'074'000;
+    const qint64 test2Hz = 21'074'000;   // cross-band (20 m → 15 m)
     c.send(QStringLiteral("FA") + hz11(test2Hz));
-    QThread::msleep(150);
-    respZz = c.query(QStringLiteral("ZZFA"));
+    pollFreqEquals(c, QStringLiteral("ZZFA"), QStringLiteral("ZZFA") + hz11(test2Hz), respZz);
     r.check(QStringLiteral("2.5  set via base FA; ZZFA; reflects the change"),
             respZz == QStringLiteral("ZZFA") + hz11(test2Hz),
             QStringLiteral("got %1").arg(repr(respZz)));
 
     c.send(QStringLiteral("FA") + hz11(origHz));
     QThread::msleep(100);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section2c(CatClient& c, Runner& r, qint64 origHz)
+{
+    r.section(QStringLiteral("Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)"));
+
+    // A band change over CAT (WSJT-X/FLDigi "change band") must move VFO A to the
+    // new band and have the radio recenter the panadapter so the pan follows —
+    // RadioModel::tuneSliceForCat(), the fix for the reported band-switch bug. The
+    // FlexCAT dialect exposes VFO-A frequency (ZZFA;/FA;) but NOT the panadapter
+    // center, so this guards the CAT round-trip across a real band boundary: the
+    // cross-band ZZFA set is accepted and VFO A lands on the requested frequency
+    // without error, clamp, or revert. The pan-follow itself is confirmed visually.
+
+    // Read the current frequency, then target a different HF band: flip between
+    // 40 m (7.100 MHz) and 20 m (14.100 MHz) across the 10 MHz divide so this is
+    // always a genuine band change regardless of where the radio started.
+    QString resp = c.query(QStringLiteral("ZZFA"));
+    const qint64 startHz = (resp.startsWith(QLatin1String("ZZFA")) && isDigits(resp.mid(4), 11))
+                           ? resp.mid(4).toLongLong()
+                           : origHz;
+    const qint64 target = (startHz < 10'150'000) ? 14'100'000 : 7'100'000;
+
+    c.send(QStringLiteral("ZZFA") + hz11(target));
+    pollFreqEquals(c, QStringLiteral("ZZFA"), QStringLiteral("ZZFA") + hz11(target), resp);
+    r.check(QStringLiteral("2c.1  cross-band set ZZFA (%1 → %2 Hz) — VFO A followed to the new band")
+                .arg(startHz).arg(target),
+            resp == QStringLiteral("ZZFA") + hz11(target),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    // Tune back across the boundary — verifies the reverse direction and restores
+    // the original band.
+    c.send(QStringLiteral("ZZFA") + hz11(origHz));
+    pollFreqEquals(c, QStringLiteral("ZZFA"), QStringLiteral("ZZFA") + hz11(origHz), resp);
+    r.check(QStringLiteral("2c.2  cross-band set ZZFA back to the original band (%1 Hz) confirms").arg(origHz),
+            resp == QStringLiteral("ZZFA") + hz11(origHz),
+            QStringLiteral("got %1").arg(repr(resp)));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -545,6 +601,18 @@ void section7(CatClient& c, Runner& r)
 {
     r.section(QStringLiteral("Section 7 — ZZAI — AI Mode (async unsolicited updates)"));
 
+    // Setup (AI still off, so these push nothing): capture the current frequency
+    // and pin a known mode. 7.5/7.6 then exercise a genuine, IN-BAND change — a
+    // cross-band ZZFA would trigger a band-stack recall that also pushes the
+    // recalled mode, and that extra unsolicited MD push would desync the ordered
+    // request/response reads for the rest of the section.
+    const QString faStart = c.query(QStringLiteral("ZZFA"));
+    const qint64 startHz = (faStart.startsWith(QLatin1String("ZZFA")) && isDigits(faStart.mid(4), 11))
+                           ? faStart.mid(4).toLongLong()
+                           : 14'100'000;
+    c.send(QStringLiteral("ZZMD01;"));   // USB, so 7.6's ZZMD05 (FM) is a real change
+    QThread::msleep(150);
+
     QString resp = c.query(QStringLiteral("ZZAI"));
     r.check(QStringLiteral("7.1  ZZAI; → ZZAI00 (disabled by default)"),
             resp == QLatin1String("ZZAI00"), repr(resp));
@@ -561,7 +629,7 @@ void section7(CatClient& c, Runner& r)
     r.check(QStringLiteral("7.4  AI; reflects ZZAI enable (shared state)"),
             aiResp == QLatin1String("AI1"), repr(aiResp));
 
-    const qint64 newHz = 14'100'000;
+    const qint64 newHz = startHz + 2000;   // +2 kHz, in-band (no band/mode recall)
     c.send(QStringLiteral("ZZFA") + hz11(newHz));
     QString push = c.tryRead(2000);
     r.check(QStringLiteral("7.5  AI push after ZZFA set → push is \"FA<freq>\" (NOT ZZFA prefix)"),
@@ -831,18 +899,19 @@ void section12(CatClient& c, Runner& r)
 {
     r.section(QStringLiteral("Section 12 — Cross-Dialect Consistency (base ↔ ZZ commands)"));
 
+    // Poll rather than assume a fixed wait (see pollFreqEquals) so the check stays
+    // timing-independent regardless of where the radio started.
     const qint64 testHz = 14'074'000;
     c.send(QStringLiteral("FA") + hz11(testHz));
-    QThread::msleep(150);
-    QString resp = c.query(QStringLiteral("ZZFA"));
+    QString resp;
+    pollFreqEquals(c, QStringLiteral("ZZFA"), QStringLiteral("ZZFA") + hz11(testHz), resp);
     r.check(QStringLiteral("12.1 set freq via FA; → ZZFA; reflects it"),
             resp == QStringLiteral("ZZFA") + hz11(testHz),
             QStringLiteral("got %1").arg(repr(resp)));
 
-    const qint64 test2Hz = 7'074'000;
+    const qint64 test2Hz = 7'074'000;   // cross-band (20 m → 40 m)
     c.send(QStringLiteral("ZZFA") + hz11(test2Hz));
-    QThread::msleep(150);
-    resp = c.query(QStringLiteral("FA"));
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(test2Hz), resp);
     r.check(QStringLiteral("12.2 set freq via ZZFA; → FA; reflects it"),
             resp == QStringLiteral("FA") + hz11(test2Hz),
             QStringLiteral("got %1").arg(repr(resp)));
@@ -1549,6 +1618,7 @@ int main(int argc, char* argv[])
 
     section1(c, r);
     section2(c, r, origHz);
+    section2c(c, r, origHz);
     section3(c, r);
     section4(c, r, origMode);
     section5(c, r);

--- a/tests/CAT_TS-2000_test.cpp
+++ b/tests/CAT_TS-2000_test.cpp
@@ -204,6 +204,21 @@ static QString hz11(qint64 hz)
     return QStringLiteral("%1").arg(hz, 11, 10, QChar('0'));
 }
 
+// Poll a frequency readback until it matches (or a generous cap elapses). A tune
+// updates the model optimistically, so the readback is normally immediate; polling
+// is belt-and-suspenders so the check never depends on exact settle timing (fast
+// simulator or a slower real radio). `got` receives the last response (for detail).
+static bool pollFreqEquals(CatClient& c, const QString& query, const QString& expect,
+                           QString& got, int capMs = 1000)
+{
+    for (int elapsed = 0; elapsed < capMs; elapsed += 50) {
+        QThread::msleep(50);
+        got = c.query(query);
+        if (got == expect) return true;
+    }
+    return false;
+}
+
 // Does this port have a usable VFO B? FB returns its frequency when present, or "?"
 // (NOT_ENABLED) on a single-VFO port / when the VFO B slice isn't open.
 static bool hasVfoB(CatClient& c)
@@ -317,18 +332,18 @@ qint64 section2(CatClient& c, Runner& r, qint64 origHz)
                        ? resp.mid(2).toLongLong()
                        : origHz;
 
+    // Poll rather than assume a fixed wait (see pollFreqEquals) so the check stays
+    // timing-independent regardless of where the radio started.
     const qint64 testHz = 14'074'000;
     c.send(QStringLiteral("FA") + hz11(testHz));
-    QThread::msleep(150);
-    resp = c.query(QStringLiteral("FA"));
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(testHz), resp);
     r.check(QStringLiteral("2.2  set FA 14.074 MHz → FA; confirms new frequency"),
             resp == QStringLiteral("FA") + hz11(testHz),
             QStringLiteral("got %1").arg(repr(resp)));
 
-    const qint64 test2Hz = 7'074'000;
+    const qint64 test2Hz = 7'074'000;   // cross-band (20 m → 40 m)
     c.send(QStringLiteral("FA") + hz11(test2Hz));
-    QThread::msleep(150);
-    resp = c.query(QStringLiteral("FA"));
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(test2Hz), resp);
     r.check(QStringLiteral("2.3  second set FA (different band) confirms correctly"),
             resp == QStringLiteral("FA") + hz11(test2Hz),
             QStringLiteral("got %1").arg(repr(resp)));
@@ -336,6 +351,47 @@ qint64 section2(CatClient& c, Runner& r, qint64 origHz)
     c.send(QStringLiteral("FA") + hz11(origHz));
     QThread::msleep(100);
     return currentHz;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section2c(CatClient& c, Runner& r, qint64 origHz)
+{
+    r.section(QStringLiteral("Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)"));
+
+    // A band change over CAT (WSJT-X/FLDigi "change band") must move VFO A to the
+    // new band and have the radio recenter the panadapter so the pan follows —
+    // RadioModel::tuneSliceForCat(), the fix for the reported band-switch bug. The
+    // TS-2000 protocol exposes VFO-A frequency (FA;) but NOT the panadapter center,
+    // so this guards the CAT round-trip across a real band boundary: the cross-band
+    // FA set is accepted and VFO A lands on the requested frequency without error,
+    // clamp, or revert. The pan-follow itself is confirmed visually on the panadapter.
+
+    // Read the current frequency, then target a different HF band: flip between
+    // 40 m (7.100 MHz) and 20 m (14.100 MHz) across the 10 MHz divide so this is
+    // always a genuine band change regardless of where the radio started.
+    QString resp = c.query(QStringLiteral("FA"));
+    const qint64 startHz = (resp.startsWith(QLatin1String("FA")) && isDigits(resp.mid(2), 11))
+                           ? resp.mid(2).toLongLong()
+                           : origHz;
+    const qint64 target = (startHz < 10'150'000) ? 14'100'000 : 7'100'000;
+
+    c.send(QStringLiteral("FA") + hz11(target));
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(target), resp);
+    r.check(QStringLiteral("2c.1  cross-band set FA (%1 → %2 Hz) — VFO A followed to the new band")
+                .arg(startHz).arg(target),
+            resp == QStringLiteral("FA") + hz11(target),
+            QStringLiteral("got %1").arg(repr(resp)));
+
+    // Tune back across the boundary — verifies the reverse direction and restores
+    // the original band.
+    c.send(QStringLiteral("FA") + hz11(origHz));
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(origHz), resp);
+    r.check(QStringLiteral("2c.2  cross-band set FA back to the original band (%1 Hz) confirms").arg(origHz),
+            resp == QStringLiteral("FA") + hz11(origHz),
+            QStringLiteral("got %1").arg(repr(resp)));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1227,6 +1283,20 @@ void section15(CatClient& c, Runner& r)
         dnHz = faDn.mid(2).toLongLong();
     r.check(QStringLiteral("15.24 DN; → FA returns to base frequency"),
             dnHz == baseHz, repr(faDn));
+
+    // 15.25  DN with a step count large enough to underflow past 0 at any tuning
+    // step. tuneSliceForCat rejects the resulting non-positive target at the
+    // boundary, so the tune is dropped and VFO A is left untouched — it must NOT
+    // move, clamp to a band edge, or emit a negative "slice tune". FA stays at
+    // base. (Regression guard for the cmdDN underflow; the guard lives in
+    // RadioModel::tuneSliceForCat.)
+    c.send(QStringLiteral("DN99999999"));
+    QString faUnder;
+    pollFreqEquals(c, QStringLiteral("FA"), QStringLiteral("FA") + hz11(baseHz), faUnder);
+    qint64 underHz = (faUnder.startsWith(QLatin1String("FA")) && isDigits(faUnder.mid(2), 11))
+                     ? faUnder.mid(2).toLongLong() : -1;
+    r.check(QStringLiteral("15.25 DN99999999 (underflow) → VFO A unchanged, no negative freq"),
+            underHz == baseHz, repr(faUnder));
 }
 
 } // namespace
@@ -1295,6 +1365,7 @@ int main(int argc, char* argv[])
 
     section1(c, r);
     section2(c, r, origHz);
+    section2c(c, r, origHz);
     section3(c, r);
     section4(c, r, origMode);
     section5(c, r);

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -2129,7 +2129,7 @@ void section15(RigctlClient& c, Runner& r)
 // Edge cases
 // ═════════════════════════════════════════════════════════════════════════════
 
-void sectionEdge(RigctlClient& c, Runner& r)
+void sectionEdge(RigctlClient& c, Runner& r, bool doCw)
 {
     r.section(QStringLiteral("Edge Cases"));
 
@@ -2161,12 +2161,18 @@ void sectionEdge(RigctlClient& c, Runner& r)
     lines = c.send(QStringLiteral("\\set_trn 1"));
     r.check(QStringLiteral("E5  set_trn 1 accepted silently (RPRT 0)"), c.ok(lines));
 
-    // E6  send_morse smoke test — verify protocol accepts it without --cw flag
-    //     Does not verify radio keying; just that the command parses and queues
-    lines = c.send(QStringLiteral("\\send_morse TEST"));
-    r.check(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0, no --cw required)"),
-            c.ok(lines), lines.join(QStringLiteral(" | ")));
-    c.send(QStringLiteral("\\stop_morse"));
+    // E6  send_morse smoke test — verify the protocol accepts/queues the command.
+    //     GATED behind --cw: send_morse routes through CwxModel → "cwx", which
+    //     KEYS CW on real hardware, so it must not run on a plain (no-TX) pass.
+    if (doCw) {
+        lines = c.send(QStringLiteral("\\send_morse TEST"));
+        r.check(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0)"),
+                c.ok(lines), lines.join(QStringLiteral(" | ")));
+        c.send(QStringLiteral("\\stop_morse"));
+    } else {
+        r.skip(QStringLiteral("E6  send_morse \"TEST\" accepted (RPRT 0)"),
+               QStringLiteral("--cw not set — send_morse keys CW on real hardware"));
+    }
 
     // E7  q (short-form quit) — must return RPRT 0 so Hamlib closes cleanly
     //     without triggering its 20-second command timeout
@@ -2423,7 +2429,7 @@ int main(int argc, char** argv)
     section13(host, port, timeout, r, origFreq, origMode, origPb);
     section14(c, r, doSplit);
     section15(c, r);
-    sectionEdge(c, r);
+    sectionEdge(c, r, doCw);
     sectionPty(r, ptyPath);
 
     // Best-effort state restore.

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -2,10 +2,12 @@
 // Requires a running AetherSDR instance with rigctld enabled (default: localhost:4532).
 //
 // Build:  cmake --build build --target rigctld_test
-// Run:    ./build/rigctld_test [--host HOST] [--port PORT] [--ptt] [--cw] [--pty PATH]
+// Run:    ./build/rigctld_test [--host HOST] [--port PORT] [--ptt] [--cw] [--no-split] [--pty PATH]
 //
 // PTT tests (section 6) and CW/Morse tests (section 11) are disabled by default.
 // Enable only when a dummy load or antenna is connected.
+// --no-split skips the split-VFO tests (section 5) for single-VFO targets that
+// cannot open a VFO B (e.g. the built-in demo/SimBackend, which is single-slice).
 // PTY test (section 16) runs automatically; skips if the per-user cat-A symlink cannot be opened.
 
 #include <QCommandLineOption>
@@ -1125,6 +1127,26 @@ void section5(RigctlClient& c, Runner& r, qint64 origFreq)
     }
 }
 
+void section5Skip(Runner& r)
+{
+    r.section(QStringLiteral("Section 5 — Split VFO  (skipped — --no-split; single-VFO target)"));
+    for (const auto* name : {
+             "5.1  get_split_vfo baseline",     "5.2  set_split_vfo 1 VFOB",
+             "5.3  split active",               "5.4  set_split_freq",
+             "5.5  get_split_freq",             "5.5b VFOA/VFOB independent",
+             "5.6  set_split_mode",             "5.7  get_split_mode",
+             "5.7b get_split_freq_mode",        "5.7c set_split_freq_mode",
+             "5.7d get_split_freq_mode confirm","5.7e set_split_mode round-trip",
+             "5.7f VFOB level independent",     "5.7g VFO-prefixed split setters",
+             "5.8  get_vfo_info VFOB split",    "5.9  disable split",
+             "5.9b split confirmed off",        "5.10 deferred stash path",
+             "5.10b stashed split freq applied","5.11 targetable VFOB auto-enable",
+             "5.12 implicit-enable reclaim",    "5.13 maxSlices guard on demand",
+             "5.14 establish split on demand",
+         })
+        r.skip(QLatin1String(name), QStringLiteral("--no-split set (single-VFO target)"));
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // Section 6 — PTT  (optional — requires dummy load or antenna)
 // ═════════════════════════════════════════════════════════════════════════════
@@ -1944,7 +1966,7 @@ void section13(const QString& host, quint16 port, int timeout,
 // Section 14 — Short-Form Character Mapping  (Hamlib source audit regression)
 // ═════════════════════════════════════════════════════════════════════════════
 
-void section14(RigctlClient& c, Runner& r)
+void section14(RigctlClient& c, Runner& r, bool doSplit)
 {
     r.section(QStringLiteral("Section 14 — Short-Form Character Mapping (Hamlib audit regression)"));
 
@@ -1998,10 +2020,17 @@ void section14(RigctlClient& c, Runner& r)
     r.check(QStringLiteral("14.6 'z' → get_xit returns XIT field"),
             c.ok(lines) && isInt(xitVal), xitVal);
 
-    // 14.7  'k' → get_split_freq_mode  (was missing before audit)
-    lines = c.send(QStringLiteral("k"));
-    r.check(QStringLiteral("14.7 'k' → get_split_freq_mode returns RPRT 0"),
-            c.ok(lines), lines.join(QStringLiteral(" | ")));
+    // 14.7  'k' → get_split_freq_mode  (was missing before audit). Returns RPRT 0
+    //       only when split is active; on a single-VFO target with no TX slice it
+    //       correctly returns RPRT -1, so skip it there (mirrors --no-split for §5).
+    if (doSplit) {
+        lines = c.send(QStringLiteral("k"));
+        r.check(QStringLiteral("14.7 'k' → get_split_freq_mode returns RPRT 0"),
+                c.ok(lines), lines.join(QStringLiteral(" | ")));
+    } else {
+        r.skip(QStringLiteral("14.7 'k' → get_split_freq_mode returns RPRT 0"),
+               QStringLiteral("--no-split set (single-VFO target — no split active)"));
+    }
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -2310,6 +2339,9 @@ int main(int argc, char** argv)
         QStringLiteral("enable PTT tests (section 6) — requires dummy load or antenna"));
     QCommandLineOption cwOpt({QStringLiteral("cw")},
         QStringLiteral("enable CW/Morse tests (section 11) — requires --ptt and CW mode"));
+    QCommandLineOption noSplitOpt({QStringLiteral("no-split")},
+        QStringLiteral("skip split-VFO tests (section 5) — for single-VFO targets that "
+                       "cannot open a VFO B (e.g. the built-in demo/SimBackend)"));
     const QString defaultPty0 = defaultPtyPath(0);
     QCommandLineOption ptyOpt({QStringLiteral("pty")},
         QStringLiteral("PTY device path for section 16 (default: %1)").arg(defaultPty0),
@@ -2320,6 +2352,7 @@ int main(int argc, char** argv)
     parser.addOption(timeoutOpt);
     parser.addOption(pttOpt);
     parser.addOption(cwOpt);
+    parser.addOption(noSplitOpt);
     parser.addOption(ptyOpt);
     parser.process(app);
 
@@ -2328,6 +2361,7 @@ int main(int argc, char** argv)
     const int      timeout = parser.value(timeoutOpt).toInt();
     const bool     doPtt   = parser.isSet(pttOpt);
     const bool     doCw    = parser.isSet(cwOpt);
+    const bool     doSplit = !parser.isSet(noSplitOpt);
     const QString  ptyPath = parser.value(ptyOpt);
 
     std::cout << '\n' << bold(QStringLiteral("AetherSDR rigctld Test Suite")).toStdString() << '\n'
@@ -2371,7 +2405,8 @@ int main(int argc, char** argv)
     section2c(c, r, origFreq);
     section3(c, r, origMode, origPb);
     section4(c, r);
-    section5(c, r, origFreq);
+    if (doSplit) section5(c, r, origFreq);
+    else         section5Skip(r);
 
     if (doPtt) section6Ptt(c, r);
     else        section6Skip(r);
@@ -2386,7 +2421,7 @@ int main(int argc, char** argv)
 
     section12(c, r);
     section13(host, port, timeout, r, origFreq, origMode, origPb);
-    section14(c, r);
+    section14(c, r, doSplit);
     section15(c, r);
     sectionEdge(c, r);
     sectionPty(r, ptyPath);

--- a/tests/rigctld_test.cpp
+++ b/tests/rigctld_test.cpp
@@ -275,6 +275,23 @@ static const QSet<QString> kKnownModes = {
     QStringLiteral("RTTYR"),  QStringLiteral("None"),
 };
 
+// Poll a get_freq-style query until it reads the wanted Hz (within tolerance) or a
+// generous cap elapses; returns the last value seen. A tune updates the model
+// optimistically, so the readback is normally immediate; polling is belt-and-
+// suspenders so confirmations never depend on exact settle timing (fast simulator
+// or a slower real radio).
+static qint64 pollFreqField(RigctlClient& c, const QString& query, qint64 wantHz,
+                            int capMs = 1000, qint64 tolHz = 100)
+{
+    qint64 got = 0;
+    for (int elapsed = 0; elapsed < capMs; elapsed += 50) {
+        QThread::msleep(50);
+        got = c.field(c.send(query), QStringLiteral("Frequency")).toLongLong();
+        if (qAbs(got - wantHz) < tolHz) break;
+    }
+    return got;
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // Section 1 — Connection & Initialization
 // ═════════════════════════════════════════════════════════════════════════════
@@ -397,16 +414,17 @@ void section2(RigctlClient& c, Runner& r, qint64 origFreq)
     const qint64 testFreq = origFreq + 1000;
     lines = c.send(QStringLiteral("\\set_freq %1").arg(testFreq));
     r.check(QStringLiteral("2.2  set_freq returns RPRT 0"), c.ok(lines));
-    QThread::msleep(150);
 
-    lines = c.send(QStringLiteral("\\get_freq"));
-    const qint64 confirmed = c.field(lines, QStringLiteral("Frequency")).toLongLong();
+    // Poll to the same 10 Hz tolerance the assert uses — the default 100 Hz
+    // would let the loop break while still 10–100 Hz off, then fail the assert
+    // with a misleading "matched but failed" result.
+    const qint64 confirmed = pollFreqField(c, QStringLiteral("\\get_freq"), testFreq, 1000, 10);
     r.check(QStringLiteral("2.3  get_freq confirms new frequency (%1 Hz)").arg(testFreq),
             qAbs(confirmed - testFreq) < 10,
             QStringLiteral("got %1").arg(confirmed));
 
     c.send(QStringLiteral("\\set_freq %1").arg(origFreq));
-    QThread::msleep(100);
+    pollFreqField(c, QStringLiteral("\\get_freq"), origFreq); // let the restore settle
 
     // 2.4  short form get
     lines = c.send(QStringLiteral("f"));
@@ -417,24 +435,23 @@ void section2(RigctlClient& c, Runner& r, qint64 origFreq)
     lines = c.send(QStringLiteral("F %1").arg(testFreq));
     r.check(QStringLiteral("2.5  short form \"F\" (set_freq) returns RPRT 0"), c.ok(lines));
     c.send(QStringLiteral("F %1").arg(origFreq));
-    QThread::msleep(100);
 
-    // 2.6  VFO-prefixed get_freq VFOA — same result as bare get_freq
-    lines = c.send(QStringLiteral("\\get_freq VFOA"));
+    // 2.6  VFO-prefixed get_freq VFOA — same result as bare get_freq (poll the
+    //      restore above to settle, then confirm VFOA reads the original freq)
+    const qint64 vfoaFreq = pollFreqField(c, QStringLiteral("\\get_freq VFOA"), gotFreq);
     r.check(QStringLiteral("2.6  get_freq VFOA returns same Hz as get_freq"),
-            c.ok(lines) && c.field(lines, QStringLiteral("Frequency")).toLongLong() == gotFreq,
-            c.field(lines, QStringLiteral("Frequency")));
+            vfoaFreq == gotFreq,
+            QStringLiteral("%1").arg(vfoaFreq));
 
     // 2.7  VFO-prefixed set_freq VFOA <hz>
     lines = c.send(QStringLiteral("\\set_freq VFOA %1").arg(testFreq));
     r.check(QStringLiteral("2.7  set_freq VFOA returns RPRT 0"), c.ok(lines));
-    QThread::msleep(50);
-    lines = c.send(QStringLiteral("\\get_freq VFOA"));
+    const qint64 vfoaSet = pollFreqField(c, QStringLiteral("\\get_freq VFOA"), testFreq);
     r.check(QStringLiteral("2.8  get_freq VFOA confirms VFO-prefixed set_freq"),
-            c.ok(lines) && std::abs(c.field(lines, QStringLiteral("Frequency")).toLongLong() - testFreq) < 100,
-            c.field(lines, QStringLiteral("Frequency")));
+            std::abs(vfoaSet - testFreq) < 100,
+            QStringLiteral("%1").arg(vfoaSet));
     c.send(QStringLiteral("\\set_freq %1").arg(origFreq));
-    QThread::msleep(50);
+    pollFreqField(c, QStringLiteral("\\get_freq"), origFreq); // restore before section 3
 
     // 2.8b  get_freq VFOB with no split — must return RIG_ENAVAIL (-8)
     lines = c.send(QStringLiteral("\\get_freq VFOB"));
@@ -464,6 +481,47 @@ void section2(RigctlClient& c, Runner& r, qint64 origFreq)
                                 [](const QString& l){ return l.startsWith(QLatin1String("RPRT")); });
     r.check(QStringLiteral("2.6  extended-mode response has echo, \"Frequency:\" label, and RPRT"),
             hasEcho && hasLabel && hasRprt, raw.join(QStringLiteral(" | ")));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)
+// ═════════════════════════════════════════════════════════════════════════════
+
+void section2c(RigctlClient& c, Runner& r, qint64 origFreq)
+{
+    r.section(QStringLiteral("Section 2c — Cross-Band Tune (VFO round-trip; pan-follow is CAT-invisible)"));
+
+    // A band change over CAT (WSJT-X/FLDigi "change band") must move the slice to
+    // the new band and have the radio recenter the panadapter so the pan follows —
+    // RadioModel::tuneSliceForCat(), the fix for the reported band-switch bug.
+    // rigctld exposes the slice frequency (get_freq) but NOT the panadapter center,
+    // so this guards the CAT round-trip across a real band boundary: the cross-band
+    // set_freq is accepted and the slice lands on the requested frequency without
+    // error, clamp, or revert. The pan-follow itself is confirmed visually.
+
+    // Target a different HF band than the current frequency: flip between 40 m
+    // (7.100 MHz) and 20 m (14.100 MHz) across the 10 MHz divide so this is always
+    // a genuine band change regardless of where the radio started.
+    const qint64 target = (origFreq < 10150000) ? 14100000 : 7100000;
+
+    QStringList lines = c.send(QStringLiteral("\\set_freq %1").arg(target));
+    r.check(QStringLiteral("2c.1  cross-band set_freq (%1 → %2 Hz) returns RPRT 0")
+                .arg(origFreq).arg(target),
+            c.ok(lines));
+    const qint64 confirmed = pollFreqField(c, QStringLiteral("\\get_freq"), target);
+    r.check(QStringLiteral("2c.2  get_freq confirms the slice followed to the new band (%1 Hz)").arg(target),
+            qAbs(confirmed - target) < 100,
+            QStringLiteral("got %1").arg(confirmed));
+
+    // Tune back across the boundary — verifies the reverse direction and restores
+    // the original band.
+    lines = c.send(QStringLiteral("\\set_freq %1").arg(origFreq));
+    r.check(QStringLiteral("2c.3  cross-band set_freq back to the original band returns RPRT 0"),
+            c.ok(lines));
+    const qint64 restored = pollFreqField(c, QStringLiteral("\\get_freq"), origFreq);
+    r.check(QStringLiteral("2c.4  get_freq confirms return to the original frequency (%1 Hz)").arg(origFreq),
+            qAbs(restored - origFreq) < 100,
+            QStringLiteral("got %1").arg(restored));
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -2310,6 +2368,7 @@ int main(int argc, char** argv)
     section1(c, r);
     section1b(c, r);
     section2(c, r, origFreq);
+    section2c(c, r, origFreq);
     section3(c, r, origMode, origPb);
     section4(c, r);
     section5(c, r, origFreq);


### PR DESCRIPTION
Resolves #4497.

## What

A band change issued over CAT — WSJT-X / FLDigi "change band", rigctld `set_freq`, SmartCAT `FA`/`FB`, VFO up/down — moved the slice but left the panadapter behind, so the operator's view stayed on the old band until a manual GUI action. Reported on Facebook against a Flex 6500.

Route every CAT/rigctld VFO move through one recenter policy, `RadioModel::tuneSliceForCat()`:

- **in-span** target → `setFrequency` (`autopan=0`, no yank — external Doppler software like SatPC32 steps every few seconds and must not recenter each step);
- **out-of-span / cross-band** target → `tuneAndRecenter`, so the radio recenters/re-bands the panadapter and it follows the VFO.

Both paths go through `SliceModel`, which updates the model and emits `frequencyChanged` — the signal the client-side follow (Center Lock / Pan-Follows-VFO) needs to actually move a centered slice.

## Relationship to #4501

This builds on **#4501** and uses the **same mechanism** — model-setter tunes rather than a raw `slice tune` written at the connection. #4501 fixed that for the TCI `vfo:` path; this PR closes the same gap on the CAT/rigctld planes. `PanadapterModel::spanContainsMhz()` is the shared in-span test (RadioModel + TciServer both call it).

> ⚠️ **Stacked PR.** This targets #4501's branch (`fix/tci-stale-vfo-confirm`) as its base, so the diff shows only this PR's three commits. **Merge #4501 first**; this base will retarget to `main` automatically when #4501 merges (or I'll retarget + rebase).

## Decisions

- **Split TX** stays bare `setFrequency` on the rigctld split paths (`set_split_freq`, deferred TX-slice apply): recentering the background TX slice would yank the operator's pan off the RX slice they're watching, and `set_split_freq` (WSJT-X "Rig" split) has no TCI analog. SmartCAT `cmdFB` keeps the recenter (operator-facing VFO). Per the #4497 triage.
- **#3543** (cross-band CAT bypasses band-stack preselect → per-band/XVTR antenna recall) was considered and is **related but out of scope** here: different mechanism, safety-critical, needs transverter hardware to validate, and it has a maintainer-owned `applyTuneRequest` design. This PR neither fixes nor regresses it.

## Found during integration testing — rigctld E6 keyed CW on real hardware

While running the rigctld suite against a live 6500, the `E6 send_morse "TEST"` edge-case ran **unconditionally** (not gated behind `--cw`). `send_morse` routes through `CwxModel` → `cwx`, which **keys CW on a real radio** — so a plain, no-TX hardware run transmitted on the operator's licence. Invisible on the simulator; unsafe on hardware. This predates this PR (present in v26.7.4). Fixed here by gating E6 behind `--cw` to match the suite's existing PTT/CW safety model. Flagged separately in case it warrants a faster path than this PR.

## Testing

Added a cross-band round-trip check (§2c) to all three CAT suites, plus a `--no-split` flag so single-VFO targets (e.g. the built-in demo/SimBackend) can run rigctld without the split section.

- **Real FLEX-6500** — all four control planes (TCI, Flex CAT, TS-2000 CAT, rigctld) pan-follow a WSJT-X band change (visual; the pan-follow is not CAT-observable). Integration suites, dual-VFO, no `--ptt`/`--cw`: **rigctld 187/187** (full split), **Flex (5001) 125/125**, **TS-2000 (5003) 96/96** — 0 failures, no transmissions.
- **Demo mode** (single-VFO), Mac + RPi5: rigctld 160/160 (`--no-split`), Flex (5002) 105/105, TS-2000 (5004) 93/93.
- `tci_server_review_test` 14/14 with this branch on top of #4501.

Built and smoke tested on: MacBook Air M2 / RPi 5 Debian trixie
