### PR TITLE
fix(gui): wrap Demo Noise button strips instead of clipping at docked rail width

### DIFF
--- a/src/gui/DemoApplet.cpp
+++ b/src/gui/DemoApplet.cpp
@@ -1,5 +1,6 @@
 #include "DemoApplet.h"
 
+#include "FlowLayout.h"
 #include "core/backends/sim/NoiseMixer.h"
 
 #include <QGridLayout>
@@ -56,8 +57,12 @@ void DemoApplet::buildUI()
     root->addWidget(title);
 
     // ── scene presets ──────────────────────────────────────────────────────
-    auto* presetRow = new QHBoxLayout();
-    presetRow->setSpacing(4);
+    // FlowLayout, not QHBoxLayout: six labeled buttons need ~450 px but the
+    // docked applet rail hands us ~246 with no horizontal overflow allowed,
+    // so a box layout compresses the buttons past their hint and clips the
+    // centred labels at both ends (#4518). Wrapping keeps every label whole
+    // at any width.
+    auto* presetRow = new FlowLayout(0, 4, 4);
     for (const QString& p : NoiseMixer::allPresetNames()) {
         auto* b = new QPushButton(p, this);
         b->setStyleSheet(QStringLiteral(
@@ -70,7 +75,6 @@ void DemoApplet::buildUI()
         });
         presetRow->addWidget(b);
     }
-    presetRow->addStretch();
     root->addLayout(presetRow);
 
     // ── per-channel rows: toggle | level slider | optional knob ────────────
@@ -153,8 +157,8 @@ void DemoApplet::buildUI()
         {"Malformed",   "malformed",  ""},
         {"Clear",       "clear",      ""},
     };
-    auto* faultRow = new QHBoxLayout();
-    faultRow->setSpacing(4);
+    // Same wrap-instead-of-compress treatment as the preset strip (#4518).
+    auto* faultRow = new FlowLayout(0, 4, 4);
     for (const FaultBtn& fb : kFaultBtns) {
         auto* b = new QPushButton(QString::fromLatin1(fb.label), this);
         const bool isClear = QLatin1String(fb.fault) == QLatin1String("clear");
@@ -175,7 +179,6 @@ void DemoApplet::buildUI()
         });
         faultRow->addWidget(b);
     }
-    faultRow->addStretch();
     root->addLayout(faultRow);
 
     root->addStretch();

--- a/src/gui/DxClusterDialog.cpp
+++ b/src/gui/DxClusterDialog.cpp
@@ -1,5 +1,6 @@
 #include "DxClusterDialog.h"
 #include "DxClusterStartupCommandsDialog.h"
+#include "FlowLayout.h"
 #include "GuardedSlider.h"
 #include "core/DxClusterClient.h"
 #include "core/AppSettings.h"
@@ -60,70 +61,9 @@ private:
     int m_resetValue{0};
 };
 
-// Left-to-right layout that wraps to a new row when it runs out of
-// horizontal space, rather than compressing children to illegibility
-// (#4157). Used for the Spot List band-filter checkboxes so the
-// checked state stays readable when SpotHub is narrow.
-class FlowLayout : public QLayout {
-public:
-    explicit FlowLayout(int margin, int hSpacing, int vSpacing)
-        : m_hSpace(hSpacing), m_vSpace(vSpacing) {
-        setContentsMargins(margin, margin, margin, margin);
-    }
-    ~FlowLayout() override {
-        while (QLayoutItem* item = takeAt(0))
-            delete item;
-    }
-
-    void addItem(QLayoutItem* item) override { m_items.append(item); }
-    Qt::Orientations expandingDirections() const override { return {}; }
-    bool hasHeightForWidth() const override { return true; }
-    int heightForWidth(int width) const override { return doLayout(QRect(0, 0, width, 0), true); }
-    int count() const override { return m_items.size(); }
-    QLayoutItem* itemAt(int index) const override { return m_items.value(index); }
-    QLayoutItem* takeAt(int index) override {
-        return (index >= 0 && index < m_items.size()) ? m_items.takeAt(index) : nullptr;
-    }
-    QSize sizeHint() const override { return minimumSize(); }
-    QSize minimumSize() const override {
-        QSize size;
-        for (QLayoutItem* item : m_items)
-            size = size.expandedTo(item->minimumSize());
-        const QMargins m = contentsMargins();
-        return size + QSize(m.left() + m.right(), m.top() + m.bottom());
-    }
-    void setGeometry(const QRect& rect) override {
-        QLayout::setGeometry(rect);
-        doLayout(rect, false);
-    }
-
-private:
-    int doLayout(const QRect& rect, bool testOnly) const {
-        const QMargins m = contentsMargins();
-        QRect effectiveRect = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom());
-        int x = effectiveRect.x();
-        int y = effectiveRect.y();
-        int lineHeight = 0;
-        for (QLayoutItem* item : m_items) {
-            int nextX = x + item->sizeHint().width() + m_hSpace;
-            if (nextX - m_hSpace > effectiveRect.right() && lineHeight > 0) {
-                x = effectiveRect.x();
-                y += lineHeight + m_vSpace;
-                nextX = x + item->sizeHint().width() + m_hSpace;
-                lineHeight = 0;
-            }
-            if (!testOnly)
-                item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
-            x = nextX;
-            lineHeight = qMax(lineHeight, item->sizeHint().height());
-        }
-        return y + lineHeight - rect.y() + m.bottom();
-    }
-
-    QList<QLayoutItem*> m_items;
-    int m_hSpace;
-    int m_vSpace;
-};
+// FlowLayout (the wrap-instead-of-compress layout born here for the Spot
+// List band filters, #4157) now lives in FlowLayout.h — promoted to a
+// shared class for #4518.
 
 // Keeps a QMenu open while its checkable actions are toggled, so several
 // columns can be shown/hidden in one pass instead of reopening the header

--- a/src/gui/FlowLayout.h
+++ b/src/gui/FlowLayout.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <QLayout>
+#include <QList>
+#include <QRect>
+
+namespace AetherSDR {
+
+// Left-to-right layout that wraps to a new row when it runs out of
+// horizontal space, rather than compressing children to illegibility.
+// Born file-local in DxClusterDialog for the Spot List band-filter
+// checkboxes (#4157); promoted to a shared class when the Demo Noise
+// applet hit the same failure mode in the fixed-width applet rail
+// (#4518). Use it for any dense control strip that must stay readable
+// at the 260 px rail width — the rail's scroll area is widget-resizable
+// with horizontal scrolling off, so a plain QHBoxLayout there is handed
+// less than its minimum and clips, it never overflows.
+class FlowLayout : public QLayout {
+public:
+    explicit FlowLayout(int margin, int hSpacing, int vSpacing)
+        : m_hSpace(hSpacing), m_vSpace(vSpacing) {
+        setContentsMargins(margin, margin, margin, margin);
+    }
+    ~FlowLayout() override {
+        while (QLayoutItem* item = takeAt(0))
+            delete item;
+    }
+
+    void addItem(QLayoutItem* item) override { m_items.append(item); }
+    Qt::Orientations expandingDirections() const override { return {}; }
+    bool hasHeightForWidth() const override { return true; }
+    int heightForWidth(int width) const override { return doLayout(QRect(0, 0, width, 0), true); }
+    int count() const override { return m_items.size(); }
+    QLayoutItem* itemAt(int index) const override { return m_items.value(index); }
+    QLayoutItem* takeAt(int index) override {
+        return (index >= 0 && index < m_items.size()) ? m_items.takeAt(index) : nullptr;
+    }
+    QSize sizeHint() const override { return minimumSize(); }
+    QSize minimumSize() const override {
+        QSize size;
+        for (QLayoutItem* item : m_items)
+            size = size.expandedTo(item->minimumSize());
+        const QMargins m = contentsMargins();
+        return size + QSize(m.left() + m.right(), m.top() + m.bottom());
+    }
+    void setGeometry(const QRect& rect) override {
+        QLayout::setGeometry(rect);
+        doLayout(rect, false);
+    }
+
+private:
+    int doLayout(const QRect& rect, bool testOnly) const {
+        const QMargins m = contentsMargins();
+        QRect effectiveRect = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom());
+        int x = effectiveRect.x();
+        int y = effectiveRect.y();
+        int lineHeight = 0;
+        for (QLayoutItem* item : m_items) {
+            int nextX = x + item->sizeHint().width() + m_hSpace;
+            if (nextX - m_hSpace > effectiveRect.right() && lineHeight > 0) {
+                x = effectiveRect.x();
+                y += lineHeight + m_vSpace;
+                nextX = x + item->sizeHint().width() + m_hSpace;
+                lineHeight = 0;
+            }
+            if (!testOnly)
+                item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+            x = nextX;
+            lineHeight = qMax(lineHeight, item->sizeHint().height());
+        }
+        return y + lineHeight - rect.y() + m.bottom();
+    }
+
+    QList<QLayoutItem*> m_items;
+    int m_hSpace;
+    int m_vSpace;
+};
+
+}  // namespace AetherSDR


### PR DESCRIPTION
Fixes #4518

## What

The Demo Noise applet's two button strips (six presets, six fault-injection buttons) were
flat `QHBoxLayout`s. Docked, the applet rail's widget-resizable scroll area with horizontal
scrolling off hands the layout less than its minimum width, so the buttons compress past
their hint and the centred labels clip at both ends to mid-word fragments (screenshots in
the issue).

This is the second occurrence of this failure mode: SpotHub's band-filter row hit it in
#4157, and that fix introduced a wrap-instead-of-compress `FlowLayout` — file-local in
`DxClusterDialog.cpp`. This PR promotes that class verbatim to a shared
`src/gui/FlowLayout.h` and uses it for both DemoApplet strips. Buttons keep their natural
width and wrap to additional rows as needed, at any width — docked (2×3) or floated.

- `src/gui/FlowLayout.h` — new; the #4157 class moved verbatim (comment updated with
  provenance and when to reach for it).
- `src/gui/DxClusterDialog.cpp` — local class removed, includes the header; its call site
  is untouched, behavior identical.
- `src/gui/DemoApplet.cpp` — each strip: `QHBoxLayout` + `addStretch()` →
  `FlowLayout(0, 4, 4)`. Buttons, styling, and signal wiring unchanged.

## Verification

- Clean build on macOS (Qt 6.11, Metal QRhi), base `2f72b304`; ctest 189/189 passed.
- [RIG] Docked at the 260 px rail: all twelve labels whole, strips wrap 3+3 (screenshot
  below).
- [RIG] Popped out: labels whole at natural width; wrap point follows window width.
- [RIG] SpotHub → Spot List band-filter row (the original FlowLayout consumer): renders
  unchanged.

<img width="287" height="478" alt="docked-after-fix" src="https://github.com/user-attachments/assets/e87da4f0-c21f-40ce-a5a6-454dda9c6af0" />

<img width="539" height="486" alt="popped-out" src="https://github.com/user-attachments/assets/838a04ea-3edc-482b-accb-32b9bb665df9" />

<img width="880" height="189" alt="spothub" src="https://github.com/user-attachments/assets/d1f814eb-abdc-4de1-a9f0-33152b6dc2c9" />


## Non-goals

Auditing other applets for similar strips, converting any, or establishing a layout convention — this promotes the existing
#4157 cure and applies it to the second occurrence of the same failure mode. Broader
adoption is maintainer discretion.

— authored by agent (Claude Code) on behalf of @skerker

