### PR TITLE
fix(automation): refuse Hz passed to the MHz tune verb

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1089,6 +1089,27 @@ transverter could plausibly need still passes. It is deliberately not
 auto-corrected: `14200000` would have to mean 14.2 MHz here and something else
 in every other frequency verb.
 
+Four refusals guard the value, and the wording differs on purpose:
+
+| input | reply |
+|---|---|
+| `> 300000` | `tune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)` |
+| `> 105000`, `<= 300000` | `tune takes MHz — got 122250, above the 105000 MHz ceiling. If that was Hz, resend as 0.122250; if it is a millimetre-wave frequency in MHz, it is beyond what AetherSDR can tune` |
+| `< 0.001` | `tune requires at least 0.001 MHz — got 1e-300` |
+| `nan`, `inf`, `-inf`, `0`, negatives, unparseable | `tune requires a positive finite frequency in MHz` |
+
+The second row exists because that window is genuinely ambiguous — an Hz
+mistake, or a real millimetre-wave allocation (122.25 / 134 / 241 GHz) entered
+correctly in MHz — so the reply offers both readings rather than asserting a
+conversion. `nan` and `inf` get their own row because `"nan"` parses as a number
+and fails every range comparison, so it would otherwise pass the guard entirely.
+
+**kHz-for-MHz is accepted**, not refused: `tune 14200` is indistinguishable from
+a 14.2 GHz transverter request, which is inside the headroom the ceiling exists
+to protect. It reaches the radio and, if 14.2 GHz is out of range, becomes the
+same silent no-op described below — so a client that might send kHz should
+verify with [`get slices`](#get).
+
 Note `ok:true` is an **acknowledgement, not a confirmation** — `tune` echoes the
 frequency you asked for. The slice model records a tune optimistically and the
 radio's own value arrives asynchronously afterwards, so a request the radio

--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1077,6 +1077,25 @@ belongs to another client` when another client owns it (Multi-Flex). To
 recenter the *pan* (band change) rather than move the slice within it, use
 [`pan center`](#pan).
 
+**The value is MHz.** Passing Hz is refused rather than converted:
+
+```json
+→ {"cmd":"tune","value":"14200000"}
+← {"ok":false,"error":"tune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)"}
+```
+
+The threshold is 105000 (ten times the top of the band table), so any value a
+transverter could plausibly need still passes. It is deliberately not
+auto-corrected: `14200000` would have to mean 14.2 MHz here and something else
+in every other frequency verb.
+
+Note `ok:true` is an **acknowledgement, not a confirmation** — `tune` echoes the
+frequency you asked for. The slice model records a tune optimistically and the
+radio's own value arrives asynchronously afterwards, so a request the radio
+rejects or clamps still returns `ok:true` with the requested value echoed back.
+Read the frequency back with [`get slices`](#get) if you need to know where the
+radio actually landed.
+
 ### `targettune`
 Tune through the same absolute-target policy used by typed frequency entry and
 other commanded jumps. Unlike `tune`, this can preselect a different band stack

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -55,6 +55,7 @@
 #include <QVariantMap>
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <limits>
 #include <utility>
@@ -6102,8 +6103,12 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
         return err(QStringLiteral("no radio model available"));
     bool okF = false;
     const double mhz = value.toDouble(&okF);
-    if (!okF || mhz <= 0)
-        return err(QStringLiteral("tune requires a positive frequency in MHz"));
+    // toDouble() accepts "nan" and "inf". NaN in particular sails past every
+    // range check below (NaN <= 0 and NaN > ceiling are both false), so
+    // non-finite input must be refused here, by name, where the message is
+    // about the value itself rather than a unit mistake it isn't.
+    if (!okF || !std::isfinite(mhz) || mhz <= 0)
+        return err(QStringLiteral("tune requires a positive finite frequency in MHz"));
     // Hz passed to an MHz verb. A value above anything AE can tune is a unit
     // mistake rather than an ambitious request, and saying so beats silently
     // doing nothing. It is NOT auto-converted: guessing the caller's intent
@@ -6116,13 +6121,35 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     // the ones a 1 THz threshold let through, such as `tune 500000` for 500 kHz,
     // which would otherwise fall past the guard and land back in the silent
     // no-op this refusal exists to prevent.
+    //
+    // kHz-for-MHz (e.g. `tune 14200` for 20m) deliberately PASSES: that value
+    // is indistinguishable from a legitimate microwave request (14.2 GHz is
+    // inside the transverter headroom this ceiling exists to protect), and
+    // refusing the range would break real 24/47/76 GHz operation. A band-table
+    // lookup was considered and rejected for the same reason — XVTR RF
+    // frequency is user-configurable beyond the table. Decided, not overlooked.
     constexpr double kMaxTunableMhz = 105'000.0;
-    if (mhz > kMaxTunableMhz)
+    if (mhz > kMaxTunableMhz) {
+        // Above the ceiling but below 300 GHz is genuinely ambiguous: it reads
+        // as an Hz-for-MHz mistake OR as a real millimetre-wave allocation
+        // entered correctly in MHz (122.25 / 134 / 241 GHz). Refuse either way,
+        // but present both readings — telling someone dialling a 122 GHz
+        // transverter "did you mean 0.122250?" would be confidently wrong,
+        // which is the failure mode this guard's messaging exists to avoid.
+        if (mhz <= 300'000.0)
+            return err(QStringLiteral("tune takes MHz — got ")
+                       + QString::number(mhz, 'f', 0)
+                       + QStringLiteral(", above the 105000 MHz ceiling. If that was "
+                                        "Hz, resend as ")
+                       + QString::number(mhz / 1.0e6, 'f', 6)
+                       + QStringLiteral("; if it is a millimetre-wave frequency in "
+                                        "MHz, it is beyond what AE can tune"));
         return err(QStringLiteral("tune takes MHz, not Hz — got ")
                    + QString::number(mhz, 'f', 0)
                    + QStringLiteral(" (did you mean ")
                    + QString::number(mhz / 1.0e6, 'f', 6)
                    + QStringLiteral("?)"));
+    }
 
     int sliceId = -1;  // -1 = active slice
     if (!id.isEmpty()) {
@@ -6168,9 +6195,9 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     // asynchronously, in applyStatus(). An echo is at least honest about being
     // an acknowledgement rather than a confirmation. Closing the gap properly
     // means waiting on that status update — a different change, and one that
-    // has to be made in MainWindow::automationTune (MainWindow.cpp:6355), which
-    // is the path the shipping app actually takes (see the m_tuneHandler
-    // dispatch above).
+    // has to be made in MainWindow::automationTune (the handler installed by
+    // MainWindow_Session.cpp), which is the path the shipping app actually
+    // takes (see the m_tuneHandler dispatch above).
     return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
                        {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
 }

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -6104,12 +6104,20 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     const double mhz = value.toDouble(&okF);
     if (!okF || mhz <= 0)
         return err(QStringLiteral("tune requires a positive frequency in MHz"));
-    // Hz passed to an MHz verb. No radio AE drives reaches 1 THz, so a value this
-    // large is a unit mistake rather than an ambitious tune, and saying so beats
-    // silently doing nothing. It is NOT auto-converted: guessing the caller's
-    // intent would make 14200000 mean 14.2 MHz here and something else in every
-    // other frequency verb.
-    if (mhz > 1.0e6)
+    // Hz passed to an MHz verb. A value above anything AE can tune is a unit
+    // mistake rather than an ambitious request, and saying so beats silently
+    // doing nothing. It is NOT auto-converted: guessing the caller's intent
+    // would make 14200000 mean 14.2 MHz here and something else in every other
+    // frequency verb.
+    //
+    // The ceiling is 10x the top of the band table (3cm ends at 10.5 GHz), so it
+    // clears any real transverter setup with an order of magnitude to spare
+    // while still catching the whole family of Hz-for-MHz mistakes — including
+    // the ones a 1 THz threshold let through, such as `tune 500000` for 500 kHz,
+    // which would otherwise fall past the guard and land back in the silent
+    // no-op this refusal exists to prevent.
+    constexpr double kMaxTunableMhz = 105'000.0;
+    if (mhz > kMaxTunableMhz)
         return err(QStringLiteral("tune takes MHz, not Hz — got ")
                    + QString::number(mhz, 'f', 0)
                    + QStringLiteral(" (did you mean ")
@@ -6151,32 +6159,20 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
         return err(QStringLiteral("refused: slice ") + s->letter() + QStringLiteral(" is VFO-locked"));
 
     s->setFrequency(mhz);
-
-    // Report what the slice ACTUALLY took, not what was asked for.
+    // The reply echoes the REQUEST, and cannot do better from here.
     //
-    // setFrequency() assigns unconditionally and the radio is free to reject the
-    // value — an out-of-band target leaves the slice where it was. Echoing the
-    // request made every such no-op indistinguishable from success: ok:true, the
-    // requested frequency echoed back, no error, and only a follow-up `get slices`
-    // revealing the radio had not moved. A caller that trusted the reply would go
-    // on to key on the previous band.
-    //
-    // The common way to hit this is passing Hz to a verb documented as MHz: an
-    // in-band Hz value is clamped and appears to work, so the mistake stays hidden
-    // until the first band change.
-    const double applied = s->frequency();
-    QJsonObject r{{QStringLiteral("ok"), true},
-                  {QStringLiteral("tune"), applied},
-                  {QStringLiteral("sliceId"), s->sliceId()},
-                  {QStringLiteral("letter"), s->letter()}};
-    if (!qFuzzyCompare(applied, mhz)) {
-        // Surfaced rather than failed: the radio, not this verb, decides what is
-        // reachable, and a clamp to a band edge is a legitimate outcome. The
-        // caller gets both numbers and can decide for itself.
-        r.insert(QStringLiteral("requested"), mhz);
-        r.insert(QStringLiteral("applied"), false);
-    }
-    return r;
+    // Confirming what the radio actually took would need a read-back, and there
+    // is nothing to read: SliceModel::setFrequency() assigns m_frequency = mhz
+    // before it sends `slice tune` (SliceModel.cpp:117-124), so the model holds
+    // the request by construction and the radio's real value only arrives later,
+    // asynchronously, in applyStatus(). An echo is at least honest about being
+    // an acknowledgement rather than a confirmation. Closing the gap properly
+    // means waiting on that status update — a different change, and one that
+    // has to be made in MainWindow::automationTune (MainWindow.cpp:6355), which
+    // is the path the shipping app actually takes (see the m_tuneHandler
+    // dispatch above).
+    return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
+                       {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
 }
 
 // ── Demo fault injection (RFC #4288 #4) ─────────────────────────────────────

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -6104,6 +6104,17 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     const double mhz = value.toDouble(&okF);
     if (!okF || mhz <= 0)
         return err(QStringLiteral("tune requires a positive frequency in MHz"));
+    // Hz passed to an MHz verb. No radio AE drives reaches 1 THz, so a value this
+    // large is a unit mistake rather than an ambitious tune, and saying so beats
+    // silently doing nothing. It is NOT auto-converted: guessing the caller's
+    // intent would make 14200000 mean 14.2 MHz here and something else in every
+    // other frequency verb.
+    if (mhz > 1.0e6)
+        return err(QStringLiteral("tune takes MHz, not Hz — got ")
+                   + QString::number(mhz, 'f', 0)
+                   + QStringLiteral(" (did you mean ")
+                   + QString::number(mhz / 1.0e6, 'f', 6)
+                   + QStringLiteral("?)"));
 
     int sliceId = -1;  // -1 = active slice
     if (!id.isEmpty()) {
@@ -6140,8 +6151,32 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
         return err(QStringLiteral("refused: slice ") + s->letter() + QStringLiteral(" is VFO-locked"));
 
     s->setFrequency(mhz);
-    return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("tune"), mhz},
-                       {QStringLiteral("sliceId"), s->sliceId()}, {QStringLiteral("letter"), s->letter()}};
+
+    // Report what the slice ACTUALLY took, not what was asked for.
+    //
+    // setFrequency() assigns unconditionally and the radio is free to reject the
+    // value — an out-of-band target leaves the slice where it was. Echoing the
+    // request made every such no-op indistinguishable from success: ok:true, the
+    // requested frequency echoed back, no error, and only a follow-up `get slices`
+    // revealing the radio had not moved. A caller that trusted the reply would go
+    // on to key on the previous band.
+    //
+    // The common way to hit this is passing Hz to a verb documented as MHz: an
+    // in-band Hz value is clamped and appears to work, so the mistake stays hidden
+    // until the first band change.
+    const double applied = s->frequency();
+    QJsonObject r{{QStringLiteral("ok"), true},
+                  {QStringLiteral("tune"), applied},
+                  {QStringLiteral("sliceId"), s->sliceId()},
+                  {QStringLiteral("letter"), s->letter()}};
+    if (!qFuzzyCompare(applied, mhz)) {
+        // Surfaced rather than failed: the radio, not this verb, decides what is
+        // reachable, and a clamp to a band edge is a legitimate outcome. The
+        // caller gets both numbers and can decide for itself.
+        r.insert(QStringLiteral("requested"), mhz);
+        r.insert(QStringLiteral("applied"), false);
+    }
+    return r;
 }
 
 // ── Demo fault injection (RFC #4288 #4) ─────────────────────────────────────

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -1124,6 +1124,20 @@ QJsonObject err(const QString& msg)
                        {QStringLiteral("error"), msg}};
 }
 
+// Render a frequency for an error message the way the caller typed it.
+//
+// 'f' with a fixed decimal count is wrong in both directions here: rounding a
+// rejected value to whole MHz makes 105000.4 report as "105000, above the
+// 105000 MHz ceiling", and printing a tiny one in full gives 300 leading zeros.
+// 'g' with 15 significant digits keeps every realistic value in plain notation
+// (it only goes exponential below 1e-5 or above 1e15, which is exactly where
+// plain notation stops being readable), and 15 digits stays inside double's
+// exact range so no rounding artifacts leak into a user-facing string.
+QString formatMhz(double mhz)
+{
+    return QString::number(mhz, 'g', 15);
+}
+
 QJsonObject deferredResponse()
 {
     return QJsonObject{{QStringLiteral("_deferred"), true}};
@@ -6109,11 +6123,25 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     // about the value itself rather than a unit mistake it isn't.
     if (!okF || !std::isfinite(mhz) || mhz <= 0)
         return err(QStringLiteral("tune requires a positive finite frequency in MHz"));
-    // Hz passed to an MHz verb. A value above anything AE can tune is a unit
-    // mistake rather than an ambitious request, and saying so beats silently
-    // doing nothing. It is NOT auto-converted: guessing the caller's intent
-    // would make 14200000 mean 14.2 MHz here and something else in every other
-    // frequency verb.
+    // Below anything a supported radio tunes. Matches the floor typed frequency
+    // entry already applies to the same value (VfoWidget.cpp / RxApplet.cpp,
+    // `freqMhz >= 0.001`), so the bridge and the VFO field agree on what is too
+    // small rather than the bridge passing values the GUI would refuse.
+    //
+    // This is NOT a unit guard and does not pretend to be one: GHz-for-MHz on HF
+    // (`tune 0.0142` meaning 14.2 MHz) lands at 14.2 kHz, which is a plausible
+    // VLF frequency, not a diagnosable mistake. What it does stop is nonsense
+    // (`tune 1e-300`) reaching setFrequency() and the radio.
+    constexpr double kMinTunableMhz = 0.001;
+    if (mhz < kMinTunableMhz)
+        return err(QStringLiteral("tune requires at least ")
+                   + formatMhz(kMinTunableMhz) + QStringLiteral(" MHz — got ")
+                   + formatMhz(mhz));
+    // Hz passed to an MHz verb. A value above anything AetherSDR can tune is a
+    // unit mistake rather than an ambitious request, and saying so beats
+    // silently doing nothing. It is NOT auto-converted: guessing the caller's
+    // intent would make 14200000 mean 14.2 MHz here and something else in every
+    // other frequency verb.
     //
     // The ceiling is 10x the top of the band table (3cm ends at 10.5 GHz), so it
     // clears any real transverter setup with an order of magnitude to spare
@@ -6122,10 +6150,16 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     // which would otherwise fall past the guard and land back in the silent
     // no-op this refusal exists to prevent.
     //
+    // It is deliberately LOOSER than the 50000.0 MHz cap typed frequency entry
+    // applies on XVTR (VfoWidget.cpp / RxApplet.cpp): the GUI cap is a limit on
+    // what a human can dial, while this one only has to be high enough that no
+    // real request trips it. Neither is "the" tuning limit — if one ever becomes
+    // the authority, the other should be derived from it rather than re-guessed.
+    //
     // kHz-for-MHz (e.g. `tune 14200` for 20m) deliberately PASSES: that value
     // is indistinguishable from a legitimate microwave request (14.2 GHz is
     // inside the transverter headroom this ceiling exists to protect), and
-    // refusing the range would break real 24/47/76 GHz operation. A band-table
+    // refusing the range would break real 24 and 47 GHz operation. A band-table
     // lookup was considered and rejected for the same reason — XVTR RF
     // frequency is user-configurable beyond the table. Decided, not overlooked.
     constexpr double kMaxTunableMhz = 105'000.0;
@@ -6137,15 +6171,13 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
         // transverter "did you mean 0.122250?" would be confidently wrong,
         // which is the failure mode this guard's messaging exists to avoid.
         if (mhz <= 300'000.0)
-            return err(QStringLiteral("tune takes MHz — got ")
-                       + QString::number(mhz, 'f', 0)
-                       + QStringLiteral(", above the 105000 MHz ceiling. If that was "
-                                        "Hz, resend as ")
+            return err(QStringLiteral("tune takes MHz — got ") + formatMhz(mhz)
+                       + QStringLiteral(", above the ") + formatMhz(kMaxTunableMhz)
+                       + QStringLiteral(" MHz ceiling. If that was Hz, resend as ")
                        + QString::number(mhz / 1.0e6, 'f', 6)
                        + QStringLiteral("; if it is a millimetre-wave frequency in "
-                                        "MHz, it is beyond what AE can tune"));
-        return err(QStringLiteral("tune takes MHz, not Hz — got ")
-                   + QString::number(mhz, 'f', 0)
+                                        "MHz, it is beyond what AetherSDR can tune"));
+        return err(QStringLiteral("tune takes MHz, not Hz — got ") + formatMhz(mhz)
                    + QStringLiteral(" (did you mean ")
                    + QString::number(mhz / 1.0e6, 'f', 6)
                    + QStringLiteral("?)"));
@@ -6190,8 +6222,8 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
     //
     // Confirming what the radio actually took would need a read-back, and there
     // is nothing to read: SliceModel::setFrequency() assigns m_frequency = mhz
-    // before it sends `slice tune` (SliceModel.cpp:117-124), so the model holds
-    // the request by construction and the radio's real value only arrives later,
+    // before it sends `slice tune`, so the model holds the request by
+    // construction and the radio's real value only arrives later,
     // asynchronously, in applyStatus(). An echo is at least honest about being
     // an acknowledgement rather than a confirmation. Closing the gap properly
     // means waiting on that status update — a different change, and one that

--- a/tests/automation_json_id_test.cpp
+++ b/tests/automation_json_id_test.cpp
@@ -79,6 +79,14 @@ QJsonObject tuneRequest(const QJsonValue& id = QJsonValue::Undefined)
     return request;
 }
 
+QJsonObject tuneValueRequest(const QString& value)
+{
+    return QJsonObject{
+        {QStringLiteral("cmd"), QStringLiteral("tune")},
+        {QStringLiteral("value"), value},
+    };
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -153,6 +161,33 @@ int main(int argc, char** argv)
                    "near-integer numeric id is not rounded up to a slice");
     expectRejected(tuneRequest(0.9999999), integerError,
                    "near-integer numeric id is not rounded down to a slice");
+
+    // ---- #4550: Hz passed to an MHz verb is refused, not silently no-opped ----
+    //
+    // A tune handler IS installed above, exactly as MainWindow_Session.cpp:1937
+    // does in the shipping app. That matters: the guard is only worth anything
+    // if it runs BEFORE the m_tuneHandler dispatch, so these cases also pin that
+    // ordering — expectRejected asserts the handler was never reached.
+    auto expectTuneValueRejected = [&](const QString& value, const char* description) {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response = client.request(tuneValueRequest(value));
+        const QString error = response.value(QStringLiteral("error")).toString();
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && error.startsWith(QStringLiteral("tune takes MHz, not Hz"))
+                  && handlerCalls == callsBefore,
+              description);
+    };
+    expectTuneValueRejected(QStringLiteral("14200000"),
+                            "#4550: 20m expressed in Hz is refused, not tuned");
+    // The case a 1 THz threshold let through: below the old guard, so it fell
+    // past it and became a 500000 MHz request — the silent no-op this refuses.
+    expectTuneValueRejected(QStringLiteral("500000"),
+                            "#4550: 500 kHz expressed in Hz is refused too");
+
+    // The ceiling must not refuse anything real. 10368.1 is the 3cm calling
+    // frequency, the top of the band table, and it has to keep working.
+    expectAccepted(tuneValueRequest(QStringLiteral("10368.1")), -1,
+                   "#4550: the top of the band table still tunes");
 
     server.stop();
     return failures == 0 ? 0 : 1;

--- a/tests/automation_json_id_test.cpp
+++ b/tests/automation_json_id_test.cpp
@@ -184,10 +184,52 @@ int main(int argc, char** argv)
     expectTuneValueRejected(QStringLiteral("500000"),
                             "#4550: 500 kHz expressed in Hz is refused too");
 
+    // Non-finite input. QString::toDouble() happily parses "nan" and "inf",
+    // and NaN in particular fails EVERY comparison (NaN <= 0 and NaN > ceiling
+    // are both false), so without an explicit isfinite check it sailed through
+    // both guards and reached the radio. These must be refused by the
+    // positive-finite check — with its message, not a bogus unit diagnosis —
+    // and must never reach the handler.
+    auto expectNonFiniteRejected = [&](const QString& value, const char* description) {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response = client.request(tuneValueRequest(value));
+        const QString error = response.value(QStringLiteral("error")).toString();
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && error == QStringLiteral("tune requires a positive finite frequency in MHz")
+                  && handlerCalls == callsBefore,
+              description);
+    };
+    expectNonFiniteRejected(QStringLiteral("nan"), "nan is refused, never tuned");
+    expectNonFiniteRejected(QStringLiteral("NaN"), "NaN is refused, never tuned");
+    expectNonFiniteRejected(QStringLiteral("inf"), "inf is refused by the finite check");
+    expectNonFiniteRejected(QStringLiteral("-inf"), "-inf is refused by the finite check");
+
+    // The ambiguous window (ceiling..300 GHz): could be an Hz mistake OR a real
+    // millimetre-wave MHz value (122.25 GHz allocation). Refused, but the
+    // message must present both readings instead of confidently asserting the
+    // wrong one ("did you mean 0.122250?" to a 122 GHz transverter user).
+    {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response =
+            client.request(tuneValueRequest(QStringLiteral("122250")));
+        const QString error = response.value(QStringLiteral("error")).toString();
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && !error.contains(QStringLiteral("did you mean"))
+                  && error.contains(QStringLiteral("millimetre-wave"))
+                  && handlerCalls == callsBefore,
+              "122.25 GHz in MHz is refused without misdiagnosing it as Hz");
+    }
+
     // The ceiling must not refuse anything real. 10368.1 is the 3cm calling
     // frequency, the top of the band table, and it has to keep working.
     expectAccepted(tuneValueRequest(QStringLiteral("10368.1")), -1,
                    "#4550: the top of the band table still tunes");
+    // kHz-for-MHz (14200 = 20m in kHz, or 14.2 GHz in MHz) deliberately passes:
+    // the value is indistinguishable from a legitimate transverter request in
+    // the headroom the ceiling protects. Pinned as a DECISION, not an omission
+    // — if this ever starts rejecting, the transverter range broke.
+    expectAccepted(tuneValueRequest(QStringLiteral("14200")), -1,
+                   "kHz-for-MHz passes: indistinguishable from a 14.2 GHz request");
 
     server.stop();
     return failures == 0 ? 0 : 1;

--- a/tests/automation_json_id_test.cpp
+++ b/tests/automation_json_id_test.cpp
@@ -164,10 +164,11 @@ int main(int argc, char** argv)
 
     // ---- #4550: Hz passed to an MHz verb is refused, not silently no-opped ----
     //
-    // A tune handler IS installed above, exactly as MainWindow_Session.cpp:1937
-    // does in the shipping app. That matters: the guard is only worth anything
-    // if it runs BEFORE the m_tuneHandler dispatch, so these cases also pin that
-    // ordering — expectRejected asserts the handler was never reached.
+    // A tune handler IS installed above, exactly as MainWindow_Session.cpp's
+    // setTuneHandler(...) call does in the shipping app. That matters: the guard
+    // is only worth anything if it runs BEFORE the m_tuneHandler dispatch, so
+    // these cases also pin that ordering — expectRejected asserts the handler
+    // was never reached.
     auto expectTuneValueRejected = [&](const QString& value, const char* description) {
         const int callsBefore = handlerCalls;
         const QJsonObject response = client.request(tuneValueRequest(value));
@@ -219,6 +220,39 @@ int main(int argc, char** argv)
                   && handlerCalls == callsBefore,
               "122.25 GHz in MHz is refused without misdiagnosing it as Hz");
     }
+
+    // A rejected value must be quoted back as sent. Rounding it to whole MHz
+    // made everything in (105000, 105000.5) report as "got 105000, above the
+    // 105000 MHz ceiling" — a message that contradicts itself, in the branch
+    // that exists to stop this guard asserting things that aren't true.
+    {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response =
+            client.request(tuneValueRequest(QStringLiteral("105000.4")));
+        const QString error = response.value(QStringLiteral("error")).toString();
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && error.contains(QStringLiteral("got 105000.4,"))
+                  && handlerCalls == callsBefore,
+              "a value just over the ceiling is quoted back unrounded");
+    }
+
+    // Floor. Nothing below what any supported radio tunes should reach
+    // setFrequency(); 0.001 matches the floor typed frequency entry applies to
+    // the same value (VfoWidget / RxApplet), so the two paths agree.
+    {
+        const int callsBefore = handlerCalls;
+        const QJsonObject response =
+            client.request(tuneValueRequest(QStringLiteral("1e-300")));
+        const QString error = response.value(QStringLiteral("error")).toString();
+        check(!response.value(QStringLiteral("ok")).toBool()
+                  && error == QStringLiteral("tune requires at least 0.001 MHz — got 1e-300")
+                  && handlerCalls == callsBefore,
+              "a sub-floor frequency is refused, never tuned");
+    }
+    // ...and the floor itself must not refuse anything real. 0.001 MHz is 1 kHz,
+    // below every amateur allocation including the VLF experiments at ~8.3 kHz.
+    expectAccepted(tuneValueRequest(QStringLiteral("0.001")), -1,
+                   "the floor value itself still tunes");
 
     // The ceiling must not refuse anything real. 10368.1 is the 3cm calling
     // frequency, the top of the band table, and it has to keep working.


### PR DESCRIPTION
Fixes #4550.

> **Revised after review.** This PR originally also tried to report what the
> slice actually took. That half was unreachable in the shipping app *and*
> could not have detected a rejection where it did run — it has been removed
> rather than moved. Detail in
> [this comment](https://github.com/aethersdr/AetherSDR/pull/4552#issuecomment-5111909430);
> the reasoning is preserved below.

## The bug

`tune` answers `ok: true` for a frequency it did not apply.

```
park at 21.2 MHz
tune 14200000  ->  {"ok": true, "tune": 14200000}   slice stays 21.2   <-- no-op
tune 14.2      ->  {"ok": true, "tune": 14.2}       slice becomes 14.2
```

The way in is passing Hz to a verb documented as `tune <mhz>`. The value is far outside any band, the radio ignores it, and every observable signal says the tune happened: `ok: true`, the frequency echoed, no error. Only a follow-up `get slices` reveals it. An in-band Hz value gets clamped and appears to work, so the mistake can stay hidden until the first band change — at which point a script tunes, confirms `ok`, and transmits on the previous band. That is how I found it, while automating a calibration sweep.

## The change

Refuse the unit mistake, naming the likely intent:

```
tune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)
```

Deliberately **not** auto-converted — guessing would make `14200000` mean 14.2 MHz here and something else in every other frequency verb.

The ceiling is `105000` MHz: ten times the top of the band table (`BandDefs.h` — 3cm ends at 10500). That clears any real transverter setup by an order of magnitude while still catching the whole family of Hz-for-MHz mistakes, including `tune 500000` for 500 kHz, which a looser threshold lets through into the same silent no-op.

The guard sits **above** the `m_tuneHandler` dispatch, so it applies on the path the shipping app actually takes.

### What this PR does *not* fix

`ok: true` remains an acknowledgement, not a confirmation. `SliceModel::setFrequency()` records the tune optimistically and the radio's own value arrives asynchronously in `applyStatus()`, so there is nothing to read back synchronously. A request the radio rejects or clamps for some *other* reason still returns `ok: true` with the request echoed.

Closing that properly means waiting on the status update, in `MainWindow::automationTune` (`MainWindow.cpp:6355`) rather than here. It is a real change and deserves its own PR. Both the code and the bridge docs now say so plainly instead of implying the reply is authoritative.

## Verification — on air, real hardware

Hermes-Lite 2 `00:1C:C0:A2:13:DD`, gateware 74. The slice is parked at 21.2 MHz first, so a silent no-op shows up as the slice failing to move:

```
park at 21.2 MHz

tune 14200000  ->  ok:false  "tune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)"
                   freq 21.2 -> 21.2   UNMOVED

tune 500000    ->  ok:false  "tune takes MHz, not Hz — got 500000 (did you mean 0.500000?)"
                   freq 21.2 -> 21.2   UNMOVED

tune 10368.1   ->  ok:true   freq 21.2     -> 10368.1   (3cm, top of the band table)
tune 14.2      ->  ok:true   freq 10368.1  -> 14.2
tune 7.1       ->  ok:true   freq 14.2     -> 7.1       (band change)
tune 14.25     ->  ok:true   freq 7.1      -> 14.25
```

Both refusals leave the slice where it was, which is the whole point — the old behaviour answered `ok:true` and moved nothing. `500000` is the case a looser threshold lets through: under 1e6 it fell past the guard and became a 500000 MHz request, landing back in the same silent no-op. `10368.1` confirms the ceiling refuses nothing real.

No regression for valid input, including across bands.

**Tests.** `automation_json_id_test` covers both refusals and pins that `10368.1` still tunes. That test installs a tune handler exactly as `MainWindow_Session.cpp:1937` does, so the cases also pin that the guard runs *before* the dispatch — they assert the handler was never reached. Verified red-before/green-after by restoring the looser threshold: the 500 kHz case fails, the rest pass.

`ctest -R "automation|bridge|slice"` — **16/16**, including `bridge_docs_check`. Full tree builds on Windows/MSVC.

## Note for reviewers

While investigating I assumed the stranded panadapter after a bridge tune was part of this. It is not — `tune` moves the slice only and `targettune` is the verb that recentres the pan, which is documented and working as intended. That observation is withdrawn.

`targettune` shares the same echo shape and the same optimistic-model caveat, and I have only exercised it with valid in-band values. It likely warrants both the guard and the async confirmation; I have not changed it here.
