### PR TITLE
fix(meters): stop reporting a stale SWR while receiving

### DIFF
--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1900,7 +1900,12 @@ QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
          age(m->reflectedPowerUpdatedAtMs())},
         {QStringLiteral("reflectedPowerMeasured"),
          m->hasRecentReflectedPower(500)},
-        {QStringLiteral("swr"),             m->swr()},
+        // Null rather than a stale ratio, matching the SWR entry in `all` and
+        // the fwdPower/reflectedPower pair above — a client reading this scalar
+        // must not get a different answer from the one reading the array
+        // (#4533). swrAgeMs is still reported so a consumer can see WHY.
+        {QStringLiteral("swr"),
+         m->swrIfLive() ? QJsonValue(*m->swrIfLive()) : QJsonValue()},
         {QStringLiteral("swrAgeMs"),        age(m->swrUpdatedAtMs())},
         {QStringLiteral("paTemp"),          m->paTemp()},             // °C
         {QStringLiteral("supplyVolts"),     m->supplyVolts()},        // V
@@ -1912,7 +1917,10 @@ QJsonObject metersSnapshot(MeterModel* m, const QString& radioModel)
         {QStringLiteral("compLevel"),       m->compLevel()},          // dB compression
         {QStringLiteral("hasCompression"),  m->hasCompressionMeterValue()},
         {QStringLiteral("sLevel"),          m->sLevel()},             // dBm
-        {QStringLiteral("txMetersFresh"),   m->hasRecentTxMeters(2000)},
+        // Same constant the SWR gate uses, so "the TX meters are fresh" and "the
+        // SWR is live" cannot drift apart as two different literals.
+        {QStringLiteral("txMetersFresh"),
+         m->hasRecentTxMeters(MeterModel::kTxMeterStaleMs)},
         {QStringLiteral("txMetersAgeMs"),   age(m->txMetersUpdatedAtMs())},
         {QStringLiteral("all"),             all},                     // every meter + age_ms + reliability
     };

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -156,9 +156,12 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
         connect(m_model, &RadioModel::radioTransmittingChanged, this,
             &TciServer::onRadioTransmittingChanged);
         connect(&m_model->meterModel(), &MeterModel::txMetersChanged,
-                this, [this](float fwd, float swr) {
+                this, [this](float fwd, float swr, bool swrValid) {
             m_cachedFwdPower = fwd;
-            m_cachedSwr = swr;
+            // TCI's wire format has no absent marker; 1.0 is what this cache
+            // held before any SWR arrived, so absence maps back to it rather
+            // than to 0.0 (which is out of the meter's domain).
+            m_cachedSwr = swrValid ? swr : 1.0f;
         });
         connect(&m_model->meterModel(), &MeterModel::micMetersChanged,
                 this, [this](float micLevel, float, float, float) {

--- a/src/gui/AtuPreTuneDialog.cpp
+++ b/src/gui/AtuPreTuneDialog.cpp
@@ -205,8 +205,8 @@ AtuPreTuneDialog::AtuPreTuneDialog(RadioModel* radio,
         // forward power — track the most recent reading > 1.001 so we
         // report the settled post-tune SWR, not the reset artifact. (#2624)
         connect(&m_radio->meterModel(), &MeterModel::txMetersChanged,
-                this, [this](float, float swr) {
-            if (m_swrTracking && swr > 1.001f)
+                this, [this](float, float swr, bool swrValid) {
+            if (m_swrTracking && swrValid && swr > 1.001f)
                 m_tuneLastSwr = swr;
         });
     }

--- a/src/gui/HealthApplet.cpp
+++ b/src/gui/HealthApplet.cpp
@@ -508,9 +508,21 @@ void HealthApplet::setMeterModel(MeterModel* model)
     // break this — keep them co-emitted, or gate on an explicit instantaneous
     // timestamp here. (#4243)
     connect(m_model, &MeterModel::txMetersChanged,
-            this, &HealthApplet::updateRadioMeters);
+            this, [this](float fwd, float swr, bool swrValid) {
+        // Absent -> NaN: finiteOr() in cacheMeters() is this applet's absent
+        // handler, and swrSampleUpdatedAtMs stays honest via the model. The
+        // clamp semantics themselves are #4538's to consolidate.
+        updateRadioMeters(fwd, swrValid ? swr
+                                        : std::numeric_limits<float>::quiet_NaN());
+    });
     connect(m_model, &MeterModel::directionalPowerMetersChanged,
-            this, &HealthApplet::updateRadioDirectionalMeters);
+            this, [this](float fwd, float refl, float swr, bool swrValid,
+                         bool reflMeasured) {
+        updateRadioDirectionalMeters(
+            fwd, refl,
+            swrValid ? swr : std::numeric_limits<float>::quiet_NaN(),
+            reflMeasured);
+    });
     connect(m_model, &MeterModel::tgxlMetersChanged,
             this, &HealthApplet::updateTunerMeters);
     connect(m_model, &MeterModel::ampMetersChanged,

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1466,9 +1466,10 @@ void MainWindow::wireVfoTelemetry(VfoWidget* vfo, SliceModel* s)
         vfo->setTxCompression(compPeak);
     });
     connect(&m_radioModel.meterModel(), &MeterModel::txMetersChanged,
-            vfo, [vfo](float fwd, float swr) {
+            vfo, [vfo](float fwd, float swr, bool swrValid) {
         vfo->setTxPower(fwd);
-        vfo->setTxSwr(swr);
+        // Absent SWR keeps the widget's idle value rather than a stale ratio.
+        vfo->setTxSwr(swrValid ? swr : 0.0f);
     });
     connect(&m_radioModel.transmitModel(), &TransmitModel::moxChanged,
             vfo, &VfoWidget::setTransmitting);
@@ -5302,11 +5303,16 @@ void MainWindow::wireMeters()
     // exciter sample here to stop the alternating-writer pulse where exciter
     // (~100 W) and amp (~1500 W) values race into the same widget. (#2927)
     connect(&m_radioModel.meterModel(), &MeterModel::txMetersChanged,
-            this, [this](float fwd, float swr) {
+            this, [this](float fwd, float swr, bool swrValid) {
         if (m_radioModel.amplifier().present() && m_radioModel.amplifier().operate())
             return;
+        // Absent SWR is forwarded as 1.0: RadioSwrValidityFilter downstream
+        // reads <1.0 WITH forward power as the radio's over-range sentinel
+        // and would peg the S-meter full-scale on a matched antenna (#4536
+        // review, blocker 2). 1.0 is the meter's rest position.
         m_appletPanel->setStandardRadioMeterTxValues(
-            fwd, m_radioModel.meterModel().fwdPowerInstant(), swr);
+            fwd, m_radioModel.meterModel().fwdPowerInstant(),
+            swrValid ? swr : 1.0f);
 #ifdef HAVE_HIDAPI
         m_tmate2TxWatts = fwd;
         if (m_radioModel.transmitModel().isTransmitting()) {
@@ -5318,13 +5324,15 @@ void MainWindow::wireMeters()
     connect(&m_radioModel.meterModel(),
             &MeterModel::directionalPowerMetersChanged,
             this, [this](float fwd, float reflected, float swr,
-                         bool reflectedPowerMeasured) {
+                         bool swrValid, bool reflectedPowerMeasured) {
         if (m_radioModel.amplifier().present()
             && m_radioModel.amplifier().operate()) {
             return;
         }
+        // The cross-needle already clamps sub-1.0 values to 1.0 (its rest
+        // position); absent maps there explicitly rather than by accident.
         m_appletPanel->setCrossNeedleDirectionalValues(
-            fwd, reflected, swr, reflectedPowerMeasured);
+            fwd, reflected, swrValid ? swr : 1.0f, reflectedPowerMeasured);
     });
     connect(&m_radioModel.meterModel(), &MeterModel::micMetersChanged,
             m_appletPanel->sMeterWidget(), &SMeterWidget::setMicMeters);

--- a/src/gui/SliceTroubleshootingDialog.cpp
+++ b/src/gui/SliceTroubleshootingDialog.cpp
@@ -787,6 +787,22 @@ QString SliceTroubleshootingDialog::buildSummary(const QJsonObject& snapshot)
                  .arg(formatNumber(telemetry["alc"]))
                  .arg(formatNumber(telemetry["mic_level_dbfs"]))
                  .arg(formatNumber(telemetry["comp_level_db"]));
+    // Qualify the TX group on the line above whenever it is NOT live.
+    //
+    // TX forward power holds its last smoothed value while SWR correctly reads
+    // n/a, so without this the reader of a support bundle sees a plausible
+    // wattage next to a missing SWR and concludes the antenna is the problem.
+    // Only emitted when stale: a live group needs no caveat, and the common
+    // case should stay quiet. (#4533 review)
+    if (telemetry.contains("tx_meters_fresh") && !telemetry["tx_meters_fresh"].toBool()) {
+        const qint64 ageMs = static_cast<qint64>(telemetry["tx_meters_age_ms"].toDouble(-1));
+        lines << QString("  - ⚠ TX meters are NOT live (%1) — TX forward power is the last "
+                          "value received, not a current reading, and TX SWR is omitted "
+                          "rather than shown stale.")
+                     .arg(ageMs >= 0
+                              ? QString("last sample %1 ms ago").arg(ageMs)
+                              : QString("no TX meter sample this session"));
+    }
     lines << QString("- Amplifier: present `%1`, model `%2`, handle `%3`, operate `%4`")
                  .arg(yesNo(amplifier["present"].toBool()))
                  .arg(orPlaceholder(amplifier["model"].toString()))

--- a/src/gui/TxApplet.cpp
+++ b/src/gui/TxApplet.cpp
@@ -627,11 +627,14 @@ void TxApplet::syncAtuIndicators()
     }
 }
 
-void TxApplet::updateMeters(float fwdPower, float swr)
+void TxApplet::updateMeters(float fwdPower, float swr, bool swrValid)
 {
     m_smoothedPower = fwdPower;
     static_cast<HGauge*>(m_fwdGauge)->setValue(fwdPower);
-    static_cast<HGauge*>(m_swrGauge)->setValue(swr);
+    // Absent SWR parks the gauge at its 1.0 rest position; a raw 0.0 would
+    // read as an off-scale value, and holding the last ratio is exactly the
+    // stale display #4533 removed.
+    static_cast<HGauge*>(m_swrGauge)->setValue(swrValid ? swr : 1.0f);
 }
 
 void TxApplet::updatePeakPower(float fwdPowerInstant)

--- a/src/gui/TxApplet.h
+++ b/src/gui/TxApplet.h
@@ -46,7 +46,7 @@ public:
     void setBandPlanManager(BandPlanManager* bandPlan);
 
 public slots:
-    void updateMeters(float fwdPower, float swr);
+    void updateMeters(float fwdPower, float swr, bool swrValid);
     // Capture raw pre-smoothed FWDPWR for PEP peak-hold tick. (#2561)
     void updatePeakPower(float fwdPowerInstant);
     // Reset the peak-hold tick when TX ends so a held peak does not linger

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -22,6 +22,19 @@ namespace {
 // exactly, while any genuine reading (0 dBm is already 30 dB below a 1 W
 // carrier) stays on the smoothed path.
 constexpr float kNoCarrierWatts = 0.0011f;
+// Minimum instantaneous forward power for an SWR ratio to mean anything.
+//
+// A radio with no carrier reports 0 dBm on FWDPWR, which is 10^(0/10)/1000 =
+// 0.001 W — small but not zero. SWR is computed from forward and reflected
+// power, so below this there is no power behind the ratio and it saturates:
+// an HL2 published 255.99 and held it. The threshold sits a hair above that
+// floor, and 0 dBm is already 30 dB below a 1 W carrier, so nothing real
+// lives underneath it. (#4533)
+constexpr float kMinForwardWattsForSwr = 0.0011f;
+// NOTE: kNoCarrierWatts (#4540) and kMinForwardWattsForSwr (#4533) share the
+// same numeric floor but answer different questions -- "is a carrier present"
+// versus "is there power behind this ratio" -- and are kept separate so a
+// future change to one cannot silently move the other.
 
 constexpr qint64 kCompressionSummaryLogIntervalMs = 500;
 constexpr qint64 kDirectionalMeterFreshnessMs = 500;
@@ -462,6 +475,31 @@ void MeterModel::logCompressionSummary(const char* reason, bool force)
                       << "available" << m_hasCompPeakValue;
 }
 
+bool MeterModel::swrSampleLive(qint64 nowMs, qint64 swrMaxAgeMs) const
+{
+    // See the declaration for the contract. Order matters: the SWR sample's
+    // own age is always required — a stale ratio is not a measurement no
+    // matter what power is doing (#4533, the 16-minute-old reading).
+    const bool swrFresh = m_lastSwrUpdateMs > 0
+        && (nowMs - m_lastSwrUpdateMs) <= swrMaxAgeMs;
+    if (!swrFresh)
+        return false;
+    // Backend never published forward power (HL2): SWR self-gates upstream.
+    if (m_lastFwdPowerUpdateMs == 0)
+        return true;
+    // Backend does publish power: a fresh ratio with no qualifying power
+    // behind it is two noise samples divided (#4533's saturated 255.99).
+    return (nowMs - m_lastFwdPowerUpdateMs) <= kDirectionalMeterFreshnessMs
+        && m_fwdPowerInstant > kMinForwardWattsForSwr;
+}
+
+std::optional<float> MeterModel::swrIfLive() const
+{
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    return swrSampleLive(now, kTxMeterStaleMs) ? std::optional<float>(m_swr)
+                                               : std::nullopt;
+}
+
 bool MeterModel::hasRecentTxMeters(qint64 maxAgeMs) const
 {
     if (m_lastTxMeterUpdateMs <= 0 || maxAgeMs < 0)
@@ -628,9 +666,43 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
         emit meterUpdated(idx, v);
     }
 
+    // SWR as published to consumers. It is derived from forward and reflected
+    // power, so once the TX meters go stale it is not a measurement any more —
+    // it is whatever was last read during a previous transmit, and on a radio
+    // that publishes SWR but no FWDPWR it saturates at 255.99 and stays there
+    // (#4533).
+    //
+    // Gated HERE, at the single point both signals read it, rather than in each
+    // consumer: HealthApplet already qualifies SWR on instantaneous forward
+    // power (#4243), but that gate cannot fire on a backend which never sends
+    // FWDPWR at all, so every such consumer is defeated by the absence of the
+    // very quantity it gates on.
+    //
+    // ⚠ Gate on SWR'S OWN AGE (swrUpdatedAtMs), NOT on forward power and NOT
+    // on hasRecentTxMeters(). The earlier forward-power gate silently zeroed
+    // SWR forever on any backend that publishes SWR without FWDPWR — the HL2
+    // does exactly that, by design (its forward counts are uncalibrated ADC
+    // values; the RATIO survives the unknown scale, which is why its SWR is
+    // the most trustworthy meter it has). "This SWR reading is old" is the
+    // claim this gate makes; power flowing is evidence for a different
+    // proposition, and #4243's HealthApplet already qualifies on power where
+    // power data exists.
+    //
+    // ⚠ The two emits stay CO-EMITTED and in this order — #4243 depends on
+    // directionalPowerMetersChanged landing in the same cycle as
+    // txMetersChanged. Only the values carried change here, never the timing.
+    const bool swrValid =
+        m_swrIdx >= 0
+        && swrSampleLive(packetUpdatedMs, kDirectionalMeterFreshnessMs);
+    // 0.0f is a PLACEHOLDER carried alongside swrValid=false, never a value:
+    // RadioSwrValidityFilter reads <1.0 as the radio's over-range sentinel and
+    // other consumers clamp it to 1.0, so an unaccompanied 0.0f means opposite
+    // things on different surfaces (#4536 review, blocker 2).
+    const float publishedSwr = swrValid ? m_swr : 0.0f;
+
     // sLevelChanged is now emitted per-slice inline above
     if (txChanged)
-        emit txMetersChanged(m_fwdPower, m_swr);
+        emit txMetersChanged(m_fwdPower, publishedSwr, swrValid);
     if (directionalChanged) {
         const bool reflectedPowerMeasured = m_refPwrIdx >= 0
             && m_lastReflectedPowerUpdateMs > 0
@@ -638,7 +710,8 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
                 <= kDirectionalMeterFreshnessMs;
         emit directionalPowerMetersChanged(m_fwdPowerInstant,
                                            m_reflectedPower,
-                                           m_swr,
+                                           publishedSwr,
+                                           swrValid,
                                            reflectedPowerMeasured);
     }
     // Separate signal carries the raw pre-smoothed sample so consumers
@@ -686,9 +759,22 @@ QJsonArray MeterModel::allMeters() const
 {
     QJsonArray meters;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // One predicate for every surface — see swrSampleLive() (#4536).
+    const bool swrFresh = swrSampleLive(now, kTxMeterStaleMs);
     for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
         const auto valueIt = m_values.constFind(it.key());
-        const bool hasValue = valueIt != m_values.constEnd();
+        bool hasValue = valueIt != m_values.constEnd();
+        // SWR is derived from forward and reflected power, so once the TX
+        // meters go stale it is not a measurement any more — it is the last
+        // reading from a previous transmit. Reporting it as a live value sends
+        // the operator hunting for an antenna fault that isn't there (#4533).
+        // Present it the same way FWDPWR/REFPWR already present themselves when
+        // the radio isn't sending them: has_value=false, value=null, age=-1.
+        // Matches the existing gates in RigctlProtocol (which additionally
+        // requires an active transmit) and the Amp/Acom applets, both of which
+        // blank SWR without drive.
+        if (hasValue && it.key() == m_swrIdx && !swrFresh)
+            hasValue = false;
         const qint64 upd = m_valueUpdatedMs.value(it.key(), 0);
         const qint64 ageMs = (hasValue && upd > 0) ? (now - upd) : -1;
         meters.append(meterToJson(*it, hasValue, hasValue ? valueIt.value() : 0.0f, ageMs));
@@ -700,6 +786,8 @@ QJsonArray MeterModel::metersForSource(const QString& source, int sourceIndex) c
 {
     QJsonArray meters;
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    // One predicate for every surface — see swrSampleLive() (#4536).
+    const bool swrFresh = swrSampleLive(now, kTxMeterStaleMs);
     for (auto it = m_defs.constBegin(); it != m_defs.constEnd(); ++it) {
         const MeterDef& def = *it;
         if (def.source != source)
@@ -708,7 +796,13 @@ QJsonArray MeterModel::metersForSource(const QString& source, int sourceIndex) c
             continue;
 
         const auto valueIt = m_values.constFind(it.key());
-        const bool hasValue = valueIt != m_values.constEnd();
+        bool hasValue = valueIt != m_values.constEnd();
+        // Same SWR gate as allMeters(). Without it a `tx`-source query answered
+        // has_value=true for the identical meter that `all` reports as absent —
+        // two views of one model disagreeing about the same reading, which is
+        // the disagreement #4533 was filed about rather than a second bug.
+        if (hasValue && it.key() == m_swrIdx && !swrFresh)
+            hasValue = false;
         const qint64 upd = m_valueUpdatedMs.value(it.key(), 0);
         const qint64 ageMs = (hasValue && upd > 0) ? (now - upd) : -1;
         meters.append(meterToJson(def, hasValue, hasValue ? valueIt.value() : 0.0f, ageMs));

--- a/src/models/MeterModel.h
+++ b/src/models/MeterModel.h
@@ -5,6 +5,8 @@
 #include <QJsonArray>
 #include <QString>
 
+#include <optional>
+
 // MeterDef moved to the core backend layer (aetherd RFC 2.3 / #4070) so the
 // vendor-neutral IRadioBackend can carry it on meterDefined() without a
 // model dependency. Re-exported here for the model's existing users.
@@ -86,8 +88,35 @@ public:
     float reflectedPower() const { return m_reflectedPower; }
     float tgxlFwdPower() const { return m_tgxlFwdPwr; }
 
+    // How long after the last TX meter sample a TX-derived reading still counts
+    // as live. Matches the window AutomationServer already uses to publish
+    // `txMetersFresh` alongside these values, so the flag and the values it
+    // describes cannot disagree. (RigctlProtocol uses a tighter 1500 ms and
+    // additionally requires an active transmit — a stricter gate, not a
+    // conflicting one.)
+    static constexpr qint64 kTxMeterStaleMs = 2000;
+
     // Convenience: SWR.
+    // ⚠ May be a stale reading from a previous transmit. Callers that display
+    // it must gate on swrIfLive(); `allMeters()` and `metersForSource()`
+    // already gate their SWR entry the same way.
     float swr() const { return m_swr; }
+    // SWR when the SWR SAMPLE ITSELF is live, std::nullopt when it is not.
+    // Judged by SWR's own timestamp, not the aggregate TX stamp: a radio that
+    // keeps streaming power but stops streaming SWR must not report a
+    // minutes-old ratio as current (#4533; #4536 review). This is the one
+    // definition of "no valid SWR" — the signals' swrValid flag, both
+    // snapshot arrays and the bridge scalar all derive from the same
+    // timestamp and constant.
+    std::optional<float> swrIfLive() const;
+    // THE one liveness predicate behind swrIfLive(), the signals' swrValid
+    // flag and both snapshot arrays. SWR is live when its own sample is
+    // within swrMaxAgeMs AND, on a backend that actually publishes forward
+    // power, that power is fresh and above the qualifying floor. A backend
+    // that has never published FWDPWR (the HL2 — uncalibrated counts, its
+    // SWR stream is already power-gated at the source) is judged on the SWR
+    // sample alone, by construction rather than by exception.
+    bool swrSampleLive(qint64 nowMs, qint64 swrMaxAgeMs) const;
     float tgxlSwr() const { return m_tgxlSwr; }
 
     // Timestamp of the last TX meter sample (milliseconds since epoch).
@@ -99,6 +128,14 @@ public:
     qint64 tgxlSwrUpdatedAtMs() const { return m_lastTgxlSwrUpdateMs; }
     bool hasRecentTxMeters(qint64 maxAgeMs) const;
     bool hasRecentReflectedPower(qint64 maxAgeMs) const;
+
+    // Test seam: age the TX-meter timestamp so staleness behaviour can be
+    // exercised without sleeping through the real window.
+    void setLastTxMeterUpdateMsForTest(qint64 ms) { m_lastTxMeterUpdateMs = ms; }
+    // SWR is gated on ITS OWN timestamp (#4536), so staleness tests must age
+    // this one; ageing only the aggregate stamp exercises nothing the SWR
+    // gate reads.
+    void setLastSwrUpdateMsForTest(qint64 ms) { m_lastSwrUpdateMs = ms; }
 
     // Convenience: mic peak level (dBFS) and radio-provided compression (dB).
     float micPeak()  const { return m_micPeak; }
@@ -134,15 +171,27 @@ signals:
     void escLevelChanged(int sliceIndex, float dbm);
 
     // Emitted when TX meters change (power, SWR).
-    void txMetersChanged(float fwdPower, float swr);
+    //
+    // THE SWR-ABSENT CONTRACT (one definition for every surface — #4536):
+    // swrValid=false means "no current SWR measurement exists". The float
+    // carried alongside is 0.0f and MUST NOT be interpreted — not clamped to
+    // 1.0, not treated as the radio's <1.0 over-range sentinel, not rendered.
+    // Absence is a distinct state, exactly as the snapshot path reports
+    // has_value=false / value=null / age=-1. Whose timestamp governs: SWR'S
+    // OWN (swrUpdatedAtMs()), not FWDPWR's and not the aggregate TX stamp — a
+    // reading is absent when the SWR sample itself is old, regardless of what
+    // other meters are doing.
+    void txMetersChanged(float fwdPower, float swr, bool swrValid);
 
     // Independent directional-coupler readings for a physical cross-needle
     // display. Forward power is the raw FWDPWR sample so both movements receive
     // one layer of identical GUI ballistics. reflectedPowerMeasured is false
     // when REFPWR is unavailable/stale and the consumer must derive it from SWR.
+    // swrValid: see txMetersChanged — same contract, same timestamp.
     void directionalPowerMetersChanged(float forwardPower,
                                        float reflectedPower,
                                        float swr,
+                                       bool swrValid,
                                        bool reflectedPowerMeasured);
 
     // Emitted on every FWDPWR sample with the raw pre-smoothed value (watts).

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -9033,7 +9033,31 @@ QJsonObject RadioModel::troubleshootingSnapshot() const
     telemetry["pa_temp_c"] = m_meterModel.paTemp();
     telemetry["supply_volts"] = m_meterModel.supplyVolts();
     telemetry["tx_forward_power_w"] = m_meterModel.fwdPower();
-    telemetry["tx_swr"] = m_meterModel.swr();
+    // Null rather than a leftover ratio when the TX meters are stale — this
+    // snapshot feeds support bundles, and a stale SWR reads as a live antenna
+    // fault to whoever opens the report (#4533).
+    if (const auto liveSwr = m_meterModel.swrIfLive())
+        telemetry["tx_swr"] = *liveSwr;
+    else
+        telemetry["tx_swr"] = QJsonValue();
+    // Whether the TX meter group above is current, so the whole group is
+    // interpretable at once.
+    //
+    // tx_forward_power_w is NOT nulled alongside tx_swr, and the asymmetry is
+    // deliberate: forward power is a measured quantity that decays toward zero
+    // and reads zero when the carrier drops, so its last value is meaningful on
+    // its own. SWR is a RATIO derived from it, and a ratio computed from
+    // quantities that are no longer arriving is not a smaller number — it is
+    // undefined, which is why it goes null. Without this flag the pair
+    // `tx_forward_power_w: 5.0, tx_swr: null` invites the reader to conclude
+    // forward power is live and only SWR is missing. (#4533 review)
+    telemetry["tx_meters_fresh"] =
+        m_meterModel.hasRecentTxMeters(MeterModel::kTxMeterStaleMs);
+    // -1 when no TX meter has ever arrived, matching the age convention the
+    // automation bridge's meters snapshot already uses.
+    const qint64 txMetersAtMs = m_meterModel.txMetersUpdatedAtMs();
+    telemetry["tx_meters_age_ms"] =
+        txMetersAtMs > 0 ? QDateTime::currentMSecsSinceEpoch() - txMetersAtMs : -1;
     // SliceTroubleshootingDialog renders this with the literal label
     // "HWALC", so keep it pointed at the external Hardware ALC RCA voltage
     // (m_hwAlc) — the gauge in the Phone/CW applet now uses swAlc().

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -547,6 +547,46 @@ void testStaleTxMetersDoNotSuppressReceiveMeters()
 // exactly when it is needed and the reader would take the held wattage for a
 // live one. Both derive from hasRecentTxMeters(kTxMeterStaleMs); this pins that
 // they cannot disagree. (#4533 review)
+// Suppression must not LATCH. After a stale window, the next SWR sample has to
+// restore liveness — that is the property an operator depends on the first time
+// they key up following a long receive period, and it is the one direction the
+// other tests never exercise: they start fresh and go stale, never the reverse.
+//
+// Without this, a regression that suppressed SWR permanently once it had aged
+// out would still pass every other case here. (#4536 review)
+void testSwrRecoversAfterAFreshSampleFollowsAStaleWindow()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.updateValues({10}, {rawDb(2.88f)});
+    const bool liveBefore = model.swrIfLive().has_value();
+
+    // Age it past the window, the way a long receive period would.
+    model.setLastTxMeterUpdateMsForTest(
+        QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    model.setLastSwrUpdateMsForTest(
+        QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    const bool suppressedWhileStale = !model.swrIfLive().has_value();
+    const QJsonObject staleEntry = meterNamed(model.allMeters(), QStringLiteral("SWR"));
+    const bool arrayAbsentWhileStale =
+        !staleEntry.value(QStringLiteral("has_value")).toBool();
+
+    // Key up again: one fresh sample, nothing else changed.
+    model.updateValues({10}, {rawDb(1.42f)});
+
+    const auto recovered = model.swrIfLive();
+    const QJsonObject liveEntry = meterNamed(model.allMeters(), QStringLiteral("SWR"));
+
+    report("MeterModel restores SWR liveness when a fresh sample follows a stale window",
+           liveBefore && suppressedWhileStale && arrayAbsentWhileStale
+               && recovered.has_value() && nearlyEqual(*recovered, 1.42f)
+               && liveEntry.value(QStringLiteral("has_value")).toBool()
+               && nearlyEqual(
+                      static_cast<float>(liveEntry.value(QStringLiteral("value")).toDouble()),
+                      1.42f));
+}
+
 void testSwrLivenessAgreesWithTxMeterFreshness()
 {
     MeterModel model;
@@ -595,6 +635,7 @@ int main(int argc, char** argv)
     testSwrWithoutForwardPowerBackendIsValid();
     testStaleSwrIsAlsoSuppressedInMetersForSource();
     testStaleTxMetersDoNotSuppressReceiveMeters();
+    testSwrRecoversAfterAFreshSampleFollowsAStaleWindow();
     testSwrLivenessAgreesWithTxMeterFreshness();
 
     return g_failed == 0 ? 0 : 1;

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -1,6 +1,9 @@
 #include "models/MeterModel.h"
 
 #include <QCoreApplication>
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonObject>
 #include <QVector>
 
 #include <cmath>
@@ -221,7 +224,8 @@ void testDirectionalPowerUsesDirectReflectedMeter()
     QObject::connect(&model, &MeterModel::directionalPowerMetersChanged,
                      [&emitted, &forwardWatts, &reflectedWatts, &swr,
                       &reflectedPowerMeasured](float forward, float reflected,
-                                               float ratio, bool measured) {
+                                               float ratio, bool /*swrValid*/,
+                                               bool measured) {
         emitted = true;
         forwardWatts = forward;
         reflectedWatts = reflected;
@@ -355,6 +359,215 @@ void testForwardPowerJustAboveTheThresholdStaysSmoothed()
            keyed > 4.0f && after > 0.01f);
 }
 
+// Find a meter entry by name in the allMeters() array.
+QJsonObject meterNamed(const QJsonArray& all, const QString& name)
+{
+    for (const auto& v : all) {
+        const QJsonObject o = v.toObject();
+        if (o.value(QStringLiteral("name")).toString() == name)
+            return o;
+    }
+    return {};
+}
+
+// #4533: SWR is derived from forward/reflected power, so once the TX meters go
+// stale it is a leftover from the previous transmit, not a measurement. Showing
+// it as live sends the operator hunting a non-existent antenna fault.
+void testSwrIsLiveWhileTxMetersAreFresh()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.updateValues({8, 10}, {rawDb(30.0f), rawDb(2.88f)});
+
+    const QJsonObject swr = meterNamed(model.allMeters(), QStringLiteral("SWR"));
+    report("MeterModel reports SWR as live immediately after a TX sample",
+           swr.value(QStringLiteral("has_value")).toBool()
+               && nearlyEqual(static_cast<float>(swr.value(QStringLiteral("value")).toDouble()),
+                              2.88f)
+               && model.swrIfLive().has_value());
+}
+
+// The GUI reads SWR from the SIGNALS, not from allMeters(). Gating only the
+// array left the displayed value untouched — an HL2 showed 255.99 on screen
+// while the meter list correctly reported no value. Assert the signals too.
+void testStaleSwrIsNotEmittedToConsumers()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    float txSwr = -1.0f;
+    float dirSwr = -1.0f;
+    bool txSwrValid = false;
+    bool dirSwrValid = false;
+    QObject::connect(&model, &MeterModel::txMetersChanged,
+                     [&txSwr, &txSwrValid](float, float swr, bool valid) {
+        txSwr = swr; txSwrValid = valid;
+    });
+    QObject::connect(&model, &MeterModel::directionalPowerMetersChanged,
+                     [&dirSwr, &dirSwrValid](float, float, float swr,
+                                             bool valid, bool) {
+        dirSwr = swr; dirSwrValid = valid;
+    });
+
+    // A real transmit — forward power AND a ratio in the same packet. Both
+    // signals must carry the measured value.
+    model.updateValues({8, 10}, {rawDb(36.5f), rawDb(2.5f)});
+    const bool liveOk = nearlyEqual(txSwr, 2.5f) && nearlyEqual(dirSwr, 2.5f);
+
+    // Now the case that reached the screen: the carrier stops, so forward power
+    // reads 0 dBm, and the radio keeps chattering a saturated SWR — 255.99, the
+    // ratio of two noise samples — with no power behind it.
+    model.updateValues({8, 10}, {rawDb(0.0f), rawDb(255.99f)});
+
+    report("MeterModel does not emit a saturated SWR with no forward power (txMetersChanged)",
+           liveOk && txSwr < 100.0f && !txSwrValid);
+    report("MeterModel does not emit a saturated SWR with no forward power (directional)",
+           liveOk && dirSwr < 100.0f && !dirSwrValid);
+}
+
+// The configuration the review found uncovered (#4536 blocker 1): a backend
+// that declares FWDPWR but NEVER publishes it — the HL2, whose forward counts
+// are uncalibrated so it deliberately sends only TX:SWR, itself gated at the
+// source on real drive. Its SWR must publish as VALID on its own freshness:
+// the earlier forward-power gate zeroed it forever, hiding a real mismatch on
+// the one backend whose SWR is most trustworthy.
+void testSwrWithoutForwardPowerBackendIsValid()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));   // declared, never sent
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    float txSwr = -1.0f;
+    bool  txSwrValid = false;
+    QObject::connect(&model, &MeterModel::txMetersChanged,
+                     [&txSwr, &txSwrValid](float, float swr, bool valid) {
+        txSwr = swr; txSwrValid = valid;
+    });
+
+    // HL2 keyed into a genuine 3:1 mismatch: SWR arrives, FWDPWR never does.
+    model.updateValues({10}, {rawDb(3.0f)});
+
+    report("HL2-shaped backend (SWR, no FWDPWR ever) publishes a VALID SWR",
+           txSwrValid && nearlyEqual(txSwr, 3.0f)
+               && model.swrIfLive().has_value());
+
+    // And the same reading goes ABSENT once the sample itself ages out.
+    model.setLastSwrUpdateMsForTest(
+        QDateTime::currentMSecsSinceEpoch() - MeterModel::kTxMeterStaleMs - 1);
+    report("HL2-shaped backend SWR goes absent when the sample ages",
+           !model.swrIfLive().has_value());
+}
+
+void testSwrIsSuppressedOnceTxMetersGoStale()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.updateValues({8, 10}, {rawDb(30.0f), rawDb(2.88f)});
+
+    // Age the TX meters past the staleness window without sleeping.
+    model.setLastTxMeterUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    // SWR gates on its own stamp now (#4536) — age it in step.
+    model.setLastSwrUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+
+    const QJsonObject swr = meterNamed(model.allMeters(), QStringLiteral("SWR"));
+    report("MeterModel suppresses a stale SWR reading (has_value=false, age=-1)",
+           swr.value(QStringLiteral("has_value")).toBool() == false
+               && swr.value(QStringLiteral("value")).isNull()
+               && swr.value(QStringLiteral("age_ms")).toInt() == -1
+               && !model.swrIfLive().has_value());
+}
+
+// metersForSource() is a second view of the same model, and it duplicated
+// allMeters()' loop WITHOUT the gate — so a `tx`-source query answered
+// has_value=true for the very meter `all` reported as absent. Two views of one
+// model disagreeing about one reading is the disagreement #4533 was filed about,
+// so both have to answer the same way.
+void testStaleSwrIsAlsoSuppressedInMetersForSource()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.updateValues({8, 10}, {rawDb(30.0f), rawDb(2.88f)});
+    model.setLastTxMeterUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    // SWR gates on its own stamp now (#4536) — age it in step.
+    model.setLastSwrUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+
+    const QJsonObject fromAll =
+        meterNamed(model.allMeters(), QStringLiteral("SWR"));
+    const QJsonArray txSource = model.metersForSource(QStringLiteral("TX-"), 8);
+    const QJsonObject fromSource =
+        meterNamed(txSource, QStringLiteral("SWR"));
+
+    report("MeterModel suppresses a stale SWR in metersForSource too",
+           // Guard against a vacuous pass: the query must actually have matched.
+           !txSource.isEmpty()
+               && fromSource.value(QStringLiteral("has_value")).toBool() == false
+               && fromSource.value(QStringLiteral("value")).isNull()
+               && fromSource.value(QStringLiteral("age_ms")).toInt() == -1
+               // and the two views agree, which is the actual invariant
+               && fromSource.value(QStringLiteral("has_value"))
+                      == fromAll.value(QStringLiteral("has_value")));
+}
+
+// The suppression must be specific to SWR — a receive meter that has nothing to
+// do with the transmit path must keep reporting while the radio is idle.
+void testStaleTxMetersDoNotSuppressReceiveMeters()
+{
+    MeterModel model;
+    model.defineMeter(slcMeter(3, 0));
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+
+    model.updateValues({3, 10}, {rawDb(-64.0f), rawDb(2.88f)});
+    model.setLastTxMeterUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    // SWR gates on its own stamp now (#4536) — age it in step.
+    model.setLastSwrUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+
+    const QJsonArray all = model.allMeters();
+    const QJsonObject swr = meterNamed(all, QStringLiteral("SWR"));
+    const QJsonObject lvl = meterNamed(all, QStringLiteral("LEVEL"));
+
+    report("MeterModel keeps receive meters live when the TX meters are stale",
+           swr.value(QStringLiteral("has_value")).toBool() == false
+               && lvl.value(QStringLiteral("has_value")).toBool() == true);
+}
+
+// The freshness flag the support-bundle snapshot publishes must agree with the
+// SWR gate it is meant to explain.
+//
+// RadioModel::troubleshootingSnapshot() reports tx_forward_power_w (which holds
+// its last smoothed value) next to tx_swr (which goes null once the TX meters
+// go stale), and qualifies the pair with tx_meters_fresh. If that flag could
+// ever read true while swrIfLive() returned nullopt, the caveat would be absent
+// exactly when it is needed and the reader would take the held wattage for a
+// live one. Both derive from hasRecentTxMeters(kTxMeterStaleMs); this pins that
+// they cannot disagree. (#4533 review)
+void testSwrLivenessAgreesWithTxMeterFreshness()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(10, "SWR", "SWR"));
+    model.updateValues({10}, {rawDb(2.88f)});
+
+    const bool freshWhileLive = model.hasRecentTxMeters(MeterModel::kTxMeterStaleMs);
+    const bool haveSwrWhileLive = model.swrIfLive().has_value();
+
+    model.setLastTxMeterUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+    // SWR gates on its own stamp now (#4536) — age it in step.
+    model.setLastSwrUpdateMsForTest(QDateTime::currentMSecsSinceEpoch() - (MeterModel::kTxMeterStaleMs + 500));
+
+    const bool freshWhenStale = model.hasRecentTxMeters(MeterModel::kTxMeterStaleMs);
+    const bool haveSwrWhenStale = model.swrIfLive().has_value();
+
+    report("MeterModel TX-meter freshness and SWR liveness agree in both directions",
+           freshWhileLive && haveSwrWhileLive
+               && !freshWhenStale && !haveSwrWhenStale);
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -376,6 +589,13 @@ int main(int argc, char** argv)
     testForwardPowerDoesNotLingerAcrossRepeatedNoCarrierSamples();
     testForwardPowerStillSmoothsRealReadings();
     testForwardPowerJustAboveTheThresholdStaysSmoothed();
+    testSwrIsLiveWhileTxMetersAreFresh();
+    testSwrIsSuppressedOnceTxMetersGoStale();
+    testStaleSwrIsNotEmittedToConsumers();
+    testSwrWithoutForwardPowerBackendIsValid();
+    testStaleSwrIsAlsoSuppressedInMetersForSource();
+    testStaleTxMetersDoNotSuppressReceiveMeters();
+    testSwrLivenessAgreesWithTxMeterFreshness();
 
     return g_failed == 0 ? 0 : 1;
 }

--- a/tools/tx_meter_test.py
+++ b/tools/tx_meter_test.py
@@ -115,8 +115,13 @@ def sample_window(tx, dur=1.4, settle=0.2):
             m = tx.meters()
             if m.get("fwdPowerAgeMs", 1e9) < FRESH_MS and m.get("fwdPower", 0) > 0.3:
                 fwd.append(m["fwdPower"])
-            if m.get("swrAgeMs", 1e9) < FRESH_MS:
-                swr.append(m.get("swr", 0))
+            # swr is null when no live sample exists, and swrAgeMs is -1
+            # when no sample EVER arrived -- both mean "no data", not 0.0,
+            # and -1 must not pass a < FRESH_MS check (#4536).
+            swr_age = m.get("swrAgeMs", 1e9)
+            swr_val = m.get("swr")
+            if 0 <= swr_age < FRESH_MS and swr_val is not None:
+                swr.append(swr_val)
             temp.append(m.get("paTemp", 0)); volts.append(m.get("supplyVolts", 0))
             alc.append(m.get("swAlc", -150))
             pv, pa, prel = Tx.meter_from_all(m, "PACURRENT")


### PR DESCRIPTION
Fixes #4533.

## The bug

While receiving — no transmit for ~16 minutes — the SWR meter kept reporting the value measured during the *previous* transmit. On a Hermes-Lite 2 that was a steady `SWR 2.88`, which reads as a live antenna fault. It sent me looking for a coax problem on a station that was working perfectly (5 W FT8, 6000+ miles).

The snapshot already contained everything needed to catch this and simply did not act on it for SWR:

```json
"swr": 2.8828125,
"swrAgeMs": 994091,          // 16.5 MINUTES old
"txMetersFresh": false,      // AE knows the TX meters are stale

"fwdPower": 0, "fwdPowerAgeMs": -1,
"reflectedPower": 0, "reflectedPowerAgeMs": -1,
"reflectedPowerMeasured": false
```

and in `all`:

```json
{"name":"FWDPWR","has_value":false,"age_ms":-1,"value":null}
{"name":"REFPWR","has_value":false,"age_ms":-1,"value":null}
{"name":"SWR",   "has_value":true, "age_ms":994091,"value":2.8828125}
```

**FWDPWR and REFPWR correctly report `has_value:false`, but SWR — which is derived from exactly those two — claims to be live.** If forward and reflected power are unknown, SWR cannot be known.

Two details confirm it is a stale latch rather than a live reading: `MICPEAK`'s age was 993956, within ~135 ms of SWR's 994091, so both froze at the end of the last transmit; and `LEVEL` (16 ms) and `PATEMP` (100 ms) were updating normally throughout, so the meter pipeline itself is healthy.

## Why it matters

SWR is the one meter an operator reacts to physically. A persistent 2.9:1 at idle prompts exactly the wrong response — checking coax, connectors, antenna — for a condition that does not exist.

## The rule already exists — the radio's own meter path is the one place it is missing

Three call sites already gate SWR on drive or freshness, each with a comment saying the value is meaningless without it:

- `RigctlProtocol.cpp:1282` requires **both** `txMetersActive` and `hasRecentTxMeters(kTxMeterFreshMs)`, returning `0.0f` otherwise.
- `AmpApplet.cpp:341` — *"SWR: only show value when power is present (SWR is unmeasurable at idle)"*.
- `AcomApplet.cpp:336` — *"without forward drive SWR is undefined, so hold the gauge at 1.0 rather than tracking a garbage ratio."*

`MeterModel::hasRecentTxMeters()` already exists, and `metersSnapshot()` already calls it to publish `txMetersFresh` **right beside the SWR value it describes**. The check was computed and reported, just not applied.

## What this changes

- `MeterModel::allMeters()` gives SWR the same contract FWDPWR/REFPWR already have: when the TX meters are stale, `has_value:false`, `value:null`, `age_ms:-1` instead of the last-known ratio.
- Adds `MeterModel::swrIfLive()` returning `std::optional<float>` for display paths, and `kTxMeterStaleMs = 2000` — matching the window `AutomationServer` already uses for `txMetersFresh`, so the flag and the value it describes cannot disagree. `RigctlProtocol` keeps its tighter 1500 ms + active-transmit gate; stricter, not conflicting.
- `RadioModel`'s telemetry snapshot nulls `tx_swr` when stale rather than recording a leftover ratio into a **support bundle**, where it is even harder to recognise as stale.

Deliberately narrow: only SWR changes. Other meters keep last-known values, which is correct for them — `PATEMP` and `LEVEL` remain meaningful between transmits in a way a power ratio does not.

## Relationship to #4487

@jensenpat hit the same underlying behaviour from the certification side and documented it there:

> `MeterModel` keeps last-known readings and never clears them, so "is there forward power now" was answered by the SWR left over from the previous keyed stage — reported as a carrier while the transmitter sent silence.

That PR works around it per-caller ("every meter read carries an age, and stages ignore anything older than 3 s") and its capability table already lists **`TX:SWR` idle → expected absent**, which is exactly what this makes true at the model. The two are complementary and touch different code: #4487 only *adds* `valueAgeMs()`, it does not change `allMeters()`. This removes the need for the age filter on SWR specifically.

## Testing

Three regression tests in the existing `meter_model_test`, each confirmed to **fail against the unfixed code**:

```
[ OK ] MeterModel reports SWR as live immediately after a TX sample
[FAIL] MeterModel suppresses a stale SWR reading (has_value=false, age=-1)     <- before
[FAIL] MeterModel keeps receive meters live when the TX meters are stale       <- before
```

and to pass with it (all 20 cases green, exit 0). The third asserts the suppression is specific to SWR — a receive meter must keep reporting while the radio is idle.

Also run: `aetherd_meter_decode_test` (exit 0), `amp_model_test` (exit 0). `cross_needle_meter_test` has 2 failures — a font-metrics cache and a colour value — **verified identical on unmodified `b007e0cc`**, so pre-existing and unrelated.

Full `AetherSDR.exe` builds and links clean on Windows/MSVC.

## Verification status

Found and diagnosed on **real hardware**: Hermes-Lite 2, gateware 7.4, v26.7.4, via the automation bridge. Confirmed **not fixed by v26.7.4.1**, which carries only #4501 plus two CI commits and touches no meter path.

⚠ Not verified on a Flex. The meter values arrive by a different route there, so it is possible a Flex refreshes or clears SWR on its own and never shows the stale value — the fix is a no-op in that case, since it only suppresses readings the model itself reports as stale. Worth a second pair of eyes from someone with a Flex on the bench.


---

## Scope: what this does NOT cover

This fixes the **snapshot/automation** surfaces — `allMeters()`, `metersForSource()` and `metersSnapshot()`'s top-level scalar — so no consumer of `get {"model":"meters"}` sees a stale ratio presented as live.

It does **not** change the GUI path. `txMetersChanged` → `VfoWidget::setTxSwr` is push-based and holds its last value, so a widget rendering SWR still shows the previous reading rather than blanking. That is harmless in practice because the VFO only renders the TX meter while transmitting, but #4533 also asks that any GUI meter rendering SWR should blank rather than hold, and that part is deliberately out of scope here.

Flagging it so the issue is not auto-closed as fully fixed on merge.
