### PR TITLE
fix(flexcontrol): recover from a lost serial port instead of dying until reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - The table is generated from `resources/themes/default-dark.json` by
   `tools/gen_theme_seed.py`, so the two can no longer disagree.
 
+### Fixed
+
+- **FlexControl now recovers on its own after losing its USB port.** The knob
+  driver had no error handling at all: if the serial port dropped — a USB
+  glitch, a driver reset, the host reclaiming the device — nothing noticed, and
+  the knob stayed dead for the rest of the session. It now detects the error,
+  releases the port, and re-detects the device every couple of seconds until it
+  comes back (re-detecting rather than reusing the old name, since a replug can
+  hand the device a different COM port). Disconnecting from AetherControl or
+  turning FlexControl off in Radio Setup still stops it for good. Enabling the
+  **Ext Devices** log category now also shows the serial error at the moment
+  the port drops, instead of silence. (#4574)
+
 ### Client settings store moved to SQLite (RFC #4603, phase 1)
 
 - **Settings now live in a SQLite database** (`AetherSDR.db` in the config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4881,6 +4881,24 @@ add_test(NAME connection_panel_size_test COMMAND connection_panel_size_test)
 set_tests_properties(connection_panel_size_test PROPERTIES
     ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 
+# FlexControl port-loss recovery (#4574). Guarded on SERIALPORT for the same
+# reason FlexControlManager itself is: the whole class is inside
+# #ifdef HAVE_SERIALPORT, so without Qt SerialPort there is nothing to test.
+if(TARGET Qt6::SerialPort)
+    add_executable(flex_control_recovery_test
+        tests/flex_control_recovery_test.cpp
+    )
+    target_include_directories(flex_control_recovery_test PRIVATE src)
+    # aethercore already carries FlexControlManager and the logging category it
+    # uses; compiling the .cpp standalone would drag in LogManager -> AppSettings
+    # -> AsyncLogWriter and need most of the core library linked by hand anyway.
+    target_link_libraries(flex_control_recovery_test PRIVATE
+        aethercore Qt6::Core Qt6::SerialPort Qt6::Test
+    )
+    set_target_properties(flex_control_recovery_test PROPERTIES AUTOMOC ON)
+    add_test(NAME flex_control_recovery_test COMMAND flex_control_recovery_test)
+endif()
+
 add_executable(pan_layout_dialog_size_test
     tests/pan_layout_dialog_size_test.cpp
     src/gui/PanLayoutDialog.cpp

--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -16,6 +16,35 @@ FlexControlManager::FlexControlManager(QObject* parent)
     // cross-thread QObject access that silently fails on macOS.
     m_port.setParent(this);
     connect(&m_port, &QSerialPort::readyRead, this, &FlexControlManager::onReadyRead);
+    // Without this the driver had NO error path at all: a port that dropped
+    // stayed "open" from Qt's point of view, readyRead simply never fired
+    // again, and nothing retried — the knob was dead until the process (or on
+    // Windows, the machine) restarted. Every other device driver in the tree
+    // handles this; see AcomConnection's serial branch and MidiControlManager's
+    // hotplug timer. (#4574)
+    connect(&m_port, &QSerialPort::errorOccurred,
+            this, &FlexControlManager::handlePortError);
+
+    m_reconnectTimer.setInterval(kReconnectIntervalMs);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, [this] {
+        if (m_wantedPort.isEmpty()) {          // nothing wanted — stop retrying
+            m_reconnectTimer.stop();
+            return;
+        }
+        if (m_port.isOpen()) {                 // recovered by another path
+            m_reconnectTimer.stop();
+            return;
+        }
+        // Re-detect rather than reusing the old name: a USB re-enumeration can
+        // hand the device a different COM port than it had before.
+        const QString port = detectPort();
+        if (port.isEmpty()) return;            // device still absent; keep trying
+        qCDebug(lcDevices) << "FlexControlManager: retrying" << port;
+        if (open(port)) {
+            m_reconnectTimer.stop();
+            qCInfo(lcDevices) << "FlexControlManager: reconnected on" << port;
+        }
+    });
 }
 
 FlexControlManager::~FlexControlManager()
@@ -37,6 +66,14 @@ bool FlexControlManager::open(const QString& portName)
 {
     if (m_port.isOpen()) close();
 
+    // Recorded BEFORE the open attempt: a connection is now wanted, so a
+    // failure here arms the retry rather than giving up. close() clears it.
+    m_wantedPort = portName;
+    m_deliberateDisconnect = false;
+    // A previous error can leave the port latched; clear it or Qt may refuse
+    // to reopen the same object.
+    m_port.clearError();
+
     m_port.setPortName(portName);
     m_port.setBaudRate(9600);
     m_port.setDataBits(QSerialPort::Data8);
@@ -47,9 +84,13 @@ bool FlexControlManager::open(const QString& portName)
     if (!m_port.open(QIODevice::ReadWrite)) {
         qCWarning(lcDevices) << "FlexControlManager: failed to open" << portName
                    << m_port.errorString();
+        // Keep trying: the device may be mid-enumeration, or another process
+        // may still be releasing it.
+        armReconnect();
         return false;
     }
 
+    m_reconnectTimer.stop();   // connected — stop retrying
     m_buffer.clear();
     qCDebug(lcDevices) << "FlexControlManager: opened" << portName;
     writeLedState();
@@ -57,17 +98,75 @@ bool FlexControlManager::open(const QString& portName)
     return true;
 }
 
+void FlexControlManager::handlePortError(QSerialPort::SerialPortError error)
+{
+    if (error == QSerialPort::NoError) return;
+    // ResourceError / DeviceNotFound are the USB-went-away cases; the rest
+    // (permission, framing, timeout) are treated the same way because the
+    // recovery is identical and re-detecting a healthy device is cheap.
+    qCWarning(lcDevices) << "FlexControlManager: serial error" << error
+                         << m_port.errorString() << "— releasing port and retrying";
+    releasePort();
+    armReconnect();
+}
+
+void FlexControlManager::releasePort()
+{
+    const bool wasOpen = m_port.isOpen();
+    // clearError() first: on an errored port Qt can refuse further operations
+    // until the error state is reset, which is exactly how the handle used to
+    // be leaked.
+    m_port.clearError();
+    if (wasOpen) m_port.close();
+    m_buffer.clear();
+    if (wasOpen) emit connectionChanged(false);
+}
+
+void FlexControlManager::armReconnect()
+{
+    if (m_wantedPort.isEmpty()) return;      // no connection wanted
+    if (m_deliberateDisconnect) return;      // operator asked for this
+    if (!m_reconnectTimer.isActive()) m_reconnectTimer.start();
+}
+
 void FlexControlManager::close()
 {
+    // Operator-initiated: stop wanting a connection, so the retry timer does
+    // not immediately undo this.
+    m_deliberateDisconnect = true;
+    m_wantedPort.clear();
+    m_reconnectTimer.stop();
+
+    // NOT an early return on !isOpen().
+    //
+    // The old code returned immediately when the port did not report itself
+    // open, which is the state an errored port can be left in — so m_port.close()
+    // never ran and the OS handle was never released. On Windows that meant a
+    // relaunched AetherSDR could not reopen a port the previous process still
+    // held, which is a plausible reason a reporter needs a full reboot rather
+    // than an app restart. (#4574)
     if (!m_port.isOpen()) {
+        // Still clear any latched error so a later open() on this object is not
+        // refused by Qt, and drop any partial frame.
+        m_port.clearError();
+        m_buffer.clear();
+        m_deliberateDisconnect = false;
         return;
     }
+    // If this write fails it calls releasePort(), which closes the port and
+    // emits connectionChanged(false) itself; the guard below then avoids a
+    // second, duplicate emission. armReconnect() is a no-op on this path
+    // because m_wantedPort is already cleared and m_deliberateDisconnect is set.
     writeLedCommand(0);
-    m_port.waitForBytesWritten(50);
-    m_port.close();
-    m_buffer.clear();
-    qCDebug(lcDevices) << "FlexControlManager: closed";
-    emit connectionChanged(false);
+    if (m_port.isOpen()) {
+        m_port.waitForBytesWritten(50);
+        m_port.close();
+        m_port.clearError();
+        m_buffer.clear();
+        qCDebug(lcDevices) << "FlexControlManager: closed";
+        emit connectionChanged(false);
+    }
+    m_deliberateDisconnect = false;
 }
 
 void FlexControlManager::setActiveLedButton(int button)
@@ -165,6 +264,14 @@ void FlexControlManager::writeLedCommand(int button)
     if (written != cmd.size()) {
         qCWarning(lcDevices) << "FlexControlManager: failed to write LED command"
                              << cmd << m_port.errorString();
+        // A short write means the port is already gone. This used to only warn,
+        // so a device that died during a write stayed dead. Route it into the
+        // same recovery as a read error. (#4574)
+        //
+        // Not called when close() is writing the LEDs off on its way out —
+        // m_deliberateDisconnect suppresses the retry in armReconnect().
+        releasePort();
+        armReconnect();
         return;
     }
     qCDebug(lcDevices) << "FlexControlManager: LED command" << cmd;

--- a/src/core/FlexControlManager.cpp
+++ b/src/core/FlexControlManager.cpp
@@ -25,26 +25,54 @@ FlexControlManager::FlexControlManager(QObject* parent)
     connect(&m_port, &QSerialPort::errorOccurred,
             this, &FlexControlManager::handlePortError);
 
-    m_reconnectTimer.setInterval(kReconnectIntervalMs);
-    connect(&m_reconnectTimer, &QTimer::timeout, this, [this] {
-        if (m_wantedPort.isEmpty()) {          // nothing wanted — stop retrying
-            m_reconnectTimer.stop();
-            return;
-        }
-        if (m_port.isOpen()) {                 // recovered by another path
-            m_reconnectTimer.stop();
-            return;
-        }
-        // Re-detect rather than reusing the old name: a USB re-enumeration can
-        // hand the device a different COM port than it had before.
-        const QString port = detectPort();
-        if (port.isEmpty()) return;            // device still absent; keep trying
-        qCDebug(lcDevices) << "FlexControlManager: retrying" << port;
-        if (open(port)) {
-            m_reconnectTimer.stop();
-            qCInfo(lcDevices) << "FlexControlManager: reconnected on" << port;
-        }
-    });
+    // Parent the timer for exactly the reason m_port is parented above, and it
+    // matters more here: MainWindow does
+    //     m_flexControl = new FlexControlManager;
+    //     m_flexControl->moveToThread(m_extCtrlThread);
+    // (MainWindow_Controllers.cpp). An unparented QTimer member is not a child,
+    // so moveToThread() leaves it on the GUI thread — and QTimer::start() from
+    // the worker thread is then silently refused, so the whole recovery below
+    // never runs. MidiControlManager avoids this by allocating its hotplug
+    // timer as `new QTimer(this)`. (#4574)
+    m_reconnectTimer.setParent(this);
+    m_reconnectTimer.setInterval(m_retryIntervalMs);
+    connect(&m_reconnectTimer, &QTimer::timeout, this, &FlexControlManager::retryOnce);
+}
+
+void FlexControlManager::retryOnce()
+{
+    if (m_wantedPort.isEmpty()) {          // nothing wanted — stop retrying
+        stopReconnect();
+        return;
+    }
+    if (m_port.isOpen()) {                 // recovered by another path
+        stopReconnect();
+        return;
+    }
+    // Re-detect rather than reusing the old name: a USB re-enumeration can
+    // hand the device a different COM port than it had before.
+    const QString port = detectPort();
+    if (port.isEmpty()) {                  // device still absent; keep trying
+        backOff();
+        return;
+    }
+    qCDebug(lcDevices) << "FlexControlManager: retrying" << port;
+    if (open(port))
+        qCInfo(lcDevices) << "FlexControlManager: reconnected on" << port;
+    else
+        backOff();
+}
+
+// Widen the retry interval towards kMaxReconnectIntervalMs. The first retries
+// stay at 2 s because that is the case worth being fast for (a replug); a
+// device that never opens settles into a 30 s poll instead of scanning and
+// warning every 2 s for the rest of the session.
+void FlexControlManager::backOff()
+{
+    if (m_retryIntervalMs >= kMaxReconnectIntervalMs)
+        return;
+    m_retryIntervalMs = qMin(m_retryIntervalMs * 2, kMaxReconnectIntervalMs);
+    m_reconnectTimer.setInterval(m_retryIntervalMs);
 }
 
 FlexControlManager::~FlexControlManager()
@@ -69,7 +97,6 @@ bool FlexControlManager::open(const QString& portName)
     // Recorded BEFORE the open attempt: a connection is now wanted, so a
     // failure here arms the retry rather than giving up. close() clears it.
     m_wantedPort = portName;
-    m_deliberateDisconnect = false;
     // A previous error can leave the port latched; clear it or Qt may refuse
     // to reopen the same object.
     m_port.clearError();
@@ -82,18 +109,33 @@ bool FlexControlManager::open(const QString& portName)
     m_port.setFlowControl(QSerialPort::NoFlowControl);
 
     if (!m_port.open(QIODevice::ReadWrite)) {
-        qCWarning(lcDevices) << "FlexControlManager: failed to open" << portName
-                   << m_port.errorString();
+        // Warn once per outage. handlePortError() has already logged the real
+        // errorString() (it runs re-entrantly from inside m_port.open()), and
+        // repeating it on every retry tick is what turns a missing `dialout`
+        // group into a log full of the same line.
+        if (!m_retryFailureLogged) {
+            qCWarning(lcDevices) << "FlexControlManager: failed to open" << portName
+                       << "— will keep retrying";
+            m_retryFailureLogged = true;
+        }
         // Keep trying: the device may be mid-enumeration, or another process
         // may still be releasing it.
         armReconnect();
         return false;
     }
 
-    m_reconnectTimer.stop();   // connected — stop retrying
     m_buffer.clear();
     qCDebug(lcDevices) << "FlexControlManager: opened" << portName;
     writeLedState();
+    // writeLedState() -> writeLedCommand() routes a short write into
+    // releasePort(), which closes the port and emits connectionChanged(false).
+    // Don't then announce a connection we no longer have: a device that is
+    // present but wedged would otherwise leave AetherControl showing
+    // "Connected" with no open port, and hand the caller a bogus true.
+    if (!m_port.isOpen())
+        return false;
+
+    stopReconnect();   // connected — stop retrying, reset the backoff
     emit connectionChanged(true);
     return true;
 }
@@ -104,59 +146,83 @@ void FlexControlManager::handlePortError(QSerialPort::SerialPortError error)
     // ResourceError / DeviceNotFound are the USB-went-away cases; the rest
     // (permission, framing, timeout) are treated the same way because the
     // recovery is identical and re-detecting a healthy device is cheap.
-    qCWarning(lcDevices) << "FlexControlManager: serial error" << error
-                         << m_port.errorString() << "— releasing port and retrying";
+    //
+    // Logged once per outage rather than once per retry: this also fires
+    // re-entrantly from inside m_port.open(), so an un-openable device would
+    // otherwise emit this line on every tick for the rest of the session.
+    if (!m_retryFailureLogged) {
+        qCWarning(lcDevices) << "FlexControlManager: serial error" << error
+                             << m_port.errorString() << "— releasing port and retrying";
+        m_retryFailureLogged = true;
+    }
     releasePort();
     armReconnect();
 }
 
 void FlexControlManager::releasePort()
 {
+    // Re-entrancy guard: m_port.close() can itself set an error, which lands
+    // back here through errorOccurred while we are still inside this function.
+    if (m_releasing) return;
+    m_releasing = true;
+
     const bool wasOpen = m_port.isOpen();
     // clearError() first: on an errored port Qt can refuse further operations
-    // until the error state is reset, which is exactly how the handle used to
-    // be leaked.
+    // until the error state is reset.
     m_port.clearError();
     if (wasOpen) m_port.close();
     m_buffer.clear();
+
+    m_releasing = false;
     if (wasOpen) emit connectionChanged(false);
 }
 
 void FlexControlManager::armReconnect()
 {
-    if (m_wantedPort.isEmpty()) return;      // no connection wanted
-    if (m_deliberateDisconnect) return;      // operator asked for this
+    // m_wantedPort is the single source of truth for "a connection is wanted".
+    // close() clears it, which is what makes a deliberate Disconnect stick.
+    if (m_wantedPort.isEmpty()) return;
     if (!m_reconnectTimer.isActive()) m_reconnectTimer.start();
+    // Mirror the timer's ACTUAL state, not the intent to start it. If start()
+    // is ever refused — a QTimer left on the wrong thread is exactly how — then
+    // isReconnecting() must report false rather than claim a recovery that is
+    // not running. Storing `true` here unconditionally would make the
+    // thread-affinity case below untestable. (#4574)
+    m_reconnecting.store(m_reconnectTimer.isActive(), std::memory_order_relaxed);
+}
+
+void FlexControlManager::stopReconnect()
+{
+    m_reconnectTimer.stop();
+    m_reconnecting.store(false, std::memory_order_relaxed);
+    m_retryIntervalMs = kReconnectIntervalMs;
+    m_reconnectTimer.setInterval(m_retryIntervalMs);
+    m_retryFailureLogged = false;
 }
 
 void FlexControlManager::close()
 {
     // Operator-initiated: stop wanting a connection, so the retry timer does
-    // not immediately undo this.
-    m_deliberateDisconnect = true;
+    // not immediately undo this. Callers must reach this unconditionally —
+    // gating on isOpen() would make Disconnect unreachable after a port drop
+    // and leave m_wantedPort set, so the driver would reclaim a device the
+    // operator had switched off. (#4574)
     m_wantedPort.clear();
-    m_reconnectTimer.stop();
+    stopReconnect();
 
-    // NOT an early return on !isOpen().
-    //
-    // The old code returned immediately when the port did not report itself
-    // open, which is the state an errored port can be left in — so m_port.close()
-    // never ran and the OS handle was never released. On Windows that meant a
-    // relaunched AetherSDR could not reopen a port the previous process still
-    // held, which is a plausible reason a reporter needs a full reboot rather
-    // than an app restart. (#4574)
     if (!m_port.isOpen()) {
+        // Nothing to release: QSerialPort has already given the OS handle back
+        // — isOpen() only goes false once QSerialPortPrivate::close() has run.
         // Still clear any latched error so a later open() on this object is not
         // refused by Qt, and drop any partial frame.
         m_port.clearError();
         m_buffer.clear();
-        m_deliberateDisconnect = false;
         return;
     }
     // If this write fails it calls releasePort(), which closes the port and
     // emits connectionChanged(false) itself; the guard below then avoids a
     // second, duplicate emission. armReconnect() is a no-op on this path
-    // because m_wantedPort is already cleared and m_deliberateDisconnect is set.
+    // because m_wantedPort has already been cleared.
     writeLedCommand(0);
     if (m_port.isOpen()) {
         m_port.waitForBytesWritten(50);
@@ -166,7 +232,6 @@ void FlexControlManager::close()
         qCDebug(lcDevices) << "FlexControlManager: closed";
         emit connectionChanged(false);
     }
-    m_deliberateDisconnect = false;
 }
 
 void FlexControlManager::setActiveLedButton(int button)
@@ -268,8 +333,8 @@ void FlexControlManager::writeLedCommand(int button)
         // so a device that died during a write stayed dead. Route it into the
         // same recovery as a read error. (#4574)
         //
-        // Not called when close() is writing the LEDs off on its way out —
-        // m_deliberateDisconnect suppresses the retry in armReconnect().
+        // Harmless when close() is writing the LEDs off on its way out:
+        // m_wantedPort is already cleared by then, so armReconnect() no-ops.
         releasePort();
         armReconnect();
         return;

--- a/src/core/FlexControlManager.h
+++ b/src/core/FlexControlManager.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QSerialPort>
 #include <QByteArray>
+#include <QTimer>
 
 namespace AetherSDR {
 
@@ -37,11 +38,23 @@ public:
     // Scan QSerialPortInfo for VID 0x2192, PID 0x0010
     static QString detectPort();
 
+    // True while the driver is retrying a connection it still wants. Exposed so
+    // the recovery behaviour is observable without a FlexControl attached —
+    // "is it still trying?" is otherwise indistinguishable from "it gave up",
+    // which is precisely the bug in #4574.
+    bool isReconnecting() const { return m_reconnectTimer.isActive(); }
+
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
     void setActiveLedButton(int button);
 
     static constexpr quint16 VendorId  = 0x2192;
     static constexpr quint16 ProductId = 0x0010;
+
+    // Retry cadence after the port drops. 2 s is between AcomConnection's
+    // reconnect and MidiControlManager's 5 s hotplug scan: the knob is a
+    // hands-on control, so a slow recovery is felt, and re-detection is just a
+    // QSerialPortInfo enumeration.
+    static constexpr int kReconnectIntervalMs = 2000;
 
 signals:
     // +N = tune up N steps, -N = tune down N steps
@@ -58,10 +71,27 @@ private:
     void writeLedState();
     void writeLedCommand(int button);
 
+    // A serial error means the port is gone (USB drop, driver reset, the host
+    // reclaiming the device). Tear the handle down and start retrying so the
+    // knob comes back by itself. (#4574)
+    void handlePortError(QSerialPort::SerialPortError error);
+    // Release the OS handle without the LED write / connectionChanged that
+    // close() performs — used when the port is already in an error state and
+    // writing to it would be pointless.
+    void releasePort();
+    void armReconnect();
+
     QSerialPort m_port;
     QByteArray  m_buffer;
     bool        m_invertDirection{false};
     int         m_activeLedButton{0};
+
+    // Reconnect state. Mirrors AcomConnection's serial recovery: a repeating
+    // timer re-detects the device while a connection is WANTED, and an
+    // operator-initiated close() suppresses it so Disconnect stays disconnected.
+    QTimer  m_reconnectTimer;
+    QString m_wantedPort;              // empty = no connection wanted
+    bool    m_deliberateDisconnect{false};
 };
 
 } // namespace AetherSDR

--- a/src/core/FlexControlManager.h
+++ b/src/core/FlexControlManager.h
@@ -7,6 +7,8 @@
 #include <QByteArray>
 #include <QTimer>
 
+#include <atomic>
+
 namespace AetherSDR {
 
 // FlexControl USB tuning knob driver.
@@ -42,7 +44,12 @@ public:
     // the recovery behaviour is observable without a FlexControl attached —
     // "is it still trying?" is otherwise indistinguishable from "it gave up",
     // which is precisely the bug in #4574.
-    bool isReconnecting() const { return m_reconnectTimer.isActive(); }
+    //
+    // Mirrored into an atomic rather than reading m_reconnectTimer.isActive():
+    // the manager lives on the ExtControllers worker thread, so a GUI-thread
+    // caller (a "Reconnecting…" indicator, say) would otherwise be racing
+    // QTimer's internals.
+    bool isReconnecting() const { return m_reconnecting.load(std::memory_order_relaxed); }
 
     void setInvertDirection(bool invert) { m_invertDirection = invert; }
     void setActiveLedButton(int button);
@@ -55,6 +62,12 @@ public:
     // hands-on control, so a slow recovery is felt, and re-detection is just a
     // QSerialPortInfo enumeration.
     static constexpr int kReconnectIntervalMs = 2000;
+    // ...but a device that is present and permanently un-openable (Linux user
+    // not in `dialout`, port held by another process) would otherwise re-scan
+    // and log forever at that rate. Back off towards a slow poll so the
+    // steady-state cost is bounded; the first few retries stay fast, which is
+    // the case that matters for a replug.
+    static constexpr int kMaxReconnectIntervalMs = 30000;
 
 signals:
     // +N = tune up N steps, -N = tune down N steps
@@ -80,6 +93,9 @@ private:
     // writing to it would be pointless.
     void releasePort();
     void armReconnect();
+    void stopReconnect();
+    void retryOnce();
+    void backOff();
 
     QSerialPort m_port;
     QByteArray  m_buffer;
@@ -89,9 +105,17 @@ private:
     // Reconnect state. Mirrors AcomConnection's serial recovery: a repeating
     // timer re-detects the device while a connection is WANTED, and an
     // operator-initiated close() suppresses it so Disconnect stays disconnected.
+    //
+    // m_reconnectTimer is parented to `this` in the constructor for the same
+    // reason m_port is: MainWindow moves this object to the ExtControllers
+    // thread, and an unparented QTimer member would stay behind on the GUI
+    // thread, where start() from the worker is silently refused. (#4574)
     QTimer  m_reconnectTimer;
     QString m_wantedPort;              // empty = no connection wanted
-    bool    m_deliberateDisconnect{false};
+    int     m_retryIntervalMs{kReconnectIntervalMs};
+    bool    m_retryFailureLogged{false};   // warn once per outage, not per tick
+    bool    m_releasing{false};            // releasePort() re-entrancy guard
+    std::atomic<bool> m_reconnecting{false};
 };
 
 } // namespace AetherSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2945,16 +2945,19 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
         const QString fcPort = fcs.value("FlexControlPort").toString();
         const bool fcInvert = fcs.value("FlexControlInvertDir", "False").toString() == "True";
         QMetaObject::invokeMethod(m_flexControl, [this, fcOpen, fcPort, fcInvert] {
+            // close() is called unconditionally, never gated on isOpen(): after
+            // a port drop the driver is closed but still *wants* the port and is
+            // retrying, and close() is the only thing that clears that. Gating
+            // on isOpen() would let the driver reclaim a device the operator
+            // had just switched off here. close() is idempotent. (#4574)
             if (fcOpen) {
                 if (fcPort.isEmpty()) {
-                    if (m_flexControl->isOpen())
-                        m_flexControl->close();
+                    m_flexControl->close();
                 } else if (!m_flexControl->isOpen() || m_flexControl->portName() != fcPort) {
-                    if (m_flexControl->isOpen())
-                        m_flexControl->close();
+                    m_flexControl->close();
                     m_flexControl->open(fcPort);
                 }
-            } else if (m_flexControl->isOpen()) {
+            } else {
                 m_flexControl->close();
             }
             m_flexControl->setInvertDirection(fcInvert);
@@ -3006,17 +3009,17 @@ void MainWindow::wireRadioSetupDialogSignals(RadioSetupDialog* dlg, const QStrin
         QString fcPort = fcs.value("FlexControlPort").toString();
         bool fcInvert = fcs.value("FlexControlInvertDir", "False").toString() == "True";
         QMetaObject::invokeMethod(m_flexControl, [this, fcOpen, fcPort, fcInvert] {
+            // Unconditional close() — see the matching comment on the
+            // serialSettingsChanged path above. (#4574)
             if (fcOpen) {
                 if (fcPort.isEmpty()) {
-                    if (m_flexControl->isOpen())
-                        m_flexControl->close();
+                    m_flexControl->close();
                 } else if (!m_flexControl->isOpen() || m_flexControl->portName() != fcPort) {
-                    if (m_flexControl->isOpen())
-                        m_flexControl->close();
+                    m_flexControl->close();
                     m_flexControl->open(fcPort);
                 }
             } else {
-                if (m_flexControl->isOpen()) m_flexControl->close();
+                m_flexControl->close();
             }
             m_flexControl->setInvertDirection(fcInvert);
         });

--- a/src/gui/MainWindow_Controllers.cpp
+++ b/src/gui/MainWindow_Controllers.cpp
@@ -292,8 +292,10 @@ void MainWindow::showFlexControlDialog()
             if (m_radioSetupDialog)
                 m_radioSetupDialog->setFlexControlConnectionStatus(false);
             QMetaObject::invokeMethod(m_flexControl, [this] {
-                if (m_flexControl->isOpen())
-                    m_flexControl->close();
+                // Unconditional: after a port drop the driver is closed but
+                // still retrying, and only close() stops it wanting the port
+                // back. close() is idempotent when already closed. (#4574)
+                m_flexControl->close();
             });
 #endif
         });

--- a/tests/flex_control_recovery_test.cpp
+++ b/tests/flex_control_recovery_test.cpp
@@ -1,0 +1,109 @@
+// FlexControlManager port-loss recovery (#4574).
+//
+// The knob had no error path at all: a dropped port stayed "open" as far as Qt
+// was concerned, readyRead never fired again, and nothing retried — so the
+// control was dead until the process (or, on Windows, the machine) restarted.
+//
+// These cases cover the parts that are testable without a FlexControl attached:
+// the recovery state machine and the close() handle-release. The USB drop
+// itself needs hardware; what is asserted here is that a connection the
+// operator WANTS keeps being retried, one they cancelled does not, and that
+// close() always releases the port rather than early-returning on an errored
+// one.
+
+#include "core/FlexControlManager.h"
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+static int g_failures = 0;
+
+static void check(bool ok, const char* what)
+{
+    if (!ok) {
+        std::fprintf(stderr, "FAIL: %s\n", what);
+        ++g_failures;
+    }
+}
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    // A port name no real device owns, so open() fails the same way on every
+    // platform and in CI, where no FlexControl exists.
+    const QString kAbsentPort = QStringLiteral("AETHER_TEST_NO_SUCH_PORT");
+
+    {
+        // A failed open ARMS the retry rather than giving up.
+        //
+        // This is THE discriminating assertion: before the fix open() returned
+        // false and nothing ever tried again, so isReconnecting() was
+        // permanently false and the operator had to reconnect by hand. isOpen()
+        // is false either way, which is why the retry state has to be
+        // observable for this test to mean anything.
+        FlexControlManager fc;
+        check(!fc.isReconnecting(), "not retrying before any open attempt");
+        check(!fc.open(kAbsentPort), "opening an absent port fails");
+        check(!fc.isOpen(), "an absent port is not reported open");
+        check(fc.isReconnecting(),
+              "a failed open ARMS the retry (was: gave up silently)");
+
+        // Still retrying after several intervals — it must not latch off.
+        QTest::qWait(FlexControlManager::kReconnectIntervalMs * 2 + 400);
+        check(fc.isReconnecting(), "still retrying while the device is absent");
+        check(!fc.isOpen(), "no device, so still not open — but not wedged");
+    }
+
+    {
+        // close() is the operator saying "stop". It must cancel the retry, or
+        // Disconnect would immediately undo itself.
+        FlexControlManager fc;
+        fc.open(kAbsentPort);
+        check(fc.isReconnecting(), "retry armed by the failed open");
+
+        fc.close();
+        check(!fc.isReconnecting(),
+              "a deliberate close() cancels the retry — Disconnect stays disconnected");
+
+        QSignalSpy spy(&fc, &FlexControlManager::connectionChanged);
+        QTest::qWait(FlexControlManager::kReconnectIntervalMs + 400);
+        check(!fc.isReconnecting(), "and stays cancelled across an interval");
+        check(spy.isEmpty(), "no reconnection happened behind the operator's back");
+    }
+
+    {
+        // close() on a never-opened port is safe, quiet, and idempotent.
+        FlexControlManager fc;
+        QSignalSpy spy(&fc, &FlexControlManager::connectionChanged);
+        fc.close();
+        fc.close();
+        check(spy.isEmpty(), "close() on a never-opened port emits nothing");
+        check(!fc.isOpen(), "still closed");
+        check(!fc.isReconnecting(), "and is not left retrying");
+    }
+
+    {
+        // A second open() after close() must re-arm: closing cleared the
+        // "connection wanted" state, so the retry has to come back with it.
+        FlexControlManager fc;
+        fc.open(kAbsentPort);
+        fc.close();
+        check(!fc.isReconnecting(), "cancelled");
+        fc.open(kAbsentPort);
+        check(fc.isReconnecting(), "a fresh open() re-arms the retry after a close()");
+        fc.close();
+    }
+
+    if (g_failures == 0) {
+        std::fprintf(stderr, "flex_control_recovery_test: all checks passed\n");
+        return 0;
+    }
+    std::fprintf(stderr, "flex_control_recovery_test: %d failure(s)\n", g_failures);
+    return 1;
+}

--- a/tests/flex_control_recovery_test.cpp
+++ b/tests/flex_control_recovery_test.cpp
@@ -16,6 +16,7 @@
 #include <QCoreApplication>
 #include <QSignalSpy>
 #include <QTest>
+#include <QThread>
 
 #include <cstdio>
 
@@ -55,9 +56,16 @@ int main(int argc, char** argv)
               "a failed open ARMS the retry (was: gave up silently)");
 
         // Still retrying after several intervals — it must not latch off.
-        QTest::qWait(FlexControlManager::kReconnectIntervalMs * 2 + 400);
-        check(fc.isReconnecting(), "still retrying while the device is absent");
-        check(!fc.isOpen(), "no device, so still not open — but not wedged");
+        //
+        // Guarded on the device being absent: with a real FlexControl attached
+        // the retry legitimately re-detects it, opens it and stops, which is
+        // success rather than failure. Without this guard the case fails on
+        // exactly the hardware we are asking someone to validate on.
+        if (FlexControlManager::detectPort().isEmpty()) {
+            QTest::qWait(FlexControlManager::kReconnectIntervalMs * 2 + 400);
+            check(fc.isReconnecting(), "still retrying while the device is absent");
+            check(!fc.isOpen(), "no device, so still not open — but not wedged");
+        }
     }
 
     {
@@ -98,6 +106,49 @@ int main(int argc, char** argv)
         fc.open(kAbsentPort);
         check(fc.isReconnecting(), "a fresh open() re-arms the retry after a close()");
         fc.close();
+    }
+
+    {
+        // THE case the first version of this test could not see.
+        //
+        // MainWindow constructs the manager on the GUI thread and immediately
+        // moves it to the ExtControllers worker thread:
+        //     m_flexControl = new FlexControlManager;
+        //     m_flexControl->moveToThread(m_extCtrlThread);
+        // Everything after that arrives via QMetaObject::invokeMethod on the
+        // worker. A QTimer member that is not parented to `this` does not move
+        // with the object, and QTimer::start() from the wrong thread is
+        // silently refused — so the retry armed fine in every single-threaded
+        // case above while never running once in the shipping app.
+        //
+        // Assert the recovery through the path the app actually uses. (#4574)
+        QThread worker;
+        worker.setObjectName("ExtControllers");
+        worker.start();
+
+        auto* fc = new FlexControlManager;      // unparented, as in MainWindow
+        fc->moveToThread(&worker);
+
+        bool armed = false;
+        QMetaObject::invokeMethod(fc, [&] {
+            fc->open(kAbsentPort);
+            armed = fc->isReconnecting();
+        }, Qt::BlockingQueuedConnection);
+        check(armed, "retry arms when driven from the worker thread "
+                     "(m_reconnectTimer must be parented to move with us)");
+
+        // ...and a deliberate close() still cancels it from over there.
+        bool cancelled = false;
+        QMetaObject::invokeMethod(fc, [&] {
+            fc->close();
+            cancelled = !fc->isReconnecting();
+        }, Qt::BlockingQueuedConnection);
+        check(cancelled, "close() cancels the retry on the worker thread too");
+
+        QMetaObject::invokeMethod(fc, [fc] { delete fc; },
+                                  Qt::BlockingQueuedConnection);
+        worker.quit();
+        worker.wait();
     }
 
     if (g_failures == 0) {


### PR DESCRIPTION
Addresses the **"and never comes back"** half of #4574 (FlexControl knob stops after split+TX, needs
a PC restart).

> ⚠ **This does not explain the split+TX trigger** and does not try to — that still needs
> @ik2yft's answers. What it fixes is why a transient port loss becomes a dead control for the rest
> of the session, which is a defect on its own merits.

## The gap

`FlexControlManager` was **the only device driver in the tree with no error path**. It connected
exactly one signal — `QSerialPort::readyRead`. No `errorOccurred` handler, no retry, no hotplug
scan. When the port dropped, Qt simply stopped delivering reads and nothing noticed.

For contrast, both in-tree neighbours already do this:

| driver | recovery |
|---|---|
| `AcomConnection` | `errorOccurred` handler → `onTransportDown()` → `armReconnect()` |
| `MidiControlManager` | 5 s `m_hotplugTimer` re-scan |
| `FlexControlManager` | *(none)* |

## Changes

1. **`errorOccurred` is handled** — releases the handle and starts retrying.
2. **A 2 s retry timer** re-runs `detectPort()` while a connection is still *wanted*. It
   **re-detects** rather than reusing the old port name, since a USB re-enumeration can hand the
   device a different COM port. A deliberate `close()` clears the wanted state, so Disconnect stays
   disconnected.
3. **`writeLedCommand()`** routes a short write into the same recovery instead of only warning.

## 4. The handle leak — possibly why it needs a *reboot*

`close()` used to begin:

```cpp
if (!m_port.isOpen()) { return; }
```

An errored port can sit in exactly that state, so `close()` did nothing, `m_port.close()` never
ran, and the OS handle was never released. On Windows a relaunched AetherSDR then cannot reopen a
port the previous process still holds — which would explain needing a full reboot rather than an
app restart.

`close()` now always releases the handle and clears any latched error.

**That is a hypothesis about #4574's symptom, not a confirmed diagnosis** — but the leak is real
regardless of what causes the drop. It also makes the retry timer necessary *but not sufficient*: a
retry loop that never released the stale handle would just spin.

## Verification

`tests/flex_control_recovery_test.cpp` covers the recovery state machine. Verified **red against
the pre-fix driver** (error handler removed): **4 failures**, exactly the retry-arming assertions.

Worth flagging how that test was reached, because the first attempt was worthless: it asserted only
on `isOpen()` and signals, which are **identical with and without the fix** when no device is
present — so it passed against unfixed code and proved nothing. The retry state had to become
observable (`isReconnecting()`) before the test meant anything. I'd rather say that than present a
green test as evidence it isn't.

`ctest -R "flex|midi|device"` **7/7**; full tree builds on Windows/MSVC.

## ⚠ Not tested on FlexControl hardware

I don't have one — I have a Flex 6700/6300 and a Hermes-Lite 2. **The USB-drop path itself is
unexercised.** What's verified is the state machine around it.

Someone with the device should confirm the knob actually returns after a replug before this is
trusted as a remedy for #4574. It should also be a strictly better starting point for diagnosing the
split+TX trigger, since the Ext Devices log will now show the serial error at the moment it drops
instead of silence.



---

## Review pass (2026-07-31)

Rebased onto current `main` and pushed fixes for the blockers found in review.
Nigel's commit is preserved with his authorship; the follow-up commit carries
the fixes. Full detail in the review thread — summary:

- **The retry never actually ran in the app.** `m_reconnectTimer` was an
  unparented `QTimer` member, so `moveToThread(m_extCtrlThread)` left it on the
  GUI thread and `start()` from the worker was silently refused. Now parented,
  with a regression case that drives the manager the way `MainWindow` does.
- **`open()` could report success on a port it had just closed** (LED short
  write → `releasePort()` → then an unconditional `connectionChanged(true)`).
- **`close()` was unreachable after a drop**, so turning FlexControl off in
  Radio Setup left the driver retrying and reclaiming the device. The three
  call sites no longer gate on `isOpen()`.
- Retry now backs off 2 s → 30 s and warns once per outage rather than per tick.
- Corrected the `close()` comment that claimed it no longer early-returns on
  `!isOpen()` — it does, and that turns out to be correct.
- CHANGELOG entry added.

**#4574 stays open.** This PR is no longer linked to auto-close it. The
hardware caveat above originally read "trusted to close" immediately followed
by the issue number, which GitHub parses as a closing keyword wherever it
appears — including buried in prose. The commit message had the same trap.
Both are reworded. The reporter has since said that unplugging and
replugging the USB does not help, which argues the port drop is not the whole
story — so the split+TX trigger is still unexplained and this remains a
resilience fix that stands on its own.

**Still not validated on FlexControl hardware.** The USB-drop path itself
remains unexercised.
