### PR TITLE
fix(theme): three silent round-trip losses in save / export / template resolve

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -43,6 +43,14 @@ ThemeGradient parseGradient(const QJsonObject& obj)
         const QJsonArray c = obj.value("center").toArray();
         if (c.size() >= 2) {
             g.center = QPointF(c.at(0).toDouble(0.5), c.at(1).toDouble(0.5));
+        } else if (obj.contains("centerX") || obj.contains("centerY")) {
+            // Recovery path for themes written before the writer was fixed: it
+            // emitted centerX/centerY as two scalars, which this parser never
+            // looked for, so those files load with a lost centre. Accept the
+            // old shape on read so an existing user theme keeps its gradient;
+            // the next save rewrites it as the "center" array.
+            g.center = QPointF(obj.value("centerX").toDouble(0.5),
+                               obj.value("centerY").toDouble(0.5));
         }
         g.radius = obj.value("radius").toDouble(0.5);
     }
@@ -1104,8 +1112,14 @@ QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
                                     : QStringLiteral("linear-gradient"));
                 gj.insert("angle", g.angle);
                 if (g.type == ThemeGradient::Radial) {
-                    gj.insert("centerX", g.center.x());
-                    gj.insert("centerY", g.center.y());
+                    // "center" as a [x, y] ARRAY — the shape the reader
+                    // parses and this file's own format comment documents.
+                    // This used to write centerX/centerY as two scalars, which
+                    // the reader never looks for, so a radial gradient came
+                    // back at the {0.5, 0.5} default. `radius` round-tripped
+                    // fine, which made the loss look like a half-working
+                    // feature rather than a format mismatch.
+                    gj.insert("center", QJsonArray{g.center.x(), g.center.y()});
                     gj.insert("radius",  g.radius);
                 }
                 QJsonArray stops;
@@ -1240,62 +1254,39 @@ bool ThemeManager::exportThemeToFile(const QString& themeName,
     if (themeName.isEmpty()) return fail(QStringLiteral("Empty theme name."));
     if (filePath.isEmpty())  return fail(QStringLiteral("Empty file path."));
 
-    // For the *active* theme, the live m_tokens already holds the operator's
-    // session edits — saveCurrentThemeAs uses that snapshot.  For any other
-    // theme, re-read its on-disk JSON so we don't accidentally export the
+    // For the *active* theme, the live scope tree already holds the operator's
+    // session edits — saveCurrentThemeAs serialises the same thing.  For any
+    // other theme, re-read its on-disk JSON so we don't accidentally export the
     // active theme's tokens under a different name.
     QJsonObject doc;
     if (themeName == m_activeTheme) {
-        QJsonObject tokensObj;
-        const int gradMetaId = qMetaTypeId<ThemeGradient>();
-        const int fontMetaId = qMetaTypeId<ThemeFont>();
-        for (auto it = m_tokens.constBegin(); it != m_tokens.constEnd(); ++it) {
-            const QVariant& v = it.value();
-            const int ut = v.userType();
-            QJsonValue leaf;
-            if (ut == QMetaType::QString)      leaf = v.toString();
-            else if (ut == QMetaType::Int)     leaf = v.toInt();
-            else if (ut == QMetaType::Double)  leaf = v.toDouble();
-            else if (ut == QMetaType::Bool)    leaf = v.toBool();
-            else if (ut == gradMetaId) {
-                const ThemeGradient g = v.value<ThemeGradient>();
-                QJsonObject gj;
-                gj.insert("type", g.type == ThemeGradient::Radial
-                                    ? QStringLiteral("radial-gradient")
-                                    : QStringLiteral("linear-gradient"));
-                gj.insert("angle", g.angle);
-                if (g.type == ThemeGradient::Radial) {
-                    gj.insert("centerX", g.center.x());
-                    gj.insert("centerY", g.center.y());
-                    gj.insert("radius",  g.radius);
-                }
-                QJsonArray stops;
-                for (const auto& s : g.stops) {
-                    QJsonObject sj;
-                    sj.insert("at",    s.at);
-                    sj.insert("color", colorToTokenString(s.color));
-                    stops.append(sj);
-                }
-                gj.insert("stops", stops);
-                leaf = gj;
-            }
-            else if (ut == fontMetaId) {
-                const ThemeFont f = v.value<ThemeFont>();
-                QJsonObject fj;
-                fj.insert("family", f.family);
-                if (f.size > 0)        fj.insert("size",  f.size);
-                if (f.color.isValid()) fj.insert("color", colorToTokenString(f.color));
-                leaf = fj;
-            }
-            else continue;
-            tokensObj.insert(it.key(), leaf);
-        }
-        doc.insert("schemaVersion", 1);
+        // Reuse the SAVE path's serialiser instead of hand-rolling a flat dump.
+        //
+        // The old code walked m_tokens and wrote a top-level "tokens" object.
+        // But m_tokens is a reference into the ROOT SCOPE only (see the header)
+        // — every child scope lives in m_rootScope/m_scopeByPath and was simply
+        // absent from the export. On the bundled dark theme that silently drops
+        // 9 of 12 scoped tokens: all the per-applet slider/knob/toggle
+        // overrides for applet/tx, applet/rx and applet/comp.
+        //
+        // The file still LOADED (the reader has a legacy flat-"tokens"
+        // fallback), which is what made this invisible: the operator got a
+        // theme file back that opened cleanly and had quietly lost its
+        // per-applet differentiation.
+        //
+        // scopeToJson() emits the schemaVersion-2 { "scopes": { "root": ... } }
+        // shape the loader prefers, recursing through the whole tree, and is
+        // already what saveCurrentThemeAs() uses — so export and save can no
+        // longer disagree about what a theme file contains.
+        QJsonObject scopes;
+        scopes.insert(QStringLiteral("root"), scopeToJson(m_rootScope.get()));
+
+        doc.insert("schemaVersion", 2);
         doc.insert("name",          themeName);
         doc.insert("author",        QStringLiteral("AetherSDR user"));
         doc.insert("version",       QStringLiteral("1.0"));
         doc.insert("description",   QStringLiteral("Exported via the Theme Editor."));
-        doc.insert("tokens",        tokensObj);
+        doc.insert("scopes",        scopes);
     } else {
         const auto pit = m_themePaths.constFind(themeName);
         if (pit == m_themePaths.constEnd())
@@ -1506,6 +1497,27 @@ QString ThemeManager::cssFragment(const QString& token) const
         if (compound.userType() == qMetaTypeId<ThemeFont>()) {
             const int sz = compound.value<ThemeFont>().size;
             if (sz > 0) return QString::number(sz);
+        }
+    }
+    // Unknown token. The empty string still goes back to resolveFor(), because
+    // substituting a placeholder would be worse — Qt would apply a wrong colour
+    // rather than none — but it must not vanish silently.
+    //
+    // What the caller sees without this: `{{color.acent}}` (typo) resolves to
+    // "", the template becomes `color: ;`, Qt discards the malformed
+    // declaration, and the widget keeps its previous appearance. No error, no
+    // log line, and the theme looks "nearly right" — which is far harder to
+    // diagnose than an obviously missing colour.
+    //
+    // Warned once per token: resolveFor() runs on every theme change and every
+    // tracked-stylesheet reapply, so an unguarded warning would flood the log.
+    {
+        QMutexLocker lock(&m_unknownTokenMutex);
+        if (!m_warnedUnknownTokens.contains(token)) {
+            m_warnedUnknownTokens.insert(token);
+            qCWarning(lcGui) << "ThemeManager: stylesheet references unknown token"
+                             << token << "— it resolves to an empty fragment, so the"
+                             << "declaration using it will be dropped by Qt";
         }
     }
     return QString();

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -106,6 +106,44 @@ QString colorHexToCssFragment(const QString& hex)
         .arg(c.alphaF(), 0, 'f', 3);
 }
 
+// The single writer for the gradient JSON shape, and the exact inverse of
+// parseGradient() above.  Both storage tiers route through here — semantic
+// tokens via scopeToJson(), the primitives palette via themeDocumentJson() —
+// because they used to hold one hand-rolled copy each and the copies drifted.
+// The palette's copy emitted type/angle/stops only, so a radial gradient
+// stored as a primitive lost its centre AND radius on every save: the same
+// defect as the scope-level one, a tier down, and one parseGradient()'s
+// centerX/centerY recovery cannot help with because there is no centerX in
+// the file to recover from either.  One writer means the next shape fix can
+// only ever need applying once.
+QJsonObject gradientToJson(const ThemeGradient& g)
+{
+    QJsonObject gj;
+    gj.insert("type", g.type == ThemeGradient::Radial
+                        ? QStringLiteral("radial-gradient")
+                        : QStringLiteral("linear-gradient"));
+    gj.insert("angle", g.angle);
+    if (g.type == ThemeGradient::Radial) {
+        // "center" as a [x, y] ARRAY — the shape the reader parses and this
+        // file's own format comment documents.  This used to write
+        // centerX/centerY as two scalars, which the reader never looks for,
+        // so a radial gradient came back at the {0.5, 0.5} default.
+        // `radius` round-tripped fine, which made the loss look like a
+        // half-working feature rather than a format mismatch.
+        gj.insert("center", QJsonArray{g.center.x(), g.center.y()});
+        gj.insert("radius", g.radius);
+    }
+    QJsonArray stops;
+    for (const auto& s : g.stops) {
+        QJsonObject sj;
+        sj.insert("at",    s.at);
+        sj.insert("color", colorToTokenString(s.color));
+        stops.append(sj);
+    }
+    gj.insert("stops", stops);
+    return gj;
+}
+
 // Recursively walk a JSON object, emitting `category.subkey...leaf = value`
 // pairs into `out`.  Schema lets users group tokens under "color", "font",
 // "sizing" without having to repeat the prefix at every leaf.
@@ -1112,32 +1150,7 @@ QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
             else if (ut == QMetaType::Double)  leaf = v.toDouble();
             else if (ut == QMetaType::Bool)    leaf = v.toBool();
             else if (ut == gradMetaId) {
-                const ThemeGradient g = v.value<ThemeGradient>();
-                QJsonObject gj;
-                gj.insert("type", g.type == ThemeGradient::Radial
-                                    ? QStringLiteral("radial-gradient")
-                                    : QStringLiteral("linear-gradient"));
-                gj.insert("angle", g.angle);
-                if (g.type == ThemeGradient::Radial) {
-                    // "center" as a [x, y] ARRAY — the shape the reader
-                    // parses and this file's own format comment documents.
-                    // This used to write centerX/centerY as two scalars, which
-                    // the reader never looks for, so a radial gradient came
-                    // back at the {0.5, 0.5} default. `radius` round-tripped
-                    // fine, which made the loss look like a half-working
-                    // feature rather than a format mismatch.
-                    gj.insert("center", QJsonArray{g.center.x(), g.center.y()});
-                    gj.insert("radius",  g.radius);
-                }
-                QJsonArray stops;
-                for (const auto& s : g.stops) {
-                    QJsonObject sj;
-                    sj.insert("at",    s.at);
-                    sj.insert("color", colorToTokenString(s.color));
-                    stops.append(sj);
-                }
-                gj.insert("stops", stops);
-                leaf = gj;
+                leaf = gradientToJson(v.value<ThemeGradient>());
             }
             else if (ut == fontMetaId) {
                 const ThemeFont f = v.value<ThemeFont>();
@@ -1189,23 +1202,10 @@ QJsonObject ThemeManager::themeDocumentJson(const QString& themeName,
         else if (ut == QMetaType::Double)  primitives.insert(it.key(), v.toDouble());
         else if (ut == QMetaType::Bool)    primitives.insert(it.key(), v.toBool());
         else if (ut == gradMetaId) {
-            // Same gradient JSON shape as scope-level tokens; the loader
-            // recognises both ambient locations.
-            const ThemeGradient g = v.value<ThemeGradient>();
-            QJsonObject gj;
-            gj.insert("type", g.type == ThemeGradient::Radial
-                                ? QStringLiteral("radial-gradient")
-                                : QStringLiteral("linear-gradient"));
-            gj.insert("angle", g.angle);
-            QJsonArray stops;
-            for (const auto& s : g.stops) {
-                QJsonObject sj;
-                sj.insert("at",    s.at);
-                sj.insert("color", colorToTokenString(s.color));
-                stops.append(sj);
-            }
-            gj.insert("stops", stops);
-            primitives.insert(it.key(), gj);
+            // Literally the same writer the scope tokens use — this used to
+            // be a separate copy that omitted `center` and `radius`, so a
+            // radial gradient in the palette round-tripped to the defaults.
+            primitives.insert(it.key(), gradientToJson(v.value<ThemeGradient>()));
         }
     }
 

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -661,6 +661,13 @@ bool ThemeManager::loadThemeFromPath(const QString& path)
     // are the floor, the JSON wins where defined.
     m_rootScope->children.clear();
     m_primitives.clear();
+    // Per-theme, not per-process: a token missing only in THIS theme should be
+    // reported again when the operator comes back to it, otherwise the one log
+    // line they need has scrolled away and never reappears.
+    {
+        QMutexLocker lock(&m_unknownTokenMutex);
+        m_warnedUnknownTokens.clear();
+    }
     rebuildScopePathIndex();
     seedBuiltinDefaults();  // resets m_tokens (= root scope tokens) + re-seeds applet/* scope tree
 
@@ -1159,10 +1166,19 @@ QJsonObject ThemeManager::scopeToJson(const ThemeScope* scope) const
     return result;
 }
 
-bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
+QJsonObject ThemeManager::themeDocumentJson(const QString& themeName,
+                                            const QString& description) const
 {
-    // v2 schema — primitives map + nested scope tree.  v1 themes loaded
-    // from disk auto-upgrade on first save through this writer.
+    // THE one place a theme document is assembled.  Save and export both come
+    // through here, so they cannot disagree about what a theme file contains —
+    // which they did: export hand-rolled its own document and left out
+    // `primitives`, and scope tokens store `{color.red.500}` aliases verbatim,
+    // so an exported theme carried aliases pointing into a palette that wasn't
+    // in the file.  On import resolveAlias() returned the literal and QColor
+    // got handed "{color.red.500}".
+    //
+    // v2 schema — primitives map + nested scope tree.  v1 themes loaded from
+    // disk auto-upgrade on first save through this writer.
     QJsonObject primitives;
     const int gradMetaId = qMetaTypeId<ThemeGradient>();
     for (auto it = m_primitives.constBegin(); it != m_primitives.constEnd(); ++it) {
@@ -1201,9 +1217,16 @@ bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
     doc.insert("name",          themeName);
     doc.insert("author",        QStringLiteral("AetherSDR user"));
     doc.insert("version",       QStringLiteral("1.0"));
-    doc.insert("description",   QStringLiteral("Edited via the Theme Editor."));
+    doc.insert("description",   description);
     if (!primitives.isEmpty()) doc.insert("primitives", primitives);
     doc.insert("scopes",        scopes);
+    return doc;
+}
+
+bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
+{
+    const QJsonObject doc = themeDocumentJson(
+        themeName, QStringLiteral("Edited via the Theme Editor."));
 
     QFile f(path);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
@@ -1260,7 +1283,8 @@ bool ThemeManager::exportThemeToFile(const QString& themeName,
     // active theme's tokens under a different name.
     QJsonObject doc;
     if (themeName == m_activeTheme) {
-        // Reuse the SAVE path's serialiser instead of hand-rolling a flat dump.
+        // Build the SAME document the save path writes, through the same
+        // function, instead of hand-rolling one here.
         //
         // The old code walked m_tokens and wrote a top-level "tokens" object.
         // But m_tokens is a reference into the ROOT SCOPE only (see the header)
@@ -1274,19 +1298,14 @@ bool ThemeManager::exportThemeToFile(const QString& themeName,
         // theme file back that opened cleanly and had quietly lost its
         // per-applet differentiation.
         //
-        // scopeToJson() emits the schemaVersion-2 { "scopes": { "root": ... } }
-        // shape the loader prefers, recursing through the whole tree, and is
-        // already what saveCurrentThemeAs() uses — so export and save can no
-        // longer disagree about what a theme file contains.
-        QJsonObject scopes;
-        scopes.insert(QStringLiteral("root"), scopeToJson(m_rootScope.get()));
-
-        doc.insert("schemaVersion", 2);
-        doc.insert("name",          themeName);
-        doc.insert("author",        QStringLiteral("AetherSDR user"));
-        doc.insert("version",       QStringLiteral("1.0"));
-        doc.insert("description",   QStringLiteral("Exported via the Theme Editor."));
-        doc.insert("scopes",        scopes);
+        // Sharing themeDocumentJson() rather than just scopeToJson() matters:
+        // scope tokens store `{color.red.500}` ALIASES verbatim, so a document
+        // carrying scopes without the `primitives` palette they point into is
+        // worse than one carrying neither — resolveAlias() hands the literal
+        // back and QColor("{color.red.500}") is invalid. Every one of the nine
+        // scoped tokens on the bundled dark theme is such an alias.
+        doc = themeDocumentJson(themeName,
+                                QStringLiteral("Exported via the Theme Editor."));
     } else {
         const auto pit = m_themePaths.constFind(themeName);
         if (pit == m_themePaths.constEnd())
@@ -1331,9 +1350,15 @@ QString ThemeManager::importThemeFromFile(const QString& filePath,
     const int schemaVersion = root.value(QStringLiteral("schemaVersion")).toInt(0);
     if (schemaVersion <= 0)
         return fail(QStringLiteral("Missing or invalid schemaVersion — file may not be a theme."));
-    if (schemaVersion > 1) {
+    if (schemaVersion > 2) {
         // Forward-compatible-ish: load anyway, but warn the operator.
         // Unknown tokens round-trip; missing tokens fall back to factory.
+        //
+        // The gate was `> 1`, which is stale: loadThemeFile() has read v2
+        // natively since the scope-tree work, and both the save and export
+        // paths now emit v2 — so every ordinary "export a theme, hand it to
+        // another operator, import it" round trip logged "newer than this
+        // build supports". v2 IS what this build writes.
         qCWarning(lcGui) << "ThemeManager::importThemeFromFile: schemaVersion"
                          << schemaVersion << "is newer than this build supports;"
                          << "loading anyway with unknown tokens preserved.";

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QStringList>
 #include <QHash>
+#include <QMutex>
 #include <QSet>
 #include <QColor>
 #include <QFont>
@@ -490,6 +491,13 @@ private:
     // every loadThemeFromPath().
     QSet<QString>                    m_declaredContainers;
     QString m_activeTheme;
+
+    // Tokens already warned about by cssFragment(), so a stylesheet typo is
+    // reported once rather than on every theme change and every tracked-
+    // stylesheet reapply.  Mutable + guarded because cssFragment() is const
+    // and resolveFor() may be reached from more than one thread.
+    mutable QSet<QString>            m_warnedUnknownTokens;
+    mutable QMutex                   m_unknownTokenMutex;
 
     // Factory-default snapshot, loaded once from `:/themes/default-dark.json`
     // at construction.  Drives the gradient editor's "Reset to default"

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -434,6 +434,16 @@ private:
     // are not committed (the previously-active theme stays loaded).
     bool loadThemeFromPath(const QString& path);
 
+    // Assemble the v2 theme document (schemaVersion + metadata + primitives
+    // palette + nested scope tree) for the live theme state.  THE single
+    // document builder: writeThemeFile() and exportThemeToFile() both go
+    // through it so the two can't emit structurally different files.  In
+    // particular `primitives` and `scopes` can only ever travel together —
+    // scope tokens hold `{primitive.key}` aliases verbatim, so scopes without
+    // the palette they point into load as invalid colours.
+    QJsonObject themeDocumentJson(const QString& themeName,
+                                  const QString& description) const;
+
     // Serialize the current scope tree into AetherSDR's v2 theme JSON
     // (primitives + nested scopes) and write it to `path`.  Shared by
     // saveCurrentThemeAs (new user copy) and saveActiveTheme (rewrite
@@ -494,8 +504,12 @@ private:
 
     // Tokens already warned about by cssFragment(), so a stylesheet typo is
     // reported once rather than on every theme change and every tracked-
-    // stylesheet reapply.  Mutable + guarded because cssFragment() is const
-    // and resolveFor() may be reached from more than one thread.
+    // stylesheet reapply.  Cleared on every theme load, so the warning tracks
+    // the theme it's about instead of latching for the process.  Mutable
+    // because cssFragment() is const; the mutex guards only this set, which is
+    // the whole of ThemeManager's locking — every other member is
+    // main-thread-only, as resolveFor()'s callers all terminate in
+    // QWidget::setStyleSheet.
     mutable QSet<QString>            m_warnedUnknownTokens;
     mutable QMutex                   m_unknownTokenMutex;
 

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -891,7 +891,11 @@ int main(int argc, char** argv)
         // absent. It wrote a flat top-level "tokens" object, which the reader's
         // legacy fallback still accepts, so the file loaded cleanly and had
         // quietly lost its per-applet overrides.
+        // Fork first: a built-in can't be re-imported by name (importThemeFromFile
+        // refuses to shadow one), and the re-import below is the assertion that
+        // actually matters.
         EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.saveCurrentThemeAs("Export Round Trip"));
         tm.setColor(QStringLiteral("applet/tx"),
                     QStringLiteral("color.slider.foreground"),
                     QColor("#123456"));
@@ -918,6 +922,35 @@ int main(int argc, char** argv)
                                      .value("tx").toObject();
         EXPECT_EQ(tx.value("tokens").toObject()
                     .value("color.slider.foreground").toString().toLower(),
+                  QString("#123456"));
+
+        // applet/rx was NOT overwritten above, so it still carries the bundled
+        // theme's ALIAS — the shape every scoped token actually ships in. An
+        // exported document that has scopes but no `primitives` is WORSE than
+        // one that has neither: the alias survives into the file, finds no
+        // palette on import, and resolveAlias() hands QColor the literal
+        // "{color.green.500}". Pin both halves.
+        const QJsonObject rx = applet.value("scopes").toObject()
+                                     .value("rx").toObject();
+        EXPECT_EQ(rx.value("tokens").toObject()
+                    .value("color.slider.foreground").toString(),
+                  QString("{color.green.500}"));
+        EXPECT_TRUE(doc.contains("primitives"));
+
+        // The assertion that inspecting JSON can't make: import the file back
+        // and read through the resolving API. Fails with an invalid QColor if
+        // `primitives` ever goes missing again, whatever the JSON looks like.
+        QString impErr;
+        const QString reimported = tm.importThemeFromFile(out, &impErr);
+        EXPECT_TRUE(!reimported.isEmpty());
+        EXPECT_TRUE(impErr.isEmpty());
+        const QColor rxSlider = tm.colorAt(QStringLiteral("applet/rx"),
+                                           QStringLiteral("color.slider.foreground"));
+        EXPECT_TRUE(rxSlider.isValid());
+        EXPECT_EQ(rxSlider.name().toLower(), QString("#4dd87a"));  // {color.green.500}
+        EXPECT_EQ(tm.colorAt(QStringLiteral("applet/tx"),
+                             QStringLiteral("color.slider.foreground"))
+                    .name().toLower(),
                   QString("#123456"));
     }
 

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -12,6 +12,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QStringList>
 #include <cstdio>
 
 using namespace AetherSDR;
@@ -952,6 +953,121 @@ int main(int argc, char** argv)
                              QStringLiteral("color.slider.foreground"))
                     .name().toLower(),
                   QString("#123456"));
+    }
+
+    {
+        // (4) A radial gradient stored as a PRIMITIVE keeps its centre and
+        // radius too.
+        //
+        // The primitives palette had its own hand-rolled gradient writer that
+        // emitted type/angle/stops only — no centre, no radius, for either
+        // gradient type. Same loss as the scope-level one a tier down, and one
+        // the reader cannot recover from: there is no centerX in the file to
+        // fall back to either. Both tiers now share gradientToJson().
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        QTemporaryDir pdir;
+        EXPECT_TRUE(pdir.isValid());
+        const QString ppath = pdir.filePath(QStringLiteral("prim-radial.json"));
+        QFile pf(ppath);
+        EXPECT_TRUE(pf.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        pf.write(R"({
+          "schemaVersion": 2, "name": "Primitive Radial",
+          "primitives": {
+            "gradient.spot": { "type": "radial-gradient", "angle": 0,
+              "center": [0.3, 0.7], "radius": 0.9,
+              "stops": [ {"at":0.0,"color":"#112233"}, {"at":1.0,"color":"#445566"} ] }
+          },
+          "scopes": { "root": { "tokens": {
+            "color.test.spot": "{gradient.spot}"
+          } } } })");
+        pf.close();
+
+        QString pErr;
+        EXPECT_EQ(tm.importThemeFromFile(ppath, &pErr), QString("Primitive Radial"));
+        EXPECT_TRUE(qFuzzyCompare(tm.gradient("color.test.spot").center.x(), 0.3));
+
+        // Re-save through the writer and reload: centre and radius must still
+        // be there. Before the shared writer both reverted to the {0.5, 0.5}
+        // / 0.5 defaults on exactly this hop.
+        EXPECT_TRUE(tm.saveCurrentThemeAs("Primitive Radial Saved"));
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.setActiveTheme("Primitive Radial Saved"));
+
+        const ThemeGradient rt = tm.gradient("color.test.spot");
+        EXPECT_EQ(rt.type, ThemeGradient::Radial);
+        EXPECT_TRUE(qFuzzyCompare(rt.center.x(), 0.3));   // was 0.5 before the fix
+        EXPECT_TRUE(qFuzzyCompare(rt.center.y(), 0.7));   // was 0.5 before the fix
+        EXPECT_TRUE(qFuzzyCompare(rt.radius,     0.9));   // was 0.5 before the fix
+    }
+
+    {
+        // (5) cssFragment() warns for an unknown token — once per theme.
+        //
+        // The warning IS the fix, so the warning is what has to be pinned.
+        // LogManager installs a message handler, so it never reaches stderr;
+        // capture it directly.
+        static QStringList s_captured;
+        static QtMessageHandler s_prev = nullptr;
+        s_captured.clear();
+        s_prev = qInstallMessageHandler(
+            [](QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
+                // Match the probe token itself, not merely "unknown token": a
+                // theme switch reapplies every tracked stylesheet, so a
+                // pre-existing template typo would otherwise inflate the count.
+                if (type == QtWarningMsg
+                    && msg.contains("color.definitely.not.a.token"))
+                    s_captured << msg;
+                if (s_prev) s_prev(type, ctx, msg);
+            });
+
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.cssFragment("color.definitely.not.a.token").isEmpty());
+        EXPECT_EQ(s_captured.size(), 1);
+
+        // Warned once — resolveFor() runs on every tracked-stylesheet reapply,
+        // so an unguarded warning would flood the log.
+        for (int i = 0; i < 5; ++i) tm.cssFragment("color.definitely.not.a.token");
+        EXPECT_EQ(s_captured.size(), 1);
+
+        // ...but once per THEME, not once per process: switching themes must
+        // re-arm it, or a token only the incoming theme is missing goes
+        // unreported because some earlier theme already burned the one warning.
+        EXPECT_TRUE(tm.setActiveTheme("Default Light"));
+        tm.cssFragment("color.definitely.not.a.token");
+        EXPECT_EQ(s_captured.size(), 2);
+
+        qInstallMessageHandler(s_prev);
+    }
+
+    {
+        // (6) Importing a file this build just wrote must not warn that the
+        // file comes from a newer build. The guard tested schemaVersion > 1
+        // while both write paths emit 2, so every ordinary save/export round
+        // trip tripped it — and a warning that fires on the common case
+        // trains operators to ignore the real one.
+        static QStringList s_verWarnings;
+        static QtMessageHandler s_verPrev = nullptr;
+        s_verWarnings.clear();
+        s_verPrev = qInstallMessageHandler(
+            [](QtMsgType type, const QMessageLogContext& ctx, const QString& msg) {
+                if (type == QtWarningMsg && msg.contains("newer than this build"))
+                    s_verWarnings << msg;
+                if (s_verPrev) s_verPrev(type, ctx, msg);
+            });
+
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.saveCurrentThemeAs("Version Guard Fork"));
+        QTemporaryDir vdir;
+        EXPECT_TRUE(vdir.isValid());
+        const QString vout = vdir.filePath(QStringLiteral("version-guard.json"));
+        QString vErr;
+        EXPECT_TRUE(tm.exportThemeToFile(tm.activeTheme(), vout, &vErr));
+
+        QString vImpErr;
+        EXPECT_TRUE(!tm.importThemeFromFile(vout, &vImpErr).isEmpty());
+        EXPECT_EQ(s_verWarnings.size(), 0);
+
+        qInstallMessageHandler(s_verPrev);
     }
 
     // Restore Default Dark for any future test additions below.

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -826,6 +826,101 @@ int main(int argc, char** argv)
         EXPECT_EQ(rt.color.name().toLower(), QString("#aabbcc"));
     }
 
+    // ---- round-trip correctness (#3184) ----
+    //
+    // Three independent losses, each silent: the file still loads, so nothing
+    // announces that something went missing.
+    {
+        // (1) A radial gradient must keep its CENTRE across save + reload.
+        //
+        // The writer emitted centerX/centerY as two scalars; the reader only
+        // looked for a "center" ARRAY, so the centre silently reverted to the
+        // {0.5, 0.5} default. `radius` used the same key on both sides and DID
+        // survive, which made the loss look like a half-working feature.
+        ThemeGradient g;
+        g.type   = ThemeGradient::Radial;
+        g.center = QPointF(0.2, 0.8);      // deliberately not the 0.5,0.5 default
+        g.radius = 0.7;
+        g.stops  = { {0.0, QColor("#000000")}, {1.0, QColor("#ffffff")} };
+        tm.setGradient("color.test.radial", g);
+
+        EXPECT_TRUE(tm.saveCurrentThemeAs("Radial Round Trip"));
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.setActiveTheme("Radial Round Trip"));
+
+        const ThemeGradient rt = tm.gradient("color.test.radial");
+        EXPECT_EQ(rt.type, ThemeGradient::Radial);
+        EXPECT_TRUE(qFuzzyCompare(rt.center.x(), 0.2));   // was 0.5 before the fix
+        EXPECT_TRUE(qFuzzyCompare(rt.center.y(), 0.8));   // was 0.5 before the fix
+        EXPECT_TRUE(qFuzzyCompare(rt.radius,     0.7));
+    }
+
+    {
+        // (2) The reader still accepts the OLD centerX/centerY shape, so a
+        // theme written by a pre-fix build keeps its gradient instead of being
+        // stranded at the default.
+        QTemporaryDir legacyDir;
+        EXPECT_TRUE(legacyDir.isValid());
+        const QString path = legacyDir.filePath(QStringLiteral("legacy.json"));
+        QFile f(path);
+        EXPECT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        f.write(R"({
+          "schemaVersion": 2, "name": "Legacy Centre",
+          "scopes": { "root": { "tokens": {
+            "color.test.legacy": { "type": "radial-gradient", "angle": 180,
+              "centerX": 0.25, "centerY": 0.75, "radius": 0.6,
+              "stops": [ {"at":0.0,"color":"#000000"}, {"at":1.0,"color":"#ffffff"} ] }
+          } } } })");
+        f.close();
+
+        QString impErr;
+        const QString name = tm.importThemeFromFile(path, &impErr);
+        EXPECT_EQ(name, QString("Legacy Centre"));
+        EXPECT_TRUE(impErr.isEmpty());
+
+        const ThemeGradient lg = tm.gradient("color.test.legacy");
+        EXPECT_TRUE(qFuzzyCompare(lg.center.x(), 0.25));
+        EXPECT_TRUE(qFuzzyCompare(lg.center.y(), 0.75));
+    }
+
+    {
+        // (3) Exporting the ACTIVE theme must not drop scoped tokens.
+        //
+        // The old export walked m_tokens, which is a reference into the ROOT
+        // SCOPE ONLY — every child scope lives in the scope tree and was simply
+        // absent. It wrote a flat top-level "tokens" object, which the reader's
+        // legacy fallback still accepts, so the file loaded cleanly and had
+        // quietly lost its per-applet overrides.
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        tm.setColor(QStringLiteral("applet/tx"),
+                    QStringLiteral("color.slider.foreground"),
+                    QColor("#123456"));
+
+        QTemporaryDir tmp;
+        EXPECT_TRUE(tmp.isValid());
+        const QString out = tmp.filePath(QStringLiteral("exported.json"));
+        QString err;
+        EXPECT_TRUE(tm.exportThemeToFile(tm.activeTheme(), out, &err));
+
+        QFile ef(out);
+        EXPECT_TRUE(ef.open(QIODevice::ReadOnly));
+        const QJsonObject doc = QJsonDocument::fromJson(ef.readAll()).object();
+        ef.close();
+
+        // Schema-2 shape, not the flat legacy dump.
+        EXPECT_TRUE(doc.contains("scopes"));
+        const QJsonObject root = doc.value("scopes").toObject()
+                                    .value("root").toObject();
+        // The scoped override survived the export.
+        const QJsonObject applet = root.value("scopes").toObject()
+                                       .value("applet").toObject();
+        const QJsonObject tx = applet.value("scopes").toObject()
+                                     .value("tx").toObject();
+        EXPECT_EQ(tx.value("tokens").toObject()
+                    .value("color.slider.foreground").toString().toLower(),
+                  QString("#123456"));
+    }
+
     // Restore Default Dark for any future test additions below.
     tm.setActiveTheme("Default Dark");
 


### PR DESCRIPTION
#3184 item 3 ("theme round-trip correctness — `cssFragment` empty-return, gradient `center`, export
scope-loss"). Grouped as one PR since they share a shape: **each loses data without reporting
anything.** The file still loads, the stylesheet still applies, so nothing announces the loss.

Independent of #4570 (theme-seed drift gate) — different files, no conflict.

## 1. Radial gradients lost their centre on every save

The writer emitted `centerX`/`centerY` as two scalars. The reader only ever looked for a `center`
**array** — which is also the shape this file's own format comment documents:

```
//   { "type": "radial-gradient", "center": [0.5, 0.5], "radius": 0.7, ...
```

So the centre silently reverted to the `{0.5, 0.5}` default. `radius` uses the same key on both
sides and **did** survive, which made this look like a half-working feature rather than a format
mismatch.

**Worse than the audit reported:** it's in `scopeToJson()`, so it hit the **normal save path**, not
just export.

Fixed both directions: the writer emits the documented array, and the reader still accepts the old
`centerX`/`centerY` shape so a theme written by a pre-fix build keeps its gradient instead of being
stranded. The next save rewrites it correctly.

## 2. Exporting the active theme dropped every scoped token

`exportThemeToFile()` walked `m_tokens` and wrote a flat top-level `tokens` object. But `m_tokens`
is a reference into the **root scope only** — the header says so:

> `m_tokens` is a reference into the root scope's token hash so every legacy `m_tokens.foo` call
> site (96 of them pre-refactor) compiles unchanged

Every child scope lives in the scope tree and was simply absent. On the bundled dark theme that is
**9 of 12 scoped tokens** — all the per-applet slider/knob/toggle overrides for `applet/tx`,
`applet/rx`, `applet/comp`.

The exported file still **loaded**, because the reader has a legacy flat-`tokens` fallback. That is
exactly what kept this invisible: the operator got a theme file back that opened cleanly and had
quietly lost its per-applet differentiation.

Export now calls `scopeToJson()` — the same serialiser `saveCurrentThemeAs()` uses — so the two
cannot disagree about what a theme file contains, and ~55 lines of duplicated token-walk go away.
That deduplication is also why fix (1) only needed applying once.

## 3. An unknown token in a QSS template failed silently

`cssFragment()` returned an empty string for an unresolvable token. In a template that yields
`color: ;` — Qt discards the malformed declaration and the widget keeps its previous appearance. No
error, no log line, and a theme that looks "nearly right", which is considerably harder to diagnose
than an obviously missing colour.

It **still returns empty** — substituting a placeholder would be worse, since Qt would then apply a
*wrong* colour rather than none — but now warns, **once per token**. Warning once matters:
`resolveFor()` runs on every theme change and every tracked-stylesheet reapply, so an unguarded
warning would flood the log.

## Verification

Three cases in `theme_manager_test`, each verified **red against the unfixed code** rather than just
green after:

| revert | failures |
|---|---|
| gradient fixes only | exactly the **4 centre** assertions — `radius` keeps passing, as it should |
| export fix only | exactly the **2 export** assertions (`scopes` key absent; scoped token missing) |
| nothing (fixes in place) | **0** |

`theme_manager_test` passes; `ctest -R "theme|s_meter|colour|color|style|applet"` is **5/5**. Full
tree builds on Windows/MSVC.

## Note

The `cssFragment` warning may surface pre-existing typos in current stylesheet templates the first
time someone runs this — that is the point, but it means the log could get noisier before it gets
quieter. If any turn up they are real bugs that were previously invisible; happy to fix them in a
follow-up rather than let them block this.

Refs #3184.
