### PR TITLE
test(logging): regression-guard the category-toggle Info enablement (#4419)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4424,6 +4424,24 @@ if(UNIX)
 endif()
 set_target_properties(async_log_writer_test PROPERTIES AUTOMOC ON)
 
+# Support & Diagnostics category toggle must enable Info alongside Debug
+# (#4419): most categories declare a QtWarningMsg threshold, and the filter
+# rules previously re-enabled .debug only, leaving every qCInfo on those
+# categories unreachable.
+add_executable(log_manager_filter_rules_test
+    tests/log_manager_filter_rules_test.cpp
+    src/core/LogManager.cpp
+    src/core/AppSettings.cpp
+    src/core/AsyncLogWriter.cpp
+)
+target_include_directories(log_manager_filter_rules_test PRIVATE src)
+target_link_libraries(log_manager_filter_rules_test PRIVATE Qt6::Core)
+if(UNIX)
+    target_link_libraries(log_manager_filter_rules_test PRIVATE pthread)
+endif()
+set_target_properties(log_manager_filter_rules_test PROPERTIES AUTOMOC ON)
+add_test(NAME log_manager_filter_rules_test COMMAND log_manager_filter_rules_test)
+
 # Pre-filled GitHub issue body + redaction-at-render guarantee (#3705).
 # IssueReport.cpp depends only on redactPii (AsyncLogWriter.cpp) — no
 # RadioModel — so the redaction contract is unit-testable in isolation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4431,7 +4431,7 @@ set_target_properties(async_log_writer_test PROPERTIES AUTOMOC ON)
 add_executable(log_manager_filter_rules_test
     tests/log_manager_filter_rules_test.cpp
     src/core/LogManager.cpp
-    src/core/AppSettings.cpp
+    ${AETHER_SETTINGS_SOURCES}
     src/core/AsyncLogWriter.cpp
 )
 target_include_directories(log_manager_filter_rules_test PRIVATE src)
@@ -4970,6 +4970,7 @@ set(AETHER_SETTINGS_CONSUMERS
     amp_applet_test
     container_manager_test
     container_nesting_test
+    log_manager_filter_rules_test
 )
 foreach(_settings_consumer IN LISTS AETHER_SETTINGS_CONSUMERS)
     if(TARGET ${_settings_consumer})

--- a/src/core/LogManager.cpp
+++ b/src/core/LogManager.cpp
@@ -172,6 +172,12 @@ void LogManager::applyFilterRules()
             // never once appeared in a log file. Neither had the 16 qCInfo
             // calls on lcDax. Two dozen categories are declared QtWarningMsg,
             // so this was most of the codebase's INFO logging.
+            //
+            // Note the asymmetry: no blanket "aether.*.info=false" is emitted
+            // above — it would newly silence the QtDebugMsg/QtInfoMsg-declared
+            // categories (aether.kiwisdr, aether.connection, aether.hl2, …)
+            // whose Info is visible today. For those, this toggle governs
+            // Debug only; their Info stays on regardless.
             rules << QString("%1.info=true").arg(c.id);
         }
     }

--- a/tests/log_manager_filter_rules_test.cpp
+++ b/tests/log_manager_filter_rules_test.cpp
@@ -1,0 +1,104 @@
+// Regression test for #4419: qCInfo on QtWarningMsg-declared categories could
+// never emit — applyFilterRules() re-enabled .debug only, so enabling a
+// category in Support & Diagnostics left its Info lines dead under every
+// runtime configuration the app can produce.
+//
+// Asserts the toggle now governs Info the same way it governs Debug, and pins
+// the behaviors the fix must not disturb: default-off stays default-off,
+// warnings always pass, the aether.audio.summary always-on Info special case
+// survives, and Info on QtDebugMsg-declared categories (visible by
+// declaration, untouched by any rule) is not newly suppressed.
+
+#include "core/LogManager.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QStandardPaths>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+
+#include <cstdio>
+
+using namespace AetherSDR;
+
+namespace {
+
+int g_failed = 0;
+
+void report(const char* name, bool ok)
+{
+    std::printf("%s %s\n", ok ? "[ OK ]" : "[FAIL]", name);
+    if (!ok) ++g_failed;
+}
+
+// Captured qCInfo payloads, to prove the emit path end-to-end rather than
+// only the category flags.
+QStringList g_infoMessages;
+
+void captureHandler(QtMsgType type, const QMessageLogContext& ctx, const QString& msg)
+{
+    if (type == QtInfoMsg)
+        g_infoMessages << QString::fromLatin1(ctx.category ? ctx.category : "") + ": " + msg;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    // Defense-in-depth only: the save path in setEnabled()/setAllEnabled() is
+    // intentionally a no-op here — AppSettings refuses to save before a
+    // successful load(), which this test never performs (the "refusing to
+    // save" warnings in the output are expected). The sandbox guards against
+    // that refusal ever changing.
+    QTemporaryDir fakeHome(QDir::tempPath() + "/aether-logmanager-filter-test-XXXXXX");
+    if (!fakeHome.isValid()) {
+        std::printf("[FAIL] create temporary home\n");
+        return 1;
+    }
+    qputenv("HOME", fakeHome.path().toUtf8());
+    qputenv("CFFIXED_USER_HOME", fakeHome.path().toUtf8());
+    qputenv("XDG_CONFIG_HOME", fakeHome.path().toUtf8());
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+
+    LogManager& lm = LogManager::instance();
+    lm.setAllEnabled(false);
+
+    // Baseline: category disabled — Debug and Info both gated, Warning passes.
+    report("disabled: debug off", !lcCat().isDebugEnabled());
+    report("disabled: info off", !lcCat().isInfoEnabled());
+    report("disabled: warning still on", lcCat().isWarningEnabled());
+
+    // The #4419 assertion: enabling a QtWarningMsg-declared category enables
+    // its Info level alongside Debug.
+    lm.setEnabled("aether.cat", true);
+    report("enabled: debug on", lcCat().isDebugEnabled());
+    report("enabled: info on (#4419)", lcCat().isInfoEnabled());
+
+    // End-to-end: a qCInfo on the enabled category reaches the handler.
+    g_infoMessages.clear();
+    QtMessageHandler prev = qInstallMessageHandler(captureHandler);
+    qCInfo(lcCat) << "info probe";
+    qInstallMessageHandler(prev);
+    report("enabled: qCInfo emitted",
+           g_infoMessages.size() == 1 && g_infoMessages.first().startsWith("aether.cat"));
+
+    // Enabling one category does not light up another.
+    report("other category stays dark", !lcDax().isInfoEnabled());
+
+    // Behaviors the fix must not disturb.
+    report("audio.summary info always on", lcAudioSummary().isInfoEnabled());
+    report("QtDebugMsg-declared info untouched", lcKiwiSdr().isInfoEnabled());
+
+    // Toggling back off closes the gate again.
+    lm.setEnabled("aether.cat", false);
+    report("re-disabled: info off", !lcCat().isInfoEnabled());
+    g_infoMessages.clear();
+    prev = qInstallMessageHandler(captureHandler);
+    qCInfo(lcCat) << "info probe while disabled";
+    qInstallMessageHandler(prev);
+    report("re-disabled: qCInfo suppressed", g_infoMessages.isEmpty());
+
+    return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Retargeted after review: the production fix landed on `main` independently via #4537 (`4077e023`) while this PR was open — same diagnosis, same line. The branch is now current `main` (`e8a4e950`) plus two commits: the regression test, and the comment-only addendum from review folding the asymmetry note into `main`'s `applyFilterRules()` comment.

Refs #4419.

## What

- `log_manager_filter_rules_test` (ctest-registered) drives the real `LogManager` toggle in a sandboxed settings home and asserts Info+Debug off when disabled and on when enabled — at the category-flag level and end-to-end through a message-handler capture of an actual `qCInfo` — plus per-category independence, warnings always passing, the `audio.summary` special case, no new suppression of QtDebugMsg-declared categories, and the gate closing again on disable.
- Six comment lines in `applyFilterRules()` recording that the missing blanket `aether.*.info=false` is deliberate: it would newly silence the QtDebugMsg/QtInfoMsg-declared categories whose Info is visible today, so for those the toggle governs Debug only.

## Verification (macOS, clean build)

- Full suite 203/203 at head `5afb957d` (`crdv_quarantined_test` skipped by design).
- A/B at `cdc68926`: with `main`'s `%1.info=true` line reverted, exactly the two #4419 assertions fail (`enabled: info on`, `enabled: qCInfo emitted`); restored, all green — matching the transfer check in the review.

— authored by agent (Claude Code) on behalf of @skerker
