### PR TITLE
Fix band-recall slice race that can black out the waterfall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2837,6 +2837,14 @@ target_include_directories(center_lock_rebind_tracker_test PRIVATE src)
 target_link_libraries(center_lock_rebind_tracker_test PRIVATE Qt6::Core)
 add_test(NAME center_lock_rebind_tracker_test COMMAND center_lock_rebind_tracker_test)
 
+# Active-slice policy during FLEX band-stack teardown/rebuild — header-only.
+add_executable(band_recall_slice_selection_policy_test
+    tests/band_recall_slice_selection_policy_test.cpp
+)
+target_include_directories(band_recall_slice_selection_policy_test PRIVATE src)
+add_test(NAME band_recall_slice_selection_policy_test
+    COMMAND band_recall_slice_selection_policy_test)
+
 add_executable(declared_bands_test
     tests/declared_bands_test.cpp
     src/models/DeclaredBands.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2845,6 +2845,16 @@ target_include_directories(band_recall_slice_selection_policy_test PRIVATE src)
 add_test(NAME band_recall_slice_selection_policy_test
     COMMAND band_recall_slice_selection_policy_test)
 
+# When that policy applies — the window opened by an actually-dispatched
+# `display pan set <pan> band=` write. Header-only.
+add_executable(band_recall_selection_guard_test
+    tests/band_recall_selection_guard_test.cpp
+)
+target_include_directories(band_recall_selection_guard_test PRIVATE src)
+target_link_libraries(band_recall_selection_guard_test PRIVATE Qt6::Core)
+add_test(NAME band_recall_selection_guard_test
+    COMMAND band_recall_selection_guard_test)
+
 add_executable(declared_bands_test
     tests/declared_bands_test.cpp
     src/models/DeclaredBands.cpp

--- a/src/gui/BandRecallSelectionGuard.h
+++ b/src/gui/BandRecallSelectionGuard.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+#include <QtGlobal>
+
+#include <algorithm>
+#include <optional>
+
+namespace AetherSDR {
+
+// Owns the window during which radio-driven active-slice selection is treated
+// as synchronization-only (see BandRecallSliceSelectionPolicy.h for what that
+// decision is; this decides WHEN it applies).
+//
+// Deliberately separate from the Kiwi/Center Lock band-recall markers, which
+// share a fixed grace timer keyed on band-recall *intent*. Two properties this
+// window needs and that one cannot give it:
+//
+//   * It must not open when the band write never reached the wire. The
+//     dispatch signal fires immediately BEFORE sendCommand() so the KiwiSDR
+//     mute handoff can bracket the write, so a dropped write (foreign-owned
+//     pan, dead WAN session, profile-load hold backstop) would otherwise
+//     suppress selection for a reconstruction that is not happening.
+//     arm()/cancelArm() are an exact pair for that.
+//   * A fixed window is a guess at how long the radio takes to rebuild a pan's
+//     slices. Over SmartLink/WAN the rebuild can outrun it, and one late
+//     transient old-band active=1 after expiry is enough to recentre the pan
+//     back onto the old band — the exact failure this guards. refresh() pushes
+//     the window out on each piece of evidence that the rebuild is still
+//     running, bounded by the hard cap the arming recall set so a chatty
+//     session cannot hold the window open indefinitely.
+//
+// Pure policy — no timers, no widgets, no clock. The caller injects nowMs and
+// owns every side effect. Unit-tested in band_recall_selection_guard_test.
+class BandRecallSelectionGuard {
+public:
+    BandRecallSelectionGuard(int windowMs, int maxWindowMs)
+        : m_windowMs(windowMs)
+        , m_maxWindowMs(std::max(windowMs, maxWindowMs))
+    {
+    }
+
+    // A `display pan set <pan> band=` write is about to reach the wire. Opens
+    // the window, or extends one an earlier recall left live. Remembers what it
+    // replaced so cancelArm() can undo exactly this call.
+    void arm(const QString& panId, qint64 nowMs)
+    {
+        if (panId.isEmpty()) {
+            return;
+        }
+        prune(nowMs);
+
+        m_armedPanId = panId;
+        const auto existing = m_windows.constFind(panId);
+        m_armReplaced = (existing != m_windows.constEnd())
+            ? std::optional<Window>(*existing)
+            : std::nullopt;
+
+        Window window;
+        window.untilMs = nowMs + m_windowMs;
+        window.hardUntilMs = nowMs + m_maxWindowMs;
+        if (m_armReplaced) {
+            // An overlapping recall never shortens the window the previous one
+            // is still owed — the older rebuild may outlast the newer request.
+            window.untilMs = std::max(window.untilMs, m_armReplaced->untilMs);
+            window.hardUntilMs =
+                std::max(window.hardUntilMs, m_armReplaced->hardUntilMs);
+        }
+        m_windows.insert(panId, window);
+    }
+
+    // The write was not dispatched. Restores the state the matching arm()
+    // replaced — which is NOT the same as removing the window: an earlier
+    // successful recall on this pan may still be rebuilding, and its window
+    // must survive a later failed request.
+    void cancelArm(const QString& panId)
+    {
+        if (panId.isEmpty() || m_armedPanId != panId) {
+            return;
+        }
+        if (m_armReplaced) {
+            m_windows.insert(panId, *m_armReplaced);
+        } else {
+            m_windows.remove(panId);
+        }
+        m_armedPanId.clear();
+        m_armReplaced.reset();
+    }
+
+    // Evidence the radio is still rebuilding this pan (a slice was recreated,
+    // or a transient activation was just suppressed). No-op once the window has
+    // closed — a refresh can extend a live window, never reopen a closed one.
+    void refresh(const QString& panId, qint64 nowMs)
+    {
+        auto it = m_windows.find(panId);
+        if (it == m_windows.end()) {
+            return;
+        }
+        if (nowMs >= it->untilMs) {
+            m_windows.erase(it);
+            return;
+        }
+        it->untilMs = extended(*it, nowMs);
+    }
+
+    // A live slice removal is the same evidence, but arrives without a pan id:
+    // the slice has already left the model, so the caller cannot say which pan
+    // it was on. Refreshing every live window is the safe read — suppression
+    // only withholds a pan recentre and an active=1 echo, each window is still
+    // bounded by its own hard cap, and a pan with no live window is untouched.
+    void refreshAll(qint64 nowMs)
+    {
+        for (auto it = m_windows.begin(); it != m_windows.end();) {
+            if (nowMs >= it->untilMs) {
+                it = m_windows.erase(it);
+            } else {
+                it->untilMs = extended(*it, nowMs);
+                ++it;
+            }
+        }
+    }
+
+    bool isActive(const QString& panId, qint64 nowMs) const
+    {
+        const auto it = m_windows.constFind(panId);
+        return it != m_windows.constEnd() && nowMs < it->untilMs;
+    }
+
+private:
+    struct Window {
+        qint64 untilMs{0};
+        qint64 hardUntilMs{0};
+    };
+
+    // nowMs is wall-clock (QDateTime::currentMSecsSinceEpoch), so an NTP step
+    // backwards must not shorten a window that is already open — extending is
+    // monotonic, and the hard cap is the only thing that bounds it.
+    qint64 extended(const Window& window, qint64 nowMs) const
+    {
+        return std::max(window.untilMs,
+                        std::min(window.hardUntilMs, nowMs + m_windowMs));
+    }
+
+    void prune(qint64 nowMs)
+    {
+        for (auto it = m_windows.begin(); it != m_windows.end();) {
+            if (nowMs >= it->untilMs) {
+                it = m_windows.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    QHash<QString, Window> m_windows;
+    QString                m_armedPanId;
+    std::optional<Window>  m_armReplaced;
+    int                    m_windowMs{0};
+    int                    m_maxWindowMs{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/BandRecallSliceSelectionPolicy.h
+++ b/src/gui/BandRecallSliceSelectionPolicy.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace AetherSDR {
+
+// MainWindow reaches the active-slice setter from two radio-driven sources:
+// an explicit active=1 status and a topology fallback while slices are being
+// removed/recreated. Outside a band recall both retain their established
+// behavior. During a FLEX band-stack rebuild, neither may reveal the transient
+// slice or send active=1 back: either write can race the radio-authoritative
+// pan/slice reconstruction and undo the selected band.
+enum class RadioSliceSelectionSource {
+    ActiveStatus,
+    TopologyFallback,
+};
+
+struct RadioSliceSelectionDecision {
+    bool revealOffscreen{true};
+    bool suppressActiveCommand{false};
+};
+
+inline RadioSliceSelectionDecision radioSliceSelectionDecision(
+    bool bandRecallInFlight,
+    RadioSliceSelectionSource source)
+{
+    if (bandRecallInFlight) {
+        return {false, true};
+    }
+
+    return {
+        true,
+        source == RadioSliceSelectionSource::ActiveStatus,
+    };
+}
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -5975,10 +5975,10 @@ bool MainWindow::activateMemorySpot(int memoryIndex, const QString& preferredPan
                 emit bandStackRestoreStarting(slicePanId);
                 clearSwrSweepForBandChange(-1, slicePanId, memoryBand);
                 m_bandSettings.setCurrentBand(memoryBand);
-                noteBandRecallForPan(slicePanId);
                 // #4142: during the profile-load hold a bare sendCommand()
                 // band= write is silently destroyed and the recall lands on
-                // the wrong band stack. requestPanBand defers it instead.
+                // the wrong band stack. requestPanBand defers it instead; the
+                // dispatch signal starts the reconstruction guard at replay.
                 m_radioModel.requestPanBand(slicePanId, stackKeyResult.key);
                 QTimer::singleShot(300, this, [this, slicePanId]() {
                     reassertUnmutedSliceAudioForPan(slicePanId);
@@ -6218,11 +6218,11 @@ MainWindow::BandStackPreselectResult MainWindow::preselectBandStackForTune(
     emit bandStackRestoreStarting(slice->panId());
     clearSwrSweepForBandChange(-1, slice->panId(), targetBand);
     m_bandSettings.setCurrentBand(targetBand);
-    noteBandRecallForPan(slice->panId());
     // #4142: the cross-band typed tune is the reported bug's worst variant —
     // the `slice tune` half survives the hold while a bare sendCommand()
     // band= write is silently destroyed, so the slice lands outside the pan.
-    // requestPanBand defers the band-stack swap and replays it band-first.
+    // requestPanBand defers the band-stack swap and replays it band-first; the
+    // dispatch signal starts the reconstruction guard at replay.
     m_radioModel.requestPanBand(slice->panId(), stackKeyResult.key);
     QTimer::singleShot(300, this, [this, panId = slice->panId()]() {
         reassertUnmutedSliceAudioForPan(panId);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6456,8 +6456,16 @@ void MainWindow::setActiveSliceInternal(int sliceId, bool revealOffscreen)
     // (m_updatingFromModel is set in the activeChanged handler). During profile
     // recall, RadioModel's profile-load hold suppresses this radio write so we
     // do not dirty the radio's restoring GUIClient session.
-    if (sliceId != prevId && !m_updatingFromModel)
+    if (sliceId != prevId && !m_updatingFromModel) {
+        // setActive() emits activeChanged(true) synchronously before the wire
+        // write (#3854 optimistic edge), re-entering the activeChanged handler
+        // for a selection we are already performing. Mark the slice so that
+        // handler can drop exactly this echo and nothing else.
+        const int previousEdgeSliceId = m_optimisticActiveEdgeSliceId;
+        m_optimisticActiveEdgeSliceId = sliceId;
         s->setActive(true);
+        m_optimisticActiveEdgeSliceId = previousEdgeSliceId;
+    }
 
     // Update RX EQ filter-cutoff guides whenever the active slice swaps —
     // the new slice may have a different mode / filter shape.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -19,6 +19,7 @@
 #include "core/RadioDiscovery.h"
 #include "core/AudioEngine.h"
 #include "core/ReceivePresentationSync.h"
+#include "gui/BandRecallSelectionGuard.h"  // band-recall slice-selection window
 #include "gui/CenterLockRebindTracker.h"
 #include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
 #include "core/CatPort.h"
@@ -1078,6 +1079,15 @@ private:
     QHash<QString, quint64> m_bandRecallGenerationByPan;
     quint64              m_bandRecallGeneration{0};
     static constexpr int kBandRecallRecreateGraceMs = 1500;
+    // Upper bound on the extended slice-selection window. The base window is
+    // the grace period above; reconstruction evidence pushes it out, but never
+    // past this, so a chatty session can't hold selection suppressed.
+    static constexpr int kBandRecallSelectionGuardMaxMs = 4000;
+    // When radio-driven active-slice selection is synchronization-only. Not
+    // m_bandRecallGenerationByPan: this window must not open when the band
+    // write is dropped, and must outlast a slow rebuild. See the header.
+    BandRecallSelectionGuard m_bandRecallSelection{
+        kBandRecallRecreateGraceMs, kBandRecallSelectionGuardMaxMs};
     ReceivePresentationSync m_receivePresentationSync;
     ReceiveAudioDelayEstimator m_receiveAudioDelayEstimator;
     ReceivePresentationQueue<std::function<void()>> m_receivePresentationVisualQueue;
@@ -1219,6 +1229,13 @@ private:
     // Guard: set true while updating controls from the model so shared tune
     // helpers do not echo model-driven changes back to the radio.
     bool m_updatingFromModel{false};
+    // The slice whose optimistic activeChanged(true) edge we are inside of.
+    // SliceModel::setActive() emits that edge synchronously, before the wire
+    // write (#3854), so the activeChanged handler re-enters on our own local
+    // selection. Identifying it by slice id — rather than by "the id already
+    // equals m_activeSliceId" — keeps a genuinely radio-originated
+    // re-activation of the already-selected slice a real selection event.
+    int  m_optimisticActiveEdgeSliceId{-1};
     bool m_shuttingDown{false};
     bool m_panadapterUiPreparedForShutdown{false};
     void preparePanadapterUiForShutdown();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -98,6 +98,8 @@ class QSystemTrayIcon;
 
 namespace AetherSDR {
 
+enum class RadioSliceSelectionSource;
+
 class AetherClockApplet;
 class AetherClockEngine;
 class AetherClockModel;
@@ -378,6 +380,9 @@ private:
     SpectrumWidget* spectrum() const;
     void setActiveSlice(int sliceId);
     void setActiveSliceInternal(int sliceId, bool revealOffscreen);
+    void selectSliceFromRadioState(
+        SliceModel* slice,
+        RadioSliceSelectionSource source);
     void queueActiveSliceForSpectrumTarget(int sliceId);
     void updateFilterLimitsForMode(const QString& mode);
     void centerActiveSliceInPanadapter(bool forceRadioCenter, double centerMhz = -1.0);

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -687,9 +687,9 @@ void MainWindow::prepareKiwiSdrBandRecallForPan(const QString& panId)
 
     // A deferred request can supersede an older one for the same pan. Re-arm
     // any still-prepared slice before beginning the new atomic command pair.
-    // The #4158/Center Lock rebind marker (noteBandRecallForPan) is owned by the
-    // band-recall trigger sites, not here — this path only performs the #4209
-    // audio-mute handoff, bracketed around the actual wire dispatch.
+    // The #4158/Center Lock rebind marker (noteBandRecallForPan) is started by
+    // the same actual-dispatch signal. This path only performs the #4209
+    // audio-mute handoff around the wire command.
     finishPreparedKiwiSdrBandRecallForPan(panId);
 
     for (SliceModel* slice : m_radioModel.slices()) {

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -555,6 +555,12 @@ void MainWindow::wireRadioModel()
         // generation-guarded grace timer — don't clear it here or a concurrent
         // recall's #4158/Center Lock window could be torn down early.
         finishPreparedKiwiSdrBandRecallForPan(panId);
+        // The slice-selection window is the exception: it gates radio-driven
+        // selection, so leaving it armed would suppress reveal and the active
+        // echo for 1500 ms with no reconstruction to protect. cancelArm() undoes
+        // only this recall's arm — a still-live window from an earlier
+        // successful recall on the same pan is restored, not dropped.
+        m_bandRecallSelection.cancelArm(panId);
     });
     // Re-bind a KiwiSDR replacement across a band-stack slice recreation (#4158).
     // A band recall DROPS then RE-CREATES the slice (same id, new band). The

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -541,6 +541,10 @@ void MainWindow::wireRadioModel()
             this, &MainWindow::onSliceAdded);
     connect(&m_radioModel, &RadioModel::sliceRemoved,
             this, &MainWindow::onSliceRemoved);
+    // Start the reconstruction window at actual dispatch, not at UI intent:
+    // requestPanBand() can defer behind a profile-load hold.
+    connect(&m_radioModel, &RadioModel::panBandAboutToDispatch,
+            this, &MainWindow::noteBandRecallForPan);
     connect(&m_radioModel, &RadioModel::panBandAboutToDispatch,
             this, &MainWindow::prepareKiwiSdrBandRecallForPan);
     connect(&m_radioModel, &RadioModel::panBandDispatchFailed,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.h"
 
 #include "AetherDspWidget.h"
+#include "BandRecallSliceSelectionPolicy.h"
 #include "DisplayStatusGate.h"       // #4261 adaptive-throttle echo gate
 #include "Ax25HfPacketDecodeDialog.h"
 #include "AppletPanel.h"
@@ -289,6 +290,36 @@ void MainWindow::noteBandRecallForPan(const QString& panId)
                      "the locked slice could not be identified safely.")
                 : tr("The band change did not restore the locked slice."));
     });
+}
+
+void MainWindow::selectSliceFromRadioState(
+    SliceModel* slice,
+    RadioSliceSelectionSource source)
+{
+    if (!slice) {
+        return;
+    }
+
+    const bool bandRecallInFlight =
+        m_bandRecallGenerationByPan.contains(slice->panId());
+    const RadioSliceSelectionDecision decision =
+        radioSliceSelectionDecision(bandRecallInFlight, source);
+
+    if (bandRecallInFlight) {
+        qCDebug(lcProtocol).noquote()
+            << "MainWindow: band recall suppressing slice reveal"
+            << "pan=" << slice->panId()
+            << "slice=" << slice->sliceId()
+            << "source="
+            << (source == RadioSliceSelectionSource::ActiveStatus
+                    ? "active-status" : "topology-fallback");
+    }
+
+    const bool wasUpdatingFromModel = m_updatingFromModel;
+    m_updatingFromModel =
+        wasUpdatingFromModel || decision.suppressActiveCommand;
+    setActiveSliceInternal(slice->sliceId(), decision.revealOffscreen);
+    m_updatingFromModel = wasUpdatingFromModel;
 }
 
 void MainWindow::showCenterLockReleaseNotification(const QString& panId,
@@ -1580,7 +1611,8 @@ void MainWindow::onSliceAdded(SliceModel* s)
 
     // First slice — wire everything up
     if (firstSlice) {
-        setActiveSlice(s->sliceId());
+        selectSliceFromRadioState(
+            s, RadioSliceSelectionSource::TopologyFallback);
 
         // Detect initial band from radio's frequency
         if (m_bandSettings.currentBand().isEmpty())
@@ -1933,14 +1965,17 @@ void MainWindow::onSliceAdded(SliceModel* s)
         }
     });
 
-    // When the radio notifies us that this slice became active, switch to it
+    // When the radio notifies us that this slice became active, switch to it.
+    // During a band-stack rebuild this is synchronization-only: FLEX can
+    // transiently activate the surviving old-band slice, and revealing it
+    // would send a stale pan-center command that undoes the selected band.
     connect(s, &SliceModel::activeChanged, this, [this, s](bool active) {
         if (!active) return;
-        // Accept radio's active echo — update client state but use
-        // m_updatingFromModel to prevent sending active=1 back (feedback loop).
-        m_updatingFromModel = true;
-        setActiveSlice(s->sliceId());
-        m_updatingFromModel = false;
+        // A local selection updates m_activeSliceId before SliceModel emits its
+        // optimistic edge, so only a differing id is a radio-originated change.
+        if (s->sliceId() == m_activeSliceId) return;
+        selectSliceFromRadioState(
+            s, RadioSliceSelectionSource::ActiveStatus);
     });
 
     // Update filter limits when the active slice's mode changes
@@ -2288,9 +2323,11 @@ void MainWindow::onSliceRemoved(int id)
         if (auto* sw = spectrum()) sw->overlayMenu()->setSlice(nullptr);
 
         const auto& slices = m_radioModel.slices();
-        if (!slices.isEmpty())
-            setActiveSlice(slices.first()->sliceId());
-        else {
+        if (!slices.isEmpty()) {
+            selectSliceFromRadioState(
+                slices.first(),
+                RadioSliceSelectionSource::TopologyFallback);
+        } else {
             m_activeSliceId = -1;
             if (m_ax25HfPacketDecodeDialog)
                 m_ax25HfPacketDecodeDialog->setAttachedSlice(nullptr);
@@ -4489,20 +4526,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             emit bandStackRestoreStarting(applet->panId());
             clearSwrSweepForBandChange(-1, applet->panId(), bandName);
             m_bandSettings.setCurrentBand(bandName);
-            // A band recall makes the radio drop+re-create this pan's slice;
-            // mark the pan (positive band-recall intent) so onSliceAdded re-binds
-            // a KiwiSDR replacement onto the recreated slice instead of reverting
-            // to Flex (#4158). One-shot: consumed by the re-bind, or expired here
-            // so a recall on a non-Kiwi slice can't leave the marker stale.
-            noteBandRecallForPan(applet->panId());
             // #4142: during the profile-load hold a bare sendCommand() band=
-            // write is silently destroyed. requestPanBand defers it instead.
-            // Outside a hold it dispatches inline, so the #4158/Center Lock
-            // grace window inside noteBandRecallForPan is unchanged on the
-            // normal user-initiated band-recall path. The KiwiSDR audio-mute
-            // handoff (#4209) is driven separately by panBandAboutToDispatch, so
-            // it brackets the actual wire dispatch even when the band write is
-            // deferred by a profile-load hold.
+            // write is silently destroyed. requestPanBand defers it instead;
+            // panBandAboutToDispatch starts every slice/Center Lock/Kiwi recall
+            // guard immediately before the command actually reaches the wire.
             m_radioModel.requestPanBand(applet->panId(), stackKey);
             QTimer::singleShot(300, this, [this, panId = applet->panId()]() {
                 reassertUnmutedSliceAudioForPan(panId);

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -203,6 +203,10 @@ void MainWindow::noteBandRecallForPan(const QString& panId)
     // command. Restoration is deferred until the full grace window elapses so
     // slice status arrival order can never choose the receiver.
     m_kiwiRebind.noteBandRecall(panId);
+    // Open the radio-driven-selection window on the same edge. It is armed
+    // here and rolled back by panBandDispatchFailed, so unlike the markers
+    // around it, it never opens for a band write that never reached the wire.
+    m_bandRecallSelection.arm(panId, QDateTime::currentMSecsSinceEpoch());
     // Stamp this recall so the grace timer below only clears the Kiwi marker if
     // it is still the latest recall for this pan. Without it, an overlapping
     // recall (band button + memory spot / tune, now all routed here) would have
@@ -300,12 +304,17 @@ void MainWindow::selectSliceFromRadioState(
         return;
     }
 
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
     const bool bandRecallInFlight =
-        m_bandRecallGenerationByPan.contains(slice->panId());
+        m_bandRecallSelection.isActive(slice->panId(), nowMs);
     const RadioSliceSelectionDecision decision =
         radioSliceSelectionDecision(bandRecallInFlight, source);
 
     if (bandRecallInFlight) {
+        // A transient activation IS the radio still rebuilding this pan: hold
+        // the window open past it (bounded), so a rebuild slower than the base
+        // grace period can't land its last old-band activation just outside.
+        m_bandRecallSelection.refresh(slice->panId(), nowMs);
         qCDebug(lcProtocol).noquote()
             << "MainWindow: band recall suppressing slice reveal"
             << "pan=" << slice->panId()
@@ -1609,6 +1618,12 @@ void MainWindow::onSliceAdded(SliceModel* s)
     qDebug() << "MainWindow: slice added" << s->sliceId();
     const bool firstSlice = (m_activeSliceId < 0);
 
+    // A slice arriving on a pan with a live band-recall window is the radio
+    // still rebuilding that pan. Extend the window (bounded) before anything
+    // below consults it, so a rebuild slower than the base grace period stays
+    // covered end to end instead of only for its first 1500 ms.
+    m_bandRecallSelection.refresh(s->panId(), QDateTime::currentMSecsSinceEpoch());
+
     // First slice — wire everything up
     if (firstSlice) {
         selectSliceFromRadioState(
@@ -1971,9 +1986,13 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // would send a stale pan-center command that undoes the selected band.
     connect(s, &SliceModel::activeChanged, this, [this, s](bool active) {
         if (!active) return;
-        // A local selection updates m_activeSliceId before SliceModel emits its
-        // optimistic edge, so only a differing id is a radio-originated change.
-        if (s->sliceId() == m_activeSliceId) return;
+        // Drop only our own optimistic edge, which setActiveSliceInternal
+        // brands as it emits. Comparing against m_activeSliceId instead would
+        // also drop a radio-originated re-activation of the already-selected
+        // slice — another client toggling active away and back, or a profile
+        // load replaying status — and that must still resync the UI and
+        // reveal the slice, as it did before this guard existed.
+        if (s->sliceId() == m_optimisticActiveEdgeSliceId) return;
         selectSliceFromRadioState(
             s, RadioSliceSelectionSource::ActiveStatus);
     });
@@ -2214,6 +2233,13 @@ void MainWindow::onSliceRemoved(int id)
     // enters the grace path, so a stale prune can't later clear a live
     // assignment.
     const bool liveRemoval = !m_radioModel.slice(id);
+    // Same reconstruction evidence as onSliceAdded, but a live removal cannot
+    // name its pan — the slice has already left the model (see the comment on
+    // the overlay cleanup below). Refresh every live window; see
+    // BandRecallSelectionGuard::refreshAll for why that is the safe read.
+    if (liveRemoval) {
+        m_bandRecallSelection.refreshAll(QDateTime::currentMSecsSinceEpoch());
+    }
     const QString kiwiRebindProfile = (liveRemoval && m_kiwiSdrManager)
         ? m_kiwiSdrManager->assignedProfileForSlice(id) : QString();
     const auto rebindAction =

--- a/tests/band_recall_selection_guard_test.cpp
+++ b/tests/band_recall_selection_guard_test.cpp
@@ -1,0 +1,170 @@
+// Regression coverage for WHEN radio-driven active-slice selection is treated
+// as synchronization-only after a band recall. The decision itself is covered
+// by band_recall_slice_selection_policy_test; this pins the window, whose two
+// failure modes both put the waterfall back on the old band or suppress a
+// selection that was never racing anything:
+//   * opening it for a band write that never reached the wire, and
+//   * closing it while the radio is still rebuilding the pan.
+
+#include "gui/BandRecallSelectionGuard.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+constexpr int kWindowMs = 1500;
+constexpr int kMaxWindowMs = 4000;
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+BandRecallSelectionGuard makeGuard()
+{
+    return BandRecallSelectionGuard(kWindowMs, kMaxWindowMs);
+}
+
+}  // namespace
+
+int main()
+{
+    const QString pan = QStringLiteral("0x40000000");
+    const QString otherPan = QStringLiteral("0x40000001");
+
+    // Baseline: the window opens on dispatch and closes on its own.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        check(!guard.isActive(pan, 0), "idle: no window before a band write");
+        guard.arm(pan, 1000);
+        check(guard.isActive(pan, 1000), "armed: window is open at dispatch");
+        check(guard.isActive(pan, 2499), "armed: window covers the grace period");
+        check(!guard.isActive(pan, 2500), "armed: window closes at the grace edge");
+        check(!guard.isActive(otherPan, 1000),
+              "armed: window is per-pan, not global");
+    }
+
+    // The reported gap #1: `display pan set ... band=` is emitted before
+    // sendCommand(), so a dropped write (foreign-owned pan, dead WAN session)
+    // must not leave selection suppressed for a rebuild that never starts.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        guard.cancelArm(pan);
+        check(!guard.isActive(pan, 1000),
+              "dispatch failed: window does not open for an undispatched write");
+    }
+
+    // ...but a failed write must not tear down a still-live window that an
+    // earlier, successful recall on the same pan is still owed.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);      // succeeded
+        guard.arm(pan, 1200);      // superseding request, about to fail
+        guard.cancelArm(pan);
+        check(guard.isActive(pan, 1200),
+              "dispatch failed: earlier live window survives the rollback");
+        check(guard.isActive(pan, 2499),
+              "dispatch failed: rollback restores the earlier deadline exactly");
+        check(!guard.isActive(pan, 2500),
+              "dispatch failed: rollback does not extend the earlier deadline");
+    }
+
+    // A rollback must only ever undo its own arm.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        guard.cancelArm(otherPan);
+        check(guard.isActive(pan, 1000),
+              "dispatch failed: a different pan's rollback is a no-op");
+        guard.cancelArm(pan);
+        guard.cancelArm(pan);
+        check(!guard.isActive(pan, 1000),
+              "dispatch failed: a repeated rollback stays idempotent");
+    }
+
+    // The reported gap #2: over SmartLink/WAN the rebuild can outrun a fixed
+    // window, and one late old-band active=1 after expiry recentres the pan.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        guard.refresh(pan, 2400);   // a slice was recreated late in the rebuild
+        check(guard.isActive(pan, 2600),
+              "slow rebuild: reconstruction evidence extends the window");
+        check(!guard.isActive(pan, 3900),
+              "slow rebuild: the extension is still bounded by the grace period");
+    }
+
+    // The extension is capped, so a chatty session cannot hold selection
+    // suppressed indefinitely.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        for (qint64 nowMs = 1100; nowMs <= 4900; nowMs += 100) {
+            guard.refresh(pan, nowMs);
+        }
+        check(guard.isActive(pan, 4999),
+              "cap: the window does stay open right up to the hard cap");
+        check(!guard.isActive(pan, 5000),
+              "cap: continuous evidence cannot extend past the hard cap");
+    }
+
+    // A refresh extends a live window; it never reopens a closed one.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        guard.refresh(pan, 5000);
+        check(!guard.isActive(pan, 5000),
+              "expired: a late refresh cannot reopen a closed window");
+        guard.refreshAll(5100);
+        check(!guard.isActive(pan, 5100),
+              "expired: refreshAll cannot reopen a closed window either");
+    }
+
+    // A live slice removal arrives without a pan id, so it refreshes every live
+    // window — and must leave pans with no window alone.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 1000);
+        guard.refreshAll(2400);
+        check(guard.isActive(pan, 2600),
+              "slice removed: refreshAll extends the live window");
+        check(!guard.isActive(otherPan, 2600),
+              "slice removed: refreshAll opens no window on an untouched pan");
+    }
+
+    // nowMs is wall-clock, so an NTP step backwards mid-rebuild must not close
+    // a window early — that is the same late-activation failure by another name.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(pan, 4000);
+        guard.refresh(pan, 3000);
+        check(guard.isActive(pan, 5400),
+              "clock step: a backwards clock cannot shorten a live window");
+    }
+
+    // An empty pan id is the "no pan" sentinel MainWindow can hand us; it must
+    // never open a window that isActive("") would then report.
+    {
+        BandRecallSelectionGuard guard = makeGuard();
+        guard.arm(QString(), 1000);
+        check(!guard.isActive(QString(), 1000),
+              "empty pan: arming a pan-less recall is a no-op");
+    }
+
+    if (failures == 0) {
+        std::printf("\nAll band-recall selection-guard tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d band-recall selection-guard test(s) failed.\n", failures);
+    return 1;
+}

--- a/tests/band_recall_slice_selection_policy_test.cpp
+++ b/tests/band_recall_slice_selection_policy_test.cpp
@@ -1,0 +1,83 @@
+// Regression coverage for the active-slice command that could undo a FLEX
+// band-stack recall and leave the waterfall mapped to the wrong band.
+
+#include "gui/BandRecallSliceSelectionPolicy.h"
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name)
+{
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++failures;
+    }
+}
+
+void checkRecallDecision(RadioSliceSelectionSource source, const char* prefix)
+{
+    const RadioSliceSelectionDecision decision =
+        radioSliceSelectionDecision(true, source);
+    check(!decision.revealOffscreen, prefix);
+    check(decision.suppressActiveCommand,
+          source == RadioSliceSelectionSource::ActiveStatus
+              ? "active-before-removal: active echo is suppressed"
+              : "removal-before-active: fallback active command is suppressed");
+}
+
+}  // namespace
+
+int main()
+{
+    // The captured failure: FLEX first activated the surviving old-band slice.
+    checkRecallDecision(
+        RadioSliceSelectionSource::ActiveStatus,
+        "active-before-removal: old-band slice is not revealed");
+
+    // The inverse valid ordering must be safe too: removing the active slice
+    // first makes MainWindow choose a surviving slice as a topology fallback.
+    checkRecallDecision(
+        RadioSliceSelectionSource::TopologyFallback,
+        "removal-before-active: old-band fallback is not revealed");
+
+    // A recreated first slice can arrive before the target pan status. It is
+    // also topology synchronization and must not write speculative state.
+    const RadioSliceSelectionDecision recreatedFirst =
+        radioSliceSelectionDecision(
+            true, RadioSliceSelectionSource::TopologyFallback);
+    check(!recreatedFirst.revealOffscreen
+              && recreatedFirst.suppressActiveCommand,
+          "slice-before-pan-status: recreated first slice is synchronization-only");
+
+    // Outside a recall, an external/radio selection retains the established
+    // off-screen reveal but never echoes active=1 back to the radio.
+    const RadioSliceSelectionDecision externalSelect =
+        radioSliceSelectionDecision(
+            false, RadioSliceSelectionSource::ActiveStatus);
+    check(externalSelect.revealOffscreen
+              && externalSelect.suppressActiveCommand,
+          "external active status: reveal is preserved without feedback");
+
+    // Ordinary add/remove fallback behavior is unchanged outside a recall.
+    const RadioSliceSelectionDecision ordinaryFallback =
+        radioSliceSelectionDecision(
+            false, RadioSliceSelectionSource::TopologyFallback);
+    check(ordinaryFallback.revealOffscreen
+              && !ordinaryFallback.suppressActiveCommand,
+          "ordinary topology fallback: existing reveal and activation remain");
+
+    if (failures == 0) {
+        std::printf("\nAll band-recall slice-selection policy tests passed.\n");
+        return 0;
+    }
+    std::printf("\n%d band-recall slice-selection policy test(s) failed.\n",
+                failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Fix a band-recall race that could leave the panadapter and waterfall on the old radio band while the UI and active slice showed the newly selected band.

FLEX band persistence removes and recreates slices during a band change. During that reconstruction, the radio can transiently mark a surviving old-band slice active. AetherSDR treated that status as an ordinary selection and revealed the off-screen slice, sending a pan-center command that could undo the radio-authoritative band change. UDP and waterfall frames continued arriving, but the old-band tiles no longer overlapped the UI's new frequency range, producing a completely black waterfall.

This change:

- Starts the reconstruction guard when `display pan ... band=` is actually dispatched, including requests deferred by a profile-load hold.
- Treats active-slice status and topology fallback selection as synchronization-only during reconstruction.
- Prevents transient slices from recentering the pan or sending `active=1` feedback.
- Remains agnostic to whether the radio restores zero, one, or multiple slices.
- Preserves FFT and waterfall scrollback across band changes.
- Leaves ordinary slice selection and off-screen reveal behavior unchanged outside band recall.

The regression was diagnosed and live-tested from a clean, freshly fetched `upstream/main` at `2f72b30498c43e7881c387017b4fb70aa4d7f445`. Before publication, this branch was freshly rebased onto current `upstream/main` at `b007e0cc0bddf5c81cf70e46dba65db60fc53f59`; the sole intervening commit was v26.7.4.1 release preparation (#4519), which touched only the version line in `CMakeLists.txt`. The change is independent of the Copy Assist/ASR work.

## Regression lineage

This was an interaction regression, not intentional black-waterfall behavior.

- Commit [`04d81cd2`](https://github.com/aethersdr/AetherSDR/commit/04d81cd2e7dcee534813b7c0a9d8bb43c75f0d7e) for [#1093](https://github.com/aethersdr/AetherSDR/issues/1093) correctly made band changes radio-authoritative. Selecting a band began sending `display pan set <panId> band=<band>`, allowing the radio to remove and recreate slices from its persistence database.
- [PR #1555](https://github.com/aethersdr/AetherSDR/pull/1555) introduced automatic pan recentering whenever `setActiveSlice()` selected an off-screen slice. That was correct for an operator selecting an off-screen slice, but the same function also handled radio-originated `active=1` status. During band reconstruction, a transient old-band active status could therefore send a stale pan-center command and undo the band change. This is the PR that directly introduced the unsafe behavior.
- [PR #1861](https://github.com/aethersdr/AetherSDR/pull/1861) consolidated recentering under the shared `RevealOffscreen` policy and preserved the behavior from #1555. It did not introduce radio band persistence, but it carried forward the missing distinction between operator selection and radio-driven reconstruction.

This fix retains the intended behavior from all three changes: band state remains radio-authoritative, operator-selected off-screen slices are still revealed, and radio-driven slice reconstruction is synchronization-only until the band recall settles.

The Copy Assist/ASR changes are not in this regression's causal history.

## Constitution principle honored

Principle II — The Radio Is Authoritative On Live State. A band selection sends one radio-authoritative band command, and transient slice status cannot overwrite the panadapter state while the radio reconstructs its persisted topology.

Principle XI — Fixes Are Demonstrated. The ordering policy has focused regression coverage and was verified against a real FLEX-6700 using the RX-only automation bridge.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Current rebased branch validation:

- `cmake --build build --target AetherSDR band_recall_slice_selection_policy_test -j10`
- `ctest --test-dir build -R '^band_recall_slice_selection_policy_test$' --output-on-failure`
- Signed commit verified after rebase with `git log --show-signature -1`.

Pre-rebase validation on the clean diagnosis base:

- Passed focused band-recall, KiwiSDR rebind, Center Lock, profile-load ordering, waterfall-history, radio-status ownership, and slice-recreation tests.
- Full local CTest result: 191 passed and one intentionally quarantined test skipped.
- Ten tests initially blocked by sandbox display/socket restrictions all passed when rerun outside the sandbox.
- `tools/check_engine_boundary.py --strict` passed.
- `tools/check_a11y.py` passed with only existing baseline warnings.

Live RX-only verification:

1. Started with two app-owned slices on 40 m.
2. Selected 20 m through the UI.
3. Confirmed AetherSDR sent only `display pan set 0x40000000 band=20`.
4. Observed the radio transiently activate an old slice, remove both 40 m slices, move the panadapter and waterfall to 14.100 MHz, and recreate the persisted 20 m slice.
5. Confirmed no stale `display pan ... center=7...` command was emitted after the band command.
6. Confirmed the 3D trace and waterfall remained visible and updated on 20 m.
7. Confirmed TX remained disabled and no resources belonging to the other connected client were modified.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention) — no meter UI changes
- [x] Documentation updated if user-visible behavior changed — no documentation change required; this restores documented radio behavior
- [x] Security-sensitive changes reference a GHSA if applicable — not applicable
