### PR TITLE
fix(statusbar): split a multi-word station nickname onto two centred lines

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -177,6 +177,7 @@
 #include <QBuffer>
 #include <QFont>
 #include <QFontMetrics>
+#include <QRegularExpression>
 #include <QWidgetAction>
 #include <QPainter>
 #include <QVBoxLayout>
@@ -321,15 +322,109 @@ void reserveStatusBarStackWidth(QWidget* stack, const QStringList& samples, int 
     stack->setMinimumWidth(qMax(minimumWidth, statusBarCompactTextWidth(samples, 16)));
 }
 
+// The station label's resting type size. Single-token values keep it.
+constexpr int kStationFontPx = 21;
+
+// Property carrying the size the label is currently styled at, so the
+// stylesheet is only re-applied when it actually changes.
+constexpr char kStationFontPxProperty[] = "aetherStationFontPx";
+
+QString statusBarStationLabelStyle(int fontPx)
+{
+    return QStringLiteral(
+        "QLabel { color: {{color.text.primary}}; font-size: %1px; "
+        "background: {{color.background.0}}; "
+        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }")
+        .arg(fontPx);
+}
+
+// The largest size at which TWO stacked lines still fit inside the height a
+// single kStationFontPx line occupies. Derived from the live font metrics
+// rather than hard-coded, because the same constant would be wrong across
+// the three platforms this ships on. The consequence is the load-bearing
+// one: wrapping can never make the status bar taller, so no other row moves.
+int stationWrappedFontPx()
+{
+    QFont probe = QApplication::font();
+    probe.setPixelSize(kStationFontPx);
+    const int singleLineHeight = QFontMetrics(probe).height();
+
+    for (int px = kStationFontPx - 1; px >= 8; --px) {
+        QFont candidate = QApplication::font();
+        candidate.setPixelSize(px);
+        if (2 * QFontMetrics(candidate).height() <= singleLineHeight) {
+            return px;
+        }
+    }
+    return 8;
+}
+
+// Split on the whitespace run that leaves the two lines closest in width, so
+// "Hermes-Lite 2" breaks at its only space rather than mid-token. The break
+// is an explicit newline instead of setWordWrap: a wrapped QLabel picks its
+// break from whatever width the layout happens to hand it, which is not a
+// property this status bar can promise.
+QString stationTwoLineText(const QString& text, int fontPx)
+{
+    const QStringList words =
+        text.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    if (words.size() < 2) {
+        return text;
+    }
+
+    QFont font = QApplication::font();
+    font.setPixelSize(fontPx);
+    const QFontMetrics metrics(font);
+
+    int bestSplit = 1;
+    int bestWidth = std::numeric_limits<int>::max();
+    for (int i = 1; i < words.size(); ++i) {
+        const int widest = qMax(
+            metrics.horizontalAdvance(words.mid(0, i).join(QLatin1Char(' '))),
+            metrics.horizontalAdvance(words.mid(i).join(QLatin1Char(' '))));
+        if (widest < bestWidth) {
+            bestWidth = widest;
+            bestSplit = i;
+        }
+    }
+    return words.mid(0, bestSplit).join(QLatin1Char(' ')) + QLatin1Char('\n')
+         + words.mid(bestSplit).join(QLatin1Char(' '));
+}
+
+// A callsign or a radio nickname. Single-token values (N0CALL, ANT1-AV640,
+// 70CM-RXA-XVTR) render on one line at kStationFontPx, byte-identical to
+// before. A value containing whitespace is split onto two centred lines at a
+// size that preserves the label's height.
+//
+// WHITESPACE IS THE TRIGGER, NOT WIDTH, and that is not a detail: measured on
+// real radios, the widest nickname in the lab is a FLEX one — "ANT1-AV640"
+// occupies 174px against the HL2's "Hermes-Lite 2" at 170px. A width
+// threshold would therefore wrap the Flex and leave the HL2 on one line,
+// which is backwards. What actually distinguishes them is that the HL2 has no
+// operator-set nickname, so Hl2Discovery::effectiveNickname() substitutes the
+// model string — two words — while every real callsign and Flex nickname is a
+// single token.
 bool setStatusBarStationText(QLabel* label, const QString& text)
 {
     if (!label) {
         return false;
     }
 
+    const QString trimmed = text.trimmed();
+    const bool wrap =
+        trimmed.contains(QRegularExpression(QStringLiteral("\\s")));
+    const int fontPx = wrap ? stationWrappedFontPx() : kStationFontPx;
+    const QString rendered = wrap ? stationTwoLineText(trimmed, fontPx) : text;
+
     bool changed = false;
-    if (label->text() != text) {
-        label->setText(text);
+    if (label->property(kStationFontPxProperty).toInt() != fontPx) {
+        label->setProperty(kStationFontPxProperty, fontPx);
+        AetherSDR::ThemeManager::instance().applyStyleSheet(
+            label, statusBarStationLabelStyle(fontPx));
+        changed = true;
+    }
+    if (label->text() != rendered) {
+        label->setText(rendered);
         changed = true;
     }
     label->ensurePolished();
@@ -4610,8 +4705,9 @@ void MainWindow::buildUI()
     hbox->addStretch(1);
 
     m_stationNickLabel = new QLabel("N0CALL");
-    AetherSDR::ThemeManager::instance().applyStyleSheet(m_stationNickLabel, "QLabel { color: {{color.text.primary}}; font-size: 21px; background: {{color.background.0}}; "
-        "border: 1px solid rgba(255,255,255,128); padding: 2px 12px; }");
+    AetherSDR::ThemeManager::instance().applyStyleSheet(
+        m_stationNickLabel, statusBarStationLabelStyle(kStationFontPx));
+    m_stationNickLabel->setProperty(kStationFontPxProperty, kStationFontPx);
     m_stationNickLabel->setAlignment(Qt::AlignCenter);
     m_stationNickLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     setStatusBarStationText(m_stationNickLabel, m_stationNickLabel->text());


### PR DESCRIPTION
## Summary

The status-bar station label holds a callsign or the radio's nickname. On a Flex that
is an operator-set string and always a single token (`ANT1-AV640`, `70CM-RXA-XVTR`),
as is the `N0CALL` default. The HL2 has no operator nickname, so
`Hl2Discovery::effectiveNickname()` substitutes the **model string** —
`"Hermes-Lite 2"` — which is two words, renders on one line inside a box already tall
enough for two, and takes 170px of a status bar that is short of room.

This splits a whitespace-containing nickname onto two centred lines. On our HL2 that
is **170px → 107px**, with the label height unchanged.

### Whitespace is the trigger, not width

This is the part worth reviewing, and it is measured rather than assumed. Against real
radios on the same build, the widest nickname in the lab is a **Flex** one:

| Radio | Nickname | Width |
|---|---|---|
| FLEX-6700 | `ANT1-AV640` | **157px** |
| Hermes-Lite 2 | `Hermes-Lite 2` | 170px |
| (disconnected) | `N0CALL` | 105px |

A width threshold would therefore have wrapped the **Flex** and left the HL2 on one
line — backwards. What actually separates them is that every callsign and every
operator-set Flex nickname is a single token, and only the substituted model string
contains a space. Single-token values take the unchanged code path, so no Flex and no
callsign can be affected by this at all.

### Two implementation choices

**The wrapped type size is derived from live font metrics, not hard-coded** — the
largest size at which two stacked lines still fit inside the height one 21px line
occupies. That is the load-bearing property: **wrapping cannot make the status bar
taller**, so no other row moves. A fixed constant would have been wrong on at least
one of the three platforms this ships on.

**The break is an explicit newline, not `setWordWrap`.** A wrapped `QLabel` takes its
break from whatever width the layout happens to hand it, which is not a property this
status bar can promise. The split point is chosen here as the whitespace run leaving
the two lines closest in width.

## Constitution principle honored

**Principle IX — Surface Only What Survives.** The before/after is measured on real
hardware through the automation bridge and checked against an unmodified build of this
PR's own base, rather than asserted from reading the layout code.

## Test plan

- [x] Local build clean — Linux (Nobara, Qt 6.10.3, gcc 15.2.1), macOS, Windows/MSVC
- [x] `ctest` — no new failures against unmodified `main` at the same commit
- [x] Behaviour verified on real radios — Hermes-Lite 2 (gateware 75) and FLEX-6700
- [x] Reproduction documented — measured before the change, not inferred

### Live A/B — automation bridge, RX only

Control is an unmodified build of `main` @ `ae6012bf` — this PR's exact base — so the
comparison isolates this change rather than a base difference.

| Build | Radio | Station label | Width | Height |
|---|---|---|---|---|
| `main` @ `ae6012bf` | Hermes-Lite 2 | `Hermes-Lite 2` (one line) | 170px | 41px |
| this branch | Hermes-Lite 2 | `Hermes-Lite` / `2` (two centred lines) | **107px** | **41px** |
| `main` @ `ae6012bf` | FLEX-6700 | `ANT1-AV640` | 157px | 41px |
| this branch | FLEX-6700 | `ANT1-AV640` | **157px** | **41px** |

The Flex row is byte-identical between control and branch — same text, same 157px,
same x, same height. Every neighbouring status-bar row (`CPU:`, `PA`, `Network:`)
keeps its y position at 762 in all four cases, which is the check that the bar did not
grow.

### ctest

**189 passed, 1 failed, 1 skipped** of 191 on this branch.

The single failure, `cross_needle_meter_test`, reproduces on an unmodified build of
`main` @ `ae6012bf` — I built and ran that target on a clean worktree of the same
commit to confirm. Its failing check is *"SWR label placement cache is keyed by the
rendered font"*. `crdv_quarantined_test` is skipped by the project. **No new
failures.**

### No unit test, deliberately

These are free functions in `MainWindow.cpp`, behind the full GUI link that no test
target takes. That is the same boundary `radio_capability_gating_test` states for the
widget calls it leaves to the bridge: *"Those sit behind the full GUI link, which no
test target takes... proven on the running app with the automation bridge."* Making
them testable would mean extracting a status-bar text unit, which is a refactor rather
than this fix. Happy to do it as a follow-up if you'd rather have the seam.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls (Principle V) — no settings touched
- [x] Code is clean-room (Principle IV)
- [x] All meter UI uses `MeterSmoother` — n/a, no meter path touched
- [x] Documentation updated if user-visible behavior changed — no architecture doc
      covers the status-bar station label; happy to add one if you want it recorded
- [ ] Security-sensitive changes reference a GHSA — n/a

### Two observations for you, not fixed here

1. **The status bar shows the model twice on an HL2.** `Hermes-Lite 2` / `75` sits in
   the model/version stack, and the station box then repeats `Hermes-Lite 2` because
   there is no operator nickname to show. This change makes the duplication tidier
   rather than removing it. The arguably better fix is upstream of the label — don't
   substitute a model string into a *station* field — but that is
   `Hl2Discovery::effectiveNickname()` and your call, so I have not touched it.
2. **The station label and the GPS/reference stack overlap at narrow widths.** With a
   Flex connected and the reference reading `OCXO_GPS`, the two collide in the capture
   at a 1400px window. This reproduces on unmodified `main`, so it predates this
   change, and I have not isolated whether the 63px this reclaims is enough to clear
   it in the HL2 case.

### On the base branch

This came off the same HL2 to-do list as the supply-voltage work, where the guidance was
*"for suppressing UX, use PR 4508 as your base"*. This one is based on `main` instead,
deliberately: it suppresses nothing — the label stays visible on every backend — and it
touches only the station-label helpers, which #4508 does not modify (its
`MainWindow.cpp` delta is 131 pure insertions, none of them in this code). Basing it
here lets it land without waiting on #4503 → #4508.

If you would rather have it on the stack, it rebases cleanly — I verified by
cherry-picking this commit onto `pull/4508/head`, which auto-merged with no conflict.
Say the word and I will move it.

---

73, Ozy **K6OZY**
