### PR TITLE
fix(gui): confine the last-session DAX restore to the post-connect window (#4558)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3050,6 +3050,12 @@ target_include_directories(center_lock_rebind_tracker_test PRIVATE src)
 target_link_libraries(center_lock_rebind_tracker_test PRIVATE Qt6::Core)
 add_test(NAME center_lock_rebind_tracker_test COMMAND center_lock_rebind_tracker_test)
 
+# Last-session DAX restore window + quit-time key prune (#4558) — header-only.
+add_executable(dax_restore_policy_test tests/dax_restore_policy_test.cpp)
+target_include_directories(dax_restore_policy_test PRIVATE src)
+target_link_libraries(dax_restore_policy_test PRIVATE Qt6::Core)
+add_test(NAME dax_restore_policy_test COMMAND dax_restore_policy_test)
+
 # Active-slice policy during FLEX band-stack teardown/rebuild — header-only.
 add_executable(band_recall_slice_selection_policy_test
     tests/band_recall_slice_selection_policy_test.cpp

--- a/src/gui/DaxRestorePolicy.h
+++ b/src/gui/DaxRestorePolicy.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <QChar>
+#include <QString>
+#include <QStringList>
+
+// DaxRestorePolicy — when the last-session per-slice DAX restore (#1221) may
+// apply, and which persisted keys a quit may prune (#4558).
+//
+// Background (#4558): the restore reads `DaxChannel_Slice<letter>` keyed by
+// SLICE LIST POSITION (A = index 0, ...) because radio-assigned slice ids are
+// not stable across sessions. That is sound for the launch-time restore it was
+// designed for and unsound for anything later: a band-stack switch destroys and
+// recreates its slice, and the recreate re-enters the list at the TAIL, so with
+// another slice alive it resolves the OTHER position's key and re-assigns that
+// stale channel to itself 300 ms after the add — stealing the surviving slice's
+// live DAX channel, unannounced. Confining the restore to the initial
+// post-connect enumeration removes the mis-key's only opportunity.
+//
+// Pulled out of MainWindow as pure, header-only logic so both decisions can be
+// unit-tested without a radio, an event loop, or a settings store — mirroring
+// CenterLockRebindTracker / KiwiRebindTracker / SliceLinkPolicy, which cover
+// the same live-vs-prune reasoning in the same two handlers.
+
+namespace AetherSDR {
+
+class DaxRestorePolicy {
+public:
+    // ── The post-connect restore window ────────────────────────────────────
+    //
+    // Opens on connect and closes on the first LIVE slice removal or a settle
+    // timeout, whichever comes first. A mid-session recreate is ALWAYS preceded
+    // by a removal, so the window is shut before the recreated slice's add can
+    // consult it; the initial enumeration is adds-only, so it restores exactly
+    // as it always did.
+
+    // A connect completed. Reopens the window and starts a new generation.
+    //
+    // NOTE this fires on EVERY connect, not just the first of the session: an
+    // auto-reconnect re-enumerates and legitimately needs the restore (its
+    // slices were torn down). The corollary is that persisted values are
+    // last-QUIT values, so a reconnect can write them over assignments the
+    // operator changed live earlier in the session. That is pre-#4558 behavior,
+    // deliberately preserved here; narrowing it further is a separate question
+    // about whether #1221 should persist Flex-owned state client-side at all.
+    void onConnected()
+    {
+        m_windowOpen = true;
+        ++m_generation;
+    }
+
+    // The link dropped. The window cannot span a disconnect — the next connect
+    // reopens it with a fresh generation.
+    void onDisconnected() { m_windowOpen = false; }
+
+    // Generation to hand to the settle timer, so a previous connect's pending
+    // timeout cannot close the window this connect just opened.
+    int generation() const { return m_generation; }
+
+    // A sliceRemoved arrived. `liveRemoval` is the caller's live-vs-prune
+    // discriminator (`m_radioModel.slice(id) == nullptr` — live removals emit
+    // AFTER the slice leaves the model, so a non-null lookup means the id
+    // already names a NEW-session slice and this is the post-reconnect stale
+    // prune). Returns true when this call is what closed the window, so the
+    // caller can log the transition once.
+    //
+    // The discriminator is one-directional: non-null proves "prune", null does
+    // not prove "live". A stale prune of an id the new session never
+    // re-enumerated, the foreign-owner takeover path, and the family-switch
+    // drop all read as live. Every one of those fails toward closing the window
+    // EARLY, and an early close can only skip a restore (see restoreAllowed()'s
+    // sole consumer, whose false branch is log-and-skip) — never fire one.
+    bool onSliceRemoved(bool liveRemoval)
+    {
+        if (!m_windowOpen || !liveRemoval) {
+            return false;
+        }
+        m_windowOpen = false;
+        return true;
+    }
+
+    // The settle timer armed for `generation` fired. Belt-and-braces for the
+    // session that never removes a slice: without it, a slice the operator adds
+    // hours later would still inherit a last-session key.
+    void onSettleTimeout(int generation)
+    {
+        if (generation == m_generation) {
+            m_windowOpen = false;
+        }
+    }
+
+    // May a slice add apply its last-session DAX key?
+    bool restoreAllowed() const { return m_windowOpen; }
+
+    // ── The quit-time key space ────────────────────────────────────────────
+
+    // Highest index the letter key space ever used. Bounds the historical
+    // space, not any radio's slice count.
+    static constexpr int kMaxSliceIndex = 'Z' - 'A';
+
+    // The persisted key for a slice at list position `index`.
+    static QString keyForIndex(int index)
+    {
+        return QStringLiteral("DaxChannel_Slice%1").arg(QChar('A' + index));
+    }
+
+    // Keys a quit should REMOVE beyond the live slices it just wrote.
+    //
+    // #4558's precondition is a key written by an earlier multi-slice quit that
+    // no later quit could clean, because the writer's loop was bounded by the
+    // slices open at quit — so `DaxChannel_SliceB` from an old two-slice
+    // session survived every single-slice quit and stayed armed forever.
+    // Pruning the tail at quit makes an affected config self-heal.
+    //
+    // Both guards are load-bearing, and each was a data-loss bug in review:
+    //
+    //  - `connected`: a radio-less quit (never connected, failed connect, or
+    //    disconnected first) has an empty list that says nothing about the
+    //    operator's saved layout. Erasing there loses the restore data on every
+    //    radio-less launch. (#4572 review 1)
+    //  - `liveSliceCount > 0`: "connected" alone does NOT mean the list is an
+    //    authoritative enumeration. RadioModel::onConnected() clears m_slices
+    //    (stageSessionModelsForReconnect) BEFORE emitting
+    //    connectionStateChanged(true), so the list is empty for the whole
+    //    pre-enumeration window, and stays empty for a connected session that
+    //    owns no slices — GUI registration rejected (#4563), every slice owned
+    //    by another client, a stalled WAN/SmartLink status trickle. An empty
+    //    list in those states is absence of evidence, not an authoritative
+    //    zero. (#4572 review 2)
+    //
+    // Refusing to prune at zero costs nothing: a session that owns no slices
+    // cannot have written a stale key, and the next quit that does own slices
+    // prunes the tail anyway.
+    static QStringList staleKeysToPrune(bool connected, int liveSliceCount)
+    {
+        QStringList keys;
+        if (!connected || liveSliceCount <= 0) {
+            return keys;
+        }
+        for (int i = liveSliceCount; i <= kMaxSliceIndex; ++i) {
+            keys << keyForIndex(i);
+        }
+        return keys;
+    }
+
+private:
+    bool m_windowOpen{false};
+    int m_generation{0};
+};
+
+}  // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3477,8 +3477,15 @@ void MainWindow::closeEvent(QCloseEvent* event)
         // survivor (e.g. DaxChannel_SliceB from an old two-slice quit) is what
         // arms the restore mis-key — this makes an affected config self-heal.
         // 'Z' bounds the historical letter space, not any radio's slice count.
-        for (int i = slices.size(); i <= 'Z' - 'A'; ++i) {
-            s.remove(QString("DaxChannel_Slice%1").arg(QChar('A' + i)));
+        // Prune only while connected: only then is the slice list an
+        // authoritative enumeration. Quitting radio-less (never connected,
+        // failed connect, or disconnected first) must not erase the previous
+        // session's keys — that would lose the restore data on any
+        // radio-less launch (#4572 review).
+        if (m_radioModel.isConnected()) {
+            for (int i = slices.size(); i <= 'Z' - 'A'; ++i) {
+                s.remove(QString("DaxChannel_Slice%1").arg(QChar('A' + i)));
+            }
         }
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3472,6 +3472,14 @@ void MainWindow::closeEvent(QCloseEvent* event)
                 s.remove(key);
             }
         }
+        // #4558: also drop keys beyond the slice count at quit. They could
+        // only be written by a session that had more slices open, and a stale
+        // survivor (e.g. DaxChannel_SliceB from an old two-slice quit) is what
+        // arms the restore mis-key — this makes an affected config self-heal.
+        // 'Z' bounds the historical letter space, not any radio's slice count.
+        for (int i = slices.size(); i <= 'Z' - 'A'; ++i) {
+            s.remove(QString("DaxChannel_Slice%1").arg(QChar('A' + i)));
+        }
     }
 
     // DAX IQ channel is radio-authoritative — no client-side persistence needed.
@@ -5378,6 +5386,15 @@ void MainWindow::onConnectionStateChanged(bool connected)
     if (connected) {
         m_terminalConnectionError.clear();
         m_suppressStartupPanLayoutRearrange = false;
+        // #4558: open the last-session DAX restore window for the initial
+        // slice enumeration only (see MainWindow.h). 10 s covers a slow
+        // WAN/SmartLink status trickle with a wide margin.
+        m_daxRestoreWindowOpen = true;
+        const int gen = ++m_daxRestoreWindowGen;
+        QTimer::singleShot(10000, this, [this, gen]() {
+            if (m_daxRestoreWindowGen == gen)
+                m_daxRestoreWindowOpen = false;
+        });
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
         m_radioVersionLabel->setText(statusBarVersionText(

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3465,27 +3465,22 @@ void MainWindow::closeEvent(QCloseEvent* event)
     {
         const QList<SliceModel*> slices = m_radioModel.slices();
         for (int i = 0; i < slices.size(); ++i) {
-            const QString key = QString("DaxChannel_Slice%1").arg(QChar('A' + i));
+            const QString key = DaxRestorePolicy::keyForIndex(i);
             if (slices[i]->daxChannel() > 0) {
                 s.setValue(key, QString::number(slices[i]->daxChannel()));
             } else {
                 s.remove(key);
             }
         }
-        // #4558: also drop keys beyond the slice count at quit. They could
-        // only be written by a session that had more slices open, and a stale
-        // survivor (e.g. DaxChannel_SliceB from an old two-slice quit) is what
-        // arms the restore mis-key — this makes an affected config self-heal.
-        // 'Z' bounds the historical letter space, not any radio's slice count.
-        // Prune only while connected: only then is the slice list an
-        // authoritative enumeration. Quitting radio-less (never connected,
-        // failed connect, or disconnected first) must not erase the previous
-        // session's keys — that would lose the restore data on any
-        // radio-less launch (#4572 review).
-        if (m_radioModel.isConnected()) {
-            for (int i = slices.size(); i <= 'Z' - 'A'; ++i) {
-                s.remove(QString("DaxChannel_Slice%1").arg(QChar('A' + i)));
-            }
+        // #4558: also drop keys beyond the slice count at quit, so a config
+        // poisoned by an earlier multi-slice quit self-heals instead of staying
+        // armed forever. Both preconditions — connected AND holding a populated
+        // slice list — are load-bearing; DaxRestorePolicy::staleKeysToPrune()
+        // carries why, and the unit test pins both.
+        for (const QString& key :
+             DaxRestorePolicy::staleKeysToPrune(m_radioModel.isConnected(),
+                                                slices.size())) {
+            s.remove(key);
         }
     }
 
@@ -5393,14 +5388,16 @@ void MainWindow::onConnectionStateChanged(bool connected)
     if (connected) {
         m_terminalConnectionError.clear();
         m_suppressStartupPanLayoutRearrange = false;
-        // #4558: open the last-session DAX restore window for the initial
-        // slice enumeration only (see MainWindow.h). 10 s covers a slow
-        // WAN/SmartLink status trickle with a wide margin.
-        m_daxRestoreWindowOpen = true;
-        const int gen = ++m_daxRestoreWindowGen;
-        QTimer::singleShot(10000, this, [this, gen]() {
-            if (m_daxRestoreWindowGen == gen)
-                m_daxRestoreWindowOpen = false;
+        // #4558: open the last-session DAX restore window for this connect's
+        // slice enumeration only (see DaxRestorePolicy.h). The primary close is
+        // the first live slice removal; the settle timer is belt-and-braces for
+        // a session that never removes one, and 10 s clears a slow WAN/SmartLink
+        // status trickle with a wide margin. The generation it carries keeps a
+        // previous connect's pending timeout from closing this window.
+        m_daxRestore.onConnected();
+        const int daxGen = m_daxRestore.generation();
+        QTimer::singleShot(10000, this, [this, daxGen]() {
+            m_daxRestore.onSettleTimeout(daxGen);
         });
         m_layoutRestoreUntilMs = kPanLayoutRestoreWaitingForFirstPan;
         m_radioInfoLabel->setText(m_radioModel.model());
@@ -5656,6 +5653,12 @@ void MainWindow::onConnectionStateChanged(bool connected)
 #endif
     } else {
         stopDigitalVoiceService(false);
+
+        // #4558: the restore window cannot span a disconnect — the next connect
+        // reopens it for its own enumeration. Disconnect teardown does not emit
+        // sliceRemoved, so without this the window would stay armed until the
+        // settle timer happened to fire.
+        m_daxRestore.onDisconnected();
 
         // Radio disconnected: trim CAT ports back to 1 so apps on channel A
         // stay connected through brief reconnects, higher channels stop cleanly.

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -22,6 +22,7 @@
 #include "core/ReceivePresentationSync.h"
 #include "gui/BandRecallSelectionGuard.h"  // band-recall slice-selection window
 #include "gui/CenterLockRebindTracker.h"
+#include "gui/DaxRestorePolicy.h"       // #4558 last-session DAX restore window
 #include "gui/KiwiRebindTracker.h"      // #4158 band-recall Kiwi re-bind policy
 #include "core/CatPort.h"
 #ifdef HAVE_WEBSOCKETS
@@ -1425,15 +1426,12 @@ private:
     // the pending timer to restore saved floating pan windows.
     bool m_suppressStartupPanLayoutRearrange{false};
     // #4558: the last-session DAX restore (#1221) may only apply during the
-    // initial post-connect slice enumeration. The window opens on connect and
-    // closes on the first LIVE slice removal (a band-stack recreate is always
-    // preceded by one; the post-reconnect stale-slice prune is not live and
-    // must not close it) or after a settle timeout, whichever comes first —
-    // a slice recreated mid-session has current state that last-session keys
-    // must never override. The generation guard keeps a previous connect's
-    // pending timeout from closing the next connect's window.
-    bool m_daxRestoreWindowOpen{false};
-    int  m_daxRestoreWindowGen{0};
+    // slice enumeration that follows a connect — a slice recreated mid-session
+    // has current state that last-session keys must never override. The window
+    // and the quit-time key prune are pure logic in DaxRestorePolicy.h (which
+    // carries the full reasoning and is covered by dax_restore_policy_test);
+    // this member is just the live instance.
+    DaxRestorePolicy m_daxRestore;
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1424,6 +1424,16 @@ private:
     // User layout choices should suppress startup rearrange, but still allow
     // the pending timer to restore saved floating pan windows.
     bool m_suppressStartupPanLayoutRearrange{false};
+    // #4558: the last-session DAX restore (#1221) may only apply during the
+    // initial post-connect slice enumeration. The window opens on connect and
+    // closes on the first LIVE slice removal (a band-stack recreate is always
+    // preceded by one; the post-reconnect stale-slice prune is not live and
+    // must not close it) or after a settle timeout, whichever comes first —
+    // a slice recreated mid-session has current state that last-session keys
+    // must never override. The generation guard keeps a previous connect's
+    // pending timeout from closing the next connect's window.
+    bool m_daxRestoreWindowOpen{false};
+    int  m_daxRestoreWindowGen{0};
     QTimer* m_heartbeatMissTimer{nullptr}; // fires every 1.5s to detect missed discovery beats
     QTimer* m_bsExpiryTimer{nullptr};    // band-stack bookmark auto-expiry, started on connect only (#1471)
     QTimer* m_bsAutoSaveTimer{nullptr};  // band-stack dwell auto-save (single-shot per dwell window)

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1683,7 +1683,15 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // during profile recall: setDaxChannel() updates local slice state before
     // sending the radio command, and profile-created slices must keep the
     // radio/profile DAX assignment.
-    {
+    //
+    // #4558: only within the post-connect restore window. The keys are
+    // position-based (A = index 0, ...), so a mid-session destroy/recreate —
+    // which re-enters the list at the tail — resolves to the WRONG key when
+    // other slices are open: with B alive, a recreated A reads
+    // DaxChannel_SliceB and steals B's live channel 300 ms later. Mid-session
+    // adds have current radio/TCI state; last-session keys apply only to the
+    // initial enumeration.
+    if (m_daxRestoreWindowOpen) {
         const int sliceIdx = m_radioModel.slices().indexOf(s);
         if (sliceIdx >= 0) {
             const QString key = QString("DaxChannel_Slice%1").arg(QChar('A' + sliceIdx));
@@ -1695,13 +1703,23 @@ void MainWindow::onSliceAdded(SliceModel* s)
                 // Removing the slice within this 300 ms window (rapid
                 // add/remove) would otherwise dereference freed memory. (#3646)
                 QPointer<SliceModel> sp(s);
-                QTimer::singleShot(300, this, [this, sp, savedDax]() {
+                QTimer::singleShot(300, this, [this, sp, savedDax, key]() {
                     if (sp && !profileLoadRadioStateWritesHeld()) {
+                        // The send path below (SliceModel::commandReady) has no
+                        // logging of its own; without this line the restore is
+                        // invisible in any capture (#4558).
+                        qCDebug(lcDax) << "MainWindow: restoring last-session DAX"
+                                       << key << "=" << savedDax
+                                       << "to slice" << sp->sliceId();
                         sp->setDaxChannel(savedDax);
                     }
                 });
             }
         }
+    } else {
+        qCDebug(lcDax) << "MainWindow: skipping last-session DAX restore for"
+                          " mid-session slice add, id" << s->sliceId()
+                       << "(#4558)";
     }
 
     // Re-claim TX assignment after profile load or slice recreation (#145).
@@ -2189,6 +2207,17 @@ void MainWindow::onSliceRemoved(int id)
     if (m_applyingLayout) return;
 
     qDebug() << "MainWindow: slice removed" << id;
+
+    // #4558: any LIVE removal ends the last-session DAX restore window — from
+    // here on, slice adds are mid-session (band-stack recreates included) and
+    // must keep their live radio state. The post-reconnect stale-slice prune
+    // emits sliceRemoved too but is not live (slice(id) is non-null, same
+    // discriminator as the Center Lock guard below) and must not end it.
+    if (m_daxRestoreWindowOpen && !m_radioModel.slice(id)) {
+        m_daxRestoreWindowOpen = false;
+        qCDebug(lcDax) << "MainWindow: last-session DAX restore window closed"
+                          " (live slice removal, id" << id << ")";
+    }
 
     // Center Lock (#3854 review): a LIVE removal normally clears the persisted
     // letter intent too — Flex recycles letters lowest-free, so a dormant

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -1690,36 +1690,41 @@ void MainWindow::onSliceAdded(SliceModel* s)
     // other slices are open: with B alive, a recreated A reads
     // DaxChannel_SliceB and steals B's live channel 300 ms later. Mid-session
     // adds have current radio/TCI state; last-session keys apply only to the
-    // initial enumeration.
-    if (m_daxRestoreWindowOpen) {
+    // enumeration that follows a connect. See DaxRestorePolicy.h.
+    {
         const int sliceIdx = m_radioModel.slices().indexOf(s);
-        if (sliceIdx >= 0) {
-            const QString key = QString("DaxChannel_Slice%1").arg(QChar('A' + sliceIdx));
-            int savedDax = AppSettings::instance().value(key, "0").toInt();
-            if (savedDax > 0) {
-                // QPointer guards against a dangling slice: a raw SliceModel*
-                // stays non-null after the slice is destroyed, so the `s &&`
-                // check below is only meaningful if the capture auto-nulls.
-                // Removing the slice within this 300 ms window (rapid
-                // add/remove) would otherwise dereference freed memory. (#3646)
-                QPointer<SliceModel> sp(s);
-                QTimer::singleShot(300, this, [this, sp, savedDax, key]() {
-                    if (sp && !profileLoadRadioStateWritesHeld()) {
-                        // The send path below (SliceModel::commandReady) has no
-                        // logging of its own; without this line the restore is
-                        // invisible in any capture (#4558).
-                        qCDebug(lcDax) << "MainWindow: restoring last-session DAX"
-                                       << key << "=" << savedDax
-                                       << "to slice" << sp->sliceId();
-                        sp->setDaxChannel(savedDax);
-                    }
-                });
-            }
+        const QString key = sliceIdx >= 0
+            ? DaxRestorePolicy::keyForIndex(sliceIdx) : QString();
+        const int savedDax = key.isEmpty()
+            ? 0 : AppSettings::instance().value(key, "0").toInt();
+        // Resolve the key before branching so the skip path can say whether a
+        // restore was actually suppressed. Logging every mid-session add would
+        // report "skipping" for the overwhelmingly common case of no key at
+        // all, which is noise in exactly the captures this logging exists for.
+        if (savedDax > 0 && m_daxRestore.restoreAllowed()) {
+            // QPointer guards against a dangling slice: a raw SliceModel*
+            // stays non-null after the slice is destroyed, so the `s &&`
+            // check below is only meaningful if the capture auto-nulls.
+            // Removing the slice within this 300 ms window (rapid
+            // add/remove) would otherwise dereference freed memory. (#3646)
+            QPointer<SliceModel> sp(s);
+            QTimer::singleShot(300, this, [this, sp, savedDax, key]() {
+                if (sp && !profileLoadRadioStateWritesHeld()) {
+                    // The send path below (SliceModel::commandReady) has no
+                    // logging of its own; without this line the restore is
+                    // invisible in any capture (#4558).
+                    qCDebug(lcDax) << "MainWindow: restoring last-session DAX"
+                                   << key << "=" << savedDax
+                                   << "to slice" << sp->sliceId();
+                    sp->setDaxChannel(savedDax);
+                }
+            });
+        } else if (savedDax > 0) {
+            qCDebug(lcDax) << "MainWindow: skipping last-session DAX restore"
+                           << key << "=" << savedDax
+                           << "for mid-session slice add, id" << s->sliceId()
+                           << "(#4558)";
         }
-    } else {
-        qCDebug(lcDax) << "MainWindow: skipping last-session DAX restore for"
-                          " mid-session slice add, id" << s->sliceId()
-                       << "(#4558)";
     }
 
     // Re-claim TX assignment after profile load or slice recreation (#145).
@@ -2213,14 +2218,9 @@ void MainWindow::onSliceRemoved(int id)
     // must keep their live radio state. The post-reconnect stale-slice prune
     // emits sliceRemoved too but is not live (slice(id) is non-null, same
     // discriminator as the Center Lock guard below) and must not end it.
-    // Limit: the discriminator holds while the reconnected session
-    // re-enumerates the same slice ids; when it does not, the prune's ids
-    // read as live removals and the window closes early. That failure only
-    // skips restores: the flag's sole restore-side consumer is the apply-gate
-    // in onSliceAdded (false = log-and-skip branch), so an early close cannot
-    // cause a restore to fire.
-    if (m_daxRestoreWindowOpen && !m_radioModel.slice(id)) {
-        m_daxRestoreWindowOpen = false;
+    // The discriminator is one-directional and its failures are all safe —
+    // DaxRestorePolicy::onSliceRemoved() has the enumeration and the argument.
+    if (m_daxRestore.onSliceRemoved(/*liveRemoval=*/!m_radioModel.slice(id))) {
         qCDebug(lcDax) << "MainWindow: last-session DAX restore window closed"
                           " (live slice removal, id" << id << ")";
     }

--- a/src/gui/MainWindow_Wiring.cpp
+++ b/src/gui/MainWindow_Wiring.cpp
@@ -2213,6 +2213,12 @@ void MainWindow::onSliceRemoved(int id)
     // must keep their live radio state. The post-reconnect stale-slice prune
     // emits sliceRemoved too but is not live (slice(id) is non-null, same
     // discriminator as the Center Lock guard below) and must not end it.
+    // Limit: the discriminator holds while the reconnected session
+    // re-enumerates the same slice ids; when it does not, the prune's ids
+    // read as live removals and the window closes early. That failure only
+    // skips restores: the flag's sole restore-side consumer is the apply-gate
+    // in onSliceAdded (false = log-and-skip branch), so an early close cannot
+    // cause a restore to fire.
     if (m_daxRestoreWindowOpen && !m_radioModel.slice(id)) {
         m_daxRestoreWindowOpen = false;
         qCDebug(lcDax) << "MainWindow: last-session DAX restore window closed"

--- a/tests/dax_restore_policy_test.cpp
+++ b/tests/dax_restore_policy_test.cpp
@@ -1,0 +1,275 @@
+// Unit tests for DaxRestorePolicy — the window that confines the last-session
+// per-slice DAX restore (#1221) to the initial post-connect enumeration, and
+// the quit-time prune that lets a config poisoned by #4558 self-heal.
+//
+// The #4558 steal is reproduced here as a sequence test (connect → enumerate →
+// band-stack recreate) so the regression is pinned by the ordering that
+// actually failed on the rig, not just by the flag's truth table.
+
+#include "gui/DaxRestorePolicy.h"
+
+#include <QString>
+#include <QStringList>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+int g_total = 0;
+
+void report(const char* label, bool ok)
+{
+    ++g_total;
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", label);
+    if (!ok) {
+        ++g_failed;
+    }
+}
+
+// Live removals emit AFTER the slice leaves the model; the post-reconnect
+// stale prune emits an id that already names a live new-session slice.
+constexpr bool kLive = true;
+constexpr bool kPrune = false;
+
+// ── The restore window ─────────────────────────────────────────────────────
+
+void testClosedBeforeAnyConnect()
+{
+    DaxRestorePolicy p;
+    report("closed before any connect", !p.restoreAllowed());
+}
+
+void testOpensOnConnect()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    report("opens on connect", p.restoreAllowed());
+}
+
+void testInitialEnumerationIsAddsOnly()
+{
+    // The launch-time restore must be untouched: the initial enumeration adds
+    // slices and removes none, so the window stays open across all of them.
+    DaxRestorePolicy p;
+    p.onConnected();
+    const bool sliceA = p.restoreAllowed();
+    const bool sliceB = p.restoreAllowed();
+    report("initial enumeration restores every slice", sliceA && sliceB);
+}
+
+void testLiveRemovalClosesWindow()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    const bool closedHere = p.onSliceRemoved(kLive);
+    report("first live removal closes the window", closedHere && !p.restoreAllowed());
+}
+
+void testCloseIsReportedOnce()
+{
+    // The caller logs the transition, so a second live removal must not claim
+    // to have closed an already-closed window.
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onSliceRemoved(kLive);
+    report("close transition reported once", !p.onSliceRemoved(kLive));
+}
+
+void testPruneRemovalDoesNotCloseWindow()
+{
+    // A reconnect prunes the previous session's staged slices. Disarming on
+    // those would break the restore exactly when a reconnect needs it.
+    DaxRestorePolicy p;
+    p.onConnected();
+    const bool closedHere = p.onSliceRemoved(kPrune);
+    report("stale prune does not close the window",
+           !closedHere && p.restoreAllowed());
+}
+
+void testPruneThenLiveStillCloses()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onSliceRemoved(kPrune);
+    p.onSliceRemoved(kPrune);
+    report("live removal after prunes still closes",
+           p.onSliceRemoved(kLive) && !p.restoreAllowed());
+}
+
+void testSettleTimeoutClosesWindow()
+{
+    // The session that never removes a slice: without the timeout, a slice
+    // added hours later would still inherit a last-session key.
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onSettleTimeout(p.generation());
+    report("settle timeout closes the window", !p.restoreAllowed());
+}
+
+void testStaleTimeoutCannotCloseNextConnectsWindow()
+{
+    // The generation guard: connect, disconnect before the timer fires,
+    // reconnect — the first connect's pending timeout must be inert.
+    DaxRestorePolicy p;
+    p.onConnected();
+    const int firstGen = p.generation();
+    p.onDisconnected();
+    p.onConnected();
+    p.onSettleTimeout(firstGen);
+    report("previous connect's timeout cannot close this window",
+           p.restoreAllowed() && p.generation() != firstGen);
+}
+
+void testCurrentTimeoutStillClosesAfterReconnect()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onDisconnected();
+    p.onConnected();
+    p.onSettleTimeout(p.generation());
+    report("current generation's timeout still closes", !p.restoreAllowed());
+}
+
+void testDisconnectClosesWindow()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onDisconnected();
+    report("disconnect closes the window", !p.restoreAllowed());
+}
+
+void testReconnectReopensWindow()
+{
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onSliceRemoved(kLive);
+    p.onDisconnected();
+    p.onConnected();
+    report("reconnect reopens the window for its enumeration",
+           p.restoreAllowed());
+}
+
+// ── The #4558 regression, as the sequence that actually failed ─────────────
+
+void test4558BandRecallRecreateIsNotRestored()
+{
+    // Rig capture: connect, two slices enumerate (both restored), then one
+    // band button click destroys and recreates slice 0. The recreate re-enters
+    // the list at the tail and would resolve DaxChannel_SliceB — the steal.
+    DaxRestorePolicy p;
+    p.onConnected();
+
+    const bool enumeratedA = p.restoreAllowed();   // slice 0 added
+    const bool enumeratedB = p.restoreAllowed();   // slice 1 added
+
+    p.onSliceRemoved(kLive);                       // band switch destroys slice 0
+    const bool recreated = p.restoreAllowed();     // ...and recreates it
+
+    report("#4558: enumeration restores, band-recall recreate does not",
+           enumeratedA && enumeratedB && !recreated);
+}
+
+void test4558MidSessionSliceAddIsNotRestored()
+{
+    // Opening a second panadapter minutes in: the new slice keeps whatever live
+    // assignment it gets (TCI auto-assign, defaults) instead of inheriting a
+    // position key from the previous session.
+    DaxRestorePolicy p;
+    p.onConnected();
+    p.onSliceRemoved(kLive);
+    report("#4558: mid-session slice add is not restored", !p.restoreAllowed());
+}
+
+// ── The quit-time prune ────────────────────────────────────────────────────
+
+void testPruneRemovesTailBeyondLiveSlices()
+{
+    const QStringList keys = DaxRestorePolicy::staleKeysToPrune(true, 1);
+    const bool spansTail = keys.size() == DaxRestorePolicy::kMaxSliceIndex
+                        && keys.first() == QStringLiteral("DaxChannel_SliceB")
+                        && keys.last() == QStringLiteral("DaxChannel_SliceZ");
+    report("prune removes every key beyond the live slices",
+           spansTail && !keys.contains(QStringLiteral("DaxChannel_SliceA")));
+}
+
+void test4558StaleKeySelfHeals()
+{
+    // The steal's precondition: DaxChannel_SliceB=2 written by an old two-slice
+    // quit, which the old bounded writer could never clean. A single-slice quit
+    // must now remove it.
+    const QStringList keys = DaxRestorePolicy::staleKeysToPrune(true, 1);
+    report("#4558: stale SliceB is pruned by a single-slice quit",
+           keys.contains(QStringLiteral("DaxChannel_SliceB")));
+}
+
+void testPruneKeepsLiveKeysOnAFullHouse()
+{
+    const QStringList keys = DaxRestorePolicy::staleKeysToPrune(
+        true, DaxRestorePolicy::kMaxSliceIndex + 1);
+    report("prune removes nothing when every position is live", keys.isEmpty());
+}
+
+void testRadioLessQuitPrunesNothing()
+{
+    // #4572 review 1: never connected, failed connect, or disconnected first.
+    // Erasing here loses the restore data on every radio-less launch.
+    const bool emptyList = DaxRestorePolicy::staleKeysToPrune(false, 0).isEmpty();
+    const bool withSlices = DaxRestorePolicy::staleKeysToPrune(false, 2).isEmpty();
+    report("radio-less quit prunes nothing", emptyList && withSlices);
+}
+
+void testConnectedButUnenumeratedQuitPrunesNothing()
+{
+    // #4572 review 2: RadioModel::onConnected() clears m_slices BEFORE emitting
+    // connectionStateChanged(true), so "connected with an empty list" covers
+    // the whole pre-enumeration window — plus a rejected GUI registration
+    // (#4563) and an all-foreign slice list, which stay empty indefinitely.
+    // Erasing there wipes A..Z on a quit that proves nothing about the layout.
+    report("connected-but-unenumerated quit prunes nothing",
+           DaxRestorePolicy::staleKeysToPrune(true, 0).isEmpty());
+}
+
+void testKeyForIndexMatchesPersistedNames()
+{
+    // The reader in onSliceAdded and the writer in closeEvent must agree with
+    // the key names already on disk from every previous release.
+    report("key names match the persisted scheme",
+           DaxRestorePolicy::keyForIndex(0) == QStringLiteral("DaxChannel_SliceA")
+        && DaxRestorePolicy::keyForIndex(1) == QStringLiteral("DaxChannel_SliceB")
+        && DaxRestorePolicy::keyForIndex(DaxRestorePolicy::kMaxSliceIndex)
+               == QStringLiteral("DaxChannel_SliceZ"));
+}
+
+}  // namespace
+
+int main()
+{
+    testClosedBeforeAnyConnect();
+    testOpensOnConnect();
+    testInitialEnumerationIsAddsOnly();
+    testLiveRemovalClosesWindow();
+    testCloseIsReportedOnce();
+    testPruneRemovalDoesNotCloseWindow();
+    testPruneThenLiveStillCloses();
+    testSettleTimeoutClosesWindow();
+    testStaleTimeoutCannotCloseNextConnectsWindow();
+    testCurrentTimeoutStillClosesAfterReconnect();
+    testDisconnectClosesWindow();
+    testReconnectReopensWindow();
+
+    test4558BandRecallRecreateIsNotRestored();
+    test4558MidSessionSliceAddIsNotRestored();
+
+    testPruneRemovesTailBeyondLiveSlices();
+    test4558StaleKeySelfHeals();
+    testPruneKeepsLiveKeysOnAFullHouse();
+    testRadioLessQuitPrunesNothing();
+    testConnectedButUnenumeratedQuitPrunesNothing();
+    testKeyForIndexMatchesPersistedNames();
+
+    std::printf("\n%d/%d passed\n", g_total - g_failed, g_total);
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #4558.

## What

The #1221 per-slice DAX restore is keyed by **list position** but ran on **every slice
add**. A band-stack switch destroys and recreates its slice, and the recreate re-enters
the list at the tail — so with two slices open, the recreated slice resolved the *other*
position's persisted key and silently re-assigned that stale channel to itself 300 ms
later, stealing the surviving slice's DAX channel (full mechanism and rig captures in
#4558; confirmed by triage).

Three changes, matching the triage plan on #4558:

1. **Post-connect restore window** (`MainWindow.h`, `MainWindow.cpp`,
   `MainWindow_Wiring.cpp`): the restore now applies only inside a window that opens on
   connect and closes on the first **live** slice removal or a 10 s settle timeout,
   whichever comes first. A mid-session recreate is always preceded by a removal, so
   recreated slices keep their live radio/TCI state; the initial post-connect enumeration
   (adds-only) still restores exactly as before. A generation counter keeps a previous
   connect's pending timeout from closing the next connect's window.
2. **Observability** (`MainWindow_Wiring.cpp`): the restore single-shot now logs on
   `aether.dax` (key, value, target slice id) and the skip path logs mid-session
   suppressions. The sender was previously invisible in any capture —
   `SliceModel::setDaxChannel` emits through an unlogged relay — which is why #4558 took
   a log-ring hunt to attribute.
3. **Stale-key self-heal** (`MainWindow.cpp` closeEvent): the writer now also removes
   `DaxChannel_Slice*` keys beyond the current slice count. The steal's precondition is a
   key written by an earlier multi-slice quit that no later quit could clean (the loop
   was bounded by the slices open at quit) — affected configs now self-heal on the next
   quit instead of staying armed forever.

## Design notes

- **The prune discriminator** (an addition to the triage sketch): after a reconnect, the
  stale-slice prune also emits `sliceRemoved`, and disarming on it would break the
  restore exactly when a reconnect legitimately needs it. The window-close therefore
  ignores prune removals using the same `m_radioModel.slice(id)` non-null discriminator
  the Center Lock guard in the same handler already relies on (live removals emit after
  the slice leaves the model).
- **Behavior change, intended:** a slice the user adds minutes into a session no longer
  inherits a `DaxChannel_*` value from the previous session — it keeps whatever live
  assignment (TCI auto-assign, defaults) it gets. That is the scope #1221's restore was
  designed for ("from last session" = at session start); applying it mid-session is what
  made the steal possible.
- **Not touched:** #4567 (TCI receiver renumbering across the same recreate) is an
  independent defect in different files and is not addressed here; the two compound but
  land separately.

## Verification

- Clean build (RelWithDebInfo, Linux/Qt 6.8.3) on `8f9c7392`; ctest **190/192** — the two
  failures (`cross_needle_meter_test`, `s_meter_geometry_test`) are the known
  local-environment pair on this box: they failed identically on a pure-main control
  build on 2026-07-23 while upstream CI was green on those commits, and this diff
  touches no meter code.
- **Hardware regression (the reason this PR is draft):** #4558's repro is deterministic —
  3-for-3 steals on stock `6ac48f9b` with the exact rig/config preserved (stale
  `DaxChannel_SliceB=2` still armed). The same drill on this build — two panadapters,
  WSJT-X on TCI, band switch on the recreating slice — must show no steal, the new skip
  log line, an intact launch-time restore on relaunch, and stale-key cleanup at quit.
  Results (log + config before/after) will be posted here, and the PR flips ready only
  after that passes.
- No unit test added: the latch is three state toggles anchored on discriminators the
  same handlers already use, and the deterministic hardware repro is the meaningful
  regression. If reviewers prefer a policy-struct extraction (SliceLinkPolicy-style) to
  make it unit-testable, happy to restructure.

— authored by agent (Claude Code) on behalf of @skerker
