### PR TITLE
fix(tci): stable receiver numbers across slice recreate (#4567)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,7 @@ set(CORE_SOURCES
     src/core/TciServer.cpp
     src/core/TciProtocol.cpp
     src/core/TciRoutingState.cpp
+    src/core/TciTrxMap.cpp
     src/core/AutomationServer.cpp
     src/core/MqttClient.cpp
     src/core/PgxlConnection.cpp
@@ -4070,6 +4071,11 @@ if(Qt6WebSockets_FOUND)
     target_include_directories(tci_protocol_test PRIVATE src)
     target_link_libraries(tci_protocol_test PRIVATE aethercore Qt6::Core)
     add_test(NAME tci_protocol_test COMMAND tci_protocol_test)
+
+    add_executable(tci_trxmap_test tests/tci_trxmap_test.cpp)
+    target_include_directories(tci_trxmap_test PRIVATE src)
+    target_link_libraries(tci_trxmap_test PRIVATE aethercore Qt6::Core)
+    add_test(NAME tci_trxmap_test COMMAND tci_trxmap_test)
 
     add_executable(tci_automation_test tests/tci_automation_test.cpp)
     target_include_directories(tci_automation_test PRIVATE src tests)

--- a/src/core/TciProtocol.cpp
+++ b/src/core/TciProtocol.cpp
@@ -2,6 +2,7 @@
 #include "TciProtocol.h"
 #include "AppSettings.h"
 #include "TciRoutingState.h"
+#include "TciTrxMap.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/PanadapterModel.h"
@@ -60,9 +61,11 @@ long long TciProtocol::mhzToHz(double mhz)
     return static_cast<long long>(std::round(mhz * 1e6));
 }
 
-TciProtocol::TciProtocol(RadioModel* model, TciRoutingState* routingState)
+TciProtocol::TciProtocol(RadioModel* model, TciRoutingState* routingState,
+                         const TciTrxMap* trxMap)
     : m_model(model)
     , m_routingState(routingState)
+    , m_trxMap(trxMap)
 {}
 
 // ── Mode conversion ────────────────────────────────────────────────────────
@@ -99,6 +102,8 @@ QString TciProtocol::tciToSmartSDR(const QString& mode)
 
 SliceModel* TciProtocol::sliceForTrx(int trx) const
 {
+    if (m_trxMap)
+        return m_trxMap->sliceForTrx(m_model, trx);
     return resolveSliceForTrx(m_model, trx);
 }
 
@@ -165,7 +170,8 @@ int TciProtocol::txSliceTrxOrNone(RadioModel* model)
 
 int TciProtocol::txTrx() const
 {
-    const int trx = txSliceTrxOrNone(m_model);
+    const int trx = m_trxMap ? m_trxMap->txSliceTrxOrNone(m_model)
+                             : txSliceTrxOrNone(m_model);
     return trx < 0 ? 0 : trx;  // request/response wire needs a concrete index
 }
 
@@ -212,7 +218,10 @@ QString TciProtocol::generateInitBurst()
     burst += QStringLiteral("if_limits:-48000,48000;");
 
     const auto slices = m_model ? m_model->slices() : QList<SliceModel*>{};
-    int trxCount = slices.size();
+    // #4567: with stable bindings, a transient hole (band-change settle
+    // window) must not advertise a count below an index a client is using —
+    // the map reports 1 + the highest trx in use instead of the list size.
+    int trxCount = m_trxMap ? m_trxMap->trxCount(m_model) : slices.size();
     if (trxCount < 1) trxCount = 1;
     burst += QStringLiteral("trx_count:%1;").arg(trxCount);
     // `channels_count` (plural).  The TCI Protocol PDF spec lists this
@@ -255,7 +264,8 @@ QString TciProtocol::generateInitBurst()
     // state machine).
     if (m_model) {
         for (auto* s : slices) {
-            int trx = tciTrxForSlice(m_model, s);
+            int trx = m_trxMap ? m_trxMap->trxForSlice(m_model, s)
+                               : tciTrxForSlice(m_model, s);
             const long long hz = mhzToHz(s->frequency());
             burst += QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(hz);
             SliceModel* txVfo = sliceForVfo(trx, 1);

--- a/src/core/TciProtocol.h
+++ b/src/core/TciProtocol.h
@@ -9,6 +9,7 @@ namespace AetherSDR {
 class RadioModel;
 class SliceModel;
 class TciRoutingState;
+class TciTrxMap;
 
 // TCI protocol handler — text command parser and response generator.
 // No I/O — receives a command string, returns the response.
@@ -35,7 +36,8 @@ public:
         QString source;
     };
 
-    explicit TciProtocol(RadioModel* model, TciRoutingState* routingState = nullptr);
+    explicit TciProtocol(RadioModel* model, TciRoutingState* routingState = nullptr,
+                         const TciTrxMap* trxMap = nullptr);
 
     // Process one TCI command (without trailing semicolon).
     // Returns response string (with trailing semicolon) or empty if no response.
@@ -209,6 +211,9 @@ private:
 
     RadioModel* m_model;
     TciRoutingState* m_routingState;
+    // #4567: stable receiver numbering; nullptr falls back to the positional
+    // statics (tests construct TciProtocol without a map).
+    const TciTrxMap* m_trxMap{nullptr};
     QString m_pendingNotification;
     std::optional<VfoRequest> m_vfoRequest;
     std::optional<SplitRequest> m_splitRequest;

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -224,8 +224,24 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             // A recreate (same Flex slice id, removal < 500 ms ago) reuses
             // its existing binding; a genuinely new slice gets the lowest
             // free number.
-            if (s)
-                m_trxMap.acquire(s->sliceId());
+            //
+            // Bind by walking EVERY live slice in list order, not just the
+            // new one (#4577 review): after a reconnect the previous
+            // session's slices are reclaimed by the status replay without
+            // sliceAdded (RadioModel's !reclaimed guard) while the map was
+            // cleared at disconnect — live slices with no binding. Acquiring
+            // only the new slice would hand it trx 0 on top of a slice the
+            // fallback resolves positionally to 0. The walk is idempotent
+            // (acquire reuses existing bindings) and on an empty map
+            // reproduces exactly the positional numbering, restoring the
+            // invariant that every live slice is bound. The added slice is
+            // already in the list here (append precedes the emit).
+            if (s) {
+                for (SliceModel* live : m_model->slices()) {
+                    if (live)
+                        m_trxMap.acquire(live->sliceId());
+                }
+            }
             for (const auto& cs : m_clients) {
                 if (cs.audioEnabled) {
                     qCInfo(lcCat) << "TCI: slice added — re-arming DAX"
@@ -250,7 +266,11 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             }
             m_tciDaxSlices.remove(sliceId);
 
-            // Removal renumbers every later slice's trx (#4160).
+            // Under the #4567 sticky map a removal does NOT renumber the
+            // survivors (that renumbering was #4160's original concern) —
+            // publishActiveTrx() still runs because the removed slice may
+            // have been the focused one, and the active-trx broadcast must
+            // move off the dead index.
             publishActiveTrx();
 
             // m_lastTxTrx caches the last TX slice's trx so a power change
@@ -280,6 +300,9 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             // same Flex slice id well within 500 ms and reclaims its number
             // via acquire() (so surviving slices never renumber); a genuine
             // close leaves the id dead and frees the number for reuse.
+            // The timer also fires during teardown after m_trxMap.clear() —
+            // intentional no-op: release() of an absent key does nothing and
+            // the liveness guard holds.
             QTimer::singleShot(500, this, [this, sliceId]() {
                 if (m_model && !m_model->slice(sliceId)) {
                     m_trxMap.release(sliceId);

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -85,38 +85,13 @@ constexpr qint64 kTxSummaryEveryBlocks = 48;
 constexpr int kPowerRateLimitMs = 100;
 
 // parseStatusHandle / streamStatusBelongsToUs  → StreamStatus.h
-// tciTrxForSlice                               → TciProtocol::tciTrxForSlice
+// trx↔slice mapping                            → TciTrxMap (m_trxMap, #4567)
 
-// TRX index of the current TX slice, or -1 when none is currently marked.
-// Thin alias over TciProtocol::txSliceTrxOrNone() so the scan lives in one
-// place (see the header comment there). The async broadcast keeps the -1
-// sentinel and resolves it against a cached last-known TX trx: a band change
-// on a multi-slice setup recreates the TX slice and restores its TX flag
-// *after* the power change is processed, so a plain scan would momentarily
-// find no TX slice and mislabel drive with trx 0 (#4161). -1 (not 0) is
-// returned for "none" because trx 0 is a legitimate TX slice and must be
-// distinguishable.
-inline int txTrxIndex(RadioModel* model)
-{
-    return TciProtocol::txSliceTrxOrNone(model);
-}
-
-// True when some live slice currently maps to `trx`. Used to tell a genuine TX
-// slice *close* (nothing carries the cached trx anymore) apart from the
-// band-change recreation gap (the recreated slice carries the trx, it just has
-// not regained its TX flag yet). (#4161)
-bool trxHasLiveSlice(RadioModel* model, int trx)
-{
-    if (!model) {
-        return false;
-    }
-    for (auto* s : model->slices()) {
-        if (s && TciProtocol::tciTrxForSlice(model, s) == trx) {
-            return true;
-        }
-    }
-    return false;
-}
+// txTrxIndex / trxHasLiveSlice (#4161) moved onto TciTrxMap (#4567) — the
+// TX-trx scan and the close-vs-recreate discrimination both need the stable
+// sliceId→trx bindings, which only the server's map instance holds. The -1
+// "no TX slice" sentinel semantics are unchanged (see the broadcastPower
+// call site): -1, not 0, because trx 0 is a legitimate TX slice.
 
 } // namespace
 
@@ -217,6 +192,7 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
                 // manage.
                 m_channelTrx.clear();
                 m_tciDaxSlices.clear();
+                m_trxMap.clear();  // #4567: slices die with the connection
                 m_lastDdsCenterHz.clear();
                 m_routingState.reset();
                 m_pendingVfoBCreate.reset();
@@ -242,7 +218,14 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             }
         });
         connect(m_model, &RadioModel::sliceAdded,
-                this, [this](SliceModel*) {
+                this, [this](SliceModel* s) {
+            // #4567: bind the receiver number FIRST, before anything below
+            // (or any later-connected handler) derives a trx for this slice.
+            // A recreate (same Flex slice id, removal < 500 ms ago) reuses
+            // its existing binding; a genuinely new slice gets the lowest
+            // free number.
+            if (s)
+                m_trxMap.acquire(s->sliceId());
             for (const auto& cs : m_clients) {
                 if (cs.audioEnabled) {
                     qCInfo(lcCat) << "TCI: slice added — re-arming DAX"
@@ -283,13 +266,25 @@ TciServer::TciServer(RadioModel* model, QObject* parent)
             // that trx and resets the cache to the burst's historical default.
             // (A renumber that leaves another live slice at that trx also
             // no-ops; a surviving TX slice refreshes the cache in broadcastPower.)
-            if (!trxHasLiveSlice(m_model, m_lastTxTrx)) {
+            if (!m_trxMap.trxHasLiveSlice(m_model, m_lastTxTrx)) {
                 QTimer::singleShot(500, this, [this]() {
-                    if (m_model && !trxHasLiveSlice(m_model, m_lastTxTrx)) {
+                    if (m_model && !m_trxMap.trxHasLiveSlice(m_model, m_lastTxTrx)) {
                         m_lastTxTrx = 0;
                     }
                 });
             }
+
+            // #4567: release the removed slice's receiver binding only if
+            // this is a genuine close. Same settle-window shape as the
+            // m_lastTxTrx cache above: a band-change recreate re-adds the
+            // same Flex slice id well within 500 ms and reclaims its number
+            // via acquire() (so surviving slices never renumber); a genuine
+            // close leaves the id dead and frees the number for reuse.
+            QTimer::singleShot(500, this, [this, sliceId]() {
+                if (m_model && !m_model->slice(sliceId)) {
+                    m_trxMap.release(sliceId);
+                }
+            });
 
             auto* ps = m_model ? m_model->panStream() : nullptr;
             if (!ps) return;
@@ -545,7 +540,7 @@ void TciServer::broadcastPower()
     // Resolve the TX trx, falling back to the last known one when a slice
     // recreation has momentarily cleared every TX flag (#4161). Refresh the
     // cache whenever a real TX slice is found.
-    int trx = txTrxIndex(m_model);
+    int trx = m_trxMap.txSliceTrxOrNone(m_model);
     if (trx < 0) {
         trx = m_lastTxTrx;
     } else {
@@ -596,7 +591,7 @@ void TciServer::publishActiveTrx()
     // while the outgoing one keeps its flag until the radio echoes active=0,
     // so a scan can transiently see two active slices (#3854 review).
     if (m_activeSlice && m_model && m_model->slices().contains(m_activeSlice)) {
-        trx = TciProtocol::tciTrxForSlice(m_model, m_activeSlice);
+        trx = m_trxMap.trxForSlice(m_model, m_activeSlice);
         letter = TciProtocol::sanitizeSliceLetter(m_activeSlice->letter());
     }
 
@@ -677,7 +672,7 @@ void TciServer::onNewConnection()
         ws->setMaxAllowedIncomingMessageSize(kMaxWsMessageBytes);
         ws->setMaxAllowedIncomingFrameSize(kMaxWsMessageBytes);
 
-        auto* protocol = new TciProtocol(m_model, &m_routingState);
+        auto* protocol = new TciProtocol(m_model, &m_routingState, &m_trxMap);
         // Seed GUI focus so this client's init burst and any `active_slice`
         // GET report the current slice, not a stale scan (#4160). Stays -1
         // if no focus change has been observed yet, in which case the
@@ -1143,7 +1138,7 @@ void TciServer::onTextMessage(const QString& msg)
 
 SliceModel* TciServer::sliceForTrx(int trx) const
 {
-    return TciProtocol::resolveSliceForTrx(m_model, trx);
+    return m_trxMap.sliceForTrx(m_model, trx);
 }
 
 QVector<TciSliceEndpoint> TciServer::routingEndpoints() const
@@ -2085,7 +2080,7 @@ void TciServer::onDaxAudioReady(int channel, const QByteArray& pcm)
     if (m_model) {
         for (auto* s : m_model->slices()) {
             if (s->daxChannel() == channel) {
-                trx = TciProtocol::tciTrxForSlice(m_model,s);
+                trx = m_trxMap.trxForSlice(m_model,s);
                 owningSliceId = s->sliceId();
                 m_channelTrx[channel] = trx;   // remember the resolved mapping (#3669)
                 break;
@@ -2343,7 +2338,7 @@ void TciServer::broadcastSliceFrequencies(SliceModel* slice)
         return;
     }
 
-    const int trx = TciProtocol::tciTrxForSlice(m_model, slice);
+    const int trx = m_trxMap.trxForSlice(m_model, slice);
     const long long ddsHz = TciProtocol::ddsCenterHz(m_model, slice);
     broadcast(QStringLiteral("vfo:%1,0,%2;").arg(trx).arg(vfoHz));
     broadcast(QStringLiteral("dds:%1,%2;").arg(trx).arg(ddsHz));
@@ -2351,7 +2346,7 @@ void TciServer::broadcastSliceFrequencies(SliceModel* slice)
     if (slice->sliceId() == m_routingState.txSliceId()) {
         SliceModel* rxSlice = m_model->slice(m_routingState.rxSliceId());
         if (rxSlice) {
-            const int rxTrx = TciProtocol::tciTrxForSlice(m_model, rxSlice);
+            const int rxTrx = m_trxMap.trxForSlice(m_model, rxSlice);
             broadcast(QStringLiteral("vfo:%1,1,%2;").arg(rxTrx).arg(vfoHz));
         }
     }
@@ -2372,20 +2367,20 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
 
     connect(slice, &SliceModel::modeChanged, this, [this, slice](const QString& mode) {
         if (m_clients.isEmpty()) return;
-        const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
+        const int trx = m_trxMap.trxForSlice(m_model,slice);
         broadcast(QStringLiteral("modulation:%1,%2;")
                       .arg(trx).arg(TciProtocol::smartsdrToTci(mode)));
     });
 
     connect(slice, &SliceModel::filterChanged, this, [this, slice](int lo, int hi) {
         if (m_clients.isEmpty()) return;
-        const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
+        const int trx = m_trxMap.trxForSlice(m_model,slice);
         broadcast(QStringLiteral("rx_filter_band:%1,%2,%3;")
                       .arg(trx).arg(lo).arg(hi));
     });
 
     connect(slice, &SliceModel::txSliceChanged, this, [this, slice](bool tx) {
-        const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
+        const int trx = m_trxMap.trxForSlice(m_model,slice);
         // Keep the drive:/tune_drive: label cache truthful even with no
         // clients attached, so a later power change resolves the right trx
         // (#4161). Only a slice *gaining* TX updates it; the losing edge
@@ -2400,12 +2395,12 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
     // Seed the TX-trx cache from current state — txSliceChanged only fires on
     // a change, so a slice that is already TX at wire time would never set it.
     if (slice->isTxSlice()) {
-        m_lastTxTrx = TciProtocol::tciTrxForSlice(m_model, slice);
+        m_lastTxTrx = m_trxMap.trxForSlice(m_model, slice);
     }
 
     connect(slice, &SliceModel::lockedChanged, this, [this, slice](bool locked) {
         if (m_clients.isEmpty()) return;
-        const int trx = TciProtocol::tciTrxForSlice(m_model,slice);
+        const int trx = m_trxMap.trxForSlice(m_model,slice);
         broadcast(QStringLiteral("lock:%1,%2;")
                       .arg(trx).arg(locked ? "true" : "false"));
     });
@@ -2452,7 +2447,7 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
     // remote controllers would drift out of sync. Part of issue #1764 fix.
     connect(slice, &SliceModel::audioGainChanged, this, [this, slice](float gain) {
         if (m_clients.isEmpty()) return;
-        const int trx = TciProtocol::tciTrxForSlice(m_model, slice);
+        const int trx = m_trxMap.trxForSlice(m_model, slice);
         broadcast(QStringLiteral("rx_volume:%1,%2;")
                       .arg(trx).arg(static_cast<int>(gain)));
     });
@@ -2495,7 +2490,7 @@ void TciServer::wireSlice(int trx, SliceModel* slice)
         if (m_clients.isEmpty()) {
             return;
         }
-        const int trx = TciProtocol::tciTrxForSlice(m_model, s);
+        const int trx = m_trxMap.trxForSlice(m_model, s);
         broadcast(QStringLiteral("%1:%2,%3;")
                       .arg(QLatin1String(cmd)).arg(trx)
                       .arg(on ? "true" : "false"));
@@ -2637,7 +2632,7 @@ void TciServer::notifySpotClicked(int spotIndex, SliceModel* slice)
         }
     }
 
-    const int trx = TciProtocol::tciTrxForSlice(m_model, resolvedSlice);
+    const int trx = m_trxMap.trxForSlice(m_model, resolvedSlice);
     const long long hz = static_cast<long long>(std::round(it->rxFreqMhz * 1e6));
     broadcastSpotClicked(it->callsign, hz, trx, 0);
 }
@@ -2666,7 +2661,7 @@ void TciServer::sendInitBurst(QWebSocket* client)
     const auto slices = m_model->slices();
     for (auto* s : slices) {
         receiverMap << QStringLiteral("trx%1=slice%2/dax%3")
-                           .arg(TciProtocol::tciTrxForSlice(m_model,s))
+                           .arg(m_trxMap.trxForSlice(m_model,s))
                            .arg(s->sliceId())
                            .arg(s->daxChannel());
     }
@@ -2949,7 +2944,7 @@ void TciServer::broadcastActualTxState(bool transmitting)
         return;
     }
     SliceModel* txSlice = m_model->txSlice();
-    int trx = m_tciPttClient ? m_tciPttTrx : TciProtocol::tciTrxForSlice(m_model, txSlice);
+    int trx = m_tciPttClient ? m_tciPttTrx : m_trxMap.trxForSlice(m_model, txSlice);
     broadcast(QStringLiteral("trx:%1,%2;").arg(trx).arg(transmitting ? "true" : "false"));
     if (transmitting && txSlice) {
         broadcast(
@@ -3050,7 +3045,7 @@ void TciServer::broadcastStatus()
     // Broadcast S-meter for each owned slice (throttled to 200ms)
     // TCI spec: rx_smeter:receiver,value; (2 args)
     for (auto* s : m_model->slices()) {
-        const int trx = TciProtocol::tciTrxForSlice(m_model,s);
+        const int trx = m_trxMap.trxForSlice(m_model,s);
         const int meterIndex = s->sliceId();
         if (trx >= 0 && meterIndex >= 0 && meterIndex < 8) {
             float dbm = m_cachedSLevel[meterIndex];
@@ -3064,7 +3059,7 @@ void TciServer::broadcastStatus()
     for (auto& cs : m_clients) {
         if (cs.rxSensorsEnabled) {
             for (auto* s : m_model->slices()) {
-                const int trx = TciProtocol::tciTrxForSlice(m_model,s);
+                const int trx = m_trxMap.trxForSlice(m_model,s);
                 const int meterIndex = s->sliceId();
                 if (trx >= 0 && meterIndex >= 0 && meterIndex < 8) {
                     float dbm = m_cachedSLevel[meterIndex];
@@ -3159,7 +3154,7 @@ void TciServer::onWaterfallRowReady(quint32 streamId, const QVector<float>& bins
             if (pan->wfStreamId() == streamId) {
                 for (auto* s : m_model->slices()) {
                     if (s->panId() == pan->panId()) {
-                        trx = TciProtocol::tciTrxForSlice(m_model, s);
+                        trx = m_trxMap.trxForSlice(m_model, s);
                         break;
                     }
                 }

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -3,6 +3,7 @@
 
 #include "TciProtocol.h"
 #include "TciRoutingState.h"
+#include "TciTrxMap.h"
 
 #include <QObject>
 #include <QPointer>
@@ -268,6 +269,10 @@ private:
     QMap<int, int>     m_channelTrx;            // DAX channel → last-resolved TCI TRX (routing cache, #3669)
     QHash<QString, long long> m_lastDdsCenterHz; // panId → last broadcast dds center, gates zoom-only re-emits (#3910)
     TciRoutingState m_routingState;
+    // #4567: stable sliceId→trx receiver bindings. Acquired on sliceAdded,
+    // released 500 ms after a genuine slice close (recreates reclaim their
+    // number), cleared on disconnect. Injected into every TciProtocol.
+    TciTrxMap m_trxMap;
     struct PendingVfoBCreate
     {
         QPointer<QWebSocket> client;

--- a/src/core/TciTrxMap.cpp
+++ b/src/core/TciTrxMap.cpp
@@ -52,9 +52,15 @@ SliceModel* TciTrxMap::sliceForTrx(RadioModel* model, int trx) const
                 continue;
             if (SliceModel* s = model->slice(it.key()))
                 return s;
-            // Bound but not live (band-change settle window): fall through to
-            // the positional fallback rather than answering with a dead id.
-            break;
+            // Bound but not live (band-change settle window). The binding is
+            // held because this slice is expected back; answering positionally
+            // would route an inbound command to whichever slice happens to sit
+            // at that index — the very re-pointing #4567 is about, inside the
+            // one window a band-changing client is most likely to send
+            // commands. Refuse until the recreate reclaims the number or the
+            // deferred release frees it; callers already treat a null slice
+            // as "unknown receiver" and drop the command (#4577 review).
+            return nullptr;
         }
     }
     return TciProtocol::resolveSliceForTrx(model, trx);

--- a/src/core/TciTrxMap.cpp
+++ b/src/core/TciTrxMap.cpp
@@ -1,0 +1,97 @@
+#include "TciTrxMap.h"
+
+#include "TciProtocol.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include <algorithm>
+
+namespace AetherSDR {
+
+int TciTrxMap::acquire(int sliceId)
+{
+    const auto it = m_trxBySliceId.constFind(sliceId);
+    if (it != m_trxBySliceId.constEnd())
+        return it.value();
+
+    // Lowest free trx keeps the wire indexes dense from 0.
+    int trx = 0;
+    while (std::find(m_trxBySliceId.cbegin(), m_trxBySliceId.cend(), trx)
+           != m_trxBySliceId.cend()) {
+        ++trx;
+    }
+    m_trxBySliceId.insert(sliceId, trx);
+    return trx;
+}
+
+void TciTrxMap::release(int sliceId)
+{
+    m_trxBySliceId.remove(sliceId);
+}
+
+void TciTrxMap::clear()
+{
+    m_trxBySliceId.clear();
+}
+
+int TciTrxMap::trxForSlice(RadioModel* model, const SliceModel* slice) const
+{
+    if (!slice)
+        return TciProtocol::tciTrxForSlice(model, slice);
+    const auto it = m_trxBySliceId.constFind(slice->sliceId());
+    if (it != m_trxBySliceId.constEnd())
+        return it.value();
+    return TciProtocol::tciTrxForSlice(model, slice);
+}
+
+SliceModel* TciTrxMap::sliceForTrx(RadioModel* model, int trx) const
+{
+    if (model) {
+        for (auto it = m_trxBySliceId.cbegin(); it != m_trxBySliceId.cend(); ++it) {
+            if (it.value() != trx)
+                continue;
+            if (SliceModel* s = model->slice(it.key()))
+                return s;
+            // Bound but not live (band-change settle window): fall through to
+            // the positional fallback rather than answering with a dead id.
+            break;
+        }
+    }
+    return TciProtocol::resolveSliceForTrx(model, trx);
+}
+
+int TciTrxMap::txSliceTrxOrNone(RadioModel* model) const
+{
+    if (!model)
+        return -1;
+    for (SliceModel* slice : model->slices()) {
+        if (slice && slice->isTxSlice())
+            return trxForSlice(model, slice);
+    }
+    return -1;
+}
+
+bool TciTrxMap::trxHasLiveSlice(RadioModel* model, int trx) const
+{
+    if (!model)
+        return false;
+    for (auto* s : model->slices()) {
+        if (s && trxForSlice(model, s) == trx)
+            return true;
+    }
+    return false;
+}
+
+int TciTrxMap::trxCount(RadioModel* model) const
+{
+    int highest = -1;
+    for (int trx : m_trxBySliceId)
+        highest = std::max(highest, trx);
+    if (model) {
+        for (auto* s : model->slices())
+            highest = std::max(highest, trxForSlice(model, s));
+    }
+    return std::max(highest + 1, 1);
+}
+
+} // namespace AetherSDR

--- a/src/core/TciTrxMap.h
+++ b/src/core/TciTrxMap.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <QHash>
+
+namespace AetherSDR {
+
+class RadioModel;
+class SliceModel;
+
+// Stable TCI receiver numbering (#4567).
+//
+// Wire receiver indexes used to be the slice's current position in
+// RadioModel::slices() (the #2145 policy) — an insertion-ordered list that a
+// band-stack destroy/recreate reorders: the recreated slice re-enters at the
+// tail, so every surviving slice silently changes receiver number under a
+// live TCI client, and the client's audio/control follow the wrong slice.
+//
+// This map pins sliceId → trx for the life of a binding instead:
+//  - acquire() on sliceAdded reuses an existing binding (a band-stack
+//    recreate keeps the same Flex slice id, so the recreated slice reclaims
+//    its old receiver number and surviving slices never move) or assigns the
+//    lowest free trx (keeping indexes dense from 0, which the TCI wire
+//    contract requires — raw Flex slice ids are sparse and MultiFlex can
+//    start them above 0, so they are NOT usable as receiver numbers).
+//  - release() is deferred by the owner past the band-change settle window
+//    (see TciServer's sliceRemoved handler), so only a genuine slice close
+//    frees a number for reuse.
+//
+// Under a session with no mid-session destroy/recreate the assignment is
+// identical to the positional policy (0,1,2… in creation order). Lookups on
+// a slice with no binding fall back to the original positional logic
+// (TciProtocol's statics), so pre-wiring windows behave exactly as before.
+//
+// Deliberately NOT part of TciRoutingState: that class excludes wire TRX
+// indexes by design (TciRoutingState.h) — this class is the one owner of
+// them. Not thread-affine; owned and driven by TciServer on its thread.
+class TciTrxMap
+{
+public:
+    // Returns the trx bound to sliceId, binding the lowest free trx first if
+    // none exists. Idempotent for an existing binding.
+    int acquire(int sliceId);
+
+    // Drops sliceId's binding (a later acquire may reuse the freed trx).
+    void release(int sliceId);
+
+    // Drops every binding (disconnect: slices die with the connection).
+    void clear();
+
+    // Map-first lookups; positional fallback when the slice has no binding.
+    int trxForSlice(RadioModel* model, const SliceModel* slice) const;
+    SliceModel* sliceForTrx(RadioModel* model, int trx) const;
+
+    // TRX index of the current TX slice, or -1 when none is marked.
+    int txSliceTrxOrNone(RadioModel* model) const;
+
+    // True when some live slice currently maps to `trx` (see TciServer's
+    // #4161 close-vs-recreate discrimination).
+    bool trxHasLiveSlice(RadioModel* model, int trx) const;
+
+    // Advertised receiver count: 1 + the highest trx in use (bound or live),
+    // never below 1 — a transient hole must not advertise a count below an
+    // index a client is actively using.
+    int trxCount(RadioModel* model) const;
+
+private:
+    QHash<int, int> m_trxBySliceId;
+};
+
+} // namespace AetherSDR

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -376,12 +376,11 @@ public:
             == QStringLiteral("active_slice:1,B;");
     }
 
-    // #4160 — trx is positional, so removing a slice renumbers every later one
-    // while the focused slice emits nothing (it never lost focus). Unlike
-    // vfo:/modulation: there is no follow-up event to self-correct, so the
-    // sliceRemoved → publishActiveTrx() path is the only thing keeping the
-    // tracked trx (and every client seeded from it) pointing at the right
-    // slice. Previously covered only on hardware.
+    // #4160 established this hook when trx was positional (removal renumbered
+    // every later slice). Under #4567's stable bindings removal no longer
+    // renumbers ANYTHING — the focused slice keeps its trx — but the hook
+    // still matters: removing the FOCUSED slice must clear the tracked trx
+    // rather than leave it naming a dead slice. Both halves covered here.
     static bool activeSliceFollowsSliceRemoval()
     {
         RadioModel model;
@@ -409,18 +408,19 @@ public:
             return false;
         }
 
-        // Remove the EARLIER, unfocused slice. Focus stays with B, but B's
-        // positional trx renumbers 1 → 0. Nothing re-fires activeChanged, so
-        // only the removal hook can correct it.
+        // Remove the EARLIER, unfocused slice. Focus stays with B — and under
+        // #4567's stable bindings B KEEPS trx 1 (the pre-#4567 positional
+        // policy renumbered it to 0 here; that silent renumber-under-a-live-
+        // client is the defect #4567 fixed).
         if (!model.automationRemoveSliceFixture(0, &error)) {
             std::fprintf(stderr, "remove slice 0 failed: %s\n",
                          error.toUtf8().constData());
             return false;
         }
-        if (server.m_activeTrx != 0
+        if (server.m_activeTrx != 1
             || server.m_activeLetter != QStringLiteral("B")) {
             std::fprintf(stderr,
-                         "after removing trx 0: expected focus B renumbered to trx 0, "
+                         "after removing trx 0: expected focus B to KEEP trx 1 (#4567), "
                          "got trx=%d letter=%s\n",
                          server.m_activeTrx,
                          server.m_activeLetter.toUtf8().constData());
@@ -447,6 +447,64 @@ public:
         TciProtocol seeded(&model, &server.m_routingState);
         seeded.setActiveSlice(server.m_activeTrx, server.m_activeLetter);
         return seeded.handleCommand(QStringLiteral("active_slice")).isEmpty();
+    }
+
+    // #4567 — the captured defect, end to end on the model: a band-stack
+    // switch destroys and recreates its slice (same Flex slice id) while a
+    // second slice is open. The recreate re-enters RadioModel's list at the
+    // tail, so positional numbering handed the surviving slice receiver 0 —
+    // silently re-routing a live client. With stable bindings the recreated
+    // slice reclaims its number (the release is deferred past the settle
+    // window, and no event loop runs here, so the binding is held exactly as
+    // it is on hardware) and the survivor never moves.
+    static bool trxStableAcrossSliceRecreate()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QStringLiteral("A"), &error)
+            || !model.automationApplySliceFixture(1, QStringLiteral("B"),
+                                                  &error)) {
+            std::fprintf(stderr, "recreate fixtures failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        SliceModel* b = model.slice(1);
+        if (server.m_trxMap.trxForSlice(&model, model.slice(0)) != 0
+            || server.m_trxMap.trxForSlice(&model, b) != 1) {
+            std::fprintf(stderr, "recreate setup: expected A=0 B=1\n");
+            return false;
+        }
+
+        // The band switch: destroy A, recreate it with the same slice id.
+        // The recreated slice is APPENDED — list order is now [B, newA].
+        if (!model.automationRemoveSliceFixture(0, &error)
+            || !model.automationApplySliceFixture(0, QStringLiteral("A"),
+                                                  &error)) {
+            std::fprintf(stderr, "recreate cycle failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+        SliceModel* newA = model.slice(0);
+        if (!newA || model.slices().indexOf(newA) != 1) {
+            std::fprintf(stderr,
+                         "recreate precondition lost: expected the recreated "
+                         "slice at the list tail\n");
+            return false;
+        }
+
+        // The regression: positional numbering answered B=0 / newA=1 here.
+        if (server.m_trxMap.trxForSlice(&model, newA) != 0) {
+            std::fprintf(stderr, "recreated slice did not reclaim trx 0\n");
+            return false;
+        }
+        if (server.m_trxMap.trxForSlice(&model, b) != 1) {
+            std::fprintf(stderr, "surviving slice lost trx 1\n");
+            return false;
+        }
+        return server.m_trxMap.sliceForTrx(&model, 0) == newA
+            && server.m_trxMap.sliceForTrx(&model, 1) == b;
     }
 
     // ── vfo: SET must confirm the frequency it actually reached (#4500/#4493) ──
@@ -624,6 +682,8 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::activeSliceSeedsFromCurrentState();
     const bool activeSliceRemoval
         = AetherSDR::TciServerReviewTest::activeSliceFollowsSliceRemoval();
+    const bool trxStableRecreate
+        = AetherSDR::TciServerReviewTest::trxStableAcrossSliceRecreate();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -645,8 +705,10 @@ int main(int argc, char** argv)
                 txTrxResets ? "PASS" : "FAIL");
     std::printf("%s  active_slice seeds from current GUI focus (#4160)\n",
                 activeSliceSeed ? "PASS" : "FAIL");
-    std::printf("%s  active_slice renumbers/clears on slice removal (#4160)\n",
+    std::printf("%s  active_slice holds trx / clears on slice removal (#4160/#4567)\n",
                 activeSliceRemoval ? "PASS" : "FAIL");
+    std::printf("%s  receiver numbers stable across slice recreate (#4567)\n",
+                trxStableRecreate ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET confirms the frequency reached (#4500/#4493)\n",
                 vfoConfirmsAccepted ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET confirms the truth when the tune is refused\n",
@@ -657,7 +719,7 @@ int main(int argc, char** argv)
     return validProfile && deferredAbort && observableFailure
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
         && flagSeedSettled && txTrxResets
-        && activeSliceSeed && activeSliceRemoval
+        && activeSliceSeed && activeSliceRemoval && trxStableRecreate
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         ? 0 : 1;
 }

--- a/tests/tci_server_review_test.cpp
+++ b/tests/tci_server_review_test.cpp
@@ -2,7 +2,10 @@
 #include "core/AppSettings.h"
 #include "core/AudioEngine.h"
 #include "core/QsoRecorder.h"
+#include "core/RadioDiscovery.h"
 #include "core/TciServer.h"
+#include "core/TciTrxMap.h"
+#include "core/backends/sim/SimBackend.h"
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
 #include "models/TransmitModel.h"
@@ -10,6 +13,7 @@
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QJsonObject>
+#include <QSet>
 #include <QTimer>
 #include <QWebSocket>
 
@@ -507,6 +511,141 @@ public:
             && server.m_trxMap.sliceForTrx(&model, 1) == b;
     }
 
+    // #4577 review — the reconnect hole: stageSessionModelsForReconnect()
+    // reclaims the previous session's slices without sliceAdded (RadioModel's
+    // !reclaimed guard) while the map was cleared at disconnect, so every
+    // slice is live but unbound. The next genuine slice-add must not collide:
+    // binding only the new slice would hand it trx 0 on top of the slice the
+    // positional fallback already resolves to 0. The fixture reproduces the
+    // reclaim END STATE directly (live slices + cleared map) rather than the
+    // staging machinery — identical from the map's point of view.
+    static bool liveSlicesKeepDistinctTrxAfterReconnect()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        QString error;
+        if (!model.automationApplySliceFixture(0, QStringLiteral("A"), &error)
+            || !model.automationApplySliceFixture(1, QStringLiteral("B"),
+                                                  &error)) {
+            std::fprintf(stderr, "reconnect fixtures failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+
+        // The disconnect/reclaim cycle: bindings die with the connection,
+        // slices survive into the new session unbound.
+        server.m_trxMap.clear();
+
+        // First slice-add of the new session.
+        if (!model.automationApplySliceFixture(2, QStringLiteral("C"),
+                                               &error)) {
+            std::fprintf(stderr, "reconnect add failed: %s\n",
+                         error.toUtf8().constData());
+            return false;
+        }
+
+        // The invariant the design rests on: no two live slices resolve to
+        // the same trx.
+        QSet<int> seen;
+        for (SliceModel* s : model.slices()) {
+            const int trx = server.m_trxMap.trxForSlice(&model, s);
+            if (seen.contains(trx)) {
+                std::fprintf(stderr,
+                             "duplicate trx %d among live slices after "
+                             "reconnect + add\n",
+                             trx);
+                return false;
+            }
+            seen.insert(trx);
+        }
+        // And the rebind walk reproduces the numbering the positional policy
+        // would have given: A=0 B=1 C=2 in list order.
+        return server.m_trxMap.trxForSlice(&model, model.slice(0)) == 0
+            && server.m_trxMap.trxForSlice(&model, model.slice(1)) == 1
+            && server.m_trxMap.trxForSlice(&model, model.slice(2)) == 2;
+    }
+
+    // #4577 review — inside the 500 ms settle window the two lookup
+    // directions must not contradict: trxForSlice answers from the held
+    // binding (the survivor keeps its number), so sliceForTrx answering the
+    // held number positionally would route an inbound command to the wrong
+    // slice — during exactly the window a band-changing client is most
+    // likely to send one. A held-but-not-live trx answers "no slice right
+    // now"; callers already treat null as unknown-receiver and drop the
+    // command.
+    //
+    // Runs against the demo's synthetic wire (the demo_backend_swap_test
+    // pattern): the positional fallback opens with an isConnected() guard,
+    // so on a disconnected fixture model the pre-fix code answers null by
+    // coincidence and the case cannot discriminate. The event loop spins
+    // only BEFORE the removal — the deferred release stays held through the
+    // assertions, exactly as it is on hardware inside the window.
+    static bool heldTrxRefusesInsteadOfRepointing()
+    {
+        RadioModel model;
+        TciServer server(&model);
+
+        RadioInfo demo;
+        demo.name    = QStringLiteral("FLEX-6700");
+        demo.model   = SimBackend::demoModelName();
+        demo.serial  = SimBackend::demoSerial();
+        demo.family  = SimBackend::familyName();
+        demo.address = QHostAddress(QHostAddress::LocalHost);  // never dialed
+        demo.port    = 4992;
+        model.connectToRadio(demo);
+        for (int i = 0;
+             i < 40 && !(model.isConnected() && !model.slices().isEmpty());
+             ++i) {
+            QEventLoop loop;
+            QTimer::singleShot(50, &loop, &QEventLoop::quit);
+            loop.exec();
+        }
+        if (!model.isConnected() || model.slices().isEmpty()) {
+            std::fprintf(stderr,
+                         "settle: demo connect did not settle (connected=%d "
+                         "slices=%d)\n",
+                         model.isConnected(), int(model.slices().size()));
+            return false;
+        }
+        SliceModel* live = model.slices().first();
+
+        // A standalone map holding the settle-window state directly: trx 0 is
+        // bound to a slice id with no live slice (exactly what the deferred
+        // release preserves after a band-change destroy), while a live slice
+        // sits at list position 0. The demo cannot grow a second slice and
+        // the slice fixtures refuse while connected, so the held state is
+        // constructed on the map itself — identical from sliceForTrx's point
+        // of view, and the model is genuinely connected, which is what arms
+        // the positional fallback the pre-fix code fell through to.
+        TciTrxMap map;
+        const int heldTrx = map.acquire(9999);            // dead id holds 0
+        const int liveTrx = map.acquire(live->sliceId()); // live slice gets 1
+        if (heldTrx != 0 || liveTrx != 1) {
+            std::fprintf(stderr, "settle setup: expected held=0 live=1, got "
+                         "%d/%d\n", heldTrx, liveTrx);
+            return false;
+        }
+
+        // Outbound: the live slice keeps its own number.
+        if (map.trxForSlice(&model, live) != liveTrx) {
+            std::fprintf(stderr, "live slice lost trx %d\n", liveTrx);
+            return false;
+        }
+        // Inbound: the held number answers nothing. The pre-fix fallback
+        // answered the live slice at list position 0 — an inbound command
+        // for the held receiver re-pointed at a different slice, the very
+        // failure #4567 is about.
+        if (SliceModel* wrong = map.sliceForTrx(&model, heldTrx)) {
+            std::fprintf(stderr,
+                         "held trx %d answered slice id %d instead of null\n",
+                         heldTrx, wrong->sliceId());
+            return false;
+        }
+        // The live slice's own number still resolves to it.
+        return map.sliceForTrx(&model, liveTrx) == live;
+    }
+
     // ── vfo: SET must confirm the frequency it actually reached (#4500/#4493) ──
     //
     // A raw `slice tune` written at the connection bypasses SliceModel, and the
@@ -684,6 +823,10 @@ int main(int argc, char** argv)
         = AetherSDR::TciServerReviewTest::activeSliceFollowsSliceRemoval();
     const bool trxStableRecreate
         = AetherSDR::TciServerReviewTest::trxStableAcrossSliceRecreate();
+    const bool trxDistinctReconnect
+        = AetherSDR::TciServerReviewTest::liveSlicesKeepDistinctTrxAfterReconnect();
+    const bool heldTrxRefuses
+        = AetherSDR::TciServerReviewTest::heldTrxRefusesInsteadOfRepointing();
 
     std::printf("%s  isolated settings profile\n",
                 validProfile ? "PASS" : "FAIL");
@@ -709,6 +852,11 @@ int main(int argc, char** argv)
                 activeSliceRemoval ? "PASS" : "FAIL");
     std::printf("%s  receiver numbers stable across slice recreate (#4567)\n",
                 trxStableRecreate ? "PASS" : "FAIL");
+    std::printf("%s  live slices keep distinct trx after reconnect (#4577)\n",
+                trxDistinctReconnect ? "PASS" : "FAIL");
+    std::printf("%s  held trx refuses instead of re-pointing in the settle "
+                "window (#4577)\n",
+                heldTrxRefuses ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET confirms the frequency reached (#4500/#4493)\n",
                 vfoConfirmsAccepted ? "PASS" : "FAIL");
     std::printf("%s  vfo: SET confirms the truth when the tune is refused\n",
@@ -720,6 +868,7 @@ int main(int argc, char** argv)
         && powerRateLimits && trxCacheHolds && cacheResets && flagSeedsDeDups
         && flagSeedSettled && txTrxResets
         && activeSliceSeed && activeSliceRemoval && trxStableRecreate
+        && trxDistinctReconnect && heldTrxRefuses
         && vfoConfirmsAccepted && vfoConfirmsRefusal && vfoAcksNoOp
         ? 0 : 1;
 }

--- a/tests/tci_trxmap_test.cpp
+++ b/tests/tci_trxmap_test.cpp
@@ -1,0 +1,96 @@
+// #4567 regression: TCI receiver numbers must survive a mid-session slice
+// destroy/recreate. The captured failure: [A(id0)=trx0, B(id1)=trx1], band
+// switch destroys+recreates A, positional numbering renumbered B to receiver
+// 0 under a live client. With TciTrxMap, the recreated slice (same Flex id)
+// reclaims its binding and surviving slices never move.
+//
+// Pure-logic test (no RadioModel): binding acquisition, recreate reuse,
+// lowest-free assignment, release, clear, and the trx_count floor. The
+// map↔model interplay (positional fallback, live-slice resolution) is
+// exercised on hardware — see PR verification.
+
+#include "core/TciTrxMap.h"
+
+#include <iostream>
+
+using AetherSDR::TciTrxMap;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const char* label)
+{
+    std::cout << (condition ? "[ OK ] " : "[FAIL] ") << label << '\n';
+    if (!condition)
+        ++failures;
+}
+
+} // namespace
+
+int main()
+{
+    // Creation order gets dense numbers from 0 — identical to the
+    // positional policy for a session with no destroy/recreate.
+    {
+        TciTrxMap map;
+        expect(map.acquire(0) == 0, "first slice binds trx 0");
+        expect(map.acquire(1) == 1, "second slice binds trx 1");
+        expect(map.acquire(0) == 0, "acquire is idempotent for a bound id");
+        expect(map.trxCount(nullptr) == 2, "trx_count = highest bound + 1");
+    }
+
+    // The #4567 capture: recreate reclaims its number, survivor never moves.
+    {
+        TciTrxMap map;
+        map.acquire(0);  // slice A
+        map.acquire(1);  // slice B
+        // Band switch: A removed (release deferred past the settle window —
+        // the owner has NOT called release), then re-added with the same id.
+        expect(map.acquire(0) == 0, "recreated slice reclaims its trx");
+        expect(map.acquire(1) == 1, "surviving slice keeps its trx");
+        expect(map.trxCount(nullptr) == 2, "count unchanged across recreate");
+    }
+
+    // A genuine close (deferred release fired) frees the number for reuse.
+    {
+        TciTrxMap map;
+        map.acquire(0);
+        map.acquire(1);
+        map.release(0);
+        expect(map.acquire(7) == 0, "freed trx is reused lowest-first");
+        expect(map.acquire(1) == 1, "unrelated binding untouched by release");
+        // A hole (release of trx 0 with trx 1 still bound) must not shrink
+        // the advertised count below an index in use.
+        map.release(7);
+        expect(map.trxCount(nullptr) == 2,
+               "count stays above a transient hole (trx 1 still bound)");
+    }
+
+    // Disconnect: everything resets; next session starts dense from 0.
+    {
+        TciTrxMap map;
+        map.acquire(3);
+        map.acquire(5);
+        map.clear();
+        expect(map.trxCount(nullptr) == 1, "cleared map advertises 1 (floor)");
+        expect(map.acquire(5) == 0, "post-clear acquisition restarts at 0");
+    }
+
+    // Null-model lookups fall back safely (no map hit, no crash).
+    {
+        TciTrxMap map;
+        expect(map.trxForSlice(nullptr, nullptr) == 0,
+               "null slice falls back to positional default 0");
+        expect(map.sliceForTrx(nullptr, 0) == nullptr,
+               "null model resolves no slice");
+        expect(map.txSliceTrxOrNone(nullptr) == -1,
+               "null model has no TX slice (-1 sentinel)");
+        expect(!map.trxHasLiveSlice(nullptr, 0),
+               "null model carries no live slice");
+    }
+
+    std::cout << (failures ? "FAILED" : "PASSED") << " (" << failures
+              << " failures)\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #4567.

## The decision this PR asks for first

This changes the receiver-numbering policy documented in #2145 (receiver number =
current list position), so the design call is stated up front rather than left for
review to discover:

- **Sessions with no mid-session slice destroy/recreate are numbered identically to
  today** (0, 1, 2… in creation order) — existing clients see no difference.
- **The departure:** after a slice is genuinely closed mid-session, surviving slices now
  KEEP their receiver numbers (the freed number is reused by the next new slice). The
  positional policy instead shifted every later slice down. A live client's binding
  stays valid under the new rule; under the old one it silently changed meaning.
- **The alternative, if preserving #2145 to the letter matters more:** the same defect
  can be fixed with no wire-visible change at all by making `RadioModel` re-insert a
  recreated slice at its old list position instead of appending (recreates are
  identifiable — same Flex slice id back within the settle window). That keeps
  positional numbering correct across recreates AND keeps the documented shuffle-down
  on genuine closes — at the cost of changing the model's ordering invariant, which
  every positional consumer in the app shares. We deliberately did not touch that
  invariant without maintainer direction; happy to implement that variant instead if
  it's the preferred shape.

## What

TCI receiver numbers were the slice's position in `RadioModel::slices()` — an
insertion-ordered list that a band-stack switch reorders (destroy + re-append). With
two slices open, one ordinary band change silently renumbered the receivers under a
live client: WSJT-X kept talking to "receiver 0" and was re-routed to a different
physical slice, with the swap indistinguishable on the wire from a retune (mechanism
and captures in #4567; confirmed by triage).

New `src/core/TciTrxMap` pins `sliceId → trx` for the life of a binding, following the
triage plan on #4567:

- **Acquire on `sliceAdded`**, reusing an existing binding — a band-stack recreate
  keeps the same Flex slice id, so the recreated slice reclaims its receiver number and
  surviving slices never move. New slices take the lowest free number (wire indexes
  must stay dense from 0; raw Flex slice ids are sparse and MultiFlex can start them
  above 0, so ids are not usable as receiver numbers — triage's argument, adopted).
- **Release deferred 500 ms** past the band-change settle window (same shape as the
  existing `m_lastTxTrx` cache in the same handler), so only a genuine close frees a
  number; cleared on disconnect alongside the rest of the per-connection state.
- **Both mapping directions** (`trxForSlice` / `sliceForTrx`, plus the TX-trx scan and
  the #4161 close-vs-recreate discriminator) consult the map first and fall back to the
  original positional logic for an unbound slice, so pre-wiring windows behave exactly
  as before. `TciProtocol` instances get the map injected at construction (nullptr =
  positional behavior, so existing constructions and tests are unaffected).
- **`trx_count`** becomes 1 + the highest trx in use, so a transient settle-window hole
  can never advertise a count below an index a client is actively using.

## Tests

- New `tests/tci_trxmap_test.cpp`: binding acquisition order, recreate reclaim,
  lowest-free reuse after release, the transient-hole count floor, clear/reset,
  null-model fallbacks.
- `tests/tci_server_review_test.cpp`: the #4160 active_slice case previously asserted
  the positional renumber ("removing slice 0 renumbers B from trx 1 → 0") — it now
  asserts the hold, with the policy change documented in the test comment; the
  focused-slice-removal half (tracked trx clears) is unchanged. A new case replays the
  captured defect end-to-end on the model: fixture A+B, destroy A, recreate at the list
  tail, assert A reclaims receiver 0 and B never moves.
- Full suite: 193 tests, green except the two known local-environment failures on this
  box (`cross_needle_meter_test`, `s_meter_geometry_test` — fail identically on
  pure-main control builds while upstream CI is green; no meter code touched).

## Hardware verification (FLEX-8400, fw 4.2.20.41343, WSJT-X on TCI receiver 0)

Same rig and drill as #4567's capture, on `207fe83d`, `aether.dax` logging enabled:

- Two panadapters (A = receiver 0 / DAX 1 / WSJT-X decoding 20 m FT8; B = DAX 2), then
  a 40 m band switch on A and a 20 m return — **two destroy/recreate cycles**.
- The periodic mapping line read `receiver=0 slice=0 dax_ch=1` on **every status tick
  through both recreates** (first tick 184 ms after the second recreate, unchanged). On
  stock, the first tick after the first recreate flipped to `receiver=0 slice=1
  dax_ch=2` and stayed wrong for 4 m 49 s (#4567's capture).
- **WSJT-X kept its binding and resumed decoding immediately after the return leg with
  the second slice still open, zero recovery actions** — on stock this required closing
  the second slice to force the list back into its original order.

Full sanitized session log attached.

## Relations

- Sibling of #4572 (the #4558 stale-DAX-restore fix): same trigger, independent
  defects, independent fixes — #4572's hardware pass demonstrated this bug still
  present with #4558 fixed, and this branch fixes only the receiver half. They land
  separately in either order.

[aethersdr-4567-fixverify-2026-07-29.zip](https://github.com/user-attachments/files/30494837/aethersdr-4567-fixverify-2026-07-29.zip)


— authored by agent (Claude Code) on behalf of @skerker
