### PR TITLE
fix(meters): forward power kept reporting for ~3s after unkey

### DIFF
--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -12,6 +12,17 @@ namespace AetherSDR {
 
 namespace {
 
+// Forward power at or below which the radio is treated as not transmitting, so
+// the display snaps to zero instead of decaying towards it (#4539).
+//
+// A radio with no carrier reports 0 dBm on FWDPWR, and 10^(0/10)/1000 is
+// 0.001 W — small, but NOT zero, which is the whole problem: an
+// exponential-decay filter converges on it rather than reaching it. The
+// threshold is a hair above that floor so the "no carrier" case is caught
+// exactly, while any genuine reading (0 dBm is already 30 dB below a 1 W
+// carrier) stays on the smoothed path.
+constexpr float kNoCarrierWatts = 0.0011f;
+
 constexpr qint64 kCompressionSummaryLogIntervalMs = 500;
 constexpr qint64 kDirectionalMeterFreshnessMs = 500;
 constexpr int kMinTxWaveformSourceIndex = 8;
@@ -528,7 +539,23 @@ void MeterModel::updateValues(const QVector<quint16>& ids, const QVector<qint16>
             directionalChanged = true;
             // Smooth: fast attack (α=0.5) to track peaks, slow decay (α=0.15)
             // for stable display without jitter (#980)
-            if (m_fwdPower < 0.01f) {
+            //
+            // The slow decay is right DURING a transmission and wrong at the end
+            // of one. On unkey the radio reports 0 dBm, which is 0.001 W rather
+            // than 0, so the filter creeps towards it at 15 % per sample instead
+            // of arriving: measured on a FLEX-6700, the dBm meter read 0 within
+            // 200 ms while the watts reading was still 3.45 W, and it took
+            // ~2.9 s to fall away. For that whole window the display claims
+            // forward power out of a radio that has stopped transmitting.
+            //
+            // So: keep the smoothing for real readings, but snap to zero once
+            // the meter says there is no carrier. REFPWR immediately below is
+            // not smoothed at all and drops instantly — this brings the two
+            // directional readings back into agreement instead of having one
+            // linger while the other is already at rest.
+            if (watts <= kNoCarrierWatts) {
+                m_fwdPower = 0.0f;
+            } else if (m_fwdPower < 0.01f) {
                 m_fwdPower = watts;  // first sample — no smoothing
             } else {
                 float alpha = (watts > m_fwdPower) ? 0.5f : 0.15f;

--- a/src/models/MeterModel.cpp
+++ b/src/models/MeterModel.cpp
@@ -13,7 +13,7 @@ namespace AetherSDR {
 namespace {
 
 // Forward power at or below which the radio is treated as not transmitting, so
-// the display snaps to zero instead of decaying towards it (#4539).
+// the display snaps to zero instead of decaying towards it (#4540).
 //
 // A radio with no carrier reports 0 dBm on FWDPWR, and 10^(0/10)/1000 is
 // 0.001 W — small, but NOT zero, which is the whole problem: an

--- a/tests/health_applet_test.cpp
+++ b/tests/health_applet_test.cpp
@@ -95,13 +95,21 @@ void testUnkeyTransientDoesNotLatchWarning()
     report("stable dummy-load sample is healthy",
            statusText(applet) == QStringLiteral("OK"), statusText(applet));
 
-    // MeterModel deliberately retains a slowly-decaying display power, while
-    // directionalPowerMetersChanged carries the near-zero instantaneous power.
-    // The SWR value is not physically meaningful during this unkey packet.
+    // 0.001 W is what a radio with no carrier reports: 0 dBm through
+    // 10^(dBm/10)/1000. MeterModel snaps the display power to zero there rather
+    // than decaying towards it (#4540), so the applet correctly stops calling
+    // the sample active and parks at IDLE. The SWR riding that packet is not
+    // physically meaningful, and what this case guards is that it cannot latch
+    // a WATCH or GROUND? verdict on the way out — IDLE proves that, since a
+    // warning state would have to have qualified on power first.
+    //
+    // Before #4540 the smoothed power lingered for ~3 s after unkey, which kept
+    // the sample active and left the pill reading OK; the guard was written
+    // against that behaviour. The no-false-warning intent is unchanged.
     sendMeters(model, 0.001f, 3.50f);
     processEventsFor(320);  // headroom over the 4-frame settle for loaded runners
     report("unkey SWR transient does not latch HLTH warning",
-           statusText(applet) == QStringLiteral("OK"), statusText(applet));
+           statusText(applet) == QStringLiteral("IDLE"), statusText(applet));
 }
 
 void testKeyTransientDoesNotPoisonBaseline()

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -276,6 +276,61 @@ void testNativeSwrRemainsRadioProvidedAtLowPower()
                && nearlyEqual(emittedSwr, 1.0859375f));
 }
 
+// #4539: the fast-attack/slow-decay smoothing on FWDPWR is right during a
+// transmission and wrong at the end of one. A radio with no carrier reports
+// 0 dBm = 0.001 W, and an exponential decay converges on that rather than
+// reaching it, so the display kept claiming forward power after unkey.
+void testForwardPowerSnapsToZeroWhenTheCarrierStops()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+
+    // Transmitting: ~36.5 dBm is about 4.5 W, the level measured on the bench.
+    model.updateValues({8}, {rawDb(36.5f)});
+    const bool keyed = model.fwdPower() > 1.0f;
+
+    // Unkey. The radio reports 0 dBm — NOT a small power, no power.
+    model.updateValues({8}, {rawDb(0.0f)});
+
+    report("MeterModel drops forward power to zero on the first no-carrier sample",
+           keyed && nearlyEqual(model.fwdPower(), 0.0f));
+}
+
+// The decay is what made this visible on the bench: without the fix the reading
+// was still 3.45 W 200 ms after unkey and took ~2.9 s to fall away. Feeding
+// several no-carrier samples reproduces exactly that window.
+void testForwardPowerDoesNotLingerAcrossRepeatedNoCarrierSamples()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+
+    model.updateValues({8}, {rawDb(36.5f)});
+    for (int i = 0; i < 5; ++i) {
+        model.updateValues({8}, {rawDb(0.0f)});
+    }
+
+    report("MeterModel reports no forward power while the carrier is absent",
+           nearlyEqual(model.fwdPower(), 0.0f));
+}
+
+// The smoothing must survive for real readings — this is a display filter that
+// exists for a reason (#980), and the fix must not flatten it.
+void testForwardPowerStillSmoothsRealReadings()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+
+    model.updateValues({8}, {rawDb(36.5f)});          // ~4.5 W, first sample
+    const float first = model.fwdPower();
+    model.updateValues({8}, {rawDb(30.0f)});          // ~1.0 W, a real drop
+
+    // Slow-decay smoothing means the displayed value must LAG the new reading,
+    // sitting between the two rather than snapping to the lower one.
+    const float after = model.fwdPower();
+    report("MeterModel still smooths a genuine drop in forward power",
+           first > 4.0f && after < first && after > 1.5f);
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -293,6 +348,9 @@ int main(int argc, char** argv)
     testRemovingAdjacentMetersDoesNotClearCompPeak();
     testDirectionalPowerUsesDirectReflectedMeter();
     testNativeSwrRemainsRadioProvidedAtLowPower();
+    testForwardPowerSnapsToZeroWhenTheCarrierStops();
+    testForwardPowerDoesNotLingerAcrossRepeatedNoCarrierSamples();
+    testForwardPowerStillSmoothsRealReadings();
 
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/meter_model_test.cpp
+++ b/tests/meter_model_test.cpp
@@ -276,7 +276,7 @@ void testNativeSwrRemainsRadioProvidedAtLowPower()
                && nearlyEqual(emittedSwr, 1.0859375f));
 }
 
-// #4539: the fast-attack/slow-decay smoothing on FWDPWR is right during a
+// #4540: the fast-attack/slow-decay smoothing on FWDPWR is right during a
 // transmission and wrong at the end of one. A radio with no carrier reports
 // 0 dBm = 0.001 W, and an exponential decay converges on that rather than
 // reaching it, so the display kept claiming forward power after unkey.
@@ -331,6 +331,30 @@ void testForwardPowerStillSmoothsRealReadings()
            first > 4.0f && after < first && after > 1.5f);
 }
 
+// The threshold has to catch the no-carrier floor WITHOUT swallowing a genuine
+// low-power reading, so pin the boundary from the other side: a value just above
+// kNoCarrierWatts must stay on the smoothed path rather than snapping to zero.
+//
+// 0.7 dBm is ~0.00117 W — a hair above the 0.0011 W threshold, and the closest a
+// real reading can plausibly sit to it. If a future change widens the threshold
+// this is the test that fails.
+void testForwardPowerJustAboveTheThresholdStaysSmoothed()
+{
+    MeterModel model;
+    model.defineMeter(txMeter(8, "FWDPWR", "dBm"));
+
+    model.updateValues({8}, {rawDb(36.5f)});          // ~4.5 W, establish a level
+    const float keyed = model.fwdPower();
+    model.updateValues({8}, {rawDb(0.7f)});           // ~0.00117 W, above the floor
+
+    // Smoothed, so it must LAG rather than snap: still well above zero after one
+    // sample. A snap-to-zero here would mean the threshold had eaten a real
+    // reading.
+    const float after = model.fwdPower();
+    report("MeterModel keeps smoothing a reading just above the no-carrier floor",
+           keyed > 4.0f && after > 0.01f);
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -351,6 +375,7 @@ int main(int argc, char** argv)
     testForwardPowerSnapsToZeroWhenTheCarrierStops();
     testForwardPowerDoesNotLingerAcrossRepeatedNoCarrierSamples();
     testForwardPowerStillSmoothsRealReadings();
+    testForwardPowerJustAboveTheThresholdStaysSmoothed();
 
     return g_failed == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #4540.

## The bug

After a transmission ends, forward power keeps reporting for about **3 seconds**. The raw `FWDPWR` dBm meter is honest — it reads 0 within 200 ms — but the derived watts value decays exponentially from full power.

FLEX-6700 into a 500 W dummy load, sampled every ~130 ms after unkey:

```
t+  50 ms   dBm=35.88   watts=4.2930
t+ 200 ms   dBm= 0.00   watts=3.4488   <- meter at zero, 3.45 W still shown
t+ 750 ms   dBm= 0.00   watts=0.9405
t+2050 ms   dBm= 0.00   watts=0.0438
t+2902 ms   dBm= 0.00   watts=0.0010
```

`REFPWR` — five lines below in the same function, unsmoothed — drops instantly, so the two directional readings disagreed about whether the radio was transmitting.

## Cause

The fast-attack/slow-decay smoothing from #980 is right *during* a transmission and wrong at the end of one. A radio with no carrier reports **0 dBm**, and `10^(0/10)/1000` is **0.001 W — not zero**. An exponential decay converges on that floor rather than reaching it, at 15% per sample.

## The change

```cpp
if (watts <= kNoCarrierWatts) {
    m_fwdPower = 0.0f;
} else if (m_fwdPower < 0.01f) {
    m_fwdPower = watts;      // first sample — no smoothing
} else {
    float alpha = (watts > m_fwdPower) ? 0.5f : 0.15f;
    m_fwdPower = alpha * watts + (1.0f - alpha) * m_fwdPower;
}
```

`kNoCarrierWatts = 0.0011f` sits a hair above the 0.001 W floor, so the no-carrier case is caught exactly while every genuine reading stays on the smoothed path. 0 dBm is already 30 dB below a 1 W carrier — nothing real lives under the threshold.

**Deliberately minimal.** #980's smoothing is kept intact; this only handles the case it was never given, which is the transition to *no signal at all*. An alternative would have been to gate on `txMetersFresh` or transmit state, but that couples the meter to session state it does not otherwise need, and the meter already tells us plainly that the carrier is gone.

## Not backend-specific

First noticed on a **Hermes-Lite 2** during power-calibration work, then reproduced deliberately on the **FLEX-6700** above. It is in AE's shared meter smoothing, so every backend is affected — which is also why the fix belongs in `MeterModel` rather than in a backend.

## Testing

Three regression tests in the existing `meter_model_test`:

```
[FAIL] MeterModel drops forward power to zero on the first no-carrier sample     <- before
[FAIL] MeterModel reports no forward power while the carrier is absent           <- before
[ OK ] MeterModel still smooths a genuine drop in forward power                  <- both
```

The first two are confirmed to **fail against the unfixed code** and pass with it. The third asserts the display still *lags* a genuine drop rather than snapping to it — it passes before **and** after, so it guards #980's behaviour rather than the new branch. All 20 cases green, exit 0.

**Verified on hardware after the fix**, same probe and same radio:

```
t+  50 ms   dBm=35.88   watts=4.2930
t+ 199 ms   dBm= 0.00   watts=0.0000   <- was 3.4488
t+1447 ms   dBm= 0.00   watts=0.0000
```

Keyed reading unchanged at 4.37 W. Full `AetherSDR.exe` builds and links clean on Windows/MSVC.

## Related

Same family as #4533/#4536 (SWR held a stale value while receiving) and the Radio Health SWR noise floor in #4538: TX-derived quantities that keep reporting after the condition that produced them has gone. Different mechanisms — stale latch, missing noise floor, and here a filter converging on a non-zero floor — but the same symptom class, and worth noting that three separate paths had it.
