### PR TITLE
feat(kiwi): per-profile "Resume audio after TX delay" to suppress the operator's own TX tail after unkey (depends on #4380)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4803,8 +4803,12 @@ add_test(NAME transmit_inhibit_policy_test COMMAND transmit_inhibit_policy_test)
 
 add_executable(kiwi_sdr_tx_mute_policy_test
     tests/kiwi_sdr_tx_mute_policy_test.cpp
+    # The resume hold's presentation-holdback input is routed by
+    # receivePresentationExternalKiwiDelayMs(); pinned against the real one.
+    src/core/ReceivePresentationSync.cpp
 )
 target_include_directories(kiwi_sdr_tx_mute_policy_test PRIVATE src)
+target_link_libraries(kiwi_sdr_tx_mute_policy_test PRIVATE Qt6::Core)
 add_test(NAME kiwi_sdr_tx_mute_policy_test COMMAND kiwi_sdr_tx_mute_policy_test)
 add_executable(slice_link_policy_test
     tests/slice_link_policy_test.cpp

--- a/docs/kiwisdr-cleanroom-design.md
+++ b/docs/kiwisdr-cleanroom-design.md
@@ -444,6 +444,61 @@ with NR2 disabled; they must not be collapsed into the legacy applet Kiwi
 output buffer, because the final mixer only treats that buffer as active when
 the applet-level Kiwi Audio toggle is enabled.
 
+## Transmit Gate For Managed Kiwi Sources
+
+The transmit mute is **presentation-only** for managed Kiwi antenna sources
+(#4380). The websocket, the jitter buffer, the drain, and the NR/DSP chain all
+keep running through TX; only the source's contribution at the final mix is
+ramped to zero over 8 ms. Nothing is dropped at the feed and no buffer is
+wiped, so unkey rejoins the live stream instead of re-priming a jitter buffer
+and letting NR re-converge from cold. The gate closes on the same TX-mute
+latch the rest of the client uses (`KiwiSdrTxMutePolicy.h`), which masks the
+radio's interlock term through our own unkey tail and bounds that mask with a
+watchdog so a foreign transmission still re-engages the mute.
+
+Two per-profile options ride on that gate. Both live in the profile's nested
+JSON object alongside `autoConnect` (Principle V — no new flat settings keys),
+and both are off by default:
+
+- **Keep audio during TX** (`keepAudioDuringTx`) — leave the gate open, so
+  this receiver stays audible while transmitting. For a receiver that cannot
+  hear your own signal, or when you want to monitor yourself deliberately.
+- **Resume audio after TX delay** (`resumeAudioAfterTxDelay`) — hold the gate
+  closed *past* unkey for this receiver's measured stream delay, so playback
+  resumes on audio the Kiwi received after the transmission ended rather than
+  on the operator's own delayed TX tail. Only meaningful for a receiver in
+  range of your own signal; inert (and disabled in the UI) while
+  **Keep audio during TX** is on, since a source that stays audible through TX
+  has nothing to resume.
+
+The hold length is computed by `kiwiSdrResumeHoldMs()` as **ingest lag +
+applied presentation holdback + a 250 ms guard**, clamped to 250–6000 ms:
+
+- *Ingest lag* prefers the Receive Sync measurement of when this Kiwi's audio
+  arrives relative to the Flex stream — but only for the profile the estimate
+  was actually measured against, and only while that estimate maintains the
+  same lock the sync engine itself requires before acting on it
+  (`kiwiSdrResumeHoldIngestLag()`). Otherwise `baseLatencyMs` stands in as a
+  rough proxy with no measured tie to this receiver's chain.
+- *Applied presentation holdback* must be the figure the mix is really playing
+  this source behind arrival — the one
+  `AudioEngine::setReceivePresentationDelays()` derives through
+  `receivePresentationExternalKiwiDelayMs()`. Under AutoAssist a source that
+  is not the delay target is played with **no** holdback; adding one anyway
+  would run the hold long and swallow real post-TX audio, because the pipeline
+  keeps draining (zeroed at the mix) through the hold rather than queueing.
+- The hold is recomputed at every key-down, so the deadline armed at the
+  coming unkey uses the freshest estimate. Re-keying inside a hold re-closes
+  the gate and re-arms from the new unkey; clearing the option disarms an
+  in-flight deadline instead of stranding it.
+
+Presentation telemetry — RX level meter, scopes, EQ FFT tap — mirrors the
+gate's closed window exactly, including the resume hold, so meters do not
+bounce with audio the operator cannot hear. The receive-sync correlator feed
+is suppressed on the same condition: feeding ramp-zeroed Kiwi chunks into
+GCC-PHAT against a live one-sided Flex stream would degrade the very estimate
+the hold is derived from.
+
 ## Source Provenance
 
 - The original KiwiSDR receive-path implementation used no KiwiSDR source code,

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -2267,18 +2267,29 @@ AudioEngine::AudioEngine(QObject* parent)
             // the pre-warm-pipeline mute froze both correlator buffers. A
             // TX-gated source's ramp-zeroed chunks (or a one-sided Flex feed
             // against them) would pollute the GCC-PHAT delay estimate and
-            // drop the auto-assist confidence on every over.
+            // drop the auto-assist confidence on every over. A source's gate
+            // stays held through its pending post-unkey resume hold ("Resume
+            // audio after TX delay"), so the pause must cover that window
+            // too; it lifts as soon as any source is audible through the
+            // gate (keepAudioDuringTx during TX, or a source with no pending
+            // hold after unkey).
             const bool kiwiTxGateEngaged = kiwiSdrAudioTransmitMuted();
-            bool anyKeepAudioDuringTx = false;
+            bool anyKiwiGateHeld = false;
+            bool anyKiwiAudibleThroughGate = false;
             for (const auto& s : m_externalKiwiSources) {
-                if (s && s->keepAudioDuringTx
-                    && externalKiwiSourceProcessing(*s)) {
-                    anyKeepAudioDuringTx = true;
-                    break;
+                if (!s || !externalKiwiSourceProcessing(*s)) {
+                    continue;
                 }
+                const bool held = !s->keepAudioDuringTx
+                    && (kiwiTxGateEngaged
+                        || !s->txResumeDeadline.hasExpired());
+                anyKiwiGateHeld = anyKiwiGateHeld || held;
+                anyKiwiAudibleThroughGate =
+                    anyKiwiAudibleThroughGate || !held;
             }
             const bool presentationPausedForTx =
-                kiwiTxGateEngaged && !anyKeepAudioDuringTx;
+                (kiwiTxGateEngaged || anyKiwiGateHeld)
+                && !anyKiwiAudibleThroughGate;
             // Per-frame gate ramp step; depends only on the device rate, so
             // compute it once for the Flex gate and every Kiwi source alike.
             const float gateStep =
@@ -2416,11 +2427,13 @@ AudioEngine::AudioEngine(QObject* parent)
                     // Transmit gate: the source keeps draining at real-time
                     // rate through TX so playback rejoins the live stream at
                     // unkey; only its mix contribution ramps to zero. The
-                    // short ramp avoids a hard-mute click on both edges.
-                    const float gateTarget =
-                        (!kiwiSdrAudioTransmitMuted()
-                         || source->keepAudioDuringTx)
-                            ? 1.0f : 0.0f;
+                    // short ramp avoids a hard-mute click on both edges. A
+                    // pending resume deadline extends the hold past unkey
+                    // ("Resume audio after TX delay").
+                    const bool gateOpen = source->keepAudioDuringTx
+                        || (!kiwiSdrAudioTransmitMuted()
+                            && source->txResumeDeadline.hasExpired());
+                    const float gateTarget = gateOpen ? 1.0f : 0.0f;
                     if (!externalKiwiSourceProcessing(*source)
                         || source->prebuffering) {
                         // Silent while skipped: snap the gate DOWNWARD only —
@@ -2478,9 +2491,12 @@ AudioEngine::AudioEngine(QObject* parent)
                         ++activeOutputSources;
                     }
                     source->outputBuffer.remove(0, sourceTake);
-                    emitOutputSource(QStringLiteral("kiwi"), source->id, sourceChunk,
-                                     kiwiTxGateEngaged
-                                         && !source->keepAudioDuringTx);
+                    // Suppress the correlator feed exactly while the mix
+                    // gate holds this source closed — including the
+                    // post-unkey resume hold, when the chunks above were
+                    // just ramped to zero.
+                    emitOutputSource(QStringLiteral("kiwi"), source->id,
+                                     sourceChunk, !gateOpen);
                 }
 
                 const qsizetype radeTake = (std::min(len, m_radeRxBuffer.size()) / floatBytes) * floatBytes;
@@ -3980,8 +3996,12 @@ void AudioEngine::setKiwiSdrAudioSourceEnabled(const QString& sourceId, bool on)
         // Entry snap: the mix-loop's downward snap only runs on ticks that
         // reach the mix path, which a lone prebuffering source never does —
         // without this, a source enabled mid-TX would enter the mix at its
-        // stale full-gain gate and blip ~8 ms of audio during transmit.
-        if (on && kiwiSdrAudioTransmitMuted() && !source->keepAudioDuringTx) {
+        // stale full-gain gate and blip ~8 ms of audio during transmit. The
+        // gate stays engaged through a pending post-unkey resume hold
+        // ("Resume audio after TX delay"), so cover that window too.
+        if (on && !source->keepAudioDuringTx
+            && (kiwiSdrAudioTransmitMuted()
+                || !source->txResumeDeadline.hasExpired())) {
             source->txGateGain = 0.0f;
         }
         updateRxBufferStats();
@@ -4024,9 +4044,11 @@ void AudioEngine::setKiwiSdrAudioSourceMuted(const QString& sourceId,
         source->prebuffering = !muted && source->enabled;
         // Entry snap — same reason as setKiwiSdrAudioSourceEnabled: a source
         // muted before key-down still has txGateGain at 1.0, and unmuting it
-        // mid-TX must not let it enter the mix at full gain.
-        if (!muted && kiwiSdrAudioTransmitMuted()
-            && !source->keepAudioDuringTx) {
+        // mid-TX (or during a pending resume hold) must not let it enter the
+        // mix at full gain.
+        if (!muted && !source->keepAudioDuringTx
+            && (kiwiSdrAudioTransmitMuted()
+                || !source->txResumeDeadline.hasExpired())) {
             source->txGateGain = 0.0f;
         }
         updateRxBufferStats();
@@ -4049,6 +4071,18 @@ void AudioEngine::setKiwiSdrAudioTransmitMuted(bool muted)
     // the legacy single-stream path keeps the historical wipe-and-reprime,
     // since nothing gates its feed during TX.
     std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    if (!muted) {
+        // Unkey: sources configured for delayed resume hold their gate
+        // closed for the Kiwi chain latency so playback rejoins on audio
+        // received after the transmission ended.
+        for (const auto& source : m_externalKiwiSources) {
+            if (source && source->txResumeHoldMs > 0
+                && !source->keepAudioDuringTx) {
+                source->txResumeDeadline =
+                    QDeadlineTimer(source->txResumeHoldMs);
+            }
+        }
+    }
     m_kiwiSdrRxBuffer.clear();
     m_kiwiSdrRxPackets.clear();
     m_kiwiSdrOutputBuffer.clear();
@@ -4072,6 +4106,24 @@ void AudioEngine::setKiwiSdrAudioSourceKeepDuringTx(const QString& sourceId,
     source->keepAudioDuringTx = keep;
 }
 
+void AudioEngine::setKiwiSdrAudioSourceResumeHold(const QString& sourceId,
+                                                  int holdMs)
+{
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    ExternalRxAudioSourceState* source = externalKiwiSource(sourceId, true);
+    if (!source) {
+        return;
+    }
+
+    source->txResumeHoldMs = std::max(holdMs, 0);
+    if (source->txResumeHoldMs == 0) {
+        // Hold disabled: disarm any deadline from the last unkey so the
+        // gate reopens promptly instead of waiting out a stale hold
+        // (default-constructed QDeadlineTimer is already expired).
+        source->txResumeDeadline = QDeadlineTimer();
+    }
+}
+
 void AudioEngine::setKiwiSdrAudioSourcePan(const QString& sourceId, int pan)
 {
     std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
@@ -4081,6 +4133,22 @@ void AudioEngine::setKiwiSdrAudioSourcePan(const QString& sourceId, int pan)
     }
 
     source->pan = qBound(0, pan, 100);
+}
+
+bool AudioEngine::hasKiwiSdrAudioSource(const QString& sourceId) const
+{
+    const QString id = sourceId.trimmed();
+    if (id.isEmpty()) {
+        return false;
+    }
+
+    std::lock_guard<std::recursive_mutex> dspLock(m_dspMutex);
+    for (const auto& source : m_externalKiwiSources) {
+        if (source && source->id == id) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void AudioEngine::removeKiwiSdrAudioSource(const QString& sourceId)
@@ -4254,9 +4322,12 @@ void AudioEngine::processMixedRxAudioData(const QByteArray& pcm,
     // processing still runs (to keep DSP state warm through TX) but the
     // presentation-side telemetry — RX level meter, scopes, EQ FFT tap,
     // receive-presentation post-DSP feed — must stay quiet, or the meters
-    // bounce with audio the operator cannot hear.
+    // bounce with audio the operator cannot hear. Mirrors the mix gate's
+    // closed condition exactly, including the post-unkey resume hold.
     const bool txPresentationGated = externalSource
-        && kiwiSdrAudioTransmitMuted() && !externalSource->keepAudioDuringTx;
+        && !externalSource->keepAudioDuringTx
+        && (kiwiSdrAudioTransmitMuted()
+            || !externalSource->txResumeDeadline.hasExpired());
 
     // TX-time RX-chain bypass (#367/#1505), decided once per packet: non-Kiwi
     // sources bypass the client RX DSP during TX so stateful stages don't

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <QBuffer>
 #include <QByteArray>
+#include <QDeadlineTimer>
 #include <QElapsedTimer>
 #include <QFutureSynchronizer>
 #include <QPointer>
@@ -173,6 +174,7 @@ public:
     bool isRxStreaming() const { return m_audioSink != nullptr; }
     bool isTxStreaming() const { return m_audioSource != nullptr; }
     bool kiwiSdrAudioTransmitMuted() const;
+    bool hasKiwiSdrAudioSource(const QString& sourceId) const;
     int  txInputSampleRate() const { return m_txInputRate; }
     int  txInputChannelCount() const { return m_txInputChannels; }
     bool txInputResamplingTo24k() const { return m_txNeedsResample; }
@@ -586,6 +588,7 @@ public slots:
     void setKiwiSdrAudioSourceGain(const QString& sourceId, float gainPercent);
     void setKiwiSdrAudioSourceMuted(const QString& sourceId, bool muted);
     void setKiwiSdrAudioSourceKeepDuringTx(const QString& sourceId, bool keep);
+    void setKiwiSdrAudioSourceResumeHold(const QString& sourceId, int holdMs);
     void setKiwiSdrAudioSourcePan(const QString& sourceId, int pan);
     void setKiwiSdrAudioTransmitMuted(bool muted);
     void removeKiwiSdrAudioSource(const QString& sourceId);
@@ -723,7 +726,13 @@ private:
         // the feed, jitter buffer, and DSP keep running through TX, and
         // only the final mix contribution is ramped to zero. With
         // keepAudioDuringTx set the source stays audible during TX.
+        // txResumeHoldMs > 0 keeps the gate closed that long past unkey so
+        // the resume lands on post-TX audio instead of the operator's own
+        // delayed TX tail (default QDeadlineTimer is already expired, so
+        // an unarmed deadline never holds the gate).
         bool keepAudioDuringTx{false};
+        int txResumeHoldMs{0};
+        QDeadlineTimer txResumeDeadline;
         float txGateGain{1.0f};
         bool prebuffering{false};
         bool dspInitializationPending{false};

--- a/src/core/KiwiSdrManager.cpp
+++ b/src/core/KiwiSdrManager.cpp
@@ -968,6 +968,8 @@ void KiwiSdrManager::loadSettings()
         p.autoConnect = obj.value(QStringLiteral("autoConnect")).toBool(false);
         p.keepAudioDuringTx =
             obj.value(QStringLiteral("keepAudioDuringTx")).toBool(false);
+        p.resumeAudioAfterTxDelay =
+            obj.value(QStringLiteral("resumeAudioAfterTxDelay")).toBool(false);
         if (obj.contains(QStringLiteral("waterfallMinDbm"))
             || obj.contains(QStringLiteral("waterfallMaxDbm"))) {
             p.waterfallMinDbm = std::clamp(
@@ -1008,6 +1010,8 @@ void KiwiSdrManager::saveSettings() const
         obj.insert(QStringLiteral("endpoint"), normalizedProfileEndpoint(p.endpoint));
         obj.insert(QStringLiteral("autoConnect"), p.autoConnect);
         obj.insert(QStringLiteral("keepAudioDuringTx"), p.keepAudioDuringTx);
+        obj.insert(QStringLiteral("resumeAudioAfterTxDelay"),
+                   p.resumeAudioAfterTxDelay);
         obj.insert(QStringLiteral("waterfallAutoScale"), p.waterfallAutoScale);
         const int waterfallMinDbm = std::clamp(
             p.waterfallMinDbm,

--- a/src/core/KiwiSdrManager.h
+++ b/src/core/KiwiSdrManager.h
@@ -26,6 +26,11 @@ struct KiwiSdrAntennaProfile {
     // stream itself always keeps flowing during TX; this only opens the
     // transmit gate at the audio mix). Default off: muted during TX.
     bool keepAudioDuringTx{false};
+    // Hold the post-TX unmute for the receiver's stream latency so the
+    // resume lands on audio received after unkey (suppresses hearing your
+    // own delayed TX tail on an in-range receiver). No effect when
+    // keepAudioDuringTx is set.
+    bool resumeAudioAfterTxDelay{false};
     bool waterfallAutoScale{true};
     int waterfallMinDbm{-110};
     int waterfallMaxDbm{-10};

--- a/src/core/KiwiSdrTxMutePolicy.h
+++ b/src/core/KiwiSdrTxMutePolicy.h
@@ -125,4 +125,52 @@ inline int kiwiSdrResumeHoldMs(bool estimateValid, int estimateOffsetMs,
                       kKiwiSdrResumeHoldMinMs, kKiwiSdrResumeHoldMaxMs);
 }
 
+// Which ingest-lag figure the hold above is entitled to use. Split out of the
+// caller because it is a decision, not arithmetic: getting it wrong does not
+// fail anything, it just silently changes how long the operator's audio stays
+// muted. A receive-sync offset only describes the ONE profile it was measured
+// against, and only while that measurement still holds the lock the sync
+// engine itself demands before acting on it — everything else falls back to
+// the caller's proxy.
+struct KiwiSdrResumeHoldSyncInputs {
+    bool isSyncTarget{false};       // this profile is the sync delay target
+    bool syncEnabled{false};
+    bool autoAssist{false};         // AutoAssist mode (false => Manual)
+    bool estimateValid{false};
+    bool estimateHeld{false};
+    float estimateConfidence{0.0f};
+    float autoLockConfidence{0.0f};
+    int estimateOffsetMs{0};        // positive delays Flex relative to Kiwi
+    int manualOffsetMs{0};
+};
+
+struct KiwiSdrResumeHoldIngestLag {
+    bool valid{false};
+    int offsetMs{0};
+};
+
+inline KiwiSdrResumeHoldIngestLag kiwiSdrResumeHoldIngestLag(
+    const KiwiSdrResumeHoldSyncInputs& in)
+{
+    if (!in.isSyncTarget || !in.syncEnabled) {
+        return {};
+    }
+    if (in.autoAssist) {
+        // Same condition ReceivePresentationSync applies before it will act
+        // on an estimate: held, or confident enough to lock.
+        if (in.estimateValid
+            && (in.estimateHeld
+                || in.estimateConfidence >= in.autoLockConfidence)) {
+            return {true, in.estimateOffsetMs};
+        }
+        return {};
+    }
+    // Manual: a negative or zero offset says the Kiwi is EARLIER than the
+    // Flex stream, which tells us nothing about its ingest lag.
+    if (in.manualOffsetMs > 0) {
+        return {true, in.manualOffsetMs};
+    }
+    return {};
+}
+
 } // namespace AetherSDR

--- a/src/core/KiwiSdrTxMutePolicy.h
+++ b/src/core/KiwiSdrTxMutePolicy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 
 // KiwiSDR transmit-mute latch (fork feature: warm Kiwi audio through TX).
@@ -99,5 +100,29 @@ struct KiwiSdrTxMaskWatchdog {
         return armedEpoch == epoch && maskedNow;
     }
 };
+
+// Hold time for "Resume audio after TX delay": how long the transmit gate
+// stays closed past unkey so the resume lands on audio the Kiwi received
+// AFTER the transmission ended, instead of replaying the operator's own
+// delayed TX tail. Two additive components: the ingest lag (the
+// receive-sync estimate measures when Kiwi audio ARRIVES relative to the
+// Flex stream; without one, the sync base latency stands in as a proxy)
+// plus the engine-applied presentation holdback for this source, which
+// delays playback beyond arrival. The guard covers what neither can see
+// (the Flex chain's own absolute latency plus websocket bunching).
+constexpr int kKiwiSdrResumeHoldGuardMs = 250;
+constexpr int kKiwiSdrResumeHoldMinMs = 250;
+constexpr int kKiwiSdrResumeHoldMaxMs = 6000;
+
+inline int kiwiSdrResumeHoldMs(bool estimateValid, int estimateOffsetMs,
+                               int fallbackLatencyMs,
+                               int appliedPresentationDelayMs)
+{
+    const int base = estimateValid ? std::max(estimateOffsetMs, 0)
+                                   : std::max(fallbackLatencyMs, 0);
+    return std::clamp(base + std::max(appliedPresentationDelayMs, 0)
+                          + kKiwiSdrResumeHoldGuardMs,
+                      kKiwiSdrResumeHoldMinMs, kKiwiSdrResumeHoldMaxMs);
+}
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -489,8 +489,24 @@ private:
     void syncKiwiSdrTransmitMute();
     void refreshKiwiSdrVirtualAudioControls();
     void refreshKiwiSdrResumeHolds();
+    // Everything the resume hold needs that does NOT vary per profile.
+    // Resolving the sync target walks slices and the audio delay walks the
+    // sync engine, so a sweep over every profile resolves them once instead
+    // of once per profile — this runs on every key-down edge, which under CW
+    // break-in is once per element.
+    struct KiwiSdrResumeHoldContext {
+        ReceivePresentationSettings sync;
+        QString syncTargetProfileId;  // receiveSyncDelayKiwiProfileId()
+        QString delayKiwiProfileId;   // as handed to the audio engine:
+                                      // the target under AutoAssist, else empty
+        int kiwiAudioDelayMs{0};      // as handed to the audio engine
+    };
+    KiwiSdrResumeHoldContext kiwiSdrResumeHoldContext() const;
     int kiwiSdrResumeHoldMsForProfile(
         const KiwiSdrAntennaProfile& profile) const;
+    int kiwiSdrResumeHoldMsForProfile(
+        const KiwiSdrAntennaProfile& profile,
+        const KiwiSdrResumeHoldContext& context) const;
     void setKiwiSdrVirtualAntennaForSlice(int sliceId, const QString& profileId);
     // Worker for the above. selectSlice=false suppresses the active-slice steal
     // for automatic re-arms (band-recall finish, #4158 recreation re-bind).

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -111,6 +111,7 @@ class ConnectionPanel;
 class ContributeDialog;
 class TitleBar;
 class KiwiSdrManager;
+struct KiwiSdrAntennaProfile;
 class SpectrumWidget;
 class SpectrumOverlayMenu;
 class IRadioBackend;
@@ -487,6 +488,9 @@ private:
     bool kiwiSdrTransmitMuteRequired() const;
     void syncKiwiSdrTransmitMute();
     void refreshKiwiSdrVirtualAudioControls();
+    void refreshKiwiSdrResumeHolds();
+    int kiwiSdrResumeHoldMsForProfile(
+        const KiwiSdrAntennaProfile& profile) const;
     void setKiwiSdrVirtualAntennaForSlice(int sliceId, const QString& profileId);
     // Worker for the above. selectSlice=false suppresses the active-slice steal
     // for automatic re-arms (band-recall finish, #4158 recreation re-bind).

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -14,6 +14,8 @@
 #include "core/KiwiSdrClient.h"
 #include "core/KiwiSdrManager.h"
 #include "core/KiwiSdrProtocol.h"
+#include "core/KiwiSdrTxMutePolicy.h"
+#include "core/ReceivePresentationSync.h"
 #include "core/LogManager.h"
 #include "models/BandSettings.h"
 #include "models/RadioModel.h"
@@ -1613,19 +1615,76 @@ void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice,
     const float gainPercent = slice->audioGain();
     const bool muted = slice->audioMute();
     const int pan = slice->audioPan();
-    const bool keepDuringTx =
-        m_kiwiSdrManager->profile(profileId).keepAudioDuringTx;
+    const KiwiSdrAntennaProfile profile = m_kiwiSdrManager->profile(profileId);
+    const bool keepDuringTx = profile.keepAudioDuringTx;
+    const int resumeHoldMs = kiwiSdrResumeHoldMsForProfile(profile);
     QMetaObject::invokeMethod(m_audio,
                               [audio = m_audio, profileId, gainPercent, muted,
-                               pan, keepDuringTx, includeEnable]() {
+                               pan, keepDuringTx, resumeHoldMs,
+                               includeEnable]() {
+        // Settings-only refreshes must not resurrect a source that
+        // removeKiwiSdrAudioSource() freed — every setter below re-creates
+        // a missing entry. Checked here on the audio thread so the answer
+        // is ordered against the queued removal itself.
+        if (!includeEnable && !audio->hasKiwiSdrAudioSource(profileId)) {
+            return;
+        }
+        // Gate policy first: the enable/unmute entry snaps below read
+        // keepAudioDuringTx and txResumeDeadline to decide whether to close
+        // the gate, so they must see this batch's values, not the last one's.
+        audio->setKiwiSdrAudioSourceKeepDuringTx(profileId, keepDuringTx);
+        audio->setKiwiSdrAudioSourceResumeHold(profileId, resumeHoldMs);
         if (includeEnable) {
             audio->setKiwiSdrAudioSourceEnabled(profileId, true);
         }
         audio->setKiwiSdrAudioSourceGain(profileId, gainPercent);
         audio->setKiwiSdrAudioSourceMuted(profileId, muted);
         audio->setKiwiSdrAudioSourcePan(profileId, pan);
-        audio->setKiwiSdrAudioSourceKeepDuringTx(profileId, keepDuringTx);
     }, Qt::QueuedConnection);
+}
+
+int MainWindow::kiwiSdrResumeHoldMsForProfile(
+    const KiwiSdrAntennaProfile& profile) const
+{
+    if (!profile.resumeAudioAfterTxDelay || profile.keepAudioDuringTx) {
+        return 0;
+    }
+
+    // Prefer the receive-sync measurement of the Kiwi's ingest lag —
+    // but only for the profile it was actually measured against, and
+    // only while it maintains the same lock the sync engine itself
+    // requires before acting on it. Everything else falls back to
+    // baseLatencyMs as an ingest-lag proxy — and when Receive Sync is
+    // off entirely, that value was never applied to anything, so it is
+    // a rough stand-in with no measured tie to this Kiwi's chain, kept
+    // sane by the clamp in kiwiSdrResumeHoldMs. The engine-side
+    // presentation holdback for this source delays playback beyond
+    // arrival, so it is added on top; kiwiSdrResumeHoldMs adds the
+    // guard for what none of these can see.
+    const ReceivePresentationSettings sync =
+        m_receivePresentationSync.settings();
+    const bool isSyncTarget =
+        profile.id == receiveSyncDelayKiwiProfileId();
+    bool estimateValid = false;
+    int estimateOffsetMs = 0;
+    if (isSyncTarget && sync.enabled
+        && sync.mode == ReceiveSyncMode::AutoAssist
+        && sync.autoEstimate.valid
+        && (sync.autoEstimate.held
+            || sync.autoEstimate.confidence >= sync.autoLockConfidence)) {
+        estimateValid = true;
+        estimateOffsetMs = sync.autoEstimate.offsetMs;
+    } else if (isSyncTarget && sync.enabled
+               && sync.mode == ReceiveSyncMode::Manual
+               && sync.manualOffsetMs > 0) {
+        estimateValid = true;
+        estimateOffsetMs = sync.manualOffsetMs;
+    }
+    const int appliedDelayMs = receivePresentationDelayMs(
+        ReceivePresentationSource::KiwiSdr,
+        ReceivePresentationSurface::Audio, profile.id);
+    return AetherSDR::kiwiSdrResumeHoldMs(
+        estimateValid, estimateOffsetMs, sync.baseLatencyMs, appliedDelayMs);
 }
 
 void MainWindow::refreshKiwiSdrVirtualAudioControls()
@@ -1649,6 +1708,36 @@ void MainWindow::refreshKiwiSdrVirtualAudioControls()
             updateKiwiSdrVirtualAudioControlsForSlice(slice,
                                                       /*includeEnable=*/false);
         }
+    }
+}
+
+void MainWindow::refreshKiwiSdrResumeHolds()
+{
+    if (!m_kiwiSdrManager || !m_audio) {
+        return;
+    }
+
+    // Key-down runs per interlock edge (per element under CW break-in), so
+    // push only the one field that actually goes stale between edges — the
+    // resume hold, whose sync estimate moves continuously. Gain/mute/pan
+    // follow slice signals and keep/hold policy follows profilesChanged.
+    const QVector<KiwiSdrAntennaProfile> profiles =
+        m_kiwiSdrManager->profiles();
+    for (const KiwiSdrAntennaProfile& profile : profiles) {
+        if (m_kiwiSdrManager->assignedSliceForProfile(profile.id) < 0) {
+            continue;
+        }
+        const int resumeHoldMs = kiwiSdrResumeHoldMsForProfile(profile);
+        QMetaObject::invokeMethod(m_audio,
+                                  [audio = m_audio, profileId = profile.id,
+                                   resumeHoldMs]() {
+            // Same resurrect guard as the settings refresh: a hold value is
+            // never worth re-creating a source the engine already freed.
+            if (!audio->hasKiwiSdrAudioSource(profileId)) {
+                return;
+            }
+            audio->setKiwiSdrAudioSourceResumeHold(profileId, resumeHoldMs);
+        }, Qt::QueuedConnection);
     }
 }
 
@@ -1836,6 +1925,12 @@ void MainWindow::syncKiwiSdrTransmitMute()
     }
 
     m_kiwiSdrAudioTransmitMuted = muted;
+    if (muted) {
+        // Key-down: re-push each source's resume hold so the deadline that
+        // arms at the coming unkey uses the freshest sync estimate.
+        // Queued ahead of the mute flag below, so ordering is guaranteed.
+        refreshKiwiSdrResumeHolds();
+    }
     QMetaObject::invokeMethod(m_audio, [audio = m_audio, muted]() {
         audio->setKiwiSdrAudioTransmitMuted(muted);
     }, Qt::QueuedConnection);

--- a/src/gui/MainWindow_KiwiSdr.cpp
+++ b/src/gui/MainWindow_KiwiSdr.cpp
@@ -1643,8 +1643,39 @@ void MainWindow::updateKiwiSdrVirtualAudioControlsForSlice(SliceModel* slice,
     }, Qt::QueuedConnection);
 }
 
+MainWindow::KiwiSdrResumeHoldContext
+MainWindow::kiwiSdrResumeHoldContext() const
+{
+    // Deliberately mirrors syncReceivePresentationDelaysToAudioEngine():
+    // whatever that pushed is what the mix is actually holding audio back
+    // by, and the resume hold has to add the same figure, not a differently
+    // derived one.
+    KiwiSdrResumeHoldContext context;
+    context.sync = m_receivePresentationSync.settings();
+    context.syncTargetProfileId = receiveSyncDelayKiwiProfileId();
+    context.delayKiwiProfileId =
+        context.sync.enabled
+            && context.sync.mode == ReceiveSyncMode::AutoAssist
+            ? context.syncTargetProfileId
+            : QString();
+    context.kiwiAudioDelayMs =
+        receivePresentationDelayMs(ReceivePresentationSource::KiwiSdr,
+                                   ReceivePresentationSurface::Audio);
+    return context;
+}
+
 int MainWindow::kiwiSdrResumeHoldMsForProfile(
     const KiwiSdrAntennaProfile& profile) const
+{
+    if (!profile.resumeAudioAfterTxDelay || profile.keepAudioDuringTx) {
+        return 0;
+    }
+    return kiwiSdrResumeHoldMsForProfile(profile, kiwiSdrResumeHoldContext());
+}
+
+int MainWindow::kiwiSdrResumeHoldMsForProfile(
+    const KiwiSdrAntennaProfile& profile,
+    const KiwiSdrResumeHoldContext& context) const
 {
     if (!profile.resumeAudioAfterTxDelay || profile.keepAudioDuringTx) {
         return 0;
@@ -1661,30 +1692,33 @@ int MainWindow::kiwiSdrResumeHoldMsForProfile(
     // presentation holdback for this source delays playback beyond
     // arrival, so it is added on top; kiwiSdrResumeHoldMs adds the
     // guard for what none of these can see.
-    const ReceivePresentationSettings sync =
-        m_receivePresentationSync.settings();
-    const bool isSyncTarget =
-        profile.id == receiveSyncDelayKiwiProfileId();
-    bool estimateValid = false;
-    int estimateOffsetMs = 0;
-    if (isSyncTarget && sync.enabled
-        && sync.mode == ReceiveSyncMode::AutoAssist
-        && sync.autoEstimate.valid
-        && (sync.autoEstimate.held
-            || sync.autoEstimate.confidence >= sync.autoLockConfidence)) {
-        estimateValid = true;
-        estimateOffsetMs = sync.autoEstimate.offsetMs;
-    } else if (isSyncTarget && sync.enabled
-               && sync.mode == ReceiveSyncMode::Manual
-               && sync.manualOffsetMs > 0) {
-        estimateValid = true;
-        estimateOffsetMs = sync.manualOffsetMs;
-    }
-    const int appliedDelayMs = receivePresentationDelayMs(
-        ReceivePresentationSource::KiwiSdr,
-        ReceivePresentationSurface::Audio, profile.id);
-    return AetherSDR::kiwiSdrResumeHoldMs(
-        estimateValid, estimateOffsetMs, sync.baseLatencyMs, appliedDelayMs);
+    const ReceivePresentationSettings& sync = context.sync;
+    AetherSDR::KiwiSdrResumeHoldSyncInputs inputs;
+    inputs.isSyncTarget = profile.id == context.syncTargetProfileId;
+    inputs.syncEnabled = sync.enabled;
+    inputs.autoAssist = sync.mode == ReceiveSyncMode::AutoAssist;
+    inputs.estimateValid = sync.autoEstimate.valid;
+    inputs.estimateHeld = sync.autoEstimate.held;
+    inputs.estimateConfidence = sync.autoEstimate.confidence;
+    inputs.autoLockConfidence = sync.autoLockConfidence;
+    inputs.estimateOffsetMs = sync.autoEstimate.offsetMs;
+    inputs.manualOffsetMs = sync.manualOffsetMs;
+    const AetherSDR::KiwiSdrResumeHoldIngestLag ingestLag =
+        AetherSDR::kiwiSdrResumeHoldIngestLag(inputs);
+
+    // The holdback this source is ACTUALLY playing behind arrival — derived
+    // exactly the way AudioEngine::setReceivePresentationDelays() derives it,
+    // because that is the number the mix obeys. Asking
+    // receivePresentationDelayMs() for this profile's own delay instead would
+    // report defaultKiwiDelayMs() for a profile that is not the AutoAssist
+    // delay target, while the engine hands that source 0 — and the hold would
+    // then run ~520 ms long, swallowing real post-TX audio rather than the
+    // operator's own tail.
+    const int appliedDelayMs =
+        AetherSDR::receivePresentationExternalKiwiDelayMs(
+            profile.id, context.delayKiwiProfileId, context.kiwiAudioDelayMs);
+    return AetherSDR::kiwiSdrResumeHoldMs(ingestLag.valid, ingestLag.offsetMs,
+                                          sync.baseLatencyMs, appliedDelayMs);
 }
 
 void MainWindow::refreshKiwiSdrVirtualAudioControls()
@@ -1721,13 +1755,17 @@ void MainWindow::refreshKiwiSdrResumeHolds()
     // push only the one field that actually goes stale between edges — the
     // resume hold, whose sync estimate moves continuously. Gain/mute/pan
     // follow slice signals and keep/hold policy follows profilesChanged.
+    // Resolve the sync target and the engine's Kiwi audio delay ONCE for the
+    // whole sweep; both walk the slice list and neither varies per profile.
     const QVector<KiwiSdrAntennaProfile> profiles =
         m_kiwiSdrManager->profiles();
+    const KiwiSdrResumeHoldContext context = kiwiSdrResumeHoldContext();
     for (const KiwiSdrAntennaProfile& profile : profiles) {
         if (m_kiwiSdrManager->assignedSliceForProfile(profile.id) < 0) {
             continue;
         }
-        const int resumeHoldMs = kiwiSdrResumeHoldMsForProfile(profile);
+        const int resumeHoldMs =
+            kiwiSdrResumeHoldMsForProfile(profile, context);
         QMetaObject::invokeMethod(m_audio,
                                   [audio = m_audio, profileId = profile.id,
                                    resumeHoldMs]() {

--- a/src/gui/RadioSetupDialog.cpp
+++ b/src/gui/RadioSetupDialog.cpp
@@ -4119,6 +4119,25 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 rowLayout->addWidget(keepTxAudioCheck, 5, 0, 1, 2,
                                      Qt::AlignLeft);
 
+                auto* resumeDelayCheck = new QCheckBox;
+                resumeDelayCheck->setText("Resume audio after TX delay");
+                resumeDelayCheck->setChecked(profile.resumeAudioAfterTxDelay);
+                resumeDelayCheck->setEnabled(!profile.keepAudioDuringTx);
+                resumeDelayCheck->setAccessibleName(
+                    "Resume KiwiSDR audio after transmit delay");
+                resumeDelayCheck->setToolTip(
+                    "After unkeying, wait out this receiver's stream delay "
+                    "before unmuting, so you rejoin on audio received after "
+                    "your transmission ended instead of hearing your own "
+                    "delayed TX tail.\nNo effect while \"Keep audio during "
+                    "TX\" is on.");
+                AetherSDR::ThemeManager::instance().applyStyleSheet(
+                    resumeDelayCheck,
+                    "QCheckBox { color: {{color.text.primary}}; font-size: 12px; spacing: 8px; }"
+                    + kCheckBoxIndicator);
+                rowLayout->addWidget(resumeDelayCheck, 6, 0, 1, 2,
+                                     Qt::AlignLeft);
+
                 const bool activeSession =
                     kiwiState == KiwiSdrClient::State::Connecting
                     || kiwiState == KiwiSdrClient::State::Waiting
@@ -4140,7 +4159,8 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 kiwiRowsLayout->addWidget(rowFrame);
 
                 auto updateProfile = [this, profile, nameEdit, endpointEdit,
-                                      autoCheck, keepTxAudioCheck] {
+                                      autoCheck, keepTxAudioCheck,
+                                      resumeDelayCheck] {
                     const QString name = nameEdit->text().trimmed();
                     const QString endpoint =
                         KiwiSdrClient::normalizeEndpoint(endpointEdit->text());
@@ -4163,6 +4183,8 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                     updated.endpoint = endpoint;
                     updated.autoConnect = autoCheck->isChecked();
                     updated.keepAudioDuringTx = keepTxAudioCheck->isChecked();
+                    updated.resumeAudioAfterTxDelay =
+                        resumeDelayCheck->isChecked();
                     m_kiwiSdrManager->updateProfile(updated);
                 };
                 connect(nameEdit, &QLineEdit::editingFinished,
@@ -4181,6 +4203,11 @@ QWidget* RadioSetupDialog::buildAntennaNamesTab()
                 connect(autoCheck, &QCheckBox::toggled,
                         this, [updateProfile](bool) { updateProfile(); });
                 connect(keepTxAudioCheck, &QCheckBox::toggled,
+                        this, [updateProfile, resumeDelayCheck](bool on) {
+                    resumeDelayCheck->setEnabled(!on);
+                    updateProfile();
+                });
+                connect(resumeDelayCheck, &QCheckBox::toggled,
                         this, [updateProfile](bool) { updateProfile(); });
                 connect(connectButton, &QPushButton::clicked,
                         this, [this, profile, activeSession] {

--- a/tests/kiwi_sdr_tx_mute_policy_test.cpp
+++ b/tests/kiwi_sdr_tx_mute_policy_test.cpp
@@ -1,4 +1,9 @@
 #include "core/KiwiSdrTxMutePolicy.h"
+// The resume hold has to add the presentation holdback the audio engine
+// really applies, which is routed here — so the two are pinned together.
+#include "core/ReceivePresentationSync.h"
+
+#include <QString>
 
 #include <iostream>
 
@@ -182,6 +187,133 @@ int main()
         ok &= expect(kiwiSdrResumeHoldMs(false, 0, 0, 0)
                          == kKiwiSdrResumeHoldMinMs,
                      "zero fallback clamps to minimum hold");
+    }
+
+    {
+        // Which ingest-lag figure the hold is entitled to use. This is the
+        // decision half of "Resume audio after TX delay" — a wrong answer
+        // here does not fail anything at runtime, it just silently mutes the
+        // operator for the wrong length of time, so every branch is pinned.
+        using AetherSDR::KiwiSdrResumeHoldSyncInputs;
+        using AetherSDR::kiwiSdrResumeHoldIngestLag;
+
+        // A locked AutoAssist estimate, measured against this very profile.
+        KiwiSdrResumeHoldSyncInputs locked;
+        locked.isSyncTarget = true;
+        locked.syncEnabled = true;
+        locked.autoAssist = true;
+        locked.estimateValid = true;
+        locked.estimateConfidence = 0.8f;
+        locked.autoLockConfidence = 0.35f;
+        locked.estimateOffsetMs = 900;
+
+        auto lag = kiwiSdrResumeHoldIngestLag(locked);
+        ok &= expect(lag.valid && lag.offsetMs == 900,
+                     "AutoAssist, confident estimate on the target: used");
+
+        // The sync engine acts on a HELD estimate even below the lock
+        // threshold; the hold must make the same call, or it would flip
+        // between measured and proxy on every over while sync itself holds.
+        auto held = locked;
+        held.estimateConfidence = 0.05f;
+        held.estimateHeld = true;
+        lag = kiwiSdrResumeHoldIngestLag(held);
+        ok &= expect(lag.valid && lag.offsetMs == 900,
+                     "AutoAssist, held estimate below threshold: still used");
+
+        auto lowConfidence = locked;
+        lowConfidence.estimateConfidence = 0.34f;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(lowConfidence).valid,
+                     "AutoAssist, unheld estimate under lock: falls back");
+
+        auto invalid = locked;
+        invalid.estimateValid = false;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(invalid).valid,
+                     "AutoAssist, invalid estimate: falls back");
+
+        // The measurement describes ONE profile's chain. A second Kiwi is a
+        // different network path entirely — this is the guard whose absence
+        // would hand every profile the target's ingest lag.
+        auto otherProfile = locked;
+        otherProfile.isSyncTarget = false;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(otherProfile).valid,
+                     "not the sync target: estimate does not apply");
+
+        auto syncOff = locked;
+        syncOff.syncEnabled = false;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(syncOff).valid,
+                     "receive sync disabled: estimate does not apply");
+
+        // Manual mode: the operator's own offset, but only when it says the
+        // Kiwi arrives LATE. Zero or negative describes the other direction
+        // and carries no ingest-lag information.
+        KiwiSdrResumeHoldSyncInputs manual;
+        manual.isSyncTarget = true;
+        manual.syncEnabled = true;
+        manual.autoAssist = false;
+        manual.manualOffsetMs = 1200;
+        lag = kiwiSdrResumeHoldIngestLag(manual);
+        ok &= expect(lag.valid && lag.offsetMs == 1200,
+                     "Manual, positive offset on the target: used");
+
+        auto manualZero = manual;
+        manualZero.manualOffsetMs = 0;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(manualZero).valid,
+                     "Manual, zero offset: falls back");
+
+        auto manualNegative = manual;
+        manualNegative.manualOffsetMs = -400;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(manualNegative).valid,
+                     "Manual, negative offset: falls back");
+
+        // Mode discipline: a stale AutoAssist estimate must not leak into
+        // Manual mode, and a manual offset must not leak into AutoAssist.
+        auto manualWithStaleEstimate = manual;
+        manualWithStaleEstimate.estimateValid = true;
+        manualWithStaleEstimate.estimateConfidence = 0.9f;
+        manualWithStaleEstimate.autoLockConfidence = 0.35f;
+        manualWithStaleEstimate.estimateOffsetMs = 900;
+        lag = kiwiSdrResumeHoldIngestLag(manualWithStaleEstimate);
+        ok &= expect(lag.valid && lag.offsetMs == 1200,
+                     "Manual mode ignores the AutoAssist estimate");
+
+        auto autoWithManualOffset = locked;
+        autoWithManualOffset.estimateValid = false;
+        autoWithManualOffset.manualOffsetMs = 1200;
+        ok &= expect(!kiwiSdrResumeHoldIngestLag(autoWithManualOffset).valid,
+                     "AutoAssist mode ignores the manual offset");
+    }
+
+    {
+        // The holdback fed to the hold must be the one the MIX applies —
+        // i.e. whatever AudioEngine::setReceivePresentationDelays() derives
+        // through receivePresentationExternalKiwiDelayMs() (that routing
+        // itself is pinned in receive_presentation_sync_test). Under
+        // AutoAssist a non-target source is played with NO holdback, so
+        // sourcing the figure anywhere else runs the hold long and swallows
+        // real post-TX audio instead of the operator's own tail.
+        using AetherSDR::kiwiSdrResumeHoldMs;
+        using AetherSDR::kKiwiSdrResumeHoldGuardMs;
+        using AetherSDR::receivePresentationExternalKiwiDelayMs;
+
+        const QString target = QStringLiteral("profile-A");
+        const QString other = QStringLiteral("profile-B");
+        constexpr int kEngineKiwiDelayMs = 900;
+        constexpr int kFallbackBaseMs = 360;
+
+        ok &= expect(kiwiSdrResumeHoldMs(
+                         false, 0, kFallbackBaseMs,
+                         receivePresentationExternalKiwiDelayMs(
+                             target, target, kEngineKiwiDelayMs))
+                         == kFallbackBaseMs + kEngineKiwiDelayMs
+                             + kKiwiSdrResumeHoldGuardMs,
+                     "sync target: hold covers the holdback it is played at");
+        ok &= expect(kiwiSdrResumeHoldMs(
+                         false, 0, kFallbackBaseMs,
+                         receivePresentationExternalKiwiDelayMs(
+                             other, target, kEngineKiwiDelayMs))
+                         == kFallbackBaseMs + kKiwiSdrResumeHoldGuardMs,
+                     "non-target: hold adds no phantom holdback");
     }
 
     if (!ok) {

--- a/tests/kiwi_sdr_tx_mute_policy_test.cpp
+++ b/tests/kiwi_sdr_tx_mute_policy_test.cpp
@@ -151,6 +151,39 @@ int main()
                      "new episode's own epoch expires normally");
     }
 
+    {
+        // Resume-hold computation ("Resume audio after TX delay").
+        using AetherSDR::kiwiSdrResumeHoldMs;
+        using AetherSDR::kKiwiSdrResumeHoldGuardMs;
+        using AetherSDR::kKiwiSdrResumeHoldMinMs;
+        using AetherSDR::kKiwiSdrResumeHoldMaxMs;
+
+        ok &= expect(kiwiSdrResumeHoldMs(true, 500, 520, 0)
+                         == 500 + kKiwiSdrResumeHoldGuardMs,
+                     "valid estimate: offset + guard");
+        ok &= expect(kiwiSdrResumeHoldMs(true, 500, 520, 520)
+                         == 500 + 520 + kKiwiSdrResumeHoldGuardMs,
+                     "applied presentation holdback adds to the hold");
+        ok &= expect(kiwiSdrResumeHoldMs(false, 0, 520, 520)
+                         == 520 + 520 + kKiwiSdrResumeHoldGuardMs,
+                     "no estimate: base latency proxy + holdback + guard");
+        ok &= expect(kiwiSdrResumeHoldMs(true, -300, 520, 0)
+                         == kKiwiSdrResumeHoldMinMs,
+                     "negative estimate clamps to minimum hold");
+        ok &= expect(kiwiSdrResumeHoldMs(true, -300, 520, -100)
+                         == kKiwiSdrResumeHoldMinMs,
+                     "negative holdback is ignored, clamps to minimum");
+        ok &= expect(kiwiSdrResumeHoldMs(true, 10000, 520, 0)
+                         == kKiwiSdrResumeHoldMaxMs,
+                     "huge estimate clamps to maximum hold");
+        ok &= expect(kiwiSdrResumeHoldMs(true, 3000, 520, 5000)
+                         == kKiwiSdrResumeHoldMaxMs,
+                     "estimate + holdback together clamp to maximum");
+        ok &= expect(kiwiSdrResumeHoldMs(false, 0, 0, 0)
+                         == kKiwiSdrResumeHoldMinMs,
+                     "zero fallback clamps to minimum hold");
+    }
+
     if (!ok) {
         std::cout << "kiwi_sdr_tx_mute_policy_test FAILED\n";
         return 1;


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #4380.** This PR is a single squashed commit that includes #4380's warm-TX-gate changes as its foundation, so the diff below shows both. Please review/merge #4380 first — merging this PR as-is would land both features at once. This PR's own delta beyond #4380 is ~220 lines across 9 files, authored pre-squash as quelleck/AetherSDR@b6d6f4a75f7d174079b2eaa09b0bd645a7ab9987 (feature) and quelleck/AetherSDR@db0bd9cf33920d9e1f0b666563954312e0377176 (correlator-feed fix) — those commits remain viewable for a delta-only review. Once #4380 lands I'll rebase and this diff collapses to just that delta.

## Motivation

#4380 makes unkey rejoin the warm Kiwi stream instantly — but at steady-state latency. On a KiwiSDR within range of your own signal, that means the first thing you hear after unkeying is your **own delayed TX tail**, for the length of the Kiwi chain latency (network + jitter buffer + any Receive Sync presentation delay — up to several seconds with a sync delay applied). Cross-band or diversity monitoring on a nearby Kiwi: after every over, you hear yourself finish the over again.

## What changed

New per-profile checkbox **"Resume audio after TX delay"** in Radio Setup (default off, disabled while "Keep audio during TX" is on — a source that stays audible through TX has nothing to resume). When enabled, the transmit gate stays closed past unkey for the receiver's measured stream delay, so the resume lands on audio the Kiwi received **after** the transmission ended. No trimming, no re-prime: the pipeline keeps draining (zeroed at the mix) through the hold, preserving #4380's warm-pipeline invariant.

- **Hold computation** (`kiwiSdrResumeHoldMs`, `src/core/KiwiSdrTxMutePolicy.h`): ingest lag + this source's engine presentation holdback + 250 ms guard, clamped 250–6000 ms. Ingest lag prefers the Receive Sync AutoAssist estimate — only when this profile is the sync target and the estimate maintains the same lock confidence the sync engine itself requires before acting — falling back to a positive manual sync offset, then to `baseLatencyMs` as a proxy. Recomputed at every key-down so the arm at the coming unkey uses a fresh estimate.
- **Engine** (`AudioEngine`): per-source `txResumeHoldMs` + `QDeadlineTimer` armed at the unmute edge; the mix gate opens on expiry through the existing 8 ms ramp. Re-keying during a hold re-closes and re-arms. Zeroing the hold disarms an in-flight deadline. Presentation telemetry (RX meter, scopes, EQ FFT tap) mirrors the full closed window, so meters stay quiet through the hold.
- **Receive Sync correlator integrity through the hold** (db0bd9cf): the correlator-feed suppression and Flex-side pause now derive from the gate's actual closed condition (TX mute *or* pending resume deadline) instead of the bare TX flag. Without this, ramp-zeroed Kiwi chunks during the hold would feed GCC-PHAT against a one-sided live Flex stream — degrading the very auto-assist estimate the hold is computed from. Verified against a truth table: plain-TX, idle, and mixed-source states are bit-identical to the previous predicate; only the hold window gains coverage.

## Constitution principle honored

Principle V — the new flag persists inside the profile's nested JSON object (same object as Auto-connect and "Keep audio during TX"); no new flat-key `AppSettings` calls.

## Testing

- Full suite green at head: **192/192**, including new unit tests for `kiwiSdrResumeHoldMs` (clamping, estimate-vs-fallback selection) in `kiwi_sdr_tx_mute_policy_test`.
- Correlator-suppression change verified against the pre-fix truth table (see db0bd9cf's message).
- Clean local build (macOS, Qt 6); commit GPG-signed; branch test-merges cleanly against current `main` (`git merge-tree` at d50377f6). The squash preserved the tested tree bit-for-bit (`git diff` between the pre-squash head and the squashed commit is empty).
- Not yet verified on-air against a live in-range KiwiSDR — but the full key → unkey → hold → resume sequence is now demonstrated end-to-end in-app on the automation bridge (next section).

### Proven on the automation bridge (no radio, no live KiwiSDR)

Rig: a mock flexd (TCP 4992 — V/H greeting, fabricated pan + slice, blanket `R<seq>|0|` replies) whose control channel emits radio-reported `S0|interlock state=TRANSMITTING/RECEIVE` status lines as sub-millisecond-timestamped edges, plus a mock KiwiSDR (HTTP `/status` + `SND`/`W/F` websockets streaming a 1 kHz tone as uncompressed 1034-byte SND frames at 12 kHz; the client classifies them `snd-observed-pcm16-meter` and reaches Connected). The profile is assigned to slice 0 via the bridge's `slice rxsource` verb, and audio is captured at two engine taps via `audioCapture`: the per-source **post-gate** mix contribution and the **final device mix**. Both gate edges land on one steady-clock capture timeline, and the TX pulse duration is measured by the mock itself, so the hold is `silence − pulse` with no cross-clock correlation.

Configuration under test: "Resume audio after TX delay" ON, receive sync seeded disabled → predicted hold = base `520` (the baseLatencyMs fallback) + engine presentation holdback `520` + guard `250` = **1290 ms** (clamped 250–6000; the same `kiwiSdrResumeHoldMs` value the unit test pins).

| Build / settings | TX pattern | Silent window | Post-unkey resume gap |
|---|---|---|---|
| **Fix, resume ON** | 3000.3 ms pulse | 4332.8 ms | **1332.5 ms** by audio edge; **≈1286 ms** by suppressed-chunk count (18 chunks × 71.4 ms, cadence calibrated in-run from the TX side: 3000.3 ms / 42 chunks) — consistent with the predicted 1290 within one ~71 ms chunk |
| **Fix, resume ON, re-key mid-hold** | 2000 + 700 gap + 1000 ms | 5122.4 ms **unbroken** | gate never reopened in the 700 ms gap; hold re-armed from the 2nd unkey |
| Fix, resume OFF | 3000.2 ms pulse | 3061.8 ms | ~62 ms (about one mixer chunk) |
| Fix, "Keep audio during TX" ON (+resume flag set) | 3000.2 ms pulse | **none** — audio continuous through TX | resume flag inert, as designed |
| **Pre-fix #4380 head (63b2fdfb), identical resume-ON settings** | 3000.2 ms pulse | 3072.0 ms | ~72 ms — the field is ignored; the hold is behavior this PR adds |

The correlator-feed suppression (the db0bd9cf half of the delta) is observable in the `get audio` counters, whose emit count ticks once per chunk actually fed to the receive-sync correlator: with the hold armed, the engine's `kiwiSdrTransmitMuted` clears at unkey yet `receivePresentationOutputSignalEmitCount` stays **frozen** and the suppressed counter keeps climbing for the duration of the hold — 42 chunks over the 3.0 s TX, 18 more through the hold — then the emit counter resumes. With resume OFF, and on the pre-fix build, the suppressed counter freezes at its unkey value and never advances (41 with resume OFF; 46 on the pre-fix build).

Caveats, honestly: edge timing is quantized by the ~230 ms audio-sink refill cadence (the mixer produces in bursts), so treat both estimators as ±one ~71 ms chunk. The rig drives the radio-reported interlock term of the mute predicate (VOX/CAT-style TX with an owned handle); the engine-side hold — arming, gate, suppression — is the same code path either way, but the client's own optimistic-unkey latch (which arms the hold at mox release, before the interlock falls) and the mask/watchdog interplay are not exercised here, so in a real client-keyed over the post-RF resume gap is the hold minus the interlock tail. The AutoAssist-estimate base is likewise not exercised (no synchronized Flex audio stream in the rig — what's measured is the `baseLatencyMs` fallback path). The correlator claim is counter-level: the feed is provably withheld through the hold, but no sync-estimate quality is measured, and the counters are engine-global — the clean per-chunk attribution relies on the rig's single producing source. 

Also validated live with 8400 and a Kiwi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
