### PR TITLE
feat(caps): hasGpsLocation, and give the health SWR the floor the meter already has

### DIFF
--- a/src/core/backends/RadioCapabilities.h
+++ b/src/core/backends/RadioCapabilities.h
@@ -128,6 +128,18 @@ struct RadioCapabilities {
     // configuration UI goes away.
     bool hasMultiClientSessions = false;
 
+    // The RADIO reports its own position/time from an on-board GNSS receiver, so
+    // a client can offer a live GPS readout and the station-location dashboard
+    // it feeds.
+    //
+    // This is about the radio as a POSITION SOURCE, not about the client knowing
+    // where the station is. A grid square the operator typed into settings is
+    // not this capability, and must never be gated on it — a radio with
+    // hasGpsLocation=false still has a station location, it just cannot tell you
+    // what it is. That distinction is why the flag is named for the receiver
+    // rather than for the dashboard it happens to drive today.
+    bool hasGpsLocation = false;
+
     // Vendor-specific capabilities, keyed by extension namespace. Clients that
     // don't understand a namespace ignore it; a backend never puts core-profile
     // fields here. Example: {"flex": {"multiFlex": true, "guiClientId": "…"}}.

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -158,7 +158,31 @@ RadioCapabilities FlexBackend::capabilities() const
     caps.hasRadioSideDsp = true;
     caps.hasWaveforms = true;            // installable SmartSDR waveforms
     caps.hasMultiClientSessions = true;  // multiFLEX
-    caps.hasGpsLocation = true;          // GPSDO / on-board GNSS, `gps` status
+    // GPSDO / on-board GNSS, reported through the `gps` status.
+    //
+    // TRUE for every Flex, and deliberately COARSER than
+    // RadioModel::hasGpsHardware(). The two answer different questions and both
+    // are needed:
+    //
+    //   - this flag: "can a radio of this family have GPS at all" — a family
+    //     fact, which is what the capability seam is for and all a backend can
+    //     honestly assert before any status has arrived;
+    //   - hasGpsHardware(): "does THIS unit have it" — model name (8400/8600/
+    //     AU-) OR a live `gps` status that is not "Not Present".
+    //
+    // Do not narrow this to the model-name test to match. That clause is one
+    // half of an OR: a FLEX-6700 with an optional GPSDO installed answers true
+    // through the STATUS clause, and a model-name test here would hide GPS on
+    // exactly those radios — a regression in the opposite direction from the one
+    // it would appear to fix.
+    //
+    // Consequence, and it is pre-existing rather than introduced by the
+    // capability gate: a GPSDO-less 6000-series still shows the GPS button
+    // reading [Waiting] forever, because this flag alone gates it. Fixing that
+    // means the gate consulting both — see the follow-up issue; it is not a
+    // one-line change, because the gate's test helper mirrors
+    // `!connected || declared` exactly.
+    caps.hasGpsLocation = true;
 
     // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
     // autotune verbs are now routed through invokeExtension() (#4092/#4094), and

--- a/src/core/backends/flex/FlexBackend.cpp
+++ b/src/core/backends/flex/FlexBackend.cpp
@@ -158,6 +158,7 @@ RadioCapabilities FlexBackend::capabilities() const
     caps.hasRadioSideDsp = true;
     caps.hasWaveforms = true;            // installable SmartSDR waveforms
     caps.hasMultiClientSessions = true;  // multiFLEX
+    caps.hasGpsLocation = true;          // GPSDO / on-board GNSS, `gps` status
 
     // Advertise the "flex" extension namespace: the amp/tuner operate/bypass/
     // autotune verbs are now routed through invokeExtension() (#4092/#4094), and

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -43,6 +43,22 @@ SampleRate sampleRateEnum(int hz) noexcept
 // drift apart, which is exactly the failure being fixed here.
 constexpr int kIqSampleRatesHz[] = {48000, 96000, 192000, 384000};
 
+// Minimum forward-power reading, in raw converter counts, below which an SWR
+// ratio is noise rather than a measurement.
+//
+// With no carrier, forward and reverse are both near zero and dominated by
+// noise; reverse frequently exceeds forward and the ratio saturates. An
+// operator glancing at that sees a catastrophic mismatch on an antenna that is
+// fine. Raw counts because that is what we have — this is a noise floor, not a
+// calibrated power level.
+//
+// File-scope so EVERY consumer shares one threshold. It was previously local to
+// the meter path, so the Radio Health snapshot computed an unguarded ratio and
+// bounced at its 500 ms refresh while the meter beside it stayed silent — two
+// surfaces disagreeing about the same radio because only one of them had the
+// guard.
+constexpr int kMinForwardCountsForSwr = 16;
+
 // Snap a requested span (Hz) to the rate that best matches it.
 //
 // Nearest in the LOG domain, not the linear one: the rates are octave-spaced, so
@@ -447,6 +463,7 @@ RadioCapabilities Hl2Backend::capabilities() const
     c.hasRadioSideDsp = false;
     c.hasWaveforms = false;             // no installable plugin surface
     c.hasMultiClientSessions = false;   // one client owns the radio
+    c.hasGpsLocation = false;           // no GNSS receiver on the board
     // No extension namespaces (no invokeExtension verbs yet), matching FlexBackend.
     return c;
 }
@@ -1224,9 +1241,16 @@ IRadioBackend::HealthSnapshot Hl2Backend::healthSnapshot() const
     // Meaningful without calibration — it is a ratio of two readings from the
     // same converter, so the unknown scale cancels. Absent below the noise
     // floor, where a ratio of two noise samples is not a mismatch reading.
+    //
+    // That last sentence described the intent but not the code: this site had no
+    // floor, so with no carrier it recomputed a noise ratio at the dialog's
+    // 500 ms refresh and the row visibly bounced — while the TX:SWR meter, which
+    // did apply the floor, correctly showed nothing. Same guard here now, from
+    // the shared constant, so the two surfaces cannot disagree.
     {
         QVariant swr;
-        if (m_telemetry.forwardPowerRaw && m_telemetry.reversePowerRaw) {
+        if (m_telemetry.forwardPowerRaw && m_telemetry.reversePowerRaw
+            && *m_telemetry.forwardPowerRaw >= kMinForwardCountsForSwr) {
             if (const auto v = swrFromRaw(*m_telemetry.forwardPowerRaw,
                                           *m_telemetry.reversePowerRaw))
                 swr = *v;
@@ -1416,8 +1440,8 @@ void Hl2Backend::publishTelemetry(const Hl2Telemetry& t)
     // catastrophic mismatch on an antenna that is fine.
     //
     // The threshold is in raw counts because that is what we have; it is a
-    // noise floor, not a calibrated power level.
-    static constexpr int kMinForwardCountsForSwr = 16;
+    // noise floor, not a calibrated power level. It lives at file scope so the
+    // Radio Health snapshot applies the SAME floor — see kMinForwardCountsForSwr.
     if (t.forwardPowerRaw && t.reversePowerRaw
         && *t.forwardPowerRaw >= kMinForwardCountsForSwr) {
         if (const auto swr = swrFromRaw(*t.forwardPowerRaw, *t.reversePowerRaw))

--- a/src/core/backends/sim/SimBackend.cpp
+++ b/src/core/backends/sim/SimBackend.cpp
@@ -301,6 +301,7 @@ RadioCapabilities SimBackend::capabilities() const
     caps.hasRadioSideDsp = false;        // synthetic scene; no firmware DSP
     caps.hasWaveforms = false;
     caps.hasMultiClientSessions = false;
+    caps.hasGpsLocation = false;         // synthetic radio has no position source
     return caps;
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6253,6 +6253,17 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     if (!gps && m_gpsLocationDialog) {
         m_gpsLocationDialog->close();  // QPointer — guarded above
     }
+    // Recompute the status bar's floor, because these two widgets are ~90 px of
+    // it. Every other status-bar visibility site in this file pairs the two, and
+    // omitting it here happens to work only by connection order: on the connect
+    // and disconnect edges onConnectionStateChanged() recomputes AFTER this runs,
+    // because wireRadioModel() binds it before setupBackend() binds
+    // publishCapabilities. A mid-session capability revision — which
+    // capabilitiesChanged now delivers, and which is the whole point of routing
+    // through publishCapabilities() — has no such recompute behind it, and leaves
+    // the container's minimumSizeHint above the window minimum (a clipped status
+    // bar at narrow widths) or below it (a window that cannot be narrowed).
+    updateStatusBarMinimumWidth();
 
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -111,6 +111,7 @@
 #include "AmpApplet.h"
 #include "MeterApplet.h"
 #include "HealthApplet.h"
+#include "GpsLocationDialog.h"   // applyCapabilitiesToUi() closes it when hasGpsLocation goes false
 #include "PersistentDialog.h"
 #include "ProfileManagerDialog.h"
 #include "ProfileImportExportDialog.h"
@@ -4701,8 +4702,9 @@ void MainWindow::buildUI()
     gpsVbox->addWidget(m_gpsLabel);
     gpsVbox->addWidget(m_gpsStatusLabel);
     hbox->addWidget(gpsStack);
+    m_gpsStatusButton = gpsStack;
 
-    addSep();
+    m_gpsSeparator = addSep();
 
     // CPU (top) + Memory (bottom) stacked
     {
@@ -6217,6 +6219,41 @@ void MainWindow::applyCapabilitiesToUi(bool connected, const RadioCapabilities& 
     if (m_multiFlexAction) {
         m_multiFlexAction->setVisible(!connected || caps.hasMultiClientSessions);
     }
+
+    // ── GPS: the status-bar position readout and the dialog it opens ────────
+    //
+    // Measured on a live Hermes-Lite 2 before this gate existed: the button sat
+    // `visible:true, enabled:true` reading **"[Waiting]"** indefinitely, because
+    // that radio has no GNSS receiver and so never sends a `gps` status at all.
+    // A control that can only ever say "waiting" is worse than an absent one —
+    // it reads as a fix that has not arrived yet rather than a receiver that
+    // does not exist.
+    //
+    // NB this stack carries the 10 MHz reference readout as well as the
+    // satellite count, so hiding it removes both. That is right for a radio
+    // declaring no position source — the reference lock is a GPSDO/external-10M
+    // concept and the same stack's tooltip already read "Actual: Unknown /
+    // Lock: Unlocked" on the HL2 — but it is a second surface, so it is called
+    // out here rather than left for a reviewer to find.
+    //
+    // Hidden WITH its trailing separator, or the divider is left stranded
+    // between the neighbouring telemetry stacks.
+    //
+    // The dialog is closed rather than merely unreachable, for the same reason
+    // the Profile Manager is above: a live GPS dashboard left on screen against
+    // a radio that has no receiver reports "Waiting for a valid GPS fix"
+    // forever, which reads as a broken fix rather than an absent one.
+    const bool gps = !connected || caps.hasGpsLocation;
+    if (m_gpsStatusButton) {
+        m_gpsStatusButton->setVisible(gps);
+    }
+    if (m_gpsSeparator) {
+        m_gpsSeparator->setVisible(gps);
+    }
+    if (!gps && m_gpsLocationDialog) {
+        m_gpsLocationDialog->close();  // QPointer — guarded above
+    }
+
 }
 
 void MainWindow::applyRadioSideDspToOverlayMenu(SpectrumOverlayMenu* menu) const

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -89,6 +89,7 @@
 
 class QAbstractSlider;
 class QMediaDevices;
+class QPushButton;
 class QShowEvent;
 class QSystemTrayIcon;
 
@@ -1258,6 +1259,13 @@ private:
     QLabel* m_networkLabel{nullptr};
     QTimer m_networkTooltipRefreshTimer;
     QTimer m_perfHeartbeatTimer;
+    // GPS/station-location status-bar button and the separator that follows it.
+    // Both are held so applyCapabilitiesToUi() can hide them together on a radio
+    // with no position source — hiding the button alone would leave its " · "
+    // divider stranded between the neighbours (same reason m_tgxlSeparator is
+    // held below).
+    QPushButton* m_gpsStatusButton{nullptr};
+    QLabel*  m_gpsSeparator{nullptr};
     QLabel*  m_tgxlSeparator{nullptr};
     QWidget* m_tgxlContainer{nullptr};
     QLabel*  m_tgxlIndicator{nullptr};   // top row: "TUN"

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -207,6 +207,8 @@ int main(int argc, char** argv)
               "connected + hasWaveforms=false hides File > Waveforms");
         check(!uiWouldShow(model.isConnected(), caps.hasMultiClientSessions),
               "connected + hasMultiClientSessions=false hides Settings > multiFLEX");
+        check(!uiWouldShow(model.isConnected(), caps.hasGpsLocation),
+              "connected + hasGpsLocation=false hides the GPS stack and its separator");
 
         // hasRadioSideDsp reaches the UI through its own accessor, which applies
         // the permissive rule itself (there is no model-name table to fall back
@@ -253,6 +255,11 @@ int main(int argc, char** argv)
               "disconnected: File > Waveforms is restored");
         check(uiWouldShow(model.isConnected(), caps.hasMultiClientSessions),
               "disconnected: Settings > multiFLEX is restored");
+        // The GPS button is the ONLY entry point to the location dialog, so a
+        // gate that failed to reopen would strand the feature entirely after
+        // unplugging a radio that happened to lack GNSS.
+        check(uiWouldShow(model.isConnected(), caps.hasGpsLocation),
+              "disconnected: the GPS stack is restored");
         check(model.hasRadioSideDsp(),
               "disconnected: hasRadioSideDsp() goes permissive, radio DSP back");
     }
@@ -274,6 +281,11 @@ int main(int argc, char** argv)
               "round-trip: Flex regains hasWaveforms after sim -> Flex");
         check(caps.hasMultiClientSessions,
               "round-trip: Flex regains hasMultiClientSessions after sim -> Flex");
+        // The one that would catch a cached flag: the sim declares
+        // hasGpsLocation=false, so a stale value here hides the GPS stack on a
+        // Flex that has a GPSDO.
+        check(caps.hasGpsLocation,
+              "round-trip: Flex regains hasGpsLocation after sim -> Flex");
     }
 
     // ---- Flex extended DSP is unchanged by the reconciliation -------------

--- a/tests/radio_capability_gating_test.cpp
+++ b/tests/radio_capability_gating_test.cpp
@@ -125,6 +125,8 @@ int main(int argc, char** argv)
               "Flex declares hasWaveforms (installable SmartSDR waveforms)");
         check(caps.hasMultiClientSessions,
               "Flex declares hasMultiClientSessions (multiFLEX)");
+        check(caps.hasGpsLocation,
+              "Flex declares hasGpsLocation (GPSDO / on-board GNSS)");
         // The two DSP flags are independent statements, not synonyms: the base
         // set and the extra 8000-series filters. A default Flex model string is
         // unknown to the platform table, so the narrower one is false here while
@@ -153,6 +155,8 @@ int main(int argc, char** argv)
               "HL2 declares hasWaveforms=false");
         check(!caps.hasMultiClientSessions,
               "HL2 declares hasMultiClientSessions=false (one client owns it)");
+        check(!caps.hasGpsLocation,
+              "HL2 declares hasGpsLocation=false (no GNSS receiver on the board)");
     }
 
     // ---- Sim declares none of them, and is genuinely CONNECTED -----------
@@ -191,6 +195,7 @@ int main(int argc, char** argv)
         check(!caps.hasWaveforms, "Sim declares hasWaveforms=false");
         check(!caps.hasMultiClientSessions,
               "Sim declares hasMultiClientSessions=false");
+        check(!caps.hasGpsLocation, "Sim declares hasGpsLocation=false");
 
         // The surfaces the GUI drives off those flags, evaluated the way the
         // GUI evaluates them. A CONNECTED radio that says no means hidden.


### PR DESCRIPTION
> **Stacked on #4508** (`feat/capabilities-flex-only-ui`), which is itself stacked on #4503. Neither is on `main` yet, so the commit list below carries their ten commits as well. **Review only the single `feat(caps)` commit — `62b194d5`.** Merge #4503, then #4508, then this.
>
> Diff against #4508's tip is 7 files, +92/−4: `git diff 2d898ce0..`

Two items from the Hermes-Lite bring-up list. Both are the same shape — a surface telling the operator something the radio cannot actually say — and both follow #4508's rule: **gate on a declared capability named for the concept, never on which radio it is.**

## 1. `hasGpsLocation`

**Measured on a live Hermes-Lite 2 before this existed**, via the automation bridge:

```json
{"objectName":"gpsStatusButton", "visible":true, "enabled":true,
 "toolTip":"Open GPS & Station Location"}
   child label value: "[Waiting]"
```

The button sits there enabled, reading **`[Waiting]`** indefinitely, because the HL2 has no GNSS receiver and never sends a `gps` status at all. A control that can only ever say "waiting" is worse than an absent one — it reads as a fix that has not arrived yet rather than a receiver that does not exist.

Declared explicitly by all three backends, as the struct's own warning requires (an omitted field silently deletes a shipping Flex feature):

| Backend | Value | Basis |
|---|---|---|
| Flex | `true` | emits `gpsChanged`; the platform table documents GPSDO-equipped 6000-series |
| HL2 | `false` | verified — no GPS code anywhere in the backend |
| Sim | `false` | synthetic radio has no position source |

**The flag is named for the radio as a POSITION SOURCE, not for the dashboard it happens to drive today.** A grid square the operator typed into settings is not this capability and must never be gated on it: a radio with `hasGpsLocation=false` still *has* a station location, it just cannot tell you what it is. Naming it `hasGpsDashboard` would have tied the capability to today's UI instead of to the radio.

Gated with the same `!connected || caps.x` permissive rule as its neighbours in `applyCapabilitiesToUi()`.

Two details worth a reviewer's eye:

- **Hidden with its trailing separator.** Hiding the button alone strands its ` · ` divider between the neighbouring telemetry stacks — the same reason `m_tgxlSeparator` is already held as a member.
- **The dialog is closed, not merely unreachable**, for the reason the Profile Manager is: a GPS dashboard left open against a radio with no receiver reports "Waiting for a valid GPS fix" forever.

⚠ **The stack carries the 10 MHz reference readout as well as the satellite count, so hiding it removes both.** That is correct for a radio declaring no position source — reference lock is a GPSDO/external-10M concept, and the same tooltip already read `Actual: Unknown / Lock: Unlocked` on the HL2 — but it is a second surface, so it is called out in the code comment rather than left to be discovered. If a radio ever has a 10 MHz input *without* GNSS, that wants its own capability.

## 2. Radio Health SWR bounced at idle

`Hl2Backend`'s **meter** path already refuses to publish SWR below a forward-power floor, with a comment explaining exactly why:

> with no carrier the forward and reverse counts are both near zero and dominated by noise, reverse frequently exceeds forward, and the computed ratio saturated the meter at 255.99:1 — a dramatic reading of nothing at all.

The **health snapshot** had no such guard. Its comment claimed one — *"Absent below the noise floor, where a ratio of two noise samples is not a mismatch reading"* — but the code computed the ratio whenever both raw values existed:

```cpp
if (m_telemetry.forwardPowerRaw && m_telemetry.reversePowerRaw) {   // no floor
    if (const auto v = swrFromRaw(...)) swr = *v;
}
```

So at the dialog's 500 ms refresh the SWR row recomputed a noise ratio twice a second and visibly bounced, **while the TX:SWR meter beside it correctly showed nothing** — two surfaces disagreeing about the same radio because only one of them had the check.

`kMinForwardCountsForSwr` moves from function-local to file scope so both consumers share one threshold. Two copies of a noise floor is how they drift apart.

**Distinct from #4533/#4536.** That is *stale* SWR persisting after a transmit (the meter holds a last-known value); this is *noise* SWR computed at idle. Same wrong reading on screen, two unrelated causes, and fixing either alone leaves the other.

## Verification

- `radio_capability_gating_test` — **exit 0**, extended with `hasGpsLocation` assertions for all three backends plus the `uiWouldShow` permissive-rule check, in the style already established there.
- `hl2_metis_protocol_test` — **exit 0**.
- Full `AetherSDR.exe` builds and links clean on Windows/MSVC.

**Not verified on hardware:** the HL2 evidence above is the *pre-fix* state, captured from the running radio. I have not yet run a build of this branch against the HL2 to watch the button disappear, nor against a Flex to confirm it stays. The capability test covers the declarations and the gating rule; the visual confirmation is still owed, and I would rather say so than imply it was done.
