### PR TITLE
fix(gui): keep Connect to Radio footer reachable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4602,6 +4602,21 @@ add_test(NAME flex_control_dialog_size_test COMMAND flex_control_dialog_size_tes
 set_tests_properties(flex_control_dialog_size_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+add_executable(connection_panel_size_test
+    tests/connection_panel_size_test.cpp
+    src/gui/ConnectionPanel.cpp
+    src/gui/FramelessResizer.cpp
+    src/gui/FramelessWindowTitleBar.cpp
+)
+target_include_directories(connection_panel_size_test PRIVATE src tests)
+target_link_libraries(connection_panel_size_test PRIVATE
+    aethercore Qt6::Core Qt6::Network Qt6::Widgets Qt6::Test
+)
+set_target_properties(connection_panel_size_test PROPERTIES AUTOMOC ON)
+add_test(NAME connection_panel_size_test COMMAND connection_panel_size_test)
+set_tests_properties(connection_panel_size_test PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 add_executable(pan_layout_dialog_size_test
     tests/pan_layout_dialog_size_test.cpp
     src/gui/PanLayoutDialog.cpp

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -281,9 +281,13 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     auto* content = new QWidget(this);
     content->setObjectName(QStringLiteral("connectionBodyContent"));
     auto* root = new QVBoxLayout(content);
-    root->setContentsMargins(12, 12, 12, 10);
+    // No right margin: the 12 px band on that edge belongs to the scroll area
+    // (see bodyContainer below), so adding one here would inset the body 24 px
+    // from the right against 12 px on the left and 12 px on the footer.
+    root->setContentsMargins(12, 12, 0, 10);
     root->setSpacing(10);
     m_rootLayout = root;
+    m_bodyContent = content;
 
     auto* bodyScroll = new QScrollArea(this);
     bodyScroll->setObjectName(QStringLiteral("connectionBodyScrollArea"));
@@ -292,6 +296,7 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     bodyScroll->setFrameShape(QFrame::NoFrame);
     bodyScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     bodyScroll->setWidget(content);
+    m_bodyScroll = bodyScroll;
 
     // Keep the scrollbars clear of FramelessResizer's edge-grab zone. The
     // fixed footer already carries its own inset; the scrolling body needs one
@@ -576,8 +581,9 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     // Baseline floor for the collapsed page. The rows and the result line carry
     // explicit minimums of their own, but a word-wrapped QLabel under-reports
     // its height, so without this the surrounding layout can still hand the
-    // group less than it needs and Qt overlaps children rather than growing the
-    // dialog. refitToContent() covers the taller states (Advanced expanded).
+    // group less than it needs and Qt overlaps children. The taller states
+    // (Advanced expanded) are covered by the enclosing QScrollArea, which never
+    // gives the body less than qSmartMinSize() and scrolls the difference.
     manualGroup->setMinimumHeight(240);
     auto* manualGroupLayout = new QVBoxLayout(manualGroup);
     manualGroupLayout->setContentsMargins(12, 14, 12, 12);
@@ -883,16 +889,13 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
         updateSmartLinkUi();
     });
 
-    // The manual page is the tallest of the three: two label+field rows, the
-    // action row, a reserved result line, and the Advanced disclosure. A dialog
-    // restored at the old 660 px height clipped the bottom of that page, so
-    // hold a floor that fits it. Everything above the stack is fixed-height, so
-    // this is the page height plus the surrounding chrome.
-    // Derive the height floor from the built layout rather than hardcoding it:
-    // the manual page is the tallest of the three and it grew a Radio type row,
-    // and a stale pixel count here is exactly what let the rows overlap before.
-    // refitToContent() raises it again if the page later gets taller.
+    // Settle the body layout so preferredClientHeight() has a real answer the
+    // first time fitToScreen() asks for one. The height floor this used to set
+    // is gone: the manual page is still the tallest of the three, but overflow
+    // now belongs to the scroll area rather than to the top-level minimum.
     refitToContent();
+    setMinimumSize(kSafeMinimumWidth, kSafeMinimumHeight);
+    resize(kPreferredWidth, kPreferredHeight);
 
     setConnected(false);
     setCurrentMode(LocalMode);
@@ -917,12 +920,46 @@ void ConnectionPanel::setFramelessMode(bool on)
     if (m_titleBar)
         m_titleBar->setVisible(on);
     if (m_rootLayout)
-        m_rootLayout->setContentsMargins(12, on ? 10 : 12, 12, 10);
-    if (wasVisible)
+        m_rootLayout->setContentsMargins(12, on ? 10 : 12, 0, 10);
+    if (wasVisible) {
+        // Turning decorations back on wraps a native frame — a title bar and
+        // borders, ~24-31 px on Windows — around a client rect that was sized
+        // for a frameless window. Without a re-fit that pushes the frame, and
+        // the footer pinned at its bottom, straight back under the taskbar:
+        // #4515 again, reached through View -> Frameless Window instead of
+        // through a connect.
+        fitAndClampToScreen();
         show();
+    }
 }
 
-void ConnectionPanel::fitToScreen(QScreen* preferredScreen)
+bool ConnectionPanel::event(QEvent* e)
+{
+    switch (e->type()) {
+    // A fit is only valid for the screen, DPI and font metrics it was made
+    // under. #4515 asks for it to be redone when any of those change beneath an
+    // open window — dragged to a shorter monitor, scaling changed in Display
+    // settings, UI font swapped. Deferred by one turn of the event loop because
+    // the children have not re-laid-out by the time these arrive, so a fit
+    // computed here would use the outgoing metrics.
+    case QEvent::ScreenChangeInternal:
+    case QEvent::ApplicationFontChange:
+    case QEvent::FontChange:
+    case QEvent::StyleChange:
+        if (isVisible()) {
+            QTimer::singleShot(0, this, [this] {
+                if (isVisible())
+                    fitAndClampToScreen();
+            });
+        }
+        break;
+    default:
+        break;
+    }
+    return QWidget::event(e);
+}
+
+QScreen* ConnectionPanel::screenFitTarget(QScreen* preferredScreen) const
 {
     QScreen* targetScreen = preferredScreen;
     if (!targetScreen && windowHandle()) {
@@ -934,8 +971,35 @@ void ConnectionPanel::fitToScreen(QScreen* preferredScreen)
     if (!targetScreen) {
         targetScreen = QGuiApplication::primaryScreen();
     }
+    return targetScreen;
+}
+
+int ConnectionPanel::preferredClientHeight() const
+{
+    if (!m_bodyContent || !m_bodyScroll) {
+        return kPreferredHeight;
+    }
+    // Everything in `outer` except the scroll area — the title bar when it is
+    // shown, the fixed footer always. Taking it as a difference rather than
+    // summing the two widgets keeps this correct without duplicating which of
+    // them is visible in which frameless mode.
+    const int chromeHeight = sizeHint().height() - m_bodyScroll->sizeHint().height();
+    return qMax(kPreferredHeight, chromeHeight + m_bodyContent->sizeHint().height());
+}
+
+void ConnectionPanel::fitToScreen(QScreen* preferredScreen)
+{
+    QScreen* targetScreen = screenFitTarget(preferredScreen);
     if (!targetScreen) {
         return;
+    }
+
+    // Realise the native window before measuring. QWindow::frameMargins() is
+    // only populated once the platform window exists, so on the very first open
+    // an un-created panel falls back to the style estimate — which on Windows,
+    // the platform #4515 was reported on, is roughly a title bar short.
+    if (!windowHandle()) {
+        (void)winId();
     }
 
     const QRect available = targetScreen->availableGeometry();
@@ -947,8 +1011,32 @@ void ConnectionPanel::fitToScreen(QScreen* preferredScreen)
         qMax(1, available.height() - frameMargins.top() - frameMargins.bottom());
     setMinimumSize(qMin(kSafeMinimumWidth, maximumClientWidth),
                    qMin(kSafeMinimumHeight, maximumClientHeight));
-    resize(qMin(width(), maximumClientWidth),
-           qMin(height(), maximumClientHeight));
+
+    // Shrinking is the invariant: the frame must fit the work area whatever the
+    // operator wants. Growing is a courtesy, so it only applies to a height
+    // this function chose — otherwise a dialog dragged short on a big screen
+    // would spring back every time it was reopened.
+    int targetHeight = qMin(height(), maximumClientHeight);
+    if (height() == m_autoFitHeight) {
+        targetHeight = qBound(qMin(kSafeMinimumHeight, maximumClientHeight),
+                              preferredClientHeight(),
+                              maximumClientHeight);
+    }
+    resize(qMin(width(), maximumClientWidth), targetHeight);
+    m_autoFitHeight = height();
+}
+
+void ConnectionPanel::fitAndClampToScreen(QScreen* preferredScreen)
+{
+    QScreen* targetScreen = screenFitTarget(preferredScreen);
+    if (!targetScreen) {
+        return;
+    }
+    fitToScreen(targetScreen);
+    // pos() on a window is its frame top-left, the same space
+    // constrainedFrameTopLeft() works in, so this is a no-op when the window
+    // already fits and a pull-back-inside when it does not.
+    move(constrainedFrameTopLeft(pos(), targetScreen->availableGeometry()));
 }
 
 QMargins ConnectionPanel::screenFitFrameMargins() const
@@ -968,14 +1056,18 @@ QMargins ConnectionPanel::screenFitFrameMargins() const
     return frameMargins;
 }
 
+QSize ConnectionPanel::screenFitFrameSize() const
+{
+    const QMargins frameMargins = screenFitFrameMargins();
+    return QSize(width() + frameMargins.left() + frameMargins.right(),
+                 height() + frameMargins.top() + frameMargins.bottom());
+}
+
 QPoint ConnectionPanel::constrainedFrameTopLeft(
     const QPoint& preferredFrameTopLeft,
     const QRect& availableGeometry) const
 {
-    const QMargins frameMargins = screenFitFrameMargins();
-    const QSize frameSize(
-        width() + frameMargins.left() + frameMargins.right(),
-        height() + frameMargins.top() + frameMargins.bottom());
+    const QSize frameSize = screenFitFrameSize();
     const int maxX =
         availableGeometry.left() + availableGeometry.width() - frameSize.width();
     const int maxY =
@@ -990,6 +1082,14 @@ void ConnectionPanel::setConnected(bool connected)
     m_connected = connected;
     m_disconnectBtn->setVisible(connected);
     updateActionState();
+    // Showing the Disconnect button is the one moment the fixed footer changes
+    // height, so it is the one moment a fit made earlier stops being right —
+    // and it is exactly when #4515 was reported. Cheap: fitToScreen() only
+    // grows from a height it chose itself, and the clamp is a no-op for a
+    // window already inside the work area.
+    if (isVisible()) {
+        fitAndClampToScreen();
+    }
 }
 
 void ConnectionPanel::setStatusText(const QString& text)
@@ -1278,9 +1378,10 @@ void ConnectionPanel::updateManualAdvancedVisibility()
 
     // Expanding the Advanced section is the biggest single height change this
     // page has, and it happens on its own whenever a saved source path goes
-    // stale — the exact VPN case this feature exists for. Without this the
-    // group is handed less room than it needs and the "Radio type"/"Radio IP"
-    // rows overlap their own labels.
+    // stale — the exact VPN case this feature exists for. The extra height goes
+    // into the scroll range now, not into the top-level minimum; this only
+    // re-activates the body layout so the new hint is published immediately
+    // rather than on the next spontaneous relayout.
     refitToContent();
 }
 
@@ -1600,11 +1701,6 @@ void ConnectionPanel::setSmartLinkClient(SmartLinkClient* client)
 
     client->tryAutoLogin();
     updateSmartLinkUi();
-}
-
-bool ConnectionPanel::event(QEvent* e)
-{
-    return QWidget::event(e);
 }
 
 void ConnectionPanel::paintEvent(QPaintEvent*)

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -13,6 +13,7 @@
 
 #include <QAbstractItemView>
 #include <QFormLayout>
+#include <QGuiApplication>
 #include <QInputDialog>
 #include <QMenu>
 #include <QFrame>
@@ -22,8 +23,11 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QPainter>
+#include <QScrollArea>
+#include <QScreen>
 #include <QSignalBlocker>
 #include <QSizePolicy>
+#include <QStyle>
 #include <QTcpSocket>
 #include <QHostInfo>
 #include <QUdpSocket>
@@ -31,6 +35,7 @@
 #include <QDeadlineTimer>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <QWindow>
 #include "core/ThemeManager.h"
 
 namespace AetherSDR {
@@ -274,11 +279,29 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     outer->addWidget(titleBar);
 
     auto* content = new QWidget(this);
+    content->setObjectName(QStringLiteral("connectionBodyContent"));
     auto* root = new QVBoxLayout(content);
-    root->setContentsMargins(12, 12, 12, 12);
+    root->setContentsMargins(12, 12, 12, 10);
     root->setSpacing(10);
     m_rootLayout = root;
-    outer->addWidget(content, 1);
+
+    auto* bodyScroll = new QScrollArea(this);
+    bodyScroll->setObjectName(QStringLiteral("connectionBodyScrollArea"));
+    bodyScroll->setAccessibleName(tr("Connection options"));
+    bodyScroll->setWidgetResizable(true);
+    bodyScroll->setFrameShape(QFrame::NoFrame);
+    bodyScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    bodyScroll->setWidget(content);
+
+    // Keep the scrollbars clear of FramelessResizer's edge-grab zone. The
+    // fixed footer already carries its own inset; the scrolling body needs one
+    // too because QScrollArea places its vertical bar at its outer edge.
+    auto* bodyContainer = new QWidget(this);
+    auto* bodyContainerLayout = new QVBoxLayout(bodyContainer);
+    bodyContainerLayout->setContentsMargins(0, 0, 12, 0);
+    bodyContainerLayout->setSpacing(0);
+    bodyContainerLayout->addWidget(bodyScroll);
+    outer->addWidget(bodyContainer, 1);
 
     auto* titleLabel = new QLabel("Connect to a Radio", this);
     AetherSDR::ThemeManager::instance().applyStyleSheet(titleLabel, "QLabel { color: {{color.text.primary}}; font-size: 18px; font-weight: bold; "
@@ -758,7 +781,12 @@ ConnectionPanel::ConnectionPanel(QWidget* parent)
     m_disconnectBtn->setAccessibleName(tr("Disconnect from radio"));
     m_disconnectBtn->setVisible(false);
     footerRow->addWidget(m_disconnectBtn, 0, Qt::AlignRight);
-    root->addLayout(footerRow);
+
+    auto* footer = new QWidget(this);
+    footer->setObjectName(QStringLiteral("connectionFooter"));
+    footer->setLayout(footerRow);
+    footerRow->setContentsMargins(12, 0, 12, 12);
+    outer->addWidget(footer);
 
     // Family first: applySavedSourceSelection() may override it with the
     // per-address choice remembered for whichever recent IP we preselect.
@@ -889,9 +917,72 @@ void ConnectionPanel::setFramelessMode(bool on)
     if (m_titleBar)
         m_titleBar->setVisible(on);
     if (m_rootLayout)
-        m_rootLayout->setContentsMargins(12, on ? 10 : 12, 12, 12);
+        m_rootLayout->setContentsMargins(12, on ? 10 : 12, 12, 10);
     if (wasVisible)
         show();
+}
+
+void ConnectionPanel::fitToScreen(QScreen* preferredScreen)
+{
+    QScreen* targetScreen = preferredScreen;
+    if (!targetScreen && windowHandle()) {
+        targetScreen = windowHandle()->screen();
+    }
+    if (!targetScreen && parentWidget()) {
+        targetScreen = parentWidget()->screen();
+    }
+    if (!targetScreen) {
+        targetScreen = QGuiApplication::primaryScreen();
+    }
+    if (!targetScreen) {
+        return;
+    }
+
+    const QRect available = targetScreen->availableGeometry();
+    const QMargins frameMargins = screenFitFrameMargins();
+
+    const int maximumClientWidth =
+        qMax(1, available.width() - frameMargins.left() - frameMargins.right());
+    const int maximumClientHeight =
+        qMax(1, available.height() - frameMargins.top() - frameMargins.bottom());
+    setMinimumSize(qMin(kSafeMinimumWidth, maximumClientWidth),
+                   qMin(kSafeMinimumHeight, maximumClientHeight));
+    resize(qMin(width(), maximumClientWidth),
+           qMin(height(), maximumClientHeight));
+}
+
+QMargins ConnectionPanel::screenFitFrameMargins() const
+{
+    QMargins frameMargins;
+    if (windowHandle()) {
+        frameMargins = windowHandle()->frameMargins();
+    }
+    if (frameMargins.isNull()
+        && !windowFlags().testFlag(Qt::FramelessWindowHint)) {
+        const int border =
+            style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, this);
+        const int titleHeight =
+            style()->pixelMetric(QStyle::PM_TitleBarHeight, nullptr, this);
+        frameMargins = QMargins(border, titleHeight, border, border);
+    }
+    return frameMargins;
+}
+
+QPoint ConnectionPanel::constrainedFrameTopLeft(
+    const QPoint& preferredFrameTopLeft,
+    const QRect& availableGeometry) const
+{
+    const QMargins frameMargins = screenFitFrameMargins();
+    const QSize frameSize(
+        width() + frameMargins.left() + frameMargins.right(),
+        height() + frameMargins.top() + frameMargins.bottom());
+    const int maxX =
+        availableGeometry.left() + availableGeometry.width() - frameSize.width();
+    const int maxY =
+        availableGeometry.top() + availableGeometry.height() - frameSize.height();
+    return QPoint(
+        qMax(availableGeometry.left(), qMin(preferredFrameTopLeft.x(), maxX)),
+        qMax(availableGeometry.top(), qMin(preferredFrameTopLeft.y(), maxY)));
 }
 
 void ConnectionPanel::setConnected(bool connected)
@@ -1837,31 +1928,14 @@ void ConnectionPanel::probeRadio(const QString& ip)
 
 void ConnectionPanel::refitToContent()
 {
-    if (!layout())
+    if (!m_rootLayout)
         return;
 
-    // minimumSize() is the layout's own answer to "how small can this get
-    // before children start overlapping", so it already accounts for whichever
-    // page is current and whether the Advanced section is expanded. Deriving
-    // the floor beats a hardcoded pixel count, which would go stale the moment
-    // the page gains a row or the operator runs a larger UI font.
-    layout()->activate();
-    const int needed = layout()->minimumSize().height();
-    if (needed <= 0)
-        return;
-
-    setMinimumHeight(needed);
-
-    // Grow whenever the current page needs it. Shrink only back to a height we
-    // set ourselves — otherwise collapsing the Advanced section would discard a
-    // size the operator chose by dragging the window. Without the shrink the
-    // dialog keeps the taller size and leaves a band of dead space.
-    const bool grow    = height() < needed;
-    const bool reclaim = height() > needed && height() == m_autoFitHeight;
-    if (grow || reclaim) {
-        resize(width(), needed);
-        m_autoFitHeight = needed;
-    }
+    // The body owns overflow now. Refresh its geometry so expanding Advanced or
+    // wrapping a result message extends the scroll range instead of increasing
+    // the top-level minimum past the screen's available height.
+    m_rootLayout->invalidate();
+    m_rootLayout->activate();
 }
 
 void ConnectionPanel::resetManualConnectButton()

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -5,6 +5,9 @@
 #include "core/IConnectionAutomation.h"
 
 #include <QWidget>
+#include <QMargins>
+#include <QPoint>
+#include <QRect>
 #include <QListWidget>
 #include <QPushButton>
 #include <QLabel>
@@ -17,6 +20,7 @@
 #include <QToolButton>
 
 class QVBoxLayout;
+class QScreen;
 
 namespace AetherSDR {
 
@@ -27,7 +31,16 @@ class ConnectionPanel : public QWidget, public IConnectionAutomation {
 public:
     explicit ConnectionPanel(QWidget* parent = nullptr);
 
+    static constexpr int kSafeMinimumWidth = 640;
+    static constexpr int kSafeMinimumHeight = 360;
+    static constexpr int kPreferredWidth = 760;
+    static constexpr int kPreferredHeight = 660;
+
     void setFramelessMode(bool on);
+    void fitToScreen(QScreen* preferredScreen = nullptr);
+    QMargins screenFitFrameMargins() const;
+    QPoint constrainedFrameTopLeft(const QPoint& preferredFrameTopLeft,
+                                   const QRect& availableGeometry) const;
     void setConnected(bool connected);
     void setStatusText(const QString& text);
     void probeRadio(const QString& ip);
@@ -50,6 +63,7 @@ public:
     void automationSetDialogVisible(bool visible) override
     {
         if (visible) {
+            fitToScreen();
             show();
             raise();
             activateWindow();
@@ -202,10 +216,6 @@ private:
     QPushButton* m_manualConnectBtn{nullptr};
     QString      m_manualProfileIp;
     bool         m_manualConnectPending{false};
-    // Last height refitToContent() set, so it can tell its own sizing from a
-    // height the operator dragged to and only reclaim the former.
-    int          m_autoFitHeight{0};
-
     QCheckBox*   m_autoConnectCheck{nullptr};
     QCheckBox*   m_showDemoCheck{nullptr};    // RFC #4288: offer the demo entry
 

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -8,6 +8,7 @@
 #include <QMargins>
 #include <QPoint>
 #include <QRect>
+#include <QSize>
 #include <QListWidget>
 #include <QPushButton>
 #include <QLabel>
@@ -21,6 +22,7 @@
 
 class QVBoxLayout;
 class QScreen;
+class QScrollArea;
 
 namespace AetherSDR {
 
@@ -38,7 +40,14 @@ public:
 
     void setFramelessMode(bool on);
     void fitToScreen(QScreen* preferredScreen = nullptr);
+    // Fit, then pull the frame back inside the work area without otherwise
+    // moving the window. The placement-preserving counterpart to
+    // MainWindow::showConnectionDialog(), for the show paths this class owns
+    // (the frameless toggle, the automation bridge) and for the screen/DPI/font
+    // changes that can invalidate a fit made earlier (#4515).
+    void fitAndClampToScreen(QScreen* preferredScreen = nullptr);
     QMargins screenFitFrameMargins() const;
+    QSize screenFitFrameSize() const;
     QPoint constrainedFrameTopLeft(const QPoint& preferredFrameTopLeft,
                                    const QRect& availableGeometry) const;
     void setConnected(bool connected);
@@ -63,7 +72,11 @@ public:
     void automationSetDialogVisible(bool visible) override
     {
         if (visible) {
-            fitToScreen();
+            // Same fit-and-place contract MainWindow::showConnectionDialog()
+            // applies, minus the re-centring: an agent-driven show must not
+            // yank a window the operator positioned, only pull it back inside
+            // the work area if it no longer fits there.
+            fitAndClampToScreen();
             show();
             raise();
             activateWindow();
@@ -156,11 +169,17 @@ private:
     Hl2ProbeResult probeHermesLite2(const QString& ip, const RadioBindSettings& bindSettings);
     void probeFlexRadio(const QString& ip, const RadioBindSettings& bindSettings);
     void resetManualConnectButton();
-    // Grow the dialog when the current page needs more room than it has. The
-    // manual page's height is not constant — the Advanced source-path section
-    // expands, and the result line wraps — and a dialog that cannot grow makes
-    // Qt overlap the rows instead. Cheap and idempotent; safe to call often.
+    // Re-activate the body layout after a page change. The overlap this used to
+    // guard against — the Advanced section expanding, or the result line
+    // wrapping, while the dialog could not grow — is now structurally
+    // impossible: the body lives in a QScrollArea, which never hands its widget
+    // less than qSmartMinSize(). Cheap and idempotent; safe to call often.
     void refitToContent();
+    // Height the body would like if the screen allows it. The panel's own
+    // sizeHint() cannot answer this — QScrollArea caps its hint by design, so
+    // it under-reports the body it is scrolling.
+    int preferredClientHeight() const;
+    QScreen* screenFitTarget(QScreen* preferredScreen) const;
     void saveManualProfile(const QString& targetIp,
                            const RadioBindSettings& settings,
                            const QHostAddress& lastSuccessfulLocalIp);
@@ -171,6 +190,13 @@ private:
 
     QWidget*     m_titleBar{nullptr};
     QVBoxLayout* m_rootLayout{nullptr};
+    QScrollArea* m_bodyScroll{nullptr};
+    QWidget*     m_bodyContent{nullptr};
+    // Last height fitToScreen() chose, so it can tell its own sizing from a
+    // height the operator dragged to. It grows the dialog back toward the
+    // body's preferred height only from the former — a size the operator
+    // picked is theirs to keep, even if that means the body scrolls.
+    int          m_autoFitHeight{kPreferredHeight};
 
     QButtonGroup* m_modeButtons{nullptr};
     QStackedWidget* m_modeStack{nullptr};

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -165,7 +165,6 @@
 #include <QGuiApplication>
 #include <QProcess>
 #include <QScreen>
-#include <QStyle>
 #include <QTimer>
 #include <QDateTime>
 #include <QPropertyAnimation>
@@ -3710,11 +3709,12 @@ void MainWindow::showConnectionDialog()
         screen = QApplication::primaryScreen();
 
     m_connPanel->fitToScreen(screen);
-    const QSize dlgSize = m_connPanel->size();
-    const QMargins frameMargins = m_connPanel->screenFitFrameMargins();
-    const QSize frameSize(
-        dlgSize.width() + frameMargins.left() + frameMargins.right(),
-        dlgSize.height() + frameMargins.top() + frameMargins.bottom());
+    // Frame coordinates throughout: QWidget::move() positions a top-level
+    // widget by its frame top-left, so anchoring on the client rect would leave
+    // the window a title bar lower than intended. screenFitFrameSize() is the
+    // same arithmetic constrainedFrameTopLeft() clamps with — one source, so
+    // the anchor and the clamp cannot drift apart.
+    const QSize frameSize = m_connPanel->screenFitFrameSize();
     QPoint frameTopLeft(labelCenter.x() - frameSize.width() / 2,
                         statusBarTop.y() - frameSize.height() - 8);
 
@@ -3723,7 +3723,6 @@ void MainWindow::showConnectionDialog()
             frameTopLeft, screen->availableGeometry());
     }
 
-    // QWidget::move() positions a top-level widget by its frame top-left.
     m_connPanel->move(frameTopLeft);
     m_connPanel->show();
     m_connPanel->raise();
@@ -4224,12 +4223,10 @@ void MainWindow::buildUI()
     m_connPanel->setWindowTitle("Connect to Radio");
     m_connPanel->setFramelessMode(
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-    // The body scrolls when its content exceeds the available height; the
-    // footer remains outside that viewport and therefore always reachable.
-    m_connPanel->setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
-                                ConnectionPanel::kSafeMinimumHeight);
-    m_connPanel->resize(ConnectionPanel::kPreferredWidth,
-                        ConnectionPanel::kPreferredHeight);
+    // Sizing belongs to the panel now. It sets these same two values in its own
+    // constructor and then adjusts them per screen in fitToScreen(), which
+    // every show path here runs first — a hardcoded pair at this level went
+    // stale the moment the panel gained a row, and that is what #4515 was.
     m_connPanel->hide();
 
     // CWX panel — left of spectrum, hidden by default

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -165,6 +165,7 @@
 #include <QGuiApplication>
 #include <QProcess>
 #include <QScreen>
+#include <QStyle>
 #include <QTimer>
 #include <QDateTime>
 #include <QPropertyAnimation>
@@ -1006,7 +1007,7 @@ void MainWindow::showForcedDisconnectDialog(bool wasWan,
             if (radioInfo.address.isNull()) {
                 setPanadapterConnectionAnimation(false);
                 m_connPanel->setStatusText("Select a radio to reconnect");
-                m_connPanel->show();
+                showConnectionDialog();
                 return;
             }
 
@@ -3708,19 +3709,22 @@ void MainWindow::showConnectionDialog()
     if (!screen)
         screen = QApplication::primaryScreen();
 
+    m_connPanel->fitToScreen(screen);
     const QSize dlgSize = m_connPanel->size();
-    QPoint pos(labelCenter.x() - dlgSize.width() / 2,
-               statusBarTop.y() - dlgSize.height() - 8);
+    const QMargins frameMargins = m_connPanel->screenFitFrameMargins();
+    const QSize frameSize(
+        dlgSize.width() + frameMargins.left() + frameMargins.right(),
+        dlgSize.height() + frameMargins.top() + frameMargins.bottom());
+    QPoint frameTopLeft(labelCenter.x() - frameSize.width() / 2,
+                        statusBarTop.y() - frameSize.height() - 8);
 
     if (screen) {
-        const QRect available = screen->availableGeometry();
-        const int maxX = available.left() + available.width() - dlgSize.width();
-        const int maxY = available.top() + available.height() - dlgSize.height();
-        pos.setX(qMax(available.left(), qMin(pos.x(), maxX)));
-        pos.setY(qMax(available.top(), qMin(pos.y(), maxY)));
+        frameTopLeft = m_connPanel->constrainedFrameTopLeft(
+            frameTopLeft, screen->availableGeometry());
     }
 
-    m_connPanel->move(pos);
+    // QWidget::move() positions a top-level widget by its frame top-left.
+    m_connPanel->move(frameTopLeft);
     m_connPanel->show();
     m_connPanel->raise();
     m_connPanel->activateWindow();
@@ -4220,14 +4224,12 @@ void MainWindow::buildUI()
     m_connPanel->setWindowTitle("Connect to Radio");
     m_connPanel->setFramelessMode(
         AppSettings::instance().value("FramelessWindow", "True").toString() == "True");
-    // Height floor comes from the panel itself — its "Connect by IP" page grew a
-    // Radio type row, so a hardcoded 580/660 here clipped the bottom of that
-    // page (the Advanced disclosure fell outside the mode stack). Open at
-    // exactly that floor, not floor + slack: the panel reclaims height it set
-    // itself when a page shrinks, and it can only tell its own sizing from an
-    // operator's drag if the two agree to start with.
-    m_connPanel->setMinimumSize(640, m_connPanel->minimumHeight());
-    m_connPanel->resize(760, m_connPanel->minimumHeight());
+    // The body scrolls when its content exceeds the available height; the
+    // footer remains outside that viewport and therefore always reachable.
+    m_connPanel->setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
+                                ConnectionPanel::kSafeMinimumHeight);
+    m_connPanel->resize(ConnectionPanel::kPreferredWidth,
+                        ConnectionPanel::kPreferredHeight);
     m_connPanel->hide();
 
     // CWX panel — left of spectrum, hidden by default
@@ -5751,7 +5753,7 @@ void MainWindow::onConnectionStateChanged(bool connected)
                 s.remove("LastConnectedRadioSerial");
                 s.remove("LastRoutedRadioIp");
                 s.save();
-                m_connPanel->show();
+                showConnectionDialog();
             });
             m_reconnectDlg->show();
         }

--- a/src/gui/MainWindow_Session.cpp
+++ b/src/gui/MainWindow_Session.cpp
@@ -360,7 +360,7 @@ void MainWindow::wireDiscovery()
             reconnectDialog->close();
             reconnectDialog->deleteLater();
         }
-        m_connPanel->show();
+        showConnectionDialog();
     });
     connect(&m_smartLink, &SmartLinkClient::serverConnected,
             this, [this] {

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -12,6 +12,7 @@
 #include <QScreen>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QStyle>
 
 #include <cstdio>
 #include <string>
@@ -59,6 +60,111 @@ bool setScaledApplicationFont(QApplication& app,
     return true;
 }
 
+// The footer invariant, in one shipped frameless configuration at one font
+// scale. Both halves of the configuration matter: the app only ever pairs the
+// window flag with the custom title bar's visibility, and screenFitFrameMargins()
+// branches on that flag, so a mixed state would test something nobody runs.
+void checkFooterReachable(QApplication& app,
+                          const QFont& originalFont,
+                          qreal scale,
+                          bool frameless)
+{
+    std::string fontDetail;
+    const bool fontScaled =
+        setScaledApplicationFont(app, originalFont, scale, &fontDetail);
+    const std::string suffix = " scale=" + std::to_string(scale)
+        + (frameless ? " frameless" : " native");
+    report("font scale is representable", fontScaled, suffix + " " + fontDetail);
+    if (!fontScaled) {
+        return;
+    }
+
+    ConnectionPanel panel;
+    panel.setFramelessMode(frameless);
+    panel.setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
+                         ConnectionPanel::kSafeMinimumHeight);
+    panel.resize(ConnectionPanel::kSafeMinimumWidth,
+                 ConnectionPanel::kSafeMinimumHeight);
+    panel.setConnected(true);
+    panel.show();
+    QApplication::processEvents();
+
+    QScrollArea* body =
+        panel.findChild<QScrollArea*>(QStringLiteral("connectionBodyScrollArea"));
+    QWidget* bodyContent =
+        panel.findChild<QWidget*>(QStringLiteral("connectionBodyContent"));
+    QPushButton* disconnect =
+        panel.findChild<QPushButton*>(QStringLiteral("connectionDisconnectButton"));
+
+    report("scrollable connection body exists",
+           body != nullptr,
+           suffix);
+    report("body overflows into a vertical scrollbar",
+           body && body->verticalScrollBar()->maximum() > 0,
+           suffix + " maximum="
+               + std::to_string(body ? body->verticalScrollBar()->maximum() : -1));
+    report("vertical scrollbar stays clear of the resize edge",
+           body
+               && body->verticalScrollBar()
+                      ->mapTo(&panel,
+                             QPoint(body->verticalScrollBar()->width(), 0))
+                      .x()
+                   <= panel.width() - 12,
+           suffix);
+    report("Disconnect remains visible",
+           disconnect && disconnect->isVisible(),
+           suffix);
+    // The load-bearing assertion. Verified by mutation: putting the footer back
+    // inside the scrolling body fails this at every scale while leaving the
+    // rest of the harness green.
+    report("Disconnect remains inside the panel",
+           disconnect && bottomInPanel(disconnect, &panel) <= panel.height(),
+           suffix + " bottom="
+               + std::to_string(disconnect ? bottomInPanel(disconnect, &panel) : -1)
+               + " panelH=" + std::to_string(panel.height()));
+    report("Disconnect footer stays below the scrolling body",
+           body && disconnect
+               && disconnect->mapTo(&panel, QPoint()).y()
+                   >= body->mapTo(&panel, QPoint(0, body->height())).y(),
+           suffix);
+
+    bool wrappedLabelsFit = bodyContent != nullptr;
+    if (bodyContent) {
+        const QList<QLabel*> labels = bodyContent->findChildren<QLabel*>();
+        for (QLabel* label : labels) {
+            if (!label->wordWrap() || !label->isVisibleTo(bodyContent)) {
+                continue;
+            }
+            const int requiredHeight = label->heightForWidth(label->width());
+            if (requiredHeight > 0 && label->height() < requiredHeight) {
+                wrappedLabelsFit = false;
+                break;
+            }
+        }
+    }
+    report("visible wrapped labels receive their required height",
+           wrappedLabelsFit,
+           suffix);
+
+    // Behavioural, not a policy read-back: squeeze the window below the body's
+    // own minimum width and require a usable horizontal scrollbar. Asserting
+    // horizontalScrollBarPolicy() instead would pass just as happily on a panel
+    // whose right-hand controls were simply cut off.
+    if (body && bodyContent) {
+        panel.setMinimumWidth(200);
+        panel.resize(200, panel.height());
+        QApplication::processEvents();
+        report("horizontal overflow is reachable, not clipped",
+               body->horizontalScrollBar()->maximum() > 0,
+               suffix + " maximum="
+                   + std::to_string(body->horizontalScrollBar()->maximum())
+                   + " contentMinW="
+                   + std::to_string(bodyContent->minimumSizeHint().width()));
+    }
+
+    panel.hide();
+}
+
 } // namespace
 
 int main(int argc, char** argv)
@@ -76,85 +182,9 @@ int main(int argc, char** argv)
 
     const QFont originalFont = app.font();
     for (const qreal scale : {1.0, 1.25, 1.5}) {
-        std::string fontDetail;
-        const bool fontScaled =
-            setScaledApplicationFont(app, originalFont, scale, &fontDetail);
-        report("font scale is representable",
-               fontScaled,
-               " scale=" + std::to_string(scale) + " " + fontDetail);
-        if (!fontScaled) {
-            continue;
+        for (const bool frameless : {true, false}) {
+            checkFooterReachable(app, originalFont, scale, frameless);
         }
-
-        ConnectionPanel panel;
-        panel.setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
-                             ConnectionPanel::kSafeMinimumHeight);
-        panel.resize(ConnectionPanel::kSafeMinimumWidth,
-                     ConnectionPanel::kSafeMinimumHeight);
-        panel.setConnected(true);
-        panel.show();
-        QApplication::processEvents();
-
-        QScrollArea* body =
-            panel.findChild<QScrollArea*>(QStringLiteral("connectionBodyScrollArea"));
-        QWidget* bodyContent =
-            panel.findChild<QWidget*>(QStringLiteral("connectionBodyContent"));
-        QPushButton* disconnect =
-            panel.findChild<QPushButton*>(QStringLiteral("connectionDisconnectButton"));
-
-        const std::string suffix = " scale=" + std::to_string(scale);
-        report("scrollable connection body exists",
-               body != nullptr,
-               suffix);
-        report("body overflows into a vertical scrollbar",
-               body && body->verticalScrollBar()->maximum() > 0,
-               suffix + " maximum="
-                   + std::to_string(body ? body->verticalScrollBar()->maximum() : -1));
-        report("horizontal overflow remains reachable",
-               body
-                   && body->horizontalScrollBarPolicy() == Qt::ScrollBarAsNeeded,
-               suffix);
-        report("vertical scrollbar stays clear of the resize edge",
-               body
-                   && body->verticalScrollBar()
-                          ->mapTo(&panel,
-                                 QPoint(body->verticalScrollBar()->width(), 0))
-                          .x()
-                       <= panel.width() - 12,
-               suffix);
-        report("Disconnect remains visible",
-               disconnect && disconnect->isVisible(),
-               suffix);
-        report("Disconnect remains inside the panel",
-               disconnect && bottomInPanel(disconnect, &panel) <= panel.height(),
-               suffix + " bottom="
-                   + std::to_string(disconnect ? bottomInPanel(disconnect, &panel) : -1)
-                   + " panelH=" + std::to_string(panel.height()));
-        report("Disconnect footer stays below the scrolling body",
-               body && disconnect
-                   && disconnect->mapTo(&panel, QPoint()).y()
-                       >= body->mapTo(&panel, QPoint(0, body->height())).y(),
-               suffix);
-
-        bool wrappedLabelsFit = bodyContent != nullptr;
-        if (bodyContent) {
-            const QList<QLabel*> labels = bodyContent->findChildren<QLabel*>();
-            for (QLabel* label : labels) {
-                if (!label->wordWrap() || !label->isVisibleTo(bodyContent)) {
-                    continue;
-                }
-                const int requiredHeight = label->heightForWidth(label->width());
-                if (requiredHeight > 0 && label->height() < requiredHeight) {
-                    wrappedLabelsFit = false;
-                    break;
-                }
-            }
-        }
-        report("visible wrapped labels receive their required height",
-               wrappedLabelsFit,
-               suffix);
-
-        panel.hide();
     }
     app.setFont(originalFont);
 
@@ -173,26 +203,112 @@ int main(int argc, char** argv)
            availableHeight > 0 && oversizedPanel.frameGeometry().height() <= availableHeight,
            "frameH=" + std::to_string(oversizedPanel.frameGeometry().height())
                + " availableH=" + std::to_string(availableHeight));
-    const QMargins frameMargins = oversizedPanel.screenFitFrameMargins();
-    report("native-frame screen fitting accounts for title-bar margins",
-           frameMargins.top() > 0,
-           "top=" + std::to_string(frameMargins.top()));
+
+    // The style fallback, on its own. A shown panel gets its margins from the
+    // platform — offscreen reports a uniform 2 px box — so asserting top() > 0
+    // there proves nothing about the branch that runs before the native window
+    // exists, which is the one the first open on Windows depends on.
+    {
+        ConnectionPanel unshownPanel;
+        unshownPanel.setFramelessMode(false);
+        const QMargins estimate = unshownPanel.screenFitFrameMargins();
+        const int titleBarHeight = unshownPanel.style()->pixelMetric(
+            QStyle::PM_TitleBarHeight, nullptr, &unshownPanel);
+        report("pre-show frame estimate reserves a title bar, not a border",
+               estimate.top() >= titleBarHeight && estimate.top() > estimate.bottom(),
+               "top=" + std::to_string(estimate.top())
+                   + " bottom=" + std::to_string(estimate.bottom())
+                   + " PM_TitleBarHeight=" + std::to_string(titleBarHeight));
+
+        ConnectionPanel unshownFrameless;
+        unshownFrameless.setFramelessMode(true);
+        report("frameless mode reserves no frame at all",
+               unshownFrameless.screenFitFrameMargins().isNull(),
+               "top=" + std::to_string(
+                            unshownFrameless.screenFitFrameMargins().top()));
+    }
+
     if (screen) {
         const QRect available = screen->availableGeometry();
         const QPoint preferred(available.right(), available.bottom());
         const QPoint constrained =
             oversizedPanel.constrainedFrameTopLeft(preferred, available);
-        const QSize frameSize(
-            oversizedPanel.width() + frameMargins.left() + frameMargins.right(),
-            oversizedPanel.height() + frameMargins.top() + frameMargins.bottom());
+        const QSize frameSize = oversizedPanel.screenFitFrameSize();
         report("constrained native frame remains inside available geometry",
                available.contains(QRect(constrained, frameSize)),
                "frameX=" + std::to_string(constrained.x())
                    + " frameY=" + std::to_string(constrained.y())
                    + " frameW=" + std::to_string(frameSize.width())
                    + " frameH=" + std::to_string(frameSize.height()));
+
+        // fitAndClampToScreen() is the show path ConnectionPanel owns itself:
+        // the frameless toggle, the automation bridge, and the deferred re-fit
+        // after a screen/DPI/font change all land here. It must pull a window
+        // back inside the work area without otherwise relocating it.
+        ConnectionPanel strayPanel;
+        strayPanel.setFramelessMode(false);
+        strayPanel.show();
+        QApplication::processEvents();
+        strayPanel.move(available.right() - 40, available.bottom() - 40);
+        strayPanel.fitAndClampToScreen(screen);
+        QApplication::processEvents();
+        report("fit-and-clamp pulls an off-work-area window back inside",
+               available.contains(strayPanel.frameGeometry()),
+               "frame=" + std::to_string(strayPanel.frameGeometry().x()) + ","
+                   + std::to_string(strayPanel.frameGeometry().y()) + " "
+                   + std::to_string(strayPanel.frameGeometry().width()) + "x"
+                   + std::to_string(strayPanel.frameGeometry().height()));
     }
 
+    // Growth policy: a height fitToScreen() chose is reclaimed toward what the
+    // body wants; a height the operator dragged to is left alone. Without the
+    // first half the dialog opens pre-scrolled on a roomy screen and never
+    // recovers; without the second half a deliberately short window springs
+    // back on every reopen.
+    //
+    // Run at 150 %, because that is where the fixed 660 px opening height was
+    // short of the body — at 100 % it happens to be enough and growth would go
+    // untested.
+    {
+        std::string fontDetail;
+        setScaledApplicationFont(app, originalFont, 1.5, &fontDetail);
+        ConnectionPanel growPanel;
+        growPanel.setFramelessMode(true);
+        growPanel.show();
+        QApplication::processEvents();
+        growPanel.fitToScreen(screen);
+        QApplication::processEvents();
+        const int autoHeight = growPanel.height();
+        QScrollArea* body = growPanel.findChild<QScrollArea*>(
+            QStringLiteral("connectionBodyScrollArea"));
+        report("auto-sized panel opens without needing to scroll",
+               body && body->verticalScrollBar()->maximum() == 0,
+               "height=" + std::to_string(autoHeight) + " vbarMax="
+                   + std::to_string(body ? body->verticalScrollBar()->maximum() : -1));
+        report("auto-sized panel grows past the nominal opening height",
+               autoHeight > ConnectionPanel::kPreferredHeight,
+               "height=" + std::to_string(autoHeight) + " kPreferredHeight="
+                   + std::to_string(ConnectionPanel::kPreferredHeight));
+
+        // Simulate the operator dragging it short, then reopening.
+        growPanel.resize(growPanel.width(), ConnectionPanel::kSafeMinimumHeight);
+        growPanel.fitToScreen(screen);
+        QApplication::processEvents();
+        report("a height the operator chose survives a re-fit",
+               growPanel.height() == ConnectionPanel::kSafeMinimumHeight,
+               "height=" + std::to_string(growPanel.height()));
+
+        // A height fitToScreen() itself set is fair game to reclaim.
+        growPanel.resize(growPanel.width(), autoHeight);
+        growPanel.fitToScreen(screen);
+        QApplication::processEvents();
+        report("a height fit-to-screen set is reclaimed toward the body",
+               growPanel.height() == autoHeight,
+               "height=" + std::to_string(growPanel.height())
+                   + " autoHeight=" + std::to_string(autoHeight));
+    }
+
+    app.setFont(originalFont);
     std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");
     return g_failed == 0 ? 0 : 1;
 }

--- a/tests/connection_panel_size_test.cpp
+++ b/tests/connection_panel_size_test.cpp
@@ -1,0 +1,198 @@
+// Regression harness for issue #4515: the Connect to Radio window must keep
+// its Disconnect footer reachable when its body is taller than the screen.
+
+#include "TestSettingsProfile.h"
+#include "core/AppSettings.h"
+#include "gui/ConnectionPanel.h"
+
+#include <QApplication>
+#include <QFont>
+#include <QLabel>
+#include <QPushButton>
+#include <QScreen>
+#include <QScrollArea>
+#include <QScrollBar>
+
+#include <cstdio>
+#include <string>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok, const std::string& detail = {})
+{
+    std::printf("%s %-58s %s\n",
+                ok ? "[ OK ]" : "[FAIL]",
+                name,
+                detail.c_str());
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+int bottomInPanel(QWidget* widget, QWidget* panel)
+{
+    return widget->mapTo(panel, QPoint(0, widget->height())).y();
+}
+
+bool setScaledApplicationFont(QApplication& app,
+                              const QFont& originalFont,
+                              qreal scale,
+                              std::string* detail)
+{
+    QFont scaledFont = originalFont;
+    if (originalFont.pointSizeF() > 0.0) {
+        scaledFont.setPointSizeF(originalFont.pointSizeF() * scale);
+        *detail = "pointSizeF=" + std::to_string(scaledFont.pointSizeF());
+    } else if (originalFont.pixelSize() > 0) {
+        scaledFont.setPixelSize(
+            qMax(1, qRound(static_cast<qreal>(originalFont.pixelSize()) * scale)));
+        *detail = "pixelSize=" + std::to_string(scaledFont.pixelSize());
+    } else {
+        *detail = "font exposes neither a point nor pixel size";
+        return false;
+    }
+    app.setFont(scaledFont);
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    TestSettingsProfile settingsProfile(QStringLiteral("aether-connection-panel-size-test"));
+    if (!settingsProfile.isValid()) {
+        return 1;
+    }
+    if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "offscreen");
+    }
+    QApplication app(argc, argv);
+    AppSettings::instance().load();
+    std::printf("ConnectionPanel screen-fit test harness (#4515)\n\n");
+
+    const QFont originalFont = app.font();
+    for (const qreal scale : {1.0, 1.25, 1.5}) {
+        std::string fontDetail;
+        const bool fontScaled =
+            setScaledApplicationFont(app, originalFont, scale, &fontDetail);
+        report("font scale is representable",
+               fontScaled,
+               " scale=" + std::to_string(scale) + " " + fontDetail);
+        if (!fontScaled) {
+            continue;
+        }
+
+        ConnectionPanel panel;
+        panel.setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
+                             ConnectionPanel::kSafeMinimumHeight);
+        panel.resize(ConnectionPanel::kSafeMinimumWidth,
+                     ConnectionPanel::kSafeMinimumHeight);
+        panel.setConnected(true);
+        panel.show();
+        QApplication::processEvents();
+
+        QScrollArea* body =
+            panel.findChild<QScrollArea*>(QStringLiteral("connectionBodyScrollArea"));
+        QWidget* bodyContent =
+            panel.findChild<QWidget*>(QStringLiteral("connectionBodyContent"));
+        QPushButton* disconnect =
+            panel.findChild<QPushButton*>(QStringLiteral("connectionDisconnectButton"));
+
+        const std::string suffix = " scale=" + std::to_string(scale);
+        report("scrollable connection body exists",
+               body != nullptr,
+               suffix);
+        report("body overflows into a vertical scrollbar",
+               body && body->verticalScrollBar()->maximum() > 0,
+               suffix + " maximum="
+                   + std::to_string(body ? body->verticalScrollBar()->maximum() : -1));
+        report("horizontal overflow remains reachable",
+               body
+                   && body->horizontalScrollBarPolicy() == Qt::ScrollBarAsNeeded,
+               suffix);
+        report("vertical scrollbar stays clear of the resize edge",
+               body
+                   && body->verticalScrollBar()
+                          ->mapTo(&panel,
+                                 QPoint(body->verticalScrollBar()->width(), 0))
+                          .x()
+                       <= panel.width() - 12,
+               suffix);
+        report("Disconnect remains visible",
+               disconnect && disconnect->isVisible(),
+               suffix);
+        report("Disconnect remains inside the panel",
+               disconnect && bottomInPanel(disconnect, &panel) <= panel.height(),
+               suffix + " bottom="
+                   + std::to_string(disconnect ? bottomInPanel(disconnect, &panel) : -1)
+                   + " panelH=" + std::to_string(panel.height()));
+        report("Disconnect footer stays below the scrolling body",
+               body && disconnect
+                   && disconnect->mapTo(&panel, QPoint()).y()
+                       >= body->mapTo(&panel, QPoint(0, body->height())).y(),
+               suffix);
+
+        bool wrappedLabelsFit = bodyContent != nullptr;
+        if (bodyContent) {
+            const QList<QLabel*> labels = bodyContent->findChildren<QLabel*>();
+            for (QLabel* label : labels) {
+                if (!label->wordWrap() || !label->isVisibleTo(bodyContent)) {
+                    continue;
+                }
+                const int requiredHeight = label->heightForWidth(label->width());
+                if (requiredHeight > 0 && label->height() < requiredHeight) {
+                    wrappedLabelsFit = false;
+                    break;
+                }
+            }
+        }
+        report("visible wrapped labels receive their required height",
+               wrappedLabelsFit,
+               suffix);
+
+        panel.hide();
+    }
+    app.setFont(originalFont);
+
+    ConnectionPanel oversizedPanel;
+    oversizedPanel.setFramelessMode(false);
+    oversizedPanel.setMinimumSize(ConnectionPanel::kSafeMinimumWidth,
+                                  ConnectionPanel::kSafeMinimumHeight);
+    oversizedPanel.resize(760, 10000);
+    oversizedPanel.show();
+    QApplication::processEvents();
+    QScreen* screen = QApplication::primaryScreen();
+    oversizedPanel.fitToScreen(screen);
+    QApplication::processEvents();
+    const int availableHeight = screen ? screen->availableGeometry().height() : 0;
+    report("screen-fit clamps an oversized panel to available height",
+           availableHeight > 0 && oversizedPanel.frameGeometry().height() <= availableHeight,
+           "frameH=" + std::to_string(oversizedPanel.frameGeometry().height())
+               + " availableH=" + std::to_string(availableHeight));
+    const QMargins frameMargins = oversizedPanel.screenFitFrameMargins();
+    report("native-frame screen fitting accounts for title-bar margins",
+           frameMargins.top() > 0,
+           "top=" + std::to_string(frameMargins.top()));
+    if (screen) {
+        const QRect available = screen->availableGeometry();
+        const QPoint preferred(available.right(), available.bottom());
+        const QPoint constrained =
+            oversizedPanel.constrainedFrameTopLeft(preferred, available);
+        const QSize frameSize(
+            oversizedPanel.width() + frameMargins.left() + frameMargins.right(),
+            oversizedPanel.height() + frameMargins.top() + frameMargins.bottom());
+        report("constrained native frame remains inside available geometry",
+               available.contains(QRect(constrained, frameSize)),
+               "frameX=" + std::to_string(constrained.x())
+                   + " frameY=" + std::to_string(constrained.y())
+                   + " frameW=" + std::to_string(frameSize.width())
+                   + " frameH=" + std::to_string(frameSize.height()));
+    }
+
+    std::printf("\n%s\n", g_failed == 0 ? "ALL PASS" : "FAILURES PRESENT");
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Fixes #4515.

The Connect to Radio panel used one tall, non-scrollable vertical layout whose
footer was its final item. Its explicit 580 px minimum height suppressed the
layout's intrinsic minimum while the 660 px initial height could still be
shorter than the content at Windows DPI/font scaling, so the footer clipped
first. Separately, `showConnectionDialog()` clamped only the client position;
it neither reduced an oversized panel to `QScreen::availableGeometry()` nor
included native window-frame margins.

This change:

- wraps only the connection body in a frameless vertical `QScrollArea`;
- pins status and Disconnect in a fixed footer below the scrolling body;
- lowers the safe minimum height and constrains the client height to the
  current screen's usable geometry, accounting for native frame margins;
- routes every MainWindow show path through the common fit-and-place helper;
- adds an offscreen regression harness covering 100%, 125%, and 150%
  font/DPI-equivalent scaling.

## Constitution principle honored

**Principle XI — Fixes Are Demonstrated.** The layout invariant has a focused
offscreen regression test and was also exercised through the agent automation
bridge on the freshly built application.

## Proof

The agent automation bridge connected the built-in RX-only demo simulator,
reopened Connect to Radio, and reported:

- panel: `y=731`, `h=660` (bottom `1391`);
- scrolling body: `y=749`, `h=602`, visible vertical scrollbar
  (`range=0..2`);
- fixed footer: `y=1351`, `h=40` (bottom `1391`);
- Disconnect: visible and enabled at `y=1351`, `h=28` (bottom `1379`).

It then invoked `connectionDisconnectButton` successfully and read back
`connected=false`, `mox=false`, `tuning=false`, and `transmitting=false`.
TX automation was explicitly pinned off for the proof.

![Connect to Radio with scrollable body and fixed Disconnect footer](https://raw.githubusercontent.com/rfoust/AetherSDR/fix-4515-assets/.pr-assets/4515-after.png)

## Test plan

- [x] Local build passes (`cmake --build build`)
- [x] Focused CTest passes:
  `ctest --test-dir build -R '^connection_panel_size_test$' --output-on-failure`
- [x] Focused executable passes with `QT_QPA_PLATFORM` unset, exercising its
  guarded offscreen fallback
- [x] Agent automation bridge proof on the built-in RX-only demo simulator
- [x] `python3 tools/check_engine_boundary.py --strict` reports zero blockers
- [x] `git diff --check` passes
- [ ] Existing tests pass (CI)
- [x] Reproduction steps documented in #4515

## Checklist

- [x] Commit is signed
- [x] No settings persistence added
- [x] Code is clean-room
- [x] No meter UI changed
- [x] Documentation update not needed; this restores reachability of an
  existing control without adding a setting or workflow
- [x] Security-sensitive changes / GHSA: not applicable

Generated with OpenAI Codex.
