### PR TITLE
fix(automation): extend the Hz-for-MHz guard to targettune and pan center

### DIFF
--- a/docs/automation-bridge.md
+++ b/docs/automation-bridge.md
@@ -1090,7 +1090,9 @@ transverter could plausibly need still passes. It is deliberately not
 auto-corrected: `14200000` would have to mean 14.2 MHz here and something else
 in every other frequency verb.
 
-Four refusals guard the value, and the wording differs on purpose:
+Four refusals guard the value, and the wording differs on purpose. The same
+four — same thresholds, one shared helper, the verb's own name in the message
+— also guard [`targettune`](#targettune) and [`pan center`](#pan):
 
 | input | reply |
 |---|---|
@@ -1129,6 +1131,18 @@ sweep guards.
 → {"cmd":"targettune","value":"146.520"}
 ← {"ok":true,"targetTune":146.52,"sliceId":0,"letter":"A"}
 ```
+
+**The value is MHz.** The [four refusals listed under `tune`](#tune) apply here
+unchanged — same thresholds, same shared helper, `targettune` in the message:
+
+```json
+→ {"cmd":"targettune","value":"14200000"}
+← {"ok":false,"error":"targettune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)"}
+```
+
+`ok:true` carries the same caveat as `tune`: it is an acknowledgement that the
+request was accepted and dispatched, not a confirmation that the radio landed
+there. Read the frequency back with [`get slices`](#get) if you need to know.
 
 ### `memory`
 Recall a radio memory through `MainWindow::activateMemorySpot()`, including its
@@ -1633,7 +1647,7 @@ Panadapter lifecycle — create or tear down a pan regardless of how it was open
 | `action` | `value` | effect |
 |---|---|---|
 | `create` (alias `add`) | — | create a new panadapter (panafall). The only UI path is an unaddressable label. |
-| `center` | `<mhz>` | recenter the active pan — the band-change lever (a plain `tune` only moves the slice and clamps to the pan's RF range, #292). |
+| `center` | `<mhz>` | recenter the active pan — the band-change lever (a plain `tune` only moves the slice and clamps to the pan's RF range, #292). **MHz, not Hz**: the [four refusals listed under `tune`](#tune) apply here too, with `pan center` in the message. It matters more on this verb — `setPanCenter()` clamps only the low edge, so an unguarded out-of-range centre is stored and advertised over TCI (`dds:`) even though the radio rejects it. |
 | `close` (alias `remove`) | `<panId>` (`0x…`) / `<index>` (panIndex) / `active` / `all` | close pan(s). Sends `display pan remove` **and** `display panafall remove`, so a panafall-created pan closes without the slice-removal workaround. A single target won't close the last pan; `all` will. |
 
 All are async (the radio echoes the change) — re-poll `get pans`. Every `pan`

--- a/src/core/AutomationServer.cpp
+++ b/src/core/AutomationServer.cpp
@@ -58,6 +58,7 @@
 #include <cmath>
 #include <cstring>
 #include <limits>
+#include <optional>
 #include <utility>
 
 // Best-effort value extraction for common control types.
@@ -1136,6 +1137,99 @@ QJsonObject err(const QString& msg)
 QString formatMhz(double mhz)
 {
     return QString::number(mhz, 'g', 15);
+}
+
+// The tunable range shared by every verb documented in MHz.
+//
+// FLOOR — below anything a supported radio tunes. Matches the floor typed
+// frequency entry already applies to the same value (VfoWidget.cpp /
+// RxApplet.cpp, `freqMhz >= 0.001`), so the bridge and the VFO field agree on
+// what is too small rather than the bridge passing values the GUI would refuse.
+// This is NOT a unit guard and does not pretend to be one: GHz-for-MHz on HF
+// (`0.0142` meaning 14.2 MHz) lands at 14.2 kHz, a plausible VLF frequency
+// rather than a diagnosable mistake. What it stops is nonsense (`1e-300`)
+// reaching setFrequency() and the radio.
+//
+// CEILING — Hz passed to an MHz verb. A value above anything AetherSDR can tune
+// is a unit mistake rather than an ambitious request, and saying so beats
+// silently doing nothing: the radio ignores an out-of-band target, the verb
+// reports ok:true, and the caller goes on to key on the previous band. (#4550)
+// It is NOT auto-converted — guessing the caller's intent would make 14200000
+// mean 14.2 MHz here and something else in every other frequency verb.
+//
+// The ceiling is 10x the top of the band table (BandDefs.h — 3cm ends at
+// 10500), so it clears any real transverter setup with an order of magnitude to
+// spare while still catching the whole family of Hz-for-MHz mistakes —
+// including the ones a 1 THz threshold let through, such as `500000` for
+// 500 kHz, which would otherwise fall past the guard and land back in the
+// silent no-op this refusal exists to prevent.
+//
+// It is deliberately LOOSER than the 50000.0 MHz cap typed frequency entry
+// applies on XVTR (VfoWidget.cpp / RxApplet.cpp): the GUI cap is a limit on
+// what a human can dial, while this one only has to be high enough that no real
+// request trips it. Neither is "the" tuning limit — if one ever becomes the
+// authority, the other should be derived from it rather than re-guessed.
+//
+// kHz-for-MHz (e.g. `14200` for 20m) deliberately PASSES: that value is
+// indistinguishable from a legitimate microwave request (14.2 GHz sits inside
+// the transverter headroom this ceiling exists to protect), and refusing the
+// range would break real 24/47/76 GHz operation. A band-table lookup was
+// considered and rejected for the same reason — XVTR RF frequency is
+// user-configurable beyond the table. Decided, not overlooked.
+constexpr double kMinTunableMhz = 0.001;
+constexpr double kMaxTunableMhz = 105'000.0;
+
+// Top of the radio spectrum. Between kMaxTunableMhz and here an over-ceiling
+// value is genuinely ambiguous rather than obviously Hz — see below.
+constexpr double kSpectrumTopMhz = 300'000.0;
+
+// Validate the frequency argument of a verb documented in MHz.
+//
+// Returns the refusal to hand straight back to the caller, or std::nullopt when
+// `value` is a plausible request — in which case `mhz` holds the parsed
+// frequency. `verb` names the caller so every message is actionable.
+//
+// ONE definition, used by every MHz-taking verb. Three of them need this rule —
+// `tune`, `targettune` and `pan center` — and three copies of a threshold is how
+// they drift apart. Parsing lives in here too, so no verb can reintroduce the
+// non-finite hole by hand: QString::toDouble() accepts "nan" and "inf", and NaN
+// in particular sails past every range check below (NaN <= 0, NaN < floor and
+// NaN > ceiling are all false), so it has to be refused by name, before any
+// comparison is reached, with a message about the value itself rather than a
+// unit mistake it isn't.
+std::optional<QJsonObject> refuseUntunableMhz(const QString& verb,
+                                              const QString& value, double& mhz)
+{
+    bool parsed = false;
+    mhz = value.toDouble(&parsed);
+    if (!parsed || !std::isfinite(mhz) || mhz <= 0)
+        return err(verb
+                   + QStringLiteral(" requires a positive finite frequency in MHz"));
+    if (mhz < kMinTunableMhz)
+        return err(verb + QStringLiteral(" requires at least ")
+                   + formatMhz(kMinTunableMhz) + QStringLiteral(" MHz — got ")
+                   + formatMhz(mhz));
+    if (mhz > kMaxTunableMhz) {
+        // Above the ceiling but below the top of the spectrum is genuinely
+        // ambiguous: it reads as an Hz-for-MHz mistake OR as a real millimetre-
+        // wave allocation entered correctly in MHz (122.25 / 134 / 241 GHz).
+        // Refuse either way, but present both readings — telling someone
+        // dialling a 122 GHz transverter "did you mean 0.122250?" would be
+        // confidently wrong, which is the failure mode this messaging exists to
+        // avoid.
+        if (mhz <= kSpectrumTopMhz)
+            return err(verb + QStringLiteral(" takes MHz — got ") + formatMhz(mhz)
+                       + QStringLiteral(", above the ") + formatMhz(kMaxTunableMhz)
+                       + QStringLiteral(" MHz ceiling. If that was Hz, resend as ")
+                       + QString::number(mhz / 1.0e6, 'f', 6)
+                       + QStringLiteral("; if it is a millimetre-wave frequency in "
+                                        "MHz, it is beyond what AetherSDR can tune"));
+        return err(verb + QStringLiteral(" takes MHz, not Hz — got ") + formatMhz(mhz)
+                   + QStringLiteral(" (did you mean ")
+                   + QString::number(mhz / 1.0e6, 'f', 6)
+                   + QStringLiteral("?)"));
+    }
+    return std::nullopt;
 }
 
 QJsonObject deferredResponse()
@@ -6158,73 +6252,10 @@ QJsonObject AutomationServer::doTune(const QString& value, const QString& id)
 {
     if (!m_radioModel)
         return err(QStringLiteral("no radio model available"));
-    bool okF = false;
-    const double mhz = value.toDouble(&okF);
-    // toDouble() accepts "nan" and "inf". NaN in particular sails past every
-    // range check below (NaN <= 0 and NaN > ceiling are both false), so
-    // non-finite input must be refused here, by name, where the message is
-    // about the value itself rather than a unit mistake it isn't.
-    if (!okF || !std::isfinite(mhz) || mhz <= 0)
-        return err(QStringLiteral("tune requires a positive finite frequency in MHz"));
-    // Below anything a supported radio tunes. Matches the floor typed frequency
-    // entry already applies to the same value (VfoWidget.cpp / RxApplet.cpp,
-    // `freqMhz >= 0.001`), so the bridge and the VFO field agree on what is too
-    // small rather than the bridge passing values the GUI would refuse.
-    //
-    // This is NOT a unit guard and does not pretend to be one: GHz-for-MHz on HF
-    // (`tune 0.0142` meaning 14.2 MHz) lands at 14.2 kHz, which is a plausible
-    // VLF frequency, not a diagnosable mistake. What it does stop is nonsense
-    // (`tune 1e-300`) reaching setFrequency() and the radio.
-    constexpr double kMinTunableMhz = 0.001;
-    if (mhz < kMinTunableMhz)
-        return err(QStringLiteral("tune requires at least ")
-                   + formatMhz(kMinTunableMhz) + QStringLiteral(" MHz — got ")
-                   + formatMhz(mhz));
-    // Hz passed to an MHz verb. A value above anything AetherSDR can tune is a
-    // unit mistake rather than an ambitious request, and saying so beats
-    // silently doing nothing. It is NOT auto-converted: guessing the caller's
-    // intent would make 14200000 mean 14.2 MHz here and something else in every
-    // other frequency verb.
-    //
-    // The ceiling is 10x the top of the band table (3cm ends at 10.5 GHz), so it
-    // clears any real transverter setup with an order of magnitude to spare
-    // while still catching the whole family of Hz-for-MHz mistakes — including
-    // the ones a 1 THz threshold let through, such as `tune 500000` for 500 kHz,
-    // which would otherwise fall past the guard and land back in the silent
-    // no-op this refusal exists to prevent.
-    //
-    // It is deliberately LOOSER than the 50000.0 MHz cap typed frequency entry
-    // applies on XVTR (VfoWidget.cpp / RxApplet.cpp): the GUI cap is a limit on
-    // what a human can dial, while this one only has to be high enough that no
-    // real request trips it. Neither is "the" tuning limit — if one ever becomes
-    // the authority, the other should be derived from it rather than re-guessed.
-    //
-    // kHz-for-MHz (e.g. `tune 14200` for 20m) deliberately PASSES: that value
-    // is indistinguishable from a legitimate microwave request (14.2 GHz is
-    // inside the transverter headroom this ceiling exists to protect), and
-    // refusing the range would break real 24 and 47 GHz operation. A band-table
-    // lookup was considered and rejected for the same reason — XVTR RF
-    // frequency is user-configurable beyond the table. Decided, not overlooked.
-    constexpr double kMaxTunableMhz = 105'000.0;
-    if (mhz > kMaxTunableMhz) {
-        // Above the ceiling but below 300 GHz is genuinely ambiguous: it reads
-        // as an Hz-for-MHz mistake OR as a real millimetre-wave allocation
-        // entered correctly in MHz (122.25 / 134 / 241 GHz). Refuse either way,
-        // but present both readings — telling someone dialling a 122 GHz
-        // transverter "did you mean 0.122250?" would be confidently wrong,
-        // which is the failure mode this guard's messaging exists to avoid.
-        if (mhz <= 300'000.0)
-            return err(QStringLiteral("tune takes MHz — got ") + formatMhz(mhz)
-                       + QStringLiteral(", above the ") + formatMhz(kMaxTunableMhz)
-                       + QStringLiteral(" MHz ceiling. If that was Hz, resend as ")
-                       + QString::number(mhz / 1.0e6, 'f', 6)
-                       + QStringLiteral("; if it is a millimetre-wave frequency in "
-                                        "MHz, it is beyond what AetherSDR can tune"));
-        return err(QStringLiteral("tune takes MHz, not Hz — got ") + formatMhz(mhz)
-                   + QStringLiteral(" (did you mean ")
-                   + QString::number(mhz / 1.0e6, 'f', 6)
-                   + QStringLiteral("?)"));
-    }
+    // Parse and range-check the value — see refuseUntunableMhz().
+    double mhz = 0.0;
+    if (const auto refusal = refuseUntunableMhz(QStringLiteral("tune"), value, mhz))
+        return *refusal;
 
     int sliceId = -1;  // -1 = active slice
     if (!id.isEmpty()) {
@@ -6321,12 +6352,13 @@ QJsonObject AutomationServer::doSimFault(const QString& fault, const QString& ar
 
 QJsonObject AutomationServer::doTargetTune(const QString& value)
 {
-    bool okFrequency = false;
-    const double mhz = value.toDouble(&okFrequency);
-    if (!okFrequency || mhz <= 0.0) {
-        return err(QStringLiteral(
-            "targettune requires a positive frequency in MHz"));
-    }
+    // Validated BEFORE the handler dispatch, so the guard applies on the path
+    // the shipping app takes: MainWindow_Session.cpp installs the targettune
+    // handler unconditionally at session setup (right beside setTuneHandler),
+    // so a guard below the dispatch would be dead code in the shipping app.
+    double mhz = 0.0;
+    if (const auto refusal = refuseUntunableMhz(QStringLiteral("targettune"), value, mhz))
+        return *refusal;
     if (!m_targetTuneHandler) {
         return err(QStringLiteral("target tune handler is unavailable"));
     }
@@ -8028,9 +8060,14 @@ QJsonObject AutomationServer::doPan(const QString& action, const QString& arg)
     }
 
     if (action == QLatin1String("center")) {
-        bool okF = false; const double mhz = arg.toDouble(&okF);
-        if (!okF || mhz <= 0)
-            return err(QStringLiteral("pan center requires a positive frequency in MHz"));
+        // Same contract as `tune` — see refuseUntunableMhz(). It matters more
+        // here: RadioModel::setPanCenter() clamps only the LOW edge, so an
+        // out-of-range centre is optimistically stored and advertised over TCI
+        // (`dds:`) even though the radio rejects it — the same silent no-op as
+        // #4550, one verb over.
+        double mhz = 0.0;
+        if (const auto refusal = refuseUntunableMhz(QStringLiteral("pan center"), arg, mhz))
+            return *refusal;
         radio->setPanCenter(mhz);
         return QJsonObject{{QStringLiteral("ok"), true}, {QStringLiteral("pan"), QStringLiteral("center")},
                            {QStringLiteral("centerMhz"), mhz}, {QStringLiteral("requested"), true}};

--- a/tests/automation_json_id_test.cpp
+++ b/tests/automation_json_id_test.cpp
@@ -79,14 +79,6 @@ QJsonObject tuneRequest(const QJsonValue& id = QJsonValue::Undefined)
     return request;
 }
 
-QJsonObject tuneValueRequest(const QString& value)
-{
-    return QJsonObject{
-        {QStringLiteral("cmd"), QStringLiteral("tune")},
-        {QStringLiteral("value"), value},
-    };
-}
-
 } // namespace
 
 int main(int argc, char** argv)
@@ -108,6 +100,19 @@ int main(int argc, char** argv)
         return QJsonObject{
             {QStringLiteral("ok"), true},
             {QStringLiteral("sliceId"), sliceId},
+        };
+    });
+
+    // targettune HARD-REQUIRES its handler — doTargetTune() errors out without
+    // one — so installing it is what makes a refusal distinguishable from
+    // "handler unavailable". As with tune, the app installs this unconditionally
+    // at session setup (MainWindow_Session.cpp:1939).
+    int targetTuneCalls = 0;
+    server.setTargetTuneHandler([&](double mhz) {
+        ++targetTuneCalls;
+        return QJsonObject{
+            {QStringLiteral("ok"), true},
+            {QStringLiteral("targetTune"), mhz},
         };
     });
 
@@ -162,108 +167,146 @@ int main(int argc, char** argv)
     expectRejected(tuneRequest(0.9999999), integerError,
                    "near-integer numeric id is not rounded down to a slice");
 
-    // ---- #4550: Hz passed to an MHz verb is refused, not silently no-opped ----
+    // ---- #4550: the MHz-value contract, shared by every verb taking MHz ----
     //
-    // A tune handler IS installed above, exactly as MainWindow_Session.cpp's
-    // setTuneHandler(...) call does in the shipping app. That matters: the guard
-    // is only worth anything if it runs BEFORE the m_tuneHandler dispatch, so
-    // these cases also pin that ordering — expectRejected asserts the handler
-    // was never reached.
-    auto expectTuneValueRejected = [&](const QString& value, const char* description) {
-        const int callsBefore = handlerCalls;
-        const QJsonObject response = client.request(tuneValueRequest(value));
-        const QString error = response.value(QStringLiteral("error")).toString();
-        check(!response.value(QStringLiteral("ok")).toBool()
-                  && error.startsWith(QStringLiteral("tune takes MHz, not Hz"))
-                  && handlerCalls == callsBefore,
-              description);
+    // `tune`, `targettune` and `pan center` route their value through one
+    // helper (AutomationServer.cpp, refuseUntunableMhz), so the contract is
+    // asserted once against a verb parameter rather than once per verb. That is
+    // the point of the shared helper and the point of this loop: if a verb ever
+    // stops using it, or the thresholds drift apart again, it shows up as one
+    // verb failing a case its siblings pass.
+    //
+    // Handlers for `tune` and `targettune` ARE installed above, exactly as
+    // MainWindow_Session.cpp installs them in the shipping app. That matters —
+    // the guard is only worth anything if it runs BEFORE the dispatch — so
+    // every rejection case also asserts the handler counter did not move.
+    auto verbRequest = [](const QString& verb, const QString& value) {
+        // `pan center` is one verb spelled as two fields. Hiding that here
+        // keeps every case below identical across all three verbs.
+        if (verb == QLatin1String("pan center")) {
+            return QJsonObject{{QStringLiteral("cmd"), QStringLiteral("pan")},
+                               {QStringLiteral("action"), QStringLiteral("center")},
+                               {QStringLiteral("value"), value}};
+        }
+        return QJsonObject{{QStringLiteral("cmd"), verb},
+                           {QStringLiteral("value"), value}};
     };
-    expectTuneValueRejected(QStringLiteral("14200000"),
-                            "#4550: 20m expressed in Hz is refused, not tuned");
-    // The case a 1 THz threshold let through: below the old guard, so it fell
-    // past it and became a 500000 MHz request — the silent no-op this refuses.
-    expectTuneValueRejected(QStringLiteral("500000"),
-                            "#4550: 500 kHz expressed in Hz is refused too");
-
-    // Non-finite input. QString::toDouble() happily parses "nan" and "inf",
-    // and NaN in particular fails EVERY comparison (NaN <= 0 and NaN > ceiling
-    // are both false), so without an explicit isfinite check it sailed through
-    // both guards and reached the radio. These must be refused by the
-    // positive-finite check — with its message, not a bogus unit diagnosis —
-    // and must never reach the handler.
-    auto expectNonFiniteRejected = [&](const QString& value, const char* description) {
-        const int callsBefore = handlerCalls;
-        const QJsonObject response = client.request(tuneValueRequest(value));
+    // `matches` is a predicate on the error text, so one helper serves the cases
+    // that pin an exact message, a prefix, or a fragment. `handlerCounter` is
+    // null for a verb with no handler indirection (`pan center`).
+    auto expectVerbRejected = [&](const QString& verb, const QString& value,
+                                  auto&& matches, int* handlerCounter,
+                                  const QString& description) {
+        const int before = handlerCounter ? *handlerCounter : 0;
+        const QJsonObject response = client.request(verbRequest(verb, value));
         const QString error = response.value(QStringLiteral("error")).toString();
+        const QByteArray desc = description.toUtf8();
         check(!response.value(QStringLiteral("ok")).toBool()
-                  && error == QStringLiteral("tune requires a positive finite frequency in MHz")
-                  && handlerCalls == callsBefore,
-              description);
+                  && matches(error)
+                  && (!handlerCounter || *handlerCounter == before),
+              desc.constData());
     };
-    expectNonFiniteRejected(QStringLiteral("nan"), "nan is refused, never tuned");
-    expectNonFiniteRejected(QStringLiteral("NaN"), "NaN is refused, never tuned");
-    expectNonFiniteRejected(QStringLiteral("inf"), "inf is refused by the finite check");
-    expectNonFiniteRejected(QStringLiteral("-inf"), "-inf is refused by the finite check");
+    auto expectVerbAccepted = [&](const QString& verb, const QString& value,
+                                  int* handlerCounter,
+                                  const QString& description) {
+        const int before = handlerCounter ? *handlerCounter : 0;
+        const QJsonObject response = client.request(verbRequest(verb, value));
+        const QByteArray desc = description.toUtf8();
+        check(response.value(QStringLiteral("ok")).toBool()
+                  && (!handlerCounter || *handlerCounter == before + 1),
+              desc.constData());
+    };
+    auto exactly = [](const QString& text) {
+        return [text](const QString& error) { return error == text; };
+    };
+    auto startingWith = [](const QString& prefix) {
+        return [prefix](const QString& error) { return error.startsWith(prefix); };
+    };
 
-    // The ambiguous window (ceiling..300 GHz): could be an Hz mistake OR a real
-    // millimetre-wave MHz value (122.25 GHz allocation). Refused, but the
-    // message must present both readings instead of confidently asserting the
-    // wrong one ("did you mean 0.122250?" to a 122 GHz transverter user).
-    {
-        const int callsBefore = handlerCalls;
-        const QJsonObject response =
-            client.request(tuneValueRequest(QStringLiteral("122250")));
-        const QString error = response.value(QStringLiteral("error")).toString();
-        check(!response.value(QStringLiteral("ok")).toBool()
-                  && !error.contains(QStringLiteral("did you mean"))
-                  && error.contains(QStringLiteral("millimetre-wave"))
-                  && handlerCalls == callsBefore,
-              "122.25 GHz in MHz is refused without misdiagnosing it as Hz");
+    struct MhzVerb { const char* name; int* calls; };
+    const MhzVerb kMhzVerbs[] = {
+        {"tune", &handlerCalls},
+        {"targettune", &targetTuneCalls},
+        {"pan center", nullptr},  // no handler indirection
+    };
+
+    for (const MhzVerb& v : kMhzVerbs) {
+        const QString verb = QString::fromLatin1(v.name);
+        const QString at = verb + QStringLiteral(": ");
+
+        // The original report: an Hz value is far outside any band, the radio
+        // ignores it, and the verb used to answer ok:true with the request
+        // echoed back.
+        expectVerbRejected(verb, QStringLiteral("14200000"),
+                           startingWith(verb + QStringLiteral(" takes MHz, not Hz")),
+                           v.calls, at + QStringLiteral("20m in Hz is refused, not applied"));
+        // The case a 1 THz threshold let through: 500000 is under 1e6, so it
+        // fell past the looser guard and became a 500000 MHz request — the
+        // silent no-op this refusal exists to prevent.
+        expectVerbRejected(verb, QStringLiteral("500000"),
+                           startingWith(verb + QStringLiteral(" takes MHz, not Hz")),
+                           v.calls, at + QStringLiteral("500 kHz in Hz is refused too"));
+
+        // Non-finite. QString::toDouble() happily parses "nan" and "inf", and
+        // NaN fails EVERY comparison (NaN <= 0, NaN < floor and NaN > ceiling
+        // are all false), so without an explicit isfinite check it sails
+        // through every guard and reaches the radio. Refused by name, with the
+        // message about the value itself rather than a unit mistake it isn't.
+        const auto finiteError = exactly(
+            verb + QStringLiteral(" requires a positive finite frequency in MHz"));
+        for (const QString& nonFinite : {QStringLiteral("nan"), QStringLiteral("NaN"),
+                                         QStringLiteral("inf"), QStringLiteral("-inf")}) {
+            expectVerbRejected(verb, nonFinite, finiteError, v.calls,
+                               at + nonFinite + QStringLiteral(" is refused by the finite check"));
+        }
+
+        // Floor. Nothing below what any supported radio tunes should reach the
+        // radio; 0.001 matches the floor typed frequency entry applies to the
+        // same value (VfoWidget / RxApplet), so the two paths agree.
+        expectVerbRejected(verb, QStringLiteral("1e-300"),
+                           exactly(verb + QStringLiteral(" requires at least 0.001 MHz — got 1e-300")),
+                           v.calls, at + QStringLiteral("a sub-floor frequency is refused"));
+
+        // The ambiguous window (ceiling..300 GHz): could be an Hz mistake OR a
+        // real millimetre-wave MHz value (the 122.25 GHz allocation). Refused,
+        // but the message must present both readings instead of confidently
+        // asserting the wrong one ("did you mean 0.122250?" to a 122 GHz user).
+        expectVerbRejected(verb, QStringLiteral("122250"),
+                           [](const QString& error) {
+                               return !error.contains(QStringLiteral("did you mean"))
+                                      && error.contains(QStringLiteral("millimetre-wave"));
+                           },
+                           v.calls,
+                           at + QStringLiteral("122.25 GHz is refused without misdiagnosing it as Hz"));
+
+        // A rejected value must be quoted back as sent. Rounding it to whole
+        // MHz made everything in (105000, 105000.5) report as "got 105000,
+        // above the 105000 MHz ceiling" — a message that contradicts itself, in
+        // the branch that exists to stop this guard asserting things that
+        // aren't true.
+        expectVerbRejected(verb, QStringLiteral("105000.4"),
+                           [](const QString& error) {
+                               return error.contains(QStringLiteral("got 105000.4,"));
+                           },
+                           v.calls,
+                           at + QStringLiteral("a value just over the ceiling is quoted back unrounded"));
+
+        // ...and neither bound may refuse anything real. 0.001 MHz is 1 kHz,
+        // below every amateur allocation including the VLF experiments at
+        // ~8.3 kHz; 10368.1 is the 3cm calling frequency, the top of the band
+        // table. Both have to keep working.
+        expectVerbAccepted(verb, QStringLiteral("0.001"), v.calls,
+                           at + QStringLiteral("the floor value itself is accepted"));
+        expectVerbAccepted(verb, QStringLiteral("10368.1"), v.calls,
+                           at + QStringLiteral("the top of the band table is accepted"));
+        // kHz-for-MHz (14200 = 20m in kHz, or 14.2 GHz in MHz) deliberately
+        // passes: the value is indistinguishable from a legitimate transverter
+        // request in the headroom the ceiling protects. Pinned as a DECISION,
+        // not an omission — if this starts rejecting, the transverter range
+        // broke.
+        expectVerbAccepted(verb, QStringLiteral("14200"), v.calls,
+                           at + QStringLiteral("kHz-for-MHz passes (indistinguishable from 14.2 GHz)"));
     }
-
-    // A rejected value must be quoted back as sent. Rounding it to whole MHz
-    // made everything in (105000, 105000.5) report as "got 105000, above the
-    // 105000 MHz ceiling" — a message that contradicts itself, in the branch
-    // that exists to stop this guard asserting things that aren't true.
-    {
-        const int callsBefore = handlerCalls;
-        const QJsonObject response =
-            client.request(tuneValueRequest(QStringLiteral("105000.4")));
-        const QString error = response.value(QStringLiteral("error")).toString();
-        check(!response.value(QStringLiteral("ok")).toBool()
-                  && error.contains(QStringLiteral("got 105000.4,"))
-                  && handlerCalls == callsBefore,
-              "a value just over the ceiling is quoted back unrounded");
-    }
-
-    // Floor. Nothing below what any supported radio tunes should reach
-    // setFrequency(); 0.001 matches the floor typed frequency entry applies to
-    // the same value (VfoWidget / RxApplet), so the two paths agree.
-    {
-        const int callsBefore = handlerCalls;
-        const QJsonObject response =
-            client.request(tuneValueRequest(QStringLiteral("1e-300")));
-        const QString error = response.value(QStringLiteral("error")).toString();
-        check(!response.value(QStringLiteral("ok")).toBool()
-                  && error == QStringLiteral("tune requires at least 0.001 MHz — got 1e-300")
-                  && handlerCalls == callsBefore,
-              "a sub-floor frequency is refused, never tuned");
-    }
-    // ...and the floor itself must not refuse anything real. 0.001 MHz is 1 kHz,
-    // below every amateur allocation including the VLF experiments at ~8.3 kHz.
-    expectAccepted(tuneValueRequest(QStringLiteral("0.001")), -1,
-                   "the floor value itself still tunes");
-
-    // The ceiling must not refuse anything real. 10368.1 is the 3cm calling
-    // frequency, the top of the band table, and it has to keep working.
-    expectAccepted(tuneValueRequest(QStringLiteral("10368.1")), -1,
-                   "#4550: the top of the band table still tunes");
-    // kHz-for-MHz (14200 = 20m in kHz, or 14.2 GHz in MHz) deliberately passes:
-    // the value is indistinguishable from a legitimate transverter request in
-    // the headroom the ceiling protects. Pinned as a DECISION, not an omission
-    // — if this ever starts rejecting, the transverter range broke.
-    expectAccepted(tuneValueRequest(QStringLiteral("14200")), -1,
-                   "kHz-for-MHz passes: indistinguishable from a 14.2 GHz request");
 
     server.stop();
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
Follow-up to #4552, which added the Hz-for-MHz guard to `tune`. Review there noted that
`targettune` shares the same echo shape and the same hole. Checking the rest of the bridge turned
up a **third** verb with it, so this hoists the rule into one helper rather than letting three
copies of a threshold drift apart — the same objection review raised against the duplicated
clamp/map in #4551.

> ⚠ **Stacked on #4552** (`5c5bba77`), which owns the helper this extends. The diff against `main`
> therefore includes that PR's commit; review this one's commit `dddce904` alone, or merge #4552
> first.

## The shared rule

`refuseIfHzNotMhz(verb, mhz)` and `kMaxTunableMhz` now live once, next to `err()`. All three
MHz-taking verbs call it.

## `targettune`

Identical to the original bug: an Hz value is far outside any band, the radio ignores it, and the
verb answers `ok:true` with the request echoed.

The guard goes **above** the handler dispatch. `MainWindow_Session.cpp:1939` installs the
targettune handler unconditionally at session setup, so a guard below it would be dead code in the
shipping app — exactly the mistake the removed half of #4552 made, and worth not repeating one verb
over.

## `pan center`

Worse in one respect. `RadioModel::setPanCenter()` clamps only the **low** edge, so an Hz-sized
centre is optimistically stored and advertised over TCI (`dds:`) even though the radio rejects it —
the function's own comment says so. Nothing upstream refused it.

## Verification — on air, real hardware

Hermes-Lite 2 `00:1C:C0:A2:13:DD`, gateware 74. State read back after each call, so a silent no-op
would show as the value failing to move:

```
park slice 21.2
targettune 14200000  ->  ok:false  "targettune takes MHz, not Hz — got 14200000 (did you mean 14.200000?)"
                         slice 21.2 -> 21.2   UNMOVED
targettune 500000    ->  ok:false  "targettune takes MHz, not Hz — got 500000 (did you mean 0.500000?)"
                         slice 21.2 -> 21.2   UNMOVED
targettune 14.2      ->  ok:true   slice 21.2 -> 14.2

park pan 21.2
pan center 14200000  ->  ok:false  "pan center takes MHz, not Hz — got 14200000 (did you mean 14.200000?)"
                         centerMhz 21.2 -> 21.2   UNMOVED
pan center 14.1      ->  ok:true   centerMhz 21.2 -> 14.1
```

**Tests.** `automation_json_id_test` gains 4 cases. It installs **both** handlers exactly as the
app does, so the targettune cases also pin that the guard runs *before* the dispatch — they assert
the handler was never reached. The `pan center` case asserts the exact error text, because without
the guard that request fails anyway (no panadapter in the fixture) and a bare `ok:false` would pass
for the wrong reason.

Red-before/green-after by removing **only the two new guards**: the three new refusal cases fail,
`tune`'s three still pass, and "top of the band table still tunes" stays green as it should. 20/20
after.

Full tree builds; `ctest -R "automation|bridge|slice"` **16/16** including `bridge_docs_check`, on
Windows/MSVC.

## Docs

`targettune` gains the refusal and the same "ok:true is an acknowledgement, not a confirmation"
caveat as `tune`. The `pan center` table row gains the MHz note and why the low-edge clamp doesn't
catch it.

## Not covered

Other verbs take frequencies in **Hz** by contract (`slice`/backend paths) and are untouched — this
is only about verbs documented in MHz. If a fourth turns up, it now needs one line rather than a
fourth copy of the threshold.
