### PR TITLE
fix(display): stabilize 3D FFT and waterfall history

### DIFF
--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -9,6 +9,8 @@ layout(location = 1) in float vDepth;
 layout(location = 2) in float vEdge;
 layout(location = 3) in float vBoundaryFade;
 layout(location = 4) in float vFrequency;
+layout(location = 5) in float vLayerAlpha;
+layout(location = 6) in float vRibbonCoord;
 
 layout(std140, binding = 0) uniform U {
     float rowOffset;
@@ -20,21 +22,22 @@ layout(std140, binding = 0) uniform U {
     float frontMaxRidgeFrac;
     float haze;
     float texCols;
-    float frequencyScale;
-    float frequencyOffset;
-    float frequencyPreview;
+    float targetBandwidthMhz;
+    float targetCenterOffsetMhz;
+    float rowFrequencyFrames;
     float scrollProgressRows;
     float texRows;
     float scrollDistanceRows;
     float colorRangeDb;
     float validRows;
-    float padding17;
-    float padding18;
-    float padding19;
+    float visibleRows;
+    float plotWidthPx;
+    float plotHeightPx;
     vec4  bgFill;
     vec4  shadowBands[8];
     vec4  shadowStyles[8];
     vec4  shadowMeta;
+    vec4  rowFrames[104];
 };
 
 layout(binding = 2) uniform sampler2D paletteLut;  // 256x1 RGBA8, floor(0)->peak(1)
@@ -48,8 +51,9 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
     }
 
     int descriptorCount = int(clamp(shadowMeta.x, 0.0, 8.0));
-    float plotWidthPx = max(shadowMeta.z, 1.0);
-    float frequencyPixel = max(fwidth(vFrequency), 1.0 / plotWidthPx);
+    float shadowPlotWidthPx = max(shadowMeta.z, 1.0);
+    float frequencyPixel =
+        max(fwidth(vFrequency), 1.0 / shadowPlotWidthPx);
     vec3 color = surfaceColor;
     for (int i = 0; i < 8; ++i) {
         if (i >= descriptorCount) {
@@ -85,14 +89,26 @@ vec3 applySliceShadow(vec3 surfaceColor, float depthFade)
 
 void main()
 {
+    if (vBoundaryFade <= 0.0 || vLayerAlpha <= 0.0) {
+        discard;
+    }
     float fade = clamp(1.0 - vDepth, 0.0, 1.0);   // 1 at front, 0 at back
     float shadowFade = pow(fade, 1.15);
 
     if (vEdge < -0.5) {
-        // Original neutral ridge highlight over the amplitude-coloured curtain.
+        // Neutral ridge highlight over the amplitude-coloured curtain. The
+        // outline is a screen-space ribbon rather than a line primitive:
+        // analytical edge coverage changes continuously as the trace moves
+        // through subpixels instead of toggling whole pixels on and off.
         vec3 oc = mix(bgFill.rgb, vec3(0.92), 0.45 + 0.55 * fade);
         oc = applySliceShadow(oc, shadowFade);
-        float a = (0.12 + 0.5 * fade) * vBoundaryFade;
+        float flatOutline = 1.0 - smoothstep(0.0, 0.035, vLut);
+        float flatOutlineScale = mix(1.0, 0.42, flatOutline);
+        float ribbonCoverage =
+            1.0 - smoothstep(0.15, 1.0, abs(vRibbonCoord));
+        float a =
+            (0.12 + 0.5 * fade) * vBoundaryFade * vLayerAlpha
+            * flatOutlineScale * ribbonCoverage;
         fragColor = vec4(oc, a);
         return;
     }
@@ -101,5 +117,5 @@ void main()
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
     c = mix(bgFill.rgb, c, vBoundaryFade);
     c = applySliceShadow(c, shadowFade);
-    fragColor = vec4(c, 1.0);
+    fragColor = vec4(c, vLayerAlpha);
 }

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -38,6 +38,8 @@ layout(std140, binding = 0) uniform U {
     vec4  shadowBands[8];
     vec4  shadowStyles[8];
     vec4  shadowMeta;
+    // Must match DssRenderer::kRows; SpectrumWidget enforces 104 with a
+    // static_assert so a C++ row-count change cannot silently overrun this UBO.
     vec4  rowFrames[104];
 };
 

--- a/resources/shaders/dss_mesh.frag
+++ b/resources/shaders/dss_mesh.frag
@@ -11,6 +11,7 @@ layout(location = 3) in float vBoundaryFade;
 layout(location = 4) in float vFrequency;
 layout(location = 5) in float vLayerAlpha;
 layout(location = 6) in float vRibbonCoord;
+layout(location = 7) flat in float vOverlayLayer;
 
 layout(std140, binding = 0) uniform U {
     float rowOffset;
@@ -106,9 +107,34 @@ void main()
         float flatOutlineScale = mix(1.0, 0.42, flatOutline);
         float ribbonCoverage =
             1.0 - smoothstep(0.15, 1.0, abs(vRibbonCoord));
-        float a =
-            (0.12 + 0.5 * fade) * vBoundaryFade * vLayerAlpha
-            * flatOutlineScale * ribbonCoverage;
+        float perspectiveWidth =
+            mix(1.0, backWidthFrac, clamp(vDepth, 0.0, 1.0));
+        float sideDistancePx =
+            max(min(vFrequency, 1.0 - vFrequency), 0.0)
+            * max(plotWidthPx, 1.0) * perspectiveWidth;
+        // The stacked endpoints form a high-contrast comb against the black
+        // outside of the perspective surface. Successive exact FFT rows can
+        // legitimately put those endpoints at different heights, so any
+        // endpoint crossfade either blinks or morphs vertically. Fade the
+        // narrow exposed side strip of the neutral ridge; every interior
+        // outline remains exact.
+        float sideOutlineScale = smoothstep(0.0, 8.0, sideDistancePx);
+        float outlineOpacity =
+            (0.12 + 0.5 * fade) * vBoundaryFade
+            * flatOutlineScale * ribbonCoverage * sideOutlineScale;
+        float a;
+        if (vOverlayLayer > 0.5) {
+            // Base is drawn first with opacity A*(1-t). Compensate the overlay
+            // under source-over blending so coincident old/new ridge pixels
+            // retain opacity A rather than dimming at the middle of every
+            // crossfade: Ab + Ao*(1-Ab) = A.
+            float baseAlpha =
+                outlineOpacity * (1.0 - vLayerAlpha);
+            a = outlineOpacity * vLayerAlpha
+                / max(1.0 - baseAlpha, 0.0001);
+        } else {
+            a = outlineOpacity * vLayerAlpha;
+        }
         fragColor = vec4(oc, a);
         return;
     }
@@ -117,5 +143,14 @@ void main()
     c = mix(c, bgFill.rgb, clamp(vDepth * haze, 0.0, 1.0));
     c = mix(bgFill.rgb, c, vBoundaryFade);
     c = applySliceShadow(c, shadowFade);
-    fragColor = vec4(c, vLayerAlpha);
+    float perspectiveWidth =
+        mix(1.0, backWidthFrac, clamp(vDepth, 0.0, 1.0));
+    float sideDistancePx =
+        max(min(vFrequency, 1.0 - vFrequency), 0.0)
+        * max(plotWidthPx, 1.0) * perspectiveWidth;
+    // The curtain has the same exposed stacked endpoints as the ridge. Fade
+    // only the narrow side strip so adjacent curtain heights cannot form a
+    // flashing comb against the black outside of the perspective surface.
+    float sideSurfaceScale = smoothstep(0.0, 8.0, sideDistancePx);
+    fragColor = vec4(c, vLayerAlpha * sideSurfaceScale);
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -3,10 +3,10 @@
 // 3DSS GPU height-map mesh. Each vertex carries its grid position (u = column,
 // v = row/depth) and an edge tag. The height comes from a ring-buffered dBm
 // texture; geometry is a receding perspective trapezoid built entirely on the
-// GPU, so pan/zoom never rebuild any vertices. The perspective grid stays
-// fixed at the leading/trailing rows while exact interior rows translate
-// through depth. Only those two boundary rows crossfade, avoiding whole-surface
-// shimmer without letting either timeline edge move.
+// GPU, so pan/zoom never rebuild any vertices. Curtains carry exact retained
+// rows through depth. Their white ridge outlines stay on the fixed perspective
+// grid and crossfade between exact rows, avoiding both interpolated peak bounce
+// and the coverage shimmer caused by translating a dense outline stack.
 // Outputs NDC directly (matching spectrum.vert).
 
 layout(location = 0) in vec3 inVert;   // x = u [0,1] col, y = v [0,1) row(0=front), z = edge
@@ -51,6 +51,7 @@ layout(location = 3) out float vBoundaryFade;
 layout(location = 4) out float vFrequency;
 layout(location = 5) out float vLayerAlpha;
 layout(location = 6) out float vRibbonCoord;  // -1..+1 across AA outline
+layout(location = 7) flat out float vOverlayLayer;
 
 vec4 sampleHistory(float texU, float sourceAge, float rows)
 {
@@ -160,7 +161,16 @@ void main()
         sourceAge < 0.5 || sourceAge > depthRows - 1.5;
     float sampleAge;
     float geometryV;
-    if (boundaryRow) {
+    if (ribbonOutline) {
+        // Keep the dense white ridge stack phase-stable. Crossfade whole exact
+        // FFT shapes at each fixed depth instead of either morphing their
+        // heights or translating their raster coverage through subpixels.
+        sampleAge =
+            sourceAge + (overlayLayer ? 0.0 : distanceRows);
+        geometryV = sourceV;
+        vLayerAlpha =
+            overlayLayer ? scrollPhase : 1.0 - scrollPhase;
+    } else if (boundaryRow) {
         sampleAge =
             sourceAge + (overlayLayer ? 0.0 : distanceRows);
         geometryV = sourceV;
@@ -214,7 +224,17 @@ void main()
             ? normalize(vec2(-tangentPx.y, tangentPx.x))
             : vec2(0.0, 1.0);
         vec2 pixelToNdc = 1.0 / viewportHalf;
-        ndc += normalPx * ribbonSide * pixelToNdc;
+        if (u <= 0.0 || u >= 1.0) {
+            // A perpendicular ribbon offset moves the endpoint sideways by an
+            // amount that changes with the last FFT segment's slope. Against
+            // the black outside of the perspective surface, the stacked row
+            // endpoints then form a crawling one-pixel silhouette. Use a butt
+            // boundary at the exact side plane: stable X and a fixed vertical
+            // AA width. Interior vertices retain the perpendicular ribbon.
+            ndc.y += ribbonSide * pixelToNdc.y;
+        } else {
+            ndc += normalPx * ribbonSide * pixelToNdc;
+        }
     }
     gl_Position = vec4(ndc, 0.0, 1.0);
 
@@ -225,4 +245,5 @@ void main()
     vEdge  = edge;
     vFrequency = u;
     vBoundaryFade = clamp(validRows - sampleAge, 0.0, 1.0);
+    vOverlayLayer = overlayLayer ? 1.0 : 0.0;
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -3,9 +3,10 @@
 // 3DSS GPU height-map mesh. Each vertex carries its grid position (u = column,
 // v = row/depth) and an edge tag. The height comes from a ring-buffered dBm
 // texture; geometry is a receding perspective trapezoid built entirely on the
-// GPU, so pan/zoom never rebuild any vertices. The per-row coloured curtains
-// and their outlines stay on a fixed perspective grid while the retained data
-// advances, avoiding shimmer from translating dense geometry across pixels.
+// GPU, so pan/zoom never rebuild any vertices. The perspective grid stays
+// fixed at the leading/trailing rows while exact interior rows translate
+// through depth. Only those two boundary rows crossfade, avoiding whole-surface
+// shimmer without letting either timeline edge move.
 // Outputs NDC directly (matching spectrum.vert).
 
 layout(location = 0) in vec3 inVert;   // x = u [0,1] col, y = v [0,1) row(0=front), z = edge
@@ -20,53 +21,111 @@ layout(std140, binding = 0) uniform U {
     float frontMaxRidgeFrac;  // max ridge height (front) as a fraction of plot H
     float haze;               // atmospheric fade toward bgFill with depth
     float texCols;            // height-texture width, for column texel-centre sampling
-    float frequencyScale;     // target bandwidth / retained-frame bandwidth
-    float frequencyOffset;    // (target centre - retained centre) / retained bandwidth
-    float frequencyPreview;   // non-zero while the interaction preview is active
+    float targetBandwidthMhz;
+    float targetCenterOffsetMhz; // relative to the CPU's per-frame reference
+    float rowFrequencyFrames;
     float scrollProgressRows; // continuous movement toward the back between rows
     float texRows;
     float scrollDistanceRows; // rows delivered by the current radio tile
     float colorRangeDb;       // stable colour aperture; independent of height range
     float validRows;
-    float padding17;
-    float padding18;
-    float padding19;
+    float visibleRows;        // perspective depth; texture also holds exit reserve
+    float plotWidthPx;        // DSS viewport width in physical pixels
+    float plotHeightPx;       // DSS viewport height in physical pixels
     vec4  bgFill;             // plot background colour (for haze)
     vec4  shadowBands[8];     // low u, high u, centre u, band alpha
     vec4  shadowStyles[8];    // cue rgb, centre-line alpha
     vec4  shadowMeta;         // descriptor count, enabled, plot width px, pad
+    vec4  rowFrames[104];     // FFT centre/bw, supplemental centre/bw; age order
 };
 
-layout(binding = 1) uniform sampler2D heightTex;  // R16F, dBm, ring-buffered rows
+// RGBA16F ring rows: RG = exact FFT dBm/coverage; BA = calibrated native
+// waterfall-tile overhang dBm/coverage. The exact FFT always wins. The wider
+// tile is consulted only outside an FFT row's captured frequency frame.
+layout(binding = 1) uniform sampler2D heightTex;
 
 layout(location = 0) out float vLut;    // palette lookup coord (floor->peak gradient)
 layout(location = 1) out float vDepth;  // row depth 0..1 for haze/fade
 layout(location = 2) out float vEdge;   // edge tag passthrough
 layout(location = 3) out float vBoundaryFade;
 layout(location = 4) out float vFrequency;
+layout(location = 5) out float vLayerAlpha;
+layout(location = 6) out float vRibbonCoord;  // -1..+1 across AA outline
 
-float sampleHistoryDbm(float texU, float historyV, float rows,
-                       float remainingRows)
+vec4 sampleHistory(float texU, float sourceAge, float rows)
 {
-    float sourceAge = historyV * rows;
     float cappedValidRows = clamp(validRows, 0.0, rows);
     if (sourceAge >= cappedValidRows) {
-        return floorDbm;
+        return vec4(floorDbm, 0.0, floorDbm, 0.0);
     }
 
-    // The oldest grid row has no older neighbour to interpolate toward. Clamp
-    // its sample age to the oldest retained texture row so it stays full-height
-    // until eviction instead of collapsing and reappearing at the rear edge.
-    float oldestRetainedAge = max(cappedValidRows - 1.0, 0.0);
-    float sampleAge = min(sourceAge + remainingRows, oldestRetainedAge);
-    float age0 = max(floor(sampleAge), 0.0);
-    float age1 = min(age0 + 1.0, oldestRetainedAge);
-    float ageBlend = fract(sampleAge);
-    float dbm0 = texture(
-        heightTex, vec2(texU, fract(rowOffset + age0 / rows))).r;
-    float dbm1 = texture(
-        heightTex, vec2(texU, fract(rowOffset + age1 / rows))).r;
-    return mix(dbm0, dbm1, ageBlend);
+    // Amplitude is never interpolated between history rows. Interpolation
+    // morphs one FFT into the next and makes every peak (and especially a
+    // zoom-created floor edge) bounce vertically as it scrolls. Move the row's
+    // geometry instead and sample its exact retained texture slot.
+    return texture(
+        heightTex, vec2(texU, fract(rowOffset + sourceAge / rows)));
+}
+
+float effectiveDbmAt(float geometryU, float sampleAge, float rows)
+{
+    int frameAge = int(clamp(
+        floor(sampleAge + 0.5), 0.0, float(103)));
+    vec4 frame = rowFrames[frameAge];
+    float rowBandwidthMhz = frame.y > 0.0
+        ? frame.y
+        : max(targetBandwidthMhz, 0.000001);
+    float sourceU =
+        0.5 + (targetCenterOffsetMhz - frame.x) / rowBandwidthMhz
+        + (geometryU - 0.5) * targetBandwidthMhz / rowBandwidthMhz;
+    bool outsideRow = rowFrequencyFrames > 0.5
+        && (sourceU < 0.0 || sourceU > 1.0);
+    float texU = (texCols > 1.0)
+        ? (sourceU * (texCols - 1.0) + 0.5) / texCols
+        : 0.5;
+    vec4 historySample = outsideRow
+        ? vec4(floorDbm, 0.0, floorDbm, 0.0)
+        : sampleHistory(texU, sampleAge, rows);
+    if (historySample.g > 0.5) {
+        return historySample.r;
+    }
+
+    float supplementalBandwidthMhz = frame.w;
+    if (rowFrequencyFrames > 0.5 && supplementalBandwidthMhz > 0.0) {
+        float supplementalU =
+            0.5
+            + (targetCenterOffsetMhz - frame.z)
+                / supplementalBandwidthMhz
+            + (geometryU - 0.5) * targetBandwidthMhz
+                / supplementalBandwidthMhz;
+        if (supplementalU >= 0.0 && supplementalU <= 1.0) {
+            float supplementalTexU = (texCols > 1.0)
+                ? (supplementalU * (texCols - 1.0) + 0.5) / texCols
+                : 0.5;
+            vec4 supplementalSample =
+                sampleHistory(supplementalTexU, sampleAge, rows);
+            if (supplementalSample.a > 0.5) {
+                return supplementalSample.b;
+            }
+        }
+    }
+    return floorDbm;
+}
+
+vec2 ridgeNdcAt(float geometryU, float dbm, float geometryV)
+{
+    float strengthLinear = clamp(
+        (dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
+    float strengthHeight =
+        pow(strengthLinear, max(zCurve, 0.05));
+    float width = mix(1.0, backWidthFrac, geometryV);
+    float plotX = 0.5 + (geometryU - 0.5) * width;
+    float baselineY =
+        mix(1.0, 1.0 - depthSpanFrac, geometryV);
+    float ridge =
+        strengthHeight * frontMaxRidgeFrac * width;
+    float topY = baselineY - ridge;
+    return vec2(plotX * 2.0 - 1.0, 1.0 - topY * 2.0);
 }
 
 void main()
@@ -75,25 +134,50 @@ void main()
     float sourceV = inVert.y;  // discrete retained-row age
     float rows = max(texRows, 1.0);
     float distanceRows = max(scrollDistanceRows, 1.0);
-    float edge = inVert.z;     // -1 = outline, 0 = ridge, 1 = curtain floor
-    // Keep geometry phase-stable. Translating this dense perspective mesh makes
-    // its subpixel line spacing shimmer, especially in the compressed rear.
-    float geometryV = sourceV;
+    float depthRows = max(visibleRows, 1.0);
+    float encodedEdge = inVert.z;
+    bool ribbonOutline = encodedEdge <= -10.0;
+    float ribbonCode = -encodedEdge;
+    bool overlayLayer = ribbonOutline
+        ? ribbonCode >= 20.0
+        : (encodedEdge >= 2.0 || encodedEdge <= -2.0);
+    float edge = ribbonOutline
+        ? -1.0
+        : (encodedEdge >= 2.0
+               ? encodedEdge - 2.0
+               : (encodedEdge <= -2.0 ? -1.0 : encodedEdge));
+    float ribbonLocalCode = overlayLayer
+        ? ribbonCode - 20.0
+        : ribbonCode - 10.0;
+    float ribbonSide = ribbonLocalCode < 0.5 ? -1.0 : 1.0;
+    vRibbonCoord = ribbonOutline ? ribbonSide : 0.0;
+    float sourceAge = sourceV * depthRows;
+    float scrollPhase = clamp(
+        scrollProgressRows / distanceRows, 0.0, 1.0);
     float remainingRows = clamp(
         distanceRows - scrollProgressRows, 0.0, distanceRows);
+    bool boundaryRow =
+        sourceAge < 0.5 || sourceAge > depthRows - 1.5;
+    float sampleAge;
+    float geometryV;
+    if (boundaryRow) {
+        sampleAge =
+            sourceAge + (overlayLayer ? 0.0 : distanceRows);
+        geometryV = sourceV;
+        vLayerAlpha = overlayLayer ? scrollPhase : 1.0;
+    } else {
+        sampleAge = sourceAge;
+        geometryV = (sourceAge - remainingRows) / depthRows;
+        vLayerAlpha = overlayLayer ? 1.0 : 0.0;
+    }
 
     // Sample texel CENTRES on both axes so Nearest filtering can't pick up the
     // neighbouring row/column. rowOffset already carries the row half-texel; the
     // column maps geometry u in [0,1] onto centre (u*(cols-1)+0.5)/cols.
-    float sourceU = 0.5 + frequencyOffset + (u - 0.5) * frequencyScale;
-    bool outsidePreview = frequencyPreview > 0.5
-        && (sourceU < 0.0 || sourceU > 1.0);
-    float texU = (texCols > 1.0)
-        ? (sourceU * (texCols - 1.0) + 0.5) / texCols
-        : 0.5;
-    float dbm = outsidePreview
-        ? floorDbm
-        : sampleHistoryDbm(texU, sourceV, rows, remainingRows);
+    // A zoom-created gap is not an amplitude measurement. Pin it to the
+    // baseline before both height and colour mapping so later range changes
+    // cannot recolour or lift it, while leaving row/layer visibility untouched.
+    float dbm = effectiveDbmAt(u, sampleAge, rows);
     // Linear strength drives COLOUR (LUT[sLin] = dbmToRgb(floor+sLin*range),
     // matching the CPU path); the zCurve lift applies to HEIGHT only.
     float sLin = clamp((dbm - floorDbm) / max(rangeDb, 1.0), 0.0, 1.0);
@@ -110,7 +194,29 @@ void main()
     float topY  = baseY - ridge;                       // up = smaller y
     float plotY = edge > 0.5 ? 1.0 : topY;
 
-    gl_Position = vec4(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0, 0.0, 1.0);
+    vec2 ndc = vec2(plotX * 2.0 - 1.0, 1.0 - plotY * 2.0);
+    if (ribbonOutline) {
+        // Metal's one-pixel line primitives toggle coverage as the mesh moves
+        // through subpixels, producing a whole-surface strobe. Expand each
+        // outline into a two-pixel screen-space ribbon; the fragment shader
+        // analytically softens its edges.
+        float du = 1.0 / max(texCols - 1.0, 1.0);
+        float previousU = max(u - du, 0.0);
+        float nextU = min(u + du, 1.0);
+        vec2 previousNdc = ridgeNdcAt(
+            previousU, effectiveDbmAt(previousU, sampleAge, rows), geometryV);
+        vec2 nextNdc = ridgeNdcAt(
+            nextU, effectiveDbmAt(nextU, sampleAge, rows), geometryV);
+        vec2 viewportHalf =
+            vec2(max(plotWidthPx, 1.0), max(plotHeightPx, 1.0)) * 0.5;
+        vec2 tangentPx = (nextNdc - previousNdc) * viewportHalf;
+        vec2 normalPx = length(tangentPx) > 0.0001
+            ? normalize(vec2(-tangentPx.y, tangentPx.x))
+            : vec2(0.0, 1.0);
+        vec2 pixelToNdc = 1.0 / viewportHalf;
+        ndc += normalPx * ribbonSide * pixelToNdc;
+    }
+    gl_Position = vec4(ndc, 0.0, 1.0);
 
     // Restore the original curtain palette mapping: ridge = full amplitude
     // colour, floor = a dimmer share of that same amplitude colour.
@@ -118,25 +224,5 @@ void main()
     vDepth = clamp(geometryV, 0.0, 1.0);
     vEdge  = edge;
     vFrequency = u;
-    // Rear visibility follows the fixed grid age, not the interpolated sample
-    // age — but only once the history is FULL.
-    //
-    // At steady state validRows is pinned at rows, so validRows - sourceAge is
-    // permanently 1 for the oldest slot: indistinguishable from a slot that has
-    // only just been populated. Subtracting the scroll advance there ramps that
-    // permanent row 0 -> 1 across every row interval and snaps it back on each
-    // arrival, which is the rear pulse (worst at slow presentation cadences,
-    // and it also disagreed with sampleHistoryDbm()'s un-advanced early-out).
-    //
-    // While history is still filling, a slot genuinely IS newly populated on
-    // each arrival, and for that one interval sampleHistoryDbm() clamps it to
-    // oldestRetainedAge — the same texture row its neighbour is already
-    // drawing. Subtracting the advance is what fades that duplicate curtain in
-    // instead of popping it opaque. So keep the term until validRows stops
-    // growing, after which nothing is ever newly populated again.
-    float sourceAge = sourceV * rows;
-    float fillFade = validRows < rows ? remainingRows : 0.0;
-    float historyAvailability = clamp(
-        validRows - sourceAge - fillFade, 0.0, 1.0);
-    vBoundaryFade = historyAvailability;
+    vBoundaryFade = clamp(validRows - sampleAge, 0.0, 1.0);
 }

--- a/resources/shaders/dss_mesh.vert
+++ b/resources/shaders/dss_mesh.vert
@@ -36,6 +36,9 @@ layout(std140, binding = 0) uniform U {
     vec4  shadowBands[8];     // low u, high u, centre u, band alpha
     vec4  shadowStyles[8];    // cue rgb, centre-line alpha
     vec4  shadowMeta;         // descriptor count, enabled, plot width px, pad
+    // Fixed GLSL array sizes cannot consume a C++ constant. SpectrumWidget has
+    // a matching static_assert against DssRenderer::kRows; update both shaders
+    // and the frame-age clamp below if that row count changes.
     vec4  rowFrames[104];     // FFT centre/bw, supplemental centre/bw; age order
 };
 

--- a/resources/shaders/texturedquad_rowframes.frag
+++ b/resources/shaders/texturedquad_rowframes.frag
@@ -5,6 +5,7 @@ layout(location = 0) out vec4 fragColor;
 
 layout(binding = 1) uniform sampler2D tex;
 layout(binding = 2) uniform sampler2D rowFrequencyFrame;
+layout(binding = 3) uniform sampler2D supplementalTex;
 
 layout(std140, binding = 0) uniform Uniforms {
     float rowOffset;
@@ -20,16 +21,24 @@ layout(std140, binding = 0) uniform Uniforms {
 vec4 sampleWaterfallRow(float rowIndex, float unit)
 {
     float rowY = fract((rowIndex + 0.5) * unit);
-    vec2 rowFrame = texture(rowFrequencyFrame, vec2(0.5, rowY)).rg;
+    vec4 rowFrame = texture(rowFrequencyFrame, vec2(0.5, rowY));
     if (rowFrame.y <= 0.0) {
         return vec4(0.0, 0.0, 0.0, 1.0);
     }
     float sourceU = 0.5 + (targetCenterOffsetMhz - rowFrame.x) / rowFrame.y
         + (v_uv.x - 0.5) * targetBandwidthMhz / rowFrame.y;
-    if (sourceU < 0.0 || sourceU > 1.0) {
-        return vec4(0.0, 0.0, 0.0, 1.0);
+    if (sourceU >= 0.0 && sourceU <= 1.0) {
+        return texture(tex, vec2(sourceU, rowY));
     }
-    return texture(tex, vec2(sourceU, rowY));
+    if (rowFrame.w > 0.0) {
+        float supplementalU =
+            0.5 + (targetCenterOffsetMhz - rowFrame.z) / rowFrame.w
+            + (v_uv.x - 0.5) * targetBandwidthMhz / rowFrame.w;
+        if (supplementalU >= 0.0 && supplementalU <= 1.0) {
+            return texture(supplementalTex, vec2(supplementalU, rowY));
+        }
+    }
+    return vec4(0.0, 0.0, 0.0, 1.0);
 }
 
 void main()

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -905,32 +905,48 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     if (numBins == 0 || binSize == 0 || totalBins == 0) return;
 
     const int binDataOffset = VITA49_HEADER_BYTES + FFT_SUBHEADER_BYTES;
-    int binDataBytes = numBins * binSize;
     const int available = totalBytes - binDataOffset - (hasTrailer ? 4 : 0);
-    if (available < binDataBytes) {
-        binDataBytes = available;
-        if (binDataBytes <= 0) return;
-    }
+    // FLEX FFT samples are uint16. A short datagram must not be read past its
+    // payload or counted as complete; wait for coverage of the missing bins.
+    if (binSize != sizeof(quint16)) return;
+    const int binsToRead = boundedVitaPayloadBinCount(
+        numBins, binSize, available);
+    if (binsToRead <= 0) return;
 
     const uchar* binData = raw + binDataOffset;
 
-    // Per-stream frame assembly
+    // Per-stream frame assembly.
     auto& frame = m_frames[streamId];
-    if (frameIndex != frame.frameIndex) {
+    const bool startsNewFrame =
+        frameIndex != frame.frameIndex || totalBins != frame.totalBins;
+    if (startsNewFrame) {
         if (frame.totalBins > 0 && !frame.isComplete())
             PerfTelemetry::instance().recordFrameRestart(PerfTelemetry::FrameKind::Panadapter);
         frame.reset(frameIndex, totalBins);
     }
 
-    if (startBin + numBins > static_cast<quint16>(frame.buf.size()))
+    if (static_cast<int>(startBin) + binsToRead > frame.buf.size())
+        return;
+    if (frame.isComplete())
+        return;
+    if (!frame.coverage.markRange(startBin, binsToRead))
         return;
 
-    for (quint16 i = 0; i < numBins; ++i)
+    for (int i = 0; i < binsToRead; ++i)
         frame.buf[startBin + i] = qFromBigEndian<quint16>(binData + i * 2);
 
-    frame.binsReceived += numBins;
-
     if (!frame.isComplete()) return;
+
+    // On an x_pixels grow, firmware 4.2.18 can complete one expanded frame
+    // with the old-width prefix followed by zero-filled new bins. Zero means
+    // max dBm in the radio's vertical pixel encoding. Reject that placeholder
+    // before it reaches FFT averaging or retained 3D history; the previous
+    // complete FFT remains live until the first valid expanded frame arrives.
+    if (hasZeroFilledFftGrowthSuffix(
+            frame.buf, frame.lastAcceptedTotalBins)) {
+        return;
+    }
+    frame.lastAcceptedTotalBins = frame.totalBins;
 
     // Convert to dBm using per-stream range
     QPair<float,float> dbmRange;
@@ -947,25 +963,11 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     const int   count = frame.buf.size();
     QVector<float> bins(count);
 
-    int effectiveYPixels = std::max(yPixVal, 2);
-    int rawMax = 0;
-    int overRangeCount = 0;
-    for (const quint16 rawBin : frame.buf) {
-        const int rawValue = static_cast<int>(rawBin);
-        rawMax = std::max(rawMax, rawValue);
-        if (rawValue >= effectiveYPixels) {
-            ++overRangeCount;
-        }
-    }
-    // A stale/tiny y_pixels status makes normal noise bins clamp to one flat
-    // floor while strong signals still poke through. If the frame itself shows
-    // that the radio is encoding against a taller pixel space, preserve the
-    // trace and let the normal dimension re-push/echo path catch up.
-    if (overRangeCount > std::max(8, count / 8)) {
-        effectiveYPixels = std::max(effectiveYPixels, rawMax + 1);
-    }
-
-    const float yPix = static_cast<float>(effectiveYPixels);
+    // The radio's configured y_pixels is the encoding scale. Values at or
+    // beyond y_pixels are bottom-clipped samples, not evidence that the frame
+    // silently switched to a taller scale. Inferring a different height from
+    // each frame makes a clipped floor look like valid, rescaled FFT data.
+    const float yPix = static_cast<float>(std::max(yPixVal, 2));
 
     for (int i = 0; i < count; ++i) {
         const float pixel = std::clamp(
@@ -1068,13 +1070,12 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
     // refactor that breaks the wfFrame.buf.size() <-> wfFrame.totalBins
     // invariant.  GHSA-7gvg-x594-pprq.
     if (firstBinIndex + binsToRead > wfFrame.buf.size()) return;
+    if (!wfFrame.coverage.markRange(firstBinIndex, binsToRead)) return;
 
     for (int i = 0; i < binsToRead; ++i) {
         const auto raw16 = static_cast<qint16>(qFromBigEndian<quint16>(tilePayload + i * 2));
         wfFrame.buf[firstBinIndex + i] = static_cast<float>(raw16) / 128.0f;
     }
-    wfFrame.binsReceived += binsToRead;
-
     // Only emit when the full frame is assembled
     if (!wfFrame.isComplete()) return;
 

--- a/src/core/PanadapterStream.cpp
+++ b/src/core/PanadapterStream.cpp
@@ -942,11 +942,20 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     // max dBm in the radio's vertical pixel encoding. Reject that placeholder
     // before it reaches FFT averaging or retained 3D history; the previous
     // complete FFT remains live until the first valid expanded frame arrives.
-    if (hasZeroFilledFftGrowthSuffix(
-            frame.buf, frame.lastAcceptedTotalBins)) {
+    const bool zeroFilledGrowth = hasZeroFilledFftGrowthSuffix(
+        frame.buf, frame.lastAcceptedTotalBins);
+    const FftGrowthSuffixAction growthAction =
+        frame.growthSuffixGuard.observe(zeroFilledGrowth, frame.totalBins);
+    if (growthAction == FftGrowthSuffixAction::Reject) {
         return;
     }
-    frame.lastAcceptedTotalBins = frame.totalBins;
+    const int floorFilledSuffixStart =
+        growthAction == FftGrowthSuffixAction::EmitWithFloorSuffix
+        ? frame.lastAcceptedTotalBins
+        : -1;
+    if (growthAction == FftGrowthSuffixAction::Accept) {
+        frame.lastAcceptedTotalBins = frame.totalBins;
+    }
 
     // Convert to dBm using per-stream range
     QPair<float,float> dbmRange;
@@ -970,8 +979,16 @@ void PanadapterStream::decodeFFT(const uchar* raw, int totalBytes, bool hasTrail
     const float yPix = static_cast<float>(std::max(yPixVal, 2));
 
     for (int i = 0; i < count; ++i) {
-        const float pixel = std::clamp(
-            static_cast<float>(frame.buf[i]), 0.0f, yPix - 1.0f);
+        // If firmware repeats its resize placeholder, keep the panadapter live
+        // after a bounded wait without ever interpreting the zero-filled suffix
+        // as max dBm. A later populated growth frame is still detected against
+        // lastAcceptedTotalBins and replaces this floor extension normally.
+        const bool floorFillSuffix = floorFilledSuffixStart >= 0
+            && i >= floorFilledSuffixStart;
+        const float pixel = floorFillSuffix
+            ? yPix - 1.0f
+            : std::clamp(
+                static_cast<float>(frame.buf[i]), 0.0f, yPix - 1.0f);
         const float dbm = maxDbm - (pixel / (yPix - 1.0f)) * range;
         bins[i] = std::clamp(dbm, minDbm, maxDbm);
     }
@@ -1070,6 +1087,7 @@ void PanadapterStream::decodeWaterfallTile(const uchar* raw, int totalBytes, boo
     // refactor that breaks the wfFrame.buf.size() <-> wfFrame.totalBins
     // invariant.  GHSA-7gvg-x594-pprq.
     if (firstBinIndex + binsToRead > wfFrame.buf.size()) return;
+    if (wfFrame.isComplete()) return;
     if (!wfFrame.coverage.markRange(firstBinIndex, binsToRead)) return;
 
     for (int i = 0; i < binsToRead; ++i) {

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -272,6 +272,7 @@ private:
         quint16        lastAcceptedTotalBins{0};
         QVector<quint16> buf;          // raw uint16 bins, host byte-order
         VitaBinCoverage coverage;
+        FftGrowthSuffixGuard growthSuffixGuard;
 
         void reset(quint32 idx, quint16 total) {
             frameIndex   = idx;

--- a/src/core/PanadapterStream.h
+++ b/src/core/PanadapterStream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PacketLossConcealment.h"
+#include "VitaBinCoverage.h"
 
 #include <QObject>
 #include <QUdpSocket>
@@ -268,16 +269,18 @@ private:
     struct FrameAssembler {
         quint32        frameIndex{0xFFFFFFFF};
         quint16        totalBins{0};
-        quint16        binsReceived{0};
+        quint16        lastAcceptedTotalBins{0};
         QVector<quint16> buf;          // raw uint16 bins, host byte-order
+        VitaBinCoverage coverage;
 
         void reset(quint32 idx, quint16 total) {
             frameIndex   = idx;
             totalBins    = total;
-            binsReceived = 0;
             buf.resize(total);
+            buf.fill(0);
+            coverage.reset(total);
         }
-        bool isComplete() const { return totalBins > 0 && binsReceived >= totalBins; }
+        bool isComplete() const { return coverage.isComplete(); }
     };
 
     // Waterfall frame assembly: tiles arrive in fragments across multiple packets.
@@ -285,23 +288,23 @@ private:
     struct WaterfallFrame {
         quint32          timecode{0xFFFFFFFF};
         quint16          totalBins{0};
-        quint16          binsReceived{0};
         double           lowFreqMhz{0};
         double           binBwMhz{0};
         quint32          autoBlack{0};
         QVector<float>   buf;   // intensity values (int16/128.0f)
+        VitaBinCoverage  coverage;
 
         void reset(quint32 tc, quint16 total, double low, double bw, quint32 ab) {
             timecode     = tc;
             totalBins    = total;
-            binsReceived = 0;
             lowFreqMhz   = low;
             binBwMhz     = bw;
             autoBlack    = ab;
             buf.resize(total);
             buf.fill(0.0f);
+            coverage.reset(total);
         }
-        bool isComplete() const { return totalBins > 0 && binsReceived >= totalBins; }
+        bool isComplete() const { return coverage.isComplete(); }
     };
 
     QMap<quint32, WaterfallFrame> m_wfFrames;  // per-stream waterfall frame assembly

--- a/src/core/VitaBinCoverage.h
+++ b/src/core/VitaBinCoverage.h
@@ -66,13 +66,15 @@ public:
             || firstBin > m_received.size() - binCount) {
             return false;
         }
+        bool markedNewBin = false;
         for (int index = firstBin; index < firstBin + binCount; ++index) {
             if (m_received[index] == 0) {
                 m_received[index] = 1;
                 ++m_uniqueBins;
+                markedNewBin = true;
             }
         }
-        return true;
+        return markedNewBin;
     }
 
     bool isComplete() const
@@ -86,6 +88,58 @@ public:
 private:
     QVector<quint8> m_received;
     int m_uniqueBins{0};
+};
+
+enum class FftGrowthSuffixAction {
+    Accept,
+    Reject,
+    EmitWithFloorSuffix,
+};
+
+// A FLEX-8600 running firmware 4.2.18 normally sends at most one expanded FFT
+// frame whose newly-added suffix is zero-filled. Rejecting every such frame is
+// safest for the common case, but an indefinitely repeated placeholder must not
+// freeze the panadapter at its old width forever. After a short bounded wait,
+// callers may emit the valid prefix with the new suffix forced to the floor;
+// the first genuinely populated expanded frame resets this guard and is
+// accepted normally.
+class FftGrowthSuffixGuard
+{
+public:
+    static constexpr int kRejectedFramesBeforeFloorFallback = 3;
+
+    FftGrowthSuffixAction observe(bool zeroFilledGrowth, int totalBins)
+    {
+        if (!zeroFilledGrowth || totalBins <= 0) {
+            reset();
+            return FftGrowthSuffixAction::Accept;
+        }
+        if (totalBins != m_rejectedTotalBins) {
+            m_rejectedTotalBins = totalBins;
+            m_consecutiveRejectedFrames = 1;
+        } else {
+            ++m_consecutiveRejectedFrames;
+        }
+        return m_consecutiveRejectedFrames
+                <= kRejectedFramesBeforeFloorFallback
+            ? FftGrowthSuffixAction::Reject
+            : FftGrowthSuffixAction::EmitWithFloorSuffix;
+    }
+
+    void reset()
+    {
+        m_rejectedTotalBins = 0;
+        m_consecutiveRejectedFrames = 0;
+    }
+
+    int consecutiveRejectedFrames() const
+    {
+        return m_consecutiveRejectedFrames;
+    }
+
+private:
+    int m_rejectedTotalBins{0};
+    int m_consecutiveRejectedFrames{0};
 };
 
 } // namespace AetherSDR

--- a/src/core/VitaBinCoverage.h
+++ b/src/core/VitaBinCoverage.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <QVector>
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+// Return the number of complete bins actually present in a VITA payload.
+// Display packet headers can advertise a full fragment even when the received
+// datagram ends early; callers must never mark or decode the missing tail.
+inline int boundedVitaPayloadBinCount(int declaredBins,
+                                      int bytesPerBin,
+                                      int availableBytes)
+{
+    if (declaredBins <= 0 || bytesPerBin <= 0 || availableBytes < bytesPerBin) {
+        return 0;
+    }
+    return std::min(declaredBins, availableBytes / bytesPerBin);
+}
+
+// FLEX can publish one transitional FFT after an x_pixels increase where the
+// old-width prefix is valid but every newly-added bin is zero. Raw FFT zero is
+// the top/max-dBm pixel, so accepting that frame creates a tall right-hand
+// shelf and contaminates the display averager for several subsequent rows.
+// Restrict the check to a genuine growth and require both a nearly-all-zero
+// suffix and a non-zero-dominated prefix so a real saturated signal is not
+// mistaken for the radio's resize placeholder.
+inline bool hasZeroFilledFftGrowthSuffix(const QVector<quint16>& bins,
+                                         int previousAcceptedBins)
+{
+    if (previousAcceptedBins <= 0
+        || previousAcceptedBins >= bins.size()) {
+        return false;
+    }
+
+    const int suffixBins = bins.size() - previousAcceptedBins;
+    if (suffixBins < 16) {
+        return false;
+    }
+
+    const int prefixZeros = static_cast<int>(std::count(
+        bins.cbegin(), bins.cbegin() + previousAcceptedBins, quint16{0}));
+    const int suffixZeros = static_cast<int>(std::count(
+        bins.cbegin() + previousAcceptedBins, bins.cend(), quint16{0}));
+
+    return suffixZeros * 10 >= suffixBins * 9
+        && prefixZeros * 10 < previousAcceptedBins;
+}
+
+// Tracks unique bin positions while a fragmented VITA display frame is
+// assembled. Packet counts cannot prove completeness because UDP duplicates or
+// overlapping fragments may repeat positions while leaving a gap elsewhere.
+class VitaBinCoverage
+{
+public:
+    void reset(int totalBins)
+    {
+        m_received.fill(0, std::max(0, totalBins));
+        m_uniqueBins = 0;
+    }
+
+    bool markRange(int firstBin, int binCount)
+    {
+        if (firstBin < 0 || binCount <= 0
+            || firstBin > m_received.size() - binCount) {
+            return false;
+        }
+        for (int index = firstBin; index < firstBin + binCount; ++index) {
+            if (m_received[index] == 0) {
+                m_received[index] = 1;
+                ++m_uniqueBins;
+            }
+        }
+        return true;
+    }
+
+    bool isComplete() const
+    {
+        return !m_received.isEmpty() && m_uniqueBins == m_received.size();
+    }
+
+    int uniqueBins() const { return m_uniqueBins; }
+    int totalBins() const { return m_received.size(); }
+
+private:
+    QVector<quint8> m_received;
+    int m_uniqueBins{0};
+};
+
+} // namespace AetherSDR

--- a/src/gui/DbmRangeTransition.h
+++ b/src/gui/DbmRangeTransition.h
@@ -170,6 +170,14 @@ inline Range manualRequestRange(float requestedMinDbm,
     return {dssFloorDbm, dssFloorDbm + dssSpanDb};
 }
 
+inline Range clippedFloorRecoveryRange(float currentMinDbm,
+                                       float currentMaxDbm,
+                                       float headroomStepDb = 6.0f)
+{
+    const float stepDb = std::max(0.0f, headroomStepDb);
+    return {currentMinDbm - stepDb, currentMaxDbm - stepDb};
+}
+
 struct Evaluation {
     bool useRebasedBins{false};
     bool newEncodingObserved{false};

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -254,12 +254,14 @@ std::array<float, DssRenderer::kCols> smoothDssRow(
 void DssRenderer::resetInputSmoothing()
 {
     m_rawHistCount = 0;
+    m_supplementalRawHistCount = 0;
     // Also break the temporal IIR blend for the next row of each path. Zeroing
     // the median-of-3 counters alone does not forget the previous *smoothed*
     // row that pushRow/appendHistoryRow blend the new row against — that row was
     // decoded under the old scale, so without this the first post-reset row is
     // contaminated by it.
     m_skipLiveTemporalBlendOnce = true;
+    m_skipSupplementalTemporalBlendOnce = true;
     m_skipHistoryTemporalBlendOnce = true;
     resetHistorySmoothing();
 }
@@ -289,6 +291,8 @@ quint64 DssRenderer::fixedStorageBytes() const
         + sizeof(m_rowSupplementalCenterMhz)
         + sizeof(m_rowSupplementalBandwidthMhz)
         + sizeof(m_rawPrev1) + sizeof(m_rawPrev2)
+        + sizeof(m_supplementalRawPrev1)
+        + sizeof(m_supplementalRawPrev2)
         + sizeof(m_historyRawPrev1) + sizeof(m_historyRawPrev2);
 }
 
@@ -414,8 +418,30 @@ void DssRenderer::pushRowWithSupplemental(
         && supplementalCenterMhz > 0.0
         && supplementalBandwidthMhz > 0.0;
     if (supplementalValid) {
-        m_rowSupplemental[m_head] =
+        const std::array<float, kCols> supplementalRaw =
             resampledRawRow(supplementalBinsDbm, -200.0f);
+        const int previousRing = (m_head + 1) % kRows;
+        const bool sameSupplementalFrameAsPrevious =
+            m_count > 0
+            && frequencyFramesMatch(
+                m_rowSupplementalCenterMhz[previousRing],
+                m_rowSupplementalBandwidthMhz[previousRing],
+                supplementalCenterMhz, supplementalBandwidthMhz);
+        if (m_count > 0 && !sameSupplementalFrameAsPrevious) {
+            m_supplementalRawHistCount = 0;
+        }
+        const std::array<float, kCols>* supplementalPrevious =
+            (sameSupplementalFrameAsPrevious
+             && !m_skipSupplementalTemporalBlendOnce)
+                ? &m_rowSupplemental[previousRing]
+                : nullptr;
+        m_skipSupplementalTemporalBlendOnce = false;
+        m_rowSupplemental[m_head] = smoothDssRow(
+            supplementalRaw,
+            m_supplementalRawPrev1,
+            m_supplementalRawPrev2,
+            m_supplementalRawHistCount,
+            supplementalPrevious);
         m_rowSupplementalCoverage[m_head].fill(1);
         m_rowSupplementalCenterMhz[m_head] = supplementalCenterMhz;
         m_rowSupplementalBandwidthMhz[m_head] =
@@ -425,6 +451,7 @@ void DssRenderer::pushRowWithSupplemental(
         m_rowSupplementalCoverage[m_head].fill(0);
         m_rowSupplementalCenterMhz[m_head] = 0.0;
         m_rowSupplementalBandwidthMhz[m_head] = 0.0;
+        m_supplementalRawHistCount = 0;
     }
     m_count = std::min(m_count + 1, kRows);
     m_dirty = true;

--- a/src/gui/DssRenderer.cpp
+++ b/src/gui/DssRenderer.cpp
@@ -18,6 +18,12 @@ constexpr float  kTemporalAlpha = 0.60f; // temporal IIR: fraction of the new ro
 constexpr double kSlopeGain     = 0.55;  // slope shading strength
 constexpr double kShadeLo       = 0.68;
 constexpr double kShadeHi       = 1.32;
+using CoverageRow = std::array<quint8, DssRenderer::kCols>;
+
+struct ReprojectedRow {
+    std::array<float, DssRenderer::kCols> values;
+    CoverageRow coverage;
+};
 
 inline int chan(double v) { return static_cast<int>(std::clamp(v, 0.0, 255.0)); }
 
@@ -41,10 +47,24 @@ inline QColor lerpColor(const QColor& c, const QColor& t, double f)
                   chan(c.blue()  + (t.blue()  - c.blue())  * f));
 }
 
-float rowSample(const std::array<float, DssRenderer::kCols>& row,
-                double srcLeft, double srcRight, double srcCenter,
-                float fallback)
+bool frequencyFramesMatch(double firstCenterMhz, double firstBandwidthMhz,
+                          double secondCenterMhz, double secondBandwidthMhz)
 {
+    const auto nearlyEqual = [](double first, double second) {
+        const double scale =
+            std::max({1.0, std::abs(first), std::abs(second)});
+        return std::abs(first - second) <= scale * 1.0e-9;
+    };
+    return nearlyEqual(firstCenterMhz, secondCenterMhz)
+        && nearlyEqual(firstBandwidthMhz, secondBandwidthMhz);
+}
+
+float rowSample(const std::array<float, DssRenderer::kCols>& row,
+                const CoverageRow* coverage,
+                double srcLeft, double srcRight, double srcCenter,
+                float fallback, bool& sampledCoverage)
+{
+    sampledCoverage = false;
     if (srcRight <= 0.0 || srcLeft >= DssRenderer::kCols) {
         return fallback;
     }
@@ -63,10 +83,24 @@ float rowSample(const std::array<float, DssRenderer::kCols>& row,
         const int left = std::clamp(static_cast<int>(std::floor(clampedCenter)),
                                     0, DssRenderer::kCols - 1);
         const int right = std::min(left + 1, DssRenderer::kCols - 1);
-        const float leftValue = std::isfinite(row[left]) ? row[left] : fallback;
-        const float rightValue = std::isfinite(row[right]) ? row[right] : leftValue;
         const float frac = static_cast<float>(clampedCenter - left);
-        return leftValue + frac * (rightValue - leftValue);
+        double weightedSum = 0.0;
+        double totalWeight = 0.0;
+        const auto add = [&](int index, double weight) {
+            if (weight <= 0.0
+                || (coverage != nullptr && (*coverage)[index] == 0)
+                || !std::isfinite(row[index])) {
+                return;
+            }
+            weightedSum += row[index] * weight;
+            totalWeight += weight;
+        };
+        add(left, 1.0 - frac);
+        add(right, frac);
+        sampledCoverage = totalWeight > 0.0;
+        return sampledCoverage
+            ? static_cast<float>(weightedSum / totalWeight)
+            : fallback;
     }
 
     const int first = std::clamp(static_cast<int>(std::floor(clampedLeft)),
@@ -76,7 +110,8 @@ float rowSample(const std::array<float, DssRenderer::kCols>& row,
     double weightedSum = 0.0;
     double totalWeight = 0.0;
     for (int i = first; i <= last; ++i) {
-        if (!std::isfinite(row[i])) {
+        if ((coverage != nullptr && (*coverage)[i] == 0)
+            || !std::isfinite(row[i])) {
             continue;
         }
         const double binLeft = static_cast<double>(i);
@@ -90,21 +125,24 @@ float rowSample(const std::array<float, DssRenderer::kCols>& row,
         weightedSum += row[i] * weight;
         totalWeight += weight;
     }
-    return totalWeight > 0.0
+    sampledCoverage = totalWeight > 0.0;
+    return sampledCoverage
         ? static_cast<float>(weightedSum / totalWeight)
         : fallback;
 }
 
-std::array<float, DssRenderer::kCols> reprojectRow(
+ReprojectedRow reprojectRow(
     const std::array<float, DssRenderer::kCols>& row,
+    const CoverageRow* sourceCoverage,
     double oldCenterMhz,
     double oldBandwidthMhz,
     double newCenterMhz,
     double newBandwidthMhz,
     float fallback)
 {
-    std::array<float, DssRenderer::kCols> remapped;
-    remapped.fill(fallback);
+    ReprojectedRow remapped;
+    remapped.values.fill(fallback);
+    remapped.coverage.fill(0);
     if (oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
         return remapped;
     }
@@ -128,11 +166,16 @@ std::array<float, DssRenderer::kCols> reprojectRow(
             || srcCenter > static_cast<double>(DssRenderer::kCols) - 0.5) {
             continue;
         }
-        remapped[dst] = rowSample(row,
-                                  srcCenter - srcWidthBins * 0.5,
-                                  srcCenter + srcWidthBins * 0.5,
-                                  srcCenter,
-                                  fallback);
+        bool sampledCoverage = false;
+        remapped.values[dst] = rowSample(
+            row,
+            sourceCoverage,
+            srcCenter - srcWidthBins * 0.5,
+            srcCenter + srcWidthBins * 0.5,
+            srcCenter,
+            fallback,
+            sampledCoverage);
+        remapped.coverage[dst] = sampledCoverage ? quint8(1) : quint8(0);
     }
     return remapped;
 }
@@ -225,6 +268,13 @@ void DssRenderer::clear()
 {
     m_head  = 0;
     m_count = 0;
+    m_rowCenterMhz.fill(0.0);
+    m_rowBandwidthMhz.fill(0.0);
+    m_rowSupplementalCenterMhz.fill(0.0);
+    m_rowSupplementalBandwidthMhz.fill(0.0);
+    for (CoverageRow& coverage : m_rowSupplementalCoverage) {
+        coverage.fill(0);
+    }
     m_dirty = true;
     m_historyWriteRow = 0;
     m_historyRowCount = 0;
@@ -233,7 +283,11 @@ void DssRenderer::clear()
 
 quint64 DssRenderer::fixedStorageBytes() const
 {
-    return sizeof(m_rows)
+    return sizeof(m_rows) + sizeof(m_rowCoverage)
+        + sizeof(m_rowSupplemental) + sizeof(m_rowSupplementalCoverage)
+        + sizeof(m_rowCenterMhz) + sizeof(m_rowBandwidthMhz)
+        + sizeof(m_rowSupplementalCenterMhz)
+        + sizeof(m_rowSupplementalBandwidthMhz)
         + sizeof(m_rawPrev1) + sizeof(m_rawPrev2)
         + sizeof(m_historyRawPrev1) + sizeof(m_historyRawPrev2);
 }
@@ -312,19 +366,66 @@ DssRenderer::RowStats DssRenderer::rowStats(int age, float epsilonDb) const
     return stats;
 }
 
-void DssRenderer::pushRow(const QVector<float>& binsDbm)
+void DssRenderer::pushRow(const QVector<float>& binsDbm,
+                          double centerMhz,
+                          double bandwidthMhz)
+{
+    pushRowWithSupplemental(
+        binsDbm, centerMhz, bandwidthMhz,
+        QVector<float>{}, 0.0, 0.0);
+}
+
+void DssRenderer::pushRowWithSupplemental(
+    const QVector<float>& binsDbm,
+    double centerMhz,
+    double bandwidthMhz,
+    const QVector<float>& supplementalBinsDbm,
+    double supplementalCenterMhz,
+    double supplementalBandwidthMhz)
 {
     const std::array<float, kCols> raw = resampledRawRow(binsDbm, -200.0f);
+    const bool sameFrameAsPrevious =
+        m_count > 0
+        && frequencyFramesMatch(
+            m_rowCenterMhz[m_head], m_rowBandwidthMhz[m_head],
+            centerMhz, bandwidthMhz);
+    if (m_count > 0 && !sameFrameAsPrevious) {
+        // Adjacent bin indices no longer represent the same frequencies.
+        // Blending them would smear a signal in the direction of the pan.
+        m_rawHistCount = 0;
+    }
     const std::array<float, kCols>* previous =
-        (m_count > 0 && !m_skipLiveTemporalBlendOnce)
-        ? &m_rows[m_head]
-        : nullptr;
+        (sameFrameAsPrevious && !m_skipLiveTemporalBlendOnce)
+            ? &m_rows[m_head]
+            : nullptr;
     m_skipLiveTemporalBlendOnce = false;
     const std::array<float, kCols> nr =
         smoothDssRow(raw, m_rawPrev1, m_rawPrev2, m_rawHistCount, previous);
 
     m_head = (m_head - 1 + kRows) % kRows;
     m_rows[m_head] = nr;
+    m_rowCoverage[m_head].fill(1);
+    m_rowCenterMhz[m_head] = centerMhz;
+    m_rowBandwidthMhz[m_head] = bandwidthMhz;
+    const bool supplementalValid =
+        !supplementalBinsDbm.isEmpty()
+        && std::isfinite(supplementalCenterMhz)
+        && std::isfinite(supplementalBandwidthMhz)
+        && supplementalCenterMhz > 0.0
+        && supplementalBandwidthMhz > 0.0;
+    if (supplementalValid) {
+        m_rowSupplemental[m_head] =
+            resampledRawRow(supplementalBinsDbm, -200.0f);
+        m_rowSupplementalCoverage[m_head].fill(1);
+        m_rowSupplementalCenterMhz[m_head] = supplementalCenterMhz;
+        m_rowSupplementalBandwidthMhz[m_head] =
+            supplementalBandwidthMhz;
+    } else {
+        m_rowSupplemental[m_head].fill(-200.0f);
+        m_rowSupplementalCoverage[m_head].fill(0);
+        m_rowSupplementalCenterMhz[m_head] = 0.0;
+        m_rowSupplementalBandwidthMhz[m_head] = 0.0;
+    }
     m_count = std::min(m_count + 1, kRows);
     m_dirty = true;
     ++m_rowGeneration;
@@ -377,11 +478,25 @@ void DssRenderer::appendHistoryRow(const QVector<float>& binsDbm,
     std::array<float, kCols> previousRow;
     const std::array<float, kCols>* previous = nullptr;
     if (m_historyRowCount > 0 && !m_skipHistoryTemporalBlendOnce) {
-        const qfloat16* src = m_historyRows.constData() + m_historyWriteRow * kCols;
-        for (int c = 0; c < kCols; ++c) {
-            previousRow[c] = static_cast<float>(src[c]);
+        const double previousCenterMhz =
+            m_historyRowCenterMhz.value(m_historyWriteRow, 0.0);
+        const double previousBandwidthMhz =
+            m_historyRowBandwidthMhz.value(m_historyWriteRow, 0.0);
+        if (frequencyFramesMatch(
+                previousCenterMhz, previousBandwidthMhz,
+                centerMhz, bandwidthMhz)) {
+            const qfloat16* src =
+                m_historyRows.constData() + m_historyWriteRow * kCols;
+            for (int c = 0; c < kCols; ++c) {
+                previousRow[c] = static_cast<float>(src[c]);
+            }
+            previous = &previousRow;
+        } else {
+            // Adjacent bin indices represent different frequencies across a
+            // zoom or band change. Blending them creates a synthetic low row at
+            // the frame boundary that later appears to rise from the floor.
+            resetHistorySmoothing();
         }
-        previous = &previousRow;
     }
     m_skipHistoryTemporalBlendOnce = false;
     const std::array<float, kCols> row =
@@ -428,6 +543,8 @@ void DssRenderer::rebuildVisibleFromHistory(int offsetRows,
             (m_historyWriteRow + historyAge) % m_historyCapacityRows;
         const qfloat16* src = m_historyRows.constData() + historyRing * kCols;
         std::array<float, kCols> row;
+        CoverageRow coverage;
+        coverage.fill(1);
         for (int c = 0; c < kCols; ++c) {
             row[c] = static_cast<float>(src[c]);
         }
@@ -438,13 +555,24 @@ void DssRenderer::rebuildVisibleFromHistory(int offsetRows,
         if (rowCenterMhz > 0.0 && rowBandwidthMhz > 0.0
             && centerMhz > 0.0 && bandwidthMhz > 0.0
             && (rowCenterMhz != centerMhz || rowBandwidthMhz != bandwidthMhz)) {
-            row = reprojectRow(row,
-                               rowCenterMhz, rowBandwidthMhz,
-                               centerMhz, bandwidthMhz,
-                               fallbackDbm);
+            const ReprojectedRow remapped = reprojectRow(
+                row,
+                nullptr,
+                rowCenterMhz, rowBandwidthMhz,
+                centerMhz, bandwidthMhz,
+                fallbackDbm);
+            row = remapped.values;
+            coverage = remapped.coverage;
         }
 
         m_rows[age] = row;
+        m_rowCoverage[age] = coverage;
+        m_rowCenterMhz[age] = centerMhz;
+        m_rowBandwidthMhz[age] = bandwidthMhz;
+        m_rowSupplemental[age].fill(-200.0f);
+        m_rowSupplementalCoverage[age].fill(0);
+        m_rowSupplementalCenterMhz[age] = 0.0;
+        m_rowSupplementalBandwidthMhz[age] = 0.0;
     }
 
     m_dirty = true;
@@ -456,34 +584,127 @@ void DssRenderer::reprojectFrequencyFrame(double oldCenterMhz,
                                           double oldBandwidthMhz,
                                           double newCenterMhz,
                                           double newBandwidthMhz,
-                                          float fallbackDbm)
+                                          float fallbackDbm,
+                                          bool refreshFromRetainedHistory)
 {
+    // The compact visible ring is already resampled to kCols. Reprojecting it
+    // repeatedly across large zoom changes compounds that loss: zooming far
+    // out can collapse a signal into one column, and zooming back in expands
+    // that column into a false ridge while uncovered bins become flat floor
+    // segments. Refresh each existing ring slot from its frame-stamped retained
+    // source instead. This preserves the head, row count, and scroll phase, so
+    // the timeline remains continuously populated throughout the zoom.
+    if (refreshFromRetainedHistory
+        && m_count > 0 && m_historyRowCount >= m_count
+        && historyStorageMatchesCapacity()) {
+        for (int age = 0; age < m_count; ++age) {
+            const int historyRing =
+                (m_historyWriteRow + age) % m_historyCapacityRows;
+            const qfloat16* src =
+                m_historyRows.constData() + historyRing * kCols;
+            std::array<float, kCols> row;
+            CoverageRow coverage;
+            coverage.fill(1);
+            for (int c = 0; c < kCols; ++c) {
+                row[c] = static_cast<float>(src[c]);
+            }
+
+            const double rowCenterMhz =
+                m_historyRowCenterMhz.value(historyRing, 0.0);
+            const double rowBandwidthMhz =
+                m_historyRowBandwidthMhz.value(historyRing, 0.0);
+            if (rowCenterMhz > 0.0 && rowBandwidthMhz > 0.0
+                && newCenterMhz > 0.0 && newBandwidthMhz > 0.0
+                && (rowCenterMhz != newCenterMhz
+                    || rowBandwidthMhz != newBandwidthMhz)) {
+                const ReprojectedRow remapped = reprojectRow(
+                    row,
+                    nullptr,
+                    rowCenterMhz, rowBandwidthMhz,
+                    newCenterMhz, newBandwidthMhz,
+                    fallbackDbm);
+                row = remapped.values;
+                coverage = remapped.coverage;
+            }
+
+            const int visibleRing = (m_head + age) % kRows;
+            m_rows[visibleRing] = row;
+            m_rowCoverage[visibleRing] = coverage;
+            m_rowCenterMhz[visibleRing] = newCenterMhz;
+            m_rowBandwidthMhz[visibleRing] = newBandwidthMhz;
+            m_rowSupplemental[visibleRing].fill(-200.0f);
+            m_rowSupplementalCoverage[visibleRing].fill(0);
+            m_rowSupplementalCenterMhz[visibleRing] = 0.0;
+            m_rowSupplementalBandwidthMhz[visibleRing] = 0.0;
+        }
+        m_dirty = true;
+        // The previous live row was just replaced from retained history.
+        // Its bin coordinates are not valid temporal-filter inputs for the
+        // first newly decoded target-frame row.
+        resetInputSmoothing();
+        ++m_rowGeneration;
+        return;
+    }
+
     if (m_count <= 0 || oldBandwidthMhz <= 0.0 || newBandwidthMhz <= 0.0) {
         return;
     }
 
     for (int age = 0; age < m_count; ++age) {
         const int ring = (m_head + age) % kRows;
-        m_rows[ring] = reprojectRow(m_rows[ring],
-                                    oldCenterMhz, oldBandwidthMhz,
-                                    newCenterMhz, newBandwidthMhz,
-                                    fallbackDbm);
+        const ReprojectedRow remapped = reprojectRow(
+            m_rows[ring],
+            &m_rowCoverage[ring],
+            oldCenterMhz, oldBandwidthMhz,
+            newCenterMhz, newBandwidthMhz,
+            fallbackDbm);
+        m_rows[ring] = remapped.values;
+        m_rowCoverage[ring] = remapped.coverage;
+        m_rowCenterMhz[ring] = newCenterMhz;
+        m_rowBandwidthMhz[ring] = newBandwidthMhz;
+        m_rowSupplemental[ring].fill(-200.0f);
+        m_rowSupplementalCoverage[ring].fill(0);
+        m_rowSupplementalCenterMhz[ring] = 0.0;
+        m_rowSupplementalBandwidthMhz[ring] = 0.0;
     }
-    if (m_rawHistCount >= 1) {
-        m_rawPrev1 = reprojectRow(m_rawPrev1,
-                                  oldCenterMhz, oldBandwidthMhz,
-                                  newCenterMhz, newBandwidthMhz,
-                                  fallbackDbm);
-    }
-    if (m_rawHistCount >= 2) {
-        m_rawPrev2 = reprojectRow(m_rawPrev2,
-                                  oldCenterMhz, oldBandwidthMhz,
-                                  newCenterMhz, newBandwidthMhz,
-                                  fallbackDbm);
-    }
-
     m_dirty = true;
+    // Even when retained history is unavailable, the first target-frame row
+    // must stand on its own. Carrying old-frame filter inputs forward would
+    // blend fallback floor into newly covered frequencies.
+    resetInputSmoothing();
     ++m_rowGeneration;
+}
+
+double DssRenderer::rowCenterMhzAtAge(int age) const
+{
+    if (age < 0 || age >= m_count) {
+        return 0.0;
+    }
+    return m_rowCenterMhz[(m_head + age) % kRows];
+}
+
+double DssRenderer::rowBandwidthMhzAtAge(int age) const
+{
+    if (age < 0 || age >= m_count) {
+        return 0.0;
+    }
+    return m_rowBandwidthMhz[(m_head + age) % kRows];
+}
+
+double DssRenderer::rowSupplementalCenterMhzAtAge(int age) const
+{
+    if (age < 0 || age >= m_count) {
+        return 0.0;
+    }
+    return m_rowSupplementalCenterMhz[(m_head + age) % kRows];
+}
+
+double DssRenderer::rowSupplementalBandwidthMhzAtAge(int age) const
+{
+    if (age < 0 || age >= m_count) {
+        return 0.0;
+    }
+    return m_rowSupplementalBandwidthMhz[(m_head + age) % kRows];
 }
 
 const QImage& DssRenderer::image(const QSize& px, int scaleStripPx,
@@ -546,7 +767,7 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
     const double frontMaxRidge = H * kFrontMaxRidgeFrac;
     // Match dss_mesh.vert's depth parametrization exactly (v = rr / rows), so
     // the CPU fallback and the GPU mesh place rows at the same depth.
-    const double denom         = kRows;
+    const double denom         = kVisibleRows;
 
     std::array<QPointF, kCols> pts;
     std::array<QColor, kCols>  cols;   // depth/slope-shaded fill colour per column
@@ -560,7 +781,7 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
 
     // Back (oldest) → front (newest): painter's algorithm. Nearer traces are
     // wider, sit lower, and fill to the floor, so they occlude farther ones.
-    for (int age = m_count - 1; age >= 0; --age) {
+    for (int age = visibleRowCount() - 1; age >= 0; --age) {
         const double depthFrac    = age / denom;
         const double rowWidthFrac = 1.0 - depthFrac * (1.0 - kBackWidthFrac);
         const double inset        = W * (1.0 - rowWidthFrac) * 0.5;
@@ -570,12 +791,15 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
         const double dim          = kMinDim + (1.0 - kMinDim) * (1.0 - depthFrac);
 
         const auto& row = rowAt(age);
+        const int ring = (m_head + age) % kRows;
+        const auto& coverage = m_rowCoverage[ring];
         // Pass 1: geometry — noise-floor-anchored ridge heights, with the same
         // pow(s, zCurve) floor-lift the GPU shader applies.
         for (int c = 0; c < kCols; ++c) {
             const double x = inset + (kCols > 1 ? double(c) / (kCols - 1) : 0.0) * rowW;
-            const float dbm = row[c];
-            double strength = std::clamp((dbm - floorDbm) / rangeDb, 0.0f, 1.0f);
+            const float dbm = coverage[c] != 0 ? row[c] : floorDbm;
+            double strength = std::clamp(
+                (dbm - floorDbm) / rangeDb, 0.0f, 1.0f);
             strength = std::pow(strength, zc);
             pts[c] = QPointF(x, baselineY - strength * maxRidge);
         }
@@ -586,7 +810,8 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
             const int cr = std::min(kCols - 1, c + 1);
             const double slope = (pts[cl].y() - pts[cr].y()) / slopeScale; // +: rises to right
             const double shade = std::clamp(1.0 + kSlopeGain * slope, kShadeLo, kShadeHi);
-            QColor base = QColor(palette(row[c]));
+            const float dbm = coverage[c] != 0 ? row[c] : floorDbm;
+            QColor base = QColor(palette(dbm));
             base = lerpColor(base, bgFill, depthFrac * kHaze);
             cols[c] = scaled(base, dim * shade);
         }
@@ -609,7 +834,8 @@ void DssRenderer::rebuild(const QSize& px, int scaleStripPx, float floorDbm,
         p.setRenderHint(QPainter::Antialiasing, true);
         ridgePen.setWidthF(age == 0 ? 1.6 : 1.0);
         for (int c = 0; c < kCols - 1; ++c) {
-            QColor rc = QColor(palette(row[c])).lighter(165);
+            const float dbm = coverage[c] != 0 ? row[c] : floorDbm;
+            QColor rc = QColor(palette(dbm)).lighter(165);
             rc = lerpColor(rc, bgFill, depthFrac * kHaze);
             ridgePen.setColor(scaled(rc, dim));
             p.setPen(ridgePen);

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -30,7 +30,9 @@
 class DssRenderer
 {
 public:
-    static constexpr int kRows = 96;   // history depth (front → back)
+    static constexpr int kVisibleRows = 96;    // front → back display depth
+    static constexpr int kTransitionRows = 8;  // outgoing rows kept during scroll
+    static constexpr int kRows = kVisibleRows + kTransitionRows;
     static constexpr int kCols = 768;  // resampled columns per row
 
     // Perspective geometry of the surface, shared by this CPU renderer and the
@@ -89,7 +91,16 @@ public:
 
     // Push one freshly-decoded FFT row (any bin count, dBm). Peak-preserving
     // downsample to kCols and store it as the newest (front) trace.
-    void pushRow(const QVector<float>& binsDbm);
+    void pushRow(const QVector<float>& binsDbm,
+                 double centerMhz = 0.0,
+                 double bandwidthMhz = 0.0);
+    void pushRowWithSupplemental(
+        const QVector<float>& binsDbm,
+        double centerMhz,
+        double bandwidthMhz,
+        const QVector<float>& supplementalBinsDbm,
+        double supplementalCenterMhz,
+        double supplementalBandwidthMhz);
     void setHistoryCapacityRows(int rows);
     int historyCapacityRows() const { return m_historyCapacityRows; }
     int historyRowCount() const { return m_historyRowCount; }
@@ -103,9 +114,14 @@ public:
     void rebuildVisibleFromHistory(int offsetRows,
                                    double centerMhz, double bandwidthMhz,
                                    float fallbackDbm);
+    // Remap the visible live viewport to a new frequency frame. Prefer an
+    // in-place refresh from retained, frame-stamped rows so ring topology and
+    // scroll phase remain intact; fall back to direct visible-ring reprojection
+    // when no matching retained history is available.
     void reprojectFrequencyFrame(double oldCenterMhz, double oldBandwidthMhz,
                                  double newCenterMhz, double newBandwidthMhz,
-                                 float fallbackDbm);
+                                 float fallbackDbm,
+                                 bool refreshFromRetainedHistory = false);
 
     // Return the cached surface sized to px. The plot region (everything above
     // the bottom scaleStripPx) is painted opaque over bgFill; the scale strip
@@ -139,8 +155,28 @@ public:
     int cols() const { return kCols; }
     int rows() const { return kRows; }
     int rowCount() const { return m_count; }     // valid rows (0..kRows)
+    int visibleRowCount() const
+    {
+        return std::min(m_count, kVisibleRows);
+    }
     int headRing() const { return m_head; }       // ring index of the newest row
     const float* rowDataRing(int ringIndex) const { return m_rows[ringIndex].data(); }
+    const quint8* rowCoverageRing(int ringIndex) const
+    {
+        return m_rowCoverage[ringIndex].data();
+    }
+    const float* rowSupplementalDataRing(int ringIndex) const
+    {
+        return m_rowSupplemental[ringIndex].data();
+    }
+    const quint8* rowSupplementalCoverageRing(int ringIndex) const
+    {
+        return m_rowSupplementalCoverage[ringIndex].data();
+    }
+    double rowCenterMhzAtAge(int age) const;
+    double rowBandwidthMhzAtAge(int age) const;
+    double rowSupplementalCenterMhzAtAge(int age) const;
+    double rowSupplementalBandwidthMhzAtAge(int age) const;
     RowStats rowStats(int age, float epsilonDb = 0.01f) const;
     quint64 rowGeneration() const { return m_rowGeneration; }
 
@@ -160,6 +196,25 @@ private:
 
     // Circular store: m_head indexes the newest row.
     std::array<std::array<float, kCols>, kRows> m_rows{};
+    // One byte per bin records whether that frequency existed in the captured
+    // row. Reprojection-created gaps remain drawable floor lines, but the
+    // marker lets both renderers keep their height/colour independent of later
+    // zoom and dBm-range changes.
+    std::array<std::array<quint8, kCols>, kRows> m_rowCoverage{};
+    // Native FLEX waterfall tiles cover more spectrum than the FFT viewport.
+    // Keep that calibrated overhang in separate channels so it can fill only
+    // frequencies the exact FFT row never captured; it must never resample or
+    // replace the working FFT trace.
+    std::array<std::array<float, kCols>, kRows> m_rowSupplemental{};
+    std::array<std::array<quint8, kCols>, kRows>
+        m_rowSupplementalCoverage{};
+    // Each live row keeps the frequency frame in which its bins were captured.
+    // The GPU maps rows independently during pan previews, allowing retained
+    // off-screen data and newly received radio coverage to coexist.
+    std::array<double, kRows> m_rowCenterMhz{};
+    std::array<double, kRows> m_rowBandwidthMhz{};
+    std::array<double, kRows> m_rowSupplementalCenterMhz{};
+    std::array<double, kRows> m_rowSupplementalBandwidthMhz{};
     int     m_head  = 0;         // index of the newest row
     int     m_count = 0;         // number of valid rows (0..kRows)
     bool    m_dirty = true;

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -31,7 +31,10 @@ class DssRenderer
 {
 public:
     static constexpr int kVisibleRows = 96;    // front → back display depth
-    static constexpr int kTransitionRows = 8;  // outgoing rows kept during scroll
+    // Outgoing rows kept during scroll. Must cover the largest row distance
+    // passed to SpectrumWidget::startWaterfallScrollAnimation(); the current
+    // Flex, Kiwi, and fallback producers append at most one row per update.
+    static constexpr int kTransitionRows = 8;
     static constexpr int kRows = kVisibleRows + kTransitionRows;
     static constexpr int kCols = 768;  // resampled columns per row
 

--- a/src/gui/DssRenderer.h
+++ b/src/gui/DssRenderer.h
@@ -226,6 +226,13 @@ private:
     std::array<float, kCols> m_rawPrev1{};
     std::array<float, kCols> m_rawPrev2{};
     int m_rawHistCount = 0;
+    // The calibrated native-tile overhang needs an independent copy of the
+    // same smoothing chain. Sharing FFT history would blend different
+    // frequency frames; storing it raw exaggerates isolated tile maxima until
+    // exact FFT coverage replaces them.
+    std::array<float, kCols> m_supplementalRawPrev1{};
+    std::array<float, kCols> m_supplementalRawPrev2{};
+    int m_supplementalRawHistCount = 0;
 
     // One-shot flags: after resetInputSmoothing() the next pushed row must not
     // blend against the retained row that preceded the reset (it was decoded
@@ -234,6 +241,7 @@ private:
     // own; the temporal IIR term against the previous smoothed row also carries
     // pre-reset data.
     bool m_skipLiveTemporalBlendOnce = false;
+    bool m_skipSupplementalTemporalBlendOnce = false;
     bool m_skipHistoryTemporalBlendOnce = false;
 
     // Retained scrollback store. This is intentionally separate from the

--- a/src/gui/DssSupplementalCoverage.h
+++ b/src/gui/DssSupplementalCoverage.h
@@ -9,9 +9,10 @@ namespace AetherSDR {
 
 // Converts a native waterfall tile into a dBm-like fallback row for the part of
 // a 3D FFT trace that lies outside its captured FFT frame. The radio's waterfall
-// tile is wider than the panadapter viewport, but its intensity values use a
-// different offset from FFT dBm. A robust overlap median supplies that offset
-// for this one row. The real FFT row always wins wherever it has coverage.
+// tile is wider than the panadapter viewport, but its intensity values are an
+// arbitrary display scale rather than FFT dBm. Robust overlap quantiles align
+// both its floor and span for this one row. The real FFT row always wins
+// wherever it has coverage.
 inline std::vector<float> buildDssSupplementalCoverage(
     std::span<const float> tileIntensity,
     double tileLowMhz,
@@ -39,8 +40,12 @@ inline std::vector<float> buildDssSupplementalCoverage(
     }
 
     const double tileBandwidthMhz = tileHighMhz - tileLowMhz;
-    std::vector<float> offsets;
-    offsets.reserve(std::min<std::size_t>(tileIntensity.size(), 256));
+    std::vector<float> tileOverlap;
+    std::vector<float> fftOverlap;
+    const std::size_t sampleCapacity =
+        std::min<std::size_t>(tileIntensity.size(), 256);
+    tileOverlap.reserve(sampleCapacity);
+    fftOverlap.reserve(sampleCapacity);
     const std::size_t sampleStep =
         std::max<std::size_t>(1, tileIntensity.size() / 256);
     for (std::size_t index = 0; index < tileIntensity.size();
@@ -70,24 +75,52 @@ inline std::vector<float> buildDssSupplementalCoverage(
             continue;
         }
         const float dbm = leftDbm + (rightDbm - leftDbm) * fraction;
-        offsets.push_back(dbm - intensity);
+        tileOverlap.push_back(intensity);
+        fftOverlap.push_back(dbm);
     }
 
     // Fewer than a handful of overlap samples cannot reject a transient carrier
     // mismatch between the asynchronous FFT and waterfall packets reliably.
-    if (offsets.size() < 8) {
+    if (tileOverlap.size() < 8) {
         return supplemental;
     }
-    const std::size_t middle = offsets.size() / 2;
-    std::nth_element(offsets.begin(), offsets.begin() + middle, offsets.end());
-    const float offsetDb = offsets[middle];
+    std::sort(tileOverlap.begin(), tileOverlap.end());
+    std::sort(fftOverlap.begin(), fftOverlap.end());
+    const auto quantile = [](const std::vector<float>& sorted, float position) {
+        const float index =
+            position * static_cast<float>(sorted.size() - 1);
+        const std::size_t left =
+            static_cast<std::size_t>(std::floor(index));
+        const std::size_t right = std::min(left + 1, sorted.size() - 1);
+        const float fraction = index - static_cast<float>(left);
+        return sorted[left] + (sorted[right] - sorted[left]) * fraction;
+    };
+
+    constexpr float kLowQuantile = 0.1f;
+    constexpr float kHighQuantile = 0.9f;
+    constexpr float kMinimumTileSpan = 0.25f;
+    constexpr float kMinimumScale = 0.25f;
+    constexpr float kMaximumScale = 4.0f;
+    const float tileFloor = quantile(tileOverlap, kLowQuantile);
+    const float fftFloor = quantile(fftOverlap, kLowQuantile);
+    const float tileSpan =
+        quantile(tileOverlap, kHighQuantile) - tileFloor;
+    const float fftSpan =
+        quantile(fftOverlap, kHighQuantile) - fftFloor;
+
+    // A flat overlap has no usable scale information. Preserve the historical
+    // one-to-one mapping in that case, while still anchoring its floor.
+    const float scale = tileSpan >= kMinimumTileSpan
+        ? std::clamp(fftSpan / tileSpan, kMinimumScale, kMaximumScale)
+        : 1.0f;
+    const float offsetDb = fftFloor - scale * tileFloor;
 
     const float lowDbm = std::min(fallbackDbm, ceilingDbm);
     const float highDbm = std::max(fallbackDbm, ceilingDbm);
     supplemental.reserve(tileIntensity.size());
     for (const float intensity : tileIntensity) {
         const float calibrated = std::isfinite(intensity)
-            ? intensity + offsetDb
+            ? intensity * scale + offsetDb
             : lowDbm;
         supplemental.push_back(std::clamp(calibrated, lowDbm, highDbm));
     }

--- a/src/gui/DssSupplementalCoverage.h
+++ b/src/gui/DssSupplementalCoverage.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <span>
+#include <vector>
+
+namespace AetherSDR {
+
+// Converts a native waterfall tile into a dBm-like fallback row for the part of
+// a 3D FFT trace that lies outside its captured FFT frame. The radio's waterfall
+// tile is wider than the panadapter viewport, but its intensity values use a
+// different offset from FFT dBm. A robust overlap median supplies that offset
+// for this one row. The real FFT row always wins wherever it has coverage.
+inline std::vector<float> buildDssSupplementalCoverage(
+    std::span<const float> tileIntensity,
+    double tileLowMhz,
+    double tileHighMhz,
+    std::span<const float> fftDbm,
+    double fftCenterMhz,
+    double fftBandwidthMhz,
+    float fallbackDbm,
+    float ceilingDbm)
+{
+    std::vector<float> supplemental;
+    if (tileIntensity.empty() || fftDbm.size() < 2
+        || !std::isfinite(tileLowMhz) || !std::isfinite(tileHighMhz)
+        || !std::isfinite(fftCenterMhz) || !std::isfinite(fftBandwidthMhz)
+        || tileHighMhz <= tileLowMhz || fftBandwidthMhz <= 0.0) {
+        return supplemental;
+    }
+
+    const double fftLowMhz = fftCenterMhz - fftBandwidthMhz * 0.5;
+    const double fftHighMhz = fftCenterMhz + fftBandwidthMhz * 0.5;
+    const double overlapLowMhz = std::max(tileLowMhz, fftLowMhz);
+    const double overlapHighMhz = std::min(tileHighMhz, fftHighMhz);
+    if (overlapHighMhz <= overlapLowMhz) {
+        return supplemental;
+    }
+
+    const double tileBandwidthMhz = tileHighMhz - tileLowMhz;
+    std::vector<float> offsets;
+    offsets.reserve(std::min<std::size_t>(tileIntensity.size(), 256));
+    const std::size_t sampleStep =
+        std::max<std::size_t>(1, tileIntensity.size() / 256);
+    for (std::size_t index = 0; index < tileIntensity.size();
+         index += sampleStep) {
+        const float intensity = tileIntensity[index];
+        if (!std::isfinite(intensity)) {
+            continue;
+        }
+        const double frequencyMhz = tileLowMhz
+            + (static_cast<double>(index) + 0.5)
+                / static_cast<double>(tileIntensity.size())
+                * tileBandwidthMhz;
+        if (frequencyMhz < overlapLowMhz || frequencyMhz > overlapHighMhz) {
+            continue;
+        }
+        const double fftPosition = (frequencyMhz - fftLowMhz)
+            / fftBandwidthMhz * static_cast<double>(fftDbm.size() - 1);
+        const std::size_t left = static_cast<std::size_t>(std::clamp(
+            std::floor(fftPosition), 0.0,
+            static_cast<double>(fftDbm.size() - 1)));
+        const std::size_t right = std::min(left + 1, fftDbm.size() - 1);
+        const float fraction =
+            static_cast<float>(fftPosition - static_cast<double>(left));
+        const float leftDbm = fftDbm[left];
+        const float rightDbm = fftDbm[right];
+        if (!std::isfinite(leftDbm) || !std::isfinite(rightDbm)) {
+            continue;
+        }
+        const float dbm = leftDbm + (rightDbm - leftDbm) * fraction;
+        offsets.push_back(dbm - intensity);
+    }
+
+    // Fewer than a handful of overlap samples cannot reject a transient carrier
+    // mismatch between the asynchronous FFT and waterfall packets reliably.
+    if (offsets.size() < 8) {
+        return supplemental;
+    }
+    const std::size_t middle = offsets.size() / 2;
+    std::nth_element(offsets.begin(), offsets.begin() + middle, offsets.end());
+    const float offsetDb = offsets[middle];
+
+    const float lowDbm = std::min(fallbackDbm, ceilingDbm);
+    const float highDbm = std::max(fallbackDbm, ceilingDbm);
+    supplemental.reserve(tileIntensity.size());
+    for (const float intensity : tileIntensity) {
+        const float calibrated = std::isfinite(intensity)
+            ? intensity + offsetDb
+            : lowDbm;
+        supplemental.push_back(std::clamp(calibrated, lowDbm, highDbm));
+    }
+    return supplemental;
+}
+
+} // namespace AetherSDR

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2885,14 +2885,24 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
     }
 
     auto pendingDbm = std::make_shared<DbmRangeTransition::Handshake>();
-    auto setStreamDbmRange = [this, applet](float minDbm, float maxDbm, bool waitForEcho = false) {
+    auto encoderDbmRange =
+        std::make_shared<DbmRangeTransition::Range>();
+    auto encoderRecoveryPending = std::make_shared<bool>(false);
+    if (auto* pan = m_radioModel.panadapter(applet->panId())) {
+        *encoderDbmRange = {pan->minDbm(), pan->maxDbm()};
+    }
+    auto setStreamDbmRange =
+        [this, applet, encoderDbmRange]
+        (float minDbm, float maxDbm, bool waitForEcho = false) {
+        *encoderDbmRange = {minDbm, maxDbm};
         if (auto* pan = m_radioModel.panadapter(applet->panId())) {
             if (pan->panStreamId() && m_radioModel.panStream()) {
                 m_radioModel.panStream()->setDbmRange(pan->panStreamId(), minDbm, maxDbm, waitForEcho);
             }
         }
     };
-    auto applyAuthoritativeDbmRange = [this, applet, sw, setStreamDbmRange]
+    auto applyAuthoritativeDbmRange =
+        [this, applet, sw, setStreamDbmRange, encoderRecoveryPending]
                                       (const DbmRangeTransition::Range& range) {
         sw->cancelPendingDbmRangeChange();
         if (auto* pan = m_radioModel.panadapter(applet->panId())) {
@@ -2901,6 +2911,11 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
         }
         setStreamDbmRange(range.minDbm, range.maxDbm);
+        if (*encoderRecoveryPending) {
+            *encoderRecoveryPending = false;
+            sw->reacquireNoiseFloorLock();
+            return;
+        }
         sw->setDbmRange(range.minDbm, range.maxDbm);
         sw->prepareForFftScaleChange();
         sw->reacquireNoiseFloorLock();
@@ -2915,7 +2930,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             }
         }
     };
-    auto retireDbmRangeWithoutEcho = [this, applet, sw]() {
+    auto retireDbmRangeWithoutEcho =
+        [this, applet, sw, encoderRecoveryPending]() {
         // Some Flex firmware accepts a display range command without echoing
         // min_dbm/max_dbm. In that case the decoder is already using the range
         // the radio adopted, so only retire the stale-echo guard; reverting to
@@ -2926,6 +2942,10 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             if (pan->panStreamId() && m_radioModel.panStream()) {
                 m_radioModel.panStream()->cancelPendingDbmRange(pan->panStreamId());
             }
+        }
+        if (*encoderRecoveryPending) {
+            *encoderRecoveryPending = false;
+            sw->reacquireNoiseFloorLock();
         }
     };
     auto finishDbmRangeHandshake = [pendingDbm, applyAuthoritativeDbmRange,
@@ -3185,7 +3205,8 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         //      update pan A's dBm scale.
         connect(pan, &PanadapterModel::levelChanged,
                 sw, [sw, pendingDbm, setStreamDbmRange,
-                     applyAuthoritativeDbmRange](float minDbm, float maxDbm) {
+                     applyAuthoritativeDbmRange,
+                     encoderRecoveryPending](float minDbm, float maxDbm) {
             const DbmRangeTransition::HandshakeDecision decision =
                 pendingDbm->observeRadioRange(
                     minDbm, maxDbm, QDateTime::currentMSecsSinceEpoch(),
@@ -3199,6 +3220,12 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
             if (decision.action
                 == DbmRangeTransition::HandshakeAction::ReconcileRadioRange) {
                 applyAuthoritativeDbmRange(decision.range);
+                return;
+            }
+            if (*encoderRecoveryPending) {
+                setStreamDbmRange(minDbm, maxDbm);
+                *encoderRecoveryPending = false;
+                sw->reacquireNoiseFloorLock();
                 return;
             }
             if (sw->isDraggingDbmScale()) {
@@ -3368,6 +3395,33 @@ void MainWindow::wirePanadapter(PanadapterApplet* applet)
         armDbmRangeHandshake(minDbm, maxDbm);
         setStreamDbmRange(minDbm, maxDbm, true);
         sendDbmRangeCommand(minDbm, maxDbm);
+    });
+    connect(sw, &SpectrumWidget::radioDbmHeadroomRecoveryRequested,
+            this, [this, applet, sw, encoderDbmRange,
+                   encoderRecoveryPending, armDbmRangeHandshake,
+                   setStreamDbmRange, sendDbmRangeCommand](float headroomDb) {
+        if (sw->kiwiSdrWaterfallActive()
+            || profileLoadRadioStateWritesHeld()) {
+            return;
+        }
+        if (auto* pan = m_radioModel.panadapter(applet->panId());
+            pan && !pan->ownedByClient(m_radioModel.ourClientHandle())) {
+            return;
+        }
+
+        const DbmRangeTransition::Range recoveryRange =
+            DbmRangeTransition::clippedFloorRecoveryRange(
+                encoderDbmRange->minDbm,
+                encoderDbmRange->maxDbm,
+                headroomDb);
+        *encoderRecoveryPending = true;
+        sw->cancelPendingDbmRangeChange();
+        armDbmRangeHandshake(
+            recoveryRange.minDbm, recoveryRange.maxDbm);
+        setStreamDbmRange(
+            recoveryRange.minDbm, recoveryRange.maxDbm, true);
+        sendDbmRangeCommand(
+            recoveryRange.minDbm, recoveryRange.maxDbm);
     });
     connect(sw, &SpectrumWidget::dbmRangeDragFinished,
             this, [this, applet, sw, armDbmRangeHandshake,

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -223,6 +223,19 @@ inline bool dssFrameFloorLooksClipped(int finiteBins,
         && longestMinRunBins >= std::max(16, finiteBins / 16);
 }
 
+// Clipped FLEX FFT input needs radio-side encoder headroom in both 2D and 3D.
+// Deliberately takes no render-mode argument: limiting recovery to the 3D
+// renderer regresses the shared 2D FFT path when y_pixels/range state is stale.
+inline bool flexFftFrameNeedsHeadroomRecovery(bool kiwiActive,
+                                              int finiteBins,
+                                              int minValueBins,
+                                              int longestMinRunBins)
+{
+    return !kiwiActive
+        && dssFrameFloorLooksClipped(
+            finiteBins, minValueBins, longestMinRunBins);
+}
+
 // Windows in which an FFT frame's dBm encoding does not correspond to the
 // settled zoom, so it must not anchor the 3D floor. Kept out of the widget so
 // the timing policy is testable without a live radio or a QWidget.

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -344,12 +344,14 @@ inline std::optional<float> dssRetainedSampleAge(float sourceAge,
 struct DssFixedGridCrossfade {
     float baseAge{0.0f};
     float overlayAge{0.0f};
+    float baseAlpha{1.0f};
     float overlayAlpha{0.0f};
 };
 
-// Mirror of dss_mesh.vert's fixed boundary-row scroll. Both layers sample exact
-// rows; only the new layer opacity changes. At the next head advance, the fully
-// opaque overlay becomes the following interval's base at the same depth.
+// Mirror of dss_mesh.vert's fixed ridge-outline scroll. Both layers sample
+// exact rows and trade opacity at a fixed depth. At the next head advance, the
+// fully opaque overlay becomes the following interval's base at that same
+// depth.
 inline std::optional<DssFixedGridCrossfade> dssFixedGridCrossfade(
     float sourceAge, float progressRows, float distanceRows)
 {
@@ -358,11 +360,34 @@ inline std::optional<DssFixedGridCrossfade> dssFixedGridCrossfade(
         || progressRows < 0.0f || distanceRows <= 0.0f) {
         return std::nullopt;
     }
+    const float overlayAlpha =
+        std::clamp(progressRows / distanceRows, 0.0f, 1.0f);
     return DssFixedGridCrossfade{
         sourceAge + distanceRows,
         sourceAge,
-        std::clamp(progressRows / distanceRows, 0.0f, 1.0f),
+        1.0f - overlayAlpha,
+        overlayAlpha,
     };
+}
+
+// Actual per-layer alpha used by the ridge shader. The base is rendered first,
+// then the overlay with source-over blending. Compensation keeps the combined
+// opacity constant when both exact outlines cover the same pixel.
+inline float dssSourceOverCrossfadeLayerAlpha(float opacity,
+                                              float overlayPhase,
+                                              bool overlayLayer)
+{
+    if (!std::isfinite(opacity) || !std::isfinite(overlayPhase)) {
+        return 0.0f;
+    }
+    const float clampedOpacity = std::clamp(opacity, 0.0f, 1.0f);
+    const float phase = std::clamp(overlayPhase, 0.0f, 1.0f);
+    if (!overlayLayer) {
+        return clampedOpacity * (1.0f - phase);
+    }
+    const float baseAlpha = clampedOpacity * (1.0f - phase);
+    return clampedOpacity * phase
+        / std::max(1.0f - baseAlpha, 0.0001f);
 }
 
 inline std::optional<float> dssMovingGeometryDepth(float sourceAge,
@@ -403,6 +428,53 @@ inline float dssRibbonCoverage(float coordinate)
         0.0f, 1.0f);
     const float smooth = t * t * (3.0f - 2.0f * t);
     return 1.0f - smooth;
+}
+
+struct DssRibbonPixelOffset {
+    float x{0.0f};
+    float y{0.0f};
+};
+
+// Mirror of dss_mesh.vert's side-endpoint treatment. A perpendicular
+// screen-space ribbon is correct in the trace interior, but its horizontal
+// component makes the exposed outer endpoint crawl as the adjacent FFT slope
+// changes. Endpoints use a fixed vertical butt boundary instead.
+inline DssRibbonPixelOffset dssRibbonPixelOffset(float frequencyUnit,
+                                                 float normalX,
+                                                 float normalY,
+                                                 float ribbonSide)
+{
+    if (!std::isfinite(frequencyUnit)
+        || !std::isfinite(normalX) || !std::isfinite(normalY)
+        || !std::isfinite(ribbonSide)) {
+        return {};
+    }
+    if (frequencyUnit <= 0.0f || frequencyUnit >= 1.0f) {
+        return DssRibbonPixelOffset{0.0f, ribbonSide};
+    }
+    return DssRibbonPixelOffset{
+        normalX * ribbonSide,
+        normalY * ribbonSide,
+    };
+}
+
+inline float dssSideOutlineAlphaScale(float frequencyUnit,
+                                      float plotWidthPx,
+                                      float perspectiveWidth)
+{
+    if (!std::isfinite(frequencyUnit) || !std::isfinite(plotWidthPx)
+        || !std::isfinite(perspectiveWidth)
+        || plotWidthPx <= 0.0f || perspectiveWidth <= 0.0f) {
+        return 0.0f;
+    }
+    constexpr float kFadeWidthPx = 8.0f;
+    const float edgeDistancePx =
+        std::max(0.0f, std::min(frequencyUnit, 1.0f - frequencyUnit))
+        * plotWidthPx * perspectiveWidth;
+    const float t = std::clamp(
+        edgeDistancePx / kFadeWidthPx, 0.0f, 1.0f);
+    const float smooth = t * t * (3.0f - 2.0f * t);
+    return smooth;
 }
 
 struct StablePresentationAnchor {

--- a/src/gui/SpectrumPreviewLogic.h
+++ b/src/gui/SpectrumPreviewLogic.h
@@ -60,6 +60,46 @@ inline FrequencyPreviewTransform frequencyPreviewTransform(
     };
 }
 
+// FFT packets do not carry their own center/bandwidth. During a zoom preview,
+// keep the compact 3D surface in one uniform base frame until commit; treating
+// each untagged arrival as the moving visual target creates artificial
+// uncovered floor bands that then scroll through retained history.
+//
+// A pure pan is different: the radio is already returning bins for the moving
+// center. Stamp those rows at the current frame so remapping them into the base
+// plus the preview shader applies the pan exactly once, matching the waterfall.
+inline bool dssUntaggedRowUsesPreviewBase(
+    const FrequencyFrame& previewBase,
+    const FrequencyFrame& previewTarget,
+    bool nativePreviewActive)
+{
+    if (!nativePreviewActive
+        || !previewBase.isValid() || !previewTarget.isValid()) {
+        return false;
+    }
+    const double bandwidthScale = std::max(
+        {1.0, std::abs(previewBase.bandwidthMhz),
+         std::abs(previewTarget.bandwidthMhz)});
+    return std::abs(
+        previewTarget.bandwidthMhz - previewBase.bandwidthMhz)
+        > bandwidthScale * 1.0e-9;
+}
+
+inline FrequencyFrame resolvedUntaggedDssFrame(
+    const FrequencyFrame& requested,
+    const FrequencyFrame& current,
+    const FrequencyFrame& previewBase,
+    bool usePreviewBase)
+{
+    if (requested.isValid()) {
+        return requested;
+    }
+    if (usePreviewBase && previewBase.isValid()) {
+        return previewBase;
+    }
+    return current;
+}
+
 inline double sourceUnitPosition(double targetUnitPosition,
                                  const FrequencyFrame& source,
                                  const FrequencyFrame& target)
@@ -127,6 +167,7 @@ public:
     {
         m_bandwidthChangeQueued = true;
         m_waitingForFreshFrame = false;
+        m_adjustmentAttempts = 0;
     }
 
     void settle(bool flex3dActive)
@@ -142,6 +183,17 @@ public:
             return false;
         }
         m_waitingForFreshFrame = false;
+        m_adjustmentAttempts = 0;
+        return true;
+    }
+
+    bool beginAdjustment(int maxAttempts)
+    {
+        if (!m_waitingForFreshFrame
+            || m_adjustmentAttempts >= std::max(0, maxAttempts)) {
+            return false;
+        }
+        ++m_adjustmentAttempts;
         return true;
     }
 
@@ -149,15 +201,27 @@ public:
     {
         m_bandwidthChangeQueued = false;
         m_waitingForFreshFrame = false;
+        m_adjustmentAttempts = 0;
     }
 
     bool bandwidthChangeQueued() const { return m_bandwidthChangeQueued; }
     bool waitingForFreshFrame() const { return m_waitingForFreshFrame; }
+    int adjustmentAttempts() const { return m_adjustmentAttempts; }
 
 private:
     bool m_bandwidthChangeQueued{false};
     bool m_waitingForFreshFrame{false};
+    int m_adjustmentAttempts{0};
 };
+
+inline bool dssFrameFloorLooksClipped(int finiteBins,
+                                      int minValueBins,
+                                      int longestMinRunBins)
+{
+    return finiteBins >= 64
+        && minValueBins >= std::max(32, finiteBins / 5)
+        && longestMinRunBins >= std::max(16, finiteBins / 16);
+}
 
 // Windows in which an FFT frame's dBm encoding does not correspond to the
 // settled zoom, so it must not anchor the 3D floor. Kept out of the widget so
@@ -244,16 +308,8 @@ inline bool dssFftScaleSettleActive(std::int64_t nowMs,
     return settleUntilMs > 0 && nowMs < settleUntilMs;
 }
 
-// Mirror of dss_mesh.vert's rear-visibility edge; it must track the shader
-// exactly, including which regime the scroll advance participates in.
-//
-// Full history (validRows >= rows): phase-stable. validRows - sourceAge is
-// permanently 1 for the oldest slot, so subtracting the advance would pulse
-// that permanent row 0 -> 1 on every arrival rather than fading anything in.
-//
-// Still filling (validRows < rows): the newest slot really is newly populated
-// each arrival, and dssRetainedSampleAge() clamps it onto its neighbour's row
-// for that one interval, so the advance is what fades the duplicate in.
+// Mirror of dss_mesh.vert's retained-row visibility edge. Scroll phase moves
+// geometry only; it must never change the opacity of a stored row.
 inline float dssHistoryAvailability(float sourceAge, float validRows,
                                     float rows, float remainingRows)
 {
@@ -262,17 +318,12 @@ inline float dssHistoryAvailability(float sourceAge, float validRows,
         || validRows <= 0.0f || rows < 1.0f || remainingRows < 0.0f) {
         return 0.0f;
     }
-    const float fillFade = validRows < rows ? remainingRows : 0.0f;
-    return std::clamp(validRows - sourceAge - fillFade, 0.0f, 1.0f);
+    return std::clamp(validRows - sourceAge, 0.0f, 1.0f);
 }
 
-// Mirror of dss_mesh.vert sampleHistoryDbm()'s retained sample-age clamp, for
-// unit testing. It must track the shader exactly, including the two clamps the
-// shader applies: cap validRows to [0, rows] (cappedValidRows) and floor the
-// oldest retained age at 0. Omitting them makes the mirror diverge from the GPU
-// path it validates outside 1 <= validRows <= rows (e.g. a negative age at
-// validRows = 0.5, or an uncapped age when validRows > rows). std::nullopt is
-// the analogue of the shader returning floorDbm (sample past the valid range).
+// Mirror of dss_mesh.vert's exact retained sample selection. remainingRows is
+// validated but deliberately does not affect the result: scroll animation must
+// not morph a row's amplitude into either neighbouring FFT.
 inline std::optional<float> dssRetainedSampleAge(float sourceAge,
                                                  float remainingRows,
                                                  float validRows,
@@ -287,8 +338,71 @@ inline std::optional<float> dssRetainedSampleAge(float sourceAge,
     if (sourceAge >= cappedValidRows) {
         return std::nullopt;
     }
-    const float oldestRetainedAge = std::max(cappedValidRows - 1.0f, 0.0f);
-    return std::min(sourceAge + remainingRows, oldestRetainedAge);
+    return sourceAge;
+}
+
+struct DssFixedGridCrossfade {
+    float baseAge{0.0f};
+    float overlayAge{0.0f};
+    float overlayAlpha{0.0f};
+};
+
+// Mirror of dss_mesh.vert's fixed boundary-row scroll. Both layers sample exact
+// rows; only the new layer opacity changes. At the next head advance, the fully
+// opaque overlay becomes the following interval's base at the same depth.
+inline std::optional<DssFixedGridCrossfade> dssFixedGridCrossfade(
+    float sourceAge, float progressRows, float distanceRows)
+{
+    if (!std::isfinite(sourceAge) || !std::isfinite(progressRows)
+        || !std::isfinite(distanceRows) || sourceAge < 0.0f
+        || progressRows < 0.0f || distanceRows <= 0.0f) {
+        return std::nullopt;
+    }
+    return DssFixedGridCrossfade{
+        sourceAge + distanceRows,
+        sourceAge,
+        std::clamp(progressRows / distanceRows, 0.0f, 1.0f),
+    };
+}
+
+inline std::optional<float> dssMovingGeometryDepth(float sourceAge,
+                                                   float remainingRows,
+                                                   float visibleRows)
+{
+    if (!std::isfinite(sourceAge) || !std::isfinite(remainingRows)
+        || !std::isfinite(visibleRows) || sourceAge < 0.0f
+        || remainingRows < 0.0f || visibleRows < 1.0f) {
+        return std::nullopt;
+    }
+    return (sourceAge - remainingRows) / visibleRows;
+}
+
+inline float dssFlatOutlineAlphaScale(float colorStrength)
+{
+    if (!std::isfinite(colorStrength)) {
+        return 1.0f;
+    }
+    constexpr float kFloorScale = 0.42f;
+    constexpr float kTransitionStrength = 0.035f;
+    const float t = std::clamp(
+        colorStrength / kTransitionStrength, 0.0f, 1.0f);
+    const float smooth = t * t * (3.0f - 2.0f * t);
+    return kFloorScale + (1.0f - kFloorScale) * smooth;
+}
+
+inline float dssRibbonCoverage(float coordinate)
+{
+    if (!std::isfinite(coordinate)) {
+        return 0.0f;
+    }
+    constexpr float kSolidHalfWidth = 0.15f;
+    constexpr float kRibbonHalfWidth = 1.0f;
+    const float t = std::clamp(
+        (std::abs(coordinate) - kSolidHalfWidth)
+            / (kRibbonHalfWidth - kSolidHalfWidth),
+        0.0f, 1.0f);
+    const float smooth = t * t * (3.0f - 2.0f * t);
+    return 1.0f - smooth;
 }
 
 struct StablePresentationAnchor {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -406,6 +406,42 @@ static bool clampDbmRange(float& minDbm, float& maxDbm)
     return true;
 }
 
+struct FftFloorClipStats {
+    int finiteBins{0};
+    int minValueBins{0};
+    int longestMinRunBins{0};
+};
+
+static FftFloorClipStats fftFloorClipStats(const QVector<float>& bins)
+{
+    FftFloorClipStats stats;
+    float frameMinDbm = std::numeric_limits<float>::infinity();
+    for (const float value : bins) {
+        if (!std::isfinite(value)) {
+            continue;
+        }
+        frameMinDbm = std::min(frameMinDbm, value);
+        ++stats.finiteBins;
+    }
+    if (stats.finiteBins == 0) {
+        return stats;
+    }
+
+    int currentMinRunBins = 0;
+    for (const float value : bins) {
+        if (std::isfinite(value)
+            && std::abs(value - frameMinDbm) <= 0.01f) {
+            ++stats.minValueBins;
+            ++currentMinRunBins;
+            stats.longestMinRunBins =
+                std::max(stats.longestMinRunBins, currentMinRunBins);
+        } else {
+            currentMinRunBins = 0;
+        }
+    }
+    return stats;
+}
+
 static Qt::CursorShape normalizedSpectrumCursorShape(Qt::CursorShape shape)
 {
 #ifdef Q_OS_MAC
@@ -3351,6 +3387,38 @@ void SpectrumWidget::beginDbmRangeTransition(float oldMinDbm, float oldMaxDbm,
     m_resetFftSmoothingOnNextFrame = true;
 }
 
+bool SpectrumWidget::flexDssInputFloorLooksClipped() const
+{
+    if (m_spectrumRenderMode != SpectrumRenderMode::Mode3D
+        || m_kiwiSdrWaterfallActive || m_bins.isEmpty()) {
+        return false;
+    }
+    const FftFloorClipStats stats = fftFloorClipStats(m_bins);
+    return dssFrameFloorLooksClipped(
+        stats.finiteBins, stats.minValueBins, stats.longestMinRunBins);
+}
+
+bool SpectrumWidget::requestFlexDssRadioHeadroom(qint64 nowMs)
+{
+    if (!flexDssInputFloorLooksClipped()) {
+        return false;
+    }
+
+    // A clipped frame contains no usable floor estimate: its apparent floor
+    // is merely the radio encoder's lower endpoint. Do not let it move the
+    // visible 3D scale. Ask the radio for enough lower headroom in one step,
+    // then let a fresh, unclipped frame drive the normal client-side floor.
+    constexpr qint64 kRecoveryRequestIntervalMs = 1000;
+    constexpr float kRecoveryHeadroomDb = 24.0f;
+    if (m_lastDssRadioHeadroomRequestMs <= 0
+        || nowMs - m_lastDssRadioHeadroomRequestMs
+            >= kRecoveryRequestIntervalMs) {
+        m_lastDssRadioHeadroomRequestMs = nowMs;
+        emit radioDbmHeadroomRecoveryRequested(kRecoveryHeadroomDb);
+    }
+    return true;
+}
+
 void SpectrumWidget::clearDbmReleaseRebase()
 {
     m_dbmReleaseRebaseUntilMs = 0;
@@ -3429,53 +3497,38 @@ void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
         return;
     }
 
-    float frameMinDbm = std::numeric_limits<float>::infinity();
-    int finiteBins = 0;
-    for (const float value : bins) {
-        if (!std::isfinite(value)) {
-            continue;
-        }
-        frameMinDbm = std::min(frameMinDbm, value);
-        ++finiteBins;
-    }
-    int minValueBins = 0;
-    int currentMinRunBins = 0;
-    int longestMinRunBins = 0;
-    for (const float value : bins) {
-        if (std::isfinite(value)
-            && std::abs(value - frameMinDbm) <= 0.01f) {
-            ++minValueBins;
-            ++currentMinRunBins;
-            longestMinRunBins =
-                std::max(longestMinRunBins, currentMinRunBins);
-        } else {
-            currentMinRunBins = 0;
-        }
-    }
+    const FftFloorClipStats clipStats = fftFloorClipStats(bins);
     const bool floorLooksClipped =
         dssFrameFloorLooksClipped(
-            finiteBins, minValueBins, longestMinRunBins);
+            clipStats.finiteBins,
+            clipStats.minValueBins,
+            clipStats.longestMinRunBins);
 
     const DbmRangeTransition::Range oldRange{
         m_refLevel - m_dynamicRange, m_refLevel};
     DbmRangeTransition::Range requestedRange;
     m_dssFloorAnchorValid = true;
-    if (floorLooksClipped) {
-        // A clipped frame cannot reveal its real noise floor: estimating it
-        // only rediscovers the radio's current lower endpoint and can leave
-        // the recovery parked there. Move the whole aperture down by one 3D
-        // floor-depth step, then verify a later radio-encoded frame.
-        requestedRange = DbmRangeTransition::clippedFloorRecoveryRange(
-            oldRange.minDbm, oldRange.maxDbm);
-        m_dssFloorAnchorDbm =
-            requestedRange.minDbm - m_dssFloorOffsetDb;
-    } else {
+    if (!floorLooksClipped) {
         m_dssFloorAnchorDbm = frameFloorDbm;
         requestedRange = DbmRangeTransition::manualRequestRange(
             oldRange.minDbm, oldRange.maxDbm, true,
             peekDssFloorDbm(), m_dynamicRange);
     }
     m_measuredNoiseFloorDbm = frameFloorDbm;
+    if (floorLooksClipped) {
+        // Move only the radio encoder. Moving m_refLevel here makes the whole
+        // 3D surface visibly step down and then back up while auto-floor
+        // converges on an estimate that the clipped frame cannot provide.
+        if (m_dssZoomFloorSync.beginAdjustment(
+                kMaxRangeAdjustmentAttempts)) {
+            m_dssZoomFloorSyncNotBeforeMs =
+                guards.nowMs + kFrequencyRangeSettleMs;
+            requestFlexDssRadioHeadroom(guards.nowMs);
+            return;
+        }
+        m_dssZoomFloorSync.consumeFreshFrame(true);
+        return;
+    }
     const bool rangeValid =
         clampDbmRange(requestedRange.minDbm, requestedRange.maxDbm);
     const bool rangeNeedsAdjustment = rangeValid
@@ -3725,6 +3778,9 @@ bool SpectrumWidget::updateNoiseFloorBaseline(const QVector<float>& bins, bool f
 void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
 {
     if (noiseFloorAutoAdjustHeld(nowMs)) {
+        return;
+    }
+    if (requestFlexDssRadioHeadroom(nowMs)) {
         return;
     }
 
@@ -12226,9 +12282,9 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
     m_dssMeshFillPipeline->setTargetBlends({fillBlend});
 
-    // Outline pipeline — alpha-blended screen-space ribbons. Metal's native
-    // one-pixel lines toggle coverage as they move through subpixels, making
-    // the entire scrolling history strobe.
+    // Outline pipeline — alpha-blended screen-space ribbons on a fixed
+    // perspective grid. The shader crossfades exact FFT shapes in place, so
+    // neither native line coverage nor translated ribbon coverage can strobe.
     QRhiGraphicsPipeline::TargetBlend lblend;
     lblend.enable = true;
     lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
@@ -12473,8 +12529,9 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         line.reserve(rows * dssLineVerticesPerRow() * 3);
         for (int rr = rows - 1; rr >= 0; --rr) {
             const float v = static_cast<float>(rr) / rows;   // 0 front .. ~1 back
-            // Base first, overlay second. The shader uses both only for the
-            // fixed front/rear crossfades; interior base vertices are discarded.
+            // Base first, overlay second. Curtains use both only at the fixed
+            // front/rear boundaries; ridge outlines use both at every fixed
+            // depth for exact-row crossfades.
             for (int layer = 0; layer < 2; ++layer) {
                 const float fillTag = layer == 0 ? 0.0f : 2.0f;
                 const float floorTag = layer == 0 ? 1.0f : 3.0f;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -129,6 +129,10 @@ bool waterfallFrameResizeFailureForced()
 
 constexpr int dssFillVerticesPerRow()
 {
+    // Two exact-row crossfade layers, each with two triangles per column.
+    // Together with the matching ribbon VBO this is about 20.2 MiB of static
+    // vertex storage at 768 columns x 96 visible rows (about 7.3 MiB before
+    // fixed-grid crossfading). It is built once, never rebuilt while scrolling.
     return (DssRenderer::kCols - 1) * 6 * 2;
 }
 
@@ -136,6 +140,11 @@ constexpr int dssLineVerticesPerRow()
 {
     return (DssRenderer::kCols - 1) * 6 * 2;
 }
+
+constexpr int kMaxWaterfallRowsPerUpdate = 1;
+static_assert(
+    kMaxWaterfallRowsPerUpdate <= DssRenderer::kTransitionRows,
+    "DSS transition reserve must hold every row in one scroll update");
 
 void appendDssVertex(QVector<float>& vertices, float u, float v, float edge)
 {
@@ -1318,35 +1327,77 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     int dssCurrentFrameRows = 0;
     int dssSupplementalRows = 0;
     double dssSupplementalMaxBandwidthMhz = 0.0;
+    int peakBin = -1;
+    float peakDbm = -1000.0f;
+    float frontMinDbm = -1000.0f;
+    float frontMaxDbm = -1000.0f;
+    float frontSpanDb = 0.0f;
+    int frontMinValueBins = 0;
+    int frontLongestFlatRunBins = 0;
+    int maxMinValueBins = 0;
+    int maxLongestFlatRunBins = 0;
+    int flatRows = 0;
+    int nonFlatRows = 0;
     for (int age = 0; age < m_dss.visibleRowCount(); ++age) {
         const double rowCenterMhz = m_dss.rowCenterMhzAtAge(age);
         const double rowBandwidthMhz = m_dss.rowBandwidthMhzAtAge(age);
-        if (!std::isfinite(rowCenterMhz)
-            || !std::isfinite(rowBandwidthMhz)
-            || rowCenterMhz <= 0.0 || rowBandwidthMhz <= 0.0) {
+        if (std::isfinite(rowCenterMhz)
+            && std::isfinite(rowBandwidthMhz)
+            && rowCenterMhz > 0.0 && rowBandwidthMhz > 0.0) {
+            dssFrameMinCenterMhz =
+                std::min(dssFrameMinCenterMhz, rowCenterMhz);
+            dssFrameMaxCenterMhz =
+                std::max(dssFrameMaxCenterMhz, rowCenterMhz);
+            ++dssFramedRows;
+            if (mhzNearlyEqual(rowCenterMhz, m_centerMhz)
+                && mhzNearlyEqual(rowBandwidthMhz, m_bandwidthMhz)) {
+                ++dssCurrentFrameRows;
+            }
+            const double supplementalCenterMhz =
+                m_dss.rowSupplementalCenterMhzAtAge(age);
+            const double supplementalBandwidthMhz =
+                m_dss.rowSupplementalBandwidthMhzAtAge(age);
+            if (std::isfinite(supplementalCenterMhz)
+                && std::isfinite(supplementalBandwidthMhz)
+                && supplementalCenterMhz > 0.0
+                && supplementalBandwidthMhz > 0.0) {
+                ++dssSupplementalRows;
+                dssSupplementalMaxBandwidthMhz = std::max(
+                    dssSupplementalMaxBandwidthMhz,
+                    supplementalBandwidthMhz);
+            }
+        }
+
+        const DssRenderer::RowStats rowStats = m_dss.rowStats(age);
+        if (age == 0) {
+            const int ring = m_dss.headRing();
+            const float* row = m_dss.rowDataRing(ring);
+            for (int column = 0; column < m_dss.cols(); ++column) {
+                if (std::isfinite(row[column])
+                    && (peakBin < 0 || row[column] > peakDbm)) {
+                    peakBin = column;
+                    peakDbm = row[column];
+                }
+            }
+        }
+        if (rowStats.finiteBins == 0) {
             continue;
         }
-        dssFrameMinCenterMhz =
-            std::min(dssFrameMinCenterMhz, rowCenterMhz);
-        dssFrameMaxCenterMhz =
-            std::max(dssFrameMaxCenterMhz, rowCenterMhz);
-        ++dssFramedRows;
-        if (mhzNearlyEqual(rowCenterMhz, m_centerMhz)
-            && mhzNearlyEqual(rowBandwidthMhz, m_bandwidthMhz)) {
-            ++dssCurrentFrameRows;
+        const float rowSpanDb = rowStats.maxDbm - rowStats.minDbm;
+        if (age == 0) {
+            frontMinDbm = rowStats.minDbm;
+            frontMaxDbm = rowStats.maxDbm;
+            frontSpanDb = rowSpanDb;
+            frontMinValueBins = rowStats.minValueBins;
+            frontLongestFlatRunBins = rowStats.longestFlatRunBins;
         }
-        const double supplementalCenterMhz =
-            m_dss.rowSupplementalCenterMhzAtAge(age);
-        const double supplementalBandwidthMhz =
-            m_dss.rowSupplementalBandwidthMhzAtAge(age);
-        if (std::isfinite(supplementalCenterMhz)
-            && std::isfinite(supplementalBandwidthMhz)
-            && supplementalCenterMhz > 0.0
-            && supplementalBandwidthMhz > 0.0) {
-            ++dssSupplementalRows;
-            dssSupplementalMaxBandwidthMhz = std::max(
-                dssSupplementalMaxBandwidthMhz,
-                supplementalBandwidthMhz);
+        maxMinValueBins = std::max(maxMinValueBins, rowStats.minValueBins);
+        maxLongestFlatRunBins =
+            std::max(maxLongestFlatRunBins, rowStats.longestFlatRunBins);
+        if (rowSpanDb > 0.01f) {
+            ++nonFlatRows;
+        } else {
+            ++flatRows;
         }
     }
     m[QStringLiteral("dssVisibleFramedRows")] = dssFramedRows;
@@ -1404,50 +1455,6 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("waterfallHistoryBytes")] =
         static_cast<qulonglong>(m_waterfallHistory.allocatedBytes());
 
-    int peakBin = -1;
-    float peakDbm = -1000.0f;
-    float frontMinDbm = -1000.0f;
-    float frontMaxDbm = -1000.0f;
-    float frontSpanDb = 0.0f;
-    int frontMinValueBins = 0;
-    int frontLongestFlatRunBins = 0;
-    int maxMinValueBins = 0;
-    int maxLongestFlatRunBins = 0;
-    int flatRows = 0;
-    int nonFlatRows = 0;
-    for (int age = 0; age < m_dss.visibleRowCount(); ++age) {
-        const int ring = (m_dss.headRing() + age) % m_dss.rows();
-        const float* row = m_dss.rowDataRing(ring);
-        const DssRenderer::RowStats rowStats = m_dss.rowStats(age);
-        for (int c = 0; c < m_dss.cols(); ++c) {
-            if (!std::isfinite(row[c])) {
-                continue;
-            }
-            if (age == 0 && (peakBin < 0 || row[c] > peakDbm)) {
-                peakBin = c;
-                peakDbm = row[c];
-            }
-        }
-        if (rowStats.finiteBins == 0) {
-            continue;
-        }
-        const float rowSpanDb = rowStats.maxDbm - rowStats.minDbm;
-        if (age == 0) {
-            frontMinDbm = rowStats.minDbm;
-            frontMaxDbm = rowStats.maxDbm;
-            frontSpanDb = rowSpanDb;
-            frontMinValueBins = rowStats.minValueBins;
-            frontLongestFlatRunBins = rowStats.longestFlatRunBins;
-        }
-        maxMinValueBins = std::max(maxMinValueBins, rowStats.minValueBins);
-        maxLongestFlatRunBins =
-            std::max(maxLongestFlatRunBins, rowStats.longestFlatRunBins);
-        if (rowSpanDb > 0.01f) {
-            ++nonFlatRows;
-        } else {
-            ++flatRows;
-        }
-    }
     m[QStringLiteral("dssVisiblePeakBin")] = peakBin;
     m[QStringLiteral("dssVisiblePeakDbm")] = peakDbm;
     m[QStringLiteral("dssVisibleFrontMinDbm")] = frontMinDbm;
@@ -3387,20 +3394,27 @@ void SpectrumWidget::beginDbmRangeTransition(float oldMinDbm, float oldMaxDbm,
     m_resetFftSmoothingOnNextFrame = true;
 }
 
-bool SpectrumWidget::flexDssInputFloorLooksClipped() const
+bool SpectrumWidget::flexInputFloorLooksClipped() const
 {
-    if (m_spectrumRenderMode != SpectrumRenderMode::Mode3D
-        || m_kiwiSdrWaterfallActive || m_bins.isEmpty()) {
+    if (m_kiwiSdrWaterfallActive || m_bins.isEmpty()) {
         return false;
     }
     const FftFloorClipStats stats = fftFloorClipStats(m_bins);
-    return dssFrameFloorLooksClipped(
-        stats.finiteBins, stats.minValueBins, stats.longestMinRunBins);
+    return flexFftFrameNeedsHeadroomRecovery(
+        m_kiwiSdrWaterfallActive,
+        stats.finiteBins,
+        stats.minValueBins,
+        stats.longestMinRunBins);
 }
 
-bool SpectrumWidget::requestFlexDssRadioHeadroom(qint64 nowMs)
+bool SpectrumWidget::requestFlexRadioHeadroom(qint64 nowMs)
 {
-    if (!flexDssInputFloorLooksClipped()) {
+    if (m_transmitting
+        || flexDssFftScaleSettling()
+        || isDraggingDbmScale()
+        || m_pendingDbmRangeEcho
+        || m_dbmReleaseRebaseUntilMs > nowMs
+        || !flexInputFloorLooksClipped()) {
         return false;
     }
 
@@ -3523,7 +3537,7 @@ void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
                 kMaxRangeAdjustmentAttempts)) {
             m_dssZoomFloorSyncNotBeforeMs =
                 guards.nowMs + kFrequencyRangeSettleMs;
-            requestFlexDssRadioHeadroom(guards.nowMs);
+            requestFlexRadioHeadroom(guards.nowMs);
             return;
         }
         m_dssZoomFloorSync.consumeFreshFrame(true);
@@ -3780,7 +3794,7 @@ void SpectrumWidget::applyNoiseFloorAutoAdjust(qint64 nowMs)
     if (noiseFloorAutoAdjustHeld(nowMs)) {
         return;
     }
-    if (requestFlexDssRadioHeadroom(nowMs)) {
+    if (requestFlexRadioHeadroom(nowMs)) {
         return;
     }
 
@@ -5019,10 +5033,10 @@ void SpectrumWidget::appendLatestDssWaterfallRow(double frameCenterMhz,
     appendDssWaterfallRow(displaySpectrumBins(), frameCenterMhz, frameBandwidthMhz);
 }
 
-void SpectrumWidget::appendNativeDssWaterfallRow(
+QVector<float> SpectrumWidget::buildNativeDssSupplementalRow(
     const QVector<float>& tileIntensity,
     double tileLowMhz,
-    double tileHighMhz)
+    double tileHighMhz) const
 {
     const QVector<float>& fftBins = displaySpectrumBins();
     const std::vector<float> calibrated =
@@ -5042,14 +5056,7 @@ void SpectrumWidget::appendNativeDssWaterfallRow(
     for (const float dbm : calibrated) {
         supplemental.append(dbm);
     }
-    appendDssWaterfallRow(
-        fftBins,
-        -1.0,
-        -1.0,
-        true,
-        supplemental,
-        (tileLowMhz + tileHighMhz) * 0.5,
-        tileHighMhz - tileLowMhz);
+    return supplemental;
 }
 
 void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
@@ -7767,6 +7774,10 @@ void SpectrumWidget::updateSpectrum(const QVector<float>& binsDbm)
         m_fftFallbackSeedMask.clear();
     }
     m_bins = *spectrumBins;
+    // Decoder floor clipping affects the shared FLEX FFT input, not only the
+    // 3D renderer. Recover the radio encoder aperture for 2D as well, even when
+    // client-side automatic floor placement is disabled.
+    requestFlexRadioHeadroom(nowMs);
     syncDssRangeFromFreshZoomFrame(*spectrumBins);
 
     if (m_kiwiSdrWaterfallActive) {
@@ -7976,7 +7987,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     const int h = m_waterfall.height();
     if (h <= 1) return;
 
-    int rowsToPush = 1;
+    int rowsToPush = kMaxWaterfallRowsPerUpdate;
     rowsToPush = std::min(rowsToPush, h - 1);
 
     // Render the tile row into a temporary scanline.
@@ -8074,6 +8085,16 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     // Write rows into history + visible viewport.
     const bool canInterp = (m_prevTileLevels.size() == destWidth && rowsToPush > 1);
     const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
+    const double supplementalCenterMhz =
+        (lowFreqMhz + highFreqMhz) * 0.5;
+    const double supplementalBandwidthMhz =
+        highFreqMhz - lowFreqMhz;
+    // Every row delivered by one native tile shares this calibration. Keep the
+    // overlap scan, quantile sort, and whole-tile conversion out of the row
+    // loop if a backend ever delivers more than one row per update.
+    const QVector<float> dssSupplemental =
+        buildNativeDssSupplementalRow(
+            binsIntensity, lowFreqMhz, highFreqMhz);
     for (int r = 0; r < rowsToPush; ++r) {
         QVector<quint8> interpolatedLevels(destWidth, 0);
         QVector<QRgb> interpolatedRow(destWidth, qRgb(0, 0, 0));
@@ -8097,18 +8118,20 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
             supplementalRow[x] = colorLut[supplementalLevels[x]];
         }
 
-        const double supplementalCenterMhz =
-            (lowFreqMhz + highFreqMhz) * 0.5;
-        const double supplementalBandwidthMhz =
-            highFreqMhz - lowFreqMhz;
         appendHistoryRow(
             interpolatedLevels.constData(), nowMs,
             -1.0, -1.0,
             supplementalLevels.constData(),
             supplementalCenterMhz,
             supplementalBandwidthMhz);
-        appendNativeDssWaterfallRow(
-            binsIntensity, lowFreqMhz, highFreqMhz);
+        appendDssWaterfallRow(
+            displaySpectrumBins(),
+            -1.0,
+            -1.0,
+            true,
+            dssSupplemental,
+            supplementalCenterMhz,
+            supplementalBandwidthMhz);
         if (m_wfLive) {
             // The whole tile gets one start() after the loop; don't restart the
             // scroll clock once per appended row.

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -1,6 +1,7 @@
 #include "SpectrumWidget.h"
 #include "DbmRangeTransition.h"
 #include "DssDcEdgeMath.h"
+#include "DssSupplementalCoverage.h"
 #include "KiwiSdrTraceMath.h"
 #include "NativeWidgetTopology.h"
 #include "PanadapterRenderScheduler.h"
@@ -128,12 +129,12 @@ bool waterfallFrameResizeFailureForced()
 
 constexpr int dssFillVerticesPerRow()
 {
-    return (DssRenderer::kCols - 1) * 6;
+    return (DssRenderer::kCols - 1) * 6 * 2;
 }
 
 constexpr int dssLineVerticesPerRow()
 {
-    return (DssRenderer::kCols - 1) * 2;
+    return (DssRenderer::kCols - 1) * 6 * 2;
 }
 
 void appendDssVertex(QVector<float>& vertices, float u, float v, float edge)
@@ -1043,8 +1044,14 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     auto accountState = [&](const WaterfallStreamState& state) {
         cachedWaterfallVisibleBytes += state.waterfall.isNull()
             ? 0 : static_cast<quint64>(state.waterfall.sizeInBytes());
+        cachedWaterfallVisibleBytes += state.waterfallSupplemental.isNull()
+            ? 0
+            : static_cast<quint64>(
+                state.waterfallSupplemental.sizeInBytes());
         cachedWaterfallHistoryBytes += static_cast<quint64>(
             state.waterfallHistory.allocatedBytes());
+        cachedWaterfallHistoryBytes += static_cast<quint64>(
+            state.waterfallSupplementalHistory.allocatedBytes());
         dssFixedBytes += state.dss.fixedStorageBytes();
         dssHistoryBytes += state.dss.historyStorageBytes();
         dssCacheBytes += state.dss.cacheStorageBytes();
@@ -1058,10 +1065,17 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     }
     const quint64 currentWaterfallVisibleBytes = m_waterfall.isNull()
         ? 0 : static_cast<quint64>(m_waterfall.sizeInBytes());
+    const quint64 currentWaterfallSupplementalVisibleBytes =
+        m_waterfallSupplemental.isNull()
+        ? 0
+        : static_cast<quint64>(m_waterfallSupplemental.sizeInBytes());
     const quint64 currentWaterfallHistoryBytes = static_cast<quint64>(
-        m_waterfallHistory.allocatedBytes());
+        m_waterfallHistory.allocatedBytes()
+        + m_waterfallSupplementalHistory.allocatedBytes());
     m[QStringLiteral("currentWaterfallVisibleBytes")] =
-        static_cast<qulonglong>(currentWaterfallVisibleBytes);
+        static_cast<qulonglong>(
+            currentWaterfallVisibleBytes
+            + currentWaterfallSupplementalVisibleBytes);
     m[QStringLiteral("currentWaterfallHistoryBytes")] =
         static_cast<qulonglong>(currentWaterfallHistoryBytes);
     m[QStringLiteral("cachedWaterfallVisibleBytes")] =
@@ -1069,7 +1083,9 @@ QVariantMap SpectrumWidget::panstatsSnapshot(bool reset)
     m[QStringLiteral("cachedWaterfallHistoryBytes")] =
         static_cast<qulonglong>(cachedWaterfallHistoryBytes);
     m[QStringLiteral("waterfallAllocatedBytes")] = static_cast<qulonglong>(
-        currentWaterfallVisibleBytes + currentWaterfallHistoryBytes
+        currentWaterfallVisibleBytes
+        + currentWaterfallSupplementalVisibleBytes
+        + currentWaterfallHistoryBytes
         + cachedWaterfallVisibleBytes + cachedWaterfallHistoryBytes);
     m[QStringLiteral("dssRendererCount")] = dssRendererCount;
     m[QStringLiteral("dssFixedBytes")] = static_cast<qulonglong>(dssFixedBytes);
@@ -1153,7 +1169,8 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
 #ifdef AETHER_GPU_SPECTRUM
     m[QStringLiteral("waterfallRowFrequencyFrames")] =
         m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
-        && m_wfFrameTexReady;
+        && m_wfFrameTexReady
+        && m_wfSupplementalGpuTex != nullptr;
     m[QStringLiteral("waterfallPipelineReady")] =
         m_wfPipeline != nullptr && m_wfSrb != nullptr;
     m[QStringLiteral("waterfallPipelineMode")] =
@@ -1168,6 +1185,8 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         double minCenterMhz = std::numeric_limits<double>::infinity();
         double maxCenterMhz = -std::numeric_limits<double>::infinity();
         int currentFrameRows = 0;
+        int supplementalRows = 0;
+        double supplementalMaxBandwidthMhz = 0.0;
         for (int row = 0; row < m_wfVisibleRowCenterMhz.size(); ++row) {
             const double rowCenterMhz = m_wfVisibleRowCenterMhz[row];
             const double rowBandwidthMhz = m_wfVisibleRowBwMhz[row];
@@ -1177,10 +1196,23 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
                 && mhzNearlyEqual(rowBandwidthMhz, m_bandwidthMhz)) {
                 ++currentFrameRows;
             }
+            if (row < m_wfVisibleSupplementalCenterMhz.size()
+                && row < m_wfVisibleSupplementalBwMhz.size()
+                && m_wfVisibleSupplementalCenterMhz[row] > 0.0
+                && m_wfVisibleSupplementalBwMhz[row] > 0.0) {
+                ++supplementalRows;
+                supplementalMaxBandwidthMhz = std::max(
+                    supplementalMaxBandwidthMhz,
+                    m_wfVisibleSupplementalBwMhz[row]);
+            }
         }
         m[QStringLiteral("waterfallVisibleFrameMinCenterMhz")] = minCenterMhz;
         m[QStringLiteral("waterfallVisibleFrameMaxCenterMhz")] = maxCenterMhz;
         m[QStringLiteral("waterfallVisibleCurrentFrameRows")] = currentFrameRows;
+        m[QStringLiteral("waterfallVisibleSupplementalRows")] =
+            supplementalRows;
+        m[QStringLiteral("waterfallVisibleSupplementalMaxBandwidthMhz")] =
+            supplementalMaxBandwidthMhz;
     }
     m[QStringLiteral("frequencyRangeCommandPending")] =
         m_frequencyRangeCommandThrottle.hasPending();
@@ -1221,6 +1253,8 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("waterfallHistoryWidth")] = m_waterfallHistory.width();
     m[QStringLiteral("waterfallHistoryAllocatedChunks")] =
         m_waterfallHistory.allocatedChunkCount();
+    m[QStringLiteral("waterfallSupplementalHistoryAllocatedChunks")] =
+        m_waterfallSupplementalHistory.allocatedChunkCount();
     m[QStringLiteral("resizeEventCount")] =
         static_cast<qulonglong>(m_resizeEventCount);
     m[QStringLiteral("resizeBufferCommitCount")] =
@@ -1239,12 +1273,74 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     m[QStringLiteral("resizeRenderBufferWidth")] = fixedColorBufferSize().width();
     m[QStringLiteral("resizeRenderBufferHeight")] = fixedColorBufferSize().height();
 #endif
-    m[QStringLiteral("dssVisibleRows")] = m_dss.rowCount();
+    m[QStringLiteral("dssVisibleRows")] = m_dss.visibleRowCount();
+    double dssFrameMinCenterMhz =
+        std::numeric_limits<double>::infinity();
+    double dssFrameMaxCenterMhz =
+        -std::numeric_limits<double>::infinity();
+    int dssFramedRows = 0;
+    int dssCurrentFrameRows = 0;
+    int dssSupplementalRows = 0;
+    double dssSupplementalMaxBandwidthMhz = 0.0;
+    for (int age = 0; age < m_dss.visibleRowCount(); ++age) {
+        const double rowCenterMhz = m_dss.rowCenterMhzAtAge(age);
+        const double rowBandwidthMhz = m_dss.rowBandwidthMhzAtAge(age);
+        if (!std::isfinite(rowCenterMhz)
+            || !std::isfinite(rowBandwidthMhz)
+            || rowCenterMhz <= 0.0 || rowBandwidthMhz <= 0.0) {
+            continue;
+        }
+        dssFrameMinCenterMhz =
+            std::min(dssFrameMinCenterMhz, rowCenterMhz);
+        dssFrameMaxCenterMhz =
+            std::max(dssFrameMaxCenterMhz, rowCenterMhz);
+        ++dssFramedRows;
+        if (mhzNearlyEqual(rowCenterMhz, m_centerMhz)
+            && mhzNearlyEqual(rowBandwidthMhz, m_bandwidthMhz)) {
+            ++dssCurrentFrameRows;
+        }
+        const double supplementalCenterMhz =
+            m_dss.rowSupplementalCenterMhzAtAge(age);
+        const double supplementalBandwidthMhz =
+            m_dss.rowSupplementalBandwidthMhzAtAge(age);
+        if (std::isfinite(supplementalCenterMhz)
+            && std::isfinite(supplementalBandwidthMhz)
+            && supplementalCenterMhz > 0.0
+            && supplementalBandwidthMhz > 0.0) {
+            ++dssSupplementalRows;
+            dssSupplementalMaxBandwidthMhz = std::max(
+                dssSupplementalMaxBandwidthMhz,
+                supplementalBandwidthMhz);
+        }
+    }
+    m[QStringLiteral("dssVisibleFramedRows")] = dssFramedRows;
+    m[QStringLiteral("dssVisibleCurrentFrameRows")] =
+        dssCurrentFrameRows;
+    m[QStringLiteral("dssVisibleSupplementalRows")] =
+        dssSupplementalRows;
+    m[QStringLiteral("dssVisibleSupplementalMaxBandwidthMhz")] =
+        dssSupplementalMaxBandwidthMhz;
+    if (dssFramedRows > 0) {
+        m[QStringLiteral("dssVisibleFrameMinCenterMhz")] =
+            dssFrameMinCenterMhz;
+        m[QStringLiteral("dssVisibleFrameMaxCenterMhz")] =
+            dssFrameMaxCenterMhz;
+    }
     m[QStringLiteral("dssRowGeneration")] =
         static_cast<qulonglong>(m_dss.rowGeneration());
     m[QStringLiteral("dssHistoryRows")] = m_dss.historyRowCount();
     m[QStringLiteral("dssHistoryCapacityRows")] = m_dss.historyCapacityRows();
     m[QStringLiteral("dssFftScaleSettling")] = flexDssFftScaleSettling();
+    m[QStringLiteral("dssZoomFloorSyncQueued")] =
+        m_dssZoomFloorSync.bandwidthChangeQueued();
+    m[QStringLiteral("dssZoomFloorSyncWaiting")] =
+        m_dssZoomFloorSync.waitingForFreshFrame();
+    m[QStringLiteral("dssZoomFloorSyncAdjustmentAttempts")] =
+        m_dssZoomFloorSync.adjustmentAttempts();
+    m[QStringLiteral("dssDbmRangeEchoPending")] = m_pendingDbmRangeEcho;
+    m[QStringLiteral("dssDbmRangeRebaseActive")] =
+        m_dbmReleaseRebaseUntilMs
+        > QDateTime::currentMSecsSinceEpoch();
     m[QStringLiteral("threeDSliceDepth")] = m_threeDSliceDepth;
     const QRect depthSpecRect(0, 0, width(), spectrumPixelHeight());
     const DssDepthGeometry depthGeometry =
@@ -1283,7 +1379,7 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
     int maxLongestFlatRunBins = 0;
     int flatRows = 0;
     int nonFlatRows = 0;
-    for (int age = 0; age < m_dss.rowCount(); ++age) {
+    for (int age = 0; age < m_dss.visibleRowCount(); ++age) {
         const int ring = (m_dss.headRing() + age) % m_dss.rows();
         const float* row = m_dss.rowDataRing(ring);
         const DssRenderer::RowStats rowStats = m_dss.rowStats(age);
@@ -1329,6 +1425,56 @@ QVariantMap SpectrumWidget::automationDssSnapshot() const
         maxLongestFlatRunBins;
     m[QStringLiteral("dssVisibleFlatRows")] = flatRows;
     m[QStringLiteral("dssVisibleNonFlatRows")] = nonFlatRows;
+
+    const auto appendFftStats = [&m](const QString& prefix,
+                                     const QVector<float>& bins) {
+        if (bins.isEmpty()) {
+            m[prefix + QStringLiteral("Bins")] = 0;
+            return;
+        }
+        float minDbm = std::numeric_limits<float>::infinity();
+        float maxDbm = -std::numeric_limits<float>::infinity();
+        for (const float value : bins) {
+            if (std::isfinite(value)) {
+                minDbm = std::min(minDbm, value);
+                maxDbm = std::max(maxDbm, value);
+            }
+        }
+        int minValueBins = 0;
+        int longestFlatRunBins = 0;
+        int currentRun = 0;
+        float previous = 0.0f;
+        bool havePrevious = false;
+        for (const float value : bins) {
+            if (!std::isfinite(value)) {
+                currentRun = 0;
+                havePrevious = false;
+                continue;
+            }
+            if (std::abs(value - minDbm) <= 0.01f) {
+                ++minValueBins;
+            }
+            currentRun = havePrevious
+                && std::abs(value - previous) <= 0.01f
+                ? currentRun + 1 : 1;
+            longestFlatRunBins = std::max(longestFlatRunBins, currentRun);
+            previous = value;
+            havePrevious = true;
+        }
+        m[prefix + QStringLiteral("Bins")] = bins.size();
+        m[prefix + QStringLiteral("MinDbm")] = minDbm;
+        m[prefix + QStringLiteral("MaxDbm")] = maxDbm;
+        m[prefix + QStringLiteral("MinValueBins")] = minValueBins;
+        m[prefix + QStringLiteral("LongestFlatRunBins")] =
+            longestFlatRunBins;
+    };
+    appendFftStats(QStringLiteral("dssInputFft"), m_bins);
+    appendFftStats(QStringLiteral("dssDisplayFft"), displaySpectrumBins());
+    m[QStringLiteral("dssDisplayMinDbm")] = m_refLevel - m_dynamicRange;
+    m[QStringLiteral("dssDisplayMaxDbm")] = m_refLevel;
+    m[QStringLiteral("dssFloorAnchorDbm")] = m_dssFloorAnchorDbm;
+    m[QStringLiteral("dssFloorAnchorValid")] = m_dssFloorAnchorValid;
+    m[QStringLiteral("dssFloorDbm")] = peekDssFloorDbm();
     return m;
 }
 
@@ -1599,15 +1745,15 @@ QVariantMap SpectrumWidget::traceDebugSnapshot()
     m[QStringLiteral("dssSpanDb")] = dssSpanDb();
     m[QStringLiteral("dssFloorAnchorDbm")] = m_dssFloorAnchorDbm;
     m[QStringLiteral("dssFloorAnchorValid")] = m_dssFloorAnchorValid;
-    m[QStringLiteral("dssRows")] = m_dss.rowCount();
+    m[QStringLiteral("dssRows")] = m_dss.visibleRowCount();
     m[QStringLiteral("dssCapacityRows")] = m_dss.rows();
     const DssRenderer& flexDss =
         m_kiwiSdrWaterfallActive ? m_nativeWaterfallState.dss : m_dss;
-    m[QStringLiteral("flexDssRows")] = flexDss.rowCount();
+    m[QStringLiteral("flexDssRows")] = flexDss.visibleRowCount();
     const WaterfallStreamState* kiwiState = activeKiwiWaterfallStateConst();
     m[QStringLiteral("kiwiDssRows")] = m_kiwiSdrWaterfallActive
-        ? m_dss.rowCount()
-        : (kiwiState ? kiwiState->dss.rowCount() : 0);
+        ? m_dss.visibleRowCount()
+        : (kiwiState ? kiwiState->dss.visibleRowCount() : 0);
 
     m[QStringLiteral("kiwiDisplayRangeValid")] = m_kiwiSdrDisplayRangeValid;
     m[QStringLiteral("kiwiDisplayRangeAutoRange")] =
@@ -3243,6 +3389,7 @@ void SpectrumWidget::armDssZoomFloorSyncAfterSettle()
 
 void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
 {
+    static constexpr int kMaxRangeAdjustmentAttempts = 4;
     const bool flex3dActive =
         m_spectrumRenderMode == SpectrumRenderMode::Mode3D
         && !m_kiwiSdrWaterfallActive;
@@ -3278,38 +3425,94 @@ void SpectrumWidget::syncDssRangeFromFreshZoomFrame(const QVector<float>& bins)
     }
 
     const float frameFloorDbm = estimateNoiseFloorDbm(bins);
-    if (!m_dssZoomFloorSync.consumeFreshFrame(
-            std::isfinite(frameFloorDbm) && frameFloorDbm > -500.0f)) {
+    if (!std::isfinite(frameFloorDbm) || frameFloorDbm <= -500.0f) {
         return;
     }
 
-    m_measuredNoiseFloorDbm = frameFloorDbm;
-    m_dssFloorAnchorDbm = frameFloorDbm;
-    m_dssFloorAnchorValid = true;
+    float frameMinDbm = std::numeric_limits<float>::infinity();
+    int finiteBins = 0;
+    for (const float value : bins) {
+        if (!std::isfinite(value)) {
+            continue;
+        }
+        frameMinDbm = std::min(frameMinDbm, value);
+        ++finiteBins;
+    }
+    int minValueBins = 0;
+    int currentMinRunBins = 0;
+    int longestMinRunBins = 0;
+    for (const float value : bins) {
+        if (std::isfinite(value)
+            && std::abs(value - frameMinDbm) <= 0.01f) {
+            ++minValueBins;
+            ++currentMinRunBins;
+            longestMinRunBins =
+                std::max(longestMinRunBins, currentMinRunBins);
+        } else {
+            currentMinRunBins = 0;
+        }
+    }
+    const bool floorLooksClipped =
+        dssFrameFloorLooksClipped(
+            finiteBins, minValueBins, longestMinRunBins);
 
     const DbmRangeTransition::Range oldRange{
         m_refLevel - m_dynamicRange, m_refLevel};
-    DbmRangeTransition::Range requestedRange =
-        DbmRangeTransition::manualRequestRange(
+    DbmRangeTransition::Range requestedRange;
+    m_dssFloorAnchorValid = true;
+    if (floorLooksClipped) {
+        // A clipped frame cannot reveal its real noise floor: estimating it
+        // only rediscovers the radio's current lower endpoint and can leave
+        // the recovery parked there. Move the whole aperture down by one 3D
+        // floor-depth step, then verify a later radio-encoded frame.
+        requestedRange = DbmRangeTransition::clippedFloorRecoveryRange(
+            oldRange.minDbm, oldRange.maxDbm);
+        m_dssFloorAnchorDbm =
+            requestedRange.minDbm - m_dssFloorOffsetDb;
+    } else {
+        m_dssFloorAnchorDbm = frameFloorDbm;
+        requestedRange = DbmRangeTransition::manualRequestRange(
             oldRange.minDbm, oldRange.maxDbm, true,
             peekDssFloorDbm(), m_dynamicRange);
-    if (!clampDbmRange(requestedRange.minDbm, requestedRange.maxDbm)
-        || !DbmRangeTransition::materiallyDifferent(
+    }
+    m_measuredNoiseFloorDbm = frameFloorDbm;
+    const bool rangeValid =
+        clampDbmRange(requestedRange.minDbm, requestedRange.maxDbm);
+    const bool rangeNeedsAdjustment = rangeValid
+        && DbmRangeTransition::materiallyDifferent(
             oldRange, requestedRange,
-            kDbmReleasePreviewChangeThresholdDb)) {
+            kDbmReleasePreviewChangeThresholdDb);
+    if (rangeNeedsAdjustment
+        && m_dssZoomFloorSync.beginAdjustment(
+            kMaxRangeAdjustmentAttempts)) {
+        // The first post-zoom frame can itself be clipped against the old
+        // radio aperture. Move the radio/decoder range, then leave the gate
+        // armed until a later frame proves the new encoding. This may take a
+        // few bounded 6 dB steps when most bins were pinned to the old floor.
+        m_dssZoomFloorSyncNotBeforeMs =
+            guards.nowMs + kFrequencyRangeSettleMs;
+        beginDbmRangeTransition(
+            oldRange.minDbm, oldRange.maxDbm,
+            requestedRange.minDbm, requestedRange.maxDbm);
+        m_refLevel = requestedRange.maxDbm;
+        m_dynamicRange = requestedRange.maxDbm - requestedRange.minDbm;
+        refreshNoiseFloorTarget();
         markOverlayDirty();
+        emit dbmRangeChangeRequested(
+            requestedRange.minDbm, requestedRange.maxDbm);
         return;
     }
 
-    beginDbmRangeTransition(
-        oldRange.minDbm, oldRange.maxDbm,
-        requestedRange.minDbm, requestedRange.maxDbm);
-    m_refLevel = requestedRange.maxDbm;
-    m_dynamicRange = requestedRange.maxDbm - requestedRange.minDbm;
-    refreshNoiseFloorTarget();
-    markOverlayDirty();
-    emit dbmRangeChangeRequested(
-        requestedRange.minDbm, requestedRange.maxDbm);
+    if (!m_dssZoomFloorSync.consumeFreshFrame(
+            rangeValid && (!floorLooksClipped
+                           || m_dssZoomFloorSync.adjustmentAttempts()
+                               >= kMaxRangeAdjustmentAttempts))) {
+        return;
+    }
+    if (!rangeNeedsAdjustment) {
+        markOverlayDirty();
+        return;
+    }
 }
 
 void SpectrumWidget::resetNoiseFloorBaseline()
@@ -4544,7 +4747,8 @@ void SpectrumWidget::ensureWaterfallHistory()
     const bool retainDssHistory =
         m_waterfallWriteVisible
         && m_spectrumRenderMode == SpectrumRenderMode::Mode3D;
-    if (m_waterfallHistory.size() == desiredSize) {
+    if (m_waterfallHistory.size() == desiredSize
+        && m_waterfallSupplementalHistory.size() == desiredSize) {
         m_dss.setHistoryCapacityRows(retainDssHistory ? desiredSize.height() : 0);
         return;
     }
@@ -4554,16 +4758,36 @@ void SpectrumWidget::ensureWaterfallHistory()
     const bool resizedExisting = m_waterfallHistory.isConfigured()
         && m_waterfallHistory.capacityRows() == desiredSize.height()
         && m_waterfallHistory.resizeWidth(desiredSize.width());
+    const bool resizedSupplemental =
+        m_waterfallSupplementalHistory.isConfigured()
+        && m_waterfallSupplementalHistory.capacityRows()
+            == desiredSize.height()
+        && m_waterfallSupplementalHistory.resizeWidth(
+            desiredSize.width());
     if (!resizedExisting) {
         m_waterfallHistory.configure(
             desiredSize.width(), desiredSize.height());
         m_wfHistoryTimestamps = QVector<qint64>(desiredSize.height(), 0);
         m_wfHistoryRowCenterMhz = QVector<double>(desiredSize.height(), 0.0);
         m_wfHistoryRowBwMhz = QVector<double>(desiredSize.height(), 0.0);
+        m_wfHistorySupplementalCenterMhz =
+            QVector<double>(desiredSize.height(), 0.0);
+        m_wfHistorySupplementalBwMhz =
+            QVector<double>(desiredSize.height(), 0.0);
         m_wfHistoryWriteRow = 0;
         m_wfHistoryRowCount = 0;
         m_wfHistoryOffsetRows = 0;
         m_wfLive = true;
+    }
+    if (!resizedSupplemental) {
+        m_waterfallSupplementalHistory.configure(
+            desiredSize.width(), desiredSize.height());
+        if (resizedExisting) {
+            m_wfHistorySupplementalCenterMhz =
+                QVector<double>(desiredSize.height(), 0.0);
+            m_wfHistorySupplementalBwMhz =
+                QVector<double>(desiredSize.height(), 0.0);
+        }
     }
     m_dss.setHistoryCapacityRows(retainDssHistory ? desiredSize.height() : 0);
 }
@@ -4584,9 +4808,21 @@ void SpectrumWidget::appendDssHistoryRow(const QVector<float>& binsDbm,
         return;
     }
     const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
-    const FrequencyFrame stampFrame = requestedFrame.isValid()
-        ? requestedFrame
-        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
+    const FrequencyFrame previewBase{
+        m_frequencyPreviewBaseCenterMhz,
+        m_frequencyPreviewBaseBandwidthMhz,
+    };
+    const FrequencyFrame previewTarget{
+        m_frequencyPreviewTargetCenterMhz,
+        m_frequencyPreviewTargetBandwidthMhz,
+    };
+    const FrequencyFrame stampFrame = resolvedUntaggedDssFrame(
+        requestedFrame,
+        FrequencyFrame{m_centerMhz, m_bandwidthMhz},
+        previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, previewTarget,
+            m_frequencyPreviewActive && !m_kiwiSdrWaterfallActive));
     retainDssHistoryRow(m_dss, binsDbm,
                         stampFrame.centerMhz, stampFrame.bandwidthMhz,
                         dssHistoryFallbackDbm());
@@ -4625,7 +4861,10 @@ const QVector<float>& dcRepairedDssBins(QVector<float>& scratch,
 void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
                                            double frameCenterMhz,
                                            double frameBandwidthMhz,
-                                           bool updateLiveSurface)
+                                           bool updateLiveSurface,
+                                           const QVector<float>& supplementalBinsDbm,
+                                           double supplementalCenterMhz,
+                                           double supplementalBandwidthMhz)
 {
     if (!m_kiwiSdrWaterfallActive && flexDssFftScaleSettling()) {
         return;
@@ -4638,13 +4877,39 @@ void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
 
     // Keep live DSS and retained scrollback DSS on the same waterfall-row cadence.
     if (m_wfLive && updateLiveSurface) {
-        if (m_frequencyPreviewActive && m_waterfallWriteVisible) {
+        const FrequencyFrame previewBase{
+            m_frequencyPreviewBaseCenterMhz,
+            m_frequencyPreviewBaseBandwidthMhz,
+        };
+        const FrequencyFrame previewTarget{
+            m_frequencyPreviewTargetCenterMhz,
+            m_frequencyPreviewTargetBandwidthMhz,
+        };
+        const bool usePreviewBase = dssUntaggedRowUsesPreviewBase(
+            previewBase, previewTarget,
+            m_frequencyPreviewActive && !m_kiwiSdrWaterfallActive);
+        const FrequencyFrame liveFrame = resolvedUntaggedDssFrame(
+            FrequencyFrame{frameCenterMhz, frameBandwidthMhz},
+            FrequencyFrame{m_centerMhz, m_bandwidthMhz},
+            previewBase, usePreviewBase);
+        if (m_frequencyPreviewActive && m_waterfallWriteVisible
+            && usePreviewBase) {
             const QVector<float>& previewBins = remapPreviewDssRow(
                 dssBins, frameCenterMhz, frameBandwidthMhz);
-            pushDssLiveRow(m_dss, previewBins, false);
+            pushDssLiveRow(
+                m_dss, previewBins, false,
+                previewBase.centerMhz, previewBase.bandwidthMhz,
+                supplementalBinsDbm,
+                supplementalCenterMhz,
+                supplementalBandwidthMhz);
             ++m_frequencyPreviewRemappedDssRows;
         } else {
-            pushDssLiveRow(m_dss, dssBins, !m_waterfallWriteVisible);
+            pushDssLiveRow(
+                m_dss, dssBins, !m_waterfallWriteVisible,
+                liveFrame.centerMhz, liveFrame.bandwidthMhz,
+                supplementalBinsDbm,
+                supplementalCenterMhz,
+                supplementalBandwidthMhz);
         }
     }
     appendDssHistoryRow(dssBins, frameCenterMhz, frameBandwidthMhz);
@@ -4652,11 +4917,20 @@ void SpectrumWidget::appendDssWaterfallRow(const QVector<float>& binsDbm,
 
 void SpectrumWidget::pushDssLiveRow(DssRenderer& dss,
                                     const QVector<float>& binsDbm,
-                                    bool hiddenStream)
+                                    bool hiddenStream,
+                                    double frameCenterMhz,
+                                    double frameBandwidthMhz,
+                                    const QVector<float>& supplementalBinsDbm,
+                                    double supplementalCenterMhz,
+                                    double supplementalBandwidthMhz)
 {
     QElapsedTimer timer;
     timer.start();
-    dss.pushRow(binsDbm);
+    dss.pushRowWithSupplemental(
+        binsDbm, frameCenterMhz, frameBandwidthMhz,
+        supplementalBinsDbm,
+        supplementalCenterMhz,
+        supplementalBandwidthMhz);
     m_panStats.dssLiveUs += static_cast<quint64>(timer.nsecsElapsed() / 1000);
     ++m_panStats.dssLiveRows;
     if (hiddenStream) {
@@ -4689,10 +4963,46 @@ void SpectrumWidget::appendLatestDssWaterfallRow(double frameCenterMhz,
     appendDssWaterfallRow(displaySpectrumBins(), frameCenterMhz, frameBandwidthMhz);
 }
 
+void SpectrumWidget::appendNativeDssWaterfallRow(
+    const QVector<float>& tileIntensity,
+    double tileLowMhz,
+    double tileHighMhz)
+{
+    const QVector<float>& fftBins = displaySpectrumBins();
+    const std::vector<float> calibrated =
+        AetherSDR::buildDssSupplementalCoverage(
+            std::span<const float>(tileIntensity.constData(),
+                                   static_cast<std::size_t>(tileIntensity.size())),
+            tileLowMhz,
+            tileHighMhz,
+            std::span<const float>(fftBins.constData(),
+                                   static_cast<std::size_t>(fftBins.size())),
+            m_centerMhz,
+            m_bandwidthMhz,
+            dssHistoryFallbackDbm(),
+            m_refLevel);
+    QVector<float> supplemental;
+    supplemental.reserve(static_cast<qsizetype>(calibrated.size()));
+    for (const float dbm : calibrated) {
+        supplemental.append(dbm);
+    }
+    appendDssWaterfallRow(
+        fftBins,
+        -1.0,
+        -1.0,
+        true,
+        supplemental,
+        (tileLowMhz + tileHighMhz) * 0.5,
+        tileHighMhz - tileLowMhz);
+}
+
 void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
                                       double frameCenterMhz,
                                       double frameBandwidthMhz,
-                                      bool startScrollAnimation)
+                                      bool startScrollAnimation,
+                                      const QRgb* supplementalRowData,
+                                      double supplementalCenterMhz,
+                                      double supplementalBandwidthMhz)
 {
     if (m_waterfall.isNull() || rowData == nullptr) {
         return;
@@ -4713,12 +5023,34 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
     m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
     auto* row = reinterpret_cast<QRgb*>(m_waterfall.bits() + m_wfWriteRow * m_waterfall.bytesPerLine());
     std::memcpy(row, rowData, m_waterfall.width() * sizeof(QRgb));
+    if (m_waterfallSupplemental.size() != m_waterfall.size()) {
+        m_waterfallSupplemental =
+            QImage(m_waterfall.size(), QImage::Format_RGB32);
+        m_waterfallSupplemental.fill(Qt::black);
+    }
+    auto* supplementalRow = reinterpret_cast<QRgb*>(
+        m_waterfallSupplemental.bits()
+        + m_wfWriteRow * m_waterfallSupplemental.bytesPerLine());
+    if (supplementalRowData != nullptr) {
+        std::memcpy(supplementalRow, supplementalRowData,
+                    m_waterfall.width() * sizeof(QRgb));
+    } else {
+        std::fill_n(supplementalRow, m_waterfall.width(), qRgb(0, 0, 0));
+    }
     if (m_wfVisibleRowCenterMhz.size() != h
-        || m_wfVisibleRowBwMhz.size() != h) {
+        || m_wfVisibleRowBwMhz.size() != h
+        || m_wfVisibleSupplementalCenterMhz.size() != h
+        || m_wfVisibleSupplementalBwMhz.size() != h) {
         resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     }
     m_wfVisibleRowCenterMhz[m_wfWriteRow] = rowFrame.centerMhz;
     m_wfVisibleRowBwMhz[m_wfWriteRow] = rowFrame.bandwidthMhz;
+    const FrequencyFrame supplementalFrame{
+        supplementalCenterMhz, supplementalBandwidthMhz};
+    m_wfVisibleSupplementalCenterMhz[m_wfWriteRow] =
+        supplementalFrame.isValid() ? supplementalFrame.centerMhz : 0.0;
+    m_wfVisibleSupplementalBwMhz[m_wfWriteRow] =
+        supplementalFrame.isValid() ? supplementalFrame.bandwidthMhz : 0.0;
 #ifdef AETHER_GPU_SPECTRUM
     m_wfFrameTexDirty = true;
 #endif
@@ -4738,7 +5070,10 @@ void SpectrumWidget::appendVisibleRow(const QRgb* rowData,
 void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
                                       qint64 timestampMs,
                                       double frameCenterMhz,
-                                      double frameBandwidthMhz)
+                                      double frameBandwidthMhz,
+                                      const quint8* supplementalIntensityData,
+                                      double supplementalCenterMhz,
+                                      double supplementalBandwidthMhz)
 {
     // A hidden Flex/Kiwi source keeps only its small viewport and 96-row live
     // DSS surface warm. Retained scrollback belongs to the visible source; it
@@ -4761,6 +5096,17 @@ void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
         return;
     }
     std::memcpy(row, intensityData, m_waterfallHistory.width());
+    quint8* supplementalRow =
+        m_waterfallSupplementalHistory.writableRow(m_wfHistoryWriteRow);
+    if (supplementalRow != nullptr) {
+        if (supplementalIntensityData != nullptr) {
+            std::memcpy(supplementalRow, supplementalIntensityData,
+                        m_waterfallHistory.width());
+        } else {
+            std::fill_n(supplementalRow, m_waterfallHistory.width(),
+                        quint8(0));
+        }
+    }
     if (m_wfHistoryWriteRow >= 0 && m_wfHistoryWriteRow < m_wfHistoryTimestamps.size()) {
         m_wfHistoryTimestamps[m_wfHistoryWriteRow] = timestampMs;
     }
@@ -4773,6 +5119,14 @@ void SpectrumWidget::appendHistoryRow(const quint8* intensityData,
     if (m_wfHistoryWriteRow >= 0 && m_wfHistoryWriteRow < m_wfHistoryRowCenterMhz.size()) {
         m_wfHistoryRowCenterMhz[m_wfHistoryWriteRow] = stampFrame.centerMhz;
         m_wfHistoryRowBwMhz[m_wfHistoryWriteRow] = stampFrame.bandwidthMhz;
+        const FrequencyFrame supplementalFrame{
+            supplementalCenterMhz, supplementalBandwidthMhz};
+        m_wfHistorySupplementalCenterMhz[m_wfHistoryWriteRow] =
+            supplementalFrame.isValid()
+                ? supplementalFrame.centerMhz : 0.0;
+        m_wfHistorySupplementalBwMhz[m_wfHistoryWriteRow] =
+            supplementalFrame.isValid()
+                ? supplementalFrame.bandwidthMhz : 0.0;
     }
     if (m_wfHistoryRowCount < h) {
         ++m_wfHistoryRowCount;
@@ -4889,11 +5243,23 @@ const QVector<float>& SpectrumWidget::remapPreviewDssRow(
         return binsDbm;
     }
 
-    const bool hasFrame = frameCenterMhz > 0.0 && frameBandwidthMhz > 0.0;
-    const double sourceCenterMhz = hasFrame ? frameCenterMhz : m_centerMhz;
-    const double sourceBandwidthMhz = hasFrame
-        ? frameBandwidthMhz
-        : m_bandwidthMhz;
+    const FrequencyFrame previewBase{
+        m_frequencyPreviewBaseCenterMhz,
+        m_frequencyPreviewBaseBandwidthMhz,
+    };
+    const FrequencyFrame previewTarget{
+        m_frequencyPreviewTargetCenterMhz,
+        m_frequencyPreviewTargetBandwidthMhz,
+    };
+    const FrequencyFrame sourceFrame = resolvedUntaggedDssFrame(
+        FrequencyFrame{frameCenterMhz, frameBandwidthMhz},
+        FrequencyFrame{m_centerMhz, m_bandwidthMhz},
+        previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, previewTarget,
+            !m_kiwiSdrWaterfallActive));
+    const double sourceCenterMhz = sourceFrame.centerMhz;
+    const double sourceBandwidthMhz = sourceFrame.bandwidthMhz;
     const double destinationCenterMhz = m_frequencyPreviewBaseCenterMhz;
     const double destinationBandwidthMhz =
         m_frequencyPreviewBaseBandwidthMhz;
@@ -4939,43 +5305,94 @@ const QVector<float>& SpectrumWidget::remapPreviewDssRow(
     return m_frequencyPreviewDssScratch;
 }
 
-static void remapHistoryRowInto(QRgb* dst, const quint8* src, int w,
-                                const std::array<QRgb, 256>& colorLut,
-                                double rowCenterMhz, double rowBwMhz,
-                                double curCenterMhz, double curBwMhz,
-                                bool preservePeaks)
+static quint8 sampleWaterfallHistoryFrame(const quint8* src, int w,
+                                          double sourceCenterMhz,
+                                          double sourceBandwidthMhz,
+                                          double destinationCenterMhz,
+                                          double destinationBandwidthMhz,
+                                          int destinationX,
+                                          bool preservePeaks)
 {
-    if (rowBwMhz <= 0.0 || curBwMhz <= 0.0
-        || (rowCenterMhz == curCenterMhz && rowBwMhz == curBwMhz)) {
+    const double sourceStartMhz =
+        sourceCenterMhz - sourceBandwidthMhz / 2.0;
+    const double destinationStartMhz =
+        destinationCenterMhz - destinationBandwidthMhz / 2.0;
+    const double destinationCenterBinMhz = destinationStartMhz
+        + (static_cast<double>(destinationX) + 0.5) / w
+            * destinationBandwidthMhz;
+    const double sourceX =
+        (destinationCenterBinMhz - sourceStartMhz)
+        / sourceBandwidthMhz * w;
+    if (!preservePeaks) {
+        return src[std::clamp(static_cast<int>(sourceX), 0, w - 1)];
+    }
+
+    const double destinationLeftMhz = destinationStartMhz
+        + static_cast<double>(destinationX) / w * destinationBandwidthMhz;
+    const double destinationRightMhz = destinationStartMhz
+        + static_cast<double>(destinationX + 1) / w
+            * destinationBandwidthMhz;
+    const double sourceLeft =
+        (destinationLeftMhz - sourceStartMhz) / sourceBandwidthMhz * w;
+    const double sourceRight =
+        (destinationRightMhz - sourceStartMhz) / sourceBandwidthMhz * w;
+    return peakPreservedWaterfallSample(
+        src, w, sourceLeft, sourceRight, sourceX);
+}
+
+static void remapHistoryRowInto(
+    QRgb* dst,
+    const quint8* src,
+    int w,
+    const std::array<QRgb, 256>& colorLut,
+    double rowCenterMhz,
+    double rowBwMhz,
+    double curCenterMhz,
+    double curBwMhz,
+    bool preservePeaks,
+    const quint8* supplementalSrc = nullptr,
+    double supplementalCenterMhz = 0.0,
+    double supplementalBandwidthMhz = 0.0)
+{
+    if (rowBwMhz <= 0.0 || curBwMhz <= 0.0) {
         for (int x = 0; x < w; ++x) {
             dst[x] = colorLut[src[x]];
         }
         return;
     }
+
     const double rowStartMhz = rowCenterMhz - rowBwMhz / 2.0;
     const double rowEndMhz = rowStartMhz + rowBwMhz;
+    const bool haveSupplemental =
+        supplementalSrc != nullptr
+        && supplementalCenterMhz > 0.0
+        && supplementalBandwidthMhz > 0.0;
+    const double supplementalStartMhz =
+        supplementalCenterMhz - supplementalBandwidthMhz / 2.0;
+    const double supplementalEndMhz =
+        supplementalStartMhz + supplementalBandwidthMhz;
     const double curStartMhz = curCenterMhz - curBwMhz / 2.0;
     for (int x = 0; x < w; ++x) {
-        const double freqMhz = curStartMhz + (static_cast<double>(x) + 0.5) / w * curBwMhz;
-        const double srcX = (freqMhz - rowStartMhz) / rowBwMhz * w;
-        if (!preservePeaks) {
-            dst[x] = (srcX < 0.0 || srcX >= w) ? qRgb(0, 0, 0)
-                : colorLut[src[static_cast<int>(srcX)]];
-            continue;
-        }
-
         const double freqLeftMhz = curStartMhz
             + static_cast<double>(x) / w * curBwMhz;
         const double freqRightMhz = curStartMhz
             + static_cast<double>(x + 1) / w * curBwMhz;
-        if (freqRightMhz <= rowStartMhz || freqLeftMhz >= rowEndMhz) {
-            dst[x] = qRgb(0, 0, 0);
+        if (freqRightMhz > rowStartMhz && freqLeftMhz < rowEndMhz) {
+            dst[x] = colorLut[sampleWaterfallHistoryFrame(
+                src, w, rowCenterMhz, rowBwMhz,
+                curCenterMhz, curBwMhz, x, preservePeaks)];
             continue;
         }
-        const double srcLeft = (freqLeftMhz - rowStartMhz) / rowBwMhz * w;
-        const double srcRight = (freqRightMhz - rowStartMhz) / rowBwMhz * w;
-        dst[x] = colorLut[peakPreservedWaterfallSample(
-            src, w, srcLeft, srcRight, srcX)];
+        if (haveSupplemental
+            && freqRightMhz > supplementalStartMhz
+            && freqLeftMhz < supplementalEndMhz) {
+            dst[x] = colorLut[sampleWaterfallHistoryFrame(
+                supplementalSrc, w,
+                supplementalCenterMhz, supplementalBandwidthMhz,
+                curCenterMhz, curBwMhz, x, preservePeaks)];
+            continue;
+        }
+        dst[x] = qRgb(0, 0, 0);
     }
 }
 
@@ -4987,6 +5404,8 @@ void SpectrumWidget::resetVisibleWaterfallFrequencyFrames(
     if (height <= 0) {
         m_wfVisibleRowCenterMhz.clear();
         m_wfVisibleRowBwMhz.clear();
+        m_wfVisibleSupplementalCenterMhz.clear();
+        m_wfVisibleSupplementalBwMhz.clear();
 #ifdef AETHER_GPU_SPECTRUM
         m_wfFrameTexDirty = true;
 #endif
@@ -5002,6 +5421,8 @@ void SpectrumWidget::resetVisibleWaterfallFrequencyFrames(
         : m_bandwidthMhz;
     m_wfVisibleRowCenterMhz.fill(validCenterMhz, height);
     m_wfVisibleRowBwMhz.fill(validBandwidthMhz, height);
+    m_wfVisibleSupplementalCenterMhz.fill(0.0, height);
+    m_wfVisibleSupplementalBwMhz.fill(0.0, height);
 #ifdef AETHER_GPU_SPECTRUM
     m_wfFrameTexDirty = true;
 #endif
@@ -5017,7 +5438,9 @@ void SpectrumWidget::prepareWaterfallFrameUpload()
         return;
     }
     if (m_wfVisibleRowCenterMhz.size() != visibleHeight
-        || m_wfVisibleRowBwMhz.size() != visibleHeight) {
+        || m_wfVisibleRowBwMhz.size() != visibleHeight
+        || m_wfVisibleSupplementalCenterMhz.size() != visibleHeight
+        || m_wfVisibleSupplementalBwMhz.size() != visibleHeight) {
         resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     }
 
@@ -5034,11 +5457,21 @@ void SpectrumWidget::prepareWaterfallFrameUpload()
         const double bandwidthMhz = visibleRow
             ? m_wfVisibleRowBwMhz[row]
             : m_bandwidthMhz;
+        const double supplementalCenterMhz = visibleRow
+            ? m_wfVisibleSupplementalCenterMhz[row]
+            : 0.0;
+        const double supplementalBandwidthMhz = visibleRow
+            ? m_wfVisibleSupplementalBwMhz[row]
+            : 0.0;
         m_wfFrameUpload[row * 4] = static_cast<float>(
             centerMhz - m_wfFrameReferenceCenterMhz);
         m_wfFrameUpload[row * 4 + 1] = static_cast<float>(bandwidthMhz);
-        m_wfFrameUpload[row * 4 + 2] = 0.0f;
-        m_wfFrameUpload[row * 4 + 3] = 0.0f;
+        m_wfFrameUpload[row * 4 + 2] = static_cast<float>(
+            supplementalCenterMhz > 0.0
+                ? supplementalCenterMhz - m_wfFrameReferenceCenterMhz
+                : 0.0);
+        m_wfFrameUpload[row * 4 + 3] =
+            static_cast<float>(supplementalBandwidthMhz);
     }
 }
 #endif
@@ -5075,6 +5508,9 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
 
     m_wfHistoryOffsetRows = std::clamp(m_wfHistoryOffsetRows, 0, maxWaterfallHistoryOffsetRows());
     m_waterfall.fill(Qt::black);
+    if (!m_waterfallSupplemental.isNull()) {
+        m_waterfallSupplemental.fill(Qt::black);
+    }
     m_wfWriteRow = 0;
     resetVisibleWaterfallFrequencyFrames(centerMhz, bandwidthMhz);
 
@@ -5086,6 +5522,11 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
     const int w = m_waterfall.width();
     const bool haveFrames = m_wfHistoryRowCenterMhz.size()
         == m_waterfallHistory.capacityRows();
+    const bool haveSupplementalFrames =
+        m_wfHistorySupplementalCenterMhz.size()
+            == m_waterfallHistory.capacityRows()
+        && m_wfHistorySupplementalBwMhz.size()
+            == m_waterfallHistory.capacityRows();
     const std::array<QRgb, 256> colorLut = waterfallHistoryColorLut();
     for (int y = 0; y < m_waterfall.height(); ++y) {
         const int rowIndex = historyRowIndexForAge(m_wfHistoryOffsetRows + y);
@@ -5099,9 +5540,17 @@ void SpectrumWidget::rebuildWaterfallViewportForFrame(double centerMhz,
         auto* dst = reinterpret_cast<QRgb*>(m_waterfall.scanLine(y));
         const double rowCenter = haveFrames ? m_wfHistoryRowCenterMhz[rowIndex] : m_centerMhz;
         const double rowBw = haveFrames ? m_wfHistoryRowBwMhz[rowIndex] : m_bandwidthMhz;
+        const quint8* supplementalSrc =
+            m_waterfallSupplementalHistory.row(rowIndex);
+        const double supplementalCenter = haveSupplementalFrames
+            ? m_wfHistorySupplementalCenterMhz[rowIndex] : 0.0;
+        const double supplementalBw = haveSupplementalFrames
+            ? m_wfHistorySupplementalBwMhz[rowIndex] : 0.0;
         remapHistoryRowInto(dst, src, w, colorLut,
                             rowCenter, rowBw, centerMhz, bandwidthMhz,
-                            m_kiwiSdrWaterfallActive);
+                            m_kiwiSdrWaterfallActive,
+                            supplementalSrc,
+                            supplementalCenter, supplementalBw);
     }
 
 #ifdef AETHER_GPU_SPECTRUM
@@ -5228,7 +5677,8 @@ void SpectrumWidget::handleWaterfallFrequencyFrameChange(double oldCenterMhz,
         if (m_wfLive || m_dss.historyRowCount() <= 0) {
             m_dss.reprojectFrequencyFrame(oldCenterMhz, oldBandwidthMhz,
                                           newCenterMhz, newBandwidthMhz,
-                                          dssFallback);
+                                          dssFallback,
+                                          !kiwiStream);
         } else {
             rebuildDssViewportFromHistoryForFrame(newCenterMhz, newBandwidthMhz);
         }
@@ -5347,10 +5797,10 @@ void SpectrumWidget::commitFrequencyPreview()
     const double targetCenterMhz = m_frequencyPreviewTargetCenterMhz;
     const double targetBandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
 
-    // Each RGB row now retains its own frequency frame, so the waterfall shader
-    // is already exact at the target center/bandwidth and needs no release-time
-    // CPU rebuild. Only the compact 3D stacked-trace surface still uses the
-    // uniform preview base and must be landed into the target frame.
+    // Both waterfall and live 3D rows retain their own frequency frames. The
+    // shaders are already exact at the target center/bandwidth, so release must
+    // not destructively reproject the live rings. Keeping those native frames
+    // also preserves the wider waterfall-tile fallback attached to 3D rows.
     m_frequencyPreviewActive = false;
     QElapsedTimer timer;
     timer.start();
@@ -5368,11 +5818,6 @@ void SpectrumWidget::commitFrequencyPreview()
         if (!m_wfLive && m_dss.historyRowCount() > 0) {
             rebuildDssViewportFromHistoryForFrame(targetCenterMhz,
                                                   targetBandwidthMhz);
-        } else {
-            m_dss.reprojectFrequencyFrame(baseCenterMhz, baseBandwidthMhz,
-                                          targetCenterMhz, targetBandwidthMhz,
-                                          dssHistoryFallbackDbm());
-            resetDssUploadState();
         }
     }
     m_frequencyPreviewCommitLastNs = timer.nsecsElapsed();
@@ -5487,12 +5932,22 @@ void SpectrumWidget::clearCurrentWaterfallRows()
     if (!m_waterfall.isNull()) {
         m_waterfall.fill(Qt::black);
     }
+    if (!m_waterfallSupplemental.isNull()) {
+        m_waterfallSupplemental.fill(Qt::black);
+    }
     if (m_waterfallHistory.isConfigured()) {
         m_waterfallHistory.discardRows();
+    }
+    if (m_waterfallSupplementalHistory.isConfigured()) {
+        m_waterfallSupplementalHistory.discardRows();
     }
     std::fill(m_wfHistoryTimestamps.begin(), m_wfHistoryTimestamps.end(), 0);
     std::fill(m_wfHistoryRowCenterMhz.begin(), m_wfHistoryRowCenterMhz.end(), 0.0);
     std::fill(m_wfHistoryRowBwMhz.begin(), m_wfHistoryRowBwMhz.end(), 0.0);
+    std::fill(m_wfHistorySupplementalCenterMhz.begin(),
+              m_wfHistorySupplementalCenterMhz.end(), 0.0);
+    std::fill(m_wfHistorySupplementalBwMhz.begin(),
+              m_wfHistorySupplementalBwMhz.end(), 0.0);
     m_wfWriteRow = 0;
     resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     m_wfHistoryWriteRow = 0;
@@ -5532,9 +5987,12 @@ void SpectrumWidget::resetCurrentWaterfallRowsForSize(
 {
     if (!waterfallSize.isEmpty()) {
         m_waterfall = QImage(waterfallSize, QImage::Format_RGB32);
+        m_waterfallSupplemental =
+            QImage(waterfallSize, QImage::Format_RGB32);
         m_waterfallStreamSizeHint = waterfallSize;
     } else {
         m_waterfall = QImage();
+        m_waterfallSupplemental = QImage();
         m_waterfallStreamSizeHint = QSize();
     }
 
@@ -5547,20 +6005,29 @@ void SpectrumWidget::resetCurrentWaterfallRowsForSize(
     if (!desiredHistorySize.isEmpty()) {
         m_waterfallHistory.configure(desiredHistorySize.width(),
                                      desiredHistorySize.height());
+        m_waterfallSupplementalHistory.configure(
+            desiredHistorySize.width(), desiredHistorySize.height());
         m_waterfallHistoryStreamSizeHint = desiredHistorySize;
         m_wfHistoryTimestamps = QVector<qint64>(desiredHistorySize.height(), 0);
         m_wfHistoryRowCenterMhz = QVector<double>(desiredHistorySize.height(), 0.0);
         m_wfHistoryRowBwMhz = QVector<double>(desiredHistorySize.height(), 0.0);
+        m_wfHistorySupplementalCenterMhz =
+            QVector<double>(desiredHistorySize.height(), 0.0);
+        m_wfHistorySupplementalBwMhz =
+            QVector<double>(desiredHistorySize.height(), 0.0);
         const bool retainDssHistory =
             m_spectrumRenderMode == SpectrumRenderMode::Mode3D;
         m_dss.setHistoryCapacityRows(
             retainDssHistory ? desiredHistorySize.height() : 0);
     } else {
         m_waterfallHistory.reset();
+        m_waterfallSupplementalHistory.reset();
         m_waterfallHistoryStreamSizeHint = QSize();
         m_wfHistoryTimestamps.clear();
         m_wfHistoryRowCenterMhz.clear();
         m_wfHistoryRowBwMhz.clear();
+        m_wfHistorySupplementalCenterMhz.clear();
+        m_wfHistorySupplementalBwMhz.clear();
         m_dss.setHistoryCapacityRows(0);
     }
 
@@ -5617,16 +6084,27 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
     // inactive source while keeping source switches allocation-free.
     WaterfallStreamState updated;
     updated.waterfall = std::move(m_waterfall);
+    updated.waterfallSupplemental = std::move(m_waterfallSupplemental);
     updated.wfWriteRow = m_wfWriteRow;
     updated.visibleRowCenterMhz = std::move(m_wfVisibleRowCenterMhz);
     updated.visibleRowBwMhz = std::move(m_wfVisibleRowBwMhz);
+    updated.visibleSupplementalCenterMhz =
+        std::move(m_wfVisibleSupplementalCenterMhz);
+    updated.visibleSupplementalBwMhz =
+        std::move(m_wfVisibleSupplementalBwMhz);
     updated.waterfallHistory = std::move(m_waterfallHistory);
+    updated.waterfallSupplementalHistory =
+        std::move(m_waterfallSupplementalHistory);
     updated.historyTimestamps = std::move(m_wfHistoryTimestamps);
     updated.historyWriteRow = m_wfHistoryWriteRow;
     updated.historyRowCount = m_wfHistoryRowCount;
     updated.historyOffsetRows = m_wfHistoryOffsetRows;
     updated.historyRowCenterMhz = std::move(m_wfHistoryRowCenterMhz);
     updated.historyRowBwMhz = std::move(m_wfHistoryRowBwMhz);
+    updated.historySupplementalCenterMhz =
+        std::move(m_wfHistorySupplementalCenterMhz);
+    updated.historySupplementalBwMhz =
+        std::move(m_wfHistorySupplementalBwMhz);
     updated.live = m_wfLive;
     updated.rowsSinceRateChange = m_wfRowsSinceRateChange;
     updated.prevTileLevels = std::move(m_prevTileLevels);
@@ -5659,12 +6137,15 @@ void SpectrumWidget::saveCurrentWaterfallStreamState()
 void SpectrumWidget::discardRetainedHistory(WaterfallStreamState& state)
 {
     state.waterfallHistory.reset();
+    state.waterfallSupplementalHistory.reset();
     state.historyTimestamps.clear();
     state.historyWriteRow = 0;
     state.historyRowCount = 0;
     state.historyOffsetRows = 0;
     state.historyRowCenterMhz.clear();
     state.historyRowBwMhz.clear();
+    state.historySupplementalCenterMhz.clear();
+    state.historySupplementalBwMhz.clear();
     state.rowsSinceRateChange = 0;
     state.live = true;
     state.dss.setHistoryCapacityRows(0);
@@ -5715,17 +6196,34 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     state = WaterfallStreamState{};
 
     m_waterfall = std::move(restored.waterfall);
+    m_waterfallSupplemental =
+        std::move(restored.waterfallSupplemental);
+    if (m_waterfallSupplemental.size() != m_waterfall.size()) {
+        m_waterfallSupplemental =
+            QImage(m_waterfall.size(), QImage::Format_RGB32);
+        m_waterfallSupplemental.fill(Qt::black);
+    }
     if (!m_waterfall.isNull()) {
         m_waterfallStreamSizeHint = m_waterfall.size();
     }
     m_wfWriteRow = restored.wfWriteRow;
     m_wfVisibleRowCenterMhz = std::move(restored.visibleRowCenterMhz);
     m_wfVisibleRowBwMhz = std::move(restored.visibleRowBwMhz);
+    m_wfVisibleSupplementalCenterMhz =
+        std::move(restored.visibleSupplementalCenterMhz);
+    m_wfVisibleSupplementalBwMhz =
+        std::move(restored.visibleSupplementalBwMhz);
     if (m_wfVisibleRowCenterMhz.size() != m_waterfall.height()
-        || m_wfVisibleRowBwMhz.size() != m_waterfall.height()) {
+        || m_wfVisibleRowBwMhz.size() != m_waterfall.height()
+        || m_wfVisibleSupplementalCenterMhz.size()
+            != m_waterfall.height()
+        || m_wfVisibleSupplementalBwMhz.size()
+            != m_waterfall.height()) {
         resetVisibleWaterfallFrequencyFrames(m_centerMhz, m_bandwidthMhz);
     }
     m_waterfallHistory = std::move(restored.waterfallHistory);
+    m_waterfallSupplementalHistory =
+        std::move(restored.waterfallSupplementalHistory);
     if (m_waterfallHistory.isConfigured()) {
         m_waterfallHistoryStreamSizeHint = m_waterfallHistory.size();
     }
@@ -5735,6 +6233,10 @@ void SpectrumWidget::restoreCurrentWaterfallStreamState()
     m_wfHistoryOffsetRows = restored.historyOffsetRows;
     m_wfHistoryRowCenterMhz = std::move(restored.historyRowCenterMhz);
     m_wfHistoryRowBwMhz = std::move(restored.historyRowBwMhz);
+    m_wfHistorySupplementalCenterMhz =
+        std::move(restored.historySupplementalCenterMhz);
+    m_wfHistorySupplementalBwMhz =
+        std::move(restored.historySupplementalBwMhz);
     m_wfLive = restored.live;
     m_wfRowsSinceRateChange = restored.rowsSinceRateChange;
     m_prevTileLevels = std::move(restored.prevTileLevels);
@@ -7430,6 +7932,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     const double panStartMhz = m_centerMhz - m_bandwidthMhz / 2.0;
 
     QVector<quint8> levels(destWidth, 0);
+    QVector<quint8> supplementalLevels(destWidth, 0);
     if (tileBw > 0) {
         for (int x = 0; x < destWidth; ++x) {
             const double freq = panStartMhz + (static_cast<double>(x) / destWidth) * m_bandwidthMhz;
@@ -7443,6 +7946,28 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
                 levels[x] = encodeWaterfallLevel(
                     intensityToWaterfallLevel(i0 + frac * (i1 - i0)));
             }
+
+            // Preserve the complete native tile independently from the exact
+            // viewport row above. The row-frequency shader consults this only
+            // when a later pan asks for a frequency outside the viewport frame.
+            const double supplementalBinF = std::clamp(
+                (static_cast<double>(x) + 0.5)
+                    / static_cast<double>(destWidth) * srcSize - 0.5,
+                0.0, static_cast<double>(srcSize - 1));
+            const int supplementalBin = std::clamp(
+                static_cast<int>(std::floor(supplementalBinF)),
+                0, srcSize - 1);
+            const int supplementalNext =
+                std::min(supplementalBin + 1, srcSize - 1);
+            const float supplementalFrac = static_cast<float>(
+                supplementalBinF - supplementalBin);
+            const float supplementalIntensity =
+                binsIntensity[supplementalBin]
+                + supplementalFrac
+                    * (binsIntensity[supplementalNext]
+                       - binsIntensity[supplementalBin]);
+            supplementalLevels[x] = encodeWaterfallLevel(
+                intensityToWaterfallLevel(supplementalIntensity));
         }
     }
 
@@ -7496,6 +8021,7 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
     for (int r = 0; r < rowsToPush; ++r) {
         QVector<quint8> interpolatedLevels(destWidth, 0);
         QVector<QRgb> interpolatedRow(destWidth, qRgb(0, 0, 0));
+        QVector<QRgb> supplementalRow(destWidth, qRgb(0, 0, 0));
         if (canInterp) {
             // t=0 at row 0 (current), t=1 at last row (previous)
             const float t = static_cast<float>(r) / rowsToPush;
@@ -7512,15 +8038,30 @@ void SpectrumWidget::updateWaterfallRow(const QVector<float>& binsIntensity,
         }
         for (int x = 0; x < destWidth; ++x) {
             interpolatedRow[x] = colorLut[interpolatedLevels[x]];
+            supplementalRow[x] = colorLut[supplementalLevels[x]];
         }
 
-        appendHistoryRow(interpolatedLevels.constData(), nowMs);
-        appendLatestDssWaterfallRow();
+        const double supplementalCenterMhz =
+            (lowFreqMhz + highFreqMhz) * 0.5;
+        const double supplementalBandwidthMhz =
+            highFreqMhz - lowFreqMhz;
+        appendHistoryRow(
+            interpolatedLevels.constData(), nowMs,
+            -1.0, -1.0,
+            supplementalLevels.constData(),
+            supplementalCenterMhz,
+            supplementalBandwidthMhz);
+        appendNativeDssWaterfallRow(
+            binsIntensity, lowFreqMhz, highFreqMhz);
         if (m_wfLive) {
             // The whole tile gets one start() after the loop; don't restart the
             // scroll clock once per appended row.
-            appendVisibleRow(interpolatedRow.constData(), -1.0, -1.0,
-                             /*startScrollAnimation=*/false);
+            appendVisibleRow(
+                interpolatedRow.constData(), -1.0, -1.0,
+                /*startScrollAnimation=*/false,
+                supplementalRow.constData(),
+                supplementalCenterMhz,
+                supplementalBandwidthMhz);
         } else {
             rebuildWaterfallViewport();
         }
@@ -9355,12 +9896,24 @@ void SpectrumWidget::mouseMoveEvent(QMouseEvent* ev)
         if (wfHeight > 0 && contentWidth() > 0) {
             QImage newWf(contentWidth(), wfHeight, QImage::Format_RGB32);
             newWf.fill(Qt::black);
+            QImage newSupplemental(
+                contentWidth(), wfHeight, QImage::Format_RGB32);
+            newSupplemental.fill(Qt::black);
             if (!m_waterfall.isNull()) {
                 QImage scaled = m_waterfall.scaled(contentWidth(), wfHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
                 if (!scaled.isNull())
                     newWf = std::move(scaled);
             }
+            if (!m_waterfallSupplemental.isNull()) {
+                QImage scaledSupplemental = m_waterfallSupplemental.scaled(
+                    contentWidth(), wfHeight,
+                    Qt::IgnoreAspectRatio, Qt::FastTransformation);
+                if (!scaledSupplemental.isNull()) {
+                    newSupplemental = std::move(scaledSupplemental);
+                }
+            }
             m_waterfall = std::move(newWf);
+            m_waterfallSupplemental = std::move(newSupplemental);
             m_wfWriteRow = 0;
             ensureWaterfallHistory();
             if (m_wfHistoryRowCount > 0) {
@@ -10446,6 +10999,8 @@ void SpectrumWidget::applySettledResizeBuffers()
     if (waterfallChanged) {
         QImage newWf(waterfallSize, QImage::Format_RGB32);
         newWf.fill(Qt::black);
+        QImage newSupplemental(waterfallSize, QImage::Format_RGB32);
+        newSupplemental.fill(Qt::black);
         if (!m_waterfall.isNull()) {
             QImage scaled = m_waterfall.scaled(
                 waterfallSize, Qt::IgnoreAspectRatio, Qt::FastTransformation);
@@ -10453,7 +11008,16 @@ void SpectrumWidget::applySettledResizeBuffers()
                 newWf = std::move(scaled);
             }
         }
+        if (!m_waterfallSupplemental.isNull()) {
+            QImage scaledSupplemental = m_waterfallSupplemental.scaled(
+                waterfallSize,
+                Qt::IgnoreAspectRatio, Qt::FastTransformation);
+            if (!scaledSupplemental.isNull()) {
+                newSupplemental = std::move(scaledSupplemental);
+            }
+        }
         m_waterfall = std::move(newWf);
+        m_waterfallSupplemental = std::move(newSupplemental);
         m_wfWriteRow = 0;
         ensureWaterfallHistory();
         if (m_wfHistoryRowCount > 0) {
@@ -10786,14 +11350,26 @@ void SpectrumWidget::pushDssRowForWaterfallStream(bool kiwiStream,
     const QVector<float>& dssBins = dcRepairedDssBins(
         repairedBins, binsDbm, !kiwiStream,
         frameCenterMhz, frameBandwidthMhz, m_centerMhz, m_bandwidthMhz);
-    if (live && updateLiveSurface) {
-        pushDssLiveRow(dss, dssBins, true);
-    }
-
     const FrequencyFrame requestedFrame{frameCenterMhz, frameBandwidthMhz};
-    const FrequencyFrame stampFrame = requestedFrame.isValid()
-        ? requestedFrame
-        : FrequencyFrame{m_centerMhz, m_bandwidthMhz};
+    const FrequencyFrame previewBase{
+        m_frequencyPreviewBaseCenterMhz,
+        m_frequencyPreviewBaseBandwidthMhz,
+    };
+    const FrequencyFrame previewTarget{
+        m_frequencyPreviewTargetCenterMhz,
+        m_frequencyPreviewTargetBandwidthMhz,
+    };
+    const FrequencyFrame stampFrame = resolvedUntaggedDssFrame(
+        requestedFrame,
+        FrequencyFrame{m_centerMhz, m_bandwidthMhz},
+        previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, previewTarget, false));
+    if (live && updateLiveSurface) {
+        pushDssLiveRow(
+            dss, dssBins, true,
+            stampFrame.centerMhz, stampFrame.bandwidthMhz);
+    }
     const float fallbackDbm = kiwiStream
         ? kKiwiSdrWaterfallMinDbm
         : m_refLevel - m_dynamicRange;
@@ -11083,6 +11659,8 @@ void SpectrumWidget::releaseWaterfallFramePipelineResources()
     m_wfFrameSrb = nullptr;
     delete m_wfFrameTex;
     m_wfFrameTex = nullptr;
+    delete m_wfSupplementalGpuTex;
+    m_wfSupplementalGpuTex = nullptr;
     delete m_wfFrameSampler;
     m_wfFrameSampler = nullptr;
     m_wfFrameTexReady = false;
@@ -11216,8 +11794,11 @@ bool SpectrumWidget::initWaterfallPipeline()
 
     std::unique_ptr<QRhiTexture> frameTexture(r->newTexture(
         QRhiTexture::RGBA32F, QSize(1, textureHeight)));
+    std::unique_ptr<QRhiTexture> supplementalTexture(r->newTexture(
+        QRhiTexture::RGBA8, QSize(textureWidth, textureHeight)));
     readiness.textureCreated = !waterfallFrameTextureFailureForced()
-        && frameTexture->create();
+        && frameTexture->create()
+        && supplementalTexture->create();
     if (!readiness.textureCreated) {
         const QString reason = waterfallFrameTextureFailureForced()
             ? QStringLiteral("row texture failure forced by automation")
@@ -11245,6 +11826,9 @@ bool SpectrumWidget::initWaterfallPipeline()
         QRhiShaderResourceBinding::sampledTexture(
             2, QRhiShaderResourceBinding::FragmentStage,
             frameTexture.get(), frameSampler.get()),
+        QRhiShaderResourceBinding::sampledTexture(
+            3, QRhiShaderResourceBinding::FragmentStage,
+            supplementalTexture.get(), m_wfSampler),
     });
     readiness.bindingsCreated = frameSrb->create();
     if (!readiness.bindingsCreated) {
@@ -11278,6 +11862,7 @@ bool SpectrumWidget::initWaterfallPipeline()
     }
 
     m_wfFrameTex = frameTexture.release();
+    m_wfSupplementalGpuTex = supplementalTexture.release();
     m_wfFrameSampler = frameSampler.release();
     m_wfFrameSrb = frameSrb.release();
     m_wfFramePipeline = framePipeline.release();
@@ -11556,10 +12141,10 @@ void SpectrumWidget::initDssMeshPipeline()
     QRhi* r = rhi();
     m_dssMeshReady = false;
 
-    // R16F height texture is the cleanest dBm store; if unsupported, fall back
-    // to the cached-image quad path (no mesh).
-    if (!r->isTextureFormatSupported(QRhiTexture::R16F, {})) {
-        qCWarning(lcGui) << "SpectrumWidget: R16F unsupported — stacked-trace mesh disabled (CPU fallback)";
+    // R stores dBm and G stores captured-frequency coverage. The second channel
+    // keeps zoom-created floor spans colour-stable without hiding their lines.
+    if (!r->isTextureFormatSupported(QRhiTexture::RGBA16F, {})) {
+        qCWarning(lcGui) << "SpectrumWidget: RGBA16F unsupported — stacked-trace mesh disabled (CPU fallback)";
         return;
     }
 
@@ -11571,9 +12156,10 @@ void SpectrumWidget::initDssMeshPipeline()
     }
 
     const int cols = m_dss.cols();
-    const int rows = m_dss.rows();
-    const int fillVerts = rows * dssFillVerticesPerRow();
-    const int lineVerts = rows * dssLineVerticesPerRow();
+    const int textureRows = m_dss.rows();
+    const int meshRows = DssRenderer::kVisibleRows;
+    const int fillVerts = meshRows * dssFillVerticesPerRow();
+    const int lineVerts = meshRows * dssLineVerticesPerRow();
 
     m_dssMeshVbo = r->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer,
                                 fillVerts * 3 * sizeof(float));
@@ -11586,7 +12172,8 @@ void SpectrumWidget::initDssMeshPipeline()
         return;
     }
 
-    m_dssHeightTex  = r->newTexture(QRhiTexture::R16F, QSize(cols, rows));
+    m_dssHeightTex =
+        r->newTexture(QRhiTexture::RGBA16F, QSize(cols, textureRows));
     m_dssPaletteTex = r->newTexture(QRhiTexture::RGBA8, QSize(256, 1));
     if (!m_dssHeightTex->create() || !m_dssPaletteTex->create()) {
         qCWarning(lcGui) << "SpectrumWidget: dss_mesh texture create failed";
@@ -11623,15 +12210,25 @@ void SpectrumWidget::initDssMeshPipeline()
     layout.setBindings({{3 * sizeof(float)}});
     layout.setAttributes({{0, 0, QRhiVertexInputAttribute::Float3, 0}});  // u, v, edge
 
-    // Fill pipeline — one opaque front curtain, height-morphed in the shader.
+    // Fill pipeline — exact moving interior rows plus old/new layers for the
+    // two fixed boundary rows. Neither layer's height is interpolated.
+    QRhiGraphicsPipeline::TargetBlend fillBlend;
+    fillBlend.enable = true;
+    fillBlend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
+    fillBlend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
+    fillBlend.srcAlpha = QRhiGraphicsPipeline::One;
+    fillBlend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
     m_dssMeshFillPipeline = r->newGraphicsPipeline();
     m_dssMeshFillPipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
     m_dssMeshFillPipeline->setVertexInputLayout(layout);
     m_dssMeshFillPipeline->setTopology(QRhiGraphicsPipeline::Triangles);
     m_dssMeshFillPipeline->setShaderResourceBindings(m_dssMeshSrb);
     m_dssMeshFillPipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
+    m_dssMeshFillPipeline->setTargetBlends({fillBlend});
 
-    // Outline pipeline — alpha-blended line segments (the dim trace line).
+    // Outline pipeline — alpha-blended screen-space ribbons. Metal's native
+    // one-pixel lines toggle coverage as they move through subpixels, making
+    // the entire scrolling history strobe.
     QRhiGraphicsPipeline::TargetBlend lblend;
     lblend.enable = true;
     lblend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
@@ -11641,7 +12238,7 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshLinePipeline = r->newGraphicsPipeline();
     m_dssMeshLinePipeline->setShaderStages({{QRhiShaderStage::Vertex, vs}, {QRhiShaderStage::Fragment, fs}});
     m_dssMeshLinePipeline->setVertexInputLayout(layout);
-    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::Lines);
+    m_dssMeshLinePipeline->setTopology(QRhiGraphicsPipeline::Triangles);
     m_dssMeshLinePipeline->setShaderResourceBindings(m_dssMeshSrb);
     m_dssMeshLinePipeline->setRenderPassDescriptor(renderTarget()->renderPassDescriptor());
     m_dssMeshLinePipeline->setTargetBlends({lblend});
@@ -11655,7 +12252,8 @@ void SpectrumWidget::initDssMeshPipeline()
     m_dssMeshRowGenUploaded = ~0ull;
     m_dssLutToken = ~0ull;
     m_dssMeshReady = true;
-    qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created" << cols << "x" << rows;
+    qDebug() << "SpectrumWidget: stacked-trace mesh pipeline created"
+             << cols << "x" << textureRows;
 }
 
 void SpectrumWidget::initDssDepthPipeline()
@@ -11868,24 +12466,38 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
     // height comes from the ring-buffered texture sampled per-vertex).
     if (m_dssMeshReady) {
         const int cols = m_dss.cols();
-        const int rows = m_dss.rows();
+        const int rows = DssRenderer::kVisibleRows;
         QVector<float> fill;
         QVector<float> line;
         fill.reserve(rows * dssFillVerticesPerRow() * 3);
         line.reserve(rows * dssLineVerticesPerRow() * 3);
         for (int rr = rows - 1; rr >= 0; --rr) {
             const float v = static_cast<float>(rr) / rows;   // 0 front .. ~1 back
-            for (int cc = 0; cc + 1 < cols; ++cc) {
-                const float u0 = static_cast<float>(cc) / (cols - 1);
-                const float u1 = static_cast<float>(cc + 1) / (cols - 1);
-                appendDssVertex(fill, u0, v, 0.0f);   // ridge
-                appendDssVertex(fill, u0, v, 1.0f);   // plot floor
-                appendDssVertex(fill, u1, v, 0.0f);   // ridge
-                appendDssVertex(fill, u1, v, 0.0f);
-                appendDssVertex(fill, u0, v, 1.0f);
-                appendDssVertex(fill, u1, v, 1.0f);   // plot floor
-                appendDssVertex(line, u0, v, -1.0f);
-                appendDssVertex(line, u1, v, -1.0f);
+            // Base first, overlay second. The shader uses both only for the
+            // fixed front/rear crossfades; interior base vertices are discarded.
+            for (int layer = 0; layer < 2; ++layer) {
+                const float fillTag = layer == 0 ? 0.0f : 2.0f;
+                const float floorTag = layer == 0 ? 1.0f : 3.0f;
+                const float ribbonLowerTag =
+                    layer == 0 ? -10.0f : -20.0f;
+                const float ribbonUpperTag =
+                    layer == 0 ? -11.0f : -21.0f;
+                for (int cc = 0; cc + 1 < cols; ++cc) {
+                    const float u0 = static_cast<float>(cc) / (cols - 1);
+                    const float u1 = static_cast<float>(cc + 1) / (cols - 1);
+                    appendDssVertex(fill, u0, v, fillTag);
+                    appendDssVertex(fill, u0, v, floorTag);
+                    appendDssVertex(fill, u1, v, fillTag);
+                    appendDssVertex(fill, u1, v, fillTag);
+                    appendDssVertex(fill, u0, v, floorTag);
+                    appendDssVertex(fill, u1, v, floorTag);
+                    appendDssVertex(line, u0, v, ribbonLowerTag);
+                    appendDssVertex(line, u0, v, ribbonUpperTag);
+                    appendDssVertex(line, u1, v, ribbonLowerTag);
+                    appendDssVertex(line, u1, v, ribbonLowerTag);
+                    appendDssVertex(line, u0, v, ribbonUpperTag);
+                    appendDssVertex(line, u1, v, ribbonUpperTag);
+                }
             }
         }
         batch->uploadStaticBuffer(m_dssMeshVbo, fill.constData());
@@ -11900,7 +12512,21 @@ void SpectrumWidget::initialize(QRhiCommandBuffer* cb)
         QRhiTextureSubresourceUploadDescription desc(rgba);
         batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
         if (m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
-            && m_wfFrameTexReady) {
+            && m_wfFrameTexReady
+            && m_wfSupplementalGpuTex != nullptr) {
+            if (m_waterfallSupplemental.size() != m_waterfall.size()) {
+                m_waterfallSupplemental =
+                    QImage(m_waterfall.size(), QImage::Format_RGB32);
+                m_waterfallSupplemental.fill(Qt::black);
+            }
+            QImage supplementalRgba =
+                m_waterfallSupplemental.convertToFormat(
+                    QImage::Format_RGBA8888);
+            QRhiTextureSubresourceUploadDescription supplementalDesc(
+                supplementalRgba);
+            batch->uploadTexture(
+                m_wfSupplementalGpuTex,
+                QRhiTextureUploadEntry(0, 0, supplementalDesc));
             prepareWaterfallFrameUpload();
             QRhiTextureSubresourceUploadDescription frameDesc(
                 m_wfFrameUpload.constData(),
@@ -12058,15 +12684,21 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
             const bool rowPipelineWasActive =
                 m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
-                && m_wfFrameTexReady;
+                && m_wfFrameTexReady
+                && m_wfSupplementalGpuTex != nullptr;
             std::unique_ptr<QRhiTexture> frameTexture;
+            std::unique_ptr<QRhiTexture> supplementalTexture;
             std::unique_ptr<QRhiShaderResourceBindings> frameSrb;
             bool frameResizeReady = !rowPipelineWasActive;
             if (legacyResizeReady && rowPipelineWasActive) {
                 frameTexture.reset(r->newTexture(
                     QRhiTexture::RGBA32F, QSize(1, desiredHeight)));
+                supplementalTexture.reset(r->newTexture(
+                    QRhiTexture::RGBA8,
+                    QSize(desiredWidth, desiredHeight)));
                 frameResizeReady = !waterfallFrameResizeFailureForced()
-                    && frameTexture->create();
+                    && frameTexture->create()
+                    && supplementalTexture->create();
                 if (frameResizeReady) {
                     frameSrb.reset(r->newShaderResourceBindings());
                     frameSrb->setBindings({
@@ -12079,6 +12711,9 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                         QRhiShaderResourceBinding::sampledTexture(
                             2, QRhiShaderResourceBinding::FragmentStage,
                             frameTexture.get(), m_wfFrameSampler),
+                        QRhiShaderResourceBinding::sampledTexture(
+                            3, QRhiShaderResourceBinding::FragmentStage,
+                            supplementalTexture.get(), m_wfSampler),
                     });
                     frameResizeReady = frameSrb->create();
                 }
@@ -12092,6 +12727,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 QRhiTexture* oldColorTexture = m_wfGpuTex;
                 QRhiShaderResourceBindings* oldLegacySrb = m_wfSrb;
                 QRhiTexture* oldFrameTexture = m_wfFrameTex;
+                QRhiTexture* oldSupplementalTexture =
+                    m_wfSupplementalGpuTex;
                 QRhiShaderResourceBindings* oldFrameSrb = m_wfFrameSrb;
                 m_wfGpuTex = colorTexture.release();
                 m_wfSrb = legacySrb.release();
@@ -12101,9 +12738,12 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
 
                 if (rowPipelineWasActive && frameResizeReady) {
                     m_wfFrameTex = frameTexture.release();
+                    m_wfSupplementalGpuTex =
+                        supplementalTexture.release();
                     m_wfFrameSrb = frameSrb.release();
                     delete oldFrameSrb;
                     delete oldFrameTexture;
+                    delete oldSupplementalTexture;
                     m_wfFrameTexDirty = true;
                 } else if (rowPipelineWasActive) {
                     releaseWaterfallFramePipelineResources();
@@ -12121,12 +12761,29 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
         const bool waterfallTextureMatchesSource =
             m_waterfall.width() == m_wfGpuTexW
             && m_waterfall.height() == m_wfGpuTexH;
+        const bool supplementalTextureReady =
+            m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
+            && m_wfFrameTexReady
+            && m_wfSupplementalGpuTex != nullptr
+            && m_waterfallSupplemental.size() == m_waterfall.size();
         if (m_wfTexFullUpload && waterfallTextureMatchesSource) {
             // Full upload (init or resize)
             QImage rgba = m_waterfall.convertToFormat(QImage::Format_RGBA8888);
             QRhiTextureSubresourceUploadDescription desc(rgba);
             batch->uploadTexture(m_wfGpuTex, QRhiTextureUploadEntry(0, 0, desc));
             m_panStats.wfUploadBytes += static_cast<quint64>(rgba.sizeInBytes());
+            if (supplementalTextureReady) {
+                QImage supplementalRgba =
+                    m_waterfallSupplemental.convertToFormat(
+                        QImage::Format_RGBA8888);
+                QRhiTextureSubresourceUploadDescription supplementalDesc(
+                    supplementalRgba);
+                batch->uploadTexture(
+                    m_wfSupplementalGpuTex,
+                    QRhiTextureUploadEntry(0, 0, supplementalDesc));
+                m_panStats.wfUploadBytes += static_cast<quint64>(
+                    supplementalRgba.sizeInBytes());
+            }
             if (perfEnabled)
                 PerfTelemetry::instance().recordGpuUpload(PerfTelemetry::GpuUploadKind::WaterfallFull);
             m_wfLastUploadedRow = m_wfWriteRow;
@@ -12142,6 +12799,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             // Upload each dirty row individually
             QRhiTextureUploadDescription uploadDesc;
             QVector<QRhiTextureUploadEntry> entries;
+            QRhiTextureUploadDescription supplementalUploadDesc;
+            QVector<QRhiTextureUploadEntry> supplementalEntries;
 
             int row = from;
             int maxRows = texH;  // safety cap
@@ -12157,13 +12816,41 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 QRhiTextureSubresourceUploadDescription desc(rowRgba);
                 desc.setDestinationTopLeft(QPoint(0, row));
                 entries.append(QRhiTextureUploadEntry(0, 0, desc));
+                if (supplementalTextureReady) {
+                    const uchar* supplementalSrcLine =
+                        m_waterfallSupplemental.constScanLine(row);
+                    QImage supplementalRowImage(
+                        reinterpret_cast<const uchar*>(
+                            supplementalSrcLine),
+                        m_wfGpuTexW, 1,
+                        m_waterfallSupplemental.bytesPerLine(),
+                        QImage::Format_RGB32);
+                    QImage supplementalRowRgba =
+                        supplementalRowImage.convertToFormat(
+                            QImage::Format_RGBA8888);
+                    QRhiTextureSubresourceUploadDescription supplementalDesc(
+                        supplementalRowRgba);
+                    supplementalDesc.setDestinationTopLeft(QPoint(0, row));
+                    supplementalEntries.append(
+                        QRhiTextureUploadEntry(0, 0, supplementalDesc));
+                }
             }
 
             if (!entries.isEmpty()) {
                 uploadDesc.setEntries(entries.begin(), entries.end());
                 batch->uploadTexture(m_wfGpuTex, uploadDesc);
+                if (!supplementalEntries.isEmpty()) {
+                    supplementalUploadDesc.setEntries(
+                        supplementalEntries.begin(),
+                        supplementalEntries.end());
+                    batch->uploadTexture(
+                        m_wfSupplementalGpuTex,
+                        supplementalUploadDesc);
+                }
                 m_panStats.wfUploadBytes +=
-                    static_cast<quint64>(entries.size()) * m_wfGpuTexW * 4;
+                    static_cast<quint64>(
+                        entries.size() + supplementalEntries.size())
+                    * m_wfGpuTexW * 4;
                 if (perfEnabled) {
                     PerfTelemetry::instance().recordGpuUpload(
                         PerfTelemetry::GpuUploadKind::WaterfallIncremental);
@@ -12212,7 +12899,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
     const float waterfallTargetBandwidthMhz = static_cast<float>(m_bandwidthMhz);
     const float waterfallRowFrequencyFrames =
         m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
-            && m_wfFrameTexReady ? 1.0f : 0.0f;
+            && m_wfFrameTexReady
+            && m_wfSupplementalGpuTex != nullptr ? 1.0f : 0.0f;
     float uniforms[] = {
         rowOffset,
         waterfallTargetCenterOffsetMhz,
@@ -12228,21 +12916,17 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                   "buffer allocs, and the .frag Uniforms blocks");
     batch->updateDynamicBuffer(m_wfUbo, 0, sizeof(uniforms), uniforms);
 
-    // The compact 3DSS height surface still shares one preview frame across its
-    // rows, so it retains the original affine preview uniforms.
-    float frequencyScale = 1.0f;
-    float frequencyOffset = 0.0f;
-    float frequencyPreview = 0.0f;
-    const FrequencyPreviewTransform previewTransform =
-        frequencyPreviewTransform(
-            FrequencyFrame{m_frequencyPreviewBaseCenterMhz,
-                           m_frequencyPreviewBaseBandwidthMhz},
-            FrequencyFrame{m_frequencyPreviewTargetCenterMhz,
-                           m_frequencyPreviewTargetBandwidthMhz});
-    if (m_frequencyPreviewActive && previewTransform.valid) {
-        frequencyScale = static_cast<float>(previewTransform.scale);
-        frequencyOffset = static_cast<float>(previewTransform.offset);
-        frequencyPreview = 1.0f;
+    // Every DSS row carries its own capture frame, matching the waterfall.
+    // The shader maps all rows directly into this target without rebuilding or
+    // destructively reprojecting the scrolling ring during a gesture.
+    double dssTargetCenterMhz = m_centerMhz;
+    double dssTargetBandwidthMhz = m_bandwidthMhz;
+    if (m_frequencyPreviewActive
+        && std::isfinite(m_frequencyPreviewTargetCenterMhz)
+        && std::isfinite(m_frequencyPreviewTargetBandwidthMhz)
+        && m_frequencyPreviewTargetBandwidthMhz > 0.0) {
+        dssTargetCenterMhz = m_frequencyPreviewTargetCenterMhz;
+        dssTargetBandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
         ++m_frequencyPreviewPresentCount;
     }
 
@@ -12707,14 +13391,27 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     : static_cast<int>(rowsSinceUpload);
                 newRows = std::clamp(newRows, 0, valid);
                 if (newRows > kDssMaxIncrementalUploadRows) {
-                    const int rowBytes = cols * int(sizeof(qfloat16));
+                    constexpr int kChannels = 4;
+                    const int rowBytes =
+                        cols * kChannels * int(sizeof(qfloat16));
                     m_dssTextureScratch.resize(rows * rowBytes);
                     char* textureData = m_dssTextureScratch.data();
                     for (int ring = 0; ring < rows; ++ring) {
                         qfloat16* dst = reinterpret_cast<qfloat16*>(textureData + ring * rowBytes);
                         const float* srcRow = m_dss.rowDataRing(ring);
+                        const quint8* coverage = m_dss.rowCoverageRing(ring);
+                        const float* supplemental =
+                            m_dss.rowSupplementalDataRing(ring);
+                        const quint8* supplementalCoverage =
+                            m_dss.rowSupplementalCoverageRing(ring);
                         for (int c = 0; c < cols; ++c) {
-                            dst[c] = qfloat16(srcRow[c]);
+                            dst[c * kChannels] = qfloat16(srcRow[c]);
+                            dst[c * kChannels + 1] =
+                                qfloat16(coverage[c] != 0 ? 1.0f : 0.0f);
+                            dst[c * kChannels + 2] =
+                                qfloat16(supplemental[c]);
+                            dst[c * kChannels + 3] = qfloat16(
+                                supplementalCoverage[c] != 0 ? 1.0f : 0.0f);
                         }
                     }
                     QRhiTextureSubresourceUploadDescription fullDesc;
@@ -12727,13 +13424,26 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                     }
                 } else {
                     QVarLengthArray<QRhiTextureUploadEntry, kDssMaxIncrementalUploadRows> entries;
-                    m_dssRowScratch.resize(cols * int(sizeof(qfloat16)));
+                    constexpr int kChannels = 4;
+                    m_dssRowScratch.resize(
+                        cols * kChannels * int(sizeof(qfloat16)));
                     for (int n = 0; n < newRows; ++n) {
                         const int ring = (head + n) % rows;  // head..head+newRows-1
                         const float* srcRow = m_dss.rowDataRing(ring);
+                        const quint8* coverage = m_dss.rowCoverageRing(ring);
+                        const float* supplemental =
+                            m_dss.rowSupplementalDataRing(ring);
+                        const quint8* supplementalCoverage =
+                            m_dss.rowSupplementalCoverageRing(ring);
                         qfloat16* dst = reinterpret_cast<qfloat16*>(m_dssRowScratch.data());
                         for (int c = 0; c < cols; ++c) {
-                            dst[c] = qfloat16(srcRow[c]);
+                            dst[c * kChannels] = qfloat16(srcRow[c]);
+                            dst[c * kChannels + 1] =
+                                qfloat16(coverage[c] != 0 ? 1.0f : 0.0f);
+                            dst[c * kChannels + 2] =
+                                qfloat16(supplemental[c]);
+                            dst[c * kChannels + 3] = qfloat16(
+                                supplementalCoverage[c] != 0 ? 1.0f : 0.0f);
                         }
                         QRhiTextureSubresourceUploadDescription rowDesc;
                         rowDesc.setData(m_dssRowScratch);  // descriptor keeps the bytes alive
@@ -12778,11 +13488,15 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 DssRenderer::kBackWidthFrac, DssRenderer::kDepthSpanFrac,
                 DssRenderer::kFrontMaxRidgeFrac, DssRenderer::kHaze,
                 static_cast<float>(cols),
-                frequencyScale, frequencyOffset, frequencyPreview,
+                static_cast<float>(dssTargetBandwidthMhz),
+                0.0f, 1.0f,
                 dssScrollProgressRows,
                 static_cast<float>(rows), m_waterfallScrollDistanceRows,
                 std::min(rangeDb, DssRenderer::kColorSpanDb),
-                static_cast<float>(valid), 0.0f, 0.0f, 0.0f,
+                static_cast<float>(valid),
+                static_cast<float>(DssRenderer::kVisibleRows),
+                static_cast<float>(specContentW * dpr),
+                static_cast<float>(specRect.height() * dpr),
                 static_cast<float>(m_bgFillColor.redF()),
                 static_cast<float>(m_bgFillColor.greenF()),
                 static_cast<float>(m_bgFillColor.blueF()),
@@ -12804,15 +13518,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                 kShadowBandsOffset + kDssMeshShadowSlices * 4;
             constexpr int kShadowMetaOffset =
                 kShadowStylesOffset + kDssMeshShadowSlices * 4;
-            double shadowCenterMhz = m_centerMhz;
-            double shadowBandwidthMhz = m_bandwidthMhz;
-            if (m_frequencyPreviewActive
-                && std::isfinite(m_frequencyPreviewTargetCenterMhz)
-                && std::isfinite(m_frequencyPreviewTargetBandwidthMhz)
-                && m_frequencyPreviewTargetBandwidthMhz > 0.0) {
-                shadowCenterMhz = m_frequencyPreviewTargetCenterMhz;
-                shadowBandwidthMhz = m_frequencyPreviewTargetBandwidthMhz;
-            }
+            const double shadowCenterMhz = dssTargetCenterMhz;
+            const double shadowBandwidthMhz = dssTargetBandwidthMhz;
             const double shadowStartMhz =
                 shadowCenterMhz - shadowBandwidthMhz * 0.5;
             const double shadowEndMhz =
@@ -12943,9 +13650,40 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
             ubo.at(kShadowMetaOffset + 2) =
                 static_cast<float>(specContentW);
 
+            constexpr int kDssRowFramesOffset = kShadowMetaOffset + 4;
+            for (int age = 0; age < DssRenderer::kRows; ++age) {
+                double rowCenterMhz = m_dss.rowCenterMhzAtAge(age);
+                double rowBandwidthMhz = m_dss.rowBandwidthMhzAtAge(age);
+                if (!std::isfinite(rowCenterMhz)
+                    || !std::isfinite(rowBandwidthMhz)
+                    || rowCenterMhz <= 0.0 || rowBandwidthMhz <= 0.0) {
+                    rowCenterMhz = dssTargetCenterMhz;
+                    rowBandwidthMhz = dssTargetBandwidthMhz;
+                }
+                const int frameBase = kDssRowFramesOffset + age * 4;
+                ubo.at(frameBase) = static_cast<float>(
+                    rowCenterMhz - dssTargetCenterMhz);
+                ubo.at(frameBase + 1) =
+                    static_cast<float>(rowBandwidthMhz);
+                const double supplementalCenterMhz =
+                    m_dss.rowSupplementalCenterMhzAtAge(age);
+                const double supplementalBandwidthMhz =
+                    m_dss.rowSupplementalBandwidthMhzAtAge(age);
+                if (std::isfinite(supplementalCenterMhz)
+                    && std::isfinite(supplementalBandwidthMhz)
+                    && supplementalCenterMhz > 0.0
+                    && supplementalBandwidthMhz > 0.0) {
+                    ubo.at(frameBase + 2) = static_cast<float>(
+                        supplementalCenterMhz - dssTargetCenterMhz);
+                    ubo.at(frameBase + 3) =
+                        static_cast<float>(supplementalBandwidthMhz);
+                }
+            }
+
             static_assert(
-                kShadowMetaOffset + 4 == kDssMeshUboFloats,
-                "DSS shadow descriptors must fill the mesh UBO");
+                kDssRowFramesOffset + DssRenderer::kRows * 4
+                    == kDssMeshUboFloats,
+                "DSS row frames must fill the mesh UBO");
             batch->updateDynamicBuffer(
                 m_dssMeshUbo, 0, sizeof(ubo), ubo.data());
         } else if (is3D) {
@@ -13117,7 +13855,8 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
     // 3DSS replaces only the spectrum trace, the waterfall stays below it.
     const bool useRowFrequencyPipeline =
         m_wfPipelineMode == WaterfallPipelineMode::RowFrequencyFrames
-        && m_wfFramePipeline && m_wfFrameSrb && m_wfFrameTexReady;
+        && m_wfFramePipeline && m_wfFrameSrb && m_wfFrameTexReady
+        && m_wfSupplementalGpuTex != nullptr;
     QRhiGraphicsPipeline* waterfallPipeline = useRowFrequencyPipeline
         ? m_wfFramePipeline : m_wfPipeline;
     QRhiShaderResourceBindings* waterfallSrb = useRowFrequencyPipeline
@@ -13162,12 +13901,13 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb,
                               static_cast<float>(h - specRect.bottom() - 1) * dpr,
                               static_cast<float>(specContentW) * dpr,
                               static_cast<float>(specRect.height()) * dpr);
-        const int drawnRows = m_dss.rowCount();
+        const int drawnRows = m_dss.visibleRowCount();
 
         if (drawnRows > 0) {
-            // Original full-height curtains, now on a fixed perspective grid
-            // with interpolated row data. Draw back-to-front for occlusion.
-            const int skippedRows = m_dss.rows() - drawnRows;
+            // Draw back-to-front: exact interior rows move through depth, while
+            // the first and last rows remain fixed old/new crossfades.
+            const int skippedRows =
+                DssRenderer::kVisibleRows - drawnRows;
             cb->setGraphicsPipeline(m_dssMeshFillPipeline);
             cb->setShaderResources(m_dssMeshSrb);
             cb->setViewport(vp);
@@ -15064,9 +15804,9 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
         frequencyPreview = true;
     }
 
-    const int rows = m_dss.rows();
+    const int rows = DssRenderer::kVisibleRows;
     const int cols = m_dss.cols();
-    const int validRows = m_dss.rowCount();
+    const int validRows = m_dss.visibleRowCount();
     const int headRing = m_dss.headRing();
 
     // This geometry is only ever drawn over the CACHED surface image, which
@@ -15098,7 +15838,7 @@ SpectrumWidget::buildDssDepthGeometry(const QRect& specRect,
         if (age < 0 || age >= validRows) {
             return floorDbm;
         }
-        const int ring = (headRing + age) % rows;
+        const int ring = (headRing + age) % m_dss.rows();
         const float value = m_dss.rowDataRing(ring)[column];
         return std::isfinite(value) ? value : floorDbm;
     };

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -914,16 +914,22 @@ private:
     void finishFrequencyRangeSettleUpdate();
     struct WaterfallStreamState {
         QImage waterfall;
+        QImage waterfallSupplemental;
         int wfWriteRow{0};
         QVector<double> visibleRowCenterMhz;
         QVector<double> visibleRowBwMhz;
+        QVector<double> visibleSupplementalCenterMhz;
+        QVector<double> visibleSupplementalBwMhz;
         WaterfallHistoryBuffer waterfallHistory;
+        WaterfallHistoryBuffer waterfallSupplementalHistory;
         QVector<qint64> historyTimestamps;
         int historyWriteRow{0};
         int historyRowCount{0};
         int historyOffsetRows{0};
         QVector<double> historyRowCenterMhz;
         QVector<double> historyRowBwMhz;
+        QVector<double> historySupplementalCenterMhz;
+        QVector<double> historySupplementalBwMhz;
         bool live{true};
         int rowsSinceRateChange{0};
         QVector<quint8> prevTileLevels;
@@ -961,20 +967,36 @@ private:
     const WaterfallStreamState* activeKiwiWaterfallStateConst() const;
     bool beginWaterfallStreamWrite(bool kiwiStream);
     void endWaterfallStreamWrite(bool kiwiStream, bool visibleStream);
-    void appendHistoryRow(const quint8* intensityData, qint64 timestampMs,
-                          double frameCenterMhz = -1.0,
-                          double frameBandwidthMhz = -1.0);
+    void appendHistoryRow(
+        const quint8* intensityData,
+        qint64 timestampMs,
+        double frameCenterMhz = -1.0,
+        double frameBandwidthMhz = -1.0,
+        const quint8* supplementalIntensityData = nullptr,
+        double supplementalCenterMhz = -1.0,
+        double supplementalBandwidthMhz = -1.0);
     void appendDssHistoryRow(const QVector<float>& binsDbm,
                              double frameCenterMhz = -1.0,
                              double frameBandwidthMhz = -1.0);
     void appendDssWaterfallRow(const QVector<float>& binsDbm,
                                double frameCenterMhz = -1.0,
                                double frameBandwidthMhz = -1.0,
-                               bool updateLiveSurface = true);
+                               bool updateLiveSurface = true,
+                               const QVector<float>& supplementalBinsDbm = {},
+                               double supplementalCenterMhz = -1.0,
+                               double supplementalBandwidthMhz = -1.0);
     void appendLatestDssWaterfallRow(double frameCenterMhz = -1.0,
                                      double frameBandwidthMhz = -1.0);
+    void appendNativeDssWaterfallRow(
+        const QVector<float>& tileIntensity,
+        double tileLowMhz,
+        double tileHighMhz);
     void pushDssLiveRow(DssRenderer& dss, const QVector<float>& binsDbm,
-                        bool hiddenStream);
+                        bool hiddenStream, double frameCenterMhz,
+                        double frameBandwidthMhz,
+                        const QVector<float>& supplementalBinsDbm = {},
+                        double supplementalCenterMhz = -1.0,
+                        double supplementalBandwidthMhz = -1.0);
     void retainDssHistoryRow(DssRenderer& dss, const QVector<float>& binsDbm,
                              double centerMhz, double bandwidthMhz,
                              float fallbackDbm);
@@ -990,10 +1012,14 @@ private:
     // startScrollAnimation: begin the one-row scroll interpolation. Multi-row
     // callers (updateWaterfallRow) pass false and issue a single start() for the
     // whole tile instead of restarting the clock once per appended row.
-    void appendVisibleRow(const QRgb* rowData,
-                          double frameCenterMhz = -1.0,
-                          double frameBandwidthMhz = -1.0,
-                          bool startScrollAnimation = true);
+    void appendVisibleRow(
+        const QRgb* rowData,
+        double frameCenterMhz = -1.0,
+        double frameBandwidthMhz = -1.0,
+        bool startScrollAnimation = true,
+        const QRgb* supplementalRowData = nullptr,
+        double supplementalCenterMhz = -1.0,
+        double supplementalBandwidthMhz = -1.0);
     int waterfallHistoryCapacityRows() const;
     int maxWaterfallHistoryOffsetRows() const;
     int historyRowIndexForAge(int ageRows) const;
@@ -1353,6 +1379,10 @@ private:
 
     // Scrolling waterfall image (Format_RGB32)
     QImage m_waterfall;
+    // Same ring topology as m_waterfall. Native FLEX tiles are rasterized over
+    // their full (wider) frequency frame here; the primary viewport row wins
+    // wherever it has coverage.
+    QImage m_waterfallSupplemental;
     int    m_wfWriteRow{0};  // ring buffer: next row to write (newest at top)
     // A received row appears immediately, then the viewport advances it by one
     // row over the observed row interval. This changes display position only;
@@ -1365,7 +1395,10 @@ private:
     // flattening the entire live texture into one pan/zoom frame.
     QVector<double> m_wfVisibleRowCenterMhz;
     QVector<double> m_wfVisibleRowBwMhz;
+    QVector<double> m_wfVisibleSupplementalCenterMhz;
+    QVector<double> m_wfVisibleSupplementalBwMhz;
     WaterfallHistoryBuffer m_waterfallHistory;
+    WaterfallHistoryBuffer m_waterfallSupplementalHistory;
     QTimer* m_resizeBufferSettleTimer{nullptr};
     quint64 m_resizeEventCount{0};
     quint64 m_resizeBufferCommitCount{0};
@@ -1386,6 +1419,8 @@ private:
     // image. rebuildWaterfallViewport remaps and colorizes only visible rows.
     QVector<double> m_wfHistoryRowCenterMhz;
     QVector<double> m_wfHistoryRowBwMhz;
+    QVector<double> m_wfHistorySupplementalCenterMhz;
+    QVector<double> m_wfHistorySupplementalBwMhz;
     bool   m_wfLive{true};
     bool   m_draggingTimeScale{false};
     bool   m_draggingTimeScaleRate{false};
@@ -1750,7 +1785,8 @@ private:
     QRhiBuffer* m_wfVbo{nullptr};
     QRhiBuffer* m_wfUbo{nullptr};
     QRhiTexture* m_wfGpuTex{nullptr};
-    QRhiTexture* m_wfFrameTex{nullptr};     // 1 x rows RGBA32F: center offset + bandwidth
+    QRhiTexture* m_wfSupplementalGpuTex{nullptr};
+    QRhiTexture* m_wfFrameTex{nullptr}; // RGBA32F: primary center/bw + supplemental center/bw
     QRhiSampler* m_wfSampler{nullptr};
     QRhiSampler* m_wfFrameSampler{nullptr};
     int m_wfGpuTexW{0};
@@ -1809,21 +1845,24 @@ private:
     int m_dssTexH{0};
 
     // 3DSS GPU height-map mesh (preferred path). The DssRenderer ring store
-    // feeds a ring-buffered R16F height texture; a static perspective grid samples
-    // it in dss_mesh.vert. Geometry never rebuilds, so pan/zoom are free. Falls
-    // back to the cached-image quad above when the pipeline can't be created.
+    // feeds a ring-buffered RGBA16F dBm + frequency-coverage texture; a static
+    // perspective grid samples it in dss_mesh.vert. Geometry never rebuilds,
+    // so pan/zoom are free. Falls back to the cached-image quad above when the
+    // pipeline can't be created.
     QRhiGraphicsPipeline* m_dssMeshFillPipeline{nullptr};  // Triangles, opaque
-    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // Lines, alpha (outline)
+    QRhiGraphicsPipeline* m_dssMeshLinePipeline{nullptr};  // AA ribbon triangles
     QRhiShaderResourceBindings* m_dssMeshSrb{nullptr};
     QRhiBuffer* m_dssMeshVbo{nullptr};       // batched curtain triangles, static
-    QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge line segments, static
+    QRhiBuffer* m_dssMeshLineVbo{nullptr};   // batched ridge ribbons, static
     QRhiBuffer* m_dssMeshUbo{nullptr};       // dynamic uniforms
     // std140 UBO float count — must match dss_mesh.{vert,frag}'s U block AND the
     // ubo writer in renderGpuFrame(): five scalar vec4 groups + bgFill, eight
-    // slice band descriptors, eight slice styles, and shadow metadata.
-    static constexpr int kDssMeshUboFloats = 92;
+    // slice band descriptors, eight slice styles, shadow metadata, and one
+    // frequency-frame vec4 for every live-ring age.
+    static constexpr int kDssMeshUboFloats =
+        92 + DssRenderer::kRows * 4;
     static constexpr int kDssMeshShadowSlices = 8;
-    QRhiTexture* m_dssHeightTex{nullptr};    // R16F ring heightmap (cols x rows)
+    QRhiTexture* m_dssHeightTex{nullptr};    // RGBA16F dBm + coverage ring
     QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT
     QRhiSampler* m_dssHeightSampler{nullptr};
     QRhiSampler* m_dssPaletteSampler{nullptr};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -990,10 +990,10 @@ private:
                                double supplementalBandwidthMhz = -1.0);
     void appendLatestDssWaterfallRow(double frameCenterMhz = -1.0,
                                      double frameBandwidthMhz = -1.0);
-    void appendNativeDssWaterfallRow(
+    QVector<float> buildNativeDssSupplementalRow(
         const QVector<float>& tileIntensity,
         double tileLowMhz,
-        double tileHighMhz);
+        double tileHighMhz) const;
     void pushDssLiveRow(DssRenderer& dss, const QVector<float>& binsDbm,
                         bool hiddenStream, double frameCenterMhz,
                         double frameBandwidthMhz,
@@ -1070,8 +1070,8 @@ private:
     void armNoiseFloorFastLock(int freshFrames, int snapFrames);
     void moveRefLevelToward(float targetRef, qint64 nowMs);
     void sendNoiseFloorRangeCommand(qint64 nowMs, bool force);
-    bool flexDssInputFloorLooksClipped() const;
-    bool requestFlexDssRadioHeadroom(qint64 nowMs);
+    bool flexInputFloorLooksClipped() const;
+    bool requestFlexRadioHeadroom(qint64 nowMs);
     void beginDbmRangeTransition(float oldMinDbm, float oldMaxDbm,
                                  float newMinDbm, float newMaxDbm);
     void clearDbmReleaseRebase();
@@ -1867,6 +1867,10 @@ private:
     // frequency-frame vec4 for every live-ring age.
     static constexpr int kDssMeshUboFloats =
         92 + DssRenderer::kRows * 4;
+    static_assert(
+        DssRenderer::kRows == 104,
+        "dss_mesh.{vert,frag} declare rowFrames[104] and clamp frame ages "
+        "at 103; update both shaders with DssRenderer::kRows");
     static constexpr int kDssMeshShadowSlices = 8;
     QRhiTexture* m_dssHeightTex{nullptr};    // RGBA16F dBm + coverage ring
     QRhiTexture* m_dssPaletteTex{nullptr};   // 256x1 RGBA8 floor->peak LUT

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -739,6 +739,9 @@ signals:
     // Emitted when the user adjusts the dBm scale (drag or arrows).
     void dbmRangeChangeRequested(float minDbm, float maxDbm);
     void dbmRangeDragFinished(float minDbm, float maxDbm);
+    // The radio FFT encoder is pinned to its lower endpoint. Request more
+    // radio-side headroom without moving the client-side 3D presentation.
+    void radioDbmHeadroomRecoveryRequested(float headroomDb);
     void noiseFloorPositionResolved(int pos);
     void dssFloorDepthResolved(int dB);
     void waterfallLineDurationChangeRequested(int ms);
@@ -1067,6 +1070,8 @@ private:
     void armNoiseFloorFastLock(int freshFrames, int snapFrames);
     void moveRefLevelToward(float targetRef, qint64 nowMs);
     void sendNoiseFloorRangeCommand(qint64 nowMs, bool force);
+    bool flexDssInputFloorLooksClipped() const;
+    bool requestFlexDssRadioHeadroom(qint64 nowMs);
     void beginDbmRangeTransition(float oldMinDbm, float oldMaxDbm,
                                  float newMinDbm, float newMaxDbm);
     void clearDbmReleaseRebase();
@@ -1356,6 +1361,7 @@ private:
     // ~100-300 ms to switch bandwidth; frames before this still carry the
     // pre-zoom encoding.
     qint64 m_dssZoomFloorSyncNotBeforeMs{0};
+    qint64 m_lastDssRadioHeadroomRequestMs{0};
     // The radio can briefly deliver FFT packets encoded with the old y_pixels
     // after acknowledging a new height. Keep those rows out of retained 3D
     // history; the live 2D trace and waterfall continue normally.

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -132,6 +132,56 @@ int testSupplementalCoverageDoesNotReplaceFft()
     return 0;
 }
 
+int testSupplementalCoverageRejectsTransientSpikes()
+{
+    DssRenderer renderer;
+    QVector<float> fft(DssRenderer::kCols, -95.0f);
+    QVector<float> supplemental(DssRenderer::kCols, -110.0f);
+    for (int row = 0; row < 2; ++row) {
+        renderer.pushRowWithSupplemental(
+            fft, 14.2, 0.2,
+            supplemental, 14.2, 0.4);
+    }
+
+    QVector<float> transient = supplemental;
+    const int center = DssRenderer::kCols / 2;
+    transient[center] = -20.0f;
+    renderer.pushRowWithSupplemental(
+        fft, 14.2, 0.2,
+        transient, 14.2, 0.4);
+    if (std::abs(
+            renderer.rowSupplementalDataRing(renderer.headRing())[center]
+            - (-110.0f))
+        > 0.1f) {
+        return fail(
+            "supplemental DSS coverage must reject one-row tile spikes");
+    }
+
+    // A real carrier that persists for a second row must still emerge; the
+    // filter rejects isolated maxima rather than flattening supplemental data.
+    renderer.pushRowWithSupplemental(
+        fft, 14.2, 0.2,
+        transient, 14.2, 0.4);
+    if (renderer.rowSupplementalDataRing(renderer.headRing())[center]
+        <= -100.0f) {
+        return fail(
+            "persistent supplemental DSS peaks must survive spike rejection");
+    }
+
+    QVector<float> newFrame(DssRenderer::kCols, -75.0f);
+    renderer.pushRowWithSupplemental(
+        fft, 14.2, 0.2,
+        newFrame, 14.5, 0.6);
+    if (std::abs(
+            renderer.rowSupplementalDataRing(renderer.headRing())[center]
+            - (-75.0f))
+        > 0.1f) {
+        return fail(
+            "supplemental DSS frame changes must break temporal smoothing");
+    }
+    return 0;
+}
+
 int testRetainedHistoryZoomRoundTrip()
 {
     DssRenderer renderer;
@@ -609,6 +659,9 @@ int main()
         return rc;
     }
     if (int rc = testSupplementalCoverageDoesNotReplaceFft(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testSupplementalCoverageRejectsTransientSpikes(); rc != 0) {
         return rc;
     }
     if (int rc = testRetainedHistoryZoomRoundTrip(); rc != 0) {

--- a/tests/dss_renderer_test.cpp
+++ b/tests/dss_renderer_test.cpp
@@ -47,7 +47,11 @@ int testFrequencyReprojection()
     DssRenderer renderer;
     QVector<float> bins(DssRenderer::kCols, -100.0f);
     bins[DssRenderer::kCols / 2] = -40.0f;
-    renderer.pushRow(bins);
+    renderer.pushRow(bins, 14.0, 1.0);
+    if (std::abs(renderer.rowCenterMhzAtAge(0) - 14.0) > 1.0e-9
+        || std::abs(renderer.rowBandwidthMhzAtAge(0) - 1.0) > 1.0e-9) {
+        return fail("live DSS row must retain its capture frame");
+    }
 
     const int beforeCount = renderer.rowCount();
     const quint64 beforeGeneration = renderer.rowGeneration();
@@ -68,7 +72,149 @@ int testFrequencyReprojection()
     if (std::abs(actualBin - expectedBin) > 3) {
         return fail("frequency reprojection should shift history into the new viewport");
     }
+    if (std::abs(renderer.rowCenterMhzAtAge(0) - 14.25) > 1.0e-9
+        || std::abs(renderer.rowBandwidthMhzAtAge(0) - 1.0) > 1.0e-9) {
+        return fail("reprojected DSS row must adopt its destination frame");
+    }
 
+    QVector<float> newFrame(DssRenderer::kCols, -72.0f);
+    renderer.pushRow(newFrame, 14.5, 1.0);
+    if (std::abs(
+            renderer.rowDataRing(renderer.headRing())[DssRenderer::kCols - 1]
+            - newFrame[0]) > 0.1f) {
+        return fail("direct DSS reprojection must break the old temporal frame");
+    }
+    if (std::abs(renderer.rowCenterMhzAtAge(0) - 14.5) > 1.0e-9
+        || std::abs(renderer.rowCenterMhzAtAge(1) - 14.25) > 1.0e-9) {
+        return fail("adjacent DSS rows must keep independent capture frames");
+    }
+
+    return 0;
+}
+
+int testSupplementalCoverageDoesNotReplaceFft()
+{
+    DssRenderer renderer;
+    DssRenderer baseline;
+    QVector<float> fft(DssRenderer::kCols, -95.0f);
+    fft[DssRenderer::kCols / 2] = -35.0f;
+    QVector<float> supplemental(DssRenderer::kCols, -70.0f);
+    baseline.pushRow(fft, 14.2, 0.2);
+    renderer.pushRowWithSupplemental(
+        fft, 14.2, 0.2,
+        supplemental, 14.2, 0.4);
+
+    const int ring = renderer.headRing();
+    const int baselineRing = baseline.headRing();
+    for (int column = 0; column < DssRenderer::kCols; ++column) {
+        if (std::abs(
+                renderer.rowDataRing(ring)[column]
+                - baseline.rowDataRing(baselineRing)[column])
+            > 0.001f) {
+            return fail("supplemental coverage must not replace exact FFT bins");
+        }
+    }
+    if (strongestBin(renderer) != strongestBin(baseline)) {
+        return fail("supplemental coverage must not replace exact FFT bins");
+    }
+    if (std::abs(
+            renderer.rowSupplementalDataRing(ring)[0] - (-70.0f))
+        > 0.1f
+        || renderer.rowSupplementalCoverageRing(ring)[0] == 0) {
+        return fail("supplemental coverage should be retained in separate channels");
+    }
+    if (std::abs(renderer.rowSupplementalCenterMhzAtAge(0) - 14.2)
+            > 1.0e-9
+        || std::abs(renderer.rowSupplementalBandwidthMhzAtAge(0) - 0.4)
+            > 1.0e-9) {
+        return fail("supplemental coverage must retain its wider frequency frame");
+    }
+    return 0;
+}
+
+int testRetainedHistoryZoomRoundTrip()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(8);
+
+    QVector<float> bins(DssRenderer::kCols, -120.0f);
+    for (int i = 208; i < 304; ++i) {
+        bins[i] = -65.0f + static_cast<float>(i % 11);
+    }
+    for (int i = 0; i < 6; ++i) {
+        renderer.pushRow(bins);
+        renderer.appendHistoryRow(bins, 14.0, 1.0, -200.0f);
+    }
+
+    std::array<float, DssRenderer::kCols> before{};
+    const float* beforeRow = renderer.rowDataRing(renderer.headRing());
+    std::copy_n(beforeRow, DssRenderer::kCols, before.begin());
+    const int headBefore = renderer.headRing();
+    const int countBefore = renderer.rowCount();
+
+    // A direct compact-ring round trip is lossy: the 1 MHz source is reduced
+    // to only a few columns in the 100 MHz view, then those columns are
+    // magnified on the way back. Frame-stamped retained rows must remain the
+    // source for both remaps so the original trace returns intact without
+    // resetting the live ring or interrupting its scrolling phase.
+    renderer.reprojectFrequencyFrame(
+        14.0, 1.0, 14.0, 100.0, -200.0f, true);
+    if (renderer.headRing() != headBefore || renderer.rowCount() != countBefore) {
+        return fail("DSS zoom must preserve the live ring and scrolling phase");
+    }
+    const float* wideRow = renderer.rowDataRing(renderer.headRing());
+    const quint8* wideCoverage =
+        renderer.rowCoverageRing(renderer.headRing());
+    if (wideCoverage[0] != 0
+        || wideCoverage[DssRenderer::kCols - 1] != 0
+        || wideCoverage[DssRenderer::kCols / 2] == 0
+        || std::abs(wideRow[0] - (-200.0f)) > 0.1f
+        || std::abs(wideRow[DssRenderer::kCols - 1] - (-200.0f)) > 0.1f) {
+        return fail("DSS zoom gaps must retain visible floor samples with an "
+                    "independent uncovered marker");
+    }
+    renderer.reprojectFrequencyFrame(
+        14.0, 100.0, 14.0, 1.0, -200.0f, true);
+
+    const float* afterRow = renderer.rowDataRing(renderer.headRing());
+    const quint8* afterCoverage =
+        renderer.rowCoverageRing(renderer.headRing());
+    for (int i = 0; i < DssRenderer::kCols; ++i) {
+        if (std::abs(afterRow[i] - before[i]) > 0.1f) {
+            return fail("retained DSS history must survive an extreme zoom round trip");
+        }
+        if (afterCoverage[i] == 0) {
+            return fail("retained DSS coverage must return after a zoom round trip");
+        }
+    }
+
+    QVector<float> newFrame(DssRenderer::kCols, -74.0f);
+    renderer.pushRow(newFrame);
+    const float* firstNewRow = renderer.rowDataRing(renderer.headRing());
+    if (std::abs(firstNewRow[0] - newFrame[0]) > 0.1f) {
+        return fail("first post-zoom DSS row must not blend with the old frequency frame");
+    }
+
+    return 0;
+}
+
+int testRetainedHistoryFrameChangeBreaksTemporalBlend()
+{
+    DssRenderer renderer;
+    renderer.setHistoryCapacityRows(8);
+
+    QVector<float> strong(DssRenderer::kCols, -40.0f);
+    for (int i = 0; i < 4; ++i) {
+        renderer.appendHistoryRow(strong, 14.0, 1.0, -200.0f);
+    }
+    QVector<float> quiet(DssRenderer::kCols, -120.0f);
+    renderer.appendHistoryRow(quiet, 14.0, 0.1, -200.0f);
+    renderer.rebuildVisibleFromHistory(0, 14.0, 0.1, -200.0f);
+
+    const float* row = renderer.rowDataRing(renderer.headRing());
+    if (std::abs(row[DssRenderer::kCols / 2] - quiet[0]) > 0.1f) {
+        return fail("retained DSS smoothing must stop across a frequency-frame change");
+    }
     return 0;
 }
 
@@ -460,6 +606,15 @@ int testSurfaceProjection()
 int main()
 {
     if (int rc = testFrequencyReprojection(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testSupplementalCoverageDoesNotReplaceFft(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRetainedHistoryZoomRoundTrip(); rc != 0) {
+        return rc;
+    }
+    if (int rc = testRetainedHistoryFrameChangeBreaksTemporalBlend(); rc != 0) {
         return rc;
     }
     if (int rc = testRetainedHistoryOffset(); rc != 0) {

--- a/tests/panadapter_dbm_range_test.cpp
+++ b/tests/panadapter_dbm_range_test.cpp
@@ -26,8 +26,11 @@ int main(int argc, char** argv)
     CHECK(fragmentCoverage.markRange(0, 4));
     CHECK(fragmentCoverage.uniqueBins() == 4);
     CHECK(!fragmentCoverage.isComplete());
-    CHECK(fragmentCoverage.markRange(0, 4));
+    CHECK(!fragmentCoverage.markRange(0, 4));
     CHECK(fragmentCoverage.uniqueBins() == 4);
+    CHECK(!fragmentCoverage.isComplete());
+    CHECK(fragmentCoverage.markRange(2, 4));
+    CHECK(fragmentCoverage.uniqueBins() == 6);
     CHECK(!fragmentCoverage.isComplete());
     CHECK(fragmentCoverage.markRange(4, 4));
     CHECK(fragmentCoverage.uniqueBins() == 8);
@@ -56,6 +59,23 @@ int main(int argc, char** argv)
     CHECK(!hasZeroFilledFftGrowthSuffix(saturatedFrame, 16));
     CHECK(!hasZeroFilledFftGrowthSuffix(zeroFilledGrowth, 0));
     CHECK(!hasZeroFilledFftGrowthSuffix(zeroFilledGrowth, 32));
+
+    FftGrowthSuffixGuard growthGuard;
+    for (int frame = 0;
+         frame < FftGrowthSuffixGuard::kRejectedFramesBeforeFloorFallback;
+         ++frame) {
+        CHECK(growthGuard.observe(true, 32)
+              == FftGrowthSuffixAction::Reject);
+    }
+    CHECK(growthGuard.observe(true, 32)
+          == FftGrowthSuffixAction::EmitWithFloorSuffix);
+    CHECK(growthGuard.consecutiveRejectedFrames() == 4);
+    CHECK(growthGuard.observe(false, 32)
+          == FftGrowthSuffixAction::Accept);
+    CHECK(growthGuard.consecutiveRejectedFrames() == 0);
+    CHECK(growthGuard.observe(true, 48)
+          == FftGrowthSuffixAction::Reject);
+    CHECK(growthGuard.consecutiveRejectedFrames() == 1);
 
     PanadapterStream stream;
     constexpr quint32 kStreamId = 0x40000000;

--- a/tests/panadapter_dbm_range_test.cpp
+++ b/tests/panadapter_dbm_range_test.cpp
@@ -1,4 +1,5 @@
 #include "core/PanadapterStream.h"
+#include "core/VitaBinCoverage.h"
 #include "gui/DbmRangeTransition.h"
 
 #include <QCoreApplication>
@@ -19,6 +20,43 @@ static int g_failures = 0;
 int main(int argc, char** argv)
 {
     QCoreApplication app(argc, argv);
+
+    VitaBinCoverage fragmentCoverage;
+    fragmentCoverage.reset(8);
+    CHECK(fragmentCoverage.markRange(0, 4));
+    CHECK(fragmentCoverage.uniqueBins() == 4);
+    CHECK(!fragmentCoverage.isComplete());
+    CHECK(fragmentCoverage.markRange(0, 4));
+    CHECK(fragmentCoverage.uniqueBins() == 4);
+    CHECK(!fragmentCoverage.isComplete());
+    CHECK(fragmentCoverage.markRange(4, 4));
+    CHECK(fragmentCoverage.uniqueBins() == 8);
+    CHECK(fragmentCoverage.isComplete());
+    fragmentCoverage.reset(10);
+    CHECK(fragmentCoverage.uniqueBins() == 0);
+    CHECK(fragmentCoverage.totalBins() == 10);
+    CHECK(!fragmentCoverage.isComplete());
+    CHECK(!fragmentCoverage.markRange(8, 4));
+
+    CHECK(boundedVitaPayloadBinCount(256, 2, 512) == 256);
+    CHECK(boundedVitaPayloadBinCount(256, 2, 510) == 255);
+    CHECK(boundedVitaPayloadBinCount(256, 2, 1) == 0);
+    CHECK(boundedVitaPayloadBinCount(256, 0, 512) == 0);
+
+    QVector<quint16> cleanGrowth(16, 300);
+    cleanGrowth.resize(32, 350);
+    CHECK(!hasZeroFilledFftGrowthSuffix(cleanGrowth, 16));
+
+    QVector<quint16> zeroFilledGrowth(32, 300);
+    std::fill(zeroFilledGrowth.begin() + 16,
+              zeroFilledGrowth.end(), quint16{0});
+    CHECK(hasZeroFilledFftGrowthSuffix(zeroFilledGrowth, 16));
+
+    QVector<quint16> saturatedFrame(32, 0);
+    CHECK(!hasZeroFilledFftGrowthSuffix(saturatedFrame, 16));
+    CHECK(!hasZeroFilledFftGrowthSuffix(zeroFilledGrowth, 0));
+    CHECK(!hasZeroFilledFftGrowthSuffix(zeroFilledGrowth, 32));
+
     PanadapterStream stream;
     constexpr quint32 kStreamId = 0x40000000;
 
@@ -199,6 +237,11 @@ int main(int argc, char** argv)
     CHECK(std::abs(clippedRecoveryRange.maxDbm - -21.5f) < 0.01f);
     CHECK(std::abs((clippedRecoveryRange.maxDbm
                     - clippedRecoveryRange.minDbm) - 95.0f) < 0.01f);
+    const DbmRangeTransition::Range oneShotRecoveryRange =
+        DbmRangeTransition::clippedFloorRecoveryRange(
+            -111.0f, -16.0f, 24.0f);
+    CHECK(std::abs(oneShotRecoveryRange.minDbm - -135.0f) < 0.01f);
+    CHECK(std::abs(oneShotRecoveryRange.maxDbm - -40.0f) < 0.01f);
 
     const DbmRangeTransition::Range flex2dRange =
         DbmRangeTransition::manualRequestRange(

--- a/tests/panadapter_dbm_range_test.cpp
+++ b/tests/panadapter_dbm_range_test.cpp
@@ -191,6 +191,15 @@ int main(int argc, char** argv)
     CHECK(!DbmRangeTransition::materiallyDifferent(
         movedFloorRange, {-123.48f, -113.48f}));
 
+    // A clipped frame cannot estimate the real floor. Recovery must add
+    // headroom while preserving the radio encoder span, then verify again.
+    const DbmRangeTransition::Range clippedRecoveryRange =
+        DbmRangeTransition::clippedFloorRecoveryRange(-110.5f, -15.5f);
+    CHECK(std::abs(clippedRecoveryRange.minDbm - -116.5f) < 0.01f);
+    CHECK(std::abs(clippedRecoveryRange.maxDbm - -21.5f) < 0.01f);
+    CHECK(std::abs((clippedRecoveryRange.maxDbm
+                    - clippedRecoveryRange.minDbm) - 95.0f) < 0.01f);
+
     const DbmRangeTransition::Range flex2dRange =
         DbmRangeTransition::manualRequestRange(
             -180.0f, -135.0f, false, -140.0f, 45.0f);

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -1,9 +1,11 @@
 #include "gui/SpectrumPreviewLogic.h"
+#include "gui/DssSupplementalCoverage.h"
 
 #include <array>
 #include <cmath>
 #include <cstdio>
 #include <limits>
+#include <vector>
 
 namespace {
 
@@ -61,6 +63,12 @@ int testFrequencyFrameMapping()
     if (sourceUnitPosition(1.0, source, FrequencyFrame{14.2, 0.2}) <= 1.0) {
         return fail("newly exposed frequency should map outside the retained frame");
     }
+    const FrequencyFrame panTarget{14.05, 0.2};
+    if (!nearlyEqual(sourceUnitPosition(0.5, source, panTarget), 0.75)
+        || !nearlyEqual(
+            sourceUnitPosition(0.5, panTarget, panTarget), 0.5)) {
+        return fail("old and newly captured DSS rows must map independently");
+    }
 
     const FrequencyFrame vhfBase{146.520000, 0.005};
     const FrequencyFrame vhfTarget{146.520375, 0.0025};
@@ -84,6 +92,55 @@ int testFrequencyFrameMapping()
         || FrequencyFrame{14.0, std::numeric_limits<double>::infinity()}
                .isValid()) {
         return fail("non-finite frequency frames should be rejected");
+    }
+    return 0;
+}
+
+int testUntaggedDssFrameResolution()
+{
+    using namespace AetherSDR;
+    const FrequencyFrame requested{7.15, 0.1};
+    const FrequencyFrame current{14.1, 0.2};
+    const FrequencyFrame previewBase{14.1, 3.2};
+    const FrequencyFrame zoomTarget{14.1, 0.2};
+    const FrequencyFrame panTarget{14.2, 3.2};
+
+    const FrequencyFrame explicitFrame = resolvedUntaggedDssFrame(
+        requested, current, previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, zoomTarget, true));
+    if (!nearlyEqual(explicitFrame.centerMhz, requested.centerMhz)
+        || !nearlyEqual(explicitFrame.bandwidthMhz,
+                        requested.bandwidthMhz)) {
+        return fail("explicit DSS row frame must remain authoritative");
+    }
+
+    const FrequencyFrame previewFrame = resolvedUntaggedDssFrame(
+        FrequencyFrame{}, current, previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, zoomTarget, true));
+    if (!nearlyEqual(previewFrame.centerMhz, previewBase.centerMhz)
+        || !nearlyEqual(previewFrame.bandwidthMhz,
+                        previewBase.bandwidthMhz)) {
+        return fail("untagged native preview row must retain the base frame");
+    }
+
+    const FrequencyFrame panningFrame = resolvedUntaggedDssFrame(
+        FrequencyFrame{}, current, previewBase,
+        dssUntaggedRowUsesPreviewBase(
+            previewBase, panTarget, true));
+    if (!nearlyEqual(panningFrame.centerMhz, current.centerMhz)
+        || !nearlyEqual(panningFrame.bandwidthMhz,
+                        current.bandwidthMhz)) {
+        return fail("untagged DSS pan row must use the current frame");
+    }
+
+    const FrequencyFrame settledFrame = resolvedUntaggedDssFrame(
+        FrequencyFrame{}, current, previewBase, false);
+    if (!nearlyEqual(settledFrame.centerMhz, current.centerMhz)
+        || !nearlyEqual(settledFrame.bandwidthMhz,
+                        current.bandwidthMhz)) {
+        return fail("settled untagged DSS row must use the current frame");
     }
     return 0;
 }
@@ -157,12 +214,20 @@ int testDssZoomFloorSyncGate()
     gate.noteBandwidthChange();
     gate.settle(true);
     if (gate.bandwidthChangeQueued() || !gate.waitingForFreshFrame()
-        || gate.consumeFreshFrame(false)
-        || !gate.waitingForFreshFrame()) {
+        || gate.consumeFreshFrame(false)) {
         return fail("coalesced 3D zoom must wait for a usable FFT frame");
     }
+    if (!gate.beginAdjustment(2)
+        || gate.adjustmentAttempts() != 1
+        || !gate.waitingForFreshFrame()
+        || !gate.beginAdjustment(2)
+        || gate.beginAdjustment(2)
+        || gate.adjustmentAttempts() != 2) {
+        return fail("3D zoom range adjustments should be bounded and keep the gate armed");
+    }
     if (!gate.consumeFreshFrame(true) || gate.waitingForFreshFrame()
-        || gate.consumeFreshFrame(true)) {
+        || gate.consumeFreshFrame(true)
+        || gate.adjustmentAttempts() != 0) {
         return fail("only the first usable post-zoom FFT frame may resynchronize");
     }
 
@@ -175,6 +240,18 @@ int testDssZoomFloorSyncGate()
     gate.clear();
     if (gate.bandwidthChangeQueued() || gate.waitingForFreshFrame()) {
         return fail("3D zoom floor synchronization should clear completely");
+    }
+    return 0;
+}
+
+int testDssFrameFloorClipDetection()
+{
+    using namespace AetherSDR;
+    if (!dssFrameFloorLooksClipped(1600, 1558, 298)
+        || dssFrameFloorLooksClipped(1600, 500, 19)
+        || dssFrameFloorLooksClipped(768, 31, 31)
+        || dssFrameFloorLooksClipped(63, 63, 63)) {
+        return fail("3D floor clipping threshold is incorrect");
     }
     return 0;
 }
@@ -318,9 +395,6 @@ int testDssFftScaleSettleWindow()
 int testDssStartupHistoryAvailability()
 {
     using namespace AetherSDR;
-    // Grid ages are integral (sourceV * rows over a fixed grid) and validRows is
-    // an int row count, so at a FULL history availability is strictly binary:
-    // populated slots opaque, the rest hidden. No partial values are reachable.
     constexpr float kRows = 96.0f;
     if (!nearlyEqual(dssHistoryAvailability(96.0f, 96.0f, kRows, 0.0f), 0.0)
         || !nearlyEqual(dssHistoryAvailability(95.0f, 96.0f, kRows, 0.0f), 1.0)
@@ -340,10 +414,8 @@ int testDssStartupHistoryAvailability()
                         0.0)) {
         return fail("3D FFT rear visibility must fail closed on bad input");
     }
-    // THE regression this guards (#4476): on a full history the oldest slot is
-    // permanently populated, so its opacity must not depend on where the scroll
-    // clock happens to be. Reinstating the advance term unconditionally makes
-    // this ramp 0 -> 1 and snap back on every delayed arrival — the rear pulse.
+    // Visibility belongs to the retained slot, not the scroll clock. This holds
+    // both for a full ring and while the ring is still filling.
     for (const float remainingRows : {0.0f, 0.25f, 0.5f, 1.0f, 3.0f}) {
         if (!nearlyEqual(
                 dssHistoryAvailability(95.0f, 96.0f, kRows, remainingRows),
@@ -352,28 +424,20 @@ int testDssStartupHistoryAvailability()
                         "latency on a full history");
         }
     }
-    // While the history is still FILLING, the newest slot is genuinely new and
-    // dssRetainedSampleAge() clamps it onto its neighbour's row for one
-    // interval, so it must fade in over that interval rather than popping a
-    // duplicate curtain opaque. Dropping the advance term in this regime makes
-    // all three of these 1.0.
     constexpr float kFilling = 10.0f;   // 10 of 96 rows populated
-    if (!nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 1.0f), 0.0)
-        || !nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 0.5f), 0.5)
-        || !nearlyEqual(dssHistoryAvailability(9.0f, kFilling, kRows, 0.0f),
-                        1.0)) {
-        return fail("3D FFT newest rear slot must fade in while history fills");
+    for (const float remainingRows : {0.0f, 0.5f, 1.0f, 3.0f}) {
+        if (!nearlyEqual(
+                dssHistoryAvailability(
+                    9.0f, kFilling, kRows, remainingRows),
+                1.0)
+            || !nearlyEqual(
+                dssHistoryAvailability(
+                    10.0f, kFilling, kRows, remainingRows),
+                0.0)) {
+            return fail("3D FFT filling visibility must not pulse with scroll");
+        }
     }
-    // ...and only the newest slot fades: settled slots behind it stay opaque
-    // regardless of the scroll clock, and unpopulated ones stay hidden.
-    if (!nearlyEqual(dssHistoryAvailability(8.0f, kFilling, kRows, 1.0f), 1.0)
-        || !nearlyEqual(dssHistoryAvailability(0.0f, kFilling, kRows, 1.0f), 1.0)
-        || !nearlyEqual(dssHistoryAvailability(10.0f, kFilling, kRows, 0.0f),
-                        0.0)) {
-        return fail("3D FFT fill fade must apply only to the newest slot");
-    }
-    // The visibility edge and the height path must agree about what exists: on
-    // a full history a slot is visible exactly when it has a retained sample.
+
     for (const float sourceAge : {0.0f, 1.0f, 94.0f, 95.0f, 96.0f, 97.0f}) {
         const bool visible =
             dssHistoryAvailability(sourceAge, 96.0f, kRows, 0.0f) > 0.0f;
@@ -384,42 +448,102 @@ int testDssStartupHistoryAvailability()
                         "path's valid-range early-out");
         }
     }
-    const std::optional<float> movingAge =
-        dssRetainedSampleAge(94.0f, 0.5f, 96.0f, 96.0f);
-    const std::optional<float> oldestAge =
-        dssRetainedSampleAge(95.0f, 1.0f, 96.0f, 96.0f);
-    if (!movingAge || !nearlyEqual(*movingAge, 94.5)
-        || !oldestAge || !nearlyEqual(*oldestAge, 95.0)
-        || dssRetainedSampleAge(96.0f, 0.0f, 96.0f, 96.0f).has_value()) {
-        return fail("3D FFT rear row should remain stable until eviction");
-    }
-    // The oldest slot's SAMPLE age is clamped to oldestRetainedAge, so it holds
-    // still under any scroll phase — this is the clamp that also makes it
-    // duplicate its neighbour for one interval while the history fills, which
-    // is why the fill fade above exists.
-    for (const float remainingRows : {0.0f, 0.5f, 1.0f, 4.0f}) {
-        const std::optional<float> clampedAge =
-            dssRetainedSampleAge(95.0f, remainingRows, 96.0f, 96.0f);
-        if (!clampedAge || !nearlyEqual(*clampedAge, 95.0)) {
-            return fail("3D FFT oldest retained sample age must not move with "
-                        "scroll latency");
+
+    // Every stored FFT is sampled at its exact age for every animation phase.
+    // The old interpolation returned e.g. 17.5 here and visibly morphed peaks.
+    for (const float sourceAge : {0.0f, 17.0f, 94.0f, 95.0f}) {
+        for (const float remainingRows : {0.0f, 0.25f, 1.0f, 3.0f}) {
+            const std::optional<float> sampleAge =
+                dssRetainedSampleAge(
+                    sourceAge, remainingRows, 96.0f, kRows);
+            if (!sampleAge || !nearlyEqual(*sampleAge, sourceAge)) {
+                return fail("3D FFT scroll must not interpolate peak height");
+            }
         }
     }
-    // Fidelity to the shader's two clamps outside 1 <= validRows <= rows:
-    // validRows > rows caps to rows (oldest age = rows - 1, not validRows - 1);
-    // 0 < validRows < 1 floors the oldest age at 0 rather than going negative.
-    // validRows = 200 > rows caps the oldest age to rows - 1 = 95, so a
-    // sourceAge+remainingRows of 100 clamps to 95 (an uncapped mirror would
-    // return 100 against validRows - 1 = 199).
-    const std::optional<float> cappedAge =
-        dssRetainedSampleAge(90.0f, 10.0f, 200.0f, 96.0f);
-    // 0 < validRows < 1 floors the oldest age at 0 rather than going negative.
-    const std::optional<float> flooredAge =
-        dssRetainedSampleAge(0.0f, 0.0f, 0.5f, 96.0f);
-    if (!cappedAge || !nearlyEqual(*cappedAge, 95.0)
-        || !flooredAge || !nearlyEqual(*flooredAge, 0.0)) {
-        return fail("3D FFT retained sample age must match shader clamps");
+    if (dssRetainedSampleAge(96.0f, 0.0f, 96.0f, kRows).has_value()
+        || dssRetainedSampleAge(90.0f, 1.0f, 200.0f, kRows)
+               != std::optional<float>{90.0f}) {
+        return fail("3D FFT exact sample selection must honor valid-row bounds");
     }
+
+    // The leading/trailing geometry is fixed. A head advance changes only which
+    // two exact ages occupy those depths: the preceding interval's fully opaque
+    // overlay is the following interval's base, representing the same FFT.
+    for (const float sourceAge : {0.0f, 17.0f, 95.0f}) {
+        for (const float distanceRows : {1.0f, 3.0f, 8.0f}) {
+            const std::optional<DssFixedGridCrossfade> before =
+                dssFixedGridCrossfade(
+                    sourceAge, distanceRows, distanceRows);
+            const std::optional<DssFixedGridCrossfade> after =
+                dssFixedGridCrossfade(sourceAge, 0.0f, distanceRows);
+            const std::optional<DssFixedGridCrossfade> halfway =
+                dssFixedGridCrossfade(
+                    sourceAge, distanceRows * 0.5f, distanceRows);
+            if (!before || !after || !halfway
+                || !nearlyEqual(before->overlayAge, sourceAge)
+                || !nearlyEqual(before->overlayAlpha, 1.0)
+                || !nearlyEqual(after->baseAge,
+                                sourceAge + distanceRows)
+                || !nearlyEqual(after->overlayAlpha, 0.0)
+                || !nearlyEqual(halfway->baseAge,
+                                sourceAge + distanceRows)
+                || !nearlyEqual(halfway->overlayAge, sourceAge)
+                || !nearlyEqual(halfway->overlayAlpha, 0.5)) {
+                return fail("3D FFT fixed-grid crossfade ages are incorrect");
+            }
+
+            // Treat the ring head as a monotonically increasing generation.
+            // The physical row identity is head - age, and must be identical
+            // on both sides of the discrete head advance.
+            const float physicalBefore = 0.0f - before->overlayAge;
+            const float physicalAfter =
+                distanceRows - after->baseAge;
+            if (!nearlyEqual(physicalBefore, physicalAfter)) {
+                return fail("3D FFT boundary rows must survive head advance");
+            }
+        }
+    }
+    if (const std::optional<DssFixedGridCrossfade> rear =
+            dssFixedGridCrossfade(95.0f, 0.0f, 8.0f);
+        !rear || rear->baseAge > 103.0f) {
+        return fail("3D FFT transition reserve must cover the trailing row");
+    }
+
+    // Interior rows move instead of crossfading, so the whole surface does not
+    // shimmer. The same physical row is continuous across a multi-row head
+    // advance even though its source age changes by that distance.
+    for (const float sourceAge : {1.0f, 17.0f, 80.0f}) {
+        for (const float distanceRows : {1.0f, 3.0f, 8.0f}) {
+            const std::optional<float> before =
+                dssMovingGeometryDepth(sourceAge, 0.0f, kRows);
+            const std::optional<float> after =
+                dssMovingGeometryDepth(
+                    sourceAge + distanceRows, distanceRows, kRows);
+            if (!before || !after || !nearlyEqual(*before, *after, 1.0e-7)) {
+                return fail("3D FFT interior geometry must remain continuous");
+            }
+        }
+    }
+    if (!nearlyEqual(dssFlatOutlineAlphaScale(0.0f), 0.42, 1.0e-6)
+        || !(dssFlatOutlineAlphaScale(0.0175f) > 0.42f)
+        || !(dssFlatOutlineAlphaScale(0.0175f) < 1.0f)
+        || !nearlyEqual(dssFlatOutlineAlphaScale(0.035f), 1.0, 1.0e-6)
+        || !nearlyEqual(dssFlatOutlineAlphaScale(0.25f), 1.0, 1.0e-6)) {
+        return fail("3D FFT floor-outline anti-shimmer curve is incorrect");
+    }
+    if (!nearlyEqual(dssRibbonCoverage(0.0f), 1.0, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(0.15f), 1.0, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(0.575f), 0.5, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(-0.575f), 0.5, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(1.0f), 0.0, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(2.0f), 0.0, 1.0e-6)
+        || !nearlyEqual(dssRibbonCoverage(
+                            std::numeric_limits<float>::quiet_NaN()),
+                        0.0, 1.0e-6)) {
+        return fail("3D FFT ribbon coverage curve is incorrect");
+    }
+
     return 0;
 }
 
@@ -551,6 +675,35 @@ int testStablePresentationAnchor()
     return 0;
 }
 
+int testDssSupplementalCoverageCalibration()
+{
+    std::vector<float> tile(128, 102.0f);
+    std::vector<float> fft(64, -108.0f);
+    const std::vector<float> supplemental =
+        AetherSDR::buildDssSupplementalCoverage(
+            tile, 14.0, 14.4,
+            fft, 14.2, 0.2,
+            -130.0f, -20.0f);
+    if (supplemental.size() != tile.size()) {
+        return fail("overlapping waterfall tile should produce DSS supplemental coverage");
+    }
+    for (const float dbm : supplemental) {
+        if (!nearlyEqual(dbm, -108.0, 1.0e-5)) {
+            return fail("supplemental tile should use the robust FFT overlap offset");
+        }
+    }
+
+    const std::vector<float> disjoint =
+        AetherSDR::buildDssSupplementalCoverage(
+            tile, 13.0, 13.1,
+            fft, 14.2, 0.2,
+            -130.0f, -20.0f);
+    if (!disjoint.empty()) {
+        return fail("disjoint waterfall tiles must not invent DSS coverage");
+    }
+    return 0;
+}
+
 } // namespace
 
 int main()
@@ -561,10 +714,16 @@ int main()
     if (const int result = testFrequencyFrameMapping(); result != 0) {
         return result;
     }
+    if (const int result = testUntaggedDssFrameResolution(); result != 0) {
+        return result;
+    }
     if (const int result = testCommandThrottle(); result != 0) {
         return result;
     }
     if (const int result = testDssZoomFloorSyncGate(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssFrameFloorClipDetection(); result != 0) {
         return result;
     }
     if (const int result = testDssZoomFloorFrameGuards(); result != 0) {
@@ -583,6 +742,10 @@ int main()
         return result;
     }
     if (const int result = testObservedWaterfallCadence(); result != 0) {
+        return result;
+    }
+    if (const int result = testDssSupplementalCoverageCalibration();
+        result != 0) {
         return result;
     }
     return testStablePresentationAnchor();

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -93,6 +93,7 @@ int testFrequencyFrameMapping()
                .isValid()) {
         return fail("non-finite frequency frames should be rejected");
     }
+
     return 0;
 }
 
@@ -482,13 +483,16 @@ int testDssStartupHistoryAvailability()
                     sourceAge, distanceRows * 0.5f, distanceRows);
             if (!before || !after || !halfway
                 || !nearlyEqual(before->overlayAge, sourceAge)
+                || !nearlyEqual(before->baseAlpha, 0.0)
                 || !nearlyEqual(before->overlayAlpha, 1.0)
                 || !nearlyEqual(after->baseAge,
                                 sourceAge + distanceRows)
+                || !nearlyEqual(after->baseAlpha, 1.0)
                 || !nearlyEqual(after->overlayAlpha, 0.0)
                 || !nearlyEqual(halfway->baseAge,
                                 sourceAge + distanceRows)
                 || !nearlyEqual(halfway->overlayAge, sourceAge)
+                || !nearlyEqual(halfway->baseAlpha, 0.5)
                 || !nearlyEqual(halfway->overlayAlpha, 0.5)) {
                 return fail("3D FFT fixed-grid crossfade ages are incorrect");
             }
@@ -510,9 +514,25 @@ int testDssStartupHistoryAvailability()
         return fail("3D FFT transition reserve must cover the trailing row");
     }
 
-    // Interior rows move instead of crossfading, so the whole surface does not
-    // shimmer. The same physical row is continuous across a multi-row head
-    // advance even though its source age changes by that distance.
+    for (const float opacity : {0.12f, 0.37f, 0.62f}) {
+        for (const float phase : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f}) {
+            const float baseAlpha =
+                dssSourceOverCrossfadeLayerAlpha(
+                    opacity, phase, false);
+            const float overlayAlpha =
+                dssSourceOverCrossfadeLayerAlpha(
+                    opacity, phase, true);
+            const float combinedAlpha =
+                baseAlpha + overlayAlpha * (1.0f - baseAlpha);
+            if (!nearlyEqual(combinedAlpha, opacity, 1.0e-6)) {
+                return fail("3D FFT outline crossfade must preserve opacity");
+            }
+        }
+    }
+
+    // Coloured curtain geometry still moves, so the same physical row is
+    // continuous across a multi-row head advance even though its source age
+    // changes by that distance.
     for (const float sourceAge : {1.0f, 17.0f, 80.0f}) {
         for (const float distanceRows : {1.0f, 3.0f, 8.0f}) {
             const std::optional<float> before =
@@ -542,6 +562,48 @@ int testDssStartupHistoryAvailability()
                             std::numeric_limits<float>::quiet_NaN()),
                         0.0, 1.0e-6)) {
         return fail("3D FFT ribbon coverage curve is incorrect");
+    }
+    const DssRibbonPixelOffset leftOffset =
+        dssRibbonPixelOffset(0.0f, -0.6f, 0.8f, 1.0f);
+    const DssRibbonPixelOffset rightOffset =
+        dssRibbonPixelOffset(1.0f, 0.6f, 0.8f, -1.0f);
+    const DssRibbonPixelOffset interiorOffset =
+        dssRibbonPixelOffset(0.5f, -0.6f, 0.8f, -1.0f);
+    const DssRibbonPixelOffset invalidOffset = dssRibbonPixelOffset(
+        std::numeric_limits<float>::quiet_NaN(),
+        -0.6f, 0.8f, 1.0f);
+    if (!nearlyEqual(leftOffset.x, 0.0, 1.0e-6)
+        || !nearlyEqual(leftOffset.y, 1.0, 1.0e-6)
+        || !nearlyEqual(rightOffset.x, 0.0, 1.0e-6)
+        || !nearlyEqual(rightOffset.y, -1.0, 1.0e-6)
+        || !nearlyEqual(interiorOffset.x, 0.6, 1.0e-6)
+        || !nearlyEqual(interiorOffset.y, -0.8, 1.0e-6)
+        || !nearlyEqual(invalidOffset.x, 0.0, 1.0e-6)
+        || !nearlyEqual(invalidOffset.y, 0.0, 1.0e-6)) {
+        return fail("3D FFT side endpoints must use a stable butt boundary");
+    }
+    if (!nearlyEqual(
+            dssSideOutlineAlphaScale(
+                0.0f, 1000.0f, 1.0f), 0.0, 1.0e-6)
+        || !nearlyEqual(
+            dssSideOutlineAlphaScale(
+                1.0f, 1000.0f, 0.5f), 0.0, 1.0e-6)
+        || !nearlyEqual(
+            dssSideOutlineAlphaScale(
+                0.004f, 1000.0f, 1.0f), 0.5, 1.0e-5)
+        || !nearlyEqual(
+            dssSideOutlineAlphaScale(
+                0.016f, 1000.0f, 0.5f), 1.0, 1.0e-6)
+        || !nearlyEqual(
+            dssSideOutlineAlphaScale(
+                0.5f, 1000.0f, 1.0f), 1.0, 1.0e-6)
+        || !nearlyEqual(
+            dssSideOutlineAlphaScale(
+                std::numeric_limits<float>::quiet_NaN(),
+                1000.0f, 1.0f),
+            0.0, 1.0e-6)) {
+        return fail(
+            "3D FFT side fade must affect only 8 pixels");
     }
 
     return 0;

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -755,6 +755,28 @@ int testDssSupplementalCoverageCalibration()
         }
     }
 
+    // Waterfall intensities are arbitrary display units, not dBm.  In
+    // particular, their signal span need not match the FFT span one-for-one.
+    // Calibrate both the floor and span so a retained off-screen carrier does
+    // not become taller than the same carrier once live FFT coverage arrives.
+    std::fill(tile.begin() + 48, tile.begin() + 80, 142.0f);
+    tile[8] = 142.0f; // same carrier level, outside the current FFT frame
+    std::fill(fft.begin() + 16, fft.begin() + 48, -88.0f);
+    const std::vector<float> scaled =
+        AetherSDR::buildDssSupplementalCoverage(
+            tile, 14.0, 14.4,
+            fft, 14.2, 0.2,
+            -130.0f, -20.0f);
+    if (scaled.size() != tile.size()) {
+        return fail("scaled waterfall tile should produce DSS supplemental coverage");
+    }
+    if (!nearlyEqual(scaled[16], -108.0, 0.25)
+        || !nearlyEqual(scaled[64], -88.0, 0.25)
+        || !nearlyEqual(scaled[8], -88.0, 0.25)) {
+        return fail(
+            "supplemental calibration must match the FFT floor and signal span");
+    }
+
     const std::vector<float> disjoint =
         AetherSDR::buildDssSupplementalCoverage(
             tile, 13.0, 13.1,

--- a/tests/spectrum_preview_logic_test.cpp
+++ b/tests/spectrum_preview_logic_test.cpp
@@ -254,6 +254,15 @@ int testDssFrameFloorClipDetection()
         || dssFrameFloorLooksClipped(63, 63, 63)) {
         return fail("3D floor clipping threshold is incorrect");
     }
+    if (!flexFftFrameNeedsHeadroomRecovery(
+            false, 1600, 1558, 298)
+        || flexFftFrameNeedsHeadroomRecovery(
+            true, 1600, 1558, 298)
+        || flexFftFrameNeedsHeadroomRecovery(
+            false, 1600, 500, 19)) {
+        return fail(
+            "FLEX floor recovery must cover both render modes but not Kiwi");
+    }
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4425, #4432, #4476, and #4477. Those changes established smooth scrolling, retained 3D history, rear-edge stability, and post-zoom floor synchronization, but repeated zoom, pan, band changes, and window resizing still exposed several coupled problems in the shared display pipeline.

The 3D FFT could develop false spikes or flat floor sections, peaks and boundary rows could bounce while scrolling, the entire surface could shimmer or strobe, pan previews could move faster than the waterfall and snap back on release, and newly exposed frequencies could remain blank even though the radio was already sending wider native waterfall tiles. Increasing the application width could also admit one transitional zero-filled FFT suffix as maximum-strength data, while retained off-screen waterfall coverage could render with exaggerated carrier heights because its arbitrary intensity span was treated as dBm. This change keeps the scrolling rings continuously populated, validates fragmented VITA coverage by bin position, maps every retained row from its own capture frame, and preserves the radio's wider tile coverage without replacing the exact FFT or current waterfall pixels.

### What changed

| Problem | Root cause | Fix |
|---|---|---|
| Zooming far out and back in produced a spike or expanded ridge that rolled through history | The compact 3D ring was repeatedly reprojected from already-downsampled rows, compounding information loss on each zoom | Refresh existing ring slots in place from frame-stamped retained source rows; preserve the ring head, row count, and scroll phase |
| Increasing the application width produced a tall shelf over only the newly added right portion of the FFT | Firmware 4.2.18 can complete one expanded `x_pixels` frame with a valid old-width prefix and a zero-filled suffix; raw FFT zero maps to maximum dBm | Reject only genuine growth frames whose new suffix is overwhelmingly zero while the retained prefix is not |
| Duplicate, overlapping, or shortened VITA fragments could make an incomplete FFT/waterfall frame appear complete | Assembly counted packet-declared bins rather than unique positions actually present in the datagram | Bound reads to complete payload bins and track unique per-position coverage before emitting a frame |
| Low portions of the trace became flat or remained on the wrong scale after zoom/band changes | The radio FFT encoder could remain clipped at its lower endpoint while the client-side presentation was already correctly positioned | Detect the clipped floor and shift only the radio encoder aperture down by 24 dB through the normal command/echo handshake; keep the visible 3D range fixed and reacquire auto-floor from a fresh unclipped frame |
| Off-screen 3D coverage appeared much spikier than the exact visible FFT | Supplemental native-tile coverage entered retained 3D history without the temporal/median filtering applied to exact FFT rows | Give supplemental coverage an independent smoothing chain, reject isolated one-row maxima, and reset it whenever its frequency frame changes |
| Peaks, leading/trailing rows, and zoom-created floor edges bounced while scrolling | Amplitude interpolation morphed adjacent FFT rows whose peaks and frequency frames did not match | Sample exact retained FFT rows and move curtain geometry through depth; reset temporal smoothing inputs when the frequency frame changes |
| Leading/trailing rows wiggled or pulsed | Boundary visibility and sample age changed with fractional scroll progress | Keep the front/rear geometry fixed and crossfade only between two exact retained rows, with reserved outgoing rows preventing premature eviction |
| The whole 3D surface shimmered or strobed | Dense one-pixel outlines changed raster coverage as the history translated through subpixels | Keep ridge geometry on the fixed perspective grid, crossfade exact rows in place, render analytical screen-space ribbons, and compensate source-over alpha so combined brightness remains constant |
| Signals at the hard left/right edge formed a flashing comb | The exposed endpoints of differently shaped colored curtains overlapped directly against the black outside of the perspective surface | Use stable butt geometry and fade only the outer eight physical pixels of the ridge and colored curtain; interior FFT lines and data remain exact |
| Flat, uncovered portions changed color or visually scrolled differently | Reprojection gaps were stored as ordinary floor-valued samples and later recolored by range changes | Track captured-frequency coverage separately and pin uncovered bins to a stable floor height/color with a subdued outline |
| 3D rows moved too quickly during horizontal pan and popped into place on release | Untagged FFT arrivals could be stamped in the moving preview frame and then transformed a second time | Stamp pure-pan arrivals in their current radio frame, keep zoom arrivals in the preview base frame, and map every row exactly once in the shader |
| Live 3D data updated while dragging, but retained rows lacked newly exposed spectrum or drew too tall when revealed | Exact FFT rows cover only the requested viewport, while wider native waterfall tiles use arbitrary intensity units rather than dBm | Calibrate the native tile floor and signal span against overlapping FFT quantiles, retain it as supplemental 3D coverage, and let exact FFT data always win wherever it exists |
| Waterfall side data was black after panning even though the radio had transmitted it | Native tiles were rasterized only into the current viewport and their overhang was discarded before entering visible or deep history | Retain the complete native tile in a separate visible ring, lazy 8-bit history, and GPU texture; sample it only outside each primary row's original viewport |

### Implementation notes

- FFT and waterfall assemblers now track unique received bin positions. Duplicate or overlapping fragments cannot satisfy a frame while another range is missing.
- Short VITA payloads decode only complete bins actually present in the datagram.
- Each live 3D row carries its exact FFT center/bandwidth, captured-bin coverage, and optional supplemental tile frame.
- Pan and zoom previews transform frame-stamped rows at render time. They do not remove or rebuild the live 3D timeline.
- Frame changes break the relevant temporal filter chain so bins from different frequency coordinates are never blended together.
- Supplemental coverage has its own median/temporal history; it cannot contaminate or replace the exact FFT.
- Supplemental native-tile intensity is aligned to overlapping FFT dBm with robust floor-and-span quantiles, preventing arbitrary waterfall units from exaggerating off-screen carrier heights.
- The 3D texture stores exact FFT data and supplemental native-tile data in separate channels.
- Ridge outlines stay on a fixed perspective grid and crossfade exact shapes with source-over opacity compensation.
- The narrow side fade affects only exposed edge geometry; it does not alter stored FFT values or interior traces.
- The radio-side headroom recovery maintains a separate encoder range, so correcting clipping does not pull the visible 3D display down and back up.
- The primary waterfall image remains unchanged inside its captured viewport. Supplemental data is consulted only outside that primary frame.
- Paused waterfall scrollback composites the same primary/supplemental policy on the CPU.
- Supplemental waterfall state follows normal resize, source-switch, clear, and retained-history lifecycles.
- Deep supplemental waterfall storage remains lazily allocated and retained only for the visible source.
- Automation diagnostics expose row frames, supplemental coverage, clipped-range recovery attempts, flat-run statistics, and allocated supplemental-history chunks.

### Reproduction

1. Enable the 3D FFT display and allow several seconds of history to accumulate.
2. Zoom far in, then far out several seconds later; repeat or switch bands.
3. Watch older rows scroll toward the rear edge, including strong signals at the hard left/right sides.
4. Pan left/right while holding the mouse and allow new radio rows to arrive during the gesture.
5. Pause the waterfall and scroll into history captured before the pan.
6. Increase the main application window width and inspect the newly exposed right portion of the FFT.

Before this change, the display could show rolling spikes, flat floor spans, bouncing peaks or whole boundary rows, a full-surface strobe, accelerated 3D panning followed by a release-time snap, black waterfall side areas where native tile data had already been received, or a maximum-height shelf over newly added window width.

After this change, the 3D and waterfall histories remain continuously populated and frequency-aligned, exact FFT rows retain their shape, newly received and retained off-screen coverage appears while panning, incomplete/placeholder frames do not enter history, radio encoder clipping recovers without moving the client presentation, and release does not rebuild or reposition the timeline.

### Review follow-up

- FLEX clipped-floor recovery now covers the shared 2D and 3D FFT input path. Existing radio ownership, profile-load, and Kiwi guards remain at the command boundary.
- Repeated zero-filled FFT growth placeholders are rejected for a bounded three-frame window, then emitted with only the new suffix forced to the floor so a misbehaving stream cannot freeze indefinitely. A later populated growth frame replaces it normally.
- Completed waterfall frames and exact duplicate fragment ranges are ignored; overlapping fragments that add new bins remain valid.
- Native-tile supplemental calibration is computed once per waterfall update rather than once per pushed row.
- The C++/shader row-count contract is compile-time asserted and documented in both shaders.
- The fixed-grid crossfade uses about 20.2 MiB of static vertex storage at 768 columns x 96 visible rows, versus about 7.3 MiB previously. The buffers are built once; boundary-only split draws remain a possible optimization if lower-end GPU profiling warrants it.
- Automation DSS snapshots now combine row metadata/statistics traversal and scan explicit peak bins only on the front row.

## Constitution principle honored

**Principle II — Radio-Authoritative Live State.** Clipped-floor recovery changes the radio encoder aperture through the existing command/echo handshake. The radio remains authoritative, while client-only presentation state is not persisted or substituted for radio state.

**Principle XI — Fixes Are Demonstrated.** Frame assembly, resize placeholders, retained-history round trips, frequency mapping, supplemental spike rejection, floor clipping, fixed-grid opacity, ribbon geometry, and side treatment have deterministic regression coverage, supplemented by RX-only proof on a real FLEX radio.

## Test plan

- [x] Local build passes (`cmake --build build -j8`)
- [x] Behavior verified on a real radio if applicable
  - FLEX-6700 running firmware 4.2.18
  - Repeated zoom, horizontal pan, live-history, paused-scrollback, band-change, and grow-resize testing
  - Row-frequency GPU pipeline remained active with no shader/resource warnings
  - Growing the main window no longer admitted a zero-filled maximum-height suffix
  - Flat/clipped 3D input recovered through radio-side headroom without moving the visible presentation
  - Overall fixed-grid ridge strobe was removed; the residual hard-edge curtain comb is suppressed by the narrow side fade
  - A 0.232 MHz viewport retained approximately 0.461 MHz of native tile coverage
  - Live pan and 200-row paused scrollback both showed continuous waterfall data
  - Retained off-screen 3D carriers matched the height of subsequent exact FFT data when panned into view
  - 96/96 visible 3D rows remained non-flat during live proof
  - Automation TX was pinned off; `mox=false`, `tuning=false`, and `transmitting=false`
- [ ] Existing tests pass (CI)
  - Focused local tests pass:
    - `./build/spectrum_preview_logic_test`
    - `./build/dss_renderer_test`
    - `./build/panadapter_dbm_range_test`
- [x] Reproduction steps documented above
- [x] `python3 tools/check_engine_boundary.py --strict` reports zero blocking findings
- [x] Shader baking completed as part of the application build
- [x] `git diff --check` passes

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — no settings persistence added
- [x] Code is clean-room — not decompiled, disassembled, or reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` — no meter UI changed
- [x] Documentation updated if user-visible behavior changed — N/A; this corrects existing display behavior without adding controls or settings
- [x] Security-sensitive changes reference a GHSA if applicable — N/A
