### PR TITLE
fix(hl2): TUNE keys at TUNE power, not RF power

### DIFF
--- a/src/core/backends/IRadioBackend.h
+++ b/src/core/backends/IRadioBackend.h
@@ -142,11 +142,22 @@ public:
     // capabilities().canTransmit is false implements this as a no-op.
     virtual void setKeying(bool key) = 0;
 
-    // Tune carrier on/off.
+    // Tune carrier on/off, at the operator's TUNE power (percent, 0..100).
     //
     // Flex takes "transmit tune N" as a text command, so FlexBackend has nothing
     // to do here. A backend that generates its own carrier implements it.
-    virtual void setTune(bool on) { Q_UNUSED(on); }
+    //
+    // tunePowerPercent is passed because a host-modulated backend has no other
+    // route to it: it raises its own carrier and sets its own drive, so without
+    // the value here it can only transmit at whatever setTxPower() last pushed —
+    // the RF Power slider. That made TUNE key at FULL power for anyone running
+    // RF 100 / Tune 10, which is the opposite of what the control is for.
+    // Defaulted so existing implementations stay source-compatible.
+    virtual void setTune(bool on, int tunePowerPercent = -1)
+    {
+        Q_UNUSED(on);
+        Q_UNUSED(tunePowerPercent);
+    }
 
     // Transmit power as a percentage, 0..100.
     //

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -841,8 +841,25 @@ void Hl2Backend::setKeying(bool key)
     // clearing that indiscriminately broke exactly that case.
     if (key && !m_tuning && m_toneFromTune)
         setTxTestTone(0.0, 0.0);
-    if (!key)
-        m_tuning = false;   // an unkey ends tune too, however it was started
+    if (!key) {
+        // An unkey ends tune too, however it was started — so the drive register
+        // has to come back HERE, not in setTune()'s release branch.
+        //
+        // setTune(false, …) is only reached when the operator releases the TUNE
+        // toggle. Every other way a tune ends — the automation TX watchdog and
+        // the key verb via RadioModel::setTransmit() (RadioModel.cpp:2696), the
+        // MOX/PTT coordinator (RadioModel.cpp:674), and the disconnect reset
+        // below — calls setKeying(false) directly and never goes through
+        // setTune() at all. Restoring there left those paths unkeyed with the
+        // drive still at TUNE power, and because m_tuning is cleared on this
+        // same line, setTxPower() no longer held off: the radio stayed at tune
+        // power until the operator happened to move the slider. A subsequent
+        // voice transmission would have gone out at 10%.
+        const bool wasTuning = m_tuning;
+        m_tuning = false;
+        if (wasTuning)
+            setTxPower(m_rfPowerPercent);
+    }
     if (m_metis)
         QMetaObject::invokeMethod(m_metis, "setMox", Qt::QueuedConnection,
             Q_ARG(bool, key));
@@ -940,29 +957,33 @@ void Hl2Backend::setTune(bool on, int tunePowerPercent)
     // running RF 100 / Tune 10 got a FULL-POWER carrier from a control whose
     // whole purpose is to reduce it. Flex is unaffected: it receives tune power
     // as a text command and applies it radio-side.
-    m_tuning = on;
+    // The RF power restore is NOT here: it lives in setKeying(false), which is
+    // the one point every unkey path converges on. See the comment there.
+    //
+    // m_tuning is therefore set only on the way UP, and left for setKeying() to
+    // clear on the way down. Assigning it unconditionally here would clear it
+    // before the setKeying(false) below could see it, and the restore that reads
+    // it would never fire on the one path that always goes through this
+    // function — the operator releasing the TUNE toggle.
     if (on) {
-        if (tunePowerPercent >= 0) {
-            const int clamped = tunePowerPercent > 100 ? 100 : tunePowerPercent;
-            // Straight to the drive register: setTxPower() would overwrite the
-            // saved RF power we have to restore on release.
-            if (m_txAllowed)
-                setTxDriveLevel(clamped * kTxDriveMax / 100);
-        }
+        m_tuning = true;
+        // Straight to the drive register rather than through setTxPower(), which
+        // would overwrite the saved RF power we have to restore on release.
+        if (tunePowerPercent >= 0)
+            applyDrive(tunePowerPercent);
         setTxTestTone(0.0, kTuneCarrierAmplitude);
         m_toneFromTune = true;   // set AFTER: setTxTestTone clears the flag
         setKeying(true);
     } else {
-        setKeying(false);
+        setKeying(false);   // clears m_tuning and restores the operator's RF power
         setTxTestTone(0.0, 0.0);
-        // Restore the operator's RF power. m_tuning is already false, so this
-        // takes the normal path rather than being swallowed by the tuning guard.
-        if (tunePowerPercent >= 0)
-            setTxPower(m_rfPowerPercent);
     }
 }
 
-void Hl2Backend::setTxPower(int percent)
+// Clamp, map to the drive register, and honour the transmit gate. Shared by
+// setTxPower() and setTune() so the mapping — whose coarseness is documented in
+// setTxPower() — exists once and cannot drift between the two.
+void Hl2Backend::applyDrive(int percent)
 {
     // Drive is gated exactly like keying. setTxDriveLevel writes the PA-enable
     // bit (0x09[19]) every frame, so an ungated call — e.g. the push-current-
@@ -973,18 +994,25 @@ void Hl2Backend::setTxPower(int percent)
         setTxDriveLevel(0);
         return;
     }
+    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    setTxDriveLevel(clamped * kTxDriveMax / 100);
+}
+
+void Hl2Backend::setTxPower(int percent)
+{
     // The operator's 0..100 maps onto the HL2's 0..255 drive field. The gateware
     // only decodes the top nibble, so the effective resolution is coarser than
     // this suggests — the mapping is linear in the register, NOT calibrated to
     // watts, and nothing here should imply otherwise.
-    const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
-    // Remember the operator's drive so setTune() can drop to tune power and put
-    // this back afterwards. Recorded even while tuning: a power change made
-    // mid-tune is still what the operator wants once the carrier drops.
-    m_rfPowerPercent = clamped;
+    //
+    // Remember the operator's drive so setTune() can drop to tune power and the
+    // unkey can put this back. Recorded BEFORE the transmit gate and even while
+    // tuning: a power change made mid-tune, or while TX is blocked, is still
+    // what the operator wants once the carrier drops or the gate opens.
+    m_rfPowerPercent = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
     if (m_tuning)
         return;   // tune power owns the drive register until the carrier drops
-    setTxDriveLevel(clamped * kTxDriveMax / 100);
+    applyDrive(m_rfPowerPercent);
 }
 
 void Hl2Backend::setTxDriveLevel(int level)

--- a/src/core/backends/hl2/Hl2Backend.cpp
+++ b/src/core/backends/hl2/Hl2Backend.cpp
@@ -922,7 +922,7 @@ void Hl2Backend::setTxTestTone(double offsetHz, double amplitude)
         Q_ARG(double, offsetHz), Q_ARG(double, amplitude));
 }
 
-void Hl2Backend::setTune(bool on)
+void Hl2Backend::setTune(bool on, int tunePowerPercent)
 {
     // A tune carrier is an unmodulated steady signal at the transmit frequency.
     // The HL2 has no tune generator of its own, so it is the built-in test tone
@@ -933,14 +933,32 @@ void Hl2Backend::setTune(bool on)
     // the first frames on the air already carry it rather than silence, and drop
     // the key BEFORE the carrier on the way out so nothing is left radiating if
     // the tone clear is delayed behind other queued control verbs.
+    //
+    // Drive is set from TUNE power, not RF power. The carrier amplitude is a
+    // fixed full-scale constant, so without this the drive register still held
+    // whatever setTxPower() last pushed — the RF Power slider — and an operator
+    // running RF 100 / Tune 10 got a FULL-POWER carrier from a control whose
+    // whole purpose is to reduce it. Flex is unaffected: it receives tune power
+    // as a text command and applies it radio-side.
     m_tuning = on;
     if (on) {
+        if (tunePowerPercent >= 0) {
+            const int clamped = tunePowerPercent > 100 ? 100 : tunePowerPercent;
+            // Straight to the drive register: setTxPower() would overwrite the
+            // saved RF power we have to restore on release.
+            if (m_txAllowed)
+                setTxDriveLevel(clamped * kTxDriveMax / 100);
+        }
         setTxTestTone(0.0, kTuneCarrierAmplitude);
         m_toneFromTune = true;   // set AFTER: setTxTestTone clears the flag
         setKeying(true);
     } else {
         setKeying(false);
         setTxTestTone(0.0, 0.0);
+        // Restore the operator's RF power. m_tuning is already false, so this
+        // takes the normal path rather than being swallowed by the tuning guard.
+        if (tunePowerPercent >= 0)
+            setTxPower(m_rfPowerPercent);
     }
 }
 
@@ -960,6 +978,12 @@ void Hl2Backend::setTxPower(int percent)
     // this suggests — the mapping is linear in the register, NOT calibrated to
     // watts, and nothing here should imply otherwise.
     const int clamped = percent < 0 ? 0 : (percent > 100 ? 100 : percent);
+    // Remember the operator's drive so setTune() can drop to tune power and put
+    // this back afterwards. Recorded even while tuning: a power change made
+    // mid-tune is still what the operator wants once the carrier drops.
+    m_rfPowerPercent = clamped;
+    if (m_tuning)
+        return;   // tune power owns the drive register until the carrier drops
     setTxDriveLevel(clamped * kTxDriveMax / 100);
 }
 

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -59,7 +59,10 @@ public:
     void setKeying(bool key) override;
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
     void setTxPower(int percent) override;
-    void setTune(bool on, int tunePowerPercent = -1) override;
+    // No default argument here on purpose: defaults on virtuals bind statically,
+    // so repeating the base's is how the two quietly diverge later. The sole
+    // call site passes it explicitly.
+    void setTune(bool on, int tunePowerPercent) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
     // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
@@ -75,6 +78,9 @@ private:
     void pushInitialState();
     void defineMeters();
     void publishTelemetry(const Hl2Telemetry& t);
+    // Clamp 0..100, map onto the drive register, honour the transmit gate.
+    // Shared by setTxPower() and setTune() so the mapping exists exactly once.
+    void applyDrive(int percent);
     static double temperatureCelsius(int raw);
 
     MetisClient* m_metis = nullptr;

--- a/src/core/backends/hl2/Hl2Backend.h
+++ b/src/core/backends/hl2/Hl2Backend.h
@@ -59,7 +59,7 @@ public:
     void setKeying(bool key) override;
     void submitTxAudio(const QByteArray& int16Stereo, int sampleRateHz) override;
     void setTxPower(int percent) override;
-    void setTune(bool on) override;
+    void setTune(bool on, int tunePowerPercent = -1) override;
     void setTxFrequency(double hz);
     void setTxDriveLevel(int level);
     // Baseband TX test tone, offsetHz from the carrier, amplitude 0..1.
@@ -138,6 +138,11 @@ private:
     bool m_keyed = false;
     bool m_tuning = false;
     bool m_toneFromTune = false;
+    // Last drive the operator asked for through setTxPower(), so TUNE can drop to
+    // tune power and put it back on release. Seeded to the same value
+    // TransmitModel defaults rfPower to, so a TUNE before any power change
+    // restores something sane rather than 0.
+    int m_rfPowerPercent = 100;
     // Tune-carrier amplitude, full scale into the modulator. Actual radiated
     // power is governed by the TX drive register, which is where an operator
     // sets it; scaling here as well would make the power control non-linear for

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -691,7 +691,9 @@ void RadioModel::setupBackend(const QString& family)
                 m_transmitModel.stopTune();
                 return;
             }
-            m_backend->setTune(on);
+            // Hand the backend the operator's TUNE power. A host-modulated
+            // backend has no other path to it — see IRadioBackend::setTune().
+            m_backend->setTune(on, m_transmitModel.tunePower());
             // A tune carrier is a transmission. Hl2Backend::setTune() calls
             // setKeying(), so the radio is on the air — the raw-TX edge has to
             // be published here for the same reason it is on the MOX path, and

--- a/tests/hl2_backend_test.cpp
+++ b/tests/hl2_backend_test.cpp
@@ -60,6 +60,27 @@ static void spin(int ms)
     loop.exec();
 }
 
+// Decode the TX drive level out of an EP2 packet, if this one happens to be
+// carrying the drive C&C bank (the round robin rotates through several).
+// Returns -1 when the packet carries some other bank.
+//
+// Same decode as hl2_tx_gate_test: C0 sits at SYNC(3) into each 512-byte frame,
+// the MOX bit is masked off the address, and the drive byte is C1 at +4.
+static int ep2DriveLevel(const QByteArray& dg)
+{
+    if (dg.size() < static_cast<int>(hl2::kUsbPacketSize))
+        return -1;
+    const auto* b = reinterpret_cast<const std::uint8_t*>(dg.constData());
+    if (b[0] != 0xEF || b[1] != 0xFE || b[2] != 0x01 || b[3] != 0x02)
+        return -1;   // not EP2
+    const std::size_t frameStarts[2] = {8, 8 + hl2::kFrameSize};
+    for (const std::size_t fs : frameStarts) {
+        if ((b[fs + 3] & ~hl2::kC0MoxBit) == hl2::kC0TxDrive)
+            return b[fs + 4];
+    }
+    return -1;
+}
+
 int main(int argc, char** argv)
 {
     // Redirect settings into a private temporary profile BEFORE QCoreApplication
@@ -475,6 +496,103 @@ int main(int argc, char** argv)
     // Already down via the watchdog; disconnectRadio() must not double-report.
     check(disconnectedSpy.count() == 1, "disconnect does not re-emit disconnected()");
     check(!backend.isConnected(), "isConnected() false after disconnect");
+
+    // ---- #4549: TUNE keys at TUNE power, and ANY unkey restores RF power ----
+    //
+    // The tune carrier's amplitude is a fixed full-scale constant, so the drive
+    // register is the only thing that sets tune power. Read it off the WIRE
+    // rather than from a flag: the register is what the radio actually obeys.
+    //
+    // This runs against its own UNCAPPED fake radio, not the shared one above.
+    // EP2 is paced only while the link is alive, and the shared radio stops
+    // answering after kCap frames so the silence-watchdog assertions can fire —
+    // which starves the very stream these checks read. Its own radio also keeps
+    // the drive traffic out of the earlier assertions.
+    //
+    // Sampling rule: the drive bank is a ONE-SHOT (MetisClient::setTxDriveLevel
+    // pushes onto m_oneShot; the steady round robin carries freq/gain/ADC only),
+    // so each call puts exactly one drive packet into a FIFO. Every check clears
+    // lastDrive and THEN acts and spins, so it reads a settled queue.
+    if (caps.canTransmit) {
+        QUdpSocket tuneRadio;
+        check(tuneRadio.bind(QHostAddress::LocalHost, 0), "#4549: tune fake radio binds");
+        std::uint32_t tuneSeq = 0;
+        int lastDrive = -1;
+        QObject::connect(&tuneRadio, &QUdpSocket::readyRead, &tuneRadio, [&] {
+            while (tuneRadio.hasPendingDatagrams()) {
+                const QNetworkDatagram dg = tuneRadio.receiveDatagram();
+                const int drive = ep2DriveLevel(dg.data());
+                if (drive >= 0)
+                    lastDrive = drive;
+                // Always answer: EP2 keeps flowing only while the link is up.
+                tuneRadio.writeDatagram(fakeEp6(tuneSeq++), dg.senderAddress(), dg.senderPort());
+            }
+        });
+
+        Hl2Backend tuner;
+        RadioConnectRequest tuneReq;
+        tuneReq.host = QStringLiteral("127.0.0.1");
+        tuneReq.port = tuneRadio.localPort();
+        tuner.connectRadio(tuneReq);
+        spin(300);
+        check(tuner.isConnected(), "#4549: tune backend connects");
+
+        const auto driveFor = [](int percent) { return percent * hl2::kTxDriveMax / 100; };
+        // Settle on a known RF power, distinguishable from tune power.
+        lastDrive = -1;
+        tuner.setTxPower(100);
+        spin(200);
+        check(lastDrive == driveFor(100),
+              "#4549: RF power 100 reaches the drive register");
+
+        // TUNE at 10% must DROP the drive, not inherit the RF slider. Before the
+        // fix the register still held 255 and the tune went out at FULL power.
+        lastDrive = -1;
+        tuner.setTune(true, 10);
+        spin(200);
+        check(lastDrive == driveFor(10),
+              "#4549: TUNE drives at TUNE power, not the RF Power slider");
+
+        // The unkey that does NOT go through setTune(): the automation TX
+        // watchdog and the key verb (RadioModel.cpp:2696) and the MOX/PTT
+        // coordinator (RadioModel.cpp:674) all call setKeying(false) directly.
+        // That clears m_tuning, so restoring in setTune()'s release branch left
+        // these paths at TUNE power with setTxPower() no longer holding off —
+        // the radio stayed at 10% until the slider next moved, and the next
+        // voice transmission went out at tune power.
+        lastDrive = -1;
+        tuner.setKeying(false);
+        spin(200);
+        check(lastDrive == driveFor(100),
+              "#4549: an unkey that BYPASSES setTune() still restores RF power");
+
+        // The ordinary path — releasing the TUNE toggle — restores too.
+        tuner.setTune(true, 10);
+        spin(200);
+        lastDrive = -1;
+        tuner.setTune(false, 10);
+        spin(200);
+        check(lastDrive == driveFor(100),
+              "#4549: releasing TUNE restores RF power");
+
+        // A power change made mid-tune is the operator's intent for after the
+        // carrier drops: remembered, but not applied while the carrier is up.
+        tuner.setTune(true, 10);
+        spin(200);
+        lastDrive = -1;
+        tuner.setTxPower(40);
+        spin(200);
+        check(lastDrive == -1,
+              "#4549: a mid-tune power change does not disturb the tune carrier");
+        lastDrive = -1;
+        tuner.setTune(false, 10);
+        spin(200);
+        check(lastDrive == driveFor(40),
+              "#4549: the unkey restores the power set DURING the tune");
+
+        tuner.disconnectRadio();
+        spin(50);
+    }
 
     // ---- F4 (#4448): a connect to a radio that never answers must surface a
     // connectionError (from MetisClient::connectFailed), not wedge silently. ----


### PR DESCRIPTION
Fixes #4549.

## The bug

On the Hermes-Lite 2, TUNE transmits at the **RF Power** level. The Tune Power slider does nothing.

Set RF Power 100 / Tune Power 10 — an ordinary configuration — press TUNE, and the radio keys at 100, into whatever is connected, for as long as tune is held. That is the opposite of what the control exists for.

## Why

`RadioModel` called the backend with no power, and the seam had nowhere to put one:

```cpp
virtual void setTune(bool on) { Q_UNUSED(on); }
```

`Hl2Backend::setTune()` raises the carrier at a fixed full-scale constant (`kTuneCarrierAmplitude = 1.0`), so the **drive register** still held whatever `setTxPower()` last pushed. `grep -c tunePower src/core/backends/hl2/Hl2Backend.cpp` returns **0** — the backend never saw the value.

The control was wired correctly all along (`MainWindow_Controllers.cpp` → `TransmitModel::setTunePower`) and reaches FlexRadio over the status protocol (`FlexBackend.cpp`, `carryClamp(kvs, "tunepower", …)`). That is presumably why this went unnoticed: on Flex the radio applies tune power itself, so nothing in the shared path ever needed to carry it. It bites any backend that modulates its own carrier host-side — the HL2 today, and the sim or a future in-process backend by inheritance.

### A second bug, found in review

Review caught that the first version of this fix restored RF power only in `setTune()`'s release branch — but `m_tuning` is cleared by **any** unkey (`Hl2Backend.cpp:845`). A tune ended any other way never called `setTune(false, …)`, so the drive register stayed at TUNE power, and because `m_tuning` was now false `setTxPower()` no longer held off. The radio sat at tune power until the operator next moved the slider, and **the next voice transmission went out at tune power**.

Relocating the restore to `setKeying(false)` then exposed a third: `setTune()` assigned `m_tuning = on` unconditionally at the top, clearing the flag before its own `setKeying(false)` could observe it. Left uncorrected, the restore would have fired on *no* path at all — including the TUNE toggle that previously worked.

## The change

`setTune()` gains the operator's tune power, **defaulted to -1** so every existing implementation stays source-compatible and behaviourally unchanged. `Hl2Backend` applies it to the drive register for the duration of the carrier.

RF power is restored in **`setKeying(false)`** — the one point every unkey path converges on — gated on the `m_tuning` it is about to clear. `m_tuning` is therefore set only on the way up and left for `setKeying()` to clear on the way down.

`applyDrive()` holds the clamp, the percent→register mapping and the `m_txAllowed` gate once; `setTxPower()` and `setTune()` were each carrying a copy. `setTxPower()` records the operator's value *before* the transmit gate and while tuning, so a power change made mid-tune — or while TX is blocked — still takes effect once the carrier drops or the gate opens.

## Verification — on air, real hardware

Hermes-Lite 2 `00:1C:C0:A2:13:DD`, gateware 74, 14.100 MHz USB, **RF Power 100 / Tune Power 10**. Observable is the radio's raw forward-power ADC counts from `aether.hl2.tx` — FWDPWR is deliberately not published as a meter on this backend (uncalibrated counts, `Hl2Backend.cpp:1127`), so the log is the honest channel. Counts are monotonic in drive; no watts are claimed. A 1500 Hz tone is fed through the TX chain so a PTT transmission produces a real RF-power carrier.

**Tune power is honoured, and the observable discriminates drive:**

| tune power | fwd counts |
|---|---|
| 10 % | 1748 |
| 30 % | 2161 |
| 60 % | 3039 |
| 100 % | 3835 |

**The unkey bug, reproduced and fixed.** The sequence is TUNE on → `key mox` (keys over the live tune) → `key mox` (unkeys) → transmit. That unkey goes through `RadioModel::setTransmit` → `setKeying(false)` and never enters `setTune()`.

At the drive register, instrumented on both binaries:

| after the mox unkey | drive write |
|---|---|
| **pre-fix** | *(none)* — register left at 25 (tune power 10) |
| **fixed** | `DRIVEWRITE level 255 m_tuning false m_rfPowerPercent 100` |

On the air, with a tone-fed PTT:

| | reference PTT | PTT after mox-over-tune unkey | ratio |
|---|---|---|---|
| **pre-fix** | 2408 | **851** | **0.35** |
| **fixed** | 2185 | 2428 | 1.11 |

Mic drive was equivalent across every run (−0.8 to −3.6 dBFS peak), so the difference is drive, not audio level. The pre-fix radio transmitted at roughly a third of the requested power with nothing on screen to explain it.

**Tests.** `hl2_backend_test` gains a wire-level block that decodes the TX drive C&C bank off EP2 and pins both halves — tune drops the drive to TUNE power, and an unkey that bypasses `setTune()` restores RF power. It runs against its own uncapped fake radio, because EP2 is paced only while the link is alive and the shared fake stops answering after `kCap` frames so the silence-watchdog assertions can fire.

Red-before/green-after: with the restore back in `setTune()`'s release branch, exactly one case fails — `an unkey that BYPASSES setTune() still restores RF power` — and the rest pass, which is the correct signature of the reported bug.

`ctest -R "hl2|tx_applet|tune|transmit|radio"` — **29/29** on Windows/MSVC. Full tree builds.

## Blast radius

FlexRadio is untouched: it never reaches `IRadioBackend::setTune()` for power, and its text-command path is unchanged. Backends that do not override `setTune` keep the default no-op.

Worth a note for reviewers: reduced-drive tuning is also what `AtuPreTuneDialog.cpp:578` assumes when it reads `tunePower()` and warns above a threshold. That warning was reasoning about a value the HL2 path did not use.
