### PR TITLE
Run ASR GPU discovery off the UI thread

### DIFF
--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -10,6 +10,7 @@
 #include "asr/RemoteAsrBackend.h"
 #include "asr/SherpaOnnxBackend.h"
 #include "asr/WhisperAsrBackend.h"
+#include "core/LogManager.h"
 #include "core/ThemeManager.h"
 #include "gui/AsrAudioTap.h"
 
@@ -30,15 +31,18 @@
 #include <QSignalBlocker>
 #include <QStandardPaths>
 #include <QTextStream>
+#include <QTimer>
 #include <QtConcurrent/QtConcurrentRun>
 
 #include <algorithm>
+#include <exception>
 
 namespace {
 
 constexpr const char* kRemoteTierId = "remote";
 constexpr const char* kCustomTierId = "custom";
 constexpr const char* kSherpaTierId = "sherpa";
+constexpr int kGpuDiscoveryTimeoutMs = 30000;
 
 // Map a 1–100 "sensitivity" (higher = more sensitive) to the VAD's RMS energy
 // threshold (lower = more sensitive), spanning a practical HF-voice range.
@@ -221,6 +225,9 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     });
     connect(m_settings, &CopyAssistSettingsDialog::tierChanged, this, &CopyAssistController::onTierChanged);
     connect(m_settings, &CopyAssistSettingsDialog::gpuChanged, this, [this](int index) {
+        if (index == CopyAssistSettingsDialog::kGpuDiscoveryPending) {
+            return;
+        }
         m_gpuDevice = index;
         saveInt("AsrGpuDevice", index);
         if (m_backend != AsrBackendKind::Remote) {
@@ -429,43 +436,86 @@ void CopyAssistController::startGpuDiscovery()
     auto* watcher = new QFutureWatcher<std::vector<AsrGpuDevice>>(this);
     connect(watcher, &QFutureWatcher<std::vector<AsrGpuDevice>>::finished,
             this, [this, watcher] {
-                applyGpuDevices(watcher->result());
+                std::vector<AsrGpuDevice> devices;
+                try {
+                    devices = watcher->result();
+                } catch (const std::exception& error) {
+                    qCWarning(lcGui) << "ASR compute-device discovery failed:"
+                                     << error.what();
+                } catch (...) {
+                    qCWarning(lcGui) << "ASR compute-device discovery failed";
+                }
+                if (m_gpuDiscoveryPending) {
+                    applyGpuDevices(devices);
+                }
                 watcher->deleteLater();
             });
     watcher->setFuture(QtConcurrent::run([] { return asrGpuDevices(); }));
+
+    QTimer::singleShot(kGpuDiscoveryTimeoutMs, this, [this] {
+        if (!m_gpuDiscoveryPending) {
+            return;
+        }
+        qCWarning(lcGui) << "ASR compute-device discovery timed out after"
+                         << kGpuDiscoveryTimeoutMs << "ms; using CPU for this session";
+        applyGpuDevices({});
+    });
 }
 
 void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus)
 {
-    if (!gpus.empty()) {
-        // Adding the first combo item changes its current index. Suppress the
-        // dialog's outward gpuChanged/tierChanged signals while this initial,
-        // discovered state is populated so we do not rebuild the idle engine.
+    const int previousDevice = m_gpuDevice;
+    int resolvedDevice = previousDevice;
+    bool persistResolvedDevice = false;
+
+    // Adding or clearing combo items changes its current index. Suppress the
+    // dialog's outward gpuChanged/tierChanged signals while discovery state is
+    // applied so the controller, rather than incidental combo transitions,
+    // decides whether the engine needs rebuilding.
+    {
         const QSignalBlocker blocker(m_settings);
         m_settings->clearGpuDevices();
-        for (const AsrGpuDevice& gpu : gpus) {
-            m_settings->addGpuDevice(gpu.index, gpu.name);
-        }
-        m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
 
-        int saved = m_gpuDevice;
-        if (saved != -1 && (saved < 0 || saved >= static_cast<int>(gpus.size()))) {
-            saved = 0;
-        }
-        m_gpuDevice = saved;
-        m_settings->setCurrentGpu(saved);
-        m_settings->setGpuSelectorVisible(true);
-        m_settings->setGpuSelectorEnabled(true);
+        if (!gpus.empty()) {
+            for (const AsrGpuDevice& gpu : gpus) {
+                m_settings->addGpuDevice(gpu.index, gpu.name);
+            }
+            m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
 
-        // Preserve the existing GPU-host default, but only while the operator
-        // has not made an explicit model choice during the background probe.
-        if (m_useGpuDefaultIfAvailable) {
-            m_tierId = QStringLiteral("large-v3-turbo");
-            m_settings->setCurrentTier(m_tierId);
+            if (resolvedDevice != -1
+                && (resolvedDevice < 0
+                    || resolvedDevice >= static_cast<int>(gpus.size()))) {
+                resolvedDevice = 0;
+                persistResolvedDevice = true;
+            }
+            m_settings->setCurrentGpu(resolvedDevice);
+            m_settings->setGpuSelectorVisible(true);
+            m_settings->setGpuSelectorEnabled(true);
+
+            // Preserve the existing GPU-host default, but only while the
+            // operator has not made an explicit model choice during the probe.
+            if (m_useGpuDefaultIfAvailable) {
+                m_tierId = QStringLiteral("large-v3-turbo");
+                m_settings->setCurrentTier(m_tierId);
+            }
+        } else {
+            // A failed, timed-out, or CPU-only probe must not trigger the same
+            // registry initialization again from Whisper's worker. Force CPU
+            // for this session, but keep the saved GPU preference so a later
+            // launch can retry discovery.
+            resolvedDevice = -1;
+            m_settings->setGpuSelectorEnabled(false);
+            m_settings->setGpuSelectorVisible(false);
         }
-    } else {
-        // Preserve the existing CPU-only presentation once discovery resolves.
-        m_settings->setGpuSelectorVisible(false);
+    }
+
+    m_gpuDevice = resolvedDevice;
+    if (persistResolvedDevice) {
+        saveInt("AsrGpuDevice", resolvedDevice);
+    }
+    if (resolvedDevice != previousDevice && m_backend == AsrBackendKind::Whisper) {
+        m_tap->setEnabled(false);
+        buildEngine();
     }
 
     m_gpuDiscoveryPending = false;

--- a/src/gui/CopyAssistController.cpp
+++ b/src/gui/CopyAssistController.cpp
@@ -24,10 +24,13 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QFormLayout>
+#include <QFutureWatcher>
 #include <QLineEdit>
 #include <QObject>
+#include <QSignalBlocker>
 #include <QStandardPaths>
 #include <QTextStream>
+#include <QtConcurrent/QtConcurrentRun>
 
 #include <algorithm>
 
@@ -128,8 +131,11 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
                                  tr("Sherpa: %1").arg(QDir(m_sherpaModelDir).dirName()));
     }
 
-    // Initial backend: remote if previously configured+enabled, else the
-    // GPU-class model when a GPU exists, else the platform default.
+    // Initial backend: remote if previously configured+enabled, otherwise use
+    // the platform default until the asynchronous GPU probe completes. On
+    // macOS the first ggml device query can compile the embedded Metal shader
+    // library and take many seconds, so it must never run in this GUI-thread
+    // constructor.
     const bool remoteConfigured =
         CopyAssistSettings::value(QStringLiteral("AsrRemoteEnabled"), QStringLiteral("False"))
                 .toString() == QStringLiteral("True")
@@ -139,8 +145,13 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_tierId = QString::fromLatin1(kRemoteTierId);
     } else {
         m_backend = AsrBackendKind::Whisper;
-        m_tierId = asrGpuAvailable() ? QStringLiteral("large-v3-turbo")
-                                     : AsrModelCatalog::defaultTierId();
+        m_tierId = AsrModelCatalog::defaultTierId();
+        m_useGpuDefaultIfAvailable = true;
+    }
+    const QString savedGpu =
+        CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QString()).toString();
+    if (!savedGpu.isEmpty()) {
+        m_gpuDevice = savedGpu.toInt(); // an explicit compute-device choice always wins
     }
     m_settings->setCurrentTier(m_tierId);
 
@@ -169,23 +180,6 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     // The ⚙ glyph renders taller than the text buttons; pin the gear to the
     // Enabled button's height so the row stays flush.
     m_panel->settingsButton()->setFixedHeight(m_panel->enableButton()->sizeHint().height());
-
-    // Compute-device selector — shown whenever a GPU exists, so the user can pick
-    // a GPU (or several) or force CPU. Hidden on GPU-less hosts (always CPU).
-    const std::vector<AsrGpuDevice> gpus = asrGpuDevices();
-    if (!gpus.empty()) {
-        for (const AsrGpuDevice& g : gpus) {
-            m_settings->addGpuDevice(g.index, g.name);
-        }
-        m_settings->addGpuDevice(-1, tr("CPU")); // force-CPU option
-        int saved =
-            CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0")).toString().toInt();
-        if (saved != -1 && (saved < 0 || saved >= static_cast<int>(gpus.size()))) {
-            saved = 0;
-        }
-        m_settings->setCurrentGpu(saved);
-        m_settings->setGpuSelectorVisible(true);
-    }
 
     // Language selector — every language the whisper build supports.
     // Multilingual models honor it; English-only models ignore it. (The
@@ -227,12 +221,13 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
     });
     connect(m_settings, &CopyAssistSettingsDialog::tierChanged, this, &CopyAssistController::onTierChanged);
     connect(m_settings, &CopyAssistSettingsDialog::gpuChanged, this, [this](int index) {
+        m_gpuDevice = index;
         saveInt("AsrGpuDevice", index);
         if (m_backend != AsrBackendKind::Remote) {
             m_tap->setEnabled(false);
             buildEngine(); // rebuild the local engine on the chosen GPU
             if (m_enabled) {
-                beginEnable();
+                requestEnable();
             }
         }
     });
@@ -243,7 +238,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
         m_tap->setEnabled(false);
         buildEngine();
         if (m_enabled) {
-            beginEnable();
+            requestEnable();
         }
     });
 
@@ -394,6 +389,7 @@ CopyAssistController::CopyAssistController(AudioEngine* audio, CopyAssistPanel* 
 
     buildEngine();
     m_constructed = true; // subsequent VAD toggles may download/rebuild
+    startGpuDiscovery();
 }
 
 CopyAssistController::~CopyAssistController() = default;
@@ -424,6 +420,61 @@ void CopyAssistController::setCurrentFrequency(double freqMhz)
     m_currentFreqMhz = freqMhz;
 }
 
+void CopyAssistController::startGpuDiscovery()
+{
+    // asrGpuDevices() initializes ggml's backend registry. With the embedded
+    // Metal source used by whisper.cpp that first call may synchronously invoke
+    // Apple's shader compiler for several seconds. Keep the panel immediately
+    // usable and deliver the result back on this controller's thread.
+    auto* watcher = new QFutureWatcher<std::vector<AsrGpuDevice>>(this);
+    connect(watcher, &QFutureWatcher<std::vector<AsrGpuDevice>>::finished,
+            this, [this, watcher] {
+                applyGpuDevices(watcher->result());
+                watcher->deleteLater();
+            });
+    watcher->setFuture(QtConcurrent::run([] { return asrGpuDevices(); }));
+}
+
+void CopyAssistController::applyGpuDevices(const std::vector<AsrGpuDevice>& gpus)
+{
+    if (!gpus.empty()) {
+        // Adding the first combo item changes its current index. Suppress the
+        // dialog's outward gpuChanged/tierChanged signals while this initial,
+        // discovered state is populated so we do not rebuild the idle engine.
+        const QSignalBlocker blocker(m_settings);
+        m_settings->clearGpuDevices();
+        for (const AsrGpuDevice& gpu : gpus) {
+            m_settings->addGpuDevice(gpu.index, gpu.name);
+        }
+        m_settings->addGpuDevice(-1, tr("CPU")); // explicit force-CPU option
+
+        int saved = m_gpuDevice;
+        if (saved != -1 && (saved < 0 || saved >= static_cast<int>(gpus.size()))) {
+            saved = 0;
+        }
+        m_gpuDevice = saved;
+        m_settings->setCurrentGpu(saved);
+        m_settings->setGpuSelectorVisible(true);
+        m_settings->setGpuSelectorEnabled(true);
+
+        // Preserve the existing GPU-host default, but only while the operator
+        // has not made an explicit model choice during the background probe.
+        if (m_useGpuDefaultIfAvailable) {
+            m_tierId = QStringLiteral("large-v3-turbo");
+            m_settings->setCurrentTier(m_tierId);
+        }
+    } else {
+        // Preserve the existing CPU-only presentation once discovery resolves.
+        m_settings->setGpuSelectorVisible(false);
+    }
+
+    m_gpuDiscoveryPending = false;
+    if (m_enableAfterGpuDiscovery && m_enabled) {
+        m_enableAfterGpuDiscovery = false;
+        requestEnable();
+    }
+}
+
 void CopyAssistController::buildEngine()
 {
     // Tear down any previous engine+tap (order: tap first — it references the
@@ -432,9 +483,6 @@ void CopyAssistController::buildEngine()
     m_tap = nullptr;
     delete m_asr;
 
-    const int gpuDevice =
-        CopyAssistSettings::value(QStringLiteral("AsrGpuDevice"), QStringLiteral("0"))
-            .toString().toInt();
     const QString language =
         CopyAssistSettings::value(QStringLiteral("AsrLanguage"), QStringLiteral("en"))
             .toString();
@@ -461,7 +509,7 @@ void CopyAssistController::buildEngine()
         m_asr = new AsrEngine(remoteAsrBackendFactory(readRemoteConfig()), segConfig, this);
         break;
     case AsrBackendKind::Whisper:
-        m_asr = new AsrEngine(whisperAsrBackendFactory(language, gpuDevice),
+        m_asr = new AsrEngine(whisperAsrBackendFactory(language, m_gpuDevice),
                               segConfig, this);
         break;
     case AsrBackendKind::SherpaOnnx:
@@ -513,8 +561,9 @@ void CopyAssistController::onEnableToggled(bool on)
     m_enabled = on;
     if (on) {
         m_lastFreqMarkerKey.clear(); // force a fresh start marker for this session
-        beginEnable();
+        requestEnable();
     } else {
+        m_enableAfterGpuDiscovery = false;
         m_tap->setEnabled(false);
         m_panel->setBusy(false);
         m_panel->setStatus(tr("Disabled"));
@@ -526,6 +575,8 @@ void CopyAssistController::onTierChanged(const QString& tierId)
     if (tierId == m_tierId) {
         return;
     }
+    m_useGpuDefaultIfAvailable = false;
+    m_enableAfterGpuDiscovery = false;
 
     if (tierId == QString::fromLatin1(kRemoteTierId)) {
         if (!promptRemoteConfig()) {
@@ -561,7 +612,7 @@ void CopyAssistController::onTierChanged(const QString& tierId)
 
     if (m_enabled) {
         m_tap->setEnabled(false);
-        beginEnable();
+        requestEnable();
     }
 }
 
@@ -609,6 +660,23 @@ void CopyAssistController::setBackend(AsrBackendKind kind, const QString& tierId
         m_tap->setEnabled(false);
         buildEngine();
     }
+}
+
+void CopyAssistController::requestEnable()
+{
+    if (m_backend == AsrBackendKind::Whisper && m_gpuDiscoveryPending) {
+        // Preserve the original compute device and model even if the operator
+        // clicks Enable immediately. Discovery continues off the GUI thread
+        // and activation resumes as soon as it finishes.
+        m_enableAfterGpuDiscovery = true;
+        m_panel->setBusy(true);
+        m_panel->setStatus(tr("Detecting compute device…"));
+        return;
+    }
+
+    m_enableAfterGpuDiscovery = false;
+    m_useGpuDefaultIfAvailable = false;
+    beginEnable();
 }
 
 void CopyAssistController::beginEnable()
@@ -842,7 +910,7 @@ void CopyAssistController::rebuildEngine()
     m_tap->setEnabled(false);
     buildEngine();
     if (m_enabled) {
-        beginEnable();
+        requestEnable();
     }
 }
 

--- a/src/gui/CopyAssistController.h
+++ b/src/gui/CopyAssistController.h
@@ -3,6 +3,8 @@
 #include <QObject>
 #include <QString>
 
+#include <vector>
+
 namespace AetherSDR {
 
 class AudioEngine;
@@ -12,6 +14,7 @@ class PersistentDialog;
 class AsrEngine;
 class AsrModelManager;
 class AsrAudioTap;
+struct AsrGpuDevice;
 struct AsrModelTier;
 
 // Which IAsrBackend the engine is currently built around. Selects the factory in
@@ -54,8 +57,11 @@ private slots:
     void onTierChanged(const QString& tierId);
 
 private:
+    void startGpuDiscovery();
+    void applyGpuDevices(const std::vector<AsrGpuDevice>& gpus);
     void buildEngine();  // (re)create the engine+tap for the current backend
     void applyTuning();  // push saved VAD tuning into the engine
+    void requestEnable(); // defer local Whisper until async GPU discovery finishes
     void beginEnable();
     void requestModel(const QString& tierId);
     bool promptRemoteConfig();  // edit + persist the remote endpoint; true if accepted
@@ -90,6 +96,10 @@ private:
     AsrModelManager* m_speakerModels = nullptr; // manager for the speaker-embedding model
     AsrAudioTap* m_tap = nullptr;
     bool m_constructed = false; // true after the initial buildEngine (guards restore)
+    bool m_useGpuDefaultIfAvailable = false; // cleared by any explicit tier choice
+    bool m_gpuDiscoveryPending = true;
+    bool m_enableAfterGpuDiscovery = false;
+    int m_gpuDevice = 0; // resolved default or explicit setting; -1 forces CPU
     QString m_tierId;
     QString m_customModelPath; // user-picked local model (for the "Custom model…" tier)
     QString m_sherpaModelDir;  // user-picked sherpa-onnx model directory

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -38,14 +38,15 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     m_gpu->setObjectName(QStringLiteral("CopyAssistGpuCombo"));
     m_gpu->setAccessibleName(tr("Copy Assist compute device"));
     m_gpu->setToolTip(tr("Which device runs the model (a GPU, or CPU)"));
+    m_gpu->addItem(tr("Detecting…"));
     connect(m_gpu, &QComboBox::currentIndexChanged, this,
             [this](int) { emit gpuChanged(currentGpu()); });
     m_gpuLabel = new QLabel(tr("Compute:"), this);
     form->addRow(m_gpuLabel, m_gpu);
-    // Hidden until the controller reports a GPU exists (CPU-only hosts show no
-    // device picker at all).
-    m_gpuLabel->hide();
-    m_gpu->hide();
+    // Device discovery can initialize Metal and compile its embedded shader
+    // library. Keep the row visible but inactive while that work runs off the
+    // GUI thread; CPU-only hosts hide it once discovery finishes.
+    setGpuSelectorEnabled(false);
 
     m_language = new QComboBox(this);
     m_language->setObjectName(QStringLiteral("CopyAssistLanguageCombo"));
@@ -196,6 +197,11 @@ void CopyAssistSettingsDialog::addGpuDevice(int index, const QString& name)
     m_gpu->addItem(name, index);
 }
 
+void CopyAssistSettingsDialog::clearGpuDevices()
+{
+    m_gpu->clear();
+}
+
 void CopyAssistSettingsDialog::setCurrentGpu(int index)
 {
     const int idx = m_gpu->findData(index);
@@ -213,6 +219,12 @@ void CopyAssistSettingsDialog::setGpuSelectorVisible(bool on)
 {
     m_gpuLabel->setVisible(on);
     m_gpu->setVisible(on);
+}
+
+void CopyAssistSettingsDialog::setGpuSelectorEnabled(bool on)
+{
+    m_gpuLabel->setEnabled(on);
+    m_gpu->setEnabled(on);
 }
 
 void CopyAssistSettingsDialog::addLanguage(const QString& code, const QString& name)

--- a/src/gui/CopyAssistSettingsDialog.cpp
+++ b/src/gui/CopyAssistSettingsDialog.cpp
@@ -38,7 +38,7 @@ CopyAssistSettingsDialog::CopyAssistSettingsDialog(QWidget* parent)
     m_gpu->setObjectName(QStringLiteral("CopyAssistGpuCombo"));
     m_gpu->setAccessibleName(tr("Copy Assist compute device"));
     m_gpu->setToolTip(tr("Which device runs the model (a GPU, or CPU)"));
-    m_gpu->addItem(tr("Detecting…"));
+    m_gpu->addItem(tr("Detecting…"), kGpuDiscoveryPending);
     connect(m_gpu, &QComboBox::currentIndexChanged, this,
             [this](int) { emit gpuChanged(currentGpu()); });
     m_gpuLabel = new QLabel(tr("Compute:"), this);
@@ -212,7 +212,9 @@ void CopyAssistSettingsDialog::setCurrentGpu(int index)
 
 int CopyAssistSettingsDialog::currentGpu() const
 {
-    return m_gpu->currentData().toInt();
+    bool ok = false;
+    const int index = m_gpu->currentData().toInt(&ok);
+    return ok ? index : kGpuDiscoveryPending;
 }
 
 void CopyAssistSettingsDialog::setGpuSelectorVisible(bool on)

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -24,6 +24,8 @@ namespace AetherSDR {
 class CopyAssistSettingsDialog : public PersistentDialog {
     Q_OBJECT
 public:
+    static constexpr int kGpuDiscoveryPending = -2;
+
     explicit CopyAssistSettingsDialog(QWidget* parent = nullptr);
 
     // Model tier selector (id + human label).

--- a/src/gui/CopyAssistSettingsDialog.h
+++ b/src/gui/CopyAssistSettingsDialog.h
@@ -32,11 +32,13 @@ public:
     void setTierLabel(const QString& id, const QString& label);
     QString currentTier() const;
 
-    // Compute-device selector — shown only when the controller finds a GPU.
+    // Compute-device selector — disabled during discovery and hidden on CPU-only hosts.
     void addGpuDevice(int index, const QString& name);
+    void clearGpuDevices();
     void setCurrentGpu(int index);
     int currentGpu() const;
     void setGpuSelectorVisible(bool on);
+    void setGpuSelectorEnabled(bool on);
 
     // Transcription-language selector (code + human label, e.g. "en"/"English").
     // The controller populates it from the whisper backend's supported list;

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -137,6 +137,8 @@ int main(int argc, char** argv)
                    && !gpuCombo->isEnabled()
                    && gpuCombo->currentText() == QStringLiteral("Detecting…"),
                "GPU combo shows a disabled discovery placeholder");
+        expect(dlg.currentGpu() == CopyAssistSettingsDialog::kGpuDiscoveryPending,
+               "discovery placeholder has a distinct non-device sentinel");
 
         dlg.clearGpuDevices();
         dlg.addGpuDevice(0, QStringLiteral("GPU0"));
@@ -150,6 +152,11 @@ int main(int argc, char** argv)
         expect(dlg.currentGpu() == -1, "setCurrentGpu selects the CPU sentinel");
         expect(!gpuSpy.isEmpty() && gpuSpy.last().at(0).toInt() == -1,
                "gpuChanged carries the device index");
+
+        dlg.clearGpuDevices();
+        dlg.setGpuSelectorVisible(false);
+        expect(gpuCombo->count() == 0 && !gpuCombo->isVisibleTo(&dlg),
+               "CPU-only resolution clears and hides the discovery placeholder");
     }
 
     // ---- Language selector: round-trip, signal, paired visibility ---------

--- a/tests/copy_assist_settings_dialog_test.cpp
+++ b/tests/copy_assist_settings_dialog_test.cpp
@@ -130,18 +130,23 @@ int main(int argc, char** argv)
                "setTierLabel renames the entry, keeps its id");
     }
 
-    // ---- Compute-device selector: hidden by default, shows + emits --------
+    // ---- Compute-device selector: pending state, discovery, selection -----
     {
         auto* gpuCombo = dlg.findChild<QComboBox*>(QStringLiteral("CopyAssistGpuCombo"));
-        expect(gpuCombo != nullptr && !gpuCombo->isVisibleTo(&dlg),
-               "GPU combo hidden until a device exists");
+        expect(gpuCombo != nullptr && gpuCombo->isVisibleTo(&dlg)
+                   && !gpuCombo->isEnabled()
+                   && gpuCombo->currentText() == QStringLiteral("Detecting…"),
+               "GPU combo shows a disabled discovery placeholder");
 
+        dlg.clearGpuDevices();
         dlg.addGpuDevice(0, QStringLiteral("GPU0"));
         dlg.addGpuDevice(-1, QStringLiteral("CPU"));
         dlg.setGpuSelectorVisible(true);
+        dlg.setGpuSelectorEnabled(true);
 
         QSignalSpy gpuSpy(&dlg, &CopyAssistSettingsDialog::gpuChanged);
         dlg.setCurrentGpu(-1);
+        expect(gpuCombo->isEnabled(), "GPU combo enables when discovery completes");
         expect(dlg.currentGpu() == -1, "setCurrentGpu selects the CPU sentinel");
         expect(!gpuSpy.isEmpty() && gpuSpy.last().at(0).toInt() == -1,
                "gpuChanged carries the device index");


### PR DESCRIPTION
## Summary

Moves Copy Assist GPU discovery and Metal initialization off the Qt UI thread so opening the ASR panel no longer freezes the application or risks interrupting the radio connection. The panel now appears immediately with the Compute control disabled and showing `Detecting…`; once background discovery finishes, the available device options are populated and the control is enabled. Enabling ASR while discovery is still running defers model loading until discovery completes. Existing Apple GPU / Large v3 Turbo defaults and saved device selections remain unchanged.

Discovery exceptions and probes that exceed 30 seconds now log a warning and fall back to CPU for the current session, so ASR cannot remain stuck on `Detecting compute device…`. CPU-only results clear the placeholder, and stale saved GPU indices are reconciled with the discovered device list.

Active Apple GPU inference can still contend with Qt's Metal renderer and cause waterfall panning latency. That separately confirmed limitation is not changed by this PR.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The original first-click UI stall was reproduced and traced to synchronous whisper/ggml Metal initialization, then the asynchronous behavior was verified with focused tests and a live connected radio.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

### Local verification

- Built `AetherSDR` and `copy_assist_settings_dialog_test`.
- Passed the Copy Assist settings dialog test, including:
  - disabled `Detecting…` placeholder during discovery
  - a distinct non-device sentinel for the placeholder
  - device population when discovery completes
  - placeholder cleanup for CPU-only results
- Passed the focused ASR model manager, segmenter, engine, Whisper backend, and remote backend tests. The remote-backend test was run outside the sandbox because its mock server binds a loopback port.
- Passed `tools/check_engine_boundary.py --strict` with no blocking findings.
- Passed `git diff --check`.
- On a live connected radio, the ASR panel appeared in approximately 80 ms with no watchdog stall, disconnect, or transmit activity.

### Reproduction

1. Connect AetherSDR to a radio.
2. Start a fresh application process and click ASR in the bottom status bar.
3. Confirm the panel appears immediately.
4. Open Settings and confirm Compute is disabled and displays `Detecting…`.
5. Wait for discovery to complete and confirm the available compute device appears and the control becomes enabled.
6. Confirm the radio remains connected throughout.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — not applicable; no meter changes
- [x] Documentation updated if user-visible behavior changed — no documentation change required for the transient discovery status
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
