### PR TITLE
fix(hl2): honour "auto-reconnect to last radio" for Hermes-Lite 2

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5137,6 +5137,11 @@ void MainWindow::onConnectionStateChanged(bool connected)
         return;
     }
 
+    // A completed connect clears the auto-connect attempt count for that radio;
+    // a drop settles any attempt still recorded as in flight. Both go through
+    // one place so the count cannot leak across sessions.
+    noteAutoConnectFinished(connected);
+
     m_connPanel->setConnected(connected);
 
     // Demo mode: reveal the Demo Noise control tile only while connected to the
@@ -5606,6 +5611,10 @@ void MainWindow::onConnectionStateChanged(bool connected)
 
 void MainWindow::onConnectionError(const QString& msg)
 {
+    // A failed auto-connect must count, or the retry is unbounded — see
+    // maybeAutoConnectToDiscoveredRadio(). Done here rather than in that slot
+    // because this is the only place a connect is known to have ended badly.
+    noteAutoConnectFinished(false);
     m_connPanel->setStatusText("Error: " + msg);
     m_connStatusLabel->setText("Error");
     statusBar()->showMessage("Connection error: " + msg, 5000);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -703,6 +703,13 @@ private:
     void showMultiFlexDialog();
     void handleMultiFlexClientDisconnect(quint32 handle, const QString& displayName);
     bool confirmClientSlotAvailability(const RadioInfo& info, QList<quint32>* disconnectHandles);
+    // Startup/reconnect autoconnect: called for every discovered radio, from EVERY
+    // discovery source (Flex RadioDiscovery *and* hl2::Hl2Discovery). Connects when
+    // the radio is the saved LastConnectedRadioSerial and the operator has left
+    // "AutoConnectToLastRadio" on. Family-agnostic on purpose — wiring it to one
+    // discovery object only is what left HL2 owners hand-picking their radio at
+    // every launch.
+    void maybeAutoConnectToDiscoveredRadio(const RadioInfo& info);
     bool confirmClientSlotAvailability(const WanRadioInfo& info, QList<quint32>* disconnectHandles);
     bool sendWanRadioClientDisconnects(const QString& serial, const QList<quint32>& handles);
     void disconnectWanRadioClients(const WanRadioInfo& info);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -710,6 +710,9 @@ private:
     // discovery object only is what left HL2 owners hand-picking their radio at
     // every launch.
     void maybeAutoConnectToDiscoveredRadio(const RadioInfo& info);
+    // Settle the bookkeeping for an auto-connect that has reached a terminal
+    // state. A no-op when the connect in question was a manual one.
+    void noteAutoConnectFinished(bool ok);
     bool confirmClientSlotAvailability(const WanRadioInfo& info, QList<quint32>* disconnectHandles);
     bool sendWanRadioClientDisconnects(const QString& serial, const QList<quint32>& handles);
     void disconnectWanRadioClients(const WanRadioInfo& info);
@@ -1230,6 +1233,16 @@ private:
     bool m_hasPaTempTelemetry{false};
     float m_lastPaTempC{0.0f};
     bool m_userDisconnected{false};  // true after explicit disconnect, blocks auto-connect
+    // Auto-reconnect bookkeeping — see maybeAutoConnectToDiscoveredRadio().
+    //
+    // The slot is driven by radioUpdated as well as radioDiscovered, and
+    // radioUpdated repeats. Neither of these is bookkeeping for its own sake:
+    // without the in-flight serial the slot re-enters its own handshake, and
+    // without the attempt count a radio that never completes one re-triggers it
+    // forever.
+    QString m_autoConnectSerial;                 // an auto-connect is in flight for this serial
+    QHash<QString, int> m_autoConnectAttempts;   // consecutive failed auto-connects, per serial
+    static constexpr int kMaxAutoConnectAttempts = 3;
     QDialog* m_reconnectDlg{nullptr}; // shown on unexpected disconnect, dismissed on reconnect
     QPointer<class ThemeEditorDialog> m_themeEditorDialog; // Phase 5 — lazy, modeless
     void cancelTransmitFromIndicator();

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -207,6 +207,18 @@ void MainWindow::wireDiscovery()
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioLost,
             m_connPanel, &ConnectionPanel::onRadioLost);
+    // "Auto-reconnect to last radio" used to be wired to the Flex RadioDiscovery
+    // only, so an HL2 owner watched their radio appear in the picker and then had
+    // to click it by hand at every launch. The HL2 sweep feeds the same slot.
+    // An HL2 that answers 0x03 (already streaming to somebody else) is skipped
+    // inside the slot — Protocol 1 is single-client, so there is nothing to join.
+    connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioDiscovered,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
+    // A radio first seen In_Use flips to Available when the other client drops;
+    // that arrives as radioUpdated, not radioDiscovered, so listen to both or the
+    // saved radio stays unconnected until it disappears and comes back.
+    connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioUpdated,
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
     m_hl2Discovery.start();
     connect(&m_discovery, &RadioDiscovery::radioUpdated,
             m_connPanel, &ConnectionPanel::onRadioUpdated);
@@ -276,30 +288,12 @@ void MainWindow::wireDiscovery()
     // the audio engine and main window are fully up first.
     QTimer::singleShot(0, this, [this] { startKissTncOnStartupIfConfigured(); });
 
-    // Auto-connect: when a radio is discovered, check if it matches the last one
+    // Auto-connect: when a radio is discovered, check if it matches the last one.
+    // Wired to the Flex discovery here; the HL2 sweep is wired to the SAME slot
+    // where Hl2Discovery is set up above, so both families honour the
+    // "Auto-reconnect to last radio" setting.
     connect(&m_discovery, &RadioDiscovery::radioDiscovered,
-            this, [this](const RadioInfo& info) {
-        if (m_userDisconnected) return;
-        if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
-            return;
-        const QString lastSerial = AppSettings::instance()
-            .value("LastConnectedRadioSerial").toString();
-        if (!lastSerial.isEmpty() && info.serial == lastSerial
-            && !m_radioModel.isConnected()) {
-            QList<quint32> disconnectHandles;
-            if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
-                m_userDisconnected = true;
-                m_connPanel->setStatusText("Connection canceled");
-                setPanadapterConnectionAnimation(false);
-                return;
-            }
-            m_radioModel.setPendingClientDisconnects(disconnectHandles);
-            qDebug() << "Auto-connecting to" << info.displayName();
-            m_connPanel->setStatusText("Auto-connecting…");
-            setPanadapterConnectionAnimation(true, "Connecting to radio…");
-            m_radioModel.connectToRadio(info);
-        }
-    });
+            this, &MainWindow::maybeAutoConnectToDiscoveredRadio);
     connect(m_connPanel, &ConnectionPanel::disconnectRequested,
             this, [this]{
         m_userDisconnected = true;
@@ -424,6 +418,44 @@ void MainWindow::wireDiscovery()
             setPanadapterConnectionAnimation(false);
     });
 
+}
+
+void MainWindow::maybeAutoConnectToDiscoveredRadio(const RadioInfo& info)
+{
+    if (m_userDisconnected) return;
+    if (m_radioModel.isConnected()) return;
+    if (AppSettings::instance().value("AutoConnectToLastRadio", "True").toString() != "True")
+        return;
+    const QString lastSerial = AppSettings::instance()
+        .value("LastConnectedRadioSerial").toString();
+    if (lastSerial.isEmpty() || info.serial != lastSerial)
+        return;
+
+    // Fail closed on a busy non-Flex radio, matching the manual connect gate in
+    // ConnectionPanel (#4448): HPSDR Protocol 1 is single-client, so connecting to
+    // an HL2 that is already streaming wedges both clients. Say so instead of
+    // silently doing nothing — this is the startup path, and the operator is
+    // staring at "Looking for your radio…".
+    if (info.inUse && info.family.compare(QLatin1String("flex"), Qt::CaseInsensitive) != 0) {
+        m_connPanel->setStatusText(
+            QStringLiteral("%1 is already in use by another client and can't be shared.")
+                .arg(info.model));
+        setPanadapterConnectionAnimation(false);
+        return;
+    }
+
+    QList<quint32> disconnectHandles;
+    if (!confirmClientSlotAvailability(info, &disconnectHandles)) {
+        m_userDisconnected = true;
+        m_connPanel->setStatusText("Connection canceled");
+        setPanadapterConnectionAnimation(false);
+        return;
+    }
+    m_radioModel.setPendingClientDisconnects(disconnectHandles);
+    qDebug() << "Auto-connecting to" << info.displayName();
+    m_connPanel->setStatusText("Auto-connecting…");
+    setPanadapterConnectionAnimation(true, "Connecting to radio…");
+    m_radioModel.connectToRadio(info);
 }
 
 void MainWindow::wireRadioModel()

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -207,6 +207,20 @@ void MainWindow::wireDiscovery()
             m_connPanel, &ConnectionPanel::onRadioUpdated);
     connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioLost,
             m_connPanel, &ConnectionPanel::onRadioLost);
+    // A radio that left discovery altogether gets its auto-connect attempts
+    // back. Power-cycling the radio is the operator's natural way of clearing a
+    // run of failures, and it should not require restarting the app.
+    //
+    // The in-flight serial is released here too. Every connect we start should
+    // end in connected() or connectionError(), but if one ever does neither the
+    // serial would latch and auto-connect would be dead for that radio until
+    // restart. The radio vanishing is unambiguous, so use it to let go.
+    connect(&m_hl2Discovery, &hl2::Hl2Discovery::radioLost, this,
+            [this](const QString& serial) {
+                m_autoConnectAttempts.remove(serial);
+                if (m_autoConnectSerial == serial)
+                    m_autoConnectSerial.clear();
+            });
     // "Auto-reconnect to last radio" used to be wired to the Flex RadioDiscovery
     // only, so an HL2 owner watched their radio appear in the picker and then had
     // to click it by hand at every launch. The HL2 sweep feeds the same slot.
@@ -235,6 +249,14 @@ void MainWindow::wireDiscovery()
     });
     connect(&m_discovery, &RadioDiscovery::radioLost,
             m_connPanel, &ConnectionPanel::onRadioLost);
+    // Same reset for the Flex sweep — the slot is family-agnostic, so its
+    // bookkeeping is too.
+    connect(&m_discovery, &RadioDiscovery::radioLost, this,
+            [this](const QString& serial) {
+                m_autoConnectAttempts.remove(serial);
+                if (m_autoConnectSerial == serial)
+                    m_autoConnectSerial.clear();
+            });
     connect(m_connPanel, &ConnectionPanel::retryDiscoveryRequested, this, [this] {
         m_connPanel->setStatusText("Searching your local network…");
         if (m_titleBar) m_titleBar->setDiscovering(true);
@@ -431,6 +453,37 @@ void MainWindow::maybeAutoConnectToDiscoveredRadio(const RadioInfo& info)
     if (lastSerial.isEmpty() || info.serial != lastSerial)
         return;
 
+    // AN AUTO-CONNECT WE STARTED IS ALREADY IN FLIGHT FOR THIS RADIO.
+    //
+    // Everything below would re-enter our own handshake, and the busy gate in
+    // particular would misread OUR OWN stream as a competing client: the radio
+    // starts answering discovery with 0x03 the moment it is told to start, while
+    // isConnected() stays false until the first EP6 packet arrives (Hl2Backend
+    // sets m_connected on linkUp, not on connectRadio). That window is the whole
+    // Metis handshake, so without this guard a normal connect reports "already in
+    // use by another client" about itself and kills its own connecting overlay.
+    if (!m_autoConnectSerial.isEmpty() && info.serial == m_autoConnectSerial)
+        return;
+
+    // BOUNDED RETRY — this slot now has a signal that repeats behind it.
+    //
+    // radioUpdated fires on every status CHANGE, and our own attempt is what
+    // produces those changes: starting the stream flips the radio to In_Use,
+    // tearing it down flips it back to Available. So a radio that never completes
+    // a handshake re-triggers this slot indefinitely — roughly every two
+    // discovery sweeps — and each pass overwrites the real error with
+    // "Auto-connecting…", so the operator never gets to read why it failed.
+    //
+    // The Flex path could not do this: radioDiscovered fires once per appearance.
+    // Adding radioUpdated is what made a latch necessary.
+    //
+    // Counted per serial and reset on a successful connect or when the radio
+    // leaves discovery entirely (radioLost) — a radio that was power-cycled
+    // deserves a fresh set of attempts, and that is also the operator's way of
+    // clearing this without restarting the app.
+    if (m_autoConnectAttempts.value(info.serial) >= kMaxAutoConnectAttempts)
+        return;
+
     // Fail closed on a busy non-Flex radio, matching the manual connect gate in
     // ConnectionPanel (#4448): HPSDR Protocol 1 is single-client, so connecting to
     // an HL2 that is already streaming wedges both clients. Say so instead of
@@ -455,7 +508,24 @@ void MainWindow::maybeAutoConnectToDiscoveredRadio(const RadioInfo& info)
     qDebug() << "Auto-connecting to" << info.displayName();
     m_connPanel->setStatusText("Auto-connecting…");
     setPanadapterConnectionAnimation(true, "Connecting to radio…");
+    // Claim the attempt BEFORE handing off. connectToRadio() can emit
+    // synchronously, so setting this afterwards would leave the window it exists
+    // to close.
+    m_autoConnectSerial = info.serial;
     m_radioModel.connectToRadio(info);
+}
+
+void MainWindow::noteAutoConnectFinished(bool ok)
+{
+    if (m_autoConnectSerial.isEmpty())
+        return;   // a manual connect — this bookkeeping is not ours to touch
+    const QString serial = m_autoConnectSerial;
+    m_autoConnectSerial.clear();
+    if (ok) {
+        m_autoConnectAttempts.remove(serial);
+    } else {
+        ++m_autoConnectAttempts[serial];
+    }
 }
 
 void MainWindow::wireRadioModel()


### PR DESCRIPTION
## The bug

"Auto-reconnect to last radio" does nothing on a Hermes-Lite 2. Every launch,
the operator watches the HL2 appear in the connect list and then has to click it
by hand, with **"Looking for your radio…"** on screen the whole time.

## Root cause

Saved-radio autoconnect was an inline lambda wired to exactly one signal:

```cpp
connect(&m_discovery, &RadioDiscovery::radioDiscovered, this, [this](const RadioInfo& info) { … });
```

`m_discovery` is the **Flex** discovery — TCP/4992 broadcast listener. An HL2
never appears there. It arrives on a completely separate sweep,
`hl2::Hl2Discovery`, which broadcasts HPSDR Protocol 1 discovery on UDP/1024,
and whose `radioDiscovered` was connected to the connect-list slots and nothing
else. Everything else on the path already worked — the HL2 connect saves
`LastConnectedRadioSerial` like any other family, the startup "Looking for your
radio…" status is family-blind — so the radio was found, matched nothing, and
sat there.

## The fix

Extract the lambda into `MainWindow::maybeAutoConnectToDiscoveredRadio()` and
connect **both** discovery sources to it. The slot is family-agnostic on
purpose: wiring autoconnect to a single discovery object is exactly what caused
this, and any future backend that grows its own sweep now gets it for free.

Two behaviours the shared slot adds, both HL2-specific concerns that the
Flex-only lambda never had to think about:

- **Fail closed on a busy non-Flex radio**, matching the manual-connect gate in
  `ConnectionPanel` (#4448). Protocol 1 is single-client; connecting to an HL2
  already streaming to somebody else wedges both clients. It now says so in the
  status line rather than silently doing nothing — this is the startup path and
  the operator is staring at a spinner.
- **Listen to `Hl2Discovery::radioUpdated` too**, not just `radioDiscovered`. A
  radio first seen `In_Use` flips to `Available` via `radioUpdated` when the
  other client drops. Without it the saved radio stays unconnected until it ages
  out of the sweep entirely and comes back.

Flex behaviour is unchanged: same conditions, same order, same status strings —
just reached through a named method instead of an inline lambda.

## Verification — real hardware

Hermes-Lite 2 at `00:1C:C0:A2:13:DD`, gateware 74, answering discovery with
status `0x02` (idle) throughout. `AutoConnectToLastRadio=True` and that MAC
already saved as `LastConnectedRadioSerial` — i.e. the reporter's exact
configuration, untouched between the two runs.

| Build | Result |
|---|---|
| `main` @ `2f72b30` | **No autoconnect within 45 s.** App sat in "Looking for your radio…"; log shows only the Flex `RadioDiscovery` re-bind loop running out its 12 attempts. Connecting required a manual click. |
| This branch | **Connects on its own at startup**, no interaction. Confirmed over four consecutive launches. |

## Notes for review

- No screenshot: the observable change is the *absence* of a manual step, and
  the after-state is the ordinary connected main window.
- `confirmClientSlotAvailability()` is a no-op for HL2 — `guiClientHandles` is
  never populated by `Hl2Discovery`, so `buildDisconnectClients()` returns empty
  and it short-circuits to `true`. No dialog can appear on the HL2 path.
- Does **not** address routed/off-subnet HL2s: `Hl2Discovery::sweepNow()` only
  broadcasts, and the startup `LastRoutedRadioIp` probe is a Flex TCP probe. An
  HL2 reached by "Connect by IP" across a subnet still won't autoconnect. That
  wants a unicast HL2 probe and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)