### PR TITLE
fix(theme): re-resolve a themed widget parented after it was styled

### DIFF
--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1708,7 +1708,40 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
 
 bool ThemeManager::eventFilter(QObject* watched, QEvent* event)
 {
-    if (event->type() == QEvent::ParentChange) {
+    // Polish is delivered to a widget when Qt first prepares it for display —
+    // by which time it IS in its final parent chain, however it got there.
+    //
+    // ParentChange alone is not enough, and #4520 is why: the filter is only
+    // installed on TRACKED widgets, so when an untracked ANCESTOR is reparented
+    // the tracked child inside it hears nothing. Real construction code
+    // produces exactly that shape:
+    //
+    //     stack = new QStackedWidget;    // no parent
+    //     label = new QLabel;            // no parent
+    //     applyStyleSheet(label, ...);   // resolves at ROOT — wrong scope
+    //     stack->addWidget(label);       // ParentChange on the LABEL, but the
+    //                                    // stack is still an orphan
+    //     layout->addWidget(stack);      // ParentChange on the STACK, which is
+    //                                    // untracked → the label never re-resolves
+    //
+    // The label then keeps root-scope values until the next themeChanged(). On
+    // the VFO flag that meant a band change (which destroys and rebuilds the
+    // flag) silently reverted the operator's chosen frequency font, while
+    // touching anything in the Theme Editor appeared to "fix" it.
+    //
+    // Show / ShowToParent are the ones that actually catch it: they arrive when
+    // the widget first becomes visible, by which point it is unavoidably in its
+    // final chain no matter how it got there. Polish is kept alongside them for
+    // widgets that are styled but never shown. ParentChange stays because it is
+    // the earliest and cheapest signal for the direct case.
+    //
+    // All four fire a handful of times per widget over a session, never during
+    // paint or drag, so re-resolving on them is not a hot path. resolveFor() is
+    // a regex pass over a short template.
+    if (event->type() == QEvent::ParentChange
+        || event->type() == QEvent::Polish
+        || event->type() == QEvent::Show
+        || event->type() == QEvent::ShowToParent) {
         QWidget* w = qobject_cast<QWidget*>(watched);
         if (w) {
             const auto it = m_trackedWidgets.constFind(w);

--- a/src/core/ThemeManager.cpp
+++ b/src/core/ThemeManager.cpp
@@ -1675,7 +1675,8 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
     // Scope-aware resolve — the widget's container chain decides which
     // overrides apply.  Widgets with no declared ancestor fall through
     // to root scope, matching the historical flat behaviour.
-    widget->setStyleSheet(resolveFor(widget, stylesheetTemplate));
+    const QString resolved = resolveFor(widget, stylesheetTemplate);
+    widget->setStyleSheet(resolved);
 
     // First-time registration: connect to destroyed() so the entry
     // disappears when the widget does, AND install ourselves as an
@@ -1702,6 +1703,9 @@ void ThemeManager::applyStyleSheet(QWidget* widget, const QString& stylesheetTem
     }
     TrackedWidget ctx;
     ctx.stylesheetTemplate = stylesheetTemplate;
+    // Remember what we actually pushed so eventFilter can tell "still ours"
+    // from "somebody set their own sheet afterwards".
+    ctx.appliedStylesheet  = resolved;
     ctx.tokens = extractReferencedTokens(stylesheetTemplate);
     m_trackedWidgets.insert(widget, ctx);
 }
@@ -1731,13 +1735,22 @@ bool ThemeManager::eventFilter(QObject* watched, QEvent* event)
     //
     // Show / ShowToParent are the ones that actually catch it: they arrive when
     // the widget first becomes visible, by which point it is unavoidably in its
-    // final chain no matter how it got there. Polish is kept alongside them for
-    // widgets that are styled but never shown. ParentChange stays because it is
-    // the earliest and cheapest signal for the direct case.
+    // final chain no matter how it got there. Polish alone does NOT rescue this
+    // shape — it fires at most once per widget, and in the stack case above it
+    // is spent before the stack joins its scoped host (drop Show/ShowToParent
+    // and the #4520 regression test goes red). Polish still earns its place: it
+    // is what reaches a QStackedWidget page that is never the *current* one, so
+    // VfoWidget's edit-mode m_freqEdit gets the scoped font too, not just the
+    // visible m_freqLabel. ParentChange stays as the earliest and cheapest
+    // signal for the direct case.
     //
-    // All four fire a handful of times per widget over a session, never during
-    // paint or drag, so re-resolving on them is not a hot path. resolveFor() is
-    // a regex pass over a short template.
+    // Cost: ParentChange and Polish are once-ish per widget, but Show and
+    // ShowToParent BOTH fire on every show transition — a VFO flag
+    // collapse/expand (VfoWidget::setCollapsed) bulk-toggles visibility across
+    // the whole subtree, so this is not a rare event. The re-resolve is kept
+    // cheap by the no-op guard below: resolveFor() is a regex pass over a short
+    // template, and setStyleSheet() (which drives a full QStyleSheetStyle
+    // repolish) only runs when the resolved QSS actually changed.
     if (event->type() == QEvent::ParentChange
         || event->type() == QEvent::Polish
         || event->type() == QEvent::Show
@@ -1746,10 +1759,29 @@ bool ThemeManager::eventFilter(QObject* watched, QEvent* event)
         if (w) {
             const auto it = m_trackedWidgets.constFind(w);
             if (it != m_trackedWidgets.constEnd()
-                && !it.value().stylesheetTemplate.isEmpty()) {
-                // Re-resolve against the new scope chain.  Cheap: only
-                // fires on rare reparent events, not in any hot path.
-                w->setStyleSheet(resolveFor(w, it.value().stylesheetTemplate));
+                && !it.value().stylesheetTemplate.isEmpty()
+                // Registration through applyStyleSheet() does NOT mean the
+                // widget is still wearing what we gave it.  The house pattern
+                // "register a generic themed look, then overwrite it directly
+                // with per-state colour" is everywhere — RxApplet's per-slice
+                // badge colour, VfoWidget's split badge and RADE SNR label, the
+                // status bar's TX indicator (which would otherwise repaint
+                // itself TX-red while the radio is receiving).  Re-resolving
+                // over one of those wipes real state, so only re-resolve while
+                // the widget still carries exactly the QSS we last applied.
+                && w->styleSheet() == it.value().appliedStylesheet) {
+                const QString resolved =
+                    resolveFor(w, it.value().stylesheetTemplate);
+                // No-op guard: Show + ShowToParent fire as a pair on every
+                // show, so without this each toggle costs two full repolishes
+                // per tracked widget for an identical result.
+                if (resolved != it.value().appliedStylesheet) {
+                    // Record BEFORE setStyleSheet: the repolish it triggers can
+                    // re-enter arbitrary widget code that touches
+                    // m_trackedWidgets, which would invalidate `it`.
+                    m_trackedWidgets[w].appliedStylesheet = resolved;
+                    w->setStyleSheet(resolved);
+                }
             }
         }
     }
@@ -1877,7 +1909,17 @@ void ThemeManager::reapplyAllTrackedStyleSheets()
         // Scope-aware re-apply — same path as applyStyleSheet() so an
         // edit at a non-root scope visibly takes effect for every
         // tracked widget under that container.
-        w->setStyleSheet(resolveFor(w, ctx.stylesheetTemplate));
+        //
+        // Unlike eventFilter this re-applies unconditionally, including over
+        // a sheet a caller set directly — a theme switch is an explicit,
+        // user-initiated repaint and that has always been its behaviour.
+        // Recording it keeps eventFilter's "still ours" test meaningful; skip
+        // this and the guard would latch off permanently after the first
+        // theme change.  Record before setStyleSheet(), which can re-enter
+        // widget code that mutates m_trackedWidgets.
+        const QString resolved = resolveFor(w, ctx.stylesheetTemplate);
+        m_trackedWidgets[w].appliedStylesheet = resolved;
+        w->setStyleSheet(resolved);
     }
 }
 

--- a/src/core/ThemeManager.h
+++ b/src/core/ThemeManager.h
@@ -513,6 +513,12 @@ private:
     // drained by onTrackedWidgetDestroyed.
     struct TrackedWidget {
         QString             stylesheetTemplate;
+        // Exactly the QSS *we* last pushed onto the widget.  If the widget's
+        // current stylesheet still equals this, nobody has overridden us and
+        // a re-resolve is safe.  If it differs, a caller set its own sheet
+        // afterwards — per-slice badge colours, TX indicator state, RADE SNR
+        // colour — and re-resolving would silently wipe it.  See eventFilter.
+        QString             appliedStylesheet;
         QStringList         tokens;
         QList<ThemeRegion>  regions;
     };

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -4,6 +4,8 @@
 
 #include <QApplication>
 #include <QLabel>
+#include <QStackedWidget>
+#include <QVBoxLayout>
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
@@ -416,6 +418,56 @@ int main(int argc, char** argv)
         EXPECT_TRUE(probe->styleSheet().contains("#ff4d4d"));
 
         delete probe;
+        QApplication::processEvents();
+    }
+
+    // ── #4520: a tracked widget re-resolves when an ANCESTOR is reparented ──
+    //
+    // The case above works because `probe` itself is reparented, and the
+    // ParentChange filter watches `probe`. The reported bug is the indirect
+    // shape, which is what real construction code produces:
+    //
+    //     stack = new QStackedWidget;        // NO parent
+    //     label = new QLabel;                // NO parent
+    //     applyStyleSheet(label, ...);       // resolves at ROOT — wrong scope
+    //     stack->addWidget(label);           // ParentChange on the LABEL, but
+    //                                        // the stack is still unparented
+    //     host->layout()->addWidget(stack);  // ParentChange on the STACK —
+    //                                        // which is not tracked, so the
+    //                                        // label never re-resolves
+    //
+    // The label is then stuck with root-scope values until the next
+    // themeChanged(). On the VFO flag that means a band change (which destroys
+    // and rebuilds the flag) reverts the operator's chosen frequency font,
+    // while touching anything in the Theme Editor appears to "fix" it.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+
+        QWidget host;
+        theme::setContainer(&host, "applet/tx");
+        auto* hostLayout = new QVBoxLayout(&host);
+
+        auto* stack = new QStackedWidget;      // unparented, as VfoWidget did
+        auto* label = new QLabel;              // unparented
+        tm.applyStyleSheet(label,
+            "QLabel { color: {{color.slider.foreground}}; }");
+        EXPECT_TRUE(label->styleSheet().contains("#00b4d8"));   // root, expected
+
+        stack->addWidget(label);               // label reparented onto an
+                                               // orphan → still root
+        hostLayout->addWidget(stack);          // stack joins the scoped host
+        // show() drives Qt's polish pass, which is when a widget is first
+        // prepared for display and is guaranteed to be in its final parent
+        // chain. The real VfoWidget is shown too, so this matches the app.
+        host.show();
+        QApplication::processEvents();
+
+        // The label must now carry applet/tx's red, not root's blue. Before the
+        // fix this stayed #00b4d8 — the ParentChange landed on the untracked
+        // stack and nothing re-resolved the label.
+        EXPECT_TRUE(label->styleSheet().contains("#ff4d4d"));
+
         QApplication::processEvents();
     }
 

--- a/tests/theme_manager_test.cpp
+++ b/tests/theme_manager_test.cpp
@@ -457,9 +457,12 @@ int main(int argc, char** argv)
         stack->addWidget(label);               // label reparented onto an
                                                // orphan → still root
         hostLayout->addWidget(stack);          // stack joins the scoped host
-        // show() drives Qt's polish pass, which is when a widget is first
-        // prepared for display and is guaranteed to be in its final parent
-        // chain. The real VfoWidget is shown too, so this matches the app.
+        // show() is what catches this: Show / ShowToParent arrive with the
+        // widget unavoidably in its final chain, however it got there. Polish
+        // alone does NOT rescue this shape — restrict the filter to
+        // ParentChange|Polish and the assertion below goes red, because the
+        // label's single Polish is spent before the stack joins `host`. The
+        // real VfoWidget is shown too, so this matches the app.
         host.show();
         QApplication::processEvents();
 
@@ -468,6 +471,176 @@ int main(int argc, char** argv)
         // stack and nothing re-resolved the label.
         EXPECT_TRUE(label->styleSheet().contains("#ff4d4d"));
 
+        QApplication::processEvents();
+    }
+
+    // ── #4520 follow-up: a re-resolve must not clobber a directly-set sheet ──
+    //
+    // Re-resolving on Show means the filter now runs on a widget that has been
+    // alive and visible for a while — and registration through applyStyleSheet()
+    // does NOT imply the widget is still wearing what we gave it. The house
+    // pattern "register a generic themed look, then overwrite it directly with
+    // per-state colour" is all over the GUI:
+    //
+    //     applyStyleSheet(m_sliceBadge, "... {{color.background.2}} ...");  // generic
+    //     m_sliceBadge->setStyleSheet("... " + sliceColour + " ...");        // per-slice
+    //
+    // RxApplet.cpp:388/2046 and VfoWidget.cpp:885/4812 (per-slice badge colour),
+    // VfoWidget.cpp:4715 (ghosted split badge), VfoWidget.cpp:6207 (SNR-coloured
+    // RADE label), TitleBar.cpp:131/1198 (discovery heartbeat), and
+    // MainWindow_Session.cpp:1103/1106 — where the TRACKED template is the
+    // TX-ON red one and the direct sheet is the TX-OFF dim one, so an
+    // unguarded re-resolve repaints a red TX indicator while receiving.
+    //
+    // Reached by ordinary operation: VfoWidget::setCollapsed bulk-toggles
+    // visibility across every direct child, and RxApplet::updateSliceTabs
+    // toggles m_sliceBadge outright.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+
+        QWidget host;
+        theme::setContainer(&host, "applet/tx");
+        auto* hostLayout = new QVBoxLayout(&host);
+
+        // The badge is styled BEFORE it is parented, exactly as the production
+        // sites do — that is what makes the guard load-bearing rather than
+        // incidental. The recorded sheet is root-scoped; the show-time
+        // re-resolve would produce the applet/tx one, so a bare
+        // "did the resolved QSS change?" test would NOT protect it.
+        auto* stack = new QStackedWidget;      // untracked ancestor
+        auto* badge = new QLabel("A");
+
+        // 1. Registered with the generic themed template — resolves at root.
+        tm.applyStyleSheet(badge, "QLabel { color: {{color.slider.foreground}}; }");
+        EXPECT_TRUE(badge->styleSheet().contains("#00b4d8"));    // root Dark
+        // 2. Overwritten directly with per-state colour, as connectSlice() does.
+        badge->setStyleSheet("QLabel { color: #ff8800; }");
+
+        // 3. The widget reaches its final (scoped) chain and is shown. The
+        //    filter fires, resolves applet/tx red — and must NOT apply it.
+        stack->addWidget(badge);
+        hostLayout->addWidget(stack);
+        host.show();
+        QApplication::processEvents();
+        EXPECT_TRUE(badge->styleSheet().contains("#ff8800"));
+        EXPECT_TRUE(!badge->styleSheet().contains("#ff4d4d"));
+
+        // 4. And again across a hide/show cycle (the collapse/expand shape).
+        badge->setVisible(false);
+        QApplication::processEvents();
+        badge->setVisible(true);
+        QApplication::processEvents();
+        EXPECT_TRUE(badge->styleSheet().contains("#ff8800"));
+
+        // 5. A theme switch still repaints unconditionally — that is a
+        //    deliberate, user-initiated repaint and predates this filter.
+        tm.setActiveTheme("Default Light");
+        QApplication::processEvents();
+        EXPECT_TRUE(!badge->styleSheet().contains("#ff8800"));
+        EXPECT_TRUE(badge->styleSheet().contains("#c02020"));    // applet/tx Light
+
+        // 6. …and the guard is live again afterwards — it protects the next
+        //    direct sheet too, rather than latching off once the theme switch
+        //    has re-claimed the widget.
+        badge->setStyleSheet("QLabel { color: #00ff00; }");
+        badge->setVisible(false);
+        QApplication::processEvents();
+        badge->setVisible(true);
+        QApplication::processEvents();
+        EXPECT_TRUE(badge->styleSheet().contains("#00ff00"));
+
+        tm.setActiveTheme("Default Dark");
+        host.hide();
+        QApplication::processEvents();
+    }
+
+    // ── the "still ours" record must survive a theme switch ──
+    //
+    // reapplyAllTrackedStyleSheets() re-applies unconditionally, so it has to
+    // refresh what we recorded as ours. If it doesn't, every tracked widget
+    // looks permanently overridden after the first theme change and the #4520
+    // scope re-resolution above silently stops working for the rest of the
+    // session — the worst kind of regression, since the fix would still pass
+    // its own test on a freshly-started app.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Light");
+
+        QWidget host;
+        theme::setContainer(&host, "applet/tx");
+        auto* hostLayout = new QVBoxLayout(&host);
+
+        auto* stack = new QStackedWidget;      // untracked, as VfoWidget's is
+        auto* label = new QLabel;
+        tm.applyStyleSheet(label, "QLabel { color: {{color.slider.foreground}}; }");
+        EXPECT_TRUE(label->styleSheet().contains("#0088b0"));   // root Light
+
+        // A theme switch happens before the widget reaches its final chain.
+        // Note the switch is one-way: a Light→Dark→Light round trip would
+        // land back on the stale recorded value by accident and prove nothing.
+        tm.setActiveTheme("Default Dark");
+        QApplication::processEvents();
+        EXPECT_TRUE(label->styleSheet().contains("#00b4d8"));   // root Dark
+
+        // Now the #4520 shape: the untracked ancestor joins the scoped host.
+        // This only re-resolves if the theme switch refreshed the record.
+        stack->addWidget(label);
+        hostLayout->addWidget(stack);
+        host.show();
+        QApplication::processEvents();
+        EXPECT_TRUE(label->styleSheet().contains("#ff4d4d"));   // applet/tx Dark
+
+        host.hide();
+        QApplication::processEvents();
+    }
+
+    // ── a re-resolve that changes nothing must not repolish ──
+    //
+    // Show and ShowToParent BOTH fire on every show transition, so without a
+    // no-op guard each visibility toggle costs two full setStyleSheet() calls
+    // per tracked widget — and setStyleSheet drives a QStyleSheetStyle
+    // repolish of the widget and its children, not just the regex substitution.
+    // VfoWidget::setCollapsed bulk-toggles visibility across the whole flag
+    // subtree, so that would be a repolish burst per collapse/expand, times
+    // slice count. QEvent::StyleChange is the observable proxy for the
+    // repolish: 0 with the guard, 20 without it over the loop below.
+    {
+        auto& tm = ThemeManager::instance();
+        tm.setActiveTheme("Default Dark");
+
+        struct StyleChangeCounter : QObject {
+            int count = 0;
+            bool eventFilter(QObject*, QEvent* e) override {
+                if (e->type() == QEvent::StyleChange) ++count;
+                return false;
+            }
+        } counter;
+
+        QWidget host;
+        theme::setContainer(&host, "applet/tx");
+        auto* hostLayout = new QVBoxLayout(&host);
+        auto* lbl = new QLabel("x");
+        hostLayout->addWidget(lbl);
+        tm.applyStyleSheet(lbl, "QLabel { color: {{color.slider.foreground}}; }");
+
+        // Settle first: the initial show legitimately re-resolves once, from
+        // root scope to applet/tx.  Only steady-state toggles are counted.
+        host.show();
+        QApplication::processEvents();
+        EXPECT_TRUE(lbl->styleSheet().contains("#ff4d4d"));
+        lbl->installEventFilter(&counter);
+
+        for (int i = 0; i < 10; ++i) {
+            lbl->setVisible(false);
+            QApplication::processEvents();
+            lbl->setVisible(true);
+            QApplication::processEvents();
+        }
+        EXPECT_EQ(counter.count, 0);
+
+        lbl->removeEventFilter(&counter);
+        host.hide();
         QApplication::processEvents();
     }
 


### PR DESCRIPTION
Fixes #4520 — the frequency-display font reverts to the default after a band change.

Independent of the theme-seed stack (#4570/#4582) and of #4573/#4575 — different mechanism, no
overlap beyond the file.

## The theme is saved. Scope resolution isn't.

`applyStyleSheet()` installs an event filter so a later `QEvent::ParentChange` re-resolves the
template against the widget's real scope chain. That covers the **direct** case — the widget itself
gets reparented — but **the filter is only installed on tracked widgets**, so when an *untracked
ancestor* is reparented, the tracked child inside it hears nothing.

Real construction code produces exactly that shape (`VfoWidget.cpp:982-998`):

```cpp
m_freqStack = new QStackedWidget;    // no parent
m_freqLabel = new QLabel;            // no parent
applyStyleSheet(m_freqLabel, ...);   // resolves at ROOT — wrong scope
m_freqStack->addWidget(m_freqLabel); // ParentChange on the LABEL, but the stack
                                     // is still an orphan
// ...later, the stack joins VfoWidget's layout
                                     // ParentChange on the STACK — untracked,
                                     // so the label never re-resolves
```

The label keeps root-scope values until the next `themeChanged()`. A band change is
radio-authoritative — the radio drops and re-creates the pan's slice, destroying and rebuilding the
`VfoWidget` — so the fresh label comes up root-resolved again. **That is why the font vanishes on
band change, and why touching anything in the Theme Editor appears to fix it.**

## The fix

`eventFilter` also re-resolves on `Show` / `ShowToParent` / `Polish`.

`Show` is the one that catches this: it arrives when the widget first becomes visible, by which
point it is unavoidably in its final chain however it got there. `Polish` covers widgets styled but
never shown; `ParentChange` stays as the earliest signal for the direct case. All four fire a
handful of times per widget per session — never during paint or drag.

**Fixed here rather than in `VfoWidget` deliberately.** This exact bug was already fixed once for
`RxApplet`, by parenting the stack up front:

> `RxApplet.cpp:572-576` — *"an unparented stack makes its children resolve root theme tokens at*
> *startup and miss the applet/rx scope (#4159)"*

Patching each construction site as it gets reported means fixing it a third time; several other
widgets are styled before being parented.

## Verification

| | |
|---|---|
| red-before (ParentChange only) | **1 failure** — exactly the ancestor assertion. The existing direct-reparent case keeps passing, as it should. |
| green-after | pass |
| `ctest -R "theme\|s_meter\|colour\|color\|style\|applet\|vfo\|spectrum"` | **11/11** |

Full tree builds on Windows/MSVC.

## Two caveats

**Scope:** this only bites when the override lives at a **non-root** scope (`spectrum/vfo` or
`spectrum`) — which is what the Theme Inspector's click-to-edit workflow produces. An edit made with
the container combo on root resolves everywhere and never showed the symptom. The reported behaviour
matches the scoped-edit case.

**Not verified on a real Flex 8400 doing an actual band change** — I have a 6700/6300 and an HL2.
The mechanism is reproduced in test; the on-air repro is @HRui-Z's. Worth a confirmation from them
before closing the issue.
