### PR TITLE
Avoid macOS bitmap cursor crash paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2707,6 +2707,13 @@ target_include_directories(vfo_flag_placement_test PRIVATE src)
 target_link_libraries(vfo_flag_placement_test PRIVATE Qt6::Widgets)
 add_test(NAME vfo_flag_placement_test COMMAND vfo_flag_placement_test)
 
+add_executable(mac_cursor_compat_test
+    tests/mac_cursor_compat_test.cpp
+)
+target_include_directories(mac_cursor_compat_test PRIVATE src)
+target_link_libraries(mac_cursor_compat_test PRIVATE Qt6::Core)
+add_test(NAME mac_cursor_compat_test COMMAND mac_cursor_compat_test)
+
 add_executable(slice_model_letter_test
     tests/slice_model_letter_test.cpp
     src/models/SliceModel.cpp

--- a/src/gui/FilterPassbandWidget.cpp
+++ b/src/gui/FilterPassbandWidget.cpp
@@ -1,4 +1,5 @@
 #include "FilterPassbandWidget.h"
+#include "MacCursorCompat.h"
 
 #include <QPainterPath>
 #include <QFontMetrics>
@@ -13,7 +14,7 @@ FilterPassbandWidget::FilterPassbandWidget(QWidget* parent)
     setMinimumSize(minimumSizeHint());
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setMouseTracking(true);
-    setCursor(Qt::SizeAllCursor);
+    setCursor(macSafeCursorShape(Qt::SizeAllCursor));
 }
 
 void FilterPassbandWidget::setFilter(int lo, int hi)
@@ -126,7 +127,7 @@ void FilterPassbandWidget::mousePressEvent(QMouseEvent* ev)
         setCursor(Qt::SizeHorCursor);
     } else {
         m_dragMode = DragShift;
-        setCursor(Qt::SizeAllCursor);
+        setCursor(macSafeCursorShape(Qt::SizeAllCursor));
     }
 }
 
@@ -140,10 +141,12 @@ void FilterPassbandWidget::mouseMoveEvent(QMouseEvent* ev)
         const int loLineX = margin + SKIRT + 8;
         const int hiLineX = width() - margin - SKIRT - 8;
         const int x = ev->pos().x();
-        Qt::CursorShape wanted = (x <= loLineX || x >= hiLineX)
-            ? Qt::SizeHorCursor : Qt::SizeAllCursor;
-        if (cursor().shape() != wanted)
+        const Qt::CursorShape wanted = macSafeCursorShape(
+            (x <= loLineX || x >= hiLineX)
+                ? Qt::SizeHorCursor : Qt::SizeAllCursor);
+        if (cursor().shape() != wanted) {
             setCursor(wanted);
+        }
         return;
     }
 

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,5 +1,4 @@
 #include "FramelessResizer.h"
-#include "MacCursorCompat.h"
 
 #include <QEvent>
 #include <QGuiApplication>
@@ -77,7 +76,7 @@ void FramelessResizer::enterEdgeZone(Qt::Edges edges)
     else                                                 shape = Qt::SizeVerCursor;
 
     if (m_cursorOverridden) QGuiApplication::restoreOverrideCursor();
-    QGuiApplication::setOverrideCursor(QCursor(macSafeCursorShape(shape)));
+    QGuiApplication::setOverrideCursor(QCursor(shape));
     m_cursorOverridden = true;
     m_lastEdges = edges;
 }

--- a/src/gui/FramelessResizer.cpp
+++ b/src/gui/FramelessResizer.cpp
@@ -1,4 +1,5 @@
 #include "FramelessResizer.h"
+#include "MacCursorCompat.h"
 
 #include <QEvent>
 #include <QGuiApplication>
@@ -76,7 +77,7 @@ void FramelessResizer::enterEdgeZone(Qt::Edges edges)
     else                                                 shape = Qt::SizeVerCursor;
 
     if (m_cursorOverridden) QGuiApplication::restoreOverrideCursor();
-    QGuiApplication::setOverrideCursor(QCursor(shape));
+    QGuiApplication::setOverrideCursor(QCursor(macSafeCursorShape(shape)));
     m_cursorOverridden = true;
     m_lastEdges = edges;
 }

--- a/src/gui/MacCursorCompat.h
+++ b/src/gui/MacCursorCompat.h
@@ -4,24 +4,14 @@
 
 namespace AetherSDR {
 
-// Qt 6.11's Cocoa plugin bitmap-renders cursor shapes without native NSCursor
-// equivalents. On macOS 26 that fallback can trap in QImage::toCGImage()
-// while realizing the cursor, so substitute shapes backed by native cursors.
+// Qt 6.11's Cocoa plugin has no native NSCursor for SizeAllCursor and
+// bitmap-renders it instead. On macOS 26 that fallback can trap in
+// QImage::toCGImage(), so substitute the native open-hand cursor.
 inline Qt::CursorShape macSafeCursorShape(Qt::CursorShape shape)
 {
 #ifdef Q_OS_MAC
-    switch (shape) {
-    case Qt::SplitVCursor:
-        return Qt::SizeVerCursor;
-    case Qt::SplitHCursor:
-        return Qt::SizeHorCursor;
-    case Qt::SizeAllCursor:
+    if (shape == Qt::SizeAllCursor) {
         return Qt::OpenHandCursor;
-    case Qt::SizeBDiagCursor:
-    case Qt::SizeFDiagCursor:
-        return Qt::SizeHorCursor;
-    default:
-        break;
     }
 #endif
     return shape;

--- a/src/gui/MacCursorCompat.h
+++ b/src/gui/MacCursorCompat.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Qt>
+
+namespace AetherSDR {
+
+// Qt 6.11's Cocoa plugin bitmap-renders cursor shapes without native NSCursor
+// equivalents. On macOS 26 that fallback can trap in QImage::toCGImage()
+// while realizing the cursor, so substitute shapes backed by native cursors.
+inline Qt::CursorShape macSafeCursorShape(Qt::CursorShape shape)
+{
+#ifdef Q_OS_MAC
+    switch (shape) {
+    case Qt::SplitVCursor:
+        return Qt::SizeVerCursor;
+    case Qt::SplitHCursor:
+        return Qt::SizeHorCursor;
+    case Qt::SizeAllCursor:
+        return Qt::OpenHandCursor;
+    case Qt::SizeBDiagCursor:
+    case Qt::SizeFDiagCursor:
+        return Qt::SizeHorCursor;
+    default:
+        break;
+    }
+#endif
+    return shape;
+}
+
+} // namespace AetherSDR

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -8,6 +8,7 @@
 #include "SpectrumOverlayMenu.h"
 #include "VfoWidget.h"
 #include "DisplaySettings.h"
+#include "MacCursorCompat.h"
 #include "SliceColors.h"
 #include "SliceColorManager.h"
 #include "SliceLabel.h"
@@ -405,21 +406,6 @@ static bool clampDbmRange(float& minDbm, float& maxDbm)
     return true;
 }
 
-static Qt::CursorShape normalizedSpectrumCursorShape(Qt::CursorShape shape)
-{
-#ifdef Q_OS_MAC
-    switch (shape) {
-    case Qt::SplitVCursor:
-        return Qt::SizeVerCursor;
-    case Qt::SizeAllCursor:
-        return Qt::OpenHandCursor;
-    default:
-        break;
-    }
-#endif
-    return shape;
-}
-
 static void setCursorOverride(QWidget* widget, Qt::CursorShape shape)
 {
     if (!widget) {
@@ -432,7 +418,7 @@ static void setCursorOverride(QWidget* widget, Qt::CursorShape shape)
                             static_cast<int>(widget->cursor().shape()));
         widget->setProperty(kSliceCursorOverrideActiveProperty, true);
     }
-    widget->setCursor(normalizedSpectrumCursorShape(shape));
+    widget->setCursor(AetherSDR::macSafeCursorShape(shape));
 }
 
 static void clearCursorOverride(QWidget* widget)
@@ -8139,7 +8125,7 @@ void SpectrumWidget::setSpectrumCursor(Qt::CursorShape shape)
     // standard Qt cursor changes can pass through QImage::toCGImage() in the
     // Cocoa platform plugin; issue #2458 crashed in that path while dispatching
     // enter/leave events.
-    shape = normalizedSpectrumCursorShape(shape);
+    shape = macSafeCursorShape(shape);
     if (cursor().shape() == shape) {
         return;
     }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -406,6 +406,17 @@ static bool clampDbmRange(float& minDbm, float& maxDbm)
     return true;
 }
 
+static Qt::CursorShape normalizedSpectrumCursorShape(Qt::CursorShape shape)
+{
+#ifdef Q_OS_MAC
+    // Preserve SpectrumWidget's established vertical split appearance.
+    if (shape == Qt::SplitVCursor) {
+        return Qt::SizeVerCursor;
+    }
+#endif
+    return macSafeCursorShape(shape);
+}
+
 static void setCursorOverride(QWidget* widget, Qt::CursorShape shape)
 {
     if (!widget) {
@@ -418,7 +429,7 @@ static void setCursorOverride(QWidget* widget, Qt::CursorShape shape)
                             static_cast<int>(widget->cursor().shape()));
         widget->setProperty(kSliceCursorOverrideActiveProperty, true);
     }
-    widget->setCursor(AetherSDR::macSafeCursorShape(shape));
+    widget->setCursor(normalizedSpectrumCursorShape(shape));
 }
 
 static void clearCursorOverride(QWidget* widget)
@@ -8125,7 +8136,7 @@ void SpectrumWidget::setSpectrumCursor(Qt::CursorShape shape)
     // standard Qt cursor changes can pass through QImage::toCGImage() in the
     // Cocoa platform plugin; issue #2458 crashed in that path while dispatching
     // enter/leave events.
-    shape = macSafeCursorShape(shape);
+    shape = normalizedSpectrumCursorShape(shape);
     if (cursor().shape() == shape) {
         return;
     }

--- a/tests/mac_cursor_compat_test.cpp
+++ b/tests/mac_cursor_compat_test.cpp
@@ -24,21 +24,24 @@ void expectShape(const char* name,
 int main()
 {
 #ifdef Q_OS_MAC
-    expectShape("vertical split uses native vertical resize",
+    expectShape("vertical split remains unchanged",
                 macSafeCursorShape(Qt::SplitVCursor),
-                Qt::SizeVerCursor);
-    expectShape("horizontal split uses native horizontal resize",
+                Qt::SplitVCursor);
+    expectShape("horizontal split remains unchanged",
                 macSafeCursorShape(Qt::SplitHCursor),
-                Qt::SizeHorCursor);
+                Qt::SplitHCursor);
     expectShape("move cursor uses native open hand",
                 macSafeCursorShape(Qt::SizeAllCursor),
                 Qt::OpenHandCursor);
-    expectShape("backward diagonal uses native horizontal resize",
+    expectShape("horizontal resize remains unchanged",
+                macSafeCursorShape(Qt::SizeHorCursor),
+                Qt::SizeHorCursor);
+    expectShape("backward diagonal remains unchanged",
                 macSafeCursorShape(Qt::SizeBDiagCursor),
-                Qt::SizeHorCursor);
-    expectShape("forward diagonal uses native horizontal resize",
+                Qt::SizeBDiagCursor);
+    expectShape("forward diagonal remains unchanged",
                 macSafeCursorShape(Qt::SizeFDiagCursor),
-                Qt::SizeHorCursor);
+                Qt::SizeFDiagCursor);
 #else
     expectShape("vertical split remains unchanged",
                 macSafeCursorShape(Qt::SplitVCursor),
@@ -49,6 +52,9 @@ int main()
     expectShape("move cursor remains unchanged",
                 macSafeCursorShape(Qt::SizeAllCursor),
                 Qt::SizeAllCursor);
+    expectShape("horizontal resize remains unchanged",
+                macSafeCursorShape(Qt::SizeHorCursor),
+                Qt::SizeHorCursor);
     expectShape("backward diagonal remains unchanged",
                 macSafeCursorShape(Qt::SizeBDiagCursor),
                 Qt::SizeBDiagCursor);

--- a/tests/mac_cursor_compat_test.cpp
+++ b/tests/mac_cursor_compat_test.cpp
@@ -1,0 +1,67 @@
+#include "gui/MacCursorCompat.h"
+
+#include <cstdio>
+
+using AetherSDR::macSafeCursorShape;
+
+namespace {
+
+int g_failures = 0;
+
+void expectShape(const char* name,
+                 Qt::CursorShape actual,
+                 Qt::CursorShape expected)
+{
+    const bool ok = actual == expected;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) {
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main()
+{
+#ifdef Q_OS_MAC
+    expectShape("vertical split uses native vertical resize",
+                macSafeCursorShape(Qt::SplitVCursor),
+                Qt::SizeVerCursor);
+    expectShape("horizontal split uses native horizontal resize",
+                macSafeCursorShape(Qt::SplitHCursor),
+                Qt::SizeHorCursor);
+    expectShape("move cursor uses native open hand",
+                macSafeCursorShape(Qt::SizeAllCursor),
+                Qt::OpenHandCursor);
+    expectShape("backward diagonal uses native horizontal resize",
+                macSafeCursorShape(Qt::SizeBDiagCursor),
+                Qt::SizeHorCursor);
+    expectShape("forward diagonal uses native horizontal resize",
+                macSafeCursorShape(Qt::SizeFDiagCursor),
+                Qt::SizeHorCursor);
+#else
+    expectShape("vertical split remains unchanged",
+                macSafeCursorShape(Qt::SplitVCursor),
+                Qt::SplitVCursor);
+    expectShape("horizontal split remains unchanged",
+                macSafeCursorShape(Qt::SplitHCursor),
+                Qt::SplitHCursor);
+    expectShape("move cursor remains unchanged",
+                macSafeCursorShape(Qt::SizeAllCursor),
+                Qt::SizeAllCursor);
+    expectShape("backward diagonal remains unchanged",
+                macSafeCursorShape(Qt::SizeBDiagCursor),
+                Qt::SizeBDiagCursor);
+    expectShape("forward diagonal remains unchanged",
+                macSafeCursorShape(Qt::SizeFDiagCursor),
+                Qt::SizeFDiagCursor);
+#endif
+
+    expectShape("native arrow remains unchanged",
+                macSafeCursorShape(Qt::ArrowCursor),
+                Qt::ArrowCursor);
+
+    std::printf("%s\n",
+                g_failures == 0 ? "All tests passed." : "Test failures.");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4525.

`FilterPassbandWidget` installed `Qt::SizeAllCursor` as its resting cursor. On Qt 6.11/macOS 26, entering the widget can lazily realize that shape through Cocoa's bitmap-cursor fallback and trap in `QImage::toCGImage()`, matching the reported crash stack.

This change extracts the evidenced `SizeAllCursor` → `OpenHandCursor` substitution into a shared GUI-only helper, applies it to the filter passband, and adds a focused mapping test. SpectrumWidget retains its pre-existing vertical-split behavior locally; frameless-resizer cursors and non-macOS behavior are unchanged.

Qt 6.11.1 source confirms the boundary:

```objc
case Qt::SplitVCursor:
    cocoaCursor = [NSCursor resizeUpDownCursor];
    break;
case Qt::SplitHCursor:
    cocoaCursor = [NSCursor resizeLeftRightCursor];
    break;
```

`SizeVerCursor`, `SizeHorCursor`, and both diagonal shapes use `frameResizeCursorFromPosition` on macOS 15+, while `SizeAllCursor` is absent from the native switch and falls through to `sizeallcursor.png` plus `createCursorFromPixmap`. See [`qcocoacursor.mm` lines 127–170](https://github.com/qt/qtbase/blob/v6.11.1/src/plugins/platforms/cocoa/qcocoacursor.mm#L127-L170) and [lines 291–294](https://github.com/qt/qtbase/blob/v6.11.1/src/plugins/platforms/cocoa/qcocoacursor.mm#L291-L294). The tested Qt 6.11.1 Cocoa plugin contains the native resize selectors and was built against macOS SDK 26.5.

## Constitution principle honored

Principle XI — Fixes Are Demonstrated. The change was built from current `upstream/main`, tested directly, and exercised through the agent automation bridge against the baseline and fixed macOS builds.

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Behavior verified on a real radio if applicable
- [x] Existing tests pass (CI)
- [x] Reproduction steps documented if user-reported bug

Local checks:

- Clean configure and full 1,211-action macOS build
- `ctest --test-dir build --output-on-failure -R '^mac_cursor_compat_test$'`
- Focused GUI/model CTest set: 6/6 passed
- `python3 tools/check_engine_boundary.py --strict` (0 blockers; existing tracked warnings only)
- `git diff --check`

## Proof

### Agent automation bridge

On the unmodified current-main build, `dumpTree` reported the visible `Filter passband` widget with `"cursor": "sizeall"`. The bridge successfully entered the widget; the reported OS trap is nondeterministic, but the risky installed cursor shape was directly observable.

On the fixed build:

- The same widget reported `"cursor": "openhand"` before entry.
- `hover 'Filter passband'` completed successfully.
- A post-hover `ping` confirmed the app remained alive.
- The connected FLEX-6700 reported `"transmitting": false` before shutdown.

A screenshot is intentionally omitted because Qt widget grabs do not capture the macOS system cursor; the bridge's widget-tree cursor field is the direct state evidence for this fix.

## Checklist

- [x] Commits are signed (`docs/COMMIT-SIGNING.md`)
- [x] No new flat-key `AppSettings` calls — use nested-JSON-under-one-key
      (Principle V)
- [x] Code is clean-room — not decompiled, disassembled, or
      reverse-engineered from a proprietary binary (Principle IV)
- [x] All meter UI uses `MeterSmoother` (AGENTS.md convention)
- [x] Documentation updated if user-visible behavior changed
- [x] Security-sensitive changes reference a GHSA if applicable

Generated with OpenAI Codex.
